### PR TITLE
fix(api): parsing of custom string types

### DIFF
--- a/api/v3/filters/parse.go
+++ b/api/v3/filters/parse.go
@@ -166,7 +166,14 @@ func parseFiltersValue(qs url.Values, v reflect.Value) error {
 			}
 
 		default:
-			return fmt.Errorf("filter[%s]: unsupported filter field type %s", name, fieldVal.Type())
+			// Handle *T where T is a named string-based type (e.g. *BillingCreditTransactionType).
+			if fieldVal.Kind() == reflect.Pointer && fieldVal.Type().Elem().Kind() == reflect.String {
+				if err := parseStringPtrTyped(qs, name, fieldVal); err != nil {
+					return err
+				}
+			} else {
+				return fmt.Errorf("filter[%s]: unsupported filter field type %s", name, fieldVal.Type())
+			}
 		}
 	}
 
@@ -186,6 +193,27 @@ func parseStringPtr(qs url.Values, name string, fieldVal reflect.Value) error {
 		}
 		if val != "" {
 			fieldVal.Set(reflect.ValueOf(&val))
+		}
+		break
+	}
+	return nil
+}
+
+// parseStringPtrTyped handles filter[field]=value for *T fields where T is a named string type.
+func parseStringPtrTyped(qs url.Values, name string, fieldVal reflect.Value) error {
+	prefix := "filter[" + name + "]"
+	for key, values := range qs {
+		if key != prefix {
+			continue
+		}
+		val, err := singleValue(key, values)
+		if err != nil {
+			return err
+		}
+		if val != "" {
+			ptr := reflect.New(fieldVal.Type().Elem())
+			ptr.Elem().SetString(val)
+			fieldVal.Set(ptr)
 		}
 		break
 	}

--- a/api/v3/filters/parse.go
+++ b/api/v3/filters/parse.go
@@ -161,6 +161,9 @@ func parseFiltersValue(qs url.Values, v reflect.Value) error {
 			fieldVal.Set(reflect.ValueOf(&parsed))
 
 		case stringPtrType:
+			if hasOperatorStyleKeys(qs, name) {
+				return fmt.Errorf("filter[%s]: operator-style keys are not supported for this field", name)
+			}
 			if err := parseStringPtr(qs, name, fieldVal); err != nil {
 				return err
 			}
@@ -168,6 +171,9 @@ func parseFiltersValue(qs url.Values, v reflect.Value) error {
 		default:
 			// Handle *T where T is a named string-based type (e.g. *BillingCreditTransactionType).
 			if fieldVal.Kind() == reflect.Pointer && fieldVal.Type().Elem().Kind() == reflect.String {
+				if hasOperatorStyleKeys(qs, name) {
+					return fmt.Errorf("filter[%s]: operator-style keys are not supported for this field", name)
+				}
 				if err := parseStringPtrTyped(qs, name, fieldVal); err != nil {
 					return err
 				}
@@ -524,6 +530,17 @@ func forEachFieldParam(qs url.Values, field string, visit func(parsedFilterParam
 func hasFilterKeys(qs url.Values) bool {
 	for key := range qs {
 		if strings.HasPrefix(key, "filter[") {
+			return true
+		}
+	}
+	return false
+}
+
+// hasOperatorStyleKeys reports whether qs contains any filter[field][op] keys for the given field.
+func hasOperatorStyleKeys(qs url.Values, name string) bool {
+	prefix := "filter[" + name + "]["
+	for key := range qs {
+		if strings.HasPrefix(key, prefix) {
 			return true
 		}
 	}

--- a/api/v3/filters/parse_test.go
+++ b/api/v3/filters/parse_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testStringType string
+
 // testFilter is a target exercising every filter type Parse recognizes.
 type testFilter struct {
 	Field     *FilterString      `json:"field,omitempty"`
@@ -24,6 +26,7 @@ type testFilter struct {
 	CreatedAt *FilterDateTime    `json:"created_at,omitempty"`
 	Enabled   *FilterBoolean     `json:"enabled,omitempty"`
 	Currency  *string            `json:"currency,omitempty"`
+	TxType    *testStringType    `json:"tx_type,omitempty"`
 }
 
 func TestParse_FilterString(t *testing.T) {
@@ -298,6 +301,21 @@ func TestParse_StringPtr(t *testing.T) {
 		var f testFilter
 		require.NoError(t, Parse(url.Values{"filter[currency]": {"USD"}}, &f))
 		assert.Equal(t, lo.ToPtr("USD"), f.Currency)
+	})
+}
+
+func TestParse_NamedStringType(t *testing.T) {
+	t.Run("named string type filter value", func(t *testing.T) {
+		var f testFilter
+		require.NoError(t, Parse(url.Values{"filter[tx_type]": {"funded"}}, &f))
+		require.NotNil(t, f.TxType)
+		assert.Equal(t, testStringType("funded"), *f.TxType)
+	})
+
+	t.Run("nil when no filter key present", func(t *testing.T) {
+		var f testFilter
+		require.NoError(t, Parse(url.Values{}, &f))
+		assert.Nil(t, f.TxType)
 	})
 }
 

--- a/api/v3/filters/parse_test.go
+++ b/api/v3/filters/parse_test.go
@@ -317,6 +317,22 @@ func TestParse_NamedStringType(t *testing.T) {
 		require.NoError(t, Parse(url.Values{}, &f))
 		assert.Nil(t, f.TxType)
 	})
+
+	t.Run("operator-style key rejected", func(t *testing.T) {
+		var f testFilter
+		err := Parse(url.Values{"filter[tx_type][eq]": {"funded"}}, &f)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "operator-style keys are not supported")
+	})
+}
+
+func TestParse_StringPtrOperatorRejected(t *testing.T) {
+	t.Run("operator-style key rejected for *string field", func(t *testing.T) {
+		var f testFilter
+		err := Parse(url.Values{"filter[currency][eq]": {"USD"}}, &f)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "operator-style keys are not supported")
+	})
 }
 
 func TestParse_PointerToPointer(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Adds support for parsing filter strings into custom string types

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter parsing now accepts pointer-to-named-string fields as valid filter targets; empty values leave those pointers unset. Operator-style filter keys for these fields are rejected.

* **Tests**
  * Added tests verifying named-string pointer parsing, nil-on-absent behavior, and rejection of operator-style keys for both named-string pointers and existing string-pointer fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->