### PR TITLE
feat(sink-worker): make some Kafka parameters configurable

### DIFF
--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -284,7 +284,8 @@ func initSink(config config.Configuration, logger *slog.Logger, metricMeter metr
 	consumerKafkaConfig := config.Ingest.Kafka.CreateKafkaConfig()
 	_ = consumerKafkaConfig.SetKey("client.id", config.Sink.ClientId)
 	_ = consumerKafkaConfig.SetKey("group.id", config.Sink.GroupId)
-	_ = consumerKafkaConfig.SetKey("session.timeout.ms", 6000)
+	// SessionTimeout defines time interval the broker waits for receiving heartbeat from the consumer before removing it from the consumer group.
+	_ = consumerKafkaConfig.SetKey("session.timeout.ms", int(config.Sink.SessionTimeout.Milliseconds()))
 	_ = consumerKafkaConfig.SetKey("enable.auto.commit", true)
 	_ = consumerKafkaConfig.SetKey("enable.auto.offset.store", false)
 	_ = consumerKafkaConfig.SetKey("go.application.rebalance.enable", true)

--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -165,8 +165,11 @@ func main() {
 	}
 
 	logger.Info("starting OpenMeter sink worker", "config", map[string]string{
-		"telemetry.address":   conf.Telemetry.Address,
-		"ingest.kafka.broker": conf.Ingest.Kafka.Broker,
+		"telemetry.address":                conf.Telemetry.Address,
+		"ingest.kafka.broker":              conf.Ingest.Kafka.Broker,
+		"ingest.kafka.brokerAddressFamily": conf.Ingest.Kafka.BrokerAddressFamily,
+		"sink.clientId":                    conf.Sink.ClientId,
+		"sink.groupId":                     conf.Sink.GroupId,
 	})
 
 	// Initialize meter repository
@@ -279,6 +282,7 @@ func initSink(config config.Configuration, logger *slog.Logger, metricMeter metr
 	)
 
 	consumerKafkaConfig := config.Ingest.Kafka.CreateKafkaConfig()
+	_ = consumerKafkaConfig.SetKey("client.id", config.Sink.ClientId)
 	_ = consumerKafkaConfig.SetKey("group.id", config.Sink.GroupId)
 	_ = consumerKafkaConfig.SetKey("session.timeout.ms", 6000)
 	_ = consumerKafkaConfig.SetKey("enable.auto.commit", true)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -95,6 +95,7 @@ func TestComplete(t *testing.T) {
 			},
 		},
 		Sink: SinkConfiguration{
+			ClientId:         "openmeter-sink-worker",
 			GroupId:          "openmeter-sink-worker",
 			MinCommitCount:   500,
 			MaxCommitWait:    30 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -83,6 +83,7 @@ func TestComplete(t *testing.T) {
 				SaslPassword:        "pass",
 				Partitions:          1,
 				EventsTopicTemplate: "om_%s_events",
+				MetadataMaxAge:      180 * time.Second,
 			},
 		},
 		Aggregation: AggregationConfiguration{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -97,6 +97,7 @@ func TestComplete(t *testing.T) {
 		Sink: SinkConfiguration{
 			ClientId:         "openmeter-sink-worker",
 			GroupId:          "openmeter-sink-worker",
+			SessionTimeout:   9 * time.Second,
 			MinCommitCount:   500,
 			MaxCommitWait:    30 * time.Second,
 			NamespaceRefetch: 15 * time.Second,

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -31,6 +31,9 @@ type KafkaIngestConfiguration struct {
 	Partitions          int
 	EventsTopicTemplate string
 	BrokerAddressFamily string
+	// SocketKeepAliveEnable defines if TCP socket keep-alive is enabled to prevent closing idle connections
+	// by Kafka brokers.
+	SocketKeepAliveEnable bool
 }
 
 // CreateKafkaConfig creates a Kafka config map.
@@ -67,6 +70,9 @@ func (c KafkaIngestConfiguration) CreateKafkaConfig() kafka.ConfigMap {
 		config["sasl.password"] = c.SaslPassword
 	}
 
+	if c.SocketKeepAliveEnable {
+		config["socket.keepalive.enable"] = c.SocketKeepAliveEnable
+	}
 	return config
 }
 
@@ -92,4 +98,5 @@ func ConfigureIngest(v *viper.Viper) {
 	v.SetDefault("ingest.kafka.saslPassword", "")
 	v.SetDefault("ingest.kafka.partitions", 1)
 	v.SetDefault("ingest.kafka.eventsTopicTemplate", "om_%s_events")
+	v.SetDefault("ingest.kafka.socketKeepAliveEnable", false)
 }

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/spf13/viper"
@@ -34,6 +35,10 @@ type KafkaIngestConfiguration struct {
 	// SocketKeepAliveEnable defines if TCP socket keep-alive is enabled to prevent closing idle connections
 	// by Kafka brokers.
 	SocketKeepAliveEnable bool
+	// MetadataMaxAge defines the time interval after the metadata cache (brokers, partitions) becomes invalid.
+	// Keeping this parameter low forces the client to refresh metadata more frequently which helps with
+	// detecting changes in the Kafka cluster (broker, partition, leader changes) faster.
+	MetadataMaxAge time.Duration
 }
 
 // CreateKafkaConfig creates a Kafka config map.
@@ -73,6 +78,11 @@ func (c KafkaIngestConfiguration) CreateKafkaConfig() kafka.ConfigMap {
 	if c.SocketKeepAliveEnable {
 		config["socket.keepalive.enable"] = c.SocketKeepAliveEnable
 	}
+
+	if c.MetadataMaxAge != 0 {
+		config["metadata.max.age.ms"] = c.MetadataMaxAge
+	}
+
 	return config
 }
 
@@ -99,4 +109,5 @@ func ConfigureIngest(v *viper.Viper) {
 	v.SetDefault("ingest.kafka.partitions", 1)
 	v.SetDefault("ingest.kafka.eventsTopicTemplate", "om_%s_events")
 	v.SetDefault("ingest.kafka.socketKeepAliveEnable", false)
+	v.SetDefault("ingest.kafka.metadataMaxAge", 180*time.Second)
 }

--- a/config/sink.go
+++ b/config/sink.go
@@ -8,6 +8,9 @@ import (
 )
 
 type SinkConfiguration struct {
+	// ClientId defines the client id for the Kafka Consumer
+	ClientId string
+	// GroupId defines the consumer group id for the Kafka Consumer
 	GroupId          string
 	Dedupe           DedupeConfiguration
 	MinCommitCount   int
@@ -53,6 +56,7 @@ func ConfigureSink(v *viper.Viper) {
 
 	// Sink
 	v.SetDefault("sink.groupId", "openmeter-sink-worker")
+	v.SetDefault("sink.clientId", "openmeter-sink-worker")
 	v.SetDefault("sink.minCommitCount", 500)
 	v.SetDefault("sink.maxCommitWait", "5s")
 	v.SetDefault("sink.namespaceRefetch", "15s")

--- a/config/sink.go
+++ b/config/sink.go
@@ -11,7 +11,10 @@ type SinkConfiguration struct {
 	// ClientId defines the client id for the Kafka Consumer
 	ClientId string
 	// GroupId defines the consumer group id for the Kafka Consumer
-	GroupId          string
+	GroupId string
+	// SessionTimeout defines time interval the broker waits for receiving heartbeat
+	// from the consumer before removing it from the consumer group.
+	SessionTimeout   time.Duration
 	Dedupe           DedupeConfiguration
 	MinCommitCount   int
 	MaxCommitWait    time.Duration
@@ -29,6 +32,10 @@ func (c SinkConfiguration) Validate() error {
 
 	if c.NamespaceRefetch < 1 {
 		return errors.New("NamespaceRefetch must be greater than 0")
+	}
+
+	if c.SessionTimeout.Milliseconds() < 3000 {
+		return errors.New("SessionTimeout must be greater than 3000ms")
 	}
 
 	return nil
@@ -60,4 +67,5 @@ func ConfigureSink(v *viper.Viper) {
 	v.SetDefault("sink.minCommitCount", 500)
 	v.SetDefault("sink.maxCommitWait", "5s")
 	v.SetDefault("sink.namespaceRefetch", "15s")
+	v.SetDefault("sink.sessionTimeout", 9*time.Second)
 }


### PR DESCRIPTION
## Overview

Make some Kafka client related parameters configurable:

* allow setting client ID for Kafka client which could help debugging
* allow using TCP keep-alive to avoid closing idle connections by the Kafka broker
* increase session timeout in order to avoid freqent partition rebalance due to missed heartbeats sent by the Kafka consumer
* allow changing the metadata cache invalidation timeout which could help with detecting changes in Kafka cluster faster in case lower value is used

## Notes for reviewer

This change is an attempt to allow tweaking Kafka client parameters to reduce the number of errors generated by the `sink-worker` during processing data from  Kafka cluster.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
