### PR TITLE
refactor: terminating services

### DIFF
--- a/app/common/runner.go
+++ b/app/common/runner.go
@@ -15,7 +15,7 @@ type Runner struct {
 }
 
 func (r Runner) Run() {
-	err := r.Group.Run()
+	err := r.Group.Run(run.WithReverseShutdownOrder())
 	if e := &(run.SignalError{}); errors.As(err, &e) {
 		r.Logger.Info("received signal: shutting down", slog.String("signal", e.Signal.String()))
 	} else if !errors.Is(err, http.ErrServerClosed) {

--- a/cmd/notification-service/main.go
+++ b/cmd/notification-service/main.go
@@ -146,7 +146,7 @@ func main() {
 	group.Add(run.SignalHandler(ctx, syscall.SIGINT, syscall.SIGTERM))
 
 	// Run the group
-	err = group.Run()
+	err = group.Run(run.WithReverseShutdownOrder())
 	if e := &(run.SignalError{}); errors.As(err, &e) {
 		logger.Info("received signal: shutting down", slog.String("signal", e.Signal.String()))
 	} else if !errors.Is(err, http.ErrServerClosed) {

--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -138,7 +138,7 @@ func main() {
 	group.Add(run.SignalHandler(ctx, syscall.SIGINT, syscall.SIGTERM))
 
 	// Run actors
-	err = group.Run()
+	err = group.Run(run.WithReverseShutdownOrder())
 
 	if e := &(run.SignalError{}); errors.As(err, &e) {
 		logger.Info("received signal: shutting down", slog.String("signal", e.Signal.String()))


### PR DESCRIPTION
## Overview

Stop components in reverse order during service termination.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated service shutdown behavior to use a reverse order during termination, ensuring components with dependencies stop in a more coordinated sequence without affecting error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->