### PR TITLE
feat: create invoice backend logic

### DIFF
--- a/openmeter/billing/adapter.go
+++ b/openmeter/billing/adapter.go
@@ -34,6 +34,17 @@ type CustomerOverrideAdapter interface {
 	GetCustomerOverride(ctx context.Context, input GetCustomerOverrideAdapterInput) (*billingentity.CustomerOverride, error)
 	UpdateCustomerOverride(ctx context.Context, input UpdateCustomerOverrideAdapterInput) (*billingentity.CustomerOverride, error)
 	DeleteCustomerOverride(ctx context.Context, input DeleteCustomerOverrideInput) error
+
+	// UpsertCustomerOverrideIgnoringTrns upserts a customer override ignoring the transactional context, the override
+	// will be empty.
+	//
+	// This allows us to provision a customer override outside of a transactional context, and rely on LockCustomerForUpdate
+	// to coordinate ongoing transactions for a single customer.
+	//
+	// This approach is used for gathering invoices where we can ensure that no more than one gathering invoice
+	// is created per customer, per currency.
+	//
+	// For invoice specific changes the LockInvoicesForUpdate should be used, which will be more performant.
 	UpsertCustomerOverrideIgnoringTrns(ctx context.Context, input UpsertCustomerOverrideIgnoringTrnsAdapterInput) error
 	LockCustomerForUpdate(ctx context.Context, input LockCustomerForUpdateAdapterInput) error
 

--- a/openmeter/billing/adapter.go
+++ b/openmeter/billing/adapter.go
@@ -35,17 +35,9 @@ type CustomerOverrideAdapter interface {
 	UpdateCustomerOverride(ctx context.Context, input UpdateCustomerOverrideAdapterInput) (*billingentity.CustomerOverride, error)
 	DeleteCustomerOverride(ctx context.Context, input DeleteCustomerOverrideInput) error
 
-	// UpsertCustomerOverrideIgnoringTrns upserts a customer override ignoring the transactional context, the override
+	// UpsertCustomerOverride upserts a customer override ignoring the transactional context, the override
 	// will be empty.
-	//
-	// This allows us to provision a customer override outside of a transactional context, and rely on LockCustomerForUpdate
-	// to coordinate ongoing transactions for a single customer.
-	//
-	// This approach is used for gathering invoices where we can ensure that no more than one gathering invoice
-	// is created per customer, per currency.
-	//
-	// For invoice specific changes the LockInvoicesForUpdate should be used, which will be more performant.
-	UpsertCustomerOverrideIgnoringTrns(ctx context.Context, input UpsertCustomerOverrideIgnoringTrnsAdapterInput) error
+	UpsertCustomerOverride(ctx context.Context, input UpsertCustomerOverrideAdapterInput) error
 	LockCustomerForUpdate(ctx context.Context, input LockCustomerForUpdateAdapterInput) error
 
 	GetCustomerOverrideReferencingProfile(ctx context.Context, input HasCustomerOverrideReferencingProfileAdapterInput) ([]customerentity.CustomerID, error)

--- a/openmeter/billing/adapter.go
+++ b/openmeter/billing/adapter.go
@@ -34,16 +34,23 @@ type CustomerOverrideAdapter interface {
 	GetCustomerOverride(ctx context.Context, input GetCustomerOverrideAdapterInput) (*billingentity.CustomerOverride, error)
 	UpdateCustomerOverride(ctx context.Context, input UpdateCustomerOverrideAdapterInput) (*billingentity.CustomerOverride, error)
 	DeleteCustomerOverride(ctx context.Context, input DeleteCustomerOverrideInput) error
+	UpsertCustomerOverrideIgnoringTrns(ctx context.Context, input UpsertCustomerOverrideIgnoringTrnsAdapterInput) error
+	LockCustomerForUpdate(ctx context.Context, input LockCustomerForUpdateAdapterInput) error
 
 	GetCustomerOverrideReferencingProfile(ctx context.Context, input HasCustomerOverrideReferencingProfileAdapterInput) ([]customerentity.CustomerID, error)
 }
 
 type InvoiceLineAdapter interface {
 	CreateInvoiceLines(ctx context.Context, input CreateInvoiceLinesAdapterInput) (*CreateInvoiceLinesResponse, error)
+	ListInvoiceLines(ctx context.Context, input ListInvoiceLinesAdapterInput) ([]billingentity.Line, error)
+	AssociateLinesToInvoice(ctx context.Context, input AssociateLinesToInvoiceAdapterInput) error
 }
 
 type InvoiceAdapter interface {
 	CreateInvoice(ctx context.Context, input CreateInvoiceAdapterInput) (CreateInvoiceAdapterRespone, error)
 	GetInvoiceById(ctx context.Context, input GetInvoiceByIdInput) (billingentity.Invoice, error)
+	LockInvoicesForUpdate(ctx context.Context, input LockInvoicesForUpdateInput) error
+	DeleteInvoices(ctx context.Context, input DeleteInvoicesAdapterInput) error
 	ListInvoices(ctx context.Context, input ListInvoicesInput) (ListInvoicesResponse, error)
+	AssociatedLineCounts(ctx context.Context, input AssociatedLineCountsAdapterInput) (AssociatedLineCountsAdapterResponse, error)
 }

--- a/openmeter/billing/adapter/adapter.go
+++ b/openmeter/billing/adapter/adapter.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log/slog"
 
+	lru "github.com/hashicorp/golang-lru/v2"
+
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
@@ -36,17 +38,27 @@ func New(config Config) (billing.Adapter, error) {
 		return nil, err
 	}
 
+	cache, err := lru.New[string, *db.BillingCustomerOverride](defaultCustomerOverrideCacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create customer override cache: %w", err)
+	}
+
 	return &adapter{
-		db:     config.Client,
-		logger: config.Logger,
+		db:                          config.Client,
+		dbWithoutTrns:               config.Client,
+		logger:                      config.Logger,
+		upsertCustomerOverrideCache: cache,
 	}, nil
 }
 
 var _ billing.Adapter = (*adapter)(nil)
 
 type adapter struct {
-	db     *entdb.Client
-	logger *slog.Logger
+	db *entdb.Client
+	// dbWithoutTrns is used to execute any upsert operations outside of ctx driven transactions
+	dbWithoutTrns               *entdb.Client
+	logger                      *slog.Logger
+	upsertCustomerOverrideCache *lru.Cache[string, *db.BillingCustomerOverride]
 }
 
 func (a adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
@@ -63,7 +75,9 @@ func (a adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) billing.Adap
 	txDb := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 
 	return &adapter{
-		db:     txDb.Client(),
-		logger: a.logger,
+		db:                          txDb.Client(),
+		dbWithoutTrns:               a.dbWithoutTrns,
+		logger:                      a.logger,
+		upsertCustomerOverrideCache: a.upsertCustomerOverrideCache,
 	}
 }

--- a/openmeter/billing/adapter/adapter.go
+++ b/openmeter/billing/adapter/adapter.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	lru "github.com/hashicorp/golang-lru/v2"
-
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
@@ -38,16 +36,10 @@ func New(config Config) (billing.Adapter, error) {
 		return nil, err
 	}
 
-	cache, err := lru.New[string, *db.BillingCustomerOverride](defaultCustomerOverrideCacheSize)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create customer override cache: %w", err)
-	}
-
 	return &adapter{
-		db:                          config.Client,
-		dbWithoutTrns:               config.Client,
-		logger:                      config.Logger,
-		upsertCustomerOverrideCache: cache,
+		db:            config.Client,
+		dbWithoutTrns: config.Client,
+		logger:        config.Logger,
 	}, nil
 }
 
@@ -56,9 +48,8 @@ var _ billing.Adapter = (*adapter)(nil)
 type adapter struct {
 	db *entdb.Client
 	// dbWithoutTrns is used to execute any upsert operations outside of ctx driven transactions
-	dbWithoutTrns               *entdb.Client
-	logger                      *slog.Logger
-	upsertCustomerOverrideCache *lru.Cache[string, *db.BillingCustomerOverride]
+	dbWithoutTrns *entdb.Client
+	logger        *slog.Logger
 }
 
 func (a adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
@@ -75,9 +66,8 @@ func (a adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) billing.Adap
 	txDb := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 
 	return &adapter{
-		db:                          txDb.Client(),
-		dbWithoutTrns:               a.dbWithoutTrns,
-		logger:                      a.logger,
-		upsertCustomerOverrideCache: a.upsertCustomerOverrideCache,
+		db:            txDb.Client(),
+		dbWithoutTrns: a.dbWithoutTrns,
+		logger:        a.logger,
 	}
 }

--- a/openmeter/billing/adapter/adapter.go
+++ b/openmeter/billing/adapter/adapter.go
@@ -37,19 +37,16 @@ func New(config Config) (billing.Adapter, error) {
 	}
 
 	return &adapter{
-		db:            config.Client,
-		dbWithoutTrns: config.Client,
-		logger:        config.Logger,
+		db:     config.Client,
+		logger: config.Logger,
 	}, nil
 }
 
 var _ billing.Adapter = (*adapter)(nil)
 
 type adapter struct {
-	db *entdb.Client
-	// dbWithoutTrns is used to execute any upsert operations outside of ctx driven transactions
-	dbWithoutTrns *entdb.Client
-	logger        *slog.Logger
+	db     *entdb.Client
+	logger *slog.Logger
 }
 
 func (a adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
@@ -66,8 +63,7 @@ func (a adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) billing.Adap
 	txDb := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 
 	return &adapter{
-		db:            txDb.Client(),
-		dbWithoutTrns: a.dbWithoutTrns,
-		logger:        a.logger,
+		db:     txDb.Client(),
+		logger: a.logger,
 	}
 }

--- a/openmeter/billing/adapter/customeroverride.go
+++ b/openmeter/billing/adapter/customeroverride.go
@@ -178,8 +178,8 @@ func (r *adapter) GetCustomerOverrideReferencingProfile(ctx context.Context, inp
 	return customerIDs, nil
 }
 
-func (r *adapter) UpsertCustomerOverrideIgnoringTrns(ctx context.Context, input billing.UpsertCustomerOverrideIgnoringTrnsAdapterInput) error {
-	err := r.dbWithoutTrns.BillingCustomerOverride.Create().
+func (r *adapter) UpsertCustomerOverride(ctx context.Context, input billing.UpsertCustomerOverrideAdapterInput) error {
+	err := r.db.BillingCustomerOverride.Create().
 		SetNamespace(input.Namespace).
 		SetCustomerID(input.ID).
 		OnConflict(

--- a/openmeter/billing/customeroverride.go
+++ b/openmeter/billing/customeroverride.go
@@ -154,6 +154,6 @@ func (i HasCustomerOverrideReferencingProfileAdapterInput) Validate() error {
 }
 
 type (
-	UpsertCustomerOverrideIgnoringTrnsAdapterInput = customerentity.CustomerID
-	LockCustomerForUpdateAdapterInput              = customerentity.CustomerID
+	UpsertCustomerOverrideAdapterInput = customerentity.CustomerID
+	LockCustomerForUpdateAdapterInput  = customerentity.CustomerID
 )

--- a/openmeter/billing/customeroverride.go
+++ b/openmeter/billing/customeroverride.go
@@ -152,3 +152,8 @@ type HasCustomerOverrideReferencingProfileAdapterInput genericNamespaceID
 func (i HasCustomerOverrideReferencingProfileAdapterInput) Validate() error {
 	return genericNamespaceID(i).Validate()
 }
+
+type (
+	UpsertCustomerOverrideIgnoringTrnsAdapterInput = customerentity.CustomerID
+	LockCustomerForUpdateAdapterInput              = customerentity.CustomerID
+)

--- a/openmeter/billing/entity/invoice.go
+++ b/openmeter/billing/entity/invoice.go
@@ -116,6 +116,12 @@ func (s InvoiceStatus) IsMutable() bool {
 	return true
 }
 
+type InvoiceID models.NamespacedID
+
+func (i InvoiceID) Validate() error {
+	return models.NamespacedID(i).Validate()
+}
+
 type Invoice struct {
 	Namespace string `json:"namespace"`
 	ID        string `json:"id"`

--- a/openmeter/billing/errors.go
+++ b/openmeter/billing/errors.go
@@ -45,6 +45,7 @@ const (
 	EntityCustomer         = "Customer"
 	EntityDefaultProfile   = "DefaultBillingProfile"
 	EntityInvoice          = "Invoice"
+	EntityInvoiceLine      = "InvoiceLine"
 )
 
 type NotFoundError struct {

--- a/openmeter/billing/httpdriver/invoiceline.go
+++ b/openmeter/billing/httpdriver/invoiceline.go
@@ -24,7 +24,7 @@ type (
 
 func (h *handler) CreateLineByCustomer() CreateLineByCustomerHandler {
 	return httptransport.NewHandlerWithArgs(
-		func(ctx context.Context, r *http.Request, customerKeyOrId string) (CreateLineByCustomerRequest, error) {
+		func(ctx context.Context, r *http.Request, customerID string) (CreateLineByCustomerRequest, error) {
 			body := api.BillingCreateLineByCustomerJSONRequestBody{}
 
 			if err := commonhttp.JSONRequestBodyDecoder(r, &body); err != nil {
@@ -46,9 +46,9 @@ func (h *handler) CreateLineByCustomer() CreateLineByCustomerHandler {
 			}
 
 			return CreateLineByCustomerRequest{
-				CustomerKeyOrID: customerKeyOrId,
-				Namespace:       ns,
-				Lines:           lines,
+				CustomerID: customerID,
+				Namespace:  ns,
+				Lines:      lines,
 			}, nil
 		},
 		func(ctx context.Context, request CreateLineByCustomerRequest) (CreateLineByCustomerResponse, error) {

--- a/openmeter/billing/invoice.go
+++ b/openmeter/billing/invoice.go
@@ -155,7 +155,7 @@ func (c CreateInvoiceAdapterInput) Validate() error {
 
 type CreateInvoiceAdapterRespone = billingentity.Invoice
 
-type CreateInvoiceAsOfInput struct {
+type CreateInvoiceInput struct {
 	Customer customerentity.CustomerID
 
 	// IncludePendingLines is a list of line IDs that should be included in the invoice.
@@ -165,7 +165,7 @@ type CreateInvoiceAsOfInput struct {
 	AsOf                *time.Time
 }
 
-func (i CreateInvoiceAsOfInput) Validate() error {
+func (i CreateInvoiceInput) Validate() error {
 	if err := i.Customer.Validate(); err != nil {
 		return fmt.Errorf("customer: %w", err)
 	}

--- a/openmeter/billing/invoice.go
+++ b/openmeter/billing/invoice.go
@@ -158,10 +158,7 @@ type CreateInvoiceAdapterRespone = billingentity.Invoice
 type CreateInvoiceInput struct {
 	Customer customerentity.CustomerID
 
-	// IncludePendingLines is a list of line IDs that should be included in the invoice.
-	// If nil, only asof is considered to collect the pending items.
-	// If the array is empty, an empty invoice is created.
-	IncludePendingLines *[]string
+	IncludePendingLines []string
 	AsOf                *time.Time
 }
 

--- a/openmeter/billing/invoiceline.go
+++ b/openmeter/billing/invoiceline.go
@@ -3,14 +3,15 @@ package billing
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	billingentity "github.com/openmeterio/openmeter/openmeter/billing/entity"
 )
 
 type CreateInvoiceLinesInput struct {
-	CustomerKeyOrID string
-	Namespace       string
-	Lines           []billingentity.Line
+	CustomerID string
+	Namespace  string
+	Lines      []billingentity.Line
 }
 
 func (c CreateInvoiceLinesInput) Validate() error {
@@ -18,7 +19,7 @@ func (c CreateInvoiceLinesInput) Validate() error {
 		return errors.New("namespace is required")
 	}
 
-	if c.CustomerKeyOrID == "" {
+	if c.CustomerID == "" {
 		return errors.New("customer key or ID is required")
 	}
 
@@ -56,4 +57,40 @@ func (c CreateInvoiceLinesAdapterInput) Validate() error {
 
 type CreateInvoiceLinesResponse struct {
 	Lines []billingentity.Line
+}
+
+type ListInvoiceLinesAdapterInput struct {
+	Namespace string
+
+	CustomerID      string
+	InvoiceStatuses []billingentity.InvoiceStatus
+	InvoiceAtBefore *time.Time
+
+	LineIDs []string
+}
+
+func (g ListInvoiceLinesAdapterInput) Validate() error {
+	if g.Namespace == "" {
+		return errors.New("namespace is required")
+	}
+
+	return nil
+}
+
+type AssociateLinesToInvoiceAdapterInput struct {
+	Invoice billingentity.InvoiceID
+
+	LineIDs []string
+}
+
+func (i AssociateLinesToInvoiceAdapterInput) Validate() error {
+	if err := i.Invoice.Validate(); err != nil {
+		return fmt.Errorf("invoice: %w", err)
+	}
+
+	if len(i.LineIDs) == 0 {
+		return errors.New("line ids are required")
+	}
+
+	return nil
 }

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -38,5 +38,5 @@ type InvoiceLineService interface {
 type InvoiceService interface {
 	ListInvoices(ctx context.Context, input ListInvoicesInput) (ListInvoicesResponse, error)
 	GetInvoiceByID(ctx context.Context, input GetInvoiceByIdInput) (billingentity.Invoice, error)
-	CreateInvoiceAsOf(ctx context.Context, input CreateInvoiceAsOfInput) ([]billingentity.Invoice, error)
+	CreateInvoice(ctx context.Context, input CreateInvoiceInput) ([]billingentity.Invoice, error)
 }

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -37,4 +37,6 @@ type InvoiceLineService interface {
 
 type InvoiceService interface {
 	ListInvoices(ctx context.Context, input ListInvoicesInput) (ListInvoicesResponse, error)
+	GetInvoiceByID(ctx context.Context, input GetInvoiceByIdInput) (billingentity.Invoice, error)
+	CreateInvoiceAsOf(ctx context.Context, input CreateInvoiceAsOfInput) ([]billingentity.Invoice, error)
 }

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -68,7 +68,7 @@ func (s *Service) GetInvoiceByID(ctx context.Context, input billing.GetInvoiceBy
 	})
 }
 
-func (s *Service) CreateInvoiceAsOf(ctx context.Context, input billing.CreateInvoiceAsOfInput) ([]billingentity.Invoice, error) {
+func (s *Service) CreateInvoice(ctx context.Context, input billing.CreateInvoiceInput) ([]billingentity.Invoice, error) {
 	if err := input.Validate(); err != nil {
 		return nil, billing.ValidationError{
 			Err: err,
@@ -193,7 +193,7 @@ func (s *Service) CreateInvoiceAsOf(ctx context.Context, input billing.CreateInv
 		})
 }
 
-func (s *Service) gatherInscopeLines(ctx context.Context, input billing.CreateInvoiceAsOfInput, txAdapter billing.Adapter, asOf time.Time) ([]billingentity.Line, error) {
+func (s *Service) gatherInscopeLines(ctx context.Context, input billing.CreateInvoiceInput, txAdapter billing.Adapter, asOf time.Time) ([]billingentity.Line, error) {
 	if input.IncludePendingLines != nil {
 		if len(*input.IncludePendingLines) == 0 {
 			// We would like to create an empty invoice

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -3,9 +3,15 @@ package billingservice
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	billingentity "github.com/openmeterio/openmeter/openmeter/billing/entity"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 )
 
@@ -36,4 +42,225 @@ func (s *Service) ListInvoices(ctx context.Context, input billing.ListInvoicesIn
 
 		return invoices, nil
 	})
+}
+
+func (s *Service) GetInvoiceByID(ctx context.Context, input billing.GetInvoiceByIdInput) (billingentity.Invoice, error) {
+	return entutils.TransactingRepo(ctx, s.adapter, func(ctx context.Context, txAdapter billing.Adapter) (billingentity.Invoice, error) {
+		invoice, err := txAdapter.GetInvoiceById(ctx, input)
+		if err != nil {
+			return billingentity.Invoice{}, err
+		}
+
+		if input.Expand.WorkflowApps {
+			resolvedApps, err := s.resolveApps(ctx, input.Invoice.Namespace, invoice.Workflow.AppReferences)
+			if err != nil {
+				return billingentity.Invoice{}, fmt.Errorf("error resolving apps for invoice [%s]: %w", invoice.ID, err)
+			}
+
+			invoice.Workflow.Apps = &billingentity.ProfileApps{
+				Tax:       resolvedApps.Tax.App,
+				Invoicing: resolvedApps.Invoicing.App,
+				Payment:   resolvedApps.Payment.App,
+			}
+		}
+
+		return invoice, nil
+	})
+}
+
+func (s *Service) CreateInvoiceAsOf(ctx context.Context, input billing.CreateInvoiceAsOfInput) ([]billingentity.Invoice, error) {
+	if err := input.Validate(); err != nil {
+		return nil, billing.ValidationError{
+			Err: err,
+		}
+	}
+
+	return TransactingRepoForGatheringInvoiceManipulation(
+		ctx,
+		s.adapter,
+		input.Customer,
+		func(ctx context.Context, txAdapter billing.Adapter) ([]billingentity.Invoice, error) {
+			// let's resolve the customer's settings
+			customerProfile, err := s.GetProfileWithCustomerOverride(ctx, billing.GetProfileWithCustomerOverrideInput{
+				Namespace:  input.Customer.Namespace,
+				CustomerID: input.Customer.ID,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("fetching customer profile: %w", err)
+			}
+
+			asof := lo.FromPtrOr(input.AsOf, clock.Now())
+
+			// let's gather the in-scope lines and validate it
+			inScopeLines, err := s.gatherInscopeLines(ctx, input, txAdapter, asof)
+			if err != nil {
+				return nil, err
+			}
+
+			sourceInvoiceIDs := lo.Uniq(lo.Map(inScopeLines, func(l billingentity.Line, _ int) string {
+				return l.InvoiceID
+			}))
+
+			if len(sourceInvoiceIDs) > 0 {
+				// let's lock the source gathering invoices, so that no other staging call can add items to them in
+				// case we would need to delete them
+				err = txAdapter.LockInvoicesForUpdate(ctx, billing.LockInvoicesForUpdateInput{
+					Namespace:  input.Customer.Namespace,
+					InvoiceIDs: sourceInvoiceIDs,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("locking gathering invoices: %w", err)
+				}
+			}
+
+			linesByCurrency := lo.GroupBy(inScopeLines, func(line billingentity.Line) currencyx.Code {
+				return line.Currency
+			})
+
+			createdInvoices := make([]billingentity.InvoiceID, 0, len(linesByCurrency))
+
+			for currency, lines := range linesByCurrency {
+				// let's create the invoice
+				invoice, err := txAdapter.CreateInvoice(ctx, billing.CreateInvoiceAdapterInput{
+					Namespace: input.Customer.Namespace,
+					Customer:  customerProfile.Customer,
+					Profile:   customerProfile.Profile,
+
+					Currency: currency,
+					Status:   billingentity.InvoiceStatusDraft,
+
+					Type: billingentity.InvoiceTypeStandard,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("creating invoice: %w", err)
+				}
+
+				createdInvoices = append(createdInvoices, billingentity.InvoiceID{
+					Namespace: invoice.Namespace,
+					ID:        invoice.ID,
+				})
+
+				// let's associate the invoice lines to the invoice
+				err = s.associateLinesToInvoice(ctx, txAdapter, invoice, lines)
+				if err != nil {
+					return nil, fmt.Errorf("associating lines to invoice: %w", err)
+				}
+			}
+
+			// Let's check if we need to remove any empty gathering invoices (e.g. if they don't have any line items)
+			// This typically should happen when a subscription has ended.
+
+			invoiceLineCounts, err := txAdapter.AssociatedLineCounts(ctx, billing.AssociatedLineCountsAdapterInput{
+				Namespace:  input.Customer.Namespace,
+				InvoiceIDs: sourceInvoiceIDs,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("cleanup: line counts check: %w", err)
+			}
+
+			invoicesWithoutLines := lo.Filter(sourceInvoiceIDs, func(id string, _ int) bool {
+				return invoiceLineCounts.Counts[billingentity.InvoiceID{
+					Namespace: input.Customer.Namespace,
+					ID:        id,
+				}] == 0
+			})
+
+			if len(invoicesWithoutLines) > 0 {
+				err = txAdapter.DeleteInvoices(ctx, billing.DeleteInvoicesAdapterInput{
+					Namespace:  input.Customer.Namespace,
+					InvoiceIDs: invoicesWithoutLines,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("cleanup invoices: %w", err)
+				}
+			}
+
+			// Assemble output: we need to refetch as the association call will have side-effects of updating
+			// invoice objects (e.g. totals, period, etc.)
+			out := make([]billingentity.Invoice, 0, len(createdInvoices))
+			for _, invoiceID := range createdInvoices {
+				invoiceWithLines, err := s.GetInvoiceByID(ctx, billing.GetInvoiceByIdInput{
+					Invoice: invoiceID,
+					Expand:  billing.InvoiceExpandAll,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("cannot get invoice[%s]: %w", invoiceWithLines.ID, err)
+				}
+
+				out = append(out, invoiceWithLines)
+			}
+			return out, nil
+		})
+}
+
+func (s *Service) gatherInscopeLines(ctx context.Context, input billing.CreateInvoiceAsOfInput, txAdapter billing.Adapter, asOf time.Time) ([]billingentity.Line, error) {
+	if input.IncludePendingLines != nil {
+		if len(*input.IncludePendingLines) == 0 {
+			// We would like to create an empty invoice
+			return []billingentity.Line{}, nil
+		}
+
+		inScopeLines, err := txAdapter.ListInvoiceLines(ctx,
+			billing.ListInvoiceLinesAdapterInput{
+				Namespace:  input.Customer.Namespace,
+				CustomerID: input.Customer.ID,
+
+				LineIDs: *input.IncludePendingLines,
+			})
+		if err != nil {
+			return nil, fmt.Errorf("resolving in scope lines: %w", err)
+		}
+
+		// output validation
+
+		// asOf validity
+		for _, line := range inScopeLines {
+			if line.InvoiceAt.After(asOf) {
+				return nil, billing.ValidationError{
+					Err: fmt.Errorf("line [%s] has invoiceAt [%s] after asOf [%s]", line.ID, line.InvoiceAt, asOf),
+				}
+			}
+		}
+
+		// all lines must be found
+		if len(inScopeLines) != len(*input.IncludePendingLines) {
+			includedLines := lo.Map(inScopeLines, func(l billingentity.Line, _ int) string {
+				return l.ID
+			})
+
+			missingIDs := lo.Without(*input.IncludePendingLines, includedLines...)
+
+			return nil, billing.NotFoundError{
+				ID:     strings.Join(missingIDs, ","),
+				Entity: billing.EntityInvoiceLine,
+				Err:    fmt.Errorf("some invoice lines are not found"),
+			}
+		}
+
+		return inScopeLines, nil
+	}
+
+	lines, err := txAdapter.ListInvoiceLines(ctx,
+		billing.ListInvoiceLinesAdapterInput{
+			Namespace:  input.Customer.Namespace,
+			CustomerID: input.Customer.ID,
+
+			InvoiceStatuses: []billingentity.InvoiceStatus{
+				billingentity.InvoiceStatusGathering,
+			},
+
+			InvoiceAtBefore: lo.ToPtr(asOf),
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(lines) == 0 {
+		// We haven't requested explicit empty invoice, so we should have some pending lines
+		return nil, billing.ValidationError{
+			Err: fmt.Errorf("no pending lines found"),
+		}
+	}
+
+	return lines, nil
 }

--- a/openmeter/billing/service/service.go
+++ b/openmeter/billing/service/service.go
@@ -66,6 +66,11 @@ func New(config Config) (*Service, error) {
 // an update lock is held on the customer record. This is useful when you need to manipulate the gathering invoices, as we cannot lock an
 // invoice, that doesn't exist yet.
 func TransactingRepoForGatheringInvoiceManipulation[T any](ctx context.Context, adapter billing.Adapter, customer customerentity.CustomerID, fn func(ctx context.Context, txAdapter billing.Adapter) (T, error)) (T, error) {
+	if err := customer.Validate(); err != nil {
+		var empty T
+		return empty, fmt.Errorf("validating customer: %w", err)
+	}
+
 	err := adapter.UpsertCustomerOverrideIgnoringTrns(ctx, customer)
 	if err != nil {
 		var empty T

--- a/openmeter/billing/service/service.go
+++ b/openmeter/billing/service/service.go
@@ -71,7 +71,8 @@ func TransactingRepoForGatheringInvoiceManipulation[T any](ctx context.Context, 
 		return empty, fmt.Errorf("validating customer: %w", err)
 	}
 
-	err := adapter.UpsertCustomerOverrideIgnoringTrns(ctx, customer)
+	// NOTE: This should not be in transaction, or we can get a conflict for parallel writes
+	err := adapter.UpsertCustomerOverride(ctx, customer)
 	if err != nil {
 		var empty T
 		return empty, fmt.Errorf("upserting customer override: %w", err)

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -86,8 +86,8 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 
 		res, err := s.BillingService.CreateInvoiceLines(ctx,
 			billing.CreateInvoiceLinesInput{
-				Namespace:       namespace,
-				CustomerKeyOrID: customerEntity.ID,
+				Namespace:  namespace,
+				CustomerID: customerEntity.ID,
 				Lines: []billingentity.Line{
 					{
 						LineBase: billingentity.LineBase{
@@ -324,5 +324,233 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 		require.NotNil(s.T(), invoice.Workflow.Apps.Tax, "apps should be resolved")
 		require.NotNil(s.T(), invoice.Workflow.Apps.Invoicing, "apps should be resolved")
 		require.NotNil(s.T(), invoice.Workflow.Apps.Payment, "apps should be resolved")
+	})
+}
+
+func (s *InvoicingTestSuite) TestCreateInvoice() {
+	namespace := "ns-create-invoice-gathering-to-draft"
+	now := time.Now().Truncate(time.Microsecond)
+	periodEnd := now.Add(-time.Hour)
+	periodStart := periodEnd.Add(-time.Hour * 24 * 30)
+	line1IssueAt := now.Add(-2 * time.Hour)
+	line2IssueAt := now.Add(-time.Hour)
+
+	_ = s.installSandboxApp(s.T(), namespace)
+
+	ctx := context.Background()
+
+	// Given we have a test customer
+
+	customerEntity, err := s.CustomerService.CreateCustomer(ctx, customerentity.CreateCustomerInput{
+		Namespace: namespace,
+
+		Customer: customerentity.Customer{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Name: "Test Customer",
+			}),
+			PrimaryEmail: lo.ToPtr("test@test.com"),
+			BillingAddress: &models.Address{
+				Country: lo.ToPtr(models.CountryCode("US")),
+			},
+			Currency: lo.ToPtr(currencyx.Code(currency.USD)),
+		},
+	})
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), customerEntity)
+	require.NotEmpty(s.T(), customerEntity.ID)
+
+	// Given we have a default profile for the namespace
+
+	minimalCreateProfileInput := minimalCreateProfileInputTemplate
+	minimalCreateProfileInput.Namespace = namespace
+
+	profile, err := s.BillingService.CreateProfile(ctx, minimalCreateProfileInput)
+
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), profile)
+
+	res, err := s.BillingService.CreateInvoiceLines(ctx,
+		billing.CreateInvoiceLinesInput{
+			Namespace:  namespace,
+			CustomerID: customerEntity.ID,
+			Lines: []billingentity.Line{
+				{
+					LineBase: billingentity.LineBase{
+						Namespace: namespace,
+						Period:    billingentity.Period{Start: periodStart, End: periodEnd},
+
+						InvoiceAt: line1IssueAt,
+
+						Type: billingentity.InvoiceLineTypeManualFee,
+
+						Name:     "Test item1",
+						Currency: currencyx.Code(currency.USD),
+
+						Metadata: map[string]string{
+							"key": "value",
+						},
+					},
+					ManualFee: &billingentity.ManualFeeLine{
+						Price:    alpacadecimal.NewFromFloat(100),
+						Quantity: alpacadecimal.NewFromFloat(1),
+					},
+				},
+				{
+					LineBase: billingentity.LineBase{
+						Namespace: namespace,
+						Period:    billingentity.Period{Start: periodStart, End: periodEnd},
+
+						InvoiceAt: line2IssueAt,
+
+						Type: billingentity.InvoiceLineTypeManualFee,
+
+						Name:     "Test item2",
+						Currency: currencyx.Code(currency.USD),
+					},
+					ManualFee: &billingentity.ManualFeeLine{
+						Price:    alpacadecimal.NewFromFloat(200),
+						Quantity: alpacadecimal.NewFromFloat(3),
+					},
+				},
+			},
+		})
+
+	// Then we should have the items created
+	require.NoError(s.T(), err)
+	require.Len(s.T(), res.Lines, 2)
+	line1ID := res.Lines[0].ID
+	line2ID := res.Lines[1].ID
+	require.NotEmpty(s.T(), line1ID)
+	require.NotEmpty(s.T(), line2ID)
+
+	// Expect that a single gathering invoice has been created
+	require.Equal(s.T(), res.Lines[0].InvoiceID, res.Lines[1].InvoiceID)
+	gatheringInvoiceID := billingentity.InvoiceID{
+		Namespace: namespace,
+		ID:        res.Lines[0].InvoiceID,
+	}
+
+	s.Run("Creating invoice in the future fails", func() {
+		_, err := s.BillingService.CreateInvoiceAsOf(ctx, billing.CreateInvoiceAsOfInput{
+			Customer: customerentity.CustomerID{
+				ID:        customerEntity.ID,
+				Namespace: customerEntity.Namespace,
+			},
+			AsOf: lo.ToPtr(now.Add(time.Hour)),
+		})
+
+		require.Error(s.T(), err)
+		require.ErrorAs(s.T(), err, &billing.ValidationError{})
+	})
+
+	s.Run("Creating invoice without any pending lines being available fails", func() {
+		_, err := s.BillingService.CreateInvoiceAsOf(ctx, billing.CreateInvoiceAsOfInput{
+			Customer: customerentity.CustomerID{
+				ID:        customerEntity.ID,
+				Namespace: customerEntity.Namespace,
+			},
+
+			AsOf: lo.ToPtr(line1IssueAt.Add(-time.Minute)),
+		})
+
+		require.Error(s.T(), err)
+		require.ErrorAs(s.T(), err, &billing.ValidationError{})
+	})
+
+	s.Run("Number of pending invoice lines is reported correctly by the adapter", func() {
+		res, err := s.BillingAdapter.AssociatedLineCounts(ctx, billing.AssociatedLineCountsAdapterInput{
+			Namespace:  namespace,
+			InvoiceIDs: []string{gatheringInvoiceID.ID},
+		})
+
+		require.NoError(s.T(), err)
+		require.Len(s.T(), res.Counts, 1)
+		require.Equal(s.T(), int64(2), res.Counts[gatheringInvoiceID])
+	})
+
+	s.Run("When creating an invoice with only item1 included", func() {
+		invoice, err := s.BillingService.CreateInvoiceAsOf(ctx, billing.CreateInvoiceAsOfInput{
+			Customer: customerentity.CustomerID{
+				ID:        customerEntity.ID,
+				Namespace: customerEntity.Namespace,
+			},
+			AsOf: lo.ToPtr(line1IssueAt.Add(time.Minute)),
+		})
+
+		// Then we should have the invoice created
+		require.NoError(s.T(), err)
+		require.Len(s.T(), invoice, 1)
+
+		// Then we should have item1 added to the invoice
+		require.Len(s.T(), invoice[0].Lines, 1)
+		require.Equal(s.T(), line1ID, invoice[0].Lines[0].ID)
+
+		// Then we expect that the gathering invoice is still present, with item2
+		gatheringInvoice, err := s.BillingService.GetInvoiceByID(ctx, billing.GetInvoiceByIdInput{
+			Invoice: gatheringInvoiceID,
+			Expand:  billing.InvoiceExpandAll,
+		})
+		require.NoError(s.T(), err)
+		require.Nil(s.T(), gatheringInvoice.DeletedAt, "gathering invoice should be present")
+		require.Len(s.T(), gatheringInvoice.Lines, 1)
+		require.Equal(s.T(), line2ID, gatheringInvoice.Lines[0].ID)
+	})
+
+	s.Run("When creating an invoice with only item2 included, but bad asof", func() {
+		_, err := s.BillingService.CreateInvoiceAsOf(ctx, billing.CreateInvoiceAsOfInput{
+			Customer: customerentity.CustomerID{
+				ID:        customerEntity.ID,
+				Namespace: customerEntity.Namespace,
+			},
+			IncludePendingLines: lo.ToPtr([]string{line2ID}),
+			AsOf:                lo.ToPtr(line1IssueAt.Add(time.Minute)),
+		})
+
+		// Then we should receive a validation error
+		require.Error(s.T(), err)
+		require.ErrorAs(s.T(), err, &billing.ValidationError{})
+	})
+
+	s.Run("When creating an invoice with only item2 included", func() {
+		invoice, err := s.BillingService.CreateInvoiceAsOf(ctx, billing.CreateInvoiceAsOfInput{
+			Customer: customerentity.CustomerID{
+				ID:        customerEntity.ID,
+				Namespace: customerEntity.Namespace,
+			},
+			IncludePendingLines: lo.ToPtr([]string{line2ID}),
+			AsOf:                lo.ToPtr(now),
+		})
+
+		// Then we should have the invoice created
+		require.NoError(s.T(), err)
+		require.Len(s.T(), invoice, 1)
+
+		// Then we should have item2 added to the invoice
+		require.Len(s.T(), invoice[0].Lines, 1)
+		require.Equal(s.T(), line2ID, invoice[0].Lines[0].ID)
+
+		// Then we expect that the gathering invoice is deleted and empty
+		gatheringInvoice, err := s.BillingService.GetInvoiceByID(ctx, billing.GetInvoiceByIdInput{
+			Invoice: gatheringInvoiceID,
+			Expand:  billing.InvoiceExpandAll,
+		})
+		require.NoError(s.T(), err)
+		require.NotNil(s.T(), gatheringInvoice.DeletedAt, "gathering invoice should be present")
+		require.Len(s.T(), gatheringInvoice.Lines, 0, "deleted gathering invoice is empty")
+	})
+
+	s.Run("When include pending lines is an empty array", func() {
+		invoice, err := s.BillingService.CreateInvoiceAsOf(ctx, billing.CreateInvoiceAsOfInput{
+			Customer: customerentity.CustomerID{
+				ID:        customerEntity.ID,
+				Namespace: customerEntity.Namespace,
+			},
+			IncludePendingLines: lo.ToPtr([]string{}),
+		})
+
+		// Then we should have the invoice created
+		require.NoError(s.T(), err)
+		// Without any items
+		require.Len(s.T(), invoice, 0)
 	})
 }

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -502,7 +502,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 				ID:        customerEntity.ID,
 				Namespace: customerEntity.Namespace,
 			},
-			IncludePendingLines: lo.ToPtr([]string{line2ID}),
+			IncludePendingLines: []string{line2ID},
 			AsOf:                lo.ToPtr(line1IssueAt.Add(time.Minute)),
 		})
 
@@ -517,7 +517,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 				ID:        customerEntity.ID,
 				Namespace: customerEntity.Namespace,
 			},
-			IncludePendingLines: lo.ToPtr([]string{line2ID}),
+			IncludePendingLines: []string{line2ID},
 			AsOf:                lo.ToPtr(now),
 		})
 
@@ -537,20 +537,5 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 		require.NoError(s.T(), err)
 		require.NotNil(s.T(), gatheringInvoice.DeletedAt, "gathering invoice should be present")
 		require.Len(s.T(), gatheringInvoice.Lines, 0, "deleted gathering invoice is empty")
-	})
-
-	s.Run("When include pending lines is an empty array", func() {
-		invoice, err := s.BillingService.CreateInvoice(ctx, billing.CreateInvoiceInput{
-			Customer: customerentity.CustomerID{
-				ID:        customerEntity.ID,
-				Namespace: customerEntity.Namespace,
-			},
-			IncludePendingLines: lo.ToPtr([]string{}),
-		})
-
-		// Then we should have the invoice created
-		require.NoError(s.T(), err)
-		// Without any items
-		require.Len(s.T(), invoice, 0)
 	})
 }

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -431,7 +431,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 	}
 
 	s.Run("Creating invoice in the future fails", func() {
-		_, err := s.BillingService.CreateInvoiceAsOf(ctx, billing.CreateInvoiceAsOfInput{
+		_, err := s.BillingService.CreateInvoice(ctx, billing.CreateInvoiceInput{
 			Customer: customerentity.CustomerID{
 				ID:        customerEntity.ID,
 				Namespace: customerEntity.Namespace,
@@ -444,7 +444,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 	})
 
 	s.Run("Creating invoice without any pending lines being available fails", func() {
-		_, err := s.BillingService.CreateInvoiceAsOf(ctx, billing.CreateInvoiceAsOfInput{
+		_, err := s.BillingService.CreateInvoice(ctx, billing.CreateInvoiceInput{
 			Customer: customerentity.CustomerID{
 				ID:        customerEntity.ID,
 				Namespace: customerEntity.Namespace,
@@ -469,7 +469,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 	})
 
 	s.Run("When creating an invoice with only item1 included", func() {
-		invoice, err := s.BillingService.CreateInvoiceAsOf(ctx, billing.CreateInvoiceAsOfInput{
+		invoice, err := s.BillingService.CreateInvoice(ctx, billing.CreateInvoiceInput{
 			Customer: customerentity.CustomerID{
 				ID:        customerEntity.ID,
 				Namespace: customerEntity.Namespace,
@@ -497,7 +497,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 	})
 
 	s.Run("When creating an invoice with only item2 included, but bad asof", func() {
-		_, err := s.BillingService.CreateInvoiceAsOf(ctx, billing.CreateInvoiceAsOfInput{
+		_, err := s.BillingService.CreateInvoice(ctx, billing.CreateInvoiceInput{
 			Customer: customerentity.CustomerID{
 				ID:        customerEntity.ID,
 				Namespace: customerEntity.Namespace,
@@ -512,7 +512,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 	})
 
 	s.Run("When creating an invoice with only item2 included", func() {
-		invoice, err := s.BillingService.CreateInvoiceAsOf(ctx, billing.CreateInvoiceAsOfInput{
+		invoice, err := s.BillingService.CreateInvoice(ctx, billing.CreateInvoiceInput{
 			Customer: customerentity.CustomerID{
 				ID:        customerEntity.ID,
 				Namespace: customerEntity.Namespace,
@@ -540,7 +540,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 	})
 
 	s.Run("When include pending lines is an empty array", func() {
-		invoice, err := s.BillingService.CreateInvoiceAsOf(ctx, billing.CreateInvoiceAsOfInput{
+		invoice, err := s.BillingService.CreateInvoice(ctx, billing.CreateInvoiceInput{
 			Customer: customerentity.CustomerID{
 				ID:        customerEntity.ID,
 				Namespace: customerEntity.Namespace,


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch adds the required backend code for the create invoice now endpoint.

The overall logic is, that we take all of the pending invoice lines and whatever is due, we assign it to a new invoice. 

Further invoice changes will be handled by a proper state machine, but this transition requires cross-invoice state coordination.
