### PR TITLE
fix: only support qty=1 for flat fee lines

### DIFF
--- a/test/app/custominvoicing/invocing_test.go
+++ b/test/app/custominvoicing/invocing_test.go
@@ -191,7 +191,7 @@ func (s *CustomInvoicingTestSuite) TestInvoicingFlowHooksEnabled() {
 						Name: "Test item - HUF",
 
 						PerUnitAmount: alpacadecimal.NewFromFloat(200),
-						Quantity:      alpacadecimal.NewFromFloat(3),
+						Quantity:      alpacadecimal.NewFromFloat(1),
 						PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 					}),
 					{
@@ -359,8 +359,8 @@ func (s *CustomInvoicingTestSuite) TestInvoicingFlowPaymentStatusOnly() {
 
 						Name: "Test item - HUF",
 
-						PerUnitAmount: alpacadecimal.NewFromFloat(200),
-						Quantity:      alpacadecimal.NewFromFloat(3),
+						PerUnitAmount: alpacadecimal.NewFromFloat(600),
+						Quantity:      alpacadecimal.NewFromFloat(1),
 						PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 					}),
 				},

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -178,7 +178,7 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 						Name: "Test item - HUF",
 
 						PerUnitAmount: alpacadecimal.NewFromFloat(200),
-						Quantity:      alpacadecimal.NewFromFloat(3),
+						Quantity:      alpacadecimal.NewFromFloat(1),
 						PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 					}),
 					{
@@ -493,7 +493,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 					Name: "Test item2",
 
 					PerUnitAmount: alpacadecimal.NewFromFloat(200),
-					Quantity:      alpacadecimal.NewFromFloat(3),
+					Quantity:      alpacadecimal.NewFromFloat(1),
 					PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 				}),
 			},

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -367,7 +367,7 @@ func (s *BaseSuite) CreateGatheringInvoice(t *testing.T, ctx context.Context, in
 					},
 					FlatFee: &billing.FlatFeeLine{
 						PerUnitAmount: alpacadecimal.NewFromFloat(200),
-						Quantity:      alpacadecimal.NewFromFloat(3),
+						Quantity:      alpacadecimal.NewFromFloat(1),
 						Category:      billing.FlatFeeCategoryRegular,
 						PaymentTerm:   productcatalog.InAdvancePaymentTerm,
 					},


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Given that product catalog drives invoicing (we are not used as standalone invoicing engine) and flat price only supports qty=1 we are no longer allowing flat fee lines with other qty on the invoice's root.

Detailed lines are also represented as flat fee lines, there we allow qty to be anything positive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for invoice line quantities, enforcing stricter rules for valid lines to ensure accuracy in billing.

- **Tests**
	- Updated test cases to reflect new quantity requirements for invoice lines, ensuring alignment with the revised validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->