### PR TITLE
feat(ingest): validate for nan

### DIFF
--- a/openmeter/ingest/ingestdriver/http_transport.go
+++ b/openmeter/ingest/ingestdriver/http_transport.go
@@ -262,16 +262,16 @@ func validateTraverse(path []string, val reflect.Value) error {
 
 // validateString checks if a string contains NaN, Inf, or -Inf.
 func validateString(s string) error {
-	if strings.Contains(s, "NaN") {
+	if s == "NaN" {
 		return fmt.Errorf("property NaN is not allowed")
 	}
 
-	if strings.Contains(s, "-Inf") {
-		return fmt.Errorf("property -Inf is not allowed")
+	if s == "Inf" || s == "+Inf" {
+		return fmt.Errorf("property Inf is not allowed")
 	}
 
-	if strings.Contains(s, "Inf") {
-		return fmt.Errorf("property Inf is not allowed")
+	if s == "-Inf" {
+		return fmt.Errorf("property -Inf is not allowed")
 	}
 
 	return nil

--- a/openmeter/ingest/ingestdriver/http_transport.go
+++ b/openmeter/ingest/ingestdriver/http_transport.go
@@ -263,15 +263,15 @@ func validateTraverse(path []string, val reflect.Value) error {
 // validateString checks if a string contains NaN, Inf, or -Inf.
 func validateString(s string) error {
 	if s == "NaN" {
-		return fmt.Errorf("NaN is not allowed")
+		return fmt.Errorf("value NaN is not allowed")
 	}
 
 	if s == "Inf" || s == "+Inf" {
-		return fmt.Errorf("Inf is not allowed")
+		return fmt.Errorf("value Inf is not allowed")
 	}
 
 	if s == "-Inf" {
-		return fmt.Errorf("-Inf is not allowed")
+		return fmt.Errorf("value -Inf is not allowed")
 	}
 
 	return nil

--- a/openmeter/ingest/ingestdriver/http_transport.go
+++ b/openmeter/ingest/ingestdriver/http_transport.go
@@ -263,15 +263,15 @@ func validateTraverse(path []string, val reflect.Value) error {
 // validateString checks if a string contains NaN, Inf, or -Inf.
 func validateString(s string) error {
 	if s == "NaN" {
-		return fmt.Errorf("property NaN is not allowed")
+		return fmt.Errorf("NaN is not allowed")
 	}
 
 	if s == "Inf" || s == "+Inf" {
-		return fmt.Errorf("property Inf is not allowed")
+		return fmt.Errorf("Inf is not allowed")
 	}
 
 	if s == "-Inf" {
-		return fmt.Errorf("property -Inf is not allowed")
+		return fmt.Errorf("-Inf is not allowed")
 	}
 
 	return nil

--- a/openmeter/ingest/ingestdriver/http_transport_test.go
+++ b/openmeter/ingest/ingestdriver/http_transport_test.go
@@ -106,7 +106,7 @@ func TestIngestEvents_InvalidEvent(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	problem := toProblem(t, resp)
-	assert.Equal(t, problem.Detail, "invalid event: invalid data: property NaN is not allowed")
+	assert.Equal(t, problem.Detail, "invalid event: invalid data: NaN is not allowed")
 
 	// Inf is not allowed
 	resp, err = client.Post(server.URL, "application/cloudevents+json", getMockEventPayload(t, "Inf"))
@@ -115,7 +115,7 @@ func TestIngestEvents_InvalidEvent(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	problem = toProblem(t, resp)
-	assert.Equal(t, problem.Detail, "invalid event: invalid data: property Inf is not allowed")
+	assert.Equal(t, problem.Detail, "invalid event: invalid data: Inf is not allowed")
 
 	// -Inf is not allowed
 	resp, err = client.Post(server.URL, "application/cloudevents+json", getMockEventPayload(t, "-Inf"))
@@ -124,7 +124,7 @@ func TestIngestEvents_InvalidEvent(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	problem = toProblem(t, resp)
-	assert.Equal(t, problem.Detail, "invalid event: invalid data: property -Inf is not allowed")
+	assert.Equal(t, problem.Detail, "invalid event: invalid data: -Inf is not allowed")
 
 	// Nested NaN is not allowed
 	resp, err = client.Post(server.URL, "application/cloudevents+json", getMockEventPayload(t, map[string]interface{}{
@@ -137,7 +137,7 @@ func TestIngestEvents_InvalidEvent(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	problem = toProblem(t, resp)
-	assert.Equal(t, problem.Detail, `invalid event: invalid data at "nested.value.[1]": property NaN is not allowed`)
+	assert.Equal(t, problem.Detail, `invalid event: invalid data at "nested.value.[1]": NaN is not allowed`)
 }
 
 // toProblem converts a response body to a StatusProblem.

--- a/openmeter/ingest/ingestdriver/http_transport_test.go
+++ b/openmeter/ingest/ingestdriver/http_transport_test.go
@@ -106,7 +106,7 @@ func TestIngestEvents_InvalidEvent(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	problem := toProblem(t, resp)
-	assert.Equal(t, problem.Detail, "invalid event: invalid data: NaN is not allowed")
+	assert.Equal(t, problem.Detail, "invalid event: invalid data: value NaN is not allowed")
 
 	// Inf is not allowed
 	resp, err = client.Post(server.URL, "application/cloudevents+json", getMockEventPayload(t, "Inf"))
@@ -115,7 +115,7 @@ func TestIngestEvents_InvalidEvent(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	problem = toProblem(t, resp)
-	assert.Equal(t, problem.Detail, "invalid event: invalid data: Inf is not allowed")
+	assert.Equal(t, problem.Detail, "invalid event: invalid data: value Inf is not allowed")
 
 	// -Inf is not allowed
 	resp, err = client.Post(server.URL, "application/cloudevents+json", getMockEventPayload(t, "-Inf"))
@@ -124,7 +124,7 @@ func TestIngestEvents_InvalidEvent(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	problem = toProblem(t, resp)
-	assert.Equal(t, problem.Detail, "invalid event: invalid data: -Inf is not allowed")
+	assert.Equal(t, problem.Detail, "invalid event: invalid data: value -Inf is not allowed")
 
 	// Nested NaN is not allowed
 	resp, err = client.Post(server.URL, "application/cloudevents+json", getMockEventPayload(t, map[string]interface{}{
@@ -137,7 +137,7 @@ func TestIngestEvents_InvalidEvent(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	problem = toProblem(t, resp)
-	assert.Equal(t, problem.Detail, `invalid event: invalid data at "nested.value.[1]": NaN is not allowed`)
+	assert.Equal(t, problem.Detail, `invalid event: invalid data at "nested.value.[1]": value NaN is not allowed`)
 }
 
 // toProblem converts a response body to a StatusProblem.


### PR DESCRIPTION
Don't allow to ingest "NaN" and "Inf" values, they make querying meter invalid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved event data validation to reject CloudEvents containing disallowed string values such as "NaN", "Inf", or "-Inf", including within nested structures. Users will receive detailed error messages indicating the location of invalid data.
- **Bug Fixes**
  - Enhanced error reporting for invalid event payloads, ensuring more accurate and informative responses for rejected events.
- **Tests**
  - Expanded test coverage to verify rejection of events with invalid string values, including nested cases, and improved error detail assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->