### PR TITLE
refactor: postgres/ent driver initialization

### DIFF
--- a/cmd/balance-worker/main.go
+++ b/cmd/balance-worker/main.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 	"time"
 
-	"entgo.io/ent/dialect/sql"
 	health "github.com/AppsFlyer/go-sundheit"
 	healthhttp "github.com/AppsFlyer/go-sundheit/http"
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -30,7 +29,6 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 
 	"github.com/openmeterio/openmeter/config"
-	"github.com/openmeterio/openmeter/internal/ent/db"
 	entitlementpgadapter "github.com/openmeterio/openmeter/internal/entitlement/adapter"
 	"github.com/openmeterio/openmeter/internal/entitlement/balanceworker"
 	"github.com/openmeterio/openmeter/internal/meter"
@@ -42,8 +40,9 @@ import (
 	"github.com/openmeterio/openmeter/internal/watermill/eventbus"
 	"github.com/openmeterio/openmeter/internal/watermill/router"
 	"github.com/openmeterio/openmeter/pkg/contextx"
-	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	entdriver "github.com/openmeterio/openmeter/pkg/framework/entutils/driver"
 	"github.com/openmeterio/openmeter/pkg/framework/operation"
+	"github.com/openmeterio/openmeter/pkg/framework/pgdriver"
 	"github.com/openmeterio/openmeter/pkg/gosundheit"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
@@ -211,14 +210,42 @@ func main() {
 	}
 
 	// Dependencies: postgresql
-	pgClients, err := initPGClients(conf.Postgres)
+
+	// Initialize Postgres driver
+	postgresDriver, err := pgdriver.NewPostgresDriver(
+		ctx,
+		conf.Postgres.URL,
+		pgdriver.WithTracerProvider(otelTracerProvider),
+		pgdriver.WithMeterProvider(otelMeterProvider),
+	)
 	if err != nil {
-		logger.Error("failed to initialize postgres clients", "error", err)
+		logger.Error("failed to initialize postgres driver", "error", err)
 		os.Exit(1)
 	}
-	defer pgClients.driver.Close()
 
-	logger.Info("Postgres clients initialized")
+	defer func() {
+		if err = postgresDriver.Close(); err != nil {
+			logger.Error("failed to close postgres driver", "error", err)
+		}
+	}()
+
+	// Initialize Ent driver
+	entPostgresDriver := entdriver.NewEntPostgresDriver(postgresDriver.DB())
+	defer func() {
+		if err = entPostgresDriver.Close(); err != nil {
+			logger.Error("failed to close ent driver", "error", err)
+		}
+	}()
+
+	entClient := entPostgresDriver.Client()
+
+	// Run database schema creation
+	err = entClient.Schema.Create(ctx)
+	if err != nil {
+		logger.Error("failed to create database schema", "error", err)
+	}
+
+	logger.Info("Postgres client initialized")
 
 	// Create  subscriber
 	wmBrokerConfig := wmBrokerConfiguration(conf, logger, metricMeter)
@@ -259,7 +286,7 @@ func main() {
 
 	// Dependencies: entitlement
 	entitlementConnectors := registrybuilder.GetEntitlementRegistry(registry.EntitlementOptions{
-		DatabaseClient:     pgClients.client,
+		DatabaseClient:     entClient,
 		StreamingConnector: clickhouseStreamingConnector,
 		MeterRepository:    meterRepository,
 		Logger:             logger,
@@ -282,7 +309,7 @@ func main() {
 		EventBus: eventPublisher,
 
 		Entitlement: entitlementConnectors,
-		Repo:        entitlementpgadapter.NewPostgresEntitlementRepo(pgClients.client),
+		Repo:        entitlementpgadapter.NewPostgresEntitlementRepo(entClient),
 
 		Logger: logger,
 	}
@@ -349,27 +376,4 @@ func initEventPublisherDriver(ctx context.Context, broker watermillkafka.BrokerO
 		Broker:          broker,
 		ProvisionTopics: provisionTopics,
 	})
-}
-
-type pgClients struct {
-	driver *sql.Driver
-	client *db.Client
-}
-
-func initPGClients(config config.PostgresConfig) (
-	*pgClients,
-	error,
-) {
-	if err := config.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid postgres config: %w", err)
-	}
-	driver, err := entutils.GetPGDriver(config.URL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to init postgres driver: %w", err)
-	}
-
-	return &pgClients{
-		driver: driver,
-		client: db.NewClient(db.Driver(driver)),
-	}, nil
 }

--- a/pkg/framework/entutils/database.go
+++ b/pkg/framework/entutils/database.go
@@ -4,10 +4,10 @@ import (
 	"entgo.io/ent/dialect"
 	entDialectSQL "entgo.io/ent/dialect/sql"
 	"github.com/XSAM/otelsql"
-	_ "github.com/jackc/pgx/v5/stdlib" // pgx database driver
 	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
 )
 
+// Deprecated: use NewEntPostgresDriver instead
 func GetPGDriver(databaseURL string) (*entDialectSQL.Driver, error) {
 	// TODO: inject trace and metrics provider
 	database, err := otelsql.Open("pgx", databaseURL, otelsql.WithAttributes(

--- a/pkg/framework/entutils/driver/driver.go
+++ b/pkg/framework/entutils/driver/driver.go
@@ -1,0 +1,60 @@
+package entutils
+
+import (
+	"database/sql"
+
+	"entgo.io/ent/dialect"
+	entDialectSQL "entgo.io/ent/dialect/sql"
+
+	entdb "github.com/openmeterio/openmeter/internal/ent/db"
+)
+
+type EntPostgresDriver struct {
+	driver *entDialectSQL.Driver
+	client *entdb.Client
+}
+
+// Close releases all the underlying resources.
+func (d *EntPostgresDriver) Close() error {
+	if err := d.client.Close(); err != nil {
+		return err
+	}
+
+	if err := d.driver.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Driver returns the underlying Driver.
+func (d *EntPostgresDriver) Driver() *entDialectSQL.Driver {
+	return d.driver
+}
+
+// Client returns the underlying Client.
+func (d *EntPostgresDriver) Client() *entdb.Client {
+	return d.client
+}
+
+// Clone returns a new EntPostgresDriver initialized by using the underlying *sql.DB.
+func (d *EntPostgresDriver) Clone() *EntPostgresDriver {
+	driver := entDialectSQL.OpenDB(dialect.Postgres, d.driver.DB())
+	client := entdb.NewClient(entdb.Driver(driver))
+
+	return &EntPostgresDriver{
+		driver: driver,
+		client: client,
+	}
+}
+
+// NewEntPostgresDriver returns a EntPostgresDriver created from *sql.DB.
+func NewEntPostgresDriver(db *sql.DB) *EntPostgresDriver {
+	driver := entDialectSQL.OpenDB(dialect.Postgres, db)
+	client := entdb.NewClient(entdb.Driver(driver))
+
+	return &EntPostgresDriver{
+		driver: driver,
+		client: client,
+	}
+}

--- a/pkg/framework/pgdriver/driver.go
+++ b/pkg/framework/pgdriver/driver.go
@@ -1,0 +1,92 @@
+package pgdriver
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/XSAM/otelsql"
+	"github.com/jackc/pgx/v5/pgxpool"
+	pgxstdlib "github.com/jackc/pgx/v5/stdlib"
+	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type Option interface {
+	apply(*options)
+}
+
+type optionFunc func(c *options)
+
+func (fn optionFunc) apply(c *options) {
+	fn(c)
+}
+
+func WithTracerProvider(p trace.TracerProvider) Option {
+	return optionFunc(func(o *options) {
+		o.otelOptions = append(o.otelOptions, otelsql.WithTracerProvider(p))
+	})
+}
+
+func WithMeterProvider(p metric.MeterProvider) Option {
+	return optionFunc(func(o *options) {
+		o.otelOptions = append(o.otelOptions, otelsql.WithMeterProvider(p))
+	})
+}
+
+type options struct {
+	connConfig  *pgxpool.Config
+	otelOptions []otelsql.Option
+}
+
+type Driver struct {
+	pool *pgxpool.Pool
+	db   *sql.DB
+}
+
+func (d *Driver) DB() *sql.DB {
+	return d.db
+}
+
+func (d *Driver) Close() error {
+	d.pool.Close()
+
+	return nil
+}
+
+func NewPostgresDriver(ctx context.Context, url string, opts ...Option) (*Driver, error) {
+	config, err := pgxpool.ParseConfig(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse postgres url: %w", err)
+	}
+
+	o := &options{
+		connConfig: config,
+		otelOptions: []otelsql.Option{
+			otelsql.WithAttributes(
+				semconv.DBSystemPostgreSQL,
+			),
+		},
+	}
+
+	for _, opt := range opts {
+		opt.apply(o)
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, o.connConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create postgres pool: %w", err)
+	}
+
+	db := otelsql.OpenDB(pgxstdlib.GetPoolConnector(pool), o.otelOptions...)
+
+	// Set maximum idle connections to 0 as connections are managed from pgx.Pool.
+	// See: https://github.com/jackc/pgx/blob/v5.6.0/stdlib/sql.go#L204-L208
+	db.SetMaxIdleConns(0)
+
+	return &Driver{
+		pool: pool,
+		db:   db,
+	}, nil
+}

--- a/test/notification/helpers.go
+++ b/test/notification/helpers.go
@@ -1,9 +1,7 @@
 package notification
 
 import (
-	"context"
 	"crypto/rand"
-	"fmt"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -11,9 +9,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/oklog/ulid/v2"
 
-	"github.com/openmeterio/openmeter/internal/ent/db"
 	"github.com/openmeterio/openmeter/internal/meter"
-	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -62,20 +58,4 @@ func NewMeterRepository() meter.Repository {
 			WindowSize: "MINUTE",
 		},
 	})
-}
-
-func NewPGClient(url string) (*db.Client, error) {
-	driver, err := entutils.GetPGDriver(url)
-	if err != nil {
-		return nil, fmt.Errorf("failed to init postgres driver: %w", err)
-	}
-
-	// initialize client & run migrations
-	dbClient := db.NewClient(db.Driver(driver))
-
-	if err = dbClient.Schema.Create(context.Background()); err != nil {
-		return nil, fmt.Errorf("failed to migrate databse schme: %w", err)
-	}
-
-	return dbClient, nil
 }

--- a/test/notification/notification_test.go
+++ b/test/notification/notification_test.go
@@ -8,7 +8,10 @@ import (
 )
 
 func TestNotification(t *testing.T) {
-	env, err := NewTestEnv()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env, err := NewTestEnv(ctx)
 	require.NoError(t, err, "NotificationTestEnv() failed")
 	require.NotNil(t, env.Notification())
 	require.NotNil(t, env.NotificationRepo())
@@ -19,9 +22,6 @@ func TestNotification(t *testing.T) {
 			t.Errorf("failed to close environment: %v", err)
 		}
 	}()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	// Test suite for testing integration with webhook provider (Svix)
 	t.Run("Webhook", func(t *testing.T) {


### PR DESCRIPTION
## Overview

* split `ent` and `postgres/pgx` driver initialization into separate packages (`entutils/driver` and `pgdriver`)
* use `pgxpool` to have a better control over client connection pool to database
* allow instrumenting database client with custom tracing providers
* deprecate previously used `GetPGDriver` helper for backward compatibility
