### PR TITLE
refactor(route): remove from and to check handled by openapi

### DIFF
--- a/internal/server/router/router.go
+++ b/internal/server/router/router.go
@@ -74,16 +74,6 @@ func (a *Router) ListEvents(w http.ResponseWriter, r *http.Request, params api.L
 	if params.Limit != nil {
 		limit = *params.Limit
 	}
-	if limit < 1 {
-		err := errors.New("limit must be greater than or equal to 1")
-		models.NewStatusProblem(r.Context(), err, http.StatusBadRequest).Respond(w, r)
-		return
-	}
-	if limit > 100 {
-		err := errors.New("limit must be less than or equal to 100")
-		models.NewStatusProblem(r.Context(), err, http.StatusBadRequest).Respond(w, r)
-		return
-	}
 
 	queryParams := streaming.ListEventsParams{
 		Limit: limit,


### PR DESCRIPTION
OpenAPI checks `from` and `to` already.