### PR TITLE
fix(productcatalog): plan add-on validation error fields

### DIFF
--- a/openmeter/productcatalog/planaddon.go
+++ b/openmeter/productcatalog/planaddon.go
@@ -63,22 +63,14 @@ func (c PlanAddon) Validate() error {
 	allowedPlanStatuses := []PlanStatus{PlanStatusDraft, PlanStatusActive, PlanStatusScheduled}
 	if !lo.Contains(allowedPlanStatuses, c.Plan.Status()) {
 		errs = append(errs, models.ErrorWithFieldPrefix(
-			models.NewFieldSelectors(models.NewFieldSelector("plans").
-				WithExpression(models.NewMultiFieldAttrValue(
-					models.NewFieldAttrValue("key", c.Plan.Key),
-					models.NewFieldAttrValue("version", c.Plan.Version),
-				))),
+			models.NewFieldSelectors(models.NewFieldSelector("plan")),
 			ErrPlanAddonIncompatibleStatus,
 		))
 	}
 
 	// Validate add-on
 
-	addonPrefix := models.NewFieldSelectors(models.NewFieldSelector("addons").
-		WithExpression(models.NewMultiFieldAttrValue(
-			models.NewFieldAttrValue("key", c.Addon.Key),
-			models.NewFieldAttrValue("version", c.Addon.Version),
-		)))
+	addonPrefix := models.NewFieldSelectors(models.NewFieldSelector("addon"))
 
 	// Add-on must be active and the effective period of add-on must be open-ended
 	// as we do not support scheduled changes for add-ons.
@@ -91,11 +83,11 @@ func (c PlanAddon) Validate() error {
 	switch c.Addon.InstanceType {
 	case AddonInstanceTypeMultiple:
 		if c.MaxQuantity != nil && *c.MaxQuantity <= 0 {
-			errs = append(errs, models.ErrorWithFieldPrefix(addonPrefix, ErrPlanAddonMaxQuantityMustBeSet))
+			errs = append(errs, ErrPlanAddonMaxQuantityMustBeSet)
 		}
 	case AddonInstanceTypeSingle:
 		if c.MaxQuantity != nil {
-			errs = append(errs, models.ErrorWithFieldPrefix(addonPrefix, ErrPlanAddonMaxQuantityMustNotBeSet))
+			errs = append(errs, ErrPlanAddonMaxQuantityMustNotBeSet)
 		}
 	}
 
@@ -115,7 +107,7 @@ func (c PlanAddon) Validate() error {
 			}
 		}
 	} else {
-		errs = append(errs, models.ErrorWithFieldPrefix(addonPrefix, ErrPlanAddonUnknownPlanPhaseKey))
+		errs = append(errs, ErrPlanAddonUnknownPlanPhaseKey)
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/productcatalog/planaddon_test.go
+++ b/openmeter/productcatalog/planaddon_test.go
@@ -352,56 +352,29 @@ func TestPlanAddon_ValidationErrors(t *testing.T) {
 			expectedIssues: models.ValidationIssues{
 				models.NewValidationIssue(ErrPlanAddonIncompatibleStatus.Code(), ErrPlanAddonIncompatibleStatus.Message()).
 					WithField(
-						models.NewFieldSelector("plans").WithExpression(
-							models.NewMultiFieldAttrValue(
-								models.NewFieldAttrValue("key", "pro"),
-								models.NewFieldAttrValue("version", 2),
-							),
-						),
+						models.NewFieldSelector("plan"),
 						models.NewFieldSelector("status"),
 					).
 					WithSeverity(models.ErrorSeverityWarning),
 				models.NewValidationIssue(ErrPlanAddonIncompatibleStatus.Code(), ErrPlanAddonIncompatibleStatus.Message()).
 					WithField(
-						models.NewFieldSelector("addons").WithExpression(
-							models.NewMultiFieldAttrValue(
-								models.NewFieldAttrValue("key", "storage"),
-								models.NewFieldAttrValue("version", 1),
-							),
-						),
+						models.NewFieldSelector("addon"),
 						models.NewFieldSelector("status"),
 					).
 					WithSeverity(models.ErrorSeverityWarning),
 				models.NewValidationIssue(ErrPlanAddonMaxQuantityMustNotBeSet.Code(), ErrPlanAddonMaxQuantityMustNotBeSet.Message()).
 					WithField(
-						models.NewFieldSelector("addons").WithExpression(
-							models.NewMultiFieldAttrValue(
-								models.NewFieldAttrValue("key", "storage"),
-								models.NewFieldAttrValue("version", 1),
-							),
-						),
 						models.NewFieldSelector("maxQuantity"),
 					).
 					WithSeverity(models.ErrorSeverityWarning),
 				models.NewValidationIssue(ErrPlanAddonCurrencyMismatch.Code(), ErrPlanAddonCurrencyMismatch.Message()).
 					WithField(
-						models.NewFieldSelector("addons").WithExpression(
-							models.NewMultiFieldAttrValue(
-								models.NewFieldAttrValue("key", "storage"),
-								models.NewFieldAttrValue("version", 1),
-							),
-						),
+						models.NewFieldSelector("addon"),
 						models.NewFieldSelector("currency"),
 					).
 					WithSeverity(models.ErrorSeverityWarning),
 				models.NewValidationIssue(ErrPlanAddonUnknownPlanPhaseKey.Code(), ErrPlanAddonUnknownPlanPhaseKey.Message()).
 					WithField(
-						models.NewFieldSelector("addons").WithExpression(
-							models.NewMultiFieldAttrValue(
-								models.NewFieldAttrValue("key", "storage"),
-								models.NewFieldAttrValue("version", 1),
-							),
-						),
 						models.NewFieldSelector("fromPlanPhase"),
 					).
 					WithSeverity(models.ErrorSeverityWarning),
@@ -564,12 +537,7 @@ func TestPlanAddon_ValidationErrors(t *testing.T) {
 			expectedIssues: models.ValidationIssues{
 				models.NewValidationIssue(ErrRateCardPriceTypeMismatch.Code(), ErrRateCardPriceTypeMismatch.Message()).
 					WithField(
-						models.NewFieldSelector("addons").WithExpression(
-							models.NewMultiFieldAttrValue(
-								models.NewFieldAttrValue("key", "storage"),
-								models.NewFieldAttrValue("version", 1),
-							),
-						),
+						models.NewFieldSelector("addon"),
 						models.NewFieldSelector("ratecards").WithExpression(
 							models.NewFieldAttrValue("key", "storage_capacity"),
 						),
@@ -578,12 +546,7 @@ func TestPlanAddon_ValidationErrors(t *testing.T) {
 					WithSeverity(models.ErrorSeverityWarning),
 				models.NewValidationIssue(ErrRateCardOnlyFlatPriceAllowed.Code(), ErrRateCardOnlyFlatPriceAllowed.Message()).
 					WithField(
-						models.NewFieldSelector("addons").WithExpression(
-							models.NewMultiFieldAttrValue(
-								models.NewFieldAttrValue("key", "storage"),
-								models.NewFieldAttrValue("version", 1),
-							),
-						),
+						models.NewFieldSelector("addon"),
 						models.NewFieldSelector("ratecards").WithExpression(
 							models.NewFieldAttrValue("key", "storage_capacity"),
 						),
@@ -592,12 +555,7 @@ func TestPlanAddon_ValidationErrors(t *testing.T) {
 					WithSeverity(models.ErrorSeverityWarning),
 				models.NewValidationIssue(ErrRateCardFeatureKeyMismatch.Code(), ErrRateCardFeatureKeyMismatch.Message()).
 					WithField(
-						models.NewFieldSelector("addons").WithExpression(
-							models.NewMultiFieldAttrValue(
-								models.NewFieldAttrValue("key", "storage"),
-								models.NewFieldAttrValue("version", 1),
-							),
-						),
+						models.NewFieldSelector("addon"),
 						models.NewFieldSelector("ratecards").WithExpression(
 							models.NewFieldAttrValue("key", "storage_capacity"),
 						),
@@ -606,12 +564,7 @@ func TestPlanAddon_ValidationErrors(t *testing.T) {
 					WithSeverity(models.ErrorSeverityWarning),
 				models.NewValidationIssue(ErrRateCardBillingCadenceMismatch.Code(), ErrRateCardBillingCadenceMismatch.Message()).
 					WithField(
-						models.NewFieldSelector("addons").WithExpression(
-							models.NewMultiFieldAttrValue(
-								models.NewFieldAttrValue("key", "storage"),
-								models.NewFieldAttrValue("version", 1),
-							),
-						),
+						models.NewFieldSelector("addon"),
 						models.NewFieldSelector("ratecards").WithExpression(
 							models.NewFieldAttrValue("key", "storage_capacity"),
 						),
@@ -620,12 +573,7 @@ func TestPlanAddon_ValidationErrors(t *testing.T) {
 					WithSeverity(models.ErrorSeverityWarning),
 				models.NewValidationIssue(ErrRateCardEntitlementTemplateTypeMismatch.Code(), ErrRateCardEntitlementTemplateTypeMismatch.Message()).
 					WithField(
-						models.NewFieldSelector("addons").WithExpression(
-							models.NewMultiFieldAttrValue(
-								models.NewFieldAttrValue("key", "storage"),
-								models.NewFieldAttrValue("version", 1),
-							),
-						),
+						models.NewFieldSelector("addon"),
 						models.NewFieldSelector("ratecards").WithExpression(
 							models.NewFieldAttrValue("key", "storage_capacity"),
 						),


### PR DESCRIPTION
## Overview

Fix JSONPath query used in validation errors `field` attribute for plan add-on assingments.
