### PR TITLE
Entitlement Reset Calculation (Entitlement Reset Part II) 

### DIFF
--- a/.dagger/test_e2e.go
+++ b/.dagger/test_e2e.go
@@ -60,12 +60,16 @@ func (m *Openmeter) Etoe(
 		WithServiceBinding("api", api).
 		WithServiceBinding("sink-worker", sinkWorker)
 
+	// FIXME(galexi): Log exceeds max size limits on GH so we can't print it
+
 	// Create a wrapper command that runs the tests and prints logs on failure
-	cmdArgs := append([]string{"sh", "-c"}, fmt.Sprintf(`%s || {
-		echo "Tests failed. Printing openmeter.log:";
-		cat /var/log/openmeter/openmeter.log;
-		exit 1;
-	}`, strings.Join(args, " ")))
+	// cmdArgs := append([]string{"sh", "-c"}, fmt.Sprintf(`%s || {
+	// 	echo "Tests failed. Printing openmeter.log:";
+	// 	cat /var/log/openmeter/openmeter.log;
+	// 	exit 1;
+	// }`, strings.Join(args, " ")))
+
+	cmdArgs := []string{"sh", "-c", strings.Join(args, " ")}
 
 	return testContainer.Container().
 		WithMountedCache("/var/log/openmeter", sharedLogs).

--- a/openmeter/billing/worker/subscription/sync_test.go
+++ b/openmeter/billing/worker/subscription/sync_test.go
@@ -223,6 +223,7 @@ func (s *SubscriptionHandlerTestSuite) SetupEntitlements() entitlement.Connector
 		grantRepo,
 		entitlementRepo,
 		mockPublisher,
+		slog.Default(),
 	)
 
 	staticEntitlementConnector := staticentitlement.NewStaticEntitlementConnector()

--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -91,10 +91,12 @@ func (m *connector) GetBalanceOfOwner(ctx context.Context, owner grant.Namespace
 		return nil, fmt.Errorf("failed to calculate balance for owner %s at %s: %w", owner.ID, at, err)
 	}
 
-	history, err := engine.NewGrantBurnDownHistory(result.History)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create grant burn down history: %w", err)
-	}
+	// TODO: add back saving snapshots
+
+	// history, err := engine.NewGrantBurnDownHistory(result.History)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("failed to create grant burn down history: %w", err)
+	// }
 
 	// FIXME: It can be the case that we never actually save anything if the history has a single segment.
 	// In practice what we can save is the balance at the last activation or recurrence event
@@ -104,23 +106,23 @@ func (m *connector) GetBalanceOfOwner(ctx context.Context, owner grant.Namespace
 	// just so it can be saved...
 	//
 	// FIXME: we should do this comparison not with the queried time but the current time...
-	if snap, err := m.getLastSaveableSnapshotAt(history, bal, at); err == nil {
-		grantMap := make(map[string]grant.Grant, len(grants))
-		for _, grant := range grants {
-			grantMap[grant.ID] = grant
-		}
-		activeBalance, err := m.excludeInactiveGrantsFromBalance(snap.Balances, grantMap, at)
-		if err != nil {
-			return nil, err
-		}
-		snap.Balances = *activeBalance
-		err = m.balanceSnapshotRepo.Save(ctx, owner, []balance.Snapshot{
-			*snap,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("failed to save balance for owner %s at %s: %w", owner.ID, at, err)
-		}
-	}
+	// if snap, err := m.getLastSaveableSnapshotAt(history, bal, at); err == nil {
+	// 	grantMap := make(map[string]grant.Grant, len(grants))
+	// 	for _, grant := range grants {
+	// 		grantMap[grant.ID] = grant
+	// 	}
+	// 	activeBalance, err := m.excludeInactiveGrantsFromBalance(snap.Balances, grantMap, at)
+	// 	if err != nil {
+	// 		return nil, err
+	// 	}
+	// 	snap.Balances = *activeBalance
+	// 	err = m.balanceSnapshotRepo.Save(ctx, owner, []balance.Snapshot{
+	// 		*snap,
+	// 	})
+	// 	if err != nil {
+	// 		return nil, fmt.Errorf("failed to save balance for owner %s at %s: %w", owner.ID, at, err)
+	// 	}
+	// }
 
 	// return balance
 	return &result.Snapshot, nil

--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -3,7 +3,6 @@ package credit
 import (
 	"context"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/openmeterio/openmeter/openmeter/credit/balance"
@@ -37,44 +36,45 @@ type BalanceHistoryParams struct {
 var _ BalanceConnector = &connector{}
 
 func (m *connector) GetBalanceOfOwner(ctx context.Context, owner grant.NamespacedOwner, at time.Time) (*balance.Snapshot, error) {
+	m.logger.Debug("getting balance of owner", "owner", owner.ID, "at", at)
+
 	// To include the current last minute lets round it trunc to the next minute
 	if trunc := at.Truncate(time.Minute); trunc.Before(at) {
 		at = trunc.Add(time.Minute)
 	}
 
 	// get last valid grantbalances
-	bal, err := m.getLastValidBalanceSnapshotForOwnerAt(ctx, owner, at)
+	snap, err := m.getLastValidBalanceSnapshotForOwnerAt(ctx, owner, at)
 	if err != nil {
 		return nil, err
 	}
 
-	periodStart, err := m.ownerConnector.GetUsagePeriodStartAt(ctx, owner, at)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current usage period start for owner %s at %s: %w", owner.ID, at, err)
+	period := timeutil.Period{
+		From: snap.At,
+		To:   at,
 	}
-	if bal.At.Before(periodStart) {
-		// This is an inconsistency check. It can only happen if we lost our snapshot for the last reset.
-		//
-		// The engine doesn't manage rollovers at usage reset so it cannot be used to calculate GrantBurnDown across resets.
-		return nil, fmt.Errorf("last valid balance snapshot %s is before current period start at %s, no snapshot was created for reset", bal.At, periodStart)
+
+	// get all usage resets between queryied period
+	resetTimesInclusive, err := m.ownerConnector.GetResetTimelineInclusive(ctx, owner, period)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get reset times between %s and %s for owner %s: %w", period.From, period.To, owner.ID, err)
+	}
+
+	resetBehavior, err := m.ownerConnector.GetResetBehavior(ctx, owner)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get reset behavior for owner %s: %w", owner.ID, err)
 	}
 
 	// get all relevant grants
-	grants, err := m.grantRepo.ListActiveGrantsBetween(ctx, owner, bal.At, at)
+	grants, err := m.grantRepo.ListActiveGrantsBetween(ctx, owner, snap.At, at)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list active grants at %s for owner %s: %w", at, owner.ID, err)
 	}
 	// These grants might not be present in the starting balance so lets fill them
 	// This is only possible in case the grant becomes active exactly at the start of the current period
-	m.populateBalanceSnapshotWithMissingGrantsActiveAt(&bal, grants, bal.At)
+	m.populateBalanceSnapshotWithMissingGrantsActiveAt(&snap, grants, snap.At)
 
-	// Let's define the period the engine will be queried for
-	queriedPeriod := timeutil.Period{
-		From: bal.At,
-		To:   at,
-	}
-
-	eng, err := m.buildEngineForOwner(ctx, owner, queriedPeriod)
+	eng, err := m.buildEngineForOwner(ctx, owner, period)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,10 @@ func (m *connector) GetBalanceOfOwner(ctx context.Context, owner grant.Namespace
 		ctx,
 		engine.RunParams{
 			Grants:           grants,
-			StartingSnapshot: bal,
-			Until:            queriedPeriod.To,
+			StartingSnapshot: snap,
+			Until:            period.To,
+			ResetBehavior:    resetBehavior,
+			Resets:           resetTimesInclusive.After(snap.At),
 		},
 	)
 	if err != nil {
@@ -134,113 +136,60 @@ func (m *connector) GetBalanceHistoryOfOwner(ctx context.Context, owner grant.Na
 	if trunc := params.To.Truncate(time.Minute); trunc.Before(params.To) {
 		params.To = trunc.Add(time.Minute)
 	}
-	// get all usage resets between queryied period
-	startTimes, err := m.ownerConnector.GetPeriodStartTimesBetween(ctx, owner, params.From, params.To)
-	if err != nil {
-		return engine.GrantBurnDownHistory{}, fmt.Errorf("failed to get period start times between %s and %s for owner %s: %w", params.From, params.To, owner.ID, err)
+
+	period := timeutil.Period{
+		From: params.From,
+		To:   params.To,
 	}
-	times := []time.Time{params.From}
-	times = append(times, startTimes...)
-	times = append(times, params.To)
 
-	periods := SortedPeriodsFromDedupedTimes(times)
-	historySegments := make([]engine.GrantBurnDownHistorySegment, 0, len(periods))
+	// get all usage resets between queryied period
+	resetTimesInclusive, err := m.ownerConnector.GetResetTimelineInclusive(ctx, owner, period)
+	if err != nil {
+		return engine.GrantBurnDownHistory{}, fmt.Errorf("failed to get reset times between %s and %s for owner %s: %w", params.From, params.To, owner.ID, err)
+	}
 
-	// For each period we'll have to calculate separately as we cannot calculate across resets.
-	// For each period, we will:
-	// 1. Find the last valid snapshot before the period start (might be at or before the period start)
-	// 2. Calculate the balance at the period start
-	// 3. Calculate the balance through the period
-	for _, period := range periods {
-		// Get last valid BalanceSnapshot before (or at) the period start
-		snap, err := m.getLastValidBalanceSnapshotForOwnerAt(ctx, owner, period.From)
-		if err != nil {
-			return engine.GrantBurnDownHistory{}, err
-		}
+	resetBehavior, err := m.ownerConnector.GetResetBehavior(ctx, owner)
+	if err != nil {
+		return engine.GrantBurnDownHistory{}, fmt.Errorf("failed to get reset behavior for owner %s: %w", owner.ID, err)
+	}
 
-		if period.From.Before(snap.At) {
-			// This is an inconsistency check. It can only happen if we lost our snapshot for the reset.
-			//
-			// The engine doesn't manage rollovers at usage reset so it cannot be used to calculate GrantBurnDown across resets.
-			// FIXME: this is theoretically possible, we need to handle it, add capability to ledger.
-			return engine.GrantBurnDownHistory{}, fmt.Errorf("current period start %s is before last valid balance snapshot at %s, no snapshot was created for reset", period.From, snap.At)
-		}
+	// For the history result to start from the correct period start we need to start from a synthetic snapshot by calculating the balance at the period start
+	snap, err := m.GetBalanceOfOwner(ctx, owner, period.From)
+	if err != nil {
+		return engine.GrantBurnDownHistory{}, err
+	}
 
-		// First, let's calculate the balance from the last snapshot until the start of the period
+	// get all relevant grants
+	grants, err := m.grantRepo.ListActiveGrantsBetween(ctx, owner, snap.At, period.To)
+	if err != nil {
+		return engine.GrantBurnDownHistory{}, err
+	}
 
-		// get all relevant grants
-		grants, err := m.grantRepo.ListActiveGrantsBetween(ctx, owner, snap.At, period.From)
-		if err != nil {
-			return engine.GrantBurnDownHistory{}, err
-		}
+	// These grants might not be present in the starting balance so lets fill them
+	// This is only possible in case the grant becomes active exactly at the start of the first period
+	m.populateBalanceSnapshotWithMissingGrantsActiveAt(snap, grants, snap.At)
 
-		// These grants might not be present in the starting balance so lets fill them
-		// This is only possible in case the grant becomes active exactly at the start of the current period
-		m.populateBalanceSnapshotWithMissingGrantsActiveAt(&snap, grants, snap.At)
+	eng, err := m.buildEngineForOwner(ctx, owner, period)
+	if err != nil {
+		return engine.GrantBurnDownHistory{}, err
+	}
 
-		periodFromSnapshotToPeriodStart := timeutil.Period{
-			From: snap.At,
-			To:   period.From,
-		}
-
-		eng, err := m.buildEngineForOwner(ctx, owner, periodFromSnapshotToPeriodStart)
-		if err != nil {
-			return engine.GrantBurnDownHistory{}, err
-		}
-
-		result, err := eng.Run(
-			ctx,
-			engine.RunParams{
-				Grants:           grants,
-				StartingSnapshot: snap,
-				Until:            periodFromSnapshotToPeriodStart.To,
-			},
-		)
-		if err != nil {
-			return engine.GrantBurnDownHistory{}, fmt.Errorf("failed to calculate balance for owner %s at %s: %w", owner.ID, period.From, err)
-		}
-
-		fakeSnapshotForPeriodStart := result.Snapshot
-
-		// Second, lets calculate the balance for the period
-
-		// get all relevant grants
-		grants, err = m.grantRepo.ListActiveGrantsBetween(ctx, owner, period.From, period.To)
-		if err != nil {
-			return engine.GrantBurnDownHistory{}, err
-		}
-
-		// These grants might not be present in the starting balance so lets fill them
-		// This is only possible in case the grant becomes active exactly at the start of the current period
-		m.populateBalanceSnapshotWithMissingGrantsActiveAt(&fakeSnapshotForPeriodStart, grants, period.From)
-
-		eng, err = m.buildEngineForOwner(ctx, owner, period)
-		if err != nil {
-			return engine.GrantBurnDownHistory{}, err
-		}
-
-		res, err := eng.Run(
-			ctx,
-			engine.RunParams{
-				Grants:           grants,
-				StartingSnapshot: fakeSnapshotForPeriodStart,
-				Until:            period.To,
-			},
-		)
-		if err != nil {
-			return engine.GrantBurnDownHistory{}, fmt.Errorf("failed to calculate balance for owner %s at %s: %w", owner.ID, period.To, err)
-		}
-
-		// set reset as reason for last segment if current period end is a reset
-		if slices.Contains(startTimes, period.To) {
-			res.History[len(res.History)-1].TerminationReasons.UsageReset = true
-		}
-
-		historySegments = append(historySegments, res.History...)
+	result, err := eng.Run(
+		ctx,
+		engine.RunParams{
+			Grants:           grants,
+			StartingSnapshot: *snap,
+			Until:            period.To,
+			ResetBehavior:    resetBehavior,
+			Resets:           resetTimesInclusive.After(snap.At),
+		},
+	)
+	if err != nil {
+		return engine.GrantBurnDownHistory{}, fmt.Errorf("failed to calculate balance for owner %s at %s: %w", owner.ID, period.From, err)
 	}
 
 	// return history
-	history, err := engine.NewGrantBurnDownHistory(historySegments)
+	history, err := engine.NewGrantBurnDownHistory(result.History)
 	if err != nil || history == nil {
 		return engine.GrantBurnDownHistory{}, fmt.Errorf("failed to create grant burn down history: %w", err)
 	}

--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -209,7 +209,7 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, owner grant.Namespac
 
 	at := params.At.Truncate(ownerMeter.Meter.WindowSize.Duration())
 
-	// check if reset is possible (after last reset)
+	// check if reset is possible (not before current period)
 	periodStart, err := m.ownerConnector.GetUsagePeriodStartAt(ctx, owner, clock.Now())
 	if err != nil {
 		if _, ok := err.(*grant.OwnerNotFoundError); ok {

--- a/openmeter/credit/connector.go
+++ b/openmeter/credit/connector.go
@@ -27,8 +27,7 @@ type connector struct {
 	streamingConnector streaming.Connector
 	logger             *slog.Logger
 	// configuration
-	snapshotGracePeriod time.Duration
-	granularity         time.Duration
+	granularity time.Duration
 }
 
 func NewCreditConnector(
@@ -53,7 +52,6 @@ func NewCreditConnector(
 		publisher: publisher,
 
 		// TODO: make configurable
-		granularity:         granularity,
-		snapshotGracePeriod: time.Hour,
+		granularity: granularity,
 	}
 }

--- a/openmeter/credit/connector.go
+++ b/openmeter/credit/connector.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/isodate"
 )
 
 type CreditConnector interface {
@@ -27,7 +28,8 @@ type connector struct {
 	streamingConnector streaming.Connector
 	logger             *slog.Logger
 	// configuration
-	granularity time.Duration
+	granularity         time.Duration
+	snapshotGracePeriod isodate.Period
 }
 
 func NewCreditConnector(
@@ -52,6 +54,12 @@ func NewCreditConnector(
 		publisher: publisher,
 
 		// TODO: make configurable
-		granularity: granularity,
+		granularity:         granularity,
+		snapshotGracePeriod: isodate.NewPeriod(0, 0, 1, 0, 0, 0, 0),
 	}
+}
+
+func (c *connector) getSnapshotBefore(at time.Time) time.Time {
+	t, _ := c.snapshotGracePeriod.Negate().AddTo(at)
+	return t
 }

--- a/openmeter/credit/engine/burnphase.go
+++ b/openmeter/credit/engine/burnphase.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -17,6 +18,7 @@ type burnPhase struct {
 }
 
 // Calculates the burn phases for the given period.
+// The period is expected not to contain any resets.
 //
 // A new burn phase starts when:
 // 1) A grant recurrs
@@ -24,9 +26,9 @@ type burnPhase struct {
 //
 // Note that grant balance does not effect the burndown order if we simply ignore grants that don't
 // have balance while burning down.
-func (e *engine) getPhases(period timeutil.Period) ([]burnPhase, error) {
-	activityChanges := e.getGrantActivityChanges(period)
-	recurrenceTimes, err := e.getGrantRecurrenceTimes(period)
+func (e *engine) getPhases(grants []grant.Grant, period timeutil.Period) ([]burnPhase, error) {
+	activityChanges := e.getGrantActivityChanges(grants, period)
+	recurrenceTimes, err := e.getGrantRecurrenceTimes(grants, period)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get grant recurrence times: %w", err)
 	}

--- a/openmeter/credit/engine/engine.go
+++ b/openmeter/credit/engine/engine.go
@@ -18,10 +18,10 @@ type RunParams struct {
 	// Starting snapshot of the balances at the START OF THE PERIOD.
 	StartingSnapshot balance.Snapshot
 	// ResetBehavior defines the behavior of the engine when a reset is encountered.
-	ResetBehavior ResetBehavior
+	ResetBehavior grant.ResetBehavior
 	// Timeline of the resets that occurred in the period.
 	// The resets must occur AFTER the starting snapshot and NOT AFTER the until time. (exclusive - inclusive)
-	Resets timeutil.Timeline
+	Resets timeutil.SimpleTimeline
 }
 
 type RunResult struct {

--- a/openmeter/credit/engine/engine.go
+++ b/openmeter/credit/engine/engine.go
@@ -20,6 +20,7 @@ type RunParams struct {
 	// ResetBehavior defines the behavior of the engine when a reset is encountered.
 	ResetBehavior ResetBehavior
 	// Timeline of the resets that occurred in the period.
+	// The resets must occur AFTER the starting snapshot and NOT AFTER the until time. (exclusive - inclusive)
 	Resets timeutil.Timeline
 }
 

--- a/openmeter/credit/engine/engine.go
+++ b/openmeter/credit/engine/engine.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/credit/balance"
 	"github.com/openmeterio/openmeter/openmeter/credit/grant"
 	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type RunParams struct {
@@ -16,6 +17,10 @@ type RunParams struct {
 	Until time.Time
 	// Starting snapshot of the balances at the START OF THE PERIOD.
 	StartingSnapshot balance.Snapshot
+	// ResetBehavior defines the behavior of the engine when a reset is encountered.
+	ResetBehavior ResetBehavior
+	// Timeline of the resets that occurred in the period.
+	Resets timeutil.Timeline
 }
 
 type RunResult struct {
@@ -50,10 +55,6 @@ func NewEngine(conf EngineConfig) Engine {
 // engine burns down grants based on usage following the rules of Grant BurnDown.
 type engine struct {
 	EngineConfig
-
-	// List of all grants that are active at the relevant period at some point.
-	// Changes during execution, runtime state.
-	grants []grant.Grant
 }
 
 // Ensure engine implements Engine

--- a/openmeter/credit/engine/reset.go
+++ b/openmeter/credit/engine/reset.go
@@ -47,10 +47,7 @@ func (e *engine) reset(grants []grant.Grant, snap balance.Snapshot, behavior gra
 		return balance.Snapshot{}, fmt.Errorf("failed to prioritize grants: %w", err)
 	}
 
-	rolledOver, _, startingOverage, err := BurnDownGrants(rolledOver, prioritizedGrants, startingOverage)
-	if err != nil {
-		return balance.Snapshot{}, fmt.Errorf("failed to burn down overage: %w", err)
-	}
+	rolledOver, _, startingOverage = e.burnDownGrants(rolledOver, prioritizedGrants, startingOverage)
 
 	return balance.Snapshot{
 		At:       at,

--- a/openmeter/credit/engine/reset.go
+++ b/openmeter/credit/engine/reset.go
@@ -9,13 +9,9 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/credit/grant"
 )
 
-type ResetBehavior struct {
-	PreserveOverage bool
-}
-
 // reset rolls over the grants and burns down the overage if needed.
 // It returns the new snapshot of the balances at the start of the next period.
-func (e *engine) reset(grants []grant.Grant, snap balance.Snapshot, behavior ResetBehavior, at time.Time) (balance.Snapshot, error) {
+func (e *engine) reset(grants []grant.Grant, snap balance.Snapshot, behavior grant.ResetBehavior, at time.Time) (balance.Snapshot, error) {
 	// Let's build a grantMap from our grants for easier lookup
 	grantMap := make(map[string]grant.Grant)
 	for _, g := range grants {

--- a/openmeter/credit/engine/reset.go
+++ b/openmeter/credit/engine/reset.go
@@ -1,0 +1,64 @@
+package engine
+
+import (
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/openmeterio/openmeter/openmeter/credit/balance"
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+)
+
+type ResetBehavior struct {
+	PreserveOverage bool
+}
+
+// reset rolls over the grants and burns down the overage if needed.
+// It returns the new snapshot of the balances at the start of the next period.
+func (e *engine) reset(grants []grant.Grant, snap balance.Snapshot, behavior ResetBehavior, at time.Time) (balance.Snapshot, error) {
+	// Let's build a grantMap from our grants for easier lookup
+	grantMap := make(map[string]grant.Grant)
+	for _, g := range grants {
+		grantMap[g.ID] = g
+	}
+
+	// First, we roll over the grants
+	rolledOver := snap.Balances.Clone()
+
+	for grantID, grantBalance := range rolledOver {
+		grant, ok := grantMap[grantID]
+		// Inconsistency check, should never happen
+		if !ok {
+			return balance.Snapshot{}, fmt.Errorf("grant %s not found", grantID)
+		}
+
+		// grants might become inactive at the reset time, in which case they're irrelevant for the next period
+		if !grant.ActiveAt(at) {
+			continue
+		}
+
+		rolledOver[grantID] = grant.RolloverBalance(grantBalance)
+	}
+
+	// Then if needed, we burn down the overage
+	startingOverage := 0.0
+	if behavior.PreserveOverage {
+		startingOverage = snap.Overage
+	}
+
+	prioritizedGrants := slices.Clone(grants)
+	if err := PrioritizeGrants(prioritizedGrants); err != nil {
+		return balance.Snapshot{}, fmt.Errorf("failed to prioritize grants: %w", err)
+	}
+
+	rolledOver, _, startingOverage, err := BurnDownGrants(rolledOver, prioritizedGrants, startingOverage)
+	if err != nil {
+		return balance.Snapshot{}, fmt.Errorf("failed to burn down overage: %w", err)
+	}
+
+	return balance.Snapshot{
+		At:       at,
+		Balances: rolledOver,
+		Overage:  startingOverage,
+	}, nil
+}

--- a/openmeter/credit/engine/reset_test.go
+++ b/openmeter/credit/engine/reset_test.go
@@ -1,0 +1,122 @@
+package engine_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openmeterio/openmeter/openmeter/credit/balance"
+	"github.com/openmeterio/openmeter/openmeter/credit/engine"
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	meterpkg "github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestReset(t *testing.T) {
+	t1 := testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")
+	meterSlug := "meter-1"
+
+	meter := meterpkg.Meter{
+		Slug: meterSlug,
+	}
+
+	grant1 := makeGrant(grant.Grant{
+		ID:          "grant-1",
+		Amount:      100.0,
+		Priority:    1,
+		EffectiveAt: t1,
+		Expiration: grant.ExpirationPeriod{
+			Duration: grant.ExpirationPeriodDurationDay,
+			Count:    30,
+		},
+	})
+
+	// grant2 := makeGrant(grant.Grant{
+	// 	ID:          "grant-2",
+	// 	Amount:      100.0,
+	// 	Priority:    1,
+	// 	EffectiveAt: t1,
+	// 	Expiration: grant.ExpirationPeriod{
+	// 		Duration: grant.ExpirationPeriodDurationDay,
+	// 		Count:    30,
+	// 	},
+	// })
+
+	// Tests with single engine
+	tt := []struct {
+		name string
+		run  func(t *testing.T, eng engine.Engine, use addUsageFunc)
+	}{
+		{
+			name: "Should reset roll over grant balance after one reset",
+			run: func(t *testing.T, eng engine.Engine, use addUsageFunc) {
+				use(10.0, t1.Add(time.Hour))
+
+				g1 := grant1
+				g1.ResetMaxRollover = 50.0
+
+				res, err := eng.Run(
+					context.Background(),
+					engine.RunParams{
+						Grants: []grant.Grant{g1},
+						StartingSnapshot: balance.Snapshot{
+							Balances: balance.Map{
+								g1.ID: 100.0,
+							},
+							Overage: 0,
+							At:      t1,
+						},
+						Until: t1.AddDate(0, 0, 1),
+						ResetBehavior: engine.ResetBehavior{
+							PreserveOverage: false,
+						},
+						Resets: timeutil.NewTimeline([]time.Time{t1.Add(time.Hour * 5)}),
+					},
+				)
+				assert.NoError(t, err)
+
+				// The grant should be rolled over:
+				// 100 - 10 = 90;
+				// Min(50, max(0, 90)) = 50
+				assert.Equal(t, 50.0, res.Snapshot.Balances[grant1.ID])
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
+
+			queryFeatureUsage := func(ctx context.Context, from, to time.Time) (float64, error) {
+				rows, err := streamingConnector.QueryMeter(ctx, "default", meter, streaming.QueryParams{
+					From: &from,
+					To:   &to,
+				})
+				if err != nil {
+					return 0.0, err
+				}
+				if len(rows) > 1 {
+					return 0.0, fmt.Errorf("expected 1 row, got %d", len(rows))
+				}
+				if len(rows) == 0 {
+					return 0.0, nil
+				}
+				return rows[0].Value, nil
+			}
+			tc.run(t, engine.NewEngine(engine.EngineConfig{
+				QueryUsage:  queryFeatureUsage,
+				Granularity: meterpkg.WindowSizeMinute,
+			}), func(usage float64, at time.Time) {
+				streamingConnector.AddSimpleEvent(meterSlug, usage, at)
+			})
+		})
+	}
+}

--- a/openmeter/credit/engine/reset_test.go
+++ b/openmeter/credit/engine/reset_test.go
@@ -37,17 +37,6 @@ func TestReset(t *testing.T) {
 		},
 	})
 
-	// grant2 := makeGrant(grant.Grant{
-	// 	ID:          "grant-2",
-	// 	Amount:      100.0,
-	// 	Priority:    1,
-	// 	EffectiveAt: t1,
-	// 	Expiration: grant.ExpirationPeriod{
-	// 		Duration: grant.ExpirationPeriodDurationDay,
-	// 		Count:    30,
-	// 	},
-	// })
-
 	setup := func(t *testing.T) (engine.Engine, addUsageFunc) {
 		streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
 
@@ -96,10 +85,10 @@ func TestReset(t *testing.T) {
 					At:      t1,
 				},
 				Until: t1.AddDate(0, 0, 1),
-				ResetBehavior: engine.ResetBehavior{
+				ResetBehavior: grant.ResetBehavior{
 					PreserveOverage: false,
 				},
-				Resets: timeutil.NewTimeline([]time.Time{t1.Add(time.Hour * 5)}),
+				Resets: timeutil.NewSimpleTimeline([]time.Time{t1.Add(time.Hour * 5)}),
 			},
 		)
 		assert.NoError(t, err)
@@ -148,10 +137,10 @@ func TestReset(t *testing.T) {
 					At:      t1,
 				},
 				Until: t1.AddDate(0, 0, 1),
-				ResetBehavior: engine.ResetBehavior{
+				ResetBehavior: grant.ResetBehavior{
 					PreserveOverage: true,
 				},
-				Resets: timeutil.NewTimeline([]time.Time{t1.Add(time.Hour * 5)}),
+				Resets: timeutil.NewSimpleTimeline([]time.Time{t1.Add(time.Hour * 5)}),
 			},
 		)
 		assert.NoError(t, err)
@@ -229,7 +218,7 @@ func TestReset(t *testing.T) {
 					At:      t1,
 				},
 				Until:  resetTime,
-				Resets: timeutil.NewTimeline([]time.Time{resetTime}),
+				Resets: timeutil.NewSimpleTimeline([]time.Time{resetTime}),
 			},
 		)
 		assert.NoError(t, err)
@@ -258,7 +247,7 @@ func TestReset(t *testing.T) {
 					At:       t1,
 				},
 				Until:  t1.AddDate(0, 0, 1),
-				Resets: timeutil.NewTimeline([]time.Time{t1}),
+				Resets: timeutil.NewSimpleTimeline([]time.Time{t1}),
 			},
 		)
 		assert.EqualError(t, err, "provided reset times must occur after the starting snapshot, got 2024-01-01 00:00:00 +0000 UTC")

--- a/openmeter/credit/engine/reset_test.go
+++ b/openmeter/credit/engine/reset_test.go
@@ -48,75 +48,219 @@ func TestReset(t *testing.T) {
 	// 	},
 	// })
 
-	// Tests with single engine
-	tt := []struct {
-		name string
-		run  func(t *testing.T, eng engine.Engine, use addUsageFunc)
-	}{
-		{
-			name: "Should reset roll over grant balance after one reset",
-			run: func(t *testing.T, eng engine.Engine, use addUsageFunc) {
-				use(10.0, t1.Add(time.Hour))
+	setup := func(t *testing.T) (engine.Engine, addUsageFunc) {
+		streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
 
-				g1 := grant1
-				g1.ResetMaxRollover = 50.0
-
-				res, err := eng.Run(
-					context.Background(),
-					engine.RunParams{
-						Grants: []grant.Grant{g1},
-						StartingSnapshot: balance.Snapshot{
-							Balances: balance.Map{
-								g1.ID: 100.0,
-							},
-							Overage: 0,
-							At:      t1,
-						},
-						Until: t1.AddDate(0, 0, 1),
-						ResetBehavior: engine.ResetBehavior{
-							PreserveOverage: false,
-						},
-						Resets: timeutil.NewTimeline([]time.Time{t1.Add(time.Hour * 5)}),
-					},
-				)
-				assert.NoError(t, err)
-
-				// The grant should be rolled over:
-				// 100 - 10 = 90;
-				// Min(50, max(0, 90)) = 50
-				assert.Equal(t, 50.0, res.Snapshot.Balances[grant1.ID])
-			},
-		},
-	}
-
-	for _, tc := range tt {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
-
-			queryFeatureUsage := func(ctx context.Context, from, to time.Time) (float64, error) {
-				rows, err := streamingConnector.QueryMeter(ctx, "default", meter, streaming.QueryParams{
-					From: &from,
-					To:   &to,
-				})
-				if err != nil {
-					return 0.0, err
-				}
-				if len(rows) > 1 {
-					return 0.0, fmt.Errorf("expected 1 row, got %d", len(rows))
-				}
-				if len(rows) == 0 {
-					return 0.0, nil
-				}
-				return rows[0].Value, nil
+		queryFeatureUsage := func(ctx context.Context, from, to time.Time) (float64, error) {
+			rows, err := streamingConnector.QueryMeter(ctx, "default", meter, streaming.QueryParams{
+				From: &from,
+				To:   &to,
+			})
+			if err != nil {
+				return 0.0, err
 			}
-			tc.run(t, engine.NewEngine(engine.EngineConfig{
+			if len(rows) > 1 {
+				return 0.0, fmt.Errorf("expected 1 row, got %d", len(rows))
+			}
+			if len(rows) == 0 {
+				return 0.0, nil
+			}
+			return rows[0].Value, nil
+		}
+
+		return engine.NewEngine(engine.EngineConfig{
 				QueryUsage:  queryFeatureUsage,
 				Granularity: meterpkg.WindowSizeMinute,
 			}), func(usage float64, at time.Time) {
 				streamingConnector.AddSimpleEvent(meterSlug, usage, at)
-			})
-		})
+			}
 	}
+
+	t.Run("Should reset roll over grant balance after one reset", func(t *testing.T) {
+		eng, use := setup(t)
+		use(10.0, t1.Add(time.Hour))
+
+		g1 := grant1
+		g1.ResetMaxRollover = 50.0
+
+		// grants can roll over their own balance so we don't check the details of that
+		res, err := eng.Run(
+			context.Background(),
+			engine.RunParams{
+				Grants: []grant.Grant{g1},
+				StartingSnapshot: balance.Snapshot{
+					Balances: balance.Map{
+						g1.ID: 100.0,
+					},
+					Overage: 0,
+					At:      t1,
+				},
+				Until: t1.AddDate(0, 0, 1),
+				ResetBehavior: engine.ResetBehavior{
+					PreserveOverage: false,
+				},
+				Resets: timeutil.NewTimeline([]time.Time{t1.Add(time.Hour * 5)}),
+			},
+		)
+		assert.NoError(t, err)
+
+		// The grant should be rolled over:
+		// 100 - 10 = 90;
+		// Min(50, max(0, 90)) = 50
+		assert.Equal(t, 50.0, res.Snapshot.Balances[grant1.ID])
+
+		// History should have 2 segments, one before and one after the reset
+		assert.Equal(t, 2, len(res.History))
+
+		// The first segment should have a balance of 100 with 10 usage
+		assert.Equal(t, 100.0, res.History[0].BalanceAtStart.Balance())
+		assert.Equal(t, 0.0, res.History[0].OverageAtStart)
+		assert.Equal(t, 10.0, res.History[0].TotalUsage)
+
+		// It should end with a reset
+		assert.True(t, res.History[0].TerminationReasons.UsageReset)
+
+		// The second segment should have a balance of 50 with no usage
+		assert.Equal(t, 50.0, res.History[1].BalanceAtStart.Balance())
+		assert.Equal(t, 0.0, res.History[1].OverageAtStart)
+		assert.Equal(t, 0.0, res.History[1].TotalUsage)
+	})
+
+	t.Run("Should carry over overage to next period", func(t *testing.T) {
+		eng, use := setup(t)
+		use(10.0, t1.Add(time.Hour))
+		use(100.0, t1.Add(time.Hour*2))
+
+		g1 := grant1
+		g1.ResetMaxRollover = 50.0
+		g1.ResetMinRollover = 50.0
+
+		// grants can roll over their own balance so we don't check the details of that
+		res, err := eng.Run(
+			context.Background(),
+			engine.RunParams{
+				Grants: []grant.Grant{g1},
+				StartingSnapshot: balance.Snapshot{
+					Balances: balance.Map{
+						g1.ID: 100.0,
+					},
+					Overage: 0,
+					At:      t1,
+				},
+				Until: t1.AddDate(0, 0, 1),
+				ResetBehavior: engine.ResetBehavior{
+					PreserveOverage: true,
+				},
+				Resets: timeutil.NewTimeline([]time.Time{t1.Add(time.Hour * 5)}),
+			},
+		)
+		assert.NoError(t, err)
+
+		// The grant should be rolled over:
+		assert.Equal(t, 40.0, res.Snapshot.Balances[grant1.ID])
+
+		// History should have 2 segments, one before and one after the reset
+		assert.Equal(t, 2, len(res.History))
+
+		// The first segment should have a balance of 0 with 10 overage
+		assert.Equal(t, 100.0, res.History[0].BalanceAtStart.Balance())
+		assert.Equal(t, 0.0, res.History[0].OverageAtStart)
+		assert.Equal(t, 10.0, res.History[0].Overage)
+		assert.Equal(t, 110.0, res.History[0].TotalUsage)
+
+		// It should end with a reset
+		assert.True(t, res.History[0].TerminationReasons.UsageReset)
+
+		// The second segment should have a balance of 50 - 10 with no usage (minRolloverAmount + overage)
+		assert.Equal(t, 40.0, res.History[1].BalanceAtStart.Balance())
+		assert.Equal(t, 0.0, res.History[1].OverageAtStart)
+		assert.Equal(t, 0.0, res.History[1].TotalUsage)
+	})
+
+	t.Run("No reset", func(t *testing.T) {
+		eng, use := setup(t)
+		use(10.0, t1.Add(time.Hour))
+
+		g2 := grant1
+		g2.EffectiveAt = t1.Add(time.Hour * 2)
+
+		res, err := eng.Run(
+			context.Background(),
+			engine.RunParams{
+				Grants: []grant.Grant{grant1, g2},
+				StartingSnapshot: balance.Snapshot{
+					Balances: balance.Map{
+						grant1.ID: 100.0,
+						g2.ID:     100.0,
+					},
+					Overage: 0,
+					At:      t1,
+				},
+				Until: t1.AddDate(0, 0, 1),
+			},
+		)
+		assert.NoError(t, err)
+
+		// Should have 2 periods, start - g2, g2 - end
+		assert.Equal(t, 2, len(res.History))
+
+		assert.False(t, res.History[0].TerminationReasons.UsageReset)
+		assert.False(t, res.History[1].TerminationReasons.UsageReset)
+	})
+
+	t.Run("Should return starting balance if the end of the queried period is a reset", func(t *testing.T) {
+		eng, use := setup(t)
+		use(10.0, t1.Add(time.Hour))
+
+		g1 := grant1
+		g1.ResetMaxRollover = 50.0
+
+		resetTime := t1.AddDate(0, 0, 1)
+
+		res, err := eng.Run(
+			context.Background(),
+			engine.RunParams{
+				Grants: []grant.Grant{g1},
+				StartingSnapshot: balance.Snapshot{
+					Balances: balance.Map{
+						g1.ID: 100.0,
+					},
+					Overage: 0,
+					At:      t1,
+				},
+				Until:  resetTime,
+				Resets: timeutil.NewTimeline([]time.Time{resetTime}),
+			},
+		)
+		assert.NoError(t, err)
+
+		// Should have 2 periods, start - reset, reset - end where reset = end, 2nd period is 0 length
+		assert.Equal(t, 2, len(res.History), "expected: %+v, got %+v, history: %+v", 2, len(res.History), res.History)
+
+		assert.True(t, res.History[0].TerminationReasons.UsageReset)
+		assert.False(t, res.History[1].TerminationReasons.UsageReset)
+	})
+
+	t.Run("Should error if a reset is provided for the starting snapshot", func(t *testing.T) {
+		eng, use := setup(t)
+		use(10.0, t1.Add(time.Hour))
+
+		g1 := grant1
+		g1.ResetMaxRollover = 50.0
+
+		_, err := eng.Run(
+			context.Background(),
+			engine.RunParams{
+				Grants: []grant.Grant{g1},
+				StartingSnapshot: balance.Snapshot{
+					Balances: balance.Map{g1.ID: 100.0},
+					Overage:  0,
+					At:       t1,
+				},
+				Until:  t1.AddDate(0, 0, 1),
+				Resets: timeutil.NewTimeline([]time.Time{t1}),
+			},
+		)
+		assert.EqualError(t, err, "provided reset times must occur after the starting snapshot, got 2024-01-01 00:00:00 +0000 UTC")
+	})
 }

--- a/openmeter/credit/engine/run.go
+++ b/openmeter/credit/engine/run.go
@@ -27,7 +27,7 @@ func (e *engine) Run(ctx context.Context, params RunParams) (RunResult, error) {
 
 	times = append(times, params.Until)
 
-	timeline := timeutil.NewTimeline(times)
+	timeline := timeutil.NewSimpleTimeline(times)
 
 	boundingPeriod := timeline.GetBoundingPeriod()
 

--- a/openmeter/credit/engine/run.go
+++ b/openmeter/credit/engine/run.go
@@ -183,10 +183,7 @@ func (e *engine) runBetweenResets(ctx context.Context, params inbetweenRunParams
 		if err != nil {
 			return RunResult{}, fmt.Errorf("failed to get feature usage for period %s - %s: %w", period.From, period.To, err)
 		}
-		balancesAtPhaseStart, segment.GrantUsages, overage, err = BurnDownGrants(balancesAtPhaseStart, activeGrants, usage+overage)
-		if err != nil {
-			return RunResult{}, fmt.Errorf("failed to burn down grants in period %s - %s: %w", period.From, period.To, err)
-		}
+		balancesAtPhaseStart, segment.GrantUsages, overage = e.burnDownGrants(balancesAtPhaseStart, activeGrants, usage+overage)
 
 		segment.TotalUsage = usage
 		segment.Overage = overage
@@ -214,7 +211,7 @@ func (e *engine) runBetweenResets(ctx context.Context, params inbetweenRunParams
 // Burns down the grants of the priority sorted list. Manages overage.
 //
 // FIXME: calculations happen on inexact representations as float64, this can lead to rounding errors.
-func BurnDownGrants(startingBalances balance.Map, prioritized []grant.Grant, usage float64) (balance.Map, []GrantUsage, float64, error) {
+func (m *engine) burnDownGrants(startingBalances balance.Map, prioritized []grant.Grant, usage float64) (balance.Map, []GrantUsage, float64) {
 	balances := startingBalances.Clone()
 	uses := make([]GrantUsage, 0, len(prioritized))
 	exactUsage := alpacadecimal.NewFromFloat(usage)
@@ -251,5 +248,5 @@ func BurnDownGrants(startingBalances balance.Map, prioritized []grant.Grant, usa
 		}
 	}
 
-	return balances, uses, getFloat(exactUsage), nil
+	return balances, uses, getFloat(exactUsage)
 }

--- a/openmeter/credit/engine/run_test.go
+++ b/openmeter/credit/engine/run_test.go
@@ -176,6 +176,36 @@ func TestEngine(t *testing.T) {
 			},
 		},
 		{
+			name: "Should do nothing for 0 length period",
+			run: func(t *testing.T, eng engine.Engine, use addUsageFunc) {
+				// We have report usage so the meter is found
+				use(100.0, t1.Add(time.Hour))
+
+				res, err := eng.Run(
+					context.Background(),
+					engine.RunParams{
+						Grants: []grant.Grant{grant1},
+						StartingSnapshot: balance.Snapshot{
+							Balances: balance.Map{
+								grant1.ID: 100.0,
+							},
+							Overage: 0,
+							At:      t1,
+						},
+						Until: t1,
+					},
+				)
+				assert.NoError(t, err)
+				assert.Equal(t, balance.Snapshot{
+					Balances: balance.Map{
+						grant1.ID: 100.0,
+					},
+					Overage: 0,
+					At:      t1,
+				}, res.Snapshot)
+			},
+		},
+		{
 			name: "Able to burn down single active grant",
 			run: func(t *testing.T, eng engine.Engine, use addUsageFunc) {
 				use(50.0, t1.Add(time.Hour))

--- a/openmeter/credit/grant.go
+++ b/openmeter/credit/grant.go
@@ -56,7 +56,7 @@ func (m *connector) CreateGrant(ctx context.Context, owner grant.NamespacedOwner
 		}
 
 		if input.EffectiveAt.Before(periodStart) {
-			return nil, models.NewGenericValidationError(fmt.Errorf("grant effective date is before the current usage period"))
+			return nil, models.NewGenericValidationError(fmt.Errorf("grant effective date %s is before the current usage period %s", input.EffectiveAt, periodStart))
 		}
 
 		err = m.ownerConnector.LockOwnerForTx(ctx, owner)

--- a/openmeter/credit/grant/grant_test.go
+++ b/openmeter/credit/grant/grant_test.go
@@ -1,0 +1,203 @@
+package grant_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestEffectivePeriod(t *testing.T) {
+	now := clock.Now()
+
+	t.Run("base case", func(t *testing.T) {
+		g := grant.Grant{
+			EffectiveAt: now,
+			ExpiresAt:   now.Add(time.Hour),
+		}
+
+		p := g.GetEffectivePeriod()
+		assert.Equal(t, g.EffectiveAt, p.From)
+		assert.Equal(t, g.ExpiresAt, p.To)
+	})
+
+	t.Run("deleted ineffectual", func(t *testing.T) {
+		g := grant.Grant{
+			EffectiveAt: now,
+			ExpiresAt:   now.Add(time.Hour),
+			ManagedModel: models.ManagedModel{
+				DeletedAt: lo.ToPtr(now.Add(time.Minute + time.Hour)), // 1H1M
+			},
+		}
+
+		p := g.GetEffectivePeriod()
+		assert.Equal(t, g.EffectiveAt, p.From)
+		assert.Equal(t, g.ExpiresAt, p.To)
+	})
+
+	t.Run("deleted before expiration", func(t *testing.T) {
+		g := grant.Grant{
+			EffectiveAt: now,
+			ExpiresAt:   now.Add(time.Hour),
+			ManagedModel: models.ManagedModel{
+				DeletedAt: lo.ToPtr(now.Add(time.Minute)), // 1M
+			},
+		}
+
+		p := g.GetEffectivePeriod()
+		assert.Equal(t, g.EffectiveAt, p.From)
+		assert.Equal(t, *g.DeletedAt, p.To)
+	})
+
+	t.Run("deleted before effective", func(t *testing.T) {
+		g := grant.Grant{
+			EffectiveAt: now,
+			ExpiresAt:   now.Add(time.Hour),
+			ManagedModel: models.ManagedModel{
+				DeletedAt: lo.ToPtr(now.Add(-time.Minute)), // -1M
+			},
+		}
+
+		p := g.GetEffectivePeriod()
+
+		// Grants that never activate have a 0 length period starting and ending at the effective date
+		assert.Equal(t, g.EffectiveAt, p.From)
+		assert.Equal(t, g.EffectiveAt, p.To)
+	})
+
+	t.Run("voided ineffectual", func(t *testing.T) {
+		g := grant.Grant{
+			EffectiveAt: now,
+			ExpiresAt:   now.Add(time.Hour),
+			VoidedAt:    lo.ToPtr(now.Add(time.Minute + time.Hour)), // 1H1M
+		}
+
+		p := g.GetEffectivePeriod()
+		assert.Equal(t, g.EffectiveAt, p.From)
+		assert.Equal(t, g.ExpiresAt, p.To)
+	})
+
+	t.Run("voided before expiration", func(t *testing.T) {
+		g := grant.Grant{
+			EffectiveAt: now,
+			ExpiresAt:   now.Add(time.Hour),
+			VoidedAt:    lo.ToPtr(now.Add(time.Minute)), // 1M
+		}
+
+		p := g.GetEffectivePeriod()
+		assert.Equal(t, g.EffectiveAt, p.From)
+		assert.Equal(t, *g.VoidedAt, p.To)
+	})
+
+	t.Run("voided before effective", func(t *testing.T) {
+		g := grant.Grant{
+			EffectiveAt: now,
+			ExpiresAt:   now.Add(time.Hour),
+			VoidedAt:    lo.ToPtr(now.Add(-time.Minute)), // -1M
+		}
+
+		p := g.GetEffectivePeriod()
+		assert.Equal(t, g.EffectiveAt, p.From)
+		assert.Equal(t, g.EffectiveAt, p.To)
+	})
+
+	t.Run("voided and deleted", func(t *testing.T) {
+		g := grant.Grant{
+			EffectiveAt: now,
+			ExpiresAt:   now.Add(time.Hour),
+			VoidedAt:    lo.ToPtr(now.Add(time.Minute)), // 1M
+			ManagedModel: models.ManagedModel{
+				DeletedAt: lo.ToPtr(now.Add(time.Minute + time.Hour)), // 1H1M
+			},
+		}
+
+		p := g.GetEffectivePeriod()
+		assert.Equal(t, g.EffectiveAt, p.From)
+		assert.Equal(t, *g.VoidedAt, p.To)
+	})
+}
+
+func TestIsActiveAt(t *testing.T) {
+	now := clock.Now()
+
+	tt := []struct {
+		name string
+		g    grant.Grant
+		at   time.Time
+		want bool
+	}{
+		{
+			name: "base case",
+			g: grant.Grant{
+				EffectiveAt: now,
+				ExpiresAt:   now.Add(time.Hour),
+			},
+			at:   now,
+			want: true,
+		},
+		{
+			name: "not active",
+			g: grant.Grant{
+				EffectiveAt: now,
+				ExpiresAt:   now.Add(time.Hour),
+			},
+			at:   now.Add(time.Hour),
+			want: false,
+		},
+		{
+			name: "voided",
+			g: grant.Grant{
+				EffectiveAt: now,
+				ExpiresAt:   now.Add(time.Hour),
+				VoidedAt:    lo.ToPtr(now.Add(time.Minute)), // 1M
+			},
+			at:   now.Add(time.Minute),
+			want: false,
+		},
+		{
+			name: "deleted",
+			g: grant.Grant{
+				EffectiveAt: now,
+				ExpiresAt:   now.Add(time.Hour),
+				ManagedModel: models.ManagedModel{
+					DeletedAt: lo.ToPtr(now.Add(time.Minute)), // 1M
+				},
+			},
+			at:   now.Add(time.Minute),
+			want: false,
+		},
+		{
+			name: "voided and deleted",
+			g: grant.Grant{
+				EffectiveAt: now,
+				ExpiresAt:   now.Add(time.Hour),
+				VoidedAt:    lo.ToPtr(now.Add(time.Minute)), // 1M
+				ManagedModel: models.ManagedModel{
+					DeletedAt: lo.ToPtr(now.Add(time.Minute + time.Hour)), // 1H1M
+				},
+			},
+			at:   now.Add(time.Minute),
+			want: false,
+		},
+		{
+			name: "0 length",
+			g: grant.Grant{
+				EffectiveAt: now,
+				ExpiresAt:   now,
+			},
+			at:   now,
+			want: false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.g.ActiveAt(tc.at))
+		})
+	}
+}

--- a/openmeter/credit/helper.go
+++ b/openmeter/credit/helper.go
@@ -211,42 +211,42 @@ func (m *connector) buildEngineForOwner(ctx context.Context, owner grant.Namespa
 //  1. We can save a segment if it is older than graceperiod.
 //  2. At the end of a segment history changes: s1.endBalance <> s2.startBalance. This means only the
 //     starting values can be saved credibly.
-func (m *connector) getLastSaveableSnapshotAt(history *engine.GrantBurnDownHistory, lastValidBalance balance.Snapshot, at time.Time) (*balance.Snapshot, error) {
-	segments := history.Segments()
+// func (m *connector) getLastSaveableSnapshotAt(history *engine.GrantBurnDownHistory, lastValidBalance balance.Snapshot, at time.Time) (*balance.Snapshot, error) {
+// 	segments := history.Segments()
 
-	for i := len(segments) - 1; i >= 0; i-- {
-		segment := segments[i]
-		if segment.From.Add(m.snapshotGracePeriod).Before(at) {
-			s := segment.ToSnapshot()
-			if s.At.After(lastValidBalance.At) {
-				return &s, nil
-			} else {
-				return nil, fmt.Errorf("the last saveable snapshot at %s is before the previous last valid snapshot", s.At)
-			}
-		}
-	}
+// 	for i := len(segments) - 1; i >= 0; i-- {
+// 		segment := segments[i]
+// 		if segment.From.Add(m.snapshotGracePeriod).Before(at) {
+// 			s := segment.ToSnapshot()
+// 			if s.At.After(lastValidBalance.At) {
+// 				return &s, nil
+// 			} else {
+// 				return nil, fmt.Errorf("the last saveable snapshot at %s is before the previous last valid snapshot", s.At)
+// 			}
+// 		}
+// 	}
 
-	return nil, fmt.Errorf("no segment can be saved at %s with gracePeriod %s", at, m.snapshotGracePeriod)
-}
+// 	return nil, fmt.Errorf("no segment can be saved at %s with gracePeriod %s", at, m.snapshotGracePeriod)
+// }
 
-func (m *connector) excludeInactiveGrantsFromBalance(balances balance.Map, grants map[string]grant.Grant, at time.Time) (*balance.Map, error) {
-	filtered := &balance.Map{}
-	for grantID, grantBalance := range balances {
-		grant, ok := grants[grantID]
-		// inconsistency check, shouldn't happen
-		if !ok {
-			return nil, fmt.Errorf("attempting to roll over unknown grant %s", grantID)
-		}
+// func (m *connector) excludeInactiveGrantsFromBalance(balances balance.Map, grants map[string]grant.Grant, at time.Time) (*balance.Map, error) {
+// 	filtered := &balance.Map{}
+// 	for grantID, grantBalance := range balances {
+// 		grant, ok := grants[grantID]
+// 		// inconsistency check, shouldn't happen
+// 		if !ok {
+// 			return nil, fmt.Errorf("attempting to roll over unknown grant %s", grantID)
+// 		}
 
-		// grants might become inactive at the reset time, in which case they're irrelevant for the next period
-		if !grant.ActiveAt(at) {
-			continue
-		}
+// 		// grants might become inactive at the reset time, in which case they're irrelevant for the next period
+// 		if !grant.ActiveAt(at) {
+// 			continue
+// 		}
 
-		filtered.Set(grantID, grantBalance)
-	}
-	return filtered, nil
-}
+// 		filtered.Set(grantID, grantBalance)
+// 	}
+// 	return filtered, nil
+// }
 
 // Fills in the snapshot's GrantBalanceMap with the provided grants so the Engine can use them.
 func (m *connector) populateBalanceSnapshotWithMissingGrantsActiveAt(snapshot *balance.Snapshot, grants []grant.Grant, at time.Time) {

--- a/openmeter/ent/db/entitlement.go
+++ b/openmeter/ent/db/entitlement.go
@@ -56,7 +56,7 @@ type Entitlement struct {
 	Config []uint8 `json:"config,omitempty"`
 	// UsagePeriodInterval holds the value of the "usage_period_interval" field.
 	UsagePeriodInterval *isodate.String `json:"usage_period_interval,omitempty"`
-	// UsagePeriodAnchor holds the value of the "usage_period_anchor" field.
+	// Historically this field had been overwritten with each anchor reset, now we keep the original anchor time and the value is populated from the last reset which is queried dynamically
 	UsagePeriodAnchor *time.Time `json:"usage_period_anchor,omitempty"`
 	// CurrentUsagePeriodStart holds the value of the "current_usage_period_start" field.
 	CurrentUsagePeriodStart *time.Time `json:"current_usage_period_start,omitempty"`

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1789,6 +1789,7 @@ var (
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "reset_time", Type: field.TypeTime},
+		{Name: "anchor", Type: field.TypeTime},
 		{Name: "entitlement_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 	}
 	// UsageResetsTable holds the schema information for the "usage_resets" table.
@@ -1799,7 +1800,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "usage_resets_entitlements_usage_reset",
-				Columns:    []*schema.Column{UsageResetsColumns[6]},
+				Columns:    []*schema.Column{UsageResetsColumns[7]},
 				RefColumns: []*schema.Column{EntitlementsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -1818,12 +1819,12 @@ var (
 			{
 				Name:    "usagereset_namespace_entitlement_id",
 				Unique:  false,
-				Columns: []*schema.Column{UsageResetsColumns[1], UsageResetsColumns[6]},
+				Columns: []*schema.Column{UsageResetsColumns[1], UsageResetsColumns[7]},
 			},
 			{
 				Name:    "usagereset_namespace_entitlement_id_reset_time",
 				Unique:  false,
-				Columns: []*schema.Column{UsageResetsColumns[1], UsageResetsColumns[6], UsageResetsColumns[5]},
+				Columns: []*schema.Column{UsageResetsColumns[1], UsageResetsColumns[7], UsageResetsColumns[5]},
 			},
 		},
 	}

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -39719,6 +39719,7 @@ type UsageResetMutation struct {
 	updated_at         *time.Time
 	deleted_at         *time.Time
 	reset_time         *time.Time
+	anchor             *time.Time
 	clearedFields      map[string]struct{}
 	entitlement        *string
 	clearedentitlement bool
@@ -40060,6 +40061,42 @@ func (m *UsageResetMutation) ResetResetTime() {
 	m.reset_time = nil
 }
 
+// SetAnchor sets the "anchor" field.
+func (m *UsageResetMutation) SetAnchor(t time.Time) {
+	m.anchor = &t
+}
+
+// Anchor returns the value of the "anchor" field in the mutation.
+func (m *UsageResetMutation) Anchor() (r time.Time, exists bool) {
+	v := m.anchor
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAnchor returns the old "anchor" field's value of the UsageReset entity.
+// If the UsageReset object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UsageResetMutation) OldAnchor(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAnchor is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAnchor requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAnchor: %w", err)
+	}
+	return oldValue.Anchor, nil
+}
+
+// ResetAnchor resets all changes to the "anchor" field.
+func (m *UsageResetMutation) ResetAnchor() {
+	m.anchor = nil
+}
+
 // ClearEntitlement clears the "entitlement" edge to the Entitlement entity.
 func (m *UsageResetMutation) ClearEntitlement() {
 	m.clearedentitlement = true
@@ -40121,7 +40158,7 @@ func (m *UsageResetMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UsageResetMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 7)
 	if m.namespace != nil {
 		fields = append(fields, usagereset.FieldNamespace)
 	}
@@ -40139,6 +40176,9 @@ func (m *UsageResetMutation) Fields() []string {
 	}
 	if m.reset_time != nil {
 		fields = append(fields, usagereset.FieldResetTime)
+	}
+	if m.anchor != nil {
+		fields = append(fields, usagereset.FieldAnchor)
 	}
 	return fields
 }
@@ -40160,6 +40200,8 @@ func (m *UsageResetMutation) Field(name string) (ent.Value, bool) {
 		return m.EntitlementID()
 	case usagereset.FieldResetTime:
 		return m.ResetTime()
+	case usagereset.FieldAnchor:
+		return m.Anchor()
 	}
 	return nil, false
 }
@@ -40181,6 +40223,8 @@ func (m *UsageResetMutation) OldField(ctx context.Context, name string) (ent.Val
 		return m.OldEntitlementID(ctx)
 	case usagereset.FieldResetTime:
 		return m.OldResetTime(ctx)
+	case usagereset.FieldAnchor:
+		return m.OldAnchor(ctx)
 	}
 	return nil, fmt.Errorf("unknown UsageReset field %s", name)
 }
@@ -40231,6 +40275,13 @@ func (m *UsageResetMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetResetTime(v)
+		return nil
+	case usagereset.FieldAnchor:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAnchor(v)
 		return nil
 	}
 	return fmt.Errorf("unknown UsageReset field %s", name)
@@ -40307,6 +40358,9 @@ func (m *UsageResetMutation) ResetField(name string) error {
 		return nil
 	case usagereset.FieldResetTime:
 		m.ResetResetTime()
+		return nil
+	case usagereset.FieldAnchor:
+		m.ResetAnchor()
 		return nil
 	}
 	return fmt.Errorf("unknown UsageReset field %s", name)

--- a/openmeter/ent/db/usagereset.go
+++ b/openmeter/ent/db/usagereset.go
@@ -30,6 +30,8 @@ type UsageReset struct {
 	EntitlementID string `json:"entitlement_id,omitempty"`
 	// ResetTime holds the value of the "reset_time" field.
 	ResetTime time.Time `json:"reset_time,omitempty"`
+	// Anchor holds the value of the "anchor" field.
+	Anchor time.Time `json:"anchor,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the UsageResetQuery when eager-loading is set.
 	Edges        UsageResetEdges `json:"edges"`
@@ -63,7 +65,7 @@ func (*UsageReset) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case usagereset.FieldID, usagereset.FieldNamespace, usagereset.FieldEntitlementID:
 			values[i] = new(sql.NullString)
-		case usagereset.FieldCreatedAt, usagereset.FieldUpdatedAt, usagereset.FieldDeletedAt, usagereset.FieldResetTime:
+		case usagereset.FieldCreatedAt, usagereset.FieldUpdatedAt, usagereset.FieldDeletedAt, usagereset.FieldResetTime, usagereset.FieldAnchor:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -122,6 +124,12 @@ func (ur *UsageReset) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field reset_time", values[i])
 			} else if value.Valid {
 				ur.ResetTime = value.Time
+			}
+		case usagereset.FieldAnchor:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field anchor", values[i])
+			} else if value.Valid {
+				ur.Anchor = value.Time
 			}
 		default:
 			ur.selectValues.Set(columns[i], values[i])
@@ -183,6 +191,9 @@ func (ur *UsageReset) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("reset_time=")
 	builder.WriteString(ur.ResetTime.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("anchor=")
+	builder.WriteString(ur.Anchor.Format(time.ANSIC))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/openmeter/ent/db/usagereset/usagereset.go
+++ b/openmeter/ent/db/usagereset/usagereset.go
@@ -26,6 +26,8 @@ const (
 	FieldEntitlementID = "entitlement_id"
 	// FieldResetTime holds the string denoting the reset_time field in the database.
 	FieldResetTime = "reset_time"
+	// FieldAnchor holds the string denoting the anchor field in the database.
+	FieldAnchor = "anchor"
 	// EdgeEntitlement holds the string denoting the entitlement edge name in mutations.
 	EdgeEntitlement = "entitlement"
 	// Table holds the table name of the usagereset in the database.
@@ -48,6 +50,7 @@ var Columns = []string{
 	FieldDeletedAt,
 	FieldEntitlementID,
 	FieldResetTime,
+	FieldAnchor,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -109,6 +112,11 @@ func ByEntitlementID(opts ...sql.OrderTermOption) OrderOption {
 // ByResetTime orders the results by the reset_time field.
 func ByResetTime(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldResetTime, opts...).ToFunc()
+}
+
+// ByAnchor orders the results by the anchor field.
+func ByAnchor(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldAnchor, opts...).ToFunc()
 }
 
 // ByEntitlementField orders the results by entitlement field.

--- a/openmeter/ent/db/usagereset/where.go
+++ b/openmeter/ent/db/usagereset/where.go
@@ -95,6 +95,11 @@ func ResetTime(v time.Time) predicate.UsageReset {
 	return predicate.UsageReset(sql.FieldEQ(FieldResetTime, v))
 }
 
+// Anchor applies equality check predicate on the "anchor" field. It's identical to AnchorEQ.
+func Anchor(v time.Time) predicate.UsageReset {
+	return predicate.UsageReset(sql.FieldEQ(FieldAnchor, v))
+}
+
 // NamespaceEQ applies the EQ predicate on the "namespace" field.
 func NamespaceEQ(v string) predicate.UsageReset {
 	return predicate.UsageReset(sql.FieldEQ(FieldNamespace, v))
@@ -393,6 +398,46 @@ func ResetTimeLT(v time.Time) predicate.UsageReset {
 // ResetTimeLTE applies the LTE predicate on the "reset_time" field.
 func ResetTimeLTE(v time.Time) predicate.UsageReset {
 	return predicate.UsageReset(sql.FieldLTE(FieldResetTime, v))
+}
+
+// AnchorEQ applies the EQ predicate on the "anchor" field.
+func AnchorEQ(v time.Time) predicate.UsageReset {
+	return predicate.UsageReset(sql.FieldEQ(FieldAnchor, v))
+}
+
+// AnchorNEQ applies the NEQ predicate on the "anchor" field.
+func AnchorNEQ(v time.Time) predicate.UsageReset {
+	return predicate.UsageReset(sql.FieldNEQ(FieldAnchor, v))
+}
+
+// AnchorIn applies the In predicate on the "anchor" field.
+func AnchorIn(vs ...time.Time) predicate.UsageReset {
+	return predicate.UsageReset(sql.FieldIn(FieldAnchor, vs...))
+}
+
+// AnchorNotIn applies the NotIn predicate on the "anchor" field.
+func AnchorNotIn(vs ...time.Time) predicate.UsageReset {
+	return predicate.UsageReset(sql.FieldNotIn(FieldAnchor, vs...))
+}
+
+// AnchorGT applies the GT predicate on the "anchor" field.
+func AnchorGT(v time.Time) predicate.UsageReset {
+	return predicate.UsageReset(sql.FieldGT(FieldAnchor, v))
+}
+
+// AnchorGTE applies the GTE predicate on the "anchor" field.
+func AnchorGTE(v time.Time) predicate.UsageReset {
+	return predicate.UsageReset(sql.FieldGTE(FieldAnchor, v))
+}
+
+// AnchorLT applies the LT predicate on the "anchor" field.
+func AnchorLT(v time.Time) predicate.UsageReset {
+	return predicate.UsageReset(sql.FieldLT(FieldAnchor, v))
+}
+
+// AnchorLTE applies the LTE predicate on the "anchor" field.
+func AnchorLTE(v time.Time) predicate.UsageReset {
+	return predicate.UsageReset(sql.FieldLTE(FieldAnchor, v))
 }
 
 // HasEntitlement applies the HasEdge predicate on the "entitlement" edge.

--- a/openmeter/ent/db/usagereset_create.go
+++ b/openmeter/ent/db/usagereset_create.go
@@ -84,6 +84,12 @@ func (urc *UsageResetCreate) SetResetTime(t time.Time) *UsageResetCreate {
 	return urc
 }
 
+// SetAnchor sets the "anchor" field.
+func (urc *UsageResetCreate) SetAnchor(t time.Time) *UsageResetCreate {
+	urc.mutation.SetAnchor(t)
+	return urc
+}
+
 // SetID sets the "id" field.
 func (urc *UsageResetCreate) SetID(s string) *UsageResetCreate {
 	urc.mutation.SetID(s)
@@ -174,6 +180,9 @@ func (urc *UsageResetCreate) check() error {
 	if _, ok := urc.mutation.ResetTime(); !ok {
 		return &ValidationError{Name: "reset_time", err: errors.New(`db: missing required field "UsageReset.reset_time"`)}
 	}
+	if _, ok := urc.mutation.Anchor(); !ok {
+		return &ValidationError{Name: "anchor", err: errors.New(`db: missing required field "UsageReset.anchor"`)}
+	}
 	if len(urc.mutation.EntitlementIDs()) == 0 {
 		return &ValidationError{Name: "entitlement", err: errors.New(`db: missing required edge "UsageReset.entitlement"`)}
 	}
@@ -232,6 +241,10 @@ func (urc *UsageResetCreate) createSpec() (*UsageReset, *sqlgraph.CreateSpec) {
 	if value, ok := urc.mutation.ResetTime(); ok {
 		_spec.SetField(usagereset.FieldResetTime, field.TypeTime, value)
 		_node.ResetTime = value
+	}
+	if value, ok := urc.mutation.Anchor(); ok {
+		_spec.SetField(usagereset.FieldAnchor, field.TypeTime, value)
+		_node.Anchor = value
 	}
 	if nodes := urc.mutation.EntitlementIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -360,6 +373,9 @@ func (u *UsageResetUpsertOne) UpdateNewValues() *UsageResetUpsertOne {
 		}
 		if _, exists := u.create.mutation.ResetTime(); exists {
 			s.SetIgnore(usagereset.FieldResetTime)
+		}
+		if _, exists := u.create.mutation.Anchor(); exists {
+			s.SetIgnore(usagereset.FieldAnchor)
 		}
 	}))
 	return u
@@ -621,6 +637,9 @@ func (u *UsageResetUpsertBulk) UpdateNewValues() *UsageResetUpsertBulk {
 			}
 			if _, exists := b.mutation.ResetTime(); exists {
 				s.SetIgnore(usagereset.FieldResetTime)
+			}
+			if _, exists := b.mutation.Anchor(); exists {
+				s.SetIgnore(usagereset.FieldAnchor)
 			}
 		}
 	}))

--- a/openmeter/ent/schema/entitlement.go
+++ b/openmeter/ent/schema/entitlement.go
@@ -52,7 +52,8 @@ func (Entitlement) Fields() []ent.Field {
 			dialect.Postgres: "jsonb",
 		}).Optional(),
 		field.String("usage_period_interval").GoType(isodate.String("")).Optional().Nillable().Immutable(),
-		field.Time("usage_period_anchor").Optional().Nillable(),
+		field.Time("usage_period_anchor").Optional().Nillable().Comment("Historically this field had been overwritten with each anchor reset, now we keep the original anchor time and the value is populated from the last reset which is queried dynamically"),
+		// TODO: get rid of current_usage_period in the db and make it calculated
 		field.Time("current_usage_period_start").Optional().Nillable(),
 		field.Time("current_usage_period_end").Optional().Nillable(),
 		field.Bool("subscription_managed").Optional().Immutable(),

--- a/openmeter/ent/schema/usage_reset.go
+++ b/openmeter/ent/schema/usage_reset.go
@@ -28,6 +28,7 @@ func (UsageReset) Fields() []ent.Field {
 			dialect.Postgres: "char(26)",
 		}),
 		field.Time("reset_time").Immutable(),
+		field.Time("anchor").Immutable(),
 	}
 }
 

--- a/openmeter/entitlement/adapter/entitlement.go
+++ b/openmeter/entitlement/adapter/entitlement.go
@@ -454,6 +454,8 @@ func mapEntitlementEntity(e *db.Entitlement) *entitlement.Entitlement {
 			Interval: timeutil.RecurrenceInterval{Period: parsed},
 		}
 
+		ent.OriginalUsagePeriodAnchor = convert.SafeToUTC(e.UsagePeriodAnchor)
+
 		// We no longer override the anchor at each reset as we need to preserve the original
 		// This edge with the last reset should be populated for each query
 		if len(e.Edges.UsageReset) > 0 && e.Edges.UsageReset[0] != nil {

--- a/openmeter/entitlement/adapter/entitlement.go
+++ b/openmeter/entitlement/adapter/entitlement.go
@@ -453,6 +453,12 @@ func mapEntitlementEntity(e *db.Entitlement) *entitlement.Entitlement {
 			Anchor:   e.UsagePeriodAnchor.In(time.UTC),
 			Interval: timeutil.RecurrenceInterval{Period: parsed},
 		}
+
+		// We no longer override the anchor at each reset as we need to preserve the original
+		// This edge with the last reset should be populated for each query
+		if len(e.Edges.UsageReset) > 0 && e.Edges.UsageReset[0] != nil {
+			ent.UsagePeriod.Anchor = e.Edges.UsageReset[0].Anchor.In(time.UTC)
+		}
 	}
 
 	if e.CurrentUsagePeriodEnd != nil && e.CurrentUsagePeriodStart != nil {
@@ -475,10 +481,6 @@ func (a *entitlementDBAdapter) UpdateEntitlementUsagePeriod(ctx context.Context,
 				SetCurrentUsagePeriodStart(params.CurrentUsagePeriod.From).
 				SetCurrentUsagePeriodEnd(params.CurrentUsagePeriod.To)
 
-			if params.NewAnchor != nil {
-				update = update.SetUsagePeriodAnchor(*params.NewAnchor)
-			}
-
 			_, err := update.Save(ctx)
 			return nil, err
 		},
@@ -486,6 +488,7 @@ func (a *entitlementDBAdapter) UpdateEntitlementUsagePeriod(ctx context.Context,
 	return err
 }
 
+// FIXME: if we don't update the CurrentUsagePeriod than this will not work
 func (a *entitlementDBAdapter) ListActiveEntitlementsWithExpiredUsagePeriod(ctx context.Context, namespaces []string, expiredBefore time.Time) ([]entitlement.Entitlement, error) {
 	return entutils.TransactingRepo(
 		ctx,
@@ -584,7 +587,9 @@ func (a *entitlementDBAdapter) GetScheduledEntitlements(ctx context.Context, nam
 		ctx,
 		a,
 		func(ctx context.Context, repo *entitlementDBAdapter) (*[]entitlement.Entitlement, error) {
-			res, err := repo.db.Entitlement.Query().
+			query := repo.db.Entitlement.Query()
+			query = withLatestUsageReset(query, []string{namespace})
+			res, err := query.
 				Where(
 					db_entitlement.Or(
 						db_entitlement.ActiveToIsNil(),

--- a/openmeter/entitlement/adapter/entitlement.go
+++ b/openmeter/entitlement/adapter/entitlement.go
@@ -490,7 +490,6 @@ func (a *entitlementDBAdapter) UpdateEntitlementUsagePeriod(ctx context.Context,
 	return err
 }
 
-// FIXME: if we don't update the CurrentUsagePeriod than this will not work
 func (a *entitlementDBAdapter) ListActiveEntitlementsWithExpiredUsagePeriod(ctx context.Context, namespaces []string, expiredBefore time.Time) ([]entitlement.Entitlement, error) {
 	return entutils.TransactingRepo(
 		ctx,

--- a/openmeter/entitlement/adapter/usage_reset.go
+++ b/openmeter/entitlement/adapter/usage_reset.go
@@ -42,6 +42,7 @@ func (a *usageResetDBAdapter) Save(ctx context.Context, usageResetTime metereden
 				SetEntitlementID(usageResetTime.EntitlementID).
 				SetNamespace(usageResetTime.Namespace).
 				SetResetTime(usageResetTime.ResetTime).
+				SetAnchor(usageResetTime.Anchor).
 				Save(ctx)
 			return nil, err
 		},
@@ -106,5 +107,6 @@ func mapUsageResetTime(res *db.UsageReset) *meteredentitlement.UsageResetTime {
 	return &meteredentitlement.UsageResetTime{
 		EntitlementID: res.EntitlementID,
 		ResetTime:     res.ResetTime,
+		Anchor:        res.Anchor,
 	}
 }

--- a/openmeter/entitlement/entitlement.go
+++ b/openmeter/entitlement/entitlement.go
@@ -334,8 +334,9 @@ type GenericProperties struct {
 	SubjectKey      string          `json:"subjectKey,omitempty"`
 	EntitlementType EntitlementType `json:"type,omitempty"`
 
-	UsagePeriod        *UsagePeriod     `json:"usagePeriod,omitempty"`
-	CurrentUsagePeriod *timeutil.Period `json:"currentUsagePeriod,omitempty"`
+	UsagePeriod               *UsagePeriod     `json:"usagePeriod,omitempty"`
+	CurrentUsagePeriod        *timeutil.Period `json:"currentUsagePeriod,omitempty"`
+	OriginalUsagePeriodAnchor *time.Time       `json:"originalUsagePeriodAnchor,omitempty"`
 
 	SubscriptionManaged bool `json:"subscriptionManaged,omitempty"`
 }
@@ -362,6 +363,13 @@ func (u UsagePeriod) Validate() error {
 	}
 
 	return nil
+}
+
+func (u UsagePeriod) AsRecurrence() timeutil.Recurrence {
+	return timeutil.Recurrence{
+		Anchor:   u.Anchor,
+		Interval: u.Interval,
+	}
 }
 
 func (u UsagePeriod) Equal(other UsagePeriod) bool {

--- a/openmeter/entitlement/metered/balance.go
+++ b/openmeter/entitlement/metered/balance.go
@@ -51,6 +51,8 @@ type BalanceHistoryParams struct {
 }
 
 func (e *connector) GetEntitlementBalance(ctx context.Context, entitlementID models.NamespacedID, at time.Time) (*EntitlementBalance, error) {
+	e.logger.DebugContext(ctx, "Getting entitlement balance", "entitlement", entitlementID, "at", at)
+
 	nsOwner := grant.NamespacedOwner{
 		Namespace: entitlementID.Namespace,
 		ID:        grant.Owner(entitlementID.ID),
@@ -72,6 +74,8 @@ func (e *connector) GetEntitlementBalance(ctx context.Context, entitlementID mod
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current usage period start at: %w", err)
 	}
+
+	// TODO: move usage calculation some place else
 
 	meterQuery := ownerMeter.DefaultParams
 	meterQuery.FilterSubject = []string{ownerMeter.SubjectKey}

--- a/openmeter/entitlement/metered/balance_test.go
+++ b/openmeter/entitlement/metered/balance_test.go
@@ -15,6 +15,7 @@ import (
 	meteredentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/metered"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/convert"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -209,9 +210,13 @@ func TestGetEntitlementBalance(t *testing.T) {
 		{
 			name: "Should save new snapshot",
 			run: func(t *testing.T, connector meteredentitlement.Connector, deps *dependencies) {
-				t.Skip("TODO: add back saving snapshots")
 				ctx := context.Background()
 				startTime := testutils.GetRFC3339Time(t, "2024-03-01T00:00:00Z")
+				clock.SetTime(startTime)
+				defer clock.ResetTime()
+
+				// register usage so meter is found
+				deps.streamingConnector.AddSimpleEvent(meterSlug, 1, startTime.AddDate(5, 0, 0))
 
 				// create featute in db
 				feature, err := deps.featureRepo.CreateFeature(ctx, exampleFeature)
@@ -220,10 +225,11 @@ func TestGetEntitlementBalance(t *testing.T) {
 				// create entitlement in db
 				inp := getEntitlement(t, feature)
 				inp.MeasureUsageFrom = &startTime
+				inp.UsagePeriod.Interval = timeutil.RecurrencePeriodDaily // we need a faster recurrence as we wont save snapshots in the current usage period
 				entitlement, err := deps.entitlementRepo.CreateEntitlement(ctx, inp)
 				assert.NoError(t, err)
 
-				queryTime := startTime.Add(3 * time.Hour) // longer than grace period for saving snapshots
+				queryTime := startTime.AddDate(0, 0, 9) // longer than grace period for saving snapshots
 
 				// issue grants
 				owner := grant.NamespacedOwner{
@@ -232,28 +238,18 @@ func TestGetEntitlementBalance(t *testing.T) {
 				}
 
 				g1, err := deps.grantRepo.CreateGrant(ctx, grant.RepoCreateInput{
-					OwnerID:     owner.ID,
-					Namespace:   namespace,
-					Amount:      1000,
-					Priority:    2,
-					EffectiveAt: startTime,
-					ExpiresAt:   startTime.AddDate(0, 0, 3),
-				})
-				assert.NoError(t, err)
-
-				g2, err := deps.grantRepo.CreateGrant(ctx, grant.RepoCreateInput{
-					OwnerID:     owner.ID,
-					Namespace:   namespace,
-					Amount:      1000,
-					Priority:    1,
-					EffectiveAt: startTime.Add(time.Hour),
-					ExpiresAt:   startTime.Add(time.Hour).AddDate(0, 0, 3),
+					OwnerID:          owner.ID,
+					Namespace:        namespace,
+					Amount:           1000,
+					ResetMaxRollover: 1000,
+					Priority:         2,
+					EffectiveAt:      startTime,
+					ExpiresAt:        startTime.AddDate(0, 0, 10),
 				})
 				assert.NoError(t, err)
 
 				// register usage for meter & feature
-				deps.streamingConnector.AddSimpleEvent(meterSlug, 100, g1.EffectiveAt.Add(time.Minute*5))
-				deps.streamingConnector.AddSimpleEvent(meterSlug, 100, g2.EffectiveAt.Add(time.Minute))
+				deps.streamingConnector.AddSimpleEvent(meterSlug, 200, g1.EffectiveAt.Add(time.Minute))
 
 				// add a balance snapshot
 				err = deps.balanceSnapshotRepo.Save(
@@ -261,13 +257,15 @@ func TestGetEntitlementBalance(t *testing.T) {
 					owner, []balance.Snapshot{
 						{
 							Balances: balance.Map{
-								g1.ID: 750,
+								g1.ID: 1000,
 							},
 							Overage: 0,
-							At:      g1.EffectiveAt.Add(time.Minute),
+							At:      g1.EffectiveAt,
 						},
 					})
 				assert.NoError(t, err)
+
+				clock.SetTime(queryTime)
 
 				// get last vaild snapshot
 				snap1, err := deps.balanceSnapshotRepo.GetLatestValidAt(ctx, owner, queryTime)
@@ -277,8 +275,8 @@ func TestGetEntitlementBalance(t *testing.T) {
 				assert.NoError(t, err)
 
 				// validate balance calc for good measure
-				assert.Equal(t, 200.0, entBalance.UsageInPeriod) // in total we had 200 usage
-				assert.Equal(t, 1550.0, entBalance.Balance)      // 750 + 1000 (g2 amount) - 200 = 1550
+				assert.Equal(t, 0.0, entBalance.UsageInPeriod)
+				assert.Equal(t, 800.0, entBalance.Balance)
 				assert.Equal(t, 0.0, entBalance.Overage)
 
 				snap2, err := deps.balanceSnapshotRepo.GetLatestValidAt(ctx, owner, queryTime)
@@ -288,18 +286,17 @@ func TestGetEntitlementBalance(t *testing.T) {
 				assert.NotEqual(t, snap1.At, snap2.At)
 				assert.Equal(t, 0.0, snap2.Overage)
 				assert.Equal(t, balance.Map{
-					g1.ID: 650,  // the grant that existed so far
-					g2.ID: 1000, // the grant that was added at this instant
+					g1.ID: 800,
 				}, snap2.Balances)
-				assert.Equal(t, g2.EffectiveAt, snap2.At)
 			},
 		},
 		{
 			name: "Should not save the same snapshot over and over again",
 			run: func(t *testing.T, connector meteredentitlement.Connector, deps *dependencies) {
-				t.Skip("TODO: add back saving snapshots")
 				ctx := context.Background()
 				startTime := testutils.GetRFC3339Time(t, "2024-03-01T00:00:00Z")
+				clock.SetTime(startTime)
+				defer clock.ResetTime()
 
 				// create featute in db
 				feature, err := deps.featureRepo.CreateFeature(ctx, exampleFeature)
@@ -308,10 +305,11 @@ func TestGetEntitlementBalance(t *testing.T) {
 				// create entitlement in db
 				inp := getEntitlement(t, feature)
 				inp.MeasureUsageFrom = &startTime
+				inp.UsagePeriod.Interval = timeutil.RecurrencePeriodDaily // we need a faster recurrence as we wont save snapshots in the current usage period
 				entitlement, err := deps.entitlementRepo.CreateEntitlement(ctx, inp)
 				assert.NoError(t, err)
 
-				queryTime := startTime.Add(3 * time.Hour) // longer than grace period for saving snapshots
+				queryTime := startTime.AddDate(0, 0, 10) // longer than grace period for saving snapshots
 
 				// issue grants
 				owner := grant.NamespacedOwner{
@@ -320,28 +318,18 @@ func TestGetEntitlementBalance(t *testing.T) {
 				}
 
 				g1, err := deps.grantRepo.CreateGrant(ctx, grant.RepoCreateInput{
-					OwnerID:     owner.ID,
-					Namespace:   namespace,
-					Amount:      1000,
-					Priority:    2,
-					EffectiveAt: startTime,
-					ExpiresAt:   startTime.AddDate(0, 0, 3),
-				})
-				assert.NoError(t, err)
-
-				g2, err := deps.grantRepo.CreateGrant(ctx, grant.RepoCreateInput{
-					OwnerID:     owner.ID,
-					Namespace:   namespace,
-					Amount:      1000,
-					Priority:    1,
-					EffectiveAt: startTime.Add(time.Hour),
-					ExpiresAt:   startTime.Add(time.Hour).AddDate(0, 0, 3),
+					OwnerID:          owner.ID,
+					Namespace:        namespace,
+					Amount:           1000,
+					ResetMaxRollover: 1000,
+					Priority:         2,
+					EffectiveAt:      startTime,
+					ExpiresAt:        startTime.AddDate(0, 5, 0),
 				})
 				assert.NoError(t, err)
 
 				// register usage for meter & feature
-				deps.streamingConnector.AddSimpleEvent(meterSlug, 100, g1.EffectiveAt.Add(time.Minute*5))
-				deps.streamingConnector.AddSimpleEvent(meterSlug, 100, g2.EffectiveAt.Add(time.Minute))
+				deps.streamingConnector.AddSimpleEvent(meterSlug, 200, g1.EffectiveAt.Add(time.Minute*5))
 
 				// add a balance snapshot
 				err = deps.balanceSnapshotRepo.Save(
@@ -349,10 +337,10 @@ func TestGetEntitlementBalance(t *testing.T) {
 					owner, []balance.Snapshot{
 						{
 							Balances: balance.Map{
-								g1.ID: 750,
+								g1.ID: 1000,
 							},
 							Overage: 0,
-							At:      g1.EffectiveAt.Add(time.Minute),
+							At:      g1.EffectiveAt,
 						},
 					})
 				assert.NoError(t, err)
@@ -361,12 +349,14 @@ func TestGetEntitlementBalance(t *testing.T) {
 				snap1, err := deps.balanceSnapshotRepo.GetLatestValidAt(ctx, owner, queryTime)
 				assert.NoError(t, err)
 
+				clock.SetTime(queryTime)
+
 				entBalance, err := connector.GetEntitlementBalance(ctx, models.NamespacedID{Namespace: namespace, ID: entitlement.ID}, queryTime)
 				assert.NoError(t, err)
 
 				// validate balance calc for good measure
-				assert.Equal(t, 200.0, entBalance.UsageInPeriod) // in total we had 200 usage
-				assert.Equal(t, 1550.0, entBalance.Balance)      // 750 + 1000 (g2 amount) - 200 = 1550
+				assert.Equal(t, 0.0, entBalance.UsageInPeriod)
+				assert.Equal(t, 800.0, entBalance.Balance)
 				assert.Equal(t, 0.0, entBalance.Overage)
 
 				snap2, err := deps.balanceSnapshotRepo.GetLatestValidAt(ctx, owner, queryTime)
@@ -376,18 +366,16 @@ func TestGetEntitlementBalance(t *testing.T) {
 				assert.NotEqual(t, snap1.At, snap2.At)
 				assert.Equal(t, 0.0, snap2.Overage)
 				assert.Equal(t, balance.Map{
-					g1.ID: 650,  // the grant that existed so far
-					g2.ID: 1000, // the grant that was added at this instant
+					g1.ID: 800,
 				}, snap2.Balances)
-				assert.Equal(t, g2.EffectiveAt, snap2.At)
 
 				// run the calc again
 				entBalance, err = connector.GetEntitlementBalance(ctx, models.NamespacedID{Namespace: namespace, ID: entitlement.ID}, queryTime)
 				assert.NoError(t, err)
 
 				// validate balance calc for good measure
-				assert.Equal(t, 200.0, entBalance.UsageInPeriod) // in total we had 200 usage
-				assert.Equal(t, 1550.0, entBalance.Balance)      // 750 + 1000 (g2 amount) - 200 = 1550
+				assert.Equal(t, 0.0, entBalance.UsageInPeriod)
+				assert.Equal(t, 800.0, entBalance.Balance)
 				assert.Equal(t, 0.0, entBalance.Overage)
 
 				// FIXME: we shouldn't check things that the contract is unable to tell us

--- a/openmeter/entitlement/metered/balance_test.go
+++ b/openmeter/entitlement/metered/balance_test.go
@@ -209,6 +209,7 @@ func TestGetEntitlementBalance(t *testing.T) {
 		{
 			name: "Should save new snapshot",
 			run: func(t *testing.T, connector meteredentitlement.Connector, deps *dependencies) {
+				t.Skip("TODO: add back saving snapshots")
 				ctx := context.Background()
 				startTime := testutils.GetRFC3339Time(t, "2024-03-01T00:00:00Z")
 
@@ -296,6 +297,7 @@ func TestGetEntitlementBalance(t *testing.T) {
 		{
 			name: "Should not save the same snapshot over and over again",
 			run: func(t *testing.T, connector meteredentitlement.Connector, deps *dependencies) {
+				t.Skip("TODO: add back saving snapshots")
 				ctx := context.Background()
 				startTime := testutils.GetRFC3339Time(t, "2024-03-01T00:00:00Z")
 

--- a/openmeter/entitlement/metered/connector.go
+++ b/openmeter/entitlement/metered/connector.go
@@ -3,6 +3,7 @@ package meteredentitlement
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/openmeterio/openmeter/openmeter/credit"
@@ -65,6 +66,8 @@ type connector struct {
 
 	granularity time.Duration
 	publisher   eventbus.Publisher
+
+	logger *slog.Logger
 }
 
 func NewMeteredEntitlementConnector(
@@ -75,6 +78,7 @@ func NewMeteredEntitlementConnector(
 	grantRepo grant.Repo,
 	entitlementRepo entitlement.EntitlementRepo,
 	publisher eventbus.Publisher,
+	logger *slog.Logger,
 ) Connector {
 	return &connector{
 		streamingConnector: streamingConnector,
@@ -88,10 +92,13 @@ func NewMeteredEntitlementConnector(
 		granularity: time.Minute,
 
 		publisher: publisher,
+		logger:    logger,
 	}
 }
 
 func (e *connector) GetValue(ctx context.Context, entitlement *entitlement.Entitlement, at time.Time) (entitlement.EntitlementValue, error) {
+	e.logger.DebugContext(ctx, "Getting entitlement value", "entitlement", entitlement, "at", at)
+
 	metered, err := ParseFromGenericEntitlement(entitlement)
 	if err != nil {
 		return nil, err

--- a/openmeter/entitlement/metered/entitlement.go
+++ b/openmeter/entitlement/metered/entitlement.go
@@ -39,6 +39,9 @@ type Entitlement struct {
 	// CurrentPeriod defines the current period for usage calculations.
 	CurrentUsagePeriod timeutil.Period `json:"currentUsagePeriod,omitempty"`
 
+	// OriginalUsagePeriodAnchor defines the original anchor of the current usage period.
+	OriginalUsagePeriodAnchor time.Time `json:"originalUsagePeriodAnchor,omitempty"`
+
 	// PreserveOverageAtReset defines if overage should be preserved when the entitlement is reset.
 	PreserveOverageAtReset bool `json:"preserveOverageAtReset,omitempty"`
 
@@ -77,6 +80,10 @@ func ParseFromGenericEntitlement(model *entitlement.Entitlement) (*Entitlement, 
 		return nil, &entitlement.InvalidValueError{Message: "CurrentUsagePeriod is required", Type: model.EntitlementType}
 	}
 
+	if model.OriginalUsagePeriodAnchor == nil {
+		return nil, &entitlement.InvalidValueError{Message: "OriginalUsagePeriodAnchor is required", Type: model.EntitlementType}
+	}
+
 	if model.IssueAfterResetPriority != nil && model.IssueAfterReset == nil {
 		return nil, &entitlement.InvalidValueError{Message: "IssueAfterReset is required for IssueAfterResetPriority", Type: model.EntitlementType}
 	}
@@ -84,12 +91,13 @@ func ParseFromGenericEntitlement(model *entitlement.Entitlement) (*Entitlement, 
 	ent := Entitlement{
 		GenericProperties: model.GenericProperties,
 
-		MeasureUsageFrom:       *model.MeasureUsageFrom,
-		IsSoftLimit:            *model.IsSoftLimit,
-		UsagePeriod:            *model.UsagePeriod,
-		LastReset:              *model.LastReset,
-		CurrentUsagePeriod:     *model.CurrentUsagePeriod,
-		PreserveOverageAtReset: defaultx.WithDefault(model.PreserveOverageAtReset, false),
+		MeasureUsageFrom:          *model.MeasureUsageFrom,
+		IsSoftLimit:               *model.IsSoftLimit,
+		UsagePeriod:               *model.UsagePeriod,
+		LastReset:                 *model.LastReset,
+		CurrentUsagePeriod:        *model.CurrentUsagePeriod,
+		OriginalUsagePeriodAnchor: *model.OriginalUsagePeriodAnchor,
+		PreserveOverageAtReset:    defaultx.WithDefault(model.PreserveOverageAtReset, false),
 	}
 
 	if model.IssueAfterReset != nil {

--- a/openmeter/entitlement/metered/grant_owner_adapter.go
+++ b/openmeter/entitlement/metered/grant_owner_adapter.go
@@ -166,6 +166,12 @@ func (e *entitlementGrantOwner) EndCurrentUsagePeriod(ctx context.Context, owner
 			return nil, fmt.Errorf("failed to update entitlement usage period: %w", err)
 		}
 
+		// Now let's see what the anchor is after the update
+		entitlementEntity, err := e.entitlementRepo.GetEntitlement(txCtx, owner.NamespacedID())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get entitlement: %w", err)
+		}
+
 		// Save usage reset
 		return nil, e.usageResetRepo.Save(txCtx, UsageResetTime{
 			NamespacedModel: models.NamespacedModel{
@@ -173,6 +179,7 @@ func (e *entitlementGrantOwner) EndCurrentUsagePeriod(ctx context.Context, owner
 			},
 			EntitlementID: owner.NamespacedID().ID,
 			ResetTime:     params.At,
+			Anchor:        entitlementEntity.UsagePeriod.Anchor,
 		})
 	})
 	return err

--- a/openmeter/entitlement/metered/grant_owner_adapter.go
+++ b/openmeter/entitlement/metered/grant_owner_adapter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type entitlementGrantOwner struct {
@@ -112,7 +113,7 @@ func (e *entitlementGrantOwner) GetUsagePeriodStartAt(ctx context.Context, owner
 	// To know if this is the first period check if usage has been reset.
 
 	lastUsageReset, err := e.usageResetRepo.GetLastAt(ctx, owner.NamespacedID(), at)
-	if _, ok := err.(*UsageResetNotFoundError); ok {
+	if _, ok := lo.ErrorsAs[*UsageResetNotFoundError](err); ok {
 		return e.GetStartOfMeasurement(ctx, owner)
 	}
 	if err != nil {
@@ -133,16 +134,179 @@ func (e *entitlementGrantOwner) GetOwnerSubjectKey(ctx context.Context, owner gr
 	return entitlement.SubjectKey, nil
 }
 
-func (e *entitlementGrantOwner) GetPeriodStartTimesBetween(ctx context.Context, owner grant.NamespacedOwner, from, to time.Time) ([]time.Time, error) {
-	times := []time.Time{}
-	usageResets, err := e.usageResetRepo.GetBetween(ctx, owner.NamespacedID(), from, to)
+func (e *entitlementGrantOwner) GetResetBehavior(ctx context.Context, owner grant.NamespacedOwner) (grant.ResetBehavior, error) {
+	ent, err := e.entitlementRepo.GetEntitlement(ctx, owner.NamespacedID())
+	if err != nil {
+		return grant.ResetBehavior{}, err
+	}
+
+	mEnt, err := ParseFromGenericEntitlement(ent)
+	if err != nil {
+		return grant.ResetBehavior{}, err
+	}
+
+	return grant.ResetBehavior{
+		PreserveOverage: mEnt.PreserveOverageAtReset,
+	}, nil
+}
+
+func (e *entitlementGrantOwner) GetResetTimelineInclusive(ctx context.Context, owner grant.NamespacedOwner, period timeutil.Period) (timeutil.SimpleTimeline, error) {
+	var def timeutil.SimpleTimeline
+
+	// Let's fetch the owner entitlement
+	ent, err := e.entitlementRepo.GetEntitlement(ctx, owner.NamespacedID())
+	if err != nil {
+		return def, err
+	}
+
+	// 1. Let's find the last reset time before the period. It doesn't necessarily exist!
+	lastReset, err := e.usageResetRepo.GetLastAt(ctx, owner.NamespacedID(), period.From)
+	if err != nil {
+		if _, ok := lo.ErrorsAs[*UsageResetNotFoundError](err); ok {
+			// We build a synthetic last reset based on the entitlement's usage period
+			// This will be the case if there have been no resets for this entitlement
+			up := entitlement.UsagePeriod{
+				Anchor:   *ent.OriginalUsagePeriodAnchor,
+				Interval: ent.UsagePeriod.Interval,
+			}
+
+			currentUsagePeriod, err := up.GetCurrentPeriodAt(period.From)
+			if err != nil {
+				return def, err
+			}
+
+			lastReset = UsageResetTime{
+				NamespacedModel: models.NamespacedModel{
+					Namespace: owner.Namespace,
+				},
+				EntitlementID: owner.NamespacedID().ID,
+				ResetTime:     currentUsagePeriod.From,
+				Anchor:        currentUsagePeriod.From,
+			}
+		} else {
+			return def, err
+		}
+	}
+
+	// 2. Now let's find all the resets between the period
+	usageResets, err := e.usageResetRepo.GetBetween(ctx, owner.NamespacedID(), period)
+	if err != nil {
+		return def, err
+	}
+
+	// The timeline would look something like:
+	// [lastReset = mReset0], [mReset1], ...[mResetN], [period.To]
+	// (where mReset0 might be equal to period.From AND mResetN might be equal to period.To)
+	// For these times, in any period between them there might be programmatic resets
+
+	resets := []UsageResetTime{lastReset}
+	// usageResets are sorted ASC by ResetTime
+	for _, reset := range usageResets {
+		// The period start could be a reset time so we need to dedupe it (would be both lastReset and usageResets[0])
+		// usageResets are sorted ASC by ResetTime
+		if l, _ := lo.Last(resets); reset.ResetTime.After(l.ResetTime) {
+			resets = append(resets, reset)
+		}
+	}
+
+	// Let's convert it to a timeline
+	resetTimeline := timeutil.NewTimeline(lo.Map(resets, func(reset UsageResetTime, _ int) timeutil.Timed[UsageResetTime] {
+		return timeutil.AsTimed(func(reset UsageResetTime) time.Time { return reset.ResetTime })(reset)
+	}))
+
+	resetTimes := make([]time.Time, 0)
+
+	periods := resetTimeline.GetPeriods()
+
+	// We need to go through all the manual reset times and check if programmatic resets occur in between
+	for idx, p := range periods {
+		resetTimes = append(resetTimes, p.From)
+
+		// There is always one less period than values in the timeline
+		val := resetTimeline.GetAt(idx)
+
+		// Let's build the UsagePeriod for the period
+		up := entitlement.UsagePeriod{
+			Anchor:   val.GetValue().Anchor,
+			Interval: ent.UsagePeriod.Interval,
+		}
+
+		inbetweenTimes, err := e.getProgrammaticResetTimesInPeriodExclusiveInclusive(p, up)
+		if err != nil {
+			return def, err
+		}
+
+		// inbetweenTimes might contain the period end, so we need to dedupe it
+		if len(inbetweenTimes) > 0 && inbetweenTimes[len(inbetweenTimes)-1].Equal(p.To) {
+			inbetweenTimes = inbetweenTimes[:len(inbetweenTimes)-1]
+		}
+
+		resetTimes = append(resetTimes, inbetweenTimes...)
+	}
+
+	// Now, let's add the last manual reset time as well (as the cycle above only added period starts)
+	lastPeriod := periods[len(periods)-1]
+
+	// Let's make sure we're not adding it twice
+	if !lastPeriod.From.Equal(lastPeriod.To) {
+		resetTimes = append(resetTimes, lastPeriod.To)
+	}
+
+	lastResetTime, ok := lo.Last(resetTimes)
+	if !ok {
+		// Cannot happen as we always add a first value
+		return def, fmt.Errorf("no last reset found")
+	}
+
+	// Now we need to check the final period, which is [lastResetTime, period.To]
+	finalPeriod := timeutil.Period{
+		From: lastResetTime,
+		To:   period.To,
+	}
+
+	// Let's build the usage period for the final period
+	finalReset, _ := lo.Last(resets)
+
+	finalUsagePeriod := entitlement.UsagePeriod{
+		Anchor:   finalReset.Anchor,
+		Interval: ent.UsagePeriod.Interval,
+	}
+
+	lastPeriodTimes, err := e.getProgrammaticResetTimesInPeriodExclusiveInclusive(finalPeriod, finalUsagePeriod)
+	if err != nil {
+		return def, err
+	}
+
+	resetTimes = append(resetTimes, lastPeriodTimes...)
+
+	// Let's return in UTC
+	return timeutil.NewSimpleTimeline(lo.Map(resetTimes, func(t time.Time, _ int) time.Time { return t.UTC() })), nil
+}
+
+// Returns all programmatic reset times in the period (start inclusive end exclusive)
+func (e *entitlementGrantOwner) getProgrammaticResetTimesInPeriodExclusiveInclusive(period timeutil.Period, up entitlement.UsagePeriod) ([]time.Time, error) {
+	rts := []time.Time{}
+
+	upr := up.AsRecurrence()
+
+	currentUP, err := up.GetCurrentPeriodAt(period.From)
 	if err != nil {
 		return nil, err
 	}
-	for _, reset := range usageResets {
-		times = append(times, reset.ResetTime)
+
+	// Now let's check if there are any programmatic resets during the period (start and end exclusive!)
+
+	// Let's find the last reset time when the period starts
+	resetTime := currentUP.From
+
+	// We might silence an error here at upr.Next but in practice this should never happen
+	for rt := resetTime; err == nil && !rt.After(period.To); rt, err = upr.Next(rt) {
+		if period.ContainsInclusive(rt) && period.From.Compare(rt) != 0 {
+			rts = append(rts, rt)
+		}
 	}
-	return times, nil
+
+	return rts, nil
 }
 
 func (e *entitlementGrantOwner) EndCurrentUsagePeriod(ctx context.Context, owner grant.NamespacedOwner, params grant.EndCurrentUsagePeriodParams) error {

--- a/openmeter/entitlement/metered/grant_owner_adapter_test.go
+++ b/openmeter/entitlement/metered/grant_owner_adapter_test.go
@@ -1,0 +1,488 @@
+package meteredentitlement_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	"github.com/openmeterio/openmeter/openmeter/entitlement"
+	meteredentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/metered"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestEntitlementGrantOwnerAdapter(t *testing.T) {
+	createFeature := func(t *testing.T, deps *dependencies) feature.Feature {
+		t.Helper()
+
+		f, err := deps.featureRepo.CreateFeature(context.Background(), feature.CreateFeatureInputs{
+			Name:      "f1",
+			Key:       "f1",
+			MeterSlug: lo.ToPtr(meterSlug),
+			Namespace: namespace,
+		})
+		require.NoError(t, err)
+
+		return f
+	}
+
+	t.Run("Should return the last reset time for the full period if there are no resets", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		now := testutils.GetRFC3339Time(t, "2025-02-01T00:00:00Z")
+		clock.SetTime(now)
+
+		_, deps := setupConnector(t)
+		defer deps.Teardown()
+		f := createFeature(t, deps)
+
+		// Let's create an entitlement
+		ent, err := deps.entitlementRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
+			Namespace:       namespace,
+			FeatureID:       f.ID,
+			FeatureKey:      f.Key,
+			SubjectKey:      "subject1",
+			EntitlementType: entitlement.EntitlementTypeMetered,
+			UsagePeriod: &entitlement.UsagePeriod{
+				Interval: timeutil.RecurrencePeriodMonth,
+				Anchor:   now,
+			},
+		})
+		require.NoError(t, err)
+
+		// We do no resets...
+
+		owner := grant.NamespacedOwner{
+			Namespace: namespace,
+			ID:        grant.Owner(ent.ID),
+		}
+
+		t.Run("Should return reset for period start if before the period", func(t *testing.T) {
+			// We query for 4 days without reset
+			timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+				From: now.AddDate(0, 0, 1),
+				To:   now.AddDate(0, 0, 5),
+			})
+			require.NoError(t, err)
+
+			require.Len(t, timeline.GetTimes(), 1)
+
+			periods := timeline.GetPeriods()
+			require.Len(t, periods, 1)
+
+			assert.Equal(t, now, periods[0].From)
+			assert.Equal(t, now, periods[0].To)
+		})
+
+		t.Run("Should return reset for period start when coincides with period start", func(t *testing.T) {
+			// We query for 4 days without reset
+			timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+				From: now,
+				To:   now.AddDate(0, 0, 5),
+			})
+			require.NoError(t, err)
+
+			require.Len(t, timeline.GetTimes(), 1)
+
+			periods := timeline.GetPeriods()
+			require.Len(t, periods, 1)
+
+			assert.Equal(t, now, periods[0].From)
+			assert.Equal(t, now, periods[0].To)
+		})
+	})
+
+	t.Run("Should return manual reset time on the 3rd day", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		now := testutils.GetRFC3339Time(t, "2025-02-01T00:00:00Z")
+		clock.SetTime(now)
+
+		_, deps := setupConnector(t)
+		defer deps.Teardown()
+		f := createFeature(t, deps)
+
+		// Let's create an entitlement
+		ent, err := deps.entitlementRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
+			Namespace:       namespace,
+			FeatureID:       f.ID,
+			FeatureKey:      f.Key,
+			SubjectKey:      "subject1",
+			EntitlementType: entitlement.EntitlementTypeMetered,
+			UsagePeriod: &entitlement.UsagePeriod{
+				Interval: timeutil.RecurrencePeriodMonth,
+				Anchor:   now,
+			},
+		})
+		require.NoError(t, err)
+
+		// We do a single reset on the 3rd day
+		resetTime := now.AddDate(0, 0, 3)
+		err = deps.usageResetRepo.Save(ctx, meteredentitlement.UsageResetTime{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: namespace,
+			},
+			ResetTime:     resetTime,
+			Anchor:        ent.UsagePeriod.Anchor,
+			EntitlementID: ent.ID,
+		})
+		require.NoError(t, err)
+
+		owner := grant.NamespacedOwner{
+			Namespace: namespace,
+			ID:        grant.Owner(ent.ID),
+		}
+
+		// We query for 4 days without the reset included
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+			From: now.AddDate(0, 0, 1),
+			To:   now.AddDate(0, 0, 5),
+		})
+		require.NoError(t, err)
+
+		times := timeline.GetTimes()
+
+		require.Len(t, times, 2)
+
+		assert.Equal(t, now, times[0])
+		assert.Equal(t, resetTime, times[1])
+	})
+
+	t.Run("Should find programmatic reset time in the period", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		now := testutils.GetRFC3339Time(t, "2025-02-01T00:00:00Z")
+		clock.SetTime(now)
+
+		_, deps := setupConnector(t)
+		defer deps.Teardown()
+		f := createFeature(t, deps)
+
+		// Let's create an entitlement
+		ent, err := deps.entitlementRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
+			Namespace:       namespace,
+			FeatureID:       f.ID,
+			FeatureKey:      f.Key,
+			SubjectKey:      "subject1",
+			EntitlementType: entitlement.EntitlementTypeMetered,
+			UsagePeriod: &entitlement.UsagePeriod{
+				Interval: timeutil.RecurrencePeriodMonth,
+				Anchor:   now,
+			},
+		})
+		require.NoError(t, err)
+
+		// We do no resets...
+
+		owner := grant.NamespacedOwner{
+			Namespace: namespace,
+			ID:        grant.Owner(ent.ID),
+		}
+
+		// We query for 4 days without the reset included
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+			From: now.AddDate(0, 0, 1),
+			To:   now.AddDate(0, 1, 5), // We query for more than usage period
+		})
+		require.NoError(t, err)
+
+		times := timeline.GetTimes()
+
+		require.Len(t, times, 2)
+
+		assert.Equal(t, now, times[0])
+		assert.Equal(t, now.AddDate(0, 1, 0), times[1])
+	})
+
+	t.Run("Should find programmatic reset time between manual resets", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		now := testutils.GetRFC3339Time(t, "2025-02-01T00:00:00Z")
+		clock.SetTime(now)
+
+		_, deps := setupConnector(t)
+		defer deps.Teardown()
+		f := createFeature(t, deps)
+
+		// Let's create an entitlement
+		ent, err := deps.entitlementRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
+			Namespace:       namespace,
+			FeatureID:       f.ID,
+			FeatureKey:      f.Key,
+			SubjectKey:      "subject1",
+			EntitlementType: entitlement.EntitlementTypeMetered,
+			UsagePeriod: &entitlement.UsagePeriod{
+				Interval: timeutil.RecurrencePeriodMonth,
+				Anchor:   now,
+			},
+		})
+		require.NoError(t, err)
+
+		// Let's do two resets, one before and one after the programmatic reset
+		resetTime1 := now.AddDate(0, 0, 15)
+		err = deps.usageResetRepo.Save(ctx, meteredentitlement.UsageResetTime{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: namespace,
+			},
+			ResetTime:     resetTime1,
+			Anchor:        ent.UsagePeriod.Anchor,
+			EntitlementID: ent.ID,
+		})
+		require.NoError(t, err)
+
+		resetTime2 := now.AddDate(0, 1, 3)
+		err = deps.usageResetRepo.Save(ctx, meteredentitlement.UsageResetTime{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: namespace,
+			},
+			ResetTime:     resetTime2,
+			Anchor:        ent.UsagePeriod.Anchor,
+			EntitlementID: ent.ID,
+		})
+		require.NoError(t, err)
+
+		owner := grant.NamespacedOwner{
+			Namespace: namespace,
+			ID:        grant.Owner(ent.ID),
+		}
+
+		// We query for 4 days without the reset included
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+			From: now.AddDate(0, 0, 1),
+			To:   now.AddDate(0, 1, 5), // We query for more than usage period
+		})
+		require.NoError(t, err)
+
+		times := timeline.GetTimes()
+
+		require.Len(t, times, 4)
+
+		assert.Equal(t, now, times[0])
+		assert.Equal(t, resetTime1, times[1])
+		assert.Equal(t, now.AddDate(0, 1, 0), times[2])
+		assert.Equal(t, resetTime2, times[3])
+	})
+
+	t.Run("Should respect if anchor has been changed during a reset - no programmatic reset", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		now := testutils.GetRFC3339Time(t, "2025-02-01T00:00:00Z")
+		clock.SetTime(now)
+
+		_, deps := setupConnector(t)
+		defer deps.Teardown()
+		f := createFeature(t, deps)
+
+		// Let's create an entitlement
+		ent, err := deps.entitlementRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
+			Namespace:       namespace,
+			FeatureID:       f.ID,
+			FeatureKey:      f.Key,
+			SubjectKey:      "subject1",
+			EntitlementType: entitlement.EntitlementTypeMetered,
+			UsagePeriod: &entitlement.UsagePeriod{
+				Interval: timeutil.RecurrencePeriodMonth,
+				Anchor:   now,
+			},
+		})
+		require.NoError(t, err)
+
+		// We do a single reset on the 10th day resetting the anchor
+		resetTime := now.AddDate(0, 0, 10)
+		err = deps.usageResetRepo.Save(ctx, meteredentitlement.UsageResetTime{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: namespace,
+			},
+			ResetTime:     resetTime,
+			Anchor:        resetTime,
+			EntitlementID: ent.ID,
+		})
+		require.NoError(t, err)
+
+		owner := grant.NamespacedOwner{
+			Namespace: namespace,
+			ID:        grant.Owner(ent.ID),
+		}
+
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+			From: now.AddDate(0, 0, 1),
+			To:   now.AddDate(0, 1, 5),
+		})
+		require.NoError(t, err)
+
+		times := timeline.GetTimes()
+
+		require.Len(t, times, 2)
+
+		assert.Equal(t, now, times[0])
+		assert.Equal(t, resetTime, times[1])
+	})
+
+	t.Run("Should return end of period if it coincides with a programmatic reset", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		now := testutils.GetRFC3339Time(t, "2025-02-01T00:00:00Z")
+		clock.SetTime(now)
+
+		_, deps := setupConnector(t)
+		defer deps.Teardown()
+		f := createFeature(t, deps)
+
+		// Let's create an entitlement
+		ent, err := deps.entitlementRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
+			Namespace:       namespace,
+			FeatureID:       f.ID,
+			FeatureKey:      f.Key,
+			SubjectKey:      "subject1",
+			EntitlementType: entitlement.EntitlementTypeMetered,
+			UsagePeriod: &entitlement.UsagePeriod{
+				Interval: timeutil.RecurrencePeriodMonth,
+				Anchor:   now,
+			},
+		})
+		require.NoError(t, err)
+
+		owner := grant.NamespacedOwner{
+			Namespace: namespace,
+			ID:        grant.Owner(ent.ID),
+		}
+
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+			From: now.AddDate(0, 0, 1),
+			To:   now.AddDate(0, 1, 0),
+		})
+		require.NoError(t, err)
+
+		times := timeline.GetTimes()
+
+		require.Len(t, times, 2)
+
+		assert.Equal(t, now, times[0])
+		assert.Equal(t, now.AddDate(0, 1, 0), times[1])
+	})
+
+	t.Run("Should return end of period if it coincides with a manual reset", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		now := testutils.GetRFC3339Time(t, "2025-02-01T00:00:00Z")
+		clock.SetTime(now)
+
+		_, deps := setupConnector(t)
+		defer deps.Teardown()
+		f := createFeature(t, deps)
+
+		// Let's create an entitlement
+		ent, err := deps.entitlementRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
+			Namespace:       namespace,
+			FeatureID:       f.ID,
+			FeatureKey:      f.Key,
+			SubjectKey:      "subject1",
+			EntitlementType: entitlement.EntitlementTypeMetered,
+			UsagePeriod: &entitlement.UsagePeriod{
+				Interval: timeutil.RecurrencePeriodMonth,
+				Anchor:   now,
+			},
+		})
+		require.NoError(t, err)
+
+		// We do a single reset on the 10th day resetting the anchor
+		resetTime := now.AddDate(0, 0, 10)
+		err = deps.usageResetRepo.Save(ctx, meteredentitlement.UsageResetTime{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: namespace,
+			},
+			ResetTime:     resetTime,
+			Anchor:        resetTime,
+			EntitlementID: ent.ID,
+		})
+		require.NoError(t, err)
+
+		owner := grant.NamespacedOwner{
+			Namespace: namespace,
+			ID:        grant.Owner(ent.ID),
+		}
+
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+			From: now,
+			To:   resetTime,
+		})
+		require.NoError(t, err)
+
+		times := timeline.GetTimes()
+
+		require.Len(t, times, 2)
+
+		assert.Equal(t, now, times[0])
+		assert.Equal(t, resetTime, times[1])
+	})
+
+	t.Run("Should return a single reset time if manual reset coincides with programmatic reset", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		now := testutils.GetRFC3339Time(t, "2025-02-01T00:00:00Z")
+		clock.SetTime(now)
+
+		_, deps := setupConnector(t)
+		defer deps.Teardown()
+		f := createFeature(t, deps)
+
+		// Let's create an entitlement
+		ent, err := deps.entitlementRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
+			Namespace:       namespace,
+			FeatureID:       f.ID,
+			FeatureKey:      f.Key,
+			SubjectKey:      "subject1",
+			EntitlementType: entitlement.EntitlementTypeMetered,
+			UsagePeriod: &entitlement.UsagePeriod{
+				Interval: timeutil.RecurrencePeriodMonth,
+				Anchor:   now,
+			},
+		})
+		require.NoError(t, err)
+
+		// We do a single reset on the 10th day resetting the anchor
+		resetTime := now.AddDate(0, 1, 0)
+		err = deps.usageResetRepo.Save(ctx, meteredentitlement.UsageResetTime{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: namespace,
+			},
+			ResetTime:     resetTime,
+			Anchor:        resetTime,
+			EntitlementID: ent.ID,
+		})
+		require.NoError(t, err)
+
+		owner := grant.NamespacedOwner{
+			Namespace: namespace,
+			ID:        grant.Owner(ent.ID),
+		}
+
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+			From: now,
+			To:   now.AddDate(0, 1, 1),
+		})
+		require.NoError(t, err)
+
+		times := timeline.GetTimes()
+
+		require.Len(t, times, 2)
+
+		assert.Equal(t, now, times[0])
+		assert.Equal(t, resetTime, times[1])
+	})
+}

--- a/openmeter/entitlement/metered/repository.go
+++ b/openmeter/entitlement/metered/repository.go
@@ -6,12 +6,13 @@ import (
 	"time"
 
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type UsageResetRepo interface {
 	Save(ctx context.Context, usageResetTime UsageResetTime) error
-	GetLastAt(ctx context.Context, entitlementID models.NamespacedID, at time.Time) (*UsageResetTime, error)
-	GetBetween(ctx context.Context, entitlementID models.NamespacedID, from time.Time, to time.Time) ([]UsageResetTime, error)
+	GetLastAt(ctx context.Context, entitlementID models.NamespacedID, at time.Time) (UsageResetTime, error)
+	GetBetween(ctx context.Context, entitlementID models.NamespacedID, period timeutil.Period) ([]UsageResetTime, error)
 }
 
 type UsageResetNotFoundError struct {

--- a/openmeter/entitlement/metered/repository.go
+++ b/openmeter/entitlement/metered/repository.go
@@ -25,5 +25,6 @@ func (e UsageResetNotFoundError) Error() string {
 type UsageResetTime struct {
 	models.NamespacedModel
 	ResetTime     time.Time
+	Anchor        time.Time
 	EntitlementID string
 }

--- a/openmeter/entitlement/metered/utils_test.go
+++ b/openmeter/entitlement/metered/utils_test.go
@@ -67,6 +67,9 @@ func setupConnector(t *testing.T) (meteredentitlement.Connector, *dependencies) 
 		Namespace:   namespace,
 		Aggregation: meter.MeterAggregationSum,
 		WindowSize:  meter.WindowSizeMinute,
+		// These will be ignored in tests
+		EventType:     "test",
+		ValueProperty: "$.value",
 	}})
 	if err != nil {
 		t.Fatalf("failed to create meter adapter: %v", err)

--- a/openmeter/entitlement/repository.go
+++ b/openmeter/entitlement/repository.go
@@ -11,7 +11,6 @@ import (
 )
 
 type UpdateEntitlementUsagePeriodParams struct {
-	NewAnchor          *time.Time
 	CurrentUsagePeriod timeutil.Period
 }
 

--- a/openmeter/registry/builder/entitlement.go
+++ b/openmeter/registry/builder/entitlement.go
@@ -68,6 +68,7 @@ func GetEntitlementRegistry(opts EntitlementOptions) *registry.Entitlement {
 		grantDBAdapter,
 		entitlementDBAdapter,
 		opts.Publisher,
+		opts.Logger,
 	)
 	entitlementConnector := entitlement.NewEntitlementConnector(
 		entitlementDBAdapter,

--- a/pkg/timeutil/period.go
+++ b/pkg/timeutil/period.go
@@ -22,6 +22,11 @@ func (p Period) ContainsInclusive(t time.Time) bool {
 	return t.After(p.From) && t.Before(p.To)
 }
 
+// Exclusive at both start and end
+func (p Period) ContainsExclusive(t time.Time) bool {
+	return p.Contains(t) && !t.Equal(p.From)
+}
+
 // Inclusive at start, exclusive at end
 func (p Period) Contains(t time.Time) bool {
 	return (t.After(p.From) || t.Equal(p.From)) && t.Before(p.To)

--- a/pkg/timeutil/period.go
+++ b/pkg/timeutil/period.go
@@ -26,3 +26,16 @@ func (p Period) ContainsInclusive(t time.Time) bool {
 func (p Period) Contains(t time.Time) bool {
 	return (t.After(p.From) || t.Equal(p.From)) && t.Before(p.To)
 }
+
+// Returns true if the two periods overlap at any point
+// Returns false if the periods are exactly sequential, e.g.: [1, 2] and [2, 3]
+func (p Period) Overlaps(other Period) bool {
+	// If one period ends before or exactly when the other starts, they don't overlap
+	return !(p.To.Before(other.From) || p.To.Equal(other.From) || other.To.Before(p.From) || other.To.Equal(p.From))
+}
+
+// Returns true if the two periods overlap at any point
+// Returns true if the periods are exactly sequential, e.g.: [1, 2] and [2, 3]
+func (p Period) OverlapsInclusive(other Period) bool {
+	return p.ContainsInclusive(other.From) || p.ContainsInclusive(other.To) || other.ContainsInclusive(p.From) || other.ContainsInclusive(p.To)
+}

--- a/pkg/timeutil/period_test.go
+++ b/pkg/timeutil/period_test.go
@@ -39,6 +39,15 @@ func TestPeriod(t *testing.T) {
 		t.Run("Should be false for later time", func(t *testing.T) {
 			assert.False(t, period.ContainsInclusive(endTime.Add(time.Second)))
 		})
+
+		t.Run("Should be true for 0 length period", func(t *testing.T) {
+			period := timeutil.Period{
+				From: startTime,
+				To:   startTime,
+			}
+
+			assert.True(t, period.ContainsInclusive(startTime))
+		})
 	})
 
 	t.Run("Contains", func(t *testing.T) {
@@ -60,6 +69,56 @@ func TestPeriod(t *testing.T) {
 
 		t.Run("Should be false for later time", func(t *testing.T) {
 			assert.False(t, period.Contains(endTime.Add(time.Second)))
+		})
+
+		t.Run("Should be false for 0 length period", func(t *testing.T) {
+			period := timeutil.Period{
+				From: startTime,
+				To:   startTime,
+			}
+
+			assert.False(t, period.Contains(startTime))
+		})
+	})
+
+	t.Run("Overlaps", func(t *testing.T) {
+		t.Run("Should be false for exactly sequential periods", func(t *testing.T) {
+			assert.False(t, period.Overlaps(timeutil.Period{From: endTime, To: endTime.Add(time.Second)}))
+		})
+
+		t.Run("Should be false for distant periods", func(t *testing.T) {
+			assert.False(t, period.Overlaps(timeutil.Period{From: endTime.Add(time.Second), To: endTime.Add(time.Second * 2)}))
+			assert.False(t, period.Overlaps(timeutil.Period{From: startTime.Add(-2 * time.Second), To: startTime.Add(-time.Second)}))
+		})
+
+		t.Run("Should be true for overlapping periods", func(t *testing.T) {
+			assert.True(t, period.Overlaps(timeutil.Period{From: startTime.Add(-time.Second), To: endTime.Add(-time.Second)}))
+			assert.True(t, period.Overlaps(timeutil.Period{From: startTime.Add(time.Second), To: endTime.Add(time.Second)}))
+		})
+
+		t.Run("Should be true for containing periods", func(t *testing.T) {
+			assert.True(t, period.Overlaps(timeutil.Period{From: startTime.Add(-time.Second), To: endTime.Add(time.Second)}))
+			assert.True(t, period.Overlaps(timeutil.Period{From: startTime.Add(time.Second), To: endTime.Add(-time.Second)}))
+		})
+	})
+	t.Run("OverlapsInclusive", func(t *testing.T) {
+		t.Run("Should be true for exactly sequential periods", func(t *testing.T) {
+			assert.True(t, period.OverlapsInclusive(timeutil.Period{From: endTime, To: endTime.Add(time.Second)}))
+		})
+
+		t.Run("Should be false for distant periods", func(t *testing.T) {
+			assert.False(t, period.OverlapsInclusive(timeutil.Period{From: endTime.Add(time.Second), To: endTime.Add(time.Second * 2)}))
+			assert.False(t, period.OverlapsInclusive(timeutil.Period{From: startTime.Add(-2 * time.Second), To: startTime.Add(-time.Second)}))
+		})
+
+		t.Run("Should be true for overlapping periods", func(t *testing.T) {
+			assert.True(t, period.OverlapsInclusive(timeutil.Period{From: startTime.Add(-time.Second), To: endTime.Add(-time.Second)}))
+			assert.True(t, period.OverlapsInclusive(timeutil.Period{From: startTime.Add(time.Second), To: endTime.Add(time.Second)}))
+		})
+
+		t.Run("Should be true for containing periods", func(t *testing.T) {
+			assert.True(t, period.OverlapsInclusive(timeutil.Period{From: startTime.Add(-time.Second), To: endTime.Add(time.Second)}))
+			assert.True(t, period.OverlapsInclusive(timeutil.Period{From: startTime.Add(time.Second), To: endTime.Add(-time.Second)}))
 		})
 	})
 }

--- a/pkg/timeutil/recurrence.go
+++ b/pkg/timeutil/recurrence.go
@@ -16,7 +16,7 @@ type Recurrence struct {
 	Anchor time.Time `json:"anchor"`
 }
 
-// Returns a period where p.Contains(t) is true
+// Returns a period where p.ContainsInclusive(t) is true
 func (r Recurrence) GetPeriodAt(t time.Time) (Period, error) {
 	var def Period
 
@@ -25,7 +25,7 @@ func (r Recurrence) GetPeriodAt(t time.Time) (Period, error) {
 		return def, err
 	}
 
-	// As Period.Contains() is inclusive at the start and exclusive at the end, we need to get the next time
+	// As Period.ContainsInclusive() is inclusive at the start and exclusive at the end, we need to get the next time
 	if next.Equal(t) {
 		start := next
 		end, err := r.Next(start)

--- a/pkg/timeutil/timeline.go
+++ b/pkg/timeutil/timeline.go
@@ -1,0 +1,52 @@
+package timeutil
+
+import (
+	"slices"
+	"time"
+)
+
+func NewTimeline(times []time.Time) Timeline {
+	// sort copy of times ASC
+	times = slices.Clone(times)
+
+	slices.SortStableFunc(times, func(a, b time.Time) int {
+		return int(a.Sub(b).Milliseconds())
+	})
+
+	return Timeline{
+		times: times,
+	}
+}
+
+type Timeline struct {
+	times []time.Time
+}
+
+func (t Timeline) GetTimes() []time.Time {
+	// Let's always return a non-nil array
+	return t.times
+}
+
+func (t Timeline) GetBoundingPeriod() Period {
+	return Period{
+		From: t.times[0],
+		To:   t.times[len(t.times)-1],
+	}
+}
+
+func (t Timeline) GetPeriods() []Period {
+	if len(t.times) < 2 {
+		return []Period{
+			{
+				From: t.times[0],
+				To:   t.times[0],
+			},
+		}
+	}
+
+	periods := make([]Period, 0, len(t.times)-1)
+	for i := 0; i < len(t.times)-1; i++ {
+		periods = append(periods, Period{From: t.times[i], To: t.times[i+1]})
+	}
+	return periods
+}

--- a/pkg/timeutil/timeline.go
+++ b/pkg/timeutil/timeline.go
@@ -28,6 +28,13 @@ func (t Timeline) GetTimes() []time.Time {
 }
 
 func (t Timeline) GetBoundingPeriod() Period {
+	if len(t.times) == 0 {
+		return Period{
+			From: time.Time{},
+			To:   time.Time{},
+		}
+	}
+
 	return Period{
 		From: t.times[0],
 		To:   t.times[len(t.times)-1],

--- a/test/entitlement/regression/framework_test.go
+++ b/test/entitlement/regression/framework_test.go
@@ -128,6 +128,7 @@ func setupDependencies(t *testing.T) Dependencies {
 		grantRepo,
 		entitlementRepo,
 		mockPublisher,
+		log,
 	)
 
 	staticEntitlementConnector := staticentitlement.NewStaticEntitlementConnector()

--- a/test/entitlement/regression/scenario_test.go
+++ b/test/entitlement/regression/scenario_test.go
@@ -124,7 +124,7 @@ func TestGrantExpiringAtReset(t *testing.T) {
 	assert.NotNil(currentBalance)
 	assert.Equal(0.0, currentBalance.Balance) // This test was previously faulty, grant2 has expired by this point while grant1 loses its balance on resets, two of which has already happened by this point
 
-	clock.SetTime(testutils.GetRFC3339Time(t, "2024-06-30T15:35:54Z"))
+	clock.SetTime(testutils.GetRFC3339Time(t, "2024-06-28T15:39:00Z"))
 	grant3, err := deps.GrantConnector.CreateGrant(ctx,
 		grant.NamespacedOwner{
 			Namespace: "namespace-1",
@@ -143,14 +143,14 @@ func TestGrantExpiringAtReset(t *testing.T) {
 	assert.NotNil(grant3)
 
 	// There should be a snapshot created
-	clock.SetTime(testutils.GetRFC3339Time(t, "2024-06-30T15:37:18Z"))
+	clock.SetTime(testutils.GetRFC3339Time(t, "2024-06-29T15:37:18Z"))
 	reset, err := deps.MeteredEntitlementConnector.ResetEntitlementUsage(ctx,
 		models.NamespacedID{
 			Namespace: "namespace-1",
 			ID:        entitlement.ID,
 		},
 		meteredentitlement.ResetEntitlementUsageParams{
-			At:           testutils.GetRFC3339Time(t, "2024-06-29T14:36:00Z"),
+			At:           testutils.GetRFC3339Time(t, "2024-06-29T14:48:00Z"),
 			RetainAnchor: false,
 		},
 	)

--- a/test/entitlement/regression/scenario_test.go
+++ b/test/entitlement/regression/scenario_test.go
@@ -261,17 +261,6 @@ func TestGrantExpiringAndRecurringAtReset(t *testing.T) {
 	assert.NotNil(currentBalance)
 	assert.Equal(0.0, currentBalance.Balance)
 
-	// Validate snapshot exists
-	snapshot, err := deps.BalanceSnapshotRepo.GetLatestValidAt(ctx, grant.NamespacedOwner{
-		Namespace: "namespace-1",
-		ID:        grant.Owner(entitlement.ID),
-	}, testutils.GetRFC3339Time(t, "2024-07-10T07:33:06Z"))
-	assert.NoError(err)
-	assert.NotNil(snapshot)
-	assert.NotEqual(resetCommand.At, snapshot.At)
-	assert.Greater(snapshot.At.Unix(), resetCommand.At.Unix())
-	assert.Equal(currentBalance.Balance, snapshot.Balances.Balance()) // because there's nothing it's just 0
-
 	// Let's query the usage again after snapshot exists
 	clock.SetTime(testutils.GetRFC3339Time(t, "2024-07-10T07:33:06Z"))
 	// clock.SetTime(testutils.GetRFC3339Time(t, "2024-07-10T09:41:00Z"))

--- a/test/entitlement/regression/scenario_test.go
+++ b/test/entitlement/regression/scenario_test.go
@@ -119,10 +119,10 @@ func TestGrantExpiringAtReset(t *testing.T) {
 			Namespace: "namespace-1",
 			ID:        entitlement.ID,
 		},
-		testutils.GetRFC3339Time(t, "2024-06-30T14:30:41Z"))
+		testutils.GetRFC3339Time(t, "2024-06-30T15:30:41Z"))
 	assert.NoError(err)
 	assert.NotNil(currentBalance)
-	assert.Equal(10.0, currentBalance.Balance)
+	assert.Equal(0.0, currentBalance.Balance) // This test was previously faulty, grant2 has expired by this point while grant1 loses its balance on resets, two of which has already happened by this point
 
 	clock.SetTime(testutils.GetRFC3339Time(t, "2024-06-30T15:35:54Z"))
 	grant3, err := deps.GrantConnector.CreateGrant(ctx,

--- a/test/entitlement/regression/scenario_test.go
+++ b/test/entitlement/regression/scenario_test.go
@@ -119,7 +119,7 @@ func TestGrantExpiringAtReset(t *testing.T) {
 			Namespace: "namespace-1",
 			ID:        entitlement.ID,
 		},
-		testutils.GetRFC3339Time(t, "2024-06-28T14:30:41Z"))
+		testutils.GetRFC3339Time(t, "2024-06-30T14:30:41Z"))
 	assert.NoError(err)
 	assert.NotNil(currentBalance)
 	assert.Equal(10.0, currentBalance.Balance)

--- a/test/notification/consumer_balance.go
+++ b/test/notification/consumer_balance.go
@@ -65,8 +65,9 @@ func NewBalanceSnapshotEvent(in BalanceSnapshotEventInput) snapshot.SnapshotEven
 				SubjectKey:      TestSubjectKey,
 				EntitlementType: entitlement.EntitlementTypeMetered,
 
-				UsagePeriod:        &TestEntitlementUsagePeriod,
-				CurrentUsagePeriod: &TestEntitlementCurrentUsagePeriod,
+				UsagePeriod:               &TestEntitlementUsagePeriod,
+				OriginalUsagePeriodAnchor: &TestEntitlementUsagePeriod.Anchor,
+				CurrentUsagePeriod:        &TestEntitlementCurrentUsagePeriod,
 			},
 			MeasureUsageFrom: &TestEntitlementCurrentUsagePeriod.From,
 			IsSoftLimit:      convert.ToPointer(true),

--- a/tools/migrate/entitlement_test.go
+++ b/tools/migrate/entitlement_test.go
@@ -1,0 +1,120 @@
+package migrate_test
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+)
+
+func TestUsageResetAnchorTimesMigration(t *testing.T) {
+	entId1 := ulid.Make()
+	ent1UPAnchor := testutils.GetRFC3339Time(t, "2025-02-01T00:00:00Z")
+	ent1ur1Id := ulid.Make()
+	ent1ur2Id := ulid.Make()
+
+	runner{stops{
+		{
+			// before: 20250218161614_billing-profile-fix-constraint.up.sql
+			// after: 20250220150245_usage-reset-anchor-times.up.sql
+			version:   20250218161614,
+			direction: directionUp,
+			action: func(t *testing.T, db *sql.DB) {
+				// 1. We need to set up a feature
+				featId := ulid.Make()
+				_, err := db.Exec(`
+					INSERT INTO features (
+						namespace,
+						id,
+						key,
+						name,
+						created_at,
+						updated_at
+					)
+					VALUES (
+						'default',
+						$1,
+						'feat_1',
+						'feat 1',
+						NOW(), -- don't mind that this is later than entitlement creation time, the DB doesn't care about it
+						NOW()  -- don't mind that this is later than entitlement creation time, the DB doesn't care about it
+					)`,
+					featId.String(),
+				)
+				require.NoError(t, err)
+
+				// 2. We need to set up an entitlement
+				_, err = db.Exec(`
+					INSERT INTO entitlements (
+						namespace,
+						id,
+						created_at,
+						updated_at,
+						entitlement_type,
+						feature_key,
+						feature_id,
+						subject_key,
+						usage_period_interval,
+						usage_period_anchor
+					)
+					VALUES (
+						'default',
+						$1,
+						'2025-02-01 23:18:35',
+						NOW(),
+						'METERED',
+						'feature_1',
+						$2,
+						'subject_1',
+						'MONTH',
+						$3
+					)`,
+					entId1.String(),
+					featId.String(),
+					ent1UPAnchor,
+				)
+				require.NoError(t, err)
+
+				// 3. We need to set up 2 (so it can correctly choose the last one) past usage resets that show some usage
+				_, err = db.Exec(`
+					INSERT INTO usage_resets (namespace, id, created_at, updated_at, entitlement_id, reset_time)
+					VALUES ('default', $1, NOW(), NOW(), $2, '2025-02-05T12:00:00Z')`,
+					ent1ur1Id.String(),
+					entId1.String(),
+				)
+				require.NoError(t, err)
+
+				_, err = db.Exec(`
+					INSERT INTO usage_resets (namespace, id, created_at, updated_at, entitlement_id, reset_time)
+					VALUES ('default', $1, NOW(), NOW(), $2, '2025-02-011T12:00:00Z')`,
+					ent1ur2Id.String(),
+					entId1.String(),
+				)
+				require.NoError(t, err)
+			},
+		},
+		{
+			// Now we assert that the migration was successful
+			version:   20250220150245,
+			direction: directionUp,
+			action: func(t *testing.T, db *sql.DB) {
+				// Let's assert that for for the first usage-reset (as its not the latest) the anchor is set to the reset time of the usage_reset
+				var anchor time.Time
+				var resetTime time.Time
+				err := db.QueryRow(`SELECT anchor, reset_time FROM usage_resets WHERE id = $1`, ent1ur1Id.String()).Scan(&anchor, &resetTime)
+				require.NoError(t, err)
+				require.Equal(t, resetTime, anchor)
+
+				// Let's assert that the second usage-reset was updated with the entitlement's usage_period_anchor
+				var anchor2 time.Time
+				err = db.QueryRow(`SELECT anchor FROM usage_resets WHERE id = $1`, ent1ur2Id.String()).Scan(&anchor2)
+				require.NoError(t, err)
+				require.Equal(t, ent1UPAnchor, anchor2.UTC())
+			},
+		},
+	}}.Test(t)
+}

--- a/tools/migrate/migrations/20250220150245_usage-reset-anchor-times.down.sql
+++ b/tools/migrate/migrations/20250220150245_usage-reset-anchor-times.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "usage_resets" table
+ALTER TABLE "usage_resets" DROP COLUMN "anchor";

--- a/tools/migrate/migrations/20250220150245_usage-reset-anchor-times.up.sql
+++ b/tools/migrate/migrations/20250220150245_usage-reset-anchor-times.up.sql
@@ -1,0 +1,43 @@
+-- modify "usage_resets" table
+ALTER TABLE
+    "usage_resets"
+ADD
+    COLUMN "anchor" timestamptz NOT NULL DEFAULT '2025-02-01 23:18:35';
+
+-- Let's drop the default used for creation
+ALTER TABLE
+    "usage_resets"
+ALTER COLUMN
+    "anchor" DROP DEFAULT;
+
+-- we need to update all existing the LAST reset for each entitlement so anchor has the same value as entitlement.usage_period_anchor
+-- As the anchor field is not nullable, we default it to the reset time.
+-- This WORKS because entitlements could only be reset manually before this:
+-- 1. between each two subsequent reset it is impossible to have a full usage period
+-- 2. setting the anchor time to the reset time guarantees that said period starts with the reset time
+-- therefore the automatic reset calculation wont find any "ghost" periods inbetween the historical resets
+WITH latest_resets AS (
+    SELECT
+        id,
+        entitlement_id,
+        reset_time,
+        ROW_NUMBER() OVER (
+            PARTITION BY entitlement_id
+            ORDER BY
+                reset_time DESC
+        ) as rn
+    FROM
+        usage_resets
+)
+UPDATE
+    usage_resets
+SET
+    anchor = CASE
+        WHEN lr.rn = 1 THEN e.usage_period_anchor
+        ELSE lr.reset_time
+    END
+FROM
+    entitlements e
+    JOIN latest_resets lr ON lr.entitlement_id = e.id
+WHERE
+    usage_resets.id = lr.id;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:u/1NBCXrF61sec0COUEJYqeOw9/dG2o+zHCqe2csLA8=
+h1:3lEDh2lWIghnJmJ6cYaoUHXyPDljjpi3EidzWfB4T2I=
 20240826120919_init.down.sql h1:AIbgwwngjkJEYa3yRZsIXQyBa2+qoZttwMXHxXEbHLI=
 20240826120919_init.up.sql h1:/hYHWF3Z3dab8SMKnw99ixVktCuJe2bAw5wstCZIEN8=
 20240903155435_entitlement-expired-index.down.sql h1:np2xgYs3KQ2z7qPBcobtGNhqWQ3V8NwEP9E5U3TmpSA=
@@ -117,3 +117,5 @@ h1:u/1NBCXrF61sec0COUEJYqeOw9/dG2o+zHCqe2csLA8=
 20250218103055_fix-unique-indexes.up.sql h1:I5q4iaRrJTrkEWLrUAL08M8FYIZPAAvbqqrD2xVkuFc=
 20250218161614_billing-profile-fix-constraint.down.sql h1:RqlXD3OCuiJsDoCE+QjcfxN/L3crjig82Y7tKQy4dY4=
 20250218161614_billing-profile-fix-constraint.up.sql h1:l0oYTNnGPCfjBMKrHYPjQd4S/D/86QX2yTs2OdU+r68=
+20250220150245_usage-reset-anchor-times.down.sql h1:3o9XEEe1iL2Fj4d5WLidvQBqGz3s/fJGNykyTgMkTKw=
+20250220150245_usage-reset-anchor-times.up.sql h1:rUTLhEYpN7YUfqyUS+PhPnioFk3Uj7vMNLoe0r0voDM=


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Part II of the Entitlement Reset
Part I: #2339

Rewrite engine calculations so they don't rely on  triggered reset actions. We build a timeline from all the manual reset times and the programmatic ones (based on entitlement's `UsagePeriod`, these were previously done via the auto reset job) and calculate grant balances seamlessly.

## Changes

- Enable engine to run across resets (localize reset calculation logic to engine)
- Introduce time abstractions to help with period and timeline calculations
- Rewrite UsageReset objects to store current anchors at time of reset (historically we overwrote this field on the entitlement)
- Snapshotting behavior is free from engine logic. We can snapshot whenever we want.
- Some of our tests were testing impossible scenarios that should not have been possible but were due to bugs. Those have been changed.

## NOTES
- balance and entitlement events published but not yet processed will fail due to entitlement schema changing

## Follow Ups
1. Disable calling `ResetEntitlementsWithExpiredUsagePeriod` in cloud (i.e. auto-reset job)
2. We could get rid of the concept of `CurrentUsagePeriod` in the DB after the job is disabled. CurrentUsagePeriod, OriginalPeriodAnchor, etc... are error prone to work with and as soon as auto reset is gone we can get rid of them.
3. Currently there's no programmatic way of creating Snapshots. This could have a performance impact as time passes.
4. Handling Snapshots could be simplified. Currently, reset always creates a snapshot. Apart from that, GetBalance will create snapshots from history no later than the current UsagePeriod start & 7 days ago (this somewhat mimics current behavior, as eventually it will result in a snapshot at every programmatic reset time). It's not clear what the snapshotting behavior should be: as long as we _eventually_ create snapshots, the system should be fine (unless we see a need for optimization). 

## TODO

- [x] test manual resets conflicting with programmatic resets (when resetting to past at time of programmatic reset)

<!-- Anything the reviewer should know? -->
