### PR TITLE
refactor: ignore/log payment app type mismatch

### DIFF
--- a/openmeter/customer/service/hooks/subject.go
+++ b/openmeter/customer/service/hooks/subject.go
@@ -225,7 +225,7 @@ func (p CustomerProvisioner) getCustomerForSubject(ctx context.Context, sub *sub
 }
 
 // EnsureCustomer returns a Customer entity created/updated based on the provided Subject.
-func (p CustomerProvisioner) ensureCustomer(ctx context.Context, sub *subject.Subject) (*customer.Customer, error) {
+func (p CustomerProvisioner) EnsureCustomer(ctx context.Context, sub *subject.Subject) (*customer.Customer, error) {
 	if sub == nil {
 		return nil, errors.New("failed to provision customer for subject: subject is nil")
 	}
@@ -342,7 +342,7 @@ func (e InvalidPaymentAppError) Error() string {
 	return fmt.Sprintf("invalid payment app type [app.type=%s app.id=%s]", e.AppType, e.AppID.ID)
 }
 
-func (p CustomerProvisioner) ensureStripeCustomer(ctx context.Context, customerID customer.CustomerID, stripeCustomerID string) error {
+func (p CustomerProvisioner) EnsureStripeCustomer(ctx context.Context, customerID customer.CustomerID, stripeCustomerID string) error {
 	customerOverride, err := p.customerOverride.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
 		Customer: customerID,
 		Expand: billing.CustomerOverrideExpand{
@@ -383,7 +383,7 @@ func (p CustomerProvisioner) ensureStripeCustomer(ctx context.Context, customerI
 }
 
 func (p CustomerProvisioner) Provision(ctx context.Context, sub *subject.Subject) error {
-	cus, err := p.ensureCustomer(ctx, sub)
+	cus, err := p.EnsureCustomer(ctx, sub)
 	if err != nil {
 		return fmt.Errorf("failed to provision customer for subject [namespace=%s subject.id=%s subject.key=%s]: %w",
 			sub.Namespace, sub.Id, sub.Key, err)
@@ -395,7 +395,7 @@ func (p CustomerProvisioner) Provision(ctx context.Context, sub *subject.Subject
 	}
 
 	if sub.StripeCustomerId != nil {
-		err = p.ensureStripeCustomer(ctx, customerID, *sub.StripeCustomerId)
+		err = p.EnsureStripeCustomer(ctx, customerID, *sub.StripeCustomerId)
 		if err != nil {
 			err = fmt.Errorf("failed to set stripe customer id for subject customer [namespace=%s subject.id=%s subject.key=%s customer.id=%s]: %w",
 				sub.Namespace, sub.Id, sub.Key, cus.ID, err)

--- a/openmeter/customer/service/hooks/subject_test.go
+++ b/openmeter/customer/service/hooks/subject_test.go
@@ -65,7 +65,7 @@ func TestCustomerProvisioner_EnsureCustomer(t *testing.T) {
 		require.ErrorAsf(t, err, new(*models.GenericNotFoundError), "error must be not found error")
 		assert.Nilf(t, cus, "customer must be nil")
 
-		cus, err = provisioner.ensureCustomer(ctx, &sub)
+		cus, err = provisioner.EnsureCustomer(ctx, &sub)
 		require.NoError(t, err, "provisioning customer should not fail")
 		assert.NotNilf(t, cus, "customer must not be nil")
 
@@ -120,7 +120,7 @@ func TestCustomerProvisioner_EnsureCustomer(t *testing.T) {
 			require.NoError(t, err, "updating customer should not fail")
 			assert.NotNilf(t, sub, "customer must not be nil")
 
-			cus, err = provisioner.ensureCustomer(ctx, &sub)
+			cus, err = provisioner.EnsureCustomer(ctx, &sub)
 			require.NoError(t, err, "provisioning customer should not fail")
 			assert.NotNilf(t, cus, "customer must not be nil")
 
@@ -175,7 +175,7 @@ func TestCustomerProvisioner_EnsureCustomer(t *testing.T) {
 			require.NoError(t, err, "creating customer should not fail")
 			assert.NotNilf(t, cus, "customer must not be nil")
 
-			cus, err = provisioner.ensureCustomer(ctx, &sub)
+			cus, err = provisioner.EnsureCustomer(ctx, &sub)
 			require.NoError(t, err, "provisioning customer should not fail")
 			assert.NotNilf(t, cus, "customer must not be nil")
 
@@ -228,7 +228,7 @@ func TestCustomerProvisioner_EnsureCustomer(t *testing.T) {
 			require.NoError(t, err, "creating customer should not fail")
 			assert.NotNilf(t, cus, "customer must not be nil")
 
-			cus, err = provisioner.ensureCustomer(ctx, &sub)
+			cus, err = provisioner.EnsureCustomer(ctx, &sub)
 			require.NoError(t, err, "provisioning customer should not fail")
 			assert.NotNilf(t, cus, "customer must not be nil")
 


### PR DESCRIPTION
## Overview

Skip migrating Stripe customer id for customer which has a payment app setup in their billing profile with type other than Stripe.
