### PR TITLE
feat: add entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ ARG VERSION
 
 COPY --link . .
 
+RUN chmod +x entrypoint.sh
+
 # See https://github.com/confluentinc/confluent-kafka-go#librdkafka
 # See https://github.com/confluentinc/confluent-kafka-go#static-builds-on-linux
 # Build server binary (default)
@@ -71,5 +73,8 @@ COPY --link --from=builder /usr/local/bin/openmeter-sink-worker /usr/local/bin/
 COPY --link --from=builder /usr/local/bin/openmeter-balance-worker /usr/local/bin/
 COPY --link --from=builder /usr/local/bin/openmeter-notification-service /usr/local/bin/
 COPY --link --from=builder /src/go.* /usr/local/src/openmeter/
+COPY --link --from=builder /src/entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
 
 CMD openmeter

--- a/benthos-collector.Dockerfile
+++ b/benthos-collector.Dockerfile
@@ -23,9 +23,10 @@ ARG VERSION
 
 COPY --link . .
 
+RUN chmod +x entrypoint.sh
+
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/go/cache \
-    --mount=type=bind,source=.,target=/src,ro \
     go build -ldflags "-X main.version=${VERSION}" -o /usr/local/bin/benthos ./cmd/benthos-collector
 
 FROM alpine:3.21.3@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c
@@ -42,5 +43,6 @@ COPY cloudevents.spec.json /etc/benthos/
 COPY collector/benthos/presets /etc/benthos/presets
 
 COPY --link --from=builder /usr/local/bin/benthos /usr/local/bin/
+COPY --link --from=builder /src/entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/usr/local/bin/benthos"]
+ENTRYPOINT ["/entrypoint.sh", "/usr/local/bin/benthos"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -euo pipefail
+
+main() {
+    # Update CA certificates if needed
+    find /usr/local/share/ca-certificates -maxdepth 0 ! -empty -exec update-ca-certificates \;
+
+    # Start CMD
+    exec "$@"
+}
+
+main "$@"


### PR DESCRIPTION
## Overview

Add `entrypoint.sh` script to Docker images in order to allow injecting CA Root certificates at runtime by mounting the certificates to `/usr/local/share/ca-certificates` directory in the container.

The `entrypoint.sh` script checks if `/usr/local/share/ca-certificates` has files in it and runs the `update-ca-certificates` script at contianer start up.

