### PR TITLE
refactor(meter): reduce cross dependencies

### DIFF
--- a/app/common/meter.go
+++ b/app/common/meter.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/meter/adapter"
 	"github.com/openmeterio/openmeter/openmeter/meter/service"
 	"github.com/openmeterio/openmeter/openmeter/namespace"
-	"github.com/openmeterio/openmeter/openmeter/registry"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 )
@@ -48,7 +47,6 @@ func NewMeterService(
 func NewMeterManageService(
 	ctx context.Context,
 	meterAdapter *adapter.Adapter,
-	entitlementRegistry *registry.Entitlement,
 	namespaceManager *namespace.Manager,
 	streamingConnector streaming.Connector,
 	publisher eventbus.Publisher,
@@ -56,8 +54,6 @@ func NewMeterManageService(
 	return service.NewManage(
 		meterAdapter,
 		publisher,
-		entitlementRegistry.EntitlementRepo,
-		entitlementRegistry.FeatureRepo,
 		namespaceManager,
 		streamingConnector,
 	)

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -404,7 +404,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	v3 := conf.Meters
-	manageService := common.NewMeterManageService(ctx, adapter, entitlement, manager, connector, eventbusPublisher)
+	manageService := common.NewMeterManageService(ctx, adapter, manager, connector, eventbusPublisher)
 	v4 := common.NewMeterConfigInitializer(logger, v3, manageService, manager)
 	metereventService := common.NewMeterEventService(connector, service)
 	repository, err := common.NewNotificationAdapter(logger, client)

--- a/openmeter/productcatalog/adapter/feature.go
+++ b/openmeter/productcatalog/adapter/feature.go
@@ -55,7 +55,7 @@ func (c *featureDBAdapter) CreateFeature(ctx context.Context, feat feature.Creat
 		return feature.Feature{}, err
 	}
 
-	return mapFeatureEntity(entity), nil
+	return MapFeatureEntity(entity), nil
 }
 
 func (c *featureDBAdapter) GetByIdOrKey(ctx context.Context, namespace string, idOrKey string, includeArchived bool) (*feature.Feature, error) {
@@ -79,7 +79,7 @@ func (c *featureDBAdapter) GetByIdOrKey(ctx context.Context, namespace string, i
 		return nil, &feature.FeatureNotFoundError{ID: idOrKey}
 	}
 
-	res := mapFeatureEntity(entities[0])
+	res := MapFeatureEntity(entities[0])
 
 	return &res, nil
 }
@@ -215,7 +215,7 @@ func (c *featureDBAdapter) ListFeatures(ctx context.Context, params feature.List
 
 		mapped := make([]feature.Feature, 0, len(entities))
 		for _, entity := range entities {
-			mapped = append(mapped, mapFeatureEntity(entity))
+			mapped = append(mapped, MapFeatureEntity(entity))
 		}
 
 		response.Items = mapped
@@ -229,8 +229,8 @@ func (c *featureDBAdapter) ListFeatures(ctx context.Context, params feature.List
 
 	list := make([]feature.Feature, 0, len(paged.Items))
 	for _, entity := range paged.Items {
-		feature := mapFeatureEntity(entity)
-		list = append(list, feature)
+		f := MapFeatureEntity(entity)
+		list = append(list, f)
 	}
 
 	response.Items = list
@@ -240,8 +240,8 @@ func (c *featureDBAdapter) ListFeatures(ctx context.Context, params feature.List
 }
 
 // mapFeatureEntity maps a database feature entity to a feature model.
-func mapFeatureEntity(entity *db.Feature) feature.Feature {
-	feature := feature.Feature{
+func MapFeatureEntity(entity *db.Feature) feature.Feature {
+	f := feature.Feature{
 		ID:         entity.ID,
 		Namespace:  entity.Namespace,
 		Name:       entity.Name,
@@ -254,8 +254,8 @@ func mapFeatureEntity(entity *db.Feature) feature.Feature {
 	}
 
 	if len(entity.MeterGroupByFilters) > 0 {
-		feature.MeterGroupByFilters = entity.MeterGroupByFilters
+		f.MeterGroupByFilters = entity.MeterGroupByFilters
 	}
 
-	return feature
+	return f
 }


### PR DESCRIPTION
## Overview

Remove dependency on `feature` and `entitlement` repositories by extending `meter` repository to support lookups for entities depending on meters through `ent`.

It is not ideal to use the db layer for resolving external (to `meter` service) entities due to the lack of having hard referencies between those, however this could hepl with reducing the cross dependencies between services/repositories until we are able to permanently fix references in the db layer. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added methods to check for active features and entitlements associated with a meter, and to list features for a meter.

* **Refactor**
  * Updated service logic to use new adapter methods for feature and entitlement checks, improving clarity in error messages.
  * Renamed a feature mapping function for consistency and broader accessibility.

* **Chores**
  * Removed unused entitlement-related parameters and dependencies from service initialization and internal logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->