### PR TITLE
fix: defaults for Kafka broker address family

### DIFF
--- a/config/kafka.go
+++ b/config/kafka.go
@@ -54,7 +54,7 @@ func ConfigureKafkaConfiguration(v *viper.Viper, prefix string) {
 	v.SetDefault(AddPrefix(prefix, "kafka.saslUsername"), "")
 	v.SetDefault(AddPrefix(prefix, "kafka.saslPassword"), "")
 	v.SetDefault(AddPrefix(prefix, "kafka.statsInterval"), 0)
-	v.SetDefault(AddPrefix(prefix, "kafka.brokerAddressFamily"), "")
+	v.SetDefault(AddPrefix(prefix, "kafka.brokerAddressFamily"), "any")
 	v.SetDefault(AddPrefix(prefix, "kafka.topicMetadataRefreshInterval"), 0)
 	v.SetDefault(AddPrefix(prefix, "kafka.socketKeepAliveEnabled"), false)
 	v.SetDefault(AddPrefix(prefix, "kafka.debugContexts"), nil)


### PR DESCRIPTION
## Overview

Fix default for broker address family configuration parameter.
