### PR TITLE
feat(collector): include all kubernetes phase pods in run.ai result

### DIFF
--- a/collector/benthos/input/runai/pods.go
+++ b/collector/benthos/input/runai/pods.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"time"
-
-	"github.com/samber/lo"
 )
 
 type Pod struct {
@@ -95,12 +93,10 @@ func (s *Service) ListPods(ctx context.Context, params ListPodsParams) (*ListPod
 		return nil, fmt.Errorf("failed to list pods, status code: %d", resp.StatusCode())
 	}
 
-	result := resp.Result().(*ListPodsResponse)
-
-	// Filter out pods where phase is not "Running"
-	result.Pods = lo.Filter(result.Pods, func(p Pod, _ int) bool {
-		return p.K8sPhase == "Running"
-	})
+	result, ok := resp.Result().(*ListPodsResponse)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse list pods response")
+	}
 
 	j, err := json.Marshal(result)
 	if err == nil {

--- a/collector/benthos/input/runai/workloads.go
+++ b/collector/benthos/input/runai/workloads.go
@@ -118,7 +118,10 @@ func (s *Service) ListWorkloads(ctx context.Context, params ListWorkloadParams) 
 		return nil, fmt.Errorf("failed to list workloads, status code: %d", resp.StatusCode())
 	}
 
-	result := resp.Result().(*ListWorkloadsResponse)
+	result, ok := resp.Result().(*ListWorkloadsResponse)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse list workloads response")
+	}
 
 	// Filter out workloads where running pod count is 0
 	result.Workloads = lo.Filter(result.Workloads, func(w Workload, _ int) bool {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when retrieving workloads to prevent unexpected failures.
  - All pods are now included in the results without filtering by status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->