### PR TITLE
Persisting Usage in Snapshots (History Rewrite Part III)

### DIFF
--- a/app/common/entitlement.go
+++ b/app/common/entitlement.go
@@ -27,10 +27,11 @@ func NewEntitlementRegistry(
 	eventPublisher eventbus.Publisher,
 ) *registry.Entitlement {
 	return registrybuilder.GetEntitlementRegistry(registrybuilder.EntitlementOptions{
-		DatabaseClient:     db,
-		StreamingConnector: streamingConnector,
-		MeterService:       meterService,
-		Logger:             logger,
-		Publisher:          eventPublisher,
+		DatabaseClient:            db,
+		StreamingConnector:        streamingConnector,
+		MeterService:              meterService,
+		Logger:                    logger,
+		Publisher:                 eventPublisher,
+		EntitlementsConfiguration: entitlementConfig,
 	})
 }

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -179,6 +179,7 @@ func SetViperDefaults(v *viper.Viper, flags *pflag.FlagSet) {
 	ConfigureBilling(v, flags)
 	ConfigureProductCatalog(v)
 	ConfigureApps(v, flags)
+	ConfigureEntitlements(v, flags)
 	ConfigureTermination(v, "termination")
 	ConfigureProgressManager(v)
 }

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	notificationwebhook "github.com/openmeterio/openmeter/openmeter/notification/webhook"
+	"github.com/openmeterio/openmeter/pkg/isodate"
 	pkgkafka "github.com/openmeterio/openmeter/pkg/kafka"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/redis"
@@ -134,6 +135,9 @@ func TestComplete(t *testing.T) {
 			EventsTableName: "om_events",
 			AsyncInsert:     false,
 			AsyncInsertWait: false,
+		},
+		Entitlements: EntitlementsConfiguration{
+			GracePeriod: isodate.String("P1D"),
 		},
 		Billing: BillingConfiguration{
 			Enabled:             false,

--- a/app/config/entitlements.go
+++ b/app/config/entitlements.go
@@ -20,8 +20,10 @@ func (c EntitlementsConfiguration) Validate() error {
 		return errors.New("gracePeriod is required")
 	}
 
-	if _, err := c.GracePeriod.Parse(); err != nil {
+	if p, err := c.GracePeriod.Parse(); err != nil {
 		return errors.New("gracePeriod is invalid")
+	} else if p.Sign() != 1 {
+		return errors.New("gracePeriod must be positive")
 	}
 
 	return nil

--- a/app/config/entitlements.go
+++ b/app/config/entitlements.go
@@ -1,8 +1,42 @@
 package config
 
-type EntitlementsConfiguration struct{}
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/openmeterio/openmeter/pkg/isodate"
+)
+
+type EntitlementsConfiguration struct {
+	GracePeriod isodate.String
+}
 
 // Validate validates the configuration.
 func (c EntitlementsConfiguration) Validate() error {
+	if c.GracePeriod == "" {
+		return errors.New("gracePeriod is required")
+	}
+
+	if _, err := c.GracePeriod.Parse(); err != nil {
+		return errors.New("gracePeriod is invalid")
+	}
+
 	return nil
+}
+
+func (c *EntitlementsConfiguration) GetGracePeriod() isodate.Period {
+	gracePeriod, err := c.GracePeriod.Parse()
+	if err != nil {
+		slog.Error("failed to parse grace period, using default of 1 day", "error", err)
+		return isodate.NewPeriod(0, 0, 0, 1, 0, 0, 0)
+	}
+	return gracePeriod
+}
+
+func ConfigureEntitlements(v *viper.Viper, flags *pflag.FlagSet) {
+	// Let's set the default grace period to 1 day so late events can arrive up to a day late and be included in balance calculations
+	v.SetDefault("entitlements.gracePeriod", "P1D")
 }

--- a/cmd/balance-worker/wire_gen.go
+++ b/cmd/balance-worker/wire_gen.go
@@ -133,6 +133,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
+	entitlementsConfiguration := conf.Entitlements
 	aggregationConfiguration := conf.Aggregation
 	clickHouseAggregationConfiguration := aggregationConfiguration.ClickHouse
 	v2, err := common.NewClickHouse(clickHouseAggregationConfiguration)
@@ -177,11 +178,12 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	entitlementOptions := registrybuilder.EntitlementOptions{
-		DatabaseClient:     client,
-		StreamingConnector: connector,
-		Logger:             logger,
-		MeterService:       meterService,
-		Publisher:          eventbusPublisher,
+		DatabaseClient:            client,
+		EntitlementsConfiguration: entitlementsConfiguration,
+		StreamingConnector:        connector,
+		Logger:                    logger,
+		MeterService:              meterService,
+		Publisher:                 eventbusPublisher,
 	}
 	entitlement := registrybuilder.GetEntitlementRegistry(entitlementOptions)
 	balanceWorkerEntitlementRepo := common.NewBalanceWorkerEntitlementRepo(client)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -54,6 +54,9 @@ termination:
 #     database: 0
 #     expiration: 768h # 32d
 
+# entitlements:
+#   gracePeriod: P1D
+
 productcatalog:
   enabled: true
 

--- a/openmeter/billing/worker/subscription/sync_test.go
+++ b/openmeter/billing/worker/subscription/sync_test.go
@@ -221,14 +221,17 @@ func (s *SubscriptionHandlerTestSuite) SetupEntitlements() entitlement.Connector
 	transactionManager := enttx.NewCreator(s.DBClient)
 
 	creditConnector := credit.NewCreditConnector(
-		grantRepo,
-		balanceSnapshotService,
-		owner,
-		s.MockStreamingConnector,
-		slog.Default(),
-		time.Minute,
-		mockPublisher,
-		transactionManager,
+		credit.CreditConnectorConfig{
+			GrantRepo:              grantRepo,
+			BalanceSnapshotService: balanceSnapshotService,
+			OwnerConnector:         owner,
+			StreamingConnector:     s.MockStreamingConnector,
+			Logger:                 slog.Default(),
+			Granularity:            time.Minute,
+			Publisher:              mockPublisher,
+			TransactionManager:     transactionManager,
+			SnapshotGracePeriod:    isodate.MustParse(s.T(), "P1W"),
+		},
 	)
 
 	meteredEntitlementConnector := meteredentitlement.NewMeteredEntitlementConnector(

--- a/openmeter/billing/worker/subscription/sync_test.go
+++ b/openmeter/billing/worker/subscription/sync_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/credit"
 	grantrepo "github.com/openmeterio/openmeter/openmeter/credit/adapter"
+	"github.com/openmeterio/openmeter/openmeter/credit/balance"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
 	"github.com/openmeterio/openmeter/openmeter/entitlement"
@@ -211,11 +212,17 @@ func (s *SubscriptionHandlerTestSuite) SetupEntitlements() entitlement.Connector
 		slog.Default(),
 	)
 
+	balanceSnapshotService := balance.NewSnapshotService(balance.SnapshotServiceConfig{
+		OwnerConnector:     owner,
+		StreamingConnector: s.MockStreamingConnector,
+		Repo:               balanceSnapshotRepo,
+	})
+
 	transactionManager := enttx.NewCreator(s.DBClient)
 
 	creditConnector := credit.NewCreditConnector(
 		grantRepo,
-		balanceSnapshotRepo,
+		balanceSnapshotService,
 		owner,
 		s.MockStreamingConnector,
 		slog.Default(),

--- a/openmeter/credit/adapter/balance_snapshot.go
+++ b/openmeter/credit/adapter/balance_snapshot.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	db_balancesnapshot "github.com/openmeterio/openmeter/openmeter/ent/db/balancesnapshot"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -18,60 +19,71 @@ type balanceSnapshotRepo struct {
 	db *db.Client
 }
 
-func NewPostgresBalanceSnapshotRepo(db *db.Client) balance.SnapshotRepo {
+func NewPostgresBalanceSnapshotRepo(db *db.Client) *balanceSnapshotRepo {
 	return &balanceSnapshotRepo{
 		db: db,
 	}
 }
 
 func (b *balanceSnapshotRepo) InvalidateAfter(ctx context.Context, owner models.NamespacedID, at time.Time) error {
-	return b.db.BalanceSnapshot.Update().
-		Where(db_balancesnapshot.OwnerID(owner.ID), db_balancesnapshot.Namespace(owner.Namespace), db_balancesnapshot.AtGT(at)).
-		SetDeletedAt(clock.Now()).
-		Exec(ctx)
+	return entutils.TransactingRepoWithNoValue(ctx, b, func(ctx context.Context, rep *balanceSnapshotRepo) error {
+		return rep.db.BalanceSnapshot.Update().
+			Where(db_balancesnapshot.OwnerID(owner.ID), db_balancesnapshot.Namespace(owner.Namespace), db_balancesnapshot.AtGT(at)).
+			SetDeletedAt(clock.Now()).
+			Exec(ctx)
+	})
 }
 
 func (b *balanceSnapshotRepo) GetLatestValidAt(ctx context.Context, owner models.NamespacedID, at time.Time) (balance.Snapshot, error) {
-	res, err := b.db.BalanceSnapshot.Query().
-		Where(
-			db_balancesnapshot.OwnerID(owner.ID),
-			db_balancesnapshot.Namespace(owner.Namespace),
-			db_balancesnapshot.AtLTE(at),
-			db_balancesnapshot.DeletedAtIsNil(),
-		).
-		// in case there were multiple snapshots for the same time return the newest one
-		Order(db_balancesnapshot.ByAt(sql.OrderDesc()), db_balancesnapshot.ByUpdatedAt(sql.OrderDesc())).
-		First(ctx)
-	if err != nil {
-		if db.IsNotFound(err) {
-			return balance.Snapshot{}, &balance.NoSavedBalanceForOwnerError{Owner: owner, Time: at}
+	return entutils.TransactingRepo(ctx, b, func(ctx context.Context, rep *balanceSnapshotRepo) (balance.Snapshot, error) {
+		res, err := rep.db.BalanceSnapshot.Query().
+			Where(
+				db_balancesnapshot.OwnerID(owner.ID),
+				db_balancesnapshot.Namespace(owner.Namespace),
+				db_balancesnapshot.AtLTE(at),
+				db_balancesnapshot.DeletedAtIsNil(),
+			).
+			// in case there were multiple snapshots for the same time return the newest one
+			Order(db_balancesnapshot.ByAt(sql.OrderDesc()), db_balancesnapshot.ByUpdatedAt(sql.OrderDesc())).
+			First(ctx)
+		if err != nil {
+			if db.IsNotFound(err) {
+				return balance.Snapshot{}, &balance.NoSavedBalanceForOwnerError{Owner: owner, Time: at}
+			}
+			return balance.Snapshot{}, err
 		}
-		return balance.Snapshot{}, err
-	}
 
-	return mapBalanceSnapshotEntity(res), nil
+		return mapBalanceSnapshotEntity(res), nil
+	})
 }
 
 func (b *balanceSnapshotRepo) Save(ctx context.Context, owner models.NamespacedID, balances []balance.Snapshot) error {
-	commands := make([]*db.BalanceSnapshotCreate, 0, len(balances))
-	for _, balance := range balances {
-		command := b.db.BalanceSnapshot.Create().
-			SetNamespace(owner.Namespace).
-			SetOwnerID(owner.ID).
-			SetBalance(balance.Balance()).
-			SetAt(balance.At).
-			SetGrantBalances(balance.Balances).
-			SetOverage(balance.Overage)
-		commands = append(commands, command)
-	}
-	_, err := b.db.BalanceSnapshot.CreateBulk(commands...).Save(ctx)
-	return err
+	return entutils.TransactingRepoWithNoValue(ctx, b, func(ctx context.Context, rep *balanceSnapshotRepo) error {
+		commands := make([]*db.BalanceSnapshotCreate, 0, len(balances))
+		for _, balance := range balances {
+			command := rep.db.BalanceSnapshot.Create().
+				SetNamespace(owner.Namespace).
+				SetOwnerID(owner.ID).
+				SetBalance(balance.Balance()).
+				SetAt(balance.At).
+				SetGrantBalances(balance.Balances).
+				SetOverage(balance.Overage).
+				SetUsage(&balance.Usage)
+			commands = append(commands, command)
+		}
+		_, err := rep.db.BalanceSnapshot.CreateBulk(commands...).Save(ctx)
+		return err
+	})
 }
 
 func mapBalanceSnapshotEntity(entity *db.BalanceSnapshot) balance.Snapshot {
-	return balance.Snapshot{
+	s := balance.Snapshot{
 		Balances: entity.GrantBalances,
 		Overage:  entity.Overage,
 		At:       entity.At.In(time.UTC),
 	}
+	if entity.Usage != nil {
+		s.Usage = *entity.Usage
+	}
+	return s
 }

--- a/openmeter/credit/adapter/transaction.go
+++ b/openmeter/credit/adapter/transaction.go
@@ -48,6 +48,6 @@ func (e *balanceSnapshotRepo) WithTx(ctx context.Context, tx *entutils.TxDriver)
 	return NewPostgresBalanceSnapshotRepo(txClient.Client())
 }
 
-func (e *balanceSnapshotRepo) Self() balance.SnapshotRepo {
+func (e *balanceSnapshotRepo) Self() *balanceSnapshotRepo {
 	return e
 }

--- a/openmeter/credit/adapter/transaction.go
+++ b/openmeter/credit/adapter/transaction.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/openmeterio/openmeter/openmeter/credit/balance"
 	"github.com/openmeterio/openmeter/openmeter/credit/grant"
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
@@ -44,7 +43,7 @@ func (e *balanceSnapshotRepo) Tx(ctx context.Context) (context.Context, transact
 	return txCtx, entutils.NewTxDriver(eDriver, rawConfig), nil
 }
 
-func (e *balanceSnapshotRepo) WithTx(ctx context.Context, tx *entutils.TxDriver) balance.SnapshotRepo {
+func (e *balanceSnapshotRepo) WithTx(ctx context.Context, tx *entutils.TxDriver) *balanceSnapshotRepo {
 	txClient := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 	return NewPostgresBalanceSnapshotRepo(txClient.Client())
 }

--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -40,7 +40,7 @@ var _ BalanceConnector = &connector{}
 
 func (m *connector) GetBalanceSinceSnapshot(ctx context.Context, ownerID models.NamespacedID, snap balance.Snapshot, at time.Time) (engine.RunResult, error) {
 	var def engine.RunResult
-	m.logger.Debug("getting balance of owner since snapshot", "owner", ownerID.ID, "since", snap.At, "at", at)
+	m.Logger.Debug("getting balance of owner since snapshot", "owner", ownerID.ID, "since", snap.At, "at", at)
 
 	period := timeutil.Period{
 		From: snap.At,
@@ -48,18 +48,18 @@ func (m *connector) GetBalanceSinceSnapshot(ctx context.Context, ownerID models.
 	}
 
 	// get all usage resets between queryied period
-	resetTimesInclusive, err := m.ownerConnector.GetResetTimelineInclusive(ctx, ownerID, period)
+	resetTimesInclusive, err := m.OwnerConnector.GetResetTimelineInclusive(ctx, ownerID, period)
 	if err != nil {
 		return def, fmt.Errorf("failed to get reset times between %s and %s for owner %s: %w", period.From, period.To, ownerID.ID, err)
 	}
 
-	owner, err := m.ownerConnector.DescribeOwner(ctx, ownerID)
+	owner, err := m.OwnerConnector.DescribeOwner(ctx, ownerID)
 	if err != nil {
 		return def, fmt.Errorf("failed to describe owner %s: %w", owner.ID, err)
 	}
 
 	// get all relevant grants
-	grants, err := m.grantRepo.ListActiveGrantsBetween(ctx, ownerID, period.From, period.To)
+	grants, err := m.GrantRepo.ListActiveGrantsBetween(ctx, ownerID, period.From, period.To)
 	if err != nil {
 		return def, fmt.Errorf("failed to list active grants at %s for owner %s: %w", at, ownerID.ID, err)
 	}
@@ -93,12 +93,13 @@ func (m *connector) GetBalanceSinceSnapshot(ctx context.Context, ownerID models.
 	}
 
 	// Let's see if a snapshot should be saved
+	// TODO: it might be the case that we don't save any snapshots as they require a history breakpoint. To solve this,
+	// we should introduce artificial history breakpoints in the engine, but that would result in more streaming.Query calls, so first lets improve the visibility of what's happening.
 	if err := m.snapshotEngineResult(ctx, snapshotParams{
 		grants: grants,
 		owner:  ownerID,
-		runRes: result,
 		before: m.getSnapshotBefore(clock.Now()),
-	}); err != nil {
+	}, result); err != nil {
 		return def, fmt.Errorf("failed to snapshot engine result: %w", err)
 	}
 
@@ -107,7 +108,7 @@ func (m *connector) GetBalanceSinceSnapshot(ctx context.Context, ownerID models.
 }
 
 func (m *connector) GetBalanceAt(ctx context.Context, ownerID models.NamespacedID, at time.Time) (engine.RunResult, error) {
-	m.logger.Debug("getting balance of owner", "owner", ownerID.ID, "at", at)
+	m.Logger.Debug("getting balance of owner", "owner", ownerID.ID, "at", at)
 
 	var def engine.RunResult
 
@@ -126,7 +127,7 @@ func (m *connector) GetBalanceAt(ctx context.Context, ownerID models.NamespacedI
 }
 
 func (m *connector) GetBalanceForPeriod(ctx context.Context, ownerID models.NamespacedID, period timeutil.Period) (engine.RunResult, error) {
-	m.logger.Debug("calculating history for owner", "owner", ownerID.ID, "period", period)
+	m.Logger.Debug("calculating history for owner", "owner", ownerID.ID, "period", period)
 
 	var def engine.RunResult
 
@@ -136,12 +137,12 @@ func (m *connector) GetBalanceForPeriod(ctx context.Context, ownerID models.Name
 	}
 
 	// get all usage resets between queryied period
-	resetTimesInclusive, err := m.ownerConnector.GetResetTimelineInclusive(ctx, ownerID, period)
+	resetTimesInclusive, err := m.OwnerConnector.GetResetTimelineInclusive(ctx, ownerID, period)
 	if err != nil {
 		return def, fmt.Errorf("failed to get reset times between %s and %s for owner %s: %w", period.From, period.To, ownerID.ID, err)
 	}
 
-	owner, err := m.ownerConnector.DescribeOwner(ctx, ownerID)
+	owner, err := m.OwnerConnector.DescribeOwner(ctx, ownerID)
 	if err != nil {
 		return def, fmt.Errorf("failed to describe owner %s: %w", ownerID.ID, err)
 	}
@@ -153,7 +154,7 @@ func (m *connector) GetBalanceForPeriod(ctx context.Context, ownerID models.Name
 	}
 
 	// get all relevant grants
-	grants, err := m.grantRepo.ListActiveGrantsBetween(ctx, ownerID, res.Snapshot.At, period.To)
+	grants, err := m.GrantRepo.ListActiveGrantsBetween(ctx, ownerID, res.Snapshot.At, period.To)
 	if err != nil {
 		return def, err
 	}
@@ -192,7 +193,7 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, ownerID models.Names
 		return nil, models.NewGenericValidationError(fmt.Errorf("cannot reset at %s in the future", params.At))
 	}
 
-	owner, err := m.ownerConnector.DescribeOwner(ctx, ownerID)
+	owner, err := m.OwnerConnector.DescribeOwner(ctx, ownerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to describe owner %s: %w", ownerID.ID, err)
 	}
@@ -200,7 +201,7 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, ownerID models.Names
 	at := params.At.Truncate(owner.Meter.WindowSize.Duration())
 
 	// check if reset is possible (not before current period)
-	periodStart, err := m.ownerConnector.GetUsagePeriodStartAt(ctx, ownerID, clock.Now())
+	periodStart, err := m.OwnerConnector.GetUsagePeriodStartAt(ctx, ownerID, clock.Now())
 	if err != nil {
 		if _, ok := err.(*grant.OwnerNotFoundError); ok {
 			return nil, err
@@ -211,7 +212,7 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, ownerID models.Names
 		return nil, models.NewGenericValidationError(fmt.Errorf("reset at %s is before current usage period start %s", at, periodStart))
 	}
 
-	resetsSinceTime, err := m.ownerConnector.GetResetTimelineInclusive(ctx, ownerID, timeutil.Period{From: at, To: clock.Now()})
+	resetsSinceTime, err := m.OwnerConnector.GetResetTimelineInclusive(ctx, ownerID, timeutil.Period{From: at, To: clock.Now()})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get reset times since %s for owner %s: %w", at, ownerID.ID, err)
 	}
@@ -232,7 +233,7 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, ownerID models.Names
 	}
 
 	// get all usage resets between queryied period
-	resetTimesInclusive, err := m.ownerConnector.GetResetTimelineInclusive(ctx, ownerID, period)
+	resetTimesInclusive, err := m.OwnerConnector.GetResetTimelineInclusive(ctx, ownerID, period)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get reset times between %s and %s for owner %s: %w", period.From, period.To, ownerID.ID, err)
 	}
@@ -245,7 +246,7 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, ownerID models.Names
 	resetBehavior := owner.ResetBehavior
 	resetBehavior.PreserveOverage = params.PreserveOverage
 
-	grants, err := m.grantRepo.ListActiveGrantsBetween(ctx, ownerID, bal.At, at)
+	grants, err := m.GrantRepo.ListActiveGrantsBetween(ctx, ownerID, bal.At, at)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list active grants at %s for owner %s: %w", at, ownerID.ID, err)
 	}
@@ -276,25 +277,26 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, ownerID models.Names
 		return nil, fmt.Errorf("failed to calculate balance for reset: %w", err)
 	}
 
-	// Some grants in the snapshot might have been terminated at the reset time, in which case they're irrelevant for the next period
-	startingSnap := res.Snapshot
-	err = m.removeInactiveGrantsFromSnapshotAt(&startingSnap, grants, at)
-	if err != nil {
-		return nil, fmt.Errorf("failed to remove inactive grants from snapshot: %w", err)
-	}
+	snap := res.Snapshot
 
-	_, err = transaction.Run(ctx, m.transactionManager, func(ctx context.Context) (*balance.Snapshot, error) {
-		err = m.ownerConnector.LockOwnerForTx(ctx, ownerID)
+	_, err = transaction.Run(ctx, m.TransactionManager, func(ctx context.Context) (*balance.Snapshot, error) {
+		err = m.OwnerConnector.LockOwnerForTx(ctx, ownerID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to lock owner %s: %w", ownerID.ID, err)
 		}
 
-		err = m.balanceSnapshotService.Save(ctx, ownerID, []balance.Snapshot{startingSnap})
+		// Let's save the snapshot
+		snap, err = m.saveSnapshot(ctx, snapshotParams{
+			grants: grants,
+			owner:  ownerID,
+			before: at,
+		}, snap)
 		if err != nil {
-			return nil, fmt.Errorf("failed to save balance for owner %s at %s: %w", ownerID.ID, at, err)
+			return nil, fmt.Errorf("failed to save snapshot: %w", err)
 		}
 
-		err = m.ownerConnector.EndCurrentUsagePeriod(ctx, ownerID, grant.EndCurrentUsagePeriodParams{
+		// Let's end the current usage period
+		err = m.OwnerConnector.EndCurrentUsagePeriod(ctx, ownerID, grant.EndCurrentUsagePeriodParams{
 			At:           at,
 			RetainAnchor: params.RetainAnchor,
 		})
@@ -308,5 +310,5 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, ownerID models.Names
 		return nil, err
 	}
 
-	return &startingSnap, nil
+	return &snap, nil
 }

--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/credit/engine"
 	"github.com/openmeterio/openmeter/openmeter/credit/grant"
 	"github.com/openmeterio/openmeter/pkg/clock"
-	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -23,6 +22,8 @@ type ResetUsageForOwnerParams struct {
 
 // Generic connector for balance related operations.
 type BalanceConnector interface {
+	// GetBalanceSinceSnapshot returns the result of the engine.Run since a given snapshot.
+	GetBalanceSinceSnapshot(ctx context.Context, ownerID models.NamespacedID, snap balance.Snapshot, at time.Time) (engine.RunResult, error)
 	// GetBalanceAt returns the result of the engine.Run at a given time.
 	// It tries to minimize execution cost by calculating from the latest valid snapshot, thus the length of the returned history WILL NOT be deterministic.
 	GetBalanceAt(ctx context.Context, ownerID models.NamespacedID, at time.Time) (engine.RunResult, error)
@@ -31,25 +32,15 @@ type BalanceConnector interface {
 	GetBalanceForPeriod(ctx context.Context, ownerID models.NamespacedID, period timeutil.Period) (engine.RunResult, error)
 	// ResetUsageForOwner resets the usage for an owner at a given time.
 	ResetUsageForOwner(ctx context.Context, ownerID models.NamespacedID, params ResetUsageForOwnerParams) (balanceAfterReset *balance.Snapshot, err error)
+	// GetLastValidSnapshotAt fetches the last valid snapshot for an owner.
+	GetLastValidSnapshotAt(ctx context.Context, owner models.NamespacedID, at time.Time) (balance.Snapshot, error)
 }
 
 var _ BalanceConnector = &connector{}
 
-func (m *connector) GetBalanceAt(ctx context.Context, ownerID models.NamespacedID, at time.Time) (engine.RunResult, error) {
-	m.logger.Debug("getting balance of owner", "owner", ownerID.ID, "at", at)
-
+func (m *connector) GetBalanceSinceSnapshot(ctx context.Context, ownerID models.NamespacedID, snap balance.Snapshot, at time.Time) (engine.RunResult, error) {
 	var def engine.RunResult
-
-	// To include the current last minute lets round it trunc to the next minute
-	if trunc := at.Truncate(time.Minute); trunc.Before(at) {
-		at = trunc.Add(time.Minute)
-	}
-
-	// get last valid grantbalances
-	snap, err := m.getLastValidBalanceSnapshotForOwnerAt(ctx, ownerID, at)
-	if err != nil {
-		return def, err
-	}
+	m.logger.Debug("getting balance of owner since snapshot", "owner", ownerID.ID, "since", snap.At, "at", at)
 
 	period := timeutil.Period{
 		From: snap.At,
@@ -68,13 +59,13 @@ func (m *connector) GetBalanceAt(ctx context.Context, ownerID models.NamespacedI
 	}
 
 	// get all relevant grants
-	grants, err := m.grantRepo.ListActiveGrantsBetween(ctx, ownerID, snap.At, at)
+	grants, err := m.grantRepo.ListActiveGrantsBetween(ctx, ownerID, period.From, period.To)
 	if err != nil {
 		return def, fmt.Errorf("failed to list active grants at %s for owner %s: %w", at, ownerID.ID, err)
 	}
 	// These grants might not be present in the starting balance so lets fill them
 	// This is only possible in case the grant becomes active exactly at the start of the current period
-	m.populateBalanceSnapshotWithMissingGrantsActiveAt(&snap, grants, snap.At)
+	m.populateBalanceSnapshotWithMissingGrantsActiveAt(&snap, grants, period.From)
 
 	eng, err := m.buildEngineForOwner(ctx, ownerID, period)
 	if err != nil {
@@ -88,7 +79,7 @@ func (m *connector) GetBalanceAt(ctx context.Context, ownerID models.NamespacedI
 			StartingSnapshot: snap,
 			Until:            period.To,
 			ResetBehavior:    owner.ResetBehavior,
-			Resets:           resetTimesInclusive.After(snap.At),
+			Resets:           resetTimesInclusive.After(period.From),
 		},
 	)
 	if err != nil {
@@ -113,6 +104,25 @@ func (m *connector) GetBalanceAt(ctx context.Context, ownerID models.NamespacedI
 
 	// return balance
 	return result, nil
+}
+
+func (m *connector) GetBalanceAt(ctx context.Context, ownerID models.NamespacedID, at time.Time) (engine.RunResult, error) {
+	m.logger.Debug("getting balance of owner", "owner", ownerID.ID, "at", at)
+
+	var def engine.RunResult
+
+	// To include the current last minute lets round it trunc to the next minute
+	if trunc := at.Truncate(time.Minute); trunc.Before(at) {
+		at = trunc.Add(time.Minute)
+	}
+
+	// get last valid grantbalances
+	snap, err := m.GetLastValidSnapshotAt(ctx, ownerID, at)
+	if err != nil {
+		return def, err
+	}
+
+	return m.GetBalanceSinceSnapshot(ctx, ownerID, snap, at)
 }
 
 func (m *connector) GetBalanceForPeriod(ctx context.Context, ownerID models.NamespacedID, period timeutil.Period) (engine.RunResult, error) {
@@ -211,7 +221,7 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, ownerID models.Names
 		return nil, models.NewGenericValidationError(fmt.Errorf("reset at %s is before last reset at %s", at, lastReset))
 	}
 
-	bal, err := m.getLastValidBalanceSnapshotForOwnerAt(ctx, ownerID, at)
+	bal, err := m.GetLastValidSnapshotAt(ctx, ownerID, at)
 	if err != nil {
 		return nil, err
 	}
@@ -274,18 +284,12 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, ownerID models.Names
 	}
 
 	_, err = transaction.Run(ctx, m.transactionManager, func(ctx context.Context) (*balance.Snapshot, error) {
-		//lint:ignore SA1019 we need to use the transaction here
-		tx, err := entutils.GetDriverFromContext(ctx)
-		if err != nil {
-			return nil, err
-		}
-
 		err = m.ownerConnector.LockOwnerForTx(ctx, ownerID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to lock owner %s: %w", ownerID.ID, err)
 		}
 
-		err = m.balanceSnapshotRepo.WithTx(ctx, tx).Save(ctx, ownerID, []balance.Snapshot{startingSnap})
+		err = m.balanceSnapshotService.Save(ctx, ownerID, []balance.Snapshot{startingSnap})
 		if err != nil {
 			return nil, fmt.Errorf("failed to save balance for owner %s at %s: %w", ownerID.ID, at, err)
 		}

--- a/openmeter/credit/balance/balance.go
+++ b/openmeter/credit/balance/balance.go
@@ -68,7 +68,17 @@ func (g Map) ExactlyForGrants(grants []grant.Grant) bool {
 	return true
 }
 
+type SnapshottedUsage struct {
+	Usage float64   `json:"usage"`
+	Since time.Time `json:"since"`
+}
+
+func (s SnapshottedUsage) IsZero() bool {
+	return s.Usage == 0.0 && s.Since.IsZero()
+}
+
 type Snapshot struct {
+	Usage    SnapshottedUsage
 	Balances Map
 	Overage  float64
 	At       time.Time

--- a/openmeter/credit/balance/repository.go
+++ b/openmeter/credit/balance/repository.go
@@ -5,17 +5,14 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type SnapshotRepo interface {
 	InvalidateAfter(ctx context.Context, owner models.NamespacedID, at time.Time) error
+	// The returned Snapshot might not have usage data.
 	GetLatestValidAt(ctx context.Context, owner models.NamespacedID, at time.Time) (Snapshot, error)
 	Save(ctx context.Context, owner models.NamespacedID, balances []Snapshot) error
-
-	entutils.TxCreator
-	entutils.TxUser[SnapshotRepo]
 }
 
 // No balance has been saved since start of measurement for the owner

--- a/openmeter/credit/balance/service.go
+++ b/openmeter/credit/balance/service.go
@@ -1,0 +1,89 @@
+package balance
+
+import (
+	"context"
+	"time"
+
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+type SnapshotService interface {
+	InvalidateAfter(ctx context.Context, owner models.NamespacedID, at time.Time) error
+	GetLatestValidAt(ctx context.Context, owner models.NamespacedID, at time.Time) (Snapshot, error)
+	Save(ctx context.Context, owner models.NamespacedID, balances []Snapshot) error
+	// To make sure repo doesn't implement the service interface
+	service()
+}
+
+type SnapshotServiceConfig struct {
+	OwnerConnector     grant.OwnerConnector
+	StreamingConnector streaming.Connector
+	Repo               SnapshotRepo
+}
+
+type service struct {
+	UsageQuerier UsageQuerier
+	SnapshotServiceConfig
+}
+
+func NewSnapshotService(conf SnapshotServiceConfig) SnapshotService {
+	return &service{
+		SnapshotServiceConfig: conf,
+		// We build a custom UsageQuerier for our usecase here
+		UsageQuerier: NewUsageQuerier(UsageQuerierConfig{
+			StreamingConnector: conf.StreamingConnector,
+			DescribeOwner:      conf.OwnerConnector.DescribeOwner,
+			GetDefaultParams: func(ctx context.Context, ownerID models.NamespacedID) (streaming.QueryParams, error) {
+				owner, err := conf.OwnerConnector.DescribeOwner(ctx, ownerID)
+				if err != nil {
+					return streaming.QueryParams{}, err
+				}
+				return owner.DefaultQueryParams, nil
+			},
+			GetUsagePeriodStartAt: conf.OwnerConnector.GetUsagePeriodStartAt,
+		}),
+	}
+}
+
+func (s *service) service() {}
+
+func (s *service) InvalidateAfter(ctx context.Context, owner models.NamespacedID, at time.Time) error {
+	return s.Repo.InvalidateAfter(ctx, owner, at)
+}
+
+func (s *service) GetLatestValidAt(ctx context.Context, owner models.NamespacedID, at time.Time) (Snapshot, error) {
+	res, err := s.Repo.GetLatestValidAt(ctx, owner, at)
+	if err != nil {
+		return Snapshot{}, err
+	}
+
+	// We have to manually fill in the usage data if it wasn't saved
+	if res.Usage.IsZero() {
+		periodStart, err := s.OwnerConnector.GetUsagePeriodStartAt(ctx, owner, res.At)
+		if err != nil {
+			return Snapshot{}, err
+		}
+
+		usage, err := s.UsageQuerier.QueryUsage(ctx, owner, timeutil.Period{
+			From: periodStart,
+			To:   res.At,
+		})
+		if err != nil {
+			return Snapshot{}, err
+		}
+
+		res.Usage = SnapshottedUsage{
+			Usage: usage,
+			Since: periodStart,
+		}
+	}
+
+	return res, nil
+}
+
+func (s *service) Save(ctx context.Context, owner models.NamespacedID, balances []Snapshot) error {
+	return s.Repo.Save(ctx, owner, balances)
+}

--- a/openmeter/credit/balance/service_test.go
+++ b/openmeter/credit/balance/service_test.go
@@ -1,0 +1,215 @@
+package balance_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/credit/balance"
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+// MockSnapshotRepo is a mock implementation of balance.SnapshotRepo
+type MockSnapshotRepo struct {
+	snapshots map[string]balance.Snapshot
+}
+
+func NewMockSnapshotRepo() *MockSnapshotRepo {
+	return &MockSnapshotRepo{
+		snapshots: make(map[string]balance.Snapshot),
+	}
+}
+
+func (m *MockSnapshotRepo) InvalidateAfter(ctx context.Context, owner models.NamespacedID, at time.Time) error {
+	return nil
+}
+
+func (m *MockSnapshotRepo) GetLatestValidAt(ctx context.Context, owner models.NamespacedID, at time.Time) (balance.Snapshot, error) {
+	key := owner.Namespace + ":" + owner.ID
+	snapshot, ok := m.snapshots[key]
+	if !ok {
+		return balance.Snapshot{}, balance.NoSavedBalanceForOwnerError{
+			Owner: owner,
+			Time:  at,
+		}
+	}
+	return snapshot, nil
+}
+
+func (m *MockSnapshotRepo) Save(ctx context.Context, owner models.NamespacedID, balances []balance.Snapshot) error {
+	key := owner.Namespace + ":" + owner.ID
+	if len(balances) > 0 {
+		m.snapshots[key] = balances[0]
+	}
+	return nil
+}
+
+// MockOwnerConnector is a mock implementation of grant.OwnerConnector
+type MockOwnerConnector struct {
+	usagePeriodStartAt time.Time
+	meterSlug          string
+}
+
+func NewMockOwnerConnector(usagePeriodStartAt time.Time, meterSlug string) *MockOwnerConnector {
+	return &MockOwnerConnector{
+		usagePeriodStartAt: usagePeriodStartAt,
+		meterSlug:          meterSlug,
+	}
+}
+
+func (m *MockOwnerConnector) DescribeOwner(ctx context.Context, id models.NamespacedID) (grant.Owner, error) {
+	return grant.Owner{
+		NamespacedID: id,
+		Meter: meter.Meter{
+			Key:         m.meterSlug,
+			Aggregation: meter.MeterAggregationSum,
+		},
+		DefaultQueryParams: streaming.QueryParams{
+			FilterSubject: []string{"subject1"},
+		},
+	}, nil
+}
+
+func (m *MockOwnerConnector) GetResetTimelineInclusive(ctx context.Context, id models.NamespacedID, period timeutil.Period) (timeutil.SimpleTimeline, error) {
+	return timeutil.SimpleTimeline{}, nil
+}
+
+func (m *MockOwnerConnector) GetUsagePeriodStartAt(ctx context.Context, id models.NamespacedID, at time.Time) (time.Time, error) {
+	return m.usagePeriodStartAt, nil
+}
+
+func (m *MockOwnerConnector) GetStartOfMeasurement(ctx context.Context, id models.NamespacedID) (time.Time, error) {
+	return m.usagePeriodStartAt, nil
+}
+
+func (m *MockOwnerConnector) EndCurrentUsagePeriod(ctx context.Context, id models.NamespacedID, params grant.EndCurrentUsagePeriodParams) error {
+	return nil
+}
+
+func (m *MockOwnerConnector) LockOwnerForTx(ctx context.Context, id models.NamespacedID) error {
+	return nil
+}
+
+func TestGetLatestValidAt(t *testing.T) {
+	// Common setup
+	ctx := context.Background()
+	now := time.Now().UTC()
+	periodStart := now.Add(-24 * time.Hour)
+	meterSlug := "test-meter"
+
+	// Create owner
+	owner := models.NamespacedID{
+		Namespace: "test-namespace",
+		ID:        "test-owner",
+	}
+
+	t.Run("Should fill usage if snapshot has zero usage", func(t *testing.T) {
+		// Create mock streaming connector
+		streamingConnector := testutils.NewMockStreamingConnector(t)
+
+		// Add usage data to the mock streaming connector
+		streamingConnector.AddSimpleEvent(meterSlug, 100.0, now.Add(-12*time.Hour))
+
+		// Create mock snapshot repo with a snapshot that has zero usage
+		mockRepo := NewMockSnapshotRepo()
+		mockRepo.snapshots[owner.Namespace+":"+owner.ID] = balance.Snapshot{
+			Usage:    balance.SnapshottedUsage{}, // Zero usage
+			Balances: balance.Map{"grant1": 1000.0},
+			At:       now.Add(-1 * time.Hour),
+		}
+
+		// Create mock owner connector
+		mockOwnerConnector := NewMockOwnerConnector(periodStart, meterSlug)
+
+		// Create the service
+		service := balance.NewSnapshotService(balance.SnapshotServiceConfig{
+			OwnerConnector:     mockOwnerConnector,
+			StreamingConnector: streamingConnector,
+			Repo:               mockRepo,
+		})
+
+		// Test
+		snapshot, err := service.GetLatestValidAt(ctx, owner, now)
+
+		// Verify
+		require.NoError(t, err)
+		assert.Equal(t, 100.0, snapshot.Usage.Usage, "Usage should be filled with the value from streaming connector")
+		assert.Equal(t, periodStart, snapshot.Usage.Since, "Usage since should be set to the period start")
+		assert.Equal(t, 1000.0, snapshot.Balances["grant1"], "Balance should remain unchanged")
+	})
+
+	t.Run("Should preserve existing usage if snapshot already has usage data", func(t *testing.T) {
+		// Create mock streaming connector
+		streamingConnector := testutils.NewMockStreamingConnector(t)
+
+		// Add usage data to the mock streaming connector
+		streamingConnector.AddSimpleEvent(meterSlug, 100.0, now.Add(-12*time.Hour))
+
+		// Create mock snapshot repo with a snapshot that already has usage data
+		mockRepo := NewMockSnapshotRepo()
+		mockRepo.snapshots[owner.Namespace+":"+owner.ID] = balance.Snapshot{
+			Usage: balance.SnapshottedUsage{
+				Usage: 50.0,
+				Since: periodStart,
+			},
+			Balances: balance.Map{"grant1": 1000.0},
+			At:       now.Add(-1 * time.Hour),
+		}
+
+		// Create mock owner connector
+		mockOwnerConnector := NewMockOwnerConnector(periodStart, meterSlug)
+
+		// Create the service
+		service := balance.NewSnapshotService(balance.SnapshotServiceConfig{
+			OwnerConnector:     mockOwnerConnector,
+			StreamingConnector: streamingConnector,
+			Repo:               mockRepo,
+		})
+
+		// Test
+		snapshot, err := service.GetLatestValidAt(ctx, owner, now)
+
+		// Verify
+		require.NoError(t, err)
+		assert.Equal(t, 50.0, snapshot.Usage.Usage, "Usage should remain unchanged")
+		assert.Equal(t, periodStart, snapshot.Usage.Since, "Usage since should remain unchanged")
+		assert.Equal(t, 1000.0, snapshot.Balances["grant1"], "Balance should remain unchanged")
+	})
+
+	t.Run("Should return error if no snapshot exists", func(t *testing.T) {
+		// Create mock streaming connector
+		streamingConnector := testutils.NewMockStreamingConnector(t)
+
+		// Add usage data to the mock streaming connector
+		streamingConnector.AddSimpleEvent(meterSlug, 100.0, now.Add(-12*time.Hour))
+
+		// Create empty mock snapshot repo (no snapshots)
+		mockRepo := NewMockSnapshotRepo()
+
+		// Create mock owner connector
+		mockOwnerConnector := NewMockOwnerConnector(periodStart, meterSlug)
+
+		// Create the service
+		service := balance.NewSnapshotService(balance.SnapshotServiceConfig{
+			OwnerConnector:     mockOwnerConnector,
+			StreamingConnector: streamingConnector,
+			Repo:               mockRepo,
+		})
+
+		// Test
+		_, err := service.GetLatestValidAt(ctx, owner, now)
+
+		// Verify
+		require.Error(t, err)
+		_, isNoSavedBalanceErr := err.(balance.NoSavedBalanceForOwnerError)
+		assert.True(t, isNoSavedBalanceErr, "Expected NoSavedBalanceForOwnerError")
+	})
+}

--- a/openmeter/credit/balance/usage.go
+++ b/openmeter/credit/balance/usage.go
@@ -1,0 +1,134 @@
+package balance
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+// UsageQuerier is a helper for querying usage for a given owner and period.
+type UsageQuerier interface {
+	QueryUsage(ctx context.Context, ownerID models.NamespacedID, period timeutil.Period) (float64, error)
+}
+
+type UsageQuerierConfig struct {
+	StreamingConnector    streaming.Connector
+	DescribeOwner         func(ctx context.Context, id models.NamespacedID) (grant.Owner, error)
+	GetDefaultParams      func(ctx context.Context, ownerID models.NamespacedID) (streaming.QueryParams, error)
+	GetUsagePeriodStartAt func(ctx context.Context, ownerID models.NamespacedID, at time.Time) (time.Time, error)
+}
+
+type usageQuerier struct {
+	UsageQuerierConfig
+}
+
+func NewUsageQuerier(conf UsageQuerierConfig) UsageQuerier {
+	return &usageQuerier{
+		UsageQuerierConfig: conf,
+	}
+}
+
+var _ UsageQuerier = (*usageQuerier)(nil)
+
+func (u *usageQuerier) QueryUsage(ctx context.Context, ownerID models.NamespacedID, period timeutil.Period) (float64, error) {
+	params, err := u.GetDefaultParams(ctx, ownerID)
+	if err != nil {
+		return 0.0, err
+	}
+
+	owner, err := u.DescribeOwner(ctx, ownerID)
+	if err != nil {
+		return 0.0, err
+	}
+
+	// Let's query the meter based on the aggregation
+	switch owner.Meter.Aggregation {
+	case meter.MeterAggregationUniqueCount:
+		periodStart, err := u.GetUsagePeriodStartAt(ctx, ownerID, period.From)
+		if err != nil {
+			return 0.0, err
+		}
+
+		// To get the UNIQUE_COUNT value between `from` and `to` we need to:
+		// 1. Query between the period start and `to` to get the unique count at `to`
+		// 2. Query between the period start and `from` to get the unique count at `from`
+		// 3. Subtract the two values
+		params.From = &periodStart
+		params.To = &period.To
+
+		var valueTo float64 = 0.0
+		var valueFrom float64 = 0.0
+
+		if !periodStart.Equal(period.To) {
+			rows, err := u.StreamingConnector.QueryMeter(ctx, ownerID.Namespace, owner.Meter, params)
+			if err != nil {
+				return 0.0, fmt.Errorf("failed to query meter %s: %w", owner.Meter.Key, err)
+			}
+
+			valueTo, err = u.getValueFromRows(rows)
+			if err != nil {
+				return 0.0, err
+			}
+		}
+
+		params.To = &period.From
+
+		// If the two times are different we need to query the value at `from`
+		if !params.From.Equal(*params.To) && !periodStart.Equal(period.From) {
+			rows, err := u.StreamingConnector.QueryMeter(ctx, ownerID.Namespace, owner.Meter, params)
+			if err != nil {
+				return 0.0, fmt.Errorf("failed to query meter %s: %w", owner.Meter.Key, err)
+			}
+
+			valueFrom, err = u.getValueFromRows(rows)
+			if err != nil {
+				return 0.0, err
+			}
+		}
+
+		// Let's do an accurate subsctraction
+		vTo := alpacadecimal.NewFromFloat(valueTo)
+		vFrom := alpacadecimal.NewFromFloat(valueFrom)
+
+		return vTo.Sub(vFrom).InexactFloat64(), nil
+
+	// For SUM and COUNT we can simply query the meter
+	case meter.MeterAggregationSum, meter.MeterAggregationCount:
+		// If the two times are the same we can return 0.0 as there's no usage
+		if period.From.Equal(period.To) {
+			return 0.0, nil
+		}
+
+		params.From = &period.From
+		params.To = &period.To
+
+		// Let's query the meter
+		rows, err := u.StreamingConnector.QueryMeter(ctx, ownerID.Namespace, owner.Meter, params)
+		if err != nil {
+			return 0.0, fmt.Errorf("failed to query meter %s: %w", owner.Meter.Key, err)
+		}
+
+		return u.getValueFromRows(rows)
+	default:
+		return 0.0, fmt.Errorf("unsupported aggregation %s", owner.Meter.Aggregation)
+	}
+}
+
+func (u *usageQuerier) getValueFromRows(rows []meter.MeterQueryRow) (float64, error) {
+	// We expect only one row
+	if len(rows) > 1 {
+		return 0.0, fmt.Errorf("expected 1 row, got %d", len(rows))
+	}
+	if len(rows) == 0 {
+		return 0.0, nil
+	}
+	return rows[0].Value, nil
+}

--- a/openmeter/credit/connector.go
+++ b/openmeter/credit/connector.go
@@ -19,8 +19,8 @@ type CreditConnector interface {
 
 type connector struct {
 	// grants and balance snapshots are managed in this same package
-	grantRepo           grant.Repo
-	balanceSnapshotRepo balance.SnapshotRepo
+	grantRepo              grant.Repo
+	balanceSnapshotService balance.SnapshotService
 	// external dependencies
 	transactionManager transaction.Creator
 	publisher          eventbus.Publisher
@@ -34,7 +34,7 @@ type connector struct {
 
 func NewCreditConnector(
 	grantRepo grant.Repo,
-	balanceSnapshotRepo balance.SnapshotRepo,
+	balanceSnapshotService balance.SnapshotService,
 	ownerConnector grant.OwnerConnector,
 	streamingConnector streaming.Connector,
 	logger *slog.Logger,
@@ -43,11 +43,11 @@ func NewCreditConnector(
 	transactionManager transaction.Creator,
 ) CreditConnector {
 	return &connector{
-		grantRepo:           grantRepo,
-		balanceSnapshotRepo: balanceSnapshotRepo,
-		ownerConnector:      ownerConnector,
-		streamingConnector:  streamingConnector,
-		logger:              logger,
+		grantRepo:              grantRepo,
+		balanceSnapshotService: balanceSnapshotService,
+		ownerConnector:         ownerConnector,
+		streamingConnector:     streamingConnector,
+		logger:                 logger,
 
 		transactionManager: transactionManager,
 

--- a/openmeter/credit/connector.go
+++ b/openmeter/credit/connector.go
@@ -18,48 +18,32 @@ type CreditConnector interface {
 }
 
 type connector struct {
-	// grants and balance snapshots are managed in this same package
-	grantRepo              grant.Repo
-	balanceSnapshotService balance.SnapshotService
-	// external dependencies
-	transactionManager transaction.Creator
-	publisher          eventbus.Publisher
-	ownerConnector     grant.OwnerConnector
-	streamingConnector streaming.Connector
-	logger             *slog.Logger
+	CreditConnectorConfig
+}
+
+type CreditConnectorConfig struct {
+	// services
+	GrantRepo              grant.Repo
+	BalanceSnapshotService balance.SnapshotService
+	OwnerConnector         grant.OwnerConnector
+	StreamingConnector     streaming.Connector
+	Logger                 *slog.Logger
+	Publisher              eventbus.Publisher
+	TransactionManager     transaction.Creator
 	// configuration
-	granularity         time.Duration
-	snapshotGracePeriod isodate.Period
+	Granularity         time.Duration
+	SnapshotGracePeriod isodate.Period
 }
 
 func NewCreditConnector(
-	grantRepo grant.Repo,
-	balanceSnapshotService balance.SnapshotService,
-	ownerConnector grant.OwnerConnector,
-	streamingConnector streaming.Connector,
-	logger *slog.Logger,
-	granularity time.Duration,
-	publisher eventbus.Publisher,
-	transactionManager transaction.Creator,
+	cfg CreditConnectorConfig,
 ) CreditConnector {
 	return &connector{
-		grantRepo:              grantRepo,
-		balanceSnapshotService: balanceSnapshotService,
-		ownerConnector:         ownerConnector,
-		streamingConnector:     streamingConnector,
-		logger:                 logger,
-
-		transactionManager: transactionManager,
-
-		publisher: publisher,
-
-		// TODO: make configurable
-		granularity:         granularity,
-		snapshotGracePeriod: isodate.NewPeriod(0, 0, 1, 0, 0, 0, 0),
+		CreditConnectorConfig: cfg,
 	}
 }
 
 func (c *connector) getSnapshotBefore(at time.Time) time.Time {
-	t, _ := c.snapshotGracePeriod.Negate().AddTo(at)
+	t, _ := c.SnapshotGracePeriod.Negate().AddTo(at)
 	return t
 }

--- a/openmeter/credit/engine/run_test.go
+++ b/openmeter/credit/engine/run_test.go
@@ -181,11 +181,19 @@ func TestEngine(t *testing.T) {
 				// We have report usage so the meter is found
 				use(100.0, t1.Add(time.Hour))
 
+				prevPeriodStart := t1.AddDate(0, 0, -1)
+
+				u := balance.SnapshottedUsage{
+					Since: prevPeriodStart,
+					Usage: 10.0,
+				}
+
 				res, err := eng.Run(
 					context.Background(),
 					engine.RunParams{
 						Grants: []grant.Grant{grant1},
 						StartingSnapshot: balance.Snapshot{
+							Usage: u,
 							Balances: balance.Map{
 								grant1.ID: 100.0,
 							},
@@ -197,6 +205,7 @@ func TestEngine(t *testing.T) {
 				)
 				assert.NoError(t, err)
 				assert.Equal(t, balance.Snapshot{
+					Usage: u, // Should pass through the original usage info
 					Balances: balance.Map{
 						grant1.ID: 100.0,
 					},

--- a/openmeter/credit/grant.go
+++ b/openmeter/credit/grant.go
@@ -81,7 +81,7 @@ func (m *connector) CreateGrant(ctx context.Context, ownerID models.NamespacedID
 		}
 
 		// invalidate snapshots
-		err = m.balanceSnapshotRepo.WithTx(ctx, tx).InvalidateAfter(ctx, ownerID, g.EffectiveAt)
+		err = m.balanceSnapshotService.InvalidateAfter(ctx, ownerID, g.EffectiveAt)
 		if err != nil {
 			return nil, fmt.Errorf("failed to invalidate snapshots after %s: %w", g.EffectiveAt, err)
 		}
@@ -142,7 +142,7 @@ func (m *connector) VoidGrant(ctx context.Context, grantID models.NamespacedID) 
 		}
 
 		// invalidate snapshots
-		err = m.balanceSnapshotRepo.WithTx(ctx, tx).InvalidateAfter(ctx, ownerID, now)
+		err = m.balanceSnapshotService.InvalidateAfter(ctx, ownerID, now)
 		if err != nil {
 			return nil, fmt.Errorf("failed to invalidate snapshots after %s: %w", g.EffectiveAt, err)
 		}

--- a/openmeter/credit/grant.go
+++ b/openmeter/credit/grant.go
@@ -33,7 +33,7 @@ type CreateGrantInput struct {
 }
 
 func (m *connector) CreateGrant(ctx context.Context, ownerID models.NamespacedID, input CreateGrantInput) (*grant.Grant, error) {
-	return transaction.Run(ctx, m.grantRepo, func(ctx context.Context) (*grant.Grant, error) {
+	return transaction.Run(ctx, m.GrantRepo, func(ctx context.Context) (*grant.Grant, error) {
 		tx, err := entutils.GetDriverFromContext(ctx)
 		if err != nil {
 			return nil, err
@@ -41,7 +41,7 @@ func (m *connector) CreateGrant(ctx context.Context, ownerID models.NamespacedID
 
 		// All metering information is stored in windowSize chunks,
 		// so we cannot do accurate calculations unless we follow that same windowing.
-		owner, err := m.ownerConnector.DescribeOwner(ctx, ownerID)
+		owner, err := m.OwnerConnector.DescribeOwner(ctx, ownerID)
 		if err != nil {
 			return nil, err
 		}
@@ -50,7 +50,7 @@ func (m *connector) CreateGrant(ctx context.Context, ownerID models.NamespacedID
 		if input.Recurrence != nil {
 			input.Recurrence.Anchor = input.Recurrence.Anchor.Truncate(granularity)
 		}
-		periodStart, err := m.ownerConnector.GetUsagePeriodStartAt(ctx, ownerID, clock.Now())
+		periodStart, err := m.OwnerConnector.GetUsagePeriodStartAt(ctx, ownerID, clock.Now())
 		if err != nil {
 			return nil, err
 		}
@@ -59,11 +59,11 @@ func (m *connector) CreateGrant(ctx context.Context, ownerID models.NamespacedID
 			return nil, models.NewGenericValidationError(fmt.Errorf("grant effective date %s is before the current usage period %s", input.EffectiveAt, periodStart))
 		}
 
-		err = m.ownerConnector.LockOwnerForTx(ctx, ownerID)
+		err = m.OwnerConnector.LockOwnerForTx(ctx, ownerID)
 		if err != nil {
 			return nil, err
 		}
-		g, err := m.grantRepo.WithTx(ctx, tx).CreateGrant(ctx, grant.RepoCreateInput{
+		g, err := m.GrantRepo.WithTx(ctx, tx).CreateGrant(ctx, grant.RepoCreateInput{
 			OwnerID:          ownerID.ID,
 			Namespace:        ownerID.Namespace,
 			Amount:           input.Amount,
@@ -81,7 +81,7 @@ func (m *connector) CreateGrant(ctx context.Context, ownerID models.NamespacedID
 		}
 
 		// invalidate snapshots
-		err = m.balanceSnapshotService.InvalidateAfter(ctx, ownerID, g.EffectiveAt)
+		err = m.BalanceSnapshotService.InvalidateAfter(ctx, ownerID, g.EffectiveAt)
 		if err != nil {
 			return nil, fmt.Errorf("failed to invalidate snapshots after %s: %w", g.EffectiveAt, err)
 		}
@@ -98,7 +98,7 @@ func (m *connector) CreateGrant(ctx context.Context, ownerID models.NamespacedID
 			Subject:   eventmodels.SubjectKeyAndID{Key: subjectKey},
 		}
 
-		if err := m.publisher.Publish(ctx, event); err != nil {
+		if err := m.Publisher.Publish(ctx, event); err != nil {
 			return nil, err
 		}
 
@@ -108,7 +108,7 @@ func (m *connector) CreateGrant(ctx context.Context, ownerID models.NamespacedID
 
 func (m *connector) VoidGrant(ctx context.Context, grantID models.NamespacedID) error {
 	// can we void grants that have been used?
-	g, err := m.grantRepo.GetGrant(ctx, grantID)
+	g, err := m.GrantRepo.GetGrant(ctx, grantID)
 	if err != nil {
 		return err
 	}
@@ -119,30 +119,30 @@ func (m *connector) VoidGrant(ctx context.Context, grantID models.NamespacedID) 
 
 	ownerID := models.NamespacedID{Namespace: grantID.Namespace, ID: g.OwnerID}
 
-	_, err = transaction.Run(ctx, m.grantRepo, func(ctx context.Context) (*interface{}, error) {
+	_, err = transaction.Run(ctx, m.GrantRepo, func(ctx context.Context) (*interface{}, error) {
 		tx, err := entutils.GetDriverFromContext(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		owner, err := m.ownerConnector.DescribeOwner(ctx, ownerID)
+		owner, err := m.OwnerConnector.DescribeOwner(ctx, ownerID)
 		if err != nil {
 			return nil, err
 		}
 
-		err = m.ownerConnector.LockOwnerForTx(ctx, ownerID)
+		err = m.OwnerConnector.LockOwnerForTx(ctx, ownerID)
 		if err != nil {
 			return nil, err
 		}
 
-		now := clock.Now().Truncate(m.granularity)
-		err = m.grantRepo.WithTx(ctx, tx).VoidGrant(ctx, grantID, now)
+		now := clock.Now().Truncate(m.Granularity)
+		err = m.GrantRepo.WithTx(ctx, tx).VoidGrant(ctx, grantID, now)
 		if err != nil {
 			return nil, err
 		}
 
 		// invalidate snapshots
-		err = m.balanceSnapshotService.InvalidateAfter(ctx, ownerID, now)
+		err = m.BalanceSnapshotService.InvalidateAfter(ctx, ownerID, now)
 		if err != nil {
 			return nil, fmt.Errorf("failed to invalidate snapshots after %s: %w", g.EffectiveAt, err)
 		}
@@ -153,7 +153,7 @@ func (m *connector) VoidGrant(ctx context.Context, grantID models.NamespacedID) 
 			return nil, err
 		}
 
-		return nil, m.publisher.Publish(ctx, grant.VoidedEvent{
+		return nil, m.Publisher.Publish(ctx, grant.VoidedEvent{
 			Grant:     g,
 			Namespace: eventmodels.NamespaceID{ID: ownerID.Namespace},
 			Subject:   eventmodels.SubjectKeyAndID{Key: subjectKey},

--- a/openmeter/credit/helper.go
+++ b/openmeter/credit/helper.go
@@ -162,6 +162,11 @@ func (m *connector) snapshotEngineResult(ctx context.Context, snapParams snapsho
 }
 
 func (m *connector) saveSnapshot(ctx context.Context, params snapshotParams, snap balance.Snapshot) (balance.Snapshot, error) {
+	// Let's validate the timestamp
+	if snap.At.Truncate(m.Granularity) != snap.At {
+		return snap, fmt.Errorf("snapshot timestamp %s is not aligned to granularity %s", snap.At, m.Granularity)
+	}
+
 	if err := m.removeInactiveGrantsFromSnapshotAt(&snap, params.grants, snap.At); err != nil {
 		return snap, fmt.Errorf("failed to remove inactive grants from snapshot: %w", err)
 	}

--- a/openmeter/credit/helper.go
+++ b/openmeter/credit/helper.go
@@ -163,7 +163,7 @@ func (m *connector) snapshotEngineResult(ctx context.Context, snapParams snapsho
 
 func (m *connector) saveSnapshot(ctx context.Context, params snapshotParams, snap balance.Snapshot) (balance.Snapshot, error) {
 	// Let's validate the timestamp
-	if snap.At.Truncate(m.Granularity) != snap.At {
+	if !snap.At.Truncate(m.Granularity).Equal(snap.At) {
 		return snap, fmt.Errorf("snapshot timestamp %s is not aligned to granularity %s", snap.At, m.Granularity)
 	}
 

--- a/openmeter/ent/db/balancesnapshot/balancesnapshot.go
+++ b/openmeter/ent/db/balancesnapshot/balancesnapshot.go
@@ -26,6 +26,8 @@ const (
 	FieldOwnerID = "owner_id"
 	// FieldGrantBalances holds the string denoting the grant_balances field in the database.
 	FieldGrantBalances = "grant_balances"
+	// FieldUsage holds the string denoting the usage field in the database.
+	FieldUsage = "usage"
 	// FieldBalance holds the string denoting the balance field in the database.
 	FieldBalance = "balance"
 	// FieldOverage holds the string denoting the overage field in the database.
@@ -54,6 +56,7 @@ var Columns = []string{
 	FieldDeletedAt,
 	FieldOwnerID,
 	FieldGrantBalances,
+	FieldUsage,
 	FieldBalance,
 	FieldOverage,
 	FieldAt,

--- a/openmeter/ent/db/balancesnapshot/where.go
+++ b/openmeter/ent/db/balancesnapshot/where.go
@@ -355,6 +355,16 @@ func OwnerIDContainsFold(v string) predicate.BalanceSnapshot {
 	return predicate.BalanceSnapshot(sql.FieldContainsFold(FieldOwnerID, v))
 }
 
+// UsageIsNil applies the IsNil predicate on the "usage" field.
+func UsageIsNil() predicate.BalanceSnapshot {
+	return predicate.BalanceSnapshot(sql.FieldIsNull(FieldUsage))
+}
+
+// UsageNotNil applies the NotNil predicate on the "usage" field.
+func UsageNotNil() predicate.BalanceSnapshot {
+	return predicate.BalanceSnapshot(sql.FieldNotNull(FieldUsage))
+}
+
 // BalanceEQ applies the EQ predicate on the "balance" field.
 func BalanceEQ(v float64) predicate.BalanceSnapshot {
 	return predicate.BalanceSnapshot(sql.FieldEQ(FieldBalance, v))

--- a/openmeter/ent/db/balancesnapshot_create.go
+++ b/openmeter/ent/db/balancesnapshot_create.go
@@ -84,6 +84,12 @@ func (bsc *BalanceSnapshotCreate) SetGrantBalances(b balance.Map) *BalanceSnapsh
 	return bsc
 }
 
+// SetUsage sets the "usage" field.
+func (bsc *BalanceSnapshotCreate) SetUsage(bu *balance.SnapshottedUsage) *BalanceSnapshotCreate {
+	bsc.mutation.SetUsage(bu)
+	return bsc
+}
+
 // SetBalance sets the "balance" field.
 func (bsc *BalanceSnapshotCreate) SetBalance(f float64) *BalanceSnapshotCreate {
 	bsc.mutation.SetBalance(f)
@@ -239,6 +245,10 @@ func (bsc *BalanceSnapshotCreate) createSpec() (*BalanceSnapshot, *sqlgraph.Crea
 		_spec.SetField(balancesnapshot.FieldGrantBalances, field.TypeJSON, value)
 		_node.GrantBalances = value
 	}
+	if value, ok := bsc.mutation.Usage(); ok {
+		_spec.SetField(balancesnapshot.FieldUsage, field.TypeJSON, value)
+		_node.Usage = value
+	}
 	if value, ok := bsc.mutation.Balance(); ok {
 		_spec.SetField(balancesnapshot.FieldBalance, field.TypeFloat64, value)
 		_node.Balance = value
@@ -372,6 +382,9 @@ func (u *BalanceSnapshotUpsertOne) UpdateNewValues() *BalanceSnapshotUpsertOne {
 		}
 		if _, exists := u.create.mutation.GrantBalances(); exists {
 			s.SetIgnore(balancesnapshot.FieldGrantBalances)
+		}
+		if _, exists := u.create.mutation.Usage(); exists {
+			s.SetIgnore(balancesnapshot.FieldUsage)
 		}
 		if _, exists := u.create.mutation.Balance(); exists {
 			s.SetIgnore(balancesnapshot.FieldBalance)
@@ -635,6 +648,9 @@ func (u *BalanceSnapshotUpsertBulk) UpdateNewValues() *BalanceSnapshotUpsertBulk
 			}
 			if _, exists := b.mutation.GrantBalances(); exists {
 				s.SetIgnore(balancesnapshot.FieldGrantBalances)
+			}
+			if _, exists := b.mutation.Usage(); exists {
+				s.SetIgnore(balancesnapshot.FieldUsage)
 			}
 			if _, exists := b.mutation.Balance(); exists {
 				s.SetIgnore(balancesnapshot.FieldBalance)

--- a/openmeter/ent/db/balancesnapshot_update.go
+++ b/openmeter/ent/db/balancesnapshot_update.go
@@ -124,6 +124,9 @@ func (bsu *BalanceSnapshotUpdate) sqlSave(ctx context.Context) (n int, err error
 	if bsu.mutation.DeletedAtCleared() {
 		_spec.ClearField(balancesnapshot.FieldDeletedAt, field.TypeTime)
 	}
+	if bsu.mutation.UsageCleared() {
+		_spec.ClearField(balancesnapshot.FieldUsage, field.TypeJSON)
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, bsu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{balancesnapshot.Label}
@@ -269,6 +272,9 @@ func (bsuo *BalanceSnapshotUpdateOne) sqlSave(ctx context.Context) (_node *Balan
 	}
 	if bsuo.mutation.DeletedAtCleared() {
 		_spec.ClearField(balancesnapshot.FieldDeletedAt, field.TypeTime)
+	}
+	if bsuo.mutation.UsageCleared() {
+		_spec.ClearField(balancesnapshot.FieldUsage, field.TypeJSON)
 	}
 	_node = &BalanceSnapshot{config: bsuo.config}
 	_spec.Assign = _node.assignValues

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -205,6 +205,7 @@ var (
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "grant_balances", Type: field.TypeJSON, SchemaType: map[string]string{"postgres": "jsonb"}},
+		{Name: "usage", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "balance", Type: field.TypeFloat64, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "overage", Type: field.TypeFloat64, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "at", Type: field.TypeTime},
@@ -218,7 +219,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "balance_snapshots_entitlements_balance_snapshot",
-				Columns:    []*schema.Column{BalanceSnapshotsColumns[9]},
+				Columns:    []*schema.Column{BalanceSnapshotsColumns[10]},
 				RefColumns: []*schema.Column{EntitlementsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -232,17 +233,17 @@ var (
 			{
 				Name:    "balancesnapshot_namespace_at",
 				Unique:  false,
-				Columns: []*schema.Column{BalanceSnapshotsColumns[1], BalanceSnapshotsColumns[8]},
+				Columns: []*schema.Column{BalanceSnapshotsColumns[1], BalanceSnapshotsColumns[9]},
 			},
 			{
 				Name:    "balancesnapshot_namespace_balance",
 				Unique:  false,
-				Columns: []*schema.Column{BalanceSnapshotsColumns[1], BalanceSnapshotsColumns[6]},
+				Columns: []*schema.Column{BalanceSnapshotsColumns[1], BalanceSnapshotsColumns[7]},
 			},
 			{
 				Name:    "balancesnapshot_namespace_balance_at",
 				Unique:  false,
-				Columns: []*schema.Column{BalanceSnapshotsColumns[1], BalanceSnapshotsColumns[6], BalanceSnapshotsColumns[8]},
+				Columns: []*schema.Column{BalanceSnapshotsColumns[1], BalanceSnapshotsColumns[7], BalanceSnapshotsColumns[9]},
 			},
 		},
 	}

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -4098,6 +4098,7 @@ type BalanceSnapshotMutation struct {
 	updated_at         *time.Time
 	deleted_at         *time.Time
 	grant_balances     *balance.Map
+	usage              **balance.SnapshottedUsage
 	balance            *float64
 	addbalance         *float64
 	overage            *float64
@@ -4438,6 +4439,55 @@ func (m *BalanceSnapshotMutation) ResetGrantBalances() {
 	m.grant_balances = nil
 }
 
+// SetUsage sets the "usage" field.
+func (m *BalanceSnapshotMutation) SetUsage(bu *balance.SnapshottedUsage) {
+	m.usage = &bu
+}
+
+// Usage returns the value of the "usage" field in the mutation.
+func (m *BalanceSnapshotMutation) Usage() (r *balance.SnapshottedUsage, exists bool) {
+	v := m.usage
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldUsage returns the old "usage" field's value of the BalanceSnapshot entity.
+// If the BalanceSnapshot object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BalanceSnapshotMutation) OldUsage(ctx context.Context) (v *balance.SnapshottedUsage, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldUsage is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldUsage requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldUsage: %w", err)
+	}
+	return oldValue.Usage, nil
+}
+
+// ClearUsage clears the value of the "usage" field.
+func (m *BalanceSnapshotMutation) ClearUsage() {
+	m.usage = nil
+	m.clearedFields[balancesnapshot.FieldUsage] = struct{}{}
+}
+
+// UsageCleared returns if the "usage" field was cleared in this mutation.
+func (m *BalanceSnapshotMutation) UsageCleared() bool {
+	_, ok := m.clearedFields[balancesnapshot.FieldUsage]
+	return ok
+}
+
+// ResetUsage resets all changes to the "usage" field.
+func (m *BalanceSnapshotMutation) ResetUsage() {
+	m.usage = nil
+	delete(m.clearedFields, balancesnapshot.FieldUsage)
+}
+
 // SetBalance sets the "balance" field.
 func (m *BalanceSnapshotMutation) SetBalance(f float64) {
 	m.balance = &f
@@ -4660,7 +4710,7 @@ func (m *BalanceSnapshotMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *BalanceSnapshotMutation) Fields() []string {
-	fields := make([]string, 0, 9)
+	fields := make([]string, 0, 10)
 	if m.namespace != nil {
 		fields = append(fields, balancesnapshot.FieldNamespace)
 	}
@@ -4678,6 +4728,9 @@ func (m *BalanceSnapshotMutation) Fields() []string {
 	}
 	if m.grant_balances != nil {
 		fields = append(fields, balancesnapshot.FieldGrantBalances)
+	}
+	if m.usage != nil {
+		fields = append(fields, balancesnapshot.FieldUsage)
 	}
 	if m.balance != nil {
 		fields = append(fields, balancesnapshot.FieldBalance)
@@ -4708,6 +4761,8 @@ func (m *BalanceSnapshotMutation) Field(name string) (ent.Value, bool) {
 		return m.OwnerID()
 	case balancesnapshot.FieldGrantBalances:
 		return m.GrantBalances()
+	case balancesnapshot.FieldUsage:
+		return m.Usage()
 	case balancesnapshot.FieldBalance:
 		return m.Balance()
 	case balancesnapshot.FieldOverage:
@@ -4735,6 +4790,8 @@ func (m *BalanceSnapshotMutation) OldField(ctx context.Context, name string) (en
 		return m.OldOwnerID(ctx)
 	case balancesnapshot.FieldGrantBalances:
 		return m.OldGrantBalances(ctx)
+	case balancesnapshot.FieldUsage:
+		return m.OldUsage(ctx)
 	case balancesnapshot.FieldBalance:
 		return m.OldBalance(ctx)
 	case balancesnapshot.FieldOverage:
@@ -4791,6 +4848,13 @@ func (m *BalanceSnapshotMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetGrantBalances(v)
+		return nil
+	case balancesnapshot.FieldUsage:
+		v, ok := value.(*balance.SnapshottedUsage)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetUsage(v)
 		return nil
 	case balancesnapshot.FieldBalance:
 		v, ok := value.(float64)
@@ -4873,6 +4937,9 @@ func (m *BalanceSnapshotMutation) ClearedFields() []string {
 	if m.FieldCleared(balancesnapshot.FieldDeletedAt) {
 		fields = append(fields, balancesnapshot.FieldDeletedAt)
 	}
+	if m.FieldCleared(balancesnapshot.FieldUsage) {
+		fields = append(fields, balancesnapshot.FieldUsage)
+	}
 	return fields
 }
 
@@ -4889,6 +4956,9 @@ func (m *BalanceSnapshotMutation) ClearField(name string) error {
 	switch name {
 	case balancesnapshot.FieldDeletedAt:
 		m.ClearDeletedAt()
+		return nil
+	case balancesnapshot.FieldUsage:
+		m.ClearUsage()
 		return nil
 	}
 	return fmt.Errorf("unknown BalanceSnapshot nullable field %s", name)
@@ -4915,6 +4985,9 @@ func (m *BalanceSnapshotMutation) ResetField(name string) error {
 		return nil
 	case balancesnapshot.FieldGrantBalances:
 		m.ResetGrantBalances()
+		return nil
+	case balancesnapshot.FieldUsage:
+		m.ResetUsage()
 		return nil
 	case balancesnapshot.FieldBalance:
 		m.ResetBalance()

--- a/openmeter/ent/schema/balance_snapshot.go
+++ b/openmeter/ent/schema/balance_snapshot.go
@@ -30,6 +30,9 @@ func (BalanceSnapshot) Fields() []ent.Field {
 		field.JSON("grant_balances", balance.Map{}).Immutable().SchemaType(map[string]string{
 			dialect.Postgres: "jsonb",
 		}),
+		field.JSON("usage", &balance.SnapshottedUsage{}).Immutable().Optional().SchemaType(map[string]string{
+			dialect.Postgres: "jsonb",
+		}),
 		field.Float("balance").Immutable().SchemaType(map[string]string{
 			dialect.Postgres: "numeric",
 		}),

--- a/openmeter/entitlement/metered/balance_test.go
+++ b/openmeter/entitlement/metered/balance_test.go
@@ -321,6 +321,132 @@ func TestGetEntitlementBalance(t *testing.T) {
 			},
 		},
 		{
+			name: "Should save snapshot with correct usage data for period",
+			run: func(t *testing.T, connector meteredentitlement.Connector, deps *dependencies) {
+				ctx := context.Background()
+				startTime := getAnchor(t)
+				clock.SetTime(startTime)
+				defer clock.ResetTime()
+
+				// register usage so meter is found
+				deps.streamingConnector.AddSimpleEvent(meterSlug, 1, startTime.AddDate(5, 0, 0)) // far in future
+
+				// create featute in db
+				feature, err := deps.featureRepo.CreateFeature(ctx, exampleFeature)
+				assert.NoError(t, err)
+
+				// create entitlement in db
+				inp := getEntitlement(t, feature)
+				inp.MeasureUsageFrom = &startTime
+				inp.UsagePeriod.Interval = timeutil.RecurrencePeriodMonth
+				entitlement, err := deps.entitlementRepo.CreateEntitlement(ctx, inp)
+				assert.NoError(t, err)
+
+				queryTime := startTime.AddDate(0, 1, 9) // will fall in next usageperiod
+
+				// issue grants
+				owner := models.NamespacedID{
+					Namespace: namespace,
+					ID:        entitlement.ID,
+				}
+
+				g1, err := deps.grantRepo.CreateGrant(ctx, grant.RepoCreateInput{
+					OwnerID:          entitlement.ID,
+					Namespace:        namespace,
+					Amount:           1000,
+					ResetMaxRollover: 1000,
+					Priority:         1,
+					EffectiveAt:      startTime,
+					ExpiresAt:        startTime.AddDate(1, 0, 0), // far future
+				})
+				assert.NoError(t, err)
+
+				// add a balance snapshot
+				err = deps.balanceSnapshotService.Save(
+					ctx,
+					owner, []balance.Snapshot{
+						{
+							Usage: balance.SnapshottedUsage{
+								Since: startTime,
+								Usage: 0,
+							},
+							Balances: balance.Map{
+								g1.ID: 1000,
+							},
+							Overage: 0,
+							At:      g1.EffectiveAt,
+						},
+					})
+				assert.NoError(t, err)
+
+				// register usage for meter & feature in first period
+				deps.streamingConnector.AddSimpleEvent(meterSlug, 200, g1.EffectiveAt.Add(time.Minute))
+
+				// register usage for meter & feature in second period
+				clock.SetTime(startTime.AddDate(0, 1, 1))
+				deps.streamingConnector.AddSimpleEvent(meterSlug, 200, startTime.AddDate(0, 1, 1))
+
+				// We need another event so there's a history breakpoint. Let's create another grant
+				g2, err := deps.grantRepo.CreateGrant(ctx, grant.RepoCreateInput{
+					OwnerID:          entitlement.ID,
+					Namespace:        namespace,
+					Amount:           1000,
+					ResetMaxRollover: 1000,
+					Priority:         10,
+					EffectiveAt:      startTime.AddDate(0, 1, 2), // After the second round of usage is in
+					ExpiresAt:        startTime.AddDate(1, 0, 0),
+				})
+				assert.NoError(t, err)
+
+				// register usage for meter & feature in second period after grant
+				deps.streamingConnector.AddSimpleEvent(meterSlug, 200, startTime.AddDate(0, 1, 3))
+
+				clock.SetTime(queryTime)
+
+				// get last vaild snapshot
+				snap1, err := deps.balanceSnapshotService.GetLatestValidAt(ctx, owner, queryTime)
+				assert.NoError(t, err)
+				// Should be the first and only snapshot we created
+				assert.Equal(t, balance.Snapshot{
+					Usage: balance.SnapshottedUsage{
+						Since: startTime,
+						Usage: 0,
+					},
+					Balances: balance.Map{
+						g1.ID: 1000,
+					},
+					Overage: 0,
+					At:      g1.EffectiveAt,
+				}, snap1)
+
+				entBalance, err := connector.GetEntitlementBalance(ctx, models.NamespacedID{Namespace: namespace, ID: entitlement.ID}, queryTime)
+				assert.NoError(t, err)
+
+				// validate balance calc for good measure
+				assert.Equal(t, 400.0, entBalance.UsageInPeriod)
+				assert.Equal(t, 1400.0, entBalance.Balance)
+				assert.Equal(t, 0.0, entBalance.Overage)
+
+				snap2, err := deps.balanceSnapshotService.GetLatestValidAt(ctx, owner, queryTime)
+				assert.NoError(t, err)
+
+				// check snapshots
+				assert.NotEqual(t, snap1.At, snap2.At)
+				assert.Equal(t, balance.Snapshot{
+					Usage: balance.SnapshottedUsage{
+						Since: startTime.AddDate(0, 1, 0), // The programmatic reset time
+						Usage: 200,                        // Total usage in second period so far
+					},
+					Balances: balance.Map{
+						g1.ID: 600,
+						g2.ID: 1000,
+					},
+					Overage: 0,
+					At:      g2.EffectiveAt, // Our period start time
+				}, snap2)
+			},
+		},
+		{
 			name: "Should not save the same snapshot over and over again",
 			run: func(t *testing.T, connector meteredentitlement.Connector, deps *dependencies) {
 				ctx := context.Background()

--- a/openmeter/entitlement/metered/lateevents_test.go
+++ b/openmeter/entitlement/metered/lateevents_test.go
@@ -99,7 +99,12 @@ func TestGetEntitlementBalanceConsistency(t *testing.T) {
 				NamespacedModel: models.NamespacedModel{
 					Namespace: namespace,
 				},
-				ID: "managed-resource-1",
+				ID:   "managed-resource-1",
+				Name: "managed-resource-1",
+				ManagedModel: models.ManagedModel{
+					CreatedAt: testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
+					UpdatedAt: testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
+				},
 			},
 			Aggregation: meter.MeterAggregationSum,
 			WindowSize:  meter.WindowSizeMinute,

--- a/openmeter/entitlement/metered/lateevents_test.go
+++ b/openmeter/entitlement/metered/lateevents_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/credit"
 	credit_postgres_adapter "github.com/openmeterio/openmeter/openmeter/credit/adapter"
+	"github.com/openmeterio/openmeter/openmeter/credit/balance"
 	"github.com/openmeterio/openmeter/openmeter/credit/engine"
 	"github.com/openmeterio/openmeter/openmeter/credit/grant"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
@@ -139,11 +140,17 @@ func TestGetEntitlementBalanceConsistency(t *testing.T) {
 			testLogger,
 		)
 
+		balanceSnapshotService := balance.NewSnapshotService(balance.SnapshotServiceConfig{
+			OwnerConnector:     ownerConnector,
+			StreamingConnector: streamingConnector,
+			Repo:               balanceSnapshotRepo,
+		})
+
 		transactionManager := enttx.NewCreator(dbClient)
 
 		creditConnector := credit.NewCreditConnector(
 			grantRepo,
-			balanceSnapshotRepo,
+			balanceSnapshotService,
 			ownerConnector,
 			streamingConnector,
 			testLogger,
@@ -176,7 +183,7 @@ func TestGetEntitlementBalanceConsistency(t *testing.T) {
 			entitlementRepo,
 			usageResetRepo,
 			grantRepo,
-			balanceSnapshotRepo,
+			balanceSnapshotService,
 			inconsistentCreditConnector,
 			ownerConnector,
 			streamingConnector,

--- a/openmeter/entitlement/metered/lateevents_test.go
+++ b/openmeter/entitlement/metered/lateevents_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/convert"
+	"github.com/openmeterio/openmeter/pkg/isodate"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -149,14 +150,17 @@ func TestGetEntitlementBalanceConsistency(t *testing.T) {
 		transactionManager := enttx.NewCreator(dbClient)
 
 		creditConnector := credit.NewCreditConnector(
-			grantRepo,
-			balanceSnapshotService,
-			ownerConnector,
-			streamingConnector,
-			testLogger,
-			time.Minute,
-			mockPublisher,
-			transactionManager,
+			credit.CreditConnectorConfig{
+				GrantRepo:              grantRepo,
+				BalanceSnapshotService: balanceSnapshotService,
+				OwnerConnector:         ownerConnector,
+				StreamingConnector:     streamingConnector,
+				Logger:                 testLogger,
+				Granularity:            time.Minute,
+				Publisher:              mockPublisher,
+				SnapshotGracePeriod:    isodate.MustParse(t, "P1W"),
+				TransactionManager:     transactionManager,
+			},
 		)
 
 		inconsistentCreditConnector := &inconsistentCreditConnector{

--- a/openmeter/entitlement/metered/reset_test.go
+++ b/openmeter/entitlement/metered/reset_test.go
@@ -233,7 +233,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 					ID:        ent.ID,
 				}
 
-				err = deps.balanceSnapshotRepo.Save(ctx, models.NamespacedID{
+				err = deps.balanceSnapshotService.Save(ctx, models.NamespacedID{
 					Namespace: namespace,
 					ID:        ent.ID,
 				}, []balance.Snapshot{
@@ -249,7 +249,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 				clock.ResetTime()
 
 				// for sanity check that snapshot was created (at g1.EffectiveAt)
-				snap, err := deps.balanceSnapshotRepo.GetLatestValidAt(ctx, owner, queryTime)
+				snap, err := deps.balanceSnapshotService.GetLatestValidAt(ctx, owner, queryTime)
 				assert.NoError(t, err)
 
 				assert.Equal(t, g1.EffectiveAt, snap.At)

--- a/openmeter/entitlement/metered/utils_test.go
+++ b/openmeter/entitlement/metered/utils_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils/entdriver"
 	"github.com/openmeterio/openmeter/pkg/framework/pgdriver"
+	"github.com/openmeterio/openmeter/pkg/isodate"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -127,14 +128,17 @@ func setupConnector(t *testing.T) (meteredentitlement.Connector, *dependencies) 
 	})
 
 	creditConnector := credit.NewCreditConnector(
-		grantRepo,
-		snapshotService,
-		ownerConnector,
-		streamingConnector,
-		testLogger,
-		time.Minute,
-		mockPublisher,
-		transactionManager,
+		credit.CreditConnectorConfig{
+			GrantRepo:              grantRepo,
+			BalanceSnapshotService: snapshotService,
+			OwnerConnector:         ownerConnector,
+			StreamingConnector:     streamingConnector,
+			Logger:                 testLogger,
+			Granularity:            time.Minute,
+			Publisher:              mockPublisher,
+			SnapshotGracePeriod:    isodate.MustParse(t, "P1W"),
+			TransactionManager:     transactionManager,
+		},
 	)
 
 	connector := meteredentitlement.NewMeteredEntitlementConnector(

--- a/openmeter/registry/builder/entitlement.go
+++ b/openmeter/registry/builder/entitlement.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/credit"
 	creditpgadapter "github.com/openmeterio/openmeter/openmeter/credit/adapter"
+	"github.com/openmeterio/openmeter/openmeter/credit/balance"
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
 	"github.com/openmeterio/openmeter/openmeter/entitlement"
@@ -48,9 +49,15 @@ func GetEntitlementRegistry(opts EntitlementOptions) *registry.Entitlement {
 	)
 	transactionManager := enttx.NewCreator(opts.DatabaseClient)
 
+	balanceSnapshotService := balance.NewSnapshotService(balance.SnapshotServiceConfig{
+		OwnerConnector:     entitlementOwnerConnector,
+		StreamingConnector: opts.StreamingConnector,
+		Repo:               balanceSnashotDBAdapter,
+	})
+
 	creditConnector := credit.NewCreditConnector(
 		grantDBAdapter,
-		balanceSnashotDBAdapter,
+		balanceSnapshotService,
 		entitlementOwnerConnector,
 		opts.StreamingConnector,
 		opts.Logger,

--- a/openmeter/subscription/testutils/customer.go
+++ b/openmeter/subscription/testutils/customer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/lo"
 
+	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customeradapter "github.com/openmeterio/openmeter/openmeter/customer/adapter"
 	customerservice "github.com/openmeterio/openmeter/openmeter/customer/service"
@@ -18,6 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/isodate"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -69,6 +71,9 @@ func NewCustomerService(t *testing.T, dbDeps *DBDeps) customer.Service {
 		Logger:             testutils.NewLogger(t),
 		MeterService:       meterAdapter,
 		Publisher:          eventbus.NewMock(t),
+		EntitlementsConfiguration: config.EntitlementsConfiguration{
+			GracePeriod: isodate.String("P1D"),
+		},
 	})
 
 	customerAdapter := NewCustomerAdapter(t, dbDeps)

--- a/openmeter/subscription/testutils/service.go
+++ b/openmeter/subscription/testutils/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	meteradapter "github.com/openmeterio/openmeter/openmeter/meter/mockadapter"
@@ -22,6 +23,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/subscription/service"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/isodate"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -75,6 +77,9 @@ func NewService(t *testing.T, dbDeps *DBDeps) (services, ExposedServiceDeps) {
 		Logger:             logger,
 		MeterService:       meterAdapter,
 		Publisher:          eventbus.NewMock(t),
+		EntitlementsConfiguration: config.EntitlementsConfiguration{
+			GracePeriod: isodate.String("P1D"),
+		},
 	})
 
 	entitlementAdapter := subscriptionentitlement.NewSubscriptionEntitlementAdapter(

--- a/test/app/stripe/testenv.go
+++ b/test/app/stripe/testenv.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/app"
 	appadapter "github.com/openmeterio/openmeter/openmeter/app/adapter"
 	appservice "github.com/openmeterio/openmeter/openmeter/app/service"
@@ -23,6 +24,7 @@ import (
 	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/isodate"
 	apptest "github.com/openmeterio/openmeter/test/app"
 )
 
@@ -124,6 +126,9 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 		Logger:             logger,
 		MeterService:       meterAdapter,
 		Publisher:          eventbus.NewMock(t),
+		EntitlementsConfiguration: config.EntitlementsConfiguration{
+			GracePeriod: isodate.String("P1D"),
+		},
 	})
 
 	customerService, err := customerservice.New(customerservice.Config{

--- a/test/app/testenv.go
+++ b/test/app/testenv.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/app"
 	appadapter "github.com/openmeterio/openmeter/openmeter/app/adapter"
 	appservice "github.com/openmeterio/openmeter/openmeter/app/service"
@@ -29,6 +30,7 @@ import (
 	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/isodate"
 	"github.com/openmeterio/openmeter/tools/migrate"
 )
 
@@ -101,6 +103,9 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 		Logger:             logger,
 		MeterService:       meterAdapter,
 		Publisher:          eventbus.NewMock(t),
+		EntitlementsConfiguration: config.EntitlementsConfiguration{
+			GracePeriod: isodate.String("P1D"),
+		},
 	})
 
 	customerService, err := customerservice.New(customerservice.Config{
@@ -230,6 +235,9 @@ func InitBillingService(t *testing.T, ctx context.Context, in InitBillingService
 		Logger:             slog.Default(),
 		MeterService:       meterAdapter,
 		Publisher:          eventbus.NewMock(t),
+		EntitlementsConfiguration: config.EntitlementsConfiguration{
+			GracePeriod: isodate.String("P1D"),
+		},
 	})
 
 	// Feature

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/app"
 	appadapter "github.com/openmeterio/openmeter/openmeter/app/adapter"
 	appsandbox "github.com/openmeterio/openmeter/openmeter/app/sandbox"
@@ -35,6 +36,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/isodate"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/tools/migrate"
 )
@@ -101,6 +103,9 @@ func (s *BaseSuite) SetupSuite() {
 		Logger:             slog.Default(),
 		MeterService:       s.MeterAdapter,
 		Publisher:          eventbus.NewMock(t),
+		EntitlementsConfiguration: config.EntitlementsConfiguration{
+			GracePeriod: isodate.String("P1D"),
+		},
 	})
 
 	// Feature

--- a/test/customer/testenv.go
+++ b/test/customer/testenv.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customeradapter "github.com/openmeterio/openmeter/openmeter/customer/adapter"
 	customerservice "github.com/openmeterio/openmeter/openmeter/customer/service"
@@ -16,6 +17,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/subscription/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/isodate"
 )
 
 const (
@@ -82,6 +84,9 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 		Logger:             logger,
 		MeterService:       meterAdapter,
 		Publisher:          eventbus.NewMock(t),
+		EntitlementsConfiguration: config.EntitlementsConfiguration{
+			GracePeriod: isodate.String("P1D"),
+		},
 	})
 
 	customerService, err := customerservice.New(customerservice.Config{

--- a/test/entitlement/regression/framework_test.go
+++ b/test/entitlement/regression/framework_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils/entdriver"
 	"github.com/openmeterio/openmeter/pkg/framework/pgdriver"
+	"github.com/openmeterio/openmeter/pkg/isodate"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -128,14 +129,17 @@ func setupDependencies(t *testing.T) Dependencies {
 	transactionManager := enttx.NewCreator(dbClient)
 
 	creditConnector := credit.NewCreditConnector(
-		grantRepo,
-		balanceSnapshotService,
-		owner,
-		streaming,
-		log,
-		time.Minute,
-		mockPublisher,
-		transactionManager,
+		credit.CreditConnectorConfig{
+			GrantRepo:              grantRepo,
+			BalanceSnapshotService: balanceSnapshotService,
+			OwnerConnector:         owner,
+			StreamingConnector:     streaming,
+			Logger:                 log,
+			Granularity:            time.Minute,
+			Publisher:              mockPublisher,
+			TransactionManager:     transactionManager,
+			SnapshotGracePeriod:    isodate.NewPeriod(0, 0, 0, 1, 0, 0, 0),
+		},
 	)
 
 	meteredEntitlementConnector := meteredentitlement.NewMeteredEntitlementConnector(

--- a/test/entitlement/regression/framework_test.go
+++ b/test/entitlement/regression/framework_test.go
@@ -36,9 +36,9 @@ type Dependencies struct {
 	PGDriver  *pgdriver.Driver
 	EntDriver *entdriver.EntPostgresDriver
 
-	GrantRepo           grant.Repo
-	BalanceSnapshotRepo balance.SnapshotRepo
-	GrantConnector      credit.GrantConnector
+	GrantRepo              grant.Repo
+	BalanceSnapshotService balance.SnapshotService
+	GrantConnector         credit.GrantConnector
 
 	EntitlementRepo entitlement.EntitlementRepo
 
@@ -119,11 +119,17 @@ func setupDependencies(t *testing.T) Dependencies {
 		log,
 	)
 
+	balanceSnapshotService := balance.NewSnapshotService(balance.SnapshotServiceConfig{
+		OwnerConnector:     owner,
+		StreamingConnector: streaming,
+		Repo:               balanceSnapshotRepo,
+	})
+
 	transactionManager := enttx.NewCreator(dbClient)
 
 	creditConnector := credit.NewCreditConnector(
 		grantRepo,
-		balanceSnapshotRepo,
+		balanceSnapshotService,
 		owner,
 		streaming,
 		log,
@@ -171,7 +177,7 @@ func setupDependencies(t *testing.T) Dependencies {
 		BooleanEntitlementConnector: booleanEntitlementConnector,
 		MeteredEntitlementConnector: meteredEntitlementConnector,
 
-		BalanceSnapshotRepo: balanceSnapshotRepo,
+		BalanceSnapshotService: balanceSnapshotService,
 
 		Streaming: streaming,
 

--- a/tools/migrate/migrations/20250307151454_balance-snapshot-usage.down.sql
+++ b/tools/migrate/migrations/20250307151454_balance-snapshot-usage.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "balance_snapshots" table
+ALTER TABLE "balance_snapshots" DROP COLUMN "usage";

--- a/tools/migrate/migrations/20250307151454_balance-snapshot-usage.up.sql
+++ b/tools/migrate/migrations/20250307151454_balance-snapshot-usage.up.sql
@@ -1,0 +1,2 @@
+-- modify "balance_snapshots" table
+ALTER TABLE "balance_snapshots" ADD COLUMN "usage" jsonb NULL;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:+DAoh8zapF264Ht/qr+3STsQExuh3oOcWteXASuKydI=
+h1:GBSDL939Zna5rKl2wFhpUqGQJUHddDKFReBELgNGbV0=
 20240826120919_init.down.sql h1:AIbgwwngjkJEYa3yRZsIXQyBa2+qoZttwMXHxXEbHLI=
 20240826120919_init.up.sql h1:/hYHWF3Z3dab8SMKnw99ixVktCuJe2bAw5wstCZIEN8=
 20240903155435_entitlement-expired-index.down.sql h1:np2xgYs3KQ2z7qPBcobtGNhqWQ3V8NwEP9E5U3TmpSA=
@@ -127,3 +127,5 @@ h1:+DAoh8zapF264Ht/qr+3STsQExuh3oOcWteXASuKydI=
 20250305025807_add_meter_table.up.sql h1:ZdafaENqMGJLgP8ela+wtuWKBb4T6R2OSU/wHpaDZhc=
 20250306040407_resource_meter.down.sql h1:Y348oWRvZ7BQoGwY8dLcVzzq4NZoI09HV1G081ABLeg=
 20250306040407_resource_meter.up.sql h1:L0bhDCSzStPWsIvx6hULDKK7eurpBD3bIv9b18mSWqc=
+20250307151454_balance-snapshot-usage.down.sql h1:UprCI9cWSumzY1NXmlO055r65VEd2M8+vvMzkJc6Q3g=
+20250307151454_balance-snapshot-usage.up.sql h1:j2x/+rYBLsHNpUCmeKwvyXe1TwXTSDMlddESgUFUqMM=


### PR DESCRIPTION
## Overview

[Part II](https://github.com/openmeterio/openmeter/pull/2383)

- Adds usage information to snapshots (all known usage in the period of the snapshot up to that point)
- As this cannot easily be backfilled in the database, a service wrapper is added around the repo that fills this information
- Engine now calculates usage too. The result snapshot will have the correct usage information to be used alongside the balance information
- Snapshot behavior is changed so snapshots can be created in the current period too. The grace period has been decreased from P1W to P1D (so late events are guaranteed to be included for up to 1D)

## Notes
- In practice, snapshots will eventually be created for all reset times, and calculations will start from there.
- There is no guarantee that any _recent_ snapshots will be created. A snapshot can only be created during a query from a history breakpoint, and the history only breaks if grants or the usage period changes. We could later introduce extra breakpoints in the history to solve for this, but that would mean more smaller queries to ClickHouse.


<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced advanced entitlement settings with a configurable grace period for improved entitlement management.
	- Enhanced balance snapshot functionality by integrating detailed usage tracking, providing more accurate billing and usage reporting.
	- Updated default configurations and sample settings to include these new entitlement and usage parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->