### PR TITLE
feat: add Kafka client configs

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,6 +9,13 @@ telemetry:
 #    # To enable stats reporting set this value to >=5s.
 #    # Setting this value to 0 makes reporting explicitly disabled.
 #    statsInterval: 5s
+#    # Set IP address family used for communicating with Kafka cluster
+#    brokerAddressFamily: v4
+#    # Use this configuration parameter to define how frequently the local metadata cache needs to be updated.
+#    # It cannot be lower than 10 seconds.
+#    topicMetadataRefreshInterval: 1m
+#    # Use this config parameter to enable TCP keep-alive in order to prevent the Kafka broker to close idle network connection.
+#    socketKeepAliveEnabled: true
 
 # dedupe:
 #   enabled: true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 
+	pkgkafka "github.com/openmeterio/openmeter/pkg/kafka"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -83,6 +84,11 @@ func TestComplete(t *testing.T) {
 				SaslPassword:        "pass",
 				Partitions:          1,
 				EventsTopicTemplate: "om_%s_events",
+
+				BrokerAddressFamily:          pkgkafka.BrokerAddressFamilyAny,
+				TopicMetadataRefreshInterval: pkgkafka.TimeDurationMilliSeconds(time.Minute),
+				StatsInterval:                pkgkafka.TimeDurationMilliSeconds(5 * time.Second),
+				SocketKeepAliveEnabled:       true,
 			},
 		},
 		Aggregation: AggregationConfiguration{

--- a/config/ingest_test.go
+++ b/config/ingest_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/stretchr/testify/assert"
+
+	pkgkafka "github.com/openmeterio/openmeter/pkg/kafka"
+)
+
+func TestKafkaIngestConfiguration(t *testing.T) {
+
+	tests := []struct {
+		Name string
+
+		KafkaConfig            KafkaIngestConfiguration
+		ExpectedKafkaConfigMap kafka.ConfigMap
+	}{
+		{
+			Name: "All",
+			KafkaConfig: KafkaIngestConfiguration{
+				Broker:                       "127.0.0.1:29092",
+				SecurityProtocol:             "SASL_SSL",
+				SaslMechanisms:               "PLAIN",
+				SaslUsername:                 "user",
+				SaslPassword:                 "pass",
+				StatsInterval:                pkgkafka.TimeDurationMilliSeconds(10 * time.Second),
+				BrokerAddressFamily:          "v6",
+				SocketKeepAliveEnabled:       true,
+				TopicMetadataRefreshInterval: pkgkafka.TimeDurationMilliSeconds(time.Minute),
+			},
+			ExpectedKafkaConfigMap: kafka.ConfigMap{
+				"bootstrap.servers":                  "127.0.0.1:29092",
+				"broker.address.family":              pkgkafka.BrokerAddressFamilyIPv6,
+				"go.logs.channel.enable":             true,
+				"metadata.max.age.ms":                pkgkafka.TimeDurationMilliSeconds(3 * time.Minute),
+				"sasl.mechanism":                     "PLAIN",
+				"sasl.password":                      "pass",
+				"sasl.username":                      "user",
+				"security.protocol":                  "SASL_SSL",
+				"socket.keepalive.enable":            true,
+				"statistics.interval.ms":             pkgkafka.TimeDurationMilliSeconds(10 * time.Second),
+				"topic.metadata.refresh.interval.ms": pkgkafka.TimeDurationMilliSeconds(time.Minute),
+			},
+		},
+		{
+			Name: "Basic",
+			KafkaConfig: KafkaIngestConfiguration{
+				Broker: "127.0.0.1:29092",
+			},
+			ExpectedKafkaConfigMap: kafka.ConfigMap{
+				"bootstrap.servers":      "127.0.0.1:29092",
+				"broker.address.family":  pkgkafka.BrokerAddressFamilyIPv4,
+				"go.logs.channel.enable": true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			config := test.KafkaConfig.CreateKafkaConfig()
+			assert.Equal(t, test.ExpectedKafkaConfigMap, config)
+		})
+	}
+}

--- a/config/testdata/complete.yaml
+++ b/config/testdata/complete.yaml
@@ -35,6 +35,10 @@ ingest:
     saslUsername: user
     saslPassword: pass
     partitions: 1
+    statsInterval: 5s
+    brokerAddressFamily: any
+    socketKeepAliveEnabled: true
+    topicMetadataRefreshInterval: 1m
 
 aggregation:
   clickhouse:

--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -1,0 +1,76 @@
+package kafka
+
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type configValue interface {
+	fmt.Stringer
+	encoding.TextUnmarshaler
+	json.Unmarshaler
+}
+
+const (
+	BrokerAddressFamilyAny  BrokerAddressFamily = "any"
+	BrokerAddressFamilyIPv4 BrokerAddressFamily = "v4"
+	BrokerAddressFamilyIPv6 BrokerAddressFamily = "v6"
+)
+
+var _ configValue = (*BrokerAddressFamily)(nil)
+
+type BrokerAddressFamily string
+
+func (s *BrokerAddressFamily) UnmarshalText(text []byte) error {
+	switch strings.ToLower(strings.TrimSpace(string(text))) {
+	case "v4":
+		*s = BrokerAddressFamilyIPv4
+	case "v6":
+		*s = BrokerAddressFamilyIPv6
+	case "any":
+		*s = BrokerAddressFamilyAny
+	default:
+		return fmt.Errorf("invalid value broker family address: %s", text)
+	}
+
+	return nil
+}
+
+func (s *BrokerAddressFamily) UnmarshalJSON(data []byte) error {
+	return s.UnmarshalText(data)
+}
+
+func (s BrokerAddressFamily) String() string {
+	return string(s)
+}
+
+var _ configValue = (*TimeDurationMilliSeconds)(nil)
+
+type TimeDurationMilliSeconds time.Duration
+
+func (d *TimeDurationMilliSeconds) UnmarshalText(text []byte) error {
+	v, err := time.ParseDuration(strings.TrimSpace(string(text)))
+	if err != nil {
+		return fmt.Errorf("failed to parse time duration: %w", err)
+	}
+
+	*d = TimeDurationMilliSeconds(v)
+
+	return nil
+}
+
+func (d *TimeDurationMilliSeconds) UnmarshalJSON(data []byte) error {
+	return d.UnmarshalText(data)
+}
+
+func (d TimeDurationMilliSeconds) Duration() time.Duration {
+	return time.Duration(d)
+}
+
+func (d TimeDurationMilliSeconds) String() string {
+	return strconv.Itoa(int(time.Duration(d).Milliseconds()))
+}

--- a/pkg/kafka/config_test.go
+++ b/pkg/kafka/config_test.go
@@ -1,0 +1,117 @@
+package kafka
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBrokerAddressFamily(t *testing.T) {
+
+	tests := []struct {
+		Name string
+
+		Value          string
+		ExpectedError  error
+		ExplectedValue BrokerAddressFamily
+	}{
+		{
+			Name:           "Any",
+			Value:          "any",
+			ExpectedError:  nil,
+			ExplectedValue: BrokerAddressFamilyAny,
+		},
+		{
+			Name:           "IPv4",
+			Value:          "v4",
+			ExpectedError:  nil,
+			ExplectedValue: BrokerAddressFamilyIPv4,
+		},
+		{
+			Name:           "IPv6",
+			Value:          "v6",
+			ExpectedError:  nil,
+			ExplectedValue: BrokerAddressFamilyIPv6,
+		},
+		{
+			Name:          "Invalid",
+			Value:         "invalid",
+			ExpectedError: errors.New("invalid value broker family address: invalid"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var family BrokerAddressFamily
+
+			err := family.UnmarshalText([]byte(test.Value))
+			assert.Equal(t, test.ExpectedError, err)
+			if err == nil {
+				assert.Equal(t, test.ExplectedValue, family)
+			}
+
+			err = family.UnmarshalJSON([]byte(test.Value))
+			assert.Equal(t, test.ExpectedError, err)
+			if err == nil {
+				assert.Equal(t, test.ExplectedValue, family)
+			}
+		})
+	}
+}
+
+func TestTimeDurationMilliSeconds(t *testing.T) {
+
+	tests := []struct {
+		Name string
+
+		Value            string
+		ExpectedError    error
+		ExplectedValue   TimeDurationMilliSeconds
+		ExpectedString   string
+		ExpectedDuration time.Duration
+	}{
+		{
+			Name:             "Duration",
+			Value:            "6s",
+			ExpectedError:    nil,
+			ExplectedValue:   TimeDurationMilliSeconds(6 * time.Second),
+			ExpectedString:   "6000",
+			ExpectedDuration: 6 * time.Second,
+		},
+		{
+			Name:          "Invalid",
+			Value:         "10000",
+			ExpectedError: fmt.Errorf("failed to parse time duration: %w", errors.New("time: missing unit in duration \"10000\"")),
+		},
+		{
+			Name:          "Invalid",
+			Value:         "invalid",
+			ExpectedError: fmt.Errorf("failed to parse time duration: %w", errors.New("time: invalid duration \"invalid\"")),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var timeMs TimeDurationMilliSeconds
+
+			err := timeMs.UnmarshalText([]byte(test.Value))
+			assert.Equal(t, test.ExpectedError, err)
+			if err == nil {
+				assert.Equal(t, test.ExplectedValue, timeMs)
+				assert.Equal(t, test.ExpectedString, timeMs.String())
+				assert.Equal(t, test.ExpectedDuration, timeMs.Duration())
+			}
+
+			err = timeMs.UnmarshalJSON([]byte(test.Value))
+			assert.Equal(t, test.ExpectedError, err)
+			if err == nil {
+				assert.Equal(t, test.ExplectedValue, timeMs)
+				assert.Equal(t, test.ExpectedString, timeMs.String())
+				assert.Equal(t, test.ExpectedDuration, timeMs.Duration())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Introduce a set of configuration parameters to allow finetuning Kafka client.

### IP address family

The `ingest.kafka.brokerAddressFamily` config parameter defines which IP address family should be used for network communication with Kafka brokers.

### Metadata

The `ingest.kafka.topicMetadataRefreshInterval` config parameter defines how frequesntly the Kafka client needs to fetch metadata from Kafka cluster.

### Keep-Alive

The `ingest.kafka.socketKeepAliveEnalbed` config parameter controlls whether TCP socket keep-alive is used or not for connections to Kafka brokers.

## Notes for reviewer
I have introduced custom types (`BrokerAddressFamily` and `TimeDurationMilliseconds`) for Kafka configuration parameters in order to:
* improve configuration validation by catching invalid configuration early on
* avoid runtime configuration errors (which may or may not be surfaced from `librdkafka`) related to type casting as config values are passed to `librdkafka` as C strings
