### PR TITLE
feat(collector): require subject in cloudevents.spec.json

### DIFF
--- a/cloudevents.spec.json
+++ b/cloudevents.spec.json
@@ -41,10 +41,7 @@
       "description": "Content type of the data value. Must adhere to RFC 2046 format.",
       "$ref": "#/definitions/datacontenttypedef",
       "examples": [
-        "text/xml",
-        "application/json",
-        "image/png",
-        "multipart/form-data"
+        "application/json"
       ]
     },
     "dataschema": {
@@ -67,10 +64,7 @@
     },
     "data": {
       "description": "The event payload.",
-      "$ref": "#/definitions/datadef",
-      "examples": [
-        "<much wow=\"xml\"/>"
-      ]
+      "$ref": "#/definitions/datadef"
     },
     "data_base64": {
       "description": "Base64 encoded event payload. Must adhere to RFC4648.",
@@ -80,7 +74,7 @@
       ]
     }
   },
-  "required": ["id", "source", "specversion", "type"],
+  "required": ["id", "source", "specversion", "type", "subject"],
   "definitions": {
     "iddef": {
       "type": "string",
@@ -118,7 +112,8 @@
       "minLength": 1
     },
     "datadef": {
-      "type": ["object", "string", "number", "array", "boolean", "null"]
+      "type": ["object", "null"],
+      "additionalProperties": true
     },
     "data_base64def": {
       "type": ["string", "null"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the CloudEvents schema for a simpler and more consistent event format.
	- Updated the required fields by adding an additional subject property.
	- Reduced content type options to a single consistent value.
	- Limited the allowed data types to object or null while still permitting extra properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->