### PR TITLE
feat(otel): upgrade semconv to 1.27.0

### DIFF
--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -24,7 +24,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/app/config"
@@ -52,7 +52,7 @@ func NewTelemetryResource(metadata Metadata) *resource.Resource {
 		resource.WithAttributes(
 			semconv.ServiceName(metadata.ServiceName),
 			semconv.ServiceVersion(metadata.Version),
-			semconv.DeploymentEnvironment(metadata.Environment),
+			semconv.DeploymentEnvironmentName(metadata.Environment),
 		),
 	)
 
@@ -209,7 +209,7 @@ func NewTelemetryRouterHook(meterProvider metric.MeterProvider, tracerProvider t
 
 					span := trace.SpanFromContext(r.Context())
 					span.SetName(routePattern)
-					span.SetAttributes(semconv.HTTPTarget(r.URL.String()), semconv.HTTPRoute(routePattern))
+					span.SetAttributes(semconv.URLPath(r.URL.String()), semconv.HTTPRoute(routePattern))
 
 					labeler, ok := otelhttp.LabelerFromContext(r.Context())
 					if ok {

--- a/pkg/framework/pgdriver/driver.go
+++ b/pkg/framework/pgdriver/driver.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	pgxstdlib "github.com/jackc/pgx/v5/stdlib"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/pkg/pgxpoolobserver"


### PR DESCRIPTION
Upgrade semconv to 1.27.0 and migrate deployment name and URL path attributes.
This is a potential breaking change in monitoring and alerting if someone uses an observability tool that can't handle semconv upgrades gradually.