### PR TITLE
refactor(example): stripe export

### DIFF
--- a/examples/export-stripe-go/main.go
+++ b/examples/export-stripe-go/main.go
@@ -1,128 +1,49 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"log"
 	"net/http"
-	"time"
+	"os"
 
 	openmeter "github.com/openmeterio/openmeter/api"
 	stripe "github.com/stripe/stripe-go/v74"
-	"github.com/stripe/stripe-go/v74/usagerecord"
-	"github.com/stripe/stripe-go/v74/webhook"
 )
 
 // Stripe Key.
-var stripeKey = "sk_test_secret"
+// Go to https://dashboard.stripe.com/test/apikeys to obtain yours
+var stripeKey = os.Getenv("STRIPE_KEY") // sk_test_...""
 
 // Stripe Webhook Secret
 // Replace this endpoint secret with your endpoint's unique secret
 // If you are testing with the CLI, find the secret by running 'stripe listen'
 // If you are using an endpoint defined with the API or dashboard, look in your webhook settings
 // at https://dashboard.stripe.com/webhooks
-var endpointSecret = "whsec_test_secret"
-
-// Map Stripe Price(s) to OpenMeter meter(s)
-var stripePriceIdToMeterId = map[string]string{
-	"price_xxx": "requests",
-}
+var endpointSecret = os.Getenv("STRIPE_WEBHOOK_SECRET") // "whsec_...."
 
 func main() {
+	stripe.Key = stripeKey
+
+	// Setup Stripe test product, price and customer
+	err := SetupStripe()
+	if err != nil {
+		panic(err)
+	}
+
+	// Initialize OpenMeter client
 	om, err := openmeter.NewClient("http://localhost:8888")
 	if err != nil {
 		panic(err.Error())
 	}
 
-	stripe.Key = stripeKey
+	// Initialize server
 	server := Server{
-		openmeter: om,
+		endpointSecret: endpointSecret,
+		openmeter:      om,
 	}
 
+	// Run server
 	http.HandleFunc("/webhook", server.handleWebhook)
 	addr := "localhost:4242"
 	log.Printf("Listening on %s", addr)
 	log.Fatal(http.ListenAndServe(addr, nil))
-}
-
-type Server struct {
-	openmeter *openmeter.Client
-}
-
-// See: https://stripe.com/docs/webhooks/quickstart
-func (s *Server) handleWebhook(w http.ResponseWriter, req *http.Request) {
-	const MaxBodyBytes = int64(65536)
-	req.Body = http.MaxBytesReader(w, req.Body, MaxBodyBytes)
-	payload, err := io.ReadAll(req.Body)
-	// handle err
-
-	event := stripe.Event{}
-	err = json.Unmarshal(payload, &event)
-	// handle err
-
-	signatureHeader := req.Header.Get("Stripe-Signature")
-	event, err = webhook.ConstructEvent(payload, signatureHeader, endpointSecret)
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Webhook signature verification failed. %v", err), http.StatusBadRequest)
-		return
-	}
-	// Unmarshal the event data into an appropriate struct depending on its Type
-	switch event.Type {
-	case "customer.subscription.updated":
-		var subscription stripe.Subscription
-		err = json.Unmarshal(event.Data.Raw, &subscription)
-		// handle err
-
-		s.reportUsage(req.Context(), &subscription)
-	default:
-		// log unhandled event type
-	}
-
-	w.WriteHeader(http.StatusOK)
-}
-
-func (s *Server) reportUsage(ctx context.Context, subscription *stripe.Subscription) {
-	for _, item := range subscription.Items.Data {
-		// Skip invoice item item if didn't have corresponding OpenMeter meter
-		if stripePriceIdToMeterId[item.Price.ID] == "" {
-			return
-		}
-		// Or not metered
-		if item.Price.Recurring.UsageType != "metered" {
-			return
-		}
-
-		// Query total usage from OpenMeter for billing period
-		meterId := stripePriceIdToMeterId[item.Price.ID]
-		periodStart := time.Unix(subscription.CurrentPeriodStart, 0)
-		periodEnd := time.Unix(subscription.CurrentPeriodEnd, 0)
-
-		_, err := s.openmeter.GetValuesByMeterId(ctx, meterId, &openmeter.GetValuesByMeterIdParams{
-			// If you don't report usage events via Stripe Customer ID you need to map Stripe IDs to your internal ID
-			Subject: &subscription.Customer.ID,
-			From:    &periodStart,
-			To:      &periodEnd,
-		})
-		if err != nil {
-			// handle err
-		}
-		var total int64 = 2000000
-
-		// Report usage to Stripe
-		// We use action=set so even if this webhook get called multiple time
-		// we still end up with only one usage record for the same period.
-		// We report on `CurrentPeriodStart` because it's going to be the
-		// same between Webhook calls and we add one as Stripe doesn't allow
-		// to report usage on the exact start and end time of the subscription.
-		recordParams := &stripe.UsageRecordParams{
-			Action:           stripe.String("set"),
-			Quantity:         stripe.Int64(total),
-			SubscriptionItem: stripe.String(item.ID),
-			Timestamp:        stripe.Int64(subscription.CurrentPeriodStart + 1),
-		}
-		_, err = usagerecord.New(recordParams)
-		// handle err
-	}
 }

--- a/examples/export-stripe-go/server.go
+++ b/examples/export-stripe-go/server.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	openmeter "github.com/openmeterio/openmeter/api"
+	stripe "github.com/stripe/stripe-go/v74"
+	"github.com/stripe/stripe-go/v74/usagerecord"
+	"github.com/stripe/stripe-go/v74/webhook"
+)
+
+type Server struct {
+	endpointSecret string
+	openmeter      *openmeter.Client
+}
+
+// See: https://stripe.com/docs/webhooks/quickstart
+func (s *Server) handleWebhook(w http.ResponseWriter, req *http.Request) {
+	const MaxBodyBytes = int64(65536)
+	req.Body = http.MaxBytesReader(w, req.Body, MaxBodyBytes)
+	payload, err := io.ReadAll(req.Body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading request body: %v\n", err)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	event := stripe.Event{}
+	err = json.Unmarshal(payload, &event)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  Webhook error while parsing basic request. %v\n", err.Error())
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	signatureHeader := req.Header.Get("Stripe-Signature")
+	event, err = webhook.ConstructEvent(payload, signatureHeader, s.endpointSecret)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Webhook signature verification failed. %v", err), http.StatusBadRequest)
+		return
+	}
+	// Unmarshal the event data into an appropriate struct depending on its Type
+	switch event.Type {
+	case "customer.subscription.updated":
+		var subscription stripe.Subscription
+		err = json.Unmarshal(event.Data.Raw, &subscription)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing webhook JSON: %v\n", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		err = s.reportUsage(req.Context(), &subscription)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error usage report: %v\n", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) reportUsage(ctx context.Context, subscription *stripe.Subscription) error {
+	for _, item := range subscription.Items.Data {
+		// Skip subscription item if it's not metered
+		if item.Price.Recurring.UsageType != "metered" {
+			return nil
+		}
+
+		meterId := item.Metadata["om_meter_id"]
+		// Skip subscription item if doesn't have corresponding OpenMeter meter
+		if meterId == "" {
+			return nil
+		}
+
+		// We round down period to closest windows as OpenMeter aggregates usage in windows.
+		// Usage occuring between rounded down CurrentPeriodEnd and CurrentPeriodEnd will be attributed to the next billing period.
+		periodStart := time.Unix(subscription.CurrentPeriodStart, 0).Truncate(time.Hour)
+		periodEnd := time.Unix(subscription.CurrentPeriodEnd, 0).Truncate(time.Hour)
+
+		// Query usage from OpenMeter for billing period
+		resp, err := s.openmeter.GetValuesByMeterId(ctx, meterId, &openmeter.GetValuesByMeterIdParams{
+			// If you don't report usage events via Stripe Customer ID you need to map Stripe IDs to your internal ID
+			Subject: &subscription.Customer.ID,
+			From:    &periodStart,
+			To:      &periodEnd,
+		})
+		if err != nil {
+			return err
+		}
+		payload, err := openmeter.ParseGetValuesByMeterIdResponse(resp)
+		if err != nil {
+			return err
+		}
+
+		// TODO (pmarton): switch to OpenMeter aggregate API
+		var total float32 = 0
+		for _, value := range *payload.JSON200.Values {
+			total += *value.Value
+		}
+
+		// Debug log
+		fmt.Printf(
+			"stripe_customer: %s, stripe_price: %s, meter: %s, total_usage: %f, from: %s, to: %s",
+			subscription.Customer.ID,
+			item.Price.ID,
+			meterId,
+			total,
+			periodStart.String(),
+			periodEnd.String(),
+		)
+
+		// Report usage to Stripe
+		// We use action=set so even if this webhook get called multiple time
+		// we still end up with only one usage record for the same period.
+		// We report on `CurrentPeriodStart` because it's going to be the
+		// same between Webhook calls and we add one as Stripe doesn't allow
+		// to report usage on the exact start and end time of the subscription.
+		recordParams := &stripe.UsageRecordParams{
+			Action:           stripe.String("set"),
+			Quantity:         stripe.Int64(int64(total)),
+			SubscriptionItem: stripe.String(item.ID),
+			Timestamp:        stripe.Int64(subscription.CurrentPeriodStart + 1),
+		}
+		_, err = usagerecord.New(recordParams)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/examples/export-stripe-go/setup.go
+++ b/examples/export-stripe-go/setup.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+
+	stripe "github.com/stripe/stripe-go/v74"
+	stripeCustomer "github.com/stripe/stripe-go/v74/customer"
+	stripePrice "github.com/stripe/stripe-go/v74/price"
+	stripeProduct "github.com/stripe/stripe-go/v74/product"
+	stripeSubscription "github.com/stripe/stripe-go/v74/subscription"
+)
+
+// Meter in your config, we use it to map our price to this meter
+var meterId = "m1"
+
+func SetupStripe() error {
+	// Create a Stripe Product
+	product, err := stripeProduct.New(&stripe.ProductParams{
+		Name: stripe.String("Execution Duration"),
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Stripe product created: https://dashboard.stripe.com/test/products/%s\n", product.ID)
+
+	// Create a metered Stripe Price
+	price, err := stripePrice.New(&stripe.PriceParams{
+		Product: &product.ID,
+		// The meter ID this price belongs to
+		Currency: stripe.String(string(stripe.CurrencyUSD)),
+		Recurring: &stripe.PriceRecurringParams{
+			Interval:  stripe.String(string(stripe.PlanIntervalMonth)),
+			UsageType: stripe.String(string(stripe.PlanUsageTypeMetered)),
+		},
+		BillingScheme: stripe.String(string(stripe.PlanBillingSchemePerUnit)),
+		UnitAmount:    stripe.Int64(10), // cents
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Stripe price created: https://dashboard.stripe.com/test/prices/%s\n", price.ID)
+
+	// Create a Stripe customer
+	customer, err := stripeCustomer.New(&stripe.CustomerParams{
+		Name: stripe.String("My Awesome Customer"),
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Stripe customer created: https://dashboard.stripe.com/test/customers/%s\n", customer.ID)
+
+	// Start a new Stripe subscription for customer with the price created above
+	subscription, err := stripeSubscription.New(&stripe.SubscriptionParams{
+		Customer: &customer.ID,
+		Items: []*stripe.SubscriptionItemsParams{
+			{
+				Price: &price.ID,
+				Metadata: map[string]string{
+					"om_meter_id": meterId,
+				},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Stripe subscription created: https://dashboard.stripe.com/test/subscriptions/%s\n", subscription.ID)
+
+	return nil
+}


### PR DESCRIPTION
## Overview

Improve Stripe export example.

- setup Stripe entities via code to reduce steps
- remove unnecessary webhook setup
- round down period dates