### PR TITLE
chore(collector): add lease health check to leader elector

### DIFF
--- a/collector/benthos/internal/logging/logging.go
+++ b/collector/benthos/internal/logging/logging.go
@@ -1,0 +1,54 @@
+package logging
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"k8s.io/klog/v2"
+)
+
+// CtrlLogger adapts Benthos service.Logger to a logr.LogSink for controller-runtime and klog.
+type CtrlLogger struct {
+	logger *service.Logger
+}
+
+// Init is a no-op.
+func (l *CtrlLogger) Init(info logr.RuntimeInfo) {}
+
+// Enabled is a no-op.
+func (l *CtrlLogger) Enabled(level int) bool {
+	return true
+}
+
+// Info logs a message at the given level.
+func (l *CtrlLogger) Info(level int, msg string, keysAndValues ...any) {
+	if level == 0 {
+		l.logger.Infof(msg, keysAndValues...)
+		return
+	}
+	l.logger.Debugf(msg, keysAndValues...)
+}
+
+// Error logs an error message.
+func (l *CtrlLogger) Error(err error, msg string, keysAndValues ...any) {
+	l.logger.Errorf(msg, keysAndValues...)
+}
+
+// WithValues returns the logger. No-op.
+func (l *CtrlLogger) WithValues(keysAndValues ...any) logr.LogSink {
+	return l
+}
+
+// WithName returns the logger. No-op.
+func (l *CtrlLogger) WithName(name string) logr.LogSink {
+	return l
+}
+
+// NewLogrLogger returns a logr.Logger backed by Benthos logger.
+func NewLogrLogger(logger *service.Logger) logr.Logger {
+	return logr.New(&CtrlLogger{logger: logger})
+}
+
+// SetupKlog configures the global klog logger to use the provided Benthos logger via logr.
+func SetupKlog(logger *service.Logger) {
+	klog.SetLogger(NewLogrLogger(logger.With("component", "kubernetes")))
+}

--- a/collector/benthos/services/leaderelection/flags.go
+++ b/collector/benthos/services/leaderelection/flags.go
@@ -8,13 +8,14 @@ import (
 )
 
 const (
-	leaderElectionEnabledFlag = "leader-election"
-	leaseLockNamespaceFlag    = "lease-lock-namespace"
-	leaseLockNameFlag         = "lease-lock-name"
-	leaseLockIdentityFlag     = "lease-lock-identity"
-	leaseDurationFlag         = "lease-duration"
-	leaseRenewDeadlineFlag    = "lease-renew-deadline"
-	leaseRetryPeriodFlag      = "lease-retry-period"
+	leaderElectionEnabledFlag   = "leader-election"
+	leaseLockNamespaceFlag      = "lease-lock-namespace"
+	leaseLockNameFlag           = "lease-lock-name"
+	leaseLockIdentityFlag       = "lease-lock-identity"
+	leaseDurationFlag           = "lease-duration"
+	leaseRenewDeadlineFlag      = "lease-renew-deadline"
+	leaseRetryPeriodFlag        = "lease-retry-period"
+	leaseHealthCheckTimeoutFlag = "lease-health-check-timeout"
 )
 
 var hostname, _ = os.Hostname()
@@ -45,18 +46,24 @@ var leaderElectionCLIFlags = []cli.Flag{
 		Name:    leaseDurationFlag,
 		Usage:   "Duration of the lease",
 		EnvVars: []string{"LEASE_DURATION"},
-		Value:   10 * time.Second,
+		Value:   15 * time.Second,
 	},
 	&cli.DurationFlag{
 		Name:    leaseRenewDeadlineFlag,
 		Usage:   "Renew deadline of the lease",
 		EnvVars: []string{"LEASE_RENEW_DEADLINE"},
-		Value:   5 * time.Second,
+		Value:   10 * time.Second,
 	},
 	&cli.DurationFlag{
 		Name:    leaseRetryPeriodFlag,
 		Usage:   "Retry period of the lease",
 		EnvVars: []string{"LEASE_RETRY_PERIOD"},
 		Value:   2 * time.Second,
+	},
+	&cli.DurationFlag{
+		Name:    leaseHealthCheckTimeoutFlag,
+		Usage:   "Timeout for lease health check. Should be longer than lease duration for inactive leader detection",
+		EnvVars: []string{"LEASE_HEALTH_CHECK_TIMEOUT"},
+		Value:   0,
 	},
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added health monitoring for leader election with a configurable lease health-check timeout.
  - Introduced a new CLI flag: --lease-health-check-timeout (also via LEASE_HEALTH_CHECK_TIMEOUT).

- Improvements
  - Unified logging for Kubernetes-related components for clearer, centralized logs.
  - Adjusted leader election defaults for better stability: lease duration to 15s and renew deadline to 10s.

- Chores
  - Internal logging integration streamlined to reduce dependencies and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->