### PR TITLE
refactor: plan status type

### DIFF
--- a/openmeter/productcatalog/plan.go
+++ b/openmeter/productcatalog/plan.go
@@ -13,21 +13,21 @@ import (
 )
 
 const (
-	DraftStatus     PlanStatus = "draft"
-	ActiveStatus    PlanStatus = "active"
-	ArchivedStatus  PlanStatus = "archived"
-	ScheduledStatus PlanStatus = "scheduled"
-	InvalidStatus   PlanStatus = "invalid"
+	PlanStatusDraft     PlanStatus = "draft"
+	PlanStatusActive    PlanStatus = "active"
+	PlanStatusArchived  PlanStatus = "archived"
+	PlanStatusScheduled PlanStatus = "scheduled"
+	PlanStatusInvalid   PlanStatus = "invalid"
 )
 
 type PlanStatus string
 
 func (s PlanStatus) Values() []string {
 	return []string{
-		string(DraftStatus),
-		string(ActiveStatus),
-		string(ArchivedStatus),
-		string(ScheduledStatus),
+		string(PlanStatusDraft),
+		string(PlanStatusActive),
+		string(PlanStatusArchived),
+		string(PlanStatusScheduled),
 	}
 }
 
@@ -231,25 +231,25 @@ func (p PlanMeta) StatusAt(t time.Time) PlanStatus {
 
 	// Plan has DraftStatus if neither the EffectiveFrom nor EffectiveTo are set
 	if from.IsZero() && to.IsZero() {
-		return DraftStatus
+		return PlanStatusDraft
 	}
 
 	// Plan has ArchivedStatus if EffectiveTo is in the past relative to time t.
 	if from.Before(t) && (to.Before(t) && from.Before(to)) {
-		return ArchivedStatus
+		return PlanStatusArchived
 	}
 
 	// Plan has ActiveStatus if EffectiveFrom is set in the past relative to time t and EffectiveTo is not set
 	// or in the future relative to time t.
 	if from.Before(t) && (to.IsZero() || to.After(t)) {
-		return ActiveStatus
+		return PlanStatusActive
 	}
 
 	// Plan is ScheduledForActiveStatus if EffectiveFrom is set in the future relative to time t and EffectiveTo is not set
 	// or in the future relative to time t.
 	if from.After(t) && (to.IsZero() || to.After(from)) {
-		return ScheduledStatus
+		return PlanStatusScheduled
 	}
 
-	return InvalidStatus
+	return PlanStatusInvalid
 }

--- a/openmeter/productcatalog/plan/adapter/adapter_test.go
+++ b/openmeter/productcatalog/plan/adapter/adapter_test.go
@@ -412,7 +412,7 @@ func testListPlanStatusFilter(ctx context.Context, t *testing.T, repo *adapter) 
 			name: "list latest active",
 			at:   testutils.GetRFC3339Time(t, "2025-03-16T00:00:00Z"),
 			filter: []productcatalog.PlanStatus{
-				productcatalog.ActiveStatus,
+				productcatalog.PlanStatusActive,
 			},
 			expectVersion: []int{2},
 		},
@@ -420,7 +420,7 @@ func testListPlanStatusFilter(ctx context.Context, t *testing.T, repo *adapter) 
 			name: "list latest draft",
 			at:   testutils.GetRFC3339Time(t, "2025-03-16T00:00:00Z"),
 			filter: []productcatalog.PlanStatus{
-				productcatalog.DraftStatus,
+				productcatalog.PlanStatusDraft,
 			},
 			expectVersion: []int{3},
 		},
@@ -428,7 +428,7 @@ func testListPlanStatusFilter(ctx context.Context, t *testing.T, repo *adapter) 
 			name: "list latest archived",
 			at:   testutils.GetRFC3339Time(t, "2025-03-16T00:00:00Z"),
 			filter: []productcatalog.PlanStatus{
-				productcatalog.ArchivedStatus,
+				productcatalog.PlanStatusArchived,
 			},
 			expectVersion: []int{1},
 		},
@@ -436,9 +436,9 @@ func testListPlanStatusFilter(ctx context.Context, t *testing.T, repo *adapter) 
 			name: "list all",
 			at:   testutils.GetRFC3339Time(t, "2025-03-16T00:00:00Z"),
 			filter: []productcatalog.PlanStatus{
-				productcatalog.ActiveStatus,
-				productcatalog.DraftStatus,
-				productcatalog.ArchivedStatus,
+				productcatalog.PlanStatusActive,
+				productcatalog.PlanStatusDraft,
+				productcatalog.PlanStatusArchived,
 			},
 			expectVersion: []int{1, 2, 3},
 		},
@@ -446,7 +446,7 @@ func testListPlanStatusFilter(ctx context.Context, t *testing.T, repo *adapter) 
 			name: "plan schedule to be actived in the future - active filter",
 			at:   testutils.GetRFC3339Time(t, "2025-03-15T01:00:00Z"),
 			filter: []productcatalog.PlanStatus{
-				productcatalog.ActiveStatus,
+				productcatalog.PlanStatusActive,
 			},
 			expectVersion: []int{1}, // 2 is not yet active
 		},
@@ -454,7 +454,7 @@ func testListPlanStatusFilter(ctx context.Context, t *testing.T, repo *adapter) 
 			name: "plan schedule to be actived in the future - draft filter",
 			at:   testutils.GetRFC3339Time(t, "2025-03-15T01:00:00Z"),
 			filter: []productcatalog.PlanStatus{
-				productcatalog.DraftStatus,
+				productcatalog.PlanStatusDraft,
 			},
 			expectVersion: []int{3},
 		},
@@ -462,7 +462,7 @@ func testListPlanStatusFilter(ctx context.Context, t *testing.T, repo *adapter) 
 			name: "plan schedule to be actived in the future - scheduled filter",
 			at:   testutils.GetRFC3339Time(t, "2025-03-15T01:00:00Z"),
 			filter: []productcatalog.PlanStatus{
-				productcatalog.ScheduledStatus,
+				productcatalog.PlanStatusScheduled,
 			},
 			expectVersion: []int{2},
 		},

--- a/openmeter/productcatalog/plan/adapter/plan.go
+++ b/openmeter/productcatalog/plan/adapter/plan.go
@@ -60,11 +60,11 @@ func (a *adapter) ListPlans(ctx context.Context, params plan.ListPlansInput) (pa
 		}
 
 		if len(params.Status) > 0 {
-			predicates := []predicate.Plan{}
+			var predicates []predicate.Plan
 
 			now := clock.Now().UTC()
 
-			if slices.Contains(params.Status, productcatalog.ActiveStatus) {
+			if slices.Contains(params.Status, productcatalog.PlanStatusActive) {
 				predicates = append(predicates, plandb.And(
 					plandb.EffectiveFromLTE(now),
 					plandb.Or(
@@ -74,14 +74,14 @@ func (a *adapter) ListPlans(ctx context.Context, params plan.ListPlansInput) (pa
 				))
 			}
 
-			if slices.Contains(params.Status, productcatalog.DraftStatus) {
+			if slices.Contains(params.Status, productcatalog.PlanStatusDraft) {
 				predicates = append(predicates, plandb.And(
 					plandb.EffectiveFromIsNil(),
 					plandb.EffectiveToIsNil(),
 				))
 			}
 
-			if slices.Contains(params.Status, productcatalog.ScheduledStatus) {
+			if slices.Contains(params.Status, productcatalog.PlanStatusScheduled) {
 				predicates = append(predicates, plandb.And(
 					plandb.Or(
 						plandb.EffectiveFromGT(now),
@@ -89,15 +89,11 @@ func (a *adapter) ListPlans(ctx context.Context, params plan.ListPlansInput) (pa
 				))
 			}
 
-			if slices.Contains(params.Status, productcatalog.ArchivedStatus) {
+			if slices.Contains(params.Status, productcatalog.PlanStatusArchived) {
 				predicates = append(predicates, plandb.EffectiveToLT(now))
 			}
 
-			if slices.Contains(params.Status, productcatalog.ScheduledStatus) {
-				predicates = append(predicates, plandb.EffectiveFromGT(now))
-			}
-
-			if slices.Contains(params.Status, productcatalog.InvalidStatus) {
+			if slices.Contains(params.Status, productcatalog.PlanStatusInvalid) {
 				predicates = append(predicates, func(s *sql.Selector) {
 					s.Where(sql.ColumnsLT(plandb.FieldEffectiveTo, plandb.FieldEffectiveFrom))
 				})

--- a/openmeter/productcatalog/plan/httpdriver/mapping.go
+++ b/openmeter/productcatalog/plan/httpdriver/mapping.go
@@ -45,13 +45,13 @@ func FromPlan(p plan.Plan) (api.Plan, error) {
 
 	var status api.PlanStatus
 	switch p.Status() {
-	case productcatalog.DraftStatus:
+	case productcatalog.PlanStatusDraft:
 		status = api.PlanStatusDraft
-	case productcatalog.ActiveStatus:
+	case productcatalog.PlanStatusActive:
 		status = api.PlanStatusActive
-	case productcatalog.ArchivedStatus:
+	case productcatalog.PlanStatusArchived:
 		status = api.PlanStatusArchived
-	case productcatalog.ScheduledStatus:
+	case productcatalog.PlanStatusScheduled:
 		status = api.PlanStatusScheduled
 	default:
 		return resp, fmt.Errorf("invalid PlanStatus: %s", p.Status())

--- a/openmeter/productcatalog/plan/service/plan.go
+++ b/openmeter/productcatalog/plan/service/plan.go
@@ -111,7 +111,7 @@ func (s service) CreatePlan(ctx context.Context, params plan.CreatePlanInput) (*
 		// * calculate the version number for the new Plan based by incrementing the last version
 		if len(allVersions.Items) >= 0 {
 			for _, p := range allVersions.Items {
-				if p.DeletedAt == nil && p.Status() == productcatalog.DraftStatus {
+				if p.DeletedAt == nil && p.Status() == productcatalog.PlanStatusDraft {
 					return nil, models.NewGenericValidationError(
 						fmt.Errorf("only a single draft version is allowed for Plan"),
 					)
@@ -178,9 +178,9 @@ func (s service) DeletePlan(ctx context.Context, params plan.DeletePlanInput) er
 		}
 
 		allowedPlanStatuses := []productcatalog.PlanStatus{
-			productcatalog.ArchivedStatus,
-			productcatalog.ScheduledStatus,
-			productcatalog.DraftStatus,
+			productcatalog.PlanStatusArchived,
+			productcatalog.PlanStatusScheduled,
+			productcatalog.PlanStatusDraft,
 		}
 		planStatus := p.Status()
 		if !lo.Contains(allowedPlanStatuses, p.Status()) {
@@ -283,8 +283,8 @@ func (s service) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (*
 		}
 
 		allowedPlanStatuses := []productcatalog.PlanStatus{
-			productcatalog.DraftStatus,
-			productcatalog.ScheduledStatus,
+			productcatalog.PlanStatusDraft,
+			productcatalog.PlanStatusScheduled,
 		}
 		planStatus := p.Status()
 		if !lo.Contains(allowedPlanStatuses, p.Status()) {
@@ -364,8 +364,8 @@ func (s service) PublishPlan(ctx context.Context, params plan.PublishPlanInput) 
 
 		// Second, let's validate that the plan status and the version history is correct
 		allowedPlanStatuses := []productcatalog.PlanStatus{
-			productcatalog.DraftStatus,
-			productcatalog.ScheduledStatus,
+			productcatalog.PlanStatusDraft,
+			productcatalog.PlanStatusScheduled,
 		}
 		planStatus := pp.Status()
 		if !lo.Contains(allowedPlanStatuses, pp.Status()) {
@@ -461,7 +461,7 @@ func (s service) ArchivePlan(ctx context.Context, params plan.ArchivePlanInput) 
 			return nil, fmt.Errorf("failed to get Plan: %w", err)
 		}
 
-		activeStatuses := []productcatalog.PlanStatus{productcatalog.ActiveStatus}
+		activeStatuses := []productcatalog.PlanStatus{productcatalog.PlanStatusActive}
 		status := p.Status()
 		if !lo.Contains(activeStatuses, status) {
 			return nil, models.NewGenericValidationError(
@@ -576,7 +576,7 @@ func (s service) NextPlan(ctx context.Context, params plan.NextPlanInput) (*plan
 		nextVersion := 1
 		var match, stop bool
 		for _, p := range allVersions.Items {
-			if p.DeletedAt == nil && p.Status() == productcatalog.DraftStatus {
+			if p.DeletedAt == nil && p.Status() == productcatalog.PlanStatusDraft {
 				return nil, models.NewGenericValidationError(
 					fmt.Errorf("only a single draft version is allowed for Plan"),
 				)

--- a/openmeter/productcatalog/plan/service/service_test.go
+++ b/openmeter/productcatalog/plan/service/service_test.go
@@ -84,8 +84,8 @@ func TestPlanService(t *testing.T) {
 			require.NotNil(t, draftPlan, "Plan must not be empty")
 
 			plan.AssertPlanCreateInputEqual(t, planInput, *draftPlan)
-			assert.Equalf(t, productcatalog.DraftStatus, draftPlan.Status(),
-				"Plan Status mismatch: expected=%s, actual=%s", productcatalog.DraftStatus, draftPlan.Status())
+			assert.Equalf(t, productcatalog.PlanStatusDraft, draftPlan.Status(),
+				"Plan Status mismatch: expected=%s, actual=%s", productcatalog.PlanStatusDraft, draftPlan.Status())
 
 			t.Run("Get", func(t *testing.T) {
 				getPlan, err := env.Plan.GetPlan(ctx, plan.GetPlanInput{
@@ -104,8 +104,8 @@ func TestPlanService(t *testing.T) {
 					"Plan Key mismatch: %s = %s", draftPlan.Key, getPlan.Key)
 				assert.Equalf(t, draftPlan.Version, getPlan.Version,
 					"Plan Version mismatch: %d = %d", draftPlan.Version, getPlan.Version)
-				assert.Equalf(t, productcatalog.DraftStatus, getPlan.Status(),
-					"Plan Status mismatch: expected=%s, actual=%s", productcatalog.DraftStatus, getPlan.Status())
+				assert.Equalf(t, productcatalog.PlanStatusDraft, getPlan.Status(),
+					"Plan Status mismatch: expected=%s, actual=%s", productcatalog.PlanStatusDraft, getPlan.Status())
 			})
 
 			t.Run("NewPhase", func(t *testing.T) {
@@ -218,8 +218,8 @@ func TestPlanService(t *testing.T) {
 				require.NotNil(t, updatedPlan, "updated draft Plan must not be empty")
 				require.NotNil(t, updatedPlan, "updated draft Plan must not be empty")
 
-				assert.Equalf(t, productcatalog.DraftStatus, updatedPlan.Status(),
-					"Plan Status mismatch: expected=%s, actual=%s", productcatalog.DraftStatus, updatedPlan.Status())
+				assert.Equalf(t, productcatalog.PlanStatusDraft, updatedPlan.Status(),
+					"Plan Status mismatch: expected=%s, actual=%s", productcatalog.PlanStatusDraft, updatedPlan.Status())
 
 				plan.AssertPlanPhasesEqual(t, updatedPhases, updatedPlan.Phases)
 
@@ -423,8 +423,8 @@ func TestPlanService(t *testing.T) {
 
 				assert.Equalf(t, publishAt, *publishedPlan.EffectiveFrom,
 					"EffectiveFrom for published Plan mismatch: expected=%s, actual=%s", publishAt, *publishedPlan.EffectiveFrom)
-				assert.Equalf(t, productcatalog.ActiveStatus, publishedPlan.Status(),
-					"Plan Status mismatch: expected=%s, actual=%s", productcatalog.ActiveStatus, publishedPlan.Status())
+				assert.Equalf(t, productcatalog.PlanStatusActive, publishedPlan.Status(),
+					"Plan Status mismatch: expected=%s, actual=%s", productcatalog.PlanStatusActive, publishedPlan.Status())
 
 				t.Run("Update", func(t *testing.T) {
 					updateInput := plan.UpdatePlanInput{
@@ -448,8 +448,8 @@ func TestPlanService(t *testing.T) {
 
 				assert.Equalf(t, publishedPlan.Version+1, nextPlan.Version,
 					"new draft Plan must have higher version number")
-				assert.Equalf(t, productcatalog.DraftStatus, nextPlan.Status(),
-					"Plan Status mismatch: expected=%s, actual=%s", productcatalog.DraftStatus, nextPlan.Status())
+				assert.Equalf(t, productcatalog.PlanStatusDraft, nextPlan.Status(),
+					"Plan Status mismatch: expected=%s, actual=%s", productcatalog.PlanStatusDraft, nextPlan.Status())
 
 				// Let's update the plan to enforce alignment
 				t.Run("Update to enforce alignment", func(t *testing.T) {
@@ -568,8 +568,8 @@ func TestPlanService(t *testing.T) {
 
 					assert.Equalf(t, publishAt, *publishedNextPlan.EffectiveFrom,
 						"EffectiveFrom for published Plan mismatch: expected=%s, actual=%s", publishAt, *publishedPlan.EffectiveFrom)
-					assert.Equalf(t, productcatalog.ActiveStatus, publishedNextPlan.Status(),
-						"Plan Status mismatch: expected=%s, actual=%s", productcatalog.ActiveStatus, publishedNextPlan.Status())
+					assert.Equalf(t, productcatalog.PlanStatusActive, publishedNextPlan.Status(),
+						"Plan Status mismatch: expected=%s, actual=%s", productcatalog.PlanStatusActive, publishedNextPlan.Status())
 
 					prevPlan, err := env.Plan.GetPlan(ctx, plan.GetPlanInput{
 						NamespacedID: models.NamespacedID{
@@ -580,8 +580,8 @@ func TestPlanService(t *testing.T) {
 					require.NoErrorf(t, err, "getting previous Plan version must not fail")
 					require.NotNil(t, prevPlan, "previous Plan version must not be empty")
 
-					assert.Equalf(t, productcatalog.ArchivedStatus, prevPlan.Status(),
-						"Plan Status mismatch: expected=%s, actual=%s", productcatalog.ArchivedStatus, prevPlan.Status())
+					assert.Equalf(t, productcatalog.PlanStatusArchived, prevPlan.Status(),
+						"Plan Status mismatch: expected=%s, actual=%s", productcatalog.PlanStatusArchived, prevPlan.Status())
 
 					t.Run("Archive", func(t *testing.T) {
 						archiveAt := time.Now().Truncate(time.Microsecond)
@@ -601,8 +601,8 @@ func TestPlanService(t *testing.T) {
 
 						assert.Equalf(t, archiveAt, *archivedPlan.EffectiveTo,
 							"EffectiveTo for published Plan mismatch: expected=%s, actual=%s", archiveAt, *archivedPlan.EffectiveTo)
-						assert.Equalf(t, productcatalog.ArchivedStatus, archivedPlan.Status(),
-							"Status mismatch for archived Plan: expected=%s, actual=%s", productcatalog.ArchivedStatus, archivedPlan.Status())
+						assert.Equalf(t, productcatalog.PlanStatusArchived, archivedPlan.Status(),
+							"Status mismatch for archived Plan: expected=%s, actual=%s", productcatalog.PlanStatusArchived, archivedPlan.Status())
 					})
 				})
 

--- a/openmeter/productcatalog/plan_test.go
+++ b/openmeter/productcatalog/plan_test.go
@@ -31,7 +31,7 @@ func TestPlanStatus(t *testing.T) {
 					},
 				},
 			},
-			Expected: productcatalog.DraftStatus,
+			Expected: productcatalog.PlanStatusDraft,
 		},
 		{
 			Name: "Archived",
@@ -43,7 +43,7 @@ func TestPlanStatus(t *testing.T) {
 					},
 				},
 			},
-			Expected: productcatalog.ArchivedStatus,
+			Expected: productcatalog.PlanStatusArchived,
 		},
 		{
 			Name: "Active with open end",
@@ -55,7 +55,7 @@ func TestPlanStatus(t *testing.T) {
 					},
 				},
 			},
-			Expected: productcatalog.ActiveStatus,
+			Expected: productcatalog.PlanStatusActive,
 		},
 		{
 			Name: "Active with fixed end",
@@ -67,7 +67,7 @@ func TestPlanStatus(t *testing.T) {
 					},
 				},
 			},
-			Expected: productcatalog.ActiveStatus,
+			Expected: productcatalog.PlanStatusActive,
 		},
 		{
 			Name: "Scheduled with open end",
@@ -79,7 +79,7 @@ func TestPlanStatus(t *testing.T) {
 					},
 				},
 			},
-			Expected: productcatalog.ScheduledStatus,
+			Expected: productcatalog.PlanStatusScheduled,
 		},
 		{
 			Name: "Scheduled with fixed period",
@@ -91,7 +91,7 @@ func TestPlanStatus(t *testing.T) {
 					},
 				},
 			},
-			Expected: productcatalog.ScheduledStatus,
+			Expected: productcatalog.PlanStatusScheduled,
 		},
 		{
 			Name: "Invalid with inverse period",
@@ -103,7 +103,7 @@ func TestPlanStatus(t *testing.T) {
 					},
 				},
 			},
-			Expected: productcatalog.InvalidStatus,
+			Expected: productcatalog.PlanStatusInvalid,
 		},
 		{
 			Name: "Invalid with no start with end in the past",
@@ -115,7 +115,7 @@ func TestPlanStatus(t *testing.T) {
 					},
 				},
 			},
-			Expected: productcatalog.ArchivedStatus,
+			Expected: productcatalog.PlanStatusArchived,
 		},
 		{
 			Name: "Invalid with no start with end in the future",
@@ -127,7 +127,7 @@ func TestPlanStatus(t *testing.T) {
 					},
 				},
 			},
-			Expected: productcatalog.ActiveStatus,
+			Expected: productcatalog.PlanStatusActive,
 		},
 	}
 

--- a/openmeter/productcatalog/subscription/service/change.go
+++ b/openmeter/productcatalog/subscription/service/change.go
@@ -31,7 +31,7 @@ func (s *service) Change(ctx context.Context, request plansubscription.ChangeSub
 			return def, err
 		}
 
-		if p.Status() != productcatalog.ActiveStatus {
+		if p.Status() != productcatalog.PlanStatusActive {
 			return def, models.NewGenericValidationError(fmt.Errorf("plan is not active"))
 		}
 


### PR DESCRIPTION
## Overview

Refactor Plan status type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Standardized the naming for plan statuses (e.g., PlanStatusDraft, PlanStatusActive, PlanStatusArchived, PlanStatusScheduled, and PlanStatusInvalid) to improve clarity and consistency. These changes do not alter any functionality, ensuring a seamless and familiar experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->