### PR TITLE
fix: quickstart

### DIFF
--- a/quickstart/README.md
+++ b/quickstart/README.md
@@ -38,7 +38,8 @@ curl -X POST http://localhost:8888/api/v1/events \
   "subject": "customer-1",
   "data": {
     "method": "GET",
-    "route": "/hello"
+    "route": "/hello",
+    "duration_ms": 10
   }
 }
 '
@@ -59,7 +60,8 @@ curl -X POST http://localhost:8888/api/v1/events \
   "subject": "customer-1",
   "data": {
     "method": "GET",
-    "route": "/hello"
+    "route": "/hello",
+    "duration_ms": 20
   }
 }
 '
@@ -80,7 +82,8 @@ curl -X POST http://localhost:8888/api/v1/events \
   "subject": "customer-1",
   "data": {
     "method": "GET",
-    "route": "/hello"
+    "route": "/hello",
+    "duration_ms": 30
   }
 }
 '


### PR DESCRIPTION
When multiple meters process the same event type, and one of them can't validate it, it'll be ignored by all meters. Consider using ClickHouse's `coalesce` in MVs: https://clickhouse.com/docs/en/sql-reference/aggregate-functions#null-processing