### PR TITLE
Do not upload trivy results

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -135,12 +135,12 @@ jobs:
           format: sarif
           output: trivy-results.sarif
 
-      - name: Upload Trivy scan results as artifact
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-        with:
-          name: "[${{ github.job }}] Trivy scan results"
-          path: trivy-results.sarif
-          retention-days: 5
+      # - name: Upload Trivy scan results as artifact
+      #   uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      #   with:
+      #     name: "[${{ github.job }}] Trivy scan results"
+      #     path: trivy-results.sarif
+      #     retention-days: 5
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@29b1f65c5e92e24fe6b6647da1eaabe529cec70f # v2.3.3


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

A recent change in GHA causes image builds to break.

The culprit is the vulnerability scan artifact upload. Since we don't actually need it as a build artifact (it gets uploaded to the GH security tab), this PR turns that off for now.
