### PR TITLE
feat: add recalculation metrics

### DIFF
--- a/cmd/jobs/entitlement/recalculatesnapshots.go
+++ b/cmd/jobs/entitlement/recalculatesnapshots.go
@@ -26,11 +26,13 @@ func NewRecalculateBalanceSnapshotsCommand() *cobra.Command {
 
 			logger := slog.Default()
 
+			metricMeter := otel.GetMeterProvider().Meter(otelNameRecalculateBalanceSnapshot)
+
 			entitlementConnectors, err := initEntitlements(
 				cmd.Context(),
 				conf,
 				logger,
-				otel.GetMeterProvider().Meter(otelNameRecalculateBalanceSnapshot),
+				metricMeter,
 				otelNameRecalculateBalanceSnapshot,
 			)
 			if err != nil {
@@ -43,6 +45,7 @@ func NewRecalculateBalanceSnapshotsCommand() *cobra.Command {
 				Entitlement: entitlementConnectors.Registry,
 				Namespace:   "default",
 				EventBus:    entitlementConnectors.EventBus,
+				MetricMeter: metricMeter,
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

We can use these metrics to determine the average time required to recalculate an entitlement in balance worker.

Fixes OM-877
