### PR TITLE
Require all reviewers

### DIFF
--- a/.github/workflows/require-all-reviewers.yml
+++ b/.github/workflows/require-all-reviewers.yml
@@ -1,0 +1,31 @@
+name: "Require All Reviewers Gate"
+
+on:
+  pull_request:
+    types:
+      [
+        assigned,
+        unassigned,
+        opened,
+        reopened,
+        synchronize,
+        review_requested,
+        review_request_removed,
+      ]
+  pull_request_review:
+    # Trigger on submitted reviews to re-check status
+    types: [submitted]
+
+jobs:
+  review-gatekeeper:
+    name: Review Gatekeeper
+    # Use ubuntu-latest for the runner
+    runs-on: ubuntu-latest
+    steps:
+      # This action checks reviewers; it doesn't need to check out the code itself.
+      - name: Ensure all requested reviewers have approved
+        # Use a specific version tag for stability
+        uses: osievert/pr-gate-all-reviewers@v1.3
+        with:
+          # GITHUB_TOKEN is automatically provided by GitHub Actions
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/require-all-reviewers.yml
+++ b/.github/workflows/require-all-reviewers.yml
@@ -11,6 +11,8 @@ on:
         synchronize,
         review_requested,
         review_request_removed,
+        labeled,
+        unlabeled,
       ]
   pull_request_review:
     # Trigger on submitted reviews to re-check status
@@ -18,6 +20,7 @@ on:
 
 jobs:
   review-gatekeeper:
+    if: contains(github.event.pull_request.labels.*.name, 'require-all-reviewers')
     name: Review Gatekeeper
     # Grant necessary permissions for the job
     permissions:

--- a/.github/workflows/require-all-reviewers.yml
+++ b/.github/workflows/require-all-reviewers.yml
@@ -19,6 +19,10 @@ on:
 jobs:
   review-gatekeeper:
     name: Review Gatekeeper
+    # Grant necessary permissions for the job
+    permissions:
+      pull-requests: read
+      statuses: write
     # Use ubuntu-latest for the runner
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/require-all-reviewers.yml
+++ b/.github/workflows/require-all-reviewers.yml
@@ -31,8 +31,9 @@ jobs:
     steps:
       # This action checks reviewers; it doesn't need to check out the code itself.
       - name: Ensure all requested reviewers have approved
-        # Use a specific version tag for stability
-        uses: osievert/pr-gate-all-reviewers@v1.3
+        # Pin to specific commit SHA for security and stability
+        # Tag v1.3 corresponds to this hash
+        uses: osievert/pr-gate-all-reviewers@2419b1ba9d948371a5291643a86f98f70af1f592
         with:
           # GITHUB_TOKEN is automatically provided by GitHub Actions
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/require-all-reviewers.yml
+++ b/.github/workflows/require-all-reviewers.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Ensure all requested reviewers have approved
         # Pin to specific commit SHA for security and stability
         # Tag v1.3 corresponds to this hash
-        uses: osievert/pr-gate-all-reviewers@2419b1ba9d948371a5291643a86f98f70af1f592
+        uses: osievert/pr-gate-all-reviewers@5754b3a4ed8a95502378546ebc4f295a74374d4c
         with:
           # GITHUB_TOKEN is automatically provided by GitHub Actions
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,19 @@ or if the change was already implemented but not yet released.
 We expect new pull requests to include tests for any affected behavior, and, as we follow semantic versioning,
 we may reserve breaking changes until the next major version release.
 
+### Ensuring All Requested Reviewers Approve
+
+By default, pull requests can often be merged once the minimum number of required approvals (e.g., from CODEOWNERS or branch protection rules) is met. However, sometimes you might explicitly request reviews from specific individuals because their input is crucial for that particular PR.
+
+To ensure that *all* individuals you've specifically requested using the GitHub "Reviewers" UI must approve before merging, follow these steps:
+
+1.  **Request Reviews:** Use the standard GitHub interface on the pull request page to request reviews from the necessary individuals.
+2.  **Add Label:** Add the label `require-all-reviewers` to the pull request.
+
+When this label is present, an automated check named "Review Gatekeeper" will run. This check will only pass if **every single user** listed under the "Reviewers" section has submitted an **approving** review. This check is required for merging, preventing merges until all explicitly requested reviewers are satisfied.
+
+If the label is removed, the "Review Gatekeeper" check will be skipped.
+
 ## Other ways to contribute
 
 We welcome anyone that wants to contribute to triage and reply to open issues to help troubleshoot and fix existing bugs.


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Via `require-all-reviewers` label it adds a new job that mandates that all requested reviewers must approve (this way we ca keep using automerge)

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an automated process that requires all designated reviewers to approve a pull request before it can proceed when a specific label is applied.
  - Added a new section in the contribution guidelines detailing the process for ensuring all requested reviewers approve a pull request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->