### PR TITLE
feat: implement realtime expand

### DIFF
--- a/api/v3/handlers/customers/charges/convert.go
+++ b/api/v3/handlers/customers/charges/convert.go
@@ -157,9 +157,15 @@ func convertChargeToAPI(charge billingcharges.Charge) (api.BillingCharge, error)
 
 // convertUsageBasedChargeTotals aggregates booked totals from persisted realization runs.
 func convertUsageBasedChargeTotals(charge usagebased.Charge) api.BillingChargeTotals {
-	return api.BillingChargeTotals{
+	out := api.BillingChargeTotals{
 		Booked: toAPIBillingTotals(charge.Realizations.Sum()),
 	}
+
+	if charge.Expands.RealtimeUsage != nil {
+		out.Realtime = lo.ToPtr(toAPIBillingTotals(*charge.Expands.RealtimeUsage))
+	}
+
+	return out
 }
 
 // toAPIBillingTotals maps a domain totals.Totals to the API BillingTotals type.

--- a/api/v3/handlers/customers/charges/list.go
+++ b/api/v3/handlers/customers/charges/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/samber/lo"
@@ -56,14 +57,19 @@ func (h *handler) ListCustomerCharges() ListCustomerChargesHandler {
 				})
 			}
 
+			// Realization runs are always required to compute booked totals.
+			expands := meta.Expands{meta.ExpandRealizations}
+			if args.Params.Expand != nil && slices.Contains(*args.Params.Expand, api.BillingChargesExpandRealTimeUsage) {
+				expands = expands.With(meta.ExpandRealtimeUsage)
+			}
+
 			req := ListCustomerChargesRequest{
 				Page:        page,
 				Namespace:   ns,
 				CustomerIDs: []string{args.CustomerID},
 				// Credit purchases are served by the credit grants API; exclude them here.
 				ChargeTypes: []meta.ChargeType{meta.ChargeTypeFlatFee, meta.ChargeTypeUsageBased},
-				// Realization runs are always required to compute booked totals.
-				Expands: meta.Expands{meta.ExpandRealizations},
+				Expands:     expands,
 			}
 
 			// Parse sort. When omitted, the service defaults to created_at ascending

--- a/openmeter/billing/charges/adapter/search.go
+++ b/openmeter/billing/charges/adapter/search.go
@@ -70,7 +70,9 @@ func (a *adapter) ListCharges(ctx context.Context, input charges.ListChargesInpu
 
 		if len(input.StatusIn) > 0 {
 			query = query.Where(dbchargessearchv1.StatusIn(input.StatusIn...))
-		} else if len(input.StatusNotIn) > 0 {
+		}
+
+		if len(input.StatusNotIn) > 0 {
 			query = query.Where(dbchargessearchv1.StatusNotIn(input.StatusNotIn...))
 		}
 

--- a/openmeter/billing/charges/meta/charge.go
+++ b/openmeter/billing/charges/meta/charge.go
@@ -67,12 +67,14 @@ func (t ChargeType) Validate() error {
 type Expand string
 
 const (
-	ExpandRealizations Expand = "realizations"
+	ExpandRealizations  Expand = "realizations"
+	ExpandRealtimeUsage Expand = "realtime_usage"
 )
 
 func (e Expand) Values() []Expand {
 	return []Expand{
 		ExpandRealizations,
+		ExpandRealtimeUsage,
 	}
 }
 

--- a/openmeter/billing/charges/service.go
+++ b/openmeter/billing/charges/service.go
@@ -144,13 +144,9 @@ type ListChargesInput struct {
 	CustomerIDs     []string
 	SubscriptionIDs []string
 	ChargeTypes     []meta.ChargeType
-	// StatusIn filters to only charges with one of the given statuses.
-	// Takes precedence over StatusNotIn when both are set.
-	// When empty and StatusNotIn is also empty, deleted charges are still
-	// excluded via the IncludeDeleted flag.
-	StatusIn       []meta.ChargeStatus
-	StatusNotIn    []meta.ChargeStatus
-	IncludeDeleted bool
+	StatusIn        []meta.ChargeStatus
+	StatusNotIn     []meta.ChargeStatus
+	IncludeDeleted  bool
 
 	// OrderBy is the field to sort by. Supported values: id, created_at,
 	// service_period.from, billing_period.from.
@@ -196,6 +192,10 @@ func (i ListChargesInput) Validate() error {
 		if err := status.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("status: %w", err))
 		}
+	}
+
+	if len(i.StatusIn) > 0 && len(i.StatusNotIn) > 0 {
+		errs = append(errs, errors.New("status_in and status_not_in cannot be set at the same time"))
 	}
 
 	if err := i.Expands.Validate(); err != nil {

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -8,6 +8,8 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -68,6 +70,7 @@ type Charge struct {
 	ChargeBase
 
 	Realizations RealizationRuns `json:"realizations"`
+	Expands      Expands         `json:"expands"`
 }
 
 type Charges []Charge
@@ -88,6 +91,13 @@ func (c Charge) GetCurrentRealizationRun() (RealizationRun, error) {
 	}
 
 	return c.Realizations.GetByID(*c.State.CurrentRealizationRunID)
+}
+
+func (c Charge) GetCustomerID() customer.CustomerID {
+	return customer.CustomerID{
+		Namespace: c.Namespace,
+		ID:        c.Intent.CustomerID,
+	}
 }
 
 func (c Charge) GetFeatureKeyOrID() ref.IDOrKey {
@@ -209,6 +219,22 @@ func (s State) Validate() error {
 
 	if s.FeatureID == "" {
 		errs = append(errs, fmt.Errorf("feature id must be set"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type Expands struct {
+	RealtimeUsage *totals.Totals `json:"realtimeUsage,omitempty"`
+}
+
+func (e Expands) Validate() error {
+	var errs []error
+
+	if e.RealtimeUsage != nil {
+		if err := e.RealtimeUsage.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("realtime usage: %w", err))
+		}
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -82,6 +82,10 @@ func (c Charge) Validate() error {
 		errs = append(errs, fmt.Errorf("charge base: %w", err))
 	}
 
+	if err := c.Expands.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("expands: %w", err))
+	}
+
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 

--- a/openmeter/billing/charges/usagebased/service/get.go
+++ b/openmeter/billing/charges/usagebased/service/get.go
@@ -141,16 +141,18 @@ func (s *service) expandChargesUsage(ctx context.Context, namespace string, char
 				}
 			}()
 
-				ratingResult, err := s.rater.GetRatingForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
-					Charge:         charge,
-					Customer:       customerOverridesById[charge.GetCustomerID()],
-					FeatureMeter:   featureMeter,
-					StoredAtOffset: storedAt,
-				})
-				if err != nil {
-					err = fmt.Errorf("rating charge %s: %w", charge.ID, err)
-					return
-				}
+			var ratingResult usagebasedrating.GetRatingForUsageResult
+			ratingResult, err = s.rater.GetRatingForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
+				Charge:         charge,
+				Customer:       customerOverridesById[charge.GetCustomerID()],
+				FeatureMeter:   featureMeter,
+				StoredAtOffset: storedAt,
+			})
+			if err != nil {
+				err = fmt.Errorf("rating charge %s: %w", charge.ID, err)
+				return
+			}
+
 			ratingResults.Store(charge.GetChargeID(), ratingResult)
 		})
 	}

--- a/openmeter/billing/charges/usagebased/service/get.go
+++ b/openmeter/billing/charges/usagebased/service/get.go
@@ -2,9 +2,25 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"sync"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	usagebasedrating "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/rating"
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/ref"
+	"github.com/openmeterio/openmeter/pkg/slicesx"
+	"github.com/samber/lo"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	defaultWorkerCount = 5
 )
 
 func (s *service) GetByIDs(ctx context.Context, input usagebased.GetByIDsInput) ([]usagebased.Charge, error) {
@@ -13,7 +29,19 @@ func (s *service) GetByIDs(ctx context.Context, input usagebased.GetByIDsInput) 
 	}
 
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) ([]usagebased.Charge, error) {
-		return s.adapter.GetByIDs(ctx, input)
+		charges, err := s.adapter.GetByIDs(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+
+		if input.Expands.Has(meta.ExpandRealtimeUsage) {
+			charges, err = s.expandChargesUsage(ctx, input.Namespace, charges)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return charges, nil
 	})
 }
 
@@ -23,6 +51,136 @@ func (s *service) GetByID(ctx context.Context, input usagebased.GetByIDInput) (u
 	}
 
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (usagebased.Charge, error) {
-		return s.adapter.GetByID(ctx, input)
+		charge, err := s.adapter.GetByID(ctx, input)
+		if err != nil {
+			return usagebased.Charge{}, err
+		}
+
+		if input.Expands.Has(meta.ExpandRealtimeUsage) {
+			totals, err := s.GetCurrentTotals(ctx, usagebased.GetCurrentTotalsInput{
+				ChargeID: charge.GetChargeID(),
+			})
+			if err != nil {
+				return usagebased.Charge{}, err
+			}
+
+			charge.Expands.RealtimeUsage = &totals.DueTotals
+		}
+
+		return charge, nil
+	})
+}
+
+func (s *service) expandChargesUsage(ctx context.Context, namespace string, charges usagebased.Charges) (usagebased.Charges, error) {
+	// Fetch unique customers from the charges to avoid duplicate calls to the customer override service.
+	uniqueCustomers := lo.Uniq(lo.Map(charges, func(charge usagebased.Charge, _ int) customer.CustomerID {
+		return charge.GetCustomerID()
+	}))
+
+	customerOverridesById := make(map[customer.CustomerID]billing.CustomerOverrideWithDetails)
+	for _, customerID := range uniqueCustomers {
+		customerOverride, err := s.customerOverrideService.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
+			Customer: customerID,
+			Expand: billing.CustomerOverrideExpand{
+				Customer: true,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		customerOverridesById[customerID] = customerOverride
+	}
+
+	// Fetch all references featureMeters in bulk
+	referencedFeatureMeters := lo.Uniq(lo.Map(charges, func(charge usagebased.Charge, _ int) ref.IDOrKey {
+		return charge.GetFeatureKeyOrID()
+	}))
+
+	featureMeters, err := s.featureService.ResolveFeatureMeters(ctx, namespace, referencedFeatureMeters...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Let's do the rating for each charge
+	sem := semaphore.NewWeighted(int64(defaultWorkerCount))
+
+	errCh := make(chan error, len(charges))
+	ratingResults := sync.Map{}
+
+	var wg sync.WaitGroup
+
+	for _, charge := range charges {
+		err := sem.Acquire(ctx, 1)
+		if err != nil {
+			// Clean up and stop the loop
+			errCh <- fmt.Errorf("acquiring worker slot: %w", err)
+			break
+		}
+
+		featureMeter, err := charge.ResolveFeatureMeter(featureMeters)
+		if err != nil {
+			errCh <- fmt.Errorf("resolving feature meter: %w", err)
+			break
+		}
+
+		wg.Go(func() {
+			defer sem.Release(1)
+			var err error
+			defer func() {
+				if err != nil {
+					errCh <- err
+				}
+			}()
+
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("rating charge %s: %v", charge.ID, r)
+				}
+			}()
+
+			ratingResult, err := s.rater.GetRatingForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
+				Charge:         charge,
+				Customer:       customerOverridesById[charge.GetCustomerID()],
+				FeatureMeter:   featureMeter,
+				StoredAtOffset: clock.Now(),
+			})
+			if err != nil {
+				errCh <- fmt.Errorf("rating charge %s: %w", charge.ID, err)
+				return
+			}
+			ratingResults.Store(charge.GetChargeID(), ratingResult)
+		})
+
+	}
+
+	wg.Wait()
+
+	close(errCh)
+
+	var errs []error
+
+	for err := range errCh {
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	return slicesx.MapWithErr(charges, func(charge usagebased.Charge) (usagebased.Charge, error) {
+		ratingResultAny, ok := ratingResults.Load(charge.GetChargeID())
+		if !ok {
+			return charge, fmt.Errorf("rating result not found for charge %s", charge.ID)
+		}
+
+		ratingResult, ok := ratingResultAny.(usagebasedrating.GetRatingForUsageResult)
+		if !ok {
+			return charge, fmt.Errorf("rating result not found for charge %s", charge.ID)
+		}
+
+		charge.Expands.RealtimeUsage = &ratingResult.Totals
+		return charge, nil
 	})
 }

--- a/openmeter/billing/charges/usagebased/service/get.go
+++ b/openmeter/billing/charges/usagebased/service/get.go
@@ -21,8 +21,8 @@ import (
 )
 
 const (
-	// defaultWorkerCount is the number of workers to use for the rating (fetching from CH).
-	defaultWorkerCount = 5
+	// defaultMaxParallelRatingsPerRequest is the number of workers to use for the rating (fetching from CH).
+	defaultMaxParallelRatingsPerRequest = 5
 )
 
 func (s *service) GetByIDs(ctx context.Context, input usagebased.GetByIDsInput) ([]usagebased.Charge, error) {
@@ -104,7 +104,8 @@ func (s *service) expandChargesUsage(ctx context.Context, namespace string, char
 	}
 
 	// Let's do the rating for each charge
-	sem := semaphore.NewWeighted(int64(defaultWorkerCount))
+	sem := semaphore.NewWeighted(int64(defaultMaxParallelRatingsPerRequest))
+	storedAt := clock.Now()
 
 	errCh := make(chan error, len(charges))
 	ratingResults := sync.Map{}
@@ -140,16 +141,16 @@ func (s *service) expandChargesUsage(ctx context.Context, namespace string, char
 				}
 			}()
 
-			ratingResult, err := s.rater.GetRatingForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
-				Charge:         charge,
-				Customer:       customerOverridesById[charge.GetCustomerID()],
-				FeatureMeter:   featureMeter,
-				StoredAtOffset: clock.Now(),
-			})
-			if err != nil {
-				errCh <- fmt.Errorf("rating charge %s: %w", charge.ID, err)
-				return
-			}
+				ratingResult, err := s.rater.GetRatingForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
+					Charge:         charge,
+					Customer:       customerOverridesById[charge.GetCustomerID()],
+					FeatureMeter:   featureMeter,
+					StoredAtOffset: storedAt,
+				})
+				if err != nil {
+					err = fmt.Errorf("rating charge %s: %w", charge.ID, err)
+					return
+				}
 			ratingResults.Store(charge.GetChargeID(), ratingResult)
 		})
 	}

--- a/openmeter/billing/charges/usagebased/service/get.go
+++ b/openmeter/billing/charges/usagebased/service/get.go
@@ -113,7 +113,6 @@ func (s *service) expandChargesUsage(ctx context.Context, namespace string, char
 	var wg sync.WaitGroup
 
 	for _, charge := range charges {
-
 		featureMeter, err := charge.ResolveFeatureMeter(featureMeters)
 		if err != nil {
 			errCh <- fmt.Errorf("resolving feature meter: %w", err)

--- a/openmeter/billing/charges/usagebased/service/get.go
+++ b/openmeter/billing/charges/usagebased/service/get.go
@@ -113,16 +113,17 @@ func (s *service) expandChargesUsage(ctx context.Context, namespace string, char
 	var wg sync.WaitGroup
 
 	for _, charge := range charges {
-		err := sem.Acquire(ctx, 1)
-		if err != nil {
-			// Clean up and stop the loop
-			errCh <- fmt.Errorf("acquiring worker slot: %w", err)
-			break
-		}
 
 		featureMeter, err := charge.ResolveFeatureMeter(featureMeters)
 		if err != nil {
 			errCh <- fmt.Errorf("resolving feature meter: %w", err)
+			break
+		}
+
+		err = sem.Acquire(ctx, 1)
+		if err != nil {
+			// Clean up and stop the loop
+			errCh <- fmt.Errorf("acquiring worker slot: %w", err)
 			break
 		}
 

--- a/openmeter/billing/charges/usagebased/service/get.go
+++ b/openmeter/billing/charges/usagebased/service/get.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/samber/lo"
+	"golang.org/x/sync/semaphore"
+
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
@@ -15,11 +18,10 @@ import (
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/ref"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
-	"github.com/samber/lo"
-	"golang.org/x/sync/semaphore"
 )
 
 const (
+	// defaultWorkerCount is the number of workers to use for the rating (fetching from CH).
 	defaultWorkerCount = 5
 )
 
@@ -150,7 +152,6 @@ func (s *service) expandChargesUsage(ctx context.Context, namespace string, char
 			}
 			ratingResults.Store(charge.GetChargeID(), ratingResult)
 		})
-
 	}
 
 	wg.Wait()

--- a/test/credits/rating_test.go
+++ b/test/credits/rating_test.go
@@ -1,0 +1,121 @@
+package credits
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestRatingTestSuite(t *testing.T) {
+	suite.Run(t, new(RatingTestSuite))
+}
+
+type RatingTestSuite struct {
+	CreditsTestSuite
+}
+
+func (s *RatingTestSuite) TestListChargesExpandsRealtimeUsageForMultipleUsageBasedCharges() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("credits-rating-list-charges")
+
+	const (
+		standardRateReference = "usage-based-standard-rate"
+		doubleRateReference   = "usage-based-double-rate"
+	)
+
+	cust := s.createLedgerBackedCustomer(ns, "rating-list-charges")
+	sandboxApp := s.InstallSandboxApp(s.T(), ns)
+	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-03-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-04-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	createAt := servicePeriod.From
+	firstUsageAt := servicePeriod.From.Add(2 * time.Hour)
+	secondUsageAt := servicePeriod.From.Add(5 * time.Hour)
+	readAt := servicePeriod.From.Add(4 * time.Hour)
+
+	clock.SetTime(createAt)
+	defer clock.ResetTime()
+
+	createdCharges, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:          cust.GetID(),
+				currency:          USD,
+				servicePeriod:     servicePeriod,
+				settlementMode:    productcatalog.InvoiceOnlySettlementMode,
+				price:             productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+				name:              standardRateReference,
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: standardRateReference,
+				featureKey:        apiRequestsTotal.Feature.Key,
+			}),
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:          cust.GetID(),
+				currency:          USD,
+				servicePeriod:     servicePeriod,
+				settlementMode:    productcatalog.InvoiceOnlySettlementMode,
+				price:             productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(2)}),
+				name:              doubleRateReference,
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: doubleRateReference,
+				featureKey:        apiRequestsTotal.Feature.Key,
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Len(createdCharges, 2)
+
+	// One event is before the service period and must not affect the current totals.
+	s.MockStreamingConnector.AddSimpleEvent(apiRequestsTotal.Feature.Key, 100, servicePeriod.From.Add(-time.Minute))
+	// Two in-period events are visible at readAt and should be summed by realtime usage expansion.
+	s.MockStreamingConnector.AddSimpleEvent(apiRequestsTotal.Feature.Key, 2, firstUsageAt)
+	s.MockStreamingConnector.AddSimpleEvent(apiRequestsTotal.Feature.Key, 5, secondUsageAt)
+	clock.SetTime(readAt)
+
+	result, err := s.Charges.ListCharges(ctx, charges.ListChargesInput{
+		Page:        pagination.NewPage(1, 20),
+		Namespace:   ns,
+		CustomerIDs: []string{cust.ID},
+		ChargeTypes: []meta.ChargeType{meta.ChargeTypeUsageBased},
+		Expands: meta.Expands{
+			meta.ExpandRealizations,
+			meta.ExpandRealtimeUsage,
+		},
+	})
+	s.NoError(err)
+	s.Len(result.Items, 2)
+
+	realtimeByReference := map[string]alpacadecimal.Decimal{}
+	bookedByReference := map[string]alpacadecimal.Decimal{}
+	for _, item := range result.Items {
+		charge, err := item.AsUsageBasedCharge()
+		s.NoError(err)
+
+		s.NotNil(charge.Expands.RealtimeUsage)
+		s.NotNil(charge.Intent.UniqueReferenceID)
+		realtimeByReference[*charge.Intent.UniqueReferenceID] = charge.Expands.RealtimeUsage.Total
+		bookedByReference[*charge.Intent.UniqueReferenceID] = charge.Realizations.Sum().Total
+	}
+
+	s.True(alpacadecimal.NewFromInt(7).Equal(realtimeByReference[standardRateReference]))
+	s.True(alpacadecimal.NewFromInt(14).Equal(realtimeByReference[doubleRateReference]))
+	s.True(alpacadecimal.Zero.Equal(bookedByReference[standardRateReference]))
+	s.True(alpacadecimal.Zero.Equal(bookedByReference[doubleRateReference]))
+}

--- a/test/credits/rating_test.go
+++ b/test/credits/rating_test.go
@@ -47,7 +47,7 @@ func (s *RatingTestSuite) TestListChargesExpandsRealtimeUsageForMultipleUsageBas
 	createAt := servicePeriod.From
 	firstUsageAt := servicePeriod.From.Add(2 * time.Hour)
 	secondUsageAt := servicePeriod.From.Add(5 * time.Hour)
-	readAt := servicePeriod.From.Add(4 * time.Hour)
+	readAt := servicePeriod.From.Add(6 * time.Hour)
 
 	clock.SetTime(createAt)
 	defer clock.ResetTime()


### PR DESCRIPTION

## Overview


Add support for getting the total usage for the charge. The total usage includes the already booked items.

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added realtime_usage expansion so charge responses can include current usage totals.

* **Improvements**
  * Charges responses now populate realtime totals when realtime_usage is requested.
  * List behavior updated to allow combining include/exclude status filters when valid.

* **Bug Fixes**
  * Validation now rejects requests that set both inclusion and exclusion status filters simultaneously.

* **Tests**
  * Added end-to-end test verifying realtime usage expansion across multiple usage-based charges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->