### PR TITLE
fix(subs): fix cadence validations

### DIFF
--- a/openmeter/subscription/subscriptionspec.go
+++ b/openmeter/subscription/subscriptionspec.go
@@ -362,7 +362,7 @@ func (s *SubscriptionSpec) ValidateAlignment() error {
 				rateCard := item.RateCard
 				if rateCard.GetBillingCadence() != nil {
 					if err := productcatalog.ValidateBillingCadencesAlign(s.BillingCadence, lo.FromPtr(rateCard.GetBillingCadence())); err != nil {
-						errs = append(errs, fmt.Errorf("phase %s has billable item %s with billing cadence %s that is not aligned with the subscription billing cadence: %w", phase.PhaseKey, item.ItemKey, rateCard.GetBillingCadence(), err))
+						errs = append(errs, err)
 					}
 				}
 			}

--- a/openmeter/subscription/subscriptionspec.go
+++ b/openmeter/subscription/subscriptionspec.go
@@ -345,25 +345,31 @@ func (s *SubscriptionSpec) Validate() error {
 			errs = append(errs, fmt.Errorf("phase %s validation failed: %w", phase.PhaseKey, err))
 		}
 	}
+
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
-// HasAlignedBillingCadences validates that the billing cadence of the subscription is aligned with the billing cadence of the rate cards.
-func (s *SubscriptionSpec) HasAlignedBillingCadences() (bool, error) {
+func (s *SubscriptionSpec) ValidateAlignment() error {
+	if !s.Alignment.BillablesMustAlign {
+		return nil
+	}
+
+	var errs []error
+
 	for _, phase := range s.GetSortedPhases() {
 		for _, itemsByKey := range phase.GetBillableItemsByKey() {
 			for _, item := range itemsByKey {
 				rateCard := item.RateCard
 				if rateCard.GetBillingCadence() != nil {
 					if err := productcatalog.ValidateBillingCadencesAlign(s.BillingCadence, lo.FromPtr(rateCard.GetBillingCadence())); err != nil {
-						return false, err
+						errs = append(errs, fmt.Errorf("phase %s has billable item %s with billing cadence %s that is not aligned with the subscription billing cadence: %w", phase.PhaseKey, item.ItemKey, rateCard.GetBillingCadence(), err))
 					}
 				}
 			}
 		}
 	}
 
-	return true, nil
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type CreateSubscriptionPhasePlanInput struct {
@@ -593,31 +599,6 @@ func (s SubscriptionPhaseSpec) Validate(
 				))
 			}
 		}
-	}
-
-	if alignment.BillablesMustAlign {
-		// Let's validate that all billables have the same billing cadence
-		billables := make([]SubscriptionItemSpec, 0)
-		for _, items := range s.ItemsByKey {
-			for _, item := range items {
-				if item.RateCard.AsMeta().Price != nil {
-					billables = append(billables, *item)
-				}
-			}
-		}
-
-		cadences := lo.UniqBy(lo.Filter(billables, func(i SubscriptionItemSpec, _ int) bool {
-			return i.RateCard.GetBillingCadence() != nil
-		}), func(i SubscriptionItemSpec) isodate.Period {
-			return *i.RateCard.GetBillingCadence()
-		})
-
-		if len(cadences) > 1 {
-			errs = append(errs, &AllowedDuringApplyingToSpecError{Inner: &AlignmentError{Inner: fmt.Errorf("all billables must have the same billing cadence")}})
-		}
-
-		// Some validations that might feel reasonable but are misleading:
-		// 1. The phase length doesn't have to be a multiple of the billing cadence. If an edit is done with resetanchor, alignment would drift either way. If a cancel or stretch is done, valid cancels and stretches would break this condition.
 	}
 
 	if len(errs) == 0 {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Context: alignment is not a consistency guarantee but a runtime validation on change (this was a necessity we have data that cant be migrated to be consistent)

FIxes some incorrect validations

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for billing cadence alignment, ensuring all misalignments are reported together instead of stopping at the first error.
- **Refactor**
	- Centralized billing cadence alignment checks at the subscription level for more consistent validation and simplified error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->