### PR TITLE
refactor: helper for provisioning Kafka topics

### DIFF
--- a/openmeter/ingest/kafkaingest/namespace.go
+++ b/openmeter/ingest/kafkaingest/namespace.go
@@ -25,8 +25,17 @@ type NamespaceHandler struct {
 
 // CreateNamespace implements the namespace handler interface.
 func (h NamespaceHandler) CreateNamespace(ctx context.Context, namespace string) error {
-	topic := h.getTopicName(namespace)
-	return pkgkafka.ProvisionTopic(ctx, h.AdminClient, h.Logger, topic, h.Partitions)
+	topicName := h.getTopicName(namespace)
+
+	err := pkgkafka.ProvisionTopics(ctx, h.AdminClient, pkgkafka.TopicConfig{
+		Name:       h.getTopicName(namespace),
+		Partitions: h.Partitions,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to provision topic %s: %s", topicName, err)
+	}
+
+	return nil
 }
 
 // DeleteNamespace implements the namespace handler interface.

--- a/openmeter/watermill/driver/kafka/topic_provision.go
+++ b/openmeter/watermill/driver/kafka/topic_provision.go
@@ -17,6 +17,7 @@ type AutoProvisionTopic struct {
 
 // provisionTopics creates the topics if they don't exist. This relies on the confluent kafka lib, as the sarama doesn't seem to
 // properly support interacting with the confluent cloud.
+// FIXME(chrisgacsal): use kafka.ProvisionTopics() from openmeter/pkg/kafka
 func provisionTopics(ctx context.Context, logger *slog.Logger, config kafka.ConfigMap, topics []AutoProvisionTopic) error {
 	// This is not supported on admin client, so we need to remove it
 	delete(config, "go.logs.channel.enable")

--- a/pkg/kafka/provisiontopic.go
+++ b/pkg/kafka/provisiontopic.go
@@ -2,30 +2,75 @@ package kafka
 
 import (
 	"context"
-	"log/slog"
+	"errors"
+	"fmt"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 )
 
-func ProvisionTopic(ctx context.Context, adminClient *kafka.AdminClient, logger *slog.Logger, topic string, partitions int) error {
-	result, err := adminClient.CreateTopics(ctx, []kafka.TopicSpecification{
-		{
-			Topic:         topic,
-			NumPartitions: partitions,
-		},
-	})
-	if err != nil {
-		return err
+type TopicConfig struct {
+	Name          string
+	Partitions    int
+	Replicas      int
+	RetentionTime TimeDurationMilliSeconds
+}
+
+func (c TopicConfig) Validate() error {
+	if c.Name == "" {
+		return errors.New("topic name must not be empty")
 	}
 
-	for _, r := range result {
-		code := r.Error.Code()
+	if c.Partitions <= 0 {
+		return errors.New("number of partitions must be greater than zero")
+	}
 
-		if code == kafka.ErrTopicAlreadyExists {
-			logger.Debug("topic already exists", slog.String("topic", topic))
-		} else if code != kafka.ErrNoError {
-			return r.Error
+	return nil
+}
+
+func ProvisionTopics(ctx context.Context, client *kafka.AdminClient, topics ...TopicConfig) error {
+	if len(topics) == 0 {
+		return nil
+	}
+
+	topicSpecs := make([]kafka.TopicSpecification, 0, len(topics))
+
+	for _, topic := range topics {
+		if err := topic.Validate(); err != nil {
+			return fmt.Errorf("invalid topic configuration: %w", err)
 		}
+
+		topicSpec := kafka.TopicSpecification{
+			Topic:         topic.Name,
+			NumPartitions: topic.Partitions,
+		}
+
+		if topic.Replicas > 0 {
+			topicSpec.ReplicationFactor = topic.Replicas
+		}
+
+		if topic.RetentionTime > 0 {
+			topicSpec.Config["retention.ms"] = topic.RetentionTime.String()
+		}
+
+		topicSpecs = append(topicSpecs, topicSpec)
+	}
+
+	results, err := client.CreateTopics(ctx, topicSpecs)
+	if err != nil {
+		return fmt.Errorf("failed to create topics: %w", err)
+	}
+
+	var errs []error
+	for _, result := range results {
+		switch result.Error.Code() {
+		case kafka.ErrNoError, kafka.ErrTopicAlreadyExists:
+		default:
+			errs = append(errs, fmt.Errorf("failed to create topic: %w", result.Error))
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
 	}
 
 	return nil


### PR DESCRIPTION
## Overview

Refactor helper used for provisioning Kafka topics to allow additional topic configuration.
Followeup PR will be created to consolidate implementations.
