### PR TITLE
fix: stripe sync issues

### DIFF
--- a/openmeter/app/stripe/client/appclient.go
+++ b/openmeter/app/stripe/client/appclient.go
@@ -66,7 +66,7 @@ type StripeAppClient interface {
 	DeleteInvoice(ctx context.Context, input DeleteInvoiceInput) error
 	FinalizeInvoice(ctx context.Context, input FinalizeInvoiceInput) (*stripe.Invoice, error)
 	// Invoice Line
-	AddInvoiceLines(ctx context.Context, input AddInvoiceLinesInput) ([]*stripe.InvoiceItem, error)
+	AddInvoiceLines(ctx context.Context, input AddInvoiceLinesInput) ([]StripeInvoiceItemWithLineID, error)
 	UpdateInvoiceLines(ctx context.Context, input UpdateInvoiceLinesInput) ([]*stripe.InvoiceItem, error)
 	RemoveInvoiceLines(ctx context.Context, input RemoveInvoiceLinesInput) error
 }

--- a/openmeter/billing/worker/subscription/sync_test.go
+++ b/openmeter/billing/worker/subscription/sync_test.go
@@ -2411,6 +2411,7 @@ func (s *SubscriptionHandlerTestSuite) TestGatheringManualDeleteSync() {
 			updatedLine = line.Clone()
 			return nil
 		},
+		IncludeDeletedLines: true,
 	})
 
 	updatedLineFromEditedInvoice := s.getLineByChildID(editedInvoice, childUniqueReferenceID)

--- a/test/app/stripe/stripe_mock.go
+++ b/test/app/stripe/stripe_mock.go
@@ -122,7 +122,7 @@ func (c *StripeAppClientMock) FinalizeInvoice(ctx context.Context, input stripec
 }
 
 // Invoice Lines
-func (c *StripeAppClientMock) AddInvoiceLines(ctx context.Context, input stripeclient.AddInvoiceLinesInput) ([]*stripe.InvoiceItem, error) {
+func (c *StripeAppClientMock) AddInvoiceLines(ctx context.Context, input stripeclient.AddInvoiceLinesInput) ([]stripeclient.StripeInvoiceItemWithLineID, error) {
 	if err := input.Validate(); err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (c *StripeAppClientMock) AddInvoiceLines(ctx context.Context, input stripec
 	c.StableSortInvoiceItemParams(input.Lines)
 
 	args := c.Called(input)
-	return args.Get(0).([]*stripe.InvoiceItem), args.Error(1)
+	return args.Get(0).([]stripeclient.StripeInvoiceItemWithLineID), args.Error(1)
 }
 
 func (c *StripeAppClientMock) StableSortInvoiceItemParams(input []*stripe.InvoiceItemParams) {

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -1657,9 +1657,11 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 			require.NotNil(s.T(), updatedInvoice)
 
 			line := updatedInvoice.Lines.GetByID(flatPerUnit.ID)
+			s.NotNil(line)
 
 			// TODO[later]: we need to decide how to handle the situation where the line is updated, but there are split
 			// lines
+
 			require.Equal(s.T(), float64(250), lo.Must(line.UsageBased.Price.AsUnit()).Amount.InexactFloat64())
 			require.True(s.T(), flatPerUnit.UpdatedAt.Before(line.UpdatedAt), "updated at should be changed")
 			require.True(s.T(), flatPerUnit.CreatedAt.Equal(line.CreatedAt), "created at should not be changed")


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch fixes the issues found around executing the flowing scenario:
- Have a draft invoice backed by stripe app
- Replace a line in the draft invoice by another line
- Sync fails

Fixes included:
- Make sure we are assigning the new line's IDs during state machine transitions by calling the updateInvoice
- Make sure that we are always expanding the Invoice object with the service parts by using the service.updateInvoice call
- Make sure that we are always saving the invoice line stripe ID to external ID instead of the invoice item ID
- Support lookups in sync code by invoice item ID as a fallback
- [misc] Do not double-call status details calculations