### PR TITLE
refactor: split ingest and kafka specific config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -77,18 +77,20 @@ func TestComplete(t *testing.T) {
 		},
 		Ingest: IngestConfiguration{
 			Kafka: KafkaIngestConfiguration{
-				Broker:              "127.0.0.1:9092",
-				SecurityProtocol:    "SASL_SSL",
-				SaslMechanisms:      "PLAIN",
-				SaslUsername:        "user",
-				SaslPassword:        "pass",
+				KafkaConfiguration: KafkaConfiguration{
+					Broker:           "127.0.0.1:9092",
+					SecurityProtocol: "SASL_SSL",
+					SaslMechanisms:   "PLAIN",
+					SaslUsername:     "user",
+					SaslPassword:     "pass",
+
+					BrokerAddressFamily:          pkgkafka.BrokerAddressFamilyAny,
+					TopicMetadataRefreshInterval: pkgkafka.TimeDurationMilliSeconds(time.Minute),
+					StatsInterval:                pkgkafka.TimeDurationMilliSeconds(5 * time.Second),
+					SocketKeepAliveEnabled:       true,
+				},
 				Partitions:          1,
 				EventsTopicTemplate: "om_%s_events",
-
-				BrokerAddressFamily:          pkgkafka.BrokerAddressFamilyAny,
-				TopicMetadataRefreshInterval: pkgkafka.TimeDurationMilliSeconds(time.Minute),
-				StatsInterval:                pkgkafka.TimeDurationMilliSeconds(5 * time.Second),
-				SocketKeepAliveEnabled:       true,
 			},
 		},
 		Aggregation: AggregationConfiguration{

--- a/config/ingest_test.go
+++ b/config/ingest_test.go
@@ -15,12 +15,12 @@ func TestKafkaIngestConfiguration(t *testing.T) {
 	tests := []struct {
 		Name string
 
-		KafkaConfig            KafkaIngestConfiguration
+		KafkaConfig            KafkaConfiguration
 		ExpectedKafkaConfigMap kafka.ConfigMap
 	}{
 		{
 			Name: "All",
-			KafkaConfig: KafkaIngestConfiguration{
+			KafkaConfig: KafkaConfiguration{
 				Broker:                       "127.0.0.1:29092",
 				SecurityProtocol:             "SASL_SSL",
 				SaslMechanisms:               "PLAIN",
@@ -47,7 +47,7 @@ func TestKafkaIngestConfiguration(t *testing.T) {
 		},
 		{
 			Name: "Basic",
-			KafkaConfig: KafkaIngestConfiguration{
+			KafkaConfig: KafkaConfiguration{
 				Broker: "127.0.0.1:29092",
 			},
 			ExpectedKafkaConfigMap: kafka.ConfigMap{


### PR DESCRIPTION

## Overview

This allows us to reuse the Kafka configuration object in other parts of the system/other configuration files.


## Notes for reviewer

The mapstructure tag is required so that viper merges the two objects as expected.

<!-- Anything the reviewer should know? -->
