### PR TITLE
feat: add clickhouse tracing

### DIFF
--- a/app/common/clickhouse.go
+++ b/app/common/clickhouse.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/google/wire"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/app/config"
+	"github.com/openmeterio/openmeter/pkg/framework/clickhouseotel"
 )
 
 var ClickHouse = wire.NewSet(
@@ -14,10 +16,20 @@ var ClickHouse = wire.NewSet(
 )
 
 // TODO: add closer function?
-func NewClickHouse(conf config.ClickHouseAggregationConfiguration) (clickhouse.Conn, error) {
+func NewClickHouse(conf config.ClickHouseAggregationConfiguration, tracer trace.Tracer) (clickhouse.Conn, error) {
 	conn, err := clickhouse.Open(conf.GetClientOptions())
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize clickhouse client: %w", err)
+	}
+
+	if conf.Tracing {
+		conn, err = clickhouseotel.NewClickHouseTracer(clickhouseotel.ClickHouseTracerConfig{
+			Conn:   conn,
+			Tracer: tracer,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize clickhouse tracer: %w", err)
+		}
 	}
 
 	return conn, nil

--- a/app/config/aggregation.go
+++ b/app/config/aggregation.go
@@ -60,6 +60,8 @@ type ClickHouseAggregationConfiguration struct {
 	MaxIdleConns    int
 	ConnMaxLifetime time.Duration
 	BlockBufferSize uint8
+
+	Tracing bool
 }
 
 func (c ClickHouseAggregationConfiguration) Validate() error {
@@ -127,7 +129,7 @@ func ConfigureAggregation(v *viper.Viper) {
 	v.SetDefault("aggregation.clickhouse.database", "openmeter")
 	v.SetDefault("aggregation.clickhouse.username", "default")
 	v.SetDefault("aggregation.clickhouse.password", "default")
-
+	v.SetDefault("aggregation.clickhouse.tracing", false)
 	// ClickHouse connection options
 	v.SetDefault("aggregation.clickhouse.dialTimeout", "10s")
 	v.SetDefault("aggregation.clickhouse.maxOpenConns", 5)

--- a/cmd/balance-worker/wire_gen.go
+++ b/cmd/balance-worker/wire_gen.go
@@ -136,7 +136,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	entitlementsConfiguration := conf.Entitlements
 	aggregationConfiguration := conf.Aggregation
 	clickHouseAggregationConfiguration := aggregationConfiguration.ClickHouse
-	v2, err := common.NewClickHouse(clickHouseAggregationConfiguration)
+	v2, err := common.NewClickHouse(clickHouseAggregationConfiguration, tracer)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/cmd/billing-worker/wire_gen.go
+++ b/cmd/billing-worker/wire_gen.go
@@ -162,7 +162,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	entitlementsConfiguration := conf.Entitlements
 	aggregationConfiguration := conf.Aggregation
 	clickHouseAggregationConfiguration := aggregationConfiguration.ClickHouse
-	v2, err := common.NewClickHouse(clickHouseAggregationConfiguration)
+	v2, err := common.NewClickHouse(clickHouseAggregationConfiguration, tracer)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/cmd/jobs/internal/wire_gen.go
+++ b/cmd/jobs/internal/wire_gen.go
@@ -147,7 +147,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	entitlementsConfiguration := conf.Entitlements
 	aggregationConfiguration := conf.Aggregation
 	clickHouseAggregationConfiguration := aggregationConfiguration.ClickHouse
-	v2, err := common.NewClickHouse(clickHouseAggregationConfiguration)
+	v2, err := common.NewClickHouse(clickHouseAggregationConfiguration, tracer)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/cmd/notification-service/wire_gen.go
+++ b/cmd/notification-service/wire_gen.go
@@ -147,7 +147,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	}
 	aggregationConfiguration := conf.Aggregation
 	clickHouseAggregationConfiguration := aggregationConfiguration.ClickHouse
-	v3, err := common.NewClickHouse(clickHouseAggregationConfiguration)
+	tracer := common.NewTracer(tracerProvider, commonMetadata)
+	v3, err := common.NewClickHouse(clickHouseAggregationConfiguration, tracer)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -151,7 +151,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	entitlementsConfiguration := conf.Entitlements
 	aggregationConfiguration := conf.Aggregation
 	clickHouseAggregationConfiguration := aggregationConfiguration.ClickHouse
-	v2, err := common.NewClickHouse(clickHouseAggregationConfiguration)
+	v2, err := common.NewClickHouse(clickHouseAggregationConfiguration, tracer)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/cmd/sink-worker/wire_gen.go
+++ b/cmd/sink-worker/wire_gen.go
@@ -111,7 +111,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	}
 	aggregationConfiguration := conf.Aggregation
 	clickHouseAggregationConfiguration := aggregationConfiguration.ClickHouse
-	v2, err := common.NewClickHouse(clickHouseAggregationConfiguration)
+	tracer := common.NewTracer(tracerProvider, commonMetadata)
+	v2, err := common.NewClickHouse(clickHouseAggregationConfiguration, tracer)
 	if err != nil {
 		cleanup4()
 		cleanup3()
@@ -156,7 +157,6 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	tracer := common.NewTracer(tracerProvider, commonMetadata)
 	postgresConfig := conf.Postgres
 	driver, cleanup6, err := common.NewPostgresDriver(ctx, postgresConfig, meterProvider, meter, tracerProvider, logger)
 	if err != nil {

--- a/pkg/framework/clickhouseotel/otel.go
+++ b/pkg/framework/clickhouseotel/otel.go
@@ -85,6 +85,7 @@ func (c *ClickHouseTracer) QueryRow(ctx context.Context, query string, args ...a
 	rows = c.Conn.QueryRow(ctx, query, args...)
 	if rows != nil && rows.Err() != nil {
 		span.RecordError(rows.Err())
+		span.SetStatus(codes.Error, err.Error())
 	}
 
 	return rows

--- a/pkg/framework/clickhouseotel/otel.go
+++ b/pkg/framework/clickhouseotel/otel.go
@@ -70,6 +70,7 @@ func (c *ClickHouseTracer) Query(ctx context.Context, query string, args ...any)
 
 	if rows != nil && rows.Err() != nil {
 		span.RecordError(rows.Err())
+		span.SetStatus(codes.Error, err.Error())
 	}
 
 	return rows, err

--- a/pkg/framework/clickhouseotel/otel.go
+++ b/pkg/framework/clickhouseotel/otel.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 	"github.com/samber/lo"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -86,7 +87,8 @@ func (c *ClickHouseTracer) QueryRow(ctx context.Context, query string, args ...a
 
 	rows = c.Conn.QueryRow(ctx, query, args...)
 	if rows != nil && rows.Err() != nil {
-		span.RecordError(rows.Err())
+		err := rows.Err()
+		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 	}
 

--- a/pkg/framework/clickhouseotel/otel.go
+++ b/pkg/framework/clickhouseotel/otel.go
@@ -66,6 +66,7 @@ func (c *ClickHouseTracer) Query(ctx context.Context, query string, args ...any)
 	rows, err = c.Conn.Query(ctx, query, args...)
 	if err != nil {
 		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 	}
 
 	if rows != nil && rows.Err() != nil {

--- a/pkg/framework/clickhouseotel/otel.go
+++ b/pkg/framework/clickhouseotel/otel.go
@@ -1,0 +1,124 @@
+package clickhouseotel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/samber/lo"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type ClickHouseTracer struct {
+	clickhouse.Conn
+
+	Tracer trace.Tracer
+}
+
+type ClickHouseTracerConfig struct {
+	Tracer trace.Tracer
+	Conn   clickhouse.Conn
+}
+
+func (c ClickHouseTracerConfig) Validate() error {
+	var errs []error
+
+	if c.Tracer == nil {
+		errs = append(errs, errors.New("tracer is required"))
+	}
+
+	if c.Conn == nil {
+		errs = append(errs, errors.New("conn is required"))
+	}
+
+	return errors.Join(errs...)
+}
+
+var _ clickhouse.Conn = (*ClickHouseTracer)(nil)
+
+func NewClickHouseTracer(cfg ClickHouseTracerConfig) (clickhouse.Conn, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &ClickHouseTracer{
+		Conn:   cfg.Conn,
+		Tracer: cfg.Tracer,
+	}, nil
+}
+
+func anyToStrings(args ...any) []string {
+	return lo.Map(args, func(arg any, _ int) string {
+		return fmt.Sprintf("%v", arg)
+	})
+}
+
+func (c *ClickHouseTracer) Query(ctx context.Context, query string, args ...any) (rows driver.Rows, err error) {
+	ctx, span := c.Tracer.Start(ctx, "clickhouse.Query", trace.WithAttributes(
+		attribute.String("query", query),
+		attribute.StringSlice("args", anyToStrings(args...)),
+	))
+	defer span.End()
+
+	rows, err = c.Conn.Query(ctx, query, args...)
+	if err != nil {
+		span.RecordError(err)
+	}
+
+	if rows != nil && rows.Err() != nil {
+		span.RecordError(rows.Err())
+	}
+
+	return rows, err
+}
+
+func (c *ClickHouseTracer) QueryRow(ctx context.Context, query string, args ...any) (rows driver.Row) {
+	ctx, span := c.Tracer.Start(ctx, "clickhouse.QueryRow", trace.WithAttributes(
+		attribute.String("query", query),
+		attribute.StringSlice("args", anyToStrings(args...)),
+	))
+	defer span.End()
+
+	rows = c.Conn.QueryRow(ctx, query, args...)
+	if rows != nil && rows.Err() != nil {
+		span.RecordError(rows.Err())
+	}
+
+	return rows
+}
+
+func (c *ClickHouseTracer) Exec(ctx context.Context, query string, args ...any) error {
+	ctx, span := c.Tracer.Start(ctx, "clickhouse.Exec", trace.WithAttributes(
+		attribute.String("query", query),
+		attribute.StringSlice("args", anyToStrings(args...)),
+	))
+	defer span.End()
+
+	err := c.Conn.Exec(ctx, query, args...)
+	if err != nil {
+		span.RecordError(err)
+
+		return err
+	}
+
+	return nil
+}
+
+func (c *ClickHouseTracer) AsyncInsert(ctx context.Context, query string, wait bool, args ...any) error {
+	ctx, span := c.Tracer.Start(ctx, "clickhouse.AsyncInsert", trace.WithAttributes(
+		attribute.String("query", query),
+		attribute.Bool("wait", wait),
+		attribute.StringSlice("args", anyToStrings(args...)),
+	))
+	defer span.End()
+
+	err := c.Conn.AsyncInsert(ctx, query, wait, args...)
+	if err != nil {
+		span.RecordError(err)
+	}
+
+	return err
+}

--- a/pkg/framework/clickhouseotel/otel.go
+++ b/pkg/framework/clickhouseotel/otel.go
@@ -100,6 +100,7 @@ func (c *ClickHouseTracer) Exec(ctx context.Context, query string, args ...any) 
 	err := c.Conn.Exec(ctx, query, args...)
 	if err != nil {
 		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 
 		return err
 	}

--- a/pkg/framework/clickhouseotel/otel.go
+++ b/pkg/framework/clickhouseotel/otel.go
@@ -118,6 +118,7 @@ func (c *ClickHouseTracer) AsyncInsert(ctx context.Context, query string, wait b
 	err := c.Conn.AsyncInsert(ctx, query, wait, args...)
 	if err != nil {
 		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 	}
 
 	return err


### PR DESCRIPTION
This patch adds support for tracing clickhouse calls.

The clickhouse client has tracing support, but that's limited to sending clickhouse the span data, and expect clickhouse to return the trace itself.

For our use-case it's enough to annotate the client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated enhanced tracing support for database operations, leveraging OpenTelemetry to improve monitoring and diagnostics.
  - Introduced a new configuration option that allows tracing to be enabled or disabled as needed.

These updates improve observability and reliability across services, enabling faster identification and resolution of issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->