### PR TITLE
fix: billing updated-at schemantics

### DIFF
--- a/openmeter/billing/adapter.go
+++ b/openmeter/billing/adapter.go
@@ -24,6 +24,7 @@ type ProfileAdapter interface {
 	GetDefaultProfile(ctx context.Context, input GetDefaultProfileInput) (*BaseProfile, error)
 	DeleteProfile(ctx context.Context, input DeleteProfileInput) error
 	UpdateProfile(ctx context.Context, input UpdateProfileAdapterInput) (*BaseProfile, error)
+	UnsetDefaultProfile(ctx context.Context, input UnsetDefaultProfileInput) error
 }
 
 type CustomerOverrideAdapter interface {

--- a/openmeter/billing/customeroverride.go
+++ b/openmeter/billing/customeroverride.go
@@ -252,11 +252,7 @@ func (i UpdateCustomerOverrideAdapterInput) Validate() error {
 	return nil
 }
 
-type HasCustomerOverrideReferencingProfileAdapterInput genericNamespaceID
-
-func (i HasCustomerOverrideReferencingProfileAdapterInput) Validate() error {
-	return genericNamespaceID(i).Validate()
-}
+type HasCustomerOverrideReferencingProfileAdapterInput = ProfileID
 
 type (
 	UpsertCustomerOverrideAdapterInput = customerentity.CustomerID

--- a/openmeter/billing/httpdriver/profile.go
+++ b/openmeter/billing/httpdriver/profile.go
@@ -101,7 +101,7 @@ func (h *handler) GetProfile() GetProfileHandler {
 			}
 
 			return GetProfileRequest{
-				Profile: models.NamespacedID{
+				Profile: billing.ProfileID{
 					Namespace: ns,
 					ID:        params.ID,
 				},

--- a/openmeter/billing/profile.go
+++ b/openmeter/billing/profile.go
@@ -185,6 +185,12 @@ func (c SupplierContact) Validate() error {
 	return nil
 }
 
+type ProfileID models.NamespacedID
+
+func (p ProfileID) Validate() error {
+	return models.NamespacedID(p).Validate()
+}
+
 type BaseProfile struct {
 	ID        string `json:"id"`
 	Namespace string `json:"namespace"`
@@ -224,6 +230,13 @@ func (p BaseProfile) Validate() error {
 	}
 
 	return nil
+}
+
+func (p BaseProfile) ProfileID() ProfileID {
+	return ProfileID{
+		Namespace: p.Namespace,
+		ID:        p.ID,
+	}
 }
 
 type Profile struct {
@@ -403,25 +416,8 @@ func (i GetDefaultProfileInput) Validate() error {
 	return nil
 }
 
-type genericNamespaceID struct {
-	Namespace string
-	ID        string
-}
-
-func (i genericNamespaceID) Validate() error {
-	if i.Namespace == "" {
-		return errors.New("namespace is required")
-	}
-
-	if i.ID == "" {
-		return errors.New("id is required")
-	}
-
-	return nil
-}
-
 type GetProfileInput struct {
-	Profile models.NamespacedID
+	Profile ProfileID
 	Expand  ProfileExpand
 }
 
@@ -437,11 +433,7 @@ func (i GetProfileInput) Validate() error {
 	return nil
 }
 
-type DeleteProfileInput genericNamespaceID
-
-func (i DeleteProfileInput) Validate() error {
-	return genericNamespaceID(i).Validate()
-}
+type DeleteProfileInput = ProfileID
 
 type UpdateProfileInput BaseProfile
 
@@ -455,6 +447,10 @@ func (i UpdateProfileInput) Validate() error {
 	}
 
 	return BaseProfile(i).Validate()
+}
+
+func (i UpdateProfileInput) ProfileID() ProfileID {
+	return BaseProfile(i).ProfileID()
 }
 
 type UpdateProfileAdapterInput struct {
@@ -471,13 +467,11 @@ func (i UpdateProfileAdapterInput) Validate() error {
 		return fmt.Errorf("id is required")
 	}
 
-	if i.TargetState.UpdatedAt.IsZero() {
-		return fmt.Errorf("updated at is required")
-	}
-
 	if i.WorkflowConfigID == "" {
 		return fmt.Errorf("workflow config id is required")
 	}
 
 	return nil
 }
+
+type UnsetDefaultProfileInput = ProfileID


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

### Billing profile default settings

We must ensure that there is at least one default billing profile in the given namespace.

We achieve that by the following constraints:

Create:

- When creating a billing profile with default = true and a default billing profile exists then 
 - the old billing profile set non-default, while the new billing profile is set to be the default
- When creating a billing profile with default = false, no checks are performed for the default profile

Update:

- When updating a non-default billing profile with default = true, the billing profile is made the default, 
 - If there's an existing default billing profile it's default flag is set to false
- When updating a default billing profile with default = true, nothing changes
- When updating a default billing profile with default = false, the request is considered invalid

Deletion:
- A default profile cannot be deleted (returns error)


### Other fixes

- UpdatedAt is not required for updates
- App types must match for now
