### PR TITLE
feat(taxcode): seed default Stripe tax codes at server startup

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -132,6 +132,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Provision default tax codes
+	err = app.TaxCodeService.ProvisionDefaultTaxCodes(ctx, app.NamespaceManager.GetDefaultNamespace())
+	if err != nil {
+		logger.Error("failed to provision default tax codes", "error", err)
+		os.Exit(1)
+	}
+
 	// Create meters from config
 	err = app.MeterConfigInitializer(ctx)
 	if err != nil {

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1904,6 +1904,10 @@ func (n NoopTaxCodeService) GetOrCreateByAppMapping(ctx context.Context, input t
 	return taxcode.TaxCode{}, nil
 }
 
+func (n NoopTaxCodeService) ProvisionDefaultTaxCodes(ctx context.Context, namespace string) error {
+	return nil
+}
+
 // SubjectService methods
 
 var _ subject.Service = &NoopSubjectService{}

--- a/openmeter/taxcode/defaults.go
+++ b/openmeter/taxcode/defaults.go
@@ -1,0 +1,57 @@
+package taxcode
+
+import "github.com/samber/lo"
+
+// DefaultTaxCodeSeed holds the minimal inputs needed to seed one well-known tax code.
+type DefaultTaxCodeSeed struct {
+	Key         string
+	Name        string
+	Description *string
+	StripeCode  string
+}
+
+// DefaultStripeTaxCodes is a curated list of commonly used Stripe tax codes for
+// software and SaaS businesses. These are seeded at startup so users can browse
+// and select from known codes without having to look up Stripe-specific identifiers.
+//
+// Keys follow the same convention used by GetOrCreateByAppMapping: "stripe_<code>".
+// This ensures that if a code was already auto-created by the billing flow, the
+// seed CreateTaxCode call will hit the unique constraint and be silently skipped.
+var DefaultStripeTaxCodes = []DefaultTaxCodeSeed{
+	{
+		Key:         "stripe_txcd_00000000",
+		Name:        "Non-taxable",
+		Description: lo.ToPtr("Use for products or services that are explicitly exempt from tax."),
+		StripeCode:  "txcd_00000000",
+	},
+	{
+		Key:         "stripe_txcd_10103001",
+		Name:        "SaaS - Business Use",
+		Description: lo.ToPtr("Software as a Service intended for business use."),
+		StripeCode:  "txcd_10103001",
+	},
+	{
+		Key:         "stripe_txcd_10101000",
+		Name:        "Infrastructure as a Service (IaaS)",
+		Description: lo.ToPtr("Cloud infrastructure services such as compute, storage, and networking."),
+		StripeCode:  "txcd_10101000",
+	},
+	{
+		Key:         "stripe_txcd_10102000",
+		Name:        "Platform as a Service (PaaS)",
+		Description: lo.ToPtr("Cloud platform services providing a managed environment for building and deploying applications."),
+		StripeCode:  "txcd_10102000",
+	},
+	{
+		Key:         "stripe_txcd_10000000",
+		Name:        "Digital Goods - General",
+		Description: lo.ToPtr("General category for digital goods and electronically supplied services. Use when no more specific code applies."),
+		StripeCode:  "txcd_10000000",
+	},
+	{
+		Key:         "stripe_txcd_20030000",
+		Name:        "Professional Services",
+		Description: lo.ToPtr("Consulting, advisory, and other professional services."),
+		StripeCode:  "txcd_20030000",
+	},
+}

--- a/openmeter/taxcode/service.go
+++ b/openmeter/taxcode/service.go
@@ -17,6 +17,11 @@ type Service interface {
 	GetTaxCodeByAppMapping(ctx context.Context, input GetTaxCodeByAppMappingInput) (TaxCode, error)
 	GetOrCreateByAppMapping(ctx context.Context, input GetOrCreateByAppMappingInput) (TaxCode, error)
 	DeleteTaxCode(ctx context.Context, input DeleteTaxCodeInput) error
+
+	// ProvisionDefaultTaxCodes seeds the well-known Stripe tax codes defined in
+	// DefaultStripeTaxCodes into the given namespace. The operation is idempotent:
+	// codes that already exist (matched by key) are silently skipped.
+	ProvisionDefaultTaxCodes(ctx context.Context, namespace string) error
 }
 
 var (

--- a/openmeter/taxcode/service/taxcode.go
+++ b/openmeter/taxcode/service/taxcode.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -122,5 +123,30 @@ func (s *service) DeleteTaxCode(ctx context.Context, input taxcode.DeleteTaxCode
 
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
 		return s.adapter.DeleteTaxCode(ctx, input)
+	})
+}
+
+// ProvisionDefaultTaxCodes seeds the well-known Stripe tax codes from
+// taxcode.DefaultStripeTaxCodes into the given namespace inside a single
+// transaction. Already-existing codes (matched by key) are silently skipped,
+// making the call idempotent.
+func (s *service) ProvisionDefaultTaxCodes(ctx context.Context, namespace string) error {
+	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
+		for _, seed := range taxcode.DefaultStripeTaxCodes {
+			_, err := s.adapter.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+				Namespace:   namespace,
+				Key:         seed.Key,
+				Name:        seed.Name,
+				Description: seed.Description,
+				AppMappings: taxcode.TaxCodeAppMappings{
+					{AppType: app.AppTypeStripe, TaxCode: seed.StripeCode},
+				},
+			})
+			if err != nil && !models.IsGenericConflictError(err) {
+				return fmt.Errorf("failed to provision default tax code %q: %w", seed.Key, err)
+			}
+		}
+
+		return nil
 	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default tax codes are now automatically provisioned during server startup, making a curated set of Stripe tax codes immediately available for use in your system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->