### PR TITLE
fix: allow marshaling event invoice into api types

### DIFF
--- a/openmeter/app/app.go
+++ b/openmeter/app/app.go
@@ -21,6 +21,8 @@ type App interface {
 	GetMetadata() map[string]string
 	GetListing() MarketplaceListing
 
+	GetEventAppData() (EventAppData, error)
+
 	UpdateAppConfig(ctx context.Context, input AppConfigUpdate) error
 
 	// ValidateCapabilities validates if the app can run for the given capabilities

--- a/openmeter/app/custominvoicing/app.go
+++ b/openmeter/app/custominvoicing/app.go
@@ -36,9 +36,25 @@ func (c Configuration) Validate() error {
 	return nil
 }
 
-type App struct {
+type Meta struct {
 	app.AppBase
 	Configuration
+}
+
+var _ app.EventAppParser = (*Meta)(nil)
+
+func (m *Meta) FromEventAppData(event app.EventApp) error {
+	m.AppBase = event.AppBase
+
+	if err := event.AppData.ParseInto(&m.Configuration); err != nil {
+		return fmt.Errorf("error parsing app data: %w", err)
+	}
+
+	return nil
+}
+
+type App struct {
+	Meta
 
 	customInvoicingService Service
 	billingService         billing.Service
@@ -62,6 +78,10 @@ func (a App) UpdateAppConfig(ctx context.Context, input app.AppConfigUpdate) err
 		AppID:         a.GetID(),
 		Configuration: cfg,
 	})
+}
+
+func (a App) GetEventAppData() (app.EventAppData, error) {
+	return app.NewEventAppData(a.Configuration)
 }
 
 // InvoicingApp

--- a/openmeter/app/custominvoicing/factory.go
+++ b/openmeter/app/custominvoicing/factory.go
@@ -103,8 +103,10 @@ func (f *Factory) NewApp(ctx context.Context, appBase app.AppBase) (app.App, err
 	}
 
 	return App{
-		AppBase:                appBase,
-		Configuration:          cfg,
+		Meta: Meta{
+			AppBase:       appBase,
+			Configuration: cfg,
+		},
 		customInvoicingService: f.customInvoicingService,
 		billingService:         f.billingService,
 	}, nil
@@ -115,7 +117,7 @@ func (f *Factory) InstallApp(ctx context.Context, input app.AppFactoryInstallApp
 		return nil, fmt.Errorf("invalid input: %w", err)
 	}
 
-	appBase, err := f.customInvoicingService.CreateApp(ctx, CreateAppInput{
+	newApp, err := f.customInvoicingService.CreateApp(ctx, CreateAppInput{
 		Namespace: input.Namespace,
 		Name:      input.Name,
 	})
@@ -123,7 +125,7 @@ func (f *Factory) InstallApp(ctx context.Context, input app.AppFactoryInstallApp
 		return nil, fmt.Errorf("failed to create app: %w", err)
 	}
 
-	return f.NewApp(ctx, appBase)
+	return f.NewApp(ctx, newApp.GetAppBase())
 }
 
 func (f *Factory) UninstallApp(ctx context.Context, input app.UninstallAppInput) error {

--- a/openmeter/app/event.go
+++ b/openmeter/app/event.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/oklog/ulid/v2"
 
@@ -37,6 +38,10 @@ func NewEventAppData(v any) (EventAppData, error) {
 
 // ParseInto parses the EventAppData into a given value, the value must be a pointer
 func (e EventAppData) ParseInto(v any) error {
+	if rv := reflect.ValueOf(v); rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return fmt.Errorf("target must be a non-nil pointer")
+	}
+
 	jsonBytes, err := json.Marshal(e)
 	if err != nil {
 		return err

--- a/openmeter/app/event.go
+++ b/openmeter/app/event.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/oklog/ulid/v2"
@@ -9,6 +10,63 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/event/metadata"
 	"github.com/openmeterio/openmeter/openmeter/session"
 )
+
+// EventAppParser should be implemented by the app's meta contents to be parsable from an EventApp
+type EventAppParser interface {
+	FromEventAppData(EventApp) error
+}
+
+type EventAppData map[string]any
+
+// NewEventAppData creates a new EventAppData from a given value
+// TODO[later]: we need to refactor apps to be able to handle serialization more gracefully, e.g. having a proper
+// union type for app instead of the interface
+func NewEventAppData(v any) (EventAppData, error) {
+	jsonBytes, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	var data EventAppData
+	if err := json.Unmarshal(jsonBytes, &data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// ParseInto parses the EventAppData into a given value, the value must be a pointer
+func (e EventAppData) ParseInto(v any) error {
+	jsonBytes, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(jsonBytes, v); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type EventApp struct {
+	AppBase
+	AppData EventAppData `json:"appData"`
+}
+
+func NewEventApp(app App) (EventApp, error) {
+	appBase := app.GetAppBase()
+
+	appData, err := app.GetEventAppData()
+	if err != nil {
+		return EventApp{}, err
+	}
+
+	return EventApp{
+		AppBase: appBase,
+		AppData: appData,
+	}, nil
+}
 
 const (
 	AppEventSubsystem  metadata.EventSubsystem = "app"
@@ -18,6 +76,8 @@ const (
 )
 
 // NewAppCreateEvent creates a new app create event
+// TODO[later]: We should use eventApp instead of AppBase, but the creation flow is somewhat tricky to change as the flow
+// is that the app calls the AppCreate without having the configuration presisted.
 func NewAppCreateEvent(ctx context.Context, appBase AppBase) AppCreateEvent {
 	return AppCreateEvent{
 		AppBase: appBase,
@@ -27,8 +87,8 @@ func NewAppCreateEvent(ctx context.Context, appBase AppBase) AppCreateEvent {
 
 // AppCreateEvent is an event that is emitted when an app is created
 type AppCreateEvent struct {
-	AppBase AppBase `json:"appBase"`
-	UserID  *string `json:"userId,omitempty"`
+	AppBase
+	UserID *string `json:"userId,omitempty"`
 }
 
 func (e AppCreateEvent) EventName() string {
@@ -58,24 +118,29 @@ func (e AppCreateEvent) Validate() error {
 }
 
 // NewAppUpdateEvent creates a new app update event
-func NewAppUpdateEvent(ctx context.Context, appBase AppBase) AppUpdateEvent {
-	return AppUpdateEvent{
-		AppBase: appBase,
-		UserID:  session.GetSessionUserID(ctx),
+func NewAppUpdateEvent(ctx context.Context, app App) (AppUpdateEvent, error) {
+	eventApp, err := NewEventApp(app)
+	if err != nil {
+		return AppUpdateEvent{}, err
 	}
+
+	return AppUpdateEvent{
+		EventApp: eventApp,
+		UserID:   session.GetSessionUserID(ctx),
+	}, nil
 }
 
 // AppUpdateEvent is an event that is emitted when an app is updated
 type AppUpdateEvent struct {
-	AppBase AppBase `json:"appBase"`
-	UserID  *string `json:"userId,omitempty"`
+	EventApp
+	UserID *string `json:"userId,omitempty"`
 }
 
 func (e AppUpdateEvent) EventName() string {
 	return metadata.GetEventName(metadata.EventType{
 		Subsystem: AppEventSubsystem,
 		Name:      AppUpdateEventName,
-		Version:   "v1",
+		Version:   "v2",
 	})
 }
 
@@ -100,24 +165,27 @@ func (e AppUpdateEvent) Validate() error {
 }
 
 // NewAppDeleteEvent creates a new app delete event
-func NewAppDeleteEvent(ctx context.Context, appBase AppBase) AppDeleteEvent {
+func NewAppDeleteEvent(ctx context.Context, app AppBase, appData EventAppData) AppDeleteEvent {
 	return AppDeleteEvent{
-		AppBase: appBase,
-		UserID:  session.GetSessionUserID(ctx),
+		EventApp: EventApp{
+			AppBase: app,
+			AppData: appData,
+		},
+		UserID: session.GetSessionUserID(ctx),
 	}
 }
 
 // AppDeleteEvent is an event that is emitted when an app is deleted
 type AppDeleteEvent struct {
-	AppBase AppBase `json:"appBase"`
-	UserID  *string `json:"userId,omitempty"`
+	EventApp
+	UserID *string `json:"userId,omitempty"`
 }
 
 func (e AppDeleteEvent) EventName() string {
 	return metadata.GetEventName(metadata.EventType{
 		Subsystem: AppEventSubsystem,
 		Name:      AppDeleteEventName,
-		Version:   "v1",
+		Version:   "v2",
 	})
 }
 

--- a/openmeter/app/httpdriver/customer.go
+++ b/openmeter/app/httpdriver/customer.go
@@ -345,7 +345,7 @@ func (h *handler) customerAppToAPI(a app.CustomerApp) (api.CustomerAppData, erro
 		apiStripeCustomerAppData := api.StripeCustomerAppData{
 			Id:                           &appId,
 			Type:                         api.StripeCustomerAppDataTypeStripe,
-			App:                          lo.ToPtr(mapStripeAppToAPI(stripeApp)),
+			App:                          lo.ToPtr(mapStripeAppToAPI(stripeApp.Meta)),
 			StripeCustomerId:             customerApp.StripeCustomerID,
 			StripeDefaultPaymentMethodId: customerApp.StripeDefaultPaymentMethodID,
 		}
@@ -361,7 +361,7 @@ func (h *handler) customerAppToAPI(a app.CustomerApp) (api.CustomerAppData, erro
 			return apiCustomerAppData, fmt.Errorf("error casting app to sandbox app")
 		}
 
-		apiApp := mapSandboxAppToAPI(sandboxApp)
+		apiApp := mapSandboxAppToAPI(sandboxApp.Meta)
 
 		apiSandboxCustomerAppData := api.SandboxCustomerAppData{
 			Id:   &appId,
@@ -374,6 +374,24 @@ func (h *handler) customerAppToAPI(a app.CustomerApp) (api.CustomerAppData, erro
 			return apiCustomerAppData, fmt.Errorf("error converting to sandbox customer app: %w", err)
 		}
 
+	case appcustominvoicing.CustomerData:
+		customInvoicingApp, ok := a.App.(appcustominvoicing.App)
+		if !ok {
+			return apiCustomerAppData, fmt.Errorf("error casting app to custom invoicing app")
+		}
+
+		apiApp := mapCustomInvoicingAppToAPI(customInvoicingApp.Meta)
+
+		apiCustomInvoicingCustomerAppData := api.CustomInvoicingCustomerAppData{
+			Id:   &appId,
+			Type: api.CustomInvoicingCustomerAppDataTypeCustomInvoicing,
+			App:  &apiApp,
+		}
+
+		err := apiCustomerAppData.FromCustomInvoicingCustomerAppData(apiCustomInvoicingCustomerAppData)
+		if err != nil {
+			return apiCustomerAppData, fmt.Errorf("error converting to custom invoicing customer app: %w", err)
+		}
 	default:
 		return apiCustomerAppData, fmt.Errorf("unsupported customer data for app: %s", appId)
 	}

--- a/openmeter/app/sandbox/mock.go
+++ b/openmeter/app/sandbox/mock.go
@@ -207,6 +207,10 @@ func (m *mockAppInstance) DeleteInvoice(ctx context.Context, invoice billing.Inv
 	return m.parent.DeleteInvoice(ctx, invoice)
 }
 
+func (m *mockAppInstance) GetEventAppData() (app.EventAppData, error) {
+	return app.EventAppData{}, nil
+}
+
 type MockableFactory struct {
 	*Factory
 

--- a/openmeter/app/stripe/entity/app/app.go
+++ b/openmeter/app/stripe/entity/app/app.go
@@ -23,7 +23,7 @@ var _ app.EventAppParser = (*Meta)(nil)
 func (m *Meta) FromEventAppData(event app.EventApp) error {
 	m.AppBase = event.AppBase
 
-	if err := event.AppData.ParseInto(&event.AppData); err != nil {
+	if err := event.AppData.ParseInto(&m.AppData); err != nil {
 		return fmt.Errorf("error parsing app data: %w", err)
 	}
 

--- a/openmeter/app/stripe/entity/app/app.go
+++ b/openmeter/app/stripe/entity/app/app.go
@@ -13,10 +13,26 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/secret"
 )
 
-// App represents an installed Stripe app
-type App struct {
+type Meta struct {
 	app.AppBase
 	appstripeentity.AppData
+}
+
+var _ app.EventAppParser = (*Meta)(nil)
+
+func (m *Meta) FromEventAppData(event app.EventApp) error {
+	m.AppBase = event.AppBase
+
+	if err := event.AppData.ParseInto(&event.AppData); err != nil {
+		return fmt.Errorf("error parsing app data: %w", err)
+	}
+
+	return nil
+}
+
+// App represents an installed Stripe app
+type App struct {
+	Meta
 
 	Logger *slog.Logger `json:"-"`
 
@@ -69,4 +85,8 @@ func (a App) Validate() error {
 	}
 
 	return nil
+}
+
+func (a App) GetEventAppData() (app.EventAppData, error) {
+	return app.NewEventAppData(a.AppData)
 }

--- a/openmeter/app/stripe/entity/input.go
+++ b/openmeter/app/stripe/entity/input.go
@@ -413,12 +413,12 @@ type AppBase struct {
 
 // AppData represents the Stripe associated data for the app
 type AppData struct {
-	StripeAccountID string
-	Livemode        bool
-	APIKey          secretentity.SecretID
-	MaskedAPIKey    string
-	StripeWebhookID string
-	WebhookSecret   secretentity.SecretID
+	StripeAccountID string                `json:"stripeAccountId"`
+	Livemode        bool                  `json:"livemode"`
+	APIKey          secretentity.SecretID `json:"-"`
+	MaskedAPIKey    string                `json:"maskedApiKey"`
+	StripeWebhookID string                `json:"stripeWebhookId"`
+	WebhookSecret   secretentity.SecretID `json:"-"`
 }
 
 func (d AppData) Validate() error {

--- a/openmeter/app/stripe/service/factory.go
+++ b/openmeter/app/stripe/service/factory.go
@@ -213,8 +213,10 @@ func (s *Service) UninstallApp(ctx context.Context, input app.UninstallAppInput)
 // newApp combines the app base and stripe app data to create a new app
 func (s *Service) newApp(appBase app.AppBase, stripeApp appstripeentity.AppData) (appstripeentityapp.App, error) {
 	app := appstripeentityapp.App{
-		AppBase:                appBase,
-		AppData:                stripeApp,
+		Meta: appstripeentityapp.Meta{
+			AppBase: appBase,
+			AppData: stripeApp,
+		},
 		AppService:             s.appService,
 		BillingService:         s.billingService,
 		StripeAppService:       s,

--- a/openmeter/billing/events.go
+++ b/openmeter/billing/events.go
@@ -13,9 +13,9 @@ const (
 )
 
 type InvoiceApps struct {
-	Tax      app.EventApp `json:"tax"`
-	Payment  app.EventApp `json:"payment"`
-	Invocing app.EventApp `json:"invocing"`
+	Tax       app.EventApp `json:"tax"`
+	Payment   app.EventApp `json:"payment"`
+	Invoicing app.EventApp `json:"invoicing"`
 }
 
 func (a InvoiceApps) Validate() error {
@@ -29,8 +29,8 @@ func (a InvoiceApps) Validate() error {
 		errs = append(errs, fmt.Errorf("payment: %w", err))
 	}
 
-	if err := a.Invocing.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("invocing: %w", err))
+	if err := a.Invoicing.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("invoicing: %w", err))
 	}
 
 	return errors.Join(errs...)
@@ -68,7 +68,7 @@ func NewEventInvoice(invoice Invoice) (EventInvoice, error) {
 	// TODO[later]: Apps are always present, so we should only use the struct without a pointer
 	if invoice.Workflow.Apps != nil {
 		var err error
-		apps.Invocing, err = app.NewEventApp(invoice.Workflow.Apps.Invoicing)
+		apps.Invoicing, err = app.NewEventApp(invoice.Workflow.Apps.Invoicing)
 		if err != nil {
 			return EventInvoice{}, err
 		}

--- a/openmeter/billing/httpdriver/invoice.go
+++ b/openmeter/billing/httpdriver/invoice.go
@@ -573,7 +573,7 @@ func MapEventInvoiceToAPI(event billing.EventInvoice) (api.Invoice, error) {
 
 	apps := api.BillingProfileApps{}
 
-	apps.Invoicing, err = apphttpdriver.MapEventAppToAPI(event.Apps.Invocing)
+	apps.Invoicing, err = apphttpdriver.MapEventAppToAPI(event.Apps.Invoicing)
 	if err != nil {
 		return api.Invoice{}, err
 	}

--- a/openmeter/billing/httpdriver/invoice.go
+++ b/openmeter/billing/httpdriver/invoice.go
@@ -10,6 +10,7 @@ import (
 	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/api"
+	apphttpdriver "github.com/openmeterio/openmeter/openmeter/app/httpdriver"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customerhttpdriver "github.com/openmeterio/openmeter/openmeter/customer/httpdriver"
@@ -560,6 +561,39 @@ func MapInvoiceToAPI(invoice billing.Invoice) (api.Invoice, error) {
 	}
 
 	return out, nil
+}
+
+func MapEventInvoiceToAPI(event billing.EventInvoice) (api.Invoice, error) {
+	invoice, err := MapInvoiceToAPI(event.Invoice)
+	if err != nil {
+		return api.Invoice{}, err
+	}
+
+	// Let's map the apps
+
+	apps := api.BillingProfileApps{}
+
+	apps.Invoicing, err = apphttpdriver.MapEventAppToAPI(event.Apps.Invocing)
+	if err != nil {
+		return api.Invoice{}, err
+	}
+
+	apps.Payment, err = apphttpdriver.MapEventAppToAPI(event.Apps.Payment)
+	if err != nil {
+		return api.Invoice{}, err
+	}
+
+	apps.Tax, err = apphttpdriver.MapEventAppToAPI(event.Apps.Tax)
+	if err != nil {
+		return api.Invoice{}, err
+	}
+
+	invoice.Workflow.Apps = &api.BillingProfileAppsOrReference{}
+	if err := invoice.Workflow.Apps.FromBillingProfileApps(apps); err != nil {
+		return api.Invoice{}, err
+	}
+
+	return invoice, nil
 }
 
 func mapPeriodToAPI(p *billing.Period) *api.Period {

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -470,7 +470,12 @@ func (s *Service) InvoicePendingLines(ctx context.Context, input billing.Invoice
 			}
 
 			for _, invoice := range out {
-				err := s.publisher.Publish(ctx, billing.NewInvoiceCreatedEvent(invoice))
+				event, err := billing.NewInvoiceCreatedEvent(invoice)
+				if err != nil {
+					return nil, fmt.Errorf("creating event: %w", err)
+				}
+
+				err = s.publisher.Publish(ctx, event)
 				if err != nil {
 					return nil, fmt.Errorf("publishing event: %w", err)
 				}

--- a/openmeter/billing/service/invoiceline.go
+++ b/openmeter/billing/service/invoiceline.go
@@ -201,7 +201,12 @@ func (s *Service) CreatePendingInvoiceLines(ctx context.Context, input billing.C
 
 			// Publish system event for newly created invoices
 			if upsertedInvoice.IsInvoiceNew {
-				if err := s.publisher.Publish(ctx, billing.NewInvoiceCreatedEvent(invoice)); err != nil {
+				event, err := billing.NewInvoiceCreatedEvent(invoice)
+				if err != nil {
+					return nil, fmt.Errorf("creating event: %w", err)
+				}
+
+				if err := s.publisher.Publish(ctx, event); err != nil {
 					return nil, fmt.Errorf("publishing invoice[%s] created event: %w", upsertedInvoice.InvoiceID.ID, err)
 				}
 			}

--- a/test/app/custominvoicing/event_test.go
+++ b/test/app/custominvoicing/event_test.go
@@ -51,11 +51,11 @@ func (s *CustomInvoicingEventTestSuite) TestCreateInvoiceEvent() {
 	// Then the event should contain the app bases as contextual information
 	s.Equal(event.Apps.Tax.AppBase, invoice.Workflow.Apps.Tax.GetAppBase())
 	s.Equal(event.Apps.Payment.AppBase, invoice.Workflow.Apps.Payment.GetAppBase())
-	s.Equal(event.Apps.Invocing.AppBase, invoice.Workflow.Apps.Invoicing.GetAppBase())
+	s.Equal(event.Apps.Invoicing.AppBase, invoice.Workflow.Apps.Invoicing.GetAppBase())
 
 	// Let's validate the app data unmarshaling
 	meta := appcustominvoicing.Meta{}
-	s.NoError(meta.FromEventAppData(event.Apps.Invocing))
+	s.NoError(meta.FromEventAppData(event.Apps.Invoicing))
 	s.Equal(invoice.Workflow.Apps.Invoicing.GetID(), meta.GetID())
 	s.True(meta.Configuration.EnableDraftSyncHook)
 	s.True(meta.Configuration.EnableIssuingSyncHook)

--- a/test/app/custominvoicing/event_test.go
+++ b/test/app/custominvoicing/event_test.go
@@ -31,7 +31,8 @@ func (s *CustomInvoicingEventTestSuite) TestCreateInvoiceEvent() {
 	})
 
 	invoice := s.CreateDraftInvoice(s.T(), ctx, billingtest.DraftInvoiceInput{
-		Customer: s.CreateTestCustomer(namespace, "test-customer"),
+		Namespace: namespace,
+		Customer:  s.CreateTestCustomer(namespace, "test-customer"),
 	})
 
 	// When we create an invoice created event

--- a/test/billing/event_test.go
+++ b/test/billing/event_test.go
@@ -51,5 +51,5 @@ func (s *InvoicingEventTestSuite) TestCreateInvoiceEvent() {
 	// Then the event should contain the app bases as contextual information
 	s.Equal(event.Apps.Tax.AppBase, invoice.Workflow.Apps.Tax.GetAppBase())
 	s.Equal(event.Apps.Payment.AppBase, invoice.Workflow.Apps.Payment.GetAppBase())
-	s.Equal(event.Apps.Invocing.AppBase, invoice.Workflow.Apps.Invoicing.GetAppBase())
+	s.Equal(event.Apps.Invoicing.AppBase, invoice.Workflow.Apps.Invoicing.GetAppBase())
 }

--- a/test/billing/event_test.go
+++ b/test/billing/event_test.go
@@ -31,7 +31,8 @@ func (s *InvoicingEventTestSuite) TestCreateInvoiceEvent() {
 	_, err := s.BillingService.CreateProfile(ctx, createProfileInput)
 	s.NoError(err)
 	invoice := s.CreateDraftInvoice(s.T(), ctx, DraftInvoiceInput{
-		Customer: s.CreateTestCustomer(namespace, "test-customer"),
+		Namespace: namespace,
+		Customer:  s.CreateTestCustomer(namespace, "test-customer"),
 	})
 
 	// When we create an invoice created event

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -3,6 +3,7 @@ package billing
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alpacahq/alpacadecimal"
 	"github.com/invopop/gobl/currency"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/lo"
@@ -30,6 +32,7 @@ import (
 	customerservice "github.com/openmeterio/openmeter/openmeter/customer/service"
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	meteradapter "github.com/openmeterio/openmeter/openmeter/meter/mockadapter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	registrybuilder "github.com/openmeterio/openmeter/openmeter/registry/builder"
 	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
@@ -285,4 +288,109 @@ func (s *BaseSuite) DebugDumpInvoice(h string, i billing.Invoice) {
 				deleted)
 		}
 	}
+}
+
+type DraftInvoiceInput struct {
+	Namespace string
+	Customer  *customer.Customer
+}
+
+func (i DraftInvoiceInput) Validate() error {
+	if i.Namespace == "" {
+		return errors.New("namespace is required")
+	}
+
+	if err := i.Customer.Validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *BaseSuite) CreateDraftInvoice(t *testing.T, ctx context.Context, in DraftInvoiceInput) billing.Invoice {
+	namespace := in.Customer.Namespace
+
+	now := time.Now()
+	invoiceAt := now.Add(-time.Second)
+	periodEnd := now.Add(-24 * time.Hour)
+	periodStart := periodEnd.Add(-24 * 30 * time.Hour)
+	// Given we have a default profile for the namespace
+
+	res, err := s.BillingService.CreatePendingInvoiceLines(ctx,
+		billing.CreateInvoiceLinesInput{
+			Namespace: in.Customer.Namespace,
+			Lines: []billing.LineWithCustomer{
+				{
+					Line: billing.Line{
+						LineBase: billing.LineBase{
+							Namespace: namespace,
+							Period:    billing.Period{Start: periodStart, End: periodEnd},
+
+							InvoiceAt: invoiceAt,
+
+							Type:      billing.InvoiceLineTypeFee,
+							ManagedBy: billing.ManuallyManagedLine,
+
+							Name:     "Test item1",
+							Currency: currencyx.Code(currency.USD),
+
+							Metadata: map[string]string{
+								"key": "value",
+							},
+						},
+						FlatFee: &billing.FlatFeeLine{
+							PerUnitAmount: alpacadecimal.NewFromFloat(100),
+							Quantity:      alpacadecimal.NewFromFloat(1),
+							Category:      billing.FlatFeeCategoryRegular,
+							PaymentTerm:   productcatalog.InAdvancePaymentTerm,
+						},
+					},
+					CustomerID: in.Customer.ID,
+				},
+				{
+					Line: billing.Line{
+						LineBase: billing.LineBase{
+							Namespace: namespace,
+							Period:    billing.Period{Start: periodStart, End: periodEnd},
+
+							InvoiceAt: invoiceAt,
+
+							Type:      billing.InvoiceLineTypeFee,
+							ManagedBy: billing.ManuallyManagedLine,
+
+							Name:     "Test item2",
+							Currency: currencyx.Code(currency.USD),
+						},
+						FlatFee: &billing.FlatFeeLine{
+							PerUnitAmount: alpacadecimal.NewFromFloat(200),
+							Quantity:      alpacadecimal.NewFromFloat(3),
+							Category:      billing.FlatFeeCategoryRegular,
+							PaymentTerm:   productcatalog.InAdvancePaymentTerm,
+						},
+					},
+					CustomerID: in.Customer.ID,
+				},
+			},
+		})
+
+	require.NoError(s.T(), err)
+	require.Len(s.T(), res, 2)
+	line1ID := res[0].ID
+	line2ID := res[1].ID
+	require.NotEmpty(s.T(), line1ID)
+	require.NotEmpty(s.T(), line2ID)
+
+	invoice, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: customer.CustomerID{
+			ID:        in.Customer.ID,
+			Namespace: in.Customer.Namespace,
+		},
+		AsOf: lo.ToPtr(now),
+	})
+
+	require.NoError(t, err)
+	require.Len(t, invoice, 1)
+	require.Len(t, invoice[0].Lines.MustGet(), 2)
+
+	return invoice[0]
 }

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -300,6 +300,10 @@ func (i DraftInvoiceInput) Validate() error {
 		return errors.New("namespace is required")
 	}
 
+	if i.Customer == nil {
+		return errors.New("customer is required")
+	}
+
 	if err := i.Customer.Validate(); err != nil {
 		return err
 	}
@@ -308,6 +312,8 @@ func (i DraftInvoiceInput) Validate() error {
 }
 
 func (s *BaseSuite) CreateDraftInvoice(t *testing.T, ctx context.Context, in DraftInvoiceInput) billing.Invoice {
+	s.NoError(in.Validate())
+
 	namespace := in.Customer.Namespace
 
 	now := time.Now()


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch adds invoice update events.

This patch provides a friendlier representation of the App type in terms of Events:

The app is not json unmarshalable, this change makes sure we have an interim representation that can travel on the event bus and can be deserialized.

Given the current structure of the code, we are using an map[string]any encoding for the app data, and the apps are expected to provide this data. We are relying on the json library for the conversion for now, so that we don't have to create custom mappers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced event data structures for apps and invoices, enabling richer, JSON-serializable app-specific data in events.
  - Introduced invoice updated events and integrated event emission during invoice state transitions.
  - Added API mapping functions for event-based app and invoice data representations.
  - Added explicit error handling for event creation and publishing in billing services.

- **Bug Fixes**
  - Fixed field naming inconsistencies and improved data handling in event and invoice structures.

- **Refactor**
  - Refactored app structs to embed new metadata types implementing event parsing interfaces.
  - Updated event constructors and handlers to support new event app data patterns.
  - Streamlined test utilities for draft invoice creation with improved input validation.

- **Tests**
  - Added and updated test suites verifying event creation, serialization, and app data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->