### PR TITLE
feat: additional client options

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -173,7 +173,7 @@ func SetViperDefaults(v *viper.Viper, flags *pflag.FlagSet) {
 
 	ConfigureTelemetry(v, flags)
 
-	ConfigurePostgres(v)
+	ConfigurePostgres(v, "postgres")
 	ConfigureNamespace(v)
 	ConfigureIngest(v)
 	ConfigureAggregation(v)

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -174,6 +174,12 @@ func SetViperDefaults(v *viper.Viper, flags *pflag.FlagSet) {
 	ConfigureTelemetry(v, flags)
 
 	ConfigurePostgres(v, "postgres")
+	// TODO: This is set to ensure backwards compatibility with the old config, however it should be removed in the future.
+	//
+	// In cloud this must never be explicitly set to prevent accidental behavior, so let's not add any kind of defaulting in
+	// the reusable config parts.
+	v.SetDefault("postgres.autoMigrate", "ent")
+
 	ConfigureNamespace(v)
 	ConfigureIngest(v)
 	ConfigureAggregation(v)

--- a/app/config/postgres.go
+++ b/app/config/postgres.go
@@ -52,7 +52,6 @@ func (c PostgresConfig) AsURL() string {
 
 func ConfigurePostgres(v *viper.Viper, prefix string) {
 	v.SetDefault(AddPrefix(prefix, "url"), "")
-	v.SetDefault(AddPrefix(prefix, "autoMigrate"), "ent")
 	v.SetDefault(AddPrefix(prefix, "options.poolMaxConns"), 0)
 	v.SetDefault(AddPrefix(prefix, "options.applicationName"), "")
 	v.SetDefault(AddPrefix(prefix, "options.sslVerify"), "")

--- a/app/config/postgres.go
+++ b/app/config/postgres.go
@@ -50,17 +50,18 @@ func (c PostgresConfig) AsURL() string {
 	return c.PostgresConnectionParams.AsURL()
 }
 
-func ConfigurePostgres(v *viper.Viper) {
-	v.SetDefault("postgres.url", "")
-	v.SetDefault("postgres.autoMigrate", "ent")
-
-	v.SetDefault("postgres.options.poolMaxConns", 0)
-	v.SetDefault("postgres.options.applicationName", "")
-	v.SetDefault("postgres.host", "")
-	v.SetDefault("postgres.port", 0)
-	v.SetDefault("postgres.database", "")
-	v.SetDefault("postgres.user", "")
-	v.SetDefault("postgres.password", "")
+func ConfigurePostgres(v *viper.Viper, prefix string) {
+	v.SetDefault(AddPrefix(prefix, "url"), "")
+	v.SetDefault(AddPrefix(prefix, "autoMigrate"), "ent")
+	v.SetDefault(AddPrefix(prefix, "options.poolMaxConns"), 0)
+	v.SetDefault(AddPrefix(prefix, "options.applicationName"), "")
+	v.SetDefault(AddPrefix(prefix, "options.sslVerify"), "")
+	v.SetDefault(AddPrefix(prefix, "options.sslRootCert"), "")
+	v.SetDefault(AddPrefix(prefix, "host"), "")
+	v.SetDefault(AddPrefix(prefix, "port"), 0)
+	v.SetDefault(AddPrefix(prefix, "database"), "")
+	v.SetDefault(AddPrefix(prefix, "user"), "")
+	v.SetDefault(AddPrefix(prefix, "password"), "")
 }
 
 type AutoMigrate string
@@ -137,6 +138,14 @@ func (c PostgresConnectionParams) AsURL() string {
 		runtimeParams.Set("pool_max_conns", strconv.Itoa(c.Options.PoolMaxConns))
 	}
 
+	if c.Options.SSLVerify != "" {
+		runtimeParams.Set("sslmode", c.Options.SSLVerify)
+	}
+
+	if c.Options.SSLRootCert != "" {
+		runtimeParams.Set("sslrootcert", c.Options.SSLRootCert)
+	}
+
 	url := url.URL{
 		Scheme:   "postgresql",
 		User:     url.UserPassword(c.User, c.Password),
@@ -151,6 +160,8 @@ func (c PostgresConnectionParams) AsURL() string {
 type PostgresConnectionOptions struct {
 	PoolMaxConns    int    `yaml:"poolMaxConns"`
 	ApplicationName string `yaml:"applicationName"`
+	SSLVerify       string `yaml:"sslVerify"`
+	SSLRootCert     string `yaml:"sslRootCert"`
 }
 
 func (c PostgresConnectionOptions) Validate() error {

--- a/openmeter/watermill/driver/kafka/broker.go
+++ b/openmeter/watermill/driver/kafka/broker.go
@@ -80,10 +80,10 @@ func (o *BrokerOptions) createKafkaConfig(role string) (*sarama.Config, error) {
 		config.Net.TLS.Config = &tls.Config{}
 
 		switch o.KafkaConfig.SaslMechanisms {
-		case "PLAIN":
+		case sarama.SASLTypePlaintext, sarama.SASLTypeSCRAMSHA512, sarama.SASLTypeSCRAMSHA256:
 			config.Net.SASL.User = o.KafkaConfig.SaslUsername
 			config.Net.SASL.Password = o.KafkaConfig.SaslPassword
-			config.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+			config.Net.SASL.Mechanism = sarama.SASLMechanism(o.KafkaConfig.SaslMechanisms)
 		default:
 			return nil, fmt.Errorf("unsupported SASL mechanism: %s", o.KafkaConfig.SaslMechanisms)
 		}

--- a/openmeter/watermill/driver/kafka/broker.go
+++ b/openmeter/watermill/driver/kafka/broker.go
@@ -80,10 +80,24 @@ func (o *BrokerOptions) createKafkaConfig(role string) (*sarama.Config, error) {
 		config.Net.TLS.Config = &tls.Config{}
 
 		switch o.KafkaConfig.SaslMechanisms {
-		case sarama.SASLTypePlaintext, sarama.SASLTypeSCRAMSHA512, sarama.SASLTypeSCRAMSHA256:
+		case sarama.SASLTypePlaintext:
 			config.Net.SASL.User = o.KafkaConfig.SaslUsername
 			config.Net.SASL.Password = o.KafkaConfig.SaslPassword
 			config.Net.SASL.Mechanism = sarama.SASLMechanism(o.KafkaConfig.SaslMechanisms)
+		case sarama.SASLTypeSCRAMSHA256:
+			config.Net.SASL.User = o.KafkaConfig.SaslUsername
+			config.Net.SASL.Password = o.KafkaConfig.SaslPassword
+			config.Net.SASL.Mechanism = sarama.SASLMechanism(o.KafkaConfig.SaslMechanisms)
+			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
+				return &XDGSCRAMClient{HashGeneratorFcn: SHA256}
+			}
+		case sarama.SASLTypeSCRAMSHA512:
+			config.Net.SASL.User = o.KafkaConfig.SaslUsername
+			config.Net.SASL.Password = o.KafkaConfig.SaslPassword
+			config.Net.SASL.Mechanism = sarama.SASLMechanism(o.KafkaConfig.SaslMechanisms)
+			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
+				return &XDGSCRAMClient{HashGeneratorFcn: SHA512}
+			}
 		default:
 			return nil, fmt.Errorf("unsupported SASL mechanism: %s", o.KafkaConfig.SaslMechanisms)
 		}

--- a/openmeter/watermill/driver/kafka/broker.go
+++ b/openmeter/watermill/driver/kafka/broker.go
@@ -82,27 +82,22 @@ func (o *BrokerOptions) createKafkaConfig(role string) (*sarama.Config, error) {
 		config.Net.TLS.Enable = true
 		config.Net.TLS.Config = &tls.Config{}
 
+		config.Net.SASL.User = o.KafkaConfig.SaslUsername
+		config.Net.SASL.Password = o.KafkaConfig.SaslPassword
+		// We rely on sarama to validate the SASL mechanism
+		config.Net.SASL.Mechanism = sarama.SASLMechanism(o.KafkaConfig.SaslMechanisms)
+
 		switch o.KafkaConfig.SaslMechanisms {
-		case sarama.SASLTypePlaintext:
-			config.Net.SASL.User = o.KafkaConfig.SaslUsername
-			config.Net.SASL.Password = o.KafkaConfig.SaslPassword
-			config.Net.SASL.Mechanism = sarama.SASLMechanism(o.KafkaConfig.SaslMechanisms)
 		case sarama.SASLTypeSCRAMSHA256:
-			config.Net.SASL.User = o.KafkaConfig.SaslUsername
-			config.Net.SASL.Password = o.KafkaConfig.SaslPassword
 			config.Net.SASL.Mechanism = sarama.SASLMechanism(o.KafkaConfig.SaslMechanisms)
 			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
 				return &XDGSCRAMClient{HashGeneratorFcn: SHA256}
 			}
 		case sarama.SASLTypeSCRAMSHA512:
-			config.Net.SASL.User = o.KafkaConfig.SaslUsername
-			config.Net.SASL.Password = o.KafkaConfig.SaslPassword
 			config.Net.SASL.Mechanism = sarama.SASLMechanism(o.KafkaConfig.SaslMechanisms)
 			config.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
 				return &XDGSCRAMClient{HashGeneratorFcn: SHA512}
 			}
-		default:
-			return nil, fmt.Errorf("unsupported SASL mechanism: %s", o.KafkaConfig.SaslMechanisms)
 		}
 	}
 

--- a/openmeter/watermill/driver/kafka/broker.go
+++ b/openmeter/watermill/driver/kafka/broker.go
@@ -51,13 +51,16 @@ func (o *BrokerOptions) createKafkaConfig(role string) (*sarama.Config, error) {
 	if role == "" {
 		return nil, errors.New("role is required")
 	}
-	if o.KafkaConfig.SocketKeepAliveEnabled {
-		config.Net.KeepAlive = defaultKeepalive
-	}
-	config.Metadata.RefreshFrequency = o.KafkaConfig.TopicMetadataRefreshInterval.Duration()
+
 	if o.ClientID == "" {
 		return nil, errors.New("client ID is required")
 	}
+
+	if o.KafkaConfig.SocketKeepAliveEnabled {
+		config.Net.KeepAlive = defaultKeepalive
+	}
+
+	config.Metadata.RefreshFrequency = o.KafkaConfig.TopicMetadataRefreshInterval.Duration()
 	config.ClientID = fmt.Sprintf("%s-%s", o.ClientID, role)
 
 	// These are globals, so we cannot append the publisher/subscriber name to them

--- a/openmeter/watermill/driver/kafka/publisher.go
+++ b/openmeter/watermill/driver/kafka/publisher.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill-kafka/v3/pkg/kafka"
@@ -35,7 +36,7 @@ func NewPublisher(ctx context.Context, in PublisherOptions) (*kafka.Publisher, e
 	}
 
 	wmConfig := kafka.PublisherConfig{
-		Brokers:   []string{in.Broker.KafkaConfig.Broker},
+		Brokers:   strings.Split(in.Broker.KafkaConfig.Broker, ","),
 		Marshaler: marshalerWithPartitionKey{},
 		Tracer:    kafka.NewOTELSaramaTracer(), // This relies on the global trace provider
 	}

--- a/openmeter/watermill/driver/kafka/saslscram.go
+++ b/openmeter/watermill/driver/kafka/saslscram.go
@@ -1,0 +1,40 @@
+package kafka
+
+// Source: https://github.com/IBM/sarama/blob/main/examples/sasl_scram_client/scram_client.go
+// Why? https://github.com/IBM/sarama/issues/1837
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+
+	"github.com/xdg-go/scram"
+)
+
+var (
+	SHA256 scram.HashGeneratorFcn = sha256.New
+	SHA512 scram.HashGeneratorFcn = sha512.New
+)
+
+type XDGSCRAMClient struct {
+	*scram.Client
+	*scram.ClientConversation
+	scram.HashGeneratorFcn
+}
+
+func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
+	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	if err != nil {
+		return err
+	}
+	x.ClientConversation = x.Client.NewConversation()
+	return nil
+}
+
+func (x *XDGSCRAMClient) Step(challenge string) (response string, err error) {
+	response, err = x.ClientConversation.Step(challenge)
+	return
+}
+
+func (x *XDGSCRAMClient) Done() bool {
+	return x.ClientConversation.Done()
+}

--- a/openmeter/watermill/driver/kafka/subscriber.go
+++ b/openmeter/watermill/driver/kafka/subscriber.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ThreeDotsLabs/watermill"
@@ -48,7 +49,7 @@ func NewSubscriber(in SubscriberOptions) (message.Subscriber, error) {
 	saramaConfig.Consumer.MaxProcessingTime = defaultMaxProcessingTime
 
 	wmConfig := kafka.SubscriberConfig{
-		Brokers:               []string{in.Broker.KafkaConfig.Broker},
+		Brokers:               strings.Split(in.Broker.KafkaConfig.Broker, ","),
 		OverwriteSaramaConfig: saramaConfig,
 		ConsumerGroup:         in.ConsumerGroupName,
 		ReconnectRetrySleep:   100 * time.Millisecond,


### PR DESCRIPTION
## Overview

**Postgres:** Add support for custom CAs when connecting to postgres.
**Kafka**: 
- Add full support for SCRAM authentication flavors
- Add support for coma seperated broker list in Sarama parts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Multiple Kafka brokers supported via comma-separated URLs.
  * Kafka SASL SCRAM-SHA-256 and SCRAM-SHA-512 authentication added.
  * Postgres configuration supports namespacing and SSL options (verify mode, root certificate); connection URLs include SSL parameters.

* Bug Fixes
  * Client ID validation for Kafka moved earlier to produce clearer errors.

* Chores
  * Default Postgres auto-migration set to “ent” (override in cloud setups as needed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->