### PR TITLE
refactor: log list events validation error on warn level

### DIFF
--- a/openmeter/server/router/event.go
+++ b/openmeter/server/router/event.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/contextx"
 	"github.com/openmeterio/openmeter/pkg/defaultx"
+	"github.com/openmeterio/openmeter/pkg/errorsx"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -35,7 +36,7 @@ func (a *Router) ListEvents(w http.ResponseWriter, r *http.Request, params api.L
 	if from.Before(minimumFrom) {
 		err := fmt.Errorf("from date is too old: %s", from)
 
-		a.config.ErrorHandler.HandleContext(ctx, err)
+		a.config.ErrorHandler.HandleContext(ctx, errorsx.NewWarnError(err))
 		models.NewStatusProblem(ctx, err, http.StatusBadRequest).Respond(w)
 
 		return
@@ -44,7 +45,7 @@ func (a *Router) ListEvents(w http.ResponseWriter, r *http.Request, params api.L
 	if params.To != nil && params.To.Before(from) {
 		err := fmt.Errorf("to date is before from date: %s < %s", params.To, params.From)
 
-		a.config.ErrorHandler.HandleContext(ctx, err)
+		a.config.ErrorHandler.HandleContext(ctx, errorsx.NewWarnError(err))
 		models.NewStatusProblem(ctx, err, http.StatusBadRequest).Respond(w)
 
 		return
@@ -53,7 +54,7 @@ func (a *Router) ListEvents(w http.ResponseWriter, r *http.Request, params api.L
 	if params.IngestedAtFrom != nil && params.IngestedAtFrom.Before(minimumFrom) {
 		err := fmt.Errorf("ingestedAtFrom date is too old: %s", params.IngestedAtFrom)
 
-		a.config.ErrorHandler.HandleContext(ctx, err)
+		a.config.ErrorHandler.HandleContext(ctx, errorsx.NewWarnError(err))
 		models.NewStatusProblem(ctx, err, http.StatusBadRequest).Respond(w)
 
 		return
@@ -62,7 +63,7 @@ func (a *Router) ListEvents(w http.ResponseWriter, r *http.Request, params api.L
 	if params.IngestedAtFrom != nil && params.IngestedAtTo != nil && params.IngestedAtTo.Before(*params.IngestedAtFrom) {
 		err := fmt.Errorf("ingestedAtTo date is before ingestedAtFrom date: %s < %s", params.IngestedAtTo, params.IngestedAtFrom)
 
-		a.config.ErrorHandler.HandleContext(ctx, err)
+		a.config.ErrorHandler.HandleContext(ctx, errorsx.NewWarnError(err))
 		models.NewStatusProblem(ctx, err, http.StatusBadRequest).Respond(w)
 
 		return

--- a/pkg/errorsx/errorsx.go
+++ b/pkg/errorsx/errorsx.go
@@ -30,3 +30,25 @@ func WithPrefix(err error, prefix string) error {
 
 	return errors.Join(errs...)
 }
+
+var _ error = (*warnError)(nil)
+
+type warnError struct {
+	Err error
+}
+
+func (w *warnError) Error() string {
+	return w.Err.Error()
+}
+
+func (w *warnError) Unwrap() error {
+	return w.Err
+}
+
+func NewWarnError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return &warnError{Err: err}
+}

--- a/pkg/errorsx/handler.go
+++ b/pkg/errorsx/handler.go
@@ -49,11 +49,19 @@ func NewSlogHandler(logger *slog.Logger) SlogHandler {
 }
 
 func (h SlogHandler) Handle(err error) {
-	h.Logger.Error(err.Error())
+	if wErr, ok := ErrorAs[*warnError](err); ok {
+		h.Logger.Warn(wErr.Error())
+	} else {
+		h.Logger.Error(err.Error())
+	}
 }
 
 func (h SlogHandler) HandleContext(ctx context.Context, err error) {
-	h.Logger.ErrorContext(ctx, err.Error())
+	if wErr, ok := ErrorAs[*warnError](err); ok {
+		h.Logger.WarnContext(ctx, wErr.Error())
+	} else {
+		h.Logger.ErrorContext(ctx, err.Error())
+	}
 }
 
 // NopHandler ignores all errors.


### PR DESCRIPTION
## Overview

Log list events validation errors on `warning` level. It is a temporary solution until we migrate the Events API to the new framework where logging and error handling are done differently.
