### PR TITLE
fix(subject-http): add errorencoder

### DIFF
--- a/openmeter/subject/httphandler/mapping.go
+++ b/openmeter/subject/httphandler/mapping.go
@@ -1,8 +1,14 @@
 package httpdriver
 
 import (
+	"context"
+	"net/http"
+
 	"github.com/openmeterio/openmeter/api"
+	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/subject"
+	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
+	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport/encoder"
 )
 
 func FromSubject(s subject.Subject) api.Subject {
@@ -27,5 +33,11 @@ func FromSubject(s subject.Subject) api.Subject {
 		DisplayName:      s.DisplayName,
 		Metadata:         metadata,
 		StripeCustomerId: s.StripeCustomerId,
+	}
+}
+
+func errorEncoder() encoder.ErrorEncoder {
+	return func(ctx context.Context, err error, w http.ResponseWriter, r *http.Request) bool {
+		return commonhttp.HandleErrorIfTypeMatches[*app.AppCustomerPreConditionError](ctx, http.StatusConflict, err, w)
 	}
 }

--- a/openmeter/subject/httphandler/subject.go
+++ b/openmeter/subject/httphandler/subject.go
@@ -257,6 +257,7 @@ func (h *handler) UpsertSubject() UpsertSubjectHandler {
 		httptransport.AppendOptions(
 			h.options,
 			httptransport.WithOperationName("upsertSubject"),
+			httptransport.WithErrorEncoder(errorEncoder()),
 		)...,
 	)
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Adds error mapping for app conflict errors to the http handler


<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upsert Subject endpoint now returns HTTP 409 Conflict when a precondition is not met, providing a more accurate and descriptive status for conflict scenarios.
  * Error handling for subject-related requests is standardized, resulting in more consistent and informative API error responses.
  * No impact on successful requests; only error responses are clarified to better align with expected HTTP semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->