### PR TITLE
fix: customer id for non-existing stripe customer

### DIFF
--- a/openmeter/app/stripe/entity/app/customer.go
+++ b/openmeter/app/stripe/entity/app/customer.go
@@ -51,7 +51,7 @@ func (a App) ValidateCustomerByID(ctx context.Context, customerID customer.Custo
 				a.GetID(),
 				a.GetType(),
 				&customerID,
-				fmt.Sprintf("stripe customer %s not found in stripe account %s", stripeCustomerData.StripeCustomerID, stripeAppData.StripeAccountID),
+				fmt.Sprintf("stripe customer not found in stripe account [stripe.customer_id=%s stripe.account_id=%s]", stripeCustomerData.StripeCustomerID, stripeAppData.StripeAccountID),
 			)
 		}
 

--- a/openmeter/customer/service/hooks/subjectcustomer.go
+++ b/openmeter/customer/service/hooks/subjectcustomer.go
@@ -493,6 +493,14 @@ func (p CustomerProvisioner) EnsureStripeCustomer(ctx context.Context, customerI
 		},
 	})
 	if err != nil {
+		var preconditionError *app.AppCustomerPreConditionError
+
+		if errors.As(err, &preconditionError) && strings.Contains(err.Error(), "stripe customer not found in stripe account") {
+			p.logger.WarnContext(ctx, "failed to setup stripe customer id for customer", "error", err.Error())
+
+			return nil
+		}
+
 		return fmt.Errorf("failed to setup stripe customer id for customer [namespace=%s customer.id=%s]: %w",
 			customerID.Namespace, customerID.ID, err)
 	}


### PR DESCRIPTION
## Overview

Setting Stripe Customer Id fails if the customer does not exists on Stripe side. Log and ignore errors triggered by this scenario as some users use the *stripe_customer_id* field of Subject entity as metadata.

```
failed to set stripe customer id for subject customer [namespace=org_AAA subject.id=BBB subject.key=CCC customer.id=DDD]: failed to setup stripe customer id for customer [namespace=org_AAA customer.id=DDD]: failed to upsert stripe customer data: precondition failed error: customer with id DDD does not meet condition stripe customer cus_EEE not found in stripe account: acct_FFF for stripe app type with id GGG in namespace org_AAA
```
