### PR TITLE
Balance & Usage Consistency (History Rewrite Part II)

### DIFF
--- a/openmeter/credit/adapter/grant.go
+++ b/openmeter/credit/adapter/grant.go
@@ -174,6 +174,7 @@ func (g *grantDBADapter) ListActiveGrantsBetween(ctx context.Context, owner mode
 				db_grant.And(db_grant.EffectiveAtLT(from), db_grant.ExpiresAtGT(from)),
 				db_grant.And(db_grant.EffectiveAtGTE(from), db_grant.EffectiveAtLT(to)),
 				db_grant.EffectiveAt(from),
+				db_grant.EffectiveAt(to),
 			),
 		).Where(
 		db_grant.Or(db_grant.Not(db_grant.DeletedAtLTE(from)), db_grant.DeletedAtIsNil()),

--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -165,12 +165,7 @@ func (m *connector) GetBalanceHistoryOfOwner(ctx context.Context, ownerID models
 		return engine.GrantBurnDownHistory{}, fmt.Errorf("failed to calculate balance for owner %s at %s: %w", ownerID.ID, period.From, err)
 	}
 
-	// return history
-	history, err := engine.NewGrantBurnDownHistory(result.History)
-	if err != nil || history == nil {
-		return engine.GrantBurnDownHistory{}, fmt.Errorf("failed to create grant burn down history: %w", err)
-	}
-	return *history, err
+	return result.History, nil
 }
 
 func (m *connector) ResetUsageForOwner(ctx context.Context, ownerID models.NamespacedID, params ResetUsageForOwnerParams) (*balance.Snapshot, error) {

--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -95,6 +95,12 @@ func (m *connector) GetBalanceAt(ctx context.Context, ownerID models.NamespacedI
 		return def, fmt.Errorf("failed to calculate balance for owner %s at %s: %w", ownerID.ID, at, err)
 	}
 
+	// Let's remove any grants that are not active at the query time
+	err = m.removeInactiveGrantsFromSnapshotAt(&result.Snapshot, grants, at)
+	if err != nil {
+		return def, fmt.Errorf("failed to remove inactive grants from snapshot: %w", err)
+	}
+
 	// Let's see if a snapshot should be saved
 	if err := m.snapshotEngineResult(ctx, snapshotParams{
 		grants: grants,

--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -23,10 +23,10 @@ type ResetUsageForOwnerParams struct {
 
 // Generic connector for balance related operations.
 type BalanceConnector interface {
-	// GetResultAt returns the result of the engine.Run at a given time.
+	// GetBalanceAt returns the result of the engine.Run at a given time.
 	// It tries to minimize execution cost by calculating from the lastest valid snapshot, thus the length of the returned history WILL NOT be deterministic.
 	GetBalanceAt(ctx context.Context, ownerID models.NamespacedID, at time.Time) (engine.RunResult, error)
-	// GetResultBetween returns the result of the engine.Run between for the provided period.
+	// GetBalanceForPeriod returns the result of the engine.Run between for the provided period.
 	// The returned history will exactly match the provided period.
 	GetBalanceForPeriod(ctx context.Context, ownerID models.NamespacedID, period timeutil.Period) (engine.RunResult, error)
 	// ResetUsageForOwner resets the usage for an owner at a given time.

--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -24,9 +24,9 @@ type ResetUsageForOwnerParams struct {
 // Generic connector for balance related operations.
 type BalanceConnector interface {
 	// GetBalanceAt returns the result of the engine.Run at a given time.
-	// It tries to minimize execution cost by calculating from the lastest valid snapshot, thus the length of the returned history WILL NOT be deterministic.
+	// It tries to minimize execution cost by calculating from the latest valid snapshot, thus the length of the returned history WILL NOT be deterministic.
 	GetBalanceAt(ctx context.Context, ownerID models.NamespacedID, at time.Time) (engine.RunResult, error)
-	// GetBalanceForPeriod returns the result of the engine.Run between for the provided period.
+	// GetBalanceForPeriod returns the result of the engine.Run for the provided period.
 	// The returned history will exactly match the provided period.
 	GetBalanceForPeriod(ctx context.Context, ownerID models.NamespacedID, period timeutil.Period) (engine.RunResult, error)
 	// ResetUsageForOwner resets the usage for an owner at a given time.
@@ -115,7 +115,6 @@ func (m *connector) GetBalanceAt(ctx context.Context, ownerID models.NamespacedI
 	return result, nil
 }
 
-// Returns the joined GrantBurnDownHistory across usage periods.
 func (m *connector) GetBalanceForPeriod(ctx context.Context, ownerID models.NamespacedID, period timeutil.Period) (engine.RunResult, error) {
 	m.logger.Debug("calculating history for owner", "owner", ownerID.ID, "period", period)
 

--- a/openmeter/credit/engine/engine.go
+++ b/openmeter/credit/engine/engine.go
@@ -28,7 +28,7 @@ type RunResult struct {
 	// Snapshot of the balances at the END OF THE PERIOD.
 	Snapshot balance.Snapshot
 	// History of the grant burn down.
-	History []GrantBurnDownHistorySegment
+	History GrantBurnDownHistory
 }
 
 type Engine interface {

--- a/openmeter/credit/engine/history.go
+++ b/openmeter/credit/engine/history.go
@@ -66,7 +66,16 @@ func (s GrantBurnDownHistorySegment) ApplyUsage() balance.Map {
 	return balance
 }
 
-func NewGrantBurnDownHistory(segments []GrantBurnDownHistorySegment) (*GrantBurnDownHistory, error) {
+// Creates a GrantBalanceSnapshot from the starting state of the segment
+func (s *GrantBurnDownHistorySegment) ToSnapshot() balance.Snapshot {
+	return balance.Snapshot{
+		Overage:  s.OverageAtStart,
+		Balances: s.BalanceAtStart,
+		At:       s.From,
+	}
+}
+
+func NewGrantBurnDownHistory(segments []GrantBurnDownHistorySegment) (GrantBurnDownHistory, error) {
 	s := make([]GrantBurnDownHistorySegment, len(segments))
 	copy(s, segments)
 
@@ -82,11 +91,11 @@ func NewGrantBurnDownHistory(segments []GrantBurnDownHistorySegment) (*GrantBurn
 		}
 
 		if s[i-1].To.After(s[i].From) {
-			return nil, fmt.Errorf("segments %d and %d overlap", i-1, i)
+			return GrantBurnDownHistory{}, fmt.Errorf("segments %d and %d overlap", i-1, i)
 		}
 	}
 
-	return &GrantBurnDownHistory{segments: s}, nil
+	return GrantBurnDownHistory{segments: s}, nil
 }
 
 type GrantBurnDownHistory struct {
@@ -108,13 +117,4 @@ func (g *GrantBurnDownHistory) TotalUsage() float64 {
 func (g *GrantBurnDownHistory) Overage() float64 {
 	lastSegment := g.segments[len(g.segments)-1]
 	return lastSegment.Overage
-}
-
-// Creates a GrantBalanceSnapshot from the starting state of the segment
-func (s *GrantBurnDownHistorySegment) ToSnapshot() balance.Snapshot {
-	return balance.Snapshot{
-		Overage:  s.OverageAtStart,
-		Balances: s.BalanceAtStart,
-		At:       s.From,
-	}
 }

--- a/openmeter/credit/engine/reset_test.go
+++ b/openmeter/credit/engine/reset_test.go
@@ -99,20 +99,20 @@ func TestReset(t *testing.T) {
 		assert.Equal(t, 50.0, res.Snapshot.Balances[grant1.ID])
 
 		// History should have 2 segments, one before and one after the reset
-		assert.Equal(t, 2, len(res.History))
+		assert.Equal(t, 2, len(res.History.Segments()))
 
 		// The first segment should have a balance of 100 with 10 usage
-		assert.Equal(t, 100.0, res.History[0].BalanceAtStart.Balance())
-		assert.Equal(t, 0.0, res.History[0].OverageAtStart)
-		assert.Equal(t, 10.0, res.History[0].TotalUsage)
+		assert.Equal(t, 100.0, res.History.Segments()[0].BalanceAtStart.Balance())
+		assert.Equal(t, 0.0, res.History.Segments()[0].OverageAtStart)
+		assert.Equal(t, 10.0, res.History.Segments()[0].TotalUsage)
 
 		// It should end with a reset
-		assert.True(t, res.History[0].TerminationReasons.UsageReset)
+		assert.True(t, res.History.Segments()[0].TerminationReasons.UsageReset)
 
 		// The second segment should have a balance of 50 with no usage
-		assert.Equal(t, 50.0, res.History[1].BalanceAtStart.Balance())
-		assert.Equal(t, 0.0, res.History[1].OverageAtStart)
-		assert.Equal(t, 0.0, res.History[1].TotalUsage)
+		assert.Equal(t, 50.0, res.History.Segments()[1].BalanceAtStart.Balance())
+		assert.Equal(t, 0.0, res.History.Segments()[1].OverageAtStart)
+		assert.Equal(t, 0.0, res.History.Segments()[1].TotalUsage)
 	})
 
 	t.Run("Should carry over overage to next period", func(t *testing.T) {
@@ -149,21 +149,21 @@ func TestReset(t *testing.T) {
 		assert.Equal(t, 40.0, res.Snapshot.Balances[grant1.ID])
 
 		// History should have 2 segments, one before and one after the reset
-		assert.Equal(t, 2, len(res.History))
+		assert.Equal(t, 2, len(res.History.Segments()))
 
 		// The first segment should have a balance of 0 with 10 overage
-		assert.Equal(t, 100.0, res.History[0].BalanceAtStart.Balance())
-		assert.Equal(t, 0.0, res.History[0].OverageAtStart)
-		assert.Equal(t, 10.0, res.History[0].Overage)
-		assert.Equal(t, 110.0, res.History[0].TotalUsage)
+		assert.Equal(t, 100.0, res.History.Segments()[0].BalanceAtStart.Balance())
+		assert.Equal(t, 0.0, res.History.Segments()[0].OverageAtStart)
+		assert.Equal(t, 10.0, res.History.Segments()[0].Overage)
+		assert.Equal(t, 110.0, res.History.Segments()[0].TotalUsage)
 
 		// It should end with a reset
-		assert.True(t, res.History[0].TerminationReasons.UsageReset)
+		assert.True(t, res.History.Segments()[0].TerminationReasons.UsageReset)
 
 		// The second segment should have a balance of 50 - 10 with no usage (minRolloverAmount + overage)
-		assert.Equal(t, 40.0, res.History[1].BalanceAtStart.Balance())
-		assert.Equal(t, 0.0, res.History[1].OverageAtStart)
-		assert.Equal(t, 0.0, res.History[1].TotalUsage)
+		assert.Equal(t, 40.0, res.History.Segments()[1].BalanceAtStart.Balance())
+		assert.Equal(t, 0.0, res.History.Segments()[1].OverageAtStart)
+		assert.Equal(t, 0.0, res.History.Segments()[1].TotalUsage)
 	})
 
 	t.Run("No reset", func(t *testing.T) {
@@ -191,10 +191,10 @@ func TestReset(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Should have 2 periods, start - g2, g2 - end
-		assert.Equal(t, 2, len(res.History))
+		assert.Equal(t, 2, len(res.History.Segments()))
 
-		assert.False(t, res.History[0].TerminationReasons.UsageReset)
-		assert.False(t, res.History[1].TerminationReasons.UsageReset)
+		assert.False(t, res.History.Segments()[0].TerminationReasons.UsageReset)
+		assert.False(t, res.History.Segments()[1].TerminationReasons.UsageReset)
 	})
 
 	t.Run("Should return starting balance if the end of the queried period is a reset", func(t *testing.T) {
@@ -224,10 +224,10 @@ func TestReset(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Should have 2 periods, start - reset, reset - end where reset = end, 2nd period is 0 length
-		assert.Equal(t, 2, len(res.History), "expected: %+v, got %+v, history: %+v", 2, len(res.History), res.History)
+		assert.Equal(t, 2, len(res.History.Segments()), "expected: %+v, got %+v, history: %+v", 2, len(res.History.Segments()), res.History.Segments())
 
-		assert.True(t, res.History[0].TerminationReasons.UsageReset)
-		assert.False(t, res.History[1].TerminationReasons.UsageReset)
+		assert.True(t, res.History.Segments()[0].TerminationReasons.UsageReset)
+		assert.False(t, res.History.Segments()[1].TerminationReasons.UsageReset)
 	})
 
 	t.Run("Should error if a reset is provided for the starting snapshot", func(t *testing.T) {

--- a/openmeter/credit/engine/run_test.go
+++ b/openmeter/credit/engine/run_test.go
@@ -126,7 +126,7 @@ func TestEngine(t *testing.T) {
 						TotalUsage:         50.0,
 						Overage:            50.0,
 					},
-				}, res.History)
+				}, res.History.Segments())
 			},
 		},
 		{
@@ -308,10 +308,10 @@ func TestEngine(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, 0.0, res.Snapshot.Balances[grant1.ID])
 				assert.Equal(t, 50.0, res.Snapshot.Overage) // usage after grant deletion
-				assert.Len(t, res.History, 2)
-				assert.Equal(t, 50.0, res.History[0].TotalUsage)
-				assert.Equal(t, 50.0, res.History[1].TotalUsage)
-				assert.Equal(t, 0.0, res.History[1].BalanceAtStart[g.ID])
+				assert.Len(t, res.History.Segments(), 2)
+				assert.Equal(t, 50.0, res.History.Segments()[0].TotalUsage)
+				assert.Equal(t, 50.0, res.History.Segments()[1].TotalUsage)
+				assert.Equal(t, 0.0, res.History.Segments()[1].BalanceAtStart[g.ID])
 			},
 		},
 		{
@@ -342,10 +342,10 @@ func TestEngine(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, 0.0, res.Snapshot.Balances[grant1.ID])
 				assert.Equal(t, 50.0, res.Snapshot.Overage) // usage after grant deletion
-				assert.Len(t, res.History, 2)
-				assert.Equal(t, 50.0, res.History[0].TotalUsage)
-				assert.Equal(t, 50.0, res.History[1].TotalUsage)
-				assert.Equal(t, 0.0, res.History[1].BalanceAtStart[g.ID])
+				assert.Len(t, res.History.Segments(), 2)
+				assert.Equal(t, 50.0, res.History.Segments()[0].TotalUsage)
+				assert.Equal(t, 50.0, res.History.Segments()[1].TotalUsage)
+				assert.Equal(t, 0.0, res.History.Segments()[1].BalanceAtStart[g.ID])
 			},
 		},
 		{
@@ -435,13 +435,13 @@ func TestEngine(t *testing.T) {
 				assert.Equal(t, 50.0, res.Snapshot.Balances[grant1.ID])
 
 				// sets correct starting balance for grant in segment
-				assert.Len(t, res.History, 2)
-				assert.Equal(t, 0.0, res.History[0].BalanceAtStart[g.ID])
+				assert.Len(t, res.History.Segments(), 2)
+				assert.Equal(t, 0.0, res.History.Segments()[0].BalanceAtStart[g.ID])
 
 				// starting balance doesnt have overage deducted
-				assert.Equal(t, g.Amount, res.History[1].BalanceAtStart[g.ID])
+				assert.Equal(t, g.Amount, res.History.Segments()[1].BalanceAtStart[g.ID])
 				// but it is stored separately
-				assert.Equal(t, 25.0, res.History[1].OverageAtStart)
+				assert.Equal(t, 25.0, res.History.Segments()[1].OverageAtStart)
 			},
 		},
 		{
@@ -795,7 +795,7 @@ func TestEngine(t *testing.T) {
 				assert.NoError(t, err)
 
 				assert.NotEmpty(t, res.History)
-				assert.Equal(t, 4, len(res.History))
+				assert.Equal(t, 4, len(res.History.Segments()))
 			},
 		},
 		{
@@ -863,17 +863,17 @@ func TestEngine(t *testing.T) {
 				assert.NoError(t, err)
 
 				assert.NotEmpty(t, res.History)
-				assert.Equal(t, 5, len(res.History))
-				assert.Equal(t, start.In(time.UTC), res.History[0].Period.From)
-				assert.Equal(t, t1.In(time.UTC), res.History[0].Period.To)
-				assert.Equal(t, t1.In(time.UTC), res.History[1].Period.From)
-				assert.Equal(t, t2.In(time.UTC), res.History[1].Period.To)
-				assert.Equal(t, t2.In(time.UTC), res.History[2].Period.From)
-				assert.Equal(t, t3.In(time.UTC), res.History[2].Period.To)
-				assert.Equal(t, t3.In(time.UTC), res.History[3].Period.From)
-				assert.Equal(t, t2.Add(time.Hour).In(time.UTC), res.History[3].Period.To)
-				assert.Equal(t, t2.Add(time.Hour).In(time.UTC), res.History[4].Period.From)
-				assert.Equal(t, end.In(time.UTC), res.History[4].Period.To)
+				assert.Equal(t, 5, len(res.History.Segments()))
+				assert.Equal(t, start.In(time.UTC), res.History.Segments()[0].Period.From)
+				assert.Equal(t, t1.In(time.UTC), res.History.Segments()[0].Period.To)
+				assert.Equal(t, t1.In(time.UTC), res.History.Segments()[1].Period.From)
+				assert.Equal(t, t2.In(time.UTC), res.History.Segments()[1].Period.To)
+				assert.Equal(t, t2.In(time.UTC), res.History.Segments()[2].Period.From)
+				assert.Equal(t, t3.In(time.UTC), res.History.Segments()[2].Period.To)
+				assert.Equal(t, t3.In(time.UTC), res.History.Segments()[3].Period.From)
+				assert.Equal(t, t2.Add(time.Hour).In(time.UTC), res.History.Segments()[3].Period.To)
+				assert.Equal(t, t2.Add(time.Hour).In(time.UTC), res.History.Segments()[4].Period.From)
+				assert.Equal(t, end.In(time.UTC), res.History.Segments()[4].Period.To)
 			},
 		},
 	}

--- a/openmeter/credit/helper.go
+++ b/openmeter/credit/helper.go
@@ -209,17 +209,12 @@ type snapshotParams struct {
 
 // It is assumed that there are no snapshots persisted during the length of the history (as engine.Run starts with a snapshot that should be the last valid snapshot)
 func (m *connector) snapshotEngineResult(ctx context.Context, params snapshotParams) error {
-	history, err := engine.NewGrantBurnDownHistory(params.runRes.History)
-	if err != nil {
-		return fmt.Errorf("failed to create grant burn down history: %w", err)
-	}
-
 	currentPeriodStart, err := m.ownerConnector.GetUsagePeriodStartAt(ctx, params.owner, params.runRes.Snapshot.At)
 	if err != nil {
 		return fmt.Errorf("failed to get current usage period start for owner %s at %s: %w", params.owner.ID, params.runRes.Snapshot.At, err)
 	}
 
-	segs := history.Segments()
+	segs := params.runRes.History.Segments()
 
 	// i >= 1 because:
 	// The first segment starts with the last valid snapshot and we don't want to create another snapshot for that same time

--- a/openmeter/entitlement/metered/lateevents_test.go
+++ b/openmeter/entitlement/metered/lateevents_test.go
@@ -181,6 +181,7 @@ func TestGetEntitlementBalanceConsistency(t *testing.T) {
 
 	t.Run("Should return consistent balance and usage values if there are late events", func(t *testing.T) {
 		connector, deps := setupMockedConnector(t)
+		defer deps.Teardown()
 
 		ctx := context.Background()
 		startTime := getAnchor(t)

--- a/openmeter/entitlement/metered/lateevents_test.go
+++ b/openmeter/entitlement/metered/lateevents_test.go
@@ -16,7 +16,7 @@ import (
 	entitlement_postgresadapter "github.com/openmeterio/openmeter/openmeter/entitlement/adapter"
 	meteredentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/metered"
 	"github.com/openmeterio/openmeter/openmeter/meter"
-	meteradapter "github.com/openmeterio/openmeter/openmeter/meter/adapter"
+	meteradapter "github.com/openmeterio/openmeter/openmeter/meter/mockadapter"
 	productcatalog_postgresadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/adapter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
@@ -92,13 +92,18 @@ func TestGetEntitlementBalanceConsistency(t *testing.T) {
 
 		streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
 		meterAdapter, err := meteradapter.New([]meter.Meter{{
-			Slug:        meterSlug,
-			Namespace:   namespace,
+			Key: meterSlug,
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{
+					Namespace: namespace,
+				},
+				ID: "managed-resource-1",
+			},
 			Aggregation: meter.MeterAggregationSum,
 			WindowSize:  meter.WindowSizeMinute,
 			// These will be ignored in tests
 			EventType:     "test",
-			ValueProperty: "$.value",
+			ValueProperty: convert.ToPointer("$.value"),
 		}})
 		if err != nil {
 			t.Fatalf("failed to create meter adapter: %v", err)

--- a/openmeter/entitlement/metered/lateevents_test.go
+++ b/openmeter/entitlement/metered/lateevents_test.go
@@ -1,0 +1,225 @@
+package meteredentitlement_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openmeterio/openmeter/openmeter/credit"
+	credit_postgres_adapter "github.com/openmeterio/openmeter/openmeter/credit/adapter"
+	"github.com/openmeterio/openmeter/openmeter/credit/engine"
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
+	"github.com/openmeterio/openmeter/openmeter/entitlement"
+	entitlement_postgresadapter "github.com/openmeterio/openmeter/openmeter/entitlement/adapter"
+	meteredentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/metered"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	meteradapter "github.com/openmeterio/openmeter/openmeter/meter/adapter"
+	productcatalog_postgresadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/adapter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/convert"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+// To test late events well add events before and after execution
+type inconsistentCreditConnector struct {
+	credit.CreditConnector
+	AddSimpleEvent func(meterSlug string, value float64, at time.Time)
+}
+
+func (c *inconsistentCreditConnector) GetBalanceAt(ctx context.Context, ownerID models.NamespacedID, at time.Time) (engine.RunResult, error) {
+	relevantTime := at.Add(-time.Minute)
+
+	c.AddSimpleEvent(meterSlug, 5, relevantTime)
+	res, err := c.CreditConnector.GetBalanceAt(ctx, ownerID, at)
+	c.AddSimpleEvent(meterSlug, 5, relevantTime)
+
+	return res, err
+}
+
+func (c *inconsistentCreditConnector) GetBalanceForPeriod(ctx context.Context, ownerID models.NamespacedID, period timeutil.Period) (engine.RunResult, error) {
+	relevantTime := period.To.Add(-time.Minute)
+
+	c.AddSimpleEvent(meterSlug, 5, relevantTime)
+	res, err := c.CreditConnector.GetBalanceForPeriod(ctx, ownerID, period)
+	c.AddSimpleEvent(meterSlug, 5, relevantTime)
+
+	return res, err
+}
+
+func TestGetEntitlementBalanceConsistency(t *testing.T) {
+	exampleFeature := feature.CreateFeatureInputs{
+		Namespace:           namespace,
+		Name:                "feature1",
+		Key:                 "feature-1",
+		MeterSlug:           &meterSlug,
+		MeterGroupByFilters: map[string]string{},
+	}
+
+	getEntitlement := func(t *testing.T, feature feature.Feature) entitlement.CreateEntitlementRepoInputs {
+		t.Helper()
+		input := entitlement.CreateEntitlementRepoInputs{
+			Namespace:        namespace,
+			FeatureID:        feature.ID,
+			FeatureKey:       feature.Key,
+			SubjectKey:       "subject1",
+			MeasureUsageFrom: convert.ToPointer(testutils.GetRFC3339Time(t, "1024-03-01T00:00:00Z")), // old, override in tests
+			EntitlementType:  entitlement.EntitlementTypeMetered,
+			IssueAfterReset:  convert.ToPointer(0.0),
+			IsSoftLimit:      convert.ToPointer(false),
+			UsagePeriod: &entitlement.UsagePeriod{
+				Anchor: getAnchor(t),
+				// Yearly interval is used which helps adjust to the correct period
+				Interval: timeutil.RecurrencePeriodYear,
+			},
+		}
+
+		currentUsagePeriod, err := input.UsagePeriod.GetCurrentPeriodAt(time.Now())
+		assert.NoError(t, err)
+		input.CurrentUsagePeriod = &currentUsagePeriod
+		return input
+	}
+
+	setupMockedConnector := func(t *testing.T) (meteredentitlement.Connector, *dependencies) {
+		testLogger := testutils.NewLogger(t)
+
+		streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
+		meterAdapter, err := meteradapter.New([]meter.Meter{{
+			Slug:        meterSlug,
+			Namespace:   namespace,
+			Aggregation: meter.MeterAggregationSum,
+			WindowSize:  meter.WindowSizeMinute,
+			// These will be ignored in tests
+			EventType:     "test",
+			ValueProperty: "$.value",
+		}})
+		if err != nil {
+			t.Fatalf("failed to create meter adapter: %v", err)
+		}
+
+		// create isolated pg db for tests
+		testdb := testutils.InitPostgresDB(t)
+		dbClient := testdb.EntDriver.Client()
+		pgDriver := testdb.PGDriver
+		entDriver := testdb.EntDriver
+
+		featureRepo := productcatalog_postgresadapter.NewPostgresFeatureRepo(dbClient, testLogger)
+		entitlementRepo := entitlement_postgresadapter.NewPostgresEntitlementRepo(dbClient)
+		usageResetRepo := entitlement_postgresadapter.NewPostgresUsageResetRepo(dbClient)
+		grantRepo := credit_postgres_adapter.NewPostgresGrantRepo(dbClient)
+		balanceSnapshotRepo := credit_postgres_adapter.NewPostgresBalanceSnapshotRepo(dbClient)
+
+		m.Lock()
+		defer m.Unlock()
+		// migrate db via ent schema upsert
+		if err := dbClient.Schema.Create(context.Background()); err != nil {
+			t.Fatalf("failed to create schema: %v", err)
+		}
+
+		mockPublisher := eventbus.NewMock(t)
+
+		// build adapters
+		ownerConnector := meteredentitlement.NewEntitlementGrantOwnerAdapter(
+			featureRepo,
+			entitlementRepo,
+			usageResetRepo,
+			meterAdapter,
+			testLogger,
+		)
+
+		transactionManager := enttx.NewCreator(dbClient)
+
+		creditConnector := credit.NewCreditConnector(
+			grantRepo,
+			balanceSnapshotRepo,
+			ownerConnector,
+			streamingConnector,
+			testLogger,
+			time.Minute,
+			mockPublisher,
+			transactionManager,
+		)
+
+		inconsistentCreditConnector := &inconsistentCreditConnector{
+			CreditConnector: creditConnector,
+			AddSimpleEvent:  streamingConnector.AddSimpleEvent,
+		}
+
+		connector := meteredentitlement.NewMeteredEntitlementConnector(
+			streamingConnector,
+			ownerConnector,
+			inconsistentCreditConnector,
+			inconsistentCreditConnector,
+			grantRepo,
+			entitlementRepo,
+			mockPublisher,
+			testLogger,
+		)
+
+		return connector, &dependencies{
+			dbClient,
+			pgDriver,
+			entDriver,
+			featureRepo,
+			entitlementRepo,
+			usageResetRepo,
+			grantRepo,
+			balanceSnapshotRepo,
+			inconsistentCreditConnector,
+			ownerConnector,
+			streamingConnector,
+			inconsistentCreditConnector,
+		}
+	}
+
+	t.Run("Should return consistent balance and usage values if there are late events", func(t *testing.T) {
+		connector, deps := setupMockedConnector(t)
+
+		ctx := context.Background()
+		startTime := getAnchor(t)
+		clock.SetTime(startTime)
+		defer clock.ResetTime()
+
+		// create featute in db
+		feature, err := deps.featureRepo.CreateFeature(ctx, exampleFeature)
+		assert.NoError(t, err)
+
+		// create entitlement in db
+		inp := getEntitlement(t, feature)
+		inp.MeasureUsageFrom = &startTime
+		inp.UsagePeriod.Interval = timeutil.RecurrencePeriodMonth
+		entitlement, err := deps.entitlementRepo.CreateEntitlement(ctx, inp)
+		assert.NoError(t, err)
+
+		queryTime := startTime.AddDate(0, 0, 10) // longer than grace period for saving snapshots
+
+		g1, err := deps.grantRepo.CreateGrant(ctx, grant.RepoCreateInput{
+			OwnerID:          entitlement.ID,
+			Namespace:        namespace,
+			Amount:           1000,
+			ResetMaxRollover: 1000,
+			Priority:         2,
+			EffectiveAt:      startTime,
+			ExpiresAt:        startTime.AddDate(0, 5, 0),
+		})
+		assert.NoError(t, err)
+
+		// register usage for meter & feature
+		deps.streamingConnector.AddSimpleEvent(meterSlug, 200, g1.EffectiveAt.Add(time.Minute*5))
+
+		clock.SetTime(queryTime)
+
+		entBalance, err := connector.GetEntitlementBalance(ctx, models.NamespacedID{Namespace: namespace, ID: entitlement.ID}, queryTime)
+		assert.NoError(t, err)
+
+		// Let's validate that balance usage and overage adds up to the grant amount
+		assert.Equal(t, g1.Amount, entBalance.UsageInPeriod+entBalance.Balance-entBalance.Overage)
+	})
+}

--- a/openmeter/entitlement/metered/reset_test.go
+++ b/openmeter/entitlement/metered/reset_test.go
@@ -322,7 +322,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 				assert.Equal(t, resetTime, balanceAfterReset.StartOfPeriod)
 
 				// get detailed balance from credit connector to check individual grant balances
-				creditBalance, err := deps.balanceConnector.GetBalanceOfOwner(ctx, models.NamespacedID{
+				creditBalance, err := deps.balanceConnector.GetBalanceAt(ctx, models.NamespacedID{
 					Namespace: namespace,
 					ID:        ent.ID,
 				}, resetTime)
@@ -331,7 +331,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 				assert.Equal(t, balance.Map{
 					g1.ID: 400,
 					g2.ID: 100,
-				}, creditBalance.Balances)
+				}, creditBalance.Snapshot.Balances)
 			},
 		},
 		{
@@ -394,7 +394,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 				assert.Equal(t, resetTime, balanceAfterReset.StartOfPeriod)
 
 				// get detailed balance from credit connector to check individual grant balances
-				creditBalance, err := deps.balanceConnector.GetBalanceOfOwner(ctx, models.NamespacedID{
+				creditBalance, err := deps.balanceConnector.GetBalanceAt(ctx, models.NamespacedID{
 					Namespace: namespace,
 					ID:        ent.ID,
 				}, resetTime)
@@ -403,7 +403,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 				assert.Equal(t, balance.Map{
 					g1.ID: 0,
 					g2.ID: 400,
-				}, creditBalance.Balances)
+				}, creditBalance.Snapshot.Balances)
 			},
 		},
 		{
@@ -466,7 +466,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 				assert.Equal(t, resetTime, balanceAfterReset.StartOfPeriod)
 
 				// get detailed balance from credit connector to check individual grant balances
-				creditBalance, err := deps.balanceConnector.GetBalanceOfOwner(ctx, models.NamespacedID{
+				creditBalance, err := deps.balanceConnector.GetBalanceAt(ctx, models.NamespacedID{
 					Namespace: namespace,
 					ID:        ent.ID,
 				}, resetTime)
@@ -475,7 +475,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 				assert.Equal(t, balance.Map{
 					g1.ID: 0,
 					g2.ID: 0,
-				}, creditBalance.Balances)
+				}, creditBalance.Snapshot.Balances)
 			},
 		},
 		{
@@ -572,7 +572,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 				assert.Equal(t, resetTime1, balanceAfterReset.StartOfPeriod)
 
 				// get detailed balance from credit connector to check individual grant balances
-				creditBalance, err := deps.balanceConnector.GetBalanceOfOwner(ctx, models.NamespacedID{
+				creditBalance, err := deps.balanceConnector.GetBalanceAt(ctx, models.NamespacedID{
 					Namespace: namespace,
 					ID:        ent.ID,
 				}, resetTime1)
@@ -581,7 +581,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 				assert.Equal(t, balance.Map{
 					g1.ID: 400,
 					g2.ID: 100,
-				}, creditBalance.Balances)
+				}, creditBalance.Snapshot.Balances)
 
 				// issue grants taking effect after first reset
 				g3, err := deps.grantRepo.CreateGrant(ctx, grant.RepoCreateInput{
@@ -613,7 +613,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 				assert.Equal(t, resetTime2, balanceAfterReset.StartOfPeriod)
 
 				// get detailed balance from credit connector to check individual grant balances
-				creditBalance, err = deps.balanceConnector.GetBalanceOfOwner(ctx, models.NamespacedID{
+				creditBalance, err = deps.balanceConnector.GetBalanceAt(ctx, models.NamespacedID{
 					Namespace: namespace,
 					ID:        ent.ID,
 				}, resetTime2)
@@ -623,7 +623,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 					g1.ID: 100,
 					g2.ID: 100,
 					g3.ID: 1000,
-				}, creditBalance.Balances)
+				}, creditBalance.Snapshot.Balances)
 			},
 		},
 		{

--- a/openmeter/entitlement/metered/utils_test.go
+++ b/openmeter/entitlement/metered/utils_test.go
@@ -43,6 +43,7 @@ type dependencies struct {
 	balanceConnector    credit.BalanceConnector
 	ownerConnector      grant.OwnerConnector
 	streamingConnector  *streamingtestutils.MockStreamingConnector
+	creditConnector     credit.CreditConnector
 }
 
 // Teardown cleans up the dependencies
@@ -153,6 +154,7 @@ func setupConnector(t *testing.T) (meteredentitlement.Connector, *dependencies) 
 		creditConnector,
 		ownerConnector,
 		streamingConnector,
+		creditConnector,
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Changes `metered/balance` to use `credit`'s history calculation. This way period's usage information is only queried once & is consistent with balance and grant information.

- As a side-effect, snapshots generated for the current usage period will be ignored in the calculations, effectively making the calculations slower (Part III will address this)
- includes some bugfixes around current period calculation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced active grant filtering now includes grants effective at period endpoints for more accurate tracking.
  - Improved balance and usage reporting for credits and entitlements, delivering more consistent and detailed information.
  - Refined usage period calculation and reset processing for entitlements to improve precision in tracking metrics.

- **Tests**
  - Expanded test coverage to validate late event handling and ensure balance consistency under various scenarios.
  - Updated tests to align with new balance retrieval methods and data structures.
  - Streamlined tests to focus on usage events and their impact on grant balances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->