### PR TITLE
fix: omit deleted when listing channels

### DIFF
--- a/openmeter/notification/adapter/channel.go
+++ b/openmeter/notification/adapter/channel.go
@@ -19,7 +19,7 @@ func (a *adapter) ListChannels(ctx context.Context, params notification.ListChan
 		query := a.db.NotificationChannel.Query().
 			Where(channeldb.Or(
 				channeldb.DeletedAtIsNil(),
-				channeldb.DeletedAtLTE(clock.Now()),
+				channeldb.DeletedAtGT(clock.Now()),
 			)) // Do not return deleted channels
 
 		if len(params.Namespaces) > 0 {


### PR DESCRIPTION
## Overview

Omit deleted ones when listing availaeble notification channels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of notification channels to ensure only active (non-deleted) channels are listed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->