### PR TITLE
refactor: event naming consistency

### DIFF
--- a/internal/credit/events.go
+++ b/internal/credit/events.go
@@ -12,8 +12,8 @@ const (
 )
 
 const (
-	EventCreateGrant spec.EventName = "createGrant"
-	EventVoidGrant   spec.EventName = "voidGrant"
+	grantCreatedEventName spec.EventName = "grant.created"
+	grantVoidedEventName  spec.EventName = "grant.voided"
 )
 
 type grantEvent struct {
@@ -48,10 +48,9 @@ func (g grantEvent) Validate() error {
 type GrantCreatedEvent grantEvent
 
 var grantCreatedEventSpec = spec.EventTypeSpec{
-	Subsystem:   EventSubsystem,
-	Name:        EventCreateGrant,
-	SpecVersion: "1.0",
-	Version:     "v1",
+	Subsystem: EventSubsystem,
+	Name:      grantCreatedEventName,
+	Version:   "v1",
 }
 
 func (e GrantCreatedEvent) Spec() *spec.EventTypeSpec {
@@ -65,10 +64,9 @@ func (e GrantCreatedEvent) Validate() error {
 type GrantVoidedEvent grantEvent
 
 var grantVoidedEventSpec = spec.EventTypeSpec{
-	Subsystem:   EventSubsystem,
-	Name:        EventVoidGrant,
-	SpecVersion: "1.0",
-	Version:     "v1",
+	Subsystem: EventSubsystem,
+	Name:      grantVoidedEventName,
+	Version:   "v1",
 }
 
 func (e GrantVoidedEvent) Spec() *spec.EventTypeSpec {

--- a/internal/entitlement/events.go
+++ b/internal/entitlement/events.go
@@ -12,8 +12,8 @@ const (
 )
 
 const (
-	EventCreateEntitlement spec.EventName = "createEntitlement"
-	EventDeleteEntitlement spec.EventName = "deleteEntitlement"
+	entitlementCreatedEventName spec.EventName = "entitlement.created"
+	entitlementDeletedEventName spec.EventName = "entitlement.deleted"
 )
 
 type entitlementEvent struct {
@@ -40,10 +40,9 @@ func (e entitlementEvent) Validate() error {
 type EntitlementCreatedEvent entitlementEvent
 
 var entitlementCreatedEventSpec = spec.EventTypeSpec{
-	Subsystem:   EventSubsystem,
-	Name:        EventCreateEntitlement,
-	SpecVersion: "1.0",
-	Version:     "v1",
+	Subsystem: EventSubsystem,
+	Name:      entitlementCreatedEventName,
+	Version:   "v1",
 }
 
 func (e EntitlementCreatedEvent) Spec() *spec.EventTypeSpec {
@@ -57,10 +56,9 @@ func (e EntitlementCreatedEvent) Validate() error {
 type EntitlementDeletedEvent entitlementEvent
 
 var entitlementDeletedEventSpec = spec.EventTypeSpec{
-	Subsystem:   EventSubsystem,
-	Name:        EventDeleteEntitlement,
-	SpecVersion: "1.0",
-	Version:     "v1",
+	Subsystem: EventSubsystem,
+	Name:      entitlementDeletedEventName,
+	Version:   "v1",
 }
 
 func (e EntitlementDeletedEvent) Spec() *spec.EventTypeSpec {

--- a/internal/entitlement/metered/events.go
+++ b/internal/entitlement/metered/events.go
@@ -13,10 +13,10 @@ const (
 )
 
 const (
-	EventResetEntitlementUsage spec.EventName = "resetEntitlementUsage"
+	resetEntitlementEventName spec.EventName = "entitlement.reset"
 )
 
-type ResetEntitlementEvent struct {
+type EntitlementResetEvent struct {
 	EntitlementID string                 `json:"entitlementId"`
 	Namespace     models.NamespaceID     `json:"namespace"`
 	Subject       models.SubjectKeyAndID `json:"subject"`
@@ -25,17 +25,16 @@ type ResetEntitlementEvent struct {
 }
 
 var resetEntitlementEventSpec = spec.EventTypeSpec{
-	Subsystem:   EventSubsystem,
-	Name:        EventResetEntitlementUsage,
-	SpecVersion: "1.0",
-	Version:     "v1",
+	Subsystem: EventSubsystem,
+	Name:      resetEntitlementEventName,
+	Version:   "v1",
 }
 
-func (e ResetEntitlementEvent) Spec() *spec.EventTypeSpec {
+func (e EntitlementResetEvent) Spec() *spec.EventTypeSpec {
 	return &resetEntitlementEventSpec
 }
 
-func (e ResetEntitlementEvent) Validate() error {
+func (e EntitlementResetEvent) Validate() error {
 	if e.EntitlementID == "" {
 		return errors.New("entitlementID must be set")
 	}

--- a/internal/entitlement/metered/reset.go
+++ b/internal/entitlement/metered/reset.go
@@ -49,7 +49,7 @@ func (e *connector) ResetEntitlementUsage(ctx context.Context, entitlementID mod
 				Source:  spec.ComposeResourcePath(entitlementID.Namespace, spec.EntityEntitlement, entitlementID.ID),
 				Subject: spec.ComposeResourcePath(entitlementID.Namespace, spec.EntitySubjectKey, ent.SubjectKey),
 			},
-			ResetEntitlementEvent{
+			EntitlementResetEvent{
 				EntitlementID: entitlementID.ID,
 				Namespace: eventmodels.NamespaceID{
 					ID: entitlementID.Namespace,

--- a/internal/entitlement/snapshot/event.go
+++ b/internal/entitlement/snapshot/event.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	EventSnapshot spec.EventName = "snapshot"
+	snapshotEventName spec.EventName = "entitlement.snapshot"
 )
 
 type BalanceOperationType string
@@ -39,7 +39,7 @@ type EntitlementValue struct {
 	Usage *float64 `json:"usage,omitempty"`
 }
 
-type EntitlementBalanceSnapshotEvent struct {
+type SnapshotEvent struct {
 	Entitlement entitlement.Entitlement `json:"entitlement"`
 	Namespace   models.NamespaceID      `json:"namespace"`
 	Subject     models.SubjectKeyAndID  `json:"subject"`
@@ -55,18 +55,17 @@ type EntitlementBalanceSnapshotEvent struct {
 	CurrentUsagePeriod *recurrence.Period `json:"currentUsagePeriod,omitempty"`
 }
 
-var entitlementBalanceSnapshotEventSpec = spec.EventTypeSpec{
-	Subsystem:   entitlement.EventSubsystem,
-	Name:        EventSnapshot,
-	SpecVersion: "1.0",
-	Version:     "v1",
+var SnapshotEventSpec = spec.EventTypeSpec{
+	Subsystem: entitlement.EventSubsystem,
+	Name:      snapshotEventName,
+	Version:   "v1",
 }
 
-func (e EntitlementBalanceSnapshotEvent) Spec() *spec.EventTypeSpec {
-	return &entitlementBalanceSnapshotEventSpec
+func (e SnapshotEvent) Spec() *spec.EventTypeSpec {
+	return &SnapshotEventSpec
 }
 
-func (e EntitlementBalanceSnapshotEvent) Validate() error {
+func (e SnapshotEvent) Validate() error {
 	if e.Operation != BalanceOperationDelete && e.Operation != BalanceOperationUpdate {
 		return errors.New("operation must be either delete or update")
 	}

--- a/internal/event/spec/event_type.go
+++ b/internal/event/spec/event_type.go
@@ -23,9 +23,6 @@ type EventTypeSpec struct {
 	// Version is the version of the event (e.g. v1, v2, etc)
 	Version EventVersion
 
-	// SpecVersion is the version of the event spec (e.g. 1.0, 1.1, etc)
-	SpecVersion EventSpecVersion
-
 	// cloudEventType is the actual cloud event type, so that we don't have the calculate it
 	// for each message
 	cloudEventType string
@@ -35,7 +32,7 @@ func (s *EventTypeSpec) Type() string {
 	if s.cloudEventType != "" {
 		return s.cloudEventType
 	}
-	s.cloudEventType = fmt.Sprintf("openmeter.%s.%s.%s", s.Subsystem, s.Version, s.Name)
+	s.cloudEventType = fmt.Sprintf("io.openmeter.%s.%s.%s", s.Subsystem, s.Version, s.Name)
 	return s.cloudEventType
 }
 

--- a/internal/event/spec/parser.go
+++ b/internal/event/spec/parser.go
@@ -44,7 +44,7 @@ func NewCloudEvent(eventSpec EventSpec, payload CloudEventsPayload) (event.Event
 func newCloudEventFromSpec(meta *EventTypeSpec, spec EventSpec) event.Event {
 	ev := event.New()
 	ev.SetType(meta.Type())
-	ev.SetSpecVersion(string(meta.SpecVersion))
+	ev.SetSpecVersion(event.CloudEventsVersionV1)
 
 	if spec.Time.IsZero() {
 		ev.SetTime(time.Now())

--- a/internal/event/spec/parser_test.go
+++ b/internal/event/spec/parser_test.go
@@ -15,10 +15,9 @@ type event struct {
 
 func (e event) Spec() *spec.EventTypeSpec {
 	return &spec.EventTypeSpec{
-		Subsystem:   "subsys",
-		Name:        "test",
-		SpecVersion: "1.0",
-		Version:     "v1",
+		Subsystem: "subsys",
+		Name:      "test",
+		Version:   "v1",
 	}
 }
 
@@ -44,7 +43,7 @@ func TestParserSanity(t *testing.T) {
 		})
 
 	assert.NoError(t, err)
-	assert.Equal(t, "openmeter.subsys.v1.test", cloudEvent.Type())
+	assert.Equal(t, "io.openmeter.subsys.v1.test", cloudEvent.Type())
 	assert.Equal(t, "//openmeter.io/namespace/default/subject/ID", cloudEvent.Subject())
 	assert.Equal(t, "somesource", cloudEvent.Source())
 

--- a/internal/sink/flushhandler/ingestnotification/events.go
+++ b/internal/sink/flushhandler/ingestnotification/events.go
@@ -12,10 +12,10 @@ const (
 )
 
 const (
-	EventIngestion spec.EventName = "ingestion"
+	ingestedEventName spec.EventName = "event.ingested"
 )
 
-type IngestEvent struct {
+type EventIngested struct {
 	Namespace  models.NamespaceID `json:"namespace"`
 	SubjectKey string             `json:"subjectKey"`
 
@@ -26,17 +26,16 @@ type IngestEvent struct {
 }
 
 var ingestEventSpec = spec.EventTypeSpec{
-	Subsystem:   EventSubsystem,
-	Name:        EventIngestion,
-	SpecVersion: "1.0",
-	Version:     "v1",
+	Subsystem: EventSubsystem,
+	Name:      ingestedEventName,
+	Version:   "v1",
 }
 
-func (i IngestEvent) Spec() *spec.EventTypeSpec {
+func (i EventIngested) Spec() *spec.EventTypeSpec {
 	return &ingestEventSpec
 }
 
-func (i IngestEvent) Validate() error {
+func (i EventIngested) Validate() error {
 	if err := i.Namespace.Validate(); err != nil {
 		return err
 	}

--- a/internal/sink/flushhandler/ingestnotification/handler.go
+++ b/internal/sink/flushhandler/ingestnotification/handler.go
@@ -55,7 +55,7 @@ func (h *handler) OnFlushSuccess(ctx context.Context, events []sinkmodels.SinkMe
 			ID:      message.Serialized.Id,
 			Source:  spec.ComposeResourcePath(message.Namespace, spec.EntityEvent, message.Serialized.Id),
 			Subject: spec.ComposeResourcePath(message.Namespace, spec.EntitySubjectKey, message.Serialized.Subject),
-		}, IngestEvent{
+		}, EventIngested{
 			Namespace:  eventmodels.NamespaceID{ID: message.Namespace},
 			SubjectKey: message.Serialized.Subject,
 			MeterSlugs: h.getMeterSlugsFromMeters(message.Meters),

--- a/openmeter/credit/events.go
+++ b/openmeter/credit/events.go
@@ -6,11 +6,6 @@ const (
 	EventSubsystem = credit.EventSubsystem
 )
 
-const (
-	EventCreateGrant = credit.EventCreateGrant
-	EventVoidGrant   = credit.EventVoidGrant
-)
-
 type (
 	GrantCreatedEvent = credit.GrantCreatedEvent
 	GrantVoidedEvent  = credit.GrantVoidedEvent

--- a/openmeter/entitlement/events.go
+++ b/openmeter/entitlement/events.go
@@ -6,11 +6,6 @@ const (
 	EventSubsystem = entitlement.EventSubsystem
 )
 
-const (
-	EventCreateEntitlement = entitlement.EventCreateEntitlement
-	EventDeleteEntitlement = entitlement.EventDeleteEntitlement
-)
-
 type (
 	EntitlementCreatedEvent = entitlement.EntitlementCreatedEvent
 	EntitlementDeletedEvent = entitlement.EntitlementDeletedEvent

--- a/openmeter/entitlement/metered/events.go
+++ b/openmeter/entitlement/metered/events.go
@@ -6,10 +6,6 @@ const (
 	EventSubsystem = meteredentitlement.EventSubsystem
 )
 
-const (
-	EventResetEntitlementUsage = meteredentitlement.EventResetEntitlementUsage
-)
-
 type (
-	ResetEntitlementEvent = meteredentitlement.ResetEntitlementEvent
+	EntitlementResetEvent = meteredentitlement.EntitlementResetEvent
 )

--- a/openmeter/sink/flushhandler/ingestnotification/ingestnotification.go
+++ b/openmeter/sink/flushhandler/ingestnotification/ingestnotification.go
@@ -15,12 +15,8 @@ const (
 	EventSubsystem = ingestnotification.EventSubsystem
 )
 
-const (
-	EventIngestion = ingestnotification.EventIngestion
-)
-
 type (
-	IngestEvent = ingestnotification.IngestEvent
+	IngestEvent = ingestnotification.EventIngested
 )
 
 // Ingest notification handler


### PR DESCRIPTION
## Overview

Changes:
- append io. to type names example io.openmeter.entitlement.v1.entitlement.created
- unify event naming (use entity.action scheme)
- remove spec version from type meta as that's 1.0 for all cloudevents (that's the cloudevent's version number)
- do not export eventName as we are getting the Type() from the object

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

## Notes for reviewer

<!-- Anything the reviewer should know? -->
