### PR TITLE
Fix entitlement alignment on aligned edits

### DIFF
--- a/openmeter/subscription/service/sync.go
+++ b/openmeter/subscription/service/sync.go
@@ -259,13 +259,13 @@ func (s *service) sync(ctx context.Context, view subscription.SubscriptionView, 
 
 					// If the item got deleted, we can create it as a whole
 					if dirty.isTouched(NewItemVersionPath(currentItemView.Spec.PhaseKey, currentItemView.Spec.ItemKey, currentItemIdx)) {
-						if _, err := s.createItem(
-							ctx,
-							view.Customer,
-							*matchingItemFromNewSpec,
-							currentPhaseView.SubscriptionPhase,
-							newPhaseCadence,
-						); err != nil {
+						if _, err := s.createItem(ctx, createItemOptions{
+							cust:         view.Customer,
+							sub:          view.Subscription,
+							phase:        currentPhaseView.SubscriptionPhase,
+							phaseCadence: newPhaseCadence,
+							itemSpec:     *matchingItemFromNewSpec,
+						}); err != nil {
 							return def, fmt.Errorf("failed to create item: %w", err)
 						}
 
@@ -312,13 +312,13 @@ func (s *service) sync(ctx context.Context, view subscription.SubscriptionView, 
 
 					// If we didn't find a matching key in the current view, we need to create the item
 					if !foundMatchingItemsByKeyInCurrentView {
-						if _, err := s.createItem(
-							ctx,
-							view.Customer,
-							*item,
-							matchingPhaseInCurrentView.SubscriptionPhase,
-							phaseCadence,
-						); err != nil {
+						if _, err := s.createItem(ctx, createItemOptions{
+							cust:         view.Customer,
+							sub:          view.Subscription,
+							phase:        matchingPhaseInCurrentView.SubscriptionPhase,
+							phaseCadence: phaseCadence,
+							itemSpec:     *item,
+						}); err != nil {
 							return def, fmt.Errorf("failed to create item: %w", err)
 						}
 
@@ -329,13 +329,13 @@ func (s *service) sync(ctx context.Context, view subscription.SubscriptionView, 
 						// present in the current phase
 
 						// The rest we create
-						if _, err := s.createItem(
-							ctx,
-							view.Customer,
-							*item,
-							matchingPhaseInCurrentView.SubscriptionPhase,
-							phaseCadence,
-						); err != nil {
+						if _, err := s.createItem(ctx, createItemOptions{
+							cust:         view.Customer,
+							sub:          view.Subscription,
+							phase:        matchingPhaseInCurrentView.SubscriptionPhase,
+							phaseCadence: phaseCadence,
+							itemSpec:     *item,
+						}); err != nil {
 							return def, fmt.Errorf("failed to create item: %w", err)
 						}
 					}

--- a/test/subscription/scenario_editaligned_test.go
+++ b/test/subscription/scenario_editaligned_test.go
@@ -363,6 +363,6 @@ func TestEditingEntitlementOfUnalignedSub(t *testing.T) {
 	// Finally, let's check that the period of the entitlement is shifted (by activeFrom)
 	require.NotEqual(t, sView.Phases[0].ItemsByKey["test_feature_1"][0].Entitlement.Entitlement.CurrentUsagePeriod.From, sUpdated.Phases[0].ItemsByKey["test_feature_1"][1].Entitlement.Entitlement.CurrentUsagePeriod.From)
 	require.NotEqual(t, sView.Phases[0].ItemsByKey["test_feature_1"][0].Entitlement.Entitlement.CurrentUsagePeriod.To, sUpdated.Phases[0].ItemsByKey["test_feature_1"][1].Entitlement.Entitlement.CurrentUsagePeriod.To)
-	// It should strat with item activeFrom time
+	// It should start with item activeFrom time
 	require.Equal(t, sUpdated.Phases[0].ItemsByKey["test_feature_1"][1].Entitlement.Entitlement.ActiveFrom.UTC().Truncate(time.Minute), sUpdated.Phases[0].ItemsByKey["test_feature_1"][1].Entitlement.Entitlement.CurrentUsagePeriod.From.UTC().Truncate(time.Minute))
 }

--- a/test/subscription/scenario_editaligned_test.go
+++ b/test/subscription/scenario_editaligned_test.go
@@ -1,0 +1,368 @@
+package subscription_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	pcsubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/openmeter/subscription/patch"
+	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/subscription/testutils"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestEditingEntitlementOfAlignedSub(t *testing.T) {
+	// Let's declare our variables
+	// note: this namespace is hardcoded in the test framework
+	namespace := "test-namespace"
+
+	currentTime := testutils.GetRFC3339Time(t, "2025-01-20T13:11:07Z")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tDeps := setup(t, setupConfig{})
+	defer tDeps.cleanup(t)
+
+	clock.SetTime(currentTime)
+
+	// 1st, let's create the features
+	f, err := tDeps.FeatureConnector.CreateFeature(ctx, feature.CreateFeatureInputs{
+		Name:      "Example Feature",
+		Key:       "test_feature_1",
+		Namespace: namespace,
+		MeterSlug: lo.ToPtr(subscriptiontestutils.ExampleFeatureMeterSlug),
+	})
+	require.NoError(t, err)
+
+	// 2nd, let's create the plan
+	p, err := tDeps.PlanService.CreatePlan(ctx, plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:     "Test Plan",
+				Key:      "test_plan",
+				Currency: "USD",
+				Alignment: productcatalog.Alignment{
+					BillablesMustAlign: true,
+				},
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: productcatalog.PhaseMeta{
+						Key:      "default",
+						Name:     "Default Phase",
+						Duration: nil,
+					},
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:     "test_feature_1",
+								Name:    "Test Rate Card",
+								Feature: &f,
+								Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+									Amount: alpacadecimal.NewFromInt(100),
+								}),
+								TaxConfig: &productcatalog.TaxConfig{
+									Stripe: &productcatalog.StripeTaxConfig{
+										Code: "txcd_10000000",
+									},
+								},
+								EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.MeteredEntitlementTemplate{
+									UsagePeriod:     testutils.GetISODuration(t, "P1M"),
+									IssueAfterReset: lo.ToPtr(0.0), // We will change this in the update
+								}),
+							},
+							BillingCadence: testutils.GetISODuration(t, "P1M"),
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	p, err = tDeps.PlanService.PublishPlan(ctx, plan.PublishPlanInput{
+		NamespacedID: p.NamespacedID,
+		EffectivePeriod: productcatalog.EffectivePeriod{
+			EffectiveFrom: lo.ToPtr(currentTime),
+		},
+	})
+	require.NoError(t, err)
+
+	// 3rd, let's create the customer
+	c, err := tDeps.CustomerService.CreateCustomer(ctx, customer.CreateCustomerInput{
+		Namespace: namespace,
+		CustomerMutate: customer.CustomerMutate{
+			Name: "Test Customer",
+			UsageAttribution: customer.CustomerUsageAttribution{
+				SubjectKeys: []string{"subject_1"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	pi := &pcsubscription.PlanInput{}
+	pi.FromRef(&pcsubscription.PlanRefInput{
+		Key:     p.Key,
+		Version: &p.Version,
+	})
+
+	// 4th, let's create the subscription
+	s, err := tDeps.pcSubscriptionService.Create(ctx, pcsubscription.CreateSubscriptionRequest{
+		WorkflowInput: subscription.CreateSubscriptionWorkflowInput{
+			Namespace:  namespace,
+			CustomerID: c.ID,
+			ChangeSubscriptionWorkflowInput: subscription.ChangeSubscriptionWorkflowInput{
+				Timing: subscription.Timing{
+					Custom: &currentTime,
+				},
+				Name: "Test Subscription",
+			},
+		},
+		PlanInput: *pi,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	// Let's also fetch the subscription
+	sView, err := tDeps.subscriptionService.GetView(ctx, s.NamespacedID)
+	require.NoError(t, err)
+	require.NotNil(t, sView)
+
+	// Now lets pass some time with the edit
+	currentTime = clock.Now().Add(time.Hour)
+	clock.SetTime(currentTime)
+
+	// 5th, let's edit the subscription
+	sUpdated, err := tDeps.subscriptionWorkflowService.EditRunning(ctx, s.NamespacedID, []subscription.Patch{
+		patch.PatchRemoveItem{
+			ItemKey:  "test_feature_1",
+			PhaseKey: "default",
+		},
+		patch.PatchAddItem{
+			PhaseKey: "default",
+			ItemKey:  "test_feature_1",
+			CreateInput: subscription.SubscriptionItemSpec{
+				CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+					CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+						PhaseKey: "default",
+						ItemKey:  "test_feature_1",
+						RateCard: subscription.RateCard{
+							Name:       "Test Rate Card",
+							FeatureKey: lo.ToPtr("test_feature_1"),
+							EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.MeteredEntitlementTemplate{
+								UsagePeriod:     testutils.GetISODuration(t, "P1M"),
+								IssueAfterReset: lo.ToPtr(100.0), // So we have an update on the entitlement
+							}),
+							Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+								Amount: alpacadecimal.NewFromInt(101),
+							}),
+							TaxConfig: &productcatalog.TaxConfig{
+								Stripe: &productcatalog.StripeTaxConfig{
+									Code: "txcd_10000000",
+								},
+							},
+							BillingCadence: lo.ToPtr(testutils.GetISODuration(t, "P1M")),
+						},
+					},
+					CreateSubscriptionItemCustomerInput: subscription.CreateSubscriptionItemCustomerInput{},
+				},
+			},
+		},
+	}, subscription.Timing{
+		Enum: lo.ToPtr(subscription.TimingImmediate),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sUpdated)
+
+	// Finally, let's check that the period of the entitlement is still the same (follows the same cadence)
+	require.Equal(t, sView.Phases[0].ItemsByKey["test_feature_1"][0].Entitlement.Entitlement.CurrentUsagePeriod.From, sUpdated.Phases[0].ItemsByKey["test_feature_1"][1].Entitlement.Entitlement.CurrentUsagePeriod.From)
+	require.Equal(t, sView.Phases[0].ItemsByKey["test_feature_1"][0].Entitlement.Entitlement.CurrentUsagePeriod.To, sUpdated.Phases[0].ItemsByKey["test_feature_1"][1].Entitlement.Entitlement.CurrentUsagePeriod.To)
+	require.Less(t, sView.Phases[0].ItemsByKey["test_feature_1"][0].Entitlement.Entitlement.CreatedAt, sUpdated.Phases[0].ItemsByKey["test_feature_1"][1].Entitlement.Entitlement.CreatedAt)
+}
+
+func TestEditingEntitlementOfUnalignedSub(t *testing.T) {
+	// Let's declare our variables
+	// note: this namespace is hardcoded in the test framework
+	namespace := "test-namespace"
+
+	currentTime := testutils.GetRFC3339Time(t, "2025-01-20T13:11:07Z")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tDeps := setup(t, setupConfig{})
+	defer tDeps.cleanup(t)
+
+	clock.SetTime(currentTime)
+
+	// 1st, let's create the features
+	f, err := tDeps.FeatureConnector.CreateFeature(ctx, feature.CreateFeatureInputs{
+		Name:      "Example Feature",
+		Key:       "test_feature_1",
+		Namespace: namespace,
+		MeterSlug: lo.ToPtr(subscriptiontestutils.ExampleFeatureMeterSlug),
+	})
+	require.NoError(t, err)
+
+	// 2nd, let's create the plan
+	p, err := tDeps.PlanService.CreatePlan(ctx, plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:     "Test Plan",
+				Key:      "test_plan",
+				Currency: "USD",
+				Alignment: productcatalog.Alignment{
+					BillablesMustAlign: false,
+				},
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: productcatalog.PhaseMeta{
+						Key:      "default",
+						Name:     "Default Phase",
+						Duration: nil,
+					},
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:     "test_feature_1",
+								Name:    "Test Rate Card",
+								Feature: &f,
+								Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+									Amount: alpacadecimal.NewFromInt(100),
+								}),
+								TaxConfig: &productcatalog.TaxConfig{
+									Stripe: &productcatalog.StripeTaxConfig{
+										Code: "txcd_10000000",
+									},
+								},
+								EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.MeteredEntitlementTemplate{
+									UsagePeriod:     testutils.GetISODuration(t, "P1M"),
+									IssueAfterReset: lo.ToPtr(0.0), // We will change this in the update
+								}),
+							},
+							BillingCadence: testutils.GetISODuration(t, "P1M"),
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	p, err = tDeps.PlanService.PublishPlan(ctx, plan.PublishPlanInput{
+		NamespacedID: p.NamespacedID,
+		EffectivePeriod: productcatalog.EffectivePeriod{
+			EffectiveFrom: lo.ToPtr(currentTime),
+		},
+	})
+	require.NoError(t, err)
+
+	// 3rd, let's create the customer
+	c, err := tDeps.CustomerService.CreateCustomer(ctx, customer.CreateCustomerInput{
+		Namespace: namespace,
+		CustomerMutate: customer.CustomerMutate{
+			Name: "Test Customer",
+			UsageAttribution: customer.CustomerUsageAttribution{
+				SubjectKeys: []string{"subject_1"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	pi := &pcsubscription.PlanInput{}
+	pi.FromRef(&pcsubscription.PlanRefInput{
+		Key:     p.Key,
+		Version: &p.Version,
+	})
+
+	// 4th, let's create the subscription
+	s, err := tDeps.pcSubscriptionService.Create(ctx, pcsubscription.CreateSubscriptionRequest{
+		WorkflowInput: subscription.CreateSubscriptionWorkflowInput{
+			Namespace:  namespace,
+			CustomerID: c.ID,
+			ChangeSubscriptionWorkflowInput: subscription.ChangeSubscriptionWorkflowInput{
+				Timing: subscription.Timing{
+					Custom: &currentTime,
+				},
+				Name: "Test Subscription",
+			},
+		},
+		PlanInput: *pi,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	// Let's also fetch the subscription
+	sView, err := tDeps.subscriptionService.GetView(ctx, s.NamespacedID)
+	require.NoError(t, err)
+	require.NotNil(t, sView)
+
+	// Now lets pass some time with the edit
+	currentTime = clock.Now().Add(time.Hour)
+	clock.SetTime(currentTime)
+
+	// 5th, let's edit the subscription
+	sUpdated, err := tDeps.subscriptionWorkflowService.EditRunning(ctx, s.NamespacedID, []subscription.Patch{
+		patch.PatchRemoveItem{
+			ItemKey:  "test_feature_1",
+			PhaseKey: "default",
+		},
+		patch.PatchAddItem{
+			PhaseKey: "default",
+			ItemKey:  "test_feature_1",
+			CreateInput: subscription.SubscriptionItemSpec{
+				CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+					CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+						PhaseKey: "default",
+						ItemKey:  "test_feature_1",
+						RateCard: subscription.RateCard{
+							Name:       "Test Rate Card",
+							FeatureKey: lo.ToPtr("test_feature_1"),
+							EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.MeteredEntitlementTemplate{
+								UsagePeriod:     testutils.GetISODuration(t, "P1M"),
+								IssueAfterReset: lo.ToPtr(100.0), // So we have an update on the entitlement
+							}),
+							Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+								Amount: alpacadecimal.NewFromInt(101),
+							}),
+							TaxConfig: &productcatalog.TaxConfig{
+								Stripe: &productcatalog.StripeTaxConfig{
+									Code: "txcd_10000000",
+								},
+							},
+							BillingCadence: lo.ToPtr(testutils.GetISODuration(t, "P1M")),
+						},
+					},
+					CreateSubscriptionItemCustomerInput: subscription.CreateSubscriptionItemCustomerInput{},
+				},
+			},
+		},
+	}, subscription.Timing{
+		Enum: lo.ToPtr(subscription.TimingImmediate),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, sUpdated)
+
+	// Finally, let's check that the period of the entitlement is shifted (by activeFrom)
+	require.NotEqual(t, sView.Phases[0].ItemsByKey["test_feature_1"][0].Entitlement.Entitlement.CurrentUsagePeriod.From, sUpdated.Phases[0].ItemsByKey["test_feature_1"][1].Entitlement.Entitlement.CurrentUsagePeriod.From)
+	require.NotEqual(t, sView.Phases[0].ItemsByKey["test_feature_1"][0].Entitlement.Entitlement.CurrentUsagePeriod.To, sUpdated.Phases[0].ItemsByKey["test_feature_1"][1].Entitlement.Entitlement.CurrentUsagePeriod.To)
+	// It should strat with item activeFrom time
+	require.Equal(t, sUpdated.Phases[0].ItemsByKey["test_feature_1"][1].Entitlement.Entitlement.ActiveFrom.UTC().Truncate(time.Minute), sUpdated.Phases[0].ItemsByKey["test_feature_1"][1].Entitlement.Entitlement.CurrentUsagePeriod.From.UTC().Truncate(time.Minute))
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Entitlement usage period will be same as aligned billingperiod for the subscription if the subscription is aligned (derived from the current phase start)

## Notes for reviewer

<!-- Anything the reviewer should know? -->
