### PR TITLE
feat: add amount discount support

### DIFF
--- a/openmeter/billing/invoicelinediscount.go
+++ b/openmeter/billing/invoicelinediscount.go
@@ -1,0 +1,772 @@
+package billing
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/equal"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/slicesx"
+)
+
+const (
+	// LineMaximumSpendReferenceID is a discount applied due to maximum spend.
+	LineMaximumSpendReferenceID = "line_maximum_spend"
+)
+
+type LineDiscountReason string
+
+const (
+	LineDiscountReasonMaximumSpend     LineDiscountReason = "maximum_spend"
+	LineDiscountReasonRatecardDiscount LineDiscountReason = "ratecard_discount"
+)
+
+func (LineDiscountReason) Values() []string {
+	return []string{
+		string(LineDiscountReasonMaximumSpend),
+		string(LineDiscountReasonRatecardDiscount),
+	}
+}
+
+type LineSetDiscountMangedFields struct {
+	ID                  string `json:"id"`
+	models.ManagedModel `json:",inline"`
+}
+
+func (i LineSetDiscountMangedFields) Validate() error {
+	// We are ignoring the managed model validation as quite often we are relying on
+	// idempotent calculations instead.
+	return nil
+}
+
+func (i LineSetDiscountMangedFields) Equal(other LineSetDiscountMangedFields) bool {
+	if i.ID != other.ID {
+		return false
+	}
+
+	return i.ManagedModel.Equal(other.ManagedModel)
+}
+
+func (i LineSetDiscountMangedFields) SetDeletedAt(deletedAt time.Time) LineSetDiscountMangedFields {
+	i.DeletedAt = &deletedAt
+	return i
+}
+
+type LineDiscountBase struct {
+	Description            *string            `json:"description,omitempty"`
+	ChildUniqueReferenceID *string            `json:"childUniqueReferenceId,omitempty"`
+	ExternalIDs            LineExternalIDs    `json:"externalIDs,omitempty"`
+	Reason                 LineDiscountReason `json:"reason"`
+
+	SourceDiscount *productcatalog.Discount `json:"rateCardDiscount,omitempty"`
+}
+
+func (i LineDiscountBase) Validate() error {
+	var errs []error
+
+	if i.Reason == "" {
+		errs = append(errs, errors.New("reason is required"))
+	}
+
+	if i.SourceDiscount != nil {
+		if err := i.SourceDiscount.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("sourceDiscount: %w", err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (i LineDiscountBase) Equal(other LineDiscountBase) bool {
+	return reflect.DeepEqual(i, other)
+}
+
+func (i LineDiscountBase) Clone() LineDiscountBase {
+	return i
+}
+
+type LineDiscountBaseManaged struct {
+	LineSetDiscountMangedFields `json:",inline"`
+	LineDiscountBase            `json:",inline"`
+}
+
+type AmountLineDiscount struct {
+	LineDiscountBase `json:",inline"`
+
+	Amount alpacadecimal.Decimal `json:"amount"`
+
+	// RoundingAmount is a correction value, to ensure that if multiple discounts are applied,
+	// then sum of discount amounts equals the total * sum(discount percentages).
+	RoundingAmount alpacadecimal.Decimal `json:"rounding"`
+}
+
+func (i AmountLineDiscount) Validate() error {
+	var errs []error
+
+	if err := i.LineDiscountBase.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if i.Amount.IsNegative() {
+		errs = append(errs, errors.New("amount should be positive or zero"))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (i AmountLineDiscount) Equal(other AmountLineDiscount) bool {
+	if !i.LineDiscountBase.Equal(other.LineDiscountBase) {
+		return false
+	}
+
+	if !i.Amount.Equal(other.Amount) {
+		return false
+	}
+
+	if !i.RoundingAmount.Equal(other.RoundingAmount) {
+		return false
+	}
+
+	return true
+}
+
+func (i AmountLineDiscount) Clone() AmountLineDiscount {
+	return AmountLineDiscount{
+		LineDiscountBase: i.LineDiscountBase.Clone(),
+		Amount:           i.Amount,
+		RoundingAmount:   i.RoundingAmount,
+	}
+}
+
+type AmountLineDiscountManaged struct {
+	LineSetDiscountMangedFields `json:",inline"`
+	AmountLineDiscount          `json:",inline"`
+}
+
+func (i AmountLineDiscountManaged) Validate() error {
+	var errs []error
+
+	if err := i.LineSetDiscountMangedFields.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := i.AmountLineDiscount.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
+}
+
+func (i AmountLineDiscountManaged) Equal(other AmountLineDiscountManaged) bool {
+	if !i.LineSetDiscountMangedFields.Equal(other.LineSetDiscountMangedFields) {
+		return false
+	}
+
+	if !i.AmountLineDiscount.Equal(other.AmountLineDiscount) {
+		return false
+	}
+
+	return true
+}
+
+func (i AmountLineDiscountManaged) Clone() AmountLineDiscountManaged {
+	return AmountLineDiscountManaged{
+		LineSetDiscountMangedFields: i.LineSetDiscountMangedFields,
+		AmountLineDiscount:          i.AmountLineDiscount.Clone(),
+	}
+}
+
+type UsageLineDiscount struct {
+	LineDiscountBase `json:",inline"`
+
+	Quantity              alpacadecimal.Decimal  `json:"quantity"`
+	PreLinePeriodQuantity *alpacadecimal.Decimal `json:"preLinePeriodQuantity"`
+}
+
+func (i UsageLineDiscount) Validate() error {
+	var errs []error
+
+	if err := i.LineDiscountBase.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if i.Quantity.IsNegative() {
+		errs = append(errs, errors.New("quantity should be positive or zero"))
+	}
+
+	if i.PreLinePeriodQuantity != nil && i.PreLinePeriodQuantity.IsNegative() {
+		errs = append(errs, errors.New("preLinePeriodQuantity should be positive or zero"))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (i UsageLineDiscount) Equal(other UsageLineDiscount) bool {
+	if !i.LineDiscountBase.Equal(other.LineDiscountBase) {
+		return false
+	}
+
+	if !i.Quantity.Equal(other.Quantity) {
+		return false
+	}
+
+	if !equal.PtrEqual(i.PreLinePeriodQuantity, other.PreLinePeriodQuantity) {
+		return false
+	}
+
+	return true
+}
+
+func (i UsageLineDiscount) Clone() UsageLineDiscount {
+	return UsageLineDiscount{
+		LineDiscountBase:      i.LineDiscountBase.Clone(),
+		Quantity:              i.Quantity,
+		PreLinePeriodQuantity: i.PreLinePeriodQuantity,
+	}
+}
+
+type UsageLineDiscountManaged struct {
+	LineSetDiscountMangedFields `json:",inline"`
+	UsageLineDiscount           `json:",inline"`
+}
+
+func (i UsageLineDiscountManaged) Validate() error {
+	var errs []error
+
+	if err := i.LineSetDiscountMangedFields.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := i.UsageLineDiscount.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
+}
+
+func (i UsageLineDiscountManaged) Equal(other UsageLineDiscountManaged) bool {
+	if !i.LineSetDiscountMangedFields.Equal(other.LineSetDiscountMangedFields) {
+		return false
+	}
+
+	if !i.UsageLineDiscount.Equal(other.UsageLineDiscount) {
+		return false
+	}
+
+	return true
+}
+
+func (i UsageLineDiscountManaged) Clone() UsageLineDiscountManaged {
+	return UsageLineDiscountManaged{
+		LineSetDiscountMangedFields: i.LineSetDiscountMangedFields,
+		UsageLineDiscount:           i.UsageLineDiscount.Clone(),
+	}
+}
+
+type LineDiscountType string
+
+const (
+	LineDiscountTypeAmount LineDiscountType = "amount"
+	LineDiscountTypeUsage  LineDiscountType = "usage"
+)
+
+func (LineDiscountType) Values() []string {
+	return []string{
+		string(LineDiscountTypeAmount),
+		string(LineDiscountTypeUsage),
+	}
+}
+
+type LineDiscountMutator func(discount LineDiscount) (LineDiscount, error)
+
+type LineDiscount interface {
+	models.Equaler[LineDiscount]
+	models.Validator
+	models.Clonable[LineDiscount]
+
+	Type() LineDiscountType
+
+	// ContentEqual checks if the discount has the same contents as the other discount, ignoring managed fields.
+	ContentsEqual(other LineDiscount) bool
+
+	// AsAmount returns the amount discount if the discount is an amount discount, if no error is returned
+	// the pointer is guaranteed to be non-nil. A pointer is used as invocing relies on in-place manipulation
+	// of the invoice.
+	AsAmount() (AmountLineDiscountManaged, error)
+
+	// AsUsage returns the usage discount if the discount is a usage discount, if no error is returned
+	// the pointer is guaranteed to be non-nil. A pointer is used as invocing relies on in-place manipulation
+	// of the invoice.
+	AsUsage() (UsageLineDiscountManaged, error)
+
+	// AsDiscountBase returns the discount base if the discount is a discount base, if no error is returned
+	// the pointer is guaranteed to be non-nil. A pointer is used as invocing relies on in-place manipulation
+	// of the invoice.
+	AsDiscountBase() (LineDiscountBaseManaged, error)
+
+	// Mutate mutates the discount and returns the modified discount.
+	Mutate(...LineDiscountMutator) (LineDiscount, error)
+
+	// Common field accessors
+	GetID() string
+	GetChildUniqueReferenceID() *string
+	GetManagedFields() LineSetDiscountMangedFields
+
+	// Internal field accessors (they don't have nil or type checks)
+	amountManaged() *AmountLineDiscountManaged
+	usageManaged() *UsageLineDiscountManaged
+}
+
+type lineDiscount struct {
+	t LineDiscountType
+
+	amount *AmountLineDiscountManaged
+	usage  *UsageLineDiscountManaged
+}
+
+func NewLineDiscountFrom[T AmountLineDiscountManaged | AmountLineDiscount | UsageLineDiscountManaged | UsageLineDiscount](discount T) LineDiscount {
+	switch any(discount).(type) {
+	// Allow provisioning an AmountLineDiscountManaged without the managed fields: given we are calculating the expected state then merge
+	// with the DB state, this is the most common case.
+	case AmountLineDiscount:
+		amount := any(discount).(AmountLineDiscount)
+
+		return lineDiscount{t: LineDiscountTypeAmount, amount: &AmountLineDiscountManaged{
+			AmountLineDiscount: amount,
+		}}
+	case AmountLineDiscountManaged:
+		amount := any(discount).(AmountLineDiscountManaged)
+
+		return lineDiscount{t: LineDiscountTypeAmount, amount: &amount}
+	case UsageLineDiscountManaged:
+		usage := any(discount).(UsageLineDiscountManaged)
+
+		return lineDiscount{t: LineDiscountTypeUsage, usage: &usage}
+	case UsageLineDiscount:
+		usage := any(discount).(UsageLineDiscount)
+
+		return lineDiscount{t: LineDiscountTypeUsage, usage: &UsageLineDiscountManaged{
+			UsageLineDiscount: usage,
+		}}
+	}
+
+	return lineDiscount{}
+}
+
+func (i lineDiscount) Type() LineDiscountType {
+	return i.t
+}
+
+func (i lineDiscount) AsAmount() (AmountLineDiscountManaged, error) {
+	empty := AmountLineDiscountManaged{}
+
+	if i.t != LineDiscountTypeAmount {
+		return empty, errors.New("not an amount discount")
+	}
+
+	if i.amount == nil {
+		return empty, errors.New("amount discount is nil")
+	}
+
+	return *i.amount, nil
+}
+
+func (i lineDiscount) AsUsage() (UsageLineDiscountManaged, error) {
+	empty := UsageLineDiscountManaged{}
+
+	if i.t != LineDiscountTypeUsage {
+		return empty, errors.New("not a usage discount")
+	}
+
+	if i.usage == nil {
+		return empty, errors.New("usage discount is nil")
+	}
+
+	return *i.usage, nil
+}
+
+func (i lineDiscount) amountManaged() *AmountLineDiscountManaged {
+	return i.amount
+}
+
+func (i lineDiscount) usageManaged() *UsageLineDiscountManaged {
+	return i.usage
+}
+
+func (i lineDiscount) AsDiscountBase() (LineDiscountBaseManaged, error) {
+	empty := LineDiscountBaseManaged{}
+
+	switch i.t {
+	case LineDiscountTypeAmount:
+		if i.amount == nil {
+			return empty, errors.New("amount discount is nil")
+		}
+
+		return LineDiscountBaseManaged{
+			LineSetDiscountMangedFields: i.amount.LineSetDiscountMangedFields,
+			LineDiscountBase:            i.amount.LineDiscountBase,
+		}, nil
+	case LineDiscountTypeUsage:
+		if i.usage == nil {
+			return empty, errors.New("usage discount is nil")
+		}
+
+		return LineDiscountBaseManaged{
+			LineSetDiscountMangedFields: i.usage.LineSetDiscountMangedFields,
+			LineDiscountBase:            i.usage.LineDiscountBase,
+		}, nil
+	default:
+		return empty, errors.New("unknown discount type")
+	}
+}
+
+func (i lineDiscount) Equal(other LineDiscount) bool {
+	if i.t != other.Type() {
+		return false
+	}
+
+	switch i.t {
+	case LineDiscountTypeAmount:
+		return equal.PtrEqual(i.amount, other.amountManaged())
+	case LineDiscountTypeUsage:
+		return equal.PtrEqual(i.usage, other.usageManaged())
+	default:
+		return false
+	}
+}
+
+func (i lineDiscount) ContentsEqual(other LineDiscount) bool {
+	if i.t != other.Type() {
+		return false
+	}
+
+	switch i.t {
+	case LineDiscountTypeAmount:
+		// Invalid state, should never happen
+		if i.amount == nil || other.amountManaged() == nil {
+			return false
+		}
+
+		return i.amount.AmountLineDiscount.Equal(other.amountManaged().AmountLineDiscount)
+	case LineDiscountTypeUsage:
+		// Invalid state, should never happen
+		if i.usage == nil || other.usageManaged() == nil {
+			return false
+		}
+
+		return i.usage.UsageLineDiscount.Equal(other.usageManaged().UsageLineDiscount)
+	default:
+		return false
+	}
+}
+
+func (i lineDiscount) Mutate(mutators ...LineDiscountMutator) (LineDiscount, error) {
+	out := LineDiscount(i)
+	for _, mutator := range mutators {
+		newValue, err := mutator(out)
+		if err != nil {
+			return out, err
+		}
+
+		out = newValue
+	}
+
+	return out, nil
+}
+
+func (i lineDiscount) GetID() string {
+	return i.GetManagedFields().ID
+}
+
+func (i lineDiscount) GetManagedFields() LineSetDiscountMangedFields {
+	switch i.t {
+	case LineDiscountTypeAmount:
+		return i.amount.LineSetDiscountMangedFields
+	case LineDiscountTypeUsage:
+		return i.usage.LineSetDiscountMangedFields
+	default:
+		return LineSetDiscountMangedFields{}
+	}
+}
+
+func (i lineDiscount) GetChildUniqueReferenceID() *string {
+	switch i.t {
+	case LineDiscountTypeAmount:
+		return i.amount.LineDiscountBase.ChildUniqueReferenceID
+	case LineDiscountTypeUsage:
+		return i.usage.LineDiscountBase.ChildUniqueReferenceID
+	default:
+		return nil
+	}
+}
+
+func (i lineDiscount) Validate() error {
+	switch i.t {
+	case LineDiscountTypeAmount:
+		return i.amount.Validate()
+	case LineDiscountTypeUsage:
+		return i.usage.Validate()
+	default:
+		return errors.New("unknown discount type")
+	}
+}
+
+func (i lineDiscount) Clone() LineDiscount {
+	switch i.t {
+	case LineDiscountTypeAmount:
+		return &lineDiscount{
+			t:      i.t,
+			amount: lo.ToPtr(i.amount.Clone()),
+		}
+	case LineDiscountTypeUsage:
+		return &lineDiscount{t: i.t, usage: lo.ToPtr(i.usage.Clone())}
+	default:
+		return &lineDiscount{}
+	}
+}
+
+// LineDiscount mutators
+
+func SetDiscountInvoicingExternalID(externalID string) LineDiscountMutator {
+	return func(discount LineDiscount) (LineDiscount, error) {
+		var out LineDiscount
+		switch discount.Type() {
+		case LineDiscountTypeAmount:
+			amount, err := discount.AsAmount()
+			if err != nil {
+				return discount, err
+			}
+
+			amount.ExternalIDs.Invoicing = externalID
+			out = NewLineDiscountFrom(amount)
+		case LineDiscountTypeUsage:
+			usage, err := discount.AsUsage()
+			if err != nil {
+				return discount, err
+			}
+
+			usage.ExternalIDs.Invoicing = externalID
+			out = NewLineDiscountFrom(usage)
+		default:
+			return discount, fmt.Errorf("unknown discount type: %s", discount.Type())
+		}
+
+		return out, nil
+	}
+}
+
+func SetDiscountMangedFields(managedFields LineSetDiscountMangedFields) LineDiscountMutator {
+	return func(discount LineDiscount) (LineDiscount, error) {
+		var out LineDiscount
+		switch discount.Type() {
+		case LineDiscountTypeAmount:
+			amount, err := discount.AsAmount()
+			if err != nil {
+				return discount, err
+			}
+
+			amount.LineSetDiscountMangedFields = managedFields
+			out = NewLineDiscountFrom(amount)
+		case LineDiscountTypeUsage:
+			usage, err := discount.AsUsage()
+			if err != nil {
+				return discount, err
+			}
+
+			usage.LineSetDiscountMangedFields = managedFields
+			out = NewLineDiscountFrom(usage)
+		default:
+			return discount, fmt.Errorf("unknown discount type: %s", discount.Type())
+		}
+
+		return out, nil
+	}
+}
+
+func EditAmountDiscount(f func(AmountLineDiscountManaged) (AmountLineDiscountManaged, error)) LineDiscountMutator {
+	return func(discount LineDiscount) (LineDiscount, error) {
+		if discount.Type() != LineDiscountTypeAmount {
+			return discount, fmt.Errorf("cannot edit non-amount discount: %s", discount.Type())
+		}
+
+		amount, err := discount.AsAmount()
+		if err != nil {
+			return discount, err
+		}
+
+		amount, err = f(amount)
+		if err != nil {
+			return discount, err
+		}
+
+		return NewLineDiscountFrom(amount), nil
+	}
+}
+
+func MarkDiscountDeleted(deletedAt time.Time) LineDiscountMutator {
+	return func(discount LineDiscount) (LineDiscount, error) {
+		managedFields := discount.GetManagedFields()
+
+		managedFields.DeletedAt = &deletedAt
+		return SetDiscountMangedFields(managedFields)(discount)
+	}
+}
+
+// LineDiscounts is a list of line discounts.
+type LineDiscounts []LineDiscount
+
+func NewLineDiscounts(discounts ...LineDiscount) LineDiscounts {
+	return LineDiscounts(discounts)
+}
+
+func (d LineDiscounts) Clone() LineDiscounts {
+	return LineDiscounts(lo.Map(d, func(discount LineDiscount, _ int) LineDiscount {
+		return discount.Clone()
+	}))
+}
+
+// ReuseIDsFrom reuses the IDs of the existing discounts by child unique reference ID.
+// This is used to prevent creation of new IDs/rows in the database when doing an idempotent reconciliation.
+func (d LineDiscounts) ReuseIDsFrom(existingItems []LineDiscount) (LineDiscounts, error) {
+	existingItemsByUniqueReference := lo.GroupBy(
+		lo.Filter(existingItems, func(item LineDiscount, _ int) bool {
+			return item.GetChildUniqueReferenceID() != nil
+		}),
+		func(item LineDiscount) string {
+			return *item.GetChildUniqueReferenceID()
+		},
+	)
+
+	discountsWithIDReuse, err := slicesx.MapWithErr(d, func(discount LineDiscount) (LineDiscount, error) {
+		childUniqueReferenceID := discount.GetChildUniqueReferenceID()
+
+		// We should not reuse the ID if they are for a different child unique reference ID
+		if childUniqueReferenceID == nil {
+			return discount, nil
+		}
+
+		existingItems, ok := existingItemsByUniqueReference[*childUniqueReferenceID]
+		if !ok {
+			// We did not find any existing items for this child unique reference ID,
+			// let's create a new entry in the DB.
+			return discount, nil
+		}
+
+		existingManagedFields := existingItems[0].GetManagedFields()
+
+		return discount.Mutate(SetDiscountMangedFields(LineSetDiscountMangedFields{
+			ID: existingManagedFields.ID,
+			ManagedModel: models.ManagedModel{
+				CreatedAt: existingManagedFields.CreatedAt,
+				// UpdatedAt is updated by the adapter layer
+				// DeletedAt should not be set, to ensure that we are not carrying over soft-deletion flags
+			},
+		}))
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return slicesx.EmptyAsNil(discountsWithIDReuse), nil
+}
+
+func (d LineDiscounts) SumAmount(currency currencyx.Calculator) alpacadecimal.Decimal {
+	sum := alpacadecimal.Zero
+	for _, amount := range d.GetAmountDiscounts() {
+		sum = sum.Add(amount.Amount).Add(amount.RoundingAmount)
+	}
+
+	return sum
+}
+
+func (d LineDiscounts) Validate() error {
+	var errs []error
+
+	for _, discount := range d {
+		if err := discount.Validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// GetAmountDiscounts returns all amount discounts in the list, the slice's items are never
+// nil.
+func (d LineDiscounts) GetAmountDiscounts() []AmountLineDiscountManaged {
+	amountDiscounts := []AmountLineDiscountManaged{}
+
+	for _, discount := range d {
+		if discount.Type() != LineDiscountTypeAmount {
+			continue
+		}
+
+		if amount, err := discount.AsAmount(); err == nil {
+			amountDiscounts = append(amountDiscounts, amount)
+		}
+	}
+
+	return amountDiscounts
+}
+
+// GetAmountDiscountsByID returns a map of amount discounts by their ID, the map's items are never
+// nil. Items with an empty ID are not included in the map.
+func (d LineDiscounts) GetAmountDiscountsByID() (map[string]AmountLineDiscountManaged, error) {
+	amountDiscountsByID, unique := slicesx.UniqueGroupBy(
+		lo.Filter(d.GetAmountDiscounts(), func(discount AmountLineDiscountManaged, _ int) bool {
+			return discount.ID != ""
+		}),
+		func(discount AmountLineDiscountManaged) string {
+			return discount.ID
+		},
+	)
+
+	if !unique {
+		return nil, errors.New("amount discounts are not unique")
+	}
+
+	return amountDiscountsByID, nil
+}
+
+// DiscountsByID returns a map of discounts by their ID, the map's items are never
+// nil. Items with an empty ID are not included in the map.
+func (d LineDiscounts) DiscountsByID() (map[string]LineDiscount, error) {
+	discountsByID, unique := slicesx.UniqueGroupBy(
+		lo.Filter(d, func(discount LineDiscount, _ int) bool {
+			return discount.GetID() != ""
+		}),
+		func(discount LineDiscount) string {
+			return discount.GetID()
+		},
+	)
+
+	if !unique {
+		return nil, errors.New("discountIDs are not unique")
+	}
+
+	return discountsByID, nil
+}
+
+func (d LineDiscounts) GetDiscountByChildUniqueReferenceID(childUniqueReferenceID string) (LineDiscount, bool) {
+	for _, discount := range d {
+		if discount.GetChildUniqueReferenceID() != nil && *discount.GetChildUniqueReferenceID() == childUniqueReferenceID {
+			return discount, true
+		}
+	}
+	return nil, false
+}
+
+// Mutate mutates the discounts in the list by applying the mutators in order, then
+// returns the mutated discounts.
+func (d LineDiscounts) Mutate(mutators ...LineDiscountMutator) (LineDiscounts, error) {
+	return slicesx.MapWithErr(d, func(discount LineDiscount) (LineDiscount, error) {
+		return discount.Mutate(mutators...)
+	})
+}

--- a/openmeter/billing/service/lineservice/feeline.go
+++ b/openmeter/billing/service/lineservice/feeline.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 )
@@ -46,13 +45,7 @@ func (l *feeLine) UpdateTotals() error {
 
 	// Calculate the line totals
 	totals := billing.Totals{
-		DiscountsTotal: calc.RoundToPrecision(
-			alpacadecimal.Sum(alpacadecimal.Zero,
-				lo.Map(l.line.Discounts, func(d billing.LineDiscount, _ int) alpacadecimal.Decimal {
-					return d.Amount
-				})...,
-			),
-		),
+		DiscountsTotal: l.line.Discounts.SumAmount(calc),
 
 		// TODO[OM-979]: implement taxes
 		TaxesInclusiveTotal: alpacadecimal.Zero,

--- a/openmeter/billing/service/lineservice/usagebasedline_test.go
+++ b/openmeter/billing/service/lineservice/usagebasedline_test.go
@@ -400,14 +400,17 @@ func TestUnitPriceCalculation(t *testing.T) {
 					Quantity:               alpacadecimal.NewFromFloat(5),
 					ChildUniqueReferenceID: UnitPriceUsageChildUniqueReferenceID,
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
-					Discounts: []billing.LineDiscount{
-						{
-							Description:            lo.ToPtr("Maximum spend discount for charges over 100"),
-							Amount:                 alpacadecimal.NewFromFloat(20),
-							ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
-							Reason:                 billing.LineDiscountReasonMaximumSpend,
+					Discounts: billing.NewLineDiscounts(
+						billing.NewLineDiscountFrom(billing.AmountLineDiscount{
+							Amount: alpacadecimal.NewFromFloat(20),
+							LineDiscountBase: billing.LineDiscountBase{
+								Description:            lo.ToPtr("Maximum spend discount for charges over 100"),
+								ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+								Reason:                 billing.LineDiscountReasonMaximumSpend,
+							},
 						},
-					},
+						),
+					),
 				},
 			},
 		})
@@ -588,14 +591,17 @@ func TestDynamicPriceCalculation(t *testing.T) {
 					Quantity:               alpacadecimal.NewFromFloat(1),
 					ChildUniqueReferenceID: UsageChildUniqueReferenceID,
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
-					Discounts: []billing.LineDiscount{
-						{
-							Reason:                 billing.LineDiscountReasonMaximumSpend,
-							Description:            lo.ToPtr("Maximum spend discount for charges over 100"),
-							Amount:                 alpacadecimal.NewFromFloat(60),
-							ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+					Discounts: billing.NewLineDiscounts(
+						billing.NewLineDiscountFrom(billing.AmountLineDiscount{
+							Amount: alpacadecimal.NewFromFloat(60),
+							LineDiscountBase: billing.LineDiscountBase{
+								Description:            lo.ToPtr("Maximum spend discount for charges over 100"),
+								ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+								Reason:                 billing.LineDiscountReasonMaximumSpend,
+							},
 						},
-					},
+						),
+					),
 				},
 			},
 		})
@@ -830,14 +836,16 @@ func TestPackagePriceCalculation(t *testing.T) {
 					Quantity:               alpacadecimal.NewFromFloat(5),
 					ChildUniqueReferenceID: UsageChildUniqueReferenceID,
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
-					Discounts: []billing.LineDiscount{
-						{
-							Reason:                 billing.LineDiscountReasonMaximumSpend,
-							Description:            lo.ToPtr("Maximum spend discount for charges over 100"),
-							Amount:                 alpacadecimal.NewFromFloat(65),
-							ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
-						},
-					},
+					Discounts: billing.NewLineDiscounts(
+						billing.NewLineDiscountFrom(billing.AmountLineDiscount{
+							Amount: alpacadecimal.NewFromFloat(65),
+							LineDiscountBase: billing.LineDiscountBase{
+								Description:            lo.ToPtr("Maximum spend discount for charges over 100"),
+								ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+								Reason:                 billing.LineDiscountReasonMaximumSpend,
+							},
+						}),
+					),
 				},
 			},
 		})
@@ -1235,14 +1243,16 @@ func TestTieredVolumeCalculation(t *testing.T) {
 					Quantity:               alpacadecimal.NewFromFloat(1),
 					ChildUniqueReferenceID: VolumeFlatPriceChildUniqueReferenceID,
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
-					Discounts: []billing.LineDiscount{
-						{
-							Reason:                 billing.LineDiscountReasonMaximumSpend,
-							Description:            lo.ToPtr("Maximum spend discount for charges over 125"),
-							Amount:                 alpacadecimal.NewFromFloat(25),
-							ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
-						},
-					},
+					Discounts: billing.NewLineDiscounts(
+						billing.NewLineDiscountFrom(billing.AmountLineDiscount{
+							Amount: alpacadecimal.NewFromFloat(25),
+							LineDiscountBase: billing.LineDiscountBase{
+								Description:            lo.ToPtr("Maximum spend discount for charges over 125"),
+								ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+								Reason:                 billing.LineDiscountReasonMaximumSpend,
+							},
+						}),
+					),
 				},
 			},
 		})
@@ -1485,14 +1495,17 @@ func TestTieredGraduatedCalculation(t *testing.T) {
 					Quantity:               alpacadecimal.NewFromFloat(3),
 					ChildUniqueReferenceID: "graduated-tiered-3-price-usage",
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
-					Discounts: []billing.LineDiscount{
-						{
-							Reason:                 billing.LineDiscountReasonMaximumSpend,
-							Description:            lo.ToPtr("Maximum spend discount for charges over 170"),
-							Amount:                 alpacadecimal.NewFromFloat(5),
-							ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+					Discounts: billing.NewLineDiscounts(
+						billing.NewLineDiscountFrom(billing.AmountLineDiscount{
+							Amount: alpacadecimal.NewFromFloat(5),
+							LineDiscountBase: billing.LineDiscountBase{
+								Description:            lo.ToPtr("Maximum spend discount for charges over 170"),
+								ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+								Reason:                 billing.LineDiscountReasonMaximumSpend,
+							},
 						},
-					},
+						),
+					),
 				},
 				{
 					Name:                   "feature: usage price for tier 4",
@@ -1500,14 +1513,16 @@ func TestTieredGraduatedCalculation(t *testing.T) {
 					Quantity:               alpacadecimal.NewFromFloat(7),
 					ChildUniqueReferenceID: "graduated-tiered-4-price-usage",
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
-					Discounts: []billing.LineDiscount{
-						{
-							Reason:                 billing.LineDiscountReasonMaximumSpend,
-							Description:            lo.ToPtr("Maximum spend discount for charges over 170"),
-							Amount:                 alpacadecimal.NewFromFloat(7),
-							ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
-						},
-					},
+					Discounts: billing.NewLineDiscounts(
+						billing.NewLineDiscountFrom(billing.AmountLineDiscount{
+							Amount: alpacadecimal.NewFromFloat(7),
+							LineDiscountBase: billing.LineDiscountBase{
+								Description:            lo.ToPtr("Maximum spend discount for charges over 170"),
+								ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+								Reason:                 billing.LineDiscountReasonMaximumSpend,
+							},
+						}),
+					),
 				},
 			},
 		})
@@ -1557,14 +1572,17 @@ func TestAddDiscountForOverage(t *testing.T) {
 		require.Equal(t, newDetailedLineInput{
 			PerUnitAmount: alpacadecimal.NewFromFloat(100),
 			Quantity:      alpacadecimal.NewFromFloat(10),
-			Discounts: []billing.LineDiscount{
-				{
-					Reason:                 billing.LineDiscountReasonMaximumSpend,
-					Description:            lo.ToPtr("Maximum spend discount for charges over 10000"),
-					Amount:                 alpacadecimal.NewFromFloat(0.01),
-					ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+			Discounts: billing.NewLineDiscounts(
+				billing.NewLineDiscountFrom(billing.AmountLineDiscount{
+					Amount: alpacadecimal.NewFromFloat(0.01),
+					LineDiscountBase: billing.LineDiscountBase{
+						Description:            lo.ToPtr("Maximum spend discount for charges over 10000"),
+						ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+						Reason:                 billing.LineDiscountReasonMaximumSpend,
+					},
 				},
-			},
+				),
+			),
 		}, lineWithDiscount)
 	})
 
@@ -1579,14 +1597,17 @@ func TestAddDiscountForOverage(t *testing.T) {
 		require.Equal(t, newDetailedLineInput{
 			PerUnitAmount: alpacadecimal.NewFromFloat(100),
 			Quantity:      alpacadecimal.NewFromFloat(10),
-			Discounts: []billing.LineDiscount{
-				{
-					Reason:                 billing.LineDiscountReasonMaximumSpend,
-					Description:            lo.ToPtr("Maximum spend discount for charges over 10000"),
-					Amount:                 alpacadecimal.NewFromFloat(600),
-					ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+			Discounts: billing.NewLineDiscounts(
+				billing.NewLineDiscountFrom(billing.AmountLineDiscount{
+					Amount: alpacadecimal.NewFromFloat(600),
+					LineDiscountBase: billing.LineDiscountBase{
+						Description:            lo.ToPtr("Maximum spend discount for charges over 10000"),
+						ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+						Reason:                 billing.LineDiscountReasonMaximumSpend,
+					},
 				},
-			},
+				),
+			),
 		}, lineWithDiscount)
 	})
 
@@ -1601,14 +1622,17 @@ func TestAddDiscountForOverage(t *testing.T) {
 		require.Equal(t, newDetailedLineInput{
 			PerUnitAmount: alpacadecimal.NewFromFloat(100),
 			Quantity:      alpacadecimal.NewFromFloat(10),
-			Discounts: []billing.LineDiscount{
-				{
-					Reason:                 billing.LineDiscountReasonMaximumSpend,
-					Description:            lo.ToPtr("Maximum spend discount for charges over 10000"),
-					Amount:                 alpacadecimal.NewFromFloat(1000),
-					ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+			Discounts: billing.NewLineDiscounts(
+				billing.NewLineDiscountFrom(billing.AmountLineDiscount{
+					Amount: alpacadecimal.NewFromFloat(1000),
+					LineDiscountBase: billing.LineDiscountBase{
+						Description:            lo.ToPtr("Maximum spend discount for charges over 10000"),
+						ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+						Reason:                 billing.LineDiscountReasonMaximumSpend,
+					},
 				},
-			},
+				),
+			),
 		}, lineWithDiscount)
 	})
 
@@ -1623,14 +1647,16 @@ func TestAddDiscountForOverage(t *testing.T) {
 		require.Equal(t, newDetailedLineInput{
 			PerUnitAmount: alpacadecimal.NewFromFloat(100),
 			Quantity:      alpacadecimal.NewFromFloat(10),
-			Discounts: []billing.LineDiscount{
-				{
-					Reason:                 billing.LineDiscountReasonMaximumSpend,
-					Description:            lo.ToPtr("Maximum spend discount for charges over 10000"),
-					Amount:                 alpacadecimal.NewFromFloat(1000),
-					ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
-				},
-			},
+			Discounts: billing.NewLineDiscounts(
+				billing.NewLineDiscountFrom(billing.AmountLineDiscount{
+					Amount: alpacadecimal.NewFromFloat(1000),
+					LineDiscountBase: billing.LineDiscountBase{
+						Description:            lo.ToPtr("Maximum spend discount for charges over 10000"),
+						ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+						Reason:                 billing.LineDiscountReasonMaximumSpend,
+					},
+				}),
+			),
 		}, lineWithDiscount)
 	})
 }

--- a/openmeter/ent/db/billinginvoicediscount.go
+++ b/openmeter/ent/db/billinginvoicediscount.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicediscount"
 )
 
@@ -36,7 +37,7 @@ type BillingInvoiceDiscount struct {
 	// InvoiceID holds the value of the "invoice_id" field.
 	InvoiceID string `json:"invoice_id,omitempty"`
 	// Type holds the value of the "type" field.
-	Type string `json:"type,omitempty"`
+	Type billing.LineDiscountType `json:"type,omitempty"`
 	// Amount holds the value of the "amount" field.
 	Amount alpacadecimal.Decimal `json:"amount,omitempty"`
 	// LineIds holds the value of the "line_ids" field.
@@ -134,7 +135,7 @@ func (bid *BillingInvoiceDiscount) assignValues(columns []string, values []any) 
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field type", values[i])
 			} else if value.Valid {
-				bid.Type = value.String
+				bid.Type = billing.LineDiscountType(value.String)
 			}
 		case billinginvoicediscount.FieldAmount:
 			if value, ok := values[i].(*alpacadecimal.Decimal); !ok {
@@ -215,7 +216,7 @@ func (bid *BillingInvoiceDiscount) String() string {
 	builder.WriteString(bid.InvoiceID)
 	builder.WriteString(", ")
 	builder.WriteString("type=")
-	builder.WriteString(bid.Type)
+	builder.WriteString(fmt.Sprintf("%v", bid.Type))
 	builder.WriteString(", ")
 	builder.WriteString("amount=")
 	builder.WriteString(fmt.Sprintf("%v", bid.Amount))

--- a/openmeter/ent/db/billinginvoicediscount/billinginvoicediscount.go
+++ b/openmeter/ent/db/billinginvoicediscount/billinginvoicediscount.go
@@ -3,9 +3,11 @@
 package billinginvoicediscount
 
 import (
+	"fmt"
 	"time"
 
 	"entgo.io/ent/dialect/sql"
+	"github.com/openmeterio/openmeter/openmeter/billing"
 )
 
 const (
@@ -77,6 +79,16 @@ var (
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
+
+// TypeValidator is a validator for the "type" field enum values. It is called by the builders before save.
+func TypeValidator(_type billing.LineDiscountType) error {
+	switch _type {
+	case "amount", "usage":
+		return nil
+	default:
+		return fmt.Errorf("billinginvoicediscount: invalid enum value for type field: %q", _type)
+	}
+}
 
 // OrderOption defines the ordering options for the BillingInvoiceDiscount queries.
 type OrderOption func(*sql.Selector)

--- a/openmeter/ent/db/billinginvoicediscount/where.go
+++ b/openmeter/ent/db/billinginvoicediscount/where.go
@@ -7,6 +7,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 )
 
@@ -98,11 +99,6 @@ func Description(v string) predicate.BillingInvoiceDiscount {
 // InvoiceID applies equality check predicate on the "invoice_id" field. It's identical to InvoiceIDEQ.
 func InvoiceID(v string) predicate.BillingInvoiceDiscount {
 	return predicate.BillingInvoiceDiscount(sql.FieldEQ(FieldInvoiceID, v))
-}
-
-// Type applies equality check predicate on the "type" field. It's identical to TypeEQ.
-func Type(v string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldEQ(FieldType, v))
 }
 
 // Amount applies equality check predicate on the "amount" field. It's identical to AmountEQ.
@@ -521,68 +517,33 @@ func InvoiceIDContainsFold(v string) predicate.BillingInvoiceDiscount {
 }
 
 // TypeEQ applies the EQ predicate on the "type" field.
-func TypeEQ(v string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldEQ(FieldType, v))
+func TypeEQ(v billing.LineDiscountType) predicate.BillingInvoiceDiscount {
+	vc := v
+	return predicate.BillingInvoiceDiscount(sql.FieldEQ(FieldType, vc))
 }
 
 // TypeNEQ applies the NEQ predicate on the "type" field.
-func TypeNEQ(v string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldNEQ(FieldType, v))
+func TypeNEQ(v billing.LineDiscountType) predicate.BillingInvoiceDiscount {
+	vc := v
+	return predicate.BillingInvoiceDiscount(sql.FieldNEQ(FieldType, vc))
 }
 
 // TypeIn applies the In predicate on the "type" field.
-func TypeIn(vs ...string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldIn(FieldType, vs...))
+func TypeIn(vs ...billing.LineDiscountType) predicate.BillingInvoiceDiscount {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.BillingInvoiceDiscount(sql.FieldIn(FieldType, v...))
 }
 
 // TypeNotIn applies the NotIn predicate on the "type" field.
-func TypeNotIn(vs ...string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldNotIn(FieldType, vs...))
-}
-
-// TypeGT applies the GT predicate on the "type" field.
-func TypeGT(v string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldGT(FieldType, v))
-}
-
-// TypeGTE applies the GTE predicate on the "type" field.
-func TypeGTE(v string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldGTE(FieldType, v))
-}
-
-// TypeLT applies the LT predicate on the "type" field.
-func TypeLT(v string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldLT(FieldType, v))
-}
-
-// TypeLTE applies the LTE predicate on the "type" field.
-func TypeLTE(v string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldLTE(FieldType, v))
-}
-
-// TypeContains applies the Contains predicate on the "type" field.
-func TypeContains(v string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldContains(FieldType, v))
-}
-
-// TypeHasPrefix applies the HasPrefix predicate on the "type" field.
-func TypeHasPrefix(v string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldHasPrefix(FieldType, v))
-}
-
-// TypeHasSuffix applies the HasSuffix predicate on the "type" field.
-func TypeHasSuffix(v string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldHasSuffix(FieldType, v))
-}
-
-// TypeEqualFold applies the EqualFold predicate on the "type" field.
-func TypeEqualFold(v string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldEqualFold(FieldType, v))
-}
-
-// TypeContainsFold applies the ContainsFold predicate on the "type" field.
-func TypeContainsFold(v string) predicate.BillingInvoiceDiscount {
-	return predicate.BillingInvoiceDiscount(sql.FieldContainsFold(FieldType, v))
+func TypeNotIn(vs ...billing.LineDiscountType) predicate.BillingInvoiceDiscount {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.BillingInvoiceDiscount(sql.FieldNotIn(FieldType, v...))
 }
 
 // AmountEQ applies the EQ predicate on the "amount" field.

--- a/openmeter/ent/db/billinginvoicediscount_create.go
+++ b/openmeter/ent/db/billinginvoicediscount_create.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicediscount"
 )
 
@@ -105,8 +106,8 @@ func (bidc *BillingInvoiceDiscountCreate) SetInvoiceID(s string) *BillingInvoice
 }
 
 // SetType sets the "type" field.
-func (bidc *BillingInvoiceDiscountCreate) SetType(s string) *BillingInvoiceDiscountCreate {
-	bidc.mutation.SetType(s)
+func (bidc *BillingInvoiceDiscountCreate) SetType(bdt billing.LineDiscountType) *BillingInvoiceDiscountCreate {
+	bidc.mutation.SetType(bdt)
 	return bidc
 }
 
@@ -210,6 +211,11 @@ func (bidc *BillingInvoiceDiscountCreate) check() error {
 	if _, ok := bidc.mutation.GetType(); !ok {
 		return &ValidationError{Name: "type", err: errors.New(`db: missing required field "BillingInvoiceDiscount.type"`)}
 	}
+	if v, ok := bidc.mutation.GetType(); ok {
+		if err := billinginvoicediscount.TypeValidator(v); err != nil {
+			return &ValidationError{Name: "type", err: fmt.Errorf(`db: validator failed for field "BillingInvoiceDiscount.type": %w`, err)}
+		}
+	}
 	if _, ok := bidc.mutation.Amount(); !ok {
 		return &ValidationError{Name: "amount", err: errors.New(`db: missing required field "BillingInvoiceDiscount.amount"`)}
 	}
@@ -282,7 +288,7 @@ func (bidc *BillingInvoiceDiscountCreate) createSpec() (*BillingInvoiceDiscount,
 		_node.InvoiceID = value
 	}
 	if value, ok := bidc.mutation.GetType(); ok {
-		_spec.SetField(billinginvoicediscount.FieldType, field.TypeString, value)
+		_spec.SetField(billinginvoicediscount.FieldType, field.TypeEnum, value)
 		_node.Type = value
 	}
 	if value, ok := bidc.mutation.Amount(); ok {
@@ -436,7 +442,7 @@ func (u *BillingInvoiceDiscountUpsert) UpdateInvoiceID() *BillingInvoiceDiscount
 }
 
 // SetType sets the "type" field.
-func (u *BillingInvoiceDiscountUpsert) SetType(v string) *BillingInvoiceDiscountUpsert {
+func (u *BillingInvoiceDiscountUpsert) SetType(v billing.LineDiscountType) *BillingInvoiceDiscountUpsert {
 	u.Set(billinginvoicediscount.FieldType, v)
 	return u
 }
@@ -637,7 +643,7 @@ func (u *BillingInvoiceDiscountUpsertOne) UpdateInvoiceID() *BillingInvoiceDisco
 }
 
 // SetType sets the "type" field.
-func (u *BillingInvoiceDiscountUpsertOne) SetType(v string) *BillingInvoiceDiscountUpsertOne {
+func (u *BillingInvoiceDiscountUpsertOne) SetType(v billing.LineDiscountType) *BillingInvoiceDiscountUpsertOne {
 	return u.Update(func(s *BillingInvoiceDiscountUpsert) {
 		s.SetType(v)
 	})
@@ -1012,7 +1018,7 @@ func (u *BillingInvoiceDiscountUpsertBulk) UpdateInvoiceID() *BillingInvoiceDisc
 }
 
 // SetType sets the "type" field.
-func (u *BillingInvoiceDiscountUpsertBulk) SetType(v string) *BillingInvoiceDiscountUpsertBulk {
+func (u *BillingInvoiceDiscountUpsertBulk) SetType(v billing.LineDiscountType) *BillingInvoiceDiscountUpsertBulk {
 	return u.Update(func(s *BillingInvoiceDiscountUpsert) {
 		s.SetType(v)
 	})

--- a/openmeter/ent/db/billinginvoicediscount_update.go
+++ b/openmeter/ent/db/billinginvoicediscount_update.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicediscount"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 )
@@ -117,15 +118,15 @@ func (bidu *BillingInvoiceDiscountUpdate) SetNillableInvoiceID(s *string) *Billi
 }
 
 // SetType sets the "type" field.
-func (bidu *BillingInvoiceDiscountUpdate) SetType(s string) *BillingInvoiceDiscountUpdate {
-	bidu.mutation.SetType(s)
+func (bidu *BillingInvoiceDiscountUpdate) SetType(bdt billing.LineDiscountType) *BillingInvoiceDiscountUpdate {
+	bidu.mutation.SetType(bdt)
 	return bidu
 }
 
 // SetNillableType sets the "type" field if the given value is not nil.
-func (bidu *BillingInvoiceDiscountUpdate) SetNillableType(s *string) *BillingInvoiceDiscountUpdate {
-	if s != nil {
-		bidu.SetType(*s)
+func (bidu *BillingInvoiceDiscountUpdate) SetNillableType(bdt *billing.LineDiscountType) *BillingInvoiceDiscountUpdate {
+	if bdt != nil {
+		bidu.SetType(*bdt)
 	}
 	return bidu
 }
@@ -203,7 +204,20 @@ func (bidu *BillingInvoiceDiscountUpdate) defaults() {
 	}
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (bidu *BillingInvoiceDiscountUpdate) check() error {
+	if v, ok := bidu.mutation.GetType(); ok {
+		if err := billinginvoicediscount.TypeValidator(v); err != nil {
+			return &ValidationError{Name: "type", err: fmt.Errorf(`db: validator failed for field "BillingInvoiceDiscount.type": %w`, err)}
+		}
+	}
+	return nil
+}
+
 func (bidu *BillingInvoiceDiscountUpdate) sqlSave(ctx context.Context) (n int, err error) {
+	if err := bidu.check(); err != nil {
+		return n, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(billinginvoicediscount.Table, billinginvoicediscount.Columns, sqlgraph.NewFieldSpec(billinginvoicediscount.FieldID, field.TypeString))
 	if ps := bidu.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
@@ -240,7 +254,7 @@ func (bidu *BillingInvoiceDiscountUpdate) sqlSave(ctx context.Context) (n int, e
 		_spec.SetField(billinginvoicediscount.FieldInvoiceID, field.TypeString, value)
 	}
 	if value, ok := bidu.mutation.GetType(); ok {
-		_spec.SetField(billinginvoicediscount.FieldType, field.TypeString, value)
+		_spec.SetField(billinginvoicediscount.FieldType, field.TypeEnum, value)
 	}
 	if value, ok := bidu.mutation.Amount(); ok {
 		_spec.SetField(billinginvoicediscount.FieldAmount, field.TypeOther, value)
@@ -363,15 +377,15 @@ func (biduo *BillingInvoiceDiscountUpdateOne) SetNillableInvoiceID(s *string) *B
 }
 
 // SetType sets the "type" field.
-func (biduo *BillingInvoiceDiscountUpdateOne) SetType(s string) *BillingInvoiceDiscountUpdateOne {
-	biduo.mutation.SetType(s)
+func (biduo *BillingInvoiceDiscountUpdateOne) SetType(bdt billing.LineDiscountType) *BillingInvoiceDiscountUpdateOne {
+	biduo.mutation.SetType(bdt)
 	return biduo
 }
 
 // SetNillableType sets the "type" field if the given value is not nil.
-func (biduo *BillingInvoiceDiscountUpdateOne) SetNillableType(s *string) *BillingInvoiceDiscountUpdateOne {
-	if s != nil {
-		biduo.SetType(*s)
+func (biduo *BillingInvoiceDiscountUpdateOne) SetNillableType(bdt *billing.LineDiscountType) *BillingInvoiceDiscountUpdateOne {
+	if bdt != nil {
+		biduo.SetType(*bdt)
 	}
 	return biduo
 }
@@ -462,7 +476,20 @@ func (biduo *BillingInvoiceDiscountUpdateOne) defaults() {
 	}
 }
 
+// check runs all checks and user-defined validators on the builder.
+func (biduo *BillingInvoiceDiscountUpdateOne) check() error {
+	if v, ok := biduo.mutation.GetType(); ok {
+		if err := billinginvoicediscount.TypeValidator(v); err != nil {
+			return &ValidationError{Name: "type", err: fmt.Errorf(`db: validator failed for field "BillingInvoiceDiscount.type": %w`, err)}
+		}
+	}
+	return nil
+}
+
 func (biduo *BillingInvoiceDiscountUpdateOne) sqlSave(ctx context.Context) (_node *BillingInvoiceDiscount, err error) {
+	if err := biduo.check(); err != nil {
+		return _node, err
+	}
 	_spec := sqlgraph.NewUpdateSpec(billinginvoicediscount.Table, billinginvoicediscount.Columns, sqlgraph.NewFieldSpec(billinginvoicediscount.FieldID, field.TypeString))
 	id, ok := biduo.mutation.ID()
 	if !ok {
@@ -516,7 +543,7 @@ func (biduo *BillingInvoiceDiscountUpdateOne) sqlSave(ctx context.Context) (_nod
 		_spec.SetField(billinginvoicediscount.FieldInvoiceID, field.TypeString, value)
 	}
 	if value, ok := biduo.mutation.GetType(); ok {
-		_spec.SetField(billinginvoicediscount.FieldType, field.TypeString, value)
+		_spec.SetField(billinginvoicediscount.FieldType, field.TypeEnum, value)
 	}
 	if value, ok := biduo.mutation.Amount(); ok {
 		_spec.SetField(billinginvoicediscount.FieldAmount, field.TypeOther, value)

--- a/openmeter/ent/db/billinginvoicelinediscount.go
+++ b/openmeter/ent/db/billinginvoicelinediscount.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicelinediscount"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 )
 
 // BillingInvoiceLineDiscount is the model entity for the BillingInvoiceLineDiscount schema.
@@ -28,16 +29,26 @@ type BillingInvoiceLineDiscount struct {
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 	// DeletedAt holds the value of the "deleted_at" field.
 	DeletedAt *time.Time `json:"deleted_at,omitempty"`
-	// LineID holds the value of the "line_id" field.
-	LineID string `json:"line_id,omitempty"`
+	// Type holds the value of the "type" field.
+	Type billing.LineDiscountType `json:"type,omitempty"`
 	// Reason holds the value of the "reason" field.
 	Reason billing.LineDiscountReason `json:"reason,omitempty"`
+	// LineID holds the value of the "line_id" field.
+	LineID string `json:"line_id,omitempty"`
 	// ChildUniqueReferenceID holds the value of the "child_unique_reference_id" field.
 	ChildUniqueReferenceID *string `json:"child_unique_reference_id,omitempty"`
 	// Description holds the value of the "description" field.
 	Description *string `json:"description,omitempty"`
 	// Amount holds the value of the "amount" field.
-	Amount alpacadecimal.Decimal `json:"amount,omitempty"`
+	Amount *alpacadecimal.Decimal `json:"amount,omitempty"`
+	// RoundingAmount holds the value of the "rounding_amount" field.
+	RoundingAmount *alpacadecimal.Decimal `json:"rounding_amount,omitempty"`
+	// Quantity holds the value of the "quantity" field.
+	Quantity *alpacadecimal.Decimal `json:"quantity,omitempty"`
+	// PreLinePeriodQuantity holds the value of the "pre_line_period_quantity" field.
+	PreLinePeriodQuantity *alpacadecimal.Decimal `json:"pre_line_period_quantity,omitempty"`
+	// SourceDiscount holds the value of the "source_discount" field.
+	SourceDiscount *productcatalog.Discount `json:"source_discount,omitempty"`
 	// InvoicingAppExternalID holds the value of the "invoicing_app_external_id" field.
 	InvoicingAppExternalID *string `json:"invoicing_app_external_id,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -71,12 +82,14 @@ func (*BillingInvoiceLineDiscount) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case billinginvoicelinediscount.FieldAmount:
-			values[i] = new(alpacadecimal.Decimal)
-		case billinginvoicelinediscount.FieldID, billinginvoicelinediscount.FieldNamespace, billinginvoicelinediscount.FieldLineID, billinginvoicelinediscount.FieldReason, billinginvoicelinediscount.FieldChildUniqueReferenceID, billinginvoicelinediscount.FieldDescription, billinginvoicelinediscount.FieldInvoicingAppExternalID:
+		case billinginvoicelinediscount.FieldAmount, billinginvoicelinediscount.FieldRoundingAmount, billinginvoicelinediscount.FieldQuantity, billinginvoicelinediscount.FieldPreLinePeriodQuantity:
+			values[i] = &sql.NullScanner{S: new(alpacadecimal.Decimal)}
+		case billinginvoicelinediscount.FieldID, billinginvoicelinediscount.FieldNamespace, billinginvoicelinediscount.FieldType, billinginvoicelinediscount.FieldReason, billinginvoicelinediscount.FieldLineID, billinginvoicelinediscount.FieldChildUniqueReferenceID, billinginvoicelinediscount.FieldDescription, billinginvoicelinediscount.FieldInvoicingAppExternalID:
 			values[i] = new(sql.NullString)
 		case billinginvoicelinediscount.FieldCreatedAt, billinginvoicelinediscount.FieldUpdatedAt, billinginvoicelinediscount.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
+		case billinginvoicelinediscount.FieldSourceDiscount:
+			values[i] = billinginvoicelinediscount.ValueScanner.SourceDiscount.ScanValue()
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -123,17 +136,23 @@ func (bild *BillingInvoiceLineDiscount) assignValues(columns []string, values []
 				bild.DeletedAt = new(time.Time)
 				*bild.DeletedAt = value.Time
 			}
-		case billinginvoicelinediscount.FieldLineID:
+		case billinginvoicelinediscount.FieldType:
 			if value, ok := values[i].(*sql.NullString); !ok {
-				return fmt.Errorf("unexpected type %T for field line_id", values[i])
+				return fmt.Errorf("unexpected type %T for field type", values[i])
 			} else if value.Valid {
-				bild.LineID = value.String
+				bild.Type = billing.LineDiscountType(value.String)
 			}
 		case billinginvoicelinediscount.FieldReason:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field reason", values[i])
 			} else if value.Valid {
 				bild.Reason = billing.LineDiscountReason(value.String)
+			}
+		case billinginvoicelinediscount.FieldLineID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field line_id", values[i])
+			} else if value.Valid {
+				bild.LineID = value.String
 			}
 		case billinginvoicelinediscount.FieldChildUniqueReferenceID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -150,10 +169,38 @@ func (bild *BillingInvoiceLineDiscount) assignValues(columns []string, values []
 				*bild.Description = value.String
 			}
 		case billinginvoicelinediscount.FieldAmount:
-			if value, ok := values[i].(*alpacadecimal.Decimal); !ok {
+			if value, ok := values[i].(*sql.NullScanner); !ok {
 				return fmt.Errorf("unexpected type %T for field amount", values[i])
-			} else if value != nil {
-				bild.Amount = *value
+			} else if value.Valid {
+				bild.Amount = new(alpacadecimal.Decimal)
+				*bild.Amount = *value.S.(*alpacadecimal.Decimal)
+			}
+		case billinginvoicelinediscount.FieldRoundingAmount:
+			if value, ok := values[i].(*sql.NullScanner); !ok {
+				return fmt.Errorf("unexpected type %T for field rounding_amount", values[i])
+			} else if value.Valid {
+				bild.RoundingAmount = new(alpacadecimal.Decimal)
+				*bild.RoundingAmount = *value.S.(*alpacadecimal.Decimal)
+			}
+		case billinginvoicelinediscount.FieldQuantity:
+			if value, ok := values[i].(*sql.NullScanner); !ok {
+				return fmt.Errorf("unexpected type %T for field quantity", values[i])
+			} else if value.Valid {
+				bild.Quantity = new(alpacadecimal.Decimal)
+				*bild.Quantity = *value.S.(*alpacadecimal.Decimal)
+			}
+		case billinginvoicelinediscount.FieldPreLinePeriodQuantity:
+			if value, ok := values[i].(*sql.NullScanner); !ok {
+				return fmt.Errorf("unexpected type %T for field pre_line_period_quantity", values[i])
+			} else if value.Valid {
+				bild.PreLinePeriodQuantity = new(alpacadecimal.Decimal)
+				*bild.PreLinePeriodQuantity = *value.S.(*alpacadecimal.Decimal)
+			}
+		case billinginvoicelinediscount.FieldSourceDiscount:
+			if value, err := billinginvoicelinediscount.ValueScanner.SourceDiscount.FromValue(values[i]); err != nil {
+				return err
+			} else {
+				bild.SourceDiscount = value
 			}
 		case billinginvoicelinediscount.FieldInvoicingAppExternalID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -217,11 +264,14 @@ func (bild *BillingInvoiceLineDiscount) String() string {
 		builder.WriteString(v.Format(time.ANSIC))
 	}
 	builder.WriteString(", ")
-	builder.WriteString("line_id=")
-	builder.WriteString(bild.LineID)
+	builder.WriteString("type=")
+	builder.WriteString(fmt.Sprintf("%v", bild.Type))
 	builder.WriteString(", ")
 	builder.WriteString("reason=")
 	builder.WriteString(fmt.Sprintf("%v", bild.Reason))
+	builder.WriteString(", ")
+	builder.WriteString("line_id=")
+	builder.WriteString(bild.LineID)
 	builder.WriteString(", ")
 	if v := bild.ChildUniqueReferenceID; v != nil {
 		builder.WriteString("child_unique_reference_id=")
@@ -233,8 +283,30 @@ func (bild *BillingInvoiceLineDiscount) String() string {
 		builder.WriteString(*v)
 	}
 	builder.WriteString(", ")
-	builder.WriteString("amount=")
-	builder.WriteString(fmt.Sprintf("%v", bild.Amount))
+	if v := bild.Amount; v != nil {
+		builder.WriteString("amount=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	if v := bild.RoundingAmount; v != nil {
+		builder.WriteString("rounding_amount=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	if v := bild.Quantity; v != nil {
+		builder.WriteString("quantity=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	if v := bild.PreLinePeriodQuantity; v != nil {
+		builder.WriteString("pre_line_period_quantity=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	if v := bild.SourceDiscount; v != nil {
+		builder.WriteString("source_discount=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
 	builder.WriteString(", ")
 	if v := bild.InvoicingAppExternalID; v != nil {
 		builder.WriteString("invoicing_app_external_id=")

--- a/openmeter/ent/db/billinginvoicelinediscount/billinginvoicelinediscount.go
+++ b/openmeter/ent/db/billinginvoicelinediscount/billinginvoicelinediscount.go
@@ -8,7 +8,9 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"entgo.io/ent/schema/field"
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 )
 
 const (
@@ -24,16 +26,26 @@ const (
 	FieldUpdatedAt = "updated_at"
 	// FieldDeletedAt holds the string denoting the deleted_at field in the database.
 	FieldDeletedAt = "deleted_at"
-	// FieldLineID holds the string denoting the line_id field in the database.
-	FieldLineID = "line_id"
+	// FieldType holds the string denoting the type field in the database.
+	FieldType = "type"
 	// FieldReason holds the string denoting the reason field in the database.
 	FieldReason = "reason"
+	// FieldLineID holds the string denoting the line_id field in the database.
+	FieldLineID = "line_id"
 	// FieldChildUniqueReferenceID holds the string denoting the child_unique_reference_id field in the database.
 	FieldChildUniqueReferenceID = "child_unique_reference_id"
 	// FieldDescription holds the string denoting the description field in the database.
 	FieldDescription = "description"
 	// FieldAmount holds the string denoting the amount field in the database.
 	FieldAmount = "amount"
+	// FieldRoundingAmount holds the string denoting the rounding_amount field in the database.
+	FieldRoundingAmount = "rounding_amount"
+	// FieldQuantity holds the string denoting the quantity field in the database.
+	FieldQuantity = "quantity"
+	// FieldPreLinePeriodQuantity holds the string denoting the pre_line_period_quantity field in the database.
+	FieldPreLinePeriodQuantity = "pre_line_period_quantity"
+	// FieldSourceDiscount holds the string denoting the source_discount field in the database.
+	FieldSourceDiscount = "source_discount"
 	// FieldInvoicingAppExternalID holds the string denoting the invoicing_app_external_id field in the database.
 	FieldInvoicingAppExternalID = "invoicing_app_external_id"
 	// EdgeBillingInvoiceLine holds the string denoting the billing_invoice_line edge name in mutations.
@@ -56,11 +68,16 @@ var Columns = []string{
 	FieldCreatedAt,
 	FieldUpdatedAt,
 	FieldDeletedAt,
-	FieldLineID,
+	FieldType,
 	FieldReason,
+	FieldLineID,
 	FieldChildUniqueReferenceID,
 	FieldDescription,
 	FieldAmount,
+	FieldRoundingAmount,
+	FieldQuantity,
+	FieldPreLinePeriodQuantity,
+	FieldSourceDiscount,
 	FieldInvoicingAppExternalID,
 }
 
@@ -85,7 +102,21 @@ var (
 	UpdateDefaultUpdatedAt func() time.Time
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
+	// ValueScanner of all BillingInvoiceLineDiscount fields.
+	ValueScanner struct {
+		SourceDiscount field.TypeValueScanner[*productcatalog.Discount]
+	}
 )
+
+// TypeValidator is a validator for the "type" field enum values. It is called by the builders before save.
+func TypeValidator(_type billing.LineDiscountType) error {
+	switch _type {
+	case "amount", "usage":
+		return nil
+	default:
+		return fmt.Errorf("billinginvoicelinediscount: invalid enum value for type field: %q", _type)
+	}
+}
 
 // ReasonValidator is a validator for the "reason" field enum values. It is called by the builders before save.
 func ReasonValidator(r billing.LineDiscountReason) error {
@@ -125,14 +156,19 @@ func ByDeletedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDeletedAt, opts...).ToFunc()
 }
 
-// ByLineID orders the results by the line_id field.
-func ByLineID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldLineID, opts...).ToFunc()
+// ByType orders the results by the type field.
+func ByType(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldType, opts...).ToFunc()
 }
 
 // ByReason orders the results by the reason field.
 func ByReason(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldReason, opts...).ToFunc()
+}
+
+// ByLineID orders the results by the line_id field.
+func ByLineID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldLineID, opts...).ToFunc()
 }
 
 // ByChildUniqueReferenceID orders the results by the child_unique_reference_id field.
@@ -148,6 +184,26 @@ func ByDescription(opts ...sql.OrderTermOption) OrderOption {
 // ByAmount orders the results by the amount field.
 func ByAmount(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAmount, opts...).ToFunc()
+}
+
+// ByRoundingAmount orders the results by the rounding_amount field.
+func ByRoundingAmount(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRoundingAmount, opts...).ToFunc()
+}
+
+// ByQuantity orders the results by the quantity field.
+func ByQuantity(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldQuantity, opts...).ToFunc()
+}
+
+// ByPreLinePeriodQuantity orders the results by the pre_line_period_quantity field.
+func ByPreLinePeriodQuantity(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldPreLinePeriodQuantity, opts...).ToFunc()
+}
+
+// BySourceDiscount orders the results by the source_discount field.
+func BySourceDiscount(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSourceDiscount, opts...).ToFunc()
 }
 
 // ByInvoicingAppExternalID orders the results by the invoicing_app_external_id field.

--- a/openmeter/ent/db/billinginvoicelinediscount/where.go
+++ b/openmeter/ent/db/billinginvoicelinediscount/where.go
@@ -107,6 +107,21 @@ func Amount(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
 	return predicate.BillingInvoiceLineDiscount(sql.FieldEQ(FieldAmount, v))
 }
 
+// RoundingAmount applies equality check predicate on the "rounding_amount" field. It's identical to RoundingAmountEQ.
+func RoundingAmount(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldEQ(FieldRoundingAmount, v))
+}
+
+// Quantity applies equality check predicate on the "quantity" field. It's identical to QuantityEQ.
+func Quantity(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldEQ(FieldQuantity, v))
+}
+
+// PreLinePeriodQuantity applies equality check predicate on the "pre_line_period_quantity" field. It's identical to PreLinePeriodQuantityEQ.
+func PreLinePeriodQuantity(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldEQ(FieldPreLinePeriodQuantity, v))
+}
+
 // InvoicingAppExternalID applies equality check predicate on the "invoicing_app_external_id" field. It's identical to InvoicingAppExternalIDEQ.
 func InvoicingAppExternalID(v string) predicate.BillingInvoiceLineDiscount {
 	return predicate.BillingInvoiceLineDiscount(sql.FieldEQ(FieldInvoicingAppExternalID, v))
@@ -307,6 +322,66 @@ func DeletedAtNotNil() predicate.BillingInvoiceLineDiscount {
 	return predicate.BillingInvoiceLineDiscount(sql.FieldNotNull(FieldDeletedAt))
 }
 
+// TypeEQ applies the EQ predicate on the "type" field.
+func TypeEQ(v billing.LineDiscountType) predicate.BillingInvoiceLineDiscount {
+	vc := v
+	return predicate.BillingInvoiceLineDiscount(sql.FieldEQ(FieldType, vc))
+}
+
+// TypeNEQ applies the NEQ predicate on the "type" field.
+func TypeNEQ(v billing.LineDiscountType) predicate.BillingInvoiceLineDiscount {
+	vc := v
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNEQ(FieldType, vc))
+}
+
+// TypeIn applies the In predicate on the "type" field.
+func TypeIn(vs ...billing.LineDiscountType) predicate.BillingInvoiceLineDiscount {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.BillingInvoiceLineDiscount(sql.FieldIn(FieldType, v...))
+}
+
+// TypeNotIn applies the NotIn predicate on the "type" field.
+func TypeNotIn(vs ...billing.LineDiscountType) predicate.BillingInvoiceLineDiscount {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNotIn(FieldType, v...))
+}
+
+// ReasonEQ applies the EQ predicate on the "reason" field.
+func ReasonEQ(v billing.LineDiscountReason) predicate.BillingInvoiceLineDiscount {
+	vc := v
+	return predicate.BillingInvoiceLineDiscount(sql.FieldEQ(FieldReason, vc))
+}
+
+// ReasonNEQ applies the NEQ predicate on the "reason" field.
+func ReasonNEQ(v billing.LineDiscountReason) predicate.BillingInvoiceLineDiscount {
+	vc := v
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNEQ(FieldReason, vc))
+}
+
+// ReasonIn applies the In predicate on the "reason" field.
+func ReasonIn(vs ...billing.LineDiscountReason) predicate.BillingInvoiceLineDiscount {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.BillingInvoiceLineDiscount(sql.FieldIn(FieldReason, v...))
+}
+
+// ReasonNotIn applies the NotIn predicate on the "reason" field.
+func ReasonNotIn(vs ...billing.LineDiscountReason) predicate.BillingInvoiceLineDiscount {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNotIn(FieldReason, v...))
+}
+
 // LineIDEQ applies the EQ predicate on the "line_id" field.
 func LineIDEQ(v string) predicate.BillingInvoiceLineDiscount {
 	return predicate.BillingInvoiceLineDiscount(sql.FieldEQ(FieldLineID, v))
@@ -370,36 +445,6 @@ func LineIDEqualFold(v string) predicate.BillingInvoiceLineDiscount {
 // LineIDContainsFold applies the ContainsFold predicate on the "line_id" field.
 func LineIDContainsFold(v string) predicate.BillingInvoiceLineDiscount {
 	return predicate.BillingInvoiceLineDiscount(sql.FieldContainsFold(FieldLineID, v))
-}
-
-// ReasonEQ applies the EQ predicate on the "reason" field.
-func ReasonEQ(v billing.LineDiscountReason) predicate.BillingInvoiceLineDiscount {
-	vc := v
-	return predicate.BillingInvoiceLineDiscount(sql.FieldEQ(FieldReason, vc))
-}
-
-// ReasonNEQ applies the NEQ predicate on the "reason" field.
-func ReasonNEQ(v billing.LineDiscountReason) predicate.BillingInvoiceLineDiscount {
-	vc := v
-	return predicate.BillingInvoiceLineDiscount(sql.FieldNEQ(FieldReason, vc))
-}
-
-// ReasonIn applies the In predicate on the "reason" field.
-func ReasonIn(vs ...billing.LineDiscountReason) predicate.BillingInvoiceLineDiscount {
-	v := make([]any, len(vs))
-	for i := range v {
-		v[i] = vs[i]
-	}
-	return predicate.BillingInvoiceLineDiscount(sql.FieldIn(FieldReason, v...))
-}
-
-// ReasonNotIn applies the NotIn predicate on the "reason" field.
-func ReasonNotIn(vs ...billing.LineDiscountReason) predicate.BillingInvoiceLineDiscount {
-	v := make([]any, len(vs))
-	for i := range v {
-		v[i] = vs[i]
-	}
-	return predicate.BillingInvoiceLineDiscount(sql.FieldNotIn(FieldReason, v...))
 }
 
 // ChildUniqueReferenceIDEQ applies the EQ predicate on the "child_unique_reference_id" field.
@@ -590,6 +635,176 @@ func AmountLT(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
 // AmountLTE applies the LTE predicate on the "amount" field.
 func AmountLTE(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
 	return predicate.BillingInvoiceLineDiscount(sql.FieldLTE(FieldAmount, v))
+}
+
+// AmountIsNil applies the IsNil predicate on the "amount" field.
+func AmountIsNil() predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldIsNull(FieldAmount))
+}
+
+// AmountNotNil applies the NotNil predicate on the "amount" field.
+func AmountNotNil() predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNotNull(FieldAmount))
+}
+
+// RoundingAmountEQ applies the EQ predicate on the "rounding_amount" field.
+func RoundingAmountEQ(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldEQ(FieldRoundingAmount, v))
+}
+
+// RoundingAmountNEQ applies the NEQ predicate on the "rounding_amount" field.
+func RoundingAmountNEQ(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNEQ(FieldRoundingAmount, v))
+}
+
+// RoundingAmountIn applies the In predicate on the "rounding_amount" field.
+func RoundingAmountIn(vs ...alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldIn(FieldRoundingAmount, vs...))
+}
+
+// RoundingAmountNotIn applies the NotIn predicate on the "rounding_amount" field.
+func RoundingAmountNotIn(vs ...alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNotIn(FieldRoundingAmount, vs...))
+}
+
+// RoundingAmountGT applies the GT predicate on the "rounding_amount" field.
+func RoundingAmountGT(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldGT(FieldRoundingAmount, v))
+}
+
+// RoundingAmountGTE applies the GTE predicate on the "rounding_amount" field.
+func RoundingAmountGTE(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldGTE(FieldRoundingAmount, v))
+}
+
+// RoundingAmountLT applies the LT predicate on the "rounding_amount" field.
+func RoundingAmountLT(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldLT(FieldRoundingAmount, v))
+}
+
+// RoundingAmountLTE applies the LTE predicate on the "rounding_amount" field.
+func RoundingAmountLTE(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldLTE(FieldRoundingAmount, v))
+}
+
+// RoundingAmountIsNil applies the IsNil predicate on the "rounding_amount" field.
+func RoundingAmountIsNil() predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldIsNull(FieldRoundingAmount))
+}
+
+// RoundingAmountNotNil applies the NotNil predicate on the "rounding_amount" field.
+func RoundingAmountNotNil() predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNotNull(FieldRoundingAmount))
+}
+
+// QuantityEQ applies the EQ predicate on the "quantity" field.
+func QuantityEQ(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldEQ(FieldQuantity, v))
+}
+
+// QuantityNEQ applies the NEQ predicate on the "quantity" field.
+func QuantityNEQ(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNEQ(FieldQuantity, v))
+}
+
+// QuantityIn applies the In predicate on the "quantity" field.
+func QuantityIn(vs ...alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldIn(FieldQuantity, vs...))
+}
+
+// QuantityNotIn applies the NotIn predicate on the "quantity" field.
+func QuantityNotIn(vs ...alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNotIn(FieldQuantity, vs...))
+}
+
+// QuantityGT applies the GT predicate on the "quantity" field.
+func QuantityGT(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldGT(FieldQuantity, v))
+}
+
+// QuantityGTE applies the GTE predicate on the "quantity" field.
+func QuantityGTE(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldGTE(FieldQuantity, v))
+}
+
+// QuantityLT applies the LT predicate on the "quantity" field.
+func QuantityLT(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldLT(FieldQuantity, v))
+}
+
+// QuantityLTE applies the LTE predicate on the "quantity" field.
+func QuantityLTE(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldLTE(FieldQuantity, v))
+}
+
+// QuantityIsNil applies the IsNil predicate on the "quantity" field.
+func QuantityIsNil() predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldIsNull(FieldQuantity))
+}
+
+// QuantityNotNil applies the NotNil predicate on the "quantity" field.
+func QuantityNotNil() predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNotNull(FieldQuantity))
+}
+
+// PreLinePeriodQuantityEQ applies the EQ predicate on the "pre_line_period_quantity" field.
+func PreLinePeriodQuantityEQ(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldEQ(FieldPreLinePeriodQuantity, v))
+}
+
+// PreLinePeriodQuantityNEQ applies the NEQ predicate on the "pre_line_period_quantity" field.
+func PreLinePeriodQuantityNEQ(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNEQ(FieldPreLinePeriodQuantity, v))
+}
+
+// PreLinePeriodQuantityIn applies the In predicate on the "pre_line_period_quantity" field.
+func PreLinePeriodQuantityIn(vs ...alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldIn(FieldPreLinePeriodQuantity, vs...))
+}
+
+// PreLinePeriodQuantityNotIn applies the NotIn predicate on the "pre_line_period_quantity" field.
+func PreLinePeriodQuantityNotIn(vs ...alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNotIn(FieldPreLinePeriodQuantity, vs...))
+}
+
+// PreLinePeriodQuantityGT applies the GT predicate on the "pre_line_period_quantity" field.
+func PreLinePeriodQuantityGT(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldGT(FieldPreLinePeriodQuantity, v))
+}
+
+// PreLinePeriodQuantityGTE applies the GTE predicate on the "pre_line_period_quantity" field.
+func PreLinePeriodQuantityGTE(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldGTE(FieldPreLinePeriodQuantity, v))
+}
+
+// PreLinePeriodQuantityLT applies the LT predicate on the "pre_line_period_quantity" field.
+func PreLinePeriodQuantityLT(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldLT(FieldPreLinePeriodQuantity, v))
+}
+
+// PreLinePeriodQuantityLTE applies the LTE predicate on the "pre_line_period_quantity" field.
+func PreLinePeriodQuantityLTE(v alpacadecimal.Decimal) predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldLTE(FieldPreLinePeriodQuantity, v))
+}
+
+// PreLinePeriodQuantityIsNil applies the IsNil predicate on the "pre_line_period_quantity" field.
+func PreLinePeriodQuantityIsNil() predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldIsNull(FieldPreLinePeriodQuantity))
+}
+
+// PreLinePeriodQuantityNotNil applies the NotNil predicate on the "pre_line_period_quantity" field.
+func PreLinePeriodQuantityNotNil() predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNotNull(FieldPreLinePeriodQuantity))
+}
+
+// SourceDiscountIsNil applies the IsNil predicate on the "source_discount" field.
+func SourceDiscountIsNil() predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldIsNull(FieldSourceDiscount))
+}
+
+// SourceDiscountNotNil applies the NotNil predicate on the "source_discount" field.
+func SourceDiscountNotNil() predicate.BillingInvoiceLineDiscount {
+	return predicate.BillingInvoiceLineDiscount(sql.FieldNotNull(FieldSourceDiscount))
 }
 
 // InvoicingAppExternalIDEQ applies the EQ predicate on the "invoicing_app_external_id" field.

--- a/openmeter/ent/db/billinginvoicelinediscount_create.go
+++ b/openmeter/ent/db/billinginvoicelinediscount_create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicelinediscount"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 )
 
 // BillingInvoiceLineDiscountCreate is the builder for creating a BillingInvoiceLineDiscount entity.
@@ -74,15 +75,21 @@ func (bildc *BillingInvoiceLineDiscountCreate) SetNillableDeletedAt(t *time.Time
 	return bildc
 }
 
-// SetLineID sets the "line_id" field.
-func (bildc *BillingInvoiceLineDiscountCreate) SetLineID(s string) *BillingInvoiceLineDiscountCreate {
-	bildc.mutation.SetLineID(s)
+// SetType sets the "type" field.
+func (bildc *BillingInvoiceLineDiscountCreate) SetType(bdt billing.LineDiscountType) *BillingInvoiceLineDiscountCreate {
+	bildc.mutation.SetType(bdt)
 	return bildc
 }
 
 // SetReason sets the "reason" field.
 func (bildc *BillingInvoiceLineDiscountCreate) SetReason(bdr billing.LineDiscountReason) *BillingInvoiceLineDiscountCreate {
 	bildc.mutation.SetReason(bdr)
+	return bildc
+}
+
+// SetLineID sets the "line_id" field.
+func (bildc *BillingInvoiceLineDiscountCreate) SetLineID(s string) *BillingInvoiceLineDiscountCreate {
+	bildc.mutation.SetLineID(s)
 	return bildc
 }
 
@@ -117,6 +124,62 @@ func (bildc *BillingInvoiceLineDiscountCreate) SetNillableDescription(s *string)
 // SetAmount sets the "amount" field.
 func (bildc *BillingInvoiceLineDiscountCreate) SetAmount(a alpacadecimal.Decimal) *BillingInvoiceLineDiscountCreate {
 	bildc.mutation.SetAmount(a)
+	return bildc
+}
+
+// SetNillableAmount sets the "amount" field if the given value is not nil.
+func (bildc *BillingInvoiceLineDiscountCreate) SetNillableAmount(a *alpacadecimal.Decimal) *BillingInvoiceLineDiscountCreate {
+	if a != nil {
+		bildc.SetAmount(*a)
+	}
+	return bildc
+}
+
+// SetRoundingAmount sets the "rounding_amount" field.
+func (bildc *BillingInvoiceLineDiscountCreate) SetRoundingAmount(a alpacadecimal.Decimal) *BillingInvoiceLineDiscountCreate {
+	bildc.mutation.SetRoundingAmount(a)
+	return bildc
+}
+
+// SetNillableRoundingAmount sets the "rounding_amount" field if the given value is not nil.
+func (bildc *BillingInvoiceLineDiscountCreate) SetNillableRoundingAmount(a *alpacadecimal.Decimal) *BillingInvoiceLineDiscountCreate {
+	if a != nil {
+		bildc.SetRoundingAmount(*a)
+	}
+	return bildc
+}
+
+// SetQuantity sets the "quantity" field.
+func (bildc *BillingInvoiceLineDiscountCreate) SetQuantity(a alpacadecimal.Decimal) *BillingInvoiceLineDiscountCreate {
+	bildc.mutation.SetQuantity(a)
+	return bildc
+}
+
+// SetNillableQuantity sets the "quantity" field if the given value is not nil.
+func (bildc *BillingInvoiceLineDiscountCreate) SetNillableQuantity(a *alpacadecimal.Decimal) *BillingInvoiceLineDiscountCreate {
+	if a != nil {
+		bildc.SetQuantity(*a)
+	}
+	return bildc
+}
+
+// SetPreLinePeriodQuantity sets the "pre_line_period_quantity" field.
+func (bildc *BillingInvoiceLineDiscountCreate) SetPreLinePeriodQuantity(a alpacadecimal.Decimal) *BillingInvoiceLineDiscountCreate {
+	bildc.mutation.SetPreLinePeriodQuantity(a)
+	return bildc
+}
+
+// SetNillablePreLinePeriodQuantity sets the "pre_line_period_quantity" field if the given value is not nil.
+func (bildc *BillingInvoiceLineDiscountCreate) SetNillablePreLinePeriodQuantity(a *alpacadecimal.Decimal) *BillingInvoiceLineDiscountCreate {
+	if a != nil {
+		bildc.SetPreLinePeriodQuantity(*a)
+	}
+	return bildc
+}
+
+// SetSourceDiscount sets the "source_discount" field.
+func (bildc *BillingInvoiceLineDiscountCreate) SetSourceDiscount(pr *productcatalog.Discount) *BillingInvoiceLineDiscountCreate {
+	bildc.mutation.SetSourceDiscount(pr)
 	return bildc
 }
 
@@ -224,8 +287,13 @@ func (bildc *BillingInvoiceLineDiscountCreate) check() error {
 	if _, ok := bildc.mutation.UpdatedAt(); !ok {
 		return &ValidationError{Name: "updated_at", err: errors.New(`db: missing required field "BillingInvoiceLineDiscount.updated_at"`)}
 	}
-	if _, ok := bildc.mutation.LineID(); !ok {
-		return &ValidationError{Name: "line_id", err: errors.New(`db: missing required field "BillingInvoiceLineDiscount.line_id"`)}
+	if _, ok := bildc.mutation.GetType(); !ok {
+		return &ValidationError{Name: "type", err: errors.New(`db: missing required field "BillingInvoiceLineDiscount.type"`)}
+	}
+	if v, ok := bildc.mutation.GetType(); ok {
+		if err := billinginvoicelinediscount.TypeValidator(v); err != nil {
+			return &ValidationError{Name: "type", err: fmt.Errorf(`db: validator failed for field "BillingInvoiceLineDiscount.type": %w`, err)}
+		}
 	}
 	if _, ok := bildc.mutation.Reason(); !ok {
 		return &ValidationError{Name: "reason", err: errors.New(`db: missing required field "BillingInvoiceLineDiscount.reason"`)}
@@ -235,8 +303,13 @@ func (bildc *BillingInvoiceLineDiscountCreate) check() error {
 			return &ValidationError{Name: "reason", err: fmt.Errorf(`db: validator failed for field "BillingInvoiceLineDiscount.reason": %w`, err)}
 		}
 	}
-	if _, ok := bildc.mutation.Amount(); !ok {
-		return &ValidationError{Name: "amount", err: errors.New(`db: missing required field "BillingInvoiceLineDiscount.amount"`)}
+	if _, ok := bildc.mutation.LineID(); !ok {
+		return &ValidationError{Name: "line_id", err: errors.New(`db: missing required field "BillingInvoiceLineDiscount.line_id"`)}
+	}
+	if v, ok := bildc.mutation.SourceDiscount(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "source_discount", err: fmt.Errorf(`db: validator failed for field "BillingInvoiceLineDiscount.source_discount": %w`, err)}
+		}
 	}
 	if len(bildc.mutation.BillingInvoiceLineIDs()) == 0 {
 		return &ValidationError{Name: "billing_invoice_line", err: errors.New(`db: missing required edge "BillingInvoiceLineDiscount.billing_invoice_line"`)}
@@ -248,7 +321,10 @@ func (bildc *BillingInvoiceLineDiscountCreate) sqlSave(ctx context.Context) (*Bi
 	if err := bildc.check(); err != nil {
 		return nil, err
 	}
-	_node, _spec := bildc.createSpec()
+	_node, _spec, err := bildc.createSpec()
+	if err != nil {
+		return nil, err
+	}
 	if err := sqlgraph.CreateNode(ctx, bildc.driver, _spec); err != nil {
 		if sqlgraph.IsConstraintError(err) {
 			err = &ConstraintError{msg: err.Error(), wrap: err}
@@ -267,7 +343,7 @@ func (bildc *BillingInvoiceLineDiscountCreate) sqlSave(ctx context.Context) (*Bi
 	return _node, nil
 }
 
-func (bildc *BillingInvoiceLineDiscountCreate) createSpec() (*BillingInvoiceLineDiscount, *sqlgraph.CreateSpec) {
+func (bildc *BillingInvoiceLineDiscountCreate) createSpec() (*BillingInvoiceLineDiscount, *sqlgraph.CreateSpec, error) {
 	var (
 		_node = &BillingInvoiceLineDiscount{config: bildc.config}
 		_spec = sqlgraph.NewCreateSpec(billinginvoicelinediscount.Table, sqlgraph.NewFieldSpec(billinginvoicelinediscount.FieldID, field.TypeString))
@@ -293,6 +369,10 @@ func (bildc *BillingInvoiceLineDiscountCreate) createSpec() (*BillingInvoiceLine
 		_spec.SetField(billinginvoicelinediscount.FieldDeletedAt, field.TypeTime, value)
 		_node.DeletedAt = &value
 	}
+	if value, ok := bildc.mutation.GetType(); ok {
+		_spec.SetField(billinginvoicelinediscount.FieldType, field.TypeEnum, value)
+		_node.Type = value
+	}
 	if value, ok := bildc.mutation.Reason(); ok {
 		_spec.SetField(billinginvoicelinediscount.FieldReason, field.TypeEnum, value)
 		_node.Reason = value
@@ -307,7 +387,27 @@ func (bildc *BillingInvoiceLineDiscountCreate) createSpec() (*BillingInvoiceLine
 	}
 	if value, ok := bildc.mutation.Amount(); ok {
 		_spec.SetField(billinginvoicelinediscount.FieldAmount, field.TypeOther, value)
-		_node.Amount = value
+		_node.Amount = &value
+	}
+	if value, ok := bildc.mutation.RoundingAmount(); ok {
+		_spec.SetField(billinginvoicelinediscount.FieldRoundingAmount, field.TypeOther, value)
+		_node.RoundingAmount = &value
+	}
+	if value, ok := bildc.mutation.Quantity(); ok {
+		_spec.SetField(billinginvoicelinediscount.FieldQuantity, field.TypeOther, value)
+		_node.Quantity = &value
+	}
+	if value, ok := bildc.mutation.PreLinePeriodQuantity(); ok {
+		_spec.SetField(billinginvoicelinediscount.FieldPreLinePeriodQuantity, field.TypeOther, value)
+		_node.PreLinePeriodQuantity = &value
+	}
+	if value, ok := bildc.mutation.SourceDiscount(); ok {
+		vv, err := billinginvoicelinediscount.ValueScanner.SourceDiscount.Value(value)
+		if err != nil {
+			return nil, nil, err
+		}
+		_spec.SetField(billinginvoicelinediscount.FieldSourceDiscount, field.TypeString, vv)
+		_node.SourceDiscount = value
 	}
 	if value, ok := bildc.mutation.InvoicingAppExternalID(); ok {
 		_spec.SetField(billinginvoicelinediscount.FieldInvoicingAppExternalID, field.TypeString, value)
@@ -330,7 +430,7 @@ func (bildc *BillingInvoiceLineDiscountCreate) createSpec() (*BillingInvoiceLine
 		_node.LineID = nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
-	return _node, _spec
+	return _node, _spec, nil
 }
 
 // OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
@@ -412,15 +512,15 @@ func (u *BillingInvoiceLineDiscountUpsert) ClearDeletedAt() *BillingInvoiceLineD
 	return u
 }
 
-// SetLineID sets the "line_id" field.
-func (u *BillingInvoiceLineDiscountUpsert) SetLineID(v string) *BillingInvoiceLineDiscountUpsert {
-	u.Set(billinginvoicelinediscount.FieldLineID, v)
+// SetType sets the "type" field.
+func (u *BillingInvoiceLineDiscountUpsert) SetType(v billing.LineDiscountType) *BillingInvoiceLineDiscountUpsert {
+	u.Set(billinginvoicelinediscount.FieldType, v)
 	return u
 }
 
-// UpdateLineID sets the "line_id" field to the value that was provided on create.
-func (u *BillingInvoiceLineDiscountUpsert) UpdateLineID() *BillingInvoiceLineDiscountUpsert {
-	u.SetExcluded(billinginvoicelinediscount.FieldLineID)
+// UpdateType sets the "type" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsert) UpdateType() *BillingInvoiceLineDiscountUpsert {
+	u.SetExcluded(billinginvoicelinediscount.FieldType)
 	return u
 }
 
@@ -433,6 +533,18 @@ func (u *BillingInvoiceLineDiscountUpsert) SetReason(v billing.LineDiscountReaso
 // UpdateReason sets the "reason" field to the value that was provided on create.
 func (u *BillingInvoiceLineDiscountUpsert) UpdateReason() *BillingInvoiceLineDiscountUpsert {
 	u.SetExcluded(billinginvoicelinediscount.FieldReason)
+	return u
+}
+
+// SetLineID sets the "line_id" field.
+func (u *BillingInvoiceLineDiscountUpsert) SetLineID(v string) *BillingInvoiceLineDiscountUpsert {
+	u.Set(billinginvoicelinediscount.FieldLineID, v)
+	return u
+}
+
+// UpdateLineID sets the "line_id" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsert) UpdateLineID() *BillingInvoiceLineDiscountUpsert {
+	u.SetExcluded(billinginvoicelinediscount.FieldLineID)
 	return u
 }
 
@@ -481,6 +593,84 @@ func (u *BillingInvoiceLineDiscountUpsert) SetAmount(v alpacadecimal.Decimal) *B
 // UpdateAmount sets the "amount" field to the value that was provided on create.
 func (u *BillingInvoiceLineDiscountUpsert) UpdateAmount() *BillingInvoiceLineDiscountUpsert {
 	u.SetExcluded(billinginvoicelinediscount.FieldAmount)
+	return u
+}
+
+// ClearAmount clears the value of the "amount" field.
+func (u *BillingInvoiceLineDiscountUpsert) ClearAmount() *BillingInvoiceLineDiscountUpsert {
+	u.SetNull(billinginvoicelinediscount.FieldAmount)
+	return u
+}
+
+// SetRoundingAmount sets the "rounding_amount" field.
+func (u *BillingInvoiceLineDiscountUpsert) SetRoundingAmount(v alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpsert {
+	u.Set(billinginvoicelinediscount.FieldRoundingAmount, v)
+	return u
+}
+
+// UpdateRoundingAmount sets the "rounding_amount" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsert) UpdateRoundingAmount() *BillingInvoiceLineDiscountUpsert {
+	u.SetExcluded(billinginvoicelinediscount.FieldRoundingAmount)
+	return u
+}
+
+// ClearRoundingAmount clears the value of the "rounding_amount" field.
+func (u *BillingInvoiceLineDiscountUpsert) ClearRoundingAmount() *BillingInvoiceLineDiscountUpsert {
+	u.SetNull(billinginvoicelinediscount.FieldRoundingAmount)
+	return u
+}
+
+// SetQuantity sets the "quantity" field.
+func (u *BillingInvoiceLineDiscountUpsert) SetQuantity(v alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpsert {
+	u.Set(billinginvoicelinediscount.FieldQuantity, v)
+	return u
+}
+
+// UpdateQuantity sets the "quantity" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsert) UpdateQuantity() *BillingInvoiceLineDiscountUpsert {
+	u.SetExcluded(billinginvoicelinediscount.FieldQuantity)
+	return u
+}
+
+// ClearQuantity clears the value of the "quantity" field.
+func (u *BillingInvoiceLineDiscountUpsert) ClearQuantity() *BillingInvoiceLineDiscountUpsert {
+	u.SetNull(billinginvoicelinediscount.FieldQuantity)
+	return u
+}
+
+// SetPreLinePeriodQuantity sets the "pre_line_period_quantity" field.
+func (u *BillingInvoiceLineDiscountUpsert) SetPreLinePeriodQuantity(v alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpsert {
+	u.Set(billinginvoicelinediscount.FieldPreLinePeriodQuantity, v)
+	return u
+}
+
+// UpdatePreLinePeriodQuantity sets the "pre_line_period_quantity" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsert) UpdatePreLinePeriodQuantity() *BillingInvoiceLineDiscountUpsert {
+	u.SetExcluded(billinginvoicelinediscount.FieldPreLinePeriodQuantity)
+	return u
+}
+
+// ClearPreLinePeriodQuantity clears the value of the "pre_line_period_quantity" field.
+func (u *BillingInvoiceLineDiscountUpsert) ClearPreLinePeriodQuantity() *BillingInvoiceLineDiscountUpsert {
+	u.SetNull(billinginvoicelinediscount.FieldPreLinePeriodQuantity)
+	return u
+}
+
+// SetSourceDiscount sets the "source_discount" field.
+func (u *BillingInvoiceLineDiscountUpsert) SetSourceDiscount(v *productcatalog.Discount) *BillingInvoiceLineDiscountUpsert {
+	u.Set(billinginvoicelinediscount.FieldSourceDiscount, v)
+	return u
+}
+
+// UpdateSourceDiscount sets the "source_discount" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsert) UpdateSourceDiscount() *BillingInvoiceLineDiscountUpsert {
+	u.SetExcluded(billinginvoicelinediscount.FieldSourceDiscount)
+	return u
+}
+
+// ClearSourceDiscount clears the value of the "source_discount" field.
+func (u *BillingInvoiceLineDiscountUpsert) ClearSourceDiscount() *BillingInvoiceLineDiscountUpsert {
+	u.SetNull(billinginvoicelinediscount.FieldSourceDiscount)
 	return u
 }
 
@@ -591,17 +781,17 @@ func (u *BillingInvoiceLineDiscountUpsertOne) ClearDeletedAt() *BillingInvoiceLi
 	})
 }
 
-// SetLineID sets the "line_id" field.
-func (u *BillingInvoiceLineDiscountUpsertOne) SetLineID(v string) *BillingInvoiceLineDiscountUpsertOne {
+// SetType sets the "type" field.
+func (u *BillingInvoiceLineDiscountUpsertOne) SetType(v billing.LineDiscountType) *BillingInvoiceLineDiscountUpsertOne {
 	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
-		s.SetLineID(v)
+		s.SetType(v)
 	})
 }
 
-// UpdateLineID sets the "line_id" field to the value that was provided on create.
-func (u *BillingInvoiceLineDiscountUpsertOne) UpdateLineID() *BillingInvoiceLineDiscountUpsertOne {
+// UpdateType sets the "type" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsertOne) UpdateType() *BillingInvoiceLineDiscountUpsertOne {
 	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
-		s.UpdateLineID()
+		s.UpdateType()
 	})
 }
 
@@ -616,6 +806,20 @@ func (u *BillingInvoiceLineDiscountUpsertOne) SetReason(v billing.LineDiscountRe
 func (u *BillingInvoiceLineDiscountUpsertOne) UpdateReason() *BillingInvoiceLineDiscountUpsertOne {
 	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
 		s.UpdateReason()
+	})
+}
+
+// SetLineID sets the "line_id" field.
+func (u *BillingInvoiceLineDiscountUpsertOne) SetLineID(v string) *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.SetLineID(v)
+	})
+}
+
+// UpdateLineID sets the "line_id" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsertOne) UpdateLineID() *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.UpdateLineID()
 	})
 }
 
@@ -672,6 +876,97 @@ func (u *BillingInvoiceLineDiscountUpsertOne) SetAmount(v alpacadecimal.Decimal)
 func (u *BillingInvoiceLineDiscountUpsertOne) UpdateAmount() *BillingInvoiceLineDiscountUpsertOne {
 	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
 		s.UpdateAmount()
+	})
+}
+
+// ClearAmount clears the value of the "amount" field.
+func (u *BillingInvoiceLineDiscountUpsertOne) ClearAmount() *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.ClearAmount()
+	})
+}
+
+// SetRoundingAmount sets the "rounding_amount" field.
+func (u *BillingInvoiceLineDiscountUpsertOne) SetRoundingAmount(v alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.SetRoundingAmount(v)
+	})
+}
+
+// UpdateRoundingAmount sets the "rounding_amount" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsertOne) UpdateRoundingAmount() *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.UpdateRoundingAmount()
+	})
+}
+
+// ClearRoundingAmount clears the value of the "rounding_amount" field.
+func (u *BillingInvoiceLineDiscountUpsertOne) ClearRoundingAmount() *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.ClearRoundingAmount()
+	})
+}
+
+// SetQuantity sets the "quantity" field.
+func (u *BillingInvoiceLineDiscountUpsertOne) SetQuantity(v alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.SetQuantity(v)
+	})
+}
+
+// UpdateQuantity sets the "quantity" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsertOne) UpdateQuantity() *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.UpdateQuantity()
+	})
+}
+
+// ClearQuantity clears the value of the "quantity" field.
+func (u *BillingInvoiceLineDiscountUpsertOne) ClearQuantity() *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.ClearQuantity()
+	})
+}
+
+// SetPreLinePeriodQuantity sets the "pre_line_period_quantity" field.
+func (u *BillingInvoiceLineDiscountUpsertOne) SetPreLinePeriodQuantity(v alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.SetPreLinePeriodQuantity(v)
+	})
+}
+
+// UpdatePreLinePeriodQuantity sets the "pre_line_period_quantity" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsertOne) UpdatePreLinePeriodQuantity() *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.UpdatePreLinePeriodQuantity()
+	})
+}
+
+// ClearPreLinePeriodQuantity clears the value of the "pre_line_period_quantity" field.
+func (u *BillingInvoiceLineDiscountUpsertOne) ClearPreLinePeriodQuantity() *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.ClearPreLinePeriodQuantity()
+	})
+}
+
+// SetSourceDiscount sets the "source_discount" field.
+func (u *BillingInvoiceLineDiscountUpsertOne) SetSourceDiscount(v *productcatalog.Discount) *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.SetSourceDiscount(v)
+	})
+}
+
+// UpdateSourceDiscount sets the "source_discount" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsertOne) UpdateSourceDiscount() *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.UpdateSourceDiscount()
+	})
+}
+
+// ClearSourceDiscount clears the value of the "source_discount" field.
+func (u *BillingInvoiceLineDiscountUpsertOne) ClearSourceDiscount() *BillingInvoiceLineDiscountUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.ClearSourceDiscount()
 	})
 }
 
@@ -764,7 +1059,10 @@ func (bildcb *BillingInvoiceLineDiscountCreateBulk) Save(ctx context.Context) ([
 				}
 				builder.mutation = mutation
 				var err error
-				nodes[i], specs[i] = builder.createSpec()
+				nodes[i], specs[i], err = builder.createSpec()
+				if err != nil {
+					return nil, err
+				}
 				if i < len(mutators)-1 {
 					_, err = mutators[i+1].Mutate(root, bildcb.builders[i+1].mutation)
 				} else {
@@ -952,17 +1250,17 @@ func (u *BillingInvoiceLineDiscountUpsertBulk) ClearDeletedAt() *BillingInvoiceL
 	})
 }
 
-// SetLineID sets the "line_id" field.
-func (u *BillingInvoiceLineDiscountUpsertBulk) SetLineID(v string) *BillingInvoiceLineDiscountUpsertBulk {
+// SetType sets the "type" field.
+func (u *BillingInvoiceLineDiscountUpsertBulk) SetType(v billing.LineDiscountType) *BillingInvoiceLineDiscountUpsertBulk {
 	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
-		s.SetLineID(v)
+		s.SetType(v)
 	})
 }
 
-// UpdateLineID sets the "line_id" field to the value that was provided on create.
-func (u *BillingInvoiceLineDiscountUpsertBulk) UpdateLineID() *BillingInvoiceLineDiscountUpsertBulk {
+// UpdateType sets the "type" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsertBulk) UpdateType() *BillingInvoiceLineDiscountUpsertBulk {
 	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
-		s.UpdateLineID()
+		s.UpdateType()
 	})
 }
 
@@ -977,6 +1275,20 @@ func (u *BillingInvoiceLineDiscountUpsertBulk) SetReason(v billing.LineDiscountR
 func (u *BillingInvoiceLineDiscountUpsertBulk) UpdateReason() *BillingInvoiceLineDiscountUpsertBulk {
 	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
 		s.UpdateReason()
+	})
+}
+
+// SetLineID sets the "line_id" field.
+func (u *BillingInvoiceLineDiscountUpsertBulk) SetLineID(v string) *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.SetLineID(v)
+	})
+}
+
+// UpdateLineID sets the "line_id" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsertBulk) UpdateLineID() *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.UpdateLineID()
 	})
 }
 
@@ -1033,6 +1345,97 @@ func (u *BillingInvoiceLineDiscountUpsertBulk) SetAmount(v alpacadecimal.Decimal
 func (u *BillingInvoiceLineDiscountUpsertBulk) UpdateAmount() *BillingInvoiceLineDiscountUpsertBulk {
 	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
 		s.UpdateAmount()
+	})
+}
+
+// ClearAmount clears the value of the "amount" field.
+func (u *BillingInvoiceLineDiscountUpsertBulk) ClearAmount() *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.ClearAmount()
+	})
+}
+
+// SetRoundingAmount sets the "rounding_amount" field.
+func (u *BillingInvoiceLineDiscountUpsertBulk) SetRoundingAmount(v alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.SetRoundingAmount(v)
+	})
+}
+
+// UpdateRoundingAmount sets the "rounding_amount" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsertBulk) UpdateRoundingAmount() *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.UpdateRoundingAmount()
+	})
+}
+
+// ClearRoundingAmount clears the value of the "rounding_amount" field.
+func (u *BillingInvoiceLineDiscountUpsertBulk) ClearRoundingAmount() *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.ClearRoundingAmount()
+	})
+}
+
+// SetQuantity sets the "quantity" field.
+func (u *BillingInvoiceLineDiscountUpsertBulk) SetQuantity(v alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.SetQuantity(v)
+	})
+}
+
+// UpdateQuantity sets the "quantity" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsertBulk) UpdateQuantity() *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.UpdateQuantity()
+	})
+}
+
+// ClearQuantity clears the value of the "quantity" field.
+func (u *BillingInvoiceLineDiscountUpsertBulk) ClearQuantity() *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.ClearQuantity()
+	})
+}
+
+// SetPreLinePeriodQuantity sets the "pre_line_period_quantity" field.
+func (u *BillingInvoiceLineDiscountUpsertBulk) SetPreLinePeriodQuantity(v alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.SetPreLinePeriodQuantity(v)
+	})
+}
+
+// UpdatePreLinePeriodQuantity sets the "pre_line_period_quantity" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsertBulk) UpdatePreLinePeriodQuantity() *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.UpdatePreLinePeriodQuantity()
+	})
+}
+
+// ClearPreLinePeriodQuantity clears the value of the "pre_line_period_quantity" field.
+func (u *BillingInvoiceLineDiscountUpsertBulk) ClearPreLinePeriodQuantity() *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.ClearPreLinePeriodQuantity()
+	})
+}
+
+// SetSourceDiscount sets the "source_discount" field.
+func (u *BillingInvoiceLineDiscountUpsertBulk) SetSourceDiscount(v *productcatalog.Discount) *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.SetSourceDiscount(v)
+	})
+}
+
+// UpdateSourceDiscount sets the "source_discount" field to the value that was provided on create.
+func (u *BillingInvoiceLineDiscountUpsertBulk) UpdateSourceDiscount() *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.UpdateSourceDiscount()
+	})
+}
+
+// ClearSourceDiscount clears the value of the "source_discount" field.
+func (u *BillingInvoiceLineDiscountUpsertBulk) ClearSourceDiscount() *BillingInvoiceLineDiscountUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineDiscountUpsert) {
+		s.ClearSourceDiscount()
 	})
 }
 

--- a/openmeter/ent/db/billinginvoicelinediscount_update.go
+++ b/openmeter/ent/db/billinginvoicelinediscount_update.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicelinediscount"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 )
 
 // BillingInvoiceLineDiscountUpdate is the builder for updating BillingInvoiceLineDiscount entities.
@@ -57,16 +58,16 @@ func (bildu *BillingInvoiceLineDiscountUpdate) ClearDeletedAt() *BillingInvoiceL
 	return bildu
 }
 
-// SetLineID sets the "line_id" field.
-func (bildu *BillingInvoiceLineDiscountUpdate) SetLineID(s string) *BillingInvoiceLineDiscountUpdate {
-	bildu.mutation.SetLineID(s)
+// SetType sets the "type" field.
+func (bildu *BillingInvoiceLineDiscountUpdate) SetType(bdt billing.LineDiscountType) *BillingInvoiceLineDiscountUpdate {
+	bildu.mutation.SetType(bdt)
 	return bildu
 }
 
-// SetNillableLineID sets the "line_id" field if the given value is not nil.
-func (bildu *BillingInvoiceLineDiscountUpdate) SetNillableLineID(s *string) *BillingInvoiceLineDiscountUpdate {
-	if s != nil {
-		bildu.SetLineID(*s)
+// SetNillableType sets the "type" field if the given value is not nil.
+func (bildu *BillingInvoiceLineDiscountUpdate) SetNillableType(bdt *billing.LineDiscountType) *BillingInvoiceLineDiscountUpdate {
+	if bdt != nil {
+		bildu.SetType(*bdt)
 	}
 	return bildu
 }
@@ -81,6 +82,20 @@ func (bildu *BillingInvoiceLineDiscountUpdate) SetReason(bdr billing.LineDiscoun
 func (bildu *BillingInvoiceLineDiscountUpdate) SetNillableReason(bdr *billing.LineDiscountReason) *BillingInvoiceLineDiscountUpdate {
 	if bdr != nil {
 		bildu.SetReason(*bdr)
+	}
+	return bildu
+}
+
+// SetLineID sets the "line_id" field.
+func (bildu *BillingInvoiceLineDiscountUpdate) SetLineID(s string) *BillingInvoiceLineDiscountUpdate {
+	bildu.mutation.SetLineID(s)
+	return bildu
+}
+
+// SetNillableLineID sets the "line_id" field if the given value is not nil.
+func (bildu *BillingInvoiceLineDiscountUpdate) SetNillableLineID(s *string) *BillingInvoiceLineDiscountUpdate {
+	if s != nil {
+		bildu.SetLineID(*s)
 	}
 	return bildu
 }
@@ -136,6 +151,84 @@ func (bildu *BillingInvoiceLineDiscountUpdate) SetNillableAmount(a *alpacadecima
 	if a != nil {
 		bildu.SetAmount(*a)
 	}
+	return bildu
+}
+
+// ClearAmount clears the value of the "amount" field.
+func (bildu *BillingInvoiceLineDiscountUpdate) ClearAmount() *BillingInvoiceLineDiscountUpdate {
+	bildu.mutation.ClearAmount()
+	return bildu
+}
+
+// SetRoundingAmount sets the "rounding_amount" field.
+func (bildu *BillingInvoiceLineDiscountUpdate) SetRoundingAmount(a alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdate {
+	bildu.mutation.SetRoundingAmount(a)
+	return bildu
+}
+
+// SetNillableRoundingAmount sets the "rounding_amount" field if the given value is not nil.
+func (bildu *BillingInvoiceLineDiscountUpdate) SetNillableRoundingAmount(a *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdate {
+	if a != nil {
+		bildu.SetRoundingAmount(*a)
+	}
+	return bildu
+}
+
+// ClearRoundingAmount clears the value of the "rounding_amount" field.
+func (bildu *BillingInvoiceLineDiscountUpdate) ClearRoundingAmount() *BillingInvoiceLineDiscountUpdate {
+	bildu.mutation.ClearRoundingAmount()
+	return bildu
+}
+
+// SetQuantity sets the "quantity" field.
+func (bildu *BillingInvoiceLineDiscountUpdate) SetQuantity(a alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdate {
+	bildu.mutation.SetQuantity(a)
+	return bildu
+}
+
+// SetNillableQuantity sets the "quantity" field if the given value is not nil.
+func (bildu *BillingInvoiceLineDiscountUpdate) SetNillableQuantity(a *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdate {
+	if a != nil {
+		bildu.SetQuantity(*a)
+	}
+	return bildu
+}
+
+// ClearQuantity clears the value of the "quantity" field.
+func (bildu *BillingInvoiceLineDiscountUpdate) ClearQuantity() *BillingInvoiceLineDiscountUpdate {
+	bildu.mutation.ClearQuantity()
+	return bildu
+}
+
+// SetPreLinePeriodQuantity sets the "pre_line_period_quantity" field.
+func (bildu *BillingInvoiceLineDiscountUpdate) SetPreLinePeriodQuantity(a alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdate {
+	bildu.mutation.SetPreLinePeriodQuantity(a)
+	return bildu
+}
+
+// SetNillablePreLinePeriodQuantity sets the "pre_line_period_quantity" field if the given value is not nil.
+func (bildu *BillingInvoiceLineDiscountUpdate) SetNillablePreLinePeriodQuantity(a *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdate {
+	if a != nil {
+		bildu.SetPreLinePeriodQuantity(*a)
+	}
+	return bildu
+}
+
+// ClearPreLinePeriodQuantity clears the value of the "pre_line_period_quantity" field.
+func (bildu *BillingInvoiceLineDiscountUpdate) ClearPreLinePeriodQuantity() *BillingInvoiceLineDiscountUpdate {
+	bildu.mutation.ClearPreLinePeriodQuantity()
+	return bildu
+}
+
+// SetSourceDiscount sets the "source_discount" field.
+func (bildu *BillingInvoiceLineDiscountUpdate) SetSourceDiscount(pr *productcatalog.Discount) *BillingInvoiceLineDiscountUpdate {
+	bildu.mutation.SetSourceDiscount(pr)
+	return bildu
+}
+
+// ClearSourceDiscount clears the value of the "source_discount" field.
+func (bildu *BillingInvoiceLineDiscountUpdate) ClearSourceDiscount() *BillingInvoiceLineDiscountUpdate {
+	bildu.mutation.ClearSourceDiscount()
 	return bildu
 }
 
@@ -219,9 +312,19 @@ func (bildu *BillingInvoiceLineDiscountUpdate) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (bildu *BillingInvoiceLineDiscountUpdate) check() error {
+	if v, ok := bildu.mutation.GetType(); ok {
+		if err := billinginvoicelinediscount.TypeValidator(v); err != nil {
+			return &ValidationError{Name: "type", err: fmt.Errorf(`db: validator failed for field "BillingInvoiceLineDiscount.type": %w`, err)}
+		}
+	}
 	if v, ok := bildu.mutation.Reason(); ok {
 		if err := billinginvoicelinediscount.ReasonValidator(v); err != nil {
 			return &ValidationError{Name: "reason", err: fmt.Errorf(`db: validator failed for field "BillingInvoiceLineDiscount.reason": %w`, err)}
+		}
+	}
+	if v, ok := bildu.mutation.SourceDiscount(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "source_discount", err: fmt.Errorf(`db: validator failed for field "BillingInvoiceLineDiscount.source_discount": %w`, err)}
 		}
 	}
 	if bildu.mutation.BillingInvoiceLineCleared() && len(bildu.mutation.BillingInvoiceLineIDs()) > 0 {
@@ -251,6 +354,9 @@ func (bildu *BillingInvoiceLineDiscountUpdate) sqlSave(ctx context.Context) (n i
 	if bildu.mutation.DeletedAtCleared() {
 		_spec.ClearField(billinginvoicelinediscount.FieldDeletedAt, field.TypeTime)
 	}
+	if value, ok := bildu.mutation.GetType(); ok {
+		_spec.SetField(billinginvoicelinediscount.FieldType, field.TypeEnum, value)
+	}
 	if value, ok := bildu.mutation.Reason(); ok {
 		_spec.SetField(billinginvoicelinediscount.FieldReason, field.TypeEnum, value)
 	}
@@ -268,6 +374,37 @@ func (bildu *BillingInvoiceLineDiscountUpdate) sqlSave(ctx context.Context) (n i
 	}
 	if value, ok := bildu.mutation.Amount(); ok {
 		_spec.SetField(billinginvoicelinediscount.FieldAmount, field.TypeOther, value)
+	}
+	if bildu.mutation.AmountCleared() {
+		_spec.ClearField(billinginvoicelinediscount.FieldAmount, field.TypeOther)
+	}
+	if value, ok := bildu.mutation.RoundingAmount(); ok {
+		_spec.SetField(billinginvoicelinediscount.FieldRoundingAmount, field.TypeOther, value)
+	}
+	if bildu.mutation.RoundingAmountCleared() {
+		_spec.ClearField(billinginvoicelinediscount.FieldRoundingAmount, field.TypeOther)
+	}
+	if value, ok := bildu.mutation.Quantity(); ok {
+		_spec.SetField(billinginvoicelinediscount.FieldQuantity, field.TypeOther, value)
+	}
+	if bildu.mutation.QuantityCleared() {
+		_spec.ClearField(billinginvoicelinediscount.FieldQuantity, field.TypeOther)
+	}
+	if value, ok := bildu.mutation.PreLinePeriodQuantity(); ok {
+		_spec.SetField(billinginvoicelinediscount.FieldPreLinePeriodQuantity, field.TypeOther, value)
+	}
+	if bildu.mutation.PreLinePeriodQuantityCleared() {
+		_spec.ClearField(billinginvoicelinediscount.FieldPreLinePeriodQuantity, field.TypeOther)
+	}
+	if value, ok := bildu.mutation.SourceDiscount(); ok {
+		vv, err := billinginvoicelinediscount.ValueScanner.SourceDiscount.Value(value)
+		if err != nil {
+			return 0, err
+		}
+		_spec.SetField(billinginvoicelinediscount.FieldSourceDiscount, field.TypeString, vv)
+	}
+	if bildu.mutation.SourceDiscountCleared() {
+		_spec.ClearField(billinginvoicelinediscount.FieldSourceDiscount, field.TypeString)
 	}
 	if value, ok := bildu.mutation.InvoicingAppExternalID(); ok {
 		_spec.SetField(billinginvoicelinediscount.FieldInvoicingAppExternalID, field.TypeString, value)
@@ -350,16 +487,16 @@ func (bilduo *BillingInvoiceLineDiscountUpdateOne) ClearDeletedAt() *BillingInvo
 	return bilduo
 }
 
-// SetLineID sets the "line_id" field.
-func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetLineID(s string) *BillingInvoiceLineDiscountUpdateOne {
-	bilduo.mutation.SetLineID(s)
+// SetType sets the "type" field.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetType(bdt billing.LineDiscountType) *BillingInvoiceLineDiscountUpdateOne {
+	bilduo.mutation.SetType(bdt)
 	return bilduo
 }
 
-// SetNillableLineID sets the "line_id" field if the given value is not nil.
-func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetNillableLineID(s *string) *BillingInvoiceLineDiscountUpdateOne {
-	if s != nil {
-		bilduo.SetLineID(*s)
+// SetNillableType sets the "type" field if the given value is not nil.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetNillableType(bdt *billing.LineDiscountType) *BillingInvoiceLineDiscountUpdateOne {
+	if bdt != nil {
+		bilduo.SetType(*bdt)
 	}
 	return bilduo
 }
@@ -374,6 +511,20 @@ func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetReason(bdr billing.LineDis
 func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetNillableReason(bdr *billing.LineDiscountReason) *BillingInvoiceLineDiscountUpdateOne {
 	if bdr != nil {
 		bilduo.SetReason(*bdr)
+	}
+	return bilduo
+}
+
+// SetLineID sets the "line_id" field.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetLineID(s string) *BillingInvoiceLineDiscountUpdateOne {
+	bilduo.mutation.SetLineID(s)
+	return bilduo
+}
+
+// SetNillableLineID sets the "line_id" field if the given value is not nil.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetNillableLineID(s *string) *BillingInvoiceLineDiscountUpdateOne {
+	if s != nil {
+		bilduo.SetLineID(*s)
 	}
 	return bilduo
 }
@@ -429,6 +580,84 @@ func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetNillableAmount(a *alpacade
 	if a != nil {
 		bilduo.SetAmount(*a)
 	}
+	return bilduo
+}
+
+// ClearAmount clears the value of the "amount" field.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) ClearAmount() *BillingInvoiceLineDiscountUpdateOne {
+	bilduo.mutation.ClearAmount()
+	return bilduo
+}
+
+// SetRoundingAmount sets the "rounding_amount" field.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetRoundingAmount(a alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdateOne {
+	bilduo.mutation.SetRoundingAmount(a)
+	return bilduo
+}
+
+// SetNillableRoundingAmount sets the "rounding_amount" field if the given value is not nil.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetNillableRoundingAmount(a *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdateOne {
+	if a != nil {
+		bilduo.SetRoundingAmount(*a)
+	}
+	return bilduo
+}
+
+// ClearRoundingAmount clears the value of the "rounding_amount" field.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) ClearRoundingAmount() *BillingInvoiceLineDiscountUpdateOne {
+	bilduo.mutation.ClearRoundingAmount()
+	return bilduo
+}
+
+// SetQuantity sets the "quantity" field.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetQuantity(a alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdateOne {
+	bilduo.mutation.SetQuantity(a)
+	return bilduo
+}
+
+// SetNillableQuantity sets the "quantity" field if the given value is not nil.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetNillableQuantity(a *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdateOne {
+	if a != nil {
+		bilduo.SetQuantity(*a)
+	}
+	return bilduo
+}
+
+// ClearQuantity clears the value of the "quantity" field.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) ClearQuantity() *BillingInvoiceLineDiscountUpdateOne {
+	bilduo.mutation.ClearQuantity()
+	return bilduo
+}
+
+// SetPreLinePeriodQuantity sets the "pre_line_period_quantity" field.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetPreLinePeriodQuantity(a alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdateOne {
+	bilduo.mutation.SetPreLinePeriodQuantity(a)
+	return bilduo
+}
+
+// SetNillablePreLinePeriodQuantity sets the "pre_line_period_quantity" field if the given value is not nil.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetNillablePreLinePeriodQuantity(a *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdateOne {
+	if a != nil {
+		bilduo.SetPreLinePeriodQuantity(*a)
+	}
+	return bilduo
+}
+
+// ClearPreLinePeriodQuantity clears the value of the "pre_line_period_quantity" field.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) ClearPreLinePeriodQuantity() *BillingInvoiceLineDiscountUpdateOne {
+	bilduo.mutation.ClearPreLinePeriodQuantity()
+	return bilduo
+}
+
+// SetSourceDiscount sets the "source_discount" field.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) SetSourceDiscount(pr *productcatalog.Discount) *BillingInvoiceLineDiscountUpdateOne {
+	bilduo.mutation.SetSourceDiscount(pr)
+	return bilduo
+}
+
+// ClearSourceDiscount clears the value of the "source_discount" field.
+func (bilduo *BillingInvoiceLineDiscountUpdateOne) ClearSourceDiscount() *BillingInvoiceLineDiscountUpdateOne {
+	bilduo.mutation.ClearSourceDiscount()
 	return bilduo
 }
 
@@ -525,9 +754,19 @@ func (bilduo *BillingInvoiceLineDiscountUpdateOne) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (bilduo *BillingInvoiceLineDiscountUpdateOne) check() error {
+	if v, ok := bilduo.mutation.GetType(); ok {
+		if err := billinginvoicelinediscount.TypeValidator(v); err != nil {
+			return &ValidationError{Name: "type", err: fmt.Errorf(`db: validator failed for field "BillingInvoiceLineDiscount.type": %w`, err)}
+		}
+	}
 	if v, ok := bilduo.mutation.Reason(); ok {
 		if err := billinginvoicelinediscount.ReasonValidator(v); err != nil {
 			return &ValidationError{Name: "reason", err: fmt.Errorf(`db: validator failed for field "BillingInvoiceLineDiscount.reason": %w`, err)}
+		}
+	}
+	if v, ok := bilduo.mutation.SourceDiscount(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "source_discount", err: fmt.Errorf(`db: validator failed for field "BillingInvoiceLineDiscount.source_discount": %w`, err)}
 		}
 	}
 	if bilduo.mutation.BillingInvoiceLineCleared() && len(bilduo.mutation.BillingInvoiceLineIDs()) > 0 {
@@ -574,6 +813,9 @@ func (bilduo *BillingInvoiceLineDiscountUpdateOne) sqlSave(ctx context.Context) 
 	if bilduo.mutation.DeletedAtCleared() {
 		_spec.ClearField(billinginvoicelinediscount.FieldDeletedAt, field.TypeTime)
 	}
+	if value, ok := bilduo.mutation.GetType(); ok {
+		_spec.SetField(billinginvoicelinediscount.FieldType, field.TypeEnum, value)
+	}
 	if value, ok := bilduo.mutation.Reason(); ok {
 		_spec.SetField(billinginvoicelinediscount.FieldReason, field.TypeEnum, value)
 	}
@@ -591,6 +833,37 @@ func (bilduo *BillingInvoiceLineDiscountUpdateOne) sqlSave(ctx context.Context) 
 	}
 	if value, ok := bilduo.mutation.Amount(); ok {
 		_spec.SetField(billinginvoicelinediscount.FieldAmount, field.TypeOther, value)
+	}
+	if bilduo.mutation.AmountCleared() {
+		_spec.ClearField(billinginvoicelinediscount.FieldAmount, field.TypeOther)
+	}
+	if value, ok := bilduo.mutation.RoundingAmount(); ok {
+		_spec.SetField(billinginvoicelinediscount.FieldRoundingAmount, field.TypeOther, value)
+	}
+	if bilduo.mutation.RoundingAmountCleared() {
+		_spec.ClearField(billinginvoicelinediscount.FieldRoundingAmount, field.TypeOther)
+	}
+	if value, ok := bilduo.mutation.Quantity(); ok {
+		_spec.SetField(billinginvoicelinediscount.FieldQuantity, field.TypeOther, value)
+	}
+	if bilduo.mutation.QuantityCleared() {
+		_spec.ClearField(billinginvoicelinediscount.FieldQuantity, field.TypeOther)
+	}
+	if value, ok := bilduo.mutation.PreLinePeriodQuantity(); ok {
+		_spec.SetField(billinginvoicelinediscount.FieldPreLinePeriodQuantity, field.TypeOther, value)
+	}
+	if bilduo.mutation.PreLinePeriodQuantityCleared() {
+		_spec.ClearField(billinginvoicelinediscount.FieldPreLinePeriodQuantity, field.TypeOther)
+	}
+	if value, ok := bilduo.mutation.SourceDiscount(); ok {
+		vv, err := billinginvoicelinediscount.ValueScanner.SourceDiscount.Value(value)
+		if err != nil {
+			return nil, err
+		}
+		_spec.SetField(billinginvoicelinediscount.FieldSourceDiscount, field.TypeString, vv)
+	}
+	if bilduo.mutation.SourceDiscountCleared() {
+		_spec.ClearField(billinginvoicelinediscount.FieldSourceDiscount, field.TypeString)
 	}
 	if value, ok := bilduo.mutation.InvoicingAppExternalID(); ok {
 		_spec.SetField(billinginvoicelinediscount.FieldInvoicingAppExternalID, field.TypeString, value)

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -622,7 +622,7 @@ var (
 		{Name: "name", Type: field.TypeString},
 		{Name: "description", Type: field.TypeString, Nullable: true},
 		{Name: "invoice_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
-		{Name: "type", Type: field.TypeString},
+		{Name: "type", Type: field.TypeEnum, Enums: []string{"amount", "usage"}},
 		{Name: "amount", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "line_ids", Type: field.TypeJSON, Nullable: true},
 	}
@@ -815,10 +815,15 @@ var (
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
+		{Name: "type", Type: field.TypeEnum, Enums: []string{"amount", "usage"}},
 		{Name: "reason", Type: field.TypeEnum, Enums: []string{"maximum_spend", "ratecard_discount"}},
 		{Name: "child_unique_reference_id", Type: field.TypeString, Nullable: true},
 		{Name: "description", Type: field.TypeString, Nullable: true},
-		{Name: "amount", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
+		{Name: "amount", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "numeric"}},
+		{Name: "rounding_amount", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "numeric"}},
+		{Name: "quantity", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "numeric"}},
+		{Name: "pre_line_period_quantity", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "numeric"}},
+		{Name: "source_discount", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "invoicing_app_external_id", Type: field.TypeString, Nullable: true},
 		{Name: "line_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 	}
@@ -830,7 +835,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "billing_invoice_line_discounts_billing_invoice_lines_line_discounts",
-				Columns:    []*schema.Column{BillingInvoiceLineDiscountsColumns[10]},
+				Columns:    []*schema.Column{BillingInvoiceLineDiscountsColumns[15]},
 				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -849,12 +854,12 @@ var (
 			{
 				Name:    "billinginvoicelinediscount_namespace_line_id",
 				Unique:  false,
-				Columns: []*schema.Column{BillingInvoiceLineDiscountsColumns[1], BillingInvoiceLineDiscountsColumns[10]},
+				Columns: []*schema.Column{BillingInvoiceLineDiscountsColumns[1], BillingInvoiceLineDiscountsColumns[15]},
 			},
 			{
 				Name:    "billinginvoicelinediscount_namespace_line_id_child_unique_reference_id",
 				Unique:  true,
-				Columns: []*schema.Column{BillingInvoiceLineDiscountsColumns[1], BillingInvoiceLineDiscountsColumns[10], BillingInvoiceLineDiscountsColumns[6]},
+				Columns: []*schema.Column{BillingInvoiceLineDiscountsColumns[1], BillingInvoiceLineDiscountsColumns[15], BillingInvoiceLineDiscountsColumns[7]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "child_unique_reference_id IS NOT NULL AND deleted_at IS NULL",
 				},

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -13834,7 +13834,7 @@ type BillingInvoiceDiscountMutation struct {
 	name           *string
 	description    *string
 	invoice_id     *string
-	_type          *string
+	_type          *billing.LineDiscountType
 	amount         *alpacadecimal.Decimal
 	line_ids       *[]string
 	appendline_ids []string
@@ -14276,12 +14276,12 @@ func (m *BillingInvoiceDiscountMutation) ResetInvoiceID() {
 }
 
 // SetType sets the "type" field.
-func (m *BillingInvoiceDiscountMutation) SetType(s string) {
-	m._type = &s
+func (m *BillingInvoiceDiscountMutation) SetType(bdt billing.LineDiscountType) {
+	m._type = &bdt
 }
 
 // GetType returns the value of the "type" field in the mutation.
-func (m *BillingInvoiceDiscountMutation) GetType() (r string, exists bool) {
+func (m *BillingInvoiceDiscountMutation) GetType() (r billing.LineDiscountType, exists bool) {
 	v := m._type
 	if v == nil {
 		return
@@ -14292,7 +14292,7 @@ func (m *BillingInvoiceDiscountMutation) GetType() (r string, exists bool) {
 // OldType returns the old "type" field's value of the BillingInvoiceDiscount entity.
 // If the BillingInvoiceDiscount object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *BillingInvoiceDiscountMutation) OldType(ctx context.Context) (v string, err error) {
+func (m *BillingInvoiceDiscountMutation) OldType(ctx context.Context) (v billing.LineDiscountType, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldType is only allowed on UpdateOne operations")
 	}
@@ -14607,7 +14607,7 @@ func (m *BillingInvoiceDiscountMutation) SetField(name string, value ent.Value) 
 		m.SetInvoiceID(v)
 		return nil
 	case billinginvoicediscount.FieldType:
-		v, ok := value.(string)
+		v, ok := value.(billing.LineDiscountType)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -18085,10 +18085,15 @@ type BillingInvoiceLineDiscountMutation struct {
 	created_at                  *time.Time
 	updated_at                  *time.Time
 	deleted_at                  *time.Time
+	_type                       *billing.LineDiscountType
 	reason                      *billing.LineDiscountReason
 	child_unique_reference_id   *string
 	description                 *string
 	amount                      *alpacadecimal.Decimal
+	rounding_amount             *alpacadecimal.Decimal
+	quantity                    *alpacadecimal.Decimal
+	pre_line_period_quantity    *alpacadecimal.Decimal
+	source_discount             **productcatalog.Discount
 	invoicing_app_external_id   *string
 	clearedFields               map[string]struct{}
 	billing_invoice_line        *string
@@ -18359,40 +18364,40 @@ func (m *BillingInvoiceLineDiscountMutation) ResetDeletedAt() {
 	delete(m.clearedFields, billinginvoicelinediscount.FieldDeletedAt)
 }
 
-// SetLineID sets the "line_id" field.
-func (m *BillingInvoiceLineDiscountMutation) SetLineID(s string) {
-	m.billing_invoice_line = &s
+// SetType sets the "type" field.
+func (m *BillingInvoiceLineDiscountMutation) SetType(bdt billing.LineDiscountType) {
+	m._type = &bdt
 }
 
-// LineID returns the value of the "line_id" field in the mutation.
-func (m *BillingInvoiceLineDiscountMutation) LineID() (r string, exists bool) {
-	v := m.billing_invoice_line
+// GetType returns the value of the "type" field in the mutation.
+func (m *BillingInvoiceLineDiscountMutation) GetType() (r billing.LineDiscountType, exists bool) {
+	v := m._type
 	if v == nil {
 		return
 	}
 	return *v, true
 }
 
-// OldLineID returns the old "line_id" field's value of the BillingInvoiceLineDiscount entity.
+// OldType returns the old "type" field's value of the BillingInvoiceLineDiscount entity.
 // If the BillingInvoiceLineDiscount object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *BillingInvoiceLineDiscountMutation) OldLineID(ctx context.Context) (v string, err error) {
+func (m *BillingInvoiceLineDiscountMutation) OldType(ctx context.Context) (v billing.LineDiscountType, err error) {
 	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldLineID is only allowed on UpdateOne operations")
+		return v, errors.New("OldType is only allowed on UpdateOne operations")
 	}
 	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldLineID requires an ID field in the mutation")
+		return v, errors.New("OldType requires an ID field in the mutation")
 	}
 	oldValue, err := m.oldValue(ctx)
 	if err != nil {
-		return v, fmt.Errorf("querying old value for OldLineID: %w", err)
+		return v, fmt.Errorf("querying old value for OldType: %w", err)
 	}
-	return oldValue.LineID, nil
+	return oldValue.Type, nil
 }
 
-// ResetLineID resets all changes to the "line_id" field.
-func (m *BillingInvoiceLineDiscountMutation) ResetLineID() {
-	m.billing_invoice_line = nil
+// ResetType resets all changes to the "type" field.
+func (m *BillingInvoiceLineDiscountMutation) ResetType() {
+	m._type = nil
 }
 
 // SetReason sets the "reason" field.
@@ -18429,6 +18434,42 @@ func (m *BillingInvoiceLineDiscountMutation) OldReason(ctx context.Context) (v b
 // ResetReason resets all changes to the "reason" field.
 func (m *BillingInvoiceLineDiscountMutation) ResetReason() {
 	m.reason = nil
+}
+
+// SetLineID sets the "line_id" field.
+func (m *BillingInvoiceLineDiscountMutation) SetLineID(s string) {
+	m.billing_invoice_line = &s
+}
+
+// LineID returns the value of the "line_id" field in the mutation.
+func (m *BillingInvoiceLineDiscountMutation) LineID() (r string, exists bool) {
+	v := m.billing_invoice_line
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldLineID returns the old "line_id" field's value of the BillingInvoiceLineDiscount entity.
+// If the BillingInvoiceLineDiscount object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BillingInvoiceLineDiscountMutation) OldLineID(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldLineID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldLineID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldLineID: %w", err)
+	}
+	return oldValue.LineID, nil
+}
+
+// ResetLineID resets all changes to the "line_id" field.
+func (m *BillingInvoiceLineDiscountMutation) ResetLineID() {
+	m.billing_invoice_line = nil
 }
 
 // SetChildUniqueReferenceID sets the "child_unique_reference_id" field.
@@ -18546,7 +18587,7 @@ func (m *BillingInvoiceLineDiscountMutation) Amount() (r alpacadecimal.Decimal, 
 // OldAmount returns the old "amount" field's value of the BillingInvoiceLineDiscount entity.
 // If the BillingInvoiceLineDiscount object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *BillingInvoiceLineDiscountMutation) OldAmount(ctx context.Context) (v alpacadecimal.Decimal, err error) {
+func (m *BillingInvoiceLineDiscountMutation) OldAmount(ctx context.Context) (v *alpacadecimal.Decimal, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldAmount is only allowed on UpdateOne operations")
 	}
@@ -18560,9 +18601,218 @@ func (m *BillingInvoiceLineDiscountMutation) OldAmount(ctx context.Context) (v a
 	return oldValue.Amount, nil
 }
 
+// ClearAmount clears the value of the "amount" field.
+func (m *BillingInvoiceLineDiscountMutation) ClearAmount() {
+	m.amount = nil
+	m.clearedFields[billinginvoicelinediscount.FieldAmount] = struct{}{}
+}
+
+// AmountCleared returns if the "amount" field was cleared in this mutation.
+func (m *BillingInvoiceLineDiscountMutation) AmountCleared() bool {
+	_, ok := m.clearedFields[billinginvoicelinediscount.FieldAmount]
+	return ok
+}
+
 // ResetAmount resets all changes to the "amount" field.
 func (m *BillingInvoiceLineDiscountMutation) ResetAmount() {
 	m.amount = nil
+	delete(m.clearedFields, billinginvoicelinediscount.FieldAmount)
+}
+
+// SetRoundingAmount sets the "rounding_amount" field.
+func (m *BillingInvoiceLineDiscountMutation) SetRoundingAmount(a alpacadecimal.Decimal) {
+	m.rounding_amount = &a
+}
+
+// RoundingAmount returns the value of the "rounding_amount" field in the mutation.
+func (m *BillingInvoiceLineDiscountMutation) RoundingAmount() (r alpacadecimal.Decimal, exists bool) {
+	v := m.rounding_amount
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRoundingAmount returns the old "rounding_amount" field's value of the BillingInvoiceLineDiscount entity.
+// If the BillingInvoiceLineDiscount object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BillingInvoiceLineDiscountMutation) OldRoundingAmount(ctx context.Context) (v *alpacadecimal.Decimal, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRoundingAmount is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRoundingAmount requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRoundingAmount: %w", err)
+	}
+	return oldValue.RoundingAmount, nil
+}
+
+// ClearRoundingAmount clears the value of the "rounding_amount" field.
+func (m *BillingInvoiceLineDiscountMutation) ClearRoundingAmount() {
+	m.rounding_amount = nil
+	m.clearedFields[billinginvoicelinediscount.FieldRoundingAmount] = struct{}{}
+}
+
+// RoundingAmountCleared returns if the "rounding_amount" field was cleared in this mutation.
+func (m *BillingInvoiceLineDiscountMutation) RoundingAmountCleared() bool {
+	_, ok := m.clearedFields[billinginvoicelinediscount.FieldRoundingAmount]
+	return ok
+}
+
+// ResetRoundingAmount resets all changes to the "rounding_amount" field.
+func (m *BillingInvoiceLineDiscountMutation) ResetRoundingAmount() {
+	m.rounding_amount = nil
+	delete(m.clearedFields, billinginvoicelinediscount.FieldRoundingAmount)
+}
+
+// SetQuantity sets the "quantity" field.
+func (m *BillingInvoiceLineDiscountMutation) SetQuantity(a alpacadecimal.Decimal) {
+	m.quantity = &a
+}
+
+// Quantity returns the value of the "quantity" field in the mutation.
+func (m *BillingInvoiceLineDiscountMutation) Quantity() (r alpacadecimal.Decimal, exists bool) {
+	v := m.quantity
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldQuantity returns the old "quantity" field's value of the BillingInvoiceLineDiscount entity.
+// If the BillingInvoiceLineDiscount object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BillingInvoiceLineDiscountMutation) OldQuantity(ctx context.Context) (v *alpacadecimal.Decimal, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldQuantity is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldQuantity requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldQuantity: %w", err)
+	}
+	return oldValue.Quantity, nil
+}
+
+// ClearQuantity clears the value of the "quantity" field.
+func (m *BillingInvoiceLineDiscountMutation) ClearQuantity() {
+	m.quantity = nil
+	m.clearedFields[billinginvoicelinediscount.FieldQuantity] = struct{}{}
+}
+
+// QuantityCleared returns if the "quantity" field was cleared in this mutation.
+func (m *BillingInvoiceLineDiscountMutation) QuantityCleared() bool {
+	_, ok := m.clearedFields[billinginvoicelinediscount.FieldQuantity]
+	return ok
+}
+
+// ResetQuantity resets all changes to the "quantity" field.
+func (m *BillingInvoiceLineDiscountMutation) ResetQuantity() {
+	m.quantity = nil
+	delete(m.clearedFields, billinginvoicelinediscount.FieldQuantity)
+}
+
+// SetPreLinePeriodQuantity sets the "pre_line_period_quantity" field.
+func (m *BillingInvoiceLineDiscountMutation) SetPreLinePeriodQuantity(a alpacadecimal.Decimal) {
+	m.pre_line_period_quantity = &a
+}
+
+// PreLinePeriodQuantity returns the value of the "pre_line_period_quantity" field in the mutation.
+func (m *BillingInvoiceLineDiscountMutation) PreLinePeriodQuantity() (r alpacadecimal.Decimal, exists bool) {
+	v := m.pre_line_period_quantity
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPreLinePeriodQuantity returns the old "pre_line_period_quantity" field's value of the BillingInvoiceLineDiscount entity.
+// If the BillingInvoiceLineDiscount object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BillingInvoiceLineDiscountMutation) OldPreLinePeriodQuantity(ctx context.Context) (v *alpacadecimal.Decimal, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPreLinePeriodQuantity is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPreLinePeriodQuantity requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPreLinePeriodQuantity: %w", err)
+	}
+	return oldValue.PreLinePeriodQuantity, nil
+}
+
+// ClearPreLinePeriodQuantity clears the value of the "pre_line_period_quantity" field.
+func (m *BillingInvoiceLineDiscountMutation) ClearPreLinePeriodQuantity() {
+	m.pre_line_period_quantity = nil
+	m.clearedFields[billinginvoicelinediscount.FieldPreLinePeriodQuantity] = struct{}{}
+}
+
+// PreLinePeriodQuantityCleared returns if the "pre_line_period_quantity" field was cleared in this mutation.
+func (m *BillingInvoiceLineDiscountMutation) PreLinePeriodQuantityCleared() bool {
+	_, ok := m.clearedFields[billinginvoicelinediscount.FieldPreLinePeriodQuantity]
+	return ok
+}
+
+// ResetPreLinePeriodQuantity resets all changes to the "pre_line_period_quantity" field.
+func (m *BillingInvoiceLineDiscountMutation) ResetPreLinePeriodQuantity() {
+	m.pre_line_period_quantity = nil
+	delete(m.clearedFields, billinginvoicelinediscount.FieldPreLinePeriodQuantity)
+}
+
+// SetSourceDiscount sets the "source_discount" field.
+func (m *BillingInvoiceLineDiscountMutation) SetSourceDiscount(pr *productcatalog.Discount) {
+	m.source_discount = &pr
+}
+
+// SourceDiscount returns the value of the "source_discount" field in the mutation.
+func (m *BillingInvoiceLineDiscountMutation) SourceDiscount() (r *productcatalog.Discount, exists bool) {
+	v := m.source_discount
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSourceDiscount returns the old "source_discount" field's value of the BillingInvoiceLineDiscount entity.
+// If the BillingInvoiceLineDiscount object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BillingInvoiceLineDiscountMutation) OldSourceDiscount(ctx context.Context) (v *productcatalog.Discount, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSourceDiscount is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSourceDiscount requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSourceDiscount: %w", err)
+	}
+	return oldValue.SourceDiscount, nil
+}
+
+// ClearSourceDiscount clears the value of the "source_discount" field.
+func (m *BillingInvoiceLineDiscountMutation) ClearSourceDiscount() {
+	m.source_discount = nil
+	m.clearedFields[billinginvoicelinediscount.FieldSourceDiscount] = struct{}{}
+}
+
+// SourceDiscountCleared returns if the "source_discount" field was cleared in this mutation.
+func (m *BillingInvoiceLineDiscountMutation) SourceDiscountCleared() bool {
+	_, ok := m.clearedFields[billinginvoicelinediscount.FieldSourceDiscount]
+	return ok
+}
+
+// ResetSourceDiscount resets all changes to the "source_discount" field.
+func (m *BillingInvoiceLineDiscountMutation) ResetSourceDiscount() {
+	m.source_discount = nil
+	delete(m.clearedFields, billinginvoicelinediscount.FieldSourceDiscount)
 }
 
 // SetInvoicingAppExternalID sets the "invoicing_app_external_id" field.
@@ -18688,7 +18938,7 @@ func (m *BillingInvoiceLineDiscountMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *BillingInvoiceLineDiscountMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 15)
 	if m.namespace != nil {
 		fields = append(fields, billinginvoicelinediscount.FieldNamespace)
 	}
@@ -18701,11 +18951,14 @@ func (m *BillingInvoiceLineDiscountMutation) Fields() []string {
 	if m.deleted_at != nil {
 		fields = append(fields, billinginvoicelinediscount.FieldDeletedAt)
 	}
-	if m.billing_invoice_line != nil {
-		fields = append(fields, billinginvoicelinediscount.FieldLineID)
+	if m._type != nil {
+		fields = append(fields, billinginvoicelinediscount.FieldType)
 	}
 	if m.reason != nil {
 		fields = append(fields, billinginvoicelinediscount.FieldReason)
+	}
+	if m.billing_invoice_line != nil {
+		fields = append(fields, billinginvoicelinediscount.FieldLineID)
 	}
 	if m.child_unique_reference_id != nil {
 		fields = append(fields, billinginvoicelinediscount.FieldChildUniqueReferenceID)
@@ -18715,6 +18968,18 @@ func (m *BillingInvoiceLineDiscountMutation) Fields() []string {
 	}
 	if m.amount != nil {
 		fields = append(fields, billinginvoicelinediscount.FieldAmount)
+	}
+	if m.rounding_amount != nil {
+		fields = append(fields, billinginvoicelinediscount.FieldRoundingAmount)
+	}
+	if m.quantity != nil {
+		fields = append(fields, billinginvoicelinediscount.FieldQuantity)
+	}
+	if m.pre_line_period_quantity != nil {
+		fields = append(fields, billinginvoicelinediscount.FieldPreLinePeriodQuantity)
+	}
+	if m.source_discount != nil {
+		fields = append(fields, billinginvoicelinediscount.FieldSourceDiscount)
 	}
 	if m.invoicing_app_external_id != nil {
 		fields = append(fields, billinginvoicelinediscount.FieldInvoicingAppExternalID)
@@ -18735,16 +19000,26 @@ func (m *BillingInvoiceLineDiscountMutation) Field(name string) (ent.Value, bool
 		return m.UpdatedAt()
 	case billinginvoicelinediscount.FieldDeletedAt:
 		return m.DeletedAt()
-	case billinginvoicelinediscount.FieldLineID:
-		return m.LineID()
+	case billinginvoicelinediscount.FieldType:
+		return m.GetType()
 	case billinginvoicelinediscount.FieldReason:
 		return m.Reason()
+	case billinginvoicelinediscount.FieldLineID:
+		return m.LineID()
 	case billinginvoicelinediscount.FieldChildUniqueReferenceID:
 		return m.ChildUniqueReferenceID()
 	case billinginvoicelinediscount.FieldDescription:
 		return m.Description()
 	case billinginvoicelinediscount.FieldAmount:
 		return m.Amount()
+	case billinginvoicelinediscount.FieldRoundingAmount:
+		return m.RoundingAmount()
+	case billinginvoicelinediscount.FieldQuantity:
+		return m.Quantity()
+	case billinginvoicelinediscount.FieldPreLinePeriodQuantity:
+		return m.PreLinePeriodQuantity()
+	case billinginvoicelinediscount.FieldSourceDiscount:
+		return m.SourceDiscount()
 	case billinginvoicelinediscount.FieldInvoicingAppExternalID:
 		return m.InvoicingAppExternalID()
 	}
@@ -18764,16 +19039,26 @@ func (m *BillingInvoiceLineDiscountMutation) OldField(ctx context.Context, name 
 		return m.OldUpdatedAt(ctx)
 	case billinginvoicelinediscount.FieldDeletedAt:
 		return m.OldDeletedAt(ctx)
-	case billinginvoicelinediscount.FieldLineID:
-		return m.OldLineID(ctx)
+	case billinginvoicelinediscount.FieldType:
+		return m.OldType(ctx)
 	case billinginvoicelinediscount.FieldReason:
 		return m.OldReason(ctx)
+	case billinginvoicelinediscount.FieldLineID:
+		return m.OldLineID(ctx)
 	case billinginvoicelinediscount.FieldChildUniqueReferenceID:
 		return m.OldChildUniqueReferenceID(ctx)
 	case billinginvoicelinediscount.FieldDescription:
 		return m.OldDescription(ctx)
 	case billinginvoicelinediscount.FieldAmount:
 		return m.OldAmount(ctx)
+	case billinginvoicelinediscount.FieldRoundingAmount:
+		return m.OldRoundingAmount(ctx)
+	case billinginvoicelinediscount.FieldQuantity:
+		return m.OldQuantity(ctx)
+	case billinginvoicelinediscount.FieldPreLinePeriodQuantity:
+		return m.OldPreLinePeriodQuantity(ctx)
+	case billinginvoicelinediscount.FieldSourceDiscount:
+		return m.OldSourceDiscount(ctx)
 	case billinginvoicelinediscount.FieldInvoicingAppExternalID:
 		return m.OldInvoicingAppExternalID(ctx)
 	}
@@ -18813,12 +19098,12 @@ func (m *BillingInvoiceLineDiscountMutation) SetField(name string, value ent.Val
 		}
 		m.SetDeletedAt(v)
 		return nil
-	case billinginvoicelinediscount.FieldLineID:
-		v, ok := value.(string)
+	case billinginvoicelinediscount.FieldType:
+		v, ok := value.(billing.LineDiscountType)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
-		m.SetLineID(v)
+		m.SetType(v)
 		return nil
 	case billinginvoicelinediscount.FieldReason:
 		v, ok := value.(billing.LineDiscountReason)
@@ -18826,6 +19111,13 @@ func (m *BillingInvoiceLineDiscountMutation) SetField(name string, value ent.Val
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetReason(v)
+		return nil
+	case billinginvoicelinediscount.FieldLineID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetLineID(v)
 		return nil
 	case billinginvoicelinediscount.FieldChildUniqueReferenceID:
 		v, ok := value.(string)
@@ -18847,6 +19139,34 @@ func (m *BillingInvoiceLineDiscountMutation) SetField(name string, value ent.Val
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetAmount(v)
+		return nil
+	case billinginvoicelinediscount.FieldRoundingAmount:
+		v, ok := value.(alpacadecimal.Decimal)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRoundingAmount(v)
+		return nil
+	case billinginvoicelinediscount.FieldQuantity:
+		v, ok := value.(alpacadecimal.Decimal)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetQuantity(v)
+		return nil
+	case billinginvoicelinediscount.FieldPreLinePeriodQuantity:
+		v, ok := value.(alpacadecimal.Decimal)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPreLinePeriodQuantity(v)
+		return nil
+	case billinginvoicelinediscount.FieldSourceDiscount:
+		v, ok := value.(*productcatalog.Discount)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSourceDiscount(v)
 		return nil
 	case billinginvoicelinediscount.FieldInvoicingAppExternalID:
 		v, ok := value.(string)
@@ -18894,6 +19214,21 @@ func (m *BillingInvoiceLineDiscountMutation) ClearedFields() []string {
 	if m.FieldCleared(billinginvoicelinediscount.FieldDescription) {
 		fields = append(fields, billinginvoicelinediscount.FieldDescription)
 	}
+	if m.FieldCleared(billinginvoicelinediscount.FieldAmount) {
+		fields = append(fields, billinginvoicelinediscount.FieldAmount)
+	}
+	if m.FieldCleared(billinginvoicelinediscount.FieldRoundingAmount) {
+		fields = append(fields, billinginvoicelinediscount.FieldRoundingAmount)
+	}
+	if m.FieldCleared(billinginvoicelinediscount.FieldQuantity) {
+		fields = append(fields, billinginvoicelinediscount.FieldQuantity)
+	}
+	if m.FieldCleared(billinginvoicelinediscount.FieldPreLinePeriodQuantity) {
+		fields = append(fields, billinginvoicelinediscount.FieldPreLinePeriodQuantity)
+	}
+	if m.FieldCleared(billinginvoicelinediscount.FieldSourceDiscount) {
+		fields = append(fields, billinginvoicelinediscount.FieldSourceDiscount)
+	}
 	if m.FieldCleared(billinginvoicelinediscount.FieldInvoicingAppExternalID) {
 		fields = append(fields, billinginvoicelinediscount.FieldInvoicingAppExternalID)
 	}
@@ -18920,6 +19255,21 @@ func (m *BillingInvoiceLineDiscountMutation) ClearField(name string) error {
 	case billinginvoicelinediscount.FieldDescription:
 		m.ClearDescription()
 		return nil
+	case billinginvoicelinediscount.FieldAmount:
+		m.ClearAmount()
+		return nil
+	case billinginvoicelinediscount.FieldRoundingAmount:
+		m.ClearRoundingAmount()
+		return nil
+	case billinginvoicelinediscount.FieldQuantity:
+		m.ClearQuantity()
+		return nil
+	case billinginvoicelinediscount.FieldPreLinePeriodQuantity:
+		m.ClearPreLinePeriodQuantity()
+		return nil
+	case billinginvoicelinediscount.FieldSourceDiscount:
+		m.ClearSourceDiscount()
+		return nil
 	case billinginvoicelinediscount.FieldInvoicingAppExternalID:
 		m.ClearInvoicingAppExternalID()
 		return nil
@@ -18943,11 +19293,14 @@ func (m *BillingInvoiceLineDiscountMutation) ResetField(name string) error {
 	case billinginvoicelinediscount.FieldDeletedAt:
 		m.ResetDeletedAt()
 		return nil
-	case billinginvoicelinediscount.FieldLineID:
-		m.ResetLineID()
+	case billinginvoicelinediscount.FieldType:
+		m.ResetType()
 		return nil
 	case billinginvoicelinediscount.FieldReason:
 		m.ResetReason()
+		return nil
+	case billinginvoicelinediscount.FieldLineID:
+		m.ResetLineID()
 		return nil
 	case billinginvoicelinediscount.FieldChildUniqueReferenceID:
 		m.ResetChildUniqueReferenceID()
@@ -18957,6 +19310,18 @@ func (m *BillingInvoiceLineDiscountMutation) ResetField(name string) error {
 		return nil
 	case billinginvoicelinediscount.FieldAmount:
 		m.ResetAmount()
+		return nil
+	case billinginvoicelinediscount.FieldRoundingAmount:
+		m.ResetRoundingAmount()
+		return nil
+	case billinginvoicelinediscount.FieldQuantity:
+		m.ResetQuantity()
+		return nil
+	case billinginvoicelinediscount.FieldPreLinePeriodQuantity:
+		m.ResetPreLinePeriodQuantity()
+		return nil
+	case billinginvoicelinediscount.FieldSourceDiscount:
+		m.ResetSourceDiscount()
 		return nil
 	case billinginvoicelinediscount.FieldInvoicingAppExternalID:
 		m.ResetInvoicingAppExternalID()

--- a/openmeter/ent/db/predicate/predicate.go
+++ b/openmeter/ent/db/predicate/predicate.go
@@ -81,6 +81,17 @@ func BillingInvoiceLineOrErr(p BillingInvoiceLine, err error) BillingInvoiceLine
 // BillingInvoiceLineDiscount is the predicate function for billinginvoicelinediscount builders.
 type BillingInvoiceLineDiscount func(*sql.Selector)
 
+// BillingInvoiceLineDiscountOrErr calls the predicate only if the error is not nit.
+func BillingInvoiceLineDiscountOrErr(p BillingInvoiceLineDiscount, err error) BillingInvoiceLineDiscount {
+	return func(s *sql.Selector) {
+		if err != nil {
+			s.AddError(err)
+			return
+		}
+		p(s)
+	}
+}
+
 // BillingInvoiceUsageBasedLineConfig is the predicate function for billinginvoiceusagebasedlineconfig builders.
 type BillingInvoiceUsageBasedLineConfig func(*sql.Selector)
 

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -512,6 +512,9 @@ func init() {
 	billinginvoicelinediscount.DefaultUpdatedAt = billinginvoicelinediscountDescUpdatedAt.Default.(func() time.Time)
 	// billinginvoicelinediscount.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	billinginvoicelinediscount.UpdateDefaultUpdatedAt = billinginvoicelinediscountDescUpdatedAt.UpdateDefault.(func() time.Time)
+	// billinginvoicelinediscountDescSourceDiscount is the schema descriptor for source_discount field.
+	billinginvoicelinediscountDescSourceDiscount := billinginvoicelinediscountFields[9].Descriptor()
+	billinginvoicelinediscount.ValueScanner.SourceDiscount = billinginvoicelinediscountDescSourceDiscount.ValueScanner.(field.TypeValueScanner[*productcatalog.Discount])
 	// billinginvoicelinediscountDescID is the schema descriptor for id field.
 	billinginvoicelinediscountDescID := billinginvoicelinediscountMixinFields0[0].Descriptor()
 	// billinginvoicelinediscount.DefaultID holds the default value on creation for the id field.

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -1189,6 +1189,76 @@ func (u *BillingInvoiceLineDiscountUpdateOne) SetOrClearDescription(value *strin
 	return u.SetDescription(*value)
 }
 
+func (u *BillingInvoiceLineDiscountUpdate) SetOrClearAmount(value *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdate {
+	if value == nil {
+		return u.ClearAmount()
+	}
+	return u.SetAmount(*value)
+}
+
+func (u *BillingInvoiceLineDiscountUpdateOne) SetOrClearAmount(value *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdateOne {
+	if value == nil {
+		return u.ClearAmount()
+	}
+	return u.SetAmount(*value)
+}
+
+func (u *BillingInvoiceLineDiscountUpdate) SetOrClearRoundingAmount(value *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdate {
+	if value == nil {
+		return u.ClearRoundingAmount()
+	}
+	return u.SetRoundingAmount(*value)
+}
+
+func (u *BillingInvoiceLineDiscountUpdateOne) SetOrClearRoundingAmount(value *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdateOne {
+	if value == nil {
+		return u.ClearRoundingAmount()
+	}
+	return u.SetRoundingAmount(*value)
+}
+
+func (u *BillingInvoiceLineDiscountUpdate) SetOrClearQuantity(value *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdate {
+	if value == nil {
+		return u.ClearQuantity()
+	}
+	return u.SetQuantity(*value)
+}
+
+func (u *BillingInvoiceLineDiscountUpdateOne) SetOrClearQuantity(value *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdateOne {
+	if value == nil {
+		return u.ClearQuantity()
+	}
+	return u.SetQuantity(*value)
+}
+
+func (u *BillingInvoiceLineDiscountUpdate) SetOrClearPreLinePeriodQuantity(value *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdate {
+	if value == nil {
+		return u.ClearPreLinePeriodQuantity()
+	}
+	return u.SetPreLinePeriodQuantity(*value)
+}
+
+func (u *BillingInvoiceLineDiscountUpdateOne) SetOrClearPreLinePeriodQuantity(value *alpacadecimal.Decimal) *BillingInvoiceLineDiscountUpdateOne {
+	if value == nil {
+		return u.ClearPreLinePeriodQuantity()
+	}
+	return u.SetPreLinePeriodQuantity(*value)
+}
+
+func (u *BillingInvoiceLineDiscountUpdate) SetOrClearSourceDiscount(value **productcatalog.Discount) *BillingInvoiceLineDiscountUpdate {
+	if value == nil {
+		return u.ClearSourceDiscount()
+	}
+	return u.SetSourceDiscount(*value)
+}
+
+func (u *BillingInvoiceLineDiscountUpdateOne) SetOrClearSourceDiscount(value **productcatalog.Discount) *BillingInvoiceLineDiscountUpdateOne {
+	if value == nil {
+		return u.ClearSourceDiscount()
+	}
+	return u.SetSourceDiscount(*value)
+}
+
 func (u *BillingInvoiceLineDiscountUpdate) SetOrClearInvoicingAppExternalID(value *string) *BillingInvoiceLineDiscountUpdate {
 	if value == nil {
 		return u.ClearInvoicingAppExternalID()

--- a/openmeter/ent/schema/billing.go
+++ b/openmeter/ent/schema/billing.go
@@ -511,13 +511,16 @@ func (BillingInvoiceLineDiscount) Mixin() []ent.Mixin {
 
 func (BillingInvoiceLineDiscount) Fields() []ent.Field {
 	return []ent.Field{
+		field.Enum("type").
+			GoType(billing.LineDiscountType("")),
+
+		field.Enum("reason").
+			GoType(billing.LineDiscountReason("")),
+
 		field.String("line_id").
 			SchemaType(map[string]string{
 				"postgres": "char(26)",
 			}),
-
-		field.Enum("reason").
-			GoType(billing.LineDiscountReason("")),
 
 		field.String("child_unique_reference_id").
 			Optional().
@@ -530,7 +533,39 @@ func (BillingInvoiceLineDiscount) Fields() []ent.Field {
 		field.Other("amount", alpacadecimal.Decimal{}).
 			SchemaType(map[string]string{
 				"postgres": "numeric",
+			}).
+			Optional().
+			Nillable(),
+
+		field.Other("rounding_amount", alpacadecimal.Decimal{}).
+			SchemaType(map[string]string{
+				"postgres": "numeric",
+			}).
+			Optional().
+			Nillable(),
+
+		field.Other("quantity", alpacadecimal.Decimal{}).
+			SchemaType(map[string]string{
+				"postgres": "numeric",
+			}).
+			Optional().
+			Nillable(),
+
+		field.Other("pre_line_period_quantity", alpacadecimal.Decimal{}).
+			Optional().
+			Nillable().
+			SchemaType(map[string]string{
+				"postgres": "numeric",
 			}),
+
+		field.String("source_discount").
+			GoType(&productcatalog.Discount{}).
+			ValueScanner(DiscountValueScanner).
+			SchemaType(map[string]string{
+				dialect.Postgres: "jsonb",
+			}).
+			Optional().
+			Nillable(),
 
 		// ID of the line discount in the external invoicing app
 		// For example, Stripe invoice line item ID
@@ -579,7 +614,8 @@ func (BillingInvoiceDiscount) Fields() []ent.Field {
 				"postgres": "char(26)",
 			}),
 
-		field.String("type"),
+		field.Enum("type").
+			GoType(billing.LineDiscountType("")),
 
 		field.Other("amount", alpacadecimal.Decimal{}).
 			SchemaType(map[string]string{

--- a/openmeter/ent/schema/productcatalog.go
+++ b/openmeter/ent/schema/productcatalog.go
@@ -215,6 +215,7 @@ var (
 	TaxConfigValueScanner           = entutils.JSONStringValueScanner[*productcatalog.TaxConfig]()
 	PriceValueScanner               = entutils.JSONStringValueScanner[*productcatalog.Price]()
 	DiscountsValueScanner           = entutils.JSONStringValueScanner[*productcatalog.Discounts]()
+	DiscountValueScanner            = entutils.JSONStringValueScanner[*productcatalog.Discount]()
 )
 
 // AlignmentMixin for Alignment config

--- a/openmeter/productcatalog/discount.go
+++ b/openmeter/productcatalog/discount.go
@@ -7,6 +7,7 @@ import (
 
 	decimal "github.com/alpacahq/alpacadecimal"
 
+	"github.com/openmeterio/openmeter/pkg/equal"
 	"github.com/openmeterio/openmeter/pkg/hasher"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -215,6 +216,21 @@ func (d *Discount) FromUsage(discount UsageDiscount) {
 	d.t = UsageDiscountType
 }
 
+func (d Discount) Equal(other Discount) bool {
+	if d.t != other.t {
+		return false
+	}
+
+	switch d.t {
+	case PercentageDiscountType:
+		return equal.HasherPtrEqual(d.percentage, other.percentage)
+	case UsageDiscountType:
+		return equal.HasherPtrEqual(d.usage, other.usage)
+	default:
+		return false
+	}
+}
+
 func NewDiscountFrom[T PercentageDiscount | UsageDiscount](v T) Discount {
 	d := Discount{}
 
@@ -349,12 +365,12 @@ func (d Discounts) Equal(v Discounts) bool {
 		return false
 	}
 
-	leftSet := make(map[uint64]struct{})
+	leftSet := make(map[hasher.Hash]struct{})
 	for _, discount := range d {
 		leftSet[discount.Hash()] = struct{}{}
 	}
 
-	rightSet := make(map[uint64]struct{})
+	rightSet := make(map[hasher.Hash]struct{})
 	for _, discount := range v {
 		rightSet[discount.Hash()] = struct{}{}
 	}

--- a/pkg/equal/equal.go
+++ b/pkg/equal/equal.go
@@ -1,10 +1,16 @@
 package equal
 
-type Comparable[T any] interface {
+import (
+	"github.com/openmeterio/openmeter/pkg/hasher"
+)
+
+// Equaler is an interface that can be used to compare two objects.
+// This is already present in models, but we need it here so that we can avoid a circular dependency.
+type Equaler[T any] interface {
 	Equal(other T) bool
 }
 
-func PtrEqual[T Comparable[T]](a, b *T) bool {
+func PtrEqual[T Equaler[T]](a, b *T) bool {
 	if a == nil && b == nil {
 		return true
 	}
@@ -14,4 +20,16 @@ func PtrEqual[T Comparable[T]](a, b *T) bool {
 	}
 
 	return (*a).Equal(*b)
+}
+
+func HasherPtrEqual[T hasher.Hasher](a, b *T) bool {
+	if a == nil && b == nil {
+		return true
+	}
+
+	if a == nil || b == nil {
+		return false
+	}
+
+	return (*a).Hash() == (*b).Hash()
 }

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/equal"
 )
 
 type ManagedUniqueResource struct {
@@ -133,6 +134,22 @@ func (m ManagedModel) IsDeletedAt(t time.Time) bool {
 	}
 
 	return !m.DeletedAt.After(t)
+}
+
+func (m ManagedModel) Equal(other ManagedModel) bool {
+	if !m.CreatedAt.Equal(other.CreatedAt) {
+		return false
+	}
+
+	if !m.UpdatedAt.Equal(other.UpdatedAt) {
+		return false
+	}
+
+	if !equal.PtrEqual(m.DeletedAt, other.DeletedAt) {
+		return false
+	}
+
+	return true
 }
 
 type NamespacedModel struct {

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -559,8 +559,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 			}
 
 			for _, discount := range line.Discounts {
-				if discount.Description != nil && group[0][2] == *discount.Description {
-					return discount.ID
+				if s.getDiscountDecription(discount) != "" && group[0][2] == s.getDiscountDecription(discount) {
+					return discount.GetID()
 				}
 			}
 
@@ -1113,4 +1113,17 @@ func mapInvoiceItemParamsToInvoiceItem(id string, i *stripe.InvoiceItemParams) s
 			Metadata: i.Metadata,
 		},
 	}
+}
+
+func (s *StripeInvoiceTestSuite) getDiscountDecription(discount billing.LineDiscount) string {
+	s.T().Helper()
+
+	base, err := discount.AsDiscountBase()
+	s.NoError(err)
+
+	if base.Description == nil {
+		return ""
+	}
+
+	return *base.Description
 }

--- a/tools/migrate/migrations/20250407191828_billing-line-discount-unit-support.down.sql
+++ b/tools/migrate/migrations/20250407191828_billing-line-discount-unit-support.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "billing_invoice_line_discounts" table
+ALTER TABLE "billing_invoice_line_discounts" DROP COLUMN "source_discount", DROP COLUMN "pre_line_period_quantity", DROP COLUMN "quantity", DROP COLUMN "rounding_amount", DROP COLUMN "type", ALTER COLUMN "amount" SET NOT NULL;

--- a/tools/migrate/migrations/20250407191828_billing-line-discount-unit-support.up.sql
+++ b/tools/migrate/migrations/20250407191828_billing-line-discount-unit-support.up.sql
@@ -1,0 +1,5 @@
+-- modify "billing_invoice_line_discounts" table
+ALTER TABLE "billing_invoice_line_discounts" ALTER COLUMN "amount" DROP NOT NULL, ADD COLUMN "type" character varying NOT NULL DEFAULT 'amount', ADD COLUMN "rounding_amount" numeric NULL DEFAULT 0, ADD COLUMN "quantity" numeric NULL, ADD COLUMN "pre_line_period_quantity" numeric NULL, ADD COLUMN "source_discount" jsonb NULL;
+
+ALTER TABLE "billing_invoice_line_discounts" ALTER COLUMN "type" DROP DEFAULT;
+ALTER TABLE "billing_invoice_line_discounts" ALTER COLUMN "rounding_amount" DROP DEFAULT;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:sNuQIhFtEztVeVlRoQK/I22PrjVv33P+E9ukdF148sY=
+h1:KsyQaWwxH1x/GUxdkCClkGEPz432NIsYrZrDlp8iVig=
 20240826120919_init.down.sql h1:AIbgwwngjkJEYa3yRZsIXQyBa2+qoZttwMXHxXEbHLI=
 20240826120919_init.up.sql h1:/hYHWF3Z3dab8SMKnw99ixVktCuJe2bAw5wstCZIEN8=
 20240903155435_entitlement-expired-index.down.sql h1:np2xgYs3KQ2z7qPBcobtGNhqWQ3V8NwEP9E5U3TmpSA=
@@ -157,3 +157,5 @@ h1:sNuQIhFtEztVeVlRoQK/I22PrjVv33P+E9ukdF148sY=
 20250405193107_addon-instance-type.up.sql h1:sPbBMyoVCqdadLv5yJwv0a29mwmBL1hZBlMgGMcl4gs=
 20250406215430_billing-line-discount-reason.down.sql h1:/nvecNFsikhlgUHGrwUJbACOriKiRAm2A4pyTyIw69Q=
 20250406215430_billing-line-discount-reason.up.sql h1:E2/fFyfuMJyYx1bv/yA3HG+iZQ7c9GlmwnnNDQ+2V4Q=
+20250407191828_billing-line-discount-unit-support.down.sql h1:L2kR0v0WGd0jkFyx2zCGb9M7+RvOWM/fNoeNVIyHfIc=
+20250407191828_billing-line-discount-unit-support.up.sql h1:RyFdJJl1BxQonfhIRQWRa4X6t0GFkRe3SxjNpqFSU/U=


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch adds a union type over the previous amount based discounts to support unit discounts, so that we can persist both amount and unit based discounts for lines.

The current implementation uses a single table, as for line diffing that's the preferred, and makes implementation easier.

We are also using immutable types (contrary to lines) as we don't need to maintain parent/child references in this codepath.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced discount processing to better support amount-based and usage-based discounts.
  - Introduced additional discount attributes for invoices, such as rounding, quantity, and external discount details.

- **Refactor / Bug Fixes**
  - Streamlined validation and error reporting in discount calculations during invoice creation and updates.
  - Improved consistency in discount mapping and merging for accurate invoice totals.

- **Tests**
  - Strengthened test coverage to ensure robust discount handling and reliable invoicing outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->