### PR TITLE
fix: adds a config option to enable TLS/SSL without needing certs loc…

### DIFF
--- a/app/config/ingest.go
+++ b/app/config/ingest.go
@@ -61,6 +61,7 @@ func (c KafkaIngestConfiguration) Validate() error {
 type KafkaConfiguration struct {
 	Broker           string
 	SecurityProtocol string
+	TLSInsecure      bool
 	SaslMechanisms   string
 	SaslUsername     string
 	SaslPassword     string

--- a/openmeter/watermill/driver/kafka/broker.go
+++ b/openmeter/watermill/driver/kafka/broker.go
@@ -72,6 +72,10 @@ func (o *BrokerOptions) createKafkaConfig(role string) (*sarama.Config, error) {
 		loggerFunc: logger.Debug,
 	}
 
+	if o.KafkaConfig.SecurityProtocol == "SSL" && o.KafkaConfig.TLSInsecure {
+		config.Net.TLS.Enable = true
+	}
+
 	if o.KafkaConfig.SecurityProtocol == "SASL_SSL" {
 		config.Net.SASL.Enable = true
 		config.Net.SASL.Handshake = true


### PR DESCRIPTION
…ally (insecure)

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an option to allow insecure TLS for Kafka SSL connections (e.g., self-signed certificates). This enables TLS without SASL when explicitly opted in.
  - Expands connectivity to Kafka deployments using SSL with untrusted/temporary certificates while keeping current defaults.
  - Existing behavior remains unchanged unless the option is enabled; SASL_SSL handling is unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->