### PR TITLE
fix(subs): validate page inputs and set defaults in http handler

### DIFF
--- a/openmeter/productcatalog/subscription/http/get.go
+++ b/openmeter/productcatalog/subscription/http/get.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/samber/lo"
+
 	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
@@ -104,9 +106,21 @@ func (h *handler) ListCustomerSubscriptions() ListCustomerSubscriptionsHandler {
 				)
 			}
 
+			page := pagination.Page{}
+
+			if params.Params.Page != nil || params.Params.PageSize != nil {
+				pageNumber := lo.FromPtrOr(params.Params.Page, 1)
+				pageSize := lo.FromPtrOr(params.Params.PageSize, 100)
+
+				page = pagination.Page{
+					PageNumber: pageNumber,
+					PageSize:   pageSize,
+				}
+			}
+
 			return ListCustomerSubscriptionsRequest{
 				CustomerID: cus.GetID(),
-				Page:       pagination.NewPageFromRef(params.Params.Page, params.Params.PageSize),
+				Page:       page,
 			}, nil
 		},
 		func(ctx context.Context, req ListCustomerSubscriptionsRequest) (ListCustomerSubscriptionsResponse, error) {

--- a/openmeter/subscription/list.go
+++ b/openmeter/subscription/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -27,7 +28,13 @@ func (i ListSubscriptionsInput) Validate() error {
 		}
 	}
 
-	return errors.Join(errs...)
+	if !i.Page.IsZero() {
+		if err := i.Page.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("page: %w", err))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type SubscriptionList = pagination.Result[Subscription]


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

I'll do a small refactor where the `pagination` pkg constructor will manage these, but currently this hack is used in all cases....

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected pagination handling in customer subscriptions: no paging applied unless parameters are provided; sensible defaults used when they are.
  - Ensured consistent request construction with the computed pagination settings.

- Error Handling
  - Improved validation feedback for pagination errors with clearer, prefixed messages.
  - Standardized error format for aggregated validation issues to ensure more consistent API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->