### PR TITLE
feat(ingest): adopt topic provisioner

### DIFF
--- a/app/common/openmeter.go
+++ b/app/common/openmeter.go
@@ -64,11 +64,18 @@ func NewNamespacedTopicResolver(config config.Configuration) (*topicresolver.Nam
 	return topicResolver, nil
 }
 
-func NewKafkaIngestCollector(producer *kafka.Producer, topicResolver topicresolver.Resolver) (*kafkaingest.Collector, error) {
+func NewKafkaIngestCollector(
+	config config.KafkaIngestConfiguration,
+	producer *kafka.Producer,
+	topicResolver topicresolver.Resolver,
+	topicProvisioner pkgkafka.TopicProvisioner,
+) (*kafkaingest.Collector, error) {
 	collector, err := kafkaingest.NewCollector(
 		producer,
 		serializer.NewJSONSerializer(),
 		topicResolver,
+		topicProvisioner,
+		config.Partitions,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize kafka ingest: %w", err)

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -166,7 +166,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration, logge
 		cleanup()
 		return Application{}, nil, err
 	}
-	collector, err := common.NewKafkaIngestCollector(producer, namespacedTopicResolver)
+	collector, err := common.NewKafkaIngestCollector(kafkaIngestConfiguration, producer, namespacedTopicResolver, topicProvisioner)
 	if err != nil {
 		cleanup6()
 		cleanup5()


### PR DESCRIPTION
## Overview

Use `TopicProvisioner` to ensure that the target topic for events is available on Kafka cluster in case Kafka driver is used for ingest. Provisioning results are caches i norder to avoid unnecessary roundtrips to between service and Kafka cluster.