### PR TITLE
refactor(sink-worker): use contex.Context for fetching namespaces

### DIFF
--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -111,7 +111,7 @@ func main() {
 	// Initialize OTel Metrics
 	otelMeterProvider, err := conf.Telemetry.Metrics.NewMeterProvider(ctx, res)
 	if err != nil {
-		logger.Error(err.Error())
+		logger.Error("failed to initialize OpenTelemetry Metrics provider", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
 	defer func() {
@@ -134,7 +134,7 @@ func main() {
 	// Initialize OTel Tracer
 	otelTracerProvider, err := conf.Telemetry.Trace.NewTracerProvider(ctx, res)
 	if err != nil {
-		logger.Error(err.Error())
+		logger.Error("failed to initialize OpenTelemetry Trace provider", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
 	defer func() {

--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -368,9 +368,6 @@ func (s *Sink) subscribeToNamespaces(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to subscribe to topics: %s", err)
 		}
-		if err != nil {
-			return fmt.Errorf("failed to subscribe to topics: %s", err)
-		}
 	}
 
 	return nil


### PR DESCRIPTION
## Overview

* use `context.Context` for fetching `namespaces`
* make OTel initialization errors more descriptive

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
