### PR TITLE
feat: mk broker.address.family configurable

### DIFF
--- a/config/ingest.go
+++ b/config/ingest.go
@@ -30,6 +30,7 @@ type KafkaIngestConfiguration struct {
 	SaslPassword        string
 	Partitions          int
 	EventsTopicTemplate string
+	BrokerAddressFamily string
 }
 
 // CreateKafkaConfig creates a Kafka config map.
@@ -44,7 +45,9 @@ func (c KafkaIngestConfiguration) CreateKafkaConfig() kafka.ConfigMap {
 	// This is needed when using localhost brokers on OSX,
 	// since the OSX resolver will return the IPv6 addresses first.
 	// See: https://github.com/openmeterio/openmeter/issues/321
-	if strings.Contains(c.Broker, "localhost") || strings.Contains(c.Broker, "127.0.0.1") {
+	if c.BrokerAddressFamily != "" {
+		config["broker.address.family"] = c.BrokerAddressFamily
+	} else if strings.Contains(c.Broker, "localhost") || strings.Contains(c.Broker, "127.0.0.1") {
 		config["broker.address.family"] = "v4"
 	}
 


### PR DESCRIPTION
## Overview

Allow setting `broker.address.family` config parameter for Kafka client(s).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
