### PR TITLE
fix: upsert of stripe customer id

### DIFF
--- a/openmeter/app/stripe/adapter/customer.go
+++ b/openmeter/app/stripe/adapter/customer.go
@@ -129,7 +129,7 @@ func (a *adapter) UpsertStripeCustomerData(ctx context.Context, input appstripee
 			SetStripeCustomerID(input.StripeCustomerID).
 			SetNillableStripeDefaultPaymentMethodID(input.StripeDefaultPaymentMethodID).
 			// Upsert
-			OnConflictColumns(appstripecustomerdb.FieldNamespace, appstripecustomerdb.FieldAppID, appstripecustomerdb.FieldCustomerID).
+			OnConflictColumns(appstripecustomerdb.FieldNamespace, appstripecustomerdb.FieldAppID, appstripecustomerdb.FieldCustomerID, appstripecustomerdb.FieldStripeCustomerID).
 			UpdateStripeCustomerID().
 			UpdateStripeDefaultPaymentMethodID().
 			Exec(ctx)


### PR DESCRIPTION
## Overview

Fix upserting Stripe Customer ID where updating exiting item fails with PreConditionError.

```
failed to set stripe customer id for subject customer [namespace=org_AAA subject.id=BBB subject.key=CCC customer.id=DDD]: failed to setup stripe customer id for customer [namespace=org_AAA customer.id=DDD]: failed to upsert stripe customer data: precondition failed error: customer with id DDD does not meet condition unique stripe customer id for stripe app type with id EEE in namespace org_AAA
``` 