### PR TITLE
feat: pin customers to billing profiles on default profile change

### DIFF
--- a/openmeter/billing/adapter.go
+++ b/openmeter/billing/adapter.go
@@ -30,8 +30,10 @@ type ProfileAdapter interface {
 	GetDefaultProfile(ctx context.Context, input GetDefaultProfileInput) (*AdapterGetProfileResponse, error)
 	DeleteProfile(ctx context.Context, input DeleteProfileInput) error
 	UpdateProfile(ctx context.Context, input UpdateProfileAdapterInput) (*BaseProfile, error)
-	UnsetDefaultProfile(ctx context.Context, input UnsetDefaultProfileInput) error
+
 	IsAppUsed(ctx context.Context, appID app.AppID) (bool, error)
+
+	GetUnpinnedCustomerIDsWithPaidSubscription(ctx context.Context, input GetUnpinnedCustomerIDsWithPaidSubscriptionInput) ([]customer.CustomerID, error)
 }
 
 type CustomerOverrideAdapter interface {
@@ -40,6 +42,8 @@ type CustomerOverrideAdapter interface {
 	UpdateCustomerOverride(ctx context.Context, input UpdateCustomerOverrideAdapterInput) (*CustomerOverride, error)
 	DeleteCustomerOverride(ctx context.Context, input DeleteCustomerOverrideInput) error
 	ListCustomerOverrides(ctx context.Context, input ListCustomerOverridesInput) (ListCustomerOverridesAdapterResult, error)
+
+	BulkAssignCustomersToProfile(ctx context.Context, input BulkAssignCustomersToProfileInput) error
 
 	GetCustomerOverrideReferencingProfile(ctx context.Context, input HasCustomerOverrideReferencingProfileAdapterInput) ([]customer.CustomerID, error)
 }

--- a/openmeter/billing/customeroverride.go
+++ b/openmeter/billing/customeroverride.go
@@ -1,6 +1,7 @@
 package billing
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -307,3 +308,26 @@ type CustomerOverrideWithCustomerID struct {
 }
 
 type ListCustomerOverridesAdapterResult = pagination.PagedResponse[CustomerOverrideWithCustomerID]
+
+type BulkAssignCustomersToProfileInput struct {
+	ProfileID   ProfileID
+	CustomerIDs []customer.CustomerID
+}
+
+func (b BulkAssignCustomersToProfileInput) Validate() error {
+	if err := b.ProfileID.Validate(); err != nil {
+		return fmt.Errorf("invalid billing profile: %w", err)
+	}
+
+	if len(b.CustomerIDs) == 0 {
+		return errors.New("customer ids are required")
+	}
+
+	for i, customerID := range b.CustomerIDs {
+		if err := customerID.Validate(); err != nil {
+			return fmt.Errorf("invalid customer id[%d]: %w", i, err)
+		}
+	}
+
+	return nil
+}

--- a/openmeter/billing/profile.go
+++ b/openmeter/billing/profile.go
@@ -475,4 +475,14 @@ func (i UpdateProfileAdapterInput) Validate() error {
 	return nil
 }
 
-type UnsetDefaultProfileInput = ProfileID
+type GetUnpinnedCustomerIDsWithPaidSubscriptionInput struct {
+	Namespace string
+}
+
+func (i GetUnpinnedCustomerIDsWithPaidSubscriptionInput) Validate() error {
+	if i.Namespace == "" {
+		return errors.New("namespace is required")
+	}
+
+	return nil
+}

--- a/test/billing/subscription_suite.go
+++ b/test/billing/subscription_suite.go
@@ -1,0 +1,204 @@
+package billing
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/openmeterio/openmeter/openmeter/credit"
+	grantrepo "github.com/openmeterio/openmeter/openmeter/credit/adapter"
+	"github.com/openmeterio/openmeter/openmeter/credit/balance"
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/ent/db"
+	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
+	"github.com/openmeterio/openmeter/openmeter/entitlement"
+	entitlementrepo "github.com/openmeterio/openmeter/openmeter/entitlement/adapter"
+	booleanentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/boolean"
+	meteredentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/metered"
+	staticentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/static"
+	meteradapter "github.com/openmeterio/openmeter/openmeter/meter/mockadapter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	planadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/plan/adapter"
+	planservice "github.com/openmeterio/openmeter/openmeter/productcatalog/plan/service"
+	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription/testutils"
+	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	subscriptionentitlementadatapter "github.com/openmeterio/openmeter/openmeter/subscription/adapters/entitlement"
+	subscriptionrepo "github.com/openmeterio/openmeter/openmeter/subscription/repo"
+	subscriptionservice "github.com/openmeterio/openmeter/openmeter/subscription/service"
+	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/isodate"
+)
+
+type SubscriptionMixin struct {
+	PlanService                 plan.Service
+	SubscriptionService         subscription.Service
+	SubscriptionPlanAdapter     subscriptiontestutils.PlanSubscriptionAdapter
+	SubscriptionWorkflowService subscription.WorkflowService
+}
+
+type SubscriptionMixInDependencies struct {
+	DBClient *db.Client
+
+	FeatureRepo     feature.FeatureRepo
+	FeatureService  feature.FeatureConnector
+	CustomerService customer.Service
+
+	MeterAdapter           *meteradapter.TestAdapter
+	MockStreamingConnector *streamingtestutils.MockStreamingConnector
+}
+
+func (d SubscriptionMixInDependencies) Validate() error {
+	if d.DBClient == nil {
+		return errors.New("DBClient is required")
+	}
+
+	if d.FeatureRepo == nil {
+		return errors.New("FeatureRepo is required")
+	}
+
+	if d.FeatureService == nil {
+		return errors.New("FeatureService is required")
+	}
+
+	if d.CustomerService == nil {
+		return errors.New("CustomerService is required")
+	}
+
+	if d.MeterAdapter == nil {
+		return errors.New("MeterAdapter is required")
+	}
+
+	if d.MockStreamingConnector == nil {
+		return errors.New("MockStreamingConnector is required")
+	}
+
+	return nil
+}
+
+func (s *SubscriptionMixin) SetupSuite(t *testing.T, deps SubscriptionMixInDependencies) {
+	require.NoError(t, deps.Validate())
+
+	planAdapter, err := planadapter.New(planadapter.Config{
+		Client: deps.DBClient,
+		Logger: slog.Default(),
+	})
+	require.NoError(t, err)
+
+	planService, err := planservice.New(planservice.Config{
+		Feature: deps.FeatureService,
+		Adapter: planAdapter,
+		Logger:  slog.Default(),
+	})
+	require.NoError(t, err)
+
+	s.PlanService = planService
+
+	subsRepo := subscriptionrepo.NewSubscriptionRepo(deps.DBClient)
+	subsItemRepo := subscriptionrepo.NewSubscriptionItemRepo(deps.DBClient)
+
+	s.SubscriptionService = subscriptionservice.New(subscriptionservice.ServiceConfig{
+		SubscriptionRepo:      subsRepo,
+		SubscriptionPhaseRepo: subscriptionrepo.NewSubscriptionPhaseRepo(deps.DBClient),
+		SubscriptionItemRepo:  subsItemRepo,
+		// connectors
+		CustomerService: deps.CustomerService,
+		// adapters
+		EntitlementAdapter: subscriptionentitlementadatapter.NewSubscriptionEntitlementAdapter(
+			s.SetupEntitlements(t, deps),
+			subsItemRepo,
+			subsRepo,
+		),
+		// framework
+		TransactionManager: subsRepo,
+		// events
+		Publisher: eventbus.NewMock(t),
+	})
+
+	s.SubscriptionPlanAdapter = subscriptiontestutils.NewPlanSubscriptionAdapter(subscriptiontestutils.PlanSubscriptionAdapterConfig{
+		PlanService: planService,
+		Logger:      slog.Default(),
+	})
+
+	s.SubscriptionWorkflowService = subscriptionservice.NewWorkflowService(subscriptionservice.WorkflowServiceConfig{
+		Service:            s.SubscriptionService,
+		CustomerService:    deps.CustomerService,
+		TransactionManager: subsRepo,
+	})
+}
+
+func (s *SubscriptionMixin) SetupEntitlements(t *testing.T, deps SubscriptionMixInDependencies) entitlement.Connector {
+	tracer := noop.NewTracerProvider().Tracer("test")
+
+	// Init grants/credit
+	grantRepo := grantrepo.NewPostgresGrantRepo(deps.DBClient)
+	balanceSnapshotRepo := grantrepo.NewPostgresBalanceSnapshotRepo(deps.DBClient)
+
+	// Init entitlements
+	entitlementRepo := entitlementrepo.NewPostgresEntitlementRepo(deps.DBClient)
+	usageResetRepo := entitlementrepo.NewPostgresUsageResetRepo(deps.DBClient)
+
+	mockPublisher := eventbus.NewMock(t)
+
+	owner := meteredentitlement.NewEntitlementGrantOwnerAdapter(
+		deps.FeatureRepo,
+		entitlementRepo,
+		usageResetRepo,
+		deps.MeterAdapter,
+		slog.Default(),
+		tracer,
+	)
+
+	balanceSnapshotService := balance.NewSnapshotService(balance.SnapshotServiceConfig{
+		OwnerConnector:     owner,
+		StreamingConnector: deps.MockStreamingConnector,
+		Repo:               balanceSnapshotRepo,
+	})
+
+	transactionManager := enttx.NewCreator(deps.DBClient)
+
+	creditConnector := credit.NewCreditConnector(
+		credit.CreditConnectorConfig{
+			GrantRepo:              grantRepo,
+			BalanceSnapshotService: balanceSnapshotService,
+			OwnerConnector:         owner,
+			StreamingConnector:     deps.MockStreamingConnector,
+			Logger:                 slog.Default(),
+			Tracer:                 tracer,
+			Granularity:            time.Minute,
+			Publisher:              mockPublisher,
+			TransactionManager:     transactionManager,
+			SnapshotGracePeriod:    isodate.MustParse(t, "P1W"),
+		},
+	)
+
+	meteredEntitlementConnector := meteredentitlement.NewMeteredEntitlementConnector(
+		deps.MockStreamingConnector,
+		owner,
+		creditConnector,
+		creditConnector,
+		grantRepo,
+		entitlementRepo,
+		mockPublisher,
+		slog.Default(),
+		tracer,
+	)
+
+	staticEntitlementConnector := staticentitlement.NewStaticEntitlementConnector()
+	booleanEntitlementConnector := booleanentitlement.NewBooleanEntitlementConnector()
+
+	return entitlement.NewEntitlementConnector(
+		entitlementRepo,
+		deps.FeatureService,
+		deps.MeterAdapter,
+		meteredEntitlementConnector,
+		staticEntitlementConnector,
+		booleanEntitlementConnector,
+		mockPublisher,
+	)
+}

--- a/test/billing/subscription_test.go
+++ b/test/billing/subscription_test.go
@@ -1,0 +1,324 @@
+package billing
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/invopop/gobl/currency"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/openmeterio/openmeter/openmeter/app"
+	appsandbox "github.com/openmeterio/openmeter/openmeter/app/sandbox"
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	billingworkersubscription "github.com/openmeterio/openmeter/openmeter/billing/worker/subscription"
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	productcatalogsubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/isodate"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type SubscriptionTestSuite struct {
+	BaseSuite
+	SubscriptionMixin
+
+	SubscriptionSyncHandler *billingworkersubscription.Handler
+}
+
+func TestSubscription(t *testing.T) {
+	suite.Run(t, new(SubscriptionTestSuite))
+}
+
+func (s *SubscriptionTestSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	s.SubscriptionMixin.SetupSuite(s.T(), s.GetSubscriptionMixInDependencies())
+
+	handler, err := billingworkersubscription.New(billingworkersubscription.Config{
+		BillingService:      s.BillingService,
+		Logger:              slog.Default(),
+		TxCreator:           s.BillingAdapter,
+		SubscriptionService: s.SubscriptionService,
+	})
+	s.NoError(err)
+	s.NotNil(handler)
+
+	s.SubscriptionSyncHandler = handler
+}
+
+func (s *SubscriptionTestSuite) TestDefaultProfileChange() {
+	namespace := "ns-default-profile-change"
+	ctx := context.Background()
+
+	// Given we have a default profile
+
+	defaultProfileSettings := MinimalCreateProfileInputTemplate
+	defaultProfileSettings.Default = true
+	defaultProfileSettings.Namespace = namespace
+
+	s.InstallSandboxApp(s.T(), namespace)
+
+	defaultProfile, err := s.BillingService.CreateProfile(context.Background(), defaultProfileSettings)
+	s.NoError(err)
+	s.NotNil(defaultProfile)
+
+	// Given we have another non-default profile pinned to a different app
+	appTypeOther := app.AppType("test-app-type-other")
+
+	appFactoryOther, err := appsandbox.NewMockableFactory(s.T(), appsandbox.Config{
+		AppService:     s.AppService,
+		BillingService: s.BillingService,
+	}, appsandbox.MockWithAppType(appTypeOther))
+	s.NoError(err)
+	s.NotNil(appFactoryOther)
+
+	otherApp, err := s.AppService.CreateApp(ctx, app.CreateAppInput{
+		Namespace: namespace,
+		Name:      "test-app-other",
+		Type:      appTypeOther,
+	})
+	s.NoError(err)
+	s.NotNil(otherApp)
+
+	otherAppReference := billing.AppReference{
+		ID: otherApp.ID,
+	}
+
+	otherProfileSettings := MinimalCreateProfileInputTemplate
+	otherProfileSettings.Namespace = namespace
+	otherProfileSettings.Apps = billing.CreateProfileAppsInput{
+		Tax:       otherAppReference,
+		Invoicing: otherAppReference,
+		Payment:   otherAppReference,
+	}
+	otherProfileSettings.Default = false
+
+	otherProfile, err := s.BillingService.CreateProfile(context.Background(), otherProfileSettings)
+	s.NoError(err)
+	s.NotNil(otherProfile)
+
+	// Given we have a paid and an unpaid plan
+	paidPlan, err := s.PlanService.CreatePlan(ctx, plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:     "Test Plan",
+				Key:      "paid-plan",
+				Version:  1,
+				Currency: currency.USD,
+			},
+
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: productcatalog.PhaseMeta{
+						Name:     "first-phase",
+						Key:      "first-phase",
+						Duration: nil,
+					},
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:  "in-arrears",
+								Name: "in-arrears",
+								Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+									Amount:      alpacadecimal.NewFromFloat(5),
+									PaymentTerm: productcatalog.InArrearsPaymentTerm,
+								}),
+							},
+							BillingCadence: isodate.MustParse(s.T(), "P1D"),
+						},
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+	s.NotNil(paidPlan)
+
+	subscriptionPaidPlan, err := s.SubscriptionPlanAdapter.GetVersion(ctx, namespace, productcatalogsubscription.PlanRefInput{
+		Key:     paidPlan.Key,
+		Version: lo.ToPtr(1),
+	})
+	s.NoError(err)
+	s.NotNil(subscriptionPaidPlan)
+
+	freePlan, err := s.PlanService.CreatePlan(ctx, plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:     "Test Plan",
+				Key:      "free-plan",
+				Version:  1,
+				Currency: currency.USD,
+			},
+
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: productcatalog.PhaseMeta{
+						Name:     "first-phase",
+						Key:      "first-phase",
+						Duration: nil,
+					},
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:  "in-arrears",
+								Name: "in-arrears",
+							},
+							BillingCadence: isodate.MustParse(s.T(), "P1D"),
+						},
+					},
+				},
+			},
+		},
+	})
+	s.NoError(err)
+	s.NotNil(freePlan)
+
+	subscriptionFreePlan, err := s.SubscriptionPlanAdapter.GetVersion(ctx, namespace, productcatalogsubscription.PlanRefInput{
+		Key:     freePlan.Key,
+		Version: lo.ToPtr(1),
+	})
+	s.NoError(err)
+	s.NotNil(subscriptionFreePlan)
+
+	// Given we have 4 customers:
+	// - 2 unpinned customers (one for paid and one for free subscription)
+	// - 1 pinned customer to the default profile (paid plan)
+	// - 1 pinned customer to the other profile (paid plan)
+
+	// Unpinned paid plan customer
+	unPinnedPaidPlanCustomer := s.createCustomerWithSubscription(ctx, namespace, "unPinnedPaidPlanCustomer", subscriptionPaidPlan)
+	s.NotNil(unPinnedPaidPlanCustomer)
+
+	// Unpinned free plan customer
+	unPinnedFreePlanCustomer := s.createCustomerWithSubscription(ctx, namespace, "unPinnedFreePlanCustomer", subscriptionFreePlan)
+	s.NotNil(unPinnedFreePlanCustomer)
+
+	// Customer pinned to the default profile
+	pinnedCustomerToDefaultProfileCustomer := s.createCustomerWithSubscription(ctx, namespace, "pinnedCustomerToDefaultProfile", subscriptionPaidPlan)
+	s.NotNil(pinnedCustomerToDefaultProfileCustomer)
+
+	override, err := s.BillingService.UpsertCustomerOverride(ctx, billing.UpsertCustomerOverrideInput{
+		Namespace:  namespace,
+		CustomerID: pinnedCustomerToDefaultProfileCustomer.ID,
+		ProfileID:  defaultProfile.ID,
+	})
+	s.NoError(err)
+	s.NotNil(override.CustomerOverride)
+	s.Equal(defaultProfile.ID, override.CustomerOverride.Profile.ID)
+
+	// Customer pinned to the other profile
+	pinnedCustomerToOtherProfileCustomer := s.createCustomerWithSubscription(ctx, namespace, "pinnedCustomerToOtherProfile", subscriptionPaidPlan)
+	s.NotNil(pinnedCustomerToOtherProfileCustomer)
+
+	override, err = s.BillingService.UpsertCustomerOverride(ctx, billing.UpsertCustomerOverrideInput{
+		Namespace:  namespace,
+		CustomerID: pinnedCustomerToOtherProfileCustomer.ID,
+		ProfileID:  otherProfile.ID,
+	})
+	s.NoError(err)
+	s.NotNil(override.CustomerOverride)
+	s.Equal(otherProfile.ID, override.CustomerOverride.Profile.ID)
+
+	// When
+	//   Changing the default profile to the "other" profile
+
+	otherProfile.Default = true
+	otherProfile.Apps = nil
+	otherProfile.AppReferences = nil
+
+	_, err = s.BillingService.UpdateProfile(ctx, billing.UpdateProfileInput(otherProfile.BaseProfile))
+	s.NoError(err)
+
+	// Then
+	//   The profiles are updated properly
+	otherProfile, err = s.BillingService.GetProfile(ctx, billing.GetProfileInput{
+		Profile: otherProfile.ProfileID(),
+	})
+	s.NoError(err)
+	s.NotNil(otherProfile)
+	s.True(otherProfile.Default)
+
+	oldDefaultProfile, err := s.BillingService.GetProfile(ctx, billing.GetProfileInput{
+		Profile: defaultProfile.ProfileID(),
+	})
+	s.NoError(err)
+	s.NotNil(oldDefaultProfile)
+	s.False(oldDefaultProfile.Default)
+
+	// Then
+	//   unPinnedPaidPlanCustomer is pinned to the old profile
+	customerOverride, err := s.BillingService.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
+		Customer: unPinnedPaidPlanCustomer.GetID(),
+	})
+	s.NoError(err)
+	s.NotNil(customerOverride.CustomerOverride)
+	s.Equal(oldDefaultProfile.ID, customerOverride.CustomerOverride.Profile.ID)
+
+	// Then
+	//  unPinnedFreePlanCustomer does not have customer overrides
+	customerOverride, err = s.BillingService.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
+		Customer: unPinnedFreePlanCustomer.GetID(),
+	})
+	s.NoError(err)
+	s.Nil(customerOverride.CustomerOverride)
+
+	// Then
+	//   pinnedCustomerToDefaultProfileCustomer is pinned to the old default profile
+	customerOverride, err = s.BillingService.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
+		Customer: pinnedCustomerToDefaultProfileCustomer.GetID(),
+	})
+	s.NoError(err)
+	s.NotNil(customerOverride.CustomerOverride)
+	s.Equal(oldDefaultProfile.ID, customerOverride.CustomerOverride.Profile.ID)
+
+	// Then
+	//   pinnedCustomerToOtherProfileCustomer is pinned to the new profile
+	customerOverride, err = s.BillingService.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
+		Customer: pinnedCustomerToOtherProfileCustomer.GetID(),
+	})
+	s.NoError(err)
+	s.NotNil(customerOverride.CustomerOverride)
+	s.Equal(otherProfile.ID, customerOverride.CustomerOverride.Profile.ID)
+}
+
+func (s *SubscriptionTestSuite) createCustomerWithSubscription(ctx context.Context, namespace string, customerKey string, plan subscription.Plan) *customer.Customer { //nolint:unparam
+	cust, err := s.CustomerService.CreateCustomer(ctx, customer.CreateCustomerInput{
+		Namespace: namespace,
+
+		CustomerMutate: customer.CustomerMutate{
+			Name: customerKey,
+			UsageAttribution: customer.CustomerUsageAttribution{
+				SubjectKeys: []string{customerKey},
+			},
+		},
+	})
+	s.NoError(err)
+	s.NotNil(cust)
+
+	subsView, err := s.SubscriptionWorkflowService.CreateFromPlan(ctx, subscription.CreateSubscriptionWorkflowInput{
+		ChangeSubscriptionWorkflowInput: subscription.ChangeSubscriptionWorkflowInput{
+			Timing: subscription.Timing{
+				Custom: lo.ToPtr(clock.Now()),
+			},
+		},
+		Namespace:  namespace,
+		CustomerID: cust.ID,
+	}, plan)
+	s.NoError(err)
+	s.NotNil(subsView)
+
+	s.NoError(s.SubscriptionSyncHandler.SyncronizeSubscription(ctx, subsView, clock.Now()))
+
+	return cust
+}

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -68,6 +68,17 @@ func (s *BaseSuite) GetUniqueNamespace(prefix string) string {
 	return fmt.Sprintf("%s_%s", prefix, ulid.Make().String())
 }
 
+func (b *BaseSuite) GetSubscriptionMixInDependencies() SubscriptionMixInDependencies {
+	return SubscriptionMixInDependencies{
+		DBClient:               b.DBClient,
+		FeatureRepo:            b.FeatureRepo,
+		FeatureService:         b.FeatureService,
+		CustomerService:        b.CustomerService,
+		MeterAdapter:           b.MeterAdapter,
+		MockStreamingConnector: b.MockStreamingConnector,
+	}
+}
+
 func (s *BaseSuite) SetupSuite() {
 	t := s.T()
 	t.Log("setup suite")


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

When the type of an app changes in the default billing profile pin customers with a paid plan to the old billing profile, to prevent any hickups or accidental billing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configurable options for component initialization that improve flexibility in specifying system behaviors.
  - Enhanced subscription management with bulk customer assignment and refined methods for retrieving subscribed customer data.
- **Refactor**
  - Streamlined billing profile transitions to ensure smoother updates and accurate customer reassignments.
- **Tests**
  - Updated and streamlined test suites to better validate subscription and billing functionality improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->