### PR TITLE
feat(meter): do not include subject in csv export when not returned

### DIFF
--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -319,8 +319,8 @@ func TestRoutes(t *testing.T) {
 				status: http.StatusOK,
 				body: strings.Join(
 					[]string{
-						"window_start,window_end,subject,value",
-						"2021-01-01T00:00:00Z,2021-01-01T01:00:00Z,,300.000000",
+						"window_start,window_end,value",
+						"2021-01-01T00:00:00Z,2021-01-01T01:00:00Z,300.000000",
 						"",
 					},
 					"\n",


### PR DESCRIPTION
do not include subject in csv export when not returned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CSV exports now only include the "subject" column and its display name when "subject" is present in the group-by keys, ensuring the CSV output matches the query parameters.
- **Tests**
  - Updated tests to reflect the new CSV format, excluding the "subject" column when it is not part of the query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->