### PR TITLE
ci: ignore cache errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,14 @@
 .direnv/
+.devenv/
 .github/
 bin/
 build/
+ci/
+deploy/
 Dockerfile
+docs/
+e2e/
+etc/
+examples/
+quickstart/
 tmp/

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -111,7 +111,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
           outputs: ${{ steps.build-output.outputs.value }}
           # push: ${{ inputs.publish }}
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Container image builds keep failing due to GHA cache errors.

While this may cause longer build times in the short run, it's still better than having to rerun builds all the time.

https://github.com/moby/buildkit/issues/2492
