### PR TITLE
chore(deps): bump Go version to 1.24.1

### DIFF
--- a/.dagger/versions_pinned.go
+++ b/.dagger/versions_pinned.go
@@ -1,9 +1,6 @@
 package main
 
 const (
-	// Alpine is required for our current build (due to Kafka and CGO), but it doesn't seem to work well with golangci-lint
-	goVersion = "1.23.4"
-
 	kafkaVersion      = "3.6"
 	clickhouseVersion = "24.5.5.78"
 	redisVersion      = "7.0.12"
@@ -13,8 +10,8 @@ const (
 	// TODO: add update mechanism for versions below
 
 	// Alpine is required for our current build (due to Kafka and CGO), but it doesn't seem to work well with golangci-lint
-	goBuildVersion = "1.23.4-alpine3.21@sha256:6c5c9590f169f77c8046e45c611d3b28fe477789acd8d3762d23d4744de69812"
+	goBuildVersion = "1.24.2-alpine3.21@sha256:7772cb5322baa875edd74705556d08f0eeca7b9c4b5367754ce3f2f00041ccee"
 	xxBaseImage    = "tonistiigi/xx:1.6.1@sha256:923441d7c25f1e2eb5789f82d987693c47b8ed987c4ab3b075d6ed2b5d6779a3"
 
-	alpineBaseImage = "alpine:3.21.0@sha256:21dc6063fd678b478f57c0e13f47560d0ea4eeba26dfc947b2a4f81f686b9f45"
+	alpineBaseImage = "alpine:3.21@sha256:a8560b36e8b8210634f77d9f7f9efd7ffa463e380b75e2e74aff4511df3ef88c"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openmeterio/openmeter
 
-go 1.23.4
+go 1.24.1
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 // ee: https://github.com/oklog/run/pull/35
 replace github.com/oklog/run => github.com/openmeterio/run v0.0.0-20250217124527-c72029d4b634
@@ -91,7 +91,6 @@ require (
 	k8s.io/api v0.32.3
 	k8s.io/apimachinery v0.32.3
 	k8s.io/client-go v0.32.3
-	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	sigs.k8s.io/controller-runtime v0.20.4
 )
 
@@ -157,6 +156,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f // indirect
+	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	modernc.org/gc/v3 v3.0.0-20241213165251-3bc300f6d0c9 // indirect
 )
 


### PR DESCRIPTION
## Overview

Bump Go version to 1.24.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded Go language version and toolchain to 1.24.2.
  - Updated the Alpine base image to a newer version.
  - Adjusted dependency management for k8s.io/utils.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->