### PR TITLE
chore: fix subscription sync deleted customer handling

### DIFF
--- a/openmeter/subscription/service/service.go
+++ b/openmeter/subscription/service/service.go
@@ -389,12 +389,6 @@ func (s *service) GetView(ctx context.Context, subscriptionID models.NamespacedI
 		return def, err
 	}
 
-	if cus != nil && cus.IsDeleted() {
-		return def, models.NewGenericPreConditionFailedError(
-			fmt.Errorf("customer is deleted [namespace=%s customer.id=%s]", cus.Namespace, cus.ID),
-		)
-	}
-
 	if cus == nil {
 		return def, fmt.Errorf("customer is nil")
 	}


### PR DESCRIPTION
## Overview

A deleted customer's subscription view should be fetchable at least for the sync pruposes, but also the user can be interested in the deleted customer's history.

The deleted customer check is there for other operations so it's fine to remove it from here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where subscriptions couldn’t sync or bill after a customer was deleted post-cancellation. Outstanding usage-based charges are now correctly gathered, invoiced, and moved to draft for approval, improving billing reliability in edge cases.

* **Tests**
  * Added comprehensive coverage for late synchronization and invoicing after customer deletion to ensure correct billing behavior and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->