### PR TITLE
fix(subs-sync): startup when credits are disabled

### DIFF
--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/reconciler.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/reconciler.go
@@ -202,7 +202,11 @@ func filterInScopeLines(inScopeLines []targetstate.StateItem, patchCollections *
 
 func (s *Service) Plan(ctx context.Context, input PlanInput) (*Plan, error) {
 	if input.Subscription.SettlementMode == productcatalog.CreditOnlySettlementMode && s.chargesService == nil {
-		return nil, fmt.Errorf("credit only settlement mode is not supported without charges service enabled")
+		s.logger.DebugContext(ctx, "skipping credit-only subscription reconciliation because charges service is disabled", "subscription_id", input.Subscription.ID)
+
+		return &Plan{
+			SubscriptionMaxGenerationTimeLimit: input.Target.MaxGenerationTimeLimit,
+		}, nil
 	}
 
 	patchCollections, err := newPatchCollectionRouter(len(input.Target.Items)+len(input.Persisted.ByUniqueID), input.Persisted.Invoices)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

To make sure if credits_only config leaks into subscriptions in a disabled environment we still don't error on sync

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of credit-only subscriptions when the charges service is disabled. The system now gracefully processes these subscriptions by providing generation time limits instead of returning errors, while optimizing reconciliation by skipping unnecessary patch-planning operations to improve billing operation stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->