### PR TITLE
fix: validate Plan before Publish

### DIFF
--- a/openmeter/productcatalog/plan/adapter/plan.go
+++ b/openmeter/productcatalog/plan/adapter/plan.go
@@ -416,6 +416,8 @@ func (a *adapter) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (
 
 		if len(diffResult.Remove) > 0 {
 			for _, deleteInput := range diffResult.Remove {
+				deleteInput.Namespace = params.Namespace
+				deleteInput.PlanID = p.ID
 				err = a.DeletePhase(ctx, deleteInput)
 				if err != nil {
 					return nil, fmt.Errorf("failed to delete PlanPhase: %w", err)
@@ -440,6 +442,7 @@ func (a *adapter) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (
 		if len(diffResult.Add) > 0 {
 			for _, createInput := range diffResult.Add {
 				createInput.Namespace = params.Namespace
+				createInput.PlanID = p.ID
 
 				phase, err := a.CreatePhase(ctx, createInput)
 				if err != nil {

--- a/openmeter/productcatalog/plan/plan.go
+++ b/openmeter/productcatalog/plan/plan.go
@@ -64,28 +64,24 @@ func (p Plan) Validate() error {
 	var errs []error
 
 	if err := p.Currency.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("invalid currency code: %s", err))
+		errs = append(errs, fmt.Errorf("invalid Currency: %s", err))
 	}
 
 	if p.Status() == InvalidStatus {
-		errs = append(errs, fmt.Errorf("invalid effective time range: to is before from"))
+		errs = append(errs, fmt.Errorf("invalid Status"))
 	}
 
-	// Check if there are multiple plan phase with the same startAfter which is not allowed.
+	// Check if there are multiple plan phase with the same startAfter which is not allowed
 	startAfters := make(map[datex.ISOString]Phase)
 	for _, phase := range p.Phases {
 		startAfter := phase.StartAfter.ISOString()
 
 		if _, ok := startAfters[startAfter]; ok {
-			errs = append(errs, fmt.Errorf("multiple plan phases have the same startAfter which is not allowed: %q", phase.Name))
-		}
-
-		if phase.Namespace != p.Namespace {
-			errs = append(errs, fmt.Errorf("invalid phase %q: namespace mismatch %s", phase.Key, phase.Namespace))
+			errs = append(errs, fmt.Errorf("multiple PlanPhases have the same startAfter which is not allowed: %q", phase.Name))
 		}
 
 		if err := phase.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("invalid phase %q: %s", phase.Name, err))
+			errs = append(errs, fmt.Errorf("invalid PlanPhase %q: %s", phase.Name, err))
 		}
 	}
 

--- a/openmeter/productcatalog/plan/service.go
+++ b/openmeter/productcatalog/plan/service.go
@@ -215,7 +215,7 @@ func (i UpdatePlanInput) Validate() error {
 	if i.Phases != nil && len(*i.Phases) > 0 {
 		for _, phase := range *i.Phases {
 			if err := phase.Validate(); err != nil {
-				return fmt.Errorf("invalid PlanPhase: %w", err)
+				errs = append(errs, fmt.Errorf("invalid PlanPhase: %w", err))
 			}
 		}
 	}


### PR DESCRIPTION
## Overview

Ensure that only valid Plan can be promoted from `draft` to `active` by publishing.
