### PR TITLE
feat: implement subscription line adding on invoice creation

### DIFF
--- a/app/common/billing.go
+++ b/app/common/billing.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 )
 
 var Billing = wire.NewSet(
@@ -45,6 +46,7 @@ func BillingService(
 	featureConnector feature.FeatureConnector,
 	meterRepo meter.Repository,
 	streamingConnector streaming.Connector,
+	eventPublisher eventbus.Publisher,
 ) (billing.Service, error) {
 	if !billingConfig.Enabled {
 		return nil, nil
@@ -58,6 +60,7 @@ func BillingService(
 		Logger:             logger,
 		MeterRepo:          meterRepo,
 		StreamingConnector: streamingConnector,
+		Publisher:          eventPublisher,
 	})
 }
 

--- a/app/common/openmeter_billingworker.go
+++ b/app/common/openmeter_billingworker.go
@@ -27,7 +27,9 @@ var BillingWorker = wire.NewSet(
 	BillingWorkerProvisionTopics,
 	BillingWorkerSubscriber,
 
-	NewFeatureConnector,
+	Subscription,
+	ProductCatalog,
+	Entitlement,
 	BillingAdapter,
 	BillingService,
 
@@ -69,16 +71,18 @@ func NewBillingWorkerOptions(
 	eventBus eventbus.Publisher,
 	billingService billing.Service,
 	billingAdapter billing.Adapter,
+	subscriptionServices SubscriptionServiceWithWorkflow,
 	logger *slog.Logger,
 ) billingworker.WorkerOptions {
 	return billingworker.WorkerOptions{
 		SystemEventsTopic: eventConfig.SystemEvents.Topic,
 
-		Router:         routerOptions,
-		EventBus:       eventBus,
-		BillingService: billingService,
-		BillingAdapter: billingAdapter,
-		Logger:         logger,
+		Router:              routerOptions,
+		EventBus:            eventBus,
+		BillingService:      billingService,
+		BillingAdapter:      billingAdapter,
+		SubscriptionService: subscriptionServices.Service,
+		Logger:              logger,
 	}
 }
 

--- a/app/common/openmeter_server.go
+++ b/app/common/openmeter_server.go
@@ -79,7 +79,6 @@ func NewIngestCollector(
 
 func NewServerPublisher(
 	ctx context.Context,
-	conf config.EventsConfiguration,
 	options watermillkafka.PublisherOptions,
 	logger *slog.Logger,
 ) (message.Publisher, func(), error) {

--- a/openmeter/app/entity/base/app.go
+++ b/openmeter/app/entity/base/app.go
@@ -37,11 +37,11 @@ const (
 type AppBase struct {
 	models.ManagedResource
 
-	Type     AppType
-	Status   AppStatus
-	Default  bool
-	Listing  MarketplaceListing
-	Metadata map[string]string
+	Type     AppType            `json:"type"`
+	Status   AppStatus          `json:"status"`
+	Default  bool               `json:"default"`
+	Listing  MarketplaceListing `json:"listing"`
+	Metadata map[string]string  `json:"metadata,omitempty"`
 }
 
 func (a AppBase) GetAppBase() AppBase {

--- a/openmeter/billing/adapter/validationissue.go
+++ b/openmeter/billing/adapter/validationissue.go
@@ -89,8 +89,8 @@ func (a *adapter) persistValidationIssues(ctx context.Context, invoice billing.I
 type ValidationIssueWithDBMeta struct {
 	billing.ValidationIssue
 
-	ID        string
-	DeletedAt *time.Time
+	ID        string     `json:"id"`
+	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 }
 
 // IntropectValidationIssues returns the validation issues for the given invoice, this is not

--- a/openmeter/billing/events.go
+++ b/openmeter/billing/events.go
@@ -1,0 +1,36 @@
+package billing
+
+import (
+	"github.com/openmeterio/openmeter/openmeter/event/metadata"
+)
+
+const (
+	EventSubsystem metadata.EventSubsystem = "billing"
+)
+
+type InvoiceCreatedEvent struct {
+	Invoice `json:",inline"`
+}
+
+func NewInvoiceCreatedEvent(invoice Invoice) InvoiceCreatedEvent {
+	return InvoiceCreatedEvent{invoice.RemoveCircularReferences()}
+}
+
+func (e InvoiceCreatedEvent) EventName() string {
+	return metadata.GetEventName(metadata.EventType{
+		Subsystem: EventSubsystem,
+		Name:      "invoice.created",
+		Version:   "v1",
+	})
+}
+
+func (e InvoiceCreatedEvent) EventMetadata() metadata.EventMetadata {
+	return metadata.EventMetadata{
+		Source:  metadata.ComposeResourcePath(e.Namespace, metadata.EntityInvoice, e.ID),
+		Subject: metadata.ComposeResourcePath(e.Namespace, metadata.EntityCustomer, e.Customer.CustomerID),
+	}
+}
+
+func (e InvoiceCreatedEvent) Validate() error {
+	return e.Invoice.Validate()
+}

--- a/openmeter/billing/profile.go
+++ b/openmeter/billing/profile.go
@@ -39,7 +39,7 @@ type WorkflowConfig struct {
 
 	CreatedAt time.Time  `json:"createdAt"`
 	UpdatedAt time.Time  `json:"updatedAt"`
-	DeletedAt *time.Time `json:"deletedAt"`
+	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 
 	Collection CollectionConfig `json:"collection"`
 	Invoicing  InvoicingConfig  `json:"invoicing"`
@@ -134,7 +134,7 @@ func (r GranularityResolution) Values() []string {
 }
 
 type PaymentConfig struct {
-	CollectionMethod CollectionMethod
+	CollectionMethod CollectionMethod `json:"collectionMethod"`
 }
 
 func (c *PaymentConfig) Validate() error {

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -302,6 +302,14 @@ func (s *Service) InvoicePendingLines(ctx context.Context, input billing.Invoice
 
 				out = append(out, invoice)
 			}
+
+			for _, invoice := range out {
+				err := s.publisher.Publish(ctx, billing.NewInvoiceCreatedEvent(invoice))
+				if err != nil {
+					return nil, fmt.Errorf("publishing event: %w", err)
+				}
+			}
+
 			return out, nil
 		})
 }

--- a/openmeter/billing/service/service.go
+++ b/openmeter/billing/service/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
 
@@ -31,6 +32,7 @@ type Service struct {
 	streamingConnector streaming.Connector
 
 	lineService *lineservice.Service
+	publisher   eventbus.Publisher
 }
 
 type Config struct {
@@ -41,6 +43,7 @@ type Config struct {
 	FeatureService     feature.FeatureConnector
 	MeterRepo          meter.Repository
 	StreamingConnector streaming.Connector
+	Publisher          eventbus.Publisher
 }
 
 func (c Config) Validate() error {
@@ -72,6 +75,10 @@ func (c Config) Validate() error {
 		return errors.New("streaming connector cannot be null")
 	}
 
+	if c.Publisher == nil {
+		return errors.New("publisher cannot be null")
+	}
+
 	return nil
 }
 
@@ -88,6 +95,7 @@ func New(config Config) (*Service, error) {
 		featureService:     config.FeatureService,
 		meterRepo:          config.MeterRepo,
 		streamingConnector: config.StreamingConnector,
+		publisher:          config.Publisher,
 	}
 
 	lineSvc, err := lineservice.New(lineservice.Config{

--- a/openmeter/billing/worker/subscription/sync.go
+++ b/openmeter/billing/worker/subscription/sync.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 	"github.com/openmeterio/openmeter/pkg/timex"
 )
@@ -30,15 +31,20 @@ type FeatureFlags struct {
 }
 
 type Config struct {
-	BillingService billing.Service
-	TxCreator      transaction.Creator
-	Logger         *slog.Logger
-	FeatureFlags   FeatureFlags
+	BillingService      billing.Service
+	SubscriptionService subscription.Service
+	TxCreator           transaction.Creator
+	Logger              *slog.Logger
+	FeatureFlags        FeatureFlags
 }
 
 func (c Config) Validate() error {
 	if c.BillingService == nil {
 		return fmt.Errorf("billing service is required")
+	}
+
+	if c.SubscriptionService == nil {
+		return fmt.Errorf("subscription service is required")
 	}
 
 	if c.TxCreator == nil {
@@ -53,10 +59,11 @@ func (c Config) Validate() error {
 }
 
 type Handler struct {
-	billingService billing.Service
-	txCreator      transaction.Creator
-	logger         *slog.Logger
-	featureFlags   FeatureFlags
+	billingService      billing.Service
+	subscriptionService subscription.Service
+	txCreator           transaction.Creator
+	logger              *slog.Logger
+	featureFlags        FeatureFlags
 }
 
 func New(config Config) (*Handler, error) {
@@ -64,10 +71,11 @@ func New(config Config) (*Handler, error) {
 		return nil, err
 	}
 	return &Handler{
-		billingService: config.BillingService,
-		txCreator:      config.TxCreator,
-		logger:         config.Logger,
-		featureFlags:   config.FeatureFlags,
+		billingService:      config.BillingService,
+		txCreator:           config.TxCreator,
+		logger:              config.Logger,
+		featureFlags:        config.FeatureFlags,
+		subscriptionService: config.SubscriptionService,
 	}, nil
 }
 
@@ -765,4 +773,41 @@ func (h *Handler) cloneLineForUpsert(line *billing.Line) *billing.Line {
 	// We need to maintain the parent line relationship, so that we can update the qty snapshots on updated usage-based lines
 	clone.ParentLine = line.ParentLine
 	return clone
+}
+
+// HandleInvoiceCreation is a handler for the invoice creation event, it will make sure that
+// we are backfilling the items consumed by invoice creation into the gathering invoice.
+func (h *Handler) HandleInvoiceCreation(ctx context.Context, invoice billing.Invoice) error {
+	if invoice.Status == billing.InvoiceStatusGathering {
+		return nil
+	}
+
+	affectedSubscriptions := lo.Uniq(
+		lo.Map(
+			lo.Filter(invoice.Lines.OrEmpty(), func(line *billing.Line, _ int) bool {
+				return line.Status == billing.InvoiceLineStatusValid &&
+					line.Subscription != nil
+			}),
+			func(line *billing.Line, _ int) string {
+				return line.Subscription.SubscriptionID
+			}),
+	)
+
+	for _, subscriptionID := range affectedSubscriptions {
+		subsView, err := h.subscriptionService.GetView(ctx, models.NamespacedID{
+			Namespace: invoice.Namespace,
+			ID:        subscriptionID,
+		})
+		if err != nil {
+			return fmt.Errorf("getting subscription view[%s]: %w", subscriptionID, err)
+		}
+
+		// We use the current time as reference point instead of the invoice, as if we are delayed
+		// we might want to provision more lines
+		if err := h.SyncronizeSubscription(ctx, subsView, clock.Now()); err != nil {
+			return fmt.Errorf("syncing subscription[%s]: %w", subscriptionID, err)
+		}
+	}
+
+	return nil
 }

--- a/openmeter/billing/worker/subscription/sync_test.go
+++ b/openmeter/billing/worker/subscription/sync_test.go
@@ -114,9 +114,10 @@ func (s *SubscriptionHandlerTestSuite) SetupSuite() {
 	})
 
 	handler, err := New(Config{
-		BillingService: s.BillingService,
-		Logger:         slog.Default(),
-		TxCreator:      s.BillingAdapter,
+		BillingService:      s.BillingService,
+		Logger:              slog.Default(),
+		TxCreator:           s.BillingAdapter,
+		SubscriptionService: s.SubscriptionService,
 	})
 	s.NoError(err)
 

--- a/openmeter/customer/entity/customer.go
+++ b/openmeter/customer/entity/customer.go
@@ -89,7 +89,7 @@ func (i CustomerID) Validate() error {
 
 // CustomerUsageAttribution represents the usage attribution for a customer
 type CustomerUsageAttribution struct {
-	SubjectKeys []string
+	SubjectKeys []string `json:"subjectKeys"`
 }
 
 // ListCustomersInput represents the input for the ListCustomers method

--- a/openmeter/event/metadata/resourcepath.go
+++ b/openmeter/event/metadata/resourcepath.go
@@ -9,6 +9,7 @@ import (
 const (
 	EntityEntitlement  = "entitlement"
 	EntitySubscription = "subscription"
+	EntityInvoice      = "invoice"
 	EntityCustomer     = "customer"
 	EntitySubjectKey   = "subjectKey"
 	EntityGrant        = "grant"

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/tools/migrate"
@@ -145,6 +146,7 @@ func (s *BaseSuite) SetupSuite() {
 		FeatureService:     s.FeatureService,
 		MeterRepo:          s.MeterRepo,
 		StreamingConnector: s.MockStreamingConnector,
+		Publisher:          eventbus.NewMock(s.T()),
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

The subscription -> billing sync is designed in a way, that we are feeding the billing with new lines when needed. There are two conditions that would necessitate such a synchronization:
- Something changes in a subscription (it's already implemented)
- We bill our customers (as then the gathering invoice's items are removed/consumed, so we need to backfill it)

For this we are relying on the eventbus.

## Example invoice created event

```json
{
	"specversion": "1.0",
	"id": "01JHTC8JNMKD60E3NVTSQ7KFJ1",
	"source": "//openmeter.io/namespace/default/invoice/01JHTC8JMWTD0BEWYBA1SCSSZP",
	"type": "io.openmeter.billing.v1.invoice.created",
	"subject": "//openmeter.io/namespace/default/customer/01JHTC8C2S00P0HF8730DPWEKF",
	"datacontenttype": "application/json",
	"time": "2025-01-17T14:56:48.820492Z",
	"data": {
		"namespace": "default",
		"id": "01JHTC8JMWTD0BEWYBA1SCSSZP",
		"type": "standard",
		"metadata": null,
		"currency": "USD",
		"status": "gathering",
		"statusDetail": {
			"immutable": false,
			"failed": false,
			"availableActions": {
				"invoice": {}
			}
		},
		"createdAt": "2025-01-17T14:56:48.79654Z",
		"updatedAt": "2025-01-17T14:56:48.79654Z",
		"customer": {
			"customerId": "01JHTC8C2S00P0HF8730DPWEKF",
			"name": "test",
			"billingAddress": {
				"country": "EI"
			},
			"usageAttribution": {
				"subjectKeys": [
					"test4"
				]
			}
		},
		"supplier": {
			"id": "",
			"name": "OpenMeter",
			"address": {
				"country": "US"
			}
		},
		"workflow": {
			"appReferences": {
				"tax": {
					"id": "01JHFKEVDRTSTS47RMT3HHGRF2",
					"type": ""
				},
				"invoicing": {
					"id": "01JHFKEVDRTSTS47RMT3HHGRF2",
					"type": ""
				},
				"payment": {
					"id": "01JHFKEVDRTSTS47RMT3HHGRF2",
					"type": ""
				}
			},
			"apps": {
				"tax": {
					"createdAt": "2025-01-13T10:30:55.672132Z",
					"updatedAt": "2025-01-13T10:30:55.672133Z",
					"id": "01JHFKEVDRTSTS47RMT3HHGRF2",
					"description": "OpenMeter Sandbox App to be used for testing purposes.",
					"name": "Sandbox",
					"type": "sandbox",
					"status": "ready",
					"default": true,
					"listing": {
						"type": "sandbox",
						"name": "Sandbox",
						"description": "Sandbox can be used to test OpenMeter without external connections.",
						"capabilities": [
							{
								"type": "collectPayments",
								"key": "sandbox_collect_payment",
								"name": "Payment",
								"description": "Process payments"
							},
							{
								"type": "calculateTax",
								"key": "sandbox_calculate_tax",
								"name": "Calculate Tax",
								"description": "Calculate tax for a payment"
							},
							{
								"type": "invoiceCustomers",
								"key": "sandbox_invoice_customer",
								"name": "Invoice Customer",
								"description": "Invoice a customer"
							}
						]
					}
				},
				"invoicing": {
					"createdAt": "2025-01-13T10:30:55.672132Z",
					"updatedAt": "2025-01-13T10:30:55.672133Z",
					"id": "01JHFKEVDRTSTS47RMT3HHGRF2",
					"description": "OpenMeter Sandbox App to be used for testing purposes.",
					"name": "Sandbox",
					"type": "sandbox",
					"status": "ready",
					"default": true,
					"listing": {
						"type": "sandbox",
						"name": "Sandbox",
						"description": "Sandbox can be used to test OpenMeter without external connections.",
						"capabilities": [
							{
								"type": "collectPayments",
								"key": "sandbox_collect_payment",
								"name": "Payment",
								"description": "Process payments"
							},
							{
								"type": "calculateTax",
								"key": "sandbox_calculate_tax",
								"name": "Calculate Tax",
								"description": "Calculate tax for a payment"
							},
							{
								"type": "invoiceCustomers",
								"key": "sandbox_invoice_customer",
								"name": "Invoice Customer",
								"description": "Invoice a customer"
							}
						]
					}
				},
				"payment": {
					"createdAt": "2025-01-13T10:30:55.672132Z",
					"updatedAt": "2025-01-13T10:30:55.672133Z",
					"id": "01JHFKEVDRTSTS47RMT3HHGRF2",
					"description": "OpenMeter Sandbox App to be used for testing purposes.",
					"name": "Sandbox",
					"type": "sandbox",
					"status": "ready",
					"default": true,
					"listing": {
						"type": "sandbox",
						"name": "Sandbox",
						"description": "Sandbox can be used to test OpenMeter without external connections.",
						"capabilities": [
							{
								"type": "collectPayments",
								"key": "sandbox_collect_payment",
								"name": "Payment",
								"description": "Process payments"
							},
							{
								"type": "calculateTax",
								"key": "sandbox_calculate_tax",
								"name": "Calculate Tax",
								"description": "Calculate tax for a payment"
							},
							{
								"type": "invoiceCustomers",
								"key": "sandbox_invoice_customer",
								"name": "Invoice Customer",
								"description": "Invoice a customer"
							}
						]
					}
				}
			},
			"sourceBillingProfileId": "01JHFKEVEAPT19NSEW0PVYW0YQ",
			"config": {
				"id": "01JHTC8JMVNCSKKZAVYAENFPRM",
				"createdAt": "2025-01-17T14:56:48.795307Z",
				"updatedAt": "2025-01-17T14:56:48.795308Z",
				"collection": {
					"alignment": "subscription",
					"period": "PT2H"
				},
				"invoicing": {
					"autoAdvance": true,
					"draftPeriod": "P1D",
					"dueAfter": "P1W"
				},
				"payment": {
					"collectionMethod": "charge_automatically"
				}
			}
		},
		"externalIds": {},
		"lines": [
			{
				"namespace": "default",
				"id": "01JHTC8JN1WC2YEMB0MAGSRDJP",
				"createdAt": "2025-01-17T14:56:48.801948Z",
				"updatedAt": "2025-01-17T14:56:48.801948Z",
				"metadata": {},
				"name": "test",
				"type": "usage_based",
				"invoiceID": "01JHTC8JMWTD0BEWYBA1SCSSZP",
				"currency": "USD",
				"period": {
					"start": "2025-01-17T09:05:00Z",
					"end": "2025-01-17T10:05:00Z"
				},
				"invoiceAt": "2025-01-17T10:05:39Z",
				"status": "valid",
				"externalIDs": {},
				"totals": {
					"amount": "0",
					"chargesTotal": "0",
					"discountsTotal": "0",
					"taxesInclusiveTotal": "0",
					"taxesExclusiveTotal": "0",
					"taxesTotal": "0",
					"total": "0"
				},
				"usageBased": {
					"configId": "01JHTC8JN0XGZ29E3HA59EXCCP",
					"price": {
						"type": "unit",
						"amount": "1.1"
					},
					"featureKey": "api_requests_total",
					"quantity": null
				},
				"children": [],
				"discounts": []
			}
		],
		"discounts": null,
		"totals": {
			"amount": "0",
			"chargesTotal": "0",
			"discountsTotal": "0",
			"taxesInclusiveTotal": "0",
			"taxesExclusiveTotal": "0",
			"taxesTotal": "0",
			"total": "0"
		}
	}
}
```