### PR TITLE
fix(streaming): aggregation condition for count

### DIFF
--- a/openmeter/streaming/clickhouse/materialized_view/meter_query.go
+++ b/openmeter/streaming/clickhouse/materialized_view/meter_query.go
@@ -129,7 +129,7 @@ func (d createMeterView) toSelectSQL() (string, error) {
 		"tumbleStart(time, toIntervalMinute(1)) AS windowstart",
 		"tumbleEnd(time, toIntervalMinute(1)) AS windowend",
 	}
-	if d.ValueProperty == "" && d.Aggregation == models.MeterAggregationCount {
+	if d.Aggregation == models.MeterAggregationCount {
 		selects = append(selects, fmt.Sprintf("%s(*) AS value", aggStateFn))
 	} else if d.Aggregation == models.MeterAggregationUniqueCount {
 		selects = append(selects, fmt.Sprintf("%s(JSON_VALUE(data, '%s')) AS value", aggStateFn, sqlbuilder.Escape(d.ValueProperty)))

--- a/openmeter/streaming/clickhouse/raw_events/meter_query.go
+++ b/openmeter/streaming/clickhouse/raw_events/meter_query.go
@@ -96,7 +96,7 @@ func (d queryMeter) toSQL() (string, []interface{}, error) {
 		return "", []interface{}{}, fmt.Errorf("invalid aggregation type: %s", d.Meter.Aggregation)
 	}
 
-	if d.Meter.ValueProperty == "" && d.Meter.Aggregation == models.MeterAggregationCount {
+	if d.Meter.Aggregation == models.MeterAggregationCount {
 		selectColumns = append(selectColumns, fmt.Sprintf("toFloat64(%s(*)) AS value", sqlAggregation))
 	} else if d.Meter.Aggregation == models.MeterAggregationUniqueCount {
 		selectColumns = append(selectColumns, fmt.Sprintf("toFloat64(%s(JSON_VALUE(%s, '%s'))) AS value", sqlAggregation, getColumn("data"), sqlbuilder.Escape(d.Meter.ValueProperty)))

--- a/openmeter/streaming/clickhouse/raw_events/meter_query_test.go
+++ b/openmeter/streaming/clickhouse/raw_events/meter_query_test.go
@@ -70,17 +70,16 @@ func TestQueryMeter(t *testing.T) {
 				EventsTableName: "om_events",
 				Namespace:       "my_namespace",
 				Meter: models.Meter{
-					Slug:          "meter1",
-					EventType:     "event1",
-					Aggregation:   models.MeterAggregationCount,
-					ValueProperty: "$.value",
+					Slug:        "meter1",
+					EventType:   "event1",
+					Aggregation: models.MeterAggregationCount,
 					GroupBy: map[string]string{
 						"group1": "$.group1",
 						"group2": "$.group2",
 					},
 				},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, count(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value'))) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, toFloat64(count(*)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
 		{ // Aggregate data from start


### PR DESCRIPTION
We don't need to check for value prop. Checking for value prop can cause issues with incorrectly created meters.