### PR TITLE
fix: ingested event key assignment

### DIFF
--- a/openmeter/ingest/kafkaingest/serializer/json.go
+++ b/openmeter/ingest/kafkaingest/serializer/json.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 
 	"github.com/cloudevents/sdk-go/v2/event"
+
+	"github.com/openmeterio/openmeter/openmeter/dedupe"
 )
 
 type JSONSerializer struct{}
@@ -12,8 +14,14 @@ func NewJSONSerializer() JSONSerializer {
 	return JSONSerializer{}
 }
 
-func (s JSONSerializer) SerializeKey(topic string, ev event.Event) ([]byte, error) {
-	return []byte(ev.Subject()), nil
+func (s JSONSerializer) SerializeKey(topic string, namespace string, ev event.Event) ([]byte, error) {
+	dedupeItem := dedupe.Item{
+		Namespace: namespace,
+		ID:        ev.ID(),
+		Source:    ev.Source(),
+	}
+
+	return []byte(dedupeItem.Key()), nil
 }
 
 func (s JSONSerializer) SerializeValue(topic string, ev event.Event) ([]byte, error) {

--- a/openmeter/ingest/kafkaingest/serializer/serializer.go
+++ b/openmeter/ingest/kafkaingest/serializer/serializer.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Serializer interface {
-	SerializeKey(topic string, ev event.Event) ([]byte, error)
+	SerializeKey(topic string, namespace string, ev event.Event) ([]byte, error)
 	SerializeValue(topic string, ev event.Event) ([]byte, error)
 	GetFormat() string
 	GetKeySchemaId() int

--- a/openmeter/ingest/kafkaingest/serializer/serializer_test.go
+++ b/openmeter/ingest/kafkaingest/serializer/serializer_test.go
@@ -204,3 +204,18 @@ func TestFromKafkaPayloadToCloudEvents(t *testing.T) {
 		})
 	}
 }
+
+func TestSerializeKey(t *testing.T) {
+	serializer := NewJSONSerializer()
+
+	ev := event.New()
+	ev.SetID("test-id")
+	ev.SetSource("test-source")
+	ev.SetType("test-type")
+	ev.SetSubject("test-subject")
+	ev.SetTime(time.Now())
+
+	key, err := serializer.SerializeKey("test-topic", "test-namespace", ev)
+	assert.Nil(t, err)
+	assert.Equal(t, "test-namespace-test-source-test-id", string(key))
+}


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

We have a race condition in dedupe as different partitions get items with the same dedupe keys, thus we are creating double records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved message key serialization to enhance deduplication and prevent race conditions during data ingestion by including namespace context.
- **Tests**
	- Added new tests to verify correct serialization of message keys with namespace support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->