### PR TITLE
Expose logs of E2E tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ go.work
 go.work.sum
 
 __debug_bin*
+
+openmeter.log

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,6 +3,12 @@ address: 127.0.0.1:8888
 telemetry:
   log:
     level: debug
+    # For writing to a file
+    exporters:
+      # file:
+      #   enabled: true
+      #   filepath: "./openmeter.log"
+      #   prettyprint: true  # optional
 
 termination:
   # checkInterval defines the time period used for updating the readiness check based on the termination status.

--- a/e2e/config.yaml
+++ b/e2e/config.yaml
@@ -2,8 +2,13 @@ address: 0.0.0.0:8080
 
 telemetry:
   address: 0.0.0.0:10000
-  # log:
-  #   level: debug
+  log:
+    level: debug
+    exporters:
+      file:
+        enabled: true
+        filepath: "/var/log/openmeter/openmeter.log"
+        prettyprint: true
 
 ingest:
   kafka:


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

The E2E tests difficult to debug as the service logs are surpassed by dagger. This PR adds simple file-logging to openmeter and enables it for the E2E tests. **If the E2E tests all logs are printed at the end.**

- It would be better if the logs could be saved to a file that can be parsed separately, we should eventually add that as an incremental upgrade, but I couldn't make that work in reasonable time.
- Sharing the log volume between dagger containers & services uses cache mounts. There's no concept of a shared mounted directory otherwise. This pollutes the number of caches we use, but in theory that shouldn't be a problem.
- Both sink and the api logs to the same file

## Example output:

```
Error logs:

✘ .withExec(args: ["sh", "-c", ETOOBIG:sha256:f7b927067baf994023e36cec34ac0b8fce2e6e61c73dfee1706dde8ac808f85b]): Container! 17.2s
=== RUN   TestPlan                                                                                               
=== RUN   TestPlan/Should_create_a_plan_on_happy_path                                                            
=== RUN   TestPlan/Should_publish_the_plan                                                                       
=== RUN   TestPlan/Should_not_allow_publishing_a_misaligned_plan                                                 
=== RUN   TestPlan/Should_create_a_custom_subscription                                                           
=== RUN   TestPlan/Should_create_a_subscription_based_on_the_plan                                                
=== RUN   TestPlan/Should_retrieve_the_subscription                                                              
=== RUN   TestPlan/Should_edit_the_subscription                                                                  
=== RUN   TestPlan/Should_schedule_a_cancellation_for_the_subscription                                           
=== RUN   TestPlan/Should_unschedule_cancellation                                                                
=== RUN   TestPlan/Should_create_and_publish_a_new_version_of_the_plan                                           
=== RUN   TestPlan/Should_migrate_the_subscription_to_a_newer_version                                            
=== RUN   TestPlan/Should_change_the_subscription's_plan                                                         
=== RUN   TestPlan/Should_list_customers_of_a_given_plan                                                         
=== RUN   TestPlan/Should_check_entitlement_of_customer                                                          
=== NAME  TestPlan                                                                                               
    productcatalog_test.go:687: FAIL                                                                             
--- FAIL: TestPlan (0.35s)                                                                                       
    --- PASS: TestPlan/Should_create_a_plan_on_happy_path (0.01s)                                                
    --- PASS: TestPlan/Should_publish_the_plan (0.01s)                                                           
    --- PASS: TestPlan/Should_not_allow_publishing_a_misaligned_plan (0.02s)                                     
    --- PASS: TestPlan/Should_create_a_custom_subscription (0.04s)                                               
    --- PASS: TestPlan/Should_create_a_subscription_based_on_the_plan (0.02s)                                    
    --- PASS: TestPlan/Should_retrieve_the_subscription (0.00s)                                                  
    --- PASS: TestPlan/Should_edit_the_subscription (0.03s)                                                      
    --- PASS: TestPlan/Should_schedule_a_cancellation_for_the_subscription (0.03s)                               
    --- PASS: TestPlan/Should_unschedule_cancellation (0.02s)                                                    
    --- PASS: TestPlan/Should_create_and_publish_a_new_version_of_the_plan (0.03s)                               
    --- PASS: TestPlan/Should_migrate_the_subscription_to_a_newer_version (0.06s)                                
    --- PASS: TestPlan/Should_change_the_subscription's_plan (0.04s)                                             
    --- PASS: TestPlan/Should_list_customers_of_a_given_plan (0.01s)                                             
    --- PASS: TestPlan/Should_check_entitlement_of_customer (0.00s)                                              
FAIL                                                                                                             
FAIL    github.com/openmeterio/openmeter/e2e    15.403s                                                          
FAIL                                                                                                             
Tests failed. Printing openmeter.log:                                                                            
time=2025-02-24T12:47:35.912Z level=DEBUG msg="mark topic to be provisioned" topic=om_sys.api_events             
time=2025-02-24T12:47:35.982Z level=DEBUG msg="provisioned topic is added to cache" topic=om_sys.api_events      
time=2025-02-24T12:47:35.982Z level=DEBUG msg="Initializing new client" otel.scope.name=sarama                   
time=2025-02-24T12:47:35.982Z level=DEBUG msg="client/metadata fetching metadata for all topics from broker k    
afka:9092\n" otel.scope.name=sarama                                                                              
time=2025-02-24T12:47:35.983Z level=DEBUG msg="Connected to broker at kafka:9092 (unregistered)\n" otel.scope    
.name=sarama                                                                                                     
time=2025-02-24T12:47:35.989Z level=DEBUG msg="client/brokers registered new broker #0 at kafka:9092" otel.sc    
ope.name=sarama                                                                                                  
time=2025-02-24T12:47:35.989Z level=DEBUG msg="Successfully initialized new client" otel.scope.name=sarama       
time=2025-02-24T12:47:35.994Z level=DEBUG msg="connected to Kafka"                                               
time=2025-02-24T12:47:35.994Z level=INFO msg="svix is disabled: using noop webhook handler"                      
time=2025-02-24T12:47:35.994Z level=INFO msg="registering event types" noophandler=""                            
time=2025-02-24T12:47:35.994Z level=DEBUG msg="Started collecting runtime metrics"                               
time=2025-02-24T12:47:35.994Z level=WARN msg="initial health check failed" component=healthcheck check=termin    
ation.check error="didn't run yet"                                                                               
time=2025-02-24T12:47:35.994Z level=INFO msg="starting OpenMeter server" config=""                               
time=2025-02-24T12:47:35.994Z level=DEBUG msg="create default namespace"                                         
time=2025-02-24T12:47:35.994Z level=DEBUG msg="mark topic to be provisioned" topic=om_default_events             
time=2025-02-24T12:47:35.994Z level=DEBUG msg="starting health check" component=healthcheck check=termination    
.check                                                                                                           
time=2025-02-24T12:47:35.994Z level=DEBUG msg="health check completed" component=healthcheck check=terminatio    
n.check                                                                                                          
time=2025-02-24T12:47:36.023Z level=DEBUG msg="provisioned topic is added to cache" topic=om_default_events      
time=2025-02-24T12:47:36.023Z level=INFO msg="default namespace created"                                         
time=2025-02-24T12:47:36.023Z level=DEBUG msg="running migrations" strategy=ent                                  
time=2025-02-24T12:47:36.278Z level=INFO msg="database initialized"                                              
time=2025-02-24T12:47:36.281Z level=INFO msg="sandbox app auto-provisioned" app_id=01JMVZZ9TRF2E0WHJ57VREZ6QJ    
                                                                                                                 
time=2025-02-24T12:47:36.422Z level=INFO msg="meters successfully created" count=""                              
time=2025-02-24T12:47:36.422Z level=INFO msg="starting telemetry server" address=0.0.0.0:10000                   
time=2025-02-24T12:47:36.422Z level=INFO msg="starting API server" address=0.0.0.0:8080                          
time=2025-02-24T12:47:36.990Z level=DEBUG msg="mark topic to be provisioned" topic=om_sys.ingest_events          
time=2025-02-24T12:47:36.995Z level=DEBUG msg="starting health check" component=healthcheck check=termination    
.check                                                                                                           
time=2025-02-24T12:47:36.996Z level=DEBUG msg="health check completed" component=healthcheck check=terminatio    
n.check                                                                                                          
time=2025-02-24T12:47:37.029Z level=DEBUG msg="provisioned topic is added to cache" topic=om_sys.ingest_event    
s                                                                                                                
time=2025-02-24T12:47:37.029Z level=DEBUG msg="Initializing new client" otel.scope.name=sarama                   
time=2025-02-24T12:47:37.029Z level=DEBUG msg="client/metadata fetching metadata for all topics from broker k    
afka:9092\n" otel.scope.name=sarama                                                                              
time=2025-02-24T12:47:37.030Z level=DEBUG msg="Connected to broker at kafka:9092 (unregistered)\n" otel.scope    
.name=sarama                                                                                                     
time=2025-02-24T12:47:37.034Z level=DEBUG msg="client/brokers registered new broker #0 at kafka:9092" otel.sc    
ope.name=sarama                                                                                                  
time=2025-02-24T12:47:37.034Z level=DEBUG msg="Successfully initialized new client" otel.scope.name=sarama       
time=2025-02-24T12:47:37.037Z level=DEBUG msg="Started collecting runtime metrics"                               
time=2025-02-24T12:47:37.037Z level=INFO msg="starting OpenMeter sink worker" config=""                          
time=2025-02-24T12:47:37.037Z level=DEBUG msg="initializing Kafka consumer with group configuration" kafka=""    
                                                                                                                 
time=2025-02-24T12:47:37.038Z level=INFO msg="starting flush event handler" operation=run                        
time=2025-02-24T12:47:37.038Z level=INFO msg="starting sink" operation=run                                       
time=2025-02-24T12:47:37.038Z level=DEBUG msg="updating topic subscription: started" operation=subscribeToNam    
espaces                                                                                                          
time=2025-02-24T12:47:37.038Z level=DEBUG msg="fetching metadata" operation=updateTopicSubscription              
time=2025-02-24T12:47:37.038Z level=DEBUG msg="updating namespace store: started" operation=subscribeToNamesp    
aces                                                                                                             
time=2025-02-24T12:47:37.038Z level=DEBUG msg="updating namespace store: done" operation=subscribeToNamespace    
s                                                                                                                
time=2025-02-24T12:47:37.045Z level=DEBUG msg="skipping topic as does not match regexp" operation=updateTopic    
Subscription topic=om_sys.ingest_events regexp=^om_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$                      
time=2025-02-24T12:47:37.045Z level=DEBUG msg="found matching topic" operation=updateTopicSubscription topic=    
om_default_events regexp=^om_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$                                            
time=2025-02-24T12:47:37.045Z level=DEBUG msg="skipping topic as does not match regexp" operation=updateTopic    
Subscription topic=om_sys.api_events regexp=^om_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$                         
time=2025-02-24T12:47:37.046Z level=DEBUG msg="successfully subscribed to topics" operation=updateTopicSubscr    
iption topics=""                                                                                                 
time=2025-02-24T12:47:37.046Z level=DEBUG msg="updating topic subscription: done" operation=subscribeToNamesp    
aces                                                                                                             
time=2025-02-24T12:47:37.995Z level=DEBUG msg="starting health check" component=healthcheck check=termination    
.check                                                                                                           
time=2025-02-24T12:47:37.995Z level=DEBUG msg="health check completed" component=healthcheck check=terminatio    
n.check                                                                                                          
time=2025-02-24T12:47:38.047Z level=DEBUG msg="buffer is empty: nothing to flush" operation=flush                
time=2025-02-24T12:47:38.048Z level=DEBUG msg="updating namespace store: started" operation=subscribeToNamesp    
aces                                                                                                             
time=2025-02-24T12:47:38.048Z level=DEBUG msg="updating namespace store: done" operation=subscribeToNamespace    
s                                                                                                                
time=2025-02-24T12:47:38.048Z level=DEBUG msg="updating topic subscription: started" operation=subscribeToNam    
espaces                                                                                                          
time=2025-02-24T12:47:38.048Z level=DEBUG msg="fetching metadata" operation=updateTopicSubscription              
time=2025-02-24T12:47:38.050Z level=DEBUG msg="skipping topic as does not match regexp" operation=updateTopic    
Subscription topic=om_sys.ingest_events regexp=^om_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$                      
time=2025-02-24T12:47:38.050Z level=DEBUG msg="found matching topic" operation=updateTopicSubscription topic=    
om_default_events regexp=^om_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$                                            
time=2025-02-24T12:47:38.050Z level=DEBUG msg="skipping topic as does not match regexp" operation=updateTopic    
Subscription topic=om_sys.api_events regexp=^om_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$                         
time=2025-02-24T12:47:38.050Z level=DEBUG msg="skipping topic as does not match regexp" operation=updateTopic    
Subscription topic=__consumer_offsets regexp=^om_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$                        
time=2025-02-24T12:47:38.050Z level=DEBUG msg="successfully subscribed to topics" operation=updateTopicSubscr    
iption topics=""                                                                                                 
[...]                                       
```