### PR TITLE
fix: customer subject hook init

### DIFF
--- a/app/common/customer.go
+++ b/app/common/customer.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/app/config"
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customeradapter "github.com/openmeterio/openmeter/openmeter/customer/adapter"
 	customerservice "github.com/openmeterio/openmeter/openmeter/customer/service"
@@ -64,6 +65,7 @@ func NewCustomerSubjectServiceHook(
 	tracer trace.Tracer,
 	subjectService subject.Service,
 	customerService customer.Service,
+	customerOverrideService billing.CustomerOverrideService,
 ) (CustomerSubjectHook, error) {
 	if !config.EnableSubjectHook {
 		return new(customerservicehooks.NoopSubjectCustomerHook), nil
@@ -71,10 +73,11 @@ func NewCustomerSubjectServiceHook(
 
 	// Initialize the subject customer hook and register it for Subject service
 	h, err := customerservicehooks.NewSubjectCustomerHook(customerservicehooks.SubjectCustomerHookConfig{
-		Customer:     customerService,
-		Logger:       logger,
-		Tracer:       tracer,
-		IgnoreErrors: config.IgnoreErrors,
+		Customer:         customerService,
+		CustomerOverride: customerOverrideService,
+		Logger:           logger,
+		Tracer:           tracer,
+		IgnoreErrors:     config.IgnoreErrors,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create customer subject hook: %w", err)

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -363,7 +363,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	customerSubjectHook, err := common.NewCustomerSubjectServiceHook(customerConfiguration, logger, tracer, subjectService, customerService)
+	customerSubjectHook, err := common.NewCustomerSubjectServiceHook(customerConfiguration, logger, tracer, subjectService, customerService, billingService)
 	if err != nil {
 		cleanup6()
 		cleanup5()


### PR DESCRIPTION
## Overview

Re-add customer override service to customer subject hook to fix init. It was accidentally removed in #3345.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customer-specific overrides in subject-related workflows, enabling tailored behavior per account and more consistent rule application.

- **Chores**
  - Internal wiring updated to integrate the new override capability across services, ensuring the override is available where subject hooks run without changing external configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->