### PR TITLE
fix: invoice deletion throws an error (OM-1251) but completes

### DIFF
--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -797,7 +797,8 @@ func (s *Service) DeleteInvoice(ctx context.Context, input billing.DeleteInvoice
 		return err
 	}
 
-	if invoice.Status != billing.InvoiceStatusDeleted {
+	// Given we are doing background processing, we might be in any delete.* state
+	if invoice.Status == billing.InvoiceStatusDeleteFailed {
 		// If we have validation issues we return them as the deletion sync handler
 		// yields validation errors
 		if len(invoice.ValidationIssues) > 0 {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This happens if background invoice progressing is enabled.

We have changed invoice deletion to happen in the background, this way we cannot expect the deletion to pass.

Fixes OM-1251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved invoice deletion processing by accurately identifying invoices with failed deletion attempts, ensuring more reliable error handling during background processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->