### PR TITLE
feat(streaming): clickhouse query optimization

### DIFF
--- a/.dagger/versions_pinned.go
+++ b/.dagger/versions_pinned.go
@@ -2,7 +2,7 @@ package main
 
 const (
 	kafkaVersion      = "3.6"
-	clickhouseVersion = "24.5.5.78"
+	clickhouseVersion = "24.10"
 	redisVersion      = "7.0.12"
 	postgresVersion   = "14.9"
 	svixVersion       = "v1.44"

--- a/app/common/streaming.go
+++ b/app/common/streaming.go
@@ -35,6 +35,7 @@ func NewStreamingConnector(
 		AsyncInsert:                           conf.AsyncInsert,
 		AsyncInsertWait:                       conf.AsyncInsertWait,
 		InsertQuerySettings:                   conf.InsertQuerySettings,
+		MeterQuerySettings:                    conf.MeterQuerySettings,
 		ProgressManager:                       progressmanager,
 		QueryCacheEnabled:                     conf.QueryCache.Enabled,
 		QueryCacheNamespaceTemplate:           conf.QueryCache.NamespaceTemplate,

--- a/app/config/aggregation.go
+++ b/app/config/aggregation.go
@@ -30,6 +30,10 @@ type AggregationConfiguration struct {
 	// or the `parallel_view_processing` setting to enable pushing to attached views concurrently.
 	InsertQuerySettings map[string]string
 
+	// MeterQuerySettings is the settings for the meter query
+	// For example, you can set the `enable_parallel_replicas` and `max_parallel_replicas` settings.
+	MeterQuerySettings map[string]string
+
 	// QueryCache is the cache configuration
 	QueryCache AggregationQueryCacheConfiguration
 }

--- a/deploy/charts/openmeter/templates/clickhouse.yaml
+++ b/deploy/charts/openmeter/templates/clickhouse.yaml
@@ -21,7 +21,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: clickhouse/clickhouse-server:23.3
+              image: clickhouse/clickhouse-server:24.10
               volumeMounts:
                 - name: data-storage-vc-template
                   mountPath: /var/lib/clickhouse

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       retries: 30
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24.9-alpine
+    image: clickhouse/clickhouse-server:24.10-alpine
     ports:
       - "127.0.0.1:8123:8123"
       - "127.0.0.1:9000:9000"

--- a/examples/collectors/database/docker-compose.yaml
+++ b/examples/collectors/database/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
   clickhouse:
     profiles:
       - clickhouse
-    image: clickhouse/clickhouse-server:23.8.9.54-alpine
+    image: clickhouse/clickhouse-server:24.0-alpine
     ports:
       - 127.0.0.1:8123:8123
       - 127.0.0.1:9000:9000

--- a/openmeter/streaming/clickhouse/connector.go
+++ b/openmeter/streaming/clickhouse/connector.go
@@ -36,6 +36,7 @@ type Config struct {
 	AsyncInsert         bool
 	AsyncInsertWait     bool
 	InsertQuerySettings map[string]string
+	MeterQuerySettings  map[string]string
 	ProgressManager     progressmanager.Service
 	SkipCreateTables    bool
 	QueryCacheEnabled   bool
@@ -205,6 +206,7 @@ func (c *Connector) QueryMeter(ctx context.Context, namespace string, meter mete
 		GroupBy:         groupBy,
 		WindowSize:      params.WindowSize,
 		WindowTimeZone:  params.WindowTimeZone,
+		QuerySettings:   c.config.MeterQuerySettings,
 	}
 
 	// Load cached rows if any

--- a/openmeter/streaming/clickhouse/meter_query.go
+++ b/openmeter/streaming/clickhouse/meter_query.go
@@ -230,28 +230,15 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 	var sqlPreWhere string
 
 	if len(d.FilterGroupBy) > 0 {
+		sqlPreWhere, _ = query.Build()
+		dataColumn := getColumn("data")
+
 		// We sort the group bys to ensure the query is deterministic
 		filterGroupByKeys := make([]string, 0, len(d.FilterGroupBy))
 		for k := range d.FilterGroupBy {
 			filterGroupByKeys = append(filterGroupByKeys, k)
 		}
 		sort.Strings(filterGroupByKeys)
-
-		// Add to prewhere
-		for _, groupByKey := range filterGroupByKeys {
-			mapFunc := func(value string) string {
-				// Subject is a special case
-				if groupByKey == "subject" {
-					return fmt.Sprintf("subject = '%s'", sqlbuilder.Escape(value))
-				}
-
-				return fmt.Sprintf("JSONHas('%s')", sqlbuilder.Escape(value))
-			}
-
-			query.Where(query.Or(slicesx.Map(d.FilterGroupBy[groupByKey], mapFunc)...))
-		}
-
-		sqlPreWhere, _ = query.Build()
 
 		// Where clauses
 		for _, groupByKey := range filterGroupByKeys {
@@ -266,7 +253,7 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 				return "", nil, fmt.Errorf("empty filter for group by: %s", groupByKey)
 			}
 			mapFunc := func(value string) string {
-				column := fmt.Sprintf("JSON_VALUE(%s, '%s')", getColumn("data"), groupByJSONPath)
+				column := fmt.Sprintf("JSON_VALUE(%s, '%s')", dataColumn, groupByJSONPath)
 
 				// Subject is a special case
 				if groupByKey == "subject" {
@@ -312,6 +299,8 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 	}
 
 	sql = sql + fmt.Sprintf(" SETTINGS %s", strings.Join(settings, ", "))
+
+	fmt.Println(sql, args)
 
 	return sql, args, nil
 }

--- a/openmeter/streaming/clickhouse/meter_query.go
+++ b/openmeter/streaming/clickhouse/meter_query.go
@@ -300,8 +300,6 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 
 	sql = sql + fmt.Sprintf(" SETTINGS %s", strings.Join(settings, ", "))
 
-	fmt.Println(sql, args)
-
 	return sql, args, nil
 }
 

--- a/openmeter/streaming/clickhouse/meter_query.go
+++ b/openmeter/streaming/clickhouse/meter_query.go
@@ -253,14 +253,7 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 				return "", nil, fmt.Errorf("empty filter for group by: %s", groupByKey)
 			}
 			mapFunc := func(value string) string {
-				column := fmt.Sprintf("JSON_VALUE(%s, '%s')", dataColumn, groupByJSONPath)
-
-				// Subject is a special case
-				if groupByKey == "subject" {
-					column = "subject"
-				}
-
-				return fmt.Sprintf("%s = '%s'", column, sqlbuilder.Escape((value)))
+				return fmt.Sprintf("JSON_VALUE(%s, '%s') = '%s'", dataColumn, groupByJSONPath, sqlbuilder.Escape((value)))
 			}
 
 			query.Where(query.Or(slicesx.Map(values, mapFunc)...))

--- a/openmeter/streaming/clickhouse/meter_query_test.go
+++ b/openmeter/streaming/clickhouse/meter_query_test.go
@@ -268,7 +268,7 @@ func TestQueryMeter(t *testing.T) {
 				},
 				FilterGroupBy: map[string][]string{"g1": {"g1v1"}},
 			},
-			wantSQL:  "SELECT toStartOfMinute(min(om_events.time)) AS windowstart, toStartOfMinute(max(om_events.time)) + INTERVAL 1 MINUTE AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events PREWHERE om_events.namespace = ? AND om_events.type = ? AND (JSONHas('g1v1')) WHERE (JSON_VALUE(om_events.data, '$.group1') = 'g1v1') SETTINGS optimize_move_to_prewhere = 1, allow_reorder_prewhere_conditions = 1",
+			wantSQL:  "SELECT toStartOfMinute(min(om_events.time)) AS windowstart, toStartOfMinute(max(om_events.time)) + INTERVAL 1 MINUTE AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events PREWHERE om_events.namespace = ? AND om_events.type = ? WHERE (JSON_VALUE(om_events.data, '$.group1') = 'g1v1') SETTINGS optimize_move_to_prewhere = 1, allow_reorder_prewhere_conditions = 1",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
 		{ // Aggregate data with filtering for a single group and multiple values
@@ -288,7 +288,7 @@ func TestQueryMeter(t *testing.T) {
 				},
 				FilterGroupBy: map[string][]string{"g1": {"g1v1", "g1v2"}},
 			},
-			wantSQL:  "SELECT toStartOfMinute(min(om_events.time)) AS windowstart, toStartOfMinute(max(om_events.time)) + INTERVAL 1 MINUTE AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events PREWHERE om_events.namespace = ? AND om_events.type = ? AND (JSONHas('g1v1') OR JSONHas('g1v2')) WHERE (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2') SETTINGS optimize_move_to_prewhere = 1, allow_reorder_prewhere_conditions = 1",
+			wantSQL:  "SELECT toStartOfMinute(min(om_events.time)) AS windowstart, toStartOfMinute(max(om_events.time)) + INTERVAL 1 MINUTE AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events PREWHERE om_events.namespace = ? AND om_events.type = ? WHERE (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2') SETTINGS optimize_move_to_prewhere = 1, allow_reorder_prewhere_conditions = 1",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
 		{ // Aggregate data with filtering for multiple groups and multiple values
@@ -308,7 +308,7 @@ func TestQueryMeter(t *testing.T) {
 				},
 				FilterGroupBy: map[string][]string{"g1": {"g1v1", "g1v2"}, "g2": {"g2v1", "g2v2"}},
 			},
-			wantSQL:  "SELECT toStartOfMinute(min(om_events.time)) AS windowstart, toStartOfMinute(max(om_events.time)) + INTERVAL 1 MINUTE AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events PREWHERE om_events.namespace = ? AND om_events.type = ? AND (JSONHas('g1v1') OR JSONHas('g1v2')) AND (JSONHas('g2v1') OR JSONHas('g2v2')) WHERE (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2') AND (JSON_VALUE(om_events.data, '$.group2') = 'g2v1' OR JSON_VALUE(om_events.data, '$.group2') = 'g2v2') SETTINGS optimize_move_to_prewhere = 1, allow_reorder_prewhere_conditions = 1",
+			wantSQL:  "SELECT toStartOfMinute(min(om_events.time)) AS windowstart, toStartOfMinute(max(om_events.time)) + INTERVAL 1 MINUTE AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events PREWHERE om_events.namespace = ? AND om_events.type = ? WHERE (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2') AND (JSON_VALUE(om_events.data, '$.group2') = 'g2v1' OR JSON_VALUE(om_events.data, '$.group2') = 'g2v2') SETTINGS optimize_move_to_prewhere = 1, allow_reorder_prewhere_conditions = 1",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
 	}


### PR DESCRIPTION
- use `prewhere` to pre-filter rows before group by filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom meter query settings, allowing advanced configuration and optimization of queries.
  - Enhanced query performance by introducing PREWHERE clauses and SETTINGS for more efficient filtering and execution.

- **Bug Fixes**
  - Improved query construction logic for more accurate and optimized time window handling.

- **Chores**
  - Updated ClickHouse server image versions in deployment configurations for Kubernetes and Docker Compose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->