### PR TITLE
Add more Tests for Subscription Edit

### DIFF
--- a/openmeter/entitlement/adapter/entitlement.go
+++ b/openmeter/entitlement/adapter/entitlement.go
@@ -85,7 +85,7 @@ func (a *entitlementDBAdapter) GetActiveEntitlementOfSubjectAt(ctx context.Conte
 					db_entitlement.Namespace(namespace),
 					db_entitlement.FeatureKey(featureKey),
 				).
-				First(ctx)
+				First(ctx) // FIXME: to better enforce consistency we should not use .First() but assert that there is only one result!
 			if err != nil {
 				if db.IsNotFound(err) {
 					return nil, &entitlement.NotFoundError{

--- a/openmeter/subscription/repo/subscriptionphaserepo.go
+++ b/openmeter/subscription/repo/subscriptionphaserepo.go
@@ -28,6 +28,7 @@ func (r *subscriptionPhaseRepo) GetForSubscriptionAt(ctx context.Context, subscr
 	return entutils.TransactingRepo(ctx, r, func(ctx context.Context, repo *subscriptionPhaseRepo) ([]subscription.SubscriptionPhase, error) {
 		phases, err := repo.db.SubscriptionPhase.Query().
 			Where(dbsubscriptionphase.SubscriptionID(subscriptionID.ID)).
+			Where(dbsubscriptionphase.Namespace(subscriptionID.Namespace)).
 			Where(dbsubscriptionphase.Or(
 				dbsubscriptionphase.DeletedAtIsNil(),
 				dbsubscriptionphase.DeletedAtGT(at),

--- a/openmeter/subscription/testutils/service.go
+++ b/openmeter/subscription/testutils/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	planrepo "github.com/openmeterio/openmeter/openmeter/productcatalog/plan/adapter"
 	planservice "github.com/openmeterio/openmeter/openmeter/productcatalog/plan/service"
+	"github.com/openmeterio/openmeter/openmeter/registry"
 	registrybuilder "github.com/openmeterio/openmeter/openmeter/registry/builder"
 	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
@@ -21,13 +22,15 @@ import (
 )
 
 type ExposedServiceDeps struct {
-	CustomerAdapter    *testCustomerRepo
-	CustomerService    customer.Service
-	FeatureConnector   *testFeatureConnector
-	EntitlementAdapter subscription.EntitlementAdapter
-	PlanHelper         *planHelper
-	PlanService        plan.Service
-	DBDeps             *DBDeps
+	ItemRepo            subscription.SubscriptionItemRepository
+	CustomerAdapter     *testCustomerRepo
+	CustomerService     customer.Service
+	FeatureConnector    *testFeatureConnector
+	EntitlementAdapter  subscription.EntitlementAdapter
+	PlanHelper          *planHelper
+	PlanService         plan.Service
+	DBDeps              *DBDeps
+	EntitlementRegistry *registry.Entitlement
 }
 
 type services struct {
@@ -100,12 +103,14 @@ func NewService(t *testing.T, dbDeps *DBDeps) (services, ExposedServiceDeps) {
 			Service:         svc,
 			WorkflowService: workflowSvc,
 		}, ExposedServiceDeps{
-			CustomerAdapter:    customerAdapter,
-			CustomerService:    customer,
-			FeatureConnector:   NewTestFeatureConnector(entitlementRegistry.Feature),
-			EntitlementAdapter: entitlementAdapter,
-			DBDeps:             dbDeps,
-			PlanHelper:         planHelper,
-			PlanService:        planService,
+			CustomerAdapter:     customerAdapter,
+			CustomerService:     customer,
+			FeatureConnector:    NewTestFeatureConnector(entitlementRegistry.Feature),
+			EntitlementAdapter:  entitlementAdapter,
+			DBDeps:              dbDeps,
+			PlanHelper:          planHelper,
+			PlanService:         planService,
+			ItemRepo:            subItemRepo,
+			EntitlementRegistry: entitlementRegistry,
 		}
 }

--- a/openmeter/testutils/time.go
+++ b/openmeter/testutils/time.go
@@ -24,3 +24,11 @@ func GetISODuration(t *testing.T, durationString string) datex.Period {
 	}
 	return d
 }
+
+func TimeEqualsApproximately(t *testing.T, expected time.Time, actual time.Time, tolerance time.Duration) {
+	t.Helper()
+	if expected.Before(actual.Add(tolerance)) && expected.After(actual.Add(-tolerance)) {
+		return
+	}
+	t.Fatalf("Expected %v but got %v, outside tolerance of %v", expected, actual, tolerance)
+}

--- a/test/subscription/framework_test.go
+++ b/test/subscription/framework_test.go
@@ -1,0 +1,48 @@
+package subscription_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pcsubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
+	pcsubscriptionservice "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription/service"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/subscription/testutils"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+)
+
+type testDeps struct {
+	subscriptiontestutils.ExposedServiceDeps
+	pcSubscriptionService       pcsubscription.PlanSubscriptionService
+	subscriptionService         subscription.Service
+	subscriptionWorkflowService subscription.WorkflowService
+	cleanup                     func(t *testing.T) // Cleanup function
+}
+
+type setupConfig struct{}
+
+func setup(t *testing.T, _ setupConfig) testDeps {
+	t.Helper()
+
+	// Let's build the dependencies
+	dbDeps := subscriptiontestutils.SetupDBDeps(t)
+	require.NotNil(t, dbDeps)
+
+	services, deps := subscriptiontestutils.NewService(t, dbDeps)
+
+	pcSubsService := pcsubscriptionservice.New(pcsubscriptionservice.Config{
+		WorkflowService:     services.WorkflowService,
+		SubscriptionService: services.Service,
+		PlanService:         deps.PlanService,
+		Logger:              testutils.NewLogger(t),
+	})
+
+	return testDeps{
+		ExposedServiceDeps:          deps,
+		pcSubscriptionService:       pcSubsService,
+		subscriptionService:         services.Service,
+		subscriptionWorkflowService: services.WorkflowService,
+		cleanup:                     dbDeps.Cleanup,
+	}
+}

--- a/test/subscription/scenario_editcancel_test.go
+++ b/test/subscription/scenario_editcancel_test.go
@@ -1,0 +1,210 @@
+package subscription_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	customerentity "github.com/openmeterio/openmeter/openmeter/customer/entity"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	pcsubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/openmeter/subscription/patch"
+	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/subscription/testutils"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestEditingAndCanceling(t *testing.T) {
+	// Let's declare our variables
+	namespace := "example"
+
+	currentTime := testutils.GetRFC3339Time(t, "2025-01-20T13:11:07Z")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tDeps := setup(t, setupConfig{})
+	defer tDeps.cleanup(t)
+
+	clock.SetTime(currentTime)
+
+	// First, let's create the features
+	f, err := tDeps.FeatureConnector.CreateFeature(ctx, feature.CreateFeatureInputs{
+		Name:      "Example Feature",
+		Key:       "test_feature_1",
+		Namespace: namespace,
+		MeterSlug: lo.ToPtr(subscriptiontestutils.ExampleFeatureMeterSlug),
+	})
+	require.NoError(t, err)
+
+	// Second, let's create the plan
+	p, err := tDeps.PlanService.CreatePlan(ctx, plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:     "Test Plan",
+				Key:      "test_plan",
+				Currency: "USD",
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: productcatalog.PhaseMeta{
+						Key:      "default",
+						Name:     "Default Phase",
+						Duration: nil,
+					},
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:     "test_feature_1",
+								Name:    "Test Rate Card",
+								Feature: &f,
+								Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+									Amount: alpacadecimal.NewFromInt(100),
+								}),
+								TaxConfig: &productcatalog.TaxConfig{
+									Stripe: &productcatalog.StripeTaxConfig{
+										Code: "txcd_10000000",
+									},
+								},
+								EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.BooleanEntitlementTemplate{}),
+							},
+							BillingCadence: testutils.GetISODuration(t, "P1M"),
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	p, err = tDeps.PlanService.PublishPlan(ctx, plan.PublishPlanInput{
+		NamespacedID: p.NamespacedID,
+		EffectivePeriod: productcatalog.EffectivePeriod{
+			EffectiveFrom: lo.ToPtr(currentTime),
+		},
+	})
+	require.NoError(t, err)
+
+	// Third, let's create the customer
+	c, err := tDeps.CustomerService.CreateCustomer(ctx, customerentity.CreateCustomerInput{
+		Namespace: namespace,
+		CustomerMutate: customerentity.CustomerMutate{
+			Name: "Test Customer",
+			UsageAttribution: customerentity.CustomerUsageAttribution{
+				SubjectKeys: []string{"subject_1"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	pi := &pcsubscription.PlanInput{}
+	pi.FromRef(&pcsubscription.PlanRefInput{
+		Key:     p.Key,
+		Version: &p.Version,
+	})
+
+	// And let's create extra customers
+	custs := []*customerentity.Customer{}
+	for i := 0; i < 10; i++ {
+		c, err := tDeps.CustomerService.CreateCustomer(ctx, customerentity.CreateCustomerInput{
+			Namespace: namespace,
+			CustomerMutate: customerentity.CustomerMutate{
+				Name: "Test Customer",
+				UsageAttribution: customerentity.CustomerUsageAttribution{
+					SubjectKeys: []string{fmt.Sprintf("subject_%d", i+2)},
+				},
+			},
+		})
+		require.NoError(t, err)
+		custs = append(custs, c)
+	}
+
+	// Fourth, let's create the subscription
+	s, err := tDeps.pcSubscriptionService.Create(ctx, pcsubscription.CreateSubscriptionRequest{
+		WorkflowInput: subscription.CreateSubscriptionWorkflowInput{
+			Namespace:  namespace,
+			CustomerID: c.ID,
+			ChangeSubscriptionWorkflowInput: subscription.ChangeSubscriptionWorkflowInput{
+				ActiveFrom: currentTime,
+				Name:       "Test Subscription",
+			},
+		},
+		PlanInput: *pi,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	// And let's subscribe the extra customers
+	for _, cust := range custs {
+		s, err := tDeps.pcSubscriptionService.Create(ctx, pcsubscription.CreateSubscriptionRequest{
+			WorkflowInput: subscription.CreateSubscriptionWorkflowInput{
+				Namespace:  namespace,
+				CustomerID: cust.ID,
+				ChangeSubscriptionWorkflowInput: subscription.ChangeSubscriptionWorkflowInput{
+					ActiveFrom: currentTime,
+					Name:       "Test Subscription",
+				},
+			},
+			PlanInput: *pi,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, s)
+	}
+
+	currentTime = currentTime.Add(time.Minute)
+	clock.SetTime(currentTime)
+
+	// Fifth, let's edit the subscription
+	_, err = tDeps.subscriptionWorkflowService.EditRunning(ctx, s.NamespacedID, []subscription.Patch{
+		patch.PatchRemoveItem{
+			ItemKey:  "test_feature_1",
+			PhaseKey: "default",
+		},
+		patch.PatchAddItem{
+			PhaseKey: "default",
+			ItemKey:  "test_feature_1",
+			CreateInput: subscription.SubscriptionItemSpec{
+				CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+					CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+						PhaseKey: "default",
+						ItemKey:  "test_feature_1",
+						RateCard: subscription.RateCard{
+							Name:                "Test Rate Card",
+							FeatureKey:          lo.ToPtr("test_feature_1"),
+							EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.BooleanEntitlementTemplate{}),
+							Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+								Amount: alpacadecimal.NewFromInt(101),
+							}),
+							TaxConfig: &productcatalog.TaxConfig{
+								Stripe: &productcatalog.StripeTaxConfig{
+									Code: "txcd_10000000",
+								},
+							},
+							BillingCadence: lo.ToPtr(testutils.GetISODuration(t, "P1M")),
+						},
+					},
+					CreateSubscriptionItemCustomerInput: subscription.CreateSubscriptionItemCustomerInput{},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	currentTime = currentTime.Add(time.Minute)
+	clock.SetTime(currentTime)
+
+	// Sixth, let's cancel the subscription
+	_, err = tDeps.subscriptionService.Cancel(ctx, s.NamespacedID, currentTime)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Adds more tests for Subscription Edit, and gets rid of redundant code-paths from sync logic

## Notes for reviewer
- The reason the sync codepath were redundant is because a change in the relevant entitlement would also constitute a change in the SubscriptionItem, so the logic just above would handle all cases
<!-- Anything the reviewer should know? -->
