### PR TITLE
fix(streaming): handling nan with decimals

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -289,7 +289,7 @@ func TestInvalidIngest(t *testing.T) {
 		require.Equal(t, http.StatusNoContent, resp.StatusCode())
 	}
 
-	// Send an event with a NaN value
+	// Send an event with a NaN value (will skip from aggregation)
 	{
 		ev := cloudevents.New()
 		ev.SetID(ulid.Make().String())
@@ -299,6 +299,23 @@ func TestInvalidIngest(t *testing.T) {
 		ev.SetTime(getTime())
 		_ = ev.SetData(cloudevents.ApplicationJSON, map[string]string{
 			"duration_ms": "NaN",
+		})
+
+		resp, err := client.IngestEventWithResponse(context.Background(), ev)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNoContent, resp.StatusCode())
+	}
+
+	// Send an event with a Inf value (will skip from aggregation)
+	{
+		ev := cloudevents.New()
+		ev.SetID(ulid.Make().String())
+		ev.SetSource("my-app")
+		ev.SetType(eventType)
+		ev.SetSubject(subject)
+		ev.SetTime(getTime())
+		_ = ev.SetData(cloudevents.ApplicationJSON, map[string]string{
+			"duration_ms": "Inf",
 		})
 
 		resp, err := client.IngestEventWithResponse(context.Background(), ev)
@@ -342,7 +359,7 @@ func TestInvalidIngest(t *testing.T) {
 	require.NotNil(t, resp.JSON200)
 
 	events := *resp.JSON200
-	require.Len(t, events, 5)
+	require.Len(t, events, 6)
 
 	// unsupported data content gets rejected with a bad request so it should not be in the list
 
@@ -364,6 +381,10 @@ func TestInvalidIngest(t *testing.T) {
 	// nan data should have processing error as it does not have the required value property
 	require.NotNil(t, events[3].ValidationError)
 	require.Equal(t, `invalid event: value cannot be NaN`, *events[3].ValidationError)
+
+	// inf data should have processing error as it does not have the required value property
+	require.NotNil(t, events[4].ValidationError)
+	require.Equal(t, `invalid event: value cannot be infinite`, *events[4].ValidationError)
 }
 
 func TestDedupe(t *testing.T) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -384,7 +384,7 @@ func TestInvalidIngest(t *testing.T) {
 
 	// inf data should have processing error as it does not have the required value property
 	require.NotNil(t, events[4].ValidationError)
-	require.Equal(t, `invalid event: value cannot be infinite`, *events[4].ValidationError)
+	require.Equal(t, `invalid event: value cannot be infinity`, *events[4].ValidationError)
 }
 
 func TestDedupe(t *testing.T) {

--- a/openmeter/streaming/clickhouse/cache_test.go
+++ b/openmeter/streaming/clickhouse/cache_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -257,7 +258,7 @@ func TestConnector_ExecuteQueryWithCaching(t *testing.T) {
 
 		*(dest[0].(*time.Time)) = currentCacheEnd
 		*(dest[1].(*time.Time)) = cachedEnd
-		*(dest[2].(**float64)) = lo.ToPtr(50.0)
+		*(dest[2].(**decimal.Decimal)) = lo.ToPtr(decimal.NewFromFloat(50.0))
 	}).Return(nil)
 	mockRows2.On("Next").Return(false)
 	mockRows2.On("Err").Return(nil)

--- a/openmeter/streaming/clickhouse/connector_test.go
+++ b/openmeter/streaming/clickhouse/connector_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -121,7 +122,7 @@ func TestConnector_QueryMeter(t *testing.T) {
 		// Different scanRows implementations might use different indices, adjust accordingly
 		*(dest[0].(*time.Time)) = windowStart
 		*(dest[1].(*time.Time)) = windowEnd
-		*(dest[2].(**float64)) = &value
+		*(dest[2].(**decimal.Decimal)) = lo.ToPtr(decimal.NewFromFloat(value))
 		// If there are more fields used in scanRows, set them appropriately
 		if len(dest) > 3 {
 			*(dest[3].(*string)) = subject

--- a/openmeter/streaming/clickhouse/meter_query.go
+++ b/openmeter/streaming/clickhouse/meter_query.go
@@ -183,7 +183,8 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 		selectColumns = append(selectColumns, fmt.Sprintf("toDecimal64(%s(JSON_VALUE(%s, '%s')), 0) AS value", sqlAggregation, getColumn("data"), sqlbuilder.Escape(*d.Meter.ValueProperty)))
 	default:
 		// JSON_VALUE returns an empty string if the JSON Path is not found. With toFloat64OrNull we convert it to NULL so the aggregation function can handle it properly.
-		selectColumns = append(selectColumns, fmt.Sprintf("%s(toDecimal64OrNull(JSON_VALUE(%s, '%s'), 8)) AS value", sqlAggregation, getColumn("data"), sqlbuilder.Escape(*d.Meter.ValueProperty)))
+		// Decimal range: -1 * 10^(18 - S), 1 * 10^(18 - S) where S=4: -1 * 10^(14), 1 * 10^(14)
+		selectColumns = append(selectColumns, fmt.Sprintf("%s(toDecimal64OrNull(JSON_VALUE(%s, '%s'), 4)) AS value", sqlAggregation, getColumn("data"), sqlbuilder.Escape(*d.Meter.ValueProperty)))
 	}
 
 	for _, groupByKey := range d.GroupBy {

--- a/openmeter/streaming/clickhouse/meter_query_test.go
+++ b/openmeter/streaming/clickhouse/meter_query_test.go
@@ -43,7 +43,7 @@ func TestQueryMeter(t *testing.T) {
 				GroupBy:    []string{"subject", "group1", "group2"},
 				WindowSize: &windowSize,
 			},
-			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value'))) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ?) AND om_events.time >= ? AND om_events.time <= ? GROUP BY windowstart, windowend, subject, group1, group2 ORDER BY windowstart",
+			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ?) AND om_events.time >= ? AND om_events.time <= ? GROUP BY windowstart, windowend, subject, group1, group2 ORDER BY windowstart",
 			wantArgs: []interface{}{"my_namespace", "event1", "subject1", from.Unix(), to.Unix()},
 		},
 		{ // Aggregate all available data
@@ -62,7 +62,7 @@ func TestQueryMeter(t *testing.T) {
 					},
 				},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value'))) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
 		{ // Aggregate with count aggregation
@@ -80,7 +80,7 @@ func TestQueryMeter(t *testing.T) {
 					},
 				},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, toFloat64(count(*)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, toDecimal64(count(*), 0) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
 		{ // Aggregate data from start
@@ -100,7 +100,7 @@ func TestQueryMeter(t *testing.T) {
 				},
 				From: &from,
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value'))) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ?",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ?",
 			wantArgs: []interface{}{"my_namespace", "event1", from.Unix()},
 		},
 		{ // Aggregate data between period
@@ -121,7 +121,7 @@ func TestQueryMeter(t *testing.T) {
 				From: &from,
 				To:   &to,
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value'))) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time <= ?",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time <= ?",
 			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
 		},
 		{ // Aggregate data between period, groupped by window size
@@ -143,7 +143,7 @@ func TestQueryMeter(t *testing.T) {
 				To:         &to,
 				WindowSize: &windowSize,
 			},
-			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value'))) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time <= ? GROUP BY windowstart, windowend ORDER BY windowstart",
+			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time <= ? GROUP BY windowstart, windowend ORDER BY windowstart",
 			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
 		},
 		{ // Aggregate data between period in a different timezone, groupped by window size
@@ -166,7 +166,7 @@ func TestQueryMeter(t *testing.T) {
 				WindowSize:     &windowSize,
 				WindowTimeZone: tz,
 			},
-			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowend, sum(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value'))) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time <= ? GROUP BY windowstart, windowend ORDER BY windowstart",
+			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time <= ? GROUP BY windowstart, windowend ORDER BY windowstart",
 			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
 		},
 		{ // Aggregate data for a single subject
@@ -187,7 +187,7 @@ func TestQueryMeter(t *testing.T) {
 				Subject: []string{subject},
 				GroupBy: []string{"subject"},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value'))) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ?) GROUP BY subject",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ?) GROUP BY subject",
 			wantArgs: []interface{}{"my_namespace", "event1", "subject1"},
 		},
 		{ // Aggregate data for a single subject and group by additional fields
@@ -208,7 +208,7 @@ func TestQueryMeter(t *testing.T) {
 				Subject: []string{subject},
 				GroupBy: []string{"subject", "group1", "group2"},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value'))) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ?) GROUP BY subject, group1, group2",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ?) GROUP BY subject, group1, group2",
 			wantArgs: []interface{}{"my_namespace", "event1", "subject1"},
 		},
 		{ // Aggregate data for a multiple subjects
@@ -229,7 +229,7 @@ func TestQueryMeter(t *testing.T) {
 				Subject: []string{subject, "subject2"},
 				GroupBy: []string{"subject"},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value'))) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ? OR om_events.subject = ?) GROUP BY subject",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ? OR om_events.subject = ?) GROUP BY subject",
 			wantArgs: []interface{}{"my_namespace", "event1", "subject1", "subject2"},
 		},
 		{ // Aggregate data with filtering for a single group and single value
@@ -249,7 +249,7 @@ func TestQueryMeter(t *testing.T) {
 				},
 				FilterGroupBy: map[string][]string{"g1": {"g1v1"}},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value'))) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1')",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1')",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
 		{ // Aggregate data with filtering for a single group and multiple values
@@ -269,7 +269,7 @@ func TestQueryMeter(t *testing.T) {
 				},
 				FilterGroupBy: map[string][]string{"g1": {"g1v1", "g1v2"}},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value'))) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2')",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2')",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
 		{ // Aggregate data with filtering for multiple groups and multiple values
@@ -289,7 +289,7 @@ func TestQueryMeter(t *testing.T) {
 				},
 				FilterGroupBy: map[string][]string{"g1": {"g1v1", "g1v2"}, "g2": {"g2v1", "g2v2"}},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value'))) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2') AND (JSON_VALUE(om_events.data, '$.group2') = 'g2v1' OR JSON_VALUE(om_events.data, '$.group2') = 'g2v2')",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2') AND (JSON_VALUE(om_events.data, '$.group2') = 'g2v1' OR JSON_VALUE(om_events.data, '$.group2') = 'g2v2')",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
 	}

--- a/openmeter/streaming/clickhouse/meter_query_test.go
+++ b/openmeter/streaming/clickhouse/meter_query_test.go
@@ -43,7 +43,7 @@ func TestQueryMeter(t *testing.T) {
 				GroupBy:    []string{"subject", "group1", "group2"},
 				WindowSize: &windowSize,
 			},
-			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ?) AND om_events.time >= ? AND om_events.time <= ? GROUP BY windowstart, windowend, subject, group1, group2 ORDER BY windowstart",
+			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 4)) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ?) AND om_events.time >= ? AND om_events.time <= ? GROUP BY windowstart, windowend, subject, group1, group2 ORDER BY windowstart",
 			wantArgs: []interface{}{"my_namespace", "event1", "subject1", from.Unix(), to.Unix()},
 		},
 		{ // Aggregate all available data
@@ -62,7 +62,7 @@ func TestQueryMeter(t *testing.T) {
 					},
 				},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 4)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
 		{ // Aggregate with count aggregation
@@ -100,7 +100,7 @@ func TestQueryMeter(t *testing.T) {
 				},
 				From: &from,
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ?",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 4)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ?",
 			wantArgs: []interface{}{"my_namespace", "event1", from.Unix()},
 		},
 		{ // Aggregate data between period
@@ -121,7 +121,7 @@ func TestQueryMeter(t *testing.T) {
 				From: &from,
 				To:   &to,
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time <= ?",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 4)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time <= ?",
 			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
 		},
 		{ // Aggregate data between period, groupped by window size
@@ -143,7 +143,7 @@ func TestQueryMeter(t *testing.T) {
 				To:         &to,
 				WindowSize: &windowSize,
 			},
-			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time <= ? GROUP BY windowstart, windowend ORDER BY windowstart",
+			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 4)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time <= ? GROUP BY windowstart, windowend ORDER BY windowstart",
 			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
 		},
 		{ // Aggregate data between period in a different timezone, groupped by window size
@@ -166,7 +166,7 @@ func TestQueryMeter(t *testing.T) {
 				WindowSize:     &windowSize,
 				WindowTimeZone: tz,
 			},
-			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time <= ? GROUP BY windowstart, windowend ORDER BY windowstart",
+			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 4)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time <= ? GROUP BY windowstart, windowend ORDER BY windowstart",
 			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
 		},
 		{ // Aggregate data for a single subject
@@ -187,7 +187,7 @@ func TestQueryMeter(t *testing.T) {
 				Subject: []string{subject},
 				GroupBy: []string{"subject"},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ?) GROUP BY subject",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 4)) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ?) GROUP BY subject",
 			wantArgs: []interface{}{"my_namespace", "event1", "subject1"},
 		},
 		{ // Aggregate data for a single subject and group by additional fields
@@ -208,7 +208,7 @@ func TestQueryMeter(t *testing.T) {
 				Subject: []string{subject},
 				GroupBy: []string{"subject", "group1", "group2"},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ?) GROUP BY subject, group1, group2",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 4)) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ?) GROUP BY subject, group1, group2",
 			wantArgs: []interface{}{"my_namespace", "event1", "subject1"},
 		},
 		{ // Aggregate data for a multiple subjects
@@ -229,7 +229,7 @@ func TestQueryMeter(t *testing.T) {
 				Subject: []string{subject, "subject2"},
 				GroupBy: []string{"subject"},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ? OR om_events.subject = ?) GROUP BY subject",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 4)) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (om_events.subject = ? OR om_events.subject = ?) GROUP BY subject",
 			wantArgs: []interface{}{"my_namespace", "event1", "subject1", "subject2"},
 		},
 		{ // Aggregate data with filtering for a single group and single value
@@ -249,7 +249,7 @@ func TestQueryMeter(t *testing.T) {
 				},
 				FilterGroupBy: map[string][]string{"g1": {"g1v1"}},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1')",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 4)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1')",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
 		{ // Aggregate data with filtering for a single group and multiple values
@@ -269,7 +269,7 @@ func TestQueryMeter(t *testing.T) {
 				},
 				FilterGroupBy: map[string][]string{"g1": {"g1v1", "g1v2"}},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2')",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 4)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2')",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
 		{ // Aggregate data with filtering for multiple groups and multiple values
@@ -289,7 +289,7 @@ func TestQueryMeter(t *testing.T) {
 				},
 				FilterGroupBy: map[string][]string{"g1": {"g1v1", "g1v2"}, "g2": {"g2v1", "g2v2"}},
 			},
-			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 8)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2') AND (JSON_VALUE(om_events.data, '$.group2') = 'g2v1' OR JSON_VALUE(om_events.data, '$.group2') = 'g2v2')",
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(toDecimal64OrNull(JSON_VALUE(om_events.data, '$.value'), 4)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2') AND (JSON_VALUE(om_events.data, '$.group2') = 'g2v1' OR JSON_VALUE(om_events.data, '$.group2') = 'g2v2')",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
 	}


### PR DESCRIPTION
Use Decimal(x, 4) over Float64 in aggregation to handle NaN and Inf values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of special floating-point values ("NaN" and "Inf") in event ingestion, ensuring these are correctly reported as invalid events with clear error messages.
- **Refactor**
	- Updated aggregation calculations to use fixed-point decimal types instead of floating-point types for more accurate and reliable results.
- **Tests**
	- Enhanced test coverage for invalid event ingestion cases.
	- Updated tests to reflect the use of decimal types in aggregation queries and result handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->