### PR TITLE
fix: invoice list containing lines

### DIFF
--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -127,6 +127,9 @@ func (s *Service) recalculateGatheringInvoice(ctx context.Context, in recalculat
 		lines, err := s.adapter.ListInvoiceLines(ctx, billing.ListInvoiceLinesAdapterInput{
 			Namespace:  invoice.Namespace,
 			InvoiceIDs: []string{invoice.ID},
+			Statuses: []billing.InvoiceLineStatus{
+				billing.InvoiceLineStatusValid,
+			},
 		})
 		if err != nil {
 			return invoice, fmt.Errorf("loading lines: %w", err)


### PR DESCRIPTION
We should only include the valid lines in the invoice calculations.