### PR TITLE
refactor: balance worker high watermark cache

### DIFF
--- a/openmeter/entitlement/balanceworker/cache/cache.go
+++ b/openmeter/entitlement/balanceworker/cache/cache.go
@@ -1,0 +1,24 @@
+package cache
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	defaultHighWatermarkCacheTTL = 24 * time.Hour
+)
+
+type HighWatermarkCacheEntry struct {
+	HighWatermark time.Time
+	IsDeleted     bool
+}
+
+type NamespacedKey interface {
+	GetNamespacedKey() string
+}
+
+type Cache interface {
+	SetHighWatermark(ctx context.Context, key NamespacedKey, highWatermark HighWatermarkCacheEntry) error
+	GetHighWatermark(ctx context.Context, key NamespacedKey) (HighWatermarkCacheEntry, error)
+}

--- a/openmeter/entitlement/balanceworker/cache/inprocess.go
+++ b/openmeter/entitlement/balanceworker/cache/inprocess.go
@@ -1,0 +1,70 @@
+package cache
+
+import (
+	"context"
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+)
+
+type inProcessCache struct {
+	highWatermarkCacheMutex sync.RWMutex
+	highWatermarkCache      *lru.Cache[string, HighWatermarkCacheEntry]
+}
+
+func NewInProcessCache(size int) (Cache, error) {
+	hwCache, err := lru.New[string, HighWatermarkCacheEntry](size)
+	if err != nil {
+		return nil, err
+	}
+
+	return &inProcessCache{
+		highWatermarkCache: hwCache,
+	}, nil
+}
+
+func (c *inProcessCache) SetHighWatermark(ctx context.Context, key NamespacedKey, highWatermark HighWatermarkCacheEntry) error {
+	// We need to lock the cache as it does not support CompareAndSwap schemantics
+	c.highWatermarkCacheMutex.Lock()
+	defer c.highWatermarkCacheMutex.Unlock()
+
+	keyStr := key.GetNamespacedKey()
+
+	prevHighWatermark, prevFound, _ := c.highWatermarkCache.PeekOrAdd(keyStr, highWatermark)
+
+	// We are done, the new item has been added to the cache
+	if !prevFound {
+		return nil
+	}
+
+	if prevHighWatermark.IsDeleted {
+		return nil
+	}
+
+	// New cache entry is deleted -> let's update the cache
+	if highWatermark.IsDeleted {
+		_ = c.highWatermarkCache.Add(keyStr, highWatermark)
+		return nil
+	}
+
+	// We are not decreasing the high watermark, if the cache has a newer entry, we are done
+	if prevHighWatermark.HighWatermark.After(highWatermark.HighWatermark) {
+		return nil
+	}
+
+	_ = c.highWatermarkCache.Add(keyStr, highWatermark)
+
+	return nil
+}
+
+func (c *inProcessCache) GetHighWatermark(ctx context.Context, key NamespacedKey) (HighWatermarkCacheEntry, error) {
+	c.highWatermarkCacheMutex.RLock()
+	defer c.highWatermarkCacheMutex.RUnlock()
+
+	highWatermark, ok := c.highWatermarkCache.Get(key.GetNamespacedKey())
+	if !ok {
+		return HighWatermarkCacheEntry{}, nil
+	}
+
+	return highWatermark, nil
+}

--- a/openmeter/entitlement/balanceworker/cache/redis.go
+++ b/openmeter/entitlement/balanceworker/cache/redis.go
@@ -1,0 +1,106 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+type redisCache struct {
+	redisClient *redis.Client
+}
+
+func NewRedisCache(redisClient *redis.Client) (Cache, error) {
+	return &redisCache{
+		redisClient: redisClient,
+	}, nil
+}
+
+func (c *redisCache) SetHighWatermark(ctx context.Context, key NamespacedKey, highWatermark HighWatermarkCacheEntry) error {
+	keyStr := key.GetNamespacedKey()
+	deletedKeyStr := fmt.Sprintf("%s:del", keyStr)
+
+	// let's check if the key is already deleted
+	_, err := c.redisClient.Get(ctx, deletedKeyStr).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return err
+	}
+
+	if err == nil {
+		// The deleted key exists, so we don't want to set a high watermark.
+		return nil
+	}
+
+	if highWatermark.IsDeleted {
+		// let's set the deleted key
+		return c.redisClient.SetArgs(ctx, deletedKeyStr, "", redis.SetArgs{
+			TTL: defaultHighWatermarkCacheTTL,
+		}).Err()
+	}
+
+	highWatermarkTS := highWatermark.HighWatermark.UnixNano()
+	// TODO: exponential backoff
+	for {
+		// We need to set the high watermark key, let's set up optimistic locking
+		err = c.redisClient.Watch(ctx, func(tx *redis.Tx) error {
+			existingValue, err := tx.Get(ctx, keyStr).Result()
+			if err != nil {
+				if !errors.Is(err, redis.Nil) {
+					return err
+				}
+			}
+
+			existingValueInt, err := strconv.ParseInt(existingValue, 10, 64)
+			if err != nil {
+				// High watermark key failed to parse => treat as non-existing
+				existingValueInt = 0
+			}
+
+			if existingValueInt >= highWatermarkTS {
+				return nil
+			}
+
+			return tx.SetArgs(ctx, keyStr, highWatermarkTS, redis.SetArgs{
+				TTL: defaultHighWatermarkCacheTTL,
+			}).Err()
+		}, keyStr)
+		if err == nil {
+			break
+		}
+
+		// The error is not due to high watermark key was modified by another process
+		if !errors.Is(err, redis.TxFailedErr) {
+			return err
+		}
+
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	return nil
+}
+
+func (c *redisCache) GetHighWatermark(ctx context.Context, key NamespacedKey) (HighWatermarkCacheEntry, error) {
+	keyStr := key.GetNamespacedKey()
+	deletedKeyStr := fmt.Sprintf("%s:del", keyStr)
+
+	// let's check if the key is already deleted
+	results, err := c.redisClient.MGet(ctx, keyStr, deletedKeyStr).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return HighWatermarkCacheEntry{}, err
+	}
+
+	if errors.Is(err, redis.Nil) || len(results) == 0 {
+		return HighWatermarkCacheEntry{}, nil
+	}
+
+	highWatermark := HighWatermarkCacheEntry{
+		HighWatermark: time.Unix(0, results[0].(int64)).In(time.UTC), // In(time.UTC) forces normalization of the time
+		IsDeleted:     results[1] != nil,
+	}
+
+	return highWatermark, nil
+}

--- a/openmeter/entitlement/balanceworker/entitlementhandler.go
+++ b/openmeter/entitlement/balanceworker/entitlementhandler.go
@@ -77,7 +77,7 @@ const (
 	skipEventAction   highWatermarkCacheAction = "skipEvent"
 )
 
-func (w *Worker) checkHighWatermarkCache(ctx context.Context, entitlementID NamespacedID, opts handleEntitlementEventOptions) highWatermarkCacheAction {
+func (w *Worker) checkHighWatermarkCache(ctx context.Context, entitlementID EntitlementID, opts handleEntitlementEventOptions) highWatermarkCacheAction {
 	// Always emit reset events
 	// TODO[later]: Only calculate if there's need for the explicit reset event
 	if lo.FromPtr(opts.sourceOperation) == snapshot.ValueOperationReset {

--- a/openmeter/entitlement/balanceworker/ingesthandler.go
+++ b/openmeter/entitlement/balanceworker/ingesthandler.go
@@ -29,7 +29,7 @@ func (w *Worker) handleBatchedIngestEvent(ctx context.Context, event ingestevent
 	for _, entitlement := range affectedEntitlements {
 		event, err := w.handleEntitlementEvent(
 			ctx,
-			NamespacedID{Namespace: entitlement.Namespace, ID: entitlement.EntitlementID},
+			EntitlementID{Namespace: entitlement.Namespace, ID: entitlement.EntitlementID},
 			WithSource(metadata.ComposeResourcePath(entitlement.Namespace, metadata.EntityEvent)),
 			WithEventAt(event.StoredAt),
 			WithRawIngestedEvents(event.RawEvents),
@@ -52,7 +52,7 @@ func (w *Worker) handleBatchedIngestEvent(ctx context.Context, event ingestevent
 	return handlingError
 }
 
-func (w *Worker) GetEntitlementsAffectedByMeterSubject(ctx context.Context, namespace string, meterSlugs []string, subject string) ([]NamespacedID, error) {
+func (w *Worker) GetEntitlementsAffectedByMeterSubject(ctx context.Context, namespace string, meterSlugs []string, subject string) ([]EntitlementID, error) {
 	featuresByMeter, err := w.entitlement.Feature.ListFeatures(ctx, feature.ListFeaturesParams{
 		Namespace:  namespace,
 		MeterSlugs: meterSlugs,
@@ -75,9 +75,9 @@ func (w *Worker) GetEntitlementsAffectedByMeterSubject(ctx context.Context, name
 		return nil, err
 	}
 
-	entitlementIDs := make([]NamespacedID, 0, len(entitlements.Items))
+	entitlementIDs := make([]EntitlementID, 0, len(entitlements.Items))
 	for _, entitlement := range entitlements.Items {
-		entitlementIDs = append(entitlementIDs, NamespacedID{
+		entitlementIDs = append(entitlementIDs, EntitlementID{
 			ID:        entitlement.ID,
 			Namespace: entitlement.Namespace,
 		})


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch adds support for high-watermark cache to be stored in Redis and makes sure that all recalculation/worker jobs are relying on the high-watermark cache.

This helps to reduce the number of recalculations during the recalculation job runs, also makes sure that if we retry the job with the same asof timestamp we are only processing the not yet processed entries.
