### PR TITLE
fix: remove unnecessary deleted check on subject when fetching

### DIFF
--- a/openmeter/entitlement/balanceworker/subject_customer.go
+++ b/openmeter/entitlement/balanceworker/subject_customer.go
@@ -20,12 +20,7 @@ func resolveCustomerAndSubject(ctx context.Context, customerService customer.Ser
 		return customer.Customer{}, subject.Subject{}, fmt.Errorf("failed to get customer: %w", err)
 	}
 
-	if cus != nil && cus.IsDeleted() {
-		return customer.Customer{}, subject.Subject{}, models.NewGenericPreConditionFailedError(
-			fmt.Errorf("customer is deleted [namespace=%s customer.id=%s]", cus.Namespace, cus.ID),
-		)
-	}
-
+	// Let's be defensive
 	if cus == nil {
 		return customer.Customer{}, subject.Subject{}, models.NewGenericNotFoundError(
 			fmt.Errorf("customer not found [namespace=%s customer.id=%s]", namespace, customerID),


### PR DESCRIPTION
As we allow deleting customers ?at=T if they have now ACTIVE entitlements ?at=T, it is perfectly possible for both UDPATE and DELETE entitlement events to reference deleted customers.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deleted customers during entitlement processing, reducing unexpected “precondition failed” errors.
  * Returns clearer “not found” responses when a customer truly doesn’t exist.
  * Ensures entitlement lookups proceed consistently for existing records, improving reliability of balance checks and related workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->