### PR TITLE
fix(sink): remove max poll records config

### DIFF
--- a/pkg/kafka/config.go
+++ b/pkg/kafka/config.go
@@ -197,12 +197,6 @@ type ConsumerConfigParams struct {
 	// Available strategies: range, roundrobin, cooperative-sticky.
 	PartitionAssignmentStrategy string
 
-	// The maximum number of records returned in a single call to poll().
-	// Note, that max.poll.records does not impact the underlying fetching behavior.
-	// The consumer will cache the records from each fetch request and returns them incrementally from each poll.
-	// See https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#max-poll-records
-	MaxPollRecords int
-
 	// The maximum delay between invocations of poll() when using consumer group management.
 	// This places an upper bound on the amount of time that the consumer can be idle before fetching more records.
 	// If poll() is not called before expiration of this timeout, then the consumer is considered failed and
@@ -234,10 +228,6 @@ func (c ConsumerConfigParams) Validate() error {
 		}
 	}
 
-	if c.MaxPollRecords < 0 {
-		return errors.New("max poll records must be non negative")
-	}
-
 	return nil
 }
 
@@ -266,12 +256,6 @@ func (c ConsumerConfigParams) AsConfigMap() (kafka.ConfigMap, error) {
 
 	if c.HeartbeatInterval > 0 {
 		if err := m.SetKey("heartbeat.interval.ms", c.HeartbeatInterval); err != nil {
-			return nil, err
-		}
-	}
-
-	if c.MaxPollRecords > 0 {
-		if err := m.SetKey("max.poll.records", c.MaxPollRecords); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
`max.poll.records` doesn't exist in Go client

https://github.com/confluentinc/confluent-kafka-go/issues/671