### PR TITLE
fix: field name in validation error

### DIFF
--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -362,7 +362,7 @@ const ErrCodeAddonHasNoRateCards models.ErrorCode = "addon_has_no_rate_cards"
 var ErrAddonHasNoRateCards = models.NewValidationIssue(
 	ErrCodeAddonHasNoRateCards,
 	"add-on must have at least one rate card",
-	models.WithFieldString("ratecards"),
+	models.WithFieldString("rateCards"),
 	models.WithWarningSeverity(),
 )
 
@@ -485,7 +485,7 @@ const ErrCodePlanPhaseHasNoRateCards models.ErrorCode = "plan_phase_has_no_rate_
 var ErrPlanPhaseHasNoRateCards = models.NewValidationIssue(
 	ErrCodePlanPhaseHasNoRateCards,
 	"plan phase must have at least one rate card",
-	models.WithFieldString("ratecards"),
+	models.WithFieldString("rateCards"),
 	models.WithWarningSeverity(),
 )
 


### PR DESCRIPTION
## Overview

Fix `rateCards` field name used in valdiation errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated field names in validation messages to improve consistency in error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->