### PR TITLE
fix: disable stats for Kafka admin client

### DIFF
--- a/app/common/kafka.go
+++ b/app/common/kafka.go
@@ -75,6 +75,10 @@ func NewKafkaAdminClient(conf config.KafkaConfiguration) (*kafka.AdminClient, er
 	// and initializing the client fails if this parameter is set.
 	delete(kafkaConfigMap, "go.logs.channel.enable")
 
+	// NOTE(chrisgacsal): disable collecting statistics as data is collected in an internal queue which needs to be polled,
+	// but the AdminClient does not expose interface for that.
+	delete(kafkaConfigMap, "statistics.interval.ms")
+
 	adminClient, err := kafka.NewAdminClient(&kafkaConfigMap)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Kafka admin client: %w", err)


### PR DESCRIPTION
## Overview

Disable collecting statistics in Kafka admin client as the data is colelcted in an internal queue which needs to be consumed but the AdminClient does not provide interface for that (one possible solution would be to derive AdminClient from Producer and run poll() in background, but we do not really need stas for admin clietns) in order to avoid growing memory.
