### PR TITLE
refactor: high watermark cache to filter framework

### DIFF
--- a/cmd/jobs/entitlement/recalculatesnapshots.go
+++ b/cmd/jobs/entitlement/recalculatesnapshots.go
@@ -1,6 +1,8 @@
 package entitlement
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 
 	"github.com/openmeterio/openmeter/cmd/jobs/internal"
@@ -22,7 +24,7 @@ func NewRecalculateBalanceSnapshotsCommand() *cobra.Command {
 				return err
 			}
 
-			return recalculator.Recalculate(cmd.Context(), "default")
+			return recalculator.Recalculate(cmd.Context(), "default", time.Now())
 		},
 	}
 }

--- a/openmeter/entitlement/balanceworker/entitlementhandler.go
+++ b/openmeter/entitlement/balanceworker/entitlementhandler.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/openmeterio/openmeter/openmeter/entitlement"
+	"github.com/openmeterio/openmeter/openmeter/entitlement/balanceworker/filters"
 	entitlementdriver "github.com/openmeterio/openmeter/openmeter/entitlement/driver"
 	"github.com/openmeterio/openmeter/openmeter/entitlement/snapshot"
 	"github.com/openmeterio/openmeter/openmeter/event/metadata"
@@ -33,6 +34,14 @@ type handleEntitlementEventOptions struct {
 	sourceOperation *snapshot.ValueOperationType
 
 	rawIngestedEvents []serializer.CloudEventsKafkaPayload
+}
+
+func (o *handleEntitlementEventOptions) Validate() error {
+	if o.eventAt.IsZero() {
+		return errors.New("eventAt is required")
+	}
+
+	return nil
 }
 
 type handleOption func(*handleEntitlementEventOptions)
@@ -71,48 +80,13 @@ func getOptions(opts ...handleOption) handleEntitlementEventOptions {
 	return options
 }
 
-type highWatermarkCacheAction string
-
-const (
-	recalculateAction highWatermarkCacheAction = "recalculate"
-	skipEventAction   highWatermarkCacheAction = "skipEvent"
-)
-
-func (w *Worker) checkHighWatermarkCache(ctx context.Context, entitlementID NamespacedID, opts handleEntitlementEventOptions) highWatermarkCacheAction {
-	// Always emit reset events
-	// TODO[later]: Only calculate if there's need for the explicit reset event
-	if lo.FromPtr(opts.sourceOperation) == snapshot.ValueOperationReset {
-		return recalculateAction
-	}
-
-	if entry, ok := w.highWatermarkCache.Get(entitlementID.ID); ok {
-		if entry.HighWatermark.After(opts.eventAt) || entry.IsDeleted {
-			if entry.IsDeleted {
-				w.metricHighWatermarkCacheStats.Add(ctx, 1, metric.WithAttributes(metricAttributeHighWatermarkCacheHitDeleted))
-			} else {
-				w.metricHighWatermarkCacheStats.Add(ctx, 1, metric.WithAttributes(metricAttributeHighWatermarkCacheHit))
-			}
-
-			return skipEventAction
-		}
-
-		w.metricHighWatermarkCacheStats.Add(ctx, 1, metric.WithAttributes(metricAttributeHighWatermarkCacheStale))
-	} else {
-		w.metricHighWatermarkCacheStats.Add(ctx, 1, metric.WithAttributes(metricAttributeHighWatermarkCacheMiss))
-	}
-
-	return recalculateAction
-}
-
-func (w *Worker) handleEntitlementEvent(ctx context.Context, entitlementID NamespacedID, options ...handleOption) (marshaler.Event, error) {
+func (w *Worker) handleEntitlementEvent(ctx context.Context, entitlementID pkgmodels.NamespacedID, options ...handleOption) (marshaler.Event, error) {
 	calculatedAt := time.Now()
 
 	opts := getOptions(options...)
 
-	if opts.eventAt.IsZero() {
-		// TODO: set to error when the queue has been flushed
-		w.opts.Logger.Warn("eventAt is zero, ignoring event", "entitlementID", entitlementID, "source", opts.source)
-		return nil, nil
+	if err := opts.Validate(); err != nil {
+		return nil, fmt.Errorf("handling entitlement event: %w", err)
 	}
 
 	inScope, err := w.filters.IsNamespaceInScope(ctx, entitlementID.Namespace)
@@ -120,12 +94,6 @@ func (w *Worker) handleEntitlementEvent(ctx context.Context, entitlementID Names
 		return nil, fmt.Errorf("failed to check if entitlement is in scope: %w", err)
 	}
 	if !inScope {
-		return nil, nil
-	}
-
-	action := w.checkHighWatermarkCache(ctx, entitlementID, opts)
-
-	if action == skipEventAction {
 		return nil, nil
 	}
 
@@ -148,7 +116,11 @@ func (w *Worker) handleEntitlementEvent(ctx context.Context, entitlementID Names
 
 	entitlementEntity := entitlements.Items[0]
 
-	inScope, err = w.filters.IsEntitlementInScope(ctx, entitlementEntity)
+	inScope, err = w.filters.IsEntitlementInScope(ctx, filters.EntitlementFilterRequest{
+		Entitlement: entitlementEntity,
+		EventAt:     opts.eventAt,
+		Operation:   lo.FromPtrOr(opts.sourceOperation, snapshot.ValueOperationUpdate),
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if entitlement is in scope: %w", err)
 	}
@@ -185,9 +157,10 @@ func (w *Worker) processEntitlementEntity(ctx context.Context, entitlementEntity
 			return nil, fmt.Errorf("failed to create entitlement delete snapshot event: %w", err)
 		}
 
-		_ = w.highWatermarkCache.Add(entitlementEntity.ID, highWatermarkCacheEntry{
-			HighWatermark: calculatedAt.Add(-defaultClockDrift),
-			IsDeleted:     true,
+		_ = w.filters.RecordLastCalculation(ctx, filters.RecordLastCalculationRequest{
+			Entitlement:  *entitlementEntity,
+			CalculatedAt: calculatedAt,
+			IsDeleted:    true,
 		})
 
 		return snapshot, nil
@@ -213,8 +186,9 @@ func (w *Worker) processEntitlementEntity(ctx context.Context, entitlementEntity
 		return nil, fmt.Errorf("failed to create entitlement update snapshot event: %w", err)
 	}
 
-	_ = w.highWatermarkCache.Add(entitlementEntity.ID, highWatermarkCacheEntry{
-		HighWatermark: calculatedAt.Add(-defaultClockDrift),
+	_ = w.filters.RecordLastCalculation(ctx, filters.RecordLastCalculationRequest{
+		Entitlement:  *entitlementEntity,
+		CalculatedAt: calculatedAt,
 	})
 
 	return snapshot, nil

--- a/openmeter/entitlement/balanceworker/filters/filter.go
+++ b/openmeter/entitlement/balanceworker/filters/filter.go
@@ -2,17 +2,61 @@ package filters
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
 	"github.com/openmeterio/openmeter/openmeter/entitlement"
+	"github.com/openmeterio/openmeter/openmeter/entitlement/snapshot"
 )
+
+type EntitlementFilterRequest struct {
+	Entitlement entitlement.Entitlement
+	EventAt     time.Time
+	Operation   snapshot.ValueOperationType
+}
+
+func (r EntitlementFilterRequest) Validate() error {
+	errs := []error{}
+
+	if r.Entitlement.ID == "" {
+		errs = append(errs, fmt.Errorf("id is required"))
+	}
+
+	if r.Entitlement.Namespace == "" {
+		errs = append(errs, fmt.Errorf("namespace is required"))
+	}
+
+	if err := r.Operation.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("operation: %w", err))
+	}
+
+	if r.EventAt.IsZero() {
+		errs = append(errs, fmt.Errorf("eventAt is required"))
+	}
+
+	return errors.Join(errs...)
+}
 
 type Filter interface {
 	IsNamespaceInScope(ctx context.Context, namespace string) (bool, error)
-	IsEntitlementInScope(ctx context.Context, entitlement entitlement.Entitlement) (bool, error)
+	IsEntitlementInScope(ctx context.Context, request EntitlementFilterRequest) (bool, error)
 }
 
 type NamedFilter interface {
 	Filter
 
 	Name() string
+}
+
+type RecordLastCalculationRequest struct {
+	Entitlement  entitlement.Entitlement
+	CalculatedAt time.Time
+	IsDeleted    bool
+}
+
+type CalculationTimeRecorder interface {
+	Filter
+
+	RecordLastCalculation(context.Context, RecordLastCalculationRequest) error
 }

--- a/openmeter/entitlement/balanceworker/filters/highwatermark.go
+++ b/openmeter/entitlement/balanceworker/filters/highwatermark.go
@@ -1,0 +1,87 @@
+package filters
+
+import (
+	"context"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/openmeterio/openmeter/openmeter/entitlement/snapshot"
+)
+
+const (
+
+	// defaultClockDrift specifies how much clock drift is allowed when calculating the current time between the worker nodes.
+	// with AWS, Google Cloud 1ms is guaranteed, this should work well for any NTP based setup.
+	defaultClockDrift = time.Millisecond
+)
+
+var (
+	_ NamedFilter             = (*HighWatermarkCacheInMemory)(nil)
+	_ CalculationTimeRecorder = (*HighWatermarkCacheInMemory)(nil)
+)
+
+type highWatermarkCacheEntry struct {
+	HighWatermark time.Time
+	IsDeleted     bool
+}
+
+type HighWatermarkCacheInMemory struct {
+	cache *lru.Cache[string, highWatermarkCacheEntry]
+}
+
+func NewHighWatermarkCacheInMemory(cacheSize int) (*HighWatermarkCacheInMemory, error) {
+	cache, err := lru.New[string, highWatermarkCacheEntry](cacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return &HighWatermarkCacheInMemory{cache: cache}, nil
+}
+
+func (f *HighWatermarkCacheInMemory) Name() string {
+	return "highwatermark-inmem"
+}
+
+func (f *HighWatermarkCacheInMemory) IsNamespaceInScope(ctx context.Context, namespace string) (bool, error) {
+	return true, nil
+}
+
+func (f *HighWatermarkCacheInMemory) IsEntitlementInScope(ctx context.Context, req EntitlementFilterRequest) (bool, error) {
+	if err := req.Validate(); err != nil {
+		return false, err
+	}
+
+	if req.Operation == snapshot.ValueOperationReset {
+		// Reset events are always in scope, so that notification has a fresh event for the new period
+		return true, nil
+	}
+
+	entry, ok := f.cache.Get(req.Entitlement.ID)
+	if !ok {
+		// Not found in cache => we consider it to be in scope
+		return true, nil
+	}
+
+	if entry.IsDeleted {
+		// Deleted entitlement => we consider it to be out of scope regardless of the high watermark
+		return false, nil
+	}
+
+	if req.EventAt.After(entry.HighWatermark.Add(-defaultClockDrift)) {
+		// Event is after the high watermark => we consider it to be in scope
+		return true, nil
+	}
+
+	// Event is before the high watermark => we consider it to be out of scope
+	return false, nil
+}
+
+func (f *HighWatermarkCacheInMemory) RecordLastCalculation(ctx context.Context, req RecordLastCalculationRequest) error {
+	f.cache.Add(req.Entitlement.ID, highWatermarkCacheEntry{
+		HighWatermark: req.CalculatedAt,
+		IsDeleted:     req.IsDeleted,
+	})
+
+	return nil
+}

--- a/openmeter/entitlement/balanceworker/filters/notifications.go
+++ b/openmeter/entitlement/balanceworker/filters/notifications.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/openmeterio/openmeter/openmeter/entitlement"
 	"github.com/openmeterio/openmeter/openmeter/notification"
 	"github.com/openmeterio/openmeter/pkg/lrux"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -77,8 +76,12 @@ func (f *NotificationsFilter) IsNamespaceInScope(ctx context.Context, namespace 
 	return len(rules) > 0, nil
 }
 
-func (f *NotificationsFilter) IsEntitlementInScope(ctx context.Context, ent entitlement.Entitlement) (bool, error) {
-	rules, err := f.ruleCache.Get(ctx, ent.Namespace)
+func (f *NotificationsFilter) IsEntitlementInScope(ctx context.Context, req EntitlementFilterRequest) (bool, error) {
+	if err := req.Validate(); err != nil {
+		return false, err
+	}
+
+	rules, err := f.ruleCache.Get(ctx, req.Entitlement.Namespace)
 	if err != nil {
 		return false, err
 	}
@@ -93,11 +96,11 @@ func (f *NotificationsFilter) IsEntitlementInScope(ctx context.Context, ent enti
 			return true, nil
 		}
 
-		if lo.Contains(rule.Config.BalanceThreshold.Features, ent.FeatureKey) {
+		if lo.Contains(rule.Config.BalanceThreshold.Features, req.Entitlement.FeatureKey) {
 			return true, nil
 		}
 
-		if lo.Contains(rule.Config.BalanceThreshold.Features, ent.FeatureID) {
+		if lo.Contains(rule.Config.BalanceThreshold.Features, req.Entitlement.FeatureID) {
 			return true, nil
 		}
 	}

--- a/openmeter/entitlement/balanceworker/ingesthandler.go
+++ b/openmeter/entitlement/balanceworker/ingesthandler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/event/metadata"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	ingestevents "github.com/openmeterio/openmeter/openmeter/sink/flushhandler/ingestnotification/events"
+	pkgmodels "github.com/openmeterio/openmeter/pkg/models"
 )
 
 func (w *Worker) handleBatchedIngestEvent(ctx context.Context, event ingestevents.EventBatchedIngest) error {
@@ -29,7 +30,7 @@ func (w *Worker) handleBatchedIngestEvent(ctx context.Context, event ingestevent
 	for _, entitlement := range affectedEntitlements {
 		event, err := w.handleEntitlementEvent(
 			ctx,
-			NamespacedID{Namespace: entitlement.Namespace, ID: entitlement.EntitlementID},
+			pkgmodels.NamespacedID{Namespace: entitlement.Namespace, ID: entitlement.EntitlementID},
 			WithSource(metadata.ComposeResourcePath(entitlement.Namespace, metadata.EntityEvent)),
 			WithEventAt(event.StoredAt),
 			WithRawIngestedEvents(event.RawEvents),
@@ -52,7 +53,7 @@ func (w *Worker) handleBatchedIngestEvent(ctx context.Context, event ingestevent
 	return handlingError
 }
 
-func (w *Worker) GetEntitlementsAffectedByMeterSubject(ctx context.Context, namespace string, meterSlugs []string, subject string) ([]NamespacedID, error) {
+func (w *Worker) GetEntitlementsAffectedByMeterSubject(ctx context.Context, namespace string, meterSlugs []string, subject string) ([]pkgmodels.NamespacedID, error) {
 	featuresByMeter, err := w.entitlement.Feature.ListFeatures(ctx, feature.ListFeaturesParams{
 		Namespace:  namespace,
 		MeterSlugs: meterSlugs,
@@ -75,9 +76,9 @@ func (w *Worker) GetEntitlementsAffectedByMeterSubject(ctx context.Context, name
 		return nil, err
 	}
 
-	entitlementIDs := make([]NamespacedID, 0, len(entitlements.Items))
+	entitlementIDs := make([]pkgmodels.NamespacedID, 0, len(entitlements.Items))
 	for _, entitlement := range entitlements.Items {
-		entitlementIDs = append(entitlementIDs, NamespacedID{
+		entitlementIDs = append(entitlementIDs, pkgmodels.NamespacedID{
 			ID:        entitlement.ID,
 			Namespace: entitlement.Namespace,
 		})


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Move the high watermark cache to filter framework. This *will* allows us to have a new redis based backend for the high watermark cache, which in turn would make sure that the recalculator job and the consumer shares high watermark cache state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a high watermark cache filter to improve entitlement event processing efficiency and prevent reprocessing of older events.
  - Centralized event timestamp validation and enhanced filtering with richer context for entitlement events.

- **Improvements**
  - Updated entitlement filtering and event handling to use structured requests that include event time and operation type, enabling more precise processing.
  - Consistent timestamping and recording of entitlement recalculation events for improved traceability.
  - Enhanced error handling and validation for entitlement event processing.

- **Refactor**
  - Removed legacy high watermark cache logic and replaced it with a more robust filtering-based approach.
  - Standardized type usage and updated function signatures for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->