### PR TITLE
fix: watermill retry logic and error reporting

### DIFF
--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -138,6 +138,7 @@ func TestComplete(t *testing.T) {
 				ConsumerConfiguration: ConsumerConfiguration{
 					ProcessingTimeout: 30 * time.Second,
 					Retry: RetryConfiguration{
+						MaxRetries:      10,
 						InitialInterval: 10 * time.Millisecond,
 						MaxInterval:     time.Second,
 						MaxElapsedTime:  time.Minute,
@@ -287,6 +288,7 @@ func TestComplete(t *testing.T) {
 			ConsumerConfiguration: ConsumerConfiguration{
 				ProcessingTimeout: 30 * time.Second,
 				Retry: RetryConfiguration{
+					MaxRetries:      10,
 					InitialInterval: 10 * time.Millisecond,
 					MaxInterval:     time.Second,
 					MaxElapsedTime:  time.Minute,
@@ -307,6 +309,7 @@ func TestComplete(t *testing.T) {
 			Consumer: ConsumerConfiguration{
 				ProcessingTimeout: 30 * time.Second,
 				Retry: RetryConfiguration{
+					MaxRetries:      10,
 					InitialInterval: 10 * time.Millisecond,
 					MaxInterval:     time.Second,
 					MaxElapsedTime:  time.Minute,

--- a/app/config/events.go
+++ b/app/config/events.go
@@ -185,13 +185,17 @@ func (c RetryConfiguration) Validate() error {
 		errs = append(errs, errors.New("max interval must be greater than 0"))
 	}
 
+	if c.MaxElapsedTime > 0 && c.MaxRetries == 0 {
+		errs = append(errs, errors.New("max elapsed time is set but max retries is disabled, set max retries to enable retries"))
+	}
+
 	return errors.Join(errs...)
 }
 
 func ConfigureConsumer(v *viper.Viper, prefix string) {
 	v.SetDefault(prefix+".processingTimeout", 30*time.Second)
 
-	v.SetDefault(prefix+".retry.maxRetries", 0)
+	v.SetDefault(prefix+".retry.maxRetries", 10)
 	v.SetDefault(prefix+".retry.initialInterval", 10*time.Millisecond)
 	v.SetDefault(prefix+".retry.maxInterval", time.Second)
 	v.SetDefault(prefix+".retry.maxElapsedTime", time.Minute)

--- a/openmeter/watermill/router/logger.go
+++ b/openmeter/watermill/router/logger.go
@@ -1,0 +1,41 @@
+package router
+
+import (
+	"log/slog"
+
+	"github.com/ThreeDotsLabs/watermill"
+)
+
+// warningOnlyLogger is a logger that logs errors as warnings instead of errors.
+// unfortunately, watermill only supports error and info level logging.
+type warningOnlyLogger struct {
+	watermill.LoggerAdapter
+
+	logger *slog.Logger
+}
+
+func newWarningOnlyLogger(logger *slog.Logger) watermill.LoggerAdapter {
+	return warningOnlyLogger{LoggerAdapter: watermill.NewSlogLogger(logger), logger: logger}
+}
+
+func (l warningOnlyLogger) With(fields watermill.LogFields) watermill.LoggerAdapter {
+	logger := l.logger.With(l.slogAttrsFromFields(fields)...)
+
+	return warningOnlyLogger{LoggerAdapter: watermill.NewSlogLogger(logger), logger: logger}
+}
+
+func (l warningOnlyLogger) slogAttrsFromFields(fields watermill.LogFields) []interface{} {
+	args := make([]any, 0, len(fields)*2+2)
+
+	for k, v := range fields {
+		args = append(args, k, v)
+	}
+
+	return args
+}
+
+func (l warningOnlyLogger) Error(msg string, err error, fields watermill.LogFields) {
+	args := append(l.slogAttrsFromFields(fields), "error", err)
+
+	l.logger.Warn(msg, args...)
+}

--- a/openmeter/watermill/router/router.go
+++ b/openmeter/watermill/router/router.go
@@ -87,7 +87,7 @@ func NewDefaultRouter(opts Options) (*message.Router, error) {
 
 		Multiplier:          1.5,
 		RandomizationFactor: 0.25,
-		Logger:              watermill.NewSlogLogger(opts.Logger),
+		Logger:              newWarningOnlyLogger(opts.Logger),
 	}.Middleware)
 
 	// This should be after Retry, so that we can retry on timeouts before pushing to DLQ


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch ensures that the max retires is set, if we have a retry timeout, as without the max retries watermill would never retry.

Given that in our use-case we also have DLQ, that would print an error if a final issue happens, we decrease the severity of a retry message to warning.