### PR TITLE
feat: support batch event ingestion

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -52,3 +52,12 @@ func ErrUnprocessableEntity(err error) render.Renderer {
 		Message:    err.Error(),
 	}
 }
+
+func ErrUnsupportedMediaType(err error) render.Renderer {
+	return &ErrResponse{
+		Err:        err,
+		StatusCode: 415,
+		StatusText: http.StatusText(415),
+		Message:    err.Error(),
+	}
+}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -17,6 +17,11 @@ paths:
           application/cloudevents+json:
             schema:
               $ref: "#/components/schemas/Event"
+          application/cloudevents-batch+json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/Event"
       responses:
         "200":
           description: OK

--- a/internal/server/router/router.go
+++ b/internal/server/router/router.go
@@ -19,6 +19,7 @@ import (
 func init() {
 	// See https://github.com/getkin/kin-openapi/issues/640
 	openapi3filter.RegisterBodyDecoder("application/cloudevents+json", jsonBodyDecoder)
+	openapi3filter.RegisterBodyDecoder("application/cloudevents-batch+json", jsonBodyDecoder)
 }
 
 func jsonBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn openapi3filter.EncodingFn) (interface{}, error) {


### PR DESCRIPTION
Hi! 
I'm new to open source and Go. I would like to try to contribute to your project through this PR based on _'good first issue'_ tag. :)

Please feel free to review my changes and request additional. Thank you!

## Overview

-  Updated the code to include Content-Type: application/cloudevents-batch+json with a body of an array of events
-  Updated the request handler (on http ingestion level) to unmarshal the body based on the content-type
-  Published the events one by one (no transaction handling yet)
-  Test included 

Fixes #54 

## Notes for reviewer

Context was moved to Handler in order to use it globally for logger.
