### PR TITLE
refactor: productcatalog errors

### DIFF
--- a/openmeter/productcatalog/discount.go
+++ b/openmeter/productcatalog/discount.go
@@ -193,11 +193,7 @@ func (f PercentageDiscount) Validate() error {
 		errs = append(errs, errors.New("discount percentage must be between 0 and 100"))
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return NewValidationError(errors.Join(errs...))
 }
 
 var _ models.Equaler[Discounts] = (*Discounts)(nil)

--- a/openmeter/productcatalog/entitlement.go
+++ b/openmeter/productcatalog/entitlement.go
@@ -308,7 +308,7 @@ func (t *MeteredEntitlementTemplate) Equal(v *MeteredEntitlementTemplate) bool {
 
 func (t *MeteredEntitlementTemplate) Validate() error {
 	if t.IssueAfterResetPriority != nil && t.IssueAfterReset == nil {
-		return errors.New("IssueAfterReset is required for IssueAfterResetPriority")
+		return NewValidationError(errors.New("IssueAfterReset is required for IssueAfterResetPriority"))
 	}
 
 	return nil
@@ -348,7 +348,7 @@ func (t *StaticEntitlementTemplate) Equal(v *StaticEntitlementTemplate) bool {
 func (t *StaticEntitlementTemplate) Validate() error {
 	if len(t.Config) > 0 {
 		if ok := json.Valid(t.Config); !ok {
-			return errors.New("invalid JSON in config")
+			return NewValidationError(errors.New("invalid JSON in config"))
 		}
 	}
 

--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -1,0 +1,23 @@
+package productcatalog
+
+var _ error = (*ValidationError)(nil)
+
+type ValidationError struct {
+	Err error
+}
+
+func (e *ValidationError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *ValidationError) Unwrap() error {
+	return e.Err
+}
+
+func NewValidationError(err error) error {
+	if err != nil {
+		return &ValidationError{err}
+	}
+
+	return nil
+}

--- a/openmeter/productcatalog/phase.go
+++ b/openmeter/productcatalog/phase.go
@@ -73,11 +73,7 @@ func (p PhaseMeta) Validate() error {
 		errs = append(errs, fmt.Errorf("the Duration period must not be negative"))
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return NewValidationError(errors.Join(errs...))
 }
 
 var (
@@ -145,9 +141,5 @@ func (p Phase) Validate() error {
 		}
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return NewValidationError(errors.Join(errs...))
 }

--- a/openmeter/productcatalog/plan.go
+++ b/openmeter/productcatalog/plan.go
@@ -55,11 +55,7 @@ func (p Plan) Validate() error {
 		}
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return NewValidationError(errors.Join(errs...))
 }
 
 // ValidForCreatingSubscriptions checks if the Plan is valid for creating Subscriptions, a stricter version of Validate
@@ -158,11 +154,7 @@ func (p PlanMeta) Validate() error {
 		errs = append(errs, fmt.Errorf("invalid Name: must not be empty"))
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return NewValidationError(errors.Join(errs...))
 }
 
 // Equal returns true if the two PlanMetas are equal.
@@ -213,7 +205,7 @@ type EffectivePeriod struct {
 
 func (p EffectivePeriod) Validate() error {
 	if p.Status() == InvalidStatus {
-		return fmt.Errorf("invalid effective time range: to is before from")
+		return NewValidationError(fmt.Errorf("invalid effective time range: to is before from"))
 	}
 
 	return nil

--- a/openmeter/productcatalog/plan/adapter/plan.go
+++ b/openmeter/productcatalog/plan/adapter/plan.go
@@ -194,10 +194,9 @@ func (a *adapter) DeletePlan(ctx context.Context, params plan.DeletePlanInput) e
 		})
 		if err != nil {
 			if entdb.IsNotFound(err) {
-				return nil, plan.NotFoundError{
-					NamespacedModel: models.NamespacedModel{
-						Namespace: params.Namespace,
-					},
+				return nil, &plan.NotFoundError{
+					Namespace: params.Namespace,
+					ID:        params.ID,
 				}
 			}
 
@@ -211,10 +210,9 @@ func (a *adapter) DeletePlan(ctx context.Context, params plan.DeletePlanInput) e
 			Exec(ctx)
 		if err != nil {
 			if entdb.IsNotFound(err) {
-				return nil, plan.NotFoundError{
-					NamespacedModel: models.NamespacedModel{
-						Namespace: params.Namespace,
-					},
+				return nil, &plan.NotFoundError{
+					Namespace: params.Namespace,
+					ID:        params.ID,
 				}
 			}
 
@@ -320,10 +318,11 @@ func (a *adapter) GetPlan(ctx context.Context, params plan.GetPlanInput) (*plan.
 		planRow, err := query.First(ctx)
 		if err != nil {
 			if entdb.IsNotFound(err) {
-				return nil, plan.NotFoundError{
-					NamespacedModel: models.NamespacedModel{
-						Namespace: params.Namespace,
-					},
+				return nil, &plan.NotFoundError{
+					Namespace: params.Namespace,
+					ID:        params.ID,
+					Key:       params.Key,
+					Version:   params.Version,
 				}
 			}
 
@@ -387,10 +386,9 @@ func (a *adapter) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (
 			})
 			if err != nil {
 				if entdb.IsNotFound(err) {
-					return nil, plan.NotFoundError{
-						NamespacedModel: models.NamespacedModel{
-							Namespace: params.Namespace,
-						},
+					return nil, &plan.NotFoundError{
+						Namespace: params.Namespace,
+						ID:        params.ID,
 					}
 				}
 

--- a/openmeter/productcatalog/plan/errors.go
+++ b/openmeter/productcatalog/plan/errors.go
@@ -3,52 +3,48 @@ package plan
 import (
 	"errors"
 	"fmt"
-
-	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 var _ error = (*NotFoundError)(nil)
 
 type NotFoundError struct {
-	models.NamespacedModel
+	Namespace string
+	ID        string
+	Key       string
+	Version   int
 }
 
-func (e NotFoundError) Error() string {
-	return fmt.Sprintf("resource not found in %s namespace", e.Namespace)
+func (e *NotFoundError) Error() string {
+	var m string
+
+	if e.Namespace != "" {
+		m += fmt.Sprintf(" namespace=%s", e.Namespace)
+	}
+
+	if e.ID != "" {
+		m += fmt.Sprintf(" id=%s", e.ID)
+	}
+
+	if e.Key != "" {
+		m += fmt.Sprintf(" key=%s", e.Key)
+	}
+
+	if e.Version != 0 {
+		m += fmt.Sprintf(" version=%d", e.Version)
+	}
+
+	if len(m) > 0 {
+		return fmt.Sprintf("plan not found. [%s]", m[1:])
+	}
+
+	return "plan not found"
 }
 
 func IsNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	var e NotFoundError
+	var e *NotFoundError
+
 	return errors.As(err, &e)
-}
-
-type genericError struct {
-	Err error
-}
-
-var _ error = (*ValidationError)(nil)
-
-type ValidationError genericError
-
-func (e ValidationError) Error() string {
-	return e.Err.Error()
-}
-
-func (e ValidationError) Unwrap() error {
-	return e.Err
-}
-
-var _ error = (*UpdateAfterDeleteError)(nil)
-
-type UpdateAfterDeleteError genericError
-
-func (e UpdateAfterDeleteError) Error() string {
-	return e.Err.Error()
-}
-
-func (e UpdateAfterDeleteError) Unwrap() error {
-	return e.Err
 }

--- a/openmeter/productcatalog/plan/errors_test.go
+++ b/openmeter/productcatalog/plan/errors_test.go
@@ -1,0 +1,94 @@
+package plan
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNotFoundError(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Error         error
+		ExpectedError bool
+	}{
+		{
+			Name: "Valid",
+			Error: &NotFoundError{
+				Namespace: "test",
+				ID:        "test",
+			},
+			ExpectedError: true,
+		},
+		{
+			Name: "Wrapped",
+			Error: errors.Join(
+				fmt.Errorf("wrapped: %w", &NotFoundError{
+					Namespace: "test",
+					ID:        "test",
+				}),
+			),
+			ExpectedError: true,
+		},
+		{
+			Name:          "Invalid",
+			Error:         errors.New("test error"),
+			ExpectedError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			assert.Equal(t, test.ExpectedError, IsNotFound(test.Error))
+		})
+	}
+}
+
+func TestIsNotFoundError_String(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Error         error
+		ExpectedError string
+	}{
+		{
+			Name: "ID",
+			Error: &NotFoundError{
+				Namespace: "namespace",
+				ID:        "id",
+			},
+			ExpectedError: "plan not found. [namespace=namespace id=id]",
+		},
+		{
+			Name: "Key",
+			Error: &NotFoundError{
+				Namespace: "namespace",
+				Key:       "key",
+			},
+			ExpectedError: "plan not found. [namespace=namespace key=key]",
+		},
+		{
+			Name: "KeyVersion",
+			Error: &NotFoundError{
+				Namespace: "namespace",
+				Key:       "key",
+				Version:   1,
+			},
+			ExpectedError: "plan not found. [namespace=namespace key=key version=1]",
+		},
+		{
+			Name:          "Default",
+			Error:         &NotFoundError{},
+			ExpectedError: "plan not found",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			t.Logf("%v", test.Error)
+
+			assert.Equal(t, test.ExpectedError, test.Error.Error())
+		})
+	}
+}

--- a/openmeter/productcatalog/plan/httpdriver/errors.go
+++ b/openmeter/productcatalog/plan/httpdriver/errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
@@ -15,7 +16,7 @@ func errorEncoder() httptransport.ErrorEncoder {
 	return func(ctx context.Context, err error, w http.ResponseWriter, r *http.Request) bool {
 		return commonhttp.HandleErrorIfTypeMatches[plan.NotFoundError](ctx, http.StatusNotFound, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*feature.FeatureNotFoundError](ctx, http.StatusBadRequest, err, w) ||
-			commonhttp.HandleErrorIfTypeMatches[plan.ValidationError](ctx, http.StatusBadRequest, err, w) ||
+			commonhttp.HandleErrorIfTypeMatches[*productcatalog.ValidationError](ctx, http.StatusBadRequest, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*models.GenericUserError](ctx, http.StatusBadRequest, err, w)
 	}
 }

--- a/openmeter/productcatalog/plan/httpdriver/errors.go
+++ b/openmeter/productcatalog/plan/httpdriver/errors.go
@@ -14,7 +14,7 @@ import (
 
 func errorEncoder() httptransport.ErrorEncoder {
 	return func(ctx context.Context, err error, w http.ResponseWriter, r *http.Request) bool {
-		return commonhttp.HandleErrorIfTypeMatches[plan.NotFoundError](ctx, http.StatusNotFound, err, w) ||
+		return commonhttp.HandleErrorIfTypeMatches[*plan.NotFoundError](ctx, http.StatusNotFound, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*feature.FeatureNotFoundError](ctx, http.StatusBadRequest, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*productcatalog.ValidationError](ctx, http.StatusBadRequest, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*models.GenericUserError](ctx, http.StatusBadRequest, err, w)

--- a/openmeter/productcatalog/plan/phase.go
+++ b/openmeter/productcatalog/plan/phase.go
@@ -47,11 +47,7 @@ func (m PhaseManagedFields) Validate() error {
 		errs = append(errs, errors.New("planID must not be empty"))
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return productcatalog.NewValidationError(errors.Join(errs...))
 }
 
 type ManagedPhase interface {
@@ -102,11 +98,7 @@ func (p Phase) Validate() error {
 		errs = append(errs, err)
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return productcatalog.NewValidationError(errors.Join(errs...))
 }
 
 func (p Phase) AsProductCatalogPhase() productcatalog.Phase {

--- a/openmeter/productcatalog/plan/plan.go
+++ b/openmeter/productcatalog/plan/plan.go
@@ -36,11 +36,7 @@ func (p Plan) Validate() error {
 		}
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return productcatalog.NewValidationError(errors.Join(errs...))
 }
 
 func (p Plan) AsProductCatalogPlan(at time.Time) (productcatalog.Plan, error) {

--- a/openmeter/productcatalog/plan/ratecard.go
+++ b/openmeter/productcatalog/plan/ratecard.go
@@ -51,11 +51,7 @@ func (m RateCardManagedFields) Validate() error {
 		errs = append(errs, errors.New("phaseID must not be empty"))
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return productcatalog.NewValidationError(errors.Join(errs...))
 }
 
 type ManagedRateCard interface {
@@ -177,11 +173,7 @@ func (r *FlatFeeRateCard) Validate() error {
 		errs = append(errs, err)
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return productcatalog.NewValidationError(errors.Join(errs...))
 }
 
 func (r *FlatFeeRateCard) Merge(v productcatalog.RateCard) error {
@@ -280,11 +272,7 @@ func (r *UsageBasedRateCard) Validate() error {
 		errs = append(errs, err)
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return productcatalog.NewValidationError(errors.Join(errs...))
 }
 
 func (r *UsageBasedRateCard) Merge(v productcatalog.RateCard) error {

--- a/openmeter/productcatalog/price.go
+++ b/openmeter/productcatalog/price.go
@@ -308,11 +308,7 @@ func (f *FlatPrice) Validate() error {
 		errs = append(errs, fmt.Errorf("invalid PaymentTerm: %s", f.PaymentTerm))
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return NewValidationError(errors.Join(errs...))
 }
 
 type UnitPrice struct {
@@ -389,11 +385,7 @@ func (u *UnitPrice) Validate() error {
 		}
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return NewValidationError(errors.Join(errs...))
 }
 
 const (
@@ -539,11 +531,7 @@ func (t *TieredPrice) Validate() error {
 		}
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return NewValidationError(errors.Join(errs...))
 }
 
 func (t *TieredPrice) WithSortedTiers() TieredPrice {
@@ -610,11 +598,7 @@ func (p PriceTier) Validate() error {
 		}
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return NewValidationError(errors.Join(errs...))
 }
 
 var _ models.Validator = (*PriceTierFlatPrice)(nil)
@@ -626,7 +610,7 @@ type PriceTierFlatPrice struct {
 
 func (f PriceTierFlatPrice) Validate() error {
 	if f.Amount.IsNegative() {
-		return errors.New("the Amount must not be negative")
+		return NewValidationError(errors.New("the Amount must not be negative"))
 	}
 
 	return nil
@@ -641,7 +625,7 @@ type PriceTierUnitPrice struct {
 
 func (u PriceTierUnitPrice) Validate() error {
 	if u.Amount.IsNegative() {
-		return errors.New("the Amount must not be negative")
+		return NewValidationError(errors.New("the Amount must not be negative"))
 	}
 
 	return nil

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -136,15 +136,11 @@ func (r RateCardMeta) Validate() error {
 
 	if r.Feature != nil {
 		if r.Key != r.Feature.Key {
-			errs = append(errs, errors.New("Feature key mismatch"))
+			errs = append(errs, errors.New("invalid Feature: key mismatch"))
 		}
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return NewValidationError(errors.Join(errs...))
 }
 
 var _ RateCard = (*FlatFeeRateCard)(nil)
@@ -228,11 +224,7 @@ func (r *FlatFeeRateCard) Validate() error {
 		}
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return NewValidationError(errors.Join(errs...))
 }
 
 var _ RateCard = (*UsageBasedRateCard)(nil)
@@ -313,11 +305,7 @@ func (r *UsageBasedRateCard) Validate() error {
 		errs = append(errs, errors.New("invalid BillingCadence: must not be negative or zero"))
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return NewValidationError(errors.Join(errs...))
 }
 
 var _ models.Equaler[RateCards] = (*RateCards)(nil)

--- a/openmeter/productcatalog/subscription/http/errors.go
+++ b/openmeter/productcatalog/subscription/http/errors.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/app"
 	customerentity "github.com/openmeterio/openmeter/openmeter/customer/entity"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
@@ -32,7 +32,7 @@ func errorEncoder() httptransport.ErrorEncoder {
 			// FIXME: dependency errors should not have to be matched everywhere
 			// dependency: plan
 			commonhttp.HandleErrorIfTypeMatches[*feature.FeatureNotFoundError](ctx, http.StatusBadRequest, err, w) ||
-			commonhttp.HandleErrorIfTypeMatches[plan.ValidationError](ctx, http.StatusBadRequest, err, w) ||
+			commonhttp.HandleErrorIfTypeMatches[*productcatalog.ValidationError](ctx, http.StatusBadRequest, err, w) ||
 			// dependency: customer
 			commonhttp.HandleErrorIfTypeMatches[customerentity.NotFoundError](ctx, http.StatusNotFound, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[customerentity.ValidationError](ctx, http.StatusBadRequest, err, w) ||

--- a/openmeter/productcatalog/subscription/service/plan.go
+++ b/openmeter/productcatalog/subscription/service/plan.go
@@ -27,7 +27,7 @@ func (s *service) getPlanByVersion(ctx context.Context, namespace string, ref pl
 		Version: version,
 	})
 
-	if _, ok := lo.ErrorsAs[plan.NotFoundError](err); ok {
+	if _, ok := lo.ErrorsAs[*plan.NotFoundError](err); ok {
 		return nil, subscription.PlanNotFoundError{
 			Key:     planKey,
 			Version: version,

--- a/openmeter/productcatalog/subscription/testutils/adapter.go
+++ b/openmeter/productcatalog/subscription/testutils/adapter.go
@@ -53,7 +53,7 @@ func (a *adapter) GetVersion(ctx context.Context, namespace string, ref plansubs
 		Version: version,
 	})
 
-	if _, ok := lo.ErrorsAs[plan.NotFoundError](err); ok {
+	if _, ok := lo.ErrorsAs[*plan.NotFoundError](err); ok {
 		return nil, subscription.PlanNotFoundError{
 			Key:     planKey,
 			Version: version,

--- a/openmeter/productcatalog/tax.go
+++ b/openmeter/productcatalog/tax.go
@@ -32,11 +32,7 @@ func (c *TaxConfig) Validate() error {
 		}
 	}
 
-	if len(errs) > 0 {
-		return errors.Join(errs...)
-	}
-
-	return nil
+	return NewValidationError(errors.Join(errs...))
 }
 
 var StripeProductTaxCodeRegexp = regexp.MustCompile(`^txcd_\d{8}$`)
@@ -62,7 +58,7 @@ func (s *StripeTaxConfig) Equal(v *StripeTaxConfig) bool {
 
 func (s *StripeTaxConfig) Validate() error {
 	if s.Code != "" && !StripeProductTaxCodeRegexp.MatchString(s.Code) {
-		return fmt.Errorf("invalid product tax code: %s", s.Code)
+		return NewValidationError(fmt.Errorf("invalid product tax code: %s", s.Code))
 	}
 
 	return nil

--- a/openmeter/productcatalog/tax_test.go
+++ b/openmeter/productcatalog/tax_test.go
@@ -31,7 +31,11 @@ func TestStripeTaxConfig(t *testing.T) {
 
 	for _, test := range tests {
 		err := test.TaxConfig.Validate()
-		assert.Equal(t, test.ExpectedError, err)
+		if test.ExpectedError == nil {
+			assert.NoError(t, err)
+		} else {
+			assert.EqualError(t, err, test.ExpectedError.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
## Overview

* use `ValidationError` to wrap validation errors
* rework Plan `NotFoundError` to capture additional metadata
