### PR TITLE
fix: nil check in app http mapper

### DIFF
--- a/openmeter/app/httpdriver/mapper.go
+++ b/openmeter/app/httpdriver/mapper.go
@@ -1,6 +1,7 @@
 package httpdriver
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/samber/lo"
@@ -14,6 +15,10 @@ import (
 
 // MapAppToAPI maps an app to an API app
 func MapAppToAPI(item app.App) (api.App, error) {
+	if item == nil {
+		return api.App{}, errors.New("invalid app: nil")
+	}
+
 	switch item.GetType() {
 	case app.AppTypeStripe:
 		stripeApp := item.(appstripeentityapp.App)


### PR DESCRIPTION
## Overview

Check for `nil` in application mapper helper function in order to avoid nil pointer derefenrece errors, panics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent issues when processing invalid or missing app data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->