### PR TITLE
fix(stripe): set webhook api version

### DIFF
--- a/openmeter/app/stripe/client/client.go
+++ b/openmeter/app/stripe/client/client.go
@@ -93,6 +93,10 @@ func (c *stripeClient) SetupWebhook(ctx context.Context, input SetupWebhookInput
 			SetupIntentDataMetadataNamespace: input.AppID.Namespace,
 			SetupIntentDataMetadataAppID:     input.AppID.ID,
 		},
+		// We set the API version to a specific date to ensure that
+		// the webhook is compatible with the Stripe client's API version.
+		// https://docs.stripe.com/sdks/set-version
+		APIVersion: lo.ToPtr(stripe.APIVersion),
 	}
 	result, err := c.client.WebhookEndpoints.New(params)
 	if err != nil {


### PR DESCRIPTION
Set Stripe webhook api version to avoid:

```
failed to construct webhook event: Received event with API version 2023-10-16, but stripe-go 80.2.1 expects API version 2024-09-30.acacia. We recommend that you create a WebhookEndpoint with this API version. Otherwise, you can disable this error by using `ConstructEventWithOptions(..., ConstructEventOptions{..., ignoreAPIVersionMismatch: true})`  but be wary that objects may be incorrectly deserialized.
```