### PR TITLE
feat: add fs for disabling invocing on a namespace

### DIFF
--- a/app/common/billing.go
+++ b/app/common/billing.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/wire"
 
+	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	billingadapter "github.com/openmeterio/openmeter/openmeter/billing/adapter"
@@ -48,6 +49,7 @@ func BillingService(
 	eventPublisher eventbus.Publisher,
 	advancementStrategy billing.AdvancementStrategy,
 	subscriptionServices SubscriptionServiceWithWorkflow,
+	fsConfig config.BillingFeatureSwitchesConfiguration,
 ) (billing.Service, error) {
 	service, err := billingservice.New(billingservice.Config{
 		Adapter:             billingAdapter,
@@ -59,6 +61,7 @@ func BillingService(
 		StreamingConnector:  streamingConnector,
 		Publisher:           eventPublisher,
 		AdvancementStrategy: advancementStrategy,
+		FSNamespaceLockdown: fsConfig.NamespaceLockdown,
 	})
 	if err != nil {
 		return nil, err

--- a/app/common/config.go
+++ b/app/common/config.go
@@ -15,6 +15,7 @@ var Config = wire.NewSet(
 	// Billing
 	wire.FieldsOf(new(config.Configuration), "Billing"),
 	wire.FieldsOf(new(config.BillingConfiguration), "AdvancementStrategy"),
+	wire.FieldsOf(new(config.BillingConfiguration), "FeatureSwitches"),
 	// ClickHouse
 	wire.FieldsOf(new(config.AggregationConfiguration), "ClickHouse"),
 	// Database

--- a/app/config/billing.go
+++ b/app/config/billing.go
@@ -12,6 +12,7 @@ import (
 type BillingConfiguration struct {
 	AdvancementStrategy billing.AdvancementStrategy
 	Worker              BillingWorkerConfiguration
+	FeatureSwitches     BillingFeatureSwitchesConfiguration
 }
 
 func (c BillingConfiguration) Validate() error {
@@ -24,7 +25,19 @@ func (c BillingConfiguration) Validate() error {
 		errs = append(errs, err)
 	}
 
+	if err := c.FeatureSwitches.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
 	return errors.Join(errs...)
+}
+
+type BillingFeatureSwitchesConfiguration struct {
+	NamespaceLockdown []string
+}
+
+func (c BillingFeatureSwitchesConfiguration) Validate() error {
+	return nil
 }
 
 func ConfigureBilling(v *viper.Viper, flags *pflag.FlagSet) {

--- a/cmd/billing-worker/wire_gen.go
+++ b/cmd/billing-worker/wire_gen.go
@@ -268,7 +268,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	billingService, err := common.BillingService(logger, service, adapter, customerService, featureConnector, meterService, connector, eventbusPublisher, advancementStrategy, subscriptionServiceWithWorkflow)
+	billingFeatureSwitchesConfiguration := billingConfiguration.FeatureSwitches
+	billingService, err := common.BillingService(logger, service, adapter, customerService, featureConnector, meterService, connector, eventbusPublisher, advancementStrategy, subscriptionServiceWithWorkflow, billingFeatureSwitchesConfiguration)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/cmd/jobs/internal/wire_gen.go
+++ b/cmd/jobs/internal/wire_gen.go
@@ -275,7 +275,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	billingService, err := common.BillingService(logger, service, billingAdapter, customerService, featureConnector, meterService, connector, eventbusPublisher, advancementStrategy, subscriptionServiceWithWorkflow)
+	billingFeatureSwitchesConfiguration := billingConfiguration.FeatureSwitches
+	billingService, err := common.BillingService(logger, service, billingAdapter, customerService, featureConnector, meterService, connector, eventbusPublisher, advancementStrategy, subscriptionServiceWithWorkflow, billingFeatureSwitchesConfiguration)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -269,7 +269,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	billingService, err := common.BillingService(logger, appService, billingAdapter, customerService, featureConnector, service, connector, eventbusPublisher, advancementStrategy, subscriptionServiceWithWorkflow)
+	billingFeatureSwitchesConfiguration := billingConfiguration.FeatureSwitches
+	billingService, err := common.BillingService(logger, appService, billingAdapter, customerService, featureConnector, service, connector, eventbusPublisher, advancementStrategy, subscriptionServiceWithWorkflow, billingFeatureSwitchesConfiguration)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/openmeter/billing/errors.go
+++ b/openmeter/billing/errors.go
@@ -55,6 +55,8 @@ var (
 
 	ErrInvoiceDiscountInvalidLineReference                  = NewValidationError("invoice_discount_invalid_line_reference", "invoice discount references non-existing line")
 	ErrInvoiceDiscountNoWildcardDiscountOnGatheringInvoices = NewValidationError("invoice_discount_no_wildcard_discount_on_gathering_invoices", "wildcard discount on gathering invoices is not allowed")
+
+	ErrNamespaceLocked = NewValidationError("namespace_locked", "namespace is locked")
 )
 
 const (

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -87,4 +87,6 @@ type InvoiceAppService interface {
 
 type ConfigService interface {
 	GetAdvancementStrategy() AdvancementStrategy
+	WithAdvancementStrategy(strategy AdvancementStrategy) Service
+	WithLockedNamespaces(namespaces []string) Service
 }

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -231,6 +231,12 @@ func (s *Service) InvoicePendingLines(ctx context.Context, input billing.Invoice
 		}
 	}
 
+	if slices.Contains(s.fsNamespaceLockdown, input.Customer.Namespace) {
+		return nil, billing.ValidationError{
+			Err: fmt.Errorf("%w: %s", billing.ErrNamespaceLocked, input.Customer.Namespace),
+		}
+	}
+
 	return TranscationForGatheringInvoiceManipulation(
 		ctx,
 		s,

--- a/openmeter/billing/service/service.go
+++ b/openmeter/billing/service/service.go
@@ -34,6 +34,7 @@ type Service struct {
 	publisher   eventbus.Publisher
 
 	advancementStrategy billing.AdvancementStrategy
+	fsNamespaceLockdown []string
 }
 
 type Config struct {
@@ -46,6 +47,7 @@ type Config struct {
 	StreamingConnector  streaming.Connector
 	Publisher           eventbus.Publisher
 	AdvancementStrategy billing.AdvancementStrategy
+	FSNamespaceLockdown []string
 }
 
 func (c Config) Validate() error {
@@ -103,6 +105,7 @@ func New(config Config) (*Service, error) {
 		streamingConnector:  config.StreamingConnector,
 		publisher:           config.Publisher,
 		advancementStrategy: config.AdvancementStrategy,
+		fsNamespaceLockdown: config.FSNamespaceLockdown,
 	}
 
 	lineSvc, err := lineservice.New(lineservice.Config{
@@ -182,4 +185,16 @@ func TranscationForGatheringInvoiceManipulation[T any](ctx context.Context, svc 
 
 func (s Service) GetAdvancementStrategy() billing.AdvancementStrategy {
 	return s.advancementStrategy
+}
+
+func (s Service) WithAdvancementStrategy(strategy billing.AdvancementStrategy) billing.Service {
+	s.advancementStrategy = strategy
+
+	return &s
+}
+
+func (s *Service) WithLockedNamespaces(namespaces []string) billing.Service {
+	s.fsNamespaceLockdown = namespaces
+
+	return s
 }

--- a/openmeter/billing/worker/collect/collect.go
+++ b/openmeter/billing/worker/collect/collect.go
@@ -158,6 +158,12 @@ func (a *InvoiceCollector) CollectCustomerInvoice(ctx context.Context, params Co
 		AsOf: lo.ToPtr(alignedAsOf),
 	})
 	if err != nil {
+		if errors.Is(err, billing.ErrNamespaceLocked) {
+			a.logger.WarnContext(ctx, "namespace is locked, skipping collection", "customer", params.CustomerID)
+
+			return nil, nil
+		}
+
 		return nil, fmt.Errorf("failed to create invoice(s) for customer [customer=%s]: %w", params.CustomerID, err)
 	}
 

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1478,3 +1478,11 @@ func (n NoopBillingService) SyncIssuingInvoice(ctx context.Context, input billin
 func (n NoopBillingService) GetAdvancementStrategy() billing.AdvancementStrategy {
 	return billing.ForegroundAdvancementStrategy
 }
+
+func (n NoopBillingService) WithAdvancementStrategy(strategy billing.AdvancementStrategy) billing.Service {
+	return n
+}
+
+func (n NoopBillingService) WithLockedNamespaces(namespaces []string) billing.Service {
+	return n
+}

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -311,7 +311,7 @@ func (i DraftInvoiceInput) Validate() error {
 	return nil
 }
 
-func (s *BaseSuite) CreateDraftInvoice(t *testing.T, ctx context.Context, in DraftInvoiceInput) billing.Invoice {
+func (s *BaseSuite) CreateGatheringInvoice(t *testing.T, ctx context.Context, in DraftInvoiceInput) {
 	s.NoError(in.Validate())
 
 	namespace := in.Customer.Namespace
@@ -385,7 +385,14 @@ func (s *BaseSuite) CreateDraftInvoice(t *testing.T, ctx context.Context, in Dra
 	line2ID := res[1].ID
 	require.NotEmpty(s.T(), line1ID)
 	require.NotEmpty(s.T(), line2ID)
+}
 
+func (s *BaseSuite) CreateDraftInvoice(t *testing.T, ctx context.Context, in DraftInvoiceInput) billing.Invoice {
+	s.NoError(in.Validate())
+
+	s.CreateGatheringInvoice(t, ctx, in)
+
+	now := time.Now()
 	invoice, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 		Customer: customer.CustomerID{
 			ID:        in.Customer.ID,


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Allow temporary suspending all billing activity on a namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to lock specific namespaces from billing operations, preventing invoice creation or progression for those namespaces.
  - Added configuration options to manage locked namespaces for billing.
- **Bug Fixes**
  - Improved error handling to gracefully skip billing actions and log warnings when a namespace is locked.
- **Tests**
  - Added tests to verify correct behavior when billing is attempted in locked namespaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->