### PR TITLE
feat(example): ai tokens

### DIFF
--- a/examples/export-stripe-node/.gitignore
+++ b/examples/export-stripe-node/.gitignore
@@ -1,1 +1,2 @@
+.env
 node_modules

--- a/examples/export-stripe-node/README.md
+++ b/examples/export-stripe-node/README.md
@@ -7,7 +7,7 @@ You can read more about Stripe's Usage-Based Pricing features [here](https://str
 
 ## Our Example
 
-In this example, we integrate usage reporting with Stripe for an imaginary serverless product called Epsilon which charges their customer after execution duration.
+In this example, we integrate usage reporting with Stripe for an imaginary AI product that need to attribute Chat GPT token usage to their users.
 To report usage, Stripe recommends a [periodic usage reporting](https://stripe.com/docs/billing/subscriptions/usage-based#report).
 In this example we will report usage when `npm start` is executed. In a real app you want to report usage periodically via cron or workflow management.
 

--- a/examples/export-stripe-node/README.md
+++ b/examples/export-stripe-node/README.md
@@ -13,7 +13,7 @@ In this example we will report usage when `npm start` is executed. In a real app
 
 ## 1. Setting Up Stripe
 
-In this example we will create a metered product and price with a monthly recurring billing period, priced at $0.1 per unit.
+In this example we will create a metered product called `AI Tokens` and price with a monthly recurring billing period, priced at $0.01 per unit (per token).
 Run the setup code in this repo with your [Stripe key](https://dashboard.stripe.com/test/apikeys):
 
 ```sh

--- a/examples/export-stripe-node/app.ts
+++ b/examples/export-stripe-node/app.ts
@@ -1,6 +1,7 @@
 import assert from 'assert'
 import fs from 'fs'
 
+import 'dotenv/config'
 import yml from 'yaml'
 import Stripe from 'stripe'
 import moment from 'moment'
@@ -14,6 +15,9 @@ assert.ok(
   'STRIPE_KEY environment variables is required'
 )
 
+// Special flag to trigger this example to report all usage occured in this month
+const reportAll = process.env.REPORT_ALL === 'true'
+
 const stripe = new Stripe(process.env.STRIPE_KEY, { apiVersion: '2022-11-15' })
 const openmeterApi = fs.readFileSync('../../api/openapi.yml', 'utf8')
 const openmeter = await new OpenAPIClientAxios({
@@ -22,15 +26,24 @@ const openmeter = await new OpenAPIClientAxios({
 }).initSync<OpenMeterClient>()
 
 // In a real app you will probably report hourly or daily and run this script at the same frequency via cron or workflow management
-const reportingFrequency = 'second'
+const reportingFrequency = 'hour'
 
 async function main() {
   // We round down period to closest windows as OpenMeter aggregates usage in windows.
   // Usage occuring between rounded down date and now will be attributed to the next billing period.
-  const to = moment().startOf(reportingFrequency).toDate()
-  const from = moment(to).subtract(1, reportingFrequency).toDate()
+  let to = moment().startOf(reportingFrequency).toDate()
+  let from = moment(to).subtract(1, reportingFrequency).toDate()
+
+  // With special flag we report entire month, useful for testing
+  if (reportAll) {
+    from = moment(to).startOf('month').toDate()
+    to = moment().endOf('month').toDate()
+  }
+
+  // List all stripe active subscriptions and expand customer object
   const { data: subscriptions } = await stripe.subscriptions.list({
     status: 'active',
+    expand: ['data.customer']
   })
 
   // Report usage for all active subscriptions
@@ -39,8 +52,12 @@ async function main() {
     if (moment(subscription.current_period_start).isAfter(to)) {
       continue
     }
+    // Type checking for TypeScript
+    if (!isCustomer(subscription.customer)) {
+      throw new TypeError('Must be customer with expand option')
+    }
 
-    await reportUsage(subscription, from, to)
+    await reportUsage(subscription.customer, subscription, from, to)
   }
 }
 
@@ -52,10 +69,17 @@ main()
  * Reports usage to Stripe
  */
 async function reportUsage(
+  customer: Stripe.Customer,
   subscription: Stripe.Subscription,
   from: Date,
   to: Date
 ) {
+  // Skip customer item if doesn't have corresponding key
+  const subject = customer.metadata['external_key']
+  if (!subject) {
+    return
+  }
+
   for (const item of subscription.items.data) {
     // Skip non metered items
     if (item.price.recurring?.usage_type != 'metered') {
@@ -69,15 +93,11 @@ async function reportUsage(
     }
 
     // Query usage from OpenMeter for billing period
-    const customerId =
-      typeof subscription.customer === 'object'
-        ? subscription.customer.id
-        : subscription.customer
     const values = await openmeter.getValuesByMeterId({
       meterId,
-      subject: customerId,
+      subject,
       from: from.toISOString(),
-      to: to.toISOString(),
+      to: moment(to).endOf('day').toISOString(),
     })
 
     // Sum usage windows
@@ -91,23 +111,34 @@ async function reportUsage(
     }
 
     // Report usage to Stripe
-    const timestamp = moment(to).unix()
+    let reportingTimestamp: number | 'now' = moment(to).unix()
+    if (reportAll) {
+      reportingTimestamp = moment().unix()
+    }
     await stripe.subscriptionItems.createUsageRecord(
       item.id,
       {
         quantity: total,
-        timestamp,
+        timestamp: reportingTimestamp,
         action: 'set',
       },
       {
         // Ensures we only report once even if scripts runs multiple times.
-        idempotencyKey: `${item.id}-${timestamp}`,
+        idempotencyKey: `${item.id}-${reportingTimestamp}`,
       }
     )
 
     // Debug log
     console.debug(
-      `stripe_customer: ${customerId}, stripe_price: ${item.price.id}, meter: ${meterId}, total_usage: ${total}, from: ${from}, to: ${to}`
+      `stripe_customer: ${customer.id}, stripe_price: ${item.price.id}, subject: ${subject}, meter: ${meterId}, total_usage: ${total}, from: ${from}, to: ${to}`
     )
   }
+}
+
+// Typeguard that returns true if customer is a `Stripe.Customer`
+function isCustomer(customer: string | Stripe.Customer | Stripe.DeletedCustomer): customer is Stripe.Customer {
+  if (typeof customer === 'object' && !customer.deleted) {
+    return true
+  }
+  return false
 }

--- a/examples/export-stripe-node/package-lock.json
+++ b/examples/export-stripe-node/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "^1.4.0",
+        "dotenv": "^16.1.4",
         "moment": "^2.29.4",
         "openapi-client-axios": "^7.1.3",
         "stripe": "^12.8.0",
@@ -471,6 +472,17 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
+      "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {
@@ -1450,6 +1462,11 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+    },
+    "dotenv": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
+      "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw=="
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/examples/export-stripe-node/package.json
+++ b/examples/export-stripe-node/package.json
@@ -5,7 +5,7 @@
   "main": "app.ts",
   "type": "module",
   "scripts": {
-    "start": "ts-node app.ts",
+    "start": "TZ=utc ts-node app.ts",
     "setup": "ts-node setup.ts",
     "lint": "prettier --write .",
     "typegen": "typegen ../../api/openapi.yml > ./openapi.d.ts",
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "axios": "^1.4.0",
+    "dotenv": "^16.1.4",
     "moment": "^2.29.4",
     "openapi-client-axios": "^7.1.3",
     "stripe": "^12.8.0",

--- a/examples/export-stripe-node/setup.ts
+++ b/examples/export-stripe-node/setup.ts
@@ -33,7 +33,7 @@ async function setup() {
       usage_type: 'metered',
     },
     billing_scheme: 'per_unit',
-    unit_amount: 10, // cents
+    unit_amount: 1, // cent
   })
   console.log(
     `Stripe price created: https://dashboard.stripe.com/test/prices/${price.id}`

--- a/examples/export-stripe-node/setup.ts
+++ b/examples/export-stripe-node/setup.ts
@@ -1,5 +1,6 @@
 import assert from 'assert'
 
+import 'dotenv/config'
 import Stripe from 'stripe'
 
 // Environment variables
@@ -11,12 +12,12 @@ assert.ok(
 const stripe = new Stripe(process.env.STRIPE_KEY, { apiVersion: '2022-11-15' })
 
 // Meter in your config, we use it to map our price to this meter
-var meterId = 'm1'
+var meterId = 'm2'
 
 async function setup() {
   // Create a Stripe Product
   const product = await stripe.products.create({
-    name: 'Execution Duration',
+    name: 'AI Tokens',
   })
   console.log(
     `Stripe product created: https://dashboard.stripe.com/test/products/${product.id}`
@@ -41,6 +42,10 @@ async function setup() {
   // Create a Stripe customer
   const customer = await stripe.customers.create({
     name: 'My Awesome Customer',
+    metadata: {
+      // Useful to map to internal ID
+      external_key: 'my-awesome-user-id'
+    }
   })
   console.log(
     `Stripe customer created: https://dashboard.stripe.com/test/customers/${customer.id}`

--- a/examples/ingest-openai-node/.gitignore
+++ b/examples/ingest-openai-node/.gitignore
@@ -1,1 +1,2 @@
+.env
 node_modules

--- a/examples/ingest-openai-node/.prettierrc.json
+++ b/examples/ingest-openai-node/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true
+}

--- a/examples/ingest-openai-node/README.md
+++ b/examples/ingest-openai-node/README.md
@@ -44,8 +44,8 @@ await openmeter.ingestEvents(null, {
     total_tokens: data.usage.total_tokens,
     prompt_tokens: data.usage.prompt_tokens,
     completion_tokens: data.usage.completion_tokens,
-    model: data.model
-  }
+    model: data.model,
+  },
 })
 ```
 

--- a/examples/ingest-openai-node/app.ts
+++ b/examples/ingest-openai-node/app.ts
@@ -1,15 +1,27 @@
 import fs from 'fs'
+import assert from 'assert'
 
-import { Configuration, OpenAIApi } from "openai";
+import 'dotenv/config'
+import { Configuration, OpenAIApi } from 'openai'
 import { OpenAPIClientAxios } from 'openapi-client-axios'
 import yml from 'yaml'
-import { Client as OpenMeterClient } from './openapi';
+import { Client as OpenMeterClient } from './openapi'
+
+// Environment variables
+assert.ok(
+  process.env.OPENAI_ORG,
+  'OPENAI_ORG environment variables is required'
+)
+assert.ok(
+  process.env.OPENAI_API_KEY,
+  'OPENAI_API_KEY environment variables is required'
+)
 
 const configuration = new Configuration({
   organization: process.env.OPENAI_ORG,
   apiKey: process.env.OPENAI_API_KEY,
-});
-const openai = new OpenAIApi(configuration);
+})
+const openai = new OpenAIApi(configuration)
 const openmeterApi = fs.readFileSync('../../api/openapi.yml', 'utf8')
 const openmeter = await new OpenAPIClientAxios({
   definition: yml.parse(openmeterApi),
@@ -18,28 +30,36 @@ const openmeter = await new OpenAPIClientAxios({
 
 async function main() {
   const { data } = await openai.createChatCompletion({
-    model: "gpt-3.5-turbo",
-    messages: [{ role: "user", content: "Hello world" }],
-  });
+    model: 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: 'Hello world' }],
+  })
 
   if (data.usage) {
-    await openmeter.ingestEvents(null, {
-      specversion: '1.0',
-      // We use Open AI response ID as idempotent key
-      id: data.id,
-      source: 'my-app',
-      type: 'openai',
-      subject: 'my-awesome-user-id',
-      // We get date from Open AI response
-      time: new Date(data.created * 1000).toISOString(),
-      // We report usage with model
-      data: {
-        total_tokens: data.usage.total_tokens,
-        prompt_tokens: data.usage.prompt_tokens,
-        completion_tokens: data.usage.completion_tokens,
-        model: data.model
+    await openmeter.ingestEvents(
+      null,
+      {
+        specversion: '1.0',
+        // We use Open AI response ID as idempotent key
+        id: data.id,
+        source: 'my-app',
+        type: 'openai',
+        subject: 'my-awesome-user-id',
+        // We get date from Open AI response
+        time: new Date(data.created * 1000).toISOString(),
+        // We report usage with model
+        data: {
+          total_tokens: data.usage.total_tokens,
+          prompt_tokens: data.usage.prompt_tokens,
+          completion_tokens: data.usage.completion_tokens,
+          model: data.model,
+        },
+      },
+      {
+        headers: {
+          'Content-Type': 'application/cloudevents+json',
+        },
       }
-    })
+    )
   }
 }
 

--- a/examples/ingest-openai-node/app.ts
+++ b/examples/ingest-openai-node/app.ts
@@ -60,6 +60,10 @@ async function main() {
         },
       }
     )
+
+    // Debug logs
+    console.debug(`input: Hello world, output: ${data.choices.map(({ message }) => message?.content).join(' ')}`)
+    console.debug(`total_tokens: ${data.usage.total_tokens}, subject: my-awesome-user-id`)
   }
 }
 

--- a/examples/ingest-openai-node/openapi.d.ts
+++ b/examples/ingest-openai-node/openapi.d.ts
@@ -4,188 +4,193 @@ import type {
   UnknownParamsObject,
   OperationResponse,
   AxiosRequestConfig,
-} from 'openapi-client-axios'; 
+} from 'openapi-client-axios'
 
 declare namespace Components {
-    namespace Schemas {
-        export interface Error {
-            statusCode?: number; // int32
-            status?: string;
-            code?: number; // int32
-            message?: string;
-        }
-        /**
-         * CloudEvents Specification JSON Schema
-         */
-        export interface Event {
-            /**
-             * Identifies the event.
-             * example:
-             * A234-1234-1234
-             */
-            id: string;
-            /**
-             * Identifies the context in which an event happened.
-             * example:
-             * https://github.com/cloudevents
-             */
-            source: string; // uri-reference
-            /**
-             * The version of the CloudEvents specification which the event uses.
-             * example:
-             * 1.0
-             */
-            specversion: string;
-            /**
-             * Describes the type of event related to the originating occurrence.
-             * example:
-             * com.github.pull_request.opened
-             */
-            type: string;
-            /**
-             * Content type of the data value. Must adhere to RFC 2046 format.
-             * example:
-             * application/json
-             */
-            datacontenttype?: "application/json";
-            /**
-             * Identifies the schema that data adheres to.
-             */
-            dataschema?: string | null; // uri
-            /**
-             * Describes the subject of the event in the context of the event producer (identified by source).
-             * example:
-             * mynewfile.jpg
-             */
-            subject: string | null;
-            /**
-             * Timestamp of when the occurrence happened. Must adhere to RFC 3339.
-             * example:
-             * 2018-04-05T17:31:00Z
-             */
-            time?: string | null; // date-time
-            /**
-             * The event payload.
-             * example:
-             * {"foo": "bar"}
-             *
-             */
-            data?: {
-                [name: string]: any;
-            };
-        }
-        export interface Meter {
-            /**
-             * example:
-             * my_meter
-             */
-            id?: string;
-            /**
-             * example:
-             * My Meter
-             */
-            name?: string;
-            /**
-             * example:
-             * My Meter Description
-             */
-            description?: string;
-            /**
-             * example:
-             * {
-             *   "my_label": "my_value"
-             * }
-             *
-             */
-            labels?: {
-                [name: string]: string;
-            };
-            /**
-             * example:
-             * event_type
-             */
-            type?: string;
-            /**
-             * example:
-             * SUM
-             */
-            aggregation?: "SUM" | "COUNT" | "MAX" | "COUNT_DISTINCT" | "LATEST_BY_OFFSET";
-            /**
-             * JSONPath expression to extract the value from the event data.
-             * example:
-             * $.duration_ms
-             */
-            valueProperty?: string;
-            /**
-             * JSONPath expressions to extract the group by values from the event data.
-             * example:
-             * [
-             *   "$.my_label"
-             * ]
-             *
-             */
-            groupBy?: string[];
-        }
+  namespace Schemas {
+    export interface Error {
+      statusCode?: number // int32
+      status?: string
+      code?: number // int32
+      message?: string
     }
+    /**
+     * CloudEvents Specification JSON Schema
+     */
+    export interface Event {
+      /**
+       * Identifies the event.
+       * example:
+       * A234-1234-1234
+       */
+      id: string
+      /**
+       * Identifies the context in which an event happened.
+       * example:
+       * https://github.com/cloudevents
+       */
+      source: string // uri-reference
+      /**
+       * The version of the CloudEvents specification which the event uses.
+       * example:
+       * 1.0
+       */
+      specversion: string
+      /**
+       * Describes the type of event related to the originating occurrence.
+       * example:
+       * com.github.pull_request.opened
+       */
+      type: string
+      /**
+       * Content type of the data value. Must adhere to RFC 2046 format.
+       * example:
+       * application/json
+       */
+      datacontenttype?: 'application/json'
+      /**
+       * Identifies the schema that data adheres to.
+       */
+      dataschema?: string | null // uri
+      /**
+       * Describes the subject of the event in the context of the event producer (identified by source).
+       * example:
+       * mynewfile.jpg
+       */
+      subject: string | null
+      /**
+       * Timestamp of when the occurrence happened. Must adhere to RFC 3339.
+       * example:
+       * 2018-04-05T17:31:00Z
+       */
+      time?: string | null // date-time
+      /**
+       * The event payload.
+       * example:
+       * {"foo": "bar"}
+       *
+       */
+      data?: {
+        [name: string]: any
+      }
+    }
+    export interface Meter {
+      /**
+       * example:
+       * my_meter
+       */
+      id?: string
+      /**
+       * example:
+       * My Meter
+       */
+      name?: string
+      /**
+       * example:
+       * My Meter Description
+       */
+      description?: string
+      /**
+       * example:
+       * {
+       *   "my_label": "my_value"
+       * }
+       *
+       */
+      labels?: {
+        [name: string]: string
+      }
+      /**
+       * example:
+       * event_type
+       */
+      type?: string
+      /**
+       * example:
+       * SUM
+       */
+      aggregation?:
+        | 'SUM'
+        | 'COUNT'
+        | 'MAX'
+        | 'COUNT_DISTINCT'
+        | 'LATEST_BY_OFFSET'
+      /**
+       * JSONPath expression to extract the value from the event data.
+       * example:
+       * $.duration_ms
+       */
+      valueProperty?: string
+      /**
+       * JSONPath expressions to extract the group by values from the event data.
+       * example:
+       * [
+       *   "$.my_label"
+       * ]
+       *
+       */
+      groupBy?: string[]
+    }
+  }
 }
 declare namespace Paths {
-    namespace GetMeters {
-        namespace Responses {
-            export type $200 = Components.Schemas.Meter[];
-            export type Default = Components.Schemas.Error;
-        }
+  namespace GetMeters {
+    namespace Responses {
+      export type $200 = Components.Schemas.Meter[]
+      export type Default = Components.Schemas.Error
     }
-    namespace GetMetersById {
-        namespace Parameters {
-            export type MeterId = string;
-        }
-        export interface PathParameters {
-            meterId: Parameters.MeterId;
-        }
-        namespace Responses {
-            export type $200 = Components.Schemas.Meter;
-            export type $404 = Components.Schemas.Error;
-            export type Default = Components.Schemas.Error;
-        }
+  }
+  namespace GetMetersById {
+    namespace Parameters {
+      export type MeterId = string
     }
-    namespace GetValuesByMeterId {
-        namespace Parameters {
-            export type From = string; // date-time
-            export type MeterId = string;
-            export type Subject = string;
-            export type To = string; // date-time
-        }
-        export interface PathParameters {
-            meterId: Parameters.MeterId;
-        }
-        export interface QueryParameters {
-            from?: Parameters.From /* date-time */;
-            to?: Parameters.To /* date-time */;
-            subject?: Parameters.Subject;
-        }
-        namespace Responses {
-            export interface $200 {
-                values?: {
-                    subject?: string;
-                    windowStart?: string; // date-time
-                    windowEnd?: string; // date-time
-                    value?: number;
-                    groupBy?: {
-                        [name: string]: string;
-                    };
-                }[];
-            }
-            export type Default = Components.Schemas.Error;
-        }
+    export interface PathParameters {
+      meterId: Parameters.MeterId
     }
-    namespace IngestEvents {
-        export type RequestBody = /* CloudEvents Specification JSON Schema */ Components.Schemas.Event;
-        namespace Responses {
-            export interface $200 {
-            }
-            export type Default = Components.Schemas.Error;
-        }
+    namespace Responses {
+      export type $200 = Components.Schemas.Meter
+      export type $404 = Components.Schemas.Error
+      export type Default = Components.Schemas.Error
     }
+  }
+  namespace GetValuesByMeterId {
+    namespace Parameters {
+      export type From = string // date-time
+      export type MeterId = string
+      export type Subject = string
+      export type To = string // date-time
+    }
+    export interface PathParameters {
+      meterId: Parameters.MeterId
+    }
+    export interface QueryParameters {
+      from?: Parameters.From /* date-time */
+      to?: Parameters.To /* date-time */
+      subject?: Parameters.Subject
+    }
+    namespace Responses {
+      export interface $200 {
+        values?: {
+          subject?: string
+          windowStart?: string // date-time
+          windowEnd?: string // date-time
+          value?: number
+          groupBy?: {
+            [name: string]: string
+          }
+        }[]
+      }
+      export type Default = Components.Schemas.Error
+    }
+  }
+  namespace IngestEvents {
+    export type RequestBody =
+      /* CloudEvents Specification JSON Schema */ Components.Schemas.Event
+    namespace Responses {
+      export interface $200 {}
+      export type Default = Components.Schemas.Error
+    }
+  }
 }
 
 export interface OperationMethods {
@@ -195,7 +200,7 @@ export interface OperationMethods {
   'ingestEvents'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: Paths.IngestEvents.RequestBody,
-    config?: AxiosRequestConfig  
+    config?: AxiosRequestConfig
   ): OperationResponse<Paths.IngestEvents.Responses.$200>
   /**
    * getMeters - Get meters
@@ -203,7 +208,7 @@ export interface OperationMethods {
   'getMeters'(
     parameters?: Parameters<UnknownParamsObject> | null,
     data?: any,
-    config?: AxiosRequestConfig  
+    config?: AxiosRequestConfig
   ): OperationResponse<Paths.GetMeters.Responses.$200>
   /**
    * getMetersById - Get meter by ID
@@ -211,15 +216,18 @@ export interface OperationMethods {
   'getMetersById'(
     parameters?: Parameters<Paths.GetMetersById.PathParameters> | null,
     data?: any,
-    config?: AxiosRequestConfig  
+    config?: AxiosRequestConfig
   ): OperationResponse<Paths.GetMetersById.Responses.$200>
   /**
    * getValuesByMeterId - Get meter values
    */
   'getValuesByMeterId'(
-    parameters?: Parameters<Paths.GetValuesByMeterId.PathParameters & Paths.GetValuesByMeterId.QueryParameters> | null,
+    parameters?: Parameters<
+      Paths.GetValuesByMeterId.PathParameters &
+        Paths.GetValuesByMeterId.QueryParameters
+    > | null,
     data?: any,
-    config?: AxiosRequestConfig  
+    config?: AxiosRequestConfig
   ): OperationResponse<Paths.GetValuesByMeterId.Responses.$200>
 }
 
@@ -231,7 +239,7 @@ export interface PathsDictionary {
     'post'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: Paths.IngestEvents.RequestBody,
-      config?: AxiosRequestConfig  
+      config?: AxiosRequestConfig
     ): OperationResponse<Paths.IngestEvents.Responses.$200>
   }
   ['/api/v1/meters']: {
@@ -241,7 +249,7 @@ export interface PathsDictionary {
     'get'(
       parameters?: Parameters<UnknownParamsObject> | null,
       data?: any,
-      config?: AxiosRequestConfig  
+      config?: AxiosRequestConfig
     ): OperationResponse<Paths.GetMeters.Responses.$200>
   }
   ['/api/v1/meters/{meterId}']: {
@@ -251,7 +259,7 @@ export interface PathsDictionary {
     'get'(
       parameters?: Parameters<Paths.GetMetersById.PathParameters> | null,
       data?: any,
-      config?: AxiosRequestConfig  
+      config?: AxiosRequestConfig
     ): OperationResponse<Paths.GetMetersById.Responses.$200>
   }
   ['/api/v1/meters/{meterId}/values']: {
@@ -259,9 +267,12 @@ export interface PathsDictionary {
      * getValuesByMeterId - Get meter values
      */
     'get'(
-      parameters?: Parameters<Paths.GetValuesByMeterId.PathParameters & Paths.GetValuesByMeterId.QueryParameters> | null,
+      parameters?: Parameters<
+        Paths.GetValuesByMeterId.PathParameters &
+          Paths.GetValuesByMeterId.QueryParameters
+      > | null,
       data?: any,
-      config?: AxiosRequestConfig  
+      config?: AxiosRequestConfig
     ): OperationResponse<Paths.GetValuesByMeterId.Responses.$200>
   }
 }

--- a/examples/ingest-openai-node/package-lock.json
+++ b/examples/ingest-openai-node/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "^1.4.0",
+        "dotenv": "^16.1.4",
         "openai": "^3.2.1",
         "openapi-client-axios": "^7.1.3",
         "ts-node": "^10.9.1",
@@ -16,7 +17,8 @@
         "yaml": "^2.3.1"
       },
       "devDependencies": {
-        "openapi-client-axios-typegen": "^7.2.0"
+        "openapi-client-axios-typegen": "^7.2.0",
+        "prettier": "^2.8.8"
       }
     },
     "node_modules/@anttiviljami/dtsgenerator": {
@@ -370,6 +372,17 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
+      "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -661,6 +674,21 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/proxy-from-env": {
@@ -1148,6 +1176,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
+    "dotenv": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
+      "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw=="
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1364,6 +1397,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "proxy-from-env": {

--- a/examples/ingest-openai-node/package.json
+++ b/examples/ingest-openai-node/package.json
@@ -6,11 +6,13 @@
   "type": "module",
   "scripts": {
     "start": "ts-node app.ts",
+    "lint": "prettier --write .",
     "typegen": "typegen ../../api/openapi.yml > ./openapi.d.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
     "axios": "^1.4.0",
+    "dotenv": "^16.1.4",
     "openai": "^3.2.1",
     "openapi-client-axios": "^7.1.3",
     "ts-node": "^10.9.1",
@@ -18,6 +20,7 @@
     "yaml": "^2.3.1"
   },
   "devDependencies": {
-    "openapi-client-axios-typegen": "^7.2.0"
+    "openapi-client-axios-typegen": "^7.2.0",
+    "prettier": "^2.8.8"
   }
 }

--- a/examples/ingest-openai-node/tsconfig.json
+++ b/examples/ingest-openai-node/tsconfig.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "lib": [
-      "es2022"
-    ],
+    "lib": ["es2022"],
     "moduleResolution": "node",
     "module": "es2022",
     "target": "es2022",

--- a/quickstart/config.yaml
+++ b/quickstart/config.yaml
@@ -7,3 +7,10 @@ meters:
     groupBy:
       - $.method
       - $.path
+  - id: m2
+    name: Open AI Tokens
+    type: openai
+    valueProperty: $.total_tokens
+    aggregation: SUM
+    groupBy:
+      - $.model

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -21,6 +21,8 @@ services:
     image: alpine/curl:3.14
     entrypoint: /bin/sh
     tty: true
+    depends_on:
+      - ksqldb-server
     healthcheck:
       test: curl --fail http://ksqldb-server:8088/healthcheck
       interval: 5s
@@ -33,6 +35,8 @@ services:
       service: zookeeper
 
   broker:
+    depends_on:
+      - zookeeper
     extends:
       file: ../docker-compose.yaml
       service: broker
@@ -40,11 +44,15 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:9092,PLAINTEXT_HOST://broker:29092
 
   schema:
+    depends_on:
+      - broker
     extends:
       file: ../docker-compose.yaml
       service: schema
 
   ksqldb-server:
+    depends_on:
+      - broker
     extends:
       file: ../docker-compose.yaml
       service: ksqldb-server


### PR DESCRIPTION
## Overview

- add `depends_on` to quickstart docker-compose (extend [doesn't inherit it](https://docs.docker.com/compose/extends/#extending-services))
- add a new metric to quickstart to track AI token usage
- change node-stripe example to be AI focused
- fix content type for node stripe example
- add `REPORT_ALL` to node stripe example to make it easy to report current usage
