### PR TITLE
refactor(entitlement): use hooks to honor subscription managed entitlements

### DIFF
--- a/openmeter/customer/httpdriver/handler.go
+++ b/openmeter/customer/httpdriver/handler.go
@@ -31,7 +31,7 @@ var _ Handler = (*handler)(nil)
 
 type handler struct {
 	service             customer.Service
-	entitlementService  entitlement.Connector
+	entitlementService  entitlement.Service
 	subscriptionService subscription.Service
 	namespaceDecoder    namespacedriver.NamespaceDecoder
 	options             []httptransport.HandlerOption
@@ -50,7 +50,7 @@ func New(
 	namespaceDecoder namespacedriver.NamespaceDecoder,
 	service customer.Service,
 	subscriptionService subscription.Service,
-	entitlementService entitlement.Connector,
+	entitlementService entitlement.Service,
 	options ...httptransport.HandlerOption,
 ) Handler {
 	return &handler{

--- a/openmeter/customer/service/hooks/entitlementvalidator.go
+++ b/openmeter/customer/service/hooks/entitlementvalidator.go
@@ -20,11 +20,11 @@ var _ models.ServiceHook[customer.Customer] = (*entitlementValidatorHook)(nil)
 type entitlementValidatorHook struct {
 	NoopEntitlementValidatorHook
 
-	entitlementService entitlement.Connector
+	entitlementService entitlement.Service
 }
 
 type EntitlementValidatorHookConfig struct {
-	EntitlementService entitlement.Connector
+	EntitlementService entitlement.Service
 }
 
 func (e EntitlementValidatorHookConfig) Validate() error {

--- a/openmeter/entitlement/connector.go
+++ b/openmeter/entitlement/connector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 	"github.com/openmeterio/openmeter/pkg/sortx"
@@ -51,7 +52,9 @@ type ListEntitlementsParams struct {
 	Offset int
 }
 
-type Connector interface {
+type Service interface {
+	models.ServiceHooks[Entitlement]
+
 	CreateEntitlement(ctx context.Context, input CreateEntitlementInputs) (*Entitlement, error)
 	ScheduleEntitlement(ctx context.Context, input CreateEntitlementInputs) (*Entitlement, error)
 	// OverrideEntitlement replaces a currently active entitlement with a new one.

--- a/openmeter/entitlement/driver/v2/handler.go
+++ b/openmeter/entitlement/driver/v2/handler.go
@@ -26,13 +26,13 @@ type EntitlementHandler interface {
 type entitlementHandler struct {
 	namespaceDecoder namespacedriver.NamespaceDecoder
 	options          []httptransport.HandlerOption
-	connector        entitlement.Connector
+	connector        entitlement.Service
 	balanceConnector meteredentitlement.Connector
 	customerService  customer.Service
 }
 
 func NewEntitlementHandler(
-	connector entitlement.Connector,
+	connector entitlement.Service,
 	balanceConnector meteredentitlement.Connector,
 	customerService customer.Service,
 	namespaceDecoder namespacedriver.NamespaceDecoder,

--- a/openmeter/entitlement/hooks/subscription/hook.go
+++ b/openmeter/entitlement/hooks/subscription/hook.go
@@ -1,0 +1,53 @@
+package entitlementsubscriptionhook
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/entitlement"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type hook struct {
+	NoopEntitlementSubscriptionHook
+}
+
+type EntitlementSubscriptionHookConfig struct{}
+
+type (
+	EntitlementSubscriptionHook     = models.ServiceHook[entitlement.Entitlement]
+	NoopEntitlementSubscriptionHook = models.NoopServiceHook[entitlement.Entitlement]
+)
+
+var _ models.ServiceHook[entitlement.Entitlement] = (*hook)(nil)
+
+func NewEntitlementSubscriptionHook(_ EntitlementSubscriptionHookConfig) EntitlementSubscriptionHook {
+	return &hook{
+		NoopEntitlementSubscriptionHook: NoopEntitlementSubscriptionHook{},
+	}
+}
+
+// The methods of entitlement.Service are not conventionally named, so check where this is used
+func (h *hook) PreDelete(ctx context.Context, ent *entitlement.Entitlement) error {
+	if subscription.IsSubscriptionOperation(ctx) {
+		return nil
+	}
+
+	if subscription.AnnotationParser.HasSubscription(ent.Annotations) {
+		return models.NewGenericForbiddenError(fmt.Errorf("entitlement is managed by subscription"))
+	}
+	return nil
+}
+
+// The methods of entitlement.Service are not conventionally named, so check where this is used
+func (h *hook) PreUpdate(ctx context.Context, ent *entitlement.Entitlement) error {
+	if subscription.IsSubscriptionOperation(ctx) {
+		return nil
+	}
+
+	if subscription.AnnotationParser.HasSubscription(ent.Annotations) {
+		return models.NewGenericForbiddenError(fmt.Errorf("entitlement is managed by subscription"))
+	}
+	return nil
+}

--- a/openmeter/entitlement/metered/entitlement.go
+++ b/openmeter/entitlement/metered/entitlement.go
@@ -49,6 +49,21 @@ type Entitlement struct {
 	LastReset time.Time `json:"lastReset"`
 }
 
+func (e *Entitlement) ToGenericEntitlement() *entitlement.Entitlement {
+	return &entitlement.Entitlement{
+		GenericProperties: e.GenericProperties,
+
+		MeasureUsageFrom:        &e.MeasureUsageFrom,
+		IssueAfterReset:         &e.IssueAfterReset.Amount,
+		IssueAfterResetPriority: e.IssueAfterReset.Priority,
+		IsSoftLimit:             &e.IsSoftLimit,
+		LastReset:               &e.LastReset,
+		PreserveOverageAtReset:  &e.PreserveOverageAtReset,
+
+		Config: nil,
+	}
+}
+
 // HasDefaultGrant returns true if the entitlement has a default grant.
 // This is the case when `IssueAfterReset` is set and greater than 0.
 func (e *Entitlement) HasDefaultGrant() bool {

--- a/openmeter/entitlement/metered/entitlement_grant.go
+++ b/openmeter/entitlement/metered/entitlement_grant.go
@@ -56,10 +56,15 @@ func (e *connector) CreateGrant(ctx context.Context, namespace string, customerI
 	if err != nil {
 		return EntitlementGrant{}, err
 	}
-	_, err = ParseFromGenericEntitlement(ent)
+	metered, err := ParseFromGenericEntitlement(ent)
 	if err != nil {
 		return EntitlementGrant{}, err
 	}
+
+	if err := e.hooks.PreUpdate(ctx, metered); err != nil {
+		return EntitlementGrant{}, err
+	}
+
 	g, err := e.grantConnector.CreateGrant(ctx, models.NamespacedID{
 		Namespace: ent.Namespace,
 		ID:        ent.ID,

--- a/openmeter/entitlement/metered/hook.go
+++ b/openmeter/entitlement/metered/hook.go
@@ -1,0 +1,40 @@
+package meteredentitlement
+
+import (
+	"context"
+
+	"github.com/openmeterio/openmeter/openmeter/entitlement"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type hook struct {
+	EntitlementHook models.ServiceHook[entitlement.Entitlement]
+}
+
+var _ models.ServiceHook[Entitlement] = (*hook)(nil)
+
+func ConvertHook(h models.ServiceHook[entitlement.Entitlement]) models.ServiceHook[Entitlement] {
+	return &hook{
+		EntitlementHook: h,
+	}
+}
+
+func (h *hook) PreDelete(ctx context.Context, ent *Entitlement) error {
+	return h.EntitlementHook.PreDelete(ctx, ent.ToGenericEntitlement())
+}
+
+func (h *hook) PreUpdate(ctx context.Context, ent *Entitlement) error {
+	return h.EntitlementHook.PreUpdate(ctx, ent.ToGenericEntitlement())
+}
+
+func (h *hook) PostCreate(ctx context.Context, ent *Entitlement) error {
+	return h.EntitlementHook.PostCreate(ctx, ent.ToGenericEntitlement())
+}
+
+func (h *hook) PostUpdate(ctx context.Context, ent *Entitlement) error {
+	return h.EntitlementHook.PostUpdate(ctx, ent.ToGenericEntitlement())
+}
+
+func (h *hook) PostDelete(ctx context.Context, ent *Entitlement) error {
+	return h.EntitlementHook.PostDelete(ctx, ent.ToGenericEntitlement())
+}

--- a/openmeter/entitlement/metered/lateevents_test.go
+++ b/openmeter/entitlement/metered/lateevents_test.go
@@ -19,6 +19,7 @@ import (
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
 	"github.com/openmeterio/openmeter/openmeter/entitlement"
 	entitlement_postgresadapter "github.com/openmeterio/openmeter/openmeter/entitlement/adapter"
+	entitlementsubscriptionhook "github.com/openmeterio/openmeter/openmeter/entitlement/hooks/subscription"
 	meteredentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/metered"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	meteradapter "github.com/openmeterio/openmeter/openmeter/meter/mockadapter"
@@ -192,6 +193,10 @@ func TestGetEntitlementBalanceConsistency(t *testing.T) {
 			mockPublisher,
 			testLogger,
 			tracer,
+		)
+
+		connector.RegisterHooks(
+			meteredentitlement.ConvertHook(entitlementsubscriptionhook.NewEntitlementSubscriptionHook(entitlementsubscriptionhook.EntitlementSubscriptionHookConfig{})),
 		)
 
 		subjectRepo, err := subjectadapter.New(dbClient)

--- a/openmeter/entitlement/metered/reset.go
+++ b/openmeter/entitlement/metered/reset.go
@@ -36,6 +36,10 @@ func (e *connector) ResetEntitlementUsage(ctx context.Context, entitlementID mod
 			return nil, fmt.Errorf("failed to parse entitlement: %w", err)
 		}
 
+		if err := e.hooks.PreUpdate(ctx, mEnt); err != nil {
+			return nil, err
+		}
+
 		balanceAfterReset, err := e.balanceConnector.ResetUsageForOwner(ctx, owner, credit.ResetUsageForOwnerParams{
 			At:              params.At,
 			RetainAnchor:    params.RetainAnchor,

--- a/openmeter/entitlement/metered/utils_test.go
+++ b/openmeter/entitlement/metered/utils_test.go
@@ -22,6 +22,7 @@ import (
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
 	"github.com/openmeterio/openmeter/openmeter/entitlement"
 	entitlement_postgresadapter "github.com/openmeterio/openmeter/openmeter/entitlement/adapter"
+	entitlementsubscriptionhook "github.com/openmeterio/openmeter/openmeter/entitlement/hooks/subscription"
 	meteredentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/metered"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	meteradapter "github.com/openmeterio/openmeter/openmeter/meter/mockadapter"
@@ -163,6 +164,10 @@ func setupConnector(t *testing.T) (meteredentitlement.Connector, *dependencies) 
 		mockPublisher,
 		testLogger,
 		tracer,
+	)
+
+	connector.RegisterHooks(
+		meteredentitlement.ConvertHook(entitlementsubscriptionhook.NewEntitlementSubscriptionHook(entitlementsubscriptionhook.EntitlementSubscriptionHookConfig{})),
 	)
 
 	subjectRepo, err := subjectadapter.New(dbClient)

--- a/openmeter/entitlement/service/scheduling_test.go
+++ b/openmeter/entitlement/service/scheduling_test.go
@@ -58,11 +58,11 @@ func TestScheduling(t *testing.T) {
 
 	tt := []struct {
 		name string
-		fn   func(t *testing.T, conn entitlement.Connector, deps *dependencies)
+		fn   func(t *testing.T, conn entitlement.Service, deps *dependencies)
 	}{
 		{
 			name: "Should not allow scheduling via create",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 				_, err := conn.CreateEntitlement(
 					ctx,
@@ -91,7 +91,7 @@ func TestScheduling(t *testing.T) {
 		},
 		{
 			name: "Should fail scheduling is contradictory",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 
 				clock.SetTime(testutils.GetRFC3339Time(t, "2024-01-03T00:00:00Z"))
@@ -152,7 +152,7 @@ func TestScheduling(t *testing.T) {
 		},
 		{
 			name: "Should allow scheduling entitlement if no entitlement is present for pair",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 
 				clock.SetTime(testutils.GetRFC3339Time(t, "2024-01-03T00:00:00Z"))
@@ -185,7 +185,7 @@ func TestScheduling(t *testing.T) {
 		},
 		{
 			name: "Should allow scheduling entitlement after current scheduled entitlement",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 
 				clock.SetTime(testutils.GetRFC3339Time(t, "2024-01-03T00:00:00Z"))
@@ -234,7 +234,7 @@ func TestScheduling(t *testing.T) {
 		},
 		{
 			name: "Should error if entitlements with defined schedules overlap",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 
 				clock.SetTime(testutils.GetRFC3339Time(t, "2024-01-03T00:00:00Z"))
@@ -286,7 +286,7 @@ func TestScheduling(t *testing.T) {
 		},
 		{
 			name: "Should error when attempting to schedule after indefinite entitlement",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 
 				clock.SetTime(testutils.GetRFC3339Time(t, "2024-01-03T00:00:00Z"))
@@ -336,7 +336,7 @@ func TestScheduling(t *testing.T) {
 		},
 		{
 			name: "Should save annotations for all entitlement types",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 
 				// create customer and subject
@@ -456,11 +456,11 @@ func TestSuperseding(t *testing.T) {
 
 	tt := []struct {
 		name string
-		fn   func(t *testing.T, conn entitlement.Connector, deps *dependencies)
+		fn   func(t *testing.T, conn entitlement.Service, deps *dependencies)
 	}{
 		{
 			name: "Should error if original entitlement is not found",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 
 				clock.SetTime(testutils.GetRFC3339Time(t, "2024-01-03T00:00:00Z"))
@@ -485,7 +485,7 @@ func TestSuperseding(t *testing.T) {
 		},
 		{
 			name: "Should error if feature is not found",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 
 				clock.SetTime(testutils.GetRFC3339Time(t, "2024-01-03T00:00:00Z"))
@@ -532,7 +532,7 @@ func TestSuperseding(t *testing.T) {
 		},
 		{
 			name: "Should error for differing feature",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 
 				clock.SetTime(testutils.GetRFC3339Time(t, "2024-01-03T00:00:00Z"))
@@ -576,7 +576,7 @@ func TestSuperseding(t *testing.T) {
 		},
 		{
 			name: "Should error for differing subjects",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 
 				clock.SetTime(testutils.GetRFC3339Time(t, "2024-01-03T00:00:00Z"))
@@ -622,7 +622,7 @@ func TestSuperseding(t *testing.T) {
 		},
 		{
 			name: "Should supersede entitlement",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 
 				clock.SetTime(testutils.GetRFC3339Time(t, "2024-01-03T00:00:00Z"))
@@ -671,7 +671,7 @@ func TestSuperseding(t *testing.T) {
 		},
 		{
 			name: "Should error if entitlements are not continuous",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 
 				clock.SetTime(testutils.GetRFC3339Time(t, "2024-01-03T00:00:00Z"))
@@ -716,7 +716,7 @@ func TestSuperseding(t *testing.T) {
 		},
 		{
 			name: "Should use current time for scheduling if activeFrom is not provided",
-			fn: func(t *testing.T, conn entitlement.Connector, deps *dependencies) {
+			fn: func(t *testing.T, conn entitlement.Service, deps *dependencies) {
 				ctx := t.Context()
 
 				activeFrom1 := testutils.GetRFC3339Time(t, "2024-01-01T12:00:00Z")

--- a/openmeter/entitlement/service/utils_test.go
+++ b/openmeter/entitlement/service/utils_test.go
@@ -85,7 +85,7 @@ func (d *dependencies) Teardown() {
 // When migrating in parallel with entgo it causes concurrent writes error
 var m sync.Mutex
 
-func setupDependecies(t *testing.T) (entitlement.Connector, *dependencies) {
+func setupDependecies(t *testing.T) (entitlement.Service, *dependencies) {
 	testLogger := testutils.NewLogger(t)
 
 	meterService, err := meteradapter.NewManage(nil)

--- a/openmeter/registry/entitlement.go
+++ b/openmeter/registry/entitlement.go
@@ -16,6 +16,6 @@ type Entitlement struct {
 	Grant              credit.GrantConnector
 	GrantRepo          grant.Repo
 	MeteredEntitlement meteredentitlement.Connector
-	Entitlement        entitlement.Connector
+	Entitlement        entitlement.Service
 	EntitlementRepo    entitlement.EntitlementRepo
 }

--- a/openmeter/server/router/router.go
+++ b/openmeter/server/router/router.go
@@ -93,7 +93,7 @@ type Config struct {
 	BillingFeatureSwitches      config.BillingFeatureSwitchesConfiguration
 	Customer                    customer.Service
 	DebugConnector              debug.DebugConnector
-	EntitlementConnector        entitlement.Connector
+	EntitlementConnector        entitlement.Service
 	EntitlementBalanceConnector meteredentitlement.Connector
 	ErrorHandler                errorsx.Handler
 	FeatureConnector            feature.FeatureConnector

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -683,9 +683,12 @@ func (n NoopFeatureConnector) ArchiveFeature(ctx context.Context, featureID mode
 }
 
 // NoopEntitlementConnector
-var _ entitlement.Connector = (*NoopEntitlementConnector)(nil)
+var _ entitlement.Service = (*NoopEntitlementConnector)(nil)
 
 type NoopEntitlementConnector struct{}
+
+func (n NoopEntitlementConnector) RegisterHooks(hooks ...models.ServiceHook[entitlement.Entitlement]) {
+}
 
 func (n NoopEntitlementConnector) CreateEntitlement(ctx context.Context, input entitlement.CreateEntitlementInputs) (*entitlement.Entitlement, error) {
 	return &entitlement.Entitlement{}, nil
@@ -736,6 +739,9 @@ func (n NoopEntitlementConnector) GetAccess(ctx context.Context, namespace strin
 var _ meteredentitlement.Connector = (*NoopEntitlementBalanceConnector)(nil)
 
 type NoopEntitlementBalanceConnector struct{}
+
+func (n NoopEntitlementBalanceConnector) RegisterHooks(hooks ...models.ServiceHook[meteredentitlement.Entitlement]) {
+}
 
 func (n NoopEntitlementBalanceConnector) GetEntitlementBalance(ctx context.Context, entitlementID models.NamespacedID, at time.Time) (*meteredentitlement.EntitlementBalance, error) {
 	return nil, nil

--- a/openmeter/subject/httphandler/handler.go
+++ b/openmeter/subject/httphandler/handler.go
@@ -31,7 +31,7 @@ type handler struct {
 	options              []httptransport.HandlerOption
 	logger               *slog.Logger
 	subjectService       subject.Service
-	entitlementConnector entitlement.Connector
+	entitlementConnector entitlement.Service
 }
 
 func (h *handler) resolveNamespace(ctx context.Context) (string, error) {
@@ -47,7 +47,7 @@ func New(
 	namespaceDecoder namespacedriver.NamespaceDecoder,
 	logger *slog.Logger,
 	subjectService subject.Service,
-	entitlementConnector entitlement.Connector,
+	entitlementConnector entitlement.Service,
 	options ...httptransport.HandlerOption,
 ) Handler {
 	return &handler{

--- a/openmeter/subject/service/hooks/entitlementvalidator.go
+++ b/openmeter/subject/service/hooks/entitlementvalidator.go
@@ -20,11 +20,11 @@ var _ models.ServiceHook[subject.Subject] = (*entitlementValidatorHook)(nil)
 type entitlementValidatorHook struct {
 	NoopEntitlementValidatorHook
 
-	entitlementService entitlement.Connector
+	entitlementService entitlement.Service
 }
 
 type EntitlementValidatorHookConfig struct {
-	EntitlementService entitlement.Connector
+	EntitlementService entitlement.Service
 }
 
 func (e EntitlementValidatorHookConfig) Validate() error {

--- a/openmeter/subscription/context.go
+++ b/openmeter/subscription/context.go
@@ -1,0 +1,22 @@
+package subscription
+
+import "context"
+
+type contextKey string
+
+const (
+	subscriptionoperation contextKey = "subscriptionoperation"
+)
+
+func NewSubscriptionOperationContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, subscriptionoperation, true)
+}
+
+func IsSubscriptionOperation(ctx context.Context) bool {
+	u, ok := ctx.Value(subscriptionoperation).(bool)
+	if !ok {
+		return false
+	}
+
+	return u
+}

--- a/openmeter/subscription/entitlement/adapter.go
+++ b/openmeter/subscription/entitlement/adapter.go
@@ -16,7 +16,7 @@ import (
 )
 
 type EntitlementSubscriptionAdapter struct {
-	entitlementConnector entitlement.Connector
+	entitlementConnector entitlement.Service
 	itemRepo             subscription.SubscriptionItemRepository
 	txCreator            transaction.Creator
 }
@@ -24,7 +24,7 @@ type EntitlementSubscriptionAdapter struct {
 var _ subscription.EntitlementAdapter = &EntitlementSubscriptionAdapter{}
 
 func NewSubscriptionEntitlementAdapter(
-	entitlementConnector entitlement.Connector,
+	entitlementConnector entitlement.Service,
 	itemRepo subscription.SubscriptionItemRepository,
 	txCreator transaction.Creator,
 ) *EntitlementSubscriptionAdapter {

--- a/openmeter/subscription/service/service.go
+++ b/openmeter/subscription/service/service.go
@@ -77,6 +77,8 @@ func (s *service) lockCustomer(ctx context.Context, customerId string) error {
 }
 
 func (s *service) Create(ctx context.Context, namespace string, spec subscription.SubscriptionSpec) (subscription.Subscription, error) {
+	ctx = subscription.NewSubscriptionOperationContext(ctx)
+
 	def := subscription.Subscription{}
 
 	// Fetch the customer & validate the customer
@@ -163,6 +165,8 @@ func (s *service) Create(ctx context.Context, namespace string, spec subscriptio
 }
 
 func (s *service) Update(ctx context.Context, subscriptionID models.NamespacedID, newSpec subscription.SubscriptionSpec) (subscription.Subscription, error) {
+	ctx = subscription.NewSubscriptionOperationContext(ctx)
+
 	var def subscription.Subscription
 
 	// Get the full view
@@ -207,6 +211,8 @@ func (s *service) Update(ctx context.Context, subscriptionID models.NamespacedID
 }
 
 func (s *service) Delete(ctx context.Context, subscriptionID models.NamespacedID) error {
+	ctx = subscription.NewSubscriptionOperationContext(ctx)
+
 	currentTime := clock.Now()
 
 	// First, let's get the subscription
@@ -256,6 +262,8 @@ func (s *service) Delete(ctx context.Context, subscriptionID models.NamespacedID
 }
 
 func (s *service) Cancel(ctx context.Context, subscriptionID models.NamespacedID, timing subscription.Timing) (subscription.Subscription, error) {
+	ctx = subscription.NewSubscriptionOperationContext(ctx)
+
 	return transaction.Run(ctx, s.TransactionManager, func(ctx context.Context) (subscription.Subscription, error) {
 		// First, let's get the subscription
 		view, err := s.GetView(ctx, subscriptionID)
@@ -314,6 +322,8 @@ func (s *service) Cancel(ctx context.Context, subscriptionID models.NamespacedID
 }
 
 func (s *service) Continue(ctx context.Context, subscriptionID models.NamespacedID) (subscription.Subscription, error) {
+	ctx = subscription.NewSubscriptionOperationContext(ctx)
+
 	// First, let's get the subscription
 	view, err := s.GetView(ctx, subscriptionID)
 	if err != nil {
@@ -363,6 +373,8 @@ func (s *service) Continue(ctx context.Context, subscriptionID models.Namespaced
 }
 
 func (s *service) Get(ctx context.Context, subscriptionID models.NamespacedID) (subscription.Subscription, error) {
+	ctx = subscription.NewSubscriptionOperationContext(ctx)
+
 	sub, err := s.SubscriptionRepo.GetByID(ctx, subscriptionID)
 	if err != nil {
 		return subscription.Subscription{}, err
@@ -371,6 +383,8 @@ func (s *service) Get(ctx context.Context, subscriptionID models.NamespacedID) (
 }
 
 func (s *service) GetView(ctx context.Context, subscriptionID models.NamespacedID) (subscription.SubscriptionView, error) {
+	ctx = subscription.NewSubscriptionOperationContext(ctx)
+
 	var def subscription.SubscriptionView
 	currentTime := clock.Now()
 
@@ -457,10 +471,14 @@ func (s *service) GetView(ctx context.Context, subscriptionID models.NamespacedI
 }
 
 func (s *service) GetAllForCustomerSince(ctx context.Context, customerID models.NamespacedID, at time.Time) ([]subscription.Subscription, error) {
+	ctx = subscription.NewSubscriptionOperationContext(ctx)
+
 	return s.SubscriptionRepo.GetAllForCustomerSince(ctx, customerID, at)
 }
 
 func (s *service) List(ctx context.Context, input subscription.ListSubscriptionsInput) (subscription.SubscriptionList, error) {
+	ctx = subscription.NewSubscriptionOperationContext(ctx)
+
 	if err := input.Validate(); err != nil {
 		return subscription.SubscriptionList{}, fmt.Errorf("input is invalid: %w", err)
 	}

--- a/test/customer/testenv.go
+++ b/test/customer/testenv.go
@@ -37,7 +37,7 @@ const (
 type TestEnv interface {
 	Customer() customer.Service
 	Subscription() subscription.Service
-	Entitlement() entitlement.Connector
+	Entitlement() entitlement.Service
 	Feature() feature.FeatureConnector
 	Subject() subject.Service
 
@@ -49,7 +49,7 @@ var _ TestEnv = (*testEnv)(nil)
 type testEnv struct {
 	customer     customer.Service
 	subscription subscription.Service
-	entitlement  entitlement.Connector
+	entitlement  entitlement.Service
 	feature      feature.FeatureConnector
 	subject      subject.Service
 
@@ -68,7 +68,7 @@ func (n testEnv) Subscription() subscription.Service {
 	return n.subscription
 }
 
-func (n testEnv) Entitlement() entitlement.Connector {
+func (n testEnv) Entitlement() entitlement.Service {
 	return n.entitlement
 }
 


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

We had issues on limitations around subscription managed entitlements not being honoured for V2 APIs. This PR moves the checks into entitlement hooks which use a context created in the subscription service.


<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Subscription-aware safeguards added across entitlement operations, ensuring consistent protection of subscription-managed entitlements.
- Bug Fixes
  - Blocking deletion of subscription-managed entitlements now enforced across both subject and customer APIs (returns 403).
- Refactor
  - Migrated entitlement backend to a unified service with hook support for extensibility; no API endpoint changes.
- Tests
  - Added end-to-end and regression tests for subscription-managed entitlement protections and late-event scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->