### PR TITLE
chore: allow setting postgres settings by field

### DIFF
--- a/app/common/database.go
+++ b/app/common/database.go
@@ -49,7 +49,7 @@ func (m Migrator) Migrate(ctx context.Context) error {
 			return fmt.Errorf("failed to migrate db: %w", err)
 		}
 	case config.AutoMigrateMigration:
-		if err := migrate.Up(m.Config.URL); err != nil {
+		if err := migrate.Up(m.Config.AsURL()); err != nil {
 			return fmt.Errorf("failed to migrate db: %w", err)
 		}
 	}
@@ -69,7 +69,7 @@ func NewPostgresDriver(
 ) (*pgdriver.Driver, func(), error) {
 	driver, err := pgdriver.NewPostgresDriver(
 		ctx,
-		conf.URL,
+		conf.AsURL(),
 		pgdriver.WithMetricMeter(meter),
 		pgdriver.WithTracerProvider(tracerProvider),
 		pgdriver.WithMeterProvider(meterProvider),

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"log/slog"
+	"os"
 	"testing"
 	"time"
 
@@ -24,6 +25,15 @@ import (
 
 func TestComplete(t *testing.T) {
 	v, flags := viper.New(), pflag.NewFlagSet("OpenMeter", pflag.ExitOnError)
+
+	// Messes with vscode defaults
+	val, set := os.LookupEnv("POSTGRES_HOST")
+	os.Unsetenv("POSTGRES_HOST")
+	defer func() {
+		if set {
+			os.Setenv("POSTGRES_HOST", val)
+		}
+	}()
 
 	SetViperDefaults(v, flags)
 

--- a/app/config/postgres.go
+++ b/app/config/postgres.go
@@ -53,6 +53,14 @@ func (c PostgresConfig) AsURL() string {
 func ConfigurePostgres(v *viper.Viper) {
 	v.SetDefault("postgres.url", "")
 	v.SetDefault("postgres.autoMigrate", "ent")
+
+	v.SetDefault("postgres.options.poolMaxConns", 0)
+	v.SetDefault("postgres.options.applicationName", "openmeter")
+	v.SetDefault("postgres.host", "")
+	v.SetDefault("postgres.port", 0)
+	v.SetDefault("postgres.database", "")
+	v.SetDefault("postgres.user", "")
+	v.SetDefault("postgres.password", "")
 }
 
 type AutoMigrate string

--- a/app/config/postgres.go
+++ b/app/config/postgres.go
@@ -2,13 +2,21 @@ package config
 
 import (
 	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
 
+	"github.com/samber/lo"
 	"github.com/spf13/viper"
 )
 
 type PostgresConfig struct {
+	// PostgresConnectionParams is the PostgreSQL connection parameters, URL and PostgresConnectionParams are mutually exclusive.
+	PostgresConnectionParams `mapstructure:",squash"`
+
 	// URL is the PostgreSQL database connection URL.
 	URL string `yaml:"url"`
+
 	// AutoMigrate is a flag that indicates whether the database should be automatically migrated.
 	// Supported values are:
 	// - "false" to disable auto-migration at startup
@@ -20,9 +28,12 @@ type PostgresConfig struct {
 // Validate validates the configuration.
 func (c PostgresConfig) Validate() error {
 	var errs []error
+	if c.URL == "" && c.PostgresConnectionParams.IsEmpty() {
+		errs = append(errs, errors.New("database URL or connection params are required"))
+	}
 
-	if c.URL == "" {
-		errs = append(errs, errors.New("database URL is required"))
+	if c.URL != "" && !c.PostgresConnectionParams.IsEmpty() {
+		errs = append(errs, errors.New("database URL and connection params are mutually exclusive"))
 	}
 
 	if err := c.AutoMigrate.Validate(); err != nil {
@@ -30,6 +41,13 @@ func (c PostgresConfig) Validate() error {
 	}
 
 	return errors.Join(errs...)
+}
+
+func (c PostgresConfig) AsURL() string {
+	if c.URL != "" {
+		return c.URL
+	}
+	return c.PostgresConnectionParams.AsURL()
 }
 
 func ConfigurePostgres(v *viper.Viper) {
@@ -57,4 +75,82 @@ func (a AutoMigrate) Validate() error {
 	default:
 		return errors.New("invalid auto-migrate value")
 	}
+}
+
+type PostgresConnectionParams struct {
+	Host     string `yaml:"host"`
+	Port     uint16 `yaml:"port"`
+	Database string `yaml:"database"`
+	User     string `yaml:"user"`
+	Password string `yaml:"password"`
+
+	Options PostgresConnectionOptions `yaml:"options"`
+}
+
+func (c PostgresConnectionParams) Validate() error {
+	var errs []error
+
+	if c.Host == "" {
+		errs = append(errs, errors.New("host is required"))
+	}
+
+	if c.Database == "" {
+		errs = append(errs, errors.New("database is required"))
+	}
+
+	if c.User == "" {
+		errs = append(errs, errors.New("user is required"))
+	}
+
+	if err := c.Options.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
+}
+
+func (c PostgresConnectionParams) IsEmpty() bool {
+	return lo.IsEmpty(c)
+}
+
+func (c PostgresConnectionParams) AsURL() string {
+	host := c.Host
+	if c.Port != 0 {
+		host = fmt.Sprintf("%s:%d", c.Host, c.Port)
+	}
+
+	runtimeParams := make(url.Values)
+
+	if c.Options.ApplicationName != "" {
+		runtimeParams.Set("application_name", c.Options.ApplicationName)
+	}
+
+	if c.Options.PoolMaxConns != 0 {
+		runtimeParams.Set("pool_max_conns", strconv.Itoa(c.Options.PoolMaxConns))
+	}
+
+	url := url.URL{
+		Scheme:   "postgresql",
+		User:     url.UserPassword(c.User, c.Password),
+		Host:     host,
+		Path:     c.Database,
+		RawQuery: runtimeParams.Encode(),
+	}
+
+	return url.String()
+}
+
+type PostgresConnectionOptions struct {
+	PoolMaxConns    int    `yaml:"poolMaxConns"`
+	ApplicationName string `yaml:"applicationName"`
+}
+
+func (c PostgresConnectionOptions) Validate() error {
+	var errs []error
+
+	if c.PoolMaxConns < 0 {
+		errs = append(errs, errors.New("poolMaxConns must be greater than 0"))
+	}
+
+	return errors.Join(errs...)
 }

--- a/app/config/postgres.go
+++ b/app/config/postgres.go
@@ -55,7 +55,7 @@ func ConfigurePostgres(v *viper.Viper) {
 	v.SetDefault("postgres.autoMigrate", "ent")
 
 	v.SetDefault("postgres.options.poolMaxConns", 0)
-	v.SetDefault("postgres.options.applicationName", "openmeter")
+	v.SetDefault("postgres.options.applicationName", "")
 	v.SetDefault("postgres.host", "")
 	v.SetDefault("postgres.port", 0)
 	v.SetDefault("postgres.database", "")


### PR DESCRIPTION
In case somebody wants to override config by environment variable field by field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring PostgreSQL connections using either a full URL or individual connection parameters (host, port, database, user, password, and options).
  * Enhanced validation to ensure only one connection method is used and required fields are provided.

* **Bug Fixes**
  * Improved error handling for invalid or incomplete PostgreSQL configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->