### PR TITLE
refactor: meter events service

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -333,16 +333,16 @@ func TestInvalidIngest(t *testing.T) {
 
 	// null data should have processing error
 	require.NotNil(t, events[0].ValidationError)
-	require.Equal(t, `event data is null and missing value property`, *events[0].ValidationError)
+	require.Equal(t, `invalid event: null and missing value property`, *events[0].ValidationError)
 
 	// missing data should have processing error
 	// we only validate events against meters in the processing pipeline so this is an async error
 	require.NotNil(t, events[1].ValidationError)
-	require.Equal(t, `event data is null and missing value property`, *events[1].ValidationError)
+	require.Equal(t, `invalid event: null and missing value property`, *events[1].ValidationError)
 
 	// empty data should have processing error as it does not have the required value property
 	require.NotNil(t, events[2].ValidationError)
-	require.Equal(t, `event data is missing value property at "$.duration_ms"`, *events[2].ValidationError)
+	require.Equal(t, `invalid event: missing value property: "$.duration_ms"`, *events[2].ValidationError)
 }
 
 func TestDedupe(t *testing.T) {

--- a/openmeter/meter/parse.go
+++ b/openmeter/meter/parse.go
@@ -1,21 +1,21 @@
 package meter
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
 
-	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/oliveagle/jsonpath"
 )
 
 // ParseEvent validates and parses an event against a meter.
-func ParseEvent(meter Meter, ev event.Event) (*float64, *string, map[string]string, error) {
+func ParseEvent(meter Meter, dataStr string) (*float64, *string, map[string]string, error) {
 	// Parse CloudEvents data
 	var data interface{}
 
-	if len(ev.Data()) > 0 {
-		err := ev.DataAs(&data)
+	if len(dataStr) > 0 {
+		err := json.Unmarshal([]byte(dataStr), &data)
 		if err != nil {
 			return nil, nil, map[string]string{}, errors.New("cannot unmarshal event data")
 		}

--- a/openmeter/meter/parse.go
+++ b/openmeter/meter/parse.go
@@ -7,49 +7,116 @@ import (
 	"strconv"
 
 	"github.com/oliveagle/jsonpath"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-// ParseEvent validates and parses an event against a meter.
-func ParseEvent(meter Meter, dataStr string) (*float64, *string, map[string]string, error) {
-	// Parse CloudEvents data
-	var data interface{}
+var _ models.GenericError = (*ErrInvalidEvent)(nil)
 
-	if len(dataStr) > 0 {
-		err := json.Unmarshal([]byte(dataStr), &data)
+type ErrInvalidEvent struct {
+	err error
+}
+
+func (e ErrInvalidEvent) Error() string {
+	s := "invalid event"
+	if e.err != nil {
+		return s + ": " + e.err.Error()
+	}
+
+	return s
+}
+
+func (e ErrInvalidEvent) Unwrap() error {
+	return e.err
+}
+
+func NewErrInvalidEvent(err error) error {
+	return ErrInvalidEvent{err: err}
+}
+
+var _ models.GenericError = (*ErrInvalidMeter)(nil)
+
+type ErrInvalidMeter struct {
+	err error
+}
+
+func (e ErrInvalidMeter) Error() string {
+	s := "invalid meter"
+	if e.err != nil {
+		return s + ": " + e.err.Error()
+	}
+
+	return s
+}
+
+func (e ErrInvalidMeter) Unwrap() error {
+	return e.err
+}
+
+func NewErrInvalidMeter(err error) error {
+	return &ErrInvalidMeter{err: err}
+}
+
+type ParsedEvent struct {
+	Value       *float64
+	ValueString *string
+	GroupBy     map[string]string
+}
+
+func ParseEventString(meter Meter, data string) (*ParsedEvent, error) {
+	return ParseEvent(meter, []byte(data))
+}
+
+// ParseEvent validates and parses an event against a meter.
+func ParseEvent(meter Meter, data []byte) (*ParsedEvent, error) {
+	// Parse CloudEvents data
+	var (
+		event interface{}
+		err   error
+	)
+
+	parsedEvent := &ParsedEvent{
+		GroupBy: map[string]string{},
+	}
+
+	if len(data) > 0 {
+		err = json.Unmarshal(data, &event)
 		if err != nil {
-			return nil, nil, map[string]string{}, errors.New("cannot unmarshal event data")
+			return parsedEvent, NewErrInvalidEvent(fmt.Errorf("failed to parse event data: %w", err))
 		}
 	}
 
 	// Parse group by fields
-	groupBy := parseGroupBy(meter, data)
+	parsedEvent.GroupBy = parseGroupBy(meter, event)
 
 	// We can skip count events as they don't have value property
 	if meter.Aggregation == MeterAggregationCount {
-		value := 1.0
-		return &value, nil, groupBy, nil
+		parsedEvent.Value = lo.ToPtr(1.0)
+
+		return parsedEvent, nil
 	}
 
 	// Non count events require value property to be present
 	// If the event data is null, we return an error as value property is missing
-	if data == nil {
-		return nil, nil, groupBy, errors.New("event data is null and missing value property")
+	if event == nil {
+		return parsedEvent, NewErrInvalidEvent(errors.New("null and missing value property"))
 	}
 
-	var rawValue interface{}
-
 	if meter.ValueProperty == nil {
-		return nil, nil, groupBy, errors.New("non count meter value property is missing")
+		return parsedEvent, NewErrInvalidEvent(errors.New("non count meter value property is missing"))
 	}
 
 	// Get value from event data by value property
-	rawValue, err := jsonpath.JsonPathLookup(data, *meter.ValueProperty)
+	var rawValue interface{}
+
+	rawValue, err = jsonpath.JsonPathLookup(event, *meter.ValueProperty)
 	if err != nil {
-		return nil, nil, groupBy, fmt.Errorf("event data is missing value property at %q", *meter.ValueProperty)
+		return parsedEvent, NewErrInvalidEvent(fmt.Errorf("missing value property: %q", *meter.ValueProperty))
 	}
 
 	if rawValue == nil {
-		return nil, nil, groupBy, errors.New("event data value cannot be null")
+		return parsedEvent, NewErrInvalidEvent(errors.New("value cannot be null"))
 	}
 
 	// Aggregation specific value validation
@@ -57,30 +124,32 @@ func ParseEvent(meter Meter, dataStr string) (*float64, *string, map[string]stri
 	// UNIQUE_COUNT aggregation requires string property value
 	case MeterAggregationUniqueCount:
 		// We convert the value to string
-		val := fmt.Sprintf("%v", rawValue)
-		return nil, &val, groupBy, nil
+		parsedEvent.ValueString = lo.ToPtr(fmt.Sprintf("%v", rawValue))
 
+		return parsedEvent, nil
 	// SUM, AVG, MIN, MAX aggregations require float64 parsable value property value
 	case MeterAggregationSum, MeterAggregationAvg, MeterAggregationMin, MeterAggregationMax:
-		switch value := rawValue.(type) {
+		switch v := rawValue.(type) {
 		case string:
-			val, err := strconv.ParseFloat(value, 64)
+			parsedValue, err := strconv.ParseFloat(v, 64)
 			if err != nil {
 				// TODO: omit value or make sure it's length is not too long
-				return nil, nil, groupBy, fmt.Errorf("event data value cannot be parsed as float64: %s", value)
+				return parsedEvent, NewErrInvalidEvent(fmt.Errorf("value cannot be parsed as float64: %s", v))
 			}
 
-			return &val, nil, groupBy, nil
+			parsedEvent.Value = lo.ToPtr(parsedValue)
 
+			return parsedEvent, nil
 		case float64:
-			return &value, nil, groupBy, nil
+			parsedEvent.Value = lo.ToPtr(v)
 
+			return parsedEvent, nil
 		default:
-			return nil, nil, groupBy, errors.New("event data value property cannot be parsed")
+			return parsedEvent, NewErrInvalidEvent(fmt.Errorf("unsupported value property type: %T", v))
 		}
 	}
 
-	return nil, nil, groupBy, fmt.Errorf("unknown meter aggregation: %s", meter.Aggregation)
+	return parsedEvent, NewErrInvalidMeter(fmt.Errorf("unknown meter aggregation: %s", meter.Aggregation))
 }
 
 // parseGroupBy parses the group by fields from the event data

--- a/openmeter/meterevent/adapter/event.go
+++ b/openmeter/meterevent/adapter/event.go
@@ -48,7 +48,7 @@ func (a *adapter) ListEvents(ctx context.Context, params meterevent.ListEventsPa
 
 		for _, m := range meters {
 			if event.Type == m.EventType {
-				_, _, _, err := meter.ParseEvent(m, event.Data)
+				_, err = meter.ParseEventString(m, event.Data)
 				if err != nil {
 					validatedEvent.ValidationErrors = append(validatedEvent.ValidationErrors, err)
 				}

--- a/openmeter/meterevent/adapter/event.go
+++ b/openmeter/meterevent/adapter/event.go
@@ -4,57 +4,59 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/samber/lo"
-
-	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/meterevent"
-	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-func (a *adapter) ListEvents(ctx context.Context, input meterevent.ListEventsInput) ([]api.IngestedEvent, error) {
+func (a *adapter) ListEvents(ctx context.Context, params meterevent.ListEventsParams) ([]meterevent.Event, error) {
 	// Validate input
-	if err := input.Validate(); err != nil {
+	if err := params.Validate(); err != nil {
 		return nil, models.NewGenericValidationError(
 			fmt.Errorf("validate input: %w", err),
 		)
 	}
 
 	// Get all events
-	events, err := a.streamingConnector.ListEvents(ctx, input.Namespace, streaming.ListEventsParams{
-		ClientID:       input.ClientID,
-		From:           input.From,
-		To:             input.To,
-		IngestedAtFrom: input.IngestedAtFrom,
-		IngestedAtTo:   input.IngestedAtTo,
-		ID:             input.ID,
-		Subject:        input.Subject,
-		Limit:          input.Limit,
-	})
+	events, err := a.streamingConnector.ListEvents(ctx, params.Namespace, params)
 	if err != nil {
 		return nil, fmt.Errorf("query events: %w", err)
 	}
 
 	// Get all meters
 	meters, err := meter.ListAll(ctx, a.meterService, meter.ListMetersParams{
-		Namespace: input.Namespace,
+		Namespace: params.Namespace,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("get meters: %w", err)
 	}
 
 	// Validate events against meters
+	validatedEvents := make([]meterevent.Event, len(events))
 	for idx, event := range events {
+		validatedEvent := meterevent.Event{
+			ID:               event.ID,
+			Type:             event.Type,
+			Source:           event.Source,
+			Subject:          event.Subject,
+			Time:             event.Time,
+			Data:             event.Data,
+			IngestedAt:       event.IngestedAt,
+			StoredAt:         event.StoredAt,
+			ValidationErrors: make([]error, 0),
+		}
+
 		for _, m := range meters {
-			if event.Event.Type() == m.EventType {
-				_, _, _, err := meter.ParseEvent(m, event.Event)
+			if event.Type == m.EventType {
+				_, _, _, err := meter.ParseEvent(m, event.Data)
 				if err != nil {
-					events[idx].ValidationError = lo.ToPtr(err.Error())
+					validatedEvent.ValidationErrors = append(validatedEvent.ValidationErrors, err)
 				}
 			}
 		}
+
+		validatedEvents[idx] = validatedEvent
 	}
 
-	return events, nil
+	return validatedEvents, nil
 }

--- a/openmeter/meterevent/httphandler/event.go
+++ b/openmeter/meterevent/httphandler/event.go
@@ -20,10 +20,7 @@ type (
 	ListEventsHandler  httptransport.HandlerWithArgs[ListEventsRequest, ListEventsResponse, ListEventsParams]
 )
 
-type ListEventsRequest struct {
-	namespace string
-	ListEventsParams
-}
+type ListEventsRequest = meterevent.ListEventsParams
 
 // ListEvents returns a handler for listing events.
 func (h *handler) ListEvents() ListEventsHandler {
@@ -34,28 +31,33 @@ func (h *handler) ListEvents() ListEventsHandler {
 				return ListEventsRequest{}, err
 			}
 
-			return ListEventsRequest{
-				namespace:        ns,
-				ListEventsParams: params,
-			}, nil
-		},
-		func(ctx context.Context, request ListEventsRequest) (ListEventsResponse, error) {
 			// We add a second to avoid validation issues
 			minimumFrom := time.Now().Add(-meterevent.MaximumFromDuration).Add(time.Second)
 
-			result, err := h.metereventService.ListEvents(ctx, meterevent.ListEventsInput{
-				Namespace:      request.namespace,
-				ClientID:       request.ClientId,
-				IngestedAtFrom: request.IngestedAtFrom,
-				IngestedAtTo:   request.IngestedAtTo,
-				From:           lo.FromPtrOr(request.From, minimumFrom),
-				To:             request.To,
-				ID:             request.Id,
-				Subject:        request.Subject,
-				Limit:          lo.FromPtrOr(request.Limit, meterevent.MaximumLimit),
-			})
+			return ListEventsRequest{
+				Namespace:      ns,
+				ClientID:       params.ClientId,
+				From:           lo.FromPtrOr(params.From, minimumFrom),
+				To:             params.To,
+				IngestedAtFrom: params.IngestedAtFrom,
+				IngestedAtTo:   params.IngestedAtTo,
+				ID:             params.Id,
+				Subject:        params.Subject,
+				Limit:          lo.FromPtrOr(params.Limit, meterevent.MaximumLimit),
+			}, nil
+		},
+		func(ctx context.Context, request ListEventsRequest) (ListEventsResponse, error) {
+			events, err := h.metereventService.ListEvents(ctx, request)
 			if err != nil {
 				return ListEventsResponse{}, fmt.Errorf("failed to list events: %w", err)
+			}
+
+			result := make(ListEventsResponse, len(events))
+			for i, event := range events {
+				result[i], err = convertEvent(event)
+				if err != nil {
+					return ListEventsResponse{}, fmt.Errorf("failed to convert event: %w", err)
+				}
 			}
 
 			return result, nil

--- a/openmeter/meterevent/httphandler/mapping.go
+++ b/openmeter/meterevent/httphandler/mapping.go
@@ -1,0 +1,47 @@
+package httpdriver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/cloudevents/sdk-go/v2/event"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/api"
+	"github.com/openmeterio/openmeter/openmeter/meterevent"
+)
+
+func convertEvent(e meterevent.Event) (api.IngestedEvent, error) {
+	ev := event.New()
+	ev.SetID(e.ID)
+	ev.SetType(e.Type)
+	ev.SetSource(e.Source)
+	ev.SetSubject(e.Subject)
+	ev.SetTime(e.Time)
+
+	if e.Data != "" {
+		var data interface{}
+		err := json.Unmarshal([]byte(e.Data), &data)
+		if err != nil {
+			return api.IngestedEvent{}, fmt.Errorf("parse cloudevents data as json: %w", err)
+		}
+
+		err = ev.SetData(event.ApplicationJSON, data)
+		if err != nil {
+			return api.IngestedEvent{}, fmt.Errorf("set cloudevents data: %w", err)
+		}
+	}
+
+	var validationError *string
+	if len(e.ValidationErrors) > 0 {
+		validationError = lo.EmptyableToPtr(errors.Join(e.ValidationErrors...).Error())
+	}
+
+	return api.IngestedEvent{
+		Event:           ev,
+		IngestedAt:      e.IngestedAt,
+		StoredAt:        e.StoredAt,
+		ValidationError: validationError,
+	}, nil
+}

--- a/openmeter/meterevent/service.go
+++ b/openmeter/meterevent/service.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"time"
-
-	"github.com/openmeterio/openmeter/api"
 )
 
 const (
@@ -15,11 +13,11 @@ const (
 )
 
 type Service interface {
-	ListEvents(ctx context.Context, input ListEventsInput) ([]api.IngestedEvent, error)
+	ListEvents(ctx context.Context, params ListEventsParams) ([]Event, error)
 }
 
-// ListEventsInput represents the input for ListEvents method.
-type ListEventsInput struct {
+// ListEventsParams represents the input for ListEvents method.
+type ListEventsParams struct {
 	// The namespace.
 	Namespace string
 	// The client ID.
@@ -40,8 +38,30 @@ type ListEventsInput struct {
 	Limit int
 }
 
+// Event represents a single event.
+type Event struct {
+	// The event ID.
+	ID string
+	// The event type.
+	Type string
+	// The event source.
+	Source string
+	// The event subject.
+	Subject string
+	// The event time.
+	Time time.Time
+	// The event data as a JSON string.
+	Data string
+	// The time the event was ingested.
+	IngestedAt time.Time
+	// The time the event was stored.
+	StoredAt time.Time
+	// Validation errors.
+	ValidationErrors []error
+}
+
 // Validate validates the input.
-func (i ListEventsInput) Validate() error {
+func (i ListEventsParams) Validate() error {
 	var errs []error
 
 	minimumFrom := time.Now().Add(-MaximumFromDuration)

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	meterhttphandler "github.com/openmeterio/openmeter/openmeter/meter/httphandler"
 	meteradapter "github.com/openmeterio/openmeter/openmeter/meter/mockadapter"
+	"github.com/openmeterio/openmeter/openmeter/meterevent"
 	metereventadapter "github.com/openmeterio/openmeter/openmeter/meterevent/adapter"
 	"github.com/openmeterio/openmeter/openmeter/namespace"
 	"github.com/openmeterio/openmeter/openmeter/namespace/namespacedriver"
@@ -582,10 +583,17 @@ func (c *MockStreamingConnector) CountEvents(ctx context.Context, namespace stri
 	return []streaming.CountEventRow{}, nil
 }
 
-func (c *MockStreamingConnector) ListEvents(ctx context.Context, namespace string, params streaming.ListEventsParams) ([]api.IngestedEvent, error) {
-	events := []api.IngestedEvent{
+func (c *MockStreamingConnector) ListEvents(ctx context.Context, namespace string, params meterevent.ListEventsParams) ([]streaming.RawEvent, error) {
+	events := []streaming.RawEvent{
 		{
-			Event: mockEvent,
+			ID:         mockEvent.ID(),
+			Type:       mockEvent.Type(),
+			Source:     mockEvent.Source(),
+			Subject:    mockEvent.Subject(),
+			Time:       mockEvent.Time(),
+			Data:       string(mockEvent.Data()),
+			IngestedAt: time.Time{},
+			StoredAt:   time.Time{},
 		},
 	}
 	return events, nil

--- a/openmeter/streaming/clickhouse/event_query.go
+++ b/openmeter/streaming/clickhouse/event_query.go
@@ -1,4 +1,4 @@
-package raw_events
+package clickhouse
 
 import (
 	_ "embed"

--- a/openmeter/streaming/clickhouse/event_query_test.go
+++ b/openmeter/streaming/clickhouse/event_query_test.go
@@ -1,4 +1,4 @@
-package raw_events
+package clickhouse
 
 import (
 	"testing"

--- a/openmeter/streaming/clickhouse/meter_query.go
+++ b/openmeter/streaming/clickhouse/meter_query.go
@@ -1,4 +1,4 @@
-package raw_events
+package clickhouse
 
 import (
 	_ "embed"

--- a/openmeter/streaming/clickhouse/meter_query_test.go
+++ b/openmeter/streaming/clickhouse/meter_query_test.go
@@ -1,4 +1,4 @@
-package raw_events
+package clickhouse
 
 import (
 	"testing"

--- a/openmeter/streaming/clickhouse/utils_query.go
+++ b/openmeter/streaming/clickhouse/utils_query.go
@@ -1,4 +1,4 @@
-package raw_events
+package clickhouse
 
 import (
 	"fmt"

--- a/openmeter/streaming/connector.go
+++ b/openmeter/streaming/connector.go
@@ -5,22 +5,11 @@ import (
 	"errors"
 	"time"
 
-	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/meterevent"
 	"github.com/openmeterio/openmeter/openmeter/namespace"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
-
-type ListEventsParams struct {
-	ClientID       *string
-	From           time.Time
-	To             *time.Time
-	IngestedAtFrom *time.Time
-	IngestedAtTo   *time.Time
-	ID             *string
-	Subject        *string
-	Limit          int
-}
 
 type CountEventsParams struct {
 	From time.Time
@@ -34,22 +23,22 @@ type CountEventRow struct {
 
 // RawEvent represents a single raw event
 type RawEvent struct {
-	Namespace  string
-	ID         string
-	Type       string
-	Source     string
-	Subject    string
-	Time       time.Time
-	Data       string
-	IngestedAt time.Time
-	StoredAt   time.Time
+	Namespace  string    `ch:"namespace"`
+	ID         string    `ch:"id"`
+	Type       string    `ch:"type"`
+	Source     string    `ch:"source"`
+	Subject    string    `ch:"subject"`
+	Time       time.Time `ch:"time"`
+	Data       string    `ch:"data"`
+	IngestedAt time.Time `ch:"ingested_at"`
+	StoredAt   time.Time `ch:"stored_at"`
 }
 
 type Connector interface {
 	namespace.Handler
 
 	CountEvents(ctx context.Context, namespace string, params CountEventsParams) ([]CountEventRow, error)
-	ListEvents(ctx context.Context, namespace string, params ListEventsParams) ([]api.IngestedEvent, error)
+	ListEvents(ctx context.Context, namespace string, params meterevent.ListEventsParams) ([]RawEvent, error)
 	CreateMeter(ctx context.Context, namespace string, meter meter.Meter) error
 	UpdateMeter(ctx context.Context, namespace string, meter meter.Meter) error
 	DeleteMeter(ctx context.Context, namespace string, meter meter.Meter) error

--- a/openmeter/streaming/testutils/streaming.go
+++ b/openmeter/streaming/testutils/streaming.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/meterevent"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 )
 
@@ -70,8 +70,8 @@ func (m *MockStreamingConnector) CountEvents(ctx context.Context, namespace stri
 	return []streaming.CountEventRow{}, nil
 }
 
-func (m *MockStreamingConnector) ListEvents(ctx context.Context, namespace string, params streaming.ListEventsParams) ([]api.IngestedEvent, error) {
-	return []api.IngestedEvent{}, nil
+func (m *MockStreamingConnector) ListEvents(ctx context.Context, namespace string, params meterevent.ListEventsParams) ([]streaming.RawEvent, error) {
+	return []streaming.RawEvent{}, nil
 }
 
 func (m *MockStreamingConnector) CreateMeter(ctx context.Context, namespace string, meter meter.Meter) error {


### PR DESCRIPTION
First batch of refactors for the meter event and streaming services.
Remove the use of `api` types other than the httpdriver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined the event processing pipeline by switching to direct JSON string inputs and unified raw event outputs, simplifying data handling and reducing external dependencies.
	- Enhanced the clarity and structure of event handling by updating method signatures and data types across various components.
- **Tests**
	- Updated test cases to use simplified JSON payloads, enhancing clarity and ensuring robust error handling.
	- Improved error messages in validation tests for better context on validation failures.
- **Chores**
	- Consolidated package structures and updated method signatures for consistency across event handling modules, contributing to improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->