### PR TITLE
feat: set max processing time for sarama consumers

### DIFF
--- a/internal/watermill/driver/kafka/subscriber.go
+++ b/internal/watermill/driver/kafka/subscriber.go
@@ -10,6 +10,14 @@ import (
 	"github.com/ThreeDotsLabs/watermill/message"
 )
 
+const (
+	// defaultMaxProcessinTime is the default maximum time a message is allowed to be processed before the
+	// partition assignment is lost by the consumer. For now we just set it to a high enough value (default 1s)
+	//
+	// Later we can make this configurable if needed.
+	defaultMaxProcessingTime = 5 * time.Minute
+)
+
 type SubscriberOptions struct {
 	Broker            BrokerOptions
 	ConsumerGroupName string
@@ -36,6 +44,8 @@ func NewSubscriber(in SubscriberOptions) (message.Subscriber, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	saramaConfig.Consumer.MaxProcessingTime = defaultMaxProcessingTime
 
 	wmConfig := kafka.SubscriberConfig{
 		Brokers:               []string{in.Broker.KafkaConfig.Broker},


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Given that we have retry and timeout middlewares in watermill we can set this to a high enough number.

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
