### PR TITLE
chore(deps): bump stripe-go-sdk to v82

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/stripe/stripe-go/v80 v80.2.1
+	github.com/stripe/stripe-go/v82 v82.5.1
 	github.com/svix/svix-webhooks v1.76.1
 	go.opentelemetry.io/contrib/bridges/otelslog v0.13.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0

--- a/go.sum
+++ b/go.sum
@@ -2002,8 +2002,6 @@ github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
-github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
-github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852 h1:Yl0tPBa8QPjGmesFh1D0rDy+q1Twx6FyU7VWHi8wZbI=
 github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852/go.mod h1:eqOVx5Vwu4gd2mmMZvVZsgIqNSaW3xxRThUJ0k/TPk4=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -2271,8 +2269,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/stripe/stripe-go/v80 v80.2.1 h1:1FQP5a/gpC4i0ezS8EPqdme3K/H9UlNWswqNHFekieY=
-github.com/stripe/stripe-go/v80 v80.2.1/go.mod h1:n7tsDvdltYlzOLGXlseMSJM6ik5uv3guptqtae/VSak=
+github.com/stripe/stripe-go/v82 v82.5.1 h1:05q6ZDKoe8PLMpQV072obF74HCgP4XJeJYoNuRSX2+8=
+github.com/stripe/stripe-go/v82 v82.5.1/go.mod h1:majCQX6AfObAvJiHraPi/5udwHi4ojRvJnnxckvHrX8=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/svix/svix-webhooks v1.76.1 h1:bavDpSPErIXTcoksO7LJucdND3d4G3SnuQwJgyBC4Jw=
@@ -2672,7 +2670,6 @@ golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLd
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210520170846-37e1c6afe023/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/openmeter/app/stripe/adapter.go
+++ b/openmeter/app/stripe/adapter.go
@@ -3,7 +3,7 @@ package appstripe
 import (
 	"context"
 
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 
 	"github.com/openmeterio/openmeter/openmeter/app/stripe/client"
 	appstripeentity "github.com/openmeterio/openmeter/openmeter/app/stripe/entity"

--- a/openmeter/app/stripe/adapter/stripe.go
+++ b/openmeter/app/stripe/adapter/stripe.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/samber/lo"
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 
 	"github.com/openmeterio/openmeter/openmeter/app"
 	appstripe "github.com/openmeterio/openmeter/openmeter/app/stripe"

--- a/openmeter/app/stripe/client/appclient.go
+++ b/openmeter/app/stripe/client/appclient.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 
 	"github.com/samber/lo"
-	"github.com/stripe/stripe-go/v80"
-	"github.com/stripe/stripe-go/v80/client"
+	"github.com/stripe/stripe-go/v82"
+	"github.com/stripe/stripe-go/v82/client"
 
 	app "github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/pkg/models"

--- a/openmeter/app/stripe/client/checkout.go
+++ b/openmeter/app/stripe/client/checkout.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/samber/lo"
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 
 	"github.com/openmeterio/openmeter/api"
 	app "github.com/openmeterio/openmeter/openmeter/app"

--- a/openmeter/app/stripe/client/client.go
+++ b/openmeter/app/stripe/client/client.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	"github.com/stripe/stripe-go/v80"
-	"github.com/stripe/stripe-go/v80/client"
+	"github.com/stripe/stripe-go/v82"
+	"github.com/stripe/stripe-go/v82/client"
 
 	app "github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/pkg/currencyx"

--- a/openmeter/app/stripe/client/customer.go
+++ b/openmeter/app/stripe/client/customer.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/samber/lo"
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 )
 
 // GetCustomer returns the stripe customer by stripe customer ID

--- a/openmeter/app/stripe/client/invoice.go
+++ b/openmeter/app/stripe/client/invoice.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/samber/lo"
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 
 	app "github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/billing"

--- a/openmeter/app/stripe/client/invoice_line.go
+++ b/openmeter/app/stripe/client/invoice_line.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/samber/lo"
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 	"golang.org/x/net/context"
 
 	"github.com/openmeterio/openmeter/pkg/slicesx"

--- a/openmeter/app/stripe/client/logger.go
+++ b/openmeter/app/stripe/client/logger.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 )
 
 // leveledLogger is a logger that implements the stripe LeveledLogger interface

--- a/openmeter/app/stripe/client/portal.go
+++ b/openmeter/app/stripe/client/portal.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/samber/lo"
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 
 	"github.com/openmeterio/openmeter/pkg/models"
 )

--- a/openmeter/app/stripe/client/stripe.go
+++ b/openmeter/app/stripe/client/stripe.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 
 	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/customer"

--- a/openmeter/app/stripe/entity/app/invoice.go
+++ b/openmeter/app/stripe/entity/app/invoice.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 
 	"github.com/openmeterio/openmeter/openmeter/app"
 	stripeclient "github.com/openmeterio/openmeter/openmeter/app/stripe/client"

--- a/openmeter/app/stripe/entity/input.go
+++ b/openmeter/app/stripe/entity/input.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 
 	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/openmeter/app"

--- a/openmeter/app/stripe/entity/portal.go
+++ b/openmeter/app/stripe/entity/portal.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 
 	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/customer"

--- a/openmeter/app/stripe/httpdriver/webhook.go
+++ b/openmeter/app/stripe/httpdriver/webhook.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/samber/lo"
-	"github.com/stripe/stripe-go/v80"
-	"github.com/stripe/stripe-go/v80/webhook"
+	"github.com/stripe/stripe-go/v82"
+	"github.com/stripe/stripe-go/v82/webhook"
 
 	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/openmeter/app"

--- a/openmeter/app/stripe/service/billing.go
+++ b/openmeter/app/stripe/service/billing.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/samber/lo"
 	"github.com/samber/mo"
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 
 	"github.com/openmeterio/openmeter/openmeter/app"
 	appstripe "github.com/openmeterio/openmeter/openmeter/app/stripe"

--- a/test/app/stripe/appstripe.go
+++ b/test/app/stripe/appstripe.go
@@ -9,7 +9,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 
 	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/openmeter/app"

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 
 	"github.com/openmeterio/openmeter/openmeter/app"
 	appstripe "github.com/openmeterio/openmeter/openmeter/app/stripe"

--- a/test/app/stripe/stripe_mock.go
+++ b/test/app/stripe/stripe_mock.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/stretchr/testify/mock"
-	"github.com/stripe/stripe-go/v80"
+	"github.com/stripe/stripe-go/v82"
 
 	stripeclient "github.com/openmeterio/openmeter/openmeter/app/stripe/client"
 )


### PR DESCRIPTION
## Overview

Bump  Stripe Go SDK to version `v82`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded the Stripe SDK used by the backend to a newer release for improved compatibility, stability, and bug fixes.
  - No user-facing feature or behavior changes; UI and functionality remain the same.
  - No action required from users or admins; deployments and usage are unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->