### PR TITLE
feat: billing use streaming specified minimum resolution [OM-1469]

### DIFF
--- a/openmeter/billing/defaults.go
+++ b/openmeter/billing/defaults.go
@@ -1,15 +1,9 @@
 package billing
 
 import (
-	"time"
-
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/pkg/datetime"
-)
-
-const (
-	DefaultMeterResolution = time.Minute
 )
 
 var DefaultWorkflowConfig = WorkflowConfig{

--- a/openmeter/billing/httpdriver/invoiceline.go
+++ b/openmeter/billing/httpdriver/invoiceline.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	productcataloghttp "github.com/openmeterio/openmeter/openmeter/productcatalog/http"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/convert"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -555,11 +556,11 @@ func mapSimulationLineToEntity(line api.InvoiceSimulationLine) (*billing.Line, e
 
 			Status: billing.InvoiceLineStatusValid,
 			Period: billing.Period{
-				Start: line.Period.From,
-				End:   line.Period.To,
+				Start: line.Period.From.Truncate(streaming.MinWindowSizeDuration),
+				End:   line.Period.To.Truncate(streaming.MinWindowSizeDuration),
 			},
 
-			InvoiceAt:         line.InvoiceAt,
+			InvoiceAt:         line.InvoiceAt.Truncate(streaming.MinWindowSizeDuration),
 			TaxConfig:         rateCardParsed.TaxConfig,
 			RateCardDiscounts: rateCardParsed.Discounts,
 		},
@@ -601,10 +602,10 @@ func lineFromInvoiceLineReplaceUpdate(line api.InvoiceLineReplaceUpdate, invoice
 			Currency:  invoice.Currency,
 
 			Period: billing.Period{
-				Start: line.Period.From,
-				End:   line.Period.To,
+				Start: line.Period.From.Truncate(streaming.MinWindowSizeDuration),
+				End:   line.Period.To.Truncate(streaming.MinWindowSizeDuration),
 			},
-			InvoiceAt: line.InvoiceAt,
+			InvoiceAt: line.InvoiceAt.Truncate(streaming.MinWindowSizeDuration),
 
 			TaxConfig:         rateCardParsed.TaxConfig,
 			RateCardDiscounts: rateCardParsed.Discounts,
@@ -644,9 +645,9 @@ func mergeLineFromInvoiceLineReplaceUpdate(existing *billing.Line, line api.Invo
 	existing.LineBase.Name = line.Name
 	existing.LineBase.Description = line.Description
 
-	existing.Period.Start = line.Period.From
-	existing.Period.End = line.Period.To
-	existing.InvoiceAt = line.InvoiceAt
+	existing.Period.Start = line.Period.From.Truncate(streaming.MinWindowSizeDuration)
+	existing.Period.End = line.Period.To.Truncate(streaming.MinWindowSizeDuration)
+	existing.InvoiceAt = line.InvoiceAt.Truncate(streaming.MinWindowSizeDuration)
 
 	existing.TaxConfig = rateCardParsed.TaxConfig
 	existing.UsageBased.Price = rateCardParsed.Price

--- a/openmeter/billing/httpdriver/invoiceline.go
+++ b/openmeter/billing/httpdriver/invoiceline.go
@@ -556,11 +556,11 @@ func mapSimulationLineToEntity(line api.InvoiceSimulationLine) (*billing.Line, e
 
 			Status: billing.InvoiceLineStatusValid,
 			Period: billing.Period{
-				Start: line.Period.From.Truncate(streaming.MinWindowSizeDuration),
-				End:   line.Period.To.Truncate(streaming.MinWindowSizeDuration),
+				Start: line.Period.From.Truncate(streaming.MinimumWindowSizeDuration),
+				End:   line.Period.To.Truncate(streaming.MinimumWindowSizeDuration),
 			},
 
-			InvoiceAt:         line.InvoiceAt.Truncate(streaming.MinWindowSizeDuration),
+			InvoiceAt:         line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration),
 			TaxConfig:         rateCardParsed.TaxConfig,
 			RateCardDiscounts: rateCardParsed.Discounts,
 		},
@@ -602,10 +602,10 @@ func lineFromInvoiceLineReplaceUpdate(line api.InvoiceLineReplaceUpdate, invoice
 			Currency:  invoice.Currency,
 
 			Period: billing.Period{
-				Start: line.Period.From.Truncate(streaming.MinWindowSizeDuration),
-				End:   line.Period.To.Truncate(streaming.MinWindowSizeDuration),
+				Start: line.Period.From.Truncate(streaming.MinimumWindowSizeDuration),
+				End:   line.Period.To.Truncate(streaming.MinimumWindowSizeDuration),
 			},
-			InvoiceAt: line.InvoiceAt.Truncate(streaming.MinWindowSizeDuration),
+			InvoiceAt: line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration),
 
 			TaxConfig:         rateCardParsed.TaxConfig,
 			RateCardDiscounts: rateCardParsed.Discounts,
@@ -645,9 +645,9 @@ func mergeLineFromInvoiceLineReplaceUpdate(existing *billing.Line, line api.Invo
 	existing.LineBase.Name = line.Name
 	existing.LineBase.Description = line.Description
 
-	existing.Period.Start = line.Period.From.Truncate(streaming.MinWindowSizeDuration)
-	existing.Period.End = line.Period.To.Truncate(streaming.MinWindowSizeDuration)
-	existing.InvoiceAt = line.InvoiceAt.Truncate(streaming.MinWindowSizeDuration)
+	existing.Period.Start = line.Period.From.Truncate(streaming.MinimumWindowSizeDuration)
+	existing.Period.End = line.Period.To.Truncate(streaming.MinimumWindowSizeDuration)
+	existing.InvoiceAt = line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration)
 
 	existing.TaxConfig = rateCardParsed.TaxConfig
 	existing.UsageBased.Price = rateCardParsed.Price

--- a/openmeter/billing/invoiceline.go
+++ b/openmeter/billing/invoiceline.go
@@ -552,8 +552,8 @@ func (i Line) ValidateUsageBased() error {
 		errs = append(errs, err)
 	}
 
-	if i.DependsOnMeteredQuantity() && i.InvoiceAt.Before(i.Period.Truncate(streaming.MinWindowSizeDuration).End) {
-		errs = append(errs, fmt.Errorf("invoice at (%s) must be after period end (%s) for usage based line", i.InvoiceAt, i.Period.Truncate(streaming.MinWindowSizeDuration).End))
+	if i.DependsOnMeteredQuantity() && i.InvoiceAt.Before(i.Period.Truncate(streaming.MinimumWindowSizeDuration).End) {
+		errs = append(errs, fmt.Errorf("invoice at (%s) must be after period end (%s) for usage based line", i.InvoiceAt, i.Period.Truncate(streaming.MinimumWindowSizeDuration).End))
 	}
 
 	return errors.Join(errs...)

--- a/openmeter/billing/invoiceline.go
+++ b/openmeter/billing/invoiceline.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/equal"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -551,8 +552,8 @@ func (i Line) ValidateUsageBased() error {
 		errs = append(errs, err)
 	}
 
-	if i.DependsOnMeteredQuantity() && i.InvoiceAt.Before(i.Period.Truncate(DefaultMeterResolution).End) {
-		errs = append(errs, fmt.Errorf("invoice at (%s) must be after period end (%s) for usage based line", i.InvoiceAt, i.Period.Truncate(DefaultMeterResolution).End))
+	if i.DependsOnMeteredQuantity() && i.InvoiceAt.Before(i.Period.Truncate(streaming.MinWindowSizeDuration).End) {
+		errs = append(errs, fmt.Errorf("invoice at (%s) must be after period end (%s) for usage based line", i.InvoiceAt, i.Period.Truncate(streaming.MinWindowSizeDuration).End))
 	}
 
 	return errors.Join(errs...)

--- a/openmeter/billing/service/lineservice/service.go
+++ b/openmeter/billing/service/lineservice/service.go
@@ -75,6 +75,7 @@ func (s *Service) FromEntity(line *billing.Line) (Line, error) {
 
 	switch line.Type {
 	case billing.InvoiceLineTypeFee:
+		// Warning: These are actually the detailed lines, but the billing refactor is not yet complete
 		return &feeLine{
 			lineBase: base,
 		}, nil

--- a/openmeter/billing/service/lineservice/usagebasedline.go
+++ b/openmeter/billing/service/lineservice/usagebasedline.go
@@ -44,8 +44,8 @@ type usageBasedLine struct {
 }
 
 func (l usageBasedLine) PrepareForCreate(context.Context) (Line, error) {
-	l.line.Period = l.line.Period.Truncate(streaming.MinWindowSizeDuration)
-	l.line.InvoiceAt = l.line.InvoiceAt.Truncate(streaming.MinWindowSizeDuration)
+	l.line.Period = l.line.Period.Truncate(streaming.MinimumWindowSizeDuration)
+	l.line.InvoiceAt = l.line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration)
 
 	return &l, nil
 }
@@ -65,7 +65,7 @@ func (l usageBasedLine) Validate(ctx context.Context, targetInvoice *billing.Inv
 		}
 	}
 
-	if l.line.LineBase.Period.Truncate(streaming.MinWindowSizeDuration).IsEmpty() {
+	if l.line.LineBase.Period.Truncate(streaming.MinimumWindowSizeDuration).IsEmpty() {
 		return billing.ValidationError{
 			Err: billing.ErrInvoiceCreateUBPLinePeriodIsEmpty,
 		}
@@ -109,13 +109,13 @@ func (l usageBasedLine) CanBeInvoicedAsOf(ctx context.Context, in CanBeInvoicedA
 
 	meter := meterAndFactory.meter
 
-	asOfTruncated := in.AsOf.Truncate(streaming.MinWindowSizeDuration)
+	asOfTruncated := in.AsOf.Truncate(streaming.MinimumWindowSizeDuration)
 
 	switch meter.Aggregation {
 	case meterpkg.MeterAggregationSum, meterpkg.MeterAggregationCount,
 		meterpkg.MeterAggregationMax, meterpkg.MeterAggregationUniqueCount:
 
-		periodStartTrucated := l.line.Period.Start.Truncate(streaming.MinWindowSizeDuration)
+		periodStartTrucated := l.line.Period.Start.Truncate(streaming.MinimumWindowSizeDuration)
 
 		if !periodStartTrucated.Before(asOfTruncated) {
 			return nil, nil
@@ -238,5 +238,5 @@ func formatMaximumSpendDiscountDescription(amount alpacadecimal.Decimal) *string
 }
 
 func (l usageBasedLine) IsPeriodEmptyConsideringTruncations() bool {
-	return l.Period().Truncate(streaming.MinWindowSizeDuration).IsEmpty()
+	return l.Period().Truncate(streaming.MinimumWindowSizeDuration).IsEmpty()
 }

--- a/openmeter/billing/service/lineservice/usagebasedline.go
+++ b/openmeter/billing/service/lineservice/usagebasedline.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	meterpkg "github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
 )
 
 var _ Line = (*usageBasedLine)(nil)
@@ -43,7 +44,8 @@ type usageBasedLine struct {
 }
 
 func (l usageBasedLine) PrepareForCreate(context.Context) (Line, error) {
-	l.line.Period = l.line.Period.Truncate(billing.DefaultMeterResolution)
+	l.line.Period = l.line.Period.Truncate(streaming.MinWindowSizeDuration)
+	l.line.InvoiceAt = l.line.InvoiceAt.Truncate(streaming.MinWindowSizeDuration)
 
 	return &l, nil
 }
@@ -63,7 +65,7 @@ func (l usageBasedLine) Validate(ctx context.Context, targetInvoice *billing.Inv
 		}
 	}
 
-	if l.line.LineBase.Period.Truncate(billing.DefaultMeterResolution).IsEmpty() {
+	if l.line.LineBase.Period.Truncate(streaming.MinWindowSizeDuration).IsEmpty() {
 		return billing.ValidationError{
 			Err: billing.ErrInvoiceCreateUBPLinePeriodIsEmpty,
 		}
@@ -107,13 +109,13 @@ func (l usageBasedLine) CanBeInvoicedAsOf(ctx context.Context, in CanBeInvoicedA
 
 	meter := meterAndFactory.meter
 
-	asOfTruncated := in.AsOf.Truncate(billing.DefaultMeterResolution)
+	asOfTruncated := in.AsOf.Truncate(streaming.MinWindowSizeDuration)
 
 	switch meter.Aggregation {
 	case meterpkg.MeterAggregationSum, meterpkg.MeterAggregationCount,
 		meterpkg.MeterAggregationMax, meterpkg.MeterAggregationUniqueCount:
 
-		periodStartTrucated := l.line.Period.Start.Truncate(billing.DefaultMeterResolution)
+		periodStartTrucated := l.line.Period.Start.Truncate(streaming.MinWindowSizeDuration)
 
 		if !periodStartTrucated.Before(asOfTruncated) {
 			return nil, nil
@@ -236,5 +238,5 @@ func formatMaximumSpendDiscountDescription(amount alpacadecimal.Decimal) *string
 }
 
 func (l usageBasedLine) IsPeriodEmptyConsideringTruncations() bool {
-	return l.Period().Truncate(billing.DefaultMeterResolution).IsEmpty()
+	return l.Period().Truncate(streaming.MinWindowSizeDuration).IsEmpty()
 }

--- a/openmeter/billing/service/lineservice/usagebasedlineflat.go
+++ b/openmeter/billing/service/lineservice/usagebasedlineflat.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
 )
 
 var _ Line = (*ubpFlatFeeLine)(nil)
@@ -41,6 +42,10 @@ func (l ubpFlatFeeLine) PrepareForCreate(context.Context) (Line, error) {
 
 		l.line.UsageBased.Price = productcatalog.NewPriceFrom(flatPrice)
 	}
+
+	// Let's apply the same truncation as the usage based line for consistency
+	l.line.Period = l.line.Period.Truncate(streaming.MinWindowSizeDuration)
+	l.line.InvoiceAt = l.line.InvoiceAt.Truncate(streaming.MinWindowSizeDuration)
 
 	return &l, nil
 }

--- a/openmeter/billing/service/lineservice/usagebasedlineflat.go
+++ b/openmeter/billing/service/lineservice/usagebasedlineflat.go
@@ -44,8 +44,8 @@ func (l ubpFlatFeeLine) PrepareForCreate(context.Context) (Line, error) {
 	}
 
 	// Let's apply the same truncation as the usage based line for consistency
-	l.line.Period = l.line.Period.Truncate(streaming.MinWindowSizeDuration)
-	l.line.InvoiceAt = l.line.InvoiceAt.Truncate(streaming.MinWindowSizeDuration)
+	l.line.Period = l.line.Period.Truncate(streaming.MinimumWindowSizeDuration)
+	l.line.InvoiceAt = l.line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration)
 
 	return &l, nil
 }

--- a/openmeter/billing/worker/subscription/invoiceupdate.go
+++ b/openmeter/billing/worker/subscription/invoiceupdate.go
@@ -286,7 +286,7 @@ func (u *InvoiceUpdater) updateImmutableInvoice(ctx context.Context, invoice bil
 			return fmt.Errorf("line[%s] is not a usage based line, cannot update", targetState.ID)
 		}
 
-		if !targetState.Period.Truncate(streaming.MinWindowSizeDuration).Equal(existingLine.Period.Truncate(streaming.MinWindowSizeDuration)) {
+		if !targetState.Period.Truncate(streaming.MinimumWindowSizeDuration).Equal(existingLine.Period.Truncate(streaming.MinimumWindowSizeDuration)) {
 			// The period of the line has changed => we need to refetch the quantity
 			targetStateWithUpdatedQty, err := u.billingService.SnapshotLineQuantity(ctx, billing.SnapshotLineQuantityInput{
 				Invoice: &invoice,

--- a/openmeter/billing/worker/subscription/invoiceupdate.go
+++ b/openmeter/billing/worker/subscription/invoiceupdate.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -285,7 +286,7 @@ func (u *InvoiceUpdater) updateImmutableInvoice(ctx context.Context, invoice bil
 			return fmt.Errorf("line[%s] is not a usage based line, cannot update", targetState.ID)
 		}
 
-		if !targetState.Period.Equal(existingLine.Period) {
+		if !targetState.Period.Truncate(streaming.MinWindowSizeDuration).Equal(existingLine.Period.Truncate(streaming.MinWindowSizeDuration)) {
 			// The period of the line has changed => we need to refetch the quantity
 			targetStateWithUpdatedQty, err := u.billingService.SnapshotLineQuantity(ctx, billing.SnapshotLineQuantityInput{
 				Invoice: &invoice,

--- a/openmeter/billing/worker/subscription/phaseiterator.go
+++ b/openmeter/billing/worker/subscription/phaseiterator.go
@@ -152,7 +152,7 @@ func (it *PhaseIterator) GetMinimumBillableTime() time.Time {
 
 			if item.SubscriptionItem.RateCard.AsMeta().Price.Type() == productcatalog.FlatPriceType {
 				if item.SubscriptionItem.ActiveFrom.Before(minTime) {
-					minTime = item.SubscriptionItem.ActiveFrom.Truncate(streaming.MinWindowSizeDuration)
+					minTime = item.SubscriptionItem.ActiveFrom.Truncate(streaming.MinimumWindowSizeDuration)
 				}
 			} else {
 				// Let's make sure that truncation won't filter out the item
@@ -169,7 +169,7 @@ func (it *PhaseIterator) GetMinimumBillableTime() time.Time {
 					period.End = *it.phaseCadence.ActiveTo
 				}
 
-				period = period.Truncate(streaming.MinWindowSizeDuration)
+				period = period.Truncate(streaming.MinimumWindowSizeDuration)
 				if period.IsEmpty() {
 					continue
 				}
@@ -195,7 +195,7 @@ func (it *PhaseIterator) Generate(ctx context.Context, iterationEnd time.Time) (
 	))
 
 	// Given we are truncating to 1s resolution, we need to make sure that iterationEnd contains the last second as a whole.
-	iterationEnd = iterationEnd.Truncate(streaming.MinWindowSizeDuration).Add(streaming.MinWindowSizeDuration - time.Nanosecond)
+	iterationEnd = iterationEnd.Truncate(streaming.MinimumWindowSizeDuration).Add(streaming.MinimumWindowSizeDuration - time.Nanosecond)
 
 	return span.Wrap(ctx, func(ctx context.Context) ([]subscriptionItemWithPeriods, error) {
 		return it.generateAligned(ctx, iterationEnd)
@@ -415,7 +415,7 @@ func (it *PhaseIterator) truncateItemsIfNeeded(in []subscriptionItemWithPeriods)
 		isFlatPrice := item.Spec.RateCard.AsMeta().Price != nil && item.Spec.RateCard.AsMeta().Price.Type() == productcatalog.FlatPriceType
 
 		// We truncate the service period to the meter resolution
-		item.ServicePeriod = item.ServicePeriod.Truncate(streaming.MinWindowSizeDuration)
+		item.ServicePeriod = item.ServicePeriod.Truncate(streaming.MinimumWindowSizeDuration)
 
 		// We only allow empty service periods for flat prices.
 		if item.ServicePeriod.IsEmpty() && !isFlatPrice {
@@ -425,8 +425,8 @@ func (it *PhaseIterator) truncateItemsIfNeeded(in []subscriptionItemWithPeriods)
 		// Let's truncate the billing period and full service period so that when
 		// doing any calculations we don't have small rounding errors due to the iterator
 		// returning ns precision.
-		item.BillingPeriod = item.BillingPeriod.Truncate(streaming.MinWindowSizeDuration)
-		item.FullServicePeriod = item.FullServicePeriod.Truncate(streaming.MinWindowSizeDuration)
+		item.BillingPeriod = item.BillingPeriod.Truncate(streaming.MinimumWindowSizeDuration)
+		item.FullServicePeriod = item.FullServicePeriod.Truncate(streaming.MinimumWindowSizeDuration)
 
 		out = append(out, item)
 	}

--- a/openmeter/billing/worker/subscription/phaseiterator_test.go
+++ b/openmeter/billing/worker/subscription/phaseiterator_test.go
@@ -421,14 +421,14 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 				{
 					Key:        "item-key",
 					Cadence:    "P1D",
-					StartAfter: lo.ToPtr(datetime.MustParse(s.T(), "P1DT20H2S")),
-					EndAfter:   lo.ToPtr(datetime.MustParse(s.T(), "P1DT20H3S")),
+					StartAfter: lo.ToPtr(datetime.MustParse(s.T(), "P1DT20H2S")), // empty period
+					EndAfter:   lo.ToPtr(datetime.MustParse(s.T(), "P1DT20H2S")),
 					Type:       productcatalog.UnitPriceType,
 				},
 				{
 					Key:        "item-key",
 					Cadence:    "P1D",
-					StartAfter: lo.ToPtr(datetime.MustParse(s.T(), "P1DT20H3S")),
+					StartAfter: lo.ToPtr(datetime.MustParse(s.T(), "P1DT20H2S")),
 					EndAfter:   lo.ToPtr(datetime.MustParse(s.T(), "P1DT20H4S")),
 					Type:       productcatalog.UnitPriceType,
 				},
@@ -460,7 +460,7 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 				{
 					ServicePeriod: billing.Period{
 						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T20:00:00Z"),
+						End:   s.mustParseTime("2021-01-02T20:00:02Z"),
 					},
 					FullServicePeriod: billing.Period{
 						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
@@ -473,10 +473,26 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[1]",
 				},
-				// 0 length service period items are dropped
+				// 0 length service period v1 is dropped
 				{
 					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T20:00:00Z"),
+						Start: s.mustParseTime("2021-01-02T20:00:02Z"),
+						End:   s.mustParseTime("2021-01-02T20:00:04Z"),
+					},
+					FullServicePeriod: billing.Period{
+						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
+						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					},
+					// billing period will follow the otherwise cadence
+					BillingPeriod: billing.Period{
+						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
+						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					},
+					Key: "subID/phase-test/item-key/v[2]/period[0]",
+				},
+				{
+					ServicePeriod: billing.Period{
+						Start: s.mustParseTime("2021-01-02T20:00:04Z"),
 						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					FullServicePeriod: billing.Period{
@@ -1064,7 +1080,7 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 
 	for _, tc := range tcs {
 		s.Run(tc.name, func() {
-			subscriptionStart := s.mustParseTime("2021-01-01T00:00:00Z")
+			subscriptionStart := s.mustParseTime("2021-01-01T00:00:00.1234Z")
 
 			phase := subscription.SubscriptionPhaseView{
 				SubscriptionPhase: subscription.SubscriptionPhase{

--- a/openmeter/billing/worker/subscription/sync.go
+++ b/openmeter/billing/worker/subscription/sync.go
@@ -765,7 +765,7 @@ func (h *Handler) getPatchesForExistingLine(existingLine *billing.Line, expected
 
 	if !isFlatFee(targetLine) {
 		// UBP Empty lines are not allowed, let's delete them instead
-		if targetLine.Period.Truncate(streaming.MinWindowSizeDuration).IsEmpty() {
+		if targetLine.Period.Truncate(streaming.MinimumWindowSizeDuration).IsEmpty() {
 			return []linePatch{
 				newDeleteLinePatch(existingLine.LineID(), existingLine.InvoiceID),
 			}, nil
@@ -889,7 +889,7 @@ func (h *Handler) getPatchesForExistingHierarchy(existingHierarchy *billing.Spli
 
 			if !isFlatFee(updatedChild) {
 				// UBP Empty lines are not allowed, let's delete them instead
-				if updatedChild.Period.Truncate(streaming.MinWindowSizeDuration).IsEmpty() {
+				if updatedChild.Period.Truncate(streaming.MinimumWindowSizeDuration).IsEmpty() {
 					patches = append(patches, newDeleteLinePatch(child.Line.LineID(), child.Line.InvoiceID))
 					continue
 				}

--- a/openmeter/billing/worker/subscription/sync_test.go
+++ b/openmeter/billing/worker/subscription/sync_test.go
@@ -410,9 +410,9 @@ func (s *SubscriptionHandlerTestSuite) TestSubscriptionHappyPath() {
 
 		s.Equal(gatheringLine.Period, billing.Period{
 			Start: s.mustParseTime("2024-02-15T00:00:00Z"),
-			End:   cancelAt.Truncate(streaming.MinWindowSizeDuration),
+			End:   cancelAt.Truncate(streaming.MinimumWindowSizeDuration),
 		})
-		s.Equal(gatheringLine.InvoiceAt, cancelAt.Truncate(streaming.MinWindowSizeDuration))
+		s.Equal(gatheringLine.InvoiceAt, cancelAt.Truncate(streaming.MinimumWindowSizeDuration))
 
 		// split group
 		s.NotNil(gatheringLine.SplitLineHierarchy)

--- a/openmeter/streaming/defaults.go
+++ b/openmeter/streaming/defaults.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	// MinWindowSizeDuration is the minimum window size the aggregation can represent.
-	MinWindowSizeDuration = time.Second
-	// MinWindowSize is the minimum window size the aggregation can represent.
-	MinWindowSize = meter.WindowSizeSecond
+	// MinimumWindowSizeDuration is the minimum window size the aggregation can represent.
+	MinimumWindowSizeDuration = time.Second
+	// MinimumWindowSize is the minimum window size the aggregation can represent.
+	MinimumWindowSize = meter.WindowSizeSecond
 )

--- a/openmeter/streaming/testutils/streaming.go
+++ b/openmeter/streaming/testutils/streaming.go
@@ -144,8 +144,8 @@ func (m *MockStreamingConnector) aggregateEvents(mm meter.Meter, params streamin
 	}
 
 	// Let's truncate the window size to the second, as clickhouse does not support sub-second precision
-	from := params.From.Truncate(streaming.MinWindowSizeDuration)
-	to := params.To.Truncate(streaming.MinWindowSizeDuration)
+	from := params.From.Truncate(streaming.MinimumWindowSizeDuration)
+	to := params.To.Truncate(streaming.MinimumWindowSizeDuration)
 
 	rows := make([]meter.MeterQueryRow, 0)
 
@@ -185,7 +185,7 @@ func (m *MockStreamingConnector) aggregateEvents(mm meter.Meter, params streamin
 		row := &rows[i]
 		var value float64
 
-		effectiveWindowSize := lo.FromPtrOr(params.WindowSize, streaming.MinWindowSize)
+		effectiveWindowSize := lo.FromPtrOr(params.WindowSize, streaming.MinimumWindowSize)
 
 		for _, event := range events {
 			eventWindowStart, err := effectiveWindowSize.Truncate(event.Time)

--- a/openmeter/subscription/subscriptionspec.go
+++ b/openmeter/subscription/subscriptionspec.go
@@ -779,8 +779,12 @@ func (s SubscriptionItemSpec) GetFullServicePeriodAt(
 	phaseCadence models.CadencedModel,
 	itemCadence models.CadencedModel,
 	at time.Time,
-	alignedBillingAnchor *time.Time,
+	alignedBillingAnchor time.Time,
 ) (timeutil.ClosedPeriod, error) {
+	if alignedBillingAnchor.IsZero() {
+		return timeutil.ClosedPeriod{}, fmt.Errorf("aligned billing anchor is zero")
+	}
+
 	if !s.RateCard.AsMeta().IsBillable() {
 		return timeutil.ClosedPeriod{}, fmt.Errorf("item is not billable")
 	}
@@ -811,9 +815,7 @@ func (s SubscriptionItemSpec) GetFullServicePeriodAt(
 		}, nil
 	}
 
-	billingAnchor := lo.FromPtrOr(alignedBillingAnchor, itemCadence.ActiveFrom)
-
-	rec, err := timeutil.RecurrenceFromISODuration(billingCadence, billingAnchor)
+	rec, err := timeutil.RecurrenceFromISODuration(billingCadence, alignedBillingAnchor)
 	if err != nil {
 		return timeutil.ClosedPeriod{}, fmt.Errorf("failed to get recurrence from ISO duration: %w", err)
 	}

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -505,8 +505,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 		// TODO: do not share env between tests
 		defer s.StripeAppClient.Restore()
 
-		expectedPeriodStartUnix := periodStart.Truncate(streaming.MinWindowSizeDuration).Unix()
-		expectedPeriodEndUnix := periodEnd.Truncate(streaming.MinWindowSizeDuration).Unix()
+		expectedPeriodStartUnix := periodStart.Truncate(streaming.MinimumWindowSizeDuration).Unix()
+		expectedPeriodEndUnix := periodEnd.Truncate(streaming.MinimumWindowSizeDuration).Unix()
 
 		getLine := func(description string) *billing.Line {
 			for _, line := range invoice.GetLeafLinesWithConsolidatedTaxBehavior() {

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/secret"
 	secretadapter "github.com/openmeterio/openmeter/openmeter/secret/adapter"
 	secretservice "github.com/openmeterio/openmeter/openmeter/secret/service"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -504,8 +505,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 		// TODO: do not share env between tests
 		defer s.StripeAppClient.Restore()
 
-		expectedPeriodStart := time.Unix(int64(1725279180), 0)
-		expectedPeriodEnd := time.Unix(int64(1725365580), 0)
+		expectedPeriodStartUnix := periodStart.Truncate(streaming.MinWindowSizeDuration).Unix()
+		expectedPeriodEndUnix := periodEnd.Truncate(streaming.MinWindowSizeDuration).Unix()
 
 		getLine := func(description string) *billing.Line {
 			for _, line := range invoice.GetLeafLinesWithConsolidatedTaxBehavior() {
@@ -555,9 +556,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 				Description: lo.ToPtr("Fee"),
 				Customer:    lo.ToPtr(customerData.StripeCustomerID),
 				Period: &stripe.InvoiceItemPeriodParams{
-					Start: lo.ToPtr(periodStart.Unix()),
-					// TODO: check time shift
-					End: lo.ToPtr(periodStart.Add(time.Hour * 24).Unix()),
+					Start: lo.ToPtr(expectedPeriodStartUnix),
+					End:   lo.ToPtr(expectedPeriodEndUnix),
 				},
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("Fee"),
@@ -570,8 +570,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 				Customer:    lo.ToPtr(customerData.StripeCustomerID),
 
 				Period: &stripe.InvoiceItemPeriodParams{
-					Start: lo.ToPtr(expectedPeriodStart.Unix()),
-					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
+					Start: lo.ToPtr(expectedPeriodStartUnix),
+					End:   lo.ToPtr(expectedPeriodEndUnix),
 				},
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - AI Usecase: usage in period"),
@@ -583,8 +583,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 				Description: lo.ToPtr("UBP - FLAT per any usage"),
 				Customer:    lo.ToPtr(customerData.StripeCustomerID),
 				Period: &stripe.InvoiceItemPeriodParams{
-					Start: lo.ToPtr(periodStart.Unix()),
-					End:   lo.ToPtr(periodEnd.Unix()),
+					Start: lo.ToPtr(expectedPeriodStartUnix),
+					End:   lo.ToPtr(expectedPeriodEndUnix),
 				},
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - FLAT per any usage"),
@@ -596,8 +596,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 				Description: lo.ToPtr("UBP - FLAT per unit: usage in period (32.20 x $100)"),
 				Customer:    lo.ToPtr(customerData.StripeCustomerID),
 				Period: &stripe.InvoiceItemPeriodParams{
-					Start: lo.ToPtr(expectedPeriodStart.Unix()),
-					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
+					Start: lo.ToPtr(expectedPeriodStartUnix),
+					End:   lo.ToPtr(expectedPeriodEndUnix),
 				},
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - FLAT per unit: usage in period"),
@@ -609,8 +609,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 				Description: lo.ToPtr("UBP - FLAT per unit: usage in period (Maximum spend discount for charges over 2000)"),
 				Customer:    lo.ToPtr(customerData.StripeCustomerID),
 				Period: &stripe.InvoiceItemPeriodParams{
-					Start: lo.ToPtr(expectedPeriodStart.Unix()),
-					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
+					Start: lo.ToPtr(expectedPeriodStartUnix),
+					End:   lo.ToPtr(expectedPeriodEndUnix),
 				},
 				Metadata: map[string]string{
 					"om_line_id":   getDiscountID("UBP - FLAT per unit: usage in period (Maximum spend discount for charges over 2000)"),
@@ -622,8 +622,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 				Description: lo.ToPtr("UBP - Tiered graduated: usage price for tier 1 (9.50 x $100)"),
 				Customer:    lo.ToPtr(customerData.StripeCustomerID),
 				Period: &stripe.InvoiceItemPeriodParams{
-					Start: lo.ToPtr(expectedPeriodStart.Unix()),
-					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
+					Start: lo.ToPtr(expectedPeriodStartUnix),
+					End:   lo.ToPtr(expectedPeriodEndUnix),
 				},
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - Tiered graduated: usage price for tier 1"),
@@ -635,8 +635,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 				Description: lo.ToPtr("UBP - Tiered graduated: usage price for tier 2 (10.50 x $90)"),
 				Customer:    lo.ToPtr(customerData.StripeCustomerID),
 				Period: &stripe.InvoiceItemPeriodParams{
-					Start: lo.ToPtr(expectedPeriodStart.Unix()),
-					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
+					Start: lo.ToPtr(expectedPeriodStartUnix),
+					End:   lo.ToPtr(expectedPeriodEndUnix),
 				},
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - Tiered graduated: usage price for tier 2"),
@@ -648,8 +648,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 				Description: lo.ToPtr("UBP - Tiered graduated: usage price for tier 3 (15.30 x $80)"),
 				Customer:    lo.ToPtr(customerData.StripeCustomerID),
 				Period: &stripe.InvoiceItemPeriodParams{
-					Start: lo.ToPtr(expectedPeriodStart.Unix()),
-					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
+					Start: lo.ToPtr(expectedPeriodStartUnix),
+					End:   lo.ToPtr(expectedPeriodEndUnix),
 				},
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - Tiered graduated: usage price for tier 3"),
@@ -661,9 +661,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 				Description: lo.ToPtr("UBP - Tiered volume: minimum spend"),
 				Customer:    lo.ToPtr(customerData.StripeCustomerID),
 				Period: &stripe.InvoiceItemPeriodParams{
-					// TODO: check rounding
-					Start: lo.ToPtr(periodStart.Truncate(time.Minute).Unix()),
-					End:   lo.ToPtr(periodEnd.Truncate(time.Minute).Unix()),
+					Start: lo.ToPtr(expectedPeriodStartUnix),
+					End:   lo.ToPtr(expectedPeriodEndUnix),
 				},
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - Tiered volume: minimum spend"),
@@ -676,8 +675,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 				Customer:    lo.ToPtr(customerData.StripeCustomerID),
 				Period: &stripe.InvoiceItemPeriodParams{
 					// TODO: check rounding
-					Start: lo.ToPtr(periodStart.Truncate(time.Minute).Unix()),
-					End:   lo.ToPtr(expectedPeriodEnd.Unix()),
+					Start: lo.ToPtr(expectedPeriodStartUnix),
+					End:   lo.ToPtr(expectedPeriodEndUnix),
 				},
 				Metadata: map[string]string{
 					"om_line_id":   getLineID("UBP - Tiered volume: unit price for tier 2"),

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -1288,8 +1290,11 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 	ctx := context.Background()
 	defer clock.ResetTime()
 
-	periodStart := lo.Must(time.Parse(time.RFC3339, "2024-09-02T12:13:14Z"))
-	periodEnd := lo.Must(time.Parse(time.RFC3339, "2024-09-03T12:13:14Z"))
+	periodStart := testutils.GetRFC3339Time(s.T(), "2024-09-02T12:13:14.1234Z")
+	periodEnd := testutils.GetRFC3339Time(s.T(), "2024-09-03T12:13:14.1234Z")
+
+	truncatedPeriodStart := periodStart.Truncate(streaming.MinWindowSizeDuration)
+	truncatedPeriodEnd := periodEnd.Truncate(streaming.MinWindowSizeDuration)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
 
@@ -1521,15 +1526,15 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 		// The flat fee line should not be truncated
 		require.Equal(s.T(),
 			billing.Period{
-				Start: periodStart,
-				End:   periodEnd,
+				Start: truncatedPeriodStart,
+				End:   truncatedPeriodEnd,
 			},
 			lines.flatFee.Period,
 			"period should not be truncated",
 		)
 		require.Equal(s.T(),
 			lines.flatFee.InvoiceAt,
-			periodEnd,
+			truncatedPeriodEnd,
 			"invoice at should be unchanged",
 		)
 
@@ -1537,8 +1542,8 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 		for _, line := range []*billing.Line{lines.flatPerUnit, lines.tieredGraduated, lines.tieredVolume} {
 			require.Equal(s.T(),
 				billing.Period{
-					Start: lo.Must(time.Parse(time.RFC3339, "2024-09-02T12:13:00Z")),
-					End:   lo.Must(time.Parse(time.RFC3339, "2024-09-03T12:13:00Z")),
+					Start: testutils.GetRFC3339Time(s.T(), "2024-09-02T12:13:14Z"),
+					End:   testutils.GetRFC3339Time(s.T(), "2024-09-03T12:13:14Z"),
 				},
 				line.Period,
 				"period should be truncated to 1 min resolution",
@@ -1546,17 +1551,16 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 
 			require.Equal(s.T(),
 				line.InvoiceAt,
-				periodEnd,
+				truncatedPeriodEnd,
 				"invoice at should be unchanged",
 			)
 		}
 	})
 
-	s.Run("create invoice with empty truncated periods", func() {
-		asOf := periodStart.Add(time.Second)
+	s.Run("create invoice with empty trucated periods", func() {
 		_, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 			Customer: customerEntity.GetID(),
-			AsOf:     &asOf,
+			AsOf:     &periodStart,
 		})
 
 		require.ErrorIs(s.T(), err, billing.ErrInvoiceCreateNoLines)
@@ -1603,8 +1607,8 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 		})
 
 		expectedPeriod := billing.Period{
-			Start: periodStart.Truncate(time.Minute),
-			End:   periodStart.Add(time.Hour).Truncate(time.Minute),
+			Start: truncatedPeriodStart,
+			End:   truncatedPeriodStart.Add(time.Hour),
 		}
 		for _, line := range invoiceLines {
 			require.True(s.T(), expectedPeriod.Equal(line.Period), "period should be changed for the line items")
@@ -1618,13 +1622,13 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 		require.Equal(s.T(), flatPerUnit.UsageBased.Quantity.InexactFloat64(), float64(10), "flat per unit should have 10 units")
 		require.Len(s.T(), tieredGraduatedHierarchy.Lines, 2, "there should be to child lines [id=%s]", tieredGraduatedHierarchy.Group.ID)
 		require.True(s.T(), tieredGraduatedHierarchy.Lines[0].Line.Period.Equal(billing.Period{
-			Start: periodStart.Truncate(time.Minute),
-			End:   periodStart.Add(time.Hour).Truncate(time.Minute),
+			Start: truncatedPeriodStart,
+			End:   truncatedPeriodStart.Add(time.Hour),
 		}), "first child period should be truncated")
-		require.True(s.T(), tieredGraduatedHierarchy.Lines[0].Line.InvoiceAt.Equal(periodStart.Add(time.Hour).Truncate(time.Minute)), "first child should be issued at the end of parent's period")
+		require.True(s.T(), tieredGraduatedHierarchy.Lines[0].Line.InvoiceAt.Equal(truncatedPeriodStart.Add(time.Hour)), "first child should be issued at the end of parent's period")
 		require.True(s.T(), tieredGraduatedHierarchy.Lines[1].Line.Period.Equal(billing.Period{
-			Start: periodStart.Add(time.Hour).Truncate(time.Minute),
-			End:   periodEnd.Truncate(time.Minute),
+			Start: truncatedPeriodStart.Add(time.Hour),
+			End:   truncatedPeriodEnd,
 		}), "second child period should be until the end of parent's period")
 
 		// Let's validate detailed line items
@@ -1902,8 +1906,8 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 		})
 
 		expectedPeriod := billing.Period{
-			Start: periodStart.Add(time.Hour).Truncate(time.Minute),
-			End:   periodStart.Add(2 * time.Hour).Truncate(time.Minute),
+			Start: truncatedPeriodStart.Add(time.Hour),
+			End:   truncatedPeriodStart.Add(2 * time.Hour),
 		}
 		for _, line := range invoiceLines {
 			require.True(s.T(), expectedPeriod.Equal(line.Period), "period should be changed for the line items")
@@ -1917,17 +1921,17 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 		require.True(s.T(), tieredGraduatedHierarchy.Group.ServicePeriod.Equal(lines.tieredGraduated.Period))
 		require.Len(s.T(), tieredGraduatedHierarchy.Lines, 3, "there should be to child lines [id=%s]", tieredGraduatedHierarchy.Group.ID)
 		require.True(s.T(), tieredGraduatedHierarchy.Lines[0].Line.Period.Equal(billing.Period{
-			Start: periodStart.Truncate(time.Minute),
-			End:   periodStart.Add(time.Hour).Truncate(time.Minute),
+			Start: truncatedPeriodStart,
+			End:   truncatedPeriodStart.Add(time.Hour),
 		}), "first child period should be truncated")
 		require.True(s.T(), tieredGraduatedHierarchy.Lines[1].Line.Period.Equal(billing.Period{
-			Start: periodStart.Add(time.Hour).Truncate(time.Minute),
-			End:   periodStart.Add(2 * time.Hour).Truncate(time.Minute),
+			Start: truncatedPeriodStart.Add(time.Hour),
+			End:   truncatedPeriodStart.Add(2 * time.Hour),
 		}), "second child period should be between the first and the third child's period")
-		require.True(s.T(), tieredGraduatedHierarchy.Lines[1].Line.InvoiceAt.Equal(periodStart.Add(2*time.Hour).Truncate(time.Minute)), "second child should be issued at the end of parent's period")
+		require.True(s.T(), tieredGraduatedHierarchy.Lines[1].Line.InvoiceAt.Equal(periodStart.Add(2*time.Hour).Truncate(streaming.MinWindowSizeDuration)), "second child should be issued at the end of parent's period")
 		require.True(s.T(), tieredGraduatedHierarchy.Lines[2].Line.Period.Equal(billing.Period{
-			Start: periodStart.Add(2 * time.Hour).Truncate(time.Minute),
-			End:   periodEnd.Truncate(time.Minute),
+			Start: truncatedPeriodStart.Add(2 * time.Hour),
+			End:   truncatedPeriodEnd,
 		}), "third child period should be until the end of parent's period")
 
 		// Detailed lines
@@ -2079,7 +2083,7 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 		})
 
 		// Usage
-		afterPreviousTest := periodStart.Add(3 * time.Hour)
+		afterPreviousTest := truncatedPeriodStart.Add(3 * time.Hour)
 		s.MockStreamingConnector.AddSimpleEvent("tiered-volume", 25, afterPreviousTest)
 		s.MockStreamingConnector.AddSimpleEvent("tiered-graduated", 15, afterPreviousTest)
 		s.MockStreamingConnector.AddSimpleEvent("flat-per-unit", 30, afterPreviousTest)
@@ -2124,8 +2128,8 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 		})
 
 		expectedPeriod := billing.Period{
-			Start: periodStart.Add(2 * time.Hour).Truncate(time.Minute),
-			End:   periodEnd.Truncate(time.Minute),
+			Start: truncatedPeriodStart.Add(2 * time.Hour),
+			End:   truncatedPeriodEnd,
 		}
 		for _, line := range []*billing.Line{flatPerUnit, tieredGraduated} {
 			require.True(s.T(), expectedPeriod.Equal(line.Period), "period should be changed for the line items")
@@ -2141,17 +2145,17 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 		require.True(s.T(), tieredGraduatedHierarchy.Group.ServicePeriod.Equal(lines.tieredGraduated.Period))
 		require.Len(s.T(), tieredGraduatedHierarchy.Lines, 3, "there should be to child lines [id=%s]", tieredGraduatedHierarchy.Group.ID)
 		require.True(s.T(), tieredGraduatedHierarchy.Lines[0].Line.Period.Equal(billing.Period{
-			Start: periodStart.Truncate(time.Minute),
-			End:   periodStart.Add(time.Hour).Truncate(time.Minute),
+			Start: truncatedPeriodStart,
+			End:   truncatedPeriodStart.Add(time.Hour),
 		}), "first child period should be truncated")
 		require.True(s.T(), tieredGraduatedHierarchy.Lines[1].Line.Period.Equal(billing.Period{
-			Start: periodStart.Add(time.Hour).Truncate(time.Minute),
-			End:   periodStart.Add(2 * time.Hour).Truncate(time.Minute),
+			Start: truncatedPeriodStart.Add(time.Hour),
+			End:   truncatedPeriodStart.Add(2 * time.Hour),
 		}), "second child period should be between the first and the third child's period")
-		require.True(s.T(), tieredGraduatedHierarchy.Lines[1].Line.InvoiceAt.Equal(periodStart.Add(2*time.Hour).Truncate(time.Minute)), "second child should be issued at the end of parent's period")
+		require.True(s.T(), tieredGraduatedHierarchy.Lines[1].Line.InvoiceAt.Equal(truncatedPeriodStart.Add(2*time.Hour)), "second child should be issued at the end of parent's period")
 		require.True(s.T(), tieredGraduatedHierarchy.Lines[2].Line.Period.Equal(billing.Period{
-			Start: periodStart.Add(2 * time.Hour).Truncate(time.Minute),
-			End:   periodEnd.Truncate(time.Minute),
+			Start: truncatedPeriodStart.Add(2 * time.Hour),
+			End:   truncatedPeriodEnd,
 		}), "third child period should be until the end of parent's period")
 
 		// Invoice app testing: discounts
@@ -2497,8 +2501,11 @@ func (s *InvoicingTestSuite) TestUBPNonProgressiveInvoicing() {
 	namespace := "ns-ubp-invoicing-non-progressive"
 	ctx := context.Background()
 
-	periodStart := lo.Must(time.Parse(time.RFC3339, "2024-09-02T12:13:14Z"))
-	periodEnd := lo.Must(time.Parse(time.RFC3339, "2024-09-03T12:13:14Z"))
+	periodStart := lo.Must(time.Parse(time.RFC3339, "2024-09-02T12:13:14.1234Z"))
+	periodEnd := lo.Must(time.Parse(time.RFC3339, "2024-09-03T12:13:14.1234Z"))
+
+	truncatedPeriodStart := periodStart.Truncate(streaming.MinWindowSizeDuration)
+	truncatedPeriodEnd := periodEnd.Truncate(streaming.MinWindowSizeDuration)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
 
@@ -2750,27 +2757,12 @@ func (s *InvoicingTestSuite) TestUBPNonProgressiveInvoicing() {
 			tieredVolume:    pendingLines.Lines[3],
 		}
 
-		// The flat fee line should not be truncated
-		require.Equal(s.T(),
-			billing.Period{
-				Start: periodStart,
-				End:   periodEnd,
-			},
-			lines.flatFee.Period,
-			"period should not be truncated",
-		)
-		require.Equal(s.T(),
-			lines.flatFee.InvoiceAt,
-			periodEnd,
-			"invoice at should be unchanged",
-		)
-
 		// The pending invoice items should be truncated to 1 min resolution (start => up to next, end down to previous)
-		for _, line := range []*billing.Line{lines.flatPerUnit, lines.tieredGraduated, lines.tieredVolume} {
+		for _, line := range []*billing.Line{lines.flatPerUnit, lines.tieredGraduated, lines.tieredVolume, lines.flatFee} {
 			require.Equal(s.T(),
 				billing.Period{
-					Start: lo.Must(time.Parse(time.RFC3339, "2024-09-02T12:13:00Z")),
-					End:   lo.Must(time.Parse(time.RFC3339, "2024-09-03T12:13:00Z")),
+					Start: truncatedPeriodStart,
+					End:   truncatedPeriodEnd,
 				},
 				line.Period,
 				"period should be truncated to 1 min resolution",
@@ -2778,7 +2770,7 @@ func (s *InvoicingTestSuite) TestUBPNonProgressiveInvoicing() {
 
 			require.Equal(s.T(),
 				line.InvoiceAt,
-				periodEnd,
+				truncatedPeriodEnd,
 				"invoice at should be unchanged",
 			)
 		}
@@ -2835,8 +2827,8 @@ func (s *InvoicingTestSuite) TestUBPNonProgressiveInvoicing() {
 		tieredVolume := s.lineByID(invoiceLines, lines.tieredVolume.ID)
 
 		expectedPeriod := billing.Period{
-			Start: periodStart.Truncate(time.Minute),
-			End:   periodEnd.Truncate(time.Minute),
+			Start: truncatedPeriodStart,
+			End:   truncatedPeriodEnd,
 		}
 		for _, line := range []*billing.Line{flatPerUnit, tieredGraduated, tieredVolume} {
 			require.True(s.T(), expectedPeriod.Equal(line.Period), "period should not be changed for the line items")
@@ -2844,8 +2836,8 @@ func (s *InvoicingTestSuite) TestUBPNonProgressiveInvoicing() {
 
 		require.Equal(s.T(),
 			billing.Period{
-				Start: periodStart,
-				End:   periodEnd,
+				Start: truncatedPeriodStart,
+				End:   truncatedPeriodEnd,
 			},
 			flatFee.Period,
 			"period should be unchanged",

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -1293,8 +1293,8 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 	periodStart := testutils.GetRFC3339Time(s.T(), "2024-09-02T12:13:14.1234Z")
 	periodEnd := testutils.GetRFC3339Time(s.T(), "2024-09-03T12:13:14.1234Z")
 
-	truncatedPeriodStart := periodStart.Truncate(streaming.MinWindowSizeDuration)
-	truncatedPeriodEnd := periodEnd.Truncate(streaming.MinWindowSizeDuration)
+	truncatedPeriodStart := periodStart.Truncate(streaming.MinimumWindowSizeDuration)
+	truncatedPeriodEnd := periodEnd.Truncate(streaming.MinimumWindowSizeDuration)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
 
@@ -1928,7 +1928,7 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 			Start: truncatedPeriodStart.Add(time.Hour),
 			End:   truncatedPeriodStart.Add(2 * time.Hour),
 		}), "second child period should be between the first and the third child's period")
-		require.True(s.T(), tieredGraduatedHierarchy.Lines[1].Line.InvoiceAt.Equal(periodStart.Add(2*time.Hour).Truncate(streaming.MinWindowSizeDuration)), "second child should be issued at the end of parent's period")
+		require.True(s.T(), tieredGraduatedHierarchy.Lines[1].Line.InvoiceAt.Equal(periodStart.Add(2*time.Hour).Truncate(streaming.MinimumWindowSizeDuration)), "second child should be issued at the end of parent's period")
 		require.True(s.T(), tieredGraduatedHierarchy.Lines[2].Line.Period.Equal(billing.Period{
 			Start: truncatedPeriodStart.Add(2 * time.Hour),
 			End:   truncatedPeriodEnd,
@@ -2504,8 +2504,8 @@ func (s *InvoicingTestSuite) TestUBPNonProgressiveInvoicing() {
 	periodStart := lo.Must(time.Parse(time.RFC3339, "2024-09-02T12:13:14.1234Z"))
 	periodEnd := lo.Must(time.Parse(time.RFC3339, "2024-09-03T12:13:14.1234Z"))
 
-	truncatedPeriodStart := periodStart.Truncate(streaming.MinWindowSizeDuration)
-	truncatedPeriodEnd := periodEnd.Truncate(streaming.MinWindowSizeDuration)
+	truncatedPeriodStart := periodStart.Truncate(streaming.MinimumWindowSizeDuration)
+	truncatedPeriodEnd := periodEnd.Truncate(streaming.MinimumWindowSizeDuration)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
 

--- a/tools/migrate/migrations/20250731160524_billing-second-resolution.up.sql
+++ b/tools/migrate/migrations/20250731160524_billing-second-resolution.up.sql
@@ -1,0 +1,20 @@
+-- We need to annotate the previous lines to indicate to subscription sync to ignore them due to the period calculation change.
+-- Billing sync will ensure that the lines are continous for a subscription item, thus we will not have a few seconds of gaps
+-- in the invoices.
+
+UPDATE billing_invoice_lines
+SET
+    annotations = CASE
+        WHEN annotations IS NULL OR annotations = 'null'::jsonb THEN '{}'::jsonb
+        ELSE annotations
+    END || jsonb_build_object('billing.subscription.sync.ignore', true)
+WHERE
+    -- Line type usage based
+    "type" = 'usage_based'
+    -- Status valid
+    AND "status" = 'valid'
+    -- InvoiceID belongs to a not gathering invoice
+    AND "invoice_id" NOT IN (
+        SELECT "id" FROM billing_invoices
+        WHERE "status" = 'gathering'
+    );

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:J2U59EjDyQ3XOBdfwEsuRRC0ROX6IzOisMxyRnB2eA4=
+h1:VexlyNLh969fVcGEu2v08GoyRgTTOj/faSBCQ55eE9k=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -114,4 +114,4 @@ h1:J2U59EjDyQ3XOBdfwEsuRRC0ROX6IzOisMxyRnB2eA4=
 20250707075725_billingline-annotations.up.sql h1:bfTEaqbIFbPBJpEICHvvyUb6T2iUycQkNLN7ZittZgM=
 20250711121333_customer_annotations.up.sql h1:AHh+LE27UZiCLCQa4eXyb8noAoyMFekQNqfe6UEsf48=
 20250731141420_billing-migrate-flat-fee-lines.up.sql h1:7JgYbt/kXZ10HkUvckDY8sed1isRt9XPjBjOtPayz1A=
-20250731160524_billing-second-resolution.up.sql h1:XPSOvrwOXr/d0no3evuHplLHEzVMutrJrFKdnsWXSNA=
+20250731160524_billing-second-resolution.up.sql h1:7m4RF8MDwJEutOGX+Lfskf4ZFdl3u18ACSgVNV5ddxY=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Dn9/JrQqIKg8KVgUmO/lmyUYl9pD/UDT683KZAmYZUY=
+h1:J2U59EjDyQ3XOBdfwEsuRRC0ROX6IzOisMxyRnB2eA4=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -114,3 +114,4 @@ h1:Dn9/JrQqIKg8KVgUmO/lmyUYl9pD/UDT683KZAmYZUY=
 20250707075725_billingline-annotations.up.sql h1:bfTEaqbIFbPBJpEICHvvyUb6T2iUycQkNLN7ZittZgM=
 20250711121333_customer_annotations.up.sql h1:AHh+LE27UZiCLCQa4eXyb8noAoyMFekQNqfe6UEsf48=
 20250731141420_billing-migrate-flat-fee-lines.up.sql h1:7JgYbt/kXZ10HkUvckDY8sed1isRt9XPjBjOtPayz1A=
+20250731160524_billing-second-resolution.up.sql h1:XPSOvrwOXr/d0no3evuHplLHEzVMutrJrFKdnsWXSNA=


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch ensures that the whole billing stack uses 1s resolution for both usage_based/metered and usage_based/flat_fee lines.

This is required as due to collection moved to the draft invoices if an invoice contains both types, we might create two invoices.

The overal approach is that all inputs to billing is sanitized to use per second resolution entries, plus a migration is added so that subscription sync will fill the gaps between the lines of the same subscription item. This is done at multiple places:
- LineService ensures that CreatePendingLines truncate the periods.
- HTTPDriver ensures that Simulation and Invoice Update truncates the period.

We are not updating the old invoices to prevent changes in already issued invoices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and consistency of time period handling across billing and invoicing by standardizing truncation to a 1-second resolution.
  * Enhanced validation and comparison of invoice line periods to prevent issues with zero-length or misaligned service periods.
  * Updated test cases to reflect new time truncation logic and ensure reliable results.

* **Chores**
  * Renamed internal constants for minimum window size duration to improve clarity.
  * Added a database migration to annotate certain invoice lines for synchronization purposes.

* **Documentation**
  * Added and updated comments to clarify billing line handling and truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->