### PR TITLE
If total value is queried for a period, replace the window start and end with the period for each row

### DIFF
--- a/internal/server/router/router.go
+++ b/internal/server/router/router.go
@@ -208,6 +208,18 @@ func (a *Router) QueryMeterWithMeter(w http.ResponseWriter, r *http.Request, log
 		Data:       data,
 	}
 
+	// If total data is queried for a period, replace the window start and end with the period for each row
+	if params.WindowSize == nil {
+		for i := range resp.Data {
+			if params.From != nil {
+				resp.Data[i].WindowStart = *params.From
+			}
+			if params.To != nil {
+				resp.Data[i].WindowEnd = *params.To
+			}
+		}
+	}
+
 	// Parse media type
 	accept := r.Header.Get("Accept")
 	if accept == "" {


### PR DESCRIPTION
```
GET http://127.0.0.1:8888/api/v1/meters/m1/query?from=2023-01-01T01:00:00Z&to=2023-01-01T09:00:00Z
```

Before:

```json
{
  "from": "2023-01-01T01:00:00Z",
  "to": "2023-01-01T09:00:00Z",
  "data": [
    {
      "value": 2,
      "windowStart": "2023-01-01T01:00:00Z",
      "windowEnd": "2023-01-01T01:02:00Z",
      "subject": null,
      "groupBy": {
        
      }
    }
  ]
}
```

After:

```json
{
  "from": "2023-01-01T01:00:00Z",
  "to": "2023-01-01T09:00:00Z",
  "data": [
    {
      "value": 2,
      "windowStart": "2023-01-01T01:00:00Z",
      "windowEnd": "2023-01-01T09:00:00Z",
      "subject": null,
      "groupBy": {
        
      }
    }
  ]
}
```