### PR TITLE
refactor(models/meter): remove redundant len check in `Validate`

### DIFF
--- a/pkg/models/meter.go
+++ b/pkg/models/meter.go
@@ -222,11 +222,9 @@ func (m *Meter) Validate() error {
 		}
 	}
 
-	if len(m.GroupBy) != 0 {
-		for key, value := range m.GroupBy {
-			if !strings.HasPrefix(value, "$") {
-				return fmt.Errorf("meter group by value must start with $ for key %s", key)
-			}
+	for key, value := range m.GroupBy {
+		if !strings.HasPrefix(value, "$") {
+			return fmt.Errorf("meter group by value must start with $ for key %s", key)
 		}
 	}
 


### PR DESCRIPTION
## Overview

From the Go specification [^1]:

> "3. If the map is nil, the number of iterations is 0."

`len` returns 0 if the map is nil [^2]. Therefore, checking `len(v) != 0` around a loop is unnecessary.

[^1]: https://go.dev/ref/spec#For_range
[^2]: https://pkg.go.dev/builtin#len

## Notes for reviewer

<!-- Anything the reviewer should know? -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
