### PR TITLE
feat(subs): unique constraints

### DIFF
--- a/openmeter/entitlement/entitlement.go
+++ b/openmeter/entitlement/entitlement.go
@@ -302,6 +302,15 @@ func (e Entitlement) GetType() EntitlementType {
 	return e.EntitlementType
 }
 
+var _ models.CadenceComparable = Entitlement{}
+
+func (e Entitlement) GetCadence() models.CadencedModel {
+	return models.CadencedModel{
+		ActiveFrom: e.ActiveFromTime(),
+		ActiveTo:   e.ActiveToTime(),
+	}
+}
+
 type EntitlementType string
 
 const (

--- a/openmeter/subscription/addon/diff/apply_test.go
+++ b/openmeter/subscription/addon/diff/apply_test.go
@@ -282,7 +282,7 @@ func TestApply(t *testing.T) {
 			env := buildSubAndAddon(
 				t,
 				&deps.deps,
-				subscriptiontestutils.BuildTestPlan(t).
+				subscriptiontestutils.BuildTestPlanInput(t).
 					AddPhase(nil, &subscriptiontestutils.ExampleRateCard5ForAddons).
 					Build(),
 				subscriptiontestutils.BuildAddonForTesting(t, productcatalog.EffectivePeriod{
@@ -315,7 +315,7 @@ func TestApply(t *testing.T) {
 			env := buildSubAndAddon(
 				t,
 				&deps.deps,
-				subscriptiontestutils.BuildTestPlan(t).
+				subscriptiontestutils.BuildTestPlanInput(t).
 					AddPhase(nil, &subscriptiontestutils.ExampleRateCard4ForAddons).
 					Build(),
 				subscriptiontestutils.BuildAddonForTesting(t, productcatalog.EffectivePeriod{
@@ -351,7 +351,7 @@ func TestApply(t *testing.T) {
 			env := buildSubAndAddon(
 				t,
 				&deps.deps,
-				subscriptiontestutils.BuildTestPlan(t).
+				subscriptiontestutils.BuildTestPlanInput(t).
 					AddPhase(nil, &subscriptiontestutils.ExampleRateCard2).
 					Build(),
 				subscriptiontestutils.BuildAddonForTesting(t, productcatalog.EffectivePeriod{
@@ -389,7 +389,7 @@ func TestApply(t *testing.T) {
 			p, a := subscriptiontestutils.CreatePlanWithAddon(
 				t,
 				deps.deps,
-				subscriptiontestutils.BuildTestPlan(t).
+				subscriptiontestutils.BuildTestPlanInput(t).
 					AddPhase(lo.ToPtr(datetime.MustParseDuration(t, "P1M")), subscriptiontestutils.ExampleRateCard3ForAddons.Clone()).
 					AddPhase(nil, subscriptiontestutils.ExampleRateCard3ForAddons.Clone()).
 					Build(),
@@ -445,7 +445,7 @@ func TestApply(t *testing.T) {
 			p, a := subscriptiontestutils.CreatePlanWithAddon(
 				t,
 				deps.deps,
-				subscriptiontestutils.BuildTestPlan(t).
+				subscriptiontestutils.BuildTestPlanInput(t).
 					AddPhase(lo.ToPtr(datetime.MustParseDuration(t, "P1M")), subscriptiontestutils.ExampleRateCard3ForAddons.Clone()).
 					AddPhase(nil, subscriptiontestutils.ExampleRateCard3ForAddons.Clone()).
 					Build(),
@@ -511,7 +511,7 @@ func TestApply(t *testing.T) {
 			p, a := subscriptiontestutils.CreatePlanWithAddon(
 				t,
 				deps.deps,
-				subscriptiontestutils.BuildTestPlan(t).
+				subscriptiontestutils.BuildTestPlanInput(t).
 					AddPhase(lo.ToPtr(datetime.MustParseDuration(t, "P1M")), subscriptiontestutils.ExampleRateCard3ForAddons.Clone()).
 					AddPhase(nil, subscriptiontestutils.ExampleRateCard3ForAddons.Clone()).
 					Build(),
@@ -622,7 +622,7 @@ func TestApply(t *testing.T) {
 			p, a := subscriptiontestutils.CreatePlanWithAddon(
 				t,
 				deps.deps,
-				subscriptiontestutils.BuildTestPlan(t).
+				subscriptiontestutils.BuildTestPlanInput(t).
 					AddPhase(nil, subscriptiontestutils.ExampleRateCard3ForAddons.Clone()).
 					Build(),
 				subscriptiontestutils.BuildAddonForTesting(t,
@@ -730,7 +730,7 @@ func TestApply(t *testing.T) {
 			pl, a := subscriptiontestutils.CreatePlanWithAddon(
 				t,
 				deps.deps,
-				subscriptiontestutils.BuildTestPlan(t).
+				subscriptiontestutils.BuildTestPlanInput(t).
 					AddPhase(nil, subscriptiontestutils.ExampleRateCard3ForAddons.Clone()).
 					Build(),
 				subscriptiontestutils.BuildAddonForTesting(t,
@@ -826,7 +826,7 @@ func TestApplyWithMultiInstance(t *testing.T) {
 			pl, a := subscriptiontestutils.CreatePlanWithAddon(
 				t,
 				deps.deps,
-				subscriptiontestutils.BuildTestPlan(t).
+				subscriptiontestutils.BuildTestPlanInput(t).
 					AddPhase(nil, subscriptiontestutils.ExampleRateCard3ForAddons.Clone()).
 					Build(),
 				subscriptiontestutils.BuildAddonForTesting(t,

--- a/openmeter/subscription/addon/diff/restore_test.go
+++ b/openmeter/subscription/addon/diff/restore_test.go
@@ -48,7 +48,7 @@ func TestRestore(t *testing.T) {
 		env := buildSubAndAddon(
 			t,
 			&deps.deps,
-			subscriptiontestutils.BuildTestPlan(t).AddPhase(nil, &subscriptiontestutils.ExampleRateCard2).Build(),
+			subscriptiontestutils.BuildTestPlanInput(t).AddPhase(nil, &subscriptiontestutils.ExampleRateCard2).Build(),
 			subscriptiontestutils.BuildAddonForTesting(t, productcatalog.EffectivePeriod{
 				EffectiveFrom: &now,
 			}, productcatalog.AddonInstanceTypeSingle, &subscriptiontestutils.ExampleAddonRateCard1),
@@ -77,7 +77,7 @@ func TestRestore(t *testing.T) {
 		env := buildSubAndAddon(
 			t,
 			&deps.deps,
-			subscriptiontestutils.BuildTestPlan(t).AddPhase(nil, &subscriptiontestutils.ExampleRateCard2).Build(),
+			subscriptiontestutils.BuildTestPlanInput(t).AddPhase(nil, &subscriptiontestutils.ExampleRateCard2).Build(),
 			subscriptiontestutils.BuildAddonForTesting(t, productcatalog.EffectivePeriod{
 				EffectiveFrom: &now,
 			}, productcatalog.AddonInstanceTypeSingle, &subscriptiontestutils.ExampleAddonRateCard1),
@@ -109,7 +109,7 @@ func TestRestore(t *testing.T) {
 		env := buildSubAndAddon(
 			t,
 			&deps.deps,
-			subscriptiontestutils.BuildTestPlan(t).AddPhase(nil, &subscriptiontestutils.ExampleRateCard1, &subscriptiontestutils.ExampleRateCard2).Build(),
+			subscriptiontestutils.BuildTestPlanInput(t).AddPhase(nil, &subscriptiontestutils.ExampleRateCard1, &subscriptiontestutils.ExampleRateCard2).Build(),
 			subscriptiontestutils.BuildAddonForTesting(t, productcatalog.EffectivePeriod{
 				EffectiveFrom: &now,
 			}, productcatalog.AddonInstanceTypeSingle, &subscriptiontestutils.ExampleAddonRateCard1),
@@ -145,7 +145,7 @@ func TestRestore(t *testing.T) {
 		env := buildSubAndAddon(
 			t,
 			&deps.deps,
-			subscriptiontestutils.BuildTestPlan(t).
+			subscriptiontestutils.BuildTestPlanInput(t).
 				AddPhase(&oneMonth, &subscriptiontestutils.ExampleRateCard1, &subscriptiontestutils.ExampleRateCard2).
 				AddPhase(nil, &subscriptiontestutils.ExampleRateCard2).
 				Build(),
@@ -176,7 +176,7 @@ func TestRestore(t *testing.T) {
 		env := buildSubAndAddon(
 			t,
 			&deps.deps,
-			subscriptiontestutils.BuildTestPlan(t).
+			subscriptiontestutils.BuildTestPlanInput(t).
 				AddPhase(nil, &subscriptiontestutils.ExampleRateCard1).
 				Build(),
 			subscriptiontestutils.BuildAddonForTesting(t, productcatalog.EffectivePeriod{
@@ -208,7 +208,7 @@ func TestRestore(t *testing.T) {
 		env := buildSubAndAddon(
 			t,
 			&deps.deps,
-			subscriptiontestutils.BuildTestPlan(t).
+			subscriptiontestutils.BuildTestPlanInput(t).
 				AddPhase(nil, &subscriptiontestutils.ExampleRateCard1).
 				Build(),
 			subscriptiontestutils.BuildAddonForTesting(t, productcatalog.EffectivePeriod{
@@ -248,7 +248,7 @@ func TestRestore(t *testing.T) {
 		env := buildSubAndAddon(
 			t,
 			&deps.deps,
-			subscriptiontestutils.BuildTestPlan(t).
+			subscriptiontestutils.BuildTestPlanInput(t).
 				AddPhase(nil, &subscriptiontestutils.ExampleRateCard1).
 				Build(),
 			subscriptiontestutils.BuildAddonForTesting(t, productcatalog.EffectivePeriod{
@@ -305,7 +305,7 @@ func TestRestore(t *testing.T) {
 		env := buildSubAndAddon(
 			t,
 			&deps.deps,
-			subscriptiontestutils.BuildTestPlan(t).
+			subscriptiontestutils.BuildTestPlanInput(t).
 				AddPhase(nil, &subscriptiontestutils.ExampleRateCard1).
 				Build(),
 			subscriptiontestutils.BuildAddonForTesting(t, productcatalog.EffectivePeriod{
@@ -341,7 +341,7 @@ func TestRestore(t *testing.T) {
 		p, a := subscriptiontestutils.CreatePlanWithAddon(
 			t,
 			deps.deps,
-			subscriptiontestutils.BuildTestPlan(t).
+			subscriptiontestutils.BuildTestPlanInput(t).
 				SetMeta(productcatalog.PlanMeta{
 					Name:           "Test Plan",
 					Key:            "test_plan",
@@ -432,7 +432,7 @@ func TestRestore(t *testing.T) {
 			env := buildSubAndAddon(
 				t,
 				&deps.deps,
-				subscriptiontestutils.BuildTestPlan(t).
+				subscriptiontestutils.BuildTestPlanInput(t).
 					AddPhase(nil, &subscriptiontestutils.ExampleRateCard4ForAddons).
 					Build(),
 				subscriptiontestutils.BuildAddonForTesting(t, productcatalog.EffectivePeriod{
@@ -468,7 +468,7 @@ func TestRestore(t *testing.T) {
 			env := buildSubAndAddon(
 				t,
 				&deps.deps,
-				subscriptiontestutils.BuildTestPlan(t).
+				subscriptiontestutils.BuildTestPlanInput(t).
 					AddPhase(nil, &subscriptiontestutils.ExampleRateCard5ForAddons).
 					Build(),
 				subscriptiontestutils.BuildAddonForTesting(t, productcatalog.EffectivePeriod{
@@ -505,7 +505,7 @@ func TestRestore(t *testing.T) {
 		env := buildSubAndMultiInstanceAddon(
 			t,
 			&deps.deps,
-			subscriptiontestutils.BuildTestPlan(t).
+			subscriptiontestutils.BuildTestPlanInput(t).
 				AddPhase(nil, &subscriptiontestutils.ExampleRateCard1).
 				Build(),
 			subscriptiontestutils.BuildAddonForTesting(t, productcatalog.EffectivePeriod{
@@ -564,7 +564,7 @@ func TestRestore(t *testing.T) {
 		p, add := subscriptiontestutils.CreatePlanWithAddon(
 			t,
 			deps.deps,
-			subscriptiontestutils.BuildTestPlan(t).
+			subscriptiontestutils.BuildTestPlanInput(t).
 				AddPhase(nil,
 					&subscriptiontestutils.ExampleRateCard1, // Flat price
 					&productcatalog.UsageBasedRateCard{ // Dynamic price

--- a/openmeter/subscription/errors.go
+++ b/openmeter/subscription/errors.go
@@ -40,11 +40,11 @@ var ErrOnlySingleSubscriptionAllowed = models.NewValidationIssue(
 
 var ErrRestoreSubscriptionNotAllowedForMultiSubscription = models.NewGenericForbiddenError(errors.New("restore subscription is not allowed for multi-subscription"))
 
-const ErrCodeOnlySingleBillableItemAllowedAtATime models.ErrorCode = "only_single_billable_item_allowed_at_a_time"
+const ErrCodeOnlySingleSubscriptionItemAllowedAtATime models.ErrorCode = "only_single_subscription_item_allowed_at_a_time"
 
-var ErrOnlySingleBillableItemAllowedAtATime = models.NewValidationIssue(
-	ErrCodeOnlySingleBillableItemAllowedAtATime,
-	"only single billable item is allowed at a time",
+var ErrOnlySingleSubscriptionItemAllowedAtATime = models.NewValidationIssue(
+	ErrCodeOnlySingleSubscriptionItemAllowedAtATime,
+	"for any given feature, only one subscription item with entitlements or billable prices can exist at a time",
 	commonhttp.WithHTTPStatusCodeAttribute(http.StatusConflict),
 )
 

--- a/openmeter/subscription/errors.go
+++ b/openmeter/subscription/errors.go
@@ -28,7 +28,13 @@ func IsErrSubscriptionBillingPeriodQueriedBeforeSubscriptionStart(err error) boo
 	return IsValidationIssueWithCode(err, ErrCodeSubscriptionBillingPeriodQueriedBeforeSubscriptionStart)
 }
 
-var ErrOnlySingleSubscriptionAllowed = models.NewGenericConflictError(errors.New("only single subscription is allowed per customer at a time"))
+const ErrCodeOnlySingleSubscriptionAllowed models.ErrorCode = "only_single_subscription_allowed_per_customer_at_a_time"
+
+// FIXME(galexi): This should be a conflict error by type, not a validation issue, but until attributes are implemented for other errors we'll use this workaround
+var ErrOnlySingleSubscriptionAllowed = models.NewValidationIssue(
+	ErrCodeOnlySingleSubscriptionAllowed,
+	"only single subscription is allowed per customer at a time",
+)
 
 var ErrRestoreSubscriptionNotAllowedForMultiSubscription = models.NewGenericForbiddenError(errors.New("restore subscription is not allowed for multi-subscription"))
 

--- a/openmeter/subscription/errors.go
+++ b/openmeter/subscription/errors.go
@@ -3,8 +3,10 @@ package subscription
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
+	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -30,13 +32,21 @@ func IsErrSubscriptionBillingPeriodQueriedBeforeSubscriptionStart(err error) boo
 
 const ErrCodeOnlySingleSubscriptionAllowed models.ErrorCode = "only_single_subscription_allowed_per_customer_at_a_time"
 
-// FIXME(galexi): This should be a conflict error by type, not a validation issue, but until attributes are implemented for other errors we'll use this workaround
 var ErrOnlySingleSubscriptionAllowed = models.NewValidationIssue(
 	ErrCodeOnlySingleSubscriptionAllowed,
 	"only single subscription is allowed per customer at a time",
+	commonhttp.WithHTTPStatusCodeAttribute(http.StatusConflict),
 )
 
 var ErrRestoreSubscriptionNotAllowedForMultiSubscription = models.NewGenericForbiddenError(errors.New("restore subscription is not allowed for multi-subscription"))
+
+const ErrCodeOnlySingleBillableItemAllowedAtATime models.ErrorCode = "only_single_billable_item_allowed_at_a_time"
+
+var ErrOnlySingleBillableItemAllowedAtATime = models.NewValidationIssue(
+	ErrCodeOnlySingleBillableItemAllowedAtATime,
+	"only single billable item is allowed at a time",
+	commonhttp.WithHTTPStatusCodeAttribute(http.StatusConflict),
+)
 
 // TODO(galexi): "ValidationIssue" is not the right concept here. We should have a different kind of error with all this capability. It's used here as a hack to localize things for the time being.
 

--- a/openmeter/subscription/plan.go
+++ b/openmeter/subscription/plan.go
@@ -14,6 +14,10 @@ type PlanRef struct {
 	Version int    `json:"version"`
 }
 
+func (p PlanRef) GetPath() SpecPath {
+	return SpecPath(fmt.Sprintf("%s/%d", p.Key, p.Version))
+}
+
 func (p PlanRef) Equal(p2 PlanRef) bool {
 	if p.Id != p2.Id {
 		return false

--- a/openmeter/subscription/service/service_test.go
+++ b/openmeter/subscription/service/service_test.go
@@ -444,6 +444,9 @@ func TestContinuing(t *testing.T) {
 		// Fourth, let's continue the first subscription
 		_, err = service.Continue(ctx, sub1.NamespacedID)
 		require.Error(t, err)
-		require.ErrorAs(t, err, lo.ToPtr(&models.GenericConflictError{}))
+		issues, err := models.AsValidationIssues(err)
+		require.NoError(t, err)
+		require.Len(t, issues, 1)
+		require.Equal(t, subscription.ErrOnlySingleSubscriptionAllowed.Code(), issues[0].Code())
 	})
 }

--- a/openmeter/subscription/service/service_test.go
+++ b/openmeter/subscription/service/service_test.go
@@ -446,7 +446,9 @@ func TestContinuing(t *testing.T) {
 		require.Error(t, err)
 		issues, err := models.AsValidationIssues(err)
 		require.NoError(t, err)
-		require.Len(t, issues, 1)
-		require.Equal(t, subscription.ErrOnlySingleSubscriptionAllowed.Code(), issues[0].Code())
+		require.Len(t, issues, 2)
+		for _, issue := range issues {
+			require.Equal(t, subscription.ErrOnlySingleSubscriptionAllowed.Code(), issue.Code())
+		}
 	})
 }

--- a/openmeter/subscription/subscriptionspec.go
+++ b/openmeter/subscription/subscriptionspec.go
@@ -354,6 +354,15 @@ func (s *SubscriptionSpec) ValidateAlignment() error {
 	return errors.Join(errs...)
 }
 
+var _ models.CadenceComparable = SubscriptionSpec{}
+
+func (s SubscriptionSpec) GetCadence() models.CadencedModel {
+	return models.CadencedModel{
+		ActiveFrom: s.ActiveFrom,
+		ActiveTo:   s.ActiveTo,
+	}
+}
+
 type CreateSubscriptionPhasePlanInput struct {
 	PhaseKey    string               `json:"key"`
 	StartAfter  datetime.ISODuration `json:"startAfter"`
@@ -572,7 +581,6 @@ func (s SubscriptionPhaseSpec) Validate(
 							WithExpression(models.NewFieldArrIndex(overlap.Index1)),
 					).WithAttrs(models.Attributes{
 						"overlaps_with_idx": overlap.Index2,
-						"reason":            overlap.Reason,
 						"cadence":           overlap.Item1,
 						"spec":              itemSpec1,
 					}),
@@ -587,7 +595,6 @@ func (s SubscriptionPhaseSpec) Validate(
 							WithExpression(models.NewFieldArrIndex(overlap.Index2)),
 					).WithAttrs(models.Attributes{
 						"overlaps_with_idx": overlap.Index1,
-						"reason":            overlap.Reason,
 						"cadence":           overlap.Item2,
 						"spec":              itemSpec2,
 					}),

--- a/openmeter/subscription/subscriptionspec.go
+++ b/openmeter/subscription/subscriptionspec.go
@@ -979,6 +979,10 @@ func (s *SubscriptionItemSpec) SyncAnnotations() error {
 	if met.EntitlementTemplate != nil && met.EntitlementTemplate.Type() == entitlement.EntitlementTypeBoolean {
 		count := AnnotationParser.GetBooleanEntitlementCount(s.Annotations)
 		if count == 0 {
+			if s.Annotations == nil {
+				s.Annotations = models.Annotations{}
+			}
+
 			if _, err := AnnotationParser.SetBooleanEntitlementCount(s.Annotations, 1); err != nil {
 				return fmt.Errorf("failed to set boolean entitlement count: %w", err)
 			}

--- a/openmeter/subscription/testutils/builder.go
+++ b/openmeter/subscription/testutils/builder.go
@@ -11,6 +11,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -100,6 +102,7 @@ func (b *testSubscriptionSpecBuilder) AddPhase(dur *datetime.ISODuration, rcs ..
 			SortHint:    lo.ToPtr(uint8(idx)),
 		},
 		CreateSubscriptionPhaseCustomerInput: subscription.CreateSubscriptionPhaseCustomerInput{},
+		ItemsByKey:                           make(map[string][]*subscription.SubscriptionItemSpec),
 	}
 
 	// Let's add the RateCards as Items
@@ -139,4 +142,30 @@ func (b *testSubscriptionSpecBuilder) Build() (subscription.SubscriptionSpec, er
 	}
 
 	return spec, nil
+}
+
+func BuildTestSubscriptionSpec(t *testing.T) *testSubscriptionSpecBuilder {
+	now := clock.Now()
+
+	return &testSubscriptionSpecBuilder{
+		s: subscription.SubscriptionSpec{
+			CreateSubscriptionPlanInput: subscription.CreateSubscriptionPlanInput{
+				Plan: &subscription.PlanRef{
+					Key:     "test_plan",
+					Version: 1,
+				},
+				BillingCadence: datetime.MustParseDuration(t, "P1M"),
+			},
+			CreateSubscriptionCustomerInput: subscription.CreateSubscriptionCustomerInput{
+				CustomerId:    "01K6JCPG631MH1EKEQB2YMDBJW",
+				ActiveFrom:    now,
+				ActiveTo:      nil,
+				Name:          "test_subscription",
+				BillingAnchor: now,
+				Currency:      currencyx.Code(currency.USD),
+			},
+			Phases: make(map[string]*subscription.SubscriptionPhaseSpec),
+		},
+		t: t,
+	}
 }

--- a/openmeter/subscription/testutils/builder.go
+++ b/openmeter/subscription/testutils/builder.go
@@ -1,0 +1,142 @@
+package subscriptiontestutils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/invopop/gobl/currency"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// First let's add utils for building plans
+type testPlanbuilder struct {
+	p plan.CreatePlanInput
+}
+
+func (b *testPlanbuilder) AddPhase(dur *datetime.ISODuration, rcs ...productcatalog.RateCard) *testPlanbuilder {
+	idx := len(b.p.Plan.Phases) + 1
+
+	b.p.Plan.Phases = append(b.p.Plan.Phases, productcatalog.Phase{
+		PhaseMeta: productcatalog.PhaseMeta{
+			Key:         fmt.Sprintf("test_phase_%d", idx),
+			Name:        fmt.Sprintf("Test Phase %d", idx),
+			Description: lo.ToPtr(fmt.Sprintf("Test Phase %d Description", idx)),
+			Duration:    dur,
+		},
+		RateCards: rcs,
+	})
+
+	return b
+}
+
+func (b *testPlanbuilder) SetMeta(meta productcatalog.PlanMeta) *testPlanbuilder {
+	b.p.Plan.PlanMeta = meta
+	return b
+}
+
+func (b *testPlanbuilder) Build() plan.CreatePlanInput {
+	return b.p
+}
+
+func BuildTestPlanInput(t *testing.T) *testPlanbuilder {
+	b := &testPlanbuilder{
+		p: plan.CreatePlanInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: ExampleNamespace,
+			},
+			Plan: productcatalog.Plan{
+				PlanMeta: productcatalog.PlanMeta{
+					Name:           "Test Plan",
+					Key:            "test_plan",
+					Version:        1,
+					Currency:       currency.USD,
+					BillingCadence: datetime.MustParseDuration(t, "P1M"),
+					ProRatingConfig: productcatalog.ProRatingConfig{
+						Enabled: true,
+						Mode:    productcatalog.ProRatingModeProratePrices,
+					},
+				},
+				Phases: []productcatalog.Phase{},
+			},
+		},
+	}
+
+	return b
+}
+
+type testSubscriptionSpecBuilder struct {
+	s subscription.SubscriptionSpec
+	t *testing.T
+}
+
+func (b *testSubscriptionSpecBuilder) AddPhase(dur *datetime.ISODuration, rcs ...productcatalog.RateCard) *testSubscriptionSpecBuilder {
+	idx := len(b.s.Phases) + 1
+	startAfter := datetime.ISODurationBetween(b.s.ActiveFrom, b.s.ActiveFrom)
+
+	if idx > 1 {
+		phases := b.s.GetSortedPhases()
+		cad, err := b.s.GetPhaseCadence(phases[idx-1].PhaseKey)
+		require.NoError(b.t, err)
+		if cad.ActiveTo == nil {
+			b.t.Fatalf("phase %s has no active to, cannot add new phase without specifying duration for previous", phases[idx-1].PhaseKey)
+		}
+		startAfter = datetime.ISODurationBetween(b.s.ActiveFrom, *cad.ActiveTo)
+	}
+
+	// Let's build the new phase
+	newPhase := subscription.SubscriptionPhaseSpec{
+		CreateSubscriptionPhasePlanInput: subscription.CreateSubscriptionPhasePlanInput{
+			PhaseKey:    fmt.Sprintf("test_phase_%d", idx),
+			Name:        fmt.Sprintf("Test Phase %d", idx),
+			Description: lo.ToPtr(fmt.Sprintf("Test Phase %d Description", idx)),
+			StartAfter:  startAfter,
+			SortHint:    lo.ToPtr(uint8(idx)),
+		},
+		CreateSubscriptionPhaseCustomerInput: subscription.CreateSubscriptionPhaseCustomerInput{},
+	}
+
+	// Let's add the RateCards as Items
+	for _, rc := range rcs {
+		newPhase.ItemsByKey[rc.Key()] = append(newPhase.ItemsByKey[rc.Key()], &subscription.SubscriptionItemSpec{
+			CreateSubscriptionItemInput: subscription.CreateSubscriptionItemInput{
+				CreateSubscriptionItemPlanInput: subscription.CreateSubscriptionItemPlanInput{
+					PhaseKey: newPhase.PhaseKey,
+					ItemKey:  rc.Key(),
+					RateCard: rc,
+				},
+				CreateSubscriptionItemCustomerInput: subscription.CreateSubscriptionItemCustomerInput{},
+			},
+		})
+	}
+
+	for key, items := range newPhase.ItemsByKey {
+		if len(items) > 1 {
+			b.t.Fatalf("multiple ratecards specified with same key %s", key)
+		}
+	}
+
+	b.s.Phases[newPhase.PhaseKey] = &newPhase
+
+	return b
+}
+
+func (b *testSubscriptionSpecBuilder) Build() (subscription.SubscriptionSpec, error) {
+	spec := b.s
+
+	if err := spec.SyncAnnotations(); err != nil {
+		return spec, fmt.Errorf("failed to sync annotations: %w", err)
+	}
+
+	if err := spec.Validate(); err != nil {
+		return spec, fmt.Errorf("failed to validate spec: %w", err)
+	}
+
+	return spec, nil
+}

--- a/openmeter/subscription/testutils/plan.go
+++ b/openmeter/subscription/testutils/plan.go
@@ -2,10 +2,8 @@ package subscriptiontestutils
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
-	"github.com/invopop/gobl/currency"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
@@ -16,66 +14,10 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/datetime"
-	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-type testPlanbuilder struct {
-	p plan.CreatePlanInput
-}
-
-func (b *testPlanbuilder) AddPhase(dur *datetime.ISODuration, rcs ...productcatalog.RateCard) *testPlanbuilder {
-	idx := len(b.p.Plan.Phases) + 1
-
-	b.p.Plan.Phases = append(b.p.Plan.Phases, productcatalog.Phase{
-		PhaseMeta: productcatalog.PhaseMeta{
-			Key:         fmt.Sprintf("test_phase_%d", idx),
-			Name:        fmt.Sprintf("Test Phase %d", idx),
-			Description: lo.ToPtr(fmt.Sprintf("Test Phase %d Description", idx)),
-			Duration:    dur,
-		},
-		RateCards: rcs,
-	})
-
-	return b
-}
-
-func (b *testPlanbuilder) SetMeta(meta productcatalog.PlanMeta) *testPlanbuilder {
-	b.p.Plan.PlanMeta = meta
-	return b
-}
-
-func (b *testPlanbuilder) Build() plan.CreatePlanInput {
-	return b.p
-}
-
-func BuildTestPlan(t *testing.T) *testPlanbuilder {
-	b := &testPlanbuilder{
-		p: plan.CreatePlanInput{
-			NamespacedModel: models.NamespacedModel{
-				Namespace: ExampleNamespace,
-			},
-			Plan: productcatalog.Plan{
-				PlanMeta: productcatalog.PlanMeta{
-					Name:           "Test Plan",
-					Key:            "test_plan",
-					Version:        1,
-					Currency:       currency.USD,
-					BillingCadence: datetime.MustParseDuration(t, "P1M"),
-					ProRatingConfig: productcatalog.ProRatingConfig{
-						Enabled: true,
-						Mode:    productcatalog.ProRatingModeProratePrices,
-					},
-				},
-				Phases: []productcatalog.Phase{},
-			},
-		},
-	}
-
-	return b
-}
-
 func GetExamplePlanInput(t *testing.T) plan.CreatePlanInput {
-	b := BuildTestPlan(t)
+	b := BuildTestPlanInput(t)
 
 	b.AddPhase(lo.ToPtr(datetime.MustParseDuration(t, "P1M")), ExampleRateCard1.Clone())
 	b.AddPhase(lo.ToPtr(datetime.MustParseDuration(t, "P2M")), ExampleRateCard1.Clone(), ExampleRateCard2.Clone(), ExampleRateCard3ForAddons.Clone())

--- a/openmeter/subscription/uniqueness.go
+++ b/openmeter/subscription/uniqueness.go
@@ -130,10 +130,13 @@ func (v featureLevelUniqueConstraintValidator) buildRelevantTimelines(itemMap ma
 func (v featureLevelUniqueConstraintValidator) collectRelevantItems(subs []SubscriptionSpec, condition func(item *SubscriptionItemSpec) bool) map[string][]itemSpecWithCircularReferences {
 	relevantItems := make(map[string][]itemSpecWithCircularReferences)
 
-	for _, sub := range subs {
-		for _, phase := range sub.Phases {
+	for si := range subs {
+		sub := subs[si]
+		for pi := range sub.Phases {
+			phase := sub.Phases[pi]
 			for itemKey, items := range phase.ItemsByKey {
-				for idx, item := range items {
+				for idx := range items {
+					item := items[idx]
 					if condition(item) {
 						relevantItems[itemKey] = append(relevantItems[itemKey], itemSpecWithCircularReferences{
 							SubscriptionItemVersion: idx,

--- a/openmeter/subscription/uniqueness.go
+++ b/openmeter/subscription/uniqueness.go
@@ -40,6 +40,11 @@ func ValidateUniqueConstraintBySubscriptions(subs []SubscriptionSpec) error {
 							Cadence:      overlap.Item2.GetCadence(),
 							Selectors:    subscriptionSpecToFieldSelectors(overlap.Item2),
 						},
+						Other: SubscriptionSubscriptionLevelUniqueConstraintErrorDetailSide{
+							Subscription: overlap.Item1,
+							Cadence:      overlap.Item1.GetCadence(),
+							Selectors:    subscriptionSpecToFieldSelectors(overlap.Item1),
+						},
 					},
 				}).WithField(subscriptionSpecToFieldSelectors(overlap.Item2)...))
 		}

--- a/openmeter/subscription/uniqueness.go
+++ b/openmeter/subscription/uniqueness.go
@@ -1,20 +1,151 @@
 package subscription
 
 import (
-	"github.com/openmeterio/openmeter/pkg/models"
-)
+	"errors"
+	"fmt"
 
-// TODO[galexi]: Implement this
-func ValidateUniqueConstraintByFeatures(subs []SubscriptionSpec) error {
-	return nil
-}
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/slicesx"
+)
 
 func ValidateUniqueConstraintBySubscriptions(subs []SubscriptionSpec) error {
 	if overlaps := models.NewSortedCadenceList(subs).GetOverlaps(); len(overlaps) > 0 {
 		return ErrOnlySingleSubscriptionAllowed.WithAttrs(models.Attributes{
+			// FIXME[galexi]: improve on this
 			"overlaps": overlaps,
 		})
 	}
 
 	return nil
+}
+
+func ValidateUniqueConstraintByFeatures(subs []SubscriptionSpec) error {
+	return featureLevelUniqueConstraintValidator{}.Validate(subs)
+}
+
+type SubscriptionUniqueConstraintErrorDetailSide struct {
+	Item    SubscriptionItemSpec `json:"-"` // useful internally but let's not expose it to the client
+	Path    SpecPath             `json:"path"`
+	PlanRef PlanRef              `json:"plan_ref"`
+}
+
+type SubscriptionUniqueConstraintErrorDetail struct {
+	Left  SubscriptionUniqueConstraintErrorDetailSide `json:"left"`
+	Right SubscriptionUniqueConstraintErrorDetailSide `json:"right"`
+}
+
+// let's localize all logic on this struct to avoid scope pollution
+type featureLevelUniqueConstraintValidator struct{}
+
+func (v featureLevelUniqueConstraintValidator) Validate(subs []SubscriptionSpec) error {
+	billableItems := v.collectRelevantItems(subs, v.itemIsBillable)
+	timelinesForBillableItems, err := v.buildRelevantTimelines(billableItems)
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, timeline := range timelinesForBillableItems {
+		if overlaps := timeline.GetOverlaps(); len(overlaps) > 0 {
+			for _, overlap := range overlaps {
+				errs = append(errs, ErrOnlySingleBillableItemAllowedAtATime.WithAttrs(models.Attributes{
+					ErrCodeOnlySingleBillableItemAllowedAtATime: SubscriptionUniqueConstraintErrorDetail{
+						Left: SubscriptionUniqueConstraintErrorDetailSide{
+							Item:    lo.FromPtr(overlap.Item1.Item.SubscriptionItemSpec),
+							Path:    overlap.Item1.Item.GetPath(),
+							PlanRef: lo.FromPtr(overlap.Item1.Item.SubscriptionSpec.Plan),
+						},
+						Right: SubscriptionUniqueConstraintErrorDetailSide{
+							Item:    lo.FromPtr(overlap.Item2.Item.SubscriptionItemSpec),
+							Path:    overlap.Item2.Item.GetPath(),
+							PlanRef: lo.FromPtr(overlap.Item2.Item.SubscriptionSpec.Plan),
+						},
+					},
+				}))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (v featureLevelUniqueConstraintValidator) buildRelevantTimelines(itemMap map[string][]itemSpecWithCircularReferences) (map[string]models.CadenceList[validationTimelineEntry], error) {
+	timelines := make(map[string]models.CadenceList[validationTimelineEntry])
+
+	for itemKey, items := range itemMap {
+		validationTimelineEntries, err := slicesx.MapWithErr(items, func(item itemSpecWithCircularReferences) (validationTimelineEntry, error) {
+			phaseCadence, err := item.SubscriptionSpec.GetPhaseCadence(item.SubscriptionPhaseSpec.PhaseKey)
+			if err != nil {
+				return validationTimelineEntry{}, fmt.Errorf("failed to get phase cadence for item %s: %w", itemKey, err)
+			}
+
+			itemCadence := item.SubscriptionItemSpec.GetCadence(phaseCadence)
+
+			return validationTimelineEntry{
+				Item:    &item,
+				Cadence: itemCadence,
+			}, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		timelines[itemKey] = models.NewSortedCadenceList(validationTimelineEntries)
+	}
+
+	return timelines, nil
+}
+
+func (v featureLevelUniqueConstraintValidator) collectRelevantItems(subs []SubscriptionSpec, condition func(item *SubscriptionItemSpec) bool) map[string][]itemSpecWithCircularReferences {
+	relevantItems := make(map[string][]itemSpecWithCircularReferences)
+
+	for _, sub := range subs {
+		for _, phase := range sub.Phases {
+			for itemKey, items := range phase.ItemsByKey {
+				for idx, item := range items {
+					if condition(item) {
+						relevantItems[itemKey] = append(relevantItems[itemKey], itemSpecWithCircularReferences{
+							SubscriptionItemVersion: idx,
+							SubscriptionItemSpec:    item,
+							SubscriptionPhaseSpec:   phase,
+							SubscriptionSpec:        &sub,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	return relevantItems
+}
+
+func (v featureLevelUniqueConstraintValidator) itemIsBillable(item *SubscriptionItemSpec) bool {
+	if item == nil {
+		return false
+	}
+
+	return item.RateCard.AsMeta().IsBillable()
+}
+
+// This will be a circular structure so be careful when using it
+type itemSpecWithCircularReferences struct {
+	SubscriptionItemVersion int
+	SubscriptionItemSpec    *SubscriptionItemSpec
+	SubscriptionPhaseSpec   *SubscriptionPhaseSpec
+	SubscriptionSpec        *SubscriptionSpec
+}
+
+func (i itemSpecWithCircularReferences) GetPath() SpecPath {
+	return NewItemVersionPath(i.SubscriptionPhaseSpec.PhaseKey, i.SubscriptionItemSpec.ItemKey, i.SubscriptionItemVersion)
+}
+
+type validationTimelineEntry struct {
+	Item    *itemSpecWithCircularReferences
+	Cadence models.CadencedModel
+}
+
+func (i validationTimelineEntry) GetCadence() models.CadencedModel {
+	return i.Cadence
 }

--- a/openmeter/subscription/uniqueness.go
+++ b/openmeter/subscription/uniqueness.go
@@ -2,7 +2,6 @@ package subscription
 
 import (
 	"github.com/openmeterio/openmeter/pkg/models"
-	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
 // TODO[galexi]: Implement this
@@ -11,12 +10,10 @@ func ValidateUniqueConstraintByFeatures(subs []SubscriptionSpec) error {
 }
 
 func ValidateUniqueConstraintBySubscriptions(subs []SubscriptionSpec) error {
-	if overlaps := models.NewSortedCadenceList(
-		slicesx.Map(subs, func(i SubscriptionSpec) CreateSubscriptionEntityInput {
-			return i.ToCreateSubscriptionEntityInput("irrelevant")
-		}),
-	).GetOverlaps(); len(overlaps) > 0 {
-		return ErrOnlySingleSubscriptionAllowed
+	if overlaps := models.NewSortedCadenceList(subs).GetOverlaps(); len(overlaps) > 0 {
+		return ErrOnlySingleSubscriptionAllowed.WithAttrs(models.Attributes{
+			"overlaps": overlaps,
+		})
 	}
 
 	return nil

--- a/openmeter/subscription/uniqueness_test.go
+++ b/openmeter/subscription/uniqueness_test.go
@@ -1,0 +1,125 @@
+package subscription_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/invopop/gobl/currency"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestValidateUniqueConstraintBySubscriptions(t *testing.T) {
+	getSimpleSub := func(cad models.CadencedModel) subscription.SubscriptionSpec {
+		sp := subscription.SubscriptionSpec{
+			CreateSubscriptionPlanInput: subscription.CreateSubscriptionPlanInput{
+				Plan: &subscription.PlanRef{
+					Key: "test_plan",
+				},
+				BillingCadence: datetime.NewISODuration(0, 1, 0, 0, 0, 0, 0),
+			},
+			CreateSubscriptionCustomerInput: subscription.CreateSubscriptionCustomerInput{
+				CustomerId:    "test_customer",
+				ActiveFrom:    cad.ActiveFrom,
+				ActiveTo:      cad.ActiveTo,
+				Name:          "test_subscription",
+				BillingAnchor: cad.ActiveFrom,
+				Currency:      currencyx.Code(currency.USD),
+			},
+		}
+
+		return sp
+	}
+
+	t.Run("Should not error if they're far apart", func(t *testing.T) {
+		s1 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)),
+		})
+		s2 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC)),
+		})
+
+		require.NoError(t, subscription.ValidateUniqueConstraintBySubscriptions([]subscription.SubscriptionSpec{s1, s2}))
+	})
+
+	t.Run("Should error if they're overlapping", func(t *testing.T) {
+		s1 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 2, 0, 0, 2, 0, time.UTC)),
+		})
+
+		s2 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC)),
+		})
+
+		err := subscription.ValidateUniqueConstraintBySubscriptions([]subscription.SubscriptionSpec{s1, s2})
+		require.Error(t, err)
+
+		// Now let's assert the error is correct
+		issues, err := models.AsValidationIssues(err)
+		require.NoError(t, err)
+		require.Len(t, issues, 1)
+		require.Equal(t, subscription.ErrOnlySingleSubscriptionAllowed.Code(), issues[0].Code())
+
+		detail := issues[0].Attributes()["overlaps"].([]models.OverlapDetail[subscription.SubscriptionSpec])
+		require.Len(t, detail, 1)
+		require.Equal(t, 0, detail[0].Index1)
+		require.Equal(t, 1, detail[0].Index2)
+		require.Equal(t, s1, detail[0].Item1)
+		require.Equal(t, s2, detail[0].Item2)
+	})
+
+	t.Run("Should not error if they're touching", func(t *testing.T) {
+		s1 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)),
+		})
+
+		s2 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC)),
+		})
+
+		require.NoError(t, subscription.ValidateUniqueConstraintBySubscriptions([]subscription.SubscriptionSpec{s1, s2}))
+	})
+
+	t.Run("Should work for many subscriptions", func(t *testing.T) {
+		s1 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)),
+		})
+
+		s2 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC)),
+		})
+
+		s3 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC)),
+		})
+
+		s4 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 5, 0, 0, 0, 0, time.UTC)),
+		})
+
+		s5 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 5, 0, 0, 0, 0, time.UTC)),
+		})
+
+		require.NoError(t, subscription.ValidateUniqueConstraintBySubscriptions([]subscription.SubscriptionSpec{s1, s2, s3, s4}))
+
+		err := subscription.ValidateUniqueConstraintBySubscriptions([]subscription.SubscriptionSpec{s1, s2, s3, s4, s5})
+		require.Error(t, err)
+	})
+}

--- a/openmeter/subscription/uniqueness_test.go
+++ b/openmeter/subscription/uniqueness_test.go
@@ -4,38 +4,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alpacahq/alpacadecimal"
 	"github.com/invopop/gobl/currency"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
+	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/subscription/testutils"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 func TestValidateUniqueConstraintBySubscriptions(t *testing.T) {
-	getSimpleSub := func(cad models.CadencedModel) subscription.SubscriptionSpec {
-		sp := subscription.SubscriptionSpec{
-			CreateSubscriptionPlanInput: subscription.CreateSubscriptionPlanInput{
-				Plan: &subscription.PlanRef{
-					Key: "test_plan",
-				},
-				BillingCadence: datetime.NewISODuration(0, 1, 0, 0, 0, 0, 0),
-			},
-			CreateSubscriptionCustomerInput: subscription.CreateSubscriptionCustomerInput{
-				CustomerId:    "test_customer",
-				ActiveFrom:    cad.ActiveFrom,
-				ActiveTo:      cad.ActiveTo,
-				Name:          "test_subscription",
-				BillingAnchor: cad.ActiveFrom,
-				Currency:      currencyx.Code(currency.USD),
-			},
-		}
-
-		return sp
-	}
-
 	t.Run("Should not error if they're far apart", func(t *testing.T) {
 		s1 := getSimpleSub(models.CadencedModel{
 			ActiveFrom: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -122,4 +105,280 @@ func TestValidateUniqueConstraintBySubscriptions(t *testing.T) {
 		err := subscription.ValidateUniqueConstraintBySubscriptions([]subscription.SubscriptionSpec{s1, s2, s3, s4, s5})
 		require.Error(t, err)
 	})
+}
+
+func TestValidateUniqueConstraintByFeatures(t *testing.T) {
+	t.Run("Should not error if on a single suscription passed in", func(t *testing.T) {
+		s1 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)),
+		})
+
+		require.NoError(t, subscription.ValidateUniqueConstraintByFeatures([]subscription.SubscriptionSpec{s1}))
+	})
+
+	t.Run("Should not error if two empty subscriptions are overlapping", func(t *testing.T) {
+		s1 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC)),
+		})
+
+		s2 := getSimpleSub(models.CadencedModel{
+			ActiveFrom: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC),
+			ActiveTo:   lo.ToPtr(time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC)),
+		})
+
+		require.NoError(t, subscription.ValidateUniqueConstraintByFeatures([]subscription.SubscriptionSpec{s1, s2}))
+	})
+
+	t.Run("Should not error if two if two subscriptions share the same feature without entitlement or price", func(t *testing.T) {
+		clock.FreezeTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+		defer clock.UnFreeze()
+
+		// First the setup
+		overlappingFeatureKey := "feature1"
+		overlappingFeatureID := "01K6JCPG631MH1EKEQB2YMDBJW"
+
+		builder1 := subscriptiontestutils.BuildTestSubscriptionSpec(t)
+		builder1 = builder1.AddPhase(nil, &productcatalog.FlatFeeRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Name:       "overlapping feature",
+				Key:        overlappingFeatureKey,
+				FeatureKey: &overlappingFeatureKey,
+				FeatureID:  &overlappingFeatureID,
+			},
+		})
+		s1, err := builder1.Build()
+		require.NoError(t, err)
+
+		builder2 := subscriptiontestutils.BuildTestSubscriptionSpec(t)
+		builder2 = builder2.AddPhase(nil, &productcatalog.FlatFeeRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Name:       "overlapping feature",
+				Key:        overlappingFeatureKey,
+				FeatureKey: &overlappingFeatureKey,
+				FeatureID:  &overlappingFeatureID,
+			},
+		})
+		s2, err := builder2.Build()
+		require.NoError(t, err)
+
+		t.Run("Should not error if the subscriptions are overlapping", func(t *testing.T) {
+			s1.ActiveFrom = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			s1.ActiveTo = lo.ToPtr(time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC))
+			s2.ActiveFrom = time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+			s2.ActiveTo = lo.ToPtr(time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC))
+
+			require.NoError(t, subscription.ValidateUniqueConstraintByFeatures([]subscription.SubscriptionSpec{s1, s2}))
+		})
+
+		t.Run("Should not error if the subscriptions are adjacent", func(t *testing.T) {
+			s1.ActiveFrom = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			s1.ActiveTo = lo.ToPtr(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC))
+			s2.ActiveFrom = time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+			s2.ActiveTo = lo.ToPtr(time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC))
+
+			require.NoError(t, subscription.ValidateUniqueConstraintByFeatures([]subscription.SubscriptionSpec{s1, s2}))
+		})
+
+		t.Run("Should not error if the subscriptions are not overlapping", func(t *testing.T) {
+			s1.ActiveFrom = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			s1.ActiveTo = lo.ToPtr(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC))
+			s2.ActiveFrom = time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC)
+			s2.ActiveTo = lo.ToPtr(time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC))
+
+			require.NoError(t, subscription.ValidateUniqueConstraintByFeatures([]subscription.SubscriptionSpec{s1, s2}))
+		})
+	})
+
+	t.Run("Should not error if two subscriptions have overlapping features, where at most one has a price and neither has an entitlement", func(t *testing.T) {
+		clock.FreezeTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+		defer clock.UnFreeze()
+
+		overlappingFeatureKey := "feature1"
+		overlappingFeatureID := "01K6JCPG631MH1EKEQB2YMDBJW"
+
+		builder1 := subscriptiontestutils.BuildTestSubscriptionSpec(t)
+		builder1 = builder1.AddPhase(nil, &productcatalog.FlatFeeRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Name: "overlapping feature",
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(int64(100)),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				Key:        overlappingFeatureKey,
+				FeatureKey: &overlappingFeatureKey,
+				FeatureID:  &overlappingFeatureID,
+			},
+		})
+		s1, err := builder1.Build()
+		require.NoError(t, err)
+
+		builder2 := subscriptiontestutils.BuildTestSubscriptionSpec(t)
+		builder2 = builder2.AddPhase(nil, &productcatalog.FlatFeeRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Name:       "overlapping feature",
+				Key:        overlappingFeatureKey,
+				FeatureKey: &overlappingFeatureKey,
+				FeatureID:  &overlappingFeatureID,
+			},
+		})
+
+		s2, err := builder2.Build()
+		require.NoError(t, err)
+
+		builder3 := subscriptiontestutils.BuildTestSubscriptionSpec(t)
+		builder3 = builder3.AddPhase(nil, &productcatalog.FlatFeeRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Name:       "overlapping feature",
+				Key:        overlappingFeatureKey,
+				FeatureKey: &overlappingFeatureKey,
+				FeatureID:  &overlappingFeatureID,
+			},
+		})
+		s3, err := builder3.Build()
+		require.NoError(t, err)
+
+		builder4 := subscriptiontestutils.BuildTestSubscriptionSpec(t)
+		builder4 = builder4.AddPhase(nil, &productcatalog.FlatFeeRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Name:       "overlapping feature",
+				Key:        overlappingFeatureKey,
+				FeatureKey: &overlappingFeatureKey,
+				FeatureID:  &overlappingFeatureID,
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(int64(100)),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+			},
+		})
+		s4, err := builder4.Build()
+		require.NoError(t, err)
+
+		t.Run("Should not error when overlapping", func(t *testing.T) {
+			s1.ActiveFrom = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			s1.ActiveTo = lo.ToPtr(time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC))
+			s2.ActiveFrom = time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+			s2.ActiveTo = lo.ToPtr(time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC))
+			s3.ActiveFrom = time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+			s3.ActiveTo = lo.ToPtr(time.Date(2025, 1, 5, 0, 0, 0, 0, time.UTC))
+			s4.ActiveFrom = time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC)
+			s4.ActiveTo = lo.ToPtr(time.Date(2025, 1, 5, 0, 0, 0, 0, time.UTC))
+			// Looks like this
+			// | s1    |   s4  |		<- have prices
+			//     |   s2  |    		<- no prices
+			//     |     s3    |		<- no prices
+			// |   |   |   |   |
+
+			require.NoError(t, subscription.ValidateUniqueConstraintByFeatures([]subscription.SubscriptionSpec{s1, s2}), "Should not error for two")
+			require.NoError(t, subscription.ValidateUniqueConstraintByFeatures([]subscription.SubscriptionSpec{s1, s2, s3}), "Should not error for three")
+			require.NoError(t, subscription.ValidateUniqueConstraintByFeatures([]subscription.SubscriptionSpec{s1, s2, s3, s4}), "Should not error for four")
+		})
+	})
+
+	t.Run("Should error if two subscriptions have overlapping billable features", func(t *testing.T) {
+		clock.FreezeTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+		defer clock.UnFreeze()
+
+		overlappingFeatureKey := "feature1"
+		overlappingFeatureID := "01K6JCPG631MH1EKEQB2YMDBJW"
+
+		builder1 := subscriptiontestutils.BuildTestSubscriptionSpec(t)
+		builder1 = builder1.AddPhase(nil, &productcatalog.FlatFeeRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Name: "overlapping feature",
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(int64(100)),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				Key:        overlappingFeatureKey,
+				FeatureKey: &overlappingFeatureKey,
+				FeatureID:  &overlappingFeatureID,
+			},
+		})
+		s1, err := builder1.Build()
+		require.NoError(t, err)
+
+		builder2 := subscriptiontestutils.BuildTestSubscriptionSpec(t)
+		builder2 = builder2.AddPhase(nil, &productcatalog.FlatFeeRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Name: "overlapping feature",
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(int64(100)),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				Key:        overlappingFeatureKey,
+				FeatureKey: &overlappingFeatureKey,
+				FeatureID:  &overlappingFeatureID,
+			},
+		})
+		s2, err := builder2.Build()
+		require.NoError(t, err)
+
+		t.Run("Should error when overlapping", func(t *testing.T) {
+			s1.ActiveFrom = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			s1.ActiveTo = lo.ToPtr(time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC))
+			s2.ActiveFrom = time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+			s2.ActiveTo = lo.ToPtr(time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC))
+
+			err := subscription.ValidateUniqueConstraintByFeatures([]subscription.SubscriptionSpec{s1, s2})
+			require.Error(t, err)
+
+			// let's assert the error is correct
+			issues, err := models.AsValidationIssues(err)
+			require.NoError(t, err)
+			require.Len(t, issues, 1)
+			require.Equal(t, subscription.ErrOnlySingleBillableItemAllowedAtATime.Code(), issues[0].Code())
+
+			attrs := issues[0].Attributes()
+			detail, ok := attrs[subscription.ErrCodeOnlySingleBillableItemAllowedAtATime]
+			require.True(t, ok)
+
+			require.NotNil(t, detail)
+
+			detailTyped, ok := detail.(subscription.SubscriptionUniqueConstraintErrorDetail)
+			require.True(t, ok)
+
+			require.Equal(t, subscription.SpecPath("/phases/test_phase_1/items/feature1/idx/0"), detailTyped.Left.Path)
+			require.Equal(t, subscription.SpecPath("/phases/test_phase_1/items/feature1/idx/0"), detailTyped.Right.Path)
+		})
+	})
+
+	t.Run("Should error if two subscriptions have overlapping features with entitlements", func(t *testing.T) {
+		t.Fatal("Not implemented")
+	})
+
+	t.Run("Should error if two subscriptions have overlapping features with entitlements or are billable", func(t *testing.T) {
+		t.Fatal("Not implemented")
+	})
+
+	t.Run("Should error if multiple subscriptions have overlaps", func(t *testing.T) {
+		t.Fatal("Not implemented")
+	})
+
+	t.Run("Should not error if multiple subscriptions have overlapping timelines but we don't double charge or have doubled entitlements", func(t *testing.T) {
+		t.Fatal("Not implemented")
+	})
+}
+
+// builds an empty subscription without phases or items, used for testing the subscription level uniqueness constraint
+func getSimpleSub(cad models.CadencedModel) subscription.SubscriptionSpec {
+	sp := subscription.SubscriptionSpec{
+		CreateSubscriptionPlanInput: subscription.CreateSubscriptionPlanInput{
+			Plan: &subscription.PlanRef{
+				Key: "test_plan",
+			},
+			BillingCadence: datetime.NewISODuration(0, 1, 0, 0, 0, 0, 0),
+		},
+		CreateSubscriptionCustomerInput: subscription.CreateSubscriptionCustomerInput{
+			CustomerId:    "test_customer",
+			ActiveFrom:    cad.ActiveFrom,
+			ActiveTo:      cad.ActiveTo,
+			Name:          "test_subscription",
+			BillingAnchor: cad.ActiveFrom,
+			Currency:      currencyx.Code(currency.USD),
+		},
+	}
+
+	return sp
 }

--- a/openmeter/subscription/validator.go
+++ b/openmeter/subscription/validator.go
@@ -1,11 +1,16 @@
 package subscription
 
-import "context"
+import (
+	"context"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+)
 
 type SubscriptionCommandValidator interface {
 	// These happen before the fact
 	ValidateCreate(context.Context, string, SubscriptionSpec) error
 	ValidateContinue(context.Context, SubscriptionView) error
+	ValidateUpdate(context.Context, models.NamespacedID, SubscriptionSpec) error
 	// These happen after the fact
 	ValidateCreated(context.Context, SubscriptionView) error
 	ValidateUpdated(context.Context, SubscriptionView) error
@@ -23,6 +28,10 @@ func (NoOpSubscriptionCommandValidator) ValidateCreate(context.Context, string, 
 }
 
 func (NoOpSubscriptionCommandValidator) ValidateContinue(context.Context, SubscriptionView) error {
+	return nil
+}
+
+func (NoOpSubscriptionCommandValidator) ValidateUpdate(context.Context, models.NamespacedID, SubscriptionSpec) error {
 	return nil
 }
 

--- a/openmeter/subscription/workflow/service/addon_test.go
+++ b/openmeter/subscription/workflow/service/addon_test.go
@@ -125,7 +125,7 @@ func TestAddAddon(t *testing.T) {
 		_ = deps.FeatureConnector.CreateExampleFeatures(t)
 
 		// Let's create a plan
-		p, err := deps.PlanService.CreatePlan(context.Background(), subscriptiontestutils.BuildTestPlan(t).
+		p, err := deps.PlanService.CreatePlan(context.Background(), subscriptiontestutils.BuildTestPlanInput(t).
 			AddPhase(nil, &subscriptiontestutils.ExampleRateCard1).
 			Build())
 		require.Nil(t, err)
@@ -497,7 +497,7 @@ func TestChangeAddonQuantity(t *testing.T) {
 		p, add := subscriptiontestutils.CreatePlanWithAddon(
 			t,
 			deps,
-			subscriptiontestutils.BuildTestPlan(t).
+			subscriptiontestutils.BuildTestPlanInput(t).
 				AddPhase(nil, &subscriptiontestutils.ExampleRateCard1).
 				Build(),
 			subscriptiontestutils.BuildAddonForTesting(t,
@@ -551,7 +551,7 @@ func TestChangeAddonQuantity(t *testing.T) {
 		p, add := subscriptiontestutils.CreatePlanWithAddon(
 			t,
 			deps,
-			subscriptiontestutils.BuildTestPlan(t).
+			subscriptiontestutils.BuildTestPlanInput(t).
 				SetMeta(productcatalog.PlanMeta{
 					Name:           "Test Plan",
 					Key:            "test_plan",
@@ -664,7 +664,7 @@ func TestAddonCombinations(t *testing.T) {
 
 	t.Run("Should handle repeated add/remove of single instance addon with dynamic price", runWithDeps(func(t *testing.T, deps subscriptiontestutils.SubscriptionDependencies) {
 		// Create a plan with mixed rate cards
-		planInput := subscriptiontestutils.BuildTestPlan(t).
+		planInput := subscriptiontestutils.BuildTestPlanInput(t).
 			AddPhase(nil,
 				&subscriptiontestutils.ExampleRateCard1, // Flat price
 				&productcatalog.UsageBasedRateCard{ // Dynamic price

--- a/openmeter/subscription/workflow/service/subscription_test.go
+++ b/openmeter/subscription/workflow/service/subscription_test.go
@@ -1652,7 +1652,10 @@ func TestMultiSubscription(t *testing.T) {
 			}, deps.Plan1)
 
 			require.Error(t, err)
-			require.ErrorIs(t, err, subscription.ErrOnlySingleSubscriptionAllowed)
+			issues, err := models.AsValidationIssues(err)
+			require.NoError(t, err)
+			require.Len(t, issues, 1)
+			require.Equal(t, subscription.ErrOnlySingleSubscriptionAllowed.Code(), issues[0].Code())
 		})
 	})
 

--- a/openmeter/subscription/workflow/service/subscription_test.go
+++ b/openmeter/subscription/workflow/service/subscription_test.go
@@ -134,7 +134,7 @@ func TestCreateFromPlan(t *testing.T) {
 		deps := subscriptiontestutils.NewService(t, dbDeps)
 		deps.FeatureConnector.CreateExampleFeatures(t)
 
-		p := deps.PlanHelper.CreatePlan(t, subscriptiontestutils.BuildTestPlan(t).
+		p := deps.PlanHelper.CreatePlan(t, subscriptiontestutils.BuildTestPlanInput(t).
 			AddPhase(nil, &subscriptiontestutils.ExampleRateCard3ForAddons, &subscriptiontestutils.ExampleRateCard4ForAddons).
 			Build())
 
@@ -1119,7 +1119,7 @@ func TestEditCombinations(t *testing.T) {
 
 	t.Run("Should add boolean entitlement count annotations", func(t *testing.T) {
 		withDeps(t)(func(t *testing.T, deps testCaseDeps) {
-			plan := deps.SubsDeps.PlanHelper.CreatePlan(t, subscriptiontestutils.BuildTestPlan(t).
+			plan := deps.SubsDeps.PlanHelper.CreatePlan(t, subscriptiontestutils.BuildTestPlanInput(t).
 				AddPhase(nil, &subscriptiontestutils.ExampleRateCard3ForAddons).
 				Build())
 

--- a/pkg/models/cadencelist.go
+++ b/pkg/models/cadencelist.go
@@ -13,6 +13,11 @@ type CadenceComparable interface {
 	GetCadence() CadencedModel
 }
 
+type Overlap[T any] struct {
+	This  T `json:"this"`
+	Other T `json:"other"`
+}
+
 type OverlapDetail[T CadenceComparable] struct {
 	Index1 int
 	Index2 int

--- a/pkg/models/cadencelist.go
+++ b/pkg/models/cadencelist.go
@@ -104,6 +104,13 @@ func (t CadenceList[T]) sort() {
 		aC := a.GetCadence()
 		bC := b.GetCadence()
 
-		return int(aC.ActiveFrom.Sub(bC.ActiveFrom).Milliseconds())
+		switch {
+		case aC.ActiveFrom.Before(bC.ActiveFrom):
+			return -1
+		case aC.ActiveFrom.After(bC.ActiveFrom):
+			return 1
+		default:
+			return 0
+		}
 	})
 }

--- a/pkg/models/cadencelist.go
+++ b/pkg/models/cadencelist.go
@@ -1,0 +1,104 @@
+package models
+
+import "slices"
+
+// TODO[galexi]: Get rid of these types and use period.Period instead:
+// - Add Intersection method to period.Period so all types implement it
+// - Write helpers using period.Period
+// CadenceList is a simple abstraction for a list of cadenced models.
+// It is useful to validate the relationship between the cadences of the models, like their ordering, overlaps, continuity, etc.
+type CadenceList[T CadenceComparable] []T
+
+type CadenceComparable interface {
+	GetCadence() CadencedModel
+}
+
+type OverlapDetail[T CadenceComparable] struct {
+	Index1 int
+	Index2 int
+	Item1  T
+	Item2  T
+}
+
+func NewSortedCadenceList[T CadenceComparable](cadences []T) CadenceList[T] {
+	local := make([]T, len(cadences))
+	copy(local, cadences)
+
+	t := CadenceList[T](local)
+	t.sort()
+
+	return t
+}
+
+// Cadences returns the cadences in the timeline
+func (t CadenceList[T]) Cadences() []T {
+	return t
+}
+
+// TODO: rewrite CadenceList helpers to use timeutil.OpenPeriod instead
+
+// GetOverlaps returns details about any overlaps between the cadences in the timeline.
+func (t CadenceList[T]) GetOverlaps() []OverlapDetail[T] {
+	var overlaps []OverlapDetail[T]
+
+	for i := 0; i < len(t); i++ {
+		if i == 0 {
+			continue
+		}
+
+		item1 := t[i-1]
+		item2 := t[i]
+		cadence1 := item1.GetCadence()
+		cadence2 := item2.GetCadence()
+
+		if cadence1.ActiveTo == nil {
+			overlaps = append(overlaps, OverlapDetail[T]{
+				Index1: i - 1,
+				Index2: i,
+				Item1:  item1,
+				Item2:  item2,
+			})
+			continue
+		}
+
+		if cadence1.ActiveTo != nil && cadence2.ActiveFrom.Before(*cadence1.ActiveTo) {
+			overlaps = append(overlaps, OverlapDetail[T]{
+				Index1: i - 1,
+				Index2: i,
+				Item1:  item1,
+				Item2:  item2,
+			})
+		}
+	}
+
+	return overlaps
+}
+
+func (t CadenceList[T]) IsSorted() bool {
+	for i := 1; i < len(t); i++ {
+		if t[i-1].GetCadence().ActiveFrom.After(t[i].GetCadence().ActiveFrom) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (t CadenceList[T]) IsContinuous() bool {
+	for i := 1; i < len(t); i++ {
+		if t[i-1].GetCadence().ActiveTo == nil || !t[i-1].GetCadence().ActiveTo.Equal(t[i].GetCadence().ActiveFrom) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (t CadenceList[T]) sort() {
+	slices.SortStableFunc(t, func(a, b T) int {
+		aC := a.GetCadence()
+		bC := b.GetCadence()
+
+		return int(aC.ActiveFrom.Sub(bC.ActiveFrom).Milliseconds())
+	})
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

> Multi-Subsc PART Final

## Overview

> ⚠️ Needs https://github.com/openmeterio/openmeter/pull/3458 merged and then rebase⚠️ 

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

- Implements the desired unique-constraint validations for multi-subscription
- ⚠️ changes the HTTP.Problem.Extensions structure for current "non-multi-sub" unique errors
  - AFAIK we don't rely on their structure

## Notes for Reviewers

To finish with multi-subscriptions there are still open work items:
- FFX still doesn't work correctly in the cloud (`namespace not found` errors)

...they will be shipped separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Granular feature-level conflict detection across subscriptions and pre-update validation for multi-subscription scenarios.
  - Streamlined cadence handling with a simple cadence accessor to improve timeline processing.

- **Bug Fixes**
  - Prevented nil annotations during subscription item sync.
  - More accurate timeline overlap detection and clearer field selectors in validation responses.

- **Tests**
  - Expanded and hardened test coverage and test helpers for plans, subscriptions, and uniqueness validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->