### PR TITLE
fix: update/maintain dueAt on invoices [OM-1376]

### DIFF
--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -303,10 +303,6 @@ func (s *Service) InvoicePendingLines(ctx context.Context, input billing.Invoice
 				return line.Currency()
 			})
 
-			dueAt, _ := customerProfile.MergedProfile.WorkflowConfig.Invoicing.DueAfter.AddTo(clock.Now())
-			// Note: Stripe uses seconds precision, so let's truncate for easier testing
-			dueAt = dueAt.Truncate(time.Second)
-
 			createdInvoices := make([]billing.Invoice, 0, len(linesByCurrency))
 
 			for currency, lines := range linesByCurrency {
@@ -332,8 +328,7 @@ func (s *Service) InvoicePendingLines(ctx context.Context, input billing.Invoice
 					Number:   invoiceNumber,
 					Status:   billing.InvoiceStatusDraftCreated,
 
-					Type:  billing.InvoiceTypeStandard,
-					DueAt: lo.ToPtr(dueAt),
+					Type: billing.InvoiceTypeStandard,
 				})
 				if err != nil {
 					return nil, fmt.Errorf("creating invoice: %w", err)

--- a/openmeter/billing/service/invoicecalc/calculator.go
+++ b/openmeter/billing/service/invoicecalc/calculator.go
@@ -15,22 +15,23 @@ type invoiceCalculatorsByType struct {
 
 var InvoiceCalculations = invoiceCalculatorsByType{
 	Invoice: []Calculation{
-		StandardInvoiceCollectionAt,
-		CalculateDraftUntil,
-		UpsertDiscountCorrelationIDs,
+		WithNoDependencies(StandardInvoiceCollectionAt),
+		WithNoDependencies(CalculateDraftUntil),
+		WithNoDependencies(CalculateDueAt),
+		WithNoDependencies(UpsertDiscountCorrelationIDs),
 		RecalculateDetailedLinesAndTotals,
 		CalculateInvoicePeriod,
 		SnapshotTaxConfigIntoLines,
 	},
 	GatheringInvoice: []Calculation{
-		UpsertDiscountCorrelationIDs,
-		GatheringInvoiceCollectionAt,
+		WithNoDependencies(UpsertDiscountCorrelationIDs),
+		WithNoDependencies(GatheringInvoiceCollectionAt),
 		CalculateInvoicePeriod,
 	},
 	// Calculations that should be running on a gathering invoice to populate line items
 	GatheringInvoiceWithLiveData: []Calculation{
-		UpsertDiscountCorrelationIDs,
-		GatheringInvoiceCollectionAt,
+		WithNoDependencies(UpsertDiscountCorrelationIDs),
+		WithNoDependencies(GatheringInvoiceCollectionAt),
 		RecalculateDetailedLinesAndTotals,
 		CalculateInvoicePeriod,
 		SnapshotTaxConfigIntoLines,
@@ -116,4 +117,10 @@ func (c *calculator) CalculateGatheringInvoiceWithLiveData(invoice *billing.Invo
 
 func (c *calculator) LineService() *lineservice.Service {
 	return c.lineService
+}
+
+func WithNoDependencies(cb func(inv *billing.Invoice) error) Calculation {
+	return func(inv *billing.Invoice, _ CalculatorDependencies) error {
+		return cb(inv)
+	}
 }

--- a/openmeter/billing/service/invoicecalc/collectionat.go
+++ b/openmeter/billing/service/invoicecalc/collectionat.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 )
 
-func GatheringInvoiceCollectionAt(i *billing.Invoice, _ CalculatorDependencies) error {
+func GatheringInvoiceCollectionAt(i *billing.Invoice) error {
 	i.CollectionAt = nil
 
 	if !i.Lines.IsPresent() {
@@ -30,7 +30,7 @@ func GatheringInvoiceCollectionAt(i *billing.Invoice, _ CalculatorDependencies) 
 	return nil
 }
 
-func StandardInvoiceCollectionAt(i *billing.Invoice, _ CalculatorDependencies) error {
+func StandardInvoiceCollectionAt(i *billing.Invoice) error {
 	if !i.Lines.IsPresent() {
 		return errors.New("lines must be expanded")
 	}

--- a/openmeter/billing/service/invoicecalc/discounts.go
+++ b/openmeter/billing/service/invoicecalc/discounts.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 )
 
-func UpsertDiscountCorrelationIDs(invoice *billing.Invoice, _ CalculatorDependencies) error {
+func UpsertDiscountCorrelationIDs(invoice *billing.Invoice) error {
 	lines := invoice.Lines.OrEmpty()
 	for _, line := range lines {
 		updatedDiscounts, err := ensureDiscountCorrelationIDs(line.RateCardDiscounts)

--- a/openmeter/billing/service/invoicecalc/draftuntil.go
+++ b/openmeter/billing/service/invoicecalc/draftuntil.go
@@ -7,7 +7,7 @@ import (
 )
 
 // CalculateDraftUntil calculates the draft until date
-func CalculateDraftUntil(i *billing.Invoice, _ CalculatorDependencies) error {
+func CalculateDraftUntil(i *billing.Invoice) error {
 	if !i.Workflow.Config.Invoicing.AutoAdvance {
 		i.DraftUntil = nil
 		return nil

--- a/openmeter/billing/service/invoicecalc/dueat.go
+++ b/openmeter/billing/service/invoicecalc/dueat.go
@@ -1,0 +1,40 @@
+package invoicecalc
+
+import (
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+)
+
+func CalculateDueAt(i *billing.Invoice) error {
+	if !i.Workflow.Config.Invoicing.AutoAdvance {
+		// In case of manual approval dueAt is started from the moment of the invoice is issued
+		// to prevent the invoice from being overdue on issuance
+
+		if i.IssuedAt == nil {
+			// If we don't know when the invoice was issued we cannot calculate the dueAt
+			return nil
+		}
+
+		dueAt, _ := i.Workflow.Config.Invoicing.DueAfter.Period.AddTo(*i.IssuedAt)
+
+		i.DueAt = lo.ToPtr(dueAt.Truncate(time.Second))
+
+		return nil
+	}
+
+	// Auto advance is enabled, so we can calculate the dueAt
+	if i.DraftUntil == nil {
+		// If we don't know the draftUntil we cannot yet calculate the dueAt
+		return nil
+	}
+
+	dueAt, _ := i.Workflow.Config.Invoicing.DueAfter.Period.AddTo(*i.DraftUntil)
+
+	// Note: Stripe uses seconds precision, so let's truncate for easier testing
+	i.DueAt = lo.ToPtr(dueAt.Truncate(time.Second))
+
+	return nil
+}

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -310,7 +310,7 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 			ExpandedFields: billing.InvoiceExpandAll,
 		}
 
-		s.NoError(invoicecalc.GatheringInvoiceCollectionAt(&expectedInvoice, nil))
+		s.NoError(invoicecalc.GatheringInvoiceCollectionAt(&expectedInvoice))
 
 		require.Equal(s.T(),
 			expectedInvoice.RemoveMetaForCompare(),


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch makes sure that:
- when an app fails and the invoice is retried, the dueAt gets updated
- if no auto approval is enabled, dueAt is calculated from invoiceAt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved calculation and assignment of invoice due dates to better align with invoicing workflows and external system compatibility.

* **Refactor**
  * Standardized calculation functions for invoices, simplifying their usage and improving maintainability.
  * Adjusted the timing of invoice issuance and due date assignments for greater consistency.

* **Bug Fixes**
  * Addressed issues with invoice due date handling during invoice finalization.

* **Tests**
  * Updated tests to reflect changes in function signatures related to invoice calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->