### PR TITLE
fix: paginate recalculation job

### DIFF
--- a/openmeter/entitlement/balanceworker/recalculate.go
+++ b/openmeter/entitlement/balanceworker/recalculate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/openmeter/watermill/marshaler"
 	"github.com/openmeterio/openmeter/pkg/convert"
+	"github.com/openmeterio/openmeter/pkg/pagination"
 )
 
 const (
@@ -28,6 +29,7 @@ const (
 	DefaultIncludeDeletedDuration = 24 * time.Hour
 
 	defaultLRUCacheSize = 10_000
+	defaultPageSize     = 20_000
 
 	metricNameRecalculationTime               = "balance_worker.entitlement_recalculation_time_ms"
 	metricNameRecalculationJobCalculationTime = "balance_worker.entitlement_recalculation_job_calculation_time_ms"
@@ -121,18 +123,44 @@ func (r *Recalculator) Recalculate(ctx context.Context, ns string) error {
 		return errors.New("namespace is required")
 	}
 
-	affectedEntitlements, err := r.opts.Entitlement.EntitlementRepo.ListEntitlements(
-		ctx,
-		entitlement.ListEntitlementsParams{
-			Namespaces:          []string{ns},
-			IncludeDeleted:      true,
-			IncludeDeletedAfter: time.Now().Add(-DefaultIncludeDeletedDuration),
-		})
-	if err != nil {
-		return err
+	// Note: this is to support namesapces with more than 64k entitlements, as the subqueries
+	// to expand the edges uses IN statements in ent. We should rather fix ent to actually chunk
+	// the subqueries.
+	affectedEntitlements := []entitlement.Entitlement{}
+
+	page := 1
+
+	for {
+
+		affectedEntitlementsPage, err := r.opts.Entitlement.EntitlementRepo.ListEntitlements(
+			ctx,
+			entitlement.ListEntitlementsParams{
+				Namespaces:          []string{ns},
+				IncludeDeleted:      true,
+				IncludeDeletedAfter: time.Now().Add(-DefaultIncludeDeletedDuration),
+				Page: pagination.Page{
+					PageNumber: page,
+					PageSize:   defaultPageSize,
+				},
+			})
+		if err != nil {
+			return err
+		}
+
+		if len(affectedEntitlementsPage.Items) == 0 {
+			break
+		}
+
+		affectedEntitlements = append(affectedEntitlements, affectedEntitlementsPage.Items...)
+
+		if len(affectedEntitlements) >= affectedEntitlementsPage.TotalCount {
+			break
+		}
+
+		page++
 	}
 
-	return r.processEntitlements(ctx, affectedEntitlements.Items)
+	return r.processEntitlements(ctx, affectedEntitlements)
 }
 
 func (r *Recalculator) processEntitlements(ctx context.Context, entitlements []entitlement.Entitlement) error {

--- a/openmeter/entitlement/balanceworker/recalculate.go
+++ b/openmeter/entitlement/balanceworker/recalculate.go
@@ -131,7 +131,6 @@ func (r *Recalculator) Recalculate(ctx context.Context, ns string) error {
 	page := 1
 
 	for {
-
 		affectedEntitlementsPage, err := r.opts.Entitlement.EntitlementRepo.ListEntitlements(
 			ctx,
 			entitlement.ListEntitlementsParams{


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

If a namespace has more than 64k entitlements, the edge expansion fails due to the parameter count being more than the 64k allowed by ent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of namespaces with large numbers of entitlements, ensuring reliable processing for cases exceeding 64,000 entitlements. This update prevents potential issues with large data sets and improves overall stability for users with extensive entitlement lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->