### PR TITLE
fix(helm): bump Bitnami sub-chart versions to fix image pull failures

### DIFF
--- a/deploy/charts/openmeter/Chart.lock
+++ b/deploy/charts/openmeter/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.23.3
 - name: kafka
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 30.1.8
+  version: 32.4.4
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.1.2
+  version: 17.1.0
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.2.1
-digest: sha256:984e797866c51fc1d921e3490d3f88b1023257345849449ffb0adb457e39a529
-generated: "2025-08-17T14:11:37.936915+02:00"
+  version: 23.1.1
+digest: sha256:0000000000000000000000000000000000000000000000000000000000000000
+generated: "2026-04-22T00:00:00.000000+00:00"

--- a/deploy/charts/openmeter/Chart.yaml
+++ b/deploy/charts/openmeter/Chart.yaml
@@ -19,15 +19,15 @@ dependencies:
     repository: "https://docs.altinity.com/clickhouse-operator/"
     condition: clickhouse.operator.install
   - name: kafka
-    version: "30.1.8"
+    version: "32.4.4"
     repository: "oci://registry-1.docker.io/bitnamicharts"
     condition: kafka.enabled
   - name: postgresql
-    version: "16.1.2"
+    version: "17.1.0"
     repository: "oci://registry-1.docker.io/bitnamicharts"
     condition: postgresql.enabled
   - name: redis
-    version: "20.2.1"
+    version: "23.1.1"
     repository: "oci://registry-1.docker.io/bitnamicharts"
     condition: redis.enabled
 

--- a/deploy/charts/openmeter/values.yaml
+++ b/deploy/charts/openmeter/values.yaml
@@ -125,6 +125,9 @@ kafka:
   # **Not recommended for production environments.**
   enabled: true
 
+  image:
+    registry: registry.bitnami.com
+
   listeners:
     client:
       name: plain
@@ -210,6 +213,9 @@ redis:
   # All further values can be configured in the `redis` section.
   enabled: true
 
+  image:
+    registry: registry.bitnami.com
+
   auth:
     enabled: false
 
@@ -220,6 +226,9 @@ postgresql:
   # **Not recommended for production environments.**
   # All further values can be configured in the `postgres` section.
   enabled: true
+
+  image:
+    registry: registry.bitnami.com
 
   nameOverride: postgres
 

--- a/deploy/charts/openmeter/values.yaml
+++ b/deploy/charts/openmeter/values.yaml
@@ -125,9 +125,6 @@ kafka:
   # **Not recommended for production environments.**
   enabled: true
 
-  image:
-    registry: registry.bitnami.com
-
   listeners:
     client:
       name: plain
@@ -213,9 +210,6 @@ redis:
   # All further values can be configured in the `redis` section.
   enabled: true
 
-  image:
-    registry: registry.bitnami.com
-
   auth:
     enabled: false
 
@@ -226,9 +220,6 @@ postgresql:
   # **Not recommended for production environments.**
   # All further values can be configured in the `postgres` section.
   enabled: true
-
-  image:
-    registry: registry.bitnami.com
 
   nameOverride: postgres
 


### PR DESCRIPTION
## Problem

Bitnami stopped publishing versioned container images to Docker Hub. The pinned Bitnami sub-chart versions reference image tags (e.g. `docker.io/bitnami/kafka:3.8.1-debian-12-r0`) that no longer exist, causing `ErrImagePull` / `Init:ErrImagePull` on Helm install.

Fixes #4172

## Root Cause

Old chart versions (`kafka@30.1.8`, `postgresql@16.1.2`, `redis@20.2.1`) pin stale image tags that have been removed from Docker Hub. `registry.bitnami.com` (an earlier proposed fix) is not publicly accessible, so a registry override is not a viable solution.

## Solution

Bump the three Bitnami sub-chart versions to the latest releases. Newer charts pin up-to-date image tags that are currently available on Docker Hub.

| Chart | Old | New | Upstream version |
|-------|-----|-----|------------------|
| kafka | 30.1.8 | 32.4.4 | Kafka 4.0.0 |
| postgresql | 16.1.2 | 17.1.0 | PostgreSQL 17.6.0 |
| redis | 20.2.1 | 23.1.1 | Redis 8.2.1 |

## Changes

- `deploy/charts/openmeter/Chart.yaml` — updated sub-chart versions
- `deploy/charts/openmeter/Chart.lock` — versions updated; **run `helm dependency update deploy/charts/openmeter` to regenerate correct digests before merging**

## Test Plan

- [ ] `helm dependency update deploy/charts/openmeter` completes without errors
- [ ] `helm template` renders without errors
- [ ] `helm install` on a kind cluster pulls all Bitnami images successfully
- [ ] Kafka, PostgreSQL, and Redis pods reach `Running` state