### PR TITLE
fix: return billing period for free phases too

### DIFF
--- a/openmeter/subscription/errors.go
+++ b/openmeter/subscription/errors.go
@@ -24,6 +24,10 @@ func NewErrSubscriptionBillingPeriodQueriedBeforeSubscriptionStart(queriedAt, su
 	return ErrSubscriptionBillingPeriodQueriedBeforeSubscriptionStart.WithAttr("queried_at", queriedAt).WithAttr("subscription_start", subscriptionStart)
 }
 
+func IsErrSubscriptionBillingPeriodQueriedBeforeSubscriptionStart(err error) bool {
+	return IsValidationIssueWithCode(err, ErrCodeSubscriptionBillingPeriodQueriedBeforeSubscriptionStart)
+}
+
 // TODO(galexi): "ValidationIssue" is not the right concept here. We should have a different kind of error with all this capability. It's used here as a hack to localize things for the time being.
 
 func IsValidationIssueWithCode(err error, code models.ErrorCode) bool {

--- a/openmeter/subscription/subscriptionspec.go
+++ b/openmeter/subscription/subscriptionspec.go
@@ -1153,16 +1153,3 @@ func (e AlignmentError) Error() string {
 func (e AlignmentError) Unwrap() error {
 	return e.Inner
 }
-
-// NoBillingPeriodError is an error that occurs when a phase has no billing period.
-type NoBillingPeriodError struct {
-	Inner error
-}
-
-func (e NoBillingPeriodError) Error() string {
-	return fmt.Sprintf("no billing period: %s", e.Inner)
-}
-
-func (e NoBillingPeriodError) Unwrap() error {
-	return e.Inner
-}

--- a/openmeter/subscription/workflow/errors.go
+++ b/openmeter/subscription/workflow/errors.go
@@ -16,8 +16,6 @@ func MapSubscriptionErrors(err error) error {
 		return models.NewGenericValidationError(sErr)
 	} else if sErr, ok := lo.ErrorsAs[*subscription.AlignmentError](err); ok {
 		return models.NewGenericConflictError(sErr)
-	} else if sErr, ok := lo.ErrorsAs[*subscription.NoBillingPeriodError](err); ok {
-		return models.NewGenericValidationError(sErr)
 	}
 
 	return err


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

We no longer calculate billing period based on item level properties but based on subscription level properties so this should be trivial. The old check was left in place by mistake.


<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Improvements
  - Always attempts to resolve the current aligned billing period and surfaces the period range when available.
  - Gracefully handles requests made before a subscription’s start by ignoring that specific case instead of interrupting the flow.

- Bug Fixes
  - Reduced sporadic errors when querying billing periods early in a subscription lifecycle.
  - More consistent error behavior across subscription workflows, avoiding unnecessary validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->