### PR TITLE
fix(dedupe): config default typo

### DIFF
--- a/config.go
+++ b/config.go
@@ -714,6 +714,6 @@ func configure(v *viper.Viper, flags *pflag.FlagSet) {
 	v.SetDefault("dedupe.config.username", "")
 	v.SetDefault("dedupe.config.password", "")
 	v.SetDefault("dedupe.config.expiration", "24h")
-	v.SetDefault("dedupe.config.useSentintel", false)
+	v.SetDefault("dedupe.config.useSentinel", false)
 	v.SetDefault("dedupe.config.masterName", "")
 }


### PR DESCRIPTION
Fix typo in default