### PR TITLE
fix(api): subscription mapping for billing anchor

### DIFF
--- a/openmeter/productcatalog/subscription/http/mapping.go
+++ b/openmeter/productcatalog/subscription/http/mapping.go
@@ -423,6 +423,7 @@ func MapSubscriptionViewToAPI(view subscription.SubscriptionView) (api.Subscript
 		Id:              apiSub.Id,
 		Metadata:        apiSub.Metadata,
 		ProRatingConfig: apiSub.ProRatingConfig,
+		BillingAnchor:   apiSub.BillingAnchor,
 		BillingCadence:  apiSub.BillingCadence,
 		Name:            apiSub.Name,
 		Phases:          nil,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the BillingAnchor field is now correctly included in the subscription details returned by the API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->