### PR TITLE
fix: missing validations in product catalog

### DIFF
--- a/openmeter/productcatalog/addon.go
+++ b/openmeter/productcatalog/addon.go
@@ -244,6 +244,10 @@ func ValidateAddonMeta() models.ValidatorFunc[Addon] {
 // which implements models.CustomValidator interface. It checks for invalid and duplicated ratecards.
 func ValidateAddonRateCards() models.ValidatorFunc[Addon] {
 	return func(a Addon) error {
+		if len(a.RateCards) == 0 {
+			return ErrAddonHasNoRateCards
+		}
+
 		return ValidateRateCards()(a.RateCards)
 	}
 }

--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -340,6 +340,15 @@ var ErrAddonInvalidPriceForMultiInstance = models.NewValidationIssue(
 	models.WithWarningSeverity(),
 )
 
+const ErrCodeAddonHasNoRateCards models.ErrorCode = "addon_has_no_rate_cards"
+
+var ErrAddonHasNoRateCards = models.NewValidationIssue(
+	ErrCodeAddonHasNoRateCards,
+	"add-on must have at least one rate card",
+	models.WithFieldString("ratecards"),
+	models.WithWarningSeverity(),
+)
+
 // Generic errors
 
 const ErrCodeResourceKeyEmpty models.ErrorCode = "resource_key_empty"

--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -335,7 +335,7 @@ const ErrCodeAddonInvalidPriceForMultiInstance models.ErrorCode = "addon_invalid
 
 var ErrAddonInvalidPriceForMultiInstance = models.NewValidationIssue(
 	ErrCodeAddonInvalidPriceForMultiInstance,
-	"only free or falt price ratecards are allowed for add-on with multiple instance type",
+	"only free or flat price ratecards are allowed for add-on with multiple instance type",
 	models.WithFieldString("price"),
 	models.WithWarningSeverity(),
 )

--- a/openmeter/productcatalog/planaddon_test.go
+++ b/openmeter/productcatalog/planaddon_test.go
@@ -581,6 +581,13 @@ func TestPlanAddon_ValidationErrors(t *testing.T) {
 						models.NewFieldSelector("type"),
 					).
 					WithSeverity(models.ErrorSeverityWarning),
+				models.NewValidationIssue(ErrRateCardBillingCadenceUnaligned.Code(), ErrRateCardBillingCadenceUnaligned.Message()).
+					WithField(
+						models.NewFieldSelector("addon"),
+						models.NewFieldSelector("ratecards").WithExpression(models.WildCard),
+						models.NewFieldSelector("billingCadence"),
+					).
+					WithSeverity(models.ErrorSeverityWarning),
 			},
 		},
 	}


### PR DESCRIPTION
## Overview

* return validation error if add-on has no rate cards
* return validation error if ratecards in plan add-on assignment have incompatible billing cadence


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in an error message related to add-on pricing.

- **New Features**
  - Added validation to ensure that every add-on includes at least one rate card, providing a clear warning if missing.

- **Refactor**
  - Improved validation logic for plan add-ons to separately check billing cadence alignment and rate card compatibility, enhancing modularity and clarity.

- **Tests**
  - Enhanced test cases to cover new validation scenarios and updated expected validation issues for better accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->