### PR TITLE
fix(e2e): force rebuild app images for e2e tests

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -29,7 +29,7 @@ env-local-up:
 		-f docker-compose.infra.yaml \
 		-f docker-compose.openmeter.yaml \
 		-f docker-compose.openmeter-local.yaml \
-		up -d
+		up -d --build --force-recreate
 
 .PHONY: help
 .DEFAULT_GOAL := help

--- a/e2e/docker-compose.openmeter-local.yaml
+++ b/e2e/docker-compose.openmeter-local.yaml
@@ -5,20 +5,6 @@
 services:
   openmeter:
     build: ..
-    develop:
-      watch:
-        - action: rebuild
-          path: ..
-          ignore:
-            - "**/*.test.go"
-            - "**/*.md"
 
   sink-worker:
     build: ..
-    develop:
-      watch:
-        - action: rebuild
-          path: ..
-          ignore:
-            - "**/*.test.go"
-            - "**/*.md"


### PR DESCRIPTION
(cherry picked from commit 63760ddfa188ef2c086b39e72a4f0364abd0a5b9)

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

- `docker compose --watch` isn't really meant for our use-case, and compose.develop section isn't respected for busting builds from previous runs otherwise, so it isn't really compatible with the current e2e setup...
- for locally running `make etoe` the change makes sense
- for CI, we have an override with 
```
- name: Create override files for e2e
        env:
          DEPOT_IMAGE_URL: ${{ needs.artifacts.outputs.container-image-url-depot }}
        run: |
          cat > e2e/docker-compose.override.yaml <<EOF
          services:
            openmeter:
              image: $DEPOT_IMAGE_URL
            sink-worker:
              image: $DEPOT_IMAGE_URL
          EOF

          cat e2e/docker-compose.override.yaml
```so we should be fine


