### PR TITLE
Fix Subscription Managed Entitlements

### DIFF
--- a/openmeter/entitlement/boolean/connector.go
+++ b/openmeter/entitlement/boolean/connector.go
@@ -53,16 +53,17 @@ func (c *connector) BeforeCreate(model entitlement.CreateEntitlementInputs, feat
 	}
 
 	return &entitlement.CreateEntitlementRepoInputs{
-		Namespace:          model.Namespace,
-		FeatureID:          feature.ID,
-		FeatureKey:         feature.Key,
-		SubjectKey:         model.SubjectKey,
-		EntitlementType:    model.EntitlementType,
-		Metadata:           model.Metadata,
-		UsagePeriod:        model.UsagePeriod,
-		CurrentUsagePeriod: currentUsagePeriod,
-		ActiveFrom:         model.ActiveFrom,
-		ActiveTo:           model.ActiveTo,
+		Namespace:           model.Namespace,
+		FeatureID:           feature.ID,
+		FeatureKey:          feature.Key,
+		SubjectKey:          model.SubjectKey,
+		EntitlementType:     model.EntitlementType,
+		Metadata:            model.Metadata,
+		UsagePeriod:         model.UsagePeriod,
+		CurrentUsagePeriod:  currentUsagePeriod,
+		ActiveFrom:          model.ActiveFrom,
+		ActiveTo:            model.ActiveTo,
+		SubscriptionManaged: model.SubscriptionManaged,
 	}, nil
 }
 

--- a/openmeter/entitlement/metered/connector.go
+++ b/openmeter/entitlement/metered/connector.go
@@ -176,6 +176,7 @@ func (c *connector) BeforeCreate(model entitlement.CreateEntitlementInputs, feat
 		PreserveOverageAtReset:  model.PreserveOverageAtReset,
 		ActiveFrom:              model.ActiveFrom,
 		ActiveTo:                model.ActiveTo,
+		SubscriptionManaged:     model.SubscriptionManaged,
 	}, nil
 }
 

--- a/openmeter/entitlement/static/connector.go
+++ b/openmeter/entitlement/static/connector.go
@@ -69,17 +69,18 @@ func (c *connector) BeforeCreate(model entitlement.CreateEntitlementInputs, feat
 	}
 
 	return &entitlement.CreateEntitlementRepoInputs{
-		Namespace:          model.Namespace,
-		FeatureID:          feature.ID,
-		FeatureKey:         feature.Key,
-		SubjectKey:         model.SubjectKey,
-		EntitlementType:    model.EntitlementType,
-		Metadata:           model.Metadata,
-		UsagePeriod:        model.UsagePeriod,
-		CurrentUsagePeriod: currentUsagePeriod,
-		Config:             model.Config,
-		ActiveFrom:         model.ActiveFrom,
-		ActiveTo:           model.ActiveTo,
+		Namespace:           model.Namespace,
+		FeatureID:           feature.ID,
+		FeatureKey:          feature.Key,
+		SubjectKey:          model.SubjectKey,
+		EntitlementType:     model.EntitlementType,
+		Metadata:            model.Metadata,
+		UsagePeriod:         model.UsagePeriod,
+		CurrentUsagePeriod:  currentUsagePeriod,
+		Config:              model.Config,
+		ActiveFrom:          model.ActiveFrom,
+		ActiveTo:            model.ActiveTo,
+		SubscriptionManaged: model.SubscriptionManaged,
 	}, nil
 }
 

--- a/openmeter/subscription/testutils/compare.go
+++ b/openmeter/subscription/testutils/compare.go
@@ -90,6 +90,9 @@ func ValidateSpecAndView(t *testing.T, expected subscription.SubscriptionSpec, f
 					entInp := ent.ToScheduleSubscriptionEntitlementInput()
 					assert.Equal(t, rcEnt.Type(), entInp.CreateEntitlementInputs.GetType())
 
+					// Let's validate that the Entitlement is marked as SubscriptionManaged
+					assert.True(t, foundItem.Entitlement.Entitlement.SubscriptionManaged)
+
 					// Let's validate that the UsagePeriod is aligned
 					require.NotNil(t, specItem.RateCard.EntitlementTemplate)
 					period := GetEntitlementTemplateUsagePeriod(t, *specItem.RateCard.EntitlementTemplate)
@@ -116,6 +119,9 @@ func ValidateSpecAndView(t *testing.T, expected subscription.SubscriptionSpec, f
 						require.NotNil(t, ent.Entitlement.ActiveTo)
 						assert.Equal(t, nextPhaseStart.UTC(), *ent.Entitlement.ActiveTo)
 					}
+				} else {
+					// If an entitlement wasn't defined then there shouldn't be an entitlement
+					assert.Nil(t, foundItem.Entitlement)
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview
Due to missing mappings Subscription Managed entitlements could be deleted which bricked the entire subscription afterwards.

## Notes for reviewer
To heal any broken entitlements in the DB this query can be run (there are non in our environments right now)
```sql
UPDATE entitlements 
SET subscription_managed = true 
FROM (
  SELECT entitlement_id FROM subscription_items WHERE entitlement_id IS NOT NULL
) AS items 
WHERE items.entitlement_id = entitlements.id;
```

<!-- Anything the reviewer should know? -->
