### PR TITLE
feat: allow any subscription anchor, do not normalize the anchor

### DIFF
--- a/openmeter/billing/worker/subscription/suitebase_test.go
+++ b/openmeter/billing/worker/subscription/suitebase_test.go
@@ -1,0 +1,468 @@
+package billingworkersubscription
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/invopop/gobl/currency"
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	productcatalogsubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/openmeter/subscription/patch"
+	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+	billingtest "github.com/openmeterio/openmeter/test/billing"
+)
+
+type SuiteBase struct {
+	billingtest.BaseSuite
+	billingtest.SubscriptionMixin
+	Handler *Handler
+
+	Namespace               string
+	Customer                *customer.Customer
+	APIRequestsTotalFeature feature.Feature
+}
+
+func (s *SuiteBase) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	s.SubscriptionMixin.SetupSuite(s.T(), s.GetSubscriptionMixInDependencies())
+
+	handler, err := New(Config{
+		BillingService:      s.BillingService,
+		Logger:              slog.Default(),
+		Tracer:              noop.NewTracerProvider().Tracer("test"),
+		TxCreator:           s.BillingAdapter,
+		SubscriptionService: s.SubscriptionService,
+	})
+	s.NoError(err)
+
+	s.Handler = handler
+}
+
+func (s *SuiteBase) BeforeTest(ctx context.Context, suiteName, testName string) {
+	s.Namespace = "test-subs-update-" + ulid.Make().String()
+
+	appSandbox := s.InstallSandboxApp(s.T(), s.Namespace)
+
+	s.ProvisionBillingProfile(ctx, s.Namespace, appSandbox.GetID())
+
+	apiRequestsTotalMeterSlug := "api-requests-total"
+
+	err := s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{
+		{
+			ManagedResource: models.ManagedResource{
+				ID: ulid.Make().String(),
+				NamespacedModel: models.NamespacedModel{
+					Namespace: s.Namespace,
+				},
+				ManagedModel: models.ManagedModel{
+					CreatedAt: time.Now(),
+					UpdatedAt: time.Now(),
+				},
+				Name: "API Requests Total",
+			},
+			Key:           apiRequestsTotalMeterSlug,
+			Aggregation:   meter.MeterAggregationSum,
+			EventType:     "test",
+			ValueProperty: lo.ToPtr("$.value"),
+		},
+	})
+	s.NoError(err, "Replacing meters must not return error")
+
+	apiRequestsTotalFeatureKey := "api-requests-total"
+
+	apiRequestsTotalFeature, err := s.FeatureService.CreateFeature(ctx, feature.CreateFeatureInputs{
+		Namespace: s.Namespace,
+		Name:      "api-requests-total",
+		Key:       apiRequestsTotalFeatureKey,
+		MeterSlug: lo.ToPtr("api-requests-total"),
+	})
+	s.NoError(err)
+	s.APIRequestsTotalFeature = apiRequestsTotalFeature
+
+	customerEntity := s.CreateTestCustomer(s.Namespace, "test")
+	require.NotNil(s.T(), customerEntity)
+	require.NotEmpty(s.T(), customerEntity.ID)
+
+	s.Customer = customerEntity
+}
+
+func (s *SuiteBase) AfterTest(ctx context.Context, suiteName, testName string) {
+	clock.UnFreeze()
+	clock.ResetTime()
+
+	err := s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{})
+	s.NoError(err, "Replacing meters must not return error")
+
+	s.MockStreamingConnector.Reset()
+	s.Handler.featureFlags = FeatureFlags{}
+}
+
+func (s *SuiteBase) gatheringInvoice(ctx context.Context, namespace string, customerID string) billing.Invoice {
+	s.T().Helper()
+
+	invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
+		Namespaces: []string{namespace},
+		Customers:  []string{customerID},
+		Page: pagination.Page{
+			PageSize:   10,
+			PageNumber: 1,
+		},
+		Expand: billing.InvoiceExpandAll,
+		Statuses: []string{
+			string(billing.InvoiceStatusGathering),
+		},
+	})
+
+	s.NoError(err)
+	s.Len(invoices.Items, 1, "expected 1 gathering invoice")
+	return invoices.Items[0]
+}
+
+func (s *SuiteBase) expectNoGatheringInvoice(ctx context.Context, namespace string, customerID string) {
+	s.T().Helper()
+
+	invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
+		Namespaces: []string{namespace},
+		Customers:  []string{customerID},
+		Page: pagination.Page{
+			PageSize:   10,
+			PageNumber: 1,
+		},
+		Expand: billing.InvoiceExpandAll,
+		Statuses: []string{
+			string(billing.InvoiceStatusGathering),
+		},
+	})
+
+	s.NoError(err)
+	s.Len(invoices.Items, 0)
+}
+
+func (s *SuiteBase) enableProrating() {
+	s.Handler.featureFlags.EnableFlatFeeInAdvanceProrating = true
+	s.Handler.featureFlags.EnableFlatFeeInArrearsProrating = true
+}
+
+func (s *SuiteBase) getLineByChildID(invoice billing.Invoice, childID string) *billing.Line {
+	s.T().Helper()
+
+	for _, line := range invoice.Lines.OrEmpty() {
+		if line.ChildUniqueReferenceID != nil && *line.ChildUniqueReferenceID == childID {
+			return line
+		}
+	}
+
+	s.Failf("line not found", "line with child id %s not found", childID)
+
+	return nil
+}
+
+func (s *SuiteBase) expectNoLineWithChildID(invoice billing.Invoice, childID string) {
+	s.T().Helper()
+
+	for _, line := range invoice.Lines.OrEmpty() {
+		if line.ChildUniqueReferenceID != nil && *line.ChildUniqueReferenceID == childID {
+			s.Failf("line found", "line with child id %s found", childID)
+		}
+	}
+}
+
+func (s *SuiteBase) timingImmediate() subscription.Timing {
+	return subscription.Timing{
+		Enum: lo.ToPtr(subscription.TimingImmediate),
+	}
+}
+
+func (s *SuiteBase) getPhaseByKey(t *testing.T, subsView subscription.SubscriptionView, key string) subscription.SubscriptionPhaseView {
+	for _, phase := range subsView.Phases {
+		if phase.SubscriptionPhase.Key == key {
+			return phase
+		}
+	}
+
+	t.Fatalf("phase with key %s not found", key)
+	return subscription.SubscriptionPhaseView{}
+}
+
+type expectedLine struct {
+	Matcher   lineMatcher
+	Qty       mo.Option[float64]
+	Price     mo.Option[*productcatalog.Price]
+	Periods   []billing.Period
+	InvoiceAt mo.Option[[]time.Time]
+}
+
+func (s *SuiteBase) expectLines(invoice billing.Invoice, subscriptionID string, expectedLines []expectedLine) {
+	s.T().Helper()
+
+	lines := invoice.Lines.OrEmpty()
+
+	existingLineChildIDs := lo.Map(lines, func(line *billing.Line, _ int) string {
+		return lo.FromPtrOr(line.ChildUniqueReferenceID, line.ID)
+	})
+
+	expectedLineIds := lo.Flatten(lo.Map(expectedLines, func(expectedLine expectedLine, _ int) []string {
+		return expectedLine.Matcher.ChildIDs(subscriptionID)
+	}))
+
+	s.ElementsMatch(expectedLineIds, existingLineChildIDs)
+
+	for _, expectedLine := range expectedLines {
+		childIDs := expectedLine.Matcher.ChildIDs(subscriptionID)
+		for idx, childID := range childIDs {
+			line, found := lo.Find(lines, func(line *billing.Line) bool {
+				return lo.FromPtrOr(line.ChildUniqueReferenceID, line.ID) == childID
+			})
+			s.Truef(found, "line not found with child id %s", childID)
+			s.NotNil(line)
+
+			if expectedLine.Qty.IsPresent() {
+				if line.UsageBased == nil {
+					s.Failf("usage based line not found", "line not found with child id %s", childID)
+				} else if line.UsageBased.Quantity == nil {
+					s.Failf("usage based line quantity not found", "line not found with child id %s", childID)
+				} else {
+					s.Equal(expectedLine.Qty.OrEmpty(), line.UsageBased.Quantity.InexactFloat64(), "%s: quantity", childID)
+				}
+			}
+
+			if expectedLine.Price.IsPresent() {
+				s.Equal(billing.InvoiceLineTypeUsageBased, line.Type, "%s: line type", childID)
+				s.Equal(*expectedLine.Price.OrEmpty(), *line.UsageBased.Price, "%s: price", childID)
+			}
+
+			s.Equal(expectedLine.Periods[idx].Start, line.Period.Start, "%s: period start", childID)
+			s.Equal(expectedLine.Periods[idx].End, line.Period.End, "%s: period end", childID)
+
+			if expectedLine.InvoiceAt.IsPresent() {
+				s.Equal(expectedLine.InvoiceAt.OrEmpty()[idx], line.InvoiceAt, "%s: invoice at", childID)
+			}
+		}
+	}
+}
+
+type lineMatcher interface {
+	ChildIDs(subsID string) []string
+}
+
+type recurringLineMatcher struct {
+	PhaseKey  string
+	ItemKey   string
+	Version   int
+	PeriodMin int
+	PeriodMax int
+}
+
+func (m recurringLineMatcher) ChildIDs(subsID string) []string {
+	out := []string{}
+	for periodID := m.PeriodMin; periodID <= m.PeriodMax; periodID++ {
+		out = append(out, fmt.Sprintf("%s/%s/%s/v[%d]/period[%d]", subsID, m.PhaseKey, m.ItemKey, m.Version, periodID))
+	}
+
+	return out
+}
+
+type oneTimeLineMatcher struct {
+	PhaseKey string
+	ItemKey  string
+	Version  int
+}
+
+func (m oneTimeLineMatcher) ChildIDs(subsID string) []string {
+	return []string{fmt.Sprintf("%s/%s/%s/v[%d]", subsID, m.PhaseKey, m.ItemKey, m.Version)}
+}
+
+// helpers
+
+//nolint:unparam
+func (s *SuiteBase) phaseMeta(key string, duration string) productcatalog.PhaseMeta {
+	out := productcatalog.PhaseMeta{
+		Key:  key,
+		Name: key,
+	}
+
+	if duration != "" {
+		out.Duration = lo.ToPtr(datetime.MustParseDuration(s.T(), duration))
+	}
+
+	return out
+}
+
+func (s *SuiteBase) enableProgressiveBilling() {
+	s.updateProfile(func(profile *billing.Profile) {
+		profile.WorkflowConfig.Invoicing.ProgressiveBilling = true
+	})
+}
+
+func (s *SuiteBase) updateProfile(modify func(profile *billing.Profile)) {
+	defaultProfile, err := s.BillingService.GetDefaultProfile(s.T().Context(), billing.GetDefaultProfileInput{
+		Namespace: s.Namespace,
+	})
+	s.NoError(err)
+
+	modify(defaultProfile)
+
+	defaultProfile.AppReferences = nil
+
+	_, err = s.BillingService.UpdateProfile(s.T().Context(), billing.UpdateProfileInput(defaultProfile.BaseProfile))
+	s.NoError(err)
+}
+
+type subscriptionAddItem struct {
+	PhaseKey       string
+	ItemKey        string
+	Price          *productcatalog.Price
+	BillingCadence *datetime.ISODuration
+	FeatureKey     string
+	TaxConfig      *productcatalog.TaxConfig
+}
+
+func (i subscriptionAddItem) AsPatch() subscription.Patch {
+	var rc productcatalog.RateCard
+
+	meta := productcatalog.RateCardMeta{
+		Name:       i.ItemKey,
+		Key:        i.ItemKey,
+		Price:      i.Price,
+		FeatureKey: lo.EmptyableToPtr(i.FeatureKey),
+		TaxConfig:  i.TaxConfig,
+	}
+
+	switch {
+	case i.Price == nil:
+		rc = &productcatalog.FlatFeeRateCard{
+			RateCardMeta:   meta,
+			BillingCadence: i.BillingCadence,
+		}
+	case i.Price.Type() == productcatalog.FlatPriceType:
+		rc = &productcatalog.FlatFeeRateCard{
+			RateCardMeta:   meta,
+			BillingCadence: i.BillingCadence,
+		}
+	default:
+		rc = &productcatalog.UsageBasedRateCard{
+			RateCardMeta:   meta,
+			BillingCadence: *i.BillingCadence,
+		}
+	}
+
+	return patch.PatchAddItem{
+		PhaseKey: i.PhaseKey,
+		ItemKey:  i.ItemKey,
+		CreateInput: subscription.SubscriptionItemSpec{
+			CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+				CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+					PhaseKey: i.PhaseKey,
+					ItemKey:  i.ItemKey,
+					RateCard: rc,
+				},
+			},
+		},
+	}
+}
+
+func (s *SuiteBase) generatePeriods(startStr, endStr string, cadenceStr string, n int) []billing.Period { //nolint: unparam
+	start := testutils.GetRFC3339Time(s.T(), startStr)
+	end := testutils.GetRFC3339Time(s.T(), endStr)
+	cadence := datetime.MustParseDuration(s.T(), cadenceStr)
+
+	out := []billing.Period{}
+
+	for n != 0 {
+		out = append(out, billing.Period{
+			Start: start,
+			End:   end,
+		})
+
+		start, _ = cadence.AddTo(start)
+		end, _ = cadence.AddTo(end)
+
+		n--
+	}
+	return out
+}
+
+// populateChildIDsFromParents copies over the child ID from the parent line, if it's not already set
+// as line splitting doesn't set the child ID on child lines to prevent conflicts if multiple split lines
+// end up on a single invoice.
+func (s *SuiteBase) populateChildIDsFromParents(invoice *billing.Invoice) {
+	for _, line := range invoice.Lines.OrEmpty() {
+		if line.ChildUniqueReferenceID == nil && line.SplitLineGroupID != nil {
+			line.ChildUniqueReferenceID = line.SplitLineHierarchy.Group.UniqueReferenceID
+		}
+	}
+}
+
+// helpers
+
+func (s *SuiteBase) createSubscriptionFromPlanPhases(phases []productcatalog.Phase) subscription.SubscriptionView {
+	planInput := plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: s.Namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Test Plan",
+				Key:            "test-plan",
+				Version:        1,
+				Currency:       currency.USD,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+				ProRatingConfig: productcatalog.ProRatingConfig{
+					Enabled: true,
+					Mode:    productcatalog.ProRatingModeProratePrices,
+				},
+			},
+			Phases: phases,
+		},
+	}
+
+	return s.createSubscriptionFromPlan(planInput)
+}
+
+func (s *SuiteBase) createSubscriptionFromPlan(planInput plan.CreatePlanInput) subscription.SubscriptionView {
+	ctx := s.T().Context()
+
+	plan, err := s.PlanService.CreatePlan(ctx, planInput)
+	s.NoError(err)
+
+	subscriptionPlan, err := s.SubscriptionPlanAdapter.GetVersion(ctx, s.Namespace, productcatalogsubscription.PlanRefInput{
+		Key:     plan.Key,
+		Version: lo.ToPtr(1),
+	})
+	s.NoError(err)
+
+	subsView, err := s.SubscriptionWorkflowService.CreateFromPlan(ctx, subscriptionworkflow.CreateSubscriptionWorkflowInput{
+		ChangeSubscriptionWorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+			Timing: subscription.Timing{
+				Custom: lo.ToPtr(clock.Now()),
+			},
+			Name: "subs-1",
+		},
+		Namespace:  s.Namespace,
+		CustomerID: s.Customer.ID,
+	}, subscriptionPlan)
+
+	s.NoError(err)
+	s.NotNil(subsView)
+	return subsView
+}

--- a/openmeter/billing/worker/subscription/syncbillinganchor_test.go
+++ b/openmeter/billing/worker/subscription/syncbillinganchor_test.go
@@ -1,0 +1,410 @@
+package billingworkersubscription
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/invopop/gobl/currency"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/entitlement"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	productcatalogsubscription "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+type BillingAnchorTestSuite struct {
+	SuiteBase
+}
+
+func TestBillingAnchor(t *testing.T) {
+	suite.Run(t, new(BillingAnchorTestSuite))
+}
+
+func (s *BillingAnchorTestSuite) SetupSuite() {
+	s.SuiteBase.SetupSuite()
+}
+
+func (s *BillingAnchorTestSuite) BeforeTest(suiteName, testName string) {
+	s.SuiteBase.BeforeTest(s.T().Context(), suiteName, testName)
+}
+
+func (s *BillingAnchorTestSuite) AfterTest(suiteName, testName string) {
+	s.SuiteBase.AfterTest(s.T().Context(), suiteName, testName)
+}
+
+func (s *BillingAnchorTestSuite) TestBillingAnchorSinglePhase() {
+	// Given we have a subscription:
+	//  - with a single usage based item
+	//  - an entitlement with a grant of 1000
+	//  - started at 2025-07-10T15:00:00Z
+	//  - billing anchor is at 2025-01-31T15:00:00Z
+	// When synchronizing the subscription up to 2025-09-29T15:00:00Z
+	// Then:
+	//  - the entitlement should be set up to be active from 2025-07-10T15:00:00Z,
+	//  - the first period should be 2025-07-10T15:00:00Z - 2025-07-31T15:00:00Z,
+	// Then:
+	//  - the gathering invoice should have the following service periods:
+	//    - 2025-07-10T15:00:00Z - 2025-07-31T15:00:00Z
+	//    - 2025-07-31T15:00:00Z - 2025-08-31T15:00:00Z
+	//    - 2025-08-31T15:00:00Z - 2025-09-30T15:00:00Z
+
+	ctx := s.T().Context()
+	defer clock.UnFreeze()
+	clock.FreezeTime(testutils.GetRFC3339Time(s.T(), "2025-06-30T15:00:00Z"))
+	billingAnchor := testutils.GetRFC3339Time(s.T(), "2025-01-31T15:00:00Z")
+
+	plan, err := s.PlanService.CreatePlan(ctx, plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: s.Namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Test Plan",
+				Key:            "test-plan",
+				Version:        1,
+				Currency:       currency.USD,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+				ProRatingConfig: productcatalog.ProRatingConfig{
+					Enabled: true,
+					Mode:    productcatalog.ProRatingModeProratePrices,
+				},
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: productcatalog.PhaseMeta{
+						Name: "first-phase",
+						Key:  "first-phase",
+					},
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Name:       "test-rate-card",
+								Key:        s.APIRequestsTotalFeature.Key,
+								FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+								Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+									Amount: alpacadecimal.NewFromFloat(100),
+								}),
+								EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.MeteredEntitlementTemplate{
+									IssueAfterReset: lo.ToPtr(1000.0),
+									UsagePeriod:     datetime.MustParseDuration(s.T(), "P1M"),
+								}),
+							},
+							BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), plan)
+
+	subscriptionPlan, err := s.SubscriptionPlanAdapter.GetVersion(ctx, s.Namespace, productcatalogsubscription.PlanRefInput{
+		Key:     plan.Key,
+		Version: lo.ToPtr(1),
+	})
+	s.NoError(err)
+
+	clock.FreezeTime(testutils.GetRFC3339Time(s.T(), "2025-07-10T15:00:00Z"))
+	subsView, err := s.SubscriptionWorkflowService.CreateFromPlan(ctx, subscriptionworkflow.CreateSubscriptionWorkflowInput{
+		ChangeSubscriptionWorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+			Timing: subscription.Timing{
+				Enum: lo.ToPtr(subscription.TimingImmediate),
+			},
+			Name: "subs-1",
+		},
+		Namespace:     s.Namespace,
+		CustomerID:    s.Customer.ID,
+		BillingAnchor: lo.ToPtr(billingAnchor),
+	}, subscriptionPlan)
+	s.NoError(err)
+	s.NotNil(subsView)
+
+	// Subscription retains the billing anchor
+	s.Equal(billingAnchor, subsView.Subscription.BillingAnchor)
+
+	// When synchronizing the subscription up to 2025-09-30T15:00:00Z
+	s.NoError(s.Handler.SyncronizeSubscription(ctx, subsView, testutils.GetRFC3339Time(s.T(), "2025-09-29T15:00:00Z")))
+
+	// Then:
+	//  - the entitlement should be set up to be active from 2025-07-10T15:00:00Z,
+	//  - the first period should be 2025-07-10T15:00:00Z - 2025-07-31T15:00:00Z,
+	ents, err := s.EntitlementConnector.ListEntitlements(ctx, entitlement.ListEntitlementsParams{
+		Namespaces:  []string{s.Namespace},
+		SubjectKeys: s.Customer.UsageAttribution.SubjectKeys,
+		FeatureKeys: []string{s.APIRequestsTotalFeature.Key},
+	})
+	s.NoError(err)
+	s.Equal(1, len(ents.Items))
+	ent := ents.Items[0]
+
+	// Assert the entitlement periods
+	s.Equal(testutils.GetRFC3339Time(s.T(), "2025-07-10T15:00:00Z"), ent.ActiveFromTime())
+	s.Equal(testutils.GetRFC3339Time(s.T(), "2025-07-10T15:00:00Z"), ent.MeasureUsageFrom.In(time.UTC))
+	s.Equal(testutils.GetRFC3339Time(s.T(), "2025-01-31T15:00:00Z"), *ent.OriginalUsagePeriodAnchor)
+	s.Equal(timeutil.ClosedPeriod{
+		From: testutils.GetRFC3339Time(s.T(), "2025-07-10T15:00:00Z"),
+		To:   testutils.GetRFC3339Time(s.T(), "2025-07-31T15:00:00Z"),
+	}, *ent.CurrentUsagePeriod)
+
+	//  - the gathering invoice should have the following service periods:
+	//    - 2025-07-10T15:00:00Z - 2025-07-31T15:00:00Z
+	//    - 2025-07-31T15:00:00Z - 2025-08-31T15:00:00Z
+	//    - 2025-08-31T15:00:00Z - 2025-09-30T15:00:00Z
+
+	invoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+
+	s.expectLines(invoice, subsView.Subscription.ID, []expectedLine{
+		{
+			Matcher: recurringLineMatcher{
+				PhaseKey: "first-phase",
+				ItemKey:  s.APIRequestsTotalFeature.Key,
+			},
+			Periods: []billing.Period{
+				{
+					Start: testutils.GetRFC3339Time(s.T(), "2025-07-10T15:00:00Z"),
+					End:   testutils.GetRFC3339Time(s.T(), "2025-07-31T15:00:00Z"),
+				},
+			},
+			InvoiceAt: mo.Some([]time.Time{
+				testutils.GetRFC3339Time(s.T(), "2025-07-31T15:00:00Z"),
+			}),
+		},
+		{
+			Matcher: recurringLineMatcher{
+				PhaseKey:  "first-phase",
+				ItemKey:   s.APIRequestsTotalFeature.Key,
+				PeriodMin: 1,
+				PeriodMax: 2,
+			},
+			Periods: []billing.Period{
+				{
+					Start: testutils.GetRFC3339Time(s.T(), "2025-07-31T15:00:00Z"),
+					End:   testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
+				},
+				{
+					Start: testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
+					End:   testutils.GetRFC3339Time(s.T(), "2025-09-30T15:00:00Z"),
+				},
+			},
+			InvoiceAt: mo.Some([]time.Time{
+				testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
+				testutils.GetRFC3339Time(s.T(), "2025-09-30T15:00:00Z"),
+			}),
+		},
+	})
+}
+
+func (s *BillingAnchorTestSuite) TestBillingAnchorMultiPhase() {
+	// Given we have a subscription:
+	//  - phases:
+	//    - first phase:
+	//		- not billable, 1 month long
+	//      - an entitlement with a grant of 1000
+	//    - second phase:
+	//		- billable, 1 month long billing cadence
+	//		- an entitlement with a grant of 1000
+	//  - started at 2025-07-10T15:00:00Z
+	//  - billing anchor is at 2025-01-31T15:00:00Z
+	// When synchronizing the subscription up to 2025-09-29T15:00:00Z
+	// Then:
+	//  - there are two entitlements for each phase
+	//  	- free phase entitlement:
+	// 			- from 2025-07-10T15:00:00Z to 2025-08-10T15:00:00Z
+	// 			- the first period should be 2025-07-10T15:00:00Z - 2025-07-31T15:00:00Z
+	//  	- billed phase entitlement:
+	// 			- from 2025-08-10T15:00:00Z
+	// 			- the first period should be 2025-08-10T15:00:00Z - 2025-08-31T15:00:00Z
+	// Then:
+	//  - the gathering invoice should have the following service periods:
+	//    - 2025-08-10T15:00:00Z - 2025-08-31T15:00:00Z
+	//    - 2025-08-31T15:00:00Z - 2025-09-30T15:00:00Z
+
+	ctx := s.T().Context()
+	defer clock.UnFreeze()
+	clock.FreezeTime(testutils.GetRFC3339Time(s.T(), "2025-06-30T15:00:00Z"))
+	billingAnchor := testutils.GetRFC3339Time(s.T(), "2025-01-31T15:00:00Z")
+
+	plan, err := s.PlanService.CreatePlan(ctx, plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: s.Namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Test Plan",
+				Key:            "test-plan",
+				Version:        1,
+				Currency:       currency.USD,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+				ProRatingConfig: productcatalog.ProRatingConfig{
+					Enabled: true,
+					Mode:    productcatalog.ProRatingModeProratePrices,
+				},
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: productcatalog.PhaseMeta{
+						Name:     "not-billable-phase",
+						Key:      "not-billable-phase",
+						Duration: lo.ToPtr(datetime.MustParseDuration(s.T(), "P1M")),
+					},
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Name:       "test-rate-card",
+								Key:        s.APIRequestsTotalFeature.Key,
+								FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+								EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.MeteredEntitlementTemplate{
+									IssueAfterReset: lo.ToPtr(1000.0),
+									UsagePeriod:     datetime.MustParseDuration(s.T(), "P1M"),
+								}),
+							},
+							BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+						},
+					},
+				},
+				{
+					PhaseMeta: productcatalog.PhaseMeta{
+						Name: "billable-phase",
+						Key:  "billable-phase",
+					},
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Name:       "test-rate-card",
+								Key:        s.APIRequestsTotalFeature.Key,
+								FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+								Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+									Amount: alpacadecimal.NewFromFloat(100),
+								}),
+								EntitlementTemplate: productcatalog.NewEntitlementTemplateFrom(productcatalog.MeteredEntitlementTemplate{
+									IssueAfterReset: lo.ToPtr(1000.0),
+									UsagePeriod:     datetime.MustParseDuration(s.T(), "P1M"),
+								}),
+							},
+							BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), plan)
+
+	subscriptionPlan, err := s.SubscriptionPlanAdapter.GetVersion(ctx, s.Namespace, productcatalogsubscription.PlanRefInput{
+		Key:     plan.Key,
+		Version: lo.ToPtr(1),
+	})
+	s.NoError(err)
+
+	clock.FreezeTime(testutils.GetRFC3339Time(s.T(), "2025-07-10T15:00:00Z"))
+	subsView, err := s.SubscriptionWorkflowService.CreateFromPlan(ctx, subscriptionworkflow.CreateSubscriptionWorkflowInput{
+		ChangeSubscriptionWorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+			Timing: subscription.Timing{
+				Enum: lo.ToPtr(subscription.TimingImmediate),
+			},
+			Name: "subs-1",
+		},
+		Namespace:     s.Namespace,
+		CustomerID:    s.Customer.ID,
+		BillingAnchor: lo.ToPtr(billingAnchor),
+	}, subscriptionPlan)
+	s.NoError(err)
+	s.NotNil(subsView)
+
+	// Subscription retains the billing anchor
+	s.Equal(billingAnchor, subsView.Subscription.BillingAnchor)
+
+	// When synchronizing the subscription up to 2025-09-30T15:00:00Z
+	s.NoError(s.Handler.SyncronizeSubscription(ctx, subsView, testutils.GetRFC3339Time(s.T(), "2025-09-29T15:00:00Z")))
+
+	// Then:
+	//  - the entitlement should be set up to be active from 2025-07-10T15:00:00Z,
+	//  - the first period should be 2025-07-10T15:00:00Z - 2025-07-31T15:00:00Z,
+	ents, err := s.EntitlementConnector.ListEntitlements(ctx, entitlement.ListEntitlementsParams{
+		Namespaces:  []string{s.Namespace},
+		SubjectKeys: s.Customer.UsageAttribution.SubjectKeys,
+		FeatureKeys: []string{s.APIRequestsTotalFeature.Key},
+	})
+	s.NoError(err)
+	slices.SortFunc(ents.Items, func(a, b entitlement.Entitlement) int {
+		return a.ActiveFromTime().Compare(b.ActiveFromTime())
+	})
+	s.Equal(2, len(ents.Items))
+	freePhaseEntitlement := ents.Items[0]
+	billedPhaseEntitlement := ents.Items[1]
+
+	// Assert the entitlement periods
+	s.Equal(testutils.GetRFC3339Time(s.T(), "2025-07-10T15:00:00Z"), freePhaseEntitlement.ActiveFromTime())
+	s.Equal(testutils.GetRFC3339Time(s.T(), "2025-08-10T15:00:00Z"), *freePhaseEntitlement.ActiveToTime())
+	s.Equal(testutils.GetRFC3339Time(s.T(), "2025-07-10T15:00:00Z"), freePhaseEntitlement.MeasureUsageFrom.In(time.UTC))
+	s.Equal(testutils.GetRFC3339Time(s.T(), "2025-01-31T15:00:00Z"), *freePhaseEntitlement.OriginalUsagePeriodAnchor)
+	s.Equal(timeutil.ClosedPeriod{
+		From: testutils.GetRFC3339Time(s.T(), "2025-07-10T15:00:00Z"),
+		To:   testutils.GetRFC3339Time(s.T(), "2025-07-31T15:00:00Z"),
+	}, *freePhaseEntitlement.CurrentUsagePeriod)
+
+	s.Equal(testutils.GetRFC3339Time(s.T(), "2025-08-10T15:00:00Z"), billedPhaseEntitlement.ActiveFromTime())
+	s.Equal(testutils.GetRFC3339Time(s.T(), "2025-08-10T15:00:00Z"), billedPhaseEntitlement.MeasureUsageFrom.In(time.UTC))
+	s.Equal(testutils.GetRFC3339Time(s.T(), "2025-01-31T15:00:00Z"), *billedPhaseEntitlement.OriginalUsagePeriodAnchor)
+	s.Equal(timeutil.ClosedPeriod{
+		From: testutils.GetRFC3339Time(s.T(), "2025-08-10T15:00:00Z"),
+		To:   testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
+	}, *billedPhaseEntitlement.CurrentUsagePeriod)
+
+	//  - the gathering invoice should have the following service periods:
+	//    - 2025-08-10T15:00:00Z - 2025-08-31T15:00:00Z
+	//    - 2025-08-31T15:00:00Z - 2025-09-30T15:00:00Z
+
+	invoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+
+	s.expectLines(invoice, subsView.Subscription.ID, []expectedLine{
+		{
+			Matcher: recurringLineMatcher{
+				PhaseKey: "billable-phase",
+				ItemKey:  s.APIRequestsTotalFeature.Key,
+			},
+			Periods: []billing.Period{
+				{
+					Start: testutils.GetRFC3339Time(s.T(), "2025-08-10T15:00:00Z"),
+					End:   testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
+				},
+			},
+			InvoiceAt: mo.Some([]time.Time{
+				testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
+			}),
+		},
+		{
+			Matcher: recurringLineMatcher{
+				PhaseKey:  "billable-phase",
+				ItemKey:   s.APIRequestsTotalFeature.Key,
+				PeriodMin: 1,
+				PeriodMax: 1,
+			},
+			Periods: []billing.Period{
+				{
+					Start: testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
+					End:   testutils.GetRFC3339Time(s.T(), "2025-09-30T15:00:00Z"),
+				},
+			},
+			InvoiceAt: mo.Some([]time.Time{
+				testutils.GetRFC3339Time(s.T(), "2025-09-30T15:00:00Z"),
+			}),
+		},
+	})
+}

--- a/openmeter/subscription/errors.go
+++ b/openmeter/subscription/errors.go
@@ -66,14 +66,6 @@ var ErrSubscriptionBillingAnchorIsRequired = models.NewValidationIssue(
 	models.WithFieldString("billingAnchor"),
 )
 
-const ErrCodeSubscriptionBillingAnchorIsInvalid models.ErrorCode = "subscription_billing_anchor_is_invalid"
-
-var ErrSubscriptionBillingAnchorIsInvalid = models.NewValidationIssue(
-	ErrCodeSubscriptionBillingAnchorIsInvalid,
-	"billing anchor must be before subscription start and normalized to the closest iteration before subscription start",
-	models.WithFieldString("billingAnchor"),
-)
-
 // Phase
 
 const ErrCodeSubscriptionPhaseStartAfterIsNegative models.ErrorCode = "subscription_phase_start_after_is_negative"

--- a/openmeter/subscription/errors_test.go
+++ b/openmeter/subscription/errors_test.go
@@ -197,15 +197,9 @@ func TestSubscriptionSpecValidation(t *testing.T) {
 		byts, err := json.MarshalIndent(exts, "", "  ")
 		require.NoError(t, err)
 
-		require.Len(t, issues, 5, "got %s", string(byts))
+		require.Len(t, issues, 4, "got %s", string(byts))
 
 		require.ElementsMatch(t, []models.ErrorExtension{
-			{
-				"code":     subscription.ErrCodeSubscriptionBillingAnchorIsInvalid,
-				"field":    models.NewFieldSelectors(models.NewFieldSelector("billingAnchor")),
-				"message":  "billing anchor must be before subscription start and normalized to the closest iteration before subscription start",
-				"severity": "critical",
-			},
 			{
 				"code": subscription.ErrCodeSubscriptionPhaseStartAfterIsNegative,
 				"field": models.NewFieldSelectors(
@@ -274,12 +268,6 @@ func TestSubscriptionSpecValidation(t *testing.T) {
 			exts := mappedIssues.AsErrorExtensions()
 
 			require.ElementsMatch(t, []models.ErrorExtension{
-				{
-					"code":     subscription.ErrCodeSubscriptionBillingAnchorIsInvalid,
-					"field":    models.NewFieldSelectors(models.NewFieldSelector("billingAnchor")),
-					"message":  "billing anchor must be before subscription start and normalized to the closest iteration before subscription start",
-					"severity": "critical",
-				},
 				{
 					"code": subscription.ErrCodeSubscriptionPhaseStartAfterIsNegative,
 					"field": models.NewFieldSelectors(

--- a/openmeter/subscription/subscriptionspec.go
+++ b/openmeter/subscription/subscriptionspec.go
@@ -301,15 +301,6 @@ func (s *SubscriptionSpec) Validate() error {
 		errs = append(errs, ErrSubscriptionBillingAnchorIsRequired)
 	}
 
-	// - is normalized to the closest iteration before subscriptiion start
-	if s.BillingAnchor.After(s.ActiveFrom) {
-		errs = append(errs, ErrSubscriptionBillingAnchorIsInvalid)
-	}
-
-	if next, _ := s.BillingCadence.AddTo(s.BillingAnchor); next.Before(s.ActiveFrom) {
-		errs = append(errs, ErrSubscriptionBillingAnchorIsInvalid)
-	}
-
 	sortedPhases := s.GetSortedPhases()
 	for idx, phase := range sortedPhases {
 		// Let's validate that if there are phases with the same start time, they have sort hint present

--- a/openmeter/subscription/workflow/service/subscription.go
+++ b/openmeter/subscription/workflow/service/subscription.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
-	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 func (s *service) CreateFromPlan(ctx context.Context, inp subscriptionworkflow.CreateSubscriptionWorkflowInput, plan subscription.Plan) (subscription.SubscriptionView, error) {
@@ -51,16 +50,6 @@ func (s *service) CreateFromPlan(ctx context.Context, inp subscriptionworkflow.C
 
 		// Let's normalize the billing anchor to the closest iteration based on the cadence
 		billingAnchor := lo.FromPtrOr(inp.BillingAnchor, activeFrom).UTC()
-
-		billingRecurrence, err := timeutil.NewRecurrenceFromISODuration(plan.ToCreateSubscriptionPlanInput().BillingCadence, billingAnchor)
-		if err != nil {
-			return def, fmt.Errorf("failed to get billing recurrence: %w", err)
-		}
-
-		billingAnchor, err = billingRecurrence.PrevBefore(activeFrom, timeutil.Inclusive)
-		if err != nil {
-			return def, fmt.Errorf("failed to get billing anchor: %w", err)
-		}
 
 		// Let's create the new Spec
 		spec, err := subscription.NewSpecFromPlan(plan, subscription.CreateSubscriptionCustomerInput{

--- a/test/billing/subscription_suite.go
+++ b/test/billing/subscription_suite.go
@@ -52,6 +52,7 @@ type SubscriptionMixin struct {
 	SubscriptionAddonService    subscriptionaddon.Service
 	SubscriptionPlanAdapter     subscriptiontestutils.PlanSubscriptionAdapter
 	SubscriptionWorkflowService subscriptionworkflow.Service
+	EntitlementConnector        entitlement.Connector
 }
 
 type SubscriptionMixInDependencies struct {
@@ -120,6 +121,8 @@ func (s *SubscriptionMixin) SetupSuite(t *testing.T, deps SubscriptionMixInDepen
 	subsRepo := subscriptionrepo.NewSubscriptionRepo(deps.DBClient)
 	subsItemRepo := subscriptionrepo.NewSubscriptionItemRepo(deps.DBClient)
 
+	s.EntitlementConnector = s.SetupEntitlements(t, deps)
+
 	s.SubscriptionService = subscriptionservice.New(subscriptionservice.ServiceConfig{
 		SubscriptionRepo:      subsRepo,
 		SubscriptionPhaseRepo: subscriptionrepo.NewSubscriptionPhaseRepo(deps.DBClient),
@@ -129,7 +132,7 @@ func (s *SubscriptionMixin) SetupSuite(t *testing.T, deps SubscriptionMixInDepen
 		FeatureService:  deps.FeatureService,
 		// adapters
 		EntitlementAdapter: subscriptionentitlementadatapter.NewSubscriptionEntitlementAdapter(
-			s.SetupEntitlements(t, deps),
+			s.EntitlementConnector,
 			subsItemRepo,
 			subsRepo,
 		),


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview


As normalizing the billing anchor could move the anchor a few days (if
it is on > 28th day of a month)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified billing anchor handling: the anchor is preserved as provided without normalization or pre-start validation. Subscription creation no longer derives cadence dynamically from plans.
* **Tests**
  * Introduced a shared subscription test suite base to standardize setup and lifecycle.
  * Migrated subscription sync tests to the new harness.
  * Added integration tests for billing anchors (single- and multi-phase), validating entitlements and invoice periods.
* **Bug Fixes**
  * Removed an invalid-billing-anchor error path, reducing false validation failures for subscription setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->