### PR TITLE
Drop separate logger initialization

### DIFF
--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -30,6 +30,13 @@ import (
 	"github.com/openmeterio/openmeter/pkg/gosundheit"
 )
 
+// Set the default logger to JSON for messages emitted before the "real" logger is initialized.
+//
+// We use JSON as a best-effort to make the logs machine-readable.
+func init() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+}
+
 const (
 	DefaultShutdownTimeout = 5 * time.Second
 )

--- a/app/common/wire.go
+++ b/app/common/wire.go
@@ -83,6 +83,8 @@ var KafkaTopic = wire.NewSet(
 var Telemetry = wire.NewSet(
 	NewTelemetryResource,
 
+	NewLogger,
+
 	NewMeterProvider,
 	wire.Bind(new(metric.MeterProvider), new(*sdkmetric.MeterProvider)),
 	NewMeter,
@@ -94,11 +96,6 @@ var Telemetry = wire.NewSet(
 
 	NewTelemetryHandler,
 	NewTelemetryServer,
-)
-
-var Logger = wire.NewSet(
-	NewTelemetryResource,
-	NewLogger,
 )
 
 var OpenMeter = wire.NewSet(

--- a/cmd/balance-worker/main.go
+++ b/cmd/balance-worker/main.go
@@ -61,6 +61,9 @@ func main() {
 	app, cleanup, err := initializeApplication(ctx, conf, logger)
 	if err != nil {
 		logger.Error("failed to initialize application", "error", err)
+
+		cleanup()
+
 		os.Exit(1)
 	}
 	defer cleanup()

--- a/cmd/balance-worker/main.go
+++ b/cmd/balance-worker/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/spf13/pflag"
@@ -60,7 +61,7 @@ func main() {
 
 	app, cleanup, err := initializeApplication(ctx, conf, logger)
 	if err != nil {
-		logger.Error("failed to initialize application", "error", err)
+		slog.Error("failed to initialize application", "error", err)
 
 		cleanup()
 

--- a/cmd/balance-worker/main.go
+++ b/cmd/balance-worker/main.go
@@ -57,9 +57,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	logger := initializeLogger(conf)
-
-	app, cleanup, err := initializeApplication(ctx, conf, logger)
+	app, cleanup, err := initializeApplication(ctx, conf)
 	if err != nil {
 		slog.Error("failed to initialize application", "error", err)
 
@@ -70,6 +68,8 @@ func main() {
 	defer cleanup()
 
 	app.SetGlobals()
+
+	logger := app.Logger
 
 	// Validate service prerequisites
 

--- a/cmd/balance-worker/wire.go
+++ b/cmd/balance-worker/wire.go
@@ -17,9 +17,11 @@ type Application struct {
 	common.GlobalInitializer
 	common.Migrator
 	common.Runner
+
+	Logger *slog.Logger
 }
 
-func initializeApplication(ctx context.Context, conf config.Configuration, logger *slog.Logger) (Application, func(), error) {
+func initializeApplication(ctx context.Context, conf config.Configuration) (Application, func(), error) {
 	wire.Build(
 		metadata,
 		common.Config,
@@ -37,13 +39,6 @@ func initializeApplication(ctx context.Context, conf config.Configuration, logge
 		wire.Struct(new(Application), "*"),
 	)
 	return Application{}, nil, nil
-}
-
-// TODO: is this necessary? Do we need a logger first?
-func initializeLogger(conf config.Configuration) *slog.Logger {
-	wire.Build(metadata, common.Config, common.Logger)
-
-	return new(slog.Logger)
 }
 
 func metadata(conf config.Configuration) common.Metadata {

--- a/cmd/notification-service/main.go
+++ b/cmd/notification-service/main.go
@@ -67,9 +67,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	logger := initializeLogger(conf)
-
-	app, cleanup, err := initializeApplication(ctx, conf, logger)
+	app, cleanup, err := initializeApplication(ctx, conf)
 	if err != nil {
 		slog.Error("failed to initialize application", "error", err)
 
@@ -80,6 +78,8 @@ func main() {
 	defer cleanup()
 
 	app.SetGlobals()
+
+	logger := app.Logger
 
 	// Validate service prerequisites
 

--- a/cmd/notification-service/main.go
+++ b/cmd/notification-service/main.go
@@ -71,7 +71,7 @@ func main() {
 
 	app, cleanup, err := initializeApplication(ctx, conf, logger)
 	if err != nil {
-		logger.Error("failed to initialize application", "error", err)
+		slog.Error("failed to initialize application", "error", err)
 
 		cleanup()
 

--- a/cmd/notification-service/main.go
+++ b/cmd/notification-service/main.go
@@ -72,6 +72,9 @@ func main() {
 	app, cleanup, err := initializeApplication(ctx, conf, logger)
 	if err != nil {
 		logger.Error("failed to initialize application", "error", err)
+
+		cleanup()
+
 		os.Exit(1)
 	}
 	defer cleanup()

--- a/cmd/notification-service/wire.go
+++ b/cmd/notification-service/wire.go
@@ -34,10 +34,11 @@ type Application struct {
 	MessagePublisher   message.Publisher
 	EventPublisher     eventbus.Publisher
 
-	Meter metric.Meter
+	Logger *slog.Logger
+	Meter  metric.Meter
 }
 
-func initializeApplication(ctx context.Context, conf config.Configuration, logger *slog.Logger) (Application, func(), error) {
+func initializeApplication(ctx context.Context, conf config.Configuration) (Application, func(), error) {
 	wire.Build(
 		metadata,
 		common.Config,
@@ -53,13 +54,6 @@ func initializeApplication(ctx context.Context, conf config.Configuration, logge
 		wire.Struct(new(Application), "*"),
 	)
 	return Application{}, nil, nil
-}
-
-// TODO: is this necessary? Do we need a logger first?
-func initializeLogger(conf config.Configuration) *slog.Logger {
-	wire.Build(metadata, common.Config, common.Logger)
-
-	return new(slog.Logger)
 }
 
 func metadata(conf config.Configuration) common.Metadata {

--- a/cmd/notification-service/wire_gen.go
+++ b/cmd/notification-service/wire_gen.go
@@ -22,11 +22,13 @@ import (
 
 // Injectors from wire.go:
 
-func initializeApplication(ctx context.Context, conf config.Configuration, logger *slog.Logger) (Application, func(), error) {
+func initializeApplication(ctx context.Context, conf config.Configuration) (Application, func(), error) {
 	telemetryConfig := conf.Telemetry
-	metricsTelemetryConfig := telemetryConfig.Metrics
+	logTelemetryConfig := telemetryConfig.Log
 	commonMetadata := metadata(conf)
 	resource := common.NewTelemetryResource(commonMetadata)
+	logger := common.NewLogger(logTelemetryConfig, resource)
+	metricsTelemetryConfig := telemetryConfig.Metrics
 	meterProvider, cleanup, err := common.NewMeterProvider(ctx, metricsTelemetryConfig, resource, logger)
 	if err != nil {
 		return Application{}, nil, err
@@ -86,7 +88,6 @@ func initializeApplication(ctx context.Context, conf config.Configuration, logge
 	ingestConfiguration := conf.Ingest
 	kafkaIngestConfiguration := ingestConfiguration.Kafka
 	kafkaConfiguration := kafkaIngestConfiguration.KafkaConfiguration
-	logTelemetryConfig := telemetryConfig.Log
 	brokerOptions := common.NewBrokerConfiguration(kafkaConfiguration, logTelemetryConfig, commonMetadata, logger, meter)
 	notificationConfiguration := conf.Notification
 	v4 := common.NotificationServiceProvisionTopics(notificationConfiguration)
@@ -146,6 +147,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration, logge
 		BrokerOptions:      brokerOptions,
 		MessagePublisher:   publisher,
 		EventPublisher:     eventbusPublisher,
+		Logger:             logger,
 		Meter:              meter,
 	}
 	return application, func() {
@@ -156,16 +158,6 @@ func initializeApplication(ctx context.Context, conf config.Configuration, logge
 		cleanup2()
 		cleanup()
 	}, nil
-}
-
-// TODO: is this necessary? Do we need a logger first?
-func initializeLogger(conf config.Configuration) *slog.Logger {
-	telemetryConfig := conf.Telemetry
-	logTelemetryConfig := telemetryConfig.Log
-	commonMetadata := metadata(conf)
-	resource := common.NewTelemetryResource(commonMetadata)
-	logger := common.NewLogger(logTelemetryConfig, resource)
-	return logger
 }
 
 // wire.go:
@@ -184,7 +176,8 @@ type Application struct {
 	MessagePublisher   message.Publisher
 	EventPublisher     eventbus.Publisher
 
-	Meter metric.Meter
+	Logger *slog.Logger
+	Meter  metric.Meter
 }
 
 func metadata(conf config.Configuration) common.Metadata {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -89,9 +89,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	logger := initializeLogger(conf)
-
-	app, cleanup, err := initializeApplication(ctx, conf, logger)
+	app, cleanup, err := initializeApplication(ctx, conf)
 	if err != nil {
 		slog.Error("failed to initialize application", "error", err)
 
@@ -102,6 +100,8 @@ func main() {
 	defer cleanup()
 
 	app.SetGlobals()
+
+	logger := app.Logger
 
 	logger.Info("starting OpenMeter server", "config", map[string]string{
 		"address":             conf.Address,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -94,6 +94,9 @@ func main() {
 	app, cleanup, err := initializeApplication(ctx, conf, logger)
 	if err != nil {
 		logger.Error("failed to initialize application", "error", err)
+
+		cleanup()
+
 		os.Exit(1)
 	}
 	defer cleanup()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	app, cleanup, err := initializeApplication(ctx, conf, logger)
 	if err != nil {
-		logger.Error("failed to initialize application", "error", err)
+		slog.Error("failed to initialize application", "error", err)
 
 		cleanup()
 

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -40,12 +40,13 @@ type Application struct {
 	NamespaceHandlers []namespace.Handler
 	NamespaceManager  *namespace.Manager
 
-	Meter metric.Meter
+	Logger *slog.Logger
+	Meter  metric.Meter
 
 	RouterHook func(chi.Router)
 }
 
-func initializeApplication(ctx context.Context, conf config.Configuration, logger *slog.Logger) (Application, func(), error) {
+func initializeApplication(ctx context.Context, conf config.Configuration) (Application, func(), error) {
 	wire.Build(
 		metadata,
 		common.Config,
@@ -64,13 +65,6 @@ func initializeApplication(ctx context.Context, conf config.Configuration, logge
 	)
 
 	return Application{}, nil, nil
-}
-
-// TODO: is this necessary? Do we need a logger first?
-func initializeLogger(conf config.Configuration) *slog.Logger {
-	wire.Build(metadata, common.Config, common.Logger)
-
-	return new(slog.Logger)
 }
 
 func metadata(conf config.Configuration) common.Metadata {

--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -78,7 +78,7 @@ func main() {
 
 	app, cleanup, err := initializeApplication(ctx, conf, logger)
 	if err != nil {
-		logger.Error("failed to initialize application", "error", err)
+		slog.Error("failed to initialize application", "error", err)
 
 		cleanup()
 

--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -79,6 +79,9 @@ func main() {
 	app, cleanup, err := initializeApplication(ctx, conf, logger)
 	if err != nil {
 		logger.Error("failed to initialize application", "error", err)
+
+		cleanup()
+
 		os.Exit(1)
 	}
 	defer cleanup()

--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -74,9 +74,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	logger := initializeLogger(conf)
-
-	app, cleanup, err := initializeApplication(ctx, conf, logger)
+	app, cleanup, err := initializeApplication(ctx, conf)
 	if err != nil {
 		slog.Error("failed to initialize application", "error", err)
 
@@ -87,6 +85,8 @@ func main() {
 	defer cleanup()
 
 	app.SetGlobals()
+
+	logger := app.Logger
 
 	logger.Info("starting OpenMeter sink worker", "config", map[string]string{
 		"telemetry.address":   conf.Telemetry.Address,

--- a/cmd/sink-worker/wire.go
+++ b/cmd/sink-worker/wire.go
@@ -32,11 +32,12 @@ type Application struct {
 	FlushHandler     flushhandler.FlushEventHandler
 	TopicProvisioner pkgkafka.TopicProvisioner
 
+	Logger *slog.Logger
 	Meter  metric.Meter
 	Tracer trace.Tracer
 }
 
-func initializeApplication(ctx context.Context, conf config.Configuration, logger *slog.Logger) (Application, func(), error) {
+func initializeApplication(ctx context.Context, conf config.Configuration) (Application, func(), error) {
 	wire.Build(
 		metadata,
 		common.Config,
@@ -52,13 +53,6 @@ func initializeApplication(ctx context.Context, conf config.Configuration, logge
 		wire.Struct(new(Application), "*"),
 	)
 	return Application{}, nil, nil
-}
-
-// TODO: is this necessary? Do we need a logger first?
-func initializeLogger(conf config.Configuration) *slog.Logger {
-	wire.Build(metadata, common.Config, common.Logger)
-
-	return new(slog.Logger)
 }
 
 func metadata(conf config.Configuration) common.Metadata {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This PR simplifies how logging is initialized in the application to increase conformity with standards (OpenTelemetry in this case).

There is a cost however: if the application initialization fails, there is no logger to notify us about that failure (and it will never reach any OTLP exporter, since the "real" logger doesn't get initialized until the whole application initialization is done).

As a compromise, we initialize a basic JSON logger, since JSON is used in most production environments. If anything goes wrong during app init, that logger prints the error to `stderr`.

The recommended approach to deal with app init failures is to have additional monitoring in place that watches over running instances of an application. If there is a crash loop, you know something is up and can directly examine pod logs.

If you have a file based log collector in place (eg. fluentbit/fluentd), you can collect the JSON logs and forward them to your log analytics system.

We may revisit this decision in the future, but for now, we feel this is an acceptable compromise.

## Notes for reviewer

<!-- Anything the reviewer should know? -->
