### PR TITLE
OSS-62: Prefix metric names in balance-worker

### DIFF
--- a/cmd/jobs/entitlement/recalculatesnapshots.go
+++ b/cmd/jobs/entitlement/recalculatesnapshots.go
@@ -26,13 +26,13 @@ func NewRecalculateBalanceSnapshotsCommand() *cobra.Command {
 
 			logger := slog.Default()
 
-			metricMeter := otel.GetMeterProvider().Meter(otelNameRecalculateBalanceSnapshot)
+			meter := otel.GetMeterProvider().Meter(otelNameRecalculateBalanceSnapshot)
 
 			entitlementConnectors, err := initEntitlements(
 				cmd.Context(),
 				conf,
 				logger,
-				metricMeter,
+				meter,
 				otelNameRecalculateBalanceSnapshot,
 			)
 			if err != nil {
@@ -44,7 +44,7 @@ func NewRecalculateBalanceSnapshotsCommand() *cobra.Command {
 			recalculator, err := balanceworker.NewRecalculator(balanceworker.RecalculatorOptions{
 				Entitlement: entitlementConnectors.Registry,
 				EventBus:    entitlementConnectors.EventBus,
-				MetricMeter: metricMeter,
+				Meter:       meter,
 			})
 			if err != nil {
 				return err

--- a/openmeter/entitlement/balanceworker/entitlementhandler.go
+++ b/openmeter/entitlement/balanceworker/entitlementhandler.go
@@ -100,7 +100,7 @@ func (w *Worker) createSnapshotEvent(ctx context.Context, entitlementEntity *ent
 		return nil, fmt.Errorf("failed to get entitlement value: %w", err)
 	}
 
-	w.metricRecalculationTime.Record(ctx, time.Since(calculationStart).Milliseconds(), metric.WithAttributes(
+	w.metricRecalculationTimeOld.Record(ctx, time.Since(calculationStart).Milliseconds(), metric.WithAttributes(
 		attribute.String(metricAttributeKeyEntitltementType, string(entitlementEntity.EntitlementType)),
 	))
 

--- a/openmeter/entitlement/balanceworker/entitlementhandler.go
+++ b/openmeter/entitlement/balanceworker/entitlementhandler.go
@@ -100,6 +100,14 @@ func (w *Worker) createSnapshotEvent(ctx context.Context, entitlementEntity *ent
 		return nil, fmt.Errorf("failed to get entitlement value: %w", err)
 	}
 
+	w.metricRecalculationTime.Record(
+		ctx,
+		time.Since(calculationStart).Milliseconds(),
+		metric.WithAttributes(
+			attribute.String(metricAttributeKeyEntitltementType, string(entitlementEntity.EntitlementType)),
+		),
+	)
+
 	w.metricRecalculationTimeOld.Record(ctx, time.Since(calculationStart).Milliseconds(), metric.WithAttributes(
 		attribute.String(metricAttributeKeyEntitltementType, string(entitlementEntity.EntitlementType)),
 	))

--- a/openmeter/entitlement/balanceworker/entitlementhandler.go
+++ b/openmeter/entitlement/balanceworker/entitlementhandler.go
@@ -108,10 +108,6 @@ func (w *Worker) createSnapshotEvent(ctx context.Context, entitlementEntity *ent
 		),
 	)
 
-	w.metricRecalculationTimeOld.Record(ctx, time.Since(calculationStart).Milliseconds(), metric.WithAttributes(
-		attribute.String(metricAttributeKeyEntitltementType, string(entitlementEntity.EntitlementType)),
-	))
-
 	mappedValues, err := entitlementdriver.MapEntitlementValueToAPI(value)
 	if err != nil {
 		return nil, fmt.Errorf("failed to map entitlement value: %w", err)

--- a/openmeter/entitlement/balanceworker/recalculate.go
+++ b/openmeter/entitlement/balanceworker/recalculate.go
@@ -39,7 +39,7 @@ type RecalculatorOptions struct {
 	Entitlement     *registry.Entitlement
 	SubjectResolver SubjectResolver
 	EventBus        eventbus.Publisher
-	MetricMeter     metric.Meter
+	Meter           metric.Meter
 }
 
 func (o RecalculatorOptions) Validate() error {
@@ -51,7 +51,7 @@ func (o RecalculatorOptions) Validate() error {
 		return errors.New("missing event bus")
 	}
 
-	if o.MetricMeter == nil {
+	if o.Meter == nil {
 		return errors.New("missing metric meter")
 	}
 
@@ -83,7 +83,7 @@ func NewRecalculator(opts RecalculatorOptions) (*Recalculator, error) {
 		return nil, fmt.Errorf("failed to create subject ID cache: %w", err)
 	}
 
-	metricRecalculationTime, err := opts.MetricMeter.Int64Histogram(
+	metricRecalculationTime, err := opts.Meter.Int64Histogram(
 		metricNameRecalculationTime,
 		metric.WithDescription("Entitlement recalculation time"),
 	)
@@ -91,7 +91,7 @@ func NewRecalculator(opts RecalculatorOptions) (*Recalculator, error) {
 		return nil, fmt.Errorf("failed to create recalculation time histogram: %w", err)
 	}
 
-	metricRecalculationJobRecalculationTime, err := opts.MetricMeter.Int64Histogram(
+	metricRecalculationJobRecalculationTime, err := opts.Meter.Int64Histogram(
 		metricNameRecalculationJobCalculationTime,
 		metric.WithDescription("Time takes to recalculate the entitlements including the necessary data fetches"),
 	)

--- a/openmeter/entitlement/balanceworker/worker.go
+++ b/openmeter/entitlement/balanceworker/worker.go
@@ -66,7 +66,7 @@ type Worker struct {
 
 	highWatermarkCache *lru.Cache[string, highWatermarkCacheEntry]
 
-	metricRecalculationTime metric.Int64Histogram
+	metricRecalculationTimeOld metric.Int64Histogram
 }
 
 func New(opts WorkerOptions) (*Worker, error) {
@@ -75,8 +75,8 @@ func New(opts WorkerOptions) (*Worker, error) {
 		return nil, fmt.Errorf("failed to create high watermark cache: %w", err)
 	}
 
-	metricRecalculationTime, err := opts.Router.MetricMeter.Int64Histogram(
-		metricNameRecalculationTime,
+	metricRecalculationTimeOld, err := opts.Router.MetricMeter.Int64Histogram(
+		metricNameRecalculationTimeOld,
 		metric.WithDescription("Entitlement recalculation time"),
 	)
 	if err != nil {
@@ -89,7 +89,7 @@ func New(opts WorkerOptions) (*Worker, error) {
 		repo:               opts.Repo,
 		highWatermarkCache: highWatermarkCache,
 
-		metricRecalculationTime: metricRecalculationTime,
+		metricRecalculationTimeOld: metricRecalculationTimeOld,
 	}
 
 	router, err := router.NewDefaultRouter(opts.Router)

--- a/openmeter/entitlement/balanceworker/worker.go
+++ b/openmeter/entitlement/balanceworker/worker.go
@@ -67,9 +67,6 @@ type Worker struct {
 	highWatermarkCache *lru.Cache[string, highWatermarkCacheEntry]
 
 	metricRecalculationTime metric.Int64Histogram
-
-	// TODO: remove old metrics once not used anymore
-	metricRecalculationTimeOld metric.Int64Histogram
 }
 
 func New(opts WorkerOptions) (*Worker, error) {
@@ -86,22 +83,13 @@ func New(opts WorkerOptions) (*Worker, error) {
 		return nil, fmt.Errorf("failed to create recalculation time histogram: %w", err)
 	}
 
-	metricRecalculationTimeOld, err := opts.Router.MetricMeter.Int64Histogram(
-		metricNameRecalculationTimeOld,
-		metric.WithDescription("Entitlement recalculation time"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create recalculation time histogram: %w", err)
-	}
-
 	worker := &Worker{
 		opts:               opts,
 		entitlement:        opts.Entitlement,
 		repo:               opts.Repo,
 		highWatermarkCache: highWatermarkCache,
 
-		metricRecalculationTime:    metricRecalculationTime,
-		metricRecalculationTimeOld: metricRecalculationTimeOld,
+		metricRecalculationTime: metricRecalculationTime,
 	}
 
 	router, err := router.NewDefaultRouter(opts.Router)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

In an effort to organize metrics better, we now prefix all metrics with `openmeter.`.

Old metrics are kept for now to make upgrades easier.

Fixes OSS-62

## Notes for reviewer

<!-- Anything the reviewer should know? -->
