### PR TITLE
feat: use sarama lib for internal message publishing

### DIFF
--- a/cmd/balance-worker/main.go
+++ b/cmd/balance-worker/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ThreeDotsLabs/watermill"
 	wmkafka "github.com/ThreeDotsLabs/watermill-kafka/v3/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
-	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-slog/otelslog"
@@ -29,7 +28,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
@@ -39,7 +37,6 @@ import (
 	"github.com/openmeterio/openmeter/internal/entitlement/balanceworker"
 	entitlementpgadapter "github.com/openmeterio/openmeter/internal/entitlement/postgresadapter"
 	"github.com/openmeterio/openmeter/internal/event/publisher"
-	"github.com/openmeterio/openmeter/internal/ingest/kafkaingest"
 	"github.com/openmeterio/openmeter/internal/meter"
 	"github.com/openmeterio/openmeter/internal/registry"
 	registrybuilder "github.com/openmeterio/openmeter/internal/registry/builder"
@@ -49,8 +46,6 @@ import (
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/framework/operation"
 	"github.com/openmeterio/openmeter/pkg/gosundheit"
-	pkgkafka "github.com/openmeterio/openmeter/pkg/kafka"
-	kafkametrics "github.com/openmeterio/openmeter/pkg/kafka/metrics"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
@@ -140,7 +135,6 @@ func main() {
 		}
 	}()
 	otel.SetMeterProvider(otelMeterProvider)
-	metricMeter := otelMeterProvider.Meter(otelName)
 
 	if conf.Telemetry.Metrics.Exporters.Prometheus.Enabled {
 		telemetryRouter.Handle("/metrics", promhttp.Handler())
@@ -233,17 +227,18 @@ func main() {
 	}
 
 	// Create publisher
-	kafkaPublisher, err := initKafkaProducer(ctx, conf, logger, metricMeter, &group)
-	if err != nil {
-		logger.Error("failed to initialize Kafka producer", slog.String("error", err.Error()))
-		os.Exit(1)
-	}
-
-	publishers, err := initEventPublisher(ctx, logger, conf, kafkaPublisher)
+	publishers, err := initEventPublisher(logger, conf)
 	if err != nil {
 		logger.Error("failed to initialize event publisher", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
+
+	defer func() {
+		// We are using sync publishing, so it's fine to close the publisher using defers.
+		if err := publishers.watermillPublisher.Close(); err != nil {
+			logger.Error("failed to close event publisher", slog.String("error", err.Error()))
+		}
+	}()
 
 	// Dependencies: entitlement
 	entitlementConnectors := registrybuilder.GetEntitlementRegistry(registry.EntitlementOptions{
@@ -361,24 +356,23 @@ type eventPublishers struct {
 	eventPublisher     publisher.Publisher
 }
 
-func initEventPublisher(ctx context.Context, logger *slog.Logger, conf config.Configuration, kafkaProducer *kafka.Producer) (*eventPublishers, error) {
-	eventDriver := watermillkafka.NewPublisher(kafkaProducer)
-
+func initEventPublisher(logger *slog.Logger, conf config.Configuration) (*eventPublishers, error) {
+	provisionTopics := []watermillkafka.AutoProvisionTopic{}
 	if conf.BalanceWorker.DLQ.AutoProvision.Enabled {
-		adminClient, err := kafka.NewAdminClientFromProducer(kafkaProducer)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create Kafka admin client: %w", err)
-		}
+		provisionTopics = append(provisionTopics, watermillkafka.AutoProvisionTopic{
+			Topic:         conf.BalanceWorker.DLQ.Topic,
+			NumPartitions: int32(conf.BalanceWorker.DLQ.AutoProvision.Partitions),
+		})
+	}
 
-		defer adminClient.Close()
-
-		if err := pkgkafka.ProvisionTopic(ctx,
-			adminClient,
-			logger,
-			conf.BalanceWorker.DLQ.Topic,
-			conf.BalanceWorker.DLQ.AutoProvision.Partitions); err != nil {
-			return nil, fmt.Errorf("failed to auto provision topic: %w", err)
-		}
+	eventDriver, err := watermillkafka.NewPublisherFromOMConfig(watermillkafka.PublisherOptions{
+		KafkaConfig:     conf.Ingest.Kafka.KafkaConfiguration,
+		ProvisionTopics: provisionTopics,
+		ClientID:        otelName,
+		Logger:          logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create event driver: %w", err)
 	}
 
 	eventPublisher, err := publisher.NewPublisher(publisher.PublisherOptions{
@@ -394,30 +388,6 @@ func initEventPublisher(ctx context.Context, logger *slog.Logger, conf config.Co
 		marshaler:          publisher.NewCloudEventMarshaler(watermillkafka.AddPartitionKeyFromSubject),
 		eventPublisher:     eventPublisher,
 	}, nil
-}
-
-func initKafkaProducer(ctx context.Context, config config.Configuration, logger *slog.Logger, metricMeter metric.Meter, group *run.Group) (*kafka.Producer, error) {
-	// Initialize Kafka Admin Client
-	kafkaConfig := config.Ingest.Kafka.CreateKafkaConfig()
-
-	// Initialize Kafka Producer
-	producer, err := kafka.NewProducer(&kafkaConfig)
-	if err != nil {
-		return nil, fmt.Errorf("init kafka ingest: %w", err)
-	}
-
-	// Initialize Kafka Client Statistics reporter
-	kafkaMetrics, err := kafkametrics.New(metricMeter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Kafka client metrics: %w", err)
-	}
-
-	group.Add(kafkaingest.KafkaProducerGroup(ctx, producer, logger, kafkaMetrics))
-
-	go pkgkafka.ConsumeLogChannel(producer, logger.WithGroup("kafka").WithGroup("producer"))
-
-	slog.Debug("connected to Kafka")
-	return producer, nil
 }
 
 type pgClients struct {

--- a/cmd/balance-worker/main.go
+++ b/cmd/balance-worker/main.go
@@ -368,7 +368,7 @@ func initEventPublisher(logger *slog.Logger, conf config.Configuration, metricMe
 		})
 	}
 
-	eventDriver, err := watermillkafka.NewPublisherFromOMConfig(watermillkafka.PublisherOptions{
+	eventDriver, err := watermillkafka.NewPublisher(watermillkafka.PublisherOptions{
 		KafkaConfig:     conf.Ingest.Kafka.KafkaConfiguration,
 		ProvisionTopics: provisionTopics,
 		ClientID:        otelName,

--- a/cmd/balance-worker/main.go
+++ b/cmd/balance-worker/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
@@ -136,6 +137,8 @@ func main() {
 	}()
 	otel.SetMeterProvider(otelMeterProvider)
 
+	metricMeter := otelMeterProvider.Meter(otelName)
+
 	if conf.Telemetry.Metrics.Exporters.Prometheus.Enabled {
 		telemetryRouter.Handle("/metrics", promhttp.Handler())
 	}
@@ -227,7 +230,7 @@ func main() {
 	}
 
 	// Create publisher
-	publishers, err := initEventPublisher(logger, conf)
+	publishers, err := initEventPublisher(logger, conf, metricMeter)
 	if err != nil {
 		logger.Error("failed to initialize event publisher", slog.String("error", err.Error()))
 		os.Exit(1)
@@ -356,7 +359,7 @@ type eventPublishers struct {
 	eventPublisher     publisher.Publisher
 }
 
-func initEventPublisher(logger *slog.Logger, conf config.Configuration) (*eventPublishers, error) {
+func initEventPublisher(logger *slog.Logger, conf config.Configuration, metricMeter metric.Meter) (*eventPublishers, error) {
 	provisionTopics := []watermillkafka.AutoProvisionTopic{}
 	if conf.BalanceWorker.DLQ.AutoProvision.Enabled {
 		provisionTopics = append(provisionTopics, watermillkafka.AutoProvisionTopic{
@@ -370,6 +373,7 @@ func initEventPublisher(logger *slog.Logger, conf config.Configuration) (*eventP
 		ProvisionTopics: provisionTopics,
 		ClientID:        otelName,
 		Logger:          logger,
+		MetricMeter:     metricMeter,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create event driver: %w", err)

--- a/cmd/notification-service/main.go
+++ b/cmd/notification-service/main.go
@@ -363,7 +363,7 @@ func initEventPublisher(logger *slog.Logger, conf config.Configuration, metricMe
 		})
 	}
 
-	eventDriver, err := watermillkafka.NewPublisherFromOMConfig(watermillkafka.PublisherOptions{
+	eventDriver, err := watermillkafka.NewPublisher(watermillkafka.PublisherOptions{
 		KafkaConfig:     conf.Ingest.Kafka.KafkaConfiguration,
 		ProvisionTopics: provisionTopics,
 		ClientID:        otelName,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -457,7 +457,7 @@ func initEventPublisher(logger *slog.Logger, conf config.Configuration, metricMe
 		})
 	}
 
-	eventDriver, err := watermillkafka.NewPublisherFromOMConfig(watermillkafka.PublisherOptions{
+	eventDriver, err := watermillkafka.NewPublisher(watermillkafka.PublisherOptions{
 		KafkaConfig:     conf.Ingest.Kafka.KafkaConfiguration,
 		ProvisionTopics: provisionTopics,
 		ClientID:        otelName,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ import (
 	health "github.com/AppsFlyer/go-sundheit"
 	healthhttp "github.com/AppsFlyer/go-sundheit/http"
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -212,11 +213,18 @@ func main() {
 		os.Exit(1)
 	}
 
-	eventPublisher, err := initEventPublisher(ctx, logger, conf, kafkaProducer)
+	eventPublishers, err := initEventPublisher(logger, conf)
 	if err != nil {
 		logger.Error("failed to initialize event publisher", "error", err)
 		os.Exit(1)
 	}
+
+	defer func() {
+		logger.Info("closing event publisher")
+		if err = eventPublishers.driver.Close(); err != nil {
+			logger.Error("failed to close event publisher", "error", err)
+		}
+	}()
 
 	// Initialize Kafka Ingest
 	ingestCollector, kafkaIngestNamespaceHandler, err := initKafkaIngest(
@@ -314,7 +322,7 @@ func main() {
 			StreamingConnector: streamingConnector,
 			MeterRepository:    meterRepository,
 			Logger:             logger,
-			Publisher:          eventPublisher.ForTopic(conf.Events.SystemEvents.Topic),
+			Publisher:          eventPublishers.eventPublisher.ForTopic(conf.Events.SystemEvents.Topic),
 		})
 	}
 
@@ -421,34 +429,54 @@ func main() {
 	}
 }
 
-func initEventPublisher(ctx context.Context, logger *slog.Logger, conf config.Configuration, kafkaProducer *kafka.Producer) (publisher.Publisher, error) {
+type publishers struct {
+	eventPublisher publisher.Publisher
+	driver         message.Publisher
+}
+
+func initEventPublisher(logger *slog.Logger, conf config.Configuration) (*publishers, error) {
 	if !conf.Events.Enabled {
-		return publisher.NewPublisher(publisher.PublisherOptions{
+		publisher, err := publisher.NewPublisher(publisher.PublisherOptions{
 			Publisher: &noop.Publisher{},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create event driver: %w", err)
+		}
+
+		return &publishers{
+			eventPublisher: publisher,
+			driver:         &noop.Publisher{},
+		}, nil
+
+	}
+
+	provisionTopics := []watermillkafka.AutoProvisionTopic{}
+	if conf.Events.SystemEvents.AutoProvision.Enabled {
+		provisionTopics = append(provisionTopics, watermillkafka.AutoProvisionTopic{
+			Topic:         conf.Events.SystemEvents.Topic,
+			NumPartitions: int32(conf.Events.SystemEvents.AutoProvision.Partitions),
 		})
 	}
 
-	eventDriver := watermillkafka.NewPublisher(kafkaProducer)
+	eventDriver, err := watermillkafka.NewPublisherFromOMConfig(watermillkafka.PublisherOptions{
+		KafkaConfig:     conf.Ingest.Kafka.KafkaConfiguration,
+		ProvisionTopics: provisionTopics,
+		ClientID:        otelName,
+		Logger:          logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create event driver: %w", err)
+	}
+
 	eventPublisher, err := publisher.NewPublisher(publisher.PublisherOptions{
 		Publisher: eventDriver,
 		Transform: watermillkafka.AddPartitionKeyFromSubject,
 	})
 
-	// Auto provision topics if needed
-	if conf.Events.SystemEvents.AutoProvision.Enabled {
-		adminClient, err := kafka.NewAdminClientFromProducer(kafkaProducer)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create Kafka admin client: %w", err)
-		}
-
-		defer adminClient.Close()
-
-		if err := pkgkafka.ProvisionTopic(ctx, adminClient, logger, conf.Events.SystemEvents.Topic, conf.Events.SystemEvents.AutoProvision.Partitions); err != nil {
-			return nil, fmt.Errorf("failed to auto provision topic: %w", err)
-		}
-	}
-
-	return eventPublisher, err
+	return &publishers{
+		eventPublisher: eventPublisher,
+		driver:         eventDriver,
+	}, err
 }
 
 func initKafkaProducer(ctx context.Context, config config.Configuration, logger *slog.Logger, metricMeter metric.Meter, group *run.Group) (*kafka.Producer, error) {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -213,7 +213,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	eventPublishers, err := initEventPublisher(logger, conf)
+	eventPublishers, err := initEventPublisher(logger, conf, metricMeter)
 	if err != nil {
 		logger.Error("failed to initialize event publisher", "error", err)
 		os.Exit(1)
@@ -434,7 +434,7 @@ type publishers struct {
 	driver         message.Publisher
 }
 
-func initEventPublisher(logger *slog.Logger, conf config.Configuration) (*publishers, error) {
+func initEventPublisher(logger *slog.Logger, conf config.Configuration, metricMeter metric.Meter) (*publishers, error) {
 	if !conf.Events.Enabled {
 		publisher, err := publisher.NewPublisher(publisher.PublisherOptions{
 			Publisher: &noop.Publisher{},
@@ -447,7 +447,6 @@ func initEventPublisher(logger *slog.Logger, conf config.Configuration) (*publis
 			eventPublisher: publisher,
 			driver:         &noop.Publisher{},
 		}, nil
-
 	}
 
 	provisionTopics := []watermillkafka.AutoProvisionTopic{}
@@ -463,6 +462,7 @@ func initEventPublisher(logger *slog.Logger, conf config.Configuration) (*publis
 		ProvisionTopics: provisionTopics,
 		ClientID:        otelName,
 		Logger:          logger,
+		MetricMeter:     metricMeter,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create event driver: %w", err)

--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -225,7 +225,7 @@ func initIngestEventPublisher(logger *slog.Logger, conf config.Configuration, me
 		return nil, nil
 	}
 
-	eventDriver, err := watermillkafka.NewPublisherFromOMConfig(watermillkafka.PublisherOptions{
+	eventDriver, err := watermillkafka.NewPublisher(watermillkafka.PublisherOptions{
 		KafkaConfig: conf.Ingest.Kafka.KafkaConfiguration,
 		ClientID:    otelName,
 		Logger:      logger,

--- a/internal/watermill/driver/kafka/marshaler.go
+++ b/internal/watermill/driver/kafka/marshaler.go
@@ -1,0 +1,38 @@
+package kafka
+
+import (
+	"github.com/IBM/sarama"
+	"github.com/ThreeDotsLabs/watermill-kafka/v3/pkg/kafka"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/cloudevents/sdk-go/v2/event"
+)
+
+const (
+	PartitionKeyMetadataKey = "x-kafka-partition-key"
+)
+
+type marshalerWithPartitionKey struct {
+	kafka.DefaultMarshaler
+}
+
+func (m marshalerWithPartitionKey) Marshal(topic string, msg *message.Message) (*sarama.ProducerMessage, error) {
+	kafkaMsg, err := m.DefaultMarshaler.Marshal(topic, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	partitionKey := msg.Metadata.Get(PartitionKeyMetadataKey)
+	if partitionKey != "" {
+		kafkaMsg.Key = sarama.ByteEncoder(partitionKey)
+	}
+
+	return kafkaMsg, nil
+}
+
+// AddPartitionKeyFromSubject adds partition key to the message based on the CloudEvent subject.
+func AddPartitionKeyFromSubject(watermillIn *message.Message, cloudEvent event.Event) (*message.Message, error) {
+	if cloudEvent.Subject() != "" {
+		watermillIn.Metadata[PartitionKeyMetadataKey] = cloudEvent.Subject()
+	}
+	return watermillIn, nil
+}

--- a/internal/watermill/driver/kafka/metrics/README.md
+++ b/internal/watermill/driver/kafka/metrics/README.md
@@ -1,0 +1,9 @@
+# go-metrics to OpenTelemetry adapter
+
+Sarama (any most probably other projects) rely on the [http://github.com/rcrowley/go-metrics](go-metrics) package, numerous connectors exist
+for the package, however there seem to be no opentelemetry one.
+
+Given the package only supports periodic scraping, it's better to wrap the metric types of go-metrics so that we can send the raw events to OpenTelemetry. The existing event interface of go-metrics is quite limited compared to OpenTelemetry esp considering the usage in Sarama lib, so right now:
+
+- Context is context.Background() for OpenTelemetry calls
+- Errors for metric registration is only logged

--- a/internal/watermill/driver/kafka/metrics/adapter.go
+++ b/internal/watermill/driver/kafka/metrics/adapter.go
@@ -1,0 +1,202 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"reflect"
+
+	"github.com/rcrowley/go-metrics"
+	otelmetric "go.opentelemetry.io/otel/metric"
+)
+
+type (
+	TransformMetricsNameToOtel func(string) string
+	ErrorHandler               func(error)
+)
+
+func LoggingErrorHandler(dest *slog.Logger) ErrorHandler {
+	return func(err error) {
+		dest.Error("error registering meter", "err", err)
+	}
+}
+
+func MetricAddNamePrefix(prefix string) TransformMetricsNameToOtel {
+	return func(name string) string {
+		return prefix + name
+	}
+}
+
+type NewRegistryOptions struct {
+	MetricMeter     otelmetric.Meter
+	NameTransformFn TransformMetricsNameToOtel
+	ErrorHandler    ErrorHandler
+}
+
+func NewRegistry(opts NewRegistryOptions) (metrics.Registry, error) {
+	if opts.MetricMeter == nil {
+		return nil, errors.New("metric meter is required")
+	}
+
+	if opts.NameTransformFn == nil {
+		opts.NameTransformFn = func(name string) string {
+			return name
+		}
+	}
+
+	if opts.ErrorHandler == nil {
+		opts.ErrorHandler = func(err error) {
+			// no-op
+		}
+	}
+
+	return &registry{
+		Registry:        metrics.NewRegistry(),
+		meticMeter:      opts.MetricMeter,
+		nameTransformFn: opts.NameTransformFn,
+		errorHandler:    opts.ErrorHandler,
+	}, nil
+}
+
+type registry struct {
+	metrics.Registry
+	meticMeter      otelmetric.Meter
+	nameTransformFn TransformMetricsNameToOtel
+	errorHandler    ErrorHandler
+}
+
+func (r *registry) GetOrRegister(name string, def interface{}) interface{} {
+	existingMeter := r.Registry.Get(name)
+	if existingMeter != nil {
+		return existingMeter
+	}
+
+	wrappedMeter, err := r.getWrappedMeter(name, def)
+	if err != nil {
+		r.errorHandler(err)
+		return def
+	}
+
+	if err := r.Register(name, wrappedMeter); err != nil {
+		r.errorHandler(err)
+	}
+
+	return wrappedMeter
+}
+
+func (r *registry) Register(name string, def interface{}) error {
+	wrappedMeter, err := r.getWrappedMeter(name, def)
+	if err != nil {
+		return err
+	}
+
+	return r.Registry.Register(name, wrappedMeter)
+}
+
+func (r *registry) getWrappedMeter(name string, def interface{}) (interface{}, error) {
+	// def might be a function that returns the actual metric, not an interface{}, so we need to have reflect here, to instantiate
+	// the actual metric in such cases
+	if v := reflect.ValueOf(def); v.Kind() == reflect.Func {
+		def = v.Call(nil)[0].Interface()
+	}
+
+	switch meterDef := def.(type) {
+	case metrics.Meter:
+		otelMeter, err := r.meticMeter.Int64Counter(r.nameTransformFn(name))
+		if err != nil {
+			return def, err
+		}
+
+		return &wrappedMeter{Meter: meterDef, otelMeter: otelMeter}, nil
+	case metrics.Counter:
+		otelMeter, err := r.meticMeter.Int64UpDownCounter(r.nameTransformFn(name))
+		if err != nil {
+			return def, err
+		}
+
+		return &wrappedCounter{Counter: meterDef, otelMeter: otelMeter}, nil
+	case metrics.GaugeFloat64:
+		otelMeter, err := r.meticMeter.Float64Gauge(r.nameTransformFn(name))
+		if err != nil {
+			return def, err
+		}
+
+		return &wrappedGaugeFloat64{GaugeFloat64: meterDef, otelMeter: otelMeter}, nil
+	case metrics.Gauge:
+		otelMeter, err := r.meticMeter.Int64Gauge(r.nameTransformFn(name))
+		if err != nil {
+			return def, err
+		}
+
+		return &wrappedGauge{Gauge: meterDef, otelMeter: otelMeter}, nil
+	case metrics.Histogram:
+		otelMeter, err := r.meticMeter.Int64Histogram(r.nameTransformFn(name))
+		if err != nil {
+			r.errorHandler(err)
+			break
+		}
+
+		return &wrappedHistogram{Histogram: meterDef, otelMeter: otelMeter}, nil
+	default:
+		// this is just a safety net, as we should have handled all the cases above (based on the lib)
+		r.errorHandler(fmt.Errorf("unsupported metric type (name=%s): %v", name, def))
+	}
+
+	return def, nil
+}
+
+type wrappedMeter struct {
+	metrics.Meter
+	otelMeter otelmetric.Int64Counter
+}
+
+func (m *wrappedMeter) Mark(n int64) {
+	m.otelMeter.Add(context.Background(), n)
+	m.Meter.Mark(n)
+}
+
+type wrappedCounter struct {
+	metrics.Counter
+	otelMeter otelmetric.Int64UpDownCounter
+}
+
+func (m *wrappedCounter) Inc(n int64) {
+	m.otelMeter.Add(context.Background(), n)
+	m.Counter.Inc(n)
+}
+
+func (m *wrappedCounter) Dec(n int64) {
+	m.otelMeter.Add(context.Background(), -n)
+	m.Counter.Dec(n)
+}
+
+type wrappedGaugeFloat64 struct {
+	metrics.GaugeFloat64
+	otelMeter otelmetric.Float64Gauge
+}
+
+func (m *wrappedGaugeFloat64) Update(newVal float64) {
+	m.otelMeter.Record(context.Background(), newVal)
+	m.GaugeFloat64.Update(newVal)
+}
+
+type wrappedGauge struct {
+	metrics.Gauge
+	otelMeter otelmetric.Int64Gauge
+}
+
+func (m *wrappedGauge) Update(newVal int64) {
+	m.otelMeter.Record(context.Background(), newVal)
+	m.Gauge.Update(newVal)
+}
+
+type wrappedHistogram struct {
+	metrics.Histogram
+	otelMeter otelmetric.Int64Histogram
+}
+
+func (m *wrappedHistogram) Update(newVal int64) {
+	m.otelMeter.Record(context.Background(), newVal)
+	m.Histogram.Update(newVal)
+}

--- a/internal/watermill/driver/kafka/publisher.go
+++ b/internal/watermill/driver/kafka/publisher.go
@@ -1,63 +1,80 @@
 package kafka
 
 import (
-	"github.com/ThreeDotsLabs/watermill/message"
-	"github.com/cloudevents/sdk-go/v2/event"
-	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/IBM/sarama"
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill-kafka/v3/pkg/kafka"
+	"github.com/openmeterio/openmeter/config"
 )
 
-const (
-	PartitionKeyMetadataKey = "x-kafka-partition-key"
-)
-
-type Publisher struct {
-	producer *kafka.Producer
+type PublisherOptions struct {
+	KafkaConfig     config.KafkaConfiguration
+	ProvisionTopics []AutoProvisionTopic
+	ClientID        string
+	Logger          *slog.Logger
 }
 
-var _ message.Publisher = (*Publisher)(nil)
-
-func NewPublisher(producer *kafka.Producer) *Publisher {
-	return &Publisher{producer: producer}
-}
-
-func (p *Publisher) Publish(topic string, messages ...*message.Message) error {
-	for _, message := range messages {
-		kafkaMessage := &kafka.Message{
-			TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny},
-			Value:          []byte(message.Payload),
-			Headers:        make([]kafka.Header, 0, len(message.Metadata)),
-		}
-
-		for k, v := range message.Metadata {
-			if k == PartitionKeyMetadataKey {
-				continue
-			}
-			kafkaMessage.Headers = append(kafkaMessage.Headers, kafka.Header{
-				Key:   k,
-				Value: []byte(v),
-			})
-		}
-
-		if partitionKey, ok := message.Metadata[PartitionKeyMetadataKey]; ok {
-			kafkaMessage.Key = []byte(partitionKey)
-		}
-
-		if err := p.producer.Produce(kafkaMessage, nil); err != nil {
-			return err
-		}
+func (o *PublisherOptions) Validate() error {
+	if err := o.KafkaConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid kafka config: %w", err)
 	}
 
+	if o.ClientID == "" {
+		return errors.New("client ID is required")
+	}
+
+	if o.Logger == nil {
+		return errors.New("logger is required")
+	}
 	return nil
 }
 
-func (p *Publisher) Close() error {
-	p.producer.Close()
-	return nil
-}
-
-func AddPartitionKeyFromSubject(watermillIn *message.Message, cloudEvent event.Event) (*message.Message, error) {
-	if cloudEvent.Subject() != "" {
-		watermillIn.Metadata[PartitionKeyMetadataKey] = cloudEvent.Subject()
+func NewPublisherFromOMConfig(in PublisherOptions) (*kafka.Publisher, error) {
+	if err := in.Validate(); err != nil {
+		return nil, err
 	}
-	return watermillIn, nil
+
+	// TODO: we need to have a proper metric bridge between the sarama metrics based on https://github.com/rcrowley/go-metrics
+	// and OTEL. I haven't found any libraries, so we might want to have a package in our org for that.
+
+	// This means that we, right now have 0 metrics for the sarama lib.
+
+	wmConfig := kafka.PublisherConfig{
+		Brokers:               []string{in.KafkaConfig.Broker},
+		OverwriteSaramaConfig: sarama.NewConfig(),
+		Marshaler:             marshalerWithPartitionKey{},
+		OTELEnabled:           true, // This relies on the global trace provider
+	}
+
+	wmConfig.OverwriteSaramaConfig.Metadata.RefreshFrequency = in.KafkaConfig.TopicMetadataRefreshInterval.Duration()
+	wmConfig.OverwriteSaramaConfig.ClientID = "openmeter/balance-worker"
+
+	switch in.KafkaConfig.SecurityProtocol {
+	case "SASL_SSL":
+		wmConfig.OverwriteSaramaConfig.Net.SASL.Enable = true
+		wmConfig.OverwriteSaramaConfig.Net.SASL.User = in.KafkaConfig.SaslUsername
+		wmConfig.OverwriteSaramaConfig.Net.SASL.Password = in.KafkaConfig.SaslPassword
+		wmConfig.OverwriteSaramaConfig.Net.SASL.Mechanism = sarama.SASLMechanism(in.KafkaConfig.SecurityProtocol)
+		wmConfig.OverwriteSaramaConfig.Net.TLS.Enable = true
+		wmConfig.OverwriteSaramaConfig.Net.TLS.Config = &tls.Config{}
+	default:
+	}
+
+	// Producer specific settings
+	wmConfig.OverwriteSaramaConfig.Producer.Return.Successes = true
+
+	if err := wmConfig.Validate(); err != nil {
+		return nil, err
+	}
+
+	if err := provisionTopics(in.KafkaConfig.Broker, wmConfig.OverwriteSaramaConfig, in.ProvisionTopics); err != nil {
+		return nil, err
+	}
+
+	return kafka.NewPublisher(wmConfig, watermill.NewSlogLogger(in.Logger))
 }

--- a/internal/watermill/driver/kafka/publisher.go
+++ b/internal/watermill/driver/kafka/publisher.go
@@ -47,7 +47,7 @@ func (o *PublisherOptions) Validate() error {
 	return nil
 }
 
-func NewPublisherFromOMConfig(in PublisherOptions) (*kafka.Publisher, error) {
+func NewPublisher(in PublisherOptions) (*kafka.Publisher, error) {
 	if err := in.Validate(); err != nil {
 		return nil, err
 	}
@@ -55,11 +55,6 @@ func NewPublisherFromOMConfig(in PublisherOptions) (*kafka.Publisher, error) {
 	if in.MeterPrefix == "" {
 		in.MeterPrefix = defaultMeterPrefix
 	}
-
-	// TODO: we need to have a proper metric bridge between the sarama metrics based on https://github.com/rcrowley/go-metrics
-	// and OTEL. I haven't found any libraries, so we might want to have a package in our org for that.
-
-	// This means that we, right now have 0 metrics for the sarama lib.
 
 	wmConfig := kafka.PublisherConfig{
 		Brokers:               []string{in.KafkaConfig.Broker},

--- a/internal/watermill/driver/kafka/topic_provision.go
+++ b/internal/watermill/driver/kafka/topic_provision.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"github.com/IBM/sarama"
+
 	"github.com/openmeterio/openmeter/pkg/errorsx"
 )
 

--- a/internal/watermill/driver/kafka/topic_provision.go
+++ b/internal/watermill/driver/kafka/topic_provision.go
@@ -1,0 +1,35 @@
+package kafka
+
+import (
+	"github.com/IBM/sarama"
+	"github.com/openmeterio/openmeter/pkg/errorsx"
+)
+
+type AutoProvisionTopic struct {
+	Topic         string
+	NumPartitions int32
+}
+
+func provisionTopics(broker string, config *sarama.Config, topics []AutoProvisionTopic) error {
+	admin, err := sarama.NewClusterAdmin([]string{broker}, config)
+	if err != nil {
+		return err
+	}
+	defer admin.Close()
+
+	for _, topic := range topics {
+		err := admin.CreateTopic(topic.Topic, &sarama.TopicDetail{
+			NumPartitions:     topic.NumPartitions,
+			ReplicationFactor: -1, // use default
+		}, false)
+		if err != nil {
+			if topicError, ok := errorsx.ErrorAs[*sarama.TopicError](err); ok && topicError.Err == sarama.ErrTopicAlreadyExists {
+				continue
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}

--- a/openmeter/watermill/driver/kafka/driver.go
+++ b/openmeter/watermill/driver/kafka/driver.go
@@ -16,8 +16,8 @@ type (
 	PublisherOptions = watermillkafka.PublisherOptions
 )
 
-func NewPublisherFromOMConfig(in PublisherOptions) (*kafka.Publisher, error) {
-	return watermillkafka.NewPublisherFromOMConfig(in)
+func NewPublisher(in PublisherOptions) (*kafka.Publisher, error) {
+	return watermillkafka.NewPublisher(in)
 }
 
 func AddPartitionKeyFromSubject(watermillIn *message.Message, cloudEvent event.Event) (*message.Message, error) {

--- a/openmeter/watermill/driver/kafka/driver.go
+++ b/openmeter/watermill/driver/kafka/driver.go
@@ -1,9 +1,9 @@
 package kafka
 
 import (
+	"github.com/ThreeDotsLabs/watermill-kafka/v3/pkg/kafka"
 	"github.com/ThreeDotsLabs/watermill/message"
 	"github.com/cloudevents/sdk-go/v2/event"
-	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 
 	watermillkafka "github.com/openmeterio/openmeter/internal/watermill/driver/kafka"
 )
@@ -13,11 +13,11 @@ const (
 )
 
 type (
-	Publisher = watermillkafka.Publisher
+	PublisherOptions = watermillkafka.PublisherOptions
 )
 
-func NewPublisher(producer *kafka.Producer) *Publisher {
-	return watermillkafka.NewPublisher(producer)
+func NewPublisherFromOMConfig(in PublisherOptions) (*kafka.Publisher, error) {
+	return watermillkafka.NewPublisherFromOMConfig(in)
 }
 
 func AddPartitionKeyFromSubject(watermillIn *message.Message, cloudEvent event.Event) (*message.Message, error) {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This patch uses the sarama lib for internal message publishing. This patch also adds support for exposing the sarama metrics using the metrics bridge.

# Events

Sarama (any most probably other projects) rely on the [http://github.com/rcrowley/go-metrics](go-metrics) package, numerous connectors exist
for the package, however there seem to be no opentelemetry one.

Given the package only supports periodic scraping, it's better to wrap the metric types of go-metrics so that we can send the raw events to OpenTelemetry. The existing event interface of go-metrics is quite limited compared to OpenTelemetry esp considering the usage in Sarama lib, so right now:

- Context is context.Background() for OpenTelemetry calls
- Errors for metric registration is only logged

Example metrics:

```
# TYPE sarama_publisher_response_size histogram
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="0"} 0
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="5"} 0
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="10"} 0
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="25"} 0
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="50"} 0
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="75"} 2
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="100"} 4
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="250"} 4
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="500"} 6
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="750"} 6
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="1000"} 6
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="2500"} 6
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="5000"} 6
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="7500"} 6
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="10000"} 6
sarama_publisher_response_size_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="+Inf"} 6
sarama_publisher_response_size_sum{otel_scope_name="openmeter.io/backend",otel_scope_version=""} 880
sarama_publisher_response_size_count{otel_scope_name="openmeter.io/backend",otel_scope_version=""} 6
# HELP sarama_publisher_response_size_for_broker_1 
# TYPE sarama_publisher_response_size_for_broker_1 histogram
sarama_publisher_response_size_for_broker_1_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="0"} 0
sarama_publisher_response_size_for_broker_1_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="5"} 0
sarama_publisher_response_size_for_broker_1_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="10"} 0
sarama_publisher_response_size_for_broker_1_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="25"} 0
sarama_publisher_response_size_for_broker_1_bucket{otel_scope_name="openmeter.io/backend",otel_scope_version="",le="50"} 0
```

## Notes for reviewer

<!-- Anything the reviewer should know? -->
