### PR TITLE
feat(otel): enable parent based sampling

### DIFF
--- a/app/config/telemetry.go
+++ b/app/config/telemetry.go
@@ -127,7 +127,7 @@ func (c TraceTelemetryConfig) GetSampler() sdktrace.Sampler {
 			panic(fmt.Errorf("trace: invalid ratio: %w", err))
 		}
 
-		return sdktrace.TraceIDRatioBased(ratio)
+		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(ratio))
 	}
 }
 


### PR DESCRIPTION
## Overview

Enable `ParentBased` sampling in case the default `TraceIDRatioBased` sampling is used.

See: https://opentelemetry.io/docs/languages/go/sampling/ 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the telemetry sampling approach to incorporate broader contextual information, which can lead to more representative trace data during monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->