### PR TITLE
feat(billing): ignore sync annotation

### DIFF
--- a/openmeter/billing/adapter/invoicelinemapper.go
+++ b/openmeter/billing/adapter/invoicelinemapper.go
@@ -137,10 +137,11 @@ func (a *adapter) mapInvoiceLineWithoutReferences(dbLine *db.BillingInvoiceLine)
 			UpdatedAt: dbLine.UpdatedAt.In(time.UTC),
 			DeletedAt: convert.TimePtrIn(dbLine.DeletedAt, time.UTC),
 
-			Metadata:  dbLine.Metadata,
-			InvoiceID: dbLine.InvoiceID,
-			Status:    dbLine.Status,
-			ManagedBy: dbLine.ManagedBy,
+			Metadata:    dbLine.Metadata,
+			Annotations: dbLine.Annotations,
+			InvoiceID:   dbLine.InvoiceID,
+			Status:      dbLine.Status,
+			ManagedBy:   dbLine.ManagedBy,
 
 			Period: billing.Period{
 				Start: dbLine.PeriodStart.In(time.UTC),

--- a/openmeter/billing/adapter/invoicelines.go
+++ b/openmeter/billing/adapter/invoicelines.go
@@ -87,6 +87,7 @@ func (a *adapter) UpsertInvoiceLines(ctx context.Context, inputIn billing.Upsert
 					SetNillableDescription(line.Description).
 					SetCurrency(line.Currency).
 					SetMetadata(line.Metadata).
+					SetAnnotations(line.Annotations).
 					SetNillableChildUniqueReferenceID(line.ChildUniqueReferenceID).
 					// Totals
 					SetAmount(line.Totals.Amount).

--- a/openmeter/billing/annotations.go
+++ b/openmeter/billing/annotations.go
@@ -1,0 +1,5 @@
+package billing
+
+const (
+	AnnotationSubscriptionSyncIgnore = "billing.subscription.sync.ignore"
+)

--- a/openmeter/billing/invoiceline.go
+++ b/openmeter/billing/invoiceline.go
@@ -132,6 +132,7 @@ type LineBase struct {
 	DeletedAt *time.Time `json:"deletedAt,omitempty"`
 
 	Metadata    map[string]string    `json:"metadata"`
+	Annotations models.Annotations   `json:"annotations"`
 	Name        string               `json:"name"`
 	Type        InvoiceLineType      `json:"type"`
 	ManagedBy   InvoiceLineManagedBy `json:"managedBy"`
@@ -210,6 +211,13 @@ func (i LineBase) Clone() LineBase {
 		out.Metadata = make(map[string]string, len(i.Metadata))
 		for k, v := range i.Metadata {
 			out.Metadata[k] = v
+		}
+	}
+
+	if i.Annotations != nil {
+		out.Annotations = make(models.Annotations, len(i.Annotations))
+		for k, v := range i.Annotations {
+			out.Annotations[k] = v
 		}
 	}
 
@@ -591,6 +599,7 @@ type NewFlatFeeLineInput struct {
 
 	Name        string
 	Metadata    map[string]string
+	Annotations models.Annotations
 	Description *string
 
 	Currency currencyx.Code
@@ -617,6 +626,7 @@ func NewFlatFeeLine(input NewFlatFeeLineInput) *Line {
 
 			Name:        input.Name,
 			Metadata:    input.Metadata,
+			Annotations: input.Annotations,
 			Description: input.Description,
 
 			Status: InvoiceLineStatusValid,
@@ -673,6 +683,7 @@ func NewUsageBasedFlatFeeLine(input NewFlatFeeLineInput, opts ...usageBasedLineO
 
 			Name:        input.Name,
 			Metadata:    input.Metadata,
+			Annotations: input.Annotations,
 			Description: input.Description,
 
 			Status: InvoiceLineStatusValid,
@@ -1102,11 +1113,12 @@ func (u UpdateInvoiceLineInput) Apply(l *Line) (*Line, error) {
 type UpdateInvoiceLineBaseInput struct {
 	InvoiceAt mo.Option[time.Time]
 
-	Metadata  mo.Option[map[string]string]
-	Name      mo.Option[string]
-	ManagedBy mo.Option[InvoiceLineManagedBy]
-	Period    mo.Option[Period]
-	TaxConfig mo.Option[*productcatalog.TaxConfig]
+	Metadata    mo.Option[map[string]string]
+	Annotations mo.Option[models.Annotations]
+	Name        mo.Option[string]
+	ManagedBy   mo.Option[InvoiceLineManagedBy]
+	Period      mo.Option[Period]
+	TaxConfig   mo.Option[*productcatalog.TaxConfig]
 }
 
 func (u UpdateInvoiceLineBaseInput) Validate() error {
@@ -1152,6 +1164,10 @@ func (u UpdateInvoiceLineBaseInput) Apply(l *Line) error {
 
 	if u.Metadata.IsPresent() {
 		l.Metadata = u.Metadata.OrEmpty()
+	}
+
+	if u.Annotations.IsPresent() {
+		l.Annotations = u.Annotations.OrEmpty()
 	}
 
 	if u.Name.IsPresent() {

--- a/openmeter/billing/worker/subscription/patch.go
+++ b/openmeter/billing/worker/subscription/patch.go
@@ -147,6 +147,11 @@ func (h *Handler) getDeletePatchesForLine(lineOrHierarchy billing.LineOrHierarch
 			return nil, fmt.Errorf("getting line: %w", err)
 		}
 
+		// Ignored lines do not take part in syncing so we skip them
+		if ignore, ok := line.Annotations[billing.AnnotationSubscriptionSyncIgnore]; ok && ignore == true {
+			return nil, nil
+		}
+
 		return []linePatch{
 			newDeleteLinePatch(line.LineID(), line.InvoiceID),
 		}, nil

--- a/openmeter/billing/worker/subscription/sync.go
+++ b/openmeter/billing/worker/subscription/sync.go
@@ -629,6 +629,15 @@ func (h *Handler) getPatchesForExistingLineOrHierarchy(existingLine billing.Line
 }
 
 func (h *Handler) getPatchesForExistingLine(existingLine *billing.Line, expectedLine *billing.Line, invoiceByID InvoiceByID) ([]linePatch, error) {
+	// Lines can be manually marked as ignored in syncing, which is used for cases where we're doing backwards incompatible changes
+	if ignore, ok := expectedLine.Annotations[billing.AnnotationSubscriptionSyncIgnore]; ok && ignore == true {
+		return nil, nil
+	}
+
+	if ignore, ok := existingLine.Annotations[billing.AnnotationSubscriptionSyncIgnore]; ok && ignore == true {
+		return nil, nil
+	}
+
 	// Manual edits prevent resyncronization so that we preserve the user intent
 	if existingLine.ManagedBy != billing.SubscriptionManagedLine {
 		return nil, nil

--- a/openmeter/billing/worker/subscription/sync_test.go
+++ b/openmeter/billing/worker/subscription/sync_test.go
@@ -3404,7 +3404,7 @@ func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLines() {
 							PaymentTerm: productcatalog.InAdvancePaymentTerm,
 						}),
 					},
-					BillingCadence: isodate.MustParse(s.T(), "P1M"),
+					BillingCadence: datetime.MustParse(s.T(), "P1M"),
 				},
 			},
 		},
@@ -3486,7 +3486,7 @@ func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLines() {
 				Amount:      alpacadecimal.NewFromFloat(10),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			}),
-			BillingCadence: lo.ToPtr(isodate.MustParse(s.T(), "P1M")),
+			BillingCadence: lo.ToPtr(datetime.MustParse(s.T(), "P1M")),
 		}.AsPatch(),
 	}, s.timingImmediate())
 	s.NoError(err)
@@ -3568,7 +3568,7 @@ func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLinesWhenPeriod
 							PaymentTerm: productcatalog.InAdvancePaymentTerm,
 						}),
 					},
-					BillingCadence: isodate.MustParse(s.T(), "P3M"),
+					BillingCadence: datetime.MustParse(s.T(), "P3M"),
 				},
 				&productcatalog.UsageBasedRateCard{
 					RateCardMeta: productcatalog.RateCardMeta{
@@ -3579,7 +3579,7 @@ func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLinesWhenPeriod
 							PaymentTerm: productcatalog.InAdvancePaymentTerm,
 						}),
 					},
-					BillingCadence: isodate.MustParse(s.T(), "P3M"),
+					BillingCadence: datetime.MustParse(s.T(), "P3M"),
 				},
 			},
 		},

--- a/openmeter/billing/worker/subscription/sync_test.go
+++ b/openmeter/billing/worker/subscription/sync_test.go
@@ -3377,6 +3377,273 @@ func (s *SubscriptionHandlerTestSuite) TestGatheringManualDeleteSync() {
 	s.expectNoLineWithChildID(gatheringInvoice, *updatedLine.ChildUniqueReferenceID)
 }
 
+func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLines() {
+	ctx := s.Context
+	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:00Z"))
+
+	// Given
+	//  we have a subscription with a single phase with recurring flat fee
+	// When
+	//  we have the draft and gathering invoices created, and manually mark lines as sync ignored, and then edit the line
+	// Then
+	//  resyncing the subscription would not cause the sync ignored lines to
+	//  - be touched on the draft invoice
+	//  - be deleted on the gathering invoice
+	//  - but new versions of lines can be created when they have NEW reference IDs
+
+	subsView := s.createSubscriptionFromPlanPhases([]productcatalog.Phase{
+		{
+			PhaseMeta: s.phaseMeta("first-phase", ""),
+			RateCards: productcatalog.RateCards{
+				&productcatalog.UsageBasedRateCard{
+					RateCardMeta: productcatalog.RateCardMeta{
+						Key:  "in-advance",
+						Name: "in-advance",
+						Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+							Amount:      alpacadecimal.NewFromFloat(5),
+							PaymentTerm: productcatalog.InAdvancePaymentTerm,
+						}),
+					},
+					BillingCadence: isodate.MustParse(s.T(), "P1M"),
+				},
+			},
+		},
+	})
+
+	// Let's sync for 2 months so we have lines on gathering and draft
+	s.NoError(s.Handler.SyncronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+
+	// Let's assert we have one line on the draft invoice
+	draftInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: s.Customer.GetID(),
+	})
+	s.NoError(err)
+	s.Len(draftInvoices, 1)
+	draftInvoice := draftInvoices[0]
+
+	s.DebugDumpInvoice("draft invoice", draftInvoice)
+
+	lines, ok := draftInvoice.Lines.Get()
+	s.True(ok)
+	s.Len(lines, 1)
+
+	draftLineReferenceID := fmt.Sprintf("%s/first-phase/in-advance/v[0]/period[0]", subsView.Subscription.ID)
+	s.Equal(draftLineReferenceID, *lines[0].ChildUniqueReferenceID)
+
+	// Let's assert we have two lines on the gathering invoice
+	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
+	gatheringLines, ok := gatheringInvoice.Lines.Get()
+	s.True(ok)
+	s.Len(gatheringLines, 2)
+
+	gatheringLineReferenceID := fmt.Sprintf("%s/first-phase/in-advance/v[0]/period[1]", subsView.Subscription.ID)
+	s.Equal(gatheringLineReferenceID, *gatheringLines[0].ChildUniqueReferenceID)
+
+	// Now let's manually mark the lines as sync ignored
+	_, err = s.BillingService.UpdateInvoice(ctx, billing.UpdateInvoiceInput{
+		Invoice: draftInvoice.InvoiceID(),
+		EditFn: func(invoice *billing.Invoice) error {
+			line := s.getLineByChildID(*invoice, draftLineReferenceID)
+
+			line.Annotations = models.Annotations{
+				billing.AnnotationSubscriptionSyncIgnore: true,
+			}
+
+			return nil
+		},
+	})
+	s.NoError(err)
+
+	var gatheringInvoiceIgnoredLine *billing.Line
+
+	gatheringInvoice, err = s.BillingService.UpdateInvoice(ctx, billing.UpdateInvoiceInput{
+		Invoice: gatheringInvoice.InvoiceID(),
+		EditFn: func(invoice *billing.Invoice) error {
+			line := s.getLineByChildID(*invoice, gatheringLineReferenceID)
+
+			line.Annotations = models.Annotations{
+				billing.AnnotationSubscriptionSyncIgnore: true,
+			}
+
+			gatheringInvoiceIgnoredLine = line.Clone()
+
+			return nil
+		},
+	})
+	s.NoError(err)
+
+	// Now let's edit the subscription
+	subsView, err = s.SubscriptionWorkflowService.EditRunning(ctx, subsView.Subscription.NamespacedID, []subscription.Patch{
+		patch.PatchRemoveItem{
+			PhaseKey: "first-phase",
+			ItemKey:  "in-advance",
+		},
+		subscriptionAddItem{
+			PhaseKey: "first-phase",
+			ItemKey:  "in-advance",
+			Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+				Amount:      alpacadecimal.NewFromFloat(10),
+				PaymentTerm: productcatalog.InAdvancePaymentTerm,
+			}),
+			BillingCadence: lo.ToPtr(isodate.MustParse(s.T(), "P1M")),
+		}.AsPatch(),
+	}, s.timingImmediate())
+	s.NoError(err)
+
+	// Now let's resync the subscription
+	s.NoError(s.Handler.SyncronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+
+	// Then the lines should not be updated
+	draftInvoiceAfterSync, err := s.BillingService.GetInvoiceByID(ctx, billing.GetInvoiceByIdInput{
+		Invoice: draftInvoice.InvoiceID(),
+		Expand:  billing.InvoiceExpandAll,
+	})
+	s.NoError(err)
+	s.DebugDumpInvoice("draft invoice - after sync", draftInvoiceAfterSync)
+
+	expectedInvoice := draftInvoice.Clone()
+	expectedInvoice.Lines = expectedInvoice.Lines.Map(func(line *billing.Line) *billing.Line {
+		if line.ChildUniqueReferenceID != nil && *line.ChildUniqueReferenceID == draftLineReferenceID {
+			line.Annotations = models.Annotations{
+				billing.AnnotationSubscriptionSyncIgnore: true,
+			}
+		}
+
+		return line
+	})
+
+	if len(expectedInvoice.ValidationIssues) == 0 {
+		expectedInvoice.ValidationIssues = nil
+	}
+
+	s.Equal(expectedInvoice.RemoveMetaForCompare(), draftInvoiceAfterSync.RemoveMetaForCompare())
+
+	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	s.DebugDumpInvoice("gathering invoice - after sync", gatheringInvoice)
+
+	gatheringInvoiceIgnoredLineAfterSync := s.getLineByChildID(gatheringInvoice, *gatheringInvoiceIgnoredLine.ChildUniqueReferenceID)
+	s.Equal(gatheringInvoiceIgnoredLine.RemoveMetaForCompare(), gatheringInvoiceIgnoredLineAfterSync.RemoveMetaForCompare())
+
+	// But the non-marked line should be deleted
+	deletedGartheringLinereferenceID := fmt.Sprintf("%s/first-phase/in-advance/v[0]/period[2]", subsView.Subscription.ID)
+	for _, line := range gatheringInvoice.Lines.OrEmpty() {
+		if line.ChildUniqueReferenceID != nil && *line.ChildUniqueReferenceID == deletedGartheringLinereferenceID {
+			s.Fail("deleted line should be deleted")
+		}
+	}
+
+	// Finally, let's assert that the new versions of the lines are created!
+	updatedGartheringLines := gatheringInvoice.Lines.OrEmpty()
+	s.Len(updatedGartheringLines, 4)
+
+	newLineReferenceID := fmt.Sprintf("%s/first-phase/in-advance/v[1]/period[0]", subsView.Subscription.ID)
+	updatedLine := s.getLineByChildID(gatheringInvoice, newLineReferenceID)
+	s.NotNil(updatedLine)
+	s.Equal(alpacadecimal.NewFromFloat(10), updatedLine.FlatFee.PerUnitAmount)
+}
+
+func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLinesWhenPeriodChanges() {
+	ctx := s.Context
+	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:00Z"))
+
+	// Given
+	//  we have a subscription with a single phase with two recurring fee items
+	// When
+	//  we have the gathering invoice and manually mark a line as sync ignored
+	//  and we cancel the subscription so the line would end earlier than before
+	// Then
+	//  the marked line doesn't change after re-syncing the subscription
+
+	subsView := s.createSubscriptionFromPlanPhases([]productcatalog.Phase{
+		{
+			PhaseMeta: s.phaseMeta("first-phase", ""),
+			RateCards: productcatalog.RateCards{
+				&productcatalog.UsageBasedRateCard{
+					RateCardMeta: productcatalog.RateCardMeta{
+						Key:  "marked",
+						Name: "marked",
+						Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+							Amount:      alpacadecimal.NewFromFloat(5),
+							PaymentTerm: productcatalog.InAdvancePaymentTerm,
+						}),
+					},
+					BillingCadence: isodate.MustParse(s.T(), "P3M"),
+				},
+				&productcatalog.UsageBasedRateCard{
+					RateCardMeta: productcatalog.RateCardMeta{
+						Key:  "non-marked",
+						Name: "non-marked",
+						Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+							Amount:      alpacadecimal.NewFromFloat(5),
+							PaymentTerm: productcatalog.InAdvancePaymentTerm,
+						}),
+					},
+					BillingCadence: isodate.MustParse(s.T(), "P3M"),
+				},
+			},
+		},
+	})
+
+	// Let's just sync for the current month
+	s.NoError(s.Handler.SyncronizeSubscription(ctx, subsView, s.mustParseTime("2024-04-01T00:00:00Z")))
+
+	// Let's assert we have two lines on the gathering invoice
+	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
+	gatheringLines, ok := gatheringInvoice.Lines.Get()
+	s.True(ok)
+	s.Len(gatheringLines, 4)
+
+	markedLineReferenceID := fmt.Sprintf("%s/first-phase/marked/v[0]/period[0]", subsView.Subscription.ID)
+	unMarkedLineReferenceID := fmt.Sprintf("%s/first-phase/non-marked/v[0]/period[0]", subsView.Subscription.ID)
+
+	// Now let's manually mark the lines as sync ignored
+	gatheringInvoice, err := s.BillingService.UpdateInvoice(ctx, billing.UpdateInvoiceInput{
+		Invoice: gatheringInvoice.InvoiceID(),
+		EditFn: func(invoice *billing.Invoice) error {
+			line := s.getLineByChildID(*invoice, markedLineReferenceID)
+
+			line.Annotations = models.Annotations{
+				billing.AnnotationSubscriptionSyncIgnore: true,
+			}
+
+			return nil
+		},
+	})
+	s.NoError(err)
+
+	// Now let's cancel the subscription
+	_, err = s.SubscriptionService.Cancel(ctx, subsView.Subscription.NamespacedID, subscription.Timing{
+		Custom: lo.ToPtr(s.mustParseTime("2024-02-01T00:00:00Z")), // we cancel after the first month
+	})
+	s.NoError(err)
+
+	subsView, err = s.SubscriptionService.GetView(ctx, subsView.Subscription.NamespacedID)
+	s.NoError(err)
+
+	// Now let's resync the subscription
+	s.NoError(s.Handler.SyncronizeSubscription(ctx, subsView, s.mustParseTime("2024-04-01T00:00:00Z")))
+
+	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	s.DebugDumpInvoice("gathering invoice - after sync", gatheringInvoice)
+
+	// And assert that everything works as expected
+	markedLine := s.getLineByChildID(gatheringInvoice, markedLineReferenceID)
+	s.NotNil(markedLine)
+	s.Equal(markedLine.Period, billing.Period{
+		Start: s.mustParseTime("2024-01-01T00:00:00Z"),
+		End:   s.mustParseTime("2024-04-01T00:00:00Z"), // period wasn't updated
+	})
+
+	unmarkedLine := s.getLineByChildID(gatheringInvoice, unMarkedLineReferenceID)
+	s.NotNil(unmarkedLine)
+	s.Equal(unmarkedLine.Period, billing.Period{
+		Start: s.mustParseTime("2024-01-01T00:00:00Z"),
+		End:   s.mustParseTime("2024-02-01T00:00:00Z"), // period was updated
+	})
+}
+
 func (s *SubscriptionHandlerTestSuite) TestSplitLineManualDeleteSync() {
 	ctx := s.Context
 	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:00Z"))

--- a/openmeter/ent/db/billinginvoiceline.go
+++ b/openmeter/ent/db/billinginvoiceline.go
@@ -29,6 +29,8 @@ type BillingInvoiceLine struct {
 	config `json:"-"`
 	// ID of the ent.
 	ID string `json:"id,omitempty"`
+	// Annotations holds the value of the "annotations" field.
+	Annotations map[string]interface{} `json:"annotations,omitempty"`
 	// Namespace holds the value of the "namespace" field.
 	Namespace string `json:"namespace,omitempty"`
 	// Metadata holds the value of the "metadata" field.
@@ -256,7 +258,7 @@ func (*BillingInvoiceLine) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case billinginvoiceline.FieldQuantity:
 			values[i] = &sql.NullScanner{S: new(alpacadecimal.Decimal)}
-		case billinginvoiceline.FieldMetadata, billinginvoiceline.FieldTaxConfig:
+		case billinginvoiceline.FieldAnnotations, billinginvoiceline.FieldMetadata, billinginvoiceline.FieldTaxConfig:
 			values[i] = new([]byte)
 		case billinginvoiceline.FieldAmount, billinginvoiceline.FieldTaxesTotal, billinginvoiceline.FieldTaxesInclusiveTotal, billinginvoiceline.FieldTaxesExclusiveTotal, billinginvoiceline.FieldChargesTotal, billinginvoiceline.FieldDiscountsTotal, billinginvoiceline.FieldTotal:
 			values[i] = new(alpacadecimal.Decimal)
@@ -290,6 +292,14 @@ func (_m *BillingInvoiceLine) assignValues(columns []string, values []any) error
 				return fmt.Errorf("unexpected type %T for field id", values[i])
 			} else if value.Valid {
 				_m.ID = value.String
+			}
+		case billinginvoiceline.FieldAnnotations:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field annotations", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &_m.Annotations); err != nil {
+					return fmt.Errorf("unmarshal field annotations: %w", err)
+				}
 			}
 		case billinginvoiceline.FieldNamespace:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -609,6 +619,9 @@ func (_m *BillingInvoiceLine) String() string {
 	var builder strings.Builder
 	builder.WriteString("BillingInvoiceLine(")
 	builder.WriteString(fmt.Sprintf("id=%v, ", _m.ID))
+	builder.WriteString("annotations=")
+	builder.WriteString(fmt.Sprintf("%v", _m.Annotations))
+	builder.WriteString(", ")
 	builder.WriteString("namespace=")
 	builder.WriteString(_m.Namespace)
 	builder.WriteString(", ")

--- a/openmeter/ent/db/billinginvoiceline/billinginvoiceline.go
+++ b/openmeter/ent/db/billinginvoiceline/billinginvoiceline.go
@@ -17,6 +17,8 @@ const (
 	Label = "billing_invoice_line"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
+	// FieldAnnotations holds the string denoting the annotations field in the database.
+	FieldAnnotations = "annotations"
 	// FieldNamespace holds the string denoting the namespace field in the database.
 	FieldNamespace = "namespace"
 	// FieldMetadata holds the string denoting the metadata field in the database.
@@ -183,6 +185,7 @@ const (
 // Columns holds all SQL columns for billinginvoiceline fields.
 var Columns = []string{
 	FieldID,
+	FieldAnnotations,
 	FieldNamespace,
 	FieldMetadata,
 	FieldCreatedAt,

--- a/openmeter/ent/db/billinginvoiceline/where.go
+++ b/openmeter/ent/db/billinginvoiceline/where.go
@@ -204,6 +204,16 @@ func LineIds(v string) predicate.BillingInvoiceLine {
 	return predicate.BillingInvoiceLine(sql.FieldEQ(FieldLineIds, v))
 }
 
+// AnnotationsIsNil applies the IsNil predicate on the "annotations" field.
+func AnnotationsIsNil() predicate.BillingInvoiceLine {
+	return predicate.BillingInvoiceLine(sql.FieldIsNull(FieldAnnotations))
+}
+
+// AnnotationsNotNil applies the NotNil predicate on the "annotations" field.
+func AnnotationsNotNil() predicate.BillingInvoiceLine {
+	return predicate.BillingInvoiceLine(sql.FieldNotNull(FieldAnnotations))
+}
+
 // NamespaceEQ applies the EQ predicate on the "namespace" field.
 func NamespaceEQ(v string) predicate.BillingInvoiceLine {
 	return predicate.BillingInvoiceLine(sql.FieldEQ(FieldNamespace, v))

--- a/openmeter/ent/db/billinginvoiceline_create.go
+++ b/openmeter/ent/db/billinginvoiceline_create.go
@@ -36,6 +36,12 @@ type BillingInvoiceLineCreate struct {
 	conflict []sql.ConflictOption
 }
 
+// SetAnnotations sets the "annotations" field.
+func (_c *BillingInvoiceLineCreate) SetAnnotations(v map[string]interface{}) *BillingInvoiceLineCreate {
+	_c.mutation.SetAnnotations(v)
+	return _c
+}
+
 // SetNamespace sets the "namespace" field.
 func (_c *BillingInvoiceLineCreate) SetNamespace(v string) *BillingInvoiceLineCreate {
 	_c.mutation.SetNamespace(v)
@@ -659,6 +665,10 @@ func (_c *BillingInvoiceLineCreate) createSpec() (*BillingInvoiceLine, *sqlgraph
 		_node.ID = id
 		_spec.ID.Value = id
 	}
+	if value, ok := _c.mutation.Annotations(); ok {
+		_spec.SetField(billinginvoiceline.FieldAnnotations, field.TypeJSON, value)
+		_node.Annotations = value
+	}
 	if value, ok := _c.mutation.Namespace(); ok {
 		_spec.SetField(billinginvoiceline.FieldNamespace, field.TypeString, value)
 		_node.Namespace = value
@@ -962,7 +972,7 @@ func (_c *BillingInvoiceLineCreate) createSpec() (*BillingInvoiceLine, *sqlgraph
 // of the `INSERT` statement. For example:
 //
 //	client.BillingInvoiceLine.Create().
-//		SetNamespace(v).
+//		SetAnnotations(v).
 //		OnConflict(
 //			// Update the row with the new values
 //			// the was proposed for insertion.
@@ -971,7 +981,7 @@ func (_c *BillingInvoiceLineCreate) createSpec() (*BillingInvoiceLine, *sqlgraph
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.BillingInvoiceLineUpsert) {
-//			SetNamespace(v+v).
+//			SetAnnotations(v+v).
 //		}).
 //		Exec(ctx)
 func (_c *BillingInvoiceLineCreate) OnConflict(opts ...sql.ConflictOption) *BillingInvoiceLineUpsertOne {
@@ -1006,6 +1016,24 @@ type (
 		*sql.UpdateSet
 	}
 )
+
+// SetAnnotations sets the "annotations" field.
+func (u *BillingInvoiceLineUpsert) SetAnnotations(v map[string]interface{}) *BillingInvoiceLineUpsert {
+	u.Set(billinginvoiceline.FieldAnnotations, v)
+	return u
+}
+
+// UpdateAnnotations sets the "annotations" field to the value that was provided on create.
+func (u *BillingInvoiceLineUpsert) UpdateAnnotations() *BillingInvoiceLineUpsert {
+	u.SetExcluded(billinginvoiceline.FieldAnnotations)
+	return u
+}
+
+// ClearAnnotations clears the value of the "annotations" field.
+func (u *BillingInvoiceLineUpsert) ClearAnnotations() *BillingInvoiceLineUpsert {
+	u.SetNull(billinginvoiceline.FieldAnnotations)
+	return u
+}
 
 // SetMetadata sets the "metadata" field.
 func (u *BillingInvoiceLineUpsert) SetMetadata(v map[string]string) *BillingInvoiceLineUpsert {
@@ -1497,6 +1525,27 @@ func (u *BillingInvoiceLineUpsertOne) Update(set func(*BillingInvoiceLineUpsert)
 		set(&BillingInvoiceLineUpsert{UpdateSet: update})
 	}))
 	return u
+}
+
+// SetAnnotations sets the "annotations" field.
+func (u *BillingInvoiceLineUpsertOne) SetAnnotations(v map[string]interface{}) *BillingInvoiceLineUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineUpsert) {
+		s.SetAnnotations(v)
+	})
+}
+
+// UpdateAnnotations sets the "annotations" field to the value that was provided on create.
+func (u *BillingInvoiceLineUpsertOne) UpdateAnnotations() *BillingInvoiceLineUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineUpsert) {
+		s.UpdateAnnotations()
+	})
+}
+
+// ClearAnnotations clears the value of the "annotations" field.
+func (u *BillingInvoiceLineUpsertOne) ClearAnnotations() *BillingInvoiceLineUpsertOne {
+	return u.Update(func(s *BillingInvoiceLineUpsert) {
+		s.ClearAnnotations()
+	})
 }
 
 // SetMetadata sets the "metadata" field.
@@ -2142,7 +2191,7 @@ func (_c *BillingInvoiceLineCreateBulk) ExecX(ctx context.Context) {
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.BillingInvoiceLineUpsert) {
-//			SetNamespace(v+v).
+//			SetAnnotations(v+v).
 //		}).
 //		Exec(ctx)
 func (_c *BillingInvoiceLineCreateBulk) OnConflict(opts ...sql.ConflictOption) *BillingInvoiceLineUpsertBulk {
@@ -2231,6 +2280,27 @@ func (u *BillingInvoiceLineUpsertBulk) Update(set func(*BillingInvoiceLineUpsert
 		set(&BillingInvoiceLineUpsert{UpdateSet: update})
 	}))
 	return u
+}
+
+// SetAnnotations sets the "annotations" field.
+func (u *BillingInvoiceLineUpsertBulk) SetAnnotations(v map[string]interface{}) *BillingInvoiceLineUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineUpsert) {
+		s.SetAnnotations(v)
+	})
+}
+
+// UpdateAnnotations sets the "annotations" field to the value that was provided on create.
+func (u *BillingInvoiceLineUpsertBulk) UpdateAnnotations() *BillingInvoiceLineUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineUpsert) {
+		s.UpdateAnnotations()
+	})
+}
+
+// ClearAnnotations clears the value of the "annotations" field.
+func (u *BillingInvoiceLineUpsertBulk) ClearAnnotations() *BillingInvoiceLineUpsertBulk {
+	return u.Update(func(s *BillingInvoiceLineUpsert) {
+		s.ClearAnnotations()
+	})
 }
 
 // SetMetadata sets the "metadata" field.

--- a/openmeter/ent/db/billinginvoiceline_query.go
+++ b/openmeter/ent/db/billinginvoiceline_query.go
@@ -660,12 +660,12 @@ func (_q *BillingInvoiceLineQuery) WithSubscriptionItem(opts ...func(*Subscripti
 // Example:
 //
 //	var v []struct {
-//		Namespace string `json:"namespace,omitempty"`
+//		Annotations map[string]interface {} `json:"annotations,omitempty"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
 //	client.BillingInvoiceLine.Query().
-//		GroupBy(billinginvoiceline.FieldNamespace).
+//		GroupBy(billinginvoiceline.FieldAnnotations).
 //		Aggregate(db.Count()).
 //		Scan(ctx, &v)
 func (_q *BillingInvoiceLineQuery) GroupBy(field string, fields ...string) *BillingInvoiceLineGroupBy {
@@ -683,11 +683,11 @@ func (_q *BillingInvoiceLineQuery) GroupBy(field string, fields ...string) *Bill
 // Example:
 //
 //	var v []struct {
-//		Namespace string `json:"namespace,omitempty"`
+//		Annotations map[string]interface {} `json:"annotations,omitempty"`
 //	}
 //
 //	client.BillingInvoiceLine.Query().
-//		Select(billinginvoiceline.FieldNamespace).
+//		Select(billinginvoiceline.FieldAnnotations).
 //		Scan(ctx, &v)
 func (_q *BillingInvoiceLineQuery) Select(fields ...string) *BillingInvoiceLineSelect {
 	_q.ctx.Fields = append(_q.ctx.Fields, fields...)

--- a/openmeter/ent/db/billinginvoiceline_update.go
+++ b/openmeter/ent/db/billinginvoiceline_update.go
@@ -40,6 +40,18 @@ func (_u *BillingInvoiceLineUpdate) Where(ps ...predicate.BillingInvoiceLine) *B
 	return _u
 }
 
+// SetAnnotations sets the "annotations" field.
+func (_u *BillingInvoiceLineUpdate) SetAnnotations(v map[string]interface{}) *BillingInvoiceLineUpdate {
+	_u.mutation.SetAnnotations(v)
+	return _u
+}
+
+// ClearAnnotations clears the value of the "annotations" field.
+func (_u *BillingInvoiceLineUpdate) ClearAnnotations() *BillingInvoiceLineUpdate {
+	_u.mutation.ClearAnnotations()
+	return _u
+}
+
 // SetMetadata sets the "metadata" field.
 func (_u *BillingInvoiceLineUpdate) SetMetadata(v map[string]string) *BillingInvoiceLineUpdate {
 	_u.mutation.SetMetadata(v)
@@ -812,6 +824,12 @@ func (_u *BillingInvoiceLineUpdate) sqlSave(ctx context.Context) (_node int, err
 			}
 		}
 	}
+	if value, ok := _u.mutation.Annotations(); ok {
+		_spec.SetField(billinginvoiceline.FieldAnnotations, field.TypeJSON, value)
+	}
+	if _u.mutation.AnnotationsCleared() {
+		_spec.ClearField(billinginvoiceline.FieldAnnotations, field.TypeJSON)
+	}
 	if value, ok := _u.mutation.Metadata(); ok {
 		_spec.SetField(billinginvoiceline.FieldMetadata, field.TypeJSON, value)
 	}
@@ -1297,6 +1315,18 @@ type BillingInvoiceLineUpdateOne struct {
 	fields   []string
 	hooks    []Hook
 	mutation *BillingInvoiceLineMutation
+}
+
+// SetAnnotations sets the "annotations" field.
+func (_u *BillingInvoiceLineUpdateOne) SetAnnotations(v map[string]interface{}) *BillingInvoiceLineUpdateOne {
+	_u.mutation.SetAnnotations(v)
+	return _u
+}
+
+// ClearAnnotations clears the value of the "annotations" field.
+func (_u *BillingInvoiceLineUpdateOne) ClearAnnotations() *BillingInvoiceLineUpdateOne {
+	_u.mutation.ClearAnnotations()
+	return _u
 }
 
 // SetMetadata sets the "metadata" field.
@@ -2100,6 +2130,12 @@ func (_u *BillingInvoiceLineUpdateOne) sqlSave(ctx context.Context) (_node *Bill
 				ps[i](selector)
 			}
 		}
+	}
+	if value, ok := _u.mutation.Annotations(); ok {
+		_spec.SetField(billinginvoiceline.FieldAnnotations, field.TypeJSON, value)
+	}
+	if _u.mutation.AnnotationsCleared() {
+		_spec.ClearField(billinginvoiceline.FieldAnnotations, field.TypeJSON)
 	}
 	if value, ok := _u.mutation.Metadata(); ok {
 		_spec.SetField(billinginvoiceline.FieldMetadata, field.TypeJSON, value)

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -717,6 +717,7 @@ var (
 	// BillingInvoiceLinesColumns holds the columns for the "billing_invoice_lines" table.
 	BillingInvoiceLinesColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeString, Unique: true, SchemaType: map[string]string{"postgres": "char(26)"}},
+		{Name: "annotations", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "namespace", Type: field.TypeString},
 		{Name: "metadata", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "created_at", Type: field.TypeTime},
@@ -761,54 +762,64 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "billing_invoice_lines_billing_invoices_billing_invoice_lines",
-				Columns:    []*schema.Column{BillingInvoiceLinesColumns[28]},
+				Columns:    []*schema.Column{BillingInvoiceLinesColumns[29]},
 				RefColumns: []*schema.Column{BillingInvoicesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "billing_invoice_lines_billing_invoice_flat_fee_line_configs_flat_fee_line",
-				Columns:    []*schema.Column{BillingInvoiceLinesColumns[29]},
+				Columns:    []*schema.Column{BillingInvoiceLinesColumns[30]},
 				RefColumns: []*schema.Column{BillingInvoiceFlatFeeLineConfigsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "billing_invoice_lines_billing_invoice_usage_based_line_configs_usage_based_line",
-				Columns:    []*schema.Column{BillingInvoiceLinesColumns[30]},
+				Columns:    []*schema.Column{BillingInvoiceLinesColumns[31]},
 				RefColumns: []*schema.Column{BillingInvoiceUsageBasedLineConfigsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "billing_invoice_lines_billing_invoice_lines_detailed_lines",
-				Columns:    []*schema.Column{BillingInvoiceLinesColumns[31]},
+				Columns:    []*schema.Column{BillingInvoiceLinesColumns[32]},
 				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "billing_invoice_lines_billing_invoice_split_line_groups_billing_invoice_lines",
-				Columns:    []*schema.Column{BillingInvoiceLinesColumns[32]},
+				Columns:    []*schema.Column{BillingInvoiceLinesColumns[33]},
 				RefColumns: []*schema.Column{BillingInvoiceSplitLineGroupsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "billing_invoice_lines_subscriptions_billing_lines",
-				Columns:    []*schema.Column{BillingInvoiceLinesColumns[33]},
+				Columns:    []*schema.Column{BillingInvoiceLinesColumns[34]},
 				RefColumns: []*schema.Column{SubscriptionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "billing_invoice_lines_subscription_items_billing_lines",
-				Columns:    []*schema.Column{BillingInvoiceLinesColumns[34]},
+				Columns:    []*schema.Column{BillingInvoiceLinesColumns[35]},
 				RefColumns: []*schema.Column{SubscriptionItemsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "billing_invoice_lines_subscription_phases_billing_lines",
-				Columns:    []*schema.Column{BillingInvoiceLinesColumns[35]},
+				Columns:    []*schema.Column{BillingInvoiceLinesColumns[36]},
 				RefColumns: []*schema.Column{SubscriptionPhasesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 		},
 		Indexes: []*schema.Index{
+			{
+				Name:    "billinginvoiceline_annotations",
+				Unique:  false,
+				Columns: []*schema.Column{BillingInvoiceLinesColumns[1]},
+				Annotation: &entsql.IndexAnnotation{
+					Types: map[string]string{
+						"postgres": "GIN",
+					},
+				},
+			},
 			{
 				Name:    "billinginvoiceline_id",
 				Unique:  true,
@@ -817,27 +828,27 @@ var (
 			{
 				Name:    "billinginvoiceline_namespace",
 				Unique:  false,
-				Columns: []*schema.Column{BillingInvoiceLinesColumns[1]},
+				Columns: []*schema.Column{BillingInvoiceLinesColumns[2]},
 			},
 			{
 				Name:    "billinginvoiceline_namespace_id",
 				Unique:  true,
-				Columns: []*schema.Column{BillingInvoiceLinesColumns[1], BillingInvoiceLinesColumns[0]},
+				Columns: []*schema.Column{BillingInvoiceLinesColumns[2], BillingInvoiceLinesColumns[0]},
 			},
 			{
 				Name:    "billinginvoiceline_namespace_invoice_id",
 				Unique:  false,
-				Columns: []*schema.Column{BillingInvoiceLinesColumns[1], BillingInvoiceLinesColumns[28]},
+				Columns: []*schema.Column{BillingInvoiceLinesColumns[2], BillingInvoiceLinesColumns[29]},
 			},
 			{
 				Name:    "billinginvoiceline_namespace_parent_line_id",
 				Unique:  false,
-				Columns: []*schema.Column{BillingInvoiceLinesColumns[1], BillingInvoiceLinesColumns[31]},
+				Columns: []*schema.Column{BillingInvoiceLinesColumns[2], BillingInvoiceLinesColumns[32]},
 			},
 			{
 				Name:    "billinginvoiceline_namespace_parent_line_id_child_unique_reference_id",
 				Unique:  true,
-				Columns: []*schema.Column{BillingInvoiceLinesColumns[1], BillingInvoiceLinesColumns[31], BillingInvoiceLinesColumns[26]},
+				Columns: []*schema.Column{BillingInvoiceLinesColumns[2], BillingInvoiceLinesColumns[32], BillingInvoiceLinesColumns[27]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "child_unique_reference_id IS NOT NULL AND deleted_at IS NULL",
 				},
@@ -845,7 +856,7 @@ var (
 			{
 				Name:    "billinginvoiceline_namespace_subscription_id_subscription_phase_id_subscription_item_id",
 				Unique:  false,
-				Columns: []*schema.Column{BillingInvoiceLinesColumns[1], BillingInvoiceLinesColumns[33], BillingInvoiceLinesColumns[35], BillingInvoiceLinesColumns[34]},
+				Columns: []*schema.Column{BillingInvoiceLinesColumns[2], BillingInvoiceLinesColumns[34], BillingInvoiceLinesColumns[36], BillingInvoiceLinesColumns[35]},
 			},
 		},
 	}

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -16212,6 +16212,7 @@ type BillingInvoiceLineMutation struct {
 	op                           Op
 	typ                          string
 	id                           *string
+	annotations                  *map[string]interface{}
 	namespace                    *string
 	metadata                     *map[string]string
 	created_at                   *time.Time
@@ -16372,6 +16373,55 @@ func (m *BillingInvoiceLineMutation) IDs(ctx context.Context) ([]string, error) 
 	default:
 		return nil, fmt.Errorf("IDs is not allowed on %s operations", m.op)
 	}
+}
+
+// SetAnnotations sets the "annotations" field.
+func (m *BillingInvoiceLineMutation) SetAnnotations(value map[string]interface{}) {
+	m.annotations = &value
+}
+
+// Annotations returns the value of the "annotations" field in the mutation.
+func (m *BillingInvoiceLineMutation) Annotations() (r map[string]interface{}, exists bool) {
+	v := m.annotations
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAnnotations returns the old "annotations" field's value of the BillingInvoiceLine entity.
+// If the BillingInvoiceLine object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *BillingInvoiceLineMutation) OldAnnotations(ctx context.Context) (v map[string]interface{}, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAnnotations is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAnnotations requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAnnotations: %w", err)
+	}
+	return oldValue.Annotations, nil
+}
+
+// ClearAnnotations clears the value of the "annotations" field.
+func (m *BillingInvoiceLineMutation) ClearAnnotations() {
+	m.annotations = nil
+	m.clearedFields[billinginvoiceline.FieldAnnotations] = struct{}{}
+}
+
+// AnnotationsCleared returns if the "annotations" field was cleared in this mutation.
+func (m *BillingInvoiceLineMutation) AnnotationsCleared() bool {
+	_, ok := m.clearedFields[billinginvoiceline.FieldAnnotations]
+	return ok
+}
+
+// ResetAnnotations resets all changes to the "annotations" field.
+func (m *BillingInvoiceLineMutation) ResetAnnotations() {
+	m.annotations = nil
+	delete(m.clearedFields, billinginvoiceline.FieldAnnotations)
 }
 
 // SetNamespace sets the "namespace" field.
@@ -18193,7 +18243,10 @@ func (m *BillingInvoiceLineMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *BillingInvoiceLineMutation) Fields() []string {
-	fields := make([]string, 0, 33)
+	fields := make([]string, 0, 34)
+	if m.annotations != nil {
+		fields = append(fields, billinginvoiceline.FieldAnnotations)
+	}
 	if m.namespace != nil {
 		fields = append(fields, billinginvoiceline.FieldNamespace)
 	}
@@ -18301,6 +18354,8 @@ func (m *BillingInvoiceLineMutation) Fields() []string {
 // schema.
 func (m *BillingInvoiceLineMutation) Field(name string) (ent.Value, bool) {
 	switch name {
+	case billinginvoiceline.FieldAnnotations:
+		return m.Annotations()
 	case billinginvoiceline.FieldNamespace:
 		return m.Namespace()
 	case billinginvoiceline.FieldMetadata:
@@ -18376,6 +18431,8 @@ func (m *BillingInvoiceLineMutation) Field(name string) (ent.Value, bool) {
 // database failed.
 func (m *BillingInvoiceLineMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
+	case billinginvoiceline.FieldAnnotations:
+		return m.OldAnnotations(ctx)
 	case billinginvoiceline.FieldNamespace:
 		return m.OldNamespace(ctx)
 	case billinginvoiceline.FieldMetadata:
@@ -18451,6 +18508,13 @@ func (m *BillingInvoiceLineMutation) OldField(ctx context.Context, name string) 
 // type.
 func (m *BillingInvoiceLineMutation) SetField(name string, value ent.Value) error {
 	switch name {
+	case billinginvoiceline.FieldAnnotations:
+		v, ok := value.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAnnotations(v)
+		return nil
 	case billinginvoiceline.FieldNamespace:
 		v, ok := value.(string)
 		if !ok {
@@ -18712,6 +18776,9 @@ func (m *BillingInvoiceLineMutation) AddField(name string, value ent.Value) erro
 // mutation.
 func (m *BillingInvoiceLineMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(billinginvoiceline.FieldAnnotations) {
+		fields = append(fields, billinginvoiceline.FieldAnnotations)
+	}
 	if m.FieldCleared(billinginvoiceline.FieldMetadata) {
 		fields = append(fields, billinginvoiceline.FieldMetadata)
 	}
@@ -18768,6 +18835,9 @@ func (m *BillingInvoiceLineMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *BillingInvoiceLineMutation) ClearField(name string) error {
 	switch name {
+	case billinginvoiceline.FieldAnnotations:
+		m.ClearAnnotations()
+		return nil
 	case billinginvoiceline.FieldMetadata:
 		m.ClearMetadata()
 		return nil
@@ -18818,6 +18888,9 @@ func (m *BillingInvoiceLineMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *BillingInvoiceLineMutation) ResetField(name string) error {
 	switch name {
+	case billinginvoiceline.FieldAnnotations:
+		m.ResetAnnotations()
+		return nil
 	case billinginvoiceline.FieldNamespace:
 		m.ResetNamespace()
 		return nil

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -505,35 +505,35 @@ func init() {
 	// billinginvoiceflatfeelineconfig.DefaultID holds the default value on creation for the id field.
 	billinginvoiceflatfeelineconfig.DefaultID = billinginvoiceflatfeelineconfigDescID.Default.(func() string)
 	billinginvoicelineMixin := schema.BillingInvoiceLine{}.Mixin()
-	billinginvoicelineMixinFields0 := billinginvoicelineMixin[0].Fields()
-	_ = billinginvoicelineMixinFields0
 	billinginvoicelineMixinFields1 := billinginvoicelineMixin[1].Fields()
 	_ = billinginvoicelineMixinFields1
+	billinginvoicelineMixinFields2 := billinginvoicelineMixin[2].Fields()
+	_ = billinginvoicelineMixinFields2
 	billinginvoicelineFields := schema.BillingInvoiceLine{}.Fields()
 	_ = billinginvoicelineFields
 	// billinginvoicelineDescNamespace is the schema descriptor for namespace field.
-	billinginvoicelineDescNamespace := billinginvoicelineMixinFields0[1].Descriptor()
+	billinginvoicelineDescNamespace := billinginvoicelineMixinFields1[1].Descriptor()
 	// billinginvoiceline.NamespaceValidator is a validator for the "namespace" field. It is called by the builders before save.
 	billinginvoiceline.NamespaceValidator = billinginvoicelineDescNamespace.Validators[0].(func(string) error)
 	// billinginvoicelineDescCreatedAt is the schema descriptor for created_at field.
-	billinginvoicelineDescCreatedAt := billinginvoicelineMixinFields0[3].Descriptor()
+	billinginvoicelineDescCreatedAt := billinginvoicelineMixinFields1[3].Descriptor()
 	// billinginvoiceline.DefaultCreatedAt holds the default value on creation for the created_at field.
 	billinginvoiceline.DefaultCreatedAt = billinginvoicelineDescCreatedAt.Default.(func() time.Time)
 	// billinginvoicelineDescUpdatedAt is the schema descriptor for updated_at field.
-	billinginvoicelineDescUpdatedAt := billinginvoicelineMixinFields0[4].Descriptor()
+	billinginvoicelineDescUpdatedAt := billinginvoicelineMixinFields1[4].Descriptor()
 	// billinginvoiceline.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	billinginvoiceline.DefaultUpdatedAt = billinginvoicelineDescUpdatedAt.Default.(func() time.Time)
 	// billinginvoiceline.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	billinginvoiceline.UpdateDefaultUpdatedAt = billinginvoicelineDescUpdatedAt.UpdateDefault.(func() time.Time)
 	// billinginvoicelineDescCurrency is the schema descriptor for currency field.
-	billinginvoicelineDescCurrency := billinginvoicelineMixinFields1[0].Descriptor()
+	billinginvoicelineDescCurrency := billinginvoicelineMixinFields2[0].Descriptor()
 	// billinginvoiceline.CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
 	billinginvoiceline.CurrencyValidator = billinginvoicelineDescCurrency.Validators[0].(func(string) error)
 	// billinginvoicelineDescRatecardDiscounts is the schema descriptor for ratecard_discounts field.
 	billinginvoicelineDescRatecardDiscounts := billinginvoicelineFields[9].Descriptor()
 	billinginvoiceline.ValueScanner.RatecardDiscounts = billinginvoicelineDescRatecardDiscounts.ValueScanner.(field.TypeValueScanner[*billing.Discounts])
 	// billinginvoicelineDescID is the schema descriptor for id field.
-	billinginvoicelineDescID := billinginvoicelineMixinFields0[0].Descriptor()
+	billinginvoicelineDescID := billinginvoicelineMixinFields1[0].Descriptor()
 	// billinginvoiceline.DefaultID holds the default value on creation for the id field.
 	billinginvoiceline.DefaultID = billinginvoicelineDescID.Default.(func() string)
 	billinginvoicelinediscountMixin := schema.BillingInvoiceLineDiscount{}.Mixin()

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -979,6 +979,20 @@ func (u *BillingInvoiceFlatFeeLineConfigUpdateOne) SetOrClearIndex(value *int) *
 	return u.SetIndex(*value)
 }
 
+func (u *BillingInvoiceLineUpdate) SetOrClearAnnotations(value *map[string]interface{}) *BillingInvoiceLineUpdate {
+	if value == nil {
+		return u.ClearAnnotations()
+	}
+	return u.SetAnnotations(*value)
+}
+
+func (u *BillingInvoiceLineUpdateOne) SetOrClearAnnotations(value *map[string]interface{}) *BillingInvoiceLineUpdateOne {
+	if value == nil {
+		return u.ClearAnnotations()
+	}
+	return u.SetAnnotations(*value)
+}
+
 func (u *BillingInvoiceLineUpdate) SetOrClearMetadata(value *map[string]string) *BillingInvoiceLineUpdate {
 	if value == nil {
 		return u.ClearMetadata()

--- a/openmeter/ent/schema/billing.go
+++ b/openmeter/ent/schema/billing.go
@@ -320,6 +320,7 @@ type BillingInvoiceLine struct {
 
 func (BillingInvoiceLine) Mixin() []ent.Mixin {
 	return []ent.Mixin{
+		entutils.AnnotationsMixin{},
 		entutils.ResourceMixin{},
 		InvoiceLineBaseMixin{},
 		TotalsMixin{},

--- a/openmeter/subscription/subscriptionspec.go
+++ b/openmeter/subscription/subscriptionspec.go
@@ -785,8 +785,8 @@ func (s SubscriptionItemSpec) GetFullServicePeriodAt(
 		return timeutil.ClosedPeriod{}, fmt.Errorf("item is not billable")
 	}
 
-	if !itemCadence.IsActiveAt(at) {
-		return timeutil.ClosedPeriod{}, fmt.Errorf("item is not active at %s", at)
+	if !itemCadence.IsActiveAt(at) && !itemCadence.ActiveFrom.Equal(at) {
+		return timeutil.ClosedPeriod{}, fmt.Errorf("item is not active at %s: [%s, %s]", at, itemCadence.ActiveFrom, itemCadence.ActiveTo)
 	}
 
 	if !phaseCadence.IsActiveAt(at) {

--- a/pkg/timeutil/openperiod_test.go
+++ b/pkg/timeutil/openperiod_test.go
@@ -348,6 +348,18 @@ func TestOpenPeriod(t *testing.T) {
 				period2:  OpenPeriod{From: &now, To: nil},
 				expected: nil,
 			},
+			{
+				name:     "zero length periods are not contained",
+				period1:  OpenPeriod{From: &now, To: &now},
+				period2:  OpenPeriod{From: &before, To: &after},
+				expected: nil,
+			},
+			{
+				name:     "zero length periods are not contained (other way around)",
+				period1:  OpenPeriod{From: &before, To: &after},
+				period2:  OpenPeriod{From: &now, To: &now},
+				expected: nil,
+			},
 		}
 
 		for _, tt := range tests {

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -140,6 +140,10 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 						Metadata: map[string]string{
 							"key": "value",
 						},
+						Annotations: models.Annotations{
+							"string_key": "value",
+							"float_key":  1.0,
+						},
 
 						PerUnitAmount: alpacadecimal.NewFromFloat(100),
 						PaymentTerm:   productcatalog.InAdvancePaymentTerm,
@@ -248,6 +252,10 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 
 				Metadata: map[string]string{
 					"key": "value",
+				},
+				Annotations: models.Annotations{
+					"string_key": "value",
+					"float_key":  1.0,
 				},
 			},
 			FlatFee: &billing.FlatFeeLine{

--- a/tools/migrate/migrations/20250707075725_billingline-annotations.down.sql
+++ b/tools/migrate/migrations/20250707075725_billingline-annotations.down.sql
@@ -1,0 +1,4 @@
+-- reverse: create index "billinginvoiceline_annotations" to table: "billing_invoice_lines"
+DROP INDEX "billinginvoiceline_annotations";
+-- reverse: modify "billing_invoice_lines" table
+ALTER TABLE "billing_invoice_lines" DROP COLUMN "annotations";

--- a/tools/migrate/migrations/20250707075725_billingline-annotations.up.sql
+++ b/tools/migrate/migrations/20250707075725_billingline-annotations.up.sql
@@ -1,0 +1,4 @@
+-- modify "billing_invoice_lines" table
+ALTER TABLE "billing_invoice_lines" ADD COLUMN "annotations" jsonb NULL;
+-- create index "billinginvoiceline_annotations" to table: "billing_invoice_lines"
+CREATE INDEX "billinginvoiceline_annotations" ON "billing_invoice_lines" USING gin ("annotations");

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:eVPfWnG3x1i+WMaG3TmZzfcjfW9g1YU1hOEj/bCzJWc=
+h1:jvfXldkcgTLzJfIOs/2ZcjxjAPWB0sdiUKj2dkwTcDI=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -111,3 +111,4 @@ h1:eVPfWnG3x1i+WMaG3TmZzfcjfW9g1YU1hOEj/bCzJWc=
 20250623133834_remove-billablesmustalign-from-plan.up.sql h1:kIfd0CDfC/sdcQFJD7krLnUMRTg6XEfEPVIBxljifLg=
 20250624115812_rm-subscription-alignment.up.sql h1:QS9su5IN4Hpm4eSX9af9mfwICXBXBexFzblD/OH98Sg=
 20250703081943_entitlement-usageperiod-interval-change.up.sql h1:b/wrWQCjYwtpd/akF3PKUgXCbe+2wb4uTb3YCnMinHY=
+20250707075725_billingline-annotations.up.sql h1:Tk1Y5+AKoYQXmePruAKzv1npmFlPEnJTnKDHTfrrrKI=


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Adds ignore annotation to billing (will be used for period fix migration)

Fixes OM-1239

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for storing and managing annotations on billing invoice lines, including a new annotations field that accepts arbitrary key-value data.
  * Introduced the ability to mark invoice lines to be ignored during subscription synchronization using a specific annotation.
  * Enhanced querying and updating capabilities for invoice line annotations.

* **Bug Fixes**
  * Improved handling of zero-length service periods to ensure accurate intersection logic.

* **Tests**
  * Added tests to verify correct handling of ignored invoice lines and validation of period intersection logic.

* **Database**
  * Added a new JSONB column and GIN index for annotations on invoice lines, with corresponding migration scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->