### PR TITLE
fix(api): python generator

### DIFF
--- a/api/client/python/config.yaml
+++ b/api/client/python/config.yaml
@@ -16,13 +16,12 @@ directive:
     where: "$.components.parameters[*]"
     transform: >
       $["x-ms-parameter-location"] = "method";
-
   - from: openapi-document
     where: "$.components.responses.BadRequestProblemResponse"
     transform: >
       $["x-ms-error-response"] = true;
   - from: openapi-document
-    where: "$.components.responses.MethodNotAllowedProblemResponse"
+    where: "$.components.responses.UnauthorizedProblemResponse"
     transform: >
       $["x-ms-error-response"] = true;
   - from: openapi-document
@@ -37,3 +36,23 @@ directive:
     where: "$.components.responses.UnexpectedProblemResponse"
     transform: >
       $["x-ms-error-response"] = true;
+  # remove CloudCookieAuth from securitySchemes
+  # and remove it from the security requirements
+  - from: openapi-document
+    where: "$.components.securitySchemes.CloudCookieAuth"
+    transform: >
+      return undefined;
+  - from: openapi-document
+    where: "$.security[*]"
+    transform: >
+      if ($.CloudCookieAuth) {
+        return undefined;
+      }
+      return $;
+suppressions:
+  - code: UnkownSecurityScheme
+    from: openapi-document
+    reason: Unkown security scheme
+  - code: PreCheck/CheckDuplicateSchemas
+    from: openapi-document
+    reason: Validator already checks

--- a/api/client/python/poetry.lock
+++ b/api/client/python/poetry.lock
@@ -159,6 +159,52 @@ typing-extensions = ">=4.6.0"
 aio = ["aiohttp (>=3.0)"]
 
 [[package]]
+name = "black"
+version = "24.3.0"
+description = "The uncompromising code formatter."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "black-24.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7d5e026f8da0322b5662fa7a8e752b3fa2dac1c1cbc213c3d7ff9bdd0ab12395"},
+    {file = "black-24.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9f50ea1132e2189d8dff0115ab75b65590a3e97de1e143795adb4ce317934995"},
+    {file = "black-24.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e2af80566f43c85f5797365077fb64a393861a3730bd110971ab7a0c94e873e7"},
+    {file = "black-24.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:4be5bb28e090456adfc1255e03967fb67ca846a03be7aadf6249096100ee32d0"},
+    {file = "black-24.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4f1373a7808a8f135b774039f61d59e4be7eb56b2513d3d2f02a8b9365b8a8a9"},
+    {file = "black-24.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aadf7a02d947936ee418777e0247ea114f78aff0d0959461057cae8a04f20597"},
+    {file = "black-24.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65c02e4ea2ae09d16314d30912a58ada9a5c4fdfedf9512d23326128ac08ac3d"},
+    {file = "black-24.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:bf21b7b230718a5f08bd32d5e4f1db7fc8788345c8aea1d155fc17852b3410f5"},
+    {file = "black-24.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:2818cf72dfd5d289e48f37ccfa08b460bf469e67fb7c4abb07edc2e9f16fb63f"},
+    {file = "black-24.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4acf672def7eb1725f41f38bf6bf425c8237248bb0804faa3965c036f7672d11"},
+    {file = "black-24.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7ed6668cbbfcd231fa0dc1b137d3e40c04c7f786e626b405c62bcd5db5857e4"},
+    {file = "black-24.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:56f52cfbd3dabe2798d76dbdd299faa046a901041faf2cf33288bc4e6dae57b5"},
+    {file = "black-24.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:79dcf34b33e38ed1b17434693763301d7ccbd1c5860674a8f871bd15139e7837"},
+    {file = "black-24.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e19cb1c6365fd6dc38a6eae2dcb691d7d83935c10215aef8e6c38edee3f77abd"},
+    {file = "black-24.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65b76c275e4c1c5ce6e9870911384bff5ca31ab63d19c76811cb1fb162678213"},
+    {file = "black-24.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:b5991d523eee14756f3c8d5df5231550ae8993e2286b8014e2fdea7156ed0959"},
+    {file = "black-24.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c45f8dff244b3c431b36e3224b6be4a127c6aca780853574c00faf99258041eb"},
+    {file = "black-24.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6905238a754ceb7788a73f02b45637d820b2f5478b20fec82ea865e4f5d4d9f7"},
+    {file = "black-24.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7de8d330763c66663661a1ffd432274a2f92f07feeddd89ffd085b5744f85e7"},
+    {file = "black-24.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:7bb041dca0d784697af4646d3b62ba4a6b028276ae878e53f6b4f74ddd6db99f"},
+    {file = "black-24.3.0-py3-none-any.whl", hash = "sha256:41622020d7120e01d377f74249e677039d20e6344ff5851de8a10f11f513bf93"},
+    {file = "black-24.3.0.tar.gz", hash = "sha256:a0c9c4a0771afc6919578cec71ce82a3e31e054904e7197deacbc9382671c41f"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "certifi"
 version = "2023.7.22"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -254,6 +300,20 @@ files = [
 ]
 
 [[package]]
+name = "click"
+version = "8.1.7"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "cloudevents"
 version = "1.10.0"
 description = "CloudEvents Python SDK"
@@ -269,6 +329,17 @@ deprecation = ">=2.0,<3.0"
 
 [package.extras]
 pydantic = ["pydantic (>=1.0.0,<3.0)"]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+files = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
 
 [[package]]
 name = "deprecation"
@@ -463,6 +534,17 @@ files = [
 ]
 
 [[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "packaging"
 version = "23.1"
 description = "Core utilities for Python packages"
@@ -472,6 +554,32 @@ files = [
     {file = "packaging-23.1-py3-none-any.whl", hash = "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61"},
     {file = "packaging-23.1.tar.gz", hash = "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"},
 ]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
+    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.2.0"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "platformdirs-4.2.0-py3-none-any.whl", hash = "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068"},
+    {file = "platformdirs-4.2.0.tar.gz", hash = "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"},
+]
+
+[package.extras]
+docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
 
 [[package]]
 name = "requests"
@@ -503,6 +611,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 files = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 
 [[package]]
@@ -626,4 +745,4 @@ aio = ["aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "608f167a68c8dd9a8fd54c7573485cb982efd0221e3308abd515c997cf971b5d"
+content-hash = "09e661be54155b6b2601192b789c8ed914c5f6a6455d80180a74aec7a8d0edb8"

--- a/api/client/python/pyproject.toml
+++ b/api/client/python/pyproject.toml
@@ -28,6 +28,9 @@ azure-core = "^1.29.4"
 isodate = "^0.6.1"
 cloudevents = "^1.10.0"
 
+[tool.poetry.group.dev.dependencies]
+black = "^24.3.0"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/api/client/python/src/openmeter/_client.py
+++ b/api/client/python/src/openmeter/_client.py
@@ -17,14 +17,20 @@ from ._serialization import Deserializer, Serializer
 
 
 class Client(ClientOperationsMixin):  # pylint: disable=client-accepts-api-version-keyword
-    """Client.
+    """OpenMeter is a cloud native usage metering service.
 
-    :keyword endpoint: Service URL. Required. Default value is "".
+    The OpenMeter API allows you to ingest events, query meter usage, and manage resources.
+    ---------------------------------------------------------------------------------------
+
+    *Operations with the ☁ (cloud) notation are only available in OpenMeter Cloud.*.
+
+    :keyword endpoint: Service URL. Known values are: "http://127.0.0.1:8888" and
+     "https://openmeter.cloud". Default value is "http://127.0.0.1:8888".
     :paramtype endpoint: str
     """
 
     def __init__(  # pylint: disable=missing-client-constructor-parameter-credential
-        self, *, endpoint: str = "", **kwargs: Any
+        self, *, endpoint: str = "http://127.0.0.1:8888", **kwargs: Any
     ) -> None:
         self._config = ClientConfiguration(**kwargs)
         _policies = kwargs.pop("policies", None)

--- a/api/client/python/src/openmeter/aio/_client.py
+++ b/api/client/python/src/openmeter/aio/_client.py
@@ -17,14 +17,20 @@ from ._operations import ClientOperationsMixin
 
 
 class Client(ClientOperationsMixin):  # pylint: disable=client-accepts-api-version-keyword
-    """Client.
+    """OpenMeter is a cloud native usage metering service.
 
-    :keyword endpoint: Service URL. Required. Default value is "".
+    The OpenMeter API allows you to ingest events, query meter usage, and manage resources.
+    ---------------------------------------------------------------------------------------
+
+    *Operations with the ☁ (cloud) notation are only available in OpenMeter Cloud.*.
+
+    :keyword endpoint: Service URL. Known values are: "http://127.0.0.1:8888" and
+     "https://openmeter.cloud". Default value is "http://127.0.0.1:8888".
     :paramtype endpoint: str
     """
 
     def __init__(  # pylint: disable=missing-client-constructor-parameter-credential
-        self, *, endpoint: str = "", **kwargs: Any
+        self, *, endpoint: str = "http://127.0.0.1:8888", **kwargs: Any
     ) -> None:
         self._config = ClientConfiguration(**kwargs)
         _policies = kwargs.pop("policies", None)


### PR DESCRIPTION
Fixes generation. The `apiKey` securityScheme type is a catch all for AzureKey.
https://github.com/Azure/autorest/blob/main/packages/extensions/modelerfour/src/modeler/security-processor.ts#L195
```
fatal   | Error: AzureKey security scheme should be of in 'header' but was 'cookie'
fatal   | Process() cancelled due to failure 
error   |   Error: Plugin modelerfour reported failure.
error   | Autorest completed with an error. If you think the error message is unclear, or is a bug, please declare an issues at 
```