### PR TITLE
feat: add meter repository

### DIFF
--- a/internal/meter/inmemory.go
+++ b/internal/meter/inmemory.go
@@ -1,0 +1,51 @@
+package meter
+
+import (
+	"context"
+	"sync"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// InMemoryRepository is an in-memory meter repository.
+type InMemoryRepository struct {
+	meters map[string]models.Meter
+
+	mu       sync.Mutex
+	initOnce sync.Once
+}
+
+// NewInMemoryRepository returns a in-memory meter repository.
+func NewInMemoryRepository(meters []models.Meter) *InMemoryRepository {
+	repository := &InMemoryRepository{}
+	repository.init()
+
+	for _, meter := range meters {
+		repository.meters[meter.Slug] = meter
+	}
+
+	return repository
+}
+
+func (c *InMemoryRepository) init() {
+	c.initOnce.Do(func() {
+		c.meters = make(map[string]models.Meter)
+	})
+}
+
+// GetMeterBySlug implements the [Repository] interface.
+func (c *InMemoryRepository) GetMeterBySlug(_ context.Context, namespace string, slug string) (models.Meter, error) {
+	c.init()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	meter, ok := c.meters[slug]
+	if !ok {
+		return models.Meter{}, &models.MeterNotFoundError{
+			MeterSlug: slug,
+		}
+	}
+
+	return meter, nil
+}

--- a/internal/meter/meter.go
+++ b/internal/meter/meter.go
@@ -1,0 +1,13 @@
+package meter
+
+import (
+	"context"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// Repository is an interface to the meter store.
+type Repository interface {
+	// GetMeterBySlug returns a meter from the meter store by slug.
+	GetMeterBySlug(ctx context.Context, namespace string, slug string) (models.Meter, error)
+}


### PR DESCRIPTION
## Overview

This PR introduces a repository interface for meters. It allows us to get meter info during meter queries where appropriate.

## Notes for reviewer

The relevant API parameters will be cleared out in a followup PR.
