### PR TITLE
feat(api): add total aggregate

### DIFF
--- a/api/api.gen.go
+++ b/api/api.gen.go
@@ -51,7 +51,9 @@ type GetValuesByMeterIdParams struct {
 	// To End date-time in RFC 3339 format.
 	// Must be aligned with the window size.
 	// Inclusive.
-	To         *time.Time  `form:"to,omitempty" json:"to,omitempty"`
+	To *time.Time `form:"to,omitempty" json:"to,omitempty"`
+
+	// WindowSize If not specified, a single usage aggregate will be returned for the entirety of the specified period for each subject and group.
 	WindowSize *WindowSize `form:"windowSize,omitempty" json:"windowSize,omitempty"`
 }
 
@@ -540,8 +542,8 @@ type GetValuesByMeterIdResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *struct {
-		Values     *[]MeterValue `json:"values,omitempty"`
-		WindowSize *WindowSize   `json:"windowSize,omitempty"`
+		Data       []MeterValue `json:"data"`
+		WindowSize *WindowSize  `json:"windowSize,omitempty"`
 	}
 	JSONDefault *Error
 }
@@ -721,8 +723,8 @@ func ParseGetValuesByMeterIdResponse(rsp *http.Response) (*GetValuesByMeterIdRes
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest struct {
-			Values     *[]MeterValue `json:"values,omitempty"`
-			WindowSize *WindowSize   `json:"windowSize,omitempty"`
+			Data       []MeterValue `json:"data"`
+			WindowSize *WindowSize  `json:"windowSize,omitempty"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
@@ -1015,33 +1017,34 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/8xYW3PbNhP9Kxh8efg6pUhZcm9880VO1UZ2JpKbppFHA5ErEikJMABoWdHov3cAkBIp",
-	"0pbcJJ28WCRxO7t7dvfAaxzwNOMMmJLYX2MZxJAS8zgQggv9kAmegVAUzOeAh6B/F1ykRGEfU6b6Pexg",
-	"tcrAvkIEAm8cnIKUJDKzi0GpBGWRHpOKqFw+MXRx7Dmb7Sc+/wCBwg5+6ES8U3wcCPEGZMaZBL354B6Y",
-	"0vuSMKSKckaS1xX7FiSR4OAQZCBopsexjy8SnodmoUTjDAK6oAHRY+i38c01GhufYWfPUSFR5PGDlMgb",
-	"50xiQKCPQRlZJZyELnYwPJA0S7Ql6ylecD7FPpriORFTvJkyvG/8xjEHB5wpYMqOrfftsYNIjyK+QCoG",
-	"pBehe5Lk4KJRLhUiYQwCkOLozdUF6nVPf0Q2FAYUy1Psv8cky5LCF94HyRm+qwJujDo4pewVsEjF2D9x",
-	"MMuThMz1XOuOBhU0KkvJphXDEJiiCwrSGGCnIRUTZY2xBkikuEa8pVEu6PNx0PDg+SZw9YCd9fqnnZPy",
-	"T+PUJvF5LgI4eJKJ7YNClKFlTIMYEVbQJiZZBgz2eBMrlUnf8yKq4nzuBjz1As1os0bu+aYjYAECWABH",
-	"4M0guAchDcp1C5mLwZJj1TyStTyydmzdiHIJsm7Eids9AlBuk6AB5tK8zUuq2GklLHskZTXn1sYywcM8",
-	"AIH+T8tQhGi+QjZg39WRpisGywVNwP2QRc+nmqJpCwUmNAWpSJppYMsYLFgeBLkwwdqFvi17+/3+L3WQ",
-	"ve7Jz53uaaf7w+TkJ79/4ne7f1WZEBIFHQPl+Qa01px6BMrKY90rICEKQo3WWCVoRBlRlEUVC+v4A566",
-	"BZ+zPElmAj7mIJXLjRMOMWXjYL2ACgh1FaN6QZF8dVYXK3fMunu62dgiYHtMZaRD04wLw8uMaEi4PRc9",
-	"Gf7dibh33/PMB4N0BApa+jCJIgERUUXylRV5fDvCDr64ub2eYAePzv4s32aXw/FkeH2hP786mwzGk9n5",
-	"u9nN1dV4MKmXbbtFsxZX47muzB+tkMGILiszWjaIBM+z81WTG7qLviYqRvCQCZDa87psI3hQggTKkMIs",
-	"1jlnepREC8HTSobqil9nyPspQ2iKX7jpapaQOSRTPGV3pmNSBWm79Cg+ECHIalf3q7k9S004Wswzh8jH",
-	"O37LcdXebtDusPr2zVirkT/S6xmx1aIZDfxEau5mG+/NCpI35pvTCxuOi9t+2MwOh4P1wg1zYbg8S2Ub",
-	"kiVlIV+O6SeD/4WABfbx/7ydePUK5eq93c08JA1THkIi3dJdx6WrrjCGA5Tvnj2tRgUjiWf33CXuH9oB",
-	"zeyt5MLRbGkEv9Lu2kNXGWF5Oreq3LpywMKauq4W/Me8r4h1yjGLnuF666Iv7/+3Nc6UBXI0vL6dDLCD",
-	"f725fYMdfHn2rlLVC/itYCv7fWmwGi5lC653SWgA+rLir4vsxmcZCWJAPSOBcpEUms73vOVy6RIz6nIR",
-	"ecVS6b0aXgyux4NOz+26sUoTKyyUybWbDJit12evh9jBWwWnNZbb1VM1VJJR7OO+23X7+mpDVGxY6ZGM",
-	"evcnXiEetdVctiiuIYtAKrTVmJrZJsGH4XZ0UA4W3fuchyt7xTT3E5MclStEpVF+b64T2/vqoZowKJpp",
-	"re9r+WI+2MuhsaXX7TZNufndtr8FyRP1BL5nYjLXa4Opftwtg4cMAi2IoJyzcbaONxSyNQRa/P4SFCqm",
-	"7Dv9JahROdJm9dFmbfvnU/bZqtroqU17v0X3emvzOww3hx2tRcnw8nFvn6+GockgQcrYvV9jqvcwBaNs",
-	"4rg4Eu+T1KmYvF9l7z4zlEdE8LGInXZPv360rrlCVzxn4bfMEc9q0iOoUkxs4YppgvJ8NdqS4OsQxil2",
-	"+piDWO22KqXEgaV1u4wgQFsRoK/Q5W2z/F/RlJnr6BwQSWjEIERLquxN34oKJOkncKdsyIIkl/ReP2uJ",
-	"3oJRq8gawON0yD7qAQv/O8yK/yvEbVstq/LjOILXtPDnloq6gN1R/vhuYIVeyzXrC6n7b7S5bDb/BAAA",
-	"///UpDoHZhcAAA==",
+	"H4sIAAAAAAAC/8xY63PauBb/VzS6/XDvXIN55L74lgfpZbcknUK22y0ZRlgHW11bciU5hDL87zuSbLCx",
+	"E8i23emXBPvo8Tvv3/EGByJJBQeuFR5ssAoiSIj9OZRSSPMjlSIFqRnY14GgYP4vhUyIxgPMuO73sIf1",
+	"OgX3CCFIvPVwAkqR0K7OhUpLxkMjU5roTD0jujz1nu3ulVh8gkBjDz+2QtHKXw6lfAcqFVyBOXz4AFyb",
+	"cwmlTDPBSfy2pN+SxAo8TEEFkqVGjgf4MhYZtRsVmqQQsCULiJGhnya3N2hibYa9A0NRosnTF2mZ1e6Z",
+	"RoDAXINSso4FoW3sYXgkSRobTTYzTDNpL54naoYHaIa7vf4Mb2ccHxph61kAgeAauHayzaFeToiMFIkl",
+	"0hEgswk9kDiDNhpnSiNCI5CAtEDvri9Rr3P2b+RcYsHxLMGDj5ikaZzbxP+kBMf3ZeA1qYcTxt8AD3WE",
+	"B10P8yyOycKsdWaphYRB5UKzrsWIAtdsyUBZBdwypCOinTJOAYW0MIh34ZRJ9nIcjB693zqw6rjzXv+s",
+	"1S3+1G6tJ4DIZABHb7K+fdSIcbSKWBAhwvPwiUiaAoeD+Im0TtXA90Omo2zRDkTiByay7R51YJuWhCVI",
+	"4AGcgDeF4AGksig3DUGdC4sYK+eTquST02NnRpQpUFUluu3OCYAylwQ1MFf2aVGEiltWwHJXMl4xbkWW",
+	"SkGzACT6OytcQdFijZzD/lFFGmRKiwTknNGXB5pmSUMATFkCSpMkNbBWETioIggyaV21d3xT7vb7/f9V",
+	"IfY63f+2Ometzr+m3f8M+t1Bp/NbOQ4o0dCyUF6uQGPFqdq/qDvOuBJiooEatFYryULGiWY8LGlYxU9S",
+	"NpfwOQOljwXF1sNmJZNATcGyPsnzrBrA+c59EN0/319cvru2UpK0WJIKaUMwJQYSbk47X9HfW6HwH3q+",
+	"fWGRjkFDQ+slYSghJDrPs6L4Tu7G2MOXt3c3U+zh8fmvxdP8ajSZjm4uzes359PhZDq/+DC/vb6eDKfV",
+	"Cu2OqJfdsvM2pfXjNbIY0VVpRcMBoRRZerGuB4JpnG+JjhA8phKUsbyp0AgetSSBthFgN5v0su1IoaUU",
+	"SSkZTXGvhsPHGUdohl+1k/U8JguIZ3jG721zZBqSZraRvyBSkvW+xO8PTdbzxLqjQT17iXq6yTdcV27n",
+	"Fu0e68A9WW0N8ifaOieuNNS9gZ/Jw/1qa715HuS19fb2XIfT/HboNnvCcWe9apfITBOSFeNUrCbsi8X/",
+	"SsISD/Df/D1f9XOy6r/frzzGBhNBIVbtwlynpatIgdsYYGL/2zcEVHIS++7MfeL+YgxQz95SLpwcLTXn",
+	"lzpbs+tKEp4lC0fEnSmHnFYIdbm6P2V9TZxRTtn0AtM7E317+7+vxExRIMejm7vpEHv4/7d377CHr84/",
+	"lKp6Dr8RbOm8bw3WwGV8KcwpMQvAzCeDTZ7d+DwlQQSoZ9lOJuOcvg18f7VatYmVtoUM/Xyr8t+MLoc3",
+	"k2Gr1+60I53EjkVom2u3KXBXr8/fjrCHd2TN0Kl2xyw1UEnK8AD3251230wzREc2Kn2SMv+h6+c80Wgt",
+	"VAO5GvEQlEY7Omki2yb4iO6kw0KYt+0LQdduqrSjiE2O0rRQapT/tJPDbkQ9VhOGeTOt9H3DVewLNw9a",
+	"XXqdTl2V259d+1uSLNbP4HshJjtRW0zV6+44PKYQGPYDxZqttzO8DSFXQ6DB7q9Bo3zJodFfgx4Xkiat",
+	"T1Zr1z+f089V1VpPrev7I5rX39j/I7o9bmhDSkZXT1v7Yj2iNoMkKXz3cYOZOcMWjKKJ4/xKfBikXknl",
+	"wyp7/5WuPMGDT3nsrHP2/b11IzS6FhmnP3KM+I6TnhAq+cKGWLFNUF2sx7sg+D4B4+Unfc5ArvdHFVTi",
+	"yNaqXpYQoB0JMNNyMVoWn4Vm3M6eC0AkZiEHilZMu6HekQqk2Bdoz/iIB3Gm2IP5bSh6A0bDIisAT+Mh",
+	"h6iHnP51mLX4BohHS8SFLr6OAPUQQYrxMAaUKRICKmZBAzCODXIJOpMG+lJIx7y5ZhL0uviGsTsMpYad",
+	"uIVAgmj3IYRw6qaup7VblRnRaTlXoedfW72av7Ge3p4c82yY+/70uFH+rGDx1D4Y/KAdcLv9IwAA//8G",
+	"W3mi/hcAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -112,6 +112,8 @@ paths:
         - name: windowSize
           in: query
           required: false
+          description: |
+            If not specified, a single usage aggregate will be returned for the entirety of the specified period for each subject and group.
           schema:
             $ref: "#/components/schemas/WindowSize"
       responses:
@@ -124,10 +126,12 @@ paths:
                 properties:
                   windowSize:
                     $ref: "#/components/schemas/WindowSize"
-                  values:
+                  data:
                     type: array
                     items:
                       $ref: "#/components/schemas/MeterValue"
+                required:
+                  - data
         default:
           description: Unexpected error
           content:
@@ -178,7 +182,7 @@ components:
           description: Describes the type of event related to the originating occurrence.
           type: string
           minLength: 1
-          example: com.github.pull_request.opened
+          example: api_request
         datacontenttype:
           description: Content type of the data value. Must adhere to RFC 2046 format.
           type: string
@@ -198,7 +202,7 @@ components:
           type: string
           nullable: true
           minLength: 1
-          example: mynewfile.jpg
+          example: customer_id
         time:
           description: Timestamp of when the occurrence happened. Must adhere to RFC 3339.
           type: string
@@ -211,7 +215,7 @@ components:
           type: object
           additionalProperties: true
           example: |
-            {"foo": "bar"}
+            {"duration_ms": "123"}
       required:
         - id
         - source

--- a/internal/models/meter_test.go
+++ b/internal/models/meter_test.go
@@ -35,6 +35,12 @@ func TestAggregateMeterValues(t *testing.T) {
 	}, {
 		start: baseTime.Add(2 * time.Hour).Truncate(time.Minute),
 		end:   baseTime.Add(2*time.Hour + time.Minute).Truncate(time.Minute),
+	}, {
+		start: baseTime.Add(48 * time.Hour).Truncate(time.Minute),
+		end:   baseTime.Add(48*time.Hour + time.Minute).Truncate(time.Minute),
+	}, {
+		start: baseTime.Add(49 * time.Hour).Truncate(time.Minute),
+		end:   baseTime.Add(49*time.Hour + time.Minute).Truncate(time.Minute),
 	}}
 	hourWindows := []struct {
 		start time.Time
@@ -250,6 +256,26 @@ func TestAggregateMeterValues(t *testing.T) {
 			meterValues: []*MeterValue{},
 			windowSize:  windowSizePtr(WindowSizeHour),
 			wantErr:     "invalid aggregation: expected window size of MINUTE for meter with ID meter15, but got HOUR",
+		},
+		// aggregate to total
+		{
+			meter: &Meter{ID: "meter16", WindowSize: WindowSizeMinute, Aggregation: MeterAggregationSum},
+			meterValues: []*MeterValue{
+				{Subject: "s1", WindowStart: minuteWindows[0].start, WindowEnd: minuteWindows[0].end, Value: 100},
+				{Subject: "s1", WindowStart: minuteWindows[1].start, WindowEnd: minuteWindows[1].end, Value: 200},
+				{Subject: "s1", WindowStart: minuteWindows[2].start, WindowEnd: minuteWindows[2].end, Value: 300},
+				{Subject: "s1", WindowStart: minuteWindows[3].start, WindowEnd: minuteWindows[3].end, Value: 400},
+				{Subject: "s1", WindowStart: minuteWindows[4].start, WindowEnd: minuteWindows[4].end, Value: 500},
+				{Subject: "s1", WindowStart: minuteWindows[5].start, WindowEnd: minuteWindows[5].end, Value: 600},
+				{Subject: "s2", WindowStart: minuteWindows[0].start, WindowEnd: minuteWindows[0].end, Value: 700},
+				{Subject: "s2", WindowStart: minuteWindows[1].start, WindowEnd: minuteWindows[1].end, Value: 800},
+				{Subject: "s2", WindowStart: minuteWindows[2].start, WindowEnd: minuteWindows[2].end, Value: 900},
+			},
+			windowSize: nil,
+			want: []*MeterValue{
+				{Subject: "s1", WindowStart: minuteWindows[0].start, WindowEnd: minuteWindows[5].end, Value: 2100},
+				{Subject: "s2", WindowStart: minuteWindows[0].start, WindowEnd: minuteWindows[2].end, Value: 2400},
+			},
 		},
 	}
 

--- a/internal/server/router/router.go
+++ b/internal/server/router/router.go
@@ -104,7 +104,7 @@ func (a *Router) GetMetersById(w http.ResponseWriter, r *http.Request, meterID s
 
 type GetValuesByMeterIdResponse struct {
 	WindowSize *models.WindowSize   `json:"windowSize"`
-	Values     []*models.MeterValue `json:"values"`
+	Data       []*models.MeterValue `json:"data"`
 }
 
 func (rd *GetValuesByMeterIdResponse) Render(w http.ResponseWriter, r *http.Request) error {
@@ -124,12 +124,23 @@ func ValidateGetValuesByMeterIdParams(meter *models.Meter, params api.GetValuesB
 		if params.To != nil && params.To.Truncate(windowDuration) != *params.To {
 			return errors.New("to must be aligned to window size")
 		}
+		if (meter.Aggregation == models.MeterAggregationCountDistinct) && *params.WindowSize != meter.WindowSize {
+			return fmt.Errorf("expected window size to be %s, but got %s", meter.WindowSize, *params.WindowSize)
+		}
 		if (meter.WindowSize == models.WindowSizeDay && *params.WindowSize != models.WindowSizeDay) ||
 			(meter.WindowSize == models.WindowSizeHour && *params.WindowSize == models.WindowSizeMinute) {
 			return fmt.Errorf("expected window size to be less than or equal to %s, but got %s", meter.WindowSize, *params.WindowSize)
 		}
-		if (meter.Aggregation == models.MeterAggregationCountDistinct) && *params.WindowSize != meter.WindowSize {
-			return fmt.Errorf("expected window size to be %s, but got %s", meter.WindowSize, *params.WindowSize)
+	} else {
+		windowDuration := meter.WindowSize.Duration()
+		if params.From != nil && params.From.Truncate(windowDuration) != *params.From {
+			return fmt.Errorf("from must be aligned to the meter's window size of %s", meter.WindowSize)
+		}
+		if params.To != nil && params.To.Truncate(windowDuration) != *params.To {
+			return fmt.Errorf("to must be aligned to the meter's window size of %s", meter.WindowSize)
+		}
+		if meter.Aggregation == models.MeterAggregationCountDistinct {
+			return fmt.Errorf("expected window size to be %s", meter.WindowSize)
 		}
 	}
 
@@ -156,13 +167,9 @@ func (a *Router) GetValuesByMeterId(w http.ResponseWriter, r *http.Request, mete
 			}
 
 			windowSize := params.WindowSize
-			if windowSize == nil {
-				windowSize = &meter.WindowSize
-			}
-
 			resp := &GetValuesByMeterIdResponse{
 				WindowSize: windowSize,
-				Values:     values,
+				Data:       values,
 			}
 
 			if err := render.Render(w, r, resp); err != nil {


### PR DESCRIPTION
When `windowSize` query parameter is not defined, the total aggregate will be returned for the specified period for each subject and group.

**BREAKING CHANGES**
- Changes the behavior of the `windowSize` query param from being the default of the meter's window size.
- Changed the response field `values` to `data`

Possible improvements:
- specify `groupBy` query parameter for groups to be ignored or selected

TODO:
- update examples