### PR TITLE
fix: balance snapshot indexes

### DIFF
--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -231,19 +231,12 @@ var (
 				Columns: []*schema.Column{BalanceSnapshotsColumns[1]},
 			},
 			{
-				Name:    "balancesnapshot_namespace_at",
+				Name:    "balancesnapshot_namespace_owner_id_at",
 				Unique:  false,
-				Columns: []*schema.Column{BalanceSnapshotsColumns[1], BalanceSnapshotsColumns[9]},
-			},
-			{
-				Name:    "balancesnapshot_namespace_balance",
-				Unique:  false,
-				Columns: []*schema.Column{BalanceSnapshotsColumns[1], BalanceSnapshotsColumns[7]},
-			},
-			{
-				Name:    "balancesnapshot_namespace_balance_at",
-				Unique:  false,
-				Columns: []*schema.Column{BalanceSnapshotsColumns[1], BalanceSnapshotsColumns[7], BalanceSnapshotsColumns[9]},
+				Columns: []*schema.Column{BalanceSnapshotsColumns[1], BalanceSnapshotsColumns[10], BalanceSnapshotsColumns[9]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "deleted_at IS NULL",
+				},
 			},
 		},
 	}

--- a/openmeter/ent/schema/balance_snapshot.go
+++ b/openmeter/ent/schema/balance_snapshot.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
+	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
@@ -45,9 +46,9 @@ func (BalanceSnapshot) Fields() []ent.Field {
 
 func (BalanceSnapshot) Indexes() []ent.Index {
 	return []ent.Index{
-		index.Fields("namespace", "at"),
-		index.Fields("namespace", "balance"),
-		index.Fields("namespace", "balance", "at"),
+		index.Fields("namespace", "owner_id", "at").Annotations(
+			entsql.IndexWhere("deleted_at IS NULL"),
+		),
 	}
 }
 

--- a/tools/migrate/migrations/20250311193204_balance-snapshot-indexes.down.sql
+++ b/tools/migrate/migrations/20250311193204_balance-snapshot-indexes.down.sql
@@ -1,0 +1,8 @@
+-- reverse: create index "balancesnapshot_namespace_owner_id_at" to table: "balance_snapshots"
+DROP INDEX "balancesnapshot_namespace_owner_id_at";
+-- reverse: drop index "balancesnapshot_namespace_balance_at" from table: "balance_snapshots"
+CREATE INDEX "balancesnapshot_namespace_balance_at" ON "balance_snapshots" ("namespace", "balance", "at");
+-- reverse: drop index "balancesnapshot_namespace_balance" from table: "balance_snapshots"
+CREATE INDEX "balancesnapshot_namespace_balance" ON "balance_snapshots" ("namespace", "balance");
+-- reverse: drop index "balancesnapshot_namespace_at" from table: "balance_snapshots"
+CREATE INDEX "balancesnapshot_namespace_at" ON "balance_snapshots" ("namespace", "at");

--- a/tools/migrate/migrations/20250311193204_balance-snapshot-indexes.up.sql
+++ b/tools/migrate/migrations/20250311193204_balance-snapshot-indexes.up.sql
@@ -1,0 +1,8 @@
+-- drop index "balancesnapshot_namespace_at" from table: "balance_snapshots"
+DROP INDEX "balancesnapshot_namespace_at";
+-- drop index "balancesnapshot_namespace_balance" from table: "balance_snapshots"
+DROP INDEX "balancesnapshot_namespace_balance";
+-- drop index "balancesnapshot_namespace_balance_at" from table: "balance_snapshots"
+DROP INDEX "balancesnapshot_namespace_balance_at";
+-- create index "balancesnapshot_namespace_owner_id_at" to table: "balance_snapshots"
+CREATE INDEX "balancesnapshot_namespace_owner_id_at" ON "balance_snapshots" ("namespace", "owner_id", "at") WHERE (deleted_at IS NULL);

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:GBSDL939Zna5rKl2wFhpUqGQJUHddDKFReBELgNGbV0=
+h1:fDFD8PZ8j8vPRxmMYjAeFv9ai8AXG8pP7VA0oDQL2Hg=
 20240826120919_init.down.sql h1:AIbgwwngjkJEYa3yRZsIXQyBa2+qoZttwMXHxXEbHLI=
 20240826120919_init.up.sql h1:/hYHWF3Z3dab8SMKnw99ixVktCuJe2bAw5wstCZIEN8=
 20240903155435_entitlement-expired-index.down.sql h1:np2xgYs3KQ2z7qPBcobtGNhqWQ3V8NwEP9E5U3TmpSA=
@@ -129,3 +129,5 @@ h1:GBSDL939Zna5rKl2wFhpUqGQJUHddDKFReBELgNGbV0=
 20250306040407_resource_meter.up.sql h1:L0bhDCSzStPWsIvx6hULDKK7eurpBD3bIv9b18mSWqc=
 20250307151454_balance-snapshot-usage.down.sql h1:UprCI9cWSumzY1NXmlO055r65VEd2M8+vvMzkJc6Q3g=
 20250307151454_balance-snapshot-usage.up.sql h1:j2x/+rYBLsHNpUCmeKwvyXe1TwXTSDMlddESgUFUqMM=
+20250311193204_balance-snapshot-indexes.down.sql h1:8EImnDEROfVw7dS2S6iIsbKH7L2VKBPdjKmfXV4bv4c=
+20250311193204_balance-snapshot-indexes.up.sql h1:pOm1/hjT5JNIKY6HGoE9cKdm7sEktvGoe70aXIXdtas=


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This should help with the usage snapshot queries.

Usage snapshot queries are the longest legs in traces. This rework changes the query:

```
SELECT "balance_snapshots"."id", "balance_snapshots"."namespace", "balance_snapshots"."created_at", "balance_snapshots"."updated_at", "balance_snapshots"."deleted_at", "balance_snapshots"."owner_id", "balance_snapshots"."grant_balances", "balance_snapshots"."usage", "balance_snapshots"."balance", "balance_snapshots"."overage", "balance_snapshots"."at" FROM "balance_snapshots" WHERE (("balance_snapshots"."owner_id" = $1 AND "balance_snapshots"."namespace" = $2) AND "balance_snapshots"."at" <= $3) AND "balance_snapshots"."deleted_at" IS NULL ORDER BY "balance_snapshots"."at" DESC, "balance_snapshots"."updated_at" DESC LIMIT 1
```

Plan before the index:
```
                             QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=8.32..8.32 rows=1 width=196)
   ->  Sort  (cost=8.32..8.32 rows=1 width=196)
         Sort Key: at DESC, updated_at DESC
         ->  Index Scan Backward using balancesnapshot_namespace_at on balance_snapshots  (cost=0.28..8.31 rows=1 width=196)
               Index Cond: (((namespace)::text = 'org_test'::text) AND (at <= now()))
               Filter: ((deleted_at IS NULL) AND (owner_id = 'dsadsadsadsA'::bpchar))
(6 rows)

```

Plan after the index change:
```
                                                          QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=8.32..8.32 rows=1 width=196)
   ->  Sort  (cost=8.32..8.32 rows=1 width=196)
         Sort Key: at DESC, updated_at DESC
         ->  Index Scan Backward using turip_test on balance_snapshots  (cost=0.28..8.31 rows=1 width=196)
               Index Cond: (((namespace)::text = 'org_test'::text) AND (owner_id = 'dsadsadsadsA'::bpchar) AND (at <= now()))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the internal indexing for balance tracking records with refined filtering conditions to improve query performance and data consistency.
- **Chores**
  - Adjusted database migration procedures to align with the new indexing strategy, ensuring a seamless schema update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->