### PR TITLE
Refactor Periods

### DIFF
--- a/openmeter/billing/worker/subscription/phaseiterator.go
+++ b/openmeter/billing/worker/subscription/phaseiterator.go
@@ -193,7 +193,7 @@ func (it *PhaseIterator) generateAligned(iterationEnd time.Time) ([]subscription
 				}
 
 				// Period otherwise is truncated by activeFrom and activeTo times
-				period := timeutil.Period{
+				period := timeutil.ClosedPeriod{
 					From: nonTruncatedPeriod.From,
 					To:   nonTruncatedPeriod.To,
 				}

--- a/openmeter/credit/balance/service.go
+++ b/openmeter/credit/balance/service.go
@@ -67,7 +67,7 @@ func (s *service) GetLatestValidAt(ctx context.Context, owner models.NamespacedI
 			return Snapshot{}, err
 		}
 
-		usage, err := s.UsageQuerier.QueryUsage(ctx, owner, timeutil.Period{
+		usage, err := s.UsageQuerier.QueryUsage(ctx, owner, timeutil.ClosedPeriod{
 			From: periodStart,
 			To:   res.At,
 		})

--- a/openmeter/credit/balance/service_test.go
+++ b/openmeter/credit/balance/service_test.go
@@ -78,7 +78,7 @@ func (m *MockOwnerConnector) DescribeOwner(ctx context.Context, id models.Namesp
 	}, nil
 }
 
-func (m *MockOwnerConnector) GetResetTimelineInclusive(ctx context.Context, id models.NamespacedID, period timeutil.Period) (timeutil.SimpleTimeline, error) {
+func (m *MockOwnerConnector) GetResetTimelineInclusive(ctx context.Context, id models.NamespacedID, period timeutil.ClosedPeriod) (timeutil.SimpleTimeline, error) {
 	return timeutil.SimpleTimeline{}, nil
 }
 

--- a/openmeter/credit/balance/usage.go
+++ b/openmeter/credit/balance/usage.go
@@ -16,7 +16,7 @@ import (
 
 // UsageQuerier is a helper for querying usage for a given owner and period.
 type UsageQuerier interface {
-	QueryUsage(ctx context.Context, ownerID models.NamespacedID, period timeutil.Period) (float64, error)
+	QueryUsage(ctx context.Context, ownerID models.NamespacedID, period timeutil.ClosedPeriod) (float64, error)
 }
 
 type UsageQuerierConfig struct {
@@ -38,7 +38,7 @@ func NewUsageQuerier(conf UsageQuerierConfig) UsageQuerier {
 
 var _ UsageQuerier = (*usageQuerier)(nil)
 
-func (u *usageQuerier) QueryUsage(ctx context.Context, ownerID models.NamespacedID, period timeutil.Period) (float64, error) {
+func (u *usageQuerier) QueryUsage(ctx context.Context, ownerID models.NamespacedID, period timeutil.ClosedPeriod) (float64, error) {
 	params, err := u.GetDefaultParams(ctx, ownerID)
 	if err != nil {
 		return 0.0, err

--- a/openmeter/credit/engine/burnphase.go
+++ b/openmeter/credit/engine/burnphase.go
@@ -26,7 +26,7 @@ type burnPhase struct {
 //
 // Note that grant balance does not effect the burndown order if we simply ignore grants that don't
 // have balance while burning down.
-func (e *engine) getPhases(grants []grant.Grant, period timeutil.Period) ([]burnPhase, error) {
+func (e *engine) getPhases(grants []grant.Grant, period timeutil.ClosedPeriod) ([]burnPhase, error) {
 	activityChanges := e.getGrantActivityChanges(grants, period)
 	recurrenceTimes, err := e.getGrantRecurrenceTimes(grants, period)
 	if err != nil {

--- a/openmeter/credit/engine/grant.go
+++ b/openmeter/credit/engine/grant.go
@@ -12,7 +12,7 @@ import (
 )
 
 // An activity change is a grant becoming active or a grant expiring.
-func (e *engine) getGrantActivityChanges(grants []grant.Grant, period timeutil.Period) []time.Time {
+func (e *engine) getGrantActivityChanges(grants []grant.Grant, period timeutil.ClosedPeriod) []time.Time {
 	activityChanges := []time.Time{}
 	for _, grant := range grants {
 		// grants that take effect in the period
@@ -57,7 +57,7 @@ func (e *engine) getGrantActivityChanges(grants []grant.Grant, period timeutil.P
 }
 
 // Get all times grants recurr in the period.
-func (e *engine) getGrantRecurrenceTimes(grants []grant.Grant, period timeutil.Period) ([]struct {
+func (e *engine) getGrantRecurrenceTimes(grants []grant.Grant, period timeutil.ClosedPeriod) ([]struct {
 	time     time.Time
 	grantIDs []string
 }, error,
@@ -123,7 +123,7 @@ func (e *engine) getGrantRecurrenceTimes(grants []grant.Grant, period timeutil.P
 
 // A grant is relevant if its active at any point during the period, both limits inclusive
 // A grant is also relevant if it is mentioned in the balance map
-func (e *engine) filterRelevantGrants(grants []grant.Grant, bm balance.Map, period timeutil.Period) []grant.Grant {
+func (e *engine) filterRelevantGrants(grants []grant.Grant, bm balance.Map, period timeutil.ClosedPeriod) []grant.Grant {
 	relevant := []grant.Grant{}
 	for _, grant := range grants {
 		if grant.GetEffectivePeriod().OverlapsInclusive(period) {

--- a/openmeter/credit/engine/history.go
+++ b/openmeter/credit/engine/history.go
@@ -48,7 +48,7 @@ type GrantUsage struct {
 //
 // It is not necessarily the largest such segment.
 type GrantBurnDownHistorySegment struct {
-	timeutil.Period
+	timeutil.ClosedPeriod
 	BalanceAtStart     balance.Map
 	TerminationReasons SegmentTerminationReason // Reason why the segment was terminated (could be multiple taking effect at same time)
 	TotalUsage         float64                  // Total usage of the feature in the Period
@@ -72,7 +72,7 @@ func NewGrantBurnDownHistory(segments []GrantBurnDownHistorySegment, usageAtStar
 
 	// sort segments by time
 	sort.Slice(s, func(i, j int) bool {
-		return s[i].Period.From.Before(s[j].Period.From)
+		return s[i].ClosedPeriod.From.Before(s[j].ClosedPeriod.From)
 	})
 
 	// validate no two segments overlap

--- a/openmeter/credit/engine/run.go
+++ b/openmeter/credit/engine/run.go
@@ -107,7 +107,7 @@ type inbetweenRunParams struct {
 // When the engine outputs a balance, it doesn't discriminate what should be in that balance.
 // If a grant is inactive at the end of the period, it will still be in the output.
 func (e *engine) runBetweenResets(ctx context.Context, params inbetweenRunParams) (RunResult, error) {
-	period := timeutil.Period{From: params.StartingSnapshot.At, To: params.Until}
+	period := timeutil.ClosedPeriod{From: params.StartingSnapshot.At, To: params.Until}
 
 	if !params.StartingSnapshot.Balances.ExactlyForGrants(params.Grants) {
 		return RunResult{}, fmt.Errorf("provided grants and balances don't pair up, grants: %+v, balances: %+v", params.Grants, params.StartingSnapshot.Balances)
@@ -182,7 +182,7 @@ func (e *engine) runBetweenResets(ctx context.Context, params inbetweenRunParams
 		}
 
 		segment := GrantBurnDownHistorySegment{
-			Period:         timeutil.Period{From: phase.from, To: phase.to},
+			ClosedPeriod:   timeutil.ClosedPeriod{From: phase.from, To: phase.to},
 			BalanceAtStart: balancesAtPhaseStart.Clone(),
 			OverageAtStart: overage,
 			TerminationReasons: SegmentTerminationReason{

--- a/openmeter/credit/engine/run_test.go
+++ b/openmeter/credit/engine/run_test.go
@@ -118,7 +118,7 @@ func TestEngine(t *testing.T) {
 					{
 						BalanceAtStart: balance.Map{},
 						GrantUsages:    []engine.GrantUsage{},
-						Period: timeutil.Period{
+						ClosedPeriod: timeutil.ClosedPeriod{
 							From: t1,
 							To:   t1.AddDate(0, 0, 30),
 						},
@@ -873,16 +873,16 @@ func TestEngine(t *testing.T) {
 
 				assert.NotEmpty(t, res.History)
 				assert.Equal(t, 5, len(res.History.Segments()))
-				assert.Equal(t, start.In(time.UTC), res.History.Segments()[0].Period.From)
-				assert.Equal(t, t1.In(time.UTC), res.History.Segments()[0].Period.To)
-				assert.Equal(t, t1.In(time.UTC), res.History.Segments()[1].Period.From)
-				assert.Equal(t, t2.In(time.UTC), res.History.Segments()[1].Period.To)
-				assert.Equal(t, t2.In(time.UTC), res.History.Segments()[2].Period.From)
-				assert.Equal(t, t3.In(time.UTC), res.History.Segments()[2].Period.To)
-				assert.Equal(t, t3.In(time.UTC), res.History.Segments()[3].Period.From)
-				assert.Equal(t, t2.Add(time.Hour).In(time.UTC), res.History.Segments()[3].Period.To)
-				assert.Equal(t, t2.Add(time.Hour).In(time.UTC), res.History.Segments()[4].Period.From)
-				assert.Equal(t, end.In(time.UTC), res.History.Segments()[4].Period.To)
+				assert.Equal(t, start.In(time.UTC), res.History.Segments()[0].ClosedPeriod.From)
+				assert.Equal(t, t1.In(time.UTC), res.History.Segments()[0].ClosedPeriod.To)
+				assert.Equal(t, t1.In(time.UTC), res.History.Segments()[1].ClosedPeriod.From)
+				assert.Equal(t, t2.In(time.UTC), res.History.Segments()[1].ClosedPeriod.To)
+				assert.Equal(t, t2.In(time.UTC), res.History.Segments()[2].ClosedPeriod.From)
+				assert.Equal(t, t3.In(time.UTC), res.History.Segments()[2].ClosedPeriod.To)
+				assert.Equal(t, t3.In(time.UTC), res.History.Segments()[3].ClosedPeriod.From)
+				assert.Equal(t, t2.Add(time.Hour).In(time.UTC), res.History.Segments()[3].ClosedPeriod.To)
+				assert.Equal(t, t2.Add(time.Hour).In(time.UTC), res.History.Segments()[4].ClosedPeriod.From)
+				assert.Equal(t, end.In(time.UTC), res.History.Segments()[4].ClosedPeriod.To)
 			},
 		},
 	}

--- a/openmeter/credit/grant/grant.go
+++ b/openmeter/credit/grant/grant.go
@@ -60,8 +60,8 @@ func (g Grant) GetExpiration() time.Time {
 	return g.Expiration.GetExpiration(g.EffectiveAt)
 }
 
-func (g Grant) GetEffectivePeriod() timeutil.Period {
-	p := timeutil.Period{
+func (g Grant) GetEffectivePeriod() timeutil.ClosedPeriod {
+	p := timeutil.ClosedPeriod{
 		From: g.EffectiveAt,
 		To:   g.ExpiresAt,
 	}

--- a/openmeter/credit/grant/owner_connector.go
+++ b/openmeter/credit/grant/owner_connector.go
@@ -49,7 +49,7 @@ type OwnerConnector interface {
 	// let LR(t Time) be the last reset time before t
 	// GetResetTimelineInclusive(period) = for t in [period.From, period.To]: LR(t)
 	// This means, the first time can be before the input period (except if the start of the period is a reset itself)
-	GetResetTimelineInclusive(ctx context.Context, id models.NamespacedID, period timeutil.Period) (timeutil.SimpleTimeline, error)
+	GetResetTimelineInclusive(ctx context.Context, id models.NamespacedID, period timeutil.ClosedPeriod) (timeutil.SimpleTimeline, error)
 	GetUsagePeriodStartAt(ctx context.Context, id models.NamespacedID, at time.Time) (time.Time, error)
 	GetStartOfMeasurement(ctx context.Context, id models.NamespacedID) (time.Time, error)
 

--- a/openmeter/credit/trace.go
+++ b/openmeter/credit/trace.go
@@ -19,7 +19,7 @@ func (c ctrace) WithOwner(owner models.NamespacedID) trace.SpanStartEventOption 
 	)
 }
 
-func (c ctrace) WithPeriod(period timeutil.Period) trace.SpanStartEventOption {
+func (c ctrace) WithPeriod(period timeutil.ClosedPeriod) trace.SpanStartEventOption {
 	return trace.WithAttributes(
 		attribute.String("period_from", period.From.String()),
 		attribute.String("period_to", period.To.String()),

--- a/openmeter/entitlement/adapter/entitlement.go
+++ b/openmeter/entitlement/adapter/entitlement.go
@@ -467,7 +467,7 @@ func mapEntitlementEntity(e *db.Entitlement) *entitlement.Entitlement {
 	}
 
 	if e.CurrentUsagePeriodEnd != nil && e.CurrentUsagePeriodStart != nil {
-		ent.CurrentUsagePeriod = &timeutil.Period{
+		ent.CurrentUsagePeriod = &timeutil.ClosedPeriod{
 			From: e.CurrentUsagePeriodStart.In(time.UTC),
 			To:   e.CurrentUsagePeriodEnd.In(time.UTC),
 		}
@@ -649,7 +649,7 @@ func (a *entitlementDBAdapter) ListActiveEntitlementsWithExpiredUsagePeriod(ctx 
 
 				// Let's set back the original current usage period
 				if e.CurrentUsagePeriodStart != nil && e.CurrentUsagePeriodEnd != nil {
-					mapped.CurrentUsagePeriod = &timeutil.Period{
+					mapped.CurrentUsagePeriod = &timeutil.ClosedPeriod{
 						From: e.CurrentUsagePeriodStart.In(time.UTC),
 						To:   e.CurrentUsagePeriodEnd.In(time.UTC),
 					}

--- a/openmeter/entitlement/adapter/entitlement_test.go
+++ b/openmeter/entitlement/adapter/entitlement_test.go
@@ -88,7 +88,7 @@ func TestUpsertEntitlementCurrentPeriods(t *testing.T) {
 				Interval: timeutil.RecurrencePeriodMonth,
 				Anchor:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
-			CurrentUsagePeriod: &timeutil.Period{
+			CurrentUsagePeriod: &timeutil.ClosedPeriod{
 				From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 				To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
 			},
@@ -123,7 +123,7 @@ func TestUpsertEntitlementCurrentPeriods(t *testing.T) {
 				Interval: timeutil.RecurrencePeriodMonth,
 				Anchor:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
-			CurrentUsagePeriod: &timeutil.Period{
+			CurrentUsagePeriod: &timeutil.ClosedPeriod{
 				From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 				To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
 			},
@@ -131,12 +131,12 @@ func TestUpsertEntitlementCurrentPeriods(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, ent3)
 
-		ent1NewPeriod := timeutil.Period{
+		ent1NewPeriod := timeutil.ClosedPeriod{
 			From: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
 			To:   time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
 		}
 
-		ent2NewPeriod := timeutil.Period{
+		ent2NewPeriod := timeutil.ClosedPeriod{
 			From: time.Date(2025, 5, 1, 0, 0, 0, 0, time.UTC),
 			To:   time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
 		}
@@ -255,7 +255,7 @@ func TestListActiveEntitlementsWithExpiredUsagePeriod(t *testing.T) {
 				Interval: timeutil.RecurrencePeriodMonth,
 				Anchor:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
-			CurrentUsagePeriod: &timeutil.Period{
+			CurrentUsagePeriod: &timeutil.ClosedPeriod{
 				From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 				To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
 			},
@@ -274,7 +274,7 @@ func TestListActiveEntitlementsWithExpiredUsagePeriod(t *testing.T) {
 				Interval: timeutil.RecurrencePeriodMonth,
 				Anchor:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 			},
-			CurrentUsagePeriod: &timeutil.Period{
+			CurrentUsagePeriod: &timeutil.ClosedPeriod{
 				From: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
 				To:   time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
 			},
@@ -324,7 +324,7 @@ func TestListActiveEntitlementsWithExpiredUsagePeriod(t *testing.T) {
 					Interval: timeutil.RecurrencePeriodMonth,
 					Anchor:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 				},
-				CurrentUsagePeriod: &timeutil.Period{
+				CurrentUsagePeriod: &timeutil.ClosedPeriod{
 					From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 					To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
 				},

--- a/openmeter/entitlement/adapter/usage_reset.go
+++ b/openmeter/entitlement/adapter/usage_reset.go
@@ -78,7 +78,7 @@ func (a *usageResetDBAdapter) GetLastAt(ctx context.Context, entitlementID model
 	)
 }
 
-func (a *usageResetDBAdapter) GetBetween(ctx context.Context, entitlementID models.NamespacedID, period timeutil.Period) ([]meteredentitlement.UsageResetTime, error) {
+func (a *usageResetDBAdapter) GetBetween(ctx context.Context, entitlementID models.NamespacedID, period timeutil.ClosedPeriod) ([]meteredentitlement.UsageResetTime, error) {
 	res, err := entutils.TransactingRepo(
 		ctx,
 		a,

--- a/openmeter/entitlement/boolean/connector.go
+++ b/openmeter/entitlement/boolean/connector.go
@@ -39,7 +39,7 @@ func (c *connector) BeforeCreate(model entitlement.CreateEntitlementInputs, feat
 	}
 
 	var usagePeriod *entitlement.UsagePeriod
-	var currentUsagePeriod *timeutil.Period
+	var currentUsagePeriod *timeutil.ClosedPeriod
 
 	if model.UsagePeriod != nil {
 		usagePeriod = model.UsagePeriod

--- a/openmeter/entitlement/driver/parser.go
+++ b/openmeter/entitlement/driver/parser.go
@@ -194,7 +194,7 @@ func mapUsagePeriod(u *entitlement.UsagePeriod) *api.RecurringPeriod {
 	}
 }
 
-func mapPeriod(u *timeutil.Period) *api.Period {
+func mapPeriod(u *timeutil.ClosedPeriod) *api.Period {
 	if u == nil {
 		return nil
 	}

--- a/openmeter/entitlement/metered/balance.go
+++ b/openmeter/entitlement/metered/balance.go
@@ -135,7 +135,7 @@ func (e *connector) GetEntitlementBalanceHistory(ctx context.Context, entitlemen
 		return nil, engine.GrantBurnDownHistory{}, fmt.Errorf("failed to describe owner: %w", err)
 	}
 
-	fullPeriodTruncated := timeutil.Period{
+	fullPeriodTruncated := timeutil.ClosedPeriod{
 		From: params.From.Truncate(owner.Meter.WindowSize.Duration()),
 		To:   params.To.Truncate(owner.Meter.WindowSize.Duration()),
 	}
@@ -236,7 +236,7 @@ func (e *connector) GetEntitlementBalanceHistory(ctx context.Context, entitlemen
 		}
 	}
 
-	historyRes, err := e.balanceConnector.GetBalanceForPeriod(ctx, owner.NamespacedID, timeutil.Period{
+	historyRes, err := e.balanceConnector.GetBalanceForPeriod(ctx, owner.NamespacedID, timeutil.ClosedPeriod{
 		From: periodToQueryEngine.From,
 		To:   periodToQueryEngine.To,
 	})
@@ -265,7 +265,7 @@ func (e *connector) GetEntitlementBalanceHistory(ctx context.Context, entitlemen
 		}{
 			balance:   segment.BalanceAtStart.Balance(),
 			overage:   segment.Overage,
-			timestamp: segment.Period.From,
+			timestamp: segment.ClosedPeriod.From,
 		})
 	}
 

--- a/openmeter/entitlement/metered/entitlement.go
+++ b/openmeter/entitlement/metered/entitlement.go
@@ -37,7 +37,7 @@ type Entitlement struct {
 	UsagePeriod entitlement.UsagePeriod `json:"usagePeriod,omitempty"`
 
 	// CurrentPeriod defines the current period for usage calculations.
-	CurrentUsagePeriod timeutil.Period `json:"currentUsagePeriod,omitempty"`
+	CurrentUsagePeriod timeutil.ClosedPeriod `json:"currentUsagePeriod,omitempty"`
 
 	// OriginalUsagePeriodAnchor defines the original anchor of the current usage period.
 	OriginalUsagePeriodAnchor time.Time `json:"originalUsagePeriodAnchor,omitempty"`

--- a/openmeter/entitlement/metered/grant_owner_adapter.go
+++ b/openmeter/entitlement/metered/grant_owner_adapter.go
@@ -176,7 +176,7 @@ func (e *entitlementGrantOwner) GetUsagePeriodStartAt(ctx context.Context, owner
 	return cp.From, nil
 }
 
-func (e *entitlementGrantOwner) GetResetTimelineInclusive(ctx context.Context, owner models.NamespacedID, period timeutil.Period) (timeutil.SimpleTimeline, error) {
+func (e *entitlementGrantOwner) GetResetTimelineInclusive(ctx context.Context, owner models.NamespacedID, period timeutil.ClosedPeriod) (timeutil.SimpleTimeline, error) {
 	ctx, span := e.tracer.Start(ctx, "meteredentitlement.GetResetTimelineInclusive", mTrace.WithOwner(owner), mTrace.WithPeriod(period))
 	defer span.End()
 
@@ -288,7 +288,7 @@ func (e *entitlementGrantOwner) GetResetTimelineInclusive(ctx context.Context, o
 	}
 
 	// Now we need to check the final period, which is [lastResetTime, period.To]
-	finalPeriod := timeutil.Period{
+	finalPeriod := timeutil.ClosedPeriod{
 		From: lastResetTime,
 		To:   period.To,
 	}
@@ -313,7 +313,7 @@ func (e *entitlementGrantOwner) GetResetTimelineInclusive(ctx context.Context, o
 }
 
 // Returns all programmatic reset times in the period (start inclusive end exclusive)
-func (e *entitlementGrantOwner) getProgrammaticResetTimesInPeriodExclusiveInclusive(period timeutil.Period, up entitlement.UsagePeriod) ([]time.Time, error) {
+func (e *entitlementGrantOwner) getProgrammaticResetTimesInPeriodExclusiveInclusive(period timeutil.ClosedPeriod, up entitlement.UsagePeriod) ([]time.Time, error) {
 	rts := []time.Time{}
 
 	upr := up.AsRecurrence()

--- a/openmeter/entitlement/metered/grant_owner_adapter_test.go
+++ b/openmeter/entitlement/metered/grant_owner_adapter_test.go
@@ -66,7 +66,7 @@ func TestEntitlementGrantOwnerAdapter(t *testing.T) {
 
 		t.Run("Should return reset for period start if before the period", func(t *testing.T) {
 			// We query for 4 days without reset
-			timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+			timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.ClosedPeriod{
 				From: now.AddDate(0, 0, 1),
 				To:   now.AddDate(0, 0, 5),
 			})
@@ -83,7 +83,7 @@ func TestEntitlementGrantOwnerAdapter(t *testing.T) {
 
 		t.Run("Should return reset for period start when coincides with period start", func(t *testing.T) {
 			// We query for 4 days without reset
-			timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+			timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.ClosedPeriod{
 				From: now,
 				To:   now.AddDate(0, 0, 5),
 			})
@@ -142,7 +142,7 @@ func TestEntitlementGrantOwnerAdapter(t *testing.T) {
 		}
 
 		// We query for 4 days without the reset included
-		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.ClosedPeriod{
 			From: now.AddDate(0, 0, 1),
 			To:   now.AddDate(0, 0, 5),
 		})
@@ -189,7 +189,7 @@ func TestEntitlementGrantOwnerAdapter(t *testing.T) {
 		}
 
 		// We query for 4 days without the reset included
-		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.ClosedPeriod{
 			From: now.AddDate(0, 0, 1),
 			To:   now.AddDate(0, 1, 5), // We query for more than usage period
 		})
@@ -257,7 +257,7 @@ func TestEntitlementGrantOwnerAdapter(t *testing.T) {
 		}
 
 		// We query for 4 days without the reset included
-		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.ClosedPeriod{
 			From: now.AddDate(0, 0, 1),
 			To:   now.AddDate(0, 1, 5), // We query for more than usage period
 		})
@@ -315,7 +315,7 @@ func TestEntitlementGrantOwnerAdapter(t *testing.T) {
 			ID:        ent.ID,
 		}
 
-		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.ClosedPeriod{
 			From: now.AddDate(0, 0, 1),
 			To:   now.AddDate(0, 1, 5),
 		})
@@ -359,7 +359,7 @@ func TestEntitlementGrantOwnerAdapter(t *testing.T) {
 			ID:        ent.ID,
 		}
 
-		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.ClosedPeriod{
 			From: now.AddDate(0, 0, 1),
 			To:   now.AddDate(0, 1, 0),
 		})
@@ -415,7 +415,7 @@ func TestEntitlementGrantOwnerAdapter(t *testing.T) {
 			ID:        ent.ID,
 		}
 
-		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.ClosedPeriod{
 			From: now,
 			To:   resetTime,
 		})
@@ -471,7 +471,7 @@ func TestEntitlementGrantOwnerAdapter(t *testing.T) {
 			ID:        ent.ID,
 		}
 
-		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.Period{
+		timeline, err := deps.ownerConnector.GetResetTimelineInclusive(ctx, owner, timeutil.ClosedPeriod{
 			From: now,
 			To:   now.AddDate(0, 1, 1),
 		})

--- a/openmeter/entitlement/metered/lateevents_test.go
+++ b/openmeter/entitlement/metered/lateevents_test.go
@@ -47,7 +47,7 @@ func (c *inconsistentCreditConnector) GetBalanceAt(ctx context.Context, ownerID 
 	return res, err
 }
 
-func (c *inconsistentCreditConnector) GetBalanceForPeriod(ctx context.Context, ownerID models.NamespacedID, period timeutil.Period) (engine.RunResult, error) {
+func (c *inconsistentCreditConnector) GetBalanceForPeriod(ctx context.Context, ownerID models.NamespacedID, period timeutil.ClosedPeriod) (engine.RunResult, error) {
 	relevantTime := period.To.Add(-time.Minute)
 
 	c.AddSimpleEvent(meterSlug, 5, relevantTime)

--- a/openmeter/entitlement/metered/repository.go
+++ b/openmeter/entitlement/metered/repository.go
@@ -12,7 +12,7 @@ import (
 type UsageResetRepo interface {
 	Save(ctx context.Context, usageResetTime UsageResetTime) error
 	GetLastAt(ctx context.Context, entitlementID models.NamespacedID, at time.Time) (UsageResetTime, error)
-	GetBetween(ctx context.Context, entitlementID models.NamespacedID, period timeutil.Period) ([]UsageResetTime, error)
+	GetBetween(ctx context.Context, entitlementID models.NamespacedID, period timeutil.ClosedPeriod) ([]UsageResetTime, error)
 }
 
 type UsageResetNotFoundError struct {

--- a/openmeter/entitlement/metered/reset_test.go
+++ b/openmeter/entitlement/metered/reset_test.go
@@ -758,7 +758,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 				anchor := startTime.Add(time.Hour)
 				inp.UsagePeriod.Anchor = anchor
 				inp.UsagePeriod.Interval = timeutil.RecurrencePeriodDaily
-				inp.CurrentUsagePeriod = &timeutil.Period{
+				inp.CurrentUsagePeriod = &timeutil.ClosedPeriod{
 					To: anchor.AddDate(0, 0, 1),
 				}
 
@@ -797,7 +797,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 				inp.UsagePeriod.Interval = timeutil.RecurrencePeriodDaily
 				anchor := startTime.Add(time.Hour)
 				inp.UsagePeriod.Anchor = anchor
-				inp.CurrentUsagePeriod = &timeutil.Period{
+				inp.CurrentUsagePeriod = &timeutil.ClosedPeriod{
 					To: anchor.AddDate(0, 0, 1),
 				}
 
@@ -838,7 +838,7 @@ func TestResetEntitlementUsage(t *testing.T) {
 				anchor := startTime.Add(time.Hour)
 				inp.UsagePeriod.Interval = timeutil.RecurrencePeriodDaily
 				inp.UsagePeriod.Anchor = anchor
-				inp.CurrentUsagePeriod = &timeutil.Period{
+				inp.CurrentUsagePeriod = &timeutil.ClosedPeriod{
 					To: anchor.AddDate(0, 0, 1),
 				}
 

--- a/openmeter/entitlement/metered/trace.go
+++ b/openmeter/entitlement/metered/trace.go
@@ -19,7 +19,7 @@ func (m mtrace) WithOwner(owner models.NamespacedID) trace.SpanStartEventOption 
 	)
 }
 
-func (m mtrace) WithPeriod(period timeutil.Period) trace.SpanStartEventOption {
+func (m mtrace) WithPeriod(period timeutil.ClosedPeriod) trace.SpanStartEventOption {
 	return trace.WithAttributes(
 		attribute.String("period_from", period.From.String()),
 		attribute.String("period_to", period.To.String()),

--- a/openmeter/entitlement/repository.go
+++ b/openmeter/entitlement/repository.go
@@ -11,7 +11,7 @@ import (
 )
 
 type UpdateEntitlementUsagePeriodParams struct {
-	CurrentUsagePeriod timeutil.Period
+	CurrentUsagePeriod timeutil.ClosedPeriod
 }
 
 type ListExpiredEntitlementsParams struct {
@@ -25,7 +25,7 @@ type ListExpiredEntitlementsParams struct {
 
 type UpsertEntitlementCurrentPeriodElement struct {
 	models.NamespacedID
-	CurrentUsagePeriod timeutil.Period
+	CurrentUsagePeriod timeutil.ClosedPeriod
 }
 
 type EntitlementRepo interface {
@@ -89,12 +89,12 @@ type CreateEntitlementRepoInputs struct {
 
 	Annotations models.Annotations `json:"annotations,omitempty"`
 
-	MeasureUsageFrom        *time.Time       `json:"measureUsageFrom,omitempty"`
-	IssueAfterReset         *float64         `json:"issueAfterReset,omitempty"`
-	IssueAfterResetPriority *uint8           `json:"issueAfterResetPriority,omitempty"`
-	IsSoftLimit             *bool            `json:"isSoftLimit,omitempty"`
-	Config                  []byte           `json:"config,omitempty"`
-	UsagePeriod             *UsagePeriod     `json:"usagePeriod,omitempty"`
-	CurrentUsagePeriod      *timeutil.Period `json:"currentUsagePeriod,omitempty"`
-	PreserveOverageAtReset  *bool            `json:"preserveOverageAtReset,omitempty"`
+	MeasureUsageFrom        *time.Time             `json:"measureUsageFrom,omitempty"`
+	IssueAfterReset         *float64               `json:"issueAfterReset,omitempty"`
+	IssueAfterResetPriority *uint8                 `json:"issueAfterResetPriority,omitempty"`
+	IsSoftLimit             *bool                  `json:"isSoftLimit,omitempty"`
+	Config                  []byte                 `json:"config,omitempty"`
+	UsagePeriod             *UsagePeriod           `json:"usagePeriod,omitempty"`
+	CurrentUsagePeriod      *timeutil.ClosedPeriod `json:"currentUsagePeriod,omitempty"`
+	PreserveOverageAtReset  *bool                  `json:"preserveOverageAtReset,omitempty"`
 }

--- a/openmeter/entitlement/snapshot/event.go
+++ b/openmeter/entitlement/snapshot/event.go
@@ -48,8 +48,8 @@ type SnapshotEvent struct {
 	// in edge-worker if the store already contains the required item.
 	CalculatedAt *time.Time `json:"calculatedAt,omitempty"`
 
-	Value              *EntitlementValue `json:"value,omitempty"`
-	CurrentUsagePeriod *timeutil.Period  `json:"currentUsagePeriod,omitempty"`
+	Value              *EntitlementValue      `json:"value,omitempty"`
+	CurrentUsagePeriod *timeutil.ClosedPeriod `json:"currentUsagePeriod,omitempty"`
 }
 
 var (

--- a/openmeter/entitlement/static/connector.go
+++ b/openmeter/entitlement/static/connector.go
@@ -55,7 +55,7 @@ func (c *connector) BeforeCreate(model entitlement.CreateEntitlementInputs, feat
 	}
 
 	var usagePeriod *entitlement.UsagePeriod
-	var currentUsagePeriod *timeutil.Period
+	var currentUsagePeriod *timeutil.ClosedPeriod
 
 	if model.UsagePeriod != nil {
 		usagePeriod = model.UsagePeriod

--- a/openmeter/notification/consumer/balancetreshold.go
+++ b/openmeter/notification/consumer/balancetreshold.go
@@ -238,7 +238,7 @@ func (b *BalanceThresholdEventHandler) isBalanceThresholdEvent(event snapshot.Sn
 func (b *BalanceThresholdEventHandler) getPeriodsDeduplicationHash(snapshot snapshot.SnapshotEvent, ruleID string) string {
 	// Note: this should not happen, but let's be safe here
 	currentUsagePeriod := defaultx.WithDefault(
-		snapshot.Entitlement.CurrentUsagePeriod, timeutil.Period{
+		snapshot.Entitlement.CurrentUsagePeriod, timeutil.ClosedPeriod{
 			From: time.Time{},
 			To:   time.Time{},
 		})

--- a/openmeter/subscription/subscriptionspec.go
+++ b/openmeter/subscription/subscriptionspec.go
@@ -171,8 +171,8 @@ func (s *SubscriptionSpec) HasMeteredBillables() bool {
 
 // For a phase in an Aligned subscription, there's a single aligned BillingPeriod for all items in that phase.
 // The period starts with the phase and iterates every BillingCadence duration, but can be reanchored to the time of an edit.
-func (s *SubscriptionSpec) GetAlignedBillingPeriodAt(phaseKey string, at time.Time) (timeutil.Period, error) {
-	var def timeutil.Period
+func (s *SubscriptionSpec) GetAlignedBillingPeriodAt(phaseKey string, at time.Time) (timeutil.ClosedPeriod, error) {
+	var def timeutil.ClosedPeriod
 
 	phase, exists := s.Phases[phaseKey]
 	if !exists {

--- a/pkg/models/cadence.go
+++ b/pkg/models/cadence.go
@@ -5,8 +5,9 @@ import (
 	"slices"
 	"time"
 
-	"github.com/openmeterio/openmeter/pkg/timeutil"
 	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 // Cadenced represents a model with active from and to dates.

--- a/pkg/models/cadence.go
+++ b/pkg/models/cadence.go
@@ -1,9 +1,11 @@
 package models
 
 import (
+	"errors"
 	"slices"
 	"time"
 
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 	"github.com/samber/lo"
 )
 
@@ -39,6 +41,24 @@ func (c CadencedModel) Equal(other CadencedModel) bool {
 	}
 
 	return true
+}
+
+func (c CadencedModel) AsPeriod() timeutil.OpenPeriod {
+	return timeutil.OpenPeriod{
+		From: &c.ActiveFrom,
+		To:   c.ActiveTo,
+	}
+}
+
+func NewCadencedModelFromPeriod(period timeutil.OpenPeriod) (CadencedModel, error) {
+	if period.From == nil {
+		return CadencedModel{}, errors.New("from date is required")
+	}
+
+	return CadencedModel{
+		ActiveFrom: *period.From,
+		ActiveTo:   period.To,
+	}, nil
 }
 
 var _ Cadenced = CadencedModel{}
@@ -85,6 +105,8 @@ func NewSortedCadenceList[T Cadenced](cadences []T) CadenceList[T] {
 func (t CadenceList[T]) Cadences() []T {
 	return t
 }
+
+// TODO: rewrite CadenceList helpers to use timeutil.OpenPeriod instead
 
 // GetOverlaps returns true if there is any overlap between the cadences in the timeline
 func (t CadenceList[T]) GetOverlaps() [][2]int {

--- a/pkg/timeutil/closedperiod.go
+++ b/pkg/timeutil/closedperiod.go
@@ -1,0 +1,55 @@
+package timeutil
+
+import (
+	"time"
+)
+
+type ClosedPeriod struct {
+	From time.Time `json:"from"`
+	To   time.Time `json:"to"`
+}
+
+var _ Period = ClosedPeriod{}
+
+func (p ClosedPeriod) Duration() time.Duration {
+	return p.To.Sub(p.From)
+}
+
+// Inclusive at both start and end
+func (p ClosedPeriod) ContainsInclusive(t time.Time) bool {
+	if t.Equal(p.From) || t.Equal(p.To) {
+		return true
+	}
+
+	return t.After(p.From) && t.Before(p.To)
+}
+
+// Exclusive at both start and end
+func (p ClosedPeriod) ContainsExclusive(t time.Time) bool {
+	return p.Contains(t) && !t.Equal(p.From)
+}
+
+// Inclusive at start, exclusive at end
+func (p ClosedPeriod) Contains(t time.Time) bool {
+	return (t.After(p.From) || t.Equal(p.From)) && t.Before(p.To)
+}
+
+// Returns true if the two periods overlap at any point
+// Returns false if the periods are exactly sequential, e.g.: [1, 2] and [2, 3]
+func (p ClosedPeriod) Overlaps(other ClosedPeriod) bool {
+	// If one period ends before or exactly when the other starts, they don't overlap
+	switch {
+	case p.To.Before(other.From) || p.To.Equal(other.From):
+		return false
+	case other.To.Before(p.From) || other.To.Equal(p.From):
+		return false
+	default:
+		return true
+	}
+}
+
+// Returns true if the two periods overlap at any point
+// Returns true if the periods are exactly sequential, e.g.: [1, 2] and [2, 3]
+func (p ClosedPeriod) OverlapsInclusive(other ClosedPeriod) bool {
+	return p.ContainsInclusive(other.From) || p.ContainsInclusive(other.To) || other.ContainsInclusive(p.From) || other.ContainsInclusive(p.To)
+}

--- a/pkg/timeutil/closedperiod_test.go
+++ b/pkg/timeutil/closedperiod_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func TestPeriod(t *testing.T) {
+func TestClosedPeriod(t *testing.T) {
 	startTime := testutils.GetRFC3339Time(t, "2021-01-01T01:00:00Z")
 	endTime := testutils.GetRFC3339Time(t, "2021-01-01T02:00:00Z")
 
-	period := timeutil.Period{
+	period := timeutil.ClosedPeriod{
 		From: startTime,
 		To:   endTime,
 	}
@@ -41,7 +41,7 @@ func TestPeriod(t *testing.T) {
 		})
 
 		t.Run("Should be true for 0 length period", func(t *testing.T) {
-			period := timeutil.Period{
+			period := timeutil.ClosedPeriod{
 				From: startTime,
 				To:   startTime,
 			}
@@ -72,7 +72,7 @@ func TestPeriod(t *testing.T) {
 		})
 
 		t.Run("Should be false for 0 length period", func(t *testing.T) {
-			period := timeutil.Period{
+			period := timeutil.ClosedPeriod{
 				From: startTime,
 				To:   startTime,
 			}
@@ -83,43 +83,43 @@ func TestPeriod(t *testing.T) {
 
 	t.Run("Overlaps", func(t *testing.T) {
 		t.Run("Should be false for exactly sequential periods", func(t *testing.T) {
-			assert.False(t, period.Overlaps(timeutil.Period{From: endTime, To: endTime.Add(time.Second)}))
-			assert.False(t, period.Overlaps(timeutil.Period{From: startTime.Add(-1 * time.Second), To: startTime}))
+			assert.False(t, period.Overlaps(timeutil.ClosedPeriod{From: endTime, To: endTime.Add(time.Second)}))
+			assert.False(t, period.Overlaps(timeutil.ClosedPeriod{From: startTime.Add(-1 * time.Second), To: startTime}))
 		})
 
 		t.Run("Should be false for distant periods", func(t *testing.T) {
-			assert.False(t, period.Overlaps(timeutil.Period{From: endTime.Add(time.Second), To: endTime.Add(time.Second * 2)}))
-			assert.False(t, period.Overlaps(timeutil.Period{From: startTime.Add(-2 * time.Second), To: startTime.Add(-time.Second)}))
+			assert.False(t, period.Overlaps(timeutil.ClosedPeriod{From: endTime.Add(time.Second), To: endTime.Add(time.Second * 2)}))
+			assert.False(t, period.Overlaps(timeutil.ClosedPeriod{From: startTime.Add(-2 * time.Second), To: startTime.Add(-time.Second)}))
 		})
 
 		t.Run("Should be true for overlapping periods", func(t *testing.T) {
-			assert.True(t, period.Overlaps(timeutil.Period{From: startTime.Add(-time.Second), To: endTime.Add(-time.Second)}))
-			assert.True(t, period.Overlaps(timeutil.Period{From: startTime.Add(time.Second), To: endTime.Add(time.Second)}))
+			assert.True(t, period.Overlaps(timeutil.ClosedPeriod{From: startTime.Add(-time.Second), To: endTime.Add(-time.Second)}))
+			assert.True(t, period.Overlaps(timeutil.ClosedPeriod{From: startTime.Add(time.Second), To: endTime.Add(time.Second)}))
 		})
 
 		t.Run("Should be true for containing periods", func(t *testing.T) {
-			assert.True(t, period.Overlaps(timeutil.Period{From: startTime.Add(-time.Second), To: endTime.Add(time.Second)}))
-			assert.True(t, period.Overlaps(timeutil.Period{From: startTime.Add(time.Second), To: endTime.Add(-time.Second)}))
+			assert.True(t, period.Overlaps(timeutil.ClosedPeriod{From: startTime.Add(-time.Second), To: endTime.Add(time.Second)}))
+			assert.True(t, period.Overlaps(timeutil.ClosedPeriod{From: startTime.Add(time.Second), To: endTime.Add(-time.Second)}))
 		})
 	})
 	t.Run("OverlapsInclusive", func(t *testing.T) {
 		t.Run("Should be true for exactly sequential periods", func(t *testing.T) {
-			assert.True(t, period.OverlapsInclusive(timeutil.Period{From: endTime, To: endTime.Add(time.Second)}))
+			assert.True(t, period.OverlapsInclusive(timeutil.ClosedPeriod{From: endTime, To: endTime.Add(time.Second)}))
 		})
 
 		t.Run("Should be false for distant periods", func(t *testing.T) {
-			assert.False(t, period.OverlapsInclusive(timeutil.Period{From: endTime.Add(time.Second), To: endTime.Add(time.Second * 2)}))
-			assert.False(t, period.OverlapsInclusive(timeutil.Period{From: startTime.Add(-2 * time.Second), To: startTime.Add(-time.Second)}))
+			assert.False(t, period.OverlapsInclusive(timeutil.ClosedPeriod{From: endTime.Add(time.Second), To: endTime.Add(time.Second * 2)}))
+			assert.False(t, period.OverlapsInclusive(timeutil.ClosedPeriod{From: startTime.Add(-2 * time.Second), To: startTime.Add(-time.Second)}))
 		})
 
 		t.Run("Should be true for overlapping periods", func(t *testing.T) {
-			assert.True(t, period.OverlapsInclusive(timeutil.Period{From: startTime.Add(-time.Second), To: endTime.Add(-time.Second)}))
-			assert.True(t, period.OverlapsInclusive(timeutil.Period{From: startTime.Add(time.Second), To: endTime.Add(time.Second)}))
+			assert.True(t, period.OverlapsInclusive(timeutil.ClosedPeriod{From: startTime.Add(-time.Second), To: endTime.Add(-time.Second)}))
+			assert.True(t, period.OverlapsInclusive(timeutil.ClosedPeriod{From: startTime.Add(time.Second), To: endTime.Add(time.Second)}))
 		})
 
 		t.Run("Should be true for containing periods", func(t *testing.T) {
-			assert.True(t, period.OverlapsInclusive(timeutil.Period{From: startTime.Add(-time.Second), To: endTime.Add(time.Second)}))
-			assert.True(t, period.OverlapsInclusive(timeutil.Period{From: startTime.Add(time.Second), To: endTime.Add(-time.Second)}))
+			assert.True(t, period.OverlapsInclusive(timeutil.ClosedPeriod{From: startTime.Add(-time.Second), To: endTime.Add(time.Second)}))
+			assert.True(t, period.OverlapsInclusive(timeutil.ClosedPeriod{From: startTime.Add(time.Second), To: endTime.Add(-time.Second)}))
 		})
 	})
 }

--- a/pkg/timeutil/openperiod.go
+++ b/pkg/timeutil/openperiod.go
@@ -1,0 +1,119 @@
+package timeutil
+
+import "time"
+
+type OpenPeriod struct {
+	From *time.Time `json:"from,omitempty"`
+	To   *time.Time `json:"to,omitempty"`
+}
+
+var _ Period = OpenPeriod{}
+
+// Inclusive at both start and end
+func (p OpenPeriod) ContainsInclusive(t time.Time) bool {
+	if p.From != nil && t.Before(*p.From) {
+		return false
+	}
+
+	if p.To != nil && t.After(*p.To) {
+		return false
+	}
+
+	return true
+}
+
+// Exclusive at both start and end
+func (p OpenPeriod) ContainsExclusive(t time.Time) bool {
+	if p.From != nil && (t.Before(*p.From) || t.Equal(*p.From)) {
+		return false
+	}
+
+	if p.To != nil && (t.After(*p.To) || t.Equal(*p.To)) {
+		return false
+	}
+
+	return true
+}
+
+// Inclusive at start, exclusive at end
+func (p OpenPeriod) Contains(t time.Time) bool {
+	if p.From != nil && t.Before(*p.From) {
+		return false
+	}
+
+	if p.To != nil && (t.After(*p.To) || t.Equal(*p.To)) {
+		return false
+	}
+
+	return true
+}
+
+func (p OpenPeriod) Intersection(other OpenPeriod) *OpenPeriod {
+	// If either period is completely empty, return a copy of the other
+	if p.From == nil && p.To == nil && other.From == nil && other.To == nil {
+		return &OpenPeriod{}
+	}
+
+	// Calculate the latest From date
+	var newFrom *time.Time
+	switch {
+	case p.From == nil && other.From == nil:
+		newFrom = nil
+	case p.From == nil:
+		tmp := *other.From
+		newFrom = &tmp
+	case other.From == nil:
+		tmp := *p.From
+		newFrom = &tmp
+	default:
+		// Both From are not nil, take the later one
+		if p.From.After(*other.From) {
+			tmp := *p.From
+			newFrom = &tmp
+		} else {
+			tmp := *other.From
+			newFrom = &tmp
+		}
+	}
+
+	// Calculate the earliest To date
+	var newTo *time.Time
+	switch {
+	case p.To == nil && other.To == nil:
+		newTo = nil
+	case p.To == nil:
+		tmp := *other.To
+		newTo = &tmp
+	case other.To == nil:
+		tmp := *p.To
+		newTo = &tmp
+	default:
+		// Both To are not nil, take the earlier one
+		if p.To.Before(*other.To) {
+			tmp := *p.To
+			newTo = &tmp
+		} else {
+			tmp := *other.To
+			newTo = &tmp
+		}
+	}
+
+	// Check if the periods overlap
+	if newFrom != nil && newTo != nil {
+		// If the start is at or after the end, there's no overlap
+		if !newFrom.Before(*newTo) {
+			return nil
+		}
+	}
+
+	// Check the case where periods are open-ended in opposite directions
+	if (p.From != nil && other.To != nil && !p.From.Before(*other.To)) ||
+		(other.From != nil && p.To != nil && !other.From.Before(*p.To)) {
+		return nil
+	}
+
+	return &OpenPeriod{
+		From: newFrom,
+		To:   newTo,
+	}
+}

--- a/pkg/timeutil/openperiod_test.go
+++ b/pkg/timeutil/openperiod_test.go
@@ -1,0 +1,385 @@
+package timeutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestOpenPeriod(t *testing.T) {
+	now := time.Now()
+	before := now.Add(-time.Hour)
+	after := now.Add(time.Hour)
+	thirtyMinLater := now.Add(30 * time.Minute)
+
+	t.Run("ContainsInclusive", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			period   OpenPeriod
+			testTime time.Time
+			want     bool
+		}{
+			{
+				name:     "both bounds nil",
+				period:   OpenPeriod{},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "from bound only, time after",
+				period:   OpenPeriod{From: &before},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "from bound only, time before",
+				period:   OpenPeriod{From: &now},
+				testTime: before,
+				want:     false,
+			},
+			{
+				name:     "from bound only, time equal",
+				period:   OpenPeriod{From: &now},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "to bound only, time before",
+				period:   OpenPeriod{To: &after},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "to bound only, time after",
+				period:   OpenPeriod{To: &now},
+				testTime: after,
+				want:     false,
+			},
+			{
+				name:     "to bound only, time equal",
+				period:   OpenPeriod{To: &now},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "both bounds, time inside",
+				period:   OpenPeriod{From: &before, To: &after},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "both bounds, time equal to from",
+				period:   OpenPeriod{From: &now, To: &after},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "both bounds, time equal to to",
+				period:   OpenPeriod{From: &before, To: &now},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "both bounds, time outside before",
+				period:   OpenPeriod{From: &now, To: &after},
+				testTime: before,
+				want:     false,
+			},
+			{
+				name:     "both bounds, time outside after",
+				period:   OpenPeriod{From: &before, To: &now},
+				testTime: after,
+				want:     false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if got := tt.period.ContainsInclusive(tt.testTime); got != tt.want {
+					t.Errorf("OpenPeriod.ContainsInclusive() = %v, want %v", got, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("ContainsExclusive", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			period   OpenPeriod
+			testTime time.Time
+			want     bool
+		}{
+			{
+				name:     "both bounds nil",
+				period:   OpenPeriod{},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "from bound only, time after",
+				period:   OpenPeriod{From: &before},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "from bound only, time before",
+				period:   OpenPeriod{From: &now},
+				testTime: before,
+				want:     false,
+			},
+			{
+				name:     "from bound only, time equal",
+				period:   OpenPeriod{From: &now},
+				testTime: now,
+				want:     false,
+			},
+			{
+				name:     "to bound only, time before",
+				period:   OpenPeriod{To: &after},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "to bound only, time after",
+				period:   OpenPeriod{To: &now},
+				testTime: after,
+				want:     false,
+			},
+			{
+				name:     "to bound only, time equal",
+				period:   OpenPeriod{To: &now},
+				testTime: now,
+				want:     false,
+			},
+			{
+				name:     "both bounds, time inside",
+				period:   OpenPeriod{From: &before, To: &after},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "both bounds, time equal to from",
+				period:   OpenPeriod{From: &now, To: &after},
+				testTime: now,
+				want:     false,
+			},
+			{
+				name:     "both bounds, time equal to to",
+				period:   OpenPeriod{From: &before, To: &now},
+				testTime: now,
+				want:     false,
+			},
+			{
+				name:     "both bounds, time outside before",
+				period:   OpenPeriod{From: &now, To: &after},
+				testTime: before,
+				want:     false,
+			},
+			{
+				name:     "both bounds, time outside after",
+				period:   OpenPeriod{From: &before, To: &now},
+				testTime: after,
+				want:     false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if got := tt.period.ContainsExclusive(tt.testTime); got != tt.want {
+					t.Errorf("OpenPeriod.ContainsExclusive() = %v, want %v", got, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("Contains", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			period   OpenPeriod
+			testTime time.Time
+			want     bool
+		}{
+			{
+				name:     "both bounds nil",
+				period:   OpenPeriod{},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "from bound only, time after",
+				period:   OpenPeriod{From: &before},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "from bound only, time before",
+				period:   OpenPeriod{From: &now},
+				testTime: before,
+				want:     false,
+			},
+			{
+				name:     "from bound only, time equal",
+				period:   OpenPeriod{From: &now},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "to bound only, time before",
+				period:   OpenPeriod{To: &after},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "to bound only, time after",
+				period:   OpenPeriod{To: &now},
+				testTime: after,
+				want:     false,
+			},
+			{
+				name:     "to bound only, time equal",
+				period:   OpenPeriod{To: &now},
+				testTime: now,
+				want:     false,
+			},
+			{
+				name:     "both bounds, time inside",
+				period:   OpenPeriod{From: &before, To: &after},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "both bounds, time equal to from",
+				period:   OpenPeriod{From: &now, To: &after},
+				testTime: now,
+				want:     true,
+			},
+			{
+				name:     "both bounds, time equal to to",
+				period:   OpenPeriod{From: &before, To: &now},
+				testTime: now,
+				want:     false,
+			},
+			{
+				name:     "both bounds, time outside before",
+				period:   OpenPeriod{From: &now, To: &after},
+				testTime: before,
+				want:     false,
+			},
+			{
+				name:     "both bounds, time outside after",
+				period:   OpenPeriod{From: &before, To: &now},
+				testTime: after,
+				want:     false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if got := tt.period.Contains(tt.testTime); got != tt.want {
+					t.Errorf("OpenPeriod.Contains() = %v, want %v", got, tt.want)
+				}
+			})
+		}
+	})
+
+	t.Run("Intersection", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			period1  OpenPeriod
+			period2  OpenPeriod
+			expected *OpenPeriod
+		}{
+			{
+				name:     "both periods empty",
+				period1:  OpenPeriod{},
+				period2:  OpenPeriod{},
+				expected: &OpenPeriod{},
+			},
+			{
+				name:     "first period empty",
+				period1:  OpenPeriod{},
+				period2:  OpenPeriod{From: &before, To: &after},
+				expected: &OpenPeriod{From: &before, To: &after},
+			},
+			{
+				name:     "second period empty",
+				period1:  OpenPeriod{From: &before, To: &after},
+				period2:  OpenPeriod{},
+				expected: &OpenPeriod{From: &before, To: &after},
+			},
+			{
+				name:     "overlapping periods",
+				period1:  OpenPeriod{From: &before, To: &after},
+				period2:  OpenPeriod{From: &now, To: nil},
+				expected: &OpenPeriod{From: &now, To: &after},
+			},
+			{
+				name:     "non-overlapping periods",
+				period1:  OpenPeriod{From: &before, To: &now},
+				period2:  OpenPeriod{From: &after, To: nil},
+				expected: nil,
+			},
+			{
+				name:     "period1 contains period2",
+				period1:  OpenPeriod{From: &before, To: &after},
+				period2:  OpenPeriod{From: &now, To: &thirtyMinLater},
+				expected: &OpenPeriod{From: &now, To: &thirtyMinLater},
+			},
+			{
+				name:     "period2 contains period1",
+				period1:  OpenPeriod{From: &now, To: &thirtyMinLater},
+				period2:  OpenPeriod{From: &before, To: &after},
+				expected: &OpenPeriod{From: &now, To: &thirtyMinLater},
+			},
+			{
+				name:     "touching periods (no overlap)",
+				period1:  OpenPeriod{From: &before, To: &now},
+				period2:  OpenPeriod{From: &now, To: &after},
+				expected: nil,
+			},
+			{
+				name:     "both periods open-ended in same direction",
+				period1:  OpenPeriod{From: &before, To: nil},
+				period2:  OpenPeriod{From: &now, To: nil},
+				expected: &OpenPeriod{From: &now, To: nil},
+			},
+			{
+				name:     "both periods open-ended in opposite directions",
+				period1:  OpenPeriod{From: nil, To: &now},
+				period2:  OpenPeriod{From: &now, To: nil},
+				expected: nil,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result := tt.period1.Intersection(tt.period2)
+
+				if tt.expected == nil {
+					if result != nil {
+						t.Errorf("Expected nil result, got %+v", *result)
+					}
+					return
+				}
+
+				if result == nil {
+					t.Errorf("Expected non-nil result %+v, got nil", *tt.expected)
+					return
+				}
+
+				// Check From value
+				if (tt.expected.From == nil) != (result.From == nil) {
+					t.Errorf("Incorrect From nil status, expected %v, got %v", tt.expected.From == nil, result.From == nil)
+				} else if tt.expected.From != nil && result.From != nil && !tt.expected.From.Equal(*result.From) {
+					t.Errorf("Incorrect From value, expected %v, got %v", *tt.expected.From, *result.From)
+				}
+
+				// Check To value
+				if (tt.expected.To == nil) != (result.To == nil) {
+					t.Errorf("Incorrect To nil status, expected %v, got %v", tt.expected.To == nil, result.To == nil)
+				} else if tt.expected.To != nil && result.To != nil && !tt.expected.To.Equal(*result.To) {
+					t.Errorf("Incorrect To value, expected %v, got %v", *tt.expected.To, *result.To)
+				}
+			})
+		}
+	})
+}

--- a/pkg/timeutil/period.go
+++ b/pkg/timeutil/period.go
@@ -1,53 +1,12 @@
 package timeutil
 
-import (
-	"time"
-)
+import "time"
 
-type Period struct {
-	From time.Time `json:"from"`
-	To   time.Time `json:"to"`
-}
-
-func (p Period) Duration() time.Duration {
-	return p.To.Sub(p.From)
-}
-
-// Inclusive at both start and end
-func (p Period) ContainsInclusive(t time.Time) bool {
-	if t.Equal(p.From) || t.Equal(p.To) {
-		return true
-	}
-
-	return t.After(p.From) && t.Before(p.To)
-}
-
-// Exclusive at both start and end
-func (p Period) ContainsExclusive(t time.Time) bool {
-	return p.Contains(t) && !t.Equal(p.From)
-}
-
-// Inclusive at start, exclusive at end
-func (p Period) Contains(t time.Time) bool {
-	return (t.After(p.From) || t.Equal(p.From)) && t.Before(p.To)
-}
-
-// Returns true if the two periods overlap at any point
-// Returns false if the periods are exactly sequential, e.g.: [1, 2] and [2, 3]
-func (p Period) Overlaps(other Period) bool {
-	// If one period ends before or exactly when the other starts, they don't overlap
-	switch {
-	case p.To.Before(other.From) || p.To.Equal(other.From):
-		return false
-	case other.To.Before(p.From) || other.To.Equal(p.From):
-		return false
-	default:
-		return true
-	}
-}
-
-// Returns true if the two periods overlap at any point
-// Returns true if the periods are exactly sequential, e.g.: [1, 2] and [2, 3]
-func (p Period) OverlapsInclusive(other Period) bool {
-	return p.ContainsInclusive(other.From) || p.ContainsInclusive(other.To) || other.ContainsInclusive(p.From) || other.ContainsInclusive(p.To)
+type Period interface {
+	// Inclusive at both start and end
+	ContainsInclusive(t time.Time) bool
+	// Exclusive at both start and end
+	ContainsExclusive(t time.Time) bool
+	// Inclusive at start, exclusive at end
+	Contains(t time.Time) bool
 }

--- a/pkg/timeutil/recurrence.go
+++ b/pkg/timeutil/recurrence.go
@@ -17,8 +17,8 @@ type Recurrence struct {
 }
 
 // Returns a period where p.ContainsInclusive(t) is true
-func (r Recurrence) GetPeriodAt(t time.Time) (Period, error) {
-	var def Period
+func (r Recurrence) GetPeriodAt(t time.Time) (ClosedPeriod, error) {
+	var def ClosedPeriod
 
 	next, err := r.NextAfter(t)
 	if err != nil {
@@ -33,7 +33,7 @@ func (r Recurrence) GetPeriodAt(t time.Time) (Period, error) {
 			return def, err
 		}
 
-		return Period{start, end}, nil
+		return ClosedPeriod{start, end}, nil
 	}
 
 	// Otherwise the next time will be the end
@@ -42,7 +42,7 @@ func (r Recurrence) GetPeriodAt(t time.Time) (Period, error) {
 		return def, err
 	}
 
-	return Period{prev, next}, nil
+	return ClosedPeriod{prev, next}, nil
 }
 
 // NextAfter returns the next time after t that the recurrence should occur.

--- a/pkg/timeutil/recurrence_test.go
+++ b/pkg/timeutil/recurrence_test.go
@@ -209,7 +209,7 @@ func TestGetPeriodAt(t *testing.T) {
 		name       string
 		recurrence timeutil.Recurrence
 		time       time.Time
-		want       timeutil.Period
+		want       timeutil.ClosedPeriod
 	}{
 		{
 			name: "Should return next period if time falls on recurrence period",
@@ -218,7 +218,7 @@ func TestGetPeriodAt(t *testing.T) {
 				Anchor:   now.AddDate(0, 0, -1),
 			},
 			time: now,
-			want: timeutil.Period{
+			want: timeutil.ClosedPeriod{
 				From: now,
 				To:   now.AddDate(0, 0, 1),
 			},
@@ -230,7 +230,7 @@ func TestGetPeriodAt(t *testing.T) {
 				Anchor:   now.AddDate(0, 0, -1),
 			},
 			time: now.Add(-time.Hour),
-			want: timeutil.Period{
+			want: timeutil.ClosedPeriod{
 				From: now.AddDate(0, 0, -1),
 				To:   now,
 			},

--- a/pkg/timeutil/timeline.go
+++ b/pkg/timeutil/timeline.go
@@ -76,27 +76,27 @@ func (t Timeline[T]) GetAt(idx int) Timed[T] {
 	return t.times[idx]
 }
 
-func (t Timeline[T]) GetBoundingPeriod() Period {
+func (t Timeline[T]) GetBoundingPeriod() ClosedPeriod {
 	if len(t.times) == 0 {
-		return Period{
+		return ClosedPeriod{
 			From: time.Time{},
 			To:   time.Time{},
 		}
 	}
 
-	return Period{
+	return ClosedPeriod{
 		From: t.times[0].GetTime(),
 		To:   t.times[len(t.times)-1].GetTime(),
 	}
 }
 
-func (t Timeline[T]) GetPeriods() []Period {
+func (t Timeline[T]) GetPeriods() []ClosedPeriod {
 	if len(t.times) == 0 {
-		return []Period{}
+		return []ClosedPeriod{}
 	}
 
 	if len(t.times) == 1 {
-		return []Period{
+		return []ClosedPeriod{
 			{
 				From: t.times[0].GetTime(),
 				To:   t.times[0].GetTime(),
@@ -104,9 +104,9 @@ func (t Timeline[T]) GetPeriods() []Period {
 		}
 	}
 
-	periods := make([]Period, 0, len(t.times)-1)
+	periods := make([]ClosedPeriod, 0, len(t.times)-1)
 	for i := 0; i < len(t.times)-1; i++ {
-		periods = append(periods, Period{From: t.times[i].GetTime(), To: t.times[i+1].GetTime()})
+		periods = append(periods, ClosedPeriod{From: t.times[i].GetTime(), To: t.times[i+1].GetTime()})
 	}
 	return periods
 }

--- a/test/notification/consumer_balance.go
+++ b/test/notification/consumer_balance.go
@@ -36,7 +36,7 @@ type BalanceNotificaiontHandlerTestSuite struct {
 }
 
 var (
-	TestEntitlementCurrentUsagePeriod = timeutil.Period{
+	TestEntitlementCurrentUsagePeriod = timeutil.ClosedPeriod{
 		From: time.Now().Add(-time.Hour),
 		To:   time.Now().Add(24 * time.Hour),
 	}
@@ -350,7 +350,7 @@ func (s *BalanceNotificaiontHandlerTestSuite) TestGrantingFlow(ctx context.Conte
 
 	// Step 8: The entitlement gets reset, no events should be created
 
-	newUsagePeriod := timeutil.Period{
+	newUsagePeriod := timeutil.ClosedPeriod{
 		From: TestEntitlementCurrentUsagePeriod.To,
 		To:   TestEntitlementCurrentUsagePeriod.To.Add(24 * time.Hour),
 	}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

To unburden `models.CadencedModel` from further time-related calculations and instead keep them centralized in `timeutil`, introducing `OpenPeriod` (where both ends can be open-ended)

## Notes for reviewer
- just renames + the new period code which is not yet used

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved how time intervals are defined and processed across billing, credit, entitlement, and notification features for more accurate boundary handling.
  - Standardized period calculations to ensure consistent treatment of start and end dates in usage and reset operations.
  - Transitioned from using `timeutil.Period` to `timeutil.ClosedPeriod` for more precise period representations.

- **Tests**
  - Updated automated tests to align with the new time interval logic, ensuring reliable and consistent performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->