### PR TITLE
feat(db): add cascading for subscriptions

### DIFF
--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -449,7 +449,7 @@ var (
 				Symbol:     "balance_snapshots_entitlements_balance_snapshot",
 				Columns:    []*schema.Column{BalanceSnapshotsColumns[10]},
 				RefColumns: []*schema.Column{EntitlementsColumns[0]},
-				OnDelete:   schema.NoAction,
+				OnDelete:   schema.Cascade,
 			},
 		},
 		Indexes: []*schema.Index{
@@ -1454,7 +1454,7 @@ var (
 				Symbol:     "grants_entitlements_grant",
 				Columns:    []*schema.Column{GrantsColumns[16]},
 				RefColumns: []*schema.Column{EntitlementsColumns[0]},
-				OnDelete:   schema.NoAction,
+				OnDelete:   schema.Cascade,
 			},
 		},
 		Indexes: []*schema.Index{
@@ -2167,7 +2167,7 @@ var (
 				Symbol:     "subscription_items_subscription_phases_items",
 				Columns:    []*schema.Column{SubscriptionItemsColumns[22]},
 				RefColumns: []*schema.Column{SubscriptionPhasesColumns[0]},
-				OnDelete:   schema.NoAction,
+				OnDelete:   schema.Cascade,
 			},
 		},
 		Indexes: []*schema.Index{
@@ -2218,7 +2218,7 @@ var (
 				Symbol:     "subscription_phases_subscriptions_phases",
 				Columns:    []*schema.Column{SubscriptionPhasesColumns[11]},
 				RefColumns: []*schema.Column{SubscriptionsColumns[0]},
-				OnDelete:   schema.NoAction,
+				OnDelete:   schema.Cascade,
 			},
 		},
 		Indexes: []*schema.Index{
@@ -2270,7 +2270,7 @@ var (
 				Symbol:     "usage_resets_entitlements_usage_reset",
 				Columns:    []*schema.Column{UsageResetsColumns[7]},
 				RefColumns: []*schema.Column{EntitlementsColumns[0]},
-				OnDelete:   schema.NoAction,
+				OnDelete:   schema.Cascade,
 			},
 		},
 		Indexes: []*schema.Index{

--- a/openmeter/ent/schema/entitlement.go
+++ b/openmeter/ent/schema/entitlement.go
@@ -5,6 +5,7 @@ import (
 
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
+	"entgo.io/ent/dialect/entsql"
 	"entgo.io/ent/schema/edge"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
@@ -82,9 +83,15 @@ func (Entitlement) Indexes() []ent.Index {
 
 func (Entitlement) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.To("usage_reset", UsageReset.Type),
-		edge.To("grant", Grant.Type),
-		edge.To("balance_snapshot", BalanceSnapshot.Type),
+		edge.To("usage_reset", UsageReset.Type).Annotations(entsql.Annotation{
+			OnDelete: entsql.Cascade,
+		}),
+		edge.To("grant", Grant.Type).Annotations(entsql.Annotation{
+			OnDelete: entsql.Cascade,
+		}),
+		edge.To("balance_snapshot", BalanceSnapshot.Type).Annotations(entsql.Annotation{
+			OnDelete: entsql.Cascade,
+		}),
 		edge.To("subscription_item", SubscriptionItem.Type),
 		edge.From("feature", Feature.Type).
 			Ref("entitlement").

--- a/openmeter/ent/schema/subscription.go
+++ b/openmeter/ent/schema/subscription.go
@@ -51,7 +51,9 @@ func (Subscription) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("plan", Plan.Type).Field("plan_id").Ref("subscriptions").Unique(),
 		edge.From("customer", Customer.Type).Field("customer_id").Ref("subscription").Immutable().Unique().Required(),
-		edge.To("phases", SubscriptionPhase.Type),
+		edge.To("phases", SubscriptionPhase.Type).Annotations(entsql.Annotation{
+			OnDelete: entsql.Cascade,
+		}),
 		edge.To("billing_lines", BillingInvoiceLine.Type),
 		edge.To("addons", SubscriptionAddon.Type).
 			Annotations(entsql.Annotation{
@@ -95,7 +97,9 @@ func (SubscriptionPhase) Indexes() []ent.Index {
 func (SubscriptionPhase) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("subscription", Subscription.Type).Field("subscription_id").Ref("phases").Unique().Immutable().Required(),
-		edge.To("items", SubscriptionItem.Type),
+		edge.To("items", SubscriptionItem.Type).Annotations(entsql.Annotation{
+			OnDelete: entsql.Cascade,
+		}),
 		edge.To("billing_lines", BillingInvoiceLine.Type),
 	}
 }
@@ -188,7 +192,9 @@ func (SubscriptionItem) Indexes() []ent.Index {
 func (SubscriptionItem) Edges() []ent.Edge {
 	return []ent.Edge{
 		edge.From("phase", SubscriptionPhase.Type).Field("phase_id").Ref("items").Unique().Immutable().Required(),
-		edge.From("entitlement", Entitlement.Type).Field("entitlement_id").Ref("subscription_item").Unique(),
+		edge.From("entitlement", Entitlement.Type).Field("entitlement_id").Ref("subscription_item").Unique().Annotations(entsql.Annotation{
+			OnDelete: entsql.Cascade,
+		}),
 		edge.To("billing_lines", BillingInvoiceLine.Type),
 	}
 }

--- a/tools/migrate/migrations/20250605102416_subscription-cascade.down.sql
+++ b/tools/migrate/migrations/20250605102416_subscription-cascade.down.sql
@@ -1,0 +1,10 @@
+-- reverse: modify "usage_resets" table
+ALTER TABLE "usage_resets" DROP CONSTRAINT "usage_resets_entitlements_usage_reset", ADD CONSTRAINT "usage_resets_entitlements_usage_reset" FOREIGN KEY ("entitlement_id") REFERENCES "entitlements" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+-- reverse: modify "subscription_items" table
+ALTER TABLE "subscription_items" DROP CONSTRAINT "subscription_items_subscription_phases_items", ADD CONSTRAINT "subscription_items_subscription_phases_items" FOREIGN KEY ("phase_id") REFERENCES "subscription_phases" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+-- reverse: modify "subscription_phases" table
+ALTER TABLE "subscription_phases" DROP CONSTRAINT "subscription_phases_subscriptions_phases", ADD CONSTRAINT "subscription_phases_subscriptions_phases" FOREIGN KEY ("subscription_id") REFERENCES "subscriptions" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+-- reverse: modify "grants" table
+ALTER TABLE "grants" DROP CONSTRAINT "grants_entitlements_grant", ADD CONSTRAINT "grants_entitlements_grant" FOREIGN KEY ("owner_id") REFERENCES "entitlements" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;
+-- reverse: modify "balance_snapshots" table
+ALTER TABLE "balance_snapshots" DROP CONSTRAINT "balance_snapshots_entitlements_balance_snapshot", ADD CONSTRAINT "balance_snapshots_entitlements_balance_snapshot" FOREIGN KEY ("owner_id") REFERENCES "entitlements" ("id") ON UPDATE NO ACTION ON DELETE NO ACTION;

--- a/tools/migrate/migrations/20250605102416_subscription-cascade.up.sql
+++ b/tools/migrate/migrations/20250605102416_subscription-cascade.up.sql
@@ -1,0 +1,27 @@
+-- modify "balance_snapshots" table
+ALTER TABLE "balance_snapshots" DROP CONSTRAINT "balance_snapshots_entitlements_balance_snapshot", ADD CONSTRAINT "balance_snapshots_entitlements_balance_snapshot" FOREIGN KEY ("owner_id") REFERENCES "entitlements" ("id") ON UPDATE NO ACTION ON DELETE CASCADE;
+-- modify "grants" table
+ALTER TABLE "grants" DROP CONSTRAINT "grants_entitlements_grant", ADD CONSTRAINT "grants_entitlements_grant" FOREIGN KEY ("owner_id") REFERENCES "entitlements" ("id") ON UPDATE NO ACTION ON DELETE CASCADE;
+-- modify "subscription_phases" table
+ALTER TABLE "subscription_phases" DROP CONSTRAINT "subscription_phases_subscriptions_phases", ADD CONSTRAINT "subscription_phases_subscriptions_phases" FOREIGN KEY ("subscription_id") REFERENCES "subscriptions" ("id") ON UPDATE NO ACTION ON DELETE CASCADE;
+-- modify "subscription_items" table
+ALTER TABLE "subscription_items" DROP CONSTRAINT "subscription_items_subscription_phases_items", ADD CONSTRAINT "subscription_items_subscription_phases_items" FOREIGN KEY ("phase_id") REFERENCES "subscription_phases" ("id") ON UPDATE NO ACTION ON DELETE CASCADE;
+-- modify "usage_resets" table
+ALTER TABLE "usage_resets" DROP CONSTRAINT "usage_resets_entitlements_usage_reset", ADD CONSTRAINT "usage_resets_entitlements_usage_reset" FOREIGN KEY ("entitlement_id") REFERENCES "entitlements" ("id") ON UPDATE NO ACTION ON DELETE CASCADE;
+
+-- create trigger to delete entitlement when subscription_item is deleted
+CREATE OR REPLACE FUNCTION delete_entitlement_on_subscription_item_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Delete the entitlement if it exists and is referenced by the deleted subscription_item
+    IF OLD.entitlement_id IS NOT NULL THEN
+        DELETE FROM entitlements WHERE id = OLD.entitlement_id;
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_delete_entitlement_on_subscription_item_delete
+    AFTER DELETE ON subscription_items
+    FOR EACH ROW
+    EXECUTE FUNCTION delete_entitlement_on_subscription_item_delete();

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:K/3hJp2I7LkDeNVvigA76PiA9vfVRfSrdVk58QOzFW8=
+h1:J71QuUsEwvxLImDJc4dCNeb9WTwDfnG16DsttCiEVKQ=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -99,3 +99,4 @@ h1:K/3hJp2I7LkDeNVvigA76PiA9vfVRfSrdVk58QOzFW8=
 20250525121526_billing-ubp-fee-line.up.sql h1:66N3LtnHAU4FWlcYOOcP/sWge80iPtUKx+yXouFfYcM=
 20250527084817_billing-backfill-periods.up.sql h1:7aDXq8VWJ3P3k/T8FfyPvuv+gAC5wZBER7JeIw7TMEk=
 20250604111901_subscription-sorthint.up.sql h1:LyUrrK8VUt0yBfh0f5zRtC+D8VnefCYDAWmBObmEJpY=
+20250605102416_subscription-cascade.up.sql h1:U1hMY2fNlRV8R3YuwrElmVm1SDHZs8YI0Xvk0SrH56k=


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Add & Test Cascading for subscriptions

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Deleting a subscription or entitlement now automatically removes all related records, such as phases, items, grants, usage resets, and balance snapshots, ensuring cleaner data management.
- **Bug Fixes**
	- Improved database integrity by ensuring related records are properly deleted when a parent record is removed.
- **Tests**
	- Added tests to verify that deleting a subscription cascades deletions to all related records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->