### PR TITLE
feat: subscription sync allow disabling continuous line logic

### DIFF
--- a/openmeter/billing/annotations.go
+++ b/openmeter/billing/annotations.go
@@ -2,7 +2,7 @@ package billing
 
 const (
 	// AnnotationSubscriptionSyncIgnore is used to mark a line or hierarchy as ignored in subscription syncing.
-	// Should be used in case there is a breaking change in the subscription syncronization process, preventing billing
+	// Should be used in case there is a breaking change in the subscription synchronization process, preventing billing
 	// from issuing credit notes for the past periods.
 	AnnotationSubscriptionSyncIgnore = "billing.subscription.sync.ignore"
 
@@ -10,5 +10,5 @@ const (
 	// If the sync process finds a previously existing line with this annotation, and the next line generated will not start at the end of the previously
 	// found line, the sync process will adjust the start of the next line to the end of the previously found line, so that we don't have gaps in the
 	// invoices.
-	AnnotationSubscriptionSyncForceContinuousLines = "billing.subscription.sync.force-continous-lines"
+	AnnotationSubscriptionSyncForceContinuousLines = "billing.subscription.sync.force-continuous-lines"
 )

--- a/openmeter/billing/annotations.go
+++ b/openmeter/billing/annotations.go
@@ -1,5 +1,14 @@
 package billing
 
 const (
+	// AnnotationSubscriptionSyncIgnore is used to mark a line or hierarchy as ignored in subscription syncing.
+	// Should be used in case there is a breaking change in the subscription syncronization process, preventing billing
+	// from issuing credit notes for the past periods.
 	AnnotationSubscriptionSyncIgnore = "billing.subscription.sync.ignore"
+
+	// AnnotationSubscriptionSyncForceContinuousLines is used to force the creation of continuous subscription item lines.
+	// If the sync process finds a previously existing line with this annotation, and the next line generated will not start at the end of the previously
+	// found line, the sync process will adjust the start of the next line to the end of the previously found line, so that we don't have gaps in the
+	// invoices.
+	AnnotationSubscriptionSyncForceContinuousLines = "billing.subscription.sync.force-continous-lines"
 )

--- a/openmeter/billing/worker/subscription/patch.go
+++ b/openmeter/billing/worker/subscription/patch.go
@@ -148,7 +148,7 @@ func (h *Handler) getDeletePatchesForLine(lineOrHierarchy billing.LineOrHierarch
 		}
 
 		// Ignored lines do not take part in syncing so we skip them
-		if ignore, ok := line.Annotations[billing.AnnotationSubscriptionSyncIgnore]; ok && ignore == true {
+		if line.Annotations.GetBool(billing.AnnotationSubscriptionSyncIgnore) {
 			return nil, nil
 		}
 

--- a/openmeter/billing/worker/subscription/sync_test.go
+++ b/openmeter/billing/worker/subscription/sync_test.go
@@ -3499,7 +3499,8 @@ func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLines() {
 			line := s.getLineByChildID(*invoice, draftLineReferenceID)
 
 			line.Annotations = models.Annotations{
-				billing.AnnotationSubscriptionSyncIgnore: true,
+				billing.AnnotationSubscriptionSyncIgnore:               true,
+				billing.AnnotationSubscriptionSyncForceContinuousLines: true,
 			}
 
 			return nil
@@ -3515,7 +3516,8 @@ func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLines() {
 			line := s.getLineByChildID(*invoice, gatheringLineReferenceID)
 
 			line.Annotations = models.Annotations{
-				billing.AnnotationSubscriptionSyncIgnore: true,
+				billing.AnnotationSubscriptionSyncIgnore:               true,
+				billing.AnnotationSubscriptionSyncForceContinuousLines: true,
 			}
 
 			gatheringInvoiceIgnoredLine = line.Clone()
@@ -3558,7 +3560,8 @@ func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLines() {
 	expectedInvoice.Lines = expectedInvoice.Lines.Map(func(line *billing.Line) *billing.Line {
 		if line.ChildUniqueReferenceID != nil && *line.ChildUniqueReferenceID == draftLineReferenceID {
 			line.Annotations = models.Annotations{
-				billing.AnnotationSubscriptionSyncIgnore: true,
+				billing.AnnotationSubscriptionSyncIgnore:               true,
+				billing.AnnotationSubscriptionSyncForceContinuousLines: true,
 			}
 		}
 
@@ -3673,7 +3676,8 @@ func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLinesWhenPeriod
 			line := s.getLineByChildID(*invoice, markedLineReferenceID)
 
 			line.Annotations = models.Annotations{
-				billing.AnnotationSubscriptionSyncIgnore: true,
+				billing.AnnotationSubscriptionSyncIgnore:               true,
+				billing.AnnotationSubscriptionSyncForceContinuousLines: true,
 			}
 
 			return nil
@@ -4514,7 +4518,8 @@ func (s *SubscriptionHandlerTestSuite) TestSyncronizeSubscriptionPeriodAlgorithm
 			line.Period.Start = s.mustParseTime("2025-01-31T00:00:00Z")
 			line.Period.End = s.mustParseTime("2025-03-02T00:00:00Z")
 			line.Annotations = models.Annotations{
-				billing.AnnotationSubscriptionSyncIgnore: true,
+				billing.AnnotationSubscriptionSyncIgnore:               true,
+				billing.AnnotationSubscriptionSyncForceContinuousLines: true,
 			}
 
 			invoice.Lines = billing.NewLineChildren([]*billing.Line{

--- a/openmeter/customer/adapter/entitymapping.go
+++ b/openmeter/customer/adapter/entitymapping.go
@@ -29,7 +29,7 @@ func CustomerFromDBEntity(e db.Customer) (*customer.Customer, error) {
 	var annotations *models.Annotations
 
 	if len(e.Annotations) > 0 {
-		annotations = lo.ToPtr((models.Annotations)(e.Annotations))
+		annotations = &e.Annotations
 	}
 
 	result := &customer.Customer{

--- a/openmeter/customer/adapter/entitymapping.go
+++ b/openmeter/customer/adapter/entitymapping.go
@@ -29,7 +29,7 @@ func CustomerFromDBEntity(e db.Customer) (*customer.Customer, error) {
 	var annotations *models.Annotations
 
 	if len(e.Annotations) > 0 {
-		annotations = lo.ToPtr(e.Annotations)
+		annotations = lo.ToPtr((models.Annotations)(e.Annotations))
 	}
 
 	result := &customer.Customer{

--- a/openmeter/ent/db/addon.go
+++ b/openmeter/ent/db/addon.go
@@ -12,6 +12,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/addon"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // Addon is the model entity for the Addon schema.
@@ -46,7 +47,7 @@ type Addon struct {
 	// EffectiveTo holds the value of the "effective_to" field.
 	EffectiveTo *time.Time `json:"effective_to,omitempty"`
 	// Annotations holds the value of the "annotations" field.
-	Annotations map[string]interface{} `json:"annotations,omitempty"`
+	Annotations models.Annotations `json:"annotations,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the AddonQuery when eager-loading is set.
 	Edges        AddonEdges `json:"edges"`

--- a/openmeter/ent/db/addon/addon.go
+++ b/openmeter/ent/db/addon/addon.go
@@ -10,6 +10,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 const (
@@ -126,7 +127,7 @@ var (
 	DefaultID func() string
 	// ValueScanner of all Addon fields.
 	ValueScanner struct {
-		Annotations field.TypeValueScanner[map[string]interface{}]
+		Annotations field.TypeValueScanner[models.Annotations]
 	}
 )
 

--- a/openmeter/ent/db/addon_create.go
+++ b/openmeter/ent/db/addon_create.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/planaddon"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionaddon"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // AddonCreate is the builder for creating a Addon entity.
@@ -170,7 +171,7 @@ func (_c *AddonCreate) SetNillableEffectiveTo(v *time.Time) *AddonCreate {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_c *AddonCreate) SetAnnotations(v map[string]interface{}) *AddonCreate {
+func (_c *AddonCreate) SetAnnotations(v models.Annotations) *AddonCreate {
 	_c.mutation.SetAnnotations(v)
 	return _c
 }
@@ -686,7 +687,7 @@ func (u *AddonUpsert) ClearEffectiveTo() *AddonUpsert {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *AddonUpsert) SetAnnotations(v map[string]interface{}) *AddonUpsert {
+func (u *AddonUpsert) SetAnnotations(v models.Annotations) *AddonUpsert {
 	u.Set(addon.FieldAnnotations, v)
 	return u
 }
@@ -932,7 +933,7 @@ func (u *AddonUpsertOne) ClearEffectiveTo() *AddonUpsertOne {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *AddonUpsertOne) SetAnnotations(v map[string]interface{}) *AddonUpsertOne {
+func (u *AddonUpsertOne) SetAnnotations(v models.Annotations) *AddonUpsertOne {
 	return u.Update(func(s *AddonUpsert) {
 		s.SetAnnotations(v)
 	})
@@ -1351,7 +1352,7 @@ func (u *AddonUpsertBulk) ClearEffectiveTo() *AddonUpsertBulk {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *AddonUpsertBulk) SetAnnotations(v map[string]interface{}) *AddonUpsertBulk {
+func (u *AddonUpsertBulk) SetAnnotations(v models.Annotations) *AddonUpsertBulk {
 	return u.Update(func(s *AddonUpsert) {
 		s.SetAnnotations(v)
 	})

--- a/openmeter/ent/db/addon_update.go
+++ b/openmeter/ent/db/addon_update.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionaddon"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // AddonUpdate is the builder for updating Addon entities.
@@ -180,7 +181,7 @@ func (_u *AddonUpdate) ClearEffectiveTo() *AddonUpdate {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *AddonUpdate) SetAnnotations(v map[string]interface{}) *AddonUpdate {
+func (_u *AddonUpdate) SetAnnotations(v models.Annotations) *AddonUpdate {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }
@@ -725,7 +726,7 @@ func (_u *AddonUpdateOne) ClearEffectiveTo() *AddonUpdateOne {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *AddonUpdateOne) SetAnnotations(v map[string]interface{}) *AddonUpdateOne {
+func (_u *AddonUpdateOne) SetAnnotations(v models.Annotations) *AddonUpdateOne {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }

--- a/openmeter/ent/db/billinginvoiceline.go
+++ b/openmeter/ent/db/billinginvoiceline.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionphase"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // BillingInvoiceLine is the model entity for the BillingInvoiceLine schema.
@@ -30,7 +31,7 @@ type BillingInvoiceLine struct {
 	// ID of the ent.
 	ID string `json:"id,omitempty"`
 	// Annotations holds the value of the "annotations" field.
-	Annotations map[string]interface{} `json:"annotations,omitempty"`
+	Annotations models.Annotations `json:"annotations,omitempty"`
 	// Namespace holds the value of the "namespace" field.
 	Namespace string `json:"namespace,omitempty"`
 	// Metadata holds the value of the "metadata" field.

--- a/openmeter/ent/db/billinginvoiceline_create.go
+++ b/openmeter/ent/db/billinginvoiceline_create.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionphase"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // BillingInvoiceLineCreate is the builder for creating a BillingInvoiceLine entity.
@@ -37,7 +38,7 @@ type BillingInvoiceLineCreate struct {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_c *BillingInvoiceLineCreate) SetAnnotations(v map[string]interface{}) *BillingInvoiceLineCreate {
+func (_c *BillingInvoiceLineCreate) SetAnnotations(v models.Annotations) *BillingInvoiceLineCreate {
 	_c.mutation.SetAnnotations(v)
 	return _c
 }
@@ -1018,7 +1019,7 @@ type (
 )
 
 // SetAnnotations sets the "annotations" field.
-func (u *BillingInvoiceLineUpsert) SetAnnotations(v map[string]interface{}) *BillingInvoiceLineUpsert {
+func (u *BillingInvoiceLineUpsert) SetAnnotations(v models.Annotations) *BillingInvoiceLineUpsert {
 	u.Set(billinginvoiceline.FieldAnnotations, v)
 	return u
 }
@@ -1528,7 +1529,7 @@ func (u *BillingInvoiceLineUpsertOne) Update(set func(*BillingInvoiceLineUpsert)
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *BillingInvoiceLineUpsertOne) SetAnnotations(v map[string]interface{}) *BillingInvoiceLineUpsertOne {
+func (u *BillingInvoiceLineUpsertOne) SetAnnotations(v models.Annotations) *BillingInvoiceLineUpsertOne {
 	return u.Update(func(s *BillingInvoiceLineUpsert) {
 		s.SetAnnotations(v)
 	})
@@ -2283,7 +2284,7 @@ func (u *BillingInvoiceLineUpsertBulk) Update(set func(*BillingInvoiceLineUpsert
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *BillingInvoiceLineUpsertBulk) SetAnnotations(v map[string]interface{}) *BillingInvoiceLineUpsertBulk {
+func (u *BillingInvoiceLineUpsertBulk) SetAnnotations(v models.Annotations) *BillingInvoiceLineUpsertBulk {
 	return u.Update(func(s *BillingInvoiceLineUpsert) {
 		s.SetAnnotations(v)
 	})

--- a/openmeter/ent/db/billinginvoiceline_query.go
+++ b/openmeter/ent/db/billinginvoiceline_query.go
@@ -660,7 +660,7 @@ func (_q *BillingInvoiceLineQuery) WithSubscriptionItem(opts ...func(*Subscripti
 // Example:
 //
 //	var v []struct {
-//		Annotations map[string]interface {} `json:"annotations,omitempty"`
+//		Annotations models.Annotations `json:"annotations,omitempty"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
@@ -683,7 +683,7 @@ func (_q *BillingInvoiceLineQuery) GroupBy(field string, fields ...string) *Bill
 // Example:
 //
 //	var v []struct {
-//		Annotations map[string]interface {} `json:"annotations,omitempty"`
+//		Annotations models.Annotations `json:"annotations,omitempty"`
 //	}
 //
 //	client.BillingInvoiceLine.Query().

--- a/openmeter/ent/db/billinginvoiceline_update.go
+++ b/openmeter/ent/db/billinginvoiceline_update.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionitem"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionphase"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // BillingInvoiceLineUpdate is the builder for updating BillingInvoiceLine entities.
@@ -41,7 +42,7 @@ func (_u *BillingInvoiceLineUpdate) Where(ps ...predicate.BillingInvoiceLine) *B
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *BillingInvoiceLineUpdate) SetAnnotations(v map[string]interface{}) *BillingInvoiceLineUpdate {
+func (_u *BillingInvoiceLineUpdate) SetAnnotations(v models.Annotations) *BillingInvoiceLineUpdate {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }
@@ -1318,7 +1319,7 @@ type BillingInvoiceLineUpdateOne struct {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *BillingInvoiceLineUpdateOne) SetAnnotations(v map[string]interface{}) *BillingInvoiceLineUpdateOne {
+func (_u *BillingInvoiceLineUpdateOne) SetAnnotations(v models.Annotations) *BillingInvoiceLineUpdateOne {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }

--- a/openmeter/ent/db/customer.go
+++ b/openmeter/ent/db/customer.go
@@ -50,7 +50,7 @@ type Customer struct {
 	// BillingAddressPhoneNumber holds the value of the "billing_address_phone_number" field.
 	BillingAddressPhoneNumber *string `json:"billing_address_phone_number,omitempty"`
 	// Annotations holds the value of the "annotations" field.
-	Annotations map[string]interface{} `json:"annotations,omitempty"`
+	Annotations models.Annotations `json:"annotations,omitempty"`
 	// Key holds the value of the "key" field.
 	Key string `json:"key,omitempty"`
 	// PrimaryEmail holds the value of the "primary_email" field.

--- a/openmeter/ent/db/customer_create.go
+++ b/openmeter/ent/db/customer_create.go
@@ -203,7 +203,7 @@ func (_c *CustomerCreate) SetNillableBillingAddressPhoneNumber(v *string) *Custo
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_c *CustomerCreate) SetAnnotations(v map[string]interface{}) *CustomerCreate {
+func (_c *CustomerCreate) SetAnnotations(v models.Annotations) *CustomerCreate {
 	_c.mutation.SetAnnotations(v)
 	return _c
 }
@@ -866,7 +866,7 @@ func (u *CustomerUpsert) ClearBillingAddressPhoneNumber() *CustomerUpsert {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *CustomerUpsert) SetAnnotations(v map[string]interface{}) *CustomerUpsert {
+func (u *CustomerUpsert) SetAnnotations(v models.Annotations) *CustomerUpsert {
 	u.Set(customer.FieldAnnotations, v)
 	return u
 }
@@ -1230,7 +1230,7 @@ func (u *CustomerUpsertOne) ClearBillingAddressPhoneNumber() *CustomerUpsertOne 
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *CustomerUpsertOne) SetAnnotations(v map[string]interface{}) *CustomerUpsertOne {
+func (u *CustomerUpsertOne) SetAnnotations(v models.Annotations) *CustomerUpsertOne {
 	return u.Update(func(s *CustomerUpsert) {
 		s.SetAnnotations(v)
 	})
@@ -1773,7 +1773,7 @@ func (u *CustomerUpsertBulk) ClearBillingAddressPhoneNumber() *CustomerUpsertBul
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *CustomerUpsertBulk) SetAnnotations(v map[string]interface{}) *CustomerUpsertBulk {
+func (u *CustomerUpsertBulk) SetAnnotations(v models.Annotations) *CustomerUpsertBulk {
 	return u.Update(func(s *CustomerUpsert) {
 		s.SetAnnotations(v)
 	})

--- a/openmeter/ent/db/customer_update.go
+++ b/openmeter/ent/db/customer_update.go
@@ -248,7 +248,7 @@ func (_u *CustomerUpdate) ClearBillingAddressPhoneNumber() *CustomerUpdate {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *CustomerUpdate) SetAnnotations(v map[string]interface{}) *CustomerUpdate {
+func (_u *CustomerUpdate) SetAnnotations(v models.Annotations) *CustomerUpdate {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }
@@ -1088,7 +1088,7 @@ func (_u *CustomerUpdateOne) ClearBillingAddressPhoneNumber() *CustomerUpdateOne
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *CustomerUpdateOne) SetAnnotations(v map[string]interface{}) *CustomerUpdateOne {
+func (_u *CustomerUpdateOne) SetAnnotations(v models.Annotations) *CustomerUpdateOne {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }

--- a/openmeter/ent/db/entitlement.go
+++ b/openmeter/ent/db/entitlement.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/entitlement"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/feature"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // Entitlement is the model entity for the Entitlement schema.
@@ -63,7 +64,7 @@ type Entitlement struct {
 	// CurrentUsagePeriodEnd holds the value of the "current_usage_period_end" field.
 	CurrentUsagePeriodEnd *time.Time `json:"current_usage_period_end,omitempty"`
 	// Annotations holds the value of the "annotations" field.
-	Annotations map[string]interface{} `json:"annotations,omitempty"`
+	Annotations models.Annotations `json:"annotations,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the EntitlementQuery when eager-loading is set.
 	Edges        EntitlementEdges `json:"edges"`

--- a/openmeter/ent/db/entitlement/entitlement.go
+++ b/openmeter/ent/db/entitlement/entitlement.go
@@ -9,6 +9,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 const (
@@ -163,7 +164,7 @@ var (
 	DefaultID func() string
 	// ValueScanner of all Entitlement fields.
 	ValueScanner struct {
-		Annotations field.TypeValueScanner[map[string]interface{}]
+		Annotations field.TypeValueScanner[models.Annotations]
 	}
 )
 

--- a/openmeter/ent/db/entitlement_create.go
+++ b/openmeter/ent/db/entitlement_create.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionitem"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/usagereset"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // EntitlementCreate is the builder for creating a Entitlement entity.
@@ -268,7 +269,7 @@ func (_c *EntitlementCreate) SetNillableCurrentUsagePeriodEnd(v *time.Time) *Ent
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_c *EntitlementCreate) SetAnnotations(v map[string]interface{}) *EntitlementCreate {
+func (_c *EntitlementCreate) SetAnnotations(v models.Annotations) *EntitlementCreate {
 	_c.mutation.SetAnnotations(v)
 	return _c
 }
@@ -846,7 +847,7 @@ func (u *EntitlementUpsert) ClearCurrentUsagePeriodEnd() *EntitlementUpsert {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *EntitlementUpsert) SetAnnotations(v map[string]interface{}) *EntitlementUpsert {
+func (u *EntitlementUpsert) SetAnnotations(v models.Annotations) *EntitlementUpsert {
 	u.Set(entitlement.FieldAnnotations, v)
 	return u
 }
@@ -1112,7 +1113,7 @@ func (u *EntitlementUpsertOne) ClearCurrentUsagePeriodEnd() *EntitlementUpsertOn
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *EntitlementUpsertOne) SetAnnotations(v map[string]interface{}) *EntitlementUpsertOne {
+func (u *EntitlementUpsertOne) SetAnnotations(v models.Annotations) *EntitlementUpsertOne {
 	return u.Update(func(s *EntitlementUpsert) {
 		s.SetAnnotations(v)
 	})
@@ -1551,7 +1552,7 @@ func (u *EntitlementUpsertBulk) ClearCurrentUsagePeriodEnd() *EntitlementUpsertB
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *EntitlementUpsertBulk) SetAnnotations(v map[string]interface{}) *EntitlementUpsertBulk {
+func (u *EntitlementUpsertBulk) SetAnnotations(v models.Annotations) *EntitlementUpsertBulk {
 	return u.Update(func(s *EntitlementUpsert) {
 		s.SetAnnotations(v)
 	})

--- a/openmeter/ent/db/entitlement_update.go
+++ b/openmeter/ent/db/entitlement_update.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionitem"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/usagereset"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // EntitlementUpdate is the builder for updating Entitlement entities.
@@ -170,7 +171,7 @@ func (_u *EntitlementUpdate) ClearCurrentUsagePeriodEnd() *EntitlementUpdate {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *EntitlementUpdate) SetAnnotations(v map[string]interface{}) *EntitlementUpdate {
+func (_u *EntitlementUpdate) SetAnnotations(v models.Annotations) *EntitlementUpdate {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }
@@ -804,7 +805,7 @@ func (_u *EntitlementUpdateOne) ClearCurrentUsagePeriodEnd() *EntitlementUpdateO
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *EntitlementUpdateOne) SetAnnotations(v map[string]interface{}) *EntitlementUpdateOne {
+func (_u *EntitlementUpdateOne) SetAnnotations(v models.Annotations) *EntitlementUpdateOne {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -142,7 +142,7 @@ type AddonMutation struct {
 	instance_type              *productcatalog.AddonInstanceType
 	effective_from             *time.Time
 	effective_to               *time.Time
-	annotations                *map[string]interface{}
+	annotations                *models.Annotations
 	clearedFields              map[string]struct{}
 	ratecards                  map[string]struct{}
 	removedratecards           map[string]struct{}
@@ -816,12 +816,12 @@ func (m *AddonMutation) ResetEffectiveTo() {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (m *AddonMutation) SetAnnotations(value map[string]interface{}) {
+func (m *AddonMutation) SetAnnotations(value models.Annotations) {
 	m.annotations = &value
 }
 
 // Annotations returns the value of the "annotations" field in the mutation.
-func (m *AddonMutation) Annotations() (r map[string]interface{}, exists bool) {
+func (m *AddonMutation) Annotations() (r models.Annotations, exists bool) {
 	v := m.annotations
 	if v == nil {
 		return
@@ -832,7 +832,7 @@ func (m *AddonMutation) Annotations() (r map[string]interface{}, exists bool) {
 // OldAnnotations returns the old "annotations" field's value of the Addon entity.
 // If the Addon object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *AddonMutation) OldAnnotations(ctx context.Context) (v map[string]interface{}, err error) {
+func (m *AddonMutation) OldAnnotations(ctx context.Context) (v models.Annotations, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldAnnotations is only allowed on UpdateOne operations")
 	}
@@ -1277,7 +1277,7 @@ func (m *AddonMutation) SetField(name string, value ent.Value) error {
 		m.SetEffectiveTo(v)
 		return nil
 	case addon.FieldAnnotations:
-		v, ok := value.(map[string]interface{})
+		v, ok := value.(models.Annotations)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -16285,7 +16285,7 @@ type BillingInvoiceLineMutation struct {
 	op                           Op
 	typ                          string
 	id                           *string
-	annotations                  *map[string]interface{}
+	annotations                  *models.Annotations
 	namespace                    *string
 	metadata                     *map[string]string
 	created_at                   *time.Time
@@ -16449,12 +16449,12 @@ func (m *BillingInvoiceLineMutation) IDs(ctx context.Context) ([]string, error) 
 }
 
 // SetAnnotations sets the "annotations" field.
-func (m *BillingInvoiceLineMutation) SetAnnotations(value map[string]interface{}) {
+func (m *BillingInvoiceLineMutation) SetAnnotations(value models.Annotations) {
 	m.annotations = &value
 }
 
 // Annotations returns the value of the "annotations" field in the mutation.
-func (m *BillingInvoiceLineMutation) Annotations() (r map[string]interface{}, exists bool) {
+func (m *BillingInvoiceLineMutation) Annotations() (r models.Annotations, exists bool) {
 	v := m.annotations
 	if v == nil {
 		return
@@ -16465,7 +16465,7 @@ func (m *BillingInvoiceLineMutation) Annotations() (r map[string]interface{}, ex
 // OldAnnotations returns the old "annotations" field's value of the BillingInvoiceLine entity.
 // If the BillingInvoiceLine object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *BillingInvoiceLineMutation) OldAnnotations(ctx context.Context) (v map[string]interface{}, err error) {
+func (m *BillingInvoiceLineMutation) OldAnnotations(ctx context.Context) (v models.Annotations, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldAnnotations is only allowed on UpdateOne operations")
 	}
@@ -18582,7 +18582,7 @@ func (m *BillingInvoiceLineMutation) OldField(ctx context.Context, name string) 
 func (m *BillingInvoiceLineMutation) SetField(name string, value ent.Value) error {
 	switch name {
 	case billinginvoiceline.FieldAnnotations:
-		v, ok := value.(map[string]interface{})
+		v, ok := value.(models.Annotations)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -28833,7 +28833,7 @@ type CustomerMutation struct {
 	billing_address_line1            *string
 	billing_address_line2            *string
 	billing_address_phone_number     *string
-	annotations                      *map[string]interface{}
+	annotations                      *models.Annotations
 	key                              *string
 	primary_email                    *string
 	currency                         *currencyx.Code
@@ -29596,12 +29596,12 @@ func (m *CustomerMutation) ResetBillingAddressPhoneNumber() {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (m *CustomerMutation) SetAnnotations(value map[string]interface{}) {
+func (m *CustomerMutation) SetAnnotations(value models.Annotations) {
 	m.annotations = &value
 }
 
 // Annotations returns the value of the "annotations" field in the mutation.
-func (m *CustomerMutation) Annotations() (r map[string]interface{}, exists bool) {
+func (m *CustomerMutation) Annotations() (r models.Annotations, exists bool) {
 	v := m.annotations
 	if v == nil {
 		return
@@ -29612,7 +29612,7 @@ func (m *CustomerMutation) Annotations() (r map[string]interface{}, exists bool)
 // OldAnnotations returns the old "annotations" field's value of the Customer entity.
 // If the Customer object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *CustomerMutation) OldAnnotations(ctx context.Context) (v map[string]interface{}, err error) {
+func (m *CustomerMutation) OldAnnotations(ctx context.Context) (v models.Annotations, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldAnnotations is only allowed on UpdateOne operations")
 	}
@@ -30332,7 +30332,7 @@ func (m *CustomerMutation) SetField(name string, value ent.Value) error {
 		m.SetBillingAddressPhoneNumber(v)
 		return nil
 	case customer.FieldAnnotations:
-		v, ok := value.(map[string]interface{})
+		v, ok := value.(models.Annotations)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -31380,7 +31380,7 @@ type EntitlementMutation struct {
 	usage_period_anchor           *time.Time
 	current_usage_period_start    *time.Time
 	current_usage_period_end      *time.Time
-	annotations                   *map[string]interface{}
+	annotations                   *models.Annotations
 	clearedFields                 map[string]struct{}
 	usage_reset                   map[string]struct{}
 	removedusage_reset            map[string]struct{}
@@ -32502,12 +32502,12 @@ func (m *EntitlementMutation) ResetCurrentUsagePeriodEnd() {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (m *EntitlementMutation) SetAnnotations(value map[string]interface{}) {
+func (m *EntitlementMutation) SetAnnotations(value models.Annotations) {
 	m.annotations = &value
 }
 
 // Annotations returns the value of the "annotations" field in the mutation.
-func (m *EntitlementMutation) Annotations() (r map[string]interface{}, exists bool) {
+func (m *EntitlementMutation) Annotations() (r models.Annotations, exists bool) {
 	v := m.annotations
 	if v == nil {
 		return
@@ -32518,7 +32518,7 @@ func (m *EntitlementMutation) Annotations() (r map[string]interface{}, exists bo
 // OldAnnotations returns the old "annotations" field's value of the Entitlement entity.
 // If the Entitlement object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *EntitlementMutation) OldAnnotations(ctx context.Context) (v map[string]interface{}, err error) {
+func (m *EntitlementMutation) OldAnnotations(ctx context.Context) (v models.Annotations, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldAnnotations is only allowed on UpdateOne operations")
 	}
@@ -33156,7 +33156,7 @@ func (m *EntitlementMutation) SetField(name string, value ent.Value) error {
 		m.SetCurrentUsagePeriodEnd(v)
 		return nil
 	case entitlement.FieldAnnotations:
-		v, ok := value.(map[string]interface{})
+		v, ok := value.(models.Annotations)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -38149,7 +38149,7 @@ type NotificationEventMutation struct {
 	created_at               *time.Time
 	_type                    *notification.EventType
 	payload                  *string
-	annotations              *map[string]interface{}
+	annotations              *models.Annotations
 	clearedFields            map[string]struct{}
 	delivery_statuses        map[string]struct{}
 	removeddelivery_statuses map[string]struct{}
@@ -38446,12 +38446,12 @@ func (m *NotificationEventMutation) ResetPayload() {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (m *NotificationEventMutation) SetAnnotations(value map[string]interface{}) {
+func (m *NotificationEventMutation) SetAnnotations(value models.Annotations) {
 	m.annotations = &value
 }
 
 // Annotations returns the value of the "annotations" field in the mutation.
-func (m *NotificationEventMutation) Annotations() (r map[string]interface{}, exists bool) {
+func (m *NotificationEventMutation) Annotations() (r models.Annotations, exists bool) {
 	v := m.annotations
 	if v == nil {
 		return
@@ -38462,7 +38462,7 @@ func (m *NotificationEventMutation) Annotations() (r map[string]interface{}, exi
 // OldAnnotations returns the old "annotations" field's value of the NotificationEvent entity.
 // If the NotificationEvent object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *NotificationEventMutation) OldAnnotations(ctx context.Context) (v map[string]interface{}, err error) {
+func (m *NotificationEventMutation) OldAnnotations(ctx context.Context) (v models.Annotations, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldAnnotations is only allowed on UpdateOne operations")
 	}
@@ -38727,7 +38727,7 @@ func (m *NotificationEventMutation) SetField(name string, value ent.Value) error
 		m.SetPayload(v)
 		return nil
 	case notificationevent.FieldAnnotations:
-		v, ok := value.(map[string]interface{})
+		v, ok := value.(models.Annotations)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -42048,7 +42048,7 @@ type PlanAddonMutation struct {
 	id              *string
 	namespace       *string
 	metadata        *map[string]string
-	annotations     *map[string]interface{}
+	annotations     *models.Annotations
 	created_at      *time.Time
 	updated_at      *time.Time
 	deleted_at      *time.Time
@@ -42255,12 +42255,12 @@ func (m *PlanAddonMutation) ResetMetadata() {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (m *PlanAddonMutation) SetAnnotations(value map[string]interface{}) {
+func (m *PlanAddonMutation) SetAnnotations(value models.Annotations) {
 	m.annotations = &value
 }
 
 // Annotations returns the value of the "annotations" field in the mutation.
-func (m *PlanAddonMutation) Annotations() (r map[string]interface{}, exists bool) {
+func (m *PlanAddonMutation) Annotations() (r models.Annotations, exists bool) {
 	v := m.annotations
 	if v == nil {
 		return
@@ -42271,7 +42271,7 @@ func (m *PlanAddonMutation) Annotations() (r map[string]interface{}, exists bool
 // OldAnnotations returns the old "annotations" field's value of the PlanAddon entity.
 // If the PlanAddon object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *PlanAddonMutation) OldAnnotations(ctx context.Context) (v map[string]interface{}, err error) {
+func (m *PlanAddonMutation) OldAnnotations(ctx context.Context) (v models.Annotations, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldAnnotations is only allowed on UpdateOne operations")
 	}
@@ -42802,7 +42802,7 @@ func (m *PlanAddonMutation) SetField(name string, value ent.Value) error {
 		m.SetMetadata(v)
 		return nil
 	case planaddon.FieldAnnotations:
-		v, ok := value.(map[string]interface{})
+		v, ok := value.(models.Annotations)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -49699,7 +49699,7 @@ type SubscriptionItemMutation struct {
 	updated_at                                   *time.Time
 	deleted_at                                   *time.Time
 	metadata                                     *map[string]string
-	annotations                                  *map[string]interface{}
+	annotations                                  *models.Annotations
 	active_from                                  *time.Time
 	active_to                                    *time.Time
 	key                                          *string
@@ -50041,12 +50041,12 @@ func (m *SubscriptionItemMutation) ResetMetadata() {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (m *SubscriptionItemMutation) SetAnnotations(value map[string]interface{}) {
+func (m *SubscriptionItemMutation) SetAnnotations(value models.Annotations) {
 	m.annotations = &value
 }
 
 // Annotations returns the value of the "annotations" field in the mutation.
-func (m *SubscriptionItemMutation) Annotations() (r map[string]interface{}, exists bool) {
+func (m *SubscriptionItemMutation) Annotations() (r models.Annotations, exists bool) {
 	v := m.annotations
 	if v == nil {
 		return
@@ -50057,7 +50057,7 @@ func (m *SubscriptionItemMutation) Annotations() (r map[string]interface{}, exis
 // OldAnnotations returns the old "annotations" field's value of the SubscriptionItem entity.
 // If the SubscriptionItem object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *SubscriptionItemMutation) OldAnnotations(ctx context.Context) (v map[string]interface{}, err error) {
+func (m *SubscriptionItemMutation) OldAnnotations(ctx context.Context) (v models.Annotations, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldAnnotations is only allowed on UpdateOne operations")
 	}
@@ -51234,7 +51234,7 @@ func (m *SubscriptionItemMutation) SetField(name string, value ent.Value) error 
 		m.SetMetadata(v)
 		return nil
 	case subscriptionitem.FieldAnnotations:
-		v, ok := value.(map[string]interface{})
+		v, ok := value.(models.Annotations)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -53010,7 +53010,7 @@ type UsageResetMutation struct {
 	typ                   string
 	id                    *string
 	namespace             *string
-	annotations           *map[string]interface{}
+	annotations           *models.Annotations
 	created_at            *time.Time
 	updated_at            *time.Time
 	deleted_at            *time.Time
@@ -53166,12 +53166,12 @@ func (m *UsageResetMutation) ResetNamespace() {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (m *UsageResetMutation) SetAnnotations(value map[string]interface{}) {
+func (m *UsageResetMutation) SetAnnotations(value models.Annotations) {
 	m.annotations = &value
 }
 
 // Annotations returns the value of the "annotations" field in the mutation.
-func (m *UsageResetMutation) Annotations() (r map[string]interface{}, exists bool) {
+func (m *UsageResetMutation) Annotations() (r models.Annotations, exists bool) {
 	v := m.annotations
 	if v == nil {
 		return
@@ -53182,7 +53182,7 @@ func (m *UsageResetMutation) Annotations() (r map[string]interface{}, exists boo
 // OldAnnotations returns the old "annotations" field's value of the UsageReset entity.
 // If the UsageReset object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *UsageResetMutation) OldAnnotations(ctx context.Context) (v map[string]interface{}, err error) {
+func (m *UsageResetMutation) OldAnnotations(ctx context.Context) (v models.Annotations, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldAnnotations is only allowed on UpdateOne operations")
 	}
@@ -53638,7 +53638,7 @@ func (m *UsageResetMutation) SetField(name string, value ent.Value) error {
 		m.SetNamespace(v)
 		return nil
 	case usagereset.FieldAnnotations:
-		v, ok := value.(map[string]interface{})
+		v, ok := value.(models.Annotations)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}

--- a/openmeter/ent/db/notificationevent.go
+++ b/openmeter/ent/db/notificationevent.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/notificationevent"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/notificationrule"
 	"github.com/openmeterio/openmeter/openmeter/notification"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // NotificationEvent is the model entity for the NotificationEvent schema.
@@ -30,7 +31,7 @@ type NotificationEvent struct {
 	// Payload holds the value of the "payload" field.
 	Payload string `json:"payload,omitempty"`
 	// Annotations holds the value of the "annotations" field.
-	Annotations map[string]interface{} `json:"annotations,omitempty"`
+	Annotations models.Annotations `json:"annotations,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the NotificationEventQuery when eager-loading is set.
 	Edges        NotificationEventEdges `json:"edges"`

--- a/openmeter/ent/db/notificationevent/notificationevent.go
+++ b/openmeter/ent/db/notificationevent/notificationevent.go
@@ -10,6 +10,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/openmeterio/openmeter/openmeter/notification"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 const (
@@ -85,7 +86,7 @@ var (
 	DefaultID func() string
 	// ValueScanner of all NotificationEvent fields.
 	ValueScanner struct {
-		Annotations field.TypeValueScanner[map[string]interface{}]
+		Annotations field.TypeValueScanner[models.Annotations]
 	}
 )
 

--- a/openmeter/ent/db/notificationevent_create.go
+++ b/openmeter/ent/db/notificationevent_create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/notificationeventdeliverystatus"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/notificationrule"
 	"github.com/openmeterio/openmeter/openmeter/notification"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // NotificationEventCreate is the builder for creating a NotificationEvent entity.
@@ -65,7 +66,7 @@ func (_c *NotificationEventCreate) SetPayload(v string) *NotificationEventCreate
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_c *NotificationEventCreate) SetAnnotations(v map[string]interface{}) *NotificationEventCreate {
+func (_c *NotificationEventCreate) SetAnnotations(v models.Annotations) *NotificationEventCreate {
 	_c.mutation.SetAnnotations(v)
 	return _c
 }
@@ -346,7 +347,7 @@ func (u *NotificationEventUpsert) UpdatePayload() *NotificationEventUpsert {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *NotificationEventUpsert) SetAnnotations(v map[string]interface{}) *NotificationEventUpsert {
+func (u *NotificationEventUpsert) SetAnnotations(v models.Annotations) *NotificationEventUpsert {
 	u.Set(notificationevent.FieldAnnotations, v)
 	return u
 }
@@ -438,7 +439,7 @@ func (u *NotificationEventUpsertOne) UpdatePayload() *NotificationEventUpsertOne
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *NotificationEventUpsertOne) SetAnnotations(v map[string]interface{}) *NotificationEventUpsertOne {
+func (u *NotificationEventUpsertOne) SetAnnotations(v models.Annotations) *NotificationEventUpsertOne {
 	return u.Update(func(s *NotificationEventUpsert) {
 		s.SetAnnotations(v)
 	})
@@ -703,7 +704,7 @@ func (u *NotificationEventUpsertBulk) UpdatePayload() *NotificationEventUpsertBu
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *NotificationEventUpsertBulk) SetAnnotations(v map[string]interface{}) *NotificationEventUpsertBulk {
+func (u *NotificationEventUpsertBulk) SetAnnotations(v models.Annotations) *NotificationEventUpsertBulk {
 	return u.Update(func(s *NotificationEventUpsert) {
 		s.SetAnnotations(v)
 	})

--- a/openmeter/ent/db/notificationevent_update.go
+++ b/openmeter/ent/db/notificationevent_update.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/notificationevent"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/notificationeventdeliverystatus"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // NotificationEventUpdate is the builder for updating NotificationEvent entities.
@@ -43,7 +44,7 @@ func (_u *NotificationEventUpdate) SetNillablePayload(v *string) *NotificationEv
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *NotificationEventUpdate) SetAnnotations(v map[string]interface{}) *NotificationEventUpdate {
+func (_u *NotificationEventUpdate) SetAnnotations(v models.Annotations) *NotificationEventUpdate {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }
@@ -235,7 +236,7 @@ func (_u *NotificationEventUpdateOne) SetNillablePayload(v *string) *Notificatio
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *NotificationEventUpdateOne) SetAnnotations(v map[string]interface{}) *NotificationEventUpdateOne {
+func (_u *NotificationEventUpdateOne) SetAnnotations(v models.Annotations) *NotificationEventUpdateOne {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }

--- a/openmeter/ent/db/planaddon.go
+++ b/openmeter/ent/db/planaddon.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/addon"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/plan"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/planaddon"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // PlanAddon is the model entity for the PlanAddon schema.
@@ -25,7 +26,7 @@ type PlanAddon struct {
 	// Metadata holds the value of the "metadata" field.
 	Metadata map[string]string `json:"metadata,omitempty"`
 	// Annotations holds the value of the "annotations" field.
-	Annotations map[string]interface{} `json:"annotations,omitempty"`
+	Annotations models.Annotations `json:"annotations,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.

--- a/openmeter/ent/db/planaddon_create.go
+++ b/openmeter/ent/db/planaddon_create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/addon"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/plan"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/planaddon"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // PlanAddonCreate is the builder for creating a PlanAddon entity.
@@ -38,7 +39,7 @@ func (_c *PlanAddonCreate) SetMetadata(v map[string]string) *PlanAddonCreate {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_c *PlanAddonCreate) SetAnnotations(v map[string]interface{}) *PlanAddonCreate {
+func (_c *PlanAddonCreate) SetAnnotations(v models.Annotations) *PlanAddonCreate {
 	_c.mutation.SetAnnotations(v)
 	return _c
 }
@@ -404,7 +405,7 @@ func (u *PlanAddonUpsert) ClearMetadata() *PlanAddonUpsert {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *PlanAddonUpsert) SetAnnotations(v map[string]interface{}) *PlanAddonUpsert {
+func (u *PlanAddonUpsert) SetAnnotations(v models.Annotations) *PlanAddonUpsert {
 	u.Set(planaddon.FieldAnnotations, v)
 	return u
 }
@@ -569,7 +570,7 @@ func (u *PlanAddonUpsertOne) ClearMetadata() *PlanAddonUpsertOne {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *PlanAddonUpsertOne) SetAnnotations(v map[string]interface{}) *PlanAddonUpsertOne {
+func (u *PlanAddonUpsertOne) SetAnnotations(v models.Annotations) *PlanAddonUpsertOne {
 	return u.Update(func(s *PlanAddonUpsert) {
 		s.SetAnnotations(v)
 	})
@@ -915,7 +916,7 @@ func (u *PlanAddonUpsertBulk) ClearMetadata() *PlanAddonUpsertBulk {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *PlanAddonUpsertBulk) SetAnnotations(v map[string]interface{}) *PlanAddonUpsertBulk {
+func (u *PlanAddonUpsertBulk) SetAnnotations(v models.Annotations) *PlanAddonUpsertBulk {
 	return u.Update(func(s *PlanAddonUpsert) {
 		s.SetAnnotations(v)
 	})

--- a/openmeter/ent/db/planaddon_update.go
+++ b/openmeter/ent/db/planaddon_update.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/planaddon"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // PlanAddonUpdate is the builder for updating PlanAddon entities.
@@ -41,7 +42,7 @@ func (_u *PlanAddonUpdate) ClearMetadata() *PlanAddonUpdate {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *PlanAddonUpdate) SetAnnotations(v map[string]interface{}) *PlanAddonUpdate {
+func (_u *PlanAddonUpdate) SetAnnotations(v models.Annotations) *PlanAddonUpdate {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }
@@ -249,7 +250,7 @@ func (_u *PlanAddonUpdateOne) ClearMetadata() *PlanAddonUpdateOne {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *PlanAddonUpdateOne) SetAnnotations(v map[string]interface{}) *PlanAddonUpdateOne {
+func (_u *PlanAddonUpdateOne) SetAnnotations(v models.Annotations) *PlanAddonUpdateOne {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -52,6 +52,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/schema"
 	"github.com/openmeterio/openmeter/openmeter/notification"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/models"
 
 	"entgo.io/ent/schema/field"
 )
@@ -95,7 +96,7 @@ func init() {
 	addon.CurrencyValidator = addonDescCurrency.Validators[0].(func(string) error)
 	// addonDescAnnotations is the schema descriptor for annotations field.
 	addonDescAnnotations := addonFields[5].Descriptor()
-	addon.ValueScanner.Annotations = addonDescAnnotations.ValueScanner.(field.TypeValueScanner[map[string]interface{}])
+	addon.ValueScanner.Annotations = addonDescAnnotations.ValueScanner.(field.TypeValueScanner[models.Annotations])
 	// addonDescID is the schema descriptor for id field.
 	addonDescID := addonMixinFields0[0].Descriptor()
 	// addon.DefaultID holds the default value on creation for the id field.
@@ -930,7 +931,7 @@ func init() {
 	entitlement.SubjectKeyValidator = entitlementDescSubjectKey.Validators[0].(func(string) error)
 	// entitlementDescAnnotations is the schema descriptor for annotations field.
 	entitlementDescAnnotations := entitlementFields[16].Descriptor()
-	entitlement.ValueScanner.Annotations = entitlementDescAnnotations.ValueScanner.(field.TypeValueScanner[map[string]interface{}])
+	entitlement.ValueScanner.Annotations = entitlementDescAnnotations.ValueScanner.(field.TypeValueScanner[models.Annotations])
 	// entitlementDescID is the schema descriptor for id field.
 	entitlementDescID := entitlementMixinFields0[0].Descriptor()
 	// entitlement.DefaultID holds the default value on creation for the id field.
@@ -1085,7 +1086,7 @@ func init() {
 	notificationevent.DefaultCreatedAt = notificationeventDescCreatedAt.Default.(func() time.Time)
 	// notificationeventDescAnnotations is the schema descriptor for annotations field.
 	notificationeventDescAnnotations := notificationeventFields[4].Descriptor()
-	notificationevent.ValueScanner.Annotations = notificationeventDescAnnotations.ValueScanner.(field.TypeValueScanner[map[string]interface{}])
+	notificationevent.ValueScanner.Annotations = notificationeventDescAnnotations.ValueScanner.(field.TypeValueScanner[models.Annotations])
 	// notificationeventDescID is the schema descriptor for id field.
 	notificationeventDescID := notificationeventMixinFields0[0].Descriptor()
 	// notificationevent.DefaultID holds the default value on creation for the id field.
@@ -1503,7 +1504,7 @@ func init() {
 	subscriptionitem.UpdateDefaultUpdatedAt = subscriptionitemDescUpdatedAt.UpdateDefault.(func() time.Time)
 	// subscriptionitemDescAnnotations is the schema descriptor for annotations field.
 	subscriptionitemDescAnnotations := subscriptionitemFields[0].Descriptor()
-	subscriptionitem.ValueScanner.Annotations = subscriptionitemDescAnnotations.ValueScanner.(field.TypeValueScanner[map[string]interface{}])
+	subscriptionitem.ValueScanner.Annotations = subscriptionitemDescAnnotations.ValueScanner.(field.TypeValueScanner[models.Annotations])
 	// subscriptionitemDescPhaseID is the schema descriptor for phase_id field.
 	subscriptionitemDescPhaseID := subscriptionitemFields[3].Descriptor()
 	// subscriptionitem.PhaseIDValidator is a validator for the "phase_id" field. It is called by the builders before save.

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -83,14 +83,14 @@ func (u *AddonUpdateOne) SetOrClearEffectiveTo(value *time.Time) *AddonUpdateOne
 	return u.SetEffectiveTo(*value)
 }
 
-func (u *AddonUpdate) SetOrClearAnnotations(value *map[string]interface{}) *AddonUpdate {
+func (u *AddonUpdate) SetOrClearAnnotations(value *models.Annotations) *AddonUpdate {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
 	return u.SetAnnotations(*value)
 }
 
-func (u *AddonUpdateOne) SetOrClearAnnotations(value *map[string]interface{}) *AddonUpdateOne {
+func (u *AddonUpdateOne) SetOrClearAnnotations(value *models.Annotations) *AddonUpdateOne {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
@@ -993,14 +993,14 @@ func (u *BillingInvoiceFlatFeeLineConfigUpdateOne) SetOrClearIndex(value *int) *
 	return u.SetIndex(*value)
 }
 
-func (u *BillingInvoiceLineUpdate) SetOrClearAnnotations(value *map[string]interface{}) *BillingInvoiceLineUpdate {
+func (u *BillingInvoiceLineUpdate) SetOrClearAnnotations(value *models.Annotations) *BillingInvoiceLineUpdate {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
 	return u.SetAnnotations(*value)
 }
 
-func (u *BillingInvoiceLineUpdateOne) SetOrClearAnnotations(value *map[string]interface{}) *BillingInvoiceLineUpdateOne {
+func (u *BillingInvoiceLineUpdateOne) SetOrClearAnnotations(value *models.Annotations) *BillingInvoiceLineUpdateOne {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
@@ -1889,14 +1889,14 @@ func (u *CustomerUpdateOne) SetOrClearBillingAddressPhoneNumber(value *string) *
 	return u.SetBillingAddressPhoneNumber(*value)
 }
 
-func (u *CustomerUpdate) SetOrClearAnnotations(value *map[string]interface{}) *CustomerUpdate {
+func (u *CustomerUpdate) SetOrClearAnnotations(value *models.Annotations) *CustomerUpdate {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
 	return u.SetAnnotations(*value)
 }
 
-func (u *CustomerUpdateOne) SetOrClearAnnotations(value *map[string]interface{}) *CustomerUpdateOne {
+func (u *CustomerUpdateOne) SetOrClearAnnotations(value *models.Annotations) *CustomerUpdateOne {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
@@ -2057,14 +2057,14 @@ func (u *EntitlementUpdateOne) SetOrClearCurrentUsagePeriodEnd(value *time.Time)
 	return u.SetCurrentUsagePeriodEnd(*value)
 }
 
-func (u *EntitlementUpdate) SetOrClearAnnotations(value *map[string]interface{}) *EntitlementUpdate {
+func (u *EntitlementUpdate) SetOrClearAnnotations(value *models.Annotations) *EntitlementUpdate {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
 	return u.SetAnnotations(*value)
 }
 
-func (u *EntitlementUpdateOne) SetOrClearAnnotations(value *map[string]interface{}) *EntitlementUpdateOne {
+func (u *EntitlementUpdateOne) SetOrClearAnnotations(value *models.Annotations) *EntitlementUpdateOne {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
@@ -2281,14 +2281,14 @@ func (u *NotificationChannelUpdateOne) SetOrClearDisabled(value *bool) *Notifica
 	return u.SetDisabled(*value)
 }
 
-func (u *NotificationEventUpdate) SetOrClearAnnotations(value *map[string]interface{}) *NotificationEventUpdate {
+func (u *NotificationEventUpdate) SetOrClearAnnotations(value *models.Annotations) *NotificationEventUpdate {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
 	return u.SetAnnotations(*value)
 }
 
-func (u *NotificationEventUpdateOne) SetOrClearAnnotations(value *map[string]interface{}) *NotificationEventUpdateOne {
+func (u *NotificationEventUpdateOne) SetOrClearAnnotations(value *models.Annotations) *NotificationEventUpdateOne {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
@@ -2421,14 +2421,14 @@ func (u *PlanAddonUpdateOne) SetOrClearMetadata(value *map[string]string) *PlanA
 	return u.SetMetadata(*value)
 }
 
-func (u *PlanAddonUpdate) SetOrClearAnnotations(value *map[string]interface{}) *PlanAddonUpdate {
+func (u *PlanAddonUpdate) SetOrClearAnnotations(value *models.Annotations) *PlanAddonUpdate {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
 	return u.SetAnnotations(*value)
 }
 
-func (u *PlanAddonUpdateOne) SetOrClearAnnotations(value *map[string]interface{}) *PlanAddonUpdateOne {
+func (u *PlanAddonUpdateOne) SetOrClearAnnotations(value *models.Annotations) *PlanAddonUpdateOne {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
@@ -2841,14 +2841,14 @@ func (u *SubscriptionItemUpdateOne) SetOrClearMetadata(value *map[string]string)
 	return u.SetMetadata(*value)
 }
 
-func (u *SubscriptionItemUpdate) SetOrClearAnnotations(value *map[string]interface{}) *SubscriptionItemUpdate {
+func (u *SubscriptionItemUpdate) SetOrClearAnnotations(value *models.Annotations) *SubscriptionItemUpdate {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
 	return u.SetAnnotations(*value)
 }
 
-func (u *SubscriptionItemUpdateOne) SetOrClearAnnotations(value *map[string]interface{}) *SubscriptionItemUpdateOne {
+func (u *SubscriptionItemUpdateOne) SetOrClearAnnotations(value *models.Annotations) *SubscriptionItemUpdateOne {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
@@ -3079,14 +3079,14 @@ func (u *SubscriptionPhaseUpdateOne) SetOrClearSortHint(value *uint8) *Subscript
 	return u.SetSortHint(*value)
 }
 
-func (u *UsageResetUpdate) SetOrClearAnnotations(value *map[string]interface{}) *UsageResetUpdate {
+func (u *UsageResetUpdate) SetOrClearAnnotations(value *models.Annotations) *UsageResetUpdate {
 	if value == nil {
 		return u.ClearAnnotations()
 	}
 	return u.SetAnnotations(*value)
 }
 
-func (u *UsageResetUpdateOne) SetOrClearAnnotations(value *map[string]interface{}) *UsageResetUpdateOne {
+func (u *UsageResetUpdateOne) SetOrClearAnnotations(value *models.Annotations) *UsageResetUpdateOne {
 	if value == nil {
 		return u.ClearAnnotations()
 	}

--- a/openmeter/ent/db/subscriptionitem.go
+++ b/openmeter/ent/db/subscriptionitem.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionphase"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // SubscriptionItem is the model entity for the SubscriptionItem schema.
@@ -33,7 +34,7 @@ type SubscriptionItem struct {
 	// Metadata holds the value of the "metadata" field.
 	Metadata map[string]string `json:"metadata,omitempty"`
 	// Annotations holds the value of the "annotations" field.
-	Annotations map[string]interface{} `json:"annotations,omitempty"`
+	Annotations models.Annotations `json:"annotations,omitempty"`
 	// ActiveFrom holds the value of the "active_from" field.
 	ActiveFrom time.Time `json:"active_from,omitempty"`
 	// ActiveTo holds the value of the "active_to" field.

--- a/openmeter/ent/db/subscriptionitem/subscriptionitem.go
+++ b/openmeter/ent/db/subscriptionitem/subscriptionitem.go
@@ -9,6 +9,7 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 const (
@@ -156,7 +157,7 @@ var (
 	DefaultID func() string
 	// ValueScanner of all SubscriptionItem fields.
 	ValueScanner struct {
-		Annotations         field.TypeValueScanner[map[string]interface{}]
+		Annotations         field.TypeValueScanner[models.Annotations]
 		EntitlementTemplate field.TypeValueScanner[*productcatalog.EntitlementTemplate]
 		TaxConfig           field.TypeValueScanner[*productcatalog.TaxConfig]
 		Price               field.TypeValueScanner[*productcatalog.Price]

--- a/openmeter/ent/db/subscriptionitem_create.go
+++ b/openmeter/ent/db/subscriptionitem_create.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionphase"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // SubscriptionItemCreate is the builder for creating a SubscriptionItem entity.
@@ -84,7 +85,7 @@ func (_c *SubscriptionItemCreate) SetMetadata(v map[string]string) *Subscription
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_c *SubscriptionItemCreate) SetAnnotations(v map[string]interface{}) *SubscriptionItemCreate {
+func (_c *SubscriptionItemCreate) SetAnnotations(v models.Annotations) *SubscriptionItemCreate {
 	_c.mutation.SetAnnotations(v)
 	return _c
 }
@@ -724,7 +725,7 @@ func (u *SubscriptionItemUpsert) ClearMetadata() *SubscriptionItemUpsert {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *SubscriptionItemUpsert) SetAnnotations(v map[string]interface{}) *SubscriptionItemUpsert {
+func (u *SubscriptionItemUpsert) SetAnnotations(v models.Annotations) *SubscriptionItemUpsert {
 	u.Set(subscriptionitem.FieldAnnotations, v)
 	return u
 }
@@ -1098,7 +1099,7 @@ func (u *SubscriptionItemUpsertOne) ClearMetadata() *SubscriptionItemUpsertOne {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *SubscriptionItemUpsertOne) SetAnnotations(v map[string]interface{}) *SubscriptionItemUpsertOne {
+func (u *SubscriptionItemUpsertOne) SetAnnotations(v models.Annotations) *SubscriptionItemUpsertOne {
 	return u.Update(func(s *SubscriptionItemUpsert) {
 		s.SetAnnotations(v)
 	})
@@ -1685,7 +1686,7 @@ func (u *SubscriptionItemUpsertBulk) ClearMetadata() *SubscriptionItemUpsertBulk
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *SubscriptionItemUpsertBulk) SetAnnotations(v map[string]interface{}) *SubscriptionItemUpsertBulk {
+func (u *SubscriptionItemUpsertBulk) SetAnnotations(v models.Annotations) *SubscriptionItemUpsertBulk {
 	return u.Update(func(s *SubscriptionItemUpsert) {
 		s.SetAnnotations(v)
 	})

--- a/openmeter/ent/db/subscriptionitem_update.go
+++ b/openmeter/ent/db/subscriptionitem_update.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionitem"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // SubscriptionItemUpdate is the builder for updating SubscriptionItem entities.
@@ -72,7 +73,7 @@ func (_u *SubscriptionItemUpdate) ClearMetadata() *SubscriptionItemUpdate {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *SubscriptionItemUpdate) SetAnnotations(v map[string]interface{}) *SubscriptionItemUpdate {
+func (_u *SubscriptionItemUpdate) SetAnnotations(v models.Annotations) *SubscriptionItemUpdate {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }
@@ -779,7 +780,7 @@ func (_u *SubscriptionItemUpdateOne) ClearMetadata() *SubscriptionItemUpdateOne 
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *SubscriptionItemUpdateOne) SetAnnotations(v map[string]interface{}) *SubscriptionItemUpdateOne {
+func (_u *SubscriptionItemUpdateOne) SetAnnotations(v models.Annotations) *SubscriptionItemUpdateOne {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }

--- a/openmeter/ent/db/usagereset.go
+++ b/openmeter/ent/db/usagereset.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/entitlement"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/usagereset"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // UsageReset is the model entity for the UsageReset schema.
@@ -23,7 +24,7 @@ type UsageReset struct {
 	// Namespace holds the value of the "namespace" field.
 	Namespace string `json:"namespace,omitempty"`
 	// Annotations holds the value of the "annotations" field.
-	Annotations map[string]interface{} `json:"annotations,omitempty"`
+	Annotations models.Annotations `json:"annotations,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.

--- a/openmeter/ent/db/usagereset_create.go
+++ b/openmeter/ent/db/usagereset_create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/entitlement"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/usagereset"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // UsageResetCreate is the builder for creating a UsageReset entity.
@@ -32,7 +33,7 @@ func (_c *UsageResetCreate) SetNamespace(v string) *UsageResetCreate {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_c *UsageResetCreate) SetAnnotations(v map[string]interface{}) *UsageResetCreate {
+func (_c *UsageResetCreate) SetAnnotations(v models.Annotations) *UsageResetCreate {
 	_c.mutation.SetAnnotations(v)
 	return _c
 }
@@ -340,7 +341,7 @@ type (
 )
 
 // SetAnnotations sets the "annotations" field.
-func (u *UsageResetUpsert) SetAnnotations(v map[string]interface{}) *UsageResetUpsert {
+func (u *UsageResetUpsert) SetAnnotations(v models.Annotations) *UsageResetUpsert {
 	u.Set(usagereset.FieldAnnotations, v)
 	return u
 }
@@ -454,7 +455,7 @@ func (u *UsageResetUpsertOne) Update(set func(*UsageResetUpsert)) *UsageResetUps
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *UsageResetUpsertOne) SetAnnotations(v map[string]interface{}) *UsageResetUpsertOne {
+func (u *UsageResetUpsertOne) SetAnnotations(v models.Annotations) *UsageResetUpsertOne {
 	return u.Update(func(s *UsageResetUpsert) {
 		s.SetAnnotations(v)
 	})
@@ -743,7 +744,7 @@ func (u *UsageResetUpsertBulk) Update(set func(*UsageResetUpsert)) *UsageResetUp
 }
 
 // SetAnnotations sets the "annotations" field.
-func (u *UsageResetUpsertBulk) SetAnnotations(v map[string]interface{}) *UsageResetUpsertBulk {
+func (u *UsageResetUpsertBulk) SetAnnotations(v models.Annotations) *UsageResetUpsertBulk {
 	return u.Update(func(s *UsageResetUpsert) {
 		s.SetAnnotations(v)
 	})

--- a/openmeter/ent/db/usagereset_update.go
+++ b/openmeter/ent/db/usagereset_update.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/usagereset"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // UsageResetUpdate is the builder for updating UsageReset entities.
@@ -29,7 +30,7 @@ func (_u *UsageResetUpdate) Where(ps ...predicate.UsageReset) *UsageResetUpdate 
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *UsageResetUpdate) SetAnnotations(v map[string]interface{}) *UsageResetUpdate {
+func (_u *UsageResetUpdate) SetAnnotations(v models.Annotations) *UsageResetUpdate {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }
@@ -163,7 +164,7 @@ type UsageResetUpdateOne struct {
 }
 
 // SetAnnotations sets the "annotations" field.
-func (_u *UsageResetUpdateOne) SetAnnotations(v map[string]interface{}) *UsageResetUpdateOne {
+func (_u *UsageResetUpdateOne) SetAnnotations(v models.Annotations) *UsageResetUpdateOne {
 	_u.mutation.SetAnnotations(v)
 	return _u
 }

--- a/openmeter/productcatalog/http/mapping.go
+++ b/openmeter/productcatalog/http/mapping.go
@@ -902,19 +902,20 @@ func FromMetadata(metadata models.Metadata) *api.Metadata {
 	return &result
 }
 
+func FromValidationAttributes(attrs models.Attributes) *api.Annotations {
+	if len(attrs) == 0 {
+		return nil
+	}
+
+	return lo.ToPtr((api.Annotations)(attrs))
+}
+
 func FromAnnotations(annotations models.Annotations) *api.Annotations {
 	if len(annotations) == 0 {
 		return nil
 	}
 
-	result := make(api.Annotations)
-	if len(annotations) > 0 {
-		for k, v := range annotations {
-			result[k] = v
-		}
-	}
-
-	return &result
+	return lo.ToPtr((api.Annotations)(annotations))
 }
 
 func FromValidationErrors(issues models.ValidationIssues) *[]api.ValidationError {
@@ -929,7 +930,7 @@ func FromValidationErrors(issues models.ValidationIssues) *[]api.ValidationError
 			Message:    issue.Message(),
 			Field:      issue.Field().JSONPath(),
 			Code:       string(issue.Code()),
-			Attributes: FromAnnotations(issue.Attributes()),
+			Attributes: FromValidationAttributes(issue.Attributes()),
 		})
 	}
 

--- a/pkg/models/annotation.go
+++ b/pkg/models/annotation.go
@@ -1,3 +1,21 @@
 package models
 
-type Annotations = map[string]interface{}
+type Annotations map[string]interface{}
+
+func (a Annotations) GetBool(key string) bool {
+	if len(a) == 0 {
+		return false
+	}
+
+	val, ok := a[key]
+	if !ok {
+		return false
+	}
+
+	boolVal, ok := val.(bool)
+	if !ok {
+		return false
+	}
+
+	return boolVal
+}

--- a/tools/migrate/migrations/20250731160524_billing-second-resolution.up.sql
+++ b/tools/migrate/migrations/20250731160524_billing-second-resolution.up.sql
@@ -2,6 +2,7 @@
 -- Billing sync will ensure that the lines are continous for a subscription item, thus we will not have a few seconds of gaps
 -- in the invoices.
 
+-- Warning: If you want to reuse this please make sure that you also add billing.subscription.sync.force-continuous-lines: true
 UPDATE billing_invoice_lines
 SET
     annotations = CASE

--- a/tools/migrate/migrations/20250807075408_usageperiod-duration-calculations.up.sql
+++ b/tools/migrate/migrations/20250807075408_usageperiod-duration-calculations.up.sql
@@ -464,6 +464,7 @@ $$ LANGUAGE plpgsql VOLATILE;
 -- Let's run the migration
 SELECT om_func_update_usage_period_durations_batch(2000, NOW());
 
+-- Warning: If you want to reuse this please make sure that you also add billing.subscription.sync.force-continuous-lines: true
 UPDATE billing_invoice_lines
 SET
     annotations = CASE

--- a/tools/migrate/migrations/20250815072132_force-continous-lines-annotation.up.sql
+++ b/tools/migrate/migrations/20250815072132_force-continous-lines-annotation.up.sql
@@ -1,0 +1,4 @@
+UPDATE billing_invoice_lines
+    SET annotations = annotations || '{"billing.subscription.sync.force-continous-lines": true}'
+    WHERE
+         (annotations is not null or annotations <> 'null'::jsonb) and (annotations -> 'billing.subscription.sync.ignore' = 'true'::jsonb);

--- a/tools/migrate/migrations/20250815072132_force-continous-lines-annotation.up.sql
+++ b/tools/migrate/migrations/20250815072132_force-continous-lines-annotation.up.sql
@@ -1,4 +1,0 @@
-UPDATE billing_invoice_lines
-    SET annotations = annotations || '{"billing.subscription.sync.force-continous-lines": true}'
-    WHERE
-         (annotations is not null or annotations <> 'null'::jsonb) and (annotations -> 'billing.subscription.sync.ignore' = 'true'::jsonb);

--- a/tools/migrate/migrations/20250815072132_force-continuous-lines-annotation.up.sql
+++ b/tools/migrate/migrations/20250815072132_force-continuous-lines-annotation.up.sql
@@ -1,0 +1,4 @@
+UPDATE billing_invoice_lines
+    SET annotations = annotations || '{"billing.subscription.sync.force-continuous-lines": true}'
+    WHERE
+         (annotations is not null and annotations <> 'null'::jsonb) and (annotations -> 'billing.subscription.sync.ignore' = 'true'::jsonb);

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:YtE5tz2Ga+KT9zN5MYPpg+/SrTXX97ViwAjooRLi0q0=
+h1:2pcdBtLX8cS2NCnMsf/i3sCNXxpuvjgi9zNLl5kipJE=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -114,7 +114,7 @@ h1:YtE5tz2Ga+KT9zN5MYPpg+/SrTXX97ViwAjooRLi0q0=
 20250707075725_billingline-annotations.up.sql h1:bfTEaqbIFbPBJpEICHvvyUb6T2iUycQkNLN7ZittZgM=
 20250711121333_customer_annotations.up.sql h1:AHh+LE27UZiCLCQa4eXyb8noAoyMFekQNqfe6UEsf48=
 20250731141420_billing-migrate-flat-fee-lines.up.sql h1:7JgYbt/kXZ10HkUvckDY8sed1isRt9XPjBjOtPayz1A=
-20250731160524_billing-second-resolution.up.sql h1:7m4RF8MDwJEutOGX+Lfskf4ZFdl3u18ACSgVNV5ddxY=
-20250807075408_usageperiod-duration-calculations.up.sql h1:OOy9oSwYtlFhCCelPJylMHTbeTU84aiXds79i62SItE=
-20250811130613_add_billing_invoice_customer_key.up.sql h1:0jXF8jye5rPKgR9ec960f1uIxLXg9D0Kt+8mkmtLuzs=
-20250815072132_force-continous-lines-annotation.up.sql h1:vItJtLi5/nP3ocGR5jFSJhD2oRhuEw7uC0jcEXPzL+U=
+20250731160524_billing-second-resolution.up.sql h1:H8Emd2PJh6zZcvxrzaeAr8vE+g7mb3KfVk0GBdkJ7gg=
+20250807075408_usageperiod-duration-calculations.up.sql h1:iSjKxSiVyEn1rz6Wm4Ke+h4BBpq2JIKDv14Tl1vG6Bc=
+20250811130613_add_billing_invoice_customer_key.up.sql h1:aSsWTNTi5mphbnSYX0qgNjo/lI6MZwc6RoUUXG9mTJ0=
+20250815072132_force-continuous-lines-annotation.up.sql h1:0LGclJBhap5VUvC8QyIp5jYRBpb1lQNHdChq5gbazFU=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:6K2bzfQBFnB8hUuyv1uTYzHBR9lWJ3gDvmEyE67nTts=
+h1:/ox+47T2f7wavklZrTTjDY5gQnvWMRdaYYmWEBIdr6A=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -117,3 +117,4 @@ h1:6K2bzfQBFnB8hUuyv1uTYzHBR9lWJ3gDvmEyE67nTts=
 20250731160524_billing-second-resolution.up.sql h1:7m4RF8MDwJEutOGX+Lfskf4ZFdl3u18ACSgVNV5ddxY=
 20250807075408_usageperiod-duration-calculations.up.sql h1:OOy9oSwYtlFhCCelPJylMHTbeTU84aiXds79i62SItE=
 20250811130613_add_billing_invoice_customer_key.up.sql h1:0jXF8jye5rPKgR9ec960f1uIxLXg9D0Kt+8mkmtLuzs=
+20250815072132_force-continous-lines-annotation.up.sql h1:rjP2/ta0xZ2zdQcYTyZjidAQAAyU1VU2Tk6l4cFfnz4=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:/ox+47T2f7wavklZrTTjDY5gQnvWMRdaYYmWEBIdr6A=
+h1:YtE5tz2Ga+KT9zN5MYPpg+/SrTXX97ViwAjooRLi0q0=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -117,4 +117,4 @@ h1:/ox+47T2f7wavklZrTTjDY5gQnvWMRdaYYmWEBIdr6A=
 20250731160524_billing-second-resolution.up.sql h1:7m4RF8MDwJEutOGX+Lfskf4ZFdl3u18ACSgVNV5ddxY=
 20250807075408_usageperiod-duration-calculations.up.sql h1:OOy9oSwYtlFhCCelPJylMHTbeTU84aiXds79i62SItE=
 20250811130613_add_billing_invoice_customer_key.up.sql h1:0jXF8jye5rPKgR9ec960f1uIxLXg9D0Kt+8mkmtLuzs=
-20250815072132_force-continous-lines-annotation.up.sql h1:rjP2/ta0xZ2zdQcYTyZjidAQAAyU1VU2Tk6l4cFfnz4=
+20250815072132_force-continous-lines-annotation.up.sql h1:vItJtLi5/nP3ocGR5jFSJhD2oRhuEw7uC0jcEXPzL+U=


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

The `billing.subscription.sync.ignore` was doing two things before this PR:
- Instructs subscription sync to skip synchronizing those lines
- Ensured that the new lines are continuous

This patch splits the continuous logic into a seperate flag, so that we can govern these behaviors independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new billing annotation to enforce continuous invoice lines during subscription sync.

* **Refactor**
  * Improved annotation handling with stronger typing and safer boolean access for more reliable billing sync behavior.

* **Chores**
  * Added migrations to backfill/adjust annotations on invoice lines and guide safe reuse with warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->