### PR TITLE
fix: invoice event unmarshaling

### DIFF
--- a/openmeter/billing/worker/subscription/sync.go
+++ b/openmeter/billing/worker/subscription/sync.go
@@ -836,7 +836,7 @@ func (h *Handler) cloneLineForUpsert(line *billing.Line) *billing.Line {
 
 // HandleInvoiceCreation is a handler for the invoice creation event, it will make sure that
 // we are backfilling the items consumed by invoice creation into the gathering invoice.
-func (h *Handler) HandleInvoiceCreation(ctx context.Context, invoice billing.Invoice) error {
+func (h *Handler) HandleInvoiceCreation(ctx context.Context, invoice billing.EventInvoice) error {
 	if invoice.Status == billing.InvoiceStatusGathering {
 		return nil
 	}

--- a/openmeter/billing/worker/worker.go
+++ b/openmeter/billing/worker/worker.go
@@ -130,7 +130,7 @@ func (w *Worker) eventHandler(opts WorkerOptions) (message.NoPublishHandlerFunc,
 			return w.subscriptionHandler.SyncronizeSubscription(ctx, event.UpdatedView, time.Now())
 		}),
 		grouphandler.NewGroupEventHandler(func(ctx context.Context, event *billing.InvoiceCreatedEvent) error {
-			return w.subscriptionHandler.HandleInvoiceCreation(ctx, event.Invoice)
+			return w.subscriptionHandler.HandleInvoiceCreation(ctx, event.EventInvoice)
 		}),
 	)
 	if err != nil {


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

We need to remove the invoice.Workflow.Apps member as it's not json serializable.

Either ways, the apps service should be used in workers to acquire an up-to-date app based on the payload.Workflow.AppReferences


## Notes for reviewer

<!-- Anything the reviewer should know? -->
