### PR TITLE
feat(ingest): allow optional group by

### DIFF
--- a/examples/export-stripe-go/report.go
+++ b/examples/export-stripe-go/report.go
@@ -73,7 +73,7 @@ func (r *Report) reportUsage(subscription *stripe.Subscription) error {
 		}
 
 		// Query usage from OpenMeter for billing period
-		resp, err := r.openmeter.GetMeterValues(r.ctx, meterSlug, &openmeter.GetMeterValuesParams{
+		resp, err := r.openmeter.QueryMeter(r.ctx, meterSlug, &openmeter.QueryMeterParams{
 			// If you don't report usage events via Stripe Customer ID you need to map Stripe IDs to your internal ID
 			Subject: &subscription.Customer.ID,
 			From:    &r.from,
@@ -82,7 +82,7 @@ func (r *Report) reportUsage(subscription *stripe.Subscription) error {
 		if err != nil {
 			return err
 		}
-		payload, err := openmeter.ParseGetMeterValuesResponse(resp)
+		payload, err := openmeter.ParseQueryMeterResponse(resp)
 		if err != nil {
 			return err
 		}

--- a/internal/sink/namespaces.go
+++ b/internal/sink/namespaces.go
@@ -74,17 +74,6 @@ func validateEventWithMeter(meter models.Meter, ev serializer.CloudEventsKafkaPa
 		return NewProcessingError("cannot unmarshal event data as json", DEADLETTER)
 	}
 
-	// Parse and validate group bys
-	for _, groupByJsonPath := range meter.GroupBy {
-		groupByValue, err := jsonpath.JsonPathLookup(data, groupByJsonPath)
-		if err != nil {
-			return NewProcessingError(fmt.Sprintf("event data is missing the group by property at %s", groupByJsonPath), DEADLETTER)
-		}
-		if groupByValue == nil {
-			return NewProcessingError(fmt.Sprintf("event data group by property is nil at %s", groupByJsonPath), DEADLETTER)
-		}
-	}
-
 	// We can skip count events as they don't have value property
 	if meter.Aggregation == models.MeterAggregationCount {
 		return nil

--- a/internal/sink/namespaces_test.go
+++ b/internal/sink/namespaces_test.go
@@ -88,24 +88,6 @@ func TestNamespaStore(t *testing.T) {
 			want: sink.NewProcessingError("event data value cannot be parsed as float64: not a number", sink.DEADLETTER),
 		},
 		{
-			description: "should return error with group by property not found",
-			namespace:   "default",
-			event: serializer.CloudEventsKafkaPayload{
-				Type: "api-calls",
-				Data: `{"duration_ms": 100, "path": "/api/v1"}`,
-			},
-			want: sink.NewProcessingError("event data is missing the group by property at $.method", sink.DEADLETTER),
-		},
-		{
-			description: "should return error when group by property is null",
-			namespace:   "default",
-			event: serializer.CloudEventsKafkaPayload{
-				Type: "api-calls",
-				Data: `{"duration_ms": 100, "method": null, "path": "/api/v1"}`,
-			},
-			want: sink.NewProcessingError("event data group by property is nil at $.method", sink.DEADLETTER),
-		},
-		{
 			description: "should pass with valid event",
 			namespace:   "default",
 			event: serializer.CloudEventsKafkaPayload{

--- a/internal/streaming/clickhouse_connector/connector.go
+++ b/internal/streaming/clickhouse_connector/connector.go
@@ -345,7 +345,7 @@ func (c *ClickhouseConnector) queryMeterView(ctx context.Context, namespace stri
 		}
 
 		// We treat empty subject as nil
-		// We store empty string in the database to allow for null values
+		// Query returns subject as empty string when we don't group by subject
 		if value.Subject != nil && *value.Subject == "" {
 			value.Subject = nil
 		}

--- a/internal/streaming/connector.go
+++ b/internal/streaming/connector.go
@@ -13,16 +13,11 @@ type ListEventsParams struct {
 	Limit int
 }
 
-type QueryResult struct {
-	WindowSize *models.WindowSize
-	Values     []*models.MeterValue
-}
-
 type Connector interface {
 	ListEvents(ctx context.Context, namespace string, params ListEventsParams) ([]event.Event, error)
 	CreateMeter(ctx context.Context, namespace string, meter *models.Meter) error
 	DeleteMeter(ctx context.Context, namespace string, meterSlug string) error
-	QueryMeter(ctx context.Context, namespace string, meterSlug string, params *QueryParams) (*QueryResult, error)
+	QueryMeter(ctx context.Context, namespace string, meterSlug string, params *QueryParams) ([]models.MeterQueryRow, error)
 	ListMeterSubjects(ctx context.Context, namespace string, meterSlug string, from *time.Time, to *time.Time) ([]string, error)
 	// Add more methods as needed ...
 }

--- a/openmeter/streaming/connector.go
+++ b/openmeter/streaming/connector.go
@@ -8,6 +8,4 @@ type ListEventsParams = streaming.ListEventsParams
 
 type QueryParams = streaming.QueryParams
 
-type QueryResult = streaming.QueryResult
-
 type Connector = streaming.Connector

--- a/pkg/models/meter.go
+++ b/pkg/models/meter.go
@@ -237,22 +237,13 @@ func (m *Meter) Render(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-// TODO: replace this model with something else in the clickhouse connector
-type MeterValue struct {
-	Subject     string            `json:"subject"`
-	WindowStart time.Time         `json:"windowStart"`
-	WindowEnd   time.Time         `json:"windowEnd"`
-	Value       float64           `json:"value"`
-	GroupBy     map[string]string `json:"groupBy,omitempty"`
-}
-
 // MeterQueryRow returns a single row from the meter dataset.
 type MeterQueryRow struct {
-	Value       float64           `json:"value"`
-	WindowStart time.Time         `json:"windowStart"`
-	WindowEnd   time.Time         `json:"windowEnd"`
-	Subject     *string           `json:"subject"`
-	GroupBy     map[string]string `json:"groupBy,omitempty"`
+	Value       float64            `json:"value"`
+	WindowStart time.Time          `json:"windowStart"`
+	WindowEnd   time.Time          `json:"windowEnd"`
+	Subject     *string            `json:"subject"`
+	GroupBy     map[string]*string `json:"groupBy"`
 }
 
 // Render implements the chi renderer interface.


### PR DESCRIPTION
- allow ingesting events without group by
- return null in meter query if group by is empty
- cleanup unnecessary intermediate types

## Ingest

Missing `method` group-by.

```sh
curl -X POST http://localhost:8888/api/v1/events \
-H "Expect:" \
-H 'Content-Type: application/cloudevents+json' \
--data-raw '
{
  "specversion" : "1.0",
  "type": "api-calls",
  "id": "00001",
  "time": "2023-01-01T00:00:00.001Z",
  "source": "service-0",
  "subject": "customer-1",
  "data": {
    "duration_ms": "1",
    "path": "/hello"
  }
}
```

Both `path` and `method` group-bys are present.

```sh
curl -X POST http://localhost:8888/api/v1/events \                      
-H "Expect:" \
-H 'Content-Type: application/cloudevents+json' \
--data-raw '
{
  "specversion" : "1.0",
  "type": "api-calls",
  "id": "00002",
  "time": "2023-01-01T00:00:00.001Z",
  "source": "service-0",
  "subject": "customer-1",
  "data": {
    "duration_ms": "1",
    "method": "GET",
    "path": "/hello"
  }
}
'
```

## Query

```js
// http://localhost:8888/api/v1/meters/m1/query?groupBy=method&groupBy=path

{
  "data": [
    {
      "value": 1,
      "windowStart": "2023-01-01T00:00:00Z",
      "windowEnd": "2023-01-01T00:01:00Z",
      "subject": null,
      "groupBy": {
        "method": null,
        "path": "/hello"
      }
    },
    {
      "value": 1,
      "windowStart": "2023-01-01T00:00:00Z",
      "windowEnd": "2023-01-01T00:01:00Z",
      "subject": null,
      "groupBy": {
        "method": "GET",
        "path": "/hello"
      }
    }
  ]
}
```