### PR TITLE
fix: subject provisioning was borken

### DIFF
--- a/openmeter/sink/flushhandler/ingestnotification/events/events.go
+++ b/openmeter/sink/flushhandler/ingestnotification/events/events.go
@@ -50,10 +50,6 @@ func (b EventBatchedIngest) Validate() error {
 		return errors.New("subjectKey must be set")
 	}
 
-	if len(b.MeterSlugs) == 0 {
-		return errors.New("meterSlugs must not be empty")
-	}
-
 	return nil
 }
 

--- a/openmeter/sink/flushhandler/ingestnotification/handler.go
+++ b/openmeter/sink/flushhandler/ingestnotification/handler.go
@@ -51,8 +51,7 @@ func (h *handler) OnFlushSuccess(ctx context.Context, events []sinkmodels.SinkMe
 
 	// Filter meaningful events for downstream
 	filtered := lo.Filter(events, func(event sinkmodels.SinkMessage, _ int) bool {
-		// We explicityl ignore non-parseable & non-meter affecting events
-		return event.Serialized != nil && len(event.Meters) > 0
+		return event.Serialized != nil
 	})
 
 	if len(filtered) == 0 {


### PR DESCRIPTION
## Overview

As we are not sending batch ingest events due to missing meters data from the sink message.

Another patch will be added to fix the meter filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted event validation so that only essential details are required, allowing events with some optional information to be processed.
  - Simplified event filtering to broaden the criteria for processing, ensuring a wider range of events are handled downstream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->