### PR TITLE
feat: make http server extensible by router hooks

### DIFF
--- a/app/common/server.go
+++ b/app/common/server.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"github.com/google/wire"
+
+	"github.com/openmeterio/openmeter/openmeter/server"
+)
+
+var Server = wire.NewSet(
+	NewTelemetryRouterHook,
+	NewRouterHooks,
+)
+
+func NewRouterHooks(
+	telemetry TelemetryMiddlewareHook,
+) *server.RouterHooks {
+	return &server.RouterHooks{
+		Middlewares: []server.MiddlewareHook{
+			telemetry,
+		},
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 
 	"github.com/oklog/run"
+	"github.com/samber/lo"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
@@ -185,7 +186,7 @@ func main() {
 			SubscriptionAddonService:    app.Subscription.SubscriptionAddonService,
 			StreamingConnector:          app.StreamingConnector,
 		},
-		RouterHook: app.RouterHook,
+		RouterHooks: lo.FromPtr(app.RouterHooks),
 	})
 	if err != nil {
 		logger.Error("failed to create server", "error", err)

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
-	"github.com/go-chi/chi/v5"
 	"github.com/google/wire"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
@@ -32,6 +31,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/progressmanager"
 	"github.com/openmeterio/openmeter/openmeter/registry"
 	"github.com/openmeterio/openmeter/openmeter/secret"
+	"github.com/openmeterio/openmeter/openmeter/server"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	kafkametrics "github.com/openmeterio/openmeter/pkg/kafka/metrics"
@@ -64,7 +64,7 @@ type Application struct {
 	PlanAddon                   planaddon.Service
 	Portal                      portal.Service
 	ProgressManager             progressmanager.Service
-	RouterHook                  func(chi.Router)
+	RouterHooks                 *server.RouterHooks
 	Secret                      secret.Service
 	Subscription                common.SubscriptionServiceWithWorkflow
 	StreamingConnector          streaming.Connector
@@ -95,12 +95,12 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		common.NewKafkaIngestCollector,
 		common.NewIngestCollector,
 		common.NewServerPublisher,
-		common.NewTelemetryRouterHook,
 		common.Notification,
 		common.Streaming,
 		common.Portal,
 		common.ProductCatalog,
 		common.ProgressManager,
+		common.Server,
 		common.Subscription,
 		common.Secret,
 		common.ServerProvisionTopics,

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -9,7 +9,6 @@ package main
 import (
 	"context"
 	kafka2 "github.com/confluentinc/confluent-kafka-go/v2/kafka"
-	"github.com/go-chi/chi/v5"
 	"github.com/openmeterio/openmeter/app/common"
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -29,6 +28,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/progressmanager"
 	"github.com/openmeterio/openmeter/openmeter/registry"
 	"github.com/openmeterio/openmeter/openmeter/secret"
+	"github.com/openmeterio/openmeter/openmeter/server"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/watermill/driver/kafka"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
@@ -446,6 +446,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	v6 := common.NewTelemetryRouterHook(meterProvider, tracerProvider)
+	routerHooks := common.NewRouterHooks(v6)
 	health := common.NewHealthChecker(logger)
 	runtimeMetricsCollector, err := common.NewRuntimeMetricsCollector(meterProvider, telemetryConfig, logger)
 	if err != nil {
@@ -499,7 +500,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		PlanAddon:                   planaddonService,
 		Portal:                      portalService,
 		ProgressManager:             progressmanagerService,
-		RouterHook:                  v6,
+		RouterHooks:                 routerHooks,
 		Secret:                      secretserviceService,
 		Subscription:                subscriptionServiceWithWorkflow,
 		StreamingConnector:          connector,
@@ -549,7 +550,7 @@ type Application struct {
 	PlanAddon                   planaddon.Service
 	Portal                      portal.Service
 	ProgressManager             progressmanager.Service
-	RouterHook                  func(chi.Router)
+	RouterHooks                 *server.RouterHooks
 	Secret                      secret.Service
 	Subscription                common.SubscriptionServiceWithWorkflow
 	StreamingConnector          streaming.Connector

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/cloudevents/sdk-go/v2/event"
-	"github.com/go-chi/chi/v5"
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -528,7 +527,7 @@ func getTestServer(t *testing.T) *Server {
 			SubscriptionWorkflowService: subscriptionWorkflowService,
 			SubscriptionAddonService:    subscriptionAddonService,
 		},
-		RouterHook: func(r chi.Router) {},
+		RouterHooks: RouterHooks{},
 	}
 
 	// Create server


### PR DESCRIPTION
## Overview

Allow extending HTTP server by providing addition middlewares, route handlers. This allows us to mount routes with handlers not covered in OpenAPI spec like operational HTTP endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated server configuration to support multiple middleware and route hooks, replacing the single router hook approach.
  - Introduced new interfaces for managing middleware and route registration, improving modularity and flexibility.
  - Adjusted application and test setup to use the new structured hooks system.
  - Enhanced telemetry middleware integration with a generic middleware management interface.
  - Modularized middleware hook provisioning and dependency injection for improved server setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->