### PR TITLE
feat(backend): add ingest event counter metric

### DIFF
--- a/collector/benthos/internal/message/transaction.go
+++ b/collector/benthos/internal/message/transaction.go
@@ -31,7 +31,7 @@ type Transaction struct {
 	// indicates whether the message has been propagated successfully.
 	responseFunc func(context.Context, error) error
 
-	// Used for cancelling transactions. When cancelled it is up to the receiver
+	// Used for canceling transactions. When canceled it is up to the receiver
 	// of this transaction to abort any attempt to deliver the transaction
 	// message.
 	ctx context.Context
@@ -60,7 +60,7 @@ func NewTransactionFunc(payload Batch, fn func(context.Context, error) error) Tr
 }
 
 // Context returns a context that indicates the cancellation of a transaction.
-// It is optional for receivers of a transaction to honour this context, and is
+// It is optional for receivers of a transaction to honor this context, and is
 // worth doing in cases where the transaction is blocked (on reconnect loops,
 // etc) as it is often used as a fail-fast mechanism.
 //
@@ -71,7 +71,7 @@ func (t *Transaction) Context() context.Context {
 }
 
 // WithContext returns a copy of the transaction associated with a context used
-// for cancellation. When cancelled it is up to the receiver of this transaction
+// for cancellation. When canceled it is up to the receiver of this transaction
 // to abort any attempt to deliver the transaction message.
 func (t *Transaction) WithContext(ctx context.Context) *Transaction {
 	newT := *t

--- a/collector/benthos/internal/shutdown/signaler.go
+++ b/collector/benthos/internal/shutdown/signaler.go
@@ -86,7 +86,7 @@ func (s *Signaller) CloseAtLeisureChan() <-chan struct{} {
 }
 
 // CloseAtLeisureCtx returns a context.Context that will be terminated when
-// either the provided context is cancelled or the signal to shut down
+// either the provided context is canceled or the signal to shut down
 // either at leisure or immediately has been made.
 func (s *Signaller) CloseAtLeisureCtx(ctx context.Context) (context.Context, context.CancelFunc) {
 	var cancel context.CancelFunc
@@ -119,7 +119,7 @@ func (s *Signaller) CloseNowChan() <-chan struct{} {
 }
 
 // CloseNowCtx returns a context.Context that will be terminated when either the
-// provided context is cancelled or the signal to shut down immediately has been
+// provided context is canceled or the signal to shut down immediately has been
 // made.
 func (s *Signaller) CloseNowCtx(ctx context.Context) (context.Context, context.CancelFunc) {
 	var cancel context.CancelFunc
@@ -151,8 +151,8 @@ func (s *Signaller) HasClosedChan() <-chan struct{} {
 	return s.hasClosedChan
 }
 
-// HasClosedCtx returns a context.Context that will be cancelled when either the
-// provided context is cancelled or the signal that the component has shut down
+// HasClosedCtx returns a context.Context that will be canceled when either the
+// provided context is canceled or the signal that the component has shut down
 // has been made.
 func (s *Signaller) HasClosedCtx(ctx context.Context) (context.Context, context.CancelFunc) {
 	var cancel context.CancelFunc

--- a/internal/ingest/kafkaingest/collector.go
+++ b/internal/ingest/kafkaingest/collector.go
@@ -22,7 +22,6 @@ type Collector struct {
 	// For example: "om_%s_events"
 	NamespacedTopicTemplate string
 
-	metricMeter        metric.Meter
 	ingestEventCounter metric.Int64Counter
 }
 


### PR DESCRIPTION
- Add a new metric to count ingested events.
- Initialize OTel the same way as in sink-worker
