### PR TITLE
feat(meter): filter meter events by data properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /build/
 /config.yaml
 /tmp/
+/.idea/
 
 # Go workspace file
 go.work

--- a/README.md
+++ b/README.md
@@ -109,10 +109,16 @@ Run the dependencies:
 make up
 ```
 
+Run OpenMeter Sink Worker
+
+```sh
+make sink-worker
+```
+
 Run OpenMeter:
 
 ```sh
-make run
+make server
 ```
 
 Run tests:

--- a/examples/export-stripe-go/go.mod
+++ b/examples/export-stripe-go/go.mod
@@ -1,6 +1,8 @@
 module github.com/openmeterio/openmeter/examples/export-stripe
 
-go 1.20
+go 1.22
+
+toolchain go1.22.1
 
 require (
 	github.com/openmeterio/openmeter v0.0.0-00010101000000-000000000000

--- a/internal/streaming/clickhouse_connector/connector.go
+++ b/internal/streaming/clickhouse_connector/connector.go
@@ -273,6 +273,7 @@ func (c *ClickhouseConnector) createMeterView(ctx context.Context, namespace str
 		EventType:     meter.EventType,
 		ValueProperty: meter.ValueProperty,
 		GroupBy:       meter.GroupBy,
+		FilterBy:      meter.FilterBy,
 	}
 	sql, args, err := view.toSQL()
 	if err != nil {

--- a/internal/streaming/clickhouse_connector/query_test.go
+++ b/internal/streaming/clickhouse_connector/query_test.go
@@ -108,19 +108,6 @@ func TestCreateMeterView(t *testing.T) {
 			wantSQL:  "CREATE MATERIALIZED VIEW IF NOT EXISTS openmeter.om_my_namespace_meter1 (subject String, windowstart DateTime, windowend DateTime, value AggregateFunction(count, Float64)) ENGINE = AggregatingMergeTree() ORDER BY (windowstart, windowend, subject) AS SELECT subject, tumbleStart(time, toIntervalMinute(1)) AS windowstart, tumbleEnd(time, toIntervalMinute(1)) AS windowend, countState(*) AS value FROM openmeter.om_events WHERE openmeter.om_events.namespace = 'my_namespace' AND empty(openmeter.om_events.validation_error) = 1 AND openmeter.om_events.type = 'myevent' GROUP BY windowstart, windowend, subject",
 			wantArgs: nil,
 		},
-		{
-			query: createMeterView{
-				Database:      "openmeter",
-				Namespace:     "my_namespace",
-				MeterSlug:     "meter1",
-				Aggregation:   models.MeterAggregationCount,
-				EventType:     "myevent",
-				ValueProperty: "",
-				GroupBy:       map[string]string{},
-			},
-			wantSQL:  "CREATE MATERIALIZED VIEW IF NOT EXISTS openmeter.om_my_namespace_meter1 (subject String, windowstart DateTime, windowend DateTime, value AggregateFunction(count, Float64)) ENGINE = AggregatingMergeTree() ORDER BY (windowstart, windowend, subject) AS SELECT subject, tumbleStart(time, toIntervalMinute(1)) AS windowstart, tumbleEnd(time, toIntervalMinute(1)) AS windowend, countState(*) AS value FROM openmeter.om_events WHERE openmeter.om_events.namespace = 'my_namespace' AND empty(openmeter.om_events.validation_error) = 1 AND openmeter.om_events.type = 'myevent' GROUP BY windowstart, windowend, subject",
-			wantArgs: nil,
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/models/meter.go
+++ b/pkg/models/meter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -202,6 +203,20 @@ func (m *Meter) Validate() error {
 			return fmt.Errorf("meter group by key %s is not unique", key)
 		}
 		seen[key] = struct{}{}
+	}
+
+	if m.FilterBy != nil {
+		for _, filter := range m.FilterBy {
+			if !strings.HasPrefix(filter.Property, "$") {
+				return fmt.Errorf("meter filterBy Property must start with $, got %s in meter %s", filter.Property, m.Slug)
+			}
+			if !slices.Contains(filter.Operator.Values(), string(filter.Operator)) {
+				return fmt.Errorf("meter filterBy Operator must be one of %s, got %s in meter %s", filter.Operator.Values(), filter.Operator, m.Slug)
+			}
+			if strings.TrimSpace(filter.Value) == "" {
+				return fmt.Errorf("meter filterBy value must not be empty in meter %s", m.Slug)
+			}
+		}
 	}
 
 	return nil

--- a/pkg/models/meter.go
+++ b/pkg/models/meter.go
@@ -49,44 +49,6 @@ func (MeterAggregation) IsValid(input string) bool {
 	return false
 }
 
-type MeterFilterOperator string
-
-const (
-	// MeterFilterOperatorIn        MeterFilterOperator = "IN"
-	// MeterFilterOperatorNotIn     MeterFilterOperator = "NOT IN"
-	MeterFilterOperatorEquals    MeterFilterOperator = "EQ"
-	MeterFilterOperatorNot       MeterFilterOperator = "NEQ"
-	MeterFilterLowerThan         MeterFilterOperator = "LT"
-	MeterFilterLowerThanOrEq     MeterFilterOperator = "LTE"
-	MeterFilterGreaterThan       MeterFilterOperator = "GT"
-	MeterFilterGreaterThanOrEq   MeterFilterOperator = "GTE"
-	MeterFilterOperatorIsNull    MeterFilterOperator = "IS NULL"
-	MeterFilterOperatorIsNotNull MeterFilterOperator = "IS NOT NULL"
-)
-
-type MeterFilter struct {
-	Property string              `json:"property" yaml:"property"`
-	Operator MeterFilterOperator `json:"operator" yaml:"operator"`
-	Value    string              `json:"value" yaml:"value"`
-}
-
-// Values provides list valid values for Enum
-func (MeterFilterOperator) Values() (kinds []string) {
-	for _, s := range []MeterFilterOperator{
-		MeterFilterOperatorEquals,
-		MeterFilterOperatorNot,
-		MeterFilterLowerThan,
-		MeterFilterLowerThanOrEq,
-		MeterFilterGreaterThan,
-		MeterFilterGreaterThanOrEq,
-		MeterFilterOperatorIsNull,
-		MeterFilterOperatorIsNotNull,
-	} {
-		kinds = append(kinds, string(s))
-	}
-	return
-}
-
 type WindowSize string
 
 const (
@@ -146,8 +108,7 @@ type Meter struct {
 	ValueProperty string            `json:"valueProperty,omitempty" yaml:"valueProperty,omitempty"`
 	GroupBy       map[string]string `json:"groupBy,omitempty" yaml:"groupBy,omitempty"`
 	WindowSize    WindowSize        `json:"windowSize,omitempty" yaml:"windowSize,omitempty"`
-	// TODO: add filter by
-	// FilterBy      []MeterFilter
+	FilterBy      []MeterFilter     `json:"filterBy,omitempty" yaml:"filterBy,omitempty"`
 }
 
 type MeterOptions struct {

--- a/pkg/models/meter_test.go
+++ b/pkg/models/meter_test.go
@@ -186,6 +186,60 @@ func TestMeterValidation(t *testing.T) {
 			},
 			error: fmt.Errorf("meter group by value must start with $ for key test_group"),
 		},
+		{
+			description: "filterBy property is invalid",
+			meter: Meter{
+				Slug:          "slug-test",
+				Aggregation:   MeterAggregationCount,
+				WindowSize:    WindowSizeMinute,
+				EventType:     "event-type-test",
+				ValueProperty: "$.my_property",
+				FilterBy: []MeterFilter{
+					{
+						Property: "invalid",
+						Operator: MeterFilterOperatorEquals,
+						Value:    "success",
+					},
+				},
+			},
+			error: fmt.Errorf("meter filterBy Property must start with $, got invalid in meter slug-test"),
+		},
+		{
+			description: "filterBy Operator is invalid",
+			meter: Meter{
+				Slug:          "slug-test",
+				Aggregation:   MeterAggregationCount,
+				WindowSize:    WindowSizeMinute,
+				EventType:     "event-type-test",
+				ValueProperty: "$.my_property",
+				FilterBy: []MeterFilter{
+					{
+						Property: "$.result",
+						Operator: "NE",
+						Value:    "success",
+					},
+				},
+			},
+			error: fmt.Errorf("meter filterBy Operator must be one of [EQ], got NE in meter slug-test"),
+		},
+		{
+			description: "filterBy Value is invalid",
+			meter: Meter{
+				Slug:          "slug-test",
+				Aggregation:   MeterAggregationCount,
+				WindowSize:    WindowSizeMinute,
+				EventType:     "event-type-test",
+				ValueProperty: "$.my_property",
+				FilterBy: []MeterFilter{
+					{
+						Property: "$.result",
+						Operator: "EQ",
+						Value:    "",
+					},
+				},
+			},
+			error: fmt.Errorf("meter filterBy value must not be empty in meter slug-test"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/models/meterfilter.go
+++ b/pkg/models/meterfilter.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+
 	"github.com/huandu/go-sqlbuilder"
 )
 

--- a/pkg/models/meterfilter.go
+++ b/pkg/models/meterfilter.go
@@ -1,0 +1,54 @@
+package models
+
+import (
+	"fmt"
+	"github.com/huandu/go-sqlbuilder"
+)
+
+type MeterFilterOperator string
+
+const (
+	MeterFilterOperatorEquals MeterFilterOperator = "EQ"
+	// TODO support more filters and value types
+	// MeterFilterOperatorIn        MeterFilterOperator = "IN"
+	// MeterFilterOperatorNotIn     MeterFilterOperator = "NOT IN"
+	// MeterFilterOperatorNot       MeterFilterOperator = "NEQ"
+	// MeterFilterLowerThan         MeterFilterOperator = "LT"
+	// MeterFilterLowerThanOrEq     MeterFilterOperator = "LTE"
+	// MeterFilterGreaterThan       MeterFilterOperator = "GT"
+	// MeterFilterGreaterThanOrEq   MeterFilterOperator = "GTE"
+	// MeterFilterOperatorIsNull    MeterFilterOperator = "IS NULL"
+	// MeterFilterOperatorIsNotNull MeterFilterOperator = "IS NOT NULL"
+)
+
+type MeterFilter struct {
+	Property string              `json:"property" yaml:"property"`
+	Operator MeterFilterOperator `json:"operator" yaml:"operator"`
+	Value    string              `json:"value" yaml:"value"`
+}
+
+// Values provides list valid values for Enum
+func (MeterFilterOperator) Values() (kinds []string) {
+	for _, s := range []MeterFilterOperator{
+		MeterFilterOperatorEquals,
+		//MeterFilterOperatorNot,
+		//MeterFilterLowerThan,
+		//MeterFilterLowerThanOrEq,
+		//MeterFilterGreaterThan,
+		//MeterFilterGreaterThanOrEq,
+		//MeterFilterOperatorIsNull,
+		//MeterFilterOperatorIsNotNull,
+	} {
+		kinds = append(kinds, string(s))
+	}
+	return
+}
+
+func (f MeterFilter) ToSql() (string, error) {
+	switch f.Operator {
+	case MeterFilterOperatorEquals:
+		return fmt.Sprintf("JSON_VALUE(data, '%s') = '%s'", sqlbuilder.Escape(f.Property), sqlbuilder.Escape(f.Value)), nil
+	default:
+		return "", fmt.Errorf("filter not implemented yet: %s", f.Operator)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Filter ingested events by data properties

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

I came across https://github.com/openmeterio/openmeter/issues/629 while looking for an issue to practice Go :) I decided to give it a Go (pun intended) and see what I can come up with and saw that you already had some FilterBy definitions. 

This PR implements the EQ operation on event data for strings, and makes is so that events that don't match the Filter are not merged into the materialized view of the meter.

i.e.:
for input
```
{
   ...
   data: {
      duration: 123,
      result: 'success'
   }
}
```
the following meters
```
# tracks only success queries
meters:
  - slug: successful_duration
    description: Successful Requests
    eventType: request
    aggregation: SUM
    valueProperty: $.duration
    filterBy:
      - property: $.result
        operator: EQ
        value: success

# tracks all durations
  - slug: all_durations
    description: All request durations
    eventType: request
    aggregation: SUM
    valueProperty: $.duration
```


Partially fixes #629

## Notes for reviewer

Before implementing any further, I wanted to check in with you, whether this Filter format is something you'd like to stick to and how deep you want to go with the supported types for filter values, what use cases are you aware of so far? 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
