### PR TITLE
fix: do not reset key on subscription starting

### DIFF
--- a/openmeter/customer/adapter/customer.go
+++ b/openmeter/customer/adapter/customer.go
@@ -338,13 +338,8 @@ func (a *adapter) UpdateCustomer(ctx context.Context, input customer.UpdateCusto
 					SetName(input.Name).
 					SetOrClearDescription(input.Description).
 					SetNillablePrimaryEmail(input.PrimaryEmail).
-					SetNillableCurrency(input.Currency)
-
-				if input.Key != nil {
-					query = query.SetKey(*input.Key)
-				} else {
-					query = query.ClearKey()
-				}
+					SetNillableCurrency(input.Currency).
+					SetOrClearKey(input.Key)
 
 				if input.BillingAddress != nil {
 					query = query.

--- a/openmeter/subscription/service/service.go
+++ b/openmeter/subscription/service/service.go
@@ -432,6 +432,7 @@ func (s *service) updateCustomerCurrencyIfNotSet(ctx context.Context, sub subscr
 			CustomerID: cust.GetID(),
 			CustomerMutate: customer.CustomerMutate{
 				Name:             cust.Name,
+				Key:              cust.Key,
 				Description:      cust.Description,
 				UsageAttribution: cust.UsageAttribution,
 				PrimaryEmail:     cust.PrimaryEmail,


### PR DESCRIPTION
On the long run we should have a specific method that updates the currency, as on the next field in customer we will have the same issue.