### PR TITLE
fix: stripe app errors

### DIFF
--- a/openmeter/customer/service/hooks/subjectcustomer.go
+++ b/openmeter/customer/service/hooks/subjectcustomer.go
@@ -493,12 +493,8 @@ func (p CustomerProvisioner) EnsureStripeCustomer(ctx context.Context, customerI
 		},
 	})
 	if err != nil {
-		var preconditionError *app.AppCustomerPreConditionError
-
-		if errors.As(err, &preconditionError) && strings.Contains(err.Error(), "stripe customer not found in stripe account") {
-			p.logger.WarnContext(ctx, "failed to setup stripe customer id for customer", "error", err.Error())
-
-			return nil
+		if e, ok := lo.ErrorsAs[*app.AppCustomerPreConditionError](err); ok {
+			return models.NewGenericPreConditionFailedError(e.Unwrap())
 		}
 
 		return fmt.Errorf("failed to setup stripe customer id for customer [namespace=%s customer.id=%s]: %w",


### PR DESCRIPTION
## Overview

Setting the same `stripe_customer_id` for multiple Subjects is allowed as uniqueness is not enforced. This causes problems when it comes to upserting Customer entities for Subjects as `stripe_customer_id` must be uniqe for each Customer.

This change will surface these errors to users so they can decide how to resolve this issues as we cannot decide on backend if the user assgined the `stripe_customer_id` to Subject as metadata or it is used for one of the Stripe integrations (Stripe Usage Reporter, Stripe App, etc).

In case of the former we encourage users to use the `metadata` field of the Subject entity to store any metadata, otherwise users need to ensure that `stripe_customer_id` are unique across Subject entities in order to resolve this issue.

