### PR TITLE
fix: shutdown procedure in server

### DIFF
--- a/app/common/config.go
+++ b/app/common/config.go
@@ -42,4 +42,6 @@ var Config = wire.NewSet(
 	wire.FieldsOf(new(config.TelemetryConfig), "Metrics"),
 	wire.FieldsOf(new(config.TelemetryConfig), "Trace"),
 	wire.FieldsOf(new(config.TelemetryConfig), "Log"),
+	// Termination
+	wire.FieldsOf(new(config.Configuration), "Termination"),
 )

--- a/app/common/termination.go
+++ b/app/common/termination.go
@@ -1,0 +1,173 @@
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	health "github.com/AppsFlyer/go-sundheit"
+	"github.com/oklog/run"
+
+	"github.com/openmeterio/openmeter/app/config"
+)
+
+type TerminationState = string
+
+const (
+	TerminationStateRunning     TerminationState = "running"
+	TerminationStateTerminating TerminationState = "terminating"
+)
+
+type status struct {
+	State     TerminationState `json:"state"`
+	Reason    error            `json:"reason,omitempty"`
+	Timestamp time.Time        `json:"timestamp,omitempty"`
+}
+
+var _ health.Check = (*TerminationChecker)(nil)
+
+type TerminationChecker struct {
+	status
+
+	mu sync.RWMutex
+
+	propagationTimeout time.Duration
+}
+
+func (s *TerminationChecker) setDetails(state TerminationState, reason error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.status.State = state
+	s.status.Reason = reason
+	s.status.Timestamp = time.Now()
+}
+
+func (s *TerminationChecker) Terminate(reason error) {
+	s.setDetails(TerminationStateTerminating, reason)
+}
+
+func (s *TerminationChecker) IsRunning() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.status.State == TerminationStateRunning
+}
+
+func (s *TerminationChecker) IsTerminating() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.status.State == TerminationStateTerminating
+}
+
+func (s *TerminationChecker) Name() string {
+	return "termination.check"
+}
+
+func (s *TerminationChecker) Execute(_ context.Context) (interface{}, error) {
+	details := struct {
+		State     TerminationState `json:"state"`
+		Reason    error            `json:"reason,omitempty"`
+		Timestamp string           `json:"timestamp"`
+	}{
+		State:     s.status.State,
+		Reason:    s.status.Reason,
+		Timestamp: s.status.Timestamp.UTC().Format(time.RFC3339),
+	}
+
+	if s.IsTerminating() {
+		return details, fmt.Errorf("termination was initiated [state=%s time=%s]: %w", details.State, details.Timestamp, details.Reason)
+	}
+
+	return details, nil
+}
+
+// WaitForPropagation blocks for
+func (s *TerminationChecker) WaitForPropagation(ctx context.Context) error {
+	if s.IsRunning() {
+		return nil
+	}
+
+	propagationDeadline := s.status.Timestamp.Add(s.propagationTimeout)
+	if time.Now().After(propagationDeadline) {
+		return nil
+	}
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case now := <-ticker.C:
+			if now.After(propagationDeadline) {
+				return nil
+			}
+		}
+	}
+}
+
+// NewTerminationChecker returns a new TerminationChecker and registers the TerminationChecker to
+// the provided health checker.
+func NewTerminationChecker(conf config.TerminationConfig, healthChecker health.Health) (*TerminationChecker, error) {
+	rc := &TerminationChecker{
+		status: status{
+			State:     TerminationStateRunning,
+			Timestamp: time.Now(),
+		},
+		propagationTimeout: conf.PropagationTimeout,
+	}
+
+	err := healthChecker.RegisterCheck(
+		rc,
+		health.ExecutionPeriod(conf.CheckInterval),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return rc, nil
+}
+
+// NewTerminationCheckerActor returns actor functions (execute, interrupt) which can be passed to run.Add() to register it.
+// Its state is set to TerminationStateStopping as soon as interrupt function is called.
+func NewTerminationCheckerActor(r *TerminationChecker, logger *slog.Logger) (execute func() error, interrupt func(error), err error) {
+	if r == nil {
+		return nil, nil, errors.New("the TerminationChecker must not be nil")
+	}
+
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	c := make(chan struct{})
+
+	return func() error {
+			// Wait until interrupt is invoked and return after
+			<-c
+
+			return nil
+		}, func(err error) {
+			logger.Debug("shutting down termination checker", "cause", err)
+
+			r.Terminate(err)
+
+			if errors.Is(err, run.ErrSignal) {
+				logger.Debug("waiting for propagation of termination...", "until", r.Timestamp.Add(r.propagationTimeout))
+
+				// Wait for propagation timeout
+				if err = r.WaitForPropagation(context.Background()); err != nil {
+					logger.Error("failed to wait for propagation", "error", err)
+				}
+
+				logger.Debug("waiting for propagation of termination is done", "until", r.Timestamp.Add(r.propagationTimeout))
+			}
+
+			close(c)
+		}, nil
+}

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -20,6 +20,8 @@ type Configuration struct {
 
 	Telemetry TelemetryConfig
 
+	Termination TerminationConfig
+
 	Aggregation    AggregationConfiguration
 	Entitlements   EntitlementsConfiguration
 	Dedupe         DedupeConfiguration
@@ -120,6 +122,10 @@ func (c Configuration) Validate() error {
 		errs = append(errs, errorsx.WithPrefix(err, "apps"))
 	}
 
+	if err := c.Termination.Validate(); err != nil {
+		errs = append(errs, errorsx.WithPrefix(err, "termination"))
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -158,4 +164,5 @@ func SetViperDefaults(v *viper.Viper, flags *pflag.FlagSet) {
 	ConfigureBilling(v, flags)
 	ConfigureProductCatalog(v)
 	ConfigureApps(v, flags)
+	ConfigureTermination(v, "termination")
 }

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -337,6 +337,11 @@ func TestComplete(t *testing.T) {
 			ServerURL: "http://127.0.0.1:8071",
 			Debug:     true,
 		},
+		Termination: TerminationConfig{
+			CheckInterval:           7 * time.Second,
+			GracefulShutdownTimeout: 43 * time.Second,
+			PropagationTimeout:      18 * time.Second,
+		},
 	}
 
 	assert.Equal(t, expected, actual)

--- a/app/config/telemetry.go
+++ b/app/config/telemetry.go
@@ -504,4 +504,6 @@ func ConfigureTelemetry(v *viper.Viper, flags *pflag.FlagSet) {
 	v.SetDefault("telemetry.log.exporters.otlp.enabled", false)
 	v.SetDefault("telemetry.log.exporters.otlp.address", "")
 	v.SetDefault("telemetry.log.exporters.stdout.enabled", false)
+
+	v.SetDefault("telemetry.readiness.interval", 3*time.Second)
 }

--- a/app/config/termination.go
+++ b/app/config/termination.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"errors"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+type TerminationConfig struct {
+	// CheckInterval defines the time period used for updating the readiness check based on the termination status
+	CheckInterval time.Duration
+
+	// GracefulShutdownTimeout defines the maximum time for the process to gracefully stop on receiving stop signal.
+	GracefulShutdownTimeout time.Duration
+
+	// PropagationTimeout defines how long to block the termination process in order
+	// to allow the termination event to be propagated to other systems. e.g. reverse proxy.
+	// Its value should be set higher than the failure threshold for readiness probe.
+	// In Kubernetes it should be: readiness.periodSeconds * (readiness.failureThreshold + 1) + CheckInterval
+	// PropagationTimeout must always less than GracefulShutdownTimeout.
+	PropagationTimeout time.Duration
+}
+
+func (c TerminationConfig) Validate() error {
+	var errs []error
+
+	if c.CheckInterval < time.Second {
+		errs = append(errs, errors.New("checkInterval must be greater than or equal to 1s"))
+	}
+
+	if c.PropagationTimeout > c.GracefulShutdownTimeout {
+		errs = append(errs, errors.New("propagationTimeout must be less or equal to gracefulShutdownTimeout"))
+	}
+
+	return errors.Join(errs...)
+}
+
+// ConfigureTermination configures some defaults in the Viper instance.
+func ConfigureTermination(v *viper.Viper, prefixes ...string) {
+	prefixer := NewViperKeyPrefixer(prefixes...)
+
+	v.SetDefault(prefixer("checkInterval"), time.Second)
+	v.SetDefault(prefixer("gracefulShutdownTimeout"), 30*time.Second)
+	v.SetDefault(prefixer("propagationTimeout"), 3*time.Second)
+}

--- a/app/config/testdata/complete.yaml
+++ b/app/config/testdata/complete.yaml
@@ -2,6 +2,11 @@ address: 127.0.0.1:8888
 
 environment: local
 
+termination:
+  checkInterval: 7s
+  gracefulShutdownTimeout: 43s
+  propagationTimeout: 18s
+
 telemetry:
   address: 127.0.0.1:10000
 

--- a/cmd/server/.air.toml
+++ b/cmd/server/.air.toml
@@ -16,13 +16,13 @@ tmp_dir = "tmp"
   include_dir = []
   include_ext = ["go", "tpl", "tmpl", "html", "yml", "yaml", "sql", "json"]
   include_file = []
-  kill_delay = "0s"
+  kill_delay = "3s"
   log = "build-errors.log"
   poll = false
   poll_interval = 0
   rerun = false
   rerun_delay = 500
-  send_interrupt = false
+  send_interrupt = true
   stop_on_error = false
 
 [color]

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/openmeterio/openmeter/app/common"
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/debug"
 	"github.com/openmeterio/openmeter/openmeter/ingest"
@@ -213,6 +214,16 @@ func main() {
 		}
 	}
 	logger.Info("meters successfully created", "count", len(conf.Meters))
+
+	// Add service termination checker
+	{
+		terminationCheckerRun, terminationCheckerShutdown, err := common.NewTerminationCheckerActor(app.TerminationChecker, app.Logger)
+		if err != nil {
+			logger.Error("failed to initialize termination checker actor", "error", err)
+		}
+
+		group.Add(terminationCheckerRun, terminationCheckerShutdown)
+	}
 
 	// Set up telemetry server
 	{

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -60,6 +60,7 @@ type Application struct {
 	Subscription            common.SubscriptionServiceWithWorkflow
 	StreamingConnector      streaming.Connector
 	TelemetryServer         common.TelemetryServer
+	TerminationChecker      *common.TerminationChecker
 	RuntimeMetricsCollector common.RuntimeMetricsCollector
 }
 
@@ -90,6 +91,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		common.Secret,
 		common.ServerProvisionTopics,
 		common.Telemetry,
+		common.NewTerminationChecker,
 		common.WatermillNoPublisher,
 		wire.Struct(new(Application), "*"),
 	)

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -364,6 +364,19 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	}
 	telemetryHandler := common.NewTelemetryHandler(metricsTelemetryConfig, health, runtimeMetricsCollector, logger)
 	v7, cleanup8 := common.NewTelemetryServer(telemetryConfig, telemetryHandler)
+	terminationConfig := conf.Termination
+	terminationChecker, err := common.NewTerminationChecker(terminationConfig, health)
+	if err != nil {
+		cleanup8()
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
 	application := Application{
 		GlobalInitializer:       globalInitializer,
 		Migrator:                migrator,
@@ -391,6 +404,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		Subscription:            subscriptionServiceWithWorkflow,
 		StreamingConnector:      connector,
 		TelemetryServer:         v7,
+		TerminationChecker:      terminationChecker,
 		RuntimeMetricsCollector: runtimeMetricsCollector,
 	}
 	return application, func() {
@@ -435,6 +449,7 @@ type Application struct {
 	Subscription            common.SubscriptionServiceWithWorkflow
 	StreamingConnector      streaming.Connector
 	TelemetryServer         common.TelemetryServer
+	TerminationChecker      *common.TerminationChecker
 	RuntimeMetricsCollector common.RuntimeMetricsCollector
 }
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -4,6 +4,18 @@ telemetry:
   log:
     level: debug
 
+termination:
+  # checkInterval defines the time period used for updating the readiness check based on the termination status.
+  checkInterval: 1s
+  # gracefulShutdownTimeout defines the maximum time for the process to gracefully stop on receiving stop signal.
+  gracefulShutdownTimeout: 30s
+  # propagationTimeout defines how long to block the termination process in order
+  # to allow the termination event to be propagated to other systems. e.g. reverse proxy.
+  # Its value should be set higher than the failure threshold for readiness probe.
+  # In Kubernetes it should be: readiness.periodSeconds * (readiness.failureThreshold + 1) + CheckInterval
+  # propagationTimeout must always less than GracefulShutdownTimeout.
+  propagationTimeout: 3s
+
 #ingest:
 #  kafka:
 #    # To enable stats reporting set this value to >=5s.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.4
 
 toolchain go1.23.5
 
-//
+// ee: https://github.com/oklog/run/pull/35
 replace github.com/oklog/run => github.com/openmeterio/run v0.0.0-20250217124527-c72029d4b634
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,9 @@ go 1.23.4
 
 toolchain go1.23.5
 
+//
+replace github.com/oklog/run => github.com/openmeterio/run v0.0.0-20250217124527-c72029d4b634
+
 require (
 	entgo.io/ent v0.14.1
 	github.com/AppsFlyer/go-sundheit v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1918,8 +1918,6 @@ github.com/oasdiff/yaml v0.0.0-20241210131133-6b86fb107d80 h1:nZspmSkneBbtxU9Top
 github.com/oasdiff/yaml v0.0.0-20241210131133-6b86fb107d80/go.mod h1:7tFDb+Y51LcDpn26GccuUgQXUk6t0CXZsivKjyimYX8=
 github.com/oasdiff/yaml3 v0.0.0-20241210130736-a94c01f36349 h1:t05Ww3DxZutOqbMN+7OIuqDwXbhl32HiZGpLy26BAPc=
 github.com/oasdiff/yaml3 v0.0.0-20241210130736-a94c01f36349/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
-github.com/oklog/run v1.1.1-0.20240127200640-eee6e044b77c h1:UPP5+t0sCRHk8JklGdZTjqaGRlukvgitcKlw0/mrjr0=
-github.com/oklog/run v1.1.1-0.20240127200640-eee6e044b77c/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid/v2 v2.1.0 h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=
@@ -1952,6 +1950,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opencontainers/runc v1.1.13 h1:98S2srgG9vw0zWcDpFMn5TRrh8kLxa/5OFUstuUhmRs=
 github.com/opencontainers/runc v1.1.13/go.mod h1:R016aXacfp/gwQBYw2FDGa9m+n6atbLWrYY8hNMT/sA=
+github.com/openmeterio/run v0.0.0-20250217124527-c72029d4b634 h1:FR/Lc0U7pVop0FM6vYNzKqLYZIPJOppcXgsIveO/KQ0=
+github.com/openmeterio/run v0.0.0-20250217124527-c72029d4b634/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/opensearch-project/opensearch-go/v3 v3.1.0 h1:7EghS/+dCYD6PrsXjfIf3fvMOObkPtrDJVbovlNl3sY=
 github.com/opensearch-project/opensearch-go/v3 v3.1.0/go.mod h1:9UWs3sbIESBpsGlfhTmj5PXm3tXvgxRan4D+W9d700Q=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/openmeter/ingest/kafkaingest/collector.go
+++ b/openmeter/ingest/kafkaingest/collector.go
@@ -176,6 +176,8 @@ func KafkaProducerGroup(ctx context.Context, producer *kafka.Producer, logger *s
 			}
 		},
 		func(error) {
+			logger.DebugContext(ctx, "kafka ingest producer shutting down...")
+
 			cancel()
 		}
 }

--- a/pkg/gosundheit/logger.go
+++ b/pkg/gosundheit/logger.go
@@ -18,7 +18,7 @@ func NewLogger(logger *slog.Logger) health.CheckListener {
 
 func (c checkListener) OnCheckRegistered(name string, result health.Result) {
 	if result.Error != nil {
-		c.logger.Error("initial health check failed", slog.String("check", name), slog.Any("error", result.Error))
+		c.logger.Warn("initial health check failed", slog.String("check", name), slog.Any("error", result.Error))
 
 		return
 	}
@@ -32,7 +32,7 @@ func (c checkListener) OnCheckStarted(name string) {
 
 func (c checkListener) OnCheckCompleted(name string, result health.Result) {
 	if result.Error != nil {
-		c.logger.Error("health check failed", slog.String("check", name), slog.Any("error", result.Error))
+		c.logger.Warn("health check failed", slog.String("check", name), slog.Any("error", result.Error))
 
 		return
 	}


### PR DESCRIPTION
## Overview

* fix stopping service/actors in reverse order on process termination by reordering actors and using forked version of `oklog/run` (until upstream accepts PR or introduces similar feature)
* fix updating readiness endpoint on process termination by intorducing `TerminationChecker` which is registered in healthchecker and also added as an actor to control (deplay) process termination

