### PR TITLE
fix: Notification API

### DIFF
--- a/internal/notification/channel.go
+++ b/internal/notification/channel.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/openmeterio/openmeter/api"
+	"github.com/openmeterio/openmeter/internal/notification/webhook"
 	"github.com/openmeterio/openmeter/pkg/convert"
 	"github.com/openmeterio/openmeter/pkg/defaultx"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -143,7 +144,17 @@ type WebHookChannelConfig struct {
 // Validate returns an error if webhook channel configuration is invalid.
 func (w WebHookChannelConfig) Validate() error {
 	if w.URL == "" {
-		return fmt.Errorf("invalid webhook channel configuration: missing URL")
+		return ValidationError{
+			Err: errors.New("missing URL"),
+		}
+	}
+
+	if w.SigningSecret != "" {
+		if err := webhook.ValidateSigningSecret(w.SigningSecret); err != nil {
+			return ValidationError{
+				Err: fmt.Errorf("invalid signing secret: %w", err),
+			}
+		}
 	}
 
 	return nil

--- a/internal/notification/repository/repository.go
+++ b/internal/notification/repository/repository.go
@@ -285,6 +285,11 @@ func (r repository) ListRules(ctx context.Context, params notification.ListRules
 		query = query.Where(ruledb.TypeIn(params.Types...))
 	}
 
+	if len(params.Channels) > 0 {
+		query = query.Where(ruledb.HasChannelsWith(channeldb.IDIn(params.Channels...)))
+	}
+
+	// Eager load Channels
 	query = query.WithChannels()
 
 	order := entutils.GetOrdering(sortx.OrderDefault)

--- a/internal/notification/rule.go
+++ b/internal/notification/rule.go
@@ -265,6 +265,7 @@ type ListRulesInput struct {
 	Rules           []string
 	IncludeDisabled bool
 	Types           []RuleType
+	Channels        []string
 
 	OrderBy api.ListNotificationRulesParamsOrderBy
 	Order   sortx.Order

--- a/internal/notification/rule.go
+++ b/internal/notification/rule.go
@@ -204,19 +204,10 @@ func (b BalanceThresholdRuleConfig) Validate(ctx context.Context, service Servic
 
 	for _, threshold := range b.Thresholds {
 		switch threshold.Type {
-		case BalanceThresholdTypeNumber:
+		case BalanceThresholdTypeNumber, BalanceThresholdTypePercent:
 			if threshold.Value <= 0 {
 				return ValidationError{
-					Err: fmt.Errorf("invalid threshold with type %s: value must be greater than 0: %f",
-						threshold.Type,
-						threshold.Value,
-					),
-				}
-			}
-		case BalanceThresholdTypePercent:
-			if threshold.Value <= 0 || threshold.Value > 100 {
-				return ValidationError{
-					Err: fmt.Errorf("invalid threshold with type %s: value must be between 0 anad 100: %f",
+					Err: fmt.Errorf("invalid threshold with type %s: value must be greater than 0: %.2f",
 						threshold.Type,
 						threshold.Value,
 					),

--- a/internal/notification/webhook/svix.go
+++ b/internal/notification/webhook/svix.go
@@ -268,7 +268,7 @@ func (h svixWebhookHandler) CreateWebhook(ctx context.Context, params CreateWebh
 	// Set custom HTTP headers for webhook endpoint if provided
 
 	if len(params.CustomHeaders) > 0 {
-		webhook.CustomHeaders, err = h.GetOrUpdateEndpointHeaders(ctx, app.Id, endpoint.Id, nil)
+		webhook.CustomHeaders, err = h.GetOrUpdateEndpointHeaders(ctx, app.Id, endpoint.Id, params.CustomHeaders)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Overview

Fix multiple issues in Notification API:

* webhook signing secret validation
* custom header not being set at notification channel creation
* balance threshold validation to allow >100% values for PERCENT type
* deleting notification channels assigned to active notification rules
