### PR TITLE
refactor: fix circular dependency

### DIFF
--- a/app/common/watermill.go
+++ b/app/common/watermill.go
@@ -57,7 +57,7 @@ func NewEventBusPublisher(
 ) (eventbus.Publisher, error) {
 	eventBusPublisher, err := eventbus.New(eventbus.Options{
 		Publisher:              publisher,
-		Config:                 conf,
+		TopicMapping:           conf.EventBusTopicMapping(),
 		Logger:                 logger,
 		MarshalerTransformFunc: watermillkafka.AddPartitionKeyFromSubject,
 	})

--- a/app/config/events.go
+++ b/app/config/events.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/viper"
 
+	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/errorsx"
 )
 
@@ -17,6 +18,13 @@ type EventsConfiguration struct {
 
 func (c EventsConfiguration) Validate() error {
 	return c.SystemEvents.Validate()
+}
+
+func (c EventsConfiguration) EventBusTopicMapping() eventbus.TopicMapping {
+	return eventbus.TopicMapping{
+		IngestEventsTopic: c.IngestEvents.Topic,
+		SystemEventsTopic: c.SystemEvents.Topic,
+	}
 }
 
 type EventSubsystemConfiguration struct {

--- a/cmd/jobs/entitlement/init.go
+++ b/cmd/jobs/entitlement/init.go
@@ -78,7 +78,7 @@ func initEntitlements(ctx context.Context, conf config.Configuration, logger *sl
 
 	eventPublisher, err := eventbus.New(eventbus.Options{
 		Publisher:              eventPublisherDriver,
-		Config:                 conf.Events,
+		TopicMapping:           conf.Events.EventBusTopicMapping(),
 		Logger:                 logger,
 		MarshalerTransformFunc: watermillkafka.AddPartitionKeyFromSubject,
 	})

--- a/openmeter/testutils/logger.go
+++ b/openmeter/testutils/logger.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 )
@@ -8,4 +9,18 @@ import (
 func NewLogger(t testing.TB) *slog.Logger {
 	t.Helper()
 	return slog.Default()
+}
+
+// discardHandler is a slog.Handler implementation which does not emit log messages
+// See: https://go-review.googlesource.com/c/go/+/548335/5/src/log/slog/example_discard_test.go#14
+type discardHandler struct {
+	slog.JSONHandler
+}
+
+func (d *discardHandler) Enabled(context.Context, slog.Level) bool { return false }
+
+func NewDiscardLogger(t testing.TB) *slog.Logger {
+	t.Helper()
+
+	return slog.New(&discardHandler{})
 }

--- a/pkg/kafka/topicprovisioner_test.go
+++ b/pkg/kafka/topicprovisioner_test.go
@@ -2,7 +2,6 @@ package kafka
 
 import (
 	"context"
-	"log/slog"
 	"testing"
 	"time"
 
@@ -10,22 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/openmeterio/openmeter/openmeter/testutils"
 )
-
-// FIXME(chrisgacsal): move discardHandler to 'testutils' pkg after import cycle is resolved.
-// discardHandler is a slog.Handler implementation which does not emit log messages
-// See: https://go-review.googlesource.com/c/go/+/548335/5/src/log/slog/example_discard_test.go#14
-type discardHandler struct {
-	slog.JSONHandler
-}
-
-func (d *discardHandler) Enabled(context.Context, slog.Level) bool { return false }
-
-func NewDiscardLogger(t testing.TB) *slog.Logger {
-	t.Helper()
-
-	return slog.New(&discardHandler{})
-}
 
 var _ AdminClient = (*mockTopicProvisioner)(nil)
 
@@ -114,7 +100,7 @@ func TestTopicProvisioner(t *testing.T) {
 
 	adminClient := &mockTopicProvisioner{}
 	meter := noop.NewMeterProvider().Meter("test")
-	logger := NewDiscardLogger(t)
+	logger := testutils.NewDiscardLogger(t)
 
 	provisioner, err := NewTopicProvisioner(TopicProvisionerConfig{
 		AdminClient: adminClient,


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This patch ensures that we are not getting circular dependencies due to the eventbus importing the config package.

A config helper is added to generate the required struct, but that should not cause any issues as this way the direction of the dependency is inversed.

## Notes for reviewer

<!-- Anything the reviewer should know? -->
