### PR TITLE
fix: app deletion check should return proper error messages

### DIFF
--- a/openmeter/app/httpdriver/app.go
+++ b/openmeter/app/httpdriver/app.go
@@ -2,7 +2,6 @@ package httpdriver
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -183,17 +182,13 @@ func (h *handler) UninstallApp() UninstallAppHandler {
 		},
 		func(ctx context.Context, request UninstallAppRequest) (UninstallAppResponse, error) {
 			// Check if the app is not used by any billing profile
-			ok, err := h.billingService.IsAppUsed(ctx, request)
-			if err != nil {
-				return nil, fmt.Errorf("failed to check if app is used: %w", err)
-			}
 
-			if ok {
-				return nil, commonhttp.NewHTTPError(http.StatusConflict, errors.New("app is used by billing profile"))
+			if err := h.billingService.IsAppUsed(ctx, request); err != nil {
+				return nil, err
 			}
 
 			// Uninstall app
-			err = h.service.UninstallApp(ctx, request)
+			err := h.service.UninstallApp(ctx, request)
 			if err != nil {
 				return nil, fmt.Errorf("failed to uninstall app: %w", err)
 			}

--- a/openmeter/billing/adapter.go
+++ b/openmeter/billing/adapter.go
@@ -31,7 +31,7 @@ type ProfileAdapter interface {
 	DeleteProfile(ctx context.Context, input DeleteProfileInput) error
 	UpdateProfile(ctx context.Context, input UpdateProfileAdapterInput) (*BaseProfile, error)
 
-	IsAppUsed(ctx context.Context, appID app.AppID) (bool, error)
+	IsAppUsed(ctx context.Context, appID app.AppID) error
 
 	GetUnpinnedCustomerIDsWithPaidSubscription(ctx context.Context, input GetUnpinnedCustomerIDsWithPaidSubscriptionInput) ([]customer.CustomerID, error)
 }

--- a/openmeter/billing/adapter/invoice.go
+++ b/openmeter/billing/adapter/invoice.go
@@ -820,25 +820,21 @@ func mapPeriodFromDB(start, end *time.Time) *billing.Period {
 }
 
 // IsAppUsed checks if the app is used in any invoice.
-func (a *adapter) IsAppUsed(ctx context.Context, appID app.AppID) (bool, error) {
+func (a *adapter) IsAppUsed(ctx context.Context, appID app.AppID) error {
 	if err := appID.Validate(); err != nil {
-		return false, billing.ValidationError{
+		return billing.ValidationError{
 			Err: fmt.Errorf("invalid app ID: %w", err),
 		}
 	}
 
 	// Check if the app is used in any billing profile
-	isUsedInBillingProfile, err := a.isBillingProfileUsed(ctx, appID)
+	err := a.isBillingProfileUsed(ctx, appID)
 	if err != nil {
-		return false, err
-	}
-
-	if isUsedInBillingProfile {
-		return true, nil
+		return err
 	}
 
 	// Check if the app is used in any invoice in gathering or issued states
-	count, err := a.db.BillingInvoice.
+	usedInInvoices, err := a.db.BillingInvoice.
 		Query().
 		Where(billinginvoice.Namespace(appID.Namespace)).
 		Where(
@@ -862,10 +858,16 @@ func (a *adapter) IsAppUsed(ctx context.Context, appID app.AppID) (bool, error) 
 				billinginvoice.TaxAppID(appID.ID),
 			),
 		).
-		Count(ctx)
+		All(ctx)
 	if err != nil {
-		return false, fmt.Errorf("failed to check if invoices are correctly associated with apps: %w", err)
+		return err
 	}
 
-	return count > 0, nil
+	if len(usedInInvoices) > 0 {
+		return models.NewGenericConflictError(fmt.Errorf("app is used in %d non-finalized invoices: %s", len(usedInInvoices), strings.Join(lo.Map(usedInInvoices, func(invoice *db.BillingInvoice, _ int) string {
+			return fmt.Sprintf("%s[%s]", invoice.Number, invoice.ID)
+		}), ",")))
+	}
+
+	return nil
 }

--- a/openmeter/billing/adapter/invoice.go
+++ b/openmeter/billing/adapter/invoice.go
@@ -850,6 +850,7 @@ func (a *adapter) IsAppUsed(ctx context.Context, appID app.AppID) error {
 				billing.InvoiceStatusPaymentProcessingActionRequired,
 				billing.InvoiceStatusOverdue,
 			),
+			billinginvoice.DeletedAtIsNil(),
 		).
 		Where(
 			billinginvoice.Or(

--- a/openmeter/billing/errors.go
+++ b/openmeter/billing/errors.go
@@ -88,24 +88,6 @@ func (e NotFoundError) Unwrap() error {
 	return e.Err
 }
 
-type ConflictError struct {
-	ID     string
-	Entity string
-	Err    error
-}
-
-func (e ConflictError) Error() string {
-	if e.ID == "" {
-		return e.Err.Error()
-	}
-
-	return fmt.Sprintf("%s [%s/%s]", e.Err, e.Entity, e.ID)
-}
-
-func (e ConflictError) Unwrap() error {
-	return e.Err
-}
-
 type genericError struct {
 	Err error
 }

--- a/openmeter/billing/httpdriver/errors.go
+++ b/openmeter/billing/httpdriver/errors.go
@@ -12,7 +12,6 @@ import (
 func errorEncoder() encoder.ErrorEncoder {
 	return func(ctx context.Context, err error, w http.ResponseWriter, r *http.Request) bool {
 		return commonhttp.HandleErrorIfTypeMatches[billing.NotFoundError](ctx, http.StatusNotFound, err, w, billing.EncodeValidationIssues) ||
-			commonhttp.HandleErrorIfTypeMatches[billing.ConflictError](ctx, http.StatusConflict, err, w, billing.EncodeValidationIssues) ||
 			commonhttp.HandleErrorIfTypeMatches[billing.ValidationError](ctx, http.StatusBadRequest, err, w, billing.EncodeValidationIssues) ||
 			commonhttp.HandleErrorIfTypeMatches[billing.UpdateAfterDeleteError](ctx, http.StatusConflict, err, w, billing.EncodeValidationIssues) ||
 			commonhttp.HandleErrorIfTypeMatches[billing.ValidationIssue](ctx, http.StatusBadRequest, err, w, billing.EncodeValidationIssues) ||

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -26,7 +26,7 @@ type ProfileService interface {
 	DeleteProfile(ctx context.Context, input DeleteProfileInput) error
 	UpdateProfile(ctx context.Context, input UpdateProfileInput) (*Profile, error)
 	ProvisionDefaultBillingProfile(ctx context.Context, namespace string) error
-	IsAppUsed(ctx context.Context, appID app.AppID) (bool, error)
+	IsAppUsed(ctx context.Context, appID app.AppID) error
 }
 
 type CustomerOverrideService interface {

--- a/openmeter/billing/service/profile.go
+++ b/openmeter/billing/service/profile.go
@@ -413,8 +413,10 @@ func (s *Service) ProvisionDefaultBillingProfile(ctx context.Context, namespace 
 	return nil
 }
 
-func (s *Service) IsAppUsed(ctx context.Context, appID app.AppID) (bool, error) {
-	return s.adapter.IsAppUsed(ctx, appID)
+func (s *Service) IsAppUsed(ctx context.Context, appID app.AppID) error {
+	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
+		return s.adapter.IsAppUsed(ctx, appID)
+	})
 }
 
 func (s *Service) resolveProfileApps(ctx context.Context, input *billing.BaseProfile) (*billing.Profile, error) {

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1212,8 +1212,8 @@ func (n NoopBillingService) ProvisionDefaultBillingProfile(ctx context.Context, 
 	return nil
 }
 
-func (n NoopBillingService) IsAppUsed(ctx context.Context, appID app.AppID) (bool, error) {
-	return false, nil
+func (n NoopBillingService) IsAppUsed(ctx context.Context, appID app.AppID) error {
+	return nil
 }
 
 // CustomerOverrideService methods

--- a/test/billing/profile_test.go
+++ b/test/billing/profile_test.go
@@ -123,9 +123,10 @@ func (s *ProfileTestSuite) TestProfileLifecycle() {
 			profile := s.createProfileFixture(true)
 			require.NotNil(t, profile)
 
-			ok, err := s.BillingService.IsAppUsed(ctx, profile.Apps.Invoicing.GetID())
-			require.NoError(t, err)
-			require.True(t, ok)
+			err := s.BillingService.IsAppUsed(ctx, profile.Apps.Invoicing.GetID())
+
+			var conflictErr *models.GenericConflictError
+			require.ErrorAs(t, err, &conflictErr)
 		})
 
 		s.T().Run("app should not be used", func(t *testing.T) {
@@ -137,9 +138,8 @@ func (s *ProfileTestSuite) TestProfileLifecycle() {
 				ID:        ulid.Make().String(),
 			}
 
-			ok, err := s.BillingService.IsAppUsed(ctx, anotherAppID)
+			err := s.BillingService.IsAppUsed(ctx, anotherAppID)
 			require.NoError(t, err)
-			require.False(t, ok)
 		})
 	})
 


### PR DESCRIPTION
It will make our users easier to understand why an app cannot be deleted.

Also fixes the bug that when invoices are deleted we don't allow app deletion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified error handling across billing and application usage checks.
  - Unification of method responses to report issues solely via error messages, removing redundant status indicators.
  - Enhanced conflict notifications for scenarios involving active billing profiles or pending invoices.
  - Removed deprecated conflict handling components for a more consistent, streamlined user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->