### PR TITLE
fix(ratecard): compatibility validation

### DIFF
--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -758,17 +758,7 @@ var ValidateRateCardsHaveCompatibleBillingCadence = models.ValidatorFunc[RateCar
 	fieldSelector := models.NewFieldSelectors(models.NewFieldSelector("ratecards").
 		WithExpression(models.NewFieldAttrValue("key", r.base.Key())))
 
-	if rBillingCadence != nil {
-		if vBillingCadence == nil {
-			errs = append(errs, models.ErrorWithFieldPrefix(fieldSelector, ErrRateCardBillingCadenceMismatch))
-		}
-
-		if vBillingCadence != nil && !rBillingCadence.Equal(vBillingCadence) {
-			errs = append(errs, models.ErrorWithFieldPrefix(fieldSelector, ErrRateCardBillingCadenceMismatch))
-		}
-	}
-
-	if rBillingCadence == nil && vBillingCadence != nil {
+	if rBillingCadence != nil && vBillingCadence != nil && !rBillingCadence.Equal(vBillingCadence) {
 		errs = append(errs, models.ErrorWithFieldPrefix(fieldSelector, ErrRateCardBillingCadenceMismatch))
 	}
 

--- a/openmeter/productcatalog/ratecard_test.go
+++ b/openmeter/productcatalog/ratecard_test.go
@@ -54,6 +54,18 @@ func TestFlatFeeRateCard(t *testing.T) {
 				ExpectedError: false,
 			},
 			{
+				Name: "valid, nil billing cadence",
+				RateCard: FlatFeeRateCard{
+					RateCardMeta: RateCardMeta{
+						Key:         "feat-1",
+						Name:        "Flat 1",
+						Description: lo.ToPtr("Flat 1"),
+					},
+					BillingCadence: nil,
+				},
+				ExpectedError: false,
+			},
+			{
 				Name: "invalid",
 				RateCard: FlatFeeRateCard{
 					RateCardMeta: RateCardMeta{

--- a/openmeter/subscription/addon/extend_test.go
+++ b/openmeter/subscription/addon/extend_test.go
@@ -109,10 +109,10 @@ func TestValidations(t *testing.T) {
 
 		t.Run("Restore", func(t *testing.T) {
 			err := rc.Restore(&productcatalog.UsageBasedRateCard{
-				RateCardMeta: meta,
+				RateCardMeta:   meta,
+				BillingCadence: testutils.GetISODuration(t, "P1M"),
 			}, models.Annotations{}, productcatalog.AddonInstanceTypeSingle)
-			require.Error(t, err)
-			require.ErrorContains(t, err, "billing cadence must match")
+			require.NoError(t, err)
 		})
 	})
 


### PR DESCRIPTION
In case free and not free rate cards are compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation logic for billing cadence compatibility, reducing unnecessary errors when one billing cadence is unspecified.

- **Tests**
  - Added a test to ensure rate cards without a billing cadence are validated correctly.
  - Updated tests to reflect relaxed billing cadence requirements during subscription restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->