### PR TITLE
fix: disallow cross fiat credit purchases

### DIFF
--- a/openmeter/billing/charges/creditpurchase/charge.go
+++ b/openmeter/billing/charges/creditpurchase/charge.go
@@ -128,6 +128,23 @@ func (i Intent) Validate() error {
 		errs = append(errs, fmt.Errorf("settlement: %w", err))
 	}
 
+	switch i.Settlement.Type() {
+	case SettlementTypeInvoice:
+		settlement, err := i.Settlement.AsInvoiceSettlement()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("settlement: %w", err))
+		} else if settlement.Currency != i.Currency {
+			errs = append(errs, fmt.Errorf("settlement currency %q must match credit currency %q", settlement.Currency, i.Currency))
+		}
+	case SettlementTypeExternal:
+		settlement, err := i.Settlement.AsExternalSettlement()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("settlement: %w", err))
+		} else if settlement.Currency != i.Currency {
+			errs = append(errs, fmt.Errorf("settlement currency %q must match credit currency %q", settlement.Currency, i.Currency))
+		}
+	}
+
 	if i.EffectiveAt != nil {
 		return errors.New("effective at is not yet supported")
 	}

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/invopop/gobl/currency"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,6 +93,64 @@ func (s *CreditPurchaseTestSuite) TestPromotionalCreditPurchase() {
 	s.NoError(err)
 	s.Equal(promotionalCallback.id, updatedCPCharge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
 	s.Equal(creditpurchase.StatusFinal, updatedCPCharge.Status)
+}
+
+func (s *CreditPurchaseTestSuite) TestCreditPurchaseRejectsMismatchedSettlementCurrency() {
+	ctx := context.Background()
+	ns := s.GetUniqueNamespace("charges-service-credit-purchase-mismatched-settlement-currency")
+
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	s.NotEmpty(cust.ID)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	for _, tc := range []struct {
+		name       string
+		settlement creditpurchase.Settlement
+	}{
+		{
+			name: "external",
+			settlement: creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{
+				InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
+				GenericSettlement: creditpurchase.GenericSettlement{
+					Currency:  currencyx.Code(currency.EUR),
+					CostBasis: alpacadecimal.NewFromFloat(0.5),
+				},
+			}),
+		},
+		{
+			name: "invoice",
+			settlement: creditpurchase.NewSettlement(creditpurchase.InvoiceSettlement{
+				GenericSettlement: creditpurchase.GenericSettlement{
+					Currency:  currencyx.Code(currency.EUR),
+					CostBasis: alpacadecimal.NewFromFloat(0.5),
+				},
+			}),
+		},
+	} {
+		s.Run(tc.name, func() {
+			intent := CreateCreditPurchaseIntent(s.T(), createCreditPurchaseIntentInput{
+				customer:      cust.GetID(),
+				currency:      USD,
+				amount:        alpacadecimal.NewFromFloat(100),
+				servicePeriod: servicePeriod,
+				settlement:    tc.settlement,
+			})
+
+			res, err := s.Charges.Create(ctx, charges.CreateInput{
+				Namespace: ns,
+				Intents: charges.ChargeIntents{
+					intent,
+				},
+			})
+			s.Error(err)
+			s.ErrorContains(err, `settlement currency "EUR" must match credit currency "USD"`)
+			s.Empty(res)
+		})
+	}
 }
 
 type createCreditPurchaseIntentInput struct {


### PR DESCRIPTION

## Overview

Forbid purchasing credits for a given fiat currency from a different currency.

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced billing validation to ensure settlement currency matches credit purchase currency. Transactions with mismatched currencies will now be rejected during charge creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->