### PR TITLE
feat(meter): add list all meters and add namespace to meter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,10 @@ func (c Configuration) Validate() error {
 	}
 
 	for _, m := range c.Meters {
+		if m.Namespace == "" {
+			m.Namespace = c.Namespace.Default
+		}
+
 		// set default window size
 		if m.WindowSize == "" {
 			m.WindowSize = models.WindowSizeMinute

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -136,6 +136,7 @@ func TestComplete(t *testing.T) {
 		},
 		Meters: []*models.Meter{
 			{
+				Namespace:     "default",
 				Slug:          "m1",
 				Description:   "",
 				Aggregation:   "SUM",

--- a/internal/meter/inmemory.go
+++ b/internal/meter/inmemory.go
@@ -34,6 +34,13 @@ func (c *InMemoryRepository) init() {
 }
 
 // ListMeters implements the [Repository] interface.
+func (c *InMemoryRepository) ListAllMeters(_ context.Context) ([]models.Meter, error) {
+	c.init()
+
+	return slices.Clone(c.meters), nil
+}
+
+// ListMeters implements the [Repository] interface.
 func (c *InMemoryRepository) ListMeters(_ context.Context, namespace string) ([]models.Meter, error) {
 	c.init()
 

--- a/internal/meter/meter.go
+++ b/internal/meter/meter.go
@@ -8,7 +8,10 @@ import (
 
 // Repository is an interface to the meter store.
 type Repository interface {
-	// ListMeters returns a list of meters.
+	// ListAllMeters returns a list of meters.
+	ListAllMeters(ctx context.Context) ([]models.Meter, error)
+
+	// ListMeters returns a list of meters for the given namespace.
 	ListMeters(ctx context.Context, namespace string) ([]models.Meter, error)
 
 	// GetMeterByIDOrSlug returns a meter from the meter store by ID or slug.

--- a/pkg/models/meter.go
+++ b/pkg/models/meter.go
@@ -135,6 +135,7 @@ func WindowSizeFromDuration(duration time.Duration) (WindowSize, error) {
 }
 
 type Meter struct {
+	Namespace     string            `json:"-" yaml:"namespace"`
 	ID            string            `json:"id,omitempty" yaml:"id,omitempty"`
 	Slug          string            `json:"slug" yaml:"slug"`
 	Description   string            `json:"description,omitempty" yaml:"description,omitempty"`


### PR DESCRIPTION
Pre-work to adapt meter repository in Sink Worker:
https://github.com/openmeterio/openmeter/pull/320

Sink worker needs to know about all namespaces to subscribe to Kafka Topics and all meters to validate events against them.