### PR TITLE
chore: get rid of billing.Period

### DIFF
--- a/openmeter/app/stripe/appinvoice.go
+++ b/openmeter/app/stripe/appinvoice.go
@@ -574,8 +574,8 @@ func getStripeAddInvoiceItemParams(line billing.DetailedLine, calculator StripeC
 // getPeriod returns the period
 func getPeriod(line billing.DetailedLine) *stripe.InvoiceItemPeriodParams {
 	return &stripe.InvoiceItemPeriodParams{
-		Start: lo.ToPtr(line.ServicePeriod.Start.Unix()),
-		End:   lo.ToPtr(line.ServicePeriod.End.Unix()),
+		Start: lo.ToPtr(line.ServicePeriod.From.Unix()),
+		End:   lo.ToPtr(line.ServicePeriod.To.Unix()),
 	}
 }
 

--- a/openmeter/billing/adapter/invoice.go
+++ b/openmeter/billing/adapter/invoice.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/sortx"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 var _ billing.InvoiceAdapter = (*adapter)(nil)
@@ -487,8 +488,8 @@ func (a *adapter) UpdateStandardInvoice(ctx context.Context, in billing.UpdateSt
 
 		if in.Period != nil {
 			updateQuery = updateQuery.
-				SetPeriodStart(in.Period.Start.In(time.UTC)).
-				SetPeriodEnd(in.Period.End.In(time.UTC))
+				SetPeriodStart(in.Period.From.In(time.UTC)).
+				SetPeriodEnd(in.Period.To.In(time.UTC))
 		} else {
 			updateQuery = updateQuery.
 				ClearPeriodStart().
@@ -782,13 +783,13 @@ func (a *adapter) mapStandardInvoiceFromDB(ctx context.Context, invoice *db.Bill
 	return res, nil
 }
 
-func mapPeriodFromDB(start, end *time.Time) *billing.Period {
+func mapPeriodFromDB(start, end *time.Time) *timeutil.ClosedPeriod {
 	if start == nil || end == nil {
 		return nil
 	}
-	return &billing.Period{
-		Start: start.In(time.UTC),
-		End:   end.In(time.UTC),
+	return &timeutil.ClosedPeriod{
+		From: start.In(time.UTC),
+		To:   end.In(time.UTC),
 	}
 }
 

--- a/openmeter/billing/adapter/invoicelinesplitgroup.go
+++ b/openmeter/billing/adapter/invoicelinesplitgroup.go
@@ -35,8 +35,8 @@ func (a *adapter) CreateSplitLineGroup(ctx context.Context, input billing.Create
 			SetName(input.Name).
 			SetNillableDescription(input.Description).
 			SetMetadata(input.Metadata).
-			SetServicePeriodStart(input.ServicePeriod.Start.UTC()).
-			SetServicePeriodEnd(input.ServicePeriod.End.UTC()).
+			SetServicePeriodStart(input.ServicePeriod.From.UTC()).
+			SetServicePeriodEnd(input.ServicePeriod.To.UTC()).
 			SetCurrency(input.Currency).
 			SetRatecardDiscounts(&input.RatecardDiscounts).
 			SetPrice(input.Price).
@@ -78,8 +78,8 @@ func (a *adapter) UpdateSplitLineGroup(ctx context.Context, input billing.Update
 			SetName(input.Name).
 			SetOrClearDescription(input.Description).
 			SetMetadata(input.Metadata).
-			SetServicePeriodStart(input.ServicePeriod.Start.UTC()).
-			SetServicePeriodEnd(input.ServicePeriod.End.UTC()).
+			SetServicePeriodStart(input.ServicePeriod.From.UTC()).
+			SetServicePeriodEnd(input.ServicePeriod.To.UTC()).
 			SetRatecardDiscounts(&input.RatecardDiscounts).
 			SetOrClearTaxConfig(input.TaxConfig).
 			Where(
@@ -214,9 +214,9 @@ func (a *adapter) mapSplitLineGroupFromDB(dbSplitLineGroup *db.BillingInvoiceSpl
 			Description: dbSplitLineGroup.Description,
 			Metadata:    dbSplitLineGroup.Metadata,
 
-			ServicePeriod: billing.Period{
-				Start: dbSplitLineGroup.ServicePeriodStart.UTC(),
-				End:   dbSplitLineGroup.ServicePeriodEnd.UTC(),
+			ServicePeriod: timeutil.ClosedPeriod{
+				From: dbSplitLineGroup.ServicePeriodStart.UTC(),
+				To:   dbSplitLineGroup.ServicePeriodEnd.UTC(),
 			},
 
 			RatecardDiscounts: lo.FromPtr(dbSplitLineGroup.RatecardDiscounts),

--- a/openmeter/billing/adapter/stdinvoicelinemapper.go
+++ b/openmeter/billing/adapter/stdinvoicelinemapper.go
@@ -80,9 +80,9 @@ func (a *adapter) mapStandardInvoiceLineWithoutReferences(dbLine *db.BillingInvo
 			ManagedBy:   dbLine.ManagedBy,
 			Engine:      dbLine.Engine,
 
-			Period: billing.Period{
-				Start: dbLine.PeriodStart.In(time.UTC),
-				End:   dbLine.PeriodEnd.In(time.UTC),
+			Period: timeutil.ClosedPeriod{
+				From: dbLine.PeriodStart.In(time.UTC),
+				To:   dbLine.PeriodEnd.In(time.UTC),
 			},
 
 			ParentLineID:           dbLine.ParentLineID,
@@ -177,9 +177,9 @@ func (a *adapter) mapStandardInvoiceDetailedLineFromDB(dbLine *db.BillingInvoice
 		ChildUniqueReferenceID: dbLine.ChildUniqueReferenceID,
 		FeeLineConfigID:        dbLine.Edges.FlatFeeLine.ID,
 
-		ServicePeriod: billing.Period{
-			Start: dbLine.PeriodStart.In(time.UTC),
-			End:   dbLine.PeriodEnd.In(time.UTC),
+		ServicePeriod: timeutil.ClosedPeriod{
+			From: dbLine.PeriodStart.In(time.UTC),
+			To:   dbLine.PeriodEnd.In(time.UTC),
 		},
 		PerUnitAmount: dbLine.Edges.FlatFeeLine.PerUnitAmount,
 		Quantity:      lo.FromPtr(dbLine.Quantity),
@@ -232,9 +232,9 @@ func (a *adapter) mapStandardInvoiceDetailedLineV2FromDB(dbLine *db.BillingStand
 		InvoiceID:              dbLine.InvoiceID,
 		ChildUniqueReferenceID: dbLine.ChildUniqueReferenceID,
 
-		ServicePeriod: billing.Period{
-			Start: dbLine.ServicePeriodStart.In(time.UTC),
-			End:   dbLine.ServicePeriodEnd.In(time.UTC),
+		ServicePeriod: timeutil.ClosedPeriod{
+			From: dbLine.ServicePeriodStart.In(time.UTC),
+			To:   dbLine.ServicePeriodEnd.In(time.UTC),
 		},
 		PerUnitAmount: dbLine.PerUnitAmount,
 		Quantity:      dbLine.Quantity,

--- a/openmeter/billing/adapter/stdinvoicelines.go
+++ b/openmeter/billing/adapter/stdinvoicelines.go
@@ -85,8 +85,8 @@ func (a *adapter) UpsertInvoiceLines(ctx context.Context, inputIn billing.Upsert
 					SetID(line.ID).
 					SetNamespace(line.Namespace).
 					SetInvoiceID(line.InvoiceID).
-					SetPeriodStart(line.Period.Start.In(time.UTC)).
-					SetPeriodEnd(line.Period.End.In(time.UTC)).
+					SetPeriodStart(line.Period.From.In(time.UTC)).
+					SetPeriodEnd(line.Period.To.In(time.UTC)).
 					SetNillableParentLineID(line.ParentLineID).
 					SetNillableSplitLineGroupID(line.SplitLineGroupID).
 					SetNillableChargeID(line.ChargeID).
@@ -305,8 +305,8 @@ func (a *adapter) upsertDetailedLines(ctx context.Context, in detailedLineDiff) 
 				SetID(line.ID).
 				SetNamespace(line.Namespace).
 				SetInvoiceID(line.InvoiceID).
-				SetPeriodStart(line.ServicePeriod.Start.In(time.UTC)).
-				SetPeriodEnd(line.ServicePeriod.End.In(time.UTC)).
+				SetPeriodStart(line.ServicePeriod.From.In(time.UTC)).
+				SetPeriodEnd(line.ServicePeriod.To.In(time.UTC)).
 				SetParentLineID(lineWithParent.Parent.ID).
 				SetInvoiceAt(lineWithParent.Parent.InvoiceAt.In(time.UTC)).
 				SetNillableDeletedAt(line.DeletedAt).
@@ -422,8 +422,8 @@ func (a *adapter) upsertDetailedLinesV2(ctx context.Context, in detailedLineDiff
 				SetID(line.ID).
 				SetNamespace(line.Namespace).
 				SetInvoiceID(line.InvoiceID).
-				SetServicePeriodStart(line.ServicePeriod.Start.In(time.UTC)).
-				SetServicePeriodEnd(line.ServicePeriod.End.In(time.UTC)).
+				SetServicePeriodStart(line.ServicePeriod.From.In(time.UTC)).
+				SetServicePeriodEnd(line.ServicePeriod.To.In(time.UTC)).
 				SetParentLineID(lineWithParent.Parent.ID).
 				SetNillableDeletedAt(line.DeletedAt).
 				SetName(line.Name).

--- a/openmeter/billing/charges/flatfee/service/invoice.go
+++ b/openmeter/billing/charges/flatfee/service/invoice.go
@@ -26,7 +26,7 @@ func (s *service) PostLineAssignedToInvoice(ctx context.Context, charge flatfee.
 
 		input := flatfee.OnAssignedToInvoiceInput{
 			Charge:            charge,
-			ServicePeriod:     line.Period.ToClosedPeriod(),
+			ServicePeriod:     line.Period,
 			PreTaxTotalAmount: currencyCalculator.RoundToPrecision(charge.State.AmountAfterProration),
 		}
 		if err := input.Validate(); err != nil {
@@ -69,7 +69,7 @@ func (s *service) PostInvoiceIssued(ctx context.Context, charge flatfee.Charge, 
 
 		ledgerTransactionRef, err := s.handler.OnInvoiceUsageAccrued(ctx, flatfee.OnInvoiceUsageAccruedInput{
 			Charge:        charge,
-			ServicePeriod: lineWithHeader.Line.Period.ToClosedPeriod(),
+			ServicePeriod: lineWithHeader.Line.Period,
 			Totals:        lineWithHeader.Line.Totals,
 		})
 		if err != nil {
@@ -78,7 +78,7 @@ func (s *service) PostInvoiceIssued(ctx context.Context, charge flatfee.Charge, 
 
 		accruedUsage := invoicedusage.AccruedUsage{
 			LineID:            lo.ToPtr(lineWithHeader.Line.ID),
-			ServicePeriod:     lineWithHeader.Line.Period.ToClosedPeriod(),
+			ServicePeriod:     lineWithHeader.Line.Period,
 			Mutable:           false,
 			Totals:            lineWithHeader.Line.Totals,
 			LedgerTransaction: &ledgerTransactionRef,

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -584,9 +584,9 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchase() {
 
 		line := lines[0]
 		s.Equal(USD, line.Currency)
-		s.Equal(billing.Period{
-			Start: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
-			End:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+		s.Equal(timeutil.ClosedPeriod{
+			From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+			To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
 		}, line.Period)
 		s.Equal(alpacadecimal.NewFromFloat(50), line.Totals.Amount)
 		s.Equal(alpacadecimal.NewFromFloat(50), line.Totals.Total)

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -1178,7 +1178,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() 
 		invoiceUsageAccruedCallback := newCountedLedgerTransactionCallback[usagebased.OnInvoiceUsageAccruedInput]()
 		s.UsageBasedTestHandler.onInvoiceUsageAccrued = invoiceUsageAccruedCallback.Handler(s.T(), func(t *testing.T, input usagebased.OnInvoiceUsageAccruedInput) {
 			s.Equal(usageBasedChargeID.ID, input.Charge.ID)
-			s.Equal(expectedLine.Period.ToClosedPeriod(), input.ServicePeriod)
+			s.Equal(expectedLine.Period, input.ServicePeriod)
 			s.Equal(float64(4.5), input.Amount.InexactFloat64())
 			s.Equal(float64(125), input.Run.MeterValue.InexactFloat64())
 			s.NotNil(input.Run.LineID)
@@ -1203,7 +1203,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() 
 		s.NotNil(finalRun.InvoiceUsage)
 		s.NotNil(finalRun.InvoiceUsage.LineID)
 		s.Equal(stdLineID.ID, *finalRun.InvoiceUsage.LineID)
-		s.Equal(invoice.Lines.OrEmpty()[0].Period.ToClosedPeriod(), finalRun.InvoiceUsage.ServicePeriod)
+		s.Equal(invoice.Lines.OrEmpty()[0].Period, finalRun.InvoiceUsage.ServicePeriod)
 		s.RequireTotals(billingtest.ExpectedTotals{
 			Amount:       12.5,
 			Total:        4.5,

--- a/openmeter/billing/charges/usagebased/service/run/invoice.go
+++ b/openmeter/billing/charges/usagebased/service/run/invoice.go
@@ -62,7 +62,7 @@ func (s *Service) BookAccruedInvoiceUsage(ctx context.Context, in BookAccruedInv
 	input := usagebased.OnInvoiceUsageAccruedInput{
 		Charge:        in.Charge,
 		Run:           in.Run,
-		ServicePeriod: in.Line.Period.ToClosedPeriod(),
+		ServicePeriod: in.Line.Period,
 		Amount:        in.Line.Totals.Total,
 	}
 
@@ -81,7 +81,7 @@ func (s *Service) BookAccruedInvoiceUsage(ctx context.Context, in BookAccruedInv
 
 	accruedUsage, err := s.adapter.CreateRunInvoicedUsage(ctx, in.Run.ID, invoicedusage.AccruedUsage{
 		LineID:            in.Run.LineID,
-		ServicePeriod:     in.Line.Period.ToClosedPeriod(),
+		ServicePeriod:     in.Line.Period,
 		Mutable:           false,
 		Totals:            in.Line.Totals,
 		LedgerTransaction: &ledgerTransactionRef,

--- a/openmeter/billing/charges/usagebased/service/run/payment.go
+++ b/openmeter/billing/charges/usagebased/service/run/payment.go
@@ -78,7 +78,7 @@ func (s *Service) BookInvoicedPaymentAuthorized(ctx context.Context, in BookInvo
 		LineID:    in.Line.ID,
 		InvoiceID: in.Invoice.ID,
 		Base: payment.Base{
-			ServicePeriod: in.Line.Period.ToClosedPeriod(),
+			ServicePeriod: in.Line.Period,
 			Amount:        in.Line.Totals.Total,
 			Authorized: &ledgertransaction.TimedGroupReference{
 				GroupReference: ledgertransaction.GroupReference{

--- a/openmeter/billing/charges/usagebased/service/run/payment_test.go
+++ b/openmeter/billing/charges/usagebased/service/run/payment_test.go
@@ -32,7 +32,7 @@ func TestBookInvoicedPaymentAuthorizedInputValidate(t *testing.T) {
 				NamespacedID: models.NamespacedID{Namespace: in.Charge.Namespace, ID: "payment-1"},
 				ManagedModel: models.ManagedModel{CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()},
 				Base: payment.Base{
-					ServicePeriod: in.Line.Period.ToClosedPeriod(),
+					ServicePeriod: in.Line.Period,
 					Status:        payment.StatusAuthorized,
 					Amount:        in.Line.Totals.Total,
 					Authorized: &ledgertransaction.TimedGroupReference{
@@ -110,9 +110,9 @@ func newBookPaymentAuthorizedInput() BookInvoicedPaymentAuthorizedInput {
 				Currency:  currencyx.Code("USD"),
 				InvoiceID: "invoice-1",
 				InvoiceAt: now,
-				Period: billing.Period{
-					Start: now.Add(-time.Hour),
-					End:   now,
+				Period: timeutil.ClosedPeriod{
+					From: now.Add(-time.Hour),
+					To:   now,
 				},
 				Totals: totals.Totals{
 					Amount: alpacadecimal.NewFromInt(10),
@@ -133,7 +133,7 @@ func newSettlePaymentInput() SettleInvoicedPaymentInput {
 	authInput := newBookPaymentAuthorizedInput()
 	authInput.Run.InvoiceUsage = &invoicedusage.AccruedUsage{
 		LineID:        &authInput.Line.ID,
-		ServicePeriod: authInput.Line.Period.ToClosedPeriod(),
+		ServicePeriod: authInput.Line.Period,
 		Mutable:       false,
 		Totals:        authInput.Line.Totals,
 	}
@@ -142,7 +142,7 @@ func newSettlePaymentInput() SettleInvoicedPaymentInput {
 			NamespacedID: models.NamespacedID{Namespace: authInput.Charge.Namespace, ID: "payment-1"},
 			ManagedModel: models.ManagedModel{CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()},
 			Base: payment.Base{
-				ServicePeriod: authInput.Line.Period.ToClosedPeriod(),
+				ServicePeriod: authInput.Line.Period,
 				Status:        payment.StatusAuthorized,
 				Amount:        authInput.Line.Totals.Total,
 				Authorized: &ledgertransaction.TimedGroupReference{

--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -708,10 +708,7 @@ func (g GatheringLine) AsNewStandardLine(invoiceID string) (*StandardLine, error
 			InvoiceID:       invoiceID,
 			Currency:        g.Currency,
 
-			Period: Period{
-				Start: g.ServicePeriod.From,
-				End:   g.ServicePeriod.To,
-			},
+			Period:    g.ServicePeriod,
 			InvoiceAt: g.InvoiceAt,
 
 			TaxConfig:              taxConfig,
@@ -870,8 +867,8 @@ func NewFlatFeeGatheringLine(input NewFlatFeeLineInput, opts ...usageBasedLineOp
 				Description: input.Description,
 			}),
 			ServicePeriod: timeutil.ClosedPeriod{
-				From: input.Period.Start,
-				To:   input.Period.End,
+				From: input.Period.From,
+				To:   input.Period.To,
 			},
 			InvoiceAt: input.InvoiceAt,
 			InvoiceID: input.InvoiceID,

--- a/openmeter/billing/httpdriver/invoice.go
+++ b/openmeter/billing/httpdriver/invoice.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 	"github.com/openmeterio/openmeter/pkg/sortx"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 var _ InvoiceHandler = (*handler)(nil)
@@ -710,15 +711,15 @@ func MapEventInvoiceToAPI(event billing.EventStandardInvoice) (api.Invoice, erro
 	return invoice, nil
 }
 
-func mapPeriodToAPI(p *billing.Period) *api.Period {
+func mapPeriodToAPI(p *timeutil.ClosedPeriod) *api.Period {
 	if p == nil {
 		return nil
 	}
 
 	// TODO[later]: let's use a common model for this
 	return &api.Period{
-		From: p.Start,
-		To:   p.End,
+		From: p.From,
+		To:   p.To,
 	}
 }
 

--- a/openmeter/billing/httpdriver/invoice_test.go
+++ b/openmeter/billing/httpdriver/invoice_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 	billingtest "github.com/openmeterio/openmeter/test/billing"
 )
 
@@ -59,7 +60,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoiceSerialization() {
 			billing.NewFlatFeeGatheringLine(
 				billing.NewFlatFeeLineInput{
 					Namespace:     namespace,
-					Period:        billing.Period{Start: now, End: now.Add(time.Hour * 24)},
+					Period:        timeutil.ClosedPeriod{From: now, To: now.Add(time.Hour * 24)},
 					InvoiceAt:     now.Add(time.Hour * 24),
 					ManagedBy:     billing.ManuallyManagedLine,
 					Name:          "Test item - USD",

--- a/openmeter/billing/httpdriver/invoiceline.go
+++ b/openmeter/billing/httpdriver/invoiceline.go
@@ -153,9 +153,9 @@ func mapCreateLineToEntity(line api.InvoicePendingLineCreate, ns string) (*billi
 			ManagedBy: billing.ManuallyManagedLine,
 			Engine:    billing.LineEngineTypeInvoice,
 
-			Period: billing.Period{
-				Start: line.Period.From,
-				End:   line.Period.To,
+			Period: timeutil.ClosedPeriod{
+				From: line.Period.From,
+				To:   line.Period.To,
 			},
 
 			InvoiceAt:         line.InvoiceAt,
@@ -271,8 +271,8 @@ func mapDetailedLineToAPI(line billing.DetailedLine, invoiceAt time.Time) (api.I
 		},
 
 		Period: api.Period{
-			From: line.ServicePeriod.Start,
-			To:   line.ServicePeriod.End,
+			From: line.ServicePeriod.From,
+			To:   line.ServicePeriod.To,
 		},
 
 		PerUnitAmount: lo.ToPtr(line.PerUnitAmount.String()),
@@ -356,8 +356,8 @@ func mapInvoiceLineToAPI(line *billing.StandardLine) (api.InvoiceLine, error) {
 
 		Metadata: convert.MapToPointer(line.Metadata),
 		Period: api.Period{
-			From: line.Period.Start,
-			To:   line.Period.End,
+			From: line.Period.From,
+			To:   line.Period.To,
 		},
 
 		TaxConfig: mapTaxConfigToAPI(line.TaxConfig),
@@ -610,9 +610,9 @@ func mapSimulationLineToEntity(line api.InvoiceSimulationLine) (*billing.Standar
 			Metadata:  lo.FromPtrOr(line.Metadata, map[string]string{}),
 			ManagedBy: billing.ManuallyManagedLine,
 
-			Period: billing.Period{
-				Start: line.Period.From.Truncate(streaming.MinimumWindowSizeDuration),
-				End:   line.Period.To.Truncate(streaming.MinimumWindowSizeDuration),
+			Period: timeutil.ClosedPeriod{
+				From: line.Period.From.Truncate(streaming.MinimumWindowSizeDuration),
+				To:   line.Period.To.Truncate(streaming.MinimumWindowSizeDuration),
 			},
 
 			InvoiceAt:         line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration),
@@ -655,9 +655,9 @@ func standardLineFromInvoiceLineReplaceUpdate(line api.InvoiceLineReplaceUpdate,
 			InvoiceID: invoice.ID,
 			Currency:  invoice.Currency,
 
-			Period: billing.Period{
-				Start: line.Period.From.Truncate(streaming.MinimumWindowSizeDuration),
-				End:   line.Period.To.Truncate(streaming.MinimumWindowSizeDuration),
+			Period: timeutil.ClosedPeriod{
+				From: line.Period.From.Truncate(streaming.MinimumWindowSizeDuration),
+				To:   line.Period.To.Truncate(streaming.MinimumWindowSizeDuration),
 			},
 			InvoiceAt: line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration),
 
@@ -738,8 +738,8 @@ func mergeStandardLineFromInvoiceLineReplaceUpdate(existing *billing.StandardLin
 	existing.Name = line.Name
 	existing.Description = line.Description
 
-	existing.Period.Start = line.Period.From.Truncate(streaming.MinimumWindowSizeDuration)
-	existing.Period.End = line.Period.To.Truncate(streaming.MinimumWindowSizeDuration)
+	existing.Period.From = line.Period.From.Truncate(streaming.MinimumWindowSizeDuration)
+	existing.Period.To = line.Period.To.Truncate(streaming.MinimumWindowSizeDuration)
 	existing.InvoiceAt = line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration)
 
 	existing.TaxConfig = rateCardParsed.TaxConfig

--- a/openmeter/billing/invoicedetailedline.go
+++ b/openmeter/billing/invoicedetailedline.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 // TODO: Rename to DetailedLineCostCategory (separate PR)
@@ -51,7 +52,7 @@ type DetailedLineBase struct {
 	ChildUniqueReferenceID *string                        `json:"childUniqueReferenceID,omitempty"`
 	Index                  *int                           `json:"index,omitempty"`
 	PaymentTerm            productcatalog.PaymentTermType `json:"paymentTerm"`
-	ServicePeriod          Period                         `json:"servicePeriod"`
+	ServicePeriod          timeutil.ClosedPeriod          `json:"servicePeriod"`
 
 	// Line amount
 	Currency      currencyx.Code        `json:"currency"`

--- a/openmeter/billing/invoiceline.go
+++ b/openmeter/billing/invoiceline.go
@@ -38,60 +38,6 @@ func (InvoiceLineManagedBy) Values() []string {
 	}
 }
 
-// Period represents a time period, in billing the time period is always interpreted as
-// [from, to) (i.e. from is inclusive, to is exclusive).
-// TODO: Lets merge this with recurrence.Period
-type Period struct {
-	Start time.Time `json:"start"`
-	End   time.Time `json:"end"`
-}
-
-func (p Period) Validate() error {
-	if p.Start.IsZero() {
-		return errors.New("start is required")
-	}
-
-	if p.End.IsZero() {
-		return errors.New("end is required")
-	}
-
-	if p.Start.After(p.End) {
-		return errors.New("start must be before end")
-	}
-
-	return nil
-}
-
-func (p Period) Truncate(resolution time.Duration) Period {
-	return Period{
-		Start: p.Start.Truncate(resolution),
-		End:   p.End.Truncate(resolution),
-	}
-}
-
-func (p Period) Equal(other Period) bool {
-	return p.Start.Equal(other.Start) && p.End.Equal(other.End)
-}
-
-func (p Period) IsEmpty() bool {
-	return !p.End.After(p.Start)
-}
-
-func (p Period) Contains(t time.Time) bool {
-	return t.After(p.Start) && t.Before(p.End)
-}
-
-func (p Period) Duration() time.Duration {
-	return p.End.Sub(p.Start)
-}
-
-func (p Period) ToClosedPeriod() timeutil.ClosedPeriod {
-	return timeutil.ClosedPeriod{
-		From: p.Start,
-		To:   p.End,
-	}
-}
-
 type GetLinesForSubscriptionInput struct {
 	Namespace      string
 	SubscriptionID string

--- a/openmeter/billing/invoicelinesplitgroup.go
+++ b/openmeter/billing/invoicelinesplitgroup.go
@@ -21,7 +21,7 @@ type SplitLineGroupMutableFields struct {
 	Description *string         `json:"description,omitempty"`
 	Metadata    models.Metadata `json:"metadata,omitempty"`
 
-	ServicePeriod Period `json:"period"`
+	ServicePeriod timeutil.ClosedPeriod `json:"period"`
 
 	RatecardDiscounts Discounts                 `json:"ratecardDiscounts"`
 	TaxConfig         *productcatalog.TaxConfig `json:"taxConfig,omitempty"`
@@ -522,7 +522,7 @@ func (i LineOrHierarchy) ServicePeriod() timeutil.ClosedPeriod {
 	case LineOrHierarchyTypeLine:
 		return i.line.GetServicePeriod()
 	case LineOrHierarchyTypeHierarchy:
-		return i.splitLineHierarchy.Group.ServicePeriod.ToClosedPeriod()
+		return i.splitLineHierarchy.Group.ServicePeriod
 	}
 
 	return timeutil.ClosedPeriod{}

--- a/openmeter/billing/lineengine/splitlinegroup.go
+++ b/openmeter/billing/lineengine/splitlinegroup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type SplitLineGroupAdapter interface {
@@ -37,9 +38,9 @@ func (e *Engine) SplitGatheringLine(ctx context.Context, in billing.SplitGatheri
 			SplitLineGroupMutableFields: billing.SplitLineGroupMutableFields{
 				Name:        line.Name,
 				Description: line.Description,
-				ServicePeriod: billing.Period{
-					Start: line.ServicePeriod.From,
-					End:   line.ServicePeriod.To,
+				ServicePeriod: timeutil.ClosedPeriod{
+					From: line.ServicePeriod.From,
+					To:   line.ServicePeriod.To,
 				},
 				RatecardDiscounts: line.RateCardDiscounts,
 				TaxConfig:         line.TaxConfig,

--- a/openmeter/billing/rating/service/mutator/credits_test.go
+++ b/openmeter/billing/rating/service/mutator/credits_test.go
@@ -354,7 +354,7 @@ func TestCreditsMutator(t *testing.T) {
 					ChildUniqueReferenceID: rating.MinSpendChildUniqueReferenceID,
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
 					Category:               billing.FlatFeeCategoryCommitment,
-					Period:                 lo.ToPtr(testutil.TestFullPeriod.ToClosedPeriod()),
+					Period:                 lo.ToPtr(testutil.TestFullPeriod),
 					CreditsApplied: []billing.CreditApplied{
 						{
 							Amount:      alpacadecimal.NewFromFloat(25),

--- a/openmeter/billing/rating/service/rate/dynamic_test.go
+++ b/openmeter/billing/rating/service/rate/dynamic_test.go
@@ -48,7 +48,7 @@ func TestDynamicPriceCalculation(t *testing.T) {
 					PerUnitAmount:          alpacadecimal.NewFromFloat(100),
 					Quantity:               alpacadecimal.NewFromFloat(1),
 					ChildUniqueReferenceID: rating.MinSpendChildUniqueReferenceID,
-					Period:                 lo.ToPtr(testutil.TestFullPeriod.ToClosedPeriod()),
+					Period:                 lo.ToPtr(testutil.TestFullPeriod),
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
 					Category:               billing.FlatFeeCategoryCommitment,
 					Totals: totals.Totals{
@@ -96,7 +96,7 @@ func TestDynamicPriceCalculation(t *testing.T) {
 					PerUnitAmount:          alpacadecimal.NewFromFloat(100),
 					Quantity:               alpacadecimal.NewFromFloat(1),
 					ChildUniqueReferenceID: rating.MinSpendChildUniqueReferenceID,
-					Period:                 lo.ToPtr(testutil.TestFullPeriod.ToClosedPeriod()),
+					Period:                 lo.ToPtr(testutil.TestFullPeriod),
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
 					Category:               billing.FlatFeeCategoryCommitment,
 					Totals: totals.Totals{

--- a/openmeter/billing/rating/service/rate/package_test.go
+++ b/openmeter/billing/rating/service/rate/package_test.go
@@ -50,7 +50,7 @@ func TestPackagePriceCalculation(t *testing.T) {
 					PerUnitAmount:          alpacadecimal.NewFromFloat(100),
 					Quantity:               alpacadecimal.NewFromFloat(1),
 					ChildUniqueReferenceID: rating.MinSpendChildUniqueReferenceID,
-					Period:                 lo.ToPtr(testutil.TestFullPeriod.ToClosedPeriod()),
+					Period:                 lo.ToPtr(testutil.TestFullPeriod),
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
 					Category:               billing.FlatFeeCategoryCommitment,
 					Totals: totals.Totals{
@@ -100,7 +100,7 @@ func TestPackagePriceCalculation(t *testing.T) {
 					PerUnitAmount:          alpacadecimal.NewFromFloat(100),
 					Quantity:               alpacadecimal.NewFromFloat(1),
 					ChildUniqueReferenceID: rating.MinSpendChildUniqueReferenceID,
-					Period:                 lo.ToPtr(testutil.TestFullPeriod.ToClosedPeriod()),
+					Period:                 lo.ToPtr(testutil.TestFullPeriod),
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
 					Category:               billing.FlatFeeCategoryCommitment,
 					Totals: totals.Totals{

--- a/openmeter/billing/rating/service/rate/tieredgraduated_test.go
+++ b/openmeter/billing/rating/service/rate/tieredgraduated_test.go
@@ -222,7 +222,7 @@ func TestTieredGraduatedCalculation(t *testing.T) {
 					// that from the charge.
 					PerUnitAmount:          alpacadecimal.NewFromFloat(900),
 					Quantity:               alpacadecimal.NewFromFloat(1),
-					Period:                 lo.ToPtr(testutil.TestFullPeriod.ToClosedPeriod()),
+					Period:                 lo.ToPtr(testutil.TestFullPeriod),
 					ChildUniqueReferenceID: rating.MinSpendChildUniqueReferenceID,
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
 					Category:               billing.FlatFeeCategoryCommitment,
@@ -255,7 +255,7 @@ func TestTieredGraduatedCalculation(t *testing.T) {
 					Name:                   "feature: minimum spend",
 					PerUnitAmount:          alpacadecimal.NewFromFloat(900),
 					Quantity:               alpacadecimal.NewFromFloat(1),
-					Period:                 lo.ToPtr(testutil.TestFullPeriod.ToClosedPeriod()),
+					Period:                 lo.ToPtr(testutil.TestFullPeriod),
 					ChildUniqueReferenceID: rating.MinSpendChildUniqueReferenceID,
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
 					Category:               billing.FlatFeeCategoryCommitment,

--- a/openmeter/billing/rating/service/rate/tieredvolume_test.go
+++ b/openmeter/billing/rating/service/rate/tieredvolume_test.go
@@ -292,7 +292,7 @@ func TestTieredVolumeCalculation(t *testing.T) {
 					PerUnitAmount:          alpacadecimal.NewFromFloat(50),
 					Quantity:               alpacadecimal.NewFromFloat(1),
 					ChildUniqueReferenceID: rating.MinSpendChildUniqueReferenceID,
-					Period:                 lo.ToPtr(testutil.TestFullPeriod.ToClosedPeriod()),
+					Period:                 lo.ToPtr(testutil.TestFullPeriod),
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
 					Category:               billing.FlatFeeCategoryCommitment,
 					Totals: totals.Totals{
@@ -362,7 +362,7 @@ func TestTieredVolumeCalculation(t *testing.T) {
 					Name:                   "feature: minimum spend",
 					PerUnitAmount:          alpacadecimal.NewFromFloat(50),
 					Quantity:               alpacadecimal.NewFromFloat(1),
-					Period:                 lo.ToPtr(testutil.TestFullPeriod.ToClosedPeriod()),
+					Period:                 lo.ToPtr(testutil.TestFullPeriod),
 					ChildUniqueReferenceID: rating.MinSpendChildUniqueReferenceID,
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
 					Category:               billing.FlatFeeCategoryCommitment,

--- a/openmeter/billing/rating/service/rate/unit_test.go
+++ b/openmeter/billing/rating/service/rate/unit_test.go
@@ -47,7 +47,7 @@ func TestUnitPriceCalculation(t *testing.T) {
 					PerUnitAmount:          alpacadecimal.NewFromFloat(100),
 					Quantity:               alpacadecimal.NewFromFloat(1),
 					ChildUniqueReferenceID: rating.MinSpendChildUniqueReferenceID,
-					Period:                 lo.ToPtr(testutil.TestFullPeriod.ToClosedPeriod()),
+					Period:                 lo.ToPtr(testutil.TestFullPeriod),
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
 					Category:               billing.FlatFeeCategoryCommitment,
 					Totals: totals.Totals{
@@ -95,7 +95,7 @@ func TestUnitPriceCalculation(t *testing.T) {
 					PerUnitAmount:          alpacadecimal.NewFromFloat(100),
 					Quantity:               alpacadecimal.NewFromFloat(1),
 					ChildUniqueReferenceID: rating.MinSpendChildUniqueReferenceID,
-					Period:                 lo.ToPtr(testutil.TestFullPeriod.ToClosedPeriod()),
+					Period:                 lo.ToPtr(testutil.TestFullPeriod),
 					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
 					Category:               billing.FlatFeeCategoryCommitment,
 					Totals: totals.Totals{

--- a/openmeter/billing/rating/service/testutil/ubptest.go
+++ b/openmeter/billing/rating/service/testutil/ubptest.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/rating/service"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type TestLineMode string
@@ -25,9 +26,9 @@ const (
 	LastInPeriodSplitLineMode TestLineMode = "last_in_period_split"
 )
 
-var TestFullPeriod = billing.Period{
-	Start: lo.Must(time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")),
-	End:   lo.Must(time.Parse(time.RFC3339, "2021-01-02T00:00:00Z")),
+var TestFullPeriod = timeutil.ClosedPeriod{
+	From: lo.Must(time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")),
+	To:   lo.Must(time.Parse(time.RFC3339, "2021-01-02T00:00:00Z")),
 }
 
 type FeatureUsageResponse struct {
@@ -98,17 +99,17 @@ func RunCalculationTestCase(t *testing.T, tc CalculationTestCase) {
 	case SinglePerPeriodLineMode:
 		line.Period = TestFullPeriod
 	case MidPeriodSplitLineMode:
-		line.Period = billing.Period{
-			Start: TestFullPeriod.Start.Add(time.Hour * 12),
-			End:   TestFullPeriod.End.Add(-time.Hour),
+		line.Period = timeutil.ClosedPeriod{
+			From: TestFullPeriod.From.Add(time.Hour * 12),
+			To:   TestFullPeriod.To.Add(-time.Hour),
 		}
 		line.SplitLineGroupID = &fakeParentGroup.ID
 		line.SplitLineHierarchy = &fakeHierarchy
 
 	case LastInPeriodSplitLineMode:
-		line.Period = billing.Period{
-			Start: TestFullPeriod.Start.Add(time.Hour * 12),
-			End:   TestFullPeriod.End,
+		line.Period = timeutil.ClosedPeriod{
+			From: TestFullPeriod.From.Add(time.Hour * 12),
+			To:   TestFullPeriod.To,
 		}
 
 		line.SplitLineGroupID = &fakeParentGroup.ID

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 var _ billing.InvoiceService = (*Service)(nil)
@@ -313,9 +314,9 @@ func (s *Service) createStandardInvoiceHeaderFromGatheringInvoice(ctx context.Co
 			Type:        billing.InvoiceTypeStandard,
 			Currency:    in.Currency,
 			Status:      billing.StandardInvoiceStatusGathering,
-			Period: &billing.Period{
-				Start: in.ServicePeriod.From,
-				End:   in.ServicePeriod.To,
+			Period: &timeutil.ClosedPeriod{
+				From: in.ServicePeriod.From,
+				To:   in.ServicePeriod.To,
 			},
 			CreatedAt: in.CreatedAt,
 			UpdatedAt: in.UpdatedAt,
@@ -741,7 +742,7 @@ func (s Service) checkIfLinesAreInvoicable(ctx context.Context, invoice *billing
 
 			if period == nil {
 				return billing.ValidationError{
-					Err: fmt.Errorf("line[%s]: %w as of %s", line.ID, billing.ErrInvoiceLinesNotBillable, line.Period.End),
+					Err: fmt.Errorf("line[%s]: %w as of %s", line.ID, billing.ErrInvoiceLinesNotBillable, line.Period.To),
 				}
 			}
 

--- a/openmeter/billing/service/invoicecalc/details.go
+++ b/openmeter/billing/service/invoicecalc/details.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 func RecalculateDetailedLinesAndTotals(invoice *billing.StandardInvoice, deps CalculatorDependencies) error {
@@ -88,9 +89,9 @@ func newDetailedLines(line *billing.StandardLine, inputs ...rating.DetailedLine)
 
 		period := line.Period
 		if in.Period != nil {
-			period = billing.Period{
-				Start: in.Period.From,
-				End:   in.Period.To,
+			period = timeutil.ClosedPeriod{
+				From: in.Period.From,
+				To:   in.Period.To,
 			}
 		}
 

--- a/openmeter/billing/service/invoicecalc/period.go
+++ b/openmeter/billing/service/invoicecalc/period.go
@@ -9,7 +9,7 @@ import (
 
 // CalculateStandardInvoiceServicePeriod calculates the period of the invoice based on the lines.
 func CalculateStandardInvoiceServicePeriod(invoice *billing.StandardInvoice) error {
-	var period *billing.Period
+	var period *timeutil.ClosedPeriod
 
 	for _, line := range invoice.Lines.OrEmpty() {
 		if line.DeletedAt != nil {
@@ -17,19 +17,19 @@ func CalculateStandardInvoiceServicePeriod(invoice *billing.StandardInvoice) err
 		}
 
 		if period == nil {
-			period = &billing.Period{
-				Start: line.Period.Start,
-				End:   line.Period.End,
+			period = &timeutil.ClosedPeriod{
+				From: line.Period.From,
+				To:   line.Period.To,
 			}
 			continue
 		}
 
-		if line.Period.Start.Before(period.Start) {
-			period.Start = line.Period.Start
+		if line.Period.From.Before(period.From) {
+			period.From = line.Period.From
 		}
 
-		if line.Period.End.After(period.End) {
-			period.End = line.Period.End
+		if line.Period.To.After(period.To) {
+			period.To = line.Period.To
 		}
 	}
 

--- a/openmeter/billing/service/quantitysnapshot.go
+++ b/openmeter/billing/service/quantitysnapshot.go
@@ -197,15 +197,15 @@ func (s *Service) getFeatureUsage(ctx context.Context, in getFeatureUsageInput) 
 
 	meterQueryParams := streaming.QueryParams{
 		FilterCustomer: []streaming.Customer{in.Customer},
-		From:           &in.Line.Period.Start,
-		To:             &in.Line.Period.End,
+		From:           &in.Line.Period.From,
+		To:             &in.Line.Period.To,
 		FilterGroupBy:  in.Feature.MeterGroupByFilters,
 	}
 
 	lineHierarchy := in.Line.SplitLineHierarchy
 
 	// If we are the first line in the split, we don't need to calculate the pre period
-	if lineHierarchy == nil || lineHierarchy.Group.ServicePeriod.Start.Equal(in.Line.Period.Start) {
+	if lineHierarchy == nil || lineHierarchy.Group.ServicePeriod.From.Equal(in.Line.Period.From) {
 		meterValues, err := s.streamingConnector.QueryMeter(
 			ctx,
 			in.Line.Namespace,
@@ -223,8 +223,8 @@ func (s *Service) getFeatureUsage(ctx context.Context, in getFeatureUsageInput) 
 
 	// Let's calculate [parent.start ... line.start] values
 	preLineQuery := meterQueryParams
-	preLineQuery.From = &lineHierarchy.Group.ServicePeriod.Start
-	preLineQuery.To = &in.Line.Period.Start
+	preLineQuery.From = &lineHierarchy.Group.ServicePeriod.From
+	preLineQuery.To = &in.Line.Period.From
 
 	preLineResult, err := s.streamingConnector.QueryMeter(
 		ctx,
@@ -240,8 +240,8 @@ func (s *Service) getFeatureUsage(ctx context.Context, in getFeatureUsageInput) 
 
 	// Let's calculate [parent.start ... line.end] values
 	upToLineEnd := meterQueryParams
-	upToLineEnd.From = &lineHierarchy.Group.ServicePeriod.Start
-	upToLineEnd.To = &in.Line.Period.End
+	upToLineEnd.From = &lineHierarchy.Group.ServicePeriod.From
+	upToLineEnd.To = &in.Line.Period.To
 
 	upToLineEndResult, err := s.streamingConnector.QueryMeter(
 		ctx,

--- a/openmeter/billing/stdinvoice.go
+++ b/openmeter/billing/stdinvoice.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type StandardInvoiceStatusCategory string
@@ -222,7 +223,7 @@ type StandardInvoiceBase struct {
 	Status        StandardInvoiceStatus        `json:"status"`
 	StatusDetails StandardInvoiceStatusDetails `json:"statusDetail,omitempty"`
 
-	Period *Period `json:"period,omitempty"`
+	Period *timeutil.ClosedPeriod `json:"period,omitempty"`
 
 	DueAt *time.Time `json:"dueDate,omitempty"`
 

--- a/openmeter/billing/stdinvoice_test.go
+++ b/openmeter/billing/stdinvoice_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 func TestSortLines(t *testing.T) {
@@ -18,8 +19,8 @@ func TestSortLines(t *testing.T) {
 					Name:        "usage-based-line",
 					Description: lo.ToPtr("index=1"),
 				}),
-				Period: Period{
-					Start: time.Now().Add(time.Hour * 24),
+				Period: timeutil.ClosedPeriod{
+					From: time.Now().Add(time.Hour * 24),
 				},
 			},
 			DetailedLines: DetailedLines{
@@ -49,8 +50,8 @@ func TestSortLines(t *testing.T) {
 					Name:        "usage-based-line",
 					Description: lo.ToPtr("index=0"),
 				}),
-				Period: Period{
-					Start: time.Now(),
+				Period: timeutil.ClosedPeriod{
+					From: time.Now(),
 				},
 			},
 		},

--- a/openmeter/billing/stdinvoiceline.go
+++ b/openmeter/billing/stdinvoiceline.go
@@ -33,8 +33,8 @@ type StandardLineBase struct {
 	Currency  currencyx.Code `json:"currency"`
 
 	// Lifecycle
-	Period    Period    `json:"period"`
-	InvoiceAt time.Time `json:"invoiceAt"`
+	Period    timeutil.ClosedPeriod `json:"period"`
+	InvoiceAt time.Time             `json:"invoiceAt"`
 
 	// Relationships
 	ParentLineID     *string `json:"parentLine,omitempty"`
@@ -276,12 +276,9 @@ func (i *StandardLine) SetDeletedAt(at *time.Time) {
 }
 
 func (i *StandardLine) UpdateServicePeriod(fn func(p *timeutil.ClosedPeriod)) {
-	period := i.Period.ToClosedPeriod()
+	period := i.Period
 	fn(&period)
-	i.Period = Period{
-		Start: period.From,
-		End:   period.To,
-	}
+	i.Period = period
 }
 
 func (i StandardLine) GetInvoiceID() string {
@@ -330,8 +327,8 @@ func (i StandardLine) GetMeteredPreLinePeriodQuantity() (*alpacadecimal.Decimal,
 func (i StandardLine) GetProgressivelyBilledServicePeriod() (timeutil.ClosedPeriod, error) {
 	if i.SplitLineGroupID == nil {
 		return timeutil.ClosedPeriod{
-			From: i.Period.Start,
-			To:   i.Period.End,
+			From: i.Period.From,
+			To:   i.Period.To,
 		}, nil
 	}
 
@@ -339,7 +336,7 @@ func (i StandardLine) GetProgressivelyBilledServicePeriod() (timeutil.ClosedPeri
 		return timeutil.ClosedPeriod{}, errors.New("split line hierarchy is required")
 	}
 
-	return i.SplitLineHierarchy.Group.ServicePeriod.ToClosedPeriod(), nil
+	return i.SplitLineHierarchy.Group.ServicePeriod, nil
 }
 
 func (i StandardLine) GetPreviouslyBilledAmount() (alpacadecimal.Decimal, error) {
@@ -352,7 +349,7 @@ func (i StandardLine) GetPreviouslyBilledAmount() (alpacadecimal.Decimal, error)
 	}
 
 	return i.SplitLineHierarchy.SumNetAmount(SumNetAmountInput{
-		PeriodEndLTE: i.Period.Start,
+		PeriodEndLTE: i.Period.From,
 	})
 }
 
@@ -391,8 +388,8 @@ func (i StandardLine) ToGatheringLineBase() (GatheringLineBase, error) {
 		InvoiceID:       i.InvoiceID,
 		Currency:        i.Currency,
 		ServicePeriod: timeutil.ClosedPeriod{
-			From: i.Period.Start,
-			To:   i.Period.End,
+			From: i.Period.From,
+			To:   i.Period.To,
 		},
 		InvoiceAt:              i.InvoiceAt,
 		Price:                  lo.FromPtr(i.UsageBased.Price),
@@ -513,8 +510,8 @@ func (i StandardLine) GetRateCardDiscounts() Discounts {
 
 func (i StandardLine) GetServicePeriod() timeutil.ClosedPeriod {
 	return timeutil.ClosedPeriod{
-		From: i.Period.Start,
-		To:   i.Period.End,
+		From: i.Period.From,
+		To:   i.Period.To,
 	}
 }
 
@@ -623,8 +620,8 @@ func (i StandardLine) Validate() error {
 	if i.UsageBased.Price.Type() != productcatalog.FlatPriceType {
 		if i.InvoiceAt.
 			Truncate(streaming.MinimumWindowSizeDuration).
-			Before(i.Period.Truncate(streaming.MinimumWindowSizeDuration).End) {
-			errs = append(errs, fmt.Errorf("invoice at (%s) must be after period end (%s) for usage based line", i.InvoiceAt, i.Period.Truncate(streaming.MinimumWindowSizeDuration).End))
+			Before(i.Period.Truncate(streaming.MinimumWindowSizeDuration).To) {
+			errs = append(errs, fmt.Errorf("invoice at (%s) must be after period end (%s) for usage based line", i.InvoiceAt, i.Period.Truncate(streaming.MinimumWindowSizeDuration).To))
 		}
 
 		if i.Period.Truncate(streaming.MinimumWindowSizeDuration).IsEmpty() {
@@ -727,8 +724,8 @@ func (i *StandardLine) SortDetailedLines() {
 			return nameOrder < 0
 		}
 
-		if !lineA.ServicePeriod.Start.Equal(lineB.ServicePeriod.Start) {
-			return lineA.ServicePeriod.Start.Before(lineB.ServicePeriod.Start)
+		if !lineA.ServicePeriod.From.Equal(lineB.ServicePeriod.From) {
+			return lineA.ServicePeriod.From.Before(lineB.ServicePeriod.From)
 		}
 
 		return strings.Compare(lineA.ID, lineB.ID) < 0
@@ -742,7 +739,7 @@ type NewFlatFeeLineInput struct {
 	UpdatedAt time.Time
 
 	Namespace string
-	Period    Period
+	Period    timeutil.ClosedPeriod
 	InvoiceAt time.Time
 
 	InvoiceID string
@@ -917,8 +914,8 @@ func (c *StandardLines) Sort() {
 			return nameOrder < 0
 		}
 
-		if !lineA.Period.Start.Equal(lineB.Period.Start) {
-			return lineA.Period.Start.Before(lineB.Period.Start)
+		if !lineA.Period.From.Equal(lineB.Period.From) {
+			return lineA.Period.From.Before(lineB.Period.From)
 		}
 
 		return strings.Compare(lineA.ID, lineB.ID) < 0

--- a/openmeter/billing/worker/subscriptionsync/service/base_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/base_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 	billingtest "github.com/openmeterio/openmeter/test/billing"
 )
 
@@ -275,7 +276,7 @@ type expectedLine struct {
 	Matcher          lineMatcher
 	Qty              mo.Option[float64]
 	Price            mo.Option[*productcatalog.Price]
-	Periods          []billing.Period
+	Periods          []timeutil.ClosedPeriod
 	InvoiceAt        mo.Option[[]time.Time]
 	AdditionalChecks func(line billing.GenericInvoiceLine)
 }
@@ -325,8 +326,8 @@ func (s *SuiteBase) expectLines(invoice billing.GenericInvoiceReader, subscripti
 				s.Equal(*expectedLine.Price.OrEmpty(), *line.GetPrice(), "%s: price", childID)
 			}
 
-			s.Equal(expectedLine.Periods[idx].Start, line.GetServicePeriod().From, "%s: period start", childID)
-			s.Equal(expectedLine.Periods[idx].End, line.GetServicePeriod().To, "%s: period end", childID)
+			s.Equal(expectedLine.Periods[idx].From, line.GetServicePeriod().From, "%s: period start", childID)
+			s.Equal(expectedLine.Periods[idx].To, line.GetServicePeriod().To, "%s: period end", childID)
 
 			if expectedLine.InvoiceAt.IsPresent() {
 				invoiceAtAccessor, ok := line.(billing.InvoiceAtAccessor)
@@ -462,17 +463,17 @@ func (i subscriptionAddItem) AsPatch() subscription.Patch {
 	}
 }
 
-func (s *SuiteBase) generatePeriods(startStr, endStr string, cadenceStr string, n int) []billing.Period { //nolint: unparam
+func (s *SuiteBase) generatePeriods(startStr, endStr string, cadenceStr string, n int) []timeutil.ClosedPeriod { //nolint: unparam
 	start := testutils.GetRFC3339Time(s.T(), startStr)
 	end := testutils.GetRFC3339Time(s.T(), endStr)
 	cadence := datetime.MustParseDuration(s.T(), cadenceStr)
 
-	out := []billing.Period{}
+	out := []timeutil.ClosedPeriod{}
 
 	for n != 0 {
-		out = append(out, billing.Period{
-			Start: start,
-			End:   end,
+		out = append(out, timeutil.ClosedPeriod{
+			From: start,
+			To:   end,
 		})
 
 		start, _ = cadence.AddTo(start)

--- a/openmeter/billing/worker/subscriptionsync/service/persistedstate/item.go
+++ b/openmeter/billing/worker/subscriptionsync/service/persistedstate/item.go
@@ -137,7 +137,7 @@ func (i persistedSplitLineHierarchy) ChildUniqueReferenceID() *string {
 }
 
 func (i persistedSplitLineHierarchy) ServicePeriod() timeutil.ClosedPeriod {
-	return i.hierarchy.Group.ServicePeriod.ToClosedPeriod()
+	return i.hierarchy.Group.ServicePeriod
 }
 
 func (i persistedSplitLineHierarchy) GetSplitLineHierarchy() *billing.SplitLineHierarchy {
@@ -172,7 +172,7 @@ func (i persistedSplitLineHierarchy) HasLastLineAnnotation(annotation string) bo
 func (i persistedSplitLineHierarchy) getLastLineForAnnotations() billing.GenericInvoiceLine {
 	servicePeriod := i.hierarchy.Group.ServicePeriod
 	for _, child := range i.hierarchy.Lines {
-		if child.Line.GetServicePeriod().To.Equal(servicePeriod.End) && child.Line.GetDeletedAt() == nil {
+		if child.Line.GetServicePeriod().To.Equal(servicePeriod.To) && child.Line.GetDeletedAt() == nil {
 			return child.Line
 		}
 	}

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/patch.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/patch.go
@@ -151,7 +151,7 @@ func (p Patch) Log(logger *slog.Logger) {
 	case PatchOpSplitLineGroupDelete:
 		logger.Info("delete split line group patch", "group_id", p.deleteSplitLineGroupPatch.Group.ID)
 	case PatchOpSplitLineGroupUpdate:
-		logger.Info("update split line group patch", "group_id", p.updateSplitLineGroupPatch.TargetState.ID, "new_service_period_from", p.updateSplitLineGroupPatch.TargetState.ServicePeriod.Start, "new_service_period_to", p.updateSplitLineGroupPatch.TargetState.ServicePeriod.End)
+		logger.Info("update split line group patch", "group_id", p.updateSplitLineGroupPatch.TargetState.ID, "new_service_period_from", p.updateSplitLineGroupPatch.TargetState.ServicePeriod.From, "new_service_period_to", p.updateSplitLineGroupPatch.TargetState.ServicePeriod.To)
 	default:
 		logger.Info("unknown patch operation", "operation", p.op)
 	}

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge.go
@@ -101,8 +101,8 @@ func (c *chargePatchCollection) AddShrink(uniqueID string, existing persistedsta
 
 	patch, err := chargesmeta.NewPatchShrink(chargesmeta.NewPatchShrinkInput{
 		NewServicePeriodTo:     targetServicePeriod.To,
-		NewFullServicePeriodTo: target.FullServicePeriod.End,
-		NewBillingPeriodTo:     target.BillingPeriod.End,
+		NewFullServicePeriodTo: target.FullServicePeriod.To,
+		NewBillingPeriodTo:     target.BillingPeriod.To,
 	})
 	if err != nil {
 		return err
@@ -116,8 +116,8 @@ func (c *chargePatchCollection) AddExtend(existing persistedstate.Item, target t
 
 	patch, err := chargesmeta.NewPatchExtend(chargesmeta.NewPatchExtendInput{
 		NewServicePeriodTo:     targetServicePeriod.To,
-		NewFullServicePeriodTo: target.FullServicePeriod.End,
-		NewBillingPeriodTo:     target.BillingPeriod.End,
+		NewFullServicePeriodTo: target.FullServicePeriod.To,
+		NewBillingPeriodTo:     target.BillingPeriod.To,
 	})
 	if err != nil {
 		return err
@@ -150,12 +150,12 @@ func newChargeIntentBaseFromTargetState(target targetstate.StateItem) (chargesme
 		Currency:      target.CurrencyCalculator.Currency,
 		ServicePeriod: target.GetServicePeriod(),
 		FullServicePeriod: timeutil.ClosedPeriod{
-			From: target.FullServicePeriod.Start,
-			To:   target.FullServicePeriod.End,
+			From: target.FullServicePeriod.From,
+			To:   target.FullServicePeriod.To,
 		},
 		BillingPeriod: timeutil.ClosedPeriod{
-			From: target.BillingPeriod.Start,
-			To:   target.BillingPeriod.End,
+			From: target.BillingPeriod.From,
+			To:   target.BillingPeriod.To,
 		},
 		TaxConfig:         rateCardMeta.TaxConfig,
 		UniqueReferenceID: &target.UniqueID,

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchinvoicelinehierarchy.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchinvoicelinehierarchy.go
@@ -79,8 +79,8 @@ func (c *lineHierarchyPatchCollection) AddShrink(uniqueID string, existing persi
 		return nil
 	}
 
-	if !expectedLine.ServicePeriod.To.Before(existingHierarchy.Group.ServicePeriod.End) {
-		return fmt.Errorf("shrink patch requires target end before existing hierarchy end: existing=%s..%s target=%s..%s", existingHierarchy.Group.ServicePeriod.Start, existingHierarchy.Group.ServicePeriod.End, expectedLine.ServicePeriod.From, expectedLine.ServicePeriod.To)
+	if !expectedLine.ServicePeriod.To.Before(existingHierarchy.Group.ServicePeriod.To) {
+		return fmt.Errorf("shrink patch requires target end before existing hierarchy end: existing=%s..%s target=%s..%s", existingHierarchy.Group.ServicePeriod.From, existingHierarchy.Group.ServicePeriod.To, expectedLine.ServicePeriod.From, expectedLine.ServicePeriod.To)
 	}
 
 	patches := make([]invoiceupdater.Patch, 0, len(existingHierarchy.Lines)+1)
@@ -127,7 +127,7 @@ func (c *lineHierarchyPatchCollection) AddShrink(uniqueID string, existing persi
 	}
 
 	updatedGroup := existingHierarchy.Group.ToUpdate()
-	updatedGroup.ServicePeriod.End = expectedLine.ServicePeriod.To
+	updatedGroup.ServicePeriod.To = expectedLine.ServicePeriod.To
 	patches = append(patches, invoiceupdater.NewUpdateSplitLineGroupPatch(updatedGroup))
 
 	return c.addPatches(uniqueID, PatchOperationShrink, patches...)
@@ -147,12 +147,12 @@ func (c *lineHierarchyPatchCollection) AddExtend(existing persistedstate.Item, t
 		return nil
 	}
 
-	if existingHierarchy.Group.ServicePeriod.End.Equal(expectedLine.ServicePeriod.To) {
+	if existingHierarchy.Group.ServicePeriod.To.Equal(expectedLine.ServicePeriod.To) {
 		return nil
 	}
 
-	if !expectedLine.ServicePeriod.To.After(existingHierarchy.Group.ServicePeriod.End) {
-		return fmt.Errorf("[line] extend patch requires target end after existing end: existing=%s..%s target=%s..%s", existingHierarchy.Group.ServicePeriod.Start, existingHierarchy.Group.ServicePeriod.End, expectedLine.ServicePeriod.From, expectedLine.ServicePeriod.To)
+	if !expectedLine.ServicePeriod.To.After(existingHierarchy.Group.ServicePeriod.To) {
+		return fmt.Errorf("[line] extend patch requires target end after existing end: existing=%s..%s target=%s..%s", existingHierarchy.Group.ServicePeriod.From, existingHierarchy.Group.ServicePeriod.To, expectedLine.ServicePeriod.From, expectedLine.ServicePeriod.To)
 	}
 
 	patches := make([]invoiceupdater.Patch, 0, 2)
@@ -189,7 +189,7 @@ func (c *lineHierarchyPatchCollection) AddExtend(existing persistedstate.Item, t
 	}
 
 	updatedGroup := existingHierarchy.Group.ToUpdate()
-	updatedGroup.ServicePeriod.End = expectedLine.ServicePeriod.To
+	updatedGroup.ServicePeriod.To = expectedLine.ServicePeriod.To
 	patches = append(patches, invoiceupdater.NewUpdateSplitLineGroupPatch(updatedGroup))
 
 	return c.addPatches(target.UniqueID, PatchOperationExtend, patches...)

--- a/openmeter/billing/worker/subscriptionsync/service/sync_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_test.go
@@ -248,9 +248,9 @@ func (s *SubscriptionHandlerTestSuite) TestSubscriptionHappyPath() {
 		s.Equal(line.Subscription.PhaseID, discountedPhase.SubscriptionPhase.ID)
 		s.Equal(line.Subscription.ItemID, discountedPhase.ItemsByKey[s.APIRequestsTotalFeature.Key][0].SubscriptionItem.ID)
 		s.Equal(line.InvoiceAt, s.mustParseTime("2024-02-15T00:00:00Z"))
-		s.Equal(line.Period, billing.Period{
-			Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-			End:   s.mustParseTime("2024-02-15T00:00:00Z"),
+		s.Equal(line.Period, timeutil.ClosedPeriod{
+			From: s.mustParseTime("2024-02-01T00:00:00Z"),
+			To:   s.mustParseTime("2024-02-15T00:00:00Z"),
 		})
 
 		// let's fetch the gathering invoice
@@ -324,9 +324,9 @@ func (s *SubscriptionHandlerTestSuite) TestSubscriptionHappyPath() {
 		splitLineGroup := gatheringLine.SplitLineHierarchy.Group
 
 		s.Equal(splitLineGroup.Subscription.SubscriptionID, subsView.Subscription.ID)
-		s.Equal(splitLineGroup.ServicePeriod, billing.Period{
-			Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-			End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+		s.Equal(splitLineGroup.ServicePeriod, timeutil.ClosedPeriod{
+			From: s.mustParseTime("2024-02-01T00:00:00Z"),
+			To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 		})
 	})
 
@@ -373,9 +373,9 @@ func (s *SubscriptionHandlerTestSuite) TestSubscriptionHappyPath() {
 		splitLineGroup := gatheringLine.SplitLineHierarchy.Group
 
 		s.Equal(splitLineGroup.Subscription.SubscriptionID, subsView.Subscription.ID)
-		s.Equal(splitLineGroup.ServicePeriod, billing.Period{
-			Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-			End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+		s.Equal(splitLineGroup.ServicePeriod, timeutil.ClosedPeriod{
+			From: s.mustParseTime("2024-02-01T00:00:00Z"),
+			To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 		})
 	})
 }
@@ -707,14 +707,14 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncNonBillableAmou
 				Amount:      alpacadecimal.NewFromFloat(10),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:40Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:40Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -820,10 +820,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncNonBillableAmou
 				Amount:      alpacadecimal.NewFromFloat(5),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-01T00:00:40Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-01T00:00:40Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -843,14 +843,14 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncNonBillableAmou
 				Amount:      alpacadecimal.NewFromFloat(10),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:40Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:40Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -954,10 +954,10 @@ func (s *SubscriptionHandlerTestSuite) TestInArrearsGatheringSyncNonBillableAmou
 				Amount:      alpacadecimal.NewFromFloat(5),
 				PaymentTerm: productcatalog.InArrearsPaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-01T00:00:40Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-01T00:00:40Z"),
 				},
 			},
 			// We'll wait till the end of the billing cadence of the item
@@ -976,10 +976,10 @@ func (s *SubscriptionHandlerTestSuite) TestInArrearsGatheringSyncNonBillableAmou
 				Amount:      alpacadecimal.NewFromFloat(10),
 				PaymentTerm: productcatalog.InArrearsPaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:40Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:40Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 			// We'll wait till the end of the billing cadence of the item
@@ -1061,10 +1061,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncBillableAmountP
 				Amount:      alpacadecimal.NewFromFloat(0.32), // 10 * 1 / 31
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-02T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-02T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -1084,10 +1084,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncBillableAmountP
 				Amount:      alpacadecimal.NewFromFloat(19.35), // 20 * 30 / 31
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-02T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-02T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -1107,10 +1107,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncBillableAmountP
 				Amount:      alpacadecimal.NewFromFloat(20),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -1182,10 +1182,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncDraftInvoicePro
 				Amount:      alpacadecimal.NewFromFloat(6),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 		},
@@ -1229,10 +1229,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncDraftInvoicePro
 				Amount:      alpacadecimal.NewFromFloat(9.68), // 10 * 30 / 31
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-02T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-02T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-01T00:00:00Z")}),
@@ -1250,10 +1250,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncDraftInvoicePro
 				Amount:      alpacadecimal.NewFromFloat(10),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
@@ -1281,10 +1281,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncDraftInvoicePro
 				Amount:      alpacadecimal.NewFromFloat(0.19), // 6 * 1 / 31
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-02T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-02T00:00:00Z"),
 				},
 			},
 		},
@@ -1355,10 +1355,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePr
 				Amount:      alpacadecimal.NewFromFloat(6),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 		},
@@ -1402,10 +1402,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePr
 				Amount:      alpacadecimal.NewFromFloat(9.68), // 10 * 30 / 31
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-02T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-02T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-01T00:00:00Z")}),
@@ -1423,10 +1423,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePr
 				Amount:      alpacadecimal.NewFromFloat(10),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
@@ -1454,10 +1454,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePr
 				Amount:      alpacadecimal.NewFromFloat(6),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 		},
@@ -1684,10 +1684,10 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionInvoicing() {
 				Amount:      alpacadecimal.NewFromFloat(5),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-02T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-02T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-01T00:00:00Z")}),
@@ -1705,39 +1705,39 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionInvoicing() {
 				Amount:      alpacadecimal.NewFromFloat(8),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-02T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-08T00:00:00Z"),
+					From: s.mustParseTime("2024-01-02T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-08T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-01-08T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-15T00:00:00Z"),
+					From: s.mustParseTime("2024-01-08T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-15T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-01-15T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-22T00:00:00Z"),
+					From: s.mustParseTime("2024-01-15T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-22T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-01-22T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-29T00:00:00Z"),
+					From: s.mustParseTime("2024-01-22T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-29T00:00:00Z"),
 				},
 				// As these are in advance items, we also generate them for the next Billing Period (from 2024-01-29 to 2024-02-26)
 				{
-					Start: s.mustParseTime("2024-01-29T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-05T00:00:00Z"),
+					From: s.mustParseTime("2024-01-29T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-05T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-02-05T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-12T00:00:00Z"),
+					From: s.mustParseTime("2024-02-05T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-12T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-02-12T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-19T00:00:00Z"),
+					From: s.mustParseTime("2024-02-12T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-19T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-02-19T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-26T00:00:00Z"),
+					From: s.mustParseTime("2024-02-19T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-26T00:00:00Z"),
 				},
 			},
 			// in-advance items are invoiced immediately when change happens
@@ -1766,10 +1766,10 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionInvoicing() {
 				Amount:      alpacadecimal.NewFromFloat(5),
 				PaymentTerm: productcatalog.InArrearsPaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-02T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-02T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-29T00:00:00Z")}),
@@ -1787,22 +1787,22 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionInvoicing() {
 				Amount:      alpacadecimal.NewFromFloat(7),
 				PaymentTerm: productcatalog.InArrearsPaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-02T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-08T00:00:00Z"),
+					From: s.mustParseTime("2024-01-02T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-08T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-01-08T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-15T00:00:00Z"),
+					From: s.mustParseTime("2024-01-08T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-15T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-01-15T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-22T00:00:00Z"),
+					From: s.mustParseTime("2024-01-15T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-22T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-01-22T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-29T00:00:00Z"),
+					From: s.mustParseTime("2024-01-22T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-29T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -1914,14 +1914,14 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionCancellation() {
 				PeriodMax: 1,
 			},
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromFloat(5)})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: startTime.AddDate(0, 1, 0),
-					End:   startTime.AddDate(0, 2, 0),
+					From: startTime.AddDate(0, 1, 0),
+					To:   startTime.AddDate(0, 2, 0),
 				},
 				{
-					Start: startTime.AddDate(0, 2, 0),
-					End:   startTime.AddDate(0, 3, 0),
+					From: startTime.AddDate(0, 2, 0),
+					To:   startTime.AddDate(0, 3, 0),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -2051,10 +2051,10 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProgressiveBilling
 				ItemKey:  s.APIRequestsTotalFeature.Key,
 			},
 			Price: mo.Some(testPrice),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: startTime,
-					End:   startTime.AddDate(0, 1, 0),
+					From: startTime,
+					To:   startTime.AddDate(0, 1, 0),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -2090,10 +2090,10 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProgressiveBilling
 				ItemKey:  s.APIRequestsTotalFeature.Key,
 			},
 			Price: mo.Some(testPrice),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: startTime,
-					End:   startTime.AddDate(0, 0, 1),
+					From: startTime,
+					To:   startTime.AddDate(0, 0, 1),
 				},
 			},
 		},
@@ -2111,10 +2111,10 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProgressiveBilling
 				ItemKey:  s.APIRequestsTotalFeature.Key,
 			},
 			Price: mo.Some(testPrice),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: startTime.AddDate(0, 0, 1),
-					End:   startTime.AddDate(0, 1, 0),
+					From: startTime.AddDate(0, 0, 1),
+					To:   startTime.AddDate(0, 1, 0),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -2191,10 +2191,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceOneTimeFeeSyncing() {
 				Amount:      alpacadecimal.NewFromFloat(5),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-01T00:00:00Z")}),
@@ -2309,10 +2309,10 @@ func (s *SubscriptionHandlerTestSuite) TestInArrearsOneTimeFeeSyncing() {
 				Amount:      alpacadecimal.NewFromFloat(5),
 				PaymentTerm: productcatalog.InArrearsPaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-15T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-15T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-15T00:00:00Z")}),
@@ -2367,10 +2367,10 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdate() {
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(10),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
@@ -2421,10 +2421,10 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdate() {
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(10),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-03T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-03T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-03T00:00:00Z")}),
@@ -2442,10 +2442,10 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdate() {
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(5),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-03T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-03T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
@@ -2517,10 +2517,10 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdateDraftInvoice
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(10),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 		},
@@ -2541,10 +2541,10 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdateDraftInvoice
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(10),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-03-01T00:00:00Z")}),
@@ -2601,10 +2601,10 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdateDraftInvoice
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(5),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-31T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-31T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
@@ -2620,10 +2620,10 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdateDraftInvoice
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(5),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-03-01T00:00:00Z")}),
@@ -2648,10 +2648,10 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdateDraftInvoice
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(10),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-31T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-31T00:00:00Z"),
 				},
 			},
 		},
@@ -2732,10 +2732,10 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdateIssuedInvoic
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(10),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 		},
@@ -2795,10 +2795,10 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdateIssuedInvoic
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(10),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"), // This is not updated, which is what we want
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"), // This is not updated, which is what we want
 				},
 			},
 		},
@@ -2885,10 +2885,10 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedUpdateWithLineSplits() {
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(10),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-15T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-15T00:00:00Z"),
 				},
 			},
 		},
@@ -2919,10 +2919,10 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedUpdateWithLineSplits() {
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(10),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-15T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-18T00:00:00Z"),
+					From: s.mustParseTime("2024-01-15T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-18T00:00:00Z"),
 				},
 			},
 		},
@@ -2945,14 +2945,14 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedUpdateWithLineSplits() {
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(10),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-18T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-18T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -3011,14 +3011,14 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedUpdateWithLineSplits() {
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(5),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-11T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-11T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -3049,10 +3049,10 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedUpdateWithLineSplits() {
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(10),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-15T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-15T00:00:00Z"),
 				},
 			},
 		},
@@ -3255,9 +3255,9 @@ func (s *SubscriptionHandlerTestSuite) TestSplitLineManualEditSync() {
 	// Field updates are supported for manually managed lines
 	s.Equal(resyncedInvoiceLine.StandardLineBase.Name, updatedLine.Name)
 	// Period however is managed by the sync to ensure consistency between line and parent (update endpoint does the filtering)
-	s.Equal(billing.Period{
-		Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-		End:   s.mustParseTime("2024-01-10T00:00:00Z"),
+	s.Equal(timeutil.ClosedPeriod{
+		From: s.mustParseTime("2024-01-01T00:00:00Z"),
+		To:   s.mustParseTime("2024-01-10T00:00:00Z"),
 	}, resyncedInvoiceLine.Period)
 }
 
@@ -3724,17 +3724,17 @@ func (s *SubscriptionHandlerTestSuite) TestSplitLineManualDeleteSync() {
 	line := resyncedInvoice.Lines.OrEmpty()[0]
 	s.NotNil(line.DeletedAt)
 	// Period is updated
-	s.Equal(billing.Period{
-		Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-		End:   s.mustParseTime("2024-01-10T00:00:00Z"),
+	s.Equal(timeutil.ClosedPeriod{
+		From: s.mustParseTime("2024-01-01T00:00:00Z"),
+		To:   s.mustParseTime("2024-01-10T00:00:00Z"),
 	}, line.Period)
 
 	s.NotNil(line.SplitLineHierarchy)
 	parentGroup := line.SplitLineHierarchy.Group
 	// Parent's period is in sync with the child
-	s.Equal(billing.Period{
-		Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-		End:   s.mustParseTime("2024-01-10T00:00:00Z"),
+	s.Equal(timeutil.ClosedPeriod{
+		From: s.mustParseTime("2024-01-01T00:00:00Z"),
+		To:   s.mustParseTime("2024-01-10T00:00:00Z"),
 	}, parentGroup.ServicePeriod)
 	s.Equal(fmt.Sprintf("%s/first-phase/api-requests-total/v[0]/period[0]", subsView.Subscription.ID), *parentGroup.UniqueReferenceID)
 }
@@ -3889,10 +3889,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceInstantBillingOnSubscription
 				Amount:      alpacadecimal.NewFromFloat(6),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 		},
@@ -3973,10 +3973,10 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceInstantBillingOnSubscription
 				Amount:      alpacadecimal.NewFromFloat(6),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
@@ -4072,10 +4072,10 @@ func (s *SubscriptionHandlerTestSuite) TestDiscountSynchronization() {
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(10),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
@@ -4093,10 +4093,10 @@ func (s *SubscriptionHandlerTestSuite) TestDiscountSynchronization() {
 				Amount:      alpacadecimal.NewFromFloat(6),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
@@ -4114,10 +4114,10 @@ func (s *SubscriptionHandlerTestSuite) TestDiscountSynchronization() {
 				Amount:      alpacadecimal.NewFromFloat(6),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 		},
@@ -4248,10 +4248,10 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProratingBehavior(
 				Amount:      alpacadecimal.NewFromFloat(2.26),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-15T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-15T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-01T00:00:00Z")}),
@@ -4265,10 +4265,10 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProratingBehavior(
 				Amount:      alpacadecimal.NewFromFloat(2.26),
 				PaymentTerm: productcatalog.InArrearsPaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-15T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-15T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-15T00:00:00Z")}),
@@ -4279,10 +4279,10 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProratingBehavior(
 				ItemKey:  "api-requests-total",
 			},
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromFloat(10)})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-01-15T00:00:00Z"),
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-15T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-15T00:00:00Z")}),
@@ -4301,10 +4301,10 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProratingBehavior(
 				Amount:      alpacadecimal.NewFromFloat(2.74),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-15T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-15T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-15T00:00:00Z")}),
@@ -4320,10 +4320,10 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProratingBehavior(
 				Amount:      alpacadecimal.NewFromFloat(5),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
@@ -4339,10 +4339,10 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProratingBehavior(
 				Amount:      alpacadecimal.NewFromFloat(2.74),
 				PaymentTerm: productcatalog.InArrearsPaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-15T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-15T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
@@ -4358,10 +4358,10 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProratingBehavior(
 				Amount:      alpacadecimal.NewFromFloat(5),
 				PaymentTerm: productcatalog.InArrearsPaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-03-01T00:00:00Z")}),
@@ -4375,14 +4375,14 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProratingBehavior(
 			},
 			// UBP does not need prorating on price due to period being shorter
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromFloat(10.0)})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-01-15T00:00:00Z"),
-					End:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					From: s.mustParseTime("2024-01-15T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z"), s.mustParseTime("2024-03-01T00:00:00Z")}),
@@ -4466,10 +4466,10 @@ func (s *SubscriptionHandlerTestSuite) TestSynchronizeSubscriptionPeriodAlgorith
 				Amount:      alpacadecimal.NewFromFloat(6),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2025-01-31T00:00:00Z"),
-					End:   s.mustParseTime("2025-03-02T00:00:00Z"),
+					From: s.mustParseTime("2025-01-31T00:00:00Z"),
+					To:   s.mustParseTime("2025-03-02T00:00:00Z"),
 				},
 			},
 		},
@@ -4495,14 +4495,14 @@ func (s *SubscriptionHandlerTestSuite) TestSynchronizeSubscriptionPeriodAlgorith
 				Amount:      alpacadecimal.NewFromFloat(6),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2025-01-31T00:00:00Z"),
-					End:   s.mustParseTime("2025-03-02T00:00:00Z"),
+					From: s.mustParseTime("2025-01-31T00:00:00Z"),
+					To:   s.mustParseTime("2025-03-02T00:00:00Z"),
 				},
 				{
-					Start: s.mustParseTime("2025-03-02T00:00:00Z"),
-					End:   s.mustParseTime("2025-03-31T00:00:00Z"),
+					From: s.mustParseTime("2025-03-02T00:00:00Z"),
+					To:   s.mustParseTime("2025-03-31T00:00:00Z"),
 				},
 			},
 
@@ -4587,10 +4587,10 @@ func (s *SubscriptionHandlerTestSuite) TestDeletedCustomerHandling() {
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(5),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2025-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2025-01-01T01:00:00Z"),
+					From: s.mustParseTime("2025-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2025-01-01T01:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2025-01-01T01:00:00Z")}),
@@ -4619,10 +4619,10 @@ func (s *SubscriptionHandlerTestSuite) TestDeletedCustomerHandling() {
 			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 				Amount: alpacadecimal.NewFromFloat(5),
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2025-01-01T00:00:00Z"),
-					End:   s.mustParseTime("2025-01-01T01:00:00Z"),
+					From: s.mustParseTime("2025-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2025-01-01T01:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2025-01-01T01:00:00Z")}),
@@ -4734,10 +4734,10 @@ func (s *SubscriptionHandlerTestSuite) TestFirstDayOfMonthBillingForSubPeriodLen
 				Amount:      alpacadecimal.NewFromFloat(6),
 				PaymentTerm: productcatalog.InAdvancePaymentTerm,
 			})),
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: s.mustParseTime("2024-02-01T00:00:00Z"),
-					End:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),

--- a/openmeter/billing/worker/subscriptionsync/service/syncbillinganchor_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/syncbillinganchor_test.go
@@ -162,10 +162,10 @@ func (s *BillingAnchorTestSuite) TestBillingAnchorSinglePhase() {
 				PhaseKey: "first-phase",
 				ItemKey:  s.APIRequestsTotalFeature.Key,
 			},
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: testutils.GetRFC3339Time(s.T(), "2025-07-10T15:00:00Z"),
-					End:   testutils.GetRFC3339Time(s.T(), "2025-07-31T15:00:00Z"),
+					From: testutils.GetRFC3339Time(s.T(), "2025-07-10T15:00:00Z"),
+					To:   testutils.GetRFC3339Time(s.T(), "2025-07-31T15:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -183,14 +183,14 @@ func (s *BillingAnchorTestSuite) TestBillingAnchorSinglePhase() {
 				PeriodMin: 1,
 				PeriodMax: 2,
 			},
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: testutils.GetRFC3339Time(s.T(), "2025-07-31T15:00:00Z"),
-					End:   testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
+					From: testutils.GetRFC3339Time(s.T(), "2025-07-31T15:00:00Z"),
+					To:   testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
 				},
 				{
-					Start: testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
-					End:   testutils.GetRFC3339Time(s.T(), "2025-09-30T15:00:00Z"),
+					From: testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
+					To:   testutils.GetRFC3339Time(s.T(), "2025-09-30T15:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -371,10 +371,10 @@ func (s *BillingAnchorTestSuite) TestBillingAnchorMultiPhase() {
 				PhaseKey: "billable-phase",
 				ItemKey:  s.APIRequestsTotalFeature.Key,
 			},
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: testutils.GetRFC3339Time(s.T(), "2025-08-10T15:00:00Z"),
-					End:   testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
+					From: testutils.GetRFC3339Time(s.T(), "2025-08-10T15:00:00Z"),
+					To:   testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{
@@ -388,10 +388,10 @@ func (s *BillingAnchorTestSuite) TestBillingAnchorMultiPhase() {
 				PeriodMin: 1,
 				PeriodMax: 1,
 			},
-			Periods: []billing.Period{
+			Periods: []timeutil.ClosedPeriod{
 				{
-					Start: testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
-					End:   testutils.GetRFC3339Time(s.T(), "2025-09-30T15:00:00Z"),
+					From: testutils.GetRFC3339Time(s.T(), "2025-08-31T15:00:00Z"),
+					To:   testutils.GetRFC3339Time(s.T(), "2025-09-30T15:00:00Z"),
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{

--- a/openmeter/billing/worker/subscriptionsync/service/targetstate/phaseiterator.go
+++ b/openmeter/billing/worker/subscriptionsync/service/targetstate/phaseiterator.go
@@ -13,7 +13,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
@@ -56,12 +55,12 @@ type SubscriptionItemWithPeriods struct {
 	// Period Information
 
 	// ServicePeriod is the de-facto service period that the item is billed for
-	ServicePeriod billing.Period
+	ServicePeriod timeutil.ClosedPeriod
 	// FullServicePeriod is the full service period that the item is billed for (previously nonTruncatedPeriod)
-	FullServicePeriod billing.Period
+	FullServicePeriod timeutil.ClosedPeriod
 
 	// BillingPeriod as determined by alignment and service period
-	BillingPeriod billing.Period
+	BillingPeriod timeutil.ClosedPeriod
 }
 
 // PeriodPercentage returns the percentage of the period that is actually billed, compared to the non-truncated period
@@ -85,14 +84,14 @@ func (r SubscriptionItemWithPeriods) GetInvoiceAt() time.Time {
 		if flatFee.PaymentTerm == productcatalog.InAdvancePaymentTerm {
 			// In advance invoicing
 			// For in advance invoicing we attempt to incoice at the start of the billing period
-			return r.BillingPeriod.Start
+			return r.BillingPeriod.From
 		}
 	}
 
 	// All other items are invoiced after the fact, meaning
 	// - not before its billing period is over
 	// - not before its service period is over
-	return lo.Latest(r.ServicePeriod.End, r.BillingPeriod.End)
+	return lo.Latest(r.ServicePeriod.To, r.BillingPeriod.To)
 }
 
 func NewPhaseIterator(logger *slog.Logger, tracer trace.Tracer, subs subscription.SubscriptionView, phaseKey string) (*PhaseIterator, error) {
@@ -156,17 +155,17 @@ func (it *PhaseIterator) GetMinimumBillableTime() time.Time {
 				}
 			} else {
 				// Let's make sure that truncation won't filter out the item
-				period := billing.Period{
-					Start: item.SubscriptionItem.ActiveFrom,
-					End:   TimeInfinity,
+				period := timeutil.ClosedPeriod{
+					From: item.SubscriptionItem.ActiveFrom,
+					To:   TimeInfinity,
 				}
 
 				if item.SubscriptionItem.ActiveTo != nil {
-					period.End = *item.SubscriptionItem.ActiveTo
+					period.To = *item.SubscriptionItem.ActiveTo
 				}
 
-				if it.phaseCadence.ActiveTo != nil && period.End.After(*it.phaseCadence.ActiveTo) {
-					period.End = *it.phaseCadence.ActiveTo
+				if it.phaseCadence.ActiveTo != nil && period.To.After(*it.phaseCadence.ActiveTo) {
+					period.To = *it.phaseCadence.ActiveTo
 				}
 
 				period = period.Truncate(streaming.MinimumWindowSizeDuration)
@@ -174,8 +173,8 @@ func (it *PhaseIterator) GetMinimumBillableTime() time.Time {
 					continue
 				}
 
-				if period.Start.Before(minTime) {
-					minTime = period.Start
+				if period.From.Before(minTime) {
+					minTime = period.From
 				}
 			}
 		}
@@ -287,7 +286,7 @@ func (it *PhaseIterator) generateForAlignedItemVersion(ctx context.Context, item
 
 			// Let's increment
 			periodIdx = periodIdx + 1
-			at = newItem.ServicePeriod.End
+			at = newItem.ServicePeriod.To
 
 			// Check if we have reached the iteration end based on invoiceAt
 			if newItem.GetInvoiceAt().After(iterationEnd) {
@@ -393,17 +392,17 @@ func (it *PhaseIterator) generateForAlignedItemVersionPeriod(ctx context.Context
 			PeriodIndex: periodIdx,
 			ItemVersion: version,
 
-			ServicePeriod: billing.Period{
-				Start: servicePeriod.From,
-				End:   servicePeriod.To,
+			ServicePeriod: timeutil.ClosedPeriod{
+				From: servicePeriod.From,
+				To:   servicePeriod.To,
 			},
-			FullServicePeriod: billing.Period{
-				Start: fullServicePeriod.From,
-				End:   fullServicePeriod.To,
+			FullServicePeriod: timeutil.ClosedPeriod{
+				From: fullServicePeriod.From,
+				To:   fullServicePeriod.To,
 			},
-			BillingPeriod: billing.Period{
-				Start: billingPeriod.From,
-				End:   billingPeriod.To,
+			BillingPeriod: timeutil.ClosedPeriod{
+				From: billingPeriod.From,
+				To:   billingPeriod.To,
 			},
 		}
 
@@ -494,17 +493,17 @@ func (it *PhaseIterator) generateOneTimeAlignedItem(item subscription.Subscripti
 		PeriodIndex: 0,
 		ItemVersion: versionID,
 
-		ServicePeriod: billing.Period{
-			Start: servicePeriod.From,
-			End:   servicePeriod.To,
+		ServicePeriod: timeutil.ClosedPeriod{
+			From: servicePeriod.From,
+			To:   servicePeriod.To,
 		},
-		FullServicePeriod: billing.Period{
-			Start: fullServicePeriod.From,
-			End:   fullServicePeriod.To,
+		FullServicePeriod: timeutil.ClosedPeriod{
+			From: fullServicePeriod.From,
+			To:   fullServicePeriod.To,
 		},
-		BillingPeriod: billing.Period{
-			Start: billingPeriod.From,
-			End:   billingPeriod.To,
+		BillingPeriod: timeutil.ClosedPeriod{
+			From: billingPeriod.From,
+			To:   billingPeriod.To,
 		},
 	}, nil
 }

--- a/openmeter/billing/worker/subscriptionsync/service/targetstate/phaseiterator_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/targetstate/phaseiterator_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel/trace/noop"
 
-	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 const NotSet = ""
@@ -35,9 +35,9 @@ func (s *PhaseIteratorTestSuite) SetupSuite() {
 }
 
 type expectedIterations struct {
-	ServicePeriod     billing.Period
-	FullServicePeriod billing.Period
-	BillingPeriod     billing.Period
+	ServicePeriod     timeutil.ClosedPeriod
+	FullServicePeriod timeutil.ClosedPeriod
+	BillingPeriod     timeutil.ClosedPeriod
 	Key               string
 }
 
@@ -94,32 +94,32 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			alignedBillingCadence: datetime.MustParseDuration(s.T(), "P1D"),
 			expected: []expectedIterations{
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[1]",
 				},
@@ -141,32 +141,32 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			alignedBillingCadence: datetime.MustParseDuration(s.T(), "P1D"),
 			expected: []expectedIterations{
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[1]",
 				},
@@ -184,32 +184,32 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			alignedBillingCadence: datetime.MustParseDuration(s.T(), "P1D"),
 			expected: []expectedIterations{
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T15:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T15:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T15:00:00Z"), // billing period can never reach over phases
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T15:00:00Z"), // billing period can never reach over phases
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[1]",
 				},
@@ -233,63 +233,63 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			expected: []expectedIterations{
 				// 1d cadence
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key-1d/v[0]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key-1d/v[0]/period[1]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-03T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-03T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-03T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key-1d/v[0]/period[2]",
 				},
 				// 2d cadence
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key-2d/v[0]/period[0]",
 				},
@@ -314,32 +314,32 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			end:                   s.mustParseTime("2021-01-03T00:00:00Z"),
 			expected: []expectedIterations{
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[1]/period[0]",
 				},
@@ -363,47 +363,47 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			end:                   s.mustParseTime("2021-01-03T00:00:00Z"),
 			expected: []expectedIterations{
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T20:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T20:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[1]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T20:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T20:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[1]/period[0]",
 				},
@@ -443,65 +443,65 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			end:                   s.mustParseTime("2021-01-03T00:00:00Z"),
 			expected: []expectedIterations{
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T20:00:02Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T20:00:02Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					// billing period will follow the otherwise cadence
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[1]",
 				},
 				// 0 length service period v1 is dropped
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T20:00:02Z"),
-						End:   s.mustParseTime("2021-01-02T20:00:04Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T20:00:02Z"),
+						To:   s.mustParseTime("2021-01-02T20:00:04Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					// billing period will follow the otherwise cadence
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[2]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T20:00:04Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T20:00:04Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[3]/period[0]",
 				},
@@ -520,48 +520,48 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			end:                   s.mustParseTime("2021-01-03T00:00:00Z"),
 			expected: []expectedIterations{
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[1]",
 				},
 				{
 					// Given end is >= invoice_at only at this point
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-03T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-03T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-03T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[2]",
 				},
@@ -581,17 +581,17 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			phaseEnd: lo.ToPtr(s.mustParseTime("2021-01-05T00:00:00Z")),
 			expected: []expectedIterations{
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-05T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-05T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-05T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-05T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-05T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-05T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]",
 				},
@@ -625,94 +625,94 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			expected: []expectedIterations{
 				// In Advance
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T20:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T20:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[1]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T20:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T20:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[1]/period[0]",
 				},
 				// As we want to generate all in advance items invoicable by end time, we get an extra in advance item
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-03T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-03T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-03T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[1]/period[1]",
 				},
 				// In Arrears
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
 					Key: "subID/phase-test/arrears-key/v[0]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/arrears-key/v[0]/period[1]",
 				},
@@ -731,18 +731,18 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			expected: []expectedIterations{
 				{
 					// If there is no phase end, the service period will be an instant
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-01T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-01T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-01T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-01T00:00:00Z"),
 					},
 					// If there is no foreseeable end to the phase, we'll bill after a single iteration
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-02-01T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-02-01T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]",
 				},
@@ -762,18 +762,18 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			expected: []expectedIterations{
 				{
 					// If there is a foreseeable phase end, the service period will account for the entire phase
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-02-05T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-02-05T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-02-05T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-02-05T00:00:00Z"),
 					},
 					// Billing period still follows the aligned cadence
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-02-01T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-02-01T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]",
 				},
@@ -798,139 +798,139 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			expected: []expectedIterations{
 				// In Advance
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[1]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-03T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-03T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[2]",
 				},
 				// We will also generate for the next billing period the in advance items (as their invoice at will be next start = current end = iteration end)
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-04T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-05T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-04T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-05T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-04T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-05T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-04T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-05T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-04T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-07T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-04T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-07T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[3]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-05T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-06T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-05T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-06T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-05T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-06T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-05T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-06T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-04T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-07T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-04T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-07T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[4]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-06T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-07T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-06T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-07T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-06T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-07T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-06T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-07T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-04T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-07T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-04T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-07T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[5]",
 				},
 				// In Arrears
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
 					Key: "subID/phase-test/arrears-key/v[0]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
 					Key: "subID/phase-test/arrears-key/v[0]/period[1]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-03T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-03T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-04T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-04T00:00:00Z"),
 					},
 					Key: "subID/phase-test/arrears-key/v[0]/period[2]",
 				},
@@ -965,20 +965,20 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			},
 			expected: []expectedIterations{
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T00:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
 						// The full service period wasn't served, this will still be a month long
-						End: s.mustParseTime("2021-02-01T00:00:00Z"),
+						To: s.mustParseTime("2021-02-01T00:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
 						// If the subscription ends, of course we can bill
 						// Also, as otherwise, cadence cannot reach cross phase boundaries, which the subscription end is
-						End: s.mustParseTime("2021-01-03T00:00:00Z"),
+						To: s.mustParseTime("2021-01-03T00:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[0]",
 				},
@@ -1010,67 +1010,67 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 			expected: []expectedIterations{
 				{
 					// Service Periods will be aligned to the billing anchor
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-01T23:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-01T23:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2020-12-31T23:00:00Z"),
-						End:   s.mustParseTime("2021-01-01T23:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2020-12-31T23:00:00Z"),
+						To:   s.mustParseTime("2021-01-01T23:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
+					BillingPeriod: timeutil.ClosedPeriod{
 						// BillingPeriod cannot fall outside of subscription active period (and phase active period) so start gets truncated
-						Start: s.mustParseTime("2021-01-01T00:00:00Z"),
-						End:   s.mustParseTime("2021-01-01T23:00:00Z"),
+						From: s.mustParseTime("2021-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2021-01-01T23:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[0]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T23:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T23:00:00Z"),
 						// Item ends so does service period
-						End: s.mustParseTime("2021-01-02T20:00:00Z"),
+						To: s.mustParseTime("2021-01-02T20:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T23:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T23:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T23:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T23:00:00Z"),
 					},
 					// Billing period will be the next whole day
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T23:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T23:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T23:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T23:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[0]/period[1]",
 				},
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T20:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T23:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T20:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T23:00:00Z"),
 					},
 					// Item was changed during period so the full service period will be the same as that of the previous version
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T23:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T23:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T23:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T23:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-01T23:00:00Z"),
-						End:   s.mustParseTime("2021-01-02T23:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-01T23:00:00Z"),
+						To:   s.mustParseTime("2021-01-02T23:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[1]/period[0]",
 				},
 				// Given invoiceAt should be >= end, we have an extra in advance item
 				{
-					ServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T23:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T23:00:00Z"),
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T23:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T23:00:00Z"),
 					},
-					FullServicePeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T23:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T23:00:00Z"),
+					FullServicePeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T23:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T23:00:00Z"),
 					},
-					BillingPeriod: billing.Period{
-						Start: s.mustParseTime("2021-01-02T23:00:00Z"),
-						End:   s.mustParseTime("2021-01-03T23:00:00Z"),
+					BillingPeriod: timeutil.ClosedPeriod{
+						From: s.mustParseTime("2021-01-02T23:00:00Z"),
+						To:   s.mustParseTime("2021-01-03T23:00:00Z"),
 					},
 					Key: "subID/phase-test/item-key/v[1]/period[1]",
 				},
@@ -1264,11 +1264,11 @@ func (s *PhaseIteratorTestSuite) TestPhaseIterator() {
 					BillingPeriod:     item.BillingPeriod,
 				})
 
-				s.T().Logf("out[%d]: %s \nService Period: [%s..%s] \nFull Service Period: [%s..%s] \nBilling Period: [%s..%s]\n", i, item.UniqueID, item.ServicePeriod.Start, item.ServicePeriod.End, item.FullServicePeriod.Start, item.FullServicePeriod.End, item.BillingPeriod.Start, item.BillingPeriod.End)
+				s.T().Logf("out[%d]: %s \nService Period: [%s..%s] \nFull Service Period: [%s..%s] \nBilling Period: [%s..%s]\n", i, item.UniqueID, item.ServicePeriod.From, item.ServicePeriod.To, item.FullServicePeriod.From, item.FullServicePeriod.To, item.BillingPeriod.From, item.BillingPeriod.To)
 			}
 
 			for i, item := range tc.expected {
-				s.T().Logf("expected[%d]: %s \nService Period: [%s..%s] \nFull Service Period: [%s..%s] \nBilling Period: [%s..%s]\n", i, item.Key, item.ServicePeriod.Start, item.ServicePeriod.End, item.FullServicePeriod.Start, item.FullServicePeriod.End, item.BillingPeriod.Start, item.BillingPeriod.End)
+				s.T().Logf("expected[%d]: %s \nService Period: [%s..%s] \nFull Service Period: [%s..%s] \nBilling Period: [%s..%s]\n", i, item.Key, item.ServicePeriod.From, item.ServicePeriod.To, item.FullServicePeriod.From, item.FullServicePeriod.To, item.BillingPeriod.From, item.BillingPeriod.To)
 			}
 
 			s.ElementsMatch(tc.expected, outAsExpect)

--- a/openmeter/billing/worker/subscriptionsync/service/targetstate/targetstate.go
+++ b/openmeter/billing/worker/subscriptionsync/service/targetstate/targetstate.go
@@ -243,19 +243,19 @@ func (b Builder) correctPeriodStartForUpcomingLines(ctx context.Context, subscri
 		// TODO: Add a migration to normalize existing billing timestamps to the precision
 		// supported by meter queries.
 		continuousStart := previousServicePeriod.To.Truncate(streaming.MinimumWindowSizeDuration)
-		if line.ServicePeriod.Start.Equal(continuousStart) {
+		if line.ServicePeriod.From.Equal(continuousStart) {
 			continue
 		}
 
-		if !line.ServicePeriod.Start.Equal(line.FullServicePeriod.Start) {
+		if !line.ServicePeriod.From.Equal(line.FullServicePeriod.From) {
 			return nil, fmt.Errorf("line[%s] service period and full service period start does not match", line.UniqueID)
 		}
 
-		inScopeLines[idx].ServicePeriod.Start = continuousStart
-		inScopeLines[idx].FullServicePeriod.Start = continuousStart
+		inScopeLines[idx].ServicePeriod.From = continuousStart
+		inScopeLines[idx].FullServicePeriod.From = continuousStart
 
-		if line.FullServicePeriod.Start.Equal(line.BillingPeriod.Start) {
-			inScopeLines[idx].BillingPeriod.Start = continuousStart
+		if line.FullServicePeriod.From.Equal(line.BillingPeriod.From) {
+			inScopeLines[idx].BillingPeriod.From = continuousStart
 		}
 	}
 

--- a/openmeter/billing/worker/subscriptionsync/service/targetstate/targetstateitem.go
+++ b/openmeter/billing/worker/subscriptionsync/service/targetstate/targetstateitem.go
@@ -45,7 +45,7 @@ func (r StateItem) IsBillable() bool {
 }
 
 func (r StateItem) GetServicePeriod() timeutil.ClosedPeriod {
-	return r.ServicePeriod.ToClosedPeriod()
+	return r.ServicePeriod
 }
 
 func (r StateItem) GetExpectedLine() (*billing.GatheringLine, error) {
@@ -68,8 +68,8 @@ func (r StateItem) GetExpectedLine() (*billing.GatheringLine, error) {
 				PhaseID:        r.PhaseID,
 				ItemID:         r.SubscriptionItem.ID,
 				BillingPeriod: timeutil.ClosedPeriod{
-					From: r.BillingPeriod.Start,
-					To:   r.BillingPeriod.End,
+					From: r.BillingPeriod.From,
+					To:   r.BillingPeriod.To,
 				},
 			},
 		},
@@ -142,7 +142,7 @@ func (r StateItem) shouldProrate() bool {
 		return false
 	}
 
-	if r.Subscription.ActiveTo != nil && !r.Subscription.ActiveTo.After(r.ServicePeriod.End) {
+	if r.Subscription.ActiveTo != nil && !r.Subscription.ActiveTo.After(r.ServicePeriod.To) {
 		return false
 	}
 

--- a/openmeter/notification/internal/rule.go
+++ b/openmeter/notification/internal/rule.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type TestEventGenerator struct {
@@ -212,9 +213,9 @@ func (t *TestEventGenerator) newTestInvoicePayload(ctx context.Context, namespac
 				ManagedBy: billing.ManuallyManagedLine,
 
 				Name: "test flat fee",
-				Period: billing.Period{
-					Start: now.Add(-time.Hour * 24 * 30),
-					End:   now,
+				Period: timeutil.ClosedPeriod{
+					From: now.Add(-time.Hour * 24 * 30),
+					To:   now,
 				},
 				InvoiceAt: now,
 

--- a/test/app/custominvoicing/invocing_test.go
+++ b/test/app/custominvoicing/invocing_test.go
@@ -136,7 +136,7 @@ func (s *CustomInvoicingTestSuite) TestInvoicingFlowHooksEnabled() {
 				Currency: currencyx.Code(currency.HUF),
 				Lines: []billing.GatheringLine{
 					billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
-						Period: billing.Period{Start: periodStart, End: periodEnd},
+						Period: timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 
 						InvoiceAt: issueAt,
 						ManagedBy: billing.ManuallyManagedLine,
@@ -301,7 +301,7 @@ func (s *CustomInvoicingTestSuite) TestInvoicingFlowPaymentStatusOnly() {
 				Currency: currencyx.Code(currency.HUF),
 				Lines: []billing.GatheringLine{
 					billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
-						Period: billing.Period{Start: periodStart, End: periodEnd},
+						Period: timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 
 						InvoiceAt: issueAt,
 						ManagedBy: billing.ManuallyManagedLine,

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -1290,7 +1290,7 @@ func (s *StripeInvoiceTestSuite) TestSendInvoice() {
 			Currency: currencyx.Code(currency.USD),
 			Lines: []billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
-					Period:        billing.Period{Start: periodStart, End: periodEnd},
+					Period:        timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 					InvoiceAt:     periodStart,
 					Name:          "Flat fee",
 					PerUnitAmount: alpacadecimal.NewFromFloat(10),

--- a/test/billing/adapter_test.go
+++ b/test/billing/adapter_test.go
@@ -84,7 +84,7 @@ func (s *BillingAdapterTestSuite) setupInvoice(ctx context.Context, ns string) *
 
 type newLineInput struct {
 	Namespace              string
-	Period                 billing.Period
+	Period                 timeutil.ClosedPeriod
 	Invoice                *billing.StandardInvoice
 	Name                   string
 	ChildUniqueReferenceID string
@@ -105,7 +105,7 @@ func newLine(in newLineInput) *billing.StandardLine {
 			Currency:  in.Invoice.Currency,
 
 			Period:    in.Period,
-			InvoiceAt: in.Period.End,
+			InvoiceAt: in.Period.To,
 
 			ChildUniqueReferenceID: lo.EmptyableToPtr(in.ChildUniqueReferenceID),
 		},
@@ -154,9 +154,9 @@ func (s *BillingAdapterTestSuite) TestDetailedLineHandling() {
 	ns := "ns-adapter-detailed-line"
 	// Given we have an invoice
 
-	period := billing.Period{
-		Start: lo.Must(time.Parse(time.RFC3339, "2023-01-10T00:00:00Z")),
-		End:   lo.Must(time.Parse(time.RFC3339, "2023-01-20T00:00:00Z")),
+	period := timeutil.ClosedPeriod{
+		From: lo.Must(time.Parse(time.RFC3339, "2023-01-10T00:00:00Z")),
+		To:   lo.Must(time.Parse(time.RFC3339, "2023-01-20T00:00:00Z")),
 	}
 
 	invoice := s.setupInvoice(ctx, ns)
@@ -389,9 +389,9 @@ func (s *BillingAdapterTestSuite) TestDiscountHandling() {
 	ns := "ns-adapter-discount-handling"
 	// Given we have an invoice
 
-	period := billing.Period{
-		Start: lo.Must(time.Parse(time.RFC3339, "2023-01-10T00:00:00Z")),
-		End:   lo.Must(time.Parse(time.RFC3339, "2023-01-20T00:00:00Z")),
+	period := timeutil.ClosedPeriod{
+		From: lo.Must(time.Parse(time.RFC3339, "2023-01-10T00:00:00Z")),
+		To:   lo.Must(time.Parse(time.RFC3339, "2023-01-20T00:00:00Z")),
 	}
 
 	invoice := s.setupInvoice(ctx, ns)

--- a/test/billing/collection_test.go
+++ b/test/billing/collection_test.go
@@ -236,7 +236,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeOnly() {
 			name:      "flat fee only",
 			namespace: "ns-collection-flow-flat-fee",
 			line: billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
-				Period:    billing.Period{Start: periodStart, End: periodEnd},
+				Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 				InvoiceAt: periodStart,
 				Name:      "Flat fee",
 
@@ -248,7 +248,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeOnly() {
 			name:      "ubp flat fee only",
 			namespace: "ns-collection-flow-ubp-flat-fee",
 			line: billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
-				Period:    billing.Period{Start: periodStart, End: periodEnd},
+				Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 				InvoiceAt: periodStart,
 				Name:      "Flat fee",
 
@@ -372,9 +372,9 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeEditing() {
 	invoice, err = s.BillingService.UpdateStandardInvoice(ctx, billing.UpdateStandardInvoiceInput{
 		Invoice: invoice.GetInvoiceID(),
 		EditFn: func(invoice *billing.StandardInvoice) error {
-			linePeriod := billing.Period{
-				Start: periodEnd.Add(time.Hour * 1),
-				End:   periodEnd.Add(time.Hour * 2),
+			linePeriod := timeutil.ClosedPeriod{
+				From: periodEnd.Add(time.Hour * 1),
+				To:   periodEnd.Add(time.Hour * 2),
 			}
 
 			invoice.Lines.Append(
@@ -383,7 +383,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeEditing() {
 					Currency:  currencyx.Code(currency.USD),
 					InvoiceID: invoice.ID,
 					Period:    linePeriod,
-					InvoiceAt: linePeriod.End,
+					InvoiceAt: linePeriod.To,
 					Name:      "Flat fee",
 
 					PerUnitAmount: alpacadecimal.NewFromFloat(10),
@@ -540,9 +540,9 @@ func (s *CollectionTestSuite) TestCollectionFlowWithUBPEditingExtendingCollectio
 	s.NotNil(previousSnapshot)
 
 	// When adding an UBP line with a new billing period
-	newLinePeriod := billing.Period{
-		Start: lo.Must(time.Parse(time.RFC3339, "2025-01-02T00:00:00Z")),
-		End:   lo.Must(time.Parse(time.RFC3339, "2025-01-03T00:00:00Z")),
+	newLinePeriod := timeutil.ClosedPeriod{
+		From: lo.Must(time.Parse(time.RFC3339, "2025-01-02T00:00:00Z")),
+		To:   lo.Must(time.Parse(time.RFC3339, "2025-01-03T00:00:00Z")),
 	}
 	s.Run("adding a new line extends the collection period", func() {
 		invoice, err = s.BillingService.UpdateStandardInvoice(ctx, billing.UpdateStandardInvoiceInput{
@@ -557,7 +557,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithUBPEditingExtendingCollectio
 						Currency:  currencyx.Code(currency.USD),
 						InvoiceID: invoice.ID,
 						Period:    newLinePeriod,
-						InvoiceAt: newLinePeriod.End,
+						InvoiceAt: newLinePeriod.To,
 						ManagedBy: billing.ManuallyManagedLine,
 					},
 					UsageBased: &billing.UsageBasedLine{
@@ -593,8 +593,8 @@ func (s *CollectionTestSuite) TestCollectionFlowWithUBPEditingExtendingCollectio
 	// - the invoice should have updated snapshots, quantity snapshoted at and totals
 
 	s.Run("advancing the invoice updates the snapshot", func() {
-		clock.SetTime(newLinePeriod.End.Add(time.Hour))
-		s.MockStreamingConnector.AddSimpleEvent(apiRequestsTotalFeature.Feature.Key, 1, newLinePeriod.Start.Add(time.Minute*30))
+		clock.SetTime(newLinePeriod.To.Add(time.Hour))
+		s.MockStreamingConnector.AddSimpleEvent(apiRequestsTotalFeature.Feature.Key, 1, newLinePeriod.From.Add(time.Minute*30))
 
 		invoice, err = s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
 			Invoice: invoice.GetInvoiceID(),
@@ -613,6 +613,6 @@ func (s *CollectionTestSuite) TestCollectionFlowWithUBPEditingExtendingCollectio
 		s.NotNil(invoice.QuantitySnapshotedAt)
 		s.Equal(float64(4), invoice.Totals.Amount.InexactFloat64())
 		s.NotEqual(previousSnapshot, *invoice.QuantitySnapshotedAt)
-		s.True(!invoice.QuantitySnapshotedAt.Before(newLinePeriod.End), "quantity should be snapshoted after the new line period")
+		s.True(!invoice.QuantitySnapshotedAt.Before(newLinePeriod.To), "quantity should be snapshoted after the new line period")
 	})
 }

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -137,7 +137,7 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 					billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 						Namespace: namespace,
 
-						Period:    billing.Period{Start: periodStart, End: periodEnd},
+						Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 						InvoiceAt: issueAt,
 
 						ManagedBy: billing.ManuallyManagedLine,
@@ -169,7 +169,7 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 				Currency: currencyx.Code(currency.HUF),
 				Lines: []billing.GatheringLine{
 					billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
-						Period: billing.Period{Start: periodStart, End: periodEnd},
+						Period: timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 
 						InvoiceAt: issueAt,
 						ManagedBy: billing.ManuallyManagedLine,
@@ -420,7 +420,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 			Lines: []billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 					Namespace: namespace,
-					Period:    billing.Period{Start: periodStart, End: periodEnd},
+					Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 
 					InvoiceAt: line1IssueAt,
 
@@ -437,7 +437,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 				}),
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 					Namespace: namespace,
-					Period:    billing.Period{Start: periodStart, End: periodEnd},
+					Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 
 					InvoiceAt: line2IssueAt,
 
@@ -601,7 +601,7 @@ func (s *InvoicingTestSuite) TestCreateInvoice() {
 					billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 						Name:      "Test item1",
 						Namespace: namespace,
-						Period:    billing.Period{Start: periodStart, End: periodEnd},
+						Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 
 						InvoiceAt: line1IssueAt,
 
@@ -1671,9 +1671,9 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 			tieredGraduated.ID,
 		})
 
-		expectedPeriod := billing.Period{
-			Start: truncatedPeriodStart,
-			End:   truncatedPeriodStart.Add(time.Hour),
+		expectedPeriod := timeutil.ClosedPeriod{
+			From: truncatedPeriodStart,
+			To:   truncatedPeriodStart.Add(time.Hour),
 		}
 		for _, line := range invoiceLines {
 			require.True(s.T(), expectedPeriod.Equal(line.Period), "period should be changed for the line items")
@@ -1971,9 +1971,9 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 			tieredGraduated.ID,
 		})
 
-		expectedPeriod := billing.Period{
-			Start: truncatedPeriodStart.Add(time.Hour),
-			End:   truncatedPeriodStart.Add(2 * time.Hour),
+		expectedPeriod := timeutil.ClosedPeriod{
+			From: truncatedPeriodStart.Add(time.Hour),
+			To:   truncatedPeriodStart.Add(2 * time.Hour),
 		}
 		for _, line := range invoiceLines {
 			require.True(s.T(), expectedPeriod.Equal(line.Period), "period should be changed for the line items")
@@ -1984,7 +1984,7 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 		s.NotNil(tieredGraduated.SplitLineHierarchy)
 		tieredGraduatedHierarchy := tieredGraduated.SplitLineHierarchy
 
-		require.True(s.T(), tieredGraduatedHierarchy.Group.ServicePeriod.ToClosedPeriod().Equal(lines.tieredGraduated.ServicePeriod))
+		require.True(s.T(), tieredGraduatedHierarchy.Group.ServicePeriod.Equal(lines.tieredGraduated.ServicePeriod))
 		require.Len(s.T(), tieredGraduatedHierarchy.Lines, 3, "there should be to child lines [id=%s]", tieredGraduatedHierarchy.Group.ID)
 		require.True(s.T(), tieredGraduatedHierarchy.Lines[0].Line.GetServicePeriod().Equal(timeutil.ClosedPeriod{
 			From: truncatedPeriodStart,
@@ -2175,22 +2175,22 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 			lines.tieredVolume.ID,
 		})
 
-		expectedPeriod := billing.Period{
-			Start: truncatedPeriodStart.Add(2 * time.Hour),
-			End:   truncatedPeriodEnd,
+		expectedPeriod := timeutil.ClosedPeriod{
+			From: truncatedPeriodStart.Add(2 * time.Hour),
+			To:   truncatedPeriodEnd,
 		}
 		for _, line := range []*billing.StandardLine{flatPerUnit, tieredGraduated} {
 			require.True(s.T(), expectedPeriod.Equal(line.Period), "period should be changed for the line items")
 		}
-		require.True(s.T(), tieredVolume.Period.ToClosedPeriod().Equal(lines.tieredVolume.ServicePeriod), "period should be unchanged for the tiered volume line")
-		require.True(s.T(), flatFee.Period.ToClosedPeriod().Equal(lines.flatFee.ServicePeriod), "period should be unchanged for the flat line")
+		require.True(s.T(), tieredVolume.Period.Equal(lines.tieredVolume.ServicePeriod), "period should be unchanged for the tiered volume line")
+		require.True(s.T(), flatFee.Period.Equal(lines.flatFee.ServicePeriod), "period should be unchanged for the flat line")
 
 		// Let's validate the output of the split itself: no new split should have occurred
 		s.sortedSplitLineGroupChildren(tieredGraduated)
 		tieredGraduatedHierarchy := tieredGraduated.SplitLineHierarchy
 		s.NotNil(tieredGraduatedHierarchy)
 
-		require.True(s.T(), tieredGraduatedHierarchy.Group.ServicePeriod.ToClosedPeriod().Equal(lines.tieredGraduated.ServicePeriod))
+		require.True(s.T(), tieredGraduatedHierarchy.Group.ServicePeriod.Equal(lines.tieredGraduated.ServicePeriod))
 		require.Len(s.T(), tieredGraduatedHierarchy.Lines, 3, "there should be to child lines [id=%s]", tieredGraduatedHierarchy.Group.ID)
 		require.True(s.T(), tieredGraduatedHierarchy.Lines[0].Line.GetServicePeriod().Equal(timeutil.ClosedPeriod{
 			From: truncatedPeriodStart,
@@ -2861,18 +2861,18 @@ func (s *InvoicingTestSuite) TestUBPNonProgressiveInvoicing() {
 		tieredGraduated := s.lineByID(invoiceLines, lines.tieredGraduated.ID)
 		tieredVolume := s.lineByID(invoiceLines, lines.tieredVolume.ID)
 
-		expectedPeriod := billing.Period{
-			Start: truncatedPeriodStart,
-			End:   truncatedPeriodEnd,
+		expectedPeriod := timeutil.ClosedPeriod{
+			From: truncatedPeriodStart,
+			To:   truncatedPeriodEnd,
 		}
 		for _, line := range []*billing.StandardLine{flatPerUnit, tieredGraduated, tieredVolume} {
 			require.True(s.T(), expectedPeriod.Equal(line.Period), "period should not be changed for the line items")
 		}
 
 		require.Equal(s.T(),
-			billing.Period{
-				Start: truncatedPeriodStart,
-				End:   truncatedPeriodEnd,
+			timeutil.ClosedPeriod{
+				From: truncatedPeriodStart,
+				To:   truncatedPeriodEnd,
 			},
 			flatFee.Period,
 			"period should be unchanged",
@@ -3674,7 +3674,7 @@ func (s *InvoicingTestSuite) TestProgressiveBillLate() {
 
 	line := lines[0]
 	s.Equal(line.Name, "UBP - volume")
-	s.True(line.Period.Equal(billing.Period{Start: periodStart, End: periodEnd}), "periods should equal")
+	s.True(line.Period.Equal(timeutil.ClosedPeriod{From: periodStart, To: periodEnd}), "periods should equal")
 }
 
 func (s *InvoicingTestSuite) TestProgressiveBillingOverride() {
@@ -3785,7 +3785,7 @@ func (s *InvoicingTestSuite) TestProgressiveBillingOverride() {
 
 	line := lines[0]
 	s.Equal(line.Name, "UBP - volume")
-	s.True(line.Period.Equal(billing.Period{Start: periodStart, End: periodEnd}), "periods should equal")
+	s.True(line.Period.Equal(timeutil.ClosedPeriod{From: periodStart, To: periodEnd}), "periods should equal")
 }
 
 func (s *InvoicingTestSuite) TestSortLines() {
@@ -3911,7 +3911,7 @@ func (s *InvoicingTestSuite) TestSortLines() {
 
 		line := lines[0]
 		s.Equal(line.Name, "UBP - volume")
-		s.True(line.Period.Equal(billing.Period{Start: periodStart, End: periodEnd}), "periods should equal")
+		s.True(line.Period.Equal(timeutil.ClosedPeriod{From: periodStart, To: periodEnd}), "periods should equal")
 
 		s.Len(line.DetailedLines, 4)
 
@@ -3950,7 +3950,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoicePeriodPersisting() {
 		Currency: currencyx.Code(currency.USD),
 		Lines: []billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
-				Period:    billing.Period{Start: periodStart, End: periodEnd},
+				Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 				InvoiceAt: periodStart,
 				Name:      "Flat fee",
 
@@ -3982,7 +3982,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoicePeriodPersisting() {
 		Currency: currencyx.Code(currency.USD),
 		Lines: []billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
-				Period:    billing.Period{Start: newPeriodStart, End: newPeriodEnd},
+				Period:    timeutil.ClosedPeriod{From: newPeriodStart, To: newPeriodEnd},
 				InvoiceAt: newPeriodStart,
 				Name:      "Flat fee",
 
@@ -4061,7 +4061,7 @@ func (s *InvoicingTestSuite) TestCreatePendingInvoiceLinesForDeletedCustomers() 
 		Currency: currencyx.Code(currency.USD),
 		Lines: []billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
-				Period:    billing.Period{Start: periodStart, End: periodEnd},
+				Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 				InvoiceAt: periodStart,
 				Name:      "Flat fee",
 
@@ -4098,7 +4098,7 @@ func (s *InvoicingTestSuite) TestCreatePendingInvoiceLinesForDeletedCustomers() 
 		Currency: currencyx.Code(currency.USD),
 		Lines: []billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
-				Period:        billing.Period{Start: clock.Now(), End: clock.Now().Add(time.Hour * 24)},
+				Period:        timeutil.ClosedPeriod{From: clock.Now(), To: clock.Now().Add(time.Hour * 24)},
 				InvoiceAt:     clock.Now(),
 				Name:          "Flat fee",
 				PerUnitAmount: alpacadecimal.NewFromFloat(10),
@@ -4297,7 +4297,7 @@ func (s *InvoicingTestSuite) TestGatheringInvoiceEmulation() {
 			Lines: []billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 					Namespace:     namespace,
-					Period:        billing.Period{Start: periodStart, End: periodEnd},
+					Period:        timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 					InvoiceAt:     now,
 					ManagedBy:     billing.ManuallyManagedLine,
 					Name:          "Test item1",
@@ -4332,7 +4332,7 @@ func (s *InvoicingTestSuite) TestUpdateInvoice() {
 	testLines := []billing.GatheringLine{
 		billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 			Namespace:     namespace,
-			Period:        billing.Period{Start: periodStart, End: periodEnd},
+			Period:        timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 			InvoiceAt:     now,
 			ManagedBy:     billing.ManuallyManagedLine,
 			Name:          "line-active",
@@ -4341,7 +4341,7 @@ func (s *InvoicingTestSuite) TestUpdateInvoice() {
 		}),
 		billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 			Namespace:     namespace,
-			Period:        billing.Period{Start: periodStart, End: periodEnd},
+			Period:        timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 			InvoiceAt:     now,
 			ManagedBy:     billing.ManuallyManagedLine,
 			Name:          "line-deleted",

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -58,6 +58,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 	"github.com/openmeterio/openmeter/tools/migrate"
 )
 
@@ -367,9 +368,9 @@ func (s *BaseSuite) DebugDumpStandardInvoice(h string, i billing.StandardInvoice
 	l := i.Lines.OrEmpty()
 
 	slices.SortFunc(l, func(l1, l2 *billing.StandardLine) int {
-		if l1.Period.Start.Before(l2.Period.Start) {
+		if l1.Period.From.Before(l2.Period.From) {
 			return -1
-		} else if l1.Period.Start.After(l2.Period.Start) {
+		} else if l1.Period.From.After(l2.Period.From) {
 			return 1
 		}
 		return 0
@@ -385,8 +386,8 @@ func (s *BaseSuite) DebugDumpStandardInvoice(h string, i billing.StandardInvoice
 		s.NoError(err)
 
 		s.T().Logf("usage[%s..%s] childUniqueReferenceID: %s, invoiceAt: %s, qty: %s, price: %s (total=%s) %s\n",
-			line.Period.Start.Format(time.RFC3339),
-			line.Period.End.Format(time.RFC3339),
+			line.Period.From.Format(time.RFC3339),
+			line.Period.To.Format(time.RFC3339),
 			lo.FromPtrOr(line.ChildUniqueReferenceID, "null"),
 			line.InvoiceAt.Format(time.RFC3339),
 			line.UsageBased.Quantity,
@@ -467,7 +468,7 @@ func (s *BaseSuite) CreateGatheringInvoice(t *testing.T, ctx context.Context, in
 				billing.NewFlatFeeGatheringLine(
 					billing.NewFlatFeeLineInput{
 						Namespace:     namespace,
-						Period:        billing.Period{Start: periodStart, End: periodEnd},
+						Period:        timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 						InvoiceAt:     invoiceAt,
 						ManagedBy:     billing.ManuallyManagedLine,
 						Name:          "Test item1",
@@ -482,7 +483,7 @@ func (s *BaseSuite) CreateGatheringInvoice(t *testing.T, ctx context.Context, in
 				billing.NewFlatFeeGatheringLine(
 					billing.NewFlatFeeLineInput{
 						Namespace:     namespace,
-						Period:        billing.Period{Start: periodStart, End: periodEnd},
+						Period:        timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
 						InvoiceAt:     invoiceAt,
 						ManagedBy:     billing.ManuallyManagedLine,
 						Name:          "Test item2",

--- a/test/billing/tax_test.go
+++ b/test/billing/tax_test.go
@@ -326,7 +326,7 @@ func (s *InvoicingTaxTestSuite) generateDraftInvoice(ctx context.Context, custom
 			Currency: currencyx.Code(currency.USD),
 			Lines: []billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
-					Period: billing.Period{Start: now, End: now.Add(time.Hour * 24)},
+					Period: timeutil.ClosedPeriod{From: now, To: now.Add(time.Hour * 24)},
 
 					InvoiceAt: now,
 					ManagedBy: billing.ManuallyManagedLine,

--- a/test/billing/taxcode_dual_write_test.go
+++ b/test/billing/taxcode_dual_write_test.go
@@ -529,7 +529,7 @@ func (s *TaxCodeDualWriteTestSuite) TestSnapshotTaxCodeIntoLinesOnAdvance() {
 		Lines: []billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 				Namespace:     ns,
-				Period:        billing.Period{Start: now, End: now.Add(time.Hour * 24)},
+				Period:        timeutil.ClosedPeriod{From: now, To: now.Add(time.Hour * 24)},
 				InvoiceAt:     now,
 				ManagedBy:     billing.ManuallyManagedLine,
 				Name:          "nil-taxconfig line",
@@ -685,7 +685,7 @@ func (s *TaxCodeDualWriteTestSuite) TestSimulateInvoiceReadOnly() {
 
 	line := billing.NewFlatFeeLine(billing.NewFlatFeeLineInput{
 		Namespace:     ns,
-		Period:        billing.Period{Start: now, End: now.Add(time.Hour * 24)},
+		Period:        timeutil.ClosedPeriod{From: now, To: now.Add(time.Hour * 24)},
 		InvoiceAt:     now,
 		Name:          "simulate line",
 		PerUnitAmount: alpacadecimal.NewFromFloat(100),

--- a/test/billing/ubpflatfee_test.go
+++ b/test/billing/ubpflatfee_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type UBPFlatFeeLineTestSuite struct {
@@ -40,15 +41,15 @@ func (s *UBPFlatFeeLineTestSuite) TestPendingLineCreation() {
 	// When we create a pending fee line using the usage based flat fee line
 	// Then the gathering invoice should be created
 
-	period := billing.Period{
-		Start: clockBase,
-		End:   clockBase.Add(time.Hour * 24),
+	period := timeutil.ClosedPeriod{
+		From: clockBase,
+		To:   clockBase.Add(time.Hour * 24),
 	}
 
 	s.Run("should create a pending line", func() {
 		lineIn := billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 			Period:    period,
-			InvoiceAt: period.End,
+			InvoiceAt: period.To,
 
 			Currency:      "USD",
 			Name:          "test in arrears",
@@ -101,7 +102,7 @@ func (s *UBPFlatFeeLineTestSuite) TestPendingLineCreation() {
 	// When we create a draft invoice
 	// Then the invoice should be created and should contain the line with it's detailed lines
 	s.Run("should create a draft invoice", func() {
-		clock.SetTime(period.End)
+		clock.SetTime(period.To)
 
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 			Customer: cust.GetID(),
@@ -152,9 +153,9 @@ func (s *UBPFlatFeeLineTestSuite) TestPercentageDiscount() {
 	// When we create a pending fee line using the usage based flat fee line with a percentage discount
 	// Then the final invoice should contain the amount details
 
-	period := billing.Period{
-		Start: clock.Now(),
-		End:   clock.Now().Add(time.Hour * 24),
+	period := timeutil.ClosedPeriod{
+		From: clock.Now(),
+		To:   clock.Now().Add(time.Hour * 24),
 	}
 
 	_, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
@@ -163,7 +164,7 @@ func (s *UBPFlatFeeLineTestSuite) TestPercentageDiscount() {
 		Lines: []billing.GatheringLine{
 			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 				Period:    period,
-				InvoiceAt: period.End,
+				InvoiceAt: period.To,
 
 				Name:          "test in arrears",
 				PerUnitAmount: alpacadecimal.NewFromInt(200),
@@ -181,7 +182,7 @@ func (s *UBPFlatFeeLineTestSuite) TestPercentageDiscount() {
 	})
 	s.NoError(err)
 
-	clock.SetTime(period.End)
+	clock.SetTime(period.To)
 
 	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 		Customer: cust.GetID(),
@@ -230,9 +231,9 @@ func (s *UBPFlatFeeLineTestSuite) TestValidations() {
 	cust := s.CreateTestCustomer(namespace, "test")
 	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
 
-	period := billing.Period{
-		Start: clock.Now(),
-		End:   clock.Now().Add(time.Hour * 24),
+	period := timeutil.ClosedPeriod{
+		From: clock.Now(),
+		To:   clock.Now().Add(time.Hour * 24),
 	}
 
 	s.Run("should not create line with usage discount", func() {
@@ -242,7 +243,7 @@ func (s *UBPFlatFeeLineTestSuite) TestValidations() {
 			Lines: []billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
 					Period:    period,
-					InvoiceAt: period.End,
+					InvoiceAt: period.To,
 
 					Name:          "test in arrears",
 					PerUnitAmount: alpacadecimal.NewFromInt(100),
@@ -267,11 +268,11 @@ func (s *UBPFlatFeeLineTestSuite) TestValidations() {
 			Currency: "USD",
 			Lines: []billing.GatheringLine{
 				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
-					Period: billing.Period{
-						Start: period.Start,
-						End:   period.Start,
+					Period: timeutil.ClosedPeriod{
+						From: period.From,
+						To:   period.From,
 					},
-					InvoiceAt: period.Start,
+					InvoiceAt: period.From,
 
 					Name:          "test in arrears",
 					PerUnitAmount: alpacadecimal.NewFromInt(100),

--- a/test/customer/subject.go
+++ b/test/customer/subject.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 func (s *CustomerHandlerTestSuite) TestSubjectDeletion(ctx context.Context, t *testing.T) {
@@ -381,7 +382,7 @@ func (s *CustomerHandlerTestSuite) TestMultiSubjectIntegrationFlow(ctx context.C
 		UpdatedAt:     now,
 		Namespace:     s.namespace,
 		Name:          "Integration Manual Line",
-		Period:        billing.Period{Start: periodStart, End: future},
+		Period:        timeutil.ClosedPeriod{From: periodStart, To: future},
 		InvoiceAt:     future,
 		PerUnitAmount: alpacadecimal.NewFromFloat(15),
 		PaymentTerm:   productcatalog.InArrearsPaymentTerm,


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

next patches will require it.

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated invoice and billing period representations to use a standardized period type with `From`/`To` field naming instead of `Start`/`End` across invoicing, rating, and subscription synchronization systems.
  * Consolidated period handling throughout invoices, service periods, and billing calculations for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->