### PR TITLE
refactor(framework): simplify logging handlers

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -138,7 +138,7 @@ func main() {
 		ingestService.IngestEvents,
 		namespacedriver.StaticNamespaceDecoder(app.NamespaceManager.GetDefaultNamespace()),
 		nil,
-		errorsx.NewContextHandler(errorsx.NewAppHandler(errorsx.NewSlogHandler(logger))),
+		errorsx.NewSlogHandler(logger),
 	)
 
 	// Initialize portal
@@ -383,7 +383,7 @@ func main() {
 			Meters:              app.MeterRepository,
 			PortalTokenStrategy: portalTokenStrategy,
 			PortalCORSEnabled:   conf.Portal.CORS.Enabled,
-			ErrorHandler:        errorsx.NewAppHandler(errorsx.NewSlogHandler(logger)),
+			ErrorHandler:        errorsx.NewSlogHandler(logger),
 			// deps
 			App:                         appService,
 			AppStripe:                   appStripeService,

--- a/openmeter/ingest/ingestdriver/http_transport_test.go
+++ b/openmeter/ingest/ingestdriver/http_transport_test.go
@@ -33,7 +33,7 @@ func TestIngestEvents(t *testing.T) {
 		service.IngestEvents,
 		namespacedriver.StaticNamespaceDecoder("test"),
 		nil,
-		errorsx.NewContextHandler(errorsx.NopHandler{}),
+		errorsx.NewNopHandler(),
 	)
 
 	server := httptest.NewServer(handler)
@@ -83,7 +83,7 @@ func TestIngestEvents_InvalidEvent(t *testing.T) {
 		service.IngestEvents,
 		namespacedriver.StaticNamespaceDecoder("test"),
 		nil,
-		errorsx.NewContextHandler(errorsx.NopHandler{}),
+		errorsx.NewNopHandler(),
 	)
 
 	server := httptest.NewServer(handler)
@@ -109,7 +109,7 @@ func TestBatchHandler(t *testing.T) {
 		service.IngestEvents,
 		namespacedriver.StaticNamespaceDecoder("test"),
 		nil,
-		errorsx.NewContextHandler(errorsx.NopHandler{}),
+		errorsx.NewNopHandler(),
 	)
 
 	server := httptest.NewServer(handler)

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -142,7 +142,7 @@ func makeRequest(r *http.Request) (*httptest.ResponseRecorder, error) {
 			DebugConnector:     MockDebugHandler{},
 			IngestHandler: ingestdriver.NewIngestEventsHandler(func(ctx context.Context, request ingest.IngestEventsRequest) (bool, error) {
 				return true, nil
-			}, namespacedriver.StaticNamespaceDecoder("test"), nil, errorsx.NewContextHandler(errorsx.NopHandler{})),
+			}, namespacedriver.StaticNamespaceDecoder("test"), nil, errorsx.NewNopHandler()),
 			NamespaceManager:    namespaceManager,
 			PortalTokenStrategy: portalTokenStrategy,
 			ErrorHandler:        errorsx.NopHandler{},

--- a/pkg/errorsx/handler.go
+++ b/pkg/errorsx/handler.go
@@ -6,37 +6,15 @@ import (
 	"log/slog"
 )
 
+var (
+	_ Handler = (*SlogHandler)(nil)
+	_ Handler = (*NopHandler)(nil)
+)
+
 // Handler handles an error.
 type Handler interface {
 	Handle(err error)
 	HandleContext(ctx context.Context, err error)
-}
-
-// AppHandler contains some custom logic to handle an error.
-type AppHandler struct {
-	Handler Handler
-}
-
-func NewAppHandler(handler Handler) AppHandler {
-	return AppHandler{Handler: handler}
-}
-
-func (h AppHandler) Handle(err error) {
-	// ignore context cancellation errors: they generally occur due to the client canceling the request
-	if errors.Is(err, context.Canceled) {
-		return
-	}
-
-	h.Handler.Handle(err)
-}
-
-func (h AppHandler) HandleContext(ctx context.Context, err error) {
-	// ignore context cancellation errors: they generally occur due to the client canceling the request
-	if errors.Is(err, context.Canceled) {
-		return
-	}
-
-	h.Handler.HandleContext(ctx, err)
 }
 
 // SlogHandler is a Handler that logs errors using slog.
@@ -49,43 +27,48 @@ func NewSlogHandler(logger *slog.Logger) SlogHandler {
 }
 
 func (h SlogHandler) Handle(err error) {
+	// Context canceled errors are logged as warnings.
+	if errors.Is(err, context.Canceled) {
+		h.Logger.Warn(err.Error())
+		return
+	}
+
+	// Warn errors are logged as warnings.
 	if wErr, ok := ErrorAs[*warnError](err); ok {
 		h.Logger.Warn(wErr.Error())
-	} else {
-		h.Logger.Error(err.Error())
+		return
 	}
+
+	// All other errors are logged as errors.
+	h.Logger.Error(err.Error())
 }
 
 func (h SlogHandler) HandleContext(ctx context.Context, err error) {
+	// Context canceled errors are logged as warnings.
+	if errors.Is(err, context.Canceled) {
+		h.Logger.WarnContext(ctx, err.Error())
+		return
+	}
+
+	// Warn errors are logged as warnings.
 	if wErr, ok := ErrorAs[*warnError](err); ok {
 		h.Logger.WarnContext(ctx, wErr.Error())
-	} else {
-		h.Logger.ErrorContext(ctx, err.Error())
+		return
 	}
+
+	// All other errors are logged as errors.
+	h.Logger.ErrorContext(ctx, err.Error())
 }
 
 // NopHandler ignores all errors.
 type NopHandler struct{}
 
+func NewNopHandler() NopHandler {
+	return NopHandler{}
+}
+
 func (h NopHandler) Handle(err error) {
 }
 
 func (h NopHandler) HandleContext(ctx context.Context, err error) {
-}
-
-// ContextHandler always accepts a context.
-type ContextHandler struct {
-	Handler Handler
-}
-
-func NewContextHandler(handler Handler) ContextHandler {
-	return ContextHandler{Handler: handler}
-}
-
-func (h ContextHandler) Handle(ctx context.Context, err error) {
-	h.Handler.HandleContext(ctx, err)
-}
-
-func (h ContextHandler) HandleContext(ctx context.Context, err error) {
-	h.Handler.HandleContext(ctx, err)
 }

--- a/pkg/errorsx/handler.go
+++ b/pkg/errorsx/handler.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+
+	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
 )
 
 var (
-	_ Handler = (*SlogHandler)(nil)
-	_ Handler = (*NopHandler)(nil)
+	_ httptransport.ErrorHandler = (Handler)(nil)
+	_ Handler                    = (*SlogHandler)(nil)
+	_ Handler                    = (*NopHandler)(nil)
 )
 
 // Handler handles an error.
+// Same interface as httptransport.ErrorHandler.
 type Handler interface {
 	Handle(err error)
 	HandleContext(ctx context.Context, err error)
@@ -60,7 +64,7 @@ func (h SlogHandler) HandleContext(ctx context.Context, err error) {
 	h.Logger.ErrorContext(ctx, err.Error())
 }
 
-// NopHandler ignores all errors.
+// NopHandler ignores all errors. Useful for testing.
 type NopHandler struct{}
 
 func NewNopHandler() NopHandler {


### PR DESCRIPTION
- ContextHandler doesn't implement Handler interface
- NewAppHandler is always used with NewSlogHandler so filter logic is merged