### PR TITLE
feat(client): go generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ update-openapi: ## Update OpenAPI spec
 	dagger call --source .:default generate openapi -o ./api/openapi.yaml
 	go generate ./api/...
 
+
+.PHONY: update-openapi-cloud
+update-openapi-cloud: ## Update OpenAPI spec
+	$(call print-target)
+	dagger call --source .:default generate openapicloud -o ./api/openapi.cloud.yaml
+	go generate ./api/...
+
 .PHONY: gen-api
 gen-api: ## Generate API and SDKs
 	$(call print-target)

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ update-openapi-cloud: ## Update OpenAPI spec
 .PHONY: gen-api
 gen-api: ## Generate API and SDKs
 	$(call print-target)
-	go generate ./api/...
-# dagger call generate node-sdk -o api/client/node
-# dagger call generate web-sdk -o api/client/web
-# dagger call generate python-sdk -o api/client/python
+	$(MAKE) update-openapi-cloud
+	dagger call generate node-sdk -o api/client/node
+	# dagger call generate web-sdk -o api/client/web
+	# dagger call generate python-sdk -o api/client/python
 
 .PHONY: migrate-check
 migrate-check: ## Validate migrations

--- a/api/client/go/client.gen.go
+++ b/api/client/go/client.gen.go
@@ -28,7 +28,6 @@ const (
 	CloudCookieAuthScopes      = "CloudCookieAuth.Scopes"
 	CloudPortalTokenAuthScopes = "CloudPortalTokenAuth.Scopes"
 	CloudTokenAuthScopes       = "CloudTokenAuth.Scopes"
-	PortalTokenAuthScopes      = "PortalTokenAuth.Scopes"
 )
 
 // Defines values for AppCapabilityType.
@@ -82,6 +81,15 @@ const (
 	BillingFlatFeeLineCreateOrUpdateTypeFlatFee BillingFlatFeeLineCreateOrUpdateType = "flat_fee"
 )
 
+// Defines values for BillingInvoiceAction.
+const (
+	Advance BillingInvoiceAction = "advance"
+	Approve BillingInvoiceAction = "approve"
+	Delete  BillingInvoiceAction = "delete"
+	Retry   BillingInvoiceAction = "retry"
+	Void    BillingInvoiceAction = "void"
+)
+
 // Defines values for BillingInvoiceExpand.
 const (
 	BillingInvoiceExpandAll          BillingInvoiceExpand = "*"
@@ -89,6 +97,24 @@ const (
 	BillingInvoiceExpandPreceding    BillingInvoiceExpand = "preceding"
 	BillingInvoiceExpandWorkflow     BillingInvoiceExpand = "workflow"
 	BillingInvoiceExpandWorkflowApps BillingInvoiceExpand = "workflow.apps"
+)
+
+// Defines values for BillingInvoiceExtendedStatus.
+const (
+	BillingInvoiceExtendedStatusDraft                     BillingInvoiceExtendedStatus = "draft"
+	BillingInvoiceExtendedStatusDraftCreated              BillingInvoiceExtendedStatus = "draft_created"
+	BillingInvoiceExtendedStatusDraftInvalid              BillingInvoiceExtendedStatus = "draft_invalid"
+	BillingInvoiceExtendedStatusDraftManualApprovalNeeded BillingInvoiceExtendedStatus = "draft_manual_approval_needed"
+	BillingInvoiceExtendedStatusDraftReadyToIssue         BillingInvoiceExtendedStatus = "draft_ready_to_issue"
+	BillingInvoiceExtendedStatusDraftSyncFailed           BillingInvoiceExtendedStatus = "draft_sync_failed"
+	BillingInvoiceExtendedStatusDraftSyncing              BillingInvoiceExtendedStatus = "draft_syncing"
+	BillingInvoiceExtendedStatusDraftValidating           BillingInvoiceExtendedStatus = "draft_validating"
+	BillingInvoiceExtendedStatusDraftWaitingAutoApproval  BillingInvoiceExtendedStatus = "draft_waiting_auto_approval"
+	BillingInvoiceExtendedStatusGathering                 BillingInvoiceExtendedStatus = "gathering"
+	BillingInvoiceExtendedStatusIssued                    BillingInvoiceExtendedStatus = "issued"
+	BillingInvoiceExtendedStatusIssuing                   BillingInvoiceExtendedStatus = "issuing"
+	BillingInvoiceExtendedStatusIssuingSyncFailed         BillingInvoiceExtendedStatus = "issuing_sync_failed"
+	BillingInvoiceExtendedStatusIssuingSyncing            BillingInvoiceExtendedStatus = "issuing_syncing"
 )
 
 // Defines values for BillingInvoiceOrderBy.
@@ -102,12 +128,10 @@ const (
 
 // Defines values for BillingInvoiceStatus.
 const (
-	Gathering              BillingInvoiceStatus = "gathering"
-	Issued                 BillingInvoiceStatus = "issued"
-	ManualApprovalRequired BillingInvoiceStatus = "manual_approval_required"
-	PaymentReceived        BillingInvoiceStatus = "payment_received"
-	Review                 BillingInvoiceStatus = "review"
-	ValidationFailed       BillingInvoiceStatus = "validation_failed"
+	BillingInvoiceStatusDraft     BillingInvoiceStatus = "draft"
+	BillingInvoiceStatusGathering BillingInvoiceStatus = "gathering"
+	BillingInvoiceStatusIssued    BillingInvoiceStatus = "issued"
+	BillingInvoiceStatusIssuing   BillingInvoiceStatus = "issuing"
 )
 
 // Defines values for BillingInvoiceType.
@@ -138,10 +162,14 @@ const (
 	ManualFee BillingManualFeeLineCreateOrUpdateType = "manual_fee"
 )
 
-// Defines values for BillingPaymentTermType.
+// Defines values for BillingPaymentTermDueDateType.
 const (
-	DueDate BillingPaymentTermType = "due_date"
-	Instant BillingPaymentTermType = "instant"
+	DueDate BillingPaymentTermDueDateType = "due_date"
+)
+
+// Defines values for BillingPaymentTermInstantType.
+const (
+	Instant BillingPaymentTermInstantType = "instant"
 )
 
 // Defines values for BillingProfileExpand.
@@ -162,6 +190,12 @@ const (
 const (
 	Exclusive BillingTaxBehavior = "exclusive"
 	Inclusive BillingTaxBehavior = "inclusive"
+)
+
+// Defines values for BillingValidationIssueSeverity.
+const (
+	Critical BillingValidationIssueSeverity = "critical"
+	Warning  BillingValidationIssueSeverity = "warning"
 )
 
 // Defines values for BillingVoidInvoiceLineAction.
@@ -186,6 +220,13 @@ const (
 const (
 	Embedded CheckoutSessionUIMode = "embedded"
 	Hosted   CheckoutSessionUIMode = "hosted"
+)
+
+// Defines values for CustomerOrderBy.
+const (
+	CustomerOrderByCreatedAt CustomerOrderBy = "createdAt"
+	CustomerOrderById        CustomerOrderBy = "id"
+	CustomerOrderByName      CustomerOrderBy = "name"
 )
 
 // Defines values for EntitlementBooleanCreateInputsType.
@@ -340,32 +381,27 @@ const (
 	UnsupportedResponseType OAuth2AuthorizationCodeGrantErrorType = "unsupported_response_type"
 )
 
-// Defines values for OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0Op.
-const (
-	OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0OpAdd OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0Op = "add"
-)
-
-// Defines values for OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1Op.
-const (
-	OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1OpRemove OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1Op = "remove"
-)
-
 // Defines values for PhasesOrderBy.
 const (
-	Key PhasesOrderBy = "key"
+	PhasesOrderByKey        PhasesOrderBy = "key"
+	PhasesOrderByStartAfter PhasesOrderBy = "start_after"
 )
 
 // Defines values for PlanOrderBy.
 const (
-	PlanOrderById  PlanOrderBy = "id"
-	PlanOrderByKey PlanOrderBy = "key"
+	PlanOrderByCreateAt  PlanOrderBy = "create_at"
+	PlanOrderById        PlanOrderBy = "id"
+	PlanOrderByKey       PlanOrderBy = "key"
+	PlanOrderByUpdatedAt PlanOrderBy = "updated_at"
+	PlanOrderByVersion   PlanOrderBy = "version"
 )
 
 // Defines values for PlanStatus.
 const (
-	Active   PlanStatus = "active"
-	Archived PlanStatus = "archived"
-	Draft    PlanStatus = "draft"
+	Active    PlanStatus = "active"
+	Archived  PlanStatus = "archived"
+	Draft     PlanStatus = "draft"
+	Scheduled PlanStatus = "scheduled"
 )
 
 // Defines values for PricePaymentTerm.
@@ -454,6 +490,41 @@ const (
 	Succeeded             StripePaymentIntentStatus = "succeeded"
 )
 
+// Defines values for SubscriptionEditAddOp.
+const (
+	SubscriptionEditAddOpAdd SubscriptionEditAddOp = "add"
+)
+
+// Defines values for SubscriptionEditAddItemOp.
+const (
+	SubscriptionEditAddItemOpAdd SubscriptionEditAddItemOp = "add"
+)
+
+// Defines values for SubscriptionEditAddUpdateItemOp.
+const (
+	Add SubscriptionEditAddUpdateItemOp = "add"
+)
+
+// Defines values for SubscriptionEditExtendOp.
+const (
+	Extend SubscriptionEditExtendOp = "extend"
+)
+
+// Defines values for SubscriptionEditRemoveItemOp.
+const (
+	SubscriptionEditRemoveItemOpRemove SubscriptionEditRemoveItemOp = "remove"
+)
+
+// Defines values for SubscriptionEditRemoveUpdateItemOp.
+const (
+	SubscriptionEditRemoveUpdateItemOpRemove SubscriptionEditRemoveUpdateItemOp = "remove"
+)
+
+// Defines values for SubscriptionEditRemoveWithValueOp.
+const (
+	Remove SubscriptionEditRemoveWithValueOp = "remove"
+)
+
 // Defines values for SvixOperationalWebhookRequestType.
 const (
 	EndpointCreated         SvixOperationalWebhookRequestType = "endpoint.created"
@@ -490,31 +561,6 @@ const (
 const (
 	False GetSubscriptionGetSubscriptionParamsExpand = false
 	True  GetSubscriptionGetSubscriptionParamsExpand = true
-)
-
-// Defines values for EditSubscriptionJSONBody0Op.
-const (
-	EditSubscriptionJSONBody0OpAdd EditSubscriptionJSONBody0Op = "add"
-)
-
-// Defines values for EditSubscriptionJSONBody1Op.
-const (
-	EditSubscriptionJSONBody1OpRemove EditSubscriptionJSONBody1Op = "remove"
-)
-
-// Defines values for EditSubscriptionJSONBody2Op.
-const (
-	Add EditSubscriptionJSONBody2Op = "add"
-)
-
-// Defines values for EditSubscriptionJSONBody3Op.
-const (
-	Extend EditSubscriptionJSONBody3Op = "extend"
-)
-
-// Defines values for EditSubscriptionJSONBody4Op.
-const (
-	Remove EditSubscriptionJSONBody4Op = "remove"
 )
 
 // Address Address
@@ -868,13 +914,6 @@ type BillingGenericDocumentRef struct {
 	Type        BillingDocumentRefType `json:"type"`
 }
 
-// BillingGenericPaymentTerms defines model for BillingGenericPaymentTerms.
-type BillingGenericPaymentTerms struct {
-	Detail *string                `json:"detail,omitempty"`
-	Notes  *string                `json:"notes,omitempty"`
-	Type   BillingPaymentTermType `json:"type"`
-}
-
 // BillingInvoice defines model for BillingInvoice.
 type BillingInvoice struct {
 	// CreatedAt Timestamp of when the resource was created.
@@ -888,6 +927,13 @@ type BillingInvoice struct {
 	// Description Optional description of the resource. Maximum 1024 characters.
 	Description *string                   `json:"description,omitempty"`
 	Discounts   *[]BillingInvoiceDiscount `json:"discounts,omitempty"`
+
+	// DraftUntil The time until the invoice is in draft status.
+	//
+	// On draft invoice creation it is calculated from the workflow settings.
+	//
+	// If manual approval is required, the draftUntil time is set.
+	DraftUntil *time.Time `json:"draftUntil,omitempty"`
 
 	// DueAt [RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.
 	DueAt *time.Time `json:"dueAt,omitempty"`
@@ -913,19 +959,21 @@ type BillingInvoice struct {
 	// Please note that the number is (depending on the upstream settings) either unique for the
 	// whole organization or unique for the customer, or in multi (stripe) account setups unique for the
 	// account.
-	Number    *BillingInvoiceNumber  `json:"number,omitempty"`
-	Payment   *BillingInvoicePayment `json:"payment,omitempty"`
-	Period    *BillingPeriod         `json:"period,omitempty"`
-	Preceding *[]BillingDocumentRef  `json:"preceding,omitempty"`
-	Status    BillingInvoiceStatus   `json:"status"`
-	Supplier  BillingParty           `json:"supplier"`
-	Totals    BillingInvoiceTotals   `json:"totals"`
-	Type      BillingInvoiceType     `json:"type"`
+	Number        *BillingInvoiceNumber       `json:"number,omitempty"`
+	Payment       *BillingInvoicePayment      `json:"payment,omitempty"`
+	Period        *BillingPeriod              `json:"period,omitempty"`
+	Preceding     *[]BillingDocumentRef       `json:"preceding,omitempty"`
+	Status        BillingInvoiceStatus        `json:"status"`
+	StatusDetails BillingInvoiceStatusDetails `json:"statusDetails"`
+	Supplier      BillingParty                `json:"supplier"`
+	Totals        BillingInvoiceTotals        `json:"totals"`
+	Type          BillingInvoiceType          `json:"type"`
 
 	// UpdatedAt Timestamp of when the resource was last updated.
 	//
 	// For updates the updatedAt field is used to detect conflicts.
-	UpdatedAt time.Time `json:"updatedAt"`
+	UpdatedAt        time.Time                 `json:"updatedAt"`
+	ValidationIssues *[]BillingValidationIssue `json:"validationIssues,omitempty"`
 
 	// VoidedAt The time the invoice was voided.
 	//
@@ -938,6 +986,9 @@ type BillingInvoice struct {
 	// field is optional as it should be explicitly requested with expand options.
 	Workflow *BillingInvoiceWorkflowSettings `json:"workflow,omitempty"`
 }
+
+// BillingInvoiceAction defines model for BillingInvoiceAction.
+type BillingInvoiceAction string
 
 // BillingInvoiceCreateInput defines model for BillingInvoiceCreateInput.
 type BillingInvoiceCreateInput struct {
@@ -963,6 +1014,12 @@ type BillingInvoiceDiscount struct {
 
 // BillingInvoiceExpand InvoiceExpand specifies the parts of the invoice to expand in the list output.
 type BillingInvoiceExpand string
+
+// BillingInvoiceExtendedStatus InvoiceExtendedStatus describes the extended status of an invoice.
+//
+// This is used to provide more detailed information about the status of the invoice. Useful for
+// troubelshooting invoice workflow issues.
+type BillingInvoiceExtendedStatus string
 
 // BillingInvoiceLine defines model for BillingInvoiceLine.
 type BillingInvoiceLine struct {
@@ -1004,6 +1061,14 @@ type BillingInvoiceReference struct {
 
 // BillingInvoiceStatus InvoiceStatus describes the status of an invoice.
 type BillingInvoiceStatus string
+
+// BillingInvoiceStatusDetails defines model for BillingInvoiceStatusDetails.
+type BillingInvoiceStatusDetails struct {
+	AvailableActions []BillingInvoiceAction       `json:"availableActions"`
+	ExtendedStatus   BillingInvoiceExtendedStatus `json:"extendedStatus"`
+	Failed           bool                         `json:"failed"`
+	Immutable        bool                         `json:"immutable"`
+}
 
 // BillingInvoiceTotals defines model for BillingInvoiceTotals.
 type BillingInvoiceTotals struct {
@@ -1181,13 +1246,25 @@ type BillingPartyCreate struct {
 }
 
 // BillingPaymentTermDueDate defines model for BillingPaymentTermDueDate.
-type BillingPaymentTermDueDate = BillingGenericPaymentTerms
+type BillingPaymentTermDueDate struct {
+	Detail *string                       `json:"detail,omitempty"`
+	DueAt  []BillingDueDate              `json:"dueAt"`
+	Notes  *string                       `json:"notes,omitempty"`
+	Type   BillingPaymentTermDueDateType `json:"type"`
+}
+
+// BillingPaymentTermDueDateType defines model for BillingPaymentTermDueDate.Type.
+type BillingPaymentTermDueDateType string
 
 // BillingPaymentTermInstant defines model for BillingPaymentTermInstant.
-type BillingPaymentTermInstant = BillingGenericPaymentTerms
+type BillingPaymentTermInstant struct {
+	Detail *string                       `json:"detail,omitempty"`
+	Notes  *string                       `json:"notes,omitempty"`
+	Type   BillingPaymentTermInstantType `json:"type"`
+}
 
-// BillingPaymentTermType defines model for BillingPaymentTermType.
-type BillingPaymentTermType string
+// BillingPaymentTermInstantType defines model for BillingPaymentTermInstant.Type.
+type BillingPaymentTermInstantType string
 
 // BillingPaymentTerms defines model for BillingPaymentTerms.
 type BillingPaymentTerms struct {
@@ -1323,6 +1400,23 @@ type BillingTaxItem struct {
 	Percent   *Percentage         `json:"percent,omitempty"`
 	Surcharge *Numeric            `json:"surcharge,omitempty"`
 }
+
+// BillingValidationIssue ValidationIssue captures any validation issues related to the invoice.
+//
+// Issues with severity "critical" will prevent the invoice from being issued.
+type BillingValidationIssue struct {
+	Code      *string                        `json:"code,omitempty"`
+	Component string                         `json:"component"`
+	Field     *string                        `json:"field,omitempty"`
+	Message   string                         `json:"message"`
+	Metadata  *Metadata                      `json:"metadata,omitempty"`
+	Severity  BillingValidationIssueSeverity `json:"severity"`
+}
+
+// BillingValidationIssueSeverity ValidationIssueSeverity describes the severity of a validation issue.
+//
+// Issues with severity "critical" will prevent the invoice from being issued.
+type BillingValidationIssueSeverity string
 
 // BillingVoidInvoiceAction InvoiceVoidAction describes how to handle the voided line items.
 type BillingVoidInvoiceAction struct {
@@ -1527,6 +1621,37 @@ type CreateStripeCheckoutSessionResult struct {
 	Url string `json:"url"`
 }
 
+// CreateSubscriptionRequestBody Create subscription request body.
+type CreateSubscriptionRequestBody struct {
+	// ActiveFrom [RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.
+	ActiveFrom time.Time `json:"activeFrom"`
+
+	// Currency Three-letter [ISO4217](https://www.iso.org/iso-4217-currency-codes.html) currency code.
+	// Custom three-letter currency codes are also supported for convenience.
+	Currency CurrencyCode `json:"currency"`
+
+	// CustomerId ULID (Universally Unique Lexicographically Sortable Identifier).
+	CustomerId string `json:"customerId"`
+
+	// Customizations Batch processing commands for customizing the susbcription.
+	// The key format is `/phases/{phaseKey}/items/{itemKey}`.
+	//
+	// Add operations insert a new member based on the creation input without altering the existing members.
+	//
+	// Remove operations remove the member from the document.
+	Customizations []CreateSubscriptionRequestBody_Customizations_Item `json:"customizations"`
+	Plan           struct {
+		// Key A key is a unique string that is used to identify a resource.
+		Key     string `json:"key"`
+		Version int    `json:"version"`
+	} `json:"plan"`
+}
+
+// CreateSubscriptionRequestBody_Customizations_Item defines model for CreateSubscriptionRequestBody.customizations.Item.
+type CreateSubscriptionRequestBody_Customizations_Item struct {
+	union json.RawMessage
+}
+
 // CurrencyCode Three-letter [ISO4217](https://www.iso.org/iso-4217-currency-codes.html) currency code.
 // Custom three-letter currency codes are also supported for convenience.
 type CurrencyCode = string
@@ -1603,6 +1728,9 @@ type CustomerList struct {
 	// TotalCount The total number of items.
 	TotalCount int `json:"totalCount"`
 }
+
+// CustomerOrderBy Order by options for customers.
+type CustomerOrderBy string
 
 // CustomerOverridePaginatedResponse Paginated response
 type CustomerOverridePaginatedResponse struct {
@@ -2619,58 +2747,6 @@ type Numeric = string
 // OAuth2AuthorizationCodeGrantErrorType OAuth2 authorization code grant error types.
 type OAuth2AuthorizationCodeGrantErrorType string
 
-// OpenMeterProductCatalogCreateSubscriptionRequestBody defines model for OpenMeter.ProductCatalog.CreateSubscriptionRequestBody.
-type OpenMeterProductCatalogCreateSubscriptionRequestBody struct {
-	// ActiveFrom [RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.
-	ActiveFrom time.Time `json:"activeFrom"`
-
-	// Currency Three-letter [ISO4217](https://www.iso.org/iso-4217-currency-codes.html) currency code.
-	// Custom three-letter currency codes are also supported for convenience.
-	Currency CurrencyCode `json:"currency"`
-
-	// CustomerId ULID (Universally Unique Lexicographically Sortable Identifier).
-	CustomerId string `json:"customerId"`
-
-	// Customizations Batch processing commands for customizing the susbcription.
-	// The key format is `/phases/{phaseKey}/items/{itemKey}`.
-	//
-	// Add operations insert a new member based on the creation input without altering the existing members.
-	//
-	// Remove operations remove the member from the document.
-	Customizations []OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item `json:"customizations"`
-	Plan           struct {
-		// Key A key is a unique string that is used to identify a resource.
-		Key     string `json:"key"`
-		Version int    `json:"version"`
-	} `json:"plan"`
-}
-
-// OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0 defines model for .
-type OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0 struct {
-	Op   OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0Op `json:"op"`
-	Path string                                                                `json:"path"`
-
-	// Value A rate card defines the pricing and entitlement of a feature or service.
-	Value RateCard `json:"value"`
-}
-
-// OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0Op defines model for OpenMeterProductCatalogCreateSubscriptionRequestBody.Customizations.0.Op.
-type OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0Op string
-
-// OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1 defines model for .
-type OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1 struct {
-	Op   OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1Op `json:"op"`
-	Path string                                                                `json:"path"`
-}
-
-// OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1Op defines model for OpenMeterProductCatalogCreateSubscriptionRequestBody.Customizations.1.Op.
-type OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1Op string
-
-// OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item defines model for OpenMeter.ProductCatalog.CreateSubscriptionRequestBody.customizations.Item.
-type OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item struct {
-	union json.RawMessage
-}
-
 // Percentage Numeric representation of a percentage
 type Percentage = string
 
@@ -2724,9 +2800,10 @@ type Plan struct {
 
 	// Status The status of the plan.
 	// Computed based on the effective start and end dates:
-	// - draft = no effectiveStartDate
-	// - active = effectiveStartDate <= now < effectiveEndDate
-	// - archived / inactive = effectiveEndDate <= now
+	// - draft = no effectiveFrom
+	// - active = effectiveFrom <= now < effectiveTo
+	// - archived / inactive = effectiveTo <= now
+	// - scheduled = now < effectiveFrom < effectiveTo
 	Status *PlanStatus `json:"status,omitempty"`
 
 	// UpdatedAt Timestamp of when the resource was last updated.
@@ -2878,7 +2955,7 @@ type PlanPhaseUpdate struct {
 	StartAfter *string `json:"startAfter"`
 }
 
-// PlanReference Referebces an exact plan.
+// PlanReference References an exact plan.
 type PlanReference struct {
 	// Key The plan key.
 	Key string `json:"key"`
@@ -3009,6 +3086,7 @@ type RateCardEntitlement struct {
 // RateCardFlatFee A flat fee rate card defines a one-time purchase or a recurring fee.
 type RateCardFlatFee struct {
 	// BillingCadence The billing cadence of the rate card.
+	// When null it means it is a one time fee.
 	BillingCadence *string `json:"billingCadence"`
 
 	// CreatedAt Timestamp of when the resource was created.
@@ -3057,6 +3135,7 @@ type RateCardFlatFeeType string
 // RateCardFlatFeeUpdateItem A flat fee rate card defines a one-time purchase or a recurring fee.
 type RateCardFlatFeeUpdateItem struct {
 	// BillingCadence The billing cadence of the rate card.
+	// When null it means it is a one time fee.
 	BillingCadence *string `json:"billingCadence"`
 
 	// Description Optional description of the resource. Maximum 1024 characters.
@@ -3140,7 +3219,6 @@ type RateCardUpdateItem struct {
 // RateCardUsageBased A usage-based rate card defines a price based on usage.
 type RateCardUsageBased struct {
 	// BillingCadence The billing cadence of the rate card.
-	// When null, the rate card is a one-time purchase.
 	BillingCadence string `json:"billingCadence"`
 
 	// CreatedAt Timestamp of when the resource was created.
@@ -3204,7 +3282,6 @@ type RateCardUsageBasedType string
 // RateCardUsageBasedUpdateItem A usage-based rate card defines a price based on usage.
 type RateCardUsageBasedUpdateItem struct {
 	// BillingCadence The billing cadence of the rate card.
-	// When null, the rate card is a one-time purchase.
 	BillingCadence string `json:"billingCadence"`
 
 	// Description Optional description of the resource. Maximum 1024 characters.
@@ -3275,7 +3352,7 @@ type RecurringPeriodCreateInput struct {
 // One of: `day`, `week`, `month`, or `year`.
 type RecurringPeriodInterval string
 
-// RemovePhaseShifting defines model for RemovePhaseShifting.
+// RemovePhaseShifting The direction of the phase shift when a phase is removed.
 type RemovePhaseShifting string
 
 // ResetEntitlementUsageInput Reset parameters
@@ -3521,6 +3598,85 @@ type Subscription struct {
 	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 }
 
+// SubscriptionEditAdd Subscription item add operation.
+type SubscriptionEditAdd struct {
+	Op   SubscriptionEditAddOp `json:"op"`
+	Path string                `json:"path"`
+
+	// Value Subscription phase create input.
+	Value SubscriptionPhaseCreate `json:"value"`
+}
+
+// SubscriptionEditAddOp defines model for SubscriptionEditAdd.Op.
+type SubscriptionEditAddOp string
+
+// SubscriptionEditAddItem Subscription item add operation.
+type SubscriptionEditAddItem struct {
+	Op   SubscriptionEditAddItemOp `json:"op"`
+	Path string                    `json:"path"`
+
+	// Value A rate card defines the pricing and entitlement of a feature or service.
+	Value RateCard `json:"value"`
+}
+
+// SubscriptionEditAddItemOp defines model for SubscriptionEditAddItem.Op.
+type SubscriptionEditAddItemOp string
+
+// SubscriptionEditAddUpdateItem Subscription item add operation.
+type SubscriptionEditAddUpdateItem struct {
+	Op   SubscriptionEditAddUpdateItemOp `json:"op"`
+	Path string                          `json:"path"`
+
+	// Value A rate card defines the pricing and entitlement of a feature or service.
+	Value RateCardUpdateItem `json:"value"`
+}
+
+// SubscriptionEditAddUpdateItemOp defines model for SubscriptionEditAddUpdateItem.Op.
+type SubscriptionEditAddUpdateItemOp string
+
+// SubscriptionEditExtend Subscription phase extend operation.
+type SubscriptionEditExtend struct {
+	Op    SubscriptionEditExtendOp `json:"op"`
+	Path  string                   `json:"path"`
+	Value struct {
+		ExtendBy string `json:"extendBy"`
+	} `json:"value"`
+}
+
+// SubscriptionEditExtendOp defines model for SubscriptionEditExtend.Op.
+type SubscriptionEditExtendOp string
+
+// SubscriptionEditRemoveItem Subscription phase remove operation.
+type SubscriptionEditRemoveItem struct {
+	Op   SubscriptionEditRemoveItemOp `json:"op"`
+	Path string                       `json:"path"`
+}
+
+// SubscriptionEditRemoveItemOp defines model for SubscriptionEditRemoveItem.Op.
+type SubscriptionEditRemoveItemOp string
+
+// SubscriptionEditRemoveUpdateItem Subscription phase remove operation.
+type SubscriptionEditRemoveUpdateItem struct {
+	Op   SubscriptionEditRemoveUpdateItemOp `json:"op"`
+	Path string                             `json:"path"`
+}
+
+// SubscriptionEditRemoveUpdateItemOp defines model for SubscriptionEditRemoveUpdateItem.Op.
+type SubscriptionEditRemoveUpdateItemOp string
+
+// SubscriptionEditRemoveWithValue Subscription item remove operation with a value.
+type SubscriptionEditRemoveWithValue struct {
+	Op    SubscriptionEditRemoveWithValueOp `json:"op"`
+	Path  string                            `json:"path"`
+	Value struct {
+		// Shift The direction of the phase shift when a phase is removed.
+		Shift RemovePhaseShifting `json:"shift"`
+	} `json:"value"`
+}
+
+// SubscriptionEditRemoveWithValueOp defines model for SubscriptionEditRemoveWithValue.Op.
+type SubscriptionEditRemoveWithValueOp string
+
 // SubscriptionExpanded Expanded subscription
 type SubscriptionExpanded struct {
 	// ActiveTo If the subscription is canceled or otherwise have to end activeTo denotes the end date.
@@ -3627,8 +3783,8 @@ type SubscriptionItem_Price struct {
 	union json.RawMessage
 }
 
-// SubscriptionPhaseCreateInput defines model for SubscriptionPhaseCreateInput.
-type SubscriptionPhaseCreateInput struct {
+// SubscriptionPhaseCreate Subscription phase create input.
+type SubscriptionPhaseCreate struct {
 	// Discounts The discounts on the plan.
 	Discounts *[]AppliedDiscountUpdateItem `json:"discounts,omitempty"`
 
@@ -3805,6 +3961,9 @@ type WindowedBalanceHistory struct {
 // BillingInvoiceListParamsExpand defines model for BillingInvoiceListParams.expand.
 type BillingInvoiceListParamsExpand = []BillingInvoiceExpand
 
+// BillingInvoiceListParamsExtendedStatuses defines model for BillingInvoiceListParams.extendedStatuses.
+type BillingInvoiceListParamsExtendedStatuses = []BillingInvoiceExtendedStatus
+
 // BillingInvoiceListParamsIssuedAfter defines model for BillingInvoiceListParams.issuedAfter.
 type BillingInvoiceListParamsIssuedAfter = time.Time
 
@@ -3813,6 +3972,12 @@ type BillingInvoiceListParamsIssuedBefore = time.Time
 
 // BillingInvoiceListParamsStatuses defines model for BillingInvoiceListParams.statuses.
 type BillingInvoiceListParamsStatuses = []BillingInvoiceStatus
+
+// CustomerOrderByOrderingOrder The order direction.
+type CustomerOrderByOrderingOrder = SortOrder
+
+// CustomerOrderByOrderingOrderBy Order by options for customers.
+type CustomerOrderByOrderingOrderBy = CustomerOrderBy
 
 // CustomerOverrideOrderByOrderingOrder The order direction.
 type CustomerOverrideOrderByOrderingOrder = SortOrder
@@ -3940,8 +4105,17 @@ type ProfileOrderByOrderingOrder = SortOrder
 // ProfileOrderByOrderingOrderBy ProfileOrderBy specifies the ordering options for profiles
 type ProfileOrderByOrderingOrderBy = BillingProfileOrderBy
 
-// QueryCustomerList defines model for queryCustomerList.
-type QueryCustomerList = bool
+// QueryCustomerListIncludeDeleted defines model for queryCustomerList.includeDeleted.
+type QueryCustomerListIncludeDeleted = bool
+
+// QueryCustomerListName defines model for queryCustomerList.name.
+type QueryCustomerListName = string
+
+// QueryCustomerListPrimaryEmail defines model for queryCustomerList.primaryEmail.
+type QueryCustomerListPrimaryEmail = string
+
+// QueryCustomerListSubject defines model for queryCustomerList.subject.
+type QueryCustomerListSubject = string
 
 // ListAppsParams defines parameters for ListApps.
 type ListAppsParams struct {
@@ -3985,11 +4159,12 @@ type BillingListCustomerOverridesParams struct {
 
 // BillingListInvoicesParams defines parameters for BillingListInvoices.
 type BillingListInvoicesParams struct {
-	Customers    *[]string                             `form:"customers,omitempty" json:"customers,omitempty"`
-	Statuses     *BillingInvoiceListParamsStatuses     `form:"statuses,omitempty" json:"statuses,omitempty"`
-	IssuedAfter  *BillingInvoiceListParamsIssuedAfter  `form:"issuedAfter,omitempty" json:"issuedAfter,omitempty"`
-	IssuedBefore *BillingInvoiceListParamsIssuedBefore `form:"issuedBefore,omitempty" json:"issuedBefore,omitempty"`
-	Expand       *BillingInvoiceListParamsExpand       `form:"expand,omitempty" json:"expand,omitempty"`
+	Customers        *[]string                                 `form:"customers,omitempty" json:"customers,omitempty"`
+	Statuses         *BillingInvoiceListParamsStatuses         `form:"statuses,omitempty" json:"statuses,omitempty"`
+	ExtendedStatuses *BillingInvoiceListParamsExtendedStatuses `form:"extendedStatuses,omitempty" json:"extendedStatuses,omitempty"`
+	IssuedAfter      *BillingInvoiceListParamsIssuedAfter      `form:"issuedAfter,omitempty" json:"issuedAfter,omitempty"`
+	IssuedBefore     *BillingInvoiceListParamsIssuedBefore     `form:"issuedBefore,omitempty" json:"issuedBefore,omitempty"`
+	Expand           *BillingInvoiceListParamsExpand           `form:"expand,omitempty" json:"expand,omitempty"`
 
 	// Page Start date-time in RFC 3339 format.
 	//
@@ -4020,10 +4195,11 @@ type BillingListInvoicesParams struct {
 
 // BillingListInvoicesByCustomerParams defines parameters for BillingListInvoicesByCustomer.
 type BillingListInvoicesByCustomerParams struct {
-	Statuses     *BillingInvoiceListParamsStatuses     `form:"statuses,omitempty" json:"statuses,omitempty"`
-	IssuedAfter  *BillingInvoiceListParamsIssuedAfter  `form:"issuedAfter,omitempty" json:"issuedAfter,omitempty"`
-	IssuedBefore *BillingInvoiceListParamsIssuedBefore `form:"issuedBefore,omitempty" json:"issuedBefore,omitempty"`
-	Expand       *BillingInvoiceListParamsExpand       `form:"expand,omitempty" json:"expand,omitempty"`
+	Statuses         *BillingInvoiceListParamsStatuses         `form:"statuses,omitempty" json:"statuses,omitempty"`
+	ExtendedStatuses *BillingInvoiceListParamsExtendedStatuses `form:"extendedStatuses,omitempty" json:"extendedStatuses,omitempty"`
+	IssuedAfter      *BillingInvoiceListParamsIssuedAfter      `form:"issuedAfter,omitempty" json:"issuedAfter,omitempty"`
+	IssuedBefore     *BillingInvoiceListParamsIssuedBefore     `form:"issuedBefore,omitempty" json:"issuedBefore,omitempty"`
+	Expand           *BillingInvoiceListParamsExpand           `form:"expand,omitempty" json:"expand,omitempty"`
 
 	// Page Start date-time in RFC 3339 format.
 	//
@@ -4096,8 +4272,26 @@ type BillingGetProfileParams struct {
 
 // ListCustomersParams defines parameters for ListCustomers.
 type ListCustomersParams struct {
+	// Order The order direction.
+	Order *CustomerOrderByOrderingOrder `form:"order,omitempty" json:"order,omitempty"`
+
+	// OrderBy The order by field.
+	OrderBy *CustomerOrderByOrderingOrderBy `form:"orderBy,omitempty" json:"orderBy,omitempty"`
+
 	// IncludeDeleted Include deleted customers.
-	IncludeDeleted *QueryCustomerList `form:"includeDeleted,omitempty" json:"includeDeleted,omitempty"`
+	IncludeDeleted *QueryCustomerListIncludeDeleted `form:"includeDeleted,omitempty" json:"includeDeleted,omitempty"`
+
+	// Name Filter customers by name.
+	// Case-insensitive partial match.
+	Name *QueryCustomerListName `form:"name,omitempty" json:"name,omitempty"`
+
+	// PrimaryEmail Filter customers by primary email.
+	// Case-insensitive partial match.
+	PrimaryEmail *QueryCustomerListPrimaryEmail `form:"primaryEmail,omitempty" json:"primaryEmail,omitempty"`
+
+	// Subject Filter customers by usage attribution subject.
+	// Case-insensitive partial match.
+	Subject *QueryCustomerListSubject `form:"subject,omitempty" json:"subject,omitempty"`
 
 	// Page The page number.
 	Page *PaginatedQueryPage `form:"page,omitempty" json:"page,omitempty"`
@@ -4611,61 +4805,6 @@ type GetSubscriptionGetSubscriptionParamsExpand bool
 // EditSubscriptionJSONBody defines parameters for EditSubscription.
 type EditSubscriptionJSONBody = []EditSubscriptionJSONBody_Item
 
-// EditSubscriptionJSONBody0 defines parameters for EditSubscription.
-type EditSubscriptionJSONBody0 struct {
-	Op   EditSubscriptionJSONBody0Op `json:"op"`
-	Path string                      `json:"path"`
-
-	// Value A rate card defines the pricing and entitlement of a feature or service.
-	Value RateCardUpdateItem `json:"value"`
-}
-
-// EditSubscriptionJSONBody0Op defines parameters for EditSubscription.
-type EditSubscriptionJSONBody0Op string
-
-// EditSubscriptionJSONBody1 defines parameters for EditSubscription.
-type EditSubscriptionJSONBody1 struct {
-	Op   EditSubscriptionJSONBody1Op `json:"op"`
-	Path string                      `json:"path"`
-}
-
-// EditSubscriptionJSONBody1Op defines parameters for EditSubscription.
-type EditSubscriptionJSONBody1Op string
-
-// EditSubscriptionJSONBody2 defines parameters for EditSubscription.
-type EditSubscriptionJSONBody2 struct {
-	Op    EditSubscriptionJSONBody2Op  `json:"op"`
-	Path  string                       `json:"path"`
-	Value SubscriptionPhaseCreateInput `json:"value"`
-}
-
-// EditSubscriptionJSONBody2Op defines parameters for EditSubscription.
-type EditSubscriptionJSONBody2Op string
-
-// EditSubscriptionJSONBody3 defines parameters for EditSubscription.
-type EditSubscriptionJSONBody3 struct {
-	Op    EditSubscriptionJSONBody3Op `json:"op"`
-	Path  string                      `json:"path"`
-	Value struct {
-		ExtendBy string `json:"extendBy"`
-	} `json:"value"`
-}
-
-// EditSubscriptionJSONBody3Op defines parameters for EditSubscription.
-type EditSubscriptionJSONBody3Op string
-
-// EditSubscriptionJSONBody4 defines parameters for EditSubscription.
-type EditSubscriptionJSONBody4 struct {
-	Op    EditSubscriptionJSONBody4Op `json:"op"`
-	Path  string                      `json:"path"`
-	Value struct {
-		Shift RemovePhaseShifting `json:"shift"`
-	} `json:"value"`
-}
-
-// EditSubscriptionJSONBody4Op defines parameters for EditSubscription.
-type EditSubscriptionJSONBody4Op string
-
 // EditSubscriptionJSONBody_Item defines parameters for EditSubscription.
 type EditSubscriptionJSONBody_Item struct {
 	union json.RawMessage
@@ -4779,7 +4918,7 @@ type OverrideEntitlementJSONRequestBody = EntitlementCreateInputs
 type ResetEntitlementUsageJSONRequestBody = ResetEntitlementUsageInput
 
 // SubscriptionsCreateJSONRequestBody defines body for SubscriptionsCreate for application/json ContentType.
-type SubscriptionsCreateJSONRequestBody = OpenMeterProductCatalogCreateSubscriptionRequestBody
+type SubscriptionsCreateJSONRequestBody = CreateSubscriptionRequestBody
 
 // EditSubscriptionJSONRequestBody defines body for EditSubscription for application/json ContentType.
 type EditSubscriptionJSONRequestBody = EditSubscriptionJSONBody
@@ -5332,6 +5471,68 @@ func (t *CreateStripeCheckoutSessionRequest_Customer) UnmarshalJSON(b []byte) er
 	return err
 }
 
+// AsSubscriptionEditAddItem returns the union data inside the CreateSubscriptionRequestBody_Customizations_Item as a SubscriptionEditAddItem
+func (t CreateSubscriptionRequestBody_Customizations_Item) AsSubscriptionEditAddItem() (SubscriptionEditAddItem, error) {
+	var body SubscriptionEditAddItem
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromSubscriptionEditAddItem overwrites any union data inside the CreateSubscriptionRequestBody_Customizations_Item as the provided SubscriptionEditAddItem
+func (t *CreateSubscriptionRequestBody_Customizations_Item) FromSubscriptionEditAddItem(v SubscriptionEditAddItem) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeSubscriptionEditAddItem performs a merge with any union data inside the CreateSubscriptionRequestBody_Customizations_Item, using the provided SubscriptionEditAddItem
+func (t *CreateSubscriptionRequestBody_Customizations_Item) MergeSubscriptionEditAddItem(v SubscriptionEditAddItem) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsSubscriptionEditRemoveItem returns the union data inside the CreateSubscriptionRequestBody_Customizations_Item as a SubscriptionEditRemoveItem
+func (t CreateSubscriptionRequestBody_Customizations_Item) AsSubscriptionEditRemoveItem() (SubscriptionEditRemoveItem, error) {
+	var body SubscriptionEditRemoveItem
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromSubscriptionEditRemoveItem overwrites any union data inside the CreateSubscriptionRequestBody_Customizations_Item as the provided SubscriptionEditRemoveItem
+func (t *CreateSubscriptionRequestBody_Customizations_Item) FromSubscriptionEditRemoveItem(v SubscriptionEditRemoveItem) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeSubscriptionEditRemoveItem performs a merge with any union data inside the CreateSubscriptionRequestBody_Customizations_Item, using the provided SubscriptionEditRemoveItem
+func (t *CreateSubscriptionRequestBody_Customizations_Item) MergeSubscriptionEditRemoveItem(v SubscriptionEditRemoveItem) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t CreateSubscriptionRequestBody_Customizations_Item) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *CreateSubscriptionRequestBody_Customizations_Item) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
 // AsEntitlementMetered returns the union data inside the Entitlement as a EntitlementMetered
 func (t Entitlement) AsEntitlementMetered() (EntitlementMetered, error) {
 	var body EntitlementMetered
@@ -5752,68 +5953,6 @@ func (t MeasureUsageFrom) MarshalJSON() ([]byte, error) {
 }
 
 func (t *MeasureUsageFrom) UnmarshalJSON(b []byte) error {
-	err := t.union.UnmarshalJSON(b)
-	return err
-}
-
-// AsOpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0 returns the union data inside the OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item as a OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0
-func (t OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item) AsOpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0() (OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0, error) {
-	var body OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromOpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0 overwrites any union data inside the OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item as the provided OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0
-func (t *OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item) FromOpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0(v OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeOpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0 performs a merge with any union data inside the OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item, using the provided OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0
-func (t *OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item) MergeOpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0(v OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations0) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-// AsOpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1 returns the union data inside the OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item as a OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1
-func (t OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item) AsOpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1() (OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1, error) {
-	var body OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromOpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1 overwrites any union data inside the OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item as the provided OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1
-func (t *OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item) FromOpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1(v OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeOpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1 performs a merge with any union data inside the OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item, using the provided OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1
-func (t *OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item) MergeOpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1(v OpenMeterProductCatalogCreateSubscriptionRequestBodyCustomizations1) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JSONMerge(t.union, b)
-	t.union = merged
-	return err
-}
-
-func (t OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item) MarshalJSON() ([]byte, error) {
-	b, err := t.union.MarshalJSON()
-	return b, err
-}
-
-func (t *OpenMeterProductCatalogCreateSubscriptionRequestBody_Customizations_Item) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }
@@ -6523,6 +6662,9 @@ type ClientInterface interface {
 	// BillingGetInvoiceByCustomerInvoiceId request
 	BillingGetInvoiceByCustomerInvoiceId(ctx context.Context, customerId string, invoiceId string, params *BillingGetInvoiceByCustomerInvoiceIdParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// BillingInvoiceAdvance request
+	BillingInvoiceAdvance(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// BillingApproveInvoice request
 	BillingApproveInvoice(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -6534,6 +6676,9 @@ type ClientInterface interface {
 
 	BillingUpdateInvoiceLine(ctx context.Context, customerId string, invoiceId string, lineId string, body BillingUpdateInvoiceLineJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// BillingInvoiceRetry request
+	BillingInvoiceRetry(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// BillingRecalculateInvoiceTax request
 	BillingRecalculateInvoiceTax(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -6541,9 +6686,6 @@ type ClientInterface interface {
 	BillingVoidInvoiceWithBody(ctx context.Context, customerId string, invoiceId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	BillingVoidInvoice(ctx context.Context, customerId string, invoiceId string, body BillingVoidInvoiceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// BillingInvoiceWorkflowAdvance request
-	BillingInvoiceWorkflowAdvance(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// BillingCreateLineByCustomerWithBody request with any body
 	BillingCreateLineByCustomerWithBody(ctx context.Context, customerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -7055,6 +7197,18 @@ func (c *Client) BillingGetInvoiceByCustomerInvoiceId(ctx context.Context, custo
 	return c.Client.Do(req)
 }
 
+func (c *Client) BillingInvoiceAdvance(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewBillingInvoiceAdvanceRequest(c.Server, customerId, invoiceId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) BillingApproveInvoice(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewBillingApproveInvoiceRequest(c.Server, customerId, invoiceId)
 	if err != nil {
@@ -7103,6 +7257,18 @@ func (c *Client) BillingUpdateInvoiceLine(ctx context.Context, customerId string
 	return c.Client.Do(req)
 }
 
+func (c *Client) BillingInvoiceRetry(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewBillingInvoiceRetryRequest(c.Server, customerId, invoiceId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) BillingRecalculateInvoiceTax(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewBillingRecalculateInvoiceTaxRequest(c.Server, customerId, invoiceId)
 	if err != nil {
@@ -7129,18 +7295,6 @@ func (c *Client) BillingVoidInvoiceWithBody(ctx context.Context, customerId stri
 
 func (c *Client) BillingVoidInvoice(ctx context.Context, customerId string, invoiceId string, body BillingVoidInvoiceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewBillingVoidInvoiceRequest(c.Server, customerId, invoiceId, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) BillingInvoiceWorkflowAdvance(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewBillingInvoiceWorkflowAdvanceRequest(c.Server, customerId, invoiceId)
 	if err != nil {
 		return nil, err
 	}
@@ -9037,6 +9191,22 @@ func NewBillingListInvoicesRequest(server string, params *BillingListInvoicesPar
 
 		}
 
+		if params.ExtendedStatuses != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "extendedStatuses", runtime.ParamLocationQuery, *params.ExtendedStatuses); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.IssuedAfter != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "issuedAfter", runtime.ParamLocationQuery, *params.IssuedAfter); err != nil {
@@ -9224,6 +9394,22 @@ func NewBillingListInvoicesByCustomerRequest(server string, customerId string, p
 		if params.Statuses != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "statuses", runtime.ParamLocationQuery, *params.Statuses); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ExtendedStatuses != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "extendedStatuses", runtime.ParamLocationQuery, *params.ExtendedStatuses); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -9539,6 +9725,47 @@ func NewBillingGetInvoiceByCustomerInvoiceIdRequest(server string, customerId st
 	return req, nil
 }
 
+// NewBillingInvoiceAdvanceRequest generates requests for BillingInvoiceAdvance
+func NewBillingInvoiceAdvanceRequest(server string, customerId string, invoiceId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "customerId", runtime.ParamLocationPath, customerId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "invoiceId", runtime.ParamLocationPath, invoiceId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/billing/invoices/%s/invoices/%s/advance", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewBillingApproveInvoiceRequest generates requests for BillingApproveInvoice
 func NewBillingApproveInvoiceRequest(server string, customerId string, invoiceId string) (*http.Request, error) {
 	var err error
@@ -9689,6 +9916,47 @@ func NewBillingUpdateInvoiceLineRequestWithBody(server string, customerId string
 	return req, nil
 }
 
+// NewBillingInvoiceRetryRequest generates requests for BillingInvoiceRetry
+func NewBillingInvoiceRetryRequest(server string, customerId string, invoiceId string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "customerId", runtime.ParamLocationPath, customerId)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "invoiceId", runtime.ParamLocationPath, invoiceId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/billing/invoices/%s/invoices/%s/retry", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewBillingRecalculateInvoiceTaxRequest generates requests for BillingRecalculateInvoiceTax
 func NewBillingRecalculateInvoiceTaxRequest(server string, customerId string, invoiceId string) (*http.Request, error) {
 	var err error
@@ -9780,47 +10048,6 @@ func NewBillingVoidInvoiceRequestWithBody(server string, customerId string, invo
 	}
 
 	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
-// NewBillingInvoiceWorkflowAdvanceRequest generates requests for BillingInvoiceWorkflowAdvance
-func NewBillingInvoiceWorkflowAdvanceRequest(server string, customerId string, invoiceId string) (*http.Request, error) {
-	var err error
-
-	var pathParam0 string
-
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "customerId", runtime.ParamLocationPath, customerId)
-	if err != nil {
-		return nil, err
-	}
-
-	var pathParam1 string
-
-	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "invoiceId", runtime.ParamLocationPath, invoiceId)
-	if err != nil {
-		return nil, err
-	}
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/api/v1/billing/invoices/%s/invoices/%s/workflow/advance", pathParam0, pathParam1)
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("POST", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
 
 	return req, nil
 }
@@ -10232,9 +10459,89 @@ func NewListCustomersRequest(server string, params *ListCustomersParams) (*http.
 	if params != nil {
 		queryValues := queryURL.Query()
 
+		if params.Order != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "order", runtime.ParamLocationQuery, *params.Order); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.OrderBy != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "orderBy", runtime.ParamLocationQuery, *params.OrderBy); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.IncludeDeleted != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "includeDeleted", runtime.ParamLocationQuery, *params.IncludeDeleted); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Name != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "name", runtime.ParamLocationQuery, *params.Name); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PrimaryEmail != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "primaryEmail", runtime.ParamLocationQuery, *params.PrimaryEmail); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Subject != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "subject", runtime.ParamLocationQuery, *params.Subject); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err
@@ -15030,6 +15337,9 @@ type ClientWithResponsesInterface interface {
 	// BillingGetInvoiceByCustomerInvoiceIdWithResponse request
 	BillingGetInvoiceByCustomerInvoiceIdWithResponse(ctx context.Context, customerId string, invoiceId string, params *BillingGetInvoiceByCustomerInvoiceIdParams, reqEditors ...RequestEditorFn) (*BillingGetInvoiceByCustomerInvoiceIdResponse, error)
 
+	// BillingInvoiceAdvanceWithResponse request
+	BillingInvoiceAdvanceWithResponse(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*BillingInvoiceAdvanceResponse, error)
+
 	// BillingApproveInvoiceWithResponse request
 	BillingApproveInvoiceWithResponse(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*BillingApproveInvoiceResponse, error)
 
@@ -15041,6 +15351,9 @@ type ClientWithResponsesInterface interface {
 
 	BillingUpdateInvoiceLineWithResponse(ctx context.Context, customerId string, invoiceId string, lineId string, body BillingUpdateInvoiceLineJSONRequestBody, reqEditors ...RequestEditorFn) (*BillingUpdateInvoiceLineResponse, error)
 
+	// BillingInvoiceRetryWithResponse request
+	BillingInvoiceRetryWithResponse(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*BillingInvoiceRetryResponse, error)
+
 	// BillingRecalculateInvoiceTaxWithResponse request
 	BillingRecalculateInvoiceTaxWithResponse(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*BillingRecalculateInvoiceTaxResponse, error)
 
@@ -15048,9 +15361,6 @@ type ClientWithResponsesInterface interface {
 	BillingVoidInvoiceWithBodyWithResponse(ctx context.Context, customerId string, invoiceId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*BillingVoidInvoiceResponse, error)
 
 	BillingVoidInvoiceWithResponse(ctx context.Context, customerId string, invoiceId string, body BillingVoidInvoiceJSONRequestBody, reqEditors ...RequestEditorFn) (*BillingVoidInvoiceResponse, error)
-
-	// BillingInvoiceWorkflowAdvanceWithResponse request
-	BillingInvoiceWorkflowAdvanceWithResponse(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*BillingInvoiceWorkflowAdvanceResponse, error)
 
 	// BillingCreateLineByCustomerWithBodyWithResponse request with any body
 	BillingCreateLineByCustomerWithBodyWithResponse(ctx context.Context, customerId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*BillingCreateLineByCustomerResponse, error)
@@ -15373,7 +15683,7 @@ type ClientWithResponsesInterface interface {
 type ListAppsResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	JSON200                       *[]AppList
+	JSON200                       *AppList
 	ApplicationproblemJSON400     *BadRequestProblemResponse
 	ApplicationproblemJSON401     *UnauthorizedProblemResponse
 	ApplicationproblemJSON403     *ForbiddenProblemResponse
@@ -15658,7 +15968,7 @@ func (r BillingListInvoicesByCustomerResponse) StatusCode() int {
 type BillingCreateInvoiceResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	JSON201                       *BillingInvoice
+	JSON201                       *[]BillingInvoice
 	ApplicationproblemJSON400     *BadRequestProblemResponse
 	ApplicationproblemJSON401     *UnauthorizedProblemResponse
 	ApplicationproblemJSON403     *ForbiddenProblemResponse
@@ -15734,6 +16044,35 @@ func (r BillingGetInvoiceByCustomerInvoiceIdResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r BillingGetInvoiceByCustomerInvoiceIdResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type BillingInvoiceAdvanceResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *BillingInvoice
+	ApplicationproblemJSON400     *BadRequestProblemResponse
+	ApplicationproblemJSON401     *UnauthorizedProblemResponse
+	ApplicationproblemJSON403     *ForbiddenProblemResponse
+	ApplicationproblemJSON404     *NotFoundProblemResponse
+	ApplicationproblemJSON500     *InternalServerErrorProblemResponse
+	ApplicationproblemJSON503     *ServiceUnavailableProblemResponse
+	ApplicationproblemJSONDefault *UnexpectedProblemResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r BillingInvoiceAdvanceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r BillingInvoiceAdvanceResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -15826,6 +16165,35 @@ func (r BillingUpdateInvoiceLineResponse) StatusCode() int {
 	return 0
 }
 
+type BillingInvoiceRetryResponse struct {
+	Body                          []byte
+	HTTPResponse                  *http.Response
+	JSON200                       *BillingInvoice
+	ApplicationproblemJSON400     *BadRequestProblemResponse
+	ApplicationproblemJSON401     *UnauthorizedProblemResponse
+	ApplicationproblemJSON403     *ForbiddenProblemResponse
+	ApplicationproblemJSON404     *NotFoundProblemResponse
+	ApplicationproblemJSON500     *InternalServerErrorProblemResponse
+	ApplicationproblemJSON503     *ServiceUnavailableProblemResponse
+	ApplicationproblemJSONDefault *UnexpectedProblemResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r BillingInvoiceRetryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r BillingInvoiceRetryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type BillingRecalculateInvoiceTaxResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
@@ -15878,35 +16246,6 @@ func (r BillingVoidInvoiceResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r BillingVoidInvoiceResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type BillingInvoiceWorkflowAdvanceResponse struct {
-	Body                          []byte
-	HTTPResponse                  *http.Response
-	JSON200                       *BillingInvoice
-	ApplicationproblemJSON400     *BadRequestProblemResponse
-	ApplicationproblemJSON401     *UnauthorizedProblemResponse
-	ApplicationproblemJSON403     *ForbiddenProblemResponse
-	ApplicationproblemJSON404     *NotFoundProblemResponse
-	ApplicationproblemJSON500     *InternalServerErrorProblemResponse
-	ApplicationproblemJSON503     *ServiceUnavailableProblemResponse
-	ApplicationproblemJSONDefault *UnexpectedProblemResponse
-}
-
-// Status returns HTTPResponse.Status
-func (r BillingInvoiceWorkflowAdvanceResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r BillingInvoiceWorkflowAdvanceResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -16086,7 +16425,7 @@ func (r BillingUpdateProfileResponse) StatusCode() int {
 type ListCustomersResponse struct {
 	Body                          []byte
 	HTTPResponse                  *http.Response
-	JSON200                       *[]CustomerList
+	JSON200                       *CustomerList
 	ApplicationproblemJSON400     *BadRequestProblemResponse
 	ApplicationproblemJSON401     *UnauthorizedProblemResponse
 	ApplicationproblemJSON403     *ForbiddenProblemResponse
@@ -18475,6 +18814,15 @@ func (c *ClientWithResponses) BillingGetInvoiceByCustomerInvoiceIdWithResponse(c
 	return ParseBillingGetInvoiceByCustomerInvoiceIdResponse(rsp)
 }
 
+// BillingInvoiceAdvanceWithResponse request returning *BillingInvoiceAdvanceResponse
+func (c *ClientWithResponses) BillingInvoiceAdvanceWithResponse(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*BillingInvoiceAdvanceResponse, error) {
+	rsp, err := c.BillingInvoiceAdvance(ctx, customerId, invoiceId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseBillingInvoiceAdvanceResponse(rsp)
+}
+
 // BillingApproveInvoiceWithResponse request returning *BillingApproveInvoiceResponse
 func (c *ClientWithResponses) BillingApproveInvoiceWithResponse(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*BillingApproveInvoiceResponse, error) {
 	rsp, err := c.BillingApproveInvoice(ctx, customerId, invoiceId, reqEditors...)
@@ -18510,6 +18858,15 @@ func (c *ClientWithResponses) BillingUpdateInvoiceLineWithResponse(ctx context.C
 	return ParseBillingUpdateInvoiceLineResponse(rsp)
 }
 
+// BillingInvoiceRetryWithResponse request returning *BillingInvoiceRetryResponse
+func (c *ClientWithResponses) BillingInvoiceRetryWithResponse(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*BillingInvoiceRetryResponse, error) {
+	rsp, err := c.BillingInvoiceRetry(ctx, customerId, invoiceId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseBillingInvoiceRetryResponse(rsp)
+}
+
 // BillingRecalculateInvoiceTaxWithResponse request returning *BillingRecalculateInvoiceTaxResponse
 func (c *ClientWithResponses) BillingRecalculateInvoiceTaxWithResponse(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*BillingRecalculateInvoiceTaxResponse, error) {
 	rsp, err := c.BillingRecalculateInvoiceTax(ctx, customerId, invoiceId, reqEditors...)
@@ -18534,15 +18891,6 @@ func (c *ClientWithResponses) BillingVoidInvoiceWithResponse(ctx context.Context
 		return nil, err
 	}
 	return ParseBillingVoidInvoiceResponse(rsp)
-}
-
-// BillingInvoiceWorkflowAdvanceWithResponse request returning *BillingInvoiceWorkflowAdvanceResponse
-func (c *ClientWithResponses) BillingInvoiceWorkflowAdvanceWithResponse(ctx context.Context, customerId string, invoiceId string, reqEditors ...RequestEditorFn) (*BillingInvoiceWorkflowAdvanceResponse, error) {
-	rsp, err := c.BillingInvoiceWorkflowAdvance(ctx, customerId, invoiceId, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseBillingInvoiceWorkflowAdvanceResponse(rsp)
 }
 
 // BillingCreateLineByCustomerWithBodyWithResponse request with arbitrary body returning *BillingCreateLineByCustomerResponse
@@ -19573,7 +19921,7 @@ func ParseListAppsResponse(rsp *http.Response) (*ListAppsResponse, error) {
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []AppList
+		var dest AppList
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -20288,7 +20636,7 @@ func ParseBillingCreateInvoiceResponse(rsp *http.Response) (*BillingCreateInvoic
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest BillingInvoice
+		var dest []BillingInvoice
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -20418,6 +20766,81 @@ func ParseBillingGetInvoiceByCustomerInvoiceIdResponse(rsp *http.Response) (*Bil
 	}
 
 	response := &BillingGetInvoiceByCustomerInvoiceIdResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest BillingInvoice
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequestProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ForbiddenProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON503 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest UnexpectedProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseBillingInvoiceAdvanceResponse parses an HTTP response from a BillingInvoiceAdvanceWithResponse call
+func ParseBillingInvoiceAdvanceResponse(rsp *http.Response) (*BillingInvoiceAdvanceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &BillingInvoiceAdvanceResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -20702,6 +21125,81 @@ func ParseBillingUpdateInvoiceLineResponse(rsp *http.Response) (*BillingUpdateIn
 	return response, nil
 }
 
+// ParseBillingInvoiceRetryResponse parses an HTTP response from a BillingInvoiceRetryWithResponse call
+func ParseBillingInvoiceRetryResponse(rsp *http.Response) (*BillingInvoiceRetryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &BillingInvoiceRetryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest BillingInvoice
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequestProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ForbiddenProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest ServiceUnavailableProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSON503 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest UnexpectedProblemResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.ApplicationproblemJSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseBillingRecalculateInvoiceTaxResponse parses an HTTP response from a BillingRecalculateInvoiceTaxWithResponse call
 func ParseBillingRecalculateInvoiceTaxResponse(rsp *http.Response) (*BillingRecalculateInvoiceTaxResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -20786,81 +21284,6 @@ func ParseBillingVoidInvoiceResponse(rsp *http.Response) (*BillingVoidInvoiceRes
 	}
 
 	response := &BillingVoidInvoiceResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest BillingInvoice
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
-		var dest BadRequestProblemResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.ApplicationproblemJSON400 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
-		var dest UnauthorizedProblemResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.ApplicationproblemJSON401 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
-		var dest ForbiddenProblemResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.ApplicationproblemJSON403 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
-		var dest NotFoundProblemResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.ApplicationproblemJSON404 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
-		var dest InternalServerErrorProblemResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.ApplicationproblemJSON500 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
-		var dest ServiceUnavailableProblemResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.ApplicationproblemJSON503 = &dest
-
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
-		var dest UnexpectedProblemResponse
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.ApplicationproblemJSONDefault = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseBillingInvoiceWorkflowAdvanceResponse parses an HTTP response from a BillingInvoiceWorkflowAdvanceWithResponse call
-func ParseBillingInvoiceWorkflowAdvanceResponse(rsp *http.Response) (*BillingInvoiceWorkflowAdvanceResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &BillingInvoiceWorkflowAdvanceResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -21364,7 +21787,7 @@ func ParseListCustomersResponse(rsp *http.Response) (*ListCustomersResponse, err
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []CustomerList
+		var dest CustomerList
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -26972,672 +27395,686 @@ func ParseUnscheduleCancelationResponse(rsp *http.Response) (*UnscheduleCancelat
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+y9i3LcNrYo+iuovnMq9uxWW5ITT+JbU1NtyU408UMjyfFk0r4KRKK7sc0GGAKU1Ml1",
-	"1fmQe35uf8ktrAWAIAn2Qw9bcvrUnB25SQILwMJ6P/7oJXKWS8GEVr2nf/RyWtAZ06yAfz3jWcbF5ECc",
-	"S56wl1zpQ/NcDdhlTkVqXmGXeSZT1ns6ppli/R4Xvae930pWzHv9nqAz1nvas2/3eyqZshk1n3HNZjDF",
-	"Xwo27j3t/V+PKjge4WvqUX365zjKx35Pc52Zcd9NqSY5LbQickz0lJGMK01kqfNSEy0JTky4gAdcTFSv",
-	"39Pz3HxMi4LOex8/9rtXyZUqWToca1asutTwk3C97JLOcgB6d3v38db2ztb2zsn2zlP432B7e+c/vX5v",
-	"LIsZ1b2nvZRqtqX5jPWqxb7gmWYFOZsTjoCSpGBUcymIexMXpnTBxWSVlT1jY1mw9ZZmv7nDa1Oa6lIx",
-	"teq6/PvXxM9jGCfEz2pZBjfd0nC+GCLulUrLGSvenLOi4Cl7U6SseDaH/3AxGUjzhwEqZSopeG42qPe0",
-	"dzJlBB6RlBcsMb8Oev2V1o4jhgtftN5jWWgAZnVon80XwXs2J2POsnQtcJ/NVwbYHlAHpLCK5wJOa8aE",
-	"vtvbvQzQz7vTbegA6BeM6rK444i8CMjPu6t1yADY7wt61zG1G8TPu5shXACoJdx3ezcXAXknqGsdQID5",
-	"JZ9x/WY8VkwPMvN3G8zX5eyMFUZuA1ZrpLWC6bIQg5EYiX02pmWmCVdkZ3t71QXgVCH4KY7Te7qzvd3v",
-	"zegln5Uz+Jf5Jxf2n54Xc6HZxG58uAgJ/1lpFeoDz5trWHkFdp7oEkKIt6MQv6LFB6bzjCZsmPMf2fxA",
-	"KE2z7Ij9VjKlB/hJDGHMEydD0zw36+D4rYEcIM2pnlaAwlD9XsF+K3nB0t5TXZRsVcQZ5vmJ+b4B85th",
-	"qae7Fmbztyz47+xOA280pX+ZIxyMQdb7vpBlHruVx9yIyATfImNZkIl5lZzNFbngekrYJU00mVGdTD3U",
-	"DeSoTxHCS9OUm4lodljInBWao/jbkJo90siz/2aJNj8oPQdRNWUsf+N/DddVyFlkOZoWmnhR3mhYRy/2",
-	"yOPHj78jKOnDFTgQSVYqfs46l2RGvyFdoqUhBKuYdJ3LwZgIqYnKWcLHnKWEEsXFJGOETiYFm1DNyAXP",
-	"MnLGLH1iKRwfo8mUqBK2jBglE/bhgotUXgxG4lf76Fdz/SkpmGLFOUv9qZNzmpWd2zKJnLHXSLoOtdIj",
-	"goVbMNoLR92Ei4kBZlZmmhv8tK+rLsDccNcHTMs2TM9FegM4peWnwCg86WP+O1uOVP0Kq0pFJ0txyxAy",
-	"JjQvmJ47wlZhaM4KLjuQEBCna2MCkFcldu+qT6LrP+Ez9h8pOggz4Li5AGYBBgi3GDjf36VghCqSsjE3",
-	"K+cCnh0MXw+JGZeYgck+1fSMKkYeTLXOnz56dHFxMeBU0IEsJo/MQFtmIPVwMBLtfTcDvj3ZgwlhPrff",
-	"pWLp4n3yS4sy497bk70oiryWmo95AsaLvSkVgmV3W75cFeDPK2t2Q9laxPPzO6/Lrwbu3dnxEMbWAo7K",
-	"jN2f7e6E9u7sdgAigI9ysROI8QrIlIE6+7woZOGM8ubvCFc1P5NEpmwwEkdW5kWhExgNPC6YyqVQbNX1",
-	"4Vyrrm7pCrxEvdZaT2sLba77TY4iMZmWMyq2CkZTepYxotmlJnkhz3lqxJ9KdiZcoBzApeiPhGERRpeg",
-	"SnGlYa+SjDOhScrOWWbkbMOzSpGyQmkqYLRqR/WUaiKTpCwKlq61rbVlhVvc5jbrbVdZ8AXbVBac8NTI",
-	"HeM5bExz4y7YGcmN+GJwZySC3SL0TJa6WnyfuM3DfWbB7o1EtX2AhPEDaA651gaahV59447LJGFK2a1L",
-	"YMrmrtW+hMtFLqY8mYZoArJGRo3Cxy6TKRUTBlIbFYTCDETLD0xEb6VCGNa+lwDtTS1daaoja/fQcpTm",
-	"RuBCYaMe8d5DckEVyY3WI7QT7Oyu0NrOFVa7HwlDa1EJRrGxYAnjRmUyOmIwwFOjBLwV/LeS9UlBRSpn",
-	"2ZxMmGAF1UbmkzmFZ0YeFlJsTUqmFCAwbgLeTK6IAmy8mDJBlNFnAekFAGhuQVKDEIY7pxk3GkJK4Ku8",
-	"kGa33L1f96xwexcf1iGdcGFmRKnbXL84m4KLKcActer8MFjcWhY1L0Vgies/Bh7RsIxZJDAfrQNfS1up",
-	"W/S6oTSiRXy3rmK7uPZ2LrE1NoCOb2vT2GgoKOzn1S2mK2zxekbTwylVTN1tcXABjJ9XCKwBhqBmVNzx",
-	"zeyC8DNvZQUWglnIMb/resoiIO+Eq6cOIMAMAzsH+0uuIqZGoKQpIynLmOGdiX1brQotxwH28fs4rbKf",
-	"W5J0JmXGqOh9NCDaRZjXh2laMKUi8px90O/lNQt6wvU8attMZCl0MV+2cXv4mhGwzFcZF2wnOp55sht9",
-	"kk+lYEj748+l0jTbs2Jq67EX4trCRcsbMBRCamBDaoFb4WO/yVGZNlzpA5tvoeyWU14oMqOCTljq4l/U",
-	"XGk2G5A9amYhZ4zMZIomzbO5URis4GLNtX/02KVmhaDZQdp72tve+W7n690k2aLbO0+2/vbdE7r17c7O",
-	"460d+t3Xu2OWpLtP0qiHY5jnsBYxfzPuPf1lyX3UBc+Z+eRjf8mbVKRn8hJefd/ckGGeD0bijWBEjp+C",
-	"2AkOp5Sbl2aG06OiPqN5bg7j6R89heOtMF2/ZwdcYQ0Om+evA8/XR9yVZ1TFFJszpQsjhYPRdSZTloHS",
-	"Yj1qLCU0zxWIHEfMSfhGas7z4B0t4chlMaHCivog4nMF/hCjAOkSFD6jOSesj5oP14rIC6NPiTGflIXV",
-	"BEVKkoKBakozoBqNS1owI5YOI7TnhM+Y0nSWGwQFod1K6rIsEgZqiv26hny93e3dr9fxFRgl+Y3I5s6X",
-	"6ELA9lwc20nUp2AQB4jaFWHPWTGj5vizuSOvt7MOoL2L17GKKSb42fkC3HoG5BVKmmRne/drkkypQUPL",
-	"JWb08iUTEz01Yuju1yFcoamkBRVPIxhOStAenbGDW4dsDZjaJm7vfP/km//87Ztvhi/eDX/84fnO7uuf",
-	"t/f+9d2LHwwqUm3IVO9p7//5ZXvrb+9/2d76brj1wz9/fPX6cOvkp63/0K3pf3+YiXxLn2/9/v6P3W8+",
-	"/mXBRh/sx9Zhw1eBkGXZCoQscKu/tN+2yZSRH2bViy5IFhVkDZc1vPXm6hqqkBIUh+pL+NjvzZimKdV0",
-	"DTDdFxEaWpmF3LjRY3IbVw3l5Ibmwf9QN2eBQ6o1InnG9AVjguwA3dn95kk3Ku5+8wQUIo+aAV5ylWd0",
-	"DpPEDtQGga68UcM8d/GlrZ3CB2EERCKFqMTW1jmVeXoNeplRpYkd4naIzUszw1uYoYPefAyjN34x19we",
-	"ej9gBuFCqyvk9/59XFjYozk945mV+1p8nST+OTBB/zpnikiRzQm75AqMXsjFiAJeOCepFF9pYoQakcKu",
-	"HrldBS7bEH6aR2x4OsnpfGbQgiQyy1hiuGWpve25YOdMlGieJfYLJ2t/BX5WsBDYQcytmko4wQ9sbvc2",
-	"Z6d26FP7WiWF7+EDcmiBqE7FfuIffGwy6IXMwVChalNDFjGI3RwAtjnGj2xev5pPvm7ezJBO063ft7e+",
-	"e/9fD/7x9NT/4+Ff/xKbL05LGkCbl6LQuqillW95hX7oE4kS7WBmM8GgdSFshNMHNq8uRjjMUtw/iUZb",
-	"1fHfzt3vMVHOzKwFy2Wh3yo0hOG/wHVocCWhWVJmVLMTegmOd4gadJojvNFAo/eR/RzmeVzJHKIFVI4N",
-	"sSozHRETfaBKe0OjNsqVcgCsnD2jlwf4OprJ6qEv/d7KhtumTa3fu5addQ3rXb+nJSiSpdAdgXbmeXPG",
-	"GNANbLSW0cDYGMzk9rkDJY/YmBVMJB3YWLjHSIuFi+0gVBFK1FQWunoHvHlWVUFmOS6zDP6NcxoJx+im",
-	"grEUmVsDgyLi5NuXB/vkwVvBz1mhaJbNCTonyEt2yRM5KWg+5Qk8OJaFBtHjwEueD29f0lzKOjt2/tiL",
-	"KO1tr+RCZKZ1KkBTQ3ZK4Vw9LO26y3Eyc1IP6AwH97q005c7Bs44S/e5Shwyr0x/ww8PWZEwoQ32RuRT",
-	"ktrXiBQkz6gYEKfx5/5DIgtCZ+at4J7UtrljwtamVM/aE7cQlcK46kTGL3JhJKuEFqlysn4wqP2WaDkY",
-	"iXdGBIwEVUXeJjTLgpFrFLS5dR/YHAMjrSrW8Mw577FzR2MEpRf5b4XPO+FzaBd0InsRMr7ggICYBwc/",
-	"rm1Ukxg3grnt5AEC+MmR3obCxOIQ6HBGd20CuN9Xs52glLCYQFhRojHCyoiMYrzhjRuU3qB0A6WbcsJa",
-	"OFbHrGsS+GCwWyL1z2hqUxkOC3mWsdmRDRdYHfq3gl3mLNEsbQ4RVxMg5rwgCRrcZYERKeZvG7lglXsM",
-	"cEhLEJCUNIphiLqwRAjF0NLIV9SFcmCg0wM2mAz6ZEYzo+Sz1A+o5kLTyz7hAuIm/O8zpiAKelzQGReT",
-	"voEsZQnLNT+vwClkafT1hx2bmVGRsB+40rKYY5RyHH3P8E0yxVddhH6LvNj3hhrCA+JjsSrJ0Y9rSQ0E",
-	"kLgLghHaNckOrkdlBJHlWRa1gDRJPg611NuJb33s9yC+fJH0jgHoFtAx5hd6peGm4G7fawOeg67f3OzY",
-	"ZXepu2DNeckFOwK1LhaNhHcATHmYNg7BazlDq0gypQWqH7XzzrhoaIWrp7oZcEL6Cio5mp2IGRcVo1iG",
-	"d7grCMFKa1eWcrRX337Hxdu7e1TblhkVJc0CIAc3vjEIEVLS+hbBrFrarbqJ7Um5fi01e1PwCRc0s1Ac",
-	"GXBXpal2sO+ZYAVP9mVSmutthjA0taH+YXGHyDH8cvRi7/Hjx9+9hywF9fTRIy1lpgac6TEkKkz1LHtU",
-	"jBPz0kMbZmTQpQpDsvICF+TtyV7LrnqlsgoHBt4hKMBoLfS5F8DG7VrBqItLi5qwhHc9r7Wj9jCs4/pj",
-	"IHY+OGYFp9lDUgU0IcJaNT31oA1CqdfJsgmc+6mQKTuV9uRPrTkpqg6WRWa+91uF0aHe2MzFB+evtPbY",
-	"avoVhWMzwyJMbdQfiFxj+4aTSRNyIYsP40xeEGk/ilzVs1pURgf/w3cMxzcvoVvHjQkCq1Iy4RjUyPUU",
-	"Y9/GTko456mXj639uDkiVySZSsUE4WNCzynP6FnGPrldo79xA98BN/D9dy31e+7qrVld5J39zN/yJrHo",
-	"8kz5+dYgIW+6YsLeuHgwCb8o5P+1iCtLR3ncKrdsVU//aEZfoNne+nbW4hFu8D0/xDHTWKcpZBggX/lX",
-	"iLLvWOctV55YbqjA3aACX0rYBUoVawVeNDD7wI3Qidh+jiV47d9zAW2rGjwWzEjzHA1T0RmdB/iqa7eO",
-	"vM6VO0f04nXbt669ajfb4jVrenntmTS9XDLLFxeA0cXaIDDD7mkDhWsnuwLnazIi1DPvPDu6SyTkLlzo",
-	"j90nHSrf64K40BgQwhlMEprl8RKCcbPpLoZ4HrO5XmF+YLXNDttkazUn19Vg3ZAl24/iPJqdV9+01+WM",
-	"FTypbcwP8oLMymQKzm9lTb055T5+29xqUMghpVUk89Xn27NfYBh8MOnBmKR8DPutq0S/nMK/3X5/hWGH",
-	"xM0LQKQluz+GmHeOjrsbwhVJy3jEkJDaFu+xH7/RU1aQlGnKMzgXTT+YO2+wM0GvhJOj0tIdU2Rg66lY",
-	"/dQa7u+2Q8eX8wDLMrgL1FSWWdqBOg2mgUfYd9gbXlJEdJJIoSkXGDEOby2aZcLPmWiuv3UvX2RUv2Bo",
-	"w22hT/sdUrgod0VoZTitkkhl5sPdnZqFwSfjjGoyZpieB6HvNsgkHFHgaDRNWUrOOSWqPPMAxULdwZq9",
-	"tn0WDLNoCA+MsviLsg5PuwyuYJWDiKvwPqtWN0i0gP/bh3gF7J5t4vlvO57f+WGvdAF8PNDHWpw2Drjy",
-	"JfgSYsB8+OVVrfpVVF5cFrV2ZqBtZyyTRhjUchDMfH+Y90nlNLFogeuqmJBdUtx9wtcKUDiimu3RIrUc",
-	"qC66WhEAK2NcWAZ0xkDwl1kK27vJwVg5B6Pyra91BZyzvS4ScZlWRegdigSRRGMosoMB+gVL5ETAzpK8",
-	"KHOpmBrUs0JWJGlBzXF66TTjNdJKTujlHmQpwHJEmYHvpsksTuhl5YayLioUuTS9bCTreZWvQT8rOUzT",
-	"y/UFmBOMrw5J9ysKjBSGc5EploYbrAHNzgY2eKJkBFUVo+rw5GoKVBeLPQGpWJWzEC/6BJOZQZ+seI9I",
-	"bZyCiro8jSh5OmYd7s0vzZi0JJEHbEq+iL6X69wZ9qtwk4rV9J2nFqjx+5W0gyCQYaMnrKcnfDJZeyOj",
-	"xmXUjXS3ke420t0dk+7ukYi2uvzRwbsrrnyj3PhNgYLEhiNvOPLGarSxGm3kio1csZEr/jxyBej+NyRc",
-	"REL+2yxrxoFUQHE99XQkcMKnxOyLbcTARVD6F4IHiiCEnUxpClEE4zFKELZ27tkcMq1gGws24TOGZiAk",
-	"KmowEmC4UU/JMaMZVHeheV7Ic5qho1yCWxgrbCms2YaizcwgL/PZWhlXmqWDkWCX+ikZ6eeXmgnlQ0OD",
-	"6suJNGfsxzhjHtq2NNNg9D7TsBotrdGdMOEgSvAKRlV9LLj0xF/6mtBgtnyOyFaFa3BFpqyAPLwwhsG1",
-	"erhmbY6OsI6PjXxanyTpzr9Ka+go07FOcEosGsUcYpU3kNs8NK6/UuA/N4tY5A+318DG9pywwqa3LqhV",
-	"l5bsFKXwxSSvGtJFrnRVpGujl0GeEBtO2KW2OOW22GYduJgKbUBfLaRivy2AJlIg6uK1sIPeHN4Em9GN",
-	"N2YFdVP2cpyBE7NNVBQaeS8YwUTRum6jpVkWpFtO6TnGTvQ9H3W40kTgRbhzUMmDX05FvhvUldwDpLRZ",
-	"1nJEwHR4PFfAqELPa9O9ZBOaYZbq3NZPd7XJJ1Kmypy8YsU5T6zksAlWuJNqp71WizVPxCh5QUXSNASY",
-	"y2yOQHslI6aS3qsIuv3SqlPSF+4Z8yxDBjgOnXyDLzohoTMD9SRM7XRkJsjsxBrxLilaCpe1HlQOrCnh",
-	"CRVkxsz/cb3hoCiAkYG3SFrQse6TCTUyKBeTpyQ+vW22hSD42pHwjs9vdMHCAzMwvtk1XC1P9UZV9K5J",
-	"omWabypt/CU0qx/7qWHsysZozgkavLnjgfpeMatl7HbfHY3+ptKHo80QXA0XzG2e1lWGD2zuZeggqtug",
-	"tx3eWnirMmoCeoloRXKZQ7W6lNCxZkUNR4xKd8aYCO/WYcaoYsSImlUBGjsqV+RB2rx7Za50wejMX4CH",
-	"hHHQ6SxZshs8EhdTmdVrKRviX3/L4wKId9xeW/IA62U99JHCiukyV60p7OPwDDuytJ0J8BrpBHbvrURc",
-	"jwcPGgCBksdEn0zlBXZz0ZJcTG2MuO+mXwsFHtyshebEF8WozZnIcyMakINxAy0UETIortBHLQxqDTFM",
-	"Zs+NWJZaPWodGlKrTFBB+COb17omFWxCixTTs9k5l6Vy4KF5IZcay2iDzGY1dIU7O8c6pRdGh05kUUCl",
-	"mRhtWbd4bf3cgzq24T5HeRFGRZUg3NyEhGzTs4A6WDkZRp8vlpNRXL/qgk/w6xCO43I2owX4T4xa0I5R",
-	"CuOEMMLpgS+gmT6sBQmtAYjVtW8wYsiQvheGGsG/laVsdng0m9UtGdqopYkU44zbPrNX1xfWSeo+lzxd",
-	"U3LCT1xBhPjTPrITXKiTdxTTjkUvGvh2hZhqkoUJ7ldBaJcPVksEa2+qF/EaJSZqFxx2F1wSNLugc6ja",
-	"KWiuptIL9i1R0RVdcgqBp8tWtR8Y+XEkPPZJpwEa2S7MHmGXecYTbhRYWy7Hgcguc0MuZeXNDTc8AlFr",
-	"iVxVvDJWrrorvM1arz3RCywE7Wg3VS9n7bko7kfDXW1/tTGRth3HcuuOjYMTeanbhp6hejNecKWoQjri",
-	"zOMehsrI01lvBNeqcSBLQ655Z5oXwXamOUTJ7KWT7WNF8FB2q3g7dpnHxjb1KNM+4fXlgMpkyHz4tRER",
-	"wQpnvzqlmozK7e3HCaHqzbjSnXCO1I2B9btQlQrGa75Oyhx7V74Z94lgF/jdVud3SkOrlkCo1yNh758r",
-	"+JLMk4x1l0C8f+7sVv2pJTchLCh78wmYQ5vgJsGYMw8ZvsEom77nuiqiDHBG16kfGJv1mdFaAkKhfd/u",
-	"qowyZF+CVdzC4CADczkXSjOaNiS3r5QLfQa1dnBLGYh+tyy/BVBBAwqgGMQdTNalUBkFa4JwVfPRcFNr",
-	"X1sauxzJZXTD1Kmxt911mu68g4cLVB5rObJcpPycp66am1qBkD8HnhbrzxU8bmjUOS1020AkHX+0lC8D",
-	"S0ap87JWdfavPWcwCRWfQP6o/hzQPI9UfO/3LrfMaFvntBB0Zi7bLwZ3Vh94COO29sKlf67WFiqSOrqs",
-	"P5T95BUU3PMfvV/cBMr7w1eHo9/Dmn4rfNaApdMV5zD3reD6sLCbdaVoOm/xCxyUD0rB9UOSF069W1hC",
-	"8BpHVCtEuP5hhZ/f+LEFg1/1AOt1Fu/2UYZhm9c7Tj/S1Y+0GuKWjtVPcL2jDZZ6J4+3akkYZSevve2T",
-	"LnC0eJnZN3C22fwjUStT5A21OJRgShHkigqhzlBfHNNEywK9FDTPnYIGazEg5KzAfg/egGp+cdvw0Hzm",
-	"HR7wfcIELbhU5EH4u3Lwop/LGtiq7t10xoygNuaXD2ti7cHrn7YqK8fW9s7ysLSOWiB2lzvrwNWfN7i6",
-	"tK1Fa0XiKjcEBJiEjNw7GlwYlnNDhYlYUX32/dIVHFZW5LpMrV0oynrRFQoleScq2uAQX0mibvScyouF",
-	"1uSlMlWtPcmX0CwksHIc7K/iWr3x8rD1rjZ1Y3C8eYn98KhRuKcNddcpdrU6qT32YViq4TutT+XujHeO",
-	"gpP3nLMLf3Gq2lenrst9xStclN+pX2i/Z/vOcylOx5RnLF3hXp14m3VDVU3PqUiuqTVibqstyUIzaPmC",
-	"tVi4IHYGjG7B1IVrTXaMeiTNskonytg5y1zObBhscVtTVcEcGDpxQ8WWsA9qNm9XXRLyYmC9bBiYe2Pn",
-	"FUyCvk3qPSDgaQDDZ6kzOke1vZClSNeqYBYD4ciOEkBR09wD82RilPiqsBD4rXAX7MfKNtP7reSakRnV",
-	"ydR6imY3dv5ByH45cyn2N3gKmLretQ0usNtaKNPrTXwwRilOeZMlNGbQth9vUMOJXlYmRNcVwMt/10iS",
-	"79pgs7dkxkWpajYX1Sd5Zn+zlxxbBEMsMb2swHnH9fTkugfzfYHuZTgevBJZZm8DGGnB298ZkmnQrko/",
-	"r4FV3d8mHqhKJgF2Ah5BaCKJ21OzsTXE5RVYWrPmHHSJpIX1PGD5Oc1W4CMtZ0+bo+T5+r5RW7R8mOfq",
-	"TdGdGASyNmguzlLtXImySKZMaejOU7c7epsSkARwXNYnPdhvs/r4e+52NGueyzDm33uDLmjQINcpLEGZ",
-	"dOfY0qhqNd1WfYt7ODLXEIN1xgjNNCvgPno7YDb31nk/vlYsG39aCfEK2xLvUzRjv0s0yPnh7W9tszK4",
-	"eTEh42a9m1G3ZtTt55QIwMWzec3bFyEPcRSsmSv9FixIWAlSQW/UAVG/CC/4JUuDZljreiWaDg2QAmVa",
-	"O9wjsMVDwsmtlCrsbDPGx2QM67PLElKHpv26f+HGvAaDK7gNqsNuOg6s0A15x1ZowMoyhoc5KumcCmds",
-	"LAuGrGwR16hlum6w68+AXV2OKYQ9ZWmZQOqb8zjdDJJVqraTTEC57flkhF6/p/KMt8B1CnfdklWPGmsk",
-	"HrZEmroHpKuGQO2tq1cRQH0+m9urOmZsU85zU85zkyGzKcywKcxwfwszbCol3ONKCWDKup6pCNysYUpO",
-	"s5TGbyWFwPLrTfMvO8qimTbVQjfVQmNVNYKgg0290GvWC0WKEdzqBfaZrvCcP72esSk+tikHupEON9Lh",
-	"Rjr8hNLh/a0KtlB+uVa90Wty86XVRzccfcPRN1arjdVqI5ds5JKNXLKRS9aqV7qOcIKVLSKxvWnBlFpD",
-	"LBjiF0Aj0GimarfliE3KjBYklwpiDnB42LwLKLYZFh+piJGCvMUxRLXGa4jc6+j4KjI+NwcRj4u3lK5e",
-	"nA9IG1x6KxvSUGwJa/zEI6Xo5cH6tOnEfIXlTlqsEn/+SpEM4DvYh7iJoHc1vSR5WSA1IidTNofisBAV",
-	"iSVoMVZf9clZqckF+6pgWEaJC80KLKkAhlWpILOYR8ZtpGwUUL4wEJ5zViisenRWKg7JPwj3omgDGKer",
-	"S/Q9uikbRPrsiNSqY7vuxsWK7JoNbFS9dRUZ1yoMVZXWnXHRxsvlvYcrTLtG62FXDGxBvVzHR3354FVL",
-	"4C5jtpaB4va9byV/BQfn6+SCTABzBdV+G/mPyzoJB8MfCKXpFUqhrYYXzQ3kdrYb3b/4vtmFLd83SGTK",
-	"w3qGK27dSRd29GPrtB82vq+Dt9ZWxEBSa+cpR1BhxQTlWJHs+FGoxYcQZugeeh2mjkgsVv7hbiq8z4XX",
-	"nFBojp6d0rS4Nzr8sba12Rcuqhk8Divsw9G1dcsacwO4Cyomi68eBqC3N80+qI/ZiPBvmSFvOfcj44nN",
-	"gKmF2jehuufBjCkb0zLTIec9ULhSCPrFx261/6iGOJMyY1RsAhVv2+T7pdSP3tgBV7YD3nDVUVgLRO5I",
-	"oWmia+qgW6ObM0rlAsK8JIzn3VXqdvoqlrNS6UYVy+BTa4VeoZTn4yuX8gxnatzuW0n4ah2W2/l2nUdv",
-	"NfSsJ1bbcUlEUlDbMUgBA1ZaMYP3S1n4MM8981Sd/Nxw2aoyQqPSm6+KrcgDnvZBdn7oTh1yLx3fXS4K",
-	"+Hotq59DuIIOJ46t/xLYEczu+227ShnqhbM6lWbxnGulgi+cT9PLhXM1VTXIKa62ulr+SviyGE2a2BEV",
-	"wG4LET7p+X+iY//cpx1K12urtAHSrKrLxujSx/ct0NAoa0b2VWWjONl4r4meHH40u4gZ1AZTmsj5FfjU",
-	"1U3gaINpDPP8IH1TtJs53SbqrgHDLWD0GrN/QkRv1CdegElXxqJOtXf1S9HE+RtT++6iurRRMz6RmmHd",
-	"W7eubNwpEdtuZVyKdpfKytOrko/u0L4rmcU2V3tztTcWhI0F4RrkbbnBYHVLQVfl79pj7+eFHuEOZbDQ",
-	"TlXyO6hwaAXrv65athtfp1nWa6sEnXVM689XqWNqIVdh/dIOQ0zFLGDTFxTDOqGXz9iUnnOsElx5YpOs",
-	"VPycAeq6vxeP4yKWULHes8VLApLzeLdJcULb8HDrP3Tr9+2t797/14NfRqPBaLQ1Gj0ip+//ET56+Ne/",
-	"9FaAIhZE5sqpXC0ypLau8Fa8Npc247+z1AbjpVBu9UK4hmiy4BNuWAG3oAUtaMOwDgc5UVoWzDFURF3f",
-	"XltLZ5afQ9dk/KIZLwLVKiuHP0Q0FAtjQVxmaWvXzgLsWHfnPGbVavYpH7gIYZQe1YgsiMc1R92g7wGW",
-	"bsG6mxgsecX4yjCe0nYxKerhk7fRz6Hm386rsjqGjfiUCAnxKKyYcREWpymoZiPxgbVKCEF9OF8/iAyJ",
-	"4JmvK8RnNhIXG/YZ6QxQc3YmR4Ir8te/sks2y/Vf/2pnspUHVVncSGFTOWMW6TjzyAtFeCrByM+1eGUL",
-	"+5f8JHlqg+aHSVygtI/Nm/hKUO4WqiRLMqUizbDYHjaXChrJtBNUqJ9oresQgPqSCwdus3bqEmj6TsJ+",
-	"6jr3BOhK1zm2Doz19Vvt9cPSkfXuQGcOsH+QB2wwGZCd7e3/BT1VFRZ4dEk3hXvxYUsWCEDuux19v9I5",
-	"d9hDjrDNlYHPzBnULr6FAwwOr91SCYf3QWWWCUQRqxYUsOwzjJmXYYh5q2BXEIxfhYs7ERpnCPtSOaHD",
-	"Nqb6Fd/4tVUHS8tGm6dB2C1pfeR3cfJYZrsR8t6I3atKibW3Gp/BAs1GuV6HYZxWsMOL315ebCyxqqOF",
-	"KDyL1VA3uPdhXBhXCdYvdVfa/3Uq2KU+xfZUwSWNDrmUrPEQ/RolIRbFj3WdXetEOl7sBCwQULrgwqgO",
-	"e1qD273Jyy+jh9I1TD6475Xwq30/2Ifas+5wl10Gu/pVaPe7QAdtKONOh4yaoAKFsCnHZxm72sm7Gff8",
-	"EJ01UatZIipu6Gm43wFaX0Zw1RfTBv/a3rsDN0InYlc+vMV4fV0fno3w7YTD+fEWQ/HFFfVZUM1nBSIa",
-	"uibbGF89dCW2213iKdR7J2kJ9iVXohsSUmxpb67c17ZvOxVkmOcYiY/3B5gcdgiheb5IemhT3GHGJ8Jh",
-	"Vn0BkZcCw5g/4kjT0irvyNJtyKnRciTiTUxUeVZNHCBmBQGhHs51VveK6alMFy0N3wjW1d2rp1rLA1pq",
-	"OaOaJ+RcWaPBw9AQCDrXqX/LyBe9fk8xkZ46ATe+zBkCvM4aF1TMD8/2mpy5whPUs6zjqX50/ah9X7qd",
-	"60IXzPQRtaYUkI11juXPqtkOT3Z+6MXUPPc6etgt1FalWGXGkBgd7uyHdOfg+M23T6CFVpuU+OwnJzuF",
-	"ckodpZbugoG8picvoz5t5tIp00VaNddwPCT6K8h8BrGHVYMffz5IjFs4AGTLbHh4Hwg0KaqBgX0JwNBa",
-	"0LG2yQdTI9tQpWp5NaEDs3q3gSxwjrEuyzBuo9mFtaV8YLk2ag+M6uo+m1fxlhPssaSuhjGYPGZW2YD0",
-	"bwshDfs1NNpb2xS7m0HeJjqsgINNsaITAxsvNjExKn6spX1UpP6alM4OVCdzUYoe3cTmSlbYxG4KfseU",
-	"q41A3Aova53t3pQlH2Spj5lSXIo9KLl0wi413Pvj8mzG9SEtaKy3+bEueM5IY4gBlm061exSt0lxNWob",
-	"fWZMKWuHjlz/JuRqyqEpqUtBv+5wNwIUJCC+GR+z4hwMRAnLNY02Qlxn3BUO7u3BKxmzq3WcUclPZxJM",
-	"NU4IZLMzlqbQaWAqle7opreXcSb0MM8hbe+IqVwKxWIWdXxS+aIS+BLUhwdvcmboFnRYTT4wkUJ0PST1",
-	"wbtvhqWe7hJsV9REobLI4gbdt0cvo8PQUk9lYfP+0cU6KajQfvzFOpeZL6Zc7dkIjcNCnmVsFu7Fajf8",
-	"rWCXOUjozSHivoHCeikSkPCF1CjlY2P01PBWkFp86EjVeRVrraB84J2j2rAIXY8oaq8RfL97UdT65eD4",
-	"DXm88+TJ1k6VUnpxcTHgSkI+KVdyC55bF/KW2Xs1mOpZ9pDQLJ/SrV3nXsbGJCNLgIi+kFsZ0xo8rNUL",
-	"6BeimZIQ0yMLbQNpEynOmeBMNKXjt8eNyKVaFMFuK4rg/R+78bJcGBGH16lxm6z7KKK3wTfE3sHEfkUU",
-	"fuYOdBALpI1Zh63jxfqerd/FRc3ZScz94jYvgRsde/4ZSpi5wn2rh9fv2S8O0qVh9e7VWNcZ3BlzB1zp",
-	"QDRNlwpsF+wSu/iSigD5Jr4jgVEyzQHwMoBChKdJiWAX1XfgV8NAmzUK/y1Fpjd2yPYi7ROrZBjA7NGD",
-	"icOHa2OTwDrG2QLpMGu14V08I9jDgff6OeQLtxAWo+zGND+WxUiUysYvtPf9K9XE4HDa5QYxhwzVIURp",
-	"9cr7ve4ddrO2JH3D9bO3Ry8jDL7fQ2bo80Gw9d7Cdi6rl5F0188IcUu/XF36a0a5+liMw0hVjladk+As",
-	"rKSKesvJPG9UG+oaIPDp6rIQXTuryiRhSnU9LrkTk9bYFitbxcWwRZilbLTzIoxyH5FjzxVQChgsxqnG",
-	"mPDIiECDRQQ5dttPovfS3r5PzDhma0XZRXf9lQuxq6/S/DwSw+yCzhX5VTFd5r+C5OA6CtfQqinMmked",
-	"m2tJQdfetkhGlK6ZYXSZHwjNhF55KPgGrIlCd467lN6boVcivs3r1WAb+Kxzn6KCuxPanR27zbJWZQEH",
-	"2NGgsdjweJp7jCBZrIuyjZCwRratYMxJqUYY/np352/dkrB5uuVIek0U9pV+GzJwOH7tnauIwft1Ofhx",
-	"TQ5+HJGDH3fIwYFs1/SZNoSmGgh/hL7uRR40dmngQFN6G3fNcZ9e1v6f8+EuJlGYGdEb7r16Tg5EMqh5",
-	"0BYCVBo9fah1wc9KZ9tSJazwRzaHKO7Z/NT+cvqBzXvvP35s0m5rGgyMFSvmy7oCe1GV0BkcbWU9p9oF",
-	"Qu3bsNIcFWllsAojnKyxiQTl/P7kffAa7LVWizu+wfYs+ot32o20qU5z2zlZIR1ZFQnwVJ/bL19RMDBG",
-	"8MG9QWb4ShUnWemFQdUu97YdUG2K5/w5i2gXfEaL+fMZ5R0mTPsGYeaVTqreq5Wwhg9wzCVdxNskJuwl",
-	"HhvevdP7IjtmxVn7erTibXOEiOqBtx6Ms/ZFZtAb2tcDBM2GF8EJwPikNsEVauu01hmXduPkr3W8q1G/",
-	"uvxzZS1kJML981pzQ9IcgR3HJTmVyg9FlYtSSGzOJ+TtDGoVCGtDxp3PXZsVW8kSk1FDx2qU4PgCeli0",
-	"EXQRur3kMdP5kOQG8eXYkI0y05FcGm8yisTX2LAZ66zH2o8r5RxU1uVaRevt7e22JSq3/rsIHTewY+Xm",
-	"QIE1evoEhzYvHPPfOz7HL6FqbGwhMxSWHFgzLuw/YzNBEs6e61TfnguTdBozxoBuJuFg+o1fSG0mt9mL",
-	"zt2F+B/SCReGUnV7E/0r3jh2ZWRwrrC1kMKqR03IY9bJbpxYCIa/nzvrY8uKAwcYvAZ6rDb4N7HBm9Vs",
-	"QvRoY89yhHkbYdbX5bSDkXgjAoaTUIHF12dlpnmeMWL1etUfibNSEyMw2Z/gZajFjn10IAdCLGSCodUg",
-	"tttuMsy9BCOPW0erK1YNe9tieViNP1oC/TgAponHzXK7wauxE3ouYFAf4LKSyy/46BUe0VLXX/DJsaaa",
-	"J+t88czF4LW1ueolotksz9CdVVQR0JiDC9vPqpdBMqckz6gYjMQLRnVZ2A/ljEPpZB/+wCJz9I10oqds",
-	"Dp/gHL7fLiSyJrQA6TjlBt6ZIYKYTD2rZDMXW7j6DoDSBhu++tFgs1ierHM0Dvvnr9H2BnjzsY4vz6hi",
-	"J3Y/IiblKTVX15ZbsIpKbCsj4sH9N2BpoHiHa7ZeCnouRTwIloIjMXTltr8gW9QYb2GXgmEf26owSMa5",
-	"cijllIemxDw8+s/j1/vPfzw5/unro6MXL/715Lvvv3kx/OkGPV8WsB/Z/OYAt39t2W+3PrB53Zbx5OtF",
-	"NTV8QY1/PD39ZUkJjZjacsRoCuzRGrVAjaksW7e/yS0k+my2K3sCtkyCY6YdEldl+/vA/OZZ5m8/rm2d",
-	"Ewi2dm7rdF2rjdX2KKDuvgpiRO9wDSnqFL1mfYKvvyBL07qk/IgZel3vo9feSSc4hDQ9srPrJJP59msB",
-	"stZoVEhol0iETuq4Cv7UpIPVBDeUyaxQ1MSsjYSwkRA2EsJGQthICLckIbhsAqeUvv+SHUd3i51bjr2Q",
-	"q98cOw9qR3cHzUIVafQORRhyix/fDGUeieeYeV6tj0j/r4PUfOP27f6S8auv8hPS/M9CPdciRTdwjcNK",
-	"6/EbXbvJVCmZcHBm+PycmpTa2YdwwaVs3sarWmBr46xtjb3q1zGSEonBatGUOi25URtpDZYr2Esb369p",
-	"O21s5Cp21O8L2uXCgWS3SJLRrNvrg88MrcGPybEvK0FJLhXX/Dx0cNa9TBW3leUZ1AH3LsrKTYQfb2og",
-	"3Q2liI3HLDGHGlvJc/cQOkHC1QO0UBAtRUUylYVt2m8po30+IIcuXeicZiXztQETxi0vg5sFOfNcpPLi",
-	"mP/OyIMZF6VmD69Z+rq1xuq2dIkYVpQOPQygk9hSqC5xlKsmGV9DkFiqc7DLnGM92TVsJv6bhbIlgl9N",
-	"gMImx7giOzNTw65QAShRXh+GXbNA+dLduKd6I708klkmz1kxDOisrc+w3Tyb7+11KhgpZGauhvmSUEjP",
-	"ZbrfrKkxrxzVlKR8DHlkmpzRjIoEk4KpjYW6sKg7J1NqCPhYWuESRh6MxDP7UVXOBJ4QqOTkS+tS9ZTY",
-	"N08hOez0CN76O3l18PrBq+Zy++TV8N8P3AfPYFb8ok9ecVF/+eHDFVhIi23cqHBZXQ43bCN5AePXbBUG",
-	"SETI+enXb4rhh+nL8zmfcvld/s3O9DvOX4hnwJxnzWVuUOCmUUCwS43SOPO1fVqxVOxSNykXsCFkVjfM",
-	"Y/KCy8IWkI+G98JTp85b4coePagDUz4xWp1/E2JAbCXdMS+UOa5D95CrUBxLWcJnPpZLDcg7M2AmL1jh",
-	"fiNcpFCKXkzcTHyWywJqVAywdYXdjb4ZOoB3x8w2M5hTFhMwuE+paLyzOxgJ1yTDwF0wotg5K2jmBYZz",
-	"yqFib9Wbg868oosZ7WquNJsRxTIbClMdm9WXAHSl/dyDkTgQJKEKC70VzE2nptSp0mYaD2vGzlnWD4ZO",
-	"MqlsBWiuVcghnciCPbvsCRzYeCiq0Id1Id2McCGRFSU0czNyhrJSyHmpZqq2YJipVCGigtwRSLkWgEbA",
-	"mEfNkgv9bRgguPvNN8viA4va/blJQ1Y1csOKZRWSL8QUiFW2V5SZDNj4wY0SnhU9e1blq4v7NYHT2gnr",
-	"ovIS4wOQr4X95iru6ktGghp/h5XSP4VC9NkUjY14vBGPN+LxbaPARhjdCKN/OmF0uTvGedUa0mizY8dS",
-	"WWmJWOQip9tZCjYhoRZJbqPNx2XmyrfOA7JlDgIwqo8R5bbKIylz61w6owYjKBbgMHhjzsOMDHW6oUbc",
-	"pTm3lGt7wmowEkN8n6uwexQOJYX3ROIMpbJNgB0FtZTPoM8Ds48j9KYRmmXywrwy6lXVos7mWApWqZKl",
-	"Dj25IqPeWVkITVJ5IUY99xoM9HATsHWNgK0mpJsArk0A158xgIurYznWL7mt7eoFzDHNVKv498GYKPf2",
-	"382AtbMwAqXjiO6s2DkThLfzUsy5XU5pqTRL+2RKlSW1wFYpVqE6Y8TMUUtFlmNNMgA2Vjucq7cCnrI0",
-	"vpi8YAmFp7Ha5vv+eZ/wiZBFRZhtHdYBOcyYkSPMOoOtI1wozWj6f4cNbZ0wUrCZPK8Sl8YlhmLEF6Bs",
-	"RXGQdNsI9bMsYZ9R4rAMpVaHnWZSTBRPW9lYKL5YdCMqYYIWXJIL3w+hamQPJWLNn5aZYXlDI0GiiYGr",
-	"qrsZMSKckT8D07EbzbDcLnAqAbEayraiHIkTI0oFA6Kgpr9SoNyAZuMLObsOk7jDlFzQuU0PBHWE0WRq",
-	"9RHDKoEJ9e2ZIqe21m6oYVZrKWpXW18qJNzbtpJ+y1SZTKstgB2dMdSvXK3JkZWYRr0+GbW1O/OzETpH",
-	"bd1/1HMJXhT31onIg95Ss40rTSK45k6wJ150a2lEDfw7rClI9jLttK9N1YATJ/Ciu9MbXAlLH2qxjhTs",
-	"W5uq0k2AR4un6rW4mMCcUaU7rlLN+gimUhxvSvOciesaIFeInKWqLBjIOy8KOVsAIIi0qLnjjTfKHX6e",
-	"Dkiz3aARTZ0Z0be0xF7Mwe3zhkYzw60v9TOEuUE/guIcOuVBXnSABkt4HCwDSQF+TKDxNo6XepsKbD2O",
-	"UUnlGFdoe5hv10vR4AB+UDdOlBN8ATHOLihsE+O8nmvoB7YstjmivtxSsHNIQaM6WoSQ1XdmNSvAyuHS",
-	"hW3f0rYRbMKlv/Rw6Y2ustFVNrrKRlf5QnWVmEawqrjc+LItVYQL/1RKxUb0v5Lov5YcfV8SdNYSCt8U",
-	"KSueRSQaeGD4nG0r0UxzUWEb0rjwG9vFYOp7UG0trCa1qbD2KSqstYs3ReoxYg7TkooKwP/j6/zn8ZvX",
-	"JKeFAo87vhnT/Qg0EcbwKK6wyj1KBOZGQo+bKUs+GF4e0mbr+4TC29q2QHLeVCeWmG8Mm9iaFBR8nfYj",
-	"L79Y+4Iltv3KjYoCzVyWBZEXwrpQB+QHqmwjTipiRe97f5ARHhcKO2rUe0p+GfUmXE/Ls1HvPfkYMuD/",
-	"VvFS1hu/56ZQxcbPufFzbgpV3LgR12bmbmy4n7xOBYoKt1+wIpJSvUK9ira0sxF2Po2wszFrb6qA3HwV",
-	"kEV0/v7YGCzJWULxTuzaG0B0F1xsWmL63lzT79y4fu9yayK3FtkafjJkLZI904x7BcVXFgBd1YnQkqsZ",
-	"FXTiiSWbu1rMVazr2BVeBrptK2gPSG2ahApDuOwC+64cUZ94Ut9WZq1NOmKlMZJgPXg84q9TA9IZ6XtW",
-	"8kwTWshSpB0xtRg6Xo/BhUDdtExqlaVrMbUDl4JACgZmPWGD1gs2o1wEfoQIKvTRrI/cSLBzVhDDiRQR",
-	"bEI1P2erZFV1SKpBuY8OthnZ1TYTVoAEK7PXBnv6wOZPyagHCxz1gB0tFay9P6wN8bspA+IbEukpVQFq",
-	"hlSJ2GLWNEkKqdCBUCtlPc8bxRQQog4IA4OqtbpeA1GtJbmJNLZkvo37F19pkpi50BWHCNcnbDAZOLdi",
-	"tQsGrbG1RB2F5ZjsbG/7jhZIDs9Km4BzYXAeFC0YnaXk2+2+TeDwzrHdbWdnru3W1bCxVNfbOewNav0O",
-	"kfU27Xo+PDuw7F0B8AZ7qJA0yhrOWcz4uJfJMoVnihyjIyRB2gPX6xg4XT3NC9osfpPsbI9pyrZ2ku/Y",
-	"1tfpk2Tr292/fbOVfLObPH7yt8c76ePEMA7QhcxdYsU5T9iW7VGkcpacs0IhEDuD7UrMDzVArELLZ0si",
-	"tuxi80LOct1rtV10ckebH7NztLPOM0nhQESZwWG7HZeCWTmguaGtdgvvP/ZhpkRCa1Ed5b97+LBW+BjE",
-	"FyBHA/KqVJrQFHBdS3L0Yo/sbn/9hCBu1EkZJGHhYT2ycnRdVmsupl24iGqKskykz7xT2xGt8TUkAwAw",
-	"AmkIXN19WPD14YhZWxrzw0nV178iCjbatLWa2VoMXTI/nOqlNlcZ/YlUWOyJh1I28D3cn63CtfxeAbrw",
-	"ngSuPXtl2hhtX3a4FV5vVbvePknSLqNUzSo+OMUyAN2l/aPlizX/OnPoU0+3wikdWbRbW3uWFzItE1aQ",
-	"B95+BAwHj6uRBF2nF0sgRnKymjFHJr56gT/m2B19/Pjxd9eLL116R7rpCeVCEUtBbIPNMxfk4OgMbmrB",
-	"MEvVCiU2rgICJqqVNrZWzgb2XwMlZwwGWrbJseZ09p7VUbpZYrzNueoaBlKB5xYG/2QLU0bN9uTUgGTN",
-	"DYNEzh4l5grAh+qRSj9sTeSj891HuA6on+eT+fbLKhE+wiuCTEn7IgGdqVKdfnjz9qjX7+0Pf+71e++e",
-	"P/+x1++9evP65Idev/fz8+FR3C/bTKZfUDkhnkvftkl1+hmrFl8QH1EKrr3bMRg8IqHs7Mb8mml59doB",
-	"frs7dGXBtQfUafcRGJvY5kHq242ISUO2T0/MyO+FXxoYYKh22iMT5pqmRmdMucK/DXS+BRD0Aj6Tego/",
-	"Ix0zX2uayQnm3DZ8+Y3qF0Uy5edXNjm7z2843N2am4cwOs26PX2bOo6f3Wd4P51XH2Jm0CH4jKCqgAUc",
-	"P8AriTZv4Gd2KXNCaz2Cb8SW6TqRVLUhDVBWXLE04hZsnoHKBXuDJgsUYRAi31Z7FrRABhX1+0KW+bP5",
-	"C55pViBZ8TbTwxq5WdzIuzYFK8jEjGvksDGOjPRuXGZO+cfXVCJzsFSdFZKmYB2hAmtseJpa0OSD+f55",
-	"ZwAstaPBqxAIm2VEyw8Mw5rBaDrBhbqATMcnZjJlWX8ktLuqbtoEBkfoUaM3b/59kuutrxvlTOCJkSXM",
-	"szCYEey7tf7TkZ3pRbgOLOc4Kyc3j+jV5YUNUqdgh7jhG4ArVWYBEXR3vbfD+zKNdN5efnHuv9N1xVpc",
-	"6HCxOmJHi1wrqiz2XX5+sWVDvjfke0O+N+S7SfoCEreAupmb097Vl5g6VHkkUH6H5l4OIyrSDwYtLpKs",
-	"TJlCB4LRbu15VLKuIg942jcH9nDF1uvNEWoQfILAAXsidq9c4/equ3tvVXHanKlDVEH4bFZio/gytsLw",
-	"3iH6TgtZTqYSHTVkeHjQH4lxVaAL+TEXmhU00Vi+UE8Jdda/r1Q7jN1v3CTXX58i8keWjOE+K5iZzLIX",
-	"4Nl6QffOqRy6x2GW1aPu7bz3IOLemUQ20fafItr+RUb1YcFjngfziOTm2aLSqKtJJK/LGSt40mFis/l0",
-	"7q4H80aCZ8zjCIrHY1QsnAtXjgL0gWazO7oH8WJwC9f0juupLYB5woqFC0PimOPLRLNi9lmPO69DvWJs",
-	"vvk8XC9O7JxUXJzS9JyipytSfDJYewSqkdgPUvC4IHasT4OdjZNcDVk3Z3r1M13jtsnijKcpE4eFPMvY",
-	"LOSpq63xrWCXOUs0S5tDdFSLZMU5K0gpUlYoLWVqrQ6/lUxpiFwp2LhU4A4ntNRTWfDfDZ8ZxPQIqK76",
-	"rCzEvrwQP3ClZTE/ZpNZNEBjSBQ+qpWqJGdlIaBgIpniAIORGIkhmfBzJvwn0VAeEF7tKExfMGY92coa",
-	"DKZUTFhKGPdxTc0pqwqrIDVZpc2MHniOonF0Q/1cdHi4wjAoF55mG+4w4YPKY56pK8ageZCONS0iO78A",
-	"IMjHvwWQYKNt8J7ye9Wl+69Q/be9zW4lZwWjH+A05Rhz8ilWM7cJ3R07/xRrAx/s+zrHda17e+f7J9/8",
-	"52/ffDN88W744w/Pd3Zf/7y996/vXvwAu/KxcxOq69HYBH86n3EbIuf9qTYCcuaicYdG3bVFVCFkjiYa",
-	"qyBU1VQbIXZUQAwFGHJsaYdVtYPvPSxHLJFF2utegFcbukMSz1mBhUkWBBXeyIXKbzLZsJ7eYmnsYEEA",
-	"4YmPB/SUN+gfJm6WejT4Z+5KFyFs1Wm0CF/HjevXaXaUONVx9H0Xr1tP6w6O/2o6N8x5v3LcsXPjRvX+",
-	"FKp3i5S1DX5wW+3TJkoAenYlJvF6f5uGabCTI9xcTtECSlSLRfbkYc2GAo1DcJvhJo7t94GYMKVZ2hGB",
-	"PDRcCt+wYWqgREnnuTinGU9tuFVRyKJh5mdu1HsQluzWOdSLPzQCfedbu/hWK8rZb8RCknNuC2qEoMSQ",
-	"BXybRl7w1UPt2VDlj+uGO9FUq14XIPzyhsGp8O65Qbs4VE3k9KXVALYxhYY+1UuDpUZsF18ZnE+wM/Hr",
-	"ZQgHzY5BRwVYP7VezARE2oH8RgUp/SgkkQKFdpT18gLWxyBjFZKXxmU25lnm4lWtSh1Vmw/EuQTTxJ1n",
-	"7M9wRRbgDVv/JGz9JVc6TPc7YgosVn8ESRw3UHpo5W/beAopIgZM62q5OojdvpqVvusA7RUtPjCdZzRh",
-	"BkrbNr1pjppVb5EMXxuMhA9AgaqEPmeK5rnDCvNn+G0YncKF0jTLwtD0CRX8dySaIzESAWxmJOvfZZdc",
-	"gSZls/+UxBSyVBqVkl1qJtBUd+S8xBAV0BAhEprTM55xpA2/NJd8DG2tyAm9rDo9KaLpJclloYNkC473",
-	"HVQXDPnAjlin/rNTTS+dN/xpb8/9bMauKJ5/2/xqTjQKjpuMOKnEtmtKSxbo9jUw7Cen/osKFEuqyF7w",
-	"yF9UeFQ96QTJ2n4VSWSGnZJkqZWmIjXkHUh/aU3k9gsHyVfKVyR0BuQZ01PUi+tbiUOfurmC3cQn5LB6",
-	"4jYUn/gHbV7m91TbgpTYwEaRuSwNStoRqhUGiwCukEjxtsh6T3uP+Mzowo8Q3EEOSdIWQny/LgLkrC3J",
-	"1fEx2gUxz79SJHxvZd40zPM99908xppqs3VPHvw+iAYhuy3pHsK8Qt4evRwsCkfp+ljYepudiTKrSTzD",
-	"PIdM+Q7vCkwFI3a4kqziEH5arb1fP8oY12rTXPOfGN3NrQWpAKYRicBbVaRZS5SJ8ARs3XiAX+9sBzx9",
-	"BfEGVlG151xXiKnyV6JL8kVLEazFfcaWyTRouWvMGAO6aXlrCS01maZbgnm1tFuCfcOq8mMsRF7JDuuU",
-	"Tz3E2pzLJIbmZxDuitJCfMCnbeZgbee28Cr6stDeF9j49t4eHT1/fXJ6+Pzo4M3+6fHJ8Oik1++9fvMu",
-	"XnbCfLd1TgtzARUMgFInWnCdCfO1vOjFgD2JJgH+cvRi7/Hjx9+9fzDVOldPHz3SUmZqwJkeD2QxeTTV",
-	"s+xRMU7MSw9tUq5RM7wi6cL+uCBvT/ZuWCN9FQakXi0e9JjBUXxg8y3MF8wphzBQN7aTyFy8IqiepJqN",
-	"cIHAApM8k6XuimT8o2fkL6OZQivQ7Z3vdr7eTZItur3zZOtv3z2hW9/u7Dze2qHffb07Zkm6+yQN2FE0",
-	"/W9G819wZe9ru8KKqKAK4Y4Qk+nKIdFKFU1treCpvICOu1RDUm9K6GRSsImRytAr2liUe2z38+2rlht8",
-	"eEBOIMr1rbW8wzgnNWNQv2cjX8NI1b8M8C+/CX8ZIOvBlJ7FBkQI62yFj8IhWwyZ44guxK5qLWwIy8Hr",
-	"tyfP26JIbbVrhEGzYhh8WQuHhj1bJmcMQ/nCyddwoPU71drrJcm/wVF01wOApFktK0yoz+mPcMlcwQlf",
-	"8ba+pjOWQiGGQ6qnhF0aHUuBo0RLo94UNNHW2mzDl+HAVVUYBlcEzXqNGvUjmysyK5WGO45RnwbpEymU",
-	"UaVAq6JZPqUCw07gKcY9QHWeZErNpBg7PhInb/bfPDXkAcJKkTIQZkhE4uqlBXenhdYtFhgLvx1GwlN9",
-	"oHgbJW7DzL40eU11RIUj5P1mIHXnSkYCssuvchy3HkUeMZCGtKW5+AjaNrEWWVBVxKjmBjA6hmFIliBh",
-	"gMtJ+Jr9XBbk+O2rPhn+9H2fvDp4jXX7Xw3/TQLqpZAROGmugKYKVYS+5Xo5LSzfc6/CrC9kQd6+PvjX",
-	"2+ene2/evj4JB+7XQUeY3A1zkwyIGaL1bbUJbhsNlLbTRf1AA8K9hOyEdH1Viv2u+qZOqx1fiGb0YyJB",
-	"yCJqs4fUdkleP/A9NUBWvmpiv8yZwEb5svr7Uf5h8giHA6hbvCiuUoZnYql/qViEzFhpFfk+HGiv3wtx",
-	"o9fvDX/6vtc3W2f+7/Dfy8qmhYsf1jbzpvcBc8i+dFlpIwltJKH7LwltJIqNRPEnkijujzDxr5IV88pz",
-	"1yadaKDFMGvkq7+ZTxq8EQ05v/wRY26Qsrqly+JMxsJIIhEpO47DYaEe3DgIH67MTrsn29tP4X//qfYW",
-	"g2trtin/kjk4sDF2PO/3tFw6AXLV/eHP3XX5VjNEV3svL2J+i3HUYnrHTXpmA+8ZyHVqsCoNaBZpMkcf",
-	"t4GHxxzhf4W8cFb/1S7aHb5f7dDC9eWktuBQVeSLM9jgSRUoHazofuJjPIfjTsPeuBN4OPUFhQezBtvz",
-	"F+hG2d9rqV/IUqSfLLwMCxS6KLOUp9Cvb8yhXraLMmoUB3DSr6bFhOmqPIAE9dZ8f+HizSRJuUoy6TIR",
-	"pGAYUaKi8WevpfblM/emVAiWrZHF1/74HTubSvkhsvbwZcjHEhizsgpIqOMfYRzdTcBXH7AN7FvhrSZm",
-	"720En6p6cQp2Yfa9tSIMokhYoSnHAVZdY7xahHdhgY5jK4oAcxAd+7m89EOjCmzXQJ+4dJoraGf3caV6",
-	"EOuFRUQ2vSNMIoar/jCXQX4Si6zA6OqooB9Hh/XSS2Jn2M42WdhbPJZ0EoHrHkSqxmjaJlz1U4Srdt2w",
-	"hS07OumPRd13z5/98ObNjytGTDgG9D4Ojnvcguh1JzG/wE/8/W/Etd3rDoZGE/iB0fR6BbkwjJL8cHJy",
-	"SKY4GsGwWUXyIMnU7WQYEO9gDYZwAEUQ7EupZurK1S1vbRy24nBoyVVV7w6Jf6S7RpMt7bspoy3hv2gx",
-	"IR52+VaxgowLzkSazWtlwKKr82qzxeJeG5jXtCMJiE8EF5NjlhTRYDJ8TBQ8xyglw9Qb1yXMy5EOuxPG",
-	"z7GHWupssDOqn5Jfz6hiT77+FdJYUsOKqUjljJzNNVM+Dy2bk7xgY37p2jX9ejFVLDn9dQCJgrMZE+Zb",
-	"xX9nT8nu17X9wDePn0x2f3gpTi7S74bTHy7eHrx6MZn8dPzdm7E8pOPX39ZP/gF+9PAfv9Ct34db/9ne",
-	"+u6/Hv39/R+Pd/s729u1umBuU+ymrVw8fqHoFmMpMentS+2ZGAtdthyRvD16aVsztW47R3JeB9zZHlwh",
-	"faNxt69GMPqVC4qGsqsNTTYrWVEAiWp8kVqjeMfgFkA5RcO5KJgMUMReUfVbIi3cP457xzjVhpZvaPm1",
-	"afndpoPrk7qOLPROLcs3HmqEgwgh0eKo1kg2CT6KJCFFY7Nt70MojAJlR2wj1j2AAPoZytS3xykVxoV0",
-	"9m8IIVixW4Nn0+19CRUzo067XjjRflU31YNilT4O/JwV82NNddlhOnHvQHvBUi0++rVNKYBk+3UwPi7U",
-	"gRAY+2rbALNqXOzCZYTqxz93f3x9uPPzyb//dfTvH072//n1j4dHfzv8z/bNqx+wF0u0DtuB7Wr2SZjg",
-	"0I4QcSTcECIvXp+fv98ryuyKltYj82XcFSJqMJspbMHjCROswK5OU66qw+4C982FYAXBma5jFX7uwzEi",
-	"AC8lpos3c4lZuG6Whe1uXfoKp1ZiCLas0cm0YGoqs/SwQsimwRYetC3JQemSX2tVjm0VpYF2Y//aIfCu",
-	"V2t+1SXsx1son7jGg66oWdUDsets3NL3baX6dWP1I9sVzEzOWCaxI/nno1U1KWoVwqUdcfmiGKhezxBd",
-	"MRgrZy7Gf3Mj1ziAuGS6gDhUZ9LvjjNZ6/q0mxu2b85tUITgqzUarFUf2dbTcP07KW692sW4aoy22nS+",
-	"FMWCOYJyFUF0ymrjH9sPFo3v3+n3Kiy7MgduYgJ2MF80v3+1FmOz9nEtnyh4mdi3m/WDguOsTrPa974P",
-	"M6ndx+X3Y/+mheqGtecGAiogLGBVD3UNXKoNuI2G/INVGUXgOC0YVV1JJvjMbQqYOS0EdseYNXvWqf4L",
-	"LCKF0So5pF7YUPYSYvPzQp7zlBVVdbTOawJzHCGI0QJcNjvkihJIHUVgtshx7IdIsoChuFIwUavU8du9",
-	"vefHx63FXsX6bJG1aXv+ZOx47W5SeE4e2eoWYHeRrnCpj3U0O6h1s9c8NJ8y5Y7sxfDg5fP9Xr93/Pz1",
-	"/sHr73v93qH9632HUtzelKhH+7jEBuh9e2vMHAzKz5g57F/vYztxGzEklZayLGDEqrD3KlzElxLcBIt8",
-	"0mCRmrnjxtXFLlVxHc6+HPyTW1cwFl63o2tZaJo7t0zkMN8s3ZbowIut/GgEMurF4u3o8q9ZshVru6XA",
-	"Eh2lcuiAKbG2WwYRD/I64WYotLUcEiCN8YlAyeeoDGvRekqzaTZ8X8NzAIHW8ngaFFjs7nTduiI83NUS",
-	"hqBgkmDTfC4mUMDQ7LL79lrYHfay+whZda5IVksVXtXGvyiwqLB05fNEFcF5XCOkCCtSd7milyzUUkpS",
-	"0biC0WSKiBEC2OWa9h8uIH/VOxVWqDLPIV9AkjNGdMEnE2YzK9cmgAtsDfUKax2oFBoD3IacVOtqI9gK",
-	"nmNYZNNtvAK3Dff8yw0LunoQjme2NdR7fwWh4BaDc1YQKOitShRcWbKbNsluI4Tl5cE+efBWGJFUQTiH",
-	"JUQv2SVP5KSg+ZQn8OBYFtjisqJRDwefvix/9ALvBUjRLMJ5/7iqwS0oFOJqeWMX4eapn81941RyoMmM",
-	"zh0/rpjw2RwaKRTkA5vfIhqMxLXa9lZVH8DzCqNoNstlQY2iJLNS2woFwDUKje21AWoqUvKjmdqaoAzr",
-	"UzlL8IbKlE2YuJEG2P/vLeDtAhlmw+s3vH5JkJYOwfYs4yqs8CfnaWlim0MUDKMCjjYrM81zd6oFxEvM",
-	"cxYpo3v1kIhOGFcIk/C7Ukf+129fPXt+VHMr1ceA8RcP0tXYpem8sh6lZS1fzsO3rnxsyy1AyMyQPp61",
-	"aIAhln6WEIEPnx/tPYcyXHbv3nd4bdpj6hgyR+3Mh6xI0MP2GjfpfWTdN5CJu1wAvIl83EruWysZ1wB3",
-	"51IvDVD3zJBej8Xa2NFv045ue+m2GaMthhU0TKWC0OKMa5Dm8oIlHApOVbXLA/FrNNr6xy8of41GA/zr",
-	"4T+iEtWbYamnu0PbIxYtoTJl0JQMmvfEKSN+5nvL2iskU9dNELsPeZbmL5SA6PlTSwXMVRK+P216mmQc",
-	"yRgFv9lpygQHwaoUnk+euhtyai+mGxPk+16/h+UZTgECs2IrAvNsfloK3wokenPf5ExAkMrgsJBpmeg9",
-	"qmkmJwMkcsflmd8DS/CeyRSoTSMaG3p2vriPFYDwIiTzZRRjz75nkKVKSGVFrBPd/dOPcTUWryNU9xnE",
-	"PeSFNGhqziKRsxkVqTVp2K+95lmqM9+cAku8BUX5uCK/PsqnVDH16A/4749s/vERUI1Hf5j/mH//ig2V",
-	"05QYRHMV34RihSYUeOiMQeW3M2p0RJuZkjizP5peDFOFEumZZoWDDkqMmH/gAFg+8IjN5DkL5yrwF6zk",
-	"BzP5snapTMpZMzadirmVLup3Q+Zhn3Saxt1jWBLmjzpRs7s0Gj2qEldGo633/zUa4Xa1n3TX9VuG4EdU",
-	"sz1apC1qL/Oehc+NFCHti1eNe/mpF965jjb875tNNSLiQEZFm/JBc5x2FO41zBq3VtzR9VX8Yxl7N2uq",
-	"3m9vVtMMW1FCu0sBVe2HvKFFZ2IygpXto8JXS0ygriorJXn13Qqywf+K7tGhb1fc6v6CvYdBSqe2HzUV",
-	"KTToNqylrcfG6+HhDHYA9+EtF7Szc4agNmfcvaEaWrYlipbxo4VbvZ7OYhCKIDkIBSuDozFycmhvaWMH",
-	"MiqUi9SzZkJo/GVmUIGUo760qhmVcLOa9lsXc0C5tdbv3tvj/V4sNsVNguKwi8rOqKin8FpIviTX+6K6",
-	"0d46Hykf7Wk9eYUNk8jO9u7XjdK/ARMwT0O4wl5X7cLS4zFbII63e7n6bYardsYSOWOK+GEG5J15QUjt",
-	"jD4s7VfvA5dLCzq+ZnSmt7S6eS2NTGPBh+EyT+T6i4RKdCSTYsKKdVbqXyVcoK9Fs2x+0ws3hLpr2esm",
-	"/URbA32aHh12XQf7sXV0yE2KzfjWaqu5ESHJwvgjSDxt70vY8GnVgvP4RdsuOKx6OLlxo+tyMFVDdbl1",
-	"fqiXIAefTmtE8ozpC8YE2YHLsPvNk246s/vNk1Yxakd0uMozio6jaAYpcOiOnnOehRPD0AueQD9KQ+Vt",
-	"m8dkSsXE/Ejh5a8UKcztTWiRKiLPWYGXmBpaE7Jrw9InBVNGOBiJoZ1EXXCjrcokKQvbqJRirpu5WSAs",
-	"ntkalCjW9QkTqqwkdEqMjgvOimAu24gT6lcCkeAiycoUS7ZPXKn7lI/HDE1rAIxZ7hrtIY2kAmJSp/fv",
-	"sBKIIn4n5dNDVkNYM5pLkI63mK4FnAJbH4k9OctLzdK68s0apNvJx4aWqacjsYV8gvzdEF//MhRa3aea",
-	"mRdQWSB/jzwmo3J7+3FiPr6wf1dvPRepH6JIpvycpeQR4aI9nn0zHG1Jygbmjn8JRXUCFdCLdTvNQ/8J",
-	"X6qdODkQCXYOZGmblQbrCjs+dkFqJ1jeyBG8ES6ApyPWp66r1hRP5TOR8bJENZKMiq6uLL5nMc5d2Yaq",
-	"JsbNijl3U9reSKkbKfXTSqkb6W4j3W2ku5uW7hrs0R4WcsCA7y1hd+ub39ohAousb/fA+w9Gwo3H/1N4",
-	"/CuM/4zE44uy6W6sp7cpl6ZcJQbNuyosuMdO53WS90p0Z4jB9ft2kDDtzv/WpkpRYcoGFHxgc0Jn0nq2",
-	"Q18JeWt9jAUDjpWgKxvvmgt7Du+LUYh3n/gF3YoPciNyrSxyFdYd34GIIREcr4+JlbM/CCj2Q8btSoUe",
-	"jqOt3g08SITNc1sXzeMjfKmIAYIWtql9iHfKNtqpSNDhzs87+zV6Y7uh9vo9UWYYztQkN9UrX37i00o2",
-	"kQqBaqe3kEnfmClkQ9w3xH1D3DfE/baJ+yKV+CoE8J4or96GsNFgP50Gixx6BeZYWHFhwyY3bHLDJjds",
-	"8k6wyShdO3L3IkbVzKOzhEEmDrukifbbu0IItDfu2RTy2w5p7pjdvjFY7mxeFvSMG7ao+mYVKUH9Tjmr",
-	"ObgefTC0+cNGKXSa0W+B22z80xv/9MY/veHBG9fvfXT9tvmRLDTNTuQHJmLBFokUqpyxguTwHtHmRch1",
-	"+wkbOsmCpJIp8ZUm8ozNieOGNm0dbZWkYiEjcczYU+KyOIPu5UrLPOOTqebykbnzuqDZI65UydSjnd2/",
-	"fd3u3mOwg6WQenqclZMF1W36hI+xrg0EGma2C4+jLMRWVoKzO2PEjlwjJkb5+8CEOgUd0HBcf2Jd7fxX",
-	"KXF4txJbW8blFqm/zFHW+aPr3aDqEL6svoBl8/uYn7t0VUEZ/0iruJ14ZliUUIDiYh4Zzgz3q2C6LMxt",
-	"o9rn09aXLGenSFROD4Zi//Fh/u7d7nD3XfHt7Lv/Hv/Ofsi+//e3l7O9f198P5h/89vXx1vDd7+9KJ/8",
-	"9t9j+uL37d//9dvXz3/f/fZIiflPF/8cj//9zW+Xr87l8nU363DbTYgK64Y6H9L5jAl9wooOES7HF4hm",
-	"xQz5xzijGkn7YCTeCCPBPiVcnNL0HKqVyAL+VRSMFo1Mf/cOpOi7V+LyvRn/hMf0yCFOTjRnheF8mmSM",
-	"Kk2ksByHeN5iDszTbC4Io0bl5LY4Qj0XMaMaJl2jr4T/JB4XXm1UAJGrg2OB6FJUX0S+jVU7KQVfF+y3",
-	"/pM42GbIq4L9NvJtFOz8RA5ncaPm29wo/0ZgQyEDRBOJFcx+K6nQXM89M7OF2fB4PYQjcTAmBsa+/w3u",
-	"bs7EFjROHPRi9YY6VwUQubmXlh8KFtcP8Co8rM77aFAe9Voj/dwH5A+gvZ/XYOkCNhfic10IOeb3olbS",
-	"M1SpLMAbr9Mn8Tp543SESHoV2upFWDPRqd+YdVWVK0SxBktGGvFFseKco0Ui5WbgmcEuCbLIjOa5kVEs",
-	"1TwdM7bMem6I2AsG+K7ohJ1CRtiyj96aV5/Bmx89Ls+hgORT3IuP/Z4UbAVK14TjY3+190MQ3gcb/gyV",
-	"oOf11l/1IwirQfpSAmh+wK/DA2gzpE9mfXKFXsOClE5edcre+5WqRy5C0cZWVXVwVjkG2yKt3gVttU+P",
-	"NdU8ucqXkTNub2zskBWhBfPVW/D2WftTVbYz8ACMhKvVCh/KGQdN2BcSYpE5+oTChZ7DJ87yYYmRv/rL",
-	"rq873vV3Aqyj0LZu/aPDpDueXOXo4mQgwDN3wyMUEaSwMWMR0kiN9Ihmh7wsEmespKRghrIbijlmkfIt",
-	"1pC4R9O4f8zwCWdsTPAl75gID2kdB96z+njRih6byPVN5HrcY1XdphNLSlZnMDFaHtcXGqJFHd9HAmzG",
-	"vuggHqVlQz9iTSzFdOgNiZHZoO75j13OZSfRoIiGhi9wLuF4QKBLdeO5hJaekw/xnMJN4uMX5v26ot3g",
-	"HdfT0PoYv0uoOkduEXpQvUbblt4Npo8LVldI/vjYzVqcUtqS4jS93JNizCerr/LEfxJflqaXRlMf80nn",
-	"2kphBRursre+CJaMrUIh7iDyoi9CoJAf+LLa/s0FHZWnWIDdjeWoYGjX9XrQ+3qUkHkvXrH6T5txYHej",
-	"ITm5S7RIhbCi3WLb4J9HyNsIGBsB48OGd98N3r3Ugr7h4l8kF49zwKvzuIi5JLqUmE3I1Z21lpnF5kWu",
-	"juVYv+Qzrpe3rzoYE+Xe/rtBNhcUb8AnCRXmSGpnyc6ZIHzcsl8Z0ng5paXSBh+mVA2hpj36bmh2QecK",
-	"+/iUNZpiYCUZABsLRIEoIoi5PmKKRbbsZ1kCmFiGH2zQhJZazqi2IRw0k2KieNqy1PVtOXC4eEQlTNCC",
-	"S3IhyywFb5Pr2GEL/po/XUse8DlRQSh4foDt+JCkKStYn1ALkvddoezUDQ4ecj26CYeHGupUhwNO6Tkj",
-	"XH+lSCGzDCLpFNMGRGUvTGk9o5Rc0LkNf4PYdHCVFmY3q5Dhfq3NC8yAYSDwuyz4hBsuYVdbX+pgJF5R",
-	"UcJe+y1TZTKttgB2dMaoMHC7OuyjHg436vXJyND4I7uSof/ZsIeRYQfNR9jzTBGKe+t6eMUdfb4o2XZQ",
-	"lVJwzWlmAaSzet6Jc/W18O+w4LLger64hNp+4JbBCXL7nWeGjhTC4xrYJRf6W2SCCPXuN9/UC6v5NRjY",
-	"3ArgaPFU3WS9mO/rszgfoFp3cc7enLOCTthQB5d5CXUCBohYiB+bu+bGgxglWPSAHIwJjgEvIyGAIAGz",
-	"JVqS7ZDqHNoB/KBunCgRavpOnIE8FtsDE3fVEQfnotCsOKeZY1cxmj4S+7gvyjX0v6oW4p3asB8Wrmu7",
-	"fNr2+zV8ZOgiWMzDEi/MtDfwn8dvXpOcFtA0sSFHhIOSkylXtgcZN6RCySq2DfSGZMqSD2ZXQyqMrVgw",
-	"IsEV6x+Xme0MiJQVFEou2NakwHAE+5EnwfbU7B3oE25YjK2fyAWZy7Ig8kIQNVeazQbkB6psnzsqCO53",
-	"XfP/g4zwFtv2FKPeU/LLqIdBuKPee/IxRID/VnEV7k54Hq2L6P2KbessKixCx8V2g7voLg8gvqLjPFRL",
-	"btaFXht5XWd6TVsKj6hyt8fqV5unW1hMNmbdQRXLF5uF12/JmtNS2yp4eNTQtIzybpx6G6fexua2cept",
-	"nHp3zzDoQ5XWjKp9x/V0T85mXEPED+xgy2bX6pC1ol2OG3Xg1qdZ6KpcMsmnMoPWzZ4bM+dSM2coSW78",
-	"lbfnr4zKuxu5diNTbWSqjR/zzosrDY/m7QsutzThih7bjTDzZxJmbsxt6yKHumz5/oV6b1BRGfgNUaCC",
-	"UJFMZVHHhx7+uDjh3Q1kaMTw58DM56oo2DHackeVao/vgG2ZWkdu0QS8md591dorQztXh4WlWs7KzLZ+",
-	"BgdugAWZjAafeECs3aQhglbjNBsOuQd9t7crYAbWzD0Qeak3SPJnQpIVcOMgWM26sFTlB35N6fzXPvn1",
-	"grEP5r8zKfT0176h0L/OGS1+DammQYJ+793z5z/2+r1Xb16f/NDr935+PjyKeiux7TnUpTme8rG23gw3",
-	"2Gt2adSlw4Kdd3yumA4EU9CLOq8C+KZpQbFkS0vN8WWhhnpRfT0dFNezzl36wZfa6juGBf40IS8G5MS/",
-	"mFAhpCZnvvjjuAQvFUGWD92B08pjqItSJBCzYd15My5KzUhaMvPLVF6QKVdaFjxByZMVBGRPI7xrWUS0",
-	"4es1d2640du7tG9gmIFyeTFlesqKbs+5BFPlhJ8z0Yc3Cp76FvnVkX6lvAhwxqb0nMtiMBJbZKlr3r0V",
-	"OOWD19zUg6jDvWCacjHsIF0dq0SXvyVXlqRBAIBNGZdFFQxQa1c4tJ24W8taMmJkhZ1fLJo3sgWxek/H",
-	"VKRn8nKY5+029BsP0saDFLd2fCkNgzOuHHda0V5Aiw9M5xlN2Ev7bVwkmFUvEjsLhstBDQoulKZZxlJC",
-	"89zcZWetG7SWsDFrrGPWWLdT7TDPOxvVHtea1JqDSqQQhsp2nFO3Vkrz/CuFuilXxNLcUMBS+FM8+OtL",
-	"s6Ov0oLV3cyg42pnANkxGkneCm/5PCzkWcZmYfmTVa1b7DJniWZpc4iORsZGKgFubCt6ZHNSCrgHRpij",
-	"Is2c6vNbyZR2Yh4Fa6ssaDEHASaTFGQJA0daGsIwo0ZoF1QkrG+FU4igzfgHls1tVUJ2zjH8FwI1lZwx",
-	"w67ofBAL5z+WhYZ2fHEcldCpL+VFheEOO4fHe71+b//58V4UQY91wXNmRYgmU6hIHb4GFykSjFYTNxbh",
-	"puE9i1lHQNUTmtMznnEUaX75o3XFASQwLtEsKbEcg6aXUN8y4Ka2midQKvDcw/Jzduo/O9X00qH1096e",
-	"+9mMXR2Gf9v8+rHfAY6bzFvWFWr4Bnds7HYTDPvJqf+iAuXAFiLdCx75CF54VD3pBMnWtFMkkVnGEq2I",
-	"LLXSVIB0X7BzJkqbUGC/cJAEor4rjDdjeirT9lbi0KdurmA38Qk5rJ64DcUn/kGMits91a6Qta0iO5el",
-	"uYl2hGqFwSKgmlEixdsi6z3tPeIzOmHqEYI7yIE6WQjx/Trlw2i5jJ+zmUy9obj5geNYQF6xwzTcpgS6",
-	"FhwYZKdJok93dh9//c2Tv337XWuSGofovjkfN/0KN+L9Rry/e+J9RSGae/7SPumD+cDlR9kxOdSzTsvE",
-	"V+ePmz022sP90B5adD8mpDkZCt8iB/uDaFXeVRURz+WqMHpgKRs1ZIka0j6u4B5HdRR4fW/Kkg+y1MdM",
-	"KS7Fq+itt2fceHcAQwcnxXSZLxDHrUh0YJQI3dVhpC7dgZAktO05EqJFYtSQjKVoXk8MRLApdjvVKU0s",
-	"L/G/gLPWHF/jdzvXKQqBZiPLJGEs7ch8QgiPzWJxKZ2LgA2xS4i1KUFxtKPLSvCtl1wHq7LG1gg8HSwN",
-	"T/GE9LAG52IJoT2VGzOq8TX2ejngbQm97S6ojXlqnqu1RwYKVG9zsLRo/rrEufsadKnyAbjuCkRphicF",
-	"HqmCs+2+/CdhaMbCMAvD/yra3Exii9GMQ5QE7CApg5YMtc4KqUzUwKouiZw90vTS/P8t87aqEWR9maSn",
-	"O9v4/+qiGjwajdI/vv34l1ZwRrqc5CaLyeM7djaV8sPz80X3/AJfgpRx3dmFvSMN/hwuuE2a1o5t1aIS",
-	"udCPd6NZru7udo3r7mEdIOmL6i/H1pDONfdOdtel5wuX2yEkLBY7FwiU3dIFzmeeD1bjvpaXelA8I+7Z",
-	"3V6KK90Vjhvo4soctw+I5vnBfezn0M74suToy1iNkcxUThP2JSwnEkDm1ta3CBhF9aojRytRyFbTgDjr",
-	"uGpOSalYQWSBrvd5096KFmsMKnkuUh9MsAuy+PZT+N9/gM8Fbx5DW8F64EHwboo6ls0ZdaZF8hrl7OXG",
-	"WzQJ+q4jQCZCwWlanqlcomEMbWI9rzztBRfADHH6z1dvskSrH3/6NmL+ai3/czSlae31akEbsRP5fD11",
-	"1ga/hiRt3J7WbQJpoLZ724DF/zpQTXTriNK9uqUrOutnadbTkT+IoPebW7jqUur37ioazMdlVaeaNK59",
-	"dRvth8JbvPRIY1KG2aoF1PVtrljxBdHYDQXdUNBPR0E3dGgVOrSABC1wAB3XGkoGPZMbnSaVhvJhbc2m",
-	"swvrwbjdp5wr4ux8hp5JPWXFBVcMy4JpCf0w3ZAkZUJqW/bEdUW94cjU++yg/HxtkcMzHYzEO1sprmDn",
-	"HJ1QZn8YoWlKZmWmeTWKKvNcFrqrp/Ii9fIkzAM82I/C8ulVyI2XeOMlXu4l3jhIV88azahYfZsOMyqw",
-	"47/obJ0IuUGQ9BclGX9Wv2NAa+2uByxlmSDx/DKnIo3ZwN2T2i5vxIaN2LARGzZiw0Zs2IgNtyQ2TKlq",
-	"9BRd6AsNrj9kkXqGFmsTuhFJ7oBI4s94mWwSL2oEoWmJLmkG3Xhdw0OzdeHHfXKBMZYMra4TplX125zk",
-	"dN4nTCeDwYJ6R+JOFDzadOvbsNabZ63Q7Dom+OOHZ5DcTH05aq7IBNOYzzlt3TZbSLiRT9/oy7oS1b1S",
-	"Xaua8dPAMggKU63RgcV+0NFpfdU6Vk2K6eCI0bsPXVWzAummWaJmJJpb76uCQSeKs+DrtE+4JlOqoBeV",
-	"ZWZPR2IkdqBiPSWuTpahSUrJBLPEfCuI5lR9W5S8moGczeFNO5AZeYccaAcKFUZa93P30RXmrNPnrFAB",
-	"yjtgHvi2tWaUZErFxFD9QirlPlEPzUy74UzkRzYPZ8JUONv6A373hdEhe0uTB6hsGmWUC/z7YQgTrVY1",
-	"ErvtHRNSr7VrHji/a1CNyYz+jhFF5+R//vf/1/HS//zv/0MKNqFFmpkLKcdQAMLV8ONasWxcnwNmTWSW",
-	"yd9KDgEuM6hUoZhQoG7bCXM6d4UXlJH9cETvdDE/6SkXk//53/9nQA4EyQ39Ma9ABoOaun4lKSv4uWsv",
-	"bIjHV8qMBUXnpQiT40jGBdvicFNvqOzbRub+9AXerlPDtb8pentPit7+OYuzNpWARbXaWlpooyZXXS5K",
-	"uYJMkI5YeP/Y0Uzo5B7Gvy/JM8o4S/ftIPUuDQFBSOoNh7yO7PWOzt4xYBR2rznUE+yC5E6JqY74cOfV",
-	"kiqu+8FPkRyrQkPvo4h52dcvg3z2lqkZvkV2X1ChgHo75o+Atu4I/Ow+5LMZSw1Xz+aLp2gu+Oed/TX1",
-	"OIgowUmWom6wJcFZrYSTa5r6cTs6DP4vCjlbUCPLCgCuShZurBEw4eONDX+j434SHfdTEtp7SF79Mte2",
-	"tHp+0lhdR4BXJjG8/hP2qthoA1fWBv6c4l5wdwIW5y5JlMGe88s3rn8lzXySERTviVFB/2qQaPQbg1I/",
-	"igltlH0zZtsefQOJoDmdY90gazA755dV8806RAagEHtDwO0iySEOF+0EvFK95VUAcBnFTKS55EIPqoQv",
-	"/5Nle7WfODTmq/1mzxuimxU0OTB0ZJbrgW8ZG3k2pjzD5OXmk4Il8ty3YFywUSer1Ii2qW2dWWwLskGP",
-	"GRhBbe3QwnVGTYIUUdVGKJu6v2Z+7KLi3zaDrpq11mK3+TBeXzLQwePZ7lBNI4hD+P/Zexvmtm1l8fur",
-	"YDR3pslzZEl2mrTxTOeO7MSpT5o4tZ20TZ3bQiQk4ZgCeAjQsuon3/0/WAAUKZJ6sSU7tnemM24oEO/E",
-	"/rDYXWh4we6B8xPmQkYpfPKDhIYpDHyVv/icPX/Fyjctyqr5VMxESILpS+Vudjeo2jtjl+/t9+mIJTyo",
-	"2fHnVc9wbbHVPNvqUE1GUtljr2n4p0wOOcRyt81+zW513VwNbf/M1jFitL6Stkr5SrrJsLIm593UzqXq",
-	"dlw+nUVcDOzM4orY2eMuTZEJySbRLoRbFeRvm+Jvl8S9b/eQbsjJf1MKPh4wV+ASZBeTNZzGjgXkZIkN",
-	"w2wnsS8hK/Pvafb+wsi8RtxmkhU2SORYFToTesD8myWqbsPGElX5RZ2Jrh8qKbyqKetxq2q2ixjhwt7q",
-	"bN5fmqBhjMxwuZl4aF/KocopL8Qgyzhz9kZPW+2lb/R0/sO2U77MX4nqb5LANQLXCFwjbmuNKCoyV1gt",
-	"ZpaAhd/+R0FTPZQJ/6cc2HNjsUF9yM8htWeKPbPNo1bDQHosoKlihGsS0eAcrpTmITHVNBvpwGoKgoTB",
-	"vppGKts6apoMmC7uScvtravqnB3H9KBolqquSsEwvpQ2JF3iiiKvmKY8Ui7IJ3lyfLBPfvix88NTM7Gm",
-	"u+zpkpkDXKfLdTnB5mJEIdophICvCvgRQnFLOMGxyziiwnZssUSuiAycLVMGoq4Sxf1uflx7MpyQUaq0",
-	"PaeGG8SngU0rjDOsm1ZVTT8eH06PeG0guUyhYj/1rMJLVjRNxK6r6C6oatpT77UtiOyynd+jpwmfHxCt",
-	"PL1/Pj394OLkWEPiARNmrzQ94ZYJH3DhY+Ta+bt0V3/f6RSDsmy/sNoQs8w2dp+/fJlJMZe4HLDFLSLl",
-	"/qZEDWWiS+6JKh2NICRvvzQPi927R0PitQJzA7B5W2zak6ne7UVUnJdtss00D6TQlAtFKMyGqjlQX51i",
-	"7vNHtRqfbFc1/deUm66l9bTZuNwayC330Ky9kWrZ0EpuCcgn2eKjWFrn2pjqYWPXXS8PQYhkzARcccHl",
-	"9P/b8fmgbbOF2mZnxRVhQKYStHyosVa2sbn5iZGT3FXoan5eGlxdPavFlmv5PEL9JvpgpmnLtGnh9nza",
-	"sKXB+xbHHBl/LYy/8U9nhb0eTrgHP+GWX6d+4yKU4xP+TxVADAYJG1iSHEM6ovg/BXXlu8P3H09fN5qN",
-	"n48+HjeacINWaVpXStJcwWsVozZfFu7RyMj1n+GSqRpD1bFLS3o2sbuSalJhVp8mJqmoze5NQoUmPlk+",
-	"o6X2ivD6XpqIV9NCTtjAmhKXlUi+4tdrHezCzaY3mpCE6TQRipidNbCrfQtuh7IGw4k9HLP3K5tXp3kr",
-	"QhNGwBxb8Qu4X0wPGU+seQmc9LHL0o9MhFk+cOTm5pbbAakRjSKwWaH2jC439SBLCAqdy7Un9dBkqpbu",
-	"7eLcsDOm3M0zH9FsnzdLk6L8fZm9BQvShOvJiSnbTqb9SKbhvpTnnHVTM8lnRw8SkO6HQzJmPRdU2aSG",
-	"Bgq4D8D8cxqX/6+/lA2fm1MhxPwtg8kCuX2QiabRqTxnYl6ZgRTKrFNwMQSNiDYvmGKh6yBCIqNJ3thn",
-	"qHWclbIwf9Om5fNcXOlrVvcrbFT7svKoU7yD2+jA0SWAWpvd9IW/oMyuQGLgjRFbZ8LM5OmLpo3Fyxe4",
-	"GJidNMSNVE3y35QlE3fnHeTZhHk9osLk7zUeMJ0jHjCnz3BD3Y1pMGRkp9VpNBsp3Nhg2rTbbo/H4xaF",
-	"XyFoj3tVtX853H/9/uT11k6r0xrqUZQ395jWOhufRrPhrMgbu43tVqfVMS+Y9ZbGvLHbeAaPwJxhCNO5",
-	"TWPevthu0ziGfw+Yrgq2qbSZydCq7PAU4i+Zn7rmXZNndsNhnTidJml/oAMuzE78V9OhrZgOGGhxVn8N",
-	"xJARzD58JjRkp9OxoWiziMyg1rJKq/Z/lDWFsYvK0rYo3Tg2Da5Ybr4u0q5lIaQBlL6fWzu3if5XuZbz",
-	"F8bQbfdLur+vX+dcDOQuhwTxEUWgBnQBtKtuBVJyxMAo323/wRosYGB/r6VVMwURZ0ITliQyIU9Ya9Bq",
-	"khGNzJ6fhVmGaiI0vWwSLqxe0T93Z96kn9ARKJdlQkIWsBi+Y58qkanmYvDUdef22rtznj52ifHepDYV",
-	"Wvxs7S0+kEmPhyETq82fVIQsUVrKsDBfeqmpcj9VDKxhs84kXEMLnm/gEwDjXEGjE6jZazP/VmsLE2BA",
-	"BwcNVJA001Eb4Ro6Y14z72O4T8j8wLU1O+2nUd85Rua6wTV1/YO1+EKx+S399q4D+5qLC7H2b7n2WKTc",
-	"Sd3CuNtFbBqZGSxI6EDBnWNG8H0xT/JitH3Fw69WiEZMV2sE7eUrcP91HJelapaiG8dlyQoUCTusjCHB",
-	"OXoKvNZwbdo3txtHuCyKv6/c5HhXNu9PDeLFbJgzNbybgk1YTMycHDJqFhu/3UgV66dRi6BIRZGKIrXx",
-	"vf3Q1tqC91IfyFQsO17F87SQhzBqfS5CM4mtwCEJcyeldoBqBoXYK6TN+2MvWCUYz0dSuRNIKRhhl1xp",
-	"hUyBTPGAmKJZvRN/w7S/q6tMDW+YfiC8sNrWfcGOHXfniBKIEogSiBKIEqiesOoJd0F023k/wZGtVAsv",
-	"NCszB1wvmrvr6p7SB0ylPRlO1gYeFbfFfS2eSro7VTeGPtV3kCEMIQwhDCEMIQwhDD1uGHKBltr5a5fr",
-	"zR8yGz/Tnwm3F9IWWcjFRTXJ/RU9R7nEM1zELuMInMf6NFLM2QaBdckUlFwVPySyz8H0vcJe4b7foTlr",
-	"t7WsCQiXYlWrEf+KtRhZ/NovfMT1Ub+vmG5J+LPqW2CvusxLsxPmKAlZsjeBP1wMWtL8z9oy2ps0Nqp1",
-	"m61EZrWDGIoYihiKFjNIYY+LwpzT4lyY8qTmw8s/eX0Zs4SPzH4mejqf3dpX09D/c21vIKIcrLizVSC9",
-	"CeFhq47q7Iuzgm0pdVfhVgI00kEpjlIclUmoTEKMQYy5txhTzxHLkMwc657VyeQNK6mb9ib2BqSHgibr",
-	"00y4PitxHOojkGSQZJBkkGSQZB4XydRAx3IYU200ZG8hadvgx4RCFPlSAbU88zFWLNEPTNOyfgOjGZL5",
-	"TSbn/UiOfX/ZMbhtm6O14dXOXB64/UqBk7+dyZnAMAkAEFx8cOJuu1NppJERkRGREZERkRGREe8/I84C",
-	"3bVoseL4zt3KuSDyTJZqjsHV4TTNNeysfHvUAzWxcgGDDnhkZqMLfZsN4uErM8HtdTQrW2O5MXD9b4bi",
-	"g/lRtWzYXaYaN8mEK5Wy0N47d/N89lhfJuxGGTG4sq7xWM3UXIdc2zpt3vubNkpzZaMtGnI9cj3aoiHW",
-	"oi3aDF3eBGFLFmiLeRaWCDq9NiFzRFiCc/cm+9PU91QxinCJcIlwiXCJcIlwiXCJcPnI4XL+abo7fHQZ",
-	"2nllL+kTocku4sJ8P2ykWmfiTJwOuSJqKNPILC/2uoDA9HFIeB+WD+jfhFElBRkzIphdpX0BeSVvqhWf",
-	"3n4rZDKiEXEATIJJEDEo87ehPws1z6nweTVrKmqnQI+REU3O7fGpe8Met2q4md5Wxyf1R61w+QmsgFLT",
-	"aOZWEl/UtDves/G8Cvhc/bLq7kPsuXvPhRw/eZpVSbBLXWz9d4r02IAL8wA05AD2woWJh4XA3hxWifV2",
-	"fB1AoJlD9eG96x7fV3G6ZDiV7Q1VBI0HkAORA5EDkQORA5c5O8/h0DoVjbmn7v+W9H/NamPo6MjQYaaV",
-	"hMlr74aCQQ4T2tfkiUwIo0nEWfI0u1KVCjNktqxFrrNOcE4Vl4e+wvdag1kV3i7XMHT3RYZBhkEDSDSA",
-	"RIhDiLv37r4rQdw8L98sI9KbkMNX85x7EZzuuKbLWJC6o9t59c4m/Z+NiAumGl+WvfG0oHl67Q+JZ201",
-	"b8Ft+jrKL1RmIQgiCCIIIggiCD4Qb+nbU+W1aRwn8oLVX9DQtQnyRElF6C5xZ5csALFhTzXpxFSLjJ2r",
-	"8PSgOKBRRODKSZgdiolQFY5ftSy6jKTKZxpI0eeD1Hw//kw0tuGK4ZKqmSK8FOCC6PH0sNmb8+2eiS3y",
-	"Nygc/96tPP9VTieVr03Tp4xSlxcz0keOmCLWNg+yHVGR0ugv26M0+ksAnlynnKzOs+XUUbwbpHt/xnuf",
-	"9Z0IwwjDCMMIwwjDCMMIw2uB4RM2Y6U3A0ybx2NQpLWvzJ9VD77BDnCpI+tfbEJktjupqR1bPEpHaERo",
-	"RGhEaERoRGh8UEfpHsSWcZBJKzSgH11UouXIzqZGskOyuyMXFjPnrE3wUWIn4x0F6cx/A6jDRBxFHEUc",
-	"RRxFHH1cOFpLjxvWXGp62U5YQKMgjaiec8B/PE2Uq+V3imh66fyeFXkyPZCncUwU0957x1fkOzV7Pv8U",
-	"HKOlZrskGJrFQJERHww1LPiTJgmZ95iWwq0Yl+bdCx6ypNZgNVddBxin9BIZG0+8kRaRFpEWkRaRFpEW",
-	"7y0tLgNjm2fHC8nDemD8JHm42MF7SC+YW7GjhNHQWTB6n25TBAvBfNPkVwzoY4d5RJNz8zVQ5VJb+8hU",
-	"WSHr4lpOyFCOZ2aaTZ4PWVRHk6ZstJp8IArQ3GCuEMEHKRYpFikWKRYpFikWKXYtFDtDiJsHVu9x1Kbh",
-	"henoedpOnUyITeYn5ZSyrc+NszKFOIzWc8i5GTHrZRRKpsR3mpw1nPdUPpezRtNMfgiI6WpT6eqUy51w",
-	"G1ZSJ1Qo+zWNfWBNmmo5opoHM55ODqNTZSVscq1m+YLNZ8tlqoihvFGsSZ/yyNF5jXPVkJG+jCI5hjiY",
-	"9W5Wf6mJCP6y+f0Nj80+gItB4RnkC1PZP64DdgdX/jbKrhtvZHfU/yI5IzkjOSM5IzkjOd9XcnY8syS/",
-	"rRWsbcygWnAuRIkvhTonT+wR/9MyM3pEDeZn4BeCLATAmOuhTDVhl2a0uI4mZ4IqxQfChl6HOZTtMTJC",
-	"n+boXe0Z10OWmLkiA5gq9kVYOvL0ygUZUJPUPLRdDvcn5cPic3UmZoO5ZyVCHbqF9LMB4Hkf2FjnvHfq",
-	"i3cp3XcVTHz4+WkT/U5kRHUwLKWlIqeUL2c/P178L1ywh3AJ1IZvx8/6SjlYvKOw8dOKHEOId4wfj8yN",
-	"zI3x4xE5ETmXih8/PSy/JlU6q8/5V1MaJpwxE5177fqHaZprXLvORRClIesmwdAs7o3KaJnufccNPSkj",
-	"RsU1AnNW3Ou+hNx2DawNuvlIr2p03XLtqxrnvb/pqxpd2XhVIyIWIhYiFiLWI0Ws9VzIOENLZ+JM7M0A",
-	"FFymU9SrK9D/VDnncGEWWCv8yX52BeMFSxIeMnUm3MmyX5BgTGcjb2rpsjZfqpkFPkGPDekFl0nd1eML",
-	"Lil0orOxUZ2NK+Tur/rzrUVVDXIEcgRyBHIEcsRSV/1VgcHNtDbtKz4/vKHToZRZoDYktX1hKtEXnx/x",
-	"+edGGCcPZSnKUjQ1QlMjhAmEiZubGs2R6De6eq6kLYAb6OZcQLdBRvg2DnFuwXT6OroE1A0gzyDPIM8g",
-	"zyDPPJCb02rZ46bBf5dVe9j0m9Z63M7ZyB3Hj0WkQaRBpEGkQaRBpHncsWNveNbjjS/UfNvcLFnZSMP8",
-	"vp/lUqKaBcaYoGzxr5usVrBRZeGv5u1VTVvzr1nz1pvqYJbSB800clYPhByDHIMcg2YbKMYfkfnnVG4u",
-	"afFZbytpk+V8cjehCciyv+Vdf7FclJMoJ1FOopxEOfkY5WTV5nWhiaK/+G8aQgSU/2UxahOuFNqCP5ZI",
-	"bCiFUQqjFEatO2rdEUNwuz7PynERZbxhGhEDEQMRAxEDEQMRAxEDEaP6RGCu2eEiyrAJ7zlo4CEGsg2y",
-	"DbINsg2yDbLNQzzFCVkvHbRHTCc8qDdDPGY6TYQikJq41OQJF+QoZuKd+7eNX/UU+tBGxE9HPZYQ2Sdc",
-	"DJiCKpqZqIjiImBkxEUo4Ob5j6f7WaD4fJb7doY/UU9Ns5g27ycTEtIJoZqMeO71Kj3PK1Nfl1djIV1o",
-	"dqnbcUT5zGjNohECBAIEAgRaQaD8fHR+jDARvADMWfuDoClKVvNl64iNTOUWx97Op7YxGqMIRkalvf+w",
-	"QCuIL9hnVKcJUy0CN7kwEcaSC1iZYThCd/sJDUdccKWNNLxgJE6TWJpvU4po0joTp5L0mb+YpFAyBKfM",
-	"gkO6skkcMaog2hK84Vvoq9a+cv/3lk2OksNXXwttz2rZOhOHfRKb5d5IkkRewGXg8Ilpes7MMxaYJTFg",
-	"0Fq4AdG7DWTDQiAulOERI1+rHCJe53u+pHgpDsABj7S9eqU3IaM00jyO2LSfDZN8NBJql/z9v+7pT+7v",
-	"1vZZ2unsvJh9vPN3ozqYhUtQHc1iBjKq4o0vU3M/JsWau6c/eaWVr3rpeW3dXcqN1j03a4jJYaYRuZ9P",
-	"JzH7CcaUhbYlsz+6cPF1zZlJvnqAkdczGWCAePdSrmOuHSR+UR6bDhQ/u4hc4+YeJH8kfyR/JH8k/wdA",
-	"/pWUnqP/vKyY6/Cbf799lfvXobWgrrVqyqNRb0J4WKnuytVjbwKX/S0+dCxU4pEYOuX6CYU6CnUU6nge",
-	"iOeBSDWP6jxweWa5WKzBnD3eG3MjZ0y38xEjCRUDew/0ob0nGeYcaGQIAIr//DKdINfEdScsQBFVmvyw",
-	"Q4YyrQuC8vpiGW3fiaaJJiHVbAtqxgU5Ptgnz549e+lOL201RRClil+wVqPu/kLb3q4+SOSooD2y2TR2",
-	"G1kpFXBTUoi9FuFaq3Uq11Cpw35xVCKz/lkOht72Q5olMMNOABtB0wwv5KeEhxOzzsDcrM7BxgOuzkKm",
-	"upxLTXcMqYJltFERtq9wnWR5obF6/sNX9ubwwBCMMnPVSHdn7lc5AGFjQdDjuqKcfrWyPP/bCqrZhSWv",
-	"60vof0vzX69j1r/PjBbctNPSnTfUFWt1o5V3mG53Os3GiF7yUTry/+LC/SurjBE9A7BNvJVgSIdumYA1",
-	"E6Mh4YYIN0So5cT9AGo5yySfV3LaB/WxkqxYUWauWaaRCelRHQxzsrQvo0iO/bzaj2RqpZDKjA7s4WaJ",
-	"8W3mGeUv55oQmPxtySt2shONX5t1+W1By/51TQk8R/LexCXiPrYXSQNJA0kDSQNJ49FoHj1I5JSM3uBu",
-	"vpoxM8urVAEe+DyWMvkDyzOT5CRKBzUb+/zv6zN7y0p+k8g03pvYp6bay9yIxUUQpSFzl4SF1WoH936V",
-	"rusx2qS5mXFte7R579+GLZqf2WiHhtyE3ITchNyEJ7YV12RVamW87CA0YYRxPWQJcZbz0J+aah60SNfD",
-	"lRkq/zvvTxGp4LNBtVk6rMw/EwdymqVHNDKRqVnrSUyVIjS0s5lGpG9px85rGDAzUm7VGg+ZIAGNgjSi",
-	"Zr3NKpWaNbpJelSZaguYMVDkd4oMLEaRPmdRqFpn4khEjrDcsePJx3fgULJ/9PH9KaGDQcIGdgE0naLS",
-	"OJaJdq4zOdePrOuczOoxkkJUj5BEVLPEHVFSh2J1YcEPMrePTQTUcLnbog5FnGq1nCJpe91VWIlLYDxs",
-	"WPXMDsckACEGc8ukUYSan9NII8cgxyDHIMcgxzweyzMvittX7v8O58cZn16c7rHBxuY6E4YJgvwPXGVi",
-	"20zFnIAXmTgnh/3qN5ogtgo+rtMMvOwyyxDXTfig7Yt+jvscQ8nsgkf7fRZoa18KRk25nFtnAlx9R4wK",
-	"1TREZsBqTIU2syvIX0/i87VWWGbO0hEj52zS9N60XrKWvY1NTcHdNmEXXKaqmGJIL5gTU7bvQ9LnidKG",
-	"xKiRZJmncI8qruoCu09BaLFbQjbiq9/BWqCc78vT5HTI7HgKSdz3AiKaidAJD/Awhs/Yjp/pmSGjZsEm",
-	"IwrfZKpYP41aBLEEsQSxBD0CkMuQyx64fmlOyPUib1W5Jt6F7O/cqYYDNRaIBogGiAaIBogGj0ZlM0jo",
-	"UuHObLr6QGcFFcgag525cothzvLBFW4U6qwQ0uEocdRgUrlybz0U2hs7HhgE7RsMgnZoLbm8Sm01+69X",
-	"2Uto/rXoJfgIrm38Vf/2Oky/qJgc9e1GaMWwc1Cv8jxrzs8A3vrgV5KpdPiCWxvc2uDWBg9jkeyR7OvJ",
-	"vn0FfxccxH6SPDSTiFretoeXZpbZQ7dIigFL7OLRhFgfkinxnUVfiHpAuCD9NAFjtR6NzHBMzcKkUC0y",
-	"W0R2mJownUgamIU2mtgcGZyvNqEa8I6YWIMy+x2YpY5GCaPhxC13Wie8l2orDrJtg50JCTNzxJ4L9tOp",
-	"cVruCLiXJlCjsbCfVZaDs5VzgdSy01w4XqVEcTGIfFlm4ZzIdGpYl9+kwAkvFYQLDgEi6Mh88WZXs93p",
-	"2NNeJUmfJuRFx9Uus61y+TVz7Xridxj5MrhWLOo/JWOZRqGvoh8L2Sffd+CA3NQfTpYvJHcbGMi0maXt",
-	"sUCOmCKd6Vnqi870oNlWLxPb5guD4ara0ZhBt9izjBrZzVQ8QEaUQpRCLfE3riX+vvNy7R2wL0U/4oFe",
-	"ccIGsOR7eyZpZJWRhRlEBS7bqaWR7x2lqQbpUDdRkZiRmB8LMUNUJ0svbQMYMWsHQxacy1S3FVPKgKxp",
-	"Q7XfhjXoJ/4N4t6oczI4gQL2XeoTm3hDLgdzSnTIcdseCHNrtLLPJPomIMMhwyHD4Uk/0s1jo5tuHM+E",
-	"5hjR5JzpOKIBa0fWQ2HRAb8fPrNSKr8doHFMcnlVn1e/myb4xZdV0vUsdyDJwl9TlkxWPcfMv2bPMjdp",
-	"WFhur/mDdoZIH0gfeBiHwheFb1n4tq/0JGbz7wuieVFL3JukN4F7FSsN9MuSaKlDFm1vT6w/YZnXjd04",
-	"tpcn3rKMRfmK8hXlK8pXlK8oX2vla5sLpWkUmaTnbFKvqT+06cz8ywvdC05J98MhecsmZYGbk0ndOO5+",
-	"OHzLJi6flfe7hbz4NCMnXFogoq2Evd5ZQJyYymtuRTOFMiqtIqC952ySrYTOsj2ZNXwxv1ltvX+lVb6a",
-	"wzNG6YIOOmI5pYKvuJnzbsj8tTJmTVeseJcQRI7KDRPXbPSdIrkiWlW3hOQI50/fBV+ydNLahd84gPdq",
-	"X0k3jveoQq9EpBmkGaQZpBmkmSVoRppPYadWeZCDGRrHADFH3VQPW2fiGDzNFKHk4/EvsBjDHWJmsCAJ",
-	"2Wl1SD+S47m4A0l3XDFvmP54/MtDUTTsg+DpxjFcrrbKco3iGcUzimcUzyieUTwb8djOPohaQd3NPhkr",
-	"UUkgQ9Y6E59YwvucqZxcNr9Yr/rLYEjFgIEvDrjOEy3PzTIkzArbT5ga2idLS/CsGiurLWw2/n0oaV+G",
-	"DPw7Tow8VOqDSa1aYFW8zBH+8lmaLrlpjnYFsfnBRFh7hn/lh3ztmacJXybThSNfoWfKAdYzu7wVJ+8x",
-	"C3nCAtcuBB4EHgQeBB4EnocGPA4G5hkL2jQ11oDMXYy1+TuxoSi8oRIlGUoylGQoyR63JHNyp/5SpX0f",
-	"dx+kV51PnpUpm/HBg7xtMbftbOdEJTrUoShFUYqiFEUpitIlRGlpW9i+gr+H4RHcLzg3oJSNdlkvb+3v",
-	"Xt4uPkwulDz3VHlEL39hYqCHjd0X3zcbIy78P7dNQdp8TI3dxv/9Sbf+6Wy9/PKvJ/+7+1f2j6f/3//8",
-	"///3Z2frhy9/drZedrd+/vfbd+8/bJ1+2vpMt4b/OR+JeEtfbP3z5Wrn+df/qbA7w3hEKHpR9KLoRdGL",
-	"ovcGu9h5fmImlb24BforSgfV/mGPQbh27nCTjJtelLwoeTGKDKIHosfj2fW37fUWdUfEEIvFMYr5wiBa",
-	"cItUPy5hCyR7gOCyhNGW+WMD2ZhvsLHaK1qu+MKYi1COl736o/TiKR+xz1Ks+rK/jmXF/oArY94kMo33",
-	"Jiu+O/BvbRwdobwsdmGzodmlbgfqopjN7MRA2kTaRNpE2kTaRNpE2qygTX8z3HybxOwqQusjUXPolFko",
-	"nvhMUTt2nYvxEFoQWhBa8HAKZfYjl9lCat73tQ2GVAgWLXGXcP414l+rFtfvc0n3fQELLseduaa1ujjC",
-	"xbShhVtni/e1/mSE/N+3c9VrTTO4MhP22u1wr/8EBa/aEvfy/b21tmICXfti2WXz2rS+qaIeFRfEIqYh",
-	"piGmIaYhpj0GTFPpaESTicesSlZoTGkuL0LKd2It9KIRbFxZRJ1jTYXE2pCbTUVJtgp3dNFVVcvREwdF",
-	"OYpyFOUoylGUzxXlU3lbIWuXluaLFDbtK/d/Cy6JP5F97ZQqlRUivQnhISghjkRQV20zNbxmhuvcJezm",
-	"Q4fHdd5C1RCx+AAna93cwxsX6rqx2+hsv3nx/PMPz593D37rvv359fbO+z86+7++PPi5UTzGQTch5ALk",
-	"AjQfQfMRBCMEo9sEo8y9+EZgNNfNag7hVHlbPWw46Xwz+hDUbyDHIMcgxyDHIMfcf44xqHFDhInTCoT5",
-	"GIe0RktTpheb+MEBzLd6toQshSyFLIUshSyFLIUstT6WcsyzocMymGKr2jbblxZbNr+2mS+wa4ZLyohp",
-	"5JbmI0a4IMcH++TZs2cvzVoworp1JsBqWPELcK6vsuwF7/JqNNvp7Dzb6mxvdbZPO9u78F+r09n+3Gg2",
-	"bP6N3UZWfLWXe7HGr0V44/pqeVu1PQA/c3ft/iiNNI8jRvqM6jRhhIfKfGLnbKKKdtYuwU/u79b2Wdrp",
-	"7LyYfbzzd92A2ASFVi7tirVkI5x/XH0jXIKf3F/fiNnHtY3wnv2bbESSRjAMxZqbpz91tv/94793fv/j",
-	"887757/t/fG28/L1q88Heyef39l2TBN9f/z9p88/b//YeXv89tcXz97v7XzqPq9rlXmtukkz261fDl+R",
-	"Jx8Fv2CJolE0IR8F/2/KyC/skgdykNB4yAP44UQmGhb4Q4CrPmfJ0xYY5d/iBum6I5Ad4c8OgvvBd/Hv",
-	"P//ww4+/73Wev/j3SefHHz/s/3Fqx6GY7mT7ePvNy9ef3r/YOX6z86z78t2Lf9cNxXQdfxSj8U36T4CY",
-	"Wov3RH1Ot+k7AbVAzwncQuMWGs0tcQeJnhMlzwnmN2br2Dy2r+Cvs7Jc1vQA3lnS8AAE2lJae1eTuTr7",
-	"uzILsK1AKYxSGKUwKrJRkY0Y8siNApgT6zeDkCSN2KoKbHhnsf76GLK+SVgOKOi+x+RYshF3EpBjRVV3",
-	"+5b13OvV4J2JLjlnE7MeUZLaVy3GZoSVKgtX3L42sQ60FgZMs0+PXh3tWg8byGW6TikZpXbNlkSlcSwT",
-	"TXpSDwnUmoqQvDVFC1jvFB0xomIWgJALZMgGTJgP6m5jxV1XAWynOw2KDl312uDu8edn71+9fnt68un7",
-	"4+ODg19fvHzz/KD7qUIbvPPH89+/f//+za8nz3b2D37c/u3l89fPrqUNvq/qVbOKrkW7WpvRbSpXTSVQ",
-	"t4q7OtzVoW4VNzWoWy3pVhO3adhUSBqT/zLxaI7tIf+mDYZNMd9MJBpoM4ahQdmNshtlN8pulN3XCEPj",
-	"jOPWoJRsX5k/140+A2aB80PPWMvBdcSdcbCw+IDVtggjziACIALgoSweyiIDIQM9vIgzKzHQ8uFmckiz",
-	"yOTrIQFJ59vQdaDuAsEFwQXBBcEFweUBWpOtyCxLx5epPm8pB5e558TyTZ4SITkhOSE5ITkhOSE5ITlt",
-	"NKDMBo692ppZ05ZqE5dTM1A1GiLFRGhmpRlApZ2z4JjrIUmoCOWIhFTTMpWZLB+qFmn7G3FKRJMZhCeE",
-	"J4QnhCeEp8d2Wfj1qGjMekMpz9vqgl/W49A+jaIeDc4JE2EsudDWl6s3IScX/NIMCGQ6IbQnU00y8KFR",
-	"bTy+YwaCyrx/NE3uoylsQuczU9RvtuUr6XzQfAdxBHEELXhRGqM0XqTKcALOSsiyRLyOPiOOqFginAAk",
-	"q44g8AFyWDFqAOT37QcKsO7TBkpMhVtmAdU64b1UsxqXZh4+5kijWU+ds8nCrjpnk2X66kYxANbhor+u",
-	"7hB22rfMmJvPMusfVd9Bn2zaQj/R0IoGGn1IzOeoOcs7zJtVcQDe5v6JtEF9zVKiJzBlQsbiI//0G/Kj",
-	"N2vJtX3na1/etL+8KRh95JHSkdKR0pHS0UfeQHPsqNgDuZER13SHB2io8YA32W5It2WytoXctos7NArP",
-	"6FDcorhFcYviFsXtcm7tsZWF8yXurOqrfWX+HIZHyVs2+doW7HKOCU9BLIcJ7WviN/Mw/0BSn4lD89Xp",
-	"NBHKVZ33zWjaMx0aJYyGE1dfwoXLSCbE1oSEktm1K2F9ljAR2LkQUbANitNexNWQhb7oMhq8Z+NXJk8H",
-	"B4vNgXJdMNcmiIrJUb9Cu3fv1Fn3QMf0pdm43BrIrZLqqerpF6QxpDGkMbSYQospxFHE0bvE0fcZGt6I",
-	"R5cOogQUOT2gzAdPsoB53XhJK9IjxkhCgkGCQYJBgkGCQYJ5ADGSlsKXucGQPJrw0N1W3SKncxRZBASu",
-	"ThNhZmDfpNN2UFPFqkMorZNRULl1b5RbnbtTbqGyClEPUQ9RD1EPUe9hRJVakvPmBZCagl5d5Kh7rkza",
-	"jHWV7ZrbDg2FyIPIg8iDyIPIg8jzmMNB3ex4rh0PqVrmImabjnBRY8ftXSg/2PzuJSPNc38zzXqE7oDf",
-	"jksdzKvrO9XVv34rbnWmePStQ3xFfEVjf6Q39K0D37oCUt3UyQ5c7EyO9Yw29bW7z5S2QU0WdMvdOQtC",
-	"8WijjhCBEIEQgRCBELGUx2BJ8N9YG2T/DdLoLZvMNeH2RlYF8MjbbtsfbmK8fc81SjXV9L07t7IbUPKg",
-	"VTkyBzIHnrvhuRtCF0LX9a3KgWv6LtrBTezLF+hsnHU4QtCGIahzx5oc1MwgJSElISUhJSElPRCD7FUR",
-	"aa5p9nxKmlpnIyitH5Q2eNh2d7bjiGiIaIhoiGiIaIhoj9iAfG0nhzYMQn3Q0Q82wdxg4C4NhmzCwzVk",
-	"EmQSZBJkEmSSR8QknhFuyCKpWEgjH32SuTySpUIiQSJBIkEiQSJBIkEieUxakowTVmYSmWgatZ3/8RX8",
-	"PYnSwde2dRiv87j/1fxKIDl8jIEUKh2xhNgMW+TUCGMmwlhyYQWUqWEQTQi7jKXyA+3fUy2y/ixLpARF",
-	"fIDs3plyloKlrE9u/VhrscM4tAJa1TJff2O1V7Rc8YUxF6EcL+sMX3rxlI/YZylWfbkP8Q3eJDKN9yYr",
-	"vjvwb23Slmpa3jH4r8HXqdmlbgfqopjN7BDjuR4SKxIrEisSKxLrIyBWFqQJ1xNALcthp/KciW5qQOnP",
-	"L0a270cyDat++5LDWvi5kmS1eWdBpCibpiY61LTkCvssdhlHMmSN3T6NFKsOrRTxEdeF4ErZ6Ow8h5BI",
-	"fJSOGrvbnQ5wovtXhn9mLgxYsgb77yyo01wro2mDK4IrIZ8gnyCfoNM+iudHIJ5L4nXhjfkzOhorWWtD",
-	"+uQkzYYMdvOy7JaNdWeLRrGJYhPFJopNFJuPTmzW7Urbbm2jNkZNtWw9zNKoavGqSG9CDl9BZ6e9/7BA",
-	"lwXuNJOZ/ex1pW6cmAI0t4KTh/PqTWihvra6rapIvq7+8zOLopnmm4WQ5tteOjfxT6TNfikUQIMTlPMo",
-	"51HOo5xHOb+6nHfSaIHi2aeqVj2f+DxuQ+3rCkOVL8o0lGko01CmPW6ZlsmeeqXvx1ixRKvc1otYva4y",
-	"fZfGdsvqfzsTZ+KwD73vHpFQMiW+09aWoWlmG/Rpj/kY4K3SK9bsoZA2polZU8xQQ5EhGXM9hLfiRF7w",
-	"kIWkz1kUqqoAHKYJXvRdfze8ioS1ZVbL2fWqp1Huo9xHuY9yH+U+yv1ryP2K3Wz7yv3fYXiULBlk3Yvu",
-	"TEl9ziZ1gdOnknixGX6xJnNt8dG7EAUkCkgUkCggUUCudWNcGx57OaH3huk7k3jrs3TKdpC4Y0SBiAIR",
-	"nZfQeQmJALfMdVvmtlnZdMRGpm6Lb7DPp56xdCIHMiHBkAXnZrrlEhIaGMnVNNtPGMT2BY1SlvOVF0oz",
-	"Gs49dn6dr+aG8aS5nCcVF0GUhszqCsJqlyr3uiuhJ2XEqLgt36lcn6FCHfEI8Qj1BUgHj5sO8mJ0+dvR",
-	"j2ImIIoIrBN6mDBGjDRRRPYLSLBrA+SwsEmcrGvC7drKkHrQImY0zYvEGWxPSGjSj7hgdumGH4uZ2rfg",
-	"k40mZq72GdVpYu/otuu36T+quZkQ2Wl7HkAgVxWzgPfNusZFYba45Z76uhdeFYyFitCsUKqUDPj0YN+9",
-	"9RQsCrbInm11kZNC1ueCuU6Y5uSoyJROzhr75uNVjJycHM2ssGeNlsn6xL5eyDlimkxkSmKqFKGRFAPr",
-	"9dbng9RylJnVESODhAojfGZL/ajs189VVi9o1u/kD6KYNq+oswZ5YgqY9pwt4SlU61250xQZ0gtGRlRM",
-	"oEkBVUw17ZrjMiVpTFIjM7d61GRsq2WGk49im4tJZQY2YpcgY7iRv8pwT4uQ1zb+4y7MjSBVWo4sF0CB",
-	"251Op0O6h94kP0wTv8hBoQYAuAzNRJuZKjCMXTLgF0xkajOTrRTRxDbLbBlpAJL9iZBiy92++7QwbWKW",
-	"+A59yyYtctiHcdLJBGJAeQdFwcaF1yxRT1+0KzeNEkbDCUx4KnzhufeahfkMK1if8sjP0O87L+2ikLtU",
-	"uDBFYWl1F92bajq+GsmQ9yeE66Ztvm0pSMNqF8o8cN6GCnH9Lpq5FtgmHYo41Wo5e5jtTVRjJVKHxdZO",
-	"q0wLYhIA1vkRNrPI/JxGGskeyR7J3rTg5dpbsC9FP+KBXnG8AplGoRsxJ//MR5shbeCynZKO14oavmBe",
-	"plWNE+5fcP9y74OJ+uAOBYBpLLvDWVkl2r7K/cukOMjg7GsbqHoJralNR7hSKbPmOsXq2y1OHsgMcvaY",
-	"2zmEhHE9ZAnpGRhThMMsyOFlpeI01xFvbD03rzatyLC2+741leySRcgkZMnepJD3vA8B+v7IvXT7il8o",
-	"HrW/yIjIiKj9RXpC7e/q2l9LD16LSUmPDekFl4nZamR6RatXs/qrCj0qEM4EsAaUaLCxMX0E66sdWFBL",
-	"hSSRUWTGiyRpxFTTTF9xDp+kHSKnoJrWZ8xDRhIqBrD5cZpEF9NceR2Y4mLg9aBmCScjaTZb1HztJsdQ",
-	"iu+0rZuWTj/IA3Dkcto6wcYO5FrkD1cHUIsB1nnGgx6wCrqKblBev2gSuxYoQp2+kY7Mt2waYXsTPlxH",
-	"gi7WSpgtsiV8tHlyZRrH+n2w92N6bJZ0A432kamXjVsiQvv4MuZOU2yet8gJqMlB0d6TemgyHFERUi2T",
-	"CRSe6wfTGDc7oOcoiRMuE64nmZ4X2lBU8vOEAETZhrIW+UWOWUJEOuqxxOU05AMDvD67ph3GDukxv15B",
-	"CqWzJPnKZNOM5ieXrxJ89KEV/zTVcmT6w2Q5oiKlEUmYGVGT0k9wZY0b3KVDTUJJSHk0yWfOFWH/TSEK",
-	"TC4DaL2iIz867IIlExLSCXnCB0KCVjqb717fbs8Sjmcf+wk/NnkOaRwzAV+FXfrMWgZjRiOznsGX4Aql",
-	"2ur7mG6RPfvzX12zmv11bB6Sn8i7w/dP3tFLX2QX5mGTvOv+/sS/sMf6MmH2jSZ5x0Ux8dOnxe73+ouh",
-	"+SxDIk2VnP6xoEwO3b0JHJrChEoTN+99Q7jKpg9XmgckYQOahJH5yGWfjIcwv00yA+qchXXKaUvC93gP",
-	"tHmVN3RRTu99h2pvt29B3Tfua3Bfg7pv1H3j7g13b7en2TZdnvDQBoJMq0yCbAIwKSnaEgQu6kaFdYOZ",
-	"uIVIGBxO162JkOxrB4XKJWIXXKaqZCBRyMG1cMtbr8SUJ2BuUZsFV5lBhWNQM6+kHrJkzBWzcUCyMCAm",
-	"G98ZU8sKIPTShV/WvRbqmMaDhIZm+xrKsfD/78txXOyYNzeq8LE73qroQGft5FgGFsF/WCKhDM1HrIy+",
-	"bphu0zLjfiMwWn0g+SL5orvbo3B3Q/RH9Ef0R/QvoD8459XatBShVw3hs7WhZZxliz1/AUdAS/ZM9GUS",
-	"uJOKbtGJ0LkRqCFN7FwYUtV1JzjeRcAanfOEWLdB30M2ys0ojTSPI+bAehoInpgcE6bTRBjRB1bmUlS6",
-	"BgDNH9g7fS+Y4KDQTxhVUqim91Ycy+TcnSbBuUihB6Gd8wxy3rC8Pc4n6OL7bY5TZRtj9iAFwxh3YtLY",
-	"bex0dp5tdba3Otunne1d+K/V6Wx/bjQbBsqobuw2QqrZlsvjNkNGlEYGzWMQphGmEaYxdgRiJmLmujBz",
-	"cXjGCm1ywi7kuaG5zEHQDGXOC9NRV4t01dTMp95zr95Jr2ltCc4aIz4w5CYGZw3/s7UR8tZBzg8OVMPR",
-	"jOcjVWTMoqh1JrpZpb0HbJphsTPqGXKlZcIDGjnjBdW0mVd0RCzjNKJeOe40111NDC8pTUdxi/xm6u+s",
-	"IJwplvmV9MB2A77zZgmAuSJKm1kdSKF4aFcKMBRq5n0Boe0J04l01k05Fbb3KbWfCFeEj+BKJKuvbxI6",
-	"kmLgAB1YQzUJTc3qIwZ1sTe/LYU1xvNEBEUERQRFBEUERQS9SxP12hineabpTQgPNxGQrKjGu/9g0rnz",
-	"s2tUnyG7ILsguyC7ILug+myu+qxt1UWT2rPZYzjtVHm1kveioSJ0TmUh1bTeicxrj1xRoKhSMQSdChKp",
-	"1PS8FRyKCMx66wi2lyYilGPxs3s1cbUB2w3NhUxVlq3sE8UG0EpQu7nDX/8Mzm4VA/QysmLiynEecc6p",
-	"yAVF0JnvW8/VYOqF5pqZD/oFdf2Nm4QsnK3r2D2v6isXM4yJhJsp7o6CvZeSsKeYZkEwfW1eiLjSUxcy",
-	"W/exaap1YjO11WC6aU+4za9Q/CLsdJW+b/TZnJ2uJ5om0EGgpLQOnFrCFJzkZ+YuyQ6GTU8dH+yTZ8+e",
-	"vSS2x1vklV0lMuVwRJX2/m5vmHmepMK6mroUZkTSiNopYg2HcvEFoUfNIFQdcZu1fUNH3KUOei3CNXeP",
-	"kGN7i6GRzEKOTdMFGay7k7S8rS6yH7Li/7CaqthP6sQmqJ+s86TFb9MsKmoAIS35iP1jeAasYOAYIaBR",
-	"kEZUe/lv66Fac6t5ykfssxSsOnBJ4+Pp/i1bRvh10nmB+pUHN3i4wcMNHm7wcIOHGzzc4K1vgwfQCi53",
-	"lYFYbLiGEU3OrahSHqCt708htHHFDs/G/BBcczAjsHsmH32iRbp6NlOXlc2XK/A1C4lMbU5uWwNmtjIy",
-	"8wHCVeQtbXlSjm7RIoeajMFsWE9iF2Klx4x4DPK3ZfsuJD33kbnagMscGBS7is0UqNJe1mew1/voq+9i",
-	"fbgi7f7VdFNVnJbZXPN964/j84bQNIrkGBZ+G0QkK4Db+BtiApDobDRCaRqkZH5fSUUwtDF1dHUsQL/t",
-	"5X0ISl4V6AImSG6SQtPv5SnF+n38KvtmhSgXaMOBmIyYjJiMmIyYjJi8NkzOSlB57i1izUk+mXXQb2wG",
-	"ErKLblofEhmmgd6nmkZy0LKl5itynCt+KYBY6xW304FBXRxCBkIGhrxCv3ckiYd4mW0OEOrZAfRs2T+d",
-	"q5Gzkai65D5LOvPPZXUluaLm6jamJ5+d7Tcvnn/+4fnz7sFv3bc/v97eef9HZ//Xlwc/Q5kQrLix2/i/",
-	"PztbP3z5s7P1srv187/fvnv/Yev009ZnujX8z/lIxFv6YuufL1c7z7/+T/Xp6DI3GLDLmIri5QhMpKPG",
-	"7p/2JdOIL9UXJFQffRKq3Wx0irssUS5AgI/OStzpcxbBK7+m2UNsiKQF6q1lmkP1N+pyTsXkqA+TaHmY",
-	"ay6f+DUMIwsbX78gAyIDIgOiogkVTYiHjxkPgaSCYfmkZs889mLFXSw7oiK0i9yICh57Y60kFRBIv8CX",
-	"rTNhhu6cTZxZnRm+v9vxkCqm2lfw9y2bfP3bDEjF8zZc29S+Mn8gnb0HIgxJRqeKcKFYot1h7oiNejOn",
-	"qTaUo/kCIGwq7AjhMDbSLLvfFj5wa6AH1ynYuwTYSF6wfFmJfQK3HtiSsuCsgYwiFkA5bRLKIM3uxYVL",
-	"yi41E7lquwfuQNpesRwQaDjhfRJLpXgvsvMxclMNvNujCLrYzHGh7QuK9CY2H2qgEi4WKB9yvg75A2L2",
-	"G5x2ZleBTUFzGv7K7nxybN+gYdj4UqpA03bU7lW+QWdnbgqfnbX/pFv/dLc+d7Zenp1tffnX2Zmdy+Vf",
-	"KlrXbGTBxOYezVLN9mkSfowNjh9qNmoUFap/mqY0/ZDaPKdNkXB0Dew8r/12yt92F9S2Y+X6r2f8rj9K",
-	"+W/ug8m9eFHE2sfLLiwbb3KxCrbQPfgQp5tEd5f6wtHN3i439huez6v0jxryvl5samFqBnPkxKSv6iqb",
-	"0Vr66Uvl7YZ4HINbcdyK41Yc4zDjeRQqHFDhcLfnUe3AdFJUb9u9D7+r0glKxW12kBJ3wGV29zdcvqJV",
-	"EQarzp0KZ1Uc4vIFzMxsPhqx0MzbaGLPodbmwVgCXmRVZFVkVWRVZFVkVWRVZNW7Z1UbAJnVw+o7m6BI",
-	"q1yb6Sf99XwBQNYFS5SZlu5TiyNaQbQuO0TaEtLapemT7UTzYMQFH6Wjxu52VqqZ1gOWlFSnxXe/IHgi",
-	"eCJ4IngieCJ4IngieH6L4JkK321bVhNnj92XU5pmHZ57tcyaH7Mi9nMl3H/aRGxDbENsQ2xDbENsQ2xD",
-	"bFsDtn1tNhQL0oTriWGir82rxn4k0/BUnjPRTfWwsfvnl+zpvpTnnGWPv5iXzdhYnprhNvNCo9lIk6ix",
-	"2xhqHavddlvGTNiwsgH8XnY4/EUGNCq9t73zQ6vT6rS2d3/88ccfG6Zo16Yrz24fZKJpBDm6J904Vvl/",
-	"v5ea9714molZkUs2L7RFLtl+qrQcmcbnHu65D6r+tQ8RnVd4cYTytYLo2Pkn7yzK5p68Yr10MJMbBFhr",
-	"fP3y9f8FAAD//4jcNsb25gYA",
+	"H4sIAAAAAAAC/+y9C3fbNtYo+lewdOesJvPJiu20mSZ3zZqlOEnraR4eP5qZqXJdmIQkfKEAlgBtq735",
+	"72dhbwAESVAPPxI71VlzvsYiCWwAG/v9+KOXyFkuBRNa9Z790ctpQWdMswL+es6zjIvJvjiXPGGvudIH",
+	"5rkasMucitS8wi7zTKas92xMM8X6PS56z3q/layY9/o9QWes96xn3+73VDJlM2o+45rNYIq/FGzce9b7",
+	"fx5VcDzC19Sj+vQvcZRP/Z7mOjPjvp9STXJaaEXkmOgpIxlXmshS56UmWhKcmHABD7iYqF6/p+e5+ZgW",
+	"BZ33Pn3qL1qlZiJl6ZGmulRMrb7exnfXXnk4XrgDr3imWUHO5oTjq8TNTVQ1+eor5kqVLB2ONStWXWz4",
+	"SbhOdklnOQC5u737eGt7Z2t753h75xn8b7C9vfPfXr83lsWM6t6zXko129J8xnqLFpcUjGouBXFv4sKU",
+	"LriYrLKy52wsC7be0uw3d3htak38VDeEl4vw0dxGtzScL4aIe6XScsaKd0XKiudz+A8Xk4E0/zDApEwl",
+	"Bc/NxvSe9Y6njMAjkvKCJebXQa+/0ppxxHDBi9Z5JAsNwCyH8vl8EZxnczLmLEvXAvP5fGVAG6DVwT1n",
+	"RcFTdk82dxG0X3aTLdZ3QAqreCngCsyY0Hd7u5cB+mV3ug0dAP2KUV0WdxyRFwH5ZXe1DhkA+0NB7zqm",
+	"doP4ZXczhAsAtdzwbu/mIiDvBHWtAwgwv+Yzrt+Nx4rpQWb+3QbzbTk7Y4UR/0F+MUJ/wXRZiMFIjMQL",
+	"NqZlpglXZGd7e9UF4FQh+CmO03u2s73d783oJZ+VM/jL/MmF/dMLOFxoNrEbHy5Cwn9WWoX6yPPmGlZe",
+	"gZ0nuoQQ4u0oxG9o8ZHpPKMJG+b8JzbfF0rTLDtkv5VM6QF+EkMY88SpYjTPzTo4fmsgB0hzqqcVoDBU",
+	"v1ew30pesLT3TBclWxVxhnl+bL5vwPxuWOrproXZ/FsW/Hd2p4E3Cve/zBEOxiBA/1DIMo/dyiNu9A6C",
+	"b5GxLMjEvErO5opccD0l7JImmsyoTqYe6gZy1KcI4aVpys1ENDsoZM4KzVGnaKgiHmnk2f+yRJsflJ6D",
+	"/J8ylr/zv4brKuQsshxNC028fmQU9cNXe+Tx48dPCapPcAX2RZKVip+zziWZ0W9IQWupXcEqJl3nsj8m",
+	"QmqicpbwMWcpoURxMckYoZNJwSZUM3LBs4ycMUufWArHx2gyJaqELSNUpKD9kQsuUnkxGIlf7aNfzfWn",
+	"pGCKFecs9adOzmlWdm7LJHLGXs3rOtRKOQsWbsFoLxwVPi4mBphZmWlu8NO+rroAc8NdHzAt2zC9FOkN",
+	"4JSWnwOj8KSP+O9sOVL1K6wqFZ0sxS1DyJjQvGB67ghbhaE5K7jsQEJAnK6NCUBeldi9rz6Jrv+Yz9h/",
+	"peggzIDj5gKYBRgg3GLgfH+XghGqSMrG3KycC3i2P3w7JGZcYgYmL6imZ1Qx8mCqdf7s0aOLi4sBp4IO",
+	"ZDF5ZAbaMgOph4ORaO+7GfDkeA8mhPncfpeKpYv3yS8tyox7J8d7URR5KzUf8wQsQntTKgTL7rZ8uSrA",
+	"X1bW7IaytYiX53del18N3Luz4yGMrQUclhm7P9vdCe3d2e0ARAAf5WInEOMVkCkDdfZlUcjCeT3MvyNc",
+	"1fxMEpmywUgcWpkXhU5gNPC4YCqXQrFV14dzrbq6pSvwEvVaaz2tLbS57nc5isRkWs6o2CoYTelZxohm",
+	"l5rkhTznqRF/KtmZcIFyAJeiPxKGRRhdgirFlYa9SjLOhCYpO2eZkbMNzypFygqlqYDRqh3VU6qJTJKy",
+	"KFi61rbWlhVucZvbrLddZcEXbFNZcMJTI3eM57AxzY27YGckN+KLwZ2RCHaL0DNZ6mrxfeI2D/eZBbs3",
+	"EtX2ARLGD6A55FobaBZ69Y07KpOEKWW3LoEpm7tW+xIuF7mY8mQaognIGhk1Ch+7TKZUTBhIbVQQCjMQ",
+	"LT8yEb2VCmFY+14CtDe1dKWpjqzdQ8tRmhuBX4qNesQ7ockFVSQ3Wo/QTrCzu0JrO1dY7X4kDK1FJRjF",
+	"xoIljBuVyeiIwQDPjBJwIvhvJeuTgopUzrI5mTDBCqqNzCdzCs+MPCyk2JqUTClAYNwEvJlcEQXYeDFl",
+	"giijzwLSCwDQ3IKkBiEMd04zbjSElMBXeSHNbrl7v+5Z4fYuPqwDOuHCzIhSt7l+cTYFF1OAOWrV+WGw",
+	"uLUsal6KwBLXfww8omEZs0hgPloHvpa2UrfodUNpRIv4bl3FdnHt7Vxia2wAHd/WprHRUFDYz6tbTFfY",
+	"4vWMpgdTqpi62+LgAhi/rBBYAwxBzai445vZBeEX3soKLASzkGN+1/WURUDeCVdPHUCAGQZ2DvbXXOkB",
+	"N4QzZS9YxjRLI9YxfE5SfIEk9mO1KvCNCaKky35uKdSZlBmjogNgHDZuIK2gM3ts3hyMxB5VbIsLxYTi",
+	"mp8zCGXjNKvM96ssA/6zmPu3Yc0LPqPF/OWM8mw1mO0XhJlPbgz4GhzrLmKJUboOv7WYal3wsxIkMvv5",
+	"ja0lZtRuLuOTewiW7mGaFkypiFpgH/R7ec0Rk3A9j5rIE1kKXcyXRgvha0ZON19lXLCd6HjmyW70ST6V",
+	"gqEIEX8ulabZntV2Wo+9LtA+4JZTaSiE1CDNqAXeqU/9pmDGtBFuPrL5FqoAOeWFIjMq6ISlLjZNzZVm",
+	"swHZo2YWcsbITKZoGQdscfKvtfr/AUGdhaDZftp71tveebrz7W6SbNHtnSdbf3v6hG59v7PzeGuHPv12",
+	"d8ySdPdJGnWUDfMc1iLm78a9Z78sIeu64Dkzn3zqL3mTivRMXsKrH5obMszzwUi8E4zI8TPQXsBvmXLz",
+	"0swIjGjvmdE8N4fx7I+ewvFWmK7fswOusAaHzfO3gQP1E+7Kc6pi+vGZ0oVR5sB2P5Mpy0D3tY5ZlhKa",
+	"5wok10PmFEWjfOV58I6WcOSymFBhNUbQFLkCt5rRo3UJdgOlqUhYHxVorhWRF0YtF2M+KQtrUBApSQoG",
+	"Fg6aAbdpXNKCGe1mGCFMx3zGlKaz3CAo6H5W4ZNlkTDQdu3XNeTr7W7vfruOy6lgNH0nsrlzSbvwzD0X",
+	"Y3ocdU0ZxAFmeEXYc1bMqDn+bO7Y8u2sA3j24nWsYtELfnYuJbeeAXmDCgvZ2d79liRTatDQShczevma",
+	"iYmeGm1m99sQrtDi1oKKR8SYISnBCOFsZtz69WvA1DZxe+eHJ9/992/ffTd89X74048vd3bf/md7719P",
+	"X/1oUJFqQ6Z6z3r/3y/bW3/78Mv21tPh1o///OnN24Ot45+3/ku3pv/7cSbyLX2+9fuHP3a/+/SXBRu9",
+	"/yK2DhtMD4Qsy1YgZEF0xmv7bZtMGTF0Vr3oQvbRzqLhsoa33lxdQxVSglJ1fQmf+r0Z0zSlmq4Bpvsi",
+	"QkMr66IbN3pMbuOqoZx80Dz4H+tWUfBrtkYkz5m+YEyQHaA7u9896UbF3e+egF7tUTPAS67yjKLgGTtQ",
+	"G6C98kYN89zFfrd2Ch+EgTSJFKLSflrnVObpNehlRpUmdojbITavzQwnMEMHvfkUBgH9Yq5534nlFTMI",
+	"F1pdIb/3H+LCwh7N6RnPrNzX4usk8c+BCfrXOVNEimxO2CVXYDtFLkYU8MI5SaX4RttsEdjVQ7erwGUb",
+	"wk/ziA1PJzmdzwxakERmGUsMtyy1d2EU7JyJEq38xH7hJPJvwF0PhiY7iLlVUwkn+JHN7d7m7NQOfWpf",
+	"q6TtPXxADiwQ1anYT/yDT00GvZA5GCpUbWrIIgaxmwPANsf4ic3rV/PJt82bGdJpuvX79tbTD//z4B/P",
+	"Tv0fD//6l9h8cVrSABr0y9jXLvht5VteoR+61qJEO5jZTDBoXQgbKPeRzauLEQ6zFPePo0F7dfy3c/d7",
+	"TJQzM2vBclnoE4X2VPwLPNAGVxKaJWVGNTumlxC/AcGnTr2ENxpo9CGyn8M8N/wsxtXBkC7HhliVmY6I",
+	"iT7eqb2hUVP3Svk5Vs6e0ct9fB2trfUIqn5vZft/0zTb713LXL+GEbjf0xIUyVLojnhN87w5YwzoBjZa",
+	"A3tgsw5mcvvcgZKHbMwKJpIObCzcY6TFwoUIEaoIJWoqC129A05hq6ogsxyXWQZ/45xGwjG6qWAsRebW",
+	"wKCIOHnyev8FeXAi+DkrFM2yOUEfF3nNLnkiJwXNpzyBB0ey0CB67HvJ8+HtS5pLWWfHzh95EaW97ZVc",
+	"iMy0TgVoashOKZzHkKVddzlOZo7rccHh4F6Xdvpyx8AZZ+kLrhKHzCvT3/DDA1YkTGiDvRH5lKT2NSIF",
+	"yTMqBsRp/Ln/kMiC0Jl5K7gntW3umLC1KdWz9sQtRKUwrjqW8YtcGMkqoUWqnKwfDGq/JVoORuK9EQEj",
+	"sXmRtwnNsmDkGgVtbt1HNsf4WquKNRy8LgjBRTVgIK4X+W+Fzzvhc2gXdCx7ETK+4ICAmAcHP65tVJMY",
+	"N3IC7OQBAvjJkd6GwsTiSPpwRndtArg/VLMdo5SwmEBYUaIxwsqIjGK84Y0blN6gdAOlm3LCWjhWx6xr",
+	"EvhgsFsi9c9pajNiDgp5lrHZoY06WR36E8Euc5ZoljaHiKsJkLpQkAQN7rLAwCbzbxsAY5V7jJNJSxCQ",
+	"lDSKYYi6sESI6NHSyFfURQRhvNwDNpgM+mRGM6Pks9QPqOZC08s+4QLCb/zvM6bANTQu6IyLSd9AlrKE",
+	"5eAJcm8VsjT6+sOOzcyoSNiPXGlZzDHYPY6+Z/gmmeKrLtGjRV7se0MNUSbxsViVK+vHtaQG4pDcBcFA",
+	"/5pkB9ejMoLI8iyLWkCaJB+HWuo0x7c+9XvgdFskvaNXzgI6xjRVrzTcFNzte23Ac9D1m5sdu+wuAxys",
+	"Oa+5YIeg1sWC2vAOgCkPSzpADGTO0CqSTGmB6kftvDMuGlrh6hmTBpyQvoJKjmYnYsZFxShWfSHcFYRg",
+	"pbUrSznaq2+/49I23D2qbcuMipJmAZCDG98YhAgpaX2LYFYt7VbdxPakXL+Vmr0r+IQLmlkoDg24q9JU",
+	"O9gPTLCCJy9kUprrbYYwNLWh/mHhlcgx/HL4au/x48dPP0Cyi3r26JGWMlMDzvQY8l2mepY9KsaJeemh",
+	"jVYz6FJFs1l5gQtycrzXsqteqeTJvoF3CAowWgt9Cg+wcbtWMOri0qImLOFdz2vtqD0M67j+FIidD45Y",
+	"wWn2kFRxcYiwVk1PPWiDUOp1smwC534qZMpOpT35U2tOiqqDZQERF36rMMjYG5u5+Oj8ldYeW02/onBs",
+	"ZliEqY0yFpFrbN9wMmlCLmTxcZzJCyLtR5GrelYL7ungf/iO4fjmJXTruDFBYFVKJhxjY7meYgjl2EkJ",
+	"5zz18rG1HzdH5IokU6mYIHxM6DnlGT3L2Ge3a/Q3buA74Aa+/66lfs9dvTWL1Ly3n/lb3iQWXZ4pP98a",
+	"JORdV2jhOxdWKOEXhfy/Fqln6SiPW+WWrerZH83oCzTbW9/OWjzCDb7nhzhiGqvGhQwD5Cv/ClH2Heu8",
+	"5coTyw0VuBtU4GsJu0CpYq3AiwZm77sROhHbz7EEr/17LqBtVYPHghlpnqNhKjqj8wBfde3Wkde5cueI",
+	"Xrxu+9a1V+1mW7xmTS+vPZOml0tm+eoCMLpYGwRm2D1toHDtZFfgfE1GhHrmnWdHd4mE3IUL/an7pEPl",
+	"e10QFxoDQjiDSUKzPF5CMG423cUQz2M21yvMD6y22WGbbK3m+LoarBuyZC+iOI9m59U37W05YwVPahvz",
+	"o7wgszKZgvNbWVNvTrmP3za3GhRyyIwWyXz1+fbsFxgGH0y6PyYpH8N+6ypfNKfwt9vvbzDskLh5AYi0",
+	"ZPfHEPPe0XF3Q7giaRmPGBJS2xpQ9uN3esoKkjJNeQbnoulHc+cNdibolXByVFq6Y4oMbD0Vq59aw/3d",
+	"duj4qjBgWQZ3gZrKMks7UKfBNPAI+w57w0uKiE4SKTTlAiPG4a1Fs0z4ORPN9bfu5auM6lcMbbgt9Gm/",
+	"QwoX5a4IrQynVS6yzHy4u1OzMPhknFFNxgyzPCH03QaZhCMKHI2mKUvJOadElWceoFioO1iz17bPgmEW",
+	"DeGBURZ/UdbhaZfBFaxyEHEV3mfV6gaJFvB/+xCvgN2zTTz/bcfzOz/slS6Ajwf6VIvTxgFXvgRfQwyY",
+	"D7+8qlW/isqLy6LWzgy07Yxl0giDWg6Cme8P8z6unCYWLXBdFROyS4q7T/haAQqHVLM9WqSWA9VFVysC",
+	"YIGVC8uAzhgI/jJLYXs3ORgr52BUvvW1roBzttdFIi7TqiWGQ5EgkmgMtZowQL9giZwI2FmSF2UuFVOD",
+	"elbIiiQt6AdAL51mvEZayTG93IMsBViOKDPw3TSZxTG9rNxQ1kWFIpeml41kPa/yNehnJYdperm+AHOM",
+	"8dUh6X5DgZHCcC4yxdJwgzWg2dnABk+UjKCqYlQdnlxNgepisccgFatyFuJFn2ASPOiTFe8RqY1TUFGX",
+	"pxElT8esw735tRmTliTygE3JN7jwcp07w34VblKxmr7z1AI1/rCSdhAEMmz0hPX0hM8ma29k1LiMupHu",
+	"NtLdRrq7Y9LdPRLRVpc/Onh3xZVvlBu/K1CQ2HDkDUfeWI02VqONXLGRKzZyxZ9HrgDd/4aEi0jIf5tl",
+	"zTiQCqjRqJ6NBE74jJh9sf08uAgqSEPwQBGEsJMpTSGKYDxGCcKWYD6bQ6YVbGPBJnzG0AyEREUNRgIM",
+	"N+oZOWI0g+ouNM8LeU4zdJRLcAtjhS2FNdtQtJkZ5GU+WyvjSrN0MBLsUj8jIw2tbZUPDQ2KeCfSnLEf",
+	"44x5aNvSTIPR+0zDarS0RnfChIMowSsYVfWx4NITf+lrQoPZ8jkiWxWuwRWZsgLy8MIYBtcx5Jq1OTrC",
+	"Oj418ml9kqQ7/yqtoaNMxzrBKbFoFHOIVd5AbvPQuP5Ggf/cLGKRP3y/4ulfT1W1G5R33QO8LVnWMibD",
+	"dKg+rM8VaKHnteleswnNMNNwbkupuzLlEylTZY5bseKcJ5b6bxzOd1J1sNdqsfaAGCUvqEiayhwjZmxz",
+	"IA7hYmpFWtCxPhE6VlPWS6CleV7zg0BlNwIfuwIeRtV9535rdcjmIDT6Ej5BbX+fp+SC/lwCkU019EwL",
+	"SDWSPptP5GFHMKGwv75h6XultUcP/j7Fl70o7XKlL2sz5lmG7GEcLn/wVYfrd+ZnHoeJjw4TgrxHLMTv",
+	"UoalcDndQV29moqaUEFmzPwf14APUuaNhLiFuNUnE2okNC4mz0h8etvRDEHwlRU7b9WWfbNruFoW540q",
+	"sF2TRIsY31RS9WuuUJCxU8PYlQXOnBN00XPHA9WvYja9GN28O/ruTSXXRjtOuAonmPk7rQvUH9ncS5hB",
+	"zLNBbzu8tX9WRcYENGzRiuQyt4yAjjUrajhiFJ4zo4cHd+sgY1QxIqRmVXkWOypX5EHavHtlrnTB6Mxf",
+	"gIeEcdB4LFmyGzwSF1OZ1SsNG7Zaf8vjAtSa4PbakgdYTeqhj6NVTJe5ak1hH4dn2JHD7Axk1wi2t3tv",
+	"Y+3r0dJBlyVQgZjok6m8wJY5WpKLqeXK7izqgbKDm7VfHPuSEbU5E3luhC6yP26ghSJCBqUH+qijQCUe",
+	"hqneuRF4U5sssQ4NqeXtVxD+xOa11lQFm9AixeRlds5lqRx4qHznUmORaZCGrf6qcGfnWMXzwmiYiSwK",
+	"qMMSoy3rlnatn3tQ5TXc5ygvCmKGrJXverO6QZqTu62ws6NyVUmJygchqRJE2JvQg2wiFVAqqw3B6PPF",
+	"2hAqZVfdhmP8OoTjqJxBFwY5BuWvHU0URvRgLNKDSk5+WAvnWQMQMC3caGyPIcOvDGWEv5WlsnZ4NHDV",
+	"bQ6aJRosfBm3jYWvrhWuk35te3VxKaB+xdryxM/170N6UD1C5gTyhCx01aTACzpWAItd8HPJ0zXFTPzE",
+	"qUbxp33kvXgSTjhUTDt5ZtHAtyvxVZMszJW/yo1zqWW1nLL2pnp5uFGtokYNYXdBUaXZBZ1DAVBBczWV",
+	"XgtqydWufpPTnpqa78AI2yPhr4d0hggjCIeJKOwyz3jCdTZ3lXcciOwyN7xFVo7hcMMjELWWyFUlWMQq",
+	"X3dFyllDuKfKgaGqHTinwqi6OlOpiSC4Pw1PuNOtRdjpY7nRcejzNJ1HgKbnVCQGajQcYOHijGm0LWlo",
+	"/2LwcVGenB3dBvCJvNRt6+ZQvRsvuMBUIVl1dv3AeuAsm52FUhx/dFYNZ4C+sYbmfdeK6QCF5tdO7YpV",
+	"70OxuhK7oAih7eRUD4/tE15fDmizhuuFXxvpfUrP/VenVJNRub39OCFUvRtXai3OkboxsPAYarnBeM3X",
+	"SZlj79Z34z4R7AK/2+r8TmnoMRPoW3ok7G13lWqSeZKx7tqN988P3yqcteSehZVwbz5zdGgz8yRYMOeh",
+	"/GMwyuYduq6iKBKd0XUKH8ZmfW4UyoAMad+3vqr/DGmjBjUcDA4ycH9xoTSjaUOo/ka5mG2wOAxuKXXS",
+	"75bl7gAqKKcBFIO4Z+yYXeqaJbymo1TFKg3vtkblpUHXkSRMN0yd1nuDdae92numuEC9vpbcy0XKz3nq",
+	"ytCt4pt6CRw01pAueNwwduS00G3bnXTc2FK+DIxMpc7LWrncv/acLSvUSQNpp/rngOZ5pFR9v3e5ZUbb",
+	"OqeFoDNz2X4xuLP6wEMYN7IX2uxo2lWdO/qa9yDi3jD7MNAqKyZeBb0F2oDrBj2ThVMHIbsi1vU5rqqS",
+	"E8XGJfSSGgldyPKMZWoqpUZbeF3qttJ5eCTemtqzXo8e2nvxFzQ1uUenlkX7v9EXcep8EadY390/dhpH",
+	"NfiprVnq/1ZzkYTPzd+nY9gG/9sF5WaMU1pq6efyT6Es+qmWpwBrBX0wdPiLG3y5mOMymVfrcBbJgl7W",
+	"6sx+8gY20X/0YXE/Mx/asToc/Z49p+WfNWDp6HNW0bITwfVBYTfrSoGh3jwf+NoflILrhyQvnC1mYTXM",
+	"axxRrabm+ocVfn7jxxYMftUDrJcMvdtHGUYgX+84/UhXP9JqiFs6Vj/B9Y42WOqdPN6qu2aUmb71jgq6",
+	"wCvqtSjf0t4alUaiVnHLe1VwKMGU4c9GTlIIdYb2ijFNtCzQpUjz3BkIYC0GhJwV2LrEezvyoAXrQ/OZ",
+	"907C9wkTtOBSkQfh78rBGzBiVRlXFJ0xI7qP+eXDmqKz//bnrcoMuLW9szzCcjEf6yxpWH/ekPOkbbZc",
+	"q3dY+QwhViqUI7xX0EUUOp9xmFMYtacs58QHlcunrmVpVqxsvrSDHMMnn4KbYR9URVHqHoqpvFjo+lkq",
+	"Zdc67XwNfW8CK9v+i1XiIG680nG9QVPdcxPvw2M/PGzUoGpD3XWKS/SCqD4QVQPWlb2XX4+jpqeqYYpw",
+	"pYPRKnjVOAJrU2zUHqdJECGbYJ+onBW2Y4EUHbjhbf6spXZdBUUayluIKi8bOlmoWzU4DDAwqx4EVoF9",
+	"VbdUGlaCb8GY7B+9dlv1fo/PZqXGyO/OoVjK4ZXYCE009sN5EFub128f9YeleH3sHXsNrLEG42vZkjBV",
+	"31aYohmoalhayuwizoCBnpiJda3JjtC6RLOsspRk7JxlrgRAGHd4W1NVcY0Y63ZDteOwrXM2bxeRE/Ji",
+	"YMMiHLbd0HkFk2AwCvVuYnDHgvOl1BmdozGvkKVI1yrIGAPh0I4SQFGz5wXXMKGKBXXSINAAd8F+rGxv",
+	"0N9KrplrgQ/u9NmNnX+QgVTOXMWQGzwFrMTRtQ0uT8X6LdLrTbw/RkleeUcG9JnR1mgVlKSjl5VjwTU5",
+	"8TrANWp+dG2w2Vsy46JUNUus6pM8s7/ZS44dz8FmRi8rcN5zPT2+7sH8UGA8EBwPXokss7cBXDcQnmXN",
+	"t21RxKBdVU2jBlZ1f5t4oCq5FEQKCJuAnri4PTXLe4uhLSf/jcwhaHpLC+v9xGqamq0ghLQczm2Okufr",
+	"M3jbg2GY5+pd0Z3nCPoWyCDOf+UsrLJIpkxpaDZW90ZUoQiGJEB0R33S/RdtcS/+nrsdzRYOMkxh8kbY",
+	"Cxr0+3ZKa9D1wTnXNUpQTdd53+Iejsy92EUzzQq4j947kM29z86PrxXLxp9XS7jCtsTbrs3Y71LUJKpj",
+	"+1vb2QSxMJhfdrMRFtHQimjogVMkARfP5rWIgwh5iKNgzYnht2CBYBdktt+oW7J+EV7xS5YGvf3W9VU2",
+	"3ZwgBcq0driH4KGD/Llbqbza2TWRj8kY1meXJaQOHX51r+ON+RIHV3AmVofddCdaoRvKKFihAQtlGR7m",
+	"qKRzNZ6xsSwYsrJFXKOWuL/Brj8DdnW5qxH2lKVlUktcuhkkq+wBTjLxfkPMpuv1eyrPeAtcp+fXrZl1",
+	"32kjj7ol0tS9YF0lUWpvXb0oCtr/s7m9qmPGNtWJN9WJN8mimzozmzoz97fOzKbwyz0u/AKmrOuZisDV",
+	"HuZQNisD/VZSyL653jT/sqMsmmlT/HhT/DhWJCgIPNmUP75m+WOkGMGtXmCf6QrR+tPrGZtaipvqxhvp",
+	"cCMdbqTDzygd3t8ihwvll2uVT74mN19aTHnD0TccfWO12litNnLJRi7ZyCUbuWSt8svrCCdY/icS25sW",
+	"TKk1xIIhfgE0Ao1mqnZbDtmkzGhBcqkg5gCHh827gNrBYdh1RYwUZDOPCeaNfj0czFdTdBiem4OI50ZY",
+	"SlevUwukDS69lQ1pKLaERdnikVL0cn992nRsvsKaUC1WiT9/o0gG8O2/gLiJoBU/vSR5WSA1IsdTNoda",
+	"1xAViRW1MV9D9clZqckF+6ZgWPeOC80KLOsChlWpoN4Aj4zbSNspoJJvIDznrFBYpu6sVBwSwBDuRdEG",
+	"ME5X0/t7dFM2iPTFEcknmHU2lMeIwEgkj/nZ14EzoAvf0xyS3BbX0l2rpJ+F7RNIPm0EXd5TvUK5Zkv1",
+	"F20VK5ECxUDEcTvowrrxjpGmJTsFPTpWCt5sSt1BszzAyXJQ3LYPrQzA4ORIysZQFxWEApgrgL6RBLus",
+	"M3ow/L5QmsZC524WMW75YLhdxY2eS/w87IYtPw8o6Z6HlW1XPBK1dsZ55DxXTDWPkIhP8XWrxSsOc60P",
+	"vCZSRykWK+1yN9XWl8LrPyj6RtFQaVrcG038SNuGEQsX1QwBhxX24ejaGmKNRQHcBRWTxXiOYeTtTbMP",
+	"6mM24vRbxsRbzuDIeGLzWGoB802o7nlIYsrGtMx0Ky3UppDYx2618eTSTbjhbRpuv5ay/Rtr3srWvBsu",
+	"sAxrgfgbKTRNdDTr3M0ZpXIBYV4SjPP+KiWKfT3cWal0ox5u8Km1Ja9QtfjxlasWhzM1bvetpG21Dsvt",
+	"fLtirLf9edYTqxK7JK4oqBIbJHIBK62YwYelLHyY5555qk5+brhsVeOiUcXRNyNQ5AFP+8TM+NCdOmRQ",
+	"Or67XBTwlXdWP4dwBR2uGFvJJ7AGmN3323aV6v8LZ3X6w+I510roXjifppcL52rqRZAZXG11tfyV8GUx",
+	"mjSxIyqA3RYifNbz/0zH/qVPO5Su11ZpA6RZVZeN0aVPH1qgoWnVjOwrRkdxsvFeEz05/Gh2EfOgDaY0",
+	"kfMb8Iyrm8DRBtMY5vl++q5odya8TdRdA4ZbwOg1Zv+MiN6oPb4Ak66MRZ1q7+qXoonzN6b23UV1aaNm",
+	"fCY1wzqpbl3ZuFMitt3KuBTtLpWVp1clH90Belcyi22u9uZqbywIGwvCNcjbcoPB6paCrqr+tce+Ns3F",
+	"lHrSZMvlVOX8g1qVVrD+66ol+fF1mmW9tkrQWZG2/nyVirQWchVWou0wxFTMAjZ9QUmrY3r5nE3pOcd6",
+	"z5XbM8lKxaF3Drt0/148jos7QsV6z5YgCUjO490mxQltw8Ot/9Kt37e3nn74nwe/jEaD0WhrNHpETj/8",
+	"I3z08K9/6a0ARSwUzBVFuVp8R21d4a14ay5txn9nqQ2pS6Fw7oVwJUFlwSfcsAJuQQu62IfBGQ5yorQs",
+	"mGOoiLq+57+Wziw/h1bu+EUz6gMrd3qvPYRSFwsjOlx+aGvXzgLsWHfnPGbVKu8pH34IwZAe1YgsiMc1",
+	"R92gpwkWYMHqmRjyeMUoyTAq0vajKOpBkLfRq6Xm386r4jiGjfjEBlkA3yhmXIQlZgqq2Uh8ZK1CQFDl",
+	"zVcBIkMieOarA/GZjafFPqlGOgPUnJ3JkeCK/PWv7JLNcv3Xv9qZbP1AVRY3Up5UzphFOs488kIpnUow",
+	"8nMtXtnC3kTNPn0tKtt4gSQ012UBFT3n5DzSyg+haFSehDZd+AYUNVfsnBXm3o16ScE1T2g26mENoBxi",
+	"l3Utaxq2GGN+q8bHcdpU5WYnU4iOFpb4gNQHtMUXPjRDQb8tXwo3Gkrgzywcf8/9aLsXuo6YMGh0GOCX",
+	"taCdqWWiVTde+Bq7tLt9rANo6NI/j969JTnVUxue0BGdrxSd1LZkiM2HKxk4oiF0g39N8T4mqDssWJsy",
+	"NpDyyI3Tatjq0Ky+ulYkhfs+POtqCz+sfH2OggUtvEbuxWYN8ABe2rpdt3KLKkEIBzCCJC2EOfQFwsrP",
+	"kqet9oHRWufmTXwlWCuUyZdkSkWaYaVN7G4Z9JZr33DqJ1oPVypQX3PhK5M3CicvgabvFPNnrplfwOXo",
+	"OtS+g9H54s0WU7FubL1h4JkD7B/kARtMBmRne/v/QAd8hdVdXcZd4V582EL1AOS+29FF+F1tXocZ9RD7",
+	"bBr4zJxB8fpbOMDg8NpdFnF44Dz0I3OyYxSx2kXpF3yGCTMyzC9pVesLMnGqXBHHZ3CGsFWl01Vsr8pf",
+	"8Y1fW0XwtGx0fhyEDRTXR36XJIN9Fhr5Lo143aqOYHur8Rks0GyU531BLGWww4vfXl5pMLEWJwtReBar",
+	"oW5w78OIYa4SLF7srrT/16lgl/oUO1YGlzQ65FKyxkP0a9SDWVRYsOvs2rwl/mInYIFe0wUXBoPZ0xrc",
+	"7k1efhk9lGZ3zB/7970VSrXv+y+g8LQ73GWXwa5+Fdr9PjBdNWx4zvQUtVwHdqSmiJ1l7Gon72bc80N0",
+	"FkSuZolYxkIH5f2O6/w6YjK/lujH6zv9990InYhduf4X4/V1Xf82MaATDuf+XwzFV1fRa0EprxWIaBjR",
+	"0Mb46qGrr+86CvgwOrDd5DlJSzBLu/r8kI1WdXu1XzMOyWtUkGGeY7YM3h9gctgiiub5IumhTXGHGZ8I",
+	"h1n1BUReCuzp/ogjfcyrpENLtyGhTsuRiHexUuVZNXGAmBUEhHo411ndG6anMl20NHwjWFd3s7ZqLQ9o",
+	"qeWMap6Qc2VtjQ9DtRl0rlP/lpEvev2eYiI9dQJufJkzBHidNS5olxGe7TU5c4UnqGdZf3X96PpRt6B0",
+	"O9eFLgY1av3NgPZqVpxj7cNqtoPjnR97MTXPvY6BORZqq1KsMmNIjA52XoR0Z//o3fdPoIdim5T4jEcn",
+	"O4VySh2llu6CgbymJy+jPm3m0inTWfm6HctkcTwk+ivIfAaxh1V3L38+SIxbOABky2x4eB+sVTMEA5uS",
+	"gH+moGNtc5amRrahStXSAMO4h+rdBrLAObZxBVOpmp1urC3lI8u1UXtgVFf03byKt5wU7JyzC3U1jMHE",
+	"UbPKBqR/Wwhp2Kyl1sDKp9XeDPI20WEFHGyKFZ0Y2HixiYlR8WMt7aMi9dekdHagOpmLUvToJjZXssIm",
+	"dlPwO6ZcbQTiVlRq62z3piz5KEt9xJTiUuxBvbVjdqnh3h+VZzOuD2hBZ5HLcqQLnjPSGGKANdtONbvU",
+	"bVJcjdpGn9Dd077+TcjVlENXald/4rrD3QhQkLf8bnzEinMwECUs1zTaCXedcVc4uJP9NzJmV+s4o5Kf",
+	"ziSYapwQyGZnLE2hzchUKt3Rh3Uv40zoYZ5Dtu8hU7kUisUs6vikcmEn8CWoDw/e5czQLWixnXxkIoWk",
+	"HMgFhnffDUs93SXYq6yJQmWRxQ26J4evo8PQUk9lYYt+oPd0UlCh/fiLdS4zX0y52rOBXQeFPMvYLNyL",
+	"1W74iWCXOUjozSHivoHCeikSkPCF1CjlG04Kyd0l9vj1EWdV620stITygY+p0IZF6HogYnuNEDKyF0Wt",
+	"X/aP3pHHO0+ebO1UmegXFxcDriSkoXMlt+C5jTzZMnuvBlM9yx4SmuVTurXrolKwK9HIEiCiL+RWxrSG",
+	"wIzqBfQL0UxJCAWUhbbx94kU50xwJprS8clRI+CxFny02wo++vDHbrwmHwbS4nVq3CbrPorobfANsXcw",
+	"sV8RhZ+5Ax3E4u9j1mHreLEhK9bv4oJt7STmfnGbzsSNjj3/AvULXdXO1bNy9uwX++nSbBz3aqzlFO6M",
+	"uQOubiiapksFtgt2iW3cSUWAfBf3kcDguuYAeBlAIcLTpESwi+o78Kvlvs/0ilU/lyLTOztke5H2iVUy",
+	"DGD26MHE4bM8sHxKHeNsdwSYtdrwLp4R7OHAe/0c8oVbCItRdmOaH8tiJEplYwPa+/6NamJwOO1yg5hD",
+	"huoQorR65f1e9w67WVuSvuH62cnh6wiD7/eQGfo0Muy7ubCX0+o1ZN31M0Lc0i9Xl/6a0TM+hOugtu6O",
+	"UjrBWVhJFfWW43neKDXWNUDg09VlIbp2VpVJwpTqelxyJyatsS1WtoqLYYswS9kkiUUY5T4iR54roBQw",
+	"WIxTjTHhkRGBBosIcuy2H0fvpb19n5lxzNYKzo3u+hsXmVtfpfl5JIbZBZ0r8qtiusx/BcnBtROvoVVT",
+	"mDWPOjfXkoKuvW2RjChdM8PoMt8Xmgm98lDwDVgThe4cdym9N0OvRHyb16vBNvBZ5z5FBXcntDs7dptl",
+	"rcoC9rGdSWOx4fE09xhBsli3gG0ENmPLLZ7LdN55sUMbsxfaz2Q6j8cgnLNXhZzd+SpPN8uc4oh4/yp1",
+	"42qsbhmRHp5TnUyN0GRuBvjM5GxGRYr2Gfe1k9dUqc7cxwPskv2Rze3RGrH+10f5lCqmHv0B//2JzT89",
+	"As756A/zH/P3r+CIG6YpMYhmqxtwoVihrYQ2M6p+4TtP47VzrjzMF3Yd5aHDtoPOS884gIKJDtlMnrNw",
+	"rgJ/MV/YmbwNoMp4CCLAVlMQwkv4MuV6mKa2k9V63yG8+OmHesnS7e22sJFnVLRtNx/ZPBYyYM6KGznY",
+	"xg7Y6+f6Gjh3apW5UVO+AyX1ybeLUmR8fsw/np3+siQjxlwka461zwyzmBjtqUFGzZqq9z/EbFCdVBd2",
+	"qVbPOSBsrUsSpbQhlYgwqIIxZw/4Zf/o3be7O3/rtjmYp1sOmJrRwTdUaFgbwvFr71zF4PCifpiPa2f5",
+	"OGJxeNxhcQi06CaqNdTTGgh/hFFFi2IV2KWBA52WbSnBHNvpZe3/uWiZxbQVU1d7w703L8m+SAa1WIWF",
+	"AJWKTthQ64Kflc6LoEpY4U9sDml2s/mp/eXUYOyHT5+aPNU6YQKz8IoFTVwd46jxzbl2bAFjX1O0Mh+c",
+	"hAV9qUgr10AYS2rN+iSomvwnbzfckKFqLU/iG2zPor94p91Im/KBt500H9KRVZEAT/Wl/fINBVdOBB/c",
+	"G2SGr1QR6ZUFLiir6t62A6pNdcM/Z6+Sgs9oMX85syWmI7EK+AZh5pVOqt6rdQqBD3DMWM1oPmO/y1j7",
+	"/GP7ZNHw7p3eV9mYNM7a16MVJ80RIkYevPXgBrMvGiVEs4KlBCBo9hULTgDGJ7UJrlD8sLXOuLQbJ3+t",
+	"412N+tXlnyvbe0Yi3D9vn2xImiOwgbgs9FL5oahy8WCJLcoBidWDWono2pDxMJ+uzYqtZIlxvmHNatRI",
+	"+woMEG0EXYRur3nMSTkkuUF8OTZko8x0JGvR6+qRSEYboGjDorA490rZXZUfr6GFx9RwGykRoeMGdmyQ",
+	"EZgKvZKLnx7x3zs+xy+hhn5sITMUlhxYMy7sn7GZIN0RPObxuTAdsjFjDOhmuiMmOvqF1GZym73o3Dur",
+	"j8ADcjavFRhxl0aFIc9x0vdhgdbqMrgO6IQL8353sIh/xfs+royBLtJhLUy0OlkT8pjzqRsRF4LhicLO",
+	"+ii64sDBtVkDJ1cb/LvY4M0ahyFOtlF2OZaeRCSE67L3wUi8EwGXS6jAxjqzMtM8z8BYbwBR/ZE4KzUx",
+	"Upr9CV6GPjvYIxFS3MRCzhuaKmK77SZDkyBYltw6Wh1Pa9jb1gXCTkvRrjZHATBNPG6WDghejZ3QSwGD",
+	"+vjFlQy2wUdv8IiW2mqDT4401TxZ54vnLsS6rUJWLxHNZnmG0QpFleCClVnQyF29rLCCQZ5RMRiJV4za",
+	"miEFI3LGwdXiLdssMkffiER6yubwCc6RursG5U0SWoBInnID78wQQSyxM6sEQhc6vvoOgKYIG7760UCv",
+	"EbPjaxyNw/75WzT4Ad58quPLc6rYsd2PiMdwSs3VtUW4rHYU28qITHL/rWYaKN7Bmm01g36aEQexpeBI",
+	"DF0Tlq/IADbGW9il1djH1pmGZJwrh1JOY2mK6cPD/z5+++LlT8dHP397ePjq1b+ePP3hu1fDn2/QT2gB",
+	"+ynmOLoq4PZfW/bbLfTg3IobKaYrHTKaAnu0ljTQnSpz2u1vcguJvpjBzJ6ALZ7lmGmHxFUZHD8yv3mW",
+	"+duPa1vnBIKtnds6XdftbLU9Cqi7r40dUXZce7Q6Ra+ZvODrr8i8tS4pP2SGXtd7JLd30gkOIU2P7Ow6",
+	"ucK+tW6ArDUaFRLaJRKhkzqugj816WA1wQ1lMisUNTFrIyFsJISNhLCREDYSwi1JCM4c6JTSD1+zt+pu",
+	"sXPLsRdy9Ztj50FHke6cCIgVRKNxhCG3+PHNUOaReImFRar1Een/2k+x8Cju2/0l41df5Wek+V+Eeq5F",
+	"im7gGof9d+I3unaTqVIy4eDM8OmXNSm1sxX0gkvZvI1XtcDWxlnbGnvVr2MkJRL41aIpdVpyozbSGixX",
+	"sJc2vl/TdtrYyFXsqD8UtMuFA7nMkdSCWbfXB58ZWoMfkyNfNYiSXCqu+XnoVa17mSpuK8sz6A7j/aKV",
+	"mwg/3pS4uxtKERuPGURkx1by0j2EzBG4eoAWCkK0qEimEoPjCkcZ7fMBOXDZoOc0K5kv/ZowbnkZ3Cwo",
+	"icJFKi+O+O+MPJhxUWr28IYTUgJy0SViWFE69DCATuJLl2NdAK6aZHwNQWKpzsEuc465EmvYTPw3C2VL",
+	"BL+aAIVNjsFMdmamhl3xCdC4pj4Mu2bbmqW7cU/1Rnp5KLNMnrNiGNBZW35nu3k2P9jrVDBSyMxcDfMl",
+	"oVB9gel+s2TSvHJUU5LyMaQJa3JGMyoSrPlAbQDWhUXdOZlSQ8DH0gqXMPJgJJ7bj6pqVfCEQKE+33CB",
+	"qmfEvnkKub+nh/DW38mb/bcP3jSX2ydvhv9+4D54DrPiF33yhov6yw8frsBCWmzjRoXL6nK4YRsZExg0",
+	"Z4vsQPZDzk+/fVcMP05fn8/5lMun+Xc706ecvxLPgTnPmsvcoMBNo4BglxqlceZLt7UCuNilblIuYEPI",
+	"rG6Yx+QFl/HeCDamWIadGqxwZY8e1IEpnxitzr8JMSC2UPqYF8oc14F7CLlkXhxLWcJnPoBMDch7M2Am",
+	"L1jhfiNcpNCgSEzcTHyWywJKEA2woZndjb4ZOoB3x8w2M5hTFhNsukBF453dwUi41mkG7sI2e6CZFxh8",
+	"iw/fsY3OvKKLBUvUXGk2I4plNhSmOjarLwHoSvu5ByOxL0hCFdbxLJibTk2pU6XNNB7WjJ2zrB8MnWRS",
+	"2QL/XKuQQzqRBTu52hPYt/FQVKEP60K6GeFCIitKaOZm5AxlpZDzUs1UbcEwU6lCRAW5I5ByLQCNgDGP",
+	"miUX+vswKnH3u++WBSUWtftzk4asauSGFcsqJF+JKRCbKKwoMxmw8YMbJTwrevasylcX92sCp7UT1kXl",
+	"JcYHIF8LuxBX3LWeRnyHldI/hUL0xRSNjXi8EY834vFto8BGGN0Io386YXS5O8Z51RrSaLMh01JZaYlY",
+	"5CKn21kKNiGhFkluo83HZeaqc88DsmUOAjCqjxHltogvKXPrXMJaLRTrKxm8MedhRrYlZfKMXZpzS7m2",
+	"J6wGIzHE97kKe4r6si/OE4kzlFCdhlYU1FI+gz4PzD6O0JtGaJbJC/PKqFcVAzybV60JU4eeXJFR76ws",
+	"hCapvBCjnnsNBnq4Cdi6RsBWE9JNANcmgOvPGMDF1ZEc69fclu72AuaYZqrV22F/TJR7++9mwNpZGIHS",
+	"cUR3VuycCcLbeSnm3C6ntFSapX0ypcqSWmCrFIsMnjFi5qjlP8uxJhkAG2sNwdWJgKcsjS8mL1hC4Wms",
+	"dcUL/7xP+ETIoiLMtsz2gBxkzMgRZp3B1hEulGY0/X+xYjz283XCCNbz8olL4xJDMeILULZhBEi6bYT6",
+	"jyxhn1HisAyl1maDZlJMFE9b2Vh9W4MM0I2ohAlacEkufLsbV/iWYgVw80/LzLB6rZEg0cTAVdW8khgR",
+	"zsifgenYjWZYbhc4lYBYDWUblI/EsRGlggFRUNPfKFBuQLPxdfpd33HcYUou6NymB4I6wmgytfqIr7HW",
+	"t2eKnNpau6FEZa3RvF1tfamQ5W+bjfstU2UyrbYAdnTGUL9yxd9GVmIa9fpk1NbuzM9G6By1df9RzyV4",
+	"UdxbJyIPekvNNq4eiuCaO8GeeNGtpRE18O+gpiDZy7TTvjZVW3acwIvuTm9wFYp9qMU6UrBveK9KNwEe",
+	"LZ6q1+JiAnNGle64SjXrI5hKcbwpzXMmrmuAXCFylqqyYCDvxOtXegBBpEXNHW+8Ue7w83RAmt1kjWjq",
+	"zIi+YzEIveHt84ZGM8OtL/ULhLlBu5niHBqhQl50gAZLeBwsA0kBfmw23I2XepsKbD2OUUnlGFdo8EhL",
+	"sl2vf4MD+EHdOFFO8BXEOLugsE2M83quoR/ZstjmiPpyS8HOIQWN6mgRQlbfmdWsACuHSxe2O1fbRrAJ",
+	"l/7aw6U3uspGV9noKhtd5SvVVWIawaricuPLtlQRLvxzKRUb0f9Kov9acvR9SdBZSyhcr95a6CcKS67F",
+	"hd/YLgZT34Nqa2E1qU2Ftc9RYa1dvClSBBJzmJZUVAD+H1/nP4/evSU5LRR43PHNmO5HoEc8hkdxhaX1",
+	"USIwNxJamE1Z8tHw8pA2W98nVPt23RScN9WJJeYbwya2JgUFX6f9yMsv1r5giW2/cqOiQDOXZUHkhbAu",
+	"1AH5kSrbZ5mKWKX93h9khMdlm1+Mes/IL6PehOtpeTbqfSCfQgb8vypeP3vj99wUqtj4OTd+zk2hihs3",
+	"4trM3I0N97PXqUBR4fYLVkRSqleoV9GWdjbCzucRdjZm7U0VkJuvArKIzt8fG4MlOUso3rFdewOI7oKL",
+	"TUtM35tr+p0b1+9dbk3k1iJbw8+GrEWyZ5pxr6D4ygKgqxrNWnI1o4JOPLFkc1eLuYp1HbvCy0C3bQXt",
+	"AalNk1BhCJddYN+VI+oTT+rbyqy1SUesNEYSrAePR/x1akA6I33PSp5pQgtZirQjphZDx+sxuBCom5ZJ",
+	"rbJ0LaZ24FIQSMHArCds0HrBZpSLwI8QQYU+mvWRGwl2zgpiOJEigk2o5udslayqDkk1KPfRwTYju9pm",
+	"wgqQYGX22mBPH9n8GRn1YIGjHrCjpYK194e1IX4/ZUB8QyI9pSpAzZAqEVvMmiZJIRU6EGqlrOd5o5gC",
+	"QtQBYWBQtVbXayCqtSQ3kcaWzLdx/+IbTRIzF7riEOH6hA0mA+dWrHbBoDX2s6ijsByTne1t30YDyeFZ",
+	"aRNwLgzOg6IFo7OUfL/dtwkc3jm2u+3szLXduho2AlTX2Dls/Wz9DpH1Nu16Pjw7sOxdAfAGe6iQNMoa",
+	"zlnM+LiXyTKFZ4ocoSMkQdoD1+sIOF09zQt6O36X7GyPacq2dpKnbOvb9Emy9f3u377bSr7bTR4/+dvj",
+	"nfRxYhgH6ELmLrHinCdsy3YHUTlLfNfR3s5guxLzQw0Qq9Dy2ZKILbvYvJCzXPdavR6d3NHmx+wc7azz",
+	"TFI4EFFmcNhux6VgVg5obmir3cKHT32YKZHQOVpH+e8ePqwVPgbxBcjRgLwplSY0BVzXkhy+2iO7298+",
+	"sc1966QMkrDwsB5ZObouqzUX0y5cRDVFWaYNqW9YhGiNryEZAIARSEPg6u7Dgq8PR8za0pgfTqq+/hVR",
+	"sNEbrtWr3GLokvnhVC+1ucroT6TCYk88lLKB7+H+bBUMMnoStgJ04T0JXHv2yrQx2r7scCu83qp2vX2S",
+	"pF1GqZpVfHCKZQC6S/tHyxdr/jpz6FNPt8IpHVm0W1t7lhcyLRNWkAfefgQMB4+rkQRdpxdLIEZyspox",
+	"Rya+eoE/5tgdffz48dPrxZcuvSPd9IRyoYilILar55kLcnB0Bje1YJilaoUSG1cBARPVShtbK2cD+9dA",
+	"yRmDgZZtcqwjnr1ndZRulhhvc666hoFU4KWFwT/ZwpRRaMFNDUjW3DBI5OxRYq4AfKgeqfTj1kQ+Ot99",
+	"hOuA+nk+me9FWSXCR3hFkClpXySgM1Wq04/vTg57/d6L4X96/d77ly9/6vV7b969Pf6x1+/95+XwMO6X",
+	"bSbTL6icEM+lb9ukOv2MVV8xiI8oBdfe7RgMHpFQdnZjfs20vHrtAL/dHbqy4NoD6rT7CIxNbPMg9e1G",
+	"xKQh26cnZuT3wi8NDDBUO+2RCXNNU6Mzplzhvw10vgUQNCA+k3oKPyMdM19rmskJ5tw2fPmN6hdFMuXn",
+	"VzY5u89vONzdmpuHMDrNuj19mzqOX9xneD+dVx9jZtAh+IygqoAFHD/AK4k2b+BndilzQmuNiW/Eluk6",
+	"kVS1IQ1QVlyxNOIWbJ6BygV7gyYLFGEQIt/Lexb0XQYV9YdClvnz+SueaVYgWfE204MauVncPbw2BSvI",
+	"xIxr5LAxjoz0blxmTvnH11Qic7BUnRWSpmAdoQJrbHiaWtDko/n+ZWcALLWjwasQCJtlRMuPDMOawWg6",
+	"wYW6gEzHJ2YyZVl/JLS7qm7aBAZH6FGjN2/+fZLrrW8b5UzgiZElzLMwmBHsu7Wm15Gd6UW4DiznKCsn",
+	"N4/o1eWFDVKnYIe44RuAK1VmARF0dw2/w/syjbT7Xn5x7r/TdcVaXOhwsTpiR19eK6os9l1+ebFlQ743",
+	"5HtDvjfku0n6AhK3gLqZm9Pe1deYOlR5JFB+h+ZeDiMq0g8GLS6SrEyZQgeC0W7teVSyriIPeNo3B/Zw",
+	"xX7vzRFqEHyGwAF7InavXLf5qqV8b1Vx2pypQ1RB+GxWYnf6MrbC8N4h+k4LWU6mEh01ZHiw3x+JcVWg",
+	"C/kxF5oVNNFYvlBPCXXWv29UO4zdb9wk19+eIvJHlozhPiuYmcyyF+DZekH3zqnc6nG+etS9nfceRNw7",
+	"k8gm2v5zRNu/yqg+KHjM82Aekdw8W1QadTWJ5G05YwVPOkxsNp/O3fVg3kjwjHkcQfF4jIqFc+HKUYDe",
+	"12x2R/cgXgxu4Zrecz21BTCPWbFwYUgcc3yZaFbMvuhx53WoV4zNN5+H68WJnZOKi1OanlP0dEWKTwZr",
+	"j0A1Ei+CFDwuiB3r82Bn4yRXQ9bNmV79TNe4bbI442nKxEEhzzI2C3nqams8EewyZ4lmaXOIjmqRrDhn",
+	"BSlFygqlpUyt1eG3kikNkSsFG5cK3OGElnoqC/674TODmB4B1VWfl4V4IS/Ej1xpWcyP2GQWDdAYEoWP",
+	"aqUqyVlZCCiYSKY4wGAkRmJIJvycCf9JNJQHhFc7CtMXjFlPtrIGgykVE5YSxn1cU3PKqsIqSE1WaTOj",
+	"B56jaBzdUL8UHR6uMAzKhafZhjtM+KDymGfqijFoHqQjTYvIzi8ACPLxbwEk2GgbvKf8XnXp/itU/21v",
+	"s1vJWcHoRzhNOcacfIrVzG1Cd8fOP8PawPsvfJ3juta9vfPDk+/++7fvvhu+ej/86ceXO7tv/7O996+n",
+	"r36EXfnUuQnV9Whsgj+dL7gNkfP+XBsBOXPRuEOj7toiqhAyRxONVRCqaqqNEDsqIIYCDDm2tMOq2sEP",
+	"HpZDlsgi7XUvwKsN3SGJ56zAwiQLggpv5ELlN5lsWE9vsTR2sCCA8NjHA3rKG/QPEzdLPRr8M3elixC2",
+	"6jRahK/jxvXrNDtKnOo4+qGL162ndQfHfzWdG+a8Xznu2Llxo3p/DtW7RcraBj+4rfZpEyUAPbsSk3i9",
+	"v03DNNjJEW4up2gBJarFInvysGZDgcYhuM1wE8f2e19MmNIs7YhAHhouhW/YMDVQoqTzXJzTjKc23Koo",
+	"ZNEw8zM36j0IS3brHOrFHxqBvvOtXXyrFeXsN2IhyTm3BTVCUGLIAr5NIy/46qH2bKjyx3XDnWiqVa8L",
+	"EH55w+BUePfSoF0cqiZy+tJqANuYQkOf6qXBUiO2i68MzifYmfj1MoSDZkegowKsn1svZgIi7UB+o4KU",
+	"fhSSSIFCO8p6eQHrY5CxCslL4zIb8yxz8apWpY6qzfviXIJp4s4z9ue4Igvwhq1/Frb+misdpvsdMgUW",
+	"qz+CJI4bKD208rdtPIUUEQOmdbVcHcRuX81K33WA9oYWH5nOM5owA6Vtm940R82qt0iGrw1GwgegQFVC",
+	"nzNF89xhhfln+G0YncKF0jTLwtD0CRX8dySaIzESAWxmJOvfZZdcgSZls/+UxBSyVBqVkl1qJtBUd+i8",
+	"xBAV0BAhEprTM55xpA2/NJd8BG2tyDG9rDo9KaLpJclloYNkC473HVQXDPnAjlin/rNTTS+dN/xZb8/9",
+	"bMauKJ5/2/xqTjQKjpuMOKnEtmtKSxbo9jUw7Cen/osKFEuqyF7wyF9UeFQ96QTJ2n4VSWSGnZJkqZWm",
+	"IjXkHUh/aU3k9gsHyTfKVyR0BuQZ01PUi+tbiUOfurmC3cQn5KB64jYUn/gHbV7m91TbgpTYwEaRuSwN",
+	"StoRqhUGiwCukEhxUmS9Z71HfGZ04UcI7iCHJGkLIb5fFwFy1pbk6vgY7YKY598oEr63Mm8a5vme+24e",
+	"Y0212bonD34fRIOQ3ZZ0D2FeISeHrweLwlG6Pha23mZnosxqEs8wzyFTvsO7AlPBiB2uJKs4hJ9Wa+/X",
+	"jzLGtdo01/wnRndza0EqgGlEIvBWFWnWEmUiPAFbN+7j1zvbAU9fQbyBVVTtOdcVYqr8leiSfNFSBGtx",
+	"n7FlMg1a7hozxoBuWt5aQktNpumWYN4s7ZZg37Cq/BgLkVeywzrlUw+wNucyiaH5GYS7orQQH/BZmzlY",
+	"27ktvIq+LLT3BTa+vZPDw5dvj08PXh7uv3txenQ8PDzu9Xtv372Pl50w322d08JcQAUDoNSJFlxnwnwr",
+	"L3oxYI+jSYC/HL7ae/z48dMPD6Za5+rZo0daykwNONPjgSwmj6Z6lj0qxol56aFNyjVqhlckXdgfF+Tk",
+	"eO+GNdI3YUDq1eJBjxgcxUc238J8wZxyCAN1YzuJzMUrgupJqtkIFwgsMMkzWequSMY/ekb+MpoptALd",
+	"3nm68+1ukmzR7Z0nW397+oRufb+z83hrhz79dnfMknT3SRqwo2j634zmv+DKPtR2hRVRQRXCHSEm05VD",
+	"opUqmtpawVN5AR13qYak3pTQyaRgEyOVoVe0sSj32O7nyZuWG3y4T44hyvXEWt5hnOOaMajfs5GvYaTq",
+	"Xwb4L78Jfxkg68GUnsUGRAjrbIWPwiFbDJnjiC7ErmotbAjL/tuT45dtUaS22jXCoFkxDL6shUPDni2T",
+	"M4ahfOHkazjQ+p1q7fWS5N/gKLrrAUDSrJYVJtTn9Ee4ZK7ghK94W9/SGUuhEMMB1VPCLo2OpcBRoqVR",
+	"bwqaaGtttuHLcOCqKgyDK4JmvUaN+onNFZmVSsMdx6hPg/SJFMqoUqBV0SyfUoFhJ/AU4x6gOk8ypWZS",
+	"jB0fieN3L949M+QBwkqRMhBmSETi6qUFd6eF1i0WGAu/HUbCU32geBslbsPMvjR5TXVEhSPk/WYgdedK",
+	"RgKyy69yHLceRR4xkIa0pbn4CNo2sRZZUFXEqOYGMDqGYUiWIGGAy3H4mv1cFuTo5E2fDH/+oU/e7L/F",
+	"uv1vhv8mAfVSyAicNFdAU4UqQt9yvZwWlu+5V2HWV7IgJ2/3/3Xy8nTv3cnb43Dgfh10hMndMDfJgJgh",
+	"Wt9Wm+C20UBpO13UDzQg3EvITkjXV6XY76tv6rTa8YVoRj8mEoQsojZ7SG2X5PUD31MDZOWrJvbLnAls",
+	"lC+rfz/KP04e4XAAdYsXxVXK8Ews9S8Vi5AZK60i34cD7fV7IW70+r3hzz/0+mbrzP8d/ntZ2bRw8cPa",
+	"Zt70PmAO2dcuK20koY0kdP8loY1EsZEo/kQSxf0RJv5VsmJeee7apBMNtBhmjXz1N/NJgzeiIeeXP2LM",
+	"DVJWt3RZnMlYGEkkImXHcTgs1IMbB+HDldlp93h7+xn877/V3mJwbc025V8yBwc2xo7n/Z6WSydArvpi",
+	"+J/uunyrGaKrvZcXMb/FOGoxveMmPbOB9wzkOjVYlQY0izSZo4/bwMNjjvC/Ql44q/9qF+0O3692aOH6",
+	"clJbcKgq8sUZbPCkCpQOVnQ/8TGew3GnYW/cCTyc+oLCg1mD7fkLdKPs763Ur2Qp0s8WXoYFCl2UWcpT",
+	"6Nc35lAv20UZNYoDOOlX02LCdFUeQIJ6a76/cPFmkqRcJZl0mQhSMIwoUdH4s7dS+/KZe1MqBMvWyOJr",
+	"f/yenU2l/BhZe/gy5GMJjFlZBSTU8Q8xju4m4KsP2Ab2RHiridl7G8Gnql6cgl2YfW+tCIMoElZoynGA",
+	"VdcYrxbhXVig49iKIsAcRMd+Li/90KgC2zXQZy6d5gra2X1cqR7EemERkU3vCJOI4ao/zGWQH8ciKzC6",
+	"Oirox9FhvfSS2Bm2s00W9haPJZ1E4LoHkaoxmrYJV/0c4apdN2xhy45O+mNR9/3L5z++e/fTihETjgF9",
+	"iIPjHrcgettJzC/wE3//G3Ft97qDodEEfmQ0vV5BLgyjJD8eHx+QKY5GMGxWkTxIMnU7GQbEO1iDIRxA",
+	"EQT7WqqZunJ1y1sbh604HFpyVdW7Q+If6a7RZEsv3JTRlvBftZgQD7s8Uawg44IzkWbzWhmw6Oq82myx",
+	"uNcG5i3tSALiE8HF5IglRTSYDB8TBc8xSskw9cZ1CfNypMPuhPFz7KGWOhvsjOpn5NczqtiTb3+FNJbU",
+	"sGIqUjkjZ3PNlM9Dy+YkL9iYX7p2Tb9eTBVLTn8dQKLgbMaE+Vbx39kzsvttbT/wzaMnk90fX4vji/Tp",
+	"cPrjxcn+m1eTyc9HT9+N5QEdv/2+fvIP8KOH//iFbv0+3Prv9tbT/3n09w9/PN7t72xv1+qCuU2xm7Zy",
+	"8fiFoluMpcSkt6+1Z2IsdNlyRHJy+Nq2Zmrddo7kvA64sz24QvpG425fjWD0KxcUDWVXG5psVrKiABLV",
+	"+CK1RvGOwS2AcoqGc1EwGaCIvaLqt0RauH8c945xqg0t39Dya9Pyu00H1yd1HVnonVqWbzzUCAcRQqLF",
+	"Ua2RbBJ8FElCisZm296HUBgFyo7YRqx7AAH0M5Spb49TKowL6ezfEEKwYrcGz6bb+xIqZkaddr1wov2q",
+	"bqoHxSp9HPg5K+ZHmuqyw3Ti3oH2gqVafPRrm1IAyV7Uwfi0UAdCYOyrbQPMqnGxC5cRqh//3P3p7cHO",
+	"f47//a/Df/94/OKf3/50cPi3g/9u37z6AXuxROuwHdiuZp+ECQ7sCBFHwg0h8uL1+fn7vaLMrmhpPTRf",
+	"xl0hogazmcIWPJ4wwQrs6jTlqjrsLnDfXQhWEJzpOlbhlz4cIwLwUmK6eDOXmIXrZlnY7talr3BqJYZg",
+	"yxodTwumpjJLDyqEbBps4UHbkhyULvm1VuXYVlEaaDf2rx0C73q15lddwot4C+Vj13jQFTWreiB2nY1b",
+	"+gtbqX7dWP3IdgUzkzOWSexI/uVoVU2KWoVwaUdcvioGqtczRFcMxsqZi/Hf3Mg1DiAumS4gDtWZ9Lvj",
+	"TNa6Pu3mhu2bcxsUIfhqjQZr1Ue29TRc/06KW692Ma4ao602nS9FsWCOoFxFEJ2y2vhH9oNF4/t3+r0K",
+	"y67MgZuYgB3MF83vX63F2Kx9XMsnCl4m9u1m/aDgOKvTrPa978NMavdx+f14cdNCdcPacwMBFRAWsKqH",
+	"ugYu1QbcRkP+waqMInCcFoyqriQTfOY2BcycFgK7Y8yaPetU/xUWkcJolRxSL2woewmx+Xkhz3nKiqo6",
+	"Wuc1gTkOEcRoAS6bHXJFCaSOIjBb5DhehEiygKG4UjBRq9TRyd7ey6Oj1mKvYn22yNq0PX82drx2Nyk8",
+	"J49sdQuwu0hXuNRHOpod1LrZax6aT5lyR/ZquP/65Ytev3f08u2L/bc/9Pq9A/uvDx1KcXtToh7toxIb",
+	"oPftrTFzMCg/Y+aw//oQ24nbiCGptJRlASNWhb1X4SK+lOAmWOSzBovUzB03ri52qYrrcPbl4B/fuoKx",
+	"8LodXstC09y5ZSKH+WbptkQHXmzlRyOQUS8Wb0eXf82SrVjbLQWW6CiVQwdMibXdMoh4kNcJN0OhreWQ",
+	"AGmMTwRKPodlWIvWU5pNs+H7Gp4DCLSWx9OgwGJ3p+vWFeHhrpYwBAWTBJvmczGBAoZml92318LusJfd",
+	"J8iqc0WyWqrwqjb+RYFFhaUrXyaqCM7jGiFFWJG6yxW9ZKGWUpKKxhWMJlNEjBDALte0/3AB+aveqbBC",
+	"lXkO+QKSnDGiCz6ZMJtZuTYBXGBrqFdY60Cl0BjgNuS4WlcbwVbwHMMim27jFbhtuOdfb1jQ1YNwPLOt",
+	"od6HKwgFtxics4JAQW9VouDKkt20SXYbISyv91+QByfCiKQKwjksIXrNLnkiJwXNpzyBB0eywBaXFY16",
+	"OPj8ZfmjF3gvQIpmEc77x1UNbkGhEFfLG7sIN0/9bO4bp5J9TWZ07vhxxYTP5tBIoSAf2fwW0WAkrtW2",
+	"t6r6AJ5XGEWzWS4LahQlmZXaVigArlFobK8NUFORkp/M1NYEZVifylmCN1SmbMLEjTTA/v9vAW8XyDAb",
+	"Xr/h9UuCtHQItmcZV2GFPztPSxPbHKJgGBVwtFmZaZ67Uy0gXmKes0gZ3auHRHTCuEKYhN+VOvK/PXnz",
+	"/OVhza1UHwPGXzxIV2OXpvPKepSWtXw5D9+68rEttwAhM0P6eNaiAYZY+llCBD54ebj3Espw2b370OG1",
+	"aY+pY8gctTMfsCJBD9tb3KQPkXXfQCbucgHwJvJxK7lvrWRcA9ydS700QN0zQ3o9FmtjR79NO7rtpdtm",
+	"jLYYVtAwlQpCizOuQZrLC5ZwKDhV1S4PxK/RaOsfv6D8NRoN8F8P/xGVqN4NSz3dHdoesWgJlSmDpmTQ",
+	"vCdOGfEz31vWXiGZum6C2H3IszR/oQREz59aKmCukvD9adPTJONIxij4zU5TJjgIVqXwfPLU3ZBTezHd",
+	"mCDf9/o9LM9wChCYFVsRmGfz01L4ViDRm2vpaBTRW0dCXQU8SvLquxXO4f9ED+LAt4ZsVdrHPo9AEant",
+	"/WkEdma7T7VlhnjtIZzBDuA+vOXiQXbOENTmjLs3VK/Elp/XMnrVDqZUMbUef8gzKkgOH4ZI/JHNoQkW",
+	"LfQpHWvDbmPnmdFI4IX5VbkYCaugQcsVM58qz/y76mvLVzb0NZmvLnfs2S8MNWr0/D45ehFt9u0mQULk",
+	"4uEyKurJUxaSr8npsahip7eLRAp3euMBeYOtKsjO9u63jaKLgdJvnoZwhV1G2iU9x2MGzYvjzSPaXfT8",
+	"NsPFO2OJnDFF/DAD8t68IKR24jZL+9X7YPBICzq+ZlyM13HdvJZiprGwj3CZx3L9RUINIJJJMWHFOiv1",
+	"rxIu0MqlWTa/6YUbst217HXDraNNGT5PdXS7rv0XsXVAO6dYl/sZ31ptNTdSe9TC+BPwlrbdK2y1sWqp",
+	"X/yirZENq+4ZbtzouhxM1VBdBrUf68VfwZrWGpE8t939d+Ay7H73pJvO7H73pFUG1BEdrvKMoskumrsD",
+	"/Lqj249n6MSw94In0AnMUHnbYMtogRPzI4WXv1GkMLc3oUWqiDxnBV5iamhNyK4NS58UTBlRYSSGdhJ1",
+	"wXUyJTJJysK2iKs3sqfkzFb/QiGvT5hQZWXypURxMQEzUTCXbYEGlcOASHCRZGWKxXInrshwysdjhkoN",
+	"AGOWu0ZjLiOpgNDUaXc9qMSjiMVP+cDcFVudZ1S41LR4c89aqA+w9ZHYk7O8NHrzGVUsdQm5rEG6nbRs",
+	"aJl6NhJbyCfI3w3xrbEp88x23P97/QkZldvbjxPzyYX9NwlIP3xYJFN+zlLyiHDRHuVYhmOYD8za0zJj",
+	"KYkPG8wbDrMkphaT+76Gqge+93Hgddpp4sbP+FINMci+SLC1E0vbHDdYV9iSqwtSO8HyTltgLnIe1g5n",
+	"LCoP535ILxj7G+NJWFSNyajoKpvvm0ri3MToDiiV+y6TzZIGd1Mo3wizG2H28wqzGyFwIwRuhMCbFgIb",
+	"7NEeFnLAgO8tYXfr2+zaPpwW1wUOeUoD7mz+6LLj3QMPDpgbN16bz+G1qS7FF6QvX5V1eGOHvU3RNeUq",
+	"MWjelSXrHjvt2Qnnq/bvzjhLX9hBwtSJF37eNlmKClw2XO4jmxM6kzZsL3TCkBMb/1Yw4GoJVnrCy+Zi",
+	"18ILY3Tn3Sd+RbfSJWgjlq0slhkyt2eoXEdGckAFx+uj4qEdPcTBQz9k3ERV6OE42q8XOm4DFTbPbXEb",
+	"j4/wpSIGCFrYzsQh3inbLaGiQQc7/9l5USM4tqVdr98TZYY+6bYxp9AIwJ8igH0l00mFQ7UDXMiob8xi",
+	"siHwGwK/IfAbAv85CPwi7fkqRPCeKLHe3LDRZD+fJotcegUGWViRYcMqN6xywyo3rPLOsMoobTt0VyNG",
+	"2ewjiKxmlzTRfofrhCx6Pb2hz6YE3k7/4dD9HZ3dvjFY7puuW8C7mMGiampV/AX1O+WM7OCphLhtzc8N",
+	"urtQCCOfuCCHTvP6LXCfjWt749reuLY3LHnjNb6PXuM2b5KFptmx/MhELE4jkUKVM1aQHN4j0EkeEuJ/",
+	"xmYdsiCpZEp8o4k8Y3PiOKNNSUT7JalYyEgcMfaMuAYRQWdapWWe8clUc/nI3Hld0OwRV6pk6tHO7t++",
+	"bXdmMNjBUqh9e5SVkwWVC/qEj7FmAYQyZrbDgqMsxFbNgLM7Y8SOXCMmRhn8yIQ6BZ3QcFx/Yl2tmlcp",
+	"X3W3+ha3DM4tUn+Zo9zzR9e7QUUJfFl9BcuOheTf+dokS1cVlGiOtAHaiWeiRQkF6DHmkeHMcL8KpsvC",
+	"3DaqbUKyzd72E8nZKRKV0/2hePH4IH//fne4+774fvb0f8e/sx+zH/79/eVs798XPwzm3/327dHW8P1v",
+	"r8onv/3vmL76ffv3f/327cvfd78/VGL+88U/x+N/f/fb5ZtzuXzdzRqrdhOigruhzgd0PmNCH7OiQ4TL",
+	"8QWiWTFD/jHOqEbSPhiJd8JIsM8IF6c0PYdMdFnAX0XBaNHI4nTvQPqleyUu35vxj3lMrRzi5ERzVhjO",
+	"p0nGqMK+1/jE8xZzYJ5mc0EYNRoot4mv9dzHjGqYdI2a4f6TeOR5tVEBRK7GgQWiS299Ffk2lsleCr4u",
+	"2Cf+kzjYZsirgn0S+TYKdn4sh7O4kfMkJ1qCwIZChm1yDtVpfiup0FzPPTOzRXfweD2EI7E/JgbGvv8N",
+	"7m7OxBY0xRr0YrUkOlcFELm5l5aWCBbXD/AqPKzO+2hQHvVaI/3cB+QPoL2f12DpAjYX4ktdCDnm96IO",
+	"xnNUqSzAGy/UZ/FCeVt1hEh6FdrqRVgPy6nfmNdVlaJCsQbLgRnxRbHinKNFIuVm4JnBLgmyyIzmuZFR",
+	"LNU8HTO2zJhuiNgrBviu6ISdQs7Zso9OzKvP4c1PHpfnUBzsGe7Fp35PCrYCpWvC8am/2vshCB+CDX+O",
+	"StDLeluX+hGElb58sQI0P+DX4QG0GdJnsz65In5hsTEnrzpl78NKlcEWoWhjq6iYr3Fstv1NvcPNap8e",
+	"aap5cpUvI2fc3tjYIStCC+YLDuLts/anqiRb4A0YCVeHDz6UMw6aMNiTGp/5OfqEwoWewyfO8mGJkb/6",
+	"y66vO971dwKso9CSaP2jw3w9nlzl6OJkIMAzd8MjFBGksDFjEdJIjfSIZoe8LBJnrKSkYIayG4o5ZpFy",
+	"MdaQuEfTuK/M8AlnbEzwJe+Y8Ic0EmgLL7OMcE1mjApl/sEtXGj9tPOv4/l7Xp85Wl1kE/u+iX2P+7aq",
+	"e3dsic7qrChG9eOaRUMIad4MsC770lN4lJZh/YQFXxWrdfiOEeSg+u1PXS5pJ/ugMIcmMnBD4XhAykt1",
+	"4wmLlvKTj/HExU125VfmJ7uiheE919PQThm/S6hkL+Iv/VDiC+R8g+njgtVVlz8+dbMWp7625D1NL/ek",
+	"GPPJ6qs89p/El6XppdHpx3zSubZSWBHIKvetL4IlY8M4iFCIvOgrHSjkB764qn9zQV/NKZbhdWM5Khha",
+	"gL3G9KEeXmTei9ct/dPmK9jdaMhY7hItUjasELjYirgRBzeiyEYUWVkU2XD5z83ll1rlN/z+q+T3cV55",
+	"dW4YMcFElxKzM7naudbas9hkydWRHOvXfMb18nYn+2Oi3Nt/N8jm4u4N+CShwhxJ7SzZOROEj1s2MUMa",
+	"L6e0VNrgw5SqIdRARn8QzS7oXGHfh7JGUwysJANgY8EtEJkEYd2HTLHIlv1HlgAmlm0GuzahpZYzqm1Y",
+	"CIU++DxtWf8Qa+3FIyphghZckgtZZil4sFyFd1u02PzTtXAAPxYVhII3CdiOD3OasoL1CbUgeX+Y7Urf",
+	"CQ4ecj1iCocfjMTxlOpwwCk9Z4TrbxQpZJZBdJ5i2oCo7IUprbeVkgs6tyF1EP4O7tfC7GYVhtyvtQWA",
+	"GTC0BH6XBZ9wwyXsautLHYzEGypK2Gu/ZapMptUWwI4aEcrA7frZjHo43KjXJyND4w/tSob+Z8MeRoYd",
+	"NB9hjxxFKO6t6/kSdx76GmnbQS1NwTWnmQWQOp9gw33Ywr+DgsuC6/niim4vAlcPTpDb7zwzdKQQHtfA",
+	"LrnQ3yMTRKh3v/uuXufNr8HA5lYAR4un6ibrxfxpX8ShARXHi3P27pwVdMKGOrjMS6gTMEDEQvzY3DU3",
+	"HsQ9waIHZH9McAx4GQkBBB6YLdGSbIdU58AO4Ad140SJUNMf44zusXghmLirFjo4LIVmxTnNHLuK0fSR",
+	"eIH7olwD6KX6SocW4h3lsB8Wrmu7kdo+gTX8buh2WMzDEi/MtDfwn0fv3pKcFtBkqyFHhIOS4ylXtmeN",
+	"0doyJat4OdAbkilLPppdDakwlu7HKAfXs2pcZraTFFJWUD25YFuTAkMc7EeeBNtTs3egT7hhMbacIxdk",
+	"LsuCyAtB1FxpNhuQH6myfZGoILjfdRvBH2SEtxhPVo16z8gvox4G9o56H8inEAH+t6Mj/Z3wZlq304cV",
+	"2xxZVFiEjostDHfRBR9AfEVnfKiW3Kxbvjbyug76mrYUHlHlwo9V3TZPt7AEbswOhCqWL5ELr9+S3WcJ",
+	"Hd048zbOvI0FbePM2zjz7p6ZzwczrRl3+57r6Z6czbiGmCDYwZYFriF7rGxl40a4v/VpFrool0zyuYya",
+	"dSPmxmi51GgZyoUbP+Xt+Smj0uvXLqVuJKSNhLTxMd454aPhbbx9MeSWJlzRm7oRTf5MosmNuVRd/E+X",
+	"nd2/UO89KirjuyEKVBAqkqks6vjQwx8XJ7i7gQyNGP4nMMG5qgl2jLYUUaXW4ztg96XWyVo0AW+mc1+1",
+	"1srQztVhL6mWszKzrZ/BvhtgQeaiwSceEGs3aYig1TjN3kTuQd/t7QqYgXVz90Ve6g2S/JmQZAXc2A9W",
+	"sy4sVbmBX1M6/7VPfr1g7KP570wKPf21byj0r3NGi19DqmmQoN97//LlT71+7827t8c/9vq9/7wcHkY9",
+	"iYdsJs8Z1KE5mvKxtp6GWNHHgiWhiG4r8JiPUHilrqyiIgWMWiPmb9mlUaMOCnbeAYhiOhBxQV/qvFTg",
+	"gaYFxWIvLfXHF5Qa6kWF+nRQpc+6cOlHX6Sr71gfeM2EvBiQY/9iQoWQmpz5KpLjEnxRBIUH6FycVn5B",
+	"XZQigcgM67SbcVFqRtKSmV+m8oJMudKy4AnKsKwgIMUaNUDLIqIlX68NdcNZ3t6lFwaGGSidF1Omp6zo",
+	"9o9LMGFO+DkTfXij4KkLwAi0oG+UFybO2JSec1kMRmKLLHXAu7cC13vwmpt6EHWrF0xTLoYdRLBjlejY",
+	"t4TPEkdAa5tsLovK5V9rpTi0PcNby1oyYmSFnV8smjeyBbFKUUdUpGfycpjnZks2LVI2nqVV7CZfSzPj",
+	"jCvH51a0PNDiI9N5RhP22n4bFy5m1YvEzoJBcVC9ggulaZaxlNA8N3fZWfEGrSVsDCTrGEjW7aI7zPPO",
+	"JrpHtQa65qASKQSKPtFz6tZvaZ5/o1DL5YpYmhvKRAp/iod4fW329VX6vrqbGbR57QwTO0Jzy4nwNtSD",
+	"Qp5lbBYWTlnVTsYuc5ZoljaH6GiybKQS4Ma2Fkg2J6WAe2CEOSrSzClRv5VMaSfmUbDbyoIWcxBgMklB",
+	"lqg6HM+oEf8FFQnrW+EU4mQz/pFlc1vPkJ1zDPKFcEwlZ8ywKzofxIL2j2ShoQdgHEcltAf0wn2IncOj",
+	"vV6/9+Ll0V4UQY90wXNmRYgmU6hIHb4GFykSclYTNxbhpuE9i1lHQNUTmtMznnEUaX75o3XFASQwU9Es",
+	"KbGQg6aXUBkz4Ka2DihQKvDow/Jzduo/O9X00qH1s96e+9mMXR2Gf9v8+qnfAY6bzNvoFdoKDO7YCO0m",
+	"GPaTU/9FBcq+LWG6FzzycbrwqHrSCZKthqdIIrOMJVoRWWqlqQDpvmDnTJQ2bcB+4SAJRH1XUm/G9FSm",
+	"7a3EoU/dXMFu4hNyUD1xG4pP/IMYFbd7ql0JbFt/di5LcxPtCNUKg0VAHaREipMi6z3rPeIzOmHqEYI7",
+	"yIE6WQjx/Trlw5i4jJ+zmUy9ybn5geNYQF6xrTXcpgT6H+wbZKdJok93dh9/+92Tv33/tDVJjUN035xP",
+	"mw6IG/F+I97fPfG+ohDNPX9tn/TBfOCyoOyYHCphp2Xi6/rHzR4b7eF+aA8tuh8T0pwMhW+R/ReDaD3f",
+	"VRURz+WqYHlgKRs1ZIka0j6u4B5HdRR4fW/Kko+y1EdMKS7Fm+itt2fceHcAQwcnxXSZLxDHrUi0b5QI",
+	"3dWnpC7dgZAktO1cEqJFYtSQDNqT5IVMDESwKXY71SlNLC/xv4Db1xxf43c71ykKgWYjyyRhLO3Ib0II",
+	"j8xicSmdi4ANsUuINThBcbSjV0vwrZdcB6uyxtYIPB0sDXTxhPSgBudiCaE9lRszqvE19no54G0Jve0u",
+	"qI15ap6rtUcGClRvkLC03P66xLn7GnSp8gG47gpEaYYnBR6pgrPtvvzHYZDHwoANw/8q2txMVYvRjAOU",
+	"BOwgKYNmDrWeDKlM1MCqLomcPdL00vz/LfO2qhFkfZmkpzvb+P/qoho8Go3SP77/9JdWmEe6nOQmi8nj",
+	"e3Y2lfLjy/NF9/wCX4LEcN3Z170j2f0cLrhNjdaObdXiG7nQj3ejuazu7naN6+5hHSDpy/Evx9aQzjX3",
+	"TnZXtOcLl9shJCwWOxcIlN3SBc5nng9W476Wl3pQPCPu2d1eiivdtZEb6OIKJLcPiOb5/n3sBNHOBLPk",
+	"6OtYjZHMVE4T9jUsJxKK5tbWtwgYRfWql0crgcjWzIACUXHVnJJSsYLIAl3v86a9FS3WGJ7yUqQ+mGAX",
+	"ZPHtZ/C//wKfC96EzoKNwIPg3RR1LJsZ6kyL5C3K2cuNt2gS9P1KgEyEgtO0PFO5RMMY2sR6XnnaCy6A",
+	"GeL0n2/eZYlWP/38fcT81Vr+l2hn09rr1YI2Yify5brxrA1+DUnauD2t2wTSQG33tgGL/3WgmujWEe97",
+	"dUtXdNYv0uanI68QQe83t3DVpdTv3VU0mE/Laks1aVz76jYaF4W3eOmRxqQMs1ULqOtJrljxFdHYDQXd",
+	"UNDPR0E3dGgVOrSABC1wAB3VWlEGnZcbPSqVhiJhbc2ms3/r/rjd8Jwr4ux8hp5JPWXFBVcMi39pCZ00",
+	"3ZAkZUJqW9zE9VO94cjU++yg/HINlcMzHYzEe1sPrmDnHJ1QZn8YoWlKZmWmeTWKKvNcFrqrG/Mi9fI4",
+	"zCjcfxGF5fOrkBsv8cZLvNxLvHGQrp5/mlGx+jYdZFQcMuiM3Nl0EbKMIH0wSjL+rH7HgNbaXQ9YyjJB",
+	"4mXK9TBNl8kTms2AC/iqnBHbdR5WUqNp3EeXU4NGf4S3dTR6hO2qR6NHv9Ct34db/93eejoabX34nyil",
+	"hvSYpTbyAHzIU8J8u7alPO9ZoNzAK+5YvBLDndi10egRuMpucj99I7kb28BFBS2++m0Mc81vZENfXmom",
+	"ll1jzLRj8Orqu4nv3/ptbuTiwaTPQSaOlhNZSDb91+2tu5HdxvzHFXAXdxwTG1ffcXz/c6Nw586sviMr",
+	"3+k/2b6853r6s0P0ZaSuuSuuwjqg52fbonUuK6TzLiV9kZzhVit2GOg2Lu1lTkUac/W7JzVhcmMd2VhH",
+	"NtaRjXVkYx3ZWEduyToCbLfWdH0tddYztFgf9Y3l5Q5YXvwZL5NN4uIyROAnuqQZSSRE+fkEgfDjPrnA",
+	"VBKGzuUJ06r6bU5yOu8TppPBYEG5R3FD3ej69Ue+IV29Ud6mSfGGtX4+1iqSrIwK/vjhGdRwob63Bldk",
+	"8n/ZOx/etm1u4X8VwrjA2vc6tpOu2xpguEjSpsu6Nl2Srs+69G60RNt8IpF6RCqO17fA/SDv/XLPJ3nB",
+	"Q1KWbMmWEzttkgMMyCpTJEVRPD8enj82Wsslp3Nfm8uKMKOqmElc32jVvVYg0NJe0fSlU4jkuUI6OXdD",
+	"dbuNA3/Orpi+H1Xr3UVdmNEC3czG9DsXs0Ofq88grVa/cHfYJlyTEVWQgtMJs91zcS62If0OJT6wqFmT",
+	"lJKBdYbP81rNNtV2GVamLZD+BEq6ikzN2+RI+65QYWg9b7ttLX78IfwlS1VhyvvOPMrz+ptaghEVQ7Pq",
+	"p1Ipf4t6bFraKbZEXrFJsSXr8e/ymMH1PMsLOKlr8shuNs1mlAv7/4+LfaLTpzoXO/MjJqReadTyzuWj",
+	"BuErTe3vGVF0Qv79P/+vptC//+d/ScqGNA0j80HKAcS58iGMuVYsGpTbgFYDGUXyXxkHO94YAnIpJhRs",
+	"t12DCZ34+FLKsJ+tMbctMZf0iIvhv//nfzvkSJDErD+mCDhqqpFPvhaylF+ykAxSGcPi8Y0ydUEGHSmK",
+	"MQBIxAXb4vClrilOLjL37UfEvUkI+zbG/L8jMf8fZmz62U3AouC2dYeqTXT9theEiySr8MQKuQLnWFUX",
+	"RtL97NdXs9kquQQucb2OOAufu0rK6akKi0dQzrSY76fzPUpt0jxQIPtifpoKNrbPXp4Ob7dfLwmR/7z2",
+	"mAv8CVMNSR8rVNF5cFgI8TOnloZ7LRqkVChY6T0o2I7OfU8uXKe9kccxCw0BRJPFTcw+8O/bz1fc84GR",
+	"rW1k6TQvDEnhXTWavyseC9jhqDkcOExlvCBsqIMFHzg0D3pqb0Z9P+6Hb2U/fJsL7R1cXvPHXFkrm8uT",
+	"maersXmPpPU4vMW0XrhzuPbO4WGiYeHbKYg4/5FUCthLfnXs7RZolPtdQzzDqlUwL1rwvf4Xg+iHiglN",
+	"+hNi6qwAxpvHxkjoxIZSdMq1S341Nboo98h0qDh7ix13D0ne2uqqYms0S2bRpAO5TZYIE8mF7kx94PNL",
+	"TuyVLnHISFy65t43OHwpyAdl1pE40Z08V37FbwPKIxvPZfaXlAXyMs89vWCgzpok4HDe/rWO/QsCZJwy",
+	"UJi6cOqpTwkfFKJmqPkJ5aIZrRgyZFFmFRdUYNpqcQbN/VgdcruwX68OAAQBxgo2CxpusPvl4oS5lFEG",
+	"n/wwpWEGL77KRmiBfqBi5Zs2ZVWCKmEiJMH0pvlhdqnjbbL85qP9JotZyoMa7UBRTR3xmLuI+bY7VJNY",
+	"KntENo2Imcshh1guzf7nPJ395npox2e2jxGj9Z20XSp20k2GlbU+r6c2MeXDEJspjk9nERdDO7O4Inb2",
+	"uPxyMiX5JNqFCPSC/GVL/OWKuPvtHtK9cvKvjILbK8wVDpkfbJj6cBpOH5CTpTbHhZ3EvoW8zb+m1ftM",
+	"2UXtua0kb2yYyrEqDSaMgPk3S1Xdho2lqvKLOhd7/lVJ4dVS+YhbtbRdxAgXhFGz2+M2PFQjooR3ZF6X",
+	"m4lH9qYCqpzxUljWnDNnU5nbbjdOZe5CqthB+bh4JapP04VrBK4RuEbc1hpRVmSusFrMLAFLv/13gmZ6",
+	"JFP+93ys842FS/dR0EfUnj/2zTaPWg0D6bOAZooRrklEgwtFLmnEQ2K6aTbSgdUUBCmDfTWNVL511DQd",
+	"Ml3ek84/b11XF+w4podKs1T1aS4+2Me5DckecU2R50xTHikX95w8Ojk8IN//0Pv+sZlY0132dMksAK7T",
+	"5bqaYHMRUwgAD1lxqmKghdBcg7gA7CqJqLADW26RKyIDZ/eUg6jrRHm/W3yvfRlOSJwpbc+0fz49flOI",
+	"9V5hyGE916t6+u7kaHocbGPr5goV+6nnHW7Y0SwVu66ju6Cq6U4d+rcg2N12cY+epXxxjNj56f3T2dlb",
+	"FzrQGh0PmTB7pelpuEz5kAufNsDO38ZD/W2vV45Tt/2d1YaYZba1+/TZs1yKucLzMezcIjI/3pSokUz1",
+	"XMQGlcUxZCkYzM3D8vDu05B4rcDCmLTebpv2ZaZ3+xEVF/P222aaB1JoyoUiFGZD1Ryo70659sVvtRqf",
+	"7FC1/ddUmK5z62m7dbU1lFvuoll7I9Wx0SbdElAsssXjRNp4I9Z/ozXkepT1IS6jTJiArF9cTv+/m1wM",
+	"u7Za6G1+rlwRGW0qQecPNdbKNrY2PzEKkrsKXc3PjcHV9bNabLknX0SoX8UYzDxak2dauj2fPlhj8L7F",
+	"d46MvxbG3/ins8JeDyfcvZ9wzdep91yEcnzK/64CiOEwZUPv22jKEcX/LqkrXx+9eXf2otVu/XT87qTV",
+	"hvSkc9O6UpIWGl6rGLX1snCfRkau/wR5N2uMWseuLOnbwi5L56TCBD9LTVFRW93LlApNfLFiRY32inD7",
+	"fpaK59NGTtnQmh3PK5F8x6/3dLALN5veaEJSprNUKGJ21sCu9i5ImGmNi1N7OAYJK+HWad2K0JQRMN1W",
+	"/BJSruoR46k1L4GTPnY19yMTYV4PHLm5ueV2QCqmUQQ2K9Se0RWmHlQJeTIKtfalHplKVePRLs8NO2Pm",
+	"h3nmI5od8/bcpKj0h1UsyFKuJ6embTuZDiKZhQdSXnC2l1lf3/LbgwJk7+0RGbO+yzNhSsMDCkiRZP45",
+	"TVX055/KZhQoqBAS/orBZIHa3spU0+hMXjCxqM1ACmXWKciVRSOizQ2mWRg6CBrNaFo09hlpneStLK3f",
+	"PFPTOj/DbnIgK88jxWvIogueKwFUbba8lz6xql0mxNBbF3bOhZlu0xtNR8pJo7gYmu0uxLtWbfKvjKUT",
+	"l6sX6mzD5IupMPV7tQTMuYgHzCkd3PvYS2gwYmSn02u1WxlkmjLPtNvtjsfjDoVfIdigu1V1fzk6ePHm",
+	"9MXWTqfXGek4KtpkTHudD2Kr3XJm4a3d1nan1+mZG8yiSBPe2m09gUvW+RrmXJcmvHu53aVJAv8eMl0V",
+	"JFxpM93gqfITTogbaX7aM/eaOvPMzHUyb1qk+5YOuTDb5V/NgHYSOmSgaln9NpAVRnr6sN/wIDu9ng2h",
+	"n2eSAN2T1Sx1/6msvYr98hvYxZjntFNvsaYrz3AB0PLtwk64De1/rtaZfRq6rfecHu7z5wV5C13ualjK",
+	"owhUci6/R1XSQiVjBsb0bisOllkBA7t5La3KJ4g4E5qwNJUpecQ6w06bxDQy+28W5hWqidD0qk24sDo+",
+	"f92dP5NBSmNQ9MqUhCxgCXyuvlQqM83F8LEbzu21D+ci3WiD971JzSY88ZO1P/GhTPs8DJlYbf5kImSp",
+	"0lKGpfnSz0yXB5liYJmaDybhGp7g6QY+ATCUFTQ6hZ69MPNvtWdhAozZQOlPBclyfbERdKEzrDXzPoF0",
+	"h+YHrq0J6CCLBs6hsTAM7lHX/7KW5ztd/KRfX7bSz4V4Dmv/lmuPKOYHaa/03u0iNk0cAdYcdKggJaqR",
+	"bx/NlaK07H7i4WcrKyOmq7VzNjecmWI0SeaFZ15iL0nmBSgQnYuS4vgBnJqn8GmNyKZjc7tpDuYl7reV",
+	"Gw7vgub9oEG8mM1rrhJ3U7ANi4mZkyNGzWLj0T9TbJBFHYIiFUUqitTWt/ZDW+sTvJH6UGai6fsqn22F",
+	"PIS3NuAiNJPYChySMndqaV9QzUsBp1b71sdesEowZI+kcqeBUjDCrrjSCpkCmeIeMUW7esP9kmmfSnSe",
+	"Gl4yfU94Ya07dNydI0ogSiBKIEogSqB6wqonutYrpus8keD4VKql+VbnmQOynxdScd5R+oCptC/DydrA",
+	"oyKZ7efyCaFL+b4x9KlOkYowhDCEMIQwhDCEMPSwYcgFSOrmCfwXWjnk9nZmPFNu8+WXWcjFMzXFfQbB",
+	"40LhGS5iV0kEjlwDGinm7HTAiGQKSq6Lb1M54GCGPh3C3G7prqf4nrWhamrpwaVY1TjE32INQ5bf9guP",
+	"uT4eDBTTHQl/Vr0LbEeb3DQ7YY7TkKX7E/jDxbAjzf+sraL9yWbtYmY7kRvnIIYihiKGosUMUtjDojDn",
+	"QLgQpjyp+bDwj15cJSzlsdnPRI8Xs1v30zRk/0LbG4juBivubBdIf0J42KmjOnvjrGBrpO4qZRNAIx2U",
+	"4ijFUZmEyiTEGMSYO4sx9RzRhGQWWPesTiYv2Zy6aX9iMxfdFzRZn2bCjdkcx6E+AkkGSQZJBkkGSeZh",
+	"kUwNdDTDmGqjIZs9pGsDERMKEd3nGqjlmXeJYqm+Z5qW9RsYzZDMe5leDCI59uPlMrjcss3R2vBqZyEP",
+	"3H6nwJffzuRcYJgCAAguVjdxWepUFmlkRGREZERkRGREZMS7z4izQHctWqw4vnPZNJcEmMlLLTC4OpqW",
+	"uYadlX8edU9NrFxcoEMemdnowtDmL/HouZngNjXMytZY7h248Tev4q35UXVsCFymWjephF3ZJFGn66iM",
+	"K5Wx0CaUu3k9+2wgU3bDp0uoCFsP1ebNDci1Td0W3b9pCzfXNhq24SYBNwlo2IaMjIZtM6h6Ex6eM2db",
+	"DsewRNBpPoTcq6EBNO9PDqal76iWFUkVSRVJFUkVSRVJFUkVSRVJdX2kuvic3x2LugrtvLKp/ERoqou4",
+	"MN8Pi1XnXJyLsxFXRI1kFpnlxSYVCMwYh4QPYPmA8U0ZVVKQMSOC2VXaN1BUP2da8WmOXCHTmEbE0TQJ",
+	"JkHEoM33I39Ka65T4etq13TUToE+IzFNL+zBrrvDHgRryF9vu+OL+kNgSJECK6DUNJrJXeKbmg7HGzZe",
+	"1AFfq19WXdbEvsuOLuT40eO8S4Jd6fLTf6NInw25MBdAdw+7BOHi1MNCwGL3Whi8BkinaJM8kDiLNE8i",
+	"Nt1k8EHdiNnEDiTkA0jXpt2HGnCmai097PxxgIIGHtVmC254/FglWcNAMqvZTzRLg1HqUYXzNtpTIIAi",
+	"gCKAIoAigC41Jyhw2DrVpYWr7v8augTnvTE4dGywNMcemLyOcMxLDlM60OSRTAmjacRZ+jjP+EqFeWW2",
+	"rWXexE6QTtWvR77Dd1oPWxXxr/Bg6AGNDIMMgzahaBOKEIcQd+c9oFeCuEWOz3lFpD8hR88X+TsjOH3h",
+	"njYxqnVnxov6nU/6P1oRF0y1Pravo4l64U+nZ/VRt+BJnivD8DQVQRBBEEEQQRBB8OE5kN+eKq9Lw0sz",
+	"vPU5K/ZsgeIp7TcKFHTwEvOTUquyK59+hpIp8Y0m52bEU3lZquW81TZTHY6sXS9U6Sx4vnZ/YqpTKpT9",
+	"dsb+6JtmWsZU8yDvAg2sBLBKRHcqPh4xUfEsmXrONOWR+sbdpsiAswi+Uk2dovK85fp53nKlarHagYwb",
+	"POToexHnCOkU6RTpFOkU6RTp9GHS6WoweAv0arFyAb067izoQ6kITf9STdgVC0CsWDM8OjHdImMX+2dq",
+	"XwksCznkYfYoJsJKUs0tKTPlKw2kGPBhZr4vb0qY2PwjkHV2pgkvJQxvjqc2mt6lZvdcbJG/4Lj8r91K",
+	"s0nlTlSLvWn7klHm6mJGOsmYKWJdWqDamIqMRn/aEaXRnwLw5Trt5H2ebacOlt1LuvOmiwjLCMsIywjL",
+	"CMsIywjLDx6WT9mMc8sMMG0ej+EYuPvJ/FnVbBO8URoZXP5iCyKzfZGe2neLhqAIjQiNCI0IjQiNCI33",
+	"yhDUg1gTv/KsQgP6zoUZbUZ2tjSSHZLdF/LMNnPOerQdp3YyfqGo+8VvAHWYiKOIo4ijiKOIow8LR2vp",
+	"ccOay5TpdFJ/rH9ifnZWo35C5uf7MPCUDCg3L82wT5zoTVqFQmcb24RC3xGr8ZAbAREBEQERAREBEQHx",
+	"zgLiNUhs8/So6VU3ZQGNgiyimi3iyLxQgXG/UUTTKxdsUpFHU3NOmiREMe0jF/mOfKNmrTsfQzRKqdku",
+	"CUZmpVAk5sORBmkwaZOQ+aiPUrjl5Mrce8lDltYSZKG7jjzO6BWiJKIkoiSiJKIkoiSiJKLkHUbJ5TC2",
+	"eXa8lDysB8bfJA+XB7cc0UvmVuwoZTR0/i9e6WiaYCFoJE195Sjq9jXHNL0wXwNVrrT1rsmUFbIuM9GE",
+	"jOR4ZqbZ4sU48XU0adpGn5t7cnxeeJkrhDVHikWKRYpFikWKRYpFil0Lxc4Q4lqB1YZ1rIXTUgahuawy",
+	"5JHVRD6e9zrPlJVVweIK/Jee+7mPuR7JTBN2ZV4H19HkXFCl+FDYtDwwSfKhyI/gpzV6f3LG9YilZjLI",
+	"AOaCvRHWBqjKsTEXZEhNUXPRuphDos5iyiSuzsVsop+8RejDXqn8bHIgPgA/e11wUalv3pX0+XkmPjXR",
+	"9BF9DKyY6mA0V5aKwt5hvvrFuX5+4YLdh2yjmyXj6VgpR4ObSPmzUkdOIAsPpvhBqEaoxhQ/yJTIlI1S",
+	"/Ex1etekSnc4vTgHumHCmdNstSjv+dtpmRn+aBLXnIsgykK2lwYjs7i3KgOau/sdN/SljBgV14idfr0M",
+	"fe4Ba+OiP9A03m5Yrp3Ge9H9m07j7drGNN6IWIhYiFiIWA8UsdaTrHuGls7FudifASjId1hWnCvQ/1TZ",
+	"EHJhFlgr/MlBnp77kqUpD5k6F+4c2S9I8E5nw0tq6ao2X6qZBb5An43oJZepzV7tTpJ5kHdkSYJpJzpb",
+	"G9XZuEY2nKa5eUdQVYMcgRyBHIEcgRzRLBtzFRjcTGvT/cQXx/BzOpR5FqiNu2xvmEr05edHfPG5EQaD",
+	"Q1mKshRtidCWCGECYeLm6TYWSPQbZQee0xZAkuAFOYI3yAhfxyHOLXj4XUeXgLoB5BnkGeQZ5BnkmXuS",
+	"3LaWPW4a4bap2sOW37TW43bORr5wkFREGkQaRBpEGkQaRJqHHSD1hmc93vhCLbbNzYvNG2mY3w/yWuao",
+	"Zokxpr/z2tacCyvYnzSpAhQ+vh7zOB1nHGxzIoTXqwMQ7lp3Jik3L/lFTHl0vRpU1v8nC/QK9r4s/NXU",
+	"sqqZcPE2ayq8SX1W8RkR/RD9EP3Q0gXJ52FZzE5Ro6GRbL15qS1WcGPehPIkr/6WFSXldlFOopxEOYly",
+	"EuXkQ5STVfv9pVadPiHgNOoKnJfMi1FbcKVoIPyhxFhGKYxSGKUwHlTgQQViCG7XFxmGLqOMl0wjYiBi",
+	"IGIgYiBiIGIgYiBiVJ8ILLTUXEYZtuAdBw08xEC2QbZBtkG2QbZBtrmPpzgh62fDbsx0yoN6y80TprNU",
+	"KAKliStNHnFBjhMmXrt/25Bfj2EM4a2ILO6zlMgB4WLIFHTRzERFFBcBIzEXoYCcou/ODvLY+sUqD+wM",
+	"f6Qem8di2tyfTkhIJ4RqEvPC7VV6nuemv66u1lK60OxKd5OI8pm3NYtGCBAIEAgQaAWB8vPBuX7CRPAC",
+	"sOAgAYKmLFnNl60jFpvOLQ9XXixtw1pGEbwZZ4CvICTjgFGdpUx1CCS/YSJMJBewMsPrCF3CGBrGXHCl",
+	"jTS8ZCTJ0kSab1OKaNI5F2eSDJjP5VJqGeJ55vE0XdskiRhVEKAK7vBP6LvW/eT+7xWbHKdHzz+Xnj3v",
+	"ZedcHA1IYpZ7I0lspvDQfmKaXjBzjQVmSQwYPK1pK/HeAflrIRBKy/CIka9VPiQviiM/p3gpv4BDHmmb",
+	"raY/IXEWaZ5EbDrOhkneGQm1S/76L3f1R/d3a/s86/V2vpu9vPNXqzr+hytQHQBkBjKqQrQ36bl/J+We",
+	"u6s/eqWV7/rc9dq+ez+QTfa9MGuIqWHmIQo/n00S9iO8UxbaJ5n90UXYr3ucmeKrx2R5MVMBxtR3NxUG",
+	"5tqeWMvq2HRs/dlF5BrJjpD8kfyR/JH8kfzvAflXUnqB/ouyYqGPdPH+7qfCv46sBXWtVVMRjfoTwsNK",
+	"dVehH/sTyI+4/NCx1IkHYuhUGCcU6ijUUajjeSCeByLVPKjzwObMcrlcgzl7vDfmRs6YYecxIykVQ5s6",
+	"+8imloY5BxoZAoDiP79cJ8g1ccMJC1BElSbf75CRzOrixry4bKLtO9U01SSkmm1Bz7ggJ4cH5MmTJ8/c",
+	"6aXtpgiiTPFL1mnVpXy0z7unD1MZl7RHtprWbitvpQJu5hRiL0S41m6dyTV06mhQfiuRWf8sB8No+1ea",
+	"FzCvnQA2gqYZbihOCQ8nZp2BuVldgw2hXF2FzPR8LTXDMaIKltFWRaTDUgbO+YXG6vmPnttk64EhGGXm",
+	"qpHuztyv8gWErSVxouuacvrVyvb8byuoZpe2vK4vYfA1zX+9jln/JjdacNNOS3feUNes1Y1Wpn3d7vXa",
+	"rZhe8TiL/b+4cP/KO2NEzxBsE2+662mkuz5yywSsmRWaa9wQ4YYIN0So5cT9wMPTcs6QfFHJaS/Ux0qy",
+	"YkWZuWaZRqakT3UwKsjSgYwiOfbz6iCSmZVCKjc6sIebc4xvK88pv5lrQmDqty2vOMhONH5u19W3BU/2",
+	"n9eUwAsk701cIu7i8yJpIGkgaSBpIGk8GM2jB4mCktEb3C1WM+ZmeZUqwENfRyOTP7A8M0VOo2xYs7Ev",
+	"/r4+s7e85ZepzJL9ib1qut0kiZgLKO3yqoXVagd3f5Wu6yHapLmZcW17tEX334Ytmp/ZaIeG3ITchNyE",
+	"3IQnthWZxSq1Ml52EJoywrgesZQ4y3kYT001Dzpkz8OVeVX+dz6YIlLJZ4Nqs3RYmX8uDuW0So9oZCIz",
+	"s9aThCpFaGhnM43IwNKOndfwwsybcqvWeMQECWgUZBE1623eqcys0W3Sp8p0W8CMgSa/UWRoMYoMOItC",
+	"1TkXxyJyhOWOHU/fvQaHkoPjd2/OCB0OUza0C6AZFJUliUy1c50puH7kQ+dkVp+RDKJ6hCSimqXuiJI6",
+	"FKsLC36Yu31sIqCGq902dSSSTKtmiqTtdXdhJS6B92HDqud2OKYACDGYW6aMItT8nEUaOQY5BjkGOQY5",
+	"5uFYnnlR3P3k/u9ocZzxaa55jw02Nte5MEwQFH/gKhfbZioWBLzIxTk5GlTf0QaxVfJxnVbgZZdZhrhu",
+	"wwdtb/Rz3NcYSmYXPDoYsEBb+1IwairU3DkX4OobMypU2xCZAasxFdrMrqCYnsTXa62wzJylMSMXbNL2",
+	"3rRess57G5uegrttyi65zFS5xIheMiem7NiHZMBTpQ2JUSPJck/hPlVc1QV2n4LQcreE/I2vnra2RDnf",
+	"zk+TsxGz71NI4r4XENFMhE54gIcxfMb2/ZmRGTFqFmwSU/gmM8UGWdQhiCWIJYgl6BGAXIZcds/1SwtC",
+	"rpd5q8o18UvI/t4X1XCgxgLRANEA0QDRANHgwahshiltFO7MlqsPdFZSgawx2JlrtxzmrBhc4Uahzkoh",
+	"HY5TRw2mlGv31kOhvbTvA4OgfYVB0I6sJZdXqa1m//U8vwnNv5bdBB/BtY2/6u9eh+kXFZPjgd0IrRh2",
+	"Dvo1P8/aiyuAu976lWQqHT7i1ga3Nri1wcNYJHsk+3qy736Cv0sOYn+TPDSTiFretoeXZpbZQ7dIiiFL",
+	"7eLRhlgfkinxjUVfiHpAuCCDLAVjtT6NzOuYmoVJoTpkton8MDVlOpU0MAttNLE1MjhfbUM34B4xsQZl",
+	"9jswSx2NUkbDiVvutE55P9NWHOTbBjsTUmbmiD0XHGRT47TCEXA/S6FHY2E/q7wGZyvnAqnlp7lwvEqJ",
+	"4mIY+bbMwjmR2dSwrrhJgRNeKggXHAJE0Nh88WZXs93r2dNeJcmApuS7nutdblvl6msXnuuR32EU2+Ba",
+	"sWjwmIxlFoW+i/5dyAH5tgcH5Kb/cLJ8KbnbwECl7bxsnwUyZor0pmep3/WmB822e7nYNl8YvK6qHY15",
+	"6RZ7mqiR3UzFA2REKUQp1BJ/5Vrib3vP1j4AB1IMIh7oFSdsAEu+t2eSRlYZWZhDVOCqnVoa+dFRmmqQ",
+	"DnUTFYkZifmhEDNEdbL00jWAkbBuMGLBhcx0VzGlDMiaZ6j227AG/cTfQdwddU4Gp9DAgSt9agtvyOVg",
+	"QYsOOW7bA2Fhj1b2mUTfBGQ4ZDhkODzpR7p5aHSzlyQzoTliml4wnUQ0YN3IeigsO+D3r8+slMpvB2iS",
+	"kEJd1efVr6cFfvFtzel6mh1IsvDXjKWTVc8xi7fZs8xNGhbOP6/5g3aGSB9IH3gYh8IXhe+88O1+0pOE",
+	"Lc4XRIuilrg7SX8CeRUrDfTnJVGjQxZtsyfWn7AsGsa9JLHJE29ZxqJ8RfmK8hXlK8pXlK+18rXLhdI0",
+	"ikzRCzap19Qf2XJm/hWF7iWnZO/tEXnFJvMCtyCT9pJk7+3RKzZx9ay83y3VxacVOeHSARFtJez1zgKS",
+	"1HRecyuaKbRRaRUBz3vBJvlK6Czb01nDF/Ob1db7WzrzqTk8Y8wl6KAxKygVfMfNnHevzKeVMWu6YuVc",
+	"QhA5qvCauGbxN4oUmuhUZQkpEM4ffgg+5uWktQu/cQDv1b6SvSTZpwq9EpFmkGaQZpBmkGYa0Iw0n8JO",
+	"rfKgADM0SQBijvcyPeqcixPwNFOEkncnv8BiDDnEzMuCImSn0yODSI4X4g4U3XHNvGT63ckv90XRcACC",
+	"Zy9JILnaKss1imcUzyieUTyjeEbxbMRjN/8gagX1Xv7JWIlKAhmyzrn4jaV8wJkqyGXzi/WqvwpGVAwZ",
+	"+OKA6zzR8sIsQ8KssIOUqZG90liC591YWW1hq/H3Q0sHMmTg33Fq5KFSb01p1QGr4iZH+M2rNENy0xrt",
+	"CmLrg4mw9gr/LL7ytVeepbxJpUvffIWeqQBYT+zyVp68JyzkKQvccyHwIPAg8CDwIPDcN+BxMLDIWNCW",
+	"qbEGZC4x1uZzYkNTmKESJRlKMpRkKMketiRzcqc+qdKBj7sP0qvOJ8/KlM344EHdtpnbdrZzohId6lCU",
+	"oihFUYqiFEVpA1E6ty3sfoK/R+Ex5BdcGFDKRrusl7f2dy9vlx8ml1peeKoc06tfmBjqUWv3u2/brZgL",
+	"/89t05A2H1Nrt/Xff9Ctv3tbzz7+56P/2v0z/8fj//Mf//e//+htff/xj97Ws72tn35+9frN262z37Y+",
+	"0K3RPy9ikWzpy62/P37aefr5PyrszjAeEYpeFL0oelH0oui9wS52kZ+YKWUTt8B4Rdmw2j/sIQjX3hfc",
+	"JOOmFyUvSl6MIoPogejxcHb9XZveou6IGGKxOEYxXxhEC+6Q6stz2ALF7iG4NDDaMn9sIBvzDbZWu0XL",
+	"FW8YcxHKcdPUH3M3nvGYfZBi1Zt9OpYVxwNSxrxMZZbsT1a8d+jv2jg6Qnt57MJ2S7Mr3Q3UZbma2YmB",
+	"tIm0ibSJtIm0ibSJtFlBmz4z3GKbxDwVofWRqDl0yi0UT32lqB27TmI8hBaEFoQWPJxCmf3AZbaQmg98",
+	"b4MRFYJFDXIJF28j/rZqcf2mUPTAN7AkOe5Mmtbq5ggX0wctZZ0t52v90Qj5v24n1WvNY3BlJuy1n8Pd",
+	"/iM0vOqTuJvvbtbaigl07cSyTevatL6poh8VCWIR0xDTENMQ0xDTHgKmqSyOaTrxmFXJCq0pzRVFyHxO",
+	"rKVeNIKNK5uoc6ypkFgbcrOpaMl24Qsluqp6cvTEQVGOohxFOYpyFOULRflU3lbI2sbSfJnCpvvJ/d+S",
+	"JPGncqCdUqWyQ6Q/ITwEJcSxCOq6baaG18xwXUjCbj50uFznLVQNEcsPcPKnW3h440Jdt3Zbve2X3z39",
+	"8P3Tp3uH7/de/fRie+fN772DX58d/tQqH+OgmxByAXIBmo+g+QiCEYLRbYJR7l58IzBa6Ga1gHCqvK3u",
+	"N5z0vhp9COo3kGOQY5BjkGOQY+4+xxjUuCHCJFkFwrxLQlqjpZmnF1v43gHM13q2hCyFLIUshSyFLIUs",
+	"hSy1PpZyzLOhwzKYYqvaNtublls2v7CVL7FrhiRlxDzkluYxI1yQk8MD8uTJk2dmLYip7pwLsBpW/BKc",
+	"66sse8G7vBrNdno7T7Z621u97bPe9i781+n1tj+02i1bf2u3lTdf7eVe7vELEd64v1reVm8Pwc/cpd2P",
+	"s0jzJGJkwKjOUkZ4qMwndsEmqmxn7Qr86P5ubZ9nvd7Od7OXd/6qeyG2QOkpG7tiNXwI5x9X/xCuwI/u",
+	"r3+I2cu1D+E9+zf5EGkWwWso99xc/bG3/fMPP+/84/cPO2+evt///VXv2YvnHw73Tz+8ts8xLfTtybe/",
+	"ffhp+4feq5NXv3735M3+zm97T+ueytxW/Ugz261fjp6TR+8Ev2SpolE0Ie8E/1fGyC/sigdymNJkxAP4",
+	"4VSmGhb4I4CrAWfp4w4Y5d/iBum6byA/wp99Ce4HP8T/+On773/4x37v6Xc/n/Z++OHtwe9n9j2Uy51u",
+	"n2y/fPbitzff7Zy83Hmy9+z1dz/XvYrpOv4g3sZX6T8BYmot3hP1Nd2m7wT0Aj0ncAuNW2g0t8QdJHpO",
+	"zHlOML8xW8fmsfsJ/jory6amB3BPQ8MDEGiNtPauJwt19l/KLMA+BUphlMIohVGRjYpsxJAHbhTAnFi/",
+	"GYSkWcRWVWDDPcv11ydQ9U3CckBDdz0mR8OH+CIBOVZUdXdvWc+9Xg3eudgjF2xi1iNKMnurxdicsDJl",
+	"4Yrb2ybWgdbCgHnss+Pnx7vWwwZqma5TSkaZXbMlUVmSyFSTvtQjAr2mIiSvTNMC1jtFY0ZUwgIQcoEM",
+	"2ZAJ80F92Vhx11UA2+lOg7JDV702eO/kw5M3z1+8Ojv97duTk8PDX7979vLp4d5vFdrgnd+f/uPbN29e",
+	"/nr6ZOfg8Ift98+evnhyLW3wXVWvmlV0LdrV2opuU7lqOoG6VdzV4a4Odau4qUHd6pxuNXWbhk2FpDH1",
+	"N4lHc2IP+TdtMGya+Woi0cAzYxgalN0ou1F2o+xG2X2NMDTOOG4NSsnuJ/PnutFnwCxwcegZazm4jrgz",
+	"DhaWH7DaJ8KIM4gAiAB4KIuHsshAyED3L+LMSgzUPNxMAWmWmXzdJyDpfR26DtRdILgguCC4ILgguNxD",
+	"a7IVmaVxfJnq85b54DJ3nFi+ylMiJCckJyQnJCckJyQnJKeNBpTZwLFXVzNr2lJt4nJmXlSNhkgxEZpZ",
+	"aV6g0s5ZcMz1iKRUhDImIdV0nspMlfdVi7T9lTgloskMwhPCE8ITwhPC00NLFn49Khqz/kjKi6665Ff1",
+	"OHRAo6hPgwvCRJhILrT15epPyOklvzIvBCqdENqXmSY5+NCoNh7fCQNBZe4/nhb30RQ2ofOZaeq9ffKV",
+	"dD5ovoM4gjiCFrwojVEaL1NlOAFnJeS8RLyOPiOJqGgQTgCKVUcQeAs1rBg1AOr7+gMFWPdpAyWmwx2z",
+	"gGqd8n6mWY1LMw8fcqTRfKQu2GTpUF2wSZOxulEMgHW46K9rOISd9h3zzs1nmY+Pqh+g32zZ0jjR0IoG",
+	"Gr1NzeeoOSs6zJtVcQje5v6KtEF9zVKiJzBlQsaSY3/1K/KjN2vJtX3na2/etL+8aRh95JHSkdKR0pHS",
+	"0UfeQHPiqNgDuZER13SHB2io8YA31W5It2Wqto3ctos7PBSe0aG4RXGL4hbFLYrbZm7tiZWFiyXurOqr",
+	"+8n8OQqP01ds8rkr2NUCE56SWA5TOtDEb+Zh/oGkPhdH5qvTWSqU6zofmLdpz3RolDIaTlx/CReuIpkS",
+	"2xMSSmbXrpQNWMpEYOdCRME2KMn6EVcjFvqm59HgDRs/N3U6OFhuDlQYgoU2QVRMjgcV2r07p866Azqm",
+	"j+3W1dZQbs2pnqqufkQaQxpDGkOLKbSYQhxFHP2SOPomR8Mb8WjjIEpAkdMDymLwJAuY142XtCI9Yowk",
+	"JBgkGCQYJBgkGCSYexAjqRG+LAyG5NGEhy5bdYecLVBkERC4OkuFmYEDU07bl5opVh1CaZ2MgsqtO6Pc",
+	"6n055RYqqxD1EPUQ9RD1EPXuR1Sphpy3KIDUFPTqIkfdcWXSZqyr7NDcdmgoRB5EHkQeRB5EHkSehxwO",
+	"6mbHc91kRFWTRMy2HOGixo7bu1C+tfXdSUZa5P5mHusBugN+PS51MK+u71RXf/utuNWZ5tG3DvEV8RWN",
+	"/ZHe0LcOfOtKSHVTJztwsTM11jPa1NfuLlPaBjVZMCxfzlkQmkcbdYQIhAiECIQIhIhGHoNzgv/G2iD7",
+	"b5BGr9hkoQm3N7IqgUfRdtv+cBPj7TuuUarpph/dhZ3dgJIHrcqROZA58NwNz90QuhC6rm9VDlwzcNEO",
+	"bmJfvkRn46zDEYI2DEG9L6zJQc0MUhJSElISUhJS0j0xyF4VkRaaZi+mpKl1NoLS+kFpg4dtX852HBEN",
+	"EQ0RDRENEQ0R7QEbkK/t5NCGQagPOvrWFlgYDNyVwZBNeLiGTIJMgkyCTIJM8oCYxDPCDVkkE0tp5J0v",
+	"spBH8lJIJEgkSCRIJEgkSCRIJA9JS5JzwspMIlNNo67zP/4Ef0+jbPi5ax3G6zzufzW/EigOH2Mghcpi",
+	"lhJbYYecGWHMRJhILqyAMj0MoglhV4lU/kX7+1SHrL/KOVKCJt5Cda9NO41gKR+TWz/WWu4wDk8BT9Ux",
+	"X39rtVu0XPGGMRehHDd1hp+78YzH7IMUq948gPgGL1OZJfuTFe8d+rs2aUs1be8E/Nfg69TsSncDdVmu",
+	"ZvYV47keEisSKxIrEisS6wMgVhZkKdcTQK2DSGahhbEzecHEXmZo6Y+PRlTn/Ao/VyKrNvcsCQlly9SE",
+	"gZq2XGGIxa6SSIastTugkWLVMZQiHnNdiqKUv4adpxD7iMdZ3Nrd7vUACN2/cs4zL33I0jUYeufRmxaa",
+	"E00fuCKKEoIIggiCCHrnoxx+AHJ4TrwuTY0/o4yxkrU2dk9B0mzIMrcoy27ZKne2aRSbKDZRbKLYRLH5",
+	"4MRm3a6069Y2aoPRVMvWo7yMqhavivQn5Og5DHbW/ycL9LzAnVYys5+9rtRNUtOA5lZw8nBRvwkt9dd2",
+	"t1MVstf1f3FlUTTz+GYhpMVnnzsg8Vekrb4RCqBlCcp5lPMo51HOo5xfXc47abRE8exLVaueT30dt6H2",
+	"dY2hyhdlGso0lGko0x62TMtlT73S912iWKpVYetFrF5XmbHLErtl9b+di3NxNIDRd5dIKJkS32hrtNA2",
+	"sw3GtM98sO/O3C3WvqFUNqGpWVPMq4YmQzLmegR3Jam85CELyYCzKFRVkTbMI3jRd/3d8CoS1rZZLWfX",
+	"q55GuY9yH+U+yn2U+yj3ryH3K3az3U/u/47C47RhNHUvunMl9QWb1EVIn0ri5fb25Z4sNLpHN0IUkCgg",
+	"UUCigEQBudaNcW0c7GZC7yXTX0zirc/SKd9B4o4RBSIKRPRSQi8lJALcMtdtmbtmZdMRi03flqeqL5ae",
+	"sXQihzIlwYgFF2a6FQoSGhjJ1TbbT3iJ3UsaZazgFC+UZjRceOz8otjNDeNJu5knFRdBlIXM6grCapcq",
+	"d7troS9lxKi4Ld+pwpihQh3xCPEI9QVIBw+bDopitHka9OOECQgXAuuEHqWMESNNFJGDEhLs2kg4LGwT",
+	"J+vakEZbGVIPOsS8TXMjcQbbExKa8jEXzC7d8GO5UnsXfLLRxMzVAaM6S20ybrt+m/GjmpsJkZ+2FwEE",
+	"alUJC/jArGtclGaLW+6p73vpVsFYqAjNG6VKyYBPD/bdXY/BomCL7NunLnNSyAZcMDcI05ocFZnWyXnr",
+	"wHy8ipHT0+OZFfa81TFVn9rbSzVHTJOJzEhClSI0kmJovd4GfJhZjjKzOmJkmFJhhM9sq++U/fq5yvsF",
+	"j/UP8jtRTJtb1HmLPDINTEfOtvAYuvV6ftAUGdFLRmIqJvBIAVVMte2a4yolWUIyIzO3+tRUbLtlXieP",
+	"E1uLKWVebMSuQMZwI3+V4Z4OIS9soMddmBtBprSMLRdAg9u9Xq9H9o68SX6YpX6Rg0YNAHAZmok2M1Xg",
+	"Ne6RIb9kIlebmWqliCb2scyWkQYg2R8JKbZcmt3HpWmTsNQP6Cs26ZCjAbwnnU4g2JN3UBRsXLrNEvX0",
+	"Rrty0yhlNJzAhKfCN164r12az7CCDSiP/Az9tvfMLgqF7MGlKQpLq8tob7rp+CqWIR9MCNdt+/j2SUEa",
+	"VrtQFoHzNlSI63fRLDyBfaQjkWRaNbOH2d5EN1YidVhs7bTKtSCmAGCdf8NmFpmfs0gj2SPZI9mbJ3i2",
+	"9ic4kGIQ8UCv+L4CmUWhe2NO/pmPNkfawFU7JR2vFTV8wbxMq3pPuH/B/cudjxrqgzuUAKbVdIezskq0",
+	"+6nwL1PiMIezz12g6gZaU1uOcKUyZs11yt23W5wikBnk7DO3cwgJ43rEUtI3MKYIh1lQwMtKxWlhIF7a",
+	"fm5ebVpRYe3wfW0q2YZNyDRk6f6kVPeiDwHG/tjddPuKX2getb/IiMiIqP1FekLt7+raX0sPXotJSZ+N",
+	"6CWXqdlq5HpFq1ez+qsKPSoQzgSwBpRosLExYwTrq32xoJYKSSqjyLwvkmYRU20zfcUFfJL2FTkF1bQ/",
+	"Yx4yklIxhM2P0yS64OXK68AUF0OvBzVLOIml2WxR87WbGkMpvtG2b1o6/SAPwJHLaesEGzuQ65DfXR9A",
+	"LQZY5xkPRsAq6CqGQXn9oinsnkAR6vSNNDbfsnkIO5rw4ToSdLFWwnyRncNHWydX5uHYYAD2fkyPzZJu",
+	"oNFeMv2ycUtEaC9fJdxpis31DjkFNTko2vtSj0yFMRUh1TKdQOOFcTAP42YHjBwlScplyvUk1/PCM5SV",
+	"/DwlAFH2QVmH/CLHLCUii/ssdTWN+NAAr6+ubV9jj/SZX6+ghNJ5kWJn8mlGi5PLdwk++tCKf5ppGZvx",
+	"MFXGVGQ0Iikzb9SU9BNcWeMGl12oTSgJKY8mxcq5IuxfGUSBKVQAT69o7N8Ou2TphIR0Qh7xoZCglc7n",
+	"u9e327OEk9nLfsKPTZ0jmiRMwFdhlz6zlsE7o5FZz+BLcI1SbfV9THfIvv35zz2zmv15Yi6SH8nrozeP",
+	"XtMr3+QezMM2eb33j0f+hn02kCmzd7TJay7KhR8/Lg+/11+MzGcZEmm65PSPJWVy6BIkcHgUJlSWunnv",
+	"H4SrfPpwpXlAUjakaRiZj1wOyHgE89sUM6DOWVinnLYkfIf3QJtXecMQFfTeX1Dt7fYtqPvGfQ3ua1D3",
+	"jbpv3L3h7u32NNtmyFMe2kCQWZVJkC0AJiVlW4LARd2osG4wE7cUCYPD6bo1EZID7aBQuULskstMzRlI",
+	"lGpwT7jlrVcSylMwt6itgqvcoMIxqJlXUo9YOuaK2TggeRgQU40fjKllBRD6XGYv614LfcySYUpDs30N",
+	"5Vj4//ftOC52zFt4q/CxO96qGEBn7eRYBhbBv1kqoQ3NYzaPvu413aZlxt1GYLT6QPJF8kV3twfh7obo",
+	"j+iP6I/oX0J/cM6rtWkpQ68awWdrQ8s4yxZ7/gKOgJbsmRjINHAnFXtlJ0LnRqBGNLVzYUTVnjvB8S4C",
+	"1uicp8S6DfoRslFu4izSPImYA+tpIHhiakyZzlJhRB9YmUtR6RoANH9ok/deMsFBoZ8yqqRQbe+tOJbp",
+	"hTtNgnOR0gjCcy4yyHnJivY4v8EQ321znCrbGLMHKRnGuBOT1m5rp7fzZKu3vdXbPutt78J/nV5v+0Or",
+	"3TJQRnVrtxVSzbZcHbcZMmLuzaB5DMI0wjTCNMaOQMxEzFwXZi4Pz1ihTU7ZpbwwNJc7CJpXWfDCdNTV",
+	"IXtqauZT77lX76TXtrYE562YDw25ieF5y/9sbYS8dZDzgwPVcDTj+UgVGbMo6pyLvbzT3gM2y7HYGfWM",
+	"uNIy5QGNnPGCatvKKwYikUkWUa8cd5rrPU0MLylN46RD3pv+OysIZ4plfiV9sN2A77w9B8BcEaXNrA6k",
+	"UDy0KwUYCrWLvoDw7CnTqXTWTQUVtvcptZ8IV4THkBLJ6uvbhMZSDB2gA2uoNqGZWX3EsC725telsMZ4",
+	"noigiKCIoIigiKCIoF/SRL02xmmRafoTwsNNBCQrq/HuPpj0vvjZNarPkF2QXZBdkF2QXVB9tlB91rXq",
+	"oknt2ewJnHaqolrJe9FQETqnspBqWu9E5rVHrilQVKkEgk4FqVRqet4KDkUEZr11BNvPUhHKsfjJ3Zq6",
+	"3oDthuZCZiqvVg6IYkN4SlC7ucNffw3ObhUD9DKyYuLacR5xzqnIBUXQue9b3/Vg6oXmHrMY9Av6+p6b",
+	"giyc7evYXa8aKxczjImUmynujoK9l5Kwp5hmQTBjbW6IuNJTFzLb97F5VOvEZnqrwXTTnnCbX6H5Zdjp",
+	"On3X6LM9O11PNU1hgEBJaR04tYQpOCnOzF2SHwybkTo5PCBPnjx5RuyId8hzu0rkyuGIKu393V4ycz3N",
+	"hHU1dSXMG8kiaqeINRwqxBeEETUvoeqI26ztGzrinhugFyJc8/AIObZZDI1kFnJsHl2Q4boHScvbGiL7",
+	"ISv+N6vpiv2kTm2B+sm6SFq8n1ZR0QMIaclj9rfhGbCCgWOEgEZBFlHt5b/th+os7OYZj9kHKVh14JLW",
+	"u7ODW7aM8Ouk8wL1Kw9u8HCDhxs83ODhBg83eLjBW98GD6AVXO4qA7HYcA0xTS+sqFIeoK3vTym0ccUO",
+	"z8b8EFxzMCOweyYffaJD9vRspa4qWy9X4GsWEpnZmty2BsxsZWTmA4SrKFra8nQ+ukWHHGkyBrNhPUlc",
+	"iJU+M+IxKGbL9kNI+u4jc70BlzkwKHYdm2lQZf18zGCv985338X6cE3a/asZpqo4LbO1FsfWH8cXDaFp",
+	"FMkxLPw2iEjeALfxN8QEINHZaITSPJCSxX0lFcHIxtTR1bEA/baXDyAoeVWgC5gghUkKj34nTynW7+NX",
+	"OTYrRLlAGw7EZMRkxGTEZMRkxOS1YXLegipybxlrTovFrIN+azOQYCsvtndSaKURJ6w1k+10/FHlhiyB",
+	"LIGRrdC9HYHhPuasLXBAPSKAOi3/p/MocqYQVbns86Iz/2yqEik0tVCFMT3g7G2//O7ph++fPt07fL/3",
+	"6qcX2ztvfu8d/Prs8CdoE2ISt3Zb//1Hb+v7j3/0tp7tbf3086vXb95unf229YFujf55EYtkS19u/f3x",
+	"087Tz/9RfQjaJFEBu0qoKOdAYCKLW7t/2JvMQ3yszoNQfcJJqHaz0enn8kKFOAA+CCtxh8x5oK7immbP",
+	"qiFgFmixmjwO1V+pZzkVk+MBTKLmMNduXvgFvEYWtj5/RAZEBkQGRH0S6pMQDx8yHgJJBaP5A5l9c9mL",
+	"FZc/NqYitItcTAVPvE1WmgmIl1/iy865MK/ugk2c9Zx5fX91kxFVTHU/wd9XbPL5L/NCKq53ITtT95P5",
+	"A+VsuocwJDmdKsKFYql2Z7Yxi/szh6Y2YqP5AiA6KuwI4cw10ixPYwsfuLXDg6wJNmUAi+UlK7aV2iuQ",
+	"3MC2lMdgDWQUsQDa6ZJQBlme/hZykV1pJgrddhfcubPNpBwQeHDCBySRSvF+ZOdj5KYaOLFHEQyxmeNC",
+	"2xsU6U9sPdRAJeQPmD/LfBHye8TsNzjUzDN+rQ6aZgz3wvBdYvj3SLN4NfIMubZT6gYV7IXhyve8gLl2",
+	"zb6+53rkojh9rEx7hgpchHeEd4R3DNCKGmzcouAW5ctqsLuBGaSo3ujzAH5XczrXijRXUBKZ2QxlHgYW",
+	"uu1T3z2nVaHHqjTVJe02h4BdATMzm8cxC828jSZWc7021yZ/RYIlJrIqsiqyKrIqsiqyKrIqsupXwao2",
+	"Miqrh9XXtkCZVrk200/6vF0BQNYlS5WZlu5TSyJaQbSuOkTaOaS1S9NvdhDNhZgLHmdxa3c7b9VM6yFL",
+	"W2WQ/GPm3o8IngieCJ4IngieCJ4IngieXyN4ZsIP25bVxFHtuKeB0jQf8MKt86z5Lm/ioNDC3adNxDbE",
+	"NsQ2xDbENsQ2xDbEtjVg2+d2S7EgS7meABMdRDILz+QFE3uZHrV2//j4ue2uHkh5wVl++aO507wYC1Mz",
+	"0GZuaLVbWRq1dlsjrRO12+3KhAkbbDKA3+f9k36RAY3m7tve+b7T6/Q627s//PDDDy3TtHugTx7c3spU",
+	"0whqdFf2kkQV//1Gaj7wsmnGk71QbJHDe6HYQaa0jM3DFy7uu6+p/ra3EV3UePn1FHsFMXOLV15bji1c",
+	"ec762XCmNgi71Pr88fP/DwAA///h6xiEzAQHAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/client/go/client.go
+++ b/api/client/go/client.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config=codegen.yaml ../../openapi.yaml
+//go:generate go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config=codegen.yaml ../../openapi.cloud.yaml
 package openmeter
 
 import (

--- a/api/client/go/client_test.go
+++ b/api/client/go/client_test.go
@@ -1,0 +1,223 @@
+package openmeter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2/event"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testSubject  string = "customer-1"
+	testMeterKey string = "meter-1"
+)
+
+func TestIngest(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a mock server to test the client
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/events", r.URL.Path)
+		assert.Equal(t, "application/cloudevents+json", r.Header.Get("Content-Type"))
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create a client with the mock server
+	om, err := NewClientWithResponses(server.URL)
+	assert.NoError(t, err)
+
+	resp, err := om.IngestEventWithResponse(ctx, mockEvent())
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+}
+
+func TestIngestBatch(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a mock server to test the client
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/events", r.URL.Path)
+		assert.Equal(t, "application/cloudevents-batch+json", r.Header.Get("Content-Type"))
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create a client with the mock server
+	om, err := NewClientWithResponses(server.URL)
+	assert.NoError(t, err)
+
+	resp, err := om.IngestEventBatchWithResponse(ctx, []cloudevents.Event{mockEvent()})
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+}
+
+func TestAuth(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a mock server to test the client
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/api/v1/events", r.URL.Path)
+		assert.Equal(t, "application/cloudevents+json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "Bearer test-api-token", r.Header.Get("Authorization"))
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Create a client with the mock server
+	om, err := NewAuthClientWithResponses(server.URL, "test-api-token")
+	assert.NoError(t, err)
+
+	resp, err := om.IngestEventWithResponse(ctx, mockEvent())
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+}
+
+func TestGetMeter(t *testing.T) {
+	ctx := context.Background()
+
+	meter := models.Meter{
+		Slug:          testMeterKey,
+		Description:   "Test Meter",
+		Aggregation:   models.MeterAggregationSum,
+		ValueProperty: "$.tokens",
+		GroupBy:       map[string]string{"model": "$.model", "type": "$.type"},
+	}
+
+	// Create a mock server to test the client
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/meters/meter-1", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		json.NewEncoder(w).Encode(meter)
+	}))
+	defer server.Close()
+
+	// Create a client with the mock server
+	om, err := NewClientWithResponses(server.URL)
+	assert.NoError(t, err)
+
+	resp, err := om.GetMeterWithResponse(ctx, testMeterKey)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+	assert.Equal(t, &meter, resp.JSON200)
+}
+
+func TestListMeters(t *testing.T) {
+	ctx := context.Background()
+
+	meters := []models.Meter{
+		{
+			Slug:          "meter-1",
+			Description:   "Test Meter",
+			Aggregation:   models.MeterAggregationSum,
+			ValueProperty: "$.tokens",
+			GroupBy:       map[string]string{"model": "$.model", "type": "$.type"},
+		},
+		{
+			Slug:          "meter-2",
+			Description:   "Test Meter 2",
+			Aggregation:   models.MeterAggregationSum,
+			ValueProperty: "$.tokens",
+			GroupBy:       map[string]string{"model": "$.model", "type": "$.type"},
+		},
+	}
+
+	// Create a mock server to test the client
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/meters", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		json.NewEncoder(w).Encode(meters)
+	}))
+	defer server.Close()
+
+	// Create a client with the mock server
+	om, err := NewClientWithResponses(server.URL)
+	assert.NoError(t, err)
+
+	resp, err := om.ListMetersWithResponse(ctx)
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+	assert.Equal(t, &meters, resp.JSON200)
+}
+
+func TestMeterQuery(t *testing.T) {
+	ctx := context.Background()
+
+	result := MeterQueryResult{
+		Data: []models.MeterQueryRow{
+			{
+				Subject:     &testSubject,
+				WindowStart: time.Now().UTC(),
+				WindowEnd:   time.Now().UTC(),
+				Value:       123,
+			},
+		},
+	}
+
+	// Create a mock server to test the client
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/meters/meter-1/query", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		json.NewEncoder(w).Encode(result)
+	}))
+	defer server.Close()
+
+	// Create a client with the mock server
+	om, err := NewClientWithResponses(server.URL)
+	assert.NoError(t, err)
+
+	subjectFilter := []string{testSubject}
+
+	resp, err := om.QueryMeterWithResponse(ctx, testMeterKey, &QueryMeterParams{
+		Subject: &subjectFilter,
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode())
+	assert.Equal(t, &result, resp.JSON200)
+}
+
+// mockEvent creates a mock CloudEvent for testing
+func mockEvent() cloudevents.Event {
+	e := cloudevents.New()
+	eventTime, _ := time.Parse(time.RFC3339, "2024-11-05T22:35:52.457Z")
+	e.SetTime(eventTime)
+	e.SetID("ec2672e8-458d-4c5e-8a3c-f3235dd38ba5")
+	e.SetSource("my-app")
+	e.SetType("usage-reports")
+	e.SetSubject("customer-1")
+	e.SetData("application/json", map[string]string{
+		"reports": "123",
+		"type":    "type",
+	})
+	return e
+}

--- a/api/client/node/package.json
+++ b/api/client/node/package.json
@@ -32,7 +32,7 @@
     "lint": "eslint . --ext .ts --format=pretty",
     "format": "prettier --write .",
     "build": "duel",
-    "generate": "rimraf ./schemas && openapi-typescript '../../openapi.yaml' --output schemas/openapi.ts && prettier --write schemas/",
+    "generate": "rimraf ./schemas && openapi-typescript '../../openapi.cloud.yaml' --output schemas/openapi.ts && prettier --write schemas/",
     "pretest": "pnpm run build",
     "test": "vitest --run",
     "test:watch": "vitest --watch",

--- a/api/openapi.cloud.yaml
+++ b/api/openapi.cloud.yaml
@@ -1,0 +1,15030 @@
+openapi: 3.0.0
+info:
+  title: OpenMeter Cloud API
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  description: |-
+    OpenMeter is a cloud native usage metering service.
+    The OpenMeter API allows you to ingest events, query meter usage, and manage resources.
+tags:
+  - name: Portal
+  - name: Apps
+  - name: Notification (Experimental)
+  - name: Entitlements (Experimental)
+  - name: Customers
+  - name: Billing (Experimental)
+  - name: Plan (Experimental)
+  - name: Subscriptions
+  - name: Events
+  - name: Meters
+  - name: Debug
+  - name: Subjects
+paths:
+  /api/v1/apps:
+    get:
+      operationId: listApps
+      description: List apps.
+      parameters:
+        - $ref: '#/components/parameters/PaginatedQuery.page'
+        - $ref: '#/components/parameters/PaginatedQuery.pageSize'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppList'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Apps
+  /api/v1/apps/{id}:
+    get:
+      operationId: getApp
+      description: Get the app.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/App'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Apps
+    delete:
+      operationId: uninstallApp
+      description: Uninstall an app.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Apps
+  /api/v1/apps/{id}/stripe/webhook:
+    post:
+      operationId: appStripeWebhook
+      description: Stripe webhook.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StripeWebhookResponse'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Apps
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StripeWebhookEvent'
+  /api/v1/billing/customer:
+    get:
+      operationId: billingListCustomerOverrides
+      summary: List customer overrides
+      description: List customer overrides
+      parameters:
+        - name: billingProfile
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              example: 01G65Z755AFWAKHE12NY0CQ9FH
+              pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+              description: ULID (Universally Unique Lexicographically Sortable Identifier).
+          explode: false
+        - $ref: '#/components/parameters/Pagination.page'
+        - $ref: '#/components/parameters/Pagination.pageSize'
+        - $ref: '#/components/parameters/LimitOffset.offset'
+        - $ref: '#/components/parameters/LimitOffset.limit'
+        - $ref: '#/components/parameters/CustomerOverrideOrderByOrdering.order'
+        - $ref: '#/components/parameters/CustomerOverrideOrderByOrdering.orderBy'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomerOverridePaginatedResponse'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+  /api/v1/billing/customer/{customerId}:
+    post:
+      operationId: billingUpsertCustomerOverride
+      summary: Create/update a customer override
+      description: Create/update a new customer override.
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingCustomerOverride'
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingCustomerOverride'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BillingCustomerWorkflowOverrideCreate'
+    get:
+      operationId: billingGetCustomerOverrideById
+      summary: Get a customer override
+      description: Get a customer override by id.
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingCustomerOverride'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+    delete:
+      operationId: billingDeleteCustomerOverride
+      summary: Delete a customer override
+      description: Delete a customer override by id.
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+  /api/v1/billing/invoices:
+    get:
+      operationId: billingListInvoices
+      summary: List invoices
+      description: List invoices
+      parameters:
+        - name: customers
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              example: 01G65Z755AFWAKHE12NY0CQ9FH
+              pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+              description: ULID (Universally Unique Lexicographically Sortable Identifier).
+            title: Filter by the customer ID or key
+          explode: false
+        - $ref: '#/components/parameters/BillingInvoiceListParams.statuses'
+        - $ref: '#/components/parameters/BillingInvoiceListParams.extendedStatuses'
+        - $ref: '#/components/parameters/BillingInvoiceListParams.issuedAfter'
+        - $ref: '#/components/parameters/BillingInvoiceListParams.issuedBefore'
+        - $ref: '#/components/parameters/BillingInvoiceListParams.expand'
+        - $ref: '#/components/parameters/Pagination.page'
+        - $ref: '#/components/parameters/Pagination.pageSize'
+        - $ref: '#/components/parameters/LimitOffset.offset'
+        - $ref: '#/components/parameters/LimitOffset.limit'
+        - $ref: '#/components/parameters/InvoiceOrderByOrdering.order'
+        - $ref: '#/components/parameters/InvoiceOrderByOrdering.orderBy'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoicePaginatedResponse'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+  /api/v1/billing/invoices/{customerId}:
+    post:
+      operationId: billingCreateInvoice
+      summary: Create an invoice
+      description: |-
+        Create a new invoice from the pending line items.
+
+        This should be only called if for some reason we need to invoice a customer outside of the normal billing cycle.
+
+        When creating an invoice, the pending line items will be marked as invoiced and the invoice will be created with the total amount of the pending items.
+
+        New pending line items will be created for the period between now() and the next billing cycle's begining date for any metered item.
+
+        The call can return multiple invoices if the pending line items are in different currencies.
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BillingInvoice'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BillingInvoiceCreateInput'
+    get:
+      operationId: billingListInvoicesByCustomer
+      summary: List invoices
+      description: List invoices for a specific customer
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - $ref: '#/components/parameters/BillingInvoiceListParams.statuses'
+        - $ref: '#/components/parameters/BillingInvoiceListParams.extendedStatuses'
+        - $ref: '#/components/parameters/BillingInvoiceListParams.issuedAfter'
+        - $ref: '#/components/parameters/BillingInvoiceListParams.issuedBefore'
+        - $ref: '#/components/parameters/BillingInvoiceListParams.expand'
+        - $ref: '#/components/parameters/Pagination.page'
+        - $ref: '#/components/parameters/Pagination.pageSize'
+        - $ref: '#/components/parameters/LimitOffset.offset'
+        - $ref: '#/components/parameters/LimitOffset.limit'
+        - $ref: '#/components/parameters/InvoiceOrderByOrdering.order'
+        - $ref: '#/components/parameters/InvoiceOrderByOrdering.orderBy'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvoicePaginatedResponse'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+  /api/v1/billing/invoices/{customerId}/invoices/{invoiceId}:
+    get:
+      operationId: billingGetInvoiceByCustomerInvoiceId
+      summary: Get an invoice
+      description: Get an invoice by ID.
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: invoiceId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: expand
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/BillingInvoiceExpand'
+            default:
+              - lines
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingInvoice'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+    delete:
+      operationId: billingDeleteInvoiceByCustomerInvoiceId
+      summary: Delete an invoice
+      description: |-
+        Delete an invoice
+
+        Only invoices that are in the draft (or earlier) status can be deleted.
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: invoiceId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+  /api/v1/billing/invoices/{customerId}/invoices/{invoiceId}/advance:
+    post:
+      operationId: billingInvoiceAdvance
+      summary: Advance the invoice's state to the next status
+      description: |-
+        Advance the invoice's state to the next status.
+
+        The call doesn't "approve the invoice", it only advances the invoice to the next status if the transition would be automatic.
+
+        The action can be called when the invoice's statusDetails' actions field contain the "advance" action.
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: invoiceId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingInvoice'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+  /api/v1/billing/invoices/{customerId}/invoices/{invoiceId}/approve:
+    post:
+      operationId: billingApproveInvoice
+      summary: Send the invoice to the customer
+      description: |-
+        Approve an invoice and start executing the payment workflow.
+
+        This call instantly sends the invoice to the customer using the configured billing profile app.
+
+        This call is valid in two invoice statuses:
+        - `draft`: the invoice will be sent to the customer, the invluce state becomes issued
+        - `manual_approval_needed`: the invoice will be sent to the customer, the invoice state becomes issued
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: invoiceId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingInvoice'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+  /api/v1/billing/invoices/{customerId}/invoices/{invoiceId}/lines/{lineId}:
+    delete:
+      operationId: billingDeleteInvoiceLine
+      summary: Delete an invoice line
+      description: Delete an invoice line
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: invoiceId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: lineId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+    put:
+      operationId: billingUpdateInvoiceLine
+      summary: Update an invoice line
+      description: Update an invoice line
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: invoiceId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: lineId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingInvoiceLine'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BillingInvoiceLineCreateOrUpdate'
+  /api/v1/billing/invoices/{customerId}/invoices/{invoiceId}/retry:
+    post:
+      operationId: billingInvoiceRetry
+      summary: Retry advancing the invoice after a failed attempt.
+      description: |-
+        Retry advancing the invoice after a failed attempt.
+
+        The action can be called when the invoice's statusDetails' actions field contain the "retry" action.
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: invoiceId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingInvoice'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+  /api/v1/billing/invoices/{customerId}/invoices/{invoiceId}/tax/recalculate:
+    post:
+      operationId: billingRecalculateInvoiceTax
+      summary: Recalculate an invoice's tax amounts
+      description: |-
+        Recalculate an invoice's tax amounts (using the app set in the customer's billing profile)
+
+        Note: charges might apply, depending on the tax provider.
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: invoiceId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingInvoice'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+  /api/v1/billing/invoices/{customerId}/invoices/{invoiceId}/void:
+    post:
+      operationId: billingVoidInvoice
+      summary: Void an invoice
+      description: |-
+        Void an invoice
+
+        Only invoices that have been alread issued can be voided.
+
+        Voiding an invoice will mark it as voided, the user can specify how to handle the voided line items.
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: invoiceId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingInvoice'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BillingVoidInvoiceInput'
+  /api/v1/billing/invoices/{customerId}/lines:
+    post:
+      operationId: billingCreateLineByCustomer
+      summary: Create line items
+      description: |-
+        Create a new pending line item (charge).
+
+        This call is used to create a new pending line item for the customer without explicitly
+        assigning it to an invoice.
+
+        The line item will be either allocated to an existing invoice in gathering state or a new invoice is
+        created for the line item.
+
+        A new invoice will be created if:
+        - there is no invoice in gathering state
+        - the currency of the line item doesn't match the currency of any invoices in gathering state
+      parameters:
+        - name: customerId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingCreateLineResult'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BillingCreateLinesRequest'
+  /api/v1/billing/profile:
+    get:
+      operationId: billingListProfiles
+      description: List all billing profiles
+      parameters:
+        - name: includeArchived
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - name: expand
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/BillingProfileExpand'
+          explode: false
+        - $ref: '#/components/parameters/Pagination.page'
+        - $ref: '#/components/parameters/Pagination.pageSize'
+        - $ref: '#/components/parameters/LimitOffset.offset'
+        - $ref: '#/components/parameters/LimitOffset.limit'
+        - $ref: '#/components/parameters/ProfileOrderByOrdering.order'
+        - $ref: '#/components/parameters/ProfileOrderByOrdering.orderBy'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProfilePaginatedResponse'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+    post:
+      operationId: billingCreateProfile
+      summary: Create a new billing profile
+      description: |-
+        Create a new billing profile
+
+        Billing profiles are representations of a customer's billing information. Customer overrides
+        can be applied to a billing profile to customize the billing behavior for a specific customer.
+      parameters: []
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingProfile'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BillingProfileCreateInput'
+  /api/v1/billing/profile/{id}:
+    delete:
+      operationId: billingArchiveProfile
+      summary: Archive a billing profile
+      description: Archive a billing profile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+    get:
+      operationId: billingGetProfile
+      summary: Get a billing profile by ID
+      description: Get a billing profile by ID
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: expand
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/BillingProfileExpand'
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingProfile'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+    put:
+      operationId: billingUpdateProfile
+      summary: Update a billing profile
+      description: Update a billing profile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillingProfile'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Billing (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BillingProfileCreateOrUpdate'
+  /api/v1/customers:
+    post:
+      operationId: createCustomer
+      description: Create a new customer.
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Customer'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Customers
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Customer'
+    get:
+      operationId: listCustomers
+      description: List customers.
+      parameters:
+        - $ref: '#/components/parameters/CustomerOrderByOrdering.order'
+        - $ref: '#/components/parameters/CustomerOrderByOrdering.orderBy'
+        - $ref: '#/components/parameters/queryCustomerList.includeDeleted'
+        - $ref: '#/components/parameters/queryCustomerList.name'
+        - $ref: '#/components/parameters/queryCustomerList.primaryEmail'
+        - $ref: '#/components/parameters/queryCustomerList.subject'
+        - $ref: '#/components/parameters/PaginatedQuery.page'
+        - $ref: '#/components/parameters/PaginatedQuery.pageSize'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomerList'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Customers
+  /api/v1/customers/{id}:
+    get:
+      operationId: getCustomer
+      description: Get a customer by ID.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Customer'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Customers
+    put:
+      operationId: updateCustomer
+      description: Update a customer by ID.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Customer'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Customers
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Customer'
+    delete:
+      operationId: deleteCustomer
+      description: Delete a customer by ID.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Customer'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Customers
+  /api/v1/debug/metrics:
+    get:
+      operationId: getDebugMetrics
+      summary: Get event metrics
+      description: |-
+        Returns debug metrics (in OpenMetrics format) like the number of ingested events since mindnight UTC.
+
+        The OpenMetrics Counter(s) reset every day at midnight UTC.
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            text/plain:
+              schema:
+                type: string
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Debug
+  /api/v1/entitlements:
+    get:
+      operationId: listEntitlements
+      summary: List all entitlements
+      description: |-
+        List all entitlements for all the subjects and features. This endpoint is intended for administrative purposes only.
+        To fetch the entitlements of a specific subject please use the /api/v1/subjects/{subjectKeyOrID}/entitlements endpoint.
+        If page is provided that takes precedence and the paginated response is returned.
+      parameters:
+        - name: feature
+          in: query
+          required: false
+          description: |-
+            Filtering by multiple features.
+
+            Usage: `?feature=feature-1&feature=feature-2`
+          schema:
+            type: array
+            items:
+              type: string
+        - name: subject
+          in: query
+          required: false
+          description: |-
+            Filtering by multiple subjects.
+
+            Usage: `?subject=customer-1&subject=customer-2`
+          schema:
+            type: array
+            items:
+              type: string
+        - name: entitlementType
+          in: query
+          required: false
+          description: |-
+            Filtering by multiple entitlement types.
+
+            Usage: `?entitlementType=metered&entitlementType=boolean`
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/EntitlementType'
+        - $ref: '#/components/parameters/Pagination.page'
+        - $ref: '#/components/parameters/Pagination.pageSize'
+        - $ref: '#/components/parameters/LimitOffset.offset'
+        - $ref: '#/components/parameters/LimitOffset.limit'
+        - $ref: '#/components/parameters/EntitlementOrderByOrdering.order'
+        - $ref: '#/components/parameters/EntitlementOrderByOrdering.orderBy'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListEntitlementsResult'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+  /api/v1/entitlements/{entitlementId}:
+    get:
+      operationId: getEntitlementById
+      description: Get entitlement by id.
+      parameters:
+        - name: entitlementId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entitlement'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+  /api/v1/events:
+    get:
+      operationId: listEvents
+      summary: List ingested events
+      description: |-
+        List ingested events within a time range.
+
+        If the from query param is not provided it defaults to last 72 hours.
+      parameters:
+        - name: ingestedAtFrom
+          in: query
+          required: false
+          description: |-
+            Start date-time in RFC 3339 format.
+
+            Inclusive.
+          schema:
+            type: string
+            format: date-time
+        - name: ingestedAtTo
+          in: query
+          required: false
+          description: |-
+            End date-time in RFC 3339 format.
+
+            Inclusive.
+          schema:
+            type: string
+            format: date-time
+        - name: hasError
+          in: query
+          required: false
+          description: |-
+            If not provided lists all events.
+
+            If provided with true, only list events with processing error.
+
+            If provided with false, only list events without processing error.
+          schema:
+            type: boolean
+        - name: id
+          in: query
+          required: false
+          description: |-
+            The event ID.
+
+            Accepts partial ID.
+          schema:
+            type: string
+        - name: subject
+          in: query
+          required: false
+          description: |-
+            The event subject.
+
+            Accepts partial subject.
+          schema:
+            type: string
+        - name: from
+          in: query
+          required: false
+          description: |-
+            Start date-time in RFC 3339 format.
+
+            Inclusive.
+          schema:
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          required: false
+          description: |-
+            End date-time in RFC 3339 format.
+
+            Inclusive.
+          schema:
+            type: string
+            format: date-time
+        - name: limit
+          in: query
+          required: false
+          description: Number of events to return.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 100
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/IngestedEvent'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Events
+    post:
+      operationId: ingestEvents
+      parameters: []
+      description: Ingests an event or batch of events following the CloudEvents specification.
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/cloudevents+json:
+              schema:
+                $ref: '#/components/schemas/Event'
+            application/cloudevents-batch+json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Events
+      requestBody:
+        required: true
+        content:
+          application/cloudevents+json:
+            schema:
+              $ref: '#/components/schemas/Event'
+          application/cloudevents-batch+json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Event'
+  /api/v1/features:
+    get:
+      operationId: listFeatures
+      description: List features.
+      parameters:
+        - name: meterSlug
+          in: query
+          required: false
+          description: Filter by meterSlug
+          schema:
+            type: array
+            items:
+              type: string
+        - name: includeArchived
+          in: query
+          required: false
+          description: Filter by meterGroupByFilters
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - $ref: '#/components/parameters/Pagination.page'
+        - $ref: '#/components/parameters/Pagination.pageSize'
+        - $ref: '#/components/parameters/LimitOffset.offset'
+        - $ref: '#/components/parameters/LimitOffset.limit'
+        - $ref: '#/components/parameters/FeatureOrderByOrdering.order'
+        - $ref: '#/components/parameters/FeatureOrderByOrdering.orderBy'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListFeaturesResult'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+    post:
+      operationId: createFeature
+      description: |-
+        Features are either metered or static. A feature is metered if meterSlug is provided at creation.
+        For metered features you can pass additional filters that will be applied when calculating feature usage, based on the meter's groupBy fields.
+        Only meters with SUM and COUNT aggregation are supported for features.
+        Features cannot be updated later, only archived.
+      parameters: []
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Feature'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FeatureCreateInputs'
+  /api/v1/features/{featureId}:
+    get:
+      operationId: getFeature
+      description: Get a feature by ID.
+      parameters:
+        - name: featureId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Feature'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+    delete:
+      operationId: deleteFeature
+      description: |-
+        Archive a feature by ID.
+
+        Once a feature is archived it cannot be unarchived. If a feature is archived, new entitlements cannot be created for it, but archiving the feature does not affect existing entitlements.
+        This means, if you want to create a new feature with the same key, and then create entitlements for it, the previous entitlements have to be deleted first on a per subject basis.
+      parameters:
+        - name: featureId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+  /api/v1/grants:
+    get:
+      operationId: listGrants
+      description: |-
+        List all grants for all the subjects and entitlements. This endpoint is intended for administrative purposes only.
+        To fetch the grants of a specific entitlement please use the /api/v1/subjects/{subjectKeyOrID}/entitlements/{entitlementOrFeatureID}/grants endpoint.
+        If page is provided that takes precedence and the paginated response is returned.
+      parameters:
+        - name: feature
+          in: query
+          required: false
+          description: |-
+            Filtering by multiple features.
+
+            Usage: `?feature=feature-1&feature=feature-2`
+          schema:
+            type: array
+            items:
+              type: string
+        - name: subject
+          in: query
+          required: false
+          description: |-
+            Filtering by multiple subjects.
+
+            Usage: `?subject=customer-1&subject=customer-2`
+          schema:
+            type: array
+            items:
+              type: string
+        - name: includeDeleted
+          in: query
+          required: false
+          description: Include deleted
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - $ref: '#/components/parameters/Pagination.page'
+        - $ref: '#/components/parameters/Pagination.pageSize'
+        - $ref: '#/components/parameters/LimitOffset.offset'
+        - $ref: '#/components/parameters/LimitOffset.limit'
+        - $ref: '#/components/parameters/GrantOrderByOrdering.order'
+        - $ref: '#/components/parameters/GrantOrderByOrdering.orderBy'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - type: array
+                    items:
+                      $ref: '#/components/schemas/EntitlementGrant'
+                  - $ref: '#/components/schemas/GrantPaginatedResponse'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+  /api/v1/grants/{grantId}:
+    delete:
+      operationId: voidGrant
+      description: |-
+        Voiding a grant means it is no longer valid, it doesn't take part in further balance calculations. Voiding a grant does not retroactively take effect, meaning any usage that has already been attributed to the grant will remain, but future usage cannot be burnt down from the grant.
+        For example, if you have a single grant for your metered entitlement with an initial amount of 100, and so far 60 usage has been metered, the grant (and the entitlement itself) would have a balance of 40. If you then void that grant, balance becomes 0, but the 60 previous usage will not be affected.
+      parameters:
+        - name: grantId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '409':
+          description: The request could not be completed due to a conflict with the current state of the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConflictProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+  /api/v1/integration/stripe/checkout/sessions:
+    post:
+      operationId: createStripeCheckoutSession
+      description: Create checkout session.
+      parameters: []
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateStripeCheckoutSessionResult'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Apps
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateStripeCheckoutSessionRequest'
+  /api/v1/marketplace/listings:
+    get:
+      operationId: listMarketplaceListings
+      description: List available apps of the app marketplace.
+      parameters:
+        - $ref: '#/components/parameters/PaginatedQuery.page'
+        - $ref: '#/components/parameters/PaginatedQuery.pageSize'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketplaceListingList'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Apps
+  /api/v1/marketplace/listings/{type}:
+    get:
+      operationId: getMarketplaceListing
+      description: Get a marketplace listing by type.
+      parameters:
+        - name: type
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppType'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketplaceListing'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Apps
+  /api/v1/marketplace/listings/{type}/install/apikey:
+    post:
+      operationId: marketplaceAppAPIKeyInstall
+      description: Install an marketplace via API Key.
+      parameters:
+        - $ref: '#/components/parameters/MarketplaceApiKeyInstallRequest.type'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppBase'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Apps
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                apiKey:
+                  type: string
+                  description: |-
+                    The API key for the provider.
+                    For example, the Stripe API key.
+                name:
+                  type: string
+                  description: |-
+                    Name of the application to install.
+
+                    If not set defaults to the marketplace item's description.
+              required:
+                - apiKey
+  /api/v1/marketplace/listings/{type}/install/oauth2:
+    get:
+      operationId: marketplaceOAuth2InstallGetURL
+      description: |-
+        Install an app via OAuth.
+        Returns a URL to start the OAuth 2.0 flow.
+      parameters:
+        - name: type
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/AppType'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientAppStartResponse'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Apps
+  /api/v1/marketplace/listings/{type}/install/oauth2/authorize:
+    get:
+      operationId: marketplaceOAuth2InstallAuthorize
+      description: |-
+        Authorize OAuth2 code.
+        Verifies the OAuth code and exchanges it for a token and refresh token
+      parameters:
+        - $ref: '#/components/parameters/OAuth2AuthorizationCodeGrantSuccessParams.state'
+        - $ref: '#/components/parameters/OAuth2AuthorizationCodeGrantSuccessParams.code'
+        - $ref: '#/components/parameters/OAuth2AuthorizationCodeGrantErrorParams.error'
+        - $ref: '#/components/parameters/OAuth2AuthorizationCodeGrantErrorParams.error_description'
+        - $ref: '#/components/parameters/OAuth2AuthorizationCodeGrantErrorParams.error_uri'
+        - $ref: '#/components/parameters/MarketplaceOAuth2InstallAuthorizeRequest.type'
+      responses:
+        '303':
+          description: Redirection
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Apps
+  /api/v1/meters:
+    get:
+      operationId: listMeters
+      description: List meters.
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Meter'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Meters
+    post:
+      operationId: createMeter
+      description: Create a meter.
+      parameters: []
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Meter'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Meters
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MeterCreate'
+  /api/v1/meters/{meterIdOrSlug}:
+    get:
+      operationId: getMeter
+      description: Get a meter by ID or slug.
+      parameters:
+        - name: meterIdOrSlug
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$|^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Meter'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Meters
+    delete:
+      operationId: deleteMeter
+      description: Delete a meter.
+      parameters:
+        - name: meterIdOrSlug
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$|^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Meters
+  /api/v1/meters/{meterIdOrSlug}/query:
+    get:
+      operationId: queryMeter
+      parameters:
+        - name: meterIdOrSlug
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$|^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - $ref: '#/components/parameters/MeterQuery.from'
+        - $ref: '#/components/parameters/MeterQuery.to'
+        - $ref: '#/components/parameters/MeterQuery.windowSize'
+        - $ref: '#/components/parameters/MeterQuery.windowTimeZone'
+        - $ref: '#/components/parameters/MeterQuery.subject'
+        - $ref: '#/components/parameters/MeterQuery.filterGroupBy'
+        - $ref: '#/components/parameters/MeterQuery.groupBy'
+      description: Query meter for usage. Query meter for usage.
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeterQueryResult'
+            text/csv:
+              schema:
+                type: string
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Meters
+  /api/v1/meters/{meterIdOrSlug}/subjects:
+    get:
+      operationId: listMeterSubjects
+      description: List subjects for a meter.
+      parameters:
+        - name: meterIdOrSlug
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$|^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Meters
+  /api/v1/notification/channels:
+    get:
+      operationId: listNotificationChannels
+      summary: List notification channels
+      description: List all notification channels.
+      parameters:
+        - name: includeDeleted
+          in: query
+          required: false
+          description: |-
+            Include deleted notification channels in response.
+
+            Usage: `?includeDeleted=true`
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - name: includeDisabled
+          in: query
+          required: false
+          description: |-
+            Include disabled notification channels in response.
+
+            Usage: `?includeDisabled=false`
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - $ref: '#/components/parameters/Pagination.page'
+        - $ref: '#/components/parameters/Pagination.pageSize'
+        - $ref: '#/components/parameters/NotificationChannelOrderByOrdering.order'
+        - $ref: '#/components/parameters/NotificationChannelOrderByOrdering.orderBy'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationChannelPaginatedResponse'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+    post:
+      operationId: createNotificationChannel
+      summary: Create a notification channel
+      description: Create a new notification channel.
+      parameters: []
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationChannel'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationChannelCreateRequest'
+  /api/v1/notification/channels/{channelId}:
+    put:
+      operationId: updateNotificationChannel
+      summary: Update a notification channel
+      description: Update notification channel.
+      parameters:
+        - name: channelId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationChannel'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationChannelCreateRequest'
+    get:
+      operationId: getNotificationChannel
+      summary: Get notification channel
+      description: Get a notification channel by id.
+      parameters:
+        - name: channelId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationChannel'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+    delete:
+      operationId: deleteNotificationChannel
+      summary: Delete a notification channel
+      description: |-
+        Soft delete notification channel by id.
+
+        Once a notification channel is deleted it cannot be undeleted.
+      parameters:
+        - name: channelId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+  /api/v1/notification/events:
+    get:
+      operationId: listNotificationEvents
+      summary: List notification events
+      description: List all notification events.
+      parameters:
+        - name: from
+          in: query
+          required: false
+          description: |-
+            Start date-time in RFC 3339 format.
+            Inclusive.
+          schema:
+            type: string
+            format: date-time
+            example: 2023-01-01T01:01:01.001Z
+        - name: to
+          in: query
+          required: false
+          description: |-
+            End date-time in RFC 3339 format.
+            Inclusive.
+          schema:
+            type: string
+            format: date-time
+            example: 2023-01-01T01:01:01.001Z
+        - name: feature
+          in: query
+          required: false
+          description: |-
+            Filtering by multiple feature ids or keys.
+
+            Usage: `?feature=feature-1&feature=feature-2`
+          schema:
+            type: array
+            items:
+              type: string
+        - name: subject
+          in: query
+          required: false
+          description: |-
+            Filtering by multiple subject ids or keys.
+
+            Usage: `?subject=subject-1&subject=subject-2`
+          schema:
+            type: array
+            items:
+              type: string
+        - name: rule
+          in: query
+          required: false
+          description: |-
+            Filtering by multiple rule ids.
+
+            Usage: `?rule=01J8J2XYZ2N5WBYK09EDZFBSZM&rule=01J8J4R4VZH180KRKQ63NB2VA5`
+          schema:
+            type: array
+            items:
+              type: string
+              example: 01G65Z755AFWAKHE12NY0CQ9FH
+              pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+              description: ULID (Universally Unique Lexicographically Sortable Identifier).
+        - name: channel
+          in: query
+          required: false
+          description: |-
+            Filtering by multiple channel ids.
+
+            Usage: `?channel=01J8J4RXH778XB056JS088PCYT&channel=01J8J4S1R1G9EVN62RG23A9M6J`
+          schema:
+            type: array
+            items:
+              type: string
+              example: 01G65Z755AFWAKHE12NY0CQ9FH
+              pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+              description: ULID (Universally Unique Lexicographically Sortable Identifier).
+        - $ref: '#/components/parameters/Pagination.page'
+        - $ref: '#/components/parameters/Pagination.pageSize'
+        - $ref: '#/components/parameters/NotificationEventOrderByOrdering.order'
+        - $ref: '#/components/parameters/NotificationEventOrderByOrdering.orderBy'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationEventPaginatedResponse'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+  /api/v1/notification/events/{eventId}:
+    get:
+      operationId: getNotificationEvent
+      summary: Get notification event
+      description: Get a notification event by id.
+      parameters:
+        - name: eventId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationEvent'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+  /api/v1/notification/rules:
+    get:
+      operationId: listNotificationRules
+      summary: List notification rules
+      description: List all notification rules.
+      parameters:
+        - name: includeDeleted
+          in: query
+          required: false
+          description: |-
+            Include deleted notification rules in response.
+
+            Usage: `?includeDeleted=true`
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - name: includeDisabled
+          in: query
+          required: false
+          description: |-
+            Include disabled notification rules in response.
+
+            Usage: `?includeDisabled=false`
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - name: feature
+          in: query
+          required: false
+          description: |-
+            Filtering by multiple feature ids/keys.
+
+            Usage: `?feature=feature-1&feature=feature-2`
+          schema:
+            type: array
+            items:
+              type: string
+              minLength: 1
+              maxLength: 64
+              pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$|^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+              description: |-
+                ULID (Universally Unique Lexicographically Sortable Identifier).
+                A key is a unique string that is used to identify a resource.
+
+                TODO: this is a temporary solution to support both ULID and Key in the same spec for codegen.
+        - name: channel
+          in: query
+          required: false
+          description: |-
+            Filtering by multiple notifiaction channel ids.
+
+            Usage: `?channel=01ARZ3NDEKTSV4RRFFQ69G5FAV&channel=01J8J2Y5X4NNGQS32CF81W95E3`
+          schema:
+            type: array
+            items:
+              type: string
+        - $ref: '#/components/parameters/Pagination.page'
+        - $ref: '#/components/parameters/Pagination.pageSize'
+        - $ref: '#/components/parameters/NotificationRuleOrderByOrdering.order'
+        - $ref: '#/components/parameters/NotificationRuleOrderByOrdering.orderBy'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationRulePaginatedResponse'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+    post:
+      operationId: createNotificationRule
+      summary: Create a notification rule
+      description: Create a new notification rule.
+      parameters: []
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationRule'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationRuleCreateRequest'
+  /api/v1/notification/rules/{ruleId}:
+    put:
+      operationId: updateNotificationRule
+      summary: Update a notification rule
+      description: Update notification rule.
+      parameters:
+        - name: ruleId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationRule'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationRuleCreateRequest'
+    get:
+      operationId: getNotificationRule
+      summary: Get notification rule
+      description: Get a notification rule by id.
+      parameters:
+        - name: ruleId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationRule'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+    delete:
+      operationId: deleteNotificationRule
+      summary: Delete a notification rule
+      description: |-
+        Soft delete notification rule by id.
+
+        Once a notification rule is deleted it cannot be undeleted.
+      parameters:
+        - name: ruleId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+  /api/v1/notification/rules/{ruleId}/test:
+    post:
+      operationId: testNotificationRule
+      description: Test a notification rule by sending a test event with random data.
+      parameters:
+        - name: ruleId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationEvent'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+  /api/v1/notification/webhook/svix:
+    post:
+      operationId: receiveSvixOperationalEvent
+      summary: Receive Svix operational events
+      description: Callback endpoint used by Svix to notify about operational events.
+      parameters: []
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Notification (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SvixOperationalWebhookRequest'
+  /api/v1/plans:
+    get:
+      operationId: listPlans
+      summary: List plans
+      description: List all plans.
+      parameters:
+        - name: includeDeleted
+          in: query
+          required: false
+          description: |-
+            Include deleted plans in response.
+
+            Usage: `?includeDeleted=true`
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - name: id
+          in: query
+          required: false
+          description: Filter by plan.id attribute
+          schema:
+            type: array
+            items:
+              type: string
+              example: 01G65Z755AFWAKHE12NY0CQ9FH
+              pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+              description: ULID (Universally Unique Lexicographically Sortable Identifier).
+        - name: key
+          in: query
+          required: false
+          description: Filter by plan.key attribute
+          schema:
+            type: array
+            items:
+              type: string
+              minLength: 1
+              maxLength: 64
+              pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+              description: A key is a unique string that is used to identify a resource.
+        - name: keyVersion
+          in: query
+          required: false
+          description: Filter by plan.key and plan.version attributes
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+          style: deepObject
+        - $ref: '#/components/parameters/Pagination.page'
+        - $ref: '#/components/parameters/Pagination.pageSize'
+        - $ref: '#/components/parameters/PlanOrderByOrdering.order'
+        - $ref: '#/components/parameters/PlanOrderByOrdering.orderBy'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlanPaginatedResponse'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Plan (Experimental)
+    post:
+      operationId: createPlan
+      summary: Create a plan
+      description: Create a new plan.
+      parameters: []
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plan'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Plan (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlanCreate'
+  /api/v1/plans/{planIdOrKey}/next:
+    post:
+      operationId: newDraftPlan
+      summary: New draft plan
+      description: |-
+        Create a new draft version from plan.
+        It returns error if there is already a plan in draft or planId does not reference the latest published version.
+      parameters:
+        - name: planIdOrKey
+          in: path
+          required: true
+          schema:
+            anyOf:
+              - type: string
+                example: 01G65Z755AFWAKHE12NY0CQ9FH
+                pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+                description: ULID (Universally Unique Lexicographically Sortable Identifier).
+              - type: string
+                minLength: 1
+                maxLength: 64
+                pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+                description: A key is a unique string that is used to identify a resource.
+            x-go-type: string
+          x-go-type: string
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plan'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Plan (Experimental)
+  /api/v1/plans/{planId}:
+    put:
+      operationId: updatePlan
+      summary: Update a plan
+      description: Update plan by id.
+      parameters:
+        - name: planId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plan'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Plan (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlanUpdate'
+    get:
+      operationId: getPlan
+      summary: Get plan
+      description: Get a plan by id or key. The latest published version is returned if latter is used.
+      parameters:
+        - name: planId
+          in: path
+          required: true
+          schema:
+            anyOf:
+              - type: string
+                example: 01G65Z755AFWAKHE12NY0CQ9FH
+                pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+                description: ULID (Universally Unique Lexicographically Sortable Identifier).
+              - type: string
+                minLength: 1
+                maxLength: 64
+                pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+                description: A key is a unique string that is used to identify a resource.
+            x-go-type: string
+          x-go-type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plan'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Plan (Experimental)
+    delete:
+      operationId: deletePlan
+      summary: Delete plan
+      description: |-
+        Soft delete plan by plan.id.
+
+        Once a plan is deleted it cannot be undeleted.
+      parameters:
+        - name: planId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Plan (Experimental)
+  /api/v1/plans/{planId}/phases:
+    get:
+      operationId: listPlanPhases
+      summary: List phases in plan
+      description: List all phases in plan.
+      parameters:
+        - name: planId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: key
+          in: query
+          required: false
+          description: Filter by phase.key attribute
+          schema:
+            type: array
+            items:
+              type: string
+              minLength: 1
+              maxLength: 64
+              pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+              description: A key is a unique string that is used to identify a resource.
+        - $ref: '#/components/parameters/Pagination.page'
+        - $ref: '#/components/parameters/Pagination.pageSize'
+        - $ref: '#/components/parameters/PhasesOrderByOrdering.order'
+        - $ref: '#/components/parameters/PhasesOrderByOrdering.orderBy'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlanPhasePaginatedResponse'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Plan (Experimental)
+    post:
+      operationId: createPlanPhases
+      summary: Create new phase in plan
+      description: Create new phase in plan.
+      parameters:
+        - name: planId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlanPhase'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Plan (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlanPhaseCreate'
+  /api/v1/plans/{planId}/phases/{planPhaseKey}:
+    put:
+      operationId: updatePlanPhases
+      summary: Update phase in plan
+      description: Update phase in plan.
+      parameters:
+        - name: planId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: planPhaseKey
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlanPhase'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Plan (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlanPhaseUpdate'
+    get:
+      operationId: getPlanPhases
+      summary: Get phase for plan
+      description: Get phase in plan.
+      parameters:
+        - name: planId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: planPhaseKey
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlanPhase'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Plan (Experimental)
+    delete:
+      operationId: deletePlanPhases
+      summary: Delete phase for plan
+      description: |-
+        Delete phase in plan.
+
+        Once a phase is deleted it cannot be undeleted.
+      parameters:
+        - name: planId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: planPhaseKey
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Plan (Experimental)
+  /api/v1/plans/{planId}/publish:
+    post:
+      operationId: publishPlan
+      summary: Publish plan
+      description: Publish a new plan.
+      parameters:
+        - name: planId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Plan (Experimental)
+  /api/v1/plans/{planId}/unpublish:
+    post:
+      operationId: unpublishPlan
+      summary: Unpublish plan
+      description: Unpublish a new plan.
+      parameters:
+        - name: planId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Plan (Experimental)
+  /api/v1/portal/meters/{meterSlug}/query:
+    get:
+      operationId: queryPortalMeter
+      parameters:
+        - name: meterSlug
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+        - $ref: '#/components/parameters/MeterQuery.from'
+        - $ref: '#/components/parameters/MeterQuery.to'
+        - $ref: '#/components/parameters/MeterQuery.windowSize'
+        - $ref: '#/components/parameters/MeterQuery.windowTimeZone'
+        - $ref: '#/components/parameters/MeterQuery.filterGroupBy'
+        - $ref: '#/components/parameters/MeterQuery.groupBy'
+      description: Query meter for consumer portal. This endpoint is publicly exposable to consumers. Query meter for consumer portal. This endpoint is publicly exposable to consumers.
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MeterQueryResult'
+            text/csv:
+              schema:
+                type: string
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Portal
+      security:
+        - CloudPortalTokenAuth: []
+  /api/v1/portal/tokens:
+    post:
+      operationId: createPortalToken
+      description: Create a consumer portal token.
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PortalToken'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Portal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PortalToken'
+    get:
+      operationId: listPortalTokens
+      description: List tokens.
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 25
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PortalToken'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Portal
+  /api/v1/portal/tokens/invalidate:
+    post:
+      operationId: invalidatePortalTokens
+      description: Invalidates consumer portal tokens by ID or subject.
+      parameters: []
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Portal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: Invalidate a portal token by ID.
+                subject:
+                  type: string
+                  description: Invalidate all portal tokens for a subject.
+  /api/v1/subjects:
+    get:
+      operationId: listSubjects
+      description: List subjects.
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subject'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Subjects
+    post:
+      operationId: upsertSubject
+      description: |-
+        Upserts a subject. Creates or updates subject.
+
+        If the subject doesn't exist, it will be created.
+        If the subject exists, it will be partially updated with the provided fields.
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subject'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Subjects
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/SubjectUpsert'
+  /api/v1/subjects/{subjectIdOrKey}:
+    get:
+      operationId: getSubject
+      description: Get subject by ID or key.
+      parameters:
+        - name: subjectIdOrKey
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subject'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Subjects
+    delete:
+      operationId: deleteSubject
+      description: Delete subject by ID or key.
+      parameters:
+        - name: subjectIdOrKey
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Subjects
+  /api/v1/subjects/{subjectIdOrKey}/entitlements:
+    post:
+      operationId: createEntitlement
+      summary: Create an entitlement
+      description: |-
+        OpenMeter has three types of entitlements: metered, boolean, and static. The type property determines the type of entitlement. The underlying feature has to be compatible with the entitlement type specified in the request (e.g., a metered entitlement needs a feature associated with a meter).
+
+        - Boolean entitlements define static feature access, e.g. "Can use SSO authentication".
+        - Static entitlements let you pass along a configuration while granting access, e.g. "Using this feature with X Y settings" (passed in the config).
+        - Metered entitlements have many use cases, from setting up usage-based access to implementing complex credit systems.  Example: The customer can use 10000 AI tokens during the usage period of the entitlement.
+
+        A given subject can only have one active (non-deleted) entitlement per featureKey. If you try to create a new entitlement for a featureKey that already has an active entitlement, the request will fail with a 409 error.
+
+        Once an entitlement is created you cannot modify it, only delete it.
+      parameters:
+        - name: subjectIdOrKey
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entitlement'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '409':
+          description: The request could not be completed due to a conflict with the current state of the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConflictProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntitlementCreateInputs'
+    get:
+      operationId: listSubjectEntitlements
+      description: List all entitlements for a subject. For checking entitlement access, use the /value endpoint instead.
+      parameters:
+        - name: subjectIdOrKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: includeDeleted
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Entitlement'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+  /api/v1/subjects/{subjectIdOrKey}/entitlements/{entitlementIdOrFeatureKey}/grants:
+    get:
+      operationId: listEntitlementGrants
+      description: List all grants issued for an entitlement. The entitlement can be defined either by its id or featureKey.
+      parameters:
+        - name: subjectIdOrKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entitlementIdOrFeatureKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: includeDeleted
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          explode: false
+        - name: orderBy
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/GrantOrderBy'
+            default: updatedAt
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntitlementGrant'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+    post:
+      operationId: createGrant
+      description: |-
+        Grants define a behavior of granting usage for a metered entitlement. They can have complicated recurrence and rollover rules, thanks to which you can define a wide range of access patterns with a single grant, in most cases you don't have to periodically create new grants. You can only issue grants for active metered entitlements.
+
+        A grant defines a given amount of usage that can be consumed for the entitlement. The grant is in effect between its effective date and its expiration date. Specifying both is mandatory for new grants.
+
+        Grants have a priority setting that determines their order of use. Lower numbers have higher priority, with 0 being the highest priority.
+
+        Grants can have a recurrence setting intended to automate the manual reissuing of grants. For example, a daily recurrence is equal to reissuing that same grant every day (ignoring rollover settings).
+
+        Rollover settings define what happens to the remaining balance of a grant at a reset. Balance_After_Reset = MIN(MaxRolloverAmount, MAX(Balance_Before_Reset, MinRolloverAmount))
+
+        Grants cannot be changed once created, only deleted. This is to ensure that balance is deterministic regardless of when it is queried.
+      parameters:
+        - name: subjectIdOrKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entitlementIdOrFeatureKey
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntitlementGrant'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '409':
+          description: The request could not be completed due to a conflict with the current state of the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConflictProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntitlementGrantCreateInput'
+  /api/v1/subjects/{subjectIdOrKey}/entitlements/{entitlementIdOrFeatureKey}/override:
+    put:
+      operationId: overrideEntitlement
+      description: |-
+        Overriding an entitlement creates a new entitlement from the provided inputs and soft deletes the previous entitlement for the provided subject-feature pair. If the previous entitlement is already deleted or otherwise doesnt exist, the override will fail.
+
+        This endpoint is useful for upgrades, downgrades, or other changes to entitlements that require a new entitlement to be created with zero downtime.
+      parameters:
+        - name: subjectIdOrKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entitlementIdOrFeatureKey
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entitlement'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '409':
+          description: The request could not be completed due to a conflict with the current state of the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConflictProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntitlementCreateInputs'
+  /api/v1/subjects/{subjectIdOrKey}/entitlements/{entitlementIdOrFeatureKey}/value:
+    get:
+      operationId: getEntitlementValue
+      description: |-
+        This endpoint should be used for access checks and enforcement. All entitlement types share the hasAccess property in their value response, but multiple other properties are returned based on the entitlement type.
+
+        For convenience reasons, /value works with both entitlementId and featureKey.
+      parameters:
+        - name: subjectIdOrKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entitlementIdOrFeatureKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: time
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date-time
+            example: 2023-01-01T01:01:01.001Z
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntitlementValue'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+  /api/v1/subjects/{subjectIdOrKey}/entitlements/{entitlementId}:
+    get:
+      operationId: getEntitlement
+      description: Get entitlement by id. For checking entitlement access, use the /value endpoint instead.
+      parameters:
+        - name: subjectIdOrKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entitlementId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entitlement'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+    delete:
+      operationId: deleteEntitlement
+      description: |-
+        Deleting an entitlement revokes access to the associated feature. As a single subject can only have one entitlement per featureKey, when "migrating" features you have to delete the old entitlements as well.
+        As access and status checks can be historical queries, deleting an entitlement populates the deletedAt timestamp. When queried for a time before that, the entitlement is still considered active, you cannot have retroactive changes to access, which is important for, among other things, auditing.
+      parameters:
+        - name: subjectIdOrKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entitlementId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+  /api/v1/subjects/{subjectIdOrKey}/entitlements/{entitlementId}/history:
+    get:
+      operationId: getEntitlementHistory
+      description: |-
+        Returns historical balance and usage data for the entitlement. The queried history can span accross multiple reset events.
+
+        BurndownHistory returns a continous history of segments, where the segments are seperated by events that changed either the grant burndown priority or the usage period.
+
+        WindowedHistory returns windowed usage data for the period enriched with balance information and the list of grants that were being burnt down in that window.
+      parameters:
+        - name: subjectIdOrKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entitlementId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: from
+          in: query
+          required: false
+          description: 'Start of time range to query entitlement: date-time in RFC 3339 format. Defaults to the last reset. Gets truncated to the granularity of the underlying meter.'
+          schema:
+            type: string
+            format: date-time
+            example: 2023-01-01T01:01:01.001Z
+        - name: to
+          in: query
+          required: false
+          description: |-
+            End of time range to query entitlement: date-time in RFC 3339 format. Defaults to now.
+            If not now then gets truncated to the granularity of the underlying meter.
+          schema:
+            type: string
+            format: date-time
+            example: 2023-01-01T01:01:01.001Z
+        - name: windowSize
+          in: query
+          required: true
+          description: Windowsize
+          schema:
+            $ref: '#/components/schemas/WindowSize'
+        - name: windowTimeZone
+          in: query
+          required: false
+          description: The timezone used when calculating the windows.
+          schema:
+            type: string
+            default: UTC
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WindowedBalanceHistory'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+  /api/v1/subjects/{subjectIdOrKey}/entitlements/{entitlementId}/reset:
+    post:
+      operationId: resetEntitlementUsage
+      description: |-
+        Reset marks the start of a new usage period for the entitlement and initiates grant rollover. At the start of a period usage is zerod out and grants are rolled over based on their rollover settings. It would typically be synced with the subjects billing period to enforce usage based on their subscription.
+
+        Usage is automatically reset for metered entitlements based on their usage period, but this endpoint allows to manually reset it at any time. When doing so the period anchor of the entitlement can be changed if needed.
+      parameters:
+        - name: subjectIdOrKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: entitlementId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Entitlements (Experimental)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ResetEntitlementUsageInput'
+  /api/v1/subscriptions:
+    post:
+      operationId: Subscriptions_create
+      parameters: []
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subscription'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '409':
+          description: The request could not be completed due to a conflict with the current state of the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConflictProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Subscriptions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSubscriptionRequestBody'
+  /api/v1/subscriptions/{subscriptionId}:
+    get:
+      operationId: getSubscription_getSubscription
+      parameters:
+        - name: subscriptionId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+        - name: expand
+          in: query
+          required: false
+          schema:
+            type: boolean
+            enum:
+              - false
+              - true
+          explode: false
+        - name: at
+          in: query
+          required: false
+          description: The time at which the subscription should be queried. If not provided the current time is used.
+          schema:
+            type: string
+            format: date-time
+            example: 2023-01-01T01:01:01.001Z
+          explode: false
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                anyOf:
+                  - $ref: '#/components/schemas/Subscription'
+                  - $ref: '#/components/schemas/SubscriptionExpanded'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Subscriptions
+    patch:
+      operationId: editSubscription
+      description: |-
+        Batch processing commands for manipulating running subscriptions.
+        The key format is `/phases/{phaseKey}` or `/phases/{phaseKey}/items/{itemKey}`.
+
+        Add operations insert a new member based on the creation input without altering the existing members.
+
+        Remove operations remove the member from the collection / document.
+
+        The extend operation extends the specific phase if possible, while delaying all subsequent phases by the same amount.
+      parameters:
+        - name: subscriptionId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subscription'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '409':
+          description: The request could not be completed due to a conflict with the current state of the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConflictProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Subscriptions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                anyOf:
+                  - $ref: '#/components/schemas/SubscriptionEditAddUpdateItem'
+                  - $ref: '#/components/schemas/SubscriptionEditRemoveUpdateItem'
+                  - $ref: '#/components/schemas/SubscriptionEditAdd'
+                  - $ref: '#/components/schemas/SubscriptionEditExtend'
+                  - $ref: '#/components/schemas/SubscriptionEditRemoveWithValue'
+  /api/v1/subscriptions/{subscriptionId}/cancel:
+    post:
+      operationId: cancelSubscription
+      description: Cancels the subscription.
+      parameters:
+        - name: subscriptionId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subscription'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '409':
+          description: The request could not be completed due to a conflict with the current state of the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConflictProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Subscriptions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                effectiveDate:
+                  type: string
+                  format: date-time
+                  example: 2023-01-01T01:01:01.001Z
+                  description: If not provided the subscription is canceled immediately.
+  /api/v1/subscriptions/{subscriptionId}/migrate:
+    post:
+      operationId: migrateSubscription
+      description: Migrates the subscripiton to the procided version of the plan.
+      parameters:
+        - name: subscriptionId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subscription'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '409':
+          description: The request could not be completed due to a conflict with the current state of the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConflictProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Subscriptions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                targetVersion:
+                  type: integer
+                  minimum: 1
+              required:
+                - targetVersion
+  /api/v1/subscriptions/{subscriptionId}/unschedule-cancelation:
+    post:
+      operationId: unscheduleCancelation
+      description: Cancels the scheduled cancelation.
+      parameters:
+        - name: subscriptionId
+          in: path
+          required: true
+          schema:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subscription'
+        '400':
+          description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/BadRequestProblemResponse'
+        '401':
+          description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedProblemResponse'
+        '403':
+          description: The server understood the request but refuses to authorize it.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenProblemResponse'
+        '404':
+          description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/NotFoundProblemResponse'
+        '409':
+          description: The request could not be completed due to a conflict with the current state of the target resource.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ConflictProblemResponse'
+        '500':
+          description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/InternalServerErrorProblemResponse'
+        '503':
+          description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ServiceUnavailableProblemResponse'
+        default:
+          description: An unexpected error response.
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/UnexpectedProblemResponse'
+      tags:
+        - Subscriptions
+security:
+  - CloudTokenAuth: []
+  - CloudCookieAuth: []
+components:
+  parameters:
+    BillingInvoiceListParams.expand:
+      name: expand
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/BillingInvoiceExpand'
+        title: What parts of the list output to expand in listings
+      explode: false
+    BillingInvoiceListParams.extendedStatuses:
+      name: extendedStatuses
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/BillingInvoiceExtendedStatus'
+        title: Filter by invoice extended statuses
+      explode: false
+    BillingInvoiceListParams.issuedAfter:
+      name: issuedAfter
+      in: query
+      required: false
+      schema:
+        type: string
+        format: date-time
+        example: 2023-01-01T01:01:01.001Z
+        title: Filter by invoice creation time
+      explode: false
+    BillingInvoiceListParams.issuedBefore:
+      name: issuedBefore
+      in: query
+      required: false
+      schema:
+        type: string
+        format: date-time
+        example: 2023-01-01T01:01:01.001Z
+        title: Filter by invoice creation time
+      explode: false
+    BillingInvoiceListParams.statuses:
+      name: statuses
+      in: query
+      required: false
+      schema:
+        type: array
+        items:
+          $ref: '#/components/schemas/BillingInvoiceStatus'
+        title: Filter by the invoice status
+      explode: false
+    CustomerOrderByOrdering.order:
+      name: order
+      in: query
+      required: false
+      description: The order direction.
+      schema:
+        $ref: '#/components/schemas/SortOrder'
+        default: ASC
+      explode: false
+    CustomerOrderByOrdering.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: The order by field.
+      schema:
+        $ref: '#/components/schemas/CustomerOrderBy'
+      explode: false
+    CustomerOverrideOrderByOrdering.order:
+      name: order
+      in: query
+      required: false
+      description: The order direction.
+      schema:
+        $ref: '#/components/schemas/SortOrder'
+        default: ASC
+      explode: false
+    CustomerOverrideOrderByOrdering.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: The order by field.
+      schema:
+        $ref: '#/components/schemas/BillingCustomerOverrideOrderBy'
+      explode: false
+    EntitlementOrderByOrdering.order:
+      name: order
+      in: query
+      required: false
+      description: The order direction.
+      schema:
+        $ref: '#/components/schemas/SortOrder'
+        default: ASC
+      explode: false
+    EntitlementOrderByOrdering.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: The order by field.
+      schema:
+        $ref: '#/components/schemas/EntitlementOrderBy'
+      explode: false
+    FeatureOrderByOrdering.order:
+      name: order
+      in: query
+      required: false
+      description: The order direction.
+      schema:
+        $ref: '#/components/schemas/SortOrder'
+        default: ASC
+      explode: false
+    FeatureOrderByOrdering.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: The order by field.
+      schema:
+        $ref: '#/components/schemas/FeatureOrderBy'
+      explode: false
+    GrantOrderByOrdering.order:
+      name: order
+      in: query
+      required: false
+      description: The order direction.
+      schema:
+        $ref: '#/components/schemas/SortOrder'
+        default: ASC
+      explode: false
+    GrantOrderByOrdering.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: The order by field.
+      schema:
+        $ref: '#/components/schemas/GrantOrderBy'
+      explode: false
+    InvoiceOrderByOrdering.order:
+      name: order
+      in: query
+      required: false
+      description: The order direction.
+      schema:
+        $ref: '#/components/schemas/SortOrder'
+        default: ASC
+      explode: false
+    InvoiceOrderByOrdering.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: The order by field.
+      schema:
+        $ref: '#/components/schemas/BillingInvoiceOrderBy'
+      explode: false
+    LimitOffset.limit:
+      name: limit
+      in: query
+      required: false
+      description: |-
+        Number of items to return.
+
+        Default is 100.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+        default: 100
+      explode: false
+    LimitOffset.offset:
+      name: offset
+      in: query
+      required: false
+      description: |-
+        Number of items to skip.
+
+        Default is 0.
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+      explode: false
+    MarketplaceApiKeyInstallRequest.type:
+      name: type
+      in: path
+      required: true
+      description: The type of the app to install.
+      schema:
+        $ref: '#/components/schemas/AppType'
+    MarketplaceOAuth2InstallAuthorizeRequest.type:
+      name: type
+      in: path
+      required: true
+      description: The type of the app to install.
+      schema:
+        $ref: '#/components/schemas/AppType'
+    MeterQuery.filterGroupBy:
+      name: filterGroupBy
+      in: query
+      required: false
+      description: Simple filter for group bys with exact match.
+      schema:
+        type: object
+        additionalProperties:
+          type: string
+      style: deepObject
+    MeterQuery.from:
+      name: from
+      in: query
+      required: false
+      description: |-
+        Start date-time in RFC 3339 format.
+
+        Inclusive.
+      schema:
+        type: string
+        format: date-time
+        example: 2023-01-01T01:01:01.001Z
+    MeterQuery.groupBy:
+      name: groupBy
+      in: query
+      required: false
+      description: |-
+        If not specified a single aggregate will be returned for each subject and time window.
+        `subject` is a reserved group by value.
+      schema:
+        type: array
+        items:
+          type: string
+    MeterQuery.subject:
+      name: subject
+      in: query
+      required: false
+      description: Filtering by multiple subjects.
+      schema:
+        type: array
+        items:
+          type: string
+    MeterQuery.to:
+      name: to
+      in: query
+      required: false
+      description: |-
+        End date-time in RFC 3339 format.
+
+        Inclusive.
+      schema:
+        type: string
+        format: date-time
+        example: 2023-01-01T01:01:01.001Z
+    MeterQuery.windowSize:
+      name: windowSize
+      in: query
+      required: false
+      description: If not specified, a single usage aggregate will be returned for the entirety of the specified period for each subject and group.
+      schema:
+        $ref: '#/components/schemas/WindowSize'
+    MeterQuery.windowTimeZone:
+      name: windowTimeZone
+      in: query
+      required: false
+      description: |-
+        The value is the name of the time zone as defined in the IANA Time Zone Database (http://www.iana.org/time-zones).
+        If not specified, the UTC timezone will be used.
+      schema:
+        type: string
+        default: UTC
+    NotificationChannelOrderByOrdering.order:
+      name: order
+      in: query
+      required: false
+      description: The order direction.
+      schema:
+        $ref: '#/components/schemas/SortOrder'
+        default: ASC
+      explode: false
+    NotificationChannelOrderByOrdering.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: The order by field.
+      schema:
+        $ref: '#/components/schemas/NotificationChannelOrderBy'
+      explode: false
+    NotificationEventOrderByOrdering.order:
+      name: order
+      in: query
+      required: false
+      description: The order direction.
+      schema:
+        $ref: '#/components/schemas/SortOrder'
+        default: ASC
+      explode: false
+    NotificationEventOrderByOrdering.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: The order by field.
+      schema:
+        $ref: '#/components/schemas/NotificationEventOrderBy'
+      explode: false
+    NotificationRuleOrderByOrdering.order:
+      name: order
+      in: query
+      required: false
+      description: The order direction.
+      schema:
+        $ref: '#/components/schemas/SortOrder'
+        default: ASC
+      explode: false
+    NotificationRuleOrderByOrdering.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: The order by field.
+      schema:
+        $ref: '#/components/schemas/NotificationRuleOrderBy'
+      explode: false
+    OAuth2AuthorizationCodeGrantErrorParams.error:
+      name: error
+      in: query
+      required: false
+      description: |-
+        Error code.
+        Required with the error response.
+      schema:
+        $ref: '#/components/schemas/OAuth2AuthorizationCodeGrantErrorType'
+      explode: false
+    OAuth2AuthorizationCodeGrantErrorParams.error_description:
+      name: error_description
+      in: query
+      required: false
+      description: |-
+        Optional human-readable text providing additional information,
+        used to assist the client developer in understanding the error that occurred.
+      schema:
+        type: string
+      explode: false
+    OAuth2AuthorizationCodeGrantErrorParams.error_uri:
+      name: error_uri
+      in: query
+      required: false
+      description: |-
+        Optional uri identifying a human-readable web page with
+        information about the error, used to provide the client
+        developer with additional information about the error
+      schema:
+        type: string
+      explode: false
+    OAuth2AuthorizationCodeGrantSuccessParams.code:
+      name: code
+      in: query
+      required: false
+      description: |-
+        Authorization code which the client will later exchange for an access token.
+        Required with the success response.
+      schema:
+        type: string
+      explode: false
+    OAuth2AuthorizationCodeGrantSuccessParams.state:
+      name: state
+      in: query
+      required: false
+      description: |-
+        Required if the "state" parameter was present in the client authorization request.
+        The exact value received from the client:
+
+        Unique, randomly generated, opaque, and non-guessable string that is sent
+        when starting an authentication request and validated when processing the response.
+      schema:
+        type: string
+      explode: false
+    PaginatedQuery.page:
+      name: page
+      in: query
+      required: false
+      description: The page number.
+      schema:
+        type: integer
+        default: 1
+      explode: false
+    PaginatedQuery.pageSize:
+      name: pageSize
+      in: query
+      required: false
+      description: The number of items in the page.
+      schema:
+        type: integer
+        default: 100
+      explode: false
+    Pagination.page:
+      name: page
+      in: query
+      required: false
+      description: |-
+        Start date-time in RFC 3339 format.
+
+        Inclusive.
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+      explode: false
+    Pagination.pageSize:
+      name: pageSize
+      in: query
+      required: false
+      description: |-
+        Number of items per page.
+
+        Default is 100.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+        default: 100
+      explode: false
+    PhasesOrderByOrdering.order:
+      name: order
+      in: query
+      required: false
+      description: The order direction.
+      schema:
+        $ref: '#/components/schemas/SortOrder'
+        default: ASC
+      explode: false
+    PhasesOrderByOrdering.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: The order by field.
+      schema:
+        $ref: '#/components/schemas/PhasesOrderBy'
+      explode: false
+    PlanOrderByOrdering.order:
+      name: order
+      in: query
+      required: false
+      description: The order direction.
+      schema:
+        $ref: '#/components/schemas/SortOrder'
+        default: ASC
+      explode: false
+    PlanOrderByOrdering.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: The order by field.
+      schema:
+        $ref: '#/components/schemas/PlanOrderBy'
+      explode: false
+    ProfileOrderByOrdering.order:
+      name: order
+      in: query
+      required: false
+      description: The order direction.
+      schema:
+        $ref: '#/components/schemas/SortOrder'
+        default: ASC
+      explode: false
+    ProfileOrderByOrdering.orderBy:
+      name: orderBy
+      in: query
+      required: false
+      description: The order by field.
+      schema:
+        $ref: '#/components/schemas/BillingProfileOrderBy'
+      explode: false
+    queryCustomerList.includeDeleted:
+      name: includeDeleted
+      in: query
+      required: false
+      description: Include deleted customers.
+      schema:
+        type: boolean
+        default: false
+      explode: false
+    queryCustomerList.name:
+      name: name
+      in: query
+      required: false
+      description: |-
+        Filter customers by name.
+        Case-insensitive partial match.
+      schema:
+        type: string
+      explode: false
+    queryCustomerList.primaryEmail:
+      name: primaryEmail
+      in: query
+      required: false
+      description: |-
+        Filter customers by primary email.
+        Case-insensitive partial match.
+      schema:
+        type: string
+      explode: false
+    queryCustomerList.subject:
+      name: subject
+      in: query
+      required: false
+      description: |-
+        Filter customers by usage attribution subject.
+        Case-insensitive partial match.
+      schema:
+        type: string
+      explode: false
+  schemas:
+    Address:
+      type: object
+      properties:
+        country:
+          $ref: '#/components/schemas/CountryCode'
+        postalCode:
+          type: string
+        state:
+          type: string
+        city:
+          type: string
+        line1:
+          type: string
+        line2:
+          type: string
+        phoneNumber:
+          type: string
+      description: Address
+    Annotations:
+      type: object
+      additionalProperties: {}
+      example:
+        externalId: 019142cc-a016-796a-8113-1a942fecd26d
+      description: Set of key-value pairs managed by the system. Cannot be modified by user.
+    App:
+      anyOf:
+        - $ref: '#/components/schemas/StripeApp'
+        - $ref: '#/components/schemas/SandboxApp'
+      discriminator:
+        propertyName: type
+        mapping:
+          stripe: '#/components/schemas/StripeApp'
+          sandbox: '#/components/schemas/SandboxApp'
+      description: |-
+        App.
+        One of: stripe
+    AppBase:
+      type: object
+      required:
+        - id
+        - name
+        - createdAt
+        - updatedAt
+        - listing
+        - status
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the resource.
+          title: ID
+          readOnly: true
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        listing:
+          allOf:
+            - $ref: '#/components/schemas/MarketplaceListing'
+          description: The marketplace listing that this installed app is based on.
+          readOnly: true
+        status:
+          allOf:
+            - $ref: '#/components/schemas/AppStatus'
+          description: Status of the app connection.
+          readOnly: true
+      description: |-
+        Abstract base model for installed apps.
+
+        Represent an app installed to the organization.
+        This is an actual instance, with its own configuration and credentials.
+    AppCapability:
+      type: object
+      required:
+        - type
+        - key
+        - name
+        - description
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/AppCapabilityType'
+          description: The capability type.
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: Key
+        name:
+          type: string
+          description: The capability name.
+        description:
+          type: string
+          description: The capability description.
+      example:
+        type: collectPayments
+        key: stripe_collect_payment
+        name: Collect Payments
+        description: Stripe payments collects outstanding revenue with Stripe customer's default payment method.
+      description: |-
+        App capability.
+
+        Capabilities only exist in config so they don't extend the Resource model.
+    AppCapabilityType:
+      type: string
+      enum:
+        - reportUsage
+        - reportEvents
+        - calculateTax
+        - invoiceCustomers
+        - collectPayments
+      description: App capability type.
+    AppList:
+      type: object
+      required:
+        - page
+        - pageSize
+        - totalCount
+        - items
+      properties:
+        page:
+          type: integer
+          description: The page number.
+        pageSize:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          description: The number of items in the page.
+        totalCount:
+          type: integer
+          description: The total number of items.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/App'
+          maxItems: 1000
+          description: The items in the page.
+      description: A page of results.
+    AppReference:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+      description: |-
+        App reference
+
+        Can be used as a short reference to an app if the full app object is not needed.
+    AppStatus:
+      type: string
+      enum:
+        - ready
+        - unauthorized
+      description: App installed status.
+    AppType:
+      type: string
+      enum:
+        - stripe
+        - sandbox
+      description: Type of the app.
+    AppliedDiscount:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/AppliedDiscountPercentage'
+      description: 'A discount on plan. One of: percentage or amount.'
+    AppliedDiscountPercentage:
+      type: object
+      required:
+        - type
+        - percentage
+      properties:
+        type:
+          type: string
+          enum:
+            - percentage
+          description: The type of the discount.
+          title: Type
+        percentage:
+          type: number
+          minimum: 0
+          maximum: 100
+          description: The percentage of the discount.
+          title: Percentage
+        appliesTo:
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+            description: A key is a unique string that is used to identify a resource.
+          description: |-
+            The rate cards that the discount applies to.
+            When not specified, the discount applies to all rate cards.
+          title: Applies To
+      description: Percentage discount on plan.
+    AppliedDiscountPercentageUpdateItem:
+      type: object
+      required:
+        - percentage
+      properties:
+        percentage:
+          type: number
+          minimum: 0
+          maximum: 100
+          description: The percentage of the discount.
+          title: Percentage
+        appliesTo:
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+            description: A key is a unique string that is used to identify a resource.
+          description: |-
+            The rate cards that the discount applies to.
+            When not specified, the discount applies to all rate cards.
+          title: Applies To
+      description: Percentage discount on plan.
+    AppliedDiscountUpdateItem:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/AppliedDiscountPercentageUpdateItem'
+      description: 'A discount on plan. One of: percentage or amount.'
+    BadRequestProblemResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/UnexpectedProblemResponse'
+      description: The server cannot or will not process the request due to something that is perceived to be a client error (e.g., malformed request syntax, invalid request message framing, or deceptive request routing).
+    BalanceHistoryWindow:
+      type: object
+      required:
+        - period
+        - usage
+        - balanceAtStart
+      properties:
+        period:
+          $ref: '#/components/schemas/Period'
+        usage:
+          type: number
+          format: double
+          example: 100
+          description: The total usage of the feature in the period.
+          readOnly: true
+        balanceAtStart:
+          type: number
+          format: double
+          example: 100
+          description: The entitlement balance at the start of the period.
+          readOnly: true
+      description: The balance history window.
+    BillingCreateLineResult:
+      type: object
+      required:
+        - lines
+      properties:
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingInvoiceLine'
+          title: The created line items
+      description: Response for creating a pending charge
+    BillingCreateLinesRequest:
+      type: object
+      required:
+        - lines
+      properties:
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingInvoiceLineCreateItem'
+          title: The line to create
+      description: CreateLinesRequest is the request for creating manual line items.
+    BillingCreditNoteOriginalInvoiceRef:
+      type: object
+      required:
+        - type
+        - url
+      properties:
+        type:
+          type: string
+          enum:
+            - credit_node_original_invoice
+        issuedAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+          title: IssueAt reflects the time the document was issued.
+        number:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceNumber'
+          title: (Serial) Number of the referenced document.
+        url:
+          type: string
+          format: uri
+          title: Link to the source document.
+      allOf:
+        - $ref: '#/components/schemas/BillingGenericDocumentRef'
+    BillingCustomerOverride:
+      type: object
+      required:
+        - createdAt
+        - updatedAt
+        - workflow
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        workflow:
+          $ref: '#/components/schemas/BillingCustomerWorkflowOverride'
+        billingProfile:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: |-
+            The billing profile this override is associated with.
+
+            If not provided, the default billing profile is chosen if available.
+      description: Customer specific workflow overrides.
+    BillingCustomerOverrideOrderBy:
+      type: string
+      enum:
+        - id
+      description: Order by options for customers.
+    BillingCustomerWorkflowOverride:
+      type: object
+      required:
+        - createdAt
+        - updatedAt
+        - id
+        - taxApp
+        - invoicingApp
+        - paymentApp
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        collection:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowCollectionSettings'
+          title: The collection settings for this workflow
+        invoicing:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowInvoicingSettings'
+          title: The invoicing settings for this workflow
+        payment:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowPaymentSettings'
+          title: The payment settings for this workflow
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the resource.
+          title: ID
+          readOnly: true
+        taxApp:
+          allOf:
+            - $ref: '#/components/schemas/App'
+          title: The tax app used for this workflow
+        invoicingApp:
+          allOf:
+            - $ref: '#/components/schemas/App'
+          title: The invoicing app used for this workflow
+        paymentApp:
+          allOf:
+            - $ref: '#/components/schemas/App'
+          title: The payment app used for this workflow
+    BillingCustomerWorkflowOverrideCreate:
+      type: object
+      properties:
+        collection:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowCollectionSettings'
+          title: The collection settings for this workflow
+        invoicing:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowInvoicingSettings'
+          title: The invoicing settings for this workflow
+        payment:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowPaymentSettings'
+          title: The payment settings for this workflow
+    BillingDocumentRef:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/BillingCreditNoteOriginalInvoiceRef'
+      title: DocumentRef is used to describe a reference to an existing document (invoice).
+    BillingDocumentRefType:
+      type: string
+      enum:
+        - credit_node_original_invoice
+    BillingDueDate:
+      type: object
+      required:
+        - dueAt
+        - amount
+      properties:
+        dueAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+          title: When the payment is due.
+        notes:
+          type: string
+          title: Other details to take into account for the due date.
+        amount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: How much needs to be paid by the date.
+        percent:
+          allOf:
+            - $ref: '#/components/schemas/Percentage'
+          title: Percentage of the total that should be paid by the date.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          title: If different from the parent document's base currency.
+      title: DueDate contains an amount that should be paid by the given date.
+    BillingFlatFeeLine:
+      type: object
+      required:
+        - name
+        - createdAt
+        - updatedAt
+        - id
+        - status
+        - currency
+        - total
+        - period
+        - invoiceAt
+        - type
+        - item
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+        status:
+          $ref: '#/components/schemas/BillingLineStatus'
+        discounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingLineDiscount'
+          title: Discounts applied to this line.
+        charges:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingLineCharge'
+          title: Charges applied to this line.
+        invoice:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceReference'
+          title: The invoice this item belongs to.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          title: The currency of this line
+        taxes:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingTaxItem'
+          title: Map of taxes to be applied and used in the invoice totals.
+        taxOverrides:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/TaxConfig'
+          nullable: true
+          title: Tax overrides specify the tax configuration for this line.
+        total:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Total sum of the line, including discounts and charges.
+          readOnly: true
+        period:
+          allOf:
+            - $ref: '#/components/schemas/BillingPeriod'
+          title: Period of the line item applies to for revenue recognition pruposes.
+        invoiceAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+          title: The time this line item should be invoiced.
+        type:
+          type: string
+          enum:
+            - flat_fee
+        item:
+          allOf:
+            - $ref: '#/components/schemas/RateCardFlatFee'
+          title: Details about what is being sold.
+      description: |-
+        BillingFlatFeeLine represents a line item that is sold to the customer as a flat fee.
+
+        This object represents an item added via subscriptions.
+    BillingFlatFeeLineCreateItem:
+      type: object
+      required:
+        - name
+        - currency
+        - period
+        - invoiceAt
+        - type
+        - item
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        discounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingLineDiscount'
+          title: Discounts applied to this line.
+        charges:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingLineCharge'
+          title: Charges applied to this line.
+        invoice:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceReference'
+          title: The invoice this item belongs to.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          title: The currency of this line
+        taxOverrides:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/TaxConfig'
+          nullable: true
+          title: Tax overrides specify the tax configuration for this line.
+        period:
+          allOf:
+            - $ref: '#/components/schemas/BillingPeriod'
+          title: Period of the line item applies to for revenue recognition pruposes.
+        invoiceAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+          title: The time this line item should be invoiced.
+        type:
+          type: string
+          enum:
+            - flat_fee
+        item:
+          allOf:
+            - $ref: '#/components/schemas/RateCardFlatFee'
+          title: Details about what is being sold.
+      description: |-
+        BillingFlatFeeLine represents a line item that is sold to the customer as a flat fee.
+
+        This object represents an item added via subscriptions.
+    BillingFlatFeeLineCreateOrUpdate:
+      type: object
+      required:
+        - name
+        - id
+        - currency
+        - period
+        - invoiceAt
+        - type
+        - item
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+        discounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingLineDiscount'
+          title: Discounts applied to this line.
+        charges:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingLineCharge'
+          title: Charges applied to this line.
+        invoice:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceReference'
+          title: The invoice this item belongs to.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          title: The currency of this line
+        taxOverrides:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/TaxConfig'
+          nullable: true
+          title: Tax overrides specify the tax configuration for this line.
+        period:
+          allOf:
+            - $ref: '#/components/schemas/BillingPeriod'
+          title: Period of the line item applies to for revenue recognition pruposes.
+        invoiceAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+          title: The time this line item should be invoiced.
+        type:
+          type: string
+          enum:
+            - flat_fee
+        item:
+          allOf:
+            - $ref: '#/components/schemas/RateCardFlatFee'
+          title: Details about what is being sold.
+      description: |-
+        BillingFlatFeeLine represents a line item that is sold to the customer as a flat fee.
+
+        This object represents an item added via subscriptions.
+    BillingGenericDocumentRef:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/BillingDocumentRefType'
+          title: Type of the document referenced.
+        reason:
+          type: string
+          title: Human readable description on why this reference is here or needs to be used.
+        description:
+          type: string
+          title: Additional details about the document.
+      description: |-
+        Omitted fields:
+        period: Tax period in which the referred document had an effect required by some tax regimes and formats.
+        stamps: Seals of approval from other organisations that may need to be listed.
+        ext: 	Extensions for additional codes that may be required.
+      title: DocumentRef is used to describe an existing document or a specific part of it's contents.
+    BillingInvoice:
+      type: object
+      required:
+        - id
+        - createdAt
+        - updatedAt
+        - type
+        - supplier
+        - customer
+        - currency
+        - totals
+        - status
+        - statusDetails
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the resource.
+          title: ID
+          readOnly: true
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: |-
+            Timestamp of when the resource was last updated.
+
+            For updates the updatedAt field is used to detect conflicts.
+          title: Last Update Time
+        type:
+          $ref: '#/components/schemas/BillingInvoiceType'
+        supplier:
+          allOf:
+            - $ref: '#/components/schemas/BillingParty'
+          title: The taxable entity supplying the goods or services.
+        customer:
+          allOf:
+            - $ref: '#/components/schemas/BillingParty'
+          title: Legal entity receiving the goods or services.
+        number:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceNumber'
+          description: |-
+            Number specifies the human readable key used to reference this Invoice.
+
+            The number only gets populated after the invoice had been issued.
+
+            Please note that the number is (depending on the upstream settings) either unique for the
+            whole organization or unique for the customer, or in multi (stripe) account setups unique for the
+            account.
+          title: (Serial) Number of the invoice
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          title: Currency for all invoice totals.
+        preceding:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingDocumentRef'
+          title: Key information regarding previous invoices and potentially details as to why they were corrected.
+        totals:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceTotals'
+          title: Summary of all the invoice totals, including taxes (calculated).
+        status:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceStatus'
+          title: The status of the invoice.
+        statusDetails:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceStatusDetails'
+          title: The details of the current invoice status
+        issuedAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: |-
+            The time the invoice was issued.
+
+            Depending on the status of the invoice this can mean multiple things:
+            - draft, gathering: The time the invoice will be issued based on the workflow settings.
+            - issued: The time the invoice was issued.
+          title: The time the invoice was issued.
+        draftUntil:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: |-
+            The time until the invoice is in draft status.
+
+            On draft invoice creation it is calculated from the workflow settings.
+
+            If manual approval is required, the draftUntil time is set.
+          title: The time until the invoice is in draft status.
+        dueAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+          title: Due time of the fulfillment of the invoice.
+        period:
+          allOf:
+            - $ref: '#/components/schemas/BillingPeriod'
+          title: The period the invoice covers. If the invoice has no line items, it's not set.
+        voidedAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: |-
+            The time the invoice was voided.
+
+            If the invoice was voided, this field will be set to the time the invoice was voided.
+          title: The time the invoice was voided.
+        workflow:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceWorkflowSettings'
+          description: |-
+            The workflow associated with the invoice.
+
+            It is always a snapshot of the workflow settings at the time of invoice creation. The
+            field is optional as it should be explicitly requested with expand options.
+          title: The workflow settings associated with this invoice
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingInvoiceLine'
+          title: List of invoice lines representing each of the items sold to the customer.
+        discounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingInvoiceDiscount'
+          title: Discounts or allowances applied to the complete invoice.
+        payment:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoicePayment'
+          title: Information on when, how, and to whom the invoice should be paid.
+        validationIssues:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingValidationIssue'
+          title: Validation issues reported by the invoice workflow.
+      title: Invoice represents an invoice in the system.
+    BillingInvoiceAction:
+      type: string
+      enum:
+        - advance
+        - approve
+        - delete
+        - retry
+        - void
+    BillingInvoiceCreateInput:
+      type: object
+      properties:
+        IncludePendingLines:
+          type: array
+          items:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+            description: ULID (Universally Unique Lexicographically Sortable Identifier).
+          description: |-
+            The pending line items to include in the invoice, if not provided:
+            - all line items that have invoice_at < asOf will be included
+            - all usage based line items will be included up to asOf, new usage-based line items will be staged for the rest
+            of the billing cycle
+        AsOf:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: |-
+            The time as of which the invoice is created.
+
+            If not provided, the current time is used.
+    BillingInvoiceDiscount:
+      type: object
+      required:
+        - amount
+      properties:
+        base:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Base represents the value used as a base for percent calculations instead of the invoice's sum of lines.
+        percent:
+          allOf:
+            - $ref: '#/components/schemas/Percentage'
+          title: Percentage to apply to the base or invoice's sum.
+        amount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Amount to apply (calculated if percent present).
+        reason:
+          type: string
+          title: Text description as to why the discount was applied
+      title: Discount represents an allowance applied to the complete document independent from the individual lines.
+    BillingInvoiceExpand:
+      type: string
+      enum:
+        - '*'
+        - lines
+        - preceding
+        - workflow
+        - workflow.apps
+      description: InvoiceExpand specifies the parts of the invoice to expand in the list output.
+      x-enum-varnames:
+        - all
+        - lines
+        - preceding
+        - workflow
+        - workflowApps
+    BillingInvoiceExtendedStatus:
+      type: string
+      enum:
+        - gathering
+        - draft
+        - issuing
+        - issued
+        - draft_created
+        - draft_manual_approval_needed
+        - draft_validating
+        - draft_invalid
+        - draft_syncing
+        - draft_sync_failed
+        - draft_waiting_auto_approval
+        - draft_ready_to_issue
+        - issuing_syncing
+        - issuing_sync_failed
+      description: |-
+        InvoiceExtendedStatus describes the extended status of an invoice.
+
+        This is used to provide more detailed information about the status of the invoice. Useful for
+        troubelshooting invoice workflow issues.
+    BillingInvoiceLine:
+      anyOf:
+        - $ref: '#/components/schemas/BillingFlatFeeLine'
+        - $ref: '#/components/schemas/BillingManualFeeLine'
+      discriminator:
+        propertyName: type
+        mapping:
+          flat_fee: '#/components/schemas/BillingFlatFeeLine'
+          manual_fee: '#/components/schemas/BillingManualFeeLine'
+      title: UnitPriceLine represents a line item that is sold to the customer based on a specific (unit) price.
+    BillingInvoiceLineCreateItem:
+      anyOf:
+        - $ref: '#/components/schemas/BillingFlatFeeLineCreateItem'
+        - $ref: '#/components/schemas/BillingManualFeeLineCreateItem'
+      discriminator:
+        propertyName: type
+        mapping:
+          flat_fee: '#/components/schemas/BillingFlatFeeLineCreateItem'
+          manual_fee: '#/components/schemas/BillingManualFeeLineCreateItem'
+      title: UnitPriceLine represents a line item that is sold to the customer based on a specific (unit) price.
+    BillingInvoiceLineCreateOrUpdate:
+      anyOf:
+        - $ref: '#/components/schemas/BillingFlatFeeLineCreateOrUpdate'
+        - $ref: '#/components/schemas/BillingManualFeeLineCreateOrUpdate'
+      discriminator:
+        propertyName: type
+        mapping:
+          flat_fee: '#/components/schemas/BillingFlatFeeLineCreateOrUpdate'
+          manual_fee: '#/components/schemas/BillingManualFeeLineCreateOrUpdate'
+      title: UnitPriceLine represents a line item that is sold to the customer based on a specific (unit) price.
+    BillingInvoiceNumber:
+      type: string
+      example: INV-2024-01-01-01
+      minLength: 1
+      maxLength: 256
+      description: |-
+        InvoiceNumber is a unique identifier for the invoice, generated by the
+        invoicing app.
+
+        The uniqueness depends on a lot of factors:
+        - app setting (unique per app or unique per customer)
+        - multiple app scenarios (multiple apps generating invoices with the same prefix)
+    BillingInvoiceOrderBy:
+      type: string
+      enum:
+        - customer.name
+        - issuedAt
+        - status
+        - createdAt
+        - updatedAt
+      description: InvoiceOrderBy specifies the ordering options for invoice listing.
+    BillingInvoicePayment:
+      type: object
+      properties:
+        terms:
+          $ref: '#/components/schemas/BillingPaymentTerms'
+      title: Payment contains details as to how the invoice should be paid.
+    BillingInvoiceReference:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+          title: The ID of the invoice.
+        number:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceNumber'
+          title: The number of the invoice.
+      title: Reference to an invoice.
+    BillingInvoiceStatus:
+      type: string
+      enum:
+        - gathering
+        - draft
+        - issuing
+        - issued
+      description: InvoiceStatus describes the status of an invoice.
+    BillingInvoiceStatusDetails:
+      type: object
+      required:
+        - immutable
+        - failed
+        - extendedStatus
+        - availableActions
+      properties:
+        immutable:
+          type: boolean
+          title: Is the invoice editable?
+        failed:
+          type: boolean
+          title: Is the invoice in a failed state?
+        extendedStatus:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceExtendedStatus'
+          title: Extended status information for the invoice.
+        availableActions:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingInvoiceAction'
+          title: The actions that can be performed on the invoice.
+    BillingInvoiceTotals:
+      type: object
+      required:
+        - sum
+        - total
+        - totalWithTax
+        - payable
+      properties:
+        sum:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Sum of all line item sums
+        discount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Sum of all document level discounts
+        charge:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Sum of all document level charges
+        taxIncluded:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: If prices include tax, this is the total tax included in the price.
+        total:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Sum of all line sums minus the discounts, plus the charges, without tax.
+        tax:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Total amount of tax to apply to the invoice.
+        totalWithTax:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Grand total after all taxes have been applied.
+        rounding:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Rounding amount to apply to the invoice in case the total and payable amounts don't quite match.
+        payable:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Total amount to be paid after applying taxes and outlays.
+        advance:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Total amount already paid in advance.
+        due:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: How much actually needs to be paid now.
+      title: Totals contains the summaries of all calculations for the invoice.
+    BillingInvoiceType:
+      type: string
+      enum:
+        - standard
+        - credit_note
+    BillingInvoiceWorkflowSettings:
+      type: object
+      required:
+        - sourceBillingProfileID
+        - workflow
+        - timezone
+      properties:
+        apps:
+          allOf:
+            - $ref: '#/components/schemas/BillingProfileAppsOrReference'
+          title: The apps that will be used to orchestrate the invoice's workflow.
+        sourceBillingProfileID:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: |-
+            sourceBillingProfileID is the billing profile on which the workflow was based on.
+
+            The profile is snapshotted on invoice creation, after which it can be altered independently
+            of the profile itself.
+          title: The billing profile on which the workflow was based on.
+        workflow:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowSettings'
+          title: The workflow details used by this invoice.
+        timezone:
+          type: string
+          title: Timezone of the invoice's date fields.
+    BillingLineCharge:
+      type: object
+      required:
+        - amount
+      properties:
+        percent:
+          allOf:
+            - $ref: '#/components/schemas/Percentage'
+          description: Percentage if fixed amount not applied
+          title: Percent
+        amount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: Fixed discount amount to apply (calculated if percent present).
+          title: Amount
+        code:
+          type: string
+          title: Reason code.
+        reason:
+          type: string
+          title: Text description as to why the discount was applied.
+      title: LineCharge represents an amount added to the line, and will be applied before taxes.
+    BillingLineDiscount:
+      type: object
+      required:
+        - amount
+      properties:
+        percent:
+          allOf:
+            - $ref: '#/components/schemas/Percentage'
+          description: Percentage if fixed amount not applied
+          title: Percent
+        amount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: Fixed discount amount to apply (calculated if percent present).
+          title: Amount
+        code:
+          type: string
+          title: Reason code.
+        reason:
+          type: string
+          title: Text description as to why the discount was applied.
+      title: LineDiscount represents an amount deducted from the line, and will be applied before taxes.
+    BillingLineStatus:
+      type: string
+      enum:
+        - valid
+        - deleted
+        - split
+      title: Line status specifies the status of the line.
+    BillingManualFeeLine:
+      type: object
+      required:
+        - name
+        - createdAt
+        - updatedAt
+        - id
+        - status
+        - currency
+        - total
+        - period
+        - invoiceAt
+        - type
+        - price
+        - quantity
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+        status:
+          $ref: '#/components/schemas/BillingLineStatus'
+        discounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingLineDiscount'
+          title: Discounts applied to this line.
+        charges:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingLineCharge'
+          title: Charges applied to this line.
+        invoice:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceReference'
+          title: The invoice this item belongs to.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          title: The currency of this line
+        taxes:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingTaxItem'
+          title: Map of taxes to be applied and used in the invoice totals.
+        taxOverrides:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/TaxConfig'
+          nullable: true
+          title: Tax overrides specify the tax configuration for this line.
+        total:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Total sum of the line, including discounts and charges.
+          readOnly: true
+        period:
+          allOf:
+            - $ref: '#/components/schemas/BillingPeriod'
+          title: Period of the line item applies to for revenue recognition pruposes.
+        invoiceAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+          title: The time this line item should be invoiced.
+        type:
+          type: string
+          enum:
+            - manual_fee
+        price:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Price of the item being sold.
+        quantity:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Quantity of the item being sold.
+      description: BillingManualFeeLine represents a line item that is sold to the customer as a manually added fee.
+    BillingManualFeeLineCreateItem:
+      type: object
+      required:
+        - name
+        - currency
+        - period
+        - invoiceAt
+        - type
+        - price
+        - quantity
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        discounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingLineDiscount'
+          title: Discounts applied to this line.
+        charges:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingLineCharge'
+          title: Charges applied to this line.
+        invoice:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceReference'
+          title: The invoice this item belongs to.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          title: The currency of this line
+        taxOverrides:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/TaxConfig'
+          nullable: true
+          title: Tax overrides specify the tax configuration for this line.
+        period:
+          allOf:
+            - $ref: '#/components/schemas/BillingPeriod'
+          title: Period of the line item applies to for revenue recognition pruposes.
+        invoiceAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+          title: The time this line item should be invoiced.
+        type:
+          type: string
+          enum:
+            - manual_fee
+        price:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Price of the item being sold.
+        quantity:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Quantity of the item being sold.
+      description: BillingManualFeeLine represents a line item that is sold to the customer as a manually added fee.
+    BillingManualFeeLineCreateOrUpdate:
+      type: object
+      required:
+        - name
+        - id
+        - currency
+        - period
+        - invoiceAt
+        - type
+        - price
+        - quantity
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+        discounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingLineDiscount'
+          title: Discounts applied to this line.
+        charges:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingLineCharge'
+          title: Charges applied to this line.
+        invoice:
+          allOf:
+            - $ref: '#/components/schemas/BillingInvoiceReference'
+          title: The invoice this item belongs to.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          title: The currency of this line
+        taxOverrides:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/TaxConfig'
+          nullable: true
+          title: Tax overrides specify the tax configuration for this line.
+        period:
+          allOf:
+            - $ref: '#/components/schemas/BillingPeriod'
+          title: Period of the line item applies to for revenue recognition pruposes.
+        invoiceAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+          title: The time this line item should be invoiced.
+        type:
+          type: string
+          enum:
+            - manual_fee
+        price:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Price of the item being sold.
+        quantity:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Quantity of the item being sold.
+      description: BillingManualFeeLine represents a line item that is sold to the customer as a manually added fee.
+    BillingParty:
+      type: object
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+          title: ID of the party.
+        name:
+          type: string
+          title: Legal name or representation of the organization.
+        taxId:
+          allOf:
+            - $ref: '#/components/schemas/BillingTaxIdentity'
+          title: The entity's legal ID code used for tax purposes. They may have other numbers, but we're only interested in those valid for tax purposes.
+        addresses:
+          type: array
+          items:
+            $ref: '#/components/schemas/Address'
+          maxItems: 1
+          title: Regular post addresses for where information should be sent if needed.
+      title: Party represents a person or business entity.
+    BillingPartyCreate:
+      type: object
+      properties:
+        name:
+          type: string
+          title: Legal name or representation of the organization.
+        taxId:
+          allOf:
+            - $ref: '#/components/schemas/BillingTaxIdentity'
+          title: The entity's legal ID code used for tax purposes. They may have other numbers, but we're only interested in those valid for tax purposes.
+        addresses:
+          type: array
+          items:
+            $ref: '#/components/schemas/Address'
+          maxItems: 1
+          title: Regular post addresses for where information should be sent if needed.
+      title: Party represents a person or business entity.
+    BillingPaymentTermDueDate:
+      type: object
+      required:
+        - type
+        - dueAt
+      properties:
+        type:
+          type: string
+          enum:
+            - due_date
+          title: Type of terms to be applied.
+        detail:
+          type: string
+          title: Text detail of the chosen payment terms.
+        notes:
+          type: string
+          title: Description of the conditions for payment.
+        dueAt:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingDueDate'
+          minItems: 1
+          title: When the payment is due.
+      title: PaymentTermDueDate defines the terms for payment on a specific date.
+    BillingPaymentTermInstant:
+      type: object
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - instant
+          title: Type of terms to be applied.
+        detail:
+          type: string
+          title: Text detail of the chosen payment terms.
+        notes:
+          type: string
+          title: Description of the conditions for payment.
+      title: PaymentTermInstant defines the terms for payment on receipt of invoice.
+    BillingPaymentTerms:
+      anyOf:
+        - $ref: '#/components/schemas/BillingPaymentTermInstant'
+        - $ref: '#/components/schemas/BillingPaymentTermDueDate'
+      title: PaymentTerms defines the terms for payment.
+    BillingPeriod:
+      type: object
+      required:
+        - start
+        - end
+      properties:
+        start:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+          title: Start of the period.
+        end:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+          title: End of the period.
+      title: Period represents a time range.
+    BillingProfile:
+      type: object
+      required:
+        - id
+        - name
+        - createdAt
+        - updatedAt
+        - supplier
+        - workflow
+        - apps
+        - default
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the resource.
+          title: ID
+          readOnly: true
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: |-
+            When the resource was last updated.
+
+            For updates this field must be set to the last update time to detect conflicts.
+          title: Last update time of the resource
+        supplier:
+          allOf:
+            - $ref: '#/components/schemas/BillingParty'
+          title: The name and contact information for the supplier this billing profile represents
+        workflow:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflow'
+          title: The billing workflow settings for this profile
+        apps:
+          allOf:
+            - $ref: '#/components/schemas/BillingProfileAppsOrReference'
+          title: The applications used by this billing profile
+        default:
+          type: boolean
+          title: Is this the default profile?
+      description: Profile represents a billing profile
+    BillingProfileAppReferences:
+      type: object
+      required:
+        - tax
+        - invoicing
+        - payment
+      properties:
+        tax:
+          allOf:
+            - $ref: '#/components/schemas/AppReference'
+          title: The tax app used for this workflow
+        invoicing:
+          allOf:
+            - $ref: '#/components/schemas/AppReference'
+          title: The invoicing app used for this workflow
+        payment:
+          allOf:
+            - $ref: '#/components/schemas/AppReference'
+          title: The payment app used for this workflow
+      description: ProfileAppsReference represents the references (id, type) to the apps used by a billing profile
+    BillingProfileApps:
+      type: object
+      required:
+        - tax
+        - invoicing
+        - payment
+      properties:
+        tax:
+          allOf:
+            - $ref: '#/components/schemas/App'
+          title: The tax app used for this workflow
+        invoicing:
+          allOf:
+            - $ref: '#/components/schemas/App'
+          title: The invoicing app used for this workflow
+        payment:
+          allOf:
+            - $ref: '#/components/schemas/App'
+          title: The payment app used for this workflow
+      description: ProfileApps represents the applications used by a billing profile
+    BillingProfileAppsOrReference:
+      anyOf:
+        - $ref: '#/components/schemas/BillingProfileApps'
+        - $ref: '#/components/schemas/BillingProfileAppReferences'
+    BillingProfileCreateAppsInput:
+      type: object
+      required:
+        - tax
+        - invoicing
+        - payment
+      properties:
+        tax:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowAppIdOrType'
+          title: The tax app used for this workflow
+        invoicing:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowAppIdOrType'
+          title: The invoicing app used for this workflow
+        payment:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowAppIdOrType'
+          title: The payment app used for this workflow
+      description: ProfileCreateAppsInput represents the input for creating a billing profile's apps
+    BillingProfileCreateInput:
+      type: object
+      required:
+        - name
+        - supplier
+        - workflow
+        - default
+        - apps
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        supplier:
+          allOf:
+            - $ref: '#/components/schemas/BillingPartyCreate'
+          title: The name and contact information for the supplier this billing profile represents
+        workflow:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflow'
+          title: The billing workflow settings for this profile
+        default:
+          type: boolean
+          title: Is this the default profile?
+        apps:
+          $ref: '#/components/schemas/BillingProfileCreateAppsInput'
+      description: ProfileCreateInput represents the input for creating a billing profile
+    BillingProfileCreateOrUpdate:
+      type: object
+      required:
+        - name
+        - updatedAt
+        - supplier
+        - workflow
+        - default
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: |-
+            When the resource was last updated.
+
+            For updates this field must be set to the last update time to detect conflicts.
+          title: Last update time of the resource
+        supplier:
+          allOf:
+            - $ref: '#/components/schemas/BillingParty'
+          title: The name and contact information for the supplier this billing profile represents
+        workflow:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflow'
+          title: The billing workflow settings for this profile
+        default:
+          type: boolean
+          title: Is this the default profile?
+      description: Profile represents a billing profile
+    BillingProfileExpand:
+      type: string
+      enum:
+        - apps
+        - '*'
+      description: ProfileExpand details what profile fields to expand
+      x-enum-varnames:
+        - apps
+        - all
+    BillingProfileOrderBy:
+      type: string
+      enum:
+        - createdAt
+        - updatedAt
+        - default
+        - name
+      description: ProfileOrderBy specifies the ordering options for profiles
+    BillingTaxBehavior:
+      type: string
+      enum:
+        - inclusive
+        - exclusive
+    BillingTaxIdentificationCode:
+      type: string
+      minLength: 1
+      maxLength: 32
+      pattern: ^[A-Za-z0-9]+([\.\-\/ _]?[A-Za-z0-9]+)*$
+    BillingTaxIdentity:
+      type: object
+      properties:
+        code:
+          allOf:
+            - $ref: '#/components/schemas/BillingTaxIdentificationCode'
+          title: Normalized tax code shown on the original identity document.
+      title: Identity stores the details required to identify an entity for tax purposes in a specific country.
+    BillingTaxItem:
+      type: object
+      properties:
+        config:
+          allOf:
+            - $ref: '#/components/schemas/TaxConfig'
+          title: Tax provider configuration.
+        percent:
+          allOf:
+            - $ref: '#/components/schemas/Percentage'
+          title: |-
+            Percent defines the percentage set manually or determined from the rate
+            key (calculated if rate present). A nil percent implies that this tax combo
+            is **exempt** from tax.
+        surcharge:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          title: Some countries require an additional surcharge (calculated if rate present).
+        behavior:
+          allOf:
+            - $ref: '#/components/schemas/BillingTaxBehavior'
+          title: Is the tax item inclusive or exclusive of the base amount.
+    BillingValidationIssue:
+      type: object
+      required:
+        - severity
+        - component
+        - message
+      properties:
+        severity:
+          allOf:
+            - $ref: '#/components/schemas/BillingValidationIssueSeverity'
+          title: The severity of the issue.
+        field:
+          type: string
+          title: The field that the issue is related to, if available in JSON path format.
+        code:
+          type: string
+          title: Machine indentifiable code for the issue, if available.
+        component:
+          type: string
+          title: Component reporting the issue.
+        message:
+          type: string
+          title: A human-readable description of the issue.
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          title: Metadata
+      description: |-
+        ValidationIssue captures any validation issues related to the invoice.
+
+        Issues with severity "critical" will prevent the invoice from being issued.
+    BillingValidationIssueSeverity:
+      type: string
+      enum:
+        - critical
+        - warning
+      description: |-
+        ValidationIssueSeverity describes the severity of a validation issue.
+
+        Issues with severity "critical" will prevent the invoice from being issued.
+    BillingVoidInvoiceAction:
+      type: object
+      required:
+        - percentage
+        - action
+      properties:
+        percentage:
+          allOf:
+            - $ref: '#/components/schemas/Percentage'
+          title: How much of the total line items to be voided? (e.g. 100% means all charges are voided)
+        action:
+          allOf:
+            - $ref: '#/components/schemas/BillingVoidInvoiceLineAction'
+          title: 'How to handle the voided line items, default: pending'
+      description: InvoiceVoidAction describes how to handle the voided line items.
+    BillingVoidInvoiceInput:
+      type: object
+      required:
+        - action
+        - reason
+        - overrides
+      properties:
+        action:
+          allOf:
+            - $ref: '#/components/schemas/BillingVoidInvoiceAction'
+          description: The action to take on the voided line items.
+          title: The action to take on the voided lines.
+        reason:
+          type: string
+          description: The reason for voiding the invoice.
+          title: The reason for voiding the invoice
+        overrides:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingVoidInvoiceLineOverride'
+          nullable: true
+          description: |-
+            Per line item overrides for the action.
+
+            If not specified, the `action` will be applied to all line items.
+      description: Request to void an invoice
+    BillingVoidInvoiceLineAction:
+      type: string
+      enum:
+        - discard
+        - pending
+        - pending_next_cycle
+      title: VoidInvoiceLineAction describes how to handle the voidied line item in the invoice.
+    BillingVoidInvoiceLineOverride:
+      type: object
+      required:
+        - lineId
+        - action
+      properties:
+        lineId:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+          title: The line item ID to override
+        action:
+          allOf:
+            - $ref: '#/components/schemas/BillingVoidInvoiceAction'
+          title: The action to take on the line item
+      description: VoidInvoiceLineOverride describes how to handle a specific line item in the invoice when voiding.
+    BillingWorkflow:
+      type: object
+      required:
+        - createdAt
+        - updatedAt
+        - id
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        collection:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowCollectionSettings'
+          title: The collection settings for this workflow
+        invoicing:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowInvoicingSettings'
+          title: The invoicing settings for this workflow
+        payment:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowPaymentSettings'
+          title: The payment settings for this workflow
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the resource.
+          title: ID
+          readOnly: true
+      description: Workflow represents a billing workflow
+    BillingWorkflowAppIdOrType:
+      type: string
+      description: |-
+        AppIdOrType can be used to reference an app during creation only.
+
+        This can be either an AppType or the ULID of an app.
+    BillingWorkflowCollectionAlignment:
+      type: string
+      enum:
+        - subscription
+      description: |-
+        CollectionAlignment specifies when the pending line items should be collected into
+        an invoice.
+      title: Collection alignment
+    BillingWorkflowCollectionMethod:
+      type: string
+      enum:
+        - charge_automatically
+        - send_invoice
+      description: CollectionMethod specifies how the invoice should be collected (automatic vs manual)
+      title: Collection method
+    BillingWorkflowCollectionSettings:
+      type: object
+      properties:
+        alignment:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowCollectionAlignment'
+          description: When to collect the pending line items into an invoice.
+          default: subscription
+        interval:
+          type: string
+          format: ISO8601
+          example: P1D
+          description: The interval for collecting the pending line items into an invoice.
+          default: PT1H
+      title: Workflow collection specifies how to collect the pending line items for an invoice
+    BillingWorkflowInvoicingSettings:
+      type: object
+      properties:
+        autoAdvance:
+          type: boolean
+          description: Whether to automatically issue the invoice after the draftPeriod has passed.
+          default: true
+        draftPeriod:
+          type: string
+          format: ISO8601
+          example: P1D
+          description: The period for the invoice to be kept in draft status for manual reviews.
+          default: P1D
+        dueAfter:
+          type: string
+          format: ISO8601
+          example: P1D
+          description: The period after which the invoice is due.
+          default: P7D
+      description: WorkflowInvoice represents the invoice settings for a billing workflow
+      title: Workflow invoice settings
+    BillingWorkflowPaymentSettings:
+      type: object
+      properties:
+        collectionMethod:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowCollectionMethod'
+          default: charge_automatically
+      description: WorkflowPaymentSettings represents the payment settings for a billing workflow
+      title: Workflow payment settings
+    BillingWorkflowSettings:
+      type: object
+      properties:
+        collection:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowCollectionSettings'
+          title: The collection settings for this workflow
+        invoicing:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowInvoicingSettings'
+          title: The invoicing settings for this workflow
+        payment:
+          allOf:
+            - $ref: '#/components/schemas/BillingWorkflowPaymentSettings'
+          title: The payment settings for this workflow
+    CheckoutSessionCustomTextAfterSubmitParams:
+      type: object
+      properties:
+        afterSubmit:
+          type: object
+          properties:
+            message:
+              type: string
+        shippingAddress:
+          type: object
+          properties:
+            message:
+              type: string
+        submit:
+          type: object
+          properties:
+            message:
+              type: string
+        termsOfServiceAcceptance:
+          type: object
+          properties:
+            message:
+              type: string
+      description: Stripe CheckoutSession.custom_text
+    CheckoutSessionUIMode:
+      type: string
+      enum:
+        - embedded
+        - hosted
+      description: Stripe CheckoutSession.ui_mode
+    ClientAppStartResponse:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
+          description: The URL to start the OAuth2 authorization code grant flow.
+      description: Response from the client app (OpenMeter backend) to start the OAuth2 flow.
+    ConflictProblemResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/UnexpectedProblemResponse'
+      description: The request could not be completed due to a conflict with the current state of the target resource.
+    CountryCode:
+      type: string
+      example: US
+      minLength: 2
+      maxLength: 2
+      pattern: ^[A-Z]{2}$
+      description: |-
+        [ISO 3166-1](https://www.iso.org/iso-3166-country-codes.html) alpha-2 country code.
+        Custom two-letter country codes are also supported for convenience.
+    CreateStripeCheckoutSessionRequest:
+      type: object
+      required:
+        - customer
+        - options
+      properties:
+        appId:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: If not provided, the default Stripe app is used if any.
+        customer:
+          anyOf:
+            - $ref: '#/components/schemas/CustomerId'
+            - $ref: '#/components/schemas/Customer'
+          description: |-
+            Provide a customer ID to use an existing OpenMeter customer.
+            or provide a customer object to create a new customer.
+        stripeCustomerId:
+          type: string
+          description: |-
+            Stripe customer ID.
+            If not provided OpenMeter creates a new Stripe customer or
+            uses the OpenMeter customer's default Stripe customer ID.
+        options:
+          allOf:
+            - $ref: '#/components/schemas/CreateStripeCheckoutSessionRequestOptions'
+          description: Options passed to Stripe when creating the checkout session.
+      description: Create Stripe checkout session request.
+    CreateStripeCheckoutSessionRequestOptions:
+      type: object
+      properties:
+        currency:
+          $ref: '#/components/schemas/CurrencyCode'
+        cancelURL:
+          type: string
+        clientReferenceID:
+          type: string
+        customText:
+          $ref: '#/components/schemas/CheckoutSessionCustomTextAfterSubmitParams'
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+        returnURL:
+          type: string
+        successURL:
+          type: string
+        uiMode:
+          $ref: '#/components/schemas/CheckoutSessionUIMode'
+        paymentMethodTypes:
+          type: array
+          items:
+            type: string
+      description: Create Stripe checkout session options
+    CreateStripeCheckoutSessionResult:
+      type: object
+      required:
+        - customerId
+        - stripeCustomerId
+        - sessionId
+        - setupIntentId
+        - url
+        - mode
+      properties:
+        customerId:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: The OpenMeter customer ID.
+        stripeCustomerId:
+          type: string
+          description: The Stripe customer ID.
+        sessionId:
+          type: string
+          description: The checkout session ID.
+        setupIntentId:
+          type: string
+          description: The checkout session setup intent ID.
+        url:
+          type: string
+          description: URL to show the checkout session.
+        mode:
+          allOf:
+            - $ref: '#/components/schemas/StripeCheckoutSessionMode'
+          description: |-
+            Mode
+            Always `setup` for now.
+        cancelURL:
+          type: string
+          description: Cancel URL.
+        successURL:
+          type: string
+          description: Success URL.
+        returnURL:
+          type: string
+          description: Return URL.
+      description: Create Stripe Checkout Session response.
+    CreateSubscriptionRequestBody:
+      type: object
+      required:
+        - customerId
+        - plan
+        - currency
+        - activeFrom
+        - customizations
+      properties:
+        customerId:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+        plan:
+          type: object
+          properties:
+            key:
+              type: string
+              minLength: 1
+              maxLength: 64
+              pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+              description: A key is a unique string that is used to identify a resource.
+            version:
+              type: integer
+          required:
+            - key
+            - version
+        currency:
+          $ref: '#/components/schemas/CurrencyCode'
+        activeFrom:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+        customizations:
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/SubscriptionEditAddItem'
+              - $ref: '#/components/schemas/SubscriptionEditRemoveItem'
+          maxItems: 100
+          description: |-
+            Batch processing commands for customizing the susbcription.
+            The key format is `/phases/{phaseKey}/items/{itemKey}`.
+
+            Add operations insert a new member based on the creation input without altering the existing members.
+
+            Remove operations remove the member from the document.
+      description: Create subscription request body.
+    CurrencyCode:
+      type: string
+      example: USD
+      minLength: 3
+      maxLength: 3
+      pattern: ^[A-Z]{3}$
+      description: |-
+        Three-letter [ISO4217](https://www.iso.org/iso-4217-currency-codes.html) currency code.
+        Custom three-letter currency codes are also supported for convenience.
+    Customer:
+      type: object
+      required:
+        - id
+        - name
+        - createdAt
+        - updatedAt
+        - usageAttribution
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the resource.
+          title: ID
+          readOnly: true
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        timezone:
+          type: string
+          description: Timezone of the customer.
+          title: Timezone
+        usageAttribution:
+          allOf:
+            - $ref: '#/components/schemas/CustomerUsageAttribution'
+          description: Mapping to attribute metered usage to the customer
+          title: Usage Attribution
+        primaryEmail:
+          type: string
+          description: The primary email address of the customer.
+          title: Primary Email
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: |-
+            Currency of the customer.
+            Used for billing, tax and invoicing.
+          title: Currency
+        billingAddress:
+          allOf:
+            - $ref: '#/components/schemas/Address'
+          description: |-
+            The billing address of the customer.
+            Used for tax and invoicing.
+          title: Billing Address
+        external:
+          allOf:
+            - $ref: '#/components/schemas/CustomerExternalMapping'
+          description: External mappings for the customer.
+          title: External Mappings
+      example:
+        id: 01G65Z755AFWAKHE12NY0CQ9FH
+        name: ACME Inc.
+        usageAttribution:
+          subjectKeys:
+            - my_subject_key
+        external:
+          stripeCustomerId: cus_xxxxxxxxxxxxxx
+        createdAt: 2024-01-01T01:01:01.001Z
+        updatedAt: 2024-01-01T01:01:01.001Z
+      description: A customer object.
+    CustomerExternalMapping:
+      type: object
+      properties:
+        stripeCustomerId:
+          type: string
+          description: |-
+            The Stripe customer ID.
+            Mapping to a Stripe Customer object.
+            Required to use Stripe as an invocing provider.
+          title: Stripe Customer
+      description: External mappings for the customer.
+    CustomerId:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+      description: Create Stripe checkout session customer ID.
+    CustomerList:
+      type: object
+      required:
+        - page
+        - pageSize
+        - totalCount
+        - items
+      properties:
+        page:
+          type: integer
+          description: The page number.
+        pageSize:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          description: The number of items in the page.
+        totalCount:
+          type: integer
+          description: The total number of items.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Customer'
+          maxItems: 1000
+          description: The items in the page.
+      description: A page of results.
+    CustomerOrderBy:
+      type: string
+      enum:
+        - id
+        - name
+        - createdAt
+      description: Order by options for customers.
+    CustomerOverridePaginatedResponse:
+      type: object
+      required:
+        - totalCount
+        - page
+        - pageSize
+        - items
+      properties:
+        totalCount:
+          type: integer
+          example: 500
+          description: The items in the current page.
+        page:
+          type: integer
+          example: 1
+          description: The items in the current page.
+        pageSize:
+          type: integer
+          example: 100
+          description: The items in the current page.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingCustomerOverride'
+          description: The items in the current page.
+      description: Paginated response
+    CustomerUsageAttribution:
+      type: object
+      required:
+        - subjectKeys
+      properties:
+        subjectKeys:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          maxItems: 1
+          description: The subjects that are attributed to the customer.
+          title: SubjectKeys
+      description: |-
+        Mapping to attribute metered usage to the customer.
+        One customer can have multiple subjects,
+        but one subject can only belong to one customer.
+    Entitlement:
+      anyOf:
+        - $ref: '#/components/schemas/EntitlementMetered'
+        - $ref: '#/components/schemas/EntitlementStatic'
+        - $ref: '#/components/schemas/EntitlementBoolean'
+      discriminator:
+        propertyName: type
+        mapping:
+          metered: '#/components/schemas/EntitlementMetered'
+          static: '#/components/schemas/EntitlementStatic'
+          boolean: '#/components/schemas/EntitlementBoolean'
+      description: |-
+        Entitlement templates are used to define the entitlements of a plan.
+        Features are omitted from the entitlement template, as they are defined in the rate card.
+    EntitlementBaseTemplate:
+      type: object
+      required:
+        - createdAt
+        - updatedAt
+        - id
+        - type
+        - subjectKey
+        - featureKey
+        - featureId
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the feature.
+        id:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: Readonly unique ULID identifier.
+          readOnly: true
+        type:
+          allOf:
+            - $ref: '#/components/schemas/EntitlementType'
+          description: The type of the entitlement.
+          title: Type
+        subjectKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: The identifier key unique to the subject
+          example: customer-1
+        featureKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: The feature the subject is entitled to use.
+          example: example-feature-key
+        featureId:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: The feature the subject is entitled to use.
+        currentUsagePeriod:
+          allOf:
+            - $ref: '#/components/schemas/Period'
+          description: The current usage period.
+        usagePeriod:
+          allOf:
+            - $ref: '#/components/schemas/RecurringPeriod'
+          description: The defined usage period of the entitlement
+      description: Shared fields of the entitlement templates.
+    EntitlementBoolean:
+      type: object
+      required:
+        - type
+        - createdAt
+        - updatedAt
+        - id
+        - subjectKey
+        - featureKey
+        - featureId
+      properties:
+        type:
+          type: string
+          enum:
+            - boolean
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the feature.
+        id:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: Readonly unique ULID identifier.
+          readOnly: true
+        subjectKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: The identifier key unique to the subject
+          example: customer-1
+        featureKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: The feature the subject is entitled to use.
+          example: example-feature-key
+        featureId:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: The feature the subject is entitled to use.
+        currentUsagePeriod:
+          allOf:
+            - $ref: '#/components/schemas/Period'
+          description: The current usage period.
+        usagePeriod:
+          allOf:
+            - $ref: '#/components/schemas/RecurringPeriod'
+          description: The defined usage period of the entitlement
+      allOf:
+        - $ref: '#/components/schemas/EntitlementBaseTemplate'
+      description: Entitlement template of a boolean entitlement.
+    EntitlementBooleanCreateInputs:
+      type: object
+      required:
+        - type
+      properties:
+        featureKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: |-
+            The feature the subject is entitled to use.
+            Either featureKey or featureId is required.
+          example: example-feature-key
+        featureId:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: |-
+            The feature the subject is entitled to use.
+            Either featureKey or featureId is required.
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the feature.
+        usagePeriod:
+          allOf:
+            - $ref: '#/components/schemas/RecurringPeriodCreateInput'
+          description: The usage period associated with the entitlement.
+        type:
+          type: string
+          enum:
+            - boolean
+      description: Create inputs for boolean entitlement
+    EntitlementCreateInputs:
+      anyOf:
+        - $ref: '#/components/schemas/EntitlementMeteredCreateInputs'
+        - $ref: '#/components/schemas/EntitlementStaticCreateInputs'
+        - $ref: '#/components/schemas/EntitlementBooleanCreateInputs'
+      discriminator:
+        propertyName: type
+        mapping:
+          metered: '#/components/schemas/EntitlementMeteredCreateInputs'
+          static: '#/components/schemas/EntitlementStaticCreateInputs'
+          boolean: '#/components/schemas/EntitlementBooleanCreateInputs'
+      description: Create inputs for entitlement
+    EntitlementGrant:
+      type: object
+      required:
+        - createdAt
+        - updatedAt
+        - amount
+        - effectiveAt
+        - expiration
+        - id
+        - entitlementId
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        amount:
+          type: number
+          format: double
+          example: 100
+          minimum: 0
+          description: The amount to grant. Should be a positive number.
+        priority:
+          type: integer
+          format: uint8
+          example: 1
+          minimum: 1
+          maximum: 255
+          description: |-
+            The priority of the grant. Grants with higher priority are applied first.
+            Priority is a positive decimal numbers. With lower numbers indicating higher importance.
+            For example, a priority of 1 is more urgent than a priority of 2.
+            When there are several grants available for the same subject, the system selects the grant with the highest priority.
+            In cases where grants share the same priority level, the grant closest to its expiration will be used first.
+            In the case of two grants have identical priorities and expiration dates, the system will use the grant that was created first.
+        effectiveAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: Effective date for grants and anchor for recurring grants. Provided value will be ceiled to metering windowSize (minute).
+        expiration:
+          allOf:
+            - $ref: '#/components/schemas/ExpirationPeriod'
+          description: The grant expiration definition
+        maxRolloverAmount:
+          type: number
+          format: double
+          example: 100
+          description: |-
+            Grants are rolled over at reset, after which they can have a different balance compared to what they had before the reset.
+            Balance after the reset is calculated as: Balance_After_Reset = MIN(MaxRolloverAmount, MAX(Balance_Before_Reset, MinRolloverAmount))
+          default: 0
+        minRolloverAmount:
+          type: number
+          format: double
+          example: 100
+          description: |-
+            Grants are rolled over at reset, after which they can have a different balance compared to what they had before the reset.
+            Balance after the reset is calculated as: Balance_After_Reset = MIN(MaxRolloverAmount, MAX(Balance_Before_Reset, MinRolloverAmount))
+          default: 0
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          example:
+            stripePaymentId: pi_4OrAkhLvyihio9p51h9iiFnB
+          description: The grant metadata.
+        id:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: Readonly unique ULID identifier.
+          readOnly: true
+        entitlementId:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          description: The unique entitlement ULID that the grant is associated with.
+          readOnly: true
+        nextRecurrence:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The next time the grant will recurr.
+        expiresAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The time the grant expires.
+          readOnly: true
+        voidedAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The time the grant was voided.
+        recurrence:
+          allOf:
+            - $ref: '#/components/schemas/RecurringPeriod'
+          description: The recurrence period of the grant.
+      description: The grant.
+    EntitlementGrantCreateInput:
+      type: object
+      required:
+        - amount
+        - effectiveAt
+        - expiration
+      properties:
+        amount:
+          type: number
+          format: double
+          example: 100
+          minimum: 0
+          description: The amount to grant. Should be a positive number.
+        priority:
+          type: integer
+          format: uint8
+          example: 1
+          minimum: 1
+          maximum: 255
+          description: |-
+            The priority of the grant. Grants with higher priority are applied first.
+            Priority is a positive decimal numbers. With lower numbers indicating higher importance.
+            For example, a priority of 1 is more urgent than a priority of 2.
+            When there are several grants available for the same subject, the system selects the grant with the highest priority.
+            In cases where grants share the same priority level, the grant closest to its expiration will be used first.
+            In the case of two grants have identical priorities and expiration dates, the system will use the grant that was created first.
+        effectiveAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: Effective date for grants and anchor for recurring grants. Provided value will be ceiled to metering windowSize (minute).
+        expiration:
+          allOf:
+            - $ref: '#/components/schemas/ExpirationPeriod'
+          description: The grant expiration definition
+        maxRolloverAmount:
+          type: number
+          format: double
+          example: 100
+          description: |-
+            Grants are rolled over at reset, after which they can have a different balance compared to what they had before the reset.
+            Balance after the reset is calculated as: Balance_After_Reset = MIN(MaxRolloverAmount, MAX(Balance_Before_Reset, MinRolloverAmount))
+          default: 0
+        minRolloverAmount:
+          type: number
+          format: double
+          example: 100
+          description: |-
+            Grants are rolled over at reset, after which they can have a different balance compared to what they had before the reset.
+            Balance after the reset is calculated as: Balance_After_Reset = MIN(MaxRolloverAmount, MAX(Balance_Before_Reset, MinRolloverAmount))
+          default: 0
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          example:
+            stripePaymentId: pi_4OrAkhLvyihio9p51h9iiFnB
+          description: The grant metadata.
+        recurrence:
+          allOf:
+            - $ref: '#/components/schemas/RecurringPeriodCreateInput'
+          description: The subject of the grant.
+      description: The grant creation input.
+    EntitlementMetered:
+      type: object
+      required:
+        - type
+        - createdAt
+        - updatedAt
+        - id
+        - subjectKey
+        - featureKey
+        - featureId
+        - lastReset
+        - currentUsagePeriod
+        - measureUsageFrom
+        - usagePeriod
+      properties:
+        type:
+          type: string
+          enum:
+            - metered
+        isSoftLimit:
+          type: boolean
+          description: If softLimit=true the subject can use the feature even if the entitlement is exhausted, hasAccess will always be true.
+          title: Soft limit
+          default: false
+        isUnlimited:
+          type: boolean
+          description: Deprecated, ignored by the backend. Please use isSoftLimit instead; this field will be removed in the future.
+          deprecated: true
+          default: false
+        issueAfterReset:
+          type: number
+          format: double
+          minimum: 0
+          description: |-
+            You can grant usage automatically alongside the entitlement, the example scenario would be creating a starting balance.
+            If an amount is specified here, a grant will be created alongside the entitlement with the specified amount.
+            That grant will have it's rollover settings configured in a way that after each reset operation, the balance will return the original amount specified here.
+            Manually creating such a grant would mean having the "amount", "minRolloverAmount", and "maxRolloverAmount" fields all be the same.
+          title: Initial grant amount
+        issueAfterResetPriority:
+          type: integer
+          format: uint8
+          minimum: 1
+          maximum: 255
+          description: Defines the grant priority for the default grant.
+          title: Issue grant after reset priority
+          default: 1
+        preserveOverageAtReset:
+          type: boolean
+          description: If true, the overage is preserved at reset. If false, the usage is reset to 0.
+          title: Preserve overage at reset
+          default: false
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the feature.
+        id:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: Readonly unique ULID identifier.
+          readOnly: true
+        subjectKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: The identifier key unique to the subject
+          example: customer-1
+        featureKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: The feature the subject is entitled to use.
+          example: example-feature-key
+        featureId:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: The feature the subject is entitled to use.
+        lastReset:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The time the last reset happened.
+          readOnly: true
+        currentUsagePeriod:
+          allOf:
+            - $ref: '#/components/schemas/Period'
+          description: The current usage period.
+          readOnly: true
+        measureUsageFrom:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The time from which usage is measured. If not specified on creation, defaults to entitlement creation time.
+          readOnly: true
+        usagePeriod:
+          allOf:
+            - $ref: '#/components/schemas/RecurringPeriod'
+          description: THe usage period of the entitlement.
+          readOnly: true
+      description: |-
+        Metered entitlements are useful for many different use cases, from setting up usage based access to implementing complex credit systems.
+        Access is determined based on feature usage using a balance calculation (the "usage allowance" provided by the issued grants is "burnt down" by the usage).
+    EntitlementMeteredCreateInputs:
+      type: object
+      required:
+        - type
+        - usagePeriod
+      properties:
+        featureKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: |-
+            The feature the subject is entitled to use.
+            Either featureKey or featureId is required.
+          example: example-feature-key
+        featureId:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: |-
+            The feature the subject is entitled to use.
+            Either featureKey or featureId is required.
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the feature.
+        type:
+          type: string
+          enum:
+            - metered
+        isSoftLimit:
+          type: boolean
+          description: If softLimit=true the subject can use the feature even if the entitlement is exhausted, hasAccess will always be true.
+          title: Soft limit
+          default: false
+        isUnlimited:
+          type: boolean
+          description: Deprecated, ignored by the backend. Please use isSoftLimit instead; this field will be removed in the future.
+          deprecated: true
+          default: false
+        usagePeriod:
+          allOf:
+            - $ref: '#/components/schemas/RecurringPeriodCreateInput'
+          description: The usage period associated with the entitlement.
+        measureUsageFrom:
+          allOf:
+            - $ref: '#/components/schemas/MeasureUsageFrom'
+          description: Defines the time from which usage is measured. If not specified on creation, defaults to entitlement creation time.
+        issueAfterReset:
+          type: number
+          format: double
+          minimum: 0
+          description: |-
+            You can grant usage automatically alongside the entitlement, the example scenario would be creating a starting balance.
+            If an amount is specified here, a grant will be created alongside the entitlement with the specified amount.
+            That grant will have it's rollover settings configured in a way that after each reset operation, the balance will return the original amount specified here.
+            Manually creating such a grant would mean having the "amount", "minRolloverAmount", and "maxRolloverAmount" fields all be the same.
+          title: Initial grant amount
+        issueAfterResetPriority:
+          type: integer
+          format: uint8
+          minimum: 1
+          maximum: 255
+          description: Defines the grant priority for the default grant.
+          title: Issue grant after reset priority
+          default: 1
+        preserveOverageAtReset:
+          type: boolean
+          description: If true, the overage is preserved at reset. If false, the usage is reset to 0.
+          title: Preserve overage at reset
+          default: false
+      description: Create inpurs for metered entitlement
+    EntitlementOrderBy:
+      type: string
+      enum:
+        - createdAt
+        - updatedAt
+      description: Order by options for entitlements.
+    EntitlementPaginatedResponse:
+      type: object
+      required:
+        - totalCount
+        - page
+        - pageSize
+        - items
+      properties:
+        totalCount:
+          type: integer
+          example: 500
+          description: The items in the current page.
+        page:
+          type: integer
+          example: 1
+          description: The items in the current page.
+        pageSize:
+          type: integer
+          example: 100
+          description: The items in the current page.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Entitlement'
+          description: The items in the current page.
+      description: Paginated response
+    EntitlementStatic:
+      type: object
+      required:
+        - type
+        - config
+        - createdAt
+        - updatedAt
+        - id
+        - subjectKey
+        - featureKey
+        - featureId
+      properties:
+        type:
+          type: string
+          enum:
+            - static
+        config:
+          type: string
+          format: json
+          example: '{ "integrations": ["github"] }'
+          description: The JSON parsable config of the entitlement. This value is also returned when checking entitlement access and it is useful for configuring fine-grained access settings to the feature, implemented in your own system. Has to be an object.
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the feature.
+        id:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: Readonly unique ULID identifier.
+          readOnly: true
+        subjectKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: The identifier key unique to the subject
+          example: customer-1
+        featureKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: The feature the subject is entitled to use.
+          example: example-feature-key
+        featureId:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: The feature the subject is entitled to use.
+        currentUsagePeriod:
+          allOf:
+            - $ref: '#/components/schemas/Period'
+          description: The current usage period.
+        usagePeriod:
+          allOf:
+            - $ref: '#/components/schemas/RecurringPeriod'
+          description: The defined usage period of the entitlement
+      description: A static entitlement.
+    EntitlementStaticCreateInputs:
+      type: object
+      required:
+        - type
+        - config
+      properties:
+        featureKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: |-
+            The feature the subject is entitled to use.
+            Either featureKey or featureId is required.
+          example: example-feature-key
+        featureId:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: |-
+            The feature the subject is entitled to use.
+            Either featureKey or featureId is required.
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the feature.
+        usagePeriod:
+          allOf:
+            - $ref: '#/components/schemas/RecurringPeriodCreateInput'
+          description: The usage period associated with the entitlement.
+        type:
+          type: string
+          enum:
+            - static
+        config:
+          type: string
+          format: json
+          example: '{ "integrations": ["github"] }'
+          description: The JSON parsable config of the entitlement. This value is also returned when checking entitlement access and it is useful for configuring fine-grained access settings to the feature, implemented in your own system. Has to be an object.
+      description: Create inputs for static entitlement
+    EntitlementType:
+      type: string
+      enum:
+        - metered
+        - boolean
+        - static
+      description: Type of the entitlement.
+      x-go-type: string
+    EntitlementValue:
+      type: object
+      required:
+        - hasAccess
+      properties:
+        hasAccess:
+          type: boolean
+          example: true
+          description: Whether the subject has access to the feature. Shared accross all entitlement types.
+          readOnly: true
+        balance:
+          type: number
+          format: double
+          example: 100
+          description: Only available for metered entitlements. Metered entitlements are built around a balance calculation where feature usage is deducted from the issued grants. Balance represents the remaining balance of the entitlement, it's value never turns negative.
+          readOnly: true
+        usage:
+          type: number
+          format: double
+          example: 50
+          description: Only available for metered entitlements. Returns the total feature usage in the current period.
+          readOnly: true
+        overage:
+          type: number
+          format: double
+          example: 0
+          description: Only available for metered entitlements. Overage represents the usage that wasn't covered by grants, e.g. if the subject had a total feature usage of 100 in the period but they were only granted 80, there would be 20 overage.
+          readOnly: true
+        config:
+          type: string
+          example: '{ key: "value" }'
+          description: Only available for static entitlements. The JSON parsable config of the entitlement.
+          readOnly: true
+      description: Entitlements are the core of OpenMeter access management. They define access to features for subjects. Entitlements can be metered, boolean, or static.
+    Event:
+      type: object
+      required:
+        - id
+        - source
+        - specversion
+        - type
+        - subject
+      properties:
+        id:
+          type: string
+          example: 5c10fade-1c9e-4d6c-8275-c52c36731d3c
+          minLength: 1
+          description: Identifies the event.
+        source:
+          type: string
+          example: service-name
+          minLength: 1
+          format: uri-reference
+          description: Identifies the context in which an event happened.
+        specversion:
+          type: string
+          example: '1.0'
+          minLength: 1
+          description: The version of the CloudEvents specification which the event uses.
+          default: '1.0'
+        type:
+          type: string
+          example: com.example.someevent
+          minLength: 1
+          description: Contains a value describing the type of event related to the originating occurrence.
+        datacontenttype:
+          type: string
+          nullable: true
+          example: application/json
+          minLength: 1
+          description: Content type of the data value. Must adhere to RFC 2046 format.
+        dataschema:
+          type: string
+          format: uri
+          nullable: true
+          minLength: 1
+          description: Identifies the schema that data adheres to.
+        subject:
+          type: string
+          example: customer-id
+          minLength: 1
+          description: Describes the subject of the event in the context of the event producer (identified by source).
+        time:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: Timestamp of when the occurrence happened. Must adhere to RFC 3339.
+          nullable: true
+        data:
+          nullable: true
+          oneOf:
+            - type: object
+            - type: string
+          description: The event payload.
+      example:
+        id: 5c10fade-1c9e-4d6c-8275-c52c36731d3c
+        source: service-name
+        specversion: '1.0'
+        type: prompt
+        subject: customer-id
+        time: 2023-01-01T01:01:01.001Z
+      description: CloudEvents Specification JSON Schema
+      x-go-type-import:
+        path: github.com/cloudevents/sdk-go/v2/event
+      x-go-type: event.Event
+    ExpirationDuration:
+      type: string
+      enum:
+        - HOUR
+        - DAY
+        - WEEK
+        - MONTH
+        - YEAR
+      description: The expiration duration enum
+    ExpirationPeriod:
+      type: object
+      required:
+        - duration
+        - count
+      properties:
+        duration:
+          allOf:
+            - $ref: '#/components/schemas/ExpirationDuration'
+          description: The unit of time for the expiration period.
+        count:
+          type: integer
+          example: 12
+          description: The number of time units in the expiration period.
+      description: The grant expiration definition
+    Feature:
+      type: object
+      required:
+        - createdAt
+        - updatedAt
+        - key
+        - name
+        - id
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        archivedAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was archived.
+          title: Archival Time
+          readOnly: true
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: A key is a unique string that is used to identify a resource.
+          title: The unique key of the feature
+        name:
+          type: string
+          title: The human-readable name of the feature
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          example:
+            key: value
+          title: Optional metadata
+        meterSlug:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: A key is a unique string that is used to identify a resource.
+          example: tokens_total
+          title: Meter slug
+        meterGroupByFilters:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            model: gpt-4
+            type: input
+          description: |-
+            Optional meter group by filters.
+            Useful if the meter scope is broader than what feature tracks.
+            Example scenario would be a meter tracking all token use with groupBy fields for the model,
+            then the feature could filter for model=gpt-4.
+          title: Meter group by filters
+        id:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: Readonly unique ULID identifier.
+          readOnly: true
+      description: |-
+        Represents a feature that can be enabled or disabled for a plan.
+        Used both for product catalog and entitlements.
+    FeatureCreateInputs:
+      type: object
+      required:
+        - key
+        - name
+      properties:
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: A key is a unique string that is used to identify a resource.
+          title: The unique key of the feature
+        name:
+          type: string
+          title: The human-readable name of the feature
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          example:
+            key: value
+          title: Optional metadata
+        meterSlug:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: A key is a unique string that is used to identify a resource.
+          example: tokens_total
+          title: Meter slug
+        meterGroupByFilters:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            model: gpt-4
+            type: input
+          description: |-
+            Optional meter group by filters.
+            Useful if the meter scope is broader than what feature tracks.
+            Example scenario would be a meter tracking all token use with groupBy fields for the model,
+            then the feature could filter for model=gpt-4.
+          title: Meter group by filters
+      description: |-
+        Represents a feature that can be enabled or disabled for a plan.
+        Used both for product catalog and entitlements.
+    FeatureMeta:
+      type: object
+      required:
+        - id
+        - key
+      properties:
+        id:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: Unique identifier of a feature.
+          title: Feature Unique Identifier
+        key:
+          type: string
+          example: gpt4_tokens
+          description: |-
+            The key is an immutable unique identifier of the feature used throughout the API,
+            for example when interacting with a subject's entitlements.
+          title: Feature Key
+      description: Limited representation of a feature resource which includes only its unique identifiers (id, key).
+    FeatureOrderBy:
+      type: string
+      enum:
+        - id
+        - createdAt
+        - updatedAt
+      description: Order by options for features.
+    FeaturePaginatedResponse:
+      type: object
+      required:
+        - totalCount
+        - page
+        - pageSize
+        - items
+      properties:
+        totalCount:
+          type: integer
+          example: 500
+          description: The items in the current page.
+        page:
+          type: integer
+          example: 1
+          description: The items in the current page.
+        pageSize:
+          type: integer
+          example: 100
+          description: The items in the current page.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Feature'
+          description: The items in the current page.
+      description: Paginated response
+    FlatPrice:
+      type: object
+      required:
+        - type
+        - amount
+      properties:
+        type:
+          type: string
+          enum:
+            - flat
+        amount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The amount of the flat price.
+      description: Flat price.
+    FlatPriceUpdateItem:
+      type: object
+      required:
+        - amount
+      properties:
+        amount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The amount of the flat price.
+      description: Flat price.
+    FlatPriceWithPaymentTerm:
+      type: object
+      required:
+        - type
+        - amount
+      properties:
+        type:
+          type: string
+          enum:
+            - flat
+        amount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The amount of the flat price.
+        paymentTerm:
+          allOf:
+            - $ref: '#/components/schemas/PricePaymentTerm'
+          description: |-
+            The payment term of the flat price.
+            Defaults to in advance.
+          default: in_advance
+      description: Flat price with payment term.
+    FlatPriceWithPaymentTermUpdateItem:
+      type: object
+      required:
+        - amount
+      properties:
+        amount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The amount of the flat price.
+        paymentTerm:
+          allOf:
+            - $ref: '#/components/schemas/PricePaymentTerm'
+          description: |-
+            The payment term of the flat price.
+            Defaults to in advance.
+          default: in_advance
+      description: Flat price with payment term.
+    ForbiddenProblemResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/UnexpectedProblemResponse'
+      description: The server understood the request but refuses to authorize it.
+    GatewayTimeoutProblemResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/UnexpectedProblemResponse'
+      description: The server, while acting as a gateway or proxy, did not receive a timely response from an upstream server it needed to access in order to complete the request.
+    GrantBurnDownHistorySegment:
+      type: object
+      required:
+        - period
+        - usage
+        - overage
+        - balanceAtStart
+        - grantBalancesAtStart
+        - balanceAtEnd
+        - grantBalancesAtEnd
+        - grantUsages
+      properties:
+        period:
+          allOf:
+            - $ref: '#/components/schemas/Period'
+          description: The period of the segment.
+        usage:
+          type: number
+          format: double
+          example: 100
+          description: The total usage of the grant in the period.
+          readOnly: true
+        overage:
+          type: number
+          format: double
+          example: 100
+          description: Overuse that wasn't covered by grants.
+          readOnly: true
+        balanceAtStart:
+          type: number
+          format: double
+          example: 100
+          description: entitlement balance at the start of the period.
+          readOnly: true
+        grantBalancesAtStart:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+          example:
+            01G65Z755AFWAKHE12NY0CQ9FH: 100
+          description: 'The balance breakdown of each active grant at the start of the period: GrantID: Balance'
+          readOnly: true
+        balanceAtEnd:
+          type: number
+          format: double
+          example: 100
+          description: The entitlement balance at the end of the period.
+          readOnly: true
+        grantBalancesAtEnd:
+          type: object
+          additionalProperties:
+            type: number
+            format: double
+          example:
+            01G65Z755AFWAKHE12NY0CQ9FH: 100
+          description: 'The balance breakdown of each active grant at the end of the period: GrantID: Balance'
+          readOnly: true
+        grantUsages:
+          type: array
+          items:
+            $ref: '#/components/schemas/GrantUsageRecord'
+          description: Which grants were actually burnt down in the period and by what amount.
+          readOnly: true
+      description: |-
+        A segment of the grant burn down history.
+
+        A given segment represents the usage of a grant between events that changed either the grant burn down priority order or the usag period.
+    GrantOrderBy:
+      type: string
+      enum:
+        - id
+        - createdAt
+        - updatedAt
+      description: Order by options for grants.
+    GrantPaginatedResponse:
+      type: object
+      required:
+        - totalCount
+        - page
+        - pageSize
+        - items
+      properties:
+        totalCount:
+          type: integer
+          example: 500
+          description: The items in the current page.
+        page:
+          type: integer
+          example: 1
+          description: The items in the current page.
+        pageSize:
+          type: integer
+          example: 100
+          description: The items in the current page.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntitlementGrant'
+          description: The items in the current page.
+      description: Paginated response
+    GrantUsageRecord:
+      type: object
+      required:
+        - grantId
+        - usage
+      properties:
+        grantId:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: The id of the grant
+        usage:
+          type: number
+          format: double
+          example: 100
+          description: The usage in the period
+      description: Usage Record
+    IngestedEvent:
+      type: object
+      required:
+        - event
+        - ingestedAt
+        - storedAt
+      properties:
+        event:
+          $ref: '#/components/schemas/Event'
+        validationError:
+          type: string
+          description: The validation error if the event failed validation.
+        ingestedAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The date and time the event was ingested.
+        storedAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The date and time the event was stored.
+      example:
+        event:
+          id: 5c10fade-1c9e-4d6c-8275-c52c36731d3c
+          source: service-name
+          specversion: '1.0'
+          type: prompt
+          subject: customer-id
+          time: 2023-01-01T01:01:01.001Z
+        ingestedAt: 2023-01-01T01:01:01.001Z
+        storedAt: 2023-01-01T01:01:02.001Z
+      description: An ingested event with optional validation error.
+    InternalServerErrorProblemResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/UnexpectedProblemResponse'
+      description: The server encountered an unexpected condition that prevented it from fulfilling the request.
+    InvoicePaginatedResponse:
+      type: object
+      required:
+        - totalCount
+        - page
+        - pageSize
+        - items
+      properties:
+        totalCount:
+          type: integer
+          example: 500
+          description: The items in the current page.
+        page:
+          type: integer
+          example: 1
+          description: The items in the current page.
+        pageSize:
+          type: integer
+          example: 100
+          description: The items in the current page.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingInvoice'
+          description: The items in the current page.
+      description: Paginated response
+    ListEntitlementsResult:
+      oneOf:
+        - type: array
+          items:
+            $ref: '#/components/schemas/Entitlement'
+        - $ref: '#/components/schemas/EntitlementPaginatedResponse'
+    ListFeaturesResult:
+      oneOf:
+        - type: array
+          items:
+            $ref: '#/components/schemas/Feature'
+        - $ref: '#/components/schemas/FeaturePaginatedResponse'
+    MarketplaceListing:
+      type: object
+      required:
+        - type
+        - name
+        - description
+        - iconUrl
+        - capabilities
+      properties:
+        type:
+          allOf:
+            - $ref: '#/components/schemas/AppType'
+          description: The app's type
+        name:
+          type: string
+          description: The app's name.
+        description:
+          type: string
+          description: The app's description.
+        iconUrl:
+          type: string
+          description: The app's icon URL.
+        capabilities:
+          type: array
+          items:
+            $ref: '#/components/schemas/AppCapability'
+          description: The app's capabilities.
+      example:
+        type: stripe
+        name: Stripe
+        description: Stripe interation allows you to collect payments with Stripe.
+        iconUrl: /images/stripe.png
+        capabilities:
+          - type: calculateTax
+            key: stripe_calculate_tax
+            name: Calculate Tax
+            description: Stripe Tax calculates tax portion of the invoices.
+          - type: invoiceCustomers
+            key: stripe_invoice_customers
+            name: Invoice Customers
+            description: Stripe invoices customers with due amount.
+          - type: collectPayments
+            key: stripe_collect_payments
+            name: Collect Payments
+            description: Stripe payments collects outstanding revenue with Stripe customer's default payment method.
+      description: |-
+        A marketplace listing.
+        Represent an available app in the app marketplace that can be installed to the organization.
+
+        Marketplace apps only exist in config so they don't extend the Resource model.
+    MarketplaceListingList:
+      type: object
+      required:
+        - page
+        - pageSize
+        - totalCount
+        - items
+      properties:
+        page:
+          type: integer
+          description: The page number.
+        pageSize:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          description: The number of items in the page.
+        totalCount:
+          type: integer
+          description: The total number of items.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketplaceListing'
+          maxItems: 1000
+          description: The items in the page.
+      description: A page of results.
+    MeasureUsageFrom:
+      oneOf:
+        - $ref: '#/components/schemas/MeasureUsageFromPreset'
+        - $ref: '#/components/schemas/MeasureUsageFromTime'
+      description: Measure usage from
+    MeasureUsageFromPreset:
+      type: string
+      enum:
+        - CURRENT_PERIOD_START
+        - NOW
+      description: Start of measurement options
+      x-enum-varnames:
+        - CurrentPeriodStart
+        - Now
+    MeasureUsageFromTime:
+      type: string
+      format: date-time
+      example: 2023-01-01T01:01:01.001Z
+      description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+    Metadata:
+      type: object
+      additionalProperties:
+        type: string
+      example:
+        externalId: 019142cc-a016-796a-8113-1a942fecd26d
+      description: |-
+        Set of key-value pairs.
+        Metadata can be used to store additional information about a resource.
+      x-go-type: map[string]string
+    Meter:
+      type: object
+      required:
+        - id
+        - slug
+        - aggregation
+        - windowSize
+        - eventType
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the meter.
+          readOnly: true
+        slug:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: |-
+            A unique, human-readable identifier for the meter.
+            Must consist only alphanumeric and underscore characters.
+          example: tokens_total
+        description:
+          type: string
+          example: AI Token Usage
+          minLength: 1
+          description: A description of the meter.
+        aggregation:
+          allOf:
+            - $ref: '#/components/schemas/MeterAggregation'
+          example: SUM
+        windowSize:
+          allOf:
+            - $ref: '#/components/schemas/WindowSize'
+          example: MINUTE
+        eventType:
+          type: string
+          example: prompt
+          minLength: 1
+          description: The event type to aggregate.
+        valueProperty:
+          type: string
+          example: $.tokens
+          minLength: 1
+          description: |-
+            JSONPath expression to extract the value from the ingested event's data property.
+
+            The ingested value for SUM, AVG, MIN, and MAX aggregations is a number or a string that can be parsed to a number.
+
+            For UNIQUE_COUNT aggregation, the ingested value must be a string. For COUNT aggregation the valueProperty is ignored.
+        groupBy:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            type: $.type
+          description: |-
+            Named JSONPath expressions to extract the group by values from the event data.
+
+            Keys must be unique and consist only alphanumeric and underscore characters.
+
+            TODO: add key format enforcement
+      example:
+        id: 01G65Z755AFWAKHE12NY0CQ9FH
+        slug: tokens_total
+        description: AI Token Usage
+        aggregation: SUM
+        windowSize: MINUTE
+        eventType: prompt
+        valueProperty: $.tokens
+        groupBy:
+          model: $.model
+          type: $.type
+      description: A meter is a configuration that defines how to match and aggregate events.
+      x-go-type-import:
+        path: github.com/openmeterio/openmeter/pkg/models
+      x-go-type: models.Meter
+    MeterAggregation:
+      type: string
+      enum:
+        - SUM
+        - COUNT
+        - UNIQUE_COUNT
+        - AVG
+        - MIN
+        - MAX
+      description: The aggregation type to use for the meter.
+      x-go-type-import:
+        path: github.com/openmeterio/openmeter/pkg/models
+      x-go-type: models.MeterAggregation
+    MeterCreate:
+      type: object
+      required:
+        - slug
+        - aggregation
+        - windowSize
+        - eventType
+      properties:
+        slug:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: |-
+            A unique, human-readable identifier for the meter.
+            Must consist only alphanumeric and underscore characters.
+          example: tokens_total
+        description:
+          type: string
+          example: AI Token Usage
+          minLength: 1
+          description: A description of the meter.
+        aggregation:
+          allOf:
+            - $ref: '#/components/schemas/MeterAggregation'
+          example: SUM
+        windowSize:
+          allOf:
+            - $ref: '#/components/schemas/WindowSize'
+          example: MINUTE
+        eventType:
+          type: string
+          example: prompt
+          minLength: 1
+          description: The event type to aggregate.
+        valueProperty:
+          type: string
+          example: $.tokens
+          minLength: 1
+          description: |-
+            JSONPath expression to extract the value from the ingested event's data property.
+
+            The ingested value for SUM, AVG, MIN, and MAX aggregations is a number or a string that can be parsed to a number.
+
+            For UNIQUE_COUNT aggregation, the ingested value must be a string. For COUNT aggregation the valueProperty is ignored.
+        groupBy:
+          type: object
+          additionalProperties:
+            type: string
+          example:
+            type: $.type
+          description: |-
+            Named JSONPath expressions to extract the group by values from the event data.
+
+            Keys must be unique and consist only alphanumeric and underscore characters.
+
+            TODO: add key format enforcement
+      example:
+        slug: tokens_total
+        description: AI Token Usage
+        aggregation: SUM
+        windowSize: MINUTE
+        eventType: prompt
+        valueProperty: $.tokens
+        groupBy:
+          model: $.model
+          type: $.type
+      description: A meter is a configuration that defines how to match and aggregate events.
+      x-go-type-import:
+        path: github.com/openmeterio/openmeter/pkg/models
+      x-go-type: models.Meter
+    MeterQueryResult:
+      type: object
+      required:
+        - data
+      properties:
+        from:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+        to:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+        windowSize:
+          $ref: '#/components/schemas/WindowSize'
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/MeterQueryRow'
+      example:
+        from: 2023-01-01T00:00:00Z
+        to: 2023-01-02T00:00:00Z
+        windowSize: DAY
+        data:
+          - value: 12
+            windowStart: 2023-01-01T00:00:00Z
+            windowEnd: 2023-01-02T00:00:00Z
+            subject: customer-1
+            groupBy:
+              model: gpt-4-turbo
+              type: prompt
+      description: The result of a meter query.
+    MeterQueryRow:
+      type: object
+      required:
+        - value
+        - windowStart
+        - windowEnd
+      properties:
+        value:
+          type: number
+        windowStart:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+        windowEnd:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+        subject:
+          type: string
+        groupBy:
+          type: object
+          additionalProperties:
+            type: string
+      example:
+        value: 12
+        windowStart: 2023-01-01T00:00:00Z
+        windowEnd: 2023-01-02T00:00:00Z
+        subject: customer-1
+        groupBy:
+          model: gpt-4-turbo
+          type: prompt
+      description: A row in the result of a meter query.
+      x-go-type-import:
+        path: github.com/openmeterio/openmeter/pkg/models
+      x-go-type: models.MeterQueryRow
+    NotFoundProblemResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/UnexpectedProblemResponse'
+      description: The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.
+    NotImplementedProblemResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/UnexpectedProblemResponse'
+      description: The server does not support the functionality required to fulfill the request.
+    NotificationChannel:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/NotificationChannelWebhook'
+      description: Notification channel.
+    NotificationChannelCreateRequest:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/NotificationChannelWebhookCreateRequest'
+      description: Union type for requests creating new notification channel with certain type.
+    NotificationChannelMeta:
+      type: object
+      required:
+        - id
+        - type
+      properties:
+        id:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: Identifies the notification channel.
+          title: Channel Unique Identifier
+          readOnly: true
+        type:
+          allOf:
+            - $ref: '#/components/schemas/NotificationChannelType'
+          description: Notification channel type.
+          title: Channel Type
+          readOnly: true
+      description: Metadata only fields of a notification channel.
+    NotificationChannelOrderBy:
+      type: string
+      enum:
+        - id
+        - type
+        - createdAt
+        - updatedAt
+      description: Order by options for notification channels.
+    NotificationChannelPaginatedResponse:
+      type: object
+      required:
+        - totalCount
+        - page
+        - pageSize
+        - items
+      properties:
+        totalCount:
+          type: integer
+          example: 500
+          description: The items in the current page.
+        page:
+          type: integer
+          example: 1
+          description: The items in the current page.
+        pageSize:
+          type: integer
+          example: 100
+          description: The items in the current page.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationChannel'
+          description: The items in the current page.
+      description: Paginated response
+    NotificationChannelType:
+      type: string
+      enum:
+        - WEBHOOK
+      description: Type of the notification channel.
+      x-enum-varnames:
+        - Webhook
+    NotificationChannelWebhook:
+      type: object
+      required:
+        - createdAt
+        - updatedAt
+        - id
+        - type
+        - name
+        - url
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        id:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: Identifies the notification channel.
+          title: Channel Unique Identifier
+          readOnly: true
+        type:
+          type: string
+          enum:
+            - WEBHOOK
+          description: Notification channel type.
+          title: Channel Type
+        name:
+          type: string
+          example: customer-webhook
+          description: User friendly name of the channel.
+          title: Channel Name
+        disabled:
+          type: boolean
+          example: true
+          description: Whether the channel is disabled or not.
+          title: Channel Disabled
+          default: false
+        url:
+          type: string
+          example: https://example.com/webhook
+          description: Webhook URL where the notification is sent.
+          title: Webhook URL
+        customHeaders:
+          type: object
+          additionalProperties:
+            type: string
+          description: Custom HTTP headers sent as part of the webhook request.
+          title: Custom HTTP Headers
+        signingSecret:
+          type: string
+          example: whsec_S6g2HLnTwd9AhHwUIMFggVS9OfoPafN8
+          pattern: ^(whsec_)?[a-zA-Z0-9+/=]{32,100}$
+          description: |-
+            Signing secret used for webhook request validation on the receiving end.
+
+            Format: `base64` encoded random bytes optionally prefixed with `whsec_`. Recommended size: 24
+          title: Signing Secret
+      description: Notification channel with webhook type.
+    NotificationChannelWebhookCreateRequest:
+      type: object
+      required:
+        - type
+        - name
+        - url
+      properties:
+        type:
+          type: string
+          enum:
+            - WEBHOOK
+          description: Notification channel type.
+          title: Channel Type
+        name:
+          type: string
+          example: customer-webhook
+          description: User friendly name of the channel.
+          title: Channel Name
+        disabled:
+          type: boolean
+          example: true
+          description: Whether the channel is disabled or not.
+          title: Channel Disabled
+          default: false
+        url:
+          type: string
+          example: https://example.com/webhook
+          description: Webhook URL where the notification is sent.
+          title: Webhook URL
+        customHeaders:
+          type: object
+          additionalProperties:
+            type: string
+          description: Custom HTTP headers sent as part of the webhook request.
+          title: Custom HTTP Headers
+        signingSecret:
+          type: string
+          example: whsec_S6g2HLnTwd9AhHwUIMFggVS9OfoPafN8
+          pattern: ^(whsec_)?[a-zA-Z0-9+/=]{32,100}$
+          description: |-
+            Signing secret used for webhook request validation on the receiving end.
+
+            Format: `base64` encoded random bytes optionally prefixed with `whsec_`. Recommended size: 24
+          title: Signing Secret
+      description: Request with input parameters for creating new notification channel with webhook type.
+    NotificationEvent:
+      type: object
+      required:
+        - id
+        - type
+        - createdAt
+        - rule
+        - deliveryStatus
+        - payload
+      properties:
+        id:
+          type: string
+          example: 01J2KNP1YTXQRXHTDJ4KPR7PZ0
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier of the notification event.
+          title: Event Identifier
+          readOnly: true
+        type:
+          allOf:
+            - $ref: '#/components/schemas/NotificationEventType'
+          description: Type of the notification event.
+          title: Event Type
+          readOnly: true
+        createdAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: Timestamp when the notification event was created in RFC 3339 format.
+          title: Creation Time
+          readOnly: true
+        rule:
+          allOf:
+            - $ref: '#/components/schemas/NotificationRule'
+          description: The nnotification rule which generated this event.
+          title: Owner Rule
+          readOnly: true
+        deliveryStatus:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationEventDeliveryStatus'
+          description: The delivery status of the notification event.
+          title: Delivery Status
+          readOnly: true
+        payload:
+          allOf:
+            - $ref: '#/components/schemas/NotificationEventPayload'
+          description: Timestamp when the notification event was created in RFC 3339 format.
+          title: Event Payload
+          readOnly: true
+        annotations:
+          allOf:
+            - $ref: '#/components/schemas/Annotations'
+          description: Set of key-value pairs managed by the system. Cannot be modified by user.
+          title: Annotations
+          readOnly: true
+      description: Type of the notification event.
+    NotificationEventBalanceThresholdPayload:
+      type: object
+      required:
+        - id
+        - type
+        - timestamp
+        - data
+      properties:
+        id:
+          type: string
+          example: 01J2KNP1YTXQRXHTDJ4KPR7PZ0
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the notification event the payload belongs to.
+          title: Notification Event Identifier
+          readOnly: true
+        type:
+          type: string
+          enum:
+            - entitlements.balance.threshold
+          description: Type of the notification event.
+          title: Notification Event Type
+          readOnly: true
+        timestamp:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: Timestamp when the notification event was created in RFC 3339 format.
+          title: Creation Time
+          readOnly: true
+        data:
+          allOf:
+            - $ref: '#/components/schemas/NotificationEventBalanceThresholdPayloadData'
+          description: The data of the payload.
+          title: Payload Data
+          readOnly: true
+      description: Payload for notification event with `entitlements.balance.threshold` type.
+    NotificationEventBalanceThresholdPayloadData:
+      type: object
+      required:
+        - entitlement
+        - feature
+        - subject
+        - value
+        - threshold
+      properties:
+        entitlement:
+          allOf:
+            - $ref: '#/components/schemas/EntitlementMetered'
+          title: Entitlement
+          readOnly: true
+        feature:
+          allOf:
+            - $ref: '#/components/schemas/Feature'
+          title: Feature
+          readOnly: true
+        subject:
+          allOf:
+            - $ref: '#/components/schemas/Subject'
+          title: Subject
+          readOnly: true
+        value:
+          allOf:
+            - $ref: '#/components/schemas/EntitlementValue'
+          title: Entitlement Value
+          readOnly: true
+        threshold:
+          allOf:
+            - $ref: '#/components/schemas/NotificationRuleBalanceThresholdValue'
+          title: Threshold
+          readOnly: true
+      description: Data of the payload for notification event with `entitlements.balance.threshold` type.
+    NotificationEventDeliveryStatus:
+      type: object
+      required:
+        - state
+        - reason
+        - updatedAt
+        - channel
+      properties:
+        state:
+          allOf:
+            - $ref: '#/components/schemas/NotificationEventDeliveryStatusState'
+          example: SUCCESS
+          description: Delivery state of the notification event to the channel.
+          readOnly: true
+        reason:
+          type: string
+          example: Failed to dispatch event due to provider error.
+          description: The reason of the last deliverry state update.
+          title: State Reason
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: Timestamp of when the status was last updated in RFC 3339 format.
+          title: Last Update Time
+          readOnly: true
+        channel:
+          allOf:
+            - $ref: '#/components/schemas/NotificationChannelMeta'
+          description: Notification channel the delivery sattus associated with.
+          title: Notification Channel
+          readOnly: true
+      description: The delivery status of the notification event.
+    NotificationEventDeliveryStatusState:
+      type: string
+      enum:
+        - SUCCESS
+        - FAILED
+        - SENDING
+        - PENDING
+      description: The delivery state of the notification event to the channel.
+      title: Delivery State
+      x-enum-varnames:
+        - Success
+        - Failed
+        - Sending
+        - Pending
+    NotificationEventOrderBy:
+      type: string
+      enum:
+        - id
+        - createdAt
+      description: Order by options for notification channels.
+    NotificationEventPaginatedResponse:
+      type: object
+      required:
+        - totalCount
+        - page
+        - pageSize
+        - items
+      properties:
+        totalCount:
+          type: integer
+          example: 500
+          description: The items in the current page.
+        page:
+          type: integer
+          example: 1
+          description: The items in the current page.
+        pageSize:
+          type: integer
+          example: 100
+          description: The items in the current page.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationEvent'
+          description: The items in the current page.
+      description: Paginated response
+    NotificationEventPayload:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/NotificationEventBalanceThresholdPayload'
+      description: The delivery status of the notification event.
+    NotificationEventType:
+      type: string
+      enum:
+        - entitlements.balance.threshold
+      description: Type of the notification event.
+    NotificationRule:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/NotificationRuleBalanceThreshold'
+      description: Notification Rule.
+    NotificationRuleBalanceThreshold:
+      type: object
+      required:
+        - createdAt
+        - updatedAt
+        - id
+        - type
+        - name
+        - channels
+        - thresholds
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        id:
+          type: string
+          example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: Identifies the notification rule.
+          title: Rule Unique Identifier
+          readOnly: true
+        type:
+          type: string
+          enum:
+            - entitlements.balance.threshold
+          description: Notification rule type.
+          title: Rule Type
+        name:
+          type: string
+          example: Balance threshold reached
+          description: The user friendly name of the notification rule.
+          title: Rule Name
+        disabled:
+          type: boolean
+          example: true
+          description: Whether the rule is disabled or not.
+          title: Rule Disabled
+          default: false
+        channels:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationChannelMeta'
+          description: List of notification channels the rule applies to.
+          title: Channels assigned to Rule
+        thresholds:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationRuleBalanceThresholdValue'
+          minItems: 1
+          maxItems: 10
+          description: List of thresholds the rule suppose to be triggered.
+          title: Entitlement Balance Thresholds
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeatureMeta'
+          minItems: 1
+          description: Optional field containing list of features the rule applies to.
+          title: Features
+      description: Notification rule with entitlements.balance.threshold type.
+    NotificationRuleBalanceThresholdCreateRequest:
+      type: object
+      required:
+        - type
+        - name
+        - thresholds
+        - channels
+      properties:
+        type:
+          type: string
+          enum:
+            - entitlements.balance.threshold
+          description: Notification rule type.
+          title: Rule Type
+        name:
+          type: string
+          example: Balance threshold reached
+          description: The user friendly name of the notification rule.
+          title: Rule Name
+        disabled:
+          type: boolean
+          example: true
+          description: Whether the rule is disabled or not.
+          title: Rule Disabled
+          default: false
+        thresholds:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationRuleBalanceThresholdValue'
+          minItems: 1
+          maxItems: 10
+          description: List of thresholds the rule suppose to be triggered.
+          title: Entitlement Balance Thresholds
+        channels:
+          type: array
+          items:
+            type: string
+            example: 01G65Z755AFWAKHE12NY0CQ9FH
+            pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+            description: ULID (Universally Unique Lexicographically Sortable Identifier).
+          minItems: 1
+          description: List of notification channels the rule is applied to.
+          title: Channels
+        features:
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 64
+            pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$|^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+            description: |-
+              ULID (Universally Unique Lexicographically Sortable Identifier).
+              A key is a unique string that is used to identify a resource.
+
+              TODO: this is a temporary solution to support both ULID and Key in the same spec for codegen.
+          minItems: 1
+          description: Optional field for defining the scope of notification by feature. It may contain features by id or key.
+          title: Features
+      description: Request with input parameters for creating new notification rule with entitlements.balance.threashold type.
+    NotificationRuleBalanceThresholdValue:
+      type: object
+      required:
+        - value
+        - type
+      properties:
+        value:
+          type: number
+          format: double
+          example: 100
+          description: Value of the threshold.
+          title: Threshold Value
+        type:
+          allOf:
+            - $ref: '#/components/schemas/NotificationRuleBalanceThresholdValueType'
+          example: NUMBER
+          description: Type of the threshold.
+      description: Threshold value with multiple supported types.
+    NotificationRuleBalanceThresholdValueType:
+      type: string
+      enum:
+        - PERCENT
+        - NUMBER
+      description: Type of the rule in the balance threshold specification.
+      title: Notification balance threshold type
+      x-enum-varnames:
+        - Percent
+        - Number
+    NotificationRuleCreateRequest:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/NotificationRuleBalanceThresholdCreateRequest'
+      description: Union type for requests creating new notification rule with certain type.
+    NotificationRuleOrderBy:
+      type: string
+      enum:
+        - id
+        - type
+        - createdAt
+        - updatedAt
+      description: Order by options for notification channels.
+    NotificationRulePaginatedResponse:
+      type: object
+      required:
+        - totalCount
+        - page
+        - pageSize
+        - items
+      properties:
+        totalCount:
+          type: integer
+          example: 500
+          description: The items in the current page.
+        page:
+          type: integer
+          example: 1
+          description: The items in the current page.
+        pageSize:
+          type: integer
+          example: 100
+          description: The items in the current page.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/NotificationRule'
+          description: The items in the current page.
+      description: Paginated response
+    Numeric:
+      type: string
+      pattern: ^\-?[0-9]+(\.[0-9]+)?$
+      description: Numeric represents an arbitrary precision number.
+    OAuth2AuthorizationCodeGrantErrorType:
+      type: string
+      enum:
+        - invalid_request
+        - unauthorized_client
+        - access_denied
+        - unsupported_response_type
+        - invalid_scope
+        - server_error
+        - temporarily_unavailable
+      description: OAuth2 authorization code grant error types.
+    Percentage:
+      type: string
+      pattern: ^\-?[0-9]+(\.[0-9]+)?%$
+      description: Numeric representation of a percentage
+    Period:
+      type: object
+      required:
+        - from
+        - to
+      properties:
+        from:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: Period start time.
+        to:
+          type: string
+          format: date-time
+          example: 2023-02-01T01:01:01.001Z
+          description: Period end time.
+      description: A period with a start and end time.
+    PhasesOrderBy:
+      type: string
+      enum:
+        - key
+        - start_after
+      description: Order by options for plan phases.
+    Plan:
+      type: object
+      required:
+        - id
+        - name
+        - createdAt
+        - updatedAt
+        - key
+        - version
+        - currency
+        - status
+        - phases
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the resource.
+          title: ID
+          readOnly: true
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: A semi-unique identifier for the resource.
+          title: Key
+        version:
+          type: integer
+          minimum: 1
+          description: Version of the plan. Incremented when the plan is updated.
+          title: Version
+          default: 1
+          readOnly: true
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: The currency code of the plan.
+          title: Currency
+          default: USD
+        effectiveFrom:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The date and time when the plan becomes effective. When not specified, the plan is a draft.
+          title: Effective start date
+        effectiveTo:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The date and time when the plan is no longer effective. When not specified, the plan is effective indefinitely.
+          title: Effective end date
+        status:
+          allOf:
+            - $ref: '#/components/schemas/PlanStatus'
+          description: |-
+            The status of the plan.
+            Computed based on the effective start and end dates:
+            - draft = no effectiveFrom
+            - active = effectiveFrom <= now < effectiveTo
+            - archived / inactive = effectiveTo <= now
+            - scheduled = now < effectiveFrom < effectiveTo
+          title: Status
+          readOnly: true
+        phases:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlanPhase'
+          minItems: 1
+          description: |-
+            The plan phase or pricing ramp allows changing a plan's rate cards over time as a subscription progresses.
+            A phase switch occurs only at the end of a billing period, ensuring that a single subscription invoice will not include charges from different phase prices.
+          title: Plan phases
+      description: Plans provide a template for subscriptions.
+    PlanCreate:
+      type: object
+      required:
+        - name
+        - key
+        - currency
+        - phases
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: A semi-unique identifier for the resource.
+          title: Key
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: The currency code of the plan.
+          title: Currency
+          default: USD
+        effectiveFrom:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The date and time when the plan becomes effective. When not specified, the plan is a draft.
+          title: Effective start date
+        effectiveTo:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The date and time when the plan is no longer effective. When not specified, the plan is effective indefinitely.
+          title: Effective end date
+        phases:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlanPhase'
+          minItems: 1
+          description: |-
+            The plan phase or pricing ramp allows changing a plan's rate cards over time as a subscription progresses.
+            A phase switch occurs only at the end of a billing period, ensuring that a single subscription invoice will not include charges from different phase prices.
+          title: Plan phases
+      description: Resource create operation model.
+    PlanOrderBy:
+      type: string
+      enum:
+        - id
+        - key
+        - version
+        - create_at
+        - updated_at
+      description: Order by options for plans.
+    PlanPaginatedResponse:
+      type: object
+      required:
+        - totalCount
+        - page
+        - pageSize
+        - items
+      properties:
+        totalCount:
+          type: integer
+          example: 500
+          description: The items in the current page.
+        page:
+          type: integer
+          example: 1
+          description: The items in the current page.
+        pageSize:
+          type: integer
+          example: 100
+          description: The items in the current page.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Plan'
+          description: The items in the current page.
+      description: Paginated response
+    PlanPhase:
+      type: object
+      required:
+        - name
+        - createdAt
+        - updatedAt
+        - key
+        - rateCards
+        - startAfter
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: Unique key among the plan phases. Used to reference the phase in the subscription & plan.
+        rateCards:
+          type: array
+          items:
+            $ref: '#/components/schemas/RateCard'
+          description: The rate cards of the plan.
+          title: Rate cards
+        startAfter:
+          type: string
+          format: duration
+          nullable: true
+          example: P1Y1D
+          description: The time after which the plan starts compared to subscription start
+          title: Start after
+        discounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/AppliedDiscount'
+          description: The discounts on the plan.
+          title: Discounts
+      description: The plan phase or pricing ramp allows changing a plan's rate cards over time as a subscription progresses.
+    PlanPhaseCreate:
+      type: object
+      required:
+        - name
+        - key
+        - rateCards
+        - startAfter
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: Unique key among the plan phases. Used to reference the phase in the subscription & plan.
+        rateCards:
+          type: array
+          items:
+            $ref: '#/components/schemas/RateCard'
+          description: The rate cards of the plan.
+          title: Rate cards
+        startAfter:
+          type: string
+          format: duration
+          nullable: true
+          example: P1Y1D
+          description: The time after which the plan starts compared to subscription start
+          title: Start after
+        discounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/AppliedDiscount'
+          description: The discounts on the plan.
+          title: Discounts
+      description: Resource create operation model.
+    PlanPhasePaginatedResponse:
+      type: object
+      required:
+        - totalCount
+        - page
+        - pageSize
+        - items
+      properties:
+        totalCount:
+          type: integer
+          example: 500
+          description: The items in the current page.
+        page:
+          type: integer
+          example: 1
+          description: The items in the current page.
+        pageSize:
+          type: integer
+          example: 100
+          description: The items in the current page.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlanPhase'
+          description: The items in the current page.
+      description: Paginated response
+    PlanPhaseUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: Unique key among the plan phases. Used to reference the phase in the subscription & plan.
+        rateCards:
+          type: array
+          items:
+            $ref: '#/components/schemas/RateCard'
+          description: The rate cards of the plan.
+          title: Rate cards
+        startAfter:
+          type: string
+          format: duration
+          nullable: true
+          example: P1Y1D
+          description: The time after which the plan starts compared to subscription start
+          title: Start after
+        discounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/AppliedDiscount'
+          description: The discounts on the plan.
+          title: Discounts
+      description: Resource create or update operation model.
+    PlanReference:
+      type: object
+      required:
+        - key
+        - version
+      properties:
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: The plan key.
+        version:
+          type: integer
+          description: The plan version.
+      description: References an exact plan.
+    PlanStatus:
+      type: string
+      enum:
+        - draft
+        - active
+        - archived
+        - scheduled
+      description: The status of a plan.
+    PlanUpdate:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: The currency code of the plan.
+          title: Currency
+          default: USD
+        effectiveFrom:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The date and time when the plan becomes effective. When not specified, the plan is a draft.
+          title: Effective start date
+        effectiveTo:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The date and time when the plan is no longer effective. When not specified, the plan is effective indefinitely.
+          title: Effective end date
+        phases:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlanPhase'
+          minItems: 1
+          description: |-
+            The plan phase or pricing ramp allows changing a plan's rate cards over time as a subscription progresses.
+            A phase switch occurs only at the end of a billing period, ensuring that a single subscription invoice will not include charges from different phase prices.
+          title: Plan phases
+      description: Resource create or update operation model.
+    PortalToken:
+      type: object
+      required:
+        - subject
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+          readOnly: true
+        subject:
+          type: string
+          example: customer-1
+        expiresAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+          readOnly: true
+        expired:
+          type: boolean
+          readOnly: true
+        createdAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+          readOnly: true
+        token:
+          type: string
+          example: om_portal_IAnD3PpWW2A2Wr8m9jfzeHlGX8xmCXwG.y5q4S-AWqFu6qjfaFz0zQq4Ez28RsnyVwJffX5qxMvo
+          description: The token is only returned at creation.
+          readOnly: true
+        allowedMeterSlugs:
+          type: array
+          items:
+            type: string
+          example:
+            - tokens_total
+          description: Optional, if defined only the specified meters will be allowed.
+      description: |-
+        A consumer portal token.
+
+        Validator doesn't obey required for readOnly properties
+        See: https://github.com/stoplightio/spectral/issues/1274
+    PreconditionFailedProblemResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/UnexpectedProblemResponse'
+      description: One or more conditions given in the request header fields evaluated to false when tested on the server.
+    PricePaymentTerm:
+      type: string
+      enum:
+        - in_advance
+        - in_arrears
+      description: |-
+        The payment term of a flat price.
+        One of: in_advance or in_arrears.
+    PriceTier:
+      type: object
+      required:
+        - upToAmount
+        - flatPrice
+        - unitPrice
+      properties:
+        upToAmount:
+          type: number
+          format: double
+          nullable: true
+          description: |-
+            Up to and including to this quantity will be contained in the tier.
+            If null, the tier is open-ended.
+          title: Up to quantity
+        flatPrice:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/FlatPrice'
+          nullable: true
+          description: The flat price component of the tier.
+          title: Flat price component
+        unitPrice:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/UnitPrice'
+          nullable: true
+          description: The unit price component of the tier.
+          title: Unit price component
+      description: |-
+        A price tier.
+        At least one price component is required in each tier.
+    PriceTierUpdateItem:
+      type: object
+      required:
+        - upToAmount
+        - flatPrice
+        - unitPrice
+      properties:
+        upToAmount:
+          type: number
+          format: double
+          nullable: true
+          description: |-
+            Up to and including to this quantity will be contained in the tier.
+            If null, the tier is open-ended.
+          title: Up to quantity
+        flatPrice:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/FlatPriceUpdateItem'
+          nullable: true
+          description: The flat price component of the tier.
+          title: Flat price component
+        unitPrice:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/UnitPriceUpdateItem'
+          nullable: true
+          description: The unit price component of the tier.
+          title: Unit price component
+      description: |-
+        A price tier.
+        At least one price component is required in each tier.
+    ProfilePaginatedResponse:
+      type: object
+      required:
+        - totalCount
+        - page
+        - pageSize
+        - items
+      properties:
+        totalCount:
+          type: integer
+          example: 500
+          description: The items in the current page.
+        page:
+          type: integer
+          example: 1
+          description: The items in the current page.
+        pageSize:
+          type: integer
+          example: 100
+          description: The items in the current page.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/BillingProfile'
+          description: The items in the current page.
+      description: Paginated response
+    RateCard:
+      oneOf:
+        - $ref: '#/components/schemas/RateCardFlatFee'
+        - $ref: '#/components/schemas/RateCardUsageBased'
+      discriminator:
+        propertyName: type
+        mapping:
+          flat_fee: '#/components/schemas/RateCardFlatFee'
+          usage_based: '#/components/schemas/RateCardUsageBased'
+      description: A rate card defines the pricing and entitlement of a feature or service.
+    RateCardBooleanEntitlement:
+      type: object
+      required:
+        - type
+      properties:
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the feature.
+        type:
+          type: string
+          enum:
+            - boolean
+      description: Entitlement template of a boolean entitlement.
+    RateCardEntitlement:
+      anyOf:
+        - $ref: '#/components/schemas/RateCardMeteredEntitlement'
+        - $ref: '#/components/schemas/RateCardStaticEntitlement'
+        - $ref: '#/components/schemas/RateCardBooleanEntitlement'
+      discriminator:
+        propertyName: type
+        mapping:
+          metered: '#/components/schemas/RateCardMeteredEntitlement'
+          static: '#/components/schemas/RateCardStaticEntitlement'
+          boolean: '#/components/schemas/RateCardBooleanEntitlement'
+      description: |-
+        Entitlement templates are used to define the entitlements of a plan.
+        Features are omitted from the entitlement template, as they are defined in the rate card.
+    RateCardFlatFee:
+      type: object
+      required:
+        - name
+        - createdAt
+        - updatedAt
+        - key
+        - type
+        - billingCadence
+        - price
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: A semi-unique identifier for the resource.
+          title: Key
+        type:
+          type: string
+          enum:
+            - flat_fee
+          description: The type of the RateCard.
+          title: RateCard type
+        featureKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: The feature the customer is entitled to use.
+          title: Feature key
+        entitlementTemplate:
+          allOf:
+            - $ref: '#/components/schemas/RateCardEntitlement'
+          description: |-
+            The entitlement of the rate card.
+            Only available when featureKey is set.
+          title: Entitlement template
+        taxConfig:
+          allOf:
+            - $ref: '#/components/schemas/TaxConfig'
+          description: |-
+            The tax config of the rate card.
+            When undefined, the tax config of the feature or the default tax config of the plan is used.
+          title: Tax config
+        billingCadence:
+          type: string
+          format: duration
+          nullable: true
+          description: |-
+            The billing cadence of the rate card.
+            When null it means it is a one time fee.
+          title: Billing cadence
+        price:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/FlatPriceWithPaymentTerm'
+          nullable: true
+          example: {}
+          description: |-
+            The price of the rate card.
+            When null, the feature or service is free.
+          title: Price
+      description: A flat fee rate card defines a one-time purchase or a recurring fee.
+    RateCardFlatFeeUpdateItem:
+      type: object
+      required:
+        - name
+        - type
+        - billingCadence
+        - price
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        type:
+          type: string
+          enum:
+            - flat_fee
+          description: The type of the RateCard.
+          title: RateCard type
+        featureKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: The feature the customer is entitled to use.
+          title: Feature key
+        entitlementTemplate:
+          allOf:
+            - $ref: '#/components/schemas/RateCardEntitlement'
+          description: |-
+            The entitlement of the rate card.
+            Only available when featureKey is set.
+          title: Entitlement template
+        taxConfig:
+          allOf:
+            - $ref: '#/components/schemas/TaxConfig'
+          description: |-
+            The tax config of the rate card.
+            When undefined, the tax config of the feature or the default tax config of the plan is used.
+          title: Tax config
+        billingCadence:
+          type: string
+          format: duration
+          nullable: true
+          description: |-
+            The billing cadence of the rate card.
+            When null it means it is a one time fee.
+          title: Billing cadence
+        price:
+          type: object
+          allOf:
+            - $ref: '#/components/schemas/FlatPriceWithPaymentTermUpdateItem'
+          nullable: true
+          example: {}
+          description: |-
+            The price of the rate card.
+            When null, the feature or service is free.
+          title: Price
+      description: A flat fee rate card defines a one-time purchase or a recurring fee.
+    RateCardMeteredEntitlement:
+      type: object
+      required:
+        - type
+      properties:
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the feature.
+        type:
+          type: string
+          enum:
+            - metered
+        isSoftLimit:
+          type: boolean
+          description: If softLimit=true the subject can use the feature even if the entitlement is exhausted, hasAccess will always be true.
+          title: Soft limit
+          default: false
+        issueAfterReset:
+          type: number
+          format: double
+          minimum: 0
+          description: |-
+            You can grant usage automatically alongside the entitlement, the example scenario would be creating a starting balance.
+            If an amount is specified here, a grant will be created alongside the entitlement with the specified amount.
+            That grant will have it's rollover settings configured in a way that after each reset operation, the balance will return the original amount specified here.
+            Manually creating such a grant would mean having the "amount", "minRolloverAmount", and "maxRolloverAmount" fields all be the same.
+          title: Initial grant amount
+        issueAfterResetPriority:
+          type: integer
+          format: uint8
+          minimum: 1
+          maximum: 255
+          description: Defines the grant priority for the default grant.
+          title: Issue grant after reset priority
+          default: 1
+        preserveOverageAtReset:
+          type: boolean
+          description: If true, the overage is preserved at reset. If false, the usage is reset to 0.
+          title: Preserve overage at reset
+          default: false
+        usagePeriod:
+          type: string
+          format: duration
+          description: |-
+            The interval of the metered entitlement.
+            Defaults to the billing cadence of the rate card.
+          title: Usage Period
+      description: The entitlement template with a metered entitlement.
+    RateCardStaticEntitlement:
+      type: object
+      required:
+        - type
+        - config
+      properties:
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the feature.
+        type:
+          type: string
+          enum:
+            - static
+        config:
+          type: string
+          format: json
+          example: '{ "integrations": ["github"] }'
+          description: The JSON parsable config of the entitlement. This value is also returned when checking entitlement access and it is useful for configuring fine-grained access settings to the feature, implemented in your own system. Has to be an object.
+      description: Entitlement template of a static entitlement.
+    RateCardUpdateItem:
+      oneOf:
+        - $ref: '#/components/schemas/RateCardFlatFeeUpdateItem'
+        - $ref: '#/components/schemas/RateCardUsageBasedUpdateItem'
+      discriminator:
+        propertyName: type
+        mapping:
+          flat_fee: '#/components/schemas/RateCardFlatFeeUpdateItem'
+          usage_based: '#/components/schemas/RateCardUsageBasedUpdateItem'
+      description: A rate card defines the pricing and entitlement of a feature or service.
+    RateCardUsageBased:
+      type: object
+      required:
+        - name
+        - createdAt
+        - updatedAt
+        - key
+        - type
+        - billingCadence
+        - price
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: A semi-unique identifier for the resource.
+          title: Key
+        type:
+          type: string
+          enum:
+            - usage_based
+          description: The type of the RateCard.
+          title: RateCard type
+        featureKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: The feature the customer is entitled to use.
+          title: Feature key
+        entitlementTemplate:
+          allOf:
+            - $ref: '#/components/schemas/RateCardEntitlement'
+          description: |-
+            The entitlement of the rate card.
+            Only available when featureKey is set.
+          title: Entitlement template
+        taxConfig:
+          allOf:
+            - $ref: '#/components/schemas/TaxConfig'
+          description: |-
+            The tax config of the rate card.
+            When undefined, the tax config of the feature or the default tax config of the plan is used.
+          title: Tax config
+        billingCadence:
+          type: string
+          format: duration
+          description: The billing cadence of the rate card.
+          title: Billing cadence
+        price:
+          anyOf:
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/UnitPriceWithCommitments'
+              nullable: true
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/TieredPriceWithCommitments'
+              nullable: true
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/FlatPriceWithPaymentTerm'
+              nullable: true
+          example: {}
+          description: |-
+            The price of the rate card.
+            When null, the feature or service is free.
+          title: Price
+      description: A usage-based rate card defines a price based on usage.
+    RateCardUsageBasedUpdateItem:
+      type: object
+      required:
+        - name
+        - type
+        - billingCadence
+        - price
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        type:
+          type: string
+          enum:
+            - usage_based
+          description: The type of the RateCard.
+          title: RateCard type
+        featureKey:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: The feature the customer is entitled to use.
+          title: Feature key
+        entitlementTemplate:
+          allOf:
+            - $ref: '#/components/schemas/RateCardEntitlement'
+          description: |-
+            The entitlement of the rate card.
+            Only available when featureKey is set.
+          title: Entitlement template
+        taxConfig:
+          allOf:
+            - $ref: '#/components/schemas/TaxConfig'
+          description: |-
+            The tax config of the rate card.
+            When undefined, the tax config of the feature or the default tax config of the plan is used.
+          title: Tax config
+        billingCadence:
+          type: string
+          format: duration
+          description: The billing cadence of the rate card.
+          title: Billing cadence
+        price:
+          anyOf:
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/UnitPriceWithCommitmentsUpdateItem'
+              nullable: true
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/TieredPriceWithCommitmentsUpdateItem'
+              nullable: true
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/FlatPriceWithPaymentTermUpdateItem'
+              nullable: true
+          example: {}
+          description: |-
+            The price of the rate card.
+            When null, the feature or service is free.
+          title: Price
+      description: A usage-based rate card defines a price based on usage.
+    RecurringPeriod:
+      type: object
+      required:
+        - interval
+        - anchor
+      properties:
+        interval:
+          allOf:
+            - $ref: '#/components/schemas/RecurringPeriodInterval'
+          description: The unit of time for the interval.
+          title: Interval
+        anchor:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: A date-time anchor to base the recurring period on.
+          title: Anchor time
+      example:
+        interval: DAY
+        anchor: 2023-01-01T01:01:01.001Z
+      description: Recurring period with an interval and an anchor.
+    RecurringPeriodCreateInput:
+      type: object
+      required:
+        - interval
+      properties:
+        interval:
+          allOf:
+            - $ref: '#/components/schemas/RecurringPeriodInterval'
+          description: The unit of time for the interval.
+          title: Interval
+        anchor:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: A date-time anchor to base the recurring period on.
+          title: Anchor time
+      example:
+        interval: DAY
+        anchor: 2023-01-01T01:01:01.001Z
+      description: Recurring period with an interval and an anchor.
+    RecurringPeriodInterval:
+      type: string
+      enum:
+        - DAY
+        - WEEK
+        - MONTH
+        - YEAR
+      description: |-
+        The unit of time for the interval.
+        One of: `day`, `week`, `month`, or `year`.
+    RemovePhaseShifting:
+      type: string
+      enum:
+        - Next
+        - Prev
+      description: The direction of the phase shift when a phase is removed.
+    ResetEntitlementUsageInput:
+      type: object
+      properties:
+        effectiveAt:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The time at which the reset takes effect, defaults to now. The reset cannot be in the future. The provided value is truncated to the minute due to how historical meter data is stored.
+        retainAnchor:
+          type: boolean
+          description: |-
+            Determines whether the usage period anchor is retained or reset to the effectiveAt time.
+            - If true, the usage period anchor is retained.
+            - If false, the usage period anchor is reset to the effectiveAt time.
+        preserveOverage:
+          type: boolean
+          description: |-
+            Determines whether the overage is preserved or forgiven, overriding the entitlement's default behavior.
+            - If true, the overage is preserved.
+            - If false, the overage is forgiven.
+      description: Reset parameters
+    SandboxApp:
+      type: object
+      required:
+        - id
+        - name
+        - createdAt
+        - updatedAt
+        - listing
+        - status
+        - type
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the resource.
+          title: ID
+          readOnly: true
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        listing:
+          allOf:
+            - $ref: '#/components/schemas/MarketplaceListing'
+          description: The marketplace listing that this installed app is based on.
+          readOnly: true
+        status:
+          allOf:
+            - $ref: '#/components/schemas/AppStatus'
+          description: Status of the app connection.
+          readOnly: true
+        type:
+          type: string
+          enum:
+            - sandbox
+          description: The app's type is Sandbox.
+    ServiceUnavailableProblemResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/UnexpectedProblemResponse'
+      description: The server is currently unable to handle the request due to a temporary overload or scheduled maintenance, which will likely be alleviated after some delay.
+    SortOrder:
+      type: string
+      enum:
+        - ASC
+        - DESC
+      description: The order direction.
+    StripeApp:
+      type: object
+      required:
+        - id
+        - name
+        - createdAt
+        - updatedAt
+        - listing
+        - status
+        - type
+        - stripeAccountId
+        - livemode
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the resource.
+          title: ID
+          readOnly: true
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        listing:
+          allOf:
+            - $ref: '#/components/schemas/MarketplaceListing'
+          description: The marketplace listing that this installed app is based on.
+          readOnly: true
+        status:
+          allOf:
+            - $ref: '#/components/schemas/AppStatus'
+          description: Status of the app connection.
+          readOnly: true
+        type:
+          type: string
+          enum:
+            - stripe
+          description: The app's type is Stripe.
+        stripeAccountId:
+          type: string
+          description: The Stripe account ID.
+        livemode:
+          type: boolean
+          description: Livemode, true if the app is in production mode.
+      example:
+        id: 01G65Z755AFWAKHE12NY0CQ9FH
+        type: stripe
+        name: Stripe
+        status: ready
+        listing:
+          type: stripe
+          name: Stripe
+          description: Stripe interation allows you to collect payments with Stripe.
+          iconUrl: /images/stripe.png
+          capabilities:
+            - type: calculateTax
+              key: stripe_calculate_tax
+              name: Calculate Tax
+              description: Stripe Tax calculates tax portion of the invoices.
+            - type: invoiceCustomers
+              key: stripe_invoice_customers
+              name: Invoice Customers
+              description: Stripe invoices customers with due amount.
+            - type: collectPayments
+              key: stripe_collect_payments
+              name: Collect Payments
+              description: Stripe payments collects outstanding revenue with Stripe customer's default payment method.
+        createdAt: 2024-01-01T01:01:01.001Z
+        updatedAt: 2024-01-01T01:01:01.001Z
+        stripeAccountId: acct_123456789
+        livemode: true
+      description: A installed Stripe app object.
+    StripeCheckoutSessionMode:
+      type: string
+      enum:
+        - setup
+      description: Stripe CheckoutSession.mode
+    StripePaymentIntentStatus:
+      type: string
+      enum:
+        - canceled
+        - processing
+        - requires_action
+        - requires_confirmation
+        - requires_payment_method
+        - succeeded
+      description: Stripe payment intent status.
+    StripeSetupIntent:
+      type: object
+      required:
+        - id
+        - status
+        - customer
+        - metadata
+      properties:
+        id:
+          type: string
+          description: The setup intent id.
+        status:
+          allOf:
+            - $ref: '#/components/schemas/StripePaymentIntentStatus'
+          description: The setup intent status.
+        payment_method:
+          type: string
+          description: The setup intent payment method.
+        payment_method_types:
+          type: array
+          items:
+            type: string
+          description: The setup intent payment method types.
+        customer:
+          type: string
+          description: The setup intent customer.
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+          description: The setup intent metadata.
+      description: Stripe setup intent.
+    StripeTaxConfig:
+      type: object
+      required:
+        - code
+      properties:
+        code:
+          type: string
+          example: txcd_10000000
+          pattern: ^txcd_\d{8}$
+          description: |-
+            Product tax code.
+
+            See: https://docs.stripe.com/tax/tax-codes
+          title: Tax code
+      description: The tax config for Stripe.
+    StripeWebhookEvent:
+      type: object
+      required:
+        - id
+        - type
+        - livemode
+        - created
+        - data
+      properties:
+        id:
+          type: string
+          description: The event ID.
+        type:
+          type: string
+          description: The event type.
+        livemode:
+          type: boolean
+          description: Live mode.
+        created:
+          type: integer
+          format: int32
+          description: The event created timestamp.
+        data:
+          type: object
+          properties:
+            object:
+              $ref: '#/components/schemas/StripeSetupIntent'
+          required:
+            - object
+          description: The event data.
+      description: Stripe webhook event.
+    StripeWebhookResponse:
+      type: object
+      required:
+        - namespaceId
+        - appId
+      properties:
+        namespaceId:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+        appId:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+        customerId:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: ULID (Universally Unique Lexicographically Sortable Identifier).
+      description: Stripe webhook response.
+    Subject:
+      type: object
+      required:
+        - id
+        - key
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the subject.
+          readOnly: true
+        key:
+          type: string
+          example: customer-id
+          description: A unique, human-readable identifier for the subject.
+        displayName:
+          type: string
+          nullable: true
+          example: Customer Name
+          description: A human-readable display name for the subject.
+        metadata:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          example: {}
+        currentPeriodStart:
+          type: string
+          format: date-time
+          example: 2023-01-01T00:00:00Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+        currentPeriodEnd:
+          type: string
+          format: date-time
+          example: 2023-02-01T00:00:00Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+        stripeCustomerId:
+          type: string
+          nullable: true
+          example: cus_JMOlctsKV8
+      example:
+        id: 01G65Z755AFWAKHE12NY0CQ9FH
+        key: customer-id
+        displayName: Customer Name
+        metadata:
+          hubspotId: '123456'
+        currentPeriodStart: 2023-01-01T00:00:00Z
+        currentPeriodEnd: 2023-02-01T00:00:00Z
+        stripeCustomerId: cus_JMOlctsKV8
+      description: A subject is a unique identifier for a user or entity.
+    SubjectUpsert:
+      type: object
+      required:
+        - key
+      properties:
+        key:
+          type: string
+          example: customer-id
+          description: A unique, human-readable identifier for the subject.
+        displayName:
+          type: string
+          nullable: true
+          example: Customer Name
+          description: A human-readable display name for the subject.
+        metadata:
+          type: object
+          additionalProperties: {}
+          nullable: true
+          example: {}
+        currentPeriodStart:
+          type: string
+          format: date-time
+          example: 2023-01-01T00:00:00Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+        currentPeriodEnd:
+          type: string
+          format: date-time
+          example: 2023-02-01T00:00:00Z
+          description: '[RFC3339](https://tools.ietf.org/html/rfc3339) formatted date-time string in UTC.'
+        stripeCustomerId:
+          type: string
+          nullable: true
+          example: cus_JMOlctsKV8
+      example:
+        key: customer-id
+        displayName: Customer Name
+        metadata:
+          hubspotId: '123456'
+        currentPeriodStart: 2023-01-01T00:00:00Z
+        currentPeriodEnd: 2023-02-01T00:00:00Z
+        stripeCustomerId: cus_JMOlctsKV8
+      description: A subject is a unique identifier for a user or entity.
+    Subscription:
+      type: object
+      required:
+        - id
+        - name
+        - createdAt
+        - updatedAt
+        - customerId
+        - plan
+        - currency
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the resource.
+          title: ID
+          readOnly: true
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        customerId:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: The customer ID of the subscription.
+        plan:
+          allOf:
+            - $ref: '#/components/schemas/PlanReference'
+          description: The base plan of the subscription.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: |-
+            The currency code of the subscription.
+            Will be revised once we add multi currency support.
+          title: Currency
+          default: USD
+        activeTo:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: If the subscription is canceled or otherwise have to end activeTo denotes the end date.
+      description: Subscription is an exact subscription instance.
+    SubscriptionEditAdd:
+      type: object
+      required:
+        - op
+        - path
+        - value
+      properties:
+        op:
+          type: string
+          enum:
+            - add
+        path:
+          type: string
+          pattern: ^\/phases\/[a-zA-Z0-9\-]+$
+        value:
+          $ref: '#/components/schemas/SubscriptionPhaseCreate'
+      description: Subscription item add operation.
+    SubscriptionEditAddItem:
+      type: object
+      required:
+        - op
+        - path
+        - value
+      properties:
+        op:
+          type: string
+          enum:
+            - add
+        path:
+          type: string
+          pattern: ^\/phases\/[a-zA-Z0-9\-]+\/items\/[a-zA-Z0-9\-]+$
+        value:
+          $ref: '#/components/schemas/RateCard'
+      description: Subscription item add operation.
+    SubscriptionEditAddUpdateItem:
+      type: object
+      required:
+        - op
+        - path
+        - value
+      properties:
+        op:
+          type: string
+          enum:
+            - add
+        path:
+          type: string
+          pattern: ^\/phases\/[a-zA-Z0-9\-]+\/items\/[a-zA-Z0-9\-]+$
+        value:
+          $ref: '#/components/schemas/RateCardUpdateItem'
+      description: Subscription item add operation.
+    SubscriptionEditExtend:
+      type: object
+      required:
+        - op
+        - path
+        - value
+      properties:
+        op:
+          type: string
+          enum:
+            - extend
+        path:
+          type: string
+          pattern: ^\/phases\/[a-zA-Z0-9\-]+$
+        value:
+          type: object
+          properties:
+            extendBy:
+              type: string
+              format: duration
+          required:
+            - extendBy
+      description: Subscription phase extend operation.
+    SubscriptionEditRemoveItem:
+      type: object
+      required:
+        - op
+        - path
+      properties:
+        op:
+          type: string
+          enum:
+            - remove
+        path:
+          type: string
+          pattern: ^\/phases\/[a-zA-Z0-9\-]+\/items\/[a-zA-Z0-9\-]+$
+      description: Subscription phase remove operation.
+    SubscriptionEditRemoveUpdateItem:
+      type: object
+      required:
+        - op
+        - path
+      properties:
+        op:
+          type: string
+          enum:
+            - remove
+        path:
+          type: string
+          pattern: ^\/phases\/[a-zA-Z0-9\-]+\/items\/[a-zA-Z0-9\-]+$
+      description: Subscription phase remove operation.
+    SubscriptionEditRemoveWithValue:
+      type: object
+      required:
+        - op
+        - path
+        - value
+      properties:
+        op:
+          type: string
+          enum:
+            - remove
+        path:
+          type: string
+          pattern: ^\/phases\/[a-zA-Z0-9\-]+$
+        value:
+          type: object
+          properties:
+            shift:
+              $ref: '#/components/schemas/RemovePhaseShifting'
+          required:
+            - shift
+      description: Subscription item remove operation with a value.
+    SubscriptionExpanded:
+      type: object
+      required:
+        - id
+        - name
+        - createdAt
+        - updatedAt
+        - customerId
+        - plan
+        - currency
+        - phases
+      properties:
+        id:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: A unique identifier for the resource.
+          title: ID
+          readOnly: true
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        customerId:
+          type: string
+          example: 01G65Z755AFWAKHE12NY0CQ9FH
+          pattern: ^[0-7][0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]{25}$
+          description: The customer ID of the subscription.
+        plan:
+          allOf:
+            - $ref: '#/components/schemas/PlanReference'
+          description: The base plan of the subscription.
+        currency:
+          allOf:
+            - $ref: '#/components/schemas/CurrencyCode'
+          description: |-
+            The currency code of the subscription.
+            Will be revised once we add multi currency support.
+          title: Currency
+          default: USD
+        activeTo:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: If the subscription is canceled or otherwise have to end activeTo denotes the end date.
+        phases:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubscriptionPhaseExpanded'
+      description: Expanded subscription
+    SubscriptionItem:
+      type: object
+      required:
+        - name
+        - createdAt
+        - updatedAt
+        - key
+        - billingCandence
+        - price
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: |-
+            The identifier of the RateCard.
+            SubscriptionItem/RateCard can be identified, it has a reference:
+
+            1. If a Feature is associated with the SubscriptionItem, it is identified by the Feature
+            1.1 It can be an ID reference, for an exact version of the Feature (Features can change across versions)
+            1.2 It can be a Key reference, which always refers to the latest (active or inactive) version of a Feature
+
+            2. If a Feature is not associated with the SubscriptionItem, it is referenced by the Price
+
+            We say “referenced by the Price” regardless of how a price itself is referenced, it colloquially makes sense to say “paying the same price for the same thing”. In practice this should be derived from what's printed on the invoice line-item.
+        billingCandence:
+          type: string
+          format: duration
+          nullable: true
+          description: |-
+            The billing cadence of the rate card.
+            When null, the rate card is a one-time purchase.
+          title: Billing cadence
+        price:
+          anyOf:
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/FlatPriceWithPaymentTerm'
+              nullable: true
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/UnitPriceWithCommitments'
+              nullable: true
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/TieredPriceWithCommitments'
+              nullable: true
+            - type: object
+              allOf:
+                - $ref: '#/components/schemas/FlatPriceWithPaymentTerm'
+              nullable: true
+          example: {}
+          description: |-
+            The price of the rate card.
+            When null, the feature or service is free.
+          title: Price
+        included:
+          type: object
+          properties:
+            feature:
+              allOf:
+                - $ref: '#/components/schemas/Feature'
+              description: The feature the customer is entitled to use.
+            entitlement:
+              allOf:
+                - $ref: '#/components/schemas/Entitlement'
+              description: The entitlement of the Subscription Item.
+          required:
+            - feature
+          description: Describes what access is gained via the SubscriptionItem
+      description: The actual contents of the Subscription, what the user gets, what they pay, etc...
+    SubscriptionPhaseCreate:
+      type: object
+      required:
+        - startAfter
+        - duration
+      properties:
+        startAfter:
+          type: string
+          format: duration
+          nullable: true
+          example: P1Y1D
+          description: |-
+            Interval after the subscription starts to transition to the phase.
+            When null, the phase starts immediately after the subscription starts.
+          title: Start after
+        duration:
+          type: string
+          format: duration
+          example: P1M
+          description: The intended duration of the new phase.
+          title: Duration
+        discounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/AppliedDiscountUpdateItem'
+          description: The discounts on the plan.
+          title: Discount
+      description: Subscription phase create input.
+    SubscriptionPhaseExpanded:
+      type: object
+      required:
+        - name
+        - createdAt
+        - updatedAt
+        - key
+        - duration
+        - activeFrom
+        - items
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 256
+          description: Human-readable name for the resource. Between 1 and 256 characters.
+          title: Display name
+        description:
+          type: string
+          maxLength: 1024
+          description: Optional description of the resource. Maximum 1024 characters.
+          title: Description
+        metadata:
+          allOf:
+            - $ref: '#/components/schemas/Metadata'
+          description: Additional metadata for the resource.
+          title: Metadata
+        createdAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was created.
+          title: Creation Time
+          readOnly: true
+        updatedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was last updated.
+          title: Last Update Time
+          readOnly: true
+        deletedAt:
+          type: string
+          format: date-time
+          example: 2024-01-01T01:01:01.001Z
+          description: Timestamp of when the resource was permanently deleted.
+          title: Deletion Time
+          readOnly: true
+        key:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: ^[a-z0-9]+(?:_[a-z0-9]+)*$
+          description: A locally unique identifier for the resource.
+        duration:
+          type: string
+          format: duration
+          example: P1M
+          description: The intended duration of the new phase.
+          title: Duration
+        discounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/AppliedDiscount'
+          description: The discounts on the plan.
+          title: Discount
+        activeFrom:
+          type: string
+          format: date-time
+          example: 2023-01-01T01:01:01.001Z
+          description: The time from which the phase is active.
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubscriptionItem'
+      description: Expanded subscription phase
+    SvixOperationalWebhookRequest:
+      type: object
+      required:
+        - type
+        - data
+      properties:
+        type:
+          type: string
+          enum:
+            - endpoint.created
+            - endpoint.deleted
+            - endpoint.disabled
+            - endpoint.updated
+            - message.attempt.exhausted
+            - message.attempt.failing
+            - message.attempt.recovered
+          description: The type of the Svix operational webhook request.
+          title: Operational Webhook Type
+        data:
+          type: object
+          additionalProperties:
+            type: string
+          description: The payload of the Svix operational webhook request.
+          title: Operational Webhook Payload
+      description: Operational webhook reqeuest sent by Svix.
+    TaxConfig:
+      type: object
+      properties:
+        stripe:
+          allOf:
+            - $ref: '#/components/schemas/StripeTaxConfig'
+          description: Stripe tax config.
+          title: Stripe tax config
+      description: Set of provider specific tax configs.
+    TieredPriceMode:
+      type: string
+      enum:
+        - volume
+        - graduated
+      description: The mode of the tiered price.
+    TieredPriceWithCommitments:
+      type: object
+      required:
+        - type
+        - mode
+        - tiers
+      properties:
+        type:
+          type: string
+          enum:
+            - tiered
+        mode:
+          allOf:
+            - $ref: '#/components/schemas/TieredPriceMode'
+          description: |-
+            Defines if the tiering mode is volume-based or graduated:
+            - In `volume`-based tiering, the maximum quantity within a period determines the per unit price.
+            - In `graduated` tiering, pricing can change as the quantity grows.
+          title: Mode
+        tiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/PriceTier'
+          minItems: 1
+          description: |-
+            The tiers of the tiered price.
+            At least one price component is required in each tier.
+          title: Tiers
+        minimumAmount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The customer is committed to spend at least the amount.
+          title: Minimum amount
+        maximumAmount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The customer is limited to spend at most the amount.
+          title: Maximum amount
+      description: Tiered price with spend commitments.
+    TieredPriceWithCommitmentsUpdateItem:
+      type: object
+      required:
+        - mode
+        - tiers
+      properties:
+        mode:
+          allOf:
+            - $ref: '#/components/schemas/TieredPriceMode'
+          description: |-
+            Defines if the tiering mode is volume-based or graduated:
+            - In `volume`-based tiering, the maximum quantity within a period determines the per unit price.
+            - In `graduated` tiering, pricing can change as the quantity grows.
+          title: Mode
+        tiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/PriceTierUpdateItem'
+          minItems: 1
+          description: |-
+            The tiers of the tiered price.
+            At least one price component is required in each tier.
+          title: Tiers
+        minimumAmount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The customer is committed to spend at least the amount.
+          title: Minimum amount
+        maximumAmount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The customer is limited to spend at most the amount.
+          title: Maximum amount
+      description: Tiered price with spend commitments.
+    UnauthorizedProblemResponse:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/UnexpectedProblemResponse'
+      description: The request has not been applied because it lacks valid authentication credentials for the target resource.
+    UnexpectedProblemResponse:
+      type: object
+      required:
+        - type
+        - title
+        - detail
+        - instance
+      properties:
+        type:
+          type: string
+          format: uri
+          example: about:blank
+          description: Type contains a URI that identifies the problem type.
+          default: about:blank
+        title:
+          type: string
+          example: Bad Request
+          description: A a short, human-readable summary of the problem type.
+        status:
+          type: integer
+          format: int16
+          example: 400
+          minimum: 400
+          maximum: 599
+          description: The HTTP status code generated by the origin server for this occurrence of the problem.
+        detail:
+          type: string
+          example: The request body must be a JSON object.
+          description: A human-readable explanation specific to this occurrence of the problem.
+        instance:
+          type: string
+          format: uri
+          example: urn:request:local/JMOlctsKV8-000001
+          description: A URI reference that identifies the specific occurrence of the problem.
+      additionalProperties:
+        anyOf:
+          - type: string
+          - type: integer
+      description: |-
+        A Problem Details object (RFC 7807).
+        Additional properties specific to the problem type may be present.
+      x-go-type-import:
+        path: github.com/openmeterio/openmeter/pkg/models
+      x-go-type: models.StatusProblem
+    UnitPrice:
+      type: object
+      required:
+        - type
+        - amount
+      properties:
+        type:
+          type: string
+          enum:
+            - unit
+        amount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The amount of the unit price.
+      description: Unit price.
+    UnitPriceUpdateItem:
+      type: object
+      required:
+        - amount
+      properties:
+        amount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The amount of the unit price.
+      description: Unit price.
+    UnitPriceWithCommitments:
+      type: object
+      required:
+        - type
+        - amount
+      properties:
+        type:
+          type: string
+          enum:
+            - unit
+        amount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The amount of the unit price.
+        minimumAmount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The customer is committed to spend at least the amount.
+          title: Minimum amount
+        maximumAmount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The customer is limited to spend at most the amount.
+          title: Maximum amount
+      description: Unit price with spend commitments.
+    UnitPriceWithCommitmentsUpdateItem:
+      type: object
+      required:
+        - amount
+      properties:
+        amount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The amount of the unit price.
+        minimumAmount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The customer is committed to spend at least the amount.
+          title: Minimum amount
+        maximumAmount:
+          allOf:
+            - $ref: '#/components/schemas/Numeric'
+          description: The customer is limited to spend at most the amount.
+          title: Maximum amount
+      description: Unit price with spend commitments.
+    WindowSize:
+      type: string
+      enum:
+        - MINUTE
+        - HOUR
+        - DAY
+      description: Aggregation window size.
+      x-go-type-import:
+        path: github.com/openmeterio/openmeter/pkg/models
+      x-go-type: models.WindowSize
+    WindowedBalanceHistory:
+      type: object
+      required:
+        - windowedHistory
+        - burndownHistory
+      properties:
+        windowedHistory:
+          type: array
+          items:
+            $ref: '#/components/schemas/BalanceHistoryWindow'
+          description: |-
+            The windowed balance history.
+            - It only returns rows for windows where there was usage.
+            - The windows are inclusive at their start and exclusive at their end.
+            - The last window may be smaller than the window size and is inclusive at both ends.
+        burndownHistory:
+          type: array
+          items:
+            $ref: '#/components/schemas/GrantBurnDownHistorySegment'
+          description: Grant burndown history.
+      description: The windowed balance history.
+  securitySchemes:
+    CloudTokenAuth:
+      type: http
+      scheme: bearer
+      description: Cloud API token.
+    CloudCookieAuth:
+      type: apiKey
+      in: cookie
+      name: __session
+      description: Cloud API web app cookie.
+    CloudPortalTokenAuth:
+      type: http
+      scheme: bearer
+      description: Cloud consumer portal token.
+servers:
+  - url: https://openmeter.cloud
+    description: Cloud
+    variables: {}
+  - url: https://127.0.0.1:8888
+    description: Local
+    variables: {}


### PR DESCRIPTION
- Generate clients after TypeSpec migration.
- Add tests to the Go client.
- Re-enable client gen for Node and Go clients