### PR TITLE
feat(config): validate meters config length

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,10 @@ func (c Configuration) Validate() error {
 		return fmt.Errorf("entitlements: %w", err)
 	}
 
+	if len(c.Meters) == 0 {
+		return errors.New("no meters configured: add meter to configuration file")
+	}
+
 	for _, m := range c.Meters {
 		// Namespace is not configurable on per meter level
 		m.Namespace = c.Namespace.Default


### PR DESCRIPTION
Why

Running OpenMeter without any meter configured makes no sense.
This is especially important as our Kubernetes Helm chart comes with [no meters](https://github.com/openmeterio/openmeter/blob/main/deploy/charts/openmeter/templates/configmap.yaml).

What

Return error when no meter is configured to indicate user that action is required.