### PR TITLE
refactor(billing): use interface based parent relationships

### DIFF
--- a/openmeter/billing/adapter/invoicelinediff.go
+++ b/openmeter/billing/adapter/invoicelinediff.go
@@ -91,8 +91,8 @@ func getParentIDAsSlice(e entityParent) []string {
 }
 
 type withParent[T any, P entityParent] struct {
-	Discount T
-	Parent   P
+	Entity T
+	Parent P
 }
 
 type (
@@ -423,15 +423,15 @@ func handleLineDiscounts[T diffable[T], P entityParent](items []T, dbItems []T, 
 	case operationCreate:
 		for _, discount := range items {
 			out.diff.NeedsCreate(withParent[T, P]{
-				Discount: discount,
-				Parent:   parentLine,
+				Entity: discount,
+				Parent: parentLine,
 			})
 		}
 	case operationDelete:
 		for _, discount := range items {
 			out.diff.NeedsDelete(withParent[T, P]{
-				Discount: discount,
-				Parent:   parentLine,
+				Entity: discount,
+				Parent: parentLine,
 			})
 		}
 	case operationUpdate:
@@ -471,8 +471,8 @@ func handleLineDiscountUpdate[T diffable[T], P entityParent](items []T, dbItems 
 		if _, ok := currentDiscountIDs[dbDiscount.GetID()]; !ok {
 			// We need to delete this discount
 			out.NeedsDelete(withParent[T, P]{
-				Discount: dbDiscount,
-				Parent:   line,
+				Entity: dbDiscount,
+				Parent: line,
 			})
 		}
 	}
@@ -481,8 +481,8 @@ func handleLineDiscountUpdate[T diffable[T], P entityParent](items []T, dbItems 
 		if currentDiscount.GetID() == "" {
 			// We need to create this discount
 			out.NeedsCreate(withParent[T, P]{
-				Discount: currentDiscount,
-				Parent:   line,
+				Entity: currentDiscount,
+				Parent: line,
 			})
 
 			continue
@@ -495,8 +495,8 @@ func handleLineDiscountUpdate[T diffable[T], P entityParent](items []T, dbItems 
 
 		if !dbDiscount.ContentsEqual(currentDiscount) {
 			out.NeedsUpdate(withParent[T, P]{
-				Discount: currentDiscount,
-				Parent:   line,
+				Entity: currentDiscount,
+				Parent: line,
 			})
 		}
 	}

--- a/openmeter/billing/adapter/invoicelinediff.go
+++ b/openmeter/billing/adapter/invoicelinediff.go
@@ -61,14 +61,43 @@ func (d *diff[T]) IsEmpty() bool {
 	return len(d.ToDelete) == 0 && len(d.ToUpdate) == 0 && len(d.ToCreate) == 0
 }
 
-type withLine[T any] struct {
+type entityParent interface {
+	// Get the ID of the parent entity
+	GetID() string
+	// Get the parent ID of the parent (if available)
+	GetParentID() (string, bool)
+}
+
+func getIDAndParentID(e entityParent) []string {
+	out := make([]string, 0, 2)
+
+	if e.GetID() != "" {
+		out = append(out, e.GetID())
+	}
+
+	if parentID, ok := e.GetParentID(); ok {
+		out = append(out, parentID)
+	}
+
+	return out
+}
+
+func getParentIDAsSlice(e entityParent) []string {
+	if parentID, ok := e.GetParentID(); ok {
+		return []string{parentID}
+	}
+
+	return nil
+}
+
+type withParent[T any, P entityParent] struct {
 	Discount T
-	Line     *billing.Line
+	Parent   P
 }
 
 type (
-	usageLineDiscountMangedWithLine  = withLine[billing.UsageLineDiscountManaged]
-	amountLineDiscountMangedWithLine = withLine[billing.AmountLineDiscountManaged]
+	usageLineDiscountMangedWithLine  = withParent[billing.UsageLineDiscountManaged, *billing.Line]
+	amountLineDiscountMangedWithLine = withParent[billing.AmountLineDiscountManaged, *billing.Line]
 )
 
 type invoiceLineDiff struct {
@@ -224,7 +253,7 @@ func diffLineBaseEntities(line *billing.Line, out *invoiceLineDiff) error {
 		case (line.DBState.LineBase.DeletedAt == nil) && (line.LineBase.DeletedAt != nil):
 			// The line got deleted
 			out.LineBase.NeedsDelete(line)
-			out.AffectedLineIDs.Add(lineParentIDs(line, lineIDExcludeSelf)...)
+			out.AffectedLineIDs.Add(getParentIDAsSlice(line)...)
 
 			if line.Children.IsPresent() {
 				// We need to delete the children as well
@@ -271,7 +300,7 @@ func diffLineBaseEntities(line *billing.Line, out *invoiceLineDiff) error {
 	if baseNeedsUpdate {
 		out.LineBase.NeedsUpdate(line)
 
-		out.AffectedLineIDs.Add(lineParentIDs(line, lineIDExcludeSelf)...)
+		out.AffectedLineIDs.Add(getParentIDAsSlice(line)...)
 	}
 
 	return handleLineDependantEntities(line, operationUpdate, out)
@@ -296,7 +325,7 @@ func getChildrenActions(dbSave []*billing.Line, current []*billing.Line, out *in
 			}
 
 			// Deleting a child is considered an update for the parent
-			out.AffectedLineIDs.Add(lineParentIDs(dbLine, lineIDExcludeSelf)...)
+			out.AffectedLineIDs.Add(getParentIDAsSlice(dbLine)...)
 		}
 	}
 
@@ -313,7 +342,7 @@ func getChildrenActions(dbSave []*billing.Line, current []*billing.Line, out *in
 			}
 
 			// Adding a child is considered an update for the parent even if the db line of parent has not changed
-			out.AffectedLineIDs.Add(lineParentIDs(currentLine, lineIDExcludeSelf)...)
+			out.AffectedLineIDs.Add(getParentIDAsSlice(currentLine)...)
 			continue
 		}
 
@@ -341,7 +370,7 @@ func deleteLineChildren(line *billing.Line, out *invoiceLineDiff) error {
 			return err
 		}
 
-		out.ChildrenDiff.AffectedLineIDs.Add(lineParentIDs(child, lineIDExcludeSelf)...)
+		out.ChildrenDiff.AffectedLineIDs.Add(getParentIDAsSlice(child)...)
 	}
 
 	return nil
@@ -380,48 +409,48 @@ type diffable[T any] interface {
 	ContentsEqual(other T) bool
 }
 
-type handleLineDiscountsResult[T diffable[T]] struct {
-	diff            diff[withLine[T]]
+type handleLineDiscountsResult[T diffable[T], P entityParent] struct {
+	diff            diff[withParent[T, P]]
 	affectedLineIDs []string
 }
 
-func handleLineDiscounts[T diffable[T]](items []T, dbItems []T, lineOperation operation, line *billing.Line) (handleLineDiscountsResult[T], error) {
-	out := handleLineDiscountsResult[T]{
-		diff: diff[withLine[T]]{},
+func handleLineDiscounts[T diffable[T], P entityParent](items []T, dbItems []T, lineOperation operation, parentLine P) (handleLineDiscountsResult[T, P], error) {
+	out := handleLineDiscountsResult[T, P]{
+		diff: diff[withParent[T, P]]{},
 	}
 
 	switch lineOperation {
 	case operationCreate:
 		for _, discount := range items {
-			out.diff.NeedsCreate(withLine[T]{
+			out.diff.NeedsCreate(withParent[T, P]{
 				Discount: discount,
-				Line:     line,
+				Parent:   parentLine,
 			})
 		}
 	case operationDelete:
 		for _, discount := range items {
-			out.diff.NeedsDelete(withLine[T]{
+			out.diff.NeedsDelete(withParent[T, P]{
 				Discount: discount,
-				Line:     line,
+				Parent:   parentLine,
 			})
 		}
 	case operationUpdate:
-		updateDiffs, err := handleLineDiscountUpdate(items, dbItems, line)
+		updateDiffs, err := handleLineDiscountUpdate(items, dbItems, parentLine)
 		if err != nil {
 			return out, err
 		}
 
 		out.diff = updateDiffs
 		if !updateDiffs.IsEmpty() {
-			out.affectedLineIDs = lineParentIDs(line, lineIDIncludeSelf)
+			out.affectedLineIDs = getIDAndParentID(parentLine)
 		}
 	}
 
 	return out, nil
 }
 
-func handleLineDiscountUpdate[T diffable[T]](items []T, dbItems []T, line *billing.Line) (diff[withLine[T]], error) {
-	out := diff[withLine[T]]{}
+func handleLineDiscountUpdate[T diffable[T], P entityParent](items []T, dbItems []T, line P) (diff[withParent[T, P]], error) {
+	out := diff[withParent[T, P]]{}
 
 	// We need to figure out what we need to update
 	currentDiscountIDs := map[string]T{}
@@ -441,9 +470,9 @@ func handleLineDiscountUpdate[T diffable[T]](items []T, dbItems []T, line *billi
 	for _, dbDiscount := range dbDiscountIDs {
 		if _, ok := currentDiscountIDs[dbDiscount.GetID()]; !ok {
 			// We need to delete this discount
-			out.NeedsDelete(withLine[T]{
+			out.NeedsDelete(withParent[T, P]{
 				Discount: dbDiscount,
-				Line:     line,
+				Parent:   line,
 			})
 		}
 	}
@@ -451,9 +480,9 @@ func handleLineDiscountUpdate[T diffable[T]](items []T, dbItems []T, line *billi
 	for _, currentDiscount := range items {
 		if currentDiscount.GetID() == "" {
 			// We need to create this discount
-			out.NeedsCreate(withLine[T]{
+			out.NeedsCreate(withParent[T, P]{
 				Discount: currentDiscount,
-				Line:     line,
+				Parent:   line,
 			})
 
 			continue
@@ -465,44 +494,12 @@ func handleLineDiscountUpdate[T diffable[T]](items []T, dbItems []T, line *billi
 		}
 
 		if !dbDiscount.ContentsEqual(currentDiscount) {
-			out.NeedsUpdate(withLine[T]{
+			out.NeedsUpdate(withParent[T, P]{
 				Discount: currentDiscount,
-				Line:     line,
+				Parent:   line,
 			})
 		}
 	}
 
 	return out, nil
-}
-
-type lineIDIncludeFlag int
-
-const (
-	lineIDIncludeSelf lineIDIncludeFlag = iota
-	lineIDExcludeSelf
-)
-
-func lineParentIDs(line *billing.Line, includeLineID lineIDIncludeFlag) []string {
-	out := make([]string, 0, 3)
-
-	if line == nil {
-		return out
-	}
-
-	if includeLineID == lineIDIncludeSelf {
-		out = append(out, line.ID)
-	}
-
-	currentLine := line
-	for currentLine != nil {
-		if currentLine.ParentLineID == nil {
-			break
-		}
-
-		out = append(out, *currentLine.ParentLineID)
-
-		currentLine = currentLine.ParentLine
-	}
-
-	return out
 }

--- a/openmeter/billing/adapter/invoicelinediff.go
+++ b/openmeter/billing/adapter/invoicelinediff.go
@@ -96,8 +96,8 @@ type withParent[T any, P entityParent] struct {
 }
 
 type (
-	usageLineDiscountMangedWithLine  = withParent[billing.UsageLineDiscountManaged, *billing.Line]
-	amountLineDiscountMangedWithLine = withParent[billing.AmountLineDiscountManaged, *billing.Line]
+	usageLineDiscountManagedWithLine  = withParent[billing.UsageLineDiscountManaged, *billing.Line]
+	amountLineDiscountManagedWithLine = withParent[billing.AmountLineDiscountManaged, *billing.Line]
 )
 
 type invoiceLineDiff struct {
@@ -106,8 +106,8 @@ type invoiceLineDiff struct {
 	UsageBased diff[*billing.Line]
 
 	// Dependant entities
-	UsageDiscounts  diff[usageLineDiscountMangedWithLine]
-	AmountDiscounts diff[amountLineDiscountMangedWithLine]
+	UsageDiscounts  diff[usageLineDiscountManagedWithLine]
+	AmountDiscounts diff[amountLineDiscountManagedWithLine]
 
 	// AffectedLineIDs contains the list of line IDs that are affected by the diff, even if they
 	// are not updated. We can use this to update the UpdatedAt of the lines if any of the dependant

--- a/openmeter/billing/adapter/invoicelinediff_test.go
+++ b/openmeter/billing/adapter/invoicelinediff_test.go
@@ -30,21 +30,27 @@ func TestInvoiceLineDiffing(t *testing.T) {
 	template := []*billing.Line{
 		{
 			LineBase: billing.LineBase{
-				ID:   "1",
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					ID: "1",
+				}),
 				Type: billing.InvoiceLineTypeFee,
 			},
 			FlatFee: &billing.FlatFeeLine{},
 		},
 		{
 			LineBase: billing.LineBase{
-				ID:   "2",
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					ID: "2",
+				}),
 				Type: billing.InvoiceLineTypeUsageBased,
 			},
 			UsageBased: &billing.UsageBasedLine{},
 			Children: billing.NewLineChildren([]*billing.Line{
 				{
 					LineBase: billing.LineBase{
-						ID:   "2.1",
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							ID: "2.1",
+						}),
 						Type: billing.InvoiceLineTypeFee,
 					},
 					FlatFee:   &billing.FlatFeeLine{},
@@ -52,7 +58,9 @@ func TestInvoiceLineDiffing(t *testing.T) {
 				},
 				{
 					LineBase: billing.LineBase{
-						ID:   "2.2",
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							ID: "2.2",
+						}),
 						Type: billing.InvoiceLineTypeFee,
 					},
 					FlatFee: &billing.FlatFeeLine{},
@@ -381,8 +389,8 @@ func mapLineDiffToIDs(in diff[*billing.Line]) idDiff {
 	}
 }
 
-func mapLineDiscountsToIDs(t *testing.T, discounts []withLine[billing.AmountLineDiscountManaged]) []string {
-	return lo.Map(discounts, func(d withLine[billing.AmountLineDiscountManaged], _ int) string {
+func mapLineDiscountsToIDs(t *testing.T, discounts []withParent[billing.AmountLineDiscountManaged, *billing.Line]) []string {
+	return lo.Map(discounts, func(d withParent[billing.AmountLineDiscountManaged, *billing.Line], _ int) string {
 		if d.Discount.Description != nil {
 			return *d.Discount.Description
 		}
@@ -391,7 +399,7 @@ func mapLineDiscountsToIDs(t *testing.T, discounts []withLine[billing.AmountLine
 	})
 }
 
-func mapLineDiscountDiffToIDs(t *testing.T, in diff[withLine[billing.AmountLineDiscountManaged]]) idDiff {
+func mapLineDiscountDiffToIDs(t *testing.T, in diff[withParent[billing.AmountLineDiscountManaged, *billing.Line]]) idDiff {
 	return idDiff{
 		ToCreate: mapLineDiscountsToIDs(t, in.ToCreate),
 		ToUpdate: mapLineDiscountsToIDs(t, in.ToUpdate),

--- a/openmeter/billing/adapter/invoicelinediff_test.go
+++ b/openmeter/billing/adapter/invoicelinediff_test.go
@@ -391,11 +391,11 @@ func mapLineDiffToIDs(in diff[*billing.Line]) idDiff {
 
 func mapLineDiscountsToIDs(t *testing.T, discounts []withParent[billing.AmountLineDiscountManaged, *billing.Line]) []string {
 	return lo.Map(discounts, func(d withParent[billing.AmountLineDiscountManaged, *billing.Line], _ int) string {
-		if d.Discount.Description != nil {
-			return *d.Discount.Description
+		if d.Entity.Description != nil {
+			return *d.Entity.Description
 		}
 
-		return d.Discount.GetID()
+		return d.Entity.GetID()
 	})
 }
 

--- a/openmeter/billing/adapter/invoicelinemapper.go
+++ b/openmeter/billing/adapter/invoicelinemapper.go
@@ -130,12 +130,15 @@ func (a *adapter) fetchInvoiceLineNewReferences(ctx context.Context, parentIDs [
 func (a *adapter) mapInvoiceLineWithoutReferences(dbLine *db.BillingInvoiceLine) (billing.Line, error) {
 	invoiceLine := billing.Line{
 		LineBase: billing.LineBase{
-			Namespace: dbLine.Namespace,
-			ID:        dbLine.ID,
-
-			CreatedAt: dbLine.CreatedAt.In(time.UTC),
-			UpdatedAt: dbLine.UpdatedAt.In(time.UTC),
-			DeletedAt: convert.TimePtrIn(dbLine.DeletedAt, time.UTC),
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace:   dbLine.Namespace,
+				ID:          dbLine.ID,
+				CreatedAt:   dbLine.CreatedAt.In(time.UTC),
+				UpdatedAt:   dbLine.UpdatedAt.In(time.UTC),
+				DeletedAt:   convert.TimePtrIn(dbLine.DeletedAt, time.UTC),
+				Name:        dbLine.Name,
+				Description: dbLine.Description,
+			}),
 
 			Metadata:    dbLine.Metadata,
 			Annotations: dbLine.Annotations,
@@ -153,9 +156,6 @@ func (a *adapter) mapInvoiceLineWithoutReferences(dbLine *db.BillingInvoiceLine)
 			ChildUniqueReferenceID: dbLine.ChildUniqueReferenceID,
 
 			InvoiceAt: dbLine.InvoiceAt.In(time.UTC),
-
-			Name:        dbLine.Name,
-			Description: dbLine.Description,
 
 			Type:     dbLine.Type,
 			Currency: dbLine.Currency,

--- a/openmeter/billing/adapter/invoicelines.go
+++ b/openmeter/billing/adapter/invoicelines.go
@@ -179,7 +179,7 @@ func (a *adapter) UpsertInvoiceLines(ctx context.Context, inputIn billing.Upsert
 		allUsageDiscountDiffs := unionOfDiffs(lineDiffs.UsageDiscounts, lineDiffs.ChildrenDiff.UsageDiscounts)
 		err = upsertWithOptions(ctx, tx.db, allUsageDiscountDiffs, upsertInput[usageLineDiscountMangedWithLine, *db.BillingInvoiceLineUsageDiscountCreate]{
 			Create: func(tx *db.Client, d usageLineDiscountMangedWithLine) (*db.BillingInvoiceLineUsageDiscountCreate, error) {
-				discount := d.Discount
+				discount := d.Entity
 
 				if discount.ID == "" {
 					discount.ID = ulid.Make().String()
@@ -213,7 +213,7 @@ func (a *adapter) UpsertInvoiceLines(ctx context.Context, inputIn billing.Upsert
 					).Exec(ctx)
 			},
 			MarkDeleted: func(ctx context.Context, d usageLineDiscountMangedWithLine) (usageLineDiscountMangedWithLine, error) {
-				d.Discount.DeletedAt = lo.ToPtr(clock.Now().In(time.UTC))
+				d.Entity.DeletedAt = lo.ToPtr(clock.Now().In(time.UTC))
 
 				return d, nil
 			},
@@ -225,7 +225,7 @@ func (a *adapter) UpsertInvoiceLines(ctx context.Context, inputIn billing.Upsert
 		allAmountDiscountDiffs := unionOfDiffs(lineDiffs.AmountDiscounts, lineDiffs.ChildrenDiff.AmountDiscounts)
 		err = upsertWithOptions(ctx, tx.db, allAmountDiscountDiffs, upsertInput[amountLineDiscountMangedWithLine, *db.BillingInvoiceLineDiscountCreate]{
 			Create: func(tx *db.Client, d amountLineDiscountMangedWithLine) (*db.BillingInvoiceLineDiscountCreate, error) {
-				discount := d.Discount
+				discount := d.Entity
 
 				if discount.ID == "" {
 					discount.ID = ulid.Make().String()
@@ -259,7 +259,7 @@ func (a *adapter) UpsertInvoiceLines(ctx context.Context, inputIn billing.Upsert
 					).Exec(ctx)
 			},
 			MarkDeleted: func(ctx context.Context, d amountLineDiscountMangedWithLine) (amountLineDiscountMangedWithLine, error) {
-				d.Discount.DeletedAt = lo.ToPtr(clock.Now().In(time.UTC))
+				d.Entity.DeletedAt = lo.ToPtr(clock.Now().In(time.UTC))
 
 				return d, nil
 			},

--- a/openmeter/billing/adapter/invoicelines.go
+++ b/openmeter/billing/adapter/invoicelines.go
@@ -187,8 +187,8 @@ func (a *adapter) UpsertInvoiceLines(ctx context.Context, inputIn billing.Upsert
 
 				create := tx.BillingInvoiceLineUsageDiscount.Create().
 					SetID(discount.ID).
-					SetNamespace(d.Line.Namespace).
-					SetLineID(d.Line.ID).
+					SetNamespace(d.Parent.GetNamespace()).
+					SetLineID(d.Parent.GetID()).
 					SetReason(discount.Reason.Type()).
 					SetReasonDetails(lo.ToPtr(discount.Reason)).
 					SetQuantity(discount.Quantity).
@@ -233,8 +233,8 @@ func (a *adapter) UpsertInvoiceLines(ctx context.Context, inputIn billing.Upsert
 
 				create := tx.BillingInvoiceLineDiscount.Create().
 					SetID(discount.ID).
-					SetNamespace(d.Line.Namespace).
-					SetLineID(d.Line.ID).
+					SetNamespace(d.Parent.GetNamespace()).
+					SetLineID(d.Parent.GetID()).
 					SetReason(discount.Reason.Type()).
 					SetSourceDiscount(lo.ToPtr(discount.Reason)).
 					SetAmount(discount.Amount).

--- a/openmeter/billing/adapter/invoicelines.go
+++ b/openmeter/billing/adapter/invoicelines.go
@@ -177,8 +177,8 @@ func (a *adapter) UpsertInvoiceLines(ctx context.Context, inputIn billing.Upsert
 		// Step 4a: Line Discounts
 
 		allUsageDiscountDiffs := unionOfDiffs(lineDiffs.UsageDiscounts, lineDiffs.ChildrenDiff.UsageDiscounts)
-		err = upsertWithOptions(ctx, tx.db, allUsageDiscountDiffs, upsertInput[usageLineDiscountMangedWithLine, *db.BillingInvoiceLineUsageDiscountCreate]{
-			Create: func(tx *db.Client, d usageLineDiscountMangedWithLine) (*db.BillingInvoiceLineUsageDiscountCreate, error) {
+		err = upsertWithOptions(ctx, tx.db, allUsageDiscountDiffs, upsertInput[usageLineDiscountManagedWithLine, *db.BillingInvoiceLineUsageDiscountCreate]{
+			Create: func(tx *db.Client, d usageLineDiscountManagedWithLine) (*db.BillingInvoiceLineUsageDiscountCreate, error) {
 				discount := d.Entity
 
 				if discount.ID == "" {
@@ -212,7 +212,7 @@ func (a *adapter) UpsertInvoiceLines(ctx context.Context, inputIn billing.Upsert
 						}),
 					).Exec(ctx)
 			},
-			MarkDeleted: func(ctx context.Context, d usageLineDiscountMangedWithLine) (usageLineDiscountMangedWithLine, error) {
+			MarkDeleted: func(ctx context.Context, d usageLineDiscountManagedWithLine) (usageLineDiscountManagedWithLine, error) {
 				d.Entity.DeletedAt = lo.ToPtr(clock.Now().In(time.UTC))
 
 				return d, nil
@@ -223,8 +223,8 @@ func (a *adapter) UpsertInvoiceLines(ctx context.Context, inputIn billing.Upsert
 		}
 
 		allAmountDiscountDiffs := unionOfDiffs(lineDiffs.AmountDiscounts, lineDiffs.ChildrenDiff.AmountDiscounts)
-		err = upsertWithOptions(ctx, tx.db, allAmountDiscountDiffs, upsertInput[amountLineDiscountMangedWithLine, *db.BillingInvoiceLineDiscountCreate]{
-			Create: func(tx *db.Client, d amountLineDiscountMangedWithLine) (*db.BillingInvoiceLineDiscountCreate, error) {
+		err = upsertWithOptions(ctx, tx.db, allAmountDiscountDiffs, upsertInput[amountLineDiscountManagedWithLine, *db.BillingInvoiceLineDiscountCreate]{
+			Create: func(tx *db.Client, d amountLineDiscountManagedWithLine) (*db.BillingInvoiceLineDiscountCreate, error) {
 				discount := d.Entity
 
 				if discount.ID == "" {
@@ -258,7 +258,7 @@ func (a *adapter) UpsertInvoiceLines(ctx context.Context, inputIn billing.Upsert
 						}),
 					).Exec(ctx)
 			},
-			MarkDeleted: func(ctx context.Context, d amountLineDiscountMangedWithLine) (amountLineDiscountMangedWithLine, error) {
+			MarkDeleted: func(ctx context.Context, d amountLineDiscountManagedWithLine) (amountLineDiscountManagedWithLine, error) {
 				d.Entity.DeletedAt = lo.ToPtr(clock.Now().In(time.UTC))
 
 				return d, nil

--- a/openmeter/billing/httpdriver/invoiceline.go
+++ b/openmeter/billing/httpdriver/invoiceline.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/equal"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/set"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
@@ -139,13 +140,15 @@ func mapCreateLineToEntity(line api.InvoicePendingLineCreate, ns string) (*billi
 
 	return &billing.Line{
 		LineBase: billing.LineBase{
-			Namespace: ns,
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace:   ns,
+				Name:        line.Name,
+				Description: line.Description,
+			}),
 
-			Metadata:    lo.FromPtrOr(line.Metadata, map[string]string{}),
-			Name:        line.Name,
-			Type:        billing.InvoiceLineTypeUsageBased,
-			Description: line.Description,
-			ManagedBy:   billing.ManuallyManagedLine,
+			Metadata:  lo.FromPtrOr(line.Metadata, map[string]string{}),
+			Type:      billing.InvoiceLineTypeUsageBased,
+			ManagedBy: billing.ManuallyManagedLine,
 
 			Status: billing.InvoiceLineStatusValid, // This is not settable from outside
 			Period: billing.Period{
@@ -547,12 +550,14 @@ func mapSimulationLineToEntity(line api.InvoiceSimulationLine) (*billing.Line, e
 
 	return &billing.Line{
 		LineBase: billing.LineBase{
-			ID:          lo.FromPtr(line.Id),
-			Metadata:    lo.FromPtrOr(line.Metadata, map[string]string{}),
-			Name:        line.Name,
-			Type:        billing.InvoiceLineTypeUsageBased,
-			Description: line.Description,
-			ManagedBy:   billing.ManuallyManagedLine,
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				ID:          lo.FromPtr(line.Id),
+				Name:        line.Name,
+				Description: line.Description,
+			}),
+			Metadata:  lo.FromPtrOr(line.Metadata, map[string]string{}),
+			Type:      billing.InvoiceLineTypeUsageBased,
+			ManagedBy: billing.ManuallyManagedLine,
 
 			Status: billing.InvoiceLineStatusValid,
 			Period: billing.Period{
@@ -588,13 +593,15 @@ func lineFromInvoiceLineReplaceUpdate(line api.InvoiceLineReplaceUpdate, invoice
 
 	return &billing.Line{
 		LineBase: billing.LineBase{
-			Namespace: invoice.Namespace,
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace:   invoice.Namespace,
+				Name:        line.Name,
+				Description: line.Description,
+			}),
 
-			Metadata:    lo.FromPtrOr(line.Metadata, map[string]string{}),
-			Name:        line.Name,
-			Description: line.Description,
-			ManagedBy:   billing.ManuallyManagedLine,
-			Status:      billing.InvoiceLineStatusValid,
+			Metadata:  lo.FromPtrOr(line.Metadata, map[string]string{}),
+			ManagedBy: billing.ManuallyManagedLine,
+			Status:    billing.InvoiceLineStatusValid,
 
 			Type: billing.InvoiceLineTypeUsageBased,
 

--- a/openmeter/billing/invoice_test.go
+++ b/openmeter/billing/invoice_test.go
@@ -6,25 +6,31 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 func TestSortLines(t *testing.T) {
 	lines := []*Line{
 		{
 			LineBase: LineBase{
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Name:        "usage-based-line",
+					Description: lo.ToPtr("index=1"),
+				}),
 				Type: InvoiceLineTypeUsageBased,
-				Name: "usage-based-line",
 				Period: Period{
 					Start: time.Now().Add(time.Hour * 24),
 				},
-				Description: lo.ToPtr("index=1"),
 			},
 			Children: NewLineChildren([]*Line{
 				{
 					LineBase: LineBase{
-						ID:          "child-2",
-						Type:        InvoiceLineTypeFee,
-						Description: lo.ToPtr("index=1.1"),
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Name:        "child-2",
+							Description: lo.ToPtr("index=1.1"),
+						}),
+						Type: InvoiceLineTypeFee,
 					},
 					FlatFee: &FlatFeeLine{
 						Index: lo.ToPtr(1),
@@ -32,9 +38,11 @@ func TestSortLines(t *testing.T) {
 				},
 				{
 					LineBase: LineBase{
-						ID:          "child-1",
-						Type:        InvoiceLineTypeFee,
-						Description: lo.ToPtr("index=1.0"),
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Name:        "child-1",
+							Description: lo.ToPtr("index=1.0"),
+						}),
+						Type: InvoiceLineTypeFee,
 					},
 					FlatFee: &FlatFeeLine{
 						Index: lo.ToPtr(0),
@@ -44,12 +52,14 @@ func TestSortLines(t *testing.T) {
 		},
 		{
 			LineBase: LineBase{
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Name:        "usage-based-line",
+					Description: lo.ToPtr("index=0"),
+				}),
 				Type: InvoiceLineTypeUsageBased,
-				Name: "usage-based-line",
 				Period: Period{
 					Start: time.Now(),
 				},
-				Description: lo.ToPtr("index=0"),
 			},
 			Children: NewLineChildren(nil),
 		},

--- a/openmeter/billing/invoiceline.go
+++ b/openmeter/billing/invoiceline.go
@@ -125,19 +125,12 @@ func (p Period) Duration() time.Duration {
 
 // LineBase represents the common fields for an invoice item.
 type LineBase struct {
-	Namespace string `json:"namespace,omitempty"`
-	ID        string `json:"id,omitempty"`
-
-	CreatedAt time.Time  `json:"createdAt"`
-	UpdatedAt time.Time  `json:"updatedAt"`
-	DeletedAt *time.Time `json:"deletedAt,omitempty"`
+	models.ManagedResource
 
 	Metadata    map[string]string    `json:"metadata,omitempty"`
 	Annotations models.Annotations   `json:"annotations,omitempty"`
-	Name        string               `json:"name"`
 	Type        InvoiceLineType      `json:"type"`
 	ManagedBy   InvoiceLineManagedBy `json:"managedBy"`
-	Description *string              `json:"description,omitempty"`
 
 	InvoiceID string         `json:"invoiceID,omitempty"`
 	Currency  currencyx.Code `json:"currency"`
@@ -164,6 +157,13 @@ type LineBase struct {
 
 func (i LineBase) Equal(other LineBase) bool {
 	return reflect.DeepEqual(i, other)
+}
+
+func (i LineBase) GetParentID() (string, bool) {
+	if i.ParentLineID == nil {
+		return "", false
+	}
+	return *i.ParentLineID, true
 }
 
 func (i LineBase) Validate() error {
@@ -616,19 +616,21 @@ type NewFlatFeeLineInput struct {
 func NewFlatFeeLine(input NewFlatFeeLineInput) *Line {
 	return &Line{
 		LineBase: LineBase{
-			Namespace: input.Namespace,
-			ID:        input.ID,
-			CreatedAt: input.CreatedAt,
-			UpdatedAt: input.UpdatedAt,
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace:   input.Namespace,
+				ID:          input.ID,
+				CreatedAt:   input.CreatedAt,
+				UpdatedAt:   input.UpdatedAt,
+				Name:        input.Name,
+				Description: input.Description,
+			}),
 
 			Period:    input.Period,
 			InvoiceAt: input.InvoiceAt,
 			InvoiceID: input.InvoiceID,
 
-			Name:        input.Name,
 			Metadata:    input.Metadata,
 			Annotations: input.Annotations,
-			Description: input.Description,
 
 			Status: InvoiceLineStatusValid,
 
@@ -673,19 +675,20 @@ func NewUsageBasedFlatFeeLine(input NewFlatFeeLineInput, opts ...usageBasedLineO
 
 	return &Line{
 		LineBase: LineBase{
-			Namespace: input.Namespace,
-			ID:        input.ID,
-			CreatedAt: input.CreatedAt,
-			UpdatedAt: input.UpdatedAt,
-
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace:   input.Namespace,
+				ID:          input.ID,
+				CreatedAt:   input.CreatedAt,
+				UpdatedAt:   input.UpdatedAt,
+				Name:        input.Name,
+				Description: input.Description,
+			}),
 			Period:    input.Period,
 			InvoiceAt: input.InvoiceAt,
 			InvoiceID: input.InvoiceID,
 
-			Name:        input.Name,
 			Metadata:    input.Metadata,
 			Annotations: input.Annotations,
-			Description: input.Description,
 
 			Status: InvoiceLineStatusValid,
 

--- a/openmeter/billing/service/lineservice/detailedlines.go
+++ b/openmeter/billing/service/lineservice/detailedlines.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
@@ -136,11 +137,13 @@ func newDetailedLines(line *billing.Line, inputs ...newDetailedLineInput) ([]*bi
 
 		line := &billing.Line{
 			LineBase: billing.LineBase{
-				Namespace:              line.Namespace,
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Namespace: line.Namespace,
+					Name:      in.Name,
+				}),
 				Type:                   billing.InvoiceLineTypeFee,
 				Status:                 billing.InvoiceLineStatusDetailed,
 				Period:                 period,
-				Name:                   in.Name,
 				ManagedBy:              billing.SystemManagedLine,
 				InvoiceAt:              line.InvoiceAt,
 				InvoiceID:              line.InvoiceID,

--- a/openmeter/billing/service/lineservice/usagebasedline_test.go
+++ b/openmeter/billing/service/lineservice/usagebasedline_test.go
@@ -50,11 +50,13 @@ func runUBPTest(t *testing.T, tc ubpCalculationTestCase) {
 
 	line := &billing.Line{
 		LineBase: billing.LineBase{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				ID:   "fake-line",
+				Name: "feature",
+			}),
 			Currency:          "USD",
-			ID:                "fake-line",
 			Type:              billing.InvoiceLineTypeUsageBased,
 			Status:            billing.InvoiceLineStatusValid,
-			Name:              "feature",
 			RateCardDiscounts: tc.discounts,
 		},
 		UsageBased: &billing.UsageBasedLine{

--- a/openmeter/billing/worker/subscription/sync.go
+++ b/openmeter/billing/worker/subscription/sync.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/tracex"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -587,9 +588,11 @@ func (h *Handler) collectUpcomingLines(ctx context.Context, subs subscription.Su
 func (h *Handler) lineFromSubscritionRateCard(subs subscription.SubscriptionView, item subscriptionItemWithPeriods, currency currencyx.Calculator) (*billing.Line, error) {
 	line := &billing.Line{
 		LineBase: billing.LineBase{
-			Namespace:              subs.Subscription.Namespace,
-			Name:                   item.Spec.RateCard.AsMeta().Name,
-			Description:            item.Spec.RateCard.AsMeta().Description,
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace:   subs.Subscription.Namespace,
+				Name:        item.Spec.RateCard.AsMeta().Name,
+				Description: item.Spec.RateCard.AsMeta().Description,
+			}),
 			ManagedBy:              billing.SubscriptionManagedLine,
 			Currency:               subs.Spec.Currency,
 			Status:                 billing.InvoiceLineStatusValid,

--- a/openmeter/billing/worker/subscription/sync_test.go
+++ b/openmeter/billing/worker/subscription/sync_test.go
@@ -440,11 +440,13 @@ func (s *SubscriptionHandlerTestSuite) TestUncollectableCollection() {
 		Lines: []*billing.Line{
 			{
 				LineBase: billing.LineBase{
+					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+						Name: "UBP - unit",
+					}),
 					Period:    lineServicePeriod,
 					InvoiceAt: lineServicePeriod.End,
 					ManagedBy: billing.ManuallyManagedLine,
 					Type:      billing.InvoiceLineTypeUsageBased,
-					Name:      "UBP - unit",
 				},
 				UsageBased: &billing.UsageBasedLine{
 					FeatureKey: apiRequestsTotalFeature.Feature.Key,

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -30,6 +30,18 @@ type ManagedResource struct {
 	Name        string  `json:"name"`
 }
 
+func (m ManagedResource) GetID() string {
+	return m.ID
+}
+
+func (m ManagedResource) GetDescription() *string {
+	return m.Description
+}
+
+func (m ManagedResource) GetName() string {
+	return m.Name
+}
+
 type ManagedResourceInput struct {
 	ID          string
 	Namespace   string
@@ -152,6 +164,18 @@ func (m ManagedModel) Equal(other ManagedModel) bool {
 	return true
 }
 
+func (m ManagedModel) GetCreatedAt() time.Time {
+	return m.CreatedAt
+}
+
+func (m ManagedModel) GetUpdatedAt() time.Time {
+	return m.UpdatedAt
+}
+
+func (m ManagedModel) GetDeletedAt() *time.Time {
+	return m.DeletedAt
+}
+
 type ManagedModelWithID struct {
 	ManagedModel `json:",inline" mapstructure:",squash"`
 	ID           string `json:"id"`
@@ -187,6 +211,10 @@ func (m NamespacedModel) Validate() error {
 	}
 
 	return nil
+}
+
+func (m NamespacedModel) GetNamespace() string {
+	return m.Namespace
 }
 
 type Address struct {

--- a/test/app/custominvoicing/invocing_test.go
+++ b/test/app/custominvoicing/invocing_test.go
@@ -180,14 +180,15 @@ func (s *CustomInvoicingTestSuite) TestInvoicingFlowHooksEnabled() {
 					}),
 					{
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "Test item - HUF",
+							}),
 							Period: billing.Period{Start: periodStart, End: periodEnd},
 
 							InvoiceAt: issueAt,
 							ManagedBy: billing.ManuallyManagedLine,
 
 							Type: billing.InvoiceLineTypeUsageBased,
-
-							Name: "Test item - HUF",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -297,11 +297,13 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 					{
 						// Covered case: standalone flat line
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "Fee",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeFee,
-							Name:      "Fee",
 						},
 						FlatFee: &billing.FlatFeeLine{
 							PerUnitAmount: alpacadecimal.NewFromFloat(100),
@@ -313,11 +315,13 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 					{
 						// Covered case: Discount caused by maximum amount
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - FLAT per unit",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - FLAT per unit",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							FeatureKey: features.flatPerUnit.Key,
@@ -332,11 +336,13 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 					{
 						// Covered case: Very small per unit amount, high quantity, rounding to two decimal places
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - AI Usecase",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - AI Usecase",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							FeatureKey: features.aiFlatPerUnit.Key,
@@ -348,11 +354,13 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 					{
 						// Covered case: Flat line represented as UBP item
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - FLAT per any usage",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - FLAT per any usage",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							FeatureKey: features.flatPerUsage.Key,
@@ -366,11 +374,13 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 					{
 						// Covered case: Multiple lines per item, tier boundary is fractional
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - Tiered graduated",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - Tiered graduated",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							FeatureKey: features.tieredGraduated.Key,
@@ -401,11 +411,13 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 					{
 						// Covered case: minimum amount charges
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - Tiered volume",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - Tiered volume",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							FeatureKey: features.tieredVolume.Key,
@@ -1100,11 +1112,13 @@ func (s *StripeInvoiceTestSuite) TestEmptyInvoiceGenerationZeroUsage() {
 			Lines: []*billing.Line{
 				{
 					LineBase: billing.LineBase{
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Name: "UBP - FLAT per unit",
+						}),
 						Period:    billing.Period{Start: periodStart, End: periodEnd},
 						InvoiceAt: periodEnd,
 						ManagedBy: billing.ManuallyManagedLine,
 						Type:      billing.InvoiceLineTypeUsageBased,
-						Name:      "UBP - FLAT per unit",
 					},
 					UsageBased: &billing.UsageBasedLine{
 						FeatureKey: flatPerUnitFeature.Key,

--- a/test/billing/adapter_test.go
+++ b/test/billing/adapter_test.go
@@ -98,12 +98,14 @@ type usageBasedLineInput struct {
 func newUsageBasedLine(in usageBasedLineInput) *billing.Line {
 	out := &billing.Line{
 		LineBase: billing.LineBase{
-			Namespace: in.Namespace,
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace: in.Namespace,
+				Name:      in.Name,
+			}),
 
 			Type:      billing.InvoiceLineTypeUsageBased,
 			ManagedBy: billing.ManuallyManagedLine,
 			InvoiceID: in.Invoice.ID,
-			Name:      in.Name,
 			Currency:  in.Invoice.Currency,
 
 			Period:    in.Period,

--- a/test/billing/collection_test.go
+++ b/test/billing/collection_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type CollectionTestSuite struct {
@@ -81,11 +82,13 @@ func (s *CollectionTestSuite) TestCollectionFlow() {
 			Lines: []*billing.Line{
 				{
 					LineBase: billing.LineBase{
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Name: "UBP - unit",
+						}),
 						Period:    billing.Period{Start: periodStart, End: periodEnd},
 						InvoiceAt: periodEnd,
 						ManagedBy: billing.ManuallyManagedLine,
 						Type:      billing.InvoiceLineTypeUsageBased,
-						Name:      "UBP - unit",
 					},
 					UsageBased: &billing.UsageBasedLine{
 						FeatureKey: apiRequestsTotalFeature.Feature.Key,
@@ -94,11 +97,13 @@ func (s *CollectionTestSuite) TestCollectionFlow() {
 				},
 				{
 					LineBase: billing.LineBase{
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Name: "UBP - volume",
+						}),
 						Period:    billing.Period{Start: periodStart, End: period2End},
 						InvoiceAt: period2End,
 						ManagedBy: billing.ManuallyManagedLine,
 						Type:      billing.InvoiceLineTypeUsageBased,
-						Name:      "UBP - volume",
 					},
 					UsageBased: &billing.UsageBasedLine{
 						FeatureKey: apiRequestsTotalFeature.Feature.Key,
@@ -337,11 +342,13 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeEditing() {
 		Lines: []*billing.Line{
 			{
 				LineBase: billing.LineBase{
+					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+						Name: "UBP - unit",
+					}),
 					Period:    billing.Period{Start: periodStart, End: periodEnd},
 					InvoiceAt: periodEnd,
 					ManagedBy: billing.ManuallyManagedLine,
 					Type:      billing.InvoiceLineTypeUsageBased,
-					Name:      "UBP - unit",
 				},
 				UsageBased: &billing.UsageBasedLine{
 					FeatureKey: apiRequestsTotalFeature.Feature.Key,
@@ -438,11 +445,13 @@ func (s *CollectionTestSuite) TestCollectionFlowWithUBPEditingExtendingCollectio
 		Lines: []*billing.Line{
 			{
 				LineBase: billing.LineBase{
+					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+						Name: "UBP - unit",
+					}),
 					Period:    billing.Period{Start: periodStart, End: periodEnd},
 					InvoiceAt: periodEnd,
 					ManagedBy: billing.ManuallyManagedLine,
 					Type:      billing.InvoiceLineTypeUsageBased,
-					Name:      "UBP - unit",
 				},
 				UsageBased: &billing.UsageBasedLine{
 					FeatureKey: apiRequestsTotalFeature.Feature.Key,
@@ -480,7 +489,10 @@ func (s *CollectionTestSuite) TestCollectionFlowWithUBPEditingExtendingCollectio
 			EditFn: func(invoice *billing.Invoice) error {
 				invoice.Lines.Append(&billing.Line{
 					LineBase: billing.LineBase{
-						Namespace: namespace,
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Namespace: namespace,
+							Name:      "UBP - unit - new",
+						}),
 						Currency:  currencyx.Code(currency.USD),
 						InvoiceID: invoice.ID,
 						Status:    billing.InvoiceLineStatusValid,
@@ -488,7 +500,6 @@ func (s *CollectionTestSuite) TestCollectionFlowWithUBPEditingExtendingCollectio
 						InvoiceAt: newLinePeriod.End,
 						ManagedBy: billing.ManuallyManagedLine,
 						Type:      billing.InvoiceLineTypeUsageBased,
-						Name:      "UBP - unit - new",
 					},
 					UsageBased: &billing.UsageBasedLine{
 						FeatureKey: apiRequestsTotalFeature.Feature.Key,

--- a/test/billing/discount_test.go
+++ b/test/billing/discount_test.go
@@ -90,15 +90,17 @@ func (s *DiscountsTestSuite) TestCorrelationIDHandling() {
 				Lines: []*billing.Line{
 					{
 						LineBase: billing.LineBase{
-							Namespace: namespace,
-							Period:    billing.Period{Start: periodStart, End: periodEnd},
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Namespace: namespace,
+								Name:      "Test item1",
+							}),
+							Period: billing.Period{Start: periodStart, End: periodEnd},
 
 							InvoiceAt: periodEnd,
 
 							Type:      billing.InvoiceLineTypeUsageBased,
 							ManagedBy: billing.ManuallyManagedLine,
 
-							Name:     "Test item1",
 							Currency: currencyx.Code(currency.USD),
 							RateCardDiscounts: billing.Discounts{
 								Percentage: &billing.PercentageDiscount{
@@ -285,15 +287,17 @@ func (s *DiscountsTestSuite) TestUnitDiscountProgressiveBilling() {
 			Lines: []*billing.Line{
 				{
 					LineBase: billing.LineBase{
-						Namespace: namespace,
-						Period:    billing.Period{Start: periodStart, End: periodEnd},
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Namespace: namespace,
+							Name:      "Test item1",
+						}),
+						Period: billing.Period{Start: periodStart, End: periodEnd},
 
 						InvoiceAt: periodEnd,
 
 						Type:      billing.InvoiceLineTypeUsageBased,
 						ManagedBy: billing.ManuallyManagedLine,
 
-						Name:     "Test item1",
 						Currency: currencyx.Code(currency.USD),
 						RateCardDiscounts: billing.Discounts{
 							Usage: &billing.UsageDiscount{

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -178,14 +178,15 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 					}),
 					{
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "Test item - HUF",
+							}),
 							Period: billing.Period{Start: periodStart, End: periodEnd},
 
 							InvoiceAt: issueAt,
 							ManagedBy: billing.ManuallyManagedLine,
 
 							Type: billing.InvoiceLineTypeUsageBased,
-
-							Name: "Test item - HUF",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
@@ -234,8 +235,13 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 		usdInvoiceLine := usdInvoice.Lines.MustGet()[0]
 		expectedUSDLine := &billing.Line{
 			LineBase: billing.LineBase{
-				ID:        items[0].ID,
-				Namespace: namespace,
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					ID:        items[0].ID,
+					Namespace: namespace,
+					Name:      "Test item - USD",
+					CreatedAt: usdInvoiceLine.CreatedAt.In(time.UTC),
+					UpdatedAt: usdInvoiceLine.UpdatedAt.In(time.UTC),
+				}),
 
 				Period: billing.Period{Start: periodStart.Truncate(time.Microsecond), End: periodEnd.Truncate(time.Microsecond)},
 
@@ -245,13 +251,9 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 
 				Type: billing.InvoiceLineTypeFee,
 
-				Name:     "Test item - USD",
 				Currency: currencyx.Code(currency.USD),
 
 				Status: billing.InvoiceLineStatusValid,
-
-				CreatedAt: usdInvoiceLine.CreatedAt.In(time.UTC),
-				UpdatedAt: usdInvoiceLine.UpdatedAt.In(time.UTC),
 
 				Metadata: map[string]string{
 					"key": "value",
@@ -639,15 +641,16 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 				Lines: []*billing.Line{
 					{
 						LineBase: billing.LineBase{
-							Namespace: namespace,
-							Period:    billing.Period{Start: periodStart, End: periodEnd},
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name:      "Test item1",
+								Namespace: namespace,
+							}),
+							Period: billing.Period{Start: periodStart, End: periodEnd},
 
 							InvoiceAt: line1IssueAt,
 
 							Type:      billing.InvoiceLineTypeFee,
 							ManagedBy: billing.ManuallyManagedLine,
-
-							Name: "Test item1",
 
 							Metadata: map[string]string{
 								"key": "value",
@@ -1412,11 +1415,13 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 				Lines: []*billing.Line{
 					{
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - FLAT per unit",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - FLAT per unit",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							FeatureKey: features.flatPerUnit.Key,
@@ -1430,11 +1435,13 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 					},
 					{
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - FLAT per any usage",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - FLAT per any usage",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
@@ -1446,11 +1453,13 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 					},
 					{
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - Tiered graduated",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - Tiered graduated",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							FeatureKey: features.tieredGraduated.Key,
@@ -1480,11 +1489,13 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 					},
 					{
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - Tiered volume",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - Tiered volume",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							FeatureKey: features.tieredVolume.Key,
@@ -2333,11 +2344,13 @@ func (s *InvoicingTestSuite) TestUBPGraduatingFlatFeeTier1() {
 				Lines: []*billing.Line{
 					{
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - Tiered graduated",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - Tiered graduated",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							FeatureKey: features.tieredGraduated.Key,
@@ -2646,11 +2659,13 @@ func (s *InvoicingTestSuite) TestUBPNonProgressiveInvoicing() {
 				Lines: []*billing.Line{
 					{
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - FLAT per unit",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - FLAT per unit",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							FeatureKey: features.flatPerUnit.Key,
@@ -2664,11 +2679,13 @@ func (s *InvoicingTestSuite) TestUBPNonProgressiveInvoicing() {
 					},
 					{
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - FLAT per any usage",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - FLAT per any usage",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
@@ -2680,11 +2697,13 @@ func (s *InvoicingTestSuite) TestUBPNonProgressiveInvoicing() {
 					},
 					{
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - Tiered graduated",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - Tiered graduated",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							FeatureKey: features.tieredGraduated.Key,
@@ -2714,11 +2733,13 @@ func (s *InvoicingTestSuite) TestUBPNonProgressiveInvoicing() {
 					},
 					{
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - Tiered volume",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - Tiered volume",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							FeatureKey: features.tieredVolume.Key,
@@ -3165,11 +3186,13 @@ func (s *InvoicingTestSuite) TestGatheringInvoiceRecalculation() {
 				Lines: []*billing.Line{
 					{
 						LineBase: billing.LineBase{
+							ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+								Name: "UBP - FLAT per unit",
+							}),
 							Period:    billing.Period{Start: periodStart, End: periodEnd},
 							InvoiceAt: periodEnd,
 							ManagedBy: billing.ManuallyManagedLine,
 							Type:      billing.InvoiceLineTypeUsageBased,
-							Name:      "UBP - FLAT per unit",
 						},
 						UsageBased: &billing.UsageBasedLine{
 							FeatureKey: flatPerUnitFeature.Key,
@@ -3331,11 +3354,13 @@ func (s *InvoicingTestSuite) TestEmptyInvoiceGenerationZeroUsage() {
 			Lines: []*billing.Line{
 				{
 					LineBase: billing.LineBase{
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Name: "UBP - FLAT per unit",
+						}),
 						Period:    billing.Period{Start: periodStart, End: periodEnd},
 						InvoiceAt: periodEnd,
 						ManagedBy: billing.ManuallyManagedLine,
 						Type:      billing.InvoiceLineTypeUsageBased,
-						Name:      "UBP - FLAT per unit",
 					},
 					UsageBased: &billing.UsageBasedLine{
 						FeatureKey: flatPerUnitFeature.Key,
@@ -3450,11 +3475,13 @@ func (s *InvoicingTestSuite) TestEmptyInvoiceGenerationZeroPrice() {
 			Lines: []*billing.Line{
 				{
 					LineBase: billing.LineBase{
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Name: "UBP - FLAT per unit",
+						}),
 						Period:    billing.Period{Start: periodStart, End: periodEnd},
 						InvoiceAt: periodEnd,
 						ManagedBy: billing.ManuallyManagedLine,
 						Type:      billing.InvoiceLineTypeUsageBased,
-						Name:      "UBP - FLAT per unit",
 					},
 					UsageBased: &billing.UsageBasedLine{
 						FeatureKey: flatPerUnitFeature.Key,
@@ -3606,11 +3633,13 @@ func (s *InvoicingTestSuite) TestProgressiveBillLate() {
 		Lines: []*billing.Line{
 			{
 				LineBase: billing.LineBase{
+					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+						Name: "UBP - volume",
+					}),
 					Period:    billing.Period{Start: periodStart, End: periodEnd},
 					InvoiceAt: periodEnd,
 					ManagedBy: billing.ManuallyManagedLine,
 					Type:      billing.InvoiceLineTypeUsageBased,
-					Name:      "UBP - volume",
 				},
 				UsageBased: &billing.UsageBasedLine{
 					FeatureKey: apiRequestsTotalFeature.Feature.Key,
@@ -3700,11 +3729,13 @@ func (s *InvoicingTestSuite) TestProgressiveBillingOverride() {
 		Lines: []*billing.Line{
 			{
 				LineBase: billing.LineBase{
+					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+						Name: "UBP - volume",
+					}),
 					Period:    billing.Period{Start: periodStart, End: periodEnd},
 					InvoiceAt: periodEnd,
 					ManagedBy: billing.ManuallyManagedLine,
 					Type:      billing.InvoiceLineTypeUsageBased,
-					Name:      "UBP - volume",
 				},
 				UsageBased: &billing.UsageBasedLine{
 					FeatureKey: apiRequestsTotalFeature.Feature.Key,
@@ -3731,11 +3762,13 @@ func (s *InvoicingTestSuite) TestProgressiveBillingOverride() {
 			},
 			{
 				LineBase: billing.LineBase{
+					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+						Name: "UBP - unit",
+					}),
 					Period:    billing.Period{Start: periodStart, End: periodStart.Add(24 * time.Hour)},
 					InvoiceAt: periodStart.Add(24 * time.Hour),
 					ManagedBy: billing.ManuallyManagedLine,
 					Type:      billing.InvoiceLineTypeUsageBased,
-					Name:      "UBP - unit",
 				},
 				UsageBased: &billing.UsageBasedLine{
 					FeatureKey: apiRequestsTotalFeature.Feature.Key,
@@ -3810,11 +3843,13 @@ func (s *InvoicingTestSuite) TestSortLines() {
 		Lines: []*billing.Line{
 			{
 				LineBase: billing.LineBase{
+					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+						Name: "UBP - volume",
+					}),
 					Period:    billing.Period{Start: periodStart, End: periodEnd},
 					InvoiceAt: periodEnd,
 					ManagedBy: billing.ManuallyManagedLine,
 					Type:      billing.InvoiceLineTypeUsageBased,
-					Name:      "UBP - volume",
 				},
 				UsageBased: &billing.UsageBasedLine{
 					FeatureKey: apiRequestsTotalFeature.Feature.Key,

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -338,15 +338,17 @@ func (s *BaseSuite) CreateGatheringInvoice(t *testing.T, ctx context.Context, in
 			Lines: []*billing.Line{
 				{
 					LineBase: billing.LineBase{
-						Namespace: namespace,
-						Period:    billing.Period{Start: periodStart, End: periodEnd},
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Namespace: namespace,
+							Name:      "Test item1",
+						}),
+						Period: billing.Period{Start: periodStart, End: periodEnd},
 
 						InvoiceAt: invoiceAt,
 
 						Type:      billing.InvoiceLineTypeFee,
 						ManagedBy: billing.ManuallyManagedLine,
 
-						Name:     "Test item1",
 						Currency: currencyx.Code(currency.USD),
 
 						Metadata: map[string]string{
@@ -362,15 +364,17 @@ func (s *BaseSuite) CreateGatheringInvoice(t *testing.T, ctx context.Context, in
 				},
 				{
 					LineBase: billing.LineBase{
-						Namespace: namespace,
-						Period:    billing.Period{Start: periodStart, End: periodEnd},
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Namespace: namespace,
+							Name:      "Test item2",
+						}),
+						Period: billing.Period{Start: periodStart, End: periodEnd},
 
 						InvoiceAt: invoiceAt,
 
 						Type:      billing.InvoiceLineTypeFee,
 						ManagedBy: billing.ManuallyManagedLine,
 
-						Name:     "Test item2",
 						Currency: currencyx.Code(currency.USD),
 					},
 					FlatFee: &billing.FlatFeeLine{

--- a/test/billing/tax_test.go
+++ b/test/billing/tax_test.go
@@ -206,15 +206,16 @@ func (s *InvoicingTaxTestSuite) TestLineSplittingRetainsTaxConfig() {
 			Lines: []*billing.Line{
 				{
 					LineBase: billing.LineBase{
-						Namespace: namespace,
-						Period:    billing.Period{Start: now, End: now.Add(time.Hour * 24)},
+						ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+							Namespace: namespace,
+							Name:      "Test item - USD",
+						}),
+						Period: billing.Period{Start: now, End: now.Add(time.Hour * 24)},
 
 						InvoiceAt: now.Add(time.Hour * 24),
 						ManagedBy: billing.ManuallyManagedLine,
 
 						Type: billing.InvoiceLineTypeUsageBased,
-
-						Name: "Test item - USD",
 
 						TaxConfig: taxConfig,
 


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This patch changes the invoidelinediff to use interface based parent/entity relationsips in anticipation of the Line/DetailedLine split, where the two types would behave the same but would be different go types implementing the same interfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only accessors for managed resource metadata (IDs, names, namespaces, timestamps).

* **Refactor**
  * Consolidated invoice line identity into a ManagedResource wrapper across creation, simulation, updates, services, and workers.
  * Line discounts now attach to their parent line to ensure correct propagation.
  * Public line structs now encapsulate identity/description in ManagedResource.

* **Tests**
  * Updated tests to use the new identity model and validate unchanged behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->