### PR TITLE
feat(subs): add config for multi-subscription

### DIFF
--- a/app/common/config.go
+++ b/app/common/config.go
@@ -38,6 +38,8 @@ var Config = wire.NewSet(
 	// Notification
 	wire.FieldsOf(new(config.Configuration), "Notification"),
 	wire.FieldsOf(new(config.NotificationConfiguration), "Webhook"),
+	// Subscription
+	wire.FieldsOf(new(config.ProductCatalogConfiguration), "Subscription"),
 	// Portal
 	wire.FieldsOf(new(config.Configuration), "Portal"),
 	// ProductCatalog

--- a/app/common/ffx.go
+++ b/app/common/ffx.go
@@ -1,0 +1,60 @@
+package common
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/google/wire"
+	"github.com/openmeterio/openmeter/app/config"
+	"github.com/openmeterio/openmeter/openmeter/namespace/namespacedriver"
+	"github.com/openmeterio/openmeter/openmeter/server"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/ffx"
+)
+
+var FFX = wire.NewSet(
+	ffx.NewContextService,
+)
+
+type FFXConfigContextMiddlewareHook server.MiddlewareHook
+
+// NewFFXConfigContextMiddlewareHook creates a middleware hook that sets the feature flag access context on the request context.
+// This hook MUST register after any session authentication step so user namespaces are available.
+func NewFFXConfigContextMiddlewareHook(
+	subsConfig config.SubscriptionConfiguration,
+	namesapceDriver namespacedriver.NamespaceDecoder,
+	logger *slog.Logger,
+) FFXConfigContextMiddlewareHook {
+	return func(m server.MiddlewareManager) {
+		accessMap := make(map[string]ffx.AccessConfig)
+		for _, ns := range subsConfig.MultiSubscriptionNamespaces {
+			acc := make(ffx.AccessConfig)
+			acc[subscription.MultiSubscriptionEnabledFF] = true
+
+			accessMap[ns] = acc
+		}
+
+		noAccess := make(ffx.AccessConfig)
+		noAccess[subscription.MultiSubscriptionEnabledFF] = false
+
+		m.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				ctx := r.Context()
+
+				// Let's try to figure out which namespace we're in
+				namespace, ok := namesapceDriver.GetNamespace(ctx)
+				if !ok {
+					logger.WarnContext(ctx, "no namespace found in request, continuing without feature flag access")
+				}
+
+				acc, ok := accessMap[namespace]
+				if !ok {
+					acc = noAccess
+				}
+
+				ctx = ffx.SetAccessOnContext(ctx, acc)
+				next.ServeHTTP(w, r.WithContext(ctx))
+			})
+		})
+	}
+}

--- a/app/common/ffx.go
+++ b/app/common/ffx.go
@@ -23,7 +23,7 @@ type FFXConfigContextMiddlewareHook server.MiddlewareHook
 // This hook MUST register after any session authentication step so user namespaces are available.
 func NewFFXConfigContextMiddlewareHook(
 	subsConfig config.SubscriptionConfiguration,
-	namesapceDriver namespacedriver.NamespaceDecoder,
+	namespaceDriver namespacedriver.NamespaceDecoder,
 	logger *slog.Logger,
 ) FFXConfigContextMiddlewareHook {
 	return func(m server.MiddlewareManager) {
@@ -43,7 +43,7 @@ func NewFFXConfigContextMiddlewareHook(
 				ctx := r.Context()
 
 				// Let's try to figure out which namespace we're in
-				namespace, ok := namesapceDriver.GetNamespace(ctx)
+				namespace, ok := namespaceDriver.GetNamespace(ctx)
 				if !ok {
 					logger.WarnContext(ctx, "no namespace found in request, continuing without feature flag access")
 				}

--- a/app/common/ffx.go
+++ b/app/common/ffx.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/google/wire"
+
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/namespace/namespacedriver"
 	"github.com/openmeterio/openmeter/openmeter/server"

--- a/app/common/namespace.go
+++ b/app/common/namespace.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/namespace"
+	"github.com/openmeterio/openmeter/openmeter/namespace/namespacedriver"
 )
 
 var Namespace = wire.NewSet(
@@ -25,4 +26,14 @@ func NewNamespaceManager(
 	}
 
 	return manager, nil
+}
+
+var StaticNamespace = wire.NewSet(
+	NewStaticNamespaceDecoder,
+)
+
+func NewStaticNamespaceDecoder(
+	conf config.NamespaceConfiguration,
+) namespacedriver.NamespaceDecoder {
+	return namespacedriver.StaticNamespaceDecoder(conf.Default)
 }

--- a/app/common/openmeter_billingworker.go
+++ b/app/common/openmeter_billingworker.go
@@ -29,6 +29,7 @@ var BillingWorker = wire.NewSet(
 	BillingWorkerSubscriber,
 
 	Lockr,
+	FFX,
 
 	Subscription,
 	ProductCatalog,

--- a/app/common/server.go
+++ b/app/common/server.go
@@ -8,15 +8,18 @@ import (
 
 var Server = wire.NewSet(
 	NewTelemetryRouterHook,
+	NewFFXConfigContextMiddlewareHook,
 	NewRouterHooks,
 )
 
 func NewRouterHooks(
 	telemetry TelemetryMiddlewareHook,
+	ffx FFXConfigContextMiddlewareHook,
 ) *server.RouterHooks {
 	return &server.RouterHooks{
 		Middlewares: []server.MiddlewareHook{
-			telemetry,
+			server.MiddlewareHook(telemetry),
+			server.MiddlewareHook(ffx),
 		},
 	}
 }

--- a/app/common/subscription.go
+++ b/app/common/subscription.go
@@ -101,6 +101,7 @@ func NewSubscriptionServices(
 		AddonService:       subAddSvc,
 		Logger:             logger.With("subsystem", "subscription.workflow.service"),
 		Lockr:              lockr,
+		FeatureFlags:       featureFlags,
 	})
 
 	planSubscriptionService := subscriptionchangeservice.New(subscriptionchangeservice.Config{

--- a/app/common/subscription.go
+++ b/app/common/subscription.go
@@ -25,6 +25,7 @@ import (
 	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
 	subscriptionworkflowservice "github.com/openmeterio/openmeter/openmeter/subscription/workflow/service"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/ffx"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
 )
 
@@ -51,6 +52,7 @@ func NewSubscriptionServices(
 	addonService addon.Service,
 	eventPublisher eventbus.Publisher,
 	lockr *lockr.Locker,
+	featureFlags ffx.Service,
 ) (SubscriptionServiceWithWorkflow, error) {
 	subscriptionRepo := subscriptionrepo.NewSubscriptionRepo(db)
 	subscriptionPhaseRepo := subscriptionrepo.NewSubscriptionPhaseRepo(db)
@@ -71,6 +73,7 @@ func NewSubscriptionServices(
 		FeatureService:        featureConnector,
 		TransactionManager:    subscriptionRepo,
 		Publisher:             eventPublisher,
+		FeatureFlags:          featureFlags,
 		Lockr:                 lockr,
 	})
 

--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -272,7 +272,7 @@ func NewTelemetryServer(conf config.TelemetryConfig, handler TelemetryHandler) (
 	return server, func() { server.Close() }
 }
 
-type TelemetryMiddlewareHook = server.MiddlewareHook
+type TelemetryMiddlewareHook server.MiddlewareHook
 
 func NewTelemetryRouterHook(meterProvider metric.MeterProvider, tracerProvider trace.TracerProvider) TelemetryMiddlewareHook {
 	return func(m server.MiddlewareManager) {

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -346,6 +346,13 @@ func TestComplete(t *testing.T) {
 				},
 			},
 		},
+		ProductCatalog: ProductCatalogConfiguration{
+			Subscription: SubscriptionConfiguration{
+				MultiSubscriptionNamespaces: []string{
+					"multi-subscription",
+				},
+			},
+		},
 		Notification: NotificationConfiguration{
 			Consumer: ConsumerConfiguration{
 				ProcessingTimeout: 30 * time.Second,

--- a/app/config/productcatalog.go
+++ b/app/config/productcatalog.go
@@ -2,11 +2,17 @@ package config
 
 import "github.com/spf13/viper"
 
-type ProductCatalogConfiguration struct{}
+type ProductCatalogConfiguration struct {
+	Subscription SubscriptionConfiguration
+}
 
 func (c ProductCatalogConfiguration) Validate() error {
 	return nil
 }
 
 func ConfigureProductCatalog(v *viper.Viper) {
+}
+
+type SubscriptionConfiguration struct {
+	MultiSubscriptionNamespaces []string
 }

--- a/app/config/testdata/complete.yaml
+++ b/app/config/testdata/complete.yaml
@@ -146,3 +146,8 @@ svix:
   apiKey: test-svix-token
   serverURL: http://127.0.0.1:8071
   debug: true
+
+productCatalog:
+  subscription:
+    multiSubscriptionNamespaces:
+      - "multi-subscription"

--- a/cmd/billing-worker/wire_gen.go
+++ b/cmd/billing-worker/wire_gen.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/watermill/driver/kafka"
 	"github.com/openmeterio/openmeter/openmeter/watermill/router"
+	"github.com/openmeterio/openmeter/pkg/ffx"
 	"log/slog"
 )
 
@@ -257,7 +258,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	subscriptionServiceWithWorkflow, err := common.NewSubscriptionServices(logger, client, featureConnector, entitlement, customerService, planService, planaddonService, addonService, eventbusPublisher, locker)
+	ffxService := ffx.NewContextService()
+	subscriptionServiceWithWorkflow, err := common.NewSubscriptionServices(logger, client, featureConnector, entitlement, customerService, planService, planaddonService, addonService, eventbusPublisher, locker, ffxService)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/cmd/jobs/internal/wire.go
+++ b/cmd/jobs/internal/wire.go
@@ -78,6 +78,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		common.Framework,
 		common.Kafka,
 		common.Meter,
+		common.FFX,
 		common.Namespace,
 		common.NewBillingAutoAdvancer,
 		common.NewBillingCollector,

--- a/cmd/jobs/internal/wire_gen.go
+++ b/cmd/jobs/internal/wire_gen.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/subject"
 	"github.com/openmeterio/openmeter/openmeter/watermill/driver/kafka"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/ffx"
 	"github.com/openmeterio/openmeter/pkg/kafka/metrics"
 	"go.opentelemetry.io/otel/metric"
 	"log/slog"
@@ -266,7 +267,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	subscriptionServiceWithWorkflow, err := common.NewSubscriptionServices(logger, client, featureConnector, entitlement, customerService, planService, planaddonService, addonService, eventbusPublisher, locker)
+	ffxService := ffx.NewContextService()
+	subscriptionServiceWithWorkflow, err := common.NewSubscriptionServices(logger, client, featureConnector, entitlement, customerService, planService, planaddonService, addonService, eventbusPublisher, locker, ffxService)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -36,6 +36,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/subject"
 	subjecthooks "github.com/openmeterio/openmeter/openmeter/subject/service/hooks"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/ffx"
 	kafkametrics "github.com/openmeterio/openmeter/pkg/kafka/metrics"
 )
 
@@ -54,6 +55,7 @@ type Application struct {
 	EventPublisher                   eventbus.Publisher
 	EntitlementRegistry              *registry.Entitlement
 	FeatureConnector                 feature.FeatureConnector
+	FeatureFlags                     ffx.Service
 	IngestCollector                  ingest.Collector
 	IngestService                    *ingest.Service
 	KafkaProducer                    *kafka.Producer
@@ -97,12 +99,14 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		common.Database,
 		common.Entitlement,
 		common.Framework,
+		common.FFX,
 		common.Kafka,
 		common.KafkaIngest,
 		common.KafkaNamespaceResolver,
 		common.MeterManageWithConfigMeters,
 		common.MeterEvent,
 		common.Namespace,
+		common.StaticNamespace,
 		common.NewDefaultTextMapPropagator,
 		common.NewKafkaIngestCollector,
 		common.NewIngestCollector,

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -261,7 +261,8 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	subscriptionServiceWithWorkflow, err := common.NewSubscriptionServices(logger, client, featureConnector, entitlement, customerService, planService, planaddonService, addonService, eventbusPublisher, locker)
+	ffxService := ffx.NewContextService()
+	subscriptionServiceWithWorkflow, err := common.NewSubscriptionServices(logger, client, featureConnector, entitlement, customerService, planService, planaddonService, addonService, eventbusPublisher, locker, ffxService)
 	if err != nil {
 		cleanup6()
 		cleanup5()
@@ -384,7 +385,6 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	ffxService := ffx.NewContextService()
 	dedupeConfiguration := conf.Dedupe
 	producer, err := common.NewKafkaProducer(kafkaIngestConfiguration, logger, commonMetadata)
 	if err != nil {

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/subject/service/hooks"
 	"github.com/openmeterio/openmeter/openmeter/watermill/driver/kafka"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
+	"github.com/openmeterio/openmeter/pkg/ffx"
 	"github.com/openmeterio/openmeter/pkg/kafka/metrics"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
@@ -383,6 +384,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
+	ffxService := ffx.NewContextService()
 	dedupeConfiguration := conf.Dedupe
 	producer, err := common.NewKafkaProducer(kafkaIngestConfiguration, logger, commonMetadata)
 	if err != nil {
@@ -522,9 +524,12 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	v6 := common.NewTelemetryRouterHook(meterProvider, tracerProvider)
-	routerHooks := common.NewRouterHooks(v6)
-	v7, err := common.NewSubjectCustomerHook(subjectService, customerService, logger, tracer)
+	telemetryMiddlewareHook := common.NewTelemetryRouterHook(meterProvider, tracerProvider)
+	subscriptionConfiguration := productCatalogConfiguration.Subscription
+	namespaceDecoder := common.NewStaticNamespaceDecoder(namespaceConfiguration)
+	ffxConfigContextMiddlewareHook := common.NewFFXConfigContextMiddlewareHook(subscriptionConfiguration, namespaceDecoder, logger)
+	routerHooks := common.NewRouterHooks(telemetryMiddlewareHook, ffxConfigContextMiddlewareHook)
+	v6, err := common.NewSubjectCustomerHook(subjectService, customerService, logger, tracer)
 	if err != nil {
 		cleanup8()
 		cleanup7()
@@ -536,7 +541,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	v8, err := common.NewSubjectEntitlementValidatorHook(logger, entitlement, subjectService)
+	v7, err := common.NewSubjectEntitlementValidatorHook(logger, entitlement, subjectService)
 	if err != nil {
 		cleanup8()
 		cleanup7()
@@ -562,7 +567,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	telemetryHandler := common.NewTelemetryHandler(metricsTelemetryConfig, health, runtimeMetricsCollector, logger)
-	v9, cleanup9 := common.NewTelemetryServer(telemetryConfig, telemetryHandler)
+	v8, cleanup9 := common.NewTelemetryServer(telemetryConfig, telemetryHandler)
 	terminationConfig := conf.Termination
 	terminationChecker, err := common.NewTerminationChecker(terminationConfig, health)
 	if err != nil {
@@ -591,6 +596,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		EventPublisher:                   eventbusPublisher,
 		EntitlementRegistry:              entitlement,
 		FeatureConnector:                 featureConnector,
+		FeatureFlags:                     ffxService,
 		IngestCollector:                  ingestCollector,
 		IngestService:                    ingestService,
 		KafkaProducer:                    producer,
@@ -610,11 +616,11 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		RouterHooks:                      routerHooks,
 		Secret:                           secretserviceService,
 		SubjectService:                   subjectService,
-		SubjectCustomerHook:              v7,
-		SubjectEntitlementValidatorHook:  v8,
+		SubjectCustomerHook:              v6,
+		SubjectEntitlementValidatorHook:  v7,
 		Subscription:                     subscriptionServiceWithWorkflow,
 		StreamingConnector:               connector,
-		TelemetryServer:                  v9,
+		TelemetryServer:                  v8,
 		TerminationChecker:               terminationChecker,
 		RuntimeMetricsCollector:          runtimeMetricsCollector,
 		Tracer:                           tracer,
@@ -649,6 +655,7 @@ type Application struct {
 	EventPublisher                   eventbus.Publisher
 	EntitlementRegistry              *registry.Entitlement
 	FeatureConnector                 feature.FeatureConnector
+	FeatureFlags                     ffx.Service
 	IngestCollector                  ingest.Collector
 	IngestService                    *ingest.Service
 	KafkaProducer                    *kafka2.Producer

--- a/openmeter/subscription/errors.go
+++ b/openmeter/subscription/errors.go
@@ -30,6 +30,8 @@ func IsErrSubscriptionBillingPeriodQueriedBeforeSubscriptionStart(err error) boo
 
 var ErrOnlySingleSubscriptionAllowed = models.NewGenericConflictError(errors.New("only single subscription is allowed per customer at a time"))
 
+var ErrRestoreSubscriptionNotAllowedForMultiSubscription = models.NewGenericForbiddenError(errors.New("restore subscription is not allowed for multi-subscription"))
+
 // TODO(galexi): "ValidationIssue" is not the right concept here. We should have a different kind of error with all this capability. It's used here as a hack to localize things for the time being.
 
 func IsValidationIssueWithCode(err error, code models.ErrorCode) bool {

--- a/openmeter/subscription/errors.go
+++ b/openmeter/subscription/errors.go
@@ -28,6 +28,8 @@ func IsErrSubscriptionBillingPeriodQueriedBeforeSubscriptionStart(err error) boo
 	return IsValidationIssueWithCode(err, ErrCodeSubscriptionBillingPeriodQueriedBeforeSubscriptionStart)
 }
 
+var ErrOnlySingleSubscriptionAllowed = models.NewGenericConflictError(errors.New("only single subscription is allowed per customer at a time"))
+
 // TODO(galexi): "ValidationIssue" is not the right concept here. We should have a different kind of error with all this capability. It's used here as a hack to localize things for the time being.
 
 func IsValidationIssueWithCode(err error, code models.ErrorCode) bool {

--- a/openmeter/subscription/featureflag.go
+++ b/openmeter/subscription/featureflag.go
@@ -1,0 +1,5 @@
+package subscription
+
+import "github.com/openmeterio/openmeter/pkg/ffx"
+
+const MultiSubscriptionEnabledFF = ffx.Feature("multi-subscription-enabled")

--- a/openmeter/subscription/service/service.go
+++ b/openmeter/subscription/service/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/ffx"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -32,6 +33,7 @@ type ServiceConfig struct {
 	TransactionManager transaction.Creator
 	Publisher          eventbus.Publisher
 	Lockr              *lockr.Locker
+	FeatureFlags       ffx.Service
 	// External validations (optional)
 	Validators []subscription.SubscriptionValidator
 }

--- a/openmeter/subscription/testutils/service.go
+++ b/openmeter/subscription/testutils/service.go
@@ -177,6 +177,10 @@ func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
 
 	planHelper := NewPlanHelper(planService)
 
+	ffService := ffx.NewTestContextService(ffx.AccessConfig{
+		subscription.MultiSubscriptionEnabledFF: false,
+	})
+
 	svc := service.New(service.ServiceConfig{
 		SubscriptionRepo:      subRepo,
 		SubscriptionPhaseRepo: subPhaseRepo,
@@ -187,9 +191,7 @@ func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
 		TransactionManager:    subItemRepo,
 		Publisher:             publisher,
 		Lockr:                 lockr,
-		FeatureFlags: ffx.NewTestContextService(ffx.AccessConfig{
-			subscription.MultiSubscriptionEnabledFF: false,
-		}),
+		FeatureFlags:          ffService,
 	})
 
 	addonRepo, err := addonrepo.New(addonrepo.Config{
@@ -242,6 +244,7 @@ func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
 		AddonService:       subAddSvc,
 		Logger:             logger.With("subsystem", "subscription.workflow.service"),
 		Lockr:              lockr,
+		FeatureFlags:       ffService,
 	})
 
 	return SubscriptionDependencies{

--- a/openmeter/subscription/testutils/service.go
+++ b/openmeter/subscription/testutils/service.go
@@ -187,8 +187,8 @@ func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
 		TransactionManager:    subItemRepo,
 		Publisher:             publisher,
 		Lockr:                 lockr,
-		FeatureFlags: ffx.NewStaticService(ffx.AccessConfig{
-			subscription.MultiSubscriptionEnabledFF: true,
+		FeatureFlags: ffx.NewTestContextService(ffx.AccessConfig{
+			subscription.MultiSubscriptionEnabledFF: false,
 		}),
 	})
 

--- a/openmeter/subscription/testutils/service.go
+++ b/openmeter/subscription/testutils/service.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/ffx"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -186,6 +187,9 @@ func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
 		TransactionManager:    subItemRepo,
 		Publisher:             publisher,
 		Lockr:                 lockr,
+		FeatureFlags: ffx.NewStaticService(ffx.AccessConfig{
+			subscription.MultiSubscriptionEnabledFF: true,
+		}),
 	})
 
 	addonRepo, err := addonrepo.New(addonrepo.Config{

--- a/openmeter/subscription/workflow/service/service.go
+++ b/openmeter/subscription/workflow/service/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	subscriptionaddon "github.com/openmeterio/openmeter/openmeter/subscription/addon"
 	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
+	"github.com/openmeterio/openmeter/pkg/ffx"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
@@ -22,6 +23,7 @@ type WorkflowServiceConfig struct {
 	TransactionManager transaction.Creator
 	Logger             *slog.Logger
 	Lockr              *lockr.Locker
+	FeatureFlags       ffx.Service
 }
 
 type service struct {

--- a/openmeter/subscription/workflow/service/subscription.go
+++ b/openmeter/subscription/workflow/service/subscription.go
@@ -215,6 +215,15 @@ func (s *service) ChangeToPlan(ctx context.Context, subscriptionID models.Namesp
 }
 
 func (s *service) Restore(ctx context.Context, subscriptionID models.NamespacedID) (subscription.Subscription, error) {
+	multiSubscriptionEnabled, err := s.FeatureFlags.IsFeatureEnabled(ctx, subscription.MultiSubscriptionEnabledFF)
+	if err != nil {
+		return subscription.Subscription{}, fmt.Errorf("failed to check if multi-subscription is enabled: %w", err)
+	}
+
+	if multiSubscriptionEnabled {
+		return subscription.Subscription{}, subscription.ErrRestoreSubscriptionNotAllowedForMultiSubscription
+	}
+
 	return transaction.Run(ctx, s.TransactionManager, func(ctx context.Context) (subscription.Subscription, error) {
 		now := clock.Now()
 

--- a/openmeter/subscription/workflow/service/subscription_test.go
+++ b/openmeter/subscription/workflow/service/subscription_test.go
@@ -1622,7 +1622,7 @@ func TestMultiSubscription(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
-			ffx.SetAccessOnContext(ctx, ffx.AccessConfig{
+			ctx = ffx.SetAccessOnContext(ctx, ffx.AccessConfig{
 				subscription.MultiSubscriptionEnabledFF: false,
 			})
 

--- a/pkg/ffx/context.go
+++ b/pkg/ffx/context.go
@@ -1,0 +1,46 @@
+package ffx
+
+import (
+	"context"
+	"fmt"
+)
+
+type contextKey string
+
+const (
+	accessContextKey contextKey = "access"
+)
+
+var ContextMissingAccessError = fmt.Errorf("access not found in context")
+
+func SetAccessOnContext(ctx context.Context, access AccessConfig) context.Context {
+	return context.WithValue(ctx, accessContextKey, access)
+}
+
+func GetAccessFromContext(ctx context.Context) (AccessConfig, error) {
+	access, ok := ctx.Value(accessContextKey).(AccessConfig)
+	if !ok {
+		return nil, ContextMissingAccessError
+	}
+	return access, nil
+}
+
+type contextService struct{}
+
+func (s *contextService) IsFeatureEnabled(ctx context.Context, feature Feature) (bool, error) {
+	access, err := GetAccessFromContext(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	acc, ok := access[feature]
+	if !ok {
+		return false, fmt.Errorf("feature %s not found in access", feature)
+	}
+
+	return acc, nil
+}
+
+func NewContextService() Service {
+	return &contextService{}
+}

--- a/pkg/ffx/featureflag.go
+++ b/pkg/ffx/featureflag.go
@@ -10,3 +10,11 @@ type Service interface {
 }
 
 type AccessConfig map[Feature]bool
+
+func (c AccessConfig) Merge(other AccessConfig) AccessConfig {
+	for feature, value := range other {
+		c[feature] = value
+	}
+
+	return c
+}

--- a/pkg/ffx/featureflag.go
+++ b/pkg/ffx/featureflag.go
@@ -1,0 +1,12 @@
+// Package ffx provides a simple feature flag service.
+package ffx
+
+import "context"
+
+type Feature string
+
+type Service interface {
+	IsFeatureEnabled(ctx context.Context, feature Feature) (bool, error)
+}
+
+type AccessConfig map[Feature]bool

--- a/pkg/ffx/static.go
+++ b/pkg/ffx/static.go
@@ -1,0 +1,27 @@
+package ffx
+
+import (
+	"context"
+	"fmt"
+)
+
+type staticService struct {
+	config AccessConfig
+}
+
+var _ Service = &staticService{}
+
+func (s *staticService) IsFeatureEnabled(ctx context.Context, feature Feature) (bool, error) {
+	acc, ok := s.config[feature]
+	if !ok {
+		return false, fmt.Errorf("feature %s not found", feature)
+	}
+
+	return acc, nil
+}
+
+func NewStaticService(config AccessConfig) Service {
+	return &staticService{
+		config: config,
+	}
+}

--- a/test/billing/subscription_suite.go
+++ b/test/billing/subscription_suite.go
@@ -125,6 +125,9 @@ func (s *SubscriptionMixin) SetupSuite(t *testing.T, deps SubscriptionMixInDepen
 
 	s.EntitlementConnector = s.SetupEntitlements(t, deps)
 
+	ffService := ffx.NewStaticService(ffx.AccessConfig{
+		subscription.MultiSubscriptionEnabledFF: true,
+	})
 	s.SubscriptionService = subscriptionservice.New(subscriptionservice.ServiceConfig{
 		SubscriptionRepo:      subsRepo,
 		SubscriptionPhaseRepo: subscriptionrepo.NewSubscriptionPhaseRepo(deps.DBClient),
@@ -141,9 +144,7 @@ func (s *SubscriptionMixin) SetupSuite(t *testing.T, deps SubscriptionMixInDepen
 		// framework
 		TransactionManager: subsRepo,
 		Lockr:              lockr,
-		FeatureFlags: ffx.NewStaticService(ffx.AccessConfig{
-			subscription.MultiSubscriptionEnabledFF: true,
-		}),
+		FeatureFlags:       ffService,
 		// events
 		Publisher: publisher,
 	})
@@ -204,6 +205,7 @@ func (s *SubscriptionMixin) SetupSuite(t *testing.T, deps SubscriptionMixInDepen
 		TransactionManager: subsRepo,
 		Logger:             slog.Default(),
 		Lockr:              lockr,
+		FeatureFlags:       ffService,
 	})
 }
 

--- a/test/billing/subscription_suite.go
+++ b/test/billing/subscription_suite.go
@@ -44,6 +44,7 @@ import (
 	subscriptionworkflowservice "github.com/openmeterio/openmeter/openmeter/subscription/workflow/service"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/ffx"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
 )
 
@@ -140,6 +141,9 @@ func (s *SubscriptionMixin) SetupSuite(t *testing.T, deps SubscriptionMixInDepen
 		// framework
 		TransactionManager: subsRepo,
 		Lockr:              lockr,
+		FeatureFlags: ffx.NewStaticService(ffx.AccessConfig{
+			subscription.MultiSubscriptionEnabledFF: true,
+		}),
 		// events
 		Publisher: publisher,
 	})


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

- Adds simple `ffx` FeatureFlag service
  - which loads in server handlers from config and ns resolution
- Disable subscription timeline validation if multi-subscripiton is enadbled
- Disable `Restore` operation if multi-subscriptions is enabled

## Notes
- `Customer.currentSubscriptionId` will map to first found subscription (not deterministic ordering)

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request, namespace-aware feature flags with middleware and a context-backed flag service; new productCatalog.subscription.multiSubscriptionNamespaces config and runtime wiring.

* **Bug Fixes / Behavior**
  * Conflicting subscription now returns a specific conflict error.
  * Restoring subscriptions blocked when multi-subscription is enabled; feature-flag checks return clear errors on failure.

* **Other**
  * Added static namespace decoder and test wiring to exercise feature-flag scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->