### PR TITLE
fix(streaming): cache materialize without group by

### DIFF
--- a/openmeter/streaming/clickhouse/cachematerialize.go
+++ b/openmeter/streaming/clickhouse/cachematerialize.go
@@ -18,7 +18,7 @@ func (c *Connector) materializeCacheRows(from time.Time, to time.Time, windowSiz
 	// Collect group by fields
 	groupByFields := []string{}
 
-	if len(rows) > 0 && rows[0].GroupBy != nil {
+	if len(rows) > 0 {
 		for k := range rows[0].GroupBy {
 			if !lo.Contains(groupByFields, k) {
 				groupByFields = append(groupByFields, k)
@@ -37,7 +37,7 @@ func (c *Connector) materializeCacheRows(from time.Time, to time.Time, windowSiz
 			}
 		}
 
-		if row.GroupBy != nil {
+		if len(row.GroupBy) > 0 {
 			groupKey := createGroupKeyFromRow(row, groupByFields)
 			if _, ok := groupByMap[groupKey]; !ok {
 				// Initialize
@@ -83,6 +83,7 @@ func (c *Connector) materializeCacheRows(from time.Time, to time.Time, windowSiz
 					WindowEnd:   windowEnd,
 					Subject:     subject,
 					Value:       cacheNoValue,
+					GroupBy:     map[string]*string{},
 				}
 
 				key := createKeyFromRow(materializedRow, &windowSize, groupByFields)

--- a/openmeter/streaming/clickhouse/cachematerialize_test.go
+++ b/openmeter/streaming/clickhouse/cachematerialize_test.go
@@ -33,7 +33,61 @@ func TestMaterializeCacheRows(t *testing.T) {
 		want       []meterpkg.MeterQueryRow
 	}{
 		{
-			name:       "no gaps does not materialize",
+			name:       "no gaps do not materialize",
+			from:       windowStart1,
+			to:         windowEnd3,
+			windowSize: meterpkg.WindowSizeHour,
+			rows: []meterpkg.MeterQueryRow{
+				{
+					WindowStart: windowStart1,
+					WindowEnd:   windowEnd1,
+					Value:       10,
+					GroupBy:     map[string]*string{},
+				},
+				{
+					WindowStart: windowStart2,
+					WindowEnd:   windowEnd2,
+					Value:       20,
+					GroupBy:     map[string]*string{},
+				},
+				{
+					WindowStart: windowStart3,
+					WindowEnd:   windowEnd3,
+					Value:       30,
+					GroupBy:     map[string]*string{},
+				},
+			},
+			want: []meterpkg.MeterQueryRow{}, // No gaps, so no materialized rows
+		},
+		{
+			name:       "no gaps do not materialize with empty values",
+			from:       windowStart1,
+			to:         windowEnd3,
+			windowSize: meterpkg.WindowSizeHour,
+			rows: []meterpkg.MeterQueryRow{
+				{
+					WindowStart: windowStart1,
+					WindowEnd:   windowEnd1,
+					Value:       10,
+					GroupBy:     map[string]*string{},
+				},
+				{
+					WindowStart: windowStart2,
+					WindowEnd:   windowEnd2,
+					Value:       math.NaN(),
+					GroupBy:     map[string]*string{},
+				},
+				{
+					WindowStart: windowStart3,
+					WindowEnd:   windowEnd3,
+					Value:       math.NaN(),
+					GroupBy:     map[string]*string{},
+				},
+			},
+			want: []meterpkg.MeterQueryRow{}, // No gaps, so no materialized rows
+		},
+		{
+			name:       "no gaps do not materialize with subject",
 			from:       windowStart1,
 			to:         windowEnd3,
 			windowSize: meterpkg.WindowSizeHour,
@@ -43,18 +97,57 @@ func TestMaterializeCacheRows(t *testing.T) {
 					WindowEnd:   windowEnd1,
 					Value:       10,
 					Subject:     &subject1,
+					GroupBy:     map[string]*string{},
 				},
 				{
 					WindowStart: windowStart2,
 					WindowEnd:   windowEnd2,
 					Value:       20,
 					Subject:     &subject1,
+					GroupBy:     map[string]*string{},
 				},
 				{
 					WindowStart: windowStart3,
 					WindowEnd:   windowEnd3,
 					Value:       30,
 					Subject:     &subject1,
+					GroupBy:     map[string]*string{},
+				},
+			},
+			want: []meterpkg.MeterQueryRow{}, // No gaps, so no materialized rows
+		},
+		{
+			name:       "no gaps do not materialize with group by",
+			from:       windowStart1,
+			to:         windowEnd3,
+			windowSize: meterpkg.WindowSizeHour,
+			rows: []meterpkg.MeterQueryRow{
+				{
+					WindowStart: windowStart1,
+					WindowEnd:   windowEnd1,
+					Value:       10,
+					Subject:     &subject1,
+					GroupBy: map[string]*string{
+						"group1": &group1Value,
+					},
+				},
+				{
+					WindowStart: windowStart2,
+					WindowEnd:   windowEnd2,
+					Value:       20,
+					Subject:     &subject1,
+					GroupBy: map[string]*string{
+						"group1": &group1Value,
+					},
+				},
+				{
+					WindowStart: windowStart3,
+					WindowEnd:   windowEnd3,
+					Value:       30,
+					Subject:     &subject1,
+					GroupBy: map[string]*string{
+						"group1": &group1Value,
+					},
 				},
 			},
 			want: []meterpkg.MeterQueryRow{}, // No gaps, so no materialized rows
@@ -69,11 +162,13 @@ func TestMaterializeCacheRows(t *testing.T) {
 					WindowStart: windowStart2,
 					WindowEnd:   windowEnd2,
 					Value:       10,
+					GroupBy:     map[string]*string{},
 				},
 				{
 					WindowStart: windowStart3,
 					WindowEnd:   windowEnd3,
 					Value:       30,
+					GroupBy:     map[string]*string{},
 				},
 			},
 			want: []meterpkg.MeterQueryRow{
@@ -81,6 +176,7 @@ func TestMaterializeCacheRows(t *testing.T) {
 					WindowStart: windowStart1,
 					WindowEnd:   windowEnd1,
 					Value:       math.NaN(),
+					GroupBy:     map[string]*string{},
 				},
 			},
 		},
@@ -94,11 +190,13 @@ func TestMaterializeCacheRows(t *testing.T) {
 					WindowStart: windowStart1,
 					WindowEnd:   windowEnd1,
 					Value:       10,
+					GroupBy:     map[string]*string{},
 				},
 				{
 					WindowStart: windowStart3,
 					WindowEnd:   windowEnd3,
 					Value:       30,
+					GroupBy:     map[string]*string{},
 				},
 			},
 			want: []meterpkg.MeterQueryRow{
@@ -106,6 +204,7 @@ func TestMaterializeCacheRows(t *testing.T) {
 					WindowStart: windowStart2,
 					WindowEnd:   windowEnd2,
 					Value:       math.NaN(),
+					GroupBy:     map[string]*string{},
 				},
 			},
 		},
@@ -119,11 +218,13 @@ func TestMaterializeCacheRows(t *testing.T) {
 					WindowStart: windowStart1,
 					WindowEnd:   windowEnd1,
 					Value:       10,
+					GroupBy:     map[string]*string{},
 				},
 				{
 					WindowStart: windowStart2,
 					WindowEnd:   windowEnd2,
 					Value:       30,
+					GroupBy:     map[string]*string{},
 				},
 			},
 			want: []meterpkg.MeterQueryRow{
@@ -131,6 +232,7 @@ func TestMaterializeCacheRows(t *testing.T) {
 					WindowStart: windowStart3,
 					WindowEnd:   windowEnd3,
 					Value:       math.NaN(),
+					GroupBy:     map[string]*string{},
 				},
 			},
 		},
@@ -145,12 +247,14 @@ func TestMaterializeCacheRows(t *testing.T) {
 					WindowEnd:   windowEnd1,
 					Value:       10,
 					Subject:     &subject1,
+					GroupBy:     map[string]*string{},
 				},
 				{
 					WindowStart: windowStart3,
 					WindowEnd:   windowEnd3,
 					Value:       30,
 					Subject:     &subject1,
+					GroupBy:     map[string]*string{},
 				},
 			},
 			want: []meterpkg.MeterQueryRow{
@@ -159,6 +263,7 @@ func TestMaterializeCacheRows(t *testing.T) {
 					WindowEnd:   windowEnd2,
 					Value:       math.NaN(),
 					Subject:     &subject1,
+					GroupBy:     map[string]*string{},
 				},
 			},
 		},
@@ -173,12 +278,14 @@ func TestMaterializeCacheRows(t *testing.T) {
 					WindowEnd:   windowEnd1,
 					Value:       10,
 					Subject:     &subject1,
+					GroupBy:     map[string]*string{},
 				},
 				{
 					WindowStart: windowStart3,
 					WindowEnd:   windowEnd3,
 					Value:       30,
 					Subject:     &subject2,
+					GroupBy:     map[string]*string{},
 				},
 			},
 			want: []meterpkg.MeterQueryRow{
@@ -187,24 +294,28 @@ func TestMaterializeCacheRows(t *testing.T) {
 					WindowEnd:   windowEnd1,
 					Value:       math.NaN(),
 					Subject:     &subject2,
+					GroupBy:     map[string]*string{},
 				},
 				{
 					WindowStart: windowStart2,
 					WindowEnd:   windowEnd2,
 					Value:       math.NaN(),
 					Subject:     &subject1,
+					GroupBy:     map[string]*string{},
 				},
 				{
 					WindowStart: windowStart2,
 					WindowEnd:   windowEnd2,
 					Value:       math.NaN(),
 					Subject:     &subject2,
+					GroupBy:     map[string]*string{},
 				},
 				{
 					WindowStart: windowStart3,
 					WindowEnd:   windowEnd3,
 					Value:       math.NaN(),
 					Subject:     &subject1,
+					GroupBy:     map[string]*string{},
 				},
 			},
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of group-by fields to ensure consistency and prevent potential issues when no group-by data is present.
- **Tests**
	- Expanded and updated test cases to cover more scenarios, including cases with empty values, subjects, and group-by fields, ensuring more robust validation of materialized rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->