### PR TITLE
fix: config validation for static entitlements

### DIFF
--- a/internal/entitlement/entitlement.go
+++ b/internal/entitlement/entitlement.go
@@ -23,7 +23,7 @@ type CreateEntitlementInputs struct {
 	MeasureUsageFrom *time.Time   `json:"measureUsageFrom,omitempty"`
 	IssueAfterReset  *float64     `json:"issueAfterReset,omitempty"`
 	IsSoftLimit      *bool        `json:"isSoftLimit,omitempty"`
-	Config           *string      `json:"config,omitempty"`
+	Config           []byte       `json:"config,omitempty"`
 	UsagePeriod      *UsagePeriod `json:"usagePeriod,omitempty"`
 }
 
@@ -43,7 +43,7 @@ type Entitlement struct {
 	LastReset        *time.Time `json:"lastReset,omitempty"`
 
 	// static
-	Config *string `json:"config,omitempty"`
+	Config []byte `json:"config,omitempty"`
 }
 
 func (e Entitlement) GetType() EntitlementType {

--- a/internal/entitlement/httpdriver/entitlement.go
+++ b/internal/entitlement/httpdriver/entitlement.go
@@ -98,7 +98,7 @@ func (h *entitlementHandler) CreateEntitlement() CreateEntitlementHandler {
 					FeatureKey:      v.FeatureKey,
 					SubjectKey:      subjectIdOrKey,
 					EntitlementType: entitlement.EntitlementTypeStatic,
-					Config:          &v.Config,
+					Config:          []byte(v.Config),
 				}
 				if v.UsagePeriod != nil {
 					request.UsagePeriod = &entitlement.UsagePeriod{
@@ -192,9 +192,14 @@ func (h *entitlementHandler) GetEntitlementValue() GetEntitlementValueHandler {
 					Overage:   &ent.Overage,
 				}, nil
 			case *staticentitlement.StaticEntitlementValue:
+				var config *string
+				if len(ent.Config) > 0 {
+					config = convert.ToPointer(string(ent.Config))
+				}
+
 				return api.EntitlementValue{
 					HasAccess: convert.ToPointer(ent.HasAccess()),
-					Config:    &ent.Config,
+					Config:    config,
 				}, nil
 			case *booleanentitlement.BooleanEntitlementValue:
 				return api.EntitlementValue{

--- a/internal/entitlement/httpdriver/parser.go
+++ b/internal/entitlement/httpdriver/parser.go
@@ -57,7 +57,7 @@ func (parser) ToStatic(e *entitlement.Entitlement) (*api.EntitlementStatic, erro
 		SubjectKey:         static.SubjectKey,
 		Type:               api.EntitlementStaticType(static.EntitlementType),
 		UpdatedAt:          &static.UpdatedAt,
-		Config:             static.Config,
+		Config:             string(static.Config),
 		CurrentUsagePeriod: mapPeriod(static.CurrentUsagePeriod),
 		UsagePeriod:        mapUsagePeriod(e.UsagePeriod),
 	}

--- a/internal/entitlement/postgresadapter/ent/db/entitlement.go
+++ b/internal/entitlement/postgresadapter/ent/db/entitlement.go
@@ -43,7 +43,7 @@ type Entitlement struct {
 	// IsSoftLimit holds the value of the "is_soft_limit" field.
 	IsSoftLimit *bool `json:"is_soft_limit,omitempty"`
 	// Config holds the value of the "config" field.
-	Config map[string]interface{} `json:"config,omitempty"`
+	Config []uint8 `json:"config,omitempty"`
 	// UsagePeriodInterval holds the value of the "usage_period_interval" field.
 	UsagePeriodInterval *entitlement.UsagePeriodInterval `json:"usage_period_interval,omitempty"`
 	// UsagePeriodAnchor holds the value of the "usage_period_anchor" field.

--- a/internal/entitlement/postgresadapter/ent/db/entitlement_create.go
+++ b/internal/entitlement/postgresadapter/ent/db/entitlement_create.go
@@ -145,8 +145,8 @@ func (ec *EntitlementCreate) SetNillableIsSoftLimit(b *bool) *EntitlementCreate 
 }
 
 // SetConfig sets the "config" field.
-func (ec *EntitlementCreate) SetConfig(m map[string]interface{}) *EntitlementCreate {
-	ec.mutation.SetConfig(m)
+func (ec *EntitlementCreate) SetConfig(u []uint8) *EntitlementCreate {
+	ec.mutation.SetConfig(u)
 	return ec
 }
 
@@ -553,7 +553,7 @@ func (u *EntitlementUpsert) ClearDeletedAt() *EntitlementUpsert {
 }
 
 // SetConfig sets the "config" field.
-func (u *EntitlementUpsert) SetConfig(v map[string]interface{}) *EntitlementUpsert {
+func (u *EntitlementUpsert) SetConfig(v []uint8) *EntitlementUpsert {
 	u.Set(entitlement.FieldConfig, v)
 	return u
 }
@@ -759,7 +759,7 @@ func (u *EntitlementUpsertOne) ClearDeletedAt() *EntitlementUpsertOne {
 }
 
 // SetConfig sets the "config" field.
-func (u *EntitlementUpsertOne) SetConfig(v map[string]interface{}) *EntitlementUpsertOne {
+func (u *EntitlementUpsertOne) SetConfig(v []uint8) *EntitlementUpsertOne {
 	return u.Update(func(s *EntitlementUpsert) {
 		s.SetConfig(v)
 	})
@@ -1144,7 +1144,7 @@ func (u *EntitlementUpsertBulk) ClearDeletedAt() *EntitlementUpsertBulk {
 }
 
 // SetConfig sets the "config" field.
-func (u *EntitlementUpsertBulk) SetConfig(v map[string]interface{}) *EntitlementUpsertBulk {
+func (u *EntitlementUpsertBulk) SetConfig(v []uint8) *EntitlementUpsertBulk {
 	return u.Update(func(s *EntitlementUpsert) {
 		s.SetConfig(v)
 	})

--- a/internal/entitlement/postgresadapter/ent/db/entitlement_update.go
+++ b/internal/entitlement/postgresadapter/ent/db/entitlement_update.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 	"github.com/openmeterio/openmeter/internal/entitlement/postgresadapter/ent/db/entitlement"
 	"github.com/openmeterio/openmeter/internal/entitlement/postgresadapter/ent/db/predicate"
@@ -68,8 +69,14 @@ func (eu *EntitlementUpdate) ClearDeletedAt() *EntitlementUpdate {
 }
 
 // SetConfig sets the "config" field.
-func (eu *EntitlementUpdate) SetConfig(m map[string]interface{}) *EntitlementUpdate {
-	eu.mutation.SetConfig(m)
+func (eu *EntitlementUpdate) SetConfig(u []uint8) *EntitlementUpdate {
+	eu.mutation.SetConfig(u)
+	return eu
+}
+
+// AppendConfig appends u to the "config" field.
+func (eu *EntitlementUpdate) AppendConfig(u []uint8) *EntitlementUpdate {
+	eu.mutation.AppendConfig(u)
 	return eu
 }
 
@@ -252,6 +259,11 @@ func (eu *EntitlementUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if value, ok := eu.mutation.Config(); ok {
 		_spec.SetField(entitlement.FieldConfig, field.TypeJSON, value)
 	}
+	if value, ok := eu.mutation.AppendedConfig(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, entitlement.FieldConfig, value)
+		})
+	}
 	if eu.mutation.ConfigCleared() {
 		_spec.ClearField(entitlement.FieldConfig, field.TypeJSON)
 	}
@@ -380,8 +392,14 @@ func (euo *EntitlementUpdateOne) ClearDeletedAt() *EntitlementUpdateOne {
 }
 
 // SetConfig sets the "config" field.
-func (euo *EntitlementUpdateOne) SetConfig(m map[string]interface{}) *EntitlementUpdateOne {
-	euo.mutation.SetConfig(m)
+func (euo *EntitlementUpdateOne) SetConfig(u []uint8) *EntitlementUpdateOne {
+	euo.mutation.SetConfig(u)
+	return euo
+}
+
+// AppendConfig appends u to the "config" field.
+func (euo *EntitlementUpdateOne) AppendConfig(u []uint8) *EntitlementUpdateOne {
+	euo.mutation.AppendConfig(u)
 	return euo
 }
 
@@ -593,6 +611,11 @@ func (euo *EntitlementUpdateOne) sqlSave(ctx context.Context) (_node *Entitlemen
 	}
 	if value, ok := euo.mutation.Config(); ok {
 		_spec.SetField(entitlement.FieldConfig, field.TypeJSON, value)
+	}
+	if value, ok := euo.mutation.AppendedConfig(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, entitlement.FieldConfig, value)
+		})
 	}
 	if euo.mutation.ConfigCleared() {
 		_spec.ClearField(entitlement.FieldConfig, field.TypeJSON)

--- a/internal/entitlement/postgresadapter/ent/db/migrate/schema.go
+++ b/internal/entitlement/postgresadapter/ent/db/migrate/schema.go
@@ -23,7 +23,7 @@ var (
 		{Name: "measure_usage_from", Type: field.TypeTime, Nullable: true},
 		{Name: "issue_after_reset", Type: field.TypeFloat64, Nullable: true},
 		{Name: "is_soft_limit", Type: field.TypeBool, Nullable: true},
-		{Name: "config", Type: field.TypeJSON, Nullable: true},
+		{Name: "config", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "usage_period_interval", Type: field.TypeEnum, Nullable: true, Enums: []string{"DAY", "WEEK", "MONTH", "YEAR"}},
 		{Name: "usage_period_anchor", Type: field.TypeTime, Nullable: true},
 		{Name: "current_usage_period_start", Type: field.TypeTime, Nullable: true},

--- a/internal/entitlement/postgresadapter/ent/db/mutation.go
+++ b/internal/entitlement/postgresadapter/ent/db/mutation.go
@@ -48,7 +48,8 @@ type EntitlementMutation struct {
 	issue_after_reset          *float64
 	addissue_after_reset       *float64
 	is_soft_limit              *bool
-	_config                    *map[string]interface{}
+	_config                    *[]uint8
+	append_config              []uint8
 	usage_period_interval      *entitlement.UsagePeriodInterval
 	usage_period_anchor        *time.Time
 	current_usage_period_start *time.Time
@@ -685,12 +686,13 @@ func (m *EntitlementMutation) ResetIsSoftLimit() {
 }
 
 // SetConfig sets the "config" field.
-func (m *EntitlementMutation) SetConfig(value map[string]interface{}) {
-	m._config = &value
+func (m *EntitlementMutation) SetConfig(u []uint8) {
+	m._config = &u
+	m.append_config = nil
 }
 
 // Config returns the value of the "config" field in the mutation.
-func (m *EntitlementMutation) Config() (r map[string]interface{}, exists bool) {
+func (m *EntitlementMutation) Config() (r []uint8, exists bool) {
 	v := m._config
 	if v == nil {
 		return
@@ -701,7 +703,7 @@ func (m *EntitlementMutation) Config() (r map[string]interface{}, exists bool) {
 // OldConfig returns the old "config" field's value of the Entitlement entity.
 // If the Entitlement object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *EntitlementMutation) OldConfig(ctx context.Context) (v map[string]interface{}, err error) {
+func (m *EntitlementMutation) OldConfig(ctx context.Context) (v []uint8, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldConfig is only allowed on UpdateOne operations")
 	}
@@ -715,9 +717,23 @@ func (m *EntitlementMutation) OldConfig(ctx context.Context) (v map[string]inter
 	return oldValue.Config, nil
 }
 
+// AppendConfig adds u to the "config" field.
+func (m *EntitlementMutation) AppendConfig(u []uint8) {
+	m.append_config = append(m.append_config, u...)
+}
+
+// AppendedConfig returns the list of values that were appended to the "config" field in this mutation.
+func (m *EntitlementMutation) AppendedConfig() ([]uint8, bool) {
+	if len(m.append_config) == 0 {
+		return nil, false
+	}
+	return m.append_config, true
+}
+
 // ClearConfig clears the value of the "config" field.
 func (m *EntitlementMutation) ClearConfig() {
 	m._config = nil
+	m.append_config = nil
 	m.clearedFields[entitlement.FieldConfig] = struct{}{}
 }
 
@@ -730,6 +746,7 @@ func (m *EntitlementMutation) ConfigCleared() bool {
 // ResetConfig resets all changes to the "config" field.
 func (m *EntitlementMutation) ResetConfig() {
 	m._config = nil
+	m.append_config = nil
 	delete(m.clearedFields, entitlement.FieldConfig)
 }
 
@@ -1248,7 +1265,7 @@ func (m *EntitlementMutation) SetField(name string, value ent.Value) error {
 		m.SetIsSoftLimit(v)
 		return nil
 	case entitlement.FieldConfig:
-		v, ok := value.(map[string]interface{})
+		v, ok := value.([]uint8)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}

--- a/internal/entitlement/postgresadapter/ent/schema/entitlement.go
+++ b/internal/entitlement/postgresadapter/ent/schema/entitlement.go
@@ -36,7 +36,9 @@ func (Entitlement) Fields() []ent.Field {
 		field.Time("measure_usage_from").Optional().Nillable().Immutable(),
 		field.Float("issue_after_reset").Optional().Nillable().Immutable(),
 		field.Bool("is_soft_limit").Optional().Nillable().Immutable(),
-		field.JSON("config", map[string]interface{}{}).Optional(),
+		field.JSON("config", []byte{}).SchemaType(map[string]string{
+			dialect.Postgres: "jsonb",
+		}).Optional(),
 		field.Enum("usage_period_interval").Values(recurrence.RecurrenceInterval("").Values()...).Optional().Nillable().Immutable(),
 		field.Time("usage_period_anchor").Optional().Nillable(),
 		field.Time("current_usage_period_start").Optional().Nillable(),

--- a/internal/entitlement/postgresadapter/entitlement.go
+++ b/internal/entitlement/postgresadapter/entitlement.go
@@ -2,7 +2,6 @@ package postgresadapter
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"time"
 
@@ -97,11 +96,7 @@ func (a *entitlementDBAdapter) CreateEntitlement(ctx context.Context, entitlemen
 	}
 
 	if entitlement.Config != nil {
-		var config map[string]interface{}
-		if err := json.Unmarshal([]byte(*entitlement.Config), &config); err != nil {
-			return nil, err
-		}
-		cmd.SetConfig(config)
+		cmd.SetConfig(entitlement.Config)
 	}
 
 	res, err := cmd.Save(ctx)
@@ -224,13 +219,7 @@ func mapEntitlementEntity(e *db.Entitlement) *entitlement.Entitlement {
 	}
 
 	if e.Config != nil {
-		cStr, err := json.Marshal(e.Config)
-		if err != nil {
-			// TODO: handle error
-			ent.Config = nil
-		} else {
-			ent.Config = convert.ToPointer(string(cStr))
-		}
+		ent.Config = e.Config
 	}
 
 	if e.UsagePeriodAnchor != nil && e.UsagePeriodInterval != nil {

--- a/internal/entitlement/repository.go
+++ b/internal/entitlement/repository.go
@@ -45,7 +45,7 @@ type CreateEntitlementRepoInputs struct {
 	MeasureUsageFrom   *time.Time         `json:"measureUsageFrom,omitempty"`
 	IssueAfterReset    *float64           `json:"issueAfterReset,omitempty"`
 	IsSoftLimit        *bool              `json:"isSoftLimit,omitempty"`
-	Config             *string            `json:"config,omitempty"`
+	Config             []byte             `json:"config,omitempty"`
 	UsagePeriod        *UsagePeriod       `json:"usagePeriod,omitempty"`
 	CurrentUsagePeriod *recurrence.Period `json:"currentUsagePeriod,omitempty"`
 }

--- a/internal/entitlement/static/connector.go
+++ b/internal/entitlement/static/connector.go
@@ -50,12 +50,8 @@ func (c *connector) BeforeCreate(model entitlement.CreateEntitlementInputs, feat
 		return nil, &entitlement.InvalidValueError{Type: model.EntitlementType, Message: "Config is required"}
 	}
 
-	if !json.Valid([]byte(*model.Config)) {
+	if !json.Valid(model.Config) {
 		return nil, &entitlement.InvalidValueError{Type: model.EntitlementType, Message: "Config is not valid JSON"}
-	}
-
-	if err := json.Unmarshal([]byte(*model.Config), &map[string]interface{}{}); err != nil {
-		return nil, &entitlement.InvalidValueError{Type: model.EntitlementType, Message: "Config is not a valid JSON object"}
 	}
 
 	var usagePeriod *entitlement.UsagePeriod
@@ -93,7 +89,7 @@ func (c *connector) AfterCreate(ctx context.Context, entitlement *entitlement.En
 }
 
 type StaticEntitlementValue struct {
-	Config string `json:"config,omitempty"`
+	Config []byte `json:"config,omitempty"`
 }
 
 var _ entitlement.EntitlementValue = &StaticEntitlementValue{}

--- a/internal/entitlement/static/entitlement.go
+++ b/internal/entitlement/static/entitlement.go
@@ -7,7 +7,7 @@ import (
 type Entitlement struct {
 	entitlement.GenericProperties
 
-	Config string `json:"config,omitempty"`
+	Config []byte `json:"config,omitempty"`
 }
 
 func ParseFromGenericEntitlement(model *entitlement.Entitlement) (*Entitlement, error) {
@@ -21,6 +21,6 @@ func ParseFromGenericEntitlement(model *entitlement.Entitlement) (*Entitlement, 
 
 	return &Entitlement{
 		GenericProperties: model.GenericProperties,
-		Config:            *model.Config,
+		Config:            model.Config,
 	}, nil
 }


### PR DESCRIPTION
## Overview

Fix `config` field validation for `static` entitlements to allow any valid JSON string to be provided.

## Notes for reviewer

This is a revert of https://github.com/openmeterio/openmeter/pull/1114 as the issue triggered the first revert turned out to be unrelated to this change.
