### PR TITLE
refactor: kafka config default setting

### DIFF
--- a/app/config/ingest.go
+++ b/app/config/ingest.go
@@ -160,16 +160,26 @@ func (c KafkaConfiguration) CreateKafkaConfig() kafka.ConfigMap {
 	return config
 }
 
+func ConfigureIngestKafkaConfiguration(v *viper.Viper, prefixes ...string) {
+	prefixer := NewViperKeyPrefixer(prefixes...)
+
+	v.SetDefault(prefixer("kafka.broker"), "127.0.0.1:29092")
+	v.SetDefault(prefixer("kafka.securityProtocol"), "")
+	v.SetDefault(prefixer("kafka.saslMechanisms"), "")
+	v.SetDefault(prefixer("kafka.saslUsername"), "")
+	v.SetDefault(prefixer("kafka.saslPassword"), "")
+	v.SetDefault(prefixer("kafka.statsInterval"), 0)
+	v.SetDefault(prefixer("kafka.brokerAddressFamily"), "")
+	v.SetDefault(prefixer("kafka.socketKeepAliveEnabled"), true)
+	v.SetDefault(prefixer("kafka.topicMetadataRefreshInterval"), 0)
+}
+
 // Configure configures some defaults in the Viper instance.
 func ConfigureIngest(v *viper.Viper) {
-	v.SetDefault("ingest.kafka.broker", "127.0.0.1:29092")
-	v.SetDefault("ingest.kafka.securityProtocol", "")
-	v.SetDefault("ingest.kafka.saslMechanisms", "")
-	v.SetDefault("ingest.kafka.saslUsername", "")
-	v.SetDefault("ingest.kafka.saslPassword", "")
 	v.SetDefault("ingest.kafka.partitions", 1)
 	v.SetDefault("ingest.kafka.eventsTopicTemplate", "om_%s_events")
 	v.SetDefault("ingest.kafka.namespaceDeletionEnabled", false)
 
+	ConfigureIngestKafkaConfiguration(v, "ingest")
 	ConfigureTopicProvisioner(v, "ingest", "kafka", "topicProvisioner")
 }

--- a/app/config/ingest.go
+++ b/app/config/ingest.go
@@ -169,7 +169,7 @@ func ConfigureIngestKafkaConfiguration(v *viper.Viper, prefixes ...string) {
 	v.SetDefault(prefixer("kafka.saslUsername"), "")
 	v.SetDefault(prefixer("kafka.saslPassword"), "")
 	v.SetDefault(prefixer("kafka.statsInterval"), 15*time.Second)
-	v.SetDefault(prefixer("kafka.brokerAddressFamily"), "")
+	v.SetDefault(prefixer("kafka.brokerAddressFamily"), "v4")
 	v.SetDefault(prefixer("kafka.socketKeepAliveEnabled"), true)
 	v.SetDefault(prefixer("kafka.topicMetadataRefreshInterval"), time.Minute)
 }

--- a/app/config/ingest.go
+++ b/app/config/ingest.go
@@ -168,10 +168,10 @@ func ConfigureIngestKafkaConfiguration(v *viper.Viper, prefixes ...string) {
 	v.SetDefault(prefixer("kafka.saslMechanisms"), "")
 	v.SetDefault(prefixer("kafka.saslUsername"), "")
 	v.SetDefault(prefixer("kafka.saslPassword"), "")
-	v.SetDefault(prefixer("kafka.statsInterval"), 0)
+	v.SetDefault(prefixer("kafka.statsInterval"), 15*time.Second)
 	v.SetDefault(prefixer("kafka.brokerAddressFamily"), "")
 	v.SetDefault(prefixer("kafka.socketKeepAliveEnabled"), true)
-	v.SetDefault(prefixer("kafka.topicMetadataRefreshInterval"), 0)
+	v.SetDefault(prefixer("kafka.topicMetadataRefreshInterval"), time.Minute)
 }
 
 // Configure configures some defaults in the Viper instance.


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This allows reusing the default values for services relying on the Ingest's kafka settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated Kafka-related ingest configuration defaults into a single, reusable setup to improve consistency and maintainability.
  * Streamlined the ingest configuration flow by delegating default initialization to the centralized routine.

* **Chores**
  * Updated existing ingest settings to rely on the centralized defaults without altering runtime behavior or values.

No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->