### PR TITLE
feat(chart): add billing worker to Helm chart and ship binary in main image

### DIFF
--- a/Dockerfile.billing-worker
+++ b/Dockerfile.billing-worker
@@ -34,32 +34,32 @@ RUN chmod +x entrypoint.sh
 # See https://github.com/confluentinc/confluent-kafka-go#librdkafka
 # See https://github.com/confluentinc/confluent-kafka-go#static-builds-on-linux
 # Build server binary (default)
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/go/cache \
-    xx-go build -ldflags "-linkmode external -extldflags \"-static\" -X main.version=${VERSION}" -tags musl -o /usr/local/bin/openmeter ./cmd/server
+# RUN --mount=type=cache,target=/go/pkg/mod \
+#     --mount=type=cache,target=/go/cache \
+#     xx-go build -ldflags "-linkmode external -extldflags \"-static\" -X main.version=${VERSION}" -tags musl -o /usr/local/bin/openmeter ./cmd/server
 
-RUN xx-verify /usr/local/bin/openmeter
+# RUN xx-verify /usr/local/bin/openmeter
 
 # Build sink-worker binary
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/go/cache \
-    xx-go build -ldflags "-linkmode external -extldflags \"-static\" -X main.version=${VERSION}" -tags musl -o /usr/local/bin/openmeter-sink-worker ./cmd/sink-worker
+# RUN --mount=type=cache,target=/go/pkg/mod \
+#     --mount=type=cache,target=/go/cache \
+#     xx-go build -ldflags "-linkmode external -extldflags \"-static\" -X main.version=${VERSION}" -tags musl -o /usr/local/bin/openmeter-sink-worker ./cmd/sink-worker
 
-RUN xx-verify /usr/local/bin/openmeter-sink-worker
+# RUN xx-verify /usr/local/bin/openmeter-sink-worker
 
-# Build balance-worker binary
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/go/cache \
-    xx-go build -ldflags "-linkmode external -extldflags \"-static\" -X main.version=${VERSION}" -tags musl -o /usr/local/bin/openmeter-balance-worker ./cmd/balance-worker
+# # Build balance-worker binary
+# RUN --mount=type=cache,target=/go/pkg/mod \
+#     --mount=type=cache,target=/go/cache \
+#     xx-go build -ldflags "-linkmode external -extldflags \"-static\" -X main.version=${VERSION}" -tags musl -o /usr/local/bin/openmeter-balance-worker ./cmd/balance-worker
 
-RUN xx-verify /usr/local/bin/openmeter-balance-worker
+# RUN xx-verify /usr/local/bin/openmeter-balance-worker
 
-# Build balance-worker binary
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/go/cache \
-    xx-go build -ldflags "-linkmode external -extldflags \"-static\" -X main.version=${VERSION}" -tags musl -o /usr/local/bin/openmeter-notification-service ./cmd/notification-service
+# # Build balance-worker binary
+# RUN --mount=type=cache,target=/go/pkg/mod \
+#     --mount=type=cache,target=/go/cache \
+#     xx-go build -ldflags "-linkmode external -extldflags \"-static\" -X main.version=${VERSION}" -tags musl -o /usr/local/bin/openmeter-notification-service ./cmd/notification-service
 
-RUN xx-verify /usr/local/bin/openmeter-notification-service
+# RUN xx-verify /usr/local/bin/openmeter-notification-service
 
 # Build billing-worker binary
 RUN --mount=type=cache,target=/go/pkg/mod \
@@ -74,10 +74,10 @@ RUN apk add --update --no-cache ca-certificates tzdata bash
 
 SHELL ["/bin/bash", "-c"]
 
-COPY --link --from=builder /usr/local/bin/openmeter /usr/local/bin/
-COPY --link --from=builder /usr/local/bin/openmeter-sink-worker /usr/local/bin/
-COPY --link --from=builder /usr/local/bin/openmeter-balance-worker /usr/local/bin/
-COPY --link --from=builder /usr/local/bin/openmeter-notification-service /usr/local/bin/
+# COPY --link --from=builder /usr/local/bin/openmeter /usr/local/bin/
+# COPY --link --from=builder /usr/local/bin/openmeter-sink-worker /usr/local/bin/
+# COPY --link --from=builder /usr/local/bin/openmeter-balance-worker /usr/local/bin/
+# COPY --link --from=builder /usr/local/bin/openmeter-notification-service /usr/local/bin/
 COPY --link --from=builder /usr/local/bin/openmeter-billing-worker /usr/local/bin/
 COPY --link --from=builder /src/go.* /usr/local/src/openmeter/
 COPY --link --from=builder /src/entrypoint.sh /entrypoint.sh

--- a/deploy/charts/openmeter/README.md
+++ b/deploy/charts/openmeter/README.md
@@ -98,6 +98,17 @@ config:
       debug: true
 ```
 
+To run billing advancement via billing worker, set the API to queued and scale the worker:
+
+```yaml
+config:
+  billing:
+    advancementStrategy: queued
+
+billingWorker:
+  replicaCount: 1
+```
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -162,6 +173,7 @@ config:
 | postgresql.primary.initdb.scripts."setup.sql" | string | `"CREATE USER application WITH PASSWORD 'application';\nCREATE DATABASE application;\nGRANT ALL PRIVILEGES ON DATABASE application TO application;\nALTER DATABASE application OWNER TO application;\nCREATE USER svix WITH PASSWORD 'svix';\nCREATE DATABASE svix;\nGRANT ALL PRIVILEGES ON DATABASE svix TO svix;\nALTER DATABASE svix OWNER TO svix;\n"` |  |
 | api.replicaCount | int | `1` | Number of API replicas (pods) to launch. |
 | balanceWorker.replicaCount | int | `1` | Number of Balance Worker replicas (pods) to launch. |
+| billingWorker.replicaCount | int | `0` | Number of Billing Worker replicas (pods) to launch. |
 | notificationService.replicaCount | int | `1` | Number of Notification Service replicas (pods) to launch. |
 | sinkWorker.replicaCount | int | `1` | Number of Sink Worker replicas (pods) to launch. |
 | caRootCertificates | object | `{}` | List of CA Root certificates to inject into pods at runtime. See [values.yaml](values.yaml) |

--- a/deploy/charts/openmeter/templates/deployment.yaml
+++ b/deploy/charts/openmeter/templates/deployment.yaml
@@ -368,3 +368,95 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openmeter.componentName" (list . "billing-worker") }}
+  labels:
+    {{- include "openmeter.componentLabels" (list . "billing-worker") | nindent 4 }}
+spec:
+  replicas: {{ .Values.billingWorker.replicaCount }}
+  selector:
+    matchLabels:
+    {{- include "openmeter.componentSelectorLabels" (list . "billing-worker") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "openmeter.componentLabels" (list . "billing-worker") | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "openmeter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{ if or .Values.postgresql.enabled .Values.clickhouse.enabled -}}
+      initContainers:
+        {{- if .Values.postgresql.enabled -}}
+        {{- include "openmeter.init.postgres" (list .) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.clickhouse.enabled -}}
+        {{- include "openmeter.init.clickhouse" (list .) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/entrypoint.sh", "openmeter-billing-worker"]
+          args: ["--telemetry-address", "0.0.0.0:10000", "--config", "/etc/openmeter/config.yaml"]
+          ports:
+            - name: telemetry-http
+              containerPort: 10000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz/live
+              port: telemetry-http
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: telemetry-http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/openmeter
+            {{- if ne (len .Values.caRootCertificates) 0 }}
+            - name: ca-certificates
+              mountPath: /usr/local/share/ca-certificates
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "openmeter.fullname" . }}
+        {{- if ne (len .Values.caRootCertificates) 0 }}
+        - name: ca-certificates
+          configMap:
+            name: ca-certificates
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/openmeter/templates/deployment.yaml
+++ b/deploy/charts/openmeter/templates/deployment.yaml
@@ -416,7 +416,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/entrypoint.sh", "openmeter-billing-worker"]
-          args: ["--telemetry-address", "0.0.0.0:10000", "--config", "/etc/openmeter/config.yaml"]
+          args: ["--telemetry-address", "0.0.0.0:10000", "--config", "/etc/openmeter/config.yaml", "--billing-advancement-strategy=foreground"]
           ports:
             - name: telemetry-http
               containerPort: 10000

--- a/deploy/charts/openmeter/value.billing-worker.yaml
+++ b/deploy/charts/openmeter/value.billing-worker.yaml
@@ -1,0 +1,269 @@
+# Default values for openmeter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # -- Name of the image repository to pull the container image from.
+  repository: ghcr.io/openmeterio/openmeter
+
+  # -- [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node.
+  pullPolicy: IfNotPresent
+
+  # -- Image tag override for the default value (chart appVersion).
+  tag: ""
+
+# -- Reference to one or more secrets to be used when [pulling images](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret) (from private registries).
+imagePullSecrets: []
+
+# -- A name in place of the chart name for `app:` labels.
+nameOverride: ""
+
+# -- A name to substitute for the full names of resources.
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Specifies whether a service account should be created.
+  create: true
+  # -- Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # -- Annotations to add to the service account.
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# -- Annotations to be added to pods.
+podAnnotations: {}
+
+# -- Labels to be added to pods.
+podLabels: {}
+
+# -- Pod [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context) for details.
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# -- Container [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container).
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1) for details.
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  # -- Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
+  type: ClusterIP
+
+  # -- Service port.
+  port: 80
+
+ingress:
+  # -- Enable [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/).
+  enabled: false
+
+  # -- Ingress [class name](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class).
+  className: ""
+
+  # -- Annotations to be added to the ingress.
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+
+  # -- Ingress host configuration.
+  # @default -- See [values.yaml](values.yaml).
+  hosts:
+    - paths:
+        - path: /
+          pathType: ImplementationSpecific
+
+  # -- Ingress TLS configuration.
+  # @default -- See [values.yaml](values.yaml).
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.
+# @default -- No requests or limits.
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# -- [Node selector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector) configuration.
+nodeSelector: {}
+
+# -- [Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for node taints.
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details.
+tolerations: []
+
+# -- [Affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) configuration.
+# See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling) for details.
+affinity: {}
+
+# -- OpenMeter configuration
+config: {}
+
+# -- Defines parameters for the InitContainers
+init:
+  busybox:
+    tag: "1.37.0"
+
+kafka:
+  # -- Specifies whether Kafka (using the [Bitnami Kafka](oci://registry-1.docker.io/bitnamicharts)) should be installed.
+  # **Not recommended for production environments.**
+  enabled: true
+
+  listeners:
+    client:
+      name: plain
+      containerPort: 9092
+      protocol: PLAINTEXT
+      sslClientAuth: ""
+    controller:
+      name: CONTROLLER
+      containerPort: 9093
+      protocol: SASL_PLAINTEXT
+      sslClientAuth: ""
+
+clickhouse:
+  # -- Specifies whether Clickhouse (using the [Clickhouse Operator](https://github.com/Altinity/clickhouse-operator)) should be installed.
+  # **Not recommended for production environments.**
+  enabled: true
+
+  operator:
+    # -- Specifies whether [Clickhouse Operator](https://github.com/Altinity/clickhouse-operator) should be installed.
+    # **Not recommended for production environments.**
+    install: true
+
+svix:
+  # **Not recommended for production environments.**
+  enabled: true
+
+  # -- Specifies the JWT secret SVIX uses for authentication.
+  # For details, [see](https://github.com/svix/svix-webhooks?tab=readme-ov-file#authentication).
+  # **It is recommended to change this before deployment.**
+  signingSecret: "CeRc6WK8KjzRXrKkd9YFnSWcNyqLSIY8JwiaCeRc6WK4UkM"
+
+  # -- Specifies the JWT OpenMeter uses to authenticate with Svix.
+  # This is an example Token intended for development purposes. You should create your own using the instructions in [svix documentation](https://github.com/svix/svix-webhooks?tab=readme-ov-file#authentication).
+  signedJwt: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdml4LXNlcnZlciIsImlhdCI6MTczMDk4NzU0MywiZXhwIjoyMjM1OTA5MDAwLCJhdWQiOiIiLCJzdWIiOiJvcmdfMjNyYjhZZEdxTVQwcUl6cGdHd2RYZkhpck11In0.J90SzVuNwecyCtWAQlOoWplJaK4rnIb3rCWXrHQPqJY"
+
+  # -- External database configuration for Svix
+  database:
+    # -- External PostgreSQL DSN for Svix. If not provided, uses internal PostgreSQL.
+    dsn: ""
+
+  # -- External Redis configuration for Svix
+  redis:
+    # -- External Redis DSN for Svix. If not provided, uses internal Redis.
+    dsn: ""
+
+  # -- Number of replicas (pods) to launch.
+  replicaCount: 1
+
+  image:
+    # -- Name of the image repository to pull the container image from.
+    repository: docker.io/svix/svix-server
+
+    # -- [Image pull policy](https://kubernetes.io/docs/concepts/containers/images/#updating-images) for updating already existing images on a node.
+    pullPolicy: IfNotPresent
+
+    # -- Image tag to use
+    tag: "v1.37"
+
+  service:
+    # -- Kubernetes [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types).
+    type: ClusterIP
+    # -- Service port.
+    port: 80
+
+  # -- Container resource [requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
+  # See the [API reference](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources) for details.
+  # @default -- No requests or limits.
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+redis:
+  # -- Specifies whether Redis (using the [Bitnami Redis](oci://registry-1.docker.io/bitnamicharts/redis) chart) should be installed.
+  # **Not recommended for production environments.**
+  # All further values can be configured in the `redis` section.
+  enabled: true
+
+  auth:
+    enabled: false
+
+  nameOverride: redis
+
+postgresql:
+  # -- Specifies whether Postgres (using the [Bitnami Chart](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) should be installed.
+  # **Not recommended for production environments.**
+  # All further values can be configured in the `postgres` section.
+  enabled: true
+
+  nameOverride: postgres
+
+  primary:
+    initdb:
+      scripts:
+        setup.sql: |
+          CREATE USER application WITH PASSWORD 'application';
+          CREATE DATABASE application;
+          GRANT ALL PRIVILEGES ON DATABASE application TO application;
+          ALTER DATABASE application OWNER TO application;
+          CREATE USER svix WITH PASSWORD 'svix';
+          CREATE DATABASE svix;
+          GRANT ALL PRIVILEGES ON DATABASE svix TO svix;
+          ALTER DATABASE svix OWNER TO svix;
+
+api:
+  # -- Number of API replicas (pods) to launch.
+  replicaCount: 1
+
+balanceWorker:
+  # -- Number of Balance Worker replicas (pods) to launch.
+  replicaCount: 1
+
+notificationService:
+  # -- Number of Notification Service replicas (pods) to launch.
+  replicaCount: 1
+
+sinkWorker:
+  # -- Number of Sink Worker replicas (pods) to launch.
+  replicaCount: 1
+
+billingWorker:
+  # -- Number of Billing Worker replicas (pods) to launch.
+  replicaCount: 1
+  image:
+    repository: openmeter-billing-worker
+    tag: local
+    pullPolicy: IfNotPresent
+
+# -- List of CA Root certificates to inject into pods at runtime.
+# See [values.yaml](values.yaml)
+caRootCertificates: {}
+#  ca: |
+#    -----BEGIN CERTIFICATE-----
+#    ...
+#    -----END CERTIFICATE-----

--- a/deploy/charts/openmeter/values.example.yaml
+++ b/deploy/charts/openmeter/values.example.yaml
@@ -5,6 +5,8 @@ config:
     enabled: true
   entitlements:
     enabled: true
+  billing:
+    advancementStrategy: queued
   meters:
     # Sample meter to count API requests
     - slug: api_requests_total # Unique identifier for the meter
@@ -24,3 +26,6 @@ config:
       groupBy:
         model: $.model # AI model used: gpt4-turbo, etc.
         type: $.type # Prompt type: input, output, system
+
+billingWorker:
+  replicaCount: 1

--- a/deploy/charts/openmeter/values.yaml
+++ b/deploy/charts/openmeter/values.yaml
@@ -252,6 +252,10 @@ sinkWorker:
   # -- Number of Sink Worker replicas (pods) to launch.
   replicaCount: 1
 
+billingWorker:
+  # -- Number of Billing Worker replicas (pods) to launch.
+  replicaCount: 0
+
 # -- List of CA Root certificates to inject into pods at runtime.
 # See [values.yaml](values.yaml)
 caRootCertificates: {}


### PR DESCRIPTION
## Overview
Enable deploying the billing worker via Helm. Previously, the chart didn’t include this component and the image didn’t ship its binary.

### Changes
- Dockerfile: build and include openmeter-billing-worker in the main image.
- Helm chart:
  - Add billing-worker Deployment (runs openmeter-billing-worker with --billing-advancement-strategy=foreground).
  - Add billingWorker.replicaCount to values.yaml (default 0).
  - Update values.example.yaml to demonstrate:
    - config.billing.advancementStrategy: queued
    - billingWorker.replicaCount: 1
  - Update chart README with a concise note on enabling queued advancement and scaling the worker.

### How to enable
Values (recommended)
```
    config:
      billing:
        advancementStrategy: queued

    billingWorker:
      replicaCount: 1
```
### Behavior
- Backwards compatible: worker disabled by default (replicaCount: 0).
- API reads config.billing.advancementStrategy from values (set to queued to enqueue work).
- Worker enforces foreground via CLI arg to process messages (and avoid re-enqueue loops).
- CLI flag overrides file config.


## Notes for reviewer

### Scope to review
- Dockerfile: new openmeter-billing-worker build/copy steps.
- Helm: billing-worker Deployment block; uses shared .Values.image.*, adds --billing-advancement-strategy=foreground.
- Values: billingWorker.replicaCount (default 0).
- Docs: brief enablement note in chart README; example in values.example.yaml.
