### PR TITLE
fix: phase iterator in advance/in arreas

### DIFF
--- a/openmeter/billing/worker/subscription/sync_test.go
+++ b/openmeter/billing/worker/subscription/sync_test.go
@@ -700,13 +700,13 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncNonBillableAmou
 				ItemKey:   "in-advance",
 				Version:   1,
 				PeriodMin: 0,
-				PeriodMax: 4,
+				PeriodMax: 5,
 			},
 
 			Qty:       mo.Some[float64](1),
 			UnitPrice: mo.Some[float64](10),
-			Periods:   s.generatePeriods("2024-01-01T00:00:40Z", "2024-01-02T00:00:40Z", "P1D", 5),
-			InvoiceAt: s.generateDailyTimestamps("2024-01-01T00:00:40Z", 5),
+			Periods:   s.generatePeriods("2024-01-01T00:00:40Z", "2024-01-02T00:00:40Z", "P1D", 6),
+			InvoiceAt: s.generateDailyTimestamps("2024-01-01T00:00:40Z", 6),
 		},
 	})
 }
@@ -796,13 +796,13 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncNonBillableAmou
 				ItemKey:   "in-advance",
 				Version:   1,
 				PeriodMin: 0,
-				PeriodMax: 4,
+				PeriodMax: 5,
 			},
 
 			Qty:       mo.Some[float64](1),
 			UnitPrice: mo.Some[float64](10),
-			Periods:   s.generatePeriods("2024-01-01T00:00:40Z", "2024-01-02T00:00:40Z", "P1D", 5),
-			InvoiceAt: s.generateDailyTimestamps("2024-01-01T00:00:40Z", 5),
+			Periods:   s.generatePeriods("2024-01-01T00:00:40Z", "2024-01-02T00:00:40Z", "P1D", 6),
+			InvoiceAt: s.generateDailyTimestamps("2024-01-01T00:00:40Z", 6),
 		},
 	})
 }
@@ -989,13 +989,13 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncBillableAmountP
 				ItemKey:   "in-advance",
 				Version:   1,
 				PeriodMin: 0,
-				PeriodMax: 3,
+				PeriodMax: 4,
 			},
 
 			Qty:       mo.Some[float64](1),
 			UnitPrice: mo.Some[float64](10),
-			Periods:   s.generatePeriods("2024-01-01T12:00:00Z", "2024-01-02T12:00:00Z", "P1D", 4),
-			InvoiceAt: s.generateDailyTimestamps("2024-01-01T12:00:00Z", 4),
+			Periods:   s.generatePeriods("2024-01-01T12:00:00Z", "2024-01-02T12:00:00Z", "P1D", 5),
+			InvoiceAt: s.generateDailyTimestamps("2024-01-01T12:00:00Z", 5),
 		},
 	})
 }
@@ -1099,13 +1099,13 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncDraftInvoicePro
 				ItemKey:   "in-advance",
 				Version:   1,
 				PeriodMin: 0,
-				PeriodMax: 3,
+				PeriodMax: 4,
 			},
 
 			Qty:       mo.Some[float64](1),
 			UnitPrice: mo.Some[float64](10),
-			Periods:   s.generatePeriods("2024-01-01T12:00:00Z", "2024-01-02T12:00:00Z", "P1D", 4),
-			InvoiceAt: s.generateDailyTimestamps("2024-01-01T12:00:00Z", 4),
+			Periods:   s.generatePeriods("2024-01-01T12:00:00Z", "2024-01-02T12:00:00Z", "P1D", 5),
+			InvoiceAt: s.generateDailyTimestamps("2024-01-01T12:00:00Z", 5),
 		},
 	})
 
@@ -1242,13 +1242,13 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePr
 				ItemKey:   "in-advance",
 				Version:   1,
 				PeriodMin: 0,
-				PeriodMax: 3,
+				PeriodMax: 4,
 			},
 
 			Qty:       mo.Some[float64](1),
 			UnitPrice: mo.Some[float64](10),
-			Periods:   s.generatePeriods("2024-01-01T12:00:00Z", "2024-01-02T12:00:00Z", "P1D", 4),
-			InvoiceAt: s.generateDailyTimestamps("2024-01-01T12:00:00Z", 4),
+			Periods:   s.generatePeriods("2024-01-01T12:00:00Z", "2024-01-02T12:00:00Z", "P1D", 5),
+			InvoiceAt: s.generateDailyTimestamps("2024-01-01T12:00:00Z", 5),
 		},
 	})
 
@@ -1510,7 +1510,7 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionInvoicing() {
 				ItemKey:   "in-advance",
 				Version:   1,
 				PeriodMin: 0,
-				PeriodMax: 0,
+				PeriodMax: 1,
 			},
 
 			Qty:       mo.Some[float64](1),
@@ -1520,9 +1520,16 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionInvoicing() {
 					Start: s.mustParseTime("2024-01-02T00:00:00Z"),
 					End:   s.mustParseTime("2024-01-08T00:00:00Z"),
 				},
+				{
+					Start: s.mustParseTime("2024-01-08T00:00:00Z"),
+					End:   s.mustParseTime("2024-01-15T00:00:00Z"),
+				},
 			},
 			// in-advance items are invoiced immediately when change happens
-			InvoiceAt: []time.Time{s.mustParseTime("2024-01-02T00:00:00Z")},
+			InvoiceAt: []time.Time{
+				s.mustParseTime("2024-01-02T00:00:00Z"),
+				s.mustParseTime("2024-01-08T00:00:00Z"),
+			},
 		},
 		{
 			Matcher: recurringLineMatcher{


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

If in advance and in arreas items are mixed on an invoice, the current phase iterator does not generate the in advance item for the next phase.

This results in the in advance and in arreas items to be included in seperate invoices.

This patch fixes this by considering the invoice_at property of the soon to be generated lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of billing periods and invoice dates to ensure extra billing periods are generated when the end time meets or exceeds invoice dates.
- **Tests**
	- Enhanced and extended test cases to cover scenarios with extra billing periods, mixed in-advance and in-arrears billing rules, and updated expected invoice schedules.
- **Refactor**
	- Unified invoice date calculation and improved data handling for generated billing periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->