### PR TITLE
feat: add raw events

### DIFF
--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -193,7 +193,7 @@ func TestComplete(t *testing.T) {
 				},
 			},
 			IngestNotifications: IngestNotificationsConfiguration{
-				MaxEventsInBatch: 500,
+				MaxEventsInBatch: 50,
 			},
 			Kafka: KafkaConfig{
 				CommonConfigParams: pkgkafka.CommonConfigParams{

--- a/app/config/sink.go
+++ b/app/config/sink.go
@@ -94,12 +94,12 @@ type IngestNotificationsConfiguration struct {
 func (c IngestNotificationsConfiguration) Validate() error {
 	var errs []error
 
-	if c.MaxEventsInBatch < 0 {
-		errs = append(errs, errors.New("ChunkSize must not be negative"))
+	if c.MaxEventsInBatch <= 0 {
+		errs = append(errs, errors.New("MaxEventsInBatch must be greater than 0"))
 	}
 
 	if c.MaxEventsInBatch > 1000 {
-		errs = append(errs, errors.New("ChunkSize must not be greater than 1000"))
+		errs = append(errs, errors.New("MaxEventsInBatch must not be greater than 1000"))
 	}
 
 	return errors.Join(errs...)
@@ -158,7 +158,7 @@ func ConfigureSink(v *viper.Viper) {
 	v.SetDefault("sink.namespaceRefetch", "15s")
 	v.SetDefault("sink.flushSuccessTimeout", "5s")
 	v.SetDefault("sink.drainTimeout", "10s")
-	v.SetDefault("sink.ingestNotifications.maxEventsInBatch", 500)
+	v.SetDefault("sink.ingestNotifications.maxEventsInBatch", 50)
 	v.SetDefault("sink.namespaceRefetchTimeout", "10s")
 	v.SetDefault("sink.namespaceTopicRegexp", "^om_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$")
 	v.SetDefault("sink.meterRefetchInterval", "15s")

--- a/openmeter/sink/flushhandler/ingestnotification/events/events.go
+++ b/openmeter/sink/flushhandler/ingestnotification/events/events.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/event/metadata"
 	"github.com/openmeterio/openmeter/openmeter/event/models"
+	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest/serializer"
 	"github.com/openmeterio/openmeter/openmeter/watermill/marshaler"
 )
 
@@ -22,7 +23,8 @@ type EventBatchedIngest struct {
 	// version, thus any code that is in opensource should not rely on them.
 	MeterSlugs []string `json:"meterSlugs"`
 
-	StoredAt time.Time `json:"storedAt"`
+	RawEvents []serializer.CloudEventsKafkaPayload `json:"rawEvents"`
+	StoredAt  time.Time                            `json:"storedAt"`
 }
 
 var (


### PR DESCRIPTION
Add raw event data for ingest events.

To make sure we fit into the kafka message size, we chunk it into configurable batches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Batched event notifications now include raw event payloads, enhancing event detail visibility.
- **Bug Fixes**
  - Improved validation for batch size configuration, now requiring a value greater than zero.
- **Refactor**
  - Batched event notifications are now split into multiple batches if the number of events exceeds the configured batch size, improving handling of large event sets.
- **Chores**
  - Updated default batch size for event notifications from 500 to 50 for more efficient processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->