### PR TITLE
Fix Aligned Canceled Sub Syncing

### DIFF
--- a/openmeter/billing/worker/subscription/phaseiterator.go
+++ b/openmeter/billing/worker/subscription/phaseiterator.go
@@ -85,6 +85,11 @@ func NewPhaseIterator(subs subscription.SubscriptionView, phaseKey string) (*Pha
 }
 
 func (it *PhaseIterator) HasInvoicableItems() bool {
+	// If the phase is 0 length it never activates so no items should be generated whatsoever
+	if it.phaseCadence.ActiveTo != nil && it.phaseCadence.ActiveTo.Equal(it.phaseCadence.ActiveFrom) {
+		return false
+	}
+
 	return it.phase.Spec.HasBillables()
 }
 

--- a/openmeter/subscription/aligment_test.go
+++ b/openmeter/subscription/aligment_test.go
@@ -1,0 +1,117 @@
+package subscription_test
+
+import (
+	"testing"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/invopop/gobl/currency"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	pcsubscriptionservice "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription/service"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/subscription/testutils"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/isodate"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestAlignedBillingPeriodCalculation(t *testing.T) {
+	ns := subscriptiontestutils.ExampleNamespace
+
+	planInp := plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: ns,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:     "Test Plan",
+				Currency: currency.USD,
+				Alignment: productcatalog.Alignment{
+					BillablesMustAlign: true,
+				},
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: productcatalog.PhaseMeta{
+						Name:     "trial",
+						Key:      "trial",
+						Duration: lo.ToPtr(testutils.GetISODuration(t, "P1M")),
+					},
+					// TODO[OM-1031]: let's add discount handling (as this could be a 100% discount for the first month)
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:  subscriptiontestutils.ExampleFeature.Key,
+								Name: subscriptiontestutils.ExampleFeature.Name,
+								// feature doesn't have to exist, we never call out to DB
+								Feature: &feature.Feature{
+									Namespace: subscriptiontestutils.ExampleFeature.Namespace,
+									Key:       subscriptiontestutils.ExampleFeature.Key,
+									ID:        "test-feature-id",
+									Name:      subscriptiontestutils.ExampleFeature.Name,
+									MeterSlug: subscriptiontestutils.ExampleFeature.MeterSlug,
+									CreatedAt: testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
+									UpdatedAt: testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
+								},
+							},
+							BillingCadence: isodate.MustParse(t, "P1M"),
+						},
+					},
+				},
+				{
+					PhaseMeta: productcatalog.PhaseMeta{
+						Name:     "default",
+						Key:      "default",
+						Duration: nil,
+					},
+					// TODO[OM-1031]: 50% discount
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:  subscriptiontestutils.ExampleFeature.Key,
+								Name: subscriptiontestutils.ExampleFeature.Name,
+								Feature: &feature.Feature{
+									Namespace: subscriptiontestutils.ExampleFeature.Namespace,
+									Key:       subscriptiontestutils.ExampleFeature.Key,
+									ID:        "test-feature-id",
+									Name:      subscriptiontestutils.ExampleFeature.Name,
+									MeterSlug: subscriptiontestutils.ExampleFeature.MeterSlug,
+									CreatedAt: testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
+									UpdatedAt: testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
+								},
+								Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+									Amount: alpacadecimal.NewFromFloat(5),
+								}),
+							},
+							BillingCadence: isodate.MustParse(t, "P1M"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	subPlan, err := pcsubscriptionservice.PlanFromPlanInput(planInp)
+	require.NoError(t, err)
+
+	t.Run("Should error if the subscription is canceled or inactive", func(t *testing.T) {
+		spec, err := subscription.NewSpecFromPlan(subPlan, subscription.CreateSubscriptionCustomerInput{
+			Name:       "test-customer",
+			CustomerId: "test-customer-id",
+			Currency:   currencyx.Code(currency.USD),
+			// active for one day
+			ActiveFrom: testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
+			ActiveTo:   lo.ToPtr(testutils.GetRFC3339Time(t, "2024-01-02T00:00:00Z")),
+		})
+		require.NoError(t, err)
+
+		// Let's check the aligned billing period after activeTo for the second phase
+		_, err = spec.GetAlignedBillingPeriodAt("default", testutils.GetRFC3339Time(t, "2024-03-02T00:00:00Z"))
+		require.Error(t, err)
+	})
+}

--- a/openmeter/subscription/testutils/feature.go
+++ b/openmeter/subscription/testutils/feature.go
@@ -13,6 +13,13 @@ var ExampleFeatureKey = "test-feature-1"
 
 var ExampleFeatureMeterSlug = "meter1"
 
+var ExampleFeature = feature.CreateFeatureInputs{
+	Name:      "Example Feature",
+	Key:       ExampleFeatureKey,
+	Namespace: ExampleNamespace,
+	MeterSlug: lo.ToPtr(ExampleFeatureMeterSlug),
+}
+
 type testFeatureConnector struct {
 	feature.FeatureConnector
 }
@@ -22,12 +29,7 @@ func NewTestFeatureConnector(conn feature.FeatureConnector) *testFeatureConnecto
 }
 
 func (c *testFeatureConnector) CreateExampleFeature(t *testing.T) feature.Feature {
-	feat, err := c.FeatureConnector.CreateFeature(context.Background(), feature.CreateFeatureInputs{
-		Name:      "Example Feature",
-		Key:       ExampleFeatureKey,
-		Namespace: ExampleNamespace,
-		MeterSlug: lo.ToPtr(ExampleFeatureMeterSlug),
-	})
+	feat, err := c.FeatureConnector.CreateFeature(context.Background(), ExampleFeature)
 	if err != nil {
 		t.Fatalf("failed to create feature: %v", err)
 	}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Trying to generate periods for future canceled phases caused an issue in subscription syncing.

<!-- Anything the reviewer should know? -->
