### PR TITLE
fix(api): query explode

### DIFF
--- a/api/spec/src/entitlements/entitlements.tsp
+++ b/api/spec/src/entitlements/entitlements.tsp
@@ -37,21 +37,24 @@ interface Entitlements {
      *
      * Usage: `?feature=feature-1&feature=feature-2`
      */
-    @query feature?: string[],
+    @query(#{explode: true})
+    feature?: string[],
 
     /**
      * Filtering by multiple subjects.
      *
      * Usage: `?subject=customer-1&subject=customer-2`
      */
-    @query subject?: string[],
+    @query(#{explode: true})
+    subject?: string[],
 
     /**
      * Filtering by multiple entitlement types.
      *
      * Usage: `?entitlementType=metered&entitlementType=boolean`
      */
-    @query entitlementType?: EntitlementType[],
+    @query(#{explode: true})
+    entitlementType?: EntitlementType[],
 
     ...OpenMeter.QueryPagination,
     ...OpenMeter.QueryLimitOffset,

--- a/api/spec/src/entitlements/grant.tsp
+++ b/api/spec/src/entitlements/grant.tsp
@@ -38,14 +38,16 @@ interface Grants {
      *
      * Usage: `?feature=feature-1&feature=feature-2`
      */
-    @query feature?: string[],
+    @query(#{explode: true})
+    feature?: string[],
 
     /**
      * Filtering by multiple subjects.
      *
      * Usage: `?subject=customer-1&subject=customer-2`
      */
-    @query subject?: string[],
+    @query(#{explode: true})
+    subject?: string[],
 
     /**
      * Include deleted

--- a/api/spec/src/notification/event.tsp
+++ b/api/spec/src/notification/event.tsp
@@ -240,7 +240,7 @@ interface Events {
      *
      * Usage: `?feature=feature-1&feature=feature-2`
      */
-    @query
+    @query(#{explode: true})
     feature?: Array<string>,
 
     /**
@@ -248,7 +248,7 @@ interface Events {
      *
      * Usage: `?subject=subject-1&subject=subject-2`
      */
-    @query
+    @query(#{explode: true})
     subject?: Array<string>,
 
     /**
@@ -256,7 +256,7 @@ interface Events {
      *
      * Usage: `?rule=01J8J2XYZ2N5WBYK09EDZFBSZM&rule=01J8J4R4VZH180KRKQ63NB2VA5`
      */
-    @query
+    @query(#{explode: true})
     rule?: Array<ULID>,
 
     /**
@@ -264,7 +264,7 @@ interface Events {
      *
      * Usage: `?channel=01J8J4RXH778XB056JS088PCYT&channel=01J8J4S1R1G9EVN62RG23A9M6J`
      */
-    @query
+    @query(#{explode: true})
     channel?: Array<ULID>,
 
     ...OpenMeter.QueryPagination,

--- a/api/spec/src/notification/rule.tsp
+++ b/api/spec/src/notification/rule.tsp
@@ -246,14 +246,16 @@ interface Rules {
      *
      * Usage: `?feature=feature-1&feature=feature-2`
      */
-    @query feature?: Array<string>,
+    @query(#{explode: true})
+    feature?: Array<string>,
 
     /**
      * Filtering by multiple notifiaction channel ids.
      *
      * Usage: `?channel=01ARZ3NDEKTSV4RRFFQ69G5FAV&channel=01J8J2Y5X4NNGQS32CF81W95E3`
      */
-    @query channel?: Array<string>,
+    @query(#{explode: true})
+    channel?: Array<string>,
 
     ...OpenMeter.QueryPagination,
     ...OpenMeter.QueryOrdering<RuleOrderBy>,


### PR DESCRIPTION
## Overview

Use `explode=true` for query parameters which accept multiple values in order to keep backward compatibility.