### PR TITLE
fix(app): stripe portal session stripe custome not found

### DIFF
--- a/openmeter/app/stripe/client/portal.go
+++ b/openmeter/app/stripe/client/portal.go
@@ -80,6 +80,11 @@ func (c *stripeAppClient) CreatePortalSession(ctx context.Context, input CreateP
 		Locale:        input.Locale,
 	})
 	if err != nil {
+		// Stripe customer not found error
+		if stripeErr, ok := err.(*stripe.Error); ok && stripeErr.Code == stripe.ErrorCodeResourceMissing {
+			return PortalSession{}, NewStripeCustomerNotFoundError(input.StripeCustomerID)
+		}
+
 		return PortalSession{}, c.providerError(err)
 	}
 


### PR DESCRIPTION
Return a not found error when stripe customer not found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing portal session creation error handling. If the linked Stripe customer is missing, users now receive a clear “customer not found” message instead of a generic provider error.
  * Reduces confusion and speeds up troubleshooting when accounts are misconfigured.
  * No changes to existing workflows; only the error messaging and outcome in this edge case are improved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->