### PR TITLE
fix: create/update plan validation

### DIFF
--- a/openmeter/productcatalog/plan/httpdriver/mapping.go
+++ b/openmeter/productcatalog/plan/httpdriver/mapping.go
@@ -169,7 +169,7 @@ func AsPlanPhase(a api.PlanPhase) (productcatalog.Phase, error) {
 
 	phase.Duration, err = (*datetime.ISODurationString)(a.Duration).ParsePtrOrNil()
 	if err != nil {
-		return phase, fmt.Errorf("failed to cast duration to period: %w", err)
+		return phase, models.NewGenericValidationError(fmt.Errorf("invalid duration: failed to cast to period: %w", err))
 	}
 
 	phase.RateCards, err = http.AsRateCards(a.RateCards)
@@ -195,7 +195,7 @@ func AsUpdatePlanRequest(a api.PlanReplaceUpdate, namespace string, planID strin
 	if a.BillingCadence != "" {
 		billingCadence, err := datetime.ISODurationString(a.BillingCadence).Parse()
 		if err != nil {
-			return req, fmt.Errorf("invalid BillingCadence: %w", err)
+			return req, models.NewGenericValidationError(fmt.Errorf("invalid billingCadence: %w", err))
 		}
 
 		req.BillingCadence = lo.ToPtr(billingCadence)

--- a/openmeter/productcatalog/plan/httpdriver/plan.go
+++ b/openmeter/productcatalog/plan/httpdriver/plan.go
@@ -167,7 +167,7 @@ func (h *handler) UpdatePlan() UpdatePlanHandler {
 
 			req, err := AsUpdatePlanRequest(body, ns, planID)
 			if err != nil {
-				return UpdatePlanRequest{}, fmt.Errorf("failed to update plan request: %w", err)
+				return UpdatePlanRequest{}, fmt.Errorf("failed to parse update plan request: %w", err)
 			}
 
 			req.NamespacedID = models.NamespacedID{


### PR DESCRIPTION
## Overview

Wrap validation errors returned for create/update Plan requests.

```
failed to update plan request: invalid BillingCadence: failed to parse duration 'undefined': undefined: expected 'P' period mark at the start
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation errors for plan phase duration and billing cadence parsing, providing clearer, consistent messages.
  * UpdatePlan endpoint now reports parsing errors more accurately, improving error clarity for clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->