### PR TITLE
fix: remove redundant error check

### DIFF
--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -422,9 +422,6 @@ func (s *Sink) subscribeToNamespaces(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to subscribe to topics: %s", err)
 		}
-		if err != nil {
-			return fmt.Errorf("failed to subscribe to topics: %s", err)
-		}
 	}
 
 	return nil


### PR DESCRIPTION
## Overview

- Removes a redundant error check that was previously removed in #880 but was reverted.
