### PR TITLE
refactor: rename Svix API key in config

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -82,5 +82,5 @@ notification:
   enabled: true
 
 svix:
-  apiToken: secret
+  apiKey: secret
   serverURL: http://localhost:8071

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -240,7 +240,7 @@ func TestComplete(t *testing.T) {
 			},
 		},
 		Svix: notificationwebhook.SvixConfig{
-			APIToken:  "test-svix-token",
+			APIKey:    "test-svix-token",
 			ServerURL: "http://127.0.0.1:8071",
 			Debug:     true,
 		},

--- a/config/testdata/complete.yaml
+++ b/config/testdata/complete.yaml
@@ -94,6 +94,6 @@ notification:
   enabled: true
 
 svix:
-  apiToken: test-svix-token
+  apiKey: test-svix-token
   serverURL: http://127.0.0.1:8071
   debug: true

--- a/internal/notification/webhook/svix.go
+++ b/internal/notification/webhook/svix.go
@@ -30,15 +30,15 @@ const (
 )
 
 type SvixConfig struct {
-	APIToken string
+	APIKey string
 
 	ServerURL string
 	Debug     bool
 }
 
 func (c SvixConfig) Validate() error {
-	if c.APIToken == "" {
-		return errors.New("no API token provided")
+	if c.APIKey == "" {
+		return errors.New("API key is required")
 	}
 
 	if c.ServerURL != "" {
@@ -70,7 +70,7 @@ func newSvixWebhookHandler(config SvixConfig) (Handler, error) {
 	}
 
 	return &svixWebhookHandler{
-		client: svix.New(config.APIToken, &opts),
+		client: svix.New(config.APIKey, &opts),
 	}, nil
 }
 

--- a/test/notification/testenv.go
+++ b/test/notification/testenv.go
@@ -120,16 +120,16 @@ func NewTestEnv() (TestEnv, error) {
 	svixHost := defaultx.IfZero(os.Getenv("SVIX_HOST"), DefaultSvixHost)
 	svixJWTSigningSecret := defaultx.IfZero(os.Getenv("SVIX_JWT_SECRET"), DefaultSvixJWTSigningSecret)
 
-	apiToken, err := NewSvixAuthToken(svixJWTSigningSecret)
+	svixAPIKey, err := NewSvixAuthToken(svixJWTSigningSecret)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate Svix API token: %w", err)
 	}
 
-	logger.Info("Svix API Token", slog.String("token", apiToken))
+	logger.Info("Svix API key", slog.String("apiKey", svixAPIKey))
 
 	webhook, err := notificationwebhook.New(notificationwebhook.Config{
 		SvixConfig: notificationwebhook.SvixConfig{
-			APIToken:  apiToken,
+			APIKey:    svixAPIKey,
 			ServerURL: fmt.Sprintf(SvixServerURLTemplate, svixHost),
 			Debug:     false,
 		},


### PR DESCRIPTION
## Overview

Rename Svix API Key in configuration to make it backward compatible with other places where Svix is used/configured.
