### PR TITLE
fix(streaming): cache dedupe

### DIFF
--- a/openmeter/streaming/clickhouse/cachemerge_test.go
+++ b/openmeter/streaming/clickhouse/cachemerge_test.go
@@ -385,6 +385,12 @@ func TestDedupeQueryRows(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 4, len(deduplicatedRows))
+	assert.Equal(t, deduplicatedRows, []meterpkg.MeterQueryRow{
+		rows[0],
+		rows[2],
+		rows[3],
+		rows[4],
+	})
 
 	// Test duplicates with inconsistent value
 	rows[0].Value = 20

--- a/openmeter/streaming/clickhouse/cachemerge_test.go
+++ b/openmeter/streaming/clickhouse/cachemerge_test.go
@@ -359,10 +359,20 @@ func TestDedupeQueryRows(t *testing.T) {
 				group2Key: &group2Value,
 			},
 		},
-		// Row with different subject
+		// Row with different time
 		{
 			WindowStart: windowStart2,
 			WindowEnd:   windowEnd2,
+			Value:       10,
+			Subject:     &subject1,
+			GroupBy: map[string]*string{
+				group1Key: &group1Value,
+			},
+		},
+		// Row with different subject
+		{
+			WindowStart: windowStart1,
+			WindowEnd:   windowEnd1,
 			Value:       10,
 			Subject:     &subject2,
 			GroupBy: map[string]*string{
@@ -374,7 +384,7 @@ func TestDedupeQueryRows(t *testing.T) {
 	deduplicatedRows, err := dedupeQueryRows(rows, []string{group1Key, group2Key})
 	require.NoError(t, err)
 
-	assert.Equal(t, 3, len(deduplicatedRows))
+	assert.Equal(t, 4, len(deduplicatedRows))
 
 	// Test duplicates with inconsistent value
 	rows[0].Value = 20


### PR DESCRIPTION
Dedupe key didn't use time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deduplication logic to distinguish rows by both group key and time windows, preventing incorrect merging of data.
- **Tests**
  - Enhanced test coverage to validate deduplication with identical group keys but different time windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->