### PR TITLE
fix: strip monotonic clock reading from time returned by clock

### DIFF
--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -5,7 +5,8 @@ import "time"
 var drift time.Duration
 
 func Now() time.Time {
-	return time.Now().Add(-drift)
+	t := time.Now().Add(-drift)
+	return t.Round(0) // Remove monotonic time reading
 }
 
 func SetTime(t time.Time) time.Time {


### PR DESCRIPTION
## Overview

Remove monotonic time reading from `time.Time` returned by `clock.Now()`.

## Notes for reviewer

This change help with comparing `time.Time` objects where one of them are generated by `clock.Now()` by forcing Go to use only the wall clock time for comparing them.
