### PR TITLE
fix: query usage for same period as balance is queried for

### DIFF
--- a/internal/entitlement/metered/balance.go
+++ b/internal/entitlement/metered/balance.go
@@ -75,7 +75,7 @@ func (e *connector) GetEntitlementBalance(ctx context.Context, entitlementID mod
 
 	// We round up to closest full minute to include all the partial usage in the last minute of querying
 	if trunc := meterQuery.To.Truncate(time.Minute); trunc.Before(*meterQuery.To) {
-		meterQuery.To = &trunc
+		meterQuery.To = convert.ToPointer(trunc.Add(time.Minute))
 	}
 
 	rows, err := e.streamingConnector.QueryMeter(ctx, entitlementID.Namespace, ownerMeter.MeterSlug, meterQuery)

--- a/internal/entitlement/metered/balance.go
+++ b/internal/entitlement/metered/balance.go
@@ -73,6 +73,11 @@ func (e *connector) GetEntitlementBalance(ctx context.Context, entitlementID mod
 	meterQuery.From = &startOfPeriod
 	meterQuery.To = &at
 
+	// We round up to closest full minute to include all the partial usage in the last minute of querying
+	if trunc := meterQuery.To.Truncate(time.Minute); trunc.Before(*meterQuery.To) {
+		meterQuery.To = &trunc
+	}
+
 	rows, err := e.streamingConnector.QueryMeter(ctx, entitlementID.Namespace, ownerMeter.MeterSlug, meterQuery)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query meter: %w", err)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

When fetching metered entitlement value, always fetch for the end of the current minute

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->
