### PR TITLE
refactor(sink-worker): add improvements

### DIFF
--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -199,10 +199,12 @@ func main() {
 	group.Add(run.SignalHandler(ctx, syscall.SIGINT, syscall.SIGTERM))
 
 	err = group.Run()
+
 	if e := (run.SignalError{}); errors.As(err, &e) {
-		slog.Info("received signal; shutting down", slog.String("signal", e.Signal.String()))
+		logger.Info("received signal: shutting down", slog.String("signal", e.Signal.String()))
 	} else if !errors.Is(err, http.ErrServerClosed) {
 		logger.Error("application stopped due to error", slog.String("error", err.Error()))
+		os.Exit(1)
 	}
 }
 

--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -709,6 +709,13 @@ func (s *Sink) Close() error {
 		s.flushTimer.Stop()
 	}
 
+	if s.config.Consumer != nil {
+		logger.Info("closing Kafka consumer")
+		if err := s.config.Consumer.Close(); err != nil {
+			logger.Error("failed to close consumer client", slog.String("err", err.Error()))
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Overview

Refactor `sink-worker` adding tiny improvements/fixes:
* proper `context.Context` propagation
* properly close Kafka consumer on exit
* set exit code on error
* remove unnecessary signal handling in `sink.Sink`
