### PR TITLE
fix: replace fmt.Sprintf in slog Logger.Debug with structured key-value args

### DIFF
--- a/openmeter/credit/helper.go
+++ b/openmeter/credit/helper.go
@@ -31,7 +31,7 @@ func (m *connector) GetLastValidSnapshotAt(ctx context.Context, owner models.Nam
 	if err != nil {
 		if _, ok := lo.ErrorsAs[*balance.NoSavedBalanceForOwnerError](err); ok {
 			// if no snapshot is found we have to calculate from start of time on all grants and usage
-			m.Logger.Debug(fmt.Sprintf("no saved balance found for owner %s before %s, calculating from start of time", owner.ID, at))
+			m.Logger.Debug("no saved balance found for owner, calculating from start of time", "owner", owner.ID, "at", at)
 
 			startOfMeasurement, err := m.OwnerConnector.GetStartOfMeasurement(ctx, owner)
 			if err != nil {


### PR DESCRIPTION
## Summary

Fixes #86

In slog, the message argument is a plain string — not a format string. Using `fmt.Sprintf` to build log messages is an anti-pattern that:
- Defeats the purpose of structured logging (values are embedded in the string instead of being queryable fields)
- Wastes an allocation for no benefit
- In the case of `%w`, produces incorrect output since `%w` is only meaningful in `fmt.Errorf`

### Change

In `openmeter/credit/helper.go`, replaced:
```go
m.Logger.Debug(fmt.Sprintf("no saved balance found for owner %s before %s, calculating from start of time", owner.ID, at))
```

With proper structured slog usage:
```go
m.Logger.Debug("no saved balance found for owner, calculating from start of time", "owner", owner.ID, "at", at)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal debug logging formatting for enhanced maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->