### PR TITLE
fix(streaming): filter for customer without group by

### DIFF
--- a/openmeter/streaming/clickhouse/meter_query.go
+++ b/openmeter/streaming/clickhouse/meter_query.go
@@ -196,7 +196,7 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 
 	// Select customer_id column
 	// We map subjects to customer IDs if they are provided
-	if len(d.FilterCustomer) > 0 && slices.Contains(d.GroupBy, "customer_id") {
+	if slices.Contains(d.GroupBy, "customer_id") {
 		var caseBuilder bytes.Buffer
 		caseBuilder.WriteString("CASE ")
 

--- a/openmeter/streaming/clickhouse/meter_query.go
+++ b/openmeter/streaming/clickhouse/meter_query.go
@@ -196,7 +196,7 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 
 	// Select customer_id column
 	// We map subjects to customer IDs if they are provided
-	if len(d.FilterCustomer) > 0 {
+	if len(d.FilterCustomer) > 0 && slices.Contains(d.GroupBy, "customer_id") {
 		var caseBuilder bytes.Buffer
 		caseBuilder.WriteString("CASE ")
 


### PR DESCRIPTION
Do not select customer_id when there is no group by for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected customer grouping behavior to include customer ID when grouping by customer, even without explicit customer filters, improving accuracy of aggregated results.

* **Tests**
  * Added coverage for filtering by multiple customers without a group-by clause to ensure reliable query behavior and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->