### PR TITLE
feat(config): stateless mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ Run linters:
 make lint
 ```
 
+## Modes
+
+OpenMeter has two modes, the config driven stateful (default, recommended) and stateless.
+
+### Stateful (config driven)
+
+Stateful is the default and recommended mode in OpenMeter. In stateful mode you can define meters via the `config.yaml`.
+As the state is defined via config, namespace and meter management HTTP endpoints are disabled by default.
+
+### Stateless
+
+You can enable stateless mode via `stateless: true` in the config. In this mode meters defined in the `config.yaml` are ignored. In stateless mode you can define namespaces and meters via the HTTP API but these states are not persisted and after restarting OpenMeter will be lost. Resources created by OpenMeter like Kafka topics, KSQL tables etc. will remain.
+
 ## Roadmap
 
 Visit our website at [https://openmeter.io](https://openmeter.io#roadmap) for our public roadmap.

--- a/README.md
+++ b/README.md
@@ -117,16 +117,16 @@ make lint
 
 ## Modes
 
-OpenMeter has two modes, the config driven stateful (default, recommended) and stateless.
+OpenMeter has two modes: config (default, recommended) and stateless.
 
-### Stateful (config driven)
+### Config Mode
 
-Stateful is the default and recommended mode in OpenMeter. In stateful mode you can define meters via the `config.yaml`.
-As the state is defined via config, namespace and meter management HTTP endpoints are disabled by default.
+Config mode is the default and recommended mode in OpenMeter. In this mode you can define meters via the `config.yaml`.
+As the state is defined in the config, namespace and meter management HTTP endpoints are disabled.
 
-### Stateless
+### Stateless Mode
 
-You can enable stateless mode via `stateless: true` in the config. In this mode meters defined in the `config.yaml` are ignored. In stateless mode you can define namespaces and meters via the HTTP API but these states are not persisted and after restarting OpenMeter will be lost. Resources created by OpenMeter like Kafka topics, KSQL tables etc. will remain.
+You can enable stateless mode via `stateless: true` in the config. In this mode meters defined in the `config.yaml` are ignored. In stateless mode you can define namespaces and meters via the HTTP API but these states are not persisted and after restarting OpenMeter they will be lost. Resources created by OpenMeter like Kafka topics, KSQL tables etc. will may remain persisted.
 
 ## Roadmap
 

--- a/config.go
+++ b/config.go
@@ -73,12 +73,12 @@ type configuration struct {
 // Validate validates the configuration.
 func (c configuration) Validate() error {
 	if !c.Stateless {
-		slog.Info("disable namespace and meter managements in stateful mode")
+		slog.Info("disable namespace and meter managements in config mode")
 
-		c.Server.EnableNamespaceCreate = false
-		c.Server.EnableNamespaceDelete = false
-		c.Server.EnableMeterCreate = false
-		c.Server.EnableMeterDelete = false
+		c.Server.DisableNamespaceCreate = true
+		c.Server.DisableNamespaceDelete = true
+		c.Server.DisableMeterCreate = true
+		c.Server.DisableMeterDelete = true
 	}
 
 	if err := c.Server.Validate(); err != nil {
@@ -157,11 +157,11 @@ type ingestKafkaConfiguration struct {
 
 // Server configuration
 type serverConfiguration struct {
-	Address               string
-	EnableNamespaceCreate bool
-	EnableNamespaceDelete bool
-	EnableMeterCreate     bool
-	EnableMeterDelete     bool
+	Address                string
+	DisableNamespaceCreate bool
+	DisableNamespaceDelete bool
+	DisableMeterCreate     bool
+	DisableMeterDelete     bool
 }
 
 func (c serverConfiguration) Validate() error {

--- a/config.go
+++ b/config.go
@@ -29,6 +29,9 @@ type configuration struct {
 		Address string
 	}
 
+	// Stateless configuration
+	Stateless bool
+
 	// Namespace configuration
 	Namespace namespaceConfiguration
 
@@ -118,8 +121,7 @@ func (c configuration) Validate() error {
 
 // Namespace configuration
 type namespaceConfiguration struct {
-	Default           string
-	DisableManagement bool
+	Default string
 }
 
 func (c namespaceConfiguration) Validate() error {
@@ -390,7 +392,10 @@ func configure(v *viper.Viper, flags *pflag.FlagSet) {
 	// Log configuration
 	v.SetDefault("log.format", "json")
 	v.SetDefault("log.level", "info")
-	//
+
+	// Stateless
+	v.SetDefault("stateless", false)
+
 	// Telemetry configuration
 	flags.String("telemetry-address", ":10000", "Telemetry HTTP server address")
 	_ = v.BindPFlag("telemetry.address", flags.Lookup("telemetry-address"))
@@ -398,7 +403,6 @@ func configure(v *viper.Viper, flags *pflag.FlagSet) {
 
 	// Namespace configuration
 	v.SetDefault("namespace.default", "default")
-	v.SetDefault("namespace.disableManagement", false)
 
 	// Ingest configuration
 	v.SetDefault("ingest.kafka.broker", "127.0.0.1:29092")

--- a/internal/namespace/namespace.go
+++ b/internal/namespace/namespace.go
@@ -12,9 +12,8 @@ type Manager struct {
 }
 
 type ManagerConfig struct {
-	DefaultNamespace  string
-	DisableManagement bool
-	Handlers          []Handler
+	DefaultNamespace string
+	Handlers         []Handler
 }
 
 func NewManager(config ManagerConfig) (*Manager, error) {
@@ -55,10 +54,6 @@ func (m Manager) CreateDefaultNamespace(ctx context.Context) error {
 
 func (m Manager) GetDefaultNamespace() string {
 	return m.config.DefaultNamespace
-}
-
-func (m Manager) IsManagementDisabled() bool {
-	return m.config.DisableManagement
 }
 
 // TODO: introduce some resiliency (eg. retries or rollbacks in case a component fails to create a namespace).

--- a/internal/server/router/router.go
+++ b/internal/server/router/router.go
@@ -37,14 +37,14 @@ type IngestHandler interface {
 }
 
 type Config struct {
-	NamespaceManager      *namespace.Manager
-	StreamingConnector    streaming.Connector
-	IngestHandler         IngestHandler
-	Meters                []*models.Meter
-	EnableNamespaceCreate bool
-	EnableNamespaceDelete bool
-	EnableMeterCreate     bool
-	EnableMeterDelete     bool
+	NamespaceManager       *namespace.Manager
+	StreamingConnector     streaming.Connector
+	IngestHandler          IngestHandler
+	Meters                 []*models.Meter
+	DisableNamespaceCreate bool
+	DisableNamespaceDelete bool
+	DisableMeterCreate     bool
+	DisableMeterDelete     bool
 }
 
 type Router struct {
@@ -61,7 +61,7 @@ func NewRouter(config Config) (*Router, error) {
 }
 
 func (a *Router) CreateNamespace(w http.ResponseWriter, r *http.Request) {
-	if !a.config.EnableNamespaceCreate {
+	if a.config.DisableNamespaceCreate {
 		models.NewStatusProblem(r.Context(), errors.New("namespace create is disabled"), http.StatusForbidden).Respond(w, r)
 		return
 	}
@@ -95,7 +95,7 @@ func (a *Router) ListMeters(w http.ResponseWriter, r *http.Request, params api.L
 }
 
 func (a *Router) CreateMeter(w http.ResponseWriter, r *http.Request, params api.CreateMeterParams) {
-	if !a.config.EnableMeterCreate {
+	if a.config.DisableMeterCreate {
 		models.NewStatusProblem(r.Context(), errors.New("meter create is disabled"), http.StatusForbidden).Respond(w, r)
 		return
 	}
@@ -120,7 +120,7 @@ func (a *Router) CreateMeter(w http.ResponseWriter, r *http.Request, params api.
 }
 
 func (a *Router) DeleteMeter(w http.ResponseWriter, r *http.Request, meterIdOrSlug string, params api.DeleteMeterParams) {
-	if !a.config.EnableMeterDelete {
+	if a.config.DisableMeterDelete {
 		models.NewStatusProblem(r.Context(), errors.New("meter delete is disabled"), http.StatusForbidden).Respond(w, r)
 		return
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -66,14 +66,10 @@ func makeRequest(r *http.Request) (*httptest.ResponseRecorder, error) {
 
 	server, _ := NewServer(&Config{
 		RouterConfig: router.Config{
-			Meters:                meters,
-			StreamingConnector:    &MockConnector{},
-			IngestHandler:         MockHandler{},
-			NamespaceManager:      namespaceManager,
-			EnableNamespaceCreate: true,
-			EnableNamespaceDelete: true,
-			EnableMeterCreate:     true,
-			EnableMeterDelete:     true,
+			Meters:             meters,
+			StreamingConnector: &MockConnector{},
+			IngestHandler:      MockHandler{},
+			NamespaceManager:   namespaceManager,
 		},
 		RouterHook: func(r chi.Router) {},
 	})

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -70,6 +70,7 @@ func makeRequest(r *http.Request) (*httptest.ResponseRecorder, error) {
 			StreamingConnector: &MockConnector{},
 			IngestHandler:      MockHandler{},
 			NamespaceManager:   namespaceManager,
+			Stateless:          true,
 		},
 		RouterHook: func(r chi.Router) {},
 	})

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -66,11 +66,14 @@ func makeRequest(r *http.Request) (*httptest.ResponseRecorder, error) {
 
 	server, _ := NewServer(&Config{
 		RouterConfig: router.Config{
-			Meters:             meters,
-			StreamingConnector: &MockConnector{},
-			IngestHandler:      MockHandler{},
-			NamespaceManager:   namespaceManager,
-			Stateless:          true,
+			Meters:                meters,
+			StreamingConnector:    &MockConnector{},
+			IngestHandler:         MockHandler{},
+			NamespaceManager:      namespaceManager,
+			EnableNamespaceCreate: true,
+			EnableNamespaceDelete: true,
+			EnableMeterCreate:     true,
+			EnableMeterDelete:     true,
 		},
 		RouterHook: func(r chi.Router) {},
 	})

--- a/main.go
+++ b/main.go
@@ -259,14 +259,14 @@ func main() {
 
 	s, err := server.NewServer(&server.Config{
 		RouterConfig: router.Config{
-			NamespaceManager:      namespaceManager,
-			StreamingConnector:    streamingConnector,
-			IngestHandler:         ingestHandler,
-			Meters:                config.Meters,
-			EnableNamespaceCreate: config.Server.EnableNamespaceCreate,
-			EnableNamespaceDelete: config.Server.EnableNamespaceDelete,
-			EnableMeterCreate:     config.Server.EnableMeterCreate,
-			EnableMeterDelete:     config.Server.EnableMeterDelete,
+			NamespaceManager:       namespaceManager,
+			StreamingConnector:     streamingConnector,
+			IngestHandler:          ingestHandler,
+			Meters:                 config.Meters,
+			DisableNamespaceCreate: config.Server.DisableNamespaceCreate,
+			DisableNamespaceDelete: config.Server.DisableNamespaceDelete,
+			DisableMeterCreate:     config.Server.DisableMeterCreate,
+			DisableMeterDelete:     config.Server.DisableMeterDelete,
 		},
 		RouterHook: func(r chi.Router) {
 			r.Use(func(h http.Handler) http.Handler {

--- a/main.go
+++ b/main.go
@@ -295,7 +295,7 @@ func main() {
 		})
 	})
 
-	if !config.Stateless {
+	if config.Stateless {
 		slog.Info("starting in stateless mode")
 		if len(config.Meters) > 0 {
 			slog.Warn("static meter configs are ignored in stateless mode", "count", len(config.Meters))


### PR DESCRIPTION
This PR adds:

- documents stateless mode
- in stateless mode ignore static meter configs (log a warning if any defined)
- enable/disable meter create and delete
- enable/disable namespace create
- enable schema registry via enable flag instead of checking on URL content
- update server start log with components' state