### PR TITLE
fix(log): contextual logging

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -106,6 +106,7 @@ func main() {
 	app.SetGlobals()
 
 	logger := app.Logger
+	slog.SetDefault(logger)
 
 	logger.Info("starting OpenMeter server", "config", map[string]string{
 		"address":             conf.Address,

--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -87,6 +87,7 @@ func main() {
 	app.SetGlobals()
 
 	logger := app.Logger
+	slog.SetDefault(logger)
 
 	logger.Info("starting OpenMeter sink worker", "config", map[string]string{
 		"telemetry.address":   conf.Telemetry.Address,

--- a/openmeter/entitlement/repository.go
+++ b/openmeter/entitlement/repository.go
@@ -25,7 +25,7 @@ type EntitlementRepo interface {
 	// GetScheduledEntitlements returns all scheduled entitlements for a given subject-feature pair that become inactive after the given time, sorted by the time they become active
 	GetScheduledEntitlements(ctx context.Context, namespace string, subjectKey models.SubjectKey, featureKey string, starting time.Time) ([]Entitlement, error)
 
-	// GetEntitlementValue deactivates an entitlement by setting the activeTo time. If the entitlement is already deactivated, it returns an error.
+	// DeactivateEntitlement deactivates an entitlement by setting the activeTo time. If the entitlement is already deactivated, it returns an error.
 	DeactivateEntitlement(ctx context.Context, entitlementID models.NamespacedID, at time.Time) error
 
 	CreateEntitlement(ctx context.Context, entitlement CreateEntitlementRepoInputs) (*Entitlement, error)

--- a/pkg/framework/operation/log.go
+++ b/pkg/framework/operation/log.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 )
 
+var _ slog.Handler = (*Handler)(nil)
+
 // NewLogHandler returns a new [slog.Handler]
 func NewLogHandler(handler slog.Handler) slog.Handler {
 	return Handler{handler}


### PR DESCRIPTION
We use the default logger in multiple places, like NewServer, and extend it with more attributes, like route-level log context.
Without setting the app logger as default for slog this context is lost in Telemetry.
