### PR TITLE
refactor: metrics

### DIFF
--- a/openmeter/entitlement/balanceworker/recalculate.go
+++ b/openmeter/entitlement/balanceworker/recalculate.go
@@ -29,7 +29,7 @@ const (
 
 	defaultLRUCacheSize = 10_000
 
-	metricNameRecalculationTime = "balance_worker_entitlement_recalculation_time_ms"
+	metricNameRecalculationTime = "balance_worker.entitlement_recalculation_time_ms"
 )
 
 var (

--- a/openmeter/entitlement/balanceworker/recalculate.go
+++ b/openmeter/entitlement/balanceworker/recalculate.go
@@ -29,7 +29,7 @@ const (
 
 	defaultLRUCacheSize = 10_000
 
-	metricNameRecalculationTime = "balance_worker_entitlement_recalculation_time"
+	metricNameRecalculationTime = "balance_worker_entitlement_recalculation_time_ms"
 )
 
 var (
@@ -70,7 +70,7 @@ type Recalculator struct {
 	featureCache *lru.Cache[string, productcatalog.Feature]
 	subjectCache *lru.Cache[string, models.Subject]
 
-	metricRecalculationTime metric.Float64Histogram
+	metricRecalculationTime metric.Int64Histogram
 }
 
 func NewRecalculator(opts RecalculatorOptions) (*Recalculator, error) {
@@ -88,7 +88,7 @@ func NewRecalculator(opts RecalculatorOptions) (*Recalculator, error) {
 		return nil, fmt.Errorf("failed to create subject ID cache: %w", err)
 	}
 
-	metricRecalculationTime, err := opts.MetricMeter.Float64Histogram(
+	metricRecalculationTime, err := opts.MetricMeter.Int64Histogram(
 		metricNameRecalculationTime,
 		metric.WithDescription("Entitlement recalculation time"),
 		metric.WithExplicitBucketBoundaries(metricRecalculationBuckets...),
@@ -135,7 +135,7 @@ func (r *Recalculator) processEntitlements(ctx context.Context, entitlements []e
 			}
 
 			r.metricRecalculationTime.Record(ctx,
-				time.Since(start).Seconds(),
+				time.Since(start).Milliseconds(),
 				metric.WithAttributes(recalculationTimeDeleteAttribute))
 		} else {
 			err := r.sendEntitlementUpdatedEvent(ctx, ent)
@@ -144,7 +144,7 @@ func (r *Recalculator) processEntitlements(ctx context.Context, entitlements []e
 			}
 
 			r.metricRecalculationTime.Record(ctx,
-				time.Since(start).Seconds(),
+				time.Since(start).Milliseconds(),
 				metric.WithAttributes(recalculationTimeUpdateAttribute))
 		}
 	}

--- a/openmeter/sink/flushhandler/handler.go
+++ b/openmeter/sink/flushhandler/handler.go
@@ -146,7 +146,7 @@ func (f *flushEventHandler) invokeCallback(ctx context.Context, events []models.
 		return err
 	}
 
-	f.metrics.eventProcessingTime.Record(ctx, time.Since(startTime).Seconds())
+	f.metrics.eventProcessingTime.Record(ctx, time.Since(startTime).Milliseconds())
 	f.metrics.eventsProcessed.Add(ctx, 1)
 
 	return nil

--- a/openmeter/sink/flushhandler/meters.go
+++ b/openmeter/sink/flushhandler/meters.go
@@ -10,7 +10,7 @@ type metrics struct {
 	eventsReceived      metric.Int64Counter
 	eventsProcessed     metric.Int64Counter
 	eventsFailed        metric.Int64Counter
-	eventProcessingTime metric.Float64Histogram
+	eventProcessingTime metric.Int64Histogram
 	eventChannelFull    metric.Int64Counter
 }
 
@@ -35,7 +35,7 @@ func newMetrics(handlerName string, meter metric.Meter) (*metrics, error) {
 		return nil, err
 	}
 
-	if r.eventProcessingTime, err = meter.Float64Histogram(fmt.Sprintf("sink.flush_handler.%s.event_processing_time", handlerName)); err != nil {
+	if r.eventProcessingTime, err = meter.Int64Histogram(fmt.Sprintf("sink.flush_handler.%s.event_processing_time_ms", handlerName)); err != nil {
 		return nil, err
 	}
 

--- a/openmeter/watermill/driver/kafka/broker.go
+++ b/openmeter/watermill/driver/kafka/broker.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultMeterPrefix = "sarama.publisher."
+	defaultMeterPrefix = "sarama."
 	defaultKeepalive   = time.Minute
 )
 

--- a/openmeter/watermill/grouphandler/grouphandler.go
+++ b/openmeter/watermill/grouphandler/grouphandler.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	meterNameHandlerMessageCount   = "grouphandler_message_count"
-	meterNameHandlerProcessingTime = "grouphandler_processing_time_ms"
+	meterNameHandlerMessageCount   = "watermill.grouphandler.message_count"
+	meterNameHandlerProcessingTime = "watermill.grouphandler.processing_time_ms"
 )
 
 var (

--- a/openmeter/watermill/grouphandler/grouphandler.go
+++ b/openmeter/watermill/grouphandler/grouphandler.go
@@ -2,9 +2,23 @@ package grouphandler
 
 import (
 	"context"
+	"time"
 
 	"github.com/ThreeDotsLabs/watermill/components/cqrs"
 	"github.com/ThreeDotsLabs/watermill/message"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	meterNameHandlerMessageCount   = "grouphandler_message_count"
+	meterNameHandlerProcessingTime = "grouphandler_processing_time_ms"
+)
+
+var (
+	meterAttributeStatusIgnored = attribute.String("status", "ignored")
+	meterAttributeStatusFailed  = attribute.String("status", "failed")
+	meterAttributeStatusSuccess = attribute.String("status", "success")
 )
 
 type GroupEventHandler = cqrs.GroupEventHandler
@@ -14,7 +28,12 @@ func NewGroupEventHandler[T any](handleFunc func(ctx context.Context, event *T) 
 }
 
 // NewNoPublishingHandler creates a NoPublishHandlerFunc that will handle events with the provided GroupEventHandlers.
-func NewNoPublishingHandler(marshaler cqrs.CommandEventMarshaler, groupHandlers ...GroupEventHandler) message.NoPublishHandlerFunc {
+func NewNoPublishingHandler(marshaler cqrs.CommandEventMarshaler, metricMeter metric.Meter, groupHandlers ...GroupEventHandler) (message.NoPublishHandlerFunc, error) {
+	meters, err := getMeters(metricMeter)
+	if err != nil {
+		return nil, err
+	}
+
 	typeHandlerMap := make(map[string]cqrs.GroupEventHandler)
 	for _, groupHandler := range groupHandlers {
 		event := groupHandler.NewEvent()
@@ -24,8 +43,14 @@ func NewNoPublishingHandler(marshaler cqrs.CommandEventMarshaler, groupHandlers 
 	return func(msg *message.Message) error {
 		eventName := marshaler.NameFromMessage(msg)
 
+		meterAttributeCEType := attribute.String("ce_type", eventName)
+
 		groupHandler, ok := typeHandlerMap[eventName]
 		if !ok {
+			meters.handlerMessageCount.Add(msg.Context(), 1, metric.WithAttributes(
+				meterAttributeCEType,
+				meterAttributeStatusIgnored,
+			))
 			return nil
 		}
 
@@ -35,6 +60,52 @@ func NewNoPublishingHandler(marshaler cqrs.CommandEventMarshaler, groupHandlers 
 			return err
 		}
 
-		return groupHandler.Handle(msg.Context(), event)
+		startedAt := time.Now()
+		err := groupHandler.Handle(msg.Context(), event)
+		if err != nil {
+			meters.handlerMessageCount.Add(msg.Context(), 1, metric.WithAttributes(
+				meterAttributeCEType,
+				meterAttributeStatusFailed,
+			))
+			meters.handlerProcessingTime.Record(msg.Context(), time.Since(startedAt).Milliseconds(), metric.WithAttributes(
+				meterAttributeCEType,
+				meterAttributeStatusFailed,
+			))
+
+			return err
+		}
+
+		meters.handlerProcessingTime.Record(msg.Context(), time.Since(startedAt).Milliseconds(), metric.WithAttributes(
+			meterAttributeCEType,
+			meterAttributeStatusSuccess,
+		))
+		meters.handlerMessageCount.Add(msg.Context(), 1, metric.WithAttributes(
+			meterAttributeCEType,
+			meterAttributeStatusSuccess,
+		))
+
+		return nil
+	}, nil
+}
+
+type meters struct {
+	handlerMessageCount   metric.Int64Counter
+	handlerProcessingTime metric.Int64Histogram
+}
+
+func getMeters(meter metric.Meter) (*meters, error) {
+	handlerMessageCount, err := meter.Int64Counter(meterNameHandlerMessageCount)
+	if err != nil {
+		return nil, err
 	}
+
+	handlerProcessingTime, err := meter.Int64Histogram(meterNameHandlerProcessingTime)
+	if err != nil {
+		return nil, err
+	}
+
+	return &meters{
+		handlerMessageCount:   handlerMessageCount,
+		handlerProcessingTime: handlerProcessingTime,
+	}, nil
 }

--- a/openmeter/watermill/router/metrics.go
+++ b/openmeter/watermill/router/metrics.go
@@ -16,12 +16,16 @@ const (
 	unkonwnEventType = "UNKNOWN"
 
 	messageHandlerProcessingTimeMetricName = "message_handler_processing_time_ms"
-	messageHandlerSuccessCountMetricName   = "message_handler_success_count"
-	messageHandlerErrorCountMetricName     = "message_handler_error_count"
+	messageHandlerMessageCountMetricName   = "message_handler_message_count"
+)
+
+var (
+	meterAttributeStatusFailed  = attribute.String("status", "failed")
+	meterAttributeStatusSuccess = attribute.String("status", "success")
 )
 
 func HandlerMetrics(metricMeter metric.Meter, prefix string, log *slog.Logger) (func(message.HandlerFunc) message.HandlerFunc, error) {
-	messageProcessingTime, err := metricMeter.Int64Histogram(
+	meterMessageProcessingTime, err := metricMeter.Int64Histogram(
 		fmt.Sprintf("%s.%s", prefix, messageHandlerProcessingTimeMetricName),
 		metric.WithDescription("Time spent by the handler processing a message"),
 	)
@@ -29,17 +33,9 @@ func HandlerMetrics(metricMeter metric.Meter, prefix string, log *slog.Logger) (
 		return nil, err
 	}
 
-	messageProcessed, err := metricMeter.Int64Counter(
-		fmt.Sprintf("%s.%s", prefix, messageHandlerSuccessCountMetricName),
+	meterMessageCount, err := metricMeter.Int64Counter(
+		fmt.Sprintf("%s.%s", prefix, messageHandlerMessageCountMetricName),
 		metric.WithDescription("Number of messages processed by the handler"),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	messageProcessingError, err := metricMeter.Int64Counter(
-		fmt.Sprintf("%s.%s", prefix, messageHandlerErrorCountMetricName),
-		metric.WithDescription("Number of messages that failed to process by the handler"),
 	)
 	if err != nil {
 		return nil, err
@@ -49,24 +45,32 @@ func HandlerMetrics(metricMeter metric.Meter, prefix string, log *slog.Logger) (
 		return func(msg *message.Message) ([]*message.Message, error) {
 			start := time.Now()
 
-			attrSet := metricAttributesFromMessage(msg)
+			meterAttributeType := metricAttributeTypeFromMessage(msg)
 
 			resMsg, err := h(msg)
 			if err != nil {
 				// This should be warning, as it might happen that the kafka message is produced later than the
 				// database commit happens.
 				log.Warn("Message handler failed, will retry later", "error", err, "message_metadata", msg.Metadata, "message_payload", string(msg.Payload))
-				messageProcessingError.Add(msg.Context(), 1, metric.WithAttributeSet(
-					attrSet,
+				meterMessageCount.Add(msg.Context(), 1, metric.WithAttributes(
+					meterAttributeType,
+					meterAttributeStatusFailed,
+				))
+
+				meterMessageProcessingTime.Record(msg.Context(), time.Since(start).Milliseconds(), metric.WithAttributes(
+					meterAttributeType,
+					meterAttributeStatusFailed,
 				))
 				return resMsg, err
 			}
 
-			messageProcessingTime.Record(msg.Context(), time.Since(start).Milliseconds(), metric.WithAttributeSet(
-				attrSet,
+			meterMessageProcessingTime.Record(msg.Context(), time.Since(start).Milliseconds(), metric.WithAttributes(
+				meterAttributeType,
+				meterAttributeStatusSuccess,
 			))
-			messageProcessed.Add(msg.Context(), 1, metric.WithAttributeSet(
-				attrSet,
+			meterMessageCount.Add(msg.Context(), 1, metric.WithAttributes(
+				meterAttributeType,
+				meterAttributeStatusSuccess,
 			))
 			return resMsg, nil
 		}
@@ -74,22 +78,22 @@ func HandlerMetrics(metricMeter metric.Meter, prefix string, log *slog.Logger) (
 }
 
 const (
-	messageProcessingErrorCountMetricName   = "message_processing_error_count"
-	messageProcessingSuccessCountMetricName = "message_processing_success_count"
+	messageProcessingCountMetricName = "message_processing_count"
+	messageProcessingTimeMetricName  = "message_processing_time_ms"
 )
 
 func DLQMetrics(metricMeter metric.Meter, prefix string, log *slog.Logger) (func(message.HandlerFunc) message.HandlerFunc, error) {
-	messageProcessingErrorCount, err := metricMeter.Int64Counter(
-		fmt.Sprintf("%s.%s", prefix, messageProcessingErrorCountMetricName),
-		metric.WithDescription("Number of messages that failed to process"),
+	meterMessageProcessingCount, err := metricMeter.Int64Counter(
+		fmt.Sprintf("%s.%s", prefix, messageProcessingCountMetricName),
+		metric.WithDescription("Number of messages processed"),
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	messageProcessingSuccessCount, err := metricMeter.Int64Counter(
-		fmt.Sprintf("%s.%s", prefix, messageProcessingSuccessCountMetricName),
-		metric.WithDescription("Number of messages that were successfully processed"),
+	meterMessageProcessingTime, err := metricMeter.Int64Histogram(
+		fmt.Sprintf("%s.%s", prefix, messageProcessingTimeMetricName),
+		metric.WithDescription("Time spent processing a message (including retries)"),
 	)
 	if err != nil {
 		return nil, err
@@ -97,19 +101,33 @@ func DLQMetrics(metricMeter metric.Meter, prefix string, log *slog.Logger) (func
 
 	return func(h message.HandlerFunc) message.HandlerFunc {
 		return func(msg *message.Message) ([]*message.Message, error) {
-			attrSet := metricAttributesFromMessage(msg)
+			start := time.Now()
+
+			meterAttributeCEType := metricAttributeTypeFromMessage(msg)
 
 			resMsg, err := h(msg)
 			if err != nil {
 				log.Error("Failed to process message, message is going to DLQ", "error", err, "message_metadata", msg.Metadata, "message_payload", string(msg.Payload))
-				messageProcessingErrorCount.Add(msg.Context(), 1, metric.WithAttributeSet(
-					attrSet,
+
+				meterMessageProcessingCount.Add(msg.Context(), 1, metric.WithAttributes(
+					meterAttributeCEType,
+					meterAttributeStatusFailed,
 				))
+				meterMessageProcessingTime.Record(msg.Context(), time.Since(start).Milliseconds(), metric.WithAttributes(
+					meterAttributeCEType,
+					meterAttributeStatusFailed,
+				))
+
 				return resMsg, err
 			}
 
-			messageProcessingSuccessCount.Add(msg.Context(), 1, metric.WithAttributeSet(
-				attrSet,
+			meterMessageProcessingCount.Add(msg.Context(), 1, metric.WithAttributes(
+				meterAttributeCEType,
+				meterAttributeStatusSuccess,
+			))
+			meterMessageProcessingTime.Record(msg.Context(), time.Since(start).Milliseconds(), metric.WithAttributes(
+				meterAttributeCEType,
+				meterAttributeStatusSuccess,
 			))
 
 			return resMsg, nil
@@ -117,12 +135,11 @@ func DLQMetrics(metricMeter metric.Meter, prefix string, log *slog.Logger) (func
 	}, nil
 }
 
-func metricAttributesFromMessage(msg *message.Message) attribute.Set {
+func metricAttributeTypeFromMessage(msg *message.Message) attribute.KeyValue {
 	ce_type := msg.Metadata.Get(marshaler.CloudEventsHeaderType)
 	if ce_type == "" {
 		ce_type = unkonwnEventType
 	}
-	attrSet := attribute.NewSet(attribute.String("ce_type", ce_type))
 
-	return attrSet
+	return attribute.String("ce_type", ce_type)
 }

--- a/openmeter/watermill/router/metrics.go
+++ b/openmeter/watermill/router/metrics.go
@@ -15,8 +15,8 @@ import (
 const (
 	unkonwnEventType = "UNKNOWN"
 
-	messageHandlerProcessingTimeMetricName = "message_handler_processing_time_ms"
-	messageHandlerMessageCountMetricName   = "message_handler_message_count"
+	messageHandlerProcessingTimeMetricName = "watermill.router.message_handler.processing_time_ms"
+	messageHandlerMessageCountMetricName   = "watermill.router.message_handler.message_count"
 )
 
 var (
@@ -78,8 +78,8 @@ func HandlerMetrics(metricMeter metric.Meter, prefix string, log *slog.Logger) (
 }
 
 const (
-	messageProcessingCountMetricName = "message_processing_count"
-	messageProcessingTimeMetricName  = "message_processing_time_ms"
+	messageProcessingCountMetricName = "watermill.router.message_processing_count"
+	messageProcessingTimeMetricName  = "watermill.router.message_processing_time_ms"
 )
 
 func DLQMetrics(metricMeter metric.Meter, prefix string, log *slog.Logger) (func(message.HandlerFunc) message.HandlerFunc, error) {

--- a/openmeter/watermill/router/metrics.go
+++ b/openmeter/watermill/router/metrics.go
@@ -15,13 +15,13 @@ import (
 const (
 	unkonwnEventType = "UNKNOWN"
 
-	messageHandlerProcessingTimeMetricName = "message_handler_processing_time_seconds"
+	messageHandlerProcessingTimeMetricName = "message_handler_processing_time_ms"
 	messageHandlerSuccessCountMetricName   = "message_handler_success_count"
 	messageHandlerErrorCountMetricName     = "message_handler_error_count"
 )
 
 func HandlerMetrics(metricMeter metric.Meter, prefix string, log *slog.Logger) (func(message.HandlerFunc) message.HandlerFunc, error) {
-	messageProcessingTime, err := metricMeter.Float64Histogram(
+	messageProcessingTime, err := metricMeter.Int64Histogram(
 		fmt.Sprintf("%s.%s", prefix, messageHandlerProcessingTimeMetricName),
 		metric.WithDescription("Time spent by the handler processing a message"),
 	)
@@ -62,7 +62,7 @@ func HandlerMetrics(metricMeter metric.Meter, prefix string, log *slog.Logger) (
 				return resMsg, err
 			}
 
-			messageProcessingTime.Record(msg.Context(), time.Since(start).Seconds(), metric.WithAttributeSet(
+			messageProcessingTime.Record(msg.Context(), time.Since(start).Milliseconds(), metric.WithAttributeSet(
 				attrSet,
 			))
 			messageProcessed.Add(msg.Context(), 1, metric.WithAttributeSet(


### PR DESCRIPTION
## Overview

This patch improves the consistency/data available in consumer metrics. Changes:
- refactor: use int64 histograms (better for datadog, float64 ones are not working properly)
- refactor: add group handler metrics (So that we can report the skipped/ignored messages too.)
- refactor: unify router metrics (so that they are better aligned with the previous one)
- refactor: rename sarama metrics (Previously it was sarama.publisher.publisher / sarama.publisher.subscriber, now the redundant publisher part is dropped)
- refactor: use namespaces (e.g. watermill.router. for metrics, for easier debugging)
