### PR TITLE
chore: remove totalCount from cursor paginated results

### DIFF
--- a/pkg/pagination/v2/pagination.go
+++ b/pkg/pagination/v2/pagination.go
@@ -14,22 +14,15 @@ type Result[T any] struct {
 	// The items returned
 	Items []T `json:"items"`
 
-	// The total count of items
-	TotalCount int64 `json:"totalCount"`
-
 	// Cursor for the next page
 	NextCursor *string `json:"nextCursor"`
 }
 
 // NewResult creates a new pagination result
 // T must implement the Item interface for cursor generation
-func NewResult[T Item](
-	items []T,
-	totalCount int64,
-) Result[T] {
+func NewResult[T Item](items []T) Result[T] {
 	result := Result[T]{
-		Items:      items,
-		TotalCount: totalCount,
+		Items: items,
 	}
 
 	// Generate next cursor from the last item if there are any items

--- a/pkg/pagination/v2/pagination_test.go
+++ b/pkg/pagination/v2/pagination_test.go
@@ -35,14 +35,10 @@ func TestCursorGeneration(t *testing.T) {
 	}
 
 	t.Run("Generate next cursor", func(t *testing.T) {
-		result := NewResult(
-			items,
-			100, // Total count of 100
-		)
+		result := NewResult(items)
 
 		// Verify next cursor
 		assert.NotNil(t, result.NextCursor)
-		assert.Equal(t, int64(100), result.TotalCount)
 
 		// Decode and verify next cursor
 		nextCursor, err := DecodeCursor(*result.NextCursor)
@@ -52,13 +48,9 @@ func TestCursorGeneration(t *testing.T) {
 	})
 
 	t.Run("Empty results", func(t *testing.T) {
-		emptyResult := NewResult(
-			[]TestItem{},
-			0, // No items total
-		)
+		emptyResult := NewResult([]TestItem{})
 
 		// Verify cursor is not set
 		assert.Nil(t, emptyResult.NextCursor)
-		assert.Equal(t, int64(0), emptyResult.TotalCount)
 	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - The pagination experience has been streamlined to deliver only the essential details needed for seamless navigation. Pagination results now focus solely on showing the list of items and a marker for progressing to subsequent pages. This update enhances efficiency and clarity, providing users with a more intuitive browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->