### PR TITLE
fix: updating RateCards in PlanPhase

### DIFF
--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1324,14 +1324,14 @@ var (
 				Columns: []*schema.Column{PlanRateCardsColumns[1], PlanRateCardsColumns[8], PlanRateCardsColumns[5]},
 			},
 			{
-				Name:    "planratecard_phase_id_key",
+				Name:    "planratecard_phase_id_key_deleted_at",
 				Unique:  true,
-				Columns: []*schema.Column{PlanRateCardsColumns[16], PlanRateCardsColumns[8]},
+				Columns: []*schema.Column{PlanRateCardsColumns[16], PlanRateCardsColumns[8], PlanRateCardsColumns[5]},
 			},
 			{
-				Name:    "planratecard_phase_id_feature_key",
+				Name:    "planratecard_phase_id_feature_key_deleted_at",
 				Unique:  true,
-				Columns: []*schema.Column{PlanRateCardsColumns[16], PlanRateCardsColumns[10]},
+				Columns: []*schema.Column{PlanRateCardsColumns[16], PlanRateCardsColumns[10], PlanRateCardsColumns[5]},
 			},
 		},
 	}

--- a/openmeter/ent/schema/productcatalog.go
+++ b/openmeter/ent/schema/productcatalog.go
@@ -178,9 +178,9 @@ func (PlanRateCard) Edges() []ent.Edge {
 
 func (PlanRateCard) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("phase_id", "key").
+		index.Fields("phase_id", "key", "deleted_at").
 			Unique(),
-		index.Fields("phase_id", "feature_key").
+		index.Fields("phase_id", "feature_key", "deleted_at").
 			Unique(),
 	}
 }

--- a/openmeter/productcatalog/plan/adapter/plan.go
+++ b/openmeter/productcatalog/plan/adapter/plan.go
@@ -409,19 +409,6 @@ func (a *adapter) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (
 			phases = append(phases, diffResult.Keep...)
 		}
 
-		if len(diffResult.Add) > 0 {
-			for _, createInput := range diffResult.Add {
-				createInput.Namespace = params.Namespace
-
-				phase, err := a.CreatePhase(ctx, createInput)
-				if err != nil {
-					return nil, fmt.Errorf("failed to create PlanPhase: %w", err)
-				}
-
-				phases = append(phases, *phase)
-			}
-		}
-
 		if len(diffResult.Remove) > 0 {
 			for _, deleteInput := range diffResult.Remove {
 				err = a.DeletePhase(ctx, deleteInput)
@@ -439,6 +426,19 @@ func (a *adapter) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (
 				phase, err := a.UpdatePhase(ctx, updateInput)
 				if err != nil {
 					return nil, fmt.Errorf("failed to update PlanPhase: %w", err)
+				}
+
+				phases = append(phases, *phase)
+			}
+		}
+
+		if len(diffResult.Add) > 0 {
+			for _, createInput := range diffResult.Add {
+				createInput.Namespace = params.Namespace
+
+				phase, err := a.CreatePhase(ctx, createInput)
+				if err != nil {
+					return nil, fmt.Errorf("failed to create PlanPhase: %w", err)
 				}
 
 				phases = append(phases, *phase)

--- a/openmeter/productcatalog/plan/assert.go
+++ b/openmeter/productcatalog/plan/assert.go
@@ -195,6 +195,8 @@ func AssertPlanRateCardsEqual(t *testing.T, r1, r2 []RateCard) {
 func AssertRateCardEqual(t *testing.T, r1, r2 RateCard) {
 	t.Helper()
 
+	assert.Equalf(t, r1.Type(), r2.Type(), "type mismatch")
+
 	m1, err := r1.AsMeta()
 	require.NoErrorf(t, err, "AsMeta must not fail")
 

--- a/openmeter/productcatalog/plan/service/phase.go
+++ b/openmeter/productcatalog/plan/service/phase.go
@@ -187,6 +187,12 @@ func (s service) UpdatePhase(ctx context.Context, params plan.UpdatePhaseInput) 
 			}
 		}
 
+		if params.RateCards != nil && len(*params.RateCards) > 0 {
+			if err := s.expandFeatures(ctx, params.Namespace, params.RateCards); err != nil {
+				return nil, fmt.Errorf("failed to expand Features for RateCards in PlanPhase: %w", err)
+			}
+		}
+
 		logger.Debug("updating PlanPhase")
 
 		phase, err := s.adapter.UpdatePhase(ctx, params)

--- a/openmeter/productcatalog/plan/service/phase.go
+++ b/openmeter/productcatalog/plan/service/phase.go
@@ -181,8 +181,12 @@ func (s service) UpdatePhase(ctx context.Context, params plan.UpdatePhaseInput) 
 
 		if params.StartAfter != nil {
 			for _, planPhase := range p.Phases {
+				if planPhase.Key == params.Key {
+					continue
+				}
+
 				if planPhase.StartAfter == *params.StartAfter {
-					return nil, fmt.Errorf("there is already a PlanPhase with the same StartAfter perdiod: %q", planPhase.Key)
+					return nil, fmt.Errorf("there is already a PlanPhase with the same StartAfter period: %q", planPhase.Key)
 				}
 			}
 		}

--- a/tools/migrate/migrations/20241119131528_plan.down.sql
+++ b/tools/migrate/migrations/20241119131528_plan.down.sql
@@ -1,0 +1,8 @@
+-- reverse: create index "planratecard_phase_id_key_deleted_at" to table: "plan_rate_cards"
+DROP INDEX "planratecard_phase_id_key_deleted_at";
+-- reverse: create index "planratecard_phase_id_feature_key_deleted_at" to table: "plan_rate_cards"
+DROP INDEX "planratecard_phase_id_feature_key_deleted_at";
+-- reverse: drop index "planratecard_phase_id_key" from table: "plan_rate_cards"
+CREATE UNIQUE INDEX "planratecard_phase_id_key" ON "plan_rate_cards" ("phase_id", "key");
+-- reverse: drop index "planratecard_phase_id_feature_key" from table: "plan_rate_cards"
+CREATE UNIQUE INDEX "planratecard_phase_id_feature_key" ON "plan_rate_cards" ("phase_id", "feature_key");

--- a/tools/migrate/migrations/20241119131528_plan.up.sql
+++ b/tools/migrate/migrations/20241119131528_plan.up.sql
@@ -1,0 +1,10 @@
+-- drop index "planratecard_phase_id_feature_key" from table: "plan_rate_cards"
+DROP INDEX "planratecard_phase_id_feature_key";
+-- drop index "planratecard_phase_id_key" from table: "plan_rate_cards"
+DROP INDEX "planratecard_phase_id_key";
+-- create index "planratecard_phase_id_feature_key_deleted_at" to table: "plan_rate_cards"
+-- atlas:nolint
+CREATE UNIQUE INDEX "planratecard_phase_id_feature_key_deleted_at" ON "plan_rate_cards" ("phase_id", "feature_key", "deleted_at");
+-- create index "planratecard_phase_id_key_deleted_at" to table: "plan_rate_cards"
+-- atlas:nolint
+CREATE UNIQUE INDEX "planratecard_phase_id_key_deleted_at" ON "plan_rate_cards" ("phase_id", "key", "deleted_at");

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:rSnbedzS0oAHQ4S5ekk/2aBWm4e6QGU5JN1QxsWF+gg=
+h1:qV76RG4d1oyWY7g1nbPxDbDm+a50TPoygl91/RHJXKI=
 20240826120919_init.down.sql h1:AIbgwwngjkJEYa3yRZsIXQyBa2+qoZttwMXHxXEbHLI=
 20240826120919_init.up.sql h1:/hYHWF3Z3dab8SMKnw99ixVktCuJe2bAw5wstCZIEN8=
 20240903155435_entitlement-expired-index.down.sql h1:np2xgYs3KQ2z7qPBcobtGNhqWQ3V8NwEP9E5U3TmpSA=
@@ -45,3 +45,5 @@ h1:rSnbedzS0oAHQ4S5ekk/2aBWm4e6QGU5JN1QxsWF+gg=
 20241108120252_billing-line-splitting.up.sql h1:iRO+DVapgNm6WZTee6e5yd+Jknz2HINvG0dxPh0uJuI=
 20241108160647_billing-reuse-plan-types.down.sql h1:sOwGFHHy7GqSR+wPhyNzK7YQgqAn9O+GZhb9xuFk2Ro=
 20241108160647_billing-reuse-plan-types.up.sql h1:ov2uppx9QjPIky0td+qJzwrjvscuArwtKAA/MyRFsaY=
+20241119131528_plan.down.sql h1:7RrK5c5RPA8zUpx9tuTwcGz9ErK6EUZjeWUm7Gvpfd8=
+20241119131528_plan.up.sql h1:kvYEz4rMQUIw72ErGJhe8V3UBjf9cDq0EwjgkbjbMa4=


### PR DESCRIPTION
## Overview

Fix updating RateCards in PlanPhase by using replace strategy in case in-place update is not possible. Like when the type of the RateCard is changed which is immutable attribute.
