### PR TITLE
fix: flat fee discount idempotency

### DIFF
--- a/test/billing/discount_test.go
+++ b/test/billing/discount_test.go
@@ -200,6 +200,11 @@ func (s *DiscountsTestSuite) TestCorrelationIDHandling() {
 		s.Equal(discountCorrelationID, rcDiscounts.Percentage.CorrelationID)
 		s.NotEqual(discountCorrelationID, rcDiscounts.Usage.CorrelationID)
 	})
+
+	s.Run("Deleting the invoice works without errors", func() {
+		err := s.BillingService.DeleteInvoice(ctx, draftInvoiceID)
+		s.NoError(err)
+	})
 }
 
 func (s *DiscountsTestSuite) TestUnitDiscountProgressiveBilling() {


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

We didn't have the merge logic in place for flat fee discounts resulting in errors when an invoice was recalculated multiple times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved discount calculation to prevent duplicate discounts and enhance error handling when applying percentage discounts to billing lines.

- **Tests**
  - Added a test to verify correct synchronization and application of 100% discounts on in-advance fee lines in invoices.
  - Added a subtest to confirm that deleting an invoice works without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->