### PR TITLE
chore: clean up gathering invoice detailed lines

### DIFF
--- a/atlas.hcl
+++ b/atlas.hcl
@@ -56,7 +56,10 @@ locals {
     local_url = "postgres://postgres:postgres@localhost:5432/postgres?search_path=public&sslmode=disable"
     ci_url = "postgres://postgres:postgres@postgres:5432/postgres?search_path=public&sslmode=disable"
 
-    migration_exlude = ["distributed_locks[type=table]"]
+    migration_exlude = [
+      "distributed_locks[type=table]",
+      "om_migration_backup_*[type=table]",
+    ]
 }
 
 lint {

--- a/tools/migrate/migrations/20260716150454_create_gathering_detail_cleanup_indexes.down.sql
+++ b/tools/migrate/migrations/20260716150454_create_gathering_detail_cleanup_indexes.down.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS
+    om_mig_bil_fee_cfg_id_idx,
+    om_mig_bil_ubp_cfg_id_idx,
+    om_mig_bil_parent_id_idx,
+    om_mig_bild_line_id_idx,
+    om_mig_biuld_line_id_idx,
+    om_mig_bsidl_parent_id_idx,
+    om_mig_bsidlad_line_id_idx;

--- a/tools/migrate/migrations/20260716150454_create_gathering_detail_cleanup_indexes.up.sql
+++ b/tools/migrate/migrations/20260716150454_create_gathering_detail_cleanup_indexes.up.sql
@@ -1,0 +1,14 @@
+CREATE INDEX IF NOT EXISTS om_mig_bil_fee_cfg_id_idx
+    ON billing_invoice_lines (fee_line_config_id);
+CREATE INDEX IF NOT EXISTS om_mig_bil_ubp_cfg_id_idx
+    ON billing_invoice_lines (usage_based_line_config_id);
+CREATE INDEX IF NOT EXISTS om_mig_bil_parent_id_idx
+    ON billing_invoice_lines (parent_line_id);
+CREATE INDEX IF NOT EXISTS om_mig_bild_line_id_idx
+    ON billing_invoice_line_discounts (line_id);
+CREATE INDEX IF NOT EXISTS om_mig_biuld_line_id_idx
+    ON billing_invoice_line_usage_discounts (line_id);
+CREATE INDEX IF NOT EXISTS om_mig_bsidl_parent_id_idx
+    ON billing_standard_invoice_detailed_lines (parent_line_id);
+CREATE INDEX IF NOT EXISTS om_mig_bsidlad_line_id_idx
+    ON billing_standard_invoice_detailed_line_amount_discounts (line_id);

--- a/tools/migrate/migrations/20260716150455_cleanup_gathering_invoice_details.down.sql
+++ b/tools/migrate/migrations/20260716150455_cleanup_gathering_invoice_details.down.sql
@@ -1,0 +1,1 @@
+-- Removed gathering-invoice detailed rows cannot be safely restored automatically.

--- a/tools/migrate/migrations/20260716150455_cleanup_gathering_invoice_details.up.sql
+++ b/tools/migrate/migrations/20260716150455_cleanup_gathering_invoice_details.up.sql
@@ -1,26 +1,12 @@
 BEGIN;
 
-CREATE INDEX om_mig_bil_fee_cfg_id_idx
-    ON billing_invoice_lines (fee_line_config_id);
-CREATE INDEX om_mig_bil_ubp_cfg_id_idx
-    ON billing_invoice_lines (usage_based_line_config_id);
-CREATE INDEX om_mig_bil_parent_id_idx
-    ON billing_invoice_lines (parent_line_id);
-CREATE INDEX om_mig_bild_line_id_idx
-    ON billing_invoice_line_discounts (line_id);
-CREATE INDEX om_mig_biuld_line_id_idx
-    ON billing_invoice_line_usage_discounts (line_id);
-CREATE INDEX om_mig_bsidl_parent_id_idx
-    ON billing_standard_invoice_detailed_lines (parent_line_id);
-CREATE INDEX om_mig_bsidlad_line_id_idx
-    ON billing_standard_invoice_detailed_line_amount_discounts (line_id);
-
-CREATE TABLE om_migration_backup_20260716150455_gathering_details (
+CREATE TABLE IF NOT EXISTS om_migration_backup_20260716150455_gathering_details (
+    backed_up_at TIMESTAMPTZ NOT NULL DEFAULT transaction_timestamp(),
     id VARCHAR NOT NULL,
     namespace VARCHAR NOT NULL,
     source_table TEXT NOT NULL,
     row_data JSONB NOT NULL,
-    PRIMARY KEY (source_table, namespace, id)
+    PRIMARY KEY (backed_up_at, source_table, namespace, id)
 );
 
 INSERT INTO om_migration_backup_20260716150455_gathering_details (id, namespace, source_table, row_data)
@@ -158,7 +144,8 @@ WHERE
 DELETE FROM billing_standard_invoice_detailed_line_amount_discounts d
 USING om_migration_backup_20260716150455_gathering_details b
 WHERE
-    b.source_table = 'billing_standard_invoice_detailed_line_amount_discounts'
+    b.backed_up_at = transaction_timestamp()
+    AND b.source_table = 'billing_standard_invoice_detailed_line_amount_discounts'
     AND d.id = b.id
     AND d.namespace = b.namespace;
 
@@ -170,7 +157,9 @@ BEGIN
         JOIN billing_standard_invoice_detailed_line_amount_discounts d
             ON d.line_id = b.id
             AND d.namespace = b.namespace
-        WHERE b.source_table = 'billing_standard_invoice_detailed_lines'
+        WHERE
+            b.backed_up_at = transaction_timestamp()
+            AND b.source_table = 'billing_standard_invoice_detailed_lines'
     ) THEN
         RAISE EXCEPTION 'deleting gathering invoice standard details would cascade to amount discounts';
     END IF;
@@ -180,21 +169,24 @@ $$;
 DELETE FROM billing_standard_invoice_detailed_lines dl
 USING om_migration_backup_20260716150455_gathering_details b
 WHERE
-    b.source_table = 'billing_standard_invoice_detailed_lines'
+    b.backed_up_at = transaction_timestamp()
+    AND b.source_table = 'billing_standard_invoice_detailed_lines'
     AND dl.id = b.id
     AND dl.namespace = b.namespace;
 
 DELETE FROM billing_invoice_line_discounts d
 USING om_migration_backup_20260716150455_gathering_details b
 WHERE
-    b.source_table = 'billing_invoice_line_discounts'
+    b.backed_up_at = transaction_timestamp()
+    AND b.source_table = 'billing_invoice_line_discounts'
     AND d.id = b.id
     AND d.namespace = b.namespace;
 
 DELETE FROM billing_invoice_line_usage_discounts d
 USING om_migration_backup_20260716150455_gathering_details b
 WHERE
-    b.source_table = 'billing_invoice_line_usage_discounts'
+    b.backed_up_at = transaction_timestamp()
+    AND b.source_table = 'billing_invoice_line_usage_discounts'
     AND d.id = b.id
     AND d.namespace = b.namespace;
 
@@ -206,7 +198,9 @@ BEGIN
         JOIN billing_invoice_line_discounts d
             ON d.line_id = b.id
             AND d.namespace = b.namespace
-        WHERE b.source_table = 'billing_invoice_lines'
+        WHERE
+            b.backed_up_at = transaction_timestamp()
+            AND b.source_table = 'billing_invoice_lines'
     ) THEN
         RAISE EXCEPTION 'deleting gathering invoice details would cascade to billing_invoice_line_discounts';
     END IF;
@@ -217,7 +211,9 @@ BEGIN
         JOIN billing_invoice_line_usage_discounts d
             ON d.line_id = b.id
             AND d.namespace = b.namespace
-        WHERE b.source_table = 'billing_invoice_lines'
+        WHERE
+            b.backed_up_at = transaction_timestamp()
+            AND b.source_table = 'billing_invoice_lines'
     ) THEN
         RAISE EXCEPTION 'deleting gathering invoice details would cascade to billing_invoice_line_usage_discounts';
     END IF;
@@ -228,7 +224,9 @@ BEGIN
         JOIN billing_standard_invoice_detailed_lines dl
             ON dl.parent_line_id = b.id
             AND dl.namespace = b.namespace
-        WHERE b.source_table = 'billing_invoice_lines'
+        WHERE
+            b.backed_up_at = transaction_timestamp()
+            AND b.source_table = 'billing_invoice_lines'
     ) THEN
         RAISE EXCEPTION 'deleting gathering invoice details would cascade to billing_standard_invoice_detailed_lines';
     END IF;
@@ -239,7 +237,9 @@ BEGIN
         JOIN charge_credit_purchase_invoiced_payments p
             ON p.line_id = b.id
             AND p.namespace = b.namespace
-        WHERE b.source_table = 'billing_invoice_lines'
+        WHERE
+            b.backed_up_at = transaction_timestamp()
+            AND b.source_table = 'billing_invoice_lines'
     ) THEN
         RAISE EXCEPTION 'deleting gathering invoice details would cascade to charge_credit_purchase_invoiced_payments';
     END IF;
@@ -250,7 +250,9 @@ BEGIN
         JOIN billing_invoice_lines dl
             ON dl.parent_line_id = b.id
             AND dl.namespace = b.namespace
-        WHERE b.source_table = 'billing_invoice_lines'
+        WHERE
+            b.backed_up_at = transaction_timestamp()
+            AND b.source_table = 'billing_invoice_lines'
     ) THEN
         RAISE EXCEPTION 'gathering invoice detail selected for deletion is not a leaf line';
     END IF;
@@ -260,7 +262,8 @@ $$;
 DELETE FROM billing_invoice_lines dl
 USING om_migration_backup_20260716150455_gathering_details b
 WHERE
-    b.source_table = 'billing_invoice_lines'
+    b.backed_up_at = transaction_timestamp()
+    AND b.source_table = 'billing_invoice_lines'
     AND dl.id = b.id
     AND dl.namespace = b.namespace;
 
@@ -272,7 +275,9 @@ BEGIN
         JOIN billing_invoice_lines l
             ON l.fee_line_config_id = b.id
             AND l.namespace = b.namespace
-        WHERE b.source_table = 'billing_invoice_flat_fee_line_configs'
+        WHERE
+            b.backed_up_at = transaction_timestamp()
+            AND b.source_table = 'billing_invoice_flat_fee_line_configs'
     ) THEN
         RAISE EXCEPTION 'deleting gathering invoice flat-fee configs would cascade to billing_invoice_lines';
     END IF;
@@ -283,7 +288,9 @@ BEGIN
         JOIN billing_invoice_lines l
             ON l.usage_based_line_config_id = b.id
             AND l.namespace = b.namespace
-        WHERE b.source_table = 'billing_invoice_usage_based_line_configs'
+        WHERE
+            b.backed_up_at = transaction_timestamp()
+            AND b.source_table = 'billing_invoice_usage_based_line_configs'
     ) THEN
         RAISE EXCEPTION 'deleting gathering invoice usage-based configs would cascade to billing_invoice_lines';
     END IF;
@@ -293,24 +300,17 @@ $$;
 DELETE FROM billing_invoice_flat_fee_line_configs c
 USING om_migration_backup_20260716150455_gathering_details b
 WHERE
-    b.source_table = 'billing_invoice_flat_fee_line_configs'
+    b.backed_up_at = transaction_timestamp()
+    AND b.source_table = 'billing_invoice_flat_fee_line_configs'
     AND c.id = b.id
     AND c.namespace = b.namespace;
 
 DELETE FROM billing_invoice_usage_based_line_configs c
 USING om_migration_backup_20260716150455_gathering_details b
 WHERE
-    b.source_table = 'billing_invoice_usage_based_line_configs'
+    b.backed_up_at = transaction_timestamp()
+    AND b.source_table = 'billing_invoice_usage_based_line_configs'
     AND c.id = b.id
     AND c.namespace = b.namespace;
-
-DROP INDEX
-    om_mig_bil_fee_cfg_id_idx,
-    om_mig_bil_ubp_cfg_id_idx,
-    om_mig_bil_parent_id_idx,
-    om_mig_bild_line_id_idx,
-    om_mig_biuld_line_id_idx,
-    om_mig_bsidl_parent_id_idx,
-    om_mig_bsidlad_line_id_idx;
 
 COMMIT;

--- a/tools/migrate/migrations/20260716150455_cleanup_gathering_invoice_details.up.sql
+++ b/tools/migrate/migrations/20260716150455_cleanup_gathering_invoice_details.up.sql
@@ -1,0 +1,316 @@
+BEGIN;
+
+CREATE INDEX om_mig_bil_fee_cfg_id_idx
+    ON billing_invoice_lines (fee_line_config_id);
+CREATE INDEX om_mig_bil_ubp_cfg_id_idx
+    ON billing_invoice_lines (usage_based_line_config_id);
+CREATE INDEX om_mig_bil_parent_id_idx
+    ON billing_invoice_lines (parent_line_id);
+CREATE INDEX om_mig_bild_line_id_idx
+    ON billing_invoice_line_discounts (line_id);
+CREATE INDEX om_mig_biuld_line_id_idx
+    ON billing_invoice_line_usage_discounts (line_id);
+CREATE INDEX om_mig_bsidl_parent_id_idx
+    ON billing_standard_invoice_detailed_lines (parent_line_id);
+CREATE INDEX om_mig_bsidlad_line_id_idx
+    ON billing_standard_invoice_detailed_line_amount_discounts (line_id);
+
+CREATE TABLE om_migration_backup_20260716150455_gathering_details (
+    id VARCHAR NOT NULL,
+    namespace VARCHAR NOT NULL,
+    source_table TEXT NOT NULL,
+    row_data JSONB NOT NULL,
+    PRIMARY KEY (source_table, namespace, id)
+);
+
+INSERT INTO om_migration_backup_20260716150455_gathering_details (id, namespace, source_table, row_data)
+SELECT dl.id, dl.namespace, 'billing_invoice_lines', to_jsonb(dl)
+FROM billing_invoices i
+JOIN billing_invoice_lines l
+    ON l.invoice_id = i.id
+    AND l.namespace = i.namespace
+JOIN billing_invoice_lines dl
+    ON dl.invoice_id = i.id
+    AND dl.namespace = i.namespace
+    AND dl.parent_line_id = l.id
+WHERE
+    i.status = 'gathering'
+    AND l.parent_line_id IS NULL
+    AND l.status = 'valid'
+    AND l.type = 'usage_based'
+    AND dl.status = 'detailed';
+
+INSERT INTO om_migration_backup_20260716150455_gathering_details (id, namespace, source_table, row_data)
+SELECT d.id, d.namespace, 'billing_invoice_line_discounts', to_jsonb(d)
+FROM billing_invoices i
+JOIN billing_invoice_lines l
+    ON l.invoice_id = i.id
+    AND l.namespace = i.namespace
+JOIN billing_invoice_lines dl
+    ON dl.invoice_id = i.id
+    AND dl.namespace = i.namespace
+    AND dl.parent_line_id = l.id
+JOIN billing_invoice_line_discounts d
+    ON d.line_id = dl.id
+    AND d.namespace = dl.namespace
+WHERE
+    i.status = 'gathering'
+    AND l.parent_line_id IS NULL
+    AND l.status = 'valid'
+    AND l.type = 'usage_based'
+    AND dl.status = 'detailed';
+
+INSERT INTO om_migration_backup_20260716150455_gathering_details (id, namespace, source_table, row_data)
+SELECT d.id, d.namespace, 'billing_invoice_line_usage_discounts', to_jsonb(d)
+FROM billing_invoices i
+JOIN billing_invoice_lines l
+    ON l.invoice_id = i.id
+    AND l.namespace = i.namespace
+JOIN billing_invoice_lines dl
+    ON dl.invoice_id = i.id
+    AND dl.namespace = i.namespace
+    AND dl.parent_line_id = l.id
+JOIN billing_invoice_line_usage_discounts d
+    ON d.line_id = dl.id
+    AND d.namespace = dl.namespace
+WHERE
+    i.status = 'gathering'
+    AND l.parent_line_id IS NULL
+    AND l.status = 'valid'
+    AND l.type = 'usage_based'
+    AND dl.status = 'detailed';
+
+INSERT INTO om_migration_backup_20260716150455_gathering_details (id, namespace, source_table, row_data)
+SELECT c.id, c.namespace, 'billing_invoice_flat_fee_line_configs', to_jsonb(c)
+FROM billing_invoices i
+JOIN billing_invoice_lines l
+    ON l.invoice_id = i.id
+    AND l.namespace = i.namespace
+JOIN billing_invoice_lines dl
+    ON dl.invoice_id = i.id
+    AND dl.namespace = i.namespace
+    AND dl.parent_line_id = l.id
+JOIN billing_invoice_flat_fee_line_configs c
+    ON c.id = dl.fee_line_config_id
+    AND c.namespace = dl.namespace
+WHERE
+    i.status = 'gathering'
+    AND l.parent_line_id IS NULL
+    AND l.status = 'valid'
+    AND l.type = 'usage_based'
+    AND dl.status = 'detailed';
+
+INSERT INTO om_migration_backup_20260716150455_gathering_details (id, namespace, source_table, row_data)
+SELECT c.id, c.namespace, 'billing_invoice_usage_based_line_configs', to_jsonb(c)
+FROM billing_invoices i
+JOIN billing_invoice_lines l
+    ON l.invoice_id = i.id
+    AND l.namespace = i.namespace
+JOIN billing_invoice_lines dl
+    ON dl.invoice_id = i.id
+    AND dl.namespace = i.namespace
+    AND dl.parent_line_id = l.id
+JOIN billing_invoice_usage_based_line_configs c
+    ON c.id = dl.usage_based_line_config_id
+    AND c.namespace = dl.namespace
+WHERE
+    i.status = 'gathering'
+    AND l.parent_line_id IS NULL
+    AND l.status = 'valid'
+    AND l.type = 'usage_based'
+    AND dl.status = 'detailed';
+
+INSERT INTO om_migration_backup_20260716150455_gathering_details (id, namespace, source_table, row_data)
+SELECT dl.id, dl.namespace, 'billing_standard_invoice_detailed_lines', to_jsonb(dl)
+FROM billing_invoices i
+JOIN billing_invoice_lines l
+    ON l.invoice_id = i.id
+    AND l.namespace = i.namespace
+JOIN billing_standard_invoice_detailed_lines dl
+    ON dl.invoice_id = i.id
+    AND dl.namespace = i.namespace
+    AND dl.parent_line_id = l.id
+WHERE
+    i.status = 'gathering'
+    AND l.parent_line_id IS NULL
+    AND l.status = 'valid'
+    AND l.type = 'usage_based';
+
+INSERT INTO om_migration_backup_20260716150455_gathering_details (id, namespace, source_table, row_data)
+SELECT d.id, d.namespace, 'billing_standard_invoice_detailed_line_amount_discounts', to_jsonb(d)
+FROM billing_invoices i
+JOIN billing_invoice_lines l
+    ON l.invoice_id = i.id
+    AND l.namespace = i.namespace
+JOIN billing_standard_invoice_detailed_lines dl
+    ON dl.invoice_id = i.id
+    AND dl.namespace = i.namespace
+    AND dl.parent_line_id = l.id
+JOIN billing_standard_invoice_detailed_line_amount_discounts d
+    ON d.line_id = dl.id
+    AND d.namespace = dl.namespace
+WHERE
+    i.status = 'gathering'
+    AND l.parent_line_id IS NULL
+    AND l.status = 'valid'
+    AND l.type = 'usage_based';
+
+DELETE FROM billing_standard_invoice_detailed_line_amount_discounts d
+USING om_migration_backup_20260716150455_gathering_details b
+WHERE
+    b.source_table = 'billing_standard_invoice_detailed_line_amount_discounts'
+    AND d.id = b.id
+    AND d.namespace = b.namespace;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM om_migration_backup_20260716150455_gathering_details b
+        JOIN billing_standard_invoice_detailed_line_amount_discounts d
+            ON d.line_id = b.id
+            AND d.namespace = b.namespace
+        WHERE b.source_table = 'billing_standard_invoice_detailed_lines'
+    ) THEN
+        RAISE EXCEPTION 'deleting gathering invoice standard details would cascade to amount discounts';
+    END IF;
+END
+$$;
+
+DELETE FROM billing_standard_invoice_detailed_lines dl
+USING om_migration_backup_20260716150455_gathering_details b
+WHERE
+    b.source_table = 'billing_standard_invoice_detailed_lines'
+    AND dl.id = b.id
+    AND dl.namespace = b.namespace;
+
+DELETE FROM billing_invoice_line_discounts d
+USING om_migration_backup_20260716150455_gathering_details b
+WHERE
+    b.source_table = 'billing_invoice_line_discounts'
+    AND d.id = b.id
+    AND d.namespace = b.namespace;
+
+DELETE FROM billing_invoice_line_usage_discounts d
+USING om_migration_backup_20260716150455_gathering_details b
+WHERE
+    b.source_table = 'billing_invoice_line_usage_discounts'
+    AND d.id = b.id
+    AND d.namespace = b.namespace;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM om_migration_backup_20260716150455_gathering_details b
+        JOIN billing_invoice_line_discounts d
+            ON d.line_id = b.id
+            AND d.namespace = b.namespace
+        WHERE b.source_table = 'billing_invoice_lines'
+    ) THEN
+        RAISE EXCEPTION 'deleting gathering invoice details would cascade to billing_invoice_line_discounts';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM om_migration_backup_20260716150455_gathering_details b
+        JOIN billing_invoice_line_usage_discounts d
+            ON d.line_id = b.id
+            AND d.namespace = b.namespace
+        WHERE b.source_table = 'billing_invoice_lines'
+    ) THEN
+        RAISE EXCEPTION 'deleting gathering invoice details would cascade to billing_invoice_line_usage_discounts';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM om_migration_backup_20260716150455_gathering_details b
+        JOIN billing_standard_invoice_detailed_lines dl
+            ON dl.parent_line_id = b.id
+            AND dl.namespace = b.namespace
+        WHERE b.source_table = 'billing_invoice_lines'
+    ) THEN
+        RAISE EXCEPTION 'deleting gathering invoice details would cascade to billing_standard_invoice_detailed_lines';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM om_migration_backup_20260716150455_gathering_details b
+        JOIN charge_credit_purchase_invoiced_payments p
+            ON p.line_id = b.id
+            AND p.namespace = b.namespace
+        WHERE b.source_table = 'billing_invoice_lines'
+    ) THEN
+        RAISE EXCEPTION 'deleting gathering invoice details would cascade to charge_credit_purchase_invoiced_payments';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM om_migration_backup_20260716150455_gathering_details b
+        JOIN billing_invoice_lines dl
+            ON dl.parent_line_id = b.id
+            AND dl.namespace = b.namespace
+        WHERE b.source_table = 'billing_invoice_lines'
+    ) THEN
+        RAISE EXCEPTION 'gathering invoice detail selected for deletion is not a leaf line';
+    END IF;
+END
+$$;
+
+DELETE FROM billing_invoice_lines dl
+USING om_migration_backup_20260716150455_gathering_details b
+WHERE
+    b.source_table = 'billing_invoice_lines'
+    AND dl.id = b.id
+    AND dl.namespace = b.namespace;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM om_migration_backup_20260716150455_gathering_details b
+        JOIN billing_invoice_lines l
+            ON l.fee_line_config_id = b.id
+            AND l.namespace = b.namespace
+        WHERE b.source_table = 'billing_invoice_flat_fee_line_configs'
+    ) THEN
+        RAISE EXCEPTION 'deleting gathering invoice flat-fee configs would cascade to billing_invoice_lines';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1
+        FROM om_migration_backup_20260716150455_gathering_details b
+        JOIN billing_invoice_lines l
+            ON l.usage_based_line_config_id = b.id
+            AND l.namespace = b.namespace
+        WHERE b.source_table = 'billing_invoice_usage_based_line_configs'
+    ) THEN
+        RAISE EXCEPTION 'deleting gathering invoice usage-based configs would cascade to billing_invoice_lines';
+    END IF;
+END
+$$;
+
+DELETE FROM billing_invoice_flat_fee_line_configs c
+USING om_migration_backup_20260716150455_gathering_details b
+WHERE
+    b.source_table = 'billing_invoice_flat_fee_line_configs'
+    AND c.id = b.id
+    AND c.namespace = b.namespace;
+
+DELETE FROM billing_invoice_usage_based_line_configs c
+USING om_migration_backup_20260716150455_gathering_details b
+WHERE
+    b.source_table = 'billing_invoice_usage_based_line_configs'
+    AND c.id = b.id
+    AND c.namespace = b.namespace;
+
+DROP INDEX
+    om_mig_bil_fee_cfg_id_idx,
+    om_mig_bil_ubp_cfg_id_idx,
+    om_mig_bil_parent_id_idx,
+    om_mig_bild_line_id_idx,
+    om_mig_biuld_line_id_idx,
+    om_mig_bsidl_parent_id_idx,
+    om_mig_bsidlad_line_id_idx;
+
+COMMIT;

--- a/tools/migrate/migrations/20260716150456_drop_gathering_detail_cleanup_indexes.down.sql
+++ b/tools/migrate/migrations/20260716150456_drop_gathering_detail_cleanup_indexes.down.sql
@@ -1,0 +1,14 @@
+CREATE INDEX IF NOT EXISTS om_mig_bil_fee_cfg_id_idx
+    ON billing_invoice_lines (fee_line_config_id);
+CREATE INDEX IF NOT EXISTS om_mig_bil_ubp_cfg_id_idx
+    ON billing_invoice_lines (usage_based_line_config_id);
+CREATE INDEX IF NOT EXISTS om_mig_bil_parent_id_idx
+    ON billing_invoice_lines (parent_line_id);
+CREATE INDEX IF NOT EXISTS om_mig_bild_line_id_idx
+    ON billing_invoice_line_discounts (line_id);
+CREATE INDEX IF NOT EXISTS om_mig_biuld_line_id_idx
+    ON billing_invoice_line_usage_discounts (line_id);
+CREATE INDEX IF NOT EXISTS om_mig_bsidl_parent_id_idx
+    ON billing_standard_invoice_detailed_lines (parent_line_id);
+CREATE INDEX IF NOT EXISTS om_mig_bsidlad_line_id_idx
+    ON billing_standard_invoice_detailed_line_amount_discounts (line_id);

--- a/tools/migrate/migrations/20260716150456_drop_gathering_detail_cleanup_indexes.up.sql
+++ b/tools/migrate/migrations/20260716150456_drop_gathering_detail_cleanup_indexes.up.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS
+    om_mig_bil_fee_cfg_id_idx,
+    om_mig_bil_ubp_cfg_id_idx,
+    om_mig_bil_parent_id_idx,
+    om_mig_bild_line_id_idx,
+    om_mig_biuld_line_id_idx,
+    om_mig_bsidl_parent_id_idx,
+    om_mig_bsidlad_line_id_idx;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:Ux/p2BEXeTyc2T6f49M3OT6jB++9XJGWcF2xgvB1ikw=
+h1:pD8amlaJqQ4l47KWTH/dmX/J0xSjGUAoxkQ0ZxOjFTk=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -233,4 +233,6 @@ h1:Ux/p2BEXeTyc2T6f49M3OT6jB++9XJGWcF2xgvB1ikw=
 20260714144104_consolidate_usage_based_realization_statuses.up.sql h1:ihKrZw9u8mv3TxideKQB5ZeakiKVfjf6UeLidLGPRoU=
 20260716092057_create_billing_gathering_invoice_lines.up.sql h1:mdYbF8T8Y/i9RX1R3CIHEk31QtRINRQZK1yYT7wi4/U=
 20260716121405_repair_flat_price_usage_discounts.up.sql h1:d6LekUgFwwqDpNVQHJokrIoiu3ic6p40rfcQxshMTn8=
-20260716150455_cleanup_gathering_invoice_details.up.sql h1:yPyofY9Xoud1vYVlHjsWJ3I/J7D62TIfCDKJS5h7sBU=
+20260716150454_create_gathering_detail_cleanup_indexes.up.sql h1:5d1aWsv+0mzERisQ5Ht29pbjsiOrK2Qpou6x9BgCli4=
+20260716150455_cleanup_gathering_invoice_details.up.sql h1:W4u33tHXJy+GfryC8j46bHi2SiQwDk6brBOex/fQ4rw=
+20260716150456_drop_gathering_detail_cleanup_indexes.up.sql h1:IJ6P54dqEy/LFG9hID2T9yBoN29FRTH/iLTSSTkdpDQ=

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:iSvCCB9fIcc1aGpnZM1y7mVSAFZ+/0RQukbmdyopjWU=
+h1:Ux/p2BEXeTyc2T6f49M3OT6jB++9XJGWcF2xgvB1ikw=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -233,3 +233,4 @@ h1:iSvCCB9fIcc1aGpnZM1y7mVSAFZ+/0RQukbmdyopjWU=
 20260714144104_consolidate_usage_based_realization_statuses.up.sql h1:ihKrZw9u8mv3TxideKQB5ZeakiKVfjf6UeLidLGPRoU=
 20260716092057_create_billing_gathering_invoice_lines.up.sql h1:mdYbF8T8Y/i9RX1R3CIHEk31QtRINRQZK1yYT7wi4/U=
 20260716121405_repair_flat_price_usage_discounts.up.sql h1:d6LekUgFwwqDpNVQHJokrIoiu3ic6p40rfcQxshMTn8=
+20260716150455_cleanup_gathering_invoice_details.up.sql h1:yPyofY9Xoud1vYVlHjsWJ3I/J7D62TIfCDKJS5h7sBU=


### PR DESCRIPTION
## Overview

Remove invalid detailed rows attached to gathering invoice lines before the remaining standard invoices are migrated to billing schema level 2.

The code before the billing refactor in Jan 2026 have sometimes persisted detailed lines, for gathering invoices which is an invalid state.

This patch cleans it up as preparation for invoice schema 2 migration.

## Changes

- Find legacy and schema-level-2 detailed rows through the full invoice -> gathering line -> detailed line hierarchy.
- Back up every row selected for deletion in `om_migration_backup_20260716150455_gathering_details`, including its source table, namespace, ID, and full JSON representation.
- Delete discounts, detailed lines, and their line configs from leaf to parent.
- Fail before deletion if an unexpected dependent row would be cascade-deleted or if a selected legacy detailed line is not a leaf.
- Create only the helper indexes required by the cleanup and drop them before the transaction commits.
- Exclude persistent migration backup tables from Atlas schema-drift checks.

The cleanup does not acquire billing customer locks because these invalid gathering details are not loaded or mutated by billing.

The migration is intentionally irreversible because the removed legacy data cannot be safely restored automatically. The persistent backup table remains available for manual recovery.

## Validation

- `atlas migrate --env local lint --latest 2`
- `atlas migrate --env local validate`
- `atlas migrate --env local diff migrate-check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Data Maintenance**
  - Added a controlled cleanup for obsolete gathering-related invoice details and configurations.
  - Preserves affected records in a backup table before removal.
  - Added safeguards to prevent unexpected cascading deletions and ensure only eligible records are removed.

- **Performance**
  - Added supporting database indexes to improve cleanup and billing-detail lookups.

- **Migration Safety**
  - Migration validation now excludes temporary backup tables.
  - Rollback documentation notes that deleted detail rows cannot be automatically restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes invalid detailed rows from gathering invoices before the remaining schema-level-2 migration. The main changes are:

- Backs up selected rows with their source table and full JSON data.
- Deletes discounts, detailed lines, and line configs from leaf to parent.
- Adds guards against unexpected cascades and non-leaf deletions.
- Creates and removes temporary indexes for the cleanup.
- Excludes persistent migration backup tables from Atlas drift checks.

<h3>Confidence Score: 5/5</h3>

No additional blocking issue qualifies for this follow-up review.

- No new incomplete or unsafe fix remains to report within the allowed follow-up scope.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tools/migrate/migrations/20260716150455_cleanup_gathering_invoice_details.up.sql | Backs up and deletes invalid gathering-invoice details with checks for dependent rows and non-leaf lines. |
| tools/migrate/migrations/20260716150455_cleanup_gathering_invoice_details.down.sql | Documents that the data cleanup cannot be reversed automatically. |
| tools/migrate/migrations/20260716150454_create_gathering_detail_cleanup_indexes.up.sql | Creates temporary indexes for the cleanup queries. |
| tools/migrate/migrations/20260716150456_drop_gathering_detail_cleanup_indexes.up.sql | Removes the temporary cleanup indexes. |
| atlas.hcl | Excludes persistent migration backup tables from schema-drift checks. |

<sub>Reviews (5): Last reviewed commit: ["fix: make gathering detail cleanup rerun..."](https://github.com/openmeterio/openmeter/commit/c886c3557c063847d175ae85f398b5f7a8f6d543) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44774482)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))

<!-- /greptile_comment -->