### PR TITLE
feat: add validate billing stack before creating a paid subscription

### DIFF
--- a/app/common/billing.go
+++ b/app/common/billing.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	billingadapter "github.com/openmeterio/openmeter/openmeter/billing/adapter"
 	billingservice "github.com/openmeterio/openmeter/openmeter/billing/service"
+	billingsubscription "github.com/openmeterio/openmeter/openmeter/billing/subscription"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/meter"
@@ -58,4 +59,15 @@ func BillingService(
 		MeterRepo:          meterRepo,
 		StreamingConnector: streamingConnector,
 	})
+}
+
+func BillingSubscriptionValidator(
+	billingService billing.Service,
+	billingConfig config.BillingConfiguration,
+) (*billingsubscription.Validator, error) {
+	if !billingConfig.Enabled {
+		return nil, nil
+	}
+
+	return billingsubscription.NewValidator(billingService)
 }

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -318,7 +318,18 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	v6 := common.NewTelemetryRouterHook(meterProvider, tracerProvider)
-	subscriptionServiceWithWorkflow, err := common.NewSubscriptionServices(logger, client, productCatalogConfiguration, entitlementsConfiguration, featureConnector, entitlement, customerService, planService, eventbusPublisher)
+	validator, err := common.BillingSubscriptionValidator(billingService, billingConfiguration)
+	if err != nil {
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
+	subscriptionServiceWithWorkflow, err := common.NewSubscriptionServices(logger, client, productCatalogConfiguration, entitlementsConfiguration, featureConnector, entitlement, customerService, planService, eventbusPublisher, validator)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/openmeter/billing/subscription/validator.go
+++ b/openmeter/billing/subscription/validator.go
@@ -1,0 +1,82 @@
+package subscription
+
+import (
+	"context"
+	"fmt"
+
+	appentitybase "github.com/openmeterio/openmeter/openmeter/app/entity/base"
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	customerapp "github.com/openmeterio/openmeter/openmeter/customer/app"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+)
+
+type Validator struct {
+	subscription.NoOpSubscriptionValidator
+	billingService billing.Service
+}
+
+func NewValidator(billingService billing.Service) (*Validator, error) {
+	if billingService == nil {
+		return nil, fmt.Errorf("billing service is required")
+	}
+
+	return &Validator{
+		billingService: billingService,
+	}, nil
+}
+
+func (v Validator) ValidateCreate(ctx context.Context, view subscription.SubscriptionView) error {
+	return v.validateBillingSetup(ctx, view)
+}
+
+func (v Validator) ValidateUpdate(ctx context.Context, view subscription.SubscriptionView) error {
+	return v.validateBillingSetup(ctx, view)
+}
+
+func (v Validator) validateBillingSetup(ctx context.Context, view subscription.SubscriptionView) error {
+	// If a subscription is going to be billed (e.g. there are phases with ratecards having prices)
+	// let's make sure that the billing setup is valid for the customer
+
+	if !v.hasBillableItems(view) {
+		return nil
+	}
+
+	// Check if the customer has a billing setup
+	customerProfile, err := v.billingService.GetProfileWithCustomerOverride(ctx, billing.GetProfileWithCustomerOverrideInput{
+		Namespace:  view.Subscription.Namespace,
+		CustomerID: view.Subscription.CustomerId,
+	})
+	if err != nil {
+		return err
+	}
+
+	appBase := customerProfile.Profile.Apps.Invoicing
+	customerApp, ok := appBase.(customerapp.App)
+	if !ok {
+		// This should not happen, as the app should have been already verified by the billing service, but let's make sure
+		return fmt.Errorf("app [type=%s, id=%s] does not implement the customer interface",
+			appBase.GetType(),
+			appBase.GetID().ID)
+	}
+
+	return customerApp.ValidateCustomer(ctx, &customerProfile.Customer, []appentitybase.CapabilityType{
+		// For now now we only support Stripe with automatic tax calculation and payment collection.
+		appentitybase.CapabilityTypeCalculateTax,
+		appentitybase.CapabilityTypeInvoiceCustomers,
+		appentitybase.CapabilityTypeCollectPayments,
+	})
+}
+
+func (v Validator) hasBillableItems(view subscription.SubscriptionView) bool {
+	for _, phase := range view.Phases {
+		for _, items := range phase.ItemsByKey {
+			for _, item := range items {
+				if item.SubscriptionItem.RateCard.Price != nil {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/openmeter/productcatalog/subscription/http/errors.go
+++ b/openmeter/productcatalog/subscription/http/errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/openmeterio/openmeter/openmeter/app"
 	customerentity "github.com/openmeterio/openmeter/openmeter/customer/entity"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
@@ -36,6 +37,15 @@ func errorEncoder() httptransport.ErrorEncoder {
 			commonhttp.HandleErrorIfTypeMatches[customerentity.NotFoundError](ctx, http.StatusNotFound, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[customerentity.ValidationError](ctx, http.StatusBadRequest, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[customerentity.UpdateAfterDeleteError](ctx, http.StatusConflict, err, w) ||
-			commonhttp.HandleErrorIfTypeMatches[customerentity.SubjectKeyConflictError](ctx, http.StatusConflict, err, w)
+			commonhttp.HandleErrorIfTypeMatches[customerentity.SubjectKeyConflictError](ctx, http.StatusConflict, err, w) ||
+			// dependency: app (due to validators)
+			commonhttp.HandleErrorIfTypeMatches[app.AppNotFoundError](ctx, http.StatusNotFound, err, w) ||
+			commonhttp.HandleErrorIfTypeMatches[app.AppDefaultNotFoundError](ctx, http.StatusNotFound, err, w) ||
+			commonhttp.HandleErrorIfTypeMatches[app.AppProviderAuthenticationError](ctx, http.StatusUnauthorized, err, w) ||
+			commonhttp.HandleErrorIfTypeMatches[app.AppProviderError](ctx, http.StatusFailedDependency, err, w) ||
+			commonhttp.HandleErrorIfTypeMatches[app.AppConflictError](ctx, http.StatusConflict, err, w) ||
+			commonhttp.HandleErrorIfTypeMatches[app.AppProviderPreConditionError](ctx, http.StatusPreconditionFailed, err, w) ||
+			commonhttp.HandleErrorIfTypeMatches[app.AppCustomerPreConditionError](ctx, http.StatusPreconditionFailed, err, w) ||
+			commonhttp.HandleErrorIfTypeMatches[app.ValidationError](ctx, http.StatusBadRequest, err, w)
 	}
 }

--- a/openmeter/subscription/subscriptionvalidator.go
+++ b/openmeter/subscription/subscriptionvalidator.go
@@ -1,0 +1,35 @@
+package subscription
+
+import "context"
+
+type SubscriptionValidator interface {
+	ValidateCreate(context.Context, SubscriptionView) error
+	ValidateUpdate(context.Context, SubscriptionView) error
+	ValidateCancel(context.Context, SubscriptionView) error
+	ValidateContinue(context.Context, SubscriptionView) error
+	ValidateDelete(context.Context, SubscriptionView) error
+}
+
+var _ SubscriptionValidator = (*NoOpSubscriptionValidator)(nil)
+
+type NoOpSubscriptionValidator struct{}
+
+func (NoOpSubscriptionValidator) ValidateCreate(context.Context, SubscriptionView) error {
+	return nil
+}
+
+func (NoOpSubscriptionValidator) ValidateUpdate(context.Context, SubscriptionView) error {
+	return nil
+}
+
+func (NoOpSubscriptionValidator) ValidateCancel(context.Context, SubscriptionView) error {
+	return nil
+}
+
+func (NoOpSubscriptionValidator) ValidateContinue(context.Context, SubscriptionView) error {
+	return nil
+}
+
+func (NoOpSubscriptionValidator) ValidateDelete(context.Context, SubscriptionView) error {
+	return nil
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch makes sure that if we are starting a subscription that would yield an invoice, then we could most probably create the invoice.

This feature ensures that we don't end up with draft_failed invoices in trivial cases.