### PR TITLE
fix: annotation should contain subject ID

### DIFF
--- a/internal/notification/consumer/balancetreshold.go
+++ b/internal/notification/consumer/balancetreshold.go
@@ -176,7 +176,7 @@ func (b *BalanceThresholdEventHandler) createEvent(ctx context.Context, in creat
 	}
 
 	if in.Snapshot.Subject.Id != nil && *in.Snapshot.Subject.Id != "" {
-		annotations[notification.AnnotationEventSubjectID] = in.Snapshot
+		annotations[notification.AnnotationEventSubjectID] = in.Snapshot.Subject.Id
 	}
 
 	if in.Snapshot.Feature.ID != "" {


### PR DESCRIPTION

## Overview

The subject ID annotation was containing the payload instead of the actual subject ID.

## Notes for reviewer

<!-- Anything the reviewer should know? -->
