### PR TITLE
fix: only return customer address if fields are set

### DIFF
--- a/openmeter/billing/httpdriver/invoice.go
+++ b/openmeter/billing/httpdriver/invoice.go
@@ -647,7 +647,7 @@ func mapInvoiceCustomerToAPI(c billing.InvoiceCustomer) api.BillingParty {
 		Name: lo.EmptyableToPtr(c.Name),
 	}
 
-	if a != nil {
+	if a != nil && !lo.IsEmpty(*a) {
 		out.Addresses = lo.ToPtr([]api.Address{
 			{
 				Country:     (*string)(a.Country),


### PR DESCRIPTION
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty customer addresses to ensure they are omitted from invoice data when not provided.

- **Tests**
  - Enhanced test coverage to verify that empty customer addresses are not included in serialized invoice output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->