### PR TITLE
Add missing assertions in Subscription tests

### DIFF
--- a/openmeter/subscription/testutils/compare.go
+++ b/openmeter/subscription/testutils/compare.go
@@ -13,44 +13,65 @@ import (
 )
 
 // Ensures the created view matches the input spec
-// TODO: Missing validations (OM-1053)
 func ValidateSpecAndView(t *testing.T, expected subscription.SubscriptionSpec, found subscription.SubscriptionView) {
-	// Test Phases
+	// Let's validate the Subscription itself
+	assert.Equal(t, expected.Name, found.Subscription.Name)
+	assert.Equal(t, expected.Description, found.Subscription.Description)
+	assert.Equal(t, expected.Plan, found.Subscription.PlanRef)
+	assert.Equal(t, expected.Currency, found.Subscription.Currency)
+	assert.Equal(t, expected.CustomerId, found.Subscription.CustomerId)
+	assert.Equal(t, expected.ActiveFrom, found.Subscription.ActiveFrom)
+	assert.Equal(t, expected.ActiveTo, found.Subscription.ActiveTo)
+	assert.Equal(t, expected.Metadata, found.Subscription.Metadata)
+
+	// Let's validate the phases
 
 	foundPhases := found.Phases
 	specPhases := expected.GetSortedPhases()
 
-	require.Equal(t, len(specPhases), len(foundPhases))
+	require.Equal(t, len(specPhases), len(foundPhases), "phase count mismatch")
 
 	for i := range specPhases {
-		assert.Equal(t, specPhases[i].PhaseKey, foundPhases[i].SubscriptionPhase.Key)
-
-		expectedStart, _ := specPhases[i].StartAfter.AddTo(found.Subscription.ActiveFrom)
-
-		assert.Equal(t, expectedStart.UTC(), foundPhases[i].ActiveFrom(found.Subscription.CadencedModel))
-
-		// Test Rate Cards of Phase
 		specPhase := specPhases[i]
 		foundPhase := foundPhases[i]
 
+		// Let's validate the phase properties
+		assert.Equal(t, specPhase.PhaseKey, foundPhase.SubscriptionPhase.Key)
+		assert.Equal(t, specPhase.Name, foundPhase.SubscriptionPhase.Name)
+		assert.Equal(t, specPhase.Description, foundPhase.SubscriptionPhase.Description)
+		assert.Equal(t, specPhase.Metadata, foundPhase.SubscriptionPhase.Metadata)
+
+		expectedStart, _ := specPhases[i].StartAfter.AddTo(found.Subscription.ActiveFrom)
+		assert.Equal(t, expectedStart.UTC(), foundPhases[i].ActiveFrom(found.Subscription.CadencedModel))
+
+		// Test Rate Cards of Phase
 		specItemsByKey := specPhase.ItemsByKey
 		foundItemsByKey := foundPhase.ItemsByKey
 
 		require.Equal(t, len(specItemsByKey), len(foundItemsByKey), "item count mismatch for phase %s", specPhase.PhaseKey)
 
 		for specItemsKey := range specItemsByKey {
-			specItems, ok := specItemsByKey[specItemsKey]
+			specItemsByKey, ok := specItemsByKey[specItemsKey]
 			require.True(t, ok, "item %s not found in spec phase %s", specItemsKey, specPhase.PhaseKey)
-			foundItemsByKey, foundItemsForKey := foundItemsByKey[specItemsKey]
-			require.True(t, foundItemsForKey, "item %s not found in found phase %s", specItemsKey, specPhase.PhaseKey)
+			foundItemsByKey, ok := foundItemsByKey[specItemsKey]
+			require.True(t, ok, "item %s not found in found phase %s", specItemsKey, specPhase.PhaseKey)
 
-			require.Equal(t, len(specItems), len(foundItemsByKey), "item count mismatch for item %s in phase %s", specItemsKey, specPhase.PhaseKey)
+			require.Equal(t, len(specItemsByKey), len(foundItemsByKey), "item count mismatch for item %s in phase %s", specItemsKey, specPhase.PhaseKey)
 
-			for idx, specItem := range specItems {
+			for idx, specItem := range specItemsByKey {
 				foundItem := foundItemsByKey[idx]
 
-				assert.Equal(t, specItem.ItemKey, foundItem.SubscriptionItem.Key)
+				// Let's validate the item properties
 
+				assert.Equal(t, specItem.ItemKey, foundItem.SubscriptionItem.Key)
+				// Validate phase linking both ways
+				assert.Equal(t, foundPhase.SubscriptionPhase.Key, specItem.PhaseKey)
+				assert.Equal(t, foundPhase.SubscriptionPhase.ID, foundItem.SubscriptionItem.PhaseId)
+
+				// Let's validate the RateCard is equal
+				assert.True(t, specItem.RateCard.Equal(foundItem.SubscriptionItem.RateCard), "rate card mismatch for item %s in phase %s: \nspec: %+v\n\nview: %+v", specItem.ItemKey, specPhase.PhaseKey, specItem.RateCard, foundItem.SubscriptionItem.RateCard)
+
+				// Let's validate the Feature linking
 				pFeatureKey := specItem.RateCard.FeatureKey
 				if foundItem.SubscriptionItem.RateCard.FeatureKey != nil {
 					require.NotNil(t, pFeatureKey)
@@ -61,6 +82,7 @@ func ValidateSpecAndView(t *testing.T, expected subscription.SubscriptionSpec, f
 
 				rcInp := specItem.CreateSubscriptionItemPlanInput
 
+				// Let's validate the Entitlement
 				if rcEnt := rcInp.RateCard.EntitlementTemplate; rcEnt != nil {
 					ent := foundItem.Entitlement
 					exists := ent != nil


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Adds missing assertions when comparing Specs and Views

Fixes [OM-1053: Test Validations](https://linear.app/openmeter/issue/OM-1053/test-validations)