### PR TITLE
feat: only syncronize lines that have changed

### DIFF
--- a/openmeter/billing/worker/subscription/sync_test.go
+++ b/openmeter/billing/worker/subscription/sync_test.go
@@ -362,6 +362,7 @@ func (s *SubscriptionHandlerTestSuite) TestSubscriptionHappyPath() {
 
 		// then there should be a gathering invoice
 		invoice := s.gatheringInvoice(ctx, namespace, s.Customer.ID)
+		invoiceUpdatedAt := invoice.UpdatedAt
 
 		s.Len(invoice.Lines.OrEmpty(), 1)
 
@@ -385,7 +386,7 @@ func (s *SubscriptionHandlerTestSuite) TestSubscriptionHappyPath() {
 
 		gatheringLine := gatheringInvoice.Lines.OrEmpty()[0]
 
-		// TODO[OM-1039]: the invoice's updated at gets updated even if the invoice is not changed
+		s.Equal(invoiceUpdatedAt, gatheringInvoice.UpdatedAt)
 		s.Equal(billing.InvoiceStatusGathering, gatheringInvoice.Status)
 		s.Equal(line.UpdatedAt, gatheringLine.UpdatedAt)
 	})


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview
This allows us to properly maintain the updatedAt of the invoice base, and decreases the amount of invoice update events.

The patch only fixes the sync, as capturing this in the adapter is a more complex venture, also except of gathering invoices, if we edit an invoice there will be an update due to the status change either ways.
