### PR TITLE
fix: creating duplicated Plans

### DIFF
--- a/openmeter/productcatalog/plan/service/service_test.go
+++ b/openmeter/productcatalog/plan/service/service_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/openmeterio/openmeter/tools/migrate"
 )
 
-func TestService(t *testing.T) {
+func TestPlanService(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
## Overview

Fix creating duplicated Plans due to insuifficient validation in Plan create operation.
