### PR TITLE
feat: add planaddon service implementation

### DIFF
--- a/openmeter/productcatalog/planaddon/adapter/planaddon.go
+++ b/openmeter/productcatalog/planaddon/adapter/planaddon.go
@@ -164,7 +164,8 @@ func (a *adapter) ListPlanAddons(ctx context.Context, params planaddon.ListPlanA
 func (a *adapter) CreatePlanAddon(ctx context.Context, params planaddon.CreatePlanAddonInput) (*planaddon.PlanAddon, error) {
 	fn := func(ctx context.Context, a *adapter) (*planaddon.PlanAddon, error) {
 		if err := params.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid create plan add-on assignment parameters: %w", err)
+			return nil, fmt.Errorf("invalid create plan add-on assignment parameters [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
 		}
 
 		planAddonRow, err := a.db.PlanAddon.Create().
@@ -360,7 +361,7 @@ func (a *adapter) UpdatePlanAddon(ctx context.Context, params planaddon.UpdatePl
 				})
 			}
 
-			return nil, fmt.Errorf("failed to get plan add-on assignment for update : %w", err)
+			return nil, fmt.Errorf("failed to get plan add-on assignment for update: %w", err)
 		}
 
 		if !params.Equal(*planAddon) {

--- a/openmeter/productcatalog/planaddon/service/planaddon.go
+++ b/openmeter/productcatalog/planaddon/service/planaddon.go
@@ -1,0 +1,352 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+)
+
+func (s service) ListPlanAddons(ctx context.Context, params planaddon.ListPlanAddonsInput) (pagination.PagedResponse[planaddon.PlanAddon], error) {
+	fn := func(ctx context.Context) (pagination.PagedResponse[planaddon.PlanAddon], error) {
+		if err := params.Validate(); err != nil {
+			return pagination.PagedResponse[planaddon.PlanAddon]{}, fmt.Errorf("invalid list plan add-on assignment params: %w", err)
+		}
+
+		return s.adapter.ListPlanAddons(ctx, params)
+	}
+
+	return fn(ctx)
+}
+
+func (s service) CreatePlanAddon(ctx context.Context, params planaddon.CreatePlanAddonInput) (*planaddon.PlanAddon, error) {
+	fn := func(ctx context.Context) (*planaddon.PlanAddon, error) {
+		if err := params.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid create plan add-on assignment params [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
+		}
+
+		logger := s.logger.With(
+			"operation", "create",
+			"namespace", params.Namespace,
+			"plan.id", params.PlanID,
+			"addon.id", params.AddonID,
+		)
+
+		// Check whether plan add-on assignment already exists or not
+		planAddons, err := s.ListPlanAddons(ctx, planaddon.ListPlanAddonsInput{
+			Namespaces: []string{params.Namespace},
+			PlanIDs:    []string{params.PlanID},
+			AddonIDs:   []string{params.AddonID},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get plan add-on assignment: %w", err)
+		}
+
+		if len(planAddons.Items) > 0 {
+			return nil, models.NewGenericConflictError(
+				fmt.Errorf("plan add-on assignment already exists [namespace=%s plan.id=%s addon.id=%s]: %w",
+					params.Namespace, params.PlanID, params.AddonID, err),
+			)
+		}
+
+		logger.Debug("validating plan add-on assignment")
+
+		p, err := s.plan.GetPlan(ctx, plan.GetPlanInput{
+			NamespacedID: models.NamespacedID{
+				Namespace: params.Namespace,
+				ID:        params.PlanID,
+			},
+		})
+		if err != nil {
+			if notFound := &(plan.NotFoundError{}); errors.As(err, &notFound) {
+				return nil, models.NewGenericNotFoundError(err)
+			}
+
+			return nil, fmt.Errorf("failed to get plan [namespace=%s plan.id=%s]: %w",
+				params.Namespace, params.PlanID, err)
+		}
+
+		a, err := s.addon.GetAddon(ctx, addon.GetAddonInput{
+			NamespacedID: models.NamespacedID{
+				Namespace: params.Namespace,
+				ID:        params.AddonID,
+			},
+		})
+		if err != nil {
+			if notFound := &(plan.NotFoundError{}); errors.As(err, &notFound) {
+				return nil, models.NewGenericNotFoundError(err)
+			}
+
+			return nil, fmt.Errorf("failed to get add-on [namespace=%s addon.id=%s]: %w",
+				params.Namespace, params.AddonID, err)
+		}
+
+		planAddonAssignment := productcatalog.PlanAddon{
+			PlanAddonMeta: productcatalog.PlanAddonMeta{
+				Metadata:    params.Metadata,
+				Annotations: params.Annotations,
+				PlanAddonConfig: productcatalog.PlanAddonConfig{
+					FromPlanPhase: params.FromPlanPhase,
+					MaxQuantity:   params.MaxQuantity,
+				},
+			},
+			Plan:  p.AsProductCatalogPlan2(),
+			Addon: a.AsProductCatalogAddon(),
+		}
+
+		if err = planAddonAssignment.Validate(); err != nil {
+			return nil, models.NewGenericValidationError(
+				fmt.Errorf("invalid plan add-on assignment [namespace=%s plan.id=%s addon.id=%s]: %w",
+					params.Namespace, params.PlanID, params.AddonID, err),
+			)
+		}
+
+		logger.Debug("creating plan add-on assignment")
+
+		planAddon, err := s.adapter.CreatePlanAddon(ctx, params)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create plan add-on assignment [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
+		}
+
+		logger.With("planaddon.id", planAddon.ID).Debug("plan add-on assignment created")
+
+		// Emit created event
+		event := planaddon.NewPlanAddonCreateEvent(ctx, planAddon)
+		if err = s.publisher.Publish(ctx, event); err != nil {
+			return nil, fmt.Errorf("failed to publish plan add-on assignment created event [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
+		}
+
+		return planAddon, nil
+	}
+
+	return transaction.Run(ctx, s.adapter, fn)
+}
+
+func (s service) DeletePlanAddon(ctx context.Context, params planaddon.DeletePlanAddonInput) error {
+	fn := func(ctx context.Context) error {
+		if err := params.Validate(); err != nil {
+			return fmt.Errorf("invalid delete plan add-on assignment params [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
+		}
+
+		logger := s.logger.With(
+			"operation", "delete",
+			"namespace", params.Namespace,
+			"planaddon.id", params.ID,
+		)
+
+		logger.Debug("deleting plan add-on assignment")
+
+		// Get the plan add-on assignment to check whether it is already deleted or not
+		planAddon, err := s.adapter.GetPlanAddon(ctx, planaddon.GetPlanAddonInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: params.Namespace,
+			},
+			ID: params.ID,
+		})
+		if err != nil {
+			if notFound := &(planaddon.NotFoundError{}); errors.As(err, &notFound) {
+				return models.NewGenericNotFoundError(err)
+			}
+
+			return fmt.Errorf("failed to get plan add-on assignment [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
+		}
+
+		if planAddon.DeletedAt != nil {
+			return nil
+		}
+
+		// Delete the plan add-on assignment
+		err = s.adapter.DeletePlanAddon(ctx, params)
+		if err != nil {
+			return fmt.Errorf("failed to delete plan add-on assignment [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
+		}
+
+		logger.Debug("add-on deleted")
+
+		// Get the deleted add-on to emit the event
+		planAddon, err = s.adapter.GetPlanAddon(ctx, planaddon.GetPlanAddonInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: params.Namespace,
+			},
+			ID: params.ID,
+		})
+		if err != nil {
+			var notfound *planaddon.NotFoundError
+
+			if errors.As(err, &notfound) {
+				return models.NewGenericNotFoundError(err)
+			}
+
+			return fmt.Errorf("failed to get deleted add-on: %w", err)
+		}
+
+		// Emit deleted event
+		event := planaddon.NewPlanAddonDeleteEvent(ctx, planAddon)
+		if err = s.publisher.Publish(ctx, event); err != nil {
+			return fmt.Errorf("failed to publish add-on deleted event: %w", err)
+		}
+
+		return nil
+	}
+
+	return transaction.RunWithNoValue(ctx, s.adapter, fn)
+}
+
+func (s service) GetPlanAddon(ctx context.Context, params planaddon.GetPlanAddonInput) (*planaddon.PlanAddon, error) {
+	fn := func(ctx context.Context) (*planaddon.PlanAddon, error) {
+		if err := params.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid get plan add-on assignment params [namespace=%s planaddon.id=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.ID, params.PlanIDOrKey, params.AddonIDOrKey, err)
+		}
+
+		logger := s.logger.With(
+			"operation", "get",
+			"namespace", params.Namespace,
+			"planaddon.id", params.ID,
+			"plan.id", params.PlanIDOrKey,
+			"addon.id", params.AddonIDOrKey,
+		)
+
+		logger.Debug("fetching plan add-on assignment")
+
+		planAddon, err := s.adapter.GetPlanAddon(ctx, params)
+		if err != nil {
+			if notFound := &(planaddon.NotFoundError{}); errors.As(err, &notFound) {
+				return nil, models.NewGenericNotFoundError(err)
+			}
+
+			return nil, fmt.Errorf("failed to get plan add-on assignment [namespace=%s planaddon.id=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.ID, params.PlanIDOrKey, params.AddonIDOrKey, err)
+		}
+
+		logger.Debug("plan add-on assignment fetched")
+
+		return planAddon, nil
+	}
+
+	return fn(ctx)
+}
+
+func (s service) UpdatePlanAddon(ctx context.Context, params planaddon.UpdatePlanAddonInput) (*planaddon.PlanAddon, error) {
+	fn := func(ctx context.Context) (*planaddon.PlanAddon, error) {
+		if err := params.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid update plan add-on assignment params [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
+		}
+
+		logger := s.logger.With(
+			"operation", "update",
+			"namespace", params.Namespace,
+			"planaddon.id", params.ID,
+			"plan.id", params.PlanID,
+			"addon.id", params.AddonID,
+		)
+
+		logger.Debug("updating plan add-on assignment")
+
+		planAddon, err := s.adapter.GetPlanAddon(ctx, planaddon.GetPlanAddonInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: params.Namespace,
+			},
+			ID:           params.ID,
+			PlanIDOrKey:  params.PlanID,
+			AddonIDOrKey: params.AddonID,
+		})
+		if err != nil {
+			if notFound := &(planaddon.NotFoundError{}); errors.As(err, &notFound) {
+				return nil, models.NewGenericNotFoundError(err)
+			}
+
+			return nil, fmt.Errorf("failed to get plan add-on assignment [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
+		}
+
+		logger.Debug("validating plan add-on assignment")
+
+		p, err := s.plan.GetPlan(ctx, plan.GetPlanInput{
+			NamespacedID: models.NamespacedID{
+				Namespace: params.Namespace,
+				ID:        planAddon.Plan.ID,
+			},
+		})
+		if err != nil {
+			if err != nil {
+				if notFound := &(plan.NotFoundError{}); errors.As(err, &notFound) {
+					return nil, models.NewGenericNotFoundError(err)
+				}
+
+				return nil, fmt.Errorf("failed to get plan [namespace=%s plan.id=%s]: %w",
+					params.Namespace, params.PlanID, err)
+			}
+		}
+
+		a, err := s.addon.GetAddon(ctx, addon.GetAddonInput{
+			NamespacedID: models.NamespacedID{
+				Namespace: params.Namespace,
+				ID:        planAddon.Addon.ID,
+			},
+		})
+		if err != nil {
+			if notFound := &(addon.NotFoundError{}); errors.As(err, &notFound) {
+				return nil, models.NewGenericNotFoundError(err)
+			}
+
+			return nil, fmt.Errorf("failed to get add-on [namespace=%s addon.id=%s]: %w",
+				params.Namespace, params.AddonID, err)
+		}
+
+		planAddonAssignment := productcatalog.PlanAddon{
+			PlanAddonMeta: productcatalog.PlanAddonMeta{
+				Metadata:    lo.FromPtr(params.Metadata),
+				Annotations: lo.FromPtr(params.Annotations),
+				PlanAddonConfig: productcatalog.PlanAddonConfig{
+					FromPlanPhase: lo.FromPtr(params.FromPlanPhase),
+					MaxQuantity:   params.MaxQuantity,
+				},
+			},
+			Plan:  p.AsProductCatalogPlan2(),
+			Addon: a.AsProductCatalogAddon(),
+		}
+
+		if err = planAddonAssignment.Validate(); err != nil {
+			return nil, models.NewGenericValidationError(
+				fmt.Errorf("invalid plan add-on assignment [namespace=%s plan.id=%s addon.id=%s]: %w",
+					params.Namespace, params.PlanID, params.AddonID, err),
+			)
+		}
+
+		planAddon, err = s.adapter.UpdatePlanAddon(ctx, params)
+		if err != nil {
+			return nil, fmt.Errorf("failed to udpate plan add-on assignment [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
+		}
+
+		logger.Debug("plan add-on assignment updated")
+
+		// Emit updated event
+		event := planaddon.NewPlanAddonUpdateEvent(ctx, planAddon)
+		if err = s.publisher.Publish(ctx, event); err != nil {
+			return nil, fmt.Errorf("failed to publish plan add-on assignment updated event [namespace=%s plan.id=%s addon.id=%s]: %w",
+				params.Namespace, params.PlanID, params.AddonID, err)
+		}
+
+		return planAddon, nil
+	}
+
+	return transaction.Run(ctx, s.adapter, fn)
+}

--- a/openmeter/productcatalog/planaddon/service/service.go
+++ b/openmeter/productcatalog/planaddon/service/service.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
+	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+)
+
+type Config struct {
+	Adapter   planaddon.Repository
+	Plan      plan.Service
+	Addon     addon.Service
+	Logger    *slog.Logger
+	Publisher eventbus.Publisher
+}
+
+func New(config Config) (planaddon.Service, error) {
+	if config.Adapter == nil {
+		return nil, errors.New("add-on assignment adapter is required")
+	}
+
+	if config.Plan == nil {
+		return nil, errors.New("plan service is required")
+	}
+
+	if config.Addon == nil {
+		return nil, errors.New("add-on service is required")
+	}
+
+	if config.Logger == nil {
+		return nil, errors.New("logger is required")
+	}
+
+	if config.Publisher == nil {
+		return nil, errors.New("publisher is required")
+	}
+
+	return &service{
+		adapter:   config.Adapter,
+		plan:      config.Plan,
+		addon:     config.Addon,
+		logger:    config.Logger,
+		publisher: config.Publisher,
+	}, nil
+}
+
+var _ planaddon.Service = (*service)(nil)
+
+type service struct {
+	adapter   planaddon.Repository
+	plan      plan.Service
+	addon     addon.Service
+	logger    *slog.Logger
+	publisher eventbus.Publisher
+}

--- a/openmeter/productcatalog/planaddon/service/service_test.go
+++ b/openmeter/productcatalog/planaddon/service/service_test.go
@@ -1,0 +1,471 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	decimal "github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
+	planaddonadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/adapter"
+	planaddontestutils "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/testutils"
+	"github.com/openmeterio/openmeter/pkg/isodate"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+)
+
+func TestPlanAddonService(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Setup test environment
+	env := planaddontestutils.NewTestEnv(t)
+	defer env.Close(t)
+
+	// Run database migrations
+	env.DBSchemaMigrate(t)
+
+	// Get new namespace ID
+	namespace := planaddontestutils.NewTestNamespace(t)
+
+	// Setup meter repository
+	err := env.Meter.ReplaceMeters(ctx, planaddontestutils.NewTestMeters(t, namespace))
+	require.NoError(t, err, "replacing meters must not fail")
+
+	result, err := env.Meter.ListMeters(ctx, meter.ListMetersParams{
+		Namespace: namespace,
+		Page: pagination.Page{
+			PageSize:   1000,
+			PageNumber: 1,
+		},
+	})
+	require.NoErrorf(t, err, "listing meters must not fail")
+
+	meters := result.Items
+	require.NotEmptyf(t, meters, "list of Meters must not be empty")
+
+	// Set Feature for each Meter
+	features := make([]feature.Feature, 0, len(meters))
+	for _, m := range meters {
+		input := planaddontestutils.NewTestFeatureFromMeter(t, &m)
+
+		feat, err := env.Feature.CreateFeature(ctx, input)
+		require.NoErrorf(t, err, "creating feature must not fail")
+		require.NotNil(t, feat, "feature must not be empty")
+
+		features = append(features, feat)
+	}
+
+	planAddonAdapter, err := planaddonadapter.New(planaddonadapter.Config{
+		Client: env.Client,
+		Logger: env.Logger,
+	})
+	require.NoError(t, err, "creating plan add-on adapter must not fail")
+
+	planAddonService, err := New(Config{
+		Adapter:   planAddonAdapter,
+		Plan:      env.Plan,
+		Addon:     env.Addon,
+		Logger:    env.Logger,
+		Publisher: env.Publisher,
+	})
+	require.NoError(t, err, "creating plan add-on service must not fail")
+
+	planV1Input := planaddontestutils.NewTestPlan(t, namespace)
+
+	addonV1Input := planaddontestutils.NewTestAddon(t, namespace)
+
+	t.Run("Addon", func(t *testing.T) {
+		var (
+			feature1  feature.Feature
+			planV1    *plan.Plan
+			addonV1   *addon.Addon
+			planAddon *planaddon.PlanAddon
+		)
+
+		feature1 = features[0]
+
+		planV1Input.Phases = []productcatalog.Phase{
+			{
+				PhaseMeta: productcatalog.PhaseMeta{
+					Key:         "invalid",
+					Name:        "Invalid",
+					Description: lo.ToPtr("Invalid invalid"),
+					Metadata:    models.Metadata{"name": "trial"},
+					Duration:    &MonthPeriod,
+				},
+				RateCards: []productcatalog.RateCard{
+					&productcatalog.FlatFeeRateCard{
+						RateCardMeta: productcatalog.RateCardMeta{
+							Key:                 feature1.Key,
+							Name:                feature1.Name,
+							Description:         lo.ToPtr("invalid RateCard 1"),
+							Metadata:            models.Metadata{"name": feature1.Name},
+							FeatureKey:          lo.ToPtr(feature1.Key),
+							FeatureID:           lo.ToPtr(feature1.ID),
+							EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.BooleanEntitlementTemplate{}),
+							TaxConfig: &productcatalog.TaxConfig{
+								Stripe: &productcatalog.StripeTaxConfig{
+									Code: "txcd_10000000",
+								},
+							},
+							Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+								Amount:      decimal.NewFromInt(0),
+								PaymentTerm: productcatalog.InArrearsPaymentTerm,
+							}),
+						},
+						BillingCadence: &MonthPeriod,
+					},
+				},
+			},
+			{
+				PhaseMeta: productcatalog.PhaseMeta{
+					Key:         "trial",
+					Name:        "Trial",
+					Description: lo.ToPtr("Trial phase"),
+					Metadata:    models.Metadata{"name": "trial"},
+					Duration:    &MonthPeriod,
+				},
+				RateCards: []productcatalog.RateCard{
+					&productcatalog.FlatFeeRateCard{
+						RateCardMeta: productcatalog.RateCardMeta{
+							Key:                 feature1.Key,
+							Name:                feature1.Name,
+							Description:         lo.ToPtr("Trial RateCard 1"),
+							Metadata:            models.Metadata{"name": feature1.Name},
+							FeatureKey:          lo.ToPtr(feature1.Key),
+							FeatureID:           lo.ToPtr(feature1.ID),
+							EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.BooleanEntitlementTemplate{}),
+							TaxConfig: &productcatalog.TaxConfig{
+								Stripe: &productcatalog.StripeTaxConfig{
+									Code: "txcd_10000000",
+								},
+							},
+							Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
+								Mode: productcatalog.VolumeTieredPrice,
+								Tiers: []productcatalog.PriceTier{
+									{
+										UpToAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+										FlatPrice: &productcatalog.PriceTierFlatPrice{
+											Amount: decimal.NewFromInt(100),
+										},
+										UnitPrice: &productcatalog.PriceTierUnitPrice{
+											Amount: decimal.NewFromInt(50),
+										},
+									},
+									{
+										UpToAmount: nil,
+										FlatPrice: &productcatalog.PriceTierFlatPrice{
+											Amount: decimal.NewFromInt(5),
+										},
+										UnitPrice: &productcatalog.PriceTierUnitPrice{
+											Amount: decimal.NewFromInt(25),
+										},
+									},
+								},
+								Commitments: productcatalog.Commitments{
+									MinimumAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+									MaximumAmount: nil,
+								},
+							}),
+						},
+						BillingCadence: &MonthPeriod,
+					},
+				},
+			},
+			{
+				PhaseMeta: productcatalog.PhaseMeta{
+					Key:         "pro",
+					Name:        "Pro",
+					Description: lo.ToPtr("Pro phase"),
+					Metadata:    models.Metadata{"name": "pro"},
+					Duration:    nil,
+				},
+				RateCards: []productcatalog.RateCard{
+					&productcatalog.UsageBasedRateCard{
+						RateCardMeta: productcatalog.RateCardMeta{
+							Key:                 feature1.Key,
+							Name:                feature1.Name,
+							Description:         lo.ToPtr("Pro RateCard 1"),
+							Metadata:            models.Metadata{"name": feature1.Name},
+							FeatureKey:          lo.ToPtr(feature1.Key),
+							FeatureID:           lo.ToPtr(feature1.ID),
+							EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.BooleanEntitlementTemplate{}),
+							TaxConfig: &productcatalog.TaxConfig{
+								Stripe: &productcatalog.StripeTaxConfig{
+									Code: "txcd_10000000",
+								},
+							},
+							Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
+								Mode: productcatalog.VolumeTieredPrice,
+								Tiers: []productcatalog.PriceTier{
+									{
+										UpToAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+										FlatPrice: &productcatalog.PriceTierFlatPrice{
+											Amount: decimal.NewFromInt(100),
+										},
+										UnitPrice: &productcatalog.PriceTierUnitPrice{
+											Amount: decimal.NewFromInt(50),
+										},
+									},
+									{
+										UpToAmount: nil,
+										FlatPrice: &productcatalog.PriceTierFlatPrice{
+											Amount: decimal.NewFromInt(5),
+										},
+										UnitPrice: &productcatalog.PriceTierUnitPrice{
+											Amount: decimal.NewFromInt(25),
+										},
+									},
+								},
+								Commitments: productcatalog.Commitments{
+									MinimumAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+									MaximumAmount: nil,
+								},
+							}),
+						},
+						BillingCadence: MonthPeriod,
+					},
+				},
+			},
+		}
+
+		planV1, err = env.Plan.CreatePlan(ctx, planV1Input)
+		require.NoErrorf(t, err, "creating plan must not fail")
+
+		planV1, err = env.Plan.PublishPlan(ctx, plan.PublishPlanInput{
+			NamespacedID: models.NamespacedID{
+				Namespace: namespace,
+				ID:        planV1.ID,
+			},
+			EffectivePeriod: productcatalog.EffectivePeriod{
+				EffectiveFrom: lo.ToPtr(time.Now()),
+				EffectiveTo:   nil,
+			},
+		})
+		require.NoErrorf(t, err, "publishing plan must not fail")
+
+		addonV1Input.RateCards = productcatalog.RateCards{
+			&productcatalog.UsageBasedRateCard{
+				RateCardMeta: productcatalog.RateCardMeta{
+					Key:                 feature1.Key,
+					Name:                feature1.Name,
+					Description:         lo.ToPtr(feature1.Name),
+					Metadata:            models.Metadata{"name": feature1.Name},
+					FeatureKey:          lo.ToPtr(feature1.Key),
+					FeatureID:           lo.ToPtr(feature1.ID),
+					EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.BooleanEntitlementTemplate{}),
+					TaxConfig: &productcatalog.TaxConfig{
+						Stripe: &productcatalog.StripeTaxConfig{
+							Code: "txcd_10000000",
+						},
+					},
+					Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
+						Mode: productcatalog.VolumeTieredPrice,
+						Tiers: []productcatalog.PriceTier{
+							{
+								UpToAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+								FlatPrice: &productcatalog.PriceTierFlatPrice{
+									Amount: decimal.NewFromInt(100),
+								},
+								UnitPrice: &productcatalog.PriceTierUnitPrice{
+									Amount: decimal.NewFromInt(50),
+								},
+							},
+							{
+								UpToAmount: nil,
+								FlatPrice: &productcatalog.PriceTierFlatPrice{
+									Amount: decimal.NewFromInt(5),
+								},
+								UnitPrice: &productcatalog.PriceTierUnitPrice{
+									Amount: decimal.NewFromInt(25),
+								},
+							},
+						},
+						Commitments: productcatalog.Commitments{
+							MinimumAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+							MaximumAmount: nil,
+						},
+					}),
+				},
+				BillingCadence: MonthPeriod,
+			},
+		}
+
+		addonV1, err = env.Addon.CreateAddon(ctx, addonV1Input)
+		require.NoErrorf(t, err, "creating add-on must not fail")
+
+		addonV1, err = env.Addon.PublishAddon(ctx, addon.PublishAddonInput{
+			NamespacedID: models.NamespacedID{
+				Namespace: namespace,
+				ID:        addonV1.ID,
+			},
+			EffectivePeriod: productcatalog.EffectivePeriod{
+				EffectiveFrom: lo.ToPtr(time.Now()),
+				EffectiveTo:   nil,
+			},
+		})
+		require.NoErrorf(t, err, "publishing add-on must not fail")
+
+		planAddonInput := planaddon.CreatePlanAddonInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: namespace,
+			},
+			Annotations: map[string]interface{}{
+				"openmeter.key": "openmeter.value",
+			},
+			PlanID:        planV1.ID,
+			AddonID:       addonV1.ID,
+			FromPlanPhase: planV1.Phases[1].Key,
+		}
+
+		t.Run("Create", func(t *testing.T) {
+			planAddon, err = planAddonService.CreatePlanAddon(ctx, planAddonInput)
+			require.NoErrorf(t, err, "creating new plan add-on assignment must not fail")
+
+			require.NotNilf(t, planAddon, "plan add-on assignment must not be nil")
+
+			planaddon.AssertPlanAddonCreateInputEqual(t, planAddonInput, *planAddon)
+
+			t.Run("Get", func(t *testing.T) {
+				t.Run("ById", func(t *testing.T) {
+					getPlanAddon, err := planAddonService.GetPlanAddon(ctx, planaddon.GetPlanAddonInput{
+						NamespacedModel: models.NamespacedModel{
+							Namespace: namespace,
+						},
+						ID: planAddon.ID,
+					})
+					assert.NoErrorf(t, err, "getting plan add-on assignment by id must not fail")
+
+					require.NotNilf(t, addonV1, "plan add-on assignment must not be nil")
+
+					planaddon.AssertPlanAddonEqual(t, *planAddon, *getPlanAddon)
+				})
+
+				t.Run("ByKey", func(t *testing.T) {
+					getPlanAddon, err := planAddonService.GetPlanAddon(ctx, planaddon.GetPlanAddonInput{
+						NamespacedModel: models.NamespacedModel{
+							Namespace: namespace,
+						},
+						PlanIDOrKey:  planAddon.Plan.Key,
+						AddonIDOrKey: planAddon.Addon.Key,
+					})
+					assert.NoErrorf(t, err, "getting plan add-on assignment by plan and add-on key must not fail")
+
+					require.NotNilf(t, addonV1, "plan add-on assignment must not be nil")
+
+					planaddon.AssertPlanAddonEqual(t, *planAddon, *getPlanAddon)
+				})
+			})
+
+			t.Run("List", func(t *testing.T) {
+				t.Run("ById", func(t *testing.T) {
+					listPlanAddons, err := planAddonService.ListPlanAddons(ctx, planaddon.ListPlanAddonsInput{
+						Namespaces: []string{namespace},
+						IDs:        []string{planAddon.ID},
+					})
+					assert.NoErrorf(t, err, "listing plan add-on assignment by id must not fail")
+
+					require.Lenf(t, listPlanAddons.Items, 1, "plan add-on assignments must not be empty")
+
+					planaddon.AssertPlanAddonEqual(t, *planAddon, listPlanAddons.Items[0])
+				})
+
+				t.Run("ByResourceKey", func(t *testing.T) {
+					listPlanAddons, err := planAddonService.ListPlanAddons(ctx, planaddon.ListPlanAddonsInput{
+						Namespaces: []string{namespace},
+						PlanKeys:   []string{planV1.Key},
+						AddonKeys:  []string{addonV1.Key},
+					})
+					assert.NoErrorf(t, err, "listing plan add-on assignment by plan and add-on keys must not fail")
+
+					require.Lenf(t, listPlanAddons.Items, 1, "plan add-on assignments must not be empty")
+
+					planaddon.AssertPlanAddonEqual(t, *planAddon, listPlanAddons.Items[0])
+				})
+			})
+
+			t.Run("Update", func(t *testing.T) {
+				t.Run("ById", func(t *testing.T) {
+					planAddonV1Update := planaddon.UpdatePlanAddonInput{
+						NamespacedModel: models.NamespacedModel{
+							Namespace: namespace,
+						},
+						Annotations: &models.Annotations{
+							"openmeter.key2": "openmeter.value2",
+						},
+						Metadata: &models.Metadata{
+							"openmeter.key2": "openmeter.value2",
+						},
+						ID:            planAddon.ID,
+						FromPlanPhase: &planV1.Phases[2].Key,
+					}
+
+					updatedPlanAddon, err := planAddonService.UpdatePlanAddon(ctx, planAddonV1Update)
+					require.NoErrorf(t, err, "updating plan add-on assignment must not fail")
+
+					require.NotNilf(t, updatedPlanAddon, "plan add-on assignment must not be nil")
+
+					planaddon.AssertPlanAddonUpdateInputEqual(t, planAddonV1Update, *updatedPlanAddon)
+				})
+
+				t.Run("ByResourceKey", func(t *testing.T) {
+					planAddonV1Update := planaddon.UpdatePlanAddonInput{
+						NamespacedModel: models.NamespacedModel{
+							Namespace: namespace,
+						},
+						Annotations: &models.Annotations{
+							"openmeter.key2": "openmeter.value2",
+						},
+						Metadata: &models.Metadata{
+							"openmeter.key2": "openmeter.value2",
+						},
+						PlanID:        planAddon.Plan.ID,
+						AddonID:       planAddon.Addon.ID,
+						FromPlanPhase: &planV1.Phases[1].Key,
+					}
+
+					updatedPlanAddon, err := planAddonService.UpdatePlanAddon(ctx, planAddonV1Update)
+					require.NoErrorf(t, err, "updating plan add-on assignment must not fail")
+
+					require.NotNilf(t, updatedPlanAddon, "plan add-on assignment must not be nil")
+
+					planaddon.AssertPlanAddonUpdateInputEqual(t, planAddonV1Update, *updatedPlanAddon)
+				})
+			})
+
+			t.Run("Delete", func(t *testing.T) {
+				err = planAddonService.DeletePlanAddon(ctx, planaddon.DeletePlanAddonInput{
+					NamespacedModel: models.NamespacedModel{
+						Namespace: namespace,
+					},
+					ID: planAddon.ID,
+				})
+				require.NoErrorf(t, err, "deleting plan add-on assignment must not fail")
+
+				getPlanAddon, err := planAddonService.GetPlanAddon(ctx, planaddon.GetPlanAddonInput{
+					NamespacedModel: models.NamespacedModel{
+						Namespace: namespace,
+					},
+					ID: planAddon.ID,
+				})
+				require.NoErrorf(t, err, "getting plan add-on assignment by id must not fail")
+
+				require.NotNilf(t, getPlanAddon, "plan add-on assignment must not be nil")
+
+				assert.NotNilf(t, getPlanAddon.DeletedAt, "plan add-on assignment must be deleted")
+			})
+		})
+	})
+}
+
+var MonthPeriod = isodate.FromDuration(30 * 24 * time.Hour)


### PR DESCRIPTION
## Overview

Add implementation for plan add-on assignment service.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a service layer for managing plan add-ons, enabling listing, creation, retrieval, updating, and deletion of plan add-on assignments.
- **Bug Fixes**
  - Improved error messages for plan add-on operations to provide more detailed context.
- **Tests**
  - Added comprehensive tests covering the full lifecycle of plan add-on assignments, including creation, retrieval, updating, listing, and deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->