### PR TITLE
feat(customer): add support for service hooks

### DIFF
--- a/openmeter/customer/service.go
+++ b/openmeter/customer/service.go
@@ -3,12 +3,15 @@ package customer
 import (
 	"context"
 
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 )
 
 type Service interface {
 	CustomerService
 	RequestValidatorService
+
+	models.ServiceHooks[Customer]
 }
 
 type RequestValidatorService interface {

--- a/openmeter/customer/service/customer.go
+++ b/openmeter/customer/service/customer.go
@@ -33,6 +33,10 @@ func (s *Service) CreateCustomer(ctx context.Context, input customer.CreateCusto
 			return nil, err
 		}
 
+		if err = s.hooks.PostCreate(ctx, createdCustomer); err != nil {
+			return nil, err
+		}
+
 		// Publish the customer created event
 		customerCreatedEvent := customer.NewCustomerCreateEvent(ctx, createdCustomer)
 		if err := s.publisher.Publish(ctx, customerCreatedEvent); err != nil {
@@ -51,14 +55,32 @@ func (s *Service) DeleteCustomer(ctx context.Context, input customer.DeleteCusto
 	}
 
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
-		// Delete the customer
-		err := s.adapter.DeleteCustomer(ctx, input)
+		cus, err := s.adapter.GetCustomer(ctx, customer.GetCustomerInput{
+			CustomerID: &input,
+		})
 		if err != nil {
+			if models.IsGenericNotFoundError(err) {
+				return nil
+			}
+
+			return fmt.Errorf("failed to get customer [namespace=%s customer.id=%s]: %w",
+				input.Namespace, input.ID, err)
+		}
+
+		// Run pre delete hooks
+		if err = s.hooks.PreDelete(ctx, cus); err != nil {
 			return err
 		}
 
+		// Delete the customer
+		err = s.adapter.DeleteCustomer(ctx, input)
+		if err != nil {
+			return fmt.Errorf("failed to delete customer [namespace=%s customer.id=%s]: %w",
+				input.Namespace, input.ID, err)
+		}
+
 		// Get the deleted customer
-		deletedCustomer, err := s.GetCustomer(ctx, customer.GetCustomerInput{
+		cus, err = s.GetCustomer(ctx, customer.GetCustomerInput{
 			CustomerID: &customer.CustomerID{
 				Namespace: input.Namespace,
 				ID:        input.ID,
@@ -68,8 +90,13 @@ func (s *Service) DeleteCustomer(ctx context.Context, input customer.DeleteCusto
 			return err
 		}
 
+		// Run post delete hooks
+		if err = s.hooks.PostDelete(ctx, cus); err != nil {
+			return err
+		}
+
 		// Publish the customer deleted event
-		customerDeletedEvent := customer.NewCustomerDeleteEvent(ctx, deletedCustomer)
+		customerDeletedEvent := customer.NewCustomerDeleteEvent(ctx, cus)
 		if err := s.publisher.Publish(ctx, customerDeletedEvent); err != nil {
 			return fmt.Errorf("failed to publish customer deleted event: %w", err)
 		}
@@ -100,19 +127,38 @@ func (s *Service) UpdateCustomer(ctx context.Context, input customer.UpdateCusto
 	}
 
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (*customer.Customer, error) {
-		// Update the customer
-		updatedCustomer, err := s.adapter.UpdateCustomer(ctx, input)
+		cus, err := s.adapter.GetCustomer(ctx, customer.GetCustomerInput{
+			CustomerID: &input.CustomerID,
+		})
 		if err != nil {
+			return nil, fmt.Errorf("failed to get customer [namespace=%s customer.id=%s]: %w",
+				input.CustomerID.Namespace, input.CustomerID.ID, err)
+		}
+
+		// Run pre update hooks
+		if err = s.hooks.PreUpdate(ctx, cus); err != nil {
+			return nil, err
+		}
+
+		// Update the customer
+		cus, err = s.adapter.UpdateCustomer(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update customer [namespace=%s customer.id=%s]: %w",
+				input.CustomerID.Namespace, input.CustomerID.ID, err)
+		}
+
+		// Run post update hooks
+		if err = s.hooks.PostUpdate(ctx, cus); err != nil {
 			return nil, err
 		}
 
 		// Publish the customer updated event
-		customerUpdatedEvent := customer.NewCustomerUpdateEvent(ctx, updatedCustomer)
+		customerUpdatedEvent := customer.NewCustomerUpdateEvent(ctx, cus)
 		if err := s.publisher.Publish(ctx, customerUpdatedEvent); err != nil {
 			return nil, fmt.Errorf("failed to publish customer updated event: %w", err)
 		}
 
-		return updatedCustomer, nil
+		return cus, nil
 	})
 }
 

--- a/openmeter/customer/service/service.go
+++ b/openmeter/customer/service/service.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 var _ customer.Service = (*Service)(nil)
@@ -13,6 +14,12 @@ type Service struct {
 	adapter                  customer.Adapter
 	requestValidatorRegistry customer.RequestValidatorRegistry
 	publisher                eventbus.Publisher
+
+	hooks models.ServiceHookRegistry[customer.Customer]
+}
+
+func (s *Service) RegisterHooks(hooks ...models.ServiceHook[customer.Customer]) {
+	s.hooks.RegisterHooks(hooks...)
 }
 
 type Config struct {
@@ -41,5 +48,6 @@ func New(config Config) (*Service, error) {
 		adapter:                  config.Adapter,
 		requestValidatorRegistry: customer.NewRequestValidatorRegistry(),
 		publisher:                config.Publisher,
+		hooks:                    models.ServiceHookRegistry[customer.Customer]{},
 	}, nil
 }

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1022,6 +1022,8 @@ var _ customer.Service = (*NoopCustomerService)(nil)
 
 type NoopCustomerService struct{}
 
+func (n NoopCustomerService) RegisterHooks(_ ...models.ServiceHook[customer.Customer]) {}
+
 func (n NoopCustomerService) ListCustomers(ctx context.Context, params customer.ListCustomersInput) (pagination.PagedResponse[customer.Customer], error) {
 	return pagination.PagedResponse[customer.Customer]{}, nil
 }


### PR DESCRIPTION
## Overview

Add support for service hooks to Customer service, so other services can easily tap into certian operations at certain stages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lifecycle hooks for customer operations (post-create, pre/post-update, pre/post-delete).
  * Added an API to register customer service hooks.

* **Bug Fixes**
  * Improved error messages with clearer namespace/id context during customer operations.
  * Deleting a non-existent customer is now treated as a no-op.

* **Tests**
  * Test shim updated so the no-op customer service accepts hook registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->