### PR TITLE
feat: add redirect response encoder

### DIFF
--- a/openmeter/ingest/ingestdriver/http_transport.go
+++ b/openmeter/ingest/ingestdriver/http_transport.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/openmeter/ingest"
 	"github.com/openmeterio/openmeter/openmeter/namespace/namespacedriver"
+	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/operation"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport/encoder"
@@ -29,7 +30,7 @@ func NewIngestEventsHandler(
 			NamespaceDecoder: namespaceDecoder,
 		}).decode,
 		op,
-		encodeIngestEventsResponse,
+		commonhttp.EmptyResponseEncoder[bool](http.StatusNoContent),
 		httptransport.WithErrorEncoder((ingestEventsErrorEncoder{
 			CommonErrorEncoder: commonErrorEncoder,
 		}).encode),
@@ -144,12 +145,6 @@ func (d ingestEventsRequestDecoder) decode(ctx context.Context, r *http.Request)
 	}
 
 	return req, nil
-}
-
-func encodeIngestEventsResponse(_ context.Context, w http.ResponseWriter, _ bool) error {
-	w.WriteHeader(http.StatusNoContent)
-
-	return nil
 }
 
 type ingestEventsErrorEncoder struct {

--- a/openmeter/productcatalog/driver/feature.go
+++ b/openmeter/productcatalog/driver/feature.go
@@ -232,10 +232,7 @@ func (h *featureHandlers) DeleteFeature() DeleteFeatureHandler {
 			return id, nil
 		},
 		operation.AsNoResponseOperation(h.connector.ArchiveFeature),
-		func(ctx context.Context, w http.ResponseWriter, response any) error {
-			w.WriteHeader(http.StatusNoContent)
-			return nil
-		},
+		commonhttp.EmptyResponseEncoder[DeleteFeatureHandlerResponse](http.StatusNoContent),
 		httptransport.AppendOptions(
 			h.options,
 			httptransport.WithOperationName("deleteFeature"),

--- a/pkg/framework/transport/httptransport/encoder/encoder.go
+++ b/pkg/framework/transport/httptransport/encoder/encoder.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 )
 
-type ResponseEncoder[Response any] func(ctx context.Context, w http.ResponseWriter, response Response) error
+type ResponseEncoder[Response any] func(ctx context.Context, w http.ResponseWriter, r *http.Request, response Response) error
 
 // ErrorEncoder is responsible for encoding an error to the ResponseWriter.
 // Users are encouraged to use custom ErrorEncoders to encode HTTP errors to

--- a/pkg/framework/transport/httptransport/handler.go
+++ b/pkg/framework/transport/httptransport/handler.go
@@ -108,7 +108,7 @@ func (h handler[Request, Response]) ServeHTTP(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if err := h.encodeResponse(ctx, w, response); err != nil {
+	if err := h.encodeResponse(ctx, w, r, response); err != nil {
 		// Always a server error (terminal)?
 
 		h.errorHandler.HandleContext(ctx, err)


### PR DESCRIPTION
## Overview

Add `RedirectResponseEncoder` to allow HTTP handlers to  return redirect responses to API client. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for HTTP redirects with validated URLs and proper 3xx status handling.

- Refactor
  - Standardized 204 No Content responses across relevant endpoints for more consistent API behavior.
  - Unified response encoding to include request context, improving consistency and enabling future enhancements without changing current API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->