### PR TITLE
fix(http): order of error encoders

### DIFF
--- a/pkg/framework/transport/httptransport/handler.go
+++ b/pkg/framework/transport/httptransport/handler.go
@@ -48,7 +48,7 @@ func newHandler[Request any, Response any](
 		encodeResponse: responseEncoder,
 	}
 
-	options = append(defaultHandlerOptions, options...)
+	options = append(options, defaultHandlerOptions...)
 
 	h.apply(options)
 


### PR DESCRIPTION
## Overview

Run custom error encoders before the default ones so:
* custom encoders have higher precedance
* custom encoders can be used to override behaviour default encoders
