### PR TITLE
Feature Validation

### DIFF
--- a/openmeter/productcatalog/addon.go
+++ b/openmeter/productcatalog/addon.go
@@ -9,6 +9,7 @@ import (
 	"github.com/invopop/gobl/currency"
 	"github.com/samber/lo"
 
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -130,7 +131,7 @@ func (m AddonMeta) Equal(v AddonMeta) bool {
 
 // Status returns the current status of the Addons
 func (m AddonMeta) Status() AddonStatus {
-	return m.StatusAt(time.Now())
+	return m.StatusAt(clock.Now())
 }
 
 // StatusAt returns the Addon status relative to time t.

--- a/openmeter/productcatalog/addon/httpdriver/addon.go
+++ b/openmeter/productcatalog/addon/httpdriver/addon.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/samber/lo"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/notification"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/defaultx"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
@@ -307,7 +307,7 @@ func (h *handler) PublishAddon() PublishAddonHandler {
 					ID:        addonID,
 				},
 				EffectivePeriod: productcatalog.EffectivePeriod{
-					EffectiveFrom: lo.ToPtr(time.Now()),
+					EffectiveFrom: lo.ToPtr(clock.Now()),
 				},
 			}
 
@@ -351,7 +351,7 @@ func (h *handler) ArchiveAddon() ArchiveAddonHandler {
 					Namespace: ns,
 					ID:        addonID,
 				},
-				EffectiveTo: time.Now(),
+				EffectiveTo: clock.Now(),
 			}
 
 			return req, nil

--- a/openmeter/productcatalog/plan.go
+++ b/openmeter/productcatalog/plan.go
@@ -235,43 +235,6 @@ func (p PlanMeta) Status() PlanStatus {
 
 // StatusAt returns the plan status relative to time t.
 func (p PlanMeta) StatusAt(t time.Time) PlanStatus {
-	from := p.EffectiveFrom
-	to := p.EffectiveTo
-
-	switch {
-	case from == nil && to == nil:
-		return PlanStatusDraft
-	case from != nil && to == nil:
-		if from.Before(t) {
-			return PlanStatusActive
-		}
-
-		return PlanStatusScheduled
-	case from == nil && to != nil:
-		if to.Before(t) {
-			return PlanStatusArchived
-		}
-
-		return PlanStatusActive
-	case from != nil && to != nil:
-		if from.Before(t) && to.After(t) {
-			return PlanStatusActive
-		}
-
-		if from.After(t) && to.After(t) {
-			return PlanStatusScheduled
-		}
-
-		if from.Before(t) && to.Before(t) {
-			return PlanStatusArchived
-		}
-	}
-
-	return PlanStatusInvalid
-}
-
-// StatusAt returns the plan status relative to time t.
-func (p PlanMeta) StatusAt2(t time.Time) PlanStatus {
 	from := lo.FromPtr(p.EffectiveFrom)
 	to := lo.FromPtr(p.EffectiveTo)
 

--- a/openmeter/productcatalog/plan/adapter/plan.go
+++ b/openmeter/productcatalog/plan/adapter/plan.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"time"
 
 	"entgo.io/ent/dialect/sql"
 
@@ -254,7 +253,7 @@ func (a *adapter) DeletePlan(ctx context.Context, params plan.DeletePlanInput) e
 			return nil, fmt.Errorf("failed to get Plan: %w", err)
 		}
 
-		deletedAt := time.Now().UTC()
+		deletedAt := clock.Now().UTC()
 		err = a.db.Plan.UpdateOneID(p.ID).
 			Where(plandb.Namespace(p.Namespace)).
 			SetDeletedAt(deletedAt).
@@ -337,7 +336,7 @@ func (a *adapter) GetPlan(ctx context.Context, params plan.GetPlanInput) (*plan.
 						)
 					})
 				} else { // get Plan in active with active status by Key
-					now := time.Now().UTC()
+					now := clock.Now().UTC()
 					query = query.Where(plandb.And(
 						plandb.Namespace(params.Namespace),
 						plandb.Key(params.Key),

--- a/openmeter/productcatalog/plan/httpdriver/plan.go
+++ b/openmeter/productcatalog/plan/httpdriver/plan.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/samber/lo"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/notification"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/defaultx"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
@@ -307,7 +307,7 @@ func (h *handler) PublishPlan() PublishPlanHandler {
 					ID:        planID,
 				},
 				EffectivePeriod: productcatalog.EffectivePeriod{
-					EffectiveFrom: lo.ToPtr(time.Now()),
+					EffectiveFrom: lo.ToPtr(clock.Now()),
 				},
 			}
 
@@ -351,7 +351,7 @@ func (h *handler) ArchivePlan() ArchivePlanHandler {
 					Namespace: ns,
 					ID:        planID,
 				},
-				EffectiveTo: time.Now(),
+				EffectiveTo: clock.Now(),
 			}
 
 			return req, nil

--- a/openmeter/productcatalog/plan_test.go
+++ b/openmeter/productcatalog/plan_test.go
@@ -106,7 +106,7 @@ func TestPlanStatus(t *testing.T) {
 			Expected: productcatalog.PlanStatusInvalid,
 		},
 		{
-			Name: "Invalid with no start with end in the past",
+			Name: "Archived with no start with end in the past",
 			Plan: productcatalog.Plan{
 				PlanMeta: productcatalog.PlanMeta{
 					EffectivePeriod: productcatalog.EffectivePeriod{
@@ -118,7 +118,7 @@ func TestPlanStatus(t *testing.T) {
 			Expected: productcatalog.PlanStatusArchived,
 		},
 		{
-			Name: "Invalid with no start with end in the future",
+			Name: "Actvive with no start with end in the future",
 			Plan: productcatalog.Plan{
 				PlanMeta: productcatalog.PlanMeta{
 					EffectivePeriod: productcatalog.EffectivePeriod{

--- a/openmeter/productcatalog/planaddon/adapter/planaddon.go
+++ b/openmeter/productcatalog/planaddon/adapter/planaddon.go
@@ -3,7 +3,6 @@ package adapter
 import (
 	"context"
 	"fmt"
-	"time"
 
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	addondb "github.com/openmeterio/openmeter/openmeter/ent/db/addon"
@@ -12,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
@@ -253,7 +253,7 @@ func (a *adapter) DeletePlanAddon(ctx context.Context, params planaddon.DeletePl
 			return nil, fmt.Errorf("failed to get plan add-on assignment: %w", err)
 		}
 
-		deletedAt := time.Now().UTC()
+		deletedAt := clock.Now().UTC()
 		err = a.db.PlanAddon.UpdateOneID(planAddon.ID).
 			Where(planaddondb.Namespace(planAddon.Namespace)).
 			SetDeletedAt(deletedAt).

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -176,6 +176,10 @@ func (r RateCardMeta) Validate() error {
 	var errs []error
 
 	if r.EntitlementTemplate != nil {
+		if r.FeatureKey == nil {
+			errs = append(errs, errors.New("feature key is required for entitlement template"))
+		}
+
 		if err := r.EntitlementTemplate.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("invalid EntitlementTemplate: %w", err))
 		}

--- a/openmeter/productcatalog/subscription/service/change.go
+++ b/openmeter/productcatalog/subscription/service/change.go
@@ -32,11 +32,14 @@ func (s *service) Change(ctx context.Context, request plansubscription.ChangeSub
 			return def, err
 		}
 
-		if p.Status() != productcatalog.PlanStatusActive {
-			return def, models.NewGenericValidationError(fmt.Errorf("plan is not active"))
+		now := clock.Now()
+
+		pStatus := p.StatusAt(now)
+		if pStatus != productcatalog.PlanStatusActive {
+			return def, models.NewGenericValidationError(fmt.Errorf("plan %s@%d is not active at %s", p.Key, p.Version, now))
 		}
 
-		if p.DeletedAt != nil && !clock.Now().Before(*p.DeletedAt) {
+		if p.DeletedAt != nil && !now.Before(*p.DeletedAt) {
 			return def, models.NewGenericValidationError(
 				fmt.Errorf("plan is deleted [namespace=%s, key=%s, version=%d, deleted_at=%s]", p.Namespace, p.Key, p.Version, p.DeletedAt),
 			)

--- a/openmeter/subscription/subscriptionspec.go
+++ b/openmeter/subscription/subscriptionspec.go
@@ -719,9 +719,7 @@ func (s SubscriptionItemSpec) ToScheduleSubscriptionEntitlementInput(
 	}
 
 	if meta.FeatureKey == nil {
-		return def, true, models.NewGenericValidationError(
-			fmt.Errorf("feature is required for rate card where entitlement is present: %s", s.ItemKey),
-		)
+		return def, true, fmt.Errorf("feature is required for rate card where entitlement is present: %s", s.ItemKey)
 	}
 
 	t := meta.EntitlementTemplate.Type()

--- a/openmeter/subscription/testutils/addon.go
+++ b/openmeter/subscription/testutils/addon.go
@@ -64,7 +64,8 @@ var ExampleAddonRateCard3 = productcatalog.FlatFeeRateCard{
 	RateCardMeta: productcatalog.RateCardMeta{
 		Name:                "Test Addon Rate Card 3",
 		Description:         lo.ToPtr("Test Addon Rate Card 3 Description"),
-		Key:                 "addon-rc-key-3",
+		Key:                 ExampleFeatureKey3,
+		FeatureKey:          lo.ToPtr(ExampleFeatureKey3),
 		EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.BooleanEntitlementTemplate{}),
 		Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
 			Amount:      alpacadecimal.NewFromInt(100),

--- a/openmeter/subscription/testutils/feature.go
+++ b/openmeter/subscription/testutils/feature.go
@@ -12,6 +12,7 @@ import (
 var (
 	ExampleFeatureKey       = "test-feature-1"
 	ExampleFeatureKey2      = "test-feature-2"
+	ExampleFeatureKey3      = "test-feature-3"
 	ExampleFeatureMeterSlug = "meter1"
 )
 
@@ -25,6 +26,13 @@ var ExampleFeature = feature.CreateFeatureInputs{
 var ExampleFeature2 = feature.CreateFeatureInputs{
 	Name:      "Example Feature 2",
 	Key:       ExampleFeatureKey2,
+	Namespace: ExampleNamespace,
+	MeterSlug: lo.ToPtr(ExampleFeatureMeterSlug),
+}
+
+var ExampleFeature3 = feature.CreateFeatureInputs{
+	Name:      "Example Feature 3",
+	Key:       ExampleFeatureKey3,
 	Namespace: ExampleNamespace,
 	MeterSlug: lo.ToPtr(ExampleFeatureMeterSlug),
 }
@@ -47,5 +55,9 @@ func (c *testFeatureConnector) CreateExampleFeatures(t *testing.T) []feature.Fea
 	if err != nil {
 		t.Fatalf("failed to create feature: %v", err)
 	}
-	return []feature.Feature{feat1, feat2}
+	feat3, err := c.FeatureConnector.CreateFeature(context.Background(), ExampleFeature3)
+	if err != nil {
+		t.Fatalf("failed to create feature: %v", err)
+	}
+	return []feature.Feature{feat1, feat2, feat3}
 }


### PR DESCRIPTION
## Overview

Supersedes this https://github.com/openmeterio/openmeter/pull/2726

1. Adds validation that RateCards with Entitlement Templates also have Features set 🤦 
2. Go through `productcatalog` so it uses clock.Now() instead of time.Now()
3. Due to a combination of above we had quite a few tests depending on buggy behavior, I fixed those

## Notes
- [See thread](https://openmeter.slack.com/archives/C065HE9LXJ9/p1745761212751779?thread_ts=1745522471.024389&cid=C065HE9LXJ9) for affected customers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for rate cards to require a feature key when an entitlement template is present.
  - Enhanced error messages for plan status and subscription changes to provide clearer feedback.
  - Corrected test case names and improved test reliability for plan and addon logic.

- **New Features**
  - Added support for a third example feature in test utilities.

- **Refactor**
  - Standardized time handling across the product catalog and subscription services using a unified clock abstraction.
  - Updated plan status logic for more explicit and accurate status determination.

- **Tests**
  - Improved test coverage and accuracy for plan status, addon application, and subscription changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->