### PR TITLE
fix: shallowing error on owner lookup

### DIFF
--- a/openmeter/entitlement/metered/grant_owner_adapter.go
+++ b/openmeter/entitlement/metered/grant_owner_adapter.go
@@ -57,11 +57,14 @@ func (e *entitlementGrantOwner) DescribeOwner(ctx context.Context, id models.Nam
 	// get feature of ent
 	ent, err := e.entitlementRepo.GetEntitlement(ctx, id)
 	if err != nil {
-		e.logger.Debug(fmt.Sprintf("failed to get entitlement for owner %s in namespace %s: %s", id.ID, id.Namespace, err))
-		return def, &grant.OwnerNotFoundError{
-			Owner:          id,
-			AttemptedOwner: "entitlement",
+		if _, ok := lo.ErrorsAs[*entitlement.NotFoundError](err); ok {
+			return def, &grant.OwnerNotFoundError{
+				Owner:          id,
+				AttemptedOwner: "entitlement",
+			}
 		}
+
+		return def, err
 	}
 
 	mEnt, err := ParseFromGenericEntitlement(ent)


### PR DESCRIPTION
## Overview

Bubble up errors which are not _NotFound_ errors as previously all the errors were wrapped as _OwnerNotFoundError_ which may hide possible issues other then the _Entitlement_ not being found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error handling when retrieving owner entitlements: now returns “not found” only when appropriate and surfaces other errors accurately.
  * Improves clarity of error messages and reduces misleading “owner not found” responses, aiding troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->