### PR TITLE
refactor: allow recalculator reuse

### DIFF
--- a/cmd/jobs/entitlement/recalculatesnapshots.go
+++ b/cmd/jobs/entitlement/recalculatesnapshots.go
@@ -43,7 +43,6 @@ func NewRecalculateBalanceSnapshotsCommand() *cobra.Command {
 
 			recalculator, err := balanceworker.NewRecalculator(balanceworker.RecalculatorOptions{
 				Entitlement: entitlementConnectors.Registry,
-				Namespace:   "default",
 				EventBus:    entitlementConnectors.EventBus,
 				MetricMeter: metricMeter,
 			})
@@ -51,7 +50,7 @@ func NewRecalculateBalanceSnapshotsCommand() *cobra.Command {
 				return err
 			}
 
-			return recalculator.Recalculate(cmd.Context())
+			return recalculator.Recalculate(cmd.Context(), "default")
 		},
 	}
 }


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch ensures that we can reuse the recalculator in multi-namespace scenarios.

This also allows us to allocate the meters only once.
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->
