### PR TITLE
fix: dedup cleanup

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -257,6 +257,12 @@ func main() {
 			logger.Error("failed to initialize deduplicator", "error", err)
 			os.Exit(1)
 		}
+		defer func() {
+			logger.Info("closing deduplicator")
+			if err = deduplicator.Close(); err != nil {
+				logger.Error("failed to close deduplicator", "error", err)
+			}
+		}()
 
 		ingestCollector = ingest.DeduplicatingCollector{
 			Collector:    ingestCollector,

--- a/config/dedupe.go
+++ b/config/dedupe.go
@@ -173,7 +173,6 @@ func (c DedupeDriverRedisConfiguration) NewDeduplicator() (dedupe.Deduplicator, 
 		return nil, fmt.Errorf("failed to initialize redis client: %w", err)
 	}
 
-	// TODO: close redis client when shutting down
 	// TODO: register health check for redis
 	return redisdedupe.Deduplicator{
 		Redis:      redisClient,

--- a/internal/dedupe/dedupe.go
+++ b/internal/dedupe/dedupe.go
@@ -17,6 +17,8 @@ type Deduplicator interface {
 	CheckUnique(ctx context.Context, item Item) (bool, error)
 	// Set adds the item(s) to the deduplicator
 	Set(ctx context.Context, events ...Item) error
+	// Close cleans up resources
+	Close() error
 }
 
 type Item struct {

--- a/internal/dedupe/memorydedupe/memorydedupe.go
+++ b/internal/dedupe/memorydedupe/memorydedupe.go
@@ -57,3 +57,7 @@ func (d *Deduplicator) Set(ctx context.Context, items ...dedupe.Item) error {
 
 	return nil
 }
+
+func (d *Deduplicator) Close() error {
+	return nil
+}

--- a/internal/dedupe/redisdedupe/redisdedupe.go
+++ b/internal/dedupe/redisdedupe/redisdedupe.go
@@ -86,3 +86,12 @@ for _, key in ipairs(KEYS) do
   redis.call("SET", key, "", "EX", expiration)
 end
 `)
+
+// Close closes underlying redis client
+func (d Deduplicator) Close() error {
+	if d.Redis != nil {
+		return d.Redis.Close()
+	}
+
+	return nil
+}

--- a/internal/sink/sink.go
+++ b/internal/sink/sink.go
@@ -777,6 +777,13 @@ func (s *Sink) Close() error {
 		}
 	}
 
+	if s.config.Deduplicator != nil {
+		logger.Info("closing deduplicator")
+		if err := s.config.Deduplicator.Close(); err != nil {
+			logger.Error("failed to close deduplicator", "error", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Overview

Make sure that resources used by `dedupe.Deduplicator` implementations are properly cleaned up on exit. Interface is extended with `Close()` method which allows proper cleanup of underlying resources used by implementations.
