### PR TITLE
fix: namespace for Subject

### DIFF
--- a/openmeter/notification/consumer/entitlementbalancethreshold.go
+++ b/openmeter/notification/consumer/entitlementbalancethreshold.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/entitlement/snapshot"
 	"github.com/openmeterio/openmeter/openmeter/notification"
 	productcatalogdriver "github.com/openmeterio/openmeter/openmeter/productcatalog/driver"
+	subjecthttphandler "github.com/openmeterio/openmeter/openmeter/subject/httphandler"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
@@ -189,7 +190,7 @@ func (b *EntitlementSnapshotHandler) createEvent(ctx context.Context, in createB
 				EntitlementValuePayloadBase: notification.EntitlementValuePayloadBase{
 					Entitlement: *entitlementAPIEntity,
 					Feature:     productcatalogdriver.MapFeatureToResponse(in.Snapshot.Feature),
-					Subject:     in.Snapshot.Subject.ToAPIModel(),
+					Subject:     subjecthttphandler.FromSubject(in.Snapshot.Subject),
 					Value:       (api.EntitlementValue)(*in.Snapshot.Value),
 				},
 				Threshold: in.Threshold,

--- a/openmeter/notification/consumer/entitlementreset.go
+++ b/openmeter/notification/consumer/entitlementreset.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/entitlement/snapshot"
 	"github.com/openmeterio/openmeter/openmeter/notification"
 	productcatalogdriver "github.com/openmeterio/openmeter/openmeter/productcatalog/driver"
+	subjecthttphandler "github.com/openmeterio/openmeter/openmeter/subject/httphandler"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/sortx"
@@ -126,7 +127,7 @@ func (b *EntitlementSnapshotHandler) createResetEvent(ctx context.Context, in cr
 			EntitlementReset: &notification.EntitlementResetPayload{
 				Entitlement: *entitlementAPIEntity,
 				Feature:     productcatalogdriver.MapFeatureToResponse(in.Snapshot.Feature),
-				Subject:     in.Snapshot.Subject.ToAPIModel(),
+				Subject:     subjecthttphandler.FromSubject(in.Snapshot.Subject),
 				Value:       (api.EntitlementValue)(*in.Snapshot.Value),
 			},
 		},

--- a/openmeter/subject/adapter/subject.go
+++ b/openmeter/subject/adapter/subject.go
@@ -280,23 +280,24 @@ func (a *adapter) Delete(ctx context.Context, id models.NamespacedID) error {
 
 // mapEntity maps subject entity to subject model
 func mapEntity(subjectEntity *db.Subject) subject.Subject {
-	subject := subject.Subject{
-		Id:       subjectEntity.ID,
-		Key:      subjectEntity.Key,
-		Metadata: subjectEntity.Metadata,
+	s := subject.Subject{
+		Namespace: subjectEntity.Namespace,
+		Id:        subjectEntity.ID,
+		Key:       subjectEntity.Key,
+		Metadata:  subjectEntity.Metadata,
 	}
 
-	if subject.Metadata == nil {
-		subject.Metadata = make(map[string]interface{})
+	if s.Metadata == nil {
+		s.Metadata = make(map[string]interface{})
 	}
 
 	if subjectEntity.DisplayName != nil {
-		subject.DisplayName = subjectEntity.DisplayName
+		s.DisplayName = subjectEntity.DisplayName
 	}
 
 	if subjectEntity.StripeCustomerID != nil {
-		subject.StripeCustomerId = subjectEntity.StripeCustomerID
+		s.StripeCustomerId = subjectEntity.StripeCustomerID
 	}
 
-	return subject
+	return s
 }

--- a/openmeter/subject/httphandler/mapping.go
+++ b/openmeter/subject/httphandler/mapping.go
@@ -1,0 +1,28 @@
+package httpdriver
+
+import (
+	"github.com/openmeterio/openmeter/api"
+	"github.com/openmeterio/openmeter/openmeter/subject"
+)
+
+func FromSubject(s subject.Subject) api.Subject {
+	var metadata *map[string]interface{}
+
+	if s.Metadata != nil {
+		m := map[string]interface{}{}
+
+		for k, v := range s.Metadata {
+			m[k] = v
+		}
+
+		metadata = &m
+	}
+
+	return api.Subject{
+		Id:               s.Id,
+		Key:              s.Key,
+		DisplayName:      s.DisplayName,
+		Metadata:         metadata,
+		StripeCustomerId: s.StripeCustomerId,
+	}
+}

--- a/openmeter/subject/httphandler/subject.go
+++ b/openmeter/subject/httphandler/subject.go
@@ -56,7 +56,7 @@ func (h *handler) GetSubject() GetSubjectHandler {
 			}
 
 			// Respond with subject
-			return sub.ToAPIModel(), nil
+			return FromSubject(sub), nil
 		},
 		commonhttp.JSONResponseEncoderWithStatus[GetSubjectResponse](http.StatusOK),
 		httptransport.AppendOptions(
@@ -96,7 +96,7 @@ func (h *handler) ListSubjects() ListSubjectsHandler {
 
 			// Response
 			resp := pagination.MapPagedResponse(result, func(sub subject.Subject) api.Subject {
-				return sub.ToAPIModel()
+				return FromSubject(sub)
 			})
 
 			return resp.Items, nil
@@ -250,8 +250,8 @@ func (h *handler) UpsertSubject() UpsertSubjectHandler {
 			// Respond with updated subject(s)
 			var list []api.Subject
 
-			for _, subjectEntity := range subjects {
-				list = append(list, subjectEntity.ToAPIModel())
+			for _, sub := range subjects {
+				list = append(list, FromSubject(sub))
 			}
 
 			return list, nil

--- a/openmeter/subject/subject.go
+++ b/openmeter/subject/subject.go
@@ -2,12 +2,11 @@ package subject
 
 import (
 	"errors"
-
-	"github.com/openmeterio/openmeter/api"
 )
 
 // Subject represents a subject in the system.
 type Subject struct {
+	Namespace   string
 	Id          string
 	Key         string
 	DisplayName *string
@@ -24,29 +23,6 @@ func (s Subject) Validate() error {
 	}
 
 	return errors.Join(errs...)
-}
-
-// ToAPIModel converts the subject to the API model.
-func (s Subject) ToAPIModel() api.Subject {
-	var metadata *map[string]interface{}
-
-	if s.Metadata != nil {
-		m := map[string]interface{}{}
-
-		for k, v := range s.Metadata {
-			m[k] = v
-		}
-
-		metadata = &m
-	}
-
-	return api.Subject{
-		Id:               s.Id,
-		Key:              s.Key,
-		DisplayName:      s.DisplayName,
-		Metadata:         metadata,
-		StripeCustomerId: s.StripeCustomerId,
-	}
 }
 
 // SubjectKey is key only version of Subject


### PR DESCRIPTION
## Overview

Add `namespace` field to `Subject`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new field, "Namespace", to the Subject data structure.

* **Refactor**
  * Updated how Subject data is converted for API responses, replacing the previous conversion method with a new mapping function.
  * Improved consistency in how Subject information is handled across event payloads and API endpoints.

* **Chores**
  * Removed outdated conversion methods and updated internal logic to use the new mapping approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->