### PR TITLE
fix: unique constraints on product catalog

### DIFF
--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1403,6 +1403,9 @@ var (
 				Name:    "plan_namespace_key_version_deleted_at",
 				Unique:  true,
 				Columns: []*schema.Column{PlansColumns[1], PlansColumns[8], PlansColumns[9], PlansColumns[5]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "deleted_at IS NULL",
+				},
 			},
 		},
 	}
@@ -1465,11 +1468,17 @@ var (
 				Name:    "planphase_plan_id_key_deleted_at",
 				Unique:  true,
 				Columns: []*schema.Column{PlanPhasesColumns[12], PlanPhasesColumns[8], PlanPhasesColumns[5]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "deleted_at IS NULL",
+				},
 			},
 			{
 				Name:    "planphase_plan_id_index_deleted_at",
 				Unique:  true,
 				Columns: []*schema.Column{PlanPhasesColumns[12], PlanPhasesColumns[9], PlanPhasesColumns[5]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "deleted_at IS NULL",
+				},
 			},
 		},
 	}
@@ -1537,11 +1546,17 @@ var (
 				Name:    "planratecard_phase_id_key_deleted_at",
 				Unique:  true,
 				Columns: []*schema.Column{PlanRateCardsColumns[16], PlanRateCardsColumns[8], PlanRateCardsColumns[5]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "deleted_at IS NULL",
+				},
 			},
 			{
 				Name:    "planratecard_phase_id_feature_key_deleted_at",
 				Unique:  true,
 				Columns: []*schema.Column{PlanRateCardsColumns[16], PlanRateCardsColumns[10], PlanRateCardsColumns[5]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "deleted_at IS NULL",
+				},
 			},
 		},
 	}

--- a/openmeter/ent/schema/productcatalog.go
+++ b/openmeter/ent/schema/productcatalog.go
@@ -53,6 +53,9 @@ func (Plan) Edges() []ent.Edge {
 func (Plan) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("namespace", "key", "version", "deleted_at").
+			Annotations(
+				entsql.IndexWhere("deleted_at IS NULL"),
+			).
 			Unique(),
 	}
 }
@@ -107,8 +110,14 @@ func (PlanPhase) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("namespace", "key"),
 		index.Fields("plan_id", "key", "deleted_at").
+			Annotations(
+				entsql.IndexWhere("deleted_at IS NULL"),
+			).
 			Unique(),
 		index.Fields("plan_id", "index", "deleted_at").
+			Annotations(
+				entsql.IndexWhere("deleted_at IS NULL"),
+			).
 			Unique(),
 	}
 }
@@ -186,8 +195,14 @@ func (PlanRateCard) Edges() []ent.Edge {
 func (PlanRateCard) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("phase_id", "key", "deleted_at").
+			Annotations(
+				entsql.IndexWhere("deleted_at IS NULL"),
+			).
 			Unique(),
 		index.Fields("phase_id", "feature_key", "deleted_at").
+			Annotations(
+				entsql.IndexWhere("deleted_at IS NULL"),
+			).
 			Unique(),
 	}
 }

--- a/tools/migrate/migrations/20250130065134_product-catalog-unique-constraints.down.sql
+++ b/tools/migrate/migrations/20250130065134_product-catalog-unique-constraints.down.sql
@@ -1,0 +1,20 @@
+-- reverse: create index "plan_namespace_key_version_deleted_at" to table: "plans"
+DROP INDEX "plan_namespace_key_version_deleted_at";
+-- reverse: drop index "plan_namespace_key_version_deleted_at" from table: "plans"
+CREATE UNIQUE INDEX "plan_namespace_key_version_deleted_at" ON "plans" ("namespace", "key", "version", "deleted_at");
+-- reverse: create index "planratecard_phase_id_key_deleted_at" to table: "plan_rate_cards"
+DROP INDEX "planratecard_phase_id_key_deleted_at";
+-- reverse: create index "planratecard_phase_id_feature_key_deleted_at" to table: "plan_rate_cards"
+DROP INDEX "planratecard_phase_id_feature_key_deleted_at";
+-- reverse: drop index "planratecard_phase_id_key_deleted_at" from table: "plan_rate_cards"
+CREATE UNIQUE INDEX "planratecard_phase_id_key_deleted_at" ON "plan_rate_cards" ("phase_id", "key", "deleted_at");
+-- reverse: drop index "planratecard_phase_id_feature_key_deleted_at" from table: "plan_rate_cards"
+CREATE UNIQUE INDEX "planratecard_phase_id_feature_key_deleted_at" ON "plan_rate_cards" ("phase_id", "feature_key", "deleted_at");
+-- reverse: create index "planphase_plan_id_key_deleted_at" to table: "plan_phases"
+DROP INDEX "planphase_plan_id_key_deleted_at";
+-- reverse: create index "planphase_plan_id_index_deleted_at" to table: "plan_phases"
+DROP INDEX "planphase_plan_id_index_deleted_at";
+-- reverse: drop index "planphase_plan_id_key_deleted_at" from table: "plan_phases"
+CREATE UNIQUE INDEX "planphase_plan_id_key_deleted_at" ON "plan_phases" ("plan_id", "key", "deleted_at");
+-- reverse: drop index "planphase_plan_id_index_deleted_at" from table: "plan_phases"
+CREATE UNIQUE INDEX "planphase_plan_id_index_deleted_at" ON "plan_phases" ("plan_id", "index", "deleted_at");

--- a/tools/migrate/migrations/20250130065134_product-catalog-unique-constraints.up.sql
+++ b/tools/migrate/migrations/20250130065134_product-catalog-unique-constraints.up.sql
@@ -1,0 +1,20 @@
+-- drop index "planphase_plan_id_index_deleted_at" from table: "plan_phases"
+DROP INDEX "planphase_plan_id_index_deleted_at";
+-- drop index "planphase_plan_id_key_deleted_at" from table: "plan_phases"
+DROP INDEX "planphase_plan_id_key_deleted_at";
+-- create index "planphase_plan_id_index_deleted_at" to table: "plan_phases"
+CREATE UNIQUE INDEX "planphase_plan_id_index_deleted_at" ON "plan_phases" ("plan_id", "index", "deleted_at") WHERE (deleted_at IS NULL);
+-- create index "planphase_plan_id_key_deleted_at" to table: "plan_phases"
+CREATE UNIQUE INDEX "planphase_plan_id_key_deleted_at" ON "plan_phases" ("plan_id", "key", "deleted_at") WHERE (deleted_at IS NULL);
+-- drop index "planratecard_phase_id_feature_key_deleted_at" from table: "plan_rate_cards"
+DROP INDEX "planratecard_phase_id_feature_key_deleted_at";
+-- drop index "planratecard_phase_id_key_deleted_at" from table: "plan_rate_cards"
+DROP INDEX "planratecard_phase_id_key_deleted_at";
+-- create index "planratecard_phase_id_feature_key_deleted_at" to table: "plan_rate_cards"
+CREATE UNIQUE INDEX "planratecard_phase_id_feature_key_deleted_at" ON "plan_rate_cards" ("phase_id", "feature_key", "deleted_at") WHERE (deleted_at IS NULL);
+-- create index "planratecard_phase_id_key_deleted_at" to table: "plan_rate_cards"
+CREATE UNIQUE INDEX "planratecard_phase_id_key_deleted_at" ON "plan_rate_cards" ("phase_id", "key", "deleted_at") WHERE (deleted_at IS NULL);
+-- drop index "plan_namespace_key_version_deleted_at" from table: "plans"
+DROP INDEX "plan_namespace_key_version_deleted_at";
+-- create index "plan_namespace_key_version_deleted_at" to table: "plans"
+CREATE UNIQUE INDEX "plan_namespace_key_version_deleted_at" ON "plans" ("namespace", "key", "version", "deleted_at") WHERE (deleted_at IS NULL);

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:yCWDEfrXA2ujEqADEJQEHUWjTUZU+9Wd6mg+7CgjPMY=
+h1:ddxsywnkvBdBItZTybew4PGI2LYvFuWDbWasZJmXNII=
 20240826120919_init.down.sql h1:AIbgwwngjkJEYa3yRZsIXQyBa2+qoZttwMXHxXEbHLI=
 20240826120919_init.up.sql h1:/hYHWF3Z3dab8SMKnw99ixVktCuJe2bAw5wstCZIEN8=
 20240903155435_entitlement-expired-index.down.sql h1:np2xgYs3KQ2z7qPBcobtGNhqWQ3V8NwEP9E5U3TmpSA=
@@ -95,3 +95,5 @@ h1:yCWDEfrXA2ujEqADEJQEHUWjTUZU+9Wd6mg+7CgjPMY=
 20250127132300_billing-tax-behavior-to-config.up.sql h1:stgHXRWc639e3f1FK5L2UdAxJOxNCimZM2WvlEtiQzw=
 20250129143720_minimum-entitlement-usageperiod.down.sql h1:R9HCNbZ1zWEG83pY4K45z3XS0bpXzvciXzxV/a8vuWo=
 20250129143720_minimum-entitlement-usageperiod.up.sql h1:89Y6CW9KMPzOg+WmuPzKKAkpvRuj5y3EgkVMRGff4dk=
+20250130065134_product-catalog-unique-constraints.down.sql h1:6CRnzx88BxNN5tIour095SyjVJRT3Gy86hpCc3CjEsc=
+20250130065134_product-catalog-unique-constraints.up.sql h1:Uf7kHOLEDCGBQ9MHGQ4/PiZ1FTuKJWLwLhicRunHz88=


### PR DESCRIPTION
Fixes the issue when we would want to delete multiple rate cards for the same key at the same time.