### PR TITLE
chore: otelsql disable unnecessary spans

### DIFF
--- a/app/common/database.go
+++ b/app/common/database.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/XSAM/otelsql"
 	"github.com/google/wire"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
@@ -72,6 +73,11 @@ func NewPostgresDriver(
 		pgdriver.WithMetricMeter(meter),
 		pgdriver.WithTracerProvider(tracerProvider),
 		pgdriver.WithMeterProvider(meterProvider),
+		pgdriver.WithSpanOptions(otelsql.SpanOptions{
+			OmitConnPrepare:      true,
+			OmitRows:             true,
+			OmitConnectorConnect: true,
+		}),
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to initialize postgres driver: %w", err)

--- a/pkg/framework/pgdriver/driver.go
+++ b/pkg/framework/pgdriver/driver.go
@@ -43,6 +43,12 @@ func WithMetricMeter(m metric.Meter) Option {
 	})
 }
 
+func WithSpanOptions(opt otelsql.SpanOptions) Option {
+	return optionFunc(func(o *options) {
+		o.otelOptions = append(o.otelOptions, otelsql.WithSpanOptions(opt))
+	})
+}
+
 type options struct {
 	connConfig  *pgxpool.Config
 	otelOptions []otelsql.Option


### PR DESCRIPTION
These are not adding anything to the observatibiliy of openmeter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced database telemetry by introducing configurable tracing options for PostgreSQL operations.
  - Now you can fine-tune how monitoring spans are handled during key database activities, improving observability in real time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->