### PR TITLE
fix: subscription sync should save deleted invoices

### DIFF
--- a/openmeter/billing/errors.go
+++ b/openmeter/billing/errors.go
@@ -40,6 +40,7 @@ var (
 	ErrInvoiceEmpty                          = NewValidationError("invoice_empty", "invoice is empty")
 	ErrInvoiceNotFound                       = NewValidationError("invoice_not_found", "invoice not found")
 	ErrInvoiceDeleteFailed                   = NewValidationError("invoice_delete_failed", "invoice delete failed")
+	ErrInvoiceCannotDeleteGathering          = NewValidationError("invoice_cannot_delete_gathering", "gathering invoices cannot be deleted, please delete the upcoming lines instead")
 
 	ErrInvoiceLineFeatureHasNoMeters                             = NewValidationError("invoice_line_feature_has_no_meters", "usage based invoice line: feature has no meters")
 	ErrInvoiceLineVolumeSplitNotSupported                        = NewValidationError("invoice_line_graduated_split_not_supported", "graduated tiered pricing is not supported for split periods")

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -67,7 +67,7 @@ type InvoiceService interface {
 	SnapshotQuantities(ctx context.Context, input SnapshotQuantitiesInput) (Invoice, error)
 	ApproveInvoice(ctx context.Context, input ApproveInvoiceInput) (Invoice, error)
 	RetryInvoice(ctx context.Context, input RetryInvoiceInput) (Invoice, error)
-	DeleteInvoice(ctx context.Context, input DeleteInvoiceInput) error
+	DeleteInvoice(ctx context.Context, input DeleteInvoiceInput) (Invoice, error)
 	// UpdateInvoice updates an invoice as a whole
 	UpdateInvoice(ctx context.Context, input UpdateInvoiceInput) (Invoice, error)
 

--- a/openmeter/billing/worker/subscription/sync.go
+++ b/openmeter/billing/worker/subscription/sync.go
@@ -221,7 +221,7 @@ func (h *Handler) SyncronizeSubscription(ctx context.Context, subs subscription.
 
 			patches = append(patches, newLinePatches...)
 
-			invoiceUpdater := NewInvoiceUpdater(h.billingService)
+			invoiceUpdater := NewInvoiceUpdater(h.billingService, h.logger)
 			if err := invoiceUpdater.ApplyPatches(ctx, customerID, patches); err != nil {
 				return fmt.Errorf("updating invoices: %w", err)
 			}

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1456,8 +1456,8 @@ func (n NoopBillingService) RetryInvoice(ctx context.Context, input billing.Retr
 	return billing.Invoice{}, nil
 }
 
-func (n NoopBillingService) DeleteInvoice(ctx context.Context, input billing.DeleteInvoiceInput) error {
-	return nil
+func (n NoopBillingService) DeleteInvoice(ctx context.Context, input billing.DeleteInvoiceInput) (billing.Invoice, error) {
+	return billing.Invoice{}, nil
 }
 
 func (n NoopBillingService) UpdateInvoice(ctx context.Context, input billing.UpdateInvoiceInput) (billing.Invoice, error) {

--- a/test/billing/discount_test.go
+++ b/test/billing/discount_test.go
@@ -201,8 +201,9 @@ func (s *DiscountsTestSuite) TestCorrelationIDHandling() {
 	})
 
 	s.Run("Deleting the invoice works without errors", func() {
-		err := s.BillingService.DeleteInvoice(ctx, draftInvoiceID)
+		invoice, err := s.BillingService.DeleteInvoice(ctx, draftInvoiceID)
 		s.NoError(err)
+		s.Len(invoice.ValidationIssues, 0)
 	})
 }
 


### PR DESCRIPTION

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Even if deletion fails the invoice should end up in delete.failed state instead of blocking the whole subscription sync process for the customer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer feedback when deleting invoices that can’t be removed (e.g., gathering invoices), including actionable validation messages.

- Bug Fixes
  - More accurate responses when an invoice deletion fails, reflecting the actual invoice status.

- Refactor
  - Invoice deletion now returns the updated invoice along with the result, enabling clients to inspect status and validation issues.
  - Added structured logging to surface warnings when automated deletions fail.

- Tests
  - Updated tests to validate returned invoice status and validation details after deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->