### PR TITLE
fix: engine cannot query windowed data

### DIFF
--- a/internal/entitlement/metered/grant_owner_adapter.go
+++ b/internal/entitlement/metered/grant_owner_adapter.go
@@ -66,7 +66,6 @@ func (e *entitlementGrantOwner) GetMeter(ctx context.Context, owner credit.Names
 
 	queryParams := &streaming.QueryParams{
 		Aggregation: meter.Aggregation,
-		WindowSize:  &meter.WindowSize,
 	}
 
 	if feature.MeterGroupByFilters != nil {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

The default meter query params should not have a windowsize.

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->
