### PR TITLE
fix(sink): deadlock in flushhandler

### DIFF
--- a/openmeter/sink/flushhandler/handler.go
+++ b/openmeter/sink/flushhandler/handler.go
@@ -121,11 +121,9 @@ func NewFlushEventHandler(opts FlushEventHandlerOptions) (FlushEventHandler, err
 }
 
 func (f *flushEventHandler) Close() error {
-	if f.isShutdown.Load() {
+	if f.isShutdown.Swap(true) {
 		return nil
 	}
-
-	f.isShutdown.Store(true)
 
 	// Close control channel
 	f.stopChanClose()

--- a/openmeter/sink/flushhandler/mux.go
+++ b/openmeter/sink/flushhandler/mux.go
@@ -9,6 +9,8 @@ import (
 
 type DrainCompleteFunc func()
 
+var _ FlushEventHandler = (*FlushEventHandlers)(nil)
+
 type FlushEventHandlers struct {
 	handlers        []FlushEventHandler
 	onDrainComplete []DrainCompleteFunc
@@ -36,6 +38,18 @@ func (f *FlushEventHandlers) OnFlushSuccess(ctx context.Context, events []models
 	}
 
 	return finalError
+}
+
+func (f *FlushEventHandlers) Close() error {
+	var errs []error
+
+	for _, handler := range f.handlers {
+		if err := handler.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 func (f *FlushEventHandlers) Start(ctx context.Context) error {

--- a/openmeter/sink/flushhandler/types.go
+++ b/openmeter/sink/flushhandler/types.go
@@ -10,6 +10,7 @@ type FlushEventHandler interface {
 	OnFlushSuccess(ctx context.Context, events []models.SinkMessage) error
 	Start(context.Context) error
 	WaitForDrain(context.Context) error
+	Close() error
 }
 
 type (


### PR DESCRIPTION
## Overview

Fix deadlock during draining events channel in flushhadler. This should fix the `failed to shutdown flush success handlers` error messages reported by `sink-worker` during shutdown.