### PR TITLE
Fix customer subject validation

### DIFF
--- a/app/common/subscription.go
+++ b/app/common/subscription.go
@@ -92,7 +92,7 @@ func NewSubscriptionServices(
 		Logger:              logger.With("subsystem", "subscription.change.service"),
 	})
 
-	validator, err := subscriptioncustomer.NewValidator(subscriptionService)
+	validator, err := subscriptioncustomer.NewValidator(subscriptionService, customerService)
 	if err != nil {
 		return SubscriptionServiceWithWorkflow{}, err
 	}

--- a/openmeter/subscription/subscriptionspec.go
+++ b/openmeter/subscription/subscriptionspec.go
@@ -389,27 +389,15 @@ func (s SubscriptionPhaseSpec) GetBillableItemsByKey() map[string][]*Subscriptio
 }
 
 func (s SubscriptionPhaseSpec) HasEntitlements() bool {
-	for _, items := range s.ItemsByKey {
-		for _, item := range items {
-			if item.RateCard.EntitlementTemplate != nil {
-				return true
-			}
-		}
-	}
-
-	return false
+	return lo.SomeBy(lo.Flatten(lo.Values(s.ItemsByKey)), func(item *SubscriptionItemSpec) bool {
+		return item.RateCard.EntitlementTemplate != nil
+	})
 }
 
 func (s SubscriptionPhaseSpec) HasMeteredBillables() bool {
-	for _, items := range s.ItemsByKey {
-		for _, item := range items {
-			if item.RateCard.Price != nil && item.RateCard.Price.Type() != productcatalog.FlatPriceType {
-				return true
-			}
-		}
-	}
-
-	return false
+	return lo.SomeBy(lo.Flatten(lo.Values(s.ItemsByKey)), func(item *SubscriptionItemSpec) bool {
+		return item.RateCard.Price != nil && item.RateCard.Price.Type() != productcatalog.FlatPriceType
+	})
 }
 
 func (s SubscriptionPhaseSpec) HasBillables() bool {

--- a/openmeter/subscription/validators/customer/validator.go
+++ b/openmeter/subscription/validators/customer/validator.go
@@ -17,6 +17,9 @@ func NewValidator(subscriptionService subscription.Service, customerService cust
 	if subscriptionService == nil {
 		return nil, fmt.Errorf("subscription service is required")
 	}
+	if customerService == nil {
+		return nil, fmt.Errorf("customer service is required")
+	}
 
 	return &Validator{
 		subscriptionService: subscriptionService,

--- a/openmeter/subscription/validators/customer/validator.go
+++ b/openmeter/subscription/validators/customer/validator.go
@@ -13,19 +13,65 @@ import (
 
 var _ customer.RequestValidator = (*Validator)(nil)
 
-func NewValidator(subscriptionService subscription.Service) (*Validator, error) {
+func NewValidator(subscriptionService subscription.Service, customerService customer.Service) (*Validator, error) {
 	if subscriptionService == nil {
 		return nil, fmt.Errorf("subscription service is required")
 	}
 
 	return &Validator{
 		subscriptionService: subscriptionService,
+		customerService:     customerService,
 	}, nil
 }
 
 type Validator struct {
 	customer.NoopRequestValidator
 	subscriptionService subscription.Service
+	customerService     customer.Service
+}
+
+func (v *Validator) ValidateUpdateCustomer(ctx context.Context, input customer.UpdateCustomerInput) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	// The subject association can only be changed if the customer doesn't have a subscription
+	subscriptions, err := v.subscriptionService.List(ctx, subscription.ListSubscriptionsInput{
+		Namespaces: []string{input.CustomerID.Namespace},
+		Customers:  []string{input.CustomerID.ID},
+		ActiveAt:   lo.ToPtr(clock.Now()),
+	})
+	if err != nil {
+		return err
+	}
+
+	hasSub := len(subscriptions.Items) > 0
+
+	// If there's an update to the subject keys we need additional checks
+	if input.CustomerMutate.UsageAttribution.SubjectKeys != nil {
+		currentCustomer, err := v.customerService.GetCustomer(ctx, customer.GetCustomerInput{
+			Namespace: input.CustomerID.Namespace,
+			ID:        input.CustomerID.ID,
+		})
+		if err != nil {
+			return err
+		}
+
+		// Let's check the two subjectKey arrays are the same
+		if hasSub {
+			if len(currentCustomer.UsageAttribution.SubjectKeys) != len(input.CustomerMutate.UsageAttribution.SubjectKeys) {
+				return fmt.Errorf("cannot change subject keys for customer with active subscriptions")
+			}
+
+			for i, key := range currentCustomer.UsageAttribution.SubjectKeys {
+				if key != input.CustomerMutate.UsageAttribution.SubjectKeys[i] {
+					return fmt.Errorf("cannot change subject keys for customer with active subscriptions")
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (v *Validator) ValidateDeleteCustomer(ctx context.Context, input customer.DeleteCustomerInput) error {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

- Check when creating a subscription that if there are entitlements or metered billables, a subject must be defined for the customer
- Only set customer currency to subscription currency if the subscription has billables
- Don't allow updating a customer's subejctkeys if they have an active subscription


<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced validations during subscription creation and updates, ensuring that customer data meets required criteria for subject keys and currency consistency.
  - Improved checks for subscriptions with entitlements, billable items, and metered billables to ensure proper eligibility.
  - Strengthened customer update validations to prevent unauthorized changes when active subscriptions exist.
  - Simplified methods in `SubscriptionPhaseSpec` for checking entitlements and billables, improving readability and efficiency.
  - Additional validation to ensure required services are provided during validator instantiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->