### PR TITLE
fix: decrease race condition period in sink worker

### DIFF
--- a/openmeter/dedupe/dedupe.go
+++ b/openmeter/dedupe/dedupe.go
@@ -17,8 +17,17 @@ type Deduplicator interface {
 	CheckUnique(ctx context.Context, item Item) (bool, error)
 	// Set adds the item(s) to the deduplicator
 	Set(ctx context.Context, events ...Item) ([]Item, error)
+	// CheckUniqueBatch checks if a batch of items is unique.
+	CheckUniqueBatch(ctx context.Context, items []Item) (CheckUniqueBatchResult, error)
 	// Close cleans up resources
 	Close() error
+}
+
+type ItemSet map[Item]struct{}
+
+type CheckUniqueBatchResult struct {
+	UniqueItems           ItemSet
+	AlreadyProcessedItems ItemSet
 }
 
 type Item struct {

--- a/openmeter/dedupe/memorydedupe/memorydedupe.go
+++ b/openmeter/dedupe/memorydedupe/memorydedupe.go
@@ -61,3 +61,20 @@ func (d *Deduplicator) Set(ctx context.Context, items ...dedupe.Item) ([]dedupe.
 func (d *Deduplicator) Close() error {
 	return nil
 }
+
+func (d *Deduplicator) CheckUniqueBatch(ctx context.Context, items []dedupe.Item) (dedupe.CheckUniqueBatchResult, error) {
+	result := dedupe.CheckUniqueBatchResult{
+		UniqueItems:           make(dedupe.ItemSet, len(items)),
+		AlreadyProcessedItems: make(dedupe.ItemSet, len(items)),
+	}
+
+	for _, item := range items {
+		if d.store.Contains(item.Key()) {
+			result.AlreadyProcessedItems[item] = struct{}{}
+		} else {
+			result.UniqueItems[item] = struct{}{}
+		}
+	}
+
+	return result, nil
+}

--- a/openmeter/sink/models/models.go
+++ b/openmeter/sink/models/models.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 
+	"github.com/openmeterio/openmeter/openmeter/dedupe"
 	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest/serializer"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 )
@@ -16,6 +17,14 @@ type SinkMessage struct {
 	Status       ProcessingStatus
 	// Meters contains the list of meters this message affects
 	Meters []*meter.Meter
+}
+
+func (m SinkMessage) GetDedupeItem() dedupe.Item {
+	return dedupe.Item{
+		Namespace: m.Namespace,
+		ID:        m.Serialized.Id,
+		Source:    m.Serialized.Source,
+	}
 }
 
 type ProcessingState int8

--- a/openmeter/sink/sink.go
+++ b/openmeter/sink/sink.go
@@ -280,6 +280,27 @@ func (s *Sink) flush(ctx context.Context) error {
 	// Dedupe messages so if we have multiple messages in the same batch
 	dedupedMessages := dedupeSinkMessages(messages)
 
+	// If deduplicator is set, let's reexecute the deduplication to decrease the number of messages double persisted
+	if s.config.Deduplicator != nil {
+		messageByDedupeItem := lo.GroupBy(dedupedMessages, func(message sinkmodels.SinkMessage) dedupe.Item {
+			return message.GetDedupeItem()
+		})
+
+		dedupeResults, err := s.config.Deduplicator.CheckUniqueBatch(ctx, lo.Keys(messageByDedupeItem))
+		if err != nil {
+			return fmt.Errorf("failed to check uniqueness of kafka messages: %w", err)
+		}
+
+		updatedDedupedMessages := make([]sinkmodels.SinkMessage, 0, len(dedupedMessages))
+		for _, message := range dedupedMessages {
+			if _, ok := dedupeResults.UniqueItems[message.GetDedupeItem()]; !ok {
+				updatedDedupedMessages = append(updatedDedupedMessages, message)
+			}
+		}
+
+		dedupedMessages = updatedDedupedMessages
+	}
+
 	// 1. Persist to storage
 	if len(dedupedMessages) > 0 {
 		// Persist events to permanent storage
@@ -850,11 +871,7 @@ func (s *Sink) parseMessage(ctx context.Context, e *kafka.Message) (*sinkmodels.
 	// Dedupe, this stores key in store which means if sink fails and restarts it will not process the same message again
 	// Dedupe is an optional dependency, so we check if it's set
 	if s.config.Deduplicator != nil {
-		isUnique, err := s.config.Deduplicator.CheckUnique(ctx, dedupe.Item{
-			Namespace: sinkMessage.Namespace,
-			ID:        sinkMessage.Serialized.Id,
-			Source:    sinkMessage.Serialized.Source,
-		})
+		isUnique, err := s.config.Deduplicator.CheckUnique(ctx, sinkMessage.GetDedupeItem())
 		if err != nil {
 			// Stop processing, non-recoverable error
 			return sinkMessage, fmt.Errorf("failed to check uniqueness of kafka message: %w", err)


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch checks the redis before starting to dedupe the messages as precheck step, this way we are validating message uniqueness just before we start the write.