### PR TITLE
fix: nil ptr deref in billing worker

### DIFF
--- a/openmeter/billing/worker/subscription/sync.go
+++ b/openmeter/billing/worker/subscription/sync.go
@@ -474,11 +474,11 @@ func (h *Handler) shouldProrateFlatFee(price productcatalog.FlatPrice) bool {
 	}
 }
 
-func (h *Handler) provisionPendingLines(ctx context.Context, subs subscription.SubscriptionView, currency currencyx.Calculator, line []subscriptionItemWithPeriod) error {
-	newLines, err := slicesx.MapWithErr(line, func(subsItem subscriptionItemWithPeriod) (*billing.LineWithCustomer, error) {
+func (h *Handler) provisionPendingLines(ctx context.Context, subs subscription.SubscriptionView, currency currencyx.Calculator, subsItems []subscriptionItemWithPeriod) error {
+	newLines, err := slicesx.MapWithErr(subsItems, func(subsItem subscriptionItemWithPeriod) (*billing.LineWithCustomer, error) {
 		line, err := h.lineFromSubscritionRateCard(subs, subsItem, currency)
 		if err != nil {
-			return nil, fmt.Errorf("generating line[%s]: %w", line.ID, err)
+			return nil, fmt.Errorf("generating line from subscription item [%s]: %w", subsItem.SubscriptionItem.ID, err)
 		}
 
 		if line == nil {


### PR DESCRIPTION
## Overview

Fix nil pointer dereference in billing worker where `line.ID` was logged even when the `line` is `nil` due to the `lineFromSubscritionRateCard` returning an error. The main issue was that the `line` variable was shadowed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messaging in subscription handling to offer more precise context when issues occur.
- **Refactor**
  - Enhanced internal processing for subscription management to ensure greater clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->