### PR TITLE
feat: Tiered price's first bucket's flat fee is always billed

### DIFF
--- a/openmeter/billing/service/lineservice/usagebasedline.go
+++ b/openmeter/billing/service/lineservice/usagebasedline.go
@@ -650,7 +650,7 @@ func tieredPriceCalculator(in tieredPriceCalculatorInput) error {
 
 	previousTierQty := alpacadecimal.Zero
 	for idx, tier := range in.TieredPrice.WithSortedTiers().Tiers {
-		if previousTierQty.GreaterThanOrEqual(in.ToQty) {
+		if previousTierQty.GreaterThan(in.ToQty) {
 			// We already have enough data to bill for this tiered price
 			break
 		}

--- a/openmeter/billing/service/lineservice/usagebasedline_test.go
+++ b/openmeter/billing/service/lineservice/usagebasedline_test.go
@@ -839,7 +839,15 @@ func TestTieredGraduatedCalculation(t *testing.T) {
 			usage: featureUsageResponse{
 				LinePeriodQty: alpacadecimal.NewFromFloat(0),
 			},
-			expect: newDetailedLinesInput{},
+			expect: newDetailedLinesInput{
+				{
+					Name:                   "feature: flat price for tier 1",
+					PerUnitAmount:          alpacadecimal.NewFromFloat(100),
+					Quantity:               alpacadecimal.NewFromFloat(1),
+					ChildUniqueReferenceID: "graduated-tiered-1-flat-price",
+					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+				},
+			},
 		})
 	})
 
@@ -932,8 +940,15 @@ func TestTieredGraduatedCalculation(t *testing.T) {
 			},
 			expect: newDetailedLinesInput{
 				{
+					Name:                   "feature: flat price for tier 1",
+					PerUnitAmount:          alpacadecimal.NewFromFloat(100),
+					Quantity:               alpacadecimal.NewFromFloat(1),
+					ChildUniqueReferenceID: "graduated-tiered-1-flat-price",
+					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+				},
+				{
 					Name:                   "feature: minimum spend",
-					PerUnitAmount:          alpacadecimal.NewFromFloat(1000),
+					PerUnitAmount:          alpacadecimal.NewFromFloat(900),
 					Quantity:               alpacadecimal.NewFromFloat(1),
 					ChildUniqueReferenceID: GraduatedMinSpendChildUniqueReferenceID,
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
@@ -1293,8 +1308,9 @@ func TestTieredPriceCalculator(t *testing.T) {
 	}
 
 	t.Run("totals, no usage", func(t *testing.T) {
+		// If there's no usage in the first tier we need to bill the flat fee regardless.
 		totalAmount := getTotalAmountForGraduatedTieredPrice(t, alpacadecimal.NewFromFloat(0), testIn)
-		require.Equal(t, alpacadecimal.NewFromFloat(0), totalAmount)
+		require.Equal(t, alpacadecimal.NewFromFloat(100), totalAmount)
 	})
 
 	t.Run("totals, usage in tier 1", func(t *testing.T) {
@@ -1306,7 +1322,10 @@ func TestTieredPriceCalculator(t *testing.T) {
 	})
 
 	t.Run("totals, usage in tier 2", func(t *testing.T) {
-		totalAmount := getTotalAmountForGraduatedTieredPrice(t, alpacadecimal.NewFromFloat(7), testIn)
+		totalAmount := getTotalAmountForGraduatedTieredPrice(t, alpacadecimal.NewFromFloat(5.001), testIn)
+		require.Equal(t, alpacadecimal.NewFromFloat(100+50), totalAmount)
+
+		totalAmount = getTotalAmountForGraduatedTieredPrice(t, alpacadecimal.NewFromFloat(7), testIn)
 		require.Equal(t, alpacadecimal.NewFromFloat(100+50), totalAmount)
 	})
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This way the user can add a mandatory flat_fee entry to the graduated volume price.