### PR TITLE
refactor(billing-sync): generate lines for first cadence for future s…

### DIFF
--- a/openmeter/subscription/errors.go
+++ b/openmeter/subscription/errors.go
@@ -3,6 +3,7 @@ package subscription
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -114,6 +115,36 @@ func IsItemNotFoundError(err error) bool {
 	}
 
 	var e *ItemNotFoundError
+
+	return errors.As(err, &e)
+}
+
+type BillingPeriodQueriedBeforeSubscriptionStartError struct {
+	err error
+}
+
+func (e *BillingPeriodQueriedBeforeSubscriptionStartError) Error() string {
+	return e.err.Error()
+}
+
+func (e *BillingPeriodQueriedBeforeSubscriptionStartError) Unwrap() error {
+	return e.err
+}
+
+func NewBillingPeriodQueriedBeforeSubscriptionStartError(queriedAt, subscriptionStart time.Time) error {
+	return &BillingPeriodQueriedBeforeSubscriptionStartError{
+		err: models.NewGenericValidationError(
+			fmt.Errorf("billing period queried before subscription start: %s < %s", queriedAt, subscriptionStart),
+		),
+	}
+}
+
+func IsBillingPeriodQueriedBeforeSubscriptionStartError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var e *BillingPeriodQueriedBeforeSubscriptionStartError
 
 	return errors.As(err, &e)
 }

--- a/openmeter/subscription/subscriptionspec.go
+++ b/openmeter/subscription/subscriptionspec.go
@@ -230,7 +230,7 @@ func (s *SubscriptionSpec) GetAlignedBillingPeriodAt(at time.Time) (timeutil.Clo
 		}
 		phase = p
 	case at.Before(subCad.ActiveFrom):
-		return def, fmt.Errorf("at %s is before the subscription active from %s, cannot calculate billing period", at, subCad.ActiveFrom)
+		return def, NewBillingPeriodQueriedBeforeSubscriptionStartError(at, subCad.ActiveFrom)
 	default:
 		if subCad.ActiveTo == nil {
 			// impossible, but lets be defensive and not panic


### PR DESCRIPTION
…ubscriptions

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of billing periods that are queried before a subscription's start date, ensuring accurate invoice line generation for subscriptions starting in the future.
- **New Features**
	- Introduced specific error messaging for cases when billing is attempted before a subscription begins, improving clarity in error reporting.
- **Tests**
	- Added a new test to verify correct invoice generation for subscriptions that start in the future, ensuring in-advance fees are included appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->