### PR TITLE
fix: Notification API in backend

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -409,6 +409,7 @@ func main() {
 			Notification:                notificationService,
 			// modules
 			EntitlementsEnabled: conf.Entitlements.Enabled,
+			NotificationEnabled: conf.Notification.Enabled,
 		},
 		RouterHook: func(r chi.Router) {
 			r.Use(func(h http.Handler) http.Handler {

--- a/internal/notification/eventhandler.go
+++ b/internal/notification/eventhandler.go
@@ -156,7 +156,7 @@ func (h *handler) dispatchWebhook(ctx context.Context, event *Event) error {
 		Namespace: event.Namespace,
 		EventID:   event.ID,
 		EventType: string(event.Type),
-		Channels:  channelIDs,
+		Channels:  []string{event.Rule.ID},
 	}
 
 	switch event.Type {

--- a/internal/notification/service.go
+++ b/internal/notification/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openmeterio/openmeter/internal/notification/webhook"
 	"github.com/openmeterio/openmeter/internal/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type Service interface {
@@ -406,6 +407,16 @@ func (c service) CreateEvent(ctx context.Context, params CreateEventInput) (*Eve
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rule: %w", err)
 	}
+
+	if rule.DeletedAt != nil {
+		return nil, NotFoundError{
+			NamespacedID: models.NamespacedID{
+				Namespace: params.Namespace,
+				ID:        params.RuleID,
+			},
+		}
+	}
+
 	if rule.Disabled {
 		return nil, ValidationError{
 			Err: errors.New("failed to send event: rule is disabled"),


### PR DESCRIPTION
## Overview

* fix notification configuration in router config
* return HTTP 404 for getting deleted rules
* fix event routing for webhook channels

