### PR TITLE
fix: mock streaming use 1s resolution

### DIFF
--- a/openmeter/meter/meter.go
+++ b/openmeter/meter/meter.go
@@ -57,6 +57,9 @@ type WindowSize string
 
 // Note: keep values up to date in the meter package
 const (
+	// WindowSizeSecond is the size of the window in seconds, this is possible to use for streaming queries
+	// but not exposed to the metering API as this seems to be an overkill for most external use-cases.
+	WindowSizeSecond WindowSize = "SECOND"
 	WindowSizeMinute WindowSize = "MINUTE"
 	WindowSizeHour   WindowSize = "HOUR"
 	WindowSizeDay    WindowSize = "DAY"
@@ -66,6 +69,7 @@ const (
 // Values provides list valid values for Enum
 func (WindowSize) Values() (kinds []string) {
 	for _, s := range []WindowSize{
+		WindowSizeSecond,
 		WindowSizeMinute,
 		WindowSizeHour,
 		WindowSizeDay,
@@ -78,6 +82,8 @@ func (WindowSize) Values() (kinds []string) {
 
 func (w WindowSize) AddTo(t time.Time) (time.Time, error) {
 	switch w {
+	case WindowSizeSecond:
+		return t.Add(time.Second), nil
 	case WindowSizeMinute:
 		return t.Add(time.Minute), nil
 	case WindowSizeHour:
@@ -93,6 +99,8 @@ func (w WindowSize) AddTo(t time.Time) (time.Time, error) {
 
 func (w WindowSize) Truncate(t time.Time) (time.Time, error) {
 	switch w {
+	case WindowSizeSecond:
+		return t.Truncate(time.Second), nil
 	case WindowSizeMinute:
 		return t.Truncate(time.Minute), nil
 	case WindowSizeHour:

--- a/openmeter/streaming/defaults.go
+++ b/openmeter/streaming/defaults.go
@@ -1,0 +1,14 @@
+package streaming
+
+import (
+	"time"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+)
+
+const (
+	// MinWindowSizeDuration is the minimum window size the aggregation can represent.
+	MinWindowSizeDuration = time.Second
+	// MinWindowSize is the minimum window size the aggregation can represent.
+	MinWindowSize = meter.WindowSizeSecond
+)

--- a/openmeter/streaming/testutils/streaming.go
+++ b/openmeter/streaming/testutils/streaming.go
@@ -143,8 +143,9 @@ func (m *MockStreamingConnector) aggregateEvents(mm meter.Meter, params streamin
 		return nil, fmt.Errorf("streaming mock connector does not support filtering without from and to")
 	}
 
-	from := *params.From
-	to := *params.To
+	// Let's truncate the window size to the second, as clickhouse does not support sub-second precision
+	from := params.From.Truncate(streaming.MinWindowSizeDuration)
+	to := params.To.Truncate(streaming.MinWindowSizeDuration)
 
 	rows := make([]meter.MeterQueryRow, 0)
 
@@ -184,7 +185,7 @@ func (m *MockStreamingConnector) aggregateEvents(mm meter.Meter, params streamin
 		row := &rows[i]
 		var value float64
 
-		effectiveWindowSize := lo.FromPtrOr(params.WindowSize, meter.WindowSizeMinute)
+		effectiveWindowSize := lo.FromPtrOr(params.WindowSize, streaming.MinWindowSize)
 
 		for _, event := range events {
 			eventWindowStart, err := effectiveWindowSize.Truncate(event.Time)

--- a/openmeter/streaming/testutils/streaming_test.go
+++ b/openmeter/streaming/testutils/streaming_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/convert"
 )
 
@@ -32,233 +33,266 @@ func TestMockStreamingConnector(t *testing.T) {
 		ExpectedError error
 	}
 
-	now, err := time.Parse(time.RFC3339, "2024-01-01T00:00:00Z")
-	assert.NoError(t, err)
-
 	tt := []tc{
 		{
 			Name: "Should return error if meter not found",
 			Query: streaming.QueryParams{
-				From: convert.ToPointer(now.Add(-time.Hour)),
-				To:   convert.ToPointer(now),
+				From: convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T23:00:00Z")),
+				To:   convert.ToPointer(testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")),
 			},
 			ExpectedError: meter.NewMeterNotFoundError(defaultMeterSlug),
 		},
 		{
 			Name: "Should error if meter exists but doesnt match",
 			Query: streaming.QueryParams{
-				From: convert.ToPointer(now.Add(-time.Hour)),
-				To:   convert.ToPointer(now),
+				From: convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T23:00:00Z")),
+				To:   convert.ToPointer(testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")),
 			},
 			ExpectedError: meter.NewMeterNotFoundError(defaultMeterSlug),
-			Events:        []SimpleEvent{{MeterSlug: ulid.Make().String(), Value: 0, Time: now}},
+			Events: []SimpleEvent{
+				{MeterSlug: ulid.Make().String(), Value: 0, Time: testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")},
+			},
 		},
 		{
 			Name: "Should return empty rows if no rows and no events",
 			Query: streaming.QueryParams{
-				From: convert.ToPointer(now.Add(-time.Hour)),
-				To:   convert.ToPointer(now),
+				From: convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T23:00:00Z")),
+				To:   convert.ToPointer(testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")),
 			},
 			Expected: []meter.MeterQueryRow{},
 			Rows:     []meter.MeterQueryRow{},
 			// meter has to exist
-			Events: []SimpleEvent{{MeterSlug: defaultMeterSlug, Value: 0, Time: now}},
+			Events: []SimpleEvent{
+				{MeterSlug: defaultMeterSlug, Value: 0, Time: testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")},
+			},
 		},
 		{
 			Name: "Should return exact row",
 			Query: streaming.QueryParams{
-				From: convert.ToPointer(now.Add(-time.Hour)),
-				To:   convert.ToPointer(now),
+				From: convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T23:00:00Z")),
+				To:   convert.ToPointer(testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")),
 			},
 			Expected: []meter.MeterQueryRow{{
 				Value:       1,
-				WindowStart: now.Add(-time.Hour),
-				WindowEnd:   now,
+				WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:00:00Z"),
+				WindowEnd:   testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
 				GroupBy:     map[string]*string{},
 			}},
 			Rows: []meter.MeterQueryRow{{
 				Value:       1,
-				WindowStart: now.Add(-time.Hour),
-				WindowEnd:   now,
+				WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:00:00Z"),
+				WindowEnd:   testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
 				GroupBy:     map[string]*string{},
 			}},
 		},
 		{
 			Name: "Should return event sum",
 			Query: streaming.QueryParams{
-				From: convert.ToPointer(now.Add(-time.Hour)),
-				To:   convert.ToPointer(now),
+				From: convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T23:00:00Z")),
+				To:   convert.ToPointer(testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")),
 			},
 			Expected: []meter.MeterQueryRow{{
 				Value:       5,
-				WindowStart: now.Add(-time.Hour),
-				WindowEnd:   now,
+				WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:00:00Z"),
+				WindowEnd:   testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
 				GroupBy:     map[string]*string{},
 			}},
 			Events: []SimpleEvent{
-				{MeterSlug: defaultMeterSlug, Value: 2, Time: now.Add(-time.Minute)},
-				{MeterSlug: defaultMeterSlug, Value: 3, Time: now.Add(-time.Second)},
+				{MeterSlug: defaultMeterSlug, Value: 2, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:00Z")},
+				{MeterSlug: defaultMeterSlug, Value: 3, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:59Z")},
 			},
 		},
 		{
-			Name: "Should aggregate events as if they were windowed",
+			Name: "Should aggregate events as if they were windowed - minute window",
 			Query: streaming.QueryParams{
-				From: convert.ToPointer(now.Truncate(time.Minute).Add(time.Second * 30).Add(-time.Minute * 2)),
-				To:   convert.ToPointer(now.Truncate(time.Minute).Add(time.Second * 30)),
+				From:       convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T23:58:30Z")),
+				To:         convert.ToPointer(testutils.GetRFC3339Time(t, "2024-01-01T00:00:30Z")),
+				WindowSize: convert.ToPointer(meter.WindowSizeMinute), // Force 1 minute window (even if this is not a valid api call on the main api)
 			},
 			Expected: []meter.MeterQueryRow{{
 				Value:       2,
-				WindowStart: now.Truncate(time.Minute).Add(time.Second * 30).Add(-time.Minute * 2),
-				WindowEnd:   now.Truncate(time.Minute).Add(time.Second * 30),
+				WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:58:30Z"),
+				WindowEnd:   testutils.GetRFC3339Time(t, "2024-01-01T00:00:30Z"),
 				GroupBy:     map[string]*string{},
 			}},
 			Events: []SimpleEvent{
 				// period start
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Truncate(time.Minute).Add(time.Second * 30).Add(-time.Minute * 2)},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:58:30Z")},
 				// event in window of periodstart but before it
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Truncate(time.Minute).Add(time.Second * 29).Add(-time.Minute * 2)},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:58:29Z")},
 				// event in window of periodstart but after it
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Truncate(time.Minute).Add(time.Second * 31).Add(-time.Minute * 2)},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:58:31Z")},
 				// event in only valid window at start of it
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Truncate(time.Minute).Add(-time.Minute)},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:00Z")},
 				// event in only valid window in middle of it
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Truncate(time.Minute).Add(-time.Minute).Add(time.Second * 30)},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:30Z")},
 				// For simple event aggregation end is exclusive so this should not count
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Truncate(time.Minute)},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")},
 				// event in window of periodend but before it
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Truncate(time.Minute).Add(time.Second * 29)},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2024-01-01T00:00:29Z")},
 				// period end
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Truncate(time.Minute).Add(time.Second * 30)},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2024-01-01T00:00:30Z")},
 				// event in window of periodend but after it
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Truncate(time.Minute).Add(time.Second * 31)},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2024-01-01T00:00:31Z")},
+			},
+		},
+		// Second window size
+		{
+			Name: "Should aggregate events as if they were windowed - second window",
+			Query: streaming.QueryParams{
+				From:       convert.ToPointer(testutils.GetRFC3339Time(t, "2024-01-01T00:00:00.1234Z")),
+				To:         convert.ToPointer(testutils.GetRFC3339Time(t, "2024-01-01T00:00:30.1234Z")),
+				WindowSize: convert.ToPointer(meter.WindowSizeSecond), // Force 1 minute window (even if this is not a valid api call on the main api)
+			},
+			Expected: []meter.MeterQueryRow{{
+				Value:       3,
+				WindowStart: testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
+				WindowEnd:   testutils.GetRFC3339Time(t, "2024-01-01T00:00:30Z"),
+				GroupBy:     map[string]*string{},
+			}},
+			Events: []SimpleEvent{
+				// event before periodstart
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:59Z")},
+				// period start
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")},
+				// event after periodstart
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2024-01-01T00:00:01.11Z")},
+				// event in window of periodend but before it
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2024-01-01T00:00:29.123Z")},
+				// period end
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2024-01-01T00:00:30Z")},
+				// For simple event aggregation end is exclusive so this should not count
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2024-01-01T00:00:30.123Z")},
+				// event in window of periodend but after it
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2024-01-01T00:00:31Z")},
 			},
 		},
 		{
 			Name: "Should return events windowed",
 			Query: streaming.QueryParams{
-				From:           convert.ToPointer(now.Add(-time.Minute * 3)),
-				To:             convert.ToPointer(now),
+				From:           convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T23:57:00Z")),
+				To:             convert.ToPointer(testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")),
 				WindowSize:     convert.ToPointer(meter.WindowSizeMinute),
 				WindowTimeZone: time.UTC,
 			},
 			Expected: []meter.MeterQueryRow{
 				{
 					Value:       1,
-					WindowStart: now.Add(-time.Minute * 3),
-					WindowEnd:   now.Add(-time.Minute * 2),
+					WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:57:00Z"),
+					WindowEnd:   testutils.GetRFC3339Time(t, "2023-12-31T23:58:00Z"),
 					GroupBy:     map[string]*string{},
 				},
 				{
 					Value:       2,
-					WindowStart: now.Add(-time.Minute * 2),
-					WindowEnd:   now.Add(-time.Minute),
+					WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:58:00Z"),
+					WindowEnd:   testutils.GetRFC3339Time(t, "2023-12-31T23:59:00Z"),
 					GroupBy:     map[string]*string{},
 				},
 				{
 					Value:       5,
-					WindowStart: now.Add(-time.Minute),
-					WindowEnd:   now,
+					WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:59:00Z"),
+					WindowEnd:   testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
 					GroupBy:     map[string]*string{},
 				},
 			},
 			Events: []SimpleEvent{
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Add(-time.Minute * 2).Add(-time.Second * 2)},
-				{MeterSlug: defaultMeterSlug, Value: 2, Time: now.Add(-time.Minute * 2).Add(time.Second * 2)},
-				{MeterSlug: defaultMeterSlug, Value: 2, Time: now.Add(-time.Minute)},
-				{MeterSlug: defaultMeterSlug, Value: 3, Time: now.Add(-time.Second)},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:57:58Z")},
+				{MeterSlug: defaultMeterSlug, Value: 2, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:58:02Z")},
+				{MeterSlug: defaultMeterSlug, Value: 2, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:00Z")},
+				{MeterSlug: defaultMeterSlug, Value: 3, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:59Z")},
 			},
 		},
 		{
 			Name: "Should return events windowed even if query from and to don't align with window boundaries",
 			Query: streaming.QueryParams{
-				From:           convert.ToPointer(now.Add(-time.Minute * 3).Add(time.Second)),
-				To:             convert.ToPointer(now.Add(-time.Second)),
+				From:           convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T23:57:01Z")),
+				To:             convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T23:59:59Z")),
 				WindowSize:     convert.ToPointer(meter.WindowSizeMinute),
 				WindowTimeZone: time.UTC,
 			},
 			Expected: []meter.MeterQueryRow{
 				{
 					Value:       1,
-					WindowStart: now.Add(-time.Minute * 3),
-					WindowEnd:   now.Add(-time.Minute * 2),
+					WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:57:00Z"),
+					WindowEnd:   testutils.GetRFC3339Time(t, "2023-12-31T23:58:00Z"),
 					GroupBy:     map[string]*string{},
 				},
 				{
 					Value:       2,
-					WindowStart: now.Add(-time.Minute * 2),
-					WindowEnd:   now.Add(-time.Minute),
+					WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:58:00Z"),
+					WindowEnd:   testutils.GetRFC3339Time(t, "2023-12-31T23:59:00Z"),
 					GroupBy:     map[string]*string{},
 				},
 				{
 					Value:       5,
-					WindowStart: now.Add(-time.Minute),
-					WindowEnd:   now,
+					WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:59:00Z"),
+					WindowEnd:   testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
 					GroupBy:     map[string]*string{},
 				},
 			},
 			Events: []SimpleEvent{
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Add(-time.Minute * 2).Add(-time.Second * 2)},
-				{MeterSlug: defaultMeterSlug, Value: 2, Time: now.Add(-time.Minute * 2).Add(time.Second * 2)},
-				{MeterSlug: defaultMeterSlug, Value: 2, Time: now.Add(-time.Minute)},
-				{MeterSlug: defaultMeterSlug, Value: 3, Time: now.Add(-time.Second)},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:57:58Z")},
+				{MeterSlug: defaultMeterSlug, Value: 2, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:58:02Z")},
+				{MeterSlug: defaultMeterSlug, Value: 2, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:00Z")},
+				{MeterSlug: defaultMeterSlug, Value: 3, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:59Z")},
 			},
 		},
 		{
 			Name: "Should not return rows for periods in which there are no events",
 			Query: streaming.QueryParams{
-				From:           convert.ToPointer(now.Add(-time.Minute * 3).Add(time.Second)),
-				To:             convert.ToPointer(now.Add(-time.Second)),
+				From:           convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T23:57:01Z")),
+				To:             convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T23:59:59Z")),
 				WindowSize:     convert.ToPointer(meter.WindowSizeMinute),
 				WindowTimeZone: time.UTC,
 			},
 			Expected: []meter.MeterQueryRow{
 				{
 					Value:       1,
-					WindowStart: now.Add(-time.Minute * 3),
-					WindowEnd:   now.Add(-time.Minute * 2),
+					WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:57:00Z"),
+					WindowEnd:   testutils.GetRFC3339Time(t, "2023-12-31T23:58:00Z"),
 					GroupBy:     map[string]*string{},
 				},
 				{
 					Value:       5,
-					WindowStart: now.Add(-time.Minute),
-					WindowEnd:   now,
+					WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:59:00Z"),
+					WindowEnd:   testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
 					GroupBy:     map[string]*string{},
 				},
 			},
 			Events: []SimpleEvent{
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Add(-time.Minute * 2).Add(-time.Second * 2)},
-				{MeterSlug: defaultMeterSlug, Value: 2, Time: now.Add(-time.Minute)},
-				{MeterSlug: defaultMeterSlug, Value: 3, Time: now.Add(-time.Second)},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:57:58Z")},
+				{MeterSlug: defaultMeterSlug, Value: 2, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:00Z")},
+				{MeterSlug: defaultMeterSlug, Value: 3, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:59Z")},
 			},
 		},
 		{
 			Name: "Should return row for queried period if window is larger than period if there are events in the period",
 			Query: streaming.QueryParams{
-				From:           convert.ToPointer(now.Add(-time.Minute * 3)),
-				To:             convert.ToPointer(now),
+				From:           convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T23:57:00Z")),
+				To:             convert.ToPointer(testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")),
 				WindowSize:     convert.ToPointer(meter.WindowSizeHour),
 				WindowTimeZone: time.UTC,
 			},
 			Expected: []meter.MeterQueryRow{
 				{
 					Value:       8,
-					WindowStart: now.Add(-time.Hour),
-					WindowEnd:   now,
+					WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:00:00Z"),
+					WindowEnd:   testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
 					GroupBy:     map[string]*string{},
 				},
 			},
 			Events: []SimpleEvent{
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Add(-time.Minute * 2).Add(-time.Second * 2)},
-				{MeterSlug: defaultMeterSlug, Value: 2, Time: now.Add(-time.Minute * 2).Add(time.Second * 2)},
-				{MeterSlug: defaultMeterSlug, Value: 2, Time: now.Add(-time.Minute)},
-				{MeterSlug: defaultMeterSlug, Value: 3, Time: now.Add(-time.Second)},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:57:58Z")},
+				{MeterSlug: defaultMeterSlug, Value: 2, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:58:02Z")},
+				{MeterSlug: defaultMeterSlug, Value: 2, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:00Z")},
+				{MeterSlug: defaultMeterSlug, Value: 3, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:59Z")},
 			},
 		},
 		{
 			Name: "Should use latest value if meter.Aggregation is LATEST when NOT windowed",
 			Query: streaming.QueryParams{
-				From: convert.ToPointer(now.Add(-time.Minute * 3)),
-				To:   convert.ToPointer(now),
+				From: convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T23:57:00Z")),
+				To:   convert.ToPointer(testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")),
 			},
 			Meter: meter.Meter{
 				Key:         defaultMeterSlug,
@@ -267,25 +301,25 @@ func TestMockStreamingConnector(t *testing.T) {
 			Expected: []meter.MeterQueryRow{
 				{
 					Value:       3,
-					WindowStart: now.Add(-time.Minute * 3),
-					WindowEnd:   now,
+					WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:57:00Z"),
+					WindowEnd:   testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
 					GroupBy:     map[string]*string{},
 				},
 			},
 			Events: []SimpleEvent{
 				// Events should be sorted by time ASC and the LAST value should be returned
-				{MeterSlug: defaultMeterSlug, Value: 2, Time: now.Add(-time.Minute)},
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Add(-time.Minute * 2).Add(-time.Second * 2)},
-				{MeterSlug: defaultMeterSlug, Value: 2, Time: now.Add(-time.Minute * 2).Add(time.Second * 2)},
-				{MeterSlug: defaultMeterSlug, Value: 3, Time: now.Add(-time.Second)},
-				{MeterSlug: defaultMeterSlug, Value: 4, Time: now.Add(time.Second * 2)},
+				{MeterSlug: defaultMeterSlug, Value: 2, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:00Z")},
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:57:58Z")},
+				{MeterSlug: defaultMeterSlug, Value: 2, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:58:02Z")},
+				{MeterSlug: defaultMeterSlug, Value: 3, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:59Z")},
+				{MeterSlug: defaultMeterSlug, Value: 4, Time: testutils.GetRFC3339Time(t, "2024-01-01T00:00:02Z")},
 			},
 		},
 		{
 			Name: "Should use latest value if meter.Aggregation is LATEST when windowed",
 			Query: streaming.QueryParams{
-				From:           convert.ToPointer(now.Add(-time.Hour * 2)),
-				To:             convert.ToPointer(now),
+				From:           convert.ToPointer(testutils.GetRFC3339Time(t, "2023-12-31T22:00:00Z")),
+				To:             convert.ToPointer(testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z")),
 				WindowSize:     convert.ToPointer(meter.WindowSizeHour),
 				WindowTimeZone: time.UTC,
 			},
@@ -296,25 +330,25 @@ func TestMockStreamingConnector(t *testing.T) {
 			Expected: []meter.MeterQueryRow{
 				{
 					Value:       3,
-					WindowStart: now.Add(-time.Hour * 2),
-					WindowEnd:   now.Add(-time.Hour),
+					WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T22:00:00Z"),
+					WindowEnd:   testutils.GetRFC3339Time(t, "2023-12-31T23:00:00Z"),
 					GroupBy:     map[string]*string{},
 				},
 				{
 					Value:       5,
-					WindowStart: now.Add(-time.Hour),
-					WindowEnd:   now,
+					WindowStart: testutils.GetRFC3339Time(t, "2023-12-31T23:00:00Z"),
+					WindowEnd:   testutils.GetRFC3339Time(t, "2024-01-01T00:00:00Z"),
 					GroupBy:     map[string]*string{},
 				},
 			},
 			Events: []SimpleEvent{
-				{MeterSlug: defaultMeterSlug, Value: 1, Time: now.Add(-time.Hour * 2).Add(-time.Second * 2)}, // Should be ignored
-				{MeterSlug: defaultMeterSlug, Value: 3, Time: now.Add(-time.Hour * 2).Add(time.Second * 6)},  // Should be last value in first window
-				{MeterSlug: defaultMeterSlug, Value: 2, Time: now.Add(-time.Hour * 2).Add(time.Second * 2)},
-				{MeterSlug: defaultMeterSlug, Value: 4, Time: now.Add(-time.Hour)}, // Should fall into second window
-				{MeterSlug: defaultMeterSlug, Value: 5, Time: now.Add(-time.Second)},
-				{MeterSlug: defaultMeterSlug, Value: 6, Time: now.Add(-time.Second * 2)},
-				{MeterSlug: defaultMeterSlug, Value: 7, Time: now.Add(time.Second * 2)}, // Should be ignored
+				{MeterSlug: defaultMeterSlug, Value: 1, Time: testutils.GetRFC3339Time(t, "2023-12-31T21:59:58Z")}, // Should be ignored
+				{MeterSlug: defaultMeterSlug, Value: 3, Time: testutils.GetRFC3339Time(t, "2023-12-31T22:00:06Z")}, // Should be last value in first window
+				{MeterSlug: defaultMeterSlug, Value: 2, Time: testutils.GetRFC3339Time(t, "2023-12-31T22:00:02Z")},
+				{MeterSlug: defaultMeterSlug, Value: 4, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:00:00Z")}, // Should fall into second window
+				{MeterSlug: defaultMeterSlug, Value: 5, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:59Z")},
+				{MeterSlug: defaultMeterSlug, Value: 6, Time: testutils.GetRFC3339Time(t, "2023-12-31T23:59:58Z")},
+				{MeterSlug: defaultMeterSlug, Value: 7, Time: testutils.GetRFC3339Time(t, "2024-01-01T23:00:02Z")}, // Should be ignored
 			},
 		},
 	}


### PR DESCRIPTION
This change enables 1s resolution in streaming mock provider (we already have this feature for queries).

This refactors the streaming test mocks to use explicit timestamps for easier understanding of the testcases.

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This change also refactors the streaming tests to use explicit timestamps for easier understanding of the testcases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for "second" as a window size option for streaming queries, allowing for finer-grained event aggregation.

* **Bug Fixes**
  * Improved time boundary handling to ensure accurate aggregation when using second-level precision.

* **Tests**
  * Enhanced test coverage with new cases for "second" window size and explicit timestamp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->