### PR TITLE
refactor(sink): namespace and topic subscription update

### DIFF
--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -122,13 +122,14 @@ func TestComplete(t *testing.T) {
 			},
 		},
 		Sink: SinkConfiguration{
-			GroupId:             "openmeter-sink-worker",
-			MinCommitCount:      500,
-			MaxCommitWait:       30 * time.Second,
-			MaxPollTimeout:      100 * time.Millisecond,
-			NamespaceRefetch:    15 * time.Second,
-			FlushSuccessTimeout: 5 * time.Second,
-			DrainTimeout:        10 * time.Second,
+			GroupId:                 "openmeter-sink-worker",
+			MinCommitCount:          500,
+			MaxCommitWait:           30 * time.Second,
+			MaxPollTimeout:          100 * time.Millisecond,
+			NamespaceRefetch:        15 * time.Second,
+			FlushSuccessTimeout:     5 * time.Second,
+			DrainTimeout:            10 * time.Second,
+			NamespaceRefetchTimeout: 9 * time.Second,
 			Dedupe: DedupeConfiguration{
 				Enabled: true,
 				DedupeDriverConfiguration: DedupeDriverRedisConfiguration{

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -130,6 +130,7 @@ func TestComplete(t *testing.T) {
 			FlushSuccessTimeout:     5 * time.Second,
 			DrainTimeout:            10 * time.Second,
 			NamespaceRefetchTimeout: 9 * time.Second,
+			NamespaceTopicRegexp:    "^om_test_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$",
 			Dedupe: DedupeConfiguration{
 				Enabled: true,
 				DedupeDriverConfiguration: DedupeDriverRedisConfiguration{

--- a/app/config/sink.go
+++ b/app/config/sink.go
@@ -28,6 +28,9 @@ type SinkConfiguration struct {
 	// NamespaceRefetchTimeout is the timeout for updating namespaces and consumer subscription.
 	// It must be less than NamespaceRefetch interval.
 	NamespaceRefetchTimeout time.Duration
+
+	// NamespaceTopicRegexp defines the regular expression to match/validate topic names the sink-worker needs to subscribe to.
+	NamespaceTopicRegexp string
 }
 
 func (c SinkConfiguration) Validate() error {
@@ -59,6 +62,10 @@ func (c SinkConfiguration) Validate() error {
 
 	if c.NamespaceRefetchTimeout != 0 && c.NamespaceRefetchTimeout > c.NamespaceRefetch {
 		errs = append(errs, errors.New("NamespaceRefetchTimeout must be less than or equal to NamespaceRefetch"))
+	}
+
+	if c.NamespaceTopicRegexp == "" {
+		errs = append(errs, errors.New("NamespaceTopicRegexp must no be empty"))
 	}
 
 	if err := c.IngestNotifications.Validate(); err != nil {
@@ -145,6 +152,7 @@ func ConfigureSink(v *viper.Viper) {
 	v.SetDefault("sink.drainTimeout", "10s")
 	v.SetDefault("sink.ingestNotifications.maxEventsInBatch", 500)
 	v.SetDefault("sink.namespaceRefetchTimeout", "10s")
+	v.SetDefault("sink.namespaceTopicRegexp", "^om_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$")
 
 	// Sink Storage
 	v.SetDefault("sink.storage.asyncInsert", false)

--- a/app/config/sink.go
+++ b/app/config/sink.go
@@ -24,6 +24,10 @@ type SinkConfiguration struct {
 	Kafka KafkaConfig
 	// Storage configuration
 	Storage StorageConfiguration
+
+	// NamespaceRefetchTimeout is the timeout for updating namespaces and consumer subscription.
+	// It must be less than NamespaceRefetch interval.
+	NamespaceRefetchTimeout time.Duration
 }
 
 func (c SinkConfiguration) Validate() error {
@@ -51,6 +55,10 @@ func (c SinkConfiguration) Validate() error {
 
 	if c.DrainTimeout == 0 {
 		errs = append(errs, errors.New("DrainTimeout must be greater than 0"))
+	}
+
+	if c.NamespaceRefetchTimeout != 0 && c.NamespaceRefetchTimeout > c.NamespaceRefetch {
+		errs = append(errs, errors.New("NamespaceRefetchTimeout must be less than or equal to NamespaceRefetch"))
 	}
 
 	if err := c.IngestNotifications.Validate(); err != nil {
@@ -136,6 +144,7 @@ func ConfigureSink(v *viper.Viper) {
 	v.SetDefault("sink.flushSuccessTimeout", "5s")
 	v.SetDefault("sink.drainTimeout", "10s")
 	v.SetDefault("sink.ingestNotifications.maxEventsInBatch", 500)
+	v.SetDefault("sink.namespaceRefetchTimeout", "10s")
 
 	// Sink Storage
 	v.SetDefault("sink.storage.asyncInsert", false)

--- a/app/config/testdata/complete.yaml
+++ b/app/config/testdata/complete.yaml
@@ -59,6 +59,7 @@ sink:
   minCommitCount: 500
   maxCommitWait: 30s
   namespaceRefetch: 15s
+  namespaceRefetchTimeout: 9s
   dedupe:
     enabled: true
     driver: redis

--- a/app/config/testdata/complete.yaml
+++ b/app/config/testdata/complete.yaml
@@ -60,6 +60,7 @@ sink:
   maxCommitWait: 30s
   namespaceRefetch: 15s
   namespaceRefetchTimeout: 9s
+  namespaceTopicRegexp: "^om_test_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$"
   dedupe:
     enabled: true
     driver: redis

--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -203,21 +203,22 @@ func initSink(config config.Configuration, logger *slog.Logger, metricMeter metr
 	}
 
 	sinkConfig := sink.SinkConfig{
-		Logger:              logger,
-		Tracer:              tracer,
-		MetricMeter:         metricMeter,
-		MeterRepository:     meterRepository,
-		Storage:             storage,
-		Deduplicator:        deduplicator,
-		Consumer:            consumer,
-		MinCommitCount:      config.Sink.MinCommitCount,
-		MaxCommitWait:       config.Sink.MaxCommitWait,
-		MaxPollTimeout:      config.Sink.MaxPollTimeout,
-		FlushSuccessTimeout: config.Sink.FlushSuccessTimeout,
-		DrainTimeout:        config.Sink.DrainTimeout,
-		NamespaceRefetch:    config.Sink.NamespaceRefetch,
-		FlushEventHandler:   flushHandler,
-		TopicResolver:       topicResolver,
+		Logger:                  logger,
+		Tracer:                  tracer,
+		MetricMeter:             metricMeter,
+		MeterRepository:         meterRepository,
+		Storage:                 storage,
+		Deduplicator:            deduplicator,
+		Consumer:                consumer,
+		MinCommitCount:          config.Sink.MinCommitCount,
+		MaxCommitWait:           config.Sink.MaxCommitWait,
+		MaxPollTimeout:          config.Sink.MaxPollTimeout,
+		FlushSuccessTimeout:     config.Sink.FlushSuccessTimeout,
+		DrainTimeout:            config.Sink.DrainTimeout,
+		NamespaceRefetch:        config.Sink.NamespaceRefetch,
+		FlushEventHandler:       flushHandler,
+		TopicResolver:           topicResolver,
+		NamespaceRefetchTimeout: config.Sink.NamespaceRefetchTimeout,
 	}
 
 	return sink.NewSink(sinkConfig)

--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -219,6 +219,7 @@ func initSink(config config.Configuration, logger *slog.Logger, metricMeter metr
 		FlushEventHandler:       flushHandler,
 		TopicResolver:           topicResolver,
 		NamespaceRefetchTimeout: config.Sink.NamespaceRefetchTimeout,
+		NamespaceTopicRegexp:    config.Sink.NamespaceTopicRegexp,
 	}
 
 	return sink.NewSink(sinkConfig)

--- a/e2e/config.yaml
+++ b/e2e/config.yaml
@@ -17,6 +17,7 @@ sink:
   minCommitCount: 500
   maxCommitWait: 1s
   namespaceRefetch: 1s
+  namespaceRefetchTimeout: 1s
   dedupe:
     enabled: true
     driver: redis

--- a/openmeter/ingest/kafkaingest/collector.go
+++ b/openmeter/ingest/kafkaingest/collector.go
@@ -16,6 +16,10 @@ import (
 	kafkastats "github.com/openmeterio/openmeter/pkg/kafka/metrics/stats"
 )
 
+const (
+	HeaderKeyNamespace = "namespace"
+)
+
 // Collector is a receiver of events that handles sending those events to a downstream Kafka broker.
 type Collector struct {
 	Producer      *kafka.Producer
@@ -66,7 +70,7 @@ func (s Collector) Ingest(ctx context.Context, namespace string, ev event.Event)
 		TopicPartition: kafka.TopicPartition{Topic: &topicName, Partition: kafka.PartitionAny},
 		Timestamp:      ev.Time(),
 		Headers: []kafka.Header{
-			{Key: "namespace", Value: []byte(namespace)},
+			{Key: HeaderKeyNamespace, Value: []byte(namespace)},
 			{Key: "specversion", Value: []byte(ev.SpecVersion())},
 			{Key: "ingested_at", Value: []byte(time.Now().UTC().Format(time.RFC3339))},
 		},

--- a/quickstart/config.yaml
+++ b/quickstart/config.yaml
@@ -9,6 +9,7 @@ aggregation:
 sink:
   minCommitCount: 1
   namespaceRefetch: 1s
+  namespaceRefetchTimeout: 1s
   kafka:
     brokers: kafka:9092
     brokerAddressFamily: v4


### PR DESCRIPTION
## Overview

* get namespace from event header instaed of the topic name it was received from
* refactor namespace, topic subscription logic by separating the two
* make topic name regexp configurable
