### PR TITLE
Add CI checks in separate PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,8 @@ jobs:
       # Required as a workaround for Dagger to properly detect Git metadata
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0 # Needed to compare against base branch
 
       - name: Run pipeline
         uses: dagger/dagger-for-github@29a88e72255e732147ba18a670978b90bcc59efd # v6.4.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,40 @@ jobs:
             engine.stderr.log
           retention-days: 14
 
+  migrations:
+    name: Migration Checks
+    runs-on: depot-ubuntu-latest-8
+
+    steps:
+      # Required as a workaround for Dagger to properly detect Git metadata
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Run pipeline
+        uses: dagger/dagger-for-github@29a88e72255e732147ba18a670978b90bcc59efd # v6.4.0
+        with:
+          verb: call
+          module: github.com/${{ github.repository }}@${{ github.ref }}
+          args: --ref ${{ github.ref }} migrate check --baseRef ${{ github.base_ref || github.event.repository.default_branch }}
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+          version: ${{ env.DAGGER_VERSION }}
+
+      - name: Export Dagger Engine logs
+        id: export-dagger-engine-logs
+        run: docker logs $(docker container list --all --filter 'name=^dagger-engine-*' --format '{{.Names}}') > engine.stdout.log 2> engine.stderr.log
+        if: always()
+        continue-on-error: true
+
+      - name: Upload Dagger Engine logs as artifact
+        uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
+        if: always() && steps.export-dagger-engine-logs.outcome == 'success'
+        with:
+          name: "[${{ github.job }}] Dagger Engine logs"
+          path: |
+            engine.stdout.log
+            engine.stderr.log
+          retention-days: 14
+
   lint:
     name: Lint
     runs-on: depot-ubuntu-latest-8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
         with:
           verb: call
           module: github.com/${{ github.repository }}@${{ github.ref }}
-          args: --ref ${{ github.ref }} migrate check --baseRef ${{ github.base_ref || github.event.repository.default_branch }}
+          args: --ref ${{ github.ref }} migrate check
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           version: ${{ env.DAGGER_VERSION }}
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ gen-api: ## Generate API and SDKs
 	dagger call --source .:default generate web-sdk -o api/client/web
 	dagger call --source .:default generate python-sdk -o api/client/python
 
+.PHONY: migrate-check
+migrate-check: ## Validate migrations
+	$(call print-target)
+	dagger call --source .:default migrate check
+
 .PHONY: generate
 generate: ## Generate code
 	$(call print-target)

--- a/ci/e2e.go
+++ b/ci/e2e.go
@@ -83,6 +83,7 @@ func postgres() *dagger.Service {
 	return pg().AsService()
 }
 
+// Creates a postgres service unique by name
 func postgresNamed(name string) *dagger.Service {
 	return pg().WithLabel("uniq-name", name).AsService()
 }

--- a/ci/e2e.go
+++ b/ci/e2e.go
@@ -70,12 +70,19 @@ func redis() *dagger.Service {
 		AsService()
 }
 
-func postgres() *dagger.Service {
+func pg() *dagger.Container {
 	return dag.Container().
 		From(fmt.Sprintf("postgres:%s", postgresVersion)).
 		WithEnvVariable("POSTGRES_USER", "postgres").
 		WithEnvVariable("POSTGRES_PASSWORD", "postgres").
 		WithEnvVariable("POSTGRES_DB", "postgres").
-		WithExposedPort(5432).
-		AsService()
+		WithExposedPort(5432)
+}
+
+func postgres() *dagger.Service {
+	return pg().AsService()
+}
+
+func postgresNamed(name string) *dagger.Service {
+	return pg().WithLabel("uniq-name", name).AsService()
 }

--- a/ci/migrate.go
+++ b/ci/migrate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/openmeterio/openmeter/ci/internal/dagger"
 	"github.com/sourcegraph/conc/pool"
@@ -20,38 +21,78 @@ type Migrate struct {
 func (m *Migrate) Check(
 	ctx context.Context,
 ) error {
-	nix := nix(m.Source)
+	app := goModuleCross("").
+		WithSource(m.Source).
+		Container().
+		WithEnvVariable("GOFLAGS", "-tags=musl")
+
+	bin := dag.Container(dagger.ContainerOpts{
+		Platform: "linux/amd64",
+	}).From("arigaio/atlas:0.25.0").File("atlas")
+
+	atlas := app.
+		WithFile("/bin/atlas", bin).
+		WithDirectory("internal/ent", m.Source.Directory("internal/ent")).
+		WithDirectory("tools/migrate/migrations", m.Source.Directory("tools/migrate/migrations")).
+		WithFile("atlas.hcl", m.Source.File("atlas.hcl"))
+
 	p := pool.New().WithErrors().WithContext(ctx)
 
 	// Always validate schema is generated
-	p.Go(syncFunc(nix.
-		WithExec([]string{"sh", "-c", "nix develop --impure .#dagger -c go generate ./internal/ent/..."}).
-		WithExec([]string{"sh", "-c", "nix develop --impure .#dagger -c sh -c 'if [[ -n $(git status --porcelain ./internal/ent) ]]; then echo \"Ent schema wasnt generated\"; exit 1; fi' "}),
-	))
+	p.Go(func(ctx context.Context) error {
+		result := app.
+			WithExec([]string{"go", "generate", "-x", "-tags=musl", "-ldflags", "linkmode=external", "./internal/ent/..."}).
+			Directory("internal/ent")
+
+		source := m.Source.Directory("internal/ent")
+
+		err := diff(ctx, source, result)
+		if err != nil {
+			return fmt.Errorf("schema is not in sync with generated code")
+		}
+		return nil
+	})
+
 	// Always validate migrations are in sync with schema
-	p.Go(syncFunc(nix.
-		WithServiceBinding("postgres", postgresNamed("no-diff")).
-		WithExec([]string{"sh", "-c", "nix develop --impure .#dagger -c atlas migrate --env ci diff test"}).
-		WithExec([]string{"sh", "-c", "nix develop --impure .#dagger -c sh -c 'if [[ -n $(git status --porcelain ./tools/migrate/migrations) ]]; then echo \"Migrations directory is dirty\"; exit 1; fi' "}),
-	))
+	p.Go(func(ctx context.Context) error {
+		result := atlas.
+			WithServiceBinding("postgres", postgresNamed("no-diff")).
+			WithExec([]string{"atlas", "migrate", "--env", "ci", "diff", "test"}).
+			Directory("tools/migrate/migrations")
+
+		source := m.Source.Directory("tools/migrate/migrations")
+		err := diff(ctx, source, result)
+		if err != nil {
+			return fmt.Errorf("migrations are not in sync with schema")
+		}
+
+		return nil
+	})
+
 	// Always lint last 10 migrations
-	p.Go(syncFunc(nix.
-		WithServiceBinding("postgres", postgresNamed("last-10")).
-		WithExec([]string{"sh", "-c", "nix develop --impure .#dagger -c atlas migrate --env ci lint --latest 10"}),
+	p.Go(syncFunc(
+		atlas.
+			WithServiceBinding("postgres", postgresNamed("last-10")).
+			WithExec([]string{"atlas", "migrate", "--env", "ci", "lint", "--latest", "10"}),
 	))
+
 	// Validate checksum is intact
-	p.Go(syncFunc(nix.
-		WithServiceBinding("postgres", postgresNamed("validate")).
-		WithExec([]string{"sh", "-c", "nix develop --impure .#dagger -c atlas migrate --env ci validate"}),
+	p.Go(syncFunc(
+		atlas.
+			WithServiceBinding("postgres", postgresNamed("validate")).
+			WithExec([]string{"atlas", "migrate", "--env", "ci", "validate"}),
 	))
 
 	return p.Wait()
 }
 
-func nix(src *dagger.Directory) *dagger.Container {
-	return dag.Nix().SetupNix(dagger.NixSetupNixOpts{
-		Src: src,
-	}).
-		// Note: we have to use `sh -c` as otherwise devenv nix assertion fails: https://github.com/cachix/devenv/blob/b285601679c7686f623791ad93a8e0debc322633/src/modules/top-level.nix#L229
-		WithExec([]string{"sh", "-c", "nix develop --impure .#dagger"}) // Prepare environment
+func diff(ctx context.Context, d1, d2 *dagger.Directory) error {
+	_, err := dag.Container(dagger.ContainerOpts{Platform: ""}).
+		From(alpineBaseImage).
+		WithExec([]string{"apk", "add", "--update", "--no-cache", "ca-certificates", "tzdata", "bash"}).
+		WithDirectory("src", d1).
+		WithDirectory("res", d2).
+		WithExec([]string{"diff", "-u", "-r", "src", "res"}).
+		Sync(ctx)
+	return err
 }

--- a/ci/migrate.go
+++ b/ci/migrate.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/ci/internal/dagger"
+	"github.com/sourcegraph/conc/pool"
+)
+
+func (m *Ci) Migrate() *Migrate {
+	return &Migrate{
+		Source: m.Source,
+	}
+}
+
+type Migrate struct {
+	Source *dagger.Directory
+}
+
+func (m *Migrate) Check(
+	ctx context.Context,
+	// +optional
+	baseRef string,
+) error {
+	if baseRef == "" {
+		baseRef = "main"
+	}
+
+	nix := nix(m.Source)
+	p := pool.New().WithErrors().WithContext(ctx)
+
+	// Always validate migrations are in sync with schema
+	p.Go(syncFunc(nix.
+		WithServiceBinding("postgres", postgresNamed("no-diff")).
+		WithExec([]string{"sh", "-c", "nix develop --impure .#dagger -c atlas migrate --env ci diff test"}).
+		WithExec([]string{"sh", "-c", "if [[ -n $(git status --porcelain ./tools/migrate/migrations) ]]; then echo 'Migrations directory is dirty'; exit 1; fi"}),
+	))
+	// Always lint last 10 migrations
+	p.Go(syncFunc(nix.
+		WithServiceBinding("postgres", postgresNamed("last-10")).
+		WithExec([]string{"sh", "-c", "nix develop --impure .#dagger -c atlas migrate --env ci lint --latest 10"}),
+	))
+	// Always compare changes with base branch (main)
+	p.Go(syncFunc(nix.
+		WithServiceBinding("postgres", postgresNamed("basebranch")).
+		WithExec([]string{"sh", "-c", fmt.Sprintf("nix develop --impure .#dagger -c atlas migrate --env ci lint --git-base \"%s\"", baseRef)}),
+	))
+	// Validate checksum is intact
+	p.Go(syncFunc(nix.
+		WithServiceBinding("postgres", postgresNamed("validate")).
+		WithExec([]string{"sh", "-c", "nix develop --impure .#dagger -c atlas migrate --env ci validate"}),
+	))
+
+	return p.Wait()
+}
+
+func nix(src *dagger.Directory) *dagger.Container {
+	return dag.Nix().SetupNix(dagger.NixSetupNixOpts{
+		Src: src,
+	}).
+		// Note: we have to use `sh -c` as otherwise devenv nix assertion fails: https://github.com/cachix/devenv/blob/b285601679c7686f623791ad93a8e0debc322633/src/modules/top-level.nix#L229
+		WithExec([]string{"sh", "-c", "nix develop --impure .#dagger"}) // Prepare environment
+}

--- a/dagger.json
+++ b/dagger.json
@@ -11,10 +11,6 @@
   ],
   "dependencies": [
     {
-      "name": "kafka",
-      "source": "github.com/sagikazarmark/daggerverse/kafka@c964ee26f982c4db0282523cd06f75ecb7e1102f"
-    },
-    {
       "name": "archivist",
       "source": "github.com/sagikazarmark/daggerverse/archivist@8f444e2c2b8e8162cea76d702086034ed3edc4f1"
     },
@@ -41,6 +37,10 @@
     {
       "name": "helm-docs",
       "source": "github.com/sagikazarmark/daggerverse/helm-docs@8f444e2c2b8e8162cea76d702086034ed3edc4f1"
+    },
+    {
+      "name": "kafka",
+      "source": "github.com/sagikazarmark/daggerverse/kafka@c964ee26f982c4db0282523cd06f75ecb7e1102f"
     },
     {
       "name": "python",

--- a/dagger.json
+++ b/dagger.json
@@ -43,6 +43,10 @@
       "source": "github.com/sagikazarmark/daggerverse/kafka@c964ee26f982c4db0282523cd06f75ecb7e1102f"
     },
     {
+      "name": "nix",
+      "source": "github.com/tsirysndr/daggerverse/nix@631932b459d218e641dec8047085f0cc87cf5f1c"
+    },
+    {
       "name": "python",
       "source": "github.com/sagikazarmark/daggerverse/python@8f444e2c2b8e8162cea76d702086034ed3edc4f1"
     },

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
         inputs.devenv.flakeModule
       ];
 
-      systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
 
       perSystem = { config, self', inputs', pkgs, system, ... }: rec {
         _module.args.pkgs = import inputs.nixpkgs {
@@ -23,6 +23,7 @@
             (final: prev: {
               dagger = inputs'.dagger.packages.dagger;
               licensei = self'.packages.licensei;
+              atlasx = self'.packages.atlasx;
             })
           ];
         };
@@ -91,7 +92,7 @@
               # python
               poetry
 
-              self'.packages.atlasx
+              atlasx
 
               just
               semver-tool
@@ -142,25 +143,42 @@
             ];
           };
 
-          atlasx = pkgs.stdenv.mkDerivation rec {
-            pname = "atlasx";
-            version = "0.25.0";
-            src = pkgs.fetchurl {
-              # License: https://ariga.io/legal/atlas/eula/eula-20240804.pdf
-              url = "https://release.ariga.io/atlas/atlas-darwin-arm64-v${version}";
-              hash = "sha256-bYJtNDE13UhJWL4ALLKI0sHMZrDS//kFWzguGX63EAo=";
+          atlasx =
+            let
+              systemMappings = {
+                x86_64-linux = "linux-amd64";
+                x86_64-darwin = "darwin-amd64";
+                aarch64-darwin = "darwin-arm64";
+                aarch64-linux = "linux-arm64";
+              };
+              hashMappings = {
+                x86_64-linux = "sha256-6270kOQ0uqiv/ljHtAi41uCzb+bkf+99rnmsc87/n6w=";
+                x86_64-darwin = "sha256-KeOp6LeHIY59Y2DJVAhMcr9xyb3KItFqEs6y9+uA7rM=";
+                aarch64-darwin = "sha256-bYJtNDE13UhJWL4ALLKI0sHMZrDS//kFWzguGX63EAo=";
+                aarch64-linux = "sha256-pRLZo7bwFJ1Xxlw2Afi/tAT6HSEvQ/B83ZzHGzCKXT8=";
+              };
+            in
+            pkgs.stdenv.mkDerivation rec {
+              pname = "atlasx";
+              version = "0.25.0";
+
+              src = pkgs.fetchurl {
+                # License: https://ariga.io/legal/atlas/eula/eula-20240804.pdf
+                url = "https://release.ariga.io/atlas/atlas-${"${systemMappings."${system}" }"}-v${version}";
+                hash = hashMappings."${system}";
+              };
+
+              unpackPhase = ''
+                cp $src atlas
+              '';
+
+              installPhase = ''
+                mkdir -p $out/bin
+                cp atlas $out/bin/atlas
+                chmod +x $out/bin/atlas
+              '';
+
             };
-
-            unpackPhase = ''
-              cp $src atlas
-            '';
-
-            installPhase = ''
-              mkdir -p $out/bin
-              cp atlas $out/bin/atlas
-            '';
-
-          };
         };
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -117,14 +117,19 @@
             containers = pkgs.lib.mkForce { };
           };
 
-          ci = lib.mkMerge [
-            devenv.shells.default
-            {
-              packages = with pkgs; [
-                git
-              ] ++ devenv.shells.default.packages;
-            }
-          ];
+          ci = devenv.shells.default;
+
+          # Lighteweight target to use inside dagger
+          dagger = {
+            languages = {
+              go = devenv.shells.default.languages.go;
+            };
+            packages = with pkgs; [
+              gnumake
+              git
+              atlasx
+            ];
+          };
         };
 
         packages = {
@@ -171,7 +176,7 @@
 
               src = pkgs.fetchurl {
                 # License: https://ariga.io/legal/atlas/eula/eula-20240804.pdf
-                url = "https://release.ariga.io/atlas/atlas-${"${systemMappings."${system}" }"}-v${version}";
+                url = "https://release.ariga.io/atlas/atlas-${systemMappings."${system}"}-v${version}";
                 hash = hashMappings."${system}";
               };
 

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
 
       systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
 
-      perSystem = { config, self', inputs', pkgs, system, ... }: rec {
+      perSystem = { config, self', inputs', pkgs, lib, system, ... }: rec {
         _module.args.pkgs = import inputs.nixpkgs {
           inherit system;
 
@@ -117,7 +117,14 @@
             containers = pkgs.lib.mkForce { };
           };
 
-          ci = devenv.shells.default;
+          ci = lib.mkMerge [
+            devenv.shells.default
+            {
+              packages = with pkgs; [
+                git
+              ] ++ devenv.shells.default.packages;
+            }
+          ];
         };
 
         packages = {

--- a/flake.nix
+++ b/flake.nix
@@ -129,6 +129,7 @@
               git
               atlasx
             ];
+            containers = devenv.shells.default.containers;
           };
         };
 

--- a/tools/migrate/migrate.go
+++ b/tools/migrate/migrate.go
@@ -18,7 +18,7 @@ const (
 type Migrate = migrate.Migrate
 
 //go:embed migrations
-var omMigrations embed.FS
+var OMMigrations embed.FS
 
 // NewMigrate creates a new migrate instance.
 func NewMigrate(conn string, fs fs.FS, fsPath string) (*Migrate, error) {
@@ -34,7 +34,7 @@ func Up(conn string) error {
 	if err != nil {
 		return err
 	}
-	m, err := NewMigrate(conn, omMigrations, "migrations")
+	m, err := NewMigrate(conn, OMMigrations, "migrations")
 	if err != nil {
 		return err
 	}

--- a/tools/migrate/migrate_test.go
+++ b/tools/migrate/migrate_test.go
@@ -1,0 +1,38 @@
+package migrate_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/openmeterio/openmeter/internal/testutils"
+	"github.com/openmeterio/openmeter/tools/migrate"
+)
+
+func TestUpDownUp(t *testing.T) {
+	testDB := testutils.InitPostgresDB(t)
+
+	migrator, err := migrate.NewMigrate(testDB.URL, migrate.OMMigrations, "migrations")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err1, err2 := migrator.Close()
+		err := errors.Join(err1, err2)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	if err := migrator.Up(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := migrator.Down(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := migrator.Up(); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

### Adds checks to validate the integrity of migrations:
1. Simple up-down-up on empty database (part of `go test ...`)
2. Validates that ent schema was generated (`internal/ent/db` in sync with `internal/ent/schema`)
3. Validates that migrations directory is in sync with schema (no diff)
4. Runs `atlas lint` for last 10 migration files checking for migrations being non-destructive and linear (10 is arbitrary)
5. Validates atlas checksum integrity (migration files weren't compromised)

The checks can also be run locally via `make migrate-check`

### Fixes the atlas nix derivation to use platform specific version
Note: it's templated locally, not the ideal solution but I have some skill issues with nix

## Follow Up Items
- We should test that migrations work not just up-down-up but with a base of the latest release

## Notes for reviewer
The checks are implemented in dagger, and for dependency management a nix-in-dagger solution was used. This is somewhat questionable, the 2 main drawbacks are:
- doesn't really fit in the conceptual paradigm of dagger
- nix core + devenv deps have to be pulled no matter how lightweight the environment is otherwise

(this latter is decently mitigated by caching but still)

The benefit form my point of view is that it's an exact replica the local environment by using the same derivation(s)

