### PR TITLE
refactor: improve billing tracing

### DIFF
--- a/openmeter/billing/worker/subscription/phaseiterator.go
+++ b/openmeter/billing/worker/subscription/phaseiterator.go
@@ -162,11 +162,11 @@ func (it *PhaseIterator) GetMinimumBillableTime() time.Time {
 //
 // This ensures that we always have the upcoming lines stored on the gathering invoice.
 func (it *PhaseIterator) Generate(ctx context.Context, iterationEnd time.Time) ([]subscriptionItemWithPeriod, error) {
-	ctx, span := it.tracer.Start(ctx, "billing.worker.subscription.phaseiterator.Generate", trace.WithAttributes(
+	ctx, span := tracex.Start[[]subscriptionItemWithPeriod](ctx, it.tracer, "billing.worker.subscription.phaseiterator.Generate", trace.WithAttributes(
 		attribute.String("phase_key", it.phase.Spec.PhaseKey),
 	))
 
-	return tracex.WithSpan(ctx, span, func(ctx context.Context) ([]subscriptionItemWithPeriod, error) {
+	return span.Wrap(ctx, func(ctx context.Context) ([]subscriptionItemWithPeriod, error) {
 		if it.sub.Subscription.BillablesMustAlign {
 			return it.generateAligned(ctx, iterationEnd)
 		}
@@ -176,117 +176,119 @@ func (it *PhaseIterator) Generate(ctx context.Context, iterationEnd time.Time) (
 }
 
 func (it *PhaseIterator) generateAligned(ctx context.Context, iterationEnd time.Time) ([]subscriptionItemWithPeriod, error) {
-	ctx, span := it.tracer.Start(ctx, "billing.worker.subscription.phaseiterator.generateAligned")
-	defer span.End()
+	ctx, span := tracex.Start[[]subscriptionItemWithPeriod](ctx, it.tracer, "billing.worker.subscription.phaseiterator.generateAligned")
 
-	if !it.sub.Subscription.BillablesMustAlign {
-		return nil, fmt.Errorf("aligned generation is not supported for non-aligned subscriptions")
-	}
-
-	items := []subscriptionItemWithPeriod{}
-
-	for _, itemsByKey := range it.phase.ItemsByKey {
-		err := slicesx.ForEachUntilWithErr(
-			itemsByKey,
-			func(item subscription.SubscriptionItemView, version int) (breaks bool, err error) {
-				return it.generateForAlignedItemVersion(ctx, item, version, iterationEnd, &items)
-			},
-		)
-		if err != nil {
-			return nil, err
+	return span.Wrap(ctx, func(ctx context.Context) ([]subscriptionItemWithPeriod, error) {
+		if !it.sub.Subscription.BillablesMustAlign {
+			return nil, fmt.Errorf("aligned generation is not supported for non-aligned subscriptions")
 		}
-	}
 
-	return it.truncateItemsIfNeeded(items), nil
+		items := []subscriptionItemWithPeriod{}
+
+		for _, itemsByKey := range it.phase.ItemsByKey {
+			err := slicesx.ForEachUntilWithErr(
+				itemsByKey,
+				func(item subscription.SubscriptionItemView, version int) (breaks bool, err error) {
+					return it.generateForAlignedItemVersion(ctx, item, version, iterationEnd, &items)
+				},
+			)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return it.truncateItemsIfNeeded(items), nil
+	})
 }
 
 func (it *PhaseIterator) generateForAlignedItemVersion(ctx context.Context, item subscription.SubscriptionItemView, version int, iterationEnd time.Time, items *[]subscriptionItemWithPeriod) (bool, error) {
-	ctx, span := it.tracer.Start(ctx, "billing.worker.subscription.phaseiterator.generateForAlignedItemVersion", trace.WithAttributes(
+	ctx, span := tracex.Start[bool](ctx, it.tracer, "billing.worker.subscription.phaseiterator.generateForAlignedItemVersion", trace.WithAttributes(
 		attribute.String("itemKey", item.Spec.ItemKey),
 		attribute.Int("itemVersion", version),
 		attribute.String("phaseKey", it.phase.Spec.PhaseKey),
 	))
-	defer span.End()
 
-	logger := it.logger.With("itemKey", item.Spec.ItemKey, "itemVersion", version, "phaseKey", it.phase.Spec.PhaseKey)
+	return span.Wrap(ctx, func(ctx context.Context) (bool, error) {
+		logger := it.logger.With("itemKey", item.Spec.ItemKey, "itemVersion", version, "phaseKey", it.phase.Spec.PhaseKey)
 
-	// Let's drop non-billable items
-	if item.Spec.RateCard.AsMeta().Price == nil {
-		return false, nil
-	}
-
-	if item.Spec.RateCard.GetBillingCadence() == nil {
-		generatedItem, err := it.generateOneTimeAlignedItem(item, version)
-		if err != nil {
-			logger.ErrorContext(ctx, "failed to generate one-time aligned item", slog.Any("error", err))
-			return false, err
+		// Let's drop non-billable items
+		if item.Spec.RateCard.AsMeta().Price == nil {
+			return false, nil
 		}
 
-		if generatedItem == nil {
-			// One time item is not billable yet, let's skip it
+		if item.Spec.RateCard.GetBillingCadence() == nil {
+			generatedItem, err := it.generateOneTimeAlignedItem(item, version)
+			if err != nil {
+				logger.ErrorContext(ctx, "failed to generate one-time aligned item", slog.Any("error", err))
+				return false, err
+			}
+
+			if generatedItem == nil {
+				// One time item is not billable yet, let's skip it
+				return true, nil
+			}
+
+			*items = append(*items, *generatedItem)
+
+			return false, nil
+		}
+
+		periodIdx := 0
+		at := item.SubscriptionItem.ActiveFrom
+
+		// If the item is already past the subscription end, we can ignore it
+		if it.sub.Spec.ActiveTo != nil && !at.Before(*it.sub.Spec.ActiveTo) {
 			return true, nil
 		}
 
-		*items = append(*items, *generatedItem)
+		// Should not happen, being a bit defensive here
+		if it.phaseCadence.ActiveTo != nil && !at.Before(*it.phaseCadence.ActiveTo) {
+			return true, nil
+		}
+
+		for {
+			logger := logger.With("periodIdx", periodIdx, "periodAt", at)
+
+			newItem, err := it.generateForAlignedItemVersionPeriod(ctx, logger, item, version, periodIdx, at)
+			if err != nil {
+				return false, err
+			}
+
+			*items = append(*items, newItem.item)
+
+			periodIdx = newItem.index + 1
+			at = newItem.period.To
+
+			// We start when the item activates, then advance until either
+			// 1. it deactivates
+			if item.SubscriptionItem.ActiveTo != nil && !at.Before(*item.SubscriptionItem.ActiveTo) {
+				logger.DebugContext(ctx, "exiting loop due to item deactivation", slog.Time("at", at), slog.Time("activeTo", *item.SubscriptionItem.ActiveTo))
+				break
+			}
+
+			// 2. the phase ends
+			if it.phaseCadence.ActiveTo != nil && !at.Before(*it.phaseCadence.ActiveTo) {
+				logger.DebugContext(ctx, "exiting loop due to phase end", slog.Time("at", at), slog.Time("activeTo", *it.phaseCadence.ActiveTo))
+				break
+			}
+
+			// 3. we reach the iteration end
+			if !at.Before(iterationEnd) && !newItem.invoiceAt.Before(iterationEnd) {
+				logger.DebugContext(ctx, "exiting loop due to iteration end", slog.Time("at", at), slog.Time("iterationEnd", iterationEnd), slog.Time("invoiceAt", newItem.invoiceAt))
+				break
+			}
+
+			// 4. we reach the max iterations
+			if periodIdx > maxSafeIter {
+				logger.ErrorContext(ctx, "max iterations reached", slog.Any("iterator", it), slog.String("stack", string(debug.Stack())))
+				break
+			}
+
+			logger.DebugContext(ctx, "iterating", slog.Time("at", at))
+		}
 
 		return false, nil
-	}
-
-	periodIdx := 0
-	at := item.SubscriptionItem.ActiveFrom
-
-	// If the item is already past the subscription end, we can ignore it
-	if it.sub.Spec.ActiveTo != nil && !at.Before(*it.sub.Spec.ActiveTo) {
-		return true, nil
-	}
-
-	// Should not happen, being a bit defensive here
-	if it.phaseCadence.ActiveTo != nil && !at.Before(*it.phaseCadence.ActiveTo) {
-		return true, nil
-	}
-
-	for {
-		logger := logger.With("periodIdx", periodIdx, "periodAt", at)
-
-		newItem, err := it.generateForAlignedItemVersionPeriod(ctx, logger, item, version, periodIdx, at)
-		if err != nil {
-			return false, err
-		}
-
-		*items = append(*items, newItem.item)
-
-		periodIdx = newItem.index + 1
-		at = newItem.period.To
-
-		// We start when the item activates, then advance until either
-		// 1. it deactivates
-		if item.SubscriptionItem.ActiveTo != nil && !at.Before(*item.SubscriptionItem.ActiveTo) {
-			logger.DebugContext(ctx, "exiting loop due to item deactivation", slog.Time("at", at), slog.Time("activeTo", *item.SubscriptionItem.ActiveTo))
-			break
-		}
-
-		// 2. the phase ends
-		if it.phaseCadence.ActiveTo != nil && !at.Before(*it.phaseCadence.ActiveTo) {
-			logger.DebugContext(ctx, "exiting loop due to phase end", slog.Time("at", at), slog.Time("activeTo", *it.phaseCadence.ActiveTo))
-			break
-		}
-
-		// 3. we reach the iteration end
-		if !at.Before(iterationEnd) && !newItem.invoiceAt.Before(iterationEnd) {
-			logger.DebugContext(ctx, "exiting loop due to iteration end", slog.Time("at", at), slog.Time("iterationEnd", iterationEnd), slog.Time("invoiceAt", newItem.invoiceAt))
-			break
-		}
-
-		// 4. we reach the max iterations
-		if periodIdx > maxSafeIter {
-			logger.ErrorContext(ctx, "max iterations reached", slog.Any("iterator", it), slog.String("stack", string(debug.Stack())))
-			break
-		}
-
-		logger.DebugContext(ctx, "iterating", slog.Time("at", at))
-	}
-
-	return false, nil
+	})
 }
 
 type generatedVersionPeriodItem struct {
@@ -297,71 +299,72 @@ type generatedVersionPeriodItem struct {
 }
 
 func (it *PhaseIterator) generateForAlignedItemVersionPeriod(ctx context.Context, logger *slog.Logger, item subscription.SubscriptionItemView, version int, periodIdx int, at time.Time) (generatedVersionPeriodItem, error) {
-	ctx, span := it.tracer.Start(ctx, "billing.worker.subscription.phaseiterator.generateForAlignedItemVersionPeriod", trace.WithAttributes(
+	ctx, span := tracex.Start[generatedVersionPeriodItem](ctx, it.tracer, "billing.worker.subscription.phaseiterator.generateForAlignedItemVersionPeriod", trace.WithAttributes(
 		attribute.Int("periodIdx", periodIdx),
 		attribute.String("periodAt", at.Format(time.RFC3339)),
 	))
-	defer span.End()
 
-	var empty generatedVersionPeriodItem
+	return span.Wrap(ctx, func(ctx context.Context) (generatedVersionPeriodItem, error) {
+		var empty generatedVersionPeriodItem
 
-	// We start when the item activates, then advance until either
-	nonTruncatedPeriod, err := it.sub.Spec.GetAlignedBillingPeriodAt(it.phase.Spec.PhaseKey, at)
-	if err != nil {
-		logger.ErrorContext(ctx, "failed to get aligned billing period", slog.Any("error", err))
-		return empty, err
-	}
+		// We start when the item activates, then advance until either
+		nonTruncatedPeriod, err := it.sub.Spec.GetAlignedBillingPeriodAt(it.phase.Spec.PhaseKey, at)
+		if err != nil {
+			logger.ErrorContext(ctx, "failed to get aligned billing period", slog.Any("error", err))
+			return empty, err
+		}
 
-	// Period otherwise is truncated by activeFrom and activeTo times
-	period := timeutil.ClosedPeriod{
-		From: nonTruncatedPeriod.From,
-		To:   nonTruncatedPeriod.To,
-	}
+		// Period otherwise is truncated by activeFrom and activeTo times
+		period := timeutil.ClosedPeriod{
+			From: nonTruncatedPeriod.From,
+			To:   nonTruncatedPeriod.To,
+		}
 
-	if item.SubscriptionItem.ActiveFrom.After(period.From) {
-		period.From = item.SubscriptionItem.ActiveFrom
-	}
+		if item.SubscriptionItem.ActiveFrom.After(period.From) {
+			period.From = item.SubscriptionItem.ActiveFrom
+		}
 
-	if item.SubscriptionItem.ActiveTo != nil && item.SubscriptionItem.ActiveTo.Before(period.To) {
-		period.To = *item.SubscriptionItem.ActiveTo
-	}
+		if item.SubscriptionItem.ActiveTo != nil && item.SubscriptionItem.ActiveTo.Before(period.To) {
+			period.To = *item.SubscriptionItem.ActiveTo
+		}
 
-	// Let's build the line
-	generatedItem := subscriptionItemWithPeriod{
-		SubscriptionItemView: item,
-		InvoiceAligned:       true,
+		// Let's build the line
+		generatedItem := subscriptionItemWithPeriod{
+			SubscriptionItemView: item,
+			InvoiceAligned:       true,
 
-		Period: billing.Period{
-			Start: period.From,
-			End:   period.To,
-		},
+			Period: billing.Period{
+				Start: period.From,
+				End:   period.To,
+			},
 
-		UniqueID: strings.Join([]string{
-			it.sub.Subscription.ID,
-			it.phase.Spec.PhaseKey,
-			item.Spec.ItemKey,
-			fmt.Sprintf("v[%d]", version),
-			fmt.Sprintf("period[%d]", periodIdx),
-		}, "/"),
+			UniqueID: strings.Join([]string{
+				it.sub.Subscription.ID,
+				it.phase.Spec.PhaseKey,
+				item.Spec.ItemKey,
+				fmt.Sprintf("v[%d]", version),
+				fmt.Sprintf("period[%d]", periodIdx),
+			}, "/"),
 
-		NonTruncatedPeriod: billing.Period{
-			Start: nonTruncatedPeriod.From,
-			End:   nonTruncatedPeriod.To,
-		},
-		PhaseID: it.phase.SubscriptionPhase.ID,
-	}
+			NonTruncatedPeriod: billing.Period{
+				Start: nonTruncatedPeriod.From,
+				End:   nonTruncatedPeriod.To,
+			},
+			PhaseID: it.phase.SubscriptionPhase.ID,
+		}
 
-	invoiceAt, err := it.getInvoiceAt(period, *item.SubscriptionItem.RateCard.AsMeta().Price)
-	if err != nil {
-		return empty, err
-	}
+		invoiceAt, err := it.getInvoiceAt(period, *item.SubscriptionItem.RateCard.AsMeta().Price)
+		if err != nil {
+			return empty, err
+		}
 
-	return generatedVersionPeriodItem{
-		period:    period,
-		invoiceAt: invoiceAt,
-		index:     periodIdx,
-		item:      generatedItem,
-	}, nil
+		return generatedVersionPeriodItem{
+			period:    period,
+			invoiceAt: invoiceAt,
+			index:     periodIdx,
+			item:      generatedItem,
+		}, nil
+	})
 }
 
 func (it *PhaseIterator) generate(iterationEnd time.Time) ([]subscriptionItemWithPeriod, error) {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch adds a helper so that we do not forget to record errors/panics into spans, as that's crucial from sampling point of view.

The current solution uses the `tracex.Start[returnValue](...).Wrap(ctx, func())` format, so that the variadic arguments of Start do not end up after the embedded function.

Current format:
```
func (it *PhaseIterator) Generate(ctx context.Context, iterationEnd time.Time) ([]subscriptionItemWithPeriod, error) {
	ctx, span := tracex.Start[[]subscriptionItemWithPeriod](ctx, it.tracer, "billing.worker.subscription.phaseiterator.Generate", trace.WithAttributes(
		attribute.String("phase_key", it.phase.Spec.PhaseKey),
	))

	return span.Wrap(ctx, func(ctx context.Context) ([]subscriptionItemWithPeriod, error) {
		if it.sub.Subscription.BillablesMustAlign {
			return it.generateAligned(ctx, iterationEnd)
		}

		return it.generate(iterationEnd)
	})
}
```

Other possibilities, that I would not prefer:
```
return tracex.Start(ctx, 
  it.tracer, 
  "billing.worker.subscription.phaseiterator.Generate", 
  func (ctx context.Context) ([]subscriptionItemWithPeriod, error) {
    ...
  }, 
  // If embedded function is too long looks strange
  trace.WithAttributes(
    attribute.String("phase_key", it.phase.Spec.PhaseKey),
  )
}
```

```
return tracex.Start(ctx, 
  it.tracer, 
  "billing.worker.subscription.phaseiterator.Generate", 
  // Too verbose, what if we don't need this? A naked nil is not too self-explanatory
  []trace.StartOptions{
     trace.WithAttributes(
        attribute.String("phase_key", it.phase.Spec.PhaseKey),
     )
  }
  func (ctx context.Context) ([]subscriptionItemWithPeriod, error) {
    ...
  }, 
}
```


```
return tracex.Start(ctx, 
  tracex.Options{
    Tracer: it.tracer,
    Name:  "billing.worker.subscription.phaseiterator.Generate", 
    Options:   []trace.StartOptions{
      trace.WithAttributes(
        attribute.String("phase_key", it.phase.Spec.PhaseKey),
       )
    },
  },   func (ctx context.Context) ([]subscriptionItemWithPeriod, error) {
    ...
  }, 
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced tracing capabilities, providing improved error and panic handling for background processes.

- **Refactor**
  - Streamlined tracing instrumentation for subscription and billing processes, resulting in clearer and more reliable trace data without affecting existing business logic or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->