### PR TITLE
feat: disallow durations less than an hour

### DIFF
--- a/openmeter/entitlement/scheduling.go
+++ b/openmeter/entitlement/scheduling.go
@@ -20,12 +20,8 @@ func (c *entitlementConnector) ScheduleEntitlement(ctx context.Context, input Cr
 	return transaction.Run(ctx, c.entitlementRepo, func(ctx context.Context) (*Entitlement, error) {
 		activeFromTime := defaultx.WithDefault(input.ActiveFrom, clock.Now())
 
-		if input.ActiveTo != nil && input.ActiveFrom == nil {
-			return nil, &models.GenericUserError{Inner: fmt.Errorf("ActiveFrom must be set if ActiveTo is set")}
-		}
-		// We can allow an active period of 0 (ActiveFrom = ActiveTo)
-		if input.ActiveTo != nil && input.ActiveTo.Before(activeFromTime) {
-			return nil, &models.GenericUserError{Inner: fmt.Errorf("ActiveTo cannot be before ActiveFrom")}
+		if err := input.Validate(); err != nil {
+			return nil, &models.GenericUserError{Inner: err}
 		}
 
 		// ID has priority over key

--- a/openmeter/productcatalog/phase.go
+++ b/openmeter/productcatalog/phase.go
@@ -69,8 +69,15 @@ func (p PhaseMeta) Validate() error {
 		errs = append(errs, errors.New("missing Name"))
 	}
 
-	if p.Duration != nil && p.Duration.IsNegative() {
-		errs = append(errs, fmt.Errorf("the Duration period must not be negative"))
+	if p.Duration != nil {
+		if p.Duration.IsNegative() {
+			errs = append(errs, fmt.Errorf("the Duration period must not be negative"))
+		}
+
+		// The duration must be at least 1 hour.
+		if per, err := p.Duration.Subtract(datex.NewPeriod(0, 0, 0, 0, 1, 0, 0)); err == nil && per.Sign() == -1 {
+			errs = append(errs, fmt.Errorf("the Duration period must be at least 1 hour"))
+		}
 	}
 
 	return NewValidationError(errors.Join(errs...))

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -222,6 +222,11 @@ func (r *FlatFeeRateCard) Validate() error {
 		if r.BillingCadence.IsNegative() || r.BillingCadence.IsZero() {
 			errs = append(errs, errors.New("invalid BillingCadence: must not be negative or zero"))
 		}
+
+		// Billing Cadence has to be at least 1 ohur
+		if per, err := r.BillingCadence.Subtract(datex.NewPeriod(0, 0, 0, 0, 1, 0, 0)); err == nil && per.Sign() == -1 {
+			errs = append(errs, errors.New("invalid BillingCadence: must be at least 1 hour"))
+		}
 	}
 
 	return NewValidationError(errors.Join(errs...))
@@ -303,6 +308,11 @@ func (r *UsageBasedRateCard) Validate() error {
 
 	if r.BillingCadence.IsNegative() || r.BillingCadence.IsZero() {
 		errs = append(errs, errors.New("invalid BillingCadence: must not be negative or zero"))
+	}
+
+	// Billing Cadence has to be at least 1 ohur
+	if per, err := r.BillingCadence.Subtract(datex.NewPeriod(0, 0, 0, 0, 1, 0, 0)); err == nil && per.Sign() == -1 {
+		errs = append(errs, errors.New("invalid BillingCadence: must be at least 1 hour"))
 	}
 
 	return NewValidationError(errors.Join(errs...))


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Disallow creating Plans & Entitlements with durations less than 1 hour

## Notes for reviewer

- The PlanPhase & RateCard validation is the same between create & otherwise assertion. Due to this if there were previous phases shorter than 1h those would always error afterwards. In our environments there **aren no** such entries.
