### PR TITLE
feat(streaming): meter query prewhere

### DIFF
--- a/.dagger/versions_pinned.go
+++ b/.dagger/versions_pinned.go
@@ -2,7 +2,7 @@ package main
 
 const (
 	kafkaVersion      = "3.6"
-	clickhouseVersion = "24.5.5.78"
+	clickhouseVersion = "24.10"
 	redisVersion      = "7.0.12"
 	postgresVersion   = "14.9"
 	svixVersion       = "v1.44"

--- a/app/common/streaming.go
+++ b/app/common/streaming.go
@@ -35,6 +35,8 @@ func NewStreamingConnector(
 		AsyncInsert:         conf.AsyncInsert,
 		AsyncInsertWait:     conf.AsyncInsertWait,
 		InsertQuerySettings: conf.InsertQuerySettings,
+		MeterQuerySettings:  conf.MeterQuerySettings,
+		EnablePrewhere:      conf.EnablePrewhere,
 		ProgressManager:     progressmanager,
 	})
 	if err != nil {

--- a/app/config/aggregation.go
+++ b/app/config/aggregation.go
@@ -28,6 +28,14 @@ type AggregationConfiguration struct {
 	// For example, you can set the `max_insert_threads` setting to control the number of threads
 	// or the `parallel_view_processing` setting to enable pushing to attached views concurrently.
 	InsertQuerySettings map[string]string
+
+	// MeterQuerySettings is the settings for the meter query
+	// For example, you can set the `enable_parallel_replicas` and `max_parallel_replicas` settings.
+	// See https://clickhouse.com/docs/en/operations/settings/settings
+	MeterQuerySettings map[string]string
+
+	// EnablePrewhere is the setting to enable prewhere for the meter query.
+	EnablePrewhere bool
 }
 
 // Validate validates the configuration.

--- a/deploy/charts/openmeter/templates/clickhouse.yaml
+++ b/deploy/charts/openmeter/templates/clickhouse.yaml
@@ -21,7 +21,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: clickhouse/clickhouse-server:23.3
+              image: clickhouse/clickhouse-server:24.10
               volumeMounts:
                 - name: data-storage-vc-template
                   mountPath: /var/lib/clickhouse

--- a/docker-compose.base.yaml
+++ b/docker-compose.base.yaml
@@ -25,7 +25,7 @@ services:
       retries: 30
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24.9-alpine
+    image: clickhouse/clickhouse-server:24.10-alpine
     environment:
       CLICKHOUSE_USER: default
       CLICKHOUSE_PASSWORD: default

--- a/examples/collectors/database/docker-compose.yaml
+++ b/examples/collectors/database/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
   clickhouse:
     profiles:
       - clickhouse
-    image: clickhouse/clickhouse-server:23.8.9.54-alpine
+    image: clickhouse/clickhouse-server:24.10-alpine
     ports:
       - 127.0.0.1:8123:8123
       - 127.0.0.1:9000:9000

--- a/openmeter/streaming/clickhouse/connector.go
+++ b/openmeter/streaming/clickhouse/connector.go
@@ -33,6 +33,8 @@ type Config struct {
 	AsyncInsert         bool
 	AsyncInsertWait     bool
 	InsertQuerySettings map[string]string
+	MeterQuerySettings  map[string]string
+	EnablePrewhere      bool
 	ProgressManager     progressmanager.Service
 	SkipCreateTables    bool
 }
@@ -154,6 +156,8 @@ func (c *Connector) QueryMeter(ctx context.Context, namespace string, meter mete
 		GroupBy:         groupBy,
 		WindowSize:      params.WindowSize,
 		WindowTimeZone:  params.WindowTimeZone,
+		QuerySettings:   c.config.MeterQuerySettings,
+		EnablePrewhere:  c.config.EnablePrewhere,
 	}
 
 	// Load cached rows if any

--- a/openmeter/streaming/clickhouse/meter_query_test.go
+++ b/openmeter/streaming/clickhouse/meter_query_test.go
@@ -21,11 +21,13 @@ func TestQueryMeter(t *testing.T) {
 	windowSize := meter.WindowSizeHour
 
 	tests := []struct {
+		name     string
 		query    queryMeter
 		wantSQL  string
 		wantArgs []interface{}
 	}{
 		{
+			name: "basic query",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -49,7 +51,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend, subject, group1, group2 ORDER BY windowstart",
 			wantArgs: []interface{}{"my_namespace", "event1", []string{"subject1"}, from.Unix(), to.Unix()},
 		},
-		{ // Aggregate all available data
+		{
+			name: "Aggregate all available data",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -68,7 +71,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
-		{ // Aggregate with count aggregation
+		{
+			name: "Aggregate with count aggregation",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -86,7 +90,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, toFloat64(count(*)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
-		{ // Aggregate with LATEST aggregation
+		{
+			name: "Aggregate with LATEST aggregation",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -105,7 +110,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, argMax(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null), om_events.time) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
-		{ // Aggregate data from start
+		{
+			name: "Aggregate data from start",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -125,7 +131,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ?",
 			wantArgs: []interface{}{"my_namespace", "event1", from.Unix()},
 		},
-		{ // Aggregate data between period
+		{
+			name: "Aggregate data between period",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -146,7 +153,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ?",
 			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
 		},
-		{ // Aggregate data between period, groupped by window size
+		{
+			name: "Aggregate data between period, groupped by window size",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -168,7 +176,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend ORDER BY windowstart",
 			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
 		},
-		{ // Aggregate data between period in a different timezone, groupped by window size
+		{
+			name: "Aggregate data between period in a different timezone, groupped by window size",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -191,7 +200,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowstart, tumbleEnd(om_events.time, toIntervalHour(1), 'Asia/Shanghai') AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? GROUP BY windowstart, windowend ORDER BY windowstart",
 			wantArgs: []interface{}{"my_namespace", "event1", from.Unix(), to.Unix()},
 		},
-		{ // Aggregate data for a single subject
+		{
+			name: "Aggregate data for a single subject",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -212,7 +222,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) GROUP BY subject",
 			wantArgs: []interface{}{"my_namespace", "event1", []string{"subject1"}},
 		},
-		{ // Aggregate data for a single subject and group by additional fields
+		{
+			name: "Aggregate data for a single subject and group by additional fields",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -233,7 +244,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value, om_events.subject, JSON_VALUE(om_events.data, '$.group1') as group1, JSON_VALUE(om_events.data, '$.group2') as group2 FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) GROUP BY subject, group1, group2",
 			wantArgs: []interface{}{"my_namespace", "event1", []string{"subject1"}},
 		},
-		{ // Aggregate data for a multiple subjects
+		{
+			name: "Aggregate data for a multiple subjects",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -254,7 +266,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value, om_events.subject FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) GROUP BY subject",
 			wantArgs: []interface{}{"my_namespace", "event1", []string{"subject1", "subject2"}},
 		},
-		{ // Select customer ID
+		{
+			name: "Select customer ID",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -294,7 +307,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "WITH map('subject1', 'customer1', 'subject2', 'customer2') as subject_to_customer_id SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value, subject_to_customer_id[om_events.subject] AS customer_id FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) GROUP BY customer_id",
 			wantArgs: []interface{}{"my_namespace", "event1", []string{"subject1", "subject2"}},
 		},
-		{ // Filter by customer ID without group by
+		{
+			name: "Filter by customer ID without group by",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -333,7 +347,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?)",
 			wantArgs: []interface{}{"my_namespace", "event1", []string{"subject1", "subject2"}},
 		},
-		{ // Filter by both customer and subject
+		{
+			name: "Filter by both customer and subject",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -363,7 +378,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "WITH map('subject1', 'customer1', 'subject2', 'customer1') as subject_to_customer_id SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value, subject_to_customer_id[om_events.subject] AS customer_id FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) AND om_events.subject IN (?) GROUP BY customer_id",
 			wantArgs: []interface{}{"my_namespace", "event1", []string{"subject1", "subject2"}, []string{"subject1"}},
 		},
-		{ // Aggregate data with filtering for a single group and single value
+		{
+			name: "Aggregate data with filtering for a single group and single value",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -383,7 +399,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1')",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
-		{ // Aggregate data with filtering for a single group and multiple values
+		{
+			name: "Aggregate data with filtering for a single group and multiple values",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -403,7 +420,8 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2')",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
-		{ // Aggregate data with filtering for multiple groups and multiple values
+		{
+			name: "Aggregate data with filtering for multiple groups and multiple values",
 			query: queryMeter{
 				Database:        "openmeter",
 				EventsTableName: "om_events",
@@ -423,10 +441,70 @@ func TestQueryMeter(t *testing.T) {
 			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? AND (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2') AND (JSON_VALUE(om_events.data, '$.group2') = 'g2v1' OR JSON_VALUE(om_events.data, '$.group2') = 'g2v2')",
 			wantArgs: []interface{}{"my_namespace", "event1"},
 		},
+		{
+			name: "Aggregate all available data, prewhere enabled (should not move anything to prewhere)",
+			query: queryMeter{
+				Database:        "openmeter",
+				EventsTableName: "om_events",
+				Namespace:       "my_namespace",
+				Meter: meter.Meter{
+					Key:           "meter1",
+					EventType:     "event1",
+					Aggregation:   meter.MeterAggregationSum,
+					ValueProperty: lo.ToPtr("$.value"),
+					GroupBy: map[string]string{
+						"group1": "$.group1",
+						"group2": "$.group2",
+					},
+				},
+				EnablePrewhere: true,
+			},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ?",
+			wantArgs: []interface{}{"my_namespace", "event1"},
+		},
+		{
+			name: "Aggregate data with with filtering for multiple groups and multiple values prewhere enabled",
+			query: queryMeter{
+				Database:        "openmeter",
+				EventsTableName: "om_events",
+				Namespace:       "my_namespace",
+				EnablePrewhere:  true,
+				Meter: meter.Meter{
+					Key:           "meter1",
+					EventType:     "event1",
+					Aggregation:   meter.MeterAggregationSum,
+					ValueProperty: lo.ToPtr("$.value"),
+					GroupBy: map[string]string{
+						"g1": "$.group1",
+						"g2": "$.group2",
+					},
+				},
+				FilterGroupBy: map[string][]string{"g1": {"g1v1", "g1v2"}, "g2": {"g2v1", "g2v2"}},
+			},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events PREWHERE om_events.namespace = ? AND om_events.type = ? WHERE (JSON_VALUE(om_events.data, '$.group1') = 'g1v1' OR JSON_VALUE(om_events.data, '$.group1') = 'g1v2') AND (JSON_VALUE(om_events.data, '$.group2') = 'g2v1' OR JSON_VALUE(om_events.data, '$.group2') = 'g2v2') SETTINGS optimize_move_to_prewhere = 1, allow_reorder_prewhere_conditions = 1",
+			wantArgs: []interface{}{"my_namespace", "event1"},
+		},
+		{
+			name: "Add query settings",
+			query: queryMeter{
+				Database:        "openmeter",
+				EventsTableName: "om_events",
+				Namespace:       "my_namespace",
+				Meter: meter.Meter{
+					Key:           "meter1",
+					EventType:     "event1",
+					Aggregation:   meter.MeterAggregationSum,
+					ValueProperty: lo.ToPtr("$.value"),
+				},
+				QuerySettings: map[string]string{"foo": "1"},
+			},
+			wantSQL:  "SELECT tumbleStart(min(om_events.time), toIntervalMinute(1)) AS windowstart, tumbleEnd(max(om_events.time), toIntervalMinute(1)) AS windowend, sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value FROM openmeter.om_events WHERE om_events.namespace = ? AND om_events.type = ? SETTINGS foo = 1",
+			wantArgs: []interface{}{"my_namespace", "event1"},
+		},
 	}
 
 	for _, tt := range tests {
-		t.Run("", func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			gotSql, gotArgs, err := tt.query.toSQL()
 			if err != nil {
 				t.Error(err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added configurable ClickHouse meter query settings.
  - Added optional PREWHERE optimization for meter queries to improve query performance.
- Chores
  - Upgraded ClickHouse to 24.10 across pinned versions, Helm chart, Docker Compose, and example collector setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->