### PR TITLE
fix(invoice): stripe sync quantity

### DIFF
--- a/openmeter/app/stripe/client/invoice.go
+++ b/openmeter/app/stripe/client/invoice.go
@@ -32,6 +32,12 @@ func (c *stripeAppClient) CreateInvoice(ctx context.Context, input CreateInvoice
 		StatementDescriptor:  lo.ToPtr(input.StatementDescriptor),
 	}
 
+	if input.AutomaticTaxEnabled {
+		params.AutomaticTax = &stripe.InvoiceAutomaticTaxParams{
+			Enabled: lo.ToPtr(true),
+		}
+	}
+
 	if input.DueDate != nil {
 		params.DueDate = lo.ToPtr(input.DueDate.Unix())
 	}
@@ -82,6 +88,7 @@ func (c *stripeAppClient) FinalizeInvoice(ctx context.Context, input FinalizeInv
 type CreateInvoiceInput struct {
 	StripeCustomerID             string
 	StripeDefaultPaymentMethodID *string
+	AutomaticTaxEnabled          bool
 	Currency                     currencyx.Code
 	DueDate                      *time.Time
 	Number                       *string

--- a/openmeter/app/stripe/entity/app/calculator.go
+++ b/openmeter/app/stripe/entity/app/calculator.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/invopop/gobl/num"
+	"golang.org/x/text/language"
+	"golang.org/x/text/message"
 
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 )
@@ -17,6 +20,7 @@ func NewStripeCalculator(currency currencyx.Code) (StripeCalculator, error) {
 
 	return StripeCalculator{
 		calculator: calculator,
+		printer:    message.NewPrinter(language.English),
 		multiplier: alpacadecimal.NewFromInt(10).Pow(alpacadecimal.NewFromInt(int64(calculator.Def.Subunits))),
 	}, nil
 }
@@ -24,10 +28,37 @@ func NewStripeCalculator(currency currencyx.Code) (StripeCalculator, error) {
 // StripeCalculator provides a currency calculator object.
 type StripeCalculator struct {
 	calculator currencyx.Calculator
+	printer    *message.Printer
 	multiplier alpacadecimal.Decimal
 }
 
 // RoundToAmount rounds the amount to the precision of the Stripe currency in Stripe amount.
 func (c StripeCalculator) RoundToAmount(amount alpacadecimal.Decimal) int64 {
 	return amount.Mul(c.multiplier).Round(0).IntPart()
+}
+
+// FormatAmount formats the amount
+func (c StripeCalculator) FormatAmount(amount alpacadecimal.Decimal) string {
+	if amount.IsInteger() {
+		return c.calculator.Def.FormatAmount(num.MakeAmount(amount.IntPart(), 0))
+	}
+
+	am, _ := amount.Float64()
+	return c.calculator.Def.FormatAmount(num.AmountFromFloat64(am, uint32(amount.NumDigits())))
+}
+
+// FormatQuantity formats the quantity to two decimal places.
+// This should be only used to display the quantity not for calculations.
+func (c StripeCalculator) FormatQuantity(quantity alpacadecimal.Decimal) string {
+	if quantity.IsInteger() {
+		return c.printer.Sprintf("%d", quantity.IntPart())
+	} else {
+		f, _ := quantity.Float64()
+		return c.printer.Sprintf("%.2f", f)
+	}
+}
+
+// IsInteger checks if the amount is an integer in the Stripe currency.
+func (c StripeCalculator) IsInteger(amount alpacadecimal.Decimal) bool {
+	return amount.Mul(c.multiplier).IsInteger()
 }

--- a/openmeter/app/stripe/entity/app/calculator.go
+++ b/openmeter/app/stripe/entity/app/calculator.go
@@ -52,10 +52,10 @@ func (c StripeCalculator) FormatAmount(amount alpacadecimal.Decimal) string {
 func (c StripeCalculator) FormatQuantity(quantity alpacadecimal.Decimal) string {
 	if quantity.IsInteger() {
 		return c.printer.Sprintf("%d", quantity.IntPart())
-	} else {
-		f, _ := quantity.Float64()
-		return c.printer.Sprintf("%.2f", f)
 	}
+
+	f, _ := quantity.Float64()
+	return c.printer.Sprintf("%.2f", f)
 }
 
 // IsInteger checks if the amount is an integer in the Stripe currency.

--- a/openmeter/app/stripe/entity/app/calculator.go
+++ b/openmeter/app/stripe/entity/app/calculator.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/alpacahq/alpacadecimal"
 
-	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 )
 
@@ -31,20 +30,4 @@ type StripeCalculator struct {
 // RoundToAmount rounds the amount to the precision of the Stripe currency in Stripe amount.
 func (c StripeCalculator) RoundToAmount(amount alpacadecimal.Decimal) int64 {
 	return amount.Mul(c.multiplier).Round(0).IntPart()
-}
-
-// IsInteger checks if the amount is an integer in the Stripe currency.
-func (c StripeCalculator) IsInteger(amount alpacadecimal.Decimal) bool {
-	return amount.Mul(c.multiplier).IsInteger()
-}
-
-// IsAllLinesInteger checks if the invoice lines have only integer amount and quantity
-func (c StripeCalculator) IsAllLinesInteger(lines []*billing.Line) bool {
-	for _, line := range lines {
-		if !c.IsInteger(line.FlatFee.PerUnitAmount) || !line.FlatFee.Quantity.IsInteger() {
-			return false
-		}
-	}
-
-	return true
 }

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -413,6 +413,7 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 		// Mock the stripe client to return the created invoice.
 		s.StripeAppClient.
 			On("CreateInvoice", stripeclient.CreateInvoiceInput{
+				AutomaticTaxEnabled: true,
 				StripeCustomerID:    customerData.StripeCustomerID,
 				Currency:            "USD",
 				StatementDescriptor: invoice.Supplier.Name,
@@ -488,7 +489,6 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 					// TODO: check time shift
 					End: lo.ToPtr(periodStart.Add(time.Hour * 24).Unix()),
 				},
-				Quantity: lo.ToPtr(int64(1)),
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("Fee"),
 					"om_line_type": "line",
@@ -496,12 +496,11 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 			},
 			{
 				Amount:      lo.ToPtr(int64(7725)),
-				Description: lo.ToPtr("UBP - AI Usecase: usage in period"),
+				Description: lo.ToPtr("UBP - AI Usecase: usage in period (103,000,025 x $0.000001)"),
 				Period: &stripe.InvoiceAddLinesLinePeriodParams{
 					Start: lo.ToPtr(expectedPeriodStart.Unix()),
 					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
 				},
-				Quantity: lo.ToPtr(int64(1)),
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - AI Usecase: usage in period"),
 					"om_line_type": "line",
@@ -514,7 +513,6 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 					Start: lo.ToPtr(expectedPeriodStart.Unix()),
 					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
 				},
-				Quantity: lo.ToPtr(int64(1)),
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - FLAT per any usage"),
 					"om_line_type": "line",
@@ -522,12 +520,11 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 			},
 			{
 				Amount:      lo.ToPtr(int64(322000)),
-				Description: lo.ToPtr("UBP - FLAT per unit: usage in period"),
+				Description: lo.ToPtr("UBP - FLAT per unit: usage in period (32.20 x $100)"),
 				Period: &stripe.InvoiceAddLinesLinePeriodParams{
 					Start: lo.ToPtr(expectedPeriodStart.Unix()),
 					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
 				},
-				Quantity: lo.ToPtr(int64(1)),
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - FLAT per unit: usage in period"),
 					"om_line_type": "line",
@@ -540,7 +537,6 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 					Start: lo.ToPtr(expectedPeriodStart.Unix()),
 					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
 				},
-				Quantity: lo.ToPtr(int64(1)),
 				Metadata: map[string]string{
 					"om_line_id":   getDiscountID("UBP - FLAT per unit: usage in period (Maximum spend discount for charges over 2000)"),
 					"om_line_type": "discount",
@@ -548,12 +544,11 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 			},
 			{
 				Amount:      lo.ToPtr(int64(95000)),
-				Description: lo.ToPtr("UBP - Tiered graduated: usage price for tier 1"),
+				Description: lo.ToPtr("UBP - Tiered graduated: usage price for tier 1 (9.50 x $100)"),
 				Period: &stripe.InvoiceAddLinesLinePeriodParams{
 					Start: lo.ToPtr(expectedPeriodStart.Unix()),
 					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
 				},
-				Quantity: lo.ToPtr(int64(1)),
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - Tiered graduated: usage price for tier 1"),
 					"om_line_type": "line",
@@ -561,12 +556,11 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 			},
 			{
 				Amount:      lo.ToPtr(int64(94500)),
-				Description: lo.ToPtr("UBP - Tiered graduated: usage price for tier 2"),
+				Description: lo.ToPtr("UBP - Tiered graduated: usage price for tier 2 (10.50 x $90)"),
 				Period: &stripe.InvoiceAddLinesLinePeriodParams{
 					Start: lo.ToPtr(expectedPeriodStart.Unix()),
 					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
 				},
-				Quantity: lo.ToPtr(int64(1)),
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - Tiered graduated: usage price for tier 2"),
 					"om_line_type": "line",
@@ -574,12 +568,11 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 			},
 			{
 				Amount:      lo.ToPtr(int64(122400)),
-				Description: lo.ToPtr("UBP - Tiered graduated: usage price for tier 3"),
+				Description: lo.ToPtr("UBP - Tiered graduated: usage price for tier 3 (15.30 x $80)"),
 				Period: &stripe.InvoiceAddLinesLinePeriodParams{
 					Start: lo.ToPtr(expectedPeriodStart.Unix()),
 					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
 				},
-				Quantity: lo.ToPtr(int64(1)),
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - Tiered graduated: usage price for tier 3"),
 					"om_line_type": "line",
@@ -593,7 +586,6 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 					Start: lo.ToPtr(periodStart.Truncate(time.Minute).Unix()),
 					End:   lo.ToPtr(periodEnd.Truncate(time.Minute).Unix()),
 				},
-				Quantity: lo.ToPtr(int64(1)),
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - Tiered volume: minimum spend"),
 					"om_line_type": "line",
@@ -601,13 +593,12 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 			},
 			{
 				Amount:      lo.ToPtr(int64(137700)),
-				Description: lo.ToPtr("UBP - Tiered volume: unit price for tier 2"),
+				Description: lo.ToPtr("UBP - Tiered volume: unit price for tier 2 (15.30 x $90)"),
 				Period: &stripe.InvoiceAddLinesLinePeriodParams{
 					// TODO: check rounding
 					Start: lo.ToPtr(periodStart.Truncate(time.Minute).Unix()),
 					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
 				},
-				Quantity: lo.ToPtr(int64(1)),
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - Tiered volume: unit price for tier 2"),
 					"om_line_type": "line",
@@ -631,7 +622,6 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 							Start: *line.Period.Start,
 							End:   *line.Period.End,
 						},
-						Quantity: *line.Quantity,
 						Metadata: line.Metadata,
 					}
 				}),
@@ -741,7 +731,6 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 							Start: &line.Period.Start,
 							End:   &line.Period.End,
 						},
-						Quantity: &line.Quantity,
 						Metadata: line.Metadata,
 					}, line.ID != stripeLineIDToRemove
 				}),


### PR DESCRIPTION
- Quantity is not supported without Stripe Billing.
- Add quantity to line item description
- Enable automatic tax collection by default

<img width="1033" alt="Screenshot 2025-01-01 at 12 09 22 PM" src="https://github.com/user-attachments/assets/77bed08b-4a85-4ebc-8341-ebe20494aad5" />
