### PR TITLE
feat: ingest events

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,20 @@
       ]
     },
     {
+      "name": "Launch Sink-Worker",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/sink-worker",
+      "args": [
+        "--config",
+        "${workspaceFolder}/config.yaml",
+        // Let's prevent port collision with server
+        "--telemetry-address",
+        ":10001",
+      ]
+    },
+    {
       "name": "Launch Balance Worker",
       "type": "go",
       "request": "launch",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -43,6 +43,13 @@ events:
 #   autoProvision:
 #     enabled: true
 #     partitions: 4
+# ingestEvents:
+#   enabled: true
+#   topic: om_sys.ingest_events
+#   autoProvision:
+#     enabled: true
+#     partitions: 8
+
 # Consumer portal
 # portal:
 #   enabled: true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -183,6 +183,14 @@ func TestComplete(t *testing.T) {
 					Partitions: 4,
 				},
 			},
+			IngestEvents: EventSubsystemConfiguration{
+				Enabled: true,
+				Topic:   "om_sys.ingest_events",
+				AutoProvision: AutoProvisionConfiguration{
+					Enabled:    true,
+					Partitions: 8,
+				},
+			},
 		},
 		BalanceWorker: BalanceWorkerConfiguration{
 			PoisionQueue: PoisionQueueConfiguration{

--- a/config/events.go
+++ b/config/events.go
@@ -11,6 +11,7 @@ import (
 type EventsConfiguration struct {
 	Enabled      bool
 	SystemEvents EventSubsystemConfiguration
+	IngestEvents EventSubsystemConfiguration
 }
 
 func (c EventsConfiguration) Validate() error {
@@ -116,4 +117,9 @@ func ConfigureEvents(v *viper.Viper) {
 	v.SetDefault("events.systemEvents.topic", "om_sys.api_events")
 	v.SetDefault("events.systemEvents.autoProvision.enabled", true)
 	v.SetDefault("events.systemEvents.autoProvision.partitions", 4)
+
+	v.SetDefault("events.ingestEvents.enabled", true)
+	v.SetDefault("events.ingestEvents.topic", "om_sys.ingest_events")
+	v.SetDefault("events.ingestEvents.autoProvision.enabled", true)
+	v.SetDefault("events.ingestEvents.autoProvision.partitions", 8)
 }

--- a/internal/event/spec/resourcepath.go
+++ b/internal/event/spec/resourcepath.go
@@ -5,10 +5,16 @@ import (
 	"strings"
 )
 
+// Entitlements
 const (
 	EntityEntitlement = "entitlement"
 	EntitySubjectKey  = "subjectKey"
 	EntityGrant       = "grant"
+)
+
+// Ingestion/Events
+const (
+	EntityEvent = "event"
 )
 
 func ComposeResourcePath(namespace string, items ...string) string {

--- a/internal/sink/flushhandler/handler.go
+++ b/internal/sink/flushhandler/handler.go
@@ -1,0 +1,191 @@
+package flushhandler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/openmeterio/openmeter/internal/sink/models"
+)
+
+const (
+	defaultFlushChanSize   = 1000
+	defaultCallbackTimeout = 30 * time.Second
+)
+
+type FlushEventHandlerOptions struct {
+	Name     string
+	Callback FlushCallback
+
+	Logger      *slog.Logger
+	MetricMeter metric.Meter
+
+	DrainTimeout    time.Duration
+	CallbackTimeout time.Duration
+}
+
+type flushEventHandler struct {
+	name      string
+	events    chan []models.SinkMessage
+	drainDone chan struct{}
+
+	callback FlushCallback
+
+	callbackTimeout time.Duration
+	drainTimeout    time.Duration
+
+	metrics *metrics
+
+	logger *slog.Logger
+
+	isShutdown atomic.Bool
+	mu         sync.Mutex
+}
+
+func NewFlushEventHandler(opts FlushEventHandlerOptions) (FlushEventHandler, error) {
+	// validate options
+	if opts.Name == "" {
+		return nil, errors.New("name is required")
+	}
+
+	if opts.Callback == nil {
+		return nil, errors.New("callback is required")
+	}
+
+	if opts.Logger == nil {
+		return nil, errors.New("logger is required")
+	}
+
+	if opts.MetricMeter == nil {
+		return nil, errors.New("metric meter is required")
+	}
+
+	if opts.CallbackTimeout == 0 {
+		opts.CallbackTimeout = defaultCallbackTimeout
+	}
+
+	if opts.DrainTimeout == 0 {
+		opts.DrainTimeout = defaultCallbackTimeout
+	}
+
+	// construct underlying object
+	metrics, err := newMetrics(opts.Name, opts.MetricMeter)
+	if err != nil {
+		return nil, err
+	}
+
+	return &flushEventHandler{
+		callback:        opts.Callback,
+		callbackTimeout: opts.CallbackTimeout,
+		drainTimeout:    opts.DrainTimeout,
+		name:            opts.Name,
+		events:          make(chan []models.SinkMessage, defaultFlushChanSize),
+		drainDone:       make(chan struct{}),
+		metrics:         metrics,
+		logger:          opts.Logger,
+	}, nil
+}
+
+func (f *flushEventHandler) Start(ctx context.Context) error {
+	go f.start(ctx)
+	return nil
+}
+
+func (f *flushEventHandler) start(ctx context.Context) {
+	defer close(f.drainDone)
+
+	if f.isShutdown.Load() {
+		f.logger.Error("failed to start flush event handler as it is already shut down")
+		return
+	}
+
+	shouldRun := true
+	for shouldRun {
+		select {
+		case event := <-f.events:
+			if err := f.invokeCallbackWithTimeout(event); err != nil {
+				f.logger.Error("failed to invoke callback", "error", err)
+			}
+		case <-ctx.Done():
+			shouldRun = false
+			f.isShutdown.Store(true)
+		}
+	}
+
+	// let's drain the queue using a new context, as the parent context is already canceled
+	drainContext, cancel := context.WithTimeout(context.Background(), f.drainTimeout)
+	defer cancel()
+
+	for event := range f.events {
+		if err := f.invokeCallback(drainContext, event); err != nil {
+			f.logger.Error("failed to invoke callback", "error", err)
+		}
+	}
+}
+
+func (f *flushEventHandler) invokeCallbackWithTimeout(events []models.SinkMessage) error {
+	// We are using a background context here, as if the parent context is canceled, we still want to
+	// allow the callbacks to call external systems. In exchange we are limiting the work with a timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), f.callbackTimeout)
+	defer cancel()
+
+	return f.invokeCallback(ctx, events)
+}
+
+func (f *flushEventHandler) invokeCallback(ctx context.Context, events []models.SinkMessage) error {
+	startTime := time.Now()
+
+	if err := f.callback(ctx, events); err != nil {
+		f.metrics.eventsFailed.Add(ctx, 1)
+		return err
+	}
+
+	f.metrics.eventProcessingTime.Record(ctx, time.Since(startTime).Seconds())
+	f.metrics.eventsProcessed.Add(ctx, 1)
+
+	return nil
+}
+
+func (f *flushEventHandler) OnFlushSuccess(ctx context.Context, event []models.SinkMessage) error {
+	if f.isShutdown.Load() {
+		return errors.New("handler is shutting down")
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	select {
+	case f.events <- event:
+		f.metrics.eventsReceived.Add(ctx, 1)
+	case <-ctx.Done():
+		f.metrics.eventsFailed.Add(ctx, 1)
+		return fmt.Errorf("context canceled handler: %s", f.name)
+	default:
+		f.logger.Error("flush handler: work queue full, callback might be hanging", "event", event, "name", f.name)
+		f.metrics.eventChannelFull.Add(ctx, 1)
+		select {
+		case f.events <- event:
+			f.metrics.eventsReceived.Add(ctx, 1)
+		case <-ctx.Done():
+			f.metrics.eventsFailed.Add(ctx, 1)
+			return fmt.Errorf("context canceled handler: %s", f.name)
+		}
+	}
+
+	return nil
+}
+
+func (f *flushEventHandler) WaitForDrain(ctx context.Context) error {
+	select {
+	case <-f.drainDone:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("context canceled while wainting for drain in handler %s", f.name)
+	}
+}

--- a/internal/sink/flushhandler/ingestnotification/events.go
+++ b/internal/sink/flushhandler/ingestnotification/events.go
@@ -1,4 +1,4 @@
-package sink
+package ingestnotification
 
 import (
 	"errors"

--- a/internal/sink/flushhandler/ingestnotification/handler.go
+++ b/internal/sink/flushhandler/ingestnotification/handler.go
@@ -1,0 +1,85 @@
+package ingestnotification
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/metric"
+
+	eventmodels "github.com/openmeterio/openmeter/internal/event/models"
+	"github.com/openmeterio/openmeter/internal/event/spec"
+	"github.com/openmeterio/openmeter/internal/sink/flushhandler"
+	sinkmodels "github.com/openmeterio/openmeter/internal/sink/models"
+	"github.com/openmeterio/openmeter/openmeter/event/publisher"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type handler struct {
+	publisher publisher.TopicPublisher
+	logger    *slog.Logger
+}
+
+func NewHandler(logger *slog.Logger, metricMeter metric.Meter, publisher publisher.TopicPublisher) (flushhandler.FlushEventHandler, error) {
+	handler := &handler{
+		publisher: publisher,
+		logger:    logger,
+	}
+
+	return flushhandler.NewFlushEventHandler(
+		flushhandler.FlushEventHandlerOptions{
+			Name:        "ingest_notification",
+			Callback:    handler.OnFlushSuccess,
+			Logger:      logger,
+			MetricMeter: metricMeter,
+		})
+}
+
+// OnFlushSuccess takes a look at the incoming messages and in case something is
+// affecting a ledger balance it will create the relevant event.
+func (h *handler) OnFlushSuccess(ctx context.Context, events []sinkmodels.SinkMessage) error {
+	var finalErr error
+
+	for _, message := range events {
+		if message.Serialized == nil {
+			// In case the incoming event was not supported by the parser (e.g. non-json payload)
+			continue
+		}
+
+		if len(message.Meters) == 0 {
+			// If the change doesn't affect a meter, we should not care about it
+			continue
+		}
+
+		event, err := spec.NewCloudEvent(spec.EventSpec{
+			ID:      message.Serialized.Id,
+			Source:  spec.ComposeResourcePath(message.Namespace, spec.EntityEvent, message.Serialized.Id),
+			Subject: spec.ComposeResourcePath(message.Namespace, spec.EntitySubjectKey, message.Serialized.Subject),
+		}, IngestEvent{
+			Namespace:  eventmodels.NamespaceID{ID: message.Namespace},
+			SubjectKey: message.Serialized.Subject,
+			MeterSlugs: h.getMeterSlugsFromMeters(message.Meters),
+		})
+		if err != nil {
+			finalErr = errors.Join(finalErr, err)
+			h.logger.Error("failed to create change notification", "error", err)
+			continue
+		}
+
+		if err := h.publisher.Publish(event); err != nil {
+			finalErr = errors.Join(finalErr, err)
+			h.logger.Error("failed to publish change notification", "error", err)
+		}
+	}
+
+	return finalErr
+}
+
+func (h *handler) getMeterSlugsFromMeters(meters []models.Meter) []string {
+	slugs := make([]string, len(meters))
+	for i, meter := range meters {
+		slugs[i] = meter.Slug
+	}
+
+	return slugs
+}

--- a/internal/sink/flushhandler/meters.go
+++ b/internal/sink/flushhandler/meters.go
@@ -1,0 +1,43 @@
+package flushhandler
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/otel/metric"
+)
+
+type metrics struct {
+	eventsReceived      metric.Int64Counter
+	eventsProcessed     metric.Int64Counter
+	eventsFailed        metric.Int64Counter
+	eventProcessingTime metric.Float64Histogram
+	eventChannelFull    metric.Int64Counter
+}
+
+func newMetrics(handlerName string, meter metric.Meter) (*metrics, error) {
+	var err error
+
+	r := &metrics{}
+
+	if r.eventsReceived, err = meter.Int64Counter(fmt.Sprintf("sink.flush_handler.%s.events_received", handlerName)); err != nil {
+		return nil, err
+	}
+
+	if r.eventsProcessed, err = meter.Int64Counter(fmt.Sprintf("sink.flush_handler.%s.events_processed", handlerName)); err != nil {
+		return nil, err
+	}
+
+	if r.eventsFailed, err = meter.Int64Counter(fmt.Sprintf("sink.flush_handler.%s.events_failed", handlerName)); err != nil {
+		return nil, err
+	}
+
+	if r.eventChannelFull, err = meter.Int64Counter(fmt.Sprintf("sink.flush_handler.%s.event_channel_full", handlerName)); err != nil {
+		return nil, err
+	}
+
+	if r.eventProcessingTime, err = meter.Float64Histogram(fmt.Sprintf("sink.flush_handler.%s.event_processing_time", handlerName)); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}

--- a/internal/sink/flushhandler/mux.go
+++ b/internal/sink/flushhandler/mux.go
@@ -1,0 +1,63 @@
+package flushhandler
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openmeterio/openmeter/internal/sink/models"
+)
+
+type DrainCompleteFunc func()
+
+type FlushEventHandlers struct {
+	handlers        []FlushEventHandler
+	onDrainComplete []DrainCompleteFunc
+}
+
+func NewFlushEventHandlers() *FlushEventHandlers {
+	return &FlushEventHandlers{}
+}
+
+func (f *FlushEventHandlers) AddHandler(handler FlushEventHandler) {
+	f.handlers = append(f.handlers, handler)
+}
+
+func (f *FlushEventHandlers) OnDrainComplete(fn DrainCompleteFunc) {
+	f.onDrainComplete = append(f.onDrainComplete, fn)
+}
+
+func (f *FlushEventHandlers) OnFlushSuccess(ctx context.Context, events []models.SinkMessage) error {
+	var finalError error
+
+	for _, handler := range f.handlers {
+		if err := handler.OnFlushSuccess(ctx, events); err != nil {
+			finalError = errors.Join(finalError, err)
+		}
+	}
+
+	return finalError
+}
+
+func (f *FlushEventHandlers) Start(ctx context.Context) error {
+	for _, handler := range f.handlers {
+		if err := handler.Start(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (f *FlushEventHandlers) WaitForDrain(ctx context.Context) error {
+	for _, handler := range f.handlers {
+		if err := handler.WaitForDrain(ctx); err != nil {
+			return err
+		}
+	}
+
+	for _, fn := range f.onDrainComplete {
+		fn()
+	}
+
+	return nil
+}

--- a/internal/sink/flushhandler/types.go
+++ b/internal/sink/flushhandler/types.go
@@ -1,0 +1,17 @@
+package flushhandler
+
+import (
+	"context"
+
+	"github.com/openmeterio/openmeter/internal/sink/models"
+)
+
+type FlushEventHandler interface {
+	OnFlushSuccess(ctx context.Context, events []models.SinkMessage) error
+	Start(context.Context) error
+	WaitForDrain(context.Context) error
+}
+
+type (
+	FlushCallback func(context.Context, []models.SinkMessage) error
+)

--- a/openmeter/sink/flushhandler/flushhandler.go
+++ b/openmeter/sink/flushhandler/flushhandler.go
@@ -1,0 +1,27 @@
+package flushhandler
+
+import "github.com/openmeterio/openmeter/internal/sink/flushhandler"
+
+type (
+	FlushEventHandler = flushhandler.FlushEventHandler
+	FlushCallback     = flushhandler.FlushCallback
+)
+
+// FlushHandlers
+type (
+	DrainCompleteFunc  = flushhandler.DrainCompleteFunc
+	FlushEventHandlers = flushhandler.FlushEventHandlers
+)
+
+func NewFlushEventHandlers() *FlushEventHandlers {
+	return flushhandler.NewFlushEventHandlers()
+}
+
+// FlushHandler
+type (
+	FlushEventHandlerOptions = flushhandler.FlushEventHandlerOptions
+)
+
+func NewFlushEventHandler(opts FlushEventHandlerOptions) (FlushEventHandler, error) {
+	return flushhandler.NewFlushEventHandler(opts)
+}

--- a/openmeter/sink/flushhandler/ingestnotification/ingestnotification.go
+++ b/openmeter/sink/flushhandler/ingestnotification/ingestnotification.go
@@ -1,0 +1,29 @@
+package ingestnotification
+
+import (
+	"log/slog"
+
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/openmeterio/openmeter/internal/sink/flushhandler/ingestnotification"
+	"github.com/openmeterio/openmeter/openmeter/event/publisher"
+	"github.com/openmeterio/openmeter/openmeter/sink/flushhandler"
+)
+
+// Event types
+const (
+	EventSubsystem = ingestnotification.EventSubsystem
+)
+
+const (
+	EventIngestion = ingestnotification.EventIngestion
+)
+
+type (
+	IngestEvent = ingestnotification.IngestEvent
+)
+
+// Ingest notification handler
+func NewHandler(logger *slog.Logger, metricMeter metric.Meter, publisher publisher.TopicPublisher) (flushhandler.FlushEventHandler, error) {
+	return ingestnotification.NewHandler(logger, metricMeter, publisher)
+}

--- a/openmeter/sink/sink.go
+++ b/openmeter/sink/sink.go
@@ -10,8 +10,6 @@ type (
 	Sink                    = sink.Sink
 	SinkConfig              = sink.SinkConfig
 	Storage                 = sink.Storage
-	FlushSuccessEvent       = sink.FlushSuccessEvent
-	FlushEventHandler       = sink.FlushEventHandler
 	ClickHouseStorage       = sink.ClickHouseStorage
 	ClickHouseStorageConfig = sink.ClickHouseStorageConfig
 )


### PR DESCRIPTION
## Overview

This patch ensures that we can create events when we have successfully ingested a new event into our system. The event payload is the following:

```
{
    "specversion": "1.0",
    "id": "9f78f699-2b60-45c5-b820-50be6841afe0",
    "source": "//openmeter.io/namespace/default/event/9f78f699-2b60-45c5-b820-50be6841afe0",
    "type": "openmeter.ingest.v1.ingestion",
    "subject": "//openmeter.io/namespace/default/subjectKey/customer-1",
    "datacontenttype": "application/json",
    "time": "2024-07-26T09:53:56.108182Z",
    "data": {
        "namespace": {
            "id": "default"
        },
        "subjectKey": "customer-1",
        "meterSlugs": [
            "api_requests_total"
        ]
    }
}
```

## Notes for reviewer

As part of the work an improved version of the flushhandler is added, so that we can hook in usage reporting in the cloud solution.
