### PR TITLE
fix: ffx hook was registered too early

### DIFF
--- a/app/common/server.go
+++ b/app/common/server.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"net/http"
+
 	"github.com/google/wire"
 
 	"github.com/openmeterio/openmeter/openmeter/server"
@@ -8,18 +10,27 @@ import (
 
 var Server = wire.NewSet(
 	NewTelemetryRouterHook,
-	NewFFXConfigContextMiddlewareHook,
+	NewFFXConfigContextMiddleware,
 	NewRouterHooks,
+	NewPostAuthMiddlewares,
 )
 
 func NewRouterHooks(
 	telemetry TelemetryMiddlewareHook,
-	ffx FFXConfigContextMiddlewareHook,
 ) *server.RouterHooks {
 	return &server.RouterHooks{
 		Middlewares: []server.MiddlewareHook{
 			server.MiddlewareHook(telemetry),
-			server.MiddlewareHook(ffx),
+		},
+	}
+}
+
+func NewPostAuthMiddlewares(
+	ffx FFXConfigContextMiddleware,
+) server.PostAuthMiddlewares {
+	return server.PostAuthMiddlewares{
+		func(h http.Handler) http.Handler {
+			return ffx(h)
 		},
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -183,7 +183,8 @@ func main() {
 			SubjectService:              app.SubjectService,
 			StreamingConnector:          app.StreamingConnector,
 		},
-		RouterHooks: lo.FromPtr(app.RouterHooks),
+		RouterHooks:         lo.FromPtr(app.RouterHooks),
+		PostAuthMiddlewares: app.PostAuthMiddlewares,
 	})
 	if err != nil {
 		logger.Error("failed to create server", "error", err)

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -73,6 +73,7 @@ type Application struct {
 	Portal                           portal.Service
 	ProgressManager                  progressmanager.Service
 	RouterHooks                      *server.RouterHooks
+	PostAuthMiddlewares              server.PostAuthMiddlewares
 	Secret                           secret.Service
 	SubjectService                   subject.Service
 	SubjectCustomerHook              subjecthooks.CustomerSubjectHook


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

We got `no namespace found in request, continuing without feature flag access` warn logs because the middleware was registered too early.

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for configurable post-authentication middlewares, enabling easier extension of request handling after auth.
  - Centralized configuration to include these middlewares in server setup.

- Refactor
  - Simplified middleware integration by switching to direct handler-based middleware and consolidating context handling.
  - Server now builds a single middleware chain (auth, validation, then post-auth) for cleaner routing.

- Chores
  - Updated internal wiring to align with the new middleware structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->