### PR TITLE
feat[charges]: common state machine operations

### DIFF
--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -70,6 +70,24 @@ type Charge struct {
 	Realizations Realizations `json:"realizations"`
 }
 
+func (c Charge) GetStatus() Status {
+	return c.Status
+}
+
+func (c Charge) WithStatus(status Status) Charge {
+	c.Status = status
+	return c
+}
+
+func (c Charge) GetBase() ChargeBase {
+	return c.ChargeBase
+}
+
+func (c Charge) WithBase(base ChargeBase) Charge {
+	c.ChargeBase = base
+	return c
+}
+
 func (c Charge) Validate() error {
 	var errs []error
 

--- a/openmeter/billing/charges/flatfee/service/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/creditsonly.go
@@ -122,5 +122,9 @@ func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, policy meta.
 		return fmt.Errorf("delete charge: %w", err)
 	}
 
-	return s.refetchCharge(ctx)
+	if err := s.RefetchCharge(ctx); err != nil {
+		return fmt.Errorf("get charge: %w", err)
+	}
+
+	return nil
 }

--- a/openmeter/billing/charges/flatfee/service/statemachine.go
+++ b/openmeter/billing/charges/flatfee/service/statemachine.go
@@ -5,29 +5,20 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/qmuntal/stateless"
-
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	flatfeerealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
-	"github.com/openmeterio/openmeter/pkg/models"
+	chargestatemachine "github.com/openmeterio/openmeter/openmeter/billing/charges/statemachine"
 )
 
 type stateMachine struct {
-	*stateless.StateMachine
-
-	Charge flatfee.Charge
+	*chargestatemachine.Machine[flatfee.Charge, flatfee.ChargeBase, flatfee.Status]
 
 	Adapter      flatfee.Adapter
 	Realizations *flatfeerealizations.Service
 }
 
-type StateMachine interface {
-	AdvanceUntilStateStable(ctx context.Context) (*flatfee.Charge, error)
-	CanFire(ctx context.Context, trigger meta.Trigger) (bool, error)
-	FireAndActivate(ctx context.Context, trigger meta.Trigger, args ...any) error
-	GetCharge() flatfee.Charge
-}
+type StateMachine = chargestatemachine.StateMachine[flatfee.Charge]
 
 type StateMachineConfig struct {
 	Charge flatfee.Charge
@@ -60,100 +51,29 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 	}
 
 	out := &stateMachine{
-		Charge:       config.Charge,
 		Adapter:      config.Adapter,
 		Realizations: config.Realizations,
 	}
 
-	stateMachine := stateless.NewStateMachineWithExternalStorage(
-		func(ctx context.Context) (stateless.State, error) {
-			return out.Charge.Status, nil
+	machine, err := chargestatemachine.New(chargestatemachine.Config[flatfee.Charge, flatfee.ChargeBase, flatfee.Status]{
+		Charge: config.Charge,
+		Persistence: chargestatemachine.Persistence[flatfee.Charge, flatfee.ChargeBase]{
+			UpdateBase: func(ctx context.Context, base flatfee.ChargeBase) (flatfee.ChargeBase, error) {
+				return out.Adapter.UpdateCharge(ctx, base)
+			},
+			Refetch: func(ctx context.Context, chargeID meta.ChargeID) (flatfee.Charge, error) {
+				return out.Adapter.GetByID(ctx, flatfee.GetByIDInput{
+					ChargeID: chargeID,
+					Expands:  meta.Expands{meta.ExpandRealizations},
+				})
+			},
 		},
-		func(ctx context.Context, state stateless.State) error {
-			newStatus := state.(flatfee.Status)
-			if err := newStatus.Validate(); err != nil {
-				return fmt.Errorf("invalid status: %w", err)
-			}
-
-			out.Charge.Status = newStatus
-			return nil
-		},
-		stateless.FiringImmediate,
-	)
-
-	out.StateMachine = stateMachine
-
-	return out, nil
-}
-
-var ErrUnsupportedOperation = models.NewGenericPreConditionFailedError(fmt.Errorf("unsupported operation"))
-
-func (s *stateMachine) CanFire(ctx context.Context, trigger meta.Trigger) (bool, error) {
-	return s.StateMachine.CanFireCtx(ctx, trigger)
-}
-
-func (s *stateMachine) FireAndActivate(ctx context.Context, trigger meta.Trigger, args ...any) error {
-	canFire, err := s.CanFire(ctx, trigger)
-	if err != nil {
-		return err
-	}
-
-	if !canFire {
-		return fmt.Errorf("%w: %s [status=%s,id=%s]", ErrUnsupportedOperation, trigger, s.Charge.Status, s.Charge.ID)
-	}
-
-	if err := s.StateMachine.FireCtx(ctx, trigger, args...); err != nil {
-		return err
-	}
-
-	return s.StateMachine.ActivateCtx(ctx)
-}
-
-func (s *stateMachine) AdvanceUntilStateStable(ctx context.Context) (*flatfee.Charge, error) {
-	var advanced bool
-
-	for {
-		canFire, err := s.StateMachine.CanFireCtx(ctx, meta.TriggerNext)
-		if err != nil {
-			return nil, err
-		}
-
-		if !canFire {
-			if !advanced {
-				return nil, nil
-			}
-
-			charge := s.Charge
-			return &charge, nil
-		}
-
-		if err := s.FireAndActivate(ctx, meta.TriggerNext); err != nil {
-			return nil, fmt.Errorf("cannot transition to the next status [current_status=%s]: %w", s.Charge.Status, err)
-		}
-
-		updatedChargeBase, err := s.Adapter.UpdateCharge(ctx, s.Charge.ChargeBase)
-		if err != nil {
-			return nil, fmt.Errorf("persist charge: %w", err)
-		}
-
-		s.Charge.ChargeBase = updatedChargeBase
-
-		advanced = true
-	}
-}
-
-func (s *stateMachine) refetchCharge(ctx context.Context) error {
-	charge, err := s.Adapter.GetByID(ctx, flatfee.GetByIDInput{
-		ChargeID: s.Charge.GetChargeID(),
 	})
 	if err != nil {
-		return fmt.Errorf("get charge: %w", err)
+		return nil, fmt.Errorf("new machine: %w", err)
 	}
 
-	s.Charge = charge
-	return nil
-}
+	out.Machine = machine
 
-func (s *stateMachine) GetCharge() flatfee.Charge {
-	return s.Charge
+	return out, nil
 }

--- a/openmeter/billing/charges/statemachine/machine.go
+++ b/openmeter/billing/charges/statemachine/machine.go
@@ -1,0 +1,176 @@
+package statemachine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/qmuntal/stateless"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type Status interface {
+	~string
+	Validate() error
+}
+
+type ChargeLike[CHARGE any, BASE any, STATUS Status] interface {
+	GetChargeID() meta.ChargeID
+	GetStatus() STATUS
+	WithStatus(STATUS) CHARGE
+	GetBase() BASE
+	WithBase(BASE) CHARGE
+}
+
+type Persistence[CHARGE any, BASE any] struct {
+	UpdateBase func(ctx context.Context, base BASE) (BASE, error)
+	Refetch    func(ctx context.Context, chargeID meta.ChargeID) (CHARGE, error)
+}
+
+type Config[CHARGE ChargeLike[CHARGE, BASE, STATUS], BASE any, STATUS Status] struct {
+	Charge      CHARGE
+	Persistence Persistence[CHARGE, BASE]
+}
+
+type StateMachine[CHARGE any] interface {
+	AdvanceUntilStateStable(ctx context.Context) (*CHARGE, error)
+	CanFire(ctx context.Context, trigger meta.Trigger) (bool, error)
+	FireAndActivate(ctx context.Context, trigger meta.Trigger, args ...any) error
+	GetCharge() CHARGE
+}
+
+func (c Config[CHARGE, BASE, STATUS]) Validate() error {
+	var errs []error
+
+	if c.Persistence.UpdateBase == nil {
+		errs = append(errs, errors.New("persistence.update base is required"))
+	}
+
+	if c.Persistence.Refetch == nil {
+		errs = append(errs, errors.New("persistence.refetch is required"))
+	}
+
+	return errors.Join(errs...)
+}
+
+type Machine[CHARGE ChargeLike[CHARGE, BASE, STATUS], BASE any, STATUS Status] struct {
+	Charge       CHARGE
+	stateMachine *stateless.StateMachine
+	config       Config[CHARGE, BASE, STATUS]
+}
+
+func New[CHARGE ChargeLike[CHARGE, BASE, STATUS], BASE any, STATUS Status](config Config[CHARGE, BASE, STATUS]) (*Machine[CHARGE, BASE, STATUS], error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("config: %w", err)
+	}
+
+	out := &Machine[CHARGE, BASE, STATUS]{
+		Charge: config.Charge,
+		config: config,
+	}
+
+	out.stateMachine = stateless.NewStateMachineWithExternalStorage(
+		func(ctx context.Context) (stateless.State, error) {
+			return out.Charge.GetStatus(), nil
+		},
+		func(ctx context.Context, state stateless.State) error {
+			newStatus := state.(STATUS)
+			if err := newStatus.Validate(); err != nil {
+				return fmt.Errorf("invalid status: %w", err)
+			}
+
+			out.Charge = out.Charge.WithStatus(newStatus)
+
+			return nil
+		},
+		stateless.FiringImmediate,
+	)
+
+	return out, nil
+}
+
+func (m *Machine[CHARGE, BASE, STATUS]) Configure(state STATUS) *stateless.StateConfiguration {
+	return m.stateMachine.Configure(state)
+}
+
+func (m *Machine[CHARGE, BASE, STATUS]) CanFire(ctx context.Context, trigger meta.Trigger) (bool, error) {
+	return m.stateMachine.CanFireCtx(ctx, trigger)
+}
+
+func (m *Machine[CHARGE, BASE, STATUS]) GetCharge() CHARGE {
+	return m.Charge
+}
+
+var ErrUnsupportedOperation = models.NewGenericPreConditionFailedError(fmt.Errorf("unsupported operation"))
+
+func (m *Machine[CHARGE, BASE, STATUS]) FireAndActivate(ctx context.Context, trigger meta.Trigger, args ...any) error {
+	canFire, err := m.CanFire(ctx, trigger)
+	if err != nil {
+		return err
+	}
+
+	if !canFire {
+		return fmt.Errorf(
+			"%w: %s [status=%s,id=%s]",
+			ErrUnsupportedOperation,
+			trigger,
+			m.Charge.GetStatus(),
+			m.Charge.GetChargeID().ID,
+		)
+	}
+
+	if err := m.stateMachine.FireCtx(ctx, trigger, args...); err != nil {
+		return err
+	}
+
+	return m.stateMachine.ActivateCtx(ctx)
+}
+
+func (m *Machine[CHARGE, BASE, STATUS]) AdvanceUntilStateStable(ctx context.Context) (*CHARGE, error) {
+	var advanced bool
+
+	for {
+		canFire, err := m.CanFire(ctx, meta.TriggerNext)
+		if err != nil {
+			return nil, err
+		}
+
+		if !canFire {
+			if !advanced {
+				return nil, nil
+			}
+
+			charge := m.Charge
+			return &charge, nil
+		}
+
+		currentStatus := m.Charge.GetStatus()
+
+		if err := m.FireAndActivate(ctx, meta.TriggerNext); err != nil {
+			return nil, fmt.Errorf("cannot transition to the next status [current_status=%s]: %w", currentStatus, err)
+		}
+
+		updatedBase, err := m.config.Persistence.UpdateBase(ctx, m.Charge.GetBase())
+		if err != nil {
+			return nil, fmt.Errorf("persist charge: %w", err)
+		}
+
+		m.Charge = m.Charge.WithBase(updatedBase)
+
+		advanced = true
+	}
+}
+
+func (m *Machine[CHARGE, BASE, STATUS]) RefetchCharge(ctx context.Context) error {
+	chargeID := m.Charge.GetChargeID()
+
+	charge, err := m.config.Persistence.Refetch(ctx, chargeID)
+	if err != nil {
+		return err
+	}
+
+	m.Charge = charge
+	return nil
+}

--- a/openmeter/billing/charges/statemachine/machine_test.go
+++ b/openmeter/billing/charges/statemachine/machine_test.go
@@ -1,0 +1,340 @@
+package statemachine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+)
+
+type fakeStatus string
+
+const (
+	fakeStatusCreated fakeStatus = "created"
+	fakeStatusActive  fakeStatus = "active"
+	fakeStatusFinal   fakeStatus = "final"
+)
+
+func (s fakeStatus) Validate() error {
+	switch s {
+	case fakeStatusCreated, fakeStatusActive, fakeStatusFinal:
+		return nil
+	default:
+		return fmt.Errorf("invalid fake status: %s", s)
+	}
+}
+
+type fakeBase struct {
+	Revision int
+}
+
+type fakeCharge struct {
+	ChargeID meta.ChargeID
+	Status   fakeStatus
+	Base     fakeBase
+	Marker   string
+}
+
+func (c fakeCharge) GetChargeID() meta.ChargeID {
+	return c.ChargeID
+}
+
+func (c fakeCharge) GetStatus() fakeStatus {
+	return c.Status
+}
+
+func (c fakeCharge) WithStatus(status fakeStatus) fakeCharge {
+	c.Status = status
+	return c
+}
+
+func (c fakeCharge) GetBase() fakeBase {
+	return c.Base
+}
+
+func (c fakeCharge) WithBase(base fakeBase) fakeCharge {
+	c.Base = base
+	return c
+}
+
+func newFakeCharge(status fakeStatus) fakeCharge {
+	return fakeCharge{
+		ChargeID: meta.ChargeID{
+			Namespace: "test-namespace",
+			ID:        "charge-1",
+		},
+		Status: status,
+		Base: fakeBase{
+			Revision: 0,
+		},
+		Marker: "initial",
+	}
+}
+
+func newTestMachine(
+	t *testing.T,
+	charge fakeCharge,
+	updateBase func(ctx context.Context, base fakeBase) (fakeBase, error),
+	refetch func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error),
+) *Machine[fakeCharge, fakeBase, fakeStatus] {
+	t.Helper()
+
+	machine, err := New(Config[fakeCharge, fakeBase, fakeStatus]{
+		Charge: charge,
+		Persistence: Persistence[fakeCharge, fakeBase]{
+			UpdateBase: updateBase,
+			Refetch:    refetch,
+		},
+	})
+	require.NoError(t, err)
+
+	return machine
+}
+
+func TestMachine_FireAndActivateUpdatesStatus(t *testing.T) {
+	// Given:
+	// a machine in created state with a next transition to active.
+	// When:
+	// FireAndActivate is called with the next trigger.
+	// Then:
+	// the machine updates the in-memory charge status to active.
+	machine := newTestMachine(
+		t,
+		newFakeCharge(fakeStatusCreated),
+		func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+	)
+
+	machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
+
+	err := machine.FireAndActivate(t.Context(), meta.TriggerNext)
+
+	require.NoError(t, err)
+	require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
+}
+
+func TestMachine_FireAndActivateReturnsUnsupportedOperationWhenTriggerCannotFire(t *testing.T) {
+	// Given:
+	// a machine in created state without a next transition.
+	// When:
+	// FireAndActivate is called with the next trigger.
+	// Then:
+	// the machine returns an unsupported-operation error that includes the trigger, status, and charge id.
+	machine := newTestMachine(
+		t,
+		newFakeCharge(fakeStatusCreated),
+		func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+	)
+
+	err := machine.FireAndActivate(t.Context(), meta.TriggerNext)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrUnsupportedOperation)
+	require.ErrorContains(t, err, fmt.Sprint(meta.TriggerNext))
+	require.ErrorContains(t, err, string(fakeStatusCreated))
+	require.ErrorContains(t, err, "charge-1")
+}
+
+func TestMachine_AdvanceUntilStateStableReturnsNilWhenAlreadyStable(t *testing.T) {
+	// Given:
+	// a machine already in a stable state with no next transition.
+	// When:
+	// AdvanceUntilStateStable is called.
+	// Then:
+	// it returns nil and does not persist the base.
+	var updateCalls int
+
+	machine := newTestMachine(
+		t,
+		newFakeCharge(fakeStatusFinal),
+		func(ctx context.Context, base fakeBase) (fakeBase, error) {
+			updateCalls++
+			return base, nil
+		},
+		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+	)
+
+	charge, err := machine.AdvanceUntilStateStable(t.Context())
+
+	require.NoError(t, err)
+	require.Nil(t, charge)
+	require.Zero(t, updateCalls)
+}
+
+func TestMachine_AdvanceUntilStateStableWalksTransitionsAndPersistsReturnedBase(t *testing.T) {
+	// Given:
+	// a machine that can advance from created to active to final.
+	// When:
+	// AdvanceUntilStateStable is called.
+	// Then:
+	// it walks all next transitions and the returned charge contains the persisted base returned by UpdateBase.
+	var updateCalls int
+
+	machine := newTestMachine(
+		t,
+		newFakeCharge(fakeStatusCreated),
+		func(ctx context.Context, base fakeBase) (fakeBase, error) {
+			updateCalls++
+			base.Revision++
+			return base, nil
+		},
+		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+	)
+
+	machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
+	machine.Configure(fakeStatusActive).Permit(meta.TriggerNext, fakeStatusFinal)
+
+	charge, err := machine.AdvanceUntilStateStable(t.Context())
+
+	require.NoError(t, err)
+	require.NotNil(t, charge)
+	require.Equal(t, fakeStatusFinal, charge.GetStatus())
+	require.Equal(t, 2, charge.GetBase().Revision)
+	require.Equal(t, 2, updateCalls)
+}
+
+func TestMachine_AdvanceUntilStateStablePersistsPostActivationBase(t *testing.T) {
+	// Given:
+	// a machine whose activation logic mutates the in-memory base before persistence.
+	// When:
+	// AdvanceUntilStateStable is called.
+	// Then:
+	// UpdateBase receives the post-activation base and the returned charge contains the persisted result.
+	var observedBase fakeBase
+
+	machine := newTestMachine(
+		t,
+		newFakeCharge(fakeStatusCreated),
+		func(ctx context.Context, base fakeBase) (fakeBase, error) {
+			observedBase = base
+			base.Revision++
+			return base, nil
+		},
+		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+	)
+
+	machine.Configure(fakeStatusCreated).
+		Permit(meta.TriggerNext, fakeStatusActive)
+	machine.Configure(fakeStatusActive).OnActive(func(ctx context.Context) error {
+		machine.Charge = machine.Charge.WithBase(fakeBase{Revision: 7})
+		return nil
+	})
+
+	charge, err := machine.AdvanceUntilStateStable(t.Context())
+
+	require.NoError(t, err)
+	require.NotNil(t, charge)
+	require.Equal(t, 7, observedBase.Revision)
+	require.Equal(t, 8, charge.GetBase().Revision)
+}
+
+func TestMachine_FireAndActivatePropagatesActivationErrors(t *testing.T) {
+	// Given:
+	// a machine whose activation callback fails after a valid transition fires.
+	// When:
+	// FireAndActivate is called.
+	// Then:
+	// the activation error is returned to the caller.
+	activationErr := errors.New("activation failed")
+
+	machine := newTestMachine(
+		t,
+		newFakeCharge(fakeStatusCreated),
+		func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+	)
+
+	machine.Configure(fakeStatusCreated).
+		Permit(meta.TriggerNext, fakeStatusActive)
+	machine.Configure(fakeStatusActive).OnActive(func(ctx context.Context) error {
+		return activationErr
+	})
+
+	err := machine.FireAndActivate(t.Context(), meta.TriggerNext)
+
+	require.ErrorIs(t, err, activationErr)
+}
+
+func TestMachine_FireAndActivateFailsFastOnInvalidTargetStatus(t *testing.T) {
+	// Given:
+	// a machine with a transition targeting an invalid status value.
+	// When:
+	// FireAndActivate is called.
+	// Then:
+	// it fails before any persistence logic is involved.
+	machine := newTestMachine(
+		t,
+		newFakeCharge(fakeStatusCreated),
+		func(ctx context.Context, base fakeBase) (fakeBase, error) {
+			t.Fatal("UpdateBase must not be called")
+			return fakeBase{}, nil
+		},
+		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+	)
+
+	machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatus("broken"))
+
+	err := machine.FireAndActivate(t.Context(), meta.TriggerNext)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid status")
+}
+
+func TestMachine_RefetchChargeReplacesTheInMemoryCharge(t *testing.T) {
+	// Given:
+	// a machine whose persistence layer can refetch a different copy of the charge.
+	// When:
+	// RefetchCharge is called.
+	// Then:
+	// the machine replaces the in-memory charge with the refetched object.
+	machine := newTestMachine(
+		t,
+		newFakeCharge(fakeStatusCreated),
+		func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) {
+			charge := newFakeCharge(fakeStatusFinal)
+			charge.Base = fakeBase{Revision: 11}
+			charge.Marker = "refetched"
+			return charge, nil
+		},
+	)
+
+	err := machine.RefetchCharge(t.Context())
+
+	require.NoError(t, err)
+	require.Equal(t, fakeStatusFinal, machine.GetCharge().GetStatus())
+	require.Equal(t, 11, machine.GetCharge().GetBase().Revision)
+	require.Equal(t, "refetched", machine.GetCharge().Marker)
+}
+
+func TestMachine_AdvanceUntilStateStablePropagatesPersistenceErrors(t *testing.T) {
+	// Given:
+	// a machine that can advance but fails while persisting the updated base.
+	// When:
+	// AdvanceUntilStateStable is called.
+	// Then:
+	// it returns the wrapped persistence error and stops advancing.
+	persistErr := errors.New("persist failed")
+
+	machine := newTestMachine(
+		t,
+		newFakeCharge(fakeStatusCreated),
+		func(ctx context.Context, base fakeBase) (fakeBase, error) {
+			return fakeBase{}, persistErr
+		},
+		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+	)
+
+	machine.Configure(fakeStatusCreated).Permit(meta.TriggerNext, fakeStatusActive)
+
+	charge, err := machine.AdvanceUntilStateStable(t.Context())
+
+	require.Nil(t, charge)
+	require.ErrorIs(t, err, persistErr)
+	require.ErrorContains(t, err, "persist charge")
+}

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -72,6 +72,24 @@ type Charge struct {
 
 type Charges []Charge
 
+func (c Charge) GetStatus() Status {
+	return c.Status
+}
+
+func (c Charge) WithStatus(status Status) Charge {
+	c.Status = status
+	return c
+}
+
+func (c Charge) GetBase() ChargeBase {
+	return c.ChargeBase
+}
+
+func (c Charge) WithBase(base ChargeBase) Charge {
+	c.ChargeBase = base
+	return c
+}
+
 func (c Charge) Validate() error {
 	var errs []error
 

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -116,7 +116,11 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, _ meta
 		return fmt.Errorf("delete charge: %w", err)
 	}
 
-	return s.refetchCharge(ctx)
+	if err := s.RefetchCharge(ctx); err != nil {
+		return fmt.Errorf("get charge: %w", err)
+	}
+
+	return nil
 }
 
 type invoiceCreatedInput struct {

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -137,7 +137,11 @@ func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, policy meta.
 		return fmt.Errorf("delete charge: %w", err)
 	}
 
-	return s.refetchCharge(ctx)
+	if err := s.RefetchCharge(ctx); err != nil {
+		return fmt.Errorf("get charge: %w", err)
+	}
+
+	return nil
 }
 
 func (s *CreditsOnlyStateMachine) StartFinalRealizationRun(ctx context.Context) error {
@@ -218,7 +222,7 @@ func (s *CreditsOnlyStateMachine) FinalizeRealizationRun(ctx context.Context) er
 		return fmt.Errorf("update charge: %w", err)
 	}
 
-	if err := s.refetchCharge(ctx); err != nil {
+	if err := s.RefetchCharge(ctx); err != nil {
 		return fmt.Errorf("refetch charge: %w", err)
 	}
 

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/samber/lo"
 	"log/slog"
 	"time"
+
+	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/samber/lo"
 	"log/slog"
 	"time"
 
-	"github.com/qmuntal/stateless"
-	"github.com/samber/lo"
-
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	chargestatemachine "github.com/openmeterio/openmeter/openmeter/billing/charges/statemachine"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	usagebasedrating "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/rating"
 	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
@@ -21,9 +20,7 @@ import (
 )
 
 type stateMachine struct {
-	*stateless.StateMachine
-
-	Charge usagebased.Charge
+	*chargestatemachine.Machine[usagebased.Charge, usagebased.ChargeBase, usagebased.Status]
 
 	Logger *slog.Logger
 
@@ -36,12 +33,7 @@ type stateMachine struct {
 	CurrencyCalculator currencyx.Calculator
 }
 
-type StateMachine interface {
-	AdvanceUntilStateStable(ctx context.Context) (*usagebased.Charge, error)
-	CanFire(ctx context.Context, trigger meta.Trigger) (bool, error)
-	FireAndActivate(ctx context.Context, trigger meta.Trigger, args ...any) error
-	GetCharge() usagebased.Charge
-}
+type StateMachine = chargestatemachine.StateMachine[usagebased.Charge]
 
 type StateMachineConfig struct {
 	Charge             usagebased.Charge
@@ -98,7 +90,6 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 	}
 
 	out := &stateMachine{
-		Charge:             config.Charge,
 		Logger:             lo.CoalesceOrEmpty(config.Logger, slog.Default()),
 		Adapter:            config.Adapter,
 		Rater:              config.Rater,
@@ -108,49 +99,27 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 		CurrencyCalculator: config.CurrencyCalculator,
 	}
 
-	stateMachine := stateless.NewStateMachineWithExternalStorage(
-		func(ctx context.Context) (stateless.State, error) {
-			return out.Charge.Status, nil
+	machine, err := chargestatemachine.New(chargestatemachine.Config[usagebased.Charge, usagebased.ChargeBase, usagebased.Status]{
+		Charge: config.Charge,
+		Persistence: chargestatemachine.Persistence[usagebased.Charge, usagebased.ChargeBase]{
+			UpdateBase: func(ctx context.Context, base usagebased.ChargeBase) (usagebased.ChargeBase, error) {
+				return out.Adapter.UpdateCharge(ctx, base)
+			},
+			Refetch: func(ctx context.Context, chargeID meta.ChargeID) (usagebased.Charge, error) {
+				return out.Adapter.GetByID(ctx, usagebased.GetByIDInput{
+					ChargeID: chargeID,
+					Expands:  meta.Expands{meta.ExpandRealizations},
+				})
+			},
 		},
-		func(ctx context.Context, state stateless.State) error {
-			newStatus := state.(usagebased.Status)
-			if err := newStatus.Validate(); err != nil {
-				return fmt.Errorf("invalid status: %w", err)
-			}
-
-			out.Charge.Status = newStatus
-			return nil
-		},
-		stateless.FiringImmediate,
-	)
-
-	out.StateMachine = stateMachine
-
-	return out, nil
-}
-
-// refetchCharge refetches the charge from the database and updates the state machine's charge.
-// The adapter's modification functions should properly support updating the charge in memory, as
-// a yearly charge with daily realization lifecycle will have a lot of realizations thus a lot of data
-// should be loaded.
-//
-// Use this where the final implementation is uncertain for now.
-func (s *stateMachine) refetchCharge(ctx context.Context) error {
-	charge, err := s.Adapter.GetByID(ctx, usagebased.GetByIDInput{
-		ChargeID: s.Charge.GetChargeID(),
-		Expands:  meta.Expands{meta.ExpandRealizations},
 	})
 	if err != nil {
-		return fmt.Errorf("get charge: %w", err)
+		return nil, fmt.Errorf("new machine: %w", err)
 	}
 
-	s.Charge = charge
+	out.Machine = machine
 
-	return nil
-}
-
-func (s *stateMachine) GetCharge() usagebased.Charge {
-	return s.Charge
+	return out, nil
 }
 
 func (s *stateMachine) IsInsideServicePeriod() bool {
@@ -214,49 +183,4 @@ func (s *stateMachine) getCurrentRunCollectionEnd() (time.Time, error) {
 	}
 
 	return meta.NormalizeTimestamp(currentRun.CollectionEnd), nil
-}
-
-func (s *stateMachine) FireAndActivate(ctx context.Context, trigger meta.Trigger, args ...any) error {
-	if err := s.StateMachine.FireCtx(ctx, trigger, args...); err != nil {
-		return err
-	}
-
-	return s.StateMachine.ActivateCtx(ctx)
-}
-
-func (s *stateMachine) CanFire(ctx context.Context, trigger meta.Trigger) (bool, error) {
-	return s.StateMachine.CanFireCtx(ctx, trigger)
-}
-
-func (s *stateMachine) AdvanceUntilStateStable(ctx context.Context) (*usagebased.Charge, error) {
-	var advanced bool
-
-	for {
-		canFire, err := s.StateMachine.CanFireCtx(ctx, meta.TriggerNext)
-		if err != nil {
-			return nil, err
-		}
-
-		if !canFire {
-			if !advanced {
-				return nil, nil
-			}
-
-			charge := s.Charge
-			return &charge, nil
-		}
-
-		if err := s.FireAndActivate(ctx, meta.TriggerNext); err != nil {
-			return nil, fmt.Errorf("cannot transition to the next status [current_status=%s]: %w", s.Charge.Status, err)
-		}
-
-		updatedChargeBase, err := s.Adapter.UpdateCharge(ctx, s.Charge.ChargeBase)
-		if err != nil {
-			return nil, fmt.Errorf("persist charge: %w", err)
-		}
-
-		s.Charge.ChargeBase = updatedChargeBase
-
-		advanced = true
-	}
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Unify base state machine. This is essential so that the Fire/CanFire etc. behaves consistently between charges components.

Given there are different flavors of charges, there were already drifts happening.

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a generic, unified billing charge state machine for consistent behavior across charge types; standardized charge status/base accessors and mutators.

* **New Features**
  * Exposed charge accessors and mutator-style methods for status and base on multiple charge types.

* **Bug Fixes**
  * Improved error handling for charge deletion and post-delete refresh operations.

* **Tests**
  * Added unit tests covering state transitions, persistence, activation, and refetch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->