### PR TITLE
fix(telemetry): filter otel logs by log level

### DIFF
--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -243,7 +243,7 @@ type LevelHandler struct {
 
 func (h *LevelHandler) Enabled(ctx context.Context, level slog.Level) bool {
 	// The higher the level, the more important or severe the event.
-	return level >= h.level.Level()
+	return level >= h.level.Level() && h.handler.Enabled(ctx, level)
 }
 
 func (h *LevelHandler) WithGroup(name string) slog.Handler {

--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -242,6 +242,7 @@ type LevelHandler struct {
 }
 
 func (h *LevelHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	// The higher the level, the more important or severe the event.
 	return level >= h.level.Level()
 }
 

--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -247,13 +247,13 @@ func (h *LevelHandler) Enabled(ctx context.Context, level slog.Level) bool {
 }
 
 func (h *LevelHandler) WithGroup(name string) slog.Handler {
-	return h.WithGroup(name)
+	return h.handler.WithGroup(name)
 }
 
 func (h *LevelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return h.WithAttrs(attrs)
+	return h.handler.WithAttrs(attrs)
 }
 
 func (h *LevelHandler) Handle(ctx context.Context, record slog.Record) error {
-	return h.Handle(ctx, record)
+	return h.handler.Handle(ctx, record)
 }

--- a/app/common/telemetry_test.go
+++ b/app/common/telemetry_test.go
@@ -1,0 +1,46 @@
+package common
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+)
+
+func TestLevelHandler(t *testing.T) {
+	mockHandler := &MockHandler{}
+	logger := slog.New(NewLevelHandler(mockHandler, slog.LevelInfo))
+
+	mockHandler.On("Enabled", mock.Anything, slog.LevelInfo).Return(true)
+	mockHandler.On("Enabled", mock.Anything, slog.LevelWarn).Return(true)
+	mockHandler.On("Enabled", mock.Anything, slog.LevelError).Return(true)
+
+	logger.Debug("debug")
+	logger.Info("info")
+	logger.Warn("warn")
+	logger.Error("error")
+
+	mockHandler.AssertExpectations(t)
+}
+
+type MockHandler struct {
+	mock.Mock
+}
+
+func (h *MockHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	args := h.Called(ctx, level)
+	return args.Bool(0)
+}
+
+func (h *MockHandler) WithGroup(name string) slog.Handler {
+	return h
+}
+
+func (h *MockHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *MockHandler) Handle(ctx context.Context, record slog.Record) error {
+	return nil
+}


### PR DESCRIPTION
The OTel slog bridge doesn't accept log-level configuration.