### PR TITLE
fix: fix slice init length

### DIFF
--- a/openmeter/dedupe/redisdedupe/redisdedupe.go
+++ b/openmeter/dedupe/redisdedupe/redisdedupe.go
@@ -65,7 +65,7 @@ func (d Deduplicator) CheckUnique(ctx context.Context, item dedupe.Item) (bool, 
 
 // Set sets events into redis
 func (d Deduplicator) Set(ctx context.Context, items ...dedupe.Item) error {
-	keys := make([]string, len(items))
+	keys := make([]string, 0, len(items))
 	for _, item := range items {
 		keys = append(keys, item.Key())
 	}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

The intention here should be to initialize a slice with a capacity of  `len(items)`  rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW

## Notes for reviewer

<!-- Anything the reviewer should know? -->
