### PR TITLE
Undo meter based entitlement precision

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -353,7 +353,6 @@ func main() {
 		entitlementConnector = entitlement.NewEntitlementConnector(
 			entitlementRepo,
 			featureConnector,
-			meterRepository,
 			meteredEntitlementConnector,
 			staticEntitlementConnector,
 			booleanEntitlementConnector,

--- a/internal/credit/engine.go
+++ b/internal/credit/engine.go
@@ -1,28 +1,25 @@
 package credit
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
 
-	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/recurrence"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
 type Engine interface {
-	Run(ctx context.Context, grants []Grant, startingBalances GrantBalanceMap, startingOverage float64, period recurrence.Period) (endingBalances GrantBalanceMap, endingOverage float64, history []GrantBurnDownHistorySegment, err error)
+	Run(grants []Grant, startingBalances GrantBalanceMap, startingOverage float64, period recurrence.Period) (endingBalances GrantBalanceMap, endingOverage float64, history []GrantBurnDownHistorySegment, err error)
 }
 
-type QueryUsageFn func(ctx context.Context, from, to time.Time) (float64, error)
+type QueryUsageFn func(from, to time.Time) (float64, error)
 
-func NewEngine(getFeatureUsage QueryUsageFn, granuality models.WindowSize) Engine {
+func NewEngine(getFeatureUsage QueryUsageFn) Engine {
 	return &engine{
 		getFeatureUsage: getFeatureUsage,
-		granularity:     granuality.Duration(),
 	}
 }
 
@@ -32,8 +29,7 @@ type engine struct {
 	grants []Grant
 	// Returns the total feature usage in the queried period
 	getFeatureUsage QueryUsageFn
-
-	granularity time.Duration
+	// granularity     models.WindowSize // TODO: add granularity checks for all resources?
 
 	// Whether the engine was able to execute all calculations exactly
 	calcsExact bool // TODO: add public API and checking
@@ -43,7 +39,7 @@ type engine struct {
 var _ Engine = (*engine)(nil)
 
 // Burns down all grants in the defined period by the usage amounts.
-func (e *engine) Run(ctx context.Context, grants []Grant, startingBalances GrantBalanceMap, overage float64, period recurrence.Period) (GrantBalanceMap, float64, []GrantBurnDownHistorySegment, error) {
+func (e *engine) Run(grants []Grant, startingBalances GrantBalanceMap, overage float64, period recurrence.Period) (GrantBalanceMap, float64, []GrantBurnDownHistorySegment, error) {
 	if !startingBalances.ExactlyForGrants(grants) {
 		return nil, 0, nil, fmt.Errorf("provided grants and balances don't pair up")
 	}
@@ -134,7 +130,7 @@ func (e *engine) Run(ctx context.Context, grants []Grant, startingBalances Grant
 		}
 
 		// query feature usage in the burning phase
-		usage, err := e.getFeatureUsage(ctx, phase.from, phase.to)
+		usage, err := e.getFeatureUsage(phase.from, phase.to)
 		if err != nil {
 			return nil, 0, nil, fmt.Errorf("failed to get feature usage for period %s - %s: %w", period.From, period.To, err)
 		}
@@ -335,7 +331,7 @@ func (e *engine) getGrantActivityChanges(period recurrence.Period) []time.Time {
 
 	// FIXME: we should truncate on input but that's hard for voidedAt and deletedAt
 	for i, t := range activityChanges {
-		activityChanges[i] = t.Truncate(e.granularity)
+		activityChanges[i] = t.Truncate(time.Minute)
 	}
 
 	sort.Slice(activityChanges, func(i, j int) bool {

--- a/internal/credit/engine_test.go
+++ b/internal/credit/engine_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openmeterio/openmeter/internal/credit"
 	"github.com/openmeterio/openmeter/internal/streaming"
 	"github.com/openmeterio/openmeter/internal/streaming/testutils"
-	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/recurrence"
 )
 
@@ -62,7 +61,6 @@ func TestEngine(t *testing.T) {
 				g1 = makeGrant(g1)
 
 				b1, o1, s1, err1 := engine.Run(
-					context.Background(),
 					[]credit.Grant{g1},
 					credit.GrantBalanceMap{
 						g1.ID: 100.0,
@@ -75,7 +73,6 @@ func TestEngine(t *testing.T) {
 				assert.NoError(t, err1)
 
 				b2, o2, s2, err2 := engine.Run(
-					context.Background(),
 					[]credit.Grant{g1},
 					credit.GrantBalanceMap{
 						g1.ID: 100.0,
@@ -97,7 +94,6 @@ func TestEngine(t *testing.T) {
 			run: func(t *testing.T, engine credit.Engine, use addUsageFunc) {
 				use(50.0, t1.Add(time.Hour))
 				res, overage, segments, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{},
 					credit.GrantBalanceMap{}, 0, recurrence.Period{
 						From: t1,
@@ -127,7 +123,6 @@ func TestEngine(t *testing.T) {
 			run: func(t *testing.T, engine credit.Engine, use addUsageFunc) {
 				use(50.0, t1.Add(time.Hour))
 				_, _, _, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{},
 					credit.GrantBalanceMap{
 						grant1.ID: 100.0,
@@ -148,7 +143,6 @@ func TestEngine(t *testing.T) {
 				g2 := grant2
 				g2 = makeGrant(g2)
 				_, _, _, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{g1, g2},
 					credit.GrantBalanceMap{
 						grant1.ID: 100.0,
@@ -165,7 +159,6 @@ func TestEngine(t *testing.T) {
 			run: func(t *testing.T, engine credit.Engine, use addUsageFunc) {
 				use(50.0, t1.Add(time.Hour))
 				res, _, _, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{grant1},
 					credit.GrantBalanceMap{
 						grant1.ID: 100.0,
@@ -187,7 +180,6 @@ func TestEngine(t *testing.T) {
 				grant = makeGrant(grant)
 
 				res, _, _, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{grant},
 					credit.GrantBalanceMap{
 						grant.ID: 100.0,
@@ -210,7 +202,6 @@ func TestEngine(t *testing.T) {
 				grant = makeGrant(grant)
 
 				res, _, _, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{grant},
 					credit.GrantBalanceMap{
 						grant.ID: 100.0,
@@ -235,7 +226,6 @@ func TestEngine(t *testing.T) {
 				grant = makeGrant(grant)
 
 				res, overage, history, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{grant},
 					credit.GrantBalanceMap{
 						grant.ID: 100.0,
@@ -265,7 +255,6 @@ func TestEngine(t *testing.T) {
 				grant = makeGrant(grant)
 
 				res, overage, history, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{grant},
 					credit.GrantBalanceMap{
 						grant.ID: 100.0,
@@ -294,7 +283,6 @@ func TestEngine(t *testing.T) {
 				grant = makeGrant(grant)
 
 				res, _, _, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{grant},
 					credit.GrantBalanceMap{
 						grant.ID: 100.0,
@@ -318,7 +306,6 @@ func TestEngine(t *testing.T) {
 				grant = makeGrant(grant)
 
 				res, _, _, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{grant},
 					credit.GrantBalanceMap{
 						grant.ID: 100.0,
@@ -347,7 +334,6 @@ func TestEngine(t *testing.T) {
 				grant = makeGrant(grant)
 
 				res, _, segments, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{grant},
 					credit.GrantBalanceMap{
 						grant.ID: 0.0,
@@ -385,7 +371,6 @@ func TestEngine(t *testing.T) {
 				g2 = makeGrant(g2)
 
 				res, _, _, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{g1, g2},
 					credit.GrantBalanceMap{
 						g1.ID: 100.0,
@@ -418,7 +403,6 @@ func TestEngine(t *testing.T) {
 				g2 = makeGrant(g2)
 
 				res, _, _, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{g2, g1},
 					credit.GrantBalanceMap{
 						g1.ID: 100.0,
@@ -451,7 +435,6 @@ func TestEngine(t *testing.T) {
 				g2 = makeGrant(g2)
 
 				res, _, _, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{g2, g1},
 					credit.GrantBalanceMap{
 						g1.ID: 100.0,
@@ -510,7 +493,6 @@ func TestEngine(t *testing.T) {
 				use(99, t1.Add(time.Hour))
 
 				res, _, _, err := engine.Run(
-					context.Background(),
 					grants,
 					bm,
 					0,
@@ -543,7 +525,6 @@ func TestEngine(t *testing.T) {
 				g1 = makeGrant(g1)
 
 				res, _, _, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{g1},
 					credit.GrantBalanceMap{
 						g1.ID: 100.0,
@@ -588,7 +569,6 @@ func TestEngine(t *testing.T) {
 				g2 = makeGrant(g2)
 
 				res1, _, _, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{g1, g2},
 					credit.GrantBalanceMap{
 						g1.ID: 80.0, // due to use before start
@@ -636,7 +616,6 @@ func TestEngine(t *testing.T) {
 				g2 = makeGrant(g2)
 
 				res2, _, _, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{g1, g2},
 					credit.GrantBalanceMap{
 						g1.ID: 80.0, // due to use before start
@@ -691,7 +670,6 @@ func TestEngine(t *testing.T) {
 				g2 = makeGrant(g2)
 
 				_, _, segments, err := engine.Run(
-					context.Background(),
 					[]credit.Grant{g1, g2},
 					credit.GrantBalanceMap{
 						g1.ID: 80.0, // due to use before start
@@ -726,8 +704,8 @@ func TestEngine(t *testing.T) {
 			t.Parallel()
 			streamingConnector := testutils.NewMockStreamingConnector(t)
 
-			queryFeatureUsage := func(ctx context.Context, from, to time.Time) (float64, error) {
-				rows, err := streamingConnector.QueryMeter(ctx, "default", meterSlug, &streaming.QueryParams{
+			queryFeatureUsage := func(from, to time.Time) (float64, error) {
+				rows, err := streamingConnector.QueryMeter(context.TODO(), "default", meterSlug, &streaming.QueryParams{
 					From: &from,
 					To:   &to,
 				})
@@ -742,7 +720,7 @@ func TestEngine(t *testing.T) {
 				}
 				return rows[0].Value, nil
 			}
-			tc.run(t, credit.NewEngine(queryFeatureUsage, models.WindowSizeMinute), func(usage float64, at time.Time) {
+			tc.run(t, credit.NewEngine(queryFeatureUsage), func(usage float64, at time.Time) {
 				streamingConnector.AddSimpleEvent(meterSlug, usage, at)
 			})
 		})
@@ -752,12 +730,12 @@ func TestEngine(t *testing.T) {
 	tt2 := []struct {
 		name   string
 		repeat int
-		run    func(t *testing.T, queryFn func(ctx context.Context, from time.Time, to time.Time) (float64, error), use addUsageFunc)
+		run    func(t *testing.T, queryFn func(from time.Time, to time.Time) (float64, error), use addUsageFunc)
 	}{
 		{
 			name:   "Calculating same period in 2 runs yields same result as calculations in one run",
 			repeat: 1,
-			run: func(t *testing.T, queryFn func(ctx context.Context, from time.Time, to time.Time) (float64, error), use addUsageFunc) {
+			run: func(t *testing.T, queryFn func(from time.Time, to time.Time) (float64, error), use addUsageFunc) {
 				// burn down with usage after grant effectiveAt
 				start := t1
 
@@ -781,12 +759,11 @@ func TestEngine(t *testing.T) {
 					g2.ID: 82.0,
 				}
 
-				engine1 := credit.NewEngine(queryFn, models.WindowSizeMinute) // runs for first part
-				engine2 := credit.NewEngine(queryFn, models.WindowSizeMinute) // runs for second part
-				engine3 := credit.NewEngine(queryFn, models.WindowSizeMinute) // runs for both parts
+				engine1 := credit.NewEngine(queryFn) // runs for first part
+				engine2 := credit.NewEngine(queryFn) // runs for second part
+				engine3 := credit.NewEngine(queryFn) // runs for both parts
 
 				intermediateBalance, overage, _, err := engine1.Run(
-					context.Background(),
 					[]credit.Grant{g1, g2},
 					startingBalance,
 					0,
@@ -798,7 +775,6 @@ func TestEngine(t *testing.T) {
 				assert.NoError(t, err)
 
 				finalBalance1, _, _, err := engine2.Run(
-					context.Background(),
 					[]credit.Grant{g1, g2},
 					intermediateBalance,
 					overage,
@@ -810,7 +786,6 @@ func TestEngine(t *testing.T) {
 				assert.NoError(t, err)
 
 				finalBalance2, _, _, err := engine3.Run(
-					context.Background(),
 					[]credit.Grant{g1, g2},
 					startingBalance,
 					0,
@@ -828,7 +803,7 @@ func TestEngine(t *testing.T) {
 		{
 			name:   "Deterministic",
 			repeat: 10,
-			run: func(t *testing.T, queryFn func(ctx context.Context, from time.Time, to time.Time) (float64, error), use addUsageFunc) {
+			run: func(t *testing.T, queryFn func(from time.Time, to time.Time) (float64, error), use addUsageFunc) {
 				granularity := time.Minute
 
 				// run for 1 month
@@ -878,16 +853,13 @@ func TestEngine(t *testing.T) {
 				balances := startingBalances.Copy()
 				results := make([]credit.GrantBalanceMap, numOfRuns)
 				for i := 0; i < numOfRuns; i++ {
-					engine := credit.NewEngine(queryFn, models.WindowSizeMinute)
+					engine := credit.NewEngine(queryFn)
 					gCp := make([]credit.Grant, len(grants))
 					copy(gCp, grants)
-					result, _, _, err := engine.Run(
-						context.Background(),
-						gCp, balances, 0,
-						recurrence.Period{
-							From: start,
-							To:   end,
-						})
+					result, _, _, err := engine.Run(gCp, balances, 0, recurrence.Period{
+						From: start,
+						To:   end,
+					})
 					if err != nil {
 						t.Fatalf("unexpected error: %v", err)
 					}
@@ -911,7 +883,7 @@ func TestEngine(t *testing.T) {
 		{
 			name:   "Fuzzing sequences",
 			repeat: 10,
-			run: func(t *testing.T, queryFn func(ctx context.Context, from time.Time, to time.Time) (float64, error), use addUsageFunc) {
+			run: func(t *testing.T, queryFn func(from time.Time, to time.Time) (float64, error), use addUsageFunc) {
 				granularity := time.Minute
 
 				// run for 1 month
@@ -958,16 +930,13 @@ func TestEngine(t *testing.T) {
 				}
 
 				// run calculation on single engine
-				singleEngine := credit.NewEngine(queryFn, models.WindowSizeMinute)
+				singleEngine := credit.NewEngine(queryFn)
 				gCp := make([]credit.Grant, len(grants))
 				copy(gCp, grants)
-				singleEngineResult, _, _, err := singleEngine.Run(
-					context.Background(),
-					gCp, startingBalances, 0,
-					recurrence.Period{
-						From: start,
-						To:   end,
-					})
+				singleEngineResult, _, _, err := singleEngine.Run(gCp, startingBalances, 0, recurrence.Period{
+					From: start,
+					To:   end,
+				})
 				if err != nil {
 					// lets save ourselves the calculation if this already fails
 					t.Fatalf("unexpected error: %v", err)
@@ -994,16 +963,13 @@ func TestEngine(t *testing.T) {
 					// 	To:   pEnd,
 					// })
 
-					engine := credit.NewEngine(queryFn, models.WindowSizeMinute)
+					engine := credit.NewEngine(queryFn)
 					gCp := make([]credit.Grant, len(grants))
 					copy(gCp, grants)
-					balances, overage, _, err = engine.Run(
-						context.Background(),
-						gCp, balances, overage,
-						recurrence.Period{
-							From: pStart,
-							To:   pEnd,
-						})
+					balances, overage, _, err = engine.Run(gCp, balances, overage, recurrence.Period{
+						From: pStart,
+						To:   pEnd,
+					})
 					if err != nil {
 						t.Fatalf("unexpected error: %v", err)
 					}
@@ -1022,8 +988,8 @@ func TestEngine(t *testing.T) {
 				t.Parallel()
 				streamingConnector := testutils.NewMockStreamingConnector(t)
 
-				queryFeatureUsage := func(ctx context.Context, from, to time.Time) (float64, error) {
-					rows, err := streamingConnector.QueryMeter(ctx, "default", meterSlug, &streaming.QueryParams{
+				queryFeatureUsage := func(from, to time.Time) (float64, error) {
+					rows, err := streamingConnector.QueryMeter(context.TODO(), "default", meterSlug, &streaming.QueryParams{
 						From: &from,
 						To:   &to,
 					})

--- a/internal/credit/owner_connector.go
+++ b/internal/credit/owner_connector.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/openmeterio/openmeter/internal/streaming"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
-	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type EndCurrentUsagePeriodParams struct {
@@ -15,14 +14,8 @@ type EndCurrentUsagePeriodParams struct {
 	RetainAnchor bool
 }
 
-type OwnerMeter struct {
-	MeterSlug     string
-	DefaultParams *streaming.QueryParams
-	WindowSize    models.WindowSize
-}
-
 type OwnerConnector interface {
-	GetMeter(ctx context.Context, owner NamespacedGrantOwner) (*OwnerMeter, error)
+	GetOwnerQueryParams(ctx context.Context, owner NamespacedGrantOwner) (meterSlug string, defaultParams *streaming.QueryParams, err error)
 	GetStartOfMeasurement(ctx context.Context, owner NamespacedGrantOwner) (time.Time, error)
 	GetPeriodStartTimesBetween(ctx context.Context, owner NamespacedGrantOwner, from, to time.Time) ([]time.Time, error)
 	GetUsagePeriodStartAt(ctx context.Context, owner NamespacedGrantOwner, at time.Time) (time.Time, error)

--- a/internal/entitlement/connector.go
+++ b/internal/entitlement/connector.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openmeterio/openmeter/internal/meter"
 	"github.com/openmeterio/openmeter/internal/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -47,13 +46,11 @@ type entitlementConnector struct {
 
 	entitlementRepo  EntitlementRepo
 	featureConnector productcatalog.FeatureConnector
-	meterRepo        meter.Repository
 }
 
 func NewEntitlementConnector(
 	entitlementRepo EntitlementRepo,
 	featureConnector productcatalog.FeatureConnector,
-	meterRepo meter.Repository,
 	meteredEntitlementConnector SubTypeConnector,
 	staticEntitlementConnector SubTypeConnector,
 	booleanEntitlementConnector SubTypeConnector,
@@ -64,7 +61,6 @@ func NewEntitlementConnector(
 		booleanEntitlementConnector: booleanEntitlementConnector,
 		entitlementRepo:             entitlementRepo,
 		featureConnector:            featureConnector,
-		meterRepo:                   meterRepo,
 	}
 }
 
@@ -113,13 +109,8 @@ func (c *entitlementConnector) CreateEntitlement(ctx context.Context, input Crea
 	var usagePeriod *UsagePeriod
 	var currentUsagePeriod *recurrence.Period
 	if input.UsagePeriod != nil {
-		meter, err := c.meterRepo.GetMeterByIDOrSlug(ctx, feature.Namespace, *feature.MeterSlug)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get meter: %w", err)
-		}
-
 		usagePeriod = input.UsagePeriod
-		usagePeriod.Anchor = usagePeriod.Anchor.Truncate(meter.WindowSize.Duration())
+		usagePeriod.Anchor = usagePeriod.Anchor.Truncate(time.Minute)
 
 		calculatedPeriod, err := usagePeriod.GetCurrentPeriod()
 		if err != nil {

--- a/internal/entitlement/metered/balance.go
+++ b/internal/entitlement/metered/balance.go
@@ -58,7 +58,7 @@ func (e *connector) GetEntitlementBalance(ctx context.Context, entitlementID mod
 		return nil, err
 	}
 
-	ownerMeter, err := e.ownerConnector.GetMeter(ctx, nsOwner)
+	meterSlug, params, err := e.ownerConnector.GetOwnerQueryParams(ctx, nsOwner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get owner query params: %w", err)
 	}
@@ -68,11 +68,10 @@ func (e *connector) GetEntitlementBalance(ctx context.Context, entitlementID mod
 		return nil, fmt.Errorf("failed to get current usage period start at: %w", err)
 	}
 
-	meterQuery := ownerMeter.DefaultParams
-	meterQuery.From = &startOfPeriod
-	meterQuery.To = &at
+	params.From = &startOfPeriod
+	params.To = &at
 
-	rows, err := e.streamingConnector.QueryMeter(ctx, entitlementID.Namespace, ownerMeter.MeterSlug, meterQuery)
+	rows, err := e.streamingConnector.QueryMeter(ctx, entitlementID.Namespace, meterSlug, params)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query meter: %w", err)
 	}
@@ -128,28 +127,25 @@ func (e *connector) GetEntitlementBalanceHistory(ctx context.Context, entitlemen
 		ID:        credit.GrantOwner(entitlementID.ID),
 	}
 
-	ownerMeter, err := e.ownerConnector.GetMeter(ctx, owner)
-	if err != nil {
-		return nil, credit.GrantBurnDownHistory{}, fmt.Errorf("failed to get owner query params: %w", err)
-	}
-
 	// 1. we get the burndown history
 	burndownHistory, err := e.balanceConnector.GetBalanceHistoryOfOwner(ctx, owner, credit.BalanceHistoryParams{
-		From: params.From.Truncate(ownerMeter.WindowSize.Duration()),
-		To:   params.To.Truncate(ownerMeter.WindowSize.Duration()),
+		From: params.From.Truncate(time.Minute),
+		To:   params.To.Truncate(time.Minute),
 	})
 	if err != nil {
 		return nil, credit.GrantBurnDownHistory{}, fmt.Errorf("failed to get balance history: %w", err)
 	}
-
 	// 2. and we get the windowed usage data
-	meterQuery := ownerMeter.DefaultParams
-	meterQuery.From = params.From
-	meterQuery.To = params.To
-	meterQuery.WindowSize = convert.ToPointer(models.WindowSize(params.WindowSize))
-	meterQuery.WindowTimeZone = &params.WindowTimeZone
+	meterSlug, meterParams, err := e.ownerConnector.GetOwnerQueryParams(ctx, owner)
+	if err != nil {
+		return nil, credit.GrantBurnDownHistory{}, fmt.Errorf("failed to get owner query params: %w", err)
+	}
+	meterParams.From = params.From
+	meterParams.To = params.To
+	meterParams.WindowSize = convert.ToPointer(models.WindowSize(params.WindowSize))
+	meterParams.WindowTimeZone = &params.WindowTimeZone
 
-	meterRows, err := e.streamingConnector.QueryMeter(ctx, owner.Namespace, ownerMeter.MeterSlug, meterQuery)
+	meterRows, err := e.streamingConnector.QueryMeter(ctx, owner.Namespace, meterSlug, meterParams)
 	if err != nil {
 		return nil, credit.GrantBurnDownHistory{}, fmt.Errorf("failed to query meter: %w", err)
 	}
@@ -157,10 +153,10 @@ func (e *connector) GetEntitlementBalanceHistory(ctx context.Context, entitlemen
 	// If we get 0 rows that means the windowsize is larger than the queried period.
 	// In this case we simply query for the entire period.
 	if len(meterRows) == 0 {
-		nonWindowedParams := *meterQuery
+		nonWindowedParams := *meterParams
 		nonWindowedParams.WindowSize = nil
 		nonWindowedParams.WindowTimeZone = nil
-		meterRows, err = e.streamingConnector.QueryMeter(ctx, owner.Namespace, ownerMeter.MeterSlug, &nonWindowedParams)
+		meterRows, err = e.streamingConnector.QueryMeter(ctx, owner.Namespace, meterSlug, &nonWindowedParams)
 		if err != nil {
 			return nil, credit.GrantBurnDownHistory{}, fmt.Errorf("failed to query meter: %w", err)
 		}

--- a/internal/entitlement/metered/balance_test.go
+++ b/internal/entitlement/metered/balance_test.go
@@ -1366,7 +1366,6 @@ func setupConnector(t *testing.T) (meteredentitlement.Connector, *testDependenci
 		Slug:        "meter1",
 		Namespace:   "ns1",
 		Aggregation: models.MeterAggregationMax,
-		WindowSize:  models.WindowSizeMinute,
 	}})
 
 	// create isolated pg db for tests

--- a/internal/entitlement/metered/grant_owner_adapter.go
+++ b/internal/entitlement/metered/grant_owner_adapter.go
@@ -39,33 +39,32 @@ func NewEntitlementGrantOwnerAdapter(
 	}
 }
 
-func (e *entitlementGrantOwner) GetMeter(ctx context.Context, owner credit.NamespacedGrantOwner) (*credit.OwnerMeter, error) {
+func (e *entitlementGrantOwner) GetOwnerQueryParams(ctx context.Context, owner credit.NamespacedGrantOwner) (meterSlug string, defaultParams *streaming.QueryParams, err error) {
 	// get feature of entitlement
 	entitlement, err := e.entitlementRepo.GetEntitlement(ctx, owner.NamespacedID())
 	if err != nil {
 		e.logger.Debug(fmt.Sprintf("failed to get entitlement for owner %s in namespace %s: %s", string(owner.ID), owner.Namespace, err))
-		return nil, &credit.OwnerNotFoundError{
+		return "", nil, &credit.OwnerNotFoundError{
 			Owner:          owner,
 			AttemptedOwner: "entitlement",
 		}
 	}
 	feature, err := e.featureRepo.GetByIdOrKey(ctx, owner.Namespace, entitlement.FeatureID, true)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get feature of entitlement: %w", err)
+		return "", nil, fmt.Errorf("failed to get feature of entitlement: %w", err)
 	}
 
 	if feature.MeterSlug == nil {
-		return nil, fmt.Errorf("feature does not have a meter")
+		return "", nil, fmt.Errorf("feature does not have a meter")
 	}
 
 	meter, err := e.meterRepo.GetMeterByIDOrSlug(ctx, feature.Namespace, *feature.MeterSlug)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get meter: %w", err)
+		return "", nil, fmt.Errorf("failed to get meter: %w", err)
 	}
 
 	queryParams := &streaming.QueryParams{
 		Aggregation: meter.Aggregation,
-		WindowSize:  &meter.WindowSize,
 	}
 
 	if feature.MeterGroupByFilters != nil {
@@ -75,11 +74,7 @@ func (e *entitlementGrantOwner) GetMeter(ctx context.Context, owner credit.Names
 		}
 	}
 
-	return &credit.OwnerMeter{
-		MeterSlug:     meter.Slug,
-		DefaultParams: queryParams,
-		WindowSize:    meter.WindowSize,
-	}, nil
+	return *feature.MeterSlug, queryParams, nil
 }
 
 func (e *entitlementGrantOwner) GetStartOfMeasurement(ctx context.Context, owner credit.NamespacedGrantOwner) (time.Time, error) {

--- a/openmeter/entitlement/adapters.go
+++ b/openmeter/entitlement/adapters.go
@@ -2,17 +2,15 @@ package entitlement
 
 import (
 	"github.com/openmeterio/openmeter/internal/entitlement"
-	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 )
 
 func NewEntitlementConnector(
 	edb EntitlementRepo,
 	fc productcatalog.FeatureConnector,
-	meterRepo meter.Repository,
 	metered SubTypeConnector,
 	static SubTypeConnector,
 	boolean SubTypeConnector,
 ) EntitlementConnector {
-	return entitlement.NewEntitlementConnector(edb, fc, meterRepo, metered, static, boolean)
+	return entitlement.NewEntitlementConnector(edb, fc, metered, static, boolean)
 }


### PR DESCRIPTION
This reverts commit 5edd28bfaff0fa602cb748cd709c2a3552d28d23, reversing changes made to 4cb2bb7e065bd4db0558414e4f2a940da5dc9916 in PR https://github.com/openmeterio/openmeter/pull/1106

Apparently we disregard the meter granularity settings, see
view creation: https://github.com/openmeterio/openmeter/blob/09ad0908c1acb5d7bfdd7171ceb625f6391631a4/internal/streaming/clickhouse_connector/query.go#L187
meter interface:
https://github.com/openmeterio/openmeter/blob/a7c1ffb973b72f31cdda20c0d36cf9384800f8bc/pkg/models/meter.go#L112

When reading the meters from config it doesn't actually have a value, and values other than minute are not supported in cloud.