### PR TITLE
feat(api): allow filtering features by meterslug

### DIFF
--- a/internal/productcatalog/feature_connector.go
+++ b/internal/productcatalog/feature_connector.go
@@ -36,6 +36,7 @@ const (
 
 type ListFeaturesParams struct {
 	Namespace       string
+	MeterSlug       string
 	IncludeArchived bool
 	Offset          int
 	Limit           int

--- a/internal/productcatalog/postgresadapter/feature.go
+++ b/internal/productcatalog/postgresadapter/feature.go
@@ -91,6 +91,10 @@ func (c *featureDBAdapter) ListFeatures(ctx context.Context, params productcatal
 	query := c.db.Feature.Query().
 		Where(db_feature.Namespace(params.Namespace))
 
+	if params.MeterSlug != "" {
+		query.Where(db_feature.MeterSlugEQ(params.MeterSlug))
+	}
+
 	if !params.IncludeArchived {
 		query = query.Where(db_feature.ArchivedAtIsNil())
 	}


### PR DESCRIPTION
## Overview

Add `MeterSlug` to `productcatalog.ListFeaturesParams` to allow filtering _features_ based on _meter slug_.
