### PR TITLE
chore: fix stripe webhook logging

### DIFF
--- a/openmeter/app/stripe/service/const.go
+++ b/openmeter/app/stripe/service/const.go
@@ -1,9 +1,7 @@
 package appservice
 
-type StripeLogAttributeName string
-
 const (
-	StripeInvoiceIDAttributeName StripeLogAttributeName = "stripe_invoice_id"
-	InvoiceIDAttributeName       StripeLogAttributeName = "invoice_id"
-	InvoiceStatusAttributeName   StripeLogAttributeName = "invoice_status"
+	StripeInvoiceIDAttributeName = "invoice.stripe_invoice_id"
+	InvoiceIDAttributeName       = "invoice.id"
+	InvoiceStatusAttributeName   = "invoice.status"
 )


### PR DESCRIPTION
## Overview

The code was using context variables instead of logger variables. This patch ensures that we log the relevant information.