### PR TITLE
feat(otel): use conventional environment tag

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -107,7 +106,7 @@ func main() {
 		resource.WithAttributes(
 			semconv.ServiceName("openmeter"),
 			semconv.ServiceVersion(version),
-			attribute.String("environment", conf.Environment),
+			semconv.DeploymentEnvironment(conf.Environment),
 		),
 	)
 	res, _ := resource.Merge(

--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -92,7 +91,7 @@ func main() {
 		resource.WithAttributes(
 			semconv.ServiceName("openmeter-sink-worker"),
 			semconv.ServiceVersion(version),
-			attribute.String("environment", conf.Environment),
+			semconv.DeploymentEnvironment(conf.Environment),
 		),
 	)
 	res, _ := resource.Merge(


### PR DESCRIPTION
Replace `environment` tag with the conventional `deployment.environment`.

For example:
https://docs.datadoghq.com/opentelemetry/schema_semantics/semantic_mapping/#unified-service-tagging