### PR TITLE
Fix Tracing Handler

### DIFF
--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -291,6 +291,7 @@ func NewTelemetryRouterHook(meterProvider metric.MeterProvider, tracerProvider t
 						span := trace.SpanFromContext(r.Context())
 						span.SetName(updatedRoutePattern)
 						span.SetAttributes(semconv.HTTPRoute(updatedRoutePattern))
+						span.SetAttributes(semconv.URLPath(r.URL.String()), semconv.HTTPRoute(updatedRoutePattern))
 
 						// Update metrics labels if available
 						labeler, ok := otelhttp.LabelerFromContext(r.Context())


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

The "tracing wrapper hook" is the first thing registered, but the hook itself registers everything after the server handler runs. This poses some problems:
- we used to always set tracing related attributes after the fact (not necessarily an issue but still)
- if the handler fails, **traces were missing**

As an example, an invalid ingest attempt (that fails validation) previously didnt show up in tracing, now it does
<img width="793" alt="image" src="https://github.com/user-attachments/assets/4385c730-0693-49f0-8c54-600cb1d80ce0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved how telemetry data is collected for HTTP requests, ensuring more accurate route information is captured for monitoring and metrics. No visible changes to functionality for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->