### PR TITLE
chore: bump atlas to v0.30.0

### DIFF
--- a/.dagger/migrate.go
+++ b/.dagger/migrate.go
@@ -27,7 +27,7 @@ func (m *Migrate) Check(ctx context.Context) error {
 
 	bin := dag.Container(dagger.ContainerOpts{
 		Platform: "linux/amd64",
-	}).From(atlasImage).File("atlas")
+	}).From(AtlasContainerImage).File("atlas")
 
 	atlas := app.
 		WithFile("/bin/atlas", bin).

--- a/.dagger/versions.go
+++ b/.dagger/versions.go
@@ -14,4 +14,7 @@ const (
 
 	// NODEJS_CONTAINER_IMAGE defines the container image to be used for Nodejs.
 	NODEJS_CONTAINER_IMAGE = "node:22.13-alpine3.21@sha256:e2b39f7b64281324929257d0f8004fb6cb4bf0fdfb9aa8cedb235a766aec31da"
+
+	// AtlasContainerImage defines the container image to be used for testing database migrations.
+	AtlasContainerImage = "arigaio/atlas:0.30.0@sha256:bb19b7d5bd47338a1fa3905d1b7ff019343d3299bc04f386f9cc97ec15ed59a2"
 )

--- a/.dagger/versions_pinned.go
+++ b/.dagger/versions_pinned.go
@@ -17,6 +17,4 @@ const (
 	xxBaseImage    = "tonistiigi/xx:1.6.1@sha256:923441d7c25f1e2eb5789f82d987693c47b8ed987c4ab3b075d6ed2b5d6779a3"
 
 	alpineBaseImage = "alpine:3.21.0@sha256:21dc6063fd678b478f57c0e13f47560d0ea4eeba26dfc947b2a4f81f686b9f45"
-
-	atlasImage = "arigaio/atlas:0.29.1-alpine@sha256:c81f42fb734ce70de3b27268d88902c2a6f493c6a9b72149623920e228597846"
 )

--- a/flake.nix
+++ b/flake.nix
@@ -177,16 +177,17 @@
                 aarch64-darwin = "darwin-arm64";
                 aarch64-linux = "linux-arm64";
               };
+              # nix hash convert --hash-algo sha256 --to sri SHA256SUM
               hashMappings = {
-                x86_64-linux = "sha256-G+ZmZYJ4ep4Je49/V8qYKd/R7h1/KpYxl0wsjfB1LXw=";
-                x86_64-darwin = "sha256-kHvKZjNiQg5CJY46re0R+1FLzKN7VC4hmJGg8RB8n6A=";
-                aarch64-darwin = "sha256-OOaMsgvu4MCVCk0ayN4XSFewpcTdKF8ilqU1Be5Aii8=";
-                aarch64-linux = "sha256-EVg7QBd3L1NXGIhF1odtADSY6/paEuXCP2mY3ripFmA=";
+                x86_64-linux = "sha256-gHiHN2OJY2+QjZdO5tcjUsEJe3NPbiYAFpdqJrnWlL8=";
+                x86_64-darwin = "sha256-Oj4MEFixx7kLr9dh+UP89j8bTU3T/8J7qtYld+CICZY=";
+                aarch64-darwin = "sha256-yLDu2M2oXSX9NbAivn8J/BGNbOeQ8wRZqtK4Ql1Ed8E=";
+                aarch64-linux = "sha256-1zgNXkcVh4xEEIq+ahORvDhzUxkpnwrzZYvVp4qgOxA=";
               };
             in
             pkgs.stdenv.mkDerivation rec {
               pname = "atlasx";
-              version = "0.26.1";
+              version = "0.30.0";
 
               src = pkgs.fetchurl {
                 # License: https://ariga.io/legal/atlas/eula/eula-20240804.pdf


### PR DESCRIPTION
## Overview

Bump `atlas` version to v0.30.0.
