### PR TITLE
fix: always generate usage based lines if price is set to 0

### DIFF
--- a/openmeter/billing/invoiceline.go
+++ b/openmeter/billing/invoiceline.go
@@ -529,8 +529,8 @@ func (i Line) ValidateFee() error {
 		errs = append(errs, errors.New("price should be positive or zero"))
 	}
 
-	if !i.FlatFee.Quantity.IsPositive() {
-		errs = append(errs, errors.New("quantity should be positive required"))
+	if i.FlatFee.Quantity.IsNegative() {
+		errs = append(errs, errors.New("quantity should be positive or zero"))
 	}
 
 	if !slices.Contains(FlatFeeCategory("").Values(), string(i.FlatFee.Category)) {
@@ -784,6 +784,12 @@ func (c *LineChildren) ReplaceByID(id string, newLine *Line) bool {
 	}
 
 	return false
+}
+
+func (c *LineChildren) GetByChildUniqueReferenceID(id string) *Line {
+	return lo.FindOrElse(c.Option.OrEmpty(), nil, func(line *Line) bool {
+		return lo.FromPtr(line.ChildUniqueReferenceID) == id
+	})
 }
 
 // ChildrenWithIDReuse returns a new LineChildren instance with the given lines. If the line has a child

--- a/openmeter/billing/service/lineservice/pricegraduatedtiered.go
+++ b/openmeter/billing/service/lineservice/pricegraduatedtiered.go
@@ -40,7 +40,7 @@ func (p graduatedTieredPricer) Calculate(l PricerCalculateInput) (newDetailedLin
 		TierCallbackFn: func(in tierCallbackInput) error {
 			tierIndex := in.TierIndex + 1
 
-			if in.Tier.UnitPrice != nil && in.Quantity.IsPositive() {
+			if in.Tier.UnitPrice != nil {
 				newLine := newDetailedLineInput{
 					Name:                   fmt.Sprintf("%s: usage price for tier %d", l.line.Name, tierIndex),
 					Quantity:               in.Quantity,

--- a/openmeter/billing/service/lineservice/pricegraduatedtiered_test.go
+++ b/openmeter/billing/service/lineservice/pricegraduatedtiered_test.go
@@ -22,6 +22,9 @@ func TestTieredGraduatedCalculation(t *testing.T) {
 				// 20/unit
 				Amount: alpacadecimal.NewFromFloat(100),
 			},
+			UnitPrice: &productcatalog.PriceTierUnitPrice{
+				Amount: alpacadecimal.NewFromFloat(0),
+			},
 		},
 		{
 			UpToAmount: lo.ToPtr(alpacadecimal.NewFromFloat(10)),
@@ -68,7 +71,15 @@ func TestTieredGraduatedCalculation(t *testing.T) {
 			usage: featureUsageResponse{
 				LinePeriodQty: alpacadecimal.NewFromFloat(0),
 			},
-			expect: newDetailedLinesInput{},
+			expect: newDetailedLinesInput{
+				{
+					Name:                   "feature: usage price for tier 1",
+					PerUnitAmount:          alpacadecimal.NewFromFloat(0),
+					Quantity:               alpacadecimal.NewFromFloat(0),
+					ChildUniqueReferenceID: "graduated-tiered-1-price-usage",
+					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+				},
+			},
 		})
 	})
 
@@ -83,6 +94,13 @@ func TestTieredGraduatedCalculation(t *testing.T) {
 				LinePeriodQty: alpacadecimal.NewFromFloat(22),
 			},
 			expect: newDetailedLinesInput{
+				{
+					Name:                   "feature: usage price for tier 1",
+					PerUnitAmount:          alpacadecimal.NewFromFloat(0),
+					Quantity:               alpacadecimal.NewFromFloat(5),
+					ChildUniqueReferenceID: "graduated-tiered-1-price-usage",
+					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+				},
 				{
 					Name:                   "feature: flat price for tier 1",
 					PerUnitAmount:          alpacadecimal.NewFromFloat(100),
@@ -163,6 +181,13 @@ func TestTieredGraduatedCalculation(t *testing.T) {
 			},
 			previousBilledAmount: alpacadecimal.NewFromFloat(100), // Due to flat fee of 100 for tier 1
 			expect: newDetailedLinesInput{
+				{
+					Name:                   "feature: usage price for tier 1",
+					PerUnitAmount:          alpacadecimal.NewFromFloat(0),
+					Quantity:               alpacadecimal.NewFromFloat(0),
+					ChildUniqueReferenceID: "graduated-tiered-1-price-usage",
+					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+				},
 				{
 					Name: "feature: minimum spend",
 					// We have a flat fee of 100 for tier 1, and given that it was invoiced as part of the previous split we need to remove

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -2398,14 +2398,15 @@ func (s *InvoicingTestSuite) TestUBPGraduatingFlatFeeTier1() {
 		}, tieredGraduated.Totals)
 
 		// Let's validate the output of the split itself
-		s.Len(tieredGraduated.Children.OrEmpty(), 1)
-		childLine := tieredGraduated.Children.OrEmpty()[0]
+		// Other line is a zero usage line
+		s.Len(tieredGraduated.Children.OrEmpty(), 2)
+		flatFeeLine := tieredGraduated.Children.GetByChildUniqueReferenceID("graduated-tiered-1-flat-price")
+		require.NotNil(s.T(), flatFeeLine)
 
 		requireTotals(s.T(), expectedTotals{
 			Amount: 100,
 			Total:  100,
-		}, childLine.Totals)
-		s.Equal(*childLine.ChildUniqueReferenceID, "graduated-tiered-1-flat-price")
+		}, flatFeeLine.Totals)
 	})
 
 	s.Run("create mid period invoice 2, no usage", func() {
@@ -2434,7 +2435,14 @@ func (s *InvoicingTestSuite) TestUBPGraduatingFlatFeeTier1() {
 		}, tieredGraduated.Totals)
 
 		// Let's validate the output of the split itself
-		s.Len(tieredGraduated.Children.OrEmpty(), 0)
+		s.Len(tieredGraduated.Children.OrEmpty(), 1)
+		usageBasedEmptyLine := tieredGraduated.Children.GetByChildUniqueReferenceID("graduated-tiered-1-price-usage")
+		require.NotNil(s.T(), usageBasedEmptyLine)
+
+		requireTotals(s.T(), expectedTotals{
+			Amount: 0,
+			Total:  0,
+		}, usageBasedEmptyLine.Totals)
 	})
 
 	s.Run("create new invoice, with usage", func() {


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

If graduating tiered price's usage is set to nil we are not generating lines.

Existing invoices are unchanged, as the change does not change the usage based's qty and totals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Zero quantity is now accepted as valid for flat fee line items, improving billing accuracy.
  * Billing logic now includes detailed lines for zero-quantity or zero-priced usage in graduated tiered pricing.

* **Tests**
  * Updated test cases to expect and validate zero-quantity or zero-priced usage lines in tiered pricing scenarios.
  * Adjusted invoice tests to verify the presence and correctness of zero-usage or flat fee child lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->