### PR TITLE
Remove high cardinality url from labels

### DIFF
--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -269,10 +269,6 @@ func NewTelemetryRouterHook(meterProvider metric.MeterProvider, tracerProvider t
 					span := trace.SpanFromContext(r.Context())
 
 					span.SetAttributes(semconv.URLPath(r.URL.String()))
-					labeler, ok := otelhttp.LabelerFromContext(r.Context())
-					if ok {
-						labeler.Add(semconv.URLPath(r.URL.String()))
-					}
 
 					// Run the instrumented handler
 					h.ServeHTTP(w, r)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Potential cause of the "memory leak"

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified telemetry handling by removing the use of an OpenTelemetry HTTP labeler and setting URL path attributes directly on spans. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->