### PR TITLE
chore: add pr-precheck skill

### DIFF
--- a/.agents/skills/pr-precheck/SKILL.md
+++ b/.agents/skills/pr-precheck/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: pr-precheck
+description: >
+  Performs a lightweight PR pre-check. Validates Go naming, repository layering
+  (Postgres/ClickHouse/Kafka), CloudEvents compliance, and logic placement in OpenMeter.
+  Use when asked to review changes, check code, or run a PR precheck.
+tools: Bash Glob Grep Read
+---
+
+# OpenMeter PR Pre-check Skill
+
+You are an expert Go developer and core maintainer of the `openmeterio/openmeter` repository. Your task is to review the current diff or proposed changes against OpenMeter's strict architectural and styling standards.
+
+Execute this review quickly and concisely.
+
+## 1. Architectural Layers & Logic Placement
+OpenMeter relies on a highly optimized stack for real-time event ingestion and billing. Ensure changes respect the following boundaries:
+* **API Layer (TypeSpec/Handlers):** Must remain thin. Complex business logic should not reside in API handlers.
+* **PostgreSQL (Ent ORM):** Used ONLY for billing, subscriptions, entitlements, and the product catalog.
+* **ClickHouse:** Used ONLY for real-time usage aggregation and analytics. Driver-specific logic should not leak into core domain services.
+* **Kafka:** Used for the event streaming and ingestion pipeline.
+* **Leaky Abstractions:** Ensure infrastructure types (e.g., Kafka message headers, specific ClickHouse row types, or Ent models) do not leak into outer domain logic or APIs. Dependency direction must point inward (API -> Service -> Repository).
+
+## 2. Domain & Data Patterns
+* **CloudEvents:** OpenMeter ingests events in the CloudEvents format. Any changes to event ingestion must strictly validate or adhere to the CloudEvents schema (`id`, `source`, `subject`, `type`, `time`, `data`).
+* **Event Deduplication:** Ensure any ingestion modifications respect deduplication logic (handled via `id` and `source` fields).
+* **Meters:** Check that aggregations use supported types (SUM, COUNT, AVG, MIN, MAX).
+
+## 3. Go Coding Standards
+* **Context:** Every exported function handling requests, database calls, or streams must accept `context.Context` as its first argument.
+* **Interfaces:** Interface names should generally end in `-er` (e.g., `EventProcessor`, `MeterFetcher`) and be defined close to where they are used.
+* **Error Handling:** Errors must be wrapped cleanly using `fmt.Errorf("doing action: %w", err)`.
+* **Naming:** Slugs and meters should ideally follow standard SI suffixing where applicable (e.g., `_total`, `_seconds`).
+
+## 4. Potential Bugs & Safety Checks
+Actively scan the diff for common Go pitfalls and logic bugs:
+* **Resource Leaks:** Ensure database rows, HTTP response bodies, and file handles are properly closed (e.g., `defer rows.Close()`).
+* **Concurrency Hazards:** Look for unsafe map access across goroutines, missing mutexes, or potential goroutine leaks (e.g., launching a goroutine that might block forever).
+* **Nil Pointers:** Check that structs or interfaces are safely initialized before dereferencing, especially when dealing with optional JSON fields or database queries that might return empty results.
+* **Unhandled Errors:** Ensure all returned errors are checked (`if err != nil`) rather than silently swallowed.
+
+## 5. Execution Protocol
+1. **Check for changes:** Run `git diff HEAD`.
+2. **Empty Diff Check:** If the output of `git diff HEAD` is empty, output exactly: **"No changes detected. The git diff HEAD is empty."** and **STOP** immediately. Do not perform any further analysis.
+3. **Review:** If changes are present, review the files and output a clean, categorized summary:
+    * **✅ Passes:** Brief list of OpenMeter patterns correctly followed.
+    * **⚠️ Warnings:** Minor style issues, Go naming nits, or missing tests.
+    * **🐛 Bugs:** Potential logic flaws, unhandled errors, panics, or resource leaks.
+    * **❌ Blockers:** Architectural violations (e.g., leaky abstractions, Ent ORM logic in ClickHouse repos, bloated API handlers).
+
+Do not output the full code; only provide the review feedback.


### PR DESCRIPTION
Add pr-precheck skill to agents. The purpose is improve your self-review skills and save time to not wait for coderabbit and CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated pre-check validation for pull requests to enforce architectural boundaries, domain compliance requirements, coding standards, and safety protocols during code review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->