### PR TITLE
Testing data-migrations

### DIFF
--- a/atlas.hcl
+++ b/atlas.hcl
@@ -41,30 +41,6 @@ env "ci" {
   dev = "${local.ci_url}"
 }
 
-// CAN be used for all remote deployments
-env "remote" {
-  src = "${local.schema_src}"
-
-  migration {
-    // Define the directory where the migrations are stored.
-    dir = "file://tools/migrate/migrations"
-    // We use golang-migrate
-    format = "${local.migrations_format}"
-    // Remote deployments already had auto deploy present
-    baseline = "${local.init_migration_ts}"
-  }
-
-  format {
-    migrate {
-      diff = "{{ sql . \"  \" }}"
-    }
-  }
-
-  // Define the URL of the Dev Database for this environment
-  // See: https://atlasgo.io/concepts/dev-database
-  dev = "docker://postgres/15/dev?search_path=public"
-}
-
 locals {
     // Define the directory where the schema definition resides.
     schema_src = "ent://openmeter/ent/schema"

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -15,6 +15,14 @@ OpenMeter uses [atlas](https://atlasgo.io/) to generate versioned migrations fro
 
 After changing the schema and running `go generate` you can create a new migration diff via `atlas migrate --env local diff <migration-name>`, the generated migration files will be placed in the `migrations` directory.
 
+## Data Migrations
+
+Data migrations can be written alongside the schema migrations code.
+
+### Testing Data Migrations
+
+To test your data migrations in hypothetical scenarios, you can use the `tools/migrate` package to write assertions on how data changes after applying the migration. Examples can be found int the package.
+
 ## Running Migrations
 
 The recommended way to run migrations is to use the `golang-migrate` CLI tool. You can run the migrations via

--- a/openmeter/testutils/pg_driver.go
+++ b/openmeter/testutils/pg_driver.go
@@ -54,7 +54,6 @@ func (*NoopMigrator) Verify(
 type TestDB struct {
 	EntDriver *entdriver.EntPostgresDriver
 	PGDriver  *pgdriver.Driver
-	SQLDriver *sql.DB
 	URL       string
 }
 

--- a/tools/migrate/migrate_test.go
+++ b/tools/migrate/migrate_test.go
@@ -1,14 +1,19 @@
 package migrate_test
 
 import (
+	"database/sql"
 	"errors"
+	"slices"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/tools/migrate"
 )
 
-func TestUpDownUp(t *testing.T) {
+// The main test runner
+func TestMigrations(t *testing.T) {
 	testDB := testutils.InitPostgresDB(t)
 	defer testDB.PGDriver.Close()
 
@@ -25,15 +30,102 @@ func TestUpDownUp(t *testing.T) {
 		}
 	}()
 
+	// Let's go through all the stops
+	t.Logf("Running migrations with %d stops", len(breaks))
+
+	for _, stop := range breaks.ups() {
+		if err := migrator.Migrate(stop.version); err != nil {
+			t.Fatal(err)
+		}
+
+		stop.action(t, testDB.PGDriver.DB())
+	}
+
+	// We go till the very end either way
 	if err := migrator.Up(); err != nil {
 		t.Fatal(err)
+	}
+
+	for _, stop := range breaks.downs() {
+		if err := migrator.Migrate(stop.version); err != nil {
+			t.Fatal(err)
+		}
+
+		stop.action(t, testDB.PGDriver.DB())
 	}
 
 	if err := migrator.Down(); err != nil {
 		t.Fatal(err)
 	}
 
+	// Then let's go up again to make sure nothing's bricked
 	if err := migrator.Up(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// helpers
+
+const (
+	directionUp int = iota
+	directionDown
+)
+
+// Define the stops
+var breaks = stops{}
+
+type stop struct {
+	// The migration version AT WHICH the break occurs (after applied = inclusive)
+	version   uint
+	direction int
+	// We have to use the raw SQL connection as any ORM would only use the latest schema version
+	action func(t *testing.T, db *sql.DB)
+}
+
+type stops []stop
+
+func (s *stops) add(stops stops) {
+	n := append(*s, stops...)
+	*s = n
+}
+
+func TestAdd(t *testing.T) {
+	b := stops{}
+
+	b.add(stops{{
+		version:   1,
+		direction: directionUp,
+	}})
+
+	require.Equal(t, 1, len(b))
+}
+
+func (s stops) ups() stops {
+	var ups stops
+	for _, stop := range s {
+		if stop.direction == directionUp {
+			ups = append(ups, stop)
+		}
+	}
+
+	slices.SortStableFunc(ups, func(i, j stop) int {
+		return int(i.version) - int(j.version)
+	})
+
+	return ups
+}
+
+func (s stops) downs() stops {
+	var downs stops
+	for _, stop := range s {
+		if stop.direction == directionDown {
+			downs = append(downs, stop)
+		}
+	}
+
+	slices.SortStableFunc(downs, func(i, j stop) int {
+		return int(i.version) - int(j.version)
+	})
+
+	return downs
 }

--- a/tools/migrate/productcatalog_test.go
+++ b/tools/migrate/productcatalog_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func init() {
+func TestStartAfterChange(t *testing.T) {
 	// This is an example test adding a plan phase before start_after is changed to duration
 	// and asserting in the next step that it is in fact deleted as per the migration
-	breaks.add(stops{
+	runner{stops{
 		{
 			// before: 20241230152834_app_stripe_account_id_unique.up.sql
 			// after: 20250103121359_plan-phase-duration.up.sql
@@ -51,5 +51,5 @@ func init() {
 				require.Equal(t, 1, count)
 			},
 		},
-	})
+	}}.Test(t)
 }

--- a/tools/migrate/productcatalog_test.go
+++ b/tools/migrate/productcatalog_test.go
@@ -1,0 +1,55 @@
+package migrate_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	// This is an example test adding a plan phase before start_after is changed to duration
+	// and asserting in the next step that it is in fact deleted as per the migration
+	breaks.add(stops{
+		{
+			// before: 20241230152834_app_stripe_account_id_unique.up.sql
+			// after: 20250103121359_plan-phase-duration.up.sql
+			version:   20241230152834,
+			direction: directionUp,
+			action: func(t *testing.T, db *sql.DB) {
+				// As we're changing the phase duration format while there are existing plans present lets make sure thats not an issue
+				someUlid := ulid.Make()
+				_, err := db.Exec(`
+					INSERT INTO plans (namespace, id, name, key, version, created_at, updated_at)
+					VALUES ('default', $1, 'test', 'test', 1, NOW(), NOW())`,
+					someUlid.String(),
+				)
+				require.NoError(t, err)
+
+				_, err = db.Exec(`
+					INSERT INTO plan_phases (namespace, id, plan_id, name, key, start_after, created_at, updated_at)
+					VALUES ('default', $1, $2, 'default', 'default', 'P1M', NOW(), NOW())`,
+					ulid.Make().String(), someUlid.String(),
+				)
+				require.NoError(t, err)
+			},
+		},
+		{
+			// The version at which all phases are deleted: 20250103121359_plan-phase-duration.up.sql
+			version:   20250103121359,
+			direction: directionUp,
+			action: func(t *testing.T, db *sql.DB) {
+				var count int
+
+				res := db.QueryRow(`SELECT COUNT(*) FROM plan_phases`)
+				require.NoError(t, res.Scan(&count))
+				require.Equal(t, 0, count)
+
+				res = db.QueryRow(`SELECT COUNT(*) FROM plans`)
+				require.NoError(t, res.Scan(&count))
+				require.Equal(t, 1, count)
+			},
+		},
+	})
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Adds some simple tooling in `tools/migrate` so that during our migration test we can stop at specific versions and make modifications & assertions on the database state. This enables testing what happens to already present data after a migration. An example for the `start_after` => `duration` migration is added to demonstrate the concept and the recommended structure of adding such tests.

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
<!-- Anything the reviewer should know? -->
