### PR TITLE
fix: metadata serialization

### DIFF
--- a/openmeter/customer/service/hooks/subject.go
+++ b/openmeter/customer/service/hooks/subject.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"maps"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -447,6 +448,8 @@ func toString(v interface{}, rec int) string {
 				result = append(result, `"`+k.String()+`"="`+s+`"`)
 			}
 		}
+
+		slices.Sort(result)
 
 		return strings.Join(result, ",")
 	case reflect.Slice:

--- a/openmeter/customer/service/hooks/subject_test.go
+++ b/openmeter/customer/service/hooks/subject_test.go
@@ -436,7 +436,7 @@ func TestMetadataFromMap(t *testing.T) {
 				"e":  `"bar","buzz"`,
 				"f1": "3.14",
 				"f2": "3.14",
-				"g":  `"foo"="bar","bar"="baz"`,
+				"g":  `"bar"="baz","foo"="bar"`,
 				"h":  "true",
 			},
 		},


### PR DESCRIPTION
## Overview

Fix `Metadata` serialization by sorting items before concat.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured consistent ordering of key-value pairs when displaying map metadata.

* **Tests**
  * Updated tests to reflect the new, consistent key-value pair ordering in map metadata output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->