### PR TITLE
chore: fix broken URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Check out the [quickstart guide](/quickstart) for a 5-minute overview and demo o
 
 ### Deploy
 
-Deploy OpenMeter to your Kubernetes cluster using our [Helm chart](https://openmeter.io/docs/manage/deploy/kubernetes).
+Deploy OpenMeter to your Kubernetes cluster using our [Helm chart](https://openmeter.io/docs/deploy/kubernetes).
 
 ## Links
 


### PR DESCRIPTION
## Overview

the previous k8s URL in docs is broken.

## Notes for reviewer

n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated deployment instructions with a simplified URL, streamlining access to the deployment guide without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->