### PR TITLE
feat(helm): add support for external PostgreSQL and Redis in Svix

### DIFF
--- a/deploy/charts/openmeter/Chart.yaml
+++ b/deploy/charts/openmeter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 type: application
 name: openmeter
-version: 1.0.0-beta.186
-appVersion: "v1.0.0-beta.186"
+version: 1.0.0-beta.213
+appVersion: "v1.0.0-beta.213"
 description: "Usage Metering for AI, DevOps, and Billing. Built for engineers to collect and aggregate millions of events in real-time."
 icon: https://openmeter.io/favicon.svg
 keywords:

--- a/deploy/charts/openmeter/templates/svix.yaml
+++ b/deploy/charts/openmeter/templates/svix.yaml
@@ -35,9 +35,9 @@ spec:
           imagePullPolicy: {{ .Values.svix.image.pullPolicy }}
           env:
             - name: SVIX_REDIS_DSN
-              value: "redis://{{ include "openmeter.fullname" . }}-redis-master:6379"
+              value: {{ if .Values.svix.redis.dsn }}{{ .Values.svix.redis.dsn | quote }}{{ else }}"redis://{{ include "openmeter.fullname" . }}-redis-master:6379"{{ end }}
             - name: SVIX_DB_DSN
-              value: "postgres://svix:svix@{{ include "openmeter.fullname" . }}-postgres:5432/svix"
+              value: {{ if .Values.svix.database.dsn }}{{ .Values.svix.database.dsn | quote }}{{ else }}"postgres://svix:svix@{{ include "openmeter.fullname" . }}-postgres:5432/svix"{{ end }}
             - name: SVIX_CACHE_TYPE
               value: "redis"
             - name: SVIX_JWT_SECRET

--- a/deploy/charts/openmeter/values.yaml
+++ b/deploy/charts/openmeter/values.yaml
@@ -160,6 +160,16 @@ svix:
   # This is an example Token intended for development purposes. You should create your own using the instructions in [svix documentation](https://github.com/svix/svix-webhooks?tab=readme-ov-file#authentication).
   signedJwt: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdml4LXNlcnZlciIsImlhdCI6MTczMDk4NzU0MywiZXhwIjoyMjM1OTA5MDAwLCJhdWQiOiIiLCJzdWIiOiJvcmdfMjNyYjhZZEdxTVQwcUl6cGdHd2RYZkhpck11In0.J90SzVuNwecyCtWAQlOoWplJaK4rnIb3rCWXrHQPqJY"
 
+  # -- External database configuration for Svix
+  database:
+    # -- External PostgreSQL DSN for Svix. If not provided, uses internal PostgreSQL.
+    dsn: ""
+
+  # -- External Redis configuration for Svix
+  redis:
+    # -- External Redis DSN for Svix. If not provided, uses internal Redis.
+    dsn: ""
+
   # -- Number of replicas (pods) to launch.
   replicaCount: 1
 
@@ -204,7 +214,6 @@ redis:
     enabled: false
 
   nameOverride: redis
-
 
 postgresql:
   # -- Specifies whether Postgres (using the [Bitnami Chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) should be installed.


### PR DESCRIPTION
## Overview

This PR adds support for configuring external PostgreSQL and Redis databases for Svix in the OpenMeter Helm chart, allowing users to use managed database services instead of the bundled databases.

### Changes
- Added `svix.database.dsn` configuration option for external PostgreSQL
- Added `svix.redis.dsn` configuration option for external Redis  
- Modified Svix deployment template to use external DSNs when provided
- Maintains backward compatibility with internal services as default

### Benefits
- Enables production deployments with managed database services (AWS RDS, ElastiCache, etc.) whereas svix running internally
- Reduces operational overhead to externally setup svix

## Notes for reviewer

This change is backward compatible - existing deployments will continue to work unchanged. The new configuration options are optional and default to the current behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying external PostgreSQL and Redis connection strings (DSNs) for Svix via Helm chart configuration.
  - Users can now override default database and Redis connections by providing custom DSNs in the Helm values.
  - Updated Helm chart and application versions to 1.0.0-beta.213.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->