### PR TITLE
fix(subs): fix error formatting on multi errors

### DIFF
--- a/openmeter/subscription/subscriptionspec.go
+++ b/openmeter/subscription/subscriptionspec.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/convert"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/errorsx"
 	"github.com/openmeterio/openmeter/pkg/isodate"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -289,6 +290,7 @@ func (s *SubscriptionSpec) SyncAnnotations() error {
 func (s *SubscriptionSpec) Validate() error {
 	// All consistency checks should happen here
 	var errs []error
+
 	for _, phase := range s.Phases {
 		cadence, err := s.GetPhaseCadence(phase.PhaseKey)
 		if err != nil {
@@ -300,7 +302,7 @@ func (s *SubscriptionSpec) Validate() error {
 			errs = append(errs, fmt.Errorf("phase %s validation failed: %w", phase.PhaseKey, err))
 		}
 	}
-	return models.NewNillableGenericValidationError(errors.Join(errs...))
+	return models.NewNillableGenericValidationError(errorsx.Join(errs...))
 }
 
 type CreateSubscriptionPhasePlanInput struct {
@@ -999,7 +1001,7 @@ type SpecValidationError struct {
 }
 
 func (e *SpecValidationError) Error() string {
-	return e.Msg
+	return fmt.Sprintf("spec validation error on paths [%+v]: %s", e.AffectedKeys, e.Msg)
 }
 
 // AlignmentError is an error that occurs when the spec is not aligned but we expect it to be.

--- a/pkg/errorsx/wrap.go
+++ b/pkg/errorsx/wrap.go
@@ -6,15 +6,12 @@ import (
 	"strings"
 )
 
-// Join joins multiple errors into a single error with nice formatting.
-// It uses errors.Join and then formats the result nicely while preserving error chains.
 func Join(errs ...error) error {
 	joined := errors.Join(errs...)
 	return FormatJoinedError(joined)
 }
 
 // FormatJoinedError formats an already-joined error nicely while preserving error chains.
-// This is useful when you already have a joined error from errors.Join.
 func FormatJoinedError(err error) error {
 	if err == nil {
 		return nil

--- a/pkg/errorsx/wrap.go
+++ b/pkg/errorsx/wrap.go
@@ -1,0 +1,45 @@
+package errorsx
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Join joins multiple errors into a single error with nice formatting.
+// It uses errors.Join and then formats the result nicely while preserving error chains.
+func Join(errs ...error) error {
+	joined := errors.Join(errs...)
+	return FormatJoinedError(joined)
+}
+
+// FormatJoinedError formats an already-joined error nicely while preserving error chains.
+// This is useful when you already have a joined error from errors.Join.
+func FormatJoinedError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// Check if it's a joined error with multiple errors
+	var joinedErr interface{ Unwrap() []error }
+	if !errors.As(err, &joinedErr) {
+		// Single error, just return
+		return err
+	}
+
+	allErrors := joinedErr.Unwrap()
+	if len(allErrors) <= 1 {
+		// Single or no errors, just return
+		return err
+	}
+
+	// Multiple errors: preserve chain for first, format the rest
+	var additionalMsgs []string
+	for i := 1; i < len(allErrors); i++ {
+		additionalMsgs = append(additionalMsgs, allErrors[i].Error())
+	}
+
+	return fmt.Errorf("multiple errors: %w; %s",
+		allErrors[0],
+		strings.Join(additionalMsgs, "; "))
+}

--- a/pkg/errorsx/wrap_test.go
+++ b/pkg/errorsx/wrap_test.go
@@ -1,0 +1,205 @@
+package errorsx
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// Custom error types for testing error chain preservation
+type ValidationError struct {
+	Field string
+	Msg   string
+}
+
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("validation error on field %s: %s", e.Field, e.Msg)
+}
+
+type SomeError struct {
+	Code string
+	Msg  string
+}
+
+func (e SomeError) Error() string {
+	return fmt.Sprintf("some error %s: %s", e.Code, e.Msg)
+}
+
+func TestFormatJoinedError(t *testing.T) {
+	t.Run("basic functionality", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			input    error
+			expected string
+			wantNil  bool
+		}{
+			{
+				name:    "nil error",
+				input:   nil,
+				wantNil: true,
+			},
+			{
+				name:     "single error",
+				input:    fmt.Errorf("single error"),
+				expected: "single error",
+			},
+			{
+				name:     "single custom error",
+				input:    ValidationError{Field: "name", Msg: "required"},
+				expected: "validation error on field name: required",
+			},
+			{
+				name:     "joined error with single error",
+				input:    errors.Join(fmt.Errorf("only error")),
+				expected: "only error",
+			},
+			{
+				name: "joined error with two errors",
+				input: errors.Join(
+					fmt.Errorf("first error"),
+					fmt.Errorf("second error"),
+				),
+				expected: "multiple errors: first error; second error",
+			},
+			{
+				name: "joined error with three errors",
+				input: errors.Join(
+					fmt.Errorf("first error"),
+					fmt.Errorf("second error"),
+					fmt.Errorf("third error"),
+				),
+				expected: "multiple errors: first error; second error; third error",
+			},
+			{
+				name: "joined error with custom error types",
+				input: errors.Join(
+					ValidationError{Field: "email", Msg: "invalid format"},
+					SomeError{Code: "BIZ001", Msg: "user already exists"},
+					fmt.Errorf("system error"),
+				),
+				expected: "multiple errors: validation error on field email: invalid format; some error BIZ001: user already exists; system error",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result := FormatJoinedError(tt.input)
+
+				if tt.wantNil {
+					if result != nil {
+						t.Errorf("FormatJoinedError() = %v, want nil", result)
+					}
+					return
+				}
+
+				if result == nil {
+					t.Fatal("FormatJoinedError() returned nil, expected an error")
+				}
+
+				if result.Error() != tt.expected {
+					t.Errorf("FormatJoinedError() = %q, want %q", result.Error(), tt.expected)
+				}
+			})
+		}
+	})
+
+	t.Run("error chain preservation", func(t *testing.T) {
+		originalErr := ValidationError{Field: "username", Msg: "too short"}
+		secondErr := SomeError{Code: "BIZ002", Msg: "rate limited"}
+		thirdErr := fmt.Errorf("network error")
+
+		joinedErr := errors.Join(originalErr, secondErr, thirdErr)
+		result := FormatJoinedError(joinedErr)
+
+		// Test that we can still find the original error using errors.Is
+		if !errors.Is(result, originalErr) {
+			t.Errorf("errors.Is(result, originalErr) = false, want true")
+		}
+
+		// Test that we can still extract the original error using errors.As
+		var validationErr ValidationError
+		if !errors.As(result, &validationErr) {
+			t.Errorf("errors.As(result, &validationErr) = false, want true")
+		} else {
+			if validationErr.Field != "username" || validationErr.Msg != "too short" {
+				t.Errorf("extracted ValidationError = %+v, want {Field: username, Msg: too short}", validationErr)
+			}
+		}
+
+		// Test that we cannot find the second error (since it's not wrapped)
+		if errors.Is(result, secondErr) {
+			t.Errorf("errors.Is(result, secondErr) = true, want false (second error should not be in chain)")
+		}
+
+		var businessErr SomeError
+		if errors.As(result, &businessErr) {
+			t.Errorf("errors.As(result, &businessErr) = true, want false (second error should not be in chain)")
+		}
+	})
+
+	t.Run("non-joined errors unchanged", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			input error
+		}{
+			{
+				name:  "simple error",
+				input: fmt.Errorf("simple error"),
+			},
+			{
+				name:  "wrapped error",
+				input: fmt.Errorf("wrapped: %w", fmt.Errorf("inner error")),
+			},
+			{
+				name:  "custom error",
+				input: ValidationError{Field: "test", Msg: "invalid"},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result := FormatJoinedError(tt.input)
+
+				// For non-joined errors, the function should return the same error
+				if result != tt.input {
+					t.Errorf("FormatJoinedError() should return the same error for non-joined errors, got different error")
+				}
+
+				if result.Error() != tt.input.Error() {
+					t.Errorf("FormatJoinedError() = %q, want %q", result.Error(), tt.input.Error())
+				}
+			})
+		}
+	})
+
+	t.Run("message format", func(t *testing.T) {
+		err1 := fmt.Errorf("error one")
+		err2 := fmt.Errorf("error two")
+		err3 := fmt.Errorf("error three")
+
+		joinedErr := errors.Join(err1, err2, err3)
+		result := FormatJoinedError(joinedErr)
+
+		resultMsg := result.Error()
+
+		// Check that it starts with "multiple errors:"
+		if !strings.HasPrefix(resultMsg, "multiple errors:") {
+			t.Errorf("result should start with 'multiple errors:', got: %s", resultMsg)
+		}
+
+		// Check that all error messages are present
+		expectedParts := []string{"error one", "error two", "error three"}
+		for _, part := range expectedParts {
+			if !strings.Contains(resultMsg, part) {
+				t.Errorf("result should contain %q, got: %s", part, resultMsg)
+			}
+		}
+
+		// Check the exact format
+		expected := "multiple errors: error one; error two; error three"
+		if resultMsg != expected {
+			t.Errorf("FormatJoinedError() = %q, want %q", resultMsg, expected)
+		}
+	})
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview


Joined errors form `errors.Join()` when wrapped as `fmt.Errorf("%w", err)` only display the contents of the first error in the message, which can be quite misleading when interpreting the errors. `errorsx.Join` solves this by both keeping the errchain  and printing all error messages

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messages for subscription specification validation, now displaying affected keys alongside error details.

- **New Features**
	- Enhanced error aggregation and formatting for validation errors, providing clearer and more informative error outputs.

- **Tests**
	- Added comprehensive tests to ensure correct formatting and behavior of aggregated error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->