### PR TITLE
feat(dedupe): add redis dedupe

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,7 +36,8 @@ type configuration struct {
 
 	// Dedupe configuration
 	Dedupe struct {
-		Redis dedupeRedisConfiguration
+		Redis  dedupeRedisConfiguration
+		Memory dedupeMemoryConfiguration
 	}
 
 	Namespace struct {
@@ -298,6 +299,24 @@ func (c dedupeRedisConfiguration) Validate() error {
 	return nil
 }
 
+// Dedupe memory configuration
+type dedupeMemoryConfiguration struct {
+	Enabled bool
+	Size    int
+}
+
+func (c dedupeMemoryConfiguration) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+
+	if c.Size == 0 {
+		return errors.New("dedupe memory size is required")
+	}
+
+	return nil
+}
+
 type logConfiguration struct {
 	// Format specifies the output log format.
 	// Accepted values are: json, text
@@ -382,12 +401,16 @@ func configure(v *viper.Viper, flags *pflag.FlagSet) {
 	v.SetDefault("sink.kafkaConnect.clickhouse.username", "default")
 	v.SetDefault("sink.kafkaConnect.clickhouse.password", "")
 
-	// Redis configuration
+	// Dedupe Redis configuration
 	v.SetDefault("dedupe.redis", false)
 	v.SetDefault("dedupe.redis.address", "127.0.0.1:6379")
 	v.SetDefault("dedupe.redis.database", 0)
 	v.SetDefault("dedupe.redis.password", "")
 	v.SetDefault("dedupe.redis.expiration", "24h")
+
+	// Dedupe Memory configuration
+	v.SetDefault("dedupe.memory", false)
+	v.SetDefault("dedupe.memory.size", 128)
 
 	// namespace configuration
 	v.SetDefault("namespace.EventsTopicTemplate", "om_%s_events")

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -131,6 +131,16 @@ services:
         soft: 262144
         hard: 262144
 
+  # Api Dedupe
+  redis:
+    profiles:
+      - dedupe-redis
+    image: redis:6-alpine
+    hostname: redis
+    container_name: redis
+    ports:
+      - '6379:6379'
+
   # Debug Profile
   # docker compose --profile ksqldb --profile debug up
   redpanda:

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
@@ -61,6 +62,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.4
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 // indirect
@@ -95,6 +97,7 @@ require (
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
+	github.com/redis/go-redis/v9 v9.0.5
 	github.com/santhosh-tekuri/jsonschema/v5 v5.2.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -710,6 +710,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dR
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
+github.com/bsm/ginkgo/v2 v2.7.0 h1:ItPMPH90RbmZJt5GtkcNvIRuGEdwlBItdNVoyzaNQao=
+github.com/bsm/gomega v1.26.0 h1:LhQm+AFcgV2M0WyKroMASzAzCAJVpAxQXv4SaI9a69Y=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
@@ -910,6 +912,7 @@ github.com/deepmap/oapi-codegen v1.13.0/go.mod h1:Amy7tbubKY9qkZOXqymI3Z6xSbndmu
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
@@ -1238,6 +1241,8 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru/v2 v2.0.4 h1:7GHuZcgid37q8o5i3QI9KMT4nCWQQ3Kx3Ov6bb9MfK0=
+github.com/hashicorp/golang-lru/v2 v2.0.4/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
@@ -1590,6 +1595,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/redis/go-redis/v9 v9.0.5 h1:CuQcn5HIEeK7BgElubPP8CGtE0KakrnbBSTLjathl5o=
+github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/clock v0.0.0-20190514195947-2896927a307a/go.mod h1:4r5QyqhjIWCcK8DO4KMclc5Iknq5qVBAlbYYzAbUScQ=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/internal/ingest/dedupe.go
+++ b/internal/ingest/dedupe.go
@@ -1,0 +1,18 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+)
+
+type Deduplicator interface {
+	IsUnique(ctx context.Context, namespace string, ev event.Event) (bool, error)
+	Set(ctx context.Context, namespace string, ev event.Event) (bool, error)
+}
+
+// CloudEvents are unique based on the source and id
+func GetEventKey(namespace string, ev event.Event) string {
+	return fmt.Sprintf("%s-%s-%s", namespace, ev.Source(), ev.ID())
+}

--- a/internal/ingest/httpingest/httpingest.go
+++ b/internal/ingest/httpingest/httpingest.go
@@ -17,8 +17,7 @@ import (
 // Handler receives an event in CloudEvents format and forwards it to a {Collector}.
 type Handler struct {
 	Collector ingest.Collector
-
-	Logger *slog.Logger
+	Logger    *slog.Logger
 }
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, params api.IngestEventsParams) {
@@ -59,7 +58,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, params api.In
 		return
 	}
 
-	logger.InfoCtx(r.Context(), "event forwarded to downstream collector")
+	logger.DebugCtx(r.Context(), "event forwarded to downstream collector")
 
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/ingest/memorydedupe/collector.go
+++ b/internal/ingest/memorydedupe/collector.go
@@ -22,7 +22,7 @@ type CollectorConfig struct {
 
 func NewCollector(config CollectorConfig) (*Collector, error) {
 	if config.Size == 0 {
-		config.Size = 128
+		return nil, fmt.Errorf("size cannot be 0")
 	}
 	if config.Collector == nil {
 		return nil, fmt.Errorf("collector is nil")

--- a/internal/ingest/memorydedupe/collector.go
+++ b/internal/ingest/memorydedupe/collector.go
@@ -1,0 +1,67 @@
+package memorydedupe
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/openmeterio/openmeter/internal/ingest"
+)
+
+type Collector struct {
+	store     *lru.Cache[string, any]
+	collector ingest.Collector
+}
+
+type CollectorConfig struct {
+	Collector ingest.Collector
+	Size      int
+}
+
+func NewCollector(config CollectorConfig) (*Collector, error) {
+	if config.Size == 0 {
+		config.Size = 128
+	}
+	if config.Collector == nil {
+		return nil, fmt.Errorf("collector is nil")
+	}
+
+	store, err := lru.New[string, any](config.Size)
+	if err != nil {
+		return nil, err
+	}
+
+	dedupe := &Collector{
+		store:     store,
+		collector: config.Collector,
+	}
+
+	return dedupe, nil
+}
+
+// TODO: pass contect to Ingest
+func (c Collector) Ingest(ev event.Event, namespace string) error {
+	ctx := context.TODO()
+
+	isUnique, err := c.IsUnique(ctx, namespace, ev)
+	if err != nil {
+		return err
+	}
+
+	if isUnique {
+		return c.collector.Ingest(ev, namespace)
+	}
+
+	return nil
+}
+
+func (c Collector) Close() {
+	c.collector.Close()
+}
+
+func (c Collector) IsUnique(ctx context.Context, namespace string, ev event.Event) (bool, error) {
+	isContained, _ := c.store.ContainsOrAdd(ingest.GetEventKey(namespace, ev), nil)
+	return !isContained, nil
+}

--- a/internal/ingest/memorydedupe/collector_test.go
+++ b/internal/ingest/memorydedupe/collector_test.go
@@ -79,7 +79,10 @@ func TestIsUnique(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ingestCount := newTestCounter()
 			downstreamCollector := newTestCollector(&ingestCount)
-			dedupeCollector, err := NewCollector(CollectorConfig{Collector: downstreamCollector})
+			dedupeCollector, err := NewCollector(CollectorConfig{
+				Collector: downstreamCollector,
+				Size:      128,
+			})
 			if err != nil {
 				t.Error(err)
 			}

--- a/internal/ingest/memorydedupe/collector_test.go
+++ b/internal/ingest/memorydedupe/collector_test.go
@@ -1,0 +1,101 @@
+package memorydedupe
+
+import (
+	"testing"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/stretchr/testify/assert"
+)
+
+// We need to define a counter to be able to change intenral state as Collector.Ingest is not a pointer receiver
+type testCounter struct {
+	counter int
+}
+
+func (c *testCounter) inc() {
+	c.counter++
+}
+
+func newTestCounter() testCounter {
+	return testCounter{
+		counter: 0,
+	}
+}
+
+type testEvent struct {
+	id        string
+	source    string
+	namespace string
+}
+
+type testCollector struct {
+	ingestCount *testCounter
+}
+
+func newTestCollector(ingestCount *testCounter) testCollector {
+	return testCollector{
+		ingestCount: ingestCount,
+	}
+}
+
+func (c testCollector) Ingest(ev event.Event, namespace string) error {
+	c.ingestCount.inc()
+	return nil
+}
+
+func (c testCollector) Close() {
+}
+
+func TestIsUnique(t *testing.T) {
+	tests := []struct {
+		name   string
+		events []testEvent
+		want   int
+	}{
+		{
+			name:   "Unique id",
+			events: []testEvent{{"id1", "source1", "namespace1"}, {"id2", "source1", "namespace1"}},
+			want:   2,
+		},
+		{
+			name:   "Unique source",
+			events: []testEvent{{"id1", "source1", "namespace1"}, {"id1", "source2", "namespace1"}},
+			want:   2,
+		},
+		{
+			name:   "Unique namespace",
+			events: []testEvent{{"id1", "source1", "namespace1"}, {"id1", "source1", "namespace2"}},
+			want:   2,
+		},
+		{
+			name:   "Same",
+			events: []testEvent{{"id1", "source1", "namespace1"}, {"id1", "source1", "namespace1"}},
+			want:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ingestCount := newTestCounter()
+			downstreamCollector := newTestCollector(&ingestCount)
+			dedupeCollector, err := NewCollector(CollectorConfig{Collector: downstreamCollector})
+			if err != nil {
+				t.Error(err)
+			}
+			for _, te := range tt.events {
+				ev := event.New()
+				ev.SetID(te.id)
+				ev.SetSource(te.source)
+				err := dedupeCollector.Ingest(ev, te.namespace)
+				if err != nil {
+					t.Error(err)
+				}
+			}
+
+			got := downstreamCollector.ingestCount.counter
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/ingest/redisdedupe/collector.go
+++ b/internal/ingest/redisdedupe/collector.go
@@ -1,0 +1,64 @@
+package redisdedupe
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/redis/go-redis/v9"
+	"golang.org/x/exp/slog"
+
+	"github.com/openmeterio/openmeter/internal/ingest"
+)
+
+type Collector struct {
+	config CollectorConfig
+}
+
+type CollectorConfig struct {
+	Logger     *slog.Logger
+	Redis      *redis.Client
+	Expiration time.Duration
+	Collector  ingest.Collector
+}
+
+func NewCollector(config CollectorConfig) (*Collector, error) {
+	if config.Collector == nil {
+		return nil, fmt.Errorf("collector is nil")
+	}
+
+	collector := &Collector{
+		config: config,
+	}
+	return collector, nil
+}
+
+// TODO: pass context to Ingest
+func (c Collector) Ingest(ev event.Event, namespace string) error {
+	ctx := context.TODO()
+
+	isUnique, err := c.isUnique(ctx, namespace, ev)
+	if err != nil {
+		return err
+	}
+
+	if isUnique {
+		return c.config.Collector.Ingest(ev, namespace)
+	}
+
+	return nil
+}
+
+func (c Collector) Close() {
+	c.config.Collector.Close()
+}
+
+// IsUnique checks if the entry is unique based on the key and sets it in store
+func (c *Collector) isUnique(ctx context.Context, namespace string, ev event.Event) (bool, error) {
+	isSet, err := c.config.Redis.Exists(ctx, ingest.GetEventKey(namespace, ev)).Result()
+	if err != nil {
+		return false, err
+	}
+	return isSet == 0, nil
+}

--- a/main.go
+++ b/main.go
@@ -222,6 +222,7 @@ func main() {
 	if config.Dedupe.Memory.Enabled {
 		ingestCollector, err = memorydedupe.NewCollector(memorydedupe.CollectorConfig{
 			Collector: ingestCollector,
+			Size:      config.Dedupe.Memory.Size,
 		})
 		if err != nil {
 			logger.Error("failed to initialize memory dedupe", "error", err)

--- a/main.go
+++ b/main.go
@@ -218,19 +218,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Initialize ingestDeduplicator
-	if config.Dedupe.Redis.Enabled {
-		ingestCollector, err = initDedupeRedis(config, logger, ingestCollector)
-		if err != nil {
-			logger.Error("failed to initialize redis dedupe", "error", err)
-			os.Exit(1)
-		}
-	} else {
+	// Initialize Memory Dedupe
+	if config.Dedupe.Memory.Enabled {
 		ingestCollector, err = memorydedupe.NewCollector(memorydedupe.CollectorConfig{
 			Collector: ingestCollector,
 		})
 		if err != nil {
 			logger.Error("failed to initialize memory dedupe", "error", err)
+			os.Exit(1)
+		}
+	}
+
+	// Initialize Redis Dedupe
+	if config.Dedupe.Redis.Enabled {
+		ingestCollector, err = initDedupeRedis(config, logger, ingestCollector)
+		if err != nil {
+			logger.Error("failed to initialize redis dedupe", "error", err)
 			os.Exit(1)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lmittmann/tint"
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/redis/go-redis/v9"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/thmeitz/ksqldb-go"
@@ -38,6 +39,8 @@ import (
 	"github.com/openmeterio/openmeter/internal/ingest/httpingest"
 	"github.com/openmeterio/openmeter/internal/ingest/kafkaingest"
 	"github.com/openmeterio/openmeter/internal/ingest/kafkaingest/serializer"
+	"github.com/openmeterio/openmeter/internal/ingest/memorydedupe"
+	"github.com/openmeterio/openmeter/internal/ingest/redisdedupe"
 	"github.com/openmeterio/openmeter/internal/namespace"
 	"github.com/openmeterio/openmeter/internal/server"
 	"github.com/openmeterio/openmeter/internal/server/router"
@@ -213,6 +216,23 @@ func main() {
 	if err != nil {
 		logger.Error("failed to initialize namespace", "error", err)
 		os.Exit(1)
+	}
+
+	// Initialize ingestDeduplicator
+	if config.Dedupe.Redis.Enabled {
+		ingestCollector, err = initDedupeRedis(config, logger, ingestCollector)
+		if err != nil {
+			logger.Error("failed to initialize redis dedupe", "error", err)
+			os.Exit(1)
+		}
+	} else {
+		ingestCollector, err = memorydedupe.NewCollector(memorydedupe.CollectorConfig{
+			Collector: ingestCollector,
+		})
+		if err != nil {
+			logger.Error("failed to initialize memory dedupe", "error", err)
+			os.Exit(1)
+		}
 	}
 
 	s, err := server.NewServer(&server.Config{
@@ -452,6 +472,28 @@ func initClickHouseStreaming(config configuration, logger *slog.Logger) (*clickh
 	}
 
 	return streamingConnector, nil
+}
+
+// initDedupe initializes the dedupe based on the configuration.
+func initDedupeRedis(config configuration, logger *slog.Logger, collector ingest.Collector) (*redisdedupe.Collector, error) {
+	// Initialize Redis
+	redisClient := redis.NewClient(&redis.Options{
+		Addr:     config.Dedupe.Redis.Address,
+		Password: config.Dedupe.Redis.Password,
+		DB:       config.Dedupe.Redis.Database,
+	})
+
+	dedupeRedis, err := redisdedupe.NewCollector(redisdedupe.CollectorConfig{
+		Logger:     logger,
+		Redis:      redisClient,
+		Expiration: config.Dedupe.Redis.Expiration,
+		Collector:  collector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("init redis dedupe: %w", err)
+	}
+
+	return dedupeRedis, nil
 }
 
 func initNamespace(namespaces ...namespace.Handler) (namespace.Manager, error) {

--- a/quickstart/docker-compose.yaml
+++ b/quickstart/docker-compose.yaml
@@ -69,3 +69,9 @@ services:
     extends:
       file: ../docker-compose.yaml
       service: clickhouse
+
+  # Profile: dedupe-redis
+  redis:
+    extends:
+      file: ../docker-compose.yaml
+      service: redis


### PR DESCRIPTION
Dedupe in API via Redis.

Deduping in the API can't guarantee consistency due to the parallel ingestion of events.
Currently, the only consistent deduplication is provided by the ksqlDB Processor.