### PR TITLE
fix(router): default to json with invalid mime

### DIFF
--- a/internal/server/router/router.go
+++ b/internal/server/router/router.go
@@ -426,9 +426,11 @@ func (a *Router) QueryMeter(w http.ResponseWriter, r *http.Request, meterIDOrSlu
 		accept = "application/json"
 	}
 	mediatype, _, err := mime.ParseMediaType(accept)
+	// Browser can send back media type Go marks as invalid
+	// If that happens, default to JSON
 	if err != nil {
-		models.NewStatusProblem(r.Context(), err, http.StatusBadRequest).Respond(w, r)
-		return
+		logger.Debug("invalid media type, default to json", "error", err)
+		accept = "application/json"
 	}
 
 	if mediatype == "text/csv" {

--- a/internal/server/router/router.go
+++ b/internal/server/router/router.go
@@ -430,7 +430,7 @@ func (a *Router) QueryMeter(w http.ResponseWriter, r *http.Request, meterIDOrSlu
 	// If that happens, default to JSON
 	if err != nil {
 		logger.Debug("invalid media type, default to json", "error", err)
-		accept = "application/json"
+		mediatype = "application/json"
 	}
 
 	if mediatype == "text/csv" {


### PR DESCRIPTION
If I want to query in my browser (Google Chrome), the mime package returns an error:
> `mime: unexpected content after media subtype`

This PR defaults to JSON when it happens instead of erroring out request.