### PR TITLE
docs(client): add version to go client

### DIFF
--- a/api/client/go/README.md
+++ b/api/client/go/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```sh
-go get github.com/openmeterio/openmeter/api/client/go
+go get github.com/openmeterio/openmeter/api/client/go@v1.0.0-beta.53
 ```
 
 ## Usage


### PR DESCRIPTION
Fix go client version for `go get` install instruction.