### PR TITLE
feat(pagination): add helpers

### DIFF
--- a/pkg/pagination/pagination.go
+++ b/pkg/pagination/pagination.go
@@ -75,12 +75,23 @@ type PagedResponse[T any] struct {
 	Items      []T  `json:"items"`
 }
 
-func NewPagedResponseWith[OUT any, IN any](resp PagedResponse[IN], items []OUT) PagedResponse[OUT] {
+// NewPagedResponse creates a new PagedResponse with the given page, totalCount and items.
+func NewPagedResponseWith[OUT any, IN any](resp PagedResponse[IN], m func(in IN) (OUT, error)) (PagedResponse[OUT], error) {
+	items := make([]OUT, 0, len(resp.Items))
+	for _, inItem := range resp.Items {
+		item, err := m(inItem)
+		if err != nil {
+			return PagedResponse[OUT]{}, err
+		}
+
+		items = append(items, item)
+	}
+
 	return PagedResponse[OUT]{
 		Page:       resp.Page,
 		TotalCount: resp.TotalCount,
 		Items:      items,
-	}
+	}, nil
 }
 
 // Implement json.Marshaler interface to flatten the Page struct

--- a/pkg/pagination/pagination.go
+++ b/pkg/pagination/pagination.go
@@ -20,6 +20,31 @@ type Page struct {
 	PageNumber int `json:"page"`
 }
 
+// NewPage creates a new Page with the given pageNumber and pageSize.
+func NewPage(pageNumber int, pageSize int) Page {
+	return Page{
+		PageSize:   pageSize,
+		PageNumber: pageNumber,
+	}
+}
+
+// NewPageFromRef creates a new Page from pointers to pageNumber and pageSize.
+// Useful for handling query parameters.
+func NewPageFromRef(pageNumber *int, pageSize *int) Page {
+	pn := 0
+	ps := 0
+
+	if pageNumber != nil {
+		pn = *pageNumber
+	}
+
+	if pageSize != nil {
+		ps = *pageSize
+	}
+
+	return NewPage(pn, ps)
+}
+
 func (p Page) Offset() int {
 	return p.PageSize * (p.PageNumber - 1)
 }
@@ -48,6 +73,14 @@ type PagedResponse[T any] struct {
 	Page       Page `json:"-"`
 	TotalCount int  `json:"totalCount"`
 	Items      []T  `json:"items"`
+}
+
+func NewPagedResponseWith[OUT any, IN any](resp PagedResponse[IN], items []OUT) PagedResponse[OUT] {
+	return PagedResponse[OUT]{
+		Page:       resp.Page,
+		TotalCount: resp.TotalCount,
+		Items:      items,
+	}
 }
 
 // Implement json.Marshaler interface to flatten the Page struct


### PR DESCRIPTION
Add helpers to:

- Parse query params to `Page`
- Create `PagedResponse` from existing with transforming items type