### PR TITLE
fix: missing usage attribution for deleted customer

### DIFF
--- a/openmeter/customer/adapter/customer.go
+++ b/openmeter/customer/adapter/customer.go
@@ -39,7 +39,10 @@ func (a *adapter) ListCustomers(ctx context.Context, input customer.ListCustomer
 
 		// Do not return deleted customers by default
 		if !input.IncludeDeleted {
-			query = query.Where(customerdb.DeletedAtIsNil())
+			query = query.Where(customerdb.Or(
+				customerdb.DeletedAtIsNil(),
+				customerdb.DeletedAtGT(now),
+			))
 		}
 
 		// Filters
@@ -223,7 +226,8 @@ func (a *adapter) CreateCustomer(ctx context.Context, input customer.CreateCusto
 						return repo.db.CustomerSubjects.Create().
 							SetNamespace(customerEntity.Namespace).
 							SetCustomerID(customerEntity.ID).
-							SetSubjectKey(subjectKey)
+							SetSubjectKey(subjectKey).
+							SetCreatedAt(customerEntity.CreatedAt)
 					},
 				)...,
 			).
@@ -329,9 +333,11 @@ func (a *adapter) GetCustomer(ctx context.Context, input customer.GetCustomerInp
 			query = query.Where(customerdb.Namespace(input.CustomerIDOrKey.Namespace))
 			query = query.Where(customerdb.Or(
 				customerdb.ID(input.CustomerIDOrKey.IDOrKey),
-				customerdb.Key(input.CustomerIDOrKey.IDOrKey),
+				customerdb.And(
+					customerdb.Key(input.CustomerIDOrKey.IDOrKey),
+					customerdb.DeletedAtIsNil(),
+				),
 			))
-			query = query.Where(customerdb.DeletedAtIsNil())
 			query = query.Order(customerdb.ByID(sql.OrderAsc()))
 		} else {
 			return nil, models.NewGenericValidationError(
@@ -365,8 +371,7 @@ func (a *adapter) GetCustomer(ctx context.Context, input customer.GetCustomerInp
 		}
 
 		return CustomerFromDBEntity(*entity)
-	},
-	)
+	})
 }
 
 // GetCustomerByUsageAttribution gets a customer by usage attribution
@@ -421,6 +426,20 @@ func (a *adapter) UpdateCustomer(ctx context.Context, input customer.UpdateCusto
 	}
 
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, repo *adapter) (*customer.Customer, error) {
+		// Get the customer to diff the subjects
+		previousCustomer, err := repo.GetCustomer(ctx, customer.GetCustomerInput{
+			CustomerID: &input.CustomerID,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if previousCustomer != nil && previousCustomer.DeletedAt != nil {
+			return nil, models.NewGenericValidationError(
+				fmt.Errorf("cannot updated already deleted customer [namespace=%s customer.id=%s]", input.CustomerID.Namespace, input.CustomerID.ID),
+			)
+		}
+
 		// Check if the key is not an ID of another customer
 		if input.Key != nil {
 			count, err := repo.db.Customer.Query().
@@ -456,14 +475,6 @@ func (a *adapter) UpdateCustomer(ctx context.Context, input customer.UpdateCusto
 					fmt.Errorf("key %s overlaps with subject of another customer: %s", *input.Key, conflictingCustomerIDs[0].CustomerID),
 				)
 			}
-		}
-
-		// Get the customer to diff the subjects
-		previousCustomer, err := repo.GetCustomer(ctx, customer.GetCustomerInput{
-			CustomerID: &input.CustomerID,
-		})
-		if err != nil {
-			return nil, err
 		}
 
 		query := repo.db.Customer.UpdateOneID(previousCustomer.ID).
@@ -633,17 +644,33 @@ func (a *adapter) UpdateCustomer(ctx context.Context, input customer.UpdateCusto
 		}
 
 		return cus, nil
-	},
-	)
+	})
 }
 
 // withSubjects returns a query with the subjects
-func withSubjects(query *entdb.CustomerQuery, at time.Time) *entdb.CustomerQuery {
-	return query.WithSubjects(func(query *entdb.CustomerSubjectsQuery) {
-		query.Where(customersubjectsdb.Or(
-			customersubjectsdb.DeletedAtIsNil(),
-			customersubjectsdb.DeletedAtGT(at),
-		))
+func withSubjects(q *entdb.CustomerQuery, at time.Time) *entdb.CustomerQuery {
+	return q.WithSubjects(func(query *entdb.CustomerSubjectsQuery) {
+		query.Where(func(s *sql.Selector) {
+			ct := sql.Table(customerdb.Table)
+
+			s.Join(ct).On(ct.C(customerdb.FieldID), s.C(customersubjectsdb.FieldCustomerID))
+
+			s.Where(
+				sql.Or(
+					sql.And(
+						sql.NotNull(ct.C(customerdb.FieldDeletedAt)),
+						sql.ColumnsEQ(s.C(customersubjectsdb.FieldDeletedAt), ct.C(customerdb.FieldDeletedAt)),
+					),
+					sql.And(
+						sql.IsNull(ct.C(customerdb.FieldDeletedAt)),
+						sql.Or(
+							sql.IsNull(s.C(customersubjectsdb.FieldDeletedAt)),
+							sql.GT(s.C(customersubjectsdb.FieldDeletedAt), at),
+						),
+					),
+				),
+			)
+		})
 	})
 }
 

--- a/openmeter/customer/service/customer.go
+++ b/openmeter/customer/service/customer.go
@@ -14,9 +14,7 @@ var _ customer.Service = (*Service)(nil)
 
 // ListCustomers lists customers
 func (s *Service) ListCustomers(ctx context.Context, input customer.ListCustomersInput) (pagination.PagedResponse[customer.Customer], error) {
-	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (pagination.PagedResponse[customer.Customer], error) {
-		return s.adapter.ListCustomers(ctx, input)
-	})
+	return s.adapter.ListCustomers(ctx, input)
 }
 
 // CreateCustomer creates a customer
@@ -107,16 +105,12 @@ func (s *Service) DeleteCustomer(ctx context.Context, input customer.DeleteCusto
 
 // GetCustomer gets a customer
 func (s *Service) GetCustomer(ctx context.Context, input customer.GetCustomerInput) (*customer.Customer, error) {
-	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (*customer.Customer, error) {
-		return s.adapter.GetCustomer(ctx, input)
-	})
+	return s.adapter.GetCustomer(ctx, input)
 }
 
 // GetCustomerByUsageAttribution gets a customer by usage attribution
 func (s *Service) GetCustomerByUsageAttribution(ctx context.Context, input customer.GetCustomerByUsageAttributionInput) (*customer.Customer, error) {
-	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (*customer.Customer, error) {
-		return s.adapter.GetCustomerByUsageAttribution(ctx, input)
-	})
+	return s.adapter.GetCustomerByUsageAttribution(ctx, input)
 }
 
 // UpdateCustomer updates a customer

--- a/openmeter/customer/service/service_test.go
+++ b/openmeter/customer/service/service_test.go
@@ -1,0 +1,222 @@
+package customerservice_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	customertestutils "github.com/openmeterio/openmeter/openmeter/customer/testutils"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func Test_CustomerService(t *testing.T) {
+	// Setup test environment
+	env := customertestutils.NewTestEnv(t)
+	t.Cleanup(func() {
+		env.Close(t)
+	})
+
+	// Run database migrations
+	env.DBSchemaMigrate(t)
+
+	// Get new namespace ID
+	namespace := customertestutils.NewTestNamespace(t)
+
+	ctx := t.Context()
+
+	t.Run("Customer", func(t *testing.T) {
+		t.Run("Create", func(t *testing.T) {
+			cus, err := env.CustomerService.CreateCustomer(ctx, customer.CreateCustomerInput{
+				Namespace: namespace,
+				CustomerMutate: customer.CustomerMutate{
+					Key:  lo.ToPtr("acme-inc"),
+					Name: "ACME Inc.",
+					UsageAttribution: customer.CustomerUsageAttribution{
+						SubjectKeys: []string{
+							"acme-inc",
+						},
+					},
+				},
+			})
+			require.NoError(t, err, "creating customer should not fail")
+			assert.NotNilf(t, cus, "customer must not be nil")
+			assert.Equalf(t, cus.Key, cus.Key, "customer key must match")
+			assert.Equalf(t, cus.Name, cus.Name, "customer name must match")
+			assert.ElementsMatchf(t, cus.UsageAttribution.SubjectKeys, []string{"acme-inc"}, "customer usage attribution must match")
+
+			t.Run("Get", func(t *testing.T) {
+				t.Run("ByID", func(t *testing.T) {
+					cusByID, err := env.CustomerService.GetCustomer(ctx, customer.GetCustomerInput{
+						CustomerID: &customer.CustomerID{
+							Namespace: cus.Namespace,
+							ID:        cus.ID,
+						},
+					})
+					require.NoError(t, err, "getting customer by id should not fail")
+					assert.NotNilf(t, cusByID, "customer must not be nil")
+					assert.Equal(t, cus.ID, cusByID.ID, "customer id must match")
+				})
+
+				t.Run("ByKey", func(t *testing.T) {
+					cusByKey, err := env.CustomerService.GetCustomer(ctx, customer.GetCustomerInput{
+						CustomerKey: &customer.CustomerKey{
+							Namespace: cus.Namespace,
+							Key:       lo.FromPtr(cus.Key),
+						},
+					})
+					require.NoError(t, err, "getting customer by key should not fail")
+					assert.NotNilf(t, cusByKey, "customer must not be nil")
+					assert.Equal(t, cus.ID, cusByKey.ID, "customer id must match")
+				})
+
+				t.Run("ByIDDOrKey", func(t *testing.T) {
+					cusByIDOrKey, err := env.CustomerService.GetCustomer(ctx, customer.GetCustomerInput{
+						CustomerIDOrKey: &customer.CustomerIDOrKey{
+							Namespace: cus.Namespace,
+							IDOrKey:   cus.ID,
+						},
+					})
+					require.NoError(t, err, "getting customer by id or key should not fail")
+					assert.NotNilf(t, cusByIDOrKey, "customer must not be nil")
+					assert.Equal(t, cus.ID, cusByIDOrKey.ID, "customer id must match")
+				})
+
+				t.Run("ByUsageAttribution", func(t *testing.T) {
+					cusByUsage, err := env.CustomerService.GetCustomerByUsageAttribution(ctx, customer.GetCustomerByUsageAttributionInput{
+						Namespace:  cus.Namespace,
+						SubjectKey: cus.UsageAttribution.SubjectKeys[0],
+					})
+					require.NoError(t, err, "getting customer usage attribution should not fail")
+					assert.NotNilf(t, cusByUsage, "customer must not be nil")
+					assert.Equal(t, cus.ID, cusByUsage.ID, "customer id must match")
+				})
+			})
+
+			t.Run("List", func(t *testing.T) {
+				list, err := env.CustomerService.ListCustomers(ctx, customer.ListCustomersInput{
+					Namespace: namespace,
+				})
+				require.NoError(t, err, "listing customers should not fail")
+				assert.NotNilf(t, list, "customer list must not be nil")
+				assert.NotEmptyf(t, list.Items, "customer list must not be empty")
+			})
+
+			subjectKeys := []string{"acme-inc", "acme-llc"}
+
+			t.Run("Update", func(t *testing.T) {
+				updatedCus, err := env.CustomerService.UpdateCustomer(ctx, customer.UpdateCustomerInput{
+					CustomerID: customer.CustomerID{
+						Namespace: cus.Namespace,
+						ID:        cus.ID,
+					},
+					CustomerMutate: customer.CustomerMutate{
+						Key:  cus.Key,
+						Name: cus.Name,
+						UsageAttribution: customer.CustomerUsageAttribution{
+							SubjectKeys: subjectKeys,
+						},
+					},
+				})
+				require.NoError(t, err, "updating customer should not fail")
+				assert.NotNilf(t, updatedCus, "customer must not be nil")
+				assert.Equalf(t, updatedCus.Key, cus.Key, "customer key must match")
+				assert.Equalf(t, updatedCus.Name, cus.Name, "customer name must match")
+				assert.ElementsMatchf(t, updatedCus.UsageAttribution.SubjectKeys, subjectKeys, "customer usage attribution must match")
+
+				t.Run("ByUsageAttribution", func(t *testing.T) {
+					cusByUsage, err := env.CustomerService.GetCustomerByUsageAttribution(ctx, customer.GetCustomerByUsageAttributionInput{
+						Namespace:  cus.Namespace,
+						SubjectKey: subjectKeys[1],
+					})
+					require.NoError(t, err, "getting customer usage attribution should not fail")
+					assert.NotNilf(t, cusByUsage, "customer must not be nil")
+					assert.Equal(t, updatedCus.ID, cusByUsage.ID, "customer id must match")
+				})
+			})
+
+			t.Run("Delete", func(t *testing.T) {
+				err = env.CustomerService.DeleteCustomer(ctx, customer.DeleteCustomerInput{
+					Namespace: cus.Namespace,
+					ID:        cus.ID,
+				})
+				require.NoError(t, err, "deleting customer should not fail")
+
+				t.Run("Get", func(t *testing.T) {
+					t.Run("ByID", func(t *testing.T) {
+						cusByID, err := env.CustomerService.GetCustomer(ctx, customer.GetCustomerInput{
+							CustomerID: &customer.CustomerID{
+								Namespace: cus.Namespace,
+								ID:        cus.ID,
+							},
+						})
+						require.NoError(t, err, "getting customer by id should not fail")
+						assert.NotNilf(t, cusByID, "customer must not be nil")
+						assert.Equal(t, cus.ID, cusByID.ID, "customer id must match")
+						assert.NotNilf(t, cusByID.DeletedAt, "customer must be deleted")
+						assert.ElementsMatchf(t, cusByID.UsageAttribution.SubjectKeys, subjectKeys, "customer usage attribution must match")
+					})
+
+					t.Run("ByKey", func(t *testing.T) {
+						cusByKey, err := env.CustomerService.GetCustomer(ctx, customer.GetCustomerInput{
+							CustomerKey: &customer.CustomerKey{
+								Namespace: cus.Namespace,
+								Key:       lo.FromPtr(cus.Key),
+							},
+						})
+
+						var notFoundErr *models.GenericNotFoundError
+
+						assert.ErrorAsf(t, err, &notFoundErr, "error must be not found error")
+						assert.Nilf(t, cusByKey, "customer must be nil")
+					})
+
+					t.Run("ByIDOrKey", func(t *testing.T) {
+						t.Run("ByID", func(t *testing.T) {
+							cusByID, err := env.CustomerService.GetCustomer(ctx, customer.GetCustomerInput{
+								CustomerID: &customer.CustomerID{
+									Namespace: cus.Namespace,
+									ID:        cus.ID,
+								},
+							})
+							require.NoError(t, err, "getting customer by id should not fail")
+							assert.NotNilf(t, cusByID, "customer must not be nil")
+							assert.Equal(t, cus.ID, cusByID.ID, "customer id must match")
+							assert.NotNilf(t, cusByID.DeletedAt, "customer must be deleted")
+							assert.ElementsMatchf(t, cusByID.UsageAttribution.SubjectKeys, subjectKeys, "customer usage attribution must match")
+						})
+
+						t.Run("ByKey", func(t *testing.T) {
+							cusByKey, err := env.CustomerService.GetCustomer(ctx, customer.GetCustomerInput{
+								CustomerKey: &customer.CustomerKey{
+									Namespace: cus.Namespace,
+									Key:       lo.FromPtr(cus.Key),
+								},
+							})
+
+							var notFoundErr *models.GenericNotFoundError
+
+							assert.ErrorAsf(t, err, &notFoundErr, "error must be not found error")
+							assert.Nilf(t, cusByKey, "customer must be nil")
+						})
+					})
+				})
+
+				t.Run("List", func(t *testing.T) {
+					list, err := env.CustomerService.ListCustomers(ctx, customer.ListCustomersInput{
+						Namespace:      namespace,
+						IncludeDeleted: true,
+					})
+					require.NoError(t, err, "listing customers including deleted should not fail")
+					require.NotNilf(t, list, "customer list must not be nil")
+					require.NotEmptyf(t, list.Items, "customer list must not be empty")
+					assert.Equal(t, cus.ID, list.Items[0].ID, "customer id must match")
+					assert.NotNilf(t, list.Items[0].DeletedAt, "customer must be deleted")
+					assert.ElementsMatchf(t, list.Items[0].UsageAttribution.SubjectKeys, subjectKeys, "customer usage attribution must match")
+				})
+			})
+		})
+	})
+}

--- a/openmeter/customer/testutils/env.go
+++ b/openmeter/customer/testutils/env.go
@@ -1,0 +1,130 @@
+package testutils
+
+import (
+	"crypto/rand"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	customeradapter "github.com/openmeterio/openmeter/openmeter/customer/adapter"
+	customerservice "github.com/openmeterio/openmeter/openmeter/customer/service"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	meteradapter "github.com/openmeterio/openmeter/openmeter/meter/mockadapter"
+	"github.com/openmeterio/openmeter/openmeter/subject"
+	subjectadapter "github.com/openmeterio/openmeter/openmeter/subject/adapter"
+	subjectservice "github.com/openmeterio/openmeter/openmeter/subject/service"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+)
+
+func NewTestULID(t *testing.T) string {
+	t.Helper()
+
+	return ulid.MustNew(ulid.Timestamp(time.Now().UTC()), rand.Reader).String()
+}
+
+var NewTestNamespace = NewTestULID
+
+type TestEnv struct {
+	Logger          *slog.Logger
+	Tracer          trace.Tracer
+	SubjectService  subject.Service
+	CustomerService customer.Service
+
+	Client *entdb.Client
+	db     *testutils.TestDB
+	close  sync.Once
+}
+
+func (e *TestEnv) DBSchemaMigrate(t *testing.T) {
+	t.Helper()
+
+	require.NotNilf(t, e.db, "database must be initialized")
+
+	err := e.db.EntDriver.Client().Schema.Create(t.Context())
+	require.NoErrorf(t, err, "schema migration must not fail")
+}
+
+func (e *TestEnv) Close(t *testing.T) {
+	t.Helper()
+
+	e.close.Do(func() {
+		if e.db != nil {
+			if err := e.db.EntDriver.Close(); err != nil {
+				t.Errorf("failed to close ent driver: %v", err)
+			}
+
+			if err := e.db.PGDriver.Close(); err != nil {
+				t.Errorf("failed to postgres driver: %v", err)
+			}
+		}
+
+		if e.Client != nil {
+			if err := e.Client.Close(); err != nil {
+				t.Errorf("failed to close ent client: %v", err)
+			}
+		}
+	})
+}
+
+func NewTestEnv(t *testing.T) *TestEnv {
+	t.Helper()
+
+	// Init logger
+	logger := testutils.NewDiscardLogger(t)
+
+	tracer := noop.NewTracerProvider().Tracer("test_env")
+
+	// Init database
+	db := testutils.InitPostgresDB(t)
+	client := db.EntDriver.Client()
+
+	// Init event publisher
+	publisher := eventbus.NewMock(t)
+
+	// Init meter service
+	meterAdapter, err := meteradapter.New(nil)
+	require.NoErrorf(t, err, "initializing meter adapter must not fail")
+	require.NotNilf(t, meterAdapter, "meter adapter must not be nil")
+
+	// Init subject service
+	subjectAdapter, err := subjectadapter.New(client)
+	require.NoErrorf(t, err, "initializing subject adapter must not fail")
+	require.NotNilf(t, subjectAdapter, "subject adapter must not be nil")
+
+	subjectService, err := subjectservice.New(subjectAdapter)
+	require.NoErrorf(t, err, "initializing subject service must not fail")
+	require.NotNilf(t, subjectService, "subject service must not be nil")
+
+	// Init Customer service
+	customerAdapter, err := customeradapter.New(customeradapter.Config{
+		Client: client,
+		Logger: logger,
+	})
+	require.NoErrorf(t, err, "initializing customer adapter must not fail")
+	require.NotNilf(t, customerAdapter, "customer adapter must not be nil")
+
+	customerService, err := customerservice.New(customerservice.Config{
+		Adapter:   customerAdapter,
+		Publisher: publisher,
+	})
+	require.NoErrorf(t, err, "initializing subject service must not fail")
+	require.NotNilf(t, customerService, "subject service must not be nil")
+
+	return &TestEnv{
+		Logger:          logger,
+		Tracer:          tracer,
+		SubjectService:  subjectService,
+		CustomerService: customerService,
+		Client:          client,
+		db:              db,
+		close:           sync.Once{},
+	}
+}


### PR DESCRIPTION
## Overview

* fix not returning usage attributions for deleted Customer
* fix allowing updating Customer after being deleted
* allow to fetch deleted Customer by ID (previously we returned not found error)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Listing customers now includes items scheduled for future deletion by default (when excluding deleted).

- Bug Fixes
  - Getting a customer by key no longer returns deleted records; deleted items remain retrievable by ID only.
  - Prevented updates to already-deleted customers with a validation error.
  - Subject entries consistently record creation/deletion timestamps and respect customer deletion timing during lookups.

- Tests
  - Added integration-style tests and a reusable test environment covering CRUD, lookups, delete, and listing behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->