### PR TITLE
Fix History Windowing

### DIFF
--- a/openmeter/meter/meter.go
+++ b/openmeter/meter/meter.go
@@ -73,7 +73,34 @@ func (WindowSize) Values() (kinds []string) {
 	return
 }
 
+func (w WindowSize) AddTo(t time.Time) (time.Time, error) {
+	switch w {
+	case WindowSizeMinute:
+		return t.Add(time.Minute), nil
+	case WindowSizeHour:
+		return t.Add(time.Hour), nil
+	case WindowSizeDay:
+		return t.AddDate(0, 0, 1), nil
+	default:
+		return time.Time{}, fmt.Errorf("invalid window size: %s", w)
+	}
+}
+
+func (w WindowSize) Truncate(t time.Time) (time.Time, error) {
+	switch w {
+	case WindowSizeMinute:
+		return t.Truncate(time.Minute), nil
+	case WindowSizeHour:
+		return t.Truncate(time.Hour), nil
+	case WindowSizeDay:
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location()), nil
+	default:
+		return time.Time{}, fmt.Errorf("invalid window size: %s", w)
+	}
+}
+
 // Duration returns the duration of the window size
+// BEWARE: a day is NOT 24 hours
 func (w WindowSize) Duration() time.Duration {
 	var windowDuration time.Duration
 	switch w {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

The clickhouse mock-connector incorrectly implemented aggregation which threw off the tests building on it. Now the behavior of what rows are returned when windowing matches what ClickHouse does.

- Return all history windows (even if no usage events were recorded)
- Check that we only return windows in which the entitlement existed for the whole period