### PR TITLE
chore: fix 500 on meter validation errors

### DIFF
--- a/openmeter/customer/httpdriver/errors.go
+++ b/openmeter/customer/httpdriver/errors.go
@@ -20,6 +20,7 @@ func errorEncoder() httptransport.ErrorEncoder {
 			commonhttp.HandleErrorIfTypeMatches[customer.SubjectKeyConflictError](ctx, http.StatusConflict, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[customer.ForbiddenError](ctx, http.StatusBadRequest, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*models.GenericUserError](ctx, http.StatusBadRequest, err, w) ||
+			commonhttp.HandleErrorIfTypeMatches[*models.GenericValidationError](ctx, http.StatusBadRequest, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*models.GenericConflictError](ctx, http.StatusConflict, err, w) ||
 			// TODO: we have to add app errors as it can happen when cutomer app data is created or updated
 			commonhttp.HandleErrorIfTypeMatches[app.AppCustomerPreConditionError](ctx, http.StatusConflict, err, w) ||

--- a/openmeter/entitlement/driver/errors.go
+++ b/openmeter/entitlement/driver/errors.go
@@ -20,6 +20,7 @@ func getErrorEncoder() httptransport.ErrorEncoder {
 			commonhttp.HandleErrorIfTypeMatches[*entitlement.NotFoundError](ctx, http.StatusNotFound, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*models.GenericUserError](ctx, http.StatusBadRequest, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*models.GenericForbiddenError](ctx, http.StatusForbidden, err, w) ||
+			commonhttp.HandleErrorIfTypeMatches[*models.GenericValidationError](ctx, http.StatusBadRequest, err, w) ||
 			commonhttp.HandleErrorIfTypeMatches[*entitlement.AlreadyExistsError](
 				ctx, http.StatusConflict, err, w,
 				func(specificErr *entitlement.AlreadyExistsError) map[string]interface{} {


### PR DESCRIPTION

## Overview

Fixes 500 errors with:
```failed to query meter: validate params: validation error: from must be rounded to MINUTE like YYYY-MM-DDTHH:mm:00```

On any entitlements querying endpoint.

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->
