### PR TITLE
feat: add command to recalculate balance snapshots

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,6 +54,19 @@
         "--telemetry-address",
         ":10003"
       ]
-    }
+    },
+    {
+      "name": "Launch recalculate entitlement snapshots",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/jobs",
+      "args": [
+        "--config",
+        "${workspaceFolder}/config.yaml",
+        "entitlement",
+        "recalculate-balance-snapshots"
+      ]
+    },
   ]
 }

--- a/cmd/jobs/config/loader.go
+++ b/cmd/jobs/config/loader.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"errors"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/openmeterio/openmeter/config"
+)
+
+func LoadConfig(fileName string) (config.Configuration, error) {
+	v, flags := viper.NewWithOptions(viper.WithDecodeHook(config.DecodeHook())), pflag.NewFlagSet("OpenMeter", pflag.ExitOnError)
+
+	config.SetViperDefaults(v, flags)
+	if fileName != "" {
+		v.SetConfigFile(fileName)
+	}
+
+	err := v.ReadInConfig()
+	if err != nil && !errors.As(err, &viper.ConfigFileNotFoundError{}) {
+		return config.Configuration{}, err
+	}
+
+	var conf config.Configuration
+	err = v.Unmarshal(&conf)
+	if err != nil {
+		return conf, err
+	}
+
+	return conf, conf.Validate()
+}
+
+var defaultConfig *config.Configuration
+
+func GetConfig() (config.Configuration, error) {
+	if defaultConfig == nil {
+		return config.Configuration{}, errors.New("config not set")
+	}
+
+	return *defaultConfig, nil
+}
+
+func SetConfig(c config.Configuration) {
+	defaultConfig = &c
+}

--- a/cmd/jobs/entitlement/init.go
+++ b/cmd/jobs/entitlement/init.go
@@ -1,0 +1,111 @@
+package entitlement
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/openmeterio/openmeter/config"
+	"github.com/openmeterio/openmeter/internal/ent/db"
+	"github.com/openmeterio/openmeter/internal/meter"
+	"github.com/openmeterio/openmeter/internal/registry"
+	registrybuilder "github.com/openmeterio/openmeter/internal/registry/builder"
+	"github.com/openmeterio/openmeter/internal/streaming/clickhouse_connector"
+	watermillkafka "github.com/openmeterio/openmeter/internal/watermill/driver/kafka"
+	"github.com/openmeterio/openmeter/internal/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/slicesx"
+)
+
+type entitlementConnectors struct {
+	Registry *registry.Entitlement
+	EventBus eventbus.Publisher
+	Shutdown func()
+}
+
+func initEntitlements(ctx context.Context, conf config.Configuration, logger *slog.Logger, metricMeter metric.Meter, otelName string) (*entitlementConnectors, error) {
+	// Postgresql
+	entDriver, err := entutils.GetPGDriver(conf.Postgres.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init postgres driver: %w", err)
+	}
+
+	dbClient := db.NewClient(db.Driver(entDriver))
+
+	// Meter repository
+	meterRepository := meter.NewInMemoryRepository(slicesx.Map(conf.Meters, func(meter *models.Meter) models.Meter {
+		return *meter
+	}))
+
+	// streaming connector
+	clickHouseClient, err := clickhouse.Open(conf.Aggregation.ClickHouse.GetClientOptions())
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize clickhouse client: %w", err)
+	}
+
+	streamingConnector, err := clickhouse_connector.NewClickhouseConnector(clickhouse_connector.ClickhouseConnectorConfig{
+		Logger:               logger,
+		ClickHouse:           clickHouseClient,
+		Database:             conf.Aggregation.ClickHouse.Database,
+		Meters:               meterRepository,
+		CreateOrReplaceMeter: conf.Aggregation.CreateOrReplaceMeter,
+		PopulateMeter:        conf.Aggregation.PopulateMeter,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("init clickhouse streaming: %w", err)
+	}
+
+	// event publishing
+	eventPublisherDriver, err := watermillkafka.NewPublisher(ctx, watermillkafka.PublisherOptions{
+		Broker: watermillkafka.BrokerOptions{
+			KafkaConfig:  conf.Ingest.Kafka.KafkaConfiguration,
+			ClientID:     otelName,
+			Logger:       logger,
+			MetricMeter:  metricMeter,
+			DebugLogging: conf.Telemetry.Log.Level == slog.LevelDebug,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize event publisher driver: %w", err)
+	}
+
+	eventPublisher, err := eventbus.New(eventbus.Options{
+		Publisher:              eventPublisherDriver,
+		Config:                 conf.Events,
+		Logger:                 logger,
+		MarshalerTransformFunc: watermillkafka.AddPartitionKeyFromSubject,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize event publisher: %w", err)
+	}
+
+	entitlementRegistry := registrybuilder.GetEntitlementRegistry(registry.EntitlementOptions{
+		DatabaseClient:     dbClient,
+		StreamingConnector: streamingConnector,
+		MeterRepository:    meterRepository,
+		Logger:             logger,
+		Publisher:          eventPublisher,
+	})
+
+	return &entitlementConnectors{
+		Registry: entitlementRegistry,
+		EventBus: eventPublisher,
+		Shutdown: func() {
+			if err := dbClient.Close(); err != nil {
+				logger.Error("failed to close entitlement db client", "error", err)
+			}
+
+			if err := clickHouseClient.Close(); err != nil {
+				logger.Error("failed to close clickhouse client", "error", err)
+			}
+
+			if err := eventPublisherDriver.Close(); err != nil {
+				logger.Error("failed to close event publisher", "error", err)
+			}
+		},
+	}, nil
+}

--- a/cmd/jobs/entitlement/recalculatesnapshots.go
+++ b/cmd/jobs/entitlement/recalculatesnapshots.go
@@ -1,0 +1,54 @@
+package entitlement
+
+import (
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"go.opentelemetry.io/otel"
+
+	"github.com/openmeterio/openmeter/cmd/jobs/config"
+	"github.com/openmeterio/openmeter/internal/entitlement/balanceworker"
+)
+
+const (
+	otelNameRecalculateBalanceSnapshot = "openmeter.io/jobs/entitlement/recalculate-balance-snapshots"
+)
+
+func NewRecalculateBalanceSnapshotsCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "recalculate-balance-snapshots",
+		Short: "Recalculate balance snapshots and send the resulting events into the eventbus",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conf, err := config.GetConfig()
+			if err != nil {
+				return err
+			}
+
+			logger := slog.Default()
+
+			entitlementConnectors, err := initEntitlements(
+				cmd.Context(),
+				conf,
+				logger,
+				otel.GetMeterProvider().Meter(otelNameRecalculateBalanceSnapshot),
+				otelNameRecalculateBalanceSnapshot,
+			)
+			if err != nil {
+				return err
+			}
+
+			defer entitlementConnectors.Shutdown()
+
+			recalculator, err := balanceworker.NewRecalculator(balanceworker.RecalculatorOptions{
+				Entitlement: entitlementConnectors.Registry,
+				Namespace:   "default",
+				EventBus:    entitlementConnectors.EventBus,
+			})
+			if err != nil {
+				return err
+			}
+
+			return recalculator.Recalculate(cmd.Context())
+		},
+	}
+}

--- a/cmd/jobs/entitlement/root.go
+++ b/cmd/jobs/entitlement/root.go
@@ -1,0 +1,14 @@
+package entitlement
+
+import "github.com/spf13/cobra"
+
+func RootCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "entitlement",
+		Short: "Entitlement related jobs",
+	}
+
+	cmd.AddCommand(NewRecalculateBalanceSnapshotsCommand())
+
+	return cmd
+}

--- a/cmd/jobs/main.go
+++ b/cmd/jobs/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/openmeterio/openmeter/cmd/jobs/config"
+	"github.com/openmeterio/openmeter/cmd/jobs/entitlement"
+	"github.com/openmeterio/openmeter/cmd/jobs/service"
+)
+
+const (
+	otelName = "openmeter.io/jobs"
+)
+
+func main() {
+	var telemetry *service.Telemetry
+
+	defer func() {
+		if telemetry != nil && telemetry.Shutdown != nil {
+			telemetry.Shutdown()
+		}
+	}()
+
+	rootCmd := cobra.Command{
+		Use: "jobs",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			conf, err := config.LoadConfig(cmd.Flag("config").Value.String())
+			if err != nil {
+				return err
+			}
+
+			config.SetConfig(conf)
+
+			telemetry, err = service.NewTelemetry(cmd.Context(), conf.Telemetry, conf.Environment, version, otelName)
+			return err
+		},
+	}
+
+	var configFileName string
+
+	rootCmd.PersistentFlags().StringVarP(&configFileName, "config", "", "config.yaml", "config file (default is config.yaml)")
+	_ = viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
+
+	rootCmd.AddCommand(versionCommand())
+	rootCmd.AddCommand(entitlement.RootCommand())
+
+	if err := rootCmd.Execute(); err != nil {
+		slog.Default().Error("failed to execute command", "error", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/jobs/service/otel.go
+++ b/cmd/jobs/service/otel.go
@@ -1,0 +1,97 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/go-slog/otelslog"
+	slogmulti "github.com/samber/slog-multi"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+
+	"github.com/openmeterio/openmeter/config"
+	"github.com/openmeterio/openmeter/pkg/contextx"
+	"github.com/openmeterio/openmeter/pkg/framework/operation"
+)
+
+const (
+	defaultShutdownTimeout = 5 * time.Second
+)
+
+type Telemetry struct {
+	Logger      *slog.Logger
+	MetricMeter metric.Meter
+	Shutdown    func()
+}
+
+func NewTelemetry(ctx context.Context, conf config.TelemetryConfig, env string, version string, otelName string) (*Telemetry, error) {
+	extraResources, _ := resource.New(
+		context.Background(),
+		resource.WithContainer(),
+		resource.WithAttributes(
+			semconv.ServiceName("openmeter"),
+			semconv.ServiceVersion(version),
+			semconv.DeploymentEnvironment(env),
+		),
+	)
+	res, _ := resource.Merge(
+		resource.Default(),
+		extraResources,
+	)
+
+	logger := slog.New(slogmulti.Pipe(
+		otelslog.NewHandler,
+		contextx.NewLogHandler,
+		operation.NewLogHandler,
+	).Handler(conf.Log.NewHandler(os.Stdout)))
+	logger = otelslog.WithResource(logger, res)
+
+	slog.SetDefault(logger)
+
+	// Initialize OTel Metrics
+	otelMeterProvider, err := conf.Metrics.NewMeterProvider(ctx, res)
+	if err != nil {
+		logger.Error("failed to initialize OpenTelemetry Metrics provider", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+	defer func() {
+		// Use dedicated context with timeout for shutdown as parent context might be canceled
+		// by the time the execution reaches this stage.
+	}()
+	otel.SetMeterProvider(otelMeterProvider)
+	metricMeter := otelMeterProvider.Meter(otelName)
+
+	// Initialize OTel Tracer
+	otelTracerProvider, err := conf.Trace.NewTracerProvider(ctx, res)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize OpenTelemetry Trace provider: %w", err)
+	}
+
+	otel.SetTracerProvider(otelTracerProvider)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	return &Telemetry{
+		Logger:      logger,
+		MetricMeter: metricMeter,
+		Shutdown: func() {
+			// Use dedicated context with timeout for shutdown as parent context might be canceled
+			// by the time the execution reaches this stage.
+			ctx, cancel := context.WithTimeout(context.Background(), defaultShutdownTimeout)
+			defer cancel()
+
+			if err := otelMeterProvider.Shutdown(ctx); err != nil {
+				logger.Error("shutting down meter provider", slog.String("error", err.Error()))
+			}
+
+			if err := otelTracerProvider.Shutdown(ctx); err != nil {
+				logger.Error("shutting down tracer provider", slog.String("error", err.Error()))
+			}
+		},
+	}, nil
+}

--- a/cmd/jobs/version.go
+++ b/cmd/jobs/version.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+// Provisioned by ldflags.
+var version string
+
+//nolint:gochecknoglobals
+var (
+	revision     string
+	revisionDate string
+)
+
+//nolint:gochecknoinits,goconst
+func init() {
+	if version == "" {
+		version = "unknown"
+	}
+
+	buildInfo, _ := debug.ReadBuildInfo()
+
+	revision = "unknown"
+	revisionDate = "unknown"
+
+	for _, setting := range buildInfo.Settings {
+		if setting.Key == "vcs.revision" {
+			revision = setting.Value
+		}
+
+		if setting.Key == "vcs.time" {
+			revisionDate = setting.Value
+		}
+	}
+}
+
+func versionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the version",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Printf("%s version %s (%s) built on %s\n", "Open Meter", version, revision, revisionDate)
+		},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/sagikazarmark/slog-shim v0.1.0
 	github.com/samber/lo v1.46.0
 	github.com/samber/slog-multi v1.2.0
+	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.20.0-alpha.6
 	github.com/stretchr/testify v1.9.0
@@ -175,7 +176,7 @@ require (
 	github.com/couchbase/gocbcoreps v0.1.2 // indirect
 	github.com/couchbase/goprotostellar v1.0.2 // indirect
 	github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/denisenkom/go-mssqldb v0.12.3 // indirect
@@ -248,6 +249,7 @@ require (
 	github.com/hashicorp/raft v1.7.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/influxdata/go-syslog/v3 v3.0.0 // indirect
 	github.com/influxdata/influxdb1-client v0.0.0-20220302092344-a9ab5670611c // indirect
 	github.com/invopop/yaml v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -389,8 +389,8 @@ github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131 h1:2E
 github.com/couchbaselabs/gocbconnstr/v2 v2.0.0-20230515165046-68b522a21131/go.mod h1:o7T431UOfFVHDNvMBUmUxpHnhivwv7BziUao/nMl81E=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
-github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
-github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danieljoos/wincred v1.2.0 h1:ozqKHaLK0W/ii4KVbbvluM91W2H3Sh0BncbUNPS7jLE=

--- a/internal/entitlement/adapter/entitlement.go
+++ b/internal/entitlement/adapter/entitlement.go
@@ -251,6 +251,10 @@ func (a *entitlementDBAdapter) ListEntitlements(ctx context.Context, params enti
 		query = query.Where(db_entitlement.Or(db_entitlement.DeletedAtGT(clock.Now()), db_entitlement.DeletedAtIsNil()))
 	}
 
+	if !params.IncludeDeletedAfter.IsZero() {
+		query = query.Where(db_entitlement.Or(db_entitlement.DeletedAtGT(params.IncludeDeletedAfter), db_entitlement.DeletedAtIsNil()))
+	}
+
 	if params.OrderBy != "" {
 		order := []sql.OrderTermOption{}
 		if !params.Order.IsDefaultValue() {

--- a/internal/entitlement/balanceworker/recalculate.go
+++ b/internal/entitlement/balanceworker/recalculate.go
@@ -1,0 +1,208 @@
+package balanceworker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/openmeterio/openmeter/internal/entitlement"
+	entitlementdriver "github.com/openmeterio/openmeter/internal/entitlement/driver"
+	"github.com/openmeterio/openmeter/internal/entitlement/snapshot"
+	"github.com/openmeterio/openmeter/internal/event/metadata"
+	"github.com/openmeterio/openmeter/internal/event/models"
+	"github.com/openmeterio/openmeter/internal/productcatalog"
+	"github.com/openmeterio/openmeter/internal/registry"
+	"github.com/openmeterio/openmeter/internal/watermill/eventbus"
+	"github.com/openmeterio/openmeter/openmeter/watermill/marshaler"
+	"github.com/openmeterio/openmeter/pkg/convert"
+)
+
+const (
+	// defaultIncludeDeletedDuration is the default duration for which deleted entitlements are included in recalculation.
+	// This ensures that the recent deleted snapshot events are also resent.
+	defaultIncludeDeletedDuration = 24 * time.Hour
+
+	defaultLRUCacheSize = 10_000
+)
+
+type RecalculatorOptions struct {
+	Entitlement       *registry.Entitlement
+	Namespace         string
+	SubjectIDResolver SubjectIDResolver
+	EventBus          eventbus.Publisher
+}
+
+type Recalculator struct {
+	opts RecalculatorOptions
+
+	featureCache   *lru.Cache[string, productcatalog.Feature]
+	subjectIDCache *lru.Cache[string, string]
+}
+
+func NewRecalculator(opts RecalculatorOptions) (*Recalculator, error) {
+	featureCache, err := lru.New[string, productcatalog.Feature](defaultLRUCacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create feature cache: %w", err)
+	}
+
+	subjectIDCache, err := lru.New[string, string](defaultLRUCacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create subject ID cache: %w", err)
+	}
+
+	return &Recalculator{
+		opts:           opts,
+		featureCache:   featureCache,
+		subjectIDCache: subjectIDCache,
+	}, nil
+}
+
+func (r *Recalculator) Recalculate(ctx context.Context) error {
+	affectedEntitlements, err := r.opts.Entitlement.EntitlementRepo.ListEntitlements(
+		ctx,
+		entitlement.ListEntitlementsParams{
+			Namespaces:          []string{r.opts.Namespace},
+			IncludeDeleted:      true,
+			IncludeDeletedAfter: time.Now().Add(-defaultIncludeDeletedDuration),
+		})
+	if err != nil {
+		return err
+	}
+
+	return r.processEntitlements(ctx, affectedEntitlements.Items)
+}
+
+func (r *Recalculator) processEntitlements(ctx context.Context, entitlements []entitlement.Entitlement) error {
+	var errs error
+	for _, ent := range entitlements {
+		if ent.DeletedAt != nil {
+			err := r.sendEntitlementDeletedEvent(ctx, ent)
+			if err != nil {
+				errs = errors.Join(errs, err)
+			}
+		} else {
+			err := r.sendEntitlementUpdatedEvent(ctx, ent)
+			if err != nil {
+				errs = errors.Join(errs, err)
+			}
+		}
+	}
+
+	return errs
+}
+
+func (r *Recalculator) sendEntitlementDeletedEvent(ctx context.Context, ent entitlement.Entitlement) error {
+	subjectID, err := r.getSubjectIDByKey(ctx, r.opts.Namespace, ent.SubjectKey)
+	if err != nil {
+		return err
+	}
+
+	feature, err := r.getFeature(ctx, ent.Namespace, ent.FeatureID)
+	if err != nil {
+		return err
+	}
+
+	event := marshaler.WithSource(
+		metadata.ComposeResourcePath(ent.Namespace, metadata.EntityEntitlement, ent.ID),
+		snapshot.SnapshotEvent{
+			Entitlement: ent,
+			Namespace: models.NamespaceID{
+				ID: ent.Namespace,
+			},
+			Subject: models.SubjectKeyAndID{
+				Key: ent.SubjectKey,
+				ID:  subjectID,
+			},
+			Feature:   feature,
+			Operation: snapshot.ValueOperationDelete,
+
+			CalculatedAt: convert.ToPointer(time.Now().Add(-defaultClockDrift)),
+
+			CurrentUsagePeriod: ent.CurrentUsagePeriod,
+		},
+	)
+
+	return r.opts.EventBus.Publish(ctx, event)
+}
+
+func (r *Recalculator) sendEntitlementUpdatedEvent(ctx context.Context, ent entitlement.Entitlement) error {
+	subjectID, err := r.getSubjectIDByKey(ctx, r.opts.Namespace, ent.SubjectKey)
+	if err != nil {
+		return err
+	}
+
+	feature, err := r.getFeature(ctx, ent.Namespace, ent.FeatureID)
+	if err != nil {
+		return err
+	}
+
+	calculatedAt := time.Now()
+
+	value, err := r.opts.Entitlement.Entitlement.GetEntitlementValue(ctx, ent.Namespace, ent.SubjectKey, ent.ID, calculatedAt)
+	if err != nil {
+		return fmt.Errorf("failed to get entitlement value: %w", err)
+	}
+
+	mappedValues, err := entitlementdriver.MapEntitlementValueToAPI(value)
+	if err != nil {
+		return fmt.Errorf("failed to map entitlement value: %w", err)
+	}
+
+	event := marshaler.WithSource(
+		metadata.ComposeResourcePath(ent.Namespace, metadata.EntityEntitlement, ent.ID),
+		snapshot.SnapshotEvent{
+			Entitlement: ent,
+			Namespace: models.NamespaceID{
+				ID: ent.Namespace,
+			},
+			Subject: models.SubjectKeyAndID{
+				Key: ent.SubjectKey,
+				ID:  subjectID,
+			},
+			Feature:   feature,
+			Operation: snapshot.ValueOperationUpdate,
+
+			CalculatedAt: &calculatedAt,
+
+			Value:              convert.ToPointer((snapshot.EntitlementValue)(mappedValues)),
+			CurrentUsagePeriod: ent.CurrentUsagePeriod,
+		},
+	)
+
+	return r.opts.EventBus.Publish(ctx, event)
+}
+
+func (r *Recalculator) getSubjectIDByKey(ctx context.Context, ns, key string) (string, error) {
+	if r.opts.SubjectIDResolver == nil {
+		return "", nil
+	}
+
+	if id, ok := r.subjectIDCache.Get(key); ok {
+		return id, nil
+	}
+
+	id, err := r.opts.SubjectIDResolver.GetSubjectIDByKey(ctx, ns, key)
+	if err != nil {
+		return "", err
+	}
+
+	r.subjectIDCache.Add(key, id)
+	return id, nil
+}
+
+func (r *Recalculator) getFeature(ctx context.Context, ns, id string) (productcatalog.Feature, error) {
+	if feature, ok := r.featureCache.Get(id); ok {
+		return feature, nil
+	}
+
+	feature, err := r.opts.Entitlement.Feature.GetFeature(ctx, ns, id, productcatalog.IncludeArchivedFeatureTrue)
+	if err != nil {
+		return productcatalog.Feature{}, err
+	}
+
+	r.featureCache.Add(id, *feature)
+	return *feature, nil
+}

--- a/internal/entitlement/balanceworker/recalculate.go
+++ b/internal/entitlement/balanceworker/recalculate.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	// defaultIncludeDeletedDuration is the default duration for which deleted entitlements are included in recalculation.
+	// DefaultIncludeDeletedDuration is the default duration for which deleted entitlements are included in recalculation.
 	// This ensures that the recent deleted snapshot events are also resent.
-	defaultIncludeDeletedDuration = 24 * time.Hour
+	DefaultIncludeDeletedDuration = 24 * time.Hour
 
 	defaultLRUCacheSize = 10_000
 )
@@ -66,7 +66,7 @@ func (r *Recalculator) Recalculate(ctx context.Context) error {
 		entitlement.ListEntitlementsParams{
 			Namespaces:          []string{r.opts.Namespace},
 			IncludeDeleted:      true,
-			IncludeDeletedAfter: time.Now().Add(-defaultIncludeDeletedDuration),
+			IncludeDeletedAfter: time.Now().Add(-DefaultIncludeDeletedDuration),
 		})
 	if err != nil {
 		return err

--- a/internal/entitlement/connector.go
+++ b/internal/entitlement/connector.go
@@ -37,16 +37,17 @@ func (o ListEntitlementsOrderBy) StrValues() []string {
 }
 
 type ListEntitlementsParams struct {
-	Namespaces       []string
-	SubjectKeys      []string
-	FeatureIDs       []string
-	FeatureKeys      []string
-	FeatureIDsOrKeys []string
-	EntitlementTypes []EntitlementType
-	OrderBy          ListEntitlementsOrderBy
-	Order            sortx.Order
-	IncludeDeleted   bool
-	Page             pagination.Page
+	Namespaces          []string
+	SubjectKeys         []string
+	FeatureIDs          []string
+	FeatureKeys         []string
+	FeatureIDsOrKeys    []string
+	EntitlementTypes    []EntitlementType
+	OrderBy             ListEntitlementsOrderBy
+	Order               sortx.Order
+	IncludeDeleted      bool
+	IncludeDeletedAfter time.Time
+	Page                pagination.Page
 	// will be deprecated
 	Limit int
 	// will be deprecated

--- a/internal/entitlement/repository.go
+++ b/internal/entitlement/repository.go
@@ -24,6 +24,7 @@ type EntitlementRepo interface {
 	DeleteEntitlement(ctx context.Context, entitlementID models.NamespacedID) error
 
 	ListEntitlements(ctx context.Context, params ListEntitlementsParams) (pagination.PagedResponse[Entitlement], error)
+	ListNamespacesWithActiveEntitlements(ctx context.Context, includeDeletedAfter time.Time) ([]string, error)
 
 	HasEntitlementForMeter(ctx context.Context, namespace string, meterSlug string) (bool, error)
 

--- a/openmeter/entitlement/balanceworker/worker.go
+++ b/openmeter/entitlement/balanceworker/worker.go
@@ -18,6 +18,10 @@ type (
 	RecalculatorOptions = balanceworker.RecalculatorOptions
 )
 
+const (
+	DefaultIncludeDeletedDuration = balanceworker.DefaultIncludeDeletedDuration
+)
+
 func NewRecalculator(opts RecalculatorOptions) (*Recalculator, error) {
 	return balanceworker.NewRecalculator(opts)
 }

--- a/openmeter/entitlement/balanceworker/worker.go
+++ b/openmeter/entitlement/balanceworker/worker.go
@@ -12,3 +12,12 @@ type (
 func New(opts WorkerOptions) (*Worker, error) {
 	return balanceworker.New(opts)
 }
+
+type (
+	Recalculator        = balanceworker.Recalculator
+	RecalculatorOptions = balanceworker.RecalculatorOptions
+)
+
+func NewRecalculator(opts RecalculatorOptions) (*Recalculator, error) {
+	return balanceworker.NewRecalculator(opts)
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This job can be used to trigger a recalculation of all the entitlement snapshots if needed.

## Notes for reviewer

The usage of cobra is because we will need additional jobs, such as the entitlement autoreset job, which we are planning to implement in openmeter using kubernetes cron jobs for now.