### PR TITLE
ci: disable fossa scan on pull-requests for now

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,6 +95,7 @@ jobs:
   fossa-scan:
     name: FOSSA Scan
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Overview

Dependabot PRs have been failing due to FOSSA not being able to push reports. (The reason behind that is the secret is not available to external PRs)

Let's disable FOSSA on PRs for now.

Fixes #17
