### PR TITLE
fix: mixin indexing tweaks

### DIFF
--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -102,7 +102,7 @@ var (
 		Indexes: []*schema.Index{
 			{
 				Name:    "billinginvoice_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{BillingInvoicesColumns[0]},
 			},
 			{
@@ -171,7 +171,7 @@ var (
 		Indexes: []*schema.Index{
 			{
 				Name:    "billinginvoiceitem_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{BillingInvoiceItemsColumns[0]},
 			},
 			{
@@ -224,7 +224,7 @@ var (
 		Indexes: []*schema.Index{
 			{
 				Name:    "billingprofile_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{BillingProfilesColumns[0]},
 			},
 			{
@@ -273,7 +273,7 @@ var (
 		Indexes: []*schema.Index{
 			{
 				Name:    "billingworkflowconfig_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{BillingWorkflowConfigsColumns[0]},
 			},
 			{
@@ -321,7 +321,7 @@ var (
 		Indexes: []*schema.Index{
 			{
 				Name:    "customer_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{CustomersColumns[0]},
 			},
 			{
@@ -331,13 +331,13 @@ var (
 			},
 			{
 				Name:    "customer_namespace_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{CustomersColumns[2], CustomersColumns[0]},
 			},
 			{
-				Name:    "customer_namespace_key",
+				Name:    "customer_namespace_key_deleted_at",
 				Unique:  true,
-				Columns: []*schema.Column{CustomersColumns[2], CustomersColumns[1]},
+				Columns: []*schema.Column{CustomersColumns[2], CustomersColumns[1], CustomersColumns[6]},
 			},
 		},
 	}
@@ -408,7 +408,7 @@ var (
 		Indexes: []*schema.Index{
 			{
 				Name:    "entitlement_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{EntitlementsColumns[0]},
 			},
 			{
@@ -470,7 +470,7 @@ var (
 		Indexes: []*schema.Index{
 			{
 				Name:    "feature_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{FeaturesColumns[0]},
 			},
 			{
@@ -516,7 +516,7 @@ var (
 		Indexes: []*schema.Index{
 			{
 				Name:    "grant_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{GrantsColumns[0]},
 			},
 			{
@@ -556,7 +556,7 @@ var (
 		Indexes: []*schema.Index{
 			{
 				Name:    "notificationchannel_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{NotificationChannelsColumns[0]},
 			},
 			{
@@ -602,7 +602,7 @@ var (
 		Indexes: []*schema.Index{
 			{
 				Name:    "notificationevent_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{NotificationEventsColumns[0]},
 			},
 			{
@@ -651,7 +651,7 @@ var (
 		Indexes: []*schema.Index{
 			{
 				Name:    "notificationeventdeliverystatus_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{NotificationEventDeliveryStatusColumns[0]},
 			},
 			{
@@ -696,7 +696,7 @@ var (
 		Indexes: []*schema.Index{
 			{
 				Name:    "notificationrule_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{NotificationRulesColumns[0]},
 			},
 			{
@@ -742,7 +742,7 @@ var (
 		Indexes: []*schema.Index{
 			{
 				Name:    "usagereset_id",
-				Unique:  false,
+				Unique:  true,
 				Columns: []*schema.Column{UsageResetsColumns[0]},
 			},
 			{

--- a/tools/migrate/migrations/20240920070940_indexing-fixes.down.sql
+++ b/tools/migrate/migrations/20240920070940_indexing-fixes.down.sql
@@ -1,0 +1,60 @@
+-- reverse: create index "usagereset_id" to table: "usage_resets"
+DROP INDEX "usagereset_id";
+-- reverse: drop index "usagereset_id" from table: "usage_resets"
+CREATE INDEX "usagereset_id" ON "usage_resets" ("id");
+-- reverse: create index "notificationrule_id" to table: "notification_rules"
+DROP INDEX "notificationrule_id";
+-- reverse: drop index "notificationrule_id" from table: "notification_rules"
+CREATE INDEX "notificationrule_id" ON "notification_rules" ("id");
+-- reverse: create index "notificationevent_id" to table: "notification_events"
+DROP INDEX "notificationevent_id";
+-- reverse: drop index "notificationevent_id" from table: "notification_events"
+CREATE INDEX "notificationevent_id" ON "notification_events" ("id");
+-- reverse: create index "notificationeventdeliverystatus_id" to table: "notification_event_delivery_status"
+DROP INDEX "notificationeventdeliverystatus_id";
+-- reverse: drop index "notificationeventdeliverystatus_id" from table: "notification_event_delivery_status"
+CREATE INDEX "notificationeventdeliverystatus_id" ON "notification_event_delivery_status" ("id");
+-- reverse: create index "notificationchannel_id" to table: "notification_channels"
+DROP INDEX "notificationchannel_id";
+-- reverse: drop index "notificationchannel_id" from table: "notification_channels"
+CREATE INDEX "notificationchannel_id" ON "notification_channels" ("id");
+-- reverse: create index "grant_id" to table: "grants"
+DROP INDEX "grant_id";
+-- reverse: drop index "grant_id" from table: "grants"
+CREATE INDEX "grant_id" ON "grants" ("id");
+-- reverse: create index "feature_id" to table: "features"
+DROP INDEX "feature_id";
+-- reverse: drop index "feature_id" from table: "features"
+CREATE INDEX "feature_id" ON "features" ("id");
+-- reverse: create index "entitlement_id" to table: "entitlements"
+DROP INDEX "entitlement_id";
+-- reverse: drop index "entitlement_id" from table: "entitlements"
+CREATE INDEX "entitlement_id" ON "entitlements" ("id");
+-- reverse: create index "customer_namespace_key_deleted_at" to table: "customers"
+DROP INDEX "customer_namespace_key_deleted_at";
+-- reverse: create index "customer_namespace_id" to table: "customers"
+DROP INDEX "customer_namespace_id";
+-- reverse: create index "customer_id" to table: "customers"
+DROP INDEX "customer_id";
+-- reverse: drop index "customer_namespace_key" from table: "customers"
+CREATE UNIQUE INDEX "customer_namespace_key" ON "customers" ("namespace", "key");
+-- reverse: drop index "customer_namespace_id" from table: "customers"
+CREATE INDEX "customer_namespace_id" ON "customers" ("namespace", "id");
+-- reverse: drop index "customer_id" from table: "customers"
+CREATE INDEX "customer_id" ON "customers" ("id");
+-- reverse: create index "billingworkflowconfig_id" to table: "billing_workflow_configs"
+DROP INDEX "billingworkflowconfig_id";
+-- reverse: drop index "billingworkflowconfig_id" from table: "billing_workflow_configs"
+CREATE INDEX "billingworkflowconfig_id" ON "billing_workflow_configs" ("id");
+-- reverse: create index "billingprofile_id" to table: "billing_profiles"
+DROP INDEX "billingprofile_id";
+-- reverse: drop index "billingprofile_id" from table: "billing_profiles"
+CREATE INDEX "billingprofile_id" ON "billing_profiles" ("id");
+-- reverse: create index "billinginvoice_id" to table: "billing_invoices"
+DROP INDEX "billinginvoice_id";
+-- reverse: drop index "billinginvoice_id" from table: "billing_invoices"
+CREATE INDEX "billinginvoice_id" ON "billing_invoices" ("id");
+-- reverse: create index "billinginvoiceitem_id" to table: "billing_invoice_items"
+DROP INDEX "billinginvoiceitem_id";
+-- reverse: drop index "billinginvoiceitem_id" from table: "billing_invoice_items"
+CREATE INDEX "billinginvoiceitem_id" ON "billing_invoice_items" ("id");

--- a/tools/migrate/migrations/20240920070940_indexing-fixes.down.sql
+++ b/tools/migrate/migrations/20240920070940_indexing-fixes.down.sql
@@ -1,3 +1,4 @@
+-- atlas:nolint MF101
 -- reverse: create index "usagereset_id" to table: "usage_resets"
 DROP INDEX "usagereset_id";
 -- reverse: drop index "usagereset_id" from table: "usage_resets"

--- a/tools/migrate/migrations/20240920070940_indexing-fixes.up.sql
+++ b/tools/migrate/migrations/20240920070940_indexing-fixes.up.sql
@@ -1,18 +1,23 @@
+
 -- drop index "billinginvoiceitem_id" from table: "billing_invoice_items"
 DROP INDEX "billinginvoiceitem_id";
 -- create index "billinginvoiceitem_id" to table: "billing_invoice_items"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "billinginvoiceitem_id" ON "billing_invoice_items" ("id");
 -- drop index "billinginvoice_id" from table: "billing_invoices"
 DROP INDEX "billinginvoice_id";
 -- create index "billinginvoice_id" to table: "billing_invoices"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "billinginvoice_id" ON "billing_invoices" ("id");
 -- drop index "billingprofile_id" from table: "billing_profiles"
 DROP INDEX "billingprofile_id";
 -- create index "billingprofile_id" to table: "billing_profiles"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "billingprofile_id" ON "billing_profiles" ("id");
 -- drop index "billingworkflowconfig_id" from table: "billing_workflow_configs"
 DROP INDEX "billingworkflowconfig_id";
 -- create index "billingworkflowconfig_id" to table: "billing_workflow_configs"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "billingworkflowconfig_id" ON "billing_workflow_configs" ("id");
 -- drop index "customer_id" from table: "customers"
 DROP INDEX "customer_id";
@@ -21,40 +26,51 @@ DROP INDEX "customer_namespace_id";
 -- drop index "customer_namespace_key" from table: "customers"
 DROP INDEX "customer_namespace_key";
 -- create index "customer_id" to table: "customers"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "customer_id" ON "customers" ("id");
 -- create index "customer_namespace_id" to table: "customers"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "customer_namespace_id" ON "customers" ("namespace", "id");
 -- create index "customer_namespace_key_deleted_at" to table: "customers"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "customer_namespace_key_deleted_at" ON "customers" ("namespace", "key", "deleted_at");
 -- drop index "entitlement_id" from table: "entitlements"
 DROP INDEX "entitlement_id";
 -- create index "entitlement_id" to table: "entitlements"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "entitlement_id" ON "entitlements" ("id");
 -- drop index "feature_id" from table: "features"
 DROP INDEX "feature_id";
 -- create index "feature_id" to table: "features"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "feature_id" ON "features" ("id");
 -- drop index "grant_id" from table: "grants"
 DROP INDEX "grant_id";
 -- create index "grant_id" to table: "grants"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "grant_id" ON "grants" ("id");
 -- drop index "notificationchannel_id" from table: "notification_channels"
 DROP INDEX "notificationchannel_id";
 -- create index "notificationchannel_id" to table: "notification_channels"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "notificationchannel_id" ON "notification_channels" ("id");
 -- drop index "notificationeventdeliverystatus_id" from table: "notification_event_delivery_status"
 DROP INDEX "notificationeventdeliverystatus_id";
 -- create index "notificationeventdeliverystatus_id" to table: "notification_event_delivery_status"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "notificationeventdeliverystatus_id" ON "notification_event_delivery_status" ("id");
 -- drop index "notificationevent_id" from table: "notification_events"
 DROP INDEX "notificationevent_id";
 -- create index "notificationevent_id" to table: "notification_events"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "notificationevent_id" ON "notification_events" ("id");
 -- drop index "notificationrule_id" from table: "notification_rules"
 DROP INDEX "notificationrule_id";
 -- create index "notificationrule_id" to table: "notification_rules"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "notificationrule_id" ON "notification_rules" ("id");
 -- drop index "usagereset_id" from table: "usage_resets"
 DROP INDEX "usagereset_id";
 -- create index "usagereset_id" to table: "usage_resets"
+-- atlas:nolint MF101
 CREATE UNIQUE INDEX "usagereset_id" ON "usage_resets" ("id");

--- a/tools/migrate/migrations/20240920070940_indexing-fixes.up.sql
+++ b/tools/migrate/migrations/20240920070940_indexing-fixes.up.sql
@@ -1,0 +1,60 @@
+-- drop index "billinginvoiceitem_id" from table: "billing_invoice_items"
+DROP INDEX "billinginvoiceitem_id";
+-- create index "billinginvoiceitem_id" to table: "billing_invoice_items"
+CREATE UNIQUE INDEX "billinginvoiceitem_id" ON "billing_invoice_items" ("id");
+-- drop index "billinginvoice_id" from table: "billing_invoices"
+DROP INDEX "billinginvoice_id";
+-- create index "billinginvoice_id" to table: "billing_invoices"
+CREATE UNIQUE INDEX "billinginvoice_id" ON "billing_invoices" ("id");
+-- drop index "billingprofile_id" from table: "billing_profiles"
+DROP INDEX "billingprofile_id";
+-- create index "billingprofile_id" to table: "billing_profiles"
+CREATE UNIQUE INDEX "billingprofile_id" ON "billing_profiles" ("id");
+-- drop index "billingworkflowconfig_id" from table: "billing_workflow_configs"
+DROP INDEX "billingworkflowconfig_id";
+-- create index "billingworkflowconfig_id" to table: "billing_workflow_configs"
+CREATE UNIQUE INDEX "billingworkflowconfig_id" ON "billing_workflow_configs" ("id");
+-- drop index "customer_id" from table: "customers"
+DROP INDEX "customer_id";
+-- drop index "customer_namespace_id" from table: "customers"
+DROP INDEX "customer_namespace_id";
+-- drop index "customer_namespace_key" from table: "customers"
+DROP INDEX "customer_namespace_key";
+-- create index "customer_id" to table: "customers"
+CREATE UNIQUE INDEX "customer_id" ON "customers" ("id");
+-- create index "customer_namespace_id" to table: "customers"
+CREATE UNIQUE INDEX "customer_namespace_id" ON "customers" ("namespace", "id");
+-- create index "customer_namespace_key_deleted_at" to table: "customers"
+CREATE UNIQUE INDEX "customer_namespace_key_deleted_at" ON "customers" ("namespace", "key", "deleted_at");
+-- drop index "entitlement_id" from table: "entitlements"
+DROP INDEX "entitlement_id";
+-- create index "entitlement_id" to table: "entitlements"
+CREATE UNIQUE INDEX "entitlement_id" ON "entitlements" ("id");
+-- drop index "feature_id" from table: "features"
+DROP INDEX "feature_id";
+-- create index "feature_id" to table: "features"
+CREATE UNIQUE INDEX "feature_id" ON "features" ("id");
+-- drop index "grant_id" from table: "grants"
+DROP INDEX "grant_id";
+-- create index "grant_id" to table: "grants"
+CREATE UNIQUE INDEX "grant_id" ON "grants" ("id");
+-- drop index "notificationchannel_id" from table: "notification_channels"
+DROP INDEX "notificationchannel_id";
+-- create index "notificationchannel_id" to table: "notification_channels"
+CREATE UNIQUE INDEX "notificationchannel_id" ON "notification_channels" ("id");
+-- drop index "notificationeventdeliverystatus_id" from table: "notification_event_delivery_status"
+DROP INDEX "notificationeventdeliverystatus_id";
+-- create index "notificationeventdeliverystatus_id" to table: "notification_event_delivery_status"
+CREATE UNIQUE INDEX "notificationeventdeliverystatus_id" ON "notification_event_delivery_status" ("id");
+-- drop index "notificationevent_id" from table: "notification_events"
+DROP INDEX "notificationevent_id";
+-- create index "notificationevent_id" to table: "notification_events"
+CREATE UNIQUE INDEX "notificationevent_id" ON "notification_events" ("id");
+-- drop index "notificationrule_id" from table: "notification_rules"
+DROP INDEX "notificationrule_id";
+-- create index "notificationrule_id" to table: "notification_rules"
+CREATE UNIQUE INDEX "notificationrule_id" ON "notification_rules" ("id");
+-- drop index "usagereset_id" from table: "usage_resets"
+DROP INDEX "usagereset_id";
+-- create index "usagereset_id" to table: "usage_resets"
+CREATE UNIQUE INDEX "usagereset_id" ON "usage_resets" ("id");

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:SAhlNZw5SuCJAs1BJuSSUlyd+3uEzAEm6pqpPSKioQA=
+h1:xsZpOJs6jnPPXtbUTxid8GPAZlJGCfc2ub2ZxVr457M=
 20240826120919_init.down.sql h1:AIbgwwngjkJEYa3yRZsIXQyBa2+qoZttwMXHxXEbHLI=
 20240826120919_init.up.sql h1:/hYHWF3Z3dab8SMKnw99ixVktCuJe2bAw5wstCZIEN8=
 20240903155435_entitlement-expired-index.down.sql h1:np2xgYs3KQ2z7qPBcobtGNhqWQ3V8NwEP9E5U3TmpSA=
@@ -9,5 +9,5 @@ h1:SAhlNZw5SuCJAs1BJuSSUlyd+3uEzAEm6pqpPSKioQA=
 20240918204720_customer.up.sql h1:o1giScZ2bR9qOF1CSkno+n9rhHFlX/g5nenMRUukeDI=
 20240919144910_customer-timezone.down.sql h1:YHTwr/Xw3Wm7lwDIBX16UQD8wp01nGTixmhkGhCN/IA=
 20240919144910_customer-timezone.up.sql h1:l/L/85zsacSORnsgUdBSOjzQvf0L91byK2wh4Dz6eCI=
-20240920070940_indexing-fixes.down.sql h1:rpRnjrLEF50atNeMfc7VMxRjJSEynQqBlst/GnpN55w=
-20240920070940_indexing-fixes.up.sql h1:w+8fyqMOuD2pJJ8ZgfhwR2+MsquC95cffJDflIAg+XE=
+20240920070940_indexing-fixes.down.sql h1:IhKm+adPcfd7XOWYmFurnMpWCSSkWTosCs/aYstpvgc=
+20240920070940_indexing-fixes.up.sql h1:ne1XfTKACTk02BAJhxLWb/xFLLI/UWYWEyn17nDHaKQ=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Q39HMkhoasOPr9RITsZnepk+F+pGZoK1zucBSM/XD+4=
+h1:SAhlNZw5SuCJAs1BJuSSUlyd+3uEzAEm6pqpPSKioQA=
 20240826120919_init.down.sql h1:AIbgwwngjkJEYa3yRZsIXQyBa2+qoZttwMXHxXEbHLI=
 20240826120919_init.up.sql h1:/hYHWF3Z3dab8SMKnw99ixVktCuJe2bAw5wstCZIEN8=
 20240903155435_entitlement-expired-index.down.sql h1:np2xgYs3KQ2z7qPBcobtGNhqWQ3V8NwEP9E5U3TmpSA=
@@ -9,3 +9,5 @@ h1:Q39HMkhoasOPr9RITsZnepk+F+pGZoK1zucBSM/XD+4=
 20240918204720_customer.up.sql h1:o1giScZ2bR9qOF1CSkno+n9rhHFlX/g5nenMRUukeDI=
 20240919144910_customer-timezone.down.sql h1:YHTwr/Xw3Wm7lwDIBX16UQD8wp01nGTixmhkGhCN/IA=
 20240919144910_customer-timezone.up.sql h1:l/L/85zsacSORnsgUdBSOjzQvf0L91byK2wh4Dz6eCI=
+20240920070940_indexing-fixes.down.sql h1:rpRnjrLEF50atNeMfc7VMxRjJSEynQqBlst/GnpN55w=
+20240920070940_indexing-fixes.up.sql h1:w+8fyqMOuD2pJJ8ZgfhwR2+MsquC95cffJDflIAg+XE=


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch addresses two issues:
- The ID index must be unique (it's an ULID so there's an astronomically small chance for collusion)
- The ResourceMixin is a soft-delete resource, so the key must be unique for non-deleted items only.

For this migration we disable [MF101](https://atlasgo.io/lint/analyzers#MF101), which checks for adding a unique index to existing columns.
