### PR TITLE
chore(deps): bump dagger to 0.18.6

### DIFF
--- a/.github/workflows/ci-exp.yaml
+++ b/.github/workflows/ci-exp.yaml
@@ -9,12 +9,12 @@ permissions:
   contents: read
 
 env:
-  DAGGER_VERSION: 0.18.5
+  DAGGER_VERSION: 0.18.6
 
 jobs:
   e2e:
     name: E2E
-    runs-on: depot-ubuntu-latest-16,dagger=0.18.5
+    runs-on: depot-ubuntu-latest-16,dagger=0.18.6
 
     steps:
       # Required as a workaround for Dagger to properly detect Git metadata
@@ -26,7 +26,7 @@ jobs:
 
   dagger:
     name: CI
-    runs-on: depot-ubuntu-latest-16,dagger=0.18.5
+    runs-on: depot-ubuntu-latest-16,dagger=0.18.6
 
     steps:
       # Required as a workaround for Dagger to properly detect Git metadata

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 env:
-  DAGGER_VERSION: 0.18.5
+  DAGGER_VERSION: 0.18.6
 
 jobs:
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 env:
-  DAGGER_VERSION: 0.18.5
+  DAGGER_VERSION: 0.18.6
 
 jobs:
   artifacts:

--- a/.github/workflows/sdk-javascript-release.yaml
+++ b/.github/workflows/sdk-javascript-release.yaml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
 env:
-  DAGGER_VERSION: 0.18.5
+  DAGGER_VERSION: 0.18.6
 
 jobs:
   generate:

--- a/.github/workflows/sdk-javascript.yaml
+++ b/.github/workflows/sdk-javascript.yaml
@@ -13,7 +13,7 @@ on:
       - api/openapi.cloud.yaml
       - .github/workflows/sdk-node.yaml
 env:
-  DAGGER_VERSION: 0.18.5
+  DAGGER_VERSION: 0.18.6
 
 jobs:
   generate:

--- a/.github/workflows/sdk-python.yaml
+++ b/.github/workflows/sdk-python.yaml
@@ -15,7 +15,7 @@ on:
   #     - .github/workflows/sdk-python.yaml
 
 env:
-  DAGGER_VERSION: 0.18.5
+  DAGGER_VERSION: 0.18.6
 
 jobs:
   generate:

--- a/dagger.json
+++ b/dagger.json
@@ -1,6 +1,6 @@
 {
   "name": "openmeter",
-  "engineVersion": "v0.18.5",
+  "engineVersion": "v0.18.6",
   "sdk": {
     "source": "go"
   },

--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745620298,
-        "narHash": "sha256-LaJc9XK+9CW1xV9fdEpr+aO58SDfD1VNdwr9BaRz/as=",
+        "lastModified": 1746551887,
+        "narHash": "sha256-l/Qr/N2ClEQCE6Orsew1JZat3nXkqBGpBJHwZNRjQPA=",
         "owner": "dagger",
         "repo": "nix",
-        "rev": "b950e8ddb6e2ee8784be195c3bf53181a5a5fb85",
+        "rev": "7ee89630aa77f56d9f628be53c6fb5a894f54fa9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Overview

Bump dagger to `0.18.6`. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the engine version to v0.18.6 across workflows and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->