### PR TITLE
chore(collector): add statefulset replicas to helm chart

### DIFF
--- a/deploy/charts/benthos-collector/README.md
+++ b/deploy/charts/benthos-collector/README.md
@@ -25,6 +25,7 @@ helm install --generate-name --wait oci://ghcr.io/openmeterio/helm-charts/bentho
 | image.repository | string | `"ghcr.io/openmeterio/benthos-collector"` | Name of the image repository to pull the container image from. |
 | image.pullPolicy | string | `"IfNotPresent"` | [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node. |
 | image.tag | string | `""` | Image tag override for the default value (chart appVersion). |
+| replicaCount | int | `1` | Number of replicas of pods in the StatefulSet |
 | openmeter.url | string | `"https://openmeter.cloud"` | OpenMeter API URL |
 | openmeter.token | string | `""` | OpenMeter token |
 | config | object | `{}` | Benthos configuration Takes precedence over `configFile` and `preset`. |

--- a/deploy/charts/benthos-collector/templates/statefulset.yaml
+++ b/deploy/charts/benthos-collector/templates/statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "benthos-collector.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount | int }}
   serviceName: {{ include "benthos-collector.fullname" . }}
   selector:
     matchLabels:

--- a/deploy/charts/benthos-collector/values.yaml
+++ b/deploy/charts/benthos-collector/values.yaml
@@ -12,6 +12,9 @@ image:
   # -- Image tag override for the default value (chart appVersion).
   tag: ""
 
+# -- Number of replicas of pods in the StatefulSet
+replicaCount: 1
+
 openmeter:
   # -- OpenMeter API URL
   url: https://openmeter.cloud


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the number of replicas for the Benthos Collector deployment via Helm values.

* **Documentation**
  * Updated the README to document the new `replicaCount` configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->