### PR TITLE
fix: store metadata in metadata

### DIFF
--- a/openmeter/entitlement/driver/metered.go
+++ b/openmeter/entitlement/driver/metered.go
@@ -113,7 +113,7 @@ func (h *meteredEntitlementHandler) CreateGrant() CreateGrantHandler {
 			}
 
 			if apiGrant.Metadata != nil {
-				req.GrantInput.Annotations = AnnotationsFromMetadata(lo.FromPtr(apiGrant.Metadata))
+				req.GrantInput.Metadata = lo.FromPtr(apiGrant.Metadata)
 			}
 
 			if apiGrant.Recurrence != nil {
@@ -446,34 +446,4 @@ func MapEntitlementGrantToAPI(grant *meteredentitlement.EntitlementGrant) api.En
 	}
 
 	return apiGrant
-}
-
-func MetadataFromAnnotations(annotations models.Annotations) *api.Metadata {
-	if len(annotations) == 0 {
-		return nil
-	}
-
-	result := make(api.Metadata)
-	if len(annotations) > 0 {
-		for k, v := range annotations {
-			result[k] = fmt.Sprintf("%v", v)
-		}
-	}
-
-	return &result
-}
-
-func AnnotationsFromMetadata(metadata api.Metadata) models.Annotations {
-	if len(metadata) == 0 {
-		return nil
-	}
-
-	result := make(models.Annotations)
-	if len(metadata) > 0 {
-		for k, v := range metadata {
-			result[k] = v
-		}
-	}
-
-	return result
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

As of https://github.com/openmeterio/openmeter/pull/3434 we've been storing the `metadata` input of the V1 API incorrectly as annotations.

```sql
-- RUN AT YOUR OWN RISK
-- copies incorrectly stored records from annotations to metadata

BEGIN;

CREATE OR REPLACE FUNCTION pg_temp.jsonb_convert_values_to_strings(input_jsonb jsonb)
RETURNS jsonb
LANGUAGE plpgsql
IMMUTABLE STRICT
AS $$
DECLARE
    key_value_pair RECORD;
    result_jsonb jsonb := '{}'::jsonb;
    string_value text;
BEGIN
    IF jsonb_typeof(input_jsonb) != 'object' THEN
        RETURN input_jsonb;
    END IF;

    FOR key_value_pair IN SELECT * FROM jsonb_each(input_jsonb)
    LOOP
        -- JSON only has 4 primitive types: string, number, boolean, null
        CASE jsonb_typeof(key_value_pair.value)
            WHEN 'string' THEN
                string_value := key_value_pair.value #>> '{}';

            WHEN 'number' THEN
                string_value := key_value_pair.value #>> '{}';

            WHEN 'boolean' THEN
                string_value := CASE
                    WHEN (key_value_pair.value)::boolean THEN 'true'
                    ELSE 'false'
                END;

            WHEN 'null' THEN
                string_value := '';

            -- array and object
            ELSE
                string_value := key_value_pair.value #>> '{}';
        END CASE;

        result_jsonb := jsonb_set(result_jsonb, ARRAY[key_value_pair.key], to_jsonb(string_value));
    END LOOP;

    RETURN result_jsonb;
END;
$$;

SAVEPOINT functions;

UPDATE grants
    -- this conversion is for parsing safety, due to API typings
    SET metadata = pg_temp.jsonb_convert_values_to_strings(annotations)
WHERE 
    -- First, let's make sure there's nothing important we could be overwriting
    (jsonb_typeof(metadata) = 'null' OR metadata IS NULL)
AND jsonb_typeof(annotations) != 'null' -- we have something to write
AND 
    -- filter for safety, THE DATES ARE EXAMPLES
    (namespace = 'replace_me' 
    AND created_at > '2025-09-28 18:10:26.291821+00'::TIMESTAMP 
    AND created_At < '2025-09-29 18:10:26.291821+00'::TIMESTAMP);
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures grant metadata is preserved and applied consistently when creating metered entitlements, preventing unexpected key drops or transformations.

* **Refactor**
  * Simplified metadata handling by passing metadata directly, removing internal conversion logic to reduce complexity and potential mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->