### PR TITLE
fix(serializer): allow cloudevents without data

### DIFF
--- a/openmeter/ingest/kafkaingest/serializer/json.go
+++ b/openmeter/ingest/kafkaingest/serializer/json.go
@@ -1,7 +1,6 @@
 package serializer
 
 import (
-	_ "embed"
 	"encoding/json"
 
 	"github.com/cloudevents/sdk-go/v2/event"

--- a/openmeter/ingest/kafkaingest/serializer/serializer.go
+++ b/openmeter/ingest/kafkaingest/serializer/serializer.go
@@ -1,7 +1,6 @@
 package serializer
 
 import (
-	_ "embed"
 	"encoding/json"
 	"errors"
 	"fmt"

--- a/openmeter/ingest/kafkaingest/serializer/serializer_test.go
+++ b/openmeter/ingest/kafkaingest/serializer/serializer_test.go
@@ -149,6 +149,28 @@ func TestFromKafkaPayloadToCloudEvents(t *testing.T) {
 			},
 		},
 		{
+			description: "should handle when data is null",
+			payload: CloudEventsKafkaPayload{
+				Id:      "123",
+				Type:    "test",
+				Source:  "test",
+				Subject: "test",
+				Time:    tm.Unix(),
+				Data:    "null",
+			},
+			want: func() event.Event {
+				ev := event.New()
+				ev.SetID("123")
+				ev.SetSource("test")
+				ev.SetType("test")
+				ev.SetSubject("test")
+				ev.SetTime(tm)
+				err := ev.SetData(event.ApplicationJSON, nil)
+				assert.Nil(t, err)
+				return ev
+			},
+		},
+		{
 			description: "should return error when data is invalid",
 			payload: CloudEventsKafkaPayload{
 				Id:      "123",

--- a/openmeter/ingest/kafkaingest/serializer/serializer_test.go
+++ b/openmeter/ingest/kafkaingest/serializer/serializer_test.go
@@ -1,0 +1,184 @@
+package serializer
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToCloudEventsKafkaPayload(t *testing.T) {
+	tm := time.Now()
+
+	tests := []struct {
+		description string
+		event       func() event.Event
+		want        CloudEventsKafkaPayload
+		error       error
+	}{
+		{
+			description: "should serialize cloud event",
+			event: func() event.Event {
+				ev := event.New()
+				ev.SetID("123")
+				ev.SetSource("test")
+				ev.SetType("test")
+				ev.SetSubject("test")
+				ev.SetTime(tm)
+				err := ev.SetData(event.ApplicationJSON, map[string]string{"key": "value"})
+				assert.Nil(t, err)
+				return ev
+			},
+			want: CloudEventsKafkaPayload{
+				Id:      "123",
+				Type:    "test",
+				Source:  "test",
+				Subject: "test",
+				Time:    tm.Unix(),
+				Data:    `{"key":"value"}`,
+			},
+		},
+		{
+			description: "should handle when data is not set",
+			event: func() event.Event {
+				ev := event.New()
+				ev.SetID("123")
+				ev.SetSource("test")
+				ev.SetType("test")
+				ev.SetSubject("test")
+				ev.SetTime(tm)
+				return ev
+			},
+			want: CloudEventsKafkaPayload{
+				Id:      "123",
+				Type:    "test",
+				Source:  "test",
+				Subject: "test",
+				Time:    tm.Unix(),
+				Data:    "",
+			},
+		},
+		{
+			description: "should return error when data is invalid",
+			event: func() event.Event {
+				ev := event.New()
+				ev.SetID("123")
+				ev.SetSource("test")
+				ev.SetType("test")
+				ev.SetSubject("test")
+				ev.SetTime(tm)
+				// We use byte array otherwise SetData validates the data
+				err := ev.SetData(event.ApplicationJSON, []byte("invalid"))
+				assert.Nil(t, err)
+				return ev
+			},
+			want:  CloudEventsKafkaPayload{},
+			error: fmt.Errorf("invalid character 'i' looking for beginning of value"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.description, func(t *testing.T) {
+			payload, err := toCloudEventsKafkaPayload(tt.event())
+
+			if tt.error != nil {
+				assert.Errorf(t, tt.error, err.Error())
+
+				return
+			}
+
+			assert.Nil(t, err)
+			assert.Equal(t, tt.want, payload)
+		})
+	}
+}
+
+func TestFromKafkaPayloadToCloudEvents(t *testing.T) {
+	// Clear location information from time
+	tm := time.Unix(time.Now().Unix(), 0)
+
+	tests := []struct {
+		description string
+		payload     CloudEventsKafkaPayload
+		want        func() event.Event
+		error       error
+	}{
+		{
+			description: "should parse to cloud event",
+			payload: CloudEventsKafkaPayload{
+				Id:      "123",
+				Type:    "test",
+				Source:  "test",
+				Subject: "test",
+				Time:    tm.Unix(),
+				Data:    `{"key":"value"}`,
+			},
+			want: func() event.Event {
+				ev := event.New()
+				ev.SetID("123")
+				ev.SetSource("test")
+				ev.SetType("test")
+				ev.SetSubject("test")
+				ev.SetTime(tm)
+				err := ev.SetData(event.ApplicationJSON, map[string]string{"key": "value"})
+				assert.Nil(t, err)
+				return ev
+			},
+		},
+		{
+			description: "should handle when data is not set",
+			payload: CloudEventsKafkaPayload{
+				Id:      "123",
+				Type:    "test",
+				Source:  "test",
+				Subject: "test",
+				Time:    tm.Unix(),
+				Data:    "",
+			},
+			want: func() event.Event {
+				ev := event.New()
+				ev.SetID("123")
+				ev.SetSource("test")
+				ev.SetType("test")
+				ev.SetSubject("test")
+				ev.SetTime(tm)
+				return ev
+			},
+		},
+		{
+			description: "should return error when data is invalid",
+			payload: CloudEventsKafkaPayload{
+				Id:      "123",
+				Type:    "test",
+				Source:  "test",
+				Subject: "test",
+				Time:    tm.Unix(),
+				Data:    "invalid",
+			},
+			want: func() event.Event {
+				ev := event.New()
+				return ev
+			},
+			error: fmt.Errorf("invalid character 'i' looking for beginning of value"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.description, func(t *testing.T) {
+			ev, err := FromKafkaPayloadToCloudEvents(tt.payload)
+
+			if tt.error != nil {
+				assert.Errorf(t, tt.error, err.Error())
+
+				return
+			}
+
+			assert.Nil(t, err)
+			assert.Equal(t, tt.want(), ev)
+		})
+	}
+}

--- a/openmeter/meter/validate.go
+++ b/openmeter/meter/validate.go
@@ -11,17 +11,17 @@ import (
 
 // ValidateEvent validates an event against a meter.
 func ValidateEvent(meter Meter, ev event.Event) error {
+	// We can skip count events as they don't have value property
+	if meter.Aggregation == MeterAggregationCount {
+		return nil
+	}
+
 	// Parse CloudEvents data
 	var data interface{}
 
 	err := ev.DataAs(&data)
 	if err != nil {
 		return errors.New("cannot unmarshal event data")
-	}
-
-	// We can skip count events as they don't have value property
-	if meter.Aggregation == MeterAggregationCount {
-		return nil
 	}
 
 	// Get value from event data by value property

--- a/openmeter/meter/validate_test.go
+++ b/openmeter/meter/validate_test.go
@@ -32,6 +32,19 @@ func TestValidateEvent(t *testing.T) {
 		want        error
 	}{
 		{
+			description: "should pass with valid event",
+			event: func(t *testing.T) event.Event {
+				ev := event.New()
+				ev.SetType("api-calls")
+
+				err := ev.SetData(event.ApplicationJSON, []byte(`{"duration_ms": 100, "method": "GET", "path": "/api/v1"}`))
+				require.NoError(t, err)
+
+				return ev
+			},
+			want: nil,
+		},
+		{
 			description: "should return error with invalid json",
 			event: func(t *testing.T) event.Event {
 				ev := event.New()
@@ -43,6 +56,16 @@ func TestValidateEvent(t *testing.T) {
 				return ev
 			},
 			want: errors.New("cannot unmarshal event data"),
+		},
+		{
+			description: "should return error with missing data property",
+			event: func(t *testing.T) event.Event {
+				ev := event.New()
+				ev.SetType("api-calls")
+
+				return ev
+			},
+			want: errors.New(`event data is missing value property at "$.duration_ms"`),
 		},
 		{
 			description: "should return error with value property not found",

--- a/openmeter/sink/namespaces.go
+++ b/openmeter/sink/namespaces.go
@@ -78,7 +78,7 @@ func validateEventWithMeter(m models.Meter, sm *sinkmodels.SinkMessage) {
 	if err != nil {
 		sm.Status = sinkmodels.ProcessingStatus{
 			State: sinkmodels.INVALID,
-			Error: errors.New("cannot parse event"),
+			Error: errors.New("cannot unmarshal event data"),
 		}
 
 		return

--- a/openmeter/sink/namespaces.go
+++ b/openmeter/sink/namespaces.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
-
-	"github.com/cloudevents/sdk-go/v2/event"
 
 	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest/serializer"
 	"github.com/openmeterio/openmeter/openmeter/meter"
@@ -75,26 +72,9 @@ func (n *NamespaceStore) ValidateEvent(_ context.Context, m *sinkmodels.SinkMess
 	}
 }
 
-func kafkaPayloadToCloudEvents(payload serializer.CloudEventsKafkaPayload) (event.Event, error) {
-	ev := event.New()
-
-	ev.SetID(payload.Id)
-	ev.SetType(payload.Type)
-	ev.SetSource(payload.Source)
-	ev.SetSubject(payload.Subject)
-	ev.SetTime(time.Unix(payload.Time, 0))
-
-	err := ev.SetData(event.ApplicationJSON, []byte(payload.Data))
-	if err != nil {
-		return event.Event{}, err
-	}
-
-	return ev, nil
-}
-
 // validateEventWithMeter validates a single event against a single meter
 func validateEventWithMeter(m models.Meter, sm *sinkmodels.SinkMessage) {
-	ev, err := kafkaPayloadToCloudEvents(*sm.Serialized)
+	ev, err := serializer.FromKafkaPayloadToCloudEvents(*sm.Serialized)
 	if err != nil {
 		sm.Status = sinkmodels.ProcessingStatus{
 			State: sinkmodels.INVALID,


### PR DESCRIPTION
The Kafka event serializer always expected the data property to be set. This resulted in an incorrect 500 error for users.
This PR makes the data property optional and sets it as an empty string in the Kafka message.

This change need to be backported to the new parser: https://github.com/openmeterio/openmeter/pull/1720/files#diff-4b55946e836c7ec5383592308e9cde246b976ed16da8a83f571c413f46166252R75