### PR TITLE
Fail e2e tests for event ingest timeouts

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -472,7 +472,7 @@ func TestCredit(t *testing.T) {
 	var featureId *api.FeatureId
 	var featureKey string
 
-	const waitTime = time.Second * 10
+	const waitTime = time.Second * 30
 
 	t.Run("Create Feature", func(t *testing.T) {
 		randKey := ulid.Make().String()
@@ -732,7 +732,7 @@ func TestCredit(t *testing.T) {
 			require.Equal(t, http.StatusNoContent, resp.StatusCode())
 		}
 
-		// Wait for events to be processed
+		// Wait for events to be processed, fail on network errors
 		testutils.EventuallyWithTf(t, func(c *assert.CollectT, saveErr func(err any)) {
 			resp, err := client.QueryMeterWithResponse(context.Background(), meterSlug, &api.QueryMeterParams{
 				Subject: &[]string{subject},

--- a/internal/testutils/async.go
+++ b/internal/testutils/async.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func EventuallyWithTf(t *testing.T, fn func(c *assert.CollectT, saveErr func(err any)), wait time.Duration, interval time.Duration) {
@@ -19,7 +20,7 @@ func EventuallyWithTf(t *testing.T, fn func(c *assert.CollectT, saveErr func(err
 		return v[0]
 	}
 
-	assert.EventuallyWithTf(t, func(c *assert.CollectT) {
+	require.EventuallyWithTf(t, func(c *assert.CollectT) {
 		fn(c, saveErr)
 	}, wait, interval, "%w", firstVal(sm.Load(errKey)))
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

It's not clear why ingest takes so long in CI, 10 seconds is already way too long, especially as the sink config being used mandates flushes every second. There's no obvious sign of the sink worker failing to start in the logs, and of course this issue is not reproducible outside of CI
- changed the timeout to use require instead of assert so it subsequent tests wont run unless this precondition is met
- increased the maximum wait to 30s in lack of a better idea

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->


<!-- Anything the reviewer should know? -->
