### PR TITLE
fix: productcatalog price clone

### DIFF
--- a/openmeter/productcatalog/price.go
+++ b/openmeter/productcatalog/price.go
@@ -557,7 +557,9 @@ type TieredPrice struct {
 }
 
 func (t *TieredPrice) Clone() TieredPrice {
-	clone := TieredPrice{}
+	clone := TieredPrice{
+		Mode: t.Mode,
+	}
 
 	if t.Commitments.MinimumAmount != nil {
 		cp := t.Commitments.MinimumAmount.Copy()


### PR DESCRIPTION
## Overview

Fix `Clone()` for `TieredPrice` where the `mode` was not set.
