### PR TITLE
fix: meters weren't filtered by subject

### DIFF
--- a/internal/credit/owner_connector.go
+++ b/internal/credit/owner_connector.go
@@ -19,6 +19,7 @@ type OwnerMeter struct {
 	MeterSlug     string
 	DefaultParams *streaming.QueryParams
 	WindowSize    models.WindowSize
+	SubjectKey    string
 }
 
 type OwnerConnector interface {
@@ -26,6 +27,7 @@ type OwnerConnector interface {
 	GetStartOfMeasurement(ctx context.Context, owner NamespacedGrantOwner) (time.Time, error)
 	GetPeriodStartTimesBetween(ctx context.Context, owner NamespacedGrantOwner, from, to time.Time) ([]time.Time, error)
 	GetUsagePeriodStartAt(ctx context.Context, owner NamespacedGrantOwner, at time.Time) (time.Time, error)
+	GetOwnerSubjectKey(ctx context.Context, owner NamespacedGrantOwner) (string, error)
 
 	//FIXME: this is a terrible hack
 	EndCurrentUsagePeriodTx(ctx context.Context, tx *entutils.TxDriver, owner NamespacedGrantOwner, params EndCurrentUsagePeriodParams) error

--- a/internal/entitlement/metered/grant_owner_adapter.go
+++ b/internal/entitlement/metered/grant_owner_adapter.go
@@ -79,6 +79,7 @@ func (e *entitlementGrantOwner) GetMeter(ctx context.Context, owner credit.Names
 		MeterSlug:     meter.Slug,
 		DefaultParams: queryParams,
 		WindowSize:    meter.WindowSize,
+		SubjectKey:    entitlement.SubjectKey,
 	}, nil
 }
 
@@ -112,6 +113,17 @@ func (e *entitlementGrantOwner) GetUsagePeriodStartAt(ctx context.Context, owner
 	}
 
 	return lastUsageReset.ResetTime, nil
+}
+
+func (e *entitlementGrantOwner) GetOwnerSubjectKey(ctx context.Context, owner credit.NamespacedGrantOwner) (string, error) {
+	entitlement, err := getRepoMaybeInTx(ctx, e.entitlementRepo, e.entitlementRepo).GetEntitlement(ctx, owner.NamespacedID())
+	if err != nil {
+		return "", &credit.OwnerNotFoundError{
+			Owner:          owner,
+			AttemptedOwner: "entitlement",
+		}
+	}
+	return entitlement.SubjectKey, nil
 }
 
 func (e *entitlementGrantOwner) GetPeriodStartTimesBetween(ctx context.Context, owner credit.NamespacedGrantOwner, from, to time.Time) ([]time.Time, error) {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Due to an oversight in the calculation logic, all metered usage were calculated towards entitlements. This patch ensures that we only use the specified subject's data.
