### PR TITLE
refactor(api): Notification API in TypeSepc

### DIFF
--- a/api/spec/src/notification/channel.tsp
+++ b/api/spec/src/notification/channel.tsp
@@ -210,8 +210,8 @@ interface Channels {
    * Update notification channel.
    */
   @put
-  @operationId("createNotificationChannel")
-  @summary("Create a notification channel")
+  @operationId("updateNotificationChannel")
+  @summary("Update a notification channel")
   update(@body request: ChannelCreateRequest): {
     @statusCode _: 200;
     @body body: Channel;

--- a/api/spec/src/notification/channel.tsp
+++ b/api/spec/src/notification/channel.tsp
@@ -154,6 +154,15 @@ enum ChannelOrderBy {
   updatedAt: "updatedAt",
 }
 
+// NOTE(chrisgacsal): this is a workaround of using the model OpenMeter.PaginatedResponse<Rule>
+// results a firendlyName RulePaginatedResponse instead of NotificationRulePaginatedResponse which
+// seems to be a bug in typespec. This way we can override the friendlyName of the paginated response.
+/**
+ * Paginated response for listing notification channels.
+ */
+@friendlyName("NotificationChannelsPaginatedResponse")
+model ChannelsPaginatedResponse is OpenMeter.PaginatedResponse<Channel>;
+
 @route("/api/v1/notification/channels")
 @tag("Notification (Experimental)")
 interface Channels {
@@ -184,7 +193,7 @@ interface Channels {
 
     ...OpenMeter.QueryPagination,
     ...OpenMeter.QueryOrdering<ChannelOrderBy>,
-  ): OpenMeter.PaginatedResponse<Channel> | OpenMeter.CommonErrors;
+  ): ChannelsPaginatedResponse | OpenMeter.CommonErrors;
 
   /**
    * Create a new notification channel.

--- a/api/spec/src/notification/channel.tsp
+++ b/api/spec/src/notification/channel.tsp
@@ -25,7 +25,7 @@ model ChannelMeta {
   /**
    * Identifies the notification channel.
    */
-  // @visibility("read")
+  @visibility("read")
   @summary("Channel Unique Identifier")
   @example("01ARZ3NDEKTSV4RRFFQ69G5FAV")
   id: ULID;
@@ -33,7 +33,7 @@ model ChannelMeta {
   /**
    * Notification channel type.
    */
-  // @visibility("read")
+  @visibility("read")
   @summary("Channel Type")
   type: ChannelType;
 }
@@ -44,26 +44,19 @@ model ChannelMeta {
 @friendlyName("NotificationChannelCommon")
 model ChannelCommon<T extends ChannelType> {
   ...ResourceTimestamps;
-
-  /**
-   * Identifies the notification channel.
-   */
-  // @visibility("read")
-  @summary("Channel Unique Identifier")
-  @example("01ARZ3NDEKTSV4RRFFQ69G5FAV")
-  id: ULID;
+  ...OmitProperties<ChannelMeta, "type">;
 
   /**
    * Notification channel type.
    */
-  // @visibility("read", "create", "query")
+  @visibility("read", "create")
   @summary("Channel Type")
   type: T;
 
   /**
    * User friendly name of the channel.
    */
-  // @visibility("read", "create", "query", "update")
+  @visibility("read", "create", "update")
   @summary("Channel Name")
   @example("customer-webhook")
   name: string;
@@ -71,7 +64,7 @@ model ChannelCommon<T extends ChannelType> {
   /**
    * Whether the channel is disabled or not.
    */
-  // @visibility("read", "create", "query", "update")
+  @visibility("read", "create", "update")
   @summary("Channel Disabled")
   @example(true)
   disabled?: boolean = false;
@@ -87,7 +80,7 @@ model ChannelWebhook {
   /**
    * Webhook URL where the notification is sent.
    */
-  // @visibility("read", "create", "query", "update")
+  @visibility("read", "create", "update")
   @summary("Webhook URL")
   @example("https://example.com/webhook")
   url: string;
@@ -95,7 +88,7 @@ model ChannelWebhook {
   /**
    * Custom HTTP headers sent as part of the webhook request.
    */
-  // @visibility("read", "create", "query", "update")
+  @visibility("read", "create", "update")
   @summary("Custom HTTP Headers")
   customHeaders?: Record<string>;
 
@@ -104,7 +97,7 @@ model ChannelWebhook {
    *
    * Format: `base64` encoded random bytes optionally prefixed with `whsec_`. Recommended size: 24
    */
-  // @visibility("read", "create", "query", "update")
+  @visibility("read", "create", "update")
   @summary("Signing Secret")
   @pattern("^(whsec_)?[a-zA-Z0-9+/=]{32,100}$")
   @example("whsec_S6g2HLnTwd9AhHwUIMFggVS9OfoPafN8")
@@ -128,15 +121,7 @@ union Channel {
 @discriminator("type")
 @oneOf
 union ChannelCreateRequest {
-  webhook: ChannelWebhookCreateRequest,
-}
-
-/**
- * Request with input parameters for creating new notification channel with webhook type.
- */
-@friendlyName("NotificationChannelWebhookCreateRequest")
-model ChannelWebhookCreateRequest{
-  ...OmitProperties<ChannelWebhook, "id" | "createdAt" | "updatedAt" | "deletedAt">;
+  webhook: ChannelWebhook,
 }
 
 /**

--- a/api/spec/src/notification/event.tsp
+++ b/api/spec/src/notification/event.tsp
@@ -25,6 +25,7 @@ model DeliveryStatus {
   /**
    * Delivery state of the notification event to the channel.
    */
+  @visibility("read")
   @summary("Delivery State")
   @example("SUCCESS")
   state: "SUCCESS" | "FAILED" | "SENDING" | "PENDING";
@@ -32,6 +33,7 @@ model DeliveryStatus {
   /**
    * The reason of the last deliverry state update.
    */
+  @visibility("read")
   @summary("State Reason")
   @example("Failed to dispatch event due to provider error.")
   reason: string;
@@ -39,6 +41,7 @@ model DeliveryStatus {
   /**
    * Timestamp of when the status was last updated in RFC 3339 format.
    */
+  @visibility("read")
   @summary("Last Update Time")
   @example(DateTime.fromISO("2023-01-01T01:01:01.001Z"))
   updatedAt: DateTime;
@@ -62,6 +65,7 @@ model EventBalanceThresholdPayload {
   /**
    * A unique identifier for the notification event the payload belongs to.
    */
+  @visibility("read")
   @summary("Notification Event Identifier")
   @example("01J2KNP1YTXQRXHTDJ4KPR7PZ0")
   id: ULID;
@@ -69,12 +73,14 @@ model EventBalanceThresholdPayload {
   /**
    * Type of the notification event.
    */
+  @visibility("read")
   @summary("Notification Event Type")
   type: EventType.entitlementsBalanceThreshold;
 
   /**
    * Timestamp when the notification event was created in RFC 3339 format.
    */
+  @visibility("read")
   @summary("Creation Time")
   @example(DateTime.fromISO("2023-01-01T01:01:01.001Z"))
   timestamp: DateTime;
@@ -82,6 +88,7 @@ model EventBalanceThresholdPayload {
   /**
    * The data of the payload.
    */
+  @visibility("read")
   @summary("Payload Data")
   data: EventBalanceThresholdPayloadData;
 }
@@ -91,18 +98,23 @@ model EventBalanceThresholdPayload {
  */
 @friendlyName("NotificationEventBalanceThresholdPayloadData")
 model EventBalanceThresholdPayloadData {
+  @visibility("read")
   @summary("Entitlement")
   entitlement: OpenMeter.Entitlements.EntitlementMetered;
 
+  @visibility("read")
   @summary("Feature")
   feature: OpenMeter.Entitlements.Feature;
 
+  @visibility("read")
   @summary("Subject")
   subject: Subject;
 
+  @visibility("read")
   @summary("Entitlement Value")
   value: OpenMeter.Entitlements.EntitlementValue;
 
+  @visibility("read")
   @summary("Threshold")
   threshold: RuleBalanceThresholdValue;
 }
@@ -121,6 +133,7 @@ model Event {
   /**
    * A unique identifier of the notification event.
    */
+  @visibility("read")
   @summary("Event Identifier")
   @example("01J2KNP1YTXQRXHTDJ4KPR7PZ0")
   id: ULID;
@@ -128,12 +141,14 @@ model Event {
   /**
    * Type of the notification event.
    */
+  @visibility("read")
   @summary("Event Type")
   type: EventType;
 
   /**
    * Timestamp when the notification event was created in RFC 3339 format.
    */
+  @visibility("read")
   @summary("Creation Time")
   @example(DateTime.fromISO("2023-01-01T01:01:01.001Z"))
   createdAt: DateTime;
@@ -141,24 +156,28 @@ model Event {
   /**
    * The nnotification rule which generated this event.
    */
+  @visibility("read")
   @summary("Owner Rule")
   rule: Rule;
 
   /**
    * The delivery status of the notification event.
    */
+  @visibility("read")
   @summary("Delivery Status")
   deliveryStatus: Array<DeliveryStatus>;
 
   /**
    * Timestamp when the notification event was created in RFC 3339 format.
    */
+  @visibility("read")
   @summary("Event Payload")
   payload: EventPayload;
 
   /**
    * Set of key-value pairs managed by the system. Cannot be modified by user.
    */
+  @visibility("read")
   @summary("Annotations")
   annotations: Annotations;
 }

--- a/api/spec/src/notification/event.tsp
+++ b/api/spec/src/notification/event.tsp
@@ -174,6 +174,15 @@ enum EventOrderBy {
   createdAt: "createdAt",
 }
 
+// NOTE(chrisgacsal): this is a workaround of using the model OpenMeter.PaginatedResponse<Rule>
+// results a firendlyName RulePaginatedResponse instead of NotificationRulePaginatedResponse which
+// seems to be a bug in typespec. This way we can override the friendlyName of the paginated response.
+/**
+ * Paginated response for listing notification events.
+ */
+@friendlyName("NotificationEventsPaginatedResponse")
+model EventsPaginatedResponse is OpenMeter.PaginatedResponse<Event>;
+
 @route("/api/v1/notification/events")
 @tag("Notification (Experimental)")
 interface Events {
@@ -234,7 +243,7 @@ interface Events {
 
     ...OpenMeter.QueryPagination,
     ...OpenMeter.QueryOrdering<EventOrderBy>,
-  ): OpenMeter.PaginatedResponse<Event> | OpenMeter.CommonErrors;
+  ): EventsPaginatedResponse | OpenMeter.CommonErrors;
 
   /**
    * Get a notification event by id.

--- a/api/spec/src/notification/event.tsp
+++ b/api/spec/src/notification/event.tsp
@@ -218,7 +218,7 @@ interface Events {
      */
     @query
     @example(DateTime.fromISO("2023-01-01T01:01:01.001Z"))
-    from?: DateTime;
+    from?: DateTime,
 
     /**
      * End date-time in RFC 3339 format.
@@ -226,7 +226,7 @@ interface Events {
      */
     @query
     @example(DateTime.fromISO("2023-02-01T01:01:01.001Z"))
-    to?: DateTime;
+    to?: DateTime,
 
     /**
      * Filtering by multiple feature ids/keys.

--- a/api/spec/src/notification/event.tsp
+++ b/api/spec/src/notification/event.tsp
@@ -228,21 +228,28 @@ interface Events {
     @example(DateTime.fromISO("2023-02-01T01:01:01.001Z"))
     to?: DateTime,
 
+    // TODO(chrisgacsal): figure out if there is a way to use union type for attribute like this
+    // where the code generation results a less complicated/more idiomatic code.
+    //
+    //  alias IdOrKey = ULID | Key;
+    //  const features = Array<IdOrKey>;
+    //
+
     /**
-     * Filtering by multiple feature ids/keys.
+     * Filtering by multiple feature ids or keys.
      *
      * Usage: `?feature=feature-1&feature=feature-2`
      */
     @query
-    feature?: Array<ULID | string>,
+    feature?: Array<string>,
 
     /**
-     * Filtering by multiple subject ids/keys.
+     * Filtering by multiple subject ids or keys.
      *
      * Usage: `?subject=subject-1&subject=subject-2`
      */
     @query
-    subject?: Array<ULID | string>,
+    subject?: Array<string>,
 
     /**
      * Filtering by multiple rule ids.

--- a/api/spec/src/notification/rule.tsp
+++ b/api/spec/src/notification/rule.tsp
@@ -266,8 +266,8 @@ interface Rules {
    * Update notification rule.
    */
   @put
-  @operationId("createNotificationChannel")
-  @summary("Create a notification channel")
+  @operationId("updateNotificationRule")
+  @summary("Update a notification rule")
   update(@body request: RuleCreateRequest): {
     @statusCode _: 200;
     @body body: Rule;

--- a/api/spec/src/notification/rule.tsp
+++ b/api/spec/src/notification/rule.tsp
@@ -166,13 +166,20 @@ union RuleCreateRequest {
 model RuleBalanceThresholdCreateRequest {
   ...OmitProperties<RuleBalanceThreshold, "features">;
 
+  // TODO(chrisgacsal): figure out if there is a way to use union type for attribute like this
+  // where the code generation results a less complicated/more idiomatic code.
+  //
+  //  alias IdOrKey = ULID | Key;
+  //  const features = Array<IdOrKey>;
+  //
+
   /**
    * Optional field for defining the scope of notification by feature. It may contain features by id or key.
    */
   @visibility("create", "update")
   @summary("Features")
   @minItems(1)
-  features?: Array<ULID | string>;
+  features?: Array<string>;
 }
 
 /**
@@ -227,19 +234,26 @@ interface Rules {
     @example(false)
     includeDisabled?: boolean,
 
+    // TODO(chrisgacsal): figure out if there is a way to use union type for attribute like this
+    // where the code generation results a less complicated/more idiomatic code.
+    //
+    //  alias IdOrKey = ULID | Key;
+    //  const features = Array<IdOrKey>;
+    //
+
     /**
      * Filtering by multiple feature ids/keys.
      *
      * Usage: `?feature=feature-1&feature=feature-2`
      */
-    @query feature?: Array<ULID | string>,
+    @query feature?: Array<string>,
 
     /**
      * Filtering by multiple notifiaction channel ids.
      *
      * Usage: `?channel=01ARZ3NDEKTSV4RRFFQ69G5FAV&channel=01J8J2Y5X4NNGQS32CF81W95E3`
      */
-    @query channel?: Array<ULID | string>,
+    @query channel?: Array<string>,
 
     ...OpenMeter.QueryPagination,
     ...OpenMeter.QueryOrdering<RuleOrderBy>,

--- a/api/spec/src/notification/rule.tsp
+++ b/api/spec/src/notification/rule.tsp
@@ -12,11 +12,11 @@ namespace OpenMeter.Notification;
  * Metadata only fields of a notification channel.
  */
 @friendlyName("NotificationRuleMeta")
-model NotificationRuleMeta {
+model RuleMeta {
   /**
    * Identifies the notification rule.
    */
-  // @visibility("read")
+  @visibility("read")
   @summary("Rule Unique Identifier")
   @example("01ARZ3NDEKTSV4RRFFQ69G5FAV")
   id: ULID;
@@ -24,7 +24,7 @@ model NotificationRuleMeta {
   /**
    * Notification rule type.
    */
-  // @visibility("read")
+  @visibility("read")
   @summary("Rule Type")
   type: EventType;
 }
@@ -35,19 +35,12 @@ model NotificationRuleMeta {
 @friendlyName("NotificationRuleCommon")
 model RuleCommon<T extends EventType> {
   ...ResourceTimestamps;
-
-  /**
-   * Identifies the notification rule.
-   */
-  // @visibility("read")
-  @summary("Rule Unique Identifier")
-  @example("01ARZ3NDEKTSV4RRFFQ69G5FAV")
-  id: ULID;
+  ...OmitProperties<RuleMeta, "type">;
 
   /**
    * Notification rule type.
    */
-  // @visibility("read", "create", "query")
+  @visibility("read", "create", "query")
   @summary("Rule Type")
   type: T;
 
@@ -56,23 +49,23 @@ model RuleCommon<T extends EventType> {
    */
   @summary("Rule Name")
   @example("Balance threshold reached")
-  // @visibility("read", "create", "query", "update")
+  @visibility("read", "create", "query", "update")
   name: string;
 
   /**
    * Whether the rule is disabled or not.
    */
-  // @visibility("read", "create", "query", "update")
+  @visibility("read", "create", "query", "update")
   @summary("Rule Disabled")
   @example(true)
   disabled?: boolean = false;
 
   /**
    * List of notification channels the rule applies to.
-  */
-  // @visibility("read")
+   */
+  @visibility("read", "create", "query", "update")
   @summary("Channels assigned to Rule")
-  channels: Array<ChannelMeta>
+  channels: Array<ChannelMeta>;
 }
 
 /**
@@ -83,14 +76,15 @@ model RuleBalanceThresholdValue {
   /**
    * Value of the threshold.
    */
-  // @visibility("read", "create", "update")
+  @visibility("read", "create", "update")
   @summary("Threshold Value")
   @example(100)
   value: float64;
+
   /**
    * Type of the threshold.
    */
-  // @visibility("read", "create", "update")
+  @visibility("read", "create", "update")
   @summary("Threshold Type")
   @example("NUMBER")
   type: "PERCENT" | "NUMBER";
@@ -104,7 +98,7 @@ model FeatureMeta {
   /**
    * Unique identifier of a feature.
    */
-  // @visibility("read", "query")
+  @visibility("read", "query")
   @summary("Feature Unique Identifier")
   @example("01ARZ3NDEKTSV4RRFFQ69G5FAV")
   id: ULID;
@@ -113,7 +107,7 @@ model FeatureMeta {
    * The key is an immutable unique identifier of the feature used throughout the API,
    * for example when interacting with a subject's entitlements.
    */
-  // @visibility("read", "query")
+  @visibility("read", "query")
   @summary("Feature Key")
   @example("gpt4_tokens")
   key: string;
@@ -129,7 +123,7 @@ model RuleBalanceThreshold {
   /**
    * List of thresholds the rule suppose to be triggered.
    */
-  // @visibility("read", "create", "query", "update")
+  @visibility("read", "create", "query", "update")
   @summary("Entitlement Balance Thresholds")
   @minItems(1)
   @maxItems(10)
@@ -137,8 +131,8 @@ model RuleBalanceThreshold {
 
   /**
    * Optional field containing list of features the rule applies to.
-  */
-  // @visibility("read", "query")
+   */
+  @visibility("read", "query")
   @summary("Features")
   @minItems(1)
   features?: Array<FeatureMeta>;
@@ -167,15 +161,15 @@ union RuleCreateRequest {
 /**
  * Request with input parameters for creating new notification channel with webhook type.
  */
-// @withVisibility("create", "update")
+@withVisibility("create", "update")
 @friendlyName("NotificationRuleBalanceThresholdCreateRequest")
-model RuleBalanceThresholdCreateRequest{
-  ...OmitProperties<RuleBalanceThreshold, "id" | "createdAt" | "updatedAt" | "deletedAt" | "features">;
+model RuleBalanceThresholdCreateRequest {
+  ...OmitProperties<RuleBalanceThreshold, "features">;
 
   /**
    * Optional field for defining the scope of notification by feature. It may contain features by id or key.
    */
-  // @visibility("create", "update")
+  @visibility("create", "update")
   @summary("Features")
   @minItems(1)
   features?: Array<ULID | string>;

--- a/api/spec/src/notification/rule.tsp
+++ b/api/spec/src/notification/rule.tsp
@@ -196,6 +196,15 @@ enum RuleOrderBy {
   updatedAt: "updatedAt",
 }
 
+// NOTE(chrisgacsal): this is a workaround of using the model OpenMeter.PaginatedResponse<Rule>
+// results a model with friendlyName set to `RulePaginatedResponse` instead of `NotificationRulePaginatedResponse` which
+// seems to be a bug in typespec. This way we can override the friendlyName of the paginated response.
+/**
+ * Paginated response for listing notification rules.
+ */
+@friendlyName("NotificationRulePaginatedResponse")
+model RulesPaginatedResponse is OpenMeter.PaginatedResponse<Rule>;
+
 @route("/api/v1/notification/rules")
 @tag("Notification (Experimental)")
 interface Rules {
@@ -240,7 +249,7 @@ interface Rules {
 
     ...OpenMeter.QueryPagination,
     ...OpenMeter.QueryOrdering<RuleOrderBy>,
-  ): OpenMeter.PaginatedResponse<Rule> | OpenMeter.CommonErrors;
+  ): RulesPaginatedResponse | OpenMeter.CommonErrors;
 
   /**
    * Create a new notification rule.

--- a/api/spec/src/notification/svix.tsp
+++ b/api/spec/src/notification/svix.tsp
@@ -17,7 +17,14 @@ model SvixOperationalWebhookRequest {
    * The type of the Svix operational webhook request.
    */
   @summary("Operational Webhook Type")
-  type: "endpoint.created" |  "endpoint.deleted" | "endpoint.disabled" | "endpoint.updated" | "message.attempt.exhausted" | "message.attempt.failing" | "message.attempt.recovered";
+  type:
+    | "endpoint.created"
+    | "endpoint.deleted"
+    | "endpoint.disabled"
+    | "endpoint.updated"
+    | "message.attempt.exhausted"
+    | "message.attempt.failing"
+    | "message.attempt.recovered";
 
   /**
    * The payload of the Svix operational webhook request.

--- a/api/spec/src/types.tsp
+++ b/api/spec/src/types.tsp
@@ -233,7 +233,7 @@ model Address {
  */
 @friendlyName("{name}Request", T)
 model Request<T, Keys extends string> {
-  ...OmitProperties<T, Keys>
+  ...OmitProperties<T, Keys>;
 }
 
 /**


### PR DESCRIPTION
## Overview

Add couple of fixes, improvments:
* re-add `visibility` to properties as it makes easier to reuse models for create/update operations
* fix update operation
* fix issue with friendlyName when templated
* fix formatting
* refactor using union of ULID and string for attributes where both area accepted
