### PR TITLE
chore: add go config to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ indent_style = tab
 
 [*{.js,.jsx,.ts,.tsx,.json,.yaml,.yml,.html,.css,.md}]
 indent_size = 2
+
+[{*.go,go.mod,go.sum,go.work,go.work.sum}]
+indent_style = tab


### PR DESCRIPTION
## Overview

Add *golang* specific configuration to `.editorconfig`.
