### PR TITLE
fix(e2e): increase timeout

### DIFF
--- a/e2e/entitlement_test.go
+++ b/e2e/entitlement_test.go
@@ -133,7 +133,7 @@ func TestEntitlementWithUniqueCountAggregation(t *testing.T) {
 
 			require.Len(t, resp.JSON200.Data, 1)
 			assert.Equal(t, float64(uniqueEventCount), resp.JSON200.Data[0].Value)
-		}, time.Minute, time.Second)
+		}, 2*time.Minute, time.Second)
 	})
 
 	t.Run("Should calculate usage correctly", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Increases assertion timeout from 1 min to 2 as theoretically it was possible that not all events fell in the current minute period.

## Notes for reviewer

The above theoretical doesn't explain the real life experience that when the test fails no events are registered.

<!-- Anything the reviewer should know? -->
