### PR TITLE
feat(telemetry): add resource k8s pod uuid

### DIFF
--- a/app/common/app.go
+++ b/app/common/app.go
@@ -21,12 +21,12 @@ type Metadata struct {
 	K8SPodUID string
 }
 
-func NewMetadata(conf config.Configuration, version string, otelName string) Metadata {
+func NewMetadata(conf config.Configuration, version string, serviceName string) Metadata {
 	return Metadata{
-		ServiceName:       "openmeter",
+		ServiceName:       fmt.Sprintf("openmeter-%s", serviceName),
 		Version:           version,
 		Environment:       conf.Environment,
-		OpenTelemetryName: fmt.Sprintf("openmeter.io/%s", otelName),
+		OpenTelemetryName: fmt.Sprintf("openmeter.io/%s", serviceName),
 		K8SPodUID:         conf.K8SPodUID,
 	}
 }

--- a/app/common/app.go
+++ b/app/common/app.go
@@ -14,6 +14,8 @@ type Metadata struct {
 	Version           string
 	Environment       string
 	OpenTelemetryName string
+
+	K8SPodUID *string
 }
 
 // Runner is a helper struct that runs a group of services.

--- a/app/common/app.go
+++ b/app/common/app.go
@@ -2,10 +2,12 @@ package common
 
 import (
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 
 	"github.com/oklog/run"
+	"github.com/openmeterio/openmeter/app/config"
 )
 
 // Metadata provides information about the service to components that need it (eg. telemetry).
@@ -15,7 +17,18 @@ type Metadata struct {
 	Environment       string
 	OpenTelemetryName string
 
-	K8SPodUID *string
+	// Optional
+	K8SPodUID string
+}
+
+func NewMetadata(conf config.Configuration, version string, otelName string) Metadata {
+	return Metadata{
+		ServiceName:       "openmeter",
+		Version:           version,
+		Environment:       conf.Environment,
+		OpenTelemetryName: fmt.Sprintf("openmeter.io/%s", otelName),
+		K8SPodUID:         conf.K8SPodUID,
+	}
 }
 
 // Runner is a helper struct that runs a group of services.

--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -52,8 +52,8 @@ func NewTelemetryResource(metadata Metadata) *resource.Resource {
 		semconv.DeploymentEnvironment(metadata.Environment),
 	}
 
-	if metadata.K8SPodUID != nil {
-		attrs = append(attrs, semconv.K8SPodUID(*metadata.K8SPodUID))
+	if metadata.K8SPodUID != "" {
+		attrs = append(attrs, semconv.K8SPodUID(metadata.K8SPodUID))
 	}
 
 	extraResources, _ := resource.New(

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -17,6 +17,7 @@ import (
 type Configuration struct {
 	Address     string
 	Environment string
+	K8SPodUID   string
 
 	Telemetry TelemetryConfig
 

--- a/cmd/balance-worker/wire.go
+++ b/cmd/balance-worker/wire.go
@@ -42,10 +42,5 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 }
 
 func metadata(conf config.Configuration) common.Metadata {
-	return common.Metadata{
-		ServiceName:       "openmeter",
-		Version:           version,
-		Environment:       conf.Environment,
-		OpenTelemetryName: "openmeter.io/balance-worker",
-	}
+	return common.NewMetadata(conf, version, "balance-worker")
 }

--- a/cmd/balance-worker/wire_gen.go
+++ b/cmd/balance-worker/wire_gen.go
@@ -214,10 +214,5 @@ type Application struct {
 }
 
 func metadata(conf config.Configuration) common.Metadata {
-	return common.Metadata{
-		ServiceName:       "openmeter",
-		Version:           version,
-		Environment:       conf.Environment,
-		OpenTelemetryName: "openmeter.io/balance-worker",
-	}
+	return common.NewMetadata(conf, version, "balance-worker")
 }

--- a/cmd/notification-service/wire.go
+++ b/cmd/notification-service/wire.go
@@ -57,10 +57,5 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 }
 
 func metadata(conf config.Configuration) common.Metadata {
-	return common.Metadata{
-		ServiceName:       "openmeter",
-		Version:           version,
-		Environment:       conf.Environment,
-		OpenTelemetryName: "openmeter.io/notification-service",
-	}
+	return common.NewMetadata(conf, version, "notification-worker")
 }

--- a/cmd/notification-service/wire_gen.go
+++ b/cmd/notification-service/wire_gen.go
@@ -195,10 +195,5 @@ type Application struct {
 }
 
 func metadata(conf config.Configuration) common.Metadata {
-	return common.Metadata{
-		ServiceName:       "openmeter",
-		Version:           version,
-		Environment:       conf.Environment,
-		OpenTelemetryName: "openmeter.io/notification-service",
-	}
+	return common.NewMetadata(conf, version, "notification-worker")
 }

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -68,10 +68,5 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 }
 
 func metadata(conf config.Configuration) common.Metadata {
-	return common.Metadata{
-		ServiceName:       "openmeter",
-		Version:           version,
-		Environment:       conf.Environment,
-		OpenTelemetryName: "openmeter.io/backend",
-	}
+	return common.NewMetadata(conf, version, "backend")
 }

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -287,10 +287,5 @@ type Application struct {
 }
 
 func metadata(conf config.Configuration) common.Metadata {
-	return common.Metadata{
-		ServiceName:       "openmeter",
-		Version:           version,
-		Environment:       conf.Environment,
-		OpenTelemetryName: "openmeter.io/backend",
-	}
+	return common.NewMetadata(conf, version, "backend")
 }

--- a/cmd/sink-worker/wire.go
+++ b/cmd/sink-worker/wire.go
@@ -56,12 +56,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 }
 
 func metadata(conf config.Configuration) common.Metadata {
-	return common.Metadata{
-		ServiceName:       "openmeter",
-		Version:           version,
-		Environment:       conf.Environment,
-		OpenTelemetryName: "openmeter.io/sink-worker",
-	}
+	return common.NewMetadata(conf, version, "sink-worker")
 }
 
 // TODO: use the primary logger

--- a/cmd/sink-worker/wire_gen.go
+++ b/cmd/sink-worker/wire_gen.go
@@ -156,12 +156,7 @@ type Application struct {
 }
 
 func metadata(conf config.Configuration) common.Metadata {
-	return common.Metadata{
-		ServiceName:       "openmeter",
-		Version:           version,
-		Environment:       conf.Environment,
-		OpenTelemetryName: "openmeter.io/sink-worker",
-	}
+	return common.NewMetadata(conf, version, "sink-worker")
 }
 
 // TODO: use the primary logger


### PR DESCRIPTION
Allow Kubernetes POD UUID to be passed to telemetry attributes.
The PR also fixes an issue that service name was "openmeter" for all microservices.