### PR TITLE
fix: adjust flat-fee shape to match usage-based

### DIFF
--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -57,7 +57,15 @@ Important types:
 - `meta.Charge` and `meta.ChargeID` define the shared charge identity and type
 - `charges.Charge` wraps concrete charge variants
 - `flatfee.Intent` carries `AmountBeforeProration`, `ProRating`, `SettlementMode`, `PaymentTerm`, `InvoiceAt` — immutable inputs provided by the caller
-- `flatfee.State` carries `AmountAfterProration`, `AdvanceAfter`, `CreditRealizations`, `AccruedUsage`, `Payment` — computed/mutable state persisted in DB
+- `flatfee.ChargeBase` stores the persisted flat-fee charge row: current `Status` plus durable `State`
+- `flatfee.State` currently tracks:
+  - `AmountAfterProration`
+  - `AdvanceAfter`
+  - `FeatureID`
+- `flatfee.Realizations` stores expanded, non-base data loaded from child tables:
+  - `CreditRealizations`
+  - `AccruedUsage`
+  - `Payment`
 - `flatfee.Intent.CalculateAmountAfterProration()` computes the prorated amount from `AmountBeforeProration`, `ServicePeriod/FullServicePeriod` ratio, and `ProRating` config, with currency-precision rounding
 - Charge-backed targets do not use invoice-style semantic proration or empty-period filtering; the charge stack materializes and prorates state itself, and the flat fee charge is responsible for omitting empty lines
 - `usagebased.Intent` carries `FeatureKey`, `Price`, `SettlementMode`, `InvoiceAt`, and `ServicePeriod`
@@ -323,8 +331,8 @@ Key differences from usage-based credits-only:
 - No collection period, no two-phase realization
 - Amount is computed at creation from `Intent.AmountBeforeProration` and stored in `State.AmountAfterProration`, no meter snapshot or rating
 - No `FeatureMeter` or `CustomerOverride` needed
-- Uses `meta.ChargeStatus` directly (not sub-statuses like `active.final_realization.*`)
-- The flat fee adapter's `UpdateCharge(...)` takes a full `flatfee.Charge` (not `ChargeBase`)
+- Uses `flatfee.Status` with only top-level states (not sub-statuses like `active.final_realization.*`)
+- Persists only `flatfee.ChargeBase`; credit allocations / payment / accrued usage live in `flatfee.Realizations`
 
 Service construction requires a `*lockr.Locker` (same as usage-based).
 
@@ -388,14 +396,14 @@ Charge status persistence is split across:
 - the shared meta charge row
 - the charge-type-specific row
 
-For usage-based charges:
+For usage-based and flat-fee charges:
 
 When status changes:
 
 - update the meta charge status to the short/meta status
-- update the usage-based charge status to the full usage-based status
+- update the type-specific charge `status_detailed` to the full type-specific status
 
-`usagebased.Status.ToMetaChargeStatus()` is the bridge between the full state-machine status and the root charge meta status.
+`usagebased.Status.ToMetaChargeStatus()` and `flatfee.Status.ToMetaChargeStatus()` are the bridges between the full state-machine status and the root charge meta status.
 
 ## Testing Guidance
 
@@ -464,10 +472,13 @@ When changing flat-fee charges:
 
 - the invoiced path (CreditThenInvoice/InvoiceOnly) starts as `Active` and is driven by invoice lifecycle hooks
 - the credit-only path starts as `Created` and is driven by the state machine — do not mix the two
-- `AmountAfterProration` lives on `flatfee.State`, not `flatfee.Intent` — it is computed at creation via `Intent.CalculateAmountAfterProration()` and persisted. Callers must not provide it; they set `AmountBeforeProration`, `ServicePeriod`, `FullServicePeriod`, and `ProRating` on the Intent
+- `AmountAfterProration` lives on `flatfee.State`, not `flatfee.Intent` — it is computed at creation via `Intent.CalculateAmountAfterProration()` and persisted on the base charge row. Callers must not provide it; they set `AmountBeforeProration`, `ServicePeriod`, `FullServicePeriod`, and `ProRating` on the Intent
 - `IntentWithInitialStatus` carries `AmountAfterProration` alongside `InitialStatus` to pass the computed value from the service to the adapter at creation time
 - `flatfee.State.AdvanceAfter` must be passed through `chargemeta.UpdateInput.AdvanceAfter` on every `UpdateCharge(...)` call
-- `flatfee.Adapter.UpdateCharge(...)` takes the full `flatfee.Charge`, not a `ChargeBase` — extract `State.AdvanceAfter` when building `chargemeta.UpdateInput`
+- `flatfee.Adapter.UpdateCharge(...)` takes `flatfee.ChargeBase` and persists only base-row fields; do not call it just because `flatfee.Realizations` changed
+- `CreatePayment(...)`, `UpdatePayment(...)`, `CreateInvoicedUsage(...)`, and `CreateCreditAllocations(...)` already persist the realization-side rows; a follow-up `UpdateCharge(...)` is redundant unless base-row fields changed too
+- `flatfee.Charge.Realizations` is expand-only data loaded from child tables; tests and service code should read payment/accrued-usage/credit-allocation state there, not from `flatfee.State`
+- `charge_flat_fees.status_detailed` mirrors `status` today; schema changes or migrations that introduce new flat-fee statuses must keep both columns consistent through `ToMetaChargeStatus()`
 - the `flatfee.Handler` interface has both invoiced-path methods and credits-only methods — implementors must satisfy all of them
 - adding new `Handler` methods requires updating: `ledger/chargeadapter/flatfee.go`, `test/credits/mockledger.go`, `charges/service/handlers_test.go`
 - the same applies to `usagebased.Handler` — new methods must be added to `UnimplementedHandler`, the ledger adapter, and the test handler

--- a/openmeter/billing/charges/adapter/search_test.go
+++ b/openmeter/billing/charges/adapter/search_test.go
@@ -87,6 +87,7 @@ func (s *ListCustomersToAdvanceSuite) insertFlatFeeCharge(namespace, customerID 
 		SetNamespace(namespace).
 		SetCustomerID(customerID).
 		SetStatus(status).
+		SetStatusDetailed(flatfee.Status(status)).
 		SetCurrency(currencyx.Code("USD")).
 		SetManagedBy(billing.SubscriptionManagedLine).
 		SetName("test-charge").

--- a/openmeter/billing/charges/flatfee/adapter.go
+++ b/openmeter/billing/charges/flatfee/adapter.go
@@ -68,6 +68,7 @@ func (i IntentWithInitialStatus) Validate() error {
 			errs = append(errs, fmt.Errorf("initial status: %w", err))
 		}
 	}
+
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 

--- a/openmeter/billing/charges/flatfee/adapter.go
+++ b/openmeter/billing/charges/flatfee/adapter.go
@@ -16,26 +16,39 @@ import (
 )
 
 type Adapter interface {
+	ChargeAdapter
+	ChargeCreditAllocationAdapter
+	ChargeInvoicedUsageAdapter
+	ChargePaymentAdapter
+
+	entutils.TxCreator
+}
+
+type ChargeAdapter interface {
 	CreateCharges(ctx context.Context, charges CreateChargesInput) ([]Charge, error)
-	UpdateCharge(ctx context.Context, charge Charge) error
+	UpdateCharge(ctx context.Context, charge ChargeBase) (ChargeBase, error)
 	DeleteCharge(ctx context.Context, charge Charge) error
 	GetByIDs(ctx context.Context, ids GetByIDsInput) ([]Charge, error)
 	GetByID(ctx context.Context, id GetByIDInput) (Charge, error)
+}
 
+type ChargeInvoicedUsageAdapter interface {
 	CreateInvoicedUsage(ctx context.Context, chargeID meta.ChargeID, invoicedUsage invoicedusage.AccruedUsage) (invoicedusage.AccruedUsage, error)
+}
 
+type ChargeCreditAllocationAdapter interface {
 	CreateCreditAllocations(ctx context.Context, chargeID meta.ChargeID, creditAllocations creditrealization.CreateInputs) (creditrealization.Realizations, error)
+}
 
+type ChargePaymentAdapter interface {
 	CreatePayment(ctx context.Context, chargeID meta.ChargeID, paymentSettlement payment.InvoicedCreate) (payment.Invoiced, error)
 	UpdatePayment(ctx context.Context, paymentSettlement payment.Invoiced) (payment.Invoiced, error)
-
-	entutils.TxCreator
 }
 
 type IntentWithInitialStatus struct {
 	Intent
 	FeatureID            *string
-	InitialStatus        meta.ChargeStatus
+	InitialStatus        Status
 	AmountAfterProration alpacadecimal.Decimal
 }
 

--- a/openmeter/billing/charges/flatfee/adapter/charge.go
+++ b/openmeter/billing/charges/flatfee/adapter/charge.go
@@ -19,16 +19,23 @@ import (
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
-func (a *adapter) UpdateCharge(ctx context.Context, charge flatfee.Charge) error {
+var _ flatfee.ChargeAdapter = (*adapter)(nil)
+
+func (a *adapter) UpdateCharge(ctx context.Context, charge flatfee.ChargeBase) (flatfee.ChargeBase, error) {
 	if err := charge.ManagedModel.Validate(); err != nil {
-		return err
+		return flatfee.ChargeBase{}, err
 	}
 
 	if err := charge.Validate(); err != nil {
-		return err
+		return flatfee.ChargeBase{}, err
 	}
 
-	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, tx *adapter) error {
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (flatfee.ChargeBase, error) {
+		metaStatus, err := charge.Status.ToMetaChargeStatus()
+		if err != nil {
+			return flatfee.ChargeBase{}, err
+		}
+
 		intent := charge.Intent
 
 		var discounts *productcatalog.Discounts
@@ -38,7 +45,7 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge flatfee.Charge) error
 
 		proRating, err := proRatingConfigToDB(intent.ProRating)
 		if err != nil {
-			return err
+			return flatfee.ChargeBase{}, err
 		}
 
 		update := tx.db.ChargeFlatFee.UpdateOneID(charge.ID).
@@ -48,25 +55,26 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge flatfee.Charge) error
 			SetDiscounts(discounts).
 			SetOrClearFeatureID(charge.State.FeatureID).
 			SetProRating(proRating).
+			SetStatusDetailed(charge.Status).
 			SetAmountBeforeProration(intent.AmountBeforeProration).
 			SetAmountAfterProration(charge.State.AmountAfterProration)
 
 		update, err = chargemeta.Update(update, chargemeta.UpdateInput{
 			ManagedResource: charge.ManagedResource,
 			Intent:          intent.Intent,
-			Status:          charge.Status,
+			Status:          metaStatus,
 			AdvanceAfter:    meta.NormalizeOptionalTimestamp(charge.State.AdvanceAfter),
 		})
 		if err != nil {
-			return err
+			return flatfee.ChargeBase{}, err
 		}
 
-		_, err = update.Save(ctx)
+		dbUpdatedChargeBase, err := update.Save(ctx)
 		if err != nil {
-			return err
+			return flatfee.ChargeBase{}, err
 		}
 
-		return nil
+		return MapChargeBaseFromDB(dbUpdatedChargeBase), nil
 	})
 }
 
@@ -84,12 +92,19 @@ func (a *adapter) DeleteCharge(ctx context.Context, charge flatfee.Charge) error
 			Where(dbchargeflatfee.NamespaceEQ(charge.Namespace))
 
 		charge.DeletedAt = lo.ToPtr(clock.Now())
-		charge.Status = meta.ChargeStatusDeleted
+		charge.Status = flatfee.StatusDeleted
 
-		update, err := chargemeta.Update(update, chargemeta.UpdateInput{
+		metaStatus, err := charge.Status.ToMetaChargeStatus()
+		if err != nil {
+			return err
+		}
+
+		update = update.SetStatusDetailed(charge.Status)
+
+		update, err = chargemeta.Update(update, chargemeta.UpdateInput{
 			ManagedResource: charge.ManagedResource,
 			Intent:          charge.Intent.Intent,
-			Status:          charge.Status,
+			Status:          metaStatus,
 		})
 		if err != nil {
 			return err
@@ -223,6 +238,11 @@ func expandRealizations(query *db.ChargeFlatFeeQuery) *db.ChargeFlatFeeQuery {
 }
 
 func (a *adapter) buildCreateFlatFeeCharge(ns string, intent flatfee.IntentWithInitialStatus) (*db.ChargeFlatFeeCreate, error) {
+	metaStatus, err := intent.InitialStatus.ToMetaChargeStatus()
+	if err != nil {
+		return nil, err
+	}
+
 	var discounts *productcatalog.Discounts
 	if intent.PercentageDiscounts != nil {
 		discounts = &productcatalog.Discounts{Percentage: intent.PercentageDiscounts}
@@ -240,6 +260,7 @@ func (a *adapter) buildCreateFlatFeeCharge(ns string, intent flatfee.IntentWithI
 		SetSettlementMode(intent.SettlementMode).
 		SetNillableFeatureID(intent.FeatureID).
 		SetNillableFeatureKey(lo.EmptyableToPtr(intent.FeatureKey)).
+		SetStatusDetailed(intent.InitialStatus).
 		SetProRating(proRating).
 		SetAmountBeforeProration(intent.AmountBeforeProration).
 		SetAmountAfterProration(intent.AmountAfterProration)
@@ -251,7 +272,7 @@ func (a *adapter) buildCreateFlatFeeCharge(ns string, intent flatfee.IntentWithI
 	create, err = chargemeta.Create[*db.ChargeFlatFeeCreate](create, chargemeta.CreateInput{
 		Namespace: ns,
 		Intent:    intent.Intent.Intent,
-		Status:    intent.InitialStatus,
+		Status:    metaStatus,
 	})
 	if err != nil {
 		return nil, err

--- a/openmeter/billing/charges/flatfee/adapter/mapper.go
+++ b/openmeter/billing/charges/flatfee/adapter/mapper.go
@@ -17,6 +17,45 @@ import (
 
 // MapFlatFeeChargeFromDB converts a DB Charge entity (with loaded FlatFee edge) to a FlatFeeCharge.
 func MapChargeFlatFeeFromDB(entity *entdb.ChargeFlatFee, expands meta.Expands) (flatfee.Charge, error) {
+	chargeBase := MapChargeBaseFromDB(entity)
+
+	charge := flatfee.Charge{
+		ChargeBase: chargeBase,
+	}
+
+	if expands.Has(meta.ExpandRealizations) {
+		dbCreditRealizations, err := entity.Edges.CreditAllocationsOrErr()
+		if err != nil {
+			return flatfee.Charge{}, fmt.Errorf("mapping flat fee charge [id=%s]: %w", entity.ID, err)
+		}
+
+		charge.Realizations.CreditRealizations = lo.Map(dbCreditRealizations, func(entity *entdb.ChargeFlatFeeCreditAllocations, _ int) creditrealization.Realization {
+			return creditrealization.MapFromDB(entity)
+		})
+
+		dbPaymentState, err := entity.Edges.PaymentOrErr()
+		if _, ok := lo.ErrorsAs[*entdb.NotLoadedError](err); ok {
+			return flatfee.Charge{}, fmt.Errorf("payment state not loaded for flat fee charge [id=%s]", entity.ID)
+		}
+
+		if dbPaymentState != nil {
+			charge.Realizations.Payment = lo.ToPtr(payment.MapInvoicedFromDB(dbPaymentState))
+		}
+
+		dbAccruedUsage, err := entity.Edges.InvoicedUsageOrErr()
+		if _, ok := lo.ErrorsAs[*entdb.NotLoadedError](err); ok {
+			return flatfee.Charge{}, fmt.Errorf("accrued usage not loaded for flat fee charge [id=%s]", entity.ID)
+		}
+
+		if dbAccruedUsage != nil {
+			charge.Realizations.AccruedUsage = lo.ToPtr(invoicedusage.MapAccruedUsageFromDB(dbAccruedUsage))
+		}
+	}
+
+	return charge, nil
+}
+
+func MapChargeBaseFromDB(entity *entdb.ChargeFlatFee) flatfee.ChargeBase {
 	var percentageDiscounts *productcatalog.PercentageDiscount
 	if entity.Discounts != nil {
 		percentageDiscounts = entity.Discounts.Percentage
@@ -24,9 +63,9 @@ func MapChargeFlatFeeFromDB(entity *entdb.ChargeFlatFee, expands meta.Expands) (
 
 	mappedMeta := chargemeta.MapFromDB(entity)
 
-	charge := flatfee.Charge{
+	return flatfee.ChargeBase{
 		ManagedResource: mappedMeta.ManagedResource,
-		Status:          mappedMeta.Status,
+		Status:          entity.StatusDetailed,
 		State: flatfee.State{
 			AdvanceAfter:         mappedMeta.AdvanceAfter,
 			FeatureID:            entity.FeatureID,
@@ -43,37 +82,6 @@ func MapChargeFlatFeeFromDB(entity *entdb.ChargeFlatFee, expands meta.Expands) (
 			AmountBeforeProration: entity.AmountBeforeProration,
 		},
 	}
-
-	if expands.Has(meta.ExpandRealizations) {
-		dbCreditRealizations, err := entity.Edges.CreditAllocationsOrErr()
-		if err != nil {
-			return flatfee.Charge{}, fmt.Errorf("mapping flat fee charge [id=%s]: %w", entity.ID, err)
-		}
-
-		charge.State.CreditRealizations = lo.Map(dbCreditRealizations, func(entity *entdb.ChargeFlatFeeCreditAllocations, _ int) creditrealization.Realization {
-			return creditrealization.MapFromDB(entity)
-		})
-
-		dbPaymentState, err := entity.Edges.PaymentOrErr()
-		if _, ok := lo.ErrorsAs[*entdb.NotLoadedError](err); ok {
-			return flatfee.Charge{}, fmt.Errorf("payment state not loaded for flat fee charge [id=%s]", entity.ID)
-		}
-
-		if dbPaymentState != nil {
-			charge.State.Payment = lo.ToPtr(payment.MapInvoicedFromDB(dbPaymentState))
-		}
-
-		dbAccruedUsage, err := entity.Edges.InvoicedUsageOrErr()
-		if _, ok := lo.ErrorsAs[*entdb.NotLoadedError](err); ok {
-			return flatfee.Charge{}, fmt.Errorf("accrued usage not loaded for flat fee charge [id=%s]", entity.ID)
-		}
-
-		if dbAccruedUsage != nil {
-			charge.State.AccruedUsage = lo.ToPtr(invoicedusage.MapAccruedUsageFromDB(dbAccruedUsage))
-		}
-	}
-
-	return charge, nil
 }
 
 // proRatingConfigFromDB converts a DB ProRatingModeAdapterEnum to a ProRatingConfig.

--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -199,6 +199,10 @@ func (s State) Validate() error {
 		}
 	}
 
+	if s.AmountAfterProration.IsNegative() {
+		errs = append(errs, fmt.Errorf("amount after proration cannot be negative"))
+	}
+
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 

--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -16,18 +16,16 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-var _ meta.ChargeAccessor = (*Charge)(nil)
-
-type Charge struct {
+type ChargeBase struct {
 	meta.ManagedResource
 
-	Intent Intent            `json:"intent"`
-	Status meta.ChargeStatus `json:"status"`
+	Intent Intent `json:"intent"`
+	Status Status `json:"status"`
 
 	State State `json:"state"`
 }
 
-func (c Charge) Validate() error {
+func (c ChargeBase) Validate() error {
 	var errs []error
 
 	if err := c.ManagedResource.Validate(); err != nil {
@@ -49,11 +47,41 @@ func (c Charge) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
-func (c Charge) GetChargeID() meta.ChargeID {
+func (c ChargeBase) GetChargeID() meta.ChargeID {
 	return meta.ChargeID{
 		Namespace: c.Namespace,
 		ID:        c.ID,
 	}
+}
+
+func (c ChargeBase) ErrorAttributes() models.Attributes {
+	return models.Attributes{
+		"charge_id":   c.ID,
+		"namespace":   c.Namespace,
+		"charge_type": string(meta.ChargeTypeFlatFee),
+	}
+}
+
+var _ meta.ChargeAccessor = (*Charge)(nil)
+
+type Charge struct {
+	ChargeBase
+
+	Realizations Realizations `json:"realizations"`
+}
+
+func (c Charge) Validate() error {
+	var errs []error
+
+	if err := c.ChargeBase.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge base: %w", err))
+	}
+
+	if err := c.Realizations.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("realizations: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type Intent struct {
@@ -150,21 +178,10 @@ func (i Intent) CalculateAmountAfterProration() (alpacadecimal.Decimal, error) {
 	return calc.RoundToPrecision(amount), nil
 }
 
-func (c Charge) ErrorAttributes() models.Attributes {
-	return models.Attributes{
-		"charge_id":   c.ID,
-		"namespace":   c.Namespace,
-		"charge_type": string(meta.ChargeTypeFlatFee),
-	}
-}
-
 type State struct {
-	AdvanceAfter         *time.Time                     `json:"advanceAfter,omitempty"`
-	FeatureID            *string                        `json:"featureId,omitempty"`
-	AmountAfterProration alpacadecimal.Decimal          `json:"amountAfterProration"`
-	CreditRealizations   creditrealization.Realizations `json:"creditRealizations"`
-	AccruedUsage         *invoicedusage.AccruedUsage    `json:"accruedUsage"`
-	Payment              *payment.Invoiced              `json:"payment"`
+	AdvanceAfter         *time.Time            `json:"advanceAfter,omitempty"`
+	FeatureID            *string               `json:"featureId,omitempty"`
+	AmountAfterProration alpacadecimal.Decimal `json:"amountAfterProration"`
 }
 
 func (s State) Normalized() State {
@@ -176,27 +193,39 @@ func (s State) Normalized() State {
 func (s State) Validate() error {
 	var errs []error
 
-	for _, realization := range s.CreditRealizations {
+	if s.AdvanceAfter != nil {
+		if s.AdvanceAfter.IsZero() {
+			errs = append(errs, fmt.Errorf("advance after is required"))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type Realizations struct {
+	CreditRealizations creditrealization.Realizations `json:"creditRealizations"`
+	AccruedUsage       *invoicedusage.AccruedUsage    `json:"accruedUsage"`
+	Payment            *payment.Invoiced              `json:"payment"`
+}
+
+func (r Realizations) Validate() error {
+	var errs []error
+
+	for _, realization := range r.CreditRealizations {
 		if err := realization.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("credit realization[id=%s]: %w", realization.ID, err))
 		}
 	}
 
-	if s.Payment != nil {
-		if err := s.Payment.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("payment[id=%s]: %w", s.Payment.ID, err))
+	if r.Payment != nil {
+		if err := r.Payment.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("payment[id=%s]: %w", r.Payment.ID, err))
 		}
 	}
 
-	if s.AccruedUsage != nil {
-		if err := s.AccruedUsage.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("accrued usage[id=%s]: %w", s.AccruedUsage.ID, err))
-		}
-	}
-
-	if s.AdvanceAfter != nil {
-		if s.AdvanceAfter.IsZero() {
-			errs = append(errs, fmt.Errorf("advance after is required"))
+	if r.AccruedUsage != nil {
+		if err := r.AccruedUsage.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("accrued usage[id=%s]: %w", r.AccruedUsage.ID, err))
 		}
 	}
 

--- a/openmeter/billing/charges/flatfee/service/create.go
+++ b/openmeter/billing/charges/flatfee/service/create.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -30,9 +29,9 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 		intentsWithStatus, err := slicesx.MapWithErr(input.Intents, func(intent flatfee.Intent) (flatfee.IntentWithInitialStatus, error) {
 			intent = intent.Normalized()
 
-			initialStatus := meta.ChargeStatusActive
+			initialStatus := flatfee.StatusActive
 			if intent.SettlementMode == productcatalog.CreditOnlySettlementMode {
-				initialStatus = meta.ChargeStatusCreated
+				initialStatus = flatfee.StatusCreated
 			}
 
 			amountAfterProration, err := intent.CalculateAmountAfterProration()

--- a/openmeter/billing/charges/flatfee/service/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/creditsonly.go
@@ -61,7 +61,7 @@ func NewCreditsOnlyStateMachine(config CreditsOnlyStateMachineConfig) (*CreditsO
 			return out.Charge.Status, nil
 		},
 		func(ctx context.Context, state stateless.State) error {
-			newStatus := state.(meta.ChargeStatus)
+			newStatus := state.(flatfee.Status)
 			if err := newStatus.Validate(); err != nil {
 				return fmt.Errorf("invalid status: %w", err)
 			}
@@ -79,25 +79,25 @@ func NewCreditsOnlyStateMachine(config CreditsOnlyStateMachineConfig) (*CreditsO
 }
 
 func (s *CreditsOnlyStateMachine) configureStates() {
-	s.Configure(meta.ChargeStatusCreated).
-		Permit(meta.TriggerNext, meta.ChargeStatusActive, statelessx.BoolFn(s.IsAfterInvoiceAt)).
-		Permit(meta.TriggerDelete, meta.ChargeStatusDeleted).
+	s.Configure(flatfee.StatusCreated).
+		Permit(meta.TriggerNext, flatfee.StatusActive, statelessx.BoolFn(s.IsAfterInvoiceAt)).
+		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
 		OnActive(
 			s.SetAdvanceAfterInvoiceAt,
 		)
 
-	s.Configure(meta.ChargeStatusActive).
-		Permit(meta.TriggerNext, meta.ChargeStatusFinal).
-		Permit(meta.TriggerDelete, meta.ChargeStatusDeleted).
+	s.Configure(flatfee.StatusActive).
+		Permit(meta.TriggerNext, flatfee.StatusFinal).
+		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
 		OnActive(
 			s.AllocateCredits,
 		)
 
-	s.Configure(meta.ChargeStatusFinal).
-		Permit(meta.TriggerDelete, meta.ChargeStatusDeleted).
+	s.Configure(flatfee.StatusFinal).
+		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
 		OnActive(s.ClearAdvanceAfter)
 
-	s.Configure(meta.ChargeStatusDeleted).
+	s.Configure(flatfee.StatusDeleted).
 		OnEntry(statelessx.WithParameters(s.DeleteCharge))
 }
 
@@ -158,7 +158,7 @@ func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {
 			return fmt.Errorf("create credit allocations: %w", err)
 		}
 
-		s.Charge.State.CreditRealizations = append(s.Charge.State.CreditRealizations, realizations...)
+		s.Charge.Realizations.CreditRealizations = append(s.Charge.Realizations.CreditRealizations, realizations...)
 	}
 
 	return nil
@@ -207,9 +207,12 @@ func (s *CreditsOnlyStateMachine) AdvanceUntilStateStable(ctx context.Context) (
 			return nil, fmt.Errorf("cannot transition to the next status [current_status=%s]: %w", s.Charge.Status, err)
 		}
 
-		if err := s.Adapter.UpdateCharge(ctx, s.Charge); err != nil {
+		updatedChargeBase, err := s.Adapter.UpdateCharge(ctx, s.Charge.ChargeBase)
+		if err != nil {
 			return nil, fmt.Errorf("persist charge: %w", err)
 		}
+
+		s.Charge.ChargeBase = updatedChargeBase
 
 		advanced = true
 	}
@@ -222,7 +225,7 @@ func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, policy meta.
 			return fmt.Errorf("get currency calculator: %w", err)
 		}
 
-		realizationIDs := lo.Map(s.Charge.State.CreditRealizations, func(realization creditrealization.Realization, _ int) string {
+		realizationIDs := lo.Map(s.Charge.Realizations.CreditRealizations, func(realization creditrealization.Realization, _ int) string {
 			return realization.ID
 		})
 		lineageSegmentsByRealization, err := s.Service.lineage.LoadActiveSegmentsByRealizationID(ctx, s.Charge.Namespace, realizationIDs)
@@ -231,7 +234,7 @@ func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, policy meta.
 		}
 
 		// Let's reverse the credit allocations
-		corrections, err := s.Charge.State.CreditRealizations.CorrectAll(currencyCalculator, func(req creditrealization.CorrectionRequest) (creditrealization.CreateCorrectionInputs, error) {
+		corrections, err := s.Charge.Realizations.CreditRealizations.CorrectAll(currencyCalculator, func(req creditrealization.CorrectionRequest) (creditrealization.CreateCorrectionInputs, error) {
 			return s.Service.handler.OnCreditsOnlyUsageAccruedCorrection(ctx, flatfee.CreditsOnlyUsageAccruedCorrectionInput{
 				Charge:                       s.Charge,
 				AllocateAt:                   clock.Now(),

--- a/openmeter/billing/charges/flatfee/service/invoice.go
+++ b/openmeter/billing/charges/flatfee/service/invoice.go
@@ -55,7 +55,7 @@ func (s *service) PostLineAssignedToInvoice(ctx context.Context, charge flatfee.
 
 func (s *service) PostInvoiceIssued(ctx context.Context, charge flatfee.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
-		if charge.State.AccruedUsage != nil {
+		if charge.Realizations.AccruedUsage != nil {
 			// Lifecycle violation: this should not happen as we should not be able to issue an invoice if the charge already has an accrued usage.
 			return fmt.Errorf("accrued invoice usage already exists for charge %s", charge.GetChargeID())
 		}

--- a/openmeter/billing/charges/flatfee/service/payment.go
+++ b/openmeter/billing/charges/flatfee/service/payment.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -15,10 +14,10 @@ import (
 
 func (s *service) PostInvoicePaymentAuthorized(ctx context.Context, charge flatfee.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
-		if charge.State.Payment != nil {
+		if charge.Realizations.Payment != nil {
 			return payment.ErrPaymentAlreadyAuthorized.
 				WithAttrs(charge.ErrorAttributes()).
-				WithAttrs(charge.State.Payment.ErrorAttributes())
+				WithAttrs(charge.Realizations.Payment.ErrorAttributes())
 		}
 
 		ledgerTransactionGroupReference, err := s.handler.OnPaymentAuthorized(ctx, charge)
@@ -48,20 +47,19 @@ func (s *service) PostInvoicePaymentAuthorized(ctx context.Context, charge flatf
 			return err
 		}
 
-		charge.State.Payment = &paymentSettlement
-		err = s.adapter.UpdateCharge(ctx, charge)
+		charge.Realizations.Payment = &paymentSettlement
 
-		return err
+		return nil
 	})
 }
 
 func (s *service) PostInvoicePaymentSettled(ctx context.Context, charge flatfee.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
-		if charge.State.Payment == nil {
+		if charge.Realizations.Payment == nil {
 			return payment.ErrCannotSettleNotAuthorizedPayment.WithAttrs(charge.ErrorAttributes())
 		}
 
-		paymentSettlement := *charge.State.Payment
+		paymentSettlement := *charge.Realizations.Payment
 
 		if paymentSettlement.LineID != lineWithHeader.Line.ID {
 			return fmt.Errorf("payment settlement line ID does not match the line ID: %s != %s", paymentSettlement.LineID, lineWithHeader.Line.ID)
@@ -90,10 +88,10 @@ func (s *service) PostInvoicePaymentSettled(ctx context.Context, charge flatfee.
 			return err
 		}
 
-		charge.State.Payment = &paymentSettlement
-		charge.Status = meta.ChargeStatusFinal
+		charge.Realizations.Payment = &paymentSettlement
+		charge.Status = flatfee.StatusFinal
 
-		err = s.adapter.UpdateCharge(ctx, charge)
+		_, err = s.adapter.UpdateCharge(ctx, charge.ChargeBase)
 		if err != nil {
 			return err
 		}

--- a/openmeter/billing/charges/flatfee/statemachine.go
+++ b/openmeter/billing/charges/flatfee/statemachine.go
@@ -14,6 +14,7 @@ const (
 	StatusCreated Status = Status(meta.ChargeStatusCreated)
 	StatusActive  Status = Status(meta.ChargeStatusActive)
 	StatusFinal   Status = Status(meta.ChargeStatusFinal)
+	StatusDeleted Status = Status(meta.ChargeStatusDeleted)
 )
 
 func (Status) Values() []string {
@@ -21,6 +22,7 @@ func (Status) Values() []string {
 		string(StatusCreated),
 		string(StatusActive),
 		string(StatusFinal),
+		string(StatusDeleted),
 	}
 }
 

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -167,8 +167,8 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 
 		// Validate the credit realizations
 		// The charge should have $30 realized as credits
-		s.Len(updatedFlatFeeCharge.State.CreditRealizations, 1)
-		creditRealization := updatedFlatFeeCharge.State.CreditRealizations[0]
+		s.Len(updatedFlatFeeCharge.Realizations.CreditRealizations, 1)
+		creditRealization := updatedFlatFeeCharge.Realizations.CreditRealizations[0]
 		s.Equal(testTrnsGroupID, creditRealization.LedgerTransaction.TransactionGroupID)
 		s.Equal(servicePeriod.From, creditRealization.ServicePeriod.From)
 		s.Equal(servicePeriod.To, creditRealization.ServicePeriod.To)
@@ -228,7 +228,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 		s.NoError(err)
 
 		// Invoice usage accrued callback should have been invoked
-		accruedUsage := updatedFlatFeeCharge.State.AccruedUsage
+		accruedUsage := updatedFlatFeeCharge.Realizations.AccruedUsage
 		s.NotNil(accruedUsage)
 		s.Equal(invoiceUsageAccruedCallback.id, accruedUsage.LedgerTransaction.TransactionGroupID, "ledger transaction gets recorded")
 		s.Equal(servicePeriod, accruedUsage.ServicePeriod, "service period should be the same as the input")
@@ -239,8 +239,8 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 		s.Equal(float64(30), accruedUsage.Totals.CreditsTotal.InexactFloat64(), "totals should be the same as the input")
 
 		// Authorization callback should have been invoked
-		s.Equal(authorizedCallback.id, updatedFlatFeeCharge.State.Payment.Authorized.TransactionGroupID)
-		s.Equal(meta.ChargeStatusActive, updatedFlatFeeCharge.Status)
+		s.Equal(authorizedCallback.id, updatedFlatFeeCharge.Realizations.Payment.Authorized.TransactionGroupID)
+		s.Equal(flatfee.StatusActive, updatedFlatFeeCharge.Status)
 	})
 
 	s.Run("payment is settled", func() {
@@ -259,8 +259,8 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 		charge := s.mustGetChargeByID(flatFeeChargeID)
 		updatedFlatFeeCharge, err := charge.AsFlatFeeCharge()
 		s.NoError(err)
-		s.Equal(settledCallback.id, updatedFlatFeeCharge.State.Payment.Settled.TransactionGroupID)
-		s.Equal(meta.ChargeStatusFinal, updatedFlatFeeCharge.Status)
+		s.Equal(settledCallback.id, updatedFlatFeeCharge.Realizations.Payment.Settled.TransactionGroupID)
+		s.Equal(flatfee.StatusFinal, updatedFlatFeeCharge.Status)
 	})
 }
 
@@ -1238,8 +1238,8 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 
 		flatFeeChargeID = flatFeeCharge.GetChargeID()
 
-		s.Equal(meta.ChargeStatusCreated, fetchedFF.Status)
-		s.Empty(fetchedFF.State.CreditRealizations)
+		s.Equal(flatfee.StatusCreated, fetchedFF.Status)
+		s.Empty(fetchedFF.Realizations.CreditRealizations)
 		s.Nil(fetchedFF.State.AdvanceAfter)
 
 		// Advancing is a noop (clock is before InvoiceAt).
@@ -1250,7 +1250,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 		fetchedCharge = s.mustGetChargeByID(flatFeeChargeID)
 		fetchedFF, err = fetchedCharge.AsFlatFeeCharge()
 		s.NoError(err)
-		s.Equal(meta.ChargeStatusCreated, fetchedFF.Status)
+		s.Equal(flatfee.StatusCreated, fetchedFF.Status)
 	})
 
 	s.NotEmpty(flatFeeChargeID)
@@ -1288,13 +1288,13 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 		s.Len(advancedCharges, 1)
 		advancedFF, err := advancedCharges[0].AsFlatFeeCharge()
 		s.NoError(err)
-		s.Equal(meta.ChargeStatusFinal, advancedFF.Status)
+		s.Equal(flatfee.StatusFinal, advancedFF.Status)
 
 		// Verify DB state matches.
 		fetchedCharge := s.mustGetChargeByID(flatFeeChargeID)
 		fetchedFF, err := fetchedCharge.AsFlatFeeCharge()
 		s.NoError(err)
-		s.Equal(meta.ChargeStatusFinal, fetchedFF.Status)
+		s.Equal(flatfee.StatusFinal, fetchedFF.Status)
 		s.Nil(fetchedFF.State.AdvanceAfter)
 
 		// The handler was called exactly once with the correct amount.
@@ -1302,8 +1302,8 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 		s.Equal(float64(100), callbacks[0].Input.AmountToAllocate.InexactFloat64())
 
 		// Credit realizations were persisted.
-		s.Len(fetchedFF.State.CreditRealizations, 1)
-		s.Equal(float64(100), fetchedFF.State.CreditRealizations[0].Amount.InexactFloat64())
+		s.Len(fetchedFF.Realizations.CreditRealizations, 1)
+		s.Equal(float64(100), fetchedFF.Realizations.CreditRealizations[0].Amount.InexactFloat64())
 	})
 
 	s.Run("#3 final charge advance is noop", func() {
@@ -1317,7 +1317,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 		fetchedCharge := s.mustGetChargeByID(flatFeeChargeID)
 		fetchedFF, err := fetchedCharge.AsFlatFeeCharge()
 		s.NoError(err)
-		s.Equal(meta.ChargeStatusFinal, fetchedFF.Status)
+		s.Equal(flatfee.StatusFinal, fetchedFF.Status)
 	})
 }
 
@@ -1385,19 +1385,19 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyCreateImmediatelyFinal
 	s.Equal(meta.ChargeTypeFlatFee, res[0].Type())
 	returnedCharge, err := res[0].AsFlatFeeCharge()
 	s.NoError(err)
-	s.Equal(meta.ChargeStatusFinal, returnedCharge.Status)
+	s.Equal(flatfee.StatusFinal, returnedCharge.Status)
 	s.Nil(returnedCharge.State.AdvanceAfter)
-	s.Len(returnedCharge.State.CreditRealizations, 1)
-	s.Equal(float64(50), returnedCharge.State.CreditRealizations[0].Amount.InexactFloat64())
+	s.Len(returnedCharge.Realizations.CreditRealizations, 1)
+	s.Equal(float64(50), returnedCharge.Realizations.CreditRealizations[0].Amount.InexactFloat64())
 
 	// And the DB state matches.
 	dbCharge := s.mustGetChargeByID(returnedCharge.GetChargeID())
 	dbFF, err := dbCharge.AsFlatFeeCharge()
 	s.NoError(err)
-	s.Equal(meta.ChargeStatusFinal, dbFF.Status)
+	s.Equal(flatfee.StatusFinal, dbFF.Status)
 	s.Nil(dbFF.State.AdvanceAfter)
-	s.Len(dbFF.State.CreditRealizations, 1)
-	s.Equal(float64(50), dbFF.State.CreditRealizations[0].Amount.InexactFloat64())
+	s.Len(dbFF.Realizations.CreditRealizations, 1)
+	s.Equal(float64(50), dbFF.Realizations.CreditRealizations[0].Amount.InexactFloat64())
 }
 
 func (s *InvoicableChargesTestSuite) mustAdvanceFlatFeeCharges(ctx context.Context, customerID customer.CustomerID) charges.Charges {

--- a/openmeter/billing/charges/service/lineage_test.go
+++ b/openmeter/billing/charges/service/lineage_test.go
@@ -122,13 +122,13 @@ func (s *CreditRealizationLineageTestSuite) TestFlatFeeCreditOnlyAllocationCreat
 
 	charge, err := s.mustGetChargeByID(chargeID).AsFlatFeeCharge()
 	s.NoError(err)
-	s.Len(charge.State.CreditRealizations, 2)
+	s.Len(charge.Realizations.CreditRealizations, 2)
 
-	lineages := s.mustListLineages(ns, realizationIDs(charge.State.CreditRealizations))
+	lineages := s.mustListLineages(ns, realizationIDs(charge.Realizations.CreditRealizations))
 	s.Require().Len(lineages, 2)
 
-	s.assertInitialLineage(lineages[charge.State.CreditRealizations[0].ID], chargeID.ID, charge.State.CreditRealizations[0].Amount, creditrealization.LineageOriginKindRealCredit, creditrealization.LineageSegmentStateRealCredit)
-	s.assertInitialLineage(lineages[charge.State.CreditRealizations[1].ID], chargeID.ID, charge.State.CreditRealizations[1].Amount, creditrealization.LineageOriginKindAdvance, creditrealization.LineageSegmentStateAdvanceUncovered)
+	s.assertInitialLineage(lineages[charge.Realizations.CreditRealizations[0].ID], chargeID.ID, charge.Realizations.CreditRealizations[0].Amount, creditrealization.LineageOriginKindRealCredit, creditrealization.LineageSegmentStateRealCredit)
+	s.assertInitialLineage(lineages[charge.Realizations.CreditRealizations[1].ID], chargeID.ID, charge.Realizations.CreditRealizations[1].Amount, creditrealization.LineageOriginKindAdvance, creditrealization.LineageSegmentStateAdvanceUncovered)
 }
 
 func (s *CreditRealizationLineageTestSuite) TestUsageBasedCreditOnlyAllocationCreatesInitialLineage() {

--- a/openmeter/billing/charges/service/truncation_test.go
+++ b/openmeter/billing/charges/service/truncation_test.go
@@ -216,7 +216,7 @@ func (s *ChargeTimestampTruncationTestSuite) TestTmpApplyPatchToCreateIntentTrun
 	}{
 		{
 			name:   "flat fee",
-			charge: charges.NewCharge(flatfee.Charge{Intent: flatFeeIntent}),
+			charge: charges.NewCharge(flatfee.Charge{ChargeBase: flatfee.ChargeBase{Intent: flatFeeIntent}}),
 			assert: func(intent charges.ChargeIntent) {
 				typed, err := intent.AsFlatFeeIntent()
 				s.NoError(err)

--- a/openmeter/billing/charges/usagebased/adapter.go
+++ b/openmeter/billing/charges/usagebased/adapter.go
@@ -22,7 +22,6 @@ type ChargeAdapter interface {
 	DeleteCharge(ctx context.Context, charge Charge) error
 	GetByIDs(ctx context.Context, input GetByIDsInput) ([]Charge, error)
 	GetByID(ctx context.Context, input GetByIDInput) (Charge, error)
-	UpdateStatus(ctx context.Context, input UpdateStatusInput) (ChargeBase, error)
 }
 
 type RealizationRunAdapter interface {

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -20,30 +20,6 @@ import (
 
 var _ usagebased.ChargeAdapter = (*adapter)(nil)
 
-func (a *adapter) UpdateStatus(ctx context.Context, input usagebased.UpdateStatusInput) (usagebased.ChargeBase, error) {
-	if err := input.Validate(); err != nil {
-		return usagebased.ChargeBase{}, err
-	}
-
-	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (usagebased.ChargeBase, error) {
-		metaStatus, err := input.Status.ToMetaChargeStatus()
-		if err != nil {
-			return usagebased.ChargeBase{}, err
-		}
-
-		dbUpdatedChargeBase, err := tx.db.ChargeUsageBased.UpdateOneID(input.Charge.ID).
-			Where(dbchargeusagebased.NamespaceEQ(input.Charge.Namespace)).
-			SetStatus(metaStatus).
-			SetStatusDetailed(input.Status).
-			Save(ctx)
-		if err != nil {
-			return usagebased.ChargeBase{}, err
-		}
-
-		return MapChargeBaseFromDB(dbUpdatedChargeBase), nil
-	})
-}
-
 func (a *adapter) UpdateCharge(ctx context.Context, charge usagebased.ChargeBase) (usagebased.ChargeBase, error) {
 	if err := charge.Validate(); err != nil {
 		return usagebased.ChargeBase{}, err

--- a/openmeter/billing/charges/usagebased/statemachine.go
+++ b/openmeter/billing/charges/usagebased/statemachine.go
@@ -1,7 +1,6 @@
 package usagebased
 
 import (
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -63,23 +62,4 @@ func (s Status) ToMetaChargeStatus() (meta.ChargeStatus, error) {
 	}
 
 	return metaStatus, nil
-}
-
-type UpdateStatusInput struct {
-	Charge ChargeBase
-	Status Status
-}
-
-func (i UpdateStatusInput) Validate() error {
-	var errs []error
-
-	if err := i.Charge.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("charge ID: %w", err))
-	}
-
-	if err := i.Status.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("new status: %w", err))
-	}
-
-	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }

--- a/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
@@ -360,7 +360,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeCancella
 
 		deletedCharge, err := deletedChargeRes.AsFlatFeeCharge()
 		s.NoError(err)
-		s.Equal(chargesmeta.ChargeStatusDeleted, deletedCharge.Status)
+		s.Equal(flatfee.StatusDeleted, deletedCharge.Status)
 		s.NotNil(deletedCharge.DeletedAt)
 		s.Equal(expectedCharges[0].ChildUniqueReferenceIDs[1], lo.FromPtr(deletedCharge.Intent.UniqueReferenceID))
 	})
@@ -515,7 +515,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeMidPerio
 
 		deletedCharge, err := deletedChargeRes.AsFlatFeeCharge()
 		s.NoError(err)
-		s.Equal(chargesmeta.ChargeStatusDeleted, deletedCharge.Status)
+		s.Equal(flatfee.StatusDeleted, deletedCharge.Status)
 		s.NotNil(deletedCharge.DeletedAt)
 		s.Equal(expectedCharges[0].ChildUniqueReferenceIDs[1], lo.FromPtr(deletedCharge.Intent.UniqueReferenceID))
 	})

--- a/openmeter/ent/db/chargeflatfee.go
+++ b/openmeter/ent/db/chargeflatfee.go
@@ -97,6 +97,8 @@ type ChargeFlatFee struct {
 	AmountBeforeProration alpacadecimal.Decimal `json:"amount_before_proration,omitempty"`
 	// AmountAfterProration holds the value of the "amount_after_proration" field.
 	AmountAfterProration alpacadecimal.Decimal `json:"amount_after_proration,omitempty"`
+	// StatusDetailed holds the value of the "status_detailed" field.
+	StatusDetailed flatfee.Status `json:"status_detailed,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ChargeFlatFeeQuery when eager-loading is set.
 	Edges        ChargeFlatFeeEdges `json:"edges"`
@@ -234,7 +236,7 @@ func (*ChargeFlatFee) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case chargeflatfee.FieldAmountBeforeProration, chargeflatfee.FieldAmountAfterProration:
 			values[i] = new(alpacadecimal.Decimal)
-		case chargeflatfee.FieldID, chargeflatfee.FieldCustomerID, chargeflatfee.FieldStatus, chargeflatfee.FieldUniqueReferenceID, chargeflatfee.FieldCurrency, chargeflatfee.FieldManagedBy, chargeflatfee.FieldSubscriptionID, chargeflatfee.FieldSubscriptionPhaseID, chargeflatfee.FieldSubscriptionItemID, chargeflatfee.FieldNamespace, chargeflatfee.FieldName, chargeflatfee.FieldDescription, chargeflatfee.FieldPaymentTerm, chargeflatfee.FieldSettlementMode, chargeflatfee.FieldProRating, chargeflatfee.FieldFeatureKey, chargeflatfee.FieldFeatureID:
+		case chargeflatfee.FieldID, chargeflatfee.FieldCustomerID, chargeflatfee.FieldStatus, chargeflatfee.FieldUniqueReferenceID, chargeflatfee.FieldCurrency, chargeflatfee.FieldManagedBy, chargeflatfee.FieldSubscriptionID, chargeflatfee.FieldSubscriptionPhaseID, chargeflatfee.FieldSubscriptionItemID, chargeflatfee.FieldNamespace, chargeflatfee.FieldName, chargeflatfee.FieldDescription, chargeflatfee.FieldPaymentTerm, chargeflatfee.FieldSettlementMode, chargeflatfee.FieldProRating, chargeflatfee.FieldFeatureKey, chargeflatfee.FieldFeatureID, chargeflatfee.FieldStatusDetailed:
 			values[i] = new(sql.NullString)
 		case chargeflatfee.FieldServicePeriodFrom, chargeflatfee.FieldServicePeriodTo, chargeflatfee.FieldBillingPeriodFrom, chargeflatfee.FieldBillingPeriodTo, chargeflatfee.FieldFullServicePeriodFrom, chargeflatfee.FieldFullServicePeriodTo, chargeflatfee.FieldAdvanceAfter, chargeflatfee.FieldCreatedAt, chargeflatfee.FieldUpdatedAt, chargeflatfee.FieldDeletedAt, chargeflatfee.FieldInvoiceAt:
 			values[i] = new(sql.NullTime)
@@ -466,6 +468,12 @@ func (_m *ChargeFlatFee) assignValues(columns []string, values []any) error {
 			} else if value != nil {
 				_m.AmountAfterProration = *value
 			}
+		case chargeflatfee.FieldStatusDetailed:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field status_detailed", values[i])
+			} else if value.Valid {
+				_m.StatusDetailed = flatfee.Status(value.String)
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -662,6 +670,9 @@ func (_m *ChargeFlatFee) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("amount_after_proration=")
 	builder.WriteString(fmt.Sprintf("%v", _m.AmountAfterProration))
+	builder.WriteString(", ")
+	builder.WriteString("status_detailed=")
+	builder.WriteString(fmt.Sprintf("%v", _m.StatusDetailed))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/openmeter/ent/db/chargeflatfee/chargeflatfee.go
+++ b/openmeter/ent/db/chargeflatfee/chargeflatfee.go
@@ -84,6 +84,8 @@ const (
 	FieldAmountBeforeProration = "amount_before_proration"
 	// FieldAmountAfterProration holds the string denoting the amount_after_proration field in the database.
 	FieldAmountAfterProration = "amount_after_proration"
+	// FieldStatusDetailed holds the string denoting the status_detailed field in the database.
+	FieldStatusDetailed = "status_detailed"
 	// EdgeCreditAllocations holds the string denoting the credit_allocations edge name in mutations.
 	EdgeCreditAllocations = "credit_allocations"
 	// EdgeInvoicedUsage holds the string denoting the invoiced_usage edge name in mutations.
@@ -204,6 +206,7 @@ var Columns = []string{
 	FieldFeatureID,
 	FieldAmountBeforeProration,
 	FieldAmountAfterProration,
+	FieldStatusDetailed,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -278,6 +281,16 @@ func ProRatingValidator(pr flatfee.ProRatingModeAdapterEnum) error {
 		return nil
 	default:
 		return fmt.Errorf("chargeflatfee: invalid enum value for pro_rating field: %q", pr)
+	}
+}
+
+// StatusDetailedValidator is a validator for the "status_detailed" field enum values. It is called by the builders before save.
+func StatusDetailedValidator(sd flatfee.Status) error {
+	switch sd {
+	case "created", "active", "final", "deleted":
+		return nil
+	default:
+		return fmt.Errorf("chargeflatfee: invalid enum value for status_detailed field: %q", sd)
 	}
 }
 
@@ -437,6 +450,11 @@ func ByAmountBeforeProration(opts ...sql.OrderTermOption) OrderOption {
 // ByAmountAfterProration orders the results by the amount_after_proration field.
 func ByAmountAfterProration(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAmountAfterProration, opts...).ToFunc()
+}
+
+// ByStatusDetailed orders the results by the status_detailed field.
+func ByStatusDetailed(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldStatusDetailed, opts...).ToFunc()
 }
 
 // ByCreditAllocationsCount orders the results by credit_allocations count.

--- a/openmeter/ent/db/chargeflatfee/where.go
+++ b/openmeter/ent/db/chargeflatfee/where.go
@@ -1776,6 +1776,36 @@ func AmountAfterProrationLTE(v alpacadecimal.Decimal) predicate.ChargeFlatFee {
 	return predicate.ChargeFlatFee(sql.FieldLTE(FieldAmountAfterProration, v))
 }
 
+// StatusDetailedEQ applies the EQ predicate on the "status_detailed" field.
+func StatusDetailedEQ(v flatfee.Status) predicate.ChargeFlatFee {
+	vc := v
+	return predicate.ChargeFlatFee(sql.FieldEQ(FieldStatusDetailed, vc))
+}
+
+// StatusDetailedNEQ applies the NEQ predicate on the "status_detailed" field.
+func StatusDetailedNEQ(v flatfee.Status) predicate.ChargeFlatFee {
+	vc := v
+	return predicate.ChargeFlatFee(sql.FieldNEQ(FieldStatusDetailed, vc))
+}
+
+// StatusDetailedIn applies the In predicate on the "status_detailed" field.
+func StatusDetailedIn(vs ...flatfee.Status) predicate.ChargeFlatFee {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.ChargeFlatFee(sql.FieldIn(FieldStatusDetailed, v...))
+}
+
+// StatusDetailedNotIn applies the NotIn predicate on the "status_detailed" field.
+func StatusDetailedNotIn(vs ...flatfee.Status) predicate.ChargeFlatFee {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.ChargeFlatFee(sql.FieldNotIn(FieldStatusDetailed, v...))
+}
+
 // HasCreditAllocations applies the HasEdge predicate on the "credit_allocations" edge.
 func HasCreditAllocations() predicate.ChargeFlatFee {
 	return predicate.ChargeFlatFee(func(s *sql.Selector) {

--- a/openmeter/ent/db/chargeflatfee_create.go
+++ b/openmeter/ent/db/chargeflatfee_create.go
@@ -319,6 +319,12 @@ func (_c *ChargeFlatFeeCreate) SetAmountAfterProration(v alpacadecimal.Decimal) 
 	return _c
 }
 
+// SetStatusDetailed sets the "status_detailed" field.
+func (_c *ChargeFlatFeeCreate) SetStatusDetailed(v flatfee.Status) *ChargeFlatFeeCreate {
+	_c.mutation.SetStatusDetailed(v)
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *ChargeFlatFeeCreate) SetID(v string) *ChargeFlatFeeCreate {
 	_c.mutation.SetID(v)
@@ -591,6 +597,14 @@ func (_c *ChargeFlatFeeCreate) check() error {
 	if _, ok := _c.mutation.AmountAfterProration(); !ok {
 		return &ValidationError{Name: "amount_after_proration", err: errors.New(`db: missing required field "ChargeFlatFee.amount_after_proration"`)}
 	}
+	if _, ok := _c.mutation.StatusDetailed(); !ok {
+		return &ValidationError{Name: "status_detailed", err: errors.New(`db: missing required field "ChargeFlatFee.status_detailed"`)}
+	}
+	if v, ok := _c.mutation.StatusDetailed(); ok {
+		if err := chargeflatfee.StatusDetailedValidator(v); err != nil {
+			return &ValidationError{Name: "status_detailed", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFee.status_detailed": %w`, err)}
+		}
+	}
 	if len(_c.mutation.CustomerIDs()) == 0 {
 		return &ValidationError{Name: "customer", err: errors.New(`db: missing required edge "ChargeFlatFee.customer"`)}
 	}
@@ -744,6 +758,10 @@ func (_c *ChargeFlatFeeCreate) createSpec() (*ChargeFlatFee, *sqlgraph.CreateSpe
 	if value, ok := _c.mutation.AmountAfterProration(); ok {
 		_spec.SetField(chargeflatfee.FieldAmountAfterProration, field.TypeOther, value)
 		_node.AmountAfterProration = value
+	}
+	if value, ok := _c.mutation.StatusDetailed(); ok {
+		_spec.SetField(chargeflatfee.FieldStatusDetailed, field.TypeEnum, value)
+		_node.StatusDetailed = value
 	}
 	if nodes := _c.mutation.CreditAllocationsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1270,6 +1288,18 @@ func (u *ChargeFlatFeeUpsert) UpdateAmountAfterProration() *ChargeFlatFeeUpsert 
 	return u
 }
 
+// SetStatusDetailed sets the "status_detailed" field.
+func (u *ChargeFlatFeeUpsert) SetStatusDetailed(v flatfee.Status) *ChargeFlatFeeUpsert {
+	u.Set(chargeflatfee.FieldStatusDetailed, v)
+	return u
+}
+
+// UpdateStatusDetailed sets the "status_detailed" field to the value that was provided on create.
+func (u *ChargeFlatFeeUpsert) UpdateStatusDetailed() *ChargeFlatFeeUpsert {
+	u.SetExcluded(chargeflatfee.FieldStatusDetailed)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -1720,6 +1750,20 @@ func (u *ChargeFlatFeeUpsertOne) SetAmountAfterProration(v alpacadecimal.Decimal
 func (u *ChargeFlatFeeUpsertOne) UpdateAmountAfterProration() *ChargeFlatFeeUpsertOne {
 	return u.Update(func(s *ChargeFlatFeeUpsert) {
 		s.UpdateAmountAfterProration()
+	})
+}
+
+// SetStatusDetailed sets the "status_detailed" field.
+func (u *ChargeFlatFeeUpsertOne) SetStatusDetailed(v flatfee.Status) *ChargeFlatFeeUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.SetStatusDetailed(v)
+	})
+}
+
+// UpdateStatusDetailed sets the "status_detailed" field to the value that was provided on create.
+func (u *ChargeFlatFeeUpsertOne) UpdateStatusDetailed() *ChargeFlatFeeUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.UpdateStatusDetailed()
 	})
 }
 
@@ -2343,6 +2387,20 @@ func (u *ChargeFlatFeeUpsertBulk) SetAmountAfterProration(v alpacadecimal.Decima
 func (u *ChargeFlatFeeUpsertBulk) UpdateAmountAfterProration() *ChargeFlatFeeUpsertBulk {
 	return u.Update(func(s *ChargeFlatFeeUpsert) {
 		s.UpdateAmountAfterProration()
+	})
+}
+
+// SetStatusDetailed sets the "status_detailed" field.
+func (u *ChargeFlatFeeUpsertBulk) SetStatusDetailed(v flatfee.Status) *ChargeFlatFeeUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.SetStatusDetailed(v)
+	})
+}
+
+// UpdateStatusDetailed sets the "status_detailed" field to the value that was provided on create.
+func (u *ChargeFlatFeeUpsertBulk) UpdateStatusDetailed() *ChargeFlatFeeUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.UpdateStatusDetailed()
 	})
 }
 

--- a/openmeter/ent/db/chargeflatfee_update.go
+++ b/openmeter/ent/db/chargeflatfee_update.go
@@ -376,6 +376,20 @@ func (_u *ChargeFlatFeeUpdate) SetNillableAmountAfterProration(v *alpacadecimal.
 	return _u
 }
 
+// SetStatusDetailed sets the "status_detailed" field.
+func (_u *ChargeFlatFeeUpdate) SetStatusDetailed(v flatfee.Status) *ChargeFlatFeeUpdate {
+	_u.mutation.SetStatusDetailed(v)
+	return _u
+}
+
+// SetNillableStatusDetailed sets the "status_detailed" field if the given value is not nil.
+func (_u *ChargeFlatFeeUpdate) SetNillableStatusDetailed(v *flatfee.Status) *ChargeFlatFeeUpdate {
+	if v != nil {
+		_u.SetStatusDetailed(*v)
+	}
+	return _u
+}
+
 // AddCreditAllocationIDs adds the "credit_allocations" edge to the ChargeFlatFeeCreditAllocations entity by IDs.
 func (_u *ChargeFlatFeeUpdate) AddCreditAllocationIDs(ids ...string) *ChargeFlatFeeUpdate {
 	_u.mutation.AddCreditAllocationIDs(ids...)
@@ -546,6 +560,11 @@ func (_u *ChargeFlatFeeUpdate) check() error {
 			return &ValidationError{Name: "feature_key", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFee.feature_key": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.StatusDetailed(); ok {
+		if err := chargeflatfee.StatusDetailedValidator(v); err != nil {
+			return &ValidationError{Name: "status_detailed", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFee.status_detailed": %w`, err)}
+		}
+	}
 	if _u.mutation.CustomerCleared() && len(_u.mutation.CustomerIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "ChargeFlatFee.customer"`)
 	}
@@ -657,6 +676,9 @@ func (_u *ChargeFlatFeeUpdate) sqlSave(ctx context.Context) (_node int, err erro
 	}
 	if value, ok := _u.mutation.AmountAfterProration(); ok {
 		_spec.SetField(chargeflatfee.FieldAmountAfterProration, field.TypeOther, value)
+	}
+	if value, ok := _u.mutation.StatusDetailed(); ok {
+		_spec.SetField(chargeflatfee.FieldStatusDetailed, field.TypeEnum, value)
 	}
 	if _u.mutation.CreditAllocationsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1148,6 +1170,20 @@ func (_u *ChargeFlatFeeUpdateOne) SetNillableAmountAfterProration(v *alpacadecim
 	return _u
 }
 
+// SetStatusDetailed sets the "status_detailed" field.
+func (_u *ChargeFlatFeeUpdateOne) SetStatusDetailed(v flatfee.Status) *ChargeFlatFeeUpdateOne {
+	_u.mutation.SetStatusDetailed(v)
+	return _u
+}
+
+// SetNillableStatusDetailed sets the "status_detailed" field if the given value is not nil.
+func (_u *ChargeFlatFeeUpdateOne) SetNillableStatusDetailed(v *flatfee.Status) *ChargeFlatFeeUpdateOne {
+	if v != nil {
+		_u.SetStatusDetailed(*v)
+	}
+	return _u
+}
+
 // AddCreditAllocationIDs adds the "credit_allocations" edge to the ChargeFlatFeeCreditAllocations entity by IDs.
 func (_u *ChargeFlatFeeUpdateOne) AddCreditAllocationIDs(ids ...string) *ChargeFlatFeeUpdateOne {
 	_u.mutation.AddCreditAllocationIDs(ids...)
@@ -1331,6 +1367,11 @@ func (_u *ChargeFlatFeeUpdateOne) check() error {
 			return &ValidationError{Name: "feature_key", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFee.feature_key": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.StatusDetailed(); ok {
+		if err := chargeflatfee.StatusDetailedValidator(v); err != nil {
+			return &ValidationError{Name: "status_detailed", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFee.status_detailed": %w`, err)}
+		}
+	}
 	if _u.mutation.CustomerCleared() && len(_u.mutation.CustomerIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "ChargeFlatFee.customer"`)
 	}
@@ -1459,6 +1500,9 @@ func (_u *ChargeFlatFeeUpdateOne) sqlSave(ctx context.Context) (_node *ChargeFla
 	}
 	if value, ok := _u.mutation.AmountAfterProration(); ok {
 		_spec.SetField(chargeflatfee.FieldAmountAfterProration, field.TypeOther, value)
+	}
+	if value, ok := _u.mutation.StatusDetailed(); ok {
+		_spec.SetField(chargeflatfee.FieldStatusDetailed, field.TypeEnum, value)
 	}
 	if _u.mutation.CreditAllocationsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1885,6 +1885,7 @@ var (
 		{Name: "feature_key", Type: field.TypeString, Nullable: true},
 		{Name: "amount_before_proration", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "amount_after_proration", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
+		{Name: "status_detailed", Type: field.TypeEnum, Enums: []string{"created", "active", "final", "deleted"}},
 		{Name: "customer_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "feature_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "subscription_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -1899,31 +1900,31 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_flat_fees_customers_charges_flat_fee",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[28]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[29]},
 				RefColumns: []*schema.Column{CustomersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "charge_flat_fees_features_flat_fee_charges",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[29]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[30]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_flat_fees_subscriptions_charges_flat_fee",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[30]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[31]},
 				RefColumns: []*schema.Column{SubscriptionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_flat_fees_subscription_items_charges_flat_fee",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[31]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[32]},
 				RefColumns: []*schema.Column{SubscriptionItemsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_flat_fees_subscription_phases_charges_flat_fee",
-				Columns:    []*schema.Column{ChargeFlatFeesColumns[32]},
+				Columns:    []*schema.Column{ChargeFlatFeesColumns[33]},
 				RefColumns: []*schema.Column{SubscriptionPhasesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -1932,7 +1933,7 @@ var (
 			{
 				Name:    "chargeflatfee_namespace_customer_id_unique_reference_id",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeFlatFeesColumns[13], ChargeFlatFeesColumns[28], ChargeFlatFeesColumns[8]},
+				Columns: []*schema.Column{ChargeFlatFeesColumns[13], ChargeFlatFeesColumns[29], ChargeFlatFeesColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "unique_reference_id IS NOT NULL AND deleted_at IS NULL",
 				},

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -41757,6 +41757,7 @@ type ChargeFlatFeeMutation struct {
 	feature_key               *string
 	amount_before_proration   *alpacadecimal.Decimal
 	amount_after_proration    *alpacadecimal.Decimal
+	status_detailed           *flatfee.Status
 	clearedFields             map[string]struct{}
 	credit_allocations        map[string]struct{}
 	removedcredit_allocations map[string]struct{}
@@ -43194,6 +43195,42 @@ func (m *ChargeFlatFeeMutation) ResetAmountAfterProration() {
 	m.amount_after_proration = nil
 }
 
+// SetStatusDetailed sets the "status_detailed" field.
+func (m *ChargeFlatFeeMutation) SetStatusDetailed(f flatfee.Status) {
+	m.status_detailed = &f
+}
+
+// StatusDetailed returns the value of the "status_detailed" field in the mutation.
+func (m *ChargeFlatFeeMutation) StatusDetailed() (r flatfee.Status, exists bool) {
+	v := m.status_detailed
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldStatusDetailed returns the old "status_detailed" field's value of the ChargeFlatFee entity.
+// If the ChargeFlatFee object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeFlatFeeMutation) OldStatusDetailed(ctx context.Context) (v flatfee.Status, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldStatusDetailed is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldStatusDetailed requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldStatusDetailed: %w", err)
+	}
+	return oldValue.StatusDetailed, nil
+}
+
+// ResetStatusDetailed resets all changes to the "status_detailed" field.
+func (m *ChargeFlatFeeMutation) ResetStatusDetailed() {
+	m.status_detailed = nil
+}
+
 // AddCreditAllocationIDs adds the "credit_allocations" edge to the ChargeFlatFeeCreditAllocations entity by ids.
 func (m *ChargeFlatFeeMutation) AddCreditAllocationIDs(ids ...string) {
 	if m.credit_allocations == nil {
@@ -43534,7 +43571,7 @@ func (m *ChargeFlatFeeMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeFlatFeeMutation) Fields() []string {
-	fields := make([]string, 0, 32)
+	fields := make([]string, 0, 33)
 	if m.customer != nil {
 		fields = append(fields, chargeflatfee.FieldCustomerID)
 	}
@@ -43631,6 +43668,9 @@ func (m *ChargeFlatFeeMutation) Fields() []string {
 	if m.amount_after_proration != nil {
 		fields = append(fields, chargeflatfee.FieldAmountAfterProration)
 	}
+	if m.status_detailed != nil {
+		fields = append(fields, chargeflatfee.FieldStatusDetailed)
+	}
 	return fields
 }
 
@@ -43703,6 +43743,8 @@ func (m *ChargeFlatFeeMutation) Field(name string) (ent.Value, bool) {
 		return m.AmountBeforeProration()
 	case chargeflatfee.FieldAmountAfterProration:
 		return m.AmountAfterProration()
+	case chargeflatfee.FieldStatusDetailed:
+		return m.StatusDetailed()
 	}
 	return nil, false
 }
@@ -43776,6 +43818,8 @@ func (m *ChargeFlatFeeMutation) OldField(ctx context.Context, name string) (ent.
 		return m.OldAmountBeforeProration(ctx)
 	case chargeflatfee.FieldAmountAfterProration:
 		return m.OldAmountAfterProration(ctx)
+	case chargeflatfee.FieldStatusDetailed:
+		return m.OldStatusDetailed(ctx)
 	}
 	return nil, fmt.Errorf("unknown ChargeFlatFee field %s", name)
 }
@@ -44009,6 +44053,13 @@ func (m *ChargeFlatFeeMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetAmountAfterProration(v)
 		return nil
+	case chargeflatfee.FieldStatusDetailed:
+		v, ok := value.(flatfee.Status)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetStatusDetailed(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ChargeFlatFee field %s", name)
 }
@@ -44228,6 +44279,9 @@ func (m *ChargeFlatFeeMutation) ResetField(name string) error {
 		return nil
 	case chargeflatfee.FieldAmountAfterProration:
 		m.ResetAmountAfterProration()
+		return nil
+	case chargeflatfee.FieldStatusDetailed:
+		m.ResetStatusDetailed()
 		return nil
 	}
 	return fmt.Errorf("unknown ChargeFlatFee field %s", name)

--- a/openmeter/ent/schema/chargesflatfee.go
+++ b/openmeter/ent/schema/chargesflatfee.go
@@ -72,6 +72,9 @@ func (ChargeFlatFee) Fields() []ent.Field {
 			SchemaType(map[string]string{
 				dialect.Postgres: "numeric",
 			}),
+
+		field.Enum("status_detailed").
+			GoType(flatfee.Status("")),
 	}
 }
 

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -208,8 +208,8 @@ func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, charge flatfee
 	}
 
 	receivableReplenishment := alpacadecimal.NewFromInt(0)
-	if charge.State.AccruedUsage != nil {
-		receivableReplenishment = charge.State.AccruedUsage.Totals.Total
+	if charge.Realizations.AccruedUsage != nil {
+		receivableReplenishment = charge.Realizations.AccruedUsage.Totals.Total
 	}
 
 	if receivableReplenishment.IsZero() {
@@ -262,7 +262,7 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, charge flatfee.Ch
 		return ledgertransaction.GroupReference{}, err
 	}
 
-	if charge.State.AccruedUsage == nil || !charge.State.AccruedUsage.Totals.Total.IsPositive() {
+	if charge.Realizations.AccruedUsage == nil || !charge.Realizations.AccruedUsage.Totals.Total.IsPositive() {
 		return ledgertransaction.GroupReference{}, nil
 	}
 
@@ -284,7 +284,7 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, charge flatfee.Ch
 		},
 		transactions.SettleCustomerReceivablePaymentTemplate{
 			At:        charge.Intent.InvoiceAt,
-			Amount:    charge.State.AccruedUsage.Totals.Total,
+			Amount:    charge.Realizations.AccruedUsage.Totals.Total,
 			Currency:  charge.Intent.Currency,
 			CostBasis: invoiceCostBasis,
 		},

--- a/openmeter/ledger/chargeadapter/flatfee_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_test.go
@@ -181,7 +181,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
 		require.NoError(t, err)
 
-		correctionsRequest, err := chargeWithRealizations.State.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
+		correctionsRequest, err := chargeWithRealizations.Realizations.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
 		require.NoError(t, err)
 
 		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
@@ -218,7 +218,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
 		require.NoError(t, err)
 
-		correctionsRequest, err := chargeWithRealizations.State.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-35), currencyCalculator)
+		correctionsRequest, err := chargeWithRealizations.Realizations.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-35), currencyCalculator)
 		require.NoError(t, err)
 
 		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
@@ -253,7 +253,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
 		require.NoError(t, err)
 
-		correctionsRequest, err := chargeWithRealizations.State.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
+		correctionsRequest, err := chargeWithRealizations.Realizations.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
 		require.NoError(t, err)
 
 		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
@@ -517,36 +517,38 @@ func (e *flatFeeHandlerTestEnv) newAssignmentInputWithMode(amount alpacadecimal.
 
 	return chargeflatfee.OnAssignedToInvoiceInput{
 		Charge: chargeflatfee.Charge{
-			ManagedResource: meta.ManagedResource{
-				NamespacedModel: models.NamespacedModel{
-					Namespace: e.Namespace,
+			ChargeBase: chargeflatfee.ChargeBase{
+				ManagedResource: meta.ManagedResource{
+					NamespacedModel: models.NamespacedModel{
+						Namespace: e.Namespace,
+					},
+					ManagedModel: models.ManagedModel{
+						CreatedAt: now,
+						UpdatedAt: now,
+					},
+					ID: "flat-fee-charge",
 				},
-				ManagedModel: models.ManagedModel{
-					CreatedAt: now,
-					UpdatedAt: now,
+				Intent: chargeflatfee.Intent{
+					Intent: meta.Intent{
+						Name:              "Flat fee",
+						ManagedBy:         billing.SystemManagedLine,
+						CustomerID:        e.CustomerID.ID,
+						Currency:          currencyx.Code("USD"),
+						ServicePeriod:     servicePeriod,
+						FullServicePeriod: servicePeriod,
+						BillingPeriod:     servicePeriod,
+					},
+					InvoiceAt:             now,
+					SettlementMode:        mode,
+					PaymentTerm:           productcatalog.InAdvancePaymentTerm,
+					ProRating:             productcatalog.ProRatingConfig{},
+					AmountBeforeProration: amount,
 				},
-				ID: "flat-fee-charge",
-			},
-			Intent: chargeflatfee.Intent{
-				Intent: meta.Intent{
-					Name:              "Flat fee",
-					ManagedBy:         billing.SystemManagedLine,
-					CustomerID:        e.CustomerID.ID,
-					Currency:          currencyx.Code("USD"),
-					ServicePeriod:     servicePeriod,
-					FullServicePeriod: servicePeriod,
-					BillingPeriod:     servicePeriod,
+				State: chargeflatfee.State{
+					AmountAfterProration: amount,
 				},
-				InvoiceAt:             now,
-				SettlementMode:        mode,
-				PaymentTerm:           productcatalog.InAdvancePaymentTerm,
-				ProRating:             productcatalog.ProRatingConfig{},
-				AmountBeforeProration: amount,
+				Status: chargeflatfee.StatusActive,
 			},
-			State: chargeflatfee.State{
-				AmountAfterProration: amount,
-			},
-			Status: meta.ChargeStatusActive,
 		},
 		ServicePeriod:     servicePeriod,
 		PreTaxTotalAmount: amount,
@@ -638,36 +640,38 @@ func (e *flatFeeHandlerTestEnv) newCreditsOnlyCharge(amount alpacadecimal.Decima
 
 func (e *flatFeeHandlerTestEnv) newBaseCharge(servicePeriod timeutil.ClosedPeriod, amount alpacadecimal.Decimal) chargeflatfee.Charge {
 	return chargeflatfee.Charge{
-		ManagedResource: meta.ManagedResource{
-			NamespacedModel: models.NamespacedModel{
-				Namespace: e.Namespace,
+		ChargeBase: chargeflatfee.ChargeBase{
+			ManagedResource: meta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{
+					Namespace: e.Namespace,
+				},
+				ManagedModel: models.ManagedModel{
+					CreatedAt: servicePeriod.To,
+					UpdatedAt: servicePeriod.To,
+				},
+				ID: "flat-fee-charge",
 			},
-			ManagedModel: models.ManagedModel{
-				CreatedAt: servicePeriod.To,
-				UpdatedAt: servicePeriod.To,
+			Intent: chargeflatfee.Intent{
+				Intent: meta.Intent{
+					Name:              "Flat fee",
+					ManagedBy:         billing.SystemManagedLine,
+					CustomerID:        e.CustomerID.ID,
+					Currency:          currencyx.Code("USD"),
+					ServicePeriod:     servicePeriod,
+					FullServicePeriod: servicePeriod,
+					BillingPeriod:     servicePeriod,
+				},
+				InvoiceAt:             servicePeriod.To,
+				SettlementMode:        productcatalog.InvoiceOnlySettlementMode,
+				PaymentTerm:           productcatalog.InAdvancePaymentTerm,
+				ProRating:             productcatalog.ProRatingConfig{},
+				AmountBeforeProration: amount,
 			},
-			ID: "flat-fee-charge",
-		},
-		Intent: chargeflatfee.Intent{
-			Intent: meta.Intent{
-				Name:              "Flat fee",
-				ManagedBy:         billing.SystemManagedLine,
-				CustomerID:        e.CustomerID.ID,
-				Currency:          currencyx.Code("USD"),
-				ServicePeriod:     servicePeriod,
-				FullServicePeriod: servicePeriod,
-				BillingPeriod:     servicePeriod,
+			State: chargeflatfee.State{
+				AmountAfterProration: amount,
 			},
-			InvoiceAt:             servicePeriod.To,
-			SettlementMode:        productcatalog.InvoiceOnlySettlementMode,
-			PaymentTerm:           productcatalog.InAdvancePaymentTerm,
-			ProRating:             productcatalog.ProRatingConfig{},
-			AmountBeforeProration: amount,
+			Status: chargeflatfee.StatusActive,
 		},
-		State: chargeflatfee.State{
-			AmountAfterProration: amount,
-		},
-		Status: meta.ChargeStatusActive,
 	}
 }
 
@@ -679,7 +683,7 @@ func (e *flatFeeHandlerTestEnv) newChargeWithAccruedUsage(total alpacadecimal.De
 	}
 
 	charge := e.newBaseCharge(servicePeriod, total)
-	charge.State.AccruedUsage = &invoicedusage.AccruedUsage{
+	charge.Realizations.AccruedUsage = &invoicedusage.AccruedUsage{
 		ServicePeriod: servicePeriod,
 		Mutable:       true,
 		Totals: totals.Totals{
@@ -718,8 +722,8 @@ func (e *flatFeeHandlerTestEnv) newChargeWithCreditRealizationsAndAccruedUsage(r
 	}
 
 	charge := e.newBaseCharge(servicePeriod, totalAmount)
-	charge.State.CreditRealizations = creditRealizations
-	charge.State.AccruedUsage = &invoicedusage.AccruedUsage{
+	charge.Realizations.CreditRealizations = creditRealizations
+	charge.Realizations.AccruedUsage = &invoicedusage.AccruedUsage{
 		ServicePeriod: servicePeriod,
 		Mutable:       true,
 		Totals: totals.Totals{
@@ -734,7 +738,7 @@ func (e *flatFeeHandlerTestEnv) newChargeWithCreditRealizationsAndAccruedUsage(r
 func (e *flatFeeHandlerTestEnv) newChargeWithPayment(total alpacadecimal.Decimal, authRef ledgertransaction.GroupReference) chargeflatfee.Charge {
 	now := time.Now().UTC()
 	charge := e.newChargeWithAccruedUsage(total)
-	charge.State.Payment = &payment.Invoiced{
+	charge.Realizations.Payment = &payment.Invoiced{
 		Payment: payment.Payment{
 			NamespacedID: models.NamespacedID{
 				Namespace: e.Namespace,

--- a/openmeter/ledger/customerbalance/calculation.go
+++ b/openmeter/ledger/customerbalance/calculation.go
@@ -38,7 +38,7 @@ func (i Impact) RealizedCredits() alpacadecimal.Decimal {
 	switch i.Type() {
 	case meta.ChargeTypeFlatFee:
 		charge, _ := i.AsFlatFeeCharge()
-		return charge.State.CreditRealizations.Sum()
+		return charge.Realizations.CreditRealizations.Sum()
 	case meta.ChargeTypeUsageBased:
 		charge, _ := i.AsUsageBasedCharge()
 		total := alpacadecimal.Zero

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -151,8 +151,8 @@ func (s *CreditsTestSuite) TestFlatFeeCreditOnlyDeleteCorrectionSanity() {
 
 	advancedCharge, err := advancedCharges[0].AsFlatFeeCharge()
 	s.NoError(err)
-	s.Equal(meta.ChargeStatusFinal, advancedCharge.Status)
-	s.Len(advancedCharge.State.CreditRealizations, 1)
+	s.Equal(flatfee.StatusFinal, advancedCharge.Status)
+	s.Len(advancedCharge.Realizations.CreditRealizations, 1)
 
 	s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromInt(-30)))
 	s.True(s.mustCustomerAccruedBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil)).Equal(alpacadecimal.NewFromInt(30)))
@@ -603,11 +603,11 @@ func (s *CreditsTestSuite) TestFlatFeeCreditThenInvoiceSanity() {
 
 		// Validate the credit realizations
 		// The charge should have $80 realized as credits
-		s.Len(updatedFlatFeeCharge.State.CreditRealizations, 2)
-		promotionalCreditRealization := updatedFlatFeeCharge.State.CreditRealizations[0]
+		s.Len(updatedFlatFeeCharge.Realizations.CreditRealizations, 2)
+		promotionalCreditRealization := updatedFlatFeeCharge.Realizations.CreditRealizations[0]
 		s.Equal(float64(30), promotionalCreditRealization.Amount.InexactFloat64())
 
-		customerCreditRealization := updatedFlatFeeCharge.State.CreditRealizations[1]
+		customerCreditRealization := updatedFlatFeeCharge.Realizations.CreditRealizations[1]
 		s.Equal(float64(50), customerCreditRealization.Amount.InexactFloat64())
 
 		assertDelta("promo FBO after invoice assignment", flatFeeStart.promoFBO, alpacadecimal.NewFromInt(-30), s.mustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&promoCostBasis)))
@@ -640,7 +640,7 @@ func (s *CreditsTestSuite) TestFlatFeeCreditThenInvoiceSanity() {
 		// - OnFlatFeePaymentAuthorized is called (I cannot make this a two step process without creating a new app) with the USD 20
 
 		// Invoice usage accrued callback should have been invoked
-		accruedUsage := updatedFlatFeeCharge.State.AccruedUsage
+		accruedUsage := updatedFlatFeeCharge.Realizations.AccruedUsage
 		s.NotNil(accruedUsage)
 		s.Equal(servicePeriod, accruedUsage.ServicePeriod, "service period should be the same as the input")
 		s.False(accruedUsage.Mutable, "accrued usage should not be mutable")
@@ -950,13 +950,13 @@ func (s *CreditsTestSuite) TestFlatFeeCreditOnlySanity() {
 		s.Equal(flatFeeChargeID.ID, advancedFlatFee.ID)
 		s.Equal(meta.ChargeStatusFinal, advancedFlatFee.Status)
 		// We expect three realizations here: promotional credit, purchased credit, and the synthetic shortfall coverage.
-		s.Len(advancedFlatFee.State.CreditRealizations, 3)
+		s.Len(advancedFlatFee.Realizations.CreditRealizations, 3)
 
 		fetchedCharge := s.mustGetChargeByID(flatFeeChargeID)
 		updatedFlatFeeCharge, err := fetchedCharge.AsFlatFeeCharge()
 		s.NoError(err)
-		s.Equal(meta.ChargeStatusFinal, updatedFlatFeeCharge.Status)
-		s.Len(updatedFlatFeeCharge.State.CreditRealizations, 3)
+		s.Equal(flatfee.StatusFinal, updatedFlatFeeCharge.Status)
+		s.Len(updatedFlatFeeCharge.Realizations.CreditRealizations, 3)
 
 		gatheringInvoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
 			Namespaces: []string{ns},

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -675,7 +675,7 @@ func (s *CreditsTestSuite) TestFlatFeeCreditThenInvoiceSanity() {
 		charge := s.mustGetChargeByID(flatFeeChargeID)
 		updatedFlatFeeCharge, err := charge.AsFlatFeeCharge()
 		s.NoError(err)
-		s.Equal(meta.ChargeStatusFinal, updatedFlatFeeCharge.Status)
+		s.Equal(flatfee.StatusFinal, updatedFlatFeeCharge.Status)
 
 		assertDelta("promo receivable after payment settlement", flatFeeStart.promoReceivable, alpacadecimal.Zero, s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen))
 		assertDelta("external receivable after payment settlement", flatFeeStart.externalReceivable, alpacadecimal.Zero, s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&externalCostBasis), ledger.TransactionAuthorizationStatusOpen))
@@ -915,7 +915,7 @@ func (s *CreditsTestSuite) TestFlatFeeCreditOnlySanity() {
 		s.NoError(err)
 
 		flatFeeChargeID = flatFeeCharge.GetChargeID()
-		s.Equal(meta.ChargeStatusCreated, flatFeeCharge.Status)
+		s.Equal(flatfee.StatusCreated, flatFeeCharge.Status)
 
 		gatheringInvoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
 			Namespaces: []string{ns},
@@ -948,7 +948,7 @@ func (s *CreditsTestSuite) TestFlatFeeCreditOnlySanity() {
 		advancedFlatFee, err := advancedCharges[0].AsFlatFeeCharge()
 		s.NoError(err)
 		s.Equal(flatFeeChargeID.ID, advancedFlatFee.ID)
-		s.Equal(meta.ChargeStatusFinal, advancedFlatFee.Status)
+		s.Equal(flatfee.StatusFinal, advancedFlatFee.Status)
 		// We expect three realizations here: promotional credit, purchased credit, and the synthetic shortfall coverage.
 		s.Len(advancedFlatFee.Realizations.CreditRealizations, 3)
 

--- a/tools/migrate/migrations/20260410132752_flat_fee_status_detailed.down.sql
+++ b/tools/migrate/migrations/20260410132752_flat_fee_status_detailed.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "charge_flat_fees" table
+ALTER TABLE "charge_flat_fees" DROP COLUMN "status_detailed";

--- a/tools/migrate/migrations/20260410132752_flat_fee_status_detailed.up.sql
+++ b/tools/migrate/migrations/20260410132752_flat_fee_status_detailed.up.sql
@@ -1,0 +1,5 @@
+-- modify "charge_flat_fees" table
+ALTER TABLE "charge_flat_fees" ADD COLUMN "status_detailed" character varying NULL;
+UPDATE "charge_flat_fees" SET "status_detailed" = "status";
+-- atlas:nolint MF104
+ALTER TABLE "charge_flat_fees" ALTER COLUMN "status_detailed" SET NOT NULL;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:v95ktNOwDMm7gmAmKGu3JqGMH/roQgLPgDfy6eWO8JI=
+h1:MZIrDgsLM16UBbmW6Jr6nOyLyMh1NuGkT8+H7ibo6Hs=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -178,3 +178,4 @@ h1:v95ktNOwDMm7gmAmKGu3JqGMH/roQgLPgDfy6eWO8JI=
 20260408082246_add_annotations_to_taxcode.up.sql h1:OFVNAijukvUz4nfnoxzbkL2F0myiNFNZchHBkNKWDkU=
 20260409112434_invoice-line-backend.up.sql h1:IAB7hvWq+fw30Y6fUAFrT0EndZ/k4UhxVzq6OB/nt4o=
 20260409130630_add_credit_realization_lineage.up.sql h1:6dB7wcaBcJEilSoVByeWxQBBLf7XVBAT7BQ7My/pXVc=
+20260410132752_flat_fee_status_detailed.up.sql h1:RlIrbITLGeIKKnclNTXUixwXndW0CPyAGeZ8TAfZk9c=


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Unify external data structure format between usage-based and flat fee charges.

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flat-fee charges now persist a dedicated, more detailed status and surface realized data (payments, credits, accrued usage) separately so readers see committed realizations explicitly.

* **Refactor**
  * Charge representation split into a durable base row and separate realization data, and services now update base vs. realization data independently to avoid redundant writes and clarify lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->