### PR TITLE
refactor: Notification API typespec

### DIFF
--- a/api/spec/src/notification/channel.tsp
+++ b/api/spec/src/notification/channel.tsp
@@ -12,7 +12,7 @@ namespace OpenMeter.Notification;
  * Type of the notification channel.
  */
 @friendlyName("NotificationChannelType")
-enum ChannelType {
+enum NotificationChannelType {
   #suppress "@openmeter/api-spec/casing" "Ignore due to backward compatibility"
   webhook: "WEBHOOK",
 }
@@ -21,7 +21,7 @@ enum ChannelType {
  * Metadata only fields of a notification channel.
  */
 @friendlyName("NotificationChannelMeta")
-model ChannelMeta {
+model NotificationChannelMeta {
   /**
    * Identifies the notification channel.
    */
@@ -35,16 +35,16 @@ model ChannelMeta {
    */
   @visibility("read")
   @summary("Channel Type")
-  type: ChannelType;
+  type: NotificationChannelType;
 }
 
 /**
  * Common fields of a notificaiton channel.
  */
 @friendlyName("NotificationChannelCommon")
-model ChannelCommon<T extends ChannelType> {
+model NotificationChannelCommon<T extends NotificationChannelType> {
   ...ResourceTimestamps;
-  ...OmitProperties<ChannelMeta, "type">;
+  ...OmitProperties<NotificationChannelMeta, "type">;
 
   /**
    * Notification channel type.
@@ -74,8 +74,8 @@ model ChannelCommon<T extends ChannelType> {
  * Notification channel with webhook type.
  */
 @friendlyName("NotificationChannelWebhook")
-model ChannelWebhook {
-  ...ChannelCommon<ChannelType.webhook>;
+model NotificationChannelWebhook {
+  ...NotificationChannelCommon<NotificationChannelType.webhook>;
 
   /**
    * Webhook URL where the notification is sent.
@@ -101,7 +101,7 @@ model ChannelWebhook {
   @summary("Signing Secret")
   @pattern("^(whsec_)?[a-zA-Z0-9+/=]{32,100}$")
   @example("whsec_S6g2HLnTwd9AhHwUIMFggVS9OfoPafN8")
-  signingSecret: string;
+  signingSecret?: string;
 }
 
 /**
@@ -110,8 +110,8 @@ model ChannelWebhook {
 @friendlyName("NotificationChannel")
 @discriminator("type")
 @oneOf
-union Channel {
-  webhook: ChannelWebhook,
+union NotificationChannel {
+  webhook: NotificationChannelWebhook,
 }
 
 /**
@@ -120,15 +120,18 @@ union Channel {
 @friendlyName("NotificationChannelCreateRequest")
 @discriminator("type")
 @oneOf
-union ChannelCreateRequest {
-  webhook: ChannelWebhook,
+union NotificationChannelCreateRequest {
+  webhook: NotificationChannelWebhookCreateRequest,
 }
+
+@friendlyName("NotificationChannelWebhookCreateRequest")
+model NotificationChannelWebhookCreateRequest is NotificationChannelWebhook;
 
 /**
  * Order by options for notification channels.
  */
 @friendlyName("NotificationChannelOrderBy")
-enum ChannelOrderBy {
+enum NotificationChannelOrderBy {
   #suppress "@openmeter/api-spec/casing" "Ignore due to backward compatibility"
   id: "id",
   #suppress "@openmeter/api-spec/casing" "Ignore due to backward compatibility"
@@ -138,15 +141,6 @@ enum ChannelOrderBy {
   #suppress "@openmeter/api-spec/casing" "Ignore due to backward compatibility"
   updatedAt: "updatedAt",
 }
-
-// NOTE(chrisgacsal): this is a workaround of using the model OpenMeter.PaginatedResponse<Rule>
-// results a firendlyName RulePaginatedResponse instead of NotificationRulePaginatedResponse which
-// seems to be a bug in typespec. This way we can override the friendlyName of the paginated response.
-/**
- * Paginated response for listing notification channels.
- */
-@friendlyName("NotificationChannelsPaginatedResponse")
-model ChannelsPaginatedResponse is OpenMeter.PaginatedResponse<Channel>;
 
 @route("/api/v1/notification/channels")
 @tag("Notification (Experimental)")
@@ -177,8 +171,8 @@ interface Channels {
     includeDisabled?: boolean = false,
 
     ...OpenMeter.QueryPagination,
-    ...OpenMeter.QueryOrdering<ChannelOrderBy>,
-  ): ChannelsPaginatedResponse | OpenMeter.CommonErrors;
+    ...OpenMeter.QueryOrdering<NotificationChannelOrderBy>,
+  ): OpenMeter.PaginatedResponse<NotificationChannel> | OpenMeter.CommonErrors;
 
   /**
    * Create a new notification channel.
@@ -186,9 +180,9 @@ interface Channels {
   @post
   @operationId("createNotificationChannel")
   @summary("Create a notification channel")
-  create(@body request: ChannelCreateRequest): {
+  create(@body request: NotificationChannelCreateRequest): {
     @statusCode _: 201;
-    @body body: Channel;
+    @body body: NotificationChannel;
   } | OpenMeter.CommonErrors;
 
   /**
@@ -197,9 +191,9 @@ interface Channels {
   @put
   @operationId("updateNotificationChannel")
   @summary("Update a notification channel")
-  update(@path channelId: ULID, @body request: ChannelCreateRequest): {
+  update(@path channelId: ULID, @body request: NotificationChannelCreateRequest): {
     @statusCode _: 200;
-    @body body: Channel;
+    @body body: NotificationChannel;
   } | OpenMeter.NotFoundError | OpenMeter.CommonErrors;
 
   /**
@@ -208,7 +202,7 @@ interface Channels {
   @get
   @operationId("getNotificationChannel")
   @summary("Get notification channel")
-  get(@path channelId: ULID): Channel | OpenMeter.NotFoundError | OpenMeter.CommonErrors;
+  get(@path channelId: ULID): NotificationChannel | OpenMeter.NotFoundError | OpenMeter.CommonErrors;
 
   /**
    * Soft delete notification channel by id.

--- a/api/spec/src/notification/event.tsp
+++ b/api/spec/src/notification/event.tsp
@@ -12,7 +12,7 @@ namespace OpenMeter.Notification;
  * Type of the notification event.
  */
 @friendlyName("NotificationEventType")
-enum EventType {
+enum NotificationEventType {
   #suppress "@openmeter/api-spec/casing" "Ignore due to backward compatibility"
   entitlementsBalanceThreshold: "entitlements.balance.threshold",
 }
@@ -20,8 +20,8 @@ enum EventType {
 /**
  * The delivery status of the notification event.
  */
-@friendlyName("NotificationDeliveryStatus")
-model DeliveryStatus {
+@friendlyName("NotificationEventDeliveryStatus")
+model NotificationEventDeliveryStatus {
   /**
    * Delivery state of the notification event to the channel.
    */
@@ -45,6 +45,13 @@ model DeliveryStatus {
   @summary("Last Update Time")
   @example(DateTime.fromISO("2023-01-01T01:01:01.001Z"))
   updatedAt: DateTime;
+
+  /**
+   * Notification channel the delivery sattus associated with.
+   */
+  @visibility("read")
+  @summary("Notification Channel")
+  channel: NotificationChannelMeta;
 }
 
 /**
@@ -53,15 +60,15 @@ model DeliveryStatus {
 @friendlyName("NotificationEventPayload")
 @discriminator("type")
 @oneOf
-union EventPayload {
-  entitlementsBalanceThreshold: EventBalanceThresholdPayload,
+union NotificationEventPayload {
+  entitlementsBalanceThreshold: NotificationEventBalanceThresholdPayload,
 }
 
 /**
  * Payload for notification event with `entitlements.balance.threshold` type.
  */
 @friendlyName("NotificationEventBalanceThresholdPayload")
-model EventBalanceThresholdPayload {
+model NotificationEventBalanceThresholdPayload {
   /**
    * A unique identifier for the notification event the payload belongs to.
    */
@@ -75,7 +82,7 @@ model EventBalanceThresholdPayload {
    */
   @visibility("read")
   @summary("Notification Event Type")
-  type: EventType.entitlementsBalanceThreshold;
+  type: NotificationEventType.entitlementsBalanceThreshold;
 
   /**
    * Timestamp when the notification event was created in RFC 3339 format.
@@ -90,14 +97,14 @@ model EventBalanceThresholdPayload {
    */
   @visibility("read")
   @summary("Payload Data")
-  data: EventBalanceThresholdPayloadData;
+  data: NotificationEventBalanceThresholdPayloadData;
 }
 
 /**
  * Data of the payload for notification event with `entitlements.balance.threshold` type.
  */
 @friendlyName("NotificationEventBalanceThresholdPayloadData")
-model EventBalanceThresholdPayloadData {
+model NotificationEventBalanceThresholdPayloadData {
   @visibility("read")
   @summary("Entitlement")
   entitlement: OpenMeter.Entitlements.EntitlementMetered;
@@ -116,14 +123,14 @@ model EventBalanceThresholdPayloadData {
 
   @visibility("read")
   @summary("Threshold")
-  threshold: RuleBalanceThresholdValue;
+  threshold: NotificationRuleBalanceThresholdValue;
 }
 
 /**
  * Type of the notification event.
  */
 @friendlyName("NotificationEvent")
-model Event {
+model NotificationEvent {
   /**
    * A unique identifier of the notification event.
    */
@@ -137,7 +144,7 @@ model Event {
    */
   @visibility("read")
   @summary("Event Type")
-  type: EventType;
+  type: NotificationEventType;
 
   /**
    * Timestamp when the notification event was created in RFC 3339 format.
@@ -152,49 +159,40 @@ model Event {
    */
   @visibility("read")
   @summary("Owner Rule")
-  rule: Rule;
+  rule: NotificationRule;
 
   /**
    * The delivery status of the notification event.
    */
   @visibility("read")
   @summary("Delivery Status")
-  deliveryStatus: Array<DeliveryStatus>;
+  deliveryStatus: Array<NotificationEventDeliveryStatus>;
 
   /**
    * Timestamp when the notification event was created in RFC 3339 format.
    */
   @visibility("read")
   @summary("Event Payload")
-  payload: EventPayload;
+  payload: NotificationEventPayload;
 
   /**
    * Set of key-value pairs managed by the system. Cannot be modified by user.
    */
   @visibility("read")
   @summary("Annotations")
-  annotations: Annotations;
+  annotations?: Annotations;
 }
 
 /**
  * Order by options for notification channels.
  */
 @friendlyName("NotificationEventOrderBy")
-enum EventOrderBy {
+enum NotificationEventOrderBy {
   #suppress "@openmeter/api-spec/casing" "Ignore due to backward compatibility"
   id: "id",
   #suppress "@openmeter/api-spec/casing" "Ignore due to backward compatibility"
   createdAt: "createdAt",
 }
-
-// NOTE(chrisgacsal): this is a workaround of using the model OpenMeter.PaginatedResponse<Rule>
-// results a firendlyName RulePaginatedResponse instead of NotificationRulePaginatedResponse which
-// seems to be a bug in typespec. This way we can override the friendlyName of the paginated response.
-/**
- * Paginated response for listing notification events.
- */
-@friendlyName("NotificationEventsPaginatedResponse")
-model EventsPaginatedResponse is OpenMeter.PaginatedResponse<Event>;
 
 @route("/api/v1/notification/events")
 @tag("Notification (Experimental)")
@@ -262,8 +260,8 @@ interface Events {
     channel?: Array<ULID>,
 
     ...OpenMeter.QueryPagination,
-    ...OpenMeter.QueryOrdering<EventOrderBy>,
-  ): EventsPaginatedResponse | OpenMeter.CommonErrors;
+    ...OpenMeter.QueryOrdering<NotificationEventOrderBy>,
+  ): OpenMeter.PaginatedResponse<NotificationEvent> | OpenMeter.CommonErrors;
 
   /**
    * Get a notification event by id.

--- a/api/spec/src/notification/rule.tsp
+++ b/api/spec/src/notification/rule.tsp
@@ -12,7 +12,7 @@ namespace OpenMeter.Notification;
  * Metadata only fields of a notification channel.
  */
 @friendlyName("NotificationRuleMeta")
-model RuleMeta {
+model NotificationRuleMeta {
   /**
    * Identifies the notification rule.
    */
@@ -26,16 +26,16 @@ model RuleMeta {
    */
   @visibility("read")
   @summary("Rule Type")
-  type: EventType;
+  type: NotificationEventType;
 }
 
 /**
  * Common fields of a notificaiton channel.
  */
 @friendlyName("NotificationRuleCommon")
-model RuleCommon<T extends EventType> {
+model NotificationRuleCommon<T extends NotificationEventType> {
   ...ResourceTimestamps;
-  ...OmitProperties<RuleMeta, "type">;
+  ...OmitProperties<NotificationRuleMeta, "type">;
 
   /**
    * Notification rule type.
@@ -65,14 +65,14 @@ model RuleCommon<T extends EventType> {
    */
   @visibility("read", "create", "query", "update")
   @summary("Channels assigned to Rule")
-  channels: Array<ChannelMeta>;
+  channels: Array<NotificationChannelMeta>;
 }
 
 /**
  * Threshold value with multiple supported types.
  */
 @friendlyName("NotificationRuleBalanceThresholdValue")
-model RuleBalanceThresholdValue {
+model NotificationRuleBalanceThresholdValue {
   /**
    * Value of the threshold.
    */
@@ -117,8 +117,8 @@ model FeatureMeta {
  * Notification rule with entitlements.balance.threshold type.
  */
 @friendlyName("NotificationRuleBalanceThreshold")
-model RuleBalanceThreshold {
-  ...RuleCommon<EventType.entitlementsBalanceThreshold>;
+model NotificationRuleBalanceThreshold {
+  ...NotificationRuleCommon<NotificationEventType.entitlementsBalanceThreshold>;
 
   /**
    * List of thresholds the rule suppose to be triggered.
@@ -127,7 +127,7 @@ model RuleBalanceThreshold {
   @summary("Entitlement Balance Thresholds")
   @minItems(1)
   @maxItems(10)
-  thresholds: Array<RuleBalanceThresholdValue>;
+  thresholds: Array<NotificationRuleBalanceThresholdValue>;
 
   /**
    * Optional field containing list of features the rule applies to.
@@ -144,34 +144,35 @@ model RuleBalanceThreshold {
 @friendlyName("NotificationRule")
 @discriminator("type")
 @oneOf
-union Rule {
-  entitlementsBalanceThreshold: RuleBalanceThreshold,
+union NotificationRule {
+  entitlementsBalanceThreshold: NotificationRuleBalanceThreshold,
 }
 
 /**
- * Union type for requests creating new notificatio nchannel with certain type.
+ * Union type for requests creating new notification rule with certain type.
  */
 @friendlyName("NotificationRuleCreateRequest")
 @discriminator("type")
 @oneOf
-union RuleCreateRequest {
-  entitlementsBalanceThreshold: RuleBalanceThresholdCreateRequest,
+union NotificationRuleCreateRequest {
+  entitlementsBalanceThreshold: NotificationRuleBalanceThresholdCreateRequest,
 }
 
 /**
- * Request with input parameters for creating new notification channel with webhook type.
+ * Request with input parameters for creating new notification rule with webhook type.
  */
 @withVisibility("create", "update")
 @friendlyName("NotificationRuleBalanceThresholdCreateRequest")
-model RuleBalanceThresholdCreateRequest {
-  ...OmitProperties<RuleBalanceThreshold, "features">;
+model NotificationRuleBalanceThresholdCreateRequest {
+  ...OmitProperties<NotificationRuleBalanceThreshold, "channels" | "features">;
 
-  // TODO(chrisgacsal): figure out if there is a way to use union type for attribute like this
-  // where the code generation results a less complicated/more idiomatic code.
-  //
-  //  alias IdOrKey = ULID | Key;
-  //  const features = Array<IdOrKey>;
-  //
+  /**
+   * List of notification channels the rule is applied to.
+   */
+  @visibility("create", "update")
+  @summary("Channels")
+  @minItems(1)
+  channels: Array<ULID>;
 
   /**
    * Optional field for defining the scope of notification by feature. It may contain features by id or key.
@@ -179,14 +180,14 @@ model RuleBalanceThresholdCreateRequest {
   @visibility("create", "update")
   @summary("Features")
   @minItems(1)
-  features?: Array<string>;
+  features?: Array<ULIDOrKey>;
 }
 
 /**
  * Order by options for notification channels.
  */
 @friendlyName("NotificationRuleOrderBy")
-enum RuleOrderBy {
+enum NotificationRuleOrderBy {
   #suppress "@openmeter/api-spec/casing" "Ignore due to backward compatibility"
   id: "id",
   #suppress "@openmeter/api-spec/casing" "Ignore due to backward compatibility"
@@ -196,15 +197,6 @@ enum RuleOrderBy {
   #suppress "@openmeter/api-spec/casing" "Ignore due to backward compatibility"
   updatedAt: "updatedAt",
 }
-
-// NOTE(chrisgacsal): this is a workaround of using the model OpenMeter.PaginatedResponse<Rule>
-// results a model with friendlyName set to `RulePaginatedResponse` instead of `NotificationRulePaginatedResponse` which
-// seems to be a bug in typespec. This way we can override the friendlyName of the paginated response.
-/**
- * Paginated response for listing notification rules.
- */
-@friendlyName("NotificationRulePaginatedResponse")
-model RulesPaginatedResponse is OpenMeter.PaginatedResponse<Rule>;
 
 @route("/api/v1/notification/rules")
 @tag("Notification (Experimental)")
@@ -234,20 +226,13 @@ interface Rules {
     @example(false)
     includeDisabled?: boolean = false,
 
-    // TODO(chrisgacsal): figure out if there is a way to use union type for attribute like this
-    // where the code generation results a less complicated/more idiomatic code.
-    //
-    //  alias IdOrKey = ULID | Key;
-    //  const features = Array<IdOrKey>;
-    //
-
     /**
      * Filtering by multiple feature ids/keys.
      *
      * Usage: `?feature=feature-1&feature=feature-2`
      */
     @query(#{ explode: true })
-    feature?: Array<string>,
+    feature?: Array<ULIDOrKey>,
 
     /**
      * Filtering by multiple notifiaction channel ids.
@@ -258,8 +243,8 @@ interface Rules {
     channel?: Array<string>,
 
     ...OpenMeter.QueryPagination,
-    ...OpenMeter.QueryOrdering<RuleOrderBy>,
-  ): RulesPaginatedResponse | OpenMeter.CommonErrors;
+    ...OpenMeter.QueryOrdering<NotificationRuleOrderBy>,
+  ): OpenMeter.PaginatedResponse<NotificationRule> | OpenMeter.CommonErrors;
 
   /**
    * Create a new notification rule.
@@ -267,9 +252,9 @@ interface Rules {
   @post
   @operationId("createNotificationRule")
   @summary("Create a notification rule")
-  create(@body request: RuleCreateRequest): {
+  create(@body request: NotificationRuleCreateRequest): {
     @statusCode _: 201;
-    @body body: Rule;
+    @body body: NotificationRule;
   } | OpenMeter.CommonErrors;
 
   /**
@@ -278,9 +263,9 @@ interface Rules {
   @put
   @operationId("updateNotificationRule")
   @summary("Update a notification rule")
-  update(@path ruleId: ULID, @body request: RuleCreateRequest): {
+  update(@path ruleId: ULID, @body request: NotificationRuleCreateRequest): {
     @statusCode _: 200;
-    @body body: Rule;
+    @body body: NotificationRule;
   } | OpenMeter.NotFoundError | OpenMeter.CommonErrors;
 
   /**
@@ -289,7 +274,7 @@ interface Rules {
   @get
   @operationId("getNotificationRule")
   @summary("Get notification rule")
-  get(@path ruleId: ULID): Rule | OpenMeter.NotFoundError | OpenMeter.CommonErrors;
+  get(@path ruleId: ULID): NotificationRule | OpenMeter.NotFoundError | OpenMeter.CommonErrors;
 
   /**
    * Soft delete notification rule by id.

--- a/api/spec/src/types.tsp
+++ b/api/spec/src/types.tsp
@@ -256,5 +256,5 @@ model Request<T, Keys extends string> {
 @example(#{ externalId: "019142cc-a016-796a-8113-1a942fecd26d" })
 @friendlyName("Annotations")
 model Annotations {
-  ...Record<string>;
+  ...Record<unknown>;
 }

--- a/openmeter/notification/annotations.go
+++ b/openmeter/notification/annotations.go
@@ -1,5 +1,7 @@
 package notification
 
+import "github.com/openmeterio/openmeter/api"
+
 const (
 	// AnnotationRuleTestEvent indicates that the event is generated as part of testing a notification rule
 	AnnotationRuleTestEvent = "notification.rule.test"
@@ -12,4 +14,4 @@ const (
 	AnnotationEventDedupeHash = "event.balance.dedupe.hash"
 )
 
-type Annotations = map[string]interface{}
+type Annotations = api.Annotations

--- a/openmeter/notification/event.go
+++ b/openmeter/notification/event.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/samber/lo"
-
 	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/sortx"
+	"github.com/samber/lo"
 )
 
 type payloadObjectMapper interface {
@@ -85,13 +84,8 @@ func (e Event) AsNotificationEvent() (api.NotificationEvent, error) {
 
 	switch e.Type {
 	case EventTypeBalanceThreshold:
-		event.Type = api.EntitlementsBalanceThreshold
-		err = event.Payload.FromNotificationEventBalanceThresholdPayload(e.AsNotificationEventBalanceThresholdPayload())
-		if err != nil {
-			return event, ValidationError{
-				Err: fmt.Errorf("invalid event type: %s", e.Type),
-			}
-		}
+		event.Type = api.NotificationEventTypeEntitlementsBalanceThreshold
+		event.Payload = e.AsNotificationEventBalanceThresholdPayload()
 	default:
 		return event, ValidationError{
 			Err: fmt.Errorf("invalid event type: %s", e.Type),
@@ -105,7 +99,7 @@ func (e Event) AsNotificationEventBalanceThresholdPayload() api.NotificationEven
 	return api.NotificationEventBalanceThresholdPayload{
 		Id:        e.ID,
 		Timestamp: e.CreatedAt,
-		Type:      api.NotificationEventType(e.Type),
+		Type:      api.NotificationEventBalanceThresholdPayloadTypeEntitlementsBalanceThreshold,
 		Data: struct {
 			Entitlement api.EntitlementMetered                    `json:"entitlement"`
 			Feature     api.Feature                               `json:"feature"`
@@ -123,7 +117,7 @@ func (e Event) AsNotificationEventBalanceThresholdPayload() api.NotificationEven
 }
 
 const (
-	EventTypeBalanceThreshold = EventType(api.EntitlementsBalanceThreshold)
+	EventTypeBalanceThreshold = EventType(api.NotificationEventTypeEntitlementsBalanceThreshold)
 )
 
 type EventType api.NotificationEventType
@@ -202,7 +196,7 @@ func (p EventPayload) AsNotificationEventBalanceThresholdPayload(eventId string,
 		},
 		Id:        eventId,
 		Timestamp: ts,
-		Type:      api.EntitlementsBalanceThreshold,
+		Type:      api.NotificationEventBalanceThresholdPayloadTypeEntitlementsBalanceThreshold,
 	}
 }
 
@@ -220,8 +214,8 @@ func (b BalanceThresholdPayload) Validate() error {
 }
 
 const (
-	EventOrderByID        = api.ListNotificationEventsParamsOrderById
-	EventOrderByCreatedAt = api.ListNotificationEventsParamsOrderByCreatedAt
+	EventOrderByID        = api.NotificationEventOrderById
+	EventOrderByCreatedAt = api.NotificationEventOrderByCreatedAt
 )
 
 var _ validator = (*ListEventsInput)(nil)
@@ -245,7 +239,7 @@ type ListEventsInput struct {
 
 	DeliveryStatusStates []EventDeliveryStatusState `json:"deliveryStatusStates,omitempty"`
 
-	OrderBy api.ListNotificationEventsParamsOrderBy
+	OrderBy api.NotificationEventOrderBy
 	Order   sortx.Order
 }
 

--- a/openmeter/notification/httpdriver/channel.go
+++ b/openmeter/notification/httpdriver/channel.go
@@ -17,7 +17,7 @@ import (
 
 type (
 	ListChannelsRequest  = notification.ListChannelsInput
-	ListChannelsResponse = api.NotificationChannelsResponse
+	ListChannelsResponse = api.NotificationChannelPaginatedResponse
 	ListChannelsParams   = api.ListNotificationChannelsParams
 	ListChannelsHandler  httptransport.HandlerWithArgs[ListChannelsRequest, ListChannelsResponse, ListChannelsParams]
 )
@@ -33,8 +33,8 @@ func (h *handler) ListChannels() ListChannelsHandler {
 			req := ListChannelsRequest{
 				Namespaces:      []string{ns},
 				IncludeDisabled: defaultx.WithDefault(params.IncludeDisabled, notification.DefaultDisabled),
-				OrderBy:         defaultx.WithDefault(params.OrderBy, api.ListNotificationChannelsParamsOrderById),
-				Order:           sortx.Order(defaultx.WithDefault(params.Order, api.ListNotificationChannelsParamsOrderSortOrderASC)),
+				OrderBy:         defaultx.WithDefault(params.OrderBy, api.NotificationChannelOrderById),
+				Order:           sortx.Order(defaultx.WithDefault(params.Order, api.SortOrderDESC)),
 				Page: pagination.Page{
 					PageSize:   defaultx.WithDefault(params.PageSize, notification.DefaultPageSize),
 					PageNumber: defaultx.WithDefault(params.Page, notification.DefaultPageNumber),
@@ -141,12 +141,12 @@ func (h *handler) CreateChannel() CreateChannelHandler {
 type (
 	UpdateChannelRequest  = notification.UpdateChannelInput
 	UpdateChannelResponse = api.NotificationChannel
-	UpdateChannelHandler  httptransport.HandlerWithArgs[UpdateChannelRequest, UpdateChannelResponse, api.ChannelId]
+	UpdateChannelHandler  httptransport.HandlerWithArgs[UpdateChannelRequest, UpdateChannelResponse, string]
 )
 
 func (h *handler) UpdateChannel() UpdateChannelHandler {
 	return httptransport.NewHandlerWithArgs(
-		func(ctx context.Context, r *http.Request, channelID api.ChannelId) (UpdateChannelRequest, error) {
+		func(ctx context.Context, r *http.Request, channelID string) (UpdateChannelRequest, error) {
 			body := api.NotificationChannelCreateRequest{}
 			if err := commonhttp.JSONRequestBodyDecoder(r, &body); err != nil {
 				return UpdateChannelRequest{}, fmt.Errorf("field to decode update channel request: %w", err)
@@ -202,12 +202,12 @@ func (h *handler) UpdateChannel() UpdateChannelHandler {
 type (
 	DeleteChannelRequest  = notification.DeleteChannelInput
 	DeleteChannelResponse = interface{}
-	DeleteChannelHandler  httptransport.HandlerWithArgs[DeleteChannelRequest, DeleteChannelResponse, api.ChannelId]
+	DeleteChannelHandler  httptransport.HandlerWithArgs[DeleteChannelRequest, DeleteChannelResponse, string]
 )
 
 func (h *handler) DeleteChannel() DeleteChannelHandler {
 	return httptransport.NewHandlerWithArgs(
-		func(ctx context.Context, r *http.Request, channelID api.ChannelId) (DeleteChannelRequest, error) {
+		func(ctx context.Context, r *http.Request, channelID string) (DeleteChannelRequest, error) {
 			ns, err := h.resolveNamespace(ctx)
 			if err != nil {
 				return DeleteChannelRequest{}, fmt.Errorf("failed to resolve namespace: %w", err)
@@ -238,12 +238,12 @@ func (h *handler) DeleteChannel() DeleteChannelHandler {
 type (
 	GetChannelRequest  = notification.GetChannelInput
 	GetChannelResponse = api.NotificationChannel
-	GetChannelHandler  httptransport.HandlerWithArgs[GetChannelRequest, GetChannelResponse, api.ChannelId]
+	GetChannelHandler  httptransport.HandlerWithArgs[GetChannelRequest, GetChannelResponse, string]
 )
 
 func (h *handler) GetChannel() GetChannelHandler {
 	return httptransport.NewHandlerWithArgs(
-		func(ctx context.Context, r *http.Request, channelID api.ChannelId) (GetChannelRequest, error) {
+		func(ctx context.Context, r *http.Request, channelID string) (GetChannelRequest, error) {
 			ns, err := h.resolveNamespace(ctx)
 			if err != nil {
 				return GetChannelRequest{}, fmt.Errorf("failed to resolve namespace: %w", err)

--- a/openmeter/notification/httpdriver/channel.go
+++ b/openmeter/notification/httpdriver/channel.go
@@ -97,27 +97,13 @@ func (h *handler) CreateChannel() CreateChannelHandler {
 				return CreateChannelRequest{}, fmt.Errorf("failed to resolve namespace: %w", err)
 			}
 
-			value, err := body.ValueByDiscriminator()
-			if err != nil {
-				return CreateChannelRequest{}, notification.ValidationError{
-					Err: err,
-				}
-			}
-
 			req := CreateChannelRequest{
 				NamespacedModel: models.NamespacedModel{
 					Namespace: ns,
 				},
 			}
 
-			switch v := value.(type) {
-			case api.NotificationChannelWebhookCreateRequest:
-				req = req.FromNotificationChannelWebhookCreateRequest(v)
-			default:
-				return CreateChannelRequest{}, notification.ValidationError{
-					Err: fmt.Errorf("invalid channel type: %T", v),
-				}
-			}
+			req = req.FromNotificationChannelWebhookCreateRequest(body)
 
 			return req, nil
 		},
@@ -157,13 +143,6 @@ func (h *handler) UpdateChannel() UpdateChannelHandler {
 				return UpdateChannelRequest{}, fmt.Errorf("failed to resolve namespace: %w", err)
 			}
 
-			value, err := body.ValueByDiscriminator()
-			if err != nil {
-				return UpdateChannelRequest{}, notification.ValidationError{
-					Err: err,
-				}
-			}
-
 			req := UpdateChannelRequest{
 				NamespacedModel: models.NamespacedModel{
 					Namespace: ns,
@@ -171,14 +150,7 @@ func (h *handler) UpdateChannel() UpdateChannelHandler {
 				ID: channelID,
 			}
 
-			switch v := value.(type) {
-			case api.NotificationChannelWebhookCreateRequest:
-				req = req.FromNotificationChannelWebhookCreateRequest(v)
-			default:
-				return UpdateChannelRequest{}, notification.ValidationError{
-					Err: fmt.Errorf("invalid channel type: %T", v),
-				}
-			}
+			req = req.FromNotificationChannelWebhookCreateRequest(body)
 
 			return req, nil
 		},

--- a/openmeter/notification/httpdriver/event.go
+++ b/openmeter/notification/httpdriver/event.go
@@ -18,7 +18,7 @@ import (
 
 type (
 	ListEventsRequest  = notification.ListEventsInput
-	ListEventsResponse = api.NotificationEventsResponse
+	ListEventsResponse = api.NotificationEventPaginatedResponse
 	ListEventsParams   = api.ListNotificationEventsParams
 	ListEventsHandler  httptransport.HandlerWithArgs[ListEventsRequest, ListEventsResponse, ListEventsParams]
 )
@@ -33,7 +33,7 @@ func (h *handler) ListEvents() ListEventsHandler {
 
 			req := ListEventsRequest{
 				Namespaces: []string{ns},
-				Order:      sortx.Order(defaultx.WithDefault(params.Order, api.ListNotificationEventsParamsOrderSortOrderDESC)),
+				Order:      sortx.Order(defaultx.WithDefault(params.Order, api.SortOrderDESC)),
 				OrderBy:    defaultx.WithDefault(params.OrderBy, notification.EventOrderByCreatedAt),
 				Page: pagination.Page{
 					PageSize:   defaultx.WithDefault(params.PageSize, notification.DefaultPageSize),
@@ -87,12 +87,12 @@ func (h *handler) ListEvents() ListEventsHandler {
 type (
 	GetEventRequest  = notification.GetEventInput
 	GetEventResponse = api.NotificationEvent
-	GetEventHandler  httptransport.HandlerWithArgs[GetEventRequest, GetEventResponse, api.EventId]
+	GetEventHandler  httptransport.HandlerWithArgs[GetEventRequest, GetEventResponse, string]
 )
 
 func (h *handler) GetEvent() GetEventHandler {
 	return httptransport.NewHandlerWithArgs(
-		func(ctx context.Context, r *http.Request, eventID api.EventId) (GetEventRequest, error) {
+		func(ctx context.Context, r *http.Request, eventID string) (GetEventRequest, error) {
 			ns, err := h.resolveNamespace(ctx)
 			if err != nil {
 				return GetEventRequest{}, fmt.Errorf("failed to resolve namespace: %w", err)

--- a/openmeter/notification/httpdriver/rule.go
+++ b/openmeter/notification/httpdriver/rule.go
@@ -98,27 +98,13 @@ func (h *handler) CreateRule() CreateRuleHandler {
 				return CreateRuleRequest{}, fmt.Errorf("failed to resolve namespace: %w", err)
 			}
 
-			value, err := body.ValueByDiscriminator()
-			if err != nil {
-				return CreateRuleRequest{}, notification.ValidationError{
-					Err: err,
-				}
-			}
-
 			req := CreateRuleRequest{
 				NamespacedModel: models.NamespacedModel{
 					Namespace: ns,
 				},
 			}
 
-			switch v := value.(type) {
-			case api.NotificationRuleBalanceThresholdCreateRequest:
-				req = req.FromNotificationRuleBalanceThresholdCreateRequest(v)
-			default:
-				return CreateRuleRequest{}, notification.ValidationError{
-					Err: fmt.Errorf("invalid channel type: %T", v),
-				}
-			}
+			req = req.FromNotificationRuleBalanceThresholdCreateRequest(body)
 
 			return req, nil
 		},
@@ -158,13 +144,6 @@ func (h *handler) UpdateRule() UpdateRuleHandler {
 				return UpdateRuleRequest{}, fmt.Errorf("failed to resolve namespace: %w", err)
 			}
 
-			value, err := body.ValueByDiscriminator()
-			if err != nil {
-				return UpdateRuleRequest{}, notification.ValidationError{
-					Err: err,
-				}
-			}
-
 			req := UpdateRuleRequest{
 				NamespacedModel: models.NamespacedModel{
 					Namespace: ns,
@@ -172,14 +151,7 @@ func (h *handler) UpdateRule() UpdateRuleHandler {
 				ID: ruleID,
 			}
 
-			switch v := value.(type) {
-			case api.NotificationRuleBalanceThresholdCreateRequest:
-				req = req.FromNotificationRuleBalanceThresholdCreateRequest(v)
-			default:
-				return UpdateRuleRequest{}, notification.ValidationError{
-					Err: fmt.Errorf("invalid rule type: %T", v),
-				}
-			}
+			req = req.FromNotificationRuleBalanceThresholdCreateRequest(body)
 
 			return req, nil
 		},

--- a/openmeter/notification/httpdriver/rule.go
+++ b/openmeter/notification/httpdriver/rule.go
@@ -18,7 +18,7 @@ import (
 
 type (
 	ListRulesRequest  = notification.ListRulesInput
-	ListRulesResponse = api.NotificationRulesResponse
+	ListRulesResponse = api.NotificationRulePaginatedResponse
 	ListRulesParams   = api.ListNotificationRulesParams
 	ListRulesHandler  httptransport.HandlerWithArgs[ListRulesRequest, ListRulesResponse, ListRulesParams]
 )
@@ -34,7 +34,7 @@ func (h *handler) ListRules() ListRulesHandler {
 			req := ListRulesRequest{
 				Namespaces:      []string{ns},
 				IncludeDisabled: defaultx.WithDefault(params.IncludeDisabled, notification.DefaultDisabled),
-				OrderBy:         defaultx.WithDefault(params.OrderBy, api.ListNotificationRulesParamsOrderById),
+				OrderBy:         defaultx.WithDefault(params.OrderBy, api.NotificationRuleOrderById),
 				Order:           sortx.Order(defaultx.WithDefault(params.Order, api.SortOrderASC)),
 				Page: pagination.Page{
 					PageSize:   defaultx.WithDefault(params.PageSize, notification.DefaultPageSize),
@@ -142,12 +142,12 @@ func (h *handler) CreateRule() CreateRuleHandler {
 type (
 	UpdateRuleRequest  = notification.UpdateRuleInput
 	UpdateRuleResponse = api.NotificationRule
-	UpdateRuleHandler  httptransport.HandlerWithArgs[UpdateRuleRequest, UpdateRuleResponse, api.RuleId]
+	UpdateRuleHandler  httptransport.HandlerWithArgs[UpdateRuleRequest, UpdateRuleResponse, string]
 )
 
 func (h *handler) UpdateRule() UpdateRuleHandler {
 	return httptransport.NewHandlerWithArgs(
-		func(ctx context.Context, r *http.Request, ruleID api.RuleId) (UpdateRuleRequest, error) {
+		func(ctx context.Context, r *http.Request, ruleID string) (UpdateRuleRequest, error) {
 			body := api.NotificationRuleCreateRequest{}
 			if err := commonhttp.JSONRequestBodyDecoder(r, &body); err != nil {
 				return UpdateRuleRequest{}, fmt.Errorf("field to decode update rule request: %w", err)
@@ -203,12 +203,12 @@ func (h *handler) UpdateRule() UpdateRuleHandler {
 type (
 	DeleteRuleRequest  = notification.DeleteRuleInput
 	DeleteRuleResponse = interface{}
-	DeleteRuleHandler  httptransport.HandlerWithArgs[DeleteRuleRequest, DeleteRuleResponse, api.RuleId]
+	DeleteRuleHandler  httptransport.HandlerWithArgs[DeleteRuleRequest, DeleteRuleResponse, string]
 )
 
 func (h *handler) DeleteRule() DeleteRuleHandler {
 	return httptransport.NewHandlerWithArgs(
-		func(ctx context.Context, r *http.Request, ruleID api.RuleId) (DeleteRuleRequest, error) {
+		func(ctx context.Context, r *http.Request, ruleID string) (DeleteRuleRequest, error) {
 			ns, err := h.resolveNamespace(ctx)
 			if err != nil {
 				return DeleteRuleRequest{}, fmt.Errorf("failed to resolve namespace: %w", err)
@@ -239,12 +239,12 @@ func (h *handler) DeleteRule() DeleteRuleHandler {
 type (
 	GetRuleRequest  = notification.GetRuleInput
 	GetRuleResponse = api.NotificationRule
-	GetRuleHandler  httptransport.HandlerWithArgs[GetRuleRequest, GetRuleResponse, api.RuleId]
+	GetRuleHandler  httptransport.HandlerWithArgs[GetRuleRequest, GetRuleResponse, string]
 )
 
 func (h *handler) GetRule() GetRuleHandler {
 	return httptransport.NewHandlerWithArgs(
-		func(ctx context.Context, r *http.Request, ruleID api.RuleId) (GetRuleRequest, error) {
+		func(ctx context.Context, r *http.Request, ruleID string) (GetRuleRequest, error) {
 			ns, err := h.resolveNamespace(ctx)
 			if err != nil {
 				return GetRuleRequest{}, fmt.Errorf("failed to resolve namespace: %w", err)
@@ -281,12 +281,12 @@ type TestRuleRequest struct {
 
 type (
 	TestRuleResponse = api.NotificationEvent
-	TestRuleHandler  httptransport.HandlerWithArgs[TestRuleRequest, TestRuleResponse, api.RuleId]
+	TestRuleHandler  httptransport.HandlerWithArgs[TestRuleRequest, TestRuleResponse, string]
 )
 
 func (h *handler) TestRule() TestRuleHandler {
 	return httptransport.NewHandlerWithArgs(
-		func(ctx context.Context, r *http.Request, ruleID api.RuleId) (TestRuleRequest, error) {
+		func(ctx context.Context, r *http.Request, ruleID string) (TestRuleRequest, error) {
 			ns, err := h.resolveNamespace(ctx)
 			if err != nil {
 				return TestRuleRequest{}, fmt.Errorf("failed to resolve namespace: %w", err)

--- a/openmeter/notification/internal/rule.go
+++ b/openmeter/notification/internal/rule.go
@@ -35,7 +35,7 @@ func NewTestEventPayload(eventType notification.EventType) notification.EventPay
 				IsSoftLimit:             convert.ToPointer(false),
 				IsUnlimited:             convert.ToPointer(true),
 				IssueAfterReset:         convert.ToPointer(10.0),
-				IssueAfterResetPriority: convert.ToPointer(5),
+				IssueAfterResetPriority: convert.ToPointer[uint8](5),
 				LastReset:               time.Time{},
 				MeasureUsageFrom:        time.Time{},
 				Metadata: &map[string]string{
@@ -45,9 +45,9 @@ func NewTestEventPayload(eventType notification.EventType) notification.EventPay
 				SubjectKey:             "test-subject-1",
 				Type:                   api.EntitlementMeteredTypeMetered,
 				UpdatedAt:              updatedAt,
-				UsagePeriod: api.RecurringPeriod{
+				UsagePeriod: &api.RecurringPeriod{
 					Anchor:   from,
-					Interval: api.RecurringPeriodEnumDAY,
+					Interval: api.RecurringPeriodIntervalDAY,
 				},
 			},
 			Feature: api.Feature{

--- a/openmeter/notification/rule.go
+++ b/openmeter/notification/rule.go
@@ -46,16 +46,10 @@ type Rule struct {
 
 func (r Rule) AsNotificationRule() (api.NotificationRule, error) {
 	var rule api.NotificationRule
-	var err error
 
 	switch r.Type {
 	case RuleTypeBalanceThreshold:
-		err = rule.FromNotificationRuleBalanceThreshold(r.AsNotificationRuleBalanceThreshold())
-		if err != nil {
-			return rule, ValidationError{
-				Err: err,
-			}
-		}
+		rule = r.AsNotificationRuleBalanceThreshold()
 	default:
 		return rule, ValidationError{
 			Err: fmt.Errorf("invalid rule type: %s", r.Type),
@@ -77,7 +71,7 @@ func (r Rule) AsNotificationRuleBalanceThreshold() api.NotificationRuleBalanceTh
 	return api.NotificationRuleBalanceThreshold{
 		Channels:  channels,
 		CreatedAt: r.CreatedAt,
-		Disabled:  r.Disabled,
+		Disabled:  convert.ToPointer(r.Disabled),
 		Features: convert.SafeDeRef(&r.Config.BalanceThreshold.Features, func(featureIDs []string) *[]FeatureMeta {
 			var features []FeatureMeta
 			for _, id := range featureIDs {
@@ -95,7 +89,7 @@ func (r Rule) AsNotificationRuleBalanceThreshold() api.NotificationRuleBalanceTh
 		Id:         r.ID,
 		Name:       r.Name,
 		Thresholds: r.Config.BalanceThreshold.Thresholds,
-		Type:       api.NotificationEventType(r.Type),
+		Type:       api.NotificationRuleBalanceThresholdTypeEntitlementsBalanceThreshold,
 		UpdatedAt:  r.UpdatedAt,
 		DeletedAt:  r.DeletedAt,
 	}
@@ -142,7 +136,7 @@ func (r Rule) HasEnabledChannels() bool {
 }
 
 const (
-	RuleTypeBalanceThreshold = RuleType(api.EntitlementsBalanceThreshold)
+	RuleTypeBalanceThreshold = RuleType(api.NotificationEventTypeEntitlementsBalanceThreshold)
 )
 
 type RuleType api.NotificationEventType
@@ -250,10 +244,10 @@ func (b BalanceThresholdRuleConfig) Validate(ctx context.Context, service Servic
 type RuleOrderBy string
 
 const (
-	RuleOrderByID        = api.ListNotificationRulesParamsOrderById
-	RuleOrderByType      = api.ListNotificationRulesParamsOrderByType
-	RuleOrderByCreatedAt = api.ListNotificationRulesParamsOrderByCreatedAt
-	RuleOrderByUpdatedAt = api.ListNotificationRulesParamsOrderByUpdatedAt
+	RuleOrderByID        = api.NotificationRuleOrderById
+	RuleOrderByType      = api.NotificationRuleOrderByType
+	RuleOrderByCreatedAt = api.NotificationRuleOrderByCreatedAt
+	RuleOrderByUpdatedAt = api.NotificationRuleOrderByUpdatedAt
 )
 
 var _ validator = (*ListRulesInput)(nil)
@@ -267,7 +261,7 @@ type ListRulesInput struct {
 	Types           []RuleType
 	Channels        []string
 
-	OrderBy api.ListNotificationRulesParamsOrderBy
+	OrderBy api.NotificationRuleOrderBy
 	Order   sortx.Order
 }
 

--- a/openmeter/notification/service/channel.go
+++ b/openmeter/notification/service/channel.go
@@ -42,18 +42,12 @@ func (s Service) CreateChannel(ctx context.Context, params notification.CreateCh
 
 		switch params.Type {
 		case notification.ChannelTypeWebhook:
-			var headers map[string]string
-			headers, err = notification.StrictInterfaceMapToStringMap(channel.Config.WebHook.CustomHeaders)
-			if err != nil {
-				return nil, fmt.Errorf("failed to cast custom headers: %w", err)
-			}
-
 			var wb *webhook.Webhook
 			wb, err = s.webhook.CreateWebhook(ctx, webhook.CreateWebhookInput{
 				Namespace:     params.Namespace,
 				ID:            &channel.ID,
 				URL:           channel.Config.WebHook.URL,
-				CustomHeaders: headers,
+				CustomHeaders: channel.Config.WebHook.CustomHeaders,
 				Disabled:      channel.Disabled,
 				Secret:        &channel.Config.WebHook.SigningSecret,
 				Metadata: map[string]string{
@@ -203,17 +197,11 @@ func (s Service) UpdateChannel(ctx context.Context, params notification.UpdateCh
 
 		switch params.Type {
 		case notification.ChannelTypeWebhook:
-			var headers map[string]string
-			headers, err = notification.StrictInterfaceMapToStringMap(channel.Config.WebHook.CustomHeaders)
-			if err != nil {
-				return nil, fmt.Errorf("failed to cast custom headers: %w", err)
-			}
-
 			_, err = s.webhook.UpdateWebhook(ctx, webhook.UpdateWebhookInput{
 				Namespace:     params.Namespace,
 				ID:            channel.ID,
 				URL:           channel.Config.WebHook.URL,
-				CustomHeaders: headers,
+				CustomHeaders: channel.Config.WebHook.CustomHeaders,
 				Disabled:      channel.Disabled,
 				Secret:        &channel.Config.WebHook.SigningSecret,
 				Metadata: map[string]string{


### PR DESCRIPTION
## Overview

Refactor typespec definition of Notification API in order to make it aligned with the existing implementation.