### PR TITLE
fix: plan listing invalid filter

### DIFF
--- a/openmeter/productcatalog/plan/adapter/plan.go
+++ b/openmeter/productcatalog/plan/adapter/plan.go
@@ -99,7 +99,7 @@ func (a *adapter) ListPlans(ctx context.Context, params plan.ListPlansInput) (pa
 
 			if slices.Contains(params.Status, productcatalog.InvalidStatus) {
 				predicates = append(predicates, func(s *sql.Selector) {
-					s.Where(sql.ColumnsLT(plandb.FieldEffectiveFrom, plandb.FieldEffectiveTo))
+					s.Where(sql.ColumnsLT(plandb.FieldEffectiveTo, plandb.FieldEffectiveFrom))
 				})
 			}
 


### PR DESCRIPTION
If effectiveTo < effectiveFrom the plan is considered invalid.

This should not happen, as we have validations in place, but let's correct the check.