### PR TITLE
chore: disable snapshotting feature by default

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -317,7 +317,12 @@ func main() {
 		entitlementRepo := entitlementpgadapter.NewPostgresEntitlementRepo(pgClients.entitlementDBClient)
 		usageResetRepo := entitlementpgadapter.NewPostgresUsageResetRepo(pgClients.entitlementDBClient)
 		grantRepo := creditpgadapter.NewPostgresGrantRepo(pgClients.creditDBClient)
-		balanceSnashotRepo := creditpgadapter.NewPostgresBalanceSnapshotRepo(pgClients.creditDBClient)
+		balanceSnashotRepo := creditpgadapter.NewPostgresBalanceSnapshotRepo(
+			pgClients.creditDBClient,
+			creditpgadapter.BalanceSnapshotConfig{
+				Enabled: conf.Entitlements.BalanceSnapshot.Enabled,
+			},
+		)
 
 		// connectors
 		featureConnector = productcatalog.NewFeatureConnector(featureRepo, meterRepository)

--- a/config/entitlements.go
+++ b/config/entitlements.go
@@ -1,6 +1,11 @@
 package config
 
 type EntitlementsConfiguration struct {
+	Enabled         bool
+	BalanceSnapshot BalanceSnapshotConfig
+}
+
+type BalanceSnapshotConfig struct {
 	Enabled bool
 }
 

--- a/internal/credit/postgresadapter/transaction.go
+++ b/internal/credit/postgresadapter/transaction.go
@@ -40,5 +40,5 @@ func (e *balanceSnapshotAdapter) Tx(ctx context.Context) (context.Context, *entu
 
 func (e *balanceSnapshotAdapter) WithTx(ctx context.Context, tx *entutils.TxDriver) credit.BalanceSnapshotConnector {
 	txClient := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
-	return NewPostgresBalanceSnapshotRepo(txClient.Client())
+	return NewPostgresBalanceSnapshotRepo(txClient.Client(), e.config)
 }

--- a/internal/entitlement/metered/balance_test.go
+++ b/internal/entitlement/metered/balance_test.go
@@ -1382,7 +1382,9 @@ func setupConnector(t *testing.T) (meteredentitlement.Connector, *testDependenci
 
 	grantDbClient := credit_postgres_adapter_db.NewClient(credit_postgres_adapter_db.Driver(driver))
 	grantDbConn := credit_postgres_adapter.NewPostgresGrantRepo(grantDbClient)
-	balanceSnapshotDbConn := credit_postgres_adapter.NewPostgresBalanceSnapshotRepo(grantDbClient)
+	balanceSnapshotDbConn := credit_postgres_adapter.NewPostgresBalanceSnapshotRepo(grantDbClient, credit_postgres_adapter.BalanceSnapshotConfig{
+		Enabled: true,
+	})
 
 	m.Lock()
 	defer m.Unlock()

--- a/openmeter/credit/postgresadapter/adapters.go
+++ b/openmeter/credit/postgresadapter/adapters.go
@@ -5,8 +5,10 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/credit"
 )
 
-func NewPostgresBalanceSnapshotDBAdapter(db *DBClient) credit.BalanceSnapshotConnector {
-	return postgresadapter.NewPostgresBalanceSnapshotRepo(db)
+type BalanceSnapshotConfig = postgresadapter.BalanceSnapshotConfig
+
+func NewPostgresBalanceSnapshotDBAdapter(db *DBClient, config BalanceSnapshotConfig) credit.BalanceSnapshotConnector {
+	return postgresadapter.NewPostgresBalanceSnapshotRepo(db, config)
 }
 
 func NewPostgresGrantDBAdapter(db *DBClient) credit.GrantRepo {


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch ensures that balance snapshots based caching is disabled by default. It can be enable to speed up queries, however any inconsistencies in the cache itself causes a ripple effect that queries for the value endpoints will fail indefinetly.

We will enable this in the forthcoming releases when the calculation algorithm has been already verified to be stable.

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
