### PR TITLE
fix(sub): setting Customer metadata/annotations

### DIFF
--- a/openmeter/subscription/service/service.go
+++ b/openmeter/subscription/service/service.go
@@ -488,6 +488,8 @@ func (s *service) updateCustomerCurrencyIfNotSet(ctx context.Context, sub subscr
 				PrimaryEmail:     cust.PrimaryEmail,
 				BillingAddress:   cust.BillingAddress,
 				Currency:         &currentSpec.Currency,
+				Metadata:         cust.Metadata,
+				Annotation:       cust.Annotation,
 			},
 		}); err != nil {
 			return fmt.Errorf("failed to update customer currency: %w", err)


### PR DESCRIPTION
## Overview

Fix setting Customer metadata and annotations on update in subecription service.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved customer metadata and annotations when updating customer currency, ensuring no information is lost during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->