### PR TITLE
fix(customer): subject service hook

### DIFF
--- a/openmeter/customer/adapter/customer.go
+++ b/openmeter/customer/adapter/customer.go
@@ -373,7 +373,8 @@ func (a *adapter) GetCustomerByUsageAttribution(ctx context.Context, input custo
 
 	query := a.db.Customer.Query().
 		Where(customerdb.Namespace(input.Namespace)).
-		Where(customerdb.HasSubjectsWith(customersubjectsdb.SubjectKey(input.SubjectKey)))
+		Where(customerdb.HasSubjectsWith(customersubjectsdb.SubjectKey(input.SubjectKey))).
+		Where(customerdb.DeletedAtIsNil())
 	query = withSubjects(query)
 	query = withActiveSubscription(query)
 

--- a/openmeter/customer/service/hooks/subject_test.go
+++ b/openmeter/customer/service/hooks/subject_test.go
@@ -57,20 +57,15 @@ func TestCustomerProvisioner_EnsureCustomer(t *testing.T) {
 			Key:              "acme-inc",
 			DisplayName:      lo.ToPtr("ACME Inc."),
 			StripeCustomerId: lo.ToPtr("cus_abcdefgh"),
-			Metadata: lo.ToPtr(map[string]interface{}{
-				"foo": "bar",
-				"bar": 1,
-				"baz": true,
-			}),
 		})
 		require.NoError(t, err, "creating subject should not fail")
 		assert.NotNilf(t, sub, "subject must not be nil")
 
-		cus, err := provisioner.GetCustomerForSubject(ctx, &sub)
+		cus, err := provisioner.getCustomerForSubject(ctx, &sub)
 		require.ErrorAsf(t, err, new(*models.GenericNotFoundError), "error must be not found error")
 		assert.Nilf(t, cus, "customer must be nil")
 
-		cus, err = provisioner.EnsureCustomer(ctx, &sub)
+		cus, err = provisioner.ensureCustomer(ctx, &sub)
 		require.NoError(t, err, "provisioning customer should not fail")
 		assert.NotNilf(t, cus, "customer must not be nil")
 
@@ -125,7 +120,7 @@ func TestCustomerProvisioner_EnsureCustomer(t *testing.T) {
 			require.NoError(t, err, "updating customer should not fail")
 			assert.NotNilf(t, sub, "customer must not be nil")
 
-			cus, err = provisioner.EnsureCustomer(ctx, &sub)
+			cus, err = provisioner.ensureCustomer(ctx, &sub)
 			require.NoError(t, err, "provisioning customer should not fail")
 			assert.NotNilf(t, cus, "customer must not be nil")
 
@@ -180,7 +175,7 @@ func TestCustomerProvisioner_EnsureCustomer(t *testing.T) {
 			require.NoError(t, err, "creating customer should not fail")
 			assert.NotNilf(t, cus, "customer must not be nil")
 
-			cus, err = provisioner.EnsureCustomer(ctx, &sub)
+			cus, err = provisioner.ensureCustomer(ctx, &sub)
 			require.NoError(t, err, "provisioning customer should not fail")
 			assert.NotNilf(t, cus, "customer must not be nil")
 
@@ -233,7 +228,7 @@ func TestCustomerProvisioner_EnsureCustomer(t *testing.T) {
 			require.NoError(t, err, "creating customer should not fail")
 			assert.NotNilf(t, cus, "customer must not be nil")
 
-			cus, err = provisioner.EnsureCustomer(ctx, &sub)
+			cus, err = provisioner.ensureCustomer(ctx, &sub)
 			require.NoError(t, err, "provisioning customer should not fail")
 			assert.NotNilf(t, cus, "customer must not be nil")
 


### PR DESCRIPTION
## Overview

* fix Customer lookup by usage attribution where deleted Customers were also returned
* ensure that deleted Customers are ignored by the Subject service hook
* fix nil pointer dereference when metadata from Subject and Customer are merged
* do not export methods internal methods of the CustomerSubjectProvisioner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded deleted customers from certain queries to ensure only active customers are considered.
  * Improved handling of deleted customers during customer provisioning to avoid conflicts.

* **Refactor**
  * Renamed several internal methods for clarity and consistency.
  * Enhanced metadata merging logic to better handle empty values.

* **Tests**
  * Updated tests to align with internal method renaming and improved test clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->