### PR TITLE
fix: NoAccessValue in entitlements

### DIFF
--- a/openmeter/customer/service/customer.go
+++ b/openmeter/customer/service/customer.go
@@ -123,7 +123,7 @@ func (s *Service) GetEntitlementValue(ctx context.Context, input customer.GetEnt
 	val, err := s.entitlementConnector.GetEntitlementValue(ctx, input.CustomerID.Namespace, subjectKey, input.FeatureKey, clock.Now())
 	if err != nil {
 		if _, ok := lo.ErrorsAs[*entitlement.NotFoundError](err); ok {
-			return entitlement.NoAccessValue{}, nil
+			return &entitlement.NoAccessValue{}, nil
 		}
 
 		return nil, err

--- a/openmeter/entitlement/entitlement_types.go
+++ b/openmeter/entitlement/entitlement_types.go
@@ -11,9 +11,11 @@ type EntitlementValue interface {
 	HasAccess() bool
 }
 
+var _ EntitlementValue = (*NoAccessValue)(nil)
+
 type NoAccessValue struct{}
 
-func (NoAccessValue) HasAccess() bool {
+func (*NoAccessValue) HasAccess() bool {
 	return false
 }
 


### PR DESCRIPTION
## Overview

Ensure the types implements `EntitlementValue` interface on pointer receiver in order to avoid breaking type matching (resulting _unknown entitlement type_ errors)([here](https://github.com/openmeterio/openmeter/blob/07667be6a44a6a878c5e53864e1a970cc57eb3b8/openmeter/entitlement/driver/parser.go#L178)) which expects pointer types.
