### PR TITLE
fix: decrease hash size by removing padding

### DIFF
--- a/openmeter/dedupe/redisdedupe/keyhash.go
+++ b/openmeter/dedupe/redisdedupe/keyhash.go
@@ -32,6 +32,6 @@ import (
 
 func GetKeyHash(itemKey string) string {
 	hashBytes := xxh3.HashString128(itemKey).Bytes()
-	b64 := base64.StdEncoding.EncodeToString(hashBytes[:])
+	b64 := base64.RawURLEncoding.EncodeToString(hashBytes[:])
 	return b64
 }


### PR DESCRIPTION
## Overview

We are not adding the mandatory == padding to the hash keys, thus we are down to 22 bytes from 24 bytes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the encoding of hash outputs to use a URL-safe base64 format without padding, ensuring compatibility with URL usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->