### PR TITLE
fix: customer lookup by usage attribution

### DIFF
--- a/openmeter/customer/adapter/customer.go
+++ b/openmeter/customer/adapter/customer.go
@@ -56,7 +56,13 @@ func (a *adapter) ListCustomers(ctx context.Context, input customer.ListCustomer
 		}
 
 		if input.Subject != nil {
-			query = query.Where(customerdb.HasSubjectsWith(customersubjectsdb.SubjectKeyContainsFold(*input.Subject)))
+			query = query.Where(customerdb.HasSubjectsWith(
+				customersubjectsdb.SubjectKeyContainsFold(*input.Subject),
+				customersubjectsdb.Or(
+					customersubjectsdb.DeletedAtIsNil(),
+					customersubjectsdb.DeletedAtGT(now),
+				),
+			))
 		}
 
 		if input.PlanKey != nil {


### PR DESCRIPTION
## Overview

Fix `Customer` lookup by usgae attribution where `Customer` was returned even if the `Subject` assignement was already deleted.
Also make sure to return `Customer` if the assignement is deleted in the future which is mostly useful for "time-travel" in testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Time-aware filtering so customers, subjects, and subscriptions reflect their state at a specific moment.

- Bug Fixes
  - More accurate handling of deleted subjects and subscription active periods to reduce inconsistent results.
  - Consistent inclusion of plan details with active subscriptions.
  - Unified time context across customer listing and retrieval for predictable outcomes.

- Refactor
  - Streamlined subscription filtering for consistent, time-based query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->