### PR TITLE
fix: Kafka config defaults

### DIFF
--- a/config/kafka.go
+++ b/config/kafka.go
@@ -46,5 +46,25 @@ func (c KafkaConfig) Validate() error {
 
 // ConfigureKafkaConfiguration sets defaults in the Viper instance.
 func ConfigureKafkaConfiguration(v *viper.Viper, prefix string) {
+	// NOTE(chrisgacsal): make sure all the possible configuration parameters defaulted (even of the default is an empty string)
+	// otherwise Viper might not register/resolve them.
 	v.SetDefault(AddPrefix(prefix, "kafka.brokers"), "127.0.0.1:29092")
+	v.SetDefault(AddPrefix(prefix, "kafka.securityProtocol"), "")
+	v.SetDefault(AddPrefix(prefix, "kafka.saslMechanisms"), "")
+	v.SetDefault(AddPrefix(prefix, "kafka.saslUsername"), "")
+	v.SetDefault(AddPrefix(prefix, "kafka.saslPassword"), "")
+	v.SetDefault(AddPrefix(prefix, "kafka.statsInterval"), 0)
+	v.SetDefault(AddPrefix(prefix, "kafka.brokerAddressFamily"), "")
+	v.SetDefault(AddPrefix(prefix, "kafka.topicMetadataRefreshInterval"), 0)
+	v.SetDefault(AddPrefix(prefix, "kafka.socketKeepAliveEnabled"), false)
+	v.SetDefault(AddPrefix(prefix, "kafka.debugContexts"), nil)
+	v.SetDefault(AddPrefix(prefix, "kafka.clientID"), "")
+	v.SetDefault(AddPrefix(prefix, "kafka.consumerGroupID"), "")
+	v.SetDefault(AddPrefix(prefix, "kafka.consumerGroupInstanceID"), "")
+	v.SetDefault(AddPrefix(prefix, "kafka.sessionTimeout"), 0)
+	v.SetDefault(AddPrefix(prefix, "kafka.heartbeatInterval"), 0)
+	v.SetDefault(AddPrefix(prefix, "kafka.enableAutoCommit"), true)
+	v.SetDefault(AddPrefix(prefix, "kafka.enableAutoOffsetStore"), true)
+	v.SetDefault(AddPrefix(prefix, "kafka.autoOffsetReset"), "")
+	v.SetDefault(AddPrefix(prefix, "kafka.partitionAssignmentStrategy"), "cooperative-sticky")
 }

--- a/config/sink.go
+++ b/config/sink.go
@@ -93,7 +93,4 @@ func ConfigureSink(v *viper.Viper) {
 
 	// Override Kafka configuration defaults
 	v.SetDefault("sink.kafka.consumerGroupId", "openmeter-sink-worker")
-	v.SetDefault("sink.kafka.sessionTimeout", "3m")
-	// Guarantees an assignment that is maximally balanced while preserving as many existing partition assignments as possible.
-	v.SetDefault("sink.kafka.partitionAssignmentStrategy", "cooperative-sticky")
 }


### PR DESCRIPTION
## Overview

Make sure that all Kafka client config parameters are defaulted in order to make sure that Viper properly register/resolve them.
