### PR TITLE
feat(connector): meter subjects from to

### DIFF
--- a/internal/server/router/router.go
+++ b/internal/server/router/router.go
@@ -421,7 +421,7 @@ func (a *Router) ListMeterSubjects(w http.ResponseWriter, r *http.Request, meter
 		namespace = *params.NamespaceInput
 	}
 
-	subjects, err := a.config.StreamingConnector.ListMeterSubjects(r.Context(), namespace, meterIDOrSlug)
+	subjects, err := a.config.StreamingConnector.ListMeterSubjects(r.Context(), namespace, meterIDOrSlug, nil, nil)
 	if err != nil {
 		if _, ok := err.(*models.MeterNotFoundError); ok {
 			logger.Warn("meter not found", "error", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -69,7 +69,7 @@ func (c *MockConnector) QueryMeter(ctx context.Context, namespace string, meterS
 	}, nil
 }
 
-func (c *MockConnector) ListMeterSubjects(ctx context.Context, namespace string, meterSlug string) ([]string, error) {
+func (c *MockConnector) ListMeterSubjects(ctx context.Context, namespace string, meterSlug string, from *time.Time, to *time.Time) ([]string, error) {
 	return []string{"s1"}, nil
 }
 

--- a/internal/streaming/clickhouse_connector/connector.go
+++ b/internal/streaming/clickhouse_connector/connector.go
@@ -134,7 +134,7 @@ func (c *ClickhouseConnector) QueryMeter(ctx context.Context, namespace string, 
 	}, nil
 }
 
-func (c *ClickhouseConnector) ListMeterSubjects(ctx context.Context, namespace string, meterSlug string) ([]string, error) {
+func (c *ClickhouseConnector) ListMeterSubjects(ctx context.Context, namespace string, meterSlug string, from *time.Time, to *time.Time) ([]string, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace is required")
 	}
@@ -142,7 +142,7 @@ func (c *ClickhouseConnector) ListMeterSubjects(ctx context.Context, namespace s
 		return nil, fmt.Errorf("slug is required")
 	}
 
-	subjects, err := c.listMeterViewSubjects(ctx, namespace, meterSlug)
+	subjects, err := c.listMeterViewSubjects(ctx, namespace, meterSlug, from, to)
 	if err != nil {
 		if _, ok := err.(*models.MeterNotFoundError); ok {
 			return nil, err
@@ -417,10 +417,12 @@ func (c *ClickhouseConnector) queryMeterView(ctx context.Context, namespace stri
 	return values, nil
 }
 
-func (c *ClickhouseConnector) listMeterViewSubjects(ctx context.Context, namespace string, meterSlug string) ([]string, error) {
+func (c *ClickhouseConnector) listMeterViewSubjects(ctx context.Context, namespace string, meterSlug string, from *time.Time, to *time.Time) ([]string, error) {
 	query := listMeterViewSubjects{
 		Database:      c.config.Database,
 		MeterViewName: getMeterViewNameBySlug(namespace, meterSlug),
+		From:          from,
+		To:            to,
 	}
 
 	sql, args, err := query.toSQL()

--- a/internal/streaming/connector.go
+++ b/internal/streaming/connector.go
@@ -33,6 +33,6 @@ type Connector interface {
 	CreateMeter(ctx context.Context, namespace string, meter *models.Meter) error
 	DeleteMeter(ctx context.Context, namespace string, meterSlug string) error
 	QueryMeter(ctx context.Context, namespace string, meterSlug string, params *QueryParams) (*QueryResult, error)
-	ListMeterSubjects(ctx context.Context, namespace string, meterSlug string) ([]string, error)
+	ListMeterSubjects(ctx context.Context, namespace string, meterSlug string, from *time.Time, to *time.Time) ([]string, error)
 	// Add more methods as needed ...
 }


### PR DESCRIPTION
Adding optional `from` and `to` filters to meter subject list.