### PR TITLE
refactor: recover from panic in eventhandler

### DIFF
--- a/openmeter/notification/service/service.go
+++ b/openmeter/notification/service/service.go
@@ -58,7 +58,6 @@ func New(config Config) (*Service, error) {
 	if config.Logger == nil {
 		return nil, errors.New("missing logger")
 	}
-	config.Logger = config.Logger.WithGroup("notification")
 
 	eventHandler, err := eventhandler.New(eventhandler.Config{
 		Repository: config.Repository,


### PR DESCRIPTION
## Overview

REvocer from panics  in `eventhandler` in order to avoid crash of the application in case there is one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by adding panic recovery to background processes, preventing unexpected crashes.
  - Ensured safe and reliable shutdown by making stop channel closure robust against multiple close attempts.

- **Refactor**
  - Simplified logging within notification event handling for clearer log output.
  - Updated logger usage to remove grouping under the "notification" label in the notification service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->