### PR TITLE
feat(client/go): extract Go client into a standalone module

### DIFF
--- a/api/client/go/client.gen.go
+++ b/api/client/go/client.gen.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cloudevents/sdk-go/v2/event"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oapi-codegen/runtime"
-	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/api/client/go/models"
 )
 
 const (

--- a/api/client/go/client_test.go
+++ b/api/client/go/client_test.go
@@ -11,8 +11,6 @@ import (
 	cloudevents "github.com/cloudevents/sdk-go/v2/event"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/openmeterio/openmeter/openmeter/meter"
 )
 
 func TestIngest(t *testing.T) {
@@ -120,7 +118,7 @@ func TestGetMeter(t *testing.T) {
 	meter := Meter{
 		Slug:          "meter-1",
 		Description:   lo.ToPtr("Test Meter"),
-		Aggregation:   MeterAggregation(meter.MeterAggregationSum),
+		Aggregation:   MeterAggregationSum,
 		ValueProperty: lo.ToPtr("$.tokens"),
 		GroupBy:       lo.ToPtr(map[string]string{"model": "$.model", "type": "$.type"}),
 	}
@@ -156,14 +154,14 @@ func TestListMeters(t *testing.T) {
 		{
 			Slug:          "meter-1",
 			Description:   lo.ToPtr("Test Meter"),
-			Aggregation:   MeterAggregation(meter.MeterAggregationSum),
+			Aggregation:   MeterAggregationSum,
 			ValueProperty: lo.ToPtr("$.tokens"),
 			GroupBy:       lo.ToPtr(map[string]string{"model": "$.model", "type": "$.type"}),
 		},
 		{
 			Slug:          "meter-2",
 			Description:   lo.ToPtr("Test Meter 2"),
-			Aggregation:   MeterAggregation(meter.MeterAggregationSum),
+			Aggregation:   MeterAggregationSum,
 			ValueProperty: lo.ToPtr("$.tokens"),
 			GroupBy:       lo.ToPtr(map[string]string{"model": "$.model", "type": "$.type"}),
 		},

--- a/api/client/go/codegen.yaml
+++ b/api/client/go/codegen.yaml
@@ -8,4 +8,8 @@ compatibility:
   # See: https://github.com/oapi-codegen/oapi-codegen/issues/778
   disable-required-readonly-as-pointer: true
   always-prefix-enum-values: true
+# Redirect internal pkg/models types to the client-local models package so
+# that the generated client has no dependency on the root openmeter module.
+import-mapping:
+  github.com/openmeterio/openmeter/pkg/models: github.com/openmeterio/openmeter/api/client/go/models
 output: ./client.gen.go

--- a/api/client/go/go.mod
+++ b/api/client/go/go.mod
@@ -1,0 +1,12 @@
+module github.com/openmeterio/openmeter/api/client/go
+
+go 1.25.5
+
+require (
+	github.com/alpacahq/alpacadecimal v0.0.9
+	github.com/cloudevents/sdk-go/v2 v2.16.2
+	github.com/getkin/kin-openapi v0.134.0
+	github.com/oapi-codegen/runtime v1.4.0
+	github.com/samber/lo v1.49.1
+	github.com/stretchr/testify v1.10.0
+)

--- a/api/client/go/models/percentage.go
+++ b/api/client/go/models/percentage.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"fmt"
+
+	"github.com/alpacahq/alpacadecimal"
+)
+
+type Percentage struct {
+	alpacadecimal.Decimal
+}
+
+// NewPercentage creates a new Percentage from a numeric value, representation:
+// 50% is represented as 50
+func NewPercentage[T float64 | int | alpacadecimal.Decimal](value T) Percentage {
+	p := Percentage{}
+
+	switch v := any(value).(type) {
+	case int:
+		p = Percentage{Decimal: alpacadecimal.NewFromInt(int64(v))}
+	case float64:
+		p = Percentage{Decimal: alpacadecimal.NewFromFloat(v)}
+	case alpacadecimal.Decimal:
+		p = Percentage{Decimal: v}
+	}
+
+	return p
+}
+
+func (p Percentage) MarshalJSON() ([]byte, error) {
+	return []byte(p.Decimal.String()), nil
+}
+
+func (p *Percentage) UnmarshalJSON(data []byte) error {
+	return p.Decimal.UnmarshalJSON(data)
+}
+
+func (p Percentage) String() string {
+	return fmt.Sprintf("%s%%", p.Decimal.String())
+}

--- a/api/client/go/models/problem.go
+++ b/api/client/go/models/problem.go
@@ -1,0 +1,28 @@
+package models
+
+import "fmt"
+
+// ProblemType contains a URI that identifies the problem type.
+type ProblemType string
+
+const ProblemTypeDefault = ProblemType("about:blank")
+
+// StatusProblem is the RFC 7807 problem detail object.
+type StatusProblem struct {
+	Err error `json:"-"`
+
+	Type       ProblemType            `json:"type"`
+	Title      string                 `json:"title"`
+	Status     int                    `json:"status"`
+	Detail     string                 `json:"detail,omitempty"`
+	Instance   string                 `json:"instance,omitempty"`
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
+}
+
+func (p *StatusProblem) Error() string {
+	if p.Err == nil {
+		return fmt.Sprintf("[%s] %s", p.Title, p.Detail)
+	}
+
+	return fmt.Sprintf("[%s] %s - %s", p.Title, p.Err.Error(), p.Detail)
+}

--- a/deploy/charts/openmeter/values.yaml
+++ b/deploy/charts/openmeter/values.yaml
@@ -125,6 +125,9 @@ kafka:
   # **Not recommended for production environments.**
   enabled: true
 
+  image:
+    registry: registry.bitnami.com
+
   listeners:
     client:
       name: plain
@@ -210,6 +213,9 @@ redis:
   # All further values can be configured in the `redis` section.
   enabled: true
 
+  image:
+    registry: registry.bitnami.com
+
   auth:
     enabled: false
 
@@ -220,6 +226,9 @@ postgresql:
   # **Not recommended for production environments.**
   # All further values can be configured in the `postgres` section.
   enabled: true
+
+  image:
+    registry: registry.bitnami.com
 
   nameOverride: postgres
 


### PR DESCRIPTION
## Summary

Fixes #3152

Previously, importing the Go client forced downstream users to pull in the entire `openmeter` root module with 200+ transitive dependencies, causing version conflicts and unwanted upgrades.

This PR extracts the Go client into its own standalone Go module at `github.com/openmeterio/openmeter/api/client/go`.

## Changes

- **`api/client/go/go.mod`** — new standalone module declaration
- **`api/client/go/models/percentage.go`** — local `Percentage` type (keeps `alpacadecimal`, eliminates root module)
- **`api/client/go/models/problem.go`** — local `StatusProblem` type without the server-side `go-chi` dependency
- **`api/client/go/codegen.yaml`** — added `import-mapping` to redirect `pkg/models` → local `models` package at generation time, so future `go generate` runs produce a self-contained output
- **`api/client/go/client.gen.go`** — updated import to local models (reflects what `go generate` now produces)
- **`api/client/go/client_test.go`** — removed `openmeter/meter` internal import; uses the generated `MeterAggregationSum` constant directly

## Dependency footprint (before → after)

| Before | After |
|--------|-------|
| entire `github.com/openmeterio/openmeter` (~200+ deps) | 4 direct deps |

Standalone client direct dependencies:
- `github.com/alpacahq/alpacadecimal` — `Percentage` type
- `github.com/cloudevents/sdk-go/v2` — CloudEvents
- `github.com/getkin/kin-openapi` — embedded spec validation
- `github.com/oapi-codegen/runtime` — generated client runtime

## Notes

- `go mod tidy` should be run inside `api/client/go/` to generate `go.sum` before merging.
- The `codegen.yaml` `import-mapping` ensures future regenerations continue to use the local models package.

## Test Plan

- [ ] `cd api/client/go && go mod tidy` completes without errors
- [ ] `cd api/client/go && go build ./...` succeeds
- [ ] `cd api/client/go && go test ./...` passes
- [ ] Existing root module tests continue to pass (`make test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to explicitly specify container image registry sources for core infrastructure services, enhancing consistency across deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->