### PR TITLE
feat: usagebased payment flows

### DIFF
--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -54,6 +54,7 @@ The generic rule is:
 - type-specific packages own type-specific lifecycle and persistence
 - `AdvanceCharges(...)` is a facade method, not the state machine itself
 - type-specific service subpackages may own reusable realization mechanics when the parent service becomes too broad; keep state-machine decisions in the lifecycle files and move only mechanical operations such as rating snapshots, realization persistence, credit allocation/correction, and realization lineage persistence into these helpers
+- invoice-backed charges must not reach the meta `final` state until their payment lifecycle is fully settled; if a charge is waiting on invoice payment authorization or settlement, keep it in an `active.*` detailed status instead of collapsing to `final`
 
 Important types:
 

--- a/openmeter/billing/charges/meta/triggers.go
+++ b/openmeter/billing/charges/meta/triggers.go
@@ -5,8 +5,10 @@ import "github.com/qmuntal/stateless"
 type Trigger = stateless.Trigger
 
 var (
-	TriggerNext                Trigger = "next"
-	TriggerInvoiceCreated      Trigger = "invoice_created"
-	TriggerCollectionCompleted Trigger = "collection_completed"
-	TriggerInvoiceIssued       Trigger = "invoice_issued"
+	TriggerNext                     Trigger = "next"
+	TriggerInvoiceCreated           Trigger = "invoice_created"
+	TriggerCollectionCompleted      Trigger = "collection_completed"
+	TriggerInvoiceIssued            Trigger = "invoice_issued"
+	TriggerInvoicePaymentAuthorized Trigger = "invoice_payment_authorized"
+	TriggerInvoicePaymentSettled    Trigger = "invoice_payment_settled"
 )

--- a/openmeter/billing/charges/service/handlers_test.go
+++ b/openmeter/billing/charges/service/handlers_test.go
@@ -144,6 +144,8 @@ var _ usagebased.Handler = (*usageBasedTestHandler)(nil)
 
 type usageBasedTestHandler struct {
 	onInvoiceUsageAccrued               func(ctx context.Context, input usagebased.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
+	onPaymentAuthorized                 func(ctx context.Context, input usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
+	onPaymentSettled                    func(ctx context.Context, input usagebased.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
 	onCreditsOnlyUsageAccrued           func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
 	onCreditsOnlyUsageAccruedCorrection func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error)
 }
@@ -158,6 +160,22 @@ func (h *usageBasedTestHandler) OnInvoiceUsageAccrued(ctx context.Context, input
 	}
 
 	return h.onInvoiceUsageAccrued(ctx, input)
+}
+
+func (h *usageBasedTestHandler) OnPaymentAuthorized(ctx context.Context, input usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {
+	if h.onPaymentAuthorized == nil {
+		return ledgertransaction.GroupReference{}, errors.New("onPaymentAuthorized is not set")
+	}
+
+	return h.onPaymentAuthorized(ctx, input)
+}
+
+func (h *usageBasedTestHandler) OnPaymentSettled(ctx context.Context, input usagebased.OnPaymentSettledInput) (ledgertransaction.GroupReference, error) {
+	if h.onPaymentSettled == nil {
+		return ledgertransaction.GroupReference{}, errors.New("onPaymentSettled is not set")
+	}
+
+	return h.onPaymentSettled(ctx, input)
 }
 
 func (h *usageBasedTestHandler) OnCreditsOnlyUsageAccrued(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -49,7 +49,7 @@ func (s *InvoicableChargesTestSuite) TearDownTest() {
 }
 
 func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-partial-credit-realizations")
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
@@ -307,7 +307,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 }
 
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDoesNotAccrueInvoiceUsage() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-fully-credited")
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
@@ -420,7 +420,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 }
 
 func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycle() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-only-lifecycle")
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
@@ -749,7 +749,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycle() {
 func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTieredCorrection() {
 	defer s.UsageBasedTestHandler.Reset()
 
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-only-lifecycle-volume-tiered-correction")
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
@@ -997,7 +997,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTier
 }
 
 func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-then-invoice")
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
@@ -1191,7 +1191,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() 
 		s.Equal(1, invoiceUsageAccruedCallback.nrInvocations)
 
 		usageBasedCharge := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
-		s.Equal(usagebased.StatusFinal, usageBasedCharge.Status)
+		s.Equal(usagebased.StatusActivePaymentPending, usageBasedCharge.Status)
 		s.Nil(usageBasedCharge.State.CurrentRealizationRunID)
 		s.Nil(usageBasedCharge.State.AdvanceAfter)
 		s.Len(usageBasedCharge.Realizations, 1)
@@ -1211,6 +1211,68 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() 
 		}, finalRun.InvoiceUsage.Totals)
 		s.NotNil(finalRun.InvoiceUsage.LedgerTransaction)
 		s.Equal(invoiceUsageAccruedCallback.id, finalRun.InvoiceUsage.LedgerTransaction.TransactionGroupID)
+	})
+
+	s.Run("#7 payment authorization moves charge to active authorized", func() {
+		defer s.UsageBasedTestHandler.Reset()
+
+		authorizedCallback := newCountedLedgerTransactionCallback[usagebased.OnPaymentAuthorizedInput]()
+		s.UsageBasedTestHandler.onPaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input usagebased.OnPaymentAuthorizedInput) {
+			assert.Equal(t, usageBasedChargeID.ID, input.Charge.ID)
+			assert.NotNil(t, input.Run.InvoiceUsage)
+			assert.Nil(t, input.Run.Payment)
+			assert.NotNil(t, input.Run.LineID)
+			assert.Equal(t, stdLineID.ID, *input.Run.LineID)
+		})
+
+		updatedInvoice, err := s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{
+			InvoiceID: invoice.GetInvoiceID(),
+			Trigger:   billing.TriggerAuthorized,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingAuthorized, updatedInvoice.Status)
+		s.Equal(1, authorizedCallback.nrInvocations)
+
+		usageBasedCharge := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
+		s.Equal(usagebased.StatusActiveAuthorized, usageBasedCharge.Status)
+		s.Len(usageBasedCharge.Realizations, 1)
+
+		finalRun := usageBasedCharge.Realizations[0]
+		s.NotNil(finalRun.Payment)
+		s.NotNil(finalRun.Payment.Authorized)
+		s.Nil(finalRun.Payment.Settled)
+		s.Equal(authorizedCallback.id, finalRun.Payment.Authorized.TransactionGroupID)
+	})
+
+	s.Run("#8 payment settlement finalizes charge", func() {
+		defer s.UsageBasedTestHandler.Reset()
+
+		settledCallback := newCountedLedgerTransactionCallback[usagebased.OnPaymentSettledInput]()
+		s.UsageBasedTestHandler.onPaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, input usagebased.OnPaymentSettledInput) {
+			assert.Equal(t, usageBasedChargeID.ID, input.Charge.ID)
+			assert.NotNil(t, input.Run.Payment)
+			assert.NotNil(t, input.Run.Payment.Authorized)
+			assert.Nil(t, input.Run.Payment.Settled)
+			assert.Equal(t, payment.StatusAuthorized, input.Run.Payment.Status)
+		})
+
+		updatedInvoice, err := s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{
+			InvoiceID: invoice.GetInvoiceID(),
+			Trigger:   billing.TriggerPaid,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaid, updatedInvoice.Status)
+		s.Equal(1, settledCallback.nrInvocations)
+
+		usageBasedCharge := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
+		s.Equal(usagebased.StatusFinal, usageBasedCharge.Status)
+		s.Len(usageBasedCharge.Realizations, 1)
+
+		finalRun := usageBasedCharge.Realizations[0]
+		s.NotNil(finalRun.Payment)
+		s.NotNil(finalRun.Payment.Settled)
+		s.Equal(settledCallback.id, finalRun.Payment.Settled.TransactionGroupID)
+		s.Equal(payment.StatusSettled, finalRun.Payment.Status)
 	})
 }
 
@@ -1384,7 +1446,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCredite
 		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
 
 		usageBasedCharge := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
-		s.Equal(usagebased.StatusFinal, usageBasedCharge.Status)
+		s.Equal(usagebased.StatusActivePaymentPending, usageBasedCharge.Status)
 		s.Nil(usageBasedCharge.State.CurrentRealizationRunID)
 		s.Nil(usageBasedCharge.State.AdvanceAfter)
 		s.Len(usageBasedCharge.Realizations, 1)
@@ -1398,7 +1460,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCredite
 }
 
 func (s *InvoicableChargesTestSuite) TestUsageBasedCreateImmediatelyActive() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-create-immediately-active")
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
@@ -1466,10 +1528,154 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreateImmediatelyActive() {
 	s.Nil(dbCharge.State.CurrentRealizationRunID)
 }
 
+func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceDirectPaidFlow() {
+	// Given
+	// - a credit-then-invoice usage-based charge with metered usage in the service period,
+	// When
+	// - the invoice is issued and the payment app emits a direct paid trigger,
+	// Then
+	// - billing should run the usage-based payment authorization and settlement hooks in order
+	//   and persist the finalized payment state on the realization run.
+
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-then-invoice-direct-paid")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	s.NotEmpty(cust.ID)
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	clock.FreezeTime(createAt)
+
+	promotionalCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
+	s.CreditPurchaseTestHandler.onPromotionalCreditPurchase = promotionalCallback.Handler(s.T())
+	s.grantPromotionalCredits(ctx, cust.GetID(), 5)
+
+	res, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: []charges.ChargeIntent{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromFloat(0.1),
+				}),
+				name:              "usage-based-direct-paid",
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: "usage-based-direct-paid",
+				featureKey:        apiRequestsTotal.Feature.Key,
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Len(res, 1)
+
+	usageBasedChargeID, err := res[0].GetChargeID()
+	s.NoError(err)
+
+	s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued, _ = newCappedCreditAllocator(5)
+
+	s.MockStreamingConnector.AddSimpleEvent(
+		apiRequestsTotal.Feature.Key,
+		100,
+		datetime.MustParseTimeInLocation(s.T(), "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+	)
+
+	clock.FreezeTime(servicePeriod.To.Add(time.Second))
+
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: cust.GetID(),
+		AsOf:     lo.ToPtr(servicePeriod.To),
+	})
+	s.NoError(err)
+	s.Len(invoices, 1)
+
+	invoice := invoices[0]
+	s.Len(invoice.Lines.OrEmpty(), 1)
+	stdLine := invoice.Lines.OrEmpty()[0]
+	stdLineID := stdLine.GetLineID()
+
+	s.MockStreamingConnector.AddSimpleEvent(
+		apiRequestsTotal.Feature.Key,
+		25,
+		datetime.MustParseTimeInLocation(s.T(), "2026-01-20T00:00:00Z", time.UTC).AsTime(),
+		streamingtestutils.WithStoredAt(datetime.MustParseTimeInLocation(s.T(), "2026-02-02T12:00:00Z", time.UTC).AsTime()),
+	)
+
+	clock.FreezeTime(invoice.DefaultCollectionAtForStandardInvoice())
+	invoice, err = s.BillingService.AdvanceInvoice(ctx, invoice.GetInvoiceID())
+	s.NoError(err)
+
+	defer s.UsageBasedTestHandler.Reset()
+
+	invoiceUsageAccruedCallback := newCountedLedgerTransactionCallback[usagebased.OnInvoiceUsageAccruedInput]()
+	s.UsageBasedTestHandler.onInvoiceUsageAccrued = invoiceUsageAccruedCallback.Handler(s.T())
+
+	invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+	s.NoError(err)
+	s.Equalf(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status, "validation issues: %v", invoice.ValidationIssues.AsError())
+	s.Equal(1, invoiceUsageAccruedCallback.nrInvocations)
+
+	authorizedCallback := newCountedLedgerTransactionCallback[usagebased.OnPaymentAuthorizedInput]()
+	s.UsageBasedTestHandler.onPaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input usagebased.OnPaymentAuthorizedInput) {
+		assert.Equal(t, usageBasedChargeID.ID, input.Charge.ID)
+		assert.NotNil(t, input.Run.InvoiceUsage)
+		assert.Nil(t, input.Run.Payment)
+		assert.NotNil(t, input.Run.LineID)
+		assert.Equal(t, stdLineID.ID, *input.Run.LineID)
+	})
+
+	settledCallback := newCountedLedgerTransactionCallback[usagebased.OnPaymentSettledInput]()
+	s.UsageBasedTestHandler.onPaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, input usagebased.OnPaymentSettledInput) {
+		assert.Equal(t, usageBasedChargeID.ID, input.Charge.ID)
+		assert.NotNil(t, input.Run.Payment)
+		assert.NotNil(t, input.Run.Payment.Authorized)
+		assert.Equal(t, authorizedCallback.id, input.Run.Payment.Authorized.TransactionGroupID)
+		assert.Nil(t, input.Run.Payment.Settled)
+		assert.Equal(t, payment.StatusAuthorized, input.Run.Payment.Status)
+	})
+
+	invoice, err = s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{
+		InvoiceID: invoice.GetInvoiceID(),
+		Trigger:   billing.TriggerPaid,
+	})
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
+	s.Equal(1, authorizedCallback.nrInvocations)
+	s.Equal(1, settledCallback.nrInvocations)
+
+	usageBasedCharge := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
+	s.Equal(usagebased.StatusFinal, usageBasedCharge.Status)
+	s.Len(usageBasedCharge.Realizations, 1)
+
+	finalRun := usageBasedCharge.Realizations[0]
+	s.NotNil(finalRun.Payment)
+	s.NotNil(finalRun.Payment.Authorized)
+	s.NotNil(finalRun.Payment.Settled)
+	s.Equal(authorizedCallback.id, finalRun.Payment.Authorized.TransactionGroupID)
+	s.Equal(settledCallback.id, finalRun.Payment.Settled.TransactionGroupID)
+	s.Equal(payment.StatusSettled, finalRun.Payment.Status)
+}
+
 func (s *InvoicableChargesTestSuite) TestUsageBasedCreateImmediatelyFinal() {
 	defer s.UsageBasedTestHandler.Reset()
 
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-create-immediately-final")
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
@@ -1580,7 +1786,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreateImmediatelyFinal() {
 }
 
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-only-lifecycle")
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
@@ -1742,7 +1948,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyCreateImmediatelyFinal() {
 	defer s.FlatFeeTestHandler.Reset()
 
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-only-create-immediately-final")
 
 	customInvoicing := s.SetupCustomInvoicing(ns)

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -1559,6 +1559,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceDirectPaidFl
 
 	createAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-01T00:00:00Z", time.UTC).AsTime()
 	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
 
 	promotionalCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
 	s.CreditPurchaseTestHandler.onPromotionalCreditPurchase = promotionalCallback.Handler(s.T())

--- a/openmeter/billing/charges/statemachine/machine.go
+++ b/openmeter/billing/charges/statemachine/machine.go
@@ -125,7 +125,18 @@ func (m *Machine[CHARGE, BASE, STATUS]) FireAndActivate(ctx context.Context, tri
 		return err
 	}
 
-	return m.stateMachine.ActivateCtx(ctx)
+	if err := m.stateMachine.ActivateCtx(ctx); err != nil {
+		return err
+	}
+
+	updatedBase, err := m.config.Persistence.UpdateBase(ctx, m.Charge.GetBase())
+	if err != nil {
+		return fmt.Errorf("persist charge: %w", err)
+	}
+
+	m.Charge = m.Charge.WithBase(updatedBase)
+
+	return nil
 }
 
 func (m *Machine[CHARGE, BASE, STATUS]) AdvanceUntilStateStable(ctx context.Context) (*CHARGE, error) {
@@ -151,13 +162,6 @@ func (m *Machine[CHARGE, BASE, STATUS]) AdvanceUntilStateStable(ctx context.Cont
 		if err := m.FireAndActivate(ctx, meta.TriggerNext); err != nil {
 			return nil, fmt.Errorf("cannot transition to the next status [current_status=%s]: %w", currentStatus, err)
 		}
-
-		updatedBase, err := m.config.Persistence.UpdateBase(ctx, m.Charge.GetBase())
-		if err != nil {
-			return nil, fmt.Errorf("persist charge: %w", err)
-		}
-
-		m.Charge = m.Charge.WithBase(updatedBase)
 
 		advanced = true
 	}

--- a/openmeter/billing/charges/statemachine/machine_test.go
+++ b/openmeter/billing/charges/statemachine/machine_test.go
@@ -101,11 +101,17 @@ func TestMachine_FireAndActivateUpdatesStatus(t *testing.T) {
 	// When:
 	// FireAndActivate is called with the next trigger.
 	// Then:
-	// the machine updates the in-memory charge status to active.
+	// the machine updates the in-memory charge status to active and persists the updated base.
+	var updateCalls int
+
 	machine := newTestMachine(
 		t,
 		newFakeCharge(fakeStatusCreated),
-		func(ctx context.Context, base fakeBase) (fakeBase, error) { return base, nil },
+		func(ctx context.Context, base fakeBase) (fakeBase, error) {
+			updateCalls++
+			base.Revision++
+			return base, nil
+		},
 		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
 	)
 
@@ -115,6 +121,8 @@ func TestMachine_FireAndActivateUpdatesStatus(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, fakeStatusActive, machine.GetCharge().GetStatus())
+	require.Equal(t, 1, machine.GetCharge().GetBase().Revision)
+	require.Equal(t, 1, updateCalls)
 }
 
 func TestMachine_FireAndActivateReturnsUnsupportedOperationWhenTriggerCannotFire(t *testing.T) {
@@ -258,6 +266,38 @@ func TestMachine_FireAndActivatePropagatesActivationErrors(t *testing.T) {
 	err := machine.FireAndActivate(t.Context(), meta.TriggerNext)
 
 	require.ErrorIs(t, err, activationErr)
+}
+
+func TestMachine_FireAndActivateDoesNotPersistWhenActivationFails(t *testing.T) {
+	// Given:
+	// a machine whose activation callback fails.
+	// When:
+	// FireAndActivate is called.
+	// Then:
+	// it returns the activation error without persisting the base.
+	activationErr := errors.New("activation failed")
+	var updateCalls int
+
+	machine := newTestMachine(
+		t,
+		newFakeCharge(fakeStatusCreated),
+		func(ctx context.Context, base fakeBase) (fakeBase, error) {
+			updateCalls++
+			return base, nil
+		},
+		func(ctx context.Context, chargeID meta.ChargeID) (fakeCharge, error) { return fakeCharge{}, nil },
+	)
+
+	machine.Configure(fakeStatusCreated).
+		Permit(meta.TriggerNext, fakeStatusActive)
+	machine.Configure(fakeStatusActive).OnActive(func(ctx context.Context) error {
+		return activationErr
+	})
+
+	err := machine.FireAndActivate(t.Context(), meta.TriggerNext)
+
+	require.ErrorIs(t, err, activationErr)
+	require.Zero(t, updateCalls)
 }
 
 func TestMachine_FireAndActivateFailsFastOnInvalidTargetStatus(t *testing.T) {

--- a/openmeter/billing/charges/testutils/handlers.go
+++ b/openmeter/billing/charges/testutils/handlers.go
@@ -99,6 +99,14 @@ func (mockUsageBasedHandler) OnInvoiceUsageAccrued(context.Context, usagebased.O
 	return newMockLedgerTransactionGroupReference(), nil
 }
 
+func (mockUsageBasedHandler) OnPaymentAuthorized(context.Context, usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {
+	return newMockLedgerTransactionGroupReference(), nil
+}
+
+func (mockUsageBasedHandler) OnPaymentSettled(context.Context, usagebased.OnPaymentSettledInput) (ledgertransaction.GroupReference, error) {
+	return newMockLedgerTransactionGroupReference(), nil
+}
+
 func (mockUsageBasedHandler) OnCreditsOnlyUsageAccrued(_ context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
 	return creditrealization.CreateAllocationInputs{
 		{

--- a/openmeter/billing/charges/usagebased/adapter.go
+++ b/openmeter/billing/charges/usagebased/adapter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 )
 
@@ -13,6 +14,7 @@ type Adapter interface {
 	RealizationRunAdapter
 	RealizationRunCreditAllocationAdapter
 	RealizationRunInvoiceUsageAdapter
+	RealizationRunPaymentAdapter
 	ChargeAdapter
 
 	entutils.TxCreator
@@ -37,4 +39,9 @@ type RealizationRunCreditAllocationAdapter interface {
 
 type RealizationRunInvoiceUsageAdapter interface {
 	CreateRunInvoicedUsage(ctx context.Context, runID RealizationRunID, invoicedUsage invoicedusage.AccruedUsage) (invoicedusage.AccruedUsage, error)
+}
+
+type RealizationRunPaymentAdapter interface {
+	CreateRunPayment(ctx context.Context, runID RealizationRunID, in payment.InvoicedCreate) (payment.Invoiced, error)
+	UpdateRunPayment(ctx context.Context, in payment.Invoiced) (payment.Invoiced, error)
 }

--- a/openmeter/billing/charges/usagebased/adapter/payment.go
+++ b/openmeter/billing/charges/usagebased/adapter/payment.go
@@ -1,0 +1,56 @@
+package adapter
+
+import (
+	"context"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedrunpayment"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+)
+
+var _ usagebased.RealizationRunPaymentAdapter = (*adapter)(nil)
+
+func (a *adapter) CreateRunPayment(ctx context.Context, runID usagebased.RealizationRunID, in payment.InvoicedCreate) (payment.Invoiced, error) {
+	if err := runID.Validate(); err != nil {
+		return payment.Invoiced{}, err
+	}
+
+	if err := in.Validate(); err != nil {
+		return payment.Invoiced{}, err
+	}
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (payment.Invoiced, error) {
+		create := tx.db.ChargeUsageBasedRunPayment.Create().
+			SetRunID(runID.ID)
+
+		create = payment.CreateInvoiced(create, in)
+
+		entity, err := create.Save(ctx)
+		if err != nil {
+			return payment.Invoiced{}, err
+		}
+
+		return payment.MapInvoicedFromDB(entity), nil
+	})
+}
+
+func (a *adapter) UpdateRunPayment(ctx context.Context, in payment.Invoiced) (payment.Invoiced, error) {
+	if err := in.Validate(); err != nil {
+		return payment.Invoiced{}, err
+	}
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (payment.Invoiced, error) {
+		update := tx.db.ChargeUsageBasedRunPayment.UpdateOneID(in.ID).
+			Where(chargeusagebasedrunpayment.Namespace(in.Namespace))
+
+		update = payment.UpdateInvoiced(update, in)
+
+		entity, err := update.Save(ctx)
+		if err != nil {
+			return payment.Invoiced{}, err
+		}
+
+		return payment.MapInvoicedFromDB(entity), nil
+	})
+}

--- a/openmeter/billing/charges/usagebased/adapter/payment.go
+++ b/openmeter/billing/charges/usagebased/adapter/payment.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
@@ -18,6 +19,10 @@ func (a *adapter) CreateRunPayment(ctx context.Context, runID usagebased.Realiza
 
 	if err := in.Validate(); err != nil {
 		return payment.Invoiced{}, err
+	}
+
+	if runID.Namespace != in.Namespace {
+		return payment.Invoiced{}, fmt.Errorf("run namespace %q does not match payment namespace %q", runID.Namespace, in.Namespace)
 	}
 
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (payment.Invoiced, error) {

--- a/openmeter/billing/charges/usagebased/handler.go
+++ b/openmeter/billing/charges/usagebased/handler.go
@@ -82,9 +82,39 @@ func (i OnInvoiceUsageAccruedInput) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
+type RunEventInput struct {
+	Charge Charge         `json:"charge"`
+	Run    RealizationRun `json:"run"`
+}
+
+func (i RunEventInput) Validate() error {
+	var errs []error
+
+	if err := i.Charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if err := i.Run.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("run: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type (
+	OnPaymentAuthorizedInput = RunEventInput
+	OnPaymentSettledInput    = RunEventInput
+)
+
 type Handler interface {
 	// OnInvoiceUsageAccrued is called when invoice-settled usage-based usage is sent to the customer.
 	OnInvoiceUsageAccrued(ctx context.Context, input OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
+
+	// OnPaymentAuthorized is called when an invoice-backed usage-based run receives payment authorization.
+	OnPaymentAuthorized(ctx context.Context, input OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
+
+	// OnPaymentSettled is called when an invoice-backed usage-based run payment is settled.
+	OnPaymentSettled(ctx context.Context, input OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
 
 	// OnCreditsOnlyUsageAccrued is called when a credit-only usage-based charge needs to be allocated as credits fully.
 	OnCreditsOnlyUsageAccrued(ctx context.Context, input CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
@@ -98,6 +128,14 @@ type UnimplementedHandler struct{}
 var _ Handler = (*UnimplementedHandler)(nil)
 
 func (h UnimplementedHandler) OnInvoiceUsageAccrued(ctx context.Context, input OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error) {
+	return ledgertransaction.GroupReference{}, errors.New("not implemented")
+}
+
+func (h UnimplementedHandler) OnPaymentAuthorized(ctx context.Context, input OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {
+	return ledgertransaction.GroupReference{}, errors.New("not implemented")
+}
+
+func (h UnimplementedHandler) OnPaymentSettled(ctx context.Context, input OnPaymentSettledInput) (ledgertransaction.GroupReference, error) {
 	return ledgertransaction.GroupReference{}, errors.New("not implemented")
 }
 

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -99,13 +99,24 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 	s.Configure(usagebased.StatusActiveFinalRealizationCompleted).
 		Permit(
 			meta.TriggerInvoiceIssued,
-			usagebased.StatusFinal,
+			usagebased.StatusActivePaymentPending,
 		).
 		Permit(meta.TriggerDelete, usagebased.StatusDeleted)
 
+	s.Configure(usagebased.StatusActivePaymentPending).
+		Permit(meta.TriggerInvoicePaymentAuthorized, usagebased.StatusActiveAuthorized).
+		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.FinalizeInvoiceRun))
+
+	s.Configure(usagebased.StatusActiveAuthorized).
+		PermitReentry(meta.TriggerInvoicePaymentAuthorized).
+		Permit(meta.TriggerInvoicePaymentSettled, usagebased.StatusFinal).
+		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		OnEntryFrom(meta.TriggerInvoicePaymentAuthorized, statelessx.WithParameters(s.RecordPaymentAuthorized))
+
 	s.Configure(usagebased.StatusFinal).
 		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
-		OnEntry(statelessx.WithParameters(s.FinalizeInvoiceRun))
+		OnEntryFrom(meta.TriggerInvoicePaymentSettled, statelessx.WithParameters(s.RecordPaymentSettled))
 
 	s.Configure(usagebased.StatusDeleted).
 		OnEntry(statelessx.WithParameters(s.DeleteCharge))
@@ -220,19 +231,7 @@ func (s *CreditThenInvoiceStateMachine) SnapshotInvoiceUsage(ctx context.Context
 	return nil
 }
 
-type invoiceIssuedInput struct {
-	Line *billing.StandardLine
-}
-
-func (i invoiceIssuedInput) Validate() error {
-	if i.Line == nil {
-		return fmt.Errorf("line is required")
-	}
-
-	return i.Line.Validate()
-}
-
-func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, input invoiceIssuedInput) error {
+func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
 	if err := input.Validate(); err != nil {
 		return err
 	}
@@ -271,4 +270,68 @@ func (s *CreditThenInvoiceStateMachine) FinalizeInvoiceRun(ctx context.Context, 
 	s.Charge.ChargeBase = updatedChargeBase
 
 	return nil
+}
+
+func (s *CreditThenInvoiceStateMachine) RecordPaymentAuthorized(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	run, err := s.getRunForLine(input.Line.ID)
+	if err != nil {
+		return err
+	}
+
+	result, err := s.Runs.BookInvoicedPaymentAuthorized(ctx, usagebasedrun.BookInvoicedPaymentAuthorizedInput{
+		Charge:  s.Charge,
+		Run:     run,
+		Invoice: input.Invoice,
+		Line:    *input.Line,
+	})
+	if err != nil {
+		return fmt.Errorf("authorize invoice payment: %w", err)
+	}
+
+	if err := s.Charge.Realizations.SetRealizationRun(result.Run); err != nil {
+		return fmt.Errorf("update realization run: %w", err)
+	}
+
+	return nil
+}
+
+func (s *CreditThenInvoiceStateMachine) RecordPaymentSettled(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	run, err := s.getRunForLine(input.Line.ID)
+	if err != nil {
+		return err
+	}
+
+	result, err := s.Runs.SettleInvoicedPayment(ctx, usagebasedrun.SettleInvoicedPaymentInput{
+		Charge:  s.Charge,
+		Run:     run,
+		Invoice: input.Invoice,
+		Line:    *input.Line,
+	})
+	if err != nil {
+		return fmt.Errorf("settle invoice payment: %w", err)
+	}
+
+	if err := s.Charge.Realizations.SetRealizationRun(result.Run); err != nil {
+		return fmt.Errorf("update realization run: %w", err)
+	}
+
+	return nil
+}
+
+func (s *CreditThenInvoiceStateMachine) getRunForLine(lineID string) (usagebased.RealizationRun, error) {
+	for _, run := range s.Charge.Realizations {
+		if run.LineID != nil && *run.LineID == lineID {
+			return run, nil
+		}
+	}
+
+	return usagebased.RealizationRun{}, fmt.Errorf("realization run not found for line %s", lineID)
 }

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -109,7 +109,6 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.FinalizeInvoiceRun))
 
 	s.Configure(usagebased.StatusActiveAuthorized).
-		PermitReentry(meta.TriggerInvoicePaymentAuthorized).
 		Permit(meta.TriggerInvoicePaymentSettled, usagebased.StatusFinal).
 		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
 		OnEntryFrom(meta.TriggerInvoicePaymentAuthorized, statelessx.WithParameters(s.RecordPaymentAuthorized))

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -166,46 +166,38 @@ func (e *LineEngine) OnInvoiceIssued(ctx context.Context, input billing.OnInvoic
 		return fmt.Errorf("validating input: %w", err)
 	}
 
-	for _, stdLine := range input.Lines {
-		stateMachine, err := e.newStateMachineForStandardLine(ctx, stdLine)
-		if err != nil {
-			return err
+	return e.fireLineTrigger(ctx, input.Lines, meta.TriggerInvoiceIssued, func(stdLine *billing.StandardLine) any {
+		return billing.StandardLineWithInvoiceHeader{
+			Line:    stdLine,
+			Invoice: input.Invoice,
 		}
+	}, true)
+}
 
-		canFire, err := stateMachine.CanFire(ctx, meta.TriggerInvoiceIssued)
-		if err != nil {
-			return fmt.Errorf("checking invoice_issued for charge[%s]: %w", stateMachine.GetCharge().ID, err)
-		}
-
-		if !canFire {
-			return fmt.Errorf(
-				"charge[%s] in status %s cannot handle invoice_issued for standard line[%s]",
-				stateMachine.GetCharge().ID,
-				stateMachine.GetCharge().Status,
-				stdLine.ID,
-			)
-		}
-
-		if err := stateMachine.FireAndActivate(ctx, meta.TriggerInvoiceIssued, invoiceIssuedInput{
-			Line: stdLine,
-		}); err != nil {
-			return fmt.Errorf("triggering invoice_issued for charge[%s]: %w", stateMachine.GetCharge().ID, err)
-		}
-
-		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
-			return fmt.Errorf("advancing usage based charge[%s] after invoice_issued: %w", stateMachine.GetCharge().ID, err)
-		}
+func (e *LineEngine) OnPaymentAuthorized(ctx context.Context, input billing.OnPaymentAuthorizedInput) error {
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("validating input: %w", err)
 	}
 
-	return nil
+	return e.fireLineTrigger(ctx, input.Lines, meta.TriggerInvoicePaymentAuthorized, func(stdLine *billing.StandardLine) any {
+		return billing.StandardLineWithInvoiceHeader{
+			Line:    stdLine,
+			Invoice: input.Invoice,
+		}
+	}, false)
 }
 
-func (e *LineEngine) OnPaymentAuthorized(_ context.Context, _ billing.OnPaymentAuthorizedInput) error {
-	return nil
-}
+func (e *LineEngine) OnPaymentSettled(ctx context.Context, input billing.OnPaymentSettledInput) error {
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("validating input: %w", err)
+	}
 
-func (e *LineEngine) OnPaymentSettled(_ context.Context, _ billing.OnPaymentSettledInput) error {
-	return nil
+	return e.fireLineTrigger(ctx, input.Lines, meta.TriggerInvoicePaymentSettled, func(stdLine *billing.StandardLine) any {
+		return billing.StandardLineWithInvoiceHeader{
+			Line:    stdLine,
+			Invoice: input.Invoice,
+		}
+	}, false)
 }
 
 func (e *LineEngine) CalculateLines(input billing.CalculateLinesInput) (billing.StandardLines, error) {
@@ -255,6 +247,48 @@ func populateUsageBasedStandardLineFromRun(stdLine *billing.StandardLine, run us
 	}
 
 	stdLine.CreditsApplied = creditsApplied
+
+	return nil
+}
+
+func (e *LineEngine) fireLineTrigger(
+	ctx context.Context,
+	lines billing.StandardLines,
+	trigger meta.Trigger,
+	inputFn func(*billing.StandardLine) any,
+	advanceAfter bool,
+) error {
+	for _, stdLine := range lines {
+		stateMachine, err := e.newStateMachineForStandardLine(ctx, stdLine)
+		if err != nil {
+			return err
+		}
+
+		canFire, err := stateMachine.CanFire(ctx, trigger)
+		if err != nil {
+			return fmt.Errorf("checking %s for charge[%s]: %w", trigger, stateMachine.GetCharge().ID, err)
+		}
+
+		if !canFire {
+			return fmt.Errorf(
+				"charge[%s] in status %s cannot handle %s for standard line[%s]",
+				stateMachine.GetCharge().ID,
+				stateMachine.GetCharge().Status,
+				trigger,
+				stdLine.ID,
+			)
+		}
+
+		if err := stateMachine.FireAndActivate(ctx, trigger, inputFn(stdLine)); err != nil {
+			return fmt.Errorf("triggering %s for charge[%s]: %w", trigger, stateMachine.GetCharge().ID, err)
+		}
+
+		if advanceAfter {
+			if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
+				return fmt.Errorf("advancing usage based charge[%s] after %s: %w", stateMachine.GetCharge().ID, trigger, err)
+			}
+		}
+	}
 
 	return nil
 }

--- a/openmeter/billing/charges/usagebased/service/run/payment.go
+++ b/openmeter/billing/charges/usagebased/service/run/payment.go
@@ -1,0 +1,194 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/pkg/clock"
+)
+
+type BookInvoicedPaymentAuthorizedInput struct {
+	Charge  usagebased.Charge
+	Run     usagebased.RealizationRun
+	Invoice billing.StandardInvoice
+	Line    billing.StandardLine
+}
+
+func (i BookInvoicedPaymentAuthorizedInput) Validate() error {
+	if err := i.Charge.Validate(); err != nil {
+		return fmt.Errorf("charge: %w", err)
+	}
+
+	if err := i.Run.Validate(); err != nil {
+		return fmt.Errorf("run: %w", err)
+	}
+
+	if err := i.Line.Validate(); err != nil {
+		return fmt.Errorf("line: %w", err)
+	}
+
+	if i.Invoice.ID == "" {
+		return fmt.Errorf("invoice id is required")
+	}
+
+	if i.Run.LineID == nil {
+		return fmt.Errorf("run %s has no linked standard line", i.Run.ID.ID)
+	}
+
+	if *i.Run.LineID != i.Line.ID {
+		return fmt.Errorf("run %s already linked to a different line", i.Run.ID.ID)
+	}
+
+	if i.Run.Payment != nil {
+		return payment.ErrPaymentAlreadyAuthorized.WithAttrs(i.Charge.ErrorAttributes())
+	}
+
+	return nil
+}
+
+type BookInvoicedPaymentAuthorizedResult struct {
+	Run     usagebased.RealizationRun
+	Payment *payment.Invoiced
+}
+
+func (s *Service) BookInvoicedPaymentAuthorized(ctx context.Context, in BookInvoicedPaymentAuthorizedInput) (BookInvoicedPaymentAuthorizedResult, error) {
+	if err := in.Validate(); err != nil {
+		return BookInvoicedPaymentAuthorizedResult{}, err
+	}
+
+	input := usagebased.OnPaymentAuthorizedInput{
+		Charge: in.Charge,
+		Run:    in.Run,
+	}
+	if err := input.Validate(); err != nil {
+		return BookInvoicedPaymentAuthorizedResult{}, fmt.Errorf("validate on payment authorized input: %w", err)
+	}
+
+	ledgerTransactionRef, err := s.handler.OnPaymentAuthorized(ctx, input)
+	if err != nil {
+		return BookInvoicedPaymentAuthorizedResult{}, fmt.Errorf("on usage-based payment authorized: %w", err)
+	}
+
+	paymentRealization, err := s.adapter.CreateRunPayment(ctx, in.Run.ID, payment.InvoicedCreate{
+		Namespace: in.Charge.Namespace,
+		LineID:    in.Line.ID,
+		InvoiceID: in.Invoice.ID,
+		Base: payment.Base{
+			ServicePeriod: in.Line.Period.ToClosedPeriod(),
+			Amount:        in.Line.Totals.Total,
+			Authorized: &ledgertransaction.TimedGroupReference{
+				GroupReference: ledgertransaction.GroupReference{
+					TransactionGroupID: ledgerTransactionRef.TransactionGroupID,
+				},
+				Time: clock.Now(),
+			},
+			Status: payment.StatusAuthorized,
+		},
+	})
+	if err != nil {
+		return BookInvoicedPaymentAuthorizedResult{}, fmt.Errorf("create invoiced payment for run %s: %w", in.Run.ID.ID, err)
+	}
+
+	in.Run.Payment = &paymentRealization
+
+	return BookInvoicedPaymentAuthorizedResult{
+		Run:     in.Run,
+		Payment: &paymentRealization,
+	}, nil
+}
+
+type SettleInvoicedPaymentInput struct {
+	Charge  usagebased.Charge
+	Run     usagebased.RealizationRun
+	Invoice billing.StandardInvoice
+	Line    billing.StandardLine
+}
+
+func (i SettleInvoicedPaymentInput) Validate() error {
+	if err := i.Charge.Validate(); err != nil {
+		return fmt.Errorf("charge: %w", err)
+	}
+
+	if err := i.Run.Validate(); err != nil {
+		return fmt.Errorf("run: %w", err)
+	}
+
+	if err := i.Line.Validate(); err != nil {
+		return fmt.Errorf("line: %w", err)
+	}
+
+	if i.Invoice.ID == "" {
+		return fmt.Errorf("invoice id is required")
+	}
+
+	if i.Run.LineID == nil {
+		return fmt.Errorf("run %s has no linked standard line", i.Run.ID.ID)
+	}
+
+	if *i.Run.LineID != i.Line.ID {
+		return fmt.Errorf("run %s already linked to a different line", i.Run.ID.ID)
+	}
+
+	if i.Run.Payment == nil {
+		return payment.ErrCannotSettleNotAuthorizedPayment.WithAttrs(i.Charge.ErrorAttributes())
+	}
+
+	if i.Run.Payment.LineID != i.Line.ID {
+		return fmt.Errorf("payment line ID does not match the line ID: %s != %s", i.Run.Payment.LineID, i.Line.ID)
+	}
+
+	if i.Run.Payment.Status != payment.StatusAuthorized {
+		return payment.ErrPaymentAlreadySettled.WithAttrs(i.Charge.ErrorAttributes())
+	}
+
+	return nil
+}
+
+type SettleInvoicedPaymentResult struct {
+	Run     usagebased.RealizationRun
+	Payment *payment.Invoiced
+}
+
+func (s *Service) SettleInvoicedPayment(ctx context.Context, in SettleInvoicedPaymentInput) (SettleInvoicedPaymentResult, error) {
+	if err := in.Validate(); err != nil {
+		return SettleInvoicedPaymentResult{}, err
+	}
+
+	input := usagebased.OnPaymentSettledInput{
+		Charge: in.Charge,
+		Run:    in.Run,
+	}
+	if err := input.Validate(); err != nil {
+		return SettleInvoicedPaymentResult{}, fmt.Errorf("validate on payment settled input: %w", err)
+	}
+
+	ledgerTransactionRef, err := s.handler.OnPaymentSettled(ctx, input)
+	if err != nil {
+		return SettleInvoicedPaymentResult{}, fmt.Errorf("on usage-based payment settled: %w", err)
+	}
+
+	paymentRealization := *in.Run.Payment
+	paymentRealization.Settled = &ledgertransaction.TimedGroupReference{
+		GroupReference: ledgertransaction.GroupReference{
+			TransactionGroupID: ledgerTransactionRef.TransactionGroupID,
+		},
+		Time: clock.Now(),
+	}
+	paymentRealization.Status = payment.StatusSettled
+
+	paymentRealization, err = s.adapter.UpdateRunPayment(ctx, paymentRealization)
+	if err != nil {
+		return SettleInvoicedPaymentResult{}, fmt.Errorf("update invoiced payment for run %s: %w", in.Run.ID.ID, err)
+	}
+
+	in.Run.Payment = &paymentRealization
+
+	return SettleInvoicedPaymentResult{
+		Run:     in.Run,
+		Payment: &paymentRealization,
+	}, nil
+}

--- a/openmeter/billing/charges/usagebased/service/run/payment_test.go
+++ b/openmeter/billing/charges/usagebased/service/run/payment_test.go
@@ -1,0 +1,214 @@
+package run
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestBookInvoicedPaymentAuthorizedInputValidate(t *testing.T) {
+	valid := newBookPaymentAuthorizedInput()
+	require.NoError(t, valid.Validate())
+
+	t.Run("rejects existing payment", func(t *testing.T) {
+		in := newBookPaymentAuthorizedInput()
+		in.Run.Payment = &payment.Invoiced{
+			Payment: payment.Payment{
+				NamespacedID: models.NamespacedID{Namespace: in.Charge.Namespace, ID: "payment-1"},
+				ManagedModel: models.ManagedModel{CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()},
+				Base: payment.Base{
+					ServicePeriod: in.Line.Period.ToClosedPeriod(),
+					Status:        payment.StatusAuthorized,
+					Amount:        in.Line.Totals.Total,
+					Authorized: &ledgertransaction.TimedGroupReference{
+						GroupReference: ledgertransaction.GroupReference{
+							TransactionGroupID: "authorized-group",
+						},
+						Time: time.Now().UTC(),
+					},
+				},
+			},
+			LineID:    in.Line.ID,
+			InvoiceID: in.Invoice.ID,
+		}
+		require.ErrorContains(t, in.Validate(), "payment already authorized")
+	})
+
+	t.Run("rejects mismatched line id", func(t *testing.T) {
+		in := newBookPaymentAuthorizedInput()
+		other := "other-line"
+		in.Run.LineID = &other
+		require.ErrorContains(t, in.Validate(), "already linked to a different line")
+	})
+}
+
+func TestSettleInvoicedPaymentInputValidate(t *testing.T) {
+	valid := newSettlePaymentInput()
+	require.NoError(t, valid.Validate())
+
+	t.Run("rejects missing payment", func(t *testing.T) {
+		in := newSettlePaymentInput()
+		in.Run.Payment = nil
+		require.ErrorContains(t, in.Validate(), "cannot settle an unauthorized payment")
+	})
+
+	t.Run("rejects mismatched payment line id", func(t *testing.T) {
+		in := newSettlePaymentInput()
+		in.Run.Payment.LineID = "other-line"
+		require.ErrorContains(t, in.Validate(), "payment line ID does not match")
+	})
+
+	t.Run("rejects non authorized payment status", func(t *testing.T) {
+		in := newSettlePaymentInput()
+		in.Run.Payment.Status = payment.StatusSettled
+		in.Run.Payment.Settled = &ledgertransaction.TimedGroupReference{
+			GroupReference: ledgertransaction.GroupReference{
+				TransactionGroupID: "settled-group",
+			},
+			Time: time.Now().UTC(),
+		}
+		require.ErrorContains(t, in.Validate(), "payment already settled")
+	})
+}
+
+func newBookPaymentAuthorizedInput() BookInvoicedPaymentAuthorizedInput {
+	lineID := "line-1"
+	now := time.Now().UTC()
+	return BookInvoicedPaymentAuthorizedInput{
+		Charge: newUsageBasedCharge(),
+		Run:    newUsageBasedRun(lineID),
+		Invoice: billing.StandardInvoice{
+			StandardInvoiceBase: billing.StandardInvoiceBase{
+				Namespace: "ns",
+				ID:        "invoice-1",
+			},
+		},
+		Line: billing.StandardLine{
+			StandardLineBase: billing.StandardLineBase{
+				ManagedResource: models.ManagedResource{
+					NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+					ManagedModel:    models.ManagedModel{CreatedAt: now, UpdatedAt: now},
+					ID:              lineID,
+					Name:            "line-1",
+				},
+				ManagedBy: billing.SystemManagedLine,
+				Currency:  currencyx.Code("USD"),
+				InvoiceID: "invoice-1",
+				InvoiceAt: now,
+				Period: billing.Period{
+					Start: now.Add(-time.Hour),
+					End:   now,
+				},
+				Totals: totals.Totals{
+					Amount: alpacadecimal.NewFromInt(10),
+					Total:  alpacadecimal.NewFromInt(10),
+				},
+			},
+			UsageBased: &billing.UsageBasedLine{
+				Price:           productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+				FeatureKey:      "api_requests",
+				Quantity:        lo.ToPtr(alpacadecimal.NewFromInt(10)),
+				MeteredQuantity: lo.ToPtr(alpacadecimal.NewFromInt(10)),
+			},
+		},
+	}
+}
+
+func newSettlePaymentInput() SettleInvoicedPaymentInput {
+	authInput := newBookPaymentAuthorizedInput()
+	authInput.Run.InvoiceUsage = &invoicedusage.AccruedUsage{
+		LineID:        &authInput.Line.ID,
+		ServicePeriod: authInput.Line.Period.ToClosedPeriod(),
+		Mutable:       false,
+		Totals:        authInput.Line.Totals,
+	}
+	authInput.Run.Payment = &payment.Invoiced{
+		Payment: payment.Payment{
+			NamespacedID: models.NamespacedID{Namespace: authInput.Charge.Namespace, ID: "payment-1"},
+			ManagedModel: models.ManagedModel{CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()},
+			Base: payment.Base{
+				ServicePeriod: authInput.Line.Period.ToClosedPeriod(),
+				Status:        payment.StatusAuthorized,
+				Amount:        authInput.Line.Totals.Total,
+				Authorized: &ledgertransaction.TimedGroupReference{
+					GroupReference: ledgertransaction.GroupReference{
+						TransactionGroupID: "authorized-group",
+					},
+					Time: time.Now().UTC(),
+				},
+			},
+		},
+		LineID:    authInput.Line.ID,
+		InvoiceID: authInput.Invoice.ID,
+	}
+
+	return SettleInvoicedPaymentInput(authInput)
+}
+
+func newUsageBasedCharge() usagebased.Charge {
+	now := time.Now().UTC()
+	period := timeutil.ClosedPeriod{From: now.Add(-2 * time.Hour), To: now.Add(-time.Hour)}
+
+	return usagebased.Charge{
+		ChargeBase: usagebased.ChargeBase{
+			ManagedResource: meta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+				ManagedModel:    models.ManagedModel{CreatedAt: now, UpdatedAt: now},
+				ID:              "charge-1",
+			},
+			Intent: usagebased.Intent{
+				Intent: meta.Intent{
+					Name:          "usage based",
+					ManagedBy:     billing.SystemManagedLine,
+					CustomerID:    "cust-1",
+					Currency:      currencyx.Code("USD"),
+					ServicePeriod: period,
+					BillingPeriod: period,
+				},
+				InvoiceAt:      now,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				FeatureKey:     "api_requests",
+				Price:          *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
+			},
+			Status: usagebased.StatusActivePaymentPending,
+			State: usagebased.State{
+				FeatureID: "feature-1",
+			},
+		},
+	}
+}
+
+func newUsageBasedRun(lineID string) usagebased.RealizationRun {
+	now := time.Now().UTC()
+	return usagebased.RealizationRun{
+		RealizationRunBase: usagebased.RealizationRunBase{
+			ID:            usagebased.RealizationRunID(models.NamespacedID{Namespace: "ns", ID: "run-1"}),
+			ManagedModel:  models.ManagedModel{CreatedAt: now, UpdatedAt: now},
+			FeatureID:     "feature-1",
+			LineID:        &lineID,
+			Type:          usagebased.RealizationRunTypeFinalRealization,
+			AsOf:          now,
+			CollectionEnd: now,
+			MeterValue:    alpacadecimal.NewFromInt(10),
+			Totals: totals.Totals{
+				Amount: alpacadecimal.NewFromInt(10),
+				Total:  alpacadecimal.NewFromInt(10),
+			},
+		},
+	}
+}

--- a/openmeter/billing/charges/usagebased/statemachine.go
+++ b/openmeter/billing/charges/usagebased/statemachine.go
@@ -21,6 +21,8 @@ const (
 	StatusActiveFinalRealizationWaitingForCollection Status = "active.final_realization.waiting_for_collection"
 	StatusActiveFinalRealizationProcessing           Status = "active.final_realization.processing"
 	StatusActiveFinalRealizationCompleted            Status = "active.final_realization.completed"
+	StatusActivePaymentPending                       Status = "active.payment_pending"
+	StatusActiveAuthorized                           Status = "active.authorized"
 
 	StatusFinal   Status = Status(meta.ChargeStatusFinal)
 	StatusDeleted Status = Status(meta.ChargeStatusDeleted)
@@ -34,6 +36,8 @@ func (Status) Values() []string {
 		string(StatusActiveFinalRealizationWaitingForCollection),
 		string(StatusActiveFinalRealizationProcessing),
 		string(StatusActiveFinalRealizationCompleted),
+		string(StatusActivePaymentPending),
+		string(StatusActiveAuthorized),
 		string(StatusFinal),
 		string(StatusDeleted),
 	}

--- a/openmeter/billing/invoicelinesplitgroup.go
+++ b/openmeter/billing/invoicelinesplitgroup.go
@@ -187,9 +187,41 @@ type GatheringLineWithInvoiceHeader struct {
 	Invoice GatheringInvoice
 }
 
+func (l GatheringLineWithInvoiceHeader) Validate() error {
+	if err := l.Line.Validate(); err != nil {
+		return fmt.Errorf("line: %w", err)
+	}
+
+	// This transport only carries the parent invoice entity as a header object,
+	// so we validate invoice identity here instead of requiring a fully fetched invoice aggregate.
+	if l.Invoice.ID == "" {
+		return fmt.Errorf("invoice id is required")
+	}
+
+	return nil
+}
+
 type StandardLineWithInvoiceHeader struct {
 	Line    *StandardLine
 	Invoice StandardInvoice
+}
+
+func (l StandardLineWithInvoiceHeader) Validate() error {
+	if l.Line == nil {
+		return fmt.Errorf("line is required")
+	}
+
+	if err := l.Line.Validate(); err != nil {
+		return fmt.Errorf("line: %w", err)
+	}
+
+	// This transport only carries the parent invoice entity as a header object,
+	// so we validate invoice identity here instead of requiring a fully fetched invoice aggregate.
+	if l.Invoice.ID == "" {
+		return fmt.Errorf("invoice id is required")
+	}
+
+	return nil
 }
 
 type LineWithInvoiceHeader struct {

--- a/openmeter/ent/db/chargeusagebased/chargeusagebased.go
+++ b/openmeter/ent/db/chargeusagebased/chargeusagebased.go
@@ -263,7 +263,7 @@ func SettlementModeValidator(sm productcatalog.SettlementMode) error {
 // StatusDetailedValidator is a validator for the "status_detailed" field enum values. It is called by the builders before save.
 func StatusDetailedValidator(sd usagebased.Status) error {
 	switch sd {
-	case "created", "active", "active.final_realization.started", "active.final_realization.waiting_for_collection", "active.final_realization.processing", "active.final_realization.completed", "final", "deleted":
+	case "created", "active", "active.final_realization.started", "active.final_realization.waiting_for_collection", "active.final_realization.processing", "active.final_realization.completed", "active.payment_pending", "active.authorized", "final", "deleted":
 		return nil
 	default:
 		return fmt.Errorf("chargeusagebased: invalid enum value for status_detailed field: %q", sd)

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -2231,7 +2231,7 @@ var (
 		{Name: "discounts", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "feature_key", Type: field.TypeString},
 		{Name: "price", Type: field.TypeString, SchemaType: map[string]string{"postgres": "jsonb"}},
-		{Name: "status_detailed", Type: field.TypeEnum, Enums: []string{"created", "active", "active.final_realization.started", "active.final_realization.waiting_for_collection", "active.final_realization.processing", "active.final_realization.completed", "final", "deleted"}},
+		{Name: "status_detailed", Type: field.TypeEnum, Enums: []string{"created", "active", "active.final_realization.started", "active.final_realization.waiting_for_collection", "active.final_realization.processing", "active.final_realization.completed", "active.payment_pending", "active.authorized", "final", "deleted"}},
 		{Name: "current_realization_run_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "customer_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "feature_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ledger/collector"
 	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
 )
 
 // usageBasedHandler maps usage-based credit lifecycle events to ledger transaction templates.
@@ -96,6 +97,7 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 	if err := input.Validate(); err != nil {
 		return ledgertransaction.GroupReference{}, err
 	}
+	eventTime := clock.Now()
 
 	if err := validateSettlementMode(
 		input.Charge.Intent.SettlementMode,
@@ -128,7 +130,7 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.FundCustomerReceivableTemplate{
-			At:        input.Charge.Intent.InvoiceAt,
+			At:        eventTime,
 			Amount:    receivableReplenishment,
 			Currency:  input.Charge.Intent.Currency,
 			CostBasis: invoiceCostBasis,
@@ -162,6 +164,7 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 	if err := input.Validate(); err != nil {
 		return ledgertransaction.GroupReference{}, err
 	}
+	eventTime := clock.Now()
 
 	if err := validateSettlementMode(
 		input.Charge.Intent.SettlementMode,
@@ -189,7 +192,7 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.SettleCustomerReceivablePaymentTemplate{
-			At:        input.Charge.Intent.InvoiceAt,
+			At:        eventTime,
 			Amount:    input.Run.InvoiceUsage.Totals.Total,
 			Currency:  input.Charge.Intent.Currency,
 			CostBasis: invoiceCostBasis,

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/alpacahq/alpacadecimal"
+
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
@@ -79,6 +81,133 @@ func (h *usageBasedHandler) OnInvoiceUsageAccrued(ctx context.Context, input usa
 	transactionGroup, err := h.ledger.CommitGroup(ctx, transactions.GroupInputs(
 		input.Charge.Namespace,
 		chargeAnnotationsForUsageBasedCharge(input.Charge),
+		inputs...,
+	))
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("commit ledger transaction group: %w", err)
+	}
+
+	return ledgertransaction.GroupReference{
+		TransactionGroupID: transactionGroup.ID().ID,
+	}, nil
+}
+
+func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {
+	if err := input.Validate(); err != nil {
+		return ledgertransaction.GroupReference{}, err
+	}
+
+	if err := validateSettlementMode(
+		input.Charge.Intent.SettlementMode,
+		productcatalog.InvoiceOnlySettlementMode,
+		productcatalog.CreditThenInvoiceSettlementMode,
+	); err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("payment authorized: %w", err)
+	}
+
+	receivableReplenishment := alpacadecimal.Zero
+	if input.Run.InvoiceUsage != nil {
+		receivableReplenishment = input.Run.InvoiceUsage.Totals.Total
+	}
+
+	if receivableReplenishment.IsZero() {
+		return ledgertransaction.GroupReference{}, nil
+	}
+
+	customerID := customer.CustomerID{
+		Namespace: input.Charge.Namespace,
+		ID:        input.Charge.Intent.CustomerID,
+	}
+	annotations := chargeAnnotationsForUsageBasedCharge(input.Charge)
+
+	inputs, err := transactions.ResolveTransactions(
+		ctx,
+		h.deps,
+		transactions.ResolutionScope{
+			CustomerID: customerID,
+			Namespace:  input.Charge.Namespace,
+		},
+		transactions.FundCustomerReceivableTemplate{
+			At:        input.Charge.Intent.InvoiceAt,
+			Amount:    receivableReplenishment,
+			Currency:  input.Charge.Intent.Currency,
+			CostBasis: invoiceCostBasis,
+		},
+	)
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("resolve transactions: %w", err)
+	}
+
+	for i, txInput := range inputs {
+		if txInput != nil {
+			inputs[i] = transactions.WithAnnotations(txInput, annotations)
+		}
+	}
+
+	transactionGroup, err := h.ledger.CommitGroup(ctx, transactions.GroupInputs(
+		input.Charge.Namespace,
+		annotations,
+		inputs...,
+	))
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("commit ledger transaction group: %w", err)
+	}
+
+	return ledgertransaction.GroupReference{
+		TransactionGroupID: transactionGroup.ID().ID,
+	}, nil
+}
+
+func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebased.OnPaymentSettledInput) (ledgertransaction.GroupReference, error) {
+	if err := input.Validate(); err != nil {
+		return ledgertransaction.GroupReference{}, err
+	}
+
+	if err := validateSettlementMode(
+		input.Charge.Intent.SettlementMode,
+		productcatalog.InvoiceOnlySettlementMode,
+		productcatalog.CreditThenInvoiceSettlementMode,
+	); err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("payment settled: %w", err)
+	}
+
+	if input.Run.InvoiceUsage == nil || !input.Run.InvoiceUsage.Totals.Total.IsPositive() {
+		return ledgertransaction.GroupReference{}, nil
+	}
+
+	customerID := customer.CustomerID{
+		Namespace: input.Charge.Namespace,
+		ID:        input.Charge.Intent.CustomerID,
+	}
+	annotations := chargeAnnotationsForUsageBasedCharge(input.Charge)
+
+	inputs, err := transactions.ResolveTransactions(
+		ctx,
+		h.deps,
+		transactions.ResolutionScope{
+			CustomerID: customerID,
+			Namespace:  input.Charge.Namespace,
+		},
+		transactions.SettleCustomerReceivablePaymentTemplate{
+			At:        input.Charge.Intent.InvoiceAt,
+			Amount:    input.Run.InvoiceUsage.Totals.Total,
+			Currency:  input.Charge.Intent.Currency,
+			CostBasis: invoiceCostBasis,
+		},
+	)
+	if err != nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("resolve transactions: %w", err)
+	}
+
+	for i, txInput := range inputs {
+		if txInput != nil {
+			inputs[i] = transactions.WithAnnotations(txInput, annotations)
+		}
+	}
+
+	transactionGroup, err := h.ledger.CommitGroup(ctx, transactions.GroupInputs(
+		input.Charge.Namespace,
+		annotations,
 		inputs...,
 	))
 	if err != nil {

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	chargeusagebased "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	ledgertransactiondb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransaction"
@@ -223,6 +226,90 @@ func TestOnUsageBasedInvoiceUsageAccrued(t *testing.T) {
 	})
 }
 
+func TestOnUsageBasedPaymentAuthorized(t *testing.T) {
+	t.Run("credit_then_invoice stages receivable funding from invoice usage", func(t *testing.T) {
+		env := newUsageBasedHandlerTestEnv(t)
+
+		total := alpacadecimal.NewFromInt(40)
+		_, err := env.handler.OnInvoiceUsageAccrued(t.Context(), chargeusagebased.OnInvoiceUsageAccruedInput{
+			Charge:        env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Run:           env.newRunWithLine("line-1"),
+			ServicePeriod: timeutil.ClosedPeriod{From: env.Now().Add(-time.Hour), To: env.Now()},
+			Amount:        total,
+		})
+		require.NoError(t, err)
+
+		ref, err := env.handler.OnPaymentAuthorized(t.Context(), chargeusagebased.OnPaymentAuthorizedInput{
+			Charge: env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Run:    env.newRunWithInvoiceUsage("line-1", total),
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, ref.TransactionGroupID)
+
+		// Receivable is only funded into the authorized staging bucket at authorization time.
+		require.True(t, env.sumBalance(t, env.receivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(-40)))
+		require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(40)))
+		require.True(t, env.sumBalance(t, env.washSubAccount(t)).Equal(alpacadecimal.NewFromInt(-40)))
+		// No revenue recognition happens here anymore.
+		require.True(t, env.sumBalance(t, env.invoiceAccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(40)))
+		require.True(t, env.sumBalance(t, env.invoiceEarningsSubAccount(t)).Equal(alpacadecimal.Zero))
+	})
+
+	t.Run("zero invoice usage is a no-op", func(t *testing.T) {
+		env := newUsageBasedHandlerTestEnv(t)
+
+		ref, err := env.handler.OnPaymentAuthorized(t.Context(), chargeusagebased.OnPaymentAuthorizedInput{
+			Charge: env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Run:    env.newRunWithInvoiceUsage("line-1", alpacadecimal.Zero),
+		})
+		require.NoError(t, err)
+		require.Empty(t, ref.TransactionGroupID)
+	})
+}
+
+func TestOnUsageBasedPaymentSettled(t *testing.T) {
+	t.Run("credit_then_invoice settles authorized receivable", func(t *testing.T) {
+		env := newUsageBasedHandlerTestEnv(t)
+
+		total := alpacadecimal.NewFromInt(25)
+		_, err := env.handler.OnInvoiceUsageAccrued(t.Context(), chargeusagebased.OnInvoiceUsageAccruedInput{
+			Charge:        env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Run:           env.newRunWithLine("line-1"),
+			ServicePeriod: timeutil.ClosedPeriod{From: env.Now().Add(-time.Hour), To: env.Now()},
+			Amount:        total,
+		})
+		require.NoError(t, err)
+
+		_, err = env.handler.OnPaymentAuthorized(t.Context(), chargeusagebased.OnPaymentAuthorizedInput{
+			Charge: env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Run:    env.newRunWithInvoiceUsage("line-1", total),
+		})
+		require.NoError(t, err)
+
+		ref, err := env.handler.OnPaymentSettled(t.Context(), chargeusagebased.OnPaymentSettledInput{
+			Charge: env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Run:    env.newRunWithAuthorizedPayment("line-1", total),
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, ref.TransactionGroupID)
+
+		require.True(t, env.sumBalance(t, env.unknownReceivableSubAccount(t)).Equal(alpacadecimal.Zero))
+		require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t)).Equal(alpacadecimal.Zero))
+		require.True(t, env.sumBalance(t, env.washSubAccount(t)).Equal(alpacadecimal.NewFromInt(-25)))
+	})
+
+	t.Run("zero invoice usage is a no-op", func(t *testing.T) {
+		env := newUsageBasedHandlerTestEnv(t)
+
+		ref, err := env.handler.OnPaymentSettled(t.Context(), chargeusagebased.OnPaymentSettledInput{
+			Charge: env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Run:    env.newRunWithAuthorizedPaymentAndInvoiceUsage("line-1", alpacadecimal.NewFromInt(1), alpacadecimal.Zero),
+		})
+		require.NoError(t, err)
+		require.Empty(t, ref.TransactionGroupID)
+	})
+}
+
 type usageBasedHandlerTestEnv struct {
 	*ledgertestutils.IntegrationEnv
 	handler chargeusagebased.Handler
@@ -321,6 +408,62 @@ func (e *usageBasedHandlerTestEnv) newRun() chargeusagebased.RealizationRun {
 	}
 }
 
+func (e *usageBasedHandlerTestEnv) newRunWithLine(lineID string) chargeusagebased.RealizationRun {
+	run := e.newRun()
+	run.LineID = &lineID
+	return run
+}
+
+func (e *usageBasedHandlerTestEnv) newRunWithInvoiceUsage(lineID string, total alpacadecimal.Decimal) chargeusagebased.RealizationRun {
+	run := e.newRunWithLine(lineID)
+	run.InvoiceUsage = &invoicedusage.AccruedUsage{
+		LineID:        &lineID,
+		ServicePeriod: e.newCharge(productcatalog.CreditThenInvoiceSettlementMode).Intent.ServicePeriod,
+		Mutable:       false,
+		Totals: totals.Totals{
+			Amount: total,
+			Total:  total,
+		},
+	}
+
+	return run
+}
+
+func (e *usageBasedHandlerTestEnv) newRunWithAuthorizedPayment(lineID string, total alpacadecimal.Decimal) chargeusagebased.RealizationRun {
+	return e.newRunWithAuthorizedPaymentAndInvoiceUsage(lineID, total, total)
+}
+
+func (e *usageBasedHandlerTestEnv) newRunWithAuthorizedPaymentAndInvoiceUsage(lineID string, paymentAmount, invoiceUsageTotal alpacadecimal.Decimal) chargeusagebased.RealizationRun {
+	run := e.newRunWithInvoiceUsage(lineID, invoiceUsageTotal)
+	run.Payment = &payment.Invoiced{
+		Payment: payment.Payment{
+			NamespacedID: models.NamespacedID{
+				Namespace: e.Namespace,
+				ID:        "payment-1",
+			},
+			ManagedModel: models.ManagedModel{
+				CreatedAt: e.Now(),
+				UpdatedAt: e.Now(),
+			},
+			Base: payment.Base{
+				ServicePeriod: run.InvoiceUsage.ServicePeriod,
+				Status:        payment.StatusAuthorized,
+				Amount:        paymentAmount,
+				Authorized: &ledgertransaction.TimedGroupReference{
+					GroupReference: ledgertransaction.GroupReference{
+						TransactionGroupID: "authorized-group",
+					},
+					Time: e.Now(),
+				},
+			},
+		},
+		LineID:    lineID,
+		InvoiceID: "invoice-1",
+	}
+
+	return run
+}
+
 func (e *usageBasedHandlerTestEnv) fundPriority(t *testing.T, priority int, amount int64) ledger.SubAccount {
 	t.Helper()
 
@@ -385,6 +528,26 @@ func (e *usageBasedHandlerTestEnv) unknownAccruedSubAccount(t *testing.T) ledger
 
 func (e *usageBasedHandlerTestEnv) unknownReceivableSubAccount(t *testing.T) ledger.SubAccount {
 	return e.ReceivableSubAccountWithCostBasis(t, nil)
+}
+
+func (e *usageBasedHandlerTestEnv) authorizedReceivableSubAccount(t *testing.T) ledger.SubAccount {
+	return e.ReceivableSubAccountWithCostBasisAndStatus(t, testInvoiceCostBasis(), ledger.TransactionAuthorizationStatusAuthorized)
+}
+
+func (e *usageBasedHandlerTestEnv) receivableSubAccount(t *testing.T) ledger.SubAccount {
+	return e.ReceivableSubAccountWithCostBasis(t, testInvoiceCostBasis())
+}
+
+func (e *usageBasedHandlerTestEnv) washSubAccount(t *testing.T) ledger.SubAccount {
+	return e.WashSubAccountWithCostBasis(t, testInvoiceCostBasis())
+}
+
+func (e *usageBasedHandlerTestEnv) invoiceAccruedSubAccount(t *testing.T) ledger.SubAccount {
+	return e.AccruedSubAccountWithCostBasis(t, testInvoiceCostBasis())
+}
+
+func (e *usageBasedHandlerTestEnv) invoiceEarningsSubAccount(t *testing.T) ledger.SubAccount {
+	return e.EarningsSubAccountWithCostBasis(t, testInvoiceCostBasis())
 }
 
 func (e *usageBasedHandlerTestEnv) unknownFboSubAccount(t *testing.T) ledger.SubAccount {

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -23,6 +23,7 @@ import (
 	ledgertestutils "github.com/openmeterio/openmeter/openmeter/ledger/testutils"
 	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -239,8 +240,14 @@ func TestOnUsageBasedPaymentAuthorized(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		charge := env.newCharge(productcatalog.CreditThenInvoiceSettlementMode)
+		charge.Intent.InvoiceAt = env.Now().Add(-24 * time.Hour)
+		eventTime := env.Now().Add(15 * time.Minute)
+		clock.FreezeTime(eventTime)
+		defer clock.UnFreeze()
+
 		ref, err := env.handler.OnPaymentAuthorized(t.Context(), chargeusagebased.OnPaymentAuthorizedInput{
-			Charge: env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Charge: charge,
 			Run:    env.newRunWithInvoiceUsage("line-1", total),
 		})
 		require.NoError(t, err)
@@ -253,6 +260,11 @@ func TestOnUsageBasedPaymentAuthorized(t *testing.T) {
 		// No revenue recognition happens here anymore.
 		require.True(t, env.sumBalance(t, env.invoiceAccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(40)))
 		require.True(t, env.sumBalance(t, env.invoiceEarningsSubAccount(t)).Equal(alpacadecimal.Zero))
+
+		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
+			require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
+			require.False(t, bookedAt.UTC().Equal(charge.Intent.InvoiceAt.UTC()))
+		}
 	})
 
 	t.Run("zero invoice usage is a no-op", func(t *testing.T) {
@@ -280,14 +292,22 @@ func TestOnUsageBasedPaymentSettled(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		authorizedCharge := env.newCharge(productcatalog.CreditThenInvoiceSettlementMode)
+		authorizedCharge.Intent.InvoiceAt = env.Now().Add(-24 * time.Hour)
 		_, err = env.handler.OnPaymentAuthorized(t.Context(), chargeusagebased.OnPaymentAuthorizedInput{
-			Charge: env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Charge: authorizedCharge,
 			Run:    env.newRunWithInvoiceUsage("line-1", total),
 		})
 		require.NoError(t, err)
 
+		settledCharge := env.newCharge(productcatalog.CreditThenInvoiceSettlementMode)
+		settledCharge.Intent.InvoiceAt = env.Now().Add(-48 * time.Hour)
+		eventTime := env.Now().Add(30 * time.Minute)
+		clock.FreezeTime(eventTime)
+		defer clock.UnFreeze()
+
 		ref, err := env.handler.OnPaymentSettled(t.Context(), chargeusagebased.OnPaymentSettledInput{
-			Charge: env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Charge: settledCharge,
 			Run:    env.newRunWithAuthorizedPayment("line-1", total),
 		})
 		require.NoError(t, err)
@@ -296,6 +316,11 @@ func TestOnUsageBasedPaymentSettled(t *testing.T) {
 		require.True(t, env.sumBalance(t, env.unknownReceivableSubAccount(t)).Equal(alpacadecimal.Zero))
 		require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t)).Equal(alpacadecimal.Zero))
 		require.True(t, env.sumBalance(t, env.washSubAccount(t)).Equal(alpacadecimal.NewFromInt(-25)))
+
+		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
+			require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
+			require.False(t, bookedAt.UTC().Equal(settledCharge.Intent.InvoiceAt.UTC()))
+		}
 	})
 
 	t.Run("zero invoice usage is a no-op", func(t *testing.T) {
@@ -582,6 +607,29 @@ func (e *usageBasedHandlerTestEnv) transactionAnnotations(t *testing.T, groupID 
 	out := make([]models.Annotations, 0, len(transactions))
 	for _, tx := range transactions {
 		out = append(out, tx.Annotations)
+	}
+
+	return out
+}
+
+func (e *usageBasedHandlerTestEnv) transactionBookedAtTimes(t *testing.T, groupID string) []time.Time {
+	t.Helper()
+
+	transactions, err := e.DB.LedgerTransaction.Query().
+		Where(
+			ledgertransactiondb.Namespace(e.Namespace),
+			ledgertransactiondb.GroupID(groupID),
+		).
+		Order(
+			ledgertransactiondb.ByCreatedAt(),
+			ledgertransactiondb.ByID(),
+		).
+		All(t.Context())
+	require.NoError(t, err)
+
+	out := make([]time.Time, 0, len(transactions))
+	for _, tx := range transactions {
+		out = append(out, tx.BookedAt)
 	}
 
 	return out

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -1,7 +1,6 @@
 package credits
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -31,6 +30,7 @@ import (
 	ledgertestutils "github.com/openmeterio/openmeter/openmeter/ledger/testutils"
 	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
 	omtestutils "github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -96,15 +96,14 @@ func (s *CreditsTestSuite) TearDownTest() {
 }
 
 func (s *CreditsTestSuite) TestFlatFeeCreditOnlyDeleteCorrectionSanity() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-flatfee-credit-only-delete")
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.createLedgerBackedCustomer(ns, "test-subject")
 
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
-		billingtest.WithProgressiveBilling(),
-		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "PT1H")),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
 		billingtest.WithManualApproval(),
 	)
 
@@ -171,7 +170,7 @@ func (s *CreditsTestSuite) TestFlatFeeCreditOnlyDeleteCorrectionSanity() {
 }
 
 func (s *CreditsTestSuite) TestUsageBasedCreditOnlyDeleteCorrectionSanity() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-usagebased-credit-only-delete")
 
 	cust := s.createLedgerBackedCustomer(ns, "test-subject")
@@ -239,7 +238,7 @@ func (s *CreditsTestSuite) TestUsageBasedCreditOnlyDeleteCorrectionSanity() {
 }
 
 func (s *CreditsTestSuite) TestUsageBasedCreditOnlyDeleteCorrectionWithPartialBackfillSanity() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-usagebased-credit-only-delete-partial-backfill")
 
 	cust := s.createLedgerBackedCustomer(ns, "test-subject")
@@ -362,7 +361,7 @@ func (s *CreditsTestSuite) TestUsageBasedCreditOnlyDeleteCorrectionWithPartialBa
 }
 
 func (s *CreditsTestSuite) TestFlatFeeCreditThenInvoiceSanity() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-test")
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
@@ -720,7 +719,7 @@ func (s *CreditsTestSuite) TestFlatFeeCreditThenInvoiceSanity() {
 }
 
 func (s *CreditsTestSuite) TestCreditPurchasePersistsPriority() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-creditpurchase-persists-priority")
 
 	cust := s.createLedgerBackedCustomer(ns, "test-subject")
@@ -760,8 +759,197 @@ func (s *CreditsTestSuite) TestCreditPurchasePersistsPriority() {
 	s.True(s.mustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&zeroCostBasis)).Equal(alpacadecimal.Zero))
 }
 
+func (s *CreditsTestSuite) TestUsageBasedCreditThenInvoicePaymentLifecycle() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-payment-lifecycle")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.createLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	promoCostBasis := alpacadecimal.Zero
+	invoiceCostBasis := alpacadecimal.NewFromInt(1)
+
+	var (
+		usageBasedChargeID meta.ChargeID
+		invoice            billing.StandardInvoice
+	)
+
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	s.Run("the customer receives a promotional credit grant", func() {
+		grantIntent := s.createCreditPurchaseIntent(createCreditPurchaseIntentInput{
+			customer:      cust.GetID(),
+			currency:      USD,
+			amount:        alpacadecimal.NewFromInt(5),
+			servicePeriod: timeutil.ClosedPeriod{From: createAt, To: createAt},
+			settlement:    creditpurchase.NewSettlement(creditpurchase.PromotionalSettlement{}),
+		})
+		grantRes, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				grantIntent,
+			},
+		})
+		s.NoError(err)
+		s.Len(grantRes, 1)
+	})
+
+	s.Run("a credit-then-invoice usage based charge is created with initial metered usage", func() {
+		s.MockStreamingConnector.AddSimpleEvent(
+			apiRequestsTotal.Feature.Key,
+			100,
+			datetime.MustParseTimeInLocation(s.T(), "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+		)
+
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.createMockChargeIntent(createMockChargeIntentInput{
+					customer:       cust.GetID(),
+					currency:       USD,
+					servicePeriod:  servicePeriod,
+					settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromFloat(0.1),
+					}),
+					name:              "usage-based-credit-then-invoice-payment-lifecycle",
+					managedBy:         billing.SubscriptionManagedLine,
+					uniqueReferenceID: "usage-based-credit-then-invoice-payment-lifecycle",
+					featureKey:        apiRequestsTotal.Feature.Key,
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		usageBasedChargeID, err = res[0].GetChargeID()
+		s.NoError(err)
+	})
+
+	s.Run("the pending invoice is created for the service period", func() {
+		clock.FreezeTime(servicePeriod.To.Add(time.Second))
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.To),
+		})
+		s.NoError(err)
+		s.Len(invoices, 1)
+		invoice = invoices[0]
+	})
+
+	s.Run("late arriving usage is ignored once the invoice finalization cutoff has passed", func() {
+		s.MockStreamingConnector.AddSimpleEvent(
+			apiRequestsTotal.Feature.Key,
+			25,
+			datetime.MustParseTimeInLocation(s.T(), "2026-01-20T00:00:00Z", time.UTC).AsTime(),
+			streamingtestutils.WithStoredAt(datetime.MustParseTimeInLocation(s.T(), "2026-02-02T12:00:00Z", time.UTC).AsTime()),
+		)
+	})
+
+	s.Run("the invoice is advanced and approved into payment pending", func() {
+		clock.FreezeTime(invoice.DefaultCollectionAtForStandardInvoice())
+
+		var err error
+		invoice, err = s.BillingService.AdvanceInvoice(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Len(invoice.Lines.OrEmpty(), 1)
+		stdLine := invoice.Lines.OrEmpty()[0]
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount:       12.5,
+			Total:        7.5,
+			CreditsTotal: 5,
+		}, stdLine.Totals)
+
+		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
+
+		usageBasedCharge := s.mustGetChargeByID(usageBasedChargeID)
+		updatedCharge, err := usageBasedCharge.AsUsageBasedCharge()
+		s.NoError(err)
+		s.Equal(usagebased.StatusActivePaymentPending, updatedCharge.Status)
+		s.Len(updatedCharge.Realizations, 1)
+		s.NotNil(updatedCharge.Realizations[0].InvoiceUsage)
+		s.Equal(float64(7.5), updatedCharge.Realizations[0].InvoiceUsage.Totals.Total.InexactFloat64())
+
+		// Aggregate open receivable still includes the promotional grant route.
+		// At this point:
+		// - promotional grant receivable (cost basis 0) is -5
+		// - invoice-backed receivable (cost basis 1) is -7.5
+		// so the aggregate open receivable is -12.5.
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-7.5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-12.5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.Zero))
+		s.True(s.mustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()).Equal(alpacadecimal.NewFromFloat(12.5)))
+		s.True(s.mustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()).Equal(alpacadecimal.Zero))
+	})
+
+	s.Run("the payment is authorized", func() {
+		var err error
+		invoice, err = s.BillingService.PaymentAuthorized(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingAuthorized, invoice.Status)
+
+		usageBasedCharge := s.mustGetChargeByID(usageBasedChargeID)
+		updatedCharge, err := usageBasedCharge.AsUsageBasedCharge()
+		s.NoError(err)
+		s.Equal(usagebased.StatusActiveAuthorized, updatedCharge.Status)
+		s.NotNil(updatedCharge.Realizations[0].Payment)
+		s.Equal(payment.StatusAuthorized, updatedCharge.Realizations[0].Payment.Status)
+		s.NotNil(updatedCharge.Realizations[0].Payment.Authorized)
+		s.Nil(updatedCharge.Realizations[0].Payment.Settled)
+
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-7.5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-12.5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.NewFromFloat(7.5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.NewFromFloat(7.5)))
+		s.True(s.mustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()).Equal(alpacadecimal.NewFromFloat(-7.5)))
+	})
+
+	s.Run("the payment is settled and the charge reaches final", func() {
+		var err error
+		invoice, err = s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{
+			InvoiceID: invoice.GetInvoiceID(),
+			Trigger:   billing.TriggerPaid,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
+
+		usageBasedCharge := s.mustGetChargeByID(usageBasedChargeID)
+		updatedCharge, err := usageBasedCharge.AsUsageBasedCharge()
+		s.NoError(err)
+		s.Equal(usagebased.StatusFinal, updatedCharge.Status)
+		s.NotNil(updatedCharge.Realizations[0].Payment)
+		s.Equal(payment.StatusSettled, updatedCharge.Realizations[0].Payment.Status)
+		s.NotNil(updatedCharge.Realizations[0].Payment.Settled)
+
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.Zero))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.Zero))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.Zero))
+		s.True(s.mustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()).Equal(alpacadecimal.NewFromFloat(-7.5)))
+	})
+}
+
 func (s *CreditsTestSuite) TestFlatFeeCreditOnlySanity() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-test-credit-only")
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
@@ -1258,11 +1446,11 @@ func (s *CreditsTestSuite) createMockChargeIntent(input createMockChargeIntentIn
 func (s *CreditsTestSuite) createLedgerBackedCustomer(ns string, subjectKey string) *customer.Customer {
 	s.T().Helper()
 
-	_, err := s.LedgerResolver.EnsureBusinessAccounts(context.Background(), ns)
+	_, err := s.LedgerResolver.EnsureBusinessAccounts(s.T().Context(), ns)
 	s.NoError(err)
 
 	cust := s.CreateTestCustomer(ns, subjectKey)
-	_, err = s.LedgerResolver.CreateCustomerAccounts(context.Background(), cust.GetID())
+	_, err = s.LedgerResolver.CreateCustomerAccounts(s.T().Context(), cust.GetID())
 	s.NoError(err)
 
 	return cust

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -851,7 +851,7 @@ func (s *CreditsTestSuite) TestUsageBasedCreditThenInvoicePaymentLifecycle() {
 		invoice = invoices[0]
 	})
 
-	s.Run("late arriving usage is ignored once the invoice finalization cutoff has passed", func() {
+	s.Run("late arriving usage is included while its stored_at remains before the invoice finalization cutoff", func() {
 		s.MockStreamingConnector.AddSimpleEvent(
 			apiRequestsTotal.Feature.Key,
 			25,


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Usage-based credit_then_invoice charges now model payment as part of the active lifecycle instead of hiding it inside final. The state machine  was updated so finalized usage moves into active.payment_pending on invoice issuance, then into active.authorized on payment authorization, and  only reaches final once payment is settled. This makes the charge status reflect the real economic lifecycle and keeps the final meta-state  reserved for fully settled charges.

**Note**: Current states are temporary until we have progressive billing in place.

  To support that flow, usage-based payment handling was added at the run level. The branch introduces run payment persistence for usage-based  realization runs, expands the usage-based handler contract to cover invoice payment authorization and settlement, and reuses the flat-fee ledger  handling pattern for authorized and settled events. The billing invoice/line flow now drives those usage-based payment transitions so late-
  arriving payment events can update already-finalized usage runs correctly.

  The generic charge state machine persistence behavior was also tightened up. FireAndActivate(...) now persists successful transitions directly, and AdvanceUntilStateStable(...) no longer performs an extra write afterward. 


## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invoice-backed charges now remain in active states during payment authorization and settlement and only reach final once payment is fully settled.
  * Introduced explicit payment-authorized and payment-settled handling so invoiced usage and ledger bookings occur at the correct lifecycle points.

* **Tests**
  * Expanded unit and end-to-end tests covering authorization, settlement, direct-paid flows, and related state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->