### PR TITLE
fix: treat inactive entitlement as deleted

### DIFF
--- a/openmeter/entitlement/balanceworker/recalculate.go
+++ b/openmeter/entitlement/balanceworker/recalculate.go
@@ -147,7 +147,7 @@ func (r *Recalculator) processEntitlements(ctx context.Context, entitlements []e
 }
 
 func (r *Recalculator) sendEntitlementEvent(ctx context.Context, ent entitlement.Entitlement) error {
-	if ent.DeletedAt != nil {
+	if ent.DeletedAt != nil || (ent.ActiveTo != nil && time.Now().After(*ent.ActiveTo)) {
 		return r.sendEntitlementDeletedEvent(ctx, ent)
 	}
 


### PR DESCRIPTION

## Overview

When an entitlement is not active anymore, the recalculator yields this error.

```
error sending event for entitlement [id=XXX]: failed to map entitlement value: unknown entitlement type
```
