### PR TITLE
Unique count entitlements

### DIFF
--- a/e2e/config.yaml
+++ b/e2e/config.yaml
@@ -85,7 +85,7 @@ meters:
       model: $.model
   - slug: entitlement_uc_meter
     description: Meter for testing entitlements with unique count
-    eventType: credit_event
+    eventType: credit_event_uc
     valueProperty: $.value
     aggregation: UNIQUE_COUNT
   - slug: plan_meter

--- a/e2e/config.yaml
+++ b/e2e/config.yaml
@@ -83,6 +83,11 @@ meters:
     aggregation: COUNT
     groupBy:
       model: $.model
+  - slug: entitlement_uc_meter
+    description: Meter for testing entitlements with unique count
+    eventType: credit_event
+    valueProperty: $.value
+    aggregation: UNIQUE_COUNT
   - slug: plan_meter
     description: Meter for testing plan metered feature
     eventType: plan_meter

--- a/e2e/entitlement_test.go
+++ b/e2e/entitlement_test.go
@@ -1,0 +1,163 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/brianvoe/gofakeit/v6"
+	cloudevents "github.com/cloudevents/sdk-go/v2/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	api "github.com/openmeterio/openmeter/api/client/go"
+	"github.com/openmeterio/openmeter/pkg/convert"
+)
+
+func TestEntitlementWithUniqueCountAggregation(t *testing.T) {
+	client := initClient(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	meterSlug := "entitlement_uc_meter"
+	subject := "ent_customer"
+	var featureId string
+	var entitlementId string
+
+	t.Run("Create Feature", func(t *testing.T) {
+		randKey := fmt.Sprintf("entitlement_uc_test_feature_%d", time.Now().Unix())
+		resp, err := client.CreateFeatureWithResponse(ctx, api.CreateFeatureJSONRequestBody{
+			Name:      "Entitlement Test Feature",
+			MeterSlug: convert.ToPointer(meterSlug),
+			Key:       randKey,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode(), "Invalid status code [response_body=%s]", string(resp.Body))
+
+		featureId = *resp.JSON201.Id
+	})
+
+	t.Run("Create a Entitlement", func(t *testing.T) {
+		meteredEntitlement := api.EntitlementMeteredCreateInputs{
+			Type:      "metered",
+			FeatureId: &featureId,
+			UsagePeriod: api.RecurringPeriodCreateInput{
+				Anchor:   convert.ToPointer(time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)),
+				Interval: "MONTH",
+			},
+		}
+		body := &api.CreateEntitlementJSONRequestBody{}
+		err := body.FromEntitlementMeteredCreateInputs(meteredEntitlement)
+		require.NoError(t, err)
+		resp, err := client.CreateEntitlementWithResponse(ctx, subject, *body)
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode(), "Invalid status code [response_body=%s]", string(resp.Body))
+
+		metered, err := resp.JSON201.AsEntitlementMetered()
+		require.NoError(t, err)
+
+		require.Equal(t, metered.SubjectKey, subject)
+		entitlementId = *metered.Id
+	})
+
+	grantAmount := 100.0
+	t.Run("Create Grant", func(t *testing.T) {
+		effectiveAt := time.Now().Truncate(time.Minute)
+
+		priority := uint8(1)
+		maxRolloverAmount := 100.0
+		minRolloverAmount := 0.0
+
+		// Create grant
+		resp, err := client.CreateGrantWithResponse(ctx, subject, entitlementId, api.EntitlementGrantCreateInput{
+			Amount:      grantAmount,
+			EffectiveAt: effectiveAt,
+			Expiration: api.ExpirationPeriod{
+				Duration: "MONTH",
+				Count:    1,
+			},
+			Priority:          &priority,
+			MaxRolloverAmount: &maxRolloverAmount,
+			MinRolloverAmount: &minRolloverAmount,
+			Recurrence: &api.RecurringPeriodCreateInput{
+				Anchor:   convert.ToPointer(time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)),
+				Interval: "YEAR",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode(), "Invalid status code [response_body=%s]", resp.Body)
+	})
+
+	uniqueEventCount := 10
+	t.Run("Report usage", func(t *testing.T) {
+		now := time.Now()
+
+		for i := 0; i < uniqueEventCount*2; i++ {
+			timestamp := gofakeit.DateRange(now, now.Add(time.Second*5))
+
+			ev := cloudevents.New()
+			ev.SetID(gofakeit.UUID())
+			ev.SetSource("my-app")
+			ev.SetType("credit_event")
+			ev.SetSubject(subject)
+			ev.SetTime(timestamp)
+			_ = ev.SetData("application/json", map[string]string{
+				// Let's have 50% of the events with the same value
+				"value": fmt.Sprintf("%v", math.Floor(float64(i)/2)),
+			})
+
+			resp, err := client.IngestEventWithResponse(ctx, ev)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusNoContent, resp.StatusCode())
+		}
+
+		// Wait for events to be processed
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			resp, err := client.QueryMeterWithResponse(ctx, meterSlug, nil)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode())
+
+			require.Len(t, resp.JSON200.Data, 1)
+			assert.Equal(t, float64(uniqueEventCount), resp.JSON200.Data[0].Value)
+		}, time.Minute, time.Second)
+	})
+
+	t.Run("Should calculate usage correctly", func(t *testing.T) {
+		resp, err := client.GetEntitlementValueWithResponse(ctx, subject, entitlementId, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode())
+
+		require.NotNil(t, resp.JSON200.Balance)
+
+		assert.Equal(t, grantAmount-float64(uniqueEventCount), *resp.JSON200.Balance)
+		assert.Equal(t, float64(uniqueEventCount), *resp.JSON200.Usage)
+	})
+
+	t.Run("Should not count usage of previous period twice", func(t *testing.T) {
+		// we have to wait for a minute to pass so we can reset
+		time.Sleep(time.Minute)
+		effectiveAt := time.Now().Truncate(time.Minute)
+
+		// Reset usage
+		_, err := client.ResetEntitlementUsageWithResponse(ctx, subject, entitlementId, api.ResetEntitlementUsageJSONRequestBody{
+			EffectiveAt: &effectiveAt,
+		})
+		require.NoError(t, err)
+
+		resp, err := client.GetEntitlementValueWithResponse(ctx, subject, entitlementId, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode())
+
+		require.NotNil(t, resp.JSON200.Balance)
+
+		// Grant can roll over with full amount
+		assert.Equal(t, grantAmount-float64(uniqueEventCount), *resp.JSON200.Balance)
+		assert.Equal(t, float64(0), *resp.JSON200.Usage)
+	})
+}

--- a/e2e/entitlement_test.go
+++ b/e2e/entitlement_test.go
@@ -104,7 +104,7 @@ func TestEntitlementWithUniqueCountAggregation(t *testing.T) {
 			ev := cloudevents.New()
 			ev.SetID(gofakeit.UUID())
 			ev.SetSource("my-app")
-			ev.SetType("credit_event")
+			ev.SetType("credit_event_uc")
 			ev.SetSubject(subject)
 			ev.SetTime(timestamp)
 			_ = ev.SetData("application/json", map[string]string{

--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"sort"
 	"time"
-
-	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/credit/balance"
 	"github.com/openmeterio/openmeter/openmeter/credit/engine"
@@ -71,17 +68,10 @@ func (m *connector) GetBalanceOfOwner(ctx context.Context, owner grant.Namespace
 	// This is only possible in case the grant becomes active exactly at the start of the current period
 	m.populateBalanceSnapshotWithMissingGrantsActiveAt(&bal, grants, bal.At)
 
-	ownerSubjectKey, err := m.ownerConnector.GetOwnerSubjectKey(ctx, owner)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get owner subject key for owner %s: %w", owner.ID, err)
-	}
-
-	// run engine and calculate grantbalance
-	engineParams, err := m.getQueryUsageFn(ctx, owner, ownerSubjectKey)
+	eng, err := m.buildEngineForOwner(ctx, owner)
 	if err != nil {
 		return nil, err
 	}
-	eng := engine.NewEngine(engineParams.QueryUsageFn, engineParams.Grantuality)
 
 	result, overage, segments, err := eng.Run(
 		ctx,
@@ -154,11 +144,6 @@ func (m *connector) GetBalanceHistoryOfOwner(ctx context.Context, owner grant.Na
 	periods := SortedPeriodsFromDedupedTimes(times)
 	historySegments := make([]engine.GrantBurnDownHistorySegment, 0, len(periods))
 
-	ownerSubjecKey, err := m.ownerConnector.GetOwnerSubjectKey(ctx, owner)
-	if err != nil {
-		return engine.GrantBurnDownHistory{}, fmt.Errorf("failed to get owner subject key for owner %s: %w", owner.ID, err)
-	}
-
 	// collect al history segments through all periods
 	for _, period := range periods {
 		// get last valid grantbalances at start of period (eq balance at start of period)
@@ -184,12 +169,11 @@ func (m *connector) GetBalanceHistoryOfOwner(ctx context.Context, owner grant.Na
 		if err != nil {
 			return engine.GrantBurnDownHistory{}, err
 		}
-		// run engine and calculate grantbalance
-		engineParams, err := m.getQueryUsageFn(ctx, owner, ownerSubjecKey)
+
+		eng, err := m.buildEngineForOwner(ctx, owner)
 		if err != nil {
 			return engine.GrantBurnDownHistory{}, err
 		}
-		eng := engine.NewEngine(engineParams.QueryUsageFn, engineParams.Grantuality)
 
 		_, _, segments, err := eng.Run(
 			ctx,
@@ -262,11 +246,10 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, owner grant.Namespac
 	}
 	m.populateBalanceSnapshotWithMissingGrantsActiveAt(&bal, grants, bal.At)
 
-	engineParams, err := m.getQueryUsageFn(ctx, owner, ownerMeter.SubjectKey)
+	eng, err := m.buildEngineForOwner(ctx, owner)
 	if err != nil {
 		return nil, err
 	}
-	eng := engine.NewEngine(engineParams.QueryUsageFn, engineParams.Grantuality)
 
 	endingBalance, endingOverage, _, err := eng.Run(
 		ctx,
@@ -360,159 +343,4 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, owner grant.Namespac
 	}
 
 	return &startingSnapshot, nil
-}
-
-// Fetches the last valid snapshot for an owner.
-//
-// If no snapshot exists returns a default snapshot for measurement start to recalculate the entire history
-// in case no usable snapshot was found.
-func (m *connector) getLastValidBalanceSnapshotForOwnerAt(ctx context.Context, owner grant.NamespacedOwner, at time.Time) (balance.Snapshot, error) {
-	bal, err := m.balanceSnapshotRepo.GetLatestValidAt(ctx, owner, at)
-	if err != nil {
-		if _, ok := err.(*balance.NoSavedBalanceForOwnerError); ok {
-			// if no snapshot is found we have to calculate from start of time on all grants and usage
-			m.logger.Debug(fmt.Sprintf("no saved balance found for owner %s before %s, calculating from start of time", owner.ID, at))
-
-			startOfMeasurement, err := m.ownerConnector.GetStartOfMeasurement(ctx, owner)
-			if err != nil {
-				return bal, err
-			}
-
-			grants, err := m.grantRepo.ListActiveGrantsBetween(ctx, owner, startOfMeasurement, at)
-			if err != nil {
-				return bal, err
-			}
-
-			balances := balance.Map{}
-			for _, grant := range grants {
-				if grant.ActiveAt(startOfMeasurement) {
-					// Grants that are active at the start will have full balance
-					balances.Set(grant.ID, grant.Amount)
-				} else {
-					// Grants that are not active at the start won't have a balance
-					balances.Set(grant.ID, 0.0)
-				}
-			}
-
-			bal = balance.Snapshot{
-				At:       startOfMeasurement,
-				Balances: balances,
-				Overage:  0.0, // There cannot be overage at the start of measurement
-			}
-		} else {
-			return bal, fmt.Errorf("failed to get latest valid grant balance at %s for owner %s: %w", at, owner.ID, err)
-		}
-	}
-
-	return bal, nil
-}
-
-type engineParams struct {
-	QueryUsageFn engine.QueryUsageFn
-	Grantuality  models.WindowSize
-}
-
-// returns owner specific QueryUsageFn
-func (m *connector) getQueryUsageFn(ctx context.Context, owner grant.NamespacedOwner, subjectKey string) (*engineParams, error) {
-	ownerMeter, err := m.ownerConnector.GetMeter(ctx, owner)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get query params for owner %v: %w", owner, err)
-	}
-	return &engineParams{
-		QueryUsageFn: func(ctx context.Context, from, to time.Time) (float64, error) {
-			// copy
-			params := ownerMeter.DefaultParams
-			params.From = &from
-			params.To = &to
-			params.FilterSubject = []string{subjectKey}
-			rows, err := m.streamingConnector.QueryMeter(ctx, owner.Namespace, ownerMeter.Meter, params)
-			if err != nil {
-				return 0.0, fmt.Errorf("failed to query meter %s: %w", ownerMeter.Meter.Slug, err)
-			}
-			if len(rows) > 1 {
-				return 0.0, fmt.Errorf("expected 1 row, got %d", len(rows))
-			}
-			if len(rows) == 0 {
-				return 0.0, nil
-			}
-			return rows[0].Value, nil
-		},
-		Grantuality: ownerMeter.Meter.WindowSize,
-	}, nil
-}
-
-// Returns a snapshot from the last segment that can be saved, taking the following into account:
-//
-//  1. We can save a segment if it is older than graceperiod.
-//  2. At the end of a segment history changes: s1.endBalance <> s2.startBalance. This means only the
-//     starting values can be saved credibly.
-func (m *connector) getLastSaveableSnapshotAt(history *engine.GrantBurnDownHistory, lastValidBalance balance.Snapshot, at time.Time) (*balance.Snapshot, error) {
-	segments := history.Segments()
-
-	for i := len(segments) - 1; i >= 0; i-- {
-		segment := segments[i]
-		if segment.From.Add(m.snapshotGracePeriod).Before(at) {
-			s := segment.ToSnapshot()
-			if s.At.After(lastValidBalance.At) {
-				return &s, nil
-			} else {
-				return nil, fmt.Errorf("the last saveable snapshot at %s is before the previous last valid snapshot", s.At)
-			}
-		}
-	}
-
-	return nil, fmt.Errorf("no segment can be saved at %s with gracePeriod %s", at, m.snapshotGracePeriod)
-}
-
-func (m *connector) excludeInactiveGrantsFromBalance(balances balance.Map, grants map[string]grant.Grant, at time.Time) (*balance.Map, error) {
-	filtered := &balance.Map{}
-	for grantID, grantBalance := range balances {
-		grant, ok := grants[grantID]
-		// inconsistency check, shouldn't happen
-		if !ok {
-			return nil, fmt.Errorf("attempting to roll over unknown grant %s", grantID)
-		}
-
-		// grants might become inactive at the reset time, in which case they're irrelevant for the next period
-		if !grant.ActiveAt(at) {
-			continue
-		}
-
-		filtered.Set(grantID, grantBalance)
-	}
-	return filtered, nil
-}
-
-// Fills in the snapshot's GrantBalanceMap with the provided grants so the Engine can use them.
-func (m *connector) populateBalanceSnapshotWithMissingGrantsActiveAt(snapshot *balance.Snapshot, grants []grant.Grant, at time.Time) {
-	for _, grant := range grants {
-		if _, ok := snapshot.Balances[grant.ID]; !ok {
-			if grant.ActiveAt(at) {
-				snapshot.Balances.Set(grant.ID, grant.Amount)
-			} else {
-				snapshot.Balances.Set(grant.ID, 0.0)
-			}
-		}
-	}
-}
-
-// Returns a list of non-overlapping periods between the sorted times.
-func SortedPeriodsFromDedupedTimes(ts []time.Time) []recurrence.Period {
-	if len(ts) < 2 {
-		return nil
-	}
-
-	times := lo.Uniq(ts)
-
-	// sort
-	sort.Slice(times, func(i, j int) bool {
-		return times[i].Before(times[j])
-	})
-
-	periods := make([]recurrence.Period, 0, len(times)-1)
-	for i := 1; i < len(times); i++ {
-		periods = append(periods, recurrence.Period{From: times[i-1], To: times[i]})
-	}
-
-	return periods
 }

--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -68,7 +68,13 @@ func (m *connector) GetBalanceOfOwner(ctx context.Context, owner grant.Namespace
 	// This is only possible in case the grant becomes active exactly at the start of the current period
 	m.populateBalanceSnapshotWithMissingGrantsActiveAt(&bal, grants, bal.At)
 
-	eng, err := m.buildEngineForOwner(ctx, owner)
+	// Let's define the period the engine will be queried for
+	queriedPeriod := recurrence.Period{
+		From: bal.At,
+		To:   at,
+	}
+
+	eng, err := m.buildEngineForOwner(ctx, owner, queriedPeriod)
 	if err != nil {
 		return nil, err
 	}
@@ -78,10 +84,7 @@ func (m *connector) GetBalanceOfOwner(ctx context.Context, owner grant.Namespace
 		grants,
 		bal.Balances,
 		bal.Overage,
-		recurrence.Period{
-			From: bal.At,
-			To:   at,
-		},
+		queriedPeriod,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate balance for owner %s at %s: %w", owner.ID, at, err)
@@ -170,7 +173,7 @@ func (m *connector) GetBalanceHistoryOfOwner(ctx context.Context, owner grant.Na
 			return engine.GrantBurnDownHistory{}, err
 		}
 
-		eng, err := m.buildEngineForOwner(ctx, owner)
+		eng, err := m.buildEngineForOwner(ctx, owner, period)
 		if err != nil {
 			return engine.GrantBurnDownHistory{}, err
 		}
@@ -246,7 +249,13 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, owner grant.Namespac
 	}
 	m.populateBalanceSnapshotWithMissingGrantsActiveAt(&bal, grants, bal.At)
 
-	eng, err := m.buildEngineForOwner(ctx, owner)
+	// Let's define the period the engine will be queried for
+	queriedPeriod := recurrence.Period{
+		From: bal.At,
+		To:   at,
+	}
+
+	eng, err := m.buildEngineForOwner(ctx, owner, queriedPeriod)
 	if err != nil {
 		return nil, err
 	}
@@ -256,10 +265,7 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, owner grant.Namespac
 		grants,
 		bal.Balances,
 		bal.Overage,
-		recurrence.Period{
-			From: bal.At,
-			To:   at,
-		},
+		queriedPeriod,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate balance for reset: %w", err)

--- a/openmeter/credit/engine/engine_test.go
+++ b/openmeter/credit/engine/engine_test.go
@@ -814,7 +814,10 @@ func TestEngine(t *testing.T) {
 				}
 				return rows[0].Value, nil
 			}
-			tc.run(t, engine.NewEngine(queryFeatureUsage, models.WindowSizeMinute), func(usage float64, at time.Time) {
+			tc.run(t, engine.NewEngine(engine.EngineConfig{
+				QueryUsage:  queryFeatureUsage,
+				Granularity: models.WindowSizeMinute,
+			}), func(usage float64, at time.Time) {
 				streamingConnector.AddSimpleEvent(meterSlug, usage, at)
 			})
 		})
@@ -853,9 +856,18 @@ func TestEngine(t *testing.T) {
 					g2.ID: 82.0,
 				}
 
-				engine1 := engine.NewEngine(queryFn, models.WindowSizeMinute) // runs for first part
-				engine2 := engine.NewEngine(queryFn, models.WindowSizeMinute) // runs for second part
-				engine3 := engine.NewEngine(queryFn, models.WindowSizeMinute) // runs for both parts
+				engine1 := engine.NewEngine(engine.EngineConfig{
+					QueryUsage:  queryFn,
+					Granularity: models.WindowSizeMinute,
+				}) // runs for first part
+				engine2 := engine.NewEngine(engine.EngineConfig{
+					QueryUsage:  queryFn,
+					Granularity: models.WindowSizeMinute,
+				}) // runs for second part
+				engine3 := engine.NewEngine(engine.EngineConfig{
+					QueryUsage:  queryFn,
+					Granularity: models.WindowSizeMinute,
+				}) // runs for both parts
 
 				intermediateBalance, overage, _, err := engine1.Run(
 					context.Background(),
@@ -950,7 +962,10 @@ func TestEngine(t *testing.T) {
 				balances := startingBalances.Copy()
 				results := make([]balance.Map, numOfRuns)
 				for i := 0; i < numOfRuns; i++ {
-					engine := engine.NewEngine(queryFn, models.WindowSizeMinute)
+					engine := engine.NewEngine(engine.EngineConfig{
+						QueryUsage:  queryFn,
+						Granularity: models.WindowSizeMinute,
+					})
 					gCp := make([]grant.Grant, len(grants))
 					copy(gCp, grants)
 					result, _, _, err := engine.Run(
@@ -1030,7 +1045,10 @@ func TestEngine(t *testing.T) {
 				}
 
 				// run calculation on single engine
-				singleEngine := engine.NewEngine(queryFn, models.WindowSizeMinute)
+				singleEngine := engine.NewEngine(engine.EngineConfig{
+					QueryUsage:  queryFn,
+					Granularity: models.WindowSizeMinute,
+				})
 				gCp := make([]grant.Grant, len(grants))
 				copy(gCp, grants)
 				singleEngineResult, _, _, err := singleEngine.Run(
@@ -1066,7 +1084,10 @@ func TestEngine(t *testing.T) {
 					// 	To:   pEnd,
 					// })
 
-					engine := engine.NewEngine(queryFn, models.WindowSizeMinute)
+					engine := engine.NewEngine(engine.EngineConfig{
+						QueryUsage:  queryFn,
+						Granularity: models.WindowSizeMinute,
+					})
 					gCp := make([]grant.Grant, len(grants))
 					copy(gCp, grants)
 					balances, overage, _, err = engine.Run(

--- a/openmeter/credit/helper.go
+++ b/openmeter/credit/helper.go
@@ -1,0 +1,173 @@
+package credit
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/credit/balance"
+	"github.com/openmeterio/openmeter/openmeter/credit/engine"
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
+)
+
+// Fetches the last valid snapshot for an owner.
+//
+// If no snapshot exists returns a default snapshot for measurement start to recalculate the entire history
+// in case no usable snapshot was found.
+func (m *connector) getLastValidBalanceSnapshotForOwnerAt(ctx context.Context, owner grant.NamespacedOwner, at time.Time) (balance.Snapshot, error) {
+	bal, err := m.balanceSnapshotRepo.GetLatestValidAt(ctx, owner, at)
+	if err != nil {
+		if _, ok := err.(*balance.NoSavedBalanceForOwnerError); ok {
+			// if no snapshot is found we have to calculate from start of time on all grants and usage
+			m.logger.Debug(fmt.Sprintf("no saved balance found for owner %s before %s, calculating from start of time", owner.ID, at))
+
+			startOfMeasurement, err := m.ownerConnector.GetStartOfMeasurement(ctx, owner)
+			if err != nil {
+				return bal, err
+			}
+
+			grants, err := m.grantRepo.ListActiveGrantsBetween(ctx, owner, startOfMeasurement, at)
+			if err != nil {
+				return bal, err
+			}
+
+			balances := balance.Map{}
+			for _, grant := range grants {
+				if grant.ActiveAt(startOfMeasurement) {
+					// Grants that are active at the start will have full balance
+					balances.Set(grant.ID, grant.Amount)
+				} else {
+					// Grants that are not active at the start won't have a balance
+					balances.Set(grant.ID, 0.0)
+				}
+			}
+
+			bal = balance.Snapshot{
+				At:       startOfMeasurement,
+				Balances: balances,
+				Overage:  0.0, // There cannot be overage at the start of measurement
+			}
+		} else {
+			return bal, fmt.Errorf("failed to get latest valid grant balance at %s for owner %s: %w", at, owner.ID, err)
+		}
+	}
+
+	return bal, nil
+}
+
+func (m *connector) buildEngineForOwner(ctx context.Context, owner grant.NamespacedOwner) (engine.Engine, error) {
+	ownerMeter, err := m.ownerConnector.GetMeter(ctx, owner)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get query params for owner %v: %w", owner, err)
+	}
+
+	subjectKey, err := m.ownerConnector.GetOwnerSubjectKey(ctx, owner)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get owner subject key for owner %s: %w", owner.ID, err)
+	}
+
+	eng := engine.NewEngine(engine.EngineConfig{
+		Granularity: ownerMeter.Meter.WindowSize,
+		QueryUsage: func(ctx context.Context, from, to time.Time) (float64, error) {
+			params := ownerMeter.DefaultParams
+			params.From = &from
+			params.To = &to
+			params.FilterSubject = []string{subjectKey}
+
+			// Let's query the meter
+			rows, err := m.streamingConnector.QueryMeter(ctx, owner.Namespace, ownerMeter.Meter, params)
+			// ...and validate the response
+			if err != nil {
+				return 0.0, fmt.Errorf("failed to query meter %s: %w", ownerMeter.Meter.Slug, err)
+			}
+			if len(rows) > 1 {
+				return 0.0, fmt.Errorf("expected 1 row, got %d", len(rows))
+			}
+			if len(rows) == 0 {
+				return 0.0, nil
+			}
+			return rows[0].Value, nil
+		},
+	})
+	return eng, nil
+}
+
+// Returns a snapshot from the last segment that can be saved, taking the following into account:
+//
+//  1. We can save a segment if it is older than graceperiod.
+//  2. At the end of a segment history changes: s1.endBalance <> s2.startBalance. This means only the
+//     starting values can be saved credibly.
+func (m *connector) getLastSaveableSnapshotAt(history *engine.GrantBurnDownHistory, lastValidBalance balance.Snapshot, at time.Time) (*balance.Snapshot, error) {
+	segments := history.Segments()
+
+	for i := len(segments) - 1; i >= 0; i-- {
+		segment := segments[i]
+		if segment.From.Add(m.snapshotGracePeriod).Before(at) {
+			s := segment.ToSnapshot()
+			if s.At.After(lastValidBalance.At) {
+				return &s, nil
+			} else {
+				return nil, fmt.Errorf("the last saveable snapshot at %s is before the previous last valid snapshot", s.At)
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no segment can be saved at %s with gracePeriod %s", at, m.snapshotGracePeriod)
+}
+
+func (m *connector) excludeInactiveGrantsFromBalance(balances balance.Map, grants map[string]grant.Grant, at time.Time) (*balance.Map, error) {
+	filtered := &balance.Map{}
+	for grantID, grantBalance := range balances {
+		grant, ok := grants[grantID]
+		// inconsistency check, shouldn't happen
+		if !ok {
+			return nil, fmt.Errorf("attempting to roll over unknown grant %s", grantID)
+		}
+
+		// grants might become inactive at the reset time, in which case they're irrelevant for the next period
+		if !grant.ActiveAt(at) {
+			continue
+		}
+
+		filtered.Set(grantID, grantBalance)
+	}
+	return filtered, nil
+}
+
+// Fills in the snapshot's GrantBalanceMap with the provided grants so the Engine can use them.
+func (m *connector) populateBalanceSnapshotWithMissingGrantsActiveAt(snapshot *balance.Snapshot, grants []grant.Grant, at time.Time) {
+	for _, grant := range grants {
+		if _, ok := snapshot.Balances[grant.ID]; !ok {
+			if grant.ActiveAt(at) {
+				snapshot.Balances.Set(grant.ID, grant.Amount)
+			} else {
+				snapshot.Balances.Set(grant.ID, 0.0)
+			}
+		}
+	}
+}
+
+// Returns a list of non-overlapping periods between the sorted times.
+func SortedPeriodsFromDedupedTimes(ts []time.Time) []recurrence.Period {
+	if len(ts) < 2 {
+		return nil
+	}
+
+	times := lo.Uniq(ts)
+
+	// sort
+	sort.Slice(times, func(i, j int) bool {
+		return times[i].Before(times[j])
+	})
+
+	periods := make([]recurrence.Period, 0, len(times)-1)
+	for i := 1; i < len(times); i++ {
+		periods = append(periods, recurrence.Period{From: times[i-1], To: times[i]})
+	}
+
+	return periods
+}

--- a/openmeter/entitlement/metered/balance_test.go
+++ b/openmeter/entitlement/metered/balance_test.go
@@ -636,7 +636,7 @@ func TestGetEntitlementHistory(t *testing.T) {
 
 				// check returned burndownhistory
 				segments := burndownHistory.Segments()
-				assert.Len(t, segments, 2)
+				assert.Len(t, segments, 1)
 			},
 		},
 	}

--- a/openmeter/entitlement/metered/utils_test.go
+++ b/openmeter/entitlement/metered/utils_test.go
@@ -59,7 +59,7 @@ func setupConnector(t *testing.T) (meteredentitlement.Connector, *dependencies) 
 	meterRepo := meter.NewInMemoryRepository([]models.Meter{{
 		Slug:        "meter1",
 		Namespace:   "ns1",
-		Aggregation: models.MeterAggregationMax,
+		Aggregation: models.MeterAggregationSum,
 		WindowSize:  models.WindowSizeMinute,
 	}})
 

--- a/openmeter/productcatalog/feature/connector.go
+++ b/openmeter/productcatalog/feature/connector.go
@@ -90,6 +90,7 @@ func NewFeatureConnector(
 		validMeterAggregations: []models.MeterAggregation{
 			models.MeterAggregationSum,
 			models.MeterAggregationCount,
+			models.MeterAggregationUniqueCount,
 		},
 	}
 }

--- a/pkg/recurrence/period.go
+++ b/pkg/recurrence/period.go
@@ -15,5 +15,9 @@ func (p Period) Duration() time.Duration {
 
 // Inclusive at both start and end
 func (p Period) Contains(t time.Time) bool {
-	return (t.After(p.From) || t.Equal(p.From)) && (t.Before(p.To) || t.Equal(p.To))
+	if t.Equal(p.From) || t.Equal(p.To) {
+		return true
+	}
+
+	return t.After(p.From) && t.Before(p.To)
 }

--- a/pkg/recurrence/period_test.go
+++ b/pkg/recurrence/period_test.go
@@ -1,0 +1,41 @@
+package recurrence_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/recurrence"
+)
+
+func TestPeriod(t *testing.T) {
+	startTime := testutils.GetRFC3339Time(t, "2021-01-01T01:00:00Z")
+	endTime := testutils.GetRFC3339Time(t, "2021-01-01T02:00:00Z")
+
+	period := recurrence.Period{
+		From: startTime,
+		To:   endTime,
+	}
+
+	t.Run("Should be inclusive of start time", func(t *testing.T) {
+		assert.True(t, period.Contains(startTime))
+	})
+
+	t.Run("Should be inclusive of end time", func(t *testing.T) {
+		assert.True(t, period.Contains(endTime))
+	})
+
+	t.Run("Should be true for value in between", func(t *testing.T) {
+		assert.True(t, period.Contains(startTime.Add(time.Second)))
+	})
+
+	t.Run("Should be false for earlier time", func(t *testing.T) {
+		assert.False(t, period.Contains(startTime.Add(-time.Second)))
+	})
+
+	t.Run("Should be false for later time", func(t *testing.T) {
+		assert.False(t, period.Contains(endTime.Add(time.Second)))
+	})
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Implements balance calculation for meters with UNIQUE_COUNT aggregation.

Misc:
- Clean up `credit.engine` building logic
- Fix a bug that was codified in the tests 😮 (not user impacting)

## Notes for reviewer

We should really invest some time in setting up ClickHouse testing for non-e2e tests (maybe we could do use in-process instances, I'm not sure, but having to rely on E2E tests to cover anything ClickHouse specific is not great)