### PR TITLE
fix: grant creation mapping

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -956,6 +956,9 @@ func TestCredit(t *testing.T) {
 				Anchor:   convert.ToPointer(time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)),
 				Interval: *apiYEAR,
 			},
+			Metadata: &api.Metadata{
+				"some_key": "some_value",
+			},
 		})
 		require.NoError(t, err)
 		require.Equal(t, http.StatusCreated, resp.StatusCode(), "Invalid status code [response_body=%s]", resp.Body)
@@ -981,6 +984,9 @@ func TestCredit(t *testing.T) {
 				Anchor:      time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC),
 				Interval:    *apiYEAR,
 				IntervalISO: "P1Y",
+			},
+			Metadata: &api.Metadata{
+				"some_key": "some_value",
 			},
 		}
 

--- a/openmeter/entitlement/metered/entitlement_grant.go
+++ b/openmeter/entitlement/metered/entitlement_grant.go
@@ -77,6 +77,7 @@ func (e *connector) CreateGrant(ctx context.Context, namespace string, customerI
 		ResetMinRollover: inputGrant.ResetMinRollover,
 		Recurrence:       inputGrant.Recurrence,
 		Annotations:      inputGrant.Annotations,
+		Metadata:         inputGrant.Metadata,
 	})
 	if err != nil {
 		if _, ok := err.(grant.OwnerNotFoundError); ok {


### PR DESCRIPTION
Adds e2e tests to assert this works as expected and adds a missing mapping.

<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added metadata support when creating entitlement grants.
  - Metadata is now returned when retrieving entitlement grants.
  - Improved propagation of metadata throughout grant creation for more complete records.

- Tests
  - Added end-to-end validation ensuring annotations created via the newer API are readable via the legacy API, confirming cross-version parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->