### PR TITLE
fix(svix): enable if url or secret provided

### DIFF
--- a/openmeter/notification/webhook/svix.go
+++ b/openmeter/notification/webhook/svix.go
@@ -40,19 +40,21 @@ type SvixConfig struct {
 func (c SvixConfig) Validate() error {
 	var errs []error
 
-	if c.ServerURL == "" {
-		return nil
-	}
-
 	if c.APIKey == "" {
 		errs = append(errs, errors.New("API key is required"))
 	}
 
-	if _, err := url.Parse(c.ServerURL); err != nil {
-		errs = append(errs, fmt.Errorf("invalid server URL: %w", err))
+	if c.ServerURL != "" {
+		if _, err := url.Parse(c.ServerURL); err != nil {
+			errs = append(errs, fmt.Errorf("invalid server URL: %w", err))
+		}
 	}
 
 	return errors.Join(errs...)
+}
+
+func (c SvixConfig) IsEnabled() bool {
+	return c.ServerURL != "" || c.APIKey != ""
 }
 
 var _ Handler = (*svixWebhookHandler)(nil)

--- a/openmeter/notification/webhook/webhook.go
+++ b/openmeter/notification/webhook/webhook.go
@@ -297,16 +297,18 @@ func New(config Config) (Handler, error) {
 		err     error
 	)
 
-	// If the Svix server URL is not provided, we use the noop webhook handler
-	if config.SvixConfig.ServerURL == "" {
-		config.Logger.InfoContext(context.Background(), "svix url not provided: using the noop webhook handler")
+	fmt.Println("config.SvixConfig.ServerURL")
 
-		handler = newNoopWebhookHandler(config.Logger)
-	} else {
+	// If Svix is not enabled, we use the noop webhook handler
+	if config.IsEnabled() {
 		handler, err = newSvixWebhookHandler(config.SvixConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize Svix webhook handler: %w", err)
 		}
+	} else {
+		config.Logger.InfoContext(context.Background(), "svix is disabled: using noop webhook handler")
+
+		handler = newNoopWebhookHandler(config.Logger)
 	}
 
 	if len(config.RegisterEventTypes) > 0 {


### PR DESCRIPTION
Enable Svix for webhooks if either URL or API Key provided.