### PR TITLE
feat(pc): add duplicated phase key error

### DIFF
--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -454,6 +454,15 @@ var ErrPlanPhaseDurationLessThenAnHour = models.NewValidationIssue(
 	models.WithWarningSeverity(),
 )
 
+const ErrCodePlanPhaseDuplicatedKey models.ErrorCode = "plan_phase_duplicated_key"
+
+var ErrPlanPhaseDuplicatedKey = models.NewValidationIssue(
+	ErrCodePlanPhaseDuplicatedKey,
+	"duplicated key",
+	models.WithFieldString("key"),
+	models.WithCriticalSeverity(),
+)
+
 const ErrCodePlanInvalidStatus models.ErrorCode = "plan_invalid_status"
 
 var ErrPlanInvalidStatus = models.NewValidationIssue(


### PR DESCRIPTION
## Overview

Return validation error if plan is created/updated with phases that have duplicated key which must be unique.
