### PR TITLE
fix(openmeter): export dedupe

### DIFF
--- a/openmeter/ingest/dedupe.go
+++ b/openmeter/ingest/dedupe.go
@@ -2,7 +2,11 @@ package ingest
 
 import (
 	"github.com/openmeterio/openmeter/internal/dedupe"
+	"github.com/openmeterio/openmeter/internal/ingest"
 )
 
 // Deduplicator checks if an event is unique.
 type Deduplicator = dedupe.Deduplicator
+
+// DeduplicatingCollector implements event deduplication at event ingestion.
+type DeduplicatingCollector = ingest.DeduplicatingCollector


### PR DESCRIPTION
It was accidentally removed in https://github.com/openmeterio/openmeter/pull/320