### PR TITLE
Add checks for Subscription dependencies so they cannot be updated inconsistently

### DIFF
--- a/openmeter/customer/adapter/customer.go
+++ b/openmeter/customer/adapter/customer.go
@@ -454,6 +454,13 @@ func (a *adapter) UpdateCustomer(ctx context.Context, input customerentity.Updat
 				return nil, fmt.Errorf("failed to fetch customer subscription: %w", err)
 			}
 
+			// Let's error if the UsageAttributions were to change with a Subscription present
+			if subsEnt != nil && (len(subjectsKeysToAdd) > 0 || len(subjectKeysToRemove) > 0) {
+				return nil, customerentity.ForbiddenError{
+					Err: fmt.Errorf("cannot update customer UsageAttribution with active subscription"),
+				}
+			}
+
 			// Final subject keys
 			entity.Edges.Subjects = []*entdb.CustomerSubjects{}
 

--- a/openmeter/customer/entity/errors.go
+++ b/openmeter/customer/entity/errors.go
@@ -67,6 +67,16 @@ func (e CustomerAppError) Error() string {
 	return fmt.Sprintf("app %s type with id %s in namespace %s: %s", e.AppType, e.AppID.ID, e.AppID.Namespace, e.Err.Error())
 }
 
+type ForbiddenError genericError
+
+func (e ForbiddenError) Error() string {
+	return e.Err.Error()
+}
+
+func (e ForbiddenError) Unwrap() error {
+	return e.Err
+}
+
 // genericError represents a generic error
 type genericError struct {
 	Err error

--- a/openmeter/customer/httpdriver/errors.go
+++ b/openmeter/customer/httpdriver/errors.go
@@ -17,6 +17,7 @@ func errorEncoder() httptransport.ErrorEncoder {
 			commonhttp.HandleErrorIfTypeMatches[customerentity.ValidationError](ctx, http.StatusBadRequest, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[customerentity.UpdateAfterDeleteError](ctx, http.StatusConflict, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[customerentity.SubjectKeyConflictError](ctx, http.StatusConflict, err, w) ||
+			commonhttp.HandleErrorIfTypeMatches[customerentity.ForbiddenError](ctx, http.StatusBadRequest, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*models.GenericUserError](ctx, http.StatusBadRequest, err, w) ||
 
 			// TODO: we have to add app errors as it can happen when cutomer app data is created or updated

--- a/openmeter/productcatalog/driver/errors.go
+++ b/openmeter/productcatalog/driver/errors.go
@@ -15,6 +15,7 @@ func getErrorEncoder() httptransport.ErrorEncoder {
 	return func(ctx context.Context, err error, w http.ResponseWriter, r *http.Request) bool {
 		return commonhttp.HandleErrorIfTypeMatches[*feature.FeatureNotFoundError](ctx, http.StatusNotFound, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*feature.FeatureInvalidFiltersError](ctx, http.StatusBadRequest, err, w) ||
+			commonhttp.HandleErrorIfTypeMatches[*feature.ForbiddenError](ctx, http.StatusBadRequest, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*pagination.InvalidError](ctx, http.StatusBadRequest, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*feature.FeatureInvalidMeterAggregationError](ctx, http.StatusBadRequest, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*models.MeterNotFoundError](ctx, http.StatusNotFound, err, w) ||

--- a/openmeter/productcatalog/feature/feature.go
+++ b/openmeter/productcatalog/feature/feature.go
@@ -52,6 +52,15 @@ func (e *FeatureInvalidMeterAggregationError) Error() string {
 	return fmt.Sprintf("meter %s's aggregation is %s but features can only be created for %s", e.MeterSlug, e.Aggregation, validAggregations)
 }
 
+type ForbiddenError struct {
+	Msg string
+	ID  string
+}
+
+func (e *ForbiddenError) Error() string {
+	return fmt.Sprintf("forbidden for feature %s: %s", e.ID, e.Msg)
+}
+
 // MeterGroupByFilters is a map of filters that can be applied to a meter when querying the usage for a feature.
 type MeterGroupByFilters map[string]string
 

--- a/openmeter/productcatalog/subscription/service/change_test.go
+++ b/openmeter/productcatalog/subscription/service/change_test.go
@@ -33,7 +33,7 @@ func TestChange(t *testing.T) {
 	withDeps := func(t *testing.T, f func(t *testing.T, deps tDeps)) {
 		t.Helper()
 		dbDeps := subscriptiontestutils.SetupDBDeps(t)
-		defer dbDeps.Cleanup()
+		defer dbDeps.Cleanup(t)
 
 		svc, exposedDeps := subscriptiontestutils.NewService(t, dbDeps)
 

--- a/openmeter/productcatalog/subscription/service/migrate_test.go
+++ b/openmeter/productcatalog/subscription/service/migrate_test.go
@@ -33,7 +33,7 @@ func TestMigrate(t *testing.T) {
 	withDeps := func(t *testing.T, f func(t *testing.T, deps tDeps)) {
 		t.Helper()
 		dbDeps := subscriptiontestutils.SetupDBDeps(t)
-		defer dbDeps.Cleanup()
+		defer dbDeps.Cleanup(t)
 
 		svc, exposedDeps := subscriptiontestutils.NewService(t, dbDeps)
 

--- a/openmeter/subscription/repo/subscriptionrepo.go
+++ b/openmeter/subscription/repo/subscriptionrepo.go
@@ -55,9 +55,9 @@ func (r *subscriptionRepo) GetAllForCustomerSince(ctx context.Context, customerI
 				dbsubscription.CustomerID(customerID.ID),
 				dbsubscription.Namespace(customerID.Namespace),
 			).Where(
-				subscriptionActiveAfter(at)...,
+				SubscriptionActiveAfter(at)...,
 			).Where(
-				subscriptionNotDeletedAt(at)...,
+				SubscriptionNotDeletedAt(at)...,
 			).All(ctx)
 			if err != nil {
 				return nil, err

--- a/openmeter/subscription/repo/utils.go
+++ b/openmeter/subscription/repo/utils.go
@@ -7,7 +7,7 @@ import (
 	db_subscription "github.com/openmeterio/openmeter/openmeter/ent/db/subscription"
 )
 
-func subscriptionActiveAfter(at time.Time) []predicate.Subscription {
+func SubscriptionActiveAfter(at time.Time) []predicate.Subscription {
 	return []predicate.Subscription{
 		db_subscription.Or(
 			db_subscription.ActiveToIsNil(),
@@ -16,7 +16,7 @@ func subscriptionActiveAfter(at time.Time) []predicate.Subscription {
 	}
 }
 
-func subscriptionNotDeletedAt(at time.Time) []predicate.Subscription {
+func SubscriptionNotDeletedAt(at time.Time) []predicate.Subscription {
 	return []predicate.Subscription{
 		db_subscription.Or(
 			db_subscription.DeletedAtGT(at),

--- a/openmeter/subscription/service/service_test.go
+++ b/openmeter/subscription/service/service_test.go
@@ -25,7 +25,7 @@ func TestCreation(t *testing.T) {
 		clock.SetTime(currentTime)
 
 		dbDeps := subscriptiontestutils.SetupDBDeps(t)
-		defer dbDeps.Cleanup()
+		defer dbDeps.Cleanup(t)
 
 		services, deps := subscriptiontestutils.NewService(t, dbDeps)
 		service := services.Service
@@ -92,7 +92,7 @@ func TestCancellation(t *testing.T) {
 		clock.SetTime(currentTime)
 
 		dbDeps := subscriptiontestutils.SetupDBDeps(t)
-		defer dbDeps.Cleanup()
+		defer dbDeps.Cleanup(t)
 
 		services, deps := subscriptiontestutils.NewService(t, dbDeps)
 		service := services.Service
@@ -206,7 +206,7 @@ func TestContinuing(t *testing.T) {
 		clock.SetTime(currentTime)
 
 		dbDeps := subscriptiontestutils.SetupDBDeps(t)
-		defer dbDeps.Cleanup()
+		defer dbDeps.Cleanup(t)
 
 		services, deps := subscriptiontestutils.NewService(t, dbDeps)
 		service := services.Service

--- a/openmeter/subscription/service/update_test.go
+++ b/openmeter/subscription/service/update_test.go
@@ -88,7 +88,7 @@ func TestEdit(t *testing.T) {
 			clock.SetTime(currentTime)
 
 			dbDeps := subscriptiontestutils.SetupDBDeps(t)
-			defer dbDeps.Cleanup()
+			defer dbDeps.Cleanup(t)
 
 			services, deps := subscriptiontestutils.NewService(t, dbDeps)
 			service := services.Service

--- a/openmeter/subscription/service/workflowservice_test.go
+++ b/openmeter/subscription/service/workflowservice_test.go
@@ -285,7 +285,7 @@ func TestCreateFromPlan(t *testing.T) {
 			clock.SetTime(tcDeps.CurrentTime)
 			dbDeps := subscriptiontestutils.SetupDBDeps(t)
 			require.NotNil(t, dbDeps)
-			defer dbDeps.Cleanup()
+			defer dbDeps.Cleanup(t)
 
 			services, deps := subscriptiontestutils.NewService(t, dbDeps)
 			deps.FeatureConnector.CreateExampleFeature(t)
@@ -480,7 +480,7 @@ func TestEditRunning(t *testing.T) {
 			// Let's build the dependencies
 			dbDeps := subscriptiontestutils.SetupDBDeps(t)
 			require.NotNil(t, dbDeps)
-			defer dbDeps.Cleanup()
+			defer dbDeps.Cleanup(t)
 
 			services, deps := subscriptiontestutils.NewService(t, dbDeps)
 			deps.FeatureConnector.CreateExampleFeature(t)
@@ -630,7 +630,7 @@ func TestChangeToPlan(t *testing.T) {
 			// Let's build the dependencies
 			dbDeps := subscriptiontestutils.SetupDBDeps(t)
 			require.NotNil(t, dbDeps)
-			defer dbDeps.Cleanup()
+			defer dbDeps.Cleanup(t)
 
 			services, deps := subscriptiontestutils.NewService(t, dbDeps)
 			deps.FeatureConnector.CreateExampleFeature(t)

--- a/openmeter/subscription/testutils/customer.go
+++ b/openmeter/subscription/testutils/customer.go
@@ -22,7 +22,7 @@ func NewCustomerAdapter(t *testing.T, dbDeps *DBDeps) *testCustomerRepo {
 	logger := testutils.NewLogger(t)
 
 	repo, err := customeradapter.New(customeradapter.Config{
-		Client: dbDeps.dbClient,
+		Client: dbDeps.DBClient,
 		Logger: logger,
 	})
 	if err != nil {

--- a/openmeter/subscription/testutils/repository.go
+++ b/openmeter/subscription/testutils/repository.go
@@ -12,7 +12,7 @@ import (
 
 func NewSubscriptionRepo(t *testing.T, dbDeps *DBDeps) testSubscriptionRepo {
 	t.Helper()
-	repo := repository.NewSubscriptionRepo(dbDeps.dbClient)
+	repo := repository.NewSubscriptionRepo(dbDeps.DBClient)
 	return testSubscriptionRepo{
 		repo,
 	}
@@ -46,7 +46,7 @@ func getExampleCreateSubscriptionInput(customerId string, planRef subscription.P
 
 func NewSubscriptionPhaseRepo(t *testing.T, dbDeps *DBDeps) testSubscriptionPhaseRepo {
 	t.Helper()
-	repo := repository.NewSubscriptionPhaseRepo(dbDeps.dbClient)
+	repo := repository.NewSubscriptionPhaseRepo(dbDeps.DBClient)
 	return testSubscriptionPhaseRepo{
 		repo,
 	}
@@ -58,7 +58,7 @@ type testSubscriptionPhaseRepo struct {
 
 func NewSubscriptionItemRepo(t *testing.T, dbDeps *DBDeps) testSubscriptionItemRepo {
 	t.Helper()
-	repo := repository.NewSubscriptionItemRepo(dbDeps.dbClient)
+	repo := repository.NewSubscriptionItemRepo(dbDeps.DBClient)
 	return testSubscriptionItemRepo{
 		repo,
 	}

--- a/openmeter/subscription/testutils/service.go
+++ b/openmeter/subscription/testutils/service.go
@@ -49,7 +49,7 @@ func NewService(t *testing.T, dbDeps *DBDeps) (services, ExposedServiceDeps) {
 	}})
 
 	entitlementRegistry := registrybuilder.GetEntitlementRegistry(registrybuilder.EntitlementOptions{
-		DatabaseClient:     dbDeps.dbClient,
+		DatabaseClient:     dbDeps.DBClient,
 		StreamingConnector: streamingtestutils.NewMockStreamingConnector(t),
 		Logger:             logger,
 		MeterRepository:    meterRepo,
@@ -66,7 +66,7 @@ func NewService(t *testing.T, dbDeps *DBDeps) (services, ExposedServiceDeps) {
 	customer := NewCustomerService(t, dbDeps)
 
 	planRepo, err := planrepo.New(planrepo.Config{
-		Client: dbDeps.dbClient,
+		Client: dbDeps.DBClient,
 		Logger: logger,
 	})
 	require.NoError(t, err)

--- a/test/customer/customer_test.go
+++ b/test/customer/customer_test.go
@@ -43,6 +43,10 @@ func TestCustomer(t *testing.T) {
 			testSuite.TestUpdate(ctx, t)
 		})
 
+		t.Run("TestUpdateWithSubscriptionPresent", func(t *testing.T) {
+			testSuite.TestUpdateWithSubscriptionPresent(ctx, t)
+		})
+
 		t.Run("TestDelete", func(t *testing.T) {
 			testSuite.TestDelete(ctx, t)
 		})


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

- Disallow updating custom UsageAttribution if a Subscription is present
- Disallow archiving features used in active or scheduled plans or subscriptions

## Notes for reviewer
- Due to how features are currently linked in plans & subscriptions, logically speaking a feature can rarely be archived once its used in the productcatalog/subscription subsystem. I added a ticket to clean this up at a later point (might even make sense to do away with "archiving" for features)

<!-- Anything the reviewer should know? -->
