### PR TITLE
chore: update helm Chart.lock digest

### DIFF
--- a/deploy/charts/openmeter/Chart.lock
+++ b/deploy/charts/openmeter/Chart.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: cp-ksql-server
   repository: file://../cp-helm-charts/charts/cp-ksql-server
   version: 0.1.0
-digest: sha256:e66fd107e2d19002aa91671bfe8d30f45a8a54fcd3b1928bdb7a0acade497fe4
-generated: "2023-06-26T13:22:20.694373+02:00"
+digest: sha256:4115c24014f772e654435d3915cabf28edc79bb787ab737f17c31fd3f9d18633
+generated: "2023-08-02T19:26:45.204429907-04:00"


### PR DESCRIPTION
## Overview

Updates the Helm chart's `Chart.lock` via `helm dependency update`. This currently blocks ArgoCD from deploying due to the out of date `Chart.lock` file.
