### PR TITLE
feat(collector): add run_ai_resource_count metric and status code to run_ai_http_request_ns

### DIFF
--- a/collector/benthos/input/runai/pods.go
+++ b/collector/benthos/input/runai/pods.go
@@ -130,5 +130,7 @@ func (s *Service) ListAllPods(ctx context.Context) ([]Pod, error) {
 		}
 	}
 
+	s.resourceTypeMetrics.Set(int64(len(pods)), "pod")
+
 	return pods, nil
 }

--- a/collector/benthos/input/runai/workloads.go
+++ b/collector/benthos/input/runai/workloads.go
@@ -153,5 +153,7 @@ func (s *Service) ListAllWorkloads(ctx context.Context) ([]Workload, error) {
 		}
 	}
 
+	s.resourceTypeMetrics.Set(int64(len(workloads)), "workload")
+
 	return workloads, nil
 }


### PR DESCRIPTION
- add run_ai_resource_count
- rename run_ai_http_requests to run_ai_http_request_ns
- add status code to run_ai_http_request_ns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new metrics to track the count of resources, including pods and workloads, providing enhanced visibility into resource types.
- **Improvements**
	- Metrics now include additional labels for better categorization, such as HTTP status codes and resource types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->