### PR TITLE
fix: list active subscriptions by time

### DIFF
--- a/openmeter/subscription/repo/subscriptionrepo.go
+++ b/openmeter/subscription/repo/subscriptionrepo.go
@@ -172,9 +172,12 @@ func (r *subscriptionRepo) List(ctx context.Context, in subscription.ListSubscri
 
 		if in.ActiveAt != nil {
 			query = query.Where(
-				dbsubscription.Or(
-					dbsubscription.ActiveToIsNil(),
-					dbsubscription.ActiveToGT(*in.ActiveAt),
+				dbsubscription.And(
+					dbsubscription.ActiveFromLT(*in.ActiveAt),
+					dbsubscription.Or(
+						dbsubscription.ActiveToIsNil(),
+						dbsubscription.ActiveToGT(*in.ActiveAt),
+					),
 				),
 			)
 		}


### PR DESCRIPTION
## Overview

Fix listing active subscription at timestamp be excluding subscriptions which has `activeFrom` set in the future compared to the provided timestamp and no `activeTo` set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced subscription filtering to accurately display only those subscriptions active based on revised date criteria, ensuring that subscriptions with a valid start date and appropriate end date (or no end date) are correctly included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->