### PR TITLE
fix: allow add-on for draft plan

### DIFF
--- a/openmeter/productcatalog/planaddon.go
+++ b/openmeter/productcatalog/planaddon.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/samber/lo"
+
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -65,11 +67,12 @@ func (c PlanAddon) Validate() error {
 
 	// Validate plan
 
-	// Plan must be active.
-	if c.Plan.Status() != PlanStatusActive {
+	// Check plan status
+	allowedPlanStatuses := []PlanStatus{PlanStatusDraft, PlanStatusScheduled}
+	if !lo.Contains(allowedPlanStatuses, c.Plan.Status()) {
 		errs = append(errs,
-			fmt.Errorf("invalid plan: status must be active [plan.key=%s plan.version=%d]",
-				c.Plan.Key, c.Plan.Version),
+			fmt.Errorf("invalid plan [plan.key=%s plan.version=%d]: invalid %s status, allowed statuses: %+v",
+				c.Plan.Key, c.Plan.Version, c.Plan.Status(), allowedPlanStatuses),
 		)
 	}
 
@@ -79,7 +82,7 @@ func (c PlanAddon) Validate() error {
 	// as we do not support scheduled changes for add-ons.
 	if c.Addon.Status() != AddonStatusActive || c.Addon.EffectiveTo != nil {
 		errs = append(errs,
-			fmt.Errorf("invalid add-on: status must be active [addon.key=%s addon.version=%d]",
+			fmt.Errorf("invalid add-on [addon.key=%s addon.version=%d]: status must be active",
 				c.Addon.Key, c.Addon.Version),
 		)
 	}

--- a/openmeter/productcatalog/planaddon/adapter/adapter_test.go
+++ b/openmeter/productcatalog/planaddon/adapter/adapter_test.go
@@ -233,18 +233,6 @@ func TestPostgresAdapter(t *testing.T) {
 		planV1, err = env.Plan.CreatePlan(ctx, planV1Input)
 		require.NoErrorf(t, err, "creating plan must not fail")
 
-		planV1, err = env.Plan.PublishPlan(ctx, plan.PublishPlanInput{
-			NamespacedID: models.NamespacedID{
-				Namespace: namespace,
-				ID:        planV1.ID,
-			},
-			EffectivePeriod: productcatalog.EffectivePeriod{
-				EffectiveFrom: lo.ToPtr(time.Now()),
-				EffectiveTo:   nil,
-			},
-		})
-		require.NoErrorf(t, err, "publishing plan must not fail")
-
 		addonV1Input.RateCards = productcatalog.RateCards{
 			&productcatalog.UsageBasedRateCard{
 				RateCardMeta: productcatalog.RateCardMeta{

--- a/openmeter/productcatalog/planaddon/service/service_test.go
+++ b/openmeter/productcatalog/planaddon/service/service_test.go
@@ -242,18 +242,6 @@ func TestPlanAddonService(t *testing.T) {
 		planV1, err = env.Plan.CreatePlan(ctx, planV1Input)
 		require.NoErrorf(t, err, "creating plan must not fail")
 
-		planV1, err = env.Plan.PublishPlan(ctx, plan.PublishPlanInput{
-			NamespacedID: models.NamespacedID{
-				Namespace: namespace,
-				ID:        planV1.ID,
-			},
-			EffectivePeriod: productcatalog.EffectivePeriod{
-				EffectiveFrom: lo.ToPtr(time.Now()),
-				EffectiveTo:   nil,
-			},
-		})
-		require.NoErrorf(t, err, "publishing plan must not fail")
-
 		addonV1Input.RateCards = productcatalog.RateCards{
 			&productcatalog.UsageBasedRateCard{
 				RateCardMeta: productcatalog.RateCardMeta{
@@ -463,6 +451,25 @@ func TestPlanAddonService(t *testing.T) {
 				require.NotNilf(t, getPlanAddon, "plan add-on assignment must not be nil")
 
 				assert.NotNilf(t, getPlanAddon.DeletedAt, "plan add-on assignment must be deleted")
+			})
+		})
+
+		t.Run("Invalid", func(t *testing.T) {
+			t.Run("Plan", func(t *testing.T) {
+				planV1, err = env.Plan.PublishPlan(ctx, plan.PublishPlanInput{
+					NamespacedID: models.NamespacedID{
+						Namespace: namespace,
+						ID:        planV1.ID,
+					},
+					EffectivePeriod: productcatalog.EffectivePeriod{
+						EffectiveFrom: lo.ToPtr(time.Now()),
+						EffectiveTo:   nil,
+					},
+				})
+				require.NoErrorf(t, err, "publishing plan must not fail")
+
+				planAddon, err = planAddonService.CreatePlanAddon(ctx, planAddonInput)
+				require.Errorf(t, err, "creating new plan add-on assignment must fail if plan is published/active")
 			})
 		})
 	})


### PR DESCRIPTION
## Overview

Allow assigning add-on to plan in `draft` state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated validation to allow only draft and scheduled plan statuses.
  - Enhanced error messages for invalid plan and add-on statuses for clearer feedback.
  - Added a new test to prevent add-on assignments on published plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->