### PR TITLE
fix: corepack pkg manager install

### DIFF
--- a/.dagger/generate.go
+++ b/.dagger/generate.go
@@ -55,7 +55,8 @@ func (m *Generate) Openapicloud() *dagger.File {
 
 func typespecBase(source *dagger.Directory) *dagger.Container {
 	return dag.Container().
-		From("node:22.8.0-alpine3.20").
+		From(NODEJS_CONTAINER_IMAGE).
+		WithExec([]string{"npm", "install", "-g", fmt.Sprintf("corepack@v%s", COREPACK_VERSION)}).
 		WithExec([]string{"corepack", "enable"}).
 		WithDirectory("/work", source).
 		WithWorkdir("/work").
@@ -72,7 +73,7 @@ func (m *Generate) PythonSdk() *dagger.Directory {
 
 	// Autorest is incompatible with latest node version
 	return dag.Container().
-		From("node:22.8.0-alpine3.20").
+		From(NODEJS_CONTAINER_IMAGE).
 		WithExec([]string{"apt", "update"}).
 		WithExec([]string{"apt", "install", "-y", "python3", "python3-pip", "python3-venv"}).
 		WithExec([]string{"npm", "install", "-g", "autorest"}).
@@ -85,7 +86,8 @@ func (m *Generate) PythonSdk() *dagger.Directory {
 // Generate the JavaScript SDK.
 func (m *Generate) JavascriptSdk() *dagger.Directory {
 	return dag.Container().
-		From("node:22.8.0-alpine3.20").
+		From(NODEJS_CONTAINER_IMAGE).
+		WithExec([]string{"npm", "install", "-g", fmt.Sprintf("corepack@v%s", COREPACK_VERSION)}).
 		WithExec([]string{"corepack", "enable"}).
 		WithDirectory("/work", m.Source.Directory("api")).
 		WithWorkdir("/work/client/javascript").

--- a/.dagger/release.go
+++ b/.dagger/release.go
@@ -125,7 +125,8 @@ func (m *Openmeter) publishPythonSdk(ctx context.Context, version string, pypiTo
 func (m *Openmeter) PublishJavascriptSdk(ctx context.Context, version string, tag string, npmToken *dagger.Secret) error {
 	// TODO: generate SDK on the fly?
 	_, err := dag.Container().
-		From("node:22.8.0-alpine3.20").
+		From(NODEJS_CONTAINER_IMAGE).
+		WithExec([]string{"npm", "install", "-g", fmt.Sprintf("corepack@v%s", COREPACK_VERSION)}).
 		WithExec([]string{"corepack", "enable"}).
 		WithDirectory("/work", m.Source.Directory("api")).
 		WithWorkdir("/work/client/javascript").

--- a/.dagger/versions.go
+++ b/.dagger/versions.go
@@ -6,3 +6,12 @@ const (
 	helmDocsVersion     = "v1.14.2"
 	spectralVersion     = "6.13.1"
 )
+
+const (
+	// COREPACK_VERSION defines the corepack version to be used in CI pipelines
+	// NOTE: Temporary measure to overcome the following issue: https://github.com/nodejs/corepack/issues/612
+	COREPACK_VERSION = "0.31.0"
+
+	// NODEJS_CONTAINER_IMAGE defines the container image to be used for Nodejs.
+	NODEJS_CONTAINER_IMAGE = "node:22.13-alpine3.21@sha256:e2b39f7b64281324929257d0f8004fb6cb4bf0fdfb9aa8cedb235a766aec31da"
+)


### PR DESCRIPTION
## Overview

Install latest `corepack` in dagger tagets to fix `Error: Cannot find matching keyid` errors.