### PR TITLE
feat(collector): run-ai collector

### DIFF
--- a/collector/benthos/bloblang/parse_resource.go
+++ b/collector/benthos/bloblang/parse_resource.go
@@ -18,6 +18,12 @@ func init() {
 			return nil, err
 		}
 
+		if value == "" {
+			return func() (any, error) {
+				return 0, nil
+			}, nil
+		}
+
 		// Parse the resource quantity.
 		quantity, err := resource.ParseQuantity(value)
 		if err != nil {

--- a/collector/benthos/input/run_ai.go
+++ b/collector/benthos/input/run_ai.go
@@ -1,0 +1,337 @@
+package input
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/go-co-op/gocron/v2"
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/robfig/cron/v3"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/collector/benthos/input/runai"
+)
+
+var resourceTypes = []string{"workload"}
+
+const (
+	fieldURL                  = "url"
+	fieldAppID                = "app_id"
+	fieldAppSecret            = "app_secret"
+	fieldResourceType         = "resource_type"
+	fieldMetrics              = "metrics"
+	fieldSchedule             = "schedule"
+	fieldHTTPConfig           = "http"
+	fieldHTTPTimeout          = "timeout"
+	fieldHTTPRetryCount       = "retry_count"
+	fieldHTTPRetryWaitTime    = "retry_wait_time"
+	fieldHTTPRetryMaxWaitTime = "retry_max_wait_time"
+)
+
+func runAIInputConfig() *service.ConfigSpec {
+	return service.NewConfigSpec().
+		Beta().
+		Summary("Run AI metrics input.").
+		Fields(
+			service.NewStringField(fieldURL).
+				Description("Run AI base URL."),
+			service.NewStringField(fieldAppID).
+				Description("Run AI app ID."),
+			service.NewStringField(fieldAppSecret).
+				Description("Run AI app secret."),
+			service.NewStringEnumField(fieldResourceType, resourceTypes...).
+				Default("workload").
+				Description("Run AI resource to collect metrics from."),
+			service.NewStringListField(fieldMetrics).
+				Description("Run AI metrics to collect.").
+				Default(lo.Map([]runai.MetricType{
+					runai.MetricTypeCPULimitCores,
+					runai.MetricTypeCPUMemoryLimit,
+					runai.MetricTypeCPUMemoryRequest,
+					runai.MetricTypeCPUMemoryUsage,
+					runai.MetricTypeCPURequestCores,
+					runai.MetricTypeCPUUsageCores,
+					runai.MetricTypeGPUAllocation,
+					runai.MetricTypeGPUMemoryRequest,
+					runai.MetricTypeGPUMemoryUsage,
+					runai.MetricTypeGPUUtilization,
+					runai.MetricTypeRunningPodCount,
+				}, func(metric runai.MetricType, _ int) string {
+					return string(metric)
+				})),
+			service.NewStringField(fieldSchedule).
+				Description("The cron expression to use for the scrape job.").
+				Examples("*/30 * * * * *", "@every 30s").
+				Default("*/30 * * * * *"),
+			service.NewObjectField(fieldHTTPConfig,
+				service.NewDurationField(fieldHTTPTimeout).
+					Description("Request timeout.").
+					Default("30s"),
+				service.NewIntField(fieldHTTPRetryCount).
+					Description("The number of retries to attempt.").
+					Default(1),
+				service.NewDurationField(fieldHTTPRetryWaitTime).
+					Description("The wait time between retries.").
+					Default("100ms"),
+				service.NewDurationField(fieldHTTPRetryMaxWaitTime).
+					Description("The maximum wait time between retries.").
+					Default("1s"),
+			).Description("HTTP client configuration"),
+		).Example("Workload metrics", "Collect workload metrics from Run AI with a scrape interval of 30 seconds.", `
+input:
+	run_ai:
+		url: "${RUNAI_URL:}"
+		app_id: "${RUNAI_APP_ID:}"
+		app_secret: "${RUNAI_APP_SECRET:}"
+		schedule: "${RUNAI_SCRAPE_SCHEDULE:*/30 * * * * *}"
+		metrics:
+      - CPU_LIMIT_CORES
+      - CPU_MEMORY_LIMIT_BYTES
+      - CPU_MEMORY_REQUEST_BYTES
+      - CPU_MEMORY_USAGE_BYTES
+      - CPU_REQUEST_CORES
+      - CPU_USAGE_CORES
+      - GPU_ALLOCATION
+      - GPU_MEMORY_REQUEST_BYTES
+      - GPU_MEMORY_USAGE_BYTES
+		http:
+			timeout: "${RUNAI_HTTP_TIMEOUT:30s}"
+			retry_count: "${RUNAI_HTTP_RETRY_COUNT:1}"
+			retry_wait_time: "${RUNAI_HTTP_RETRY_WAIT_TIME:100ms}"
+			retry_max_wait_time: "${RUNAI_HTTP_RETRY_MAX_WAIT_TIME:1s}"
+`)
+}
+
+func init() {
+	// Set the global timezone to UTC.
+	loc, _ := time.LoadLocation("UTC")
+	time.Local = loc
+
+	err := service.RegisterBatchInput("run_ai", runAIInputConfig(), func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
+		return newRunAIInput(conf, mgr.Logger())
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+var _ service.BatchInput = (*runAIInput)(nil)
+
+type runAIInput struct {
+	logger       *service.Logger
+	service      *runai.Service
+	resourceType string
+	metrics      []runai.MetricType
+	interval     time.Duration
+	schedule     string
+	scheduler    gocron.Scheduler
+	store        map[time.Time][]runai.WorkloadWithMetrics
+	mu           sync.Mutex
+}
+
+func newRunAIInput(conf *service.ParsedConfig, logger *service.Logger) (*runAIInput, error) {
+	url, err := conf.FieldString(fieldURL)
+	if err != nil {
+		return nil, err
+	}
+
+	appID, err := conf.FieldString(fieldAppID)
+	if err != nil {
+		return nil, err
+	}
+
+	appSecret, err := conf.FieldString(fieldAppSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceType, err := conf.FieldString(fieldResourceType)
+	if err != nil {
+		return nil, err
+	}
+
+	metrics, err := conf.FieldStringList(fieldMetrics)
+	if err != nil {
+		return nil, err
+	}
+
+	schedule, err := conf.FieldString(fieldSchedule)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a cron scheduler
+	parser := cron.NewParser(cron.Second | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+	cronSchedule, err := parser.Parse(schedule)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get current time
+	now := time.Now()
+
+	// Get next two occurrences
+	nextRun := cronSchedule.Next(now)
+	secondRun := cronSchedule.Next(nextRun)
+
+	// Calculate the duration between runs
+	interval := secondRun.Sub(nextRun)
+
+	requestTimeout, err := conf.FieldDuration(fieldHTTPConfig, fieldHTTPTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	retryCount, err := conf.FieldInt(fieldHTTPConfig, fieldHTTPRetryCount)
+	if err != nil {
+		return nil, err
+	}
+
+	retryWaitTime, err := conf.FieldDuration(fieldHTTPConfig, fieldHTTPRetryWaitTime)
+	if err != nil {
+		return nil, err
+	}
+
+	retryMaxWaitTime, err := conf.FieldDuration(fieldHTTPConfig, fieldHTTPRetryMaxWaitTime)
+	if err != nil {
+		return nil, err
+	}
+
+	service, err := runai.NewService(url, appID, appSecret, logger, runai.HTTPRequestConfig{
+		Timeout:          requestTimeout,
+		RetryCount:       retryCount,
+		RetryWaitTime:    retryWaitTime,
+		RetryMaxWaitTime: retryMaxWaitTime,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	scheduler, err := gocron.NewScheduler()
+	if err != nil {
+		return nil, err
+	}
+
+	return &runAIInput{
+		logger:       logger,
+		service:      service,
+		resourceType: resourceType,
+		interval:     interval,
+		schedule:     schedule,
+		scheduler:    scheduler,
+		metrics: lo.Map(metrics, func(metric string, _ int) runai.MetricType {
+			return runai.MetricType(metric)
+		}),
+		store: make(map[time.Time][]runai.WorkloadWithMetrics),
+		mu:    sync.Mutex{},
+	}, nil
+}
+
+// scrape scrapes the metrics for the given time and adds them to the store.
+func (in *runAIInput) scrape(ctx context.Context, t time.Time) error {
+	in.logger.Debugf("scraping metrics between %s and %s", t.Add(-in.interval).Format(time.RFC3339), t.Format(time.RFC3339))
+	workloadsWithMetrics, err := in.service.GetAllWorkloadWithMetrics(ctx, runai.MeasurementParams{
+		MetricType: in.metrics,
+		StartTime:  t.Add(-in.interval),
+		EndTime:    t,
+	})
+	if err != nil {
+		return err
+	}
+
+	in.mu.Lock()
+	in.store[t] = workloadsWithMetrics
+	in.mu.Unlock()
+
+	return nil
+}
+
+func (in *runAIInput) Connect(ctx context.Context) error {
+	// Add a job to the scheduler
+	_, err := in.scheduler.NewJob(
+		gocron.CronJob(in.schedule, true),
+		gocron.NewTask(
+			func(ctx context.Context) error {
+				t := time.Now()
+				err := in.scrape(ctx, t)
+				if err != nil {
+					in.logger.Errorf("error scraping metrics: %v", err)
+					return err
+				}
+
+				return nil
+			},
+		),
+		gocron.WithContext(ctx),
+	)
+	if err != nil {
+		return err
+	}
+
+	// Start the scheduler
+	in.scheduler.Start()
+
+	return nil
+}
+
+func (in *runAIInput) ReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
+	if len(in.store) == 0 {
+		return nil, func(context.Context, error) error { return nil }, nil
+	}
+
+	in.mu.Lock()
+	defer in.mu.Unlock()
+
+	processing := make(map[time.Time][]runai.WorkloadWithMetrics)
+	batch := make([]*service.Message, 0)
+
+	for t, workloadsWithMetrics := range in.store {
+		in.logger.Tracef("reading metrics of %s", t.Format(time.RFC3339))
+
+		for _, workloadWithMetrics := range workloadsWithMetrics {
+			encoded, err := json.Marshal(workloadWithMetrics)
+			if err != nil {
+				return nil, func(context.Context, error) error { return nil }, err
+			}
+
+			msg := service.NewMessage(encoded)
+			msg.MetaSet("scrape_time", t.Format(time.RFC3339))
+			msg.MetaSet("scrape_interval", in.interval.String())
+			batch = append(batch, msg)
+		}
+
+		processing[t] = workloadsWithMetrics
+		delete(in.store, t)
+	}
+
+	in.logger.Debugf("read %d metrics", len(batch))
+
+	return batch, func(ctx context.Context, err error) error {
+		if err != nil {
+			in.mu.Lock()
+			defer in.mu.Unlock()
+
+			for t := range processing {
+				in.logger.Tracef("nack received, readding unprocessed metrics to store: %s", t.Format(time.RFC3339))
+				in.store[t] = processing[t]
+			}
+
+			return nil
+		}
+
+		in.logger.Tracef("ack received, discarding processed metrics")
+
+		return nil
+	}, nil
+}
+
+func (in *runAIInput) Close(ctx context.Context) error {
+	err := in.scheduler.StopJobs()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/collector/benthos/input/runai/metrics.go
+++ b/collector/benthos/input/runai/metrics.go
@@ -1,0 +1,129 @@
+package runai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
+)
+
+type MetricType string
+
+const (
+	MetricTypeCPULimitCores    MetricType = "CPU_LIMIT_CORES"
+	MetricTypeCPUMemoryLimit   MetricType = "CPU_MEMORY_LIMIT_BYTES"
+	MetricTypeCPUMemoryRequest MetricType = "CPU_MEMORY_REQUEST_BYTES"
+	MetricTypeCPUMemoryUsage   MetricType = "CPU_MEMORY_USAGE_BYTES"
+	MetricTypeCPURequestCores  MetricType = "CPU_REQUEST_CORES"
+	MetricTypeCPUUsageCores    MetricType = "CPU_USAGE_CORES"
+	MetricTypeGPUAllocation    MetricType = "GPU_ALLOCATION"
+	MetricTypeGPUMemoryRequest MetricType = "GPU_MEMORY_REQUEST_BYTES"
+	MetricTypeGPUMemoryUsage   MetricType = "GPU_MEMORY_USAGE_BYTES"
+	MetricTypeGPUUtilization   MetricType = "GPU_UTILIZATION"
+	MetricTypePodCount         MetricType = "POD_COUNT"
+	MetricTypeRunningPodCount  MetricType = "RUNNING_POD_COUNT"
+)
+
+type MeasurementParams struct {
+	MetricType []MetricType `json:"metricType"`
+	StartTime  time.Time    `json:"start"`
+	EndTime    time.Time    `json:"end"`
+}
+
+type Measurement struct {
+	Type   string `json:"type"`
+	Values []struct {
+		Value     string    `json:"value"`
+		Timestamp time.Time `json:"timestamp"`
+	} `json:"values"`
+}
+
+type MeasurementResponse struct {
+	Measurements []Measurement `json:"measurements"`
+}
+
+type Metrics struct {
+	Timestamp time.Time              `json:"timestamp"`
+	Values    map[MetricType]float64 `json:"values"`
+}
+
+// GetWorkloadMetrics gets metrics of a workload.
+func (s *Service) GetWorkloadMetrics(ctx context.Context, workloadID string, params MeasurementParams) (Metrics, error) {
+	m := Metrics{
+		Timestamp: params.StartTime,
+		Values:    make(map[MetricType]float64),
+	}
+
+	resp, err := s.client.R().
+		SetContext(ctx).
+		SetHeader("Accept", "application/json").
+		SetQueryParams(map[string]string{
+			"metricType": strings.Join(lo.Map(params.MetricType, func(metricType MetricType, _ int) string {
+				return string(metricType)
+			}), ","),
+			"start":           params.StartTime.Format(time.RFC3339),
+			"end":             params.EndTime.Format(time.RFC3339),
+			"numberOfSamples": "1",
+		}).
+		SetResult(&MeasurementResponse{}).
+		Get(fmt.Sprintf("/api/v1/workloads/%s/metrics", workloadID))
+	if err != nil {
+		return m, err
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return m, fmt.Errorf("failed to get workload metrics, status code: %d", resp.StatusCode())
+	}
+
+	result := resp.Result().(*MeasurementResponse)
+	if result == nil {
+		return m, fmt.Errorf("failed to get workload metrics, result is nil")
+	}
+
+	for _, measurement := range result.Measurements {
+		if len(measurement.Values) > 0 {
+			v, err := strconv.ParseFloat(measurement.Values[0].Value, 64)
+			if err != nil {
+				return m, fmt.Errorf("failed to parse metric value: %w", err)
+			}
+
+			m.Values[MetricType(measurement.Type)] = v
+		} else {
+			m.Values[MetricType(measurement.Type)] = 0
+		}
+	}
+
+	return m, nil
+}
+
+type WorkloadWithMetrics struct {
+	Workload
+	Timestamp time.Time `json:"timestamp"`
+	Metrics   Metrics   `json:"metrics"`
+}
+
+func (s *Service) GetAllWorkloadWithMetrics(ctx context.Context, params MeasurementParams) ([]WorkloadWithMetrics, error) {
+	workloads, err := s.ListAllWorkloads(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	workloadsWithMetrics := make([]WorkloadWithMetrics, len(workloads))
+	for i, workload := range workloads {
+		metrics, err := s.GetWorkloadMetrics(ctx, workload.ID, params)
+		if err != nil {
+			return nil, err
+		}
+
+		workloadsWithMetrics[i] = WorkloadWithMetrics{
+			Workload: workload,
+			Metrics:  metrics,
+		}
+	}
+
+	return workloadsWithMetrics, nil
+}

--- a/collector/benthos/input/runai/service.go
+++ b/collector/benthos/input/runai/service.go
@@ -1,0 +1,68 @@
+package runai
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+type Service struct {
+	logger    *service.Logger
+	client    *resty.Client
+	appID     string
+	appSecret string
+	token     string
+}
+
+type HTTPRequestConfig struct {
+	Timeout          time.Duration
+	RetryWaitTime    time.Duration
+	RetryMaxWaitTime time.Duration
+	RetryCount       int
+}
+
+func NewService(baseURL, appID, appSecret string, logger *service.Logger, requestConfig HTTPRequestConfig) (*Service, error) {
+	service := &Service{
+		logger:    logger,
+		appID:     appID,
+		appSecret: appSecret,
+	}
+
+	client := resty.New().
+		SetBaseURL(baseURL).
+		SetLogger(logger).
+		SetTimeout(requestConfig.Timeout).
+		SetRetryCount(requestConfig.RetryCount).
+		SetRetryWaitTime(requestConfig.RetryWaitTime).
+		SetRetryMaxWaitTime(requestConfig.RetryMaxWaitTime).
+		OnBeforeRequest(func(client *resty.Client, request *resty.Request) error {
+			service.logger.Tracef("request: %s", request.URL)
+
+			// Skip token request.
+			if request.URL == "/api/v1/token" {
+				return nil
+			}
+
+			err := service.RefreshToken(request.Context())
+			if err != nil {
+				return err
+			}
+
+			request.SetAuthToken(service.GetToken())
+
+			return nil
+		}).
+		OnAfterResponse(func(client *resty.Client, response *resty.Response) error {
+			if response.StatusCode() == http.StatusUnauthorized {
+				service.SetToken("")
+			}
+
+			return nil
+		})
+
+	service.client = client
+
+	return service, nil
+}

--- a/collector/benthos/input/runai/token.go
+++ b/collector/benthos/input/runai/token.go
@@ -1,0 +1,96 @@
+package runai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// TokenRequest represents the payload sent to obtain an API token.
+type TokenRequest struct {
+	GrantType string `json:"grantType"`
+	AppId     string `json:"AppId"`
+	AppSecret string `json:"AppSecret"`
+}
+
+// TokenResponse represents the response containing the access token.
+type TokenResponse struct {
+	AccessToken string `json:"accessToken"`
+}
+
+// RefreshToken refreshes the token if it's expired.
+func (s *Service) RefreshToken(ctx context.Context) error {
+	// If the token is not set, refresh it.
+	if s.token == "" {
+		token, err := s.NewToken(ctx)
+		if err != nil {
+			return err
+		}
+
+		s.SetToken(token)
+	}
+
+	// If the token is expired, refresh it.
+	err := s.verifyToken()
+	if err != nil {
+		token, err := s.NewToken(ctx)
+		if err != nil {
+			return err
+		}
+
+		s.SetToken(token)
+	}
+
+	return nil
+}
+
+// GetToken gets the current token for the service.
+func (s *Service) GetToken() string {
+	return s.token
+}
+
+// SetToken sets the token for the service.
+func (s *Service) SetToken(token string) {
+	s.token = token
+}
+
+// NewToken gets an access token for the application.
+func (s *Service) NewToken(ctx context.Context) (string, error) {
+	s.logger.Trace("refreshing token")
+
+	resp, err := s.client.R().
+		SetContext(ctx).
+		SetHeader("Accept", "application/json").
+		SetHeader("Content-Type", "application/json").
+		SetBody(TokenRequest{
+			GrantType: "app_token",
+			AppId:     s.appID,
+			AppSecret: s.appSecret,
+		}).
+		SetResult(&TokenResponse{}).
+		Post("/api/v1/token")
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return "", fmt.Errorf("failed to refresh token, status code: %d", resp.StatusCode())
+	}
+
+	result := resp.Result().(*TokenResponse)
+	return result.AccessToken, nil
+}
+
+// verifyToken parses the token and checks if the token is expired.
+func (s *Service) verifyToken() error {
+	// Parse the token without verifying its signature.
+	parser := jwt.NewParser(jwt.WithoutClaimsValidation(), jwt.WithExpirationRequired())
+	_, _, err := parser.ParseUnverified(s.token, jwt.MapClaims{})
+	if err != nil {
+		return fmt.Errorf("failed to parse token: %w", err)
+	}
+
+	return nil
+}

--- a/collector/benthos/input/runai/workloads.go
+++ b/collector/benthos/input/runai/workloads.go
@@ -1,0 +1,121 @@
+package runai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// TODO: add fields as needed, see: https://api-docs.run.ai/latest/tag/Workloads#operation/get_workloads
+// Workload represents a Run:ai workload.
+type Workload struct {
+	TenantID                   int    `json:"tenantId"`
+	Type                       string `json:"type"`
+	Namespace                  string `json:"namespace"`
+	Name                       string `json:"name"`
+	ID                         string `json:"id"`
+	PriorityClassName          string `json:"priorityClassName"`
+	SubmittedBy                string `json:"submittedBy"`
+	ClusterID                  string `json:"clusterId"`
+	ProjectName                string `json:"projectName"`
+	ProjectID                  string `json:"projectId"`
+	DepartmentName             string `json:"departmentName"`
+	DepartmentID               string `json:"departmentId"`
+	RunningPods                int    `json:"runningPods"`
+	WorkloadRequestedResources struct {
+		GPURequestType string `json:"gpuRequestType"`
+		GPU            struct {
+			Limit   float64 `json:"limit"`
+			Request float64 `json:"request"`
+		} `json:"gpu"`
+		GPUMemory struct {
+			Limit   string `json:"limit"`
+			Request string `json:"request"`
+		} `json:"gpuMemory"`
+		CPU struct {
+			Limit   float64 `json:"limit"`
+			Request float64 `json:"request"`
+		} `json:"cpu"`
+		CPUMemory struct {
+			Limit   string `json:"limit"`
+			Request string `json:"request"`
+		} `json:"cpuMemory"`
+	} `json:"workloadRequestedResources"`
+	AllocatedResources struct {
+		GPU       float64 `json:"gpu"`
+		GPUMemory string  `json:"gpuMemory"`
+		CPU       float64 `json:"cpu"`
+		CPUMemory string  `json:"cpuMemory"`
+	} `json:"allocatedResources"`
+	Phase         string `json:"phase"`
+	Preemptible   *bool  `json:"preemptible,omitempty"`
+	RequestedPods struct {
+		Count int `json:"count"`
+	} `json:"requestedPods"`
+	IdleGPUs          *int      `json:"idleGpus,omitempty"`
+	IdleAllocatedGPUs *float64  `json:"idleAllocatedGpus,omitempty"`
+	CreatedAt         time.Time `json:"createdAt"`
+}
+
+type ListWorkloadParams struct {
+	Limit  int `json:"limit,omitempty"`
+	Offset int `json:"offset,omitempty"`
+}
+
+type ListWorkloadsResponse struct {
+	Workloads []Workload `json:"workloads"`
+	Next      int        `json:"next"`
+}
+
+// ListWorkloads lists workloads.
+func (s *Service) ListWorkloads(ctx context.Context, params ListWorkloadParams) (*ListWorkloadsResponse, error) {
+	if params.Limit > 500 {
+		return nil, fmt.Errorf("limit must be less than 500")
+	}
+
+	resp, err := s.client.R().
+		SetContext(ctx).
+		SetHeader("Accept", "application/json").
+		SetQueryParams(map[string]string{
+			"limit":    fmt.Sprintf("%d", params.Limit),
+			"offset":   fmt.Sprintf("%d", params.Offset),
+			"filterBy": "phase==Running",
+		}).
+		SetResult(&ListWorkloadsResponse{}).
+		Get("/api/v1/workloads")
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("failed to list workloads, status code: %d", resp.StatusCode())
+	}
+
+	s.logger.Tracef("list workloads response: %+v", resp.Result())
+	result := resp.Result().(*ListWorkloadsResponse)
+	return result, nil
+}
+
+// ListAllWorkloads lists all workloads.
+func (s *Service) ListAllWorkloads(ctx context.Context) ([]Workload, error) {
+	workloads := make([]Workload, 0)
+
+	for {
+		resp, err := s.ListWorkloads(ctx, ListWorkloadParams{
+			Limit:  500,
+			Offset: len(workloads),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		workloads = append(workloads, resp.Workloads...)
+
+		if resp.Next == 0 {
+			break
+		}
+	}
+
+	return workloads, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/go-chi/cors v1.2.1
 	github.com/go-chi/render v1.0.3
+	github.com/go-co-op/gocron/v2 v2.15.0
+	github.com/go-resty/resty/v2 v2.15.3
 	github.com/go-slog/otelslog v0.3.0
 	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/golang-cz/devslog v0.0.11
@@ -126,6 +128,7 @@ require (
 	github.com/hamba/avro/v2 v2.27.0 // indirect
 	github.com/invopop/validation v0.8.0 // indirect
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
+	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/jzelinskie/stringz v0.0.3 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/neo4j/neo4j-go-driver/v5 v5.27.0 // indirect
@@ -409,7 +412,7 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rickb777/plural v1.4.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
-	github.com/robfig/cron/v3 v3.0.1 // indirect
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.6.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1253,6 +1253,8 @@ github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
 github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-chi/render v1.0.3 h1:AsXqd2a1/INaIfUSKq3G5uA8weYx20FOsM7uSoCyyt4=
 github.com/go-chi/render v1.0.3/go.mod h1:/gr3hVkmYR0YlEy3LxCuVRFzEu9Ruok+gFqbIofjao0=
+github.com/go-co-op/gocron/v2 v2.15.0 h1:Kpvo71VSihE+RImmpA+3ta5CcMhoRzMGw4dJawrj4zo=
+github.com/go-co-op/gocron/v2 v2.15.0/go.mod h1:ZF70ZwEqz0OO4RBXE1sNxnANy/zvwLcattWEFsqpKig=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-faker/faker/v4 v4.5.0 h1:ARzAY2XoOL9tOUK+KSecUQzyXQsUaZHefjyF8x6YFHc=
@@ -1308,6 +1310,8 @@ github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GO
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/go-resty/resty/v2 v2.15.3 h1:bqff+hcqAflpiF591hhJzNdkRsFhlB96CYfBwSFvql8=
+github.com/go-resty/resty/v2 v2.15.3/go.mod h1:0fHAoK7JoBy/Ch36N8VFeMsK7xQOHhvWaC3iOktwmIU=
 github.com/go-slog/otelslog v0.3.0 h1:O/ettamJL9sJKCmtEa/xHF5dqHvWF6xION/NIiZJ6gk=
 github.com/go-slog/otelslog v0.3.0/go.mod h1:TxQTymq11rhMaNLE4yMe3kXuUf9ksoGyN9ivieHFWu8=
 github.com/go-sourcemap/sourcemap v2.1.4+incompatible h1:a+iTbH5auLKxaNwQFg0B+TCYl6lbukKPc7b5x0n1s6Q=


### PR DESCRIPTION
Example config:

```yaml
logger:
  level: DEBUG

input:
  run_ai:
    url: "${RUNAI_URL:}"
    app_id: "${RUNAI_APP_ID:}"
    app_secret: "${RUNAI_APP_SECRET:}"
    schedule: "${RUNAI_SCRAPE_SCHEDULE:*/30 * * * * *}"
    metrics:
      - CPU_LIMIT_CORES
      - CPU_MEMORY_LIMIT_BYTES
      - CPU_MEMORY_REQUEST_BYTES
      - CPU_MEMORY_USAGE_BYTES
      - CPU_REQUEST_CORES
      - CPU_USAGE_CORES
      - GPU_ALLOCATION
      - GPU_MEMORY_REQUEST_BYTES
      - GPU_MEMORY_USAGE_BYTES
      - RUNNING_POD_COUNT
    http:
      timeout: "30s"
      retry_count: 1
      retry_wait_time: "100ms"
      retry_max_wait_time: "1s"

pipeline:
  processors:
    - mapping: |
        let duration_seconds = (meta("scrape_interval").parse_duration() / 1000 / 1000 / 1000).round().int64()

        root = {
          "id": "%s-%d-%s".format(this.metrics.timestamp, $duration_seconds, this.id).hash("sha1").encode("hex"),
          "specversion": "1.0",
          "type": "run-ai",
          "source": "collector",
          "time": this.metrics.timestamp,
          "subject": this.tenantId.string(),
          "data": {
            "workload_id": this.id,
            "type": this.type,
            "name": this.name,
            "namespace": this.namespace,
            "workload_minutes": $duration_seconds / 60,
            "priority": this.priorityClassName,
            "submitted_by": this.submittedBy,
            "cluster_id": this.clusterId,
            "project_name": this.projectName,
            "project_id": this.projectId,
            "department_name": this.departmentName,
            "department_id": this.departmentId,
            "cpu_limit_core_minutes": this.metrics.values.CPU_LIMIT_CORES.number(0) * $duration_seconds / 60,
            "cpu_request_core_minutes": this.metrics.values.CPU_REQUEST_CORES.number(0) * $duration_seconds / 60,
            "cpu_memory_limit_gigabyte_minutes": this.metrics.values.CPU_MEMORY_LIMIT_BYTES.number(0) / 1024 / 1024 / 1024 * $duration_seconds / 60,
            "cpu_memory_request_gigabyte_minutes": this.metrics.values.CPU_MEMORY_REQUEST_BYTES.number(0) / 1024 / 1024 / 1024 * $duration_seconds / 60,
            "cpu_memory_usage_gigabyte_minutes": this.metrics.values.CPU_MEMORY_USAGE_BYTES.number(0) / 1024 / 1024 / 1024 * $duration_seconds / 60,
            "cpu_usage_core_minutes": this.metrics.values.CPU_USAGE_CORES.number(0) * $duration_seconds / 60,
            "gpu_allocation_minutes": this.metrics.values.GPU_ALLOCATION.number(0) * $duration_seconds / 60,
            "gpu_memory_request_gigabyte_minutes": this.metrics.values.GPU_MEMORY_REQUEST_BYTES.number(0) / 1024 / 1024 / 1024 * $duration_seconds / 60,
            "gpu_memory_usage_gigabyte_minutes": this.metrics.values.GPU_MEMORY_USAGE_BYTES.number(0) / 1024 / 1024 / 1024 * $duration_seconds / 60,
            "gpu_utilization_minutes": this.metrics.values.GPU_UTILIZATION.number(0) * $duration_seconds / 60,
            "running_pod_count_minutes": this.metrics.values.RUNNING_POD_COUNT.number(0) * $duration_seconds / 60,
          },
        }
    - json_schema:
        schema_path: "file://./cloudevents.spec.json"
    - catch:
        - log:
            level: ERROR
            message: "schema validation failed due to: ${!error()}"
        - mapping: "root = deleted()"

output:
  switch:
    cases:
      - check: ""
        continue: true
        output:
          openmeter:
            url: "${OPENMETER_URL:https://openmeter.cloud}"
            token: "${OPENMETER_TOKEN:}"
            batching:
              count: ${BATCH_SIZE:20}
              period: ${BATCH_PERIOD:1s}

      - check: '"${DEBUG:false}" == "true"'
        output:
          stdout:
            codec: lines
```

Example event:

```json
{
  "specversion": "1.0",
  "id": "869ccc46e20c320c221b46d6c20b9ae027dcaf4c",
  "source": "collector",
  "type": "run-ai",
  "subject": "1738",
  "datacontenttype": "application/json",
  "time": "2025-02-18T21:02:00Z",
  "data": {
    "cluster_id": "29dcaea8-9f15-49e3-b381-562e81d217e8",
    "cpu_limit_core_minutes": 0,
    "cpu_memory_limit_gigabyte_minutes": 0,
    "cpu_memory_request_gigabyte_minutes": 0.046566128730773926,
    "cpu_memory_usage_gigabyte_minutes": 0.27559471130371094,
    "cpu_request_core_minutes": 0.05,
    "cpu_usage_core_minutes": 0.0000472136392523649,
    "department_id": "4519671",
    "department_name": "benchmark",
    "gpu_allocation_minutes": 0,
    "gpu_memory_request_gigabyte_minutes": 0,
    "gpu_memory_usage_gigabyte_minutes": 0,
    "gpu_utilization_minutes": 0,
    "name": "jupyter",
    "namespace": "notebooks",
    "priority": "build",
    "project_id": "4519672",
    "project_name": "project",
    "running_pod_count_minutes": 0.5,
    "submitted_by": "user@email.com",
    "type": "Workspace",
    "workload_id": "e07a77ff-dc77-4b45-91c8-8be00dba0d10",
    "workload_minutes": 0.5
  }
}
```