### PR TITLE
feat: subscription sync job

### DIFF
--- a/app/common/billing.go
+++ b/app/common/billing.go
@@ -14,6 +14,7 @@ import (
 	billingsubscription "github.com/openmeterio/openmeter/openmeter/billing/validators/subscription"
 	billingworkerautoadvance "github.com/openmeterio/openmeter/openmeter/billing/worker/advance"
 	billingworkercollect "github.com/openmeterio/openmeter/openmeter/billing/worker/collect"
+	billingworkersubscription "github.com/openmeterio/openmeter/openmeter/billing/worker/subscription"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/meter"
@@ -93,5 +94,22 @@ func NewBillingCollector(logger *slog.Logger, service billing.Service) (*billing
 	return billingworkercollect.NewInvoiceCollector(billingworkercollect.Config{
 		BillingService: service,
 		Logger:         logger,
+	})
+}
+
+func NewBillingSubscriptionReconciler(logger *slog.Logger, subsServices SubscriptionServiceWithWorkflow, subscriptionSync *billingworkersubscription.Handler) (*billingworkersubscription.Reconciler, error) {
+	return billingworkersubscription.NewReconciler(billingworkersubscription.ReconcilerConfig{
+		SubscriptionService: subsServices.Service,
+		SubscriptionSync:    subscriptionSync,
+		Logger:              logger,
+	})
+}
+
+func NewBillingSubscriptionHandler(logger *slog.Logger, subsServices SubscriptionServiceWithWorkflow, billingService billing.Service, billingAdapter billing.Adapter) (*billingworkersubscription.Handler, error) {
+	return billingworkersubscription.New(billingworkersubscription.Config{
+		SubscriptionService: subsServices.Service,
+		BillingService:      billingService,
+		TxCreator:           billingAdapter,
+		Logger:              logger,
 	})
 }

--- a/cmd/jobs/billing/billing.go
+++ b/cmd/jobs/billing/billing.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openmeterio/openmeter/cmd/jobs/billing/advance"
 	"github.com/openmeterio/openmeter/cmd/jobs/billing/collect"
+	"github.com/openmeterio/openmeter/cmd/jobs/billing/subscriptionsync"
 )
 
 var Cmd = &cobra.Command{
@@ -15,4 +16,5 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.AddCommand(advance.Cmd)
 	Cmd.AddCommand(collect.Cmd)
+	Cmd.AddCommand(subscriptionsync.Cmd)
 }

--- a/cmd/jobs/billing/subscriptionsync/sync.go
+++ b/cmd/jobs/billing/subscriptionsync/sync.go
@@ -1,0 +1,89 @@
+package subscriptionsync
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openmeterio/openmeter/cmd/jobs/internal"
+	billingworkersubscription "github.com/openmeterio/openmeter/openmeter/billing/worker/subscription"
+)
+
+const (
+	defaultLookback = 24 * time.Hour
+)
+
+var (
+	namespaces  []string
+	customerIDs []string
+	lookback    time.Duration
+)
+
+var Cmd = &cobra.Command{
+	Use:   "subscriptionsync",
+	Short: "Subscription sync operations",
+}
+
+func init() {
+	Cmd.AddCommand(ListCmd())
+	Cmd.AddCommand(AllCmd())
+}
+
+var ListCmd = func() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List subscriptions which can be synced",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			subs, err := internal.App.BillingSubscriptionReconciler.ListSubscriptions(cmd.Context(), billingworkersubscription.ReconcilerListSubscriptionsInput{
+				Namespaces: namespaces,
+				Customers:  customerIDs,
+				Lookback:   lookback,
+			})
+			if err != nil {
+				return err
+			}
+
+			for _, sub := range subs {
+				activeTo := ""
+				if sub.ActiveTo != nil {
+					activeTo = fmt.Sprintf(" ActiveTo: %s", sub.ActiveTo.Format(time.RFC3339))
+				}
+
+				fmt.Printf("Namespace: %s ID: %s CustomerID: %s ActiveFrom: %s%s\n",
+					sub.Namespace,
+					sub.ID,
+					sub.CustomerId,
+					sub.ActiveFrom.Format(time.RFC3339),
+					activeTo)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().StringSliceVar(&namespaces, "n", nil, "filter by namespaces")
+	cmd.PersistentFlags().StringSliceVar(&customerIDs, "c", nil, "filter by customer ids")
+	cmd.PersistentFlags().DurationVar(&lookback, "l", defaultLookback, "lookback period")
+
+	return cmd
+}
+
+var AllCmd = func() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "all",
+		Short: "Sync all subscriptions",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return internal.App.BillingSubscriptionReconciler.All(cmd.Context(), billingworkersubscription.ReconcilerAllInput{
+				Namespaces: namespaces,
+				Customers:  customerIDs,
+				Lookback:   lookback,
+			})
+		},
+	}
+
+	cmd.PersistentFlags().StringSliceVar(&namespaces, "n", nil, "filter by namespaces")
+	cmd.PersistentFlags().StringSliceVar(&customerIDs, "c", nil, "filter by customer ids")
+	cmd.PersistentFlags().DurationVar(&lookback, "l", defaultLookback, "lookback period")
+	return cmd
+}

--- a/cmd/jobs/internal/wire.go
+++ b/cmd/jobs/internal/wire.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	billingworkerautoadvance "github.com/openmeterio/openmeter/openmeter/billing/worker/advance"
 	billingworkercollect "github.com/openmeterio/openmeter/openmeter/billing/worker/collect"
+	billingworkersubscription "github.com/openmeterio/openmeter/openmeter/billing/worker/subscription"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/meter"
@@ -35,28 +36,29 @@ type Application struct {
 	common.GlobalInitializer
 	common.Migrator
 
-	App                   app.Service
-	AppStripe             appstripe.Service
-	AppSandboxProvisioner common.AppSandboxProvisioner
-	Customer              customer.Service
-	Billing               billing.Service
-	BillingAutoAdvancer   *billingworkerautoadvance.AutoAdvancer
-	BillingCollector      *billingworkercollect.InvoiceCollector
-	EntClient             *db.Client
-	EventPublisher        eventbus.Publisher
-	EntitlementRegistry   *registry.Entitlement
-	FeatureConnector      feature.FeatureConnector
-	KafkaProducer         *kafka.Producer
-	KafkaMetrics          *kafkametrics.Metrics
-	Logger                *slog.Logger
-	MeterService          meter.Service
-	NamespaceHandlers     []namespace.Handler
-	NamespaceManager      *namespace.Manager
-	Meter                 metric.Meter
-	Plan                  plan.Service
-	Secret                secret.Service
-	Subscription          common.SubscriptionServiceWithWorkflow
-	StreamingConnector    streaming.Connector
+	App                           app.Service
+	AppStripe                     appstripe.Service
+	AppSandboxProvisioner         common.AppSandboxProvisioner
+	Customer                      customer.Service
+	Billing                       billing.Service
+	BillingAutoAdvancer           *billingworkerautoadvance.AutoAdvancer
+	BillingCollector              *billingworkercollect.InvoiceCollector
+	BillingSubscriptionReconciler *billingworkersubscription.Reconciler
+	EntClient                     *db.Client
+	EventPublisher                eventbus.Publisher
+	EntitlementRegistry           *registry.Entitlement
+	FeatureConnector              feature.FeatureConnector
+	KafkaProducer                 *kafka.Producer
+	KafkaMetrics                  *kafkametrics.Metrics
+	Logger                        *slog.Logger
+	MeterService                  meter.Service
+	NamespaceHandlers             []namespace.Handler
+	NamespaceManager              *namespace.Manager
+	Meter                         metric.Meter
+	Plan                          plan.Service
+	Secret                        secret.Service
+	Subscription                  common.SubscriptionServiceWithWorkflow
+	StreamingConnector            streaming.Connector
 }
 
 func initializeApplication(ctx context.Context, conf config.Configuration) (Application, func(), error) {
@@ -76,6 +78,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		common.Namespace,
 		common.NewBillingAutoAdvancer,
 		common.NewBillingCollector,
+		common.NewBillingSubscriptionHandler,
+		common.NewBillingSubscriptionReconciler,
 		common.NewDefaultTextMapPropagator,
 		common.NewServerPublisher,
 		common.Streaming,

--- a/openmeter/billing/worker/subscription/reconciler.go
+++ b/openmeter/billing/worker/subscription/reconciler.go
@@ -1,0 +1,119 @@
+package billingworkersubscription
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// Reconciler is a component that periodically reconciles the subscription state with the billing state
+// this is essential, as the invoice creation is purley event driven. In case a processing error happens,
+// we might fail to create an invoice, and stop processing the subscription.
+type Reconciler struct {
+	subscriptionSync    *Handler
+	subscriptionService subscription.Service
+
+	logger *slog.Logger
+}
+
+type ReconcilerConfig struct {
+	SubscriptionSync    *Handler
+	SubscriptionService subscription.Service
+
+	Logger *slog.Logger
+}
+
+func (c ReconcilerConfig) Validate() error {
+	if c.SubscriptionSync == nil {
+		return errors.New("subscriptionSync is required")
+	}
+
+	if c.SubscriptionService == nil {
+		return errors.New("subscriptionService is required")
+	}
+
+	if c.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	return nil
+}
+
+func NewReconciler(config ReconcilerConfig) (*Reconciler, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &Reconciler{
+		subscriptionSync:    config.SubscriptionSync,
+		subscriptionService: config.SubscriptionService,
+		logger:              config.Logger,
+	}, nil
+}
+
+type ReconcilerListSubscriptionsInput struct {
+	Namespaces []string
+	Customers  []string
+	Lookback   time.Duration
+}
+
+func (i ReconcilerListSubscriptionsInput) Validate() error {
+	if i.Lookback <= 0 {
+		return errors.New("lookback must be greater than 0")
+	}
+
+	return nil
+}
+
+func (r *Reconciler) ListSubscriptions(ctx context.Context, in ReconcilerListSubscriptionsInput) ([]subscription.Subscription, error) {
+	if err := in.Validate(); err != nil {
+		return nil, err
+	}
+
+	subscriptions, err := r.subscriptionService.List(ctx, subscription.ListSubscriptionsInput{
+		Namespaces: in.Namespaces,
+		Customers:  in.Customers,
+		ActiveAt:   lo.ToPtr(time.Now().Add(in.Lookback)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list subscriptions: %w", err)
+	}
+
+	return subscriptions.Items, nil
+}
+
+func (r *Reconciler) ReconcileSubscription(ctx context.Context, subsID models.NamespacedID) error {
+	subsView, err := r.subscriptionService.GetView(ctx, subsID)
+	if err != nil {
+		return fmt.Errorf("failed to get subscription: %w", err)
+	}
+
+	return r.subscriptionSync.SyncronizeSubscription(ctx, subsView, time.Now())
+}
+
+type ReconcilerAllInput = ReconcilerListSubscriptionsInput
+
+func (r *Reconciler) All(ctx context.Context, in ReconcilerAllInput) error {
+	subscriptions, err := r.ListSubscriptions(ctx, in)
+	if err != nil {
+		return fmt.Errorf("failed to list subscriptions: %w", err)
+	}
+
+	var outErr error
+	for _, subscription := range subscriptions {
+		if err := r.ReconcileSubscription(ctx, subscription.NamespacedID); err != nil {
+			r.logger.ErrorContext(ctx, "failed to reconcile subscription", "error", err)
+
+			outErr = errors.Join(outErr, fmt.Errorf("failed to reconcile subscription: %w", err))
+		}
+	}
+
+	return outErr
+}


### PR DESCRIPTION

## Overview

This job can be used to resyncronize the state between subscriptions and billing.

Given the flow is fully event driven, a missed/failed event can cause the subscription billing to stop permanently.

This is a safeguard against this possibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new subscription synchronization commands for listing and syncing subscriptions with filtering options.
  - Enhanced billing subscription reconciliation to improve invoicing accuracy.
  - Optimized handling of subscription events, ensuring more reliable and consistent billing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->