### PR TITLE
fix: check for deleted customer

### DIFF
--- a/openmeter/app/stripe/adapter/stripe.go
+++ b/openmeter/app/stripe/adapter/stripe.go
@@ -376,6 +376,13 @@ func (a *adapter) CreateCheckoutSession(ctx context.Context, input appstripeenti
 			if err != nil {
 				return appstripeentity.CreateCheckoutSessionOutput{}, fmt.Errorf("failed to get customer: %w", err)
 			}
+
+			if targetCustomer != nil && targetCustomer.IsDeleted() {
+				return appstripeentity.CreateCheckoutSessionOutput{},
+					models.NewGenericPreConditionFailedError(
+						fmt.Errorf("customer is deleted [namespace=%s customer.id=%s]", targetCustomer.Namespace, targetCustomer.ID),
+					)
+			}
 		}
 
 		// Create a customer if create input is provided

--- a/openmeter/app/stripe/httpdriver/checkout_session.go
+++ b/openmeter/app/stripe/httpdriver/checkout_session.go
@@ -90,6 +90,13 @@ func (h *handler) CreateAppStripeCheckoutSession() CreateAppStripeCheckoutSessio
 					return CreateAppStripeCheckoutSessionRequest{}, fmt.Errorf("failed to get customer by key: %w", err)
 				}
 
+				if cus != nil && cus.IsDeleted() {
+					return CreateAppStripeCheckoutSessionRequest{},
+						models.NewGenericPreConditionFailedError(
+							fmt.Errorf("customer is deleted [namespace=%s customer.id=%s]", cus.Namespace, cus.ID),
+						)
+				}
+
 				customerId = lo.ToPtr(cus.GetID())
 			}
 

--- a/openmeter/app/stripe/httpdriver/customer.go
+++ b/openmeter/app/stripe/httpdriver/customer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type (
@@ -48,6 +49,13 @@ func (h *handler) GetCustomerStripeAppData() GetCustomerStripeAppDataHandler {
 			})
 			if err != nil {
 				return GetCustomerStripeAppDataRequest{}, err
+			}
+
+			if cus != nil && cus.IsDeleted() {
+				return GetCustomerStripeAppDataRequest{},
+					models.NewGenericPreConditionFailedError(
+						fmt.Errorf("customer is deleted [namespace=%s customer.id=%s]", cus.Namespace, cus.ID),
+					)
 			}
 
 			// Construct the request
@@ -107,6 +115,13 @@ func (h *handler) UpsertCustomerStripeAppData() UpsertCustomerStripeAppDataHandl
 			})
 			if err != nil {
 				return UpsertCustomerStripeAppDataRequest{}, err
+			}
+
+			if cus != nil && cus.IsDeleted() {
+				return UpsertCustomerStripeAppDataRequest{},
+					models.NewGenericPreConditionFailedError(
+						fmt.Errorf("customer is deleted [namespace=%s customer.id=%s]", cus.Namespace, cus.ID),
+					)
 			}
 
 			return UpsertCustomerStripeAppDataRequest{
@@ -182,6 +197,13 @@ func (h *handler) CreateStripeCustomerPortalSession() CreateStripeCustomerPortal
 			})
 			if err != nil {
 				return CreateStripeCustomerPortalSessionRequest{}, err
+			}
+
+			if cus != nil && cus.IsDeleted() {
+				return CreateStripeCustomerPortalSessionRequest{},
+					models.NewGenericPreConditionFailedError(
+						fmt.Errorf("customer is deleted [namespace=%s customer.id=%s]", cus.Namespace, cus.ID),
+					)
 			}
 
 			// Create request

--- a/openmeter/billing/worker/subscription/reconciler.go
+++ b/openmeter/billing/worker/subscription/reconciler.go
@@ -103,7 +103,7 @@ func (r *Reconciler) ReconcileSubscription(ctx context.Context, subsID models.Na
 		return fmt.Errorf("failed to get subscription: %w", err)
 	}
 
-	customer, err := r.customerService.GetCustomer(ctx, customer.GetCustomerInput{
+	cus, err := r.customerService.GetCustomer(ctx, customer.GetCustomerInput{
 		CustomerID: &customer.CustomerID{
 			ID:        subsView.Customer.ID,
 			Namespace: subsID.Namespace,
@@ -113,8 +113,10 @@ func (r *Reconciler) ReconcileSubscription(ctx context.Context, subsID models.Na
 		return fmt.Errorf("failed to get customer: %w", err)
 	}
 
-	if customer.DeletedAt != nil {
+	// TODO: remove this check to make sure that deleted customers are fully invoiced
+	if cus != nil && cus.IsDeleted() {
 		r.logger.WarnContext(ctx, "customer is deleted, skipping reconciliation", "customer_id", subsView.Customer.ID)
+
 		return nil
 	}
 

--- a/openmeter/credit/driver/grant.go
+++ b/openmeter/credit/driver/grant.go
@@ -3,6 +3,7 @@ package creditdriver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"slices"
 
@@ -248,6 +249,14 @@ func (h *grantHandler) ListGrantsV2() ListGrantsV2Handler {
 					if err != nil {
 						return ListGrantsV2HandlerRequest{}, err
 					}
+
+					if cus != nil && cus.IsDeleted() {
+						return ListGrantsV2HandlerRequest{},
+							models.NewGenericPreConditionFailedError(
+								fmt.Errorf("customer is deleted [namespace=%s customer.id=%s]", cus.Namespace, cus.ID),
+							)
+					}
+
 					subjectKeys = append(subjectKeys, cus.UsageAttribution.SubjectKeys...)
 				}
 			}

--- a/openmeter/customer/customer.go
+++ b/openmeter/customer/customer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
@@ -44,6 +45,10 @@ func (c Customer) GetID() CustomerID {
 		Namespace: c.Namespace,
 		ID:        c.ID,
 	}
+}
+
+func (c Customer) IsDeleted() bool {
+	return c.DeletedAt != nil && c.DeletedAt.Before(clock.Now())
 }
 
 // Validate validates the customer

--- a/openmeter/customer/service/customer.go
+++ b/openmeter/customer/service/customer.go
@@ -65,6 +65,10 @@ func (s *Service) DeleteCustomer(ctx context.Context, input customer.DeleteCusto
 				input.Namespace, input.ID, err)
 		}
 
+		if cus != nil && cus.IsDeleted() {
+			return nil
+		}
+
 		// Run pre delete hooks
 		if err = s.hooks.PreDelete(ctx, cus); err != nil {
 			return err
@@ -127,6 +131,12 @@ func (s *Service) UpdateCustomer(ctx context.Context, input customer.UpdateCusto
 		if err != nil {
 			return nil, fmt.Errorf("failed to get customer [namespace=%s customer.id=%s]: %w",
 				input.CustomerID.Namespace, input.CustomerID.ID, err)
+		}
+
+		if cus != nil && cus.IsDeleted() {
+			return nil, models.NewGenericPreConditionFailedError(
+				fmt.Errorf("customer is deleted [namespace=%s customer.id=%s]", cus.Namespace, cus.ID),
+			)
 		}
 
 		// Run pre update hooks

--- a/openmeter/customer/service/hooks/subjectcustomer.go
+++ b/openmeter/customer/service/hooks/subjectcustomer.go
@@ -254,6 +254,12 @@ func (p CustomerProvisioner) getCustomerForSubject(ctx context.Context, sub *sub
 		return nil, err
 	}
 
+	if cus != nil && cus.IsDeleted() {
+		return nil, models.NewGenericPreConditionFailedError(
+			fmt.Errorf("customer is deleted [namespace=%s customer.id=%s]", cus.Namespace, cus.ID),
+		)
+	}
+
 	// Return Customer if it has the Subject in usage attribution.
 	// There are cases where the Customer and the Subject have the same key,
 	// while the Subject is not included in the Customers usage attribution.

--- a/openmeter/productcatalog/subscription/http/create.go
+++ b/openmeter/productcatalog/subscription/http/create.go
@@ -205,5 +205,11 @@ func (h *handler) getCustomer(ctx context.Context, namespace string, id *string,
 		return nil, err
 	}
 
+	if cus != nil && cus.IsDeleted() {
+		return nil, models.NewGenericPreConditionFailedError(
+			fmt.Errorf("customer is deleted [namespace=%s customer.id=%s]", cus.Namespace, cus.ID),
+		)
+	}
+
 	return cus, nil
 }

--- a/openmeter/productcatalog/subscription/http/get.go
+++ b/openmeter/productcatalog/subscription/http/get.go
@@ -98,6 +98,12 @@ func (h *handler) ListCustomerSubscriptions() ListCustomerSubscriptionsHandler {
 				return ListCustomerSubscriptionsRequest{}, err
 			}
 
+			if cus != nil && cus.IsDeleted() {
+				return ListCustomerSubscriptionsRequest{}, models.NewGenericPreConditionFailedError(
+					fmt.Errorf("customer is deleted [namespace=%s customer.id=%s]", cus.Namespace, cus.ID),
+				)
+			}
+
 			return ListCustomerSubscriptionsRequest{
 				CustomerID: cus.GetID(),
 				Page:       pagination.NewPageFromRef(params.Params.Page, params.Params.PageSize),

--- a/openmeter/subscription/validators/customer/validator.go
+++ b/openmeter/subscription/validators/customer/validator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 var _ customer.RequestValidator = (*Validator)(nil)
@@ -60,6 +61,18 @@ func (v *Validator) ValidateUpdateCustomer(ctx context.Context, input customer.U
 		})
 		if err != nil {
 			return err
+		}
+
+		if currentCustomer != nil && currentCustomer.IsDeleted() {
+			return models.NewGenericPreConditionFailedError(
+				fmt.Errorf("customer is deleted [namespace=%s customer.id=%s]", currentCustomer.Namespace, currentCustomer.ID),
+			)
+		}
+
+		if currentCustomer == nil {
+			return models.NewGenericNotFoundError(
+				fmt.Errorf("customer [namespace=%s customer.id=%s]", input.CustomerID.Namespace, input.CustomerID.ID),
+			)
 		}
 
 		// Let's check the two subjectKey arrays are the same


### PR DESCRIPTION
## Overview

Add additional checks for deleted Customer entities as the Customer Service API returned deleted entites in case they are referenced by ID instead of key which change was introduced in #3327.

This change ensures that the consumers will handle deleted Customer entities as they did before, except Billing Service which does expect the Customer Service API to return deleted entities instead of NotFound errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Consistent precondition errors when acting on deleted customers across APIs (customers, entitlements, subscriptions, credits, product catalog, Stripe checkout/portal), with clear messages including namespace and ID.

- Bug Fixes
  - Blocked operations on deleted customers to prevent unintended actions (listing, creating, updating, deleting, checkout, portal sessions).
  - Deleting an already-deleted customer is now idempotent (no-op).
  - Improved nil/not-found handling to avoid ambiguous failures and ensure reliable validation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->