### PR TITLE
fix: store masked api key in db

### DIFF
--- a/openmeter/app/httpdriver/app.go
+++ b/openmeter/app/httpdriver/app.go
@@ -48,7 +48,7 @@ func (h *handler) ListApps() ListAppsHandler {
 
 			items := make([]api.App, 0, len(result.Items))
 			for _, item := range result.Items {
-				app, err := h.appMapper.MapAppToAPI(ctx, item)
+				app, err := h.appMapper.MapAppToAPI(item)
 				if err != nil {
 					return ListAppsResponse{}, fmt.Errorf("failed to map app to api: %w", err)
 				}
@@ -99,7 +99,7 @@ func (h *handler) GetApp() GetAppHandler {
 				return GetAppResponse{}, fmt.Errorf("failed to get app: %w", err)
 			}
 
-			return h.appMapper.MapAppToAPI(ctx, app)
+			return h.appMapper.MapAppToAPI(app)
 		},
 		commonhttp.JSONResponseEncoderWithStatus[GetAppResponse](http.StatusOK),
 		httptransport.AppendOptions(
@@ -148,7 +148,7 @@ func (h *handler) UpdateApp() UpdateAppHandler {
 				return UpdateAppResponse{}, fmt.Errorf("failed to update app: %w", err)
 			}
 
-			return h.appMapper.MapAppToAPI(ctx, app)
+			return h.appMapper.MapAppToAPI(app)
 		},
 		commonhttp.JSONResponseEncoderWithStatus[UpdateAppResponse](http.StatusOK),
 		httptransport.AppendOptions(

--- a/openmeter/app/httpdriver/marketplace.go
+++ b/openmeter/app/httpdriver/marketplace.go
@@ -147,7 +147,7 @@ func (h *handler) MarketplaceAppAPIKeyInstall() MarketplaceAppAPIKeyInstallHandl
 			}
 
 			// Map app to API
-			apiApp, err := h.appMapper.MapAppToAPI(ctx, installedApp)
+			apiApp, err := h.appMapper.MapAppToAPI(installedApp)
 			if err != nil {
 				return resp, fmt.Errorf("failed to map app to API: %w", err)
 			}

--- a/openmeter/app/stripe/adapter.go
+++ b/openmeter/app/stripe/adapter.go
@@ -8,7 +8,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/app/stripe/client"
 	appstripeentity "github.com/openmeterio/openmeter/openmeter/app/stripe/entity"
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	secretentity "github.com/openmeterio/openmeter/openmeter/secret/entity"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 )
 
@@ -25,7 +24,6 @@ type AppStripeAdapter interface {
 	UpdateAPIKey(ctx context.Context, input appstripeentity.UpdateAPIKeyInput) error
 	CreateCheckoutSession(ctx context.Context, input appstripeentity.CreateCheckoutSessionInput) (appstripeentity.CreateCheckoutSessionOutput, error)
 	GetWebhookSecret(ctx context.Context, input appstripeentity.GetWebhookSecretInput) (appstripeentity.GetWebhookSecretOutput, error)
-	GetMaskedSecretAPIKey(ctx context.Context, secretAPIKeyID secretentity.SecretID) (string, error)
 	// App
 	CreateStripeApp(ctx context.Context, input appstripeentity.CreateAppStripeInput) (appstripeentity.AppBase, error)
 	GetStripeAppData(ctx context.Context, input appstripeentity.GetStripeAppDataInput) (appstripeentity.AppData, error)

--- a/openmeter/app/stripe/adapter.go
+++ b/openmeter/app/stripe/adapter.go
@@ -21,7 +21,7 @@ type AppStripeAdapter interface {
 	GetStripeClientFactory() client.StripeClientFactory
 	GetStripeAppClientFactory() client.StripeAppClientFactory
 
-	UpdateAPIKey(ctx context.Context, input appstripeentity.UpdateAPIKeyInput) error
+	UpdateAPIKey(ctx context.Context, input appstripeentity.UpdateAPIKeyAdapterInput) error
 	CreateCheckoutSession(ctx context.Context, input appstripeentity.CreateCheckoutSessionInput) (appstripeentity.CreateCheckoutSessionOutput, error)
 	GetWebhookSecret(ctx context.Context, input appstripeentity.GetWebhookSecretInput) (appstripeentity.GetWebhookSecretOutput, error)
 	// App

--- a/openmeter/app/stripe/adapter/stripe.go
+++ b/openmeter/app/stripe/adapter/stripe.go
@@ -82,7 +82,7 @@ func (a *adapter) CreateStripeApp(ctx context.Context, input appstripeentity.Cre
 }
 
 // UpdateAPIKey replaces the API key
-func (a *adapter) UpdateAPIKey(ctx context.Context, input appstripeentity.UpdateAPIKeyInput) error {
+func (a *adapter) UpdateAPIKey(ctx context.Context, input appstripeentity.UpdateAPIKeyAdapterInput) error {
 	// Validate the input
 	if err := input.Validate(); err != nil {
 		return models.NewGenericValidationError(

--- a/openmeter/app/stripe/adapter/stripe.go
+++ b/openmeter/app/stripe/adapter/stripe.go
@@ -57,7 +57,8 @@ func (a *adapter) CreateStripeApp(ctx context.Context, input appstripeentity.Cre
 			SetStripeLivemode(input.Livemode).
 			SetAPIKey(input.APIKey.ID).
 			SetStripeWebhookID(input.StripeWebhookID).
-			SetWebhookSecret(input.WebhookSecret.ID)
+			SetWebhookSecret(input.WebhookSecret.ID).
+			SetMaskedAPIKey(input.MaskedAPIKey)
 
 		dbApp, err := appStripeCreateQuery.Save(ctx)
 		if err != nil {
@@ -156,6 +157,7 @@ func (a *adapter) UpdateAPIKey(ctx context.Context, input appstripeentity.Update
 				Where(appstripedb.Namespace(input.AppID.Namespace)).
 				Where(appstripedb.ID(input.AppID.ID)).
 				SetAPIKey(newApiKeySecretID.ID).
+				SetMaskedAPIKey(input.MaskedAPIKey).
 				Exec(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to update api key: %w", err)
@@ -610,27 +612,6 @@ func (a adapter) GetStripeInvoice(ctx context.Context, input appstripeentity.Get
 	})
 }
 
-// GetMaskedSecretAPIKey returns a masked secret API key
-func (a adapter) GetMaskedSecretAPIKey(ctx context.Context, secretAPIKeyID secretentity.SecretID) (string, error) {
-	// Validate input
-	if err := secretAPIKeyID.Validate(); err != nil {
-		return "", models.NewGenericValidationError(
-			fmt.Errorf("error validate input: %w", err),
-		)
-	}
-
-	// Get the secret API key
-	secretAPIKey, err := a.secretService.GetAppSecret(ctx, secretAPIKeyID)
-	if err != nil {
-		return "", fmt.Errorf("failed to get secret api key: %w", err)
-	}
-
-	// Mask the secret API key
-	maskedAPIKey := fmt.Sprintf("%s***%s", secretAPIKey.Value[:8], secretAPIKey.Value[len(secretAPIKey.Value)-3:])
-
-	return maskedAPIKey, nil
-}
-
 // getStripeAppClient returns a Stripe App Client based on App ID
 func (a adapter) getStripeAppClient(ctx context.Context, appID app.AppID, logOperation string, logFields ...any) (appstripeentity.AppData, stripeclient.StripeAppClient, error) {
 	// Validate app id
@@ -672,6 +653,7 @@ func mapAppStripeData(appID app.AppID, dbApp *entdb.AppStripe) appstripeentity.A
 		StripeAccountID: dbApp.StripeAccountID,
 		Livemode:        dbApp.StripeLivemode,
 		APIKey:          secretentity.NewSecretID(appID, dbApp.APIKey, appstripeentity.APIKeySecretKey),
+		MaskedAPIKey:    dbApp.MaskedAPIKey,
 		StripeWebhookID: dbApp.StripeWebhookID,
 		WebhookSecret:   secretentity.NewSecretID(appID, dbApp.WebhookSecret, appstripeentity.WebhookSecretKey),
 	}

--- a/openmeter/app/stripe/entity/input.go
+++ b/openmeter/app/stripe/entity/input.go
@@ -26,6 +26,7 @@ type CreateAppStripeInput struct {
 	StripeAccountID string
 	Livemode        bool
 	APIKey          secretentity.SecretID
+	MaskedAPIKey    string
 	StripeWebhookID string
 	WebhookSecret   secretentity.SecretID
 }
@@ -49,6 +50,10 @@ func (i CreateAppStripeInput) Validate() error {
 
 	if err := i.APIKey.Validate(); err != nil {
 		return fmt.Errorf("error validating api key: %w", err)
+	}
+
+	if i.MaskedAPIKey == "" {
+		return errors.New("masked api key is required")
 	}
 
 	if i.ID != nil && i.APIKey.Namespace != i.ID.Namespace {
@@ -244,8 +249,9 @@ func (i GetWebhookSecretInput) Validate() error {
 type GetWebhookSecretOutput = secretentity.Secret
 
 type UpdateAPIKeyInput struct {
-	AppID  app.AppID
-	APIKey string
+	AppID        app.AppID
+	APIKey       string
+	MaskedAPIKey string
 }
 
 func (i UpdateAPIKeyInput) Validate() error {
@@ -255,6 +261,10 @@ func (i UpdateAPIKeyInput) Validate() error {
 
 	if i.APIKey == "" {
 		return errors.New("api key is required")
+	}
+
+	if i.MaskedAPIKey == "" {
+		return errors.New("masked api key is required")
 	}
 
 	return nil
@@ -388,6 +398,7 @@ type AppData struct {
 	StripeAccountID string
 	Livemode        bool
 	APIKey          secretentity.SecretID
+	MaskedAPIKey    string
 	StripeWebhookID string
 	WebhookSecret   secretentity.SecretID
 }

--- a/openmeter/app/stripe/entity/input.go
+++ b/openmeter/app/stripe/entity/input.go
@@ -249,9 +249,8 @@ func (i GetWebhookSecretInput) Validate() error {
 type GetWebhookSecretOutput = secretentity.Secret
 
 type UpdateAPIKeyInput struct {
-	AppID        app.AppID
-	APIKey       string
-	MaskedAPIKey string
+	AppID  app.AppID
+	APIKey string
 }
 
 func (i UpdateAPIKeyInput) Validate() error {
@@ -261,6 +260,20 @@ func (i UpdateAPIKeyInput) Validate() error {
 
 	if i.APIKey == "" {
 		return errors.New("api key is required")
+	}
+
+	return nil
+}
+
+type UpdateAPIKeyAdapterInput struct {
+	UpdateAPIKeyInput
+
+	MaskedAPIKey string
+}
+
+func (i UpdateAPIKeyAdapterInput) Validate() error {
+	if err := i.UpdateAPIKeyInput.Validate(); err != nil {
+		return fmt.Errorf("error validating update api key input: %w", err)
 	}
 
 	if i.MaskedAPIKey == "" {

--- a/openmeter/app/stripe/service.go
+++ b/openmeter/app/stripe/service.go
@@ -6,7 +6,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/app"
 	appstripeentity "github.com/openmeterio/openmeter/openmeter/app/stripe/entity"
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	secretentity "github.com/openmeterio/openmeter/openmeter/secret/entity"
 )
 
 type Service interface {
@@ -27,7 +26,6 @@ type AppFactoryService interface {
 // StripeAppService contains methods for managing stripe app
 type StripeAppService interface {
 	UpdateAPIKey(ctx context.Context, input appstripeentity.UpdateAPIKeyInput) error
-	GetMaskedSecretAPIKey(ctx context.Context, secretAPIKeyID secretentity.SecretID) (string, error)
 	GetStripeAppData(ctx context.Context, input appstripeentity.GetStripeAppDataInput) (appstripeentity.AppData, error)
 	GetWebhookSecret(ctx context.Context, input appstripeentity.GetWebhookSecretInput) (appstripeentity.GetWebhookSecretOutput, error)
 }

--- a/openmeter/app/stripe/service/app.go
+++ b/openmeter/app/stripe/service/app.go
@@ -23,7 +23,10 @@ func (s *Service) GetWebhookSecret(ctx context.Context, input appstripeentity.Ge
 
 func (s *Service) UpdateAPIKey(ctx context.Context, input appstripeentity.UpdateAPIKeyInput) error {
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
-		return s.adapter.UpdateAPIKey(ctx, input)
+		return s.adapter.UpdateAPIKey(ctx, appstripeentity.UpdateAPIKeyAdapterInput{
+			UpdateAPIKeyInput: input,
+			MaskedAPIKey:      s.generateMaskedSecretAPIKey(input.APIKey),
+		})
 	})
 }
 

--- a/openmeter/app/stripe/service/app.go
+++ b/openmeter/app/stripe/service/app.go
@@ -10,7 +10,6 @@ import (
 	appstripe "github.com/openmeterio/openmeter/openmeter/app/stripe"
 	stripeclient "github.com/openmeterio/openmeter/openmeter/app/stripe/client"
 	appstripeentity "github.com/openmeterio/openmeter/openmeter/app/stripe/entity"
-	secretentity "github.com/openmeterio/openmeter/openmeter/secret/entity"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
 
@@ -88,8 +87,6 @@ func (s *Service) HandleSetupIntentSucceeded(ctx context.Context, input appstrip
 	})
 }
 
-func (s *Service) GetMaskedSecretAPIKey(ctx context.Context, secretAPIKeyID secretentity.SecretID) (string, error) {
-	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (string, error) {
-		return s.adapter.GetMaskedSecretAPIKey(ctx, secretAPIKeyID)
-	})
+func (s *Service) generateMaskedSecretAPIKey(secretAPIKey string) string {
+	return fmt.Sprintf("%s***%s", secretAPIKey[:8], secretAPIKey[len(secretAPIKey)-3:])
 }

--- a/openmeter/app/stripe/service/factory.go
+++ b/openmeter/app/stripe/service/factory.go
@@ -115,6 +115,7 @@ func (s *Service) InstallAppWithAPIKey(ctx context.Context, input app.AppFactory
 		StripeAccountID: stripeAccount.StripeAccountID,
 		Livemode:        livemode,
 		APIKey:          apiKeySecretID,
+		MaskedAPIKey:    s.generateMaskedSecretAPIKey(input.APIKey),
 		StripeWebhookID: stripeWebhookEndpoint.EndpointID,
 		WebhookSecret:   webhookSecretID,
 	}

--- a/openmeter/billing/httpdriver/invoice.go
+++ b/openmeter/billing/httpdriver/invoice.go
@@ -86,7 +86,7 @@ func (h *handler) ListInvoices() ListInvoicesHandler {
 			}
 
 			for _, invoice := range invoices.Items {
-				invoice, err := h.mapInvoiceToAPI(ctx, invoice)
+				invoice, err := h.mapInvoiceToAPI(invoice)
 				if err != nil {
 					return ListInvoicesResponse{}, err
 				}
@@ -149,7 +149,7 @@ func (h *handler) InvoicePendingLinesAction() InvoicePendingLinesActionHandler {
 			out := make([]api.Invoice, 0, len(invoices))
 
 			for _, invoice := range invoices {
-				invoice, err := h.mapInvoiceToAPI(ctx, invoice)
+				invoice, err := h.mapInvoiceToAPI(invoice)
 				if err != nil {
 					return nil, err
 				}
@@ -205,7 +205,7 @@ func (h *handler) GetInvoice() GetInvoiceHandler {
 				return GetInvoiceResponse{}, err
 			}
 
-			return h.mapInvoiceToAPI(ctx, invoice)
+			return h.mapInvoiceToAPI(invoice)
 		},
 		commonhttp.JSONResponseEncoderWithStatus[GetInvoiceResponse](http.StatusOK),
 		httptransport.AppendOptions(
@@ -286,7 +286,7 @@ func (h *handler) ProgressInvoice(action ProgressAction) ProgressInvoiceHandler 
 				return ProgressInvoiceResponse{}, err
 			}
 
-			return h.mapInvoiceToAPI(ctx, invoice)
+			return h.mapInvoiceToAPI(invoice)
 		},
 		commonhttp.JSONResponseEncoderWithStatus[ProgressInvoiceResponse](http.StatusOK),
 		httptransport.AppendOptions(
@@ -381,7 +381,7 @@ func (h *handler) SimulateInvoice() SimulateInvoiceHandler {
 				return SimulateInvoiceResponse{}, err
 			}
 
-			return h.mapInvoiceToAPI(ctx, invoice)
+			return h.mapInvoiceToAPI(invoice)
 		},
 		commonhttp.JSONResponseEncoderWithStatus[SimulateInvoiceResponse](http.StatusOK),
 		httptransport.AppendOptions(
@@ -456,7 +456,7 @@ func (h *handler) UpdateInvoice() UpdateInvoiceHandler {
 				return UpdateInvoiceResponse{}, err
 			}
 
-			return h.mapInvoiceToAPI(ctx, invoice)
+			return h.mapInvoiceToAPI(invoice)
 		},
 		commonhttp.JSONResponseEncoderWithStatus[UpdateInvoiceResponse](http.StatusOK),
 		httptransport.AppendOptions(
@@ -467,12 +467,12 @@ func (h *handler) UpdateInvoice() UpdateInvoiceHandler {
 	)
 }
 
-func (h *handler) mapInvoiceToAPI(ctx context.Context, invoice billing.Invoice) (api.Invoice, error) {
+func (h *handler) mapInvoiceToAPI(invoice billing.Invoice) (api.Invoice, error) {
 	var apps *api.BillingProfileAppsOrReference
 	var err error
 
 	if invoice.Workflow.Apps != nil {
-		apps, err = h.mapProfileAppsToAPI(ctx, invoice.Workflow.Apps)
+		apps, err = h.mapProfileAppsToAPI(invoice.Workflow.Apps)
 		if err != nil {
 			return api.Invoice{}, fmt.Errorf("failed to map profile apps to API: %w", err)
 		}

--- a/openmeter/billing/httpdriver/profile.go
+++ b/openmeter/billing/httpdriver/profile.go
@@ -436,7 +436,7 @@ func (h *handler) MapProfileToApi(ctx context.Context, p *billing.Profile) (api.
 	}
 
 	if p.Apps != nil {
-		apps, err := h.mapProfileAppsToAPI(ctx, p.Apps)
+		apps, err := h.mapProfileAppsToAPI(p.Apps)
 		if err != nil {
 			return api.BillingProfile{}, fmt.Errorf("failed to map profile apps: %w", err)
 		}
@@ -458,22 +458,22 @@ func (h *handler) MapProfileToApi(ctx context.Context, p *billing.Profile) (api.
 	return out, nil
 }
 
-func (h *handler) mapProfileAppsToAPI(ctx context.Context, a *billing.ProfileApps) (*api.BillingProfileAppsOrReference, error) {
+func (h *handler) mapProfileAppsToAPI(a *billing.ProfileApps) (*api.BillingProfileAppsOrReference, error) {
 	if a == nil {
 		return nil, nil
 	}
 
-	tax, err := h.appMapper.MapAppToAPI(ctx, a.Tax)
+	tax, err := h.appMapper.MapAppToAPI(a.Tax)
 	if err != nil {
 		return nil, fmt.Errorf("cannot map tax app: %w", err)
 	}
 
-	invoicing, err := h.appMapper.MapAppToAPI(ctx, a.Invoicing)
+	invoicing, err := h.appMapper.MapAppToAPI(a.Invoicing)
 	if err != nil {
 		return nil, fmt.Errorf("cannot map invoicing app: %w", err)
 	}
 
-	payment, err := h.appMapper.MapAppToAPI(ctx, a.Payment)
+	payment, err := h.appMapper.MapAppToAPI(a.Payment)
 	if err != nil {
 		return nil, fmt.Errorf("cannot map payment app: %w", err)
 	}

--- a/openmeter/ent/db/appstripe.go
+++ b/openmeter/ent/db/appstripe.go
@@ -32,6 +32,8 @@ type AppStripe struct {
 	StripeLivemode bool `json:"stripe_livemode,omitempty"`
 	// APIKey holds the value of the "api_key" field.
 	APIKey string `json:"-"`
+	// MaskedAPIKey holds the value of the "masked_api_key" field.
+	MaskedAPIKey string `json:"masked_api_key,omitempty"`
 	// StripeWebhookID holds the value of the "stripe_webhook_id" field.
 	StripeWebhookID string `json:"stripe_webhook_id,omitempty"`
 	// WebhookSecret holds the value of the "webhook_secret" field.
@@ -80,7 +82,7 @@ func (*AppStripe) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case appstripe.FieldStripeLivemode:
 			values[i] = new(sql.NullBool)
-		case appstripe.FieldID, appstripe.FieldNamespace, appstripe.FieldStripeAccountID, appstripe.FieldAPIKey, appstripe.FieldStripeWebhookID, appstripe.FieldWebhookSecret:
+		case appstripe.FieldID, appstripe.FieldNamespace, appstripe.FieldStripeAccountID, appstripe.FieldAPIKey, appstripe.FieldMaskedAPIKey, appstripe.FieldStripeWebhookID, appstripe.FieldWebhookSecret:
 			values[i] = new(sql.NullString)
 		case appstripe.FieldCreatedAt, appstripe.FieldUpdatedAt, appstripe.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -147,6 +149,12 @@ func (as *AppStripe) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field api_key", values[i])
 			} else if value.Valid {
 				as.APIKey = value.String
+			}
+		case appstripe.FieldMaskedAPIKey:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field masked_api_key", values[i])
+			} else if value.Valid {
+				as.MaskedAPIKey = value.String
 			}
 		case appstripe.FieldStripeWebhookID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -227,6 +235,9 @@ func (as *AppStripe) String() string {
 	builder.WriteString(fmt.Sprintf("%v", as.StripeLivemode))
 	builder.WriteString(", ")
 	builder.WriteString("api_key=<sensitive>")
+	builder.WriteString(", ")
+	builder.WriteString("masked_api_key=")
+	builder.WriteString(as.MaskedAPIKey)
 	builder.WriteString(", ")
 	builder.WriteString("stripe_webhook_id=")
 	builder.WriteString(as.StripeWebhookID)

--- a/openmeter/ent/db/appstripe/appstripe.go
+++ b/openmeter/ent/db/appstripe/appstripe.go
@@ -28,6 +28,8 @@ const (
 	FieldStripeLivemode = "stripe_livemode"
 	// FieldAPIKey holds the string denoting the api_key field in the database.
 	FieldAPIKey = "api_key"
+	// FieldMaskedAPIKey holds the string denoting the masked_api_key field in the database.
+	FieldMaskedAPIKey = "masked_api_key"
 	// FieldStripeWebhookID holds the string denoting the stripe_webhook_id field in the database.
 	FieldStripeWebhookID = "stripe_webhook_id"
 	// FieldWebhookSecret holds the string denoting the webhook_secret field in the database.
@@ -64,6 +66,7 @@ var Columns = []string{
 	FieldStripeAccountID,
 	FieldStripeLivemode,
 	FieldAPIKey,
+	FieldMaskedAPIKey,
 	FieldStripeWebhookID,
 	FieldWebhookSecret,
 }
@@ -89,6 +92,8 @@ var (
 	UpdateDefaultUpdatedAt func() time.Time
 	// APIKeyValidator is a validator for the "api_key" field. It is called by the builders before save.
 	APIKeyValidator func(string) error
+	// MaskedAPIKeyValidator is a validator for the "masked_api_key" field. It is called by the builders before save.
+	MaskedAPIKeyValidator func(string) error
 	// StripeWebhookIDValidator is a validator for the "stripe_webhook_id" field. It is called by the builders before save.
 	StripeWebhookIDValidator func(string) error
 	// WebhookSecretValidator is a validator for the "webhook_secret" field. It is called by the builders before save.
@@ -138,6 +143,11 @@ func ByStripeLivemode(opts ...sql.OrderTermOption) OrderOption {
 // ByAPIKey orders the results by the api_key field.
 func ByAPIKey(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAPIKey, opts...).ToFunc()
+}
+
+// ByMaskedAPIKey orders the results by the masked_api_key field.
+func ByMaskedAPIKey(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldMaskedAPIKey, opts...).ToFunc()
 }
 
 // ByStripeWebhookID orders the results by the stripe_webhook_id field.

--- a/openmeter/ent/db/appstripe/where.go
+++ b/openmeter/ent/db/appstripe/where.go
@@ -100,6 +100,11 @@ func APIKey(v string) predicate.AppStripe {
 	return predicate.AppStripe(sql.FieldEQ(FieldAPIKey, v))
 }
 
+// MaskedAPIKey applies equality check predicate on the "masked_api_key" field. It's identical to MaskedAPIKeyEQ.
+func MaskedAPIKey(v string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldEQ(FieldMaskedAPIKey, v))
+}
+
 // StripeWebhookID applies equality check predicate on the "stripe_webhook_id" field. It's identical to StripeWebhookIDEQ.
 func StripeWebhookID(v string) predicate.AppStripe {
 	return predicate.AppStripe(sql.FieldEQ(FieldStripeWebhookID, v))
@@ -443,6 +448,71 @@ func APIKeyEqualFold(v string) predicate.AppStripe {
 // APIKeyContainsFold applies the ContainsFold predicate on the "api_key" field.
 func APIKeyContainsFold(v string) predicate.AppStripe {
 	return predicate.AppStripe(sql.FieldContainsFold(FieldAPIKey, v))
+}
+
+// MaskedAPIKeyEQ applies the EQ predicate on the "masked_api_key" field.
+func MaskedAPIKeyEQ(v string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldEQ(FieldMaskedAPIKey, v))
+}
+
+// MaskedAPIKeyNEQ applies the NEQ predicate on the "masked_api_key" field.
+func MaskedAPIKeyNEQ(v string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldNEQ(FieldMaskedAPIKey, v))
+}
+
+// MaskedAPIKeyIn applies the In predicate on the "masked_api_key" field.
+func MaskedAPIKeyIn(vs ...string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldIn(FieldMaskedAPIKey, vs...))
+}
+
+// MaskedAPIKeyNotIn applies the NotIn predicate on the "masked_api_key" field.
+func MaskedAPIKeyNotIn(vs ...string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldNotIn(FieldMaskedAPIKey, vs...))
+}
+
+// MaskedAPIKeyGT applies the GT predicate on the "masked_api_key" field.
+func MaskedAPIKeyGT(v string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldGT(FieldMaskedAPIKey, v))
+}
+
+// MaskedAPIKeyGTE applies the GTE predicate on the "masked_api_key" field.
+func MaskedAPIKeyGTE(v string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldGTE(FieldMaskedAPIKey, v))
+}
+
+// MaskedAPIKeyLT applies the LT predicate on the "masked_api_key" field.
+func MaskedAPIKeyLT(v string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldLT(FieldMaskedAPIKey, v))
+}
+
+// MaskedAPIKeyLTE applies the LTE predicate on the "masked_api_key" field.
+func MaskedAPIKeyLTE(v string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldLTE(FieldMaskedAPIKey, v))
+}
+
+// MaskedAPIKeyContains applies the Contains predicate on the "masked_api_key" field.
+func MaskedAPIKeyContains(v string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldContains(FieldMaskedAPIKey, v))
+}
+
+// MaskedAPIKeyHasPrefix applies the HasPrefix predicate on the "masked_api_key" field.
+func MaskedAPIKeyHasPrefix(v string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldHasPrefix(FieldMaskedAPIKey, v))
+}
+
+// MaskedAPIKeyHasSuffix applies the HasSuffix predicate on the "masked_api_key" field.
+func MaskedAPIKeyHasSuffix(v string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldHasSuffix(FieldMaskedAPIKey, v))
+}
+
+// MaskedAPIKeyEqualFold applies the EqualFold predicate on the "masked_api_key" field.
+func MaskedAPIKeyEqualFold(v string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldEqualFold(FieldMaskedAPIKey, v))
+}
+
+// MaskedAPIKeyContainsFold applies the ContainsFold predicate on the "masked_api_key" field.
+func MaskedAPIKeyContainsFold(v string) predicate.AppStripe {
+	return predicate.AppStripe(sql.FieldContainsFold(FieldMaskedAPIKey, v))
 }
 
 // StripeWebhookIDEQ applies the EQ predicate on the "stripe_webhook_id" field.

--- a/openmeter/ent/db/appstripe_create.go
+++ b/openmeter/ent/db/appstripe_create.go
@@ -91,6 +91,12 @@ func (asc *AppStripeCreate) SetAPIKey(s string) *AppStripeCreate {
 	return asc
 }
 
+// SetMaskedAPIKey sets the "masked_api_key" field.
+func (asc *AppStripeCreate) SetMaskedAPIKey(s string) *AppStripeCreate {
+	asc.mutation.SetMaskedAPIKey(s)
+	return asc
+}
+
 // SetStripeWebhookID sets the "stripe_webhook_id" field.
 func (asc *AppStripeCreate) SetStripeWebhookID(s string) *AppStripeCreate {
 	asc.mutation.SetStripeWebhookID(s)
@@ -230,6 +236,14 @@ func (asc *AppStripeCreate) check() error {
 			return &ValidationError{Name: "api_key", err: fmt.Errorf(`db: validator failed for field "AppStripe.api_key": %w`, err)}
 		}
 	}
+	if _, ok := asc.mutation.MaskedAPIKey(); !ok {
+		return &ValidationError{Name: "masked_api_key", err: errors.New(`db: missing required field "AppStripe.masked_api_key"`)}
+	}
+	if v, ok := asc.mutation.MaskedAPIKey(); ok {
+		if err := appstripe.MaskedAPIKeyValidator(v); err != nil {
+			return &ValidationError{Name: "masked_api_key", err: fmt.Errorf(`db: validator failed for field "AppStripe.masked_api_key": %w`, err)}
+		}
+	}
 	if _, ok := asc.mutation.StripeWebhookID(); !ok {
 		return &ValidationError{Name: "stripe_webhook_id", err: errors.New(`db: missing required field "AppStripe.stripe_webhook_id"`)}
 	}
@@ -309,6 +323,10 @@ func (asc *AppStripeCreate) createSpec() (*AppStripe, *sqlgraph.CreateSpec) {
 	if value, ok := asc.mutation.APIKey(); ok {
 		_spec.SetField(appstripe.FieldAPIKey, field.TypeString, value)
 		_node.APIKey = value
+	}
+	if value, ok := asc.mutation.MaskedAPIKey(); ok {
+		_spec.SetField(appstripe.FieldMaskedAPIKey, field.TypeString, value)
+		_node.MaskedAPIKey = value
 	}
 	if value, ok := asc.mutation.StripeWebhookID(); ok {
 		_spec.SetField(appstripe.FieldStripeWebhookID, field.TypeString, value)
@@ -445,6 +463,18 @@ func (u *AppStripeUpsert) UpdateAPIKey() *AppStripeUpsert {
 	return u
 }
 
+// SetMaskedAPIKey sets the "masked_api_key" field.
+func (u *AppStripeUpsert) SetMaskedAPIKey(v string) *AppStripeUpsert {
+	u.Set(appstripe.FieldMaskedAPIKey, v)
+	return u
+}
+
+// UpdateMaskedAPIKey sets the "masked_api_key" field to the value that was provided on create.
+func (u *AppStripeUpsert) UpdateMaskedAPIKey() *AppStripeUpsert {
+	u.SetExcluded(appstripe.FieldMaskedAPIKey)
+	return u
+}
+
 // SetStripeWebhookID sets the "stripe_webhook_id" field.
 func (u *AppStripeUpsert) SetStripeWebhookID(v string) *AppStripeUpsert {
 	u.Set(appstripe.FieldStripeWebhookID, v)
@@ -575,6 +605,20 @@ func (u *AppStripeUpsertOne) SetAPIKey(v string) *AppStripeUpsertOne {
 func (u *AppStripeUpsertOne) UpdateAPIKey() *AppStripeUpsertOne {
 	return u.Update(func(s *AppStripeUpsert) {
 		s.UpdateAPIKey()
+	})
+}
+
+// SetMaskedAPIKey sets the "masked_api_key" field.
+func (u *AppStripeUpsertOne) SetMaskedAPIKey(v string) *AppStripeUpsertOne {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.SetMaskedAPIKey(v)
+	})
+}
+
+// UpdateMaskedAPIKey sets the "masked_api_key" field to the value that was provided on create.
+func (u *AppStripeUpsertOne) UpdateMaskedAPIKey() *AppStripeUpsertOne {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.UpdateMaskedAPIKey()
 	})
 }
 
@@ -879,6 +923,20 @@ func (u *AppStripeUpsertBulk) SetAPIKey(v string) *AppStripeUpsertBulk {
 func (u *AppStripeUpsertBulk) UpdateAPIKey() *AppStripeUpsertBulk {
 	return u.Update(func(s *AppStripeUpsert) {
 		s.UpdateAPIKey()
+	})
+}
+
+// SetMaskedAPIKey sets the "masked_api_key" field.
+func (u *AppStripeUpsertBulk) SetMaskedAPIKey(v string) *AppStripeUpsertBulk {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.SetMaskedAPIKey(v)
+	})
+}
+
+// UpdateMaskedAPIKey sets the "masked_api_key" field to the value that was provided on create.
+func (u *AppStripeUpsertBulk) UpdateMaskedAPIKey() *AppStripeUpsertBulk {
+	return u.Update(func(s *AppStripeUpsert) {
+		s.UpdateMaskedAPIKey()
 	})
 }
 

--- a/openmeter/ent/db/appstripe_update.go
+++ b/openmeter/ent/db/appstripe_update.go
@@ -69,6 +69,20 @@ func (asu *AppStripeUpdate) SetNillableAPIKey(s *string) *AppStripeUpdate {
 	return asu
 }
 
+// SetMaskedAPIKey sets the "masked_api_key" field.
+func (asu *AppStripeUpdate) SetMaskedAPIKey(s string) *AppStripeUpdate {
+	asu.mutation.SetMaskedAPIKey(s)
+	return asu
+}
+
+// SetNillableMaskedAPIKey sets the "masked_api_key" field if the given value is not nil.
+func (asu *AppStripeUpdate) SetNillableMaskedAPIKey(s *string) *AppStripeUpdate {
+	if s != nil {
+		asu.SetMaskedAPIKey(*s)
+	}
+	return asu
+}
+
 // SetStripeWebhookID sets the "stripe_webhook_id" field.
 func (asu *AppStripeUpdate) SetStripeWebhookID(s string) *AppStripeUpdate {
 	asu.mutation.SetStripeWebhookID(s)
@@ -181,6 +195,11 @@ func (asu *AppStripeUpdate) check() error {
 			return &ValidationError{Name: "api_key", err: fmt.Errorf(`db: validator failed for field "AppStripe.api_key": %w`, err)}
 		}
 	}
+	if v, ok := asu.mutation.MaskedAPIKey(); ok {
+		if err := appstripe.MaskedAPIKeyValidator(v); err != nil {
+			return &ValidationError{Name: "masked_api_key", err: fmt.Errorf(`db: validator failed for field "AppStripe.masked_api_key": %w`, err)}
+		}
+	}
 	if v, ok := asu.mutation.StripeWebhookID(); ok {
 		if err := appstripe.StripeWebhookIDValidator(v); err != nil {
 			return &ValidationError{Name: "stripe_webhook_id", err: fmt.Errorf(`db: validator failed for field "AppStripe.stripe_webhook_id": %w`, err)}
@@ -217,6 +236,9 @@ func (asu *AppStripeUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := asu.mutation.APIKey(); ok {
 		_spec.SetField(appstripe.FieldAPIKey, field.TypeString, value)
+	}
+	if value, ok := asu.mutation.MaskedAPIKey(); ok {
+		_spec.SetField(appstripe.FieldMaskedAPIKey, field.TypeString, value)
 	}
 	if value, ok := asu.mutation.StripeWebhookID(); ok {
 		_spec.SetField(appstripe.FieldStripeWebhookID, field.TypeString, value)
@@ -325,6 +347,20 @@ func (asuo *AppStripeUpdateOne) SetAPIKey(s string) *AppStripeUpdateOne {
 func (asuo *AppStripeUpdateOne) SetNillableAPIKey(s *string) *AppStripeUpdateOne {
 	if s != nil {
 		asuo.SetAPIKey(*s)
+	}
+	return asuo
+}
+
+// SetMaskedAPIKey sets the "masked_api_key" field.
+func (asuo *AppStripeUpdateOne) SetMaskedAPIKey(s string) *AppStripeUpdateOne {
+	asuo.mutation.SetMaskedAPIKey(s)
+	return asuo
+}
+
+// SetNillableMaskedAPIKey sets the "masked_api_key" field if the given value is not nil.
+func (asuo *AppStripeUpdateOne) SetNillableMaskedAPIKey(s *string) *AppStripeUpdateOne {
+	if s != nil {
+		asuo.SetMaskedAPIKey(*s)
 	}
 	return asuo
 }
@@ -454,6 +490,11 @@ func (asuo *AppStripeUpdateOne) check() error {
 			return &ValidationError{Name: "api_key", err: fmt.Errorf(`db: validator failed for field "AppStripe.api_key": %w`, err)}
 		}
 	}
+	if v, ok := asuo.mutation.MaskedAPIKey(); ok {
+		if err := appstripe.MaskedAPIKeyValidator(v); err != nil {
+			return &ValidationError{Name: "masked_api_key", err: fmt.Errorf(`db: validator failed for field "AppStripe.masked_api_key": %w`, err)}
+		}
+	}
 	if v, ok := asuo.mutation.StripeWebhookID(); ok {
 		if err := appstripe.StripeWebhookIDValidator(v); err != nil {
 			return &ValidationError{Name: "stripe_webhook_id", err: fmt.Errorf(`db: validator failed for field "AppStripe.stripe_webhook_id": %w`, err)}
@@ -507,6 +548,9 @@ func (asuo *AppStripeUpdateOne) sqlSave(ctx context.Context) (_node *AppStripe, 
 	}
 	if value, ok := asuo.mutation.APIKey(); ok {
 		_spec.SetField(appstripe.FieldAPIKey, field.TypeString, value)
+	}
+	if value, ok := asuo.mutation.MaskedAPIKey(); ok {
+		_spec.SetField(appstripe.FieldMaskedAPIKey, field.TypeString, value)
 	}
 	if value, ok := asuo.mutation.StripeWebhookID(); ok {
 		_spec.SetField(appstripe.FieldStripeWebhookID, field.TypeString, value)

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -111,6 +111,7 @@ var (
 		{Name: "stripe_account_id", Type: field.TypeString},
 		{Name: "stripe_livemode", Type: field.TypeBool},
 		{Name: "api_key", Type: field.TypeString},
+		{Name: "masked_api_key", Type: field.TypeString},
 		{Name: "stripe_webhook_id", Type: field.TypeString},
 		{Name: "webhook_secret", Type: field.TypeString},
 	}

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -2304,6 +2304,7 @@ type AppStripeMutation struct {
 	stripe_account_id    *string
 	stripe_livemode      *bool
 	api_key              *string
+	masked_api_key       *string
 	stripe_webhook_id    *string
 	webhook_secret       *string
 	clearedFields        map[string]struct{}
@@ -2686,6 +2687,42 @@ func (m *AppStripeMutation) ResetAPIKey() {
 	m.api_key = nil
 }
 
+// SetMaskedAPIKey sets the "masked_api_key" field.
+func (m *AppStripeMutation) SetMaskedAPIKey(s string) {
+	m.masked_api_key = &s
+}
+
+// MaskedAPIKey returns the value of the "masked_api_key" field in the mutation.
+func (m *AppStripeMutation) MaskedAPIKey() (r string, exists bool) {
+	v := m.masked_api_key
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldMaskedAPIKey returns the old "masked_api_key" field's value of the AppStripe entity.
+// If the AppStripe object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AppStripeMutation) OldMaskedAPIKey(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldMaskedAPIKey is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldMaskedAPIKey requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldMaskedAPIKey: %w", err)
+	}
+	return oldValue.MaskedAPIKey, nil
+}
+
+// ResetMaskedAPIKey resets all changes to the "masked_api_key" field.
+func (m *AppStripeMutation) ResetMaskedAPIKey() {
+	m.masked_api_key = nil
+}
+
 // SetStripeWebhookID sets the "stripe_webhook_id" field.
 func (m *AppStripeMutation) SetStripeWebhookID(s string) {
 	m.stripe_webhook_id = &s
@@ -2885,7 +2922,7 @@ func (m *AppStripeMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AppStripeMutation) Fields() []string {
-	fields := make([]string, 0, 9)
+	fields := make([]string, 0, 10)
 	if m.namespace != nil {
 		fields = append(fields, appstripe.FieldNamespace)
 	}
@@ -2906,6 +2943,9 @@ func (m *AppStripeMutation) Fields() []string {
 	}
 	if m.api_key != nil {
 		fields = append(fields, appstripe.FieldAPIKey)
+	}
+	if m.masked_api_key != nil {
+		fields = append(fields, appstripe.FieldMaskedAPIKey)
 	}
 	if m.stripe_webhook_id != nil {
 		fields = append(fields, appstripe.FieldStripeWebhookID)
@@ -2935,6 +2975,8 @@ func (m *AppStripeMutation) Field(name string) (ent.Value, bool) {
 		return m.StripeLivemode()
 	case appstripe.FieldAPIKey:
 		return m.APIKey()
+	case appstripe.FieldMaskedAPIKey:
+		return m.MaskedAPIKey()
 	case appstripe.FieldStripeWebhookID:
 		return m.StripeWebhookID()
 	case appstripe.FieldWebhookSecret:
@@ -2962,6 +3004,8 @@ func (m *AppStripeMutation) OldField(ctx context.Context, name string) (ent.Valu
 		return m.OldStripeLivemode(ctx)
 	case appstripe.FieldAPIKey:
 		return m.OldAPIKey(ctx)
+	case appstripe.FieldMaskedAPIKey:
+		return m.OldMaskedAPIKey(ctx)
 	case appstripe.FieldStripeWebhookID:
 		return m.OldStripeWebhookID(ctx)
 	case appstripe.FieldWebhookSecret:
@@ -3023,6 +3067,13 @@ func (m *AppStripeMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetAPIKey(v)
+		return nil
+	case appstripe.FieldMaskedAPIKey:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetMaskedAPIKey(v)
 		return nil
 	case appstripe.FieldStripeWebhookID:
 		v, ok := value.(string)
@@ -3116,6 +3167,9 @@ func (m *AppStripeMutation) ResetField(name string) error {
 		return nil
 	case appstripe.FieldAPIKey:
 		m.ResetAPIKey()
+		return nil
+	case appstripe.FieldMaskedAPIKey:
+		m.ResetMaskedAPIKey()
 		return nil
 	case appstripe.FieldStripeWebhookID:
 		m.ResetStripeWebhookID()

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -133,12 +133,16 @@ func init() {
 	appstripeDescAPIKey := appstripeFields[2].Descriptor()
 	// appstripe.APIKeyValidator is a validator for the "api_key" field. It is called by the builders before save.
 	appstripe.APIKeyValidator = appstripeDescAPIKey.Validators[0].(func(string) error)
+	// appstripeDescMaskedAPIKey is the schema descriptor for masked_api_key field.
+	appstripeDescMaskedAPIKey := appstripeFields[3].Descriptor()
+	// appstripe.MaskedAPIKeyValidator is a validator for the "masked_api_key" field. It is called by the builders before save.
+	appstripe.MaskedAPIKeyValidator = appstripeDescMaskedAPIKey.Validators[0].(func(string) error)
 	// appstripeDescStripeWebhookID is the schema descriptor for stripe_webhook_id field.
-	appstripeDescStripeWebhookID := appstripeFields[3].Descriptor()
+	appstripeDescStripeWebhookID := appstripeFields[4].Descriptor()
 	// appstripe.StripeWebhookIDValidator is a validator for the "stripe_webhook_id" field. It is called by the builders before save.
 	appstripe.StripeWebhookIDValidator = appstripeDescStripeWebhookID.Validators[0].(func(string) error)
 	// appstripeDescWebhookSecret is the schema descriptor for webhook_secret field.
-	appstripeDescWebhookSecret := appstripeFields[4].Descriptor()
+	appstripeDescWebhookSecret := appstripeFields[5].Descriptor()
 	// appstripe.WebhookSecretValidator is a validator for the "webhook_secret" field. It is called by the builders before save.
 	appstripe.WebhookSecretValidator = appstripeDescWebhookSecret.Validators[0].(func(string) error)
 	// appstripeDescID is the schema descriptor for id field.

--- a/openmeter/ent/schema/app_stripe.go
+++ b/openmeter/ent/schema/app_stripe.go
@@ -29,6 +29,7 @@ func (AppStripe) Fields() []ent.Field {
 		field.String("stripe_account_id").Immutable(),
 		field.Bool("stripe_livemode").Immutable(),
 		field.String("api_key").NotEmpty().Sensitive(),
+		field.String("masked_api_key").NotEmpty(),
 		field.String("stripe_webhook_id").NotEmpty(),
 		field.String("webhook_secret").NotEmpty().Sensitive(),
 	}

--- a/tools/migrate/migrations/20250318123842_app-stripe-store-masked-key.down.sql
+++ b/tools/migrate/migrations/20250318123842_app-stripe-store-masked-key.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "app_stripes" table
+ALTER TABLE "app_stripes" DROP COLUMN "masked_api_key";

--- a/tools/migrate/migrations/20250318123842_app-stripe-store-masked-key.up.sql
+++ b/tools/migrate/migrations/20250318123842_app-stripe-store-masked-key.up.sql
@@ -1,0 +1,3 @@
+-- modify "app_stripes" table
+ALTER TABLE "app_stripes" ADD COLUMN "masked_api_key" character varying NOT NULL DEFAULT 'sk_***';
+ALTER TABLE "app_stripes" ALTER COLUMN "masked_api_key" DROP DEFAULT;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:fDFD8PZ8j8vPRxmMYjAeFv9ai8AXG8pP7VA0oDQL2Hg=
+h1:4J/84Eh1zbOTLoIo/oyE2mjHT2l9rLcwtUKJ4Lap/dI=
 20240826120919_init.down.sql h1:AIbgwwngjkJEYa3yRZsIXQyBa2+qoZttwMXHxXEbHLI=
 20240826120919_init.up.sql h1:/hYHWF3Z3dab8SMKnw99ixVktCuJe2bAw5wstCZIEN8=
 20240903155435_entitlement-expired-index.down.sql h1:np2xgYs3KQ2z7qPBcobtGNhqWQ3V8NwEP9E5U3TmpSA=
@@ -131,3 +131,5 @@ h1:fDFD8PZ8j8vPRxmMYjAeFv9ai8AXG8pP7VA0oDQL2Hg=
 20250307151454_balance-snapshot-usage.up.sql h1:j2x/+rYBLsHNpUCmeKwvyXe1TwXTSDMlddESgUFUqMM=
 20250311193204_balance-snapshot-indexes.down.sql h1:8EImnDEROfVw7dS2S6iIsbKH7L2VKBPdjKmfXV4bv4c=
 20250311193204_balance-snapshot-indexes.up.sql h1:pOm1/hjT5JNIKY6HGoE9cKdm7sEktvGoe70aXIXdtas=
+20250318123842_app-stripe-store-masked-key.down.sql h1:5qtoEQDhImUZlDa8UZctf537UlLByNFldG4mve/85MA=
+20250318123842_app-stripe-store-masked-key.up.sql h1:0FdVfvwRrXul3yotzfXN1hoI3UqYueVR0osAFXoakeg=


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This is only for troubleshooting purposes, the masked key is not sensitive, so let's just store it in the db.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced, masked API key support that now secures and validates API key information.
- **Refactor**
	- Streamlined data mapping and parameter handling to improve overall operational efficiency.
- **Database Migrations**
	- Updated the schema to include a masked API key field, bolstering data integrity and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->