### PR TITLE
chore: support error.Is for validation issues

### DIFF
--- a/pkg/models/testutils.go
+++ b/pkg/models/testutils.go
@@ -25,6 +25,8 @@ func RequireValidationIssuesMatch(t *testing.T, expected ValidationIssues, actua
 
 		actCopy[i].field = nil
 		expCopy[i].field = nil
+		actCopy[i].wraps = nil
+		expCopy[i].wraps = nil
 	}
 
 	require.Equalf(t, expCopy, actCopy, "issues must match")

--- a/pkg/models/validationissue.go
+++ b/pkg/models/validationissue.go
@@ -168,12 +168,27 @@ func (i ValidationIssue) Unwrap() error {
 }
 
 func (i ValidationIssue) Equal(other ValidationIssue) bool {
-	return maps.Equal(i.attributes, other.attributes) &&
+	return maps.EqualFunc(i.attributes, other.attributes, equalValidationIssueAttributeValue) &&
 		i.code == other.code &&
 		i.component == other.component &&
 		i.message == other.message &&
 		i.severity == other.severity &&
 		i.Field().String() == other.Field().String()
+}
+
+// equalValidationIssueAttributeValue is used to compare attribute values for equality.
+// It's better than reflect.DeepEqual because it handles nil values properly (DeepEqual would consider nil and empty value equal)
+func equalValidationIssueAttributeValue(left, right any) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+
+	// Let's not use DeepEqual for comparable types
+	if t := reflect.TypeOf(left); t != nil && t.Comparable() {
+		return left == right
+	}
+
+	return reflect.DeepEqual(left, right)
 }
 
 func asValidationIssue(err error) (ValidationIssue, bool) {

--- a/pkg/models/validationissue.go
+++ b/pkg/models/validationissue.go
@@ -12,8 +12,9 @@ import (
 type ErrorExtension map[string]any
 
 var (
-	_ error          = (*ValidationIssue)(nil)
-	_ json.Marshaler = (*ValidationIssue)(nil)
+	_ error                    = (*ValidationIssue)(nil)
+	_ json.Marshaler           = (*ValidationIssue)(nil)
+	_ Equaler[ValidationIssue] = (*ValidationIssue)(nil)
 )
 
 type ValidationIssue struct {
@@ -23,6 +24,7 @@ type ValidationIssue struct {
 	message    string
 	field      *FieldDescriptor
 	severity   ErrorSeverity
+	wraps      error
 }
 
 func (i ValidationIssue) MarshalJSON() ([]byte, error) {
@@ -39,6 +41,7 @@ func (i ValidationIssue) Clone() ValidationIssue {
 		message:    i.message,
 		field:      i.field,
 		severity:   i.severity,
+		wraps:      i,
 	}
 }
 
@@ -146,6 +149,46 @@ func (i ValidationIssue) SetAttributes(attrs Attributes) ValidationIssue {
 
 func (i ValidationIssue) Error() string {
 	return i.message
+}
+
+// Is is required in addition to Unwrap because ValidationIssue is not comparable:
+// it contains map-backed attributes, so errors.Is cannot use == when it reaches a
+// wrapped ValidationIssue in the chain.
+func (i ValidationIssue) Is(target error) bool {
+	targetIssue, ok := asValidationIssue(target)
+	if !ok {
+		return false
+	}
+
+	return i.Equal(targetIssue)
+}
+
+func (i ValidationIssue) Unwrap() error {
+	return i.wraps
+}
+
+func (i ValidationIssue) Equal(other ValidationIssue) bool {
+	return maps.Equal(i.attributes, other.attributes) &&
+		i.code == other.code &&
+		i.component == other.component &&
+		i.message == other.message &&
+		i.severity == other.severity &&
+		i.Field().String() == other.Field().String()
+}
+
+func asValidationIssue(err error) (ValidationIssue, bool) {
+	switch t := err.(type) {
+	case ValidationIssue:
+		return t, true
+	case *ValidationIssue:
+		if t == nil {
+			return ValidationIssue{}, false
+		}
+
+		return *t, true
+	default:
+		return ValidationIssue{}, false
+	}
 }
 
 func (i ValidationIssue) AsErrorExtension() ErrorExtension {
@@ -352,27 +395,13 @@ func asValidationIssues(err error, prefix *FieldDescriptor, component ComponentN
 	case fieldPrefixedWrapper:
 		return asValidationIssues(e.err, e.prefix.WithPrefix(prefix), component, true)
 	case ValidationIssue:
-		opts := []ValidationIssueOption{
-			withMessage(e.message),
-			withCode(e.code),
-			WithComponent(func() ComponentName {
-				if component == "" {
-					return e.component
-				}
-
-				return component
-			}()),
-			WithSeverity(e.severity),
-			WithAttributes(e.Attributes()),
+		return validationIssueAsValidationIssues(e, prefix, component), nil
+	case *ValidationIssue:
+		if e == nil {
+			return nil, nil
 		}
 
-		if e.field != nil {
-			opts = append(opts, WithField(e.field.WithPrefix(prefix)))
-		}
-
-		return ValidationIssues{
-			newValidationIssue(opts...),
-		}, nil
+		return validationIssueAsValidationIssues(*e, prefix, component), nil
 	}
 
 	switch e := err.(type) {
@@ -408,6 +437,30 @@ func asValidationIssues(err error, prefix *FieldDescriptor, component ComponentN
 		}
 
 		return nil, err
+	}
+}
+
+func validationIssueAsValidationIssues(e ValidationIssue, prefix *FieldDescriptor, component ComponentName) ValidationIssues {
+	opts := []ValidationIssueOption{
+		withMessage(e.message),
+		withCode(e.code),
+		WithComponent(func() ComponentName {
+			if component == "" {
+				return e.component
+			}
+
+			return component
+		}()),
+		WithSeverity(e.severity),
+		WithAttributes(e.Attributes()),
+	}
+
+	if e.field != nil {
+		opts = append(opts, WithField(e.field.WithPrefix(prefix)))
+	}
+
+	return ValidationIssues{
+		newValidationIssue(opts...),
 	}
 }
 

--- a/pkg/models/validationissue_test.go
+++ b/pkg/models/validationissue_test.go
@@ -156,12 +156,13 @@ func TestValidationIssue_Clone(t *testing.T) {
 				message:    errTestValidationIssue.message,
 				field:      errTestValidationIssue.field,
 				severity:   errTestValidationIssue.severity,
+				wraps:      errTestValidationIssue,
 			},
 		},
 		{
 			name:          "empty",
 			issue:         ValidationIssue{},
-			expectedIssue: ValidationIssue{},
+			expectedIssue: ValidationIssue{wraps: ValidationIssue{}},
 		},
 	}
 
@@ -172,6 +173,28 @@ func TestValidationIssue_Clone(t *testing.T) {
 			assert.Equalf(t, test.expectedIssue, actual, "must match after clone")
 		})
 	}
+}
+
+func TestValidationIssue_UnwrapAndErrorsIs(t *testing.T) {
+	base := errTestValidationIssue
+	withField := base.WithField(NewFieldSelectorGroup(NewFieldSelector("field_name")))
+	withAttrs := withField.WithAttr("key", "value")
+
+	require.ErrorIs(t, withField, base)
+	require.ErrorIs(t, withAttrs, withField)
+	require.ErrorIs(t, withAttrs, base)
+
+	assert.Equal(t, base.Error(), withField.Error())
+	assert.Equal(t, withField.Error(), withAttrs.Error())
+}
+
+func TestValidationIssue_ErrorsIsWithJoin(t *testing.T) {
+	base := NewValidationError("joined_code", "joined message")
+	derived := base.WithPathString("field_name")
+	joined := errors.Join(errors.New("other error"), derived)
+
+	require.ErrorIs(t, joined, derived)
+	require.ErrorIs(t, joined, base)
 }
 
 func TestAsValidationIssues(t *testing.T) {
@@ -397,4 +420,19 @@ func TestValidationIssues_AsError(t *testing.T) {
 	validationIssues, err := AsValidationIssues(err)
 	require.NoError(t, err)
 	RequireValidationIssuesMatch(t, issues, validationIssues)
+}
+
+func TestAsValidationIssues_PointerValidationIssue(t *testing.T) {
+	issue := NewValidationIssue("errcode1", "error message 1",
+		WithFieldString("field1"),
+		WithWarningSeverity(),
+		WithAttributes(Attributes{
+			"attr1": "value1",
+		}),
+	)
+
+	actual, err := AsValidationIssues(&issue)
+	require.NoError(t, err)
+
+	RequireValidationIssuesMatch(t, ValidationIssues{issue}, actual)
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

We are maintaining the wrapping history for clone, so that we can use `errors.Is` on validation issues.

This prevents fun codes like this:
```

func IsTaxCodeNotFoundError(err error) bool {
	var vi models.ValidationIssue
	return errors.As(err, &vi) && vi.Code() == ErrCodeTaxCodeNotFound
}

```

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Validation items now participate in standard error chains (unwrap/Is), support deep equality, and cloning preserves wrapped error context. Conversion/aggregation logic for validation items was centralized and pointer/nil cases handled explicitly; comparison helpers were added to support robust attribute equality.

* **Tests**
  * Added tests for cloning, unwrapping/identity across derived and joined errors, pointer-to-item conversion, and adjusted test helpers to ignore wrapped-error details during deep comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->