### PR TITLE
feat: add support for background invoice progressing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -79,7 +79,9 @@
         "--config",
         "${workspaceFolder}/config.yaml",
         "--telemetry-address",
-        ":10004"
+        ":10004",
+        // force foreground billing advancement strategy, or billing-worker will not start (this way the config can be set to queued to validate that in local dev mode)
+        "--billing-advancement-strategy=foreground",
       ]
     },
   ]

--- a/app/common/billing.go
+++ b/app/common/billing.go
@@ -47,20 +47,22 @@ func BillingService(
 	meterRepo meter.Repository,
 	streamingConnector streaming.Connector,
 	eventPublisher eventbus.Publisher,
+	advancementStrategy billing.AdvancementStrategy,
 ) (billing.Service, error) {
 	if !billingConfig.Enabled {
 		return nil, nil
 	}
 
 	return billingservice.New(billingservice.Config{
-		Adapter:            billingAdapter,
-		AppService:         appService,
-		CustomerService:    customerService,
-		FeatureService:     featureConnector,
-		Logger:             logger,
-		MeterRepo:          meterRepo,
-		StreamingConnector: streamingConnector,
-		Publisher:          eventPublisher,
+		Adapter:             billingAdapter,
+		AppService:          appService,
+		CustomerService:     customerService,
+		FeatureService:      featureConnector,
+		Logger:              logger,
+		MeterRepo:           meterRepo,
+		StreamingConnector:  streamingConnector,
+		Publisher:           eventPublisher,
+		AdvancementStrategy: advancementStrategy,
 	})
 }
 

--- a/app/common/config.go
+++ b/app/common/config.go
@@ -14,6 +14,7 @@ var Config = wire.NewSet(
 	wire.FieldsOf(new(config.Configuration), "Aggregation"),
 	// Billing
 	wire.FieldsOf(new(config.Configuration), "Billing"),
+	wire.FieldsOf(new(config.BillingConfiguration), "AdvancementStrategy"),
 	// ClickHouse
 	wire.FieldsOf(new(config.AggregationConfiguration), "ClickHouse"),
 	// Database

--- a/app/config/billing.go
+++ b/app/config/billing.go
@@ -1,18 +1,45 @@
 package config
 
-import "github.com/spf13/viper"
+import (
+	"errors"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+)
 
 type BillingConfiguration struct {
-	Enabled bool
-	Worker  BillingWorkerConfiguration
+	Enabled             bool
+	AdvancementStrategy billing.AdvancementStrategy
+	Worker              BillingWorkerConfiguration
 }
 
 func (c BillingConfiguration) Validate() error {
-	return nil
+	if !c.Enabled {
+		return nil
+	}
+
+	var errs []error
+	if err := c.Worker.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := c.AdvancementStrategy.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
 }
 
-func ConfigureBilling(v *viper.Viper) {
+func ConfigureBilling(v *viper.Viper, flags *pflag.FlagSet) {
 	v.SetDefault("billing.enabled", false)
 
 	ConfigureBillingWorker(v)
+
+	// Allow overriding the advancement strategy for local development purposes where we are
+	// likely to use the same configuration file for multiple services.
+	flags.String("billing-advancement-strategy", "foreground", "Advancement strategy for billing")
+	_ = v.BindPFlag("billing.advancementStrategy", flags.Lookup("billing-advancement-strategy"))
+	v.SetDefault("billing.advancementStrategy", billing.ForegroundAdvancementStrategy)
 }

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -155,7 +155,7 @@ func SetViperDefaults(v *viper.Viper, flags *pflag.FlagSet) {
 	ConfigureEvents(v)
 	ConfigureBalanceWorker(v)
 	ConfigureNotification(v)
-	ConfigureBilling(v)
+	ConfigureBilling(v, flags)
 	ConfigureProductCatalog(v)
 	ConfigureApps(v, flags)
 }

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	notificationwebhook "github.com/openmeterio/openmeter/openmeter/notification/webhook"
 	pkgkafka "github.com/openmeterio/openmeter/pkg/kafka"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -133,7 +134,8 @@ func TestComplete(t *testing.T) {
 			AsyncInsertWait: false,
 		},
 		Billing: BillingConfiguration{
-			Enabled: false,
+			Enabled:             false,
+			AdvancementStrategy: billing.ForegroundAdvancementStrategy,
 			Worker: BillingWorkerConfiguration{
 				ConsumerConfiguration: ConsumerConfiguration{
 					ProcessingTimeout: 30 * time.Second,

--- a/cmd/billing-worker/wire_gen.go
+++ b/cmd/billing-worker/wire_gen.go
@@ -195,7 +195,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	featureConnector := common.NewFeatureConnector(logger, client, inMemoryRepository)
-	billingService, err := common.BillingService(logger, client, service, adapter, billingConfiguration, customerService, featureConnector, inMemoryRepository, connector, eventbusPublisher)
+	advancementStrategy := billingConfiguration.AdvancementStrategy
+	billingService, err := common.BillingService(logger, client, service, adapter, billingConfiguration, customerService, featureConnector, inMemoryRepository, connector, eventbusPublisher, advancementStrategy)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/cmd/jobs/internal/wire_gen.go
+++ b/cmd/jobs/internal/wire_gen.go
@@ -197,7 +197,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	}
 	billingConfiguration := conf.Billing
 	featureConnector := common.NewFeatureConnector(logger, client, inMemoryRepository)
-	billingService, err := common.BillingService(logger, client, service, adapter, billingConfiguration, customerService, featureConnector, inMemoryRepository, connector, eventbusPublisher)
+	advancementStrategy := billingConfiguration.AdvancementStrategy
+	billingService, err := common.BillingService(logger, client, service, adapter, billingConfiguration, customerService, featureConnector, inMemoryRepository, connector, eventbusPublisher, advancementStrategy)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -198,7 +198,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	}
 	billingConfiguration := conf.Billing
 	featureConnector := common.NewFeatureConnector(logger, client, inMemoryRepository)
-	billingService, err := common.BillingService(logger, client, service, adapter, billingConfiguration, customerService, featureConnector, inMemoryRepository, connector, eventbusPublisher)
+	advancementStrategy := billingConfiguration.AdvancementStrategy
+	billingService, err := common.BillingService(logger, client, service, adapter, billingConfiguration, customerService, featureConnector, inMemoryRepository, connector, eventbusPublisher, advancementStrategy)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -41,6 +41,8 @@ productcatalog:
 
 billing:
   enabled: true
+  # for production deployments it's recommended to use queued for server only
+  # advancementStrategy: foreground
 
 apps:
   enabled: true

--- a/openmeter/billing/events.go
+++ b/openmeter/billing/events.go
@@ -1,6 +1,8 @@
 package billing
 
 import (
+	"fmt"
+
 	"github.com/openmeterio/openmeter/openmeter/event/metadata"
 )
 
@@ -47,4 +49,36 @@ func (e InvoiceCreatedEvent) EventMetadata() metadata.EventMetadata {
 
 func (e InvoiceCreatedEvent) Validate() error {
 	return e.EventInvoice.Validate()
+}
+
+type AdvanceInvoiceEvent struct {
+	Invoice    InvoiceID `json:"invoice"`
+	CustomerID string    `json:"customer_id"`
+}
+
+func (e AdvanceInvoiceEvent) EventName() string {
+	return metadata.GetEventName(metadata.EventType{
+		Subsystem: EventSubsystem,
+		Name:      "invoice.advance",
+		Version:   "v1",
+	})
+}
+
+func (e AdvanceInvoiceEvent) EventMetadata() metadata.EventMetadata {
+	return metadata.EventMetadata{
+		Source:  metadata.ComposeResourcePath(e.Invoice.Namespace, metadata.EntityInvoice, e.Invoice.ID),
+		Subject: metadata.ComposeResourcePath(e.Invoice.Namespace, metadata.EntityCustomer, e.CustomerID),
+	}
+}
+
+func (e AdvanceInvoiceEvent) Validate() error {
+	if err := e.Invoice.Validate(); err != nil {
+		return err
+	}
+
+	if e.CustomerID == "" {
+		return fmt.Errorf("customer_id cannot be empty")
+	}
+
+	return nil
 }

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -14,6 +14,8 @@ type Service interface {
 	SequenceService
 
 	InvoiceAppService
+
+	ConfigIntrospectionService
 }
 
 type ProfileService interface {
@@ -78,4 +80,8 @@ type InvoiceAppService interface {
 	// UpdateInvoiceFields updates the fields of an invoice which are not managed by the state machine
 	// These are usually metadata fields settable after the invoice has been finalized
 	UpdateInvoiceFields(ctx context.Context, input UpdateInvoiceFieldsInput) error
+}
+
+type ConfigIntrospectionService interface {
+	GetAdvancementStrategy() AdvancementStrategy
 }

--- a/openmeter/billing/serviceconfig.go
+++ b/openmeter/billing/serviceconfig.go
@@ -1,0 +1,33 @@
+package billing
+
+import (
+	"fmt"
+	"slices"
+)
+
+type AdvancementStrategy string
+
+const (
+	// ForgegroundAdvancementStrategy is the strategy where the invoice is advanced immediately as part
+	// of the same transaction. Should be used in workers as advancement might take long time and we don't want
+	// to block a HTTP request for that long.
+	ForegroundAdvancementStrategy AdvancementStrategy = "foreground"
+	// QueuedAdvancementStrategy is the strategy where the invoice is advanced in a separate worker (billing-worker).
+	// This is useful for cases where the advancement might take a long time and we don't want to block the current
+	// HTTP request.
+	QueuedAdvancementStrategy AdvancementStrategy = "queued"
+)
+
+func (s AdvancementStrategy) Validate() error {
+	if !slices.Contains(
+		[]AdvancementStrategy{
+			ForegroundAdvancementStrategy,
+			QueuedAdvancementStrategy,
+		},
+		s,
+	) {
+		return fmt.Errorf("invalid advancement strategy: %s", s)
+	}
+
+	return nil
+}

--- a/openmeter/billing/worker/asyncadvance/asyncadvance.go
+++ b/openmeter/billing/worker/asyncadvance/asyncadvance.go
@@ -1,0 +1,57 @@
+package asyncadvance
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+)
+
+type Handler struct {
+	billingService billing.Service
+	logger         *slog.Logger
+}
+
+type Config struct {
+	Logger         *slog.Logger
+	BillingService billing.Service
+}
+
+func (c Config) Validate() error {
+	if c.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	if c.BillingService == nil {
+		return errors.New("billing service is required")
+	}
+
+	if c.BillingService.GetAdvancementStrategy() != billing.ForegroundAdvancementStrategy {
+		return errors.New("billing service must have foreground advancement strategy or we are creating an infinite loop")
+	}
+
+	return nil
+}
+
+func New(c Config) (*Handler, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &Handler{
+		billingService: c.BillingService,
+		logger:         c.Logger,
+	}, nil
+}
+
+func (h *Handler) Handle(ctx context.Context, event *billing.AdvanceInvoiceEvent) error {
+	_, err := h.billingService.AdvanceInvoice(ctx, event.Invoice)
+
+	if errors.Is(err, billing.ErrInvoiceCannotAdvance) {
+		h.logger.WarnContext(ctx, "invoice cannot advance (most probably a late message has occurred)", "invoice_id", event.Invoice)
+		return nil
+	}
+
+	return err
+}

--- a/test/app/testenv.go
+++ b/test/app/testenv.go
@@ -234,13 +234,14 @@ func InitBillingService(t *testing.T, ctx context.Context, in InitBillingService
 	require.NoError(t, err)
 
 	return billingservice.New(billingservice.Config{
-		Adapter:            billingAdapter,
-		CustomerService:    in.CustomerService,
-		AppService:         in.AppService,
-		Logger:             slog.Default(),
-		FeatureService:     featureService,
-		MeterRepo:          meterRepo,
-		StreamingConnector: mockStreamingConnector,
-		Publisher:          eventbus.NewMock(t),
+		Adapter:             billingAdapter,
+		CustomerService:     in.CustomerService,
+		AppService:          in.AppService,
+		Logger:              slog.Default(),
+		FeatureService:      featureService,
+		MeterRepo:           meterRepo,
+		StreamingConnector:  mockStreamingConnector,
+		Publisher:           eventbus.NewMock(t),
+		AdvancementStrategy: billing.ForegroundAdvancementStrategy,
 	})
 }

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -143,14 +143,15 @@ func (s *BaseSuite) SetupSuite() {
 	s.BillingAdapter = billingAdapter
 
 	billingService, err := billingservice.New(billingservice.Config{
-		Adapter:            billingAdapter,
-		CustomerService:    s.CustomerService,
-		AppService:         s.AppService,
-		Logger:             slog.Default(),
-		FeatureService:     s.FeatureService,
-		MeterRepo:          s.MeterRepo,
-		StreamingConnector: s.MockStreamingConnector,
-		Publisher:          eventbus.NewMock(s.T()),
+		Adapter:             billingAdapter,
+		CustomerService:     s.CustomerService,
+		AppService:          s.AppService,
+		Logger:              slog.Default(),
+		FeatureService:      s.FeatureService,
+		MeterRepo:           s.MeterRepo,
+		StreamingConnector:  s.MockStreamingConnector,
+		Publisher:           eventbus.NewMock(s.T()),
+		AdvancementStrategy: billing.ForegroundAdvancementStrategy,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Overview

This patch allows for invoices to be processed by the billing-worker instead of being processed by the server during the HTTP call.

For apps that are slower to process it's a better user experience, while it gives us more space to execute the synchronization steps.