### PR TITLE
Enable granting on subs managed entitlements

### DIFF
--- a/openmeter/entitlement/driver/metered.go
+++ b/openmeter/entitlement/driver/metered.go
@@ -120,19 +120,6 @@ func (h *meteredEntitlementHandler) CreateGrant() CreateGrantHandler {
 			return req, nil
 		},
 		func(ctx context.Context, request CreateGrantHandlerRequest) (api.EntitlementGrant, error) {
-			ent, err := h.entitlementConnector.GetEntitlementOfSubjectAt(ctx, request.Namespace, request.SubjectKey, request.EntitlementIdOrFeatureKey, clock.Now())
-			if err != nil {
-				return api.EntitlementGrant{}, err
-			}
-
-			if ent == nil {
-				return api.EntitlementGrant{}, fmt.Errorf("unexpected nil entitlement")
-			}
-
-			if ent.SubscriptionManaged {
-				return api.EntitlementGrant{}, models.NewGenericForbiddenError(fmt.Errorf("entitlement is managed by subscription"))
-			}
-
 			grant, err := h.balanceConnector.CreateGrant(ctx, request.Namespace, request.SubjectKey, request.EntitlementIdOrFeatureKey, request.GrantInput)
 			if err != nil {
 				return api.EntitlementGrant{}, err


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Might make sense to reenable this due to user requests.

### Context (copied from slack)
Some reasons it made sense to forbid this:
- **non-intuitive behavior** (i think the main reason): the `entitlementId` changes with edits, phase changes, etc... the user expectation might be that it stays the same as long as the user has access to the feature

_(i'm actually in favor of changing this behavior, most likely as an additional effort as part of / after addons)_

- most usecases can be covered by editing the subscription instead: for a very temporary grant this doesn't really make sense (as UI doesn't allow queuing multiple edits, you can't really time the changes), but otherwise a good approach

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined the permission granting process by removing intermediary validation steps, resulting in a more direct workflow with updated error handling. These changes simplify the underlying process, potentially affecting responses in specific edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->