### PR TITLE
fix: required and readonly fields be optional

### DIFF
--- a/api/api.gen.go
+++ b/api/api.gen.go
@@ -300,7 +300,7 @@ type Customer struct {
 	External *CustomerExternalMapping `json:"external,omitempty"`
 
 	// Id A unique identifier for the customer.
-	Id *ULID `json:"id,omitempty"`
+	Id ULID `json:"id"`
 
 	// Metadata Additional metadata for the resource.
 	Metadata *Metadata `json:"metadata,omitempty"`
@@ -366,7 +366,7 @@ type Entitlement struct {
 // EntitlementBoolean defines model for EntitlementBoolean.
 type EntitlementBoolean struct {
 	// CreatedAt The date and time the resource was created.
-	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
 
 	// CurrentUsagePeriod A time period
 	CurrentUsagePeriod *Period `json:"currentUsagePeriod,omitempty"`
@@ -383,7 +383,7 @@ type EntitlementBoolean struct {
 	FeatureKey string `json:"featureKey"`
 
 	// Id Readonly unique ULID identifier.
-	Id *string `json:"id,omitempty"`
+	Id string `json:"id"`
 
 	// Metadata Additional metadata for the feature.
 	Metadata *map[string]string `json:"metadata,omitempty"`
@@ -393,7 +393,7 @@ type EntitlementBoolean struct {
 	Type       EntitlementBooleanType `json:"type"`
 
 	// UpdatedAt The date and time the resource was last updated. The initial value is the same as createdAt.
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt"`
 
 	// UsagePeriod Recurring period of an entitlement.
 	UsagePeriod *RecurringPeriod `json:"usagePeriod,omitempty"`
@@ -451,7 +451,7 @@ type EntitlementGrant struct {
 	Amount float64 `json:"amount"`
 
 	// CreatedAt The date and time the resource was created.
-	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
 
 	// DeletedAt The date and time the resource was deleted.
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
@@ -460,14 +460,14 @@ type EntitlementGrant struct {
 	EffectiveAt time.Time `json:"effectiveAt"`
 
 	// EntitlementId The unique entitlement ULID that the grant is associated with.
-	EntitlementId *string          `json:"entitlementId,omitempty"`
+	EntitlementId string           `json:"entitlementId"`
 	Expiration    ExpirationPeriod `json:"expiration"`
 
 	// ExpiresAt The expiration date of the grant.
 	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
 
 	// Id Readonly unique ULID identifier.
-	Id *string `json:"id,omitempty"`
+	Id string `json:"id"`
 
 	// MaxRolloverAmount Grants are rolled over at reset, after which they can have a different balance compared to what they had before the reset.
 	//
@@ -497,7 +497,7 @@ type EntitlementGrant struct {
 	Recurrence *RecurringPeriod `json:"recurrence,omitempty"`
 
 	// UpdatedAt The date and time the resource was last updated. The initial value is the same as createdAt.
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt"`
 
 	// VoidedAt The date and time the grant was voided (cannot be used after that).
 	VoidedAt *time.Time `json:"voidedAt,omitempty"`
@@ -540,7 +540,7 @@ type EntitlementGrantCreateInput struct {
 // EntitlementMetered defines model for EntitlementMetered.
 type EntitlementMetered struct {
 	// CreatedAt The date and time the resource was created.
-	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
 
 	// CurrentUsagePeriod A time period
 	CurrentUsagePeriod Period `json:"currentUsagePeriod"`
@@ -557,7 +557,7 @@ type EntitlementMetered struct {
 	FeatureKey string `json:"featureKey"`
 
 	// Id Readonly unique ULID identifier.
-	Id *string `json:"id,omitempty"`
+	Id string `json:"id"`
 
 	// IsSoftLimit If softLimit=true the subject can use the feature even if the entitlement is exhausted, hasAccess will always be true.
 	IsSoftLimit *bool `json:"isSoftLimit,omitempty"`
@@ -591,7 +591,7 @@ type EntitlementMetered struct {
 	Type       EntitlementMeteredType `json:"type"`
 
 	// UpdatedAt The date and time the resource was last updated. The initial value is the same as createdAt.
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt"`
 
 	// UsagePeriod Recurring period of an entitlement.
 	UsagePeriod RecurringPeriod `json:"usagePeriod"`
@@ -658,7 +658,7 @@ type EntitlementMeteredCreateInputsType string
 // EntitlementSharedFields defines model for EntitlementSharedFields.
 type EntitlementSharedFields struct {
 	// CreatedAt The date and time the resource was created.
-	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
 
 	// CurrentUsagePeriod A time period
 	CurrentUsagePeriod *Period `json:"currentUsagePeriod,omitempty"`
@@ -675,7 +675,7 @@ type EntitlementSharedFields struct {
 	FeatureKey string `json:"featureKey"`
 
 	// Id Readonly unique ULID identifier.
-	Id *string `json:"id,omitempty"`
+	Id string `json:"id"`
 
 	// Metadata Additional metadata for the feature.
 	Metadata *map[string]string `json:"metadata,omitempty"`
@@ -684,7 +684,7 @@ type EntitlementSharedFields struct {
 	SubjectKey string `json:"subjectKey"`
 
 	// UpdatedAt The date and time the resource was last updated. The initial value is the same as createdAt.
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt"`
 
 	// UsagePeriod Recurring period of an entitlement.
 	UsagePeriod *RecurringPeriod `json:"usagePeriod,omitempty"`
@@ -696,7 +696,7 @@ type EntitlementStatic struct {
 	Config string `json:"config"`
 
 	// CreatedAt The date and time the resource was created.
-	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
 
 	// CurrentUsagePeriod A time period
 	CurrentUsagePeriod *Period `json:"currentUsagePeriod,omitempty"`
@@ -713,7 +713,7 @@ type EntitlementStatic struct {
 	FeatureKey string `json:"featureKey"`
 
 	// Id Readonly unique ULID identifier.
-	Id *string `json:"id,omitempty"`
+	Id string `json:"id"`
 
 	// Metadata Additional metadata for the feature.
 	Metadata *map[string]string `json:"metadata,omitempty"`
@@ -723,7 +723,7 @@ type EntitlementStatic struct {
 	Type       EntitlementStaticType `json:"type"`
 
 	// UpdatedAt The date and time the resource was last updated. The initial value is the same as createdAt.
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt"`
 
 	// UsagePeriod Recurring period of an entitlement.
 	UsagePeriod *RecurringPeriod `json:"usagePeriod,omitempty"`
@@ -765,7 +765,7 @@ type EntitlementValue struct {
 	Config *string `json:"config,omitempty"`
 
 	// HasAccess Whether the subject has access to the feature. Shared accross all entitlement types.
-	HasAccess *bool `json:"hasAccess,omitempty"`
+	HasAccess bool `json:"hasAccess"`
 
 	// Overage Only available for metered entitlements. Overage represents the usage that wasn't covered by grants, e.g. if the subject had a total feature usage of 100 in the period but they were only granted 80, there would be 20 overage.
 	Overage *float64 `json:"overage,omitempty"`
@@ -795,13 +795,13 @@ type Feature struct {
 	ArchivedAt *time.Time `json:"archivedAt,omitempty"`
 
 	// CreatedAt The date and time the resource was created.
-	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
 
 	// DeletedAt The date and time the resource was deleted.
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 
 	// Id Readonly unique ULID identifier.
-	Id *string `json:"id,omitempty"`
+	Id string `json:"id"`
 
 	// Key The key is an immutable unique identifier of the feature used throughout the API, for example when interacting with a subject's entitlements. The key has to be unique across all active features, but archived features can share the same key. The key should consist of lowercase alphanumeric characters and dashes.
 	Key string `json:"key"`
@@ -820,7 +820,7 @@ type Feature struct {
 	Name string `json:"name"`
 
 	// UpdatedAt The date and time the resource was last updated. The initial value is the same as createdAt.
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt"`
 }
 
 // FeatureCreateInputs A feature is a feature or service offered to a customer.
@@ -1473,16 +1473,16 @@ type RecurringPeriodEnum string
 // These fields are automatically populated by the system for managed entities. Their use and meaning is uniform across all resources.
 type SharedMetaFields struct {
 	// CreatedAt The date and time the resource was created.
-	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
 
 	// DeletedAt The date and time the resource was deleted.
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 
 	// Id Readonly unique ULID identifier.
-	Id *string `json:"id,omitempty"`
+	Id string `json:"id"`
 
 	// UpdatedAt The date and time the resource was last updated. The initial value is the same as createdAt.
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+	UpdatedAt time.Time `json:"updatedAt"`
 }
 
 // Subject A subject is a unique identifier for a user or entity.

--- a/api/codegen.yaml
+++ b/api/codegen.yaml
@@ -5,4 +5,6 @@ generate:
   embedded-spec: true
 compatibility:
   apply-chi-middleware-first-to-last: true
+  # See: https://github.com/oapi-codegen/oapi-codegen/issues/778
+  disable-required-readonly-as-pointer: true
 output: ./api.gen.go

--- a/openmeter/customer/customer.go
+++ b/openmeter/customer/customer.go
@@ -29,7 +29,7 @@ type Customer struct {
 // AsAPICustomer converts a Customer to an API Customer
 func (c Customer) AsAPICustomer() (api.Customer, error) {
 	customer := api.Customer{
-		Id:               &c.ManagedResource.ID,
+		Id:               c.ManagedResource.ID,
 		Name:             c.Name,
 		UsageAttribution: api.CustomerUsageAttribution{SubjectKeys: c.UsageAttribution.SubjectKeys},
 		PrimaryEmail:     c.PrimaryEmail,

--- a/openmeter/entitlement/driver/metered.go
+++ b/openmeter/entitlement/driver/metered.go
@@ -355,18 +355,18 @@ func (h *meteredEntitlementHandler) resolveNamespace(ctx context.Context) (strin
 func MapEntitlementGrantToAPI(subjectKey *string, grant *meteredentitlement.EntitlementGrant) api.EntitlementGrant {
 	apiGrant := api.EntitlementGrant{
 		Amount:      grant.Amount,
-		CreatedAt:   &grant.CreatedAt,
+		CreatedAt:   grant.CreatedAt,
 		EffectiveAt: grant.EffectiveAt,
 		Expiration: api.ExpirationPeriod{
 			Count:    int(grant.Expiration.Count),
 			Duration: api.ExpirationPeriodDuration(grant.Expiration.Duration),
 		},
-		Id:                &grant.ID,
+		Id:                grant.ID,
 		Metadata:          &grant.Metadata,
 		Priority:          convert.ToPointer(int(grant.Priority)),
-		UpdatedAt:         &grant.UpdatedAt,
+		UpdatedAt:         grant.UpdatedAt,
 		DeletedAt:         grant.DeletedAt,
-		EntitlementId:     &grant.EntitlementID,
+		EntitlementId:     grant.EntitlementID,
 		ExpiresAt:         &grant.ExpiresAt,
 		MaxRolloverAmount: &grant.MaxRolloverAmount,
 		MinRolloverAmount: &grant.MinRolloverAmount,

--- a/openmeter/entitlement/driver/parser.go
+++ b/openmeter/entitlement/driver/parser.go
@@ -26,11 +26,11 @@ func (parser) ToMetered(e *entitlement.Entitlement) (*api.EntitlementMetered, er
 	}
 
 	return &api.EntitlementMetered{
-		CreatedAt:   &metered.CreatedAt,
+		CreatedAt:   metered.CreatedAt,
 		DeletedAt:   metered.DeletedAt,
 		FeatureId:   metered.FeatureID,
 		FeatureKey:  metered.FeatureKey,
-		Id:          &metered.ID,
+		Id:          metered.ID,
 		IsSoftLimit: convert.ToPointer(metered.IsSoftLimit),
 		IsUnlimited: convert.ToPointer(false), // implement
 		IssueAfterReset: convert.SafeDeRef(metered.IssueAfterReset, func(i meteredentitlement.IssueAfterReset) *float64 {
@@ -45,7 +45,7 @@ func (parser) ToMetered(e *entitlement.Entitlement) (*api.EntitlementMetered, er
 		Metadata:               convert.MapToPointer(metered.Metadata),
 		SubjectKey:             metered.SubjectKey,
 		Type:                   api.EntitlementMeteredType(metered.EntitlementType),
-		UpdatedAt:              &metered.UpdatedAt,
+		UpdatedAt:              metered.UpdatedAt,
 		UsagePeriod:            *mapUsagePeriod(e.UsagePeriod),
 		CurrentUsagePeriod:     *mapPeriod(e.CurrentUsagePeriod),
 		LastReset:              metered.LastReset,
@@ -60,15 +60,15 @@ func (parser) ToStatic(e *entitlement.Entitlement) (*api.EntitlementStatic, erro
 	}
 
 	apiRes := &api.EntitlementStatic{
-		CreatedAt:          &static.CreatedAt,
+		CreatedAt:          static.CreatedAt,
 		DeletedAt:          static.DeletedAt,
 		FeatureId:          static.FeatureID,
 		FeatureKey:         static.FeatureKey,
-		Id:                 &static.ID,
+		Id:                 static.ID,
 		Metadata:           convert.MapToPointer(static.Metadata),
 		SubjectKey:         static.SubjectKey,
 		Type:               api.EntitlementStaticType(static.EntitlementType),
-		UpdatedAt:          &static.UpdatedAt,
+		UpdatedAt:          static.UpdatedAt,
 		Config:             string(static.Config),
 		CurrentUsagePeriod: mapPeriod(static.CurrentUsagePeriod),
 		UsagePeriod:        mapUsagePeriod(e.UsagePeriod),
@@ -84,15 +84,15 @@ func (parser) ToBoolean(e *entitlement.Entitlement) (*api.EntitlementBoolean, er
 	}
 
 	apiRes := &api.EntitlementBoolean{
-		CreatedAt:          &boolean.CreatedAt,
+		CreatedAt:          boolean.CreatedAt,
 		DeletedAt:          boolean.DeletedAt,
 		FeatureId:          boolean.FeatureID,
 		FeatureKey:         boolean.FeatureKey,
-		Id:                 &boolean.ID,
+		Id:                 boolean.ID,
 		Metadata:           convert.MapToPointer(boolean.Metadata),
 		SubjectKey:         boolean.SubjectKey,
 		Type:               api.EntitlementBooleanType(boolean.EntitlementType),
-		UpdatedAt:          &boolean.UpdatedAt,
+		UpdatedAt:          boolean.UpdatedAt,
 		CurrentUsagePeriod: mapPeriod(boolean.CurrentUsagePeriod),
 		UsagePeriod:        mapUsagePeriod(e.UsagePeriod),
 	}
@@ -142,7 +142,7 @@ func MapEntitlementValueToAPI(entitlementValue entitlement.EntitlementValue) (ap
 	switch ent := entitlementValue.(type) {
 	case *meteredentitlement.MeteredEntitlementValue:
 		return api.EntitlementValue{
-			HasAccess: convert.ToPointer(ent.HasAccess()),
+			HasAccess: ent.HasAccess(),
 			Balance:   &ent.Balance,
 			Usage:     &ent.UsageInPeriod,
 			Overage:   &ent.Overage,
@@ -154,12 +154,12 @@ func MapEntitlementValueToAPI(entitlementValue entitlement.EntitlementValue) (ap
 		}
 
 		return api.EntitlementValue{
-			HasAccess: convert.ToPointer(ent.HasAccess()),
+			HasAccess: ent.HasAccess(),
 			Config:    config,
 		}, nil
 	case *booleanentitlement.BooleanEntitlementValue:
 		return api.EntitlementValue{
-			HasAccess: convert.ToPointer(ent.HasAccess()),
+			HasAccess: ent.HasAccess(),
 		}, nil
 	default:
 		return api.EntitlementValue{}, errors.New("unknown entitlement type")

--- a/openmeter/entitlement/snapshot/event.go
+++ b/openmeter/entitlement/snapshot/event.go
@@ -27,7 +27,7 @@ type EntitlementValue struct {
 	Config *string `json:"config,omitempty"`
 
 	// HasAccess Whether the subject has access to the feature. Shared across all entitlement types.
-	HasAccess *bool `json:"hasAccess,omitempty"`
+	HasAccess bool `json:"hasAccess,omitempty"`
 
 	// Overage Only available for metered entitlements. Overage represents the usage that wasn't covered by grants, e.g. if the subject had a total feature usage of 100 in the period but they were only granted 80, there would be 20 overage.
 	Overage *float64 `json:"overage,omitempty"`

--- a/openmeter/notification/internal/rule.go
+++ b/openmeter/notification/internal/rule.go
@@ -23,7 +23,7 @@ func NewTestEventPayload(eventType notification.EventType) notification.EventPay
 		},
 		BalanceThreshold: notification.BalanceThresholdPayload{
 			Entitlement: api.EntitlementMetered{
-				CreatedAt: convert.ToPointer(createdAt),
+				CreatedAt: createdAt,
 				CurrentUsagePeriod: api.Period{
 					From: from,
 					To:   to,
@@ -31,7 +31,7 @@ func NewTestEventPayload(eventType notification.EventType) notification.EventPay
 				DeletedAt:               nil,
 				FeatureId:               "01J5AVN2T6S0RDGJHVNN0BW3F5",
 				FeatureKey:              "test-feature-1",
-				Id:                      convert.ToPointer("01J5AVNM7H1PT65RDFWGXXPT47"),
+				Id:                      "01J5AVNM7H1PT65RDFWGXXPT47",
 				IsSoftLimit:             convert.ToPointer(false),
 				IsUnlimited:             convert.ToPointer(true),
 				IssueAfterReset:         convert.ToPointer(10.0),
@@ -44,7 +44,7 @@ func NewTestEventPayload(eventType notification.EventType) notification.EventPay
 				PreserveOverageAtReset: convert.ToPointer(true),
 				SubjectKey:             "test-subject-1",
 				Type:                   api.EntitlementMeteredTypeMetered,
-				UpdatedAt:              convert.ToPointer(updatedAt),
+				UpdatedAt:              updatedAt,
 				UsagePeriod: api.RecurringPeriod{
 					Anchor:   from,
 					Interval: api.RecurringPeriodEnumDAY,
@@ -52,9 +52,9 @@ func NewTestEventPayload(eventType notification.EventType) notification.EventPay
 			},
 			Feature: api.Feature{
 				ArchivedAt: nil,
-				CreatedAt:  convert.ToPointer(createdAt),
+				CreatedAt:  createdAt,
 				DeletedAt:  nil,
-				Id:         convert.ToPointer("01J5AVN2T6S0RDGJHVNN0BW3F5"),
+				Id:         "01J5AVN2T6S0RDGJHVNN0BW3F5",
 				Key:        "test-feature-1",
 				Metadata: &map[string]string{
 					"test-metadata-key": "test-metadata-value",
@@ -62,7 +62,7 @@ func NewTestEventPayload(eventType notification.EventType) notification.EventPay
 				MeterGroupByFilters: nil,
 				MeterSlug:           convert.ToPointer("test-meter-1"),
 				Name:                "test-meter-1",
-				UpdatedAt:           convert.ToPointer(updatedAt),
+				UpdatedAt:           updatedAt,
 			},
 			Subject: api.Subject{
 				CurrentPeriodEnd:   convert.ToPointer(from),
@@ -81,7 +81,7 @@ func NewTestEventPayload(eventType notification.EventType) notification.EventPay
 			},
 			Value: api.EntitlementValue{
 				Balance:   convert.ToPointer(10_000.0),
-				HasAccess: convert.ToPointer(true),
+				HasAccess: true,
 				Overage:   convert.ToPointer(99.0),
 				Usage:     convert.ToPointer(5_001.0),
 			},

--- a/openmeter/productcatalog/driver/parser.go
+++ b/openmeter/productcatalog/driver/parser.go
@@ -8,10 +8,10 @@ import (
 
 func MapFeatureToResponse(f feature.Feature) api.Feature {
 	return api.Feature{
-		CreatedAt:           &f.CreatedAt,
+		CreatedAt:           f.CreatedAt,
 		DeletedAt:           nil,
-		UpdatedAt:           &f.UpdatedAt,
-		Id:                  &f.ID,
+		UpdatedAt:           f.UpdatedAt,
+		Id:                  f.ID,
 		Key:                 f.Key,
 		Metadata:            convert.MapToPointer(f.Metadata),
 		Name:                f.Name,

--- a/test/notification/consumer_balance.go
+++ b/test/notification/consumer_balance.go
@@ -182,7 +182,7 @@ func (s *BalanceNotificaiontHandlerTestSuite) TestGrantingFlow(ctx context.Conte
 	event := events.Items[0]
 	require.Equal(t, s.rule.ID, event.Rule.ID, "Event must be associated with the rule")
 	require.Equal(t, notification.EventTypeBalanceThreshold, event.Payload.Type, "Event must be of type balance threshold")
-	require.Equal(t, TestEntitlementID, *event.Payload.BalanceThreshold.Entitlement.Id, "Event must be associated with the entitlement")
+	require.Equal(t, TestEntitlementID, event.Payload.BalanceThreshold.Entitlement.Id, "Event must be associated with the entitlement")
 	require.NotEmpty(t, event.Annotations[notification.AnnotationEventDedupeHash], "Event must have a deduplication hash")
 	require.NoError(t, event.Payload.BalanceThreshold.Validate(), "Event must be valid")
 	require.Equal(t, api.NotificationRuleBalanceThresholdValue{

--- a/test/notification/event.go
+++ b/test/notification/event.go
@@ -24,7 +24,7 @@ func NewBalanceThresholdPayload() notification.EventPayload {
 		},
 		BalanceThreshold: notification.BalanceThresholdPayload{
 			Entitlement: api.EntitlementMetered{
-				CreatedAt: convert.ToPointer(time.Now().Add(-10 * 24 * time.Hour).UTC()),
+				CreatedAt: time.Now().Add(-10 * 24 * time.Hour).UTC(),
 				CurrentUsagePeriod: api.Period{
 					From: time.Now().Add(-24 * time.Hour).UTC(),
 					To:   time.Now().UTC(),
@@ -32,7 +32,7 @@ func NewBalanceThresholdPayload() notification.EventPayload {
 				DeletedAt:               nil,
 				FeatureId:               "01J4VCZKH5QAF85GE501M8637W",
 				FeatureKey:              "feature-1",
-				Id:                      convert.ToPointer("01J4VCTKG06VJ0H78GD0MZBE49"),
+				Id:                      "01J4VCTKG06VJ0H78GD0MZBE49",
 				IsSoftLimit:             nil,
 				IsUnlimited:             nil,
 				IssueAfterReset:         nil,
@@ -42,7 +42,7 @@ func NewBalanceThresholdPayload() notification.EventPayload {
 				Metadata:                nil,
 				SubjectKey:              "customer-1",
 				Type:                    "",
-				UpdatedAt:               convert.ToPointer(time.Now().Add(-2 * time.Hour).UTC()),
+				UpdatedAt:               time.Now().Add(-2 * time.Hour).UTC(),
 				UsagePeriod: api.RecurringPeriod{
 					Anchor:   time.Date(2024, 1, 1, 8, 0, 0, 0, time.UTC),
 					Interval: "MONTH",
@@ -50,15 +50,15 @@ func NewBalanceThresholdPayload() notification.EventPayload {
 			},
 			Feature: api.Feature{
 				ArchivedAt:          nil,
-				CreatedAt:           convert.ToPointer(time.Now().Add(-10 * 24 * time.Hour).UTC()),
+				CreatedAt:           time.Now().Add(-10 * 24 * time.Hour).UTC(),
 				DeletedAt:           nil,
-				Id:                  convert.ToPointer("01J4VCZKH5QAF85GE501M8637W"),
+				Id:                  "01J4VCZKH5QAF85GE501M8637W",
 				Key:                 "feature-1",
 				Metadata:            nil,
 				MeterGroupByFilters: nil,
 				MeterSlug:           nil,
 				Name:                "feature-1",
-				UpdatedAt:           convert.ToPointer(time.Now().Add(-24 * time.Hour).UTC()),
+				UpdatedAt:           time.Now().Add(-24 * time.Hour).UTC(),
 			},
 			Subject: api.Subject{
 				CurrentPeriodEnd:   &time.Time{},
@@ -72,7 +72,7 @@ func NewBalanceThresholdPayload() notification.EventPayload {
 			Value: api.EntitlementValue{
 				Balance:   convert.ToPointer(10000.0),
 				Config:    nil,
-				HasAccess: convert.ToPointer(true),
+				HasAccess: true,
 				Overage:   convert.ToPointer(500.0),
 				Usage:     convert.ToPointer(50000.0),
 			},


### PR DESCRIPTION
## Overview

If the a field in OpenAPI spec is marked as readonly and required at the same time the Go code generator makes the field optional by setting its type to pointer which is not the desired behaviour.

Fortunatelly it is possible to disable this behaviour in the generator configuration.

See: https://github.com/oapi-codegen/oapi-codegen/issues/778