### PR TITLE
feat: entitlement auto reset support pt1

### DIFF
--- a/api/api.gen.go
+++ b/api/api.gen.go
@@ -157,6 +157,9 @@ type EntitlementBoolean struct {
 	// CreatedAt The date and time the resource was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 
+	// CurrentUsagePeriod A time period
+	CurrentUsagePeriod *Period `json:"currentUsagePeriod,omitempty"`
+
 	// DeletedAt The date and time the resource was deleted.
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 
@@ -307,6 +310,9 @@ type EntitlementMetered struct {
 	// CreatedAt The date and time the resource was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 
+	// CurrentUsagePeriod A time period
+	CurrentUsagePeriod Period `json:"currentUsagePeriod"`
+
 	// DeletedAt The date and time the resource was deleted.
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 
@@ -325,6 +331,9 @@ type EntitlementMetered struct {
 	// IssueAfterReset You can issue usage automatically after reset. This usage is not rolled over.
 	IssueAfterReset *float64 `json:"issueAfterReset,omitempty"`
 
+	// LastReset The last time the meter was reset.
+	LastReset time.Time `json:"lastReset"`
+
 	// Metadata Additional metadata for the feature.
 	Metadata *map[string]string `json:"metadata,omitempty"`
 
@@ -341,6 +350,15 @@ type EntitlementMetered struct {
 
 // EntitlementMeteredType defines model for EntitlementMetered.Type.
 type EntitlementMeteredType string
+
+// EntitlementMeteredCalculatedFields Calculated fields for a metered entitlement.
+type EntitlementMeteredCalculatedFields struct {
+	// CurrentUsagePeriod A time period
+	CurrentUsagePeriod Period `json:"currentUsagePeriod"`
+
+	// LastReset The last time the meter was reset.
+	LastReset time.Time `json:"lastReset"`
+}
 
 // EntitlementMeteredCreateInputs defines model for EntitlementMeteredCreateInputs.
 type EntitlementMeteredCreateInputs struct {
@@ -372,6 +390,9 @@ type EntitlementSharedFields struct {
 	// CreatedAt The date and time the resource was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 
+	// CurrentUsagePeriod A time period
+	CurrentUsagePeriod *Period `json:"currentUsagePeriod,omitempty"`
+
 	// DeletedAt The date and time the resource was deleted.
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 
@@ -401,6 +422,9 @@ type EntitlementStatic struct {
 
 	// CreatedAt The date and time the resource was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
+
+	// CurrentUsagePeriod A time period
+	CurrentUsagePeriod *Period `json:"currentUsagePeriod,omitempty"`
 
 	// DeletedAt The date and time the resource was deleted.
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
@@ -966,6 +990,11 @@ type ResetEntitlementUsageJSONBody struct {
 	// The reset cannot be in the future.
 	// The provided value is truncated to the granularity of the underlying meter.
 	EffectiveAt *time.Time `json:"effectiveAt,omitempty"`
+
+	// RetainAnchor Should the reset retain the usage period anchor.
+	// If true, the usage period anchor is retained.
+	// If false, the usage period anchor is reset to the effectiveAt time.
+	RetainAnchor *bool `json:"retainAnchor,omitempty"`
 }
 
 // IngestEventsApplicationCloudeventsPlusJSONRequestBody defines body for IngestEvents for application/cloudevents+json ContentType.
@@ -3117,172 +3146,174 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+y9+3IbN7I4/Cqo+bZq7V2SoijJsVSV2mJ0cRRfo4vtxPLnBWdAEtEQGAMYUbRKf5y3",
-	"OM93nuRXuM1gZjDkkKJsJXEqtRtxcGk0Go3uRl9ugpBOEkoQETzYuwkSyOAECcTUX4gILGI0QUQcR/KH",
-	"CPGQ4URgSoK9oA9Sgj+nCJy/OD4AQ8oAJMDp0wlaAZYNEyjGQSsgcIKCvdKorYChzylmKAr2BEtRK+Dh",
-	"GE2gmv8aTpJY9ulu9k9+33p1cPj87PTt9snJ0dGvT3af7Rz13watQMwS2YYLhskouL1tFad4zY4QFClD",
-	"z9GsuoizMQI4AnQIxBi50APK1E+XaGa/DvU4TdZVmPSua5SgjBKx/UnQS0S4d8kGtsX7hCMJ6BAjprds",
-	"waryce9lp0YMLiCuCryqSw20drh7gRWTME4jdIBiJJAH5GP9HUS6gSQmhhHPQP2cIjbLYS0N54IYoSFM",
-	"YxHsDWHMUSsHWa/FgDagNEaQKNjUoZVkdxqno+bYlFStutbgszjsPKz+g6FhsBf8fxs5Q9nQX/lGNoCE",
-	"VGHhCMcCsWeMpslP6lD6EDQsNHIng1GE5cpg/IbRBDGBkWJYpT1rlbBwiiUWgR5XrX8kBweDGQdTLMYA",
-	"XcNQgAkU4bhzQS7IOYcjtAf++58CKB/kNB9/xCRJxUXa7faeFD9PaITijz+OEtHe/u8FCZz9uwnUR0mp",
-	"8mtOZmowCbH5mw7+QKH6gYuZItYIoeR19quDxdNU/1rZdP0ZkxEYzMAkjQWWq+e6OXcX+B/z449hygWd",
-	"INbe1Aur/N5T6/Htlmla2Ccs0MS/MeYHyBicOWTB6KS6jlMBmQARFKgt8AQBTMDJ0T7Y2tralZs4gaJz",
-	"QdTh4/gKdWohHMrR/Zyg1+1ttbub7e7mWbe7p/79PWgFenSJfDu5lzGoeRxiLrGFISBUAJ6gUB68CEDA",
-	"MRnFCMDRiKERFAhMcRyDAQIMiZQRFCniRDAc2+0CkERArX6KSUSnnQvyX/PpvwBzAAFDHLErFGU0Da5g",
-	"nM5Bx8hzsDKMfDCEapb7sbX0Xr7AE+whylfpZICYvFENewSCmmXXwBmrgbzscbPb7Tqna1P+NYHXeJJO",
-	"7McJJuZP56wJNEIsB/X1cMhRU1j5JU5qIKV6HC+oLpwuWN16sM5oFaRDEq3hJAi66Bz0Vj4H7xR9nuIv",
-	"aPFRaOVnIZWcaNGJsCIaQyITyvJzlSCGac3RUcRej5BpDnTTS81ZZ2ntZ3iCfqcE+YVNdSrlkZXAy+nt",
-	"QtSOfqEEAchBhIZYrhoT9e24/6oP5LhADgwOoIADyBF4NBYi2dvYmE6nHQwJ7FA22pADteVA/LEkhwrO",
-	"5YDnZ/tqQjWfxXXKUbQIR9nivFQenJ/tu/dd0J8ghkO48QpNP/1G2aWXbsxGSTHBK6PXy4KmZ430Uhq3",
-	"mVCYXXU48gB7KwfhCSVcSxw/wegEfU4RF28YHcRocmK+yo8hJQIRxVhgksQ4hHJBG4lu+e8/uFzdjSsd",
-	"REhALMWDMYIRYmBfj9A+myUIjCEHKUHXCQqleKkJ6aIw9PUkvgjk1ggoUh7sbUsWqNSSYE/CCgyw+cpS",
-	"RvYMQG35094ARm1mWt02PQxm8RpBxc1zZ71tBfuUDGMcrgddoRkMk9EhEUxLkpGS7H9+//Zl97S7//L3",
-	"X05/7W092335/P3Jr29+CJSsDCMo1KLkxiboDZxZJTdI8Kft16x/OX5xNcNjTHeTnc3xLsZH5Kcgp9Wc",
-	"utqbWtA0GxejaIQYQNeYC17Yid18J0wjGDMEo1neuG5PTIPG21FCsm9bXmgQDrORX1FxRFMSrZeOlQKh",
-	"GNBQDl5AyHaOkFdUgCPToA4JhIq2HmQdZJnPqNd+LEGXRIDWjAGjQCsc4HwSBxM73c0iJo4Lzebhwx1w",
-	"XVg5Lo55TmAqxpThL+vGzARzefkDygAmVzDGEVAGjgKROKhxIZmDl9Rttg6knJcGPM948Hrx4fB2xBhl",
-	"BRLpunjI2h2advW4sE3XhIkShLfZqOY2jCEJ0c+YC2qlId91rkUJKfgMdA8w1l209JEUlHrTpC+UHugX",
-	"qly7nR0SCi0fKu3RyFhaROwUlXKlNuQiLk0HMVLCAoxek3hWsroQpRRIdOrBFqJTt7ptBUrE9cMvqICx",
-	"kYGLxkYrAa4Rcp+VoXxj1BpZ9IjFFdjORUtH8XLGYnac3cyvDn452dnqHT59dvbT29P93vvnOwfbQfUW",
-	"fWQEy059r8fuLSq4UIKhlfzzK1rKh1xIujDHxIg4ezENYbzxy8vXcSj487dP2135z2bdze0s1aq9A5qK",
-	"vUEMyaUiigLt2gVVj8A4nUDSlpDDQYwAuk5iSBSvsKJ6KLVNMcYc0DBMGUOSqC0d623qFGTtAY1mYJJy",
-	"IWV5CH45ff0KUGuUqWjt6FogwjElvH6zjfmxuCbvvs43qztd9FGdFSFf0hCbi/EfvNB89BB4vv3VvTg/",
-	"OQYMDZFGsRhDkWsa3FUyw6Zb0YzCspObMuzbIkuBPuT+fHb2BugGIKQRAiNEEIOSNQ9mCjDK8AgToKxC",
-	"1trbmJi2C5wFE7HVCxzbys7urmPD0FpGyYqRnZkqviHgY8pEq3wIeDqZQDYrwQXkyEX0ejWZskGqgjWp",
-	"Q8nrGWLCAVS77tvr+mnn6kqLtrNEt+qrxVG21RkL9JHwYX7JqdVhuboJJlBQpkzLMEnkVPLONE8DNXeS",
-	"M9JPpqV5QpDALezz0rTUYOOwQZdT3TBnkLNXxhQlV3nbCihBr4fB3of5l6kHiNtW4y4ZEI17WOzcfizi",
-	"3/4uOWccLwe46bvPEBTomCSp0r+aL2IMGYqOMIojHtx+bFUMhKolz40j8hpJOXJe+pQQMY+8fCCuslQ9",
-	"QBHi1s2qECeet56bABHJgj5kJP+xeCVa6m5wGqtnrrTrZXys9QQWBl/hNJb6L3kyS9S47lO6MrH7gLvb",
-	"SfPuaYFE925KpDbnbf3MkdSVoGAoGHOrk0SGmkui+1IyT9FmteLrZz/rBuxomVF9PmdQesmbRtrOCZLS",
-	"BSYj3dxBfeXM5VhdcNk9Y9Ao1MvyH9WzAMMC4tF08BIJ6LCrIjEscIqRBGGs1a5SqlwvlLQh0a3cFNSz",
-	"Hec0xEpqm2IxXopGarQ8V8JPMEO8X6czy89a44igyKRB7V5RAmSZ99GFcBF0LTSdIK9ALoGTbfSLSI4v",
-	"9UzBVMe7wFeBhxVgWYK6ZecriiMU1eFYITZ7unWWAjnQPcGjEBJChX1/AXAoEFOk8rizIopLB61IsQtv",
-	"ucqhqaxMteAAMgOyoACTkCHIUWZ9ocNcaXJcDirXOJzQlNRgT3+Tw2uiBKdjmsaRVm8TyrHAVwhos0Yz",
-	"y0jFhoOGQxTKYWpPiW2gtrAD3jB6pfZNP7/Yp7MQYcPq1cUtFd38TRE8mmCSCvR4rWSbn98leGPWx1Kw",
-	"3PwJvD6hcUyvEOs725G/XFfRYjRBu0Uu79BsLoREPd/SWOJFDt0BB3pI9YzeVf4nbTmQnhP8CG60ygrj",
-	"T3rYW9C+SLvdLT2MHAPYFmbi8gjdrAehWadyo91uddzdrmwiQToeAiz+yUEM2UgfRAK6cnUkX+I/eUbn",
-	"lgDkt5f9948cXLZso8fg3wbeFal0pdvfMcUt/cpVuY4ThinDYlZ0v/BRhm1ZvE+A4RnKzWqMR2PE8paS",
-	"kShjOYrAEDMu0fTGflTOLdlhj1CIJzA2h553wDs5YEyniNnfACaRMruTkZ0JTxLKlPmnc0GOKAMGNy05",
-	"tAPvppxtQiVfYyOkSZmU2vQ6F+SdoQYJN0OAoyvEYKyXygG8gjhWBg0rXnE4yURD/f7OZ1ygCeAoloyx",
-	"cMmJsfpTgc5FNrfy7AAh5IiDqZraTMelzJJPk8EaoysUt5yhw5hyOaJk14K797/rAJDtwLEmeDmj2ssp",
-	"tTOO4ZV9iw9hbGfEUoUjUVmu4IUFq5mkbldiF/JCDNWdkwNQOCmO8am3szPfr+cOV/o8gdVcVcVLo8CH",
-	"Fwiy1mSxiih7V0XqK1gNfCDem9XATFYQsvWxgGGIOJcnOZJtJsqPZgAlaVOSKWtKp/EJJJif0qFwvNeK",
-	"rrgVhyZuW/8oZbGCEijvQEvrdl50hQjAVW9zqTBej2HKhfXBKXv5tgLMz4nyhrPexwtAS23rZqDJn2yP",
-	"wn3lg4SnqC8l1RPkdZ37jaZqDtXQOnelgk6g4hnxzMi5THbvgLMx5qYV5uqp3BUcFBANrsmyScjaUAom",
-	"oUlmvKzcmPej5xpLrzv4Qhm8bI9odoa82uvdDl3xbBjqmRNIkflnXaKZ1YPVM1ZGegUBOPc3Xu9+VDbB",
-	"gXwx8o3pbAXWdTd71ddg0h4I741H67kKbG5EjYcmQ4k8+0SJaZYDhZQM8SjVt6mPOesGfuJT750JZFyJ",
-	"XrqlJ66nrIPdXASXaLZ5EeyBi0ApdZsXwe28ZyXLXoyJtcBdzG8NX3/MchZS5FsJVtUuadQLPzocRRyC",
-	"SfW27KzDBaLRfiBnQ8zeGu1ZwcYrVNJptkELDU1jyPtKGKgC+G6MpPxeuBPHkFvhwbAsJzSqFIJTM7dz",
-	"Rcqbq9bfw3xstjmrbU2dt0lTTxNgwpm4BZYXgNpZ0fPEPQX5/ngF5yvrRzXPN6HkiRLTNFIdOTg15idN",
-	"cIoaT7UDVEE3tnp1ITCnLVI2oPIY64i7vWCzt+UL11HepjvhZncII9TeDHdRezt6Eraf9n7YaYc7vXDr",
-	"yQ9bm9GWZAmcpkz5n3DErnCI2spNuRXwBIVXiHG9hM1ON3DdTEv+yHhSNhxt7ql/O93u5u85hAmjk0R4",
-	"PFLmmhF83j3KCiZRChI4iymMOnMimmoQ5zMpSEiMt5z/wd44P6uHeEur6tVCB7aAlykXAEZK6BdURUL0",
-	"uttPbCSEhNJwatcTT3ngFXh25avSLl8gMhJjpV+SNFb6fC2jkVC53vAFObzkSaKaaaVXLUYvQLKcTtWH",
-	"YEk4cLRwfrWTRQbbkHyLsFSdVQx1L5hf7fi1kMxmOsbhWMUMK+oawyRBBBXJq3xWXPy0M5+dBtC5Z8wb",
-	"lqE/WjpzGQkvMBINdYZKKX8VOaM5wYsAqovaO1B/DSy5mLvJyjFqSsOoLSoL3xJGozREDDzKhHHlEaS3",
-	"53HHL34r3rIAYs16KrjDE8QFnCQSjKm1kjpORtm2+s7r1tbWbqfWJF7ibF6z+JInxM9piji3/EYjlKFY",
-	"WaWMSGAM0EpszVdZXIPhvYuEQIV0c2yKFNqyAqKlksr92Aqu2yPaNj/qQ60vTOdLW9s9dWC/xFAwwmKc",
-	"DjohnWyEksJVR77Bo8v2iG5c9TbUDwrSylNBNRYtN/SZ0CslzjgPiGXhvfalB1WGUo1BjC8R2OyBCSVi",
-	"zMs2wZ7P9Bel+aNIk4lsez2XmsjMYy6Pn1+fnwSt4KD/W9AK3h0ePg9awcvXr85+DlrBb4f9E2dzajY6",
-	"A6llcOATd0y+gKI2VnorY+EYX/lfG49LshwHtnULYPN26j4z6uhnZc6lzLWG3cujr+f+n69qGmwspUlX",
-	"zR8VFbpfQFD2B2XA3DOADodKGBcUQGD5Y/HVYA/svzlv/0xTxlvgTMk5LdB/cwz2YRzzFkAirNHDfavy",
-	"+Ed+TRiLFHZZZ9kxppxqMgwdvmt9Z7EAQ0YnYEZTBhy5qkxac7NZfGNvF6WOmWhuHULP7wDH6ySHAuUJ",
-	"B0wSAt4B5xwN09iahHUrHtJEbf+AURUHqN6hplJmzNDOYHhZ5ojl9AK3dcvzZ4k4ywDIPFVcUiz6qqi3",
-	"ngjpZ39ueclglvGS4yEwJh79AuTVOc0zsVGBy2SiKeSTio7w0YmO8/T6jziBtYXtdkJTj83BWHhRX6Is",
-	"DNbHudXT5k8pIwd0SkzsyykaZX66pdPN9afim/kgZQREdEqcSJgL0gcjfIVI1iUzmvEiRqH1KCIA5m4X",
-	"bshITUjNIYmWDqhBJLqXcJoHG+ejcGtCm3iGszp+0OCdot5YN2AIXioykPInlOqRdj7R+1u/1D39wH58",
-	"sAcMpGXOMMeXTGLmthYROaGXEJHt098VFSp7ite4KFVEwxGn+k1SpOrVS55zoQ96wdymuOlgpnm8+/aW",
-	"pd2YJ/k8y6A5QSFlUVC/BJOlY4598vUVYvppUL/Lk38KEMrWWpHUyyodrd7Ot46gK9wuGTf8CpFzFdxX",
-	"zPS1Oa6KQVJex8vlvISXws9Kvkg+DCyVdqoz74LP3ctLcacvjg/Ao3OCpYKsztG5HvcFusYhHTGYjM2z",
-	"8illQr03ZHYn9riE0WdPdn7/YWenf/Su//znw83eq9+6+7/uHkl9LoFCICan/P8/dNu7/Z/2Dw6Pnv38",
-	"y/OXr978enJ69vbd+99+/3jTe3L7Dw/+b+pXNoHX1kzxZKtstXBnhe0v3fbux38/+s/ep+yPx//yTPfR",
-	"QwDHZIS4QNEqtvO+ZEm6uzF9KDGPWgFWRWhrVVkF/5bMwMhOuYxBfQkLevTtLOj5ynW8dSWtgc45o00n",
-	"ZVkrw8vcl1XbtzKVS1M2Sh4ZQ8+SbsCql0+AVb40vtOrl6nU0OLznTZfqxw1HIzpVDm+QhFqrSDP4qPt",
-	"SyVKsZ/NI/H5y6BCisc6E4DmWrK3HOessC+tLIGVQ2v/6BTSVskfbOgKVxyqfC7VU4I5GjPd3uoETk6g",
-	"veDl8avzs8Pq7hbWMn+PFZb7Tvuy+FPFv/O3Zd1Ztr6qIgPODbYWWkEddN7UvvYoM6ig+W42M3IW9qVO",
-	"MsyHqexYnSL9Ck5QpJ7x3kCVqk+qQip+WQKJrqVCbKMr3ARoXFskcgu55E8d8BzNeBYsbW4pSbshJRxz",
-	"ASiJZwDGyRiSVOUwUl9TEiHGQyo11zGUM0od3q+Cz6HFanRytGLOxob32sKncj73/q5E6taCpI38d0Xi",
-	"V7g9K0e/vHYPpZUJTTsxZORVvD3/yfX7no2k61yQM7eR6UwZOD1/2QL9t89a4OXxq5ZC0cv+e+CwFq55",
-	"MDH56FTmK7WOgq+98rUwVsEsKOKIMnD+6vjX88NP+6/PX525w7aKYGuI8gQCeooOkENU+uYIsCiUMOIR",
-	"oR47jsNVK9swLeSLWyLjWsG9S6cndbmxy+UKsyx4S1GHlnf0ndj0MYUmiOjAD5r/90ZyOdrQwymAKxeA",
-	"P+jFxbFhwVIdqx598z6hL1C1QUErcPc6aAX9t8+Clry95P/23xcfvnXP4o7UI6NfQO668fJritjsBHHl",
-	"0OrDC1PfHI8ZoPLTdXzeHB9ufMJBSRAtS3l1AuOVdr7a7FkqUgagulSJhtC0acT/hCIld5WLtPaJRdCF",
-	"E8wXS6wMnufzfPAYaWTocEiFTqu5Ry1eb9YVYyXo2vJjronTqZ2tFeIz1Hiuckan1iTS7Cw9ZIJpVWws",
-	"C2XOeQFSDddXI1g7yZrrvDrOqr4cGvHal2mOV8ZCYf7KOof6HsZzW5uD+HVTtLUDryufskvvenXFqdzF",
-	"LHGbZ4djrbdXnXdEX8f8auuj5w1m6M11rUczZm2d71n7y+ThsFPIbbRcBxwP7TPrIEZrDS8VtBY6lOWi",
-	"/iawlfMI6LTegnrZ4hvKBIyVfuzbI6mpSNUEqADBWJsdyvaKOKZT5VigH0658uB2NZSPrcAEr/VF/dp0",
-	"PH7kZPXP4vPrjqFJZjpHs6s1c+kVB3TySS/t03GfHGy9Sd696/V779jTye4fwy/o5/jZ+6fXk/3302ed",
-	"2c7n7dN2/93no/TJ5z+G8OhL98uvn7cPv/SennAyezv9ZTh8v/P5+uUV9RhCqki6qXkKbwE8zBIcKxWx",
-	"mMdZFyDJghLNyO6eVNFfn518gsmx/rhZEhdagdZuzWfJXm8LG3lzXxkQMkq4aeBIXkjjsBrjXggQjsqV",
-	"Me5kTMhvwYZ5lTN69SdHvEREapeKVrKE4FLxlXuFafHA3hfJL2tvrfXdk1xplTSLfWC6gQOVJIyb7H7g",
-	"0cnRPvjhafeHx50L4ji+5Ce0lFOwmOQMTOBM2Q+0b0FZo7I5GeemF1xfwuk/TQLF7xkFv2cU/DNnFPQK",
-	"yqeql2VPaxWUyyGaFXRmDVx3YlKN3SsJHiQcU9/rFQGQDbBgcv91I8kPVNkErQOXZyPlQON54rGkSnYF",
-	"4yUDUw9JOqk6gtuxWnY1vjtjTsjxg0SlKTyR2IQ5KoVK5KSAIXQKBEtJ6PrXj2nKvvk+NEC/GqCCqRfq",
-	"1UM5PrathKtxwgum+swFO0edLrik4oOiNMZkpDwAD/q/7QH1z+EVYjMQwdkFeXd4+HzP+XGK0OUFUT7p",
-	"e/mvypX9gvx22D9xG88QZAX/9mUc21tBxcl6z5OZwbjbqgamUgdD+vFeP4NwZL+q3C+FxAAJTdLYvXZM",
-	"6hC3AIySaaZSciE1aRwKYnyTxFwWQDcVSef+kqCZInErwmd63yN82MugYaRkcH89wfVmr0uT6A4bGEMu",
-	"gBmic49RDZV4npzu3CW4++1jLk4Nt2U8dtx0k7C2SE7K9aOhJ/P2TaBFN2GZWm6W7ZUxVGg51zrbCiLM",
-	"kxja7KH7RvUDr7S7zmKrhopDKIenOUEB43TAE6pTWW32trZ3nmjpluEE2dnUxzDln3JBuapfVJdf1bF7",
-	"jWhloZ3Wh79VLQyLI1LdDXBnKe9Fw5jSdZkGTIBJY7PA4kgQPZFD0X7aWGy6rxBPCUyXjhbizRNB4Dv3",
-	"84qlOe+ttmAGx1+Q+/Rrnv9aboxa4YU3a9DgkfedWwNtjXK/HhdFxeIgfq4+NW0b1QVJmWxM5g5YE13h",
-	"8w1u7mldE+vheY6061l10a9zixcHjE61NKU78Nz8zvSl50TxNVqMt1yLr6BjiW7laZFyKxYzlVFB74cK",
-	"md6n9BKjfiop5caXnEEFoU3RAMAkAaFqbYu3ZX+Z8m2fPnHtd+MU20jwc6QwqwZzjPt2ygGCDLEjyzRp",
-	"Aj+r9yMfKF7jvy1spwxCarB8+rEQSTb5ytNKDDSeavES/5iKwFORpboySfTylLaNnJRHGy+A4taUC2EE",
-	"xgc09Mj8BzRM5Rmw3iEpi01vvreRs4YOphuRHEApbkPqeyNA5KXjdaoQRqAK/NAu7Fl+VeMDbPyq8o4S",
-	"verNgIMZTXVy2hHiwjijtvRbt3l+VWNqnyutS2RiJO9ckHa7fUH+9TpBzLhhZdkZ/+9//wc8UtA9llqu",
-	"5tJSl9Eub1kGSEwcyNT2d/6lDmiMQ2RKRhly7ycwHCPQU97LOQJNdUeovqr6jqYr33hxvH/46vSw3et0",
-	"O2MxiR0TWVDAR9AKCu7Rna6KAEkQgQkO9oKtTrezpd3fx2p3N2CCN642NxyDgX5m9+V6U0qv21JeUdQi",
-	"Td3DssmhO1arUGq+Ju9U3mTDKSlbFwZcbm2qulbTUr1mEWI6BhPFUV0tV9moVB03L3PpSvn2MvZL/p7g",
-	"8I+lGpK9bndO5TBbMcxTVblhri4PS6+WAzSGi+I23raC7e5m3VTZIjbm1YhTUxm8LR6nrrKaLhOqjLk+",
-	"ipMcC+qHWZfMwKPDa3nFK9YUPw4+ymEy2r5aTNVFl059/lWQpdI6GST2vvWQ+9XqhK7qYDel8zPqoXGn",
-	"dLGG/G5VlucVWV5QY/mu1O66sK0UY/InTNqkQomWXKvUdJxw9lS4i93d7EWb0dMf2t1dGLW3B2HYhjs/",
-	"RO2dwdbOTm97dwtFvftebK9usU2d/4rBTcswNX0EpOgcoUE6GmEyMsytu5gp1Zf4fdDsscS6XA6pf/h4",
-	"2woSyn25RFRXnqdmogwMVHSPi0wpYmkX9DnpknzcUQ+f8Ufz3PUTjWZzGIOTrubfVSbRILbqtlU3Xlut",
-	"7d/zWc9fPU3cX5/PNGUzjdlLHirlOR+Z2mH0E0PloORj4B4cx99AxXhIhYJB9Xhd04ybwetGmRQzbpVP",
-	"am2GRH1qi9XSbyv3+HaVc5ymKp/jMI3jWcaB/sqs9thVLX081hE4TR6SBSKnbVUnVx7ZUf7kKpQ6xFZ3",
-	"mvN04suuVb2wVKrSLOVVjsQa0LDu0Dft/SCaN5eyR97X0d9sOrAlxJx80Q9aMBnmBNxMZ6sTU7QHBC9n",
-	"vy4eGd3IYrOptLGchOFNVua/L5ysWZrcOw0Y7ea6IfVBd2QzMtmn7wfDtHeajDG/hP99ELPebrujq1gg",
-	"7EnYuMlq4d1qMo+R8KaplL87OeEGM3CJZj6y101zsl/uqshL83mYnefat7STuSWsaee39WQLd/6IpuSr",
-	"7LnZgWX3vOW/758h4W4ljnw7+QyJe9nG7tdkKipLxl+XLJyNXIUP6JRK88VCGMeF1EtVwVBX2Pqzi4Wu",
-	"z8zK0uGCRRjpTx/mNRyOZQ3yuqDpEpKd2fiHLdeNLP2tSP8bNyZR1tw78C3FEXikvz7Osg2Dvq1xBol+",
-	"ghtktxHAQ4BVdQfyT6l1q7QyyMtr5eB6c5Y9RTbHV7P7Us2h6k0ocHQl0Ackcd2VwW53dxf336dkGONQ",
-	"fMV725DLKjRqSWEej9Zt/K+fL3X/NT6GfJs0Sg0iEteSaGmpjADL8FK7SQ+al04stVg6NeRTrwz/q7/A",
-	"5+Bfpp6jxwOkZUMuYa7/OUUGnLxfQxwjOdiFKapu8wfUa942j8p96N1m7/2atklkvG49+5vnMftaB7B1",
-	"103Y/25IaHbi/+9//weY4zQxp6Vy7Cs30caN+n+be3OuzLSQN1yQ7ILUx2YwA8cHKuV8nI7q7Qv2cC8n",
-	"KxUAbygxaYCL9oW7ySgPmBjMZtQSwxxzgmf7fBaFe9q47ncGukYGqmneNZ08QLPH6hxL2xJqJepfHS/N",
-	"YVaipELMqtlayLl1f75ZTZq6OZ+W6nKGJ+h3Spp300UtbMjRcr1MXYzGvbL2d2YWf9vMbktwETeJnvLb",
-	"R9diI+RXNUqkmfGTyjbUMn8gErVsqXqF35bEZ0vh6oL4ltUq/bipfrSo/rTZcranpVxiWpu9ylCbxaE0",
-	"anqLh+p1K0P1fENtFYfqFYbSbiytbU+QfYUtqyy7OovsX9ixwWG/q3F3Q0MLTCa2lQlVzJJb1hhQTu2g",
-	"30R08dlhSiwlp6/5WYmaWissftZEavdorchAXUAuOiKlSDWryAOl4B1TQx6RKKFY19NP0kGMw3gG0HVC",
-	"dVVoQbN+vEaW0AE3NRLFChma1ROICp3LXkDyEkxlm0TLy6bnl0H6uwkuX1kE+X79fr9+v9r1a6IqFa+p",
-	"RP59+ChJ3h/4+OGjJO/y9W2i/8q3uO7tZcvWzbeGCTewJKkbwRtZWfty7ayGL+K5eWBLYeg8vqUDDvRm",
-	"yCugt9NZPt6lt1OqbPQVo10avXm4OS2XkCWKe/HdLNvAEqdQV8Cb7xjNd1DUxVP8WUZ9Lybu7i77brJs",
-	"1lK/ZtxY6SwQov8ZphCAvNRrzPou5wVgPryHivvyVSzFuTe+DzZM5SGoXxdWfIG8IMfZMLzminBM15o0",
-	"/QFEdpjSzbHSYVHklg8JYBz7QqLc72VWmifhvlVFuLK2ajXzRyueENXBHXChubo6Y20S8nmLMAq4xboL",
-	"QQ2TuC2wiWJuDl/2qAaLbl4lf7mlLKxGXWUKKnudqs7H3CxLWZbilprXTGhTFefHJOqsFkDzprCQwnjf",
-	"7+vF97VDFgtvbYfZLbRVNZV7M3NNjaTr2K/uX0zMLfyrmpse4E2WSWUec1OG3Tu4yVyQ84QjJrjDQYCN",
-	"NKHM5JTjzvVkKu9bJhFRpBwN0TXmIq+9P8gjKypdVFNeaJtAJrBKh2h8XfPUI1lCTZ1B0Udqegl2/1d3",
-	"vlk3mblVMAQFqQJz/bLgusE2TQ2833lxs1OqiTCTRrzH1MODN27Mfx1Hr9lzNFubZ4slvEzCnBs6kx+e",
-	"5R4aisA39G6xBFb0b/kreAI/fC+bufTZWlkceIZEY4p7hsT9kdv61OiMY9ZzyL94nI8kG2djV+dpSyTW",
-	"kmqG27qk3cwXNO+Uc6tMWw8/sOZ7pqumUdOlbPCLiUp3c3G9Fla1fqdwB8QmAdkuEr5RUHaBgKtQOp8f",
-	"YHD2XUN9HnZwNyrQ+9JBQ834/8aN85dsYaJmVcPMClfr8it1Qps5VlV0zErLVMo9VMQOZyVvTaG9+74j",
-	"atfqiSd9o1w56NAkeacgHKPwUtdM3ANZQmwphJ0c7YOtra1doPNlZ6+AttKESYvreQk0KbV9D/R3KVJ3",
-	"n5JYZdsaMDdTaPIvo1ncizdzs7P01VhBo2wQxYu8No+Abr7OC3zJs95QF3avu79LPolVrpk5QSCN6KHI",
-	"/R8CMSzHH2Ecvx7WQupXDsrPVDHk4gRxVFNjRBURUReMTj09hRww2fw+K4qUXqY+LpAI/waZNb6FEHa7",
-	"ZFIOrUCRRSJXKQ/2iik77nz2ltfkH2aqj++JO9aXuMNDwWuzNZjkHM3OiO60WhqO9dxK92qUUAtzi/fV",
-	"yO4aZd/eJGFovgqkTmLyPV3cchaFlROQrHiNjfPKM40sCLZAzjxLgk46a6vQQCYV8DBOOb5CAKrhMDMl",
-	"7CGJALqufEQkMqlrlYxlyhuZOsR8AuMYMSDGUOegcKofqQExL044oGIsh+SL5VxbiOdbXLmlJxOFH2vb",
-	"UKUE5GnXxUmczgvsHOqliVfraEo6S2PIsMiq36YkQiyeYTJyk3b47m1TUr9JbMqd6vhXdb/o7hjxWH5M",
-	"KVJVcHSMCBitH2WCBl8BQafyCBjY1PrN0RAUqLBYXULVHOHBrAP2IZErl6dqTJmwp0qHUTkLrl/Y1C0L",
-	"Noci5pckWzFmqRwodJ9GtZo6ZQv0r3LNLnA8tJxR7pXrMqhpz90hzPW25bVO3UJvF+S7ta6xtW7xvfUV",
-	"L11mbQp+sViZHPJatoaStI1B3m/m6gQETW2FOqBVxUIRYXnxMhrHKAL0yp+DSc3krPbcpNH480jVRYMN",
-	"Gg5RKPAVqisLq5giFGA6xuHYloWVyIaXiAPdvVWuQp2l6Jctw4xjmgxYw9Tklj5zne+UOV0e4NWvkTXd",
-	"ET5f5hU8j12mZoxc37lPHffRJ3glw1QpzC8L6fMH+rn1FE2MH2JX/tC4mIYqPrhQO26z90On2+l2Nvee",
-	"Pn361COHqkIoc0r26e9yZrNAj9CmQq45YCi2B0HXfpAELxlaVnXHMDldLqFzQT68QJARMKEMfXxUWy5w",
-	"Y4SEHKutGCOKNtQoG5LpXWE0faxOkxFXTOEFr2xZBVNpr5iMdAVAJXJkh/QO8Bku6AXQxMQ3BNCk4CtE",
-	"ujcGa0IJEvgL2oggHw8oZJEJ62lH6ArFkrG2RymOUAFA4yDfEEDH431FZNkRCkBk/lQNwSh48yyPoMJt",
-	"7qerOaf69uPt/wsAAP//ssaA7EnvAAA=",
+	"H4sIAAAAAAAC/+x9+3LbttL4q2D4OzNNWkmWZTuNPdM5o/qSuomd1JckbexfDkRCEmsKUADSsuLxH99b",
+	"fM93nuQbLAASJEGJkuXEbdPpnFOLuCwWi8XuYi+3ns9GY0YJjYW3c+uNMccjEhMOfxEah3FERoTGh4H8",
+	"ISDC5+E4Dhn1drwuSmj4KSHo/NXhHuozjjBFVp+W1/BC2XCM46HX8CgeEW+nMGrD4+RTEnISeDsxT0jD",
+	"E/6QjDDMf4NH40j2aa93T/7YON7bf3l2+nbz5OTg4Ldn2y+2DrpvvYYXT8eyjYh5SAfe3V0jP8VrfkBw",
+	"nHDykkzLizgbEhQGiPVRPCQ29Ihx+OmKTM3Xvhqnzrpyk953jRKUwTje/BizK0KFc8katvn7FAYS0H5I",
+	"uNqyOavKxn2QnRpwPIe4SvBClwpozXAPAmtI/SgJyB6JSEwcIB+q7yhQDSQx8ZCIFNRPCeHTDNbCcDaI",
+	"AenjJIq9nT6OBGlkIKu1aNB6jEUEU4ANDq0ku9MoGdTHpqRq6FqBz/yws7D6L0763o73/9YyhrKmvoq1",
+	"dAAJKWDhIIxiwl9wlox/hkPpQlA/18ieDAdBKFeGozecjQmPQwIMq7BnjQIWTkOJRaTGhfUP5OCoNxVo",
+	"EsZDRG6wH6MRjv1h64Je0HOBB2QH/effOVA+yGkufwrpOIkvkna78yz/ecQCEl3+NBjHzc3/XFDP2r9b",
+	"Dz5KSpVfMzKDwSTE+m/W+5P48IOIp0CsASHj1+mvFhZPE/VradPV55AOUG+KRkkUh3L1QjUX9gL/rX/8",
+	"yU9EzEaEN9fVwkq/d2A9rt3STXP7FMZk5N4Y/QPmHE8tsuBsVF7HaYx5jAIck2YcjggKKTo52EUbGxvb",
+	"chNHOG5dUDh8IrwmrUoI+3J0NyfotDsbzfZ6s71+1m7vwL9/eA1PjS6RbyZ3MgaYxyLmAlvoI8piJMbE",
+	"lwcvQBiJkA4igvBgwMkAxwRNwihCPYI4iRNOSQDESbA/NNuFMA0QrH4S0oBNWhf0P/rTf1AoEEacCMKv",
+	"SZDSNLrGUTIDHQPHwUox8kETql7uZWPhvXwVjkIHUR4nox7h8kbV7BHFTC+7As4IBnKyx/V2u22drnX5",
+	"1wjfhKNkZD6OQqr/tM5aTAaEZ6C+7vcFqQuruArHFZAyNY4TVBtOG6x2NVhnrAzSPg1WcBJiNu8cdJY+",
+	"B++APk/Dz2T+UWhkZyGRnGjeiTAiGidxKpRl52pMeMgqjg4QezVCJhnQdS81a52FtZ+FI/IHo8QtbMKp",
+	"lEdWAi+nNwuBHf3MKEFYoID0Q7nqkMK3w+5xF8lxkRwY7eEY97Ag6Mkwjsc7a2uTyaQVYopbjA/W5EBN",
+	"OZB4KsmhhHM54PnZLkwI8xlcJ4IE83CULs5J5d752a5933ndEeGhj9eOyeTj74xfOelGb5QUE5wyerUs",
+	"qHtWSC+FcesJhelVFwYOYO/kIGLMqFASx884OCGfEiLiN5z1IjI60V/lR5/RmFBgLHg8jkIfywWtjVXL",
+	"H/4UcnW3tnQQkBiHUjwYEhwQjnbVCM2z6ZigIRYooeRmTHwpXipCusgNfTOKLjy5NTGOE+HtbEoWCGqJ",
+	"tyNhRRrYbGUJpzsaoKb8aaeHgybXre7qHga9eIWg/ObZs941vF1G+1HorwZdvh4spIN9GnMlSQYg2f/y",
+	"/u1R+7S9e/THr6e/dTZebB+9fH/y25sfPZCVcYBjWJTc2DF5g6dGyfXG4cfN17x7NXx1PQ2HIdseb60P",
+	"t8PwgP7sZbSaUVdzXQmaeuMiEgwIR+QmFLHI7cR2thO6EY44wcE0a1y1J7pB7e0oINm1La8UCPvpyMcs",
+	"PmAJDVZLx6BAAAPqy8FzCNnMEHLMYnSgG1QhgbK4qQZZBVlmM6q1H0rQJRGQFWNAK9CAgzCbxMLEVns9",
+	"j4nDXLNZ+LAHXBVWDvNjnlOcxEPGw8+rxswoFPLyR4yjkF7jKAwQGDhyRGKhxoZkBl4Su9kqkHJeGPA8",
+	"5cGrxYfF2wnnjOdIpG3jIW23r9tV48I0XREmChDepaPq2zDC1Ce/hCJmRhpyXedKlJCCT0/1QEPVRUkf",
+	"45xSr5t0Y9AD3UKVbbczQ+JYyYegPWoZS4mIrbxSDmpDJuKypBcREBZw8JpG04LVhYJSINGpBpuLTtXq",
+	"ruGBiOuGP2YxjrQMnDc2GglwhZC7rAzFG6PSyKJGzK/AdM5bOvKXcxhPD9Ob+Xjv15Otjc7+8xdnP789",
+	"3e28f7m1t+mVb9EnWrBsVfd6at+isYhBMDSSf3ZFS/lQxJIu9DHRIs5OxHwcrf169DryY/Hy7fNmW/6z",
+	"XnVzW0s1am+PJfFOL8L0CogiR7tmQeUjMExGmDYl5LgXEURuxhGmwCuMqO5LbTMehgIx3084J5KoDR2r",
+	"bWrlZO0eC6ZolIhYyvIY/Xr6+hgxY5Qpae3kJiZUhIyK6s3W5sf8mpz7OtusbnVRR3Wah3xBQ2wmxn9w",
+	"QnPpIPBs+8t7cX5yiDjpE4XieIjjTNMQtpLp192KehSWntyEh64tMhToQu4vZ2dvkGqAfBYQNCCUcCxZ",
+	"c28KgDEeDkKKwCpkrL21iWkzx1lCGm90PMu2srW9bdkwlJZRsGKkZ6aMb4zEkPG4UTwEIhmNMJ8W4EJy",
+	"5Dx6nZpM0SBVwprUoeT1jEMqEIZdd+119bQzdaV521mgW/hqcJRudcoCXSS8n11ysLpQrm4UUhwzDqZl",
+	"PB7LqeSdqZ8GKu4ka6SfdUv9hCCBm9vnSLdUYId+jS6nqmHGIKfH2hQlV3nX8Bglr/vezofZl6kDiLtG",
+	"7S4pELV7GOzcXebxb36XnDOKFgNc993lBMfkkI4T0L/qL2KIOQkOQhIFwru7bJQMhNBSZMYReY0kglgv",
+	"fSBEzCIvF4jLLFUNkIe4cbssxGPHW8+tR6hkQR9Skr/MX4mGumucxvKZK+x6ER8rPYG5wZc4jYX+C57M",
+	"AjWu+pQuTewu4O530px7miPRndsCqc14Wz+zJHUQFDQFh8LoJIGm5oLovpDMk7dZLfn62U27ITNaalSf",
+	"zRlAL3lTS9s5IVK6COlANbdQXzpzGVbnXHYvONYK9aL8B3rmYJhDPIoOjkiMLXaVJ4Y5TjGSILS12lZK",
+	"wfUCpA2JbnBTgGc7IZgfgtQ2CePhQjRSoeXZEv445ER0q3Rm+VlpHAGOU2lQuVcUAFnkfXQuXJTcxIpO",
+	"iFMgl8DJNupFJMMXPFNw6Hgf+Erw8BwsC1C37HzNwoAEVTgGxKZPt9ZSsECqJ3riY0pZbN5fEO7HhAOp",
+	"PG0tieLCQctT7NxbrnRoSiuDFgJhrkGOGQqpzwkWJLW+sH6mNFkuB6VrHI9YQiuwp77J4RVRotMhS6JA",
+	"qbdjJsI4vCZImTXqWUZKNhzS7xNfDlN5SkwD2MIWesPZNeyben4xT2c+CTWrh4tbKrrZmyJ6MgppEpOn",
+	"KyXb7PwuwBvTPoaC5eaP8M0JiyJ2TXjX2o7s5bqMFq0Jmi2yeYdicz6m8HzLIokXOXQL7akh4Rm9Df4n",
+	"TTmQmhP9hG6Vyoqjj2rYO9S8SNrtDTWMHAOZFnri4gjttAdlaadio+12edzttmwiQTrsozD+TqAI84E6",
+	"iBS15epotsTvRErnhgDkt6Pu+ycWLhum0VP0g4Z3SSpd6va3THELv3KVruMxDxkP42ne/cJFGaZl/j5B",
+	"mmeAm9UwHAwJz1pKRgLGchKgfsiFRNMb8xGcW9LDHhA/HOFIH3rRQu/kgBGbEG5+QyENwOxOB2amcDRm",
+	"HMw/rQt6wDjSuGnIoS141+VsIyb5Gh8QRcq00KbTuqDvNDVIuDlBglwTjiO1VIHwNQ4jMGgY8UrgUSoa",
+	"qvd3MRUxGSFBIskYc5dcPIQ/AXQRp3ODZwfysSACTWBqPZ2QMks2TQprRK5J1LCG9iMm5IiSXcfCvv9t",
+	"B4B0Bw4VwcsZYS8nzMw4xNfmLd7HkZkxlCocDYpyhcgtGGaSul2BXcgL0Yc7JwMgd1Is41Nna2u2X889",
+	"rvRZAqu+qvKXRo4PzxFkjcliGVH2noqU6Y4jP4kkli359hEZHqrALF3NWQvUhybaIUSrzUU39IIFG2gj",
+	"Pq+v1mTyXoRFfEKc7mKS+8nPmbCnXr8lbXPZZYXXf4E0M6gartXVo8svY+45Ku+Q5mfY94kQkgUHss0I",
+	"HKB6WPIkRlMtG5RRlyQZilPWjy23w7wPdckTTZjWP0khOqe9S+HFMCkzL7kmFIXlMAGp6d8McSJi4zxV",
+	"dM9ueKE4p+DGaNzG54CWmNb1QJM/mR45QcMFiUhIV6oYFUT8O0tgDmhovPKSmI0wMPtoqhUURdDobBgK",
+	"3SoU4ONgS3wARA35pmjLM8avnC1vlFqdS6LOwxgotIk+mXmQCspT0ZBU7ww5zQ73O3Sr43ia8mZEz6RO",
+	"eVdkaowf8HaZkm2O7WVO5qvdy9IGWpDP3zhtL12C7d3PSPklrlUHhA/G39VcORY5YNotl5Ox5BsUZHPD",
+	"vXxG++EgUSKUi7GrBm7ig0fuMeYC5G3V0hHMVbx5by+8KzJdv/B20IUHmvz6hXc36y3RsCZtV89xJv1b",
+	"zSc/vZy5FPlWglU2Rmud0o0Oy/pSKQvd2++l1n4Qa0P03mqTCcAmSlTSqrdBc62LQyy6IEiUAXw3JFJp",
+	"y92nQyyM4KFZlhUPV4i7qpjbul7lrVfp5KM/1tuc5bamysWornsR0jFswgArckBtLeluZJ+CbH+cUum1",
+	"cZ6b5ZBS0AUilgTQUaBTbXNUBAfUeKq83nIGEWNMyUVjNeOE95g8xirMcsdb72y4YrTAxXjLX2/3cUCa",
+	"6/42aW4Gz/zm886PW01/q+NvPPtxYz3YkCxBsISD05Eg/Dr0SRN80xueGBP/mnChlrDeanu2b3HBCT0c",
+	"FdWF9R34t9Vur/+RQTjmbDSOHW5IM21HLpcuMH1KlKIxnkYMB60ZYWwViHPZkSQk2kXS7aWhPd7B+8LQ",
+	"KjxVqWgmdJSIGOEAFIaYQfhLp735zIS/SCg1p7bdL8HtMsezS1/BpPCK0EE8BKMCTSIw4lQyGgmVHQKR",
+	"k+EL7kPQTFk6YDFqAZLltMqOIwvCEQZz54edzDPYmuSbh6XsoaSpe878sOM3sWQ2k2HoDyFQHKhriMdj",
+	"QkmevIpnxcZPM3XUqgGdfcacsTjqo6Ezm5GIHCNRUKeolPJXnjPqEzwPoKpQzT34q2fIRd9NRo6BKTWj",
+	"NqjMfRtzFiQ+4ehJKoyDG5janqctt/gNvGUOxIr1lHAXjoiI8WgswZgY07jlWZZuq+u8bmxsbLcqDSEF",
+	"zuY0hix4QtycJo9zw28UQjlRtiUtEuhXBxBbs1Xm16B57zwhEJCuj02eQhtGQDRUUrofG95Nc8Ca+kd1",
+	"qNWFaX1pKmO3yuYgMeQNwniY9Fo+G635ksKho1gTwVVzwNauO2vwA0Baeh8qByBm1l0dbwfijPVqXBTe",
+	"K5/3SGkoaIyi8Iqg9Q4aMRoPRdEQ3HHZe4MkewmrM5Fpr+aCifQ8+vL45fX5idfw9rq/ew3v3f7+S6/h",
+	"Hb0+PvvFa3i/73dPrM2p2OgUpIbGgUvc0Uki8tpY4YGU+8Pw2v3EfFiQ5QQyrRso1A/m9tuyCnkHGz7j",
+	"tiXtQV76Hff/bFVTY2MhTbpsOimp0N0cgtI/GEf6nkGs3wdhPGYII8Mf809FO2j3zXnzF5Zw0UBnIOc0",
+	"UPfNIdrFUSQaiMR+hR7uWpXDKfZLwpinsKsqy4425ZQzoKiYbeMwHcaoz9kITVnCkSVXFUlrZgqTr+zi",
+	"BOqYDuFXeRPEPeB4Pc6gIFmWCZ15QrTQuSD9JDLmZNVK+GwM29/jDII/4fFxImXGFO0c+1dFjljMKXFX",
+	"tTx3apCzFIDUPckmxbyDEjzwBUT5egjDS3rTlJcc9pE28ahnP6fOqX0DtApcJBNFIR8hJMZFJyq41+k0",
+	"ZEVT57bbikc+1Adj7kV9RdLYZxfnhvfsnxNO99iE6oCnUzJInbMLp1uoT3lHiV7CKQrYhFrhTxe0iwbh",
+	"NaFpl9RoJvIYxcaNjCKc+drYcUIVcVT7NFg4iorQ4EFiqB5tcBfgVseziRRnVfygxhtHtbGuxwm+AjKQ",
+	"8ieW6pHyOFL7W73UHeVVcbi3gzSkRc4ww4FQYuauEhEZoRcQke7TPxUV8IbiNC5KFVFzxIl6z4wTeDGT",
+	"5zxWBz1nbgNu2psqHm+/26W5VmZJPi9SaE6Iz3jgVS9Bp2aZYZ98fU24elZUzhj0uxj5srVSJNWyCker",
+	"s/W1wyZzt0vKDb9AuGQJ9yUzfWVis3xknNPbdjHX8IXws5QDmgsDC+Uaa8264LOYgkKw8avDPfTknIZS",
+	"QYZzdK7GfUVuQp8NOB4P9ZP0KeMxvDekdif+tIDRF8+2/vhxa6t78K778pf99c7x7+3d37YPpD43xnFM",
+	"uJzy/39oN7e7P+/u7R+8+OXXl0fHb347OT17++79739c3nae3f3Lgf/b6pWN8I0xUzzbKFot7Flx83O7",
+	"uX35w5N/73xM/3j6vWO6SwcBHNIBETEJlrGddyVLUt216QPEPGYEWAjLV6oyRHwXzMDETLmIQX0BC3rw",
+	"9Szo2cpVkH0pl4VKNKRMJ0VZK8XLzJdV07c0lU1TJjUC0YaeBX2/oZdLgAU/HNfpVcsENTT/fKfM15CY",
+	"SKAhm4C3M459pRVkqZuUfalAKeazfiQ+P/JKpHio0j8oriV7y3HOcvvSSLOWWbT2r1YuV5n8wcQrCeBQ",
+	"xXMJTwn6aExVe6MTWImgdryjw+Pzs/3y7ubWMnuPActdq31R/Cnj3/rbsO40RWNZkUHnGltzraAWOm8r",
+	"X3vADBqzbDfrGTlz+1IlGWbDlHasSpE+xiMSwDPeGwz5GaUqBEHrEkhyIxViE1JjZ70TyiKRWcglf2qh",
+	"l2Qq0gh5fUtJ2vUZFaGIEaPRFOFoPMQ0gcRV8DWhAeHCZ1JzHWI5o9Th3Sr4DFosh6QHSybqrHmvzX0q",
+	"FzPv71J4diVIysh/XyR+gduzdPSLa3dQWpHQlBNDSl752/M7od73TPhk64Ke2Y10Z8bR6flRA3Xfvmig",
+	"o8PjBqDoqPseWaxFKB5MdRJCSHcG68gFWICvhbYKppEwB4yj8+PD3873P+6+Pj8+s4dt5MFWEGVZI9QU",
+	"LSSHKPXNEGBQKGEMB5Q57DgWVy1twySXJHCBNHs59y6Vk9bmxjaXy80y5y0FDq1oqTux7mMKGxOqon1Y",
+	"9t9r46vBmhoOAC5dAO5IJxvHmgVLdax89PX7hLpAYYO8hmfvtdfwum9feA15e8n/7b7PP3yrnvkdqUZG",
+	"N4fcVePlt4Tw6QkR4AzrwguHb5bHDIKkhC2XN8eHW5dwUBBEi1JelcB4rZyv1juGisAAVJUfUxOaMo24",
+	"n1Ck5A4JaCufWGI2d4LZYomRwbMkro8eI7UMHRapsEk54azB6+2qAutitrKkqCvidLCzlUJ8ihrHVc7Z",
+	"xJhE6p2lx0wwjZKNZa7MOSsqrub6KgRrK0N3lVfHWdmXQyFe+TLN8MqYK8xfG+dQ18N4ZmuzEL9qijZ2",
+	"4IcIZ1Gry09lL2aB2zw9HCu9vaq8I7oq9kdZHx1vMH1ngnM1mjZrqyTfyl8mi4GeYGFCJFvosG+eWXsR",
+	"WWlMccwqoSNpAvKvAlsxeYTK5R4zJ1t8w3iMI9CPXXskNRWpmiCICo2U2aFor4giNgHHAvVwKsCD29ZQ",
+	"LhuejljsxtVrU0kYAquUQ5qUoeoY6gy2MzS7SjOXWrHHRh/V0j4edunexpvxu3edbucdfz7a/rP/mfwS",
+	"vXj//Ga0+37yojXd+rR52uy++3SQPPv0Zx8ffG5//u3T5v7nzvMTQadvJ7/2+++3Pt0cXTOHIaSMpNuK",
+	"p/AGCvtpVmtQEfPJu1XVmTQSVY9s70kZ/dUp6UchPVQf1wviQsNT2q3+LNnrXW4jbx8q7UVKCbc1HMlz",
+	"uTuWY9xzAQqDYjmUexkTsluwZjLtlF7dGTGvCJXaJdBKmgVeKr5yr0KWP7APRfKL2lsrffckV1omt2YX",
+	"6W5oDzLDCZ3SET05OdhFPz5v//i0dUEtx5fshBYSSeYz26ERnoL9QPkWFDUqk4hzZk7J1WUZ/8tkzfyW",
+	"RvJbGsm/chpJp6B8Cr0Me1qpoFwM0SyhM21guxPTcuxeQfCg/pC5Xq8owrwXxlzuv2ok+QHUylA6cHE2",
+	"WgxSniUeS6rk1zhaMDB1nyajsiO4GathVuO6M2aEKz9KVOpqI2OTJQny5gRW3h/KJijmCfVt//ohS/hX",
+	"34ca6IcBSph6Ba8e4PjYNBKuwonImepTF+wMdarKFsQHBUkU0gF4AO51f99B8M/+NeFTFODpBX23v/9y",
+	"x/pxQsjVBQWf9J3sV3Blv6C/73dP7MZTgnnOv30Rx/aGV3Ky3nFkddDutnY2Dk7U4716BhHEfIWEP7mk",
+	"AmM21uk89LWj88XYVX9ApplIyYVWpIDIifF1srEZAO38M62Hy3ynKwMuCZ/u/YDwhU4GjQOQwd1FJFeb",
+	"sjAZB/fYQEi+oodoPWBUQymeJ6M7ewn2fruYi1W4bxGPHTvHKK6sjJQI9WjoSLeepoMwTC0zy3aKGMq1",
+	"nGmdbXhBKMYRNiljd7Xqh46Vu858qwbEIRTD06yggGHSE2Om8petdzY2t54p6ZaHY2Jmg49+Ij5mgnJZ",
+	"vygvv6xjd2rRylw7rQt/y1oY5kek2htgz1Lci5oxpasyDegAk9pmgfmRIGoii6LdtDHfdF8ingKYNh3N",
+	"xZsjgsB17mdVyLPeW02VFBF+JvbTr37+a9gxarkX3rRBjUfed3bhuxXK/WpcEuQrwri5+kS3rVUMJuGy",
+	"MZ05YEV0hcs3uL6ndUWsh+M50qxn2UW/zixeAnE2UdKU6iAy8ztXl54VxVdrMc4aPa4qngW6ladFyq1h",
+	"PIWMCmo/IGR6l7GrkHQTSSm3ruQMEIQ2IT2Ex2PkQ2tTsS/9S9fs+/hRKL8bq8LKOHxJALMwmGXcN1P2",
+	"COaEHximycb4E7wfuUBxGv9NNUMwCMFg2fTDOB6nky89rcRA7anmL/HPSew5yvCUVyaJXp7SppaTsmjj",
+	"OVDc6RoxnOJoj/kOmX+P+Yk8A8Y7JOGR7i121jLW0ArZWiAHAMWtz1xvBIQeWV6ngDCKIfBDubCnSXW1",
+	"D7D2q8o6SvTCm4FAU5aojMQDImLtjNpQb936+RXGVD5XSpdIxUjRuqDNZvOCfv96TLh2w0pTcv73f/8H",
+	"PQHonkotV3Fpqcsol7c07WdILchg+1vfwwGNQp/oOmGa3Ltj7A8J6oD3coZAXdITw1co6qm7irVXh7v7",
+	"x6f7zU6r3RrGo8gykXk5fHgNL+ce3WpDBMiYUDwOvR1vo9VubSj39yHs7hoeh2vX62uWwUA9s7vyxIHS",
+	"a7eUVxQzSIN7WDbZt8eSc3GsXnoq805lTdasOsJVYcDF1rqUbzkt1WseEK5iMEkUVBXwlY0KJZGz2qa2",
+	"lG8uY7fk7wgOvywUDu202zPKxZkycY5S2jVzdTlYerkGpDZc5LfxruFttterpkoXsTarMCBMpfE2f5yq",
+	"cnqqNiwYc10UJzkWVg+zNpmhJ/s38ooH1hQ99S7lMCltX8+n6rxLpzr/EGQJWifH1Ny3DnK/Xp7Qofh5",
+	"XTo/Yw4at+pVK8jvV1p7VmXtOYW170vttgvbUjEmf8GkTRBKtOBapaZjhbMnsb3Y7fVOsB48/7HZ3sZB",
+	"c7Pn+0289WPQ3OptbG11Nrc3SNB56MV2qhZb1/kvH9y0CFNTR0CKzgHpJYNBSAeaubXnM6Xqus6Pmj0W",
+	"WJfNIdUPl3cNb8yEK5cIdBVZaibGUQ+ie2xkShFLuaDPSJfk4o5q+JQ/6ueun1kwncEYrHQ1P5SZRI3Y",
+	"qrtG1XhNWNsPs1nP3z1N3N+fz9RlM7XZSxYq5Tgfqdqh9RNN5ajgY2AfHMvfAGI8pELBMTxeVzQTevCq",
+	"UUb5jFvFk1qZIVGd2nyJ/LvSPb5Z5hynCeRz7CdRNE050N+Z1R7aqqWLx1oCp85DMkfkNK2q5MoDM8pf",
+	"XIWCQ2x0pxlPJ67sWuULC1KVpimvMiRWgBaqDl3d3g2ifnMpeuR9Gf3NpANbQMzJFv2oBZN+RsD1dLYq",
+	"MUV5QIhi9uv8kVGNDDbrShuLSRjOZGXu+8LKmqXIvVWD0a6vGlIXdAcmI5N5+n40THurzhjHLD6Uwpok",
+	"my9DzGq7zY4uY4EwJ2HtNi2AeKfIPCKxM02l/N3KCdeboisydZG9apqR/WJXRVaP0cHsHNe+oZ3ULWFF",
+	"O7+pJpu78wcsoV9kz/UOLLrnDfd9/4LE9laGgWsnX5D4Qbax/SWZCmTJ+PuShbWRy/ABlVJptliIoyiX",
+	"eqksGKqyan91sdD2mVlaOpyzCC39qcO8gsOxqEFeVbFdQLLTG/+45bqBob8l6X/tVifKmnkHvmVhgJ6o",
+	"r0/TbMOoawrbYaqe4HrpbYTCPgqhugP9TmrdkFaGOHmtHFxtzqKnyOT4qndfwhxQbwLAUeVfH5HEdV8G",
+	"u9nent9/l9F+FPrxF7y3NbksQ6OGFGbxaNXG/fp5pPqv8DHk66RRqhGRuJJESwtlBFiEl5pNetS8dGSo",
+	"xdCpJp9qZfj77hyfg+91EU+HB0jDhFziTP+zigxYeb/6YUTkYBe6kr7JH1CteZs8Kg+hd+u9d2vaOpHx",
+	"qvXsr57H7EsdwMZ9N2H3myGh3on/7//+D9LHaaRPS+nYl26itVv4f5N7c6bMNJc3XND0glTHpjdFh3uQ",
+	"cj5KBtX2BXO4F5OVcoDXlJgUwHn7wv1klEdMDHozKolhhjnBsX0ui8IDbVz7GwNdIQNVNG+bTh6h2WN5",
+	"jqVsCZUS9W+Wl2Y/LVFSImZothJybjycb1adpnbOp4W6nIUj8gej9bupohYm5GixXrouRu1eaft7M4t/",
+	"bGa3BbiInUQP/PbJTbzmi+sKJVLP+BGyDTX0H4QGDY2wBuC3IfHZAFxdUNeyGoUf1+FHg+qP6w1rexrg",
+	"EtNY75SGWs8PpVDTmT9Up10aquMaaiM/VCc3lHJjaWw6guxLbBmy7Kossn9jxwaL/S7H3TUNzTGZmFZ2",
+	"zf4ZBpRTM+hXEV1cdpgCS8noa3ZWorrWCoOfFZHaA1orUlDnkIuKSMlTzTLyQCF4R9efJzQYs1DV4h8n",
+	"vSj0oykiN2OmqkLHLO0nKmQJFXBTIVEskaEZnkAgdC59AclKMBVtEg0nm55dBumfJrh8YRHk2/X77fr9",
+	"YtevjqoEXlOK/PtwKUneHfj44VKSd/H61tF/xVtc9XayZePmW8GEa1iS4EZwRlZWvlxbqxHzeG4W2JIb",
+	"OotvaaE9tRnyCuhstRaPd+lsFSobfcFol1pvHnZOywVkifxefDPL1rDEAepyeHMdo9kOiqp4ijvLqOvF",
+	"xN7dRd9NFs1a6taMayudOUJ0P8PkApAXeo1Z3eU8B8zH91DxUL6KhTj32vfBmq48hNXrwpIvkBf0MB1G",
+	"VFwRlulakaY7gMgMU7g5ljosQG7ZkAhHkSskyv5eZKVZEu47KMKVtoXVzB4tf0Kggz3gXHN1ecbKJOSz",
+	"FqEVcIN1G4IKJnGXYxP53Byu7FE1Fl2/Sv5iS5lbjbrMFCB7HVTn43aWpTRLcQPm1ROaVMXZMQlaywXQ",
+	"vMktJDfet/t6/n1tkcXcW9tidnNtVXXl3tRcUyHpWvarhxcTMwv/suamR3iTpVKZw9yUYvcebjIX9Hws",
+	"CI+FxUGQiTRhXOeUE9b1pCvvGyYRMAKOhuQmFHFWe7+XRVaUukBTkWs7xjwOIR2i9nXNUo+kCTVVBkUX",
+	"qaklmP1f3vlm1WRmV8GIGUoAzNXLgqsGWzfV8H7jxfVOqSLCVBpxHlMHD1671f91GLzmL8l0ZZ4thvBS",
+	"CXNm6Ex2eBZ7aMgDX9O7xRBY3r/l7+AJ/Pi9bGbSZ2NpceAFiWtT3AsSPxy5rU6NTjlmNYf8m8f5SLKx",
+	"NnZ5nrZAYi2pZtitC9rNbEHzXjm3irT1+ANrvmW6qhs1XcgGP5+oVDcb1ythVat3CrdArBOQbSPhKwVl",
+	"5wi4DKX1+REGZ9831OdxB3eTHL0vHDRUj/+v3Vp/yRY6ahYapla4SpdfqROazLFQ0TEtLVMq91ASO6yV",
+	"vNWF9h76jqhcqyOe9A24crC+TvLOkD8k/pWqmbiD0oTYUgg7OdhFGxsb20jly05fAU2lCZ0W1/ESqFNq",
+	"ux7o71Ok7iElsdK21WBuutDk30azeBBv5npn6YuxglrZIPIXeWUeAdV8lRf4gme9pi5sX3f/lHwSy1wz",
+	"M4JAatFDnvs/BmJYjD/iKHrdr4TUrRwUn6kiLOITIkhFjREoIgIXjEo9PcECcdn8ISuKFF6mLudIhP+A",
+	"zBpfQwi7WzAph1Kg6DyRq5AHe8mUHfc+e4tr8o8z1ce3xB2rS9zhoOCV2Rp0co56Z0R1Wi4Nx2pupQc1",
+	"SsDC7OJ9FbK7QtnXN0lomi8DqZKYfEsXt5hFYekEJEteY8Os8kwtC4IpkDPLkqCSzpoqNJhLBdyPEhFe",
+	"E4RhuJDrEvaYBojclD4SGujUtSBj6fJGug6xGOEoIhzFQ6xyUFjVj2DAUOQn7LF4KIcU8+VcU4jna1y5",
+	"hScTwI+xbUApAXnaVXESq/McOwe8NIlyHU1JZ0mEeRin1W8TGhAeTUM6sJN2uO5tXVK/TmzKver4l3W/",
+	"4P4YcVh+dClSKDg6JBQNVo+ymHlfAEGn8gho2GD9+mjEDEFYrCqhqo9wb9pCu5jKlctTNWQ8NqdKhVFZ",
+	"C65e2MQuCzaDImaXJFsyZqkYKPSQRrWKOmVz9K9izS502DecUe6V7TKoaM/eoVCobctqndqF3i7oN2td",
+	"bWvd/HvrC1663NgU3GIxmByyWraakpSNQd5v+upElExMhTqkVMVcEWF58XIWRSRA7NqdgwlmslZ7rtNo",
+	"/HWk6rzBhvT7xI/Da1JVFhaYIo7RZBj6Q1MWViIbXxGBVPdGsQp1mqJftvRTjqkzYPUTnVv6zHa+A3O6",
+	"PMDLXyMruSMkZmMc0m5F7e7TIUuiwMKEaq7AAorTNbtVXW/tnCiZe1UTuWg1iPFlVInSZ7eHTVAIsjYR",
+	"9ktho5Rm3emkvYRLtc2ttfXuG1utYquKNS1lcSvEL6axiu4IRrtQpA5eJPzaHfMXMR8Cn3NF8dY7P7ba",
+	"rXZrfef58+fPHQI2VHiZUYtQfZcz6wU6pFGIJZfkG5kTropayJMsOXVaTkgTvqoD0bqgH14RzCkaMU4u",
+	"n1TWQVwbkFiO1QSOT4I1GGVNcvPrkEyewsHQcpiuKOEUmstggloe0oEqbQiyVMp97gGfZu9OAHWwf00A",
+	"dW7BXAh/bbBGjJI4/EzWAiyGPYZ5oOOVmgG5JpG8MZqDJAxIDkDt+V8TQMuVf0lkmRFyQKSOYjXByLkp",
+	"LY6gnJjipqsZp/ru8u7/AgAA//+QnyapF/IAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/client/go/client.gen.go
+++ b/api/client/go/client.gen.go
@@ -157,6 +157,9 @@ type EntitlementBoolean struct {
 	// CreatedAt The date and time the resource was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 
+	// CurrentUsagePeriod A time period
+	CurrentUsagePeriod *Period `json:"currentUsagePeriod,omitempty"`
+
 	// DeletedAt The date and time the resource was deleted.
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 
@@ -307,6 +310,9 @@ type EntitlementMetered struct {
 	// CreatedAt The date and time the resource was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 
+	// CurrentUsagePeriod A time period
+	CurrentUsagePeriod Period `json:"currentUsagePeriod"`
+
 	// DeletedAt The date and time the resource was deleted.
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 
@@ -325,6 +331,9 @@ type EntitlementMetered struct {
 	// IssueAfterReset You can issue usage automatically after reset. This usage is not rolled over.
 	IssueAfterReset *float64 `json:"issueAfterReset,omitempty"`
 
+	// LastReset The last time the meter was reset.
+	LastReset time.Time `json:"lastReset"`
+
 	// Metadata Additional metadata for the feature.
 	Metadata *map[string]string `json:"metadata,omitempty"`
 
@@ -341,6 +350,15 @@ type EntitlementMetered struct {
 
 // EntitlementMeteredType defines model for EntitlementMetered.Type.
 type EntitlementMeteredType string
+
+// EntitlementMeteredCalculatedFields Calculated fields for a metered entitlement.
+type EntitlementMeteredCalculatedFields struct {
+	// CurrentUsagePeriod A time period
+	CurrentUsagePeriod Period `json:"currentUsagePeriod"`
+
+	// LastReset The last time the meter was reset.
+	LastReset time.Time `json:"lastReset"`
+}
 
 // EntitlementMeteredCreateInputs defines model for EntitlementMeteredCreateInputs.
 type EntitlementMeteredCreateInputs struct {
@@ -372,6 +390,9 @@ type EntitlementSharedFields struct {
 	// CreatedAt The date and time the resource was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
 
+	// CurrentUsagePeriod A time period
+	CurrentUsagePeriod *Period `json:"currentUsagePeriod,omitempty"`
+
 	// DeletedAt The date and time the resource was deleted.
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 
@@ -401,6 +422,9 @@ type EntitlementStatic struct {
 
 	// CreatedAt The date and time the resource was created.
 	CreatedAt *time.Time `json:"createdAt,omitempty"`
+
+	// CurrentUsagePeriod A time period
+	CurrentUsagePeriod *Period `json:"currentUsagePeriod,omitempty"`
 
 	// DeletedAt The date and time the resource was deleted.
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
@@ -966,6 +990,11 @@ type ResetEntitlementUsageJSONBody struct {
 	// The reset cannot be in the future.
 	// The provided value is truncated to the granularity of the underlying meter.
 	EffectiveAt *time.Time `json:"effectiveAt,omitempty"`
+
+	// RetainAnchor Should the reset retain the usage period anchor.
+	// If true, the usage period anchor is retained.
+	// If false, the usage period anchor is reset to the effectiveAt time.
+	RetainAnchor *bool `json:"retainAnchor,omitempty"`
 }
 
 // IngestEventsApplicationCloudeventsPlusJSONRequestBody defines body for IngestEvents for application/cloudevents+json ContentType.
@@ -6706,172 +6735,174 @@ func ParseResetEntitlementUsageResponse(rsp *http.Response) (*ResetEntitlementUs
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+y9+3IbN7I4/Cqo+bZq7V2SoijJsVSV2mJ0cRRfo4vtxPLnBWdAEtEQGAMYUbRKf5y3",
-	"OM93nuRXuM1gZjDkkKJsJXEqtRtxcGk0Go3uRl9ugpBOEkoQETzYuwkSyOAECcTUX4gILGI0QUQcR/KH",
-	"CPGQ4URgSoK9oA9Sgj+nCJy/OD4AQ8oAJMDp0wlaAZYNEyjGQSsgcIKCvdKorYChzylmKAr2BEtRK+Dh",
-	"GE2gmv8aTpJY9ulu9k9+33p1cPj87PTt9snJ0dGvT3af7Rz13watQMwS2YYLhskouL1tFad4zY4QFClD",
-	"z9GsuoizMQI4AnQIxBi50APK1E+XaGa/DvU4TdZVmPSua5SgjBKx/UnQS0S4d8kGtsX7hCMJ6BAjprds",
-	"waryce9lp0YMLiCuCryqSw20drh7gRWTME4jdIBiJJAH5GP9HUS6gSQmhhHPQP2cIjbLYS0N54IYoSFM",
-	"YxHsDWHMUSsHWa/FgDagNEaQKNjUoZVkdxqno+bYlFStutbgszjsPKz+g6FhsBf8fxs5Q9nQX/lGNoCE",
-	"VGHhCMcCsWeMpslP6lD6EDQsNHIng1GE5cpg/IbRBDGBkWJYpT1rlbBwiiUWgR5XrX8kBweDGQdTLMYA",
-	"XcNQgAkU4bhzQS7IOYcjtAf++58CKB/kNB9/xCRJxUXa7faeFD9PaITijz+OEtHe/u8FCZz9uwnUR0mp",
-	"8mtOZmowCbH5mw7+QKH6gYuZItYIoeR19quDxdNU/1rZdP0ZkxEYzMAkjQWWq+e6OXcX+B/z449hygWd",
-	"INbe1Aur/N5T6/Htlmla2Ccs0MS/MeYHyBicOWTB6KS6jlMBmQARFKgt8AQBTMDJ0T7Y2tralZs4gaJz",
-	"QdTh4/gKdWohHMrR/Zyg1+1ttbub7e7mWbe7p/79PWgFenSJfDu5lzGoeRxiLrGFISBUAJ6gUB68CEDA",
-	"MRnFCMDRiKERFAhMcRyDAQIMiZQRFCniRDAc2+0CkERArX6KSUSnnQvyX/PpvwBzAAFDHLErFGU0Da5g",
-	"nM5Bx8hzsDKMfDCEapb7sbX0Xr7AE+whylfpZICYvFENewSCmmXXwBmrgbzscbPb7Tqna1P+NYHXeJJO",
-	"7McJJuZP56wJNEIsB/X1cMhRU1j5JU5qIKV6HC+oLpwuWN16sM5oFaRDEq3hJAi66Bz0Vj4H7xR9nuIv",
-	"aPFRaOVnIZWcaNGJsCIaQyITyvJzlSCGac3RUcRej5BpDnTTS81ZZ2ntZ3iCfqcE+YVNdSrlkZXAy+nt",
-	"QtSOfqEEAchBhIZYrhoT9e24/6oP5LhADgwOoIADyBF4NBYi2dvYmE6nHQwJ7FA22pADteVA/LEkhwrO",
-	"5YDnZ/tqQjWfxXXKUbQIR9nivFQenJ/tu/dd0J8ghkO48QpNP/1G2aWXbsxGSTHBK6PXy4KmZ430Uhq3",
-	"mVCYXXU48gB7KwfhCSVcSxw/wegEfU4RF28YHcRocmK+yo8hJQIRxVhgksQ4hHJBG4lu+e8/uFzdjSsd",
-	"REhALMWDMYIRYmBfj9A+myUIjCEHKUHXCQqleKkJ6aIw9PUkvgjk1ggoUh7sbUsWqNSSYE/CCgyw+cpS",
-	"RvYMQG35094ARm1mWt02PQxm8RpBxc1zZ71tBfuUDGMcrgddoRkMk9EhEUxLkpGS7H9+//Zl97S7//L3",
-	"X05/7W092335/P3Jr29+CJSsDCMo1KLkxiboDZxZJTdI8Kft16x/OX5xNcNjTHeTnc3xLsZH5Kcgp9Wc",
-	"utqbWtA0GxejaIQYQNeYC17Yid18J0wjGDMEo1neuG5PTIPG21FCsm9bXmgQDrORX1FxRFMSrZeOlQKh",
-	"GNBQDl5AyHaOkFdUgCPToA4JhIq2HmQdZJnPqNd+LEGXRIDWjAGjQCsc4HwSBxM73c0iJo4Lzebhwx1w",
-	"XVg5Lo55TmAqxpThL+vGzARzefkDygAmVzDGEVAGjgKROKhxIZmDl9Rttg6knJcGPM948Hrx4fB2xBhl",
-	"BRLpunjI2h2advW4sE3XhIkShLfZqOY2jCEJ0c+YC2qlId91rkUJKfgMdA8w1l209JEUlHrTpC+UHugX",
-	"qly7nR0SCi0fKu3RyFhaROwUlXKlNuQiLk0HMVLCAoxek3hWsroQpRRIdOrBFqJTt7ptBUrE9cMvqICx",
-	"kYGLxkYrAa4Rcp+VoXxj1BpZ9IjFFdjORUtH8XLGYnac3cyvDn452dnqHT59dvbT29P93vvnOwfbQfUW",
-	"fWQEy059r8fuLSq4UIKhlfzzK1rKh1xIujDHxIg4ezENYbzxy8vXcSj487dP2135z2bdze0s1aq9A5qK",
-	"vUEMyaUiigLt2gVVj8A4nUDSlpDDQYwAuk5iSBSvsKJ6KLVNMcYc0DBMGUOSqC0d623qFGTtAY1mYJJy",
-	"IWV5CH45ff0KUGuUqWjt6FogwjElvH6zjfmxuCbvvs43qztd9FGdFSFf0hCbi/EfvNB89BB4vv3VvTg/",
-	"OQYMDZFGsRhDkWsa3FUyw6Zb0YzCspObMuzbIkuBPuT+fHb2BugGIKQRAiNEEIOSNQ9mCjDK8AgToKxC",
-	"1trbmJi2C5wFE7HVCxzbys7urmPD0FpGyYqRnZkqviHgY8pEq3wIeDqZQDYrwQXkyEX0ejWZskGqgjWp",
-	"Q8nrGWLCAVS77tvr+mnn6kqLtrNEt+qrxVG21RkL9JHwYX7JqdVhuboJJlBQpkzLMEnkVPLONE8DNXeS",
-	"M9JPpqV5QpDALezz0rTUYOOwQZdT3TBnkLNXxhQlV3nbCihBr4fB3of5l6kHiNtW4y4ZEI17WOzcfizi",
-	"3/4uOWccLwe46bvPEBTomCSp0r+aL2IMGYqOMIojHtx+bFUMhKolz40j8hpJOXJe+pQQMY+8fCCuslQ9",
-	"QBHi1s2qECeet56bABHJgj5kJP+xeCVa6m5wGqtnrrTrZXys9QQWBl/hNJb6L3kyS9S47lO6MrH7gLvb",
-	"SfPuaYFE925KpDbnbf3MkdSVoGAoGHOrk0SGmkui+1IyT9FmteLrZz/rBuxomVF9PmdQesmbRtrOCZLS",
-	"BSYj3dxBfeXM5VhdcNk9Y9Ao1MvyH9WzAMMC4tF08BIJ6LCrIjEscIqRBGGs1a5SqlwvlLQh0a3cFNSz",
-	"Hec0xEpqm2IxXopGarQ8V8JPMEO8X6czy89a44igyKRB7V5RAmSZ99GFcBF0LTSdIK9ALoGTbfSLSI4v",
-	"9UzBVMe7wFeBhxVgWYK6ZecriiMU1eFYITZ7unWWAjnQPcGjEBJChX1/AXAoEFOk8rizIopLB61IsQtv",
-	"ucqhqaxMteAAMgOyoACTkCHIUWZ9ocNcaXJcDirXOJzQlNRgT3+Tw2uiBKdjmsaRVm8TyrHAVwhos0Yz",
-	"y0jFhoOGQxTKYWpPiW2gtrAD3jB6pfZNP7/Yp7MQYcPq1cUtFd38TRE8mmCSCvR4rWSbn98leGPWx1Kw",
-	"3PwJvD6hcUyvEOs725G/XFfRYjRBu0Uu79BsLoREPd/SWOJFDt0BB3pI9YzeVf4nbTmQnhP8CG60ygrj",
-	"T3rYW9C+SLvdLT2MHAPYFmbi8gjdrAehWadyo91uddzdrmwiQToeAiz+yUEM2UgfRAK6cnUkX+I/eUbn",
-	"lgDkt5f9948cXLZso8fg3wbeFal0pdvfMcUt/cpVuY4ThinDYlZ0v/BRhm1ZvE+A4RnKzWqMR2PE8paS",
-	"kShjOYrAEDMu0fTGflTOLdlhj1CIJzA2h553wDs5YEyniNnfACaRMruTkZ0JTxLKlPmnc0GOKAMGNy05",
-	"tAPvppxtQiVfYyOkSZmU2vQ6F+SdoQYJN0OAoyvEYKyXygG8gjhWBg0rXnE4yURD/f7OZ1ygCeAoloyx",
-	"cMmJsfpTgc5FNrfy7AAh5IiDqZraTMelzJJPk8EaoysUt5yhw5hyOaJk14K797/rAJDtwLEmeDmj2ssp",
-	"tTOO4ZV9iw9hbGfEUoUjUVmu4IUFq5mkbldiF/JCDNWdkwNQOCmO8am3szPfr+cOV/o8gdVcVcVLo8CH",
-	"Fwiy1mSxiih7V0XqK1gNfCDem9XATFYQsvWxgGGIOJcnOZJtJsqPZgAlaVOSKWtKp/EJJJif0qFwvNeK",
-	"rrgVhyZuW/8oZbGCEijvQEvrdl50hQjAVW9zqTBej2HKhfXBKXv5tgLMz4nyhrPexwtAS23rZqDJn2yP",
-	"wn3lg4SnqC8l1RPkdZ37jaZqDtXQOnelgk6g4hnxzMi5THbvgLMx5qYV5uqp3BUcFBANrsmyScjaUAom",
-	"oUlmvKzcmPej5xpLrzv4Qhm8bI9odoa82uvdDl3xbBjqmRNIkflnXaKZ1YPVM1ZGegUBOPc3Xu9+VDbB",
-	"gXwx8o3pbAXWdTd71ddg0h4I741H67kKbG5EjYcmQ4k8+0SJaZYDhZQM8SjVt6mPOesGfuJT750JZFyJ",
-	"XrqlJ66nrIPdXASXaLZ5EeyBi0ApdZsXwe28ZyXLXoyJtcBdzG8NX3/MchZS5FsJVtUuadQLPzocRRyC",
-	"SfW27KzDBaLRfiBnQ8zeGu1ZwcYrVNJptkELDU1jyPtKGKgC+G6MpPxeuBPHkFvhwbAsJzSqFIJTM7dz",
-	"Rcqbq9bfw3xstjmrbU2dt0lTTxNgwpm4BZYXgNpZ0fPEPQX5/ngF5yvrRzXPN6HkiRLTNFIdOTg15idN",
-	"cIoaT7UDVEE3tnp1ITCnLVI2oPIY64i7vWCzt+UL11HepjvhZncII9TeDHdRezt6Eraf9n7YaYc7vXDr",
-	"yQ9bm9GWZAmcpkz5n3DErnCI2spNuRXwBIVXiHG9hM1ON3DdTEv+yHhSNhxt7ql/O93u5u85hAmjk0R4",
-	"PFLmmhF83j3KCiZRChI4iymMOnMimmoQ5zMpSEiMt5z/wd44P6uHeEur6tVCB7aAlykXAEZK6BdURUL0",
-	"uttPbCSEhNJwatcTT3ngFXh25avSLl8gMhJjpV+SNFb6fC2jkVC53vAFObzkSaKaaaVXLUYvQLKcTtWH",
-	"YEk4cLRwfrWTRQbbkHyLsFSdVQx1L5hf7fi1kMxmOsbhWMUMK+oawyRBBBXJq3xWXPy0M5+dBtC5Z8wb",
-	"lqE/WjpzGQkvMBINdYZKKX8VOaM5wYsAqovaO1B/DSy5mLvJyjFqSsOoLSoL3xJGozREDDzKhHHlEaS3",
-	"53HHL34r3rIAYs16KrjDE8QFnCQSjKm1kjpORtm2+s7r1tbWbqfWJF7ibF6z+JInxM9piji3/EYjlKFY",
-	"WaWMSGAM0EpszVdZXIPhvYuEQIV0c2yKFNqyAqKlksr92Aqu2yPaNj/qQ60vTOdLW9s9dWC/xFAwwmKc",
-	"DjohnWyEksJVR77Bo8v2iG5c9TbUDwrSylNBNRYtN/SZ0CslzjgPiGXhvfalB1WGUo1BjC8R2OyBCSVi",
-	"zMs2wZ7P9Bel+aNIk4lsez2XmsjMYy6Pn1+fnwSt4KD/W9AK3h0ePg9awcvXr85+DlrBb4f9E2dzajY6",
-	"A6llcOATd0y+gKI2VnorY+EYX/lfG49LshwHtnULYPN26j4z6uhnZc6lzLWG3cujr+f+n69qGmwspUlX",
-	"zR8VFbpfQFD2B2XA3DOADodKGBcUQGD5Y/HVYA/svzlv/0xTxlvgTMk5LdB/cwz2YRzzFkAirNHDfavy",
-	"+Ed+TRiLFHZZZ9kxppxqMgwdvmt9Z7EAQ0YnYEZTBhy5qkxac7NZfGNvF6WOmWhuHULP7wDH6ySHAuUJ",
-	"B0wSAt4B5xwN09iahHUrHtJEbf+AURUHqN6hplJmzNDOYHhZ5ojl9AK3dcvzZ4k4ywDIPFVcUiz6qqi3",
-	"ngjpZ39ueclglvGS4yEwJh79AuTVOc0zsVGBy2SiKeSTio7w0YmO8/T6jziBtYXtdkJTj83BWHhRX6Is",
-	"DNbHudXT5k8pIwd0SkzsyykaZX66pdPN9afim/kgZQREdEqcSJgL0gcjfIVI1iUzmvEiRqH1KCIA5m4X",
-	"bshITUjNIYmWDqhBJLqXcJoHG+ejcGtCm3iGszp+0OCdot5YN2AIXioykPInlOqRdj7R+1u/1D39wH58",
-	"sAcMpGXOMMeXTGLmthYROaGXEJHt098VFSp7ite4KFVEwxGn+k1SpOrVS55zoQ96wdymuOlgpnm8+/aW",
-	"pd2YJ/k8y6A5QSFlUVC/BJOlY4598vUVYvppUL/Lk38KEMrWWpHUyyodrd7Ot46gK9wuGTf8CpFzFdxX",
-	"zPS1Oa6KQVJex8vlvISXws9Kvkg+DCyVdqoz74LP3ctLcacvjg/Ao3OCpYKsztG5HvcFusYhHTGYjM2z",
-	"8illQr03ZHYn9riE0WdPdn7/YWenf/Su//znw83eq9+6+7/uHkl9LoFCICan/P8/dNu7/Z/2Dw6Pnv38",
-	"y/OXr978enJ69vbd+99+/3jTe3L7Dw/+b+pXNoHX1kzxZKtstXBnhe0v3fbux38/+s/ep+yPx//yTPfR",
-	"QwDHZIS4QNEqtvO+ZEm6uzF9KDGPWgFWRWhrVVkF/5bMwMhOuYxBfQkLevTtLOj5ynW8dSWtgc45o00n",
-	"ZVkrw8vcl1XbtzKVS1M2Sh4ZQ8+SbsCql0+AVb40vtOrl6nU0OLznTZfqxw1HIzpVDm+QhFqrSDP4qPt",
-	"SyVKsZ/NI/H5y6BCisc6E4DmWrK3HOessC+tLIGVQ2v/6BTSVskfbOgKVxyqfC7VU4I5GjPd3uoETk6g",
-	"veDl8avzs8Pq7hbWMn+PFZb7Tvuy+FPFv/O3Zd1Ztr6qIgPODbYWWkEddN7UvvYoM6ig+W42M3IW9qVO",
-	"MsyHqexYnSL9Ck5QpJ7x3kCVqk+qQip+WQKJrqVCbKMr3ARoXFskcgu55E8d8BzNeBYsbW4pSbshJRxz",
-	"ASiJZwDGyRiSVOUwUl9TEiHGQyo11zGUM0od3q+Cz6HFanRytGLOxob32sKncj73/q5E6taCpI38d0Xi",
-	"V7g9K0e/vHYPpZUJTTsxZORVvD3/yfX7no2k61yQM7eR6UwZOD1/2QL9t89a4OXxq5ZC0cv+e+CwFq55",
-	"MDH56FTmK7WOgq+98rUwVsEsKOKIMnD+6vjX88NP+6/PX525w7aKYGuI8gQCeooOkENU+uYIsCiUMOIR",
-	"oR47jsNVK9swLeSLWyLjWsG9S6cndbmxy+UKsyx4S1GHlnf0ndj0MYUmiOjAD5r/90ZyOdrQwymAKxeA",
-	"P+jFxbFhwVIdqx598z6hL1C1QUErcPc6aAX9t8+Clry95P/23xcfvnXP4o7UI6NfQO668fJritjsBHHl",
-	"0OrDC1PfHI8ZoPLTdXzeHB9ufMJBSRAtS3l1AuOVdr7a7FkqUgagulSJhtC0acT/hCIld5WLtPaJRdCF",
-	"E8wXS6wMnufzfPAYaWTocEiFTqu5Ry1eb9YVYyXo2vJjronTqZ2tFeIz1Hiuckan1iTS7Cw9ZIJpVWws",
-	"C2XOeQFSDddXI1g7yZrrvDrOqr4cGvHal2mOV8ZCYf7KOof6HsZzW5uD+HVTtLUDryufskvvenXFqdzF",
-	"LHGbZ4djrbdXnXdEX8f8auuj5w1m6M11rUczZm2d71n7y+ThsFPIbbRcBxwP7TPrIEZrDS8VtBY6lOWi",
-	"/iawlfMI6LTegnrZ4hvKBIyVfuzbI6mpSNUEqADBWJsdyvaKOKZT5VigH0658uB2NZSPrcAEr/VF/dp0",
-	"PH7kZPXP4vPrjqFJZjpHs6s1c+kVB3TySS/t03GfHGy9Sd696/V779jTye4fwy/o5/jZ+6fXk/3302ed",
-	"2c7n7dN2/93no/TJ5z+G8OhL98uvn7cPv/SennAyezv9ZTh8v/P5+uUV9RhCqki6qXkKbwE8zBIcKxWx",
-	"mMdZFyDJghLNyO6eVNFfn518gsmx/rhZEhdagdZuzWfJXm8LG3lzXxkQMkq4aeBIXkjjsBrjXggQjsqV",
-	"Me5kTMhvwYZ5lTN69SdHvEREapeKVrKE4FLxlXuFafHA3hfJL2tvrfXdk1xplTSLfWC6gQOVJIyb7H7g",
-	"0cnRPvjhafeHx50L4ji+5Ce0lFOwmOQMTOBM2Q+0b0FZo7I5GeemF1xfwuk/TQLF7xkFv2cU/DNnFPQK",
-	"yqeql2VPaxWUyyGaFXRmDVx3YlKN3SsJHiQcU9/rFQGQDbBgcv91I8kPVNkErQOXZyPlQON54rGkSnYF",
-	"4yUDUw9JOqk6gtuxWnY1vjtjTsjxg0SlKTyR2IQ5KoVK5KSAIXQKBEtJ6PrXj2nKvvk+NEC/GqCCqRfq",
-	"1UM5PrathKtxwgum+swFO0edLrik4oOiNMZkpDwAD/q/7QH1z+EVYjMQwdkFeXd4+HzP+XGK0OUFUT7p",
-	"e/mvypX9gvx22D9xG88QZAX/9mUc21tBxcl6z5OZwbjbqgamUgdD+vFeP4NwZL+q3C+FxAAJTdLYvXZM",
-	"6hC3AIySaaZSciE1aRwKYnyTxFwWQDcVSef+kqCZInErwmd63yN82MugYaRkcH89wfVmr0uT6A4bGEMu",
-	"gBmic49RDZV4npzu3CW4++1jLk4Nt2U8dtx0k7C2SE7K9aOhJ/P2TaBFN2GZWm6W7ZUxVGg51zrbCiLM",
-	"kxja7KH7RvUDr7S7zmKrhopDKIenOUEB43TAE6pTWW32trZ3nmjpluEE2dnUxzDln3JBuapfVJdf1bF7",
-	"jWhloZ3Wh79VLQyLI1LdDXBnKe9Fw5jSdZkGTIBJY7PA4kgQPZFD0X7aWGy6rxBPCUyXjhbizRNB4Dv3",
-	"84qlOe+ttmAGx1+Q+/Rrnv9aboxa4YU3a9DgkfedWwNtjXK/HhdFxeIgfq4+NW0b1QVJmWxM5g5YE13h",
-	"8w1u7mldE+vheY6061l10a9zixcHjE61NKU78Nz8zvSl50TxNVqMt1yLr6BjiW7laZFyKxYzlVFB74cK",
-	"md6n9BKjfiop5caXnEEFoU3RAMAkAaFqbYu3ZX+Z8m2fPnHtd+MU20jwc6QwqwZzjPt2ygGCDLEjyzRp",
-	"Aj+r9yMfKF7jvy1spwxCarB8+rEQSTb5ytNKDDSeavES/5iKwFORpboySfTylLaNnJRHGy+A4taUC2EE",
-	"xgc09Mj8BzRM5Rmw3iEpi01vvreRs4YOphuRHEApbkPqeyNA5KXjdaoQRqAK/NAu7Fl+VeMDbPyq8o4S",
-	"verNgIMZTXVy2hHiwjijtvRbt3l+VWNqnyutS2RiJO9ckHa7fUH+9TpBzLhhZdkZ/+9//wc8UtA9llqu",
-	"5tJSl9Eub1kGSEwcyNT2d/6lDmiMQ2RKRhly7ycwHCPQU97LOQJNdUeovqr6jqYr33hxvH/46vSw3et0",
-	"O2MxiR0TWVDAR9AKCu7Rna6KAEkQgQkO9oKtTrezpd3fx2p3N2CCN642NxyDgX5m9+V6U0qv21JeUdQi",
-	"Td3DssmhO1arUGq+Ju9U3mTDKSlbFwZcbm2qulbTUr1mEWI6BhPFUV0tV9moVB03L3PpSvn2MvZL/p7g",
-	"8I+lGpK9bndO5TBbMcxTVblhri4PS6+WAzSGi+I23raC7e5m3VTZIjbm1YhTUxm8LR6nrrKaLhOqjLk+",
-	"ipMcC+qHWZfMwKPDa3nFK9YUPw4+ymEy2r5aTNVFl059/lWQpdI6GST2vvWQ+9XqhK7qYDel8zPqoXGn",
-	"dLGG/G5VlucVWV5QY/mu1O66sK0UY/InTNqkQomWXKvUdJxw9lS4i93d7EWb0dMf2t1dGLW3B2HYhjs/",
-	"RO2dwdbOTm97dwtFvftebK9usU2d/4rBTcswNX0EpOgcoUE6GmEyMsytu5gp1Zf4fdDsscS6XA6pf/h4",
-	"2woSyn25RFRXnqdmogwMVHSPi0wpYmkX9DnpknzcUQ+f8Ufz3PUTjWZzGIOTrubfVSbRILbqtlU3Xlut",
-	"7d/zWc9fPU3cX5/PNGUzjdlLHirlOR+Z2mH0E0PloORj4B4cx99AxXhIhYJB9Xhd04ybwetGmRQzbpVP",
-	"am2GRH1qi9XSbyv3+HaVc5ymKp/jMI3jWcaB/sqs9thVLX081hE4TR6SBSKnbVUnVx7ZUf7kKpQ6xFZ3",
-	"mvN04suuVb2wVKrSLOVVjsQa0LDu0Dft/SCaN5eyR97X0d9sOrAlxJx80Q9aMBnmBNxMZ6sTU7QHBC9n",
-	"vy4eGd3IYrOptLGchOFNVua/L5ysWZrcOw0Y7ea6IfVBd2QzMtmn7wfDtHeajDG/hP99ELPebrujq1gg",
-	"7EnYuMlq4d1qMo+R8KaplL87OeEGM3CJZj6y101zsl/uqshL83mYnefat7STuSWsaee39WQLd/6IpuSr",
-	"7LnZgWX3vOW/758h4W4ljnw7+QyJe9nG7tdkKipLxl+XLJyNXIUP6JRK88VCGMeF1EtVwVBX2Pqzi4Wu",
-	"z8zK0uGCRRjpTx/mNRyOZQ3yuqDpEpKd2fiHLdeNLP2tSP8bNyZR1tw78C3FEXikvz7Osg2Dvq1xBol+",
-	"ghtktxHAQ4BVdQfyT6l1q7QyyMtr5eB6c5Y9RTbHV7P7Us2h6k0ocHQl0Ackcd2VwW53dxf336dkGONQ",
-	"fMV725DLKjRqSWEej9Zt/K+fL3X/NT6GfJs0Sg0iEteSaGmpjADL8FK7SQ+al04stVg6NeRTrwz/q7/A",
-	"5+Bfpp6jxwOkZUMuYa7/OUUGnLxfQxwjOdiFKapu8wfUa942j8p96N1m7/2atklkvG49+5vnMftaB7B1",
-	"103Y/25IaHbi/+9//weY4zQxp6Vy7Cs30caN+n+be3OuzLSQN1yQ7ILUx2YwA8cHKuV8nI7q7Qv2cC8n",
-	"KxUAbygxaYCL9oW7ySgPmBjMZtQSwxxzgmf7fBaFe9q47ncGukYGqmneNZ08QLPH6hxL2xJqJepfHS/N",
-	"YVaipELMqtlayLl1f75ZTZq6OZ+W6nKGJ+h3Spp300UtbMjRcr1MXYzGvbL2d2YWf9vMbktwETeJnvLb",
-	"R9diI+RXNUqkmfGTyjbUMn8gErVsqXqF35bEZ0vh6oL4ltUq/bipfrSo/rTZcranpVxiWpu9ylCbxaE0",
-	"anqLh+p1K0P1fENtFYfqFYbSbiytbU+QfYUtqyy7OovsX9ixwWG/q3F3Q0MLTCa2lQlVzJJb1hhQTu2g",
-	"30R08dlhSiwlp6/5WYmaWissftZEavdorchAXUAuOiKlSDWryAOl4B1TQx6RKKFY19NP0kGMw3gG0HVC",
-	"dVVoQbN+vEaW0AE3NRLFChma1ROICp3LXkDyEkxlm0TLy6bnl0H6uwkuX1kE+X79fr9+v9r1a6IqFa+p",
-	"RP59+ChJ3h/4+OGjJO/y9W2i/8q3uO7tZcvWzbeGCTewJKkbwRtZWfty7ayGL+K5eWBLYeg8vqUDDvRm",
-	"yCugt9NZPt6lt1OqbPQVo10avXm4OS2XkCWKe/HdLNvAEqdQV8Cb7xjNd1DUxVP8WUZ9Lybu7i77brJs",
-	"1lK/ZtxY6SwQov8ZphCAvNRrzPou5wVgPryHivvyVSzFuTe+DzZM5SGoXxdWfIG8IMfZMLzminBM15o0",
-	"/QFEdpjSzbHSYVHklg8JYBz7QqLc72VWmifhvlVFuLK2ajXzRyueENXBHXChubo6Y20S8nmLMAq4xboL",
-	"QQ2TuC2wiWJuDl/2qAaLbl4lf7mlLKxGXWUKKnudqs7H3CxLWZbilprXTGhTFefHJOqsFkDzprCQwnjf",
-	"7+vF97VDFgtvbYfZLbRVNZV7M3NNjaTr2K/uX0zMLfyrmpse4E2WSWUec1OG3Tu4yVyQ84QjJrjDQYCN",
-	"NKHM5JTjzvVkKu9bJhFRpBwN0TXmIq+9P8gjKypdVFNeaJtAJrBKh2h8XfPUI1lCTZ1B0Udqegl2/1d3",
-	"vlk3mblVMAQFqQJz/bLgusE2TQ2833lxs1OqiTCTRrzH1MODN27Mfx1Hr9lzNFubZ4slvEzCnBs6kx+e",
-	"5R4aisA39G6xBFb0b/kreAI/fC+bufTZWlkceIZEY4p7hsT9kdv61OiMY9ZzyL94nI8kG2djV+dpSyTW",
-	"kmqG27qk3cwXNO+Uc6tMWw8/sOZ7pqumUdOlbPCLiUp3c3G9Fla1fqdwB8QmAdkuEr5RUHaBgKtQOp8f",
-	"YHD2XUN9HnZwNyrQ+9JBQ834/8aN85dsYaJmVcPMClfr8it1Qps5VlV0zErLVMo9VMQOZyVvTaG9+74j",
-	"atfqiSd9o1w56NAkeacgHKPwUtdM3ANZQmwphJ0c7YOtra1doPNlZ6+AttKESYvreQk0KbV9D/R3KVJ3",
-	"n5JYZdsaMDdTaPIvo1ncizdzs7P01VhBo2wQxYu8No+Abr7OC3zJs95QF3avu79LPolVrpk5QSCN6KHI",
-	"/R8CMSzHH2Ecvx7WQupXDsrPVDHk4gRxVFNjRBURUReMTj09hRww2fw+K4qUXqY+LpAI/waZNb6FEHa7",
-	"ZFIOrUCRRSJXKQ/2iik77nz2ltfkH2aqj++JO9aXuMNDwWuzNZjkHM3OiO60WhqO9dxK92qUUAtzi/fV",
-	"yO4aZd/eJGFovgqkTmLyPV3cchaFlROQrHiNjfPKM40sCLZAzjxLgk46a6vQQCYV8DBOOb5CAKrhMDMl",
-	"7CGJALqufEQkMqlrlYxlyhuZOsR8AuMYMSDGUOegcKofqQExL044oGIsh+SL5VxbiOdbXLmlJxOFH2vb",
-	"UKUE5GnXxUmczgvsHOqliVfraEo6S2PIsMiq36YkQiyeYTJyk3b47m1TUr9JbMqd6vhXdb/o7hjxWH5M",
-	"KVJVcHSMCBitH2WCBl8BQafyCBjY1PrN0RAUqLBYXULVHOHBrAP2IZErl6dqTJmwp0qHUTkLrl/Y1C0L",
-	"Noci5pckWzFmqRwodJ9GtZo6ZQv0r3LNLnA8tJxR7pXrMqhpz90hzPW25bVO3UJvF+S7ta6xtW7xvfUV",
-	"L11mbQp+sViZHPJatoaStI1B3m/m6gQETW2FOqBVxUIRYXnxMhrHKAL0yp+DSc3krPbcpNH480jVRYMN",
-	"Gg5RKPAVqisLq5giFGA6xuHYloWVyIaXiAPdvVWuQp2l6Jctw4xjmgxYw9Tklj5zne+UOV0e4NWvkTXd",
-	"ET5f5hU8j12mZoxc37lPHffRJ3glw1QpzC8L6fMH+rn1FE2MH2JX/tC4mIYqPrhQO26z90On2+l2Nvee",
-	"Pn361COHqkIoc0r26e9yZrNAj9CmQq45YCi2B0HXfpAELxlaVnXHMDldLqFzQT68QJARMKEMfXxUWy5w",
-	"Y4SEHKutGCOKNtQoG5LpXWE0faxOkxFXTOEFr2xZBVNpr5iMdAVAJXJkh/QO8Bku6AXQxMQ3BNCk4CtE",
-	"ujcGa0IJEvgL2oggHw8oZJEJ62lH6ArFkrG2RymOUAFA4yDfEEDH431FZNkRCkBk/lQNwSh48yyPoMJt",
-	"7qerOaf69uPt/wsAAP//ssaA7EnvAAA=",
+	"H4sIAAAAAAAC/+x9+3LbttL4q2D4OzNNWkmWZTuNPdM5o/qSuomd1JckbexfDkRCEmsKUADSsuLxH99b",
+	"fM93nuQbLAASJEGJkuXEbdPpnFOLuCwWi8XuYi+3ns9GY0YJjYW3c+uNMccjEhMOfxEah3FERoTGh4H8",
+	"ISDC5+E4Dhn1drwuSmj4KSHo/NXhHuozjjBFVp+W1/BC2XCM46HX8CgeEW+nMGrD4+RTEnISeDsxT0jD",
+	"E/6QjDDMf4NH40j2aa93T/7YON7bf3l2+nbz5OTg4Ldn2y+2DrpvvYYXT8eyjYh5SAfe3V0jP8VrfkBw",
+	"nHDykkzLizgbEhQGiPVRPCQ29Ihx+OmKTM3Xvhqnzrpyk953jRKUwTje/BizK0KFc8katvn7FAYS0H5I",
+	"uNqyOavKxn2QnRpwPIe4SvBClwpozXAPAmtI/SgJyB6JSEwcIB+q7yhQDSQx8ZCIFNRPCeHTDNbCcDaI",
+	"AenjJIq9nT6OBGlkIKu1aNB6jEUEU4ANDq0ku9MoGdTHpqRq6FqBz/yws7D6L0763o73/9YyhrKmvoq1",
+	"dAAJKWDhIIxiwl9wlox/hkPpQlA/18ieDAdBKFeGozecjQmPQwIMq7BnjQIWTkOJRaTGhfUP5OCoNxVo",
+	"EsZDRG6wH6MRjv1h64Je0HOBB2QH/effOVA+yGkufwrpOIkvkna78yz/ecQCEl3+NBjHzc3/XFDP2r9b",
+	"Dz5KSpVfMzKDwSTE+m/W+5P48IOIp0CsASHj1+mvFhZPE/VradPV55AOUG+KRkkUh3L1QjUX9gL/rX/8",
+	"yU9EzEaEN9fVwkq/d2A9rt3STXP7FMZk5N4Y/QPmHE8tsuBsVF7HaYx5jAIck2YcjggKKTo52EUbGxvb",
+	"chNHOG5dUDh8IrwmrUoI+3J0NyfotDsbzfZ6s71+1m7vwL9/eA1PjS6RbyZ3MgaYxyLmAlvoI8piJMbE",
+	"lwcvQBiJkA4igvBgwMkAxwRNwihCPYI4iRNOSQDESbA/NNuFMA0QrH4S0oBNWhf0P/rTf1AoEEacCMKv",
+	"SZDSNLrGUTIDHQPHwUox8kETql7uZWPhvXwVjkIHUR4nox7h8kbV7BHFTC+7As4IBnKyx/V2u22drnX5",
+	"1wjfhKNkZD6OQqr/tM5aTAaEZ6C+7vcFqQuruArHFZAyNY4TVBtOG6x2NVhnrAzSPg1WcBJiNu8cdJY+",
+	"B++APk/Dz2T+UWhkZyGRnGjeiTAiGidxKpRl52pMeMgqjg4QezVCJhnQdS81a52FtZ+FI/IHo8QtbMKp",
+	"lEdWAi+nNwuBHf3MKEFYoID0Q7nqkMK3w+5xF8lxkRwY7eEY97Ag6Mkwjsc7a2uTyaQVYopbjA/W5EBN",
+	"OZB4KsmhhHM54PnZLkwI8xlcJ4IE83CULs5J5d752a5933ndEeGhj9eOyeTj74xfOelGb5QUE5wyerUs",
+	"qHtWSC+FcesJhelVFwYOYO/kIGLMqFASx884OCGfEiLiN5z1IjI60V/lR5/RmFBgLHg8jkIfywWtjVXL",
+	"H/4UcnW3tnQQkBiHUjwYEhwQjnbVCM2z6ZigIRYooeRmTHwpXipCusgNfTOKLjy5NTGOE+HtbEoWCGqJ",
+	"tyNhRRrYbGUJpzsaoKb8aaeHgybXre7qHga9eIWg/ObZs941vF1G+1HorwZdvh4spIN9GnMlSQYg2f/y",
+	"/u1R+7S9e/THr6e/dTZebB+9fH/y25sfPZCVcYBjWJTc2DF5g6dGyfXG4cfN17x7NXx1PQ2HIdseb60P",
+	"t8PwgP7sZbSaUVdzXQmaeuMiEgwIR+QmFLHI7cR2thO6EY44wcE0a1y1J7pB7e0oINm1La8UCPvpyMcs",
+	"PmAJDVZLx6BAAAPqy8FzCNnMEHLMYnSgG1QhgbK4qQZZBVlmM6q1H0rQJRGQFWNAK9CAgzCbxMLEVns9",
+	"j4nDXLNZ+LAHXBVWDvNjnlOcxEPGw8+rxswoFPLyR4yjkF7jKAwQGDhyRGKhxoZkBl4Su9kqkHJeGPA8",
+	"5cGrxYfF2wnnjOdIpG3jIW23r9tV48I0XREmChDepaPq2zDC1Ce/hCJmRhpyXedKlJCCT0/1QEPVRUkf",
+	"45xSr5t0Y9AD3UKVbbczQ+JYyYegPWoZS4mIrbxSDmpDJuKypBcREBZw8JpG04LVhYJSINGpBpuLTtXq",
+	"ruGBiOuGP2YxjrQMnDc2GglwhZC7rAzFG6PSyKJGzK/AdM5bOvKXcxhPD9Ob+Xjv15Otjc7+8xdnP789",
+	"3e28f7m1t+mVb9EnWrBsVfd6at+isYhBMDSSf3ZFS/lQxJIu9DHRIs5OxHwcrf169DryY/Hy7fNmW/6z",
+	"XnVzW0s1am+PJfFOL8L0CogiR7tmQeUjMExGmDYl5LgXEURuxhGmwCuMqO5LbTMehgIx3084J5KoDR2r",
+	"bWrlZO0eC6ZolIhYyvIY/Xr6+hgxY5Qpae3kJiZUhIyK6s3W5sf8mpz7OtusbnVRR3Wah3xBQ2wmxn9w",
+	"QnPpIPBs+8t7cX5yiDjpE4XieIjjTNMQtpLp192KehSWntyEh64tMhToQu4vZ2dvkGqAfBYQNCCUcCxZ",
+	"c28KgDEeDkKKwCpkrL21iWkzx1lCGm90PMu2srW9bdkwlJZRsGKkZ6aMb4zEkPG4UTwEIhmNMJ8W4EJy",
+	"5Dx6nZpM0SBVwprUoeT1jEMqEIZdd+119bQzdaV521mgW/hqcJRudcoCXSS8n11ysLpQrm4UUhwzDqZl",
+	"PB7LqeSdqZ8GKu4ka6SfdUv9hCCBm9vnSLdUYId+jS6nqmHGIKfH2hQlV3nX8Bglr/vezofZl6kDiLtG",
+	"7S4pELV7GOzcXebxb36XnDOKFgNc993lBMfkkI4T0L/qL2KIOQkOQhIFwru7bJQMhNBSZMYReY0kglgv",
+	"fSBEzCIvF4jLLFUNkIe4cbssxGPHW8+tR6hkQR9Skr/MX4mGumucxvKZK+x6ER8rPYG5wZc4jYX+C57M",
+	"AjWu+pQuTewu4O530px7miPRndsCqc14Wz+zJHUQFDQFh8LoJIGm5oLovpDMk7dZLfn62U27ITNaalSf",
+	"zRlAL3lTS9s5IVK6COlANbdQXzpzGVbnXHYvONYK9aL8B3rmYJhDPIoOjkiMLXaVJ4Y5TjGSILS12lZK",
+	"wfUCpA2JbnBTgGc7IZgfgtQ2CePhQjRSoeXZEv445ER0q3Rm+VlpHAGOU2lQuVcUAFnkfXQuXJTcxIpO",
+	"iFMgl8DJNupFJMMXPFNw6Hgf+Erw8BwsC1C37HzNwoAEVTgGxKZPt9ZSsECqJ3riY0pZbN5fEO7HhAOp",
+	"PG0tieLCQctT7NxbrnRoSiuDFgJhrkGOGQqpzwkWJLW+sH6mNFkuB6VrHI9YQiuwp77J4RVRotMhS6JA",
+	"qbdjJsI4vCZImTXqWUZKNhzS7xNfDlN5SkwD2MIWesPZNeyben4xT2c+CTWrh4tbKrrZmyJ6MgppEpOn",
+	"KyXb7PwuwBvTPoaC5eaP8M0JiyJ2TXjX2o7s5bqMFq0Jmi2yeYdicz6m8HzLIokXOXQL7akh4Rm9Df4n",
+	"TTmQmhP9hG6Vyoqjj2rYO9S8SNrtDTWMHAOZFnri4gjttAdlaadio+12edzttmwiQTrsozD+TqAI84E6",
+	"iBS15epotsTvRErnhgDkt6Pu+ycWLhum0VP0g4Z3SSpd6va3THELv3KVruMxDxkP42ne/cJFGaZl/j5B",
+	"mmeAm9UwHAwJz1pKRgLGchKgfsiFRNMb8xGcW9LDHhA/HOFIH3rRQu/kgBGbEG5+QyENwOxOB2amcDRm",
+	"HMw/rQt6wDjSuGnIoS141+VsIyb5Gh8QRcq00KbTuqDvNDVIuDlBglwTjiO1VIHwNQ4jMGgY8UrgUSoa",
+	"qvd3MRUxGSFBIskYc5dcPIQ/AXQRp3ODZwfysSACTWBqPZ2QMks2TQprRK5J1LCG9iMm5IiSXcfCvv9t",
+	"B4B0Bw4VwcsZYS8nzMw4xNfmLd7HkZkxlCocDYpyhcgtGGaSul2BXcgL0Yc7JwMgd1Is41Nna2u2X889",
+	"rvRZAqu+qvKXRo4PzxFkjcliGVH2noqU6Y4jP4kkli359hEZHqrALF3NWQvUhybaIUSrzUU39IIFG2gj",
+	"Pq+v1mTyXoRFfEKc7mKS+8nPmbCnXr8lbXPZZYXXf4E0M6gartXVo8svY+45Ku+Q5mfY94kQkgUHss0I",
+	"HKB6WPIkRlMtG5RRlyQZilPWjy23w7wPdckTTZjWP0khOqe9S+HFMCkzL7kmFIXlMAGp6d8McSJi4zxV",
+	"dM9ueKE4p+DGaNzG54CWmNb1QJM/mR45QcMFiUhIV6oYFUT8O0tgDmhovPKSmI0wMPtoqhUURdDobBgK",
+	"3SoU4ONgS3wARA35pmjLM8avnC1vlFqdS6LOwxgotIk+mXmQCspT0ZBU7ww5zQ73O3Sr43ia8mZEz6RO",
+	"eVdkaowf8HaZkm2O7WVO5qvdy9IGWpDP3zhtL12C7d3PSPklrlUHhA/G39VcORY5YNotl5Ox5BsUZHPD",
+	"vXxG++EgUSKUi7GrBm7ig0fuMeYC5G3V0hHMVbx5by+8KzJdv/B20IUHmvz6hXc36y3RsCZtV89xJv1b",
+	"zSc/vZy5FPlWglU2Rmud0o0Oy/pSKQvd2++l1n4Qa0P03mqTCcAmSlTSqrdBc62LQyy6IEiUAXw3JFJp",
+	"y92nQyyM4KFZlhUPV4i7qpjbul7lrVfp5KM/1tuc5bamysWornsR0jFswgArckBtLeluZJ+CbH+cUum1",
+	"cZ6b5ZBS0AUilgTQUaBTbXNUBAfUeKq83nIGEWNMyUVjNeOE95g8xirMcsdb72y4YrTAxXjLX2/3cUCa",
+	"6/42aW4Gz/zm886PW01/q+NvPPtxYz3YkCxBsISD05Eg/Dr0SRN80xueGBP/mnChlrDeanu2b3HBCT0c",
+	"FdWF9R34t9Vur/+RQTjmbDSOHW5IM21HLpcuMH1KlKIxnkYMB60ZYWwViHPZkSQk2kXS7aWhPd7B+8LQ",
+	"KjxVqWgmdJSIGOEAFIaYQfhLp735zIS/SCg1p7bdL8HtMsezS1/BpPCK0EE8BKMCTSIw4lQyGgmVHQKR",
+	"k+EL7kPQTFk6YDFqAZLltMqOIwvCEQZz54edzDPYmuSbh6XsoaSpe878sOM3sWQ2k2HoDyFQHKhriMdj",
+	"QkmevIpnxcZPM3XUqgGdfcacsTjqo6Ezm5GIHCNRUKeolPJXnjPqEzwPoKpQzT34q2fIRd9NRo6BKTWj",
+	"NqjMfRtzFiQ+4ehJKoyDG5janqctt/gNvGUOxIr1lHAXjoiI8WgswZgY07jlWZZuq+u8bmxsbLcqDSEF",
+	"zuY0hix4QtycJo9zw28UQjlRtiUtEuhXBxBbs1Xm16B57zwhEJCuj02eQhtGQDRUUrofG95Nc8Ca+kd1",
+	"qNWFaX1pKmO3yuYgMeQNwniY9Fo+G635ksKho1gTwVVzwNauO2vwA0Baeh8qByBm1l0dbwfijPVqXBTe",
+	"K5/3SGkoaIyi8Iqg9Q4aMRoPRdEQ3HHZe4MkewmrM5Fpr+aCifQ8+vL45fX5idfw9rq/ew3v3f7+S6/h",
+	"Hb0+PvvFa3i/73dPrM2p2OgUpIbGgUvc0Uki8tpY4YGU+8Pw2v3EfFiQ5QQyrRso1A/m9tuyCnkHGz7j",
+	"tiXtQV76Hff/bFVTY2MhTbpsOimp0N0cgtI/GEf6nkGs3wdhPGYII8Mf809FO2j3zXnzF5Zw0UBnIOc0",
+	"UPfNIdrFUSQaiMR+hR7uWpXDKfZLwpinsKsqy4425ZQzoKiYbeMwHcaoz9kITVnCkSVXFUlrZgqTr+zi",
+	"BOqYDuFXeRPEPeB4Pc6gIFmWCZ15QrTQuSD9JDLmZNVK+GwM29/jDII/4fFxImXGFO0c+1dFjljMKXFX",
+	"tTx3apCzFIDUPckmxbyDEjzwBUT5egjDS3rTlJcc9pE28ahnP6fOqX0DtApcJBNFIR8hJMZFJyq41+k0",
+	"ZEVT57bbikc+1Adj7kV9RdLYZxfnhvfsnxNO99iE6oCnUzJInbMLp1uoT3lHiV7CKQrYhFrhTxe0iwbh",
+	"NaFpl9RoJvIYxcaNjCKc+drYcUIVcVT7NFg4iorQ4EFiqB5tcBfgVseziRRnVfygxhtHtbGuxwm+AjKQ",
+	"8ieW6pHyOFL7W73UHeVVcbi3gzSkRc4ww4FQYuauEhEZoRcQke7TPxUV8IbiNC5KFVFzxIl6z4wTeDGT",
+	"5zxWBz1nbgNu2psqHm+/26W5VmZJPi9SaE6Iz3jgVS9Bp2aZYZ98fU24elZUzhj0uxj5srVSJNWyCker",
+	"s/W1wyZzt0vKDb9AuGQJ9yUzfWVis3xknNPbdjHX8IXws5QDmgsDC+Uaa8264LOYgkKw8avDPfTknIZS",
+	"QYZzdK7GfUVuQp8NOB4P9ZP0KeMxvDekdif+tIDRF8+2/vhxa6t78K778pf99c7x7+3d37YPpD43xnFM",
+	"uJzy/39oN7e7P+/u7R+8+OXXl0fHb347OT17++79739c3nae3f3Lgf/b6pWN8I0xUzzbKFot7Flx83O7",
+	"uX35w5N/73xM/3j6vWO6SwcBHNIBETEJlrGddyVLUt216QPEPGYEWAjLV6oyRHwXzMDETLmIQX0BC3rw",
+	"9Szo2cpVkH0pl4VKNKRMJ0VZK8XLzJdV07c0lU1TJjUC0YaeBX2/oZdLgAU/HNfpVcsENTT/fKfM15CY",
+	"SKAhm4C3M459pRVkqZuUfalAKeazfiQ+P/JKpHio0j8oriV7y3HOcvvSSLOWWbT2r1YuV5n8wcQrCeBQ",
+	"xXMJTwn6aExVe6MTWImgdryjw+Pzs/3y7ubWMnuPActdq31R/Cnj3/rbsO40RWNZkUHnGltzraAWOm8r",
+	"X3vADBqzbDfrGTlz+1IlGWbDlHasSpE+xiMSwDPeGwz5GaUqBEHrEkhyIxViE1JjZ70TyiKRWcglf2qh",
+	"l2Qq0gh5fUtJ2vUZFaGIEaPRFOFoPMQ0gcRV8DWhAeHCZ1JzHWI5o9Th3Sr4DFosh6QHSybqrHmvzX0q",
+	"FzPv71J4diVIysh/XyR+gduzdPSLa3dQWpHQlBNDSl752/M7od73TPhk64Ke2Y10Z8bR6flRA3Xfvmig",
+	"o8PjBqDoqPseWaxFKB5MdRJCSHcG68gFWICvhbYKppEwB4yj8+PD3873P+6+Pj8+s4dt5MFWEGVZI9QU",
+	"LSSHKPXNEGBQKGEMB5Q57DgWVy1twySXJHCBNHs59y6Vk9bmxjaXy80y5y0FDq1oqTux7mMKGxOqon1Y",
+	"9t9r46vBmhoOAC5dAO5IJxvHmgVLdax89PX7hLpAYYO8hmfvtdfwum9feA15e8n/7b7PP3yrnvkdqUZG",
+	"N4fcVePlt4Tw6QkR4AzrwguHb5bHDIKkhC2XN8eHW5dwUBBEi1JelcB4rZyv1juGisAAVJUfUxOaMo24",
+	"n1Ck5A4JaCufWGI2d4LZYomRwbMkro8eI7UMHRapsEk54azB6+2qAutitrKkqCvidLCzlUJ8ihrHVc7Z",
+	"xJhE6p2lx0wwjZKNZa7MOSsqrub6KgRrK0N3lVfHWdmXQyFe+TLN8MqYK8xfG+dQ18N4ZmuzEL9qijZ2",
+	"4IcIZ1Gry09lL2aB2zw9HCu9vaq8I7oq9kdZHx1vMH1ngnM1mjZrqyTfyl8mi4GeYGFCJFvosG+eWXsR",
+	"WWlMccwqoSNpAvKvAlsxeYTK5R4zJ1t8w3iMI9CPXXskNRWpmiCICo2U2aFor4giNgHHAvVwKsCD29ZQ",
+	"LhuejljsxtVrU0kYAquUQ5qUoeoY6gy2MzS7SjOXWrHHRh/V0j4edunexpvxu3edbucdfz7a/rP/mfwS",
+	"vXj//Ga0+37yojXd+rR52uy++3SQPPv0Zx8ffG5//u3T5v7nzvMTQadvJ7/2+++3Pt0cXTOHIaSMpNuK",
+	"p/AGCvtpVmtQEfPJu1XVmTQSVY9s70kZ/dUp6UchPVQf1wviQsNT2q3+LNnrXW4jbx8q7UVKCbc1HMlz",
+	"uTuWY9xzAQqDYjmUexkTsluwZjLtlF7dGTGvCJXaJdBKmgVeKr5yr0KWP7APRfKL2lsrffckV1omt2YX",
+	"6W5oDzLDCZ3SET05OdhFPz5v//i0dUEtx5fshBYSSeYz26ERnoL9QPkWFDUqk4hzZk7J1WUZ/8tkzfyW",
+	"RvJbGsm/chpJp6B8Cr0Me1qpoFwM0SyhM21guxPTcuxeQfCg/pC5Xq8owrwXxlzuv2ok+QHUylA6cHE2",
+	"WgxSniUeS6rk1zhaMDB1nyajsiO4GathVuO6M2aEKz9KVOpqI2OTJQny5gRW3h/KJijmCfVt//ohS/hX",
+	"34ca6IcBSph6Ba8e4PjYNBKuwonImepTF+wMdarKFsQHBUkU0gF4AO51f99B8M/+NeFTFODpBX23v/9y",
+	"x/pxQsjVBQWf9J3sV3Blv6C/73dP7MZTgnnOv30Rx/aGV3Ky3nFkddDutnY2Dk7U4716BhHEfIWEP7mk",
+	"AmM21uk89LWj88XYVX9ApplIyYVWpIDIifF1srEZAO38M62Hy3ynKwMuCZ/u/YDwhU4GjQOQwd1FJFeb",
+	"sjAZB/fYQEi+oodoPWBUQymeJ6M7ewn2fruYi1W4bxGPHTvHKK6sjJQI9WjoSLeepoMwTC0zy3aKGMq1",
+	"nGmdbXhBKMYRNiljd7Xqh46Vu858qwbEIRTD06yggGHSE2Om8petdzY2t54p6ZaHY2Jmg49+Ij5mgnJZ",
+	"vygvv6xjd2rRylw7rQt/y1oY5kek2htgz1Lci5oxpasyDegAk9pmgfmRIGoii6LdtDHfdF8ingKYNh3N",
+	"xZsjgsB17mdVyLPeW02VFBF+JvbTr37+a9gxarkX3rRBjUfed3bhuxXK/WpcEuQrwri5+kS3rVUMJuGy",
+	"MZ05YEV0hcs3uL6ndUWsh+M50qxn2UW/zixeAnE2UdKU6iAy8ztXl54VxVdrMc4aPa4qngW6ladFyq1h",
+	"PIWMCmo/IGR6l7GrkHQTSSm3ruQMEIQ2IT2Ex2PkQ2tTsS/9S9fs+/hRKL8bq8LKOHxJALMwmGXcN1P2",
+	"COaEHximycb4E7wfuUBxGv9NNUMwCMFg2fTDOB6nky89rcRA7anmL/HPSew5yvCUVyaJXp7SppaTsmjj",
+	"OVDc6RoxnOJoj/kOmX+P+Yk8A8Y7JOGR7i121jLW0ArZWiAHAMWtz1xvBIQeWV6ngDCKIfBDubCnSXW1",
+	"D7D2q8o6SvTCm4FAU5aojMQDImLtjNpQb936+RXGVD5XSpdIxUjRuqDNZvOCfv96TLh2w0pTcv73f/8H",
+	"PQHonkotV3Fpqcsol7c07WdILchg+1vfwwGNQp/oOmGa3Ltj7A8J6oD3coZAXdITw1co6qm7irVXh7v7",
+	"x6f7zU6r3RrGo8gykXk5fHgNL+ce3WpDBMiYUDwOvR1vo9VubSj39yHs7hoeh2vX62uWwUA9s7vyxIHS",
+	"a7eUVxQzSIN7WDbZt8eSc3GsXnoq805lTdasOsJVYcDF1rqUbzkt1WseEK5iMEkUVBXwlY0KJZGz2qa2",
+	"lG8uY7fk7wgOvywUDu202zPKxZkycY5S2jVzdTlYerkGpDZc5LfxruFttterpkoXsTarMCBMpfE2f5yq",
+	"cnqqNiwYc10UJzkWVg+zNpmhJ/s38ooH1hQ99S7lMCltX8+n6rxLpzr/EGQJWifH1Ny3DnK/Xp7Qofh5",
+	"XTo/Yw4at+pVK8jvV1p7VmXtOYW170vttgvbUjEmf8GkTRBKtOBapaZjhbMnsb3Y7fVOsB48/7HZ3sZB",
+	"c7Pn+0289WPQ3OptbG11Nrc3SNB56MV2qhZb1/kvH9y0CFNTR0CKzgHpJYNBSAeaubXnM6Xqus6Pmj0W",
+	"WJfNIdUPl3cNb8yEK5cIdBVZaibGUQ+ie2xkShFLuaDPSJfk4o5q+JQ/6ueun1kwncEYrHQ1P5SZRI3Y",
+	"qrtG1XhNWNsPs1nP3z1N3N+fz9RlM7XZSxYq5Tgfqdqh9RNN5ajgY2AfHMvfAGI8pELBMTxeVzQTevCq",
+	"UUb5jFvFk1qZIVGd2nyJ/LvSPb5Z5hynCeRz7CdRNE050N+Z1R7aqqWLx1oCp85DMkfkNK2q5MoDM8pf",
+	"XIWCQ2x0pxlPJ67sWuULC1KVpimvMiRWgBaqDl3d3g2ifnMpeuR9Gf3NpANbQMzJFv2oBZN+RsD1dLYq",
+	"MUV5QIhi9uv8kVGNDDbrShuLSRjOZGXu+8LKmqXIvVWD0a6vGlIXdAcmI5N5+n40THurzhjHLD6Uwpok",
+	"my9DzGq7zY4uY4EwJ2HtNi2AeKfIPCKxM02l/N3KCdeboisydZG9apqR/WJXRVaP0cHsHNe+oZ3ULWFF",
+	"O7+pJpu78wcsoV9kz/UOLLrnDfd9/4LE9laGgWsnX5D4Qbax/SWZCmTJ+PuShbWRy/ABlVJptliIoyiX",
+	"eqksGKqyan91sdD2mVlaOpyzCC39qcO8gsOxqEFeVbFdQLLTG/+45bqBob8l6X/tVifKmnkHvmVhgJ6o",
+	"r0/TbMOoawrbYaqe4HrpbYTCPgqhugP9TmrdkFaGOHmtHFxtzqKnyOT4qndfwhxQbwLAUeVfH5HEdV8G",
+	"u9nent9/l9F+FPrxF7y3NbksQ6OGFGbxaNXG/fp5pPqv8DHk66RRqhGRuJJESwtlBFiEl5pNetS8dGSo",
+	"xdCpJp9qZfj77hyfg+91EU+HB0jDhFziTP+zigxYeb/6YUTkYBe6kr7JH1CteZs8Kg+hd+u9d2vaOpHx",
+	"qvXsr57H7EsdwMZ9N2H3myGh3on/7//+D9LHaaRPS+nYl26itVv4f5N7c6bMNJc3XND0glTHpjdFh3uQ",
+	"cj5KBtX2BXO4F5OVcoDXlJgUwHn7wv1klEdMDHozKolhhjnBsX0ui8IDbVz7GwNdIQNVNG+bTh6h2WN5",
+	"jqVsCZUS9W+Wl2Y/LVFSImZothJybjycb1adpnbOp4W6nIUj8gej9bupohYm5GixXrouRu1eaft7M4t/",
+	"bGa3BbiInUQP/PbJTbzmi+sKJVLP+BGyDTX0H4QGDY2wBuC3IfHZAFxdUNeyGoUf1+FHg+qP6w1rexrg",
+	"EtNY75SGWs8PpVDTmT9Up10aquMaaiM/VCc3lHJjaWw6guxLbBmy7Kossn9jxwaL/S7H3TUNzTGZmFZ2",
+	"zf4ZBpRTM+hXEV1cdpgCS8noa3ZWorrWCoOfFZHaA1orUlDnkIuKSMlTzTLyQCF4R9efJzQYs1DV4h8n",
+	"vSj0oykiN2OmqkLHLO0nKmQJFXBTIVEskaEZnkAgdC59AclKMBVtEg0nm55dBumfJrh8YRHk2/X77fr9",
+	"YtevjqoEXlOK/PtwKUneHfj44VKSd/H61tF/xVtc9XayZePmW8GEa1iS4EZwRlZWvlxbqxHzeG4W2JIb",
+	"OotvaaE9tRnyCuhstRaPd+lsFSobfcFol1pvHnZOywVkifxefDPL1rDEAepyeHMdo9kOiqp4ijvLqOvF",
+	"xN7dRd9NFs1a6taMayudOUJ0P8PkApAXeo1Z3eU8B8zH91DxUL6KhTj32vfBmq48hNXrwpIvkBf0MB1G",
+	"VFwRlulakaY7gMgMU7g5ljosQG7ZkAhHkSskyv5eZKVZEu47KMKVtoXVzB4tf0Kggz3gXHN1ecbKJOSz",
+	"FqEVcIN1G4IKJnGXYxP53Byu7FE1Fl2/Sv5iS5lbjbrMFCB7HVTn43aWpTRLcQPm1ROaVMXZMQlaywXQ",
+	"vMktJDfet/t6/n1tkcXcW9tidnNtVXXl3tRcUyHpWvarhxcTMwv/suamR3iTpVKZw9yUYvcebjIX9Hws",
+	"CI+FxUGQiTRhXOeUE9b1pCvvGyYRMAKOhuQmFHFWe7+XRVaUukBTkWs7xjwOIR2i9nXNUo+kCTVVBkUX",
+	"qaklmP1f3vlm1WRmV8GIGUoAzNXLgqsGWzfV8H7jxfVOqSLCVBpxHlMHD1671f91GLzmL8l0ZZ4thvBS",
+	"CXNm6Ex2eBZ7aMgDX9O7xRBY3r/l7+AJ/Pi9bGbSZ2NpceAFiWtT3AsSPxy5rU6NTjlmNYf8m8f5SLKx",
+	"NnZ5nrZAYi2pZtitC9rNbEHzXjm3irT1+ANrvmW6qhs1XcgGP5+oVDcb1ythVat3CrdArBOQbSPhKwVl",
+	"5wi4DKX1+REGZ9831OdxB3eTHL0vHDRUj/+v3Vp/yRY6ahYapla4SpdfqROazLFQ0TEtLVMq91ASO6yV",
+	"vNWF9h76jqhcqyOe9A24crC+TvLOkD8k/pWqmbiD0oTYUgg7OdhFGxsb20jly05fAU2lCZ0W1/ESqFNq",
+	"ux7o71Ok7iElsdK21WBuutDk30azeBBv5npn6YuxglrZIPIXeWUeAdV8lRf4gme9pi5sX3f/lHwSy1wz",
+	"M4JAatFDnvs/BmJYjD/iKHrdr4TUrRwUn6kiLOITIkhFjREoIgIXjEo9PcECcdn8ISuKFF6mLudIhP+A",
+	"zBpfQwi7WzAph1Kg6DyRq5AHe8mUHfc+e4tr8o8z1ce3xB2rS9zhoOCV2Rp0co56Z0R1Wi4Nx2pupQc1",
+	"SsDC7OJ9FbK7QtnXN0lomi8DqZKYfEsXt5hFYekEJEteY8Os8kwtC4IpkDPLkqCSzpoqNJhLBdyPEhFe",
+	"E4RhuJDrEvaYBojclD4SGujUtSBj6fJGug6xGOEoIhzFQ6xyUFjVj2DAUOQn7LF4KIcU8+VcU4jna1y5",
+	"hScTwI+xbUApAXnaVXESq/McOwe8NIlyHU1JZ0mEeRin1W8TGhAeTUM6sJN2uO5tXVK/TmzKver4l3W/",
+	"4P4YcVh+dClSKDg6JBQNVo+ymHlfAEGn8gho2GD9+mjEDEFYrCqhqo9wb9pCu5jKlctTNWQ8NqdKhVFZ",
+	"C65e2MQuCzaDImaXJFsyZqkYKPSQRrWKOmVz9K9izS502DecUe6V7TKoaM/eoVCobctqndqF3i7oN2td",
+	"bWvd/HvrC1663NgU3GIxmByyWraakpSNQd5v+upElExMhTqkVMVcEWF58XIWRSRA7NqdgwlmslZ7rtNo",
+	"/HWk6rzBhvT7xI/Da1JVFhaYIo7RZBj6Q1MWViIbXxGBVPdGsQp1mqJftvRTjqkzYPUTnVv6zHa+A3O6",
+	"PMDLXyMruSMkZmMc0m5F7e7TIUuiwMKEaq7AAorTNbtVXW/tnCiZe1UTuWg1iPFlVInSZ7eHTVAIsjYR",
+	"9ktho5Rm3emkvYRLtc2ttfXuG1utYquKNS1lcSvEL6axiu4IRrtQpA5eJPzaHfMXMR8Cn3NF8dY7P7ba",
+	"rXZrfef58+fPHQI2VHiZUYtQfZcz6wU6pFGIJZfkG5kTropayJMsOXVaTkgTvqoD0bqgH14RzCkaMU4u",
+	"n1TWQVwbkFiO1QSOT4I1GGVNcvPrkEyewsHQcpiuKOEUmstggloe0oEqbQiyVMp97gGfZu9OAHWwf00A",
+	"dW7BXAh/bbBGjJI4/EzWAiyGPYZ5oOOVmgG5JpG8MZqDJAxIDkDt+V8TQMuVf0lkmRFyQKSOYjXByLkp",
+	"LY6gnJjipqsZp/ru8u7/AgAA//+QnyapF/IAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/client/node/schemas/openapi.ts
+++ b/api/client/node/schemas/openapi.ts
@@ -522,6 +522,7 @@ export interface components {
          */
         subjectKey: string
         usagePeriod?: components['schemas']['RecurringPeriod']
+        currentUsagePeriod?: components['schemas']['Period']
       }
     EntitlementMeteredCreateInputs: components['schemas']['EntitlementCreateSharedFields'] & {
       /**
@@ -554,7 +555,19 @@ export interface components {
       | components['schemas']['EntitlementBooleanCreateInputs']
     /** @description Entitles a subject to use a feature. */
     EntitlementMetered: components['schemas']['EntitlementMeteredCreateInputs'] &
+      components['schemas']['EntitlementMeteredCalculatedFields'] &
       components['schemas']['EntitlementSharedFields']
+    /** @description Calculated fields for a metered entitlement. */
+    EntitlementMeteredCalculatedFields: {
+      /**
+       * Format: date-time
+       * @description The last time the meter was reset.
+       *
+       * @example 2023-01-01T00:00:00Z
+       */
+      lastReset: string
+      currentUsagePeriod: components['schemas']['Period']
+    }
     EntitlementStaticCreateInputs: components['schemas']['EntitlementCreateSharedFields'] & {
       /**
        * @example static
@@ -2030,6 +2043,12 @@ export interface operations {
            * @example 2023-01-01T00:00:00Z
            */
           effectiveAt?: string
+          /**
+           * @description Should the reset retain the usage period anchor.
+           * If true, the usage period anchor is retained.
+           * If false, the usage period anchor is reset to the effectiveAt time.
+           */
+          retainAnchor?: boolean
         }
       }
     }

--- a/api/client/python/src/openmeter/_operations/_operations.py
+++ b/api/client/python/src/openmeter/_operations/_operations.py
@@ -4486,9 +4486,12 @@ class ClientOperationsMixin(ClientMixinABC):  # pylint: disable=too-many-public-
 
                 # JSON input template you can fill out and use as your body input.
                 body = {
-                    "effectiveAt": "2020-02-20 00:00:00"  # Optional. The time at which the reset
-                      takes effect, defaults to now. The reset cannot be in the future. The provided
-                      value is truncated to the granularity of the underlying meter.
+                    "effectiveAt": "2020-02-20 00:00:00",  # Optional. The time at which the
+                      reset takes effect, defaults to now. The reset cannot be in the future. The
+                      provided value is truncated to the granularity of the underlying meter.
+                    "retainAnchor": bool  # Optional. Should the reset retain the usage period
+                      anchor. If true, the usage period anchor is retained. If false, the usage period
+                      anchor is reset to the effectiveAt time.
                 }
         """
 
@@ -4544,9 +4547,12 @@ class ClientOperationsMixin(ClientMixinABC):  # pylint: disable=too-many-public-
 
                 # JSON input template you can fill out and use as your body input.
                 body = {
-                    "effectiveAt": "2020-02-20 00:00:00"  # Optional. The time at which the reset
-                      takes effect, defaults to now. The reset cannot be in the future. The provided
-                      value is truncated to the granularity of the underlying meter.
+                    "effectiveAt": "2020-02-20 00:00:00",  # Optional. The time at which the
+                      reset takes effect, defaults to now. The reset cannot be in the future. The
+                      provided value is truncated to the granularity of the underlying meter.
+                    "retainAnchor": bool  # Optional. Should the reset retain the usage period
+                      anchor. If true, the usage period anchor is retained. If false, the usage period
+                      anchor is reset to the effectiveAt time.
                 }
         """
         error_map = {

--- a/api/client/python/src/openmeter/aio/_operations/_operations.py
+++ b/api/client/python/src/openmeter/aio/_operations/_operations.py
@@ -3785,9 +3785,12 @@ class ClientOperationsMixin(ClientMixinABC):  # pylint: disable=too-many-public-
 
                 # JSON input template you can fill out and use as your body input.
                 body = {
-                    "effectiveAt": "2020-02-20 00:00:00"  # Optional. The time at which the reset
-                      takes effect, defaults to now. The reset cannot be in the future. The provided
-                      value is truncated to the granularity of the underlying meter.
+                    "effectiveAt": "2020-02-20 00:00:00",  # Optional. The time at which the
+                      reset takes effect, defaults to now. The reset cannot be in the future. The
+                      provided value is truncated to the granularity of the underlying meter.
+                    "retainAnchor": bool  # Optional. Should the reset retain the usage period
+                      anchor. If true, the usage period anchor is retained. If false, the usage period
+                      anchor is reset to the effectiveAt time.
                 }
         """
 
@@ -3843,9 +3846,12 @@ class ClientOperationsMixin(ClientMixinABC):  # pylint: disable=too-many-public-
 
                 # JSON input template you can fill out and use as your body input.
                 body = {
-                    "effectiveAt": "2020-02-20 00:00:00"  # Optional. The time at which the reset
-                      takes effect, defaults to now. The reset cannot be in the future. The provided
-                      value is truncated to the granularity of the underlying meter.
+                    "effectiveAt": "2020-02-20 00:00:00",  # Optional. The time at which the
+                      reset takes effect, defaults to now. The reset cannot be in the future. The
+                      provided value is truncated to the granularity of the underlying meter.
+                    "retainAnchor": bool  # Optional. Should the reset retain the usage period
+                      anchor. If true, the usage period anchor is retained. If false, the usage period
+                      anchor is reset to the effectiveAt time.
                 }
         """
         error_map = {

--- a/api/client/web/src/client/openapi.ts
+++ b/api/client/web/src/client/openapi.ts
@@ -522,6 +522,7 @@ export interface components {
          */
         subjectKey: string
         usagePeriod?: components['schemas']['RecurringPeriod']
+        currentUsagePeriod?: components['schemas']['Period']
       }
     EntitlementMeteredCreateInputs: components['schemas']['EntitlementCreateSharedFields'] & {
       /**
@@ -554,7 +555,19 @@ export interface components {
       | components['schemas']['EntitlementBooleanCreateInputs']
     /** @description Entitles a subject to use a feature. */
     EntitlementMetered: components['schemas']['EntitlementMeteredCreateInputs'] &
+      components['schemas']['EntitlementMeteredCalculatedFields'] &
       components['schemas']['EntitlementSharedFields']
+    /** @description Calculated fields for a metered entitlement. */
+    EntitlementMeteredCalculatedFields: {
+      /**
+       * Format: date-time
+       * @description The last time the meter was reset.
+       *
+       * @example 2023-01-01T00:00:00Z
+       */
+      lastReset: string
+      currentUsagePeriod: components['schemas']['Period']
+    }
     EntitlementStaticCreateInputs: components['schemas']['EntitlementCreateSharedFields'] & {
       /**
        * @example static
@@ -2030,6 +2043,12 @@ export interface operations {
            * @example 2023-01-01T00:00:00Z
            */
           effectiveAt?: string
+          /**
+           * @description Should the reset retain the usage period anchor.
+           * If true, the usage period anchor is retained.
+           * If false, the usage period anchor is reset to the effectiveAt time.
+           */
+          retainAnchor?: boolean
         }
       }
     }

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1139,6 +1139,12 @@ paths:
                     The reset cannot be in the future.
                     The provided value is truncated to the granularity of the underlying meter.
                   example: "2023-01-01T00:00:00Z"
+                retainAnchor:
+                  type: boolean
+                  description: |
+                    Should the reset retain the usage period anchor.
+                    If true, the usage period anchor is retained.
+                    If false, the usage period anchor is reset to the effectiveAt time.
       responses:
         "204":
           description: Entitlement reset.
@@ -1478,6 +1484,8 @@ components:
               example: customer-1
             usagePeriod:
               $ref: "#/components/schemas/RecurringPeriod"
+            currentUsagePeriod:
+              $ref: "#/components/schemas/Period"
     EntitlementMeteredCreateInputs:
       allOf:
         - $ref: "#/components/schemas/EntitlementCreateSharedFields"
@@ -1529,7 +1537,23 @@ components:
         Entitles a subject to use a feature.
       allOf:
         - $ref: "#/components/schemas/EntitlementMeteredCreateInputs"
+        - $ref: "#/components/schemas/EntitlementMeteredCalculatedFields"
         - $ref: "#/components/schemas/EntitlementSharedFields"
+    EntitlementMeteredCalculatedFields:
+      type: object
+      description: Calculated fields for a metered entitlement.
+      required:
+        - lastReset
+        - currentUsagePeriod
+      properties:
+        lastReset:
+          description: |
+            The last time the meter was reset.
+          type: string
+          format: date-time
+          example: "2023-01-01T00:00:00Z"
+        currentUsagePeriod:
+          $ref: "#/components/schemas/Period"
     EntitlementStaticCreateInputs:
       allOf:
         - $ref: "#/components/schemas/EntitlementCreateSharedFields"

--- a/internal/credit/engine_test.go
+++ b/internal/credit/engine_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/internal/credit"
 	"github.com/openmeterio/openmeter/internal/streaming"
 	"github.com/openmeterio/openmeter/internal/streaming/testutils"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
 )
 
 func TestEngine(t *testing.T) {
@@ -517,8 +518,8 @@ func TestEngine(t *testing.T) {
 				use(120, t1.Add(time.Hour))
 				g1 := grant1
 				g1.EffectiveAt = t1
-				g1.Recurrence = &credit.Recurrence{
-					Period: credit.RecurrencePeriodDaily,
+				g1.Recurrence = &recurrence.Recurrence{
+					Period: recurrence.RecurrencePeriodDaily,
 					Anchor: t1,
 				}
 				g1 = makeGrant(g1)
@@ -561,8 +562,8 @@ func TestEngine(t *testing.T) {
 				g2 := grant2
 				g2.EffectiveAt = tg2
 				g2.Priority = 1
-				g2.Recurrence = &credit.Recurrence{
-					Period: credit.RecurrencePeriodWeek,
+				g2.Recurrence = &recurrence.Recurrence{
+					Period: recurrence.RecurrencePeriodWeek,
 					Anchor: tg2r,
 				}
 				g2 = makeGrant(g2)
@@ -608,8 +609,8 @@ func TestEngine(t *testing.T) {
 				g2 := grant2
 				g2.EffectiveAt = tg2
 				g2.Priority = 1
-				g2.Recurrence = &credit.Recurrence{
-					Period: credit.RecurrencePeriodWeek,
+				g2.Recurrence = &recurrence.Recurrence{
+					Period: recurrence.RecurrencePeriodWeek,
 					Anchor: tg2r,
 				}
 				g2 = makeGrant(g2)
@@ -662,8 +663,8 @@ func TestEngine(t *testing.T) {
 				// so they dont expire
 				g2.Expiration.Count = 2
 				g2.Expiration.Duration = credit.ExpirationPeriodDurationMonth
-				g2.Recurrence = &credit.Recurrence{
-					Period: credit.RecurrencePeriodWeek,
+				g2.Recurrence = &recurrence.Recurrence{
+					Period: recurrence.RecurrencePeriodWeek,
 					Anchor: tg2r,
 				}
 				g2 = makeGrant(g2)
@@ -829,8 +830,8 @@ func TestEngine(t *testing.T) {
 					}
 
 					if gofakeit.Bool() {
-						grant.Recurrence = &credit.Recurrence{
-							Period: credit.RecurrencePeriodDaily,
+						grant.Recurrence = &recurrence.Recurrence{
+							Period: recurrence.RecurrencePeriodDaily,
 							Anchor: gofakeit.DateRange(start, end).Truncate(granularity),
 						}
 					}
@@ -909,8 +910,8 @@ func TestEngine(t *testing.T) {
 					}
 
 					if gofakeit.Bool() {
-						grant.Recurrence = &credit.Recurrence{
-							Period: credit.RecurrencePeriodDaily,
+						grant.Recurrence = &recurrence.Recurrence{
+							Period: recurrence.RecurrencePeriodDaily,
 							Anchor: gofakeit.DateRange(start, end).Truncate(granularity),
 						}
 					}

--- a/internal/credit/grant.go
+++ b/internal/credit/grant.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
 )
 
 type GrantOwner string
@@ -59,7 +60,7 @@ type Grant struct {
 	ResetMaxRollover float64 `json:"resetMaxRollover"`
 
 	// Recurrence config for the grant. If nil the grant doesn't recur.
-	Recurrence *Recurrence `json:"recurrence,omitempty"`
+	Recurrence *recurrence.Recurrence `json:"recurrence,omitempty"`
 }
 
 // Calculates expiration from effectiveAt and Expiration.

--- a/internal/credit/grant_connector.go
+++ b/internal/credit/grant_connector.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
 )
 
 type CreateGrantInput struct {
@@ -16,7 +17,7 @@ type CreateGrantInput struct {
 	Expiration       ExpirationPeriod
 	Metadata         map[string]string
 	ResetMaxRollover float64
-	Recurrence       *Recurrence
+	Recurrence       *recurrence.Recurrence
 }
 
 type GrantConnector interface {
@@ -56,7 +57,7 @@ type GrantRepoCreateGrantInput struct {
 	ExpiresAt        time.Time
 	Metadata         map[string]string
 	ResetMaxRollover float64
-	Recurrence       *Recurrence
+	Recurrence       *recurrence.Recurrence
 }
 
 type GrantRepo interface {

--- a/internal/credit/owner_connector.go
+++ b/internal/credit/owner_connector.go
@@ -9,15 +9,19 @@ import (
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 )
 
+type EndCurrentUsagePeriodParams struct {
+	At           time.Time
+	RetainAnchor bool
+}
+
 type OwnerConnector interface {
 	GetOwnerQueryParams(ctx context.Context, owner NamespacedGrantOwner) (meterSlug string, defaultParams *streaming.QueryParams, err error)
 	GetStartOfMeasurement(ctx context.Context, owner NamespacedGrantOwner) (time.Time, error)
 	GetPeriodStartTimesBetween(ctx context.Context, owner NamespacedGrantOwner, from, to time.Time) ([]time.Time, error)
 	GetUsagePeriodStartAt(ctx context.Context, owner NamespacedGrantOwner, at time.Time) (time.Time, error)
-	EndCurrentUsagePeriod(ctx context.Context, owner NamespacedGrantOwner, at time.Time) error
 
 	//FIXME: this is a terrible hack
-	EndCurrentUsagePeriodTx(ctx context.Context, tx *entutils.TxDriver, owner NamespacedGrantOwner, at time.Time) error
+	EndCurrentUsagePeriodTx(ctx context.Context, tx *entutils.TxDriver, owner NamespacedGrantOwner, params EndCurrentUsagePeriodParams) error
 	//FIXME: this is a terrible hack
 	LockOwnerForTx(ctx context.Context, tx *entutils.TxDriver, owner NamespacedGrantOwner) error
 }

--- a/internal/credit/postgresadapter/ent/db/grant.go
+++ b/internal/credit/postgresadapter/ent/db/grant.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/openmeterio/openmeter/internal/credit"
 	"github.com/openmeterio/openmeter/internal/credit/postgresadapter/ent/db/grant"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
 )
 
 // Grant is the model entity for the Grant schema.
@@ -46,7 +47,7 @@ type Grant struct {
 	// ResetMaxRollover holds the value of the "reset_max_rollover" field.
 	ResetMaxRollover float64 `json:"reset_max_rollover,omitempty"`
 	// RecurrencePeriod holds the value of the "recurrence_period" field.
-	RecurrencePeriod *credit.RecurrencePeriod `json:"recurrence_period,omitempty"`
+	RecurrencePeriod *recurrence.RecurrencePeriod `json:"recurrence_period,omitempty"`
 	// RecurrenceAnchor holds the value of the "recurrence_anchor" field.
 	RecurrenceAnchor *time.Time `json:"recurrence_anchor,omitempty"`
 	selectValues     sql.SelectValues
@@ -176,8 +177,8 @@ func (gr *Grant) assignValues(columns []string, values []any) error {
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field recurrence_period", values[i])
 			} else if value.Valid {
-				gr.RecurrencePeriod = new(credit.RecurrencePeriod)
-				*gr.RecurrencePeriod = credit.RecurrencePeriod(value.String)
+				gr.RecurrencePeriod = new(recurrence.RecurrencePeriod)
+				*gr.RecurrencePeriod = recurrence.RecurrencePeriod(value.String)
 			}
 		case grant.FieldRecurrenceAnchor:
 			if value, ok := values[i].(*sql.NullTime); !ok {

--- a/internal/credit/postgresadapter/ent/db/grant/grant.go
+++ b/internal/credit/postgresadapter/ent/db/grant/grant.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"entgo.io/ent/dialect/sql"
-	"github.com/openmeterio/openmeter/internal/credit"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
 )
 
 const (
@@ -95,7 +95,7 @@ var (
 )
 
 // RecurrencePeriodValidator is a validator for the "recurrence_period" field enum values. It is called by the builders before save.
-func RecurrencePeriodValidator(rp credit.RecurrencePeriod) error {
+func RecurrencePeriodValidator(rp recurrence.RecurrencePeriod) error {
 	switch rp {
 	case "DAY", "WEEK", "MONTH", "YEAR":
 		return nil

--- a/internal/credit/postgresadapter/ent/db/grant/where.go
+++ b/internal/credit/postgresadapter/ent/db/grant/where.go
@@ -8,6 +8,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/openmeterio/openmeter/internal/credit"
 	"github.com/openmeterio/openmeter/internal/credit/postgresadapter/ent/db/predicate"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
 )
 
 // ID filters vertices based on their ID field.
@@ -666,19 +667,19 @@ func ResetMaxRolloverLTE(v float64) predicate.Grant {
 }
 
 // RecurrencePeriodEQ applies the EQ predicate on the "recurrence_period" field.
-func RecurrencePeriodEQ(v credit.RecurrencePeriod) predicate.Grant {
+func RecurrencePeriodEQ(v recurrence.RecurrencePeriod) predicate.Grant {
 	vc := v
 	return predicate.Grant(sql.FieldEQ(FieldRecurrencePeriod, vc))
 }
 
 // RecurrencePeriodNEQ applies the NEQ predicate on the "recurrence_period" field.
-func RecurrencePeriodNEQ(v credit.RecurrencePeriod) predicate.Grant {
+func RecurrencePeriodNEQ(v recurrence.RecurrencePeriod) predicate.Grant {
 	vc := v
 	return predicate.Grant(sql.FieldNEQ(FieldRecurrencePeriod, vc))
 }
 
 // RecurrencePeriodIn applies the In predicate on the "recurrence_period" field.
-func RecurrencePeriodIn(vs ...credit.RecurrencePeriod) predicate.Grant {
+func RecurrencePeriodIn(vs ...recurrence.RecurrencePeriod) predicate.Grant {
 	v := make([]any, len(vs))
 	for i := range v {
 		v[i] = vs[i]
@@ -687,7 +688,7 @@ func RecurrencePeriodIn(vs ...credit.RecurrencePeriod) predicate.Grant {
 }
 
 // RecurrencePeriodNotIn applies the NotIn predicate on the "recurrence_period" field.
-func RecurrencePeriodNotIn(vs ...credit.RecurrencePeriod) predicate.Grant {
+func RecurrencePeriodNotIn(vs ...recurrence.RecurrencePeriod) predicate.Grant {
 	v := make([]any, len(vs))
 	for i := range v {
 		v[i] = vs[i]

--- a/internal/credit/postgresadapter/ent/db/grant_create.go
+++ b/internal/credit/postgresadapter/ent/db/grant_create.go
@@ -14,6 +14,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/openmeterio/openmeter/internal/credit"
 	"github.com/openmeterio/openmeter/internal/credit/postgresadapter/ent/db/grant"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
 )
 
 // GrantCreate is the builder for creating a Grant entity.
@@ -143,15 +144,15 @@ func (gc *GrantCreate) SetResetMaxRollover(f float64) *GrantCreate {
 }
 
 // SetRecurrencePeriod sets the "recurrence_period" field.
-func (gc *GrantCreate) SetRecurrencePeriod(cp credit.RecurrencePeriod) *GrantCreate {
-	gc.mutation.SetRecurrencePeriod(cp)
+func (gc *GrantCreate) SetRecurrencePeriod(rp recurrence.RecurrencePeriod) *GrantCreate {
+	gc.mutation.SetRecurrencePeriod(rp)
 	return gc
 }
 
 // SetNillableRecurrencePeriod sets the "recurrence_period" field if the given value is not nil.
-func (gc *GrantCreate) SetNillableRecurrencePeriod(cp *credit.RecurrencePeriod) *GrantCreate {
-	if cp != nil {
-		gc.SetRecurrencePeriod(*cp)
+func (gc *GrantCreate) SetNillableRecurrencePeriod(rp *recurrence.RecurrencePeriod) *GrantCreate {
+	if rp != nil {
+		gc.SetRecurrencePeriod(*rp)
 	}
 	return gc
 }

--- a/internal/credit/postgresadapter/ent/db/mutation.go
+++ b/internal/credit/postgresadapter/ent/db/mutation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/internal/credit/postgresadapter/ent/db/balancesnapshot"
 	"github.com/openmeterio/openmeter/internal/credit/postgresadapter/ent/db/grant"
 	"github.com/openmeterio/openmeter/internal/credit/postgresadapter/ent/db/predicate"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
 )
 
 const (
@@ -901,7 +902,7 @@ type GrantMutation struct {
 	voided_at             *time.Time
 	reset_max_rollover    *float64
 	addreset_max_rollover *float64
-	recurrence_period     *credit.RecurrencePeriod
+	recurrence_period     *recurrence.RecurrencePeriod
 	recurrence_anchor     *time.Time
 	clearedFields         map[string]struct{}
 	done                  bool
@@ -1581,12 +1582,12 @@ func (m *GrantMutation) ResetResetMaxRollover() {
 }
 
 // SetRecurrencePeriod sets the "recurrence_period" field.
-func (m *GrantMutation) SetRecurrencePeriod(cp credit.RecurrencePeriod) {
-	m.recurrence_period = &cp
+func (m *GrantMutation) SetRecurrencePeriod(rp recurrence.RecurrencePeriod) {
+	m.recurrence_period = &rp
 }
 
 // RecurrencePeriod returns the value of the "recurrence_period" field in the mutation.
-func (m *GrantMutation) RecurrencePeriod() (r credit.RecurrencePeriod, exists bool) {
+func (m *GrantMutation) RecurrencePeriod() (r recurrence.RecurrencePeriod, exists bool) {
 	v := m.recurrence_period
 	if v == nil {
 		return
@@ -1597,7 +1598,7 @@ func (m *GrantMutation) RecurrencePeriod() (r credit.RecurrencePeriod, exists bo
 // OldRecurrencePeriod returns the old "recurrence_period" field's value of the Grant entity.
 // If the Grant object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *GrantMutation) OldRecurrencePeriod(ctx context.Context) (v *credit.RecurrencePeriod, err error) {
+func (m *GrantMutation) OldRecurrencePeriod(ctx context.Context) (v *recurrence.RecurrencePeriod, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldRecurrencePeriod is only allowed on UpdateOne operations")
 	}
@@ -1936,7 +1937,7 @@ func (m *GrantMutation) SetField(name string, value ent.Value) error {
 		m.SetResetMaxRollover(v)
 		return nil
 	case grant.FieldRecurrencePeriod:
-		v, ok := value.(credit.RecurrencePeriod)
+		v, ok := value.(recurrence.RecurrencePeriod)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}

--- a/internal/credit/postgresadapter/ent/schema/grant.go
+++ b/internal/credit/postgresadapter/ent/schema/grant.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openmeterio/openmeter/internal/credit"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
 )
 
 type Grant struct {
@@ -41,7 +42,7 @@ func (Grant) Fields() []ent.Field {
 		field.Float("reset_max_rollover").Immutable().SchemaType(map[string]string{
 			dialect.Postgres: "numeric",
 		}),
-		field.Enum("recurrence_period").Optional().Nillable().GoType(credit.RecurrencePeriod("")).Immutable(),
+		field.Enum("recurrence_period").Optional().Nillable().GoType(recurrence.RecurrencePeriod("")).Immutable(),
 		field.Time("recurrence_anchor").Optional().Nillable().Immutable(),
 	}
 }

--- a/internal/credit/postgresadapter/grant.go
+++ b/internal/credit/postgresadapter/grant.go
@@ -9,6 +9,7 @@ import (
 	db_grant "github.com/openmeterio/openmeter/internal/credit/postgresadapter/ent/db/grant"
 	"github.com/openmeterio/openmeter/pkg/convert"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
 )
 
 type grantDBADapter struct {
@@ -168,9 +169,9 @@ func mapGrantEntity(entity *db.Grant) credit.Grant {
 	}
 
 	if entity.RecurrencePeriod != nil && entity.RecurrenceAnchor != nil {
-		g.Recurrence = &credit.Recurrence{
+		g.Recurrence = &recurrence.Recurrence{
 			Period: *entity.RecurrencePeriod,
-			Anchor: *convert.SafeToUTC(entity.RecurrenceAnchor),
+			Anchor: entity.RecurrenceAnchor.In(time.UTC),
 		}
 	}
 

--- a/internal/entitlement/httpdriver/metered.go
+++ b/internal/entitlement/httpdriver/metered.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
 )
 
 type MeteredEntitlementHandler interface {
@@ -105,8 +106,8 @@ func (h *meteredEntitlementHandler) CreateGrant() CreateGrantHandler {
 			}
 
 			if apiGrant.Recurrence != nil {
-				inp.inp.Recurrence = &credit.Recurrence{
-					Period: credit.RecurrencePeriod(apiGrant.Recurrence.Interval),
+				inp.inp.Recurrence = &recurrence.Recurrence{
+					Period: recurrence.RecurrencePeriod(apiGrant.Recurrence.Interval),
 					Anchor: defaultx.WithDefault(apiGrant.Recurrence.Anchor, apiGrant.EffectiveAt),
 				}
 			}
@@ -219,6 +220,7 @@ type ResetEntitlementUsageHandlerRequest struct {
 	Namespace     string
 	SubjectID     string
 	At            time.Time
+	RetainAnchor  bool
 }
 type ResetEntitlementUsageHandlerResponse = interface{}
 type ResetEntitlementUsageHandlerParams struct {
@@ -246,13 +248,17 @@ func (h *meteredEntitlementHandler) ResetEntitlementUsage() ResetEntitlementUsag
 				Namespace:     ns,
 				SubjectID:     params.SubjectKey,
 				At:            defaultx.WithDefault(body.EffectiveAt, time.Now()),
+				RetainAnchor:  defaultx.WithDefault(body.RetainAnchor, false),
 			}, nil
 		},
 		func(ctx context.Context, request ResetEntitlementUsageHandlerRequest) (interface{}, error) {
 			_, err := h.balanceConnector.ResetEntitlementUsage(ctx, models.NamespacedID{
 				Namespace: request.Namespace,
 				ID:        request.EntitlementID,
-			}, request.At)
+			}, meteredentitlement.ResetEntitlementUsageParams{
+				At:           request.At,
+				RetainAnchor: request.RetainAnchor,
+			})
 			return nil, err
 		},
 		commonhttp.EmptyResponseEncoder[interface{}](http.StatusNoContent),

--- a/internal/entitlement/httpdriver/parser.go
+++ b/internal/entitlement/httpdriver/parser.go
@@ -22,20 +22,19 @@ func (parser) ToMetered(e *entitlement.Entitlement) (*api.EntitlementMetered, er
 	}
 
 	return &api.EntitlementMetered{
-		CreatedAt:       &metered.CreatedAt,
-		DeletedAt:       metered.DeletedAt,
-		FeatureId:       metered.FeatureID,
-		Id:              &metered.ID,
-		IsUnlimited:     convert.ToPointer(false), // implement
-		IssueAfterReset: metered.IssuesAfterReset,
-		Metadata:        &metered.Metadata,
-		SubjectKey:      metered.SubjectKey,
-		Type:            api.EntitlementMeteredType(metered.EntitlementType),
-		UpdatedAt:       &metered.UpdatedAt,
-		UsagePeriod: api.RecurringPeriod{
-			Anchor:   metered.UsagePeriod.Anchor,
-			Interval: api.RecurringPeriodEnum(metered.UsagePeriod.Interval),
-		},
+		CreatedAt:          &metered.CreatedAt,
+		DeletedAt:          metered.DeletedAt,
+		FeatureId:          metered.FeatureID,
+		Id:                 &metered.ID,
+		IsUnlimited:        convert.ToPointer(false), // implement
+		IssueAfterReset:    metered.IssuesAfterReset,
+		Metadata:           &metered.Metadata,
+		SubjectKey:         metered.SubjectKey,
+		Type:               api.EntitlementMeteredType(metered.EntitlementType),
+		UpdatedAt:          &metered.UpdatedAt,
+		UsagePeriod:        e.UsagePeriod.ToRecurringPeriod(),
+		CurrentUsagePeriod: *e.CurrentUsagePeriod,
+		LastReset:          metered.LastReset,
 	}, nil
 }
 
@@ -46,22 +45,20 @@ func (parser) ToStatic(e *entitlement.Entitlement) (*api.EntitlementStatic, erro
 	}
 
 	apiRes := &api.EntitlementStatic{
-		CreatedAt:  &static.CreatedAt,
-		DeletedAt:  static.DeletedAt,
-		FeatureId:  static.FeatureID,
-		Id:         &static.ID,
-		Metadata:   &static.Metadata,
-		SubjectKey: static.SubjectKey,
-		Type:       api.EntitlementStaticType(static.EntitlementType),
-		UpdatedAt:  &static.UpdatedAt,
-		Config:     static.Config,
+		CreatedAt:          &static.CreatedAt,
+		DeletedAt:          static.DeletedAt,
+		FeatureId:          static.FeatureID,
+		Id:                 &static.ID,
+		Metadata:           &static.Metadata,
+		SubjectKey:         static.SubjectKey,
+		Type:               api.EntitlementStaticType(static.EntitlementType),
+		UpdatedAt:          &static.UpdatedAt,
+		Config:             static.Config,
+		CurrentUsagePeriod: static.CurrentUsagePeriod,
 	}
 
 	if static.UsagePeriod != nil {
-		apiRes.UsagePeriod = &api.RecurringPeriod{
-			Anchor:   static.UsagePeriod.Anchor,
-			Interval: api.RecurringPeriodEnum(static.UsagePeriod.Interval),
-		}
+		apiRes.UsagePeriod = convert.ToPointer(static.UsagePeriod.ToRecurringPeriod())
 	}
 
 	return apiRes, nil
@@ -74,21 +71,24 @@ func (parser) ToBoolean(e *entitlement.Entitlement) (*api.EntitlementBoolean, er
 	}
 
 	apiRes := &api.EntitlementBoolean{
-		CreatedAt:  &boolean.CreatedAt,
-		DeletedAt:  boolean.DeletedAt,
-		FeatureId:  boolean.FeatureID,
-		Id:         &boolean.ID,
-		Metadata:   &boolean.Metadata,
-		SubjectKey: boolean.SubjectKey,
-		Type:       api.EntitlementBooleanType(boolean.EntitlementType),
-		UpdatedAt:  &boolean.UpdatedAt,
+		CreatedAt:          &boolean.CreatedAt,
+		DeletedAt:          boolean.DeletedAt,
+		FeatureId:          boolean.FeatureID,
+		Id:                 &boolean.ID,
+		Metadata:           &boolean.Metadata,
+		SubjectKey:         boolean.SubjectKey,
+		Type:               api.EntitlementBooleanType(boolean.EntitlementType),
+		UpdatedAt:          &boolean.UpdatedAt,
+		CurrentUsagePeriod: boolean.CurrentUsagePeriod,
 	}
 
 	if boolean.UsagePeriod != nil {
-		apiRes.UsagePeriod = &api.RecurringPeriod{
-			Anchor:   boolean.UsagePeriod.Anchor,
-			Interval: api.RecurringPeriodEnum(boolean.UsagePeriod.Interval),
+		apiRes.UsagePeriod = convert.ToPointer(boolean.UsagePeriod.ToRecurringPeriod())
+		currentPeriod, err := boolean.UsagePeriod.GetCurrentPeriod()
+		if err != nil {
+			return nil, err
 		}
+		apiRes.CurrentUsagePeriod = &currentPeriod
 	}
 
 	return apiRes, nil

--- a/internal/entitlement/metered/balance_test.go
+++ b/internal/entitlement/metered/balance_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/internal/credit"
 	credit_postgres_adapter "github.com/openmeterio/openmeter/internal/credit/postgresadapter"
 	credit_postgres_adapter_db "github.com/openmeterio/openmeter/internal/credit/postgresadapter/ent/db"
@@ -37,9 +38,9 @@ func TestGetEntitlementBalance(t *testing.T) {
 		MeterGroupByFilters: map[string]string{},
 	}
 
-	getEntitlement := func(t *testing.T, feature productcatalog.Feature) entitlement.CreateEntitlementInputs {
+	getEntitlement := func(t *testing.T, feature productcatalog.Feature) entitlement.CreateEntitlementRepoInputs {
 		t.Helper()
-		return entitlement.CreateEntitlementInputs{
+		input := entitlement.CreateEntitlementRepoInputs{
 			Namespace:        namespace,
 			FeatureID:        feature.ID,
 			MeasureUsageFrom: convert.ToPointer(testutils.GetRFC3339Time(t, "1024-03-01T00:00:00Z")), // old, override in tests
@@ -52,6 +53,11 @@ func TestGetEntitlementBalance(t *testing.T) {
 				Interval: entitlement.UsagePeriodIntervalYear,
 			},
 		}
+
+		currentUsagePeriod, err := input.UsagePeriod.GetCurrentPeriod()
+		assert.NoError(t, err)
+		input.CurrentUsagePeriod = &currentUsagePeriod
+		return input
 	}
 
 	tt := []struct {
@@ -132,7 +138,12 @@ func TestGetEntitlementBalance(t *testing.T) {
 
 				// reset (empty) entitlement
 				resetTime := startTime.Add(time.Hour * 5)
-				_, err = connector.ResetEntitlementUsage(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID}, resetTime)
+				_, err = connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime,
+					},
+				)
 				assert.NoError(t, err)
 
 				// usage on ledger that will be deducted
@@ -412,9 +423,9 @@ func TestGetEntitlementHistory(t *testing.T) {
 		MeterGroupByFilters: map[string]string{},
 	}
 
-	getEntitlement := func(t *testing.T, feature productcatalog.Feature) entitlement.CreateEntitlementInputs {
+	getEntitlement := func(t *testing.T, feature productcatalog.Feature) entitlement.CreateEntitlementRepoInputs {
 		t.Helper()
-		return entitlement.CreateEntitlementInputs{
+		input := entitlement.CreateEntitlementRepoInputs{
 			Namespace:        namespace,
 			FeatureID:        feature.ID,
 			MeasureUsageFrom: convert.ToPointer(testutils.GetRFC3339Time(t, "1024-03-01T00:00:00Z")), // old, override in tests
@@ -427,6 +438,11 @@ func TestGetEntitlementHistory(t *testing.T) {
 				Interval: entitlement.UsagePeriodIntervalYear,
 			},
 		}
+
+		currentUsagePeriod, err := input.UsagePeriod.GetCurrentPeriod()
+		assert.NoError(t, err)
+		input.CurrentUsagePeriod = &currentUsagePeriod
+		return input
 	}
 
 	tt := []struct {
@@ -556,9 +572,9 @@ func TestResetEntitlementUsage(t *testing.T) {
 		MeterGroupByFilters: map[string]string{},
 	}
 
-	getEntitlement := func(t *testing.T, feature productcatalog.Feature) entitlement.CreateEntitlementInputs {
+	getEntitlement := func(t *testing.T, feature productcatalog.Feature) entitlement.CreateEntitlementRepoInputs {
 		t.Helper()
-		return entitlement.CreateEntitlementInputs{
+		input := entitlement.CreateEntitlementRepoInputs{
 			Namespace:        namespace,
 			FeatureID:        feature.ID,
 			MeasureUsageFrom: convert.ToPointer(testutils.GetRFC3339Time(t, "1024-03-01T00:00:00Z")), // old, override in tests
@@ -571,6 +587,11 @@ func TestResetEntitlementUsage(t *testing.T) {
 				Interval: entitlement.UsagePeriodIntervalYear,
 			},
 		}
+
+		currentUsagePeriod, err := input.UsagePeriod.GetCurrentPeriod()
+		assert.NoError(t, err)
+		input.CurrentUsagePeriod = &currentUsagePeriod
+		return input
 	}
 
 	tt := []struct {
@@ -598,7 +619,11 @@ func TestResetEntitlementUsage(t *testing.T) {
 				// some usage on ledger, should be inconsequential
 				deps.streaming.AddSimpleEvent(meterSlug, 100, startTime.Add(time.Minute))
 
-				startingBalance, err := connector.ResetEntitlementUsage(ctx, models.NamespacedID{Namespace: namespace, ID: entitlement.ID}, resetTime)
+				startingBalance, err := connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: entitlement.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime,
+					})
 				assert.NoError(t, err)
 
 				assert.Equal(t, 0.0, startingBalance.UsageInPeriod) // cannot be usage
@@ -627,7 +652,11 @@ func TestResetEntitlementUsage(t *testing.T) {
 
 				// resetTime before start of measurement
 				resetTime := startTime.Add(-time.Hour)
-				_, err = connector.ResetEntitlementUsage(ctx, models.NamespacedID{Namespace: namespace, ID: entitlement.ID}, resetTime)
+				_, err = connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: entitlement.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime,
+					})
 				assert.ErrorContains(t, err, "before current usage period start")
 			},
 		},
@@ -661,7 +690,11 @@ func TestResetEntitlementUsage(t *testing.T) {
 
 				// resetTime before prior reset time
 				resetTime := priorResetTime.Add(-time.Minute)
-				_, err = connector.ResetEntitlementUsage(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID}, resetTime)
+				_, err = connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime,
+					})
 				assert.ErrorContains(t, err, "before current usage period start")
 			},
 		},
@@ -687,7 +720,11 @@ func TestResetEntitlementUsage(t *testing.T) {
 
 				// resetTime in future
 				resetTime := now.Add(time.Minute)
-				_, err = connector.ResetEntitlementUsage(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID}, resetTime)
+				_, err = connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime,
+					})
 				assert.ErrorContains(t, err, "in the future")
 			},
 		},
@@ -740,7 +777,11 @@ func TestResetEntitlementUsage(t *testing.T) {
 
 				// resetTime before snapshot
 				resetTime := snap.At.Add(-time.Minute)
-				_, err = connector.ResetEntitlementUsage(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID}, resetTime)
+				_, err = connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime,
+					})
 
 				assert.NoError(t, err)
 			},
@@ -789,7 +830,11 @@ func TestResetEntitlementUsage(t *testing.T) {
 
 				// resetTime before snapshot
 				resetTime := startTime.Add(time.Hour * 5)
-				balanceAfterReset, err := connector.ResetEntitlementUsage(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID}, resetTime)
+				balanceAfterReset, err := connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime,
+					})
 
 				assert.NoError(t, err)
 				assert.Equal(t, 0.0, balanceAfterReset.UsageInPeriod) // 0 usage right after reset
@@ -808,6 +853,80 @@ func TestResetEntitlementUsage(t *testing.T) {
 					g1.ID: 400,
 					g2.ID: 100,
 				}, creditBalance.Balances)
+			},
+		},
+		{
+			name: "Should return proper last reset time after reset",
+			run: func(t *testing.T, connector meteredentitlement.Connector, deps *testDependencies) {
+				ctx := context.Background()
+				startTime := testutils.GetRFC3339Time(t, "2024-03-01T00:00:00Z")
+
+				// create featute in db
+				feature, err := deps.featureDB.CreateFeature(ctx, exampleFeature)
+				assert.NoError(t, err)
+
+				// create entitlement in db
+				inp := getEntitlement(t, feature)
+				inp.MeasureUsageFrom = &startTime
+				ent, err := deps.entitlementDB.CreateEntitlement(ctx, inp)
+				assert.NoError(t, err)
+
+				ent, err = deps.entitlementDB.GetEntitlement(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID})
+				assert.NoError(t, err)
+				assert.Equal(t, startTime.Format(time.RFC3339), ent.LastReset.Format(time.RFC3339))
+
+				deps.streaming.AddSimpleEvent(meterSlug, 600, startTime.Add(time.Minute))
+
+				// resetTime before snapshot
+				resetTime := startTime.Add(time.Hour * 5)
+				_, err = connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime,
+					})
+				assert.NoError(t, err)
+
+				// validate that lastReset time is properly set
+				ent, err = deps.entitlementDB.GetEntitlement(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID})
+				assert.NoError(t, err)
+				assert.Equal(t, resetTime.Format(time.RFC3339), ent.LastReset.Format(time.RFC3339))
+			},
+		},
+		{
+			name: "Should return proper last reset time after reset",
+			run: func(t *testing.T, connector meteredentitlement.Connector, deps *testDependencies) {
+				ctx := context.Background()
+				startTime := testutils.GetRFC3339Time(t, "2024-03-01T00:00:00Z")
+
+				// create featute in db
+				feature, err := deps.featureDB.CreateFeature(ctx, exampleFeature)
+				assert.NoError(t, err)
+
+				// create entitlement in db
+				inp := getEntitlement(t, feature)
+				inp.MeasureUsageFrom = &startTime
+				ent, err := deps.entitlementDB.CreateEntitlement(ctx, inp)
+				assert.NoError(t, err)
+
+				ent, err = deps.entitlementDB.GetEntitlement(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID})
+				assert.NoError(t, err)
+				assert.Equal(t, startTime.Format(time.RFC3339), ent.LastReset.Format(time.RFC3339))
+
+				deps.streaming.AddSimpleEvent(meterSlug, 600, startTime.Add(time.Minute))
+
+				// resetTime before snapshot
+				resetTime := startTime.Add(time.Hour * 5)
+				_, err = connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime,
+					})
+				assert.NoError(t, err)
+
+				// validate that lastReset time is properly set
+				ent, err = deps.entitlementDB.GetEntitlement(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID})
+				assert.NoError(t, err)
+				assert.Equal(t, resetTime.Format(time.RFC3339), ent.LastReset.Format(time.RFC3339))
 			},
 		},
 		{
@@ -854,7 +973,11 @@ func TestResetEntitlementUsage(t *testing.T) {
 
 				// do a reset
 				resetTime1 := startTime.Add(time.Hour * 5)
-				balanceAfterReset, err := connector.ResetEntitlementUsage(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID}, resetTime1)
+				balanceAfterReset, err := connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime1,
+					})
 
 				assert.NoError(t, err)
 				assert.Equal(t, 0.0, balanceAfterReset.UsageInPeriod) // 0 usage right after reset
@@ -891,7 +1014,11 @@ func TestResetEntitlementUsage(t *testing.T) {
 
 				// do a 2nd reset
 				resetTime2 := resetTime1.Add(time.Hour * 5)
-				balanceAfterReset, err = connector.ResetEntitlementUsage(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID}, resetTime2)
+				balanceAfterReset, err = connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime2,
+					})
 
 				assert.NoError(t, err)
 				assert.Equal(t, 0.0, balanceAfterReset.UsageInPeriod) // 0 usage right after reset
@@ -946,7 +1073,11 @@ func TestResetEntitlementUsage(t *testing.T) {
 
 				// do a reset
 				resetTime := startTime.Add(time.Hour * 5)
-				balanceAfterReset, err := connector.ResetEntitlementUsage(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID}, resetTime)
+				balanceAfterReset, err := connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime,
+					})
 
 				// assert balance after reset is 0 for grant
 				assert.NoError(t, err)
@@ -978,6 +1109,127 @@ func TestResetEntitlementUsage(t *testing.T) {
 
 				assert.Equal(t, 0.0, balanceAfterReset.UsageInPeriod) // 0 usage right after reset
 				assert.Equal(t, g2.Amount, balanceAfterReset.Balance) // 1000 - 0 = 1000
+			},
+		},
+		{
+			name: "Should reseting without anchor update keeps the next reset time intact",
+			run: func(t *testing.T, connector meteredentitlement.Connector, deps *testDependencies) {
+				ctx := context.Background()
+				startTime := time.Now().Add(-12 * time.Hour).Truncate(time.Minute)
+
+				// create featute in db
+				feature, err := deps.featureDB.CreateFeature(ctx, exampleFeature)
+				assert.NoError(t, err)
+
+				// create entitlement in db
+				inp := getEntitlement(t, feature)
+				inp.MeasureUsageFrom = &startTime
+				anchor := startTime.Add(time.Hour)
+				inp.UsagePeriod.Anchor = anchor
+				inp.UsagePeriod.Interval = entitlement.UsagePeriodIntervalDay
+				inp.CurrentUsagePeriod = &api.Period{
+					To: anchor.AddDate(0, 0, 1),
+				}
+
+				ent, err := deps.entitlementDB.CreateEntitlement(ctx, inp)
+				assert.NoError(t, err)
+
+				deps.streaming.AddSimpleEvent(meterSlug, 600, startTime.Add(time.Minute))
+
+				resetTime := startTime.Add(time.Hour * 5)
+				_, err = connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At:           resetTime,
+						RetainAnchor: true,
+					})
+
+				assert.NoError(t, err)
+				ent, err = deps.entitlementDB.GetEntitlement(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID})
+				assert.NoError(t, err)
+				assertUsagePeriodEquals(t, inp.UsagePeriod, ent.UsagePeriod)
+			},
+		},
+		{
+			name: "Should reseting with anchor update updates the next reset time too",
+			run: func(t *testing.T, connector meteredentitlement.Connector, deps *testDependencies) {
+				ctx := context.Background()
+				startTime := time.Now().Add(-12 * time.Hour).Truncate(time.Minute)
+
+				// create featute in db
+				feature, err := deps.featureDB.CreateFeature(ctx, exampleFeature)
+				assert.NoError(t, err)
+
+				// create entitlement in db
+				inp := getEntitlement(t, feature)
+				inp.MeasureUsageFrom = &startTime
+				inp.UsagePeriod.Interval = entitlement.UsagePeriodIntervalDay
+				anchor := startTime.Add(time.Hour)
+				inp.UsagePeriod.Anchor = anchor
+				inp.CurrentUsagePeriod = &api.Period{
+					To: anchor.AddDate(0, 0, 1),
+				}
+
+				ent, err := deps.entitlementDB.CreateEntitlement(ctx, inp)
+				assert.NoError(t, err)
+
+				deps.streaming.AddSimpleEvent(meterSlug, 600, startTime.Add(time.Minute))
+
+				resetTime := startTime.Add(time.Hour * 5)
+				_, err = connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime,
+					})
+
+				assert.NoError(t, err)
+				ent, err = deps.entitlementDB.GetEntitlement(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID})
+				assert.NoError(t, err)
+				assertUsagePeriodEquals(t, &entitlement.UsagePeriod{
+					Interval: entitlement.UsagePeriodIntervalDay,
+					Anchor:   resetTime,
+				}, ent.UsagePeriod)
+			},
+		},
+		{
+			name: "When resetting with anchor update the anchor gets truncated to per minute resolution",
+			run: func(t *testing.T, connector meteredentitlement.Connector, deps *testDependencies) {
+				ctx := context.Background()
+				startTime := time.Now().Add(-12 * time.Hour).Truncate(time.Minute)
+
+				// create featute in db
+				feature, err := deps.featureDB.CreateFeature(ctx, exampleFeature)
+				assert.NoError(t, err)
+
+				// create entitlement in db
+				inp := getEntitlement(t, feature)
+				inp.MeasureUsageFrom = &startTime
+				anchor := startTime.Add(time.Hour)
+				inp.UsagePeriod.Interval = entitlement.UsagePeriodIntervalDay
+				inp.UsagePeriod.Anchor = anchor
+				inp.CurrentUsagePeriod = &api.Period{
+					To: anchor.AddDate(0, 0, 1),
+				}
+
+				ent, err := deps.entitlementDB.CreateEntitlement(ctx, inp)
+				assert.NoError(t, err)
+
+				deps.streaming.AddSimpleEvent(meterSlug, 600, startTime.Add(time.Minute))
+
+				resetTime := startTime.Add(time.Hour * 5).Add(time.Second)
+				_, err = connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime,
+					})
+
+				assert.NoError(t, err)
+				ent, err = deps.entitlementDB.GetEntitlement(ctx, models.NamespacedID{Namespace: namespace, ID: ent.ID})
+				assert.NoError(t, err)
+				assertUsagePeriodEquals(t, &entitlement.UsagePeriod{
+					Interval: entitlement.UsagePeriodIntervalDay,
+					Anchor:   resetTime.Truncate(time.Minute),
+				}, ent.UsagePeriod)
 			},
 		},
 	}
@@ -1085,4 +1337,11 @@ func setupConnector(t *testing.T) (meteredentitlement.Connector, *testDependenci
 		creditBalance:     balance,
 		streaming:         streaming,
 	}
+}
+
+func assertUsagePeriodEquals(t *testing.T, expected, actual *entitlement.UsagePeriod) {
+	assert.NotNil(t, expected, "expected is nil")
+	assert.NotNil(t, actual, "actual is nil")
+	assert.Equal(t, expected.Interval, actual.Interval, "periods do not match")
+	assert.Equal(t, expected.Anchor.Format(time.RFC3339), actual.Anchor.Format(time.RFC3339), "anchors do not match")
 }

--- a/internal/entitlement/metered/entitlement.go
+++ b/internal/entitlement/metered/entitlement.go
@@ -3,6 +3,7 @@ package meteredentitlement
 import (
 	"time"
 
+	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/internal/entitlement"
 )
 
@@ -23,6 +24,12 @@ type Entitlement struct {
 
 	// UsagePeriod defines the recurring period for usage calculations.
 	UsagePeriod entitlement.UsagePeriod `json:"usagePeriod,omitempty"`
+
+	// CurrentPeriod defines the current period for usage calculations.
+	CurrentUsagePeriod api.Period `json:"currentUsagePeriod,omitempty"`
+
+	// LastReset defines the last time the entitlement was reset.
+	LastReset time.Time `json:"lastReset"`
 }
 
 func ParseFromGenericEntitlement(model *entitlement.Entitlement) (*Entitlement, error) {
@@ -42,12 +49,22 @@ func ParseFromGenericEntitlement(model *entitlement.Entitlement) (*Entitlement, 
 		return nil, &entitlement.InvalidValueError{Message: "UsagePeriod is required", Type: model.EntitlementType}
 	}
 
+	if model.LastReset == nil {
+		return nil, &entitlement.InvalidValueError{Message: "LastReset is required", Type: model.EntitlementType}
+	}
+
+	if model.CurrentUsagePeriod == nil {
+		return nil, &entitlement.InvalidValueError{Message: "CurrentUsagePeriod is required", Type: model.EntitlementType}
+	}
+
 	return &Entitlement{
 		GenericProperties: model.GenericProperties,
 
-		MeasureUsageFrom: *model.MeasureUsageFrom,
-		IssuesAfterReset: model.IssueAfterReset,
-		IsSoftLimit:      *model.IsSoftLimit,
-		UsagePeriod:      *model.UsagePeriod,
+		MeasureUsageFrom:   *model.MeasureUsageFrom,
+		IssuesAfterReset:   model.IssueAfterReset,
+		IsSoftLimit:        *model.IsSoftLimit,
+		UsagePeriod:        *model.UsagePeriod,
+		LastReset:          *model.LastReset,
+		CurrentUsagePeriod: *model.CurrentUsagePeriod,
 	}, nil
 }

--- a/internal/entitlement/postgresadapter/ent/db/entitlement.go
+++ b/internal/entitlement/postgresadapter/ent/db/entitlement.go
@@ -46,6 +46,10 @@ type Entitlement struct {
 	UsagePeriodInterval *entitlement.UsagePeriodInterval `json:"usage_period_interval,omitempty"`
 	// UsagePeriodAnchor holds the value of the "usage_period_anchor" field.
 	UsagePeriodAnchor *time.Time `json:"usage_period_anchor,omitempty"`
+	// CurrentUsagePeriodStart holds the value of the "current_usage_period_start" field.
+	CurrentUsagePeriodStart *time.Time `json:"current_usage_period_start,omitempty"`
+	// CurrentUsagePeriodEnd holds the value of the "current_usage_period_end" field.
+	CurrentUsagePeriodEnd *time.Time `json:"current_usage_period_end,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the EntitlementQuery when eager-loading is set.
 	Edges        EntitlementEdges `json:"edges"`
@@ -83,7 +87,7 @@ func (*Entitlement) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullFloat64)
 		case entitlement.FieldID, entitlement.FieldNamespace, entitlement.FieldEntitlementType, entitlement.FieldFeatureID, entitlement.FieldSubjectKey, entitlement.FieldUsagePeriodInterval:
 			values[i] = new(sql.NullString)
-		case entitlement.FieldCreatedAt, entitlement.FieldUpdatedAt, entitlement.FieldDeletedAt, entitlement.FieldMeasureUsageFrom, entitlement.FieldUsagePeriodAnchor:
+		case entitlement.FieldCreatedAt, entitlement.FieldUpdatedAt, entitlement.FieldDeletedAt, entitlement.FieldMeasureUsageFrom, entitlement.FieldUsagePeriodAnchor, entitlement.FieldCurrentUsagePeriodStart, entitlement.FieldCurrentUsagePeriodEnd:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -200,6 +204,20 @@ func (e *Entitlement) assignValues(columns []string, values []any) error {
 				e.UsagePeriodAnchor = new(time.Time)
 				*e.UsagePeriodAnchor = value.Time
 			}
+		case entitlement.FieldCurrentUsagePeriodStart:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field current_usage_period_start", values[i])
+			} else if value.Valid {
+				e.CurrentUsagePeriodStart = new(time.Time)
+				*e.CurrentUsagePeriodStart = value.Time
+			}
+		case entitlement.FieldCurrentUsagePeriodEnd:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field current_usage_period_end", values[i])
+			} else if value.Valid {
+				e.CurrentUsagePeriodEnd = new(time.Time)
+				*e.CurrentUsagePeriodEnd = value.Time
+			}
 		default:
 			e.selectValues.Set(columns[i], values[i])
 		}
@@ -292,6 +310,16 @@ func (e *Entitlement) String() string {
 	builder.WriteString(", ")
 	if v := e.UsagePeriodAnchor; v != nil {
 		builder.WriteString("usage_period_anchor=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
+	builder.WriteString(", ")
+	if v := e.CurrentUsagePeriodStart; v != nil {
+		builder.WriteString("current_usage_period_start=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
+	builder.WriteString(", ")
+	if v := e.CurrentUsagePeriodEnd; v != nil {
+		builder.WriteString("current_usage_period_end=")
 		builder.WriteString(v.Format(time.ANSIC))
 	}
 	builder.WriteByte(')')

--- a/internal/entitlement/postgresadapter/ent/db/entitlement/entitlement.go
+++ b/internal/entitlement/postgresadapter/ent/db/entitlement/entitlement.go
@@ -43,6 +43,10 @@ const (
 	FieldUsagePeriodInterval = "usage_period_interval"
 	// FieldUsagePeriodAnchor holds the string denoting the usage_period_anchor field in the database.
 	FieldUsagePeriodAnchor = "usage_period_anchor"
+	// FieldCurrentUsagePeriodStart holds the string denoting the current_usage_period_start field in the database.
+	FieldCurrentUsagePeriodStart = "current_usage_period_start"
+	// FieldCurrentUsagePeriodEnd holds the string denoting the current_usage_period_end field in the database.
+	FieldCurrentUsagePeriodEnd = "current_usage_period_end"
 	// EdgeUsageReset holds the string denoting the usage_reset edge name in mutations.
 	EdgeUsageReset = "usage_reset"
 	// Table holds the table name of the entitlement in the database.
@@ -73,6 +77,8 @@ var Columns = []string{
 	FieldConfig,
 	FieldUsagePeriodInterval,
 	FieldUsagePeriodAnchor,
+	FieldCurrentUsagePeriodStart,
+	FieldCurrentUsagePeriodEnd,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -213,6 +219,16 @@ func ByUsagePeriodInterval(opts ...sql.OrderTermOption) OrderOption {
 // ByUsagePeriodAnchor orders the results by the usage_period_anchor field.
 func ByUsagePeriodAnchor(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUsagePeriodAnchor, opts...).ToFunc()
+}
+
+// ByCurrentUsagePeriodStart orders the results by the current_usage_period_start field.
+func ByCurrentUsagePeriodStart(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCurrentUsagePeriodStart, opts...).ToFunc()
+}
+
+// ByCurrentUsagePeriodEnd orders the results by the current_usage_period_end field.
+func ByCurrentUsagePeriodEnd(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCurrentUsagePeriodEnd, opts...).ToFunc()
 }
 
 // ByUsageResetCount orders the results by usage_reset count.

--- a/internal/entitlement/postgresadapter/ent/db/entitlement/where.go
+++ b/internal/entitlement/postgresadapter/ent/db/entitlement/where.go
@@ -115,6 +115,16 @@ func UsagePeriodAnchor(v time.Time) predicate.Entitlement {
 	return predicate.Entitlement(sql.FieldEQ(FieldUsagePeriodAnchor, v))
 }
 
+// CurrentUsagePeriodStart applies equality check predicate on the "current_usage_period_start" field. It's identical to CurrentUsagePeriodStartEQ.
+func CurrentUsagePeriodStart(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldEQ(FieldCurrentUsagePeriodStart, v))
+}
+
+// CurrentUsagePeriodEnd applies equality check predicate on the "current_usage_period_end" field. It's identical to CurrentUsagePeriodEndEQ.
+func CurrentUsagePeriodEnd(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldEQ(FieldCurrentUsagePeriodEnd, v))
+}
+
 // NamespaceEQ applies the EQ predicate on the "namespace" field.
 func NamespaceEQ(v string) predicate.Entitlement {
 	return predicate.Entitlement(sql.FieldEQ(FieldNamespace, v))
@@ -678,6 +688,106 @@ func UsagePeriodAnchorIsNil() predicate.Entitlement {
 // UsagePeriodAnchorNotNil applies the NotNil predicate on the "usage_period_anchor" field.
 func UsagePeriodAnchorNotNil() predicate.Entitlement {
 	return predicate.Entitlement(sql.FieldNotNull(FieldUsagePeriodAnchor))
+}
+
+// CurrentUsagePeriodStartEQ applies the EQ predicate on the "current_usage_period_start" field.
+func CurrentUsagePeriodStartEQ(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldEQ(FieldCurrentUsagePeriodStart, v))
+}
+
+// CurrentUsagePeriodStartNEQ applies the NEQ predicate on the "current_usage_period_start" field.
+func CurrentUsagePeriodStartNEQ(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldNEQ(FieldCurrentUsagePeriodStart, v))
+}
+
+// CurrentUsagePeriodStartIn applies the In predicate on the "current_usage_period_start" field.
+func CurrentUsagePeriodStartIn(vs ...time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldIn(FieldCurrentUsagePeriodStart, vs...))
+}
+
+// CurrentUsagePeriodStartNotIn applies the NotIn predicate on the "current_usage_period_start" field.
+func CurrentUsagePeriodStartNotIn(vs ...time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldNotIn(FieldCurrentUsagePeriodStart, vs...))
+}
+
+// CurrentUsagePeriodStartGT applies the GT predicate on the "current_usage_period_start" field.
+func CurrentUsagePeriodStartGT(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldGT(FieldCurrentUsagePeriodStart, v))
+}
+
+// CurrentUsagePeriodStartGTE applies the GTE predicate on the "current_usage_period_start" field.
+func CurrentUsagePeriodStartGTE(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldGTE(FieldCurrentUsagePeriodStart, v))
+}
+
+// CurrentUsagePeriodStartLT applies the LT predicate on the "current_usage_period_start" field.
+func CurrentUsagePeriodStartLT(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldLT(FieldCurrentUsagePeriodStart, v))
+}
+
+// CurrentUsagePeriodStartLTE applies the LTE predicate on the "current_usage_period_start" field.
+func CurrentUsagePeriodStartLTE(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldLTE(FieldCurrentUsagePeriodStart, v))
+}
+
+// CurrentUsagePeriodStartIsNil applies the IsNil predicate on the "current_usage_period_start" field.
+func CurrentUsagePeriodStartIsNil() predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldIsNull(FieldCurrentUsagePeriodStart))
+}
+
+// CurrentUsagePeriodStartNotNil applies the NotNil predicate on the "current_usage_period_start" field.
+func CurrentUsagePeriodStartNotNil() predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldNotNull(FieldCurrentUsagePeriodStart))
+}
+
+// CurrentUsagePeriodEndEQ applies the EQ predicate on the "current_usage_period_end" field.
+func CurrentUsagePeriodEndEQ(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldEQ(FieldCurrentUsagePeriodEnd, v))
+}
+
+// CurrentUsagePeriodEndNEQ applies the NEQ predicate on the "current_usage_period_end" field.
+func CurrentUsagePeriodEndNEQ(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldNEQ(FieldCurrentUsagePeriodEnd, v))
+}
+
+// CurrentUsagePeriodEndIn applies the In predicate on the "current_usage_period_end" field.
+func CurrentUsagePeriodEndIn(vs ...time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldIn(FieldCurrentUsagePeriodEnd, vs...))
+}
+
+// CurrentUsagePeriodEndNotIn applies the NotIn predicate on the "current_usage_period_end" field.
+func CurrentUsagePeriodEndNotIn(vs ...time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldNotIn(FieldCurrentUsagePeriodEnd, vs...))
+}
+
+// CurrentUsagePeriodEndGT applies the GT predicate on the "current_usage_period_end" field.
+func CurrentUsagePeriodEndGT(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldGT(FieldCurrentUsagePeriodEnd, v))
+}
+
+// CurrentUsagePeriodEndGTE applies the GTE predicate on the "current_usage_period_end" field.
+func CurrentUsagePeriodEndGTE(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldGTE(FieldCurrentUsagePeriodEnd, v))
+}
+
+// CurrentUsagePeriodEndLT applies the LT predicate on the "current_usage_period_end" field.
+func CurrentUsagePeriodEndLT(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldLT(FieldCurrentUsagePeriodEnd, v))
+}
+
+// CurrentUsagePeriodEndLTE applies the LTE predicate on the "current_usage_period_end" field.
+func CurrentUsagePeriodEndLTE(v time.Time) predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldLTE(FieldCurrentUsagePeriodEnd, v))
+}
+
+// CurrentUsagePeriodEndIsNil applies the IsNil predicate on the "current_usage_period_end" field.
+func CurrentUsagePeriodEndIsNil() predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldIsNull(FieldCurrentUsagePeriodEnd))
+}
+
+// CurrentUsagePeriodEndNotNil applies the NotNil predicate on the "current_usage_period_end" field.
+func CurrentUsagePeriodEndNotNil() predicate.Entitlement {
+	return predicate.Entitlement(sql.FieldNotNull(FieldCurrentUsagePeriodEnd))
 }
 
 // HasUsageReset applies the HasEdge predicate on the "usage_reset" edge.

--- a/internal/entitlement/postgresadapter/ent/db/entitlement_create.go
+++ b/internal/entitlement/postgresadapter/ent/db/entitlement_create.go
@@ -172,6 +172,34 @@ func (ec *EntitlementCreate) SetNillableUsagePeriodAnchor(t *time.Time) *Entitle
 	return ec
 }
 
+// SetCurrentUsagePeriodStart sets the "current_usage_period_start" field.
+func (ec *EntitlementCreate) SetCurrentUsagePeriodStart(t time.Time) *EntitlementCreate {
+	ec.mutation.SetCurrentUsagePeriodStart(t)
+	return ec
+}
+
+// SetNillableCurrentUsagePeriodStart sets the "current_usage_period_start" field if the given value is not nil.
+func (ec *EntitlementCreate) SetNillableCurrentUsagePeriodStart(t *time.Time) *EntitlementCreate {
+	if t != nil {
+		ec.SetCurrentUsagePeriodStart(*t)
+	}
+	return ec
+}
+
+// SetCurrentUsagePeriodEnd sets the "current_usage_period_end" field.
+func (ec *EntitlementCreate) SetCurrentUsagePeriodEnd(t time.Time) *EntitlementCreate {
+	ec.mutation.SetCurrentUsagePeriodEnd(t)
+	return ec
+}
+
+// SetNillableCurrentUsagePeriodEnd sets the "current_usage_period_end" field if the given value is not nil.
+func (ec *EntitlementCreate) SetNillableCurrentUsagePeriodEnd(t *time.Time) *EntitlementCreate {
+	if t != nil {
+		ec.SetCurrentUsagePeriodEnd(*t)
+	}
+	return ec
+}
+
 // SetID sets the "id" field.
 func (ec *EntitlementCreate) SetID(s string) *EntitlementCreate {
 	ec.mutation.SetID(s)
@@ -377,6 +405,14 @@ func (ec *EntitlementCreate) createSpec() (*Entitlement, *sqlgraph.CreateSpec) {
 		_spec.SetField(entitlement.FieldUsagePeriodAnchor, field.TypeTime, value)
 		_node.UsagePeriodAnchor = &value
 	}
+	if value, ok := ec.mutation.CurrentUsagePeriodStart(); ok {
+		_spec.SetField(entitlement.FieldCurrentUsagePeriodStart, field.TypeTime, value)
+		_node.CurrentUsagePeriodStart = &value
+	}
+	if value, ok := ec.mutation.CurrentUsagePeriodEnd(); ok {
+		_spec.SetField(entitlement.FieldCurrentUsagePeriodEnd, field.TypeTime, value)
+		_node.CurrentUsagePeriodEnd = &value
+	}
 	if nodes := ec.mutation.UsageResetIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2M,
@@ -511,6 +547,60 @@ func (u *EntitlementUpsert) ClearConfig() *EntitlementUpsert {
 	return u
 }
 
+// SetUsagePeriodAnchor sets the "usage_period_anchor" field.
+func (u *EntitlementUpsert) SetUsagePeriodAnchor(v time.Time) *EntitlementUpsert {
+	u.Set(entitlement.FieldUsagePeriodAnchor, v)
+	return u
+}
+
+// UpdateUsagePeriodAnchor sets the "usage_period_anchor" field to the value that was provided on create.
+func (u *EntitlementUpsert) UpdateUsagePeriodAnchor() *EntitlementUpsert {
+	u.SetExcluded(entitlement.FieldUsagePeriodAnchor)
+	return u
+}
+
+// ClearUsagePeriodAnchor clears the value of the "usage_period_anchor" field.
+func (u *EntitlementUpsert) ClearUsagePeriodAnchor() *EntitlementUpsert {
+	u.SetNull(entitlement.FieldUsagePeriodAnchor)
+	return u
+}
+
+// SetCurrentUsagePeriodStart sets the "current_usage_period_start" field.
+func (u *EntitlementUpsert) SetCurrentUsagePeriodStart(v time.Time) *EntitlementUpsert {
+	u.Set(entitlement.FieldCurrentUsagePeriodStart, v)
+	return u
+}
+
+// UpdateCurrentUsagePeriodStart sets the "current_usage_period_start" field to the value that was provided on create.
+func (u *EntitlementUpsert) UpdateCurrentUsagePeriodStart() *EntitlementUpsert {
+	u.SetExcluded(entitlement.FieldCurrentUsagePeriodStart)
+	return u
+}
+
+// ClearCurrentUsagePeriodStart clears the value of the "current_usage_period_start" field.
+func (u *EntitlementUpsert) ClearCurrentUsagePeriodStart() *EntitlementUpsert {
+	u.SetNull(entitlement.FieldCurrentUsagePeriodStart)
+	return u
+}
+
+// SetCurrentUsagePeriodEnd sets the "current_usage_period_end" field.
+func (u *EntitlementUpsert) SetCurrentUsagePeriodEnd(v time.Time) *EntitlementUpsert {
+	u.Set(entitlement.FieldCurrentUsagePeriodEnd, v)
+	return u
+}
+
+// UpdateCurrentUsagePeriodEnd sets the "current_usage_period_end" field to the value that was provided on create.
+func (u *EntitlementUpsert) UpdateCurrentUsagePeriodEnd() *EntitlementUpsert {
+	u.SetExcluded(entitlement.FieldCurrentUsagePeriodEnd)
+	return u
+}
+
+// ClearCurrentUsagePeriodEnd clears the value of the "current_usage_period_end" field.
+func (u *EntitlementUpsert) ClearCurrentUsagePeriodEnd() *EntitlementUpsert {
+	u.SetNull(entitlement.FieldCurrentUsagePeriodEnd)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -554,9 +644,6 @@ func (u *EntitlementUpsertOne) UpdateNewValues() *EntitlementUpsertOne {
 		}
 		if _, exists := u.create.mutation.UsagePeriodInterval(); exists {
 			s.SetIgnore(entitlement.FieldUsagePeriodInterval)
-		}
-		if _, exists := u.create.mutation.UsagePeriodAnchor(); exists {
-			s.SetIgnore(entitlement.FieldUsagePeriodAnchor)
 		}
 	}))
 	return u
@@ -663,6 +750,69 @@ func (u *EntitlementUpsertOne) UpdateConfig() *EntitlementUpsertOne {
 func (u *EntitlementUpsertOne) ClearConfig() *EntitlementUpsertOne {
 	return u.Update(func(s *EntitlementUpsert) {
 		s.ClearConfig()
+	})
+}
+
+// SetUsagePeriodAnchor sets the "usage_period_anchor" field.
+func (u *EntitlementUpsertOne) SetUsagePeriodAnchor(v time.Time) *EntitlementUpsertOne {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.SetUsagePeriodAnchor(v)
+	})
+}
+
+// UpdateUsagePeriodAnchor sets the "usage_period_anchor" field to the value that was provided on create.
+func (u *EntitlementUpsertOne) UpdateUsagePeriodAnchor() *EntitlementUpsertOne {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.UpdateUsagePeriodAnchor()
+	})
+}
+
+// ClearUsagePeriodAnchor clears the value of the "usage_period_anchor" field.
+func (u *EntitlementUpsertOne) ClearUsagePeriodAnchor() *EntitlementUpsertOne {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.ClearUsagePeriodAnchor()
+	})
+}
+
+// SetCurrentUsagePeriodStart sets the "current_usage_period_start" field.
+func (u *EntitlementUpsertOne) SetCurrentUsagePeriodStart(v time.Time) *EntitlementUpsertOne {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.SetCurrentUsagePeriodStart(v)
+	})
+}
+
+// UpdateCurrentUsagePeriodStart sets the "current_usage_period_start" field to the value that was provided on create.
+func (u *EntitlementUpsertOne) UpdateCurrentUsagePeriodStart() *EntitlementUpsertOne {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.UpdateCurrentUsagePeriodStart()
+	})
+}
+
+// ClearCurrentUsagePeriodStart clears the value of the "current_usage_period_start" field.
+func (u *EntitlementUpsertOne) ClearCurrentUsagePeriodStart() *EntitlementUpsertOne {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.ClearCurrentUsagePeriodStart()
+	})
+}
+
+// SetCurrentUsagePeriodEnd sets the "current_usage_period_end" field.
+func (u *EntitlementUpsertOne) SetCurrentUsagePeriodEnd(v time.Time) *EntitlementUpsertOne {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.SetCurrentUsagePeriodEnd(v)
+	})
+}
+
+// UpdateCurrentUsagePeriodEnd sets the "current_usage_period_end" field to the value that was provided on create.
+func (u *EntitlementUpsertOne) UpdateCurrentUsagePeriodEnd() *EntitlementUpsertOne {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.UpdateCurrentUsagePeriodEnd()
+	})
+}
+
+// ClearCurrentUsagePeriodEnd clears the value of the "current_usage_period_end" field.
+func (u *EntitlementUpsertOne) ClearCurrentUsagePeriodEnd() *EntitlementUpsertOne {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.ClearCurrentUsagePeriodEnd()
 	})
 }
 
@@ -876,9 +1026,6 @@ func (u *EntitlementUpsertBulk) UpdateNewValues() *EntitlementUpsertBulk {
 			if _, exists := b.mutation.UsagePeriodInterval(); exists {
 				s.SetIgnore(entitlement.FieldUsagePeriodInterval)
 			}
-			if _, exists := b.mutation.UsagePeriodAnchor(); exists {
-				s.SetIgnore(entitlement.FieldUsagePeriodAnchor)
-			}
 		}
 	}))
 	return u
@@ -985,6 +1132,69 @@ func (u *EntitlementUpsertBulk) UpdateConfig() *EntitlementUpsertBulk {
 func (u *EntitlementUpsertBulk) ClearConfig() *EntitlementUpsertBulk {
 	return u.Update(func(s *EntitlementUpsert) {
 		s.ClearConfig()
+	})
+}
+
+// SetUsagePeriodAnchor sets the "usage_period_anchor" field.
+func (u *EntitlementUpsertBulk) SetUsagePeriodAnchor(v time.Time) *EntitlementUpsertBulk {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.SetUsagePeriodAnchor(v)
+	})
+}
+
+// UpdateUsagePeriodAnchor sets the "usage_period_anchor" field to the value that was provided on create.
+func (u *EntitlementUpsertBulk) UpdateUsagePeriodAnchor() *EntitlementUpsertBulk {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.UpdateUsagePeriodAnchor()
+	})
+}
+
+// ClearUsagePeriodAnchor clears the value of the "usage_period_anchor" field.
+func (u *EntitlementUpsertBulk) ClearUsagePeriodAnchor() *EntitlementUpsertBulk {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.ClearUsagePeriodAnchor()
+	})
+}
+
+// SetCurrentUsagePeriodStart sets the "current_usage_period_start" field.
+func (u *EntitlementUpsertBulk) SetCurrentUsagePeriodStart(v time.Time) *EntitlementUpsertBulk {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.SetCurrentUsagePeriodStart(v)
+	})
+}
+
+// UpdateCurrentUsagePeriodStart sets the "current_usage_period_start" field to the value that was provided on create.
+func (u *EntitlementUpsertBulk) UpdateCurrentUsagePeriodStart() *EntitlementUpsertBulk {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.UpdateCurrentUsagePeriodStart()
+	})
+}
+
+// ClearCurrentUsagePeriodStart clears the value of the "current_usage_period_start" field.
+func (u *EntitlementUpsertBulk) ClearCurrentUsagePeriodStart() *EntitlementUpsertBulk {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.ClearCurrentUsagePeriodStart()
+	})
+}
+
+// SetCurrentUsagePeriodEnd sets the "current_usage_period_end" field.
+func (u *EntitlementUpsertBulk) SetCurrentUsagePeriodEnd(v time.Time) *EntitlementUpsertBulk {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.SetCurrentUsagePeriodEnd(v)
+	})
+}
+
+// UpdateCurrentUsagePeriodEnd sets the "current_usage_period_end" field to the value that was provided on create.
+func (u *EntitlementUpsertBulk) UpdateCurrentUsagePeriodEnd() *EntitlementUpsertBulk {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.UpdateCurrentUsagePeriodEnd()
+	})
+}
+
+// ClearCurrentUsagePeriodEnd clears the value of the "current_usage_period_end" field.
+func (u *EntitlementUpsertBulk) ClearCurrentUsagePeriodEnd() *EntitlementUpsertBulk {
+	return u.Update(func(s *EntitlementUpsert) {
+		s.ClearCurrentUsagePeriodEnd()
 	})
 }
 

--- a/internal/entitlement/postgresadapter/ent/db/entitlement_update.go
+++ b/internal/entitlement/postgresadapter/ent/db/entitlement_update.go
@@ -79,6 +79,66 @@ func (eu *EntitlementUpdate) ClearConfig() *EntitlementUpdate {
 	return eu
 }
 
+// SetUsagePeriodAnchor sets the "usage_period_anchor" field.
+func (eu *EntitlementUpdate) SetUsagePeriodAnchor(t time.Time) *EntitlementUpdate {
+	eu.mutation.SetUsagePeriodAnchor(t)
+	return eu
+}
+
+// SetNillableUsagePeriodAnchor sets the "usage_period_anchor" field if the given value is not nil.
+func (eu *EntitlementUpdate) SetNillableUsagePeriodAnchor(t *time.Time) *EntitlementUpdate {
+	if t != nil {
+		eu.SetUsagePeriodAnchor(*t)
+	}
+	return eu
+}
+
+// ClearUsagePeriodAnchor clears the value of the "usage_period_anchor" field.
+func (eu *EntitlementUpdate) ClearUsagePeriodAnchor() *EntitlementUpdate {
+	eu.mutation.ClearUsagePeriodAnchor()
+	return eu
+}
+
+// SetCurrentUsagePeriodStart sets the "current_usage_period_start" field.
+func (eu *EntitlementUpdate) SetCurrentUsagePeriodStart(t time.Time) *EntitlementUpdate {
+	eu.mutation.SetCurrentUsagePeriodStart(t)
+	return eu
+}
+
+// SetNillableCurrentUsagePeriodStart sets the "current_usage_period_start" field if the given value is not nil.
+func (eu *EntitlementUpdate) SetNillableCurrentUsagePeriodStart(t *time.Time) *EntitlementUpdate {
+	if t != nil {
+		eu.SetCurrentUsagePeriodStart(*t)
+	}
+	return eu
+}
+
+// ClearCurrentUsagePeriodStart clears the value of the "current_usage_period_start" field.
+func (eu *EntitlementUpdate) ClearCurrentUsagePeriodStart() *EntitlementUpdate {
+	eu.mutation.ClearCurrentUsagePeriodStart()
+	return eu
+}
+
+// SetCurrentUsagePeriodEnd sets the "current_usage_period_end" field.
+func (eu *EntitlementUpdate) SetCurrentUsagePeriodEnd(t time.Time) *EntitlementUpdate {
+	eu.mutation.SetCurrentUsagePeriodEnd(t)
+	return eu
+}
+
+// SetNillableCurrentUsagePeriodEnd sets the "current_usage_period_end" field if the given value is not nil.
+func (eu *EntitlementUpdate) SetNillableCurrentUsagePeriodEnd(t *time.Time) *EntitlementUpdate {
+	if t != nil {
+		eu.SetCurrentUsagePeriodEnd(*t)
+	}
+	return eu
+}
+
+// ClearCurrentUsagePeriodEnd clears the value of the "current_usage_period_end" field.
+func (eu *EntitlementUpdate) ClearCurrentUsagePeriodEnd() *EntitlementUpdate {
+	eu.mutation.ClearCurrentUsagePeriodEnd()
+	return eu
+}
+
 // AddUsageResetIDs adds the "usage_reset" edge to the UsageReset entity by IDs.
 func (eu *EntitlementUpdate) AddUsageResetIDs(ids ...string) *EntitlementUpdate {
 	eu.mutation.AddUsageResetIDs(ids...)
@@ -198,8 +258,23 @@ func (eu *EntitlementUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if eu.mutation.UsagePeriodIntervalCleared() {
 		_spec.ClearField(entitlement.FieldUsagePeriodInterval, field.TypeEnum)
 	}
+	if value, ok := eu.mutation.UsagePeriodAnchor(); ok {
+		_spec.SetField(entitlement.FieldUsagePeriodAnchor, field.TypeTime, value)
+	}
 	if eu.mutation.UsagePeriodAnchorCleared() {
 		_spec.ClearField(entitlement.FieldUsagePeriodAnchor, field.TypeTime)
+	}
+	if value, ok := eu.mutation.CurrentUsagePeriodStart(); ok {
+		_spec.SetField(entitlement.FieldCurrentUsagePeriodStart, field.TypeTime, value)
+	}
+	if eu.mutation.CurrentUsagePeriodStartCleared() {
+		_spec.ClearField(entitlement.FieldCurrentUsagePeriodStart, field.TypeTime)
+	}
+	if value, ok := eu.mutation.CurrentUsagePeriodEnd(); ok {
+		_spec.SetField(entitlement.FieldCurrentUsagePeriodEnd, field.TypeTime, value)
+	}
+	if eu.mutation.CurrentUsagePeriodEndCleared() {
+		_spec.ClearField(entitlement.FieldCurrentUsagePeriodEnd, field.TypeTime)
 	}
 	if eu.mutation.UsageResetCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -313,6 +388,66 @@ func (euo *EntitlementUpdateOne) SetConfig(m map[string]interface{}) *Entitlemen
 // ClearConfig clears the value of the "config" field.
 func (euo *EntitlementUpdateOne) ClearConfig() *EntitlementUpdateOne {
 	euo.mutation.ClearConfig()
+	return euo
+}
+
+// SetUsagePeriodAnchor sets the "usage_period_anchor" field.
+func (euo *EntitlementUpdateOne) SetUsagePeriodAnchor(t time.Time) *EntitlementUpdateOne {
+	euo.mutation.SetUsagePeriodAnchor(t)
+	return euo
+}
+
+// SetNillableUsagePeriodAnchor sets the "usage_period_anchor" field if the given value is not nil.
+func (euo *EntitlementUpdateOne) SetNillableUsagePeriodAnchor(t *time.Time) *EntitlementUpdateOne {
+	if t != nil {
+		euo.SetUsagePeriodAnchor(*t)
+	}
+	return euo
+}
+
+// ClearUsagePeriodAnchor clears the value of the "usage_period_anchor" field.
+func (euo *EntitlementUpdateOne) ClearUsagePeriodAnchor() *EntitlementUpdateOne {
+	euo.mutation.ClearUsagePeriodAnchor()
+	return euo
+}
+
+// SetCurrentUsagePeriodStart sets the "current_usage_period_start" field.
+func (euo *EntitlementUpdateOne) SetCurrentUsagePeriodStart(t time.Time) *EntitlementUpdateOne {
+	euo.mutation.SetCurrentUsagePeriodStart(t)
+	return euo
+}
+
+// SetNillableCurrentUsagePeriodStart sets the "current_usage_period_start" field if the given value is not nil.
+func (euo *EntitlementUpdateOne) SetNillableCurrentUsagePeriodStart(t *time.Time) *EntitlementUpdateOne {
+	if t != nil {
+		euo.SetCurrentUsagePeriodStart(*t)
+	}
+	return euo
+}
+
+// ClearCurrentUsagePeriodStart clears the value of the "current_usage_period_start" field.
+func (euo *EntitlementUpdateOne) ClearCurrentUsagePeriodStart() *EntitlementUpdateOne {
+	euo.mutation.ClearCurrentUsagePeriodStart()
+	return euo
+}
+
+// SetCurrentUsagePeriodEnd sets the "current_usage_period_end" field.
+func (euo *EntitlementUpdateOne) SetCurrentUsagePeriodEnd(t time.Time) *EntitlementUpdateOne {
+	euo.mutation.SetCurrentUsagePeriodEnd(t)
+	return euo
+}
+
+// SetNillableCurrentUsagePeriodEnd sets the "current_usage_period_end" field if the given value is not nil.
+func (euo *EntitlementUpdateOne) SetNillableCurrentUsagePeriodEnd(t *time.Time) *EntitlementUpdateOne {
+	if t != nil {
+		euo.SetCurrentUsagePeriodEnd(*t)
+	}
+	return euo
+}
+
+// ClearCurrentUsagePeriodEnd clears the value of the "current_usage_period_end" field.
+func (euo *EntitlementUpdateOne) ClearCurrentUsagePeriodEnd() *EntitlementUpdateOne {
+	euo.mutation.ClearCurrentUsagePeriodEnd()
 	return euo
 }
 
@@ -465,8 +600,23 @@ func (euo *EntitlementUpdateOne) sqlSave(ctx context.Context) (_node *Entitlemen
 	if euo.mutation.UsagePeriodIntervalCleared() {
 		_spec.ClearField(entitlement.FieldUsagePeriodInterval, field.TypeEnum)
 	}
+	if value, ok := euo.mutation.UsagePeriodAnchor(); ok {
+		_spec.SetField(entitlement.FieldUsagePeriodAnchor, field.TypeTime, value)
+	}
 	if euo.mutation.UsagePeriodAnchorCleared() {
 		_spec.ClearField(entitlement.FieldUsagePeriodAnchor, field.TypeTime)
+	}
+	if value, ok := euo.mutation.CurrentUsagePeriodStart(); ok {
+		_spec.SetField(entitlement.FieldCurrentUsagePeriodStart, field.TypeTime, value)
+	}
+	if euo.mutation.CurrentUsagePeriodStartCleared() {
+		_spec.ClearField(entitlement.FieldCurrentUsagePeriodStart, field.TypeTime)
+	}
+	if value, ok := euo.mutation.CurrentUsagePeriodEnd(); ok {
+		_spec.SetField(entitlement.FieldCurrentUsagePeriodEnd, field.TypeTime, value)
+	}
+	if euo.mutation.CurrentUsagePeriodEndCleared() {
+		_spec.ClearField(entitlement.FieldCurrentUsagePeriodEnd, field.TypeTime)
 	}
 	if euo.mutation.UsageResetCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/internal/entitlement/postgresadapter/ent/db/migrate/schema.go
+++ b/internal/entitlement/postgresadapter/ent/db/migrate/schema.go
@@ -25,6 +25,8 @@ var (
 		{Name: "config", Type: field.TypeJSON, Nullable: true},
 		{Name: "usage_period_interval", Type: field.TypeEnum, Nullable: true, Enums: []string{"DAY", "WEEK", "MONTH", "YEAR"}},
 		{Name: "usage_period_anchor", Type: field.TypeTime, Nullable: true},
+		{Name: "current_usage_period_start", Type: field.TypeTime, Nullable: true},
+		{Name: "current_usage_period_end", Type: field.TypeTime, Nullable: true},
 	}
 	// EntitlementsTable holds the schema information for the "entitlements" table.
 	EntitlementsTable = &schema.Table{
@@ -56,6 +58,11 @@ var (
 				Name:    "entitlement_namespace_feature_id_id",
 				Unique:  false,
 				Columns: []*schema.Column{EntitlementsColumns[1], EntitlementsColumns[7], EntitlementsColumns[0]},
+			},
+			{
+				Name:    "entitlement_namespace_current_usage_period_end",
+				Unique:  false,
+				Columns: []*schema.Column{EntitlementsColumns[1], EntitlementsColumns[16]},
 			},
 		},
 	}

--- a/internal/entitlement/postgresadapter/ent/db/mutation.go
+++ b/internal/entitlement/postgresadapter/ent/db/mutation.go
@@ -32,31 +32,33 @@ const (
 // EntitlementMutation represents an operation that mutates the Entitlement nodes in the graph.
 type EntitlementMutation struct {
 	config
-	op                    Op
-	typ                   string
-	id                    *string
-	namespace             *string
-	metadata              *map[string]string
-	created_at            *time.Time
-	updated_at            *time.Time
-	deleted_at            *time.Time
-	entitlement_type      *entitlement.EntitlementType
-	feature_id            *string
-	subject_key           *string
-	measure_usage_from    *time.Time
-	issue_after_reset     *float64
-	addissue_after_reset  *float64
-	is_soft_limit         *bool
-	_config               *map[string]interface{}
-	usage_period_interval *entitlement.UsagePeriodInterval
-	usage_period_anchor   *time.Time
-	clearedFields         map[string]struct{}
-	usage_reset           map[string]struct{}
-	removedusage_reset    map[string]struct{}
-	clearedusage_reset    bool
-	done                  bool
-	oldValue              func(context.Context) (*Entitlement, error)
-	predicates            []predicate.Entitlement
+	op                         Op
+	typ                        string
+	id                         *string
+	namespace                  *string
+	metadata                   *map[string]string
+	created_at                 *time.Time
+	updated_at                 *time.Time
+	deleted_at                 *time.Time
+	entitlement_type           *entitlement.EntitlementType
+	feature_id                 *string
+	subject_key                *string
+	measure_usage_from         *time.Time
+	issue_after_reset          *float64
+	addissue_after_reset       *float64
+	is_soft_limit              *bool
+	_config                    *map[string]interface{}
+	usage_period_interval      *entitlement.UsagePeriodInterval
+	usage_period_anchor        *time.Time
+	current_usage_period_start *time.Time
+	current_usage_period_end   *time.Time
+	clearedFields              map[string]struct{}
+	usage_reset                map[string]struct{}
+	removedusage_reset         map[string]struct{}
+	clearedusage_reset         bool
+	done                       bool
+	oldValue                   func(context.Context) (*Entitlement, error)
+	predicates                 []predicate.Entitlement
 }
 
 var _ ent.Mutation = (*EntitlementMutation)(nil)
@@ -792,6 +794,104 @@ func (m *EntitlementMutation) ResetUsagePeriodAnchor() {
 	delete(m.clearedFields, entitlement.FieldUsagePeriodAnchor)
 }
 
+// SetCurrentUsagePeriodStart sets the "current_usage_period_start" field.
+func (m *EntitlementMutation) SetCurrentUsagePeriodStart(t time.Time) {
+	m.current_usage_period_start = &t
+}
+
+// CurrentUsagePeriodStart returns the value of the "current_usage_period_start" field in the mutation.
+func (m *EntitlementMutation) CurrentUsagePeriodStart() (r time.Time, exists bool) {
+	v := m.current_usage_period_start
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCurrentUsagePeriodStart returns the old "current_usage_period_start" field's value of the Entitlement entity.
+// If the Entitlement object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *EntitlementMutation) OldCurrentUsagePeriodStart(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCurrentUsagePeriodStart is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCurrentUsagePeriodStart requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCurrentUsagePeriodStart: %w", err)
+	}
+	return oldValue.CurrentUsagePeriodStart, nil
+}
+
+// ClearCurrentUsagePeriodStart clears the value of the "current_usage_period_start" field.
+func (m *EntitlementMutation) ClearCurrentUsagePeriodStart() {
+	m.current_usage_period_start = nil
+	m.clearedFields[entitlement.FieldCurrentUsagePeriodStart] = struct{}{}
+}
+
+// CurrentUsagePeriodStartCleared returns if the "current_usage_period_start" field was cleared in this mutation.
+func (m *EntitlementMutation) CurrentUsagePeriodStartCleared() bool {
+	_, ok := m.clearedFields[entitlement.FieldCurrentUsagePeriodStart]
+	return ok
+}
+
+// ResetCurrentUsagePeriodStart resets all changes to the "current_usage_period_start" field.
+func (m *EntitlementMutation) ResetCurrentUsagePeriodStart() {
+	m.current_usage_period_start = nil
+	delete(m.clearedFields, entitlement.FieldCurrentUsagePeriodStart)
+}
+
+// SetCurrentUsagePeriodEnd sets the "current_usage_period_end" field.
+func (m *EntitlementMutation) SetCurrentUsagePeriodEnd(t time.Time) {
+	m.current_usage_period_end = &t
+}
+
+// CurrentUsagePeriodEnd returns the value of the "current_usage_period_end" field in the mutation.
+func (m *EntitlementMutation) CurrentUsagePeriodEnd() (r time.Time, exists bool) {
+	v := m.current_usage_period_end
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCurrentUsagePeriodEnd returns the old "current_usage_period_end" field's value of the Entitlement entity.
+// If the Entitlement object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *EntitlementMutation) OldCurrentUsagePeriodEnd(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCurrentUsagePeriodEnd is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCurrentUsagePeriodEnd requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCurrentUsagePeriodEnd: %w", err)
+	}
+	return oldValue.CurrentUsagePeriodEnd, nil
+}
+
+// ClearCurrentUsagePeriodEnd clears the value of the "current_usage_period_end" field.
+func (m *EntitlementMutation) ClearCurrentUsagePeriodEnd() {
+	m.current_usage_period_end = nil
+	m.clearedFields[entitlement.FieldCurrentUsagePeriodEnd] = struct{}{}
+}
+
+// CurrentUsagePeriodEndCleared returns if the "current_usage_period_end" field was cleared in this mutation.
+func (m *EntitlementMutation) CurrentUsagePeriodEndCleared() bool {
+	_, ok := m.clearedFields[entitlement.FieldCurrentUsagePeriodEnd]
+	return ok
+}
+
+// ResetCurrentUsagePeriodEnd resets all changes to the "current_usage_period_end" field.
+func (m *EntitlementMutation) ResetCurrentUsagePeriodEnd() {
+	m.current_usage_period_end = nil
+	delete(m.clearedFields, entitlement.FieldCurrentUsagePeriodEnd)
+}
+
 // AddUsageResetIDs adds the "usage_reset" edge to the UsageReset entity by ids.
 func (m *EntitlementMutation) AddUsageResetIDs(ids ...string) {
 	if m.usage_reset == nil {
@@ -880,7 +980,7 @@ func (m *EntitlementMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *EntitlementMutation) Fields() []string {
-	fields := make([]string, 0, 14)
+	fields := make([]string, 0, 16)
 	if m.namespace != nil {
 		fields = append(fields, entitlement.FieldNamespace)
 	}
@@ -923,6 +1023,12 @@ func (m *EntitlementMutation) Fields() []string {
 	if m.usage_period_anchor != nil {
 		fields = append(fields, entitlement.FieldUsagePeriodAnchor)
 	}
+	if m.current_usage_period_start != nil {
+		fields = append(fields, entitlement.FieldCurrentUsagePeriodStart)
+	}
+	if m.current_usage_period_end != nil {
+		fields = append(fields, entitlement.FieldCurrentUsagePeriodEnd)
+	}
 	return fields
 }
 
@@ -959,6 +1065,10 @@ func (m *EntitlementMutation) Field(name string) (ent.Value, bool) {
 		return m.UsagePeriodInterval()
 	case entitlement.FieldUsagePeriodAnchor:
 		return m.UsagePeriodAnchor()
+	case entitlement.FieldCurrentUsagePeriodStart:
+		return m.CurrentUsagePeriodStart()
+	case entitlement.FieldCurrentUsagePeriodEnd:
+		return m.CurrentUsagePeriodEnd()
 	}
 	return nil, false
 }
@@ -996,6 +1106,10 @@ func (m *EntitlementMutation) OldField(ctx context.Context, name string) (ent.Va
 		return m.OldUsagePeriodInterval(ctx)
 	case entitlement.FieldUsagePeriodAnchor:
 		return m.OldUsagePeriodAnchor(ctx)
+	case entitlement.FieldCurrentUsagePeriodStart:
+		return m.OldCurrentUsagePeriodStart(ctx)
+	case entitlement.FieldCurrentUsagePeriodEnd:
+		return m.OldCurrentUsagePeriodEnd(ctx)
 	}
 	return nil, fmt.Errorf("unknown Entitlement field %s", name)
 }
@@ -1103,6 +1217,20 @@ func (m *EntitlementMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetUsagePeriodAnchor(v)
 		return nil
+	case entitlement.FieldCurrentUsagePeriodStart:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCurrentUsagePeriodStart(v)
+		return nil
+	case entitlement.FieldCurrentUsagePeriodEnd:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCurrentUsagePeriodEnd(v)
+		return nil
 	}
 	return fmt.Errorf("unknown Entitlement field %s", name)
 }
@@ -1172,6 +1300,12 @@ func (m *EntitlementMutation) ClearedFields() []string {
 	if m.FieldCleared(entitlement.FieldUsagePeriodAnchor) {
 		fields = append(fields, entitlement.FieldUsagePeriodAnchor)
 	}
+	if m.FieldCleared(entitlement.FieldCurrentUsagePeriodStart) {
+		fields = append(fields, entitlement.FieldCurrentUsagePeriodStart)
+	}
+	if m.FieldCleared(entitlement.FieldCurrentUsagePeriodEnd) {
+		fields = append(fields, entitlement.FieldCurrentUsagePeriodEnd)
+	}
 	return fields
 }
 
@@ -1209,6 +1343,12 @@ func (m *EntitlementMutation) ClearField(name string) error {
 		return nil
 	case entitlement.FieldUsagePeriodAnchor:
 		m.ClearUsagePeriodAnchor()
+		return nil
+	case entitlement.FieldCurrentUsagePeriodStart:
+		m.ClearCurrentUsagePeriodStart()
+		return nil
+	case entitlement.FieldCurrentUsagePeriodEnd:
+		m.ClearCurrentUsagePeriodEnd()
 		return nil
 	}
 	return fmt.Errorf("unknown Entitlement nullable field %s", name)
@@ -1259,6 +1399,12 @@ func (m *EntitlementMutation) ResetField(name string) error {
 		return nil
 	case entitlement.FieldUsagePeriodAnchor:
 		m.ResetUsagePeriodAnchor()
+		return nil
+	case entitlement.FieldCurrentUsagePeriodStart:
+		m.ResetCurrentUsagePeriodStart()
+		return nil
+	case entitlement.FieldCurrentUsagePeriodEnd:
+		m.ResetCurrentUsagePeriodEnd()
 		return nil
 	}
 	return fmt.Errorf("unknown Entitlement field %s", name)

--- a/internal/entitlement/postgresadapter/ent/schema/entitlement.go
+++ b/internal/entitlement/postgresadapter/ent/schema/entitlement.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openmeterio/openmeter/internal/entitlement"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
 )
 
 type Entitlement struct {
@@ -35,8 +36,10 @@ func (Entitlement) Fields() []ent.Field {
 		field.Float("issue_after_reset").Optional().Nillable().Immutable(),
 		field.Bool("is_soft_limit").Optional().Nillable().Immutable(),
 		field.JSON("config", map[string]interface{}{}).Optional(),
-		field.Enum("usage_period_interval").Values(entitlement.UsagePeriodInterval("").StrValues()...).Optional().Nillable().Immutable(),
-		field.Time("usage_period_anchor").Optional().Nillable().Immutable(),
+		field.Enum("usage_period_interval").Values(recurrence.RecurrencePeriod("").Values()...).Optional().Nillable().Immutable(),
+		field.Time("usage_period_anchor").Optional().Nillable(),
+		field.Time("current_usage_period_start").Optional().Nillable(),
+		field.Time("current_usage_period_end").Optional().Nillable(),
 	}
 }
 
@@ -46,6 +49,7 @@ func (Entitlement) Indexes() []ent.Index {
 		index.Fields("namespace", "subject_key"),
 		index.Fields("namespace", "id", "subject_key"),
 		index.Fields("namespace", "feature_id", "id"),
+		index.Fields("namespace", "current_usage_period_end"),
 	}
 }
 

--- a/internal/entitlement/repository.go
+++ b/internal/entitlement/repository.go
@@ -2,15 +2,22 @@ package entitlement
 
 import (
 	"context"
+	"time"
 
+	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
+type UpdateEntitlementUsagePeriodParams struct {
+	NewAnchor          *time.Time
+	CurrentUsagePeriod api.Period
+}
+
 type EntitlementRepo interface {
 	// Entitlement Management
 	GetEntitlementsOfSubject(ctx context.Context, namespace string, subjectKey models.SubjectKey) ([]Entitlement, error)
-	CreateEntitlement(ctx context.Context, entitlement CreateEntitlementInputs) (*Entitlement, error)
+	CreateEntitlement(ctx context.Context, entitlement CreateEntitlementRepoInputs) (*Entitlement, error)
 	GetEntitlement(ctx context.Context, entitlementID models.NamespacedID) (*Entitlement, error)
 	GetEntitlementOfSubject(ctx context.Context, namespace string, subjectKey string, id string) (*Entitlement, error)
 
@@ -19,6 +26,23 @@ type EntitlementRepo interface {
 	//FIXME: This is a terrbile hack
 	LockEntitlementForTx(ctx context.Context, entitlementID models.NamespacedID) error
 
+	UpdateEntitlementUsagePeriod(ctx context.Context, entitlementID models.NamespacedID, params UpdateEntitlementUsagePeriodParams) error
+	ListEntitlementsWithExpiredUsagePeriod(ctx context.Context, namespace string, highwatermark time.Time) ([]Entitlement, error)
+
 	entutils.TxCreator
 	entutils.TxUser[EntitlementRepo]
+}
+
+type CreateEntitlementRepoInputs struct {
+	Namespace       string          `json:"namespace"`
+	FeatureID       string          `json:"featureId"`
+	SubjectKey      string          `json:"subjectKey"`
+	EntitlementType EntitlementType `json:"type"`
+
+	MeasureUsageFrom   *time.Time   `json:"measureUsageFrom,omitempty"`
+	IssueAfterReset    *float64     `json:"issueAfterReset,omitempty"`
+	IsSoftLimit        *bool        `json:"isSoftLimit,omitempty"`
+	Config             *string      `json:"config,omitempty"`
+	UsagePeriod        *UsagePeriod `json:"usagePeriod,omitempty"`
+	CurrentUsagePeriod *api.Period  `json:"currentUsagePeriod,omitempty"`
 }

--- a/openmeter/credit/types.go
+++ b/openmeter/credit/types.go
@@ -31,6 +31,4 @@ type OwnerConnector = credit.OwnerConnector
 type Pagination = credit.Pagination
 type Period = credit.Period
 type QueryUsageFn = credit.QueryUsageFn
-type Recurrence = credit.Recurrence
-type RecurrencePeriod = credit.RecurrencePeriod
 type SegmentTerminationReason = credit.SegmentTerminationReason

--- a/pkg/recurrence/recurrence.go
+++ b/pkg/recurrence/recurrence.go
@@ -1,4 +1,4 @@
-package credit
+package recurrence
 
 import (
 	"fmt"

--- a/pkg/recurrence/recurrence_test.go
+++ b/pkg/recurrence/recurrence_test.go
@@ -1,4 +1,4 @@
-package credit
+package recurrence
 
 import (
 	"testing"


### PR DESCRIPTION
This patch ensures that for metered entitlements we have the next reset time captured. Also we are providing the required function to perform the which can be supported as a cron job in the OpenMeter solution.

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->
