### PR TITLE
chore: fix lo.FromPtrOr usages

### DIFF
--- a/openmeter/app/httpdriver/marketplace.go
+++ b/openmeter/app/httpdriver/marketplace.go
@@ -115,7 +115,7 @@ func (h *handler) MarketplaceAppAPIKeyInstall() MarketplaceAppAPIKeyInstallHandl
 				MarketplaceListingID: app.MarketplaceListingID{Type: app.AppType(appType)},
 				Namespace:            namespace,
 				APIKey:               body.ApiKey,
-				Name:                 lo.FromPtrOr(body.Name, ""),
+				Name:                 lo.FromPtr(body.Name),
 			}
 
 			return req, nil

--- a/openmeter/app/stripe/entity/app/invoice.go
+++ b/openmeter/app/stripe/entity/app/invoice.go
@@ -416,8 +416,8 @@ func sortInvoiceLines[K StripeInvoiceLineOperationParams](stripeLineAdd []*K) {
 			descB = params[j].Description
 		}
 
-		a := lo.FromPtrOr(descA, "")
-		b := lo.FromPtrOr(descB, "")
+		a := lo.FromPtr(descA)
+		b := lo.FromPtr(descB)
 
 		return a < b
 	})

--- a/openmeter/billing/adapter/invoice.go
+++ b/openmeter/billing/adapter/invoice.go
@@ -703,8 +703,8 @@ func (a *adapter) mapInvoiceBaseFromDB(ctx context.Context, invoice *db.BillingI
 		CollectionAt: lo.ToPtr(invoice.CollectionAt.In(time.UTC)),
 
 		ExternalIDs: billing.InvoiceExternalIDs{
-			Invoicing: lo.FromPtrOr(invoice.InvoicingAppExternalID, ""),
-			Payment:   lo.FromPtrOr(invoice.PaymentAppExternalID, ""),
+			Invoicing: lo.FromPtr(invoice.InvoicingAppExternalID),
+			Payment:   lo.FromPtr(invoice.PaymentAppExternalID),
 		},
 	}
 }
@@ -777,9 +777,9 @@ func (a *adapter) mapInvoiceFromDB(ctx context.Context, invoice *db.BillingInvoi
 
 				Severity:  issue.Severity,
 				Message:   issue.Message,
-				Code:      lo.FromPtrOr(issue.Code, ""),
+				Code:      lo.FromPtr(issue.Code),
 				Component: billing.ComponentName(issue.Component),
-				Path:      lo.FromPtrOr(issue.Path, ""),
+				Path:      lo.FromPtr(issue.Path),
 			}
 		})
 	}

--- a/openmeter/billing/adapter/invoicelinemapper.go
+++ b/openmeter/billing/adapter/invoicelinemapper.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -160,7 +159,7 @@ func (a *adapter) mapInvoiceLineWithoutReferences(dbLine *db.BillingInvoiceLine)
 			Currency: dbLine.Currency,
 
 			TaxConfig:         lo.EmptyableToPtr(dbLine.TaxConfig),
-			RateCardDiscounts: lo.FromPtrOr(dbLine.RatecardDiscounts, billing.Discounts{}),
+			RateCardDiscounts: lo.FromPtr(dbLine.RatecardDiscounts),
 			Totals: billing.Totals{
 				Amount:              dbLine.Amount,
 				ChargesTotal:        dbLine.ChargesTotal,
@@ -171,7 +170,7 @@ func (a *adapter) mapInvoiceLineWithoutReferences(dbLine *db.BillingInvoiceLine)
 				Total:               dbLine.Total,
 			},
 			ExternalIDs: billing.LineExternalIDs{
-				Invoicing: lo.FromPtrOr(dbLine.InvoicingAppExternalID, ""),
+				Invoicing: lo.FromPtr(dbLine.InvoicingAppExternalID),
 			},
 		},
 	}
@@ -189,7 +188,7 @@ func (a *adapter) mapInvoiceLineWithoutReferences(dbLine *db.BillingInvoiceLine)
 		invoiceLine.FlatFee = &billing.FlatFeeLine{
 			ConfigID:      dbLine.Edges.FlatFeeLine.ID,
 			PerUnitAmount: dbLine.Edges.FlatFeeLine.PerUnitAmount,
-			Quantity:      lo.FromPtrOr(dbLine.Quantity, alpacadecimal.Zero),
+			Quantity:      lo.FromPtr(dbLine.Quantity),
 			Category:      dbLine.Edges.FlatFeeLine.Category,
 			PaymentTerm:   dbLine.Edges.FlatFeeLine.PaymentTerm,
 		}
@@ -235,7 +234,7 @@ func (a *adapter) mapInvoiceLineUsageDiscountFromDB(dbDiscount *db.BillingInvoic
 		Description:            dbDiscount.Description,
 		ChildUniqueReferenceID: dbDiscount.ChildUniqueReferenceID,
 		ExternalIDs: billing.LineExternalIDs{
-			Invoicing: lo.FromPtrOr(dbDiscount.InvoicingAppExternalID, ""),
+			Invoicing: lo.FromPtr(dbDiscount.InvoicingAppExternalID),
 		},
 	}
 
@@ -273,7 +272,7 @@ func (a *adapter) mapInvoiceLineAmountDiscountFromDB(dbDiscount *db.BillingInvoi
 		Description:            dbDiscount.Description,
 		ChildUniqueReferenceID: dbDiscount.ChildUniqueReferenceID,
 		ExternalIDs: billing.LineExternalIDs{
-			Invoicing: lo.FromPtrOr(dbDiscount.InvoicingAppExternalID, ""),
+			Invoicing: lo.FromPtr(dbDiscount.InvoicingAppExternalID),
 		},
 	}
 
@@ -301,7 +300,7 @@ func (a *adapter) mapInvoiceLineAmountDiscountFromDB(dbDiscount *db.BillingInvoi
 		AmountLineDiscount: billing.AmountLineDiscount{
 			LineDiscountBase: base,
 			Amount:           dbDiscount.Amount,
-			RoundingAmount:   lo.FromPtrOr(dbDiscount.RoundingAmount, alpacadecimal.Zero),
+			RoundingAmount:   lo.FromPtr(dbDiscount.RoundingAmount),
 		},
 	}, nil
 }

--- a/openmeter/billing/adapter/validationissue.go
+++ b/openmeter/billing/adapter/validationissue.go
@@ -117,9 +117,9 @@ func (a *adapter) IntrospectValidationIssues(ctx context.Context, invoice billin
 			ValidationIssue: billing.ValidationIssue{
 				Severity:  issue.Severity,
 				Message:   issue.Message,
-				Code:      lo.FromPtrOr(issue.Code, ""),
+				Code:      lo.FromPtr(issue.Code),
 				Component: billing.ComponentName(issue.Component),
-				Path:      lo.FromPtrOr(issue.Path, ""),
+				Path:      lo.FromPtr(issue.Path),
 			},
 			ID:        issue.ID,
 			DeletedAt: issue.DeletedAt,

--- a/openmeter/billing/httpdriver/discounts.go
+++ b/openmeter/billing/httpdriver/discounts.go
@@ -13,7 +13,7 @@ import (
 func AsPercentageDiscount(d api.BillingDiscountPercentage) billing.PercentageDiscount {
 	return billing.PercentageDiscount{
 		PercentageDiscount: productcataloghttp.AsPercentageDiscount(api.FromBillingDiscountPercentageToDiscountPercentage(d)),
-		CorrelationID:      lo.FromPtrOr(d.CorrelationId, ""),
+		CorrelationID:      lo.FromPtr(d.CorrelationId),
 	}
 }
 
@@ -27,7 +27,7 @@ func AsUsageDiscount(d api.BillingDiscountUsage) (billing.UsageDiscount, error) 
 
 	return billing.UsageDiscount{
 		UsageDiscount: usageDiscount,
-		CorrelationID: lo.FromPtrOr(d.CorrelationId, ""),
+		CorrelationID: lo.FromPtr(d.CorrelationId),
 	}, nil
 }
 
@@ -42,7 +42,7 @@ func AsDiscounts(discounts *api.BillingDiscounts) (billing.Discounts, error) {
 
 		out.Percentage = &billing.PercentageDiscount{
 			PercentageDiscount: productcataloghttp.AsPercentageDiscount(pctDiscount),
-			CorrelationID:      lo.FromPtrOr(discounts.Percentage.CorrelationId, ""),
+			CorrelationID:      lo.FromPtr(discounts.Percentage.CorrelationId),
 		}
 	}
 
@@ -56,7 +56,7 @@ func AsDiscounts(discounts *api.BillingDiscounts) (billing.Discounts, error) {
 
 		out.Usage = &billing.UsageDiscount{
 			UsageDiscount: usageDiscount,
-			CorrelationID: lo.FromPtrOr(discounts.Usage.CorrelationId, ""),
+			CorrelationID: lo.FromPtr(discounts.Usage.CorrelationId),
 		}
 	}
 

--- a/openmeter/billing/httpdriver/invoice.go
+++ b/openmeter/billing/httpdriver/invoice.go
@@ -43,15 +43,15 @@ func (h *handler) ListInvoices() ListInvoicesHandler {
 			return ListInvoicesRequest{
 				Namespaces: []string{ns},
 
-				Customers: lo.FromPtrOr(input.Customers, nil),
+				Customers: lo.FromPtr(input.Customers),
 				Statuses: lo.Map(
-					lo.FromPtrOr(input.Statuses, nil),
+					lo.FromPtr(input.Statuses),
 					func(status api.InvoiceStatus, _ int) string {
 						return string(status)
 					},
 				),
 				ExtendedStatuses: lo.Map(
-					lo.FromPtrOr(input.ExtendedStatuses, nil),
+					lo.FromPtr(input.ExtendedStatuses),
 					func(status string, _ int) billing.InvoiceStatus {
 						return billing.InvoiceStatus(status)
 					},
@@ -59,10 +59,10 @@ func (h *handler) ListInvoices() ListInvoicesHandler {
 
 				IssuedAfter:  input.IssuedAfter,
 				IssuedBefore: input.IssuedBefore,
-				Expand:       mapInvoiceExpandToEntity(lo.FromPtrOr(input.Expand, nil)).SetRecalculateGatheringInvoice(true),
+				Expand:       mapInvoiceExpandToEntity(lo.FromPtr(input.Expand)).SetRecalculateGatheringInvoice(true),
 
 				Order:   sortx.Order(lo.FromPtrOr(input.Order, api.InvoiceOrderByOrderingOrder(sortx.OrderDefault))),
-				OrderBy: lo.FromPtrOr(input.OrderBy, ""),
+				OrderBy: lo.FromPtr(input.OrderBy),
 
 				IncludeDeleted: lo.FromPtrOr(input.IncludeDeleted, false),
 
@@ -640,7 +640,7 @@ func mapInvoiceAvailableActionDetailsToAPI(actions *billing.InvoiceAvailableActi
 }
 
 func mergeInvoiceSupplierFromAPI(existing billing.SupplierContact, updatedSupplier api.BillingPartyReplaceUpdate) billing.SupplierContact {
-	existing.Name = lo.FromPtrOr(updatedSupplier.Name, "")
+	existing.Name = lo.FromPtr(updatedSupplier.Name)
 
 	if updatedSupplier.Addresses == nil || len(*updatedSupplier.Addresses) == 0 {
 		existing.Address = models.Address{}
@@ -659,7 +659,7 @@ func mergeInvoiceSupplierFromAPI(existing billing.SupplierContact, updatedSuppli
 }
 
 func mergeInvoiceCustomerFromAPI(existing billing.InvoiceCustomer, updatedCustomer api.BillingPartyReplaceUpdate) billing.InvoiceCustomer {
-	existing.Name = lo.FromPtrOr(updatedCustomer.Name, "")
+	existing.Name = lo.FromPtr(updatedCustomer.Name)
 
 	if updatedCustomer.Addresses == nil || len(*updatedCustomer.Addresses) == 0 {
 		existing.BillingAddress = nil

--- a/openmeter/billing/httpdriver/invoiceline.go
+++ b/openmeter/billing/httpdriver/invoiceline.go
@@ -580,7 +580,7 @@ func mapSimulationFlatFeeLineToEntity(line api.InvoiceSimulationFlatFeeLine) (*b
 
 	return &billing.Line{
 		LineBase: billing.LineBase{
-			ID:          lo.FromPtrOr(line.Id, ""),
+			ID:          lo.FromPtr(line.Id),
 			Metadata:    lo.FromPtrOr(line.Metadata, map[string]string{}),
 			Name:        line.Name,
 			Type:        billing.InvoiceLineTypeFee,
@@ -629,7 +629,7 @@ func mapUsageBasedSimulationLineToEntity(line api.InvoiceSimulationUsageBasedLin
 
 	return &billing.Line{
 		LineBase: billing.LineBase{
-			ID:          lo.FromPtrOr(line.Id, ""),
+			ID:          lo.FromPtr(line.Id),
 			Metadata:    lo.FromPtrOr(line.Metadata, map[string]string{}),
 			Name:        line.Name,
 			Type:        billing.InvoiceLineTypeUsageBased,
@@ -663,9 +663,9 @@ func getIDFromLineReplace(line api.InvoiceLineReplaceUpdate) (string, error) {
 
 	switch v := value.(type) {
 	case api.InvoiceFlatFeeLineReplaceUpdate:
-		return lo.FromPtrOr(v.Id, ""), nil
+		return lo.FromPtr(v.Id), nil
 	case api.InvoiceUsageBasedLineReplaceUpdate:
-		return lo.FromPtrOr(v.Id, ""), nil
+		return lo.FromPtr(v.Id), nil
 	default:
 		return "", fmt.Errorf("unknown line type: %T", value)
 	}

--- a/openmeter/billing/httpdriver/profile.go
+++ b/openmeter/billing/httpdriver/profile.go
@@ -278,7 +278,7 @@ func (h *handler) ListProfiles() ListProfilesHandler {
 
 func apiBillingPartyCreateToSupplierContact(c api.BillingParty) billing.SupplierContact {
 	out := billing.SupplierContact{
-		Name: lo.FromPtrOr(c.Name, ""),
+		Name: lo.FromPtr(c.Name),
 	}
 
 	if c.Addresses == nil || len(*c.Addresses) == 0 {
@@ -306,7 +306,7 @@ func apiBillingPartyCreateToSupplierContact(c api.BillingParty) billing.Supplier
 
 func apiBillingPartyToSupplierContact(c api.BillingParty) billing.SupplierContact {
 	out := billing.SupplierContact{
-		Name: lo.FromPtrOr(c.Name, ""),
+		Name: lo.FromPtr(c.Name),
 	}
 
 	if c.Addresses == nil || len(*c.Addresses) == 0 {

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -308,7 +308,7 @@ func (s *Service) InvoicePendingLines(ctx context.Context, input billing.Invoice
 				// let's create the invoice
 				invoice, err := s.adapter.CreateInvoice(ctx, billing.CreateInvoiceAdapterInput{
 					Namespace: input.Customer.Namespace,
-					Customer:  lo.FromPtrOr(customerProfile.Customer, customer.Customer{}),
+					Customer:  lo.FromPtr(customerProfile.Customer),
 					Profile:   customerProfile.MergedProfile,
 
 					Currency: currency,
@@ -1060,7 +1060,7 @@ func (s Service) SimulateInvoice(ctx context.Context, input billing.SimulateInvo
 			},
 
 			Workflow: billing.InvoiceWorkflow{
-				AppReferences:          lo.FromPtrOr(customerProfile.MergedProfile.AppReferences, billing.ProfileAppReferences{}),
+				AppReferences:          lo.FromPtr(customerProfile.MergedProfile.AppReferences),
 				Apps:                   customerProfile.MergedProfile.Apps,
 				SourceBillingProfileID: customerProfile.MergedProfile.ID,
 				Config:                 customerProfile.MergedProfile.WorkflowConfig,

--- a/openmeter/billing/worker/subscription/sync.go
+++ b/openmeter/billing/worker/subscription/sync.go
@@ -789,7 +789,7 @@ func (h *Handler) updateImmutableInvoice(ctx context.Context, invoice billing.In
 					return fmt.Errorf("recalculating line[%s]: %w", targetStateWithUpdatedQty.ID, err)
 				}
 
-				if !targetStateWithUpdatedQty.UsageBased.Quantity.Equal(lo.FromPtrOr(existingLine.UsageBased.Quantity, alpacadecimal.Zero)) {
+				if !targetStateWithUpdatedQty.UsageBased.Quantity.Equal(lo.FromPtr(existingLine.UsageBased.Quantity)) {
 					validationIssues = append(validationIssues,
 						newValidationIssueOnLine(existingLine, "usage based line's quantity cannot be changed on immutable invoice (new qty: %s)",
 							targetStateWithUpdatedQty.UsageBased.Quantity.String()),

--- a/openmeter/entitlement/adapter/entitlement.go
+++ b/openmeter/entitlement/adapter/entitlement.go
@@ -475,7 +475,7 @@ func mapEntitlementEntity(e *db.Entitlement) *entitlement.Entitlement {
 
 	// Let's update the current usage period
 	if ent.UsagePeriod != nil {
-		cp, ok := ent.CalculateCurrentUsagePeriodAt(lo.FromPtrOr(ent.LastReset, time.Time{}), clock.Now())
+		cp, ok := ent.CalculateCurrentUsagePeriodAt(lo.FromPtr(ent.LastReset), clock.Now())
 		if ok {
 			ent.CurrentUsagePeriod = &cp
 		}

--- a/openmeter/productcatalog/addon.go
+++ b/openmeter/productcatalog/addon.go
@@ -135,8 +135,8 @@ func (m AddonMeta) Status() AddonStatus {
 
 // StatusAt returns the Addon status relative to time t.
 func (m AddonMeta) StatusAt(t time.Time) AddonStatus {
-	from := lo.FromPtrOr(m.EffectiveFrom, time.Time{})
-	to := lo.FromPtrOr(m.EffectiveTo, time.Time{})
+	from := lo.FromPtr(m.EffectiveFrom)
+	to := lo.FromPtr(m.EffectiveTo)
 
 	// Add-on has DraftStatus if neither the EffectiveFrom nor EffectiveTo are set
 	if from.IsZero() && to.IsZero() {

--- a/openmeter/productcatalog/addon/adapter/mapping.go
+++ b/openmeter/productcatalog/addon/adapter/mapping.go
@@ -75,7 +75,7 @@ func FromAddonRateCardRow(r entdb.AddonRateCard) (*addon.RateCard, error) {
 		FeatureID:           r.FeatureID,
 		TaxConfig:           r.TaxConfig,
 		Price:               r.Price,
-		Discounts:           lo.FromPtrOr(r.Discounts, productcatalog.Discounts{}),
+		Discounts:           lo.FromPtr(r.Discounts),
 	}
 
 	// Get billing cadence

--- a/openmeter/productcatalog/addon/assert.go
+++ b/openmeter/productcatalog/addon/assert.go
@@ -34,7 +34,7 @@ func AssertAddonUpdateInputEqual(t *testing.T, i UpdateAddonInput, a Addon) {
 	}
 
 	if i.Description != nil {
-		assert.Equalf(t, lo.FromPtrOr(i.Description, ""), lo.FromPtrOr(a.Description, ""), "update input: description mismatch")
+		assert.Equalf(t, lo.FromPtr(i.Description), lo.FromPtr(a.Description), "update input: description mismatch")
 	}
 
 	if i.Metadata != nil {

--- a/openmeter/productcatalog/addon/httpdriver/addon.go
+++ b/openmeter/productcatalog/addon/httpdriver/addon.go
@@ -51,11 +51,11 @@ func (h *handler) ListAddons() ListAddonsHandler {
 					PageNumber: defaultx.WithDefault(params.Page, notification.DefaultPageNumber),
 				},
 				Namespaces:     []string{ns},
-				IDs:            lo.FromPtrOr(params.Id, nil),
-				Keys:           lo.FromPtrOr(params.Key, nil),
-				KeyVersions:    lo.FromPtrOr(params.KeyVersion, nil),
-				IncludeDeleted: lo.FromPtrOr(params.IncludeDeleted, false),
-				Currencies:     lo.FromPtrOr(params.Currency, nil),
+				IDs:            lo.FromPtr(params.Id),
+				Keys:           lo.FromPtr(params.Key),
+				KeyVersions:    lo.FromPtr(params.KeyVersion),
+				IncludeDeleted: lo.FromPtr(params.IncludeDeleted),
+				Currencies:     lo.FromPtr(params.Currency),
 				Status:         statusFilter,
 			}
 

--- a/openmeter/productcatalog/addon/service.go
+++ b/openmeter/productcatalog/addon/service.go
@@ -161,7 +161,7 @@ func (i UpdateAddonInput) Equal(p Addon) bool {
 		return false
 	}
 
-	if i.Description != nil && lo.FromPtrOr(i.Description, "") != lo.FromPtrOr(p.Description, "") {
+	if i.Description != nil && lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
 		return false
 	}
 
@@ -271,7 +271,7 @@ func (i PublishAddonInput) Validate() error {
 
 	now := clock.Now()
 
-	from := lo.FromPtrOr(i.EffectiveFrom, time.Time{})
+	from := lo.FromPtr(i.EffectiveFrom)
 
 	if from.IsZero() {
 		errs = append(errs, errors.New("invalid EffectiveFrom: must not be empty"))
@@ -281,7 +281,7 @@ func (i PublishAddonInput) Validate() error {
 		errs = append(errs, errors.New("invalid EffectiveFrom: period start must not be in the past"))
 	}
 
-	to := lo.FromPtrOr(i.EffectiveTo, time.Time{})
+	to := lo.FromPtr(i.EffectiveTo)
 
 	if !to.IsZero() && from.IsZero() {
 		errs = append(errs, errors.New("invalid EffectiveFrom: must not be empty if EffectiveTo is also set"))

--- a/openmeter/productcatalog/effectiveperiod.go
+++ b/openmeter/productcatalog/effectiveperiod.go
@@ -40,6 +40,6 @@ func (p EffectivePeriod) Validate() error {
 
 // Equal returns true if the two EffectivePeriod objects are equal.
 func (p EffectivePeriod) Equal(o EffectivePeriod) bool {
-	return lo.FromPtrOr(p.EffectiveFrom, time.Time{}).Equal(lo.FromPtrOr(o.EffectiveFrom, time.Time{})) &&
-		lo.FromPtrOr(p.EffectiveTo, time.Time{}).Equal(lo.FromPtrOr(o.EffectiveTo, time.Time{}))
+	return lo.FromPtr(p.EffectiveFrom).Equal(lo.FromPtr(o.EffectiveFrom)) &&
+		lo.FromPtr(p.EffectiveTo).Equal(lo.FromPtr(o.EffectiveTo))
 }

--- a/openmeter/productcatalog/http/mapping.go
+++ b/openmeter/productcatalog/http/mapping.go
@@ -401,7 +401,7 @@ func AsFlatFeeRateCard(flat api.RateCardFlatFee) (productcatalog.FlatFeeRateCard
 			Key:         flat.Key,
 			Name:        flat.Name,
 			Description: flat.Description,
-			Metadata:    lo.FromPtrOr(flat.Metadata, nil),
+			Metadata:    lo.FromPtr(flat.Metadata),
 		},
 	}
 
@@ -474,7 +474,7 @@ func AsUsageBasedRateCard(usage api.RateCardUsageBased) (productcatalog.UsageBas
 			Key:         usage.Key,
 			Name:        usage.Name,
 			Description: usage.Description,
-			Metadata:    lo.FromPtrOr(usage.Metadata, nil),
+			Metadata:    lo.FromPtr(usage.Metadata),
 		},
 	}
 
@@ -834,8 +834,8 @@ func AsEntitlementTemplate(e api.RateCardEntitlement, billingCadence *isodate.Pe
 		}
 
 		meteredTemplate := productcatalog.MeteredEntitlementTemplate{
-			Metadata:                lo.FromPtrOr(metered.Metadata, nil),
-			IsSoftLimit:             lo.FromPtrOr(metered.IsSoftLimit, false),
+			Metadata:                lo.FromPtr(metered.Metadata),
+			IsSoftLimit:             lo.FromPtr(metered.IsSoftLimit),
 			IssueAfterReset:         metered.IssueAfterReset,
 			IssueAfterResetPriority: metered.IssueAfterResetPriority,
 			PreserveOverageAtReset:  metered.PreserveOverageAtReset,
@@ -850,7 +850,7 @@ func AsEntitlementTemplate(e api.RateCardEntitlement, billingCadence *isodate.Pe
 		}
 
 		staticTemplate := productcatalog.StaticEntitlementTemplate{
-			Metadata: lo.FromPtrOr(static.Metadata, nil),
+			Metadata: lo.FromPtr(static.Metadata),
 			Config:   static.Config,
 		}
 
@@ -862,7 +862,7 @@ func AsEntitlementTemplate(e api.RateCardEntitlement, billingCadence *isodate.Pe
 		}
 
 		booleanTemplate := productcatalog.BooleanEntitlementTemplate{
-			Metadata: lo.FromPtrOr(boolean.Metadata, nil),
+			Metadata: lo.FromPtr(boolean.Metadata),
 		}
 
 		tmpl = productcatalog.NewEntitlementTemplateFrom(booleanTemplate)

--- a/openmeter/productcatalog/plan.go
+++ b/openmeter/productcatalog/plan.go
@@ -234,8 +234,8 @@ func (p PlanMeta) Status() PlanStatus {
 
 // StatusAt returns the plan status relative to time t.
 func (p PlanMeta) StatusAt(t time.Time) PlanStatus {
-	from := lo.FromPtrOr(p.EffectiveFrom, time.Time{})
-	to := lo.FromPtrOr(p.EffectiveTo, time.Time{})
+	from := lo.FromPtr(p.EffectiveFrom)
+	to := lo.FromPtr(p.EffectiveTo)
 
 	// Plan has DraftStatus if neither the EffectiveFrom nor EffectiveTo are set
 	if from.IsZero() && to.IsZero() {

--- a/openmeter/productcatalog/plan/adapter/mapping.go
+++ b/openmeter/productcatalog/plan/adapter/mapping.go
@@ -136,7 +136,7 @@ func fromPlanRateCardRow(r entdb.PlanRateCard) (productcatalog.RateCard, error) 
 		EntitlementTemplate: r.EntitlementTemplate,
 		TaxConfig:           r.TaxConfig,
 		Price:               r.Price,
-		Discounts:           lo.FromPtrOr(r.Discounts, productcatalog.Discounts{}),
+		Discounts:           lo.FromPtr(r.Discounts),
 	}
 
 	// Get billing cadence

--- a/openmeter/productcatalog/plan/assert.go
+++ b/openmeter/productcatalog/plan/assert.go
@@ -33,7 +33,7 @@ func AssertPlanUpdateInputEqual(t *testing.T, i UpdatePlanInput, p Plan) {
 	}
 
 	if i.Description != nil {
-		assert.Equalf(t, lo.FromPtrOr(i.Description, ""), lo.FromPtrOr(p.Description, ""), "update input: description mismatch")
+		assert.Equalf(t, lo.FromPtr(i.Description), lo.FromPtr(p.Description), "update input: description mismatch")
 	}
 
 	if i.Metadata != nil {

--- a/openmeter/productcatalog/plan/httpdriver/mapping.go
+++ b/openmeter/productcatalog/plan/httpdriver/mapping.go
@@ -96,7 +96,7 @@ func AsCreatePlanRequest(a api.PlanCreate, namespace string) (CreatePlanRequest,
 				Key:         a.Key,
 				Name:        a.Name,
 				Description: a.Description,
-				Metadata:    lo.FromPtrOr(a.Metadata, nil),
+				Metadata:    lo.FromPtr(a.Metadata),
 				Alignment: productcatalog.Alignment{
 					BillablesMustAlign: func() bool {
 						if a.Alignment != nil {
@@ -141,7 +141,7 @@ func AsPlanPhase(a api.PlanPhase) (productcatalog.Phase, error) {
 			Key:         a.Key,
 			Name:        a.Name,
 			Description: a.Description,
-			Metadata:    lo.FromPtrOr(a.Metadata, nil),
+			Metadata:    lo.FromPtr(a.Metadata),
 		},
 	}
 

--- a/openmeter/productcatalog/plan/httpdriver/plan.go
+++ b/openmeter/productcatalog/plan/httpdriver/plan.go
@@ -51,11 +51,11 @@ func (h *handler) ListPlans() ListPlansHandler {
 					PageNumber: defaultx.WithDefault(params.Page, notification.DefaultPageNumber),
 				},
 				Namespaces:     []string{ns},
-				IDs:            lo.FromPtrOr(params.Id, nil),
-				Keys:           lo.FromPtrOr(params.Key, nil),
-				KeyVersions:    lo.FromPtrOr(params.KeyVersion, nil),
-				IncludeDeleted: lo.FromPtrOr(params.IncludeDeleted, false),
-				Currencies:     lo.FromPtrOr(params.Currency, nil),
+				IDs:            lo.FromPtr(params.Id),
+				Keys:           lo.FromPtr(params.Key),
+				KeyVersions:    lo.FromPtr(params.KeyVersion),
+				IncludeDeleted: lo.FromPtr(params.IncludeDeleted),
+				Currencies:     lo.FromPtr(params.Currency),
 				Status:         statusFilter,
 			}
 

--- a/openmeter/productcatalog/plan/service.go
+++ b/openmeter/productcatalog/plan/service.go
@@ -162,7 +162,7 @@ func (i UpdatePlanInput) Equal(p Plan) bool {
 		return false
 	}
 
-	if i.Description != nil && lo.FromPtrOr(i.Description, "") != lo.FromPtrOr(p.Description, "") {
+	if i.Description != nil && lo.FromPtr(i.Description) != lo.FromPtr(p.Description) {
 		return false
 	}
 
@@ -282,7 +282,7 @@ func (i PublishPlanInput) Validate() error {
 
 	now := clock.Now()
 
-	from := lo.FromPtrOr(i.EffectiveFrom, time.Time{})
+	from := lo.FromPtr(i.EffectiveFrom)
 
 	if from.IsZero() {
 		errs = append(errs, errors.New("invalid EffectiveFrom: must not be empty"))
@@ -292,7 +292,7 @@ func (i PublishPlanInput) Validate() error {
 		errs = append(errs, errors.New("invalid EffectiveFrom: period start must not be in the past"))
 	}
 
-	to := lo.FromPtrOr(i.EffectiveTo, time.Time{})
+	to := lo.FromPtr(i.EffectiveTo)
 
 	if !to.IsZero() && from.IsZero() {
 		errs = append(errs, errors.New("invalid EffectiveFrom: must not be empty if EffectiveTo is also set"))

--- a/openmeter/productcatalog/price.go
+++ b/openmeter/productcatalog/price.go
@@ -558,7 +558,7 @@ func (t *TieredPrice) Validate() error {
 			tierOpenEndedPresent = true
 		}
 
-		uta := lo.FromPtrOr(tier.UpToAmount, decimal.Zero)
+		uta := lo.FromPtr(tier.UpToAmount)
 		if !uta.IsZero() {
 			if _, ok := upToAmounts[uta.String()]; ok {
 				errs = append(errs, errors.New("multiple PriceTiers with same UpToAmount are not allowed"))
@@ -627,7 +627,7 @@ type PriceTier struct {
 func (p PriceTier) Validate() error {
 	var errs []error
 
-	upToAmount := lo.FromPtrOr(p.UpToAmount, decimal.Zero)
+	upToAmount := lo.FromPtr(p.UpToAmount)
 	if upToAmount.IsNegative() {
 		errs = append(errs, errors.New("the UpToAmount must not be negative"))
 	}
@@ -716,12 +716,12 @@ type Commitments struct {
 func (c Commitments) Validate() error {
 	var errs []error
 
-	minAmount := lo.FromPtrOr(c.MinimumAmount, decimal.Zero)
+	minAmount := lo.FromPtr(c.MinimumAmount)
 	if minAmount.IsNegative() {
 		errs = append(errs, errors.New("the MinimumAmount must not be negative"))
 	}
 
-	maxAmount := lo.FromPtrOr(c.MaximumAmount, decimal.Zero)
+	maxAmount := lo.FromPtr(c.MaximumAmount)
 	if maxAmount.IsNegative() {
 		errs = append(errs, errors.New("the MaximumAmount must not be negative"))
 	}

--- a/openmeter/productcatalog/subscription/http/change.go
+++ b/openmeter/productcatalog/subscription/http/change.go
@@ -115,7 +115,7 @@ func (h *handler) ChangeSubscription() ChangeSubscriptionHandler {
 						MetadataModel: models.MetadataModel{
 							Metadata: convert.DerefHeaderPtr[string](parsedBody.Metadata),
 						},
-						Name:        lo.FromPtrOr(parsedBody.Name, ""),
+						Name:        lo.FromPtr(parsedBody.Name),
 						Description: parsedBody.Description,
 					},
 				}, nil

--- a/openmeter/productcatalog/subscription/http/create.go
+++ b/openmeter/productcatalog/subscription/http/create.go
@@ -135,7 +135,7 @@ func (h *handler) CreateSubscription() CreateSubscriptionHandler {
 					WorkflowInput: subscriptionworkflow.CreateSubscriptionWorkflowInput{
 						ChangeSubscriptionWorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
 							Timing:      timing,
-							Name:        lo.FromPtrOr(parsedBody.Name, ""),
+							Name:        lo.FromPtr(parsedBody.Name),
 							Description: parsedBody.Description,
 							MetadataModel: models.MetadataModel{
 								Metadata: convert.DerefHeaderPtr[string](parsedBody.Metadata),

--- a/openmeter/productcatalog/subscription/http/mapping.go
+++ b/openmeter/productcatalog/subscription/http/mapping.go
@@ -450,7 +450,7 @@ func CustomPlanToCreatePlanRequest(a api.CustomPlanInput, namespace string) (pla
 			PlanMeta: productcatalog.PlanMeta{
 				Name:        a.Name,
 				Description: a.Description,
-				Metadata:    lo.FromPtrOr(a.Metadata, nil),
+				Metadata:    lo.FromPtr(a.Metadata),
 			},
 			Phases: nil,
 		},

--- a/openmeter/productcatalog/subscription/plan.go
+++ b/openmeter/productcatalog/subscription/plan.go
@@ -85,7 +85,7 @@ func (p *Plan) GetPhases() []subscription.PlanPhase {
 			StartAfter: startAfter,
 		})
 
-		startAfter, _ = startAfter.Add(lo.FromPtrOr(ph.Duration, isodate.Period{}))
+		startAfter, _ = startAfter.Add(lo.FromPtr(ph.Duration))
 	}
 
 	return ps

--- a/openmeter/server/router/billing.go
+++ b/openmeter/server/router/billing.go
@@ -153,7 +153,7 @@ func (a *Router) DeleteBillingProfile(w http.ResponseWriter, r *http.Request, id
 func (a *Router) GetBillingProfile(w http.ResponseWriter, r *http.Request, id string, params api.GetBillingProfileParams) {
 	a.billingHandler.GetProfile().With(httpdriver.GetProfileParams{
 		ID:     id,
-		Expand: lo.FromPtrOr(params.Expand, nil),
+		Expand: lo.FromPtr(params.Expand),
 	}).ServeHTTP(w, r)
 }
 

--- a/openmeter/subscription/repo/mapping.go
+++ b/openmeter/subscription/repo/mapping.go
@@ -119,7 +119,7 @@ func MapDBSubscriptionItem(item *db.SubscriptionItem) (subscription.Subscription
 		EntitlementTemplate: item.EntitlementTemplate,
 		TaxConfig:           item.TaxConfig,
 		Price:               item.Price,
-		Discounts:           lo.FromPtrOr(item.Discounts, productcatalog.Discounts{}),
+		Discounts:           lo.FromPtr(item.Discounts),
 		Key:                 item.Key,
 		FeatureID:           nil, // FIXME: is this an issue?
 	}

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -559,7 +559,7 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 			}
 
 			for _, discount := range line.Discounts.Amount {
-				if lo.FromPtrOr(discount.Description, "") != "" && group[0][2] == lo.FromPtrOr(discount.Description, "") {
+				if lo.FromPtr(discount.Description) != "" && group[0][2] == lo.FromPtr(discount.Description) {
 					return discount.GetID()
 				}
 			}
@@ -1102,9 +1102,9 @@ func mapInvoiceItemParamsToInvoiceItem(id string, i *stripe.InvoiceItemParams) s
 		InvoiceItem: &stripe.InvoiceItem{
 			ID:          fmt.Sprintf("ii_%s", id),
 			Amount:      *i.Amount,
-			Quantity:    lo.FromPtrOr(i.Quantity, 0),
+			Quantity:    lo.FromPtr(i.Quantity),
 			Description: *i.Description,
-			Currency:    stripe.Currency(lo.FromPtrOr(i.Currency, "")),
+			Currency:    stripe.Currency(lo.FromPtr(i.Currency)),
 
 			Period: &stripe.Period{
 				Start: *i.Period.Start,

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -3287,11 +3287,11 @@ func requireDetailedLines(t *testing.T, line *billing.Line, expectations lineExp
 		require.Len(t, discounts.Usage, len(expect.UsageDiscounts), "usage discounts should match")
 
 		amountDiscountsById := lo.GroupBy(discounts.Amount, func(d billing.AmountLineDiscountManaged) string {
-			return lo.FromPtrOr(d.ChildUniqueReferenceID, "")
+			return lo.FromPtr(d.ChildUniqueReferenceID)
 		})
 
 		usageDiscountsById := lo.GroupBy(discounts.Usage, func(d billing.UsageLineDiscountManaged) string {
-			return lo.FromPtrOr(d.ChildUniqueReferenceID, "")
+			return lo.FromPtr(d.ChildUniqueReferenceID)
 		})
 
 		for discountType, discountExpect := range expect.AmountDiscounts {


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

lo.FromPtr returns the default value, so if we provide the default value in FromPtrOr, that's not necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the handling of optional and missing values across invoicing, billing, subscription, and product catalog features. Now, when data is absent (e.g., names, descriptions, metadata, numeric fields), it is preserved as missing rather than substituted with defaults. This ensures more explicit behavior and validation.
  
- **Tests**
  - Updated test cases to align with the revised handling of missing values, verifying consistent behavior in discount processing, invoice mapping, and related functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->