### PR TITLE
feat: add trancing to service hooks

### DIFF
--- a/app/common/customer.go
+++ b/app/common/customer.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/google/wire"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -61,6 +62,7 @@ type CustomerSubjectHook customerservicehooks.SubjectCustomerHook
 func NewCustomerSubjectServiceHook(
 	config config.CustomerConfiguration,
 	logger *slog.Logger,
+	tracer trace.Tracer,
 	subjectService subject.Service,
 	customerService customer.Service,
 	customerOverrideService billing.CustomerOverrideService,
@@ -74,6 +76,7 @@ func NewCustomerSubjectServiceHook(
 		Customer:         customerService,
 		CustomerOverride: customerOverrideService,
 		Logger:           logger,
+		Tracer:           tracer,
 		IgnoreErrors:     config.IgnoreErrors,
 	})
 	if err != nil {

--- a/app/common/subject.go
+++ b/app/common/subject.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	"github.com/google/wire"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/customer"
@@ -65,10 +66,12 @@ func NewSubjectCustomerHook(
 	subject subject.Service,
 	customer customer.Service,
 	logger *slog.Logger,
+	tracer trace.Tracer,
 ) (subjecthooks.CustomerSubjectHook, error) {
 	h, err := subjecthooks.NewCustomerSubjectHook(subjecthooks.CustomerSubjectHookConfig{
 		Subject: subject,
 		Logger:  logger,
+		Tracer:  tracer,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create customer subject hook: %w", err)

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -363,7 +363,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	customerSubjectHook, err := common.NewCustomerSubjectServiceHook(customerConfiguration, logger, subjectService, customerService, billingService)
+	customerSubjectHook, err := common.NewCustomerSubjectServiceHook(customerConfiguration, logger, tracer, subjectService, customerService, billingService)
 	if err != nil {
 		cleanup6()
 		cleanup5()
@@ -534,7 +534,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	}
 	v6 := common.NewTelemetryRouterHook(meterProvider, tracerProvider)
 	routerHooks := common.NewRouterHooks(v6)
-	v7, err := common.NewSubjectCustomerHook(subjectService, customerService, logger)
+	v7, err := common.NewSubjectCustomerHook(subjectService, customerService, logger, tracer)
 	if err != nil {
 		cleanup8()
 		cleanup7()

--- a/openmeter/customer/service/hooks/subjectcustomer_test.go
+++ b/openmeter/customer/service/hooks/subjectcustomer_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customeradapter "github.com/openmeterio/openmeter/openmeter/customer/adapter"
@@ -42,6 +44,7 @@ func TestCustomerProvisioner_EnsureCustomer(t *testing.T) {
 		customer:         env.CustomerService,
 		customerOverride: nil,
 		logger:           env.Logger,
+		tracer:           env.Tracer,
 	}
 
 	ctx := t.Context()
@@ -274,6 +277,7 @@ var NewTestNamespace = NewTestULID
 
 type TestEnv struct {
 	Logger          *slog.Logger
+	Tracer          trace.Tracer
 	SubjectService  subject.Service
 	CustomerService customer.Service
 
@@ -319,6 +323,8 @@ func NewTestEnv(t *testing.T) *TestEnv {
 	// Init logger
 	logger := testutils.NewDiscardLogger(t)
 
+	tracer := noop.NewTracerProvider().Tracer("test_env")
+
 	// Init database
 	db := testutils.InitPostgresDB(t)
 	client := db.EntDriver.Client()
@@ -357,6 +363,7 @@ func NewTestEnv(t *testing.T) *TestEnv {
 
 	return &TestEnv{
 		Logger:          logger,
+		Tracer:          tracer,
 		SubjectService:  subjectService,
 		CustomerService: customerService,
 		Client:          client,

--- a/openmeter/subject/service/hooks/customersubject.go
+++ b/openmeter/subject/service/hooks/customersubject.go
@@ -7,6 +7,9 @@ import (
 	"log/slog"
 
 	"github.com/samber/lo"
+	"go.opentelemetry.io/otel/attribute"
+	otelcodes "go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/subject"
@@ -42,14 +45,37 @@ type customerSubjectHook struct {
 
 	provisioner *SubjectProvisioner
 	logger      *slog.Logger
+	tracer      trace.Tracer
 }
 
 func (s customerSubjectHook) PostCreate(ctx context.Context, cus *customer.Customer) error {
-	return s.provisioner.EnsureSubjects(ctx, cus)
+	ctx, span := s.tracer.Start(ctx, "customer_subject_hook.post_create")
+	defer span.End()
+
+	err := s.provisioner.EnsureSubjects(ctx, cus)
+	if err != nil {
+		span.SetStatus(otelcodes.Error, "failed to provision subjects for customer")
+		span.RecordError(err)
+	} else {
+		span.SetStatus(otelcodes.Ok, "subjects provisioned for customer")
+	}
+
+	return err
 }
 
 func (s customerSubjectHook) PostUpdate(ctx context.Context, cus *customer.Customer) error {
-	return s.provisioner.EnsureSubjects(ctx, cus)
+	ctx, span := s.tracer.Start(ctx, "customer_subject_hook.post_update")
+	defer span.End()
+
+	err := s.provisioner.EnsureSubjects(ctx, cus)
+	if err != nil {
+		span.SetStatus(otelcodes.Error, "failed to provision subjects for customer")
+		span.RecordError(err)
+	} else {
+		span.SetStatus(otelcodes.Ok, "subjects provisioned for customer")
+	}
+
+	return err
 }
 
 func NewCustomerSubjectHook(config CustomerSubjectHookConfig) (CustomerSubjectHook, error) {
@@ -65,6 +91,7 @@ func NewCustomerSubjectHook(config CustomerSubjectHookConfig) (CustomerSubjectHo
 	return &customerSubjectHook{
 		provisioner: provisioner,
 		logger:      config.Logger.With("subsystem", "subject_customer_provisioner"),
+		tracer:      config.Tracer,
 	}, nil
 }
 
@@ -75,6 +102,7 @@ var _ models.Validator = (*SubjectProvisionerConfig)(nil)
 type SubjectProvisionerConfig struct {
 	Subject subject.Service
 	Logger  *slog.Logger
+	Tracer  trace.Tracer
 }
 
 func (c SubjectProvisionerConfig) Validate() error {
@@ -88,6 +116,10 @@ func (c SubjectProvisionerConfig) Validate() error {
 		errs = append(errs, fmt.Errorf("logger is required"))
 	}
 
+	if c.Tracer == nil {
+		errs = append(errs, fmt.Errorf("tracer is required"))
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -99,12 +131,14 @@ func NewSubjectProvisioner(config SubjectProvisionerConfig) (*SubjectProvisioner
 	return &SubjectProvisioner{
 		subject: config.Subject,
 		logger:  config.Logger.With("subsystem", "subject.provisioner"),
+		tracer:  config.Tracer,
 	}, nil
 }
 
 type SubjectProvisioner struct {
 	subject subject.Service
 	logger  *slog.Logger
+	tracer  trace.Tracer
 }
 
 // EnsureSubjects ensures that Subjects are provisioned for each usage attribution entry.
@@ -117,35 +151,31 @@ func (p SubjectProvisioner) EnsureSubjects(ctx context.Context, cus *customer.Cu
 		return errors.New("failed to provision subject for customer: customer is nil")
 	}
 
+	var err error
+
+	ctx, span := p.tracer.Start(ctx, "subject_provisioner.ensure_subjects")
+	defer func() {
+		if err != nil {
+			span.SetStatus(otelcodes.Error, err.Error())
+			span.RecordError(err)
+		} else {
+			span.SetStatus(otelcodes.Ok, "subjects provisioned for customer")
+		}
+
+		span.End()
+	}()
+
+	span.SetAttributes(
+		attribute.String("customer.id", cus.ID),
+		attribute.String("customer.key", lo.FromPtrOr(cus.Key, "nil")),
+	)
+
 	var errs []error
 
 	for _, subKey := range cus.UsageAttribution.SubjectKeys {
-		// Check if the subject exists
-		sub, err := p.subject.GetByIdOrKey(ctx, cus.Namespace, subKey)
+		sub, err := p.EnsureSubject(ctx, cus, subKey)
 		if err != nil {
-			if models.IsGenericNotFoundError(err) {
-				// Create Subject if it does not exist
-				_, err = p.subject.Create(NewContextWithSkipSubjectCustomer(ctx),
-					subject.CreateInput{
-						Namespace: cus.Namespace,
-						Key:       subKey,
-						Metadata: lo.ToPtr(map[string]interface{}{
-							"createdBy":  "subject.provisioner",
-							"customerId": cus.ID,
-						}),
-					})
-				if err != nil {
-					errs = append(errs,
-						fmt.Errorf("failed to create subject for customer [namespace=%s customer.id=%s customer.usage_attribution_key: %s]: %w",
-							cus.Namespace, cus.ID, subKey, err),
-					)
-				}
-
-				continue
-			}
-
 			errs = append(errs, err)
-
 			continue
 		}
 
@@ -159,5 +189,69 @@ func (p SubjectProvisioner) EnsureSubjects(ctx context.Context, cus *customer.Cu
 		}
 	}
 
-	return errors.Join(errs...)
+	err = errors.Join(errs...)
+
+	return err
+}
+
+func (p SubjectProvisioner) EnsureSubject(ctx context.Context, cus *customer.Customer, subjectKey string) (*subject.Subject, error) {
+	if cus == nil {
+		return nil, errors.New("failed to provision subject for customer: customer is nil")
+	}
+
+	var err error
+
+	ctx, span := p.tracer.Start(ctx, "subject_provisioner.ensure_subject")
+	defer func() {
+		if err != nil {
+			span.SetStatus(otelcodes.Error, err.Error())
+			span.RecordError(err)
+		} else {
+			span.SetStatus(otelcodes.Ok, "subject provisioned for customer")
+		}
+
+		span.End()
+	}()
+
+	span.SetAttributes(
+		attribute.String("customer.id", cus.ID),
+		attribute.String("customer.key", lo.FromPtrOr(cus.Key, "nil")),
+	)
+
+	// Check if the subject exists
+	sub, err := p.subject.GetByIdOrKey(ctx, cus.Namespace, subjectKey)
+	if err != nil {
+		if models.IsGenericNotFoundError(err) {
+			// Create Subject if it does not exist
+			sub, err = p.subject.Create(NewContextWithSkipSubjectCustomer(ctx),
+				subject.CreateInput{
+					Namespace: cus.Namespace,
+					Key:       subjectKey,
+					Metadata: lo.ToPtr(map[string]interface{}{
+						"createdBy":  "subject.provisioner",
+						"customerId": cus.ID,
+					}),
+				})
+			if err != nil {
+				return nil, fmt.Errorf("failed to create subject for customer [namespace=%s customer.id=%s customer.usage_attribution_key: %s]: %w",
+					cus.Namespace, cus.ID, subjectKey, err)
+			}
+
+			span.AddEvent("created subject", trace.WithAttributes(
+				attribute.String("subject.id", sub.Id),
+				attribute.String("subject.key", sub.Key),
+			))
+
+			return &sub, nil
+		}
+
+		return nil, err
+	}
+
+	span.AddEvent("found subject", trace.WithAttributes(
+		attribute.String("subject.id", sub.Id),
+		attribute.String("subject.key", sub.Key),
+	))
+
+	return &sub, nil
 }


### PR DESCRIPTION
## Overview

Add Otel tracing to service hooks responsible for syncing customers and subjects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OpenTelemetry tracing across customer and subject provisioning flows (per-operation spans, events, status and error recording), including new per-subject instrumentation and ensure operations.
  - Configuration and hooks now accept a tracer to enable observability while preserving existing behavior when tracing is disabled.
- **Tests**
  - Test environment updated with a noop tracer and tracing wired through hook setups to validate instrumentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->