### PR TITLE
fix(entitlement): delete customer entitlement no response

### DIFF
--- a/openmeter/entitlement/driver/v2/customer.go
+++ b/openmeter/entitlement/driver/v2/customer.go
@@ -310,9 +310,15 @@ func (h *entitlementHandler) DeleteCustomerEntitlement() DeleteCustomerEntitleme
 				return nil, err
 			}
 
-			return nil, h.connector.DeleteEntitlement(ctx, request.Namespace, ent.ID, clock.Now())
+			err = h.connector.DeleteEntitlement(ctx, request.Namespace, ent.ID, clock.Now())
+			if err != nil {
+				return nil, err
+			}
+
+			// 204, no content
+			return nil, nil
 		},
-		commonhttp.JSONResponseEncoderWithStatus[DeleteCustomerEntitlementHandlerResponse](http.StatusNoContent),
+		commonhttp.EmptyResponseEncoder[DeleteCustomerEntitlementHandlerResponse](http.StatusNoContent),
 		httptransport.AppendOptions(
 			h.options,
 			httptransport.WithOperationName("deleteCustomerEntitlementV2"),
@@ -403,8 +409,6 @@ func (h *entitlementHandler) OverrideCustomerEntitlement() OverrideCustomerEntit
 		)...,
 	)
 }
-
-func defaultIncludeDeleted(p *bool) bool { return lo.FromPtrOr(p, false) }
 
 func (h *entitlementHandler) resolveNamespace(ctx context.Context) (string, error) {
 	ns, ok := h.namespaceDecoder.GetNamespace(ctx)

--- a/openmeter/portal/httphandler/portal.go
+++ b/openmeter/portal/httphandler/portal.go
@@ -184,9 +184,10 @@ func (h *handler) InvalidateToken() InvalidateTokenHandler {
 				return nil, fmt.Errorf("failed to invalidate token: %w", err)
 			}
 
+			// 204, no content
 			return nil, nil
 		},
-		commonhttp.JSONResponseEncoderWithStatus[InvalidateTokenResponse](http.StatusNoContent),
+		commonhttp.EmptyResponseEncoder[InvalidateTokenResponse](http.StatusNoContent),
 		httptransport.AppendOptions(
 			h.options,
 			httptransport.WithOperationName("invalidatePortalTokens"),


### PR DESCRIPTION
Fix empty response for v2 customer entitlement delete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized API behavior: successful Delete Customer Entitlement and Invalidate Token calls now return HTTP 204 with no response body for improved HTTP compliance and consistency.
  * Improved error handling on customer entitlement deletion to reliably surface failures to clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->