### PR TITLE
Plan-Addon RateCard Compatibility adjustments

### DIFF
--- a/openmeter/productcatalog/addon.go
+++ b/openmeter/productcatalog/addon.go
@@ -284,3 +284,11 @@ func AddonWithCompatiblePrices() models.ValidatorFunc[Addon] {
 		}
 	}
 }
+
+// Determines if an Addon RateCard will effect a given Plan RateCard
+// Right now we only support a single RateCard per addon effecting a single plan RateCard and we match them by key.
+func AddonRateCardMatcherForAGivenPlanRateCard(planRateCard RateCard) func(addonRateCard RateCard) bool {
+	return func(addonRateCard RateCard) bool {
+		return addonRateCard.Key() == planRateCard.Key()
+	}
+}

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -560,46 +560,6 @@ func (c RateCards) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
-func (c RateCards) Compatible(overlays RateCards) error {
-	if err := c.Validate(); err != nil {
-		return err
-	}
-
-	if err := overlays.Validate(); err != nil {
-		return err
-	}
-
-	var errs []error
-
-	m := make(map[string]rateCardWithOverlays)
-
-	// Collect ratecards by their keys
-	for _, rc := range lo.Union(c, overlays) {
-		_, ok := m[rc.Key()]
-		if !ok {
-			m[rc.Key()] = rateCardWithOverlays{base: rc}
-		}
-
-		m[rc.Key()] = rateCardWithOverlays{
-			base:     m[rc.Key()].base,
-			overlays: append(m[rc.Key()].overlays, rc),
-		}
-	}
-
-	for key, rc := range m {
-		// Skip compatibility check
-		if len(rc.overlays) == 0 {
-			continue
-		}
-
-		if err := rc.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("incompatible ratecards [key=%s]: %w", key, err))
-		}
-	}
-
-	return models.NewNillableGenericValidationError(errors.Join(errs...))
-}
-
 type rateCardWithOverlays struct {
 	base     RateCard
 	overlays []RateCard

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -670,8 +670,8 @@ func rateCardsCompatible(r, v RateCard) error {
 
 	// Validate  Entitlement
 
-	if rMeta.EntitlementTemplate != nil {
-		if vMeta.EntitlementTemplate == nil || rMeta.EntitlementTemplate.Type() != vMeta.EntitlementTemplate.Type() {
+	if rMeta.EntitlementTemplate != nil && vMeta.EntitlementTemplate != nil {
+		if rMeta.EntitlementTemplate.Type() != vMeta.EntitlementTemplate.Type() {
 			errs = append(errs, errors.New("incompatible entitlement template type"))
 		} else {
 			switch rMeta.EntitlementTemplate.Type() {
@@ -692,10 +692,6 @@ func rateCardsCompatible(r, v RateCard) error {
 					errs = append(errs, fmt.Errorf("incompatible usage period for metered entitlement [%s, %s]",
 						rMetered.UsagePeriod.ISOString(), vMetered.UsagePeriod.ISOString()),
 					)
-				}
-
-				if lo.FromPtr(rMetered.IssueAfterReset) > lo.FromPtr(vMetered.IssueAfterReset) {
-					errs = append(errs, errors.New("incompatible issue after reset for metered entitlement"))
 				}
 			case entitlement.EntitlementTypeBoolean:
 			}

--- a/pkg/slicesx/iteratee.go
+++ b/pkg/slicesx/iteratee.go
@@ -1,0 +1,7 @@
+package slicesx
+
+func AsFilterIteratee[T any](f func(T) bool) func(T, int) bool {
+	return func(v T, _ int) bool {
+		return f(v)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

- Simplifies the logic a bit, as in general its not a defined behavior what two arrays of RateCards being compatible would mean. In the context of Plans & Addons, its a fairly simple check right now (as implemented)
- Changes the RateCard compatible validation for EntitlementTemplate to follow the same nil check logic as we do for Price

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new matcher for determining if an add-on rate card affects a specific plan rate card.
	- Added a utility to adapt simple filter predicates for use in more complex iteration scenarios.

- **Refactor**
	- Improved validation logic for rate card compatibility between plan phases and add-ons, providing more granular error reporting.

- **Bug Fixes**
	- Adjusted entitlement template compatibility checks to be stricter and removed obsolete compatibility conditions.

- **Chores**
	- Removed outdated compatibility checking logic for rate cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->