### PR TITLE
fix: correct subscription event publishing

### DIFF
--- a/openmeter/subscription/events.go
+++ b/openmeter/subscription/events.go
@@ -48,6 +48,30 @@ func (s CreatedEvent) Validate() error {
 	return viewEvent(s).Validate()
 }
 
+type DeletedEvent viewEvent
+
+var (
+	_ marshaler.Event = CreatedEvent{}
+
+	subscriptionDeletedEventName = metadata.GetEventName(metadata.EventType{
+		Subsystem: EventSubsystem,
+		Name:      "subscription.deleted",
+		Version:   "v1",
+	})
+)
+
+func (s DeletedEvent) EventName() string {
+	return subscriptionDeletedEventName
+}
+
+func (s DeletedEvent) EventMetadata() metadata.EventMetadata {
+	return viewEvent(s).EventMetadata()
+}
+
+func (s DeletedEvent) Validate() error {
+	return viewEvent(s).Validate()
+}
+
 type CancelledEvent viewEvent
 
 var (
@@ -104,15 +128,15 @@ type UpdatedEvent struct {
 var (
 	_ marshaler.Event = UpdatedEvent{}
 
-	subscriptionEditedEventName = metadata.GetEventName(metadata.EventType{
+	subscriptionUpdatedEventName = metadata.GetEventName(metadata.EventType{
 		Subsystem: EventSubsystem,
-		Name:      "subscription.edited",
+		Name:      "subscription.updated",
 		Version:   "v1",
 	})
 )
 
 func (s UpdatedEvent) EventName() string {
-	return subscriptionEditedEventName
+	return subscriptionUpdatedEventName
 }
 
 func (s UpdatedEvent) EventMetadata() metadata.EventMetadata {


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch fixes that subscription have published the wrong events on some action.

Fixes that Update didn't yield an event.

Adds the deleted event type.