### PR TITLE
chore: fix main integartion tests

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -44,7 +44,7 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
       tag: ${{ steps.meta.outputs.version }}
       ref: ${{ steps.image-ref.outputs.value }}
-      depot-image-url: "registry.depot.dev/${{ steps.build.outputs.project-id }}@${{ steps.build.outputs.image-id }}"
+      depot-image-url: "registry.depot.dev/${{ steps.build.outputs.project-id }}@${{ steps.build.outputs.imageid }}"
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -102,7 +102,8 @@ jobs:
         env:
           DEPOT_IMAGE_METADATA: ${{ steps.build.outputs.metadata }}
         run: |
-          echo "url=$(echo "$DEPOT_IMAGE_METADATA" | jq -r '."image.name"')" >> $GITHUB_OUTPUT
+          # the image.name is a list of strings, we want the first one
+          echo "url=$(echo "$DEPOT_IMAGE_METADATA" | jq -r '."image.name"' | cut -f1 -d, )" >> $GITHUB_OUTPUT
 
 
       - name: Retrieve pull token

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -44,7 +44,7 @@ jobs:
       digest: ${{ steps.build.outputs.digest }}
       tag: ${{ steps.meta.outputs.version }}
       ref: ${{ steps.image-ref.outputs.value }}
-      depot-image-url: ${{ steps.extract-dagger-image-url.outputs.url }}
+      depot-image-url: "registry.depot.dev/${{ steps.build.outputs.project-id }}@${{ steps.build.outputs.image-id }}"
 
     steps:
       - name: Checkout repository
@@ -96,15 +96,6 @@ jobs:
       - name: Set image ref
         id: image-ref
         run: echo "value=${{ steps.image-name.outputs.value }}@${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
-
-      - name: Extract dagger image URL
-        id: extract-dagger-image-url
-        env:
-          DEPOT_IMAGE_METADATA: ${{ steps.build.outputs.metadata }}
-        run: |
-          # the image.name is a list of strings, we want the first one
-          echo "url=$(echo "$DEPOT_IMAGE_METADATA" | jq -r '."image.name"' | cut -f1 -d, )" >> $GITHUB_OUTPUT
-
 
       - name: Retrieve pull token
         id: pull-token


### PR DESCRIPTION
let's force the image for test to be coming from the depot internal registries (from where we push the image in case of main runs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved artifact URL extraction in the CI workflow to correctly handle list-based image names, increasing reliability and consistency across runs.
  * Added clarifying comments in the workflow for future maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->