### PR TITLE
fix: allow empty description for apps

### DIFF
--- a/openmeter/app/adapter/app.go
+++ b/openmeter/app/adapter/app.go
@@ -256,7 +256,7 @@ func (a *adapter) UpdateApp(ctx context.Context, input app.UpdateAppInput) (app.
 					Where(appdb.Namespace(input.AppID.Namespace)).
 					Where(appdb.ID(input.AppID.ID)).
 					SetName(input.Name).
-					SetNillableDescription(input.Description).
+					SetOrClearDescription(input.Description).
 					SetIsDefault(input.Default)
 
 				if input.Metadata != nil {

--- a/openmeter/app/adapter/app.go
+++ b/openmeter/app/adapter/app.go
@@ -257,11 +257,8 @@ func (a *adapter) UpdateApp(ctx context.Context, input app.UpdateAppInput) (app.
 					Where(appdb.ID(input.AppID.ID)).
 					SetName(input.Name).
 					SetOrClearDescription(input.Description).
+					SetOrClearMetadata(input.Metadata).
 					SetIsDefault(input.Default)
-
-				if input.Metadata != nil {
-					query.SetMetadata(*input.Metadata)
-				}
 
 				_, err = query.Save(ctx)
 				if err != nil {

--- a/openmeter/app/app.go
+++ b/openmeter/app/app.go
@@ -118,11 +118,6 @@ func (i UpdateAppInput) Validate() error {
 		return errors.New("name is required")
 	}
 
-	// Optional fields
-	if i.Description != nil && *i.Description == "" {
-		return errors.New("description is required")
-	}
-
 	if i.Metadata != nil {
 		for k, v := range *i.Metadata {
 			if k == "" {

--- a/test/app/stripe/appstripe.go
+++ b/test/app/stripe/appstripe.go
@@ -295,7 +295,7 @@ func (s *AppHandlerTestSuite) TestUpdate(ctx context.Context, t *testing.T) {
 	require.NoError(t, err, "Update app must not return error")
 	require.NotNil(t, updateApp, "Update app must return app")
 
-	// Partial update (only required fields)
+	// Set non-required field to nil
 	updateApp, err = s.Env.App().UpdateApp(ctx, app.UpdateAppInput{
 		AppID:   testApp.GetID(),
 		Name:    "Updated Stripe App 2",
@@ -310,8 +310,8 @@ func (s *AppHandlerTestSuite) TestUpdate(ctx context.Context, t *testing.T) {
 	require.Equal(t, false, updateApp.GetAppBase().Default, "Default must remain the same")
 
 	// Remains the same
-	require.Equal(t, "Updated description 1", *updateApp.GetAppBase().Description, "Description must be updated")
-	require.Equal(t, map[string]string{"key": "value"}, updateApp.GetAppBase().Metadata, "Metadata must be updated")
+	require.Nil(t, nil, updateApp.GetAppBase().Description, "Description must be updated")
+	require.Empty(t, updateApp.GetAppBase().Metadata, "Metadata must be updated")
 }
 
 // TestUninstall tests uninstalling a stripe app


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the app description and metadata fields during updates, allowing users to clear or update these fields as needed.

- **Refactor**
	- Simplified validation rules for the app description, removing restrictions on empty descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->