### PR TITLE
feat: redis high watermark cache

### DIFF
--- a/app/config/balanceworker.go
+++ b/app/config/balanceworker.go
@@ -2,14 +2,21 @@ package config
 
 import (
 	"errors"
+	"fmt"
+	"slices"
+	"time"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 
 	"github.com/openmeterio/openmeter/pkg/errorsx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/redis"
 )
 
 type BalanceWorkerConfiguration struct {
 	ConsumerConfiguration `mapstructure:",squash"`
+	StateStorage          BalanceWorkerStateStorageConfiguration
 }
 
 func (c BalanceWorkerConfiguration) Validate() error {
@@ -19,6 +26,127 @@ func (c BalanceWorkerConfiguration) Validate() error {
 		errs = append(errs, errorsx.WithPrefix(err, "consumer"))
 	}
 
+	if err := c.StateStorage.Validate(); err != nil {
+		errs = append(errs, errorsx.WithPrefix(err, "stateStorage"))
+	}
+
+	return errors.Join(errs...)
+}
+
+type BalanceWorkerStateStorageDriver string
+
+const (
+	BalanceWorkerStateStorageDriverRedis    BalanceWorkerStateStorageDriver = "redis"
+	BalanceWorkerStateStorageDriverInMemory BalanceWorkerStateStorageDriver = "in-memory"
+)
+
+type rawBalanceWorkerStateStorageConfiguration struct {
+	Driver BalanceWorkerStateStorageDriver
+	Config map[string]any
+}
+
+type BalanceWorkerStateStorageConfiguration struct {
+	Driver BalanceWorkerStateStorageDriver
+
+	BalanceWorkerStateStorageBackendConfiguration
+}
+
+func (c *BalanceWorkerStateStorageConfiguration) DecodeMap(v map[string]any) error {
+	var raw rawBalanceWorkerStateStorageConfiguration
+
+	if err := mapstructure.Decode(v, &raw); err != nil {
+		return err
+	}
+
+	c.Driver = raw.Driver
+
+	switch c.Driver {
+	case BalanceWorkerStateStorageDriverRedis:
+		var redisConfig BalanceWorkerStateStorageRedisBackendConfiguration
+
+		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			Metadata:         nil,
+			Result:           &redisConfig,
+			WeaklyTypedInput: true,
+			DecodeHook: mapstructure.ComposeDecodeHookFunc(
+				mapstructure.StringToTimeDurationHookFunc(),
+			),
+		})
+		if err != nil {
+			return err
+		}
+
+		if err := decoder.Decode(raw.Config); err != nil {
+			return err
+		}
+
+		c.BalanceWorkerStateStorageBackendConfiguration = redisConfig
+	case BalanceWorkerStateStorageDriverInMemory:
+		// no config
+	}
+
+	return nil
+}
+
+func (c BalanceWorkerStateStorageConfiguration) Validate() error {
+	errs := []error{}
+	if !slices.Contains([]BalanceWorkerStateStorageDriver{
+		BalanceWorkerStateStorageDriverRedis,
+		BalanceWorkerStateStorageDriverInMemory,
+	}, c.Driver) {
+		errs = append(errs, fmt.Errorf("invalid driver: %s", c.Driver))
+	}
+
+	if c.Driver == BalanceWorkerStateStorageDriverRedis {
+		if c.BalanceWorkerStateStorageBackendConfiguration == nil {
+			errs = append(errs, errors.New("state storage backend configuration is required"))
+		} else {
+			if err := c.BalanceWorkerStateStorageBackendConfiguration.Validate(); err != nil {
+				errs = append(errs, fmt.Errorf("state storage backend: %w", err))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (c BalanceWorkerStateStorageConfiguration) GetRedisBackendConfiguration() (BalanceWorkerStateStorageRedisBackendConfiguration, error) {
+	if c.Driver != BalanceWorkerStateStorageDriverRedis {
+		return BalanceWorkerStateStorageRedisBackendConfiguration{}, fmt.Errorf("driver is not redis")
+	}
+
+	if c.BalanceWorkerStateStorageBackendConfiguration == nil {
+		return BalanceWorkerStateStorageRedisBackendConfiguration{}, errors.New("state storage backend configuration is required")
+	}
+
+	redisConfig, ok := c.BalanceWorkerStateStorageBackendConfiguration.(BalanceWorkerStateStorageRedisBackendConfiguration)
+	if !ok {
+		return BalanceWorkerStateStorageRedisBackendConfiguration{}, fmt.Errorf("state storage backend configuration is not a redis configuration")
+	}
+
+	return redisConfig, nil
+}
+
+type BalanceWorkerStateStorageBackendConfiguration interface {
+	models.Validator
+}
+
+type BalanceWorkerStateStorageRedisBackendConfiguration struct {
+	redis.Config `mapstructure:",squash"`
+	Expiration   time.Duration
+}
+
+func (c BalanceWorkerStateStorageRedisBackendConfiguration) Validate() error {
+	errs := []error{}
+
+	if c.Expiration <= 0 {
+		errs = append(errs, errors.New("expiration should be greater than 0"))
+	}
+
+	if err := c.Config.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("redis: %w", err))
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -26,4 +154,7 @@ func ConfigureBalanceWorker(v *viper.Viper) {
 	ConfigureConsumer(v, "balanceWorker")
 	v.SetDefault("balanceWorker.dlq.topic", "om_sys.balance_worker_dlq")
 	v.SetDefault("balanceWorker.consumerGroupName", "om_balance_worker")
+
+	v.SetDefault("balanceWorker.stateStorage.driver", BalanceWorkerStateStorageDriverInMemory)
+	v.SetDefault("balanceWorker.stateStorage.config.expiration", 24*time.Hour)
 }

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -324,6 +324,15 @@ func TestComplete(t *testing.T) {
 				},
 				ConsumerGroupName: "om_balance_worker",
 			},
+			StateStorage: BalanceWorkerStateStorageConfiguration{
+				Driver: BalanceWorkerStateStorageDriverRedis,
+				BalanceWorkerStateStorageBackendConfiguration: BalanceWorkerStateStorageRedisBackendConfiguration{
+					Expiration: 23 * time.Hour,
+					Config: redis.Config{
+						Address: "127.0.0.1:6379",
+					},
+				},
+			},
 		},
 		Notification: NotificationConfiguration{
 			Consumer: ConsumerConfiguration{

--- a/app/config/testdata/complete.yaml
+++ b/app/config/testdata/complete.yaml
@@ -118,6 +118,13 @@ dedupe:
     tls:
       enabled: true
 
+balanceWorker:
+  stateStorage:
+    driver: redis
+    config:
+      expiration: 23h
+      address: 127.0.0.1:6379
+
 meters:
   - slug: m1
     eventType: api-calls

--- a/cmd/balance-worker/wire_gen.go
+++ b/cmd/balance-worker/wire_gen.go
@@ -255,7 +255,17 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	workerOptions := common.NewBalanceWorkerOptions(eventsConfiguration, options, eventbusPublisher, entitlement, balanceWorkerEntitlementRepo, notificationService, subjectService, logger)
+	filterStateStorage, err := common.NewBalanceWorkerFilterStateStorage(balanceWorkerConfiguration)
+	if err != nil {
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
+	workerOptions := common.NewBalanceWorkerOptions(eventsConfiguration, options, eventbusPublisher, entitlement, balanceWorkerEntitlementRepo, notificationService, subjectService, logger, filterStateStorage)
 	worker, err := common.NewBalanceWorker(workerOptions)
 	if err != nil {
 		cleanup6()

--- a/cmd/jobs/entitlement/recalculatesnapshots.go
+++ b/cmd/jobs/entitlement/recalculatesnapshots.go
@@ -14,11 +14,18 @@ func NewRecalculateBalanceSnapshotsCommand() *cobra.Command {
 		Use:   "recalculate-balance-snapshots",
 		Short: "Recalculate balance snapshots and send the resulting events into the eventbus",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			filterStateStorage, err := balanceworker.NewFilterStateStorage(balanceworker.FilterStateStorageInMemory{})
+			if err != nil {
+				return err
+			}
+
 			recalculator, err := balanceworker.NewRecalculator(balanceworker.RecalculatorOptions{
 				Entitlement:         internal.App.EntitlementRegistry,
 				EventBus:            internal.App.EventPublisher,
 				MetricMeter:         internal.App.Meter,
 				NotificationService: internal.App.NotificationService,
+				FilterStateStorage:  filterStateStorage,
+				Logger:              internal.App.Logger,
 			})
 			if err != nil {
 				return err

--- a/openmeter/entitlement/balanceworker/filters/highwatermark.go
+++ b/openmeter/entitlement/balanceworker/filters/highwatermark.go
@@ -2,52 +2,55 @@ package filters
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/openmeterio/openmeter/openmeter/entitlement/snapshot"
 )
 
 const (
-
 	// defaultClockDrift specifies how much clock drift is allowed when calculating the current time between the worker nodes.
 	// with AWS, Google Cloud 1ms is guaranteed, this should work well for any NTP based setup.
 	defaultClockDrift = time.Millisecond
 )
 
 var (
-	_ NamedFilter             = (*HighWatermarkCacheInMemory)(nil)
-	_ CalculationTimeRecorder = (*HighWatermarkCacheInMemory)(nil)
+	_ NamedFilter             = (*HighWatermarkCache)(nil)
+	_ CalculationTimeRecorder = (*HighWatermarkCache)(nil)
 )
 
 type highWatermarkCacheEntry struct {
-	HighWatermark time.Time
-	IsDeleted     bool
+	HighWatermark time.Time `json:"wm"`
+	IsDeleted     bool      `json:"del"`
 }
 
-type HighWatermarkCacheInMemory struct {
-	cache *lru.Cache[string, highWatermarkCacheEntry]
+type HighWatermarkCache struct {
+	backend HighWatermarkBackend
 }
 
-func NewHighWatermarkCacheInMemory(cacheSize int) (*HighWatermarkCacheInMemory, error) {
-	cache, err := lru.New[string, highWatermarkCacheEntry](cacheSize)
-	if err != nil {
-		return nil, err
+func NewHighWatermarkCache(backend HighWatermarkBackend) (*HighWatermarkCache, error) {
+	if backend == nil {
+		return nil, errors.New("backend is required")
 	}
 
-	return &HighWatermarkCacheInMemory{cache: cache}, nil
+	return &HighWatermarkCache{backend: backend}, nil
 }
 
-func (f *HighWatermarkCacheInMemory) Name() string {
-	return "highwatermark-inmem"
+func (f *HighWatermarkCache) Name() string {
+	return "highwatermark"
 }
 
-func (f *HighWatermarkCacheInMemory) IsNamespaceInScope(ctx context.Context, namespace string) (bool, error) {
+func (f *HighWatermarkCache) IsNamespaceInScope(ctx context.Context, namespace string) (bool, error) {
 	return true, nil
 }
 
-func (f *HighWatermarkCacheInMemory) IsEntitlementInScope(ctx context.Context, req EntitlementFilterRequest) (bool, error) {
+func (f *HighWatermarkCache) IsEntitlementInScope(ctx context.Context, req EntitlementFilterRequest) (bool, error) {
 	if err := req.Validate(); err != nil {
 		return false, err
 	}
@@ -57,8 +60,12 @@ func (f *HighWatermarkCacheInMemory) IsEntitlementInScope(ctx context.Context, r
 		return true, nil
 	}
 
-	entry, ok := f.cache.Get(req.Entitlement.ID)
-	if !ok {
+	entry, err := f.backend.Get(ctx, req.Entitlement.ID)
+	if err != nil {
+		return false, err
+	}
+
+	if !entry.IsPresent {
 		// Not found in cache => we consider it to be in scope
 		return true, nil
 	}
@@ -77,11 +84,188 @@ func (f *HighWatermarkCacheInMemory) IsEntitlementInScope(ctx context.Context, r
 	return false, nil
 }
 
-func (f *HighWatermarkCacheInMemory) RecordLastCalculation(ctx context.Context, req RecordLastCalculationRequest) error {
-	f.cache.Add(req.Entitlement.ID, highWatermarkCacheEntry{
+func (f *HighWatermarkCache) RecordLastCalculation(ctx context.Context, req RecordLastCalculationRequest) error {
+	return f.backend.Record(ctx, req)
+}
+
+// Backend interface
+
+type highWatermarkBackendGetResult struct {
+	highWatermarkCacheEntry
+	IsPresent bool
+}
+
+type HighWatermarkBackend interface {
+	Get(ctx context.Context, entitlementID string) (highWatermarkBackendGetResult, error)
+	Record(ctx context.Context, req RecordLastCalculationRequest) error
+}
+
+// In memory backend
+
+var _ HighWatermarkBackend = (*HighWatermarkInMemoryBackend)(nil)
+
+type HighWatermarkInMemoryBackend struct {
+	cache *lru.Cache[string, highWatermarkCacheEntry]
+}
+
+func NewHighWatermarkInMemoryBackend(cacheSize int) (*HighWatermarkInMemoryBackend, error) {
+	cache, err := lru.New[string, highWatermarkCacheEntry](cacheSize)
+	if err != nil {
+		return nil, err
+	}
+
+	return &HighWatermarkInMemoryBackend{cache: cache}, nil
+}
+
+func (b *HighWatermarkInMemoryBackend) Get(ctx context.Context, entitlementID string) (highWatermarkBackendGetResult, error) {
+	entry, ok := b.cache.Get(entitlementID)
+	if !ok {
+		return highWatermarkBackendGetResult{IsPresent: false}, nil
+	}
+
+	return highWatermarkBackendGetResult{IsPresent: true, highWatermarkCacheEntry: entry}, nil
+}
+
+func (b *HighWatermarkInMemoryBackend) Record(ctx context.Context, req RecordLastCalculationRequest) error {
+	b.cache.Add(req.Entitlement.ID, highWatermarkCacheEntry{
 		HighWatermark: req.CalculatedAt,
 		IsDeleted:     req.IsDeleted,
 	})
 
 	return nil
+}
+
+// Redis backend
+
+var _ HighWatermarkBackend = (*HighWatermarkRedisBackend)(nil)
+
+type HighWatermarkRedisBackendConfig struct {
+	Redis      *redis.Client
+	Logger     *slog.Logger
+	Expiration time.Duration
+}
+
+func (c HighWatermarkRedisBackendConfig) Validate() error {
+	if c.Redis == nil {
+		return errors.New("redis is required")
+	}
+
+	if c.Expiration <= 0 {
+		return errors.New("ttl must be greater than 0")
+	}
+
+	if c.Logger == nil {
+		return errors.New("logger is required")
+	}
+
+	return nil
+}
+
+type HighWatermarkRedisBackend struct {
+	HighWatermarkRedisBackendConfig
+}
+
+func NewHighWatermarkRedisBackend(cfg HighWatermarkRedisBackendConfig) (*HighWatermarkRedisBackend, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &HighWatermarkRedisBackend{
+		HighWatermarkRedisBackendConfig: cfg,
+	}, nil
+}
+
+func (b *HighWatermarkRedisBackend) getCacheKey(entitlementID string) string {
+	return fmt.Sprintf("hw.v1:%s", entitlementID)
+}
+
+func (b *HighWatermarkRedisBackend) Get(ctx context.Context, entitlementID string) (highWatermarkBackendGetResult, error) {
+	cacheKey := b.getCacheKey(entitlementID)
+
+	return b.getEntry(ctx, b.Redis, cacheKey)
+}
+
+func (b *HighWatermarkRedisBackend) getEntry(ctx context.Context, tx redis.Cmdable, cacheKey string) (highWatermarkBackendGetResult, error) {
+	highWatermark, err := tx.Get(ctx, cacheKey).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return highWatermarkBackendGetResult{IsPresent: false}, nil
+		}
+
+		return highWatermarkBackendGetResult{IsPresent: false}, err
+	}
+
+	entry := highWatermarkCacheEntry{}
+	if err := json.Unmarshal([]byte(highWatermark), &entry); err != nil {
+		return highWatermarkBackendGetResult{IsPresent: false}, err
+	}
+
+	return highWatermarkBackendGetResult{IsPresent: true, highWatermarkCacheEntry: entry}, nil
+}
+
+func (b *HighWatermarkRedisBackend) Record(ctx context.Context, req RecordLastCalculationRequest) error {
+	cacheKey := b.getCacheKey(req.Entitlement.ID)
+
+	// Let's start an optimistic lock on the cache key
+	err := b.Redis.Watch(ctx, func(tx *redis.Tx) error {
+		entry, err := b.getEntry(ctx, tx, cacheKey)
+		if err != nil {
+			return err
+		}
+
+		if !b.shouldUpdateCacheEntry(entry, req) {
+			return nil
+		}
+
+		newEntry := highWatermarkCacheEntry{
+			HighWatermark: req.CalculatedAt,
+			IsDeleted:     req.IsDeleted,
+		}
+
+		json, err := json.Marshal(newEntry)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+			return pipe.SetEx(ctx, cacheKey, string(json), b.Expiration).Err()
+		})
+
+		return err
+	}, cacheKey)
+
+	// Redis uses optimistic locking, so in case there are multiple updates happening in parallel, one will succeed
+	// others will fail with a TxFailedErr. (and could retry)
+	//
+	// We are just ignoring the TxFailedErr as in such cases we have a recent highwatermark cache entry either ways
+	if errors.Is(err, redis.TxFailedErr) {
+		b.Logger.Info("high watermark cache update skipped due to parallel updates", "entry.key", cacheKey, "entry.highwatermark", req.CalculatedAt, "entry.isdeleted", req.IsDeleted)
+		return nil
+	}
+
+	return err
+}
+
+func (b *HighWatermarkRedisBackend) shouldUpdateCacheEntry(existing highWatermarkBackendGetResult, req RecordLastCalculationRequest) bool {
+	// Entry is missing => we should add it to redis
+	if !existing.IsPresent {
+		return true
+	}
+
+	// Entitlement deletion status changed => we should update the cache
+	if req.IsDeleted != existing.IsDeleted {
+		return true
+	}
+
+	// The entitlement is deleted in the cache => we should just keep it that way
+	if existing.IsDeleted {
+		return false
+	}
+
+	// The new watermark is after the existing watermark => we should update the cache
+	if req.CalculatedAt.After(existing.HighWatermark) {
+		return true
+	}
+
+	return false
 }

--- a/openmeter/entitlement/balanceworker/filterstate.go
+++ b/openmeter/entitlement/balanceworker/filterstate.go
@@ -1,0 +1,107 @@
+package balanceworker
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type FilterStateStorageDriver string
+
+const (
+	FilterStateStorageDriverRedis    FilterStateStorageDriver = "redis"
+	FilterStateStorageDriverInMemory FilterStateStorageDriver = "in-memory"
+)
+
+var _ models.Validator = (*FilterStateStorage)(nil)
+
+type FilterStateStorage struct {
+	driver FilterStateStorageDriver
+	redis  *FilterStateStorageRedis
+}
+
+func NewFilterStateStorage[T FilterStateStorageRedis | FilterStateStorageInMemory](storage T) (FilterStateStorage, error) {
+	switch driver := any(storage).(type) {
+	case FilterStateStorageRedis:
+		if err := driver.Validate(); err != nil {
+			return FilterStateStorage{}, fmt.Errorf("redis: %w", err)
+		}
+
+		return FilterStateStorage{driver: FilterStateStorageDriverRedis, redis: &driver}, nil
+	case FilterStateStorageInMemory:
+		if err := driver.Validate(); err != nil {
+			return FilterStateStorage{}, fmt.Errorf("in-memory: %w", err)
+		}
+
+		return FilterStateStorage{driver: FilterStateStorageDriverInMemory}, nil
+	}
+
+	return FilterStateStorage{}, fmt.Errorf("unsupported driver: %T", storage)
+}
+
+func (c FilterStateStorage) Validate() error {
+	var errs []error
+
+	if c.driver == "" {
+		errs = append(errs, errors.New("driver is required"))
+	}
+
+	if c.driver == FilterStateStorageDriverRedis {
+		if c.redis == nil {
+			errs = append(errs, errors.New("redis is required"))
+		} else {
+			if err := c.redis.Validate(); err != nil {
+				errs = append(errs, fmt.Errorf("redis: %w", err))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (c FilterStateStorage) Driver() FilterStateStorageDriver {
+	return c.driver
+}
+
+func (c FilterStateStorage) Redis() (FilterStateStorageRedis, error) {
+	if c.driver != FilterStateStorageDriverRedis {
+		return FilterStateStorageRedis{}, fmt.Errorf("driver is not redis")
+	}
+
+	if c.redis == nil {
+		return FilterStateStorageRedis{}, fmt.Errorf("redis is not initialized")
+	}
+
+	return *c.redis, nil
+}
+
+type FilterStateStorageRedis struct {
+	Client     *redis.Client
+	Expiration time.Duration
+}
+
+var _ models.Validator = (*FilterStateStorageRedis)(nil)
+
+func (c FilterStateStorageRedis) Validate() error {
+	if c.Client == nil {
+		return errors.New("client is required")
+	}
+
+	if c.Expiration <= 0 {
+		return errors.New("expiration must be greater than 0")
+	}
+
+	return nil
+}
+
+type FilterStateStorageInMemory struct{}
+
+var _ models.Validator = (*FilterStateStorageInMemory)(nil)
+
+func (c FilterStateStorageInMemory) Validate() error {
+	return nil
+}

--- a/openmeter/entitlement/balanceworker/worker.go
+++ b/openmeter/entitlement/balanceworker/worker.go
@@ -49,6 +49,8 @@ type WorkerOptions struct {
 	MetricMeter metric.Meter
 
 	Logger *slog.Logger
+
+	FilterStateStorage FilterStateStorage
 }
 
 func (o *WorkerOptions) Validate() error {
@@ -82,6 +84,10 @@ func (o *WorkerOptions) Validate() error {
 
 	if o.NotificationService == nil {
 		return errors.New("notification service is required")
+	}
+
+	if err := o.FilterStateStorage.Validate(); err != nil {
+		return fmt.Errorf("filter state storage: %w", err)
 	}
 
 	return nil
@@ -123,6 +129,8 @@ func New(opts WorkerOptions) (*Worker, error) {
 	filters, err := NewEntitlementFilters(EntitlementFiltersConfig{
 		NotificationService: opts.NotificationService,
 		MetricMeter:         opts.MetricMeter,
+		StateStorage:        opts.FilterStateStorage,
+		Logger:              opts.Logger,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create entitlement filters: %w", err)


### PR DESCRIPTION
This patch adds support for using redis as a shared cache on for balance-worker pool, for high watermark cache entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable filter state storage for balance worker and entitlement recalculation, supporting both Redis and in-memory backends.
  * Introduced backend selection for high watermark cache, allowing use of Redis or in-memory storage.
  * Enhanced configuration options to specify state storage driver and settings.
  * Improved validation and error reporting for configuration and initialization.

* **Bug Fixes**
  * Improved validation logic now accumulates and reports multiple configuration errors at once.

* **Tests**
  * Updated test configurations to cover new state storage options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->