### PR TITLE
feat: add webhook provider to Notification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.20.0-alpha.6
 	github.com/stretchr/testify v1.9.0
+	github.com/svix/svix-webhooks v1.29.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
 	go.opentelemetry.io/otel v1.28.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.28.0
@@ -69,6 +70,7 @@ require (
 	google.golang.org/protobuf v1.34.2
 	k8s.io/apimachinery v0.30.3
 	k8s.io/client-go v0.30.3
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.18.4
 )
 
@@ -408,7 +410,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	lukechampine.com/uint128 v1.3.0 // indirect
 	modernc.org/cc/v3 v3.40.0 // indirect
 	modernc.org/ccgo/v3 v3.16.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1238,6 +1238,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/svix/svix-webhooks v1.29.0 h1:+uB/mo2gOu3qhm6kONNGFczWAOaYBuveCeBuGYU213c=
+github.com/svix/svix-webhooks v1.29.0/go.mod h1:CteUj578U/Mmem33Hda4lhzQ6mIs8pwmgj3f9NAG7vQ=
 github.com/testcontainers/testcontainers-go v0.32.0 h1:ug1aK08L3gCHdhknlTTwWjPHPS+/alvLJU/DRxTD/ME=
 github.com/testcontainers/testcontainers-go v0.32.0/go.mod h1:CRHrzHLQhlXUsa5gXjTOfqIEJcrK5+xMDmBr/WMI88E=
 github.com/testcontainers/testcontainers-go/modules/compose v0.31.0 h1:H74o3HisnApIDQx7sWibGzOl/Oo0By8DjyVeUf3qd6I=

--- a/internal/notification/webhook/events.go
+++ b/internal/notification/webhook/events.go
@@ -1,0 +1,23 @@
+package webhook
+
+import (
+	_ "embed"
+)
+
+const (
+	EntitlementsEventGroupName              = "entitlements"
+	EntitlementsBalanceThresholdType        = "entitlements.balance.threshold"
+	EntitlementsBalanceThresholdDescription = "Notification event for entitlements balance threshold violations"
+)
+
+var NotificationEventTypes = []EventType{
+	EntitlementsBalanceThresholdEventType,
+}
+
+var EntitlementsBalanceThresholdEventType = EventType{
+	Name:        EntitlementsBalanceThresholdType,
+	Description: EntitlementsBalanceThresholdDescription,
+	GroupName:   EntitlementsEventGroupName,
+}
+
+// TODO(chrisgacsal): add JSON Schema for entitlements.balance.threshold event type

--- a/internal/notification/webhook/secret.go
+++ b/internal/notification/webhook/secret.go
@@ -1,0 +1,22 @@
+package webhook
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+)
+
+const DefaultSigningSecretSize = 32
+
+func NewSigningSecret(size int) (string, error) {
+	b := make([]byte, size)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+
+	return "whsec_" + base64.StdEncoding.EncodeToString(b), nil
+}
+
+func NewSigningSecretWithDefaultSize() (string, error) {
+	return NewSigningSecret(DefaultSigningSecretSize)
+}

--- a/internal/notification/webhook/svix.go
+++ b/internal/notification/webhook/svix.go
@@ -1,0 +1,595 @@
+package webhook
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	svix "github.com/svix/svix-webhooks/go"
+	"k8s.io/utils/strings/slices"
+
+	"github.com/openmeterio/openmeter/pkg/convert"
+	"github.com/openmeterio/openmeter/pkg/defaultx"
+)
+
+const (
+	// NullChannel is an internal channel type which should receive no messages at any time.
+	// Channels and EventTypes are used as message filters in Svix
+	// which means that a webhook without any filtering will receive all messages
+	// sent to the application the webhook belongs to. In order to prevent this we
+	// use the NoMessageChannel as a dummy filter, so it is possible to set up webhook endpoint
+	// prior knowing what type of messages are going to be routed to it.
+	NullChannel = "__null_channel"
+)
+
+type SvixConfig struct {
+	APIToken string
+
+	ServerURL string
+	Debug     bool
+}
+
+func (c SvixConfig) Validate() error {
+	if c.APIToken == "" {
+		return errors.New("no API token provided")
+	}
+
+	if c.ServerURL != "" {
+		if _, err := url.Parse(c.ServerURL); err != nil {
+			return fmt.Errorf("invalid server URL: %w", err)
+		}
+	}
+
+	return nil
+}
+
+var _ Handler = (*svixWebhookHandler)(nil)
+
+type svixWebhookHandler struct {
+	client *svix.Svix
+}
+
+func newSvixWebhookHandler(config SvixConfig) (Handler, error) {
+	opts := svix.SvixOptions{
+		Debug: config.Debug,
+	}
+
+	var err error
+	if config.ServerURL != "" {
+		opts.ServerUrl, err = url.Parse(config.ServerURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse server URL: %w", err)
+		}
+	}
+
+	return &svixWebhookHandler{
+		client: svix.New(config.APIToken, &opts),
+	}, nil
+}
+
+func (h svixWebhookHandler) RegisterEventTypes(ctx context.Context, params RegisterEventTypesInputs) error {
+	for _, evenType := range params.EvenTypes {
+		input := &svix.EventTypeUpdate{
+			Description: evenType.Description,
+			FeatureFlag: *svix.NullableString(nil),
+			GroupName:   *svix.NullableString(&evenType.GroupName),
+			Schemas:     evenType.Schemas,
+		}
+
+		_, err := h.client.EventType.Update(ctx, evenType.Name, input)
+		if err != nil {
+			return fmt.Errorf("failed to create event type: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (h svixWebhookHandler) CreateApplication(ctx context.Context, id string) (*svix.ApplicationOut, error) {
+	input := &svix.ApplicationIn{
+		Name: id,
+		Uid:  *svix.NullableString(&id),
+	}
+
+	idempotencyKey, err := toIdempotencyKey(input, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate idempotency key: %w", err)
+	}
+
+	app, err := h.client.Application.GetOrCreateWithOptions(ctx, input, &svix.PostOptions{
+		IdempotencyKey: &idempotencyKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get or create Svix application: %w", err)
+	}
+
+	return app, nil
+}
+
+func (h svixWebhookHandler) GetOrUpdateEndpointHeaders(ctx context.Context, appID, endpointID string, headers map[string]string) (map[string]string, error) {
+	var resp map[string]string
+
+	if len(headers) > 0 {
+		input := &svix.EndpointHeadersIn{
+			Headers: headers,
+		}
+
+		err := h.client.Endpoint.UpdateHeaders(ctx, appID, endpointID, input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set custom headers for Svix endpoint: %w", err)
+		}
+
+		resp = headers
+	} else {
+		out, err := h.client.Endpoint.GetHeaders(ctx, appID, endpointID)
+		if err != nil || out == nil {
+			return nil, fmt.Errorf("failed to get custom headers for Svix endpoint: %w", err)
+		}
+
+		if len(out.Headers) > 0 {
+			resp = out.Headers
+		}
+	}
+
+	return resp, nil
+}
+
+func (h svixWebhookHandler) GetOrUpdateEndpointSecret(ctx context.Context, appID, endpointID string, secret *string) (string, error) {
+	var resp string
+
+	secretOut, err := h.client.Endpoint.GetSecret(ctx, appID, endpointID)
+	if err != nil {
+		return resp, fmt.Errorf("failed to get Svix endpoint secret: %w", err)
+	}
+	if secretOut == nil {
+		return resp, fmt.Errorf("failed to get Svix endpoint secret: %w", err)
+	}
+
+	resp = secretOut.Key
+
+	if secret != nil && *secret != secretOut.Key {
+		input := &svix.EndpointSecretRotateIn{
+			Key: *svix.NullableString(secret),
+		}
+
+		idempotencyKey, err := toIdempotencyKey(input, time.Now())
+		if err != nil {
+			return resp, fmt.Errorf("failed to generate idempotency key: %w", err)
+		}
+
+		err = h.client.Endpoint.RotateSecretWithOptions(ctx, appID, endpointID, input, &svix.PostOptions{
+			IdempotencyKey: &idempotencyKey,
+		})
+		if err != nil {
+			return resp, fmt.Errorf("failed to update Svix endpoint secret: %w", err)
+		}
+
+		resp = *secret
+	}
+
+	return resp, nil
+}
+
+func (h svixWebhookHandler) CreateWebhook(ctx context.Context, params CreateWebhookInput) (*Webhook, error) {
+	if err := params.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate UpdateWebhookInputs: %w", err)
+	}
+
+	// Ensure that application is created for namespace
+
+	app, err := h.CreateApplication(ctx, params.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Svix webhook: %w", err)
+	}
+
+	// Create webhook endpoint in application.
+	//
+	// Channels and EventTypes are used as message filters in Svix
+	// which means that a webhook without any filtering will receive all messages
+	// sent to the application the webhook belongs to. In order to prevent this we
+	// use the NullFilterChannel as a dummy filter, so it is possible to set up webhook endpoint
+	// prior knowing what type of messages are going to be routed to it.
+
+	if len(params.EventTypes) == 0 && len(params.Channels) == 0 {
+		params.Channels = []string{
+			NullChannel,
+		}
+	}
+
+	if params.Secret == nil || *params.Secret == "" {
+		var secret string
+
+		secret, err = NewSigningSecretWithDefaultSize()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate signing secret: %w", err)
+		}
+
+		params.Secret = &secret
+	}
+
+	var endpointUID string
+	if params.ID != nil {
+		endpointUID = *params.ID
+	} else {
+		uid, err := ulid.New(ulid.Timestamp(time.Now()), rand.Reader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate ULID for webhook: %w", err)
+		}
+		endpointUID = uid.String()
+	}
+
+	input := &svix.EndpointIn{
+		Uid: *svix.NullableString(&endpointUID),
+		Description: convert.SafeDeRef(params.Description, func(p string) *string {
+			if p != "" {
+				return &p
+			}
+
+			return nil
+		}),
+		Url:         params.URL,
+		Disabled:    &params.Disabled,
+		RateLimit:   *svix.NullableInt32(params.RateLimit),
+		Secret:      *svix.NullableString(params.Secret),
+		FilterTypes: params.EventTypes,
+		Channels:    params.Channels,
+	}
+
+	idempotencyKey, err := toIdempotencyKey(input, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate idempotency key: %w", err)
+	}
+
+	endpoint, err := h.client.Endpoint.CreateWithOptions(ctx, app.Id, input, &svix.PostOptions{
+		IdempotencyKey: &idempotencyKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Svix endpoint: %w", err)
+	}
+
+	webhook := WebhookFromSvixEndpointOut(endpoint)
+	webhook.Namespace = params.Namespace
+
+	// Get signing secret for webhook endpoint.
+	// Skip fetching secret if it was provided in the request.
+
+	webhook.Secret, err = h.GetOrUpdateEndpointSecret(ctx, app.Id, endpoint.Id, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set custom HTTP headers for webhook endpoint if provided
+
+	if len(params.CustomHeaders) > 0 {
+		webhook.CustomHeaders, err = h.GetOrUpdateEndpointHeaders(ctx, app.Id, endpoint.Id, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return webhook, nil
+}
+
+func (h svixWebhookHandler) UpdateWebhook(ctx context.Context, params UpdateWebhookInput) (*Webhook, error) {
+	if err := params.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate UpdateWebhookInputs: %w", err)
+	}
+
+	// Ensure that application is created for namespace
+
+	app, err := h.CreateApplication(ctx, params.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Svix webhook: %w", err)
+	}
+
+	// Update webhook endpoint in application
+	//
+	// Channels and EventTypes are used as message filters in Svix
+	// which means that a webhook without any filtering will receive all messages
+	// sent to the application the webhook belongs to. In order to prevent this we
+	// use the NoMessageChannel as a dummy filter, so it is possible to set up webhook endpoint
+	// prior knowing what type of messages are going to be routed to it.
+
+	if len(params.EventTypes) == 0 && len(params.Channels) == 0 {
+		params.Channels = []string{
+			NullChannel,
+		}
+	}
+
+	input := &svix.EndpointUpdate{
+		Uid: *svix.NullableString(&params.ID),
+		Description: convert.SafeDeRef(params.Description, func(p string) *string {
+			if p != "" {
+				return &p
+			}
+
+			return nil
+		}),
+		Url:         params.URL,
+		Disabled:    &params.Disabled,
+		RateLimit:   *svix.NullableInt32(params.RateLimit),
+		FilterTypes: params.EventTypes,
+		Channels:    params.Channels,
+	}
+
+	endpoint, err := h.client.Endpoint.Update(ctx, app.Id, params.ID, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update Svix endpoint: %w", err)
+	}
+
+	webhook := WebhookFromSvixEndpointOut(endpoint)
+	webhook.Namespace = params.Namespace
+
+	// Update signing secret for webhook endpoint if provided
+
+	// Get signing secret for webhook endpoint.
+	// Skip fetching secret if it was provided in the request.
+
+	webhook.Secret, err = h.GetOrUpdateEndpointSecret(ctx, app.Id, endpoint.Id, params.Secret)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set custom HTTP headers for webhook endpoint if provided
+
+	if len(params.CustomHeaders) > 0 {
+		webhook.CustomHeaders, err = h.GetOrUpdateEndpointHeaders(ctx, app.Id, endpoint.Id, params.CustomHeaders)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return webhook, nil
+}
+
+func (h svixWebhookHandler) UpdateWebhookChannels(ctx context.Context, params UpdateWebhookChannelsInput) (*Webhook, error) {
+	webhook, err := h.GetWebhook(ctx, GetWebhookInput{
+		Namespace: params.Namespace,
+		ID:        params.ID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get webhook: %w", err)
+	}
+
+	channels := func(channels, add, remove []string) []string {
+		channelKeys := make(map[string]struct{})
+
+		for _, channel := range channels {
+			channelKeys[channel] = struct{}{}
+		}
+
+		for _, channel := range add {
+			channelKeys[channel] = struct{}{}
+		}
+
+		for _, channel := range remove {
+			delete(channelKeys, channel)
+		}
+
+		result := make([]string, 0, len(channels))
+		for channel := range channelKeys {
+			result = append(result, channel)
+		}
+
+		return result
+	}(webhook.Channels, params.AddChannels, params.RemoveChannels)
+
+	if len(channels) == 0 {
+		channels = []string{
+			NullChannel,
+		}
+	}
+
+	webhook, err = h.UpdateWebhook(ctx, UpdateWebhookInput{
+		Namespace:     webhook.Namespace,
+		ID:            webhook.ID,
+		URL:           webhook.URL,
+		CustomHeaders: webhook.CustomHeaders,
+		Disabled:      webhook.Disabled,
+		Secret:        &webhook.Secret,
+		RateLimit:     webhook.RateLimit,
+		Description:   &webhook.Description,
+		EventTypes:    webhook.EventTypes,
+		Channels:      channels,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to update webhook channels: %w", err)
+	}
+
+	return webhook, nil
+}
+
+func (h svixWebhookHandler) DeleteWebhook(ctx context.Context, params DeleteWebhookInput) error {
+	if err := params.Validate(); err != nil {
+		return fmt.Errorf("failed to validate DeleteWebhookInputs: %w", err)
+	}
+
+	err := h.client.Endpoint.Delete(ctx, params.Namespace, params.ID)
+	if err != nil {
+		return fmt.Errorf("failed to delete Svix endpoint: %w", err)
+	}
+
+	return nil
+}
+
+func (h svixWebhookHandler) GetWebhook(ctx context.Context, params GetWebhookInput) (*Webhook, error) {
+	if err := params.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate GetWebhookInputs: %w", err)
+	}
+
+	endpoint, err := h.client.Endpoint.Get(ctx, params.Namespace, params.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Svix endpoint: %w", err)
+	}
+
+	webhook := WebhookFromSvixEndpointOut(endpoint)
+	webhook.Namespace = params.Namespace
+
+	// Get signing secret for webhook endpoint.
+
+	webhook.Secret, err = h.GetOrUpdateEndpointSecret(ctx, params.Namespace, endpoint.Id, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get custom HTTP headers for webhook endpoint if provided
+
+	webhook.CustomHeaders, err = h.GetOrUpdateEndpointHeaders(ctx, params.Namespace, endpoint.Id, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return webhook, nil
+}
+
+func (h svixWebhookHandler) ListWebhooks(ctx context.Context, params ListWebhooksInput) ([]Webhook, error) {
+	listOut, err := h.client.Endpoint.List(ctx, params.Namespace, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Svix endpoints: %w", err)
+	}
+
+	filterFn := func(o svix.EndpointOut) bool {
+		if slices.Contains(params.IDs, o.Id) {
+			return true
+		}
+
+		if o.Uid.IsSet() && slices.Contains(params.IDs, *o.Uid.Get()) {
+			return true
+		}
+
+		for _, eventType := range params.EventTypes {
+			if slices.Contains(o.FilterTypes, eventType) {
+				return true
+			}
+		}
+
+		for _, channel := range params.Channels {
+			if slices.Contains(o.Channels, channel) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	webhooks := make([]Webhook, 0, len(listOut.Data))
+	for _, endpointOut := range listOut.Data {
+		if !filterFn(endpointOut) {
+			continue
+		}
+
+		webhook := WebhookFromSvixEndpointOut(&endpointOut)
+		webhook.Namespace = params.Namespace
+
+		// Get signing secret for webhook endpoint.
+		// Skip fetching secret if it was provided in the request.
+
+		webhook.Secret, err = h.GetOrUpdateEndpointSecret(ctx, params.Namespace, webhook.ID, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		webhook.CustomHeaders, err = h.GetOrUpdateEndpointHeaders(ctx, params.Namespace, webhook.ID, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return webhooks, nil
+}
+
+func (h svixWebhookHandler) SendMessage(ctx context.Context, params SendMessageInput) (*Message, error) {
+	if err := params.Validate(); err != nil {
+		return nil, fmt.Errorf("failed to validate SendMessageInputs: %w", err)
+	}
+
+	var eventID *string
+	if params.EventID != "" {
+		eventID = &params.EventID
+	}
+
+	input := &svix.MessageIn{
+		Channels:  params.Channels,
+		EventId:   *svix.NullableString(eventID),
+		EventType: params.EventType,
+		Payload:   params.Payload,
+	}
+
+	idempotencyKey, err := toIdempotencyKey(input, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate idempotency key: %w", err)
+	}
+
+	o, err := h.client.Message.CreateWithOptions(ctx, params.Namespace, input, &svix.PostOptions{
+		IdempotencyKey: &idempotencyKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete Svix endpoint: %w", err)
+	}
+
+	return &Message{
+		Namespace: params.Namespace,
+		ID:        o.Id,
+		EventID: func() string {
+			if o.EventId.IsSet() {
+				return *o.EventId.Get()
+			}
+
+			return ""
+		}(),
+		EventType: o.EventType,
+		Channels:  o.Channels,
+		Payload:   o.Payload,
+	}, nil
+}
+
+func WebhookFromSvixEndpointOut(e *svix.EndpointOut) *Webhook {
+	return &Webhook{
+		ID: func() string {
+			if e.Uid.IsSet() {
+				return *e.Uid.Get()
+			}
+
+			return e.Id
+		}(),
+		URL:         e.Url,
+		Disabled:    defaultx.WithDefault(e.Disabled, false),
+		RateLimit:   e.RateLimit.Get(),
+		Description: e.Description,
+		EventTypes:  e.FilterTypes,
+		Channels: slices.Filter(nil, e.Channels, func(s string) bool {
+			return s != NullChannel
+		}),
+		CreatedAt: e.CreatedAt,
+		UpdatedAt: e.UpdatedAt,
+	}
+}
+
+type idempotencyKeyTypes interface {
+	*svix.ApplicationIn | *svix.EndpointIn | *svix.EndpointSecretRotateIn | *svix.MessageIn
+}
+
+func toIdempotencyKey[T idempotencyKeyTypes](v T, t time.Time) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+
+	if t.IsZero() {
+		t = time.Now().UTC()
+	}
+	t = t.UTC()
+
+	h := sha256.New()
+	h.Write(b)
+	h.Write([]byte(t.String()))
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/notification/webhook/webhook.go
+++ b/internal/notification/webhook/webhook.go
@@ -1,0 +1,264 @@
+package webhook
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	SigningSecretPrefix = "whsec_"
+)
+
+type Webhook struct {
+	Namespace string
+
+	ID            string
+	URL           string
+	Secret        string
+	CustomHeaders map[string]string
+	Disabled      bool
+	RateLimit     *int32
+	Description   string
+	EventTypes    []string
+	Channels      []string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+type validator interface {
+	Validate() error
+}
+
+var _ validator = (*ListWebhooksInput)(nil)
+
+type ListWebhooksInput struct {
+	Namespace string
+
+	IDs        []string
+	EventTypes []string
+	Channels   []string
+}
+
+func (i ListWebhooksInput) Validate() error {
+	if i.Namespace == "" {
+		return errors.New("namespace is required")
+	}
+
+	return nil
+}
+
+var _ validator = (*CreateWebhookInput)(nil)
+
+type CreateWebhookInput struct {
+	Namespace string
+
+	ID            *string
+	URL           string
+	CustomHeaders map[string]string
+	Disabled      bool
+	Secret        *string
+	RateLimit     *int32
+	Description   *string
+	EventTypes    []string
+	Channels      []string
+}
+
+func (i CreateWebhookInput) Validate() error {
+	if i.Namespace == "" {
+		return errors.New("namespace is required")
+	}
+
+	if i.URL == "" {
+		return errors.New("url is required")
+	}
+
+	if i.Secret != nil {
+		secret, _ := strings.CutPrefix(*i.Secret, SigningSecretPrefix)
+		if _, err := base64.StdEncoding.DecodeString(secret); err != nil {
+			return errors.New("invalid secret: must be base64 encoded")
+		}
+	}
+
+	return nil
+}
+
+var _ validator = (*UpdateWebhookInput)(nil)
+
+type UpdateWebhookInput struct {
+	Namespace string
+
+	ID            string
+	URL           string
+	CustomHeaders map[string]string
+	Disabled      bool
+	Secret        *string
+	RateLimit     *int32
+	Description   *string
+	EventTypes    []string
+	Channels      []string
+}
+
+func (i UpdateWebhookInput) Validate() error {
+	if i.Namespace == "" {
+		return errors.New("namespace is required")
+	}
+
+	if i.ID == "" {
+		return errors.New("id is required")
+	}
+
+	if i.URL == "" {
+		return errors.New("url is required")
+	}
+
+	if i.Secret == nil {
+		return errors.New("secret is required")
+	} else {
+		secret, _ := strings.CutPrefix(*i.Secret, SigningSecretPrefix)
+		if _, err := base64.StdEncoding.DecodeString(secret); err != nil {
+			return errors.New("invalid secret: must be base64 encoded")
+		}
+	}
+
+	return nil
+}
+
+var _ validator = (*UpdateWebhookChannelsInput)(nil)
+
+type UpdateWebhookChannelsInput struct {
+	Namespace string
+
+	ID             string
+	AddChannels    []string
+	RemoveChannels []string
+}
+
+func (i UpdateWebhookChannelsInput) Validate() error {
+	if i.Namespace == "" {
+		return errors.New("namespace is required")
+	}
+
+	if i.ID == "" {
+		return errors.New("id is required")
+	}
+
+	return nil
+}
+
+var _ validator = (*GetWebhookInput)(nil)
+
+type GetWebhookInput struct {
+	Namespace string
+
+	ID string
+}
+
+func (i GetWebhookInput) Validate() error {
+	if i.Namespace == "" {
+		return errors.New("namespace is required")
+	}
+
+	if i.ID == "" {
+		return errors.New("id is required")
+	}
+
+	return nil
+}
+
+type DeleteWebhookInput = GetWebhookInput
+
+type Message struct {
+	Namespace string
+
+	ID        string
+	EventID   string
+	EventType string
+	Channels  []string
+	Payload   map[string]interface{}
+}
+
+var _ validator = (*SendMessageInput)(nil)
+
+type SendMessageInput struct {
+	Namespace string
+
+	EventID   string
+	EventType string
+	Channels  []string
+	Payload   map[string]interface{}
+}
+
+func (i SendMessageInput) Validate() error {
+	if i.Namespace == "" {
+		return errors.New("namespace is required")
+	}
+
+	if i.EventType == "" {
+		return errors.New("event type is required")
+	}
+
+	if len(i.Payload) == 0 {
+		return errors.New("payload must not be empty")
+	}
+
+	return nil
+}
+
+type RegisterEventTypesInputs struct {
+	EvenTypes   []EventType
+	AllowUpdate bool
+}
+
+type EventType struct {
+	Name        string
+	Description string
+	GroupName   string
+	// Schemas defines the list of schemas for each event type version
+	Schemas map[string]map[string]interface{}
+}
+
+type Handler interface {
+	RegisterEventTypes(ctx context.Context, params RegisterEventTypesInputs) error
+	ListWebhooks(ctx context.Context, params ListWebhooksInput) ([]Webhook, error)
+	CreateWebhook(ctx context.Context, params CreateWebhookInput) (*Webhook, error)
+	UpdateWebhook(ctx context.Context, params UpdateWebhookInput) (*Webhook, error)
+	UpdateWebhookChannels(ctx context.Context, params UpdateWebhookChannelsInput) (*Webhook, error)
+	GetWebhook(ctx context.Context, params GetWebhookInput) (*Webhook, error)
+	DeleteWebhook(ctx context.Context, params DeleteWebhookInput) error
+	SendMessage(ctx context.Context, params SendMessageInput) (*Message, error)
+}
+
+type Config struct {
+	SvixConfig
+
+	RegisterEvenTypes []EventType
+}
+
+func New(config Config) (Handler, error) {
+	if config.RegisterEvenTypes == nil {
+		config.RegisterEvenTypes = NotificationEventTypes
+	}
+
+	handler, err := newSvixWebhookHandler(config.SvixConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Svix webhook handler: %w", err)
+	}
+
+	if len(config.RegisterEvenTypes) > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		err = handler.RegisterEventTypes(ctx, RegisterEventTypesInputs{
+			EvenTypes: config.RegisterEvenTypes,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to register event types: %w", err)
+		}
+	}
+
+	return handler, nil
+}


### PR DESCRIPTION
## Overview

Add `webhook` package with interface definistions and Svix implementation to `notification` package. This package will be used by Notification API to support sending events to user defined webhook endpoints.
