### PR TITLE
refactor: reconcile events in parallel

### DIFF
--- a/app/common/notification.go
+++ b/app/common/notification.go
@@ -65,6 +65,7 @@ func NewNotificationEventHandler(
 		ReconcileInterval: config.ReconcileInterval,
 		SendingTimeout:    config.SendingTimeout,
 		PendingTimeout:    config.PendingTimeout,
+		ReconcilerWorkers: config.ReconcilerWorkers,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize notification event handler: %w", err)

--- a/app/common/notification.go
+++ b/app/common/notification.go
@@ -18,6 +18,8 @@ import (
 	webhooknoop "github.com/openmeterio/openmeter/openmeter/notification/webhook/noop"
 	webhooksvix "github.com/openmeterio/openmeter/openmeter/notification/webhook/svix"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/framework/lockr"
+	"github.com/openmeterio/openmeter/pkg/framework/pgdriver"
 )
 
 var Notification = wire.NewSet(
@@ -56,7 +58,16 @@ func NewNotificationEventHandler(
 	tracer trace.Tracer,
 	adapter notification.Repository,
 	webhook notificationwebhook.Handler,
+	driver *pgdriver.Driver,
 ) (notification.EventHandler, error) {
+	sessionLockr, err := lockr.NewSessionLockr(lockr.SessionLockerConfig{
+		Logger:         logger,
+		PostgresDriver: driver,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize session lockr: %w", err)
+	}
+
 	eventHandler, err := eventhandler.New(eventhandler.Config{
 		Repository:        adapter,
 		Webhook:           webhook,
@@ -66,6 +77,7 @@ func NewNotificationEventHandler(
 		SendingTimeout:    config.SendingTimeout,
 		PendingTimeout:    config.PendingTimeout,
 		ReconcilerWorkers: config.ReconcilerWorkers,
+		Lockr:             sessionLockr,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize notification event handler: %w", err)

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -395,6 +395,7 @@ func TestComplete(t *testing.T) {
 			ReconcileInterval: time.Minute,
 			SendingTimeout:    time.Hour,
 			PendingTimeout:    2 * time.Hour,
+			ReconcilerWorkers: 10,
 		},
 		Svix: svix.SvixConfig{
 			APIKey:    "test-svix-token",

--- a/app/config/notification.go
+++ b/app/config/notification.go
@@ -23,9 +23,12 @@ type NotificationConfiguration struct {
 
 	Webhook WebhookConfiguration
 
+	// EventHandler configuration
 	ReconcileInterval time.Duration
 	SendingTimeout    time.Duration
 	PendingTimeout    time.Duration
+
+	ReconcilerWorkers int
 }
 
 func (c NotificationConfiguration) Validate() error {
@@ -47,4 +50,5 @@ func ConfigureNotification(v *viper.Viper) {
 	v.SetDefault("notification.reconcileInterval", notification.DefaultReconcileInterval)
 	v.SetDefault("notification.sendingTimeout", notification.DefaultDeliveryStateSendingTimeout)
 	v.SetDefault("notification.pendingTimeout", notification.DefaultDeliveryStatePendingTimeout)
+	v.SetDefault("notification.reconcilerWorkers", notification.DefaultReconcilerWorkers)
 }

--- a/app/config/testdata/complete.yaml
+++ b/app/config/testdata/complete.yaml
@@ -152,6 +152,7 @@ notification:
   reconcileInterval: 1m
   sendingTimeout: 1h
   pendingTimeout: 2h
+  reconcilerWorkers: 10
 
 svix:
   apiKey: test-svix-token

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -659,7 +659,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	eventHandler, err := common.NewNotificationEventHandler(notificationConfiguration, logger, tracer, notificationRepository, webhookHandler)
+	eventHandler, err := common.NewNotificationEventHandler(notificationConfiguration, logger, tracer, notificationRepository, webhookHandler, driver)
 	if err != nil {
 		cleanup8()
 		cleanup7()

--- a/openmeter/notification/eventhandler.go
+++ b/openmeter/notification/eventhandler.go
@@ -2,6 +2,7 @@ package notification
 
 import (
 	"context"
+	"runtime"
 	"time"
 )
 
@@ -11,6 +12,8 @@ const (
 	DefaultDeliveryStatePendingTimeout = 3 * time.Hour
 	DefaultDeliveryStateSendingTimeout = 48 * time.Hour
 )
+
+var DefaultReconcilerWorkers = runtime.GOMAXPROCS(0)
 
 type EventHandler interface {
 	EventDispatcher

--- a/openmeter/notification/eventhandler/handler.go
+++ b/openmeter/notification/eventhandler/handler.go
@@ -26,6 +26,7 @@ type Config struct {
 	SendingTimeout    time.Duration
 	PendingTimeout    time.Duration
 	ReconcilerWorkers int
+	Lockr             *lockr.SessionLocker
 }
 
 func (c *Config) Validate() error {
@@ -47,6 +48,10 @@ func (c *Config) Validate() error {
 		errs = append(errs, fmt.Errorf("tracer is required"))
 	}
 
+	if c.Lockr == nil {
+		errs = append(errs, fmt.Errorf("session lockr is required"))
+	}
+
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
@@ -64,7 +69,7 @@ type Handler struct {
 	stopCh      chan struct{}
 	stopChClose func()
 
-	lockr *lockr.Locker
+	lockr *lockr.SessionLocker
 
 	// Delivery status timeouts
 	sendingTimeout time.Duration
@@ -86,6 +91,12 @@ func (h *Handler) Start() error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
+	err := h.lockr.Start(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to start session lockr: %w", err)
+	}
+	defer h.lockr.Close()
 
 	ticker := time.NewTicker(h.reconcileInterval)
 	defer ticker.Stop()
@@ -127,11 +138,6 @@ func New(config Config) (*Handler, error) {
 		config.SendingTimeout = notification.DefaultDeliveryStateSendingTimeout
 	}
 
-	reconcileLockr, err := lockr.NewLocker(&lockr.LockerConfig{Logger: config.Logger})
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize lockr: %w", err)
-	}
-
 	if config.ReconcilerWorkers == 0 {
 		config.ReconcilerWorkers = notification.DefaultReconcilerWorkers
 	}
@@ -149,7 +155,7 @@ func New(config Config) (*Handler, error) {
 		tracer:            config.Tracer,
 		stopCh:            stopCh,
 		stopChClose:       stopChClose,
-		lockr:             reconcileLockr,
+		lockr:             config.Lockr,
 		sendingTimeout:    config.SendingTimeout,
 		pendingTimeout:    config.PendingTimeout,
 		workerPoolSize:    int64(config.ReconcilerWorkers),

--- a/openmeter/notification/eventhandler/handler.go
+++ b/openmeter/notification/eventhandler/handler.go
@@ -138,7 +138,7 @@ func New(config Config) (*Handler, error) {
 		config.SendingTimeout = notification.DefaultDeliveryStateSendingTimeout
 	}
 
-	if config.ReconcilerWorkers == 0 {
+	if config.ReconcilerWorkers <= 0 {
 		config.ReconcilerWorkers = notification.DefaultReconcilerWorkers
 	}
 

--- a/openmeter/notification/eventhandler/handler.go
+++ b/openmeter/notification/eventhandler/handler.go
@@ -25,6 +25,7 @@ type Config struct {
 	ReconcileInterval time.Duration
 	SendingTimeout    time.Duration
 	PendingTimeout    time.Duration
+	ReconcilerWorkers int
 }
 
 func (c *Config) Validate() error {
@@ -68,6 +69,8 @@ type Handler struct {
 	// Delivery status timeouts
 	sendingTimeout time.Duration
 	pendingTimeout time.Duration
+
+	workerPoolSize int64
 }
 
 func (h *Handler) Start() error {
@@ -129,6 +132,10 @@ func New(config Config) (*Handler, error) {
 		return nil, fmt.Errorf("failed to initialize lockr: %w", err)
 	}
 
+	if config.ReconcilerWorkers == 0 {
+		config.ReconcilerWorkers = notification.DefaultReconcilerWorkers
+	}
+
 	stopCh := make(chan struct{})
 	stopChClose := sync.OnceFunc(func() {
 		close(stopCh)
@@ -145,5 +152,6 @@ func New(config Config) (*Handler, error) {
 		lockr:             reconcileLockr,
 		sendingTimeout:    config.SendingTimeout,
 		pendingTimeout:    config.PendingTimeout,
+		workerPoolSize:    int64(config.ReconcilerWorkers),
 	}, nil
 }

--- a/openmeter/notification/eventhandler/reconcile.go
+++ b/openmeter/notification/eventhandler/reconcile.go
@@ -16,7 +16,6 @@ import (
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
 	"github.com/openmeterio/openmeter/pkg/framework/tracex"
-	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 )
 
@@ -70,82 +69,86 @@ const (
 
 func (h *Handler) Reconcile(ctx context.Context) error {
 	fn := func(ctx context.Context) error {
-		return transaction.RunWithNoValue(ctx, h.repo, func(ctx context.Context) error {
-			span := trace.SpanFromContext(ctx)
+		span := trace.SpanFromContext(ctx)
 
-			span.AddEvent("acquiring lock")
+		span.AddEvent("acquiring lock")
 
-			if err := h.lockr.LockForTXWithScopes(ctx, reconcileLockKey); err != nil {
-				if errors.Is(err, lockr.ErrLockTimeout) {
-					h.logger.WarnContext(ctx, "reconciliation lock is not available, skipping reconciliation")
+		releaser, err := h.lockr.TryLockWithScopes(ctx, reconcileLockKey)
+		if err != nil {
+			if errors.Is(err, lockr.ErrNoLockAcquired) {
+				h.logger.DebugContext(ctx, "lock not acquired, skipping reconciliation")
 
-					return nil
-				}
-
-				return fmt.Errorf("failed to acquire reconciliation lock: %w", err)
+				return nil
 			}
 
-			span.AddEvent("lock acquired")
+			return fmt.Errorf("failed to acquire lock: %w", err)
+		}
+		defer func() {
+			if err := releaser(ctx); err != nil {
+				h.logger.ErrorContext(ctx, "failed to release lock", "error", err)
+			}
+		}()
 
-			workerPool := semaphore.NewWeighted(h.workerPoolSize)
-			wg := sync.WaitGroup{}
+		span.AddEvent("lock acquired")
 
-			page := pagination.Page{
-				PageSize:   50,
-				PageNumber: 1,
+		workerPool := semaphore.NewWeighted(h.workerPoolSize)
+		wg := sync.WaitGroup{}
+
+		page := pagination.Page{
+			PageSize:   50,
+			PageNumber: 1,
+		}
+
+		nextAttemptBefore := clock.Now().Add(-1 * nextAttemptDelay)
+
+		for {
+			out, err := h.repo.ListEvents(ctx, notification.ListEventsInput{
+				Page: page,
+				DeliveryStatusStates: []notification.EventDeliveryStatusState{
+					notification.EventDeliveryStatusStatePending,
+					notification.EventDeliveryStatusStateSending,
+					notification.EventDeliveryStatusStateResending,
+				},
+				NextAttemptBefore: nextAttemptBefore,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to fetch notification delivery statuses for reconciliation: %w", err)
 			}
 
-			nextAttemptBefore := clock.Now().Add(-1 * nextAttemptDelay)
+			span.AddEvent("reconciling events", trace.WithAttributes(
+				attribute.Int("event_handler.reconcile.count", len(out.Items)),
+			))
 
-			for {
-				out, err := h.repo.ListEvents(ctx, notification.ListEventsInput{
-					Page: page,
-					DeliveryStatusStates: []notification.EventDeliveryStatusState{
-						notification.EventDeliveryStatusStatePending,
-						notification.EventDeliveryStatusStateSending,
-						notification.EventDeliveryStatusStateResending,
-					},
-					NextAttemptBefore: nextAttemptBefore,
-				})
+			for _, event := range out.Items {
+				err = workerPool.Acquire(ctx, 1)
 				if err != nil {
-					return fmt.Errorf("failed to fetch notification delivery statuses for reconciliation: %w", err)
+					return fmt.Errorf("failed to acquire worker from pool: %w", err)
 				}
 
-				span.AddEvent("reconciling events", trace.WithAttributes(
-					attribute.Int("event_handler.reconcile.count", len(out.Items)),
-				))
+				wg.Go(func() {
+					defer workerPool.Release(1)
 
-				for _, event := range out.Items {
-					err = workerPool.Acquire(ctx, 1)
-					if err != nil {
-						return fmt.Errorf("failed to acquire worker from pool: %w", err)
+					if rErr := h.reconcileEvent(ctx, &event); rErr != nil {
+						h.logger.ErrorContext(ctx, "failed to reconcile notification event",
+							"namespace", event.Namespace,
+							"notification.event.id", event.ID,
+							"error", rErr.Error(),
+						)
 					}
-
-					wg.Go(func() {
-						defer workerPool.Release(1)
-
-						if rErr := h.reconcileEvent(ctx, &event); rErr != nil {
-							h.logger.ErrorContext(ctx, "failed to reconcile notification event",
-								"namespace", event.Namespace,
-								"notification.event.id", event.ID,
-								"error", rErr.Error(),
-							)
-						}
-					})
-				}
-
-				if out.TotalCount <= page.PageSize*page.PageNumber || len(out.Items) == 0 {
-					break
-				}
-
-				page.PageNumber++
+				})
 			}
 
-			// Wait for all workers to finish
-			wg.Wait()
+			if out.TotalCount <= page.PageSize*page.PageNumber || len(out.Items) == 0 {
+				break
+			}
 
-			return nil
-		})
+			page.PageNumber++
+		}
+
+		// Wait for all workers to finish
+		wg.Wait()
+
+		return nil
 	}
 
 	return tracex.StartWithNoValue(ctx, h.tracer, "event_handler.reconcile").Wrap(fn)

--- a/openmeter/notification/eventhandler/reconcile.go
+++ b/openmeter/notification/eventhandler/reconcile.go
@@ -92,7 +92,14 @@ func (h *Handler) Reconcile(ctx context.Context) error {
 		span.AddEvent("lock acquired")
 
 		workerPool := semaphore.NewWeighted(h.workerPoolSize)
+
 		wg := sync.WaitGroup{}
+		defer func() {
+			// Wait for all workers to finish
+			wg.Wait()
+
+			h.logger.DebugContext(ctx, "all workers finished")
+		}()
 
 		page := pagination.Page{
 			PageSize:   50,
@@ -144,9 +151,6 @@ func (h *Handler) Reconcile(ctx context.Context) error {
 
 			page.PageNumber++
 		}
-
-		// Wait for all workers to finish
-		wg.Wait()
 
 		return nil
 	}

--- a/openmeter/notification/eventhandler/reconcile.go
+++ b/openmeter/notification/eventhandler/reconcile.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/samber/lo"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/openmeterio/openmeter/openmeter/notification"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -85,10 +87,15 @@ func (h *Handler) Reconcile(ctx context.Context) error {
 
 			span.AddEvent("lock acquired")
 
+			workerPool := semaphore.NewWeighted(h.workerPoolSize)
+			wg := sync.WaitGroup{}
+
 			page := pagination.Page{
 				PageSize:   50,
 				PageNumber: 1,
 			}
+
+			nextAttemptBefore := clock.Now().Add(-1 * nextAttemptDelay)
 
 			for {
 				out, err := h.repo.ListEvents(ctx, notification.ListEventsInput{
@@ -98,7 +105,7 @@ func (h *Handler) Reconcile(ctx context.Context) error {
 						notification.EventDeliveryStatusStateSending,
 						notification.EventDeliveryStatusStateResending,
 					},
-					NextAttemptBefore: clock.Now().Add(-1 * nextAttemptDelay),
+					NextAttemptBefore: nextAttemptBefore,
 				})
 				if err != nil {
 					return fmt.Errorf("failed to fetch notification delivery statuses for reconciliation: %w", err)
@@ -109,14 +116,22 @@ func (h *Handler) Reconcile(ctx context.Context) error {
 				))
 
 				for _, event := range out.Items {
-					// TODO: run reconciliation in parallel (goroutines)
-					if err = h.reconcileEvent(ctx, &event); err != nil {
-						h.logger.ErrorContext(ctx, "failed to reconcile notification event",
-							"namespace", event.Namespace,
-							"notification.event.id", event.ID,
-							"error", err.Error(),
-						)
+					err = workerPool.Acquire(ctx, 1)
+					if err != nil {
+						return fmt.Errorf("failed to acquire worker from pool: %w", err)
 					}
+
+					wg.Go(func() {
+						defer workerPool.Release(1)
+
+						if rErr := h.reconcileEvent(ctx, &event); rErr != nil {
+							h.logger.ErrorContext(ctx, "failed to reconcile notification event",
+								"namespace", event.Namespace,
+								"notification.event.id", event.ID,
+								"error", rErr.Error(),
+							)
+						}
+					})
 				}
 
 				if out.TotalCount <= page.PageSize*page.PageNumber || len(out.Items) == 0 {
@@ -125,6 +140,9 @@ func (h *Handler) Reconcile(ctx context.Context) error {
 
 				page.PageNumber++
 			}
+
+			// Wait for all workers to finish
+			wg.Wait()
 
 			return nil
 		})

--- a/pkg/framework/lockr/session.go
+++ b/pkg/framework/lockr/session.go
@@ -65,14 +65,18 @@ type SessionLockerConfig struct {
 // It requires a dedicated connection to acquire locks.
 type SessionLocker struct {
 	logger *slog.Logger
-	conn   *sql.Conn
+	driver *pgdriver.Driver
+
+	conn *sql.Conn
 
 	closed atomic.Bool
 	closer func()
-	mu     sync.Mutex
+
+	mu   sync.Mutex
+	once sync.Once
 }
 
-func NewSessionLockr(ctx context.Context, config SessionLockerConfig) (*SessionLocker, error) {
+func NewSessionLockr(config SessionLockerConfig) (*SessionLocker, error) {
 	if config.Logger == nil {
 		return nil, errors.New("logger is required")
 	}
@@ -81,26 +85,36 @@ func NewSessionLockr(ctx context.Context, config SessionLockerConfig) (*SessionL
 		return nil, errors.New("postgres driver is required")
 	}
 
-	conn, err := config.PostgresDriver.DB().Conn(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get postgres connection: %w", err)
-	}
-
 	id := clock.Now().UTC().UnixNano()
 
 	logger := config.Logger.With("component", "session-lockr", "id", id)
 
-	closer := sync.OnceFunc(func() {
-		if err := conn.Close(); err != nil {
-			logger.Error("failed to close postgres connection", "error", err)
+	return &SessionLocker{
+		logger: logger,
+		driver: config.PostgresDriver,
+	}, nil
+}
+
+func (l *SessionLocker) Start(ctx context.Context) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	var err error
+
+	if l.conn == nil {
+		l.conn, err = l.driver.DB().Conn(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get postgres connection: %w", err)
+		}
+	}
+
+	l.closer = sync.OnceFunc(func() {
+		if err := l.conn.Close(); err != nil {
+			l.logger.Error("failed to close postgres connection: some session-level advisory locks might be dangling", "error", err)
 		}
 	})
 
-	return &SessionLocker{
-		logger: logger,
-		conn:   conn,
-		closer: closer,
-	}, nil
+	return err
 }
 
 func (l *SessionLocker) lock(ctx context.Context, key Key, nonblocking bool) (Releaser, error) {
@@ -182,6 +196,15 @@ func (l *SessionLocker) TryLock(ctx context.Context, key Key) (Releaser, error) 
 	return l.lock(ctx, key, true)
 }
 
+func (l *SessionLocker) TryLockWithScopes(ctx context.Context, scopes ...string) (Releaser, error) {
+	k, err := NewKey(scopes...)
+	if err != nil {
+		return nil, err
+	}
+
+	return l.TryLock(ctx, k)
+}
+
 // Lock blocks until a lock is acquired and returns a Releaser that can be used to release the lock if it is successfully acquired.
 // The ErrNoLockAcquired is acquiring the lock is denied by the database server.
 // The ErrSessionLockerDone is returned if SessionLocker is closed, meaning it cannot be used for acquiring locks.
@@ -190,6 +213,15 @@ func (l *SessionLocker) Lock(ctx context.Context, key Key) (Releaser, error) {
 	defer l.mu.Unlock()
 
 	return l.lock(ctx, key, false)
+}
+
+func (l *SessionLocker) LockWithScopes(ctx context.Context, scopes ...string) (Releaser, error) {
+	k, err := NewKey(scopes...)
+	if err != nil {
+		return nil, err
+	}
+
+	return l.Lock(ctx, k)
 }
 
 func (l *SessionLocker) release(ctx context.Context, key Key) error {
@@ -250,6 +282,7 @@ func (l *SessionLocker) Close() {
 	l.closer()
 	l.closed.Store(true)
 
-	// Release references to conn so it can be GC'd
+	// Release references to conn and closer so it can be GC'd
 	l.conn = nil
+	l.closer = nil
 }

--- a/pkg/framework/lockr/session_test.go
+++ b/pkg/framework/lockr/session_test.go
@@ -27,7 +27,7 @@ func newTestSessionLocker(t *testing.T, dbConn string, opts ...pgdriver.Option) 
 		}
 	})
 
-	locker, err := NewSessionLockr(t.Context(), SessionLockerConfig{
+	locker, err := NewSessionLockr(SessionLockerConfig{
 		Logger:         testutils.NewLogger(t),
 		PostgresDriver: postgresDriver,
 	})
@@ -44,6 +44,9 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Lock and release", func(t *testing.T) {
 		locker := newTestSessionLocker(t, testDB.URL)
+
+		err := locker.Start(t.Context())
+		require.NoError(t, err)
 		defer locker.Close()
 
 		k, err := NewKey("test", "lock-release")
@@ -59,6 +62,9 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("TryLock and release", func(t *testing.T) {
 		locker := newTestSessionLocker(t, testDB.URL)
+
+		err := locker.Start(t.Context())
+		require.NoError(t, err)
 		defer locker.Close()
 
 		k, err := NewKey("test", "trylock-release")
@@ -74,6 +80,9 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Same session can acquire the same lock twice", func(t *testing.T) {
 		locker := newTestSessionLocker(t, testDB.URL)
+
+		err := locker.Start(t.Context())
+		require.NoError(t, err)
 		defer locker.Close()
 
 		k, err := NewKey("test", "reentrant")
@@ -93,9 +102,15 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("TryLock fails when lock is held by another session", func(t *testing.T) {
 		locker1 := newTestSessionLocker(t, testDB.URL)
+
+		err := locker1.Start(t.Context())
+		require.NoError(t, err)
 		defer locker1.Close()
 
 		locker2 := newTestSessionLocker(t, testDB.URL)
+
+		err = locker2.Start(t.Context())
+		require.NoError(t, err)
 		defer locker2.Close()
 
 		k, err := NewKey("test", "trylock-contention")
@@ -119,9 +134,15 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Different keys do not conflict", func(t *testing.T) {
 		locker1 := newTestSessionLocker(t, testDB.URL)
+
+		err := locker1.Start(t.Context())
+		require.NoError(t, err)
 		defer locker1.Close()
 
 		locker2 := newTestSessionLocker(t, testDB.URL)
+
+		err = locker2.Start(t.Context())
+		require.NoError(t, err)
 		defer locker2.Close()
 
 		key1, err := NewKey("test", "key-a")
@@ -143,9 +164,15 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Lock blocks until released by another session", func(t *testing.T) {
 		locker1 := newTestSessionLocker(t, testDB.URL)
+
+		err := locker1.Start(t.Context())
+		require.NoError(t, err)
 		defer locker1.Close()
 
 		locker2 := newTestSessionLocker(t, testDB.URL)
+
+		err = locker2.Start(t.Context())
+		require.NoError(t, err)
 		defer locker2.Close()
 
 		k, err := NewKey("test", "blocking")
@@ -207,9 +234,16 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Lock respects context cancellation", func(t *testing.T) {
 		locker1 := newTestSessionLocker(t, testDB.URL)
+
+		err := locker1.Start(t.Context())
+		require.NoError(t, err)
+
 		defer locker1.Close()
 
 		locker2 := newTestSessionLocker(t, testDB.URL)
+
+		err = locker2.Start(t.Context())
+		require.NoError(t, err)
 		defer locker2.Close()
 
 		k, err := NewKey("test", "ctx-cancel")
@@ -218,6 +252,7 @@ func Test_SessionLocker(t *testing.T) {
 		// Session 1 holds the lock
 		releaser, err := locker1.Lock(t.Context(), k)
 		require.NoError(t, err)
+
 		t.Cleanup(func() {
 			_ = releaser(t.Context())
 		})
@@ -237,9 +272,15 @@ func Test_SessionLocker(t *testing.T) {
 		}
 
 		locker1 := newTestSessionLocker(t, testDB.URL, opts...)
+
+		err := locker1.Start(t.Context())
+		require.NoError(t, err)
 		defer locker1.Close()
 
 		locker2 := newTestSessionLocker(t, testDB.URL, opts...)
+
+		err = locker2.Start(t.Context())
+		require.NoError(t, err)
 		defer locker2.Close()
 
 		k, err := NewKey("test", "timeout")
@@ -274,6 +315,9 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Multiple locks held and released independently", func(t *testing.T) {
 		locker := newTestSessionLocker(t, testDB.URL)
+
+		err := locker.Start(t.Context())
+		require.NoError(t, err)
 		defer locker.Close()
 
 		key1, err := NewKey("test", "multi-a")
@@ -302,9 +346,15 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Releaser only releases lock once", func(t *testing.T) {
 		locker1 := newTestSessionLocker(t, testDB.URL)
+
+		err := locker1.Start(t.Context())
+		require.NoError(t, err)
 		defer locker1.Close()
 
 		locker2 := newTestSessionLocker(t, testDB.URL)
+
+		err = locker2.Start(t.Context())
+		require.NoError(t, err)
 		defer locker2.Close()
 
 		k, err := NewKey("test", "release-once")
@@ -340,9 +390,15 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("TryLock succeeds after blocking Lock is released", func(t *testing.T) {
 		locker1 := newTestSessionLocker(t, testDB.URL)
+
+		err := locker1.Start(t.Context())
+		require.NoError(t, err)
 		defer locker1.Close()
 
 		locker2 := newTestSessionLocker(t, testDB.URL)
+
+		err = locker2.Start(t.Context())
+		require.NoError(t, err)
 		defer locker2.Close()
 
 		k, err := NewKey("test", "trylock-after-release")

--- a/test/notification/notification_test.go
+++ b/test/notification/notification_test.go
@@ -8,22 +8,24 @@ import (
 )
 
 func TestNotification(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	namespace := NewTestNamespace(t)
 
 	env, err := NewTestEnv(t, ctx, namespace)
 	require.NoError(t, err, "NotificationTestEnv() failed")
+	t.Cleanup(func() {
+		if env != nil {
+			if err := env.Close(); err != nil {
+				t.Errorf("failed to close environment: %v", err)
+			}
+		}
+	})
+
 	require.NotNil(t, env.Notification())
 	require.NotNil(t, env.NotificationRepo())
 	require.NotNil(t, env.Feature())
-
-	defer func() {
-		if err := env.Close(); err != nil {
-			t.Errorf("failed to close environment: %v", err)
-		}
-	}()
 
 	// Test suite for testing integration with webhook provider (Svix)
 	t.Run("Webhook", func(t *testing.T) {

--- a/test/notification/testenv.go
+++ b/test/notification/testenv.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/defaultx"
+	"github.com/openmeterio/openmeter/pkg/framework/lockr"
 )
 
 const (
@@ -185,11 +186,20 @@ func NewTestEnv(t *testing.T, ctx context.Context, namespace string) (TestEnv, e
 		return nil, fmt.Errorf("failed to create webhook handler: %w", err)
 	}
 
+	sessionLockr, err := lockr.NewSessionLockr(lockr.SessionLockerConfig{
+		Logger:         logger,
+		PostgresDriver: driver.PGDriver,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize session lockr: %w", err)
+	}
+
 	eventHandler, err := eventhandler.New(eventhandler.Config{
 		Repository: adapter,
 		Webhook:    webhook,
 		Logger:     logger,
 		Tracer:     tracer,
+		Lockr:      sessionLockr,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize notification event handler: %w", err)
@@ -215,6 +225,8 @@ func NewTestEnv(t *testing.T, ctx context.Context, namespace string) (TestEnv, e
 		if err = eventHandler.Close(); err != nil {
 			errs = errors.Join(errs, fmt.Errorf("failed to close notification event handler: %w", err))
 		}
+
+		sessionLockr.Close()
 
 		if err = entClient.Close(); err != nil {
 			errs = errors.Join(errs, fmt.Errorf("failed to close ent driver: %w", err))


### PR DESCRIPTION
## Overview

Use worker pool for processing in-flight notification events in parallel.

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable ReconcilerWorkers to control concurrent notification processing.
  * Notification reconciliation now uses a bounded worker pool for improved throughput; a sensible default is auto-detected from host parallelism.
* **Bug Fixes**
  * Improved lock handling during reconciliation to reduce conflicts and failures.
* **Tests**
  * Sample configuration/test updated to include reconcilerWorkers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->