### PR TITLE
feat: add entitlements initialization - v2

### DIFF
--- a/internal/entitlement/balanceworker/worker.go
+++ b/internal/entitlement/balanceworker/worker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/internal/entitlement"
 	"github.com/openmeterio/openmeter/internal/event/publisher"
 	"github.com/openmeterio/openmeter/internal/event/spec"
+	"github.com/openmeterio/openmeter/internal/registry"
 )
 
 type WorkerOptions struct {
@@ -26,6 +27,8 @@ type WorkerOptions struct {
 	Publisher   message.Publisher
 
 	Marshaler publisher.CloudEventMarshaler
+
+	Entitlement *registry.Entitlement
 
 	Logger *slog.Logger
 }

--- a/internal/registry/entitlement.go
+++ b/internal/registry/entitlement.go
@@ -1,0 +1,96 @@
+package registry
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/openmeterio/openmeter/internal/ent/db"
+	"github.com/openmeterio/openmeter/internal/meter"
+	"github.com/openmeterio/openmeter/openmeter/credit"
+	creditpgadapter "github.com/openmeterio/openmeter/openmeter/credit/postgresadapter"
+	"github.com/openmeterio/openmeter/openmeter/entitlement"
+	booleanentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/boolean"
+	meteredentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/metered"
+	entitlementpgadapter "github.com/openmeterio/openmeter/openmeter/entitlement/postgresadapter"
+	staticentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/static"
+	"github.com/openmeterio/openmeter/openmeter/event/publisher"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	productcatalogpgadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/postgresadapter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+)
+
+type Entitlement struct {
+	Feature            productcatalog.FeatureConnector
+	EntitlementOwner   credit.OwnerConnector
+	CreditBalance      credit.BalanceConnector
+	Grant              credit.GrantConnector
+	MeteredEntitlement meteredentitlement.Connector
+	Entitlement        entitlement.EntitlementConnector
+}
+
+type EntitlementOptions struct {
+	DatabaseClient     *db.Client
+	StreamingConnector streaming.Connector
+	Logger             *slog.Logger
+	MeterRepository    meter.Repository
+	Publisher          publisher.TopicPublisher
+}
+
+func GetEntitlementRegistry(opts EntitlementOptions) *Entitlement {
+	// Initialize database adapters
+	featureDBAdapter := productcatalogpgadapter.NewPostgresFeatureDBAdapter(opts.DatabaseClient, opts.Logger)
+	entitlementDBAdapter := entitlementpgadapter.NewPostgresEntitlementDBAdapter(opts.DatabaseClient)
+	usageResetDBAdapter := entitlementpgadapter.NewPostgresUsageResetDBAdapter(opts.DatabaseClient)
+	grantDBAdapter := creditpgadapter.NewPostgresGrantDBAdapter(opts.DatabaseClient)
+	balanceSnashotDBAdapter := creditpgadapter.NewPostgresBalanceSnapshotDBAdapter(opts.DatabaseClient)
+
+	// Initialize connectors
+	featureConnector := productcatalog.NewFeatureConnector(featureDBAdapter, opts.MeterRepository)
+	entitlementOwnerConnector := meteredentitlement.NewEntitlementGrantOwnerAdapter(
+		featureDBAdapter,
+		entitlementDBAdapter,
+		usageResetDBAdapter,
+		opts.MeterRepository,
+		opts.Logger,
+	)
+	creditBalanceConnector := credit.NewBalanceConnector(
+		grantDBAdapter,
+		balanceSnashotDBAdapter,
+		entitlementOwnerConnector,
+		opts.StreamingConnector,
+		opts.Logger,
+	)
+	grantConnector := credit.NewGrantConnector(
+		entitlementOwnerConnector,
+		grantDBAdapter,
+		balanceSnashotDBAdapter,
+		time.Minute,
+		opts.Publisher,
+	)
+	meteredEntitlementConnector := meteredentitlement.NewMeteredEntitlementConnector(
+		opts.StreamingConnector,
+		entitlementOwnerConnector,
+		creditBalanceConnector,
+		grantConnector,
+		entitlementDBAdapter,
+		opts.Publisher,
+	)
+	entitlementConnector := entitlement.NewEntitlementConnector(
+		entitlementDBAdapter,
+		featureConnector,
+		opts.MeterRepository,
+		meteredEntitlementConnector,
+		staticentitlement.NewStaticEntitlementConnector(),
+		booleanentitlement.NewBooleanEntitlementConnector(),
+		opts.Publisher,
+	)
+
+	return &Entitlement{
+		Feature:            featureConnector,
+		EntitlementOwner:   entitlementOwnerConnector,
+		CreditBalance:      creditBalanceConnector,
+		Grant:              grantConnector,
+		MeteredEntitlement: meteredEntitlementConnector,
+		Entitlement:        entitlementConnector,
+	}
+}


### PR DESCRIPTION
## Overview

This patch ensures that entitlements are initialized for the balance workers.

This patch moves the clickhouse initialization's options part to the config package, as we have some magic constants there that should become config options.

It moves the entitlements initialization to a registry package, as at most of the places we are initializing credit, entitlements, and product catalog together: that's just a boilerplate we should not copy.

This is based on feedback from https://github.com/openmeterio/openmeter/pull/1274