### PR TITLE
chore: remove deprecated windowSize from meters

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -102,9 +102,6 @@ func (c Configuration) Validate() error {
 			Description: m.Description,
 		}
 
-		// Window size is deprecated, always set to MINUTE
-		c.Meters[idx].WindowSize = meter.WindowSizeMinute
-
 		if err := c.Meters[idx].Validate(); err != nil {
 			errs = append(errs, err)
 		}

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -283,7 +283,6 @@ func TestComplete(t *testing.T) {
 					"method": "$.method",
 					"path":   "$.path",
 				},
-				WindowSize: meter.WindowSizeMinute,
 			},
 		},
 		Events: EventsConfiguration{

--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -122,6 +122,7 @@ func (m *connector) GetBalanceAt(ctx context.Context, ownerID models.NamespacedI
 
 	var def engine.RunResult
 
+	// FIXME: remove truncation
 	// To include the current last minute lets round it trunc to the next minute
 	if trunc := at.Truncate(time.Minute); trunc.Before(at) {
 		at = trunc.Add(time.Minute)
@@ -144,6 +145,7 @@ func (m *connector) GetBalanceForPeriod(ctx context.Context, ownerID models.Name
 
 	var def engine.RunResult
 
+	// FIXME: remove truncation
 	// To include the current last minute lets round it trunc to the next minute
 	if trunc := period.To.Truncate(time.Minute); trunc.Before(period.To) {
 		period.To = trunc.Add(time.Minute)
@@ -215,6 +217,7 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, ownerID models.Names
 		return nil, fmt.Errorf("failed to describe owner %s: %w", ownerID.ID, err)
 	}
 
+	// FIXME: remove truncation
 	at := params.At.Truncate(time.Minute)
 
 	// check if reset is possible (not before current period)

--- a/openmeter/credit/balance.go
+++ b/openmeter/credit/balance.go
@@ -215,7 +215,7 @@ func (m *connector) ResetUsageForOwner(ctx context.Context, ownerID models.Names
 		return nil, fmt.Errorf("failed to describe owner %s: %w", ownerID.ID, err)
 	}
 
-	at := params.At.Truncate(owner.Meter.WindowSize.Duration())
+	at := params.At.Truncate(time.Minute)
 
 	// check if reset is possible (not before current period)
 	periodStart, err := m.OwnerConnector.GetUsagePeriodStartAt(ctx, ownerID, clock.Now())

--- a/openmeter/credit/engine/engine.go
+++ b/openmeter/credit/engine/engine.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/credit/balance"
 	"github.com/openmeterio/openmeter/openmeter/credit/grant"
-	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -43,8 +42,7 @@ type Engine interface {
 type QueryUsageFn func(ctx context.Context, from, to time.Time) (float64, error)
 
 type EngineConfig struct {
-	Granularity meter.WindowSize
-	QueryUsage  QueryUsageFn
+	QueryUsage QueryUsageFn
 }
 
 func NewEngine(conf EngineConfig) Engine {

--- a/openmeter/credit/engine/engine_test.go
+++ b/openmeter/credit/engine/engine_test.go
@@ -100,16 +100,13 @@ func Test_Fuzzing(t *testing.T) {
 				}
 
 				engine1 := engine.NewEngine(engine.EngineConfig{
-					QueryUsage:  queryFn,
-					Granularity: meterpkg.WindowSizeMinute,
+					QueryUsage: queryFn,
 				}) // runs for first part
 				engine2 := engine.NewEngine(engine.EngineConfig{
-					QueryUsage:  queryFn,
-					Granularity: meterpkg.WindowSizeMinute,
+					QueryUsage: queryFn,
 				}) // runs for second part
 				engine3 := engine.NewEngine(engine.EngineConfig{
-					QueryUsage:  queryFn,
-					Granularity: meterpkg.WindowSizeMinute,
+					QueryUsage: queryFn,
 				}) // runs for both parts
 
 				res, err := engine1.Run(
@@ -204,8 +201,7 @@ func Test_Fuzzing(t *testing.T) {
 				results := make([]balance.Map, numOfRuns)
 				for i := 0; i < numOfRuns; i++ {
 					eng := engine.NewEngine(engine.EngineConfig{
-						QueryUsage:  queryFn,
-						Granularity: meterpkg.WindowSizeMinute,
+						QueryUsage: queryFn,
 					})
 					gCp := make([]grant.Grant, len(grants))
 					copy(gCp, grants)
@@ -291,8 +287,7 @@ func Test_Fuzzing(t *testing.T) {
 
 				// run calculation on single engine
 				singleEngine := engine.NewEngine(engine.EngineConfig{
-					QueryUsage:  queryFn,
-					Granularity: meterpkg.WindowSizeMinute,
+					QueryUsage: queryFn,
 				})
 				gCp := make([]grant.Grant, len(grants))
 				copy(gCp, grants)
@@ -329,8 +324,7 @@ func Test_Fuzzing(t *testing.T) {
 					}
 
 					eng := engine.NewEngine(engine.EngineConfig{
-						QueryUsage:  queryFn,
-						Granularity: meterpkg.WindowSizeMinute,
+						QueryUsage: queryFn,
 					})
 					gCp := make([]grant.Grant, len(grants))
 					copy(gCp, grants)

--- a/openmeter/credit/engine/grant.go
+++ b/openmeter/credit/engine/grant.go
@@ -38,6 +38,7 @@ func (e *engine) getGrantActivityChanges(grants []grant.Grant, period timeutil.C
 	}
 
 	// FIXME: we should truncate on input but that's hard for voidedAt and deletedAt
+	// FIXME: remove truncation
 	for i, t := range activityChanges {
 		activityChanges[i] = t.Truncate(time.Minute).In(time.UTC)
 	}

--- a/openmeter/credit/engine/grant.go
+++ b/openmeter/credit/engine/grant.go
@@ -39,7 +39,7 @@ func (e *engine) getGrantActivityChanges(grants []grant.Grant, period timeutil.C
 
 	// FIXME: we should truncate on input but that's hard for voidedAt and deletedAt
 	for i, t := range activityChanges {
-		activityChanges[i] = t.Truncate(e.Granularity.Duration()).In(time.UTC)
+		activityChanges[i] = t.Truncate(time.Minute).In(time.UTC)
 	}
 
 	sort.Slice(activityChanges, func(i, j int) bool {

--- a/openmeter/credit/engine/reset_test.go
+++ b/openmeter/credit/engine/reset_test.go
@@ -58,8 +58,7 @@ func TestReset(t *testing.T) {
 		}
 
 		return engine.NewEngine(engine.EngineConfig{
-				QueryUsage:  queryFeatureUsage,
-				Granularity: meterpkg.WindowSizeMinute,
+				QueryUsage: queryFeatureUsage,
 			}), func(usage float64, at time.Time) {
 				streamingConnector.AddSimpleEvent(meterSlug, usage, at)
 			}

--- a/openmeter/credit/engine/run_test.go
+++ b/openmeter/credit/engine/run_test.go
@@ -910,8 +910,7 @@ func TestEngine(t *testing.T) {
 				return rows[0].Value, nil
 			}
 			tc.run(t, engine.NewEngine(engine.EngineConfig{
-				QueryUsage:  queryFeatureUsage,
-				Granularity: meterpkg.WindowSizeMinute,
+				QueryUsage: queryFeatureUsage,
 			}), func(usage float64, at time.Time) {
 				streamingConnector.AddSimpleEvent(meterSlug, usage, at)
 			})

--- a/openmeter/credit/grant.go
+++ b/openmeter/credit/grant.go
@@ -49,7 +49,7 @@ func (m *connector) CreateGrant(ctx context.Context, ownerID models.NamespacedID
 		if err != nil {
 			return nil, err
 		}
-		granularity := owner.Meter.WindowSize.Duration()
+		granularity := time.Minute
 		input.EffectiveAt = input.EffectiveAt.Truncate(granularity)
 		if input.Recurrence != nil {
 			input.Recurrence.Anchor = input.Recurrence.Anchor.Truncate(granularity)

--- a/openmeter/credit/helper.go
+++ b/openmeter/credit/helper.go
@@ -124,7 +124,6 @@ func (m *connector) buildEngineForOwner(ctx context.Context, params buildEngineF
 	})
 
 	eng := engine.NewEngine(engine.EngineConfig{
-		Granularity: params.owner.Meter.WindowSize,
 		QueryUsage: func(ctx context.Context, from, to time.Time) (float64, error) {
 			ctx, span := m.Tracer.Start(
 				ctx,

--- a/openmeter/entitlement/metered/balance.go
+++ b/openmeter/entitlement/metered/balance.go
@@ -136,13 +136,13 @@ func (e *connector) GetEntitlementBalanceHistory(ctx context.Context, entitlemen
 	}
 
 	fullPeriodTruncated := timeutil.ClosedPeriod{
-		From: params.From.Truncate(owner.Meter.WindowSize.Duration()),
-		To:   params.To.Truncate(owner.Meter.WindowSize.Duration()),
+		From: params.From.Truncate(time.Minute),
+		To:   params.To.Truncate(time.Minute),
 	}
 
 	// If `to` time is not truncated to minute we assume to query until the next minute so fresh usage data shows up
 	if !params.To.Truncate(time.Minute).Equal(*params.To) {
-		fullPeriodTruncated.To = fullPeriodTruncated.To.Add(owner.Meter.WindowSize.Duration())
+		fullPeriodTruncated.To = fullPeriodTruncated.To.Add(time.Minute)
 	}
 
 	// 1. Let's query the windowed usage data

--- a/openmeter/entitlement/metered/balance.go
+++ b/openmeter/entitlement/metered/balance.go
@@ -135,6 +135,7 @@ func (e *connector) GetEntitlementBalanceHistory(ctx context.Context, entitlemen
 		return nil, engine.GrantBurnDownHistory{}, fmt.Errorf("failed to describe owner: %w", err)
 	}
 
+	// FIXME: remove truncation
 	fullPeriodTruncated := timeutil.ClosedPeriod{
 		From: params.From.Truncate(time.Minute),
 		To:   params.To.Truncate(time.Minute),

--- a/openmeter/entitlement/metered/lateevents_test.go
+++ b/openmeter/entitlement/metered/lateevents_test.go
@@ -110,7 +110,6 @@ func TestGetEntitlementBalanceConsistency(t *testing.T) {
 				},
 			},
 			Aggregation: meter.MeterAggregationSum,
-			WindowSize:  meter.WindowSizeMinute,
 			// These will be ignored in tests
 			EventType:     "test",
 			ValueProperty: convert.ToPointer("$.value"),

--- a/openmeter/meter/adapter/meter.go
+++ b/openmeter/meter/adapter/meter.go
@@ -131,6 +131,5 @@ func MapFromEntityFactory(entity *db.Meter) (meter.Meter, error) {
 		EventFrom:     entity.EventFrom,
 		ValueProperty: entity.ValueProperty,
 		GroupBy:       entity.GroupBy,
-		WindowSize:    meter.WindowSizeMinute,
 	}, nil
 }

--- a/openmeter/meter/meter.go
+++ b/openmeter/meter/meter.go
@@ -100,35 +100,6 @@ func (w WindowSize) Truncate(t time.Time) (time.Time, error) {
 	}
 }
 
-// Duration returns the duration of the window size
-// BEWARE: a day is NOT 24 hours
-func (w WindowSize) Duration() time.Duration {
-	var windowDuration time.Duration
-	switch w {
-	case WindowSizeMinute:
-		windowDuration = time.Minute
-	case WindowSizeHour:
-		windowDuration = time.Hour
-	case WindowSizeDay:
-		windowDuration = 24 * time.Hour
-	}
-
-	return windowDuration
-}
-
-func WindowSizeFromDuration(duration time.Duration) (WindowSize, error) {
-	switch duration.Minutes() {
-	case time.Minute.Minutes():
-		return WindowSizeMinute, nil
-	case time.Hour.Minutes():
-		return WindowSizeHour, nil
-	case 24 * time.Hour.Minutes():
-		return WindowSizeDay, nil
-	default:
-		return "", fmt.Errorf("invalid window size duration: %s", duration)
-	}
-}
-
 // OrderBy is the order by clause for features
 type OrderBy string
 
@@ -160,27 +131,6 @@ type Meter struct {
 	EventFrom     *time.Time
 	ValueProperty *string
 	GroupBy       map[string]string
-
-	// Deprecated, always set to MINUTE
-	WindowSize WindowSize
-}
-
-func (m *Meter) SupportsWindowSize(w *WindowSize) error {
-	// Ensure `from` and `to` aligns with query param window size if any
-	if w != nil {
-		// Ensure query param window size is not smaller than meter window size
-		switch m.WindowSize {
-		case WindowSizeHour:
-			if w != nil && *w == WindowSizeMinute {
-				return fmt.Errorf("cannot query meter with window size %s on window size %s", m.WindowSize, *w)
-			}
-		case WindowSizeDay:
-			if w != nil && (*w == WindowSizeMinute || *w == WindowSizeHour) {
-				return fmt.Errorf("cannot query meter with window size %s on window size %s", m.WindowSize, *w)
-			}
-		}
-	}
-	return nil
 }
 
 func (m1 Meter) Equal(m2 Meter) error {

--- a/openmeter/meter/meter_test.go
+++ b/openmeter/meter/meter_test.go
@@ -7,55 +7,9 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	"github.com/samber/lo"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/openmeterio/openmeter/pkg/models"
 )
-
-func TestWindowSizeFromDuration(t *testing.T) {
-	tests := []struct {
-		input time.Duration
-		want  WindowSize
-		error error
-	}{
-		{
-			input: time.Minute,
-			want:  WindowSizeMinute,
-			error: nil,
-		},
-		{
-			input: time.Hour,
-			want:  WindowSizeHour,
-			error: nil,
-		},
-		{
-			input: 24 * time.Hour,
-			want:  WindowSizeDay,
-			error: nil,
-		},
-		{
-			input: 2 * time.Minute,
-			want:  "",
-			error: fmt.Errorf("invalid window size duration: %s", 2*time.Minute),
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run("", func(t *testing.T) {
-			got, err := WindowSizeFromDuration(tt.input)
-			if err != nil {
-				if tt.error == nil {
-					t.Error(err)
-				}
-
-				assert.Equal(t, tt.error, err)
-			}
-
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
 
 func TestMeterValidation(t *testing.T) {
 	tests := []struct {

--- a/openmeter/meter/mockadapter/adapter.go
+++ b/openmeter/meter/mockadapter/adapter.go
@@ -14,10 +14,7 @@ func New(meters []meter.Meter) (*adapter, error) {
 
 	a.init()
 
-	for idx, m := range meters {
-		// Window size is deprecated, it's always minute
-		meters[idx].WindowSize = meter.WindowSizeMinute
-
+	for _, m := range meters {
 		if err := m.Validate(); err != nil {
 			return nil, models.NewGenericValidationError(
 				fmt.Errorf("failed to validate meter: %w", err),

--- a/openmeter/meter/mockadapter/manage.go
+++ b/openmeter/meter/mockadapter/manage.go
@@ -40,7 +40,6 @@ func (a manageAdapter) CreateMeter(ctx context.Context, input meterpkg.CreateMet
 		EventFrom:     input.EventFrom,
 		ValueProperty: input.ValueProperty,
 		GroupBy:       input.GroupBy,
-		WindowSize:    meterpkg.WindowSizeMinute,
 	}
 
 	a.adapter.meters = append(a.adapter.meters, meter)
@@ -76,7 +75,6 @@ func (a manageAdapter) UpdateMeter(ctx context.Context, input meterpkg.UpdateMet
 		Aggregation:   currentMeter.Aggregation,
 		EventType:     currentMeter.EventType,
 		ValueProperty: currentMeter.ValueProperty,
-		WindowSize:    currentMeter.WindowSize,
 		// Mutable fields
 		EventFrom: currentMeter.EventFrom,
 		GroupBy:   input.GroupBy,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Standardized all time truncation and granularity handling to use a fixed one-minute interval instead of variable window sizes throughout the application.
	- Simplified meter configuration by removing explicit window size settings and related conversion methods.
	- Updated test cases and helper methods to align with the new minute-based granularity.
	- Centralized conversion from window size enums to durations in streaming utilities.
- **Bug Fixes**
	- Prevented unintended overwriting of meter window size values during configuration and validation.
- **Tests**
	- Removed obsolete tests related to window size duration conversions and updated test setups to reflect the new approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->