### PR TITLE
feat(sink): create deadletter topic with admin client

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -313,6 +313,8 @@ func main() {
 func initKafkaIngest(ctx context.Context, config config.Configuration, logger *slog.Logger, serializer serializer.Serializer, group run.Group) (*kafkaingest.Collector, *kafkaingest.NamespaceHandler, error) {
 	// Initialize Kafka Admin Client
 	kafkaConfig := config.Ingest.Kafka.CreateKafkaConfig()
+	// Required for logging
+	_ = kafkaConfig.SetKey("go.logs.channel.enable", true)
 
 	// Initialize Kafka Producer
 	producer, err := kafka.NewProducer(&kafkaConfig)

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -36,9 +36,6 @@ type KafkaIngestConfiguration struct {
 func (c KafkaIngestConfiguration) CreateKafkaConfig() kafka.ConfigMap {
 	config := kafka.ConfigMap{
 		"bootstrap.servers": c.Broker,
-
-		// Required for logging
-		"go.logs.channel.enable": true,
 	}
 
 	// This is needed when using localhost brokers on OSX,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,7 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "false"
     healthcheck:
       test: kafka-topics --bootstrap-server kafka:9092 --list
       interval: 5s


### PR DESCRIPTION
Explicitly create dead-letter topics with a Kafka admin client.
Useful when Kafka broker setting is `auto.create.topics.enable: false`