### PR TITLE
fix(collector): filter out completed phase from runai workloads

### DIFF
--- a/collector/benthos/input/runai/workloads.go
+++ b/collector/benthos/input/runai/workloads.go
@@ -89,6 +89,7 @@ func (s *Service) ListWorkloads(ctx context.Context, params ListWorkloadParams) 
 		"Updating",
 		"Stopped",
 		"Stopping",
+		"Completed",
 		// "Degraded",
 		"Failed",
 	}


### PR DESCRIPTION
Filter out completed workloads from the Run:ai workload listing.