### PR TITLE
chore: fix ingest event partition assignment

### DIFF
--- a/openmeter/entitlement/balanceworker/ingesthandler.go
+++ b/openmeter/entitlement/balanceworker/ingesthandler.go
@@ -9,18 +9,17 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/event/metadata"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	ingestevents "github.com/openmeterio/openmeter/openmeter/sink/flushhandler/ingestnotification/events"
-	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
 func (w *Worker) handleBatchedIngestEvent(ctx context.Context, event ingestevents.EventBatchedIngest) error {
-	filters := slicesx.Map(event.Events, func(e ingestevents.IngestEventData) IngestEventQueryFilter {
-		return IngestEventQueryFilter{
-			Namespace:  e.Namespace.ID,
-			SubjectKey: e.SubjectKey,
-			MeterSlugs: e.MeterSlugs,
-		}
-	})
-	affectedEntitlements, err := w.repo.ListAffectedEntitlements(ctx, filters)
+	affectedEntitlements, err := w.repo.ListAffectedEntitlements(ctx,
+		[]IngestEventQueryFilter{
+			{
+				Namespace:  event.Namespace.ID,
+				SubjectKey: event.SubjectKey,
+				MeterSlugs: event.MeterSlugs,
+			},
+		})
 	if err != nil {
 		return err
 	}

--- a/openmeter/sink/flushhandler/ingestnotification/handler.go
+++ b/openmeter/sink/flushhandler/ingestnotification/handler.go
@@ -60,18 +60,47 @@ func (h *handler) OnFlushSuccess(ctx context.Context, events []sinkmodels.SinkMe
 	}
 
 	// Map the filtered events to the ingest event
-	iEvents := slicesx.Map(filtered, func(message sinkmodels.SinkMessage) ingestevents.IngestEventData {
-		return ingestevents.IngestEventData{
+	iEvents := slicesx.Map(filtered, func(message sinkmodels.SinkMessage) ingestevents.EventBatchedIngest {
+		return ingestevents.EventBatchedIngest{
 			Namespace:  eventmodels.NamespaceID{ID: message.Namespace},
 			SubjectKey: message.Serialized.Subject,
 			MeterSlugs: h.getMeterSlugsFromMeters(message.Meters),
 		}
 	})
 
+	// Let's group the events by subject
+	iEventsBySubject := lo.GroupBy(iEvents, func(event ingestevents.EventBatchedIngest) string {
+		return event.Namespace.ID + "/" + event.SubjectKey
+	})
+
+	// Let's merge the events by subject
+	iEvents = make([]ingestevents.EventBatchedIngest, 0, len(iEventsBySubject))
+	for _, events := range iEventsBySubject {
+		if len(events) == 0 {
+			continue
+		}
+
+		if len(events) == 1 {
+			iEvents = append(iEvents, events[0])
+			continue
+		}
+
+		meterSlugs := make([]string, 0, len(events))
+
+		for _, event := range events[1:] {
+			meterSlugs = append(meterSlugs, event.MeterSlugs...)
+		}
+
+		iEvents = append(iEvents, ingestevents.EventBatchedIngest{
+			Namespace:  events[0].Namespace,
+			SubjectKey: events[0].SubjectKey,
+			MeterSlugs: lo.Uniq(meterSlugs),
+		})
+	}
+
 	// We need to chunk the events to not exceed message size limits
-	chunkedEvents := lo.Chunk(iEvents, h.config.MaxEventsInBatch)
-	for _, chunk := range chunkedEvents {
-		if err := h.publisher.Publish(ctx, ingestevents.EventBatchedIngest{Events: chunk}); err != nil {
+	for _, event := range iEvents {
+		if err := h.publisher.Publish(ctx, event); err != nil {
 			finalErr = errors.Join(finalErr, err)
 			h.logger.ErrorContext(ctx, "failed to publish change notification", "error", err)
 		}

--- a/openmeter/subscription/validators/customer/validator.go
+++ b/openmeter/subscription/validators/customer/validator.go
@@ -28,8 +28,6 @@ type Validator struct {
 	subscriptionService subscription.Service
 }
 
-// TODO: Wire in
-
 func (v *Validator) ValidateDeleteCustomer(ctx context.Context, input customer.DeleteCustomerInput) error {
 	// A customer can only be deleted if all of his invocies are in final state
 


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Previously we were using random partitions for ingest events, making the high watermark cache unusable. This patch ensures that we are consistent with partition selection.