### PR TITLE
fix(stripe): send invoice payment collection method with period due date

### DIFF
--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -1213,11 +1213,12 @@ func (s *StripeInvoiceTestSuite) TestEmptyInvoiceGenerationZeroUsage() {
 	s.Equal(billing.InvoiceStatusDraftManualApprovalNeeded, invoice.Status)
 }
 
-func (s *StripeInvoiceTestSuite) TestSendInvoiceBillingProfile() {
+func (s *StripeInvoiceTestSuite) TestSendInvoice() {
 	// Given we have a test customer and a billing profile with send_invoice collection method
-	// we can create an invoice that will be sent to the customer instead of charged automatically
+	// we can create an invoice that will be sent to the customer instead of charged automatically.
+	// In this test we should see due date set and collection method set to send_invoice.
 
-	namespace := "ns-send-invoice-billing-profile"
+	namespace := "ns-send-invoice"
 	ctx := context.Background()
 	periodStart := lo.Must(time.Parse(time.RFC3339, "2024-09-02T12:13:14Z"))
 	periodEnd := lo.Must(time.Parse(time.RFC3339, "2024-09-03T12:13:14Z"))
@@ -1363,7 +1364,8 @@ func (s *StripeInvoiceTestSuite) TestSendInvoiceBillingProfile() {
 	s.NoError(err, "failed to create invoice")
 
 	// Assert the client is called with the correct arguments.
-	// FIXME: fix this test
+	// FIXME: fix this assert, for some reason other tests are bleeding into this test at mock assertion
+	// This does not impact the test, the create invoice mock is still called and the assert passes
 	// s.StripeAppClient.AssertExpectations(s.T())
 }
 

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
 	billingtest "github.com/openmeterio/openmeter/test/billing"
 )
@@ -1210,6 +1211,146 @@ func (s *StripeInvoiceTestSuite) TestEmptyInvoiceGenerationZeroUsage() {
 
 	s.Equal("ACME Inc. (updated)", invoice.Supplier.Name)
 	s.Equal(billing.InvoiceStatusDraftManualApprovalNeeded, invoice.Status)
+}
+
+func (s *StripeInvoiceTestSuite) TestSendInvoiceBillingProfile() {
+	// Given we have a test customer and a billing profile with send_invoice collection method
+	// we can create an invoice that will be sent to the customer instead of charged automatically
+
+	namespace := "ns-send-invoice-billing-profile"
+	ctx := context.Background()
+	periodStart := lo.Must(time.Parse(time.RFC3339, "2024-09-02T12:13:14Z"))
+	periodEnd := lo.Must(time.Parse(time.RFC3339, "2024-09-03T12:13:14Z"))
+	clock.FreezeTime(periodStart)
+	defer clock.UnFreeze()
+
+	_ = s.InstallSandboxApp(s.T(), namespace)
+
+	// Create a test customer
+	customerEntity, err := s.CustomerService.CreateCustomer(ctx, customer.CreateCustomerInput{
+		Namespace: namespace,
+
+		CustomerMutate: customer.CustomerMutate{
+			Name:     "Test Customer",
+			Currency: lo.ToPtr(currencyx.Code(currency.USD)),
+			UsageAttribution: customer.CustomerUsageAttribution{
+				SubjectKeys: []string{"test"},
+			},
+		},
+	})
+	s.NoError(err)
+	s.NotNil(customerEntity)
+	s.NotEmpty(customerEntity.ID)
+
+	// Create a test app
+	app, err := s.Fixture.setupApp(ctx, namespace)
+	s.NoError(err)
+
+	// Given we have a default profile for the namespace
+	s.ProvisionBillingProfile(ctx, namespace, app.GetID(), billingtest.WithBillingProfileEditFn(func(profile *billing.CreateProfileInput) {
+		// manual advancement for testing the update invoice flow
+		profile.WorkflowConfig.Invoicing.AutoAdvance = false
+		profile.WorkflowConfig.Payment.CollectionMethod = billing.CollectionMethodSendInvoice
+		profile.WorkflowConfig.Invoicing.DueAfter = lo.Must(datetime.ISODurationString("PT45D").Parse())
+	}))
+
+	// Setup the app with the customer
+
+	customerData, err := s.Fixture.setupAppCustomerData(ctx, app, customerEntity)
+	s.NoError(err)
+	s.NotNil(customerData)
+
+	// Mock the stripe app client for the get stripe customer call
+	s.StripeAppClient.
+		On("GetCustomer", defaultStripeCustomerID).
+		Return(stripeclient.StripeCustomer{
+			StripeCustomerID: defaultStripeCustomerID,
+			DefaultPaymentMethod: &stripeclient.StripePaymentMethod{
+				ID:    "pm_123",
+				Name:  "ACME Inc.",
+				Email: "acme@test.com",
+				BillingAddress: &models.Address{
+					City:       lo.ToPtr("San Francisco"),
+					PostalCode: lo.ToPtr("94103"),
+					State:      lo.ToPtr("CA"),
+					Country:    lo.ToPtr(models.CountryCode("US")),
+					Line1:      lo.ToPtr("123 Market St"),
+				},
+			},
+		}, nil)
+
+	// Get the default profile
+	defaultProfile, err := s.BillingService.GetDefaultProfile(ctx, billing.GetDefaultProfileInput{
+		Namespace: namespace,
+	})
+	s.NoError(err)
+
+	// The default profile should be the same as the app
+	s.Equal(defaultProfile.Apps.Invoicing.GetType(), app.GetType())
+
+	// Add a pending invoice line with a flat fee
+	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx,
+		billing.CreatePendingInvoiceLinesInput{
+			Customer: customerEntity.GetID(),
+			Currency: currencyx.Code(currency.USD),
+			Lines: []*billing.Line{
+				billing.NewUsageBasedFlatFeeLine(billing.NewFlatFeeLineInput{
+					Period:    billing.Period{Start: periodStart, End: periodEnd},
+					InvoiceAt: periodStart,
+					Name:      "Flat fee",
+
+					PerUnitAmount: alpacadecimal.NewFromFloat(10),
+					PaymentTerm:   productcatalog.InAdvancePaymentTerm,
+				}),
+			},
+		},
+	)
+	s.NoError(err)
+	s.Len(pendingLines.Lines, 1)
+
+	clock.FreezeTime(periodEnd.Add(time.Minute))
+
+	// Mock the stripe app client for the create invoice call
+	stripeAppCreateInvoiceMock := s.StripeAppClient.
+		// See expect for args below: we cannot setup argument expect here
+		// because we don't know the invoice ID before the call
+		On("CreateInvoice", mock.Anything).
+		Return(&stripe.Invoice{
+			ID: "stripe-invoice-id",
+			Customer: &stripe.Customer{
+				ID: customerData.StripeCustomerID,
+			},
+			Currency: "USD",
+			Lines: &stripe.InvoiceLineItemList{
+				Data: []*stripe.InvoiceLineItem{},
+			},
+		}, nil)
+
+		// When we create an invoice
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: customerEntity.GetID(),
+		AsOf:     &periodEnd,
+	})
+	s.NoError(err)
+	s.Len(invoices, 1)
+
+	invoice := invoices[0].RemoveCircularReferences()
+
+	// Assert the args of the create invoice call
+	// We have to do it after the call because the invoice ID is not known at the time of setting up the mock
+	stripeAppCreateInvoiceMock.Arguments.Assert(s.T(), stripeclient.CreateInvoiceInput{
+		AppID:               app.GetID(),
+		CustomerID:          customerEntity.GetID(),
+		InvoiceID:           invoice.ID,
+		AutomaticTaxEnabled: true,
+
+		StripeCustomerID: customerData.StripeCustomerID,
+		Currency:         "USD",
+
+		// This is what we test for in the send invoice billing profile test
+		CollectionMethod: billing.CollectionMethodSendInvoice,
+		DaysUntilDue:     lo.ToPtr(int64(45)),
+	})
 }
 
 func mapInvoiceItemParamsToInvoiceItem(id string, i *stripe.InvoiceItemParams) stripeclient.StripeInvoiceItemWithLineID {


### PR DESCRIPTION
- Add an integration test for Stripe Invoice sync with the Send Invoice setting.
- Handle when due is defined as period

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added comprehensive test coverage for the “Send invoice” billing flow, including due date handling (45 days), currency, tax settings, and invoice line processing. Improves reliability of invoice generation without altering user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->