### PR TITLE
chore: revert min tls for sarama

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -6,3 +6,4 @@ api/client/python/src/openmeter/_serialization.py
 openmeter/billing/service/seq.go
 collector/benthos/input/otel_log.go
 openmeter/productcatalog/feature/connector.go
+openmeter/watermill/driver/kafka/broker.go

--- a/openmeter/watermill/driver/kafka/broker.go
+++ b/openmeter/watermill/driver/kafka/broker.go
@@ -80,9 +80,9 @@ func (o *BrokerOptions) createKafkaConfig(role string) (*sarama.Config, error) {
 		config.Net.SASL.Handshake = true
 
 		config.Net.TLS.Enable = true
-		config.Net.TLS.Config = &tls.Config{
-			MinVersion: tls.VersionTLS13,
-		}
+		// Sarama has issues with min version TLS 1.3, so let's use the defaults for now
+		// remote error: tls: protocol version not supported
+		config.Net.TLS.Config = &tls.Config{} // nosemgrep
 
 		config.Net.SASL.User = o.KafkaConfig.SaslUsername
 		config.Net.SASL.Password = o.KafkaConfig.SaslPassword


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

fixes:
`failed to initialize event publisher: cannot create Kafka producer: kafka: client has run out of available brokers to talk to: remote error: tls: protocol version not supported`

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated Kafka SASL_SSL TLS behavior to rely on default system settings rather than explicitly enforcing TLS 1.3. This may affect compatibility with brokers using different TLS versions.

- Chores
  - Expanded static analysis ignores to exclude an additional path from Semgrep checks.

- Notes
  - No other functional changes or UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->