### PR TITLE
fix: make sure that split lines are expanded for line service

### DIFF
--- a/openmeter/billing/service/lineservice/linebase.go
+++ b/openmeter/billing/service/lineservice/linebase.go
@@ -106,15 +106,18 @@ func (l lineBase) Validate(ctx context.Context, invoice *billing.Invoice) error 
 		}
 	}
 
+	// Expanding the split lines are mandatory for the lineservice to work properly.
+	if l.line.SplitLineGroupID != nil && l.line.SplitLineHierarchy == nil {
+		return billing.ValidationError{
+			Err: fmt.Errorf("split line group[%s] has no hierarchy expanded hierarchy", *l.line.SplitLineGroupID),
+		}
+	}
+
 	return nil
 }
 
 func (l lineBase) IsLastInPeriod() bool {
 	if l.line.SplitLineGroupID == nil {
-		return true
-	}
-
-	if l.line.SplitLineHierarchy == nil {
 		return true
 	}
 
@@ -127,10 +130,6 @@ func (l lineBase) IsLastInPeriod() bool {
 
 func (l lineBase) IsFirstInPeriod() bool {
 	if l.line.SplitLineGroupID == nil {
-		return true
-	}
-
-	if l.line.SplitLineHierarchy == nil {
 		return true
 	}
 


### PR DESCRIPTION
## Overview

This changes https://github.com/openmeterio/openmeter/pull/2990 so that we are not missreporting the start/end of the period in case the hierarchy is not expanded, instead we are making sure that we are returning an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to ensure lines in a split line group have the required split line hierarchy.
  * Adjusted logic for determining first and last lines in a period to be more accurate for split line groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->