### PR TITLE
chore: bump Dagger to v0.14.0

### DIFF
--- a/.github/workflows/ci-exp.yaml
+++ b/.github/workflows/ci-exp.yaml
@@ -9,12 +9,12 @@ permissions:
   contents: read
 
 env:
-  DAGGER_VERSION: 0.13.6
+  DAGGER_VERSION: 0.14.0
 
 jobs:
   e2e:
     name: E2E
-    runs-on: depot-ubuntu-latest-16,dagger=0.13.6
+    runs-on: depot-ubuntu-latest-16,dagger=0.14.0
 
     steps:
       # Required as a workaround for Dagger to properly detect Git metadata
@@ -26,7 +26,7 @@ jobs:
 
   dagger:
     name: CI
-    runs-on: depot-ubuntu-latest-16,dagger=0.13.6
+    runs-on: depot-ubuntu-latest-16,dagger=0.14.0
 
     steps:
       # Required as a workaround for Dagger to properly detect Git metadata

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  DAGGER_VERSION: 0.13.6
+  DAGGER_VERSION: 0.14.0
 
 jobs:
   build:

--- a/dagger.json
+++ b/dagger.json
@@ -1,5 +1,6 @@
 {
   "name": "openmeter",
+  "engineVersion": "v0.14.0",
   "sdk": "go",
   "exclude": [
     ".devenv",
@@ -94,7 +95,6 @@
     }
   ],
   "source": ".dagger",
-  "engineVersion": "v0.13.6",
   "views": [
     {
       "name": "default",

--- a/flake.lock
+++ b/flake.lock
@@ -73,11 +73,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729855591,
-        "narHash": "sha256-0DEWHLr795uFJQddLhrMOAT8bRNjgQLaow6LvS6wQZg=",
+        "lastModified": 1731102567,
+        "narHash": "sha256-A0xTZedeIwMceV86/BB3b6GgS+DVoqQwxywDgH68x7s=",
         "owner": "dagger",
         "repo": "nix",
-        "rev": "64c33026d77a4d3401959418692a27ee189c408b",
+        "rev": "9852fdddcdcb52841275ffb6a39fa1524d538d5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Overview

Bump Dagger to v0.14.0 and its dependencies to latest.
