### PR TITLE
fix: customer delete

### DIFF
--- a/openmeter/customer/adapter/customer.go
+++ b/openmeter/customer/adapter/customer.go
@@ -293,7 +293,8 @@ func (a *adapter) DeleteCustomer(ctx context.Context, input customer.DeleteCusto
 			Where(customersubjectsdb.CustomerID(input.ID)).
 			Where(customersubjectsdb.Namespace(input.Namespace)).
 			Where(customersubjectsdb.DeletedAtIsNil()).
-			SetDeletedAt(deletedAt).
+			Where(customersubjectsdb.CustomerDeletedAtIsNil()).
+			SetCustomerDeletedAt(deletedAt).
 			Exec(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to delete customer subjects: %w", err)

--- a/openmeter/ent/db/customersubjects.go
+++ b/openmeter/ent/db/customersubjects.go
@@ -28,6 +28,8 @@ type CustomerSubjects struct {
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// DeletedAt holds the value of the "deleted_at" field.
 	DeletedAt *time.Time `json:"deleted_at,omitempty"`
+	// CustomerDeletedAt holds the value of the "customer_deleted_at" field.
+	CustomerDeletedAt *time.Time `json:"customer_deleted_at,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CustomerSubjectsQuery when eager-loading is set.
 	Edges        CustomerSubjectsEdges `json:"edges"`
@@ -63,7 +65,7 @@ func (*CustomerSubjects) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullInt64)
 		case customersubjects.FieldNamespace, customersubjects.FieldCustomerID, customersubjects.FieldSubjectKey:
 			values[i] = new(sql.NullString)
-		case customersubjects.FieldCreatedAt, customersubjects.FieldDeletedAt:
+		case customersubjects.FieldCreatedAt, customersubjects.FieldDeletedAt, customersubjects.FieldCustomerDeletedAt:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -116,6 +118,13 @@ func (_m *CustomerSubjects) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.DeletedAt = new(time.Time)
 				*_m.DeletedAt = value.Time
+			}
+		case customersubjects.FieldCustomerDeletedAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field customer_deleted_at", values[i])
+			} else if value.Valid {
+				_m.CustomerDeletedAt = new(time.Time)
+				*_m.CustomerDeletedAt = value.Time
 			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
@@ -172,6 +181,11 @@ func (_m *CustomerSubjects) String() string {
 	builder.WriteString(", ")
 	if v := _m.DeletedAt; v != nil {
 		builder.WriteString("deleted_at=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
+	builder.WriteString(", ")
+	if v := _m.CustomerDeletedAt; v != nil {
+		builder.WriteString("customer_deleted_at=")
 		builder.WriteString(v.Format(time.ANSIC))
 	}
 	builder.WriteByte(')')

--- a/openmeter/ent/db/customersubjects/customersubjects.go
+++ b/openmeter/ent/db/customersubjects/customersubjects.go
@@ -24,6 +24,8 @@ const (
 	FieldCreatedAt = "created_at"
 	// FieldDeletedAt holds the string denoting the deleted_at field in the database.
 	FieldDeletedAt = "deleted_at"
+	// FieldCustomerDeletedAt holds the string denoting the customer_deleted_at field in the database.
+	FieldCustomerDeletedAt = "customer_deleted_at"
 	// EdgeCustomer holds the string denoting the customer edge name in mutations.
 	EdgeCustomer = "customer"
 	// Table holds the table name of the customersubjects in the database.
@@ -45,6 +47,7 @@ var Columns = []string{
 	FieldSubjectKey,
 	FieldCreatedAt,
 	FieldDeletedAt,
+	FieldCustomerDeletedAt,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -99,6 +102,11 @@ func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 // ByDeletedAt orders the results by the deleted_at field.
 func ByDeletedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDeletedAt, opts...).ToFunc()
+}
+
+// ByCustomerDeletedAt orders the results by the customer_deleted_at field.
+func ByCustomerDeletedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCustomerDeletedAt, opts...).ToFunc()
 }
 
 // ByCustomerField orders the results by customer field.

--- a/openmeter/ent/db/customersubjects/where.go
+++ b/openmeter/ent/db/customersubjects/where.go
@@ -80,6 +80,11 @@ func DeletedAt(v time.Time) predicate.CustomerSubjects {
 	return predicate.CustomerSubjects(sql.FieldEQ(FieldDeletedAt, v))
 }
 
+// CustomerDeletedAt applies equality check predicate on the "customer_deleted_at" field. It's identical to CustomerDeletedAtEQ.
+func CustomerDeletedAt(v time.Time) predicate.CustomerSubjects {
+	return predicate.CustomerSubjects(sql.FieldEQ(FieldCustomerDeletedAt, v))
+}
+
 // NamespaceEQ applies the EQ predicate on the "namespace" field.
 func NamespaceEQ(v string) predicate.CustomerSubjects {
 	return predicate.CustomerSubjects(sql.FieldEQ(FieldNamespace, v))
@@ -363,6 +368,56 @@ func DeletedAtIsNil() predicate.CustomerSubjects {
 // DeletedAtNotNil applies the NotNil predicate on the "deleted_at" field.
 func DeletedAtNotNil() predicate.CustomerSubjects {
 	return predicate.CustomerSubjects(sql.FieldNotNull(FieldDeletedAt))
+}
+
+// CustomerDeletedAtEQ applies the EQ predicate on the "customer_deleted_at" field.
+func CustomerDeletedAtEQ(v time.Time) predicate.CustomerSubjects {
+	return predicate.CustomerSubjects(sql.FieldEQ(FieldCustomerDeletedAt, v))
+}
+
+// CustomerDeletedAtNEQ applies the NEQ predicate on the "customer_deleted_at" field.
+func CustomerDeletedAtNEQ(v time.Time) predicate.CustomerSubjects {
+	return predicate.CustomerSubjects(sql.FieldNEQ(FieldCustomerDeletedAt, v))
+}
+
+// CustomerDeletedAtIn applies the In predicate on the "customer_deleted_at" field.
+func CustomerDeletedAtIn(vs ...time.Time) predicate.CustomerSubjects {
+	return predicate.CustomerSubjects(sql.FieldIn(FieldCustomerDeletedAt, vs...))
+}
+
+// CustomerDeletedAtNotIn applies the NotIn predicate on the "customer_deleted_at" field.
+func CustomerDeletedAtNotIn(vs ...time.Time) predicate.CustomerSubjects {
+	return predicate.CustomerSubjects(sql.FieldNotIn(FieldCustomerDeletedAt, vs...))
+}
+
+// CustomerDeletedAtGT applies the GT predicate on the "customer_deleted_at" field.
+func CustomerDeletedAtGT(v time.Time) predicate.CustomerSubjects {
+	return predicate.CustomerSubjects(sql.FieldGT(FieldCustomerDeletedAt, v))
+}
+
+// CustomerDeletedAtGTE applies the GTE predicate on the "customer_deleted_at" field.
+func CustomerDeletedAtGTE(v time.Time) predicate.CustomerSubjects {
+	return predicate.CustomerSubjects(sql.FieldGTE(FieldCustomerDeletedAt, v))
+}
+
+// CustomerDeletedAtLT applies the LT predicate on the "customer_deleted_at" field.
+func CustomerDeletedAtLT(v time.Time) predicate.CustomerSubjects {
+	return predicate.CustomerSubjects(sql.FieldLT(FieldCustomerDeletedAt, v))
+}
+
+// CustomerDeletedAtLTE applies the LTE predicate on the "customer_deleted_at" field.
+func CustomerDeletedAtLTE(v time.Time) predicate.CustomerSubjects {
+	return predicate.CustomerSubjects(sql.FieldLTE(FieldCustomerDeletedAt, v))
+}
+
+// CustomerDeletedAtIsNil applies the IsNil predicate on the "customer_deleted_at" field.
+func CustomerDeletedAtIsNil() predicate.CustomerSubjects {
+	return predicate.CustomerSubjects(sql.FieldIsNull(FieldCustomerDeletedAt))
+}
+
+// CustomerDeletedAtNotNil applies the NotNil predicate on the "customer_deleted_at" field.
+func CustomerDeletedAtNotNil() predicate.CustomerSubjects {
+	return predicate.CustomerSubjects(sql.FieldNotNull(FieldCustomerDeletedAt))
 }
 
 // HasCustomer applies the HasEdge predicate on the "customer" edge.

--- a/openmeter/ent/db/customersubjects_create.go
+++ b/openmeter/ent/db/customersubjects_create.go
@@ -69,6 +69,20 @@ func (_c *CustomerSubjectsCreate) SetNillableDeletedAt(v *time.Time) *CustomerSu
 	return _c
 }
 
+// SetCustomerDeletedAt sets the "customer_deleted_at" field.
+func (_c *CustomerSubjectsCreate) SetCustomerDeletedAt(v time.Time) *CustomerSubjectsCreate {
+	_c.mutation.SetCustomerDeletedAt(v)
+	return _c
+}
+
+// SetNillableCustomerDeletedAt sets the "customer_deleted_at" field if the given value is not nil.
+func (_c *CustomerSubjectsCreate) SetNillableCustomerDeletedAt(v *time.Time) *CustomerSubjectsCreate {
+	if v != nil {
+		_c.SetCustomerDeletedAt(*v)
+	}
+	return _c
+}
+
 // SetCustomer sets the "customer" edge to the Customer entity.
 func (_c *CustomerSubjectsCreate) SetCustomer(v *Customer) *CustomerSubjectsCreate {
 	return _c.SetCustomerID(v.ID)
@@ -190,6 +204,10 @@ func (_c *CustomerSubjectsCreate) createSpec() (*CustomerSubjects, *sqlgraph.Cre
 		_spec.SetField(customersubjects.FieldDeletedAt, field.TypeTime, value)
 		_node.DeletedAt = &value
 	}
+	if value, ok := _c.mutation.CustomerDeletedAt(); ok {
+		_spec.SetField(customersubjects.FieldCustomerDeletedAt, field.TypeTime, value)
+		_node.CustomerDeletedAt = &value
+	}
 	if nodes := _c.mutation.CustomerIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -277,6 +295,24 @@ func (u *CustomerSubjectsUpsert) ClearDeletedAt() *CustomerSubjectsUpsert {
 	return u
 }
 
+// SetCustomerDeletedAt sets the "customer_deleted_at" field.
+func (u *CustomerSubjectsUpsert) SetCustomerDeletedAt(v time.Time) *CustomerSubjectsUpsert {
+	u.Set(customersubjects.FieldCustomerDeletedAt, v)
+	return u
+}
+
+// UpdateCustomerDeletedAt sets the "customer_deleted_at" field to the value that was provided on create.
+func (u *CustomerSubjectsUpsert) UpdateCustomerDeletedAt() *CustomerSubjectsUpsert {
+	u.SetExcluded(customersubjects.FieldCustomerDeletedAt)
+	return u
+}
+
+// ClearCustomerDeletedAt clears the value of the "customer_deleted_at" field.
+func (u *CustomerSubjectsUpsert) ClearCustomerDeletedAt() *CustomerSubjectsUpsert {
+	u.SetNull(customersubjects.FieldCustomerDeletedAt)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -349,6 +385,27 @@ func (u *CustomerSubjectsUpsertOne) UpdateDeletedAt() *CustomerSubjectsUpsertOne
 func (u *CustomerSubjectsUpsertOne) ClearDeletedAt() *CustomerSubjectsUpsertOne {
 	return u.Update(func(s *CustomerSubjectsUpsert) {
 		s.ClearDeletedAt()
+	})
+}
+
+// SetCustomerDeletedAt sets the "customer_deleted_at" field.
+func (u *CustomerSubjectsUpsertOne) SetCustomerDeletedAt(v time.Time) *CustomerSubjectsUpsertOne {
+	return u.Update(func(s *CustomerSubjectsUpsert) {
+		s.SetCustomerDeletedAt(v)
+	})
+}
+
+// UpdateCustomerDeletedAt sets the "customer_deleted_at" field to the value that was provided on create.
+func (u *CustomerSubjectsUpsertOne) UpdateCustomerDeletedAt() *CustomerSubjectsUpsertOne {
+	return u.Update(func(s *CustomerSubjectsUpsert) {
+		s.UpdateCustomerDeletedAt()
+	})
+}
+
+// ClearCustomerDeletedAt clears the value of the "customer_deleted_at" field.
+func (u *CustomerSubjectsUpsertOne) ClearCustomerDeletedAt() *CustomerSubjectsUpsertOne {
+	return u.Update(func(s *CustomerSubjectsUpsert) {
+		s.ClearCustomerDeletedAt()
 	})
 }
 
@@ -590,6 +647,27 @@ func (u *CustomerSubjectsUpsertBulk) UpdateDeletedAt() *CustomerSubjectsUpsertBu
 func (u *CustomerSubjectsUpsertBulk) ClearDeletedAt() *CustomerSubjectsUpsertBulk {
 	return u.Update(func(s *CustomerSubjectsUpsert) {
 		s.ClearDeletedAt()
+	})
+}
+
+// SetCustomerDeletedAt sets the "customer_deleted_at" field.
+func (u *CustomerSubjectsUpsertBulk) SetCustomerDeletedAt(v time.Time) *CustomerSubjectsUpsertBulk {
+	return u.Update(func(s *CustomerSubjectsUpsert) {
+		s.SetCustomerDeletedAt(v)
+	})
+}
+
+// UpdateCustomerDeletedAt sets the "customer_deleted_at" field to the value that was provided on create.
+func (u *CustomerSubjectsUpsertBulk) UpdateCustomerDeletedAt() *CustomerSubjectsUpsertBulk {
+	return u.Update(func(s *CustomerSubjectsUpsert) {
+		s.UpdateCustomerDeletedAt()
+	})
+}
+
+// ClearCustomerDeletedAt clears the value of the "customer_deleted_at" field.
+func (u *CustomerSubjectsUpsertBulk) ClearCustomerDeletedAt() *CustomerSubjectsUpsertBulk {
+	return u.Update(func(s *CustomerSubjectsUpsert) {
+		s.ClearCustomerDeletedAt()
 	})
 }
 

--- a/openmeter/ent/db/customersubjects_update.go
+++ b/openmeter/ent/db/customersubjects_update.go
@@ -48,6 +48,26 @@ func (_u *CustomerSubjectsUpdate) ClearDeletedAt() *CustomerSubjectsUpdate {
 	return _u
 }
 
+// SetCustomerDeletedAt sets the "customer_deleted_at" field.
+func (_u *CustomerSubjectsUpdate) SetCustomerDeletedAt(v time.Time) *CustomerSubjectsUpdate {
+	_u.mutation.SetCustomerDeletedAt(v)
+	return _u
+}
+
+// SetNillableCustomerDeletedAt sets the "customer_deleted_at" field if the given value is not nil.
+func (_u *CustomerSubjectsUpdate) SetNillableCustomerDeletedAt(v *time.Time) *CustomerSubjectsUpdate {
+	if v != nil {
+		_u.SetCustomerDeletedAt(*v)
+	}
+	return _u
+}
+
+// ClearCustomerDeletedAt clears the value of the "customer_deleted_at" field.
+func (_u *CustomerSubjectsUpdate) ClearCustomerDeletedAt() *CustomerSubjectsUpdate {
+	_u.mutation.ClearCustomerDeletedAt()
+	return _u
+}
+
 // Mutation returns the CustomerSubjectsMutation object of the builder.
 func (_u *CustomerSubjectsUpdate) Mutation() *CustomerSubjectsMutation {
 	return _u.mutation
@@ -106,6 +126,12 @@ func (_u *CustomerSubjectsUpdate) sqlSave(ctx context.Context) (_node int, err e
 	if _u.mutation.DeletedAtCleared() {
 		_spec.ClearField(customersubjects.FieldDeletedAt, field.TypeTime)
 	}
+	if value, ok := _u.mutation.CustomerDeletedAt(); ok {
+		_spec.SetField(customersubjects.FieldCustomerDeletedAt, field.TypeTime, value)
+	}
+	if _u.mutation.CustomerDeletedAtCleared() {
+		_spec.ClearField(customersubjects.FieldCustomerDeletedAt, field.TypeTime)
+	}
 	if _node, err = sqlgraph.UpdateNodes(ctx, _u.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{customersubjects.Label}
@@ -143,6 +169,26 @@ func (_u *CustomerSubjectsUpdateOne) SetNillableDeletedAt(v *time.Time) *Custome
 // ClearDeletedAt clears the value of the "deleted_at" field.
 func (_u *CustomerSubjectsUpdateOne) ClearDeletedAt() *CustomerSubjectsUpdateOne {
 	_u.mutation.ClearDeletedAt()
+	return _u
+}
+
+// SetCustomerDeletedAt sets the "customer_deleted_at" field.
+func (_u *CustomerSubjectsUpdateOne) SetCustomerDeletedAt(v time.Time) *CustomerSubjectsUpdateOne {
+	_u.mutation.SetCustomerDeletedAt(v)
+	return _u
+}
+
+// SetNillableCustomerDeletedAt sets the "customer_deleted_at" field if the given value is not nil.
+func (_u *CustomerSubjectsUpdateOne) SetNillableCustomerDeletedAt(v *time.Time) *CustomerSubjectsUpdateOne {
+	if v != nil {
+		_u.SetCustomerDeletedAt(*v)
+	}
+	return _u
+}
+
+// ClearCustomerDeletedAt clears the value of the "customer_deleted_at" field.
+func (_u *CustomerSubjectsUpdateOne) ClearCustomerDeletedAt() *CustomerSubjectsUpdateOne {
+	_u.mutation.ClearCustomerDeletedAt()
 	return _u
 }
 
@@ -233,6 +279,12 @@ func (_u *CustomerSubjectsUpdateOne) sqlSave(ctx context.Context) (_node *Custom
 	}
 	if _u.mutation.DeletedAtCleared() {
 		_spec.ClearField(customersubjects.FieldDeletedAt, field.TypeTime)
+	}
+	if value, ok := _u.mutation.CustomerDeletedAt(); ok {
+		_spec.SetField(customersubjects.FieldCustomerDeletedAt, field.TypeTime, value)
+	}
+	if _u.mutation.CustomerDeletedAtCleared() {
+		_spec.ClearField(customersubjects.FieldCustomerDeletedAt, field.TypeTime)
 	}
 	_node = &CustomerSubjects{config: _u.config}
 	_spec.Assign = _node.assignValues

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1359,6 +1359,7 @@ var (
 		{Name: "subject_key", Type: field.TypeString},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
+		{Name: "customer_deleted_at", Type: field.TypeTime, Nullable: true},
 		{Name: "customer_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 	}
 	// CustomerSubjectsTable holds the schema information for the "customer_subjects" table.
@@ -1369,7 +1370,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "customer_subjects_customers_subjects",
-				Columns:    []*schema.Column{CustomerSubjectsColumns[5]},
+				Columns:    []*schema.Column{CustomerSubjectsColumns[6]},
 				RefColumns: []*schema.Column{CustomersColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -1383,14 +1384,14 @@ var (
 			{
 				Name:    "customersubjects_namespace_customer_id_deleted_at",
 				Unique:  false,
-				Columns: []*schema.Column{CustomerSubjectsColumns[1], CustomerSubjectsColumns[5], CustomerSubjectsColumns[4]},
+				Columns: []*schema.Column{CustomerSubjectsColumns[1], CustomerSubjectsColumns[6], CustomerSubjectsColumns[4]},
 			},
 			{
 				Name:    "customersubjects_namespace_subject_key",
 				Unique:  true,
 				Columns: []*schema.Column{CustomerSubjectsColumns[1], CustomerSubjectsColumns[2]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "deleted_at IS NULL",
+					Where: "deleted_at IS NULL AND customer_deleted_at IS NULL",
 				},
 			},
 		},

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -31111,19 +31111,20 @@ func (m *CustomerMutation) ResetEdge(name string) error {
 // CustomerSubjectsMutation represents an operation that mutates the CustomerSubjects nodes in the graph.
 type CustomerSubjectsMutation struct {
 	config
-	op              Op
-	typ             string
-	id              *int
-	namespace       *string
-	subject_key     *string
-	created_at      *time.Time
-	deleted_at      *time.Time
-	clearedFields   map[string]struct{}
-	customer        *string
-	clearedcustomer bool
-	done            bool
-	oldValue        func(context.Context) (*CustomerSubjects, error)
-	predicates      []predicate.CustomerSubjects
+	op                  Op
+	typ                 string
+	id                  *int
+	namespace           *string
+	subject_key         *string
+	created_at          *time.Time
+	deleted_at          *time.Time
+	customer_deleted_at *time.Time
+	clearedFields       map[string]struct{}
+	customer            *string
+	clearedcustomer     bool
+	done                bool
+	oldValue            func(context.Context) (*CustomerSubjects, error)
+	predicates          []predicate.CustomerSubjects
 }
 
 var _ ent.Mutation = (*CustomerSubjectsMutation)(nil)
@@ -31417,6 +31418,55 @@ func (m *CustomerSubjectsMutation) ResetDeletedAt() {
 	delete(m.clearedFields, customersubjects.FieldDeletedAt)
 }
 
+// SetCustomerDeletedAt sets the "customer_deleted_at" field.
+func (m *CustomerSubjectsMutation) SetCustomerDeletedAt(t time.Time) {
+	m.customer_deleted_at = &t
+}
+
+// CustomerDeletedAt returns the value of the "customer_deleted_at" field in the mutation.
+func (m *CustomerSubjectsMutation) CustomerDeletedAt() (r time.Time, exists bool) {
+	v := m.customer_deleted_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCustomerDeletedAt returns the old "customer_deleted_at" field's value of the CustomerSubjects entity.
+// If the CustomerSubjects object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CustomerSubjectsMutation) OldCustomerDeletedAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCustomerDeletedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCustomerDeletedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCustomerDeletedAt: %w", err)
+	}
+	return oldValue.CustomerDeletedAt, nil
+}
+
+// ClearCustomerDeletedAt clears the value of the "customer_deleted_at" field.
+func (m *CustomerSubjectsMutation) ClearCustomerDeletedAt() {
+	m.customer_deleted_at = nil
+	m.clearedFields[customersubjects.FieldCustomerDeletedAt] = struct{}{}
+}
+
+// CustomerDeletedAtCleared returns if the "customer_deleted_at" field was cleared in this mutation.
+func (m *CustomerSubjectsMutation) CustomerDeletedAtCleared() bool {
+	_, ok := m.clearedFields[customersubjects.FieldCustomerDeletedAt]
+	return ok
+}
+
+// ResetCustomerDeletedAt resets all changes to the "customer_deleted_at" field.
+func (m *CustomerSubjectsMutation) ResetCustomerDeletedAt() {
+	m.customer_deleted_at = nil
+	delete(m.clearedFields, customersubjects.FieldCustomerDeletedAt)
+}
+
 // ClearCustomer clears the "customer" edge to the Customer entity.
 func (m *CustomerSubjectsMutation) ClearCustomer() {
 	m.clearedcustomer = true
@@ -31478,7 +31528,7 @@ func (m *CustomerSubjectsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CustomerSubjectsMutation) Fields() []string {
-	fields := make([]string, 0, 5)
+	fields := make([]string, 0, 6)
 	if m.namespace != nil {
 		fields = append(fields, customersubjects.FieldNamespace)
 	}
@@ -31493,6 +31543,9 @@ func (m *CustomerSubjectsMutation) Fields() []string {
 	}
 	if m.deleted_at != nil {
 		fields = append(fields, customersubjects.FieldDeletedAt)
+	}
+	if m.customer_deleted_at != nil {
+		fields = append(fields, customersubjects.FieldCustomerDeletedAt)
 	}
 	return fields
 }
@@ -31512,6 +31565,8 @@ func (m *CustomerSubjectsMutation) Field(name string) (ent.Value, bool) {
 		return m.CreatedAt()
 	case customersubjects.FieldDeletedAt:
 		return m.DeletedAt()
+	case customersubjects.FieldCustomerDeletedAt:
+		return m.CustomerDeletedAt()
 	}
 	return nil, false
 }
@@ -31531,6 +31586,8 @@ func (m *CustomerSubjectsMutation) OldField(ctx context.Context, name string) (e
 		return m.OldCreatedAt(ctx)
 	case customersubjects.FieldDeletedAt:
 		return m.OldDeletedAt(ctx)
+	case customersubjects.FieldCustomerDeletedAt:
+		return m.OldCustomerDeletedAt(ctx)
 	}
 	return nil, fmt.Errorf("unknown CustomerSubjects field %s", name)
 }
@@ -31575,6 +31632,13 @@ func (m *CustomerSubjectsMutation) SetField(name string, value ent.Value) error 
 		}
 		m.SetDeletedAt(v)
 		return nil
+	case customersubjects.FieldCustomerDeletedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCustomerDeletedAt(v)
+		return nil
 	}
 	return fmt.Errorf("unknown CustomerSubjects field %s", name)
 }
@@ -31608,6 +31672,9 @@ func (m *CustomerSubjectsMutation) ClearedFields() []string {
 	if m.FieldCleared(customersubjects.FieldDeletedAt) {
 		fields = append(fields, customersubjects.FieldDeletedAt)
 	}
+	if m.FieldCleared(customersubjects.FieldCustomerDeletedAt) {
+		fields = append(fields, customersubjects.FieldCustomerDeletedAt)
+	}
 	return fields
 }
 
@@ -31624,6 +31691,9 @@ func (m *CustomerSubjectsMutation) ClearField(name string) error {
 	switch name {
 	case customersubjects.FieldDeletedAt:
 		m.ClearDeletedAt()
+		return nil
+	case customersubjects.FieldCustomerDeletedAt:
+		m.ClearCustomerDeletedAt()
 		return nil
 	}
 	return fmt.Errorf("unknown CustomerSubjects nullable field %s", name)
@@ -31647,6 +31717,9 @@ func (m *CustomerSubjectsMutation) ResetField(name string) error {
 		return nil
 	case customersubjects.FieldDeletedAt:
 		m.ResetDeletedAt()
+		return nil
+	case customersubjects.FieldCustomerDeletedAt:
+		m.ResetCustomerDeletedAt()
 		return nil
 	}
 	return fmt.Errorf("unknown CustomerSubjects field %s", name)

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -2015,6 +2015,20 @@ func (u *CustomerSubjectsUpdateOne) SetOrClearDeletedAt(value *time.Time) *Custo
 	return u.SetDeletedAt(*value)
 }
 
+func (u *CustomerSubjectsUpdate) SetOrClearCustomerDeletedAt(value *time.Time) *CustomerSubjectsUpdate {
+	if value == nil {
+		return u.ClearCustomerDeletedAt()
+	}
+	return u.SetCustomerDeletedAt(*value)
+}
+
+func (u *CustomerSubjectsUpdateOne) SetOrClearCustomerDeletedAt(value *time.Time) *CustomerSubjectsUpdateOne {
+	if value == nil {
+		return u.ClearCustomerDeletedAt()
+	}
+	return u.SetCustomerDeletedAt(*value)
+}
+
 func (u *EntitlementUpdate) SetOrClearMetadata(value *map[string]string) *EntitlementUpdate {
 	if value == nil {
 		return u.ClearMetadata()

--- a/openmeter/ent/schema/customer.go
+++ b/openmeter/ent/schema/customer.go
@@ -96,6 +96,9 @@ func (CustomerSubjects) Fields() []ent.Field {
 		field.Time("deleted_at").
 			Optional().
 			Nillable(),
+		field.Time("customer_deleted_at").
+			Optional().
+			Nillable(),
 	}
 }
 
@@ -105,7 +108,7 @@ func (CustomerSubjects) Indexes() []ent.Index {
 		index.Fields("namespace", "subject_key").
 			Annotations(
 				// Partial index: We skip the index on active non deleted customer subjects.
-				entsql.IndexWhere("deleted_at IS NULL"),
+				entsql.IndexWhere("deleted_at IS NULL AND customer_deleted_at IS NULL"),
 			).
 			Unique(),
 	}

--- a/tools/migrate/migrations/20250907132537_differentiate-customer-and-subject-mapping-deletion.down.sql
+++ b/tools/migrate/migrations/20250907132537_differentiate-customer-and-subject-mapping-deletion.down.sql
@@ -1,0 +1,6 @@
+-- reverse: create index "customersubjects_namespace_subject_key" to table: "customer_subjects"
+DROP INDEX "customersubjects_namespace_subject_key";
+-- reverse: modify "customer_subjects" table
+ALTER TABLE "customer_subjects" DROP COLUMN "customer_deleted_at";
+-- reverse: drop index "customersubjects_namespace_subject_key" from table: "customer_subjects"
+CREATE UNIQUE INDEX "customersubjects_namespace_subject_key" ON "customer_subjects" ("namespace", "subject_key") WHERE (deleted_at IS NULL);

--- a/tools/migrate/migrations/20250907132537_differentiate-customer-and-subject-mapping-deletion.up.sql
+++ b/tools/migrate/migrations/20250907132537_differentiate-customer-and-subject-mapping-deletion.up.sql
@@ -1,0 +1,6 @@
+-- drop index "customersubjects_namespace_subject_key" from table: "customer_subjects"
+DROP INDEX "customersubjects_namespace_subject_key";
+-- modify "customer_subjects" table
+ALTER TABLE "customer_subjects" ADD COLUMN "customer_deleted_at" timestamptz NULL;
+-- create index "customersubjects_namespace_subject_key" to table: "customer_subjects"
+CREATE UNIQUE INDEX "customersubjects_namespace_subject_key" ON "customer_subjects" ("namespace", "subject_key") WHERE ((deleted_at IS NULL) AND (customer_deleted_at IS NULL));

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:6oUKNaoZ75QTSlUUvXt/eNd4CszaLZR5SqYq2Atg6iI=
+h1:xGzGxB0CfPk3rcWKQTIjOjBZ5cpq3urD7GqzICbtj2s=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -122,3 +122,4 @@ h1:6oUKNaoZ75QTSlUUvXt/eNd4CszaLZR5SqYq2Atg6iI=
 20250818093933_entitlement-subject-id.up.sql h1:gpRPmlpH/H1eJ2BG4t/CBWWMeZ64A+guu7jIUGPh7Fk=
 20250821121421_entitlement-customer-link.up.sql h1:zDOaRmPqG0M0Dxl6+oZnhZ/M0RnkJUq49EmuXOOKjco=
 20250904120629_subject-created-at-index.up.sql h1:DD2yI27rAIj/eW/3aYojOrlk0KxE/rpqER3RzOMKDmk=
+20250907132537_differentiate-customer-and-subject-mapping-deletion.up.sql h1:HxjyuNnBB/edIiNDrmiGV2fEDh/wVPN1ag0lxhB26AY=


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Use a different field to determine if the usage_attribution of the subject has been deleted due to the customer being deleted or if the mapping has changend.

I would prefer this approach instead of checking for equality with the customer.deleted_at field as it makes it more explicit why the deletion have happened.

# Migration

Most probably the following migration would work to update the DB (but it's fine to test it seperately):

```

with deleted_customers as (
select cs.id, c.deleted_at 
from customer_subjects cs join customers c on (cs.customer_id = c.id) 
where
  cs.deleted_at is not null and c.deleted_at is not null and cs.deleted_at = c.deleted_at;

)
update customer_subjects cs
set cs.deleted_at = null, cs.customer_deleted_at = dc.deleted_at
from deleted_customers dc
where dc.id = customer_subjects.id;
```