### PR TITLE
feat(app): stripe add metadata to invoice

### DIFF
--- a/openmeter/app/stripe/client/appclient.go
+++ b/openmeter/app/stripe/client/appclient.go
@@ -16,17 +16,18 @@ import (
 )
 
 const (
-	SetupIntentDataMetadataNamespace  = "om_namespace"
-	SetupIntentDataMetadataAppID      = "om_app_id"
-	SetupIntentDataMetadataCustomerID = "om_customer_id"
+	StripeMetadataNamespace  = "om_namespace"
+	StripeMetadataAppID      = "om_app_id"
+	StripeMetadataCustomerID = "om_customer_id"
+	StripeMetadataInvoiceID  = "om_invoice_id"
 )
 
 // SetupIntentReservedMetadataKeys are the keys that are reserved for internal use by OpenMeter
 // specifying these keys in the metadata will result in a validation error
 var SetupIntentReservedMetadataKeys = []string{
-	SetupIntentDataMetadataNamespace,
-	SetupIntentDataMetadataAppID,
-	SetupIntentDataMetadataCustomerID,
+	StripeMetadataNamespace,
+	StripeMetadataAppID,
+	StripeMetadataCustomerID,
 }
 
 const (

--- a/openmeter/app/stripe/client/checkout.go
+++ b/openmeter/app/stripe/client/checkout.go
@@ -28,9 +28,9 @@ func (c *stripeAppClient) CreateCheckoutSession(ctx context.Context, input Creat
 		metadata = map[string]string{}
 	}
 
-	metadata[SetupIntentDataMetadataNamespace] = input.AppID.Namespace
-	metadata[SetupIntentDataMetadataAppID] = input.AppID.ID
-	metadata[SetupIntentDataMetadataCustomerID] = input.CustomerID.ID
+	metadata[StripeMetadataNamespace] = input.AppID.Namespace
+	metadata[StripeMetadataAppID] = input.AppID.ID
+	metadata[StripeMetadataCustomerID] = input.CustomerID.ID
 
 	// Create checkout session
 	params := &stripe.CheckoutSessionParams{

--- a/openmeter/app/stripe/client/client.go
+++ b/openmeter/app/stripe/client/client.go
@@ -111,8 +111,8 @@ func (c *stripeClient) SetupWebhook(ctx context.Context, input SetupWebhookInput
 		URL:         lo.ToPtr(webhookURL),
 		Description: lo.ToPtr("OpenMeter Stripe Webhook, do not delete or modify manually"),
 		Metadata: map[string]string{
-			SetupIntentDataMetadataNamespace: input.AppID.Namespace,
-			SetupIntentDataMetadataAppID:     input.AppID.ID,
+			StripeMetadataNamespace: input.AppID.Namespace,
+			StripeMetadataAppID:     input.AppID.ID,
 		},
 		// We set the API version to a specific date to ensure that
 		// the webhook is compatible with the Stripe client's API version.

--- a/openmeter/app/stripe/client/customer.go
+++ b/openmeter/app/stripe/client/customer.go
@@ -66,8 +66,8 @@ func (c *stripeAppClient) CreateCustomer(ctx context.Context, input CreateStripe
 		Name:  input.Name,
 		Email: input.Email,
 		Metadata: map[string]string{
-			SetupIntentDataMetadataNamespace:  input.AppID.Namespace,
-			SetupIntentDataMetadataCustomerID: input.CustomerID.ID,
+			StripeMetadataNamespace:  input.AppID.Namespace,
+			StripeMetadataCustomerID: input.CustomerID.ID,
 		},
 	})
 	if err != nil {

--- a/openmeter/app/stripe/entity/app/invoice.go
+++ b/openmeter/app/stripe/entity/app/invoice.go
@@ -173,6 +173,8 @@ func (a App) createInvoice(ctx context.Context, invoice billing.Invoice) (*billi
 
 	// Create the invoice in Stripe
 	createInvoiceParams := stripeclient.CreateInvoiceInput{
+		AppID:                        a.GetID(),
+		CustomerID:                   customerID,
 		InvoiceID:                    invoice.ID,
 		AutomaticTaxEnabled:          invoice.Workflow.Config.Tax.Enabled,
 		CollectionMethod:             invoice.Workflow.Config.Payment.CollectionMethod,

--- a/openmeter/app/stripe/httpdriver/webhook.go
+++ b/openmeter/app/stripe/httpdriver/webhook.go
@@ -91,7 +91,7 @@ func (h *handler) AppStripeWebhook() AppStripeWebhookHandler {
 				}
 
 				// Validate the payment intent metadata
-				metadataAppId, hasMetadataAppId := paymentIntent.Metadata[stripeclient.SetupIntentDataMetadataAppID]
+				metadataAppId, hasMetadataAppId := paymentIntent.Metadata[stripeclient.StripeMetadataAppID]
 
 				// If the event has not app metadata it's not initiated by an OpenMeter app and we ignore it.
 				// This can be the case when someone manually creates a payment intent.
@@ -118,7 +118,7 @@ func (h *handler) AppStripeWebhook() AppStripeWebhookHandler {
 
 				// Validate the namespace
 				// At this point we know that the event is for this specific app so require the namespace.
-				metadataNamespace, hasMetadataNamespace := paymentIntent.Metadata[stripeclient.SetupIntentDataMetadataNamespace]
+				metadataNamespace, hasMetadataNamespace := paymentIntent.Metadata[stripeclient.StripeMetadataNamespace]
 				if !hasMetadataNamespace {
 					return AppStripeWebhookResponse{}, models.NewGenericValidationError(
 						fmt.Errorf("namespace metadata is required for app: %s in event: %s", request.AppID.ID, request.Event.ID),

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -484,6 +484,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 		// Mock the stripe client to return the created invoice.
 		s.StripeAppClient.
 			On("CreateInvoice", stripeclient.CreateInvoiceInput{
+				AppID:               app.GetID(),
+				CustomerID:          customerEntity.GetID(),
 				InvoiceID:           invoice.ID,
 				AutomaticTaxEnabled: true,
 				CollectionMethod:    billing.CollectionMethodChargeAutomatically,
@@ -1145,6 +1147,8 @@ func (s *StripeInvoiceTestSuite) TestEmptyInvoiceGenerationZeroUsage() {
 	// Assert the args of the create invoice call
 	// We have to do it after the call because the invoice ID is not known at the time of setting up the mock
 	stripeAppCreateInvoiceMock.Arguments.Assert(s.T(), stripeclient.CreateInvoiceInput{
+		AppID:               app.GetID(),
+		CustomerID:          customerEntity.GetID(),
 		InvoiceID:           invoice.ID,
 		AutomaticTaxEnabled: true,
 		CollectionMethod:    billing.CollectionMethodChargeAutomatically,


### PR DESCRIPTION
Add OM IDs as metadata to Stripe invoice to provide an easy way to lookup customer information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for including application and customer identifiers as metadata when creating Stripe invoices.

* **Bug Fixes**
  * Improved validation for invoice creation by reporting all detected input issues at once.

* **Chores**
  * Updated metadata key names for consistency and clarity across Stripe integration.
  * Enhanced tests to verify correct passing of application and customer identifiers during invoice creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->