### PR TITLE
fix: do not generate items past the end of the subscription

### DIFF
--- a/openmeter/billing/worker/subscription/phaseiterator.go
+++ b/openmeter/billing/worker/subscription/phaseiterator.go
@@ -227,6 +227,17 @@ func (it *PhaseIterator) generateForAlignedItemVersion(ctx context.Context, item
 
 	periodIdx := 0
 	at := item.SubscriptionItem.ActiveFrom
+
+	// If the item is already past the subscription end, we can ignore it
+	if it.sub.Spec.ActiveTo != nil && !at.Before(*it.sub.Spec.ActiveTo) {
+		return true, nil
+	}
+
+	// Should not happen, being a bit defensive here
+	if it.phaseCadence.ActiveTo != nil && !at.Before(*it.phaseCadence.ActiveTo) {
+		return true, nil
+	}
+
 	var err error
 
 	for {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Makes sure that addons scheduled after the cancelation of a subscription aren't taken into consideration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of billing periods for subscription items that start after the subscription or phase end date, preventing unnecessary processing.

- **Tests**
  - Added new test cases to ensure correct behavior when subscription items interact with subscription or phase end boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->