### PR TITLE
Don't create Transactions for Everything

### DIFF
--- a/openmeter/app/adapter/adapter.go
+++ b/openmeter/app/adapter/adapter.go
@@ -53,8 +53,8 @@ type adapter struct {
 }
 
 // Tx implements entutils.TxCreator interface
-func (e adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
-	txCtx, rawConfig, eDriver, err := e.db.HijackTx(ctx, &sql.TxOptions{
+func (a *adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
+	txCtx, rawConfig, eDriver, err := a.db.HijackTx(ctx, &sql.TxOptions{
 		ReadOnly: false,
 	})
 	if err != nil {
@@ -63,11 +63,15 @@ func (e adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, e
 	return txCtx, entutils.NewTxDriver(eDriver, rawConfig), nil
 }
 
-func (a adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *adapter {
+func (a *adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *adapter {
 	txClient := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 	return &adapter{
 		db:       txClient.Client(),
 		registry: a.registry,
 		baseURL:  a.baseURL,
 	}
+}
+
+func (a *adapter) Self() *adapter {
+	return a
 }

--- a/openmeter/app/adapter/customer.go
+++ b/openmeter/app/adapter/customer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	appcustomerdb "github.com/openmeterio/openmeter/openmeter/ent/db/appcustomer"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 )
@@ -16,7 +17,7 @@ import (
 var _ app.AppAdapter = (*adapter)(nil)
 
 // ListCustomerData lists app customer data
-func (a adapter) ListCustomerData(ctx context.Context, input app.ListCustomerInput) (pagination.PagedResponse[app.CustomerApp], error) {
+func (a *adapter) ListCustomerData(ctx context.Context, input app.ListCustomerInput) (pagination.PagedResponse[app.CustomerApp], error) {
 	if err := input.Validate(); err != nil {
 		return pagination.PagedResponse[app.CustomerApp]{}, models.NewGenericValidationError(
 			fmt.Errorf("error listing customer data: %w", err),
@@ -60,103 +61,107 @@ func (a adapter) ListCustomerData(ctx context.Context, input app.ListCustomerInp
 // If the app or customer does not exist, an error is returned
 // If the app customer relationship already exists, nothing is done
 // If the app customer relationship is deleted, it is restored
-func (a adapter) EnsureCustomer(ctx context.Context, input app.EnsureCustomerInput) error {
-	if err := input.Validate(); err != nil {
-		return models.NewGenericValidationError(
-			err,
+func (a *adapter) EnsureCustomer(ctx context.Context, input app.EnsureCustomerInput) error {
+	return transaction.RunWithNoValue(ctx, a, func(ctx context.Context) error {
+		if err := input.Validate(); err != nil {
+			return models.NewGenericValidationError(
+				err,
+			)
+		}
+
+		_, err := entutils.TransactingRepo(
+			ctx,
+			a,
+			func(ctx context.Context, repo *adapter) (any, error) {
+				// Upsert customer data for the app
+				err := repo.db.AppCustomer.
+					Create().
+					SetNamespace(input.AppID.Namespace).
+					SetAppID(input.AppID.ID).
+					SetCustomerID(input.CustomerID.ID).
+					SetNillableDeletedAt(nil).
+					// Upsert
+					OnConflictColumns(
+						appcustomerdb.FieldNamespace,
+						appcustomerdb.FieldAppID,
+						appcustomerdb.FieldCustomerID,
+					).
+					UpdateDeletedAt().
+					Exec(ctx)
+				if err != nil {
+					// TODO: differentiate between app or customer not found
+					// When the constraint error is returned, it means that the app or customer does not exist.
+					if db.IsConstraintError(err) {
+						return nil, app.NewAppNotFoundError(input.AppID)
+					}
+
+					// TODO (pmarton): This is a workaround for the issue where DoNothing() returns an error when no rows are affected.
+					// See: https://github.com/ent/ent/issues/1821
+					if err.Error() == "sql: no rows in result set" {
+						return nil, nil
+					}
+
+					return nil, fmt.Errorf("failed to upsert app customer: %w", err)
+				}
+
+				return nil, nil
+			},
 		)
-	}
 
-	_, err := entutils.TransactingRepo(
-		ctx,
-		a,
-		func(ctx context.Context, repo *adapter) (any, error) {
-			// Upsert customer data for the app
-			err := repo.db.AppCustomer.
-				Create().
-				SetNamespace(input.AppID.Namespace).
-				SetAppID(input.AppID.ID).
-				SetCustomerID(input.CustomerID.ID).
-				SetNillableDeletedAt(nil).
-				// Upsert
-				OnConflictColumns(
-					appcustomerdb.FieldNamespace,
-					appcustomerdb.FieldAppID,
-					appcustomerdb.FieldCustomerID,
-				).
-				UpdateDeletedAt().
-				Exec(ctx)
-			if err != nil {
-				// TODO: differentiate between app or customer not found
-				// When the constraint error is returned, it means that the app or customer does not exist.
-				if db.IsConstraintError(err) {
-					return nil, app.NewAppNotFoundError(input.AppID)
-				}
-
-				// TODO (pmarton): This is a workaround for the issue where DoNothing() returns an error when no rows are affected.
-				// See: https://github.com/ent/ent/issues/1821
-				if err.Error() == "sql: no rows in result set" {
-					return nil, nil
-				}
-
-				return nil, fmt.Errorf("failed to upsert app customer: %w", err)
-			}
-
-			return nil, nil
-		},
-	)
-
-	return err
+		return err
+	})
 }
 
 // DeleteCustomer deletes app customer
-func (a adapter) DeleteCustomer(ctx context.Context, input app.DeleteCustomerInput) error {
-	if err := input.Validate(); err != nil {
-		return models.NewGenericValidationError(
-			fmt.Errorf("error delete customer: %w", err),
-		)
-	}
-
-	// Determine namespace
-	var namespace string
-
-	if input.AppID != nil {
-		namespace = input.AppID.Namespace
-	}
-
-	if input.CustomerID != nil {
-		namespace = input.CustomerID.Namespace
-	}
-
-	if namespace == "" {
-		return models.NewGenericValidationError(
-			fmt.Errorf("error delete customer: namespace is empty"),
-		)
-	}
-
-	_, err := entutils.TransactingRepo(ctx, a, func(ctx context.Context, repo *adapter) (any, error) {
-		// Delete app customer
-		query := repo.db.AppCustomer.
-			Update().
-			SetDeletedAt(time.Now()).
-			Where(
-				appcustomerdb.Namespace(namespace),
+func (a *adapter) DeleteCustomer(ctx context.Context, input app.DeleteCustomerInput) error {
+	return transaction.RunWithNoValue(ctx, a, func(ctx context.Context) error {
+		if err := input.Validate(); err != nil {
+			return models.NewGenericValidationError(
+				fmt.Errorf("error delete customer: %w", err),
 			)
+		}
+
+		// Determine namespace
+		var namespace string
 
 		if input.AppID != nil {
-			query = query.Where(appcustomerdb.AppID(input.AppID.ID))
+			namespace = input.AppID.Namespace
 		}
 
 		if input.CustomerID != nil {
-			query = query.Where(appcustomerdb.CustomerID(input.CustomerID.ID))
+			namespace = input.CustomerID.Namespace
 		}
 
-		_, err := query.Save(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to delete app customer: %w", err)
+		if namespace == "" {
+			return models.NewGenericValidationError(
+				fmt.Errorf("error delete customer: namespace is empty"),
+			)
 		}
 
-		return nil, nil
+		_, err := entutils.TransactingRepo(ctx, a, func(ctx context.Context, repo *adapter) (any, error) {
+			// Delete app customer
+			query := repo.db.AppCustomer.
+				Update().
+				SetDeletedAt(time.Now()).
+				Where(
+					appcustomerdb.Namespace(namespace),
+				)
+
+			if input.AppID != nil {
+				query = query.Where(appcustomerdb.AppID(input.AppID.ID))
+			}
+
+			if input.CustomerID != nil {
+				query = query.Where(appcustomerdb.CustomerID(input.CustomerID.ID))
+			}
+
+			_, err := query.Save(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to delete app customer: %w", err)
+			}
+
+			return nil, nil
+		})
+		return err
 	})
-	return err
 }

--- a/openmeter/app/stripe/adapter/adapter.go
+++ b/openmeter/app/stripe/adapter/adapter.go
@@ -98,7 +98,7 @@ type adapter struct {
 }
 
 // Tx implements entutils.TxCreator interface
-func (a adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
+func (a *adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
 	txCtx, rawConfig, eDriver, err := a.db.HijackTx(ctx, &sql.TxOptions{
 		ReadOnly: false,
 	})
@@ -108,7 +108,7 @@ func (a adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, e
 	return txCtx, entutils.NewTxDriver(eDriver, rawConfig), nil
 }
 
-func (a adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *adapter {
+func (a *adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *adapter {
 	txClient := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 	return &adapter{
 		db:                     txClient.Client(),
@@ -118,4 +118,8 @@ func (a adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *adapter {
 		stripeClientFactory:    a.stripeClientFactory,
 		stripeAppClientFactory: a.stripeAppClientFactory,
 	}
+}
+
+func (a *adapter) Self() *adapter {
+	return a
 }

--- a/openmeter/app/stripe/adapter/customer.go
+++ b/openmeter/app/stripe/adapter/customer.go
@@ -14,7 +14,7 @@ import (
 )
 
 // GetStripeCustomerData gets stripe customer data
-func (a adapter) GetStripeCustomerData(ctx context.Context, input appstripeentity.GetStripeCustomerDataInput) (appstripeentity.CustomerData, error) {
+func (a *adapter) GetStripeCustomerData(ctx context.Context, input appstripeentity.GetStripeCustomerDataInput) (appstripeentity.CustomerData, error) {
 	if err := input.Validate(); err != nil {
 		return appstripeentity.CustomerData{}, models.NewGenericValidationError(
 			fmt.Errorf("error getting stripe customer data: %w", err),
@@ -53,7 +53,7 @@ func (a adapter) GetStripeCustomerData(ctx context.Context, input appstripeentit
 }
 
 // UpsertStripeCustomerData upserts stripe customer data
-func (a adapter) UpsertStripeCustomerData(ctx context.Context, input appstripeentity.UpsertStripeCustomerDataInput) error {
+func (a *adapter) UpsertStripeCustomerData(ctx context.Context, input appstripeentity.UpsertStripeCustomerDataInput) error {
 	if err := input.Validate(); err != nil {
 		return models.NewGenericValidationError(
 			fmt.Errorf("error upsert stripe customer data: %w", err),
@@ -152,7 +152,7 @@ func (a adapter) UpsertStripeCustomerData(ctx context.Context, input appstripeen
 }
 
 // DeleteStripeCustomerData deletes stripe customer data
-func (a adapter) DeleteStripeCustomerData(ctx context.Context, input appstripeentity.DeleteStripeCustomerDataInput) error {
+func (a *adapter) DeleteStripeCustomerData(ctx context.Context, input appstripeentity.DeleteStripeCustomerDataInput) error {
 	if err := input.Validate(); err != nil {
 		return models.NewGenericValidationError(
 			fmt.Errorf("error delete stripe customer data: %w", err),
@@ -213,7 +213,7 @@ func (a adapter) DeleteStripeCustomerData(ctx context.Context, input appstripeen
 }
 
 // createStripeCustomer creates a new stripe customer
-func (a adapter) createStripeCustomer(ctx context.Context, input appstripeentity.CreateStripeCustomerInput) (appstripeentity.CreateStripeCustomerOutput, error) {
+func (a *adapter) createStripeCustomer(ctx context.Context, input appstripeentity.CreateStripeCustomerInput) (appstripeentity.CreateStripeCustomerOutput, error) {
 	// Get the stripe app
 	stripeAppData, err := a.GetStripeAppData(ctx, appstripeentity.GetStripeAppDataInput{
 		AppID: input.AppID,

--- a/openmeter/app/stripe/adapter/stripe.go
+++ b/openmeter/app/stripe/adapter/stripe.go
@@ -36,7 +36,7 @@ func (a adapter) GetStripeAppClientFactory() stripeclient.StripeAppClientFactory
 }
 
 // CreateApp creates a new app
-func (a adapter) CreateStripeApp(ctx context.Context, input appstripeentity.CreateAppStripeInput) (appstripeentity.AppBase, error) {
+func (a *adapter) CreateStripeApp(ctx context.Context, input appstripeentity.CreateAppStripeInput) (appstripeentity.AppBase, error) {
 	if err := input.Validate(); err != nil {
 		return appstripeentity.AppBase{}, models.NewGenericValidationError(
 			fmt.Errorf("error create stripe app: %w", err),
@@ -82,7 +82,7 @@ func (a adapter) CreateStripeApp(ctx context.Context, input appstripeentity.Crea
 }
 
 // UpdateAPIKey replaces the API key
-func (a adapter) UpdateAPIKey(ctx context.Context, input appstripeentity.UpdateAPIKeyInput) error {
+func (a *adapter) UpdateAPIKey(ctx context.Context, input appstripeentity.UpdateAPIKeyInput) error {
 	// Validate the input
 	if err := input.Validate(); err != nil {
 		return models.NewGenericValidationError(
@@ -179,7 +179,7 @@ func (a adapter) UpdateAPIKey(ctx context.Context, input appstripeentity.UpdateA
 }
 
 // GetStripeAppData gets stripe customer data
-func (a adapter) GetStripeAppData(ctx context.Context, input appstripeentity.GetStripeAppDataInput) (appstripeentity.AppData, error) {
+func (a *adapter) GetStripeAppData(ctx context.Context, input appstripeentity.GetStripeAppDataInput) (appstripeentity.AppData, error) {
 	if err := input.Validate(); err != nil {
 		return appstripeentity.AppData{}, models.NewGenericValidationError(
 			fmt.Errorf("error getting stripe customer data: %w", err),
@@ -211,7 +211,7 @@ func (a adapter) GetStripeAppData(ctx context.Context, input appstripeentity.Get
 }
 
 // DeleteStripeAppData deletes the stripe app data
-func (a adapter) DeleteStripeAppData(ctx context.Context, input appstripeentity.DeleteStripeAppDataInput) error {
+func (a *adapter) DeleteStripeAppData(ctx context.Context, input appstripeentity.DeleteStripeAppDataInput) error {
 	if err := input.Validate(); err != nil {
 		return models.NewGenericValidationError(
 			fmt.Errorf("error delete stripe app: %w", err),
@@ -238,7 +238,7 @@ func (a adapter) DeleteStripeAppData(ctx context.Context, input appstripeentity.
 }
 
 // GetWebhookSecret gets the webhook secret
-func (a adapter) GetWebhookSecret(ctx context.Context, input appstripeentity.GetWebhookSecretInput) (appstripeentity.GetWebhookSecretOutput, error) {
+func (a *adapter) GetWebhookSecret(ctx context.Context, input appstripeentity.GetWebhookSecretInput) (appstripeentity.GetWebhookSecretOutput, error) {
 	if err := input.Validate(); err != nil {
 		return secretentity.Secret{}, models.NewGenericValidationError(
 			fmt.Errorf("error get webhook secret: %w", err),
@@ -280,7 +280,7 @@ func (a adapter) GetWebhookSecret(ctx context.Context, input appstripeentity.Get
 }
 
 // SetCustomerDefaultPaymentMethod sets the default payment method for a customer
-func (a adapter) SetCustomerDefaultPaymentMethod(ctx context.Context, input appstripeentity.SetCustomerDefaultPaymentMethodInput) (appstripeentity.SetCustomerDefaultPaymentMethodOutput, error) {
+func (a *adapter) SetCustomerDefaultPaymentMethod(ctx context.Context, input appstripeentity.SetCustomerDefaultPaymentMethodInput) (appstripeentity.SetCustomerDefaultPaymentMethodOutput, error) {
 	if err := input.Validate(); err != nil {
 		return appstripeentity.SetCustomerDefaultPaymentMethodOutput{}, models.NewGenericValidationError(
 			fmt.Errorf("error set customer default payment method: %w", err),
@@ -343,7 +343,7 @@ func (a adapter) SetCustomerDefaultPaymentMethod(ctx context.Context, input apps
 }
 
 // CreateCheckoutSession creates a new checkout session
-func (a adapter) CreateCheckoutSession(ctx context.Context, input appstripeentity.CreateCheckoutSessionInput) (appstripeentity.CreateCheckoutSessionOutput, error) {
+func (a *adapter) CreateCheckoutSession(ctx context.Context, input appstripeentity.CreateCheckoutSessionInput) (appstripeentity.CreateCheckoutSessionOutput, error) {
 	if err := input.Validate(); err != nil {
 		return appstripeentity.CreateCheckoutSessionOutput{}, models.NewGenericValidationError(
 			fmt.Errorf("error create checkout session: %w", err),

--- a/openmeter/billing/adapter/adapter.go
+++ b/openmeter/billing/adapter/adapter.go
@@ -67,3 +67,7 @@ func (a *adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *adapter {
 		logger: a.logger,
 	}
 }
+
+func (a *adapter) Self() *adapter {
+	return a
+}

--- a/openmeter/credit/adapter/transaction.go
+++ b/openmeter/credit/adapter/transaction.go
@@ -30,6 +30,10 @@ func (e *grantDBADapter) WithTx(ctx context.Context, tx *entutils.TxDriver) gran
 	return NewPostgresGrantRepo(txClient.Client())
 }
 
+func (e *grantDBADapter) Self() grant.Repo {
+	return e
+}
+
 func (e *balanceSnapshotRepo) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
 	txCtx, rawConfig, eDriver, err := e.db.HijackTx(ctx, &sql.TxOptions{
 		ReadOnly: false,
@@ -43,4 +47,8 @@ func (e *balanceSnapshotRepo) Tx(ctx context.Context) (context.Context, transact
 func (e *balanceSnapshotRepo) WithTx(ctx context.Context, tx *entutils.TxDriver) balance.SnapshotRepo {
 	txClient := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 	return NewPostgresBalanceSnapshotRepo(txClient.Client())
+}
+
+func (e *balanceSnapshotRepo) Self() balance.SnapshotRepo {
+	return e
 }

--- a/openmeter/customer/adapter/adapter.go
+++ b/openmeter/customer/adapter/adapter.go
@@ -50,7 +50,7 @@ type adapter struct {
 }
 
 // Tx implements entutils.TxCreator interface
-func (a adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
+func (a *adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
 	txCtx, rawConfig, eDriver, err := a.db.HijackTx(ctx, &sql.TxOptions{
 		ReadOnly: false,
 	})
@@ -60,10 +60,14 @@ func (a adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, e
 	return txCtx, entutils.NewTxDriver(eDriver, rawConfig), nil
 }
 
-func (a adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *adapter {
+func (a *adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *adapter {
 	txClient := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 	return &adapter{
 		db:     txClient.Client(),
 		logger: a.logger,
 	}
+}
+
+func (a *adapter) Self() *adapter {
+	return a
 }

--- a/openmeter/entitlement/adapter/transaction.go
+++ b/openmeter/entitlement/adapter/transaction.go
@@ -28,6 +28,10 @@ func (e *entitlementDBAdapter) WithTx(ctx context.Context, tx *entutils.TxDriver
 	return NewPostgresEntitlementRepo(txClient.Client())
 }
 
+func (e *entitlementDBAdapter) Self() *entitlementDBAdapter {
+	return e
+}
+
 func (u *usageResetDBAdapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
 	txCtx, rawConfig, eDriver, err := u.db.HijackTx(ctx, &sql.TxOptions{
 		ReadOnly: false,
@@ -41,4 +45,8 @@ func (u *usageResetDBAdapter) Tx(ctx context.Context) (context.Context, transact
 func (u *usageResetDBAdapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *usageResetDBAdapter {
 	txClient := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 	return NewPostgresUsageResetRepo(txClient.Client())
+}
+
+func (u *usageResetDBAdapter) Self() *usageResetDBAdapter {
+	return u
 }

--- a/openmeter/meter/adapter/adapter.go
+++ b/openmeter/meter/adapter/adapter.go
@@ -119,7 +119,7 @@ type manageAdapter struct {
 }
 
 // Tx implements entutils.TxCreator interface
-func (a manageAdapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
+func (a *manageAdapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
 	txCtx, rawConfig, eDriver, err := a.db.HijackTx(ctx, &sql.TxOptions{
 		ReadOnly: false,
 	})
@@ -130,7 +130,7 @@ func (a manageAdapter) Tx(ctx context.Context) (context.Context, transaction.Dri
 	return txCtx, entutils.NewTxDriver(eDriver, rawConfig), nil
 }
 
-func (a manageAdapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *manageAdapter {
+func (a *manageAdapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *manageAdapter {
 	txClient := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 
 	return &manageAdapter{
@@ -142,4 +142,8 @@ func (a manageAdapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *manag
 		namespaceManager:      a.namespaceManager,
 		streamingConnector:    a.streamingConnector,
 	}
+}
+
+func (a *manageAdapter) Self() *manageAdapter {
+	return a
 }

--- a/openmeter/meter/adapter/manage.go
+++ b/openmeter/meter/adapter/manage.go
@@ -10,6 +10,7 @@ import (
 	meterpkg "github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -20,212 +21,218 @@ func (a *manageAdapter) RegisterPreUpdateMeterHook(hook meterpkg.PreUpdateMeterH
 }
 
 // CreateMeter creates a new meter.
-func (a manageAdapter) CreateMeter(ctx context.Context, input meterpkg.CreateMeterInput) (meterpkg.Meter, error) {
-	if err := input.Validate(); err != nil {
-		return meterpkg.Meter{}, models.NewGenericValidationError(err)
-	}
+func (a *manageAdapter) CreateMeter(ctx context.Context, input meterpkg.CreateMeterInput) (meterpkg.Meter, error) {
+	return transaction.Run(ctx, a, func(ctx context.Context) (meterpkg.Meter, error) {
+		if err := input.Validate(); err != nil {
+			return meterpkg.Meter{}, models.NewGenericValidationError(err)
+		}
 
-	return entutils.TransactingRepo(
-		ctx,
-		a,
-		func(ctx context.Context, repo *manageAdapter) (meterpkg.Meter, error) {
-			entity, err := repo.db.Meter.Create().
-				SetNamespace(input.Namespace).
-				SetKey(input.Key).
-				SetName(input.Name).
-				SetNillableDescription(input.Description).
-				SetAggregation(input.Aggregation).
-				SetEventType(input.EventType).
-				SetNillableEventFrom(input.EventFrom).
-				SetNillableValueProperty(input.ValueProperty).
-				SetGroupBy(input.GroupBy).
-				Save(ctx)
-			if err != nil {
-				if db.IsConstraintError(err) {
-					return meterpkg.Meter{}, models.NewGenericConflictError(fmt.Errorf("meter with the same slug already exists"))
+		return entutils.TransactingRepo(
+			ctx,
+			a,
+			func(ctx context.Context, repo *manageAdapter) (meterpkg.Meter, error) {
+				entity, err := repo.db.Meter.Create().
+					SetNamespace(input.Namespace).
+					SetKey(input.Key).
+					SetName(input.Name).
+					SetNillableDescription(input.Description).
+					SetAggregation(input.Aggregation).
+					SetEventType(input.EventType).
+					SetNillableEventFrom(input.EventFrom).
+					SetNillableValueProperty(input.ValueProperty).
+					SetGroupBy(input.GroupBy).
+					Save(ctx)
+				if err != nil {
+					if db.IsConstraintError(err) {
+						return meterpkg.Meter{}, models.NewGenericConflictError(fmt.Errorf("meter with the same slug already exists"))
+					}
+
+					return meterpkg.Meter{}, fmt.Errorf("failed to create meter: %w", err)
 				}
 
-				return meterpkg.Meter{}, fmt.Errorf("failed to create meter: %w", err)
-			}
+				meter, err := MapFromEntityFactory(entity)
+				if err != nil {
+					return meterpkg.Meter{}, fmt.Errorf("failed to map meter: %w", err)
+				}
 
-			meter, err := MapFromEntityFactory(entity)
-			if err != nil {
-				return meterpkg.Meter{}, fmt.Errorf("failed to map meter: %w", err)
-			}
+				// TODO: remove this once we are sure that the namespace is created at signup
+				err = a.namespaceManager.CreateNamespace(ctx, input.Namespace)
+				if err != nil {
+					return meter, fmt.Errorf("failed to create namespace: %w", err)
+				}
 
-			// TODO: remove this once we are sure that the namespace is created at signup
-			err = a.namespaceManager.CreateNamespace(ctx, input.Namespace)
-			if err != nil {
-				return meter, fmt.Errorf("failed to create namespace: %w", err)
-			}
+				// Create the meter in the streaming connector
+				err = a.streamingConnector.CreateMeter(ctx, input.Namespace, meter)
+				if err != nil {
+					return meter, fmt.Errorf("failed to create meter in streaming connector: %w", err)
+				}
 
-			// Create the meter in the streaming connector
-			err = a.streamingConnector.CreateMeter(ctx, input.Namespace, meter)
-			if err != nil {
-				return meter, fmt.Errorf("failed to create meter in streaming connector: %w", err)
-			}
-
-			return meter, nil
-		})
+				return meter, nil
+			})
+	})
 }
 
 // UpdateMeter updates a new meter.
-func (a manageAdapter) UpdateMeter(ctx context.Context, input meterpkg.UpdateMeterInput) (meterpkg.Meter, error) {
-	// Get the meter by ID
-	currentMeter, err := a.GetMeterByIDOrSlug(ctx, meterpkg.GetMeterInput{
-		Namespace: input.ID.Namespace,
-		IDOrSlug:  input.ID.ID,
-	})
-	if err != nil {
-		return meterpkg.Meter{}, err
-	}
-
-	if err := input.Validate(currentMeter.ValueProperty); err != nil {
-		return meterpkg.Meter{}, models.NewGenericValidationError(err)
-	}
-
-	// Collect group by changes
-	var groupByToDelete []string
-
-	for key := range currentMeter.GroupBy {
-		if _, ok := input.GroupBy[key]; !ok {
-			groupByToDelete = append(groupByToDelete, key)
-		}
-	}
-
-	// FIXME: use foreign keys after we migrate Feature reference on meter id
-	// Check if features are compatible with the new group by values
-	// We only need to check deleted group bys because only those can be incompatible
-	if len(groupByToDelete) > 0 {
-		// List features depending on the meter
-		features, err := a.featureRepository.ListFeatures(ctx, feature.ListFeaturesParams{
-			Namespace:  input.ID.Namespace,
-			MeterSlugs: []string{currentMeter.Key},
+func (a *manageAdapter) UpdateMeter(ctx context.Context, input meterpkg.UpdateMeterInput) (meterpkg.Meter, error) {
+	return transaction.Run(ctx, a, func(ctx context.Context) (meterpkg.Meter, error) {
+		// Get the meter by ID
+		currentMeter, err := a.GetMeterByIDOrSlug(ctx, meterpkg.GetMeterInput{
+			Namespace: input.ID.Namespace,
+			IDOrSlug:  input.ID.ID,
 		})
 		if err != nil {
-			return meterpkg.Meter{}, fmt.Errorf("failed to list features for meter: %w", err)
-		}
-
-		// Check if the features are compatible with the new group by values
-		for _, feature := range features.Items {
-			for _, groupBy := range groupByToDelete {
-				if _, ok := feature.MeterGroupByFilters[groupBy]; ok {
-					return meterpkg.Meter{}, models.NewGenericConflictError(
-						fmt.Errorf("meter group by: %s cannot be dropped because it is used by feature: %s", groupBy, feature.Key),
-					)
-				}
-			}
-		}
-	}
-
-	// Run pre-update hooks
-	for _, hook := range a.preUpdateHooks {
-		if err := hook(ctx, input); err != nil {
 			return meterpkg.Meter{}, err
 		}
-	}
 
-	// Update the meter
-	return entutils.TransactingRepo(
-		ctx,
-		a,
-		func(ctx context.Context, repo *manageAdapter) (meterpkg.Meter, error) {
-			entity, err := repo.db.Meter.UpdateOneID(input.ID.ID).
-				Where(meterdb.NamespaceEQ(input.ID.Namespace)).
-				SetName(input.Name).
-				SetNillableDescription(input.Description).
-				SetGroupBy(input.GroupBy).
-				Save(ctx)
+		if err := input.Validate(currentMeter.ValueProperty); err != nil {
+			return meterpkg.Meter{}, models.NewGenericValidationError(err)
+		}
+
+		// Collect group by changes
+		var groupByToDelete []string
+
+		for key := range currentMeter.GroupBy {
+			if _, ok := input.GroupBy[key]; !ok {
+				groupByToDelete = append(groupByToDelete, key)
+			}
+		}
+
+		// FIXME: use foreign keys after we migrate Feature reference on meter id
+		// Check if features are compatible with the new group by values
+		// We only need to check deleted group bys because only those can be incompatible
+		if len(groupByToDelete) > 0 {
+			// List features depending on the meter
+			features, err := a.featureRepository.ListFeatures(ctx, feature.ListFeaturesParams{
+				Namespace:  input.ID.Namespace,
+				MeterSlugs: []string{currentMeter.Key},
+			})
 			if err != nil {
-				if db.IsConstraintError(err) {
-					return meterpkg.Meter{}, models.NewGenericConflictError(fmt.Errorf("meter with the same slug already exists"))
+				return meterpkg.Meter{}, fmt.Errorf("failed to list features for meter: %w", err)
+			}
+
+			// Check if the features are compatible with the new group by values
+			for _, feature := range features.Items {
+				for _, groupBy := range groupByToDelete {
+					if _, ok := feature.MeterGroupByFilters[groupBy]; ok {
+						return meterpkg.Meter{}, models.NewGenericConflictError(
+							fmt.Errorf("meter group by: %s cannot be dropped because it is used by feature: %s", groupBy, feature.Key),
+						)
+					}
+				}
+			}
+		}
+
+		// Run pre-update hooks
+		for _, hook := range a.preUpdateHooks {
+			if err := hook(ctx, input); err != nil {
+				return meterpkg.Meter{}, err
+			}
+		}
+
+		// Update the meter
+		return entutils.TransactingRepo(
+			ctx,
+			a,
+			func(ctx context.Context, repo *manageAdapter) (meterpkg.Meter, error) {
+				entity, err := repo.db.Meter.UpdateOneID(input.ID.ID).
+					Where(meterdb.NamespaceEQ(input.ID.Namespace)).
+					SetName(input.Name).
+					SetNillableDescription(input.Description).
+					SetGroupBy(input.GroupBy).
+					Save(ctx)
+				if err != nil {
+					if db.IsConstraintError(err) {
+						return meterpkg.Meter{}, models.NewGenericConflictError(fmt.Errorf("meter with the same slug already exists"))
+					}
+
+					return meterpkg.Meter{}, fmt.Errorf("failed to update meter: %w", err)
 				}
 
-				return meterpkg.Meter{}, fmt.Errorf("failed to update meter: %w", err)
-			}
+				meter, err := MapFromEntityFactory(entity)
+				if err != nil {
+					return meterpkg.Meter{}, fmt.Errorf("failed to map meter: %w", err)
+				}
 
-			meter, err := MapFromEntityFactory(entity)
-			if err != nil {
-				return meterpkg.Meter{}, fmt.Errorf("failed to map meter: %w", err)
-			}
+				// Update the meter in the streaming connector
+				err = a.streamingConnector.UpdateMeter(ctx, input.ID.Namespace, meter)
+				if err != nil {
+					return meter, fmt.Errorf("failed to update meter in streaming connector: %w", err)
+				}
 
-			// Update the meter in the streaming connector
-			err = a.streamingConnector.UpdateMeter(ctx, input.ID.Namespace, meter)
-			if err != nil {
-				return meter, fmt.Errorf("failed to update meter in streaming connector: %w", err)
-			}
-
-			return meter, nil
-		})
+				return meter, nil
+			})
+	})
 }
 
 // DeleteMeter deletes a meter.
-func (a manageAdapter) DeleteMeter(ctx context.Context, input meterpkg.DeleteMeterInput) error {
-	if err := input.Validate(); err != nil {
-		return models.NewGenericValidationError(err)
-	}
+func (a *manageAdapter) DeleteMeter(ctx context.Context, input meterpkg.DeleteMeterInput) error {
+	return transaction.RunWithNoValue(ctx, a, func(ctx context.Context) error {
+		if err := input.Validate(); err != nil {
+			return models.NewGenericValidationError(err)
+		}
 
-	// Get the meter
-	meter, err := a.GetMeterByIDOrSlug(ctx, meterpkg.GetMeterInput(input))
-	if err != nil {
-		return err
-	}
+		// Get the meter
+		meter, err := a.GetMeterByIDOrSlug(ctx, meterpkg.GetMeterInput(input))
+		if err != nil {
+			return err
+		}
 
-	// Check if the meter is already deleted
-	if meter.DeletedAt != nil {
-		return meterpkg.NewMeterNotFoundError(meter.Key)
-	}
+		// Check if the meter is already deleted
+		if meter.DeletedAt != nil {
+			return meterpkg.NewMeterNotFoundError(meter.Key)
+		}
 
-	// Check if the meter has active features
-	hasFeatures, err := a.featureRepository.HasActiveFeatureForMeter(ctx, input.Namespace, meter.Key)
-	if err != nil {
-		return fmt.Errorf("failed to check if meter has features: %w", err)
-	}
+		// Check if the meter has active features
+		hasFeatures, err := a.featureRepository.HasActiveFeatureForMeter(ctx, input.Namespace, meter.Key)
+		if err != nil {
+			return fmt.Errorf("failed to check if meter has features: %w", err)
+		}
 
-	if hasFeatures {
-		return models.NewGenericConflictError(
-			fmt.Errorf("meter has active features and cannot be deleted"),
-		)
-	}
+		if hasFeatures {
+			return models.NewGenericConflictError(
+				fmt.Errorf("meter has active features and cannot be deleted"),
+			)
+		}
 
-	// Check if the meter has active entitlements
-	hasEntitlements, err := a.entitlementRepository.HasEntitlementForMeter(ctx, meter.Namespace, meter.Key)
-	if err != nil {
-		return fmt.Errorf("failed to check if meter has entitlements: %w", err)
-	}
+		// Check if the meter has active entitlements
+		hasEntitlements, err := a.entitlementRepository.HasEntitlementForMeter(ctx, meter.Namespace, meter.Key)
+		if err != nil {
+			return fmt.Errorf("failed to check if meter has entitlements: %w", err)
+		}
 
-	if hasEntitlements {
-		return models.NewGenericConflictError(
-			fmt.Errorf("meter has active entitlements and cannot be deleted"),
-		)
-	}
+		if hasEntitlements {
+			return models.NewGenericConflictError(
+				fmt.Errorf("meter has active entitlements and cannot be deleted"),
+			)
+		}
 
-	// Delete the meter
-	return entutils.TransactingRepoWithNoValue(
-		ctx,
-		a,
-		func(ctx context.Context, repo *manageAdapter) error {
-			_, err := repo.db.Meter.UpdateOneID(meter.ID).
-				SetDeletedAt(time.Now()).
-				Save(ctx)
-			if err != nil {
-				if db.IsNotFound(err) {
-					return meterpkg.NewMeterNotFoundError(meter.Key)
+		// Delete the meter
+		return entutils.TransactingRepoWithNoValue(
+			ctx,
+			a,
+			func(ctx context.Context, repo *manageAdapter) error {
+				_, err := repo.db.Meter.UpdateOneID(meter.ID).
+					SetDeletedAt(time.Now()).
+					Save(ctx)
+				if err != nil {
+					if db.IsNotFound(err) {
+						return meterpkg.NewMeterNotFoundError(meter.Key)
+					}
+
+					if db.IsConstraintError(err) {
+						return models.NewGenericConflictError(fmt.Errorf("delete first related resources like reports"))
+					}
+
+					return fmt.Errorf("failed to delete meter: %w", err)
 				}
 
-				if db.IsConstraintError(err) {
-					return models.NewGenericConflictError(fmt.Errorf("delete first related resources like reports"))
+				// Delete the meter in the streaming connector
+				err = a.streamingConnector.DeleteMeter(ctx, input.Namespace, meter)
+				if err != nil {
+					return fmt.Errorf("failed to delete meter in streaming connector: %w", err)
 				}
 
-				return fmt.Errorf("failed to delete meter: %w", err)
-			}
-
-			// Delete the meter in the streaming connector
-			err = a.streamingConnector.DeleteMeter(ctx, input.Namespace, meter)
-			if err != nil {
-				return fmt.Errorf("failed to delete meter in streaming connector: %w", err)
-			}
-
-			return nil
-		})
+				return nil
+			})
+	})
 }

--- a/openmeter/productcatalog/adapter/transaction.go
+++ b/openmeter/productcatalog/adapter/transaction.go
@@ -28,3 +28,7 @@ func (e *featureDBAdapter) WithTx(ctx context.Context, tx *entutils.TxDriver) fe
 	txClient := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 	return NewPostgresFeatureRepo(txClient.Client(), e.logger)
 }
+
+func (e *featureDBAdapter) Self() feature.FeatureRepo {
+	return e
+}

--- a/openmeter/productcatalog/plan/adapter/adapter.go
+++ b/openmeter/productcatalog/plan/adapter/adapter.go
@@ -77,3 +77,7 @@ func (a *adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *adapter {
 		logger: a.logger,
 	}
 }
+
+func (a *adapter) Self() *adapter {
+	return a
+}

--- a/openmeter/subscription/repo/transaction.go
+++ b/openmeter/subscription/repo/transaction.go
@@ -20,6 +20,10 @@ func (r *subscriptionRepo) Tx(ctx context.Context) (context.Context, transaction
 	return txCtx, entutils.NewTxDriver(eDriver, rawConfig), nil
 }
 
+func (r *subscriptionRepo) Self() *subscriptionRepo {
+	return r
+}
+
 func (r *subscriptionRepo) WithTx(ctx context.Context, tx *entutils.TxDriver) *subscriptionRepo {
 	txClient := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 	return NewSubscriptionRepo(txClient.Client())
@@ -35,6 +39,10 @@ func (r *subscriptionPhaseRepo) Tx(ctx context.Context) (context.Context, transa
 	return txCtx, entutils.NewTxDriver(eDriver, rawConfig), nil
 }
 
+func (r *subscriptionPhaseRepo) Self() *subscriptionPhaseRepo {
+	return r
+}
+
 func (r *subscriptionPhaseRepo) WithTx(ctx context.Context, tx *entutils.TxDriver) *subscriptionPhaseRepo {
 	txClient := db.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 	return NewSubscriptionPhaseRepo(txClient.Client())
@@ -48,6 +56,10 @@ func (r *subscriptionItemRepo) Tx(ctx context.Context) (context.Context, transac
 		return nil, nil, fmt.Errorf("failed to hijack transaction: %w", err)
 	}
 	return txCtx, entutils.NewTxDriver(eDriver, rawConfig), nil
+}
+
+func (r *subscriptionItemRepo) Self() *subscriptionItemRepo {
+	return r
 }
 
 func (r *subscriptionItemRepo) WithTx(ctx context.Context, tx *entutils.TxDriver) *subscriptionItemRepo {

--- a/pkg/framework/entutils/transaction_test.go
+++ b/pkg/framework/entutils/transaction_test.go
@@ -57,6 +57,10 @@ func (d *db1Adapter) Tx(ctx context.Context) (context.Context, transaction.Drive
 	return txCtx, entutils.NewTxDriver(eDriver, rawConfig), nil
 }
 
+func (d *db1Adapter) Self() SomeDB[db1.Example1] {
+	return d
+}
+
 func (d *db1Adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) SomeDB[db1.Example1] {
 	txClient := db1.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
 	res := &db1Adapter{db: txClient.Client()}
@@ -89,6 +93,10 @@ func (d *db2Adapter) Tx(ctx context.Context) (context.Context, transaction.Drive
 		return nil, nil, fmt.Errorf("failed to hijack transaction: %w", err)
 	}
 	return txCtx, entutils.NewTxDriver(eDriver, rawConfig), nil
+}
+
+func (d *db2Adapter) Self() SomeDB[db2.Example2] {
+	return d
 }
 
 func (d *db2Adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) SomeDB[db2.Example2] {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

`entutils.TransactingRepo` used to create transactions for each repo call. This in effect meant that even simple DB reads had to go through unnecessary transactions, causing significant performance overhead. Transactions now are only created via `transacton.Run`

Example of a simple GetEntitlement request before the change:
<img width="929" alt="image" src="https://github.com/user-attachments/assets/2ebff28b-8883-4c7d-9667-5d0909fe386d" />

This in practice caused significant overhead for all queries (2 unnecessary db requests for each repo call)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced transaction management across app, customer, billing, and subscription operations for smoother, more reliable processes.
  - Optimized internal operations to deliver improved error reporting and performance.

- **Chores**
  - Performed comprehensive code maintenance and cleanup to ensure consistent, maintainable behavior across core functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->