### PR TITLE
fix(sink): do not close consumer

### DIFF
--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -645,7 +645,7 @@ func (s *Sink) ParseMessage(e *kafka.Message) (string, *serializer.CloudEventsKa
 }
 
 func (s *Sink) Close() error {
-	s.config.Logger.Debug("closing sink")
+	s.config.Logger.Info("closing sink")
 
 	s.running = false
 	if s.namespaceRefetch != nil {

--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -652,7 +652,7 @@ func (s *Sink) Close() error {
 	if s.flushTimer != nil {
 		s.flushTimer.Stop()
 	}
-	return s.config.Consumer.Close()
+	return nil
 }
 
 // getNamespace from topic

--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -645,6 +645,8 @@ func (s *Sink) ParseMessage(e *kafka.Message) (string, *serializer.CloudEventsKa
 }
 
 func (s *Sink) Close() error {
+	s.config.Logger.Debug("closing sink")
+
 	s.running = false
 	if s.namespaceRefetch != nil {
 		s.namespaceRefetch.Stop()
@@ -652,6 +654,7 @@ func (s *Sink) Close() error {
 	if s.flushTimer != nil {
 		s.flushTimer.Stop()
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Sink shouldn't control the `consumer` lifecycle.