### PR TITLE
fix: maxQuantity in API request mapper 

### DIFF
--- a/openmeter/productcatalog/planaddon/httpdriver/mapping.go
+++ b/openmeter/productcatalog/planaddon/httpdriver/mapping.go
@@ -76,7 +76,7 @@ func AsCreatePlanAddonRequest(a api.PlanAddonCreate, namespace string, planID st
 		PlanID:        planID,
 		AddonID:       a.Addon.Id,
 		FromPlanPhase: a.FromPlanPhase,
-		MaxQuantity:   nil,
+		MaxQuantity:   a.MaxQuantity,
 	}
 
 	return req, nil


### PR DESCRIPTION
## Overview

Fix missing `maxQuantity` from HTTP API request mapper.
