### PR TITLE
refactor(streaming): rm meter management

### DIFF
--- a/app/common/meter.go
+++ b/app/common/meter.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/meter/adapter"
 	"github.com/openmeterio/openmeter/openmeter/meter/service"
 	"github.com/openmeterio/openmeter/openmeter/namespace"
-	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 )
 
@@ -45,17 +44,14 @@ func NewMeterService(
 }
 
 func NewMeterManageService(
-	ctx context.Context,
 	meterAdapter *adapter.Adapter,
 	namespaceManager *namespace.Manager,
-	streamingConnector streaming.Connector,
 	publisher eventbus.Publisher,
 ) meter.ManageService {
 	return service.NewManage(
 		meterAdapter,
 		publisher,
 		namespaceManager,
-		streamingConnector,
 	)
 }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -203,15 +203,6 @@ func main() {
 		})
 	})
 
-	for _, meter := range conf.Meters {
-		err := app.StreamingConnector.CreateMeter(ctx, app.NamespaceManager.GetDefaultNamespace(), *meter)
-		if err != nil {
-			logger.Warn("failed to initialize meter", "error", err)
-			os.Exit(1)
-		}
-	}
-	logger.Info("meters successfully created", "count", len(conf.Meters))
-
 	var group run.Group
 
 	// Set up telemetry server

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -404,7 +404,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	v3 := conf.Meters
-	manageService := common.NewMeterManageService(ctx, adapter, manager, connector, eventbusPublisher)
+	manageService := common.NewMeterManageService(adapter, manager, eventbusPublisher)
 	v4 := common.NewMeterConfigInitializer(logger, v3, manageService, manager)
 	metereventService := common.NewMeterEventService(connector, service)
 	repository, err := common.NewNotificationAdapter(logger, client)

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -635,18 +635,6 @@ func (c *MockStreamingConnector) ListEventsV2(ctx context.Context, params metere
 	return events, nil
 }
 
-func (c *MockStreamingConnector) CreateMeter(ctx context.Context, namespace string, meter meter.Meter) error {
-	return nil
-}
-
-func (c *MockStreamingConnector) UpdateMeter(ctx context.Context, namespace string, meter meter.Meter) error {
-	return nil
-}
-
-func (c *MockStreamingConnector) DeleteMeter(ctx context.Context, namespace string, meter meter.Meter) error {
-	return nil
-}
-
 func (c *MockStreamingConnector) QueryMeter(ctx context.Context, namespace string, m meter.Meter, params streaming.QueryParams) ([]meter.MeterQueryRow, error) {
 	value := mockQueryValue
 

--- a/openmeter/streaming/clickhouse/connector.go
+++ b/openmeter/streaming/clickhouse/connector.go
@@ -127,21 +127,6 @@ func (c *Connector) ListEventsV2(ctx context.Context, params meterevent.ListEven
 	return events, nil
 }
 
-func (c *Connector) CreateMeter(ctx context.Context, namespace string, meter meterpkg.Meter) error {
-	// Do nothing
-	return nil
-}
-
-func (c *Connector) UpdateMeter(ctx context.Context, namespace string, meter meterpkg.Meter) error {
-	// Do nothing
-	return nil
-}
-
-func (c *Connector) DeleteMeter(ctx context.Context, namespace string, meter meterpkg.Meter) error {
-	// Do nothing
-	return nil
-}
-
 func (c *Connector) QueryMeter(ctx context.Context, namespace string, meter meterpkg.Meter, params streaming.QueryParams) ([]meterpkg.MeterQueryRow, error) {
 	// Validate params
 	if namespace == "" {

--- a/openmeter/streaming/connector.go
+++ b/openmeter/streaming/connector.go
@@ -41,9 +41,6 @@ type Connector interface {
 	CountEvents(ctx context.Context, namespace string, params CountEventsParams) ([]CountEventRow, error)
 	ListEvents(ctx context.Context, namespace string, params meterevent.ListEventsParams) ([]RawEvent, error)
 	ListEventsV2(ctx context.Context, params meterevent.ListEventsV2Params) ([]RawEvent, error)
-	CreateMeter(ctx context.Context, namespace string, meter meter.Meter) error
-	UpdateMeter(ctx context.Context, namespace string, meter meter.Meter) error
-	DeleteMeter(ctx context.Context, namespace string, meter meter.Meter) error
 	QueryMeter(ctx context.Context, namespace string, meter meter.Meter, params QueryParams) ([]meter.MeterQueryRow, error)
 	ListMeterSubjects(ctx context.Context, namespace string, meter meter.Meter, params ListMeterSubjectsParams) ([]string, error)
 	BatchInsert(ctx context.Context, events []RawEvent) error

--- a/openmeter/streaming/testutils/streaming.go
+++ b/openmeter/streaming/testutils/streaming.go
@@ -78,18 +78,6 @@ func (m *MockStreamingConnector) ListEventsV2(ctx context.Context, params metere
 	return []streaming.RawEvent{}, nil
 }
 
-func (m *MockStreamingConnector) CreateMeter(ctx context.Context, namespace string, meter meter.Meter) error {
-	return nil
-}
-
-func (m *MockStreamingConnector) UpdateMeter(ctx context.Context, namespace string, meter meter.Meter) error {
-	return nil
-}
-
-func (m *MockStreamingConnector) DeleteMeter(ctx context.Context, namespace string, meter meter.Meter) error {
-	return nil
-}
-
 // Returns the result query set for the given params. If the query set is not found,
 // it will try to approximate the result by aggregating the simple events
 func (m *MockStreamingConnector) QueryMeter(ctx context.Context, namespace string, mm meter.Meter, params streaming.QueryParams) ([]meter.MeterQueryRow, error) {


### PR DESCRIPTION
## Overview

Remove `meter` management from `streaming` as it became unused since meters are not backed by materialized view tables in Clickhouse anymore.
