### PR TITLE
feat: add customer subject service hook

### DIFF
--- a/app/common/billing.go
+++ b/app/common/billing.go
@@ -27,6 +27,7 @@ import (
 var Billing = wire.NewSet(
 	BillingService,
 	BillingAdapter,
+	wire.Bind(new(billing.CustomerOverrideService), new(billing.Service)),
 )
 
 func BillingAdapter(

--- a/app/common/config.go
+++ b/app/common/config.go
@@ -18,6 +18,8 @@ var Config = wire.NewSet(
 	wire.FieldsOf(new(config.BillingConfiguration), "FeatureSwitches"),
 	// ClickHouse
 	wire.FieldsOf(new(config.AggregationConfiguration), "ClickHouse"),
+	// Customer
+	wire.FieldsOf(new(config.Configuration), "Customer"),
 	// Database
 	wire.FieldsOf(new(config.Configuration), "Postgres"),
 	// Entitlement

--- a/app/common/customer.go
+++ b/app/common/customer.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/wire"
 
+	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customeradapter "github.com/openmeterio/openmeter/openmeter/customer/adapter"
@@ -57,11 +58,16 @@ func NewCustomerService(
 }
 
 func NewCustomerSubjectServiceHook(
+	config config.CustomerConfiguration,
 	logger *slog.Logger,
 	subjectService subject.Service,
 	customerService customer.Service,
 	customerOverrideService billing.CustomerOverrideService,
 ) (customerservicehooks.SubjectHook, error) {
+	if !config.EnableSubjectHook {
+		return new(customerservicehooks.NoopSubjectHook), nil
+	}
+
 	// Initialize the customer subject hook and register for subject service
 	h, err := customerservicehooks.NewSubjectHook(customerService, customerOverrideService, logger)
 	if err != nil {

--- a/app/common/customer.go
+++ b/app/common/customer.go
@@ -6,12 +6,15 @@ import (
 
 	"github.com/google/wire"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customeradapter "github.com/openmeterio/openmeter/openmeter/customer/adapter"
 	customerservice "github.com/openmeterio/openmeter/openmeter/customer/service"
+	customerservicehooks "github.com/openmeterio/openmeter/openmeter/customer/service/hooks"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	entitlementvalidator "github.com/openmeterio/openmeter/openmeter/entitlement/validators/customer"
 	"github.com/openmeterio/openmeter/openmeter/registry"
+	"github.com/openmeterio/openmeter/openmeter/subject"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 )
 
@@ -51,4 +54,21 @@ func NewCustomerService(
 	service.RegisterRequestValidator(validator)
 
 	return service, nil
+}
+
+func NewCustomerSubjectServiceHook(
+	logger *slog.Logger,
+	subjectService subject.Service,
+	customerService customer.Service,
+	customerOverrideService billing.CustomerOverrideService,
+) (customerservicehooks.SubjectHook, error) {
+	// Initialize the customer subject hook and register for subject service
+	h, err := customerservicehooks.NewSubjectHook(customerService, customerOverrideService, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create customer subject hook: %w", err)
+	}
+
+	subjectService.RegisterHooks(h)
+
+	return h, nil
 }

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -27,6 +27,7 @@ type Configuration struct {
 
 	Aggregation     AggregationConfiguration
 	Entitlements    EntitlementsConfiguration
+	Customer        CustomerConfiguration
 	Dedupe          DedupeConfiguration
 	Events          EventsConfiguration
 	Ingest          IngestConfiguration
@@ -143,6 +144,10 @@ func (c Configuration) Validate() error {
 		errs = append(errs, errorsx.WithPrefix(err, "termination"))
 	}
 
+	if err := c.Customer.Validate(); err != nil {
+		errs = append(errs, errorsx.WithPrefix(err, "customer"))
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -185,4 +190,5 @@ func SetViperDefaults(v *viper.Viper, flags *pflag.FlagSet) {
 	ConfigureEntitlements(v, flags)
 	ConfigureTermination(v, "termination")
 	ConfigureProgressManager(v)
+	ConfigureCustomer(v, "customer")
 }

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -403,6 +403,9 @@ func TestComplete(t *testing.T) {
 				PaginationSize:      10000,
 			},
 		},
+		Customer: CustomerConfiguration{
+			EnableSubjectHook: true,
+		},
 	}
 
 	assert.Equal(t, expected, actual)

--- a/app/config/customer.go
+++ b/app/config/customer.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"github.com/spf13/viper"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+var _ models.Validator = (*CustomerConfiguration)(nil)
+
+type CustomerConfiguration struct {
+	EnableSubjectHook bool
+}
+
+func (c CustomerConfiguration) Validate() error {
+	return nil
+}
+
+// ConfigureCustomer configures some defaults in the Viper instance.
+func ConfigureCustomer(v *viper.Viper, prefixes ...string) {
+	prefixer := NewViperKeyPrefixer(prefixes...)
+
+	v.SetDefault(prefixer("enableSubjectHook"), false)
+}

--- a/app/config/testdata/complete.yaml
+++ b/app/config/testdata/complete.yaml
@@ -106,6 +106,9 @@ sink:
       - "range"
       - "roundrobin"
 
+customer:
+  enableSubjectHook: true
+
 dedupe:
   enabled: true
   driver: redis

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	customerservicehooks "github.com/openmeterio/openmeter/openmeter/customer/service/hooks"
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/ingest"
 	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest"
@@ -45,6 +46,7 @@ type Application struct {
 	Addon                       addon.Service
 	AppRegistry                 common.AppRegistry
 	Customer                    customer.Service
+	CustomerSubjectHook         customerservicehooks.SubjectHook
 	Billing                     billing.Service
 	EntClient                   *db.Client
 	EventPublisher              eventbus.Publisher
@@ -85,6 +87,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		common.ClickHouse,
 		common.Config,
 		common.Customer,
+		common.NewCustomerSubjectServiceHook,
 		common.Database,
 		common.Entitlement,
 		common.Framework,

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -342,6 +342,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	appRegistry := common.NewAppRegistry(appService, appSandboxProvisioner, appstripeService, appcustominvoicingService)
+	customerConfiguration := conf.Customer
 	subjectAdapter, err := common.NewSubjectAdapter(client)
 	if err != nil {
 		cleanup6()
@@ -362,7 +363,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	v3, err := common.NewCustomerSubjectServiceHook(logger, subjectService, customerService, billingService)
+	v3, err := common.NewCustomerSubjectServiceHook(customerConfiguration, logger, subjectService, customerService, billingService)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/customer/service/hooks"
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/ingest"
 	"github.com/openmeterio/openmeter/openmeter/ingest/kafkaingest"
@@ -341,6 +342,36 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	appRegistry := common.NewAppRegistry(appService, appSandboxProvisioner, appstripeService, appcustominvoicingService)
+	subjectAdapter, err := common.NewSubjectAdapter(client)
+	if err != nil {
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
+	subjectService, err := common.NewSubjectService(subjectAdapter)
+	if err != nil {
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
+	v3, err := common.NewCustomerSubjectServiceHook(logger, subjectService, customerService, billingService)
+	if err != nil {
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
 	dedupeConfiguration := conf.Dedupe
 	producer, err := common.NewKafkaProducer(kafkaIngestConfiguration, logger, commonMetadata)
 	if err != nil {
@@ -415,9 +446,9 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	v3 := conf.Meters
+	v4 := conf.Meters
 	manageService := common.NewMeterManageService(adapter, manager, eventbusPublisher)
-	v4 := common.NewMeterConfigInitializer(logger, v3, manageService, manager)
+	v5 := common.NewMeterConfigInitializer(logger, v4, manageService, manager)
 	metereventService := common.NewMeterEventService(connector, service)
 	repository, err := common.NewNotificationAdapter(logger, client)
 	if err != nil {
@@ -432,8 +463,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	}
 	notificationConfiguration := conf.Notification
 	webhookConfiguration := notificationConfiguration.Webhook
-	v5 := conf.Svix
-	handler, err := common.NewNotificationWebhookHandler(logger, webhookConfiguration, v5)
+	v6 := conf.Svix
+	handler, err := common.NewNotificationWebhookHandler(logger, webhookConfiguration, v6)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -480,32 +511,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	v6 := common.NewTelemetryRouterHook(meterProvider, tracerProvider)
-	routerHooks := common.NewRouterHooks(v6)
-	subjectAdapter, err := common.NewSubjectAdapter(client)
-	if err != nil {
-		cleanup8()
-		cleanup7()
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return Application{}, nil, err
-	}
-	subjectService, err := common.NewSubjectService(subjectAdapter)
-	if err != nil {
-		cleanup8()
-		cleanup7()
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return Application{}, nil, err
-	}
+	v7 := common.NewTelemetryRouterHook(meterProvider, tracerProvider)
+	routerHooks := common.NewRouterHooks(v7)
 	health := common.NewHealthChecker(logger)
 	runtimeMetricsCollector, err := common.NewRuntimeMetricsCollector(meterProvider, telemetryConfig, logger)
 	if err != nil {
@@ -520,7 +527,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	telemetryHandler := common.NewTelemetryHandler(metricsTelemetryConfig, health, runtimeMetricsCollector, logger)
-	v7, cleanup9 := common.NewTelemetryServer(telemetryConfig, telemetryHandler)
+	v8, cleanup9 := common.NewTelemetryServer(telemetryConfig, telemetryHandler)
 	terminationConfig := conf.Termination
 	terminationChecker, err := common.NewTerminationChecker(terminationConfig, health)
 	if err != nil {
@@ -541,6 +548,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		Addon:                       addonService,
 		AppRegistry:                 appRegistry,
 		Customer:                    customerService,
+		CustomerSubjectHook:         v3,
 		Billing:                     billingService,
 		EntClient:                   client,
 		EventPublisher:              eventbusPublisher,
@@ -553,7 +561,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		KafkaIngestNamespaceHandler: namespaceHandler,
 		Logger:                      logger,
 		MetricMeter:                 meter,
-		MeterConfigInitializer:      v4,
+		MeterConfigInitializer:      v5,
 		MeterManageService:          manageService,
 		MeterEventService:           metereventService,
 		NamespaceManager:            manager,
@@ -567,7 +575,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		SubjectService:              subjectService,
 		Subscription:                subscriptionServiceWithWorkflow,
 		StreamingConnector:          connector,
-		TelemetryServer:             v7,
+		TelemetryServer:             v8,
 		TerminationChecker:          terminationChecker,
 		RuntimeMetricsCollector:     runtimeMetricsCollector,
 		Tracer:                      tracer,
@@ -594,6 +602,7 @@ type Application struct {
 	Addon                       addon.Service
 	AppRegistry                 common.AppRegistry
 	Customer                    customer.Service
+	CustomerSubjectHook         hooks.SubjectHook
 	Billing                     billing.Service
 	EntClient                   *db.Client
 	EventPublisher              eventbus.Publisher

--- a/openmeter/customer/service/hooks/subject.go
+++ b/openmeter/customer/service/hooks/subject.go
@@ -1,0 +1,441 @@
+package hooks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/app"
+	appstripeentity "github.com/openmeterio/openmeter/openmeter/app/stripe/entity"
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/subject"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type (
+	SubjectHook     = models.ServiceHook[subject.Subject]
+	NoopSubjectHook = models.NoopServiceHook[subject.Subject]
+)
+
+var _ models.ServiceHook[subject.Subject] = (*subjectHook)(nil)
+
+type subjectHook struct {
+	models.NoopServiceHook[subject.Subject]
+
+	provisioner *CustomerProvisioner
+	logger      *slog.Logger
+}
+
+func (s subjectHook) PostCreate(ctx context.Context, sub *subject.Subject) error {
+	return s.provisioner.ProvisionCustomerForSubject(ctx, sub)
+}
+
+func (s subjectHook) PostUpdate(ctx context.Context, sub *subject.Subject) error {
+	return s.provisioner.ProvisionCustomerForSubject(ctx, sub)
+}
+
+func NewSubjectHook(
+	customer customer.Service,
+	customerOverride billing.CustomerOverrideService,
+	logger *slog.Logger,
+) (SubjectHook, error) {
+	if customer == nil {
+		return nil, fmt.Errorf("customer service is required")
+	}
+
+	if logger == nil {
+		return nil, fmt.Errorf("logger is required")
+	}
+
+	provisioner, err := NewCustomerProvisioner(CustomerProvisionerConfig{
+		Customer:         customer,
+		CustomerOverride: customerOverride,
+		Logger:           logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize customer provisioner: %w", err)
+	}
+
+	return &subjectHook{
+		provisioner: provisioner,
+		logger:      logger.With("subsystem", "customer.subject.hook"),
+	}, nil
+}
+
+func CmpSubjectCustomer(s *subject.Subject, c *customer.Customer) bool {
+	if c == nil || s == nil {
+		return false
+	}
+
+	if c.Namespace != s.Namespace {
+		return false
+	}
+
+	if !lo.Contains(c.UsageAttribution.SubjectKeys, s.Key) {
+		return false
+	}
+
+	if c.Key == nil {
+		return false
+	}
+
+	if s.DisplayName != nil && *s.DisplayName != c.Name {
+		return false
+	}
+
+	sm := MetadataFromMap(s.Metadata)
+	cm := lo.FromPtr(c.Metadata)
+	for k, v := range sm {
+		if vv, ok := cm[k]; !ok || vv != v {
+			return false
+		}
+	}
+
+	return true
+}
+
+var _ models.Validator = (*CustomerProvisionerConfig)(nil)
+
+type CustomerProvisionerConfig struct {
+	Customer         customer.Service
+	CustomerOverride billing.CustomerOverrideService
+	Logger           *slog.Logger
+}
+
+func (c CustomerProvisionerConfig) Validate() error {
+	var errs []error
+
+	if c.Customer == nil {
+		errs = append(errs, fmt.Errorf("customer service is required"))
+	}
+
+	if c.CustomerOverride == nil {
+		errs = append(errs, fmt.Errorf("customer override service is required"))
+	}
+
+	if c.Logger == nil {
+		errs = append(errs, fmt.Errorf("logger is required"))
+	}
+
+	return errors.Join(errs...)
+}
+
+func NewCustomerProvisioner(config CustomerProvisionerConfig) (*CustomerProvisioner, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid customer provisioner config: %w", err)
+	}
+
+	return &CustomerProvisioner{
+		customer:         config.Customer,
+		customerOverride: config.CustomerOverride,
+		logger:           config.Logger.With("subsystem", "customer.provisioner"),
+	}, nil
+}
+
+type CustomerProvisioner struct {
+	customer         customer.Service
+	customerOverride billing.CustomerOverrideService
+	logger           *slog.Logger
+}
+
+var ErrCustomerKeyConflict = errors.New("customer key conflict")
+
+func (p CustomerProvisioner) GetCustomerForSubject(ctx context.Context, sub *subject.Subject) (*customer.Customer, error) {
+	var (
+		cus *customer.Customer
+		err error
+	)
+
+	// Try to find Customer for Subject by key
+	cus, err = p.customer.GetCustomer(ctx, customer.GetCustomerInput{
+		CustomerKey: &customer.CustomerKey{
+			Namespace: sub.Namespace,
+			Key:       sub.Key,
+		},
+	})
+	if err != nil && !models.IsGenericNotFoundError(err) {
+		return nil, err
+	}
+
+	// Return Customer if it has the Subject in usage attribution.
+	// There are cases where the Customer and the Subject have the same key,
+	// while the Subject is not included in the Customers usage attribution.
+	// In this case the Customer must not match the Subject.
+	if cus != nil {
+		if lo.Contains(cus.UsageAttribution.SubjectKeys, sub.Key) {
+			return cus, nil
+		}
+
+		return nil, ErrCustomerKeyConflict
+	}
+
+	// Try to find Customer for Subject by usage attribution
+	return p.customer.GetCustomerByUsageAttribution(ctx, customer.GetCustomerByUsageAttributionInput{
+		Namespace:  sub.Namespace,
+		SubjectKey: sub.Key,
+	})
+}
+
+// EnsureCustomer returns a Customer entity created/updated based on the provided Subject.
+func (p CustomerProvisioner) EnsureCustomer(ctx context.Context, sub *subject.Subject) (*customer.Customer, error) {
+	if sub == nil {
+		return nil, errors.New("failed to provision customer for subject: subject is nil")
+	}
+
+	var keyConflict bool
+
+	cus, err := p.GetCustomerForSubject(ctx, sub)
+	if err != nil {
+		if errors.Is(err, ErrCustomerKeyConflict) {
+			keyConflict = true
+		} else if !models.IsGenericNotFoundError(err) {
+			return nil, err
+		}
+	}
+
+	annotations := models.Annotations{
+		"createdBy": "customer.subject.hook",
+		"subjectId": sub.Id,
+	}
+
+	if sub.StripeCustomerId != nil {
+		annotations["stripeCustomerId"] = *sub.StripeCustomerId
+	}
+
+	if cus != nil {
+		if CmpSubjectCustomer(sub, cus) {
+			return cus, nil
+		}
+
+		// Update Customer for Subject in case there is non to be found
+		cus, err = p.customer.UpdateCustomer(ctx, customer.UpdateCustomerInput{
+			CustomerID: customer.CustomerID{
+				Namespace: cus.Namespace,
+				ID:        cus.ID,
+			},
+			CustomerMutate: customer.CustomerMutate{
+				Key:              lo.ToPtr(lo.FromPtrOr(cus.Key, sub.Key)),
+				Name:             lo.FromPtr(sub.DisplayName),
+				Description:      cus.Description,
+				UsageAttribution: cus.UsageAttribution,
+				PrimaryEmail:     cus.PrimaryEmail,
+				Currency:         cus.Currency,
+				BillingAddress:   cus.BillingAddress,
+				Metadata:         lo.ToPtr(cus.Metadata.Merge(MetadataFromMap(sub.Metadata))),
+				Annotation: func() *models.Annotations {
+					if len(lo.FromPtr(cus.Annotation)) == 0 && len(annotations) == 0 {
+						return nil
+					}
+
+					m := make(models.Annotations)
+
+					maps.Copy(m, lo.FromPtr(cus.Annotation))
+					maps.Copy(m, annotations)
+
+					return &m
+				}(),
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to update customer for subject [namespace=%s customer.id=%s]: %w",
+				cus.Namespace, cus.ID, err)
+		}
+
+		return cus, nil
+	}
+
+	// Create Customer for Subject in case there is none to be found
+	return p.customer.CreateCustomer(ctx, customer.CreateCustomerInput{
+		Namespace: sub.Namespace,
+		CustomerMutate: customer.CustomerMutate{
+			Key: func() *string {
+				if keyConflict {
+					return nil
+				}
+
+				return lo.ToPtr(sub.Key)
+			}(),
+			Name:        lo.FromPtrOr(sub.DisplayName, sub.Key),
+			Description: nil,
+			UsageAttribution: customer.CustomerUsageAttribution{
+				SubjectKeys: []string{sub.Key},
+			},
+			PrimaryEmail:   nil,
+			Currency:       nil,
+			BillingAddress: nil,
+			Metadata:       lo.ToPtr(MetadataFromMap(sub.Metadata)),
+			Annotation:     &annotations,
+		},
+	})
+}
+
+func (p CustomerProvisioner) EnsureStripeCustomer(ctx context.Context, customerID customer.CustomerID, stripeCustomerID string) error {
+	customerOverride, err := p.customerOverride.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
+		Customer: customerID,
+		Expand: billing.CustomerOverrideExpand{
+			Apps: true,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get customer override for subject [namespace=%s customer.id=%s]: %w",
+			customerID.Namespace, customerID.ID, err)
+	}
+
+	profile := customerOverride.MergedProfile
+
+	if profile.Apps == nil {
+		return fmt.Errorf("failed to setup stripe customer id for customer [namespace=%s customer.id=%s]: apps profile is nil",
+			customerID.Namespace, customerID.ID)
+	}
+
+	if appPaymentType := profile.Apps.Payment.GetType(); appPaymentType != app.AppTypeStripe {
+		return fmt.Errorf("failed to setup stripe customer id for customer [namespace=%s customer.id=%s app.payment.type=%s]: payment app is not stripe",
+			customerID.Namespace, customerID.ID, appPaymentType)
+	}
+
+	err = profile.Apps.Payment.UpsertCustomerData(ctx, app.UpsertAppInstanceCustomerDataInput{
+		CustomerID: customerID,
+		Data: appstripeentity.CustomerData{
+			StripeCustomerID: stripeCustomerID,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to setup stripe customer id for customer [namespace=%s customer.id=%s]: %w",
+			customerID.Namespace, customerID.ID, err)
+	}
+
+	return nil
+}
+
+func (p CustomerProvisioner) ProvisionCustomerForSubject(ctx context.Context, sub *subject.Subject) error {
+	cus, err := p.EnsureCustomer(ctx, sub)
+	if err != nil {
+		return fmt.Errorf("failed to provision customer for subject [namespace=%s subject.id=%s subject.key=%s]: %w",
+			sub.Namespace, sub.Id, sub.Key, err)
+	}
+
+	customerID := customer.CustomerID{
+		Namespace: cus.Namespace,
+		ID:        cus.ID,
+	}
+
+	if sub.StripeCustomerId != nil {
+		if err := p.EnsureStripeCustomer(ctx, customerID, *sub.StripeCustomerId); err != nil {
+			return fmt.Errorf("failed to update stripe customer id for subject customer [namespace=%s subject.id=%s subject.key=%s customer.id=%s]: %w",
+				sub.Namespace, sub.Id, sub.Key, cus.ID, err)
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func MetadataFromMap(m map[string]interface{}) models.Metadata {
+	if len(m) == 0 {
+		return nil
+	}
+
+	var metadata models.Metadata
+
+	for k, v := range m {
+		if value := toString(v, 0); value != "" {
+			if metadata == nil {
+				metadata = make(models.Metadata)
+			}
+
+			metadata[k] = value
+		}
+	}
+
+	return metadata
+}
+
+func toString(v interface{}, rec int) string {
+	if v == nil {
+		return ""
+	}
+
+	if rec > 1 {
+		return ""
+	}
+
+	vv := reflect.ValueOf(v)
+
+	switch vv.Kind() {
+	case reflect.Ptr:
+		if vv.IsNil() {
+			return ""
+		}
+
+		return toString(vv.Elem().Interface(), rec+1)
+	case reflect.Map:
+		if vv.Len() == 0 {
+			return ""
+		}
+
+		var result []string
+		for _, k := range vv.MapKeys() {
+			if k.Kind() != reflect.String {
+				continue
+			}
+
+			if s := toString(vv.MapIndex(k).Interface(), rec+1); s != "" {
+				result = append(result, `"`+k.String()+`"="`+s+`"`)
+			}
+		}
+
+		return strings.Join(result, ",")
+	case reflect.Slice:
+		if vv.Len() == 0 {
+			return ""
+		}
+
+		var result []string
+		for i := 0; i < vv.Len(); i++ {
+			if s := toString(vv.Index(i).Interface(), rec+1); s != "" {
+				result = append(result, `"`+s+`"`)
+			}
+		}
+
+		return strings.Join(result, ",")
+	case reflect.String:
+		return v.(string)
+	case reflect.Int:
+		return strconv.FormatInt(int64(v.(int)), 10)
+	case reflect.Int8:
+		return strconv.FormatInt(int64(v.(int8)), 10)
+	case reflect.Int16:
+		return strconv.FormatInt(int64(v.(int16)), 10)
+	case reflect.Int32:
+		return strconv.FormatInt(int64(v.(int32)), 10)
+	case reflect.Int64:
+		return strconv.FormatInt(v.(int64), 10)
+	case reflect.Uint:
+		return strconv.FormatUint(uint64(v.(uint)), 10)
+	case reflect.Uint8:
+		return strconv.FormatUint(uint64(v.(uint8)), 10)
+	case reflect.Uint16:
+		return strconv.FormatUint(uint64(v.(uint16)), 10)
+	case reflect.Uint32:
+		return strconv.FormatUint(uint64(v.(uint32)), 10)
+	case reflect.Uint64:
+		return strconv.FormatUint(v.(uint64), 10)
+	case reflect.Float32:
+		return strconv.FormatFloat(float64(v.(float32)), 'f', -1, 32)
+	case reflect.Float64:
+		return strconv.FormatFloat(v.(float64), 'f', -1, 64)
+	case reflect.Bool:
+		return strconv.FormatBool(v.(bool))
+	default:
+		return ""
+	}
+}

--- a/openmeter/customer/service/hooks/subject_test.go
+++ b/openmeter/customer/service/hooks/subject_test.go
@@ -1,0 +1,457 @@
+package hooks
+
+import (
+	"crypto/rand"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/app/config"
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	customeradapter "github.com/openmeterio/openmeter/openmeter/customer/adapter"
+	customerservice "github.com/openmeterio/openmeter/openmeter/customer/service"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	meteradapter "github.com/openmeterio/openmeter/openmeter/meter/mockadapter"
+	registrybuilder "github.com/openmeterio/openmeter/openmeter/registry/builder"
+	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+	"github.com/openmeterio/openmeter/openmeter/subject"
+	subjectadapter "github.com/openmeterio/openmeter/openmeter/subject/adapter"
+	subjectservice "github.com/openmeterio/openmeter/openmeter/subject/service"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/framework/lockr"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestCustomerProvisioner_EnsureCustomer(t *testing.T) {
+	// Setup test environment
+	env := NewTestEnv(t)
+	t.Cleanup(func() {
+		env.Close(t)
+	})
+
+	// Run database migrations
+	env.DBSchemaMigrate(t)
+
+	// Get new namespace ID
+	namespace := NewTestNamespace(t)
+
+	provisioner := CustomerProvisioner{
+		customer:         env.CustomerService,
+		customerOverride: nil,
+		logger:           env.Logger,
+	}
+
+	ctx := t.Context()
+
+	t.Run("Create", func(t *testing.T) {
+		sub, err := env.SubjectService.Create(ctx, subject.CreateInput{
+			Namespace:        namespace,
+			Key:              "acme-inc",
+			DisplayName:      lo.ToPtr("ACME Inc."),
+			StripeCustomerId: lo.ToPtr("cus_abcdefgh"),
+			Metadata: lo.ToPtr(map[string]interface{}{
+				"foo": "bar",
+				"bar": 1,
+				"baz": true,
+			}),
+		})
+		require.NoError(t, err, "creating subject should not fail")
+		assert.NotNilf(t, sub, "subject must not be nil")
+
+		cus, err := provisioner.GetCustomerForSubject(ctx, &sub)
+		require.ErrorAsf(t, err, new(*models.GenericNotFoundError), "error must be not found error")
+		assert.Nilf(t, cus, "customer must be nil")
+
+		cus, err = provisioner.EnsureCustomer(ctx, &sub)
+		require.NoError(t, err, "provisioning customer should not fail")
+		assert.NotNilf(t, cus, "customer must not be nil")
+
+		cus, err = env.CustomerService.GetCustomer(ctx, customer.GetCustomerInput{
+			CustomerID: &customer.CustomerID{
+				Namespace: cus.Namespace,
+				ID:        cus.ID,
+			},
+		})
+		require.NoErrorf(t, err, "getting customer for subject should not fail")
+		assert.NotNilf(t, cus, "customer must not be nil")
+		AssertSubjectCustomerStrictEqual(t, &sub, cus)
+
+		t.Run("Update", func(t *testing.T) {
+			sub, err = env.SubjectService.Update(ctx, subject.UpdateInput{
+				ID:        sub.Id,
+				Namespace: sub.Namespace,
+				DisplayName: subject.OptionalNullable[string]{
+					Value: lo.ToPtr("ACME2 Inc."),
+					IsSet: true,
+				},
+				StripeCustomerId: subject.OptionalNullable[string]{
+					Value: lo.ToPtr("cus_12345678"),
+					IsSet: true,
+				},
+				Metadata: subject.OptionalNullable[map[string]interface{}]{
+					Value: lo.ToPtr(map[string]interface{}{
+						"foo": "bar",
+						"bar": 1,
+						"baz": false,
+					}),
+					IsSet: true,
+				},
+			})
+			require.NoError(t, err, "updating subject should not fail")
+			assert.NotNilf(t, sub, "subject must not be nil")
+
+			cus, err = env.CustomerService.UpdateCustomer(ctx, customer.UpdateCustomerInput{
+				CustomerID: customer.CustomerID{
+					Namespace: cus.Namespace,
+					ID:        cus.ID,
+				},
+				CustomerMutate: customer.CustomerMutate{
+					Key:  lo.ToPtr("example-corp"),
+					Name: "Example Corporation",
+					Metadata: lo.ToPtr(models.Metadata{
+						"buz": "qux",
+					}),
+					UsageAttribution: cus.UsageAttribution,
+				},
+			})
+			require.NoError(t, err, "updating customer should not fail")
+			assert.NotNilf(t, sub, "customer must not be nil")
+
+			cus, err = provisioner.EnsureCustomer(ctx, &sub)
+			require.NoError(t, err, "provisioning customer should not fail")
+			assert.NotNilf(t, cus, "customer must not be nil")
+
+			cus, err = env.CustomerService.GetCustomer(ctx, customer.GetCustomerInput{
+				CustomerID: &customer.CustomerID{
+					Namespace: cus.Namespace,
+					ID:        cus.ID,
+				},
+			})
+			require.NoErrorf(t, err, "getting customer for subject should not fail")
+			assert.NotNilf(t, cus, "customer must not be nil")
+			AssertSubjectCustomerEqual(t, &sub, cus)
+		})
+	})
+
+	t.Run("Conflict", func(t *testing.T) {
+		t.Run("CustomerUsageAttributionMismatch", func(t *testing.T) {
+			sub, err := env.SubjectService.Create(ctx, subject.CreateInput{
+				Namespace:        namespace,
+				Key:              "org-1",
+				DisplayName:      lo.ToPtr("Org. 1"),
+				StripeCustomerId: lo.ToPtr("cus_abcdefgh"),
+				Metadata: lo.ToPtr(map[string]interface{}{
+					"foo": "bar",
+					"bar": 1,
+					"baz": true,
+				}),
+			})
+			require.NoError(t, err, "creating subject should not fail")
+			assert.NotNilf(t, sub, "subject must not be nil")
+
+			cus, err := env.CustomerService.CreateCustomer(ctx, customer.CreateCustomerInput{
+				Namespace: namespace,
+				CustomerMutate: customer.CustomerMutate{
+					Key:         lo.ToPtr(sub.Key),
+					Name:        "Org. 1",
+					Description: nil,
+					UsageAttribution: customer.CustomerUsageAttribution{
+						SubjectKeys: []string{
+							"not-" + sub.Key,
+						},
+					},
+					PrimaryEmail:   nil,
+					Currency:       nil,
+					BillingAddress: nil,
+					Metadata: &models.Metadata{
+						"baz": "qux",
+					},
+					Annotation: nil,
+				},
+			})
+			require.NoError(t, err, "creating customer should not fail")
+			assert.NotNilf(t, cus, "customer must not be nil")
+
+			cus, err = provisioner.EnsureCustomer(ctx, &sub)
+			require.NoError(t, err, "provisioning customer should not fail")
+			assert.NotNilf(t, cus, "customer must not be nil")
+
+			cus, err = env.CustomerService.GetCustomer(ctx, customer.GetCustomerInput{
+				CustomerID: &customer.CustomerID{
+					Namespace: cus.Namespace,
+					ID:        cus.ID,
+				},
+			})
+			require.NoErrorf(t, err, "getting customer for subject should not fail")
+			assert.NotNilf(t, cus, "customer must not be nil")
+			AssertSubjectCustomerEqual(t, &sub, cus)
+		})
+
+		t.Run("CustomerKeyMismatch", func(t *testing.T) {
+			sub, err := env.SubjectService.Create(ctx, subject.CreateInput{
+				Namespace:        namespace,
+				Key:              "org-10",
+				DisplayName:      lo.ToPtr("Org. 10"),
+				StripeCustomerId: lo.ToPtr("cus_abcdefgh"),
+				Metadata: lo.ToPtr(map[string]interface{}{
+					"foo": "bar",
+					"bar": 1,
+					"baz": true,
+				}),
+			})
+			require.NoError(t, err, "creating subject should not fail")
+			assert.NotNilf(t, sub, "subject must not be nil")
+
+			cus, err := env.CustomerService.CreateCustomer(ctx, customer.CreateCustomerInput{
+				Namespace: namespace,
+				CustomerMutate: customer.CustomerMutate{
+					Key:         lo.ToPtr("not-" + sub.Key),
+					Name:        "Org. 30",
+					Description: nil,
+					UsageAttribution: customer.CustomerUsageAttribution{
+						SubjectKeys: []string{
+							sub.Key,
+						},
+					},
+					PrimaryEmail:   nil,
+					Currency:       nil,
+					BillingAddress: nil,
+					Metadata: &models.Metadata{
+						"baz": "qux",
+					},
+					Annotation: nil,
+				},
+			})
+			require.NoError(t, err, "creating customer should not fail")
+			assert.NotNilf(t, cus, "customer must not be nil")
+
+			cus, err = provisioner.EnsureCustomer(ctx, &sub)
+			require.NoError(t, err, "provisioning customer should not fail")
+			assert.NotNilf(t, cus, "customer must not be nil")
+
+			cus, err = env.CustomerService.GetCustomer(ctx, customer.GetCustomerInput{
+				CustomerID: &customer.CustomerID{
+					Namespace: cus.Namespace,
+					ID:        cus.ID,
+				},
+			})
+			require.NoErrorf(t, err, "getting customer for subject should not fail")
+			assert.NotNilf(t, cus, "customer must not be nil")
+			AssertSubjectCustomerEqual(t, &sub, cus)
+		})
+	})
+}
+
+func AssertSubjectCustomerStrictEqual(t *testing.T, s *subject.Subject, c *customer.Customer) {
+	t.Helper()
+
+	assert.Equalf(t, s.Key, lo.FromPtr(c.Key), "subject key must be equal to customer key")
+
+	AssertSubjectCustomerEqual(t, s, c)
+}
+
+func AssertSubjectCustomerEqual(t *testing.T, s *subject.Subject, c *customer.Customer) {
+	t.Helper()
+
+	assert.Equalf(t, s.Namespace, c.Namespace, "subject namespace must be equal to customer namespace")
+	assert.Containsf(t, c.UsageAttribution.SubjectKeys, s.Key, "customer usage attribute must contain subject key")
+	assert.Equalf(t, lo.FromPtr(s.DisplayName), c.Name, "subject display name must be equal to customer display name")
+
+	sm := MetadataFromMap(s.Metadata)
+	cm := lo.FromPtr(c.Metadata)
+	for k, v := range sm {
+		vv, ok := cm[k]
+		assert.Truef(t, ok, "customer metadata must contain subject metadata key %s", k)
+		assert.Equalf(t, v, vv, "customer metadata value must be equal to subject metadata value")
+	}
+}
+
+func NewTestULID(t *testing.T) string {
+	t.Helper()
+
+	return ulid.MustNew(ulid.Timestamp(time.Now().UTC()), rand.Reader).String()
+}
+
+var NewTestNamespace = NewTestULID
+
+type TestEnv struct {
+	Logger          *slog.Logger
+	SubjectService  subject.Service
+	CustomerService customer.Service
+
+	Client *entdb.Client
+	db     *testutils.TestDB
+	close  sync.Once
+}
+
+func (e *TestEnv) DBSchemaMigrate(t *testing.T) {
+	t.Helper()
+
+	require.NotNilf(t, e.db, "database must be initialized")
+
+	err := e.db.EntDriver.Client().Schema.Create(t.Context())
+	require.NoErrorf(t, err, "schema migration must not fail")
+}
+
+func (e *TestEnv) Close(t *testing.T) {
+	t.Helper()
+
+	e.close.Do(func() {
+		if e.db != nil {
+			if err := e.db.EntDriver.Close(); err != nil {
+				t.Errorf("failed to close ent driver: %v", err)
+			}
+
+			if err := e.db.PGDriver.Close(); err != nil {
+				t.Errorf("failed to postgres driver: %v", err)
+			}
+		}
+
+		if e.Client != nil {
+			if err := e.Client.Close(); err != nil {
+				t.Errorf("failed to close ent client: %v", err)
+			}
+		}
+	})
+}
+
+func NewTestEnv(t *testing.T) *TestEnv {
+	t.Helper()
+
+	// Init logger
+	logger := testutils.NewDiscardLogger(t)
+
+	// Init database
+	db := testutils.InitPostgresDB(t)
+	client := db.EntDriver.Client()
+
+	// Init event publisher
+	publisher := eventbus.NewMock(t)
+
+	// Init meter service
+	meterAdapter, err := meteradapter.New(nil)
+	require.NoErrorf(t, err, "initializing meter adapter must not fail")
+	require.NotNilf(t, meterAdapter, "meter adapter must not be nil")
+
+	// Init lockr
+	locker, err := lockr.NewLocker(&lockr.LockerConfig{
+		Logger: slog.Default(),
+	})
+	require.NoError(t, err, "initializing lockr must not fail")
+
+	// Entitlement
+	entitlementRegistry := registrybuilder.GetEntitlementRegistry(registrybuilder.EntitlementOptions{
+		DatabaseClient:     client,
+		StreamingConnector: streamingtestutils.NewMockStreamingConnector(t),
+		Logger:             logger,
+		MeterService:       meterAdapter,
+		Publisher:          publisher,
+		EntitlementsConfiguration: config.EntitlementsConfiguration{
+			GracePeriod: datetime.ISODurationString("P1D"),
+		},
+		Locker: locker,
+	})
+
+	// Init subject service
+	subjectAdapter, err := subjectadapter.New(client)
+	require.NoErrorf(t, err, "initializing subject adapter must not fail")
+	require.NotNilf(t, subjectAdapter, "subject adapter must not be nil")
+
+	subjectService, err := subjectservice.New(subjectAdapter)
+	require.NoErrorf(t, err, "initializing subject service must not fail")
+	require.NotNilf(t, subjectAdapter, "subject service must not be nil")
+
+	// Init Customer service
+	customerAdapter, err := customeradapter.New(customeradapter.Config{
+		Client: client,
+		Logger: logger,
+	})
+	require.NoErrorf(t, err, "initializing customer adapter must not fail")
+	require.NotNilf(t, customerAdapter, "customer adapter must not be nil")
+
+	customerService, err := customerservice.New(customerservice.Config{
+		Adapter:              customerAdapter,
+		EntitlementConnector: entitlementRegistry.Entitlement,
+		Publisher:            publisher,
+	})
+	require.NoErrorf(t, err, "initializing subject service must not fail")
+	require.NotNilf(t, subjectAdapter, "subject service must not be nil")
+
+	return &TestEnv{
+		Logger:          logger,
+		SubjectService:  subjectService,
+		CustomerService: customerService,
+		Client:          client,
+		db:              db,
+		close:           sync.Once{},
+	}
+}
+
+func TestMetadataFromMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata map[string]interface{}
+		expected models.Metadata
+	}{
+		{
+			name: "string",
+			metadata: map[string]interface{}{
+				"foo": "bar",
+			},
+			expected: models.Metadata{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "skip",
+			metadata: map[string]interface{}{
+				"a":  true,
+				"b":  "baz",
+				"c":  nil,
+				"d1": 1,
+				"d2": int8(2),
+				"d3": int16(3),
+				"d4": int32(4),
+				"d5": int64(5),
+				"e":  []string{"bar", "buzz"},
+				"f1": float32(3.14),
+				"f2": 3.14,
+				"g": map[string]interface{}{
+					"foo": "bar",
+					"bar": "baz",
+				},
+				"h": lo.ToPtr(true),
+			},
+			expected: models.Metadata{
+				"a":  "true",
+				"b":  "baz",
+				"d1": "1",
+				"d2": "2",
+				"d3": "3",
+				"d4": "4",
+				"d5": "5",
+				"e":  `"bar","buzz"`,
+				"f1": "3.14",
+				"f2": "3.14",
+				"g":  `"foo"="bar","bar"="baz"`,
+				"h":  "true",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := MetadataFromMap(test.metadata)
+
+			assert.Equalf(t, test.expected, actual, "expected: %v, actual: %v", test.expected, actual)
+		})
+	}
+}

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1512,6 +1512,8 @@ var _ subject.Service = &NoopSubjectService{}
 
 type NoopSubjectService struct{}
 
+func (n NoopSubjectService) RegisterHooks(_ ...models.ServiceHook[subject.Subject]) {}
+
 func (n NoopSubjectService) Create(ctx context.Context, input subject.CreateInput) (subject.Subject, error) {
 	return subject.Subject{}, nil
 }

--- a/openmeter/subject/service.go
+++ b/openmeter/subject/service.go
@@ -9,6 +9,8 @@ import (
 )
 
 type Service interface {
+	models.ServiceHooks[Subject]
+
 	Create(ctx context.Context, input CreateInput) (Subject, error)
 	Update(ctx context.Context, input UpdateInput) (Subject, error)
 

--- a/pkg/models/metadata.go
+++ b/pkg/models/metadata.go
@@ -16,6 +16,24 @@ func (m Metadata) ToMap() map[string]string {
 	return m
 }
 
+func (m Metadata) Merge(d Metadata) Metadata {
+	if len(m) == 0 && len(d) == 0 {
+		return nil
+	}
+
+	r := make(Metadata)
+
+	for k, v := range m {
+		r[k] = v
+	}
+
+	for k, v := range d {
+		r[k] = v
+	}
+
+	return r
+}
+
 func NewMetadata[T ~map[string]string](m T) Metadata {
 	return Metadata(m)
 }

--- a/pkg/models/servicehook.go
+++ b/pkg/models/servicehook.go
@@ -1,0 +1,132 @@
+package models
+
+import (
+	"context"
+	"sync"
+)
+
+type ServiceHook[T any] interface {
+	PreUpdate(context.Context, *T) error
+	PreDelete(context.Context, *T) error
+	PostCreate(context.Context, *T) error
+	PostUpdate(context.Context, *T) error
+	PostDelete(context.Context, *T) error
+}
+
+type ServiceHooks[T any] interface {
+	RegisterHooks(...ServiceHook[T])
+}
+
+var (
+	_ ServiceHooks[any] = (*ServiceHookRegistry[any])(nil)
+	_ ServiceHook[any]  = (*ServiceHookRegistry[any])(nil)
+)
+
+type ServiceHookRegistry[T any] struct {
+	hooks []ServiceHook[T]
+
+	mu sync.RWMutex
+}
+
+func (r *ServiceHookRegistry[T]) PreUpdate(ctx context.Context, t *T) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, hook := range r.hooks {
+		if err := hook.PreUpdate(ctx, t); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *ServiceHookRegistry[T]) PreDelete(ctx context.Context, t *T) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, hook := range r.hooks {
+		if err := hook.PreDelete(ctx, t); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *ServiceHookRegistry[T]) PostCreate(ctx context.Context, t *T) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, hook := range r.hooks {
+		if err := hook.PostCreate(ctx, t); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *ServiceHookRegistry[T]) PostUpdate(ctx context.Context, t *T) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, hook := range r.hooks {
+		if err := hook.PostUpdate(ctx, t); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *ServiceHookRegistry[T]) PostDelete(ctx context.Context, t *T) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, hook := range r.hooks {
+		if err := hook.PostDelete(ctx, t); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *ServiceHookRegistry[T]) RegisterHooks(hooks ...ServiceHook[T]) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.hooks = append(r.hooks, hooks...)
+}
+
+func NewServiceHookRegistry[T any]() *ServiceHookRegistry[T] {
+	return &ServiceHookRegistry[T]{
+		hooks: []ServiceHook[T]{},
+		mu:    sync.RWMutex{},
+	}
+}
+
+var _ ServiceHook[any] = (*NoopServiceHook[any])(nil)
+
+type NoopServiceHook[T any] struct{}
+
+func (n NoopServiceHook[T]) PreUpdate(context.Context, *T) error {
+	return nil
+}
+
+func (n NoopServiceHook[T]) PreDelete(context.Context, *T) error {
+	return nil
+}
+
+func (n NoopServiceHook[T]) PostCreate(context.Context, *T) error {
+	return nil
+}
+
+func (n NoopServiceHook[T]) PostUpdate(context.Context, *T) error {
+	return nil
+}
+
+func (n NoopServiceHook[T]) PostDelete(context.Context, *T) error {
+	return nil
+}


### PR DESCRIPTION
## Overview

Add service hook which can be registered to Subejct service in order to perform additional operations like creating/updating Customer for Subject.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a flexible service hook system, enabling registration of lifecycle hooks for entities such as subjects and customers.
  * Added automatic provisioning and synchronization of customer records when subjects are created or updated, with optional Stripe billing integration.
  * Added configuration options to enable or disable customer subject hooks via settings.
  * Exposed new metadata merging capabilities for improved data management.

* **Bug Fixes**
  * Improved error handling and consistency checks during customer provisioning and synchronization.

* **Tests**
  * Added comprehensive unit tests for customer provisioning, subject hooks, and metadata handling to ensure reliability and correctness.

* **Documentation**
  * Updated configuration documentation to include new customer-related options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->