### PR TITLE
Add validation for Continuing

### DIFF
--- a/openmeter/subscription/service/servicevalidator.go
+++ b/openmeter/subscription/service/servicevalidator.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func (s *service) validateCanContinue(ctx context.Context, view subscription.SubscriptionView) error {
+	// Check if there are any future subscriptions scheduled for this customer
+	// If so, we should not allow continuing this subscription
+	futureSubscriptions, err := s.SubscriptionRepo.GetAllForCustomerSince(ctx, models.NamespacedID{
+		ID:        view.Customer.ID,
+		Namespace: view.Subscription.Namespace,
+	}, view.Subscription.ActiveFrom)
+	if err != nil {
+		return fmt.Errorf("failed to get future subscriptions: %w", err)
+	}
+
+	// Filter out the current subscription from the list
+	futureSubscriptions = lo.Filter(futureSubscriptions, func(sub subscription.Subscription, _ int) bool {
+		return sub.ID != view.Subscription.ID
+	})
+
+	if len(futureSubscriptions) > 0 {
+		return models.NewGenericConflictError(
+			fmt.Errorf("cannot continue subscription as there are future subscriptions scheduled for this customer"),
+		)
+	}
+
+	return nil
+}
+
+// validateTimelineWithSpec validates that a new subscription spec fits into the existing timeline
+func (s *service) validateTimelineWithSpec(ctx context.Context, namespace string, customerId string, spec subscription.SubscriptionSpec, currentSubID *string) error {
+	// Let's build a timeline of every already scheduled subscription
+	scheduled, err := s.SubscriptionRepo.GetAllForCustomerSince(ctx, models.NamespacedID{
+		ID:        customerId,
+		Namespace: namespace,
+	}, spec.ActiveFrom)
+	if err != nil {
+		return fmt.Errorf("failed to get scheduled subscriptions: %w", err)
+	}
+
+	// If we're updating an existing subscription, filter it out from the timeline check
+	if currentSubID != nil {
+		scheduled = lo.Filter(scheduled, func(sub subscription.Subscription, _ int) bool {
+			return sub.ID != *currentSubID
+		})
+	}
+
+	// Sanity check, validate that the scheduled timeline is consistent
+	if err := subscription.ValidateSubscriptionTimeline(scheduled); err != nil {
+		return fmt.Errorf("inconsistency error: %w", err)
+	}
+
+	// Now check that the new Spec also fits into the timeline
+	if err := subscription.ValidateSubscriptionTimelineWithNew(scheduled, spec, namespace); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/openmeter/subscription/timeline.go
+++ b/openmeter/subscription/timeline.go
@@ -1,0 +1,49 @@
+package subscription
+
+import (
+	"fmt"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// ValidateSubscriptionTimeline checks if the given subscriptions form a valid timeline without overlaps
+func ValidateSubscriptionTimeline(subscriptions []Subscription) error {
+	// Convert subscriptions to entity inputs for the cadence list
+	subscriptionInputs := lo.Map(subscriptions, func(sub Subscription, _ int) CreateSubscriptionEntityInput {
+		return sub.AsEntityInput()
+	})
+
+	// Create a sorted cadence list
+	subscriptionTimeline := models.NewSortedCadenceList(subscriptionInputs)
+
+	// Check for overlaps
+	if overlaps := subscriptionTimeline.GetOverlaps(); len(overlaps) > 0 {
+		return fmt.Errorf("subscription timeline has overlaps: %v", overlaps)
+	}
+
+	return nil
+}
+
+// ValidateSubscriptionTimelineWithNew checks if adding a new subscription to the existing ones
+// would result in a valid timeline without overlaps
+func ValidateSubscriptionTimelineWithNew(existingSubscriptions []Subscription, newSpec SubscriptionSpec, namespace string) error {
+	// Convert existing subscriptions to entity inputs
+	subscriptionInputs := lo.Map(existingSubscriptions, func(sub Subscription, _ int) CreateSubscriptionEntityInput {
+		return sub.AsEntityInput()
+	})
+
+	// Add the new subscription spec
+	subscriptionInputs = append(subscriptionInputs, newSpec.ToCreateSubscriptionEntityInput(namespace))
+
+	// Create a sorted cadence list
+	subscriptionTimeline := models.NewSortedCadenceList(subscriptionInputs)
+
+	// Check for overlaps
+	if overlaps := subscriptionTimeline.GetOverlaps(); len(overlaps) > 0 {
+		return models.NewGenericConflictError(fmt.Errorf("new subscription would overlap with existing ones: %v", overlaps))
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes [OM-1226: Subscription disallow "Continue" if a future sub is scheduled](https://linear.app/openmeter/issue/OM-1226/subscription-disallow-continue-if-a-future-sub-is-scheduled)
