### PR TITLE
Map subscription errors in workflow service

### DIFF
--- a/openmeter/subscription/service/errors.go
+++ b/openmeter/subscription/service/errors.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// mapSubscriptionErrors maps subscription errors to user errors
+func mapSubscriptionErrors(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if sErr, ok := lo.ErrorsAs[*subscription.SpecValidationError](err); ok {
+		return models.NewGenericValidationError(sErr)
+	} else if sErr, ok := lo.ErrorsAs[*subscription.AlignmentError](err); ok {
+		return models.NewGenericConflictError(sErr)
+	} else if sErr, ok := lo.ErrorsAs[*subscription.NoBillingPeriodError](err); ok {
+		return models.NewGenericValidationError(sErr)
+	}
+
+	return err
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Let's use a unified errorMapper to map package internal errors to public errors
