### PR TITLE
fix: reenable affected meter reporting

### DIFF
--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -172,6 +172,7 @@ func TestComplete(t *testing.T) {
 			DrainTimeout:            10 * time.Second,
 			NamespaceRefetchTimeout: 9 * time.Second,
 			NamespaceTopicRegexp:    "^om_test_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$",
+			MeterRefetchInterval:    15 * time.Second,
 			Dedupe: DedupeConfiguration{
 				Enabled: true,
 				DedupeDriverConfiguration: DedupeDriverRedisConfiguration{

--- a/app/config/sink.go
+++ b/app/config/sink.go
@@ -32,6 +32,9 @@ type SinkConfiguration struct {
 
 	// NamespaceTopicRegexp defines the regular expression to match/validate topic names the sink-worker needs to subscribe to.
 	NamespaceTopicRegexp string
+
+	// MeterRefetchInterval is the interval to refetch meters from the database
+	MeterRefetchInterval time.Duration
 }
 
 func (c SinkConfiguration) Validate() error {
@@ -75,6 +78,10 @@ func (c SinkConfiguration) Validate() error {
 
 	if err := c.Kafka.Validate(); err != nil {
 		errs = append(errs, errorsx.WithPrefix(err, "kafka"))
+	}
+
+	if c.MeterRefetchInterval <= 0 {
+		errs = append(errs, errors.New("MeterRefetchInterval must be greater than 0"))
 	}
 
 	return errors.Join(errs...)
@@ -154,6 +161,7 @@ func ConfigureSink(v *viper.Viper) {
 	v.SetDefault("sink.ingestNotifications.maxEventsInBatch", 500)
 	v.SetDefault("sink.namespaceRefetchTimeout", "10s")
 	v.SetDefault("sink.namespaceTopicRegexp", "^om_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$")
+	v.SetDefault("sink.meterRefetchInterval", "15s")
 
 	// TODO: remove, config moved to aggregation config
 	// Sink Storage

--- a/cmd/sink-worker/main.go
+++ b/cmd/sink-worker/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/dedupe"
 	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest/topicresolver"
+	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/sink"
 	"github.com/openmeterio/openmeter/openmeter/sink/flushhandler"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
@@ -109,6 +110,7 @@ func main() {
 		app.Tracer,
 		app.TopicResolver,
 		app.FlushHandler,
+		app.MeterService,
 	)
 	if err != nil {
 		logger.Error("failed to initialize sink worker", "error", err)
@@ -156,6 +158,7 @@ func initSink(
 	tracer trace.Tracer,
 	topicResolver *topicresolver.NamespacedTopicResolver,
 	flushHandler flushhandler.FlushEventHandler,
+	meterService meter.Service,
 ) (*sink.Sink, error) {
 	var err error
 
@@ -242,6 +245,8 @@ func initSink(
 		TopicResolver:           topicResolver,
 		NamespaceRefetchTimeout: conf.Sink.NamespaceRefetchTimeout,
 		NamespaceTopicRegexp:    conf.Sink.NamespaceTopicRegexp,
+		MeterRefetchInterval:    conf.Sink.MeterRefetchInterval,
+		MeterService:            meterService,
 	}
 
 	return sink.NewSink(sinkConfig)

--- a/cmd/sink-worker/wire.go
+++ b/cmd/sink-worker/wire.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openmeterio/openmeter/app/common"
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest/topicresolver"
+	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/sink/flushhandler"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	pkgkafka "github.com/openmeterio/openmeter/pkg/kafka"
@@ -35,6 +36,7 @@ type Application struct {
 	TopicProvisioner pkgkafka.TopicProvisioner
 	TopicResolver    *topicresolver.NamespacedTopicResolver
 	Tracer           trace.Tracer
+	MeterService     meter.Service
 }
 
 func initializeApplication(ctx context.Context, conf config.Configuration) (Application, func(), error) {
@@ -44,9 +46,11 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		metadata,
 		common.ClickHouse,
 		common.Config,
+		common.Database,
 		common.Framework,
 		common.KafkaTopic,
 		common.KafkaNamespaceResolver,
+		common.Meter,
 		common.NewDefaultTextMapPropagator,
 		common.NewFlushHandler,
 		common.NewSinkWorkerPublisher,

--- a/openmeter/meter/adapter/meter.go
+++ b/openmeter/meter/adapter/meter.go
@@ -21,8 +21,11 @@ func (a *Adapter) ListMeters(ctx context.Context, params meter.ListMetersParams)
 
 	if !params.WithoutNamespace {
 		query = query.
-			Where(meterdb.NamespaceEQ(params.Namespace)).
-			Where(meterdb.DeletedAtIsNil())
+			Where(meterdb.NamespaceEQ(params.Namespace))
+	}
+
+	if !params.IncludeDeleted {
+		query = query.Where(meterdb.DeletedAtIsNil())
 	}
 
 	if params.SlugFilter != nil {

--- a/openmeter/meter/service.go
+++ b/openmeter/meter/service.go
@@ -64,6 +64,9 @@ type ListMetersParams struct {
 	// We do this instead of letting the namespace be empty to avoid
 	// accidental listing of all meters across all namespaces.
 	WithoutNamespace bool
+
+	// IncludeDeleted is a flag to include deleted meters in the list.
+	IncludeDeleted bool
 }
 
 // Validate validates the list meters parameters.
@@ -72,10 +75,6 @@ func (p ListMetersParams) Validate() error {
 
 	if p.Namespace == "" && !p.WithoutNamespace {
 		errs = append(errs, errors.New("namespace is required"))
-	}
-
-	if err := p.Page.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("invalid pagination: %w", err))
 	}
 
 	if p.SlugFilter != nil {

--- a/openmeter/sink/flushhandler/ingestnotification/handler.go
+++ b/openmeter/sink/flushhandler/ingestnotification/handler.go
@@ -115,7 +115,7 @@ func (h *handler) OnFlushSuccess(ctx context.Context, events []sinkmodels.SinkMe
 	return finalErr
 }
 
-func (h *handler) getMeterSlugsFromMeters(meters []meter.Meter) []string {
+func (h *handler) getMeterSlugsFromMeters(meters []*meter.Meter) []string {
 	slugs := make([]string, len(meters))
 	for i, meter := range meters {
 		slugs[i] = meter.Key

--- a/openmeter/sink/meters.go
+++ b/openmeter/sink/meters.go
@@ -1,0 +1,151 @@
+package sink
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	sinkmodels "github.com/openmeterio/openmeter/openmeter/sink/models"
+)
+
+type MetersByType map[string][]*meter.Meter
+
+type NamespacedMeterCache struct {
+	mu        sync.RWMutex
+	isRunning atomic.Bool
+
+	namespaces              map[string]MetersByType
+	logger                  *slog.Logger
+	periodicRefetchInterval time.Duration
+	meterService            meter.Service
+}
+
+type NamespacedMeterCacheConfig struct {
+	PeriodicRefetchInterval time.Duration
+	Logger                  *slog.Logger
+	MeterService            meter.Service
+}
+
+func (c NamespacedMeterCacheConfig) Validate() error {
+	if c.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	if c.MeterService == nil {
+		return errors.New("meter service is required")
+	}
+
+	if c.PeriodicRefetchInterval <= 0 {
+		return errors.New("periodic refetch interval must be greater than 0")
+	}
+
+	return nil
+}
+
+func NewNamespaceStore(config NamespacedMeterCacheConfig) (*NamespacedMeterCache, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &NamespacedMeterCache{
+		namespaces:              map[string]MetersByType{},
+		meterService:            config.MeterService,
+		logger:                  config.Logger,
+		periodicRefetchInterval: config.PeriodicRefetchInterval,
+	}, nil
+}
+
+func (n *NamespacedMeterCache) Start(ctx context.Context) error {
+	if n.isRunning.Swap(true) {
+		return errors.New("namespaced meter cache is already running")
+	}
+
+	meters, err := n.fetchMeters(ctx)
+	if err != nil {
+		return err
+	}
+
+	n.updateCache(meters)
+	go n.start(ctx)
+
+	return nil
+}
+
+func (n *NamespacedMeterCache) start(ctx context.Context) {
+	lastFetch := time.Now()
+
+	periodicRefetchTicker := time.NewTicker(n.periodicRefetchInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-periodicRefetchTicker.C:
+			updatedCache, err := n.fetchMeters(ctx)
+			if err != nil {
+				n.logger.Error("failed to fetch meters", "error", err)
+				continue
+			}
+
+			n.updateCache(updatedCache)
+
+			n.logger.Info("refetched meters", "namespaces", len(n.namespaces), "age", time.Since(lastFetch).String())
+			lastFetch = time.Now()
+		}
+	}
+}
+
+func (n *NamespacedMeterCache) fetchMeters(ctx context.Context) (map[string]MetersByType, error) {
+	meters, err := n.meterService.ListMeters(ctx, meter.ListMetersParams{
+		WithoutNamespace: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	metersByType := make(map[string]MetersByType)
+	for _, meterEntity := range meters.Items {
+		if _, found := metersByType[meterEntity.Namespace]; !found {
+			metersByType[meterEntity.Namespace] = MetersByType{}
+		}
+
+		if _, found := metersByType[meterEntity.Namespace]; !found {
+			metersByType[meterEntity.Namespace] = MetersByType{}
+		}
+
+		metersByType[meterEntity.Namespace][meterEntity.EventType] = append(metersByType[meterEntity.Namespace][meterEntity.EventType], lo.ToPtr(meterEntity))
+	}
+
+	return metersByType, nil
+}
+
+func (n *NamespacedMeterCache) updateCache(meters map[string]MetersByType) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	n.namespaces = meters
+}
+
+// GetAffectedMeters gets the list of meters that are affected by an event
+func (n *NamespacedMeterCache) GetAffectedMeters(_ context.Context, m *sinkmodels.SinkMessage) ([]*meter.Meter, error) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
+	namespaceStore, ok := n.namespaces[m.Namespace]
+	if !ok || namespaceStore == nil {
+		n.logger.Warn("no namespace store found for namespace", "namespace", m.Namespace)
+		return nil, nil
+	}
+
+	// We are not interested in processing events that were dropped
+	if m.Status.DropError != nil {
+		return nil, nil
+	}
+
+	return n.namespaces[m.Namespace][m.Serialized.Type], nil
+}

--- a/openmeter/sink/models/models.go
+++ b/openmeter/sink/models/models.go
@@ -15,7 +15,7 @@ type SinkMessage struct {
 	Serialized   *serializer.CloudEventsKafkaPayload
 	Status       ProcessingStatus
 	// Meters contains the list of meters this message affects
-	Meters []meter.Meter
+	Meters []*meter.Meter
 }
 
 type ProcessingState int8


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch readds the list of meter keys to be embedded into the batch ingest events. This fixes an issue where balance worker depends on this field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable meter refresh interval (defaulting to 15 seconds) for up-to-date meter data.
  - Enabled an option to include or exclude deleted meter entries when listing meter information.
  - Added an enhanced caching mechanism for organizing meter data by namespace, improving both reliability and performance.
  - Implemented improved validation and error handling for meter configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->