### PR TITLE
fix: invalid error on period correction

### DIFF
--- a/openmeter/billing/worker/subscription/sync.go
+++ b/openmeter/billing/worker/subscription/sync.go
@@ -394,14 +394,13 @@ func (h *Handler) correctPeriodStartForUpcomingLines(ctx context.Context, subscr
 			continue
 		}
 
-		// Should not happen as this line is never the first line
-		// TODO: harmonize truncation logic here!
-		if !line.ServicePeriod.Start.Equal(line.BillingPeriod.Start) || !line.FullServicePeriod.Start.Equal(line.BillingPeriod.Start) {
-			return nil, fmt.Errorf("line[%s] service period start does not match billing period start or full service period start", line.UniqueID)
+		if !line.ServicePeriod.Start.Equal(line.FullServicePeriod.Start) {
+			// These should match otherwise any pro-rating logic will be invalid (we are never truncating the start of the service period so this should never happen)
+			return nil, fmt.Errorf("line[%s] service period and full service period start does not match", line.UniqueID)
 		}
 
+		// We are not overriding the billing period start as that is only used to determine the invoiceAt for inAdvance items
 		inScopeLines[idx].ServicePeriod.Start = previousServicePeriod.End
-		inScopeLines[idx].BillingPeriod.Start = previousServicePeriod.End
 		inScopeLines[idx].FullServicePeriod.Start = previousServicePeriod.End
 	}
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch makes sure that the period correction logic:
- Is only executed for lines where the transition happens
- The checks are relaxed, so that we only mandate service period and  full service period start to match
- If billing periods matching the service period, let's update the billing   period too, so that invoiceAt gets updated properly.