### PR TITLE
Revert "chore(deps): bump github.com/getkin/kin-openapi from 0.120.0 to 0.121.0"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,8 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.14.0
 	github.com/confluentinc/confluent-kafka-go/v2 v2.2.0
 	github.com/deepmap/oapi-codegen/v2 v2.0.0
-	github.com/getkin/kin-openapi v0.121.0
+	github.com/getkin/kin-openapi v0.120.0
 	github.com/go-chi/chi/v5 v5.0.10
-	github.com/go-chi/cors v1.2.1
 	github.com/go-chi/render v1.0.3
 	github.com/go-slog/otelslog v0.1.0
 	github.com/golang-jwt/jwt/v5 v5.1.0
@@ -59,6 +58,7 @@ require (
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/go-chi/cors v1.2.1 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.6.1 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -977,8 +977,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
-github.com/getkin/kin-openapi v0.121.0 h1:KbQmTugy+lQF+ed5H3tikjT4prqx5+KCLAq4U81Hkcw=
-github.com/getkin/kin-openapi v0.121.0/go.mod h1:PCWw/lfBrJY4HcdqE3jj+QFkaFK8ABoqo7PvqVhXXqw=
+github.com/getkin/kin-openapi v0.120.0 h1:MqJcNJFrMDFNc07iwE8iFC5eT2k/NPUFDIpNeiZv8Jg=
+github.com/getkin/kin-openapi v0.120.0/go.mod h1:PCWw/lfBrJY4HcdqE3jj+QFkaFK8ABoqo7PvqVhXXqw=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
Reverts openmeterio/openmeter#452

```
go generate ./...
# github.com/deepmap/oapi-codegen/v2/pkg/codegen
../.devenv/state/go/pkg/mod/github.com/deepmap/oapi-codegen/v2@v2.0.0/pkg/codegen/codegen.go:231:53: cannot use spec.Components.Responses (variable of type openapi3.ResponseBodies) as openapi3.Responses value in argument to GenerateResponseDefinitions
../.devenv/state/go/pkg/mod/github.com/deepmap/oapi-codegen/v2@v2.0.0/pkg/codegen/codegen.go:403:54: cannot use swagger.Components.Responses (variable of type openapi3.ResponseBodies) as openapi3.Responses value in argument to GenerateTypesForResponses
../.devenv/state/go/pkg/mod/github.com/deepmap/oapi-codegen/v2@v2.0.0/pkg/codegen/codegen.go:564:29: invalid operation: cannot index responses (variable of type openapi3.Responses)
../.devenv/state/go/pkg/mod/github.com/deepmap/oapi-codegen/v2@v2.0.0/pkg/codegen/filter.go:7:29: cannot use swagger.Paths (variable of type *openapi3.Paths) as openapi3.Paths value in argument to excludeOperationsWithTags
../.devenv/state/go/pkg/mod/github.com/deepmap/oapi-codegen/v2@v2.0.0/pkg/codegen/filter.go:10:29: cannot use swagger.Paths (variable of type *openapi3.Paths) as openapi3.Paths value in argument to includeOperationsWithTags
../.devenv/state/go/pkg/mod/github.com/deepmap/oapi-codegen/v2@v2.0.0/pkg/codegen/filter.go:19:27: cannot range over paths (variable of type openapi3.Paths)
../.devenv/state/go/pkg/mod/github.com/deepmap/oapi-codegen/v2@v2.0.0/pkg/codegen/operations.go:278:45: cannot use responses (variable of type *openapi3.Responses) as openapi3.Responses value in argument to SortedResponsesKeys
../.devenv/state/go/pkg/mod/github.com/deepmap/oapi-codegen/v2@v2.0.0/pkg/codegen/operations.go:280:27: invalid operation: cannot index responses (variable of type *openapi3.Responses)
../.devenv/state/go/pkg/mod/github.com/deepmap/oapi-codegen/v2@v2.0.0/pkg/codegen/operations.go:539:46: cannot use swagger.Paths (variable of type *openapi3.Paths) as openapi3.Paths value in argument to SortedPathsKeys
../.devenv/state/go/pkg/mod/github.com/deepmap/oapi-codegen/v2@v2.0.0/pkg/codegen/operations.go:540:28: invalid operation: cannot index swagger.Paths (variable of type *openapi3.Paths)
../.devenv/state/go/pkg/mod/github.com/deepmap/oapi-codegen/v2@v2.0.0/pkg/codegen/operations.go:540:28: too many errors
api/api.go:1: running "go": exit status 1
```