### PR TITLE
Add cursor pagination to internal streaming API

### DIFF
--- a/openmeter/server/router/event.go
+++ b/openmeter/server/router/event.go
@@ -69,18 +69,20 @@ func (a *Router) ListEvents(w http.ResponseWriter, r *http.Request, params api.L
 	}
 
 	queryParams := streaming.ListEventsParams{
-		From:           &from,
-		To:             params.To,
-		IngestedAtFrom: params.IngestedAtFrom,
-		IngestedAtTo:   params.IngestedAtTo,
-		ID:             params.Id,
-		Subject:        params.Subject,
-		HasError:       params.HasError,
-		Limit:          limit,
+		Filters: streaming.EventsTableFilters{
+			From:           &from,
+			To:             params.To,
+			IngestedAtFrom: params.IngestedAtFrom,
+			IngestedAtTo:   params.IngestedAtTo,
+			ID:             params.Id,
+			Subject:        params.Subject,
+			HasError:       params.HasError,
+		},
+		Limit: limit,
 	}
 
 	// Query events
-	events, err := a.config.StreamingConnector.ListEvents(ctx, namespace, queryParams)
+	events, _, err := a.config.StreamingConnector.ListEvents(ctx, namespace, queryParams)
 	if err != nil {
 		err := fmt.Errorf("query events: %w", err)
 

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -65,17 +65,23 @@ var (
 
 type MockStreamingConnector struct{}
 
+var _ streaming.Connector = &MockStreamingConnector{}
+
 func (c *MockStreamingConnector) CountEvents(ctx context.Context, namespace string, params streaming.CountEventsParams) ([]streaming.CountEventRow, error) {
 	return []streaming.CountEventRow{}, nil
 }
 
-func (c *MockStreamingConnector) ListEvents(ctx context.Context, namespace string, params streaming.ListEventsParams) ([]api.IngestedEvent, error) {
+func (c *MockStreamingConnector) ListEvents(ctx context.Context, namespace string, params streaming.ListEventsParams) ([]api.IngestedEvent, *streaming.EventsCursor, error) {
 	events := []api.IngestedEvent{
 		{
 			Event: mockEvent,
 		},
 	}
-	return events, nil
+	return events, nil, nil
+}
+
+func (c *MockStreamingConnector) PaginateEvents(ctx context.Context, namespace string, params streaming.PaginateEventsParams) ([]api.IngestedEvent, *streaming.EventsCursor, error) {
+	return []api.IngestedEvent{}, nil, nil
 }
 
 func (c *MockStreamingConnector) CreateMeter(ctx context.Context, namespace string, meter *models.Meter) error {

--- a/openmeter/streaming/clickhouse_connector/model.go
+++ b/openmeter/streaming/clickhouse_connector/model.go
@@ -1,9 +1,62 @@
 package clickhouse_connector
 
-import "github.com/openmeterio/openmeter/pkg/models"
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+
+	"github.com/openmeterio/openmeter/api"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
 
 type MeterView struct {
 	Slug        string
 	Aggregation models.MeterAggregation
 	GroupBy     []string
+}
+
+type ScannedEventRow struct {
+	id              string
+	eventType       string
+	subject         string
+	source          string
+	eventTime       time.Time
+	dataStr         string
+	validationError string
+	ingestedAt      time.Time
+	storedAt        time.Time
+}
+
+func parseEventRow(row ScannedEventRow) (api.IngestedEvent, error) {
+	var data interface{}
+	err := json.Unmarshal([]byte(row.dataStr), &data)
+	if err != nil {
+		return api.IngestedEvent{}, fmt.Errorf("query events parse data: %w", err)
+	}
+
+	event := event.New()
+	event.SetID(row.id)
+	event.SetType(row.eventType)
+	event.SetSubject(row.subject)
+	event.SetSource(row.source)
+	event.SetTime(row.eventTime)
+	err = event.SetData("application/json", data)
+	if err != nil {
+		return api.IngestedEvent{}, fmt.Errorf("query events set data: %w", err)
+	}
+
+	ingestedEvent := api.IngestedEvent{
+		Event: event,
+	}
+
+	if row.validationError != "" {
+		ingestedEvent.ValidationError = &row.validationError
+	}
+
+	ingestedEvent.IngestedAt = row.ingestedAt
+	ingestedEvent.StoredAt = row.storedAt
+
+	return ingestedEvent, nil
 }

--- a/openmeter/streaming/clickhouse_connector/query.go
+++ b/openmeter/streaming/clickhouse_connector/query.go
@@ -96,7 +96,7 @@ func (d queryEventsTable) toSQL() (string, []interface{}) {
 	}
 	query.Where(where...)
 
-	query.Desc().OrderBy("time")
+	query.Desc().OrderBy("time").OrderBy("id")
 	query.Limit(d.Limit)
 
 	sql, args := query.Build()

--- a/openmeter/streaming/clickhouse_connector/query_test.go
+++ b/openmeter/streaming/clickhouse_connector/query_test.go
@@ -48,7 +48,7 @@ func TestQueryEventsTable(t *testing.T) {
 				Namespace: "my_namespace",
 				Limit:     100,
 			},
-			wantSQL:  "SELECT id, type, subject, source, time, data, validation_error, ingested_at, stored_at FROM openmeter.om_events WHERE namespace = ? ORDER BY time DESC LIMIT 100",
+			wantSQL:  "SELECT id, type, subject, source, time, data, validation_error, ingested_at, stored_at FROM openmeter.om_events WHERE namespace = ? ORDER BY time, id DESC LIMIT 100",
 			wantArgs: []interface{}{"my_namespace"},
 		},
 		{
@@ -58,7 +58,7 @@ func TestQueryEventsTable(t *testing.T) {
 				Limit:     100,
 				Subject:   &subjectFilter,
 			},
-			wantSQL:  "SELECT id, type, subject, source, time, data, validation_error, ingested_at, stored_at FROM openmeter.om_events WHERE namespace = ? AND subject = ? ORDER BY time DESC LIMIT 100",
+			wantSQL:  "SELECT id, type, subject, source, time, data, validation_error, ingested_at, stored_at FROM openmeter.om_events WHERE namespace = ? AND subject = ? ORDER BY time, id DESC LIMIT 100",
 			wantArgs: []interface{}{"my_namespace", subjectFilter},
 		},
 		{
@@ -68,7 +68,7 @@ func TestQueryEventsTable(t *testing.T) {
 				Limit:     100,
 				ID:        &idFilter,
 			},
-			wantSQL:  "SELECT id, type, subject, source, time, data, validation_error, ingested_at, stored_at FROM openmeter.om_events WHERE namespace = ? AND id LIKE ? ORDER BY time DESC LIMIT 100",
+			wantSQL:  "SELECT id, type, subject, source, time, data, validation_error, ingested_at, stored_at FROM openmeter.om_events WHERE namespace = ? AND id LIKE ? ORDER BY time, id DESC LIMIT 100",
 			wantArgs: []interface{}{"my_namespace", "%event-id-1%"},
 		},
 		{
@@ -78,7 +78,7 @@ func TestQueryEventsTable(t *testing.T) {
 				Limit:     100,
 				HasError:  &hasErrorTrue,
 			},
-			wantSQL:  "SELECT id, type, subject, source, time, data, validation_error, ingested_at, stored_at FROM openmeter.om_events WHERE namespace = ? AND notEmpty(validation_error) = 1 ORDER BY time DESC LIMIT 100",
+			wantSQL:  "SELECT id, type, subject, source, time, data, validation_error, ingested_at, stored_at FROM openmeter.om_events WHERE namespace = ? AND notEmpty(validation_error) = 1 ORDER BY time, id DESC LIMIT 100",
 			wantArgs: []interface{}{"my_namespace"},
 		},
 		{
@@ -88,7 +88,7 @@ func TestQueryEventsTable(t *testing.T) {
 				Limit:     100,
 				HasError:  &hasErrorFalse,
 			},
-			wantSQL:  "SELECT id, type, subject, source, time, data, validation_error, ingested_at, stored_at FROM openmeter.om_events WHERE namespace = ? AND empty(validation_error) = 1 ORDER BY time DESC LIMIT 100",
+			wantSQL:  "SELECT id, type, subject, source, time, data, validation_error, ingested_at, stored_at FROM openmeter.om_events WHERE namespace = ? AND empty(validation_error) = 1 ORDER BY time, id DESC LIMIT 100",
 			wantArgs: []interface{}{"my_namespace"},
 		},
 	}

--- a/openmeter/streaming/connector.go
+++ b/openmeter/streaming/connector.go
@@ -8,17 +8,6 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-type ListEventsParams struct {
-	From           *time.Time
-	To             *time.Time
-	IngestedAtFrom *time.Time
-	IngestedAtTo   *time.Time
-	ID             *string
-	Subject        *string
-	HasError       *bool
-	Limit          int
-}
-
 type CountEventsParams struct {
 	From time.Time
 }
@@ -32,7 +21,8 @@ type CountEventRow struct {
 
 type Connector interface {
 	CountEvents(ctx context.Context, namespace string, params CountEventsParams) ([]CountEventRow, error)
-	ListEvents(ctx context.Context, namespace string, params ListEventsParams) ([]api.IngestedEvent, error)
+	ListEvents(ctx context.Context, namespace string, params ListEventsParams) ([]api.IngestedEvent, *EventsCursor, error)
+	PaginateEvents(ctx context.Context, namespace string, params PaginateEventsParams) ([]api.IngestedEvent, *EventsCursor, error)
 	CreateMeter(ctx context.Context, namespace string, meter *models.Meter) error
 	DeleteMeter(ctx context.Context, namespace string, meterSlug string) error
 	QueryMeter(ctx context.Context, namespace string, meterSlug string, params *QueryParams) ([]models.MeterQueryRow, error)

--- a/openmeter/streaming/events_params.go
+++ b/openmeter/streaming/events_params.go
@@ -1,0 +1,62 @@
+package streaming
+
+import (
+	"fmt"
+	"time"
+)
+
+type EventsTableFilters struct {
+	From           *time.Time
+	To             *time.Time
+	IngestedAtFrom *time.Time
+	IngestedAtTo   *time.Time
+	ID             *string
+	Subject        *string
+	HasError       *bool
+}
+
+// EventsTableCursor contains all properties by which the events table is ordered deterministically.
+type EventsTableCursor struct {
+	Namespace string
+	Time      time.Time
+	Type      string
+	Subject   string
+	ID        string
+
+	IsGreater bool
+}
+
+func (c EventsTableCursor) Validate() error {
+	if c.Namespace == "" {
+		return fmt.Errorf("All properties are required")
+	}
+	if c.Time.IsZero() {
+		return fmt.Errorf("All properties are required")
+	}
+	if c.Type == "" {
+		return fmt.Errorf("All properties are required")
+	}
+	if c.Subject == "" {
+		return fmt.Errorf("All properties are required")
+	}
+	if c.ID == "" {
+		return fmt.Errorf("All properties are required")
+	}
+
+	return nil
+}
+
+type EventsCursor struct {
+	Cursor  EventsTableCursor
+	Filters EventsTableFilters
+}
+
+type ListEventsParams struct {
+	Filters EventsTableFilters
+	Limit   int
+}
+
+type PaginateEventsParams struct {
+	Cursor EventsCursor
+	Limit  int
+}

--- a/openmeter/streaming/testutils/streaming.go
+++ b/openmeter/streaming/testutils/streaming.go
@@ -30,6 +30,8 @@ type MockStreamingConnector struct {
 	events map[string][]SimpleEvent
 }
 
+var _ streaming.Connector = &MockStreamingConnector{}
+
 func (m *MockStreamingConnector) AddSimpleEvent(meterSlug string, value float64, at time.Time) {
 	m.events[meterSlug] = append(m.events[meterSlug], SimpleEvent{
 		MeterSlug: meterSlug,
@@ -53,8 +55,12 @@ func (m *MockStreamingConnector) CountEvents(ctx context.Context, namespace stri
 	return []streaming.CountEventRow{}, nil
 }
 
-func (m *MockStreamingConnector) ListEvents(ctx context.Context, namespace string, params streaming.ListEventsParams) ([]api.IngestedEvent, error) {
-	return []api.IngestedEvent{}, nil
+func (m *MockStreamingConnector) ListEvents(ctx context.Context, namespace string, params streaming.ListEventsParams) ([]api.IngestedEvent, *streaming.EventsCursor, error) {
+	return []api.IngestedEvent{}, nil, nil
+}
+
+func (m *MockStreamingConnector) PaginateEvents(ctx context.Context, namespace string, params streaming.PaginateEventsParams) ([]api.IngestedEvent, *streaming.EventsCursor, error) {
+	return []api.IngestedEvent{}, nil, nil
 }
 
 func (m *MockStreamingConnector) CreateMeter(ctx context.Context, namespace string, meter *models.Meter) error {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->
Relates to Issue #1527 

## Overview

Adds cursor based pagination to the internal streaming API. Unfortunately this requires a change in the main `events` table, we'd have to change the ordering in the table definition for reasonable query performance (`id` is used as the tie-breaker which previously wasn't present in the index)

## Notes for reviewer

- Its currently unclear how to expose this through the external API, should we do a V2 API for this, etc... I'd treat that as a separate effort, this is just the ground-work for that.
- To emphasize again, changing the table ordering is a significant issue, we need to measure the impact

<!-- Anything the reviewer should know? -->
