### PR TITLE
fix(ingest): parse data

### DIFF
--- a/internal/ingest/kafkaingest/schema.go
+++ b/internal/ingest/kafkaingest/schema.go
@@ -54,8 +54,8 @@ type cloudEventsKafkaPayload struct {
 	Data    interface{} `json:"DATA"`
 }
 
-func toCloudEventsKafkaPayload(ev event.Event) (*cloudEventsKafkaPayload, error) {
-	payload := &cloudEventsKafkaPayload{
+func toCloudEventsKafkaPayload(ev event.Event) (cloudEventsKafkaPayload, error) {
+	payload := cloudEventsKafkaPayload{
 		Id:      ev.ID(),
 		Type:    ev.Type(),
 		Source:  ev.Source(),
@@ -67,7 +67,7 @@ func toCloudEventsKafkaPayload(ev event.Event) (*cloudEventsKafkaPayload, error)
 	// CloudEvents data can be other than JSON but currently only support JSON data.
 	err := json.Unmarshal(ev.Data(), &payload.Data)
 	if err != nil {
-		return nil, err
+		return payload, err
 	}
 
 	return payload, nil

--- a/internal/ingest/kafkaingest/schema.go
+++ b/internal/ingest/kafkaingest/schema.go
@@ -54,7 +54,7 @@ type cloudEventsKafkaPayload struct {
 	Data    interface{} `json:"DATA"`
 }
 
-func toCloudEventsKafkaPayload(ev *event.Event) (*cloudEventsKafkaPayload, error) {
+func toCloudEventsKafkaPayload(ev event.Event) (*cloudEventsKafkaPayload, error) {
 	payload := &cloudEventsKafkaPayload{
 		Id:      ev.ID(),
 		Type:    ev.Type(),

--- a/internal/ingest/kafkaingest/schema.go
+++ b/internal/ingest/kafkaingest/schema.go
@@ -63,6 +63,8 @@ func toCloudEventsKafkaPayload(ev event.Event) (*cloudEventsKafkaPayload, error)
 		Time:    ev.Time().String(),
 	}
 
+	// We try to parse data as JSON.
+	// CloudEvents data can be other than JSON but currently only support JSON data.
 	err := json.Unmarshal(ev.Data(), &payload.Data)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We didn't try to parse incoming CloudEvents `data` as JSON before. 
Even if it was JSON, whitespace, and new lines made into the Kafka message.

This PR tries to parse data as JSON before serializing.