### PR TITLE
fix(collector): run-ai metric timestamps

### DIFF
--- a/collector/benthos/input/run_ai.go
+++ b/collector/benthos/input/run_ai.go
@@ -96,7 +96,7 @@ input:
     app_id: "${RUNAI_APP_ID:}"
     app_secret: "${RUNAI_APP_SECRET:}"
     schedule: "*/30 * * * * *"
-    metrics_scrape_offset: "30s"
+    metrics_offset: "30s"
     resource_type: "workload"
     page_size: 500
     metrics:

--- a/collector/benthos/input/runai/metrics.go
+++ b/collector/benthos/input/runai/metrics.go
@@ -71,7 +71,7 @@ type Metrics struct {
 // GetWorkloadMetrics gets metrics of a workload.
 func (s *Service) GetWorkloadMetrics(ctx context.Context, workloadID string, params MeasurementParams) (Metrics, error) {
 	m := Metrics{
-		Timestamp: params.StartTime,
+		Timestamp: params.EndTime,
 		Values:    make(map[MetricType]float64),
 	}
 
@@ -152,7 +152,7 @@ func (s *Service) GetAllWorkloadWithMetrics(ctx context.Context, params Measurem
 	workloadsWithMetrics := make([]WorkloadWithMetrics, len(workloads))
 	for i, workload := range workloads {
 		metrics := Metrics{
-			Timestamp: params.StartTime.UTC(),
+			Timestamp: params.EndTime.UTC(),
 			Values:    make(map[MetricType]float64),
 		}
 
@@ -167,7 +167,6 @@ func (s *Service) GetAllWorkloadWithMetrics(ctx context.Context, params Measurem
 				return nil, err
 			}
 
-			metrics.Timestamp = m.Timestamp.UTC()
 			for mt, v := range m.Values {
 				metrics.Values[mt] = v
 			}
@@ -208,7 +207,7 @@ const (
 // GetPodMetrics gets metrics of a pod.
 func (s *Service) GetPodMetrics(ctx context.Context, workloadID string, podID string, params MeasurementParams) (Metrics, error) {
 	m := Metrics{
-		Timestamp: params.StartTime,
+		Timestamp: params.EndTime,
 		Values:    make(map[MetricType]float64),
 	}
 
@@ -289,7 +288,7 @@ func (s *Service) GetAllPodWithMetrics(ctx context.Context, params MeasurementPa
 	podsWithMetrics := make([]PodWithMetrics, len(pods))
 	for i, pod := range pods {
 		metrics := Metrics{
-			Timestamp: params.StartTime.UTC(),
+			Timestamp: params.EndTime.UTC(),
 			Values:    make(map[MetricType]float64),
 		}
 
@@ -304,7 +303,6 @@ func (s *Service) GetAllPodWithMetrics(ctx context.Context, params MeasurementPa
 				return nil, err
 			}
 
-			metrics.Timestamp = m.Timestamp.UTC()
 			for mt, v := range m.Values {
 				metrics.Values[mt] = v
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated configuration example to use the field name `metrics_offset` instead of `metrics_scrape_offset`.

- **Bug Fixes**
  - Adjusted metrics timestamp reporting to use the end time of the measurement period instead of the start time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->