### PR TITLE
fix: sarama debug log

### DIFF
--- a/app/common/watermill.go
+++ b/app/common/watermill.go
@@ -40,17 +40,15 @@ var WatermillRouter = wire.NewSet(
 
 func NewBrokerConfiguration(
 	kafkaConfig config.KafkaConfiguration,
-	logConfig config.LogTelemetryConfig,
 	appMetadata Metadata,
 	logger *slog.Logger,
 	meter metric.Meter,
 ) watermillkafka.BrokerOptions {
 	return watermillkafka.BrokerOptions{
-		KafkaConfig:  kafkaConfig,
-		ClientID:     appMetadata.OpenTelemetryName, // TODO: use a better name or rename otel name
-		Logger:       logger,
-		MetricMeter:  meter,
-		DebugLogging: logConfig.Level == slog.LevelDebug,
+		KafkaConfig: kafkaConfig,
+		ClientID:    appMetadata.OpenTelemetryName, // TODO: use a better name or rename otel name
+		Logger:      logger,
+		MetricMeter: meter,
 	}
 }
 

--- a/cmd/balance-worker/wire_gen.go
+++ b/cmd/balance-worker/wire_gen.go
@@ -70,7 +70,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	ingestConfiguration := conf.Ingest
 	kafkaIngestConfiguration := ingestConfiguration.Kafka
 	kafkaConfiguration := kafkaIngestConfiguration.KafkaConfiguration
-	brokerOptions := common.NewBrokerConfiguration(kafkaConfiguration, logTelemetryConfig, commonMetadata, logger, meter)
+	brokerOptions := common.NewBrokerConfiguration(kafkaConfiguration, commonMetadata, logger, meter)
 	subscriber, err := common.BalanceWorkerSubscriber(balanceWorkerConfiguration, brokerOptions)
 	if err != nil {
 		cleanup5()

--- a/cmd/billing-worker/wire_gen.go
+++ b/cmd/billing-worker/wire_gen.go
@@ -73,7 +73,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	ingestConfiguration := conf.Ingest
 	kafkaIngestConfiguration := ingestConfiguration.Kafka
 	kafkaConfiguration := kafkaIngestConfiguration.KafkaConfiguration
-	brokerOptions := common.NewBrokerConfiguration(kafkaConfiguration, logTelemetryConfig, commonMetadata, logger, meter)
+	brokerOptions := common.NewBrokerConfiguration(kafkaConfiguration, commonMetadata, logger, meter)
 	subscriber, err := common.BillingWorkerSubscriber(billingConfiguration, brokerOptions)
 	if err != nil {
 		cleanup5()

--- a/cmd/jobs/internal/wire_gen.go
+++ b/cmd/jobs/internal/wire_gen.go
@@ -117,7 +117,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	ingestConfiguration := conf.Ingest
 	kafkaIngestConfiguration := ingestConfiguration.Kafka
 	kafkaConfiguration := kafkaIngestConfiguration.KafkaConfiguration
-	brokerOptions := common.NewBrokerConfiguration(kafkaConfiguration, logTelemetryConfig, commonMetadata, logger, meter)
+	brokerOptions := common.NewBrokerConfiguration(kafkaConfiguration, commonMetadata, logger, meter)
 	eventsConfiguration := conf.Events
 	v3 := common.ServerProvisionTopics(eventsConfiguration)
 	adminClient, err := common.NewKafkaAdminClient(kafkaConfiguration)

--- a/cmd/notification-service/wire_gen.go
+++ b/cmd/notification-service/wire_gen.go
@@ -74,7 +74,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	ingestConfiguration := conf.Ingest
 	kafkaIngestConfiguration := ingestConfiguration.Kafka
 	kafkaConfiguration := kafkaIngestConfiguration.KafkaConfiguration
-	brokerOptions := common.NewBrokerConfiguration(kafkaConfiguration, logTelemetryConfig, commonMetadata, logger, meter)
+	brokerOptions := common.NewBrokerConfiguration(kafkaConfiguration, commonMetadata, logger, meter)
 	notificationConfiguration := conf.Notification
 	v := common.NotificationServiceProvisionTopics(notificationConfiguration)
 	adminClient, err := common.NewKafkaAdminClient(kafkaConfiguration)

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -118,7 +118,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	ingestConfiguration := conf.Ingest
 	kafkaIngestConfiguration := ingestConfiguration.Kafka
 	kafkaConfiguration := kafkaIngestConfiguration.KafkaConfiguration
-	brokerOptions := common.NewBrokerConfiguration(kafkaConfiguration, logTelemetryConfig, commonMetadata, logger, meter)
+	brokerOptions := common.NewBrokerConfiguration(kafkaConfiguration, commonMetadata, logger, meter)
 	eventsConfiguration := conf.Events
 	v3 := common.ServerProvisionTopics(eventsConfiguration)
 	adminClient, err := common.NewKafkaAdminClient(kafkaConfiguration)

--- a/cmd/sink-worker/wire_gen.go
+++ b/cmd/sink-worker/wire_gen.go
@@ -63,7 +63,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	kafkaIngestConfiguration := ingestConfiguration.Kafka
 	kafkaConfiguration := kafkaIngestConfiguration.KafkaConfiguration
 	meter := common.NewMeter(meterProvider, commonMetadata)
-	brokerOptions := common.NewBrokerConfiguration(kafkaConfiguration, logTelemetryConfig, commonMetadata, logger, meter)
+	brokerOptions := common.NewBrokerConfiguration(kafkaConfiguration, commonMetadata, logger, meter)
 	v := common.SinkWorkerProvisionTopics(eventsConfiguration)
 	adminClient, err := common.NewKafkaAdminClient(kafkaConfiguration)
 	if err != nil {

--- a/openmeter/watermill/driver/kafka/broker.go
+++ b/openmeter/watermill/driver/kafka/broker.go
@@ -19,11 +19,10 @@ const (
 )
 
 type BrokerOptions struct {
-	KafkaConfig  config.KafkaConfiguration
-	ClientID     string
-	Logger       *slog.Logger
-	MetricMeter  otelmetric.Meter
-	DebugLogging bool
+	KafkaConfig config.KafkaConfiguration
+	ClientID    string
+	Logger      *slog.Logger
+	MetricMeter otelmetric.Meter
 }
 
 func (o *BrokerOptions) Validate() error {
@@ -65,10 +64,9 @@ func (o *BrokerOptions) createKafkaConfig(role string) (*sarama.Config, error) {
 		loggerFunc: o.Logger.Info,
 	}
 
-	if o.DebugLogging {
-		sarama.DebugLogger = &SaramaLoggerAdaptor{
-			loggerFunc: o.Logger.Debug,
-		}
+	// NOTE: always set the sarama.DebugLogger otherwise the debug level logs are redirected to the sarama.Logger by default
+	sarama.DebugLogger = &SaramaLoggerAdaptor{
+		loggerFunc: o.Logger.Debug,
 	}
 
 	if o.KafkaConfig.SecurityProtocol == "SASL_SSL" {


### PR DESCRIPTION
## Overview

Fix `sarama` logging configuration by always setting `sarama.DebugLogger` in order to avoid redeirecting debug log to `sarama.Logger` logger which is the default behaviour if the former is not set.

See: https://github.com/IBM/sarama/blob/main/sarama.go#L135-L139 
