### PR TITLE
feat: add adapter for planaddon service

### DIFF
--- a/openmeter/productcatalog/plan/adapter/mapping.go
+++ b/openmeter/productcatalog/plan/adapter/mapping.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-func fromPlanRow(p entdb.Plan) (*plan.Plan, error) {
+func FromPlanRow(p entdb.Plan) (*plan.Plan, error) {
 	pp := &plan.Plan{
 		NamespacedID: models.NamespacedID{
 			Namespace: p.Namespace,

--- a/openmeter/productcatalog/plan/adapter/plan.go
+++ b/openmeter/productcatalog/plan/adapter/plan.go
@@ -146,7 +146,7 @@ func (a *adapter) ListPlans(ctx context.Context, params plan.ListPlansInput) (pa
 				continue
 			}
 
-			p, err := fromPlanRow(*item)
+			p, err := FromPlanRow(*item)
 			if err != nil {
 				return response, fmt.Errorf("failed to cast Plan: %w", err)
 			}
@@ -191,7 +191,7 @@ func (a *adapter) CreatePlan(ctx context.Context, params plan.CreatePlanInput) (
 			return nil, fmt.Errorf("invalid query result: nil Plan received")
 		}
 
-		p, err := fromPlanRow(*planRow)
+		p, err := FromPlanRow(*planRow)
 		if err != nil {
 			return nil, fmt.Errorf("failed to cast Plan: %w", err)
 		}
@@ -383,7 +383,7 @@ func (a *adapter) GetPlan(ctx context.Context, params plan.GetPlanInput) (*plan.
 			return nil, fmt.Errorf("invalid query result: nil Plan received")
 		}
 
-		p, err := fromPlanRow(*planRow)
+		p, err := FromPlanRow(*planRow)
 		if err != nil {
 			return nil, fmt.Errorf("failed to cast Plan: %w", err)
 		}

--- a/openmeter/productcatalog/plan/plan.go
+++ b/openmeter/productcatalog/plan/plan.go
@@ -56,3 +56,10 @@ func (p Plan) AsProductCatalogPlan(at time.Time) (productcatalog.Plan, error) {
 		Phases:   lo.Map(phases, func(phase Phase, _ int) productcatalog.Phase { return phase.AsProductCatalogPhase() }),
 	}, nil
 }
+
+func (p Plan) AsProductCatalogPlan2() productcatalog.Plan {
+	return productcatalog.Plan{
+		PlanMeta: p.PlanMeta,
+		Phases:   lo.Map(p.Phases, func(phase Phase, _ int) productcatalog.Phase { return phase.AsProductCatalogPhase() }),
+	}
+}

--- a/openmeter/productcatalog/planaddon.go
+++ b/openmeter/productcatalog/planaddon.go
@@ -92,7 +92,7 @@ func (c PlanAddon) Validate() error {
 	}
 
 	if len(c.Plan.Phases) > 0 {
-		var phaseIdx = -1
+		phaseIdx := -1
 		for i, phase := range c.Plan.Phases {
 			if phase.Key == c.FromPlanPhase {
 				phaseIdx = i

--- a/openmeter/productcatalog/planaddon/adapter/adapter.go
+++ b/openmeter/productcatalog/planaddon/adapter/adapter.go
@@ -1,0 +1,83 @@
+package adapter
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+var _ models.Validator = (*Config)(nil)
+
+type Config struct {
+	Client *entdb.Client
+	Logger *slog.Logger
+}
+
+func (c Config) Validate() error {
+	var errs []error
+
+	if c.Client == nil {
+		errs = append(errs, errors.New("postgres client is required"))
+	}
+
+	if c.Logger == nil {
+		errs = append(errs, errors.New("logger is required"))
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
+	return nil
+}
+
+func New(config Config) (planaddon.Repository, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &adapter{
+		db:     config.Client,
+		logger: config.Logger,
+	}, nil
+}
+
+var _ planaddon.Repository = (*adapter)(nil)
+
+type adapter struct {
+	db *entdb.Client
+
+	logger *slog.Logger
+}
+
+func (a *adapter) Tx(ctx context.Context) (context.Context, transaction.Driver, error) {
+	ctx, rawConfig, eDriver, err := a.db.HijackTx(ctx, &sql.TxOptions{
+		ReadOnly: false,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to hijack transaction: %w", err)
+	}
+
+	return ctx, entutils.NewTxDriver(eDriver, rawConfig), nil
+}
+
+func (a *adapter) WithTx(ctx context.Context, tx *entutils.TxDriver) *adapter {
+	txClient := entdb.NewTxClientFromRawConfig(ctx, *tx.GetConfig())
+
+	return &adapter{
+		db:     txClient.Client(),
+		logger: a.logger,
+	}
+}
+
+func (a *adapter) Self() *adapter {
+	return a
+}

--- a/openmeter/productcatalog/planaddon/adapter/adapter_test.go
+++ b/openmeter/productcatalog/planaddon/adapter/adapter_test.go
@@ -337,7 +337,7 @@ func TestPostgresAdapter(t *testing.T) {
 					})
 					assert.NoErrorf(t, err, "getting plan add-on assignment by id must not fail")
 
-					require.NotNilf(t, addonV1, "plan add-on assignment must not be nil")
+					require.NotNilf(t, getPlanAddon, "plan add-on assignment must not be nil")
 
 					planaddon.AssertPlanAddonEqual(t, *planAddon, *getPlanAddon)
 				})
@@ -352,7 +352,7 @@ func TestPostgresAdapter(t *testing.T) {
 					})
 					assert.NoErrorf(t, err, "getting plan add-on assignment by plan and add-on key must not fail")
 
-					require.NotNilf(t, addonV1, "plan add-on assignment must not be nil")
+					require.NotNilf(t, getPlanAddon, "plan add-on assignment must not be nil")
 
 					planaddon.AssertPlanAddonEqual(t, *planAddon, *getPlanAddon)
 				})

--- a/openmeter/productcatalog/planaddon/adapter/adapter_test.go
+++ b/openmeter/productcatalog/planaddon/adapter/adapter_test.go
@@ -1,0 +1,497 @@
+package adapter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	decimal "github.com/alpacahq/alpacadecimal"
+	"github.com/invopop/gobl/currency"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	featureadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/adapter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	addonadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/addon/adapter"
+	addonservice "github.com/openmeterio/openmeter/openmeter/productcatalog/addon/service"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	planadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/plan/adapter"
+	planservice "github.com/openmeterio/openmeter/openmeter/productcatalog/plan/service"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/isodate"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+var (
+	MonthPeriod = isodate.FromDuration(30 * 24 * time.Hour)
+	namespace   = "01JBX0P4GQZCQY1WNGX3VT94P4"
+)
+
+var featureInput = feature.CreateFeatureInputs{
+	Name:      "Feature 1",
+	Key:       "feature1",
+	Namespace: namespace,
+}
+
+var addonV1Input = addon.CreateAddonInput{
+	NamespacedModel: models.NamespacedModel{
+		Namespace: namespace,
+	},
+	Addon: productcatalog.Addon{
+		AddonMeta: productcatalog.AddonMeta{
+			Key:          "addon1",
+			Name:         "Addon v1",
+			Description:  lo.ToPtr("Addon v1"),
+			Metadata:     models.Metadata{"name": "addon1"},
+			Annotations:  models.Annotations{"key": "value"},
+			Currency:     currency.USD,
+			InstanceType: productcatalog.AddonInstanceTypeSingle,
+		},
+		RateCards: nil,
+	},
+}
+
+var planV1Input = plan.CreatePlanInput{
+	NamespacedModel: models.NamespacedModel{
+		Namespace: namespace,
+	},
+	Plan: productcatalog.Plan{
+		PlanMeta: productcatalog.PlanMeta{
+			Key:         "pro",
+			Name:        "Pro",
+			Description: lo.ToPtr("Pro plan v1"),
+			Metadata:    models.Metadata{"name": "pro"},
+			Currency:    currency.USD,
+		},
+	},
+}
+
+func TestPostgresAdapter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pg := testutils.InitPostgresDB(t)
+	defer func() {
+		if err := pg.EntDriver.Close(); err != nil {
+			t.Errorf("failed to close ent driver: %v", err)
+		}
+
+		if err := pg.PGDriver.Close(); err != nil {
+			t.Errorf("failed to postgres driver: %v", err)
+		}
+	}()
+
+	err := pg.EntDriver.Client().Schema.Create(context.Background())
+	require.NoErrorf(t, err, "schema migration must not fail")
+
+	entClient := pg.EntDriver.Client()
+	defer func() {
+		if err = entClient.Close(); err != nil {
+			t.Errorf("failed to close ent client: %v", err)
+		}
+	}()
+
+	logger := testutils.NewDiscardLogger(t)
+
+	publisher := eventbus.NewMock(t)
+
+	featureSrv := feature.NewFeatureConnector(
+		featureadapter.NewPostgresFeatureRepo(entClient, logger),
+		nil,
+		publisher,
+	)
+
+	planAdapter, err := planadapter.New(planadapter.Config{
+		Client: entClient,
+		Logger: logger,
+	})
+	require.NoErrorf(t, err, "creating plan repo must not fail")
+
+	planSrv, err := planservice.New(planservice.Config{
+		Adapter:   planAdapter,
+		Feature:   featureSrv,
+		Logger:    logger,
+		Publisher: publisher,
+	})
+
+	addonAdapter, err := addonadapter.New(addonadapter.Config{
+		Client: entClient,
+		Logger: logger,
+	})
+	require.NoErrorf(t, err, "creating plan repo must not fail")
+
+	addonSrv, err := addonservice.New(addonservice.Config{
+		Adapter:   addonAdapter,
+		Feature:   featureSrv,
+		Logger:    logger,
+		Publisher: publisher,
+	})
+
+	planAddonRepo := &adapter{
+		db:     entClient,
+		logger: logger,
+	}
+
+	t.Run("Addon", func(t *testing.T) {
+		var (
+			feature1  feature.Feature
+			planV1    *plan.Plan
+			addonV1   *addon.Addon
+			planAddon *planaddon.PlanAddon
+		)
+
+		feature1, err = featureSrv.CreateFeature(ctx, featureInput)
+		require.NoErrorf(t, err, "creating feature must not fail")
+
+		planV1Input.Phases = []productcatalog.Phase{
+			{
+				PhaseMeta: productcatalog.PhaseMeta{
+					Key:         "invalid",
+					Name:        "Invalid",
+					Description: lo.ToPtr("Invalid invalid"),
+					Metadata:    models.Metadata{"name": "trial"},
+					Duration:    &MonthPeriod,
+				},
+				RateCards: []productcatalog.RateCard{
+					&productcatalog.FlatFeeRateCard{
+						RateCardMeta: productcatalog.RateCardMeta{
+							Key:                 feature1.Key,
+							Name:                feature1.Name,
+							Description:         lo.ToPtr("invalid RateCard 1"),
+							Metadata:            models.Metadata{"name": feature1.Name},
+							FeatureKey:          lo.ToPtr(feature1.Key),
+							FeatureID:           lo.ToPtr(feature1.ID),
+							EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.BooleanEntitlementTemplate{}),
+							TaxConfig: &productcatalog.TaxConfig{
+								Stripe: &productcatalog.StripeTaxConfig{
+									Code: "txcd_10000000",
+								},
+							},
+							Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+								Amount:      decimal.NewFromInt(0),
+								PaymentTerm: productcatalog.InArrearsPaymentTerm,
+							}),
+						},
+						BillingCadence: &MonthPeriod,
+					},
+				},
+			},
+			{
+				PhaseMeta: productcatalog.PhaseMeta{
+					Key:         "trial",
+					Name:        "Trial",
+					Description: lo.ToPtr("Trial phase"),
+					Metadata:    models.Metadata{"name": "trial"},
+					Duration:    &MonthPeriod,
+				},
+				RateCards: []productcatalog.RateCard{
+					&productcatalog.FlatFeeRateCard{
+						RateCardMeta: productcatalog.RateCardMeta{
+							Key:                 feature1.Key,
+							Name:                feature1.Name,
+							Description:         lo.ToPtr("Trial RateCard 1"),
+							Metadata:            models.Metadata{"name": feature1.Name},
+							FeatureKey:          lo.ToPtr(feature1.Key),
+							FeatureID:           lo.ToPtr(feature1.ID),
+							EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.BooleanEntitlementTemplate{}),
+							TaxConfig: &productcatalog.TaxConfig{
+								Stripe: &productcatalog.StripeTaxConfig{
+									Code: "txcd_10000000",
+								},
+							},
+							Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
+								Mode: productcatalog.VolumeTieredPrice,
+								Tiers: []productcatalog.PriceTier{
+									{
+										UpToAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+										FlatPrice: &productcatalog.PriceTierFlatPrice{
+											Amount: decimal.NewFromInt(100),
+										},
+										UnitPrice: &productcatalog.PriceTierUnitPrice{
+											Amount: decimal.NewFromInt(50),
+										},
+									},
+									{
+										UpToAmount: nil,
+										FlatPrice: &productcatalog.PriceTierFlatPrice{
+											Amount: decimal.NewFromInt(5),
+										},
+										UnitPrice: &productcatalog.PriceTierUnitPrice{
+											Amount: decimal.NewFromInt(25),
+										},
+									},
+								},
+								Commitments: productcatalog.Commitments{
+									MinimumAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+									MaximumAmount: nil,
+								},
+							}),
+						},
+						BillingCadence: &MonthPeriod,
+					},
+				},
+			},
+			{
+				PhaseMeta: productcatalog.PhaseMeta{
+					Key:         "pro",
+					Name:        "Pro",
+					Description: lo.ToPtr("Pro phase"),
+					Metadata:    models.Metadata{"name": "pro"},
+					Duration:    nil,
+				},
+				RateCards: []productcatalog.RateCard{
+					&productcatalog.UsageBasedRateCard{
+						RateCardMeta: productcatalog.RateCardMeta{
+							Key:                 feature1.Key,
+							Name:                feature1.Name,
+							Description:         lo.ToPtr("Pro RateCard 1"),
+							Metadata:            models.Metadata{"name": feature1.Name},
+							FeatureKey:          lo.ToPtr(feature1.Key),
+							FeatureID:           lo.ToPtr(feature1.ID),
+							EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.BooleanEntitlementTemplate{}),
+							TaxConfig: &productcatalog.TaxConfig{
+								Stripe: &productcatalog.StripeTaxConfig{
+									Code: "txcd_10000000",
+								},
+							},
+							Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
+								Mode: productcatalog.VolumeTieredPrice,
+								Tiers: []productcatalog.PriceTier{
+									{
+										UpToAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+										FlatPrice: &productcatalog.PriceTierFlatPrice{
+											Amount: decimal.NewFromInt(100),
+										},
+										UnitPrice: &productcatalog.PriceTierUnitPrice{
+											Amount: decimal.NewFromInt(50),
+										},
+									},
+									{
+										UpToAmount: nil,
+										FlatPrice: &productcatalog.PriceTierFlatPrice{
+											Amount: decimal.NewFromInt(5),
+										},
+										UnitPrice: &productcatalog.PriceTierUnitPrice{
+											Amount: decimal.NewFromInt(25),
+										},
+									},
+								},
+								Commitments: productcatalog.Commitments{
+									MinimumAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+									MaximumAmount: nil,
+								},
+							}),
+						},
+						BillingCadence: MonthPeriod,
+					},
+				},
+			},
+		}
+
+		planV1, err = planSrv.CreatePlan(ctx, planV1Input)
+		require.NoErrorf(t, err, "creating plan must not fail")
+
+		planV1, err = planSrv.PublishPlan(ctx, plan.PublishPlanInput{
+			NamespacedID: models.NamespacedID{
+				Namespace: namespace,
+				ID:        planV1.ID,
+			},
+			EffectivePeriod: productcatalog.EffectivePeriod{
+				EffectiveFrom: lo.ToPtr(time.Now()),
+				EffectiveTo:   nil,
+			},
+		})
+		require.NoErrorf(t, err, "publishing plan must not fail")
+
+		addonV1Input.RateCards = productcatalog.RateCards{
+			&productcatalog.UsageBasedRateCard{
+				RateCardMeta: productcatalog.RateCardMeta{
+					Key:                 feature1.Key,
+					Name:                feature1.Name,
+					Description:         lo.ToPtr(feature1.Name),
+					Metadata:            models.Metadata{"name": feature1.Name},
+					FeatureKey:          lo.ToPtr(feature1.Key),
+					FeatureID:           lo.ToPtr(feature1.ID),
+					EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.BooleanEntitlementTemplate{}),
+					TaxConfig: &productcatalog.TaxConfig{
+						Stripe: &productcatalog.StripeTaxConfig{
+							Code: "txcd_10000000",
+						},
+					},
+					Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
+						Mode: productcatalog.VolumeTieredPrice,
+						Tiers: []productcatalog.PriceTier{
+							{
+								UpToAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+								FlatPrice: &productcatalog.PriceTierFlatPrice{
+									Amount: decimal.NewFromInt(100),
+								},
+								UnitPrice: &productcatalog.PriceTierUnitPrice{
+									Amount: decimal.NewFromInt(50),
+								},
+							},
+							{
+								UpToAmount: nil,
+								FlatPrice: &productcatalog.PriceTierFlatPrice{
+									Amount: decimal.NewFromInt(5),
+								},
+								UnitPrice: &productcatalog.PriceTierUnitPrice{
+									Amount: decimal.NewFromInt(25),
+								},
+							},
+						},
+						Commitments: productcatalog.Commitments{
+							MinimumAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+							MaximumAmount: nil,
+						},
+					}),
+				},
+				BillingCadence: MonthPeriod,
+			},
+		}
+
+		addonV1, err = addonSrv.CreateAddon(ctx, addonV1Input)
+		require.NoErrorf(t, err, "creating add-on must not fail")
+
+		addonV1, err = addonSrv.PublishAddon(ctx, addon.PublishAddonInput{
+			NamespacedID: models.NamespacedID{
+				Namespace: namespace,
+				ID:        addonV1.ID,
+			},
+			EffectivePeriod: productcatalog.EffectivePeriod{
+				EffectiveFrom: lo.ToPtr(time.Now()),
+				EffectiveTo:   nil,
+			},
+		})
+		require.NoErrorf(t, err, "publishing add-on must not fail")
+
+		planAddonInput := planaddon.CreatePlanAddonInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: namespace,
+			},
+			Annotations: map[string]interface{}{
+				"openmeter.key": "openmeter.value",
+			},
+			PlanID:        planV1.ID,
+			AddonID:       addonV1.ID,
+			FromPlanPhase: planV1.Phases[1].Key,
+		}
+
+		t.Run("Create", func(t *testing.T) {
+			planAddon, err = planAddonRepo.CreatePlanAddon(ctx, planAddonInput)
+			require.NoErrorf(t, err, "creating new plan add-on assignment must not fail")
+
+			require.NotNilf(t, planAddon, "plan add-on assignment must not be nil")
+
+			planaddon.AssertPlanAddonCreateInputEqual(t, planAddonInput, *planAddon)
+
+			t.Run("Get", func(t *testing.T) {
+				t.Run("ById", func(t *testing.T) {
+					getPlanAddon, err := planAddonRepo.GetPlanAddon(ctx, planaddon.GetPlanAddonInput{
+						NamespacedModel: models.NamespacedModel{
+							Namespace: namespace,
+						},
+						ID: planAddon.ID,
+					})
+					assert.NoErrorf(t, err, "getting plan add-on assignment by id must not fail")
+
+					require.NotNilf(t, addonV1, "plan add-on assignment must not be nil")
+
+					planaddon.AssertPlanAddonEqual(t, *planAddon, *getPlanAddon)
+				})
+
+				t.Run("ByKey", func(t *testing.T) {
+					getPlanAddon, err := planAddonRepo.GetPlanAddon(ctx, planaddon.GetPlanAddonInput{
+						NamespacedModel: models.NamespacedModel{
+							Namespace: namespace,
+						},
+						PlanIDOrKey:  planAddon.Plan.Key,
+						AddonIDOrKey: planAddon.Addon.Key,
+					})
+					assert.NoErrorf(t, err, "getting plan add-on assignment by plan and add-on key must not fail")
+
+					require.NotNilf(t, addonV1, "plan add-on assignment must not be nil")
+
+					planaddon.AssertPlanAddonEqual(t, *planAddon, *getPlanAddon)
+				})
+			})
+
+			t.Run("List", func(t *testing.T) {
+				t.Run("ById", func(t *testing.T) {
+					listPlanAddons, err := planAddonRepo.ListPlanAddons(ctx, planaddon.ListPlanAddonsInput{
+						Namespaces: []string{namespace},
+						IDs:        []string{planAddon.ID},
+					})
+					assert.NoErrorf(t, err, "listing plan add-on assignment by id must not fail")
+
+					require.Lenf(t, listPlanAddons.Items, 1, "plan add-on assignments must not be empty")
+
+					planaddon.AssertPlanAddonEqual(t, *planAddon, listPlanAddons.Items[0])
+				})
+
+				t.Run("ByResourceKey", func(t *testing.T) {
+					listPlanAddons, err := planAddonRepo.ListPlanAddons(ctx, planaddon.ListPlanAddonsInput{
+						Namespaces: []string{namespace},
+						PlanKeys:   []string{planV1.Key},
+						AddonKeys:  []string{addonV1.Key},
+					})
+					assert.NoErrorf(t, err, "listing plan add-on assignment by plan and add-on keys must not fail")
+
+					require.Lenf(t, listPlanAddons.Items, 1, "plan add-on assignments must not be empty")
+
+					planaddon.AssertPlanAddonEqual(t, *planAddon, listPlanAddons.Items[0])
+				})
+			})
+
+			t.Run("Update", func(t *testing.T) {
+				planAddonV1Update := planaddon.UpdatePlanAddonInput{
+					NamespacedModel: models.NamespacedModel{
+						Namespace: namespace,
+					},
+					Annotations: &models.Annotations{
+						"openmeter.key2": "openmeter.value2",
+					},
+					Metadata: &models.Metadata{
+						"openmeter.key2": "openmeter.value2",
+					},
+					ID:            planAddon.ID,
+					FromPlanPhase: &planV1.Phases[2].Key,
+				}
+
+				updatedPlanAddon, err := planAddonRepo.UpdatePlanAddon(ctx, planAddonV1Update)
+				require.NoErrorf(t, err, "updating plan add-on assignment must not fail")
+
+				require.NotNilf(t, updatedPlanAddon, "plan add-on assignment must not be nil")
+
+				planaddon.AssertPlanAddonUpdateInputEqual(t, planAddonV1Update, *updatedPlanAddon)
+			})
+
+			t.Run("Delete", func(t *testing.T) {
+				err = planAddonRepo.DeletePlanAddon(ctx, planaddon.DeletePlanAddonInput{
+					NamespacedModel: models.NamespacedModel{
+						Namespace: namespace,
+					},
+					ID: planAddon.ID,
+				})
+				require.NoErrorf(t, err, "deleting plan add-on assignment must not fail")
+
+				getPlanAddon, err := planAddonRepo.GetPlanAddon(ctx, planaddon.GetPlanAddonInput{
+					NamespacedModel: models.NamespacedModel{
+						Namespace: namespace,
+					},
+					ID: planAddon.ID,
+				})
+				require.NoErrorf(t, err, "getting plan add-on assignment by id must not fail")
+
+				require.NotNilf(t, getPlanAddon, "plan add-on assignment must not be nil")
+
+				assert.NotNilf(t, getPlanAddon.DeletedAt, "plan add-on assignment must be deleted")
+			})
+		})
+	})
+}

--- a/openmeter/productcatalog/planaddon/adapter/mapping.go
+++ b/openmeter/productcatalog/planaddon/adapter/mapping.go
@@ -1,0 +1,85 @@
+package adapter
+
+import (
+	"errors"
+	"fmt"
+
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	addonadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/addon/adapter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	planadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/plan/adapter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func FromPlanAddonRow(a entdb.PlanAddon) (*planaddon.PlanAddon, error) {
+	planAddon := &planaddon.PlanAddon{
+		NamespacedID: models.NamespacedID{
+			Namespace: a.Namespace,
+			ID:        a.ID,
+		},
+		ManagedModel: models.ManagedModel{
+			CreatedAt: a.CreatedAt,
+			UpdatedAt: a.UpdatedAt,
+			DeletedAt: a.DeletedAt,
+		},
+		PlanAddonMeta: productcatalog.PlanAddonMeta{
+			Metadata:    a.Metadata,
+			Annotations: a.Annotations,
+			PlanAddonConfig: productcatalog.PlanAddonConfig{
+				FromPlanPhase: a.FromPlanPhase,
+				MaxQuantity:   a.MaxQuantity,
+			},
+		},
+	}
+
+	// Set Plan
+	planAddon.Plan = plan.Plan{
+		NamespacedID: models.NamespacedID{
+			Namespace: a.Namespace,
+			ID:        a.PlanID,
+		},
+	}
+
+	if a.Edges.Plan != nil {
+		p, err := planadapter.FromPlanRow(*a.Edges.Plan)
+		if err != nil {
+			return nil, fmt.Errorf("failed to cast plan: %w", err)
+		}
+
+		if p == nil {
+			return nil, errors.New("failed to cast plan: plan is nil")
+		}
+
+		planAddon.Plan = *p
+	}
+
+	// Set Addon
+	planAddon.Addon = addon.Addon{
+		NamespacedID: models.NamespacedID{
+			Namespace: a.Namespace,
+			ID:        a.PlanID,
+		},
+	}
+
+	if a.Edges.Addon != nil {
+		aa, err := addonadapter.FromAddonRow(*a.Edges.Addon)
+		if err != nil {
+			return nil, fmt.Errorf("failed to cast add-on: %w", err)
+		}
+
+		if aa == nil {
+			return nil, errors.New("failed to cast add-on: add-on is nil")
+		}
+
+		planAddon.Addon = *aa
+	}
+
+	if err := planAddon.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid add-on [namespace=%s id=%s]: %w", planAddon.Namespace, planAddon.ID, err)
+	}
+
+	return planAddon, nil
+}

--- a/openmeter/productcatalog/planaddon/adapter/mapping.go
+++ b/openmeter/productcatalog/planaddon/adapter/mapping.go
@@ -60,7 +60,7 @@ func FromPlanAddonRow(a entdb.PlanAddon) (*planaddon.PlanAddon, error) {
 	planAddon.Addon = addon.Addon{
 		NamespacedID: models.NamespacedID{
 			Namespace: a.Namespace,
-			ID:        a.PlanID,
+			ID:        a.AddonID,
 		},
 	}
 

--- a/openmeter/productcatalog/planaddon/adapter/planaddon.go
+++ b/openmeter/productcatalog/planaddon/adapter/planaddon.go
@@ -1,0 +1,411 @@
+package adapter
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	addondb "github.com/openmeterio/openmeter/openmeter/ent/db/addon"
+	plandb "github.com/openmeterio/openmeter/openmeter/ent/db/plan"
+	planaddondb "github.com/openmeterio/openmeter/openmeter/ent/db/planaddon"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+	"github.com/openmeterio/openmeter/pkg/sortx"
+)
+
+func (a *adapter) ListPlanAddons(ctx context.Context, params planaddon.ListPlanAddonsInput) (pagination.PagedResponse[planaddon.PlanAddon], error) {
+	fn := func(ctx context.Context, a *adapter) (pagination.PagedResponse[planaddon.PlanAddon], error) {
+		if err := params.Validate(); err != nil {
+			return pagination.PagedResponse[planaddon.PlanAddon]{}, fmt.Errorf("invalid list add-on assignments parameters: %w", err)
+		}
+
+		query := a.db.PlanAddon.Query()
+
+		if len(params.Namespaces) > 0 {
+			query = query.Where(planaddondb.NamespaceIn(params.Namespaces...))
+		}
+
+		var orFilters []predicate.PlanAddon
+		if len(params.IDs) > 0 {
+			orFilters = append(orFilters, planaddondb.IDIn(params.IDs...))
+		}
+
+		// Plan predicates
+
+		var planOrFilters []predicate.Plan
+
+		if len(params.PlanIDs) > 0 {
+			planOrFilters = append(planOrFilters, plandb.IDIn(params.PlanIDs...))
+		}
+
+		if len(params.PlanKeys) > 0 {
+			planOrFilters = append(planOrFilters, plandb.KeyIn(params.PlanKeys...))
+		}
+
+		if len(params.PlanKeyVersions) > 0 {
+			var planKeyVersionFilters []predicate.Plan
+
+			for key, version := range params.PlanKeyVersions {
+				planOrFilters = append(planOrFilters, plandb.And(plandb.Key(key), plandb.VersionIn(version...)))
+			}
+
+			planOrFilters = append(planOrFilters, plandb.Or(planKeyVersionFilters...))
+		}
+
+		if len(params.Currencies) > 0 {
+			planOrFilters = append(planOrFilters, plandb.CurrencyIn(params.Currencies...))
+		}
+
+		if len(planOrFilters) > 0 {
+			orFilters = append(orFilters, planaddondb.HasPlanWith(
+				plandb.Or(planOrFilters...),
+			))
+		}
+
+		// Addon predicates
+
+		var addonOrFilters []predicate.Addon
+
+		if len(params.AddonIDs) > 0 {
+			addonOrFilters = append(addonOrFilters, addondb.IDIn(params.AddonIDs...))
+		}
+
+		if len(params.AddonKeys) > 0 {
+			addonOrFilters = append(addonOrFilters, addondb.KeyIn(params.AddonKeys...))
+		}
+
+		if len(params.PlanKeyVersions) > 0 {
+			var planKeyVersionFilters []predicate.Addon
+
+			for key, version := range params.PlanKeyVersions {
+				addonOrFilters = append(addonOrFilters, addondb.And(addondb.Key(key), addondb.VersionIn(version...)))
+			}
+
+			addonOrFilters = append(addonOrFilters, addondb.Or(planKeyVersionFilters...))
+		}
+
+		if len(params.Currencies) > 0 {
+			addonOrFilters = append(addonOrFilters, addondb.CurrencyIn(params.Currencies...))
+		}
+
+		if len(addonOrFilters) > 0 {
+			orFilters = append(orFilters, planaddondb.HasAddonWith(
+				addondb.Or(addonOrFilters...),
+			))
+		}
+
+		if len(orFilters) > 0 {
+			query = query.Where(planaddondb.Or(orFilters...))
+		}
+
+		if !params.IncludeDeleted {
+			query = query.Where(planaddondb.DeletedAtIsNil())
+		}
+
+		// Eager load Plans and Addons
+		query = query.
+			WithPlan(PlanEagerLoadPhasesWithRateCardsWithFeaturesFn).
+			WithAddon(AddonEagerLoadRateCardsWithFeaturesFn)
+
+		order := entutils.GetOrdering(sortx.OrderDefault)
+		if !params.Order.IsDefaultValue() {
+			order = entutils.GetOrdering(params.Order)
+		}
+
+		switch params.OrderBy {
+		case planaddon.OrderByCreatedAt:
+			query = query.Order(planaddondb.ByCreatedAt(order...))
+		case planaddon.OrderByUpdatedAt:
+			query = query.Order(planaddondb.ByUpdatedAt(order...))
+		case planaddon.OrderByID:
+			fallthrough
+		default:
+			query = query.Order(planaddondb.ByID(order...))
+		}
+
+		response := pagination.PagedResponse[planaddon.PlanAddon]{
+			Page: params.Page,
+		}
+
+		paged, err := query.Paginate(ctx, params.Page)
+		if err != nil {
+			return response, fmt.Errorf("failed to list plan add-on assignments: %w", err)
+		}
+
+		result := make([]planaddon.PlanAddon, 0, len(paged.Items))
+		for _, item := range paged.Items {
+			if item == nil {
+				a.logger.WarnContext(ctx, "invalid query result: nil plan add-on assignments received")
+				continue
+			}
+
+			planAddon, err := FromPlanAddonRow(*item)
+			if err != nil {
+				return response, fmt.Errorf("failed to cast add-on: %w", err)
+			}
+
+			result = append(result, *planAddon)
+		}
+
+		response.TotalCount = paged.TotalCount
+		response.Items = result
+
+		return response, nil
+	}
+
+	return entutils.TransactingRepo[pagination.PagedResponse[planaddon.PlanAddon], *adapter](ctx, a, fn)
+}
+
+func (a *adapter) CreatePlanAddon(ctx context.Context, params planaddon.CreatePlanAddonInput) (*planaddon.PlanAddon, error) {
+	fn := func(ctx context.Context, a *adapter) (*planaddon.PlanAddon, error) {
+		if err := params.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid create plan add-on assignment parameters: %w", err)
+		}
+
+		planAddonRow, err := a.db.PlanAddon.Create().
+			SetNamespace(params.Namespace).
+			SetPlanID(params.PlanID).
+			SetAddonID(params.AddonID).
+			SetAnnotations(params.Annotations).
+			SetFromPlanPhase(params.FromPlanPhase).
+			SetNillableMaxQuantity(params.MaxQuantity).
+			Save(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create plan add-on assignment [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
+		}
+
+		if planAddonRow == nil {
+			return nil, fmt.Errorf("invalid query result: nil plan add-on assignment received [namespace=%s plan.id=%s addon.id=%s]",
+				params.Namespace, params.PlanID, params.AddonID)
+		}
+
+		// Refetch newly created addon
+		planAddonRow, err = a.db.PlanAddon.Query().
+			Where(planaddondb.And(
+				planaddondb.Namespace(params.Namespace),
+				planaddondb.ID(planAddonRow.ID)),
+			).
+			WithPlan(PlanEagerLoadPhasesWithRateCardsWithFeaturesFn).
+			WithAddon(AddonEagerLoadRateCardsWithFeaturesFn).
+			First(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create plan add-on assignment [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
+		}
+
+		planAddon, err := FromPlanAddonRow(*planAddonRow)
+		if err != nil {
+			return nil, fmt.Errorf("failed to cast plan add-on assignment [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
+		}
+
+		return planAddon, nil
+	}
+
+	return entutils.TransactingRepo[*planaddon.PlanAddon, *adapter](ctx, a, fn)
+}
+
+var PlanEagerLoadPhasesWithRateCardsWithFeaturesFn = func(pq *entdb.PlanQuery) {
+	pq.WithPhases(func(ppq *entdb.PlanPhaseQuery) {
+		ppq.WithRatecards(func(prq *entdb.PlanRateCardQuery) {
+			prq.WithFeatures()
+		})
+	})
+}
+
+var AddonEagerLoadRateCardsWithFeaturesFn = func(aq *entdb.AddonQuery) {
+	aq.WithRatecards(func(arq *entdb.AddonRateCardQuery) {
+		arq.WithFeatures()
+	})
+}
+
+func (a *adapter) DeletePlanAddon(ctx context.Context, params planaddon.DeletePlanAddonInput) error {
+	fn := func(ctx context.Context, a *adapter) (interface{}, error) {
+		if err := params.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid delete plan add-on assignment parameters: %w", err)
+		}
+
+		planAddon, err := a.GetPlanAddon(ctx, planaddon.GetPlanAddonInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: params.Namespace,
+			},
+			ID:           params.ID,
+			PlanIDOrKey:  params.PlanID,
+			AddonIDOrKey: params.AddonID,
+		})
+		if err != nil {
+			if entdb.IsNotFound(err) {
+				return nil, planaddon.NewNotFoundError(planaddon.NotFoundErrorParams{
+					Namespace:    params.Namespace,
+					ID:           params.ID,
+					PlanIDOrKey:  params.PlanID,
+					AddonIDOrKey: params.AddonID,
+				})
+			}
+
+			return nil, fmt.Errorf("failed to get plan add-on assignment: %w", err)
+		}
+
+		deletedAt := time.Now().UTC()
+		err = a.db.PlanAddon.UpdateOneID(planAddon.ID).
+			Where(planaddondb.Namespace(planAddon.Namespace)).
+			SetDeletedAt(deletedAt).
+			Exec(ctx)
+		if err != nil {
+			if entdb.IsNotFound(err) {
+				return nil, planaddon.NewNotFoundError(planaddon.NotFoundErrorParams{
+					Namespace:    params.Namespace,
+					ID:           planAddon.ID,
+					PlanIDOrKey:  params.PlanID,
+					AddonIDOrKey: params.AddonID,
+				})
+			}
+
+			return nil, fmt.Errorf("failed to delete plan add-on assignment [namespace=%s planaddon.id=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, planAddon.ID, params.PlanID, params.AddonID, err)
+		}
+
+		return nil, nil
+	}
+
+	_, resp := entutils.TransactingRepo[interface{}, *adapter](ctx, a, fn)
+
+	return resp
+}
+
+func (a *adapter) GetPlanAddon(ctx context.Context, params planaddon.GetPlanAddonInput) (*planaddon.PlanAddon, error) {
+	fn := func(ctx context.Context, a *adapter) (*planaddon.PlanAddon, error) {
+		if err := params.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid get add-on parameters: %w", err)
+		}
+
+		query := a.db.PlanAddon.Query()
+
+		if params.ID != "" { // get plan add-on assignment by ID
+			query = query.Where(planaddondb.And(
+				planaddondb.Namespace(params.Namespace),
+				planaddondb.ID(params.ID)),
+			)
+		} else {
+			query = query.Where(planaddondb.And(
+				planaddondb.Namespace(params.Namespace),
+				planaddondb.HasPlanWith(plandb.Or(plandb.ID(params.PlanIDOrKey), plandb.Key(params.PlanIDOrKey))),
+				planaddondb.HasAddonWith(addondb.Or(addondb.ID(params.AddonIDOrKey), addondb.Key(params.AddonIDOrKey))),
+				planaddondb.DeletedAtIsNil(),
+			))
+		}
+
+		// Eager load Plan and Addon
+		query = query.
+			WithPlan(PlanEagerLoadPhasesWithRateCardsWithFeaturesFn).
+			WithAddon(AddonEagerLoadRateCardsWithFeaturesFn)
+
+		planAddonRow, err := query.First(ctx)
+		if err != nil {
+			if entdb.IsNotFound(err) {
+				return nil, planaddon.NewNotFoundError(planaddon.NotFoundErrorParams{
+					Namespace:    params.Namespace,
+					ID:           params.ID,
+					PlanIDOrKey:  params.PlanIDOrKey,
+					AddonIDOrKey: params.AddonIDOrKey,
+				})
+			}
+
+			return nil, fmt.Errorf("failed to get plan add-on assignment [namespace=%s planaddon.id=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.ID, params.PlanIDOrKey, params.AddonIDOrKey, err)
+		}
+
+		if planAddonRow == nil {
+			return nil, fmt.Errorf("invalid query result: nil plan add-on assignments received")
+		}
+
+		planAddon, err := FromPlanAddonRow(*planAddonRow)
+		if err != nil {
+			return nil, fmt.Errorf("failed to cast plan add-on assignment [namespace=%s planaddon.id=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.ID, params.PlanIDOrKey, params.AddonIDOrKey, err)
+		}
+
+		return planAddon, nil
+	}
+
+	return entutils.TransactingRepo[*planaddon.PlanAddon, *adapter](ctx, a, fn)
+}
+
+func (a *adapter) UpdatePlanAddon(ctx context.Context, params planaddon.UpdatePlanAddonInput) (*planaddon.PlanAddon, error) {
+	fn := func(ctx context.Context, a *adapter) (*planaddon.PlanAddon, error) {
+		if err := params.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid update add-on parameters: %w", err)
+		}
+
+		planAddon, err := a.GetPlanAddon(ctx, planaddon.GetPlanAddonInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: params.Namespace,
+			},
+			ID:           params.ID,
+			PlanIDOrKey:  params.PlanID,
+			AddonIDOrKey: params.AddonID,
+		})
+		if err != nil {
+			if entdb.IsNotFound(err) {
+				return nil, planaddon.NewNotFoundError(planaddon.NotFoundErrorParams{
+					Namespace:    params.Namespace,
+					PlanIDOrKey:  params.PlanID,
+					AddonIDOrKey: params.AddonID,
+				})
+			}
+
+			return nil, fmt.Errorf("failed to get plan add-on assignment for update : %w", err)
+		}
+
+		if !params.Equal(*planAddon) {
+			query := a.db.PlanAddon.UpdateOneID(planAddon.ID).
+				Where(planaddondb.Namespace(params.Namespace)).
+				SetNillableMaxQuantity(params.MaxQuantity)
+
+			if params.FromPlanPhase != nil {
+				query = query.SetFromPlanPhase(*params.FromPlanPhase)
+			}
+
+			if params.Annotations != nil {
+				query = query.SetAnnotations(*params.Annotations)
+			}
+
+			if params.Metadata != nil {
+				query = query.SetMetadata(*params.Metadata)
+			}
+
+			err = query.Exec(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to update add-on: %w", err)
+			}
+		}
+
+		// Plan add-on assignment needs to be re-fetched after updated in order to populate all sub-resources
+		planAddon, err = a.GetPlanAddon(ctx, planaddon.GetPlanAddonInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: params.Namespace,
+			},
+			ID: planAddon.ID,
+		})
+		if err != nil {
+			if entdb.IsNotFound(err) {
+				return nil, addon.NewNotFoundError(addon.NotFoundErrorParams{
+					Namespace: params.Namespace,
+					ID:        params.ID,
+				})
+			}
+
+			return nil, fmt.Errorf("failed to get updated add-on: %w", err)
+		}
+
+		return planAddon, nil
+	}
+
+	return entutils.TransactingRepo[*planaddon.PlanAddon, *adapter](ctx, a, fn)
+}

--- a/openmeter/productcatalog/planaddon/assert.go
+++ b/openmeter/productcatalog/planaddon/assert.go
@@ -12,7 +12,6 @@ func AssertPlanAddonCreateInputEqual(t *testing.T, i CreatePlanAddonInput, a Pla
 	assert.Equalf(t, i.Namespace, a.Namespace, "create input: namespace mismatch")
 	assert.Equalf(t, i.Metadata, a.Metadata, "metadata mismatch")
 	assert.Equalf(t, i.Annotations, a.Annotations, "annotations mismatch")
-	assert.Equalf(t, i.Annotations, a.Annotations, "annotations mismatch")
 	assert.Equalf(t, i.PlanID, a.Plan.ID, "plan id mismatch")
 	assert.Equalf(t, i.AddonID, a.Addon.ID, "add-on id mismatch")
 	assert.Equalf(t, i.FromPlanPhase, a.FromPlanPhase, "plan phase key mismatch")
@@ -52,7 +51,7 @@ func AssertPlanAddonUpdateInputEqual(t *testing.T, i UpdatePlanAddonInput, a Pla
 	}
 
 	if i.MaxQuantity != nil {
-		assert.Equalf(t, *i.MaxQuantity, a.MaxQuantity, "max quality mismatch")
+		assert.Equalf(t, *i.MaxQuantity, *a.MaxQuantity, "max quality mismatch")
 	}
 }
 

--- a/openmeter/productcatalog/planaddon/assert.go
+++ b/openmeter/productcatalog/planaddon/assert.go
@@ -1,0 +1,66 @@
+package planaddon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func AssertPlanAddonCreateInputEqual(t *testing.T, i CreatePlanAddonInput, a PlanAddon) {
+	t.Helper()
+
+	assert.Equalf(t, i.Namespace, a.Namespace, "create input: namespace mismatch")
+	assert.Equalf(t, i.Metadata, a.Metadata, "metadata mismatch")
+	assert.Equalf(t, i.Annotations, a.Annotations, "annotations mismatch")
+	assert.Equalf(t, i.Annotations, a.Annotations, "annotations mismatch")
+	assert.Equalf(t, i.PlanID, a.Plan.ID, "plan id mismatch")
+	assert.Equalf(t, i.AddonID, a.Addon.ID, "add-on id mismatch")
+	assert.Equalf(t, i.FromPlanPhase, a.FromPlanPhase, "plan phase key mismatch")
+
+	if i.MaxQuantity != nil {
+		assert.Equalf(t, *i.MaxQuantity, *a.MaxQuantity, "max quantity mismatch")
+	}
+}
+
+func AssertPlanAddonUpdateInputEqual(t *testing.T, i UpdatePlanAddonInput, a PlanAddon) {
+	t.Helper()
+
+	assert.Equalf(t, i.Namespace, a.Namespace, "update input: namespace mismatch")
+
+	if i.Metadata != nil {
+		assert.Equalf(t, *i.Metadata, a.Metadata, "metadata mismatch")
+	}
+
+	if i.Annotations != nil {
+		assert.Equalf(t, *i.Annotations, a.Annotations, "annotations mismatch")
+	}
+
+	if i.ID != "" {
+		assert.Equalf(t, i.ID, a.ID, "id mismatch")
+	}
+
+	if i.PlanID != "" {
+		assert.Equalf(t, i.PlanID, a.Plan.ID, "plan id mismatch")
+	}
+
+	if i.AddonID != "" {
+		assert.Equalf(t, i.AddonID, a.Addon.ID, "add-on id mismatch")
+	}
+
+	if i.FromPlanPhase != nil {
+		assert.Equalf(t, *i.FromPlanPhase, a.FromPlanPhase, "plan phase key mismatch")
+	}
+
+	if i.MaxQuantity != nil {
+		assert.Equalf(t, *i.MaxQuantity, a.MaxQuantity, "max quality mismatch")
+	}
+}
+
+func AssertPlanAddonEqual(t *testing.T, expected, actual PlanAddon) {
+	t.Helper()
+
+	assert.Equalf(t, expected.ID, actual.ID, "id mismatch")
+	assert.Equalf(t, expected.FromPlanPhase, actual.FromPlanPhase, "plan phase key mismatch")
+	assert.Equalf(t, expected.Metadata, actual.Metadata, "metadata mismatch")
+	assert.Equalf(t, expected.Annotations, actual.Annotations, "annotations mismatch")
+}

--- a/openmeter/productcatalog/planaddon/errors.go
+++ b/openmeter/productcatalog/planaddon/errors.go
@@ -1,0 +1,72 @@
+package planaddon
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+var _ error = (*NotFoundError)(nil)
+
+type NotFoundErrorParams struct {
+	Namespace    string
+	ID           string
+	PlanIDOrKey  string
+	AddonIDOrKey string
+}
+
+func NewNotFoundError(e NotFoundErrorParams) *NotFoundError {
+	var m string
+
+	if e.Namespace != "" {
+		m += fmt.Sprintf(" namespace=%s", e.Namespace)
+	}
+
+	if e.ID != "" {
+		m += fmt.Sprintf(" id=%s", e.ID)
+	}
+
+	if e.PlanIDOrKey != "" {
+		m += fmt.Sprintf(" plan.idOrKey=%s", e.PlanIDOrKey)
+	}
+
+	if e.AddonIDOrKey != "" {
+		m += fmt.Sprintf(" addon.idOrKey=%s", e.AddonIDOrKey)
+	}
+
+	if len(m) > 0 {
+		m = fmt.Sprintf("plan add-on assignment not found [%s]", m[1:])
+	} else {
+		m = "plan add-on assignment not found"
+	}
+
+	return &NotFoundError{
+		err: models.NewGenericNotFoundError(
+			errors.New(m),
+		),
+	}
+}
+
+var _ models.GenericError = &NotFoundError{}
+
+type NotFoundError struct {
+	err error
+}
+
+func (e *NotFoundError) Error() string {
+	return e.err.Error()
+}
+
+func (e *NotFoundError) Unwrap() error {
+	return e.err
+}
+
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	var e *NotFoundError
+
+	return errors.As(err, &e)
+}

--- a/openmeter/productcatalog/planaddon/errors_test.go
+++ b/openmeter/productcatalog/planaddon/errors_test.go
@@ -1,0 +1,85 @@
+package planaddon
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNotFoundError(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Error         error
+		ExpectedError bool
+	}{
+		{
+			Name: "Valid",
+			Error: NewNotFoundError(NotFoundErrorParams{
+				Namespace: "test",
+				ID:        "test",
+			}),
+			ExpectedError: true,
+		},
+		{
+			Name: "Wrapped",
+			Error: fmt.Errorf("wrapped: %w", NewNotFoundError(NotFoundErrorParams{
+				Namespace: "test",
+				ID:        "test",
+			}),
+			),
+			ExpectedError: true,
+		},
+		{
+			Name:          "Invalid",
+			Error:         errors.New("test error"),
+			ExpectedError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			assert.Equal(t, test.ExpectedError, IsNotFound(test.Error))
+		})
+	}
+}
+
+func TestIsNotFoundError_String(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Error         error
+		ExpectedError string
+	}{
+		{
+			Name: "ID",
+			Error: NewNotFoundError(NotFoundErrorParams{
+				Namespace: "namespace",
+				ID:        "id",
+			}),
+			ExpectedError: "not found error: plan add-on assignment not found [namespace=namespace id=id]",
+		},
+		{
+			Name: "Key",
+			Error: NewNotFoundError(NotFoundErrorParams{
+				Namespace:    "namespace",
+				PlanIDOrKey:  "plan_key",
+				AddonIDOrKey: "addon_key",
+			}),
+			ExpectedError: "not found error: plan add-on assignment not found [namespace=namespace plan.idOrKey=plan_key addon.idOrKey=addon_key]",
+		},
+		{
+			Name:          "Default",
+			Error:         NewNotFoundError(NotFoundErrorParams{}),
+			ExpectedError: "not found error: plan add-on assignment not found",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			t.Logf("%v", test.Error)
+
+			assert.Equal(t, test.ExpectedError, test.Error.Error())
+		})
+	}
+}

--- a/openmeter/productcatalog/planaddon/event.go
+++ b/openmeter/productcatalog/planaddon/event.go
@@ -1,0 +1,152 @@
+package planaddon
+
+import (
+	"context"
+	"errors"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/event/metadata"
+	"github.com/openmeterio/openmeter/openmeter/session"
+)
+
+const (
+	PlanAddonEventSubsystem  metadata.EventSubsystem = "planaddon"
+	PlanAddonCreateEventName metadata.EventName      = "planaddon.created"
+	PlanAddonUpdateEventName metadata.EventName      = "planaddon.updated"
+	PlanAddonDeleteEventName metadata.EventName      = "planaddon.deleted"
+)
+
+// NewPlanAddonCreateEvent creates a new PlanAddon create event
+func NewPlanAddonCreateEvent(ctx context.Context, planAddon *PlanAddon) PlanAddonCreateEvent {
+	return PlanAddonCreateEvent{
+		PlanAddon: planAddon,
+		UserID:    session.GetSessionUserID(ctx),
+	}
+}
+
+// PlanAddonCreateEvent is an event that is emitted when an PlanAddon is created
+type PlanAddonCreateEvent struct {
+	PlanAddon *PlanAddon `json:"planAddon"`
+	UserID    *string    `json:"userId,omitempty"`
+}
+
+func (e PlanAddonCreateEvent) EventName() string {
+	return metadata.GetEventName(metadata.EventType{
+		Subsystem: PlanAddonEventSubsystem,
+		Name:      PlanAddonCreateEventName,
+		Version:   "v1",
+	})
+}
+
+func (e PlanAddonCreateEvent) EventMetadata() metadata.EventMetadata {
+	resourcePath := metadata.ComposeResourcePath(e.PlanAddon.Namespace, metadata.EntityAddon, e.PlanAddon.ID)
+
+	return metadata.EventMetadata{
+		ID:      ulid.Make().String(),
+		Source:  resourcePath,
+		Subject: resourcePath,
+		Time:    e.PlanAddon.CreatedAt,
+	}
+}
+
+func (e PlanAddonCreateEvent) Validate() error {
+	var errs []error
+
+	if e.PlanAddon == nil {
+		errs = append(errs, errors.New("plan add-on assignment is required"))
+	}
+
+	return errors.Join(errs...)
+}
+
+// NewPlanAddonUpdateEvent creates a new PlanAddon update event
+func NewPlanAddonUpdateEvent(ctx context.Context, addon *PlanAddon) PlanAddonUpdateEvent {
+	return PlanAddonUpdateEvent{
+		PlanAddon: addon,
+		UserID:    session.GetSessionUserID(ctx),
+	}
+}
+
+// PlanAddonUpdateEvent is an event that is emitted when an PlanAddon is updated
+type PlanAddonUpdateEvent struct {
+	PlanAddon *PlanAddon `json:"planAddon"`
+	UserID    *string    `json:"userId,omitempty"`
+}
+
+func (e PlanAddonUpdateEvent) EventName() string {
+	return metadata.GetEventName(metadata.EventType{
+		Subsystem: PlanAddonEventSubsystem,
+		Name:      PlanAddonUpdateEventName,
+		Version:   "v1",
+	})
+}
+
+func (e PlanAddonUpdateEvent) EventMetadata() metadata.EventMetadata {
+	resourcePath := metadata.ComposeResourcePath(e.PlanAddon.Namespace, metadata.EntityAddon, e.PlanAddon.ID)
+
+	return metadata.EventMetadata{
+		ID:      ulid.Make().String(),
+		Source:  resourcePath,
+		Subject: resourcePath,
+		Time:    e.PlanAddon.UpdatedAt,
+	}
+}
+
+func (e PlanAddonUpdateEvent) Validate() error {
+	var errs []error
+
+	if e.PlanAddon == nil {
+		errs = append(errs, errors.New("plan add-on assignment is required"))
+	}
+
+	return errors.Join(errs...)
+}
+
+// NewPlanAddonDeleteEvent creates a new PlanAddon delete event
+func NewPlanAddonDeleteEvent(ctx context.Context, addon *PlanAddon) PlanAddonDeleteEvent {
+	return PlanAddonDeleteEvent{
+		PlanAddon: addon,
+		UserID:    session.GetSessionUserID(ctx),
+	}
+}
+
+// PlanAddonDeleteEvent is an event that is emitted when an PlanAddon is deleted
+type PlanAddonDeleteEvent struct {
+	PlanAddon *PlanAddon `json:"planAddon"`
+	UserID    *string    `json:"userId,omitempty"`
+}
+
+func (e PlanAddonDeleteEvent) EventName() string {
+	return metadata.GetEventName(metadata.EventType{
+		Subsystem: PlanAddonEventSubsystem,
+		Name:      PlanAddonDeleteEventName,
+		Version:   "v1",
+	})
+}
+
+func (e PlanAddonDeleteEvent) EventMetadata() metadata.EventMetadata {
+	resourcePath := metadata.ComposeResourcePath(e.PlanAddon.Namespace, metadata.EntityAddon, e.PlanAddon.ID)
+
+	return metadata.EventMetadata{
+		ID:      ulid.Make().String(),
+		Source:  resourcePath,
+		Subject: resourcePath,
+		Time:    lo.FromPtr(e.PlanAddon.DeletedAt),
+	}
+}
+
+func (e PlanAddonDeleteEvent) Validate() error {
+	var errs []error
+
+	if e.PlanAddon == nil {
+		errs = append(errs, errors.New("plan add-on assignment is required"))
+	}
+
+	if e.PlanAddon.DeletedAt == nil {
+		errs = append(errs, errors.New(`"deleted at" attribute for plan add-on assignment is required`))
+	}
+
+	return errors.Join(errs...)
+}

--- a/openmeter/productcatalog/planaddon/event.go
+++ b/openmeter/productcatalog/planaddon/event.go
@@ -144,7 +144,7 @@ func (e PlanAddonDeleteEvent) Validate() error {
 		errs = append(errs, errors.New("plan add-on assignment is required"))
 	}
 
-	if e.PlanAddon.DeletedAt == nil {
+	if e.PlanAddon != nil && e.PlanAddon.DeletedAt == nil {
 		errs = append(errs, errors.New(`"deleted at" attribute for plan add-on assignment is required`))
 	}
 

--- a/openmeter/productcatalog/planaddon/planaddon.go
+++ b/openmeter/productcatalog/planaddon/planaddon.go
@@ -1,0 +1,59 @@
+package planaddon
+
+import (
+	"errors"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+var _ models.Validator = (*PlanAddon)(nil)
+
+type PlanAddon struct {
+	models.NamespacedID
+	models.ManagedModel
+
+	productcatalog.PlanAddonMeta
+
+	// Addon
+	Plan plan.Plan `json:"plan"`
+
+	// Addon
+	Addon addon.Addon `json:"addon"`
+}
+
+func (a PlanAddon) Validate() error {
+	var errs []error
+
+	if err := a.NamespacedID.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := a.ManagedModel.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := a.Plan.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := a.Addon.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if err := a.AsProductCatalogPlanAddon().Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func (a PlanAddon) AsProductCatalogPlanAddon() productcatalog.PlanAddon {
+	return productcatalog.PlanAddon{
+		PlanAddonMeta: a.PlanAddonMeta,
+		Plan:          a.Plan.AsProductCatalogPlan2(),
+		Addon:         a.Addon.AsProductCatalogAddon(),
+	}
+}

--- a/openmeter/productcatalog/planaddon/repository.go
+++ b/openmeter/productcatalog/planaddon/repository.go
@@ -1,0 +1,18 @@
+package planaddon
+
+import (
+	"context"
+
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+)
+
+type Repository interface {
+	entutils.TxCreator
+
+	ListPlanAddons(ctx context.Context, params ListPlanAddonsInput) (pagination.PagedResponse[PlanAddon], error)
+	CreatePlanAddon(ctx context.Context, params CreatePlanAddonInput) (*PlanAddon, error)
+	DeletePlanAddon(ctx context.Context, params DeletePlanAddonInput) error
+	GetPlanAddon(ctx context.Context, params GetPlanAddonInput) (*PlanAddon, error)
+	UpdatePlanAddon(ctx context.Context, params UpdatePlanAddonInput) (*PlanAddon, error)
+}

--- a/openmeter/productcatalog/planaddon/service.go
+++ b/openmeter/productcatalog/planaddon/service.go
@@ -1,0 +1,273 @@
+package planaddon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+	"github.com/openmeterio/openmeter/pkg/sortx"
+)
+
+const timeJitter = 30 * time.Second
+
+const (
+	OrderAsc  = sortx.OrderAsc
+	OrderDesc = sortx.OrderDesc
+)
+
+const (
+	OrderByID        OrderBy = "id"
+	OrderByCreatedAt OrderBy = "created_at"
+	OrderByUpdatedAt OrderBy = "updated_at"
+)
+
+type OrderBy string
+
+type Service interface {
+	ListPlanAddons(ctx context.Context, params ListPlanAddonsInput) (pagination.PagedResponse[PlanAddon], error)
+	CreatePlanAddon(ctx context.Context, params CreatePlanAddonInput) (*PlanAddon, error)
+	DeletePlanAddon(ctx context.Context, params DeletePlanAddonInput) error
+	GetPlanAddon(ctx context.Context, params GetPlanAddonInput) (*PlanAddon, error)
+	UpdatePlanAddon(ctx context.Context, params UpdatePlanAddonInput) (*PlanAddon, error)
+}
+
+var _ models.Validator = (*ListPlanAddonsInput)(nil)
+
+type ListPlanAddonsInput struct {
+	// Page is the pagination parameters.
+	pagination.Page
+
+	// OrderBy is the field to order by.
+	OrderBy OrderBy
+
+	// Order is the order direction.
+	Order sortx.Order
+
+	// Namespaces is the list of namespaces to filter by.
+	Namespaces []string
+
+	// IDs is the list of PlanAddonAssignment ids to filter by.
+	IDs []string
+
+	// PlanIDs is the list of plan.Plan ids to filter by.
+	PlanIDs []string
+
+	// PlanKeys is the list of plan.Plan keys to filter by.
+	PlanKeys []string
+
+	// PlanKeyVersions is the map of plan.Plan versioned keys to filter by.
+	PlanKeyVersions map[string][]int
+
+	// AddonIDs is the list of addon.Addon ids to filter by.
+	AddonIDs []string
+
+	// AddonKeys is the list of addon.Addon keys to filter by.
+	AddonKeys []string
+
+	// AddonKeyVersions is the map of addon.Addon versioned keys to filter by.
+	AddonKeyVersions map[string][]int
+
+	// IncludeDeleted defines whether to include deleted PlanAddonAssignments.
+	IncludeDeleted bool
+
+	// Currencies is the list of currencies to filter by.
+	Currencies []string
+}
+
+func (i ListPlanAddonsInput) Validate() error {
+	return nil
+}
+
+var _ models.Validator = (*CreatePlanAddonInput)(nil)
+
+type CreatePlanAddonInput struct {
+	models.NamespacedModel
+
+	// Metadata
+	Metadata models.Metadata `json:"metadata,omitempty"`
+
+	// Annotations
+	Annotations models.Annotations `json:"annotations,omitempty"`
+
+	// PlanID
+	PlanID string `json:"planId"`
+
+	// AddonID
+	AddonID string `json:"addonId"`
+
+	// FromPhase
+	FromPlanPhase string `json:"fromPlanPhase"`
+
+	// MaxQuantity
+	MaxQuantity *int `json:"maxQuantity"`
+}
+
+func (i CreatePlanAddonInput) Validate() error {
+	var errs []error
+
+	if err := i.NamespacedModel.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("invalid namespace: %w", err))
+	}
+
+	if i.PlanID == "" {
+		errs = append(errs, errors.New("invalid add-on assignment: plan id must be provided"))
+	}
+
+	if i.AddonID == "" {
+		errs = append(errs, errors.New("invalid add-on assignment: add-on id must be provided"))
+	}
+
+	return errors.Join(errs...)
+}
+
+var (
+	_ models.Validator          = (*UpdatePlanAddonInput)(nil)
+	_ models.Equaler[PlanAddon] = (*UpdatePlanAddonInput)(nil)
+)
+
+type UpdatePlanAddonInput struct {
+	models.NamespacedModel
+
+	// Annotations
+	Annotations *models.Annotations `json:"annotations,omitempty"`
+
+	// Annotations
+	Metadata *models.Metadata `json:"metadata,omitempty"`
+
+	// ID defines the plan add-on assignment ID
+	ID string `json:"id"`
+
+	// PlanID
+	PlanID string `json:"planId"`
+
+	// AddonID
+	AddonID string `json:"addonId"`
+
+	// FromPhase
+	FromPlanPhase *string `json:"fromPlanPhase"`
+
+	// MaxQuantity
+	MaxQuantity *int `json:"maxQuantity"`
+}
+
+func (i UpdatePlanAddonInput) Equal(p PlanAddon) bool {
+	if i.Namespace != p.Namespace {
+		return false
+	}
+
+	if i.PlanID != p.Plan.ID {
+		return false
+	}
+
+	if i.AddonID != p.Addon.ID {
+		return false
+	}
+
+	if i.FromPlanPhase != nil && *i.FromPlanPhase != p.FromPlanPhase {
+		return false
+	}
+
+	if i.MaxQuantity == nil && p.MaxQuantity != nil {
+		return false
+	}
+
+	if i.MaxQuantity != nil && p.MaxQuantity == nil {
+		return false
+	}
+
+	if lo.FromPtr(i.MaxQuantity) != lo.FromPtr(p.MaxQuantity) {
+		return false
+	}
+
+	return true
+}
+
+func (i UpdatePlanAddonInput) Validate() error {
+	var errs []error
+
+	if i.Namespace == "" {
+		errs = append(errs, errors.New("invalid Namespace: must not be empty"))
+	}
+
+	if i.ID == "" {
+		if i.PlanID == "" {
+			errs = append(errs, errors.New("plan id must be provided if assignment id is not provided"))
+		}
+
+		if i.AddonID == "" {
+			errs = append(errs, errors.New("add-on id must be provided if assignment id is not provided"))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// GetPlanAddonInput defines the input parameters for fetching plan add-on assignment either by PlanAddon.ID or
+// by the plan and add-on identifiers.
+type GetPlanAddonInput struct {
+	models.NamespacedModel
+
+	// ID defines the plan add-on assignment ID
+	ID string `json:"id"`
+
+	// PlanIDOrKey
+	PlanIDOrKey string `json:"planIdOrKey"`
+
+	// AddonIDOrKey
+	AddonIDOrKey string `json:"addonIdOrKey"`
+}
+
+func (i GetPlanAddonInput) Validate() error {
+	var errs []error
+
+	if err := i.NamespacedModel.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("invalid namespace: %w", err))
+	}
+
+	if i.ID == "" {
+		if i.PlanIDOrKey == "" {
+			errs = append(errs, errors.New("plan id or key must be provided if assignment id is not provided"))
+		}
+
+		if i.AddonIDOrKey == "" {
+			errs = append(errs, errors.New("add-on id or key must be provided if assignment id is not provided"))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+type DeletePlanAddonInput struct {
+	models.NamespacedModel
+
+	ID string `json:"id"`
+
+	PlanID string `json:"planID"`
+
+	AddonID string `json:"addonID"`
+}
+
+func (i DeletePlanAddonInput) Validate() error {
+	var errs []error
+
+	if err := i.NamespacedModel.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("invalid namespace: %w", err))
+	}
+
+	if i.ID == "" {
+		if i.PlanID == "" {
+			errs = append(errs, errors.New("plan id must be provided if assignment id is not provided"))
+		}
+
+		if i.AddonID == "" {
+			errs = append(errs, errors.New("add-on id must be provided if assignment id is not provided"))
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/openmeter/productcatalog/planaddon/testutils/addon.go
+++ b/openmeter/productcatalog/planaddon/testutils/addon.go
@@ -1,0 +1,34 @@
+package testutils
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/currency"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func NewTestAddon(t *testing.T, namespace string) addon.CreateAddonInput {
+	t.Helper()
+
+	return addon.CreateAddonInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: namespace,
+		},
+		Addon: productcatalog.Addon{
+			AddonMeta: productcatalog.AddonMeta{
+				Key:          "addon1",
+				Name:         "Addon v1",
+				Description:  lo.ToPtr("Addon v1"),
+				Metadata:     models.Metadata{"name": "addon1"},
+				Annotations:  models.Annotations{"key": "value"},
+				Currency:     currency.USD,
+				InstanceType: productcatalog.AddonInstanceTypeSingle,
+			},
+			RateCards: nil,
+		},
+	}
+}

--- a/openmeter/productcatalog/planaddon/testutils/env.go
+++ b/openmeter/productcatalog/planaddon/testutils/env.go
@@ -1,0 +1,135 @@
+package testutils
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	meteradapter "github.com/openmeterio/openmeter/openmeter/meter/mockadapter"
+	productcatalogadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/adapter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	addonadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/addon/adapter"
+	addonservice "github.com/openmeterio/openmeter/openmeter/productcatalog/addon/service"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	planadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/plan/adapter"
+	planservice "github.com/openmeterio/openmeter/openmeter/productcatalog/plan/service"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+)
+
+type TestEnv struct {
+	Logger    *slog.Logger
+	Publisher eventbus.Publisher
+	Meter     *meteradapter.TestAdapter
+	Feature   feature.FeatureConnector
+	Plan      plan.Service
+	Addon     addon.Service
+
+	Client *entdb.Client
+	db     *testutils.TestDB
+	close  sync.Once
+}
+
+func (e *TestEnv) DBSchemaMigrate(t *testing.T) {
+	t.Helper()
+
+	require.NotNilf(t, e.db, "database must be initialized")
+
+	err := e.db.EntDriver.Client().Schema.Create(context.Background())
+	require.NoErrorf(t, err, "schema migration must not fail")
+}
+
+func (e *TestEnv) Close(t *testing.T) {
+	t.Helper()
+
+	e.close.Do(func() {
+		if e.db != nil {
+			if err := e.db.EntDriver.Close(); err != nil {
+				t.Errorf("failed to close ent driver: %v", err)
+			}
+
+			if err := e.db.PGDriver.Close(); err != nil {
+				t.Errorf("failed to postgres driver: %v", err)
+			}
+		}
+
+		if e.Client != nil {
+			if err := e.Client.Close(); err != nil {
+				t.Errorf("failed to close ent client: %v", err)
+			}
+		}
+	})
+}
+
+func NewTestEnv(t *testing.T) *TestEnv {
+	t.Helper()
+
+	// Init logger
+	logger := testutils.NewDiscardLogger(t)
+
+	// Init database
+	db := testutils.InitPostgresDB(t)
+	client := db.EntDriver.Client()
+
+	// Init event publisher
+	publisher := eventbus.NewMock(t)
+
+	// Init meter service
+	meterAdapter, err := meteradapter.New(nil)
+	require.NoErrorf(t, err, "initializing meter adapter must not fail")
+	require.NotNilf(t, meterAdapter, "meter adapter must not be nil")
+
+	// Init feature service
+	featureAdapter := productcatalogadapter.NewPostgresFeatureRepo(client, logger)
+	featureService := feature.NewFeatureConnector(featureAdapter, meterAdapter, publisher)
+
+	// Init plan service
+	planAdapter, err := planadapter.New(planadapter.Config{
+		Client: client,
+		Logger: logger,
+	})
+	require.NoErrorf(t, err, "initializing plan adapter must not fail")
+	require.NotNilf(t, planAdapter, "plan adapter must not be nil")
+
+	planService, err := planservice.New(planservice.Config{
+		Adapter:   planAdapter,
+		Feature:   featureService,
+		Logger:    logger,
+		Publisher: publisher,
+	})
+	require.NoErrorf(t, err, "initializing plan service must not fail")
+	require.NotNilf(t, planService, "plan service must not be nil")
+
+	// Init addon service
+	addonAdapter, err := addonadapter.New(addonadapter.Config{
+		Client: client,
+		Logger: logger,
+	})
+	require.NoErrorf(t, err, "initializing addon adapter must not fail")
+	require.NotNilf(t, addonAdapter, "addon adapter must not be nil")
+
+	addonService, err := addonservice.New(addonservice.Config{
+		Adapter:   addonAdapter,
+		Feature:   featureService,
+		Logger:    logger,
+		Publisher: publisher,
+	})
+	require.NoErrorf(t, err, "initializing addon service must not fail")
+	require.NotNilf(t, addonService, "addon service must not be nil")
+
+	return &TestEnv{
+		Logger:    logger,
+		Publisher: publisher,
+		Meter:     meterAdapter,
+		Feature:   featureService,
+		Plan:      planService,
+		Addon:     addonService,
+		db:        db,
+		Client:    client,
+	}
+}

--- a/openmeter/productcatalog/planaddon/testutils/feature.go
+++ b/openmeter/productcatalog/planaddon/testutils/feature.go
@@ -1,0 +1,33 @@
+package testutils
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+)
+
+func NewTestFeature(t *testing.T, namespace string) feature.CreateFeatureInputs {
+	t.Helper()
+
+	return feature.CreateFeatureInputs{
+		Name:      "Feature 1",
+		Key:       "feature1",
+		Namespace: namespace,
+	}
+}
+
+func NewTestFeatureFromMeter(t *testing.T, meter *meter.Meter) feature.CreateFeatureInputs {
+	t.Helper()
+
+	return feature.CreateFeatureInputs{
+		Name:                meter.Key,
+		Key:                 meter.Key,
+		Namespace:           meter.Namespace,
+		MeterSlug:           lo.ToPtr(meter.Key),
+		MeterGroupByFilters: meter.GroupBy,
+		Metadata:            map[string]string{},
+	}
+}

--- a/openmeter/productcatalog/planaddon/testutils/meters.go
+++ b/openmeter/productcatalog/planaddon/testutils/meters.go
@@ -1,0 +1,81 @@
+package testutils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func NewTestMeters(t *testing.T, namespace string) []meter.Meter {
+	t.Helper()
+
+	return []meter.Meter{
+		{
+			ManagedResource: models.ManagedResource{
+				ID: NewTestULID(t),
+				NamespacedModel: models.NamespacedModel{
+					Namespace: namespace,
+				},
+				ManagedModel: models.ManagedModel{
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+				Name: "Test meter",
+			},
+			Key:         "api_requests_total",
+			Aggregation: meter.MeterAggregationCount,
+			EventType:   "request",
+			GroupBy: map[string]string{
+				"method": "$.method",
+				"path":   "$.path",
+			},
+		},
+		{
+			ManagedResource: models.ManagedResource{
+				ID: NewTestULID(t),
+				NamespacedModel: models.NamespacedModel{
+					Namespace: namespace,
+				},
+				ManagedModel: models.ManagedModel{
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+				Name: "Test meter",
+			},
+			Key:           "tokens_total",
+			Aggregation:   meter.MeterAggregationSum,
+			EventType:     "prompt",
+			ValueProperty: lo.ToPtr("$.tokens"),
+			GroupBy: map[string]string{
+				"model": "$.model",
+				"type":  "$.type",
+			},
+		},
+		{
+			ManagedResource: models.ManagedResource{
+				ID: NewTestULID(t),
+				NamespacedModel: models.NamespacedModel{
+					Namespace: namespace,
+				},
+				ManagedModel: models.ManagedModel{
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+				Name: "Test meter",
+			},
+			Key:           "workload_runtime_duration_seconds",
+			Aggregation:   meter.MeterAggregationSum,
+			EventType:     "workload",
+			ValueProperty: lo.ToPtr("$.duration_seconds"),
+			GroupBy: map[string]string{
+				"region":        "$.region",
+				"zone":          "$.zone",
+				"instance_type": "$.instance_type",
+			},
+		},
+	}
+}

--- a/openmeter/productcatalog/planaddon/testutils/namespace.go
+++ b/openmeter/productcatalog/planaddon/testutils/namespace.go
@@ -1,0 +1,17 @@
+package testutils
+
+import (
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+)
+
+func NewTestULID(t *testing.T) string {
+	t.Helper()
+
+	return ulid.MustNew(ulid.Timestamp(time.Now().UTC()), rand.Reader).String()
+}
+
+var NewTestNamespace = NewTestULID

--- a/openmeter/productcatalog/planaddon/testutils/plan.go
+++ b/openmeter/productcatalog/planaddon/testutils/plan.go
@@ -1,0 +1,31 @@
+package testutils
+
+import (
+	"testing"
+
+	"github.com/invopop/gobl/currency"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func NewTestPlan(t *testing.T, namespace string) plan.CreatePlanInput {
+	t.Helper()
+
+	return plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Key:         "pro",
+				Name:        "Pro",
+				Description: lo.ToPtr("Pro plan v1"),
+				Metadata:    models.Metadata{"name": "pro"},
+				Currency:    currency.USD,
+			},
+		},
+	}
+}

--- a/openmeter/testutils/logger.go
+++ b/openmeter/testutils/logger.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 )
@@ -13,5 +14,15 @@ func NewLogger(t testing.TB) *slog.Logger {
 func NewDiscardLogger(t testing.TB) *slog.Logger {
 	t.Helper()
 
-	return slog.New(slog.DiscardHandler)
+	return slog.New(discardHandler{})
 }
+
+// TODO: remove discardHandler as soon as the project is bumped to go1.24 as minimum version
+// where the discard handler has been introduced.
+// This is the exact copy from slog package: https://cs.opensource.google/go/go/+/refs/tags/go1.24.2:src/log/slog/handler.go;l=608-615
+type discardHandler struct{}
+
+func (dh discardHandler) Enabled(context.Context, slog.Level) bool  { return false }
+func (dh discardHandler) Handle(context.Context, slog.Record) error { return nil }
+func (dh discardHandler) WithAttrs(attrs []slog.Attr) slog.Handler  { return dh }
+func (dh discardHandler) WithGroup(name string) slog.Handler        { return dh }

--- a/openmeter/testutils/logger.go
+++ b/openmeter/testutils/logger.go
@@ -1,7 +1,6 @@
 package testutils
 
 import (
-	"context"
 	"log/slog"
 	"testing"
 )
@@ -11,16 +10,8 @@ func NewLogger(t testing.TB) *slog.Logger {
 	return slog.Default()
 }
 
-// discardHandler is a slog.Handler implementation which does not emit log messages
-// See: https://go-review.googlesource.com/c/go/+/548335/5/src/log/slog/example_discard_test.go#14
-type discardHandler struct {
-	slog.JSONHandler
-}
-
-func (d *discardHandler) Enabled(context.Context, slog.Level) bool { return false }
-
 func NewDiscardLogger(t testing.TB) *slog.Logger {
 	t.Helper()
 
-	return slog.New(&discardHandler{})
+	return slog.New(slog.DiscardHandler)
 }


### PR DESCRIPTION
## Overview

Add adapter implementation for plan add-on assignment service which includes common types and the adapter itself.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive support for managing plan add-ons, including creation, retrieval, updating, listing, and deletion.
  - Added event types and error handling specific to plan add-on lifecycle events.
  - Enhanced validation and conversion for plan add-on entities.
  - Added a new method to convert plans without filtering deleted phases.
  - Implemented a transactional repository adapter for plan add-ons with integrated logging.
  - Provided a structured service interface with robust input validation and flexible filtering for plan add-ons.

- **Bug Fixes**
  - Improved error messages and validation checks for plan add-on assignments.
  - Enhanced validation to verify phase keys and rate card compatibility in plan add-ons.

- **Tests**
  - Added extensive integration and unit tests for plan add-on functionality, including lifecycle operations.
  - Introduced test utilities for creating consistent test data for plans, add-ons, features, meters, and namespaces.
  - Provided assertion helpers to facilitate plan add-on test validations.

- **Documentation**
  - Updated and clarified error messages and event metadata for better traceability.

- **Refactor**
  - Refactored plan add-on assignment structures for improved metadata handling and validation logic.
  - Improved internal logging and error handling in adapters and test environments.
  - Replaced discard logger implementation with a full interface-compliant handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->