### PR TITLE
fix: gathering invoice deletion from sync

### DIFF
--- a/openmeter/billing/worker/subscription/sync.go
+++ b/openmeter/billing/worker/subscription/sync.go
@@ -725,6 +725,11 @@ func (h *Handler) updateMutableInvoice(ctx context.Context, invoice billing.Invo
 	}
 
 	if updatedInvoice.Lines.NonDeletedLineCount() == 0 {
+		if updatedInvoice.Status == billing.InvoiceStatusGathering {
+			// Gathering invoice deletion is handled by the service layer if they are empty
+			return nil
+		}
+
 		// The invoice has no lines, so let's just delete it
 		if err := h.billingService.DeleteInvoice(ctx, updatedInvoice.InvoiceID()); err != nil {
 			return fmt.Errorf("deleting empty invoice: %w", err)


### PR DESCRIPTION
## Overview

Fixes the issue when there's a subscription is canceled at the end of the billing period and there was no sync.

This fixes the following error:
```
failed to reconcile subscription [namespace=org_2l3uuzkgTdvCyom82y11jeZO2u5 subscriptionID=01JFQR5CWX8DJYPFKACQ5GB6CC]: updating mutable invoice[01JKBTW7YF0E9V7Y0PDZWM5A0A]: deleting empty invoice: cannot trigger_delete invoice in status [gathering]: invoice action not available
```
