### PR TITLE
fix: missing validations and attributes in productcatalog

### DIFF
--- a/openmeter/productcatalog/addon/service.go
+++ b/openmeter/productcatalog/addon/service.go
@@ -203,9 +203,25 @@ func (i UpdateAddonInput) Validate() error {
 		}
 	}
 
-	// FIXME: validate ratecards
+	if i.RateCards != nil {
+		// Check for
+		// * duplicated rate card keys
+		// * invalid RateCards
+		rateCardKeys := make(map[string]productcatalog.RateCard)
+		for _, rateCard := range *i.RateCards {
+			if _, ok := rateCardKeys[rateCard.Key()]; ok {
+				errs = append(errs, fmt.Errorf("duplicated ratecard: %s", rateCard.Key()))
+			} else {
+				rateCardKeys[rateCard.Key()] = rateCard
+			}
 
-	return errors.Join(errs...)
+			if err := rateCard.Validate(); err != nil {
+				errs = append(errs, fmt.Errorf("invalid ratecard: %w", err))
+			}
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type GetAddonInput struct {

--- a/openmeter/productcatalog/planaddon/service.go
+++ b/openmeter/productcatalog/planaddon/service.go
@@ -184,6 +184,14 @@ func (i UpdatePlanAddonInput) Equal(p PlanAddon) bool {
 		return false
 	}
 
+	// FIXME: annotations
+
+	if i.Metadata != nil {
+		if !i.Metadata.Equal(p.Metadata) {
+			return false
+		}
+	}
+
 	return true
 }
 


### PR DESCRIPTION
## Overview

* fix ratecard validation on add-on update
* fix missing `metadata` from plan add-on assignment
* fix deleting plan add-on assignment
