### PR TITLE
feat: add plan-addon compatibility

### DIFF
--- a/openmeter/productcatalog/assignment.go
+++ b/openmeter/productcatalog/assignment.go
@@ -1,0 +1,98 @@
+package productcatalog
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+var (
+	_ models.Validator                            = (*PlanAddonAssignment)(nil)
+	_ models.CustomValidator[PlanAddonAssignment] = (*PlanAddonAssignment)(nil)
+)
+
+type PlanAddonAssignment struct {
+	// Addon
+	Plan Plan `json:"plan"`
+
+	// Addon
+	Addon Addon `json:"addon"`
+
+	// FromPhase
+	FromPlanPhase int `json:"fromPlanPhase"`
+
+	// MaxQuantity
+	MaxQuantity *int `json:"maxQuantity"`
+}
+
+func (c PlanAddonAssignment) ValidateWith(validators ...models.ValidatorFunc[PlanAddonAssignment]) error {
+	return models.Validate(c, validators...)
+}
+
+func (c PlanAddonAssignment) Validate() error {
+	var errs []error
+
+	// Validate config
+
+	switch c.Addon.InstanceType {
+	case AddonInstanceTypeMultiple:
+		if c.MaxQuantity != nil && *c.MaxQuantity <= 0 {
+			errs = append(errs,
+				fmt.Errorf("maxQuantity must be set to positive number for add-on with multiple instance type [addon.key=%s addon.version=%d]",
+					c.Addon.Key, c.Addon.Version),
+			)
+		}
+	case AddonInstanceTypeSingle:
+		if c.MaxQuantity != nil {
+			errs = append(errs,
+				fmt.Errorf("maxQuantity must not be set for add-on with single instance type [addon.key=%s addon.version=%d]",
+					c.Addon.Key, c.Addon.Version),
+			)
+		}
+	}
+
+	// Validate plan
+
+	// Plan must be active.
+	if c.Plan.Status() != PlanStatusActive {
+		errs = append(errs,
+			fmt.Errorf("invalid plan: status must be active [plan.key=%s plan.version=%d]",
+				c.Plan.Key, c.Plan.Version),
+		)
+	}
+
+	// Validate add-on
+
+	// Add-on must be active and the effective period of add-on must be open-ended
+	// as we do not support scheduled changes for add-ons.
+	if c.Addon.Status() != AddonStatusActive || c.Addon.EffectiveTo != nil {
+		errs = append(errs,
+			fmt.Errorf("invalid add-on: status must be active [addon.key=%s addon.version=%d]",
+				c.Addon.Key, c.Addon.Version),
+		)
+	}
+
+	// validate plan with add-on
+
+	// Currency must match.
+	if c.Addon.Currency != c.Plan.Currency {
+		errs = append(errs, errors.New("currency mismatch"))
+	}
+
+	// Validate ratecards from plan phases and addon.
+	for idx, phase := range c.Plan.Phases {
+		if idx < c.FromPlanPhase {
+			continue
+		}
+
+		// If ratecards can be merged then they are compatible.
+		if err := phase.RateCards.Compatible(c.Addon.RateCards); err != nil {
+			errs = append(errs,
+				fmt.Errorf("invalid phase [phase.key=%s]: ratecards cannot be merged: %w", phase.Key, err),
+			)
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}

--- a/openmeter/productcatalog/entitlement.go
+++ b/openmeter/productcatalog/entitlement.go
@@ -168,27 +168,48 @@ func (e *EntitlementTemplate) Type() entitlement.EntitlementType {
 }
 
 func (e *EntitlementTemplate) AsMetered() (MeteredEntitlementTemplate, error) {
-	if e.t == "" || e.metered == nil {
+	switch e.t {
+	case entitlement.EntitlementTypeMetered:
+		if e.metered == nil {
+			return MeteredEntitlementTemplate{}, errors.New("invalid metered entitlement template: not initialized")
+		}
+
+		return *e.metered, nil
+	case entitlement.EntitlementTypeBoolean, entitlement.EntitlementTypeStatic:
+		return MeteredEntitlementTemplate{}, fmt.Errorf("invalid entitlement template: type mismatch: %s", e.t)
+	default:
 		return MeteredEntitlementTemplate{}, errors.New("invalid entitlement template: not initialized")
 	}
-
-	return *e.metered, nil
 }
 
 func (e *EntitlementTemplate) AsStatic() (StaticEntitlementTemplate, error) {
-	if e.t == "" || e.static == nil {
+	switch e.t {
+	case entitlement.EntitlementTypeStatic:
+		if e.static == nil {
+			return StaticEntitlementTemplate{}, errors.New("invalid static entitlement template: not initialized")
+		}
+
+		return *e.static, nil
+	case entitlement.EntitlementTypeBoolean, entitlement.EntitlementTypeMetered:
+		return StaticEntitlementTemplate{}, fmt.Errorf("invalid entitlement template: type mismatch: %s", e.t)
+	default:
 		return StaticEntitlementTemplate{}, errors.New("invalid entitlement template: not initialized")
 	}
-
-	return *e.static, nil
 }
 
 func (e *EntitlementTemplate) AsBoolean() (BooleanEntitlementTemplate, error) {
-	if e.t == "" || e.boolean == nil {
+	switch e.t {
+	case entitlement.EntitlementTypeBoolean:
+		if e.boolean == nil {
+			return BooleanEntitlementTemplate{}, errors.New("invalid boolean entitlement template: not initialized")
+		}
+
+		return *e.boolean, nil
+	case entitlement.EntitlementTypeStatic, entitlement.EntitlementTypeMetered:
+		return BooleanEntitlementTemplate{}, fmt.Errorf("invalid entitlement template: type mismatch: %s", e.t)
+	default:
 		return BooleanEntitlementTemplate{}, errors.New("invalid entitlement template: not initialized")
 	}
-
-	return *e.boolean, nil
 }
 
 func (e *EntitlementTemplate) FromMetered(t MeteredEntitlementTemplate) {


### PR DESCRIPTION
## Overview

* add new `PlanAddonAssignment` type which describes the association of `Addon` to a `Plan`
* add support for cehcking compatibility of `Addon` and `Plan` resources and their ratecards


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new add-on assignment capability for the product catalog, featuring robust validations for quantity constraints, active statuses, and compatibility checks.
	- Enhanced entitlement processing with explicit type handling and clearer error messaging.
	- Upgraded plan validations with flexible rule sets and status verifications.
	- Improved rate card compatibility checks to ensure consistency in pricing, features, and billing configurations.
	- Added comprehensive tests for rate card compatibility scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->