### PR TITLE
feat: add session level lockr

### DIFF
--- a/openmeter/testutils/pg_driver.go
+++ b/openmeter/testutils/pg_driver.go
@@ -57,32 +57,85 @@ type TestDB struct {
 	URL       string
 }
 
-func InitPostgresDB(t *testing.T) *TestDB {
-	t.Helper()
-
-	// Set POSTGRES_HOST to point tests at your local Postgres.
-	// For example to use the Postgres in docker compose you can run `POSTGRES_HOST=localhost go test ./internal/credit/...`
-	host := os.Getenv("POSTGRES_HOST")
-	if host == "" {
-		t.Skip("POSTGRES_HOST not set")
+func (d *TestDB) Close(t *testing.T) {
+	if err := d.EntDriver.Close(); err != nil {
+		t.Errorf("failed to close Ent driver: %v", err)
 	}
 
-	// TODO: fix migrations
-	dbConf := pgtestdb.Custom(t, pgtestdb.Config{
-		DriverName: "pgx",
-		User:       "postgres",
-		Password:   "postgres",
-		Host:       host,
-		Port:       "5432",
-		Options:    "sslmode=disable",
-	}, &NoopMigrator{})
+	if err := d.PGDriver.Close(); err != nil {
+		t.Errorf("failed to close Postgres driver: %v", err)
+	}
+}
+
+type options struct {
+	config        pgtestdb.Config
+	migrator      pgtestdb.Migrator
+	driverOptions []pgdriver.Option
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type optionFunc func(c *options)
+
+func (fn optionFunc) apply(c *options) {
+	fn(c)
+}
+
+func WithPostgresConfig(config pgtestdb.Config) Option {
+	return optionFunc(func(o *options) {
+		o.config = config
+	})
+}
+
+func WithMigrator(migrator pgtestdb.Migrator) Option {
+	return optionFunc(func(o *options) {
+		o.migrator = migrator
+	})
+}
+
+func WithDriverOptions(opts []pgdriver.Option) Option {
+	return optionFunc(func(o *options) {
+		o.driverOptions = opts
+	})
+}
+
+func InitPostgresDB(t *testing.T, opts ...Option) *TestDB {
+	t.Helper()
+
+	o := options{
+		config: pgtestdb.Config{
+			DriverName: "pgx",
+			User:       "postgres",
+			Password:   "postgres",
+			Host:       os.Getenv("POSTGRES_HOST"),
+			Port:       "5432",
+			Options:    "sslmode=disable",
+		},
+		migrator: &NoopMigrator{}, // TODO: fix migrations
+	}
+
+	for _, opt := range opts {
+		opt.apply(&o)
+	}
+
+	if o.config.Host == "" {
+		t.Skip("postgres host is not set. Either set POSTGRES_HOST environment variable or use WithPostgresConfig option")
+	}
+
+	dbConf := pgtestdb.Custom(t, o.config, o.migrator)
+	if dbConf == nil {
+		t.Fatalf("failed to get db config")
+	}
 
 	postgresDriver, err := pgdriver.NewPostgresDriver(
-		context.TODO(),
+		t.Context(),
 		dbConf.URL(),
+		o.driverOptions...,
 	)
 	if err != nil {
-		t.Fatalf("failed to get pg driver: %s", err)
+		t.Fatalf("failed to get postgres driver: %s", err)
 	}
 
 	entDriver := entdriver.NewEntPostgresDriver(postgresDriver.DB())

--- a/pkg/framework/lockr/locker.go
+++ b/pkg/framework/lockr/locker.go
@@ -73,7 +73,7 @@ func (l *Locker) lock(ctx context.Context, client *db.Tx, key Key) error {
 	}()
 
 	if err != nil {
-		return l.checkForTimeout(err)
+		return checkForTimeout(err)
 	}
 
 	// Consume the result set
@@ -82,7 +82,7 @@ func (l *Locker) lock(ctx context.Context, client *db.Tx, key Key) error {
 	}
 
 	if err := rows.Err(); err != nil {
-		return l.checkForTimeout(err)
+		return checkForTimeout(err)
 	}
 
 	return nil
@@ -90,7 +90,7 @@ func (l *Locker) lock(ctx context.Context, client *db.Tx, key Key) error {
 
 // Note: it would be great to use in-process timeouts with context.WithTimeout
 // Unfortunately, due to this https://github.com/jackc/pgx/issues/2100#issuecomment-2395092552 (context cancellation resulting in query cancellation resulting in errored tx states) we rely on the pg timeout which leaves the connection intact
-func (l *Locker) checkForTimeout(err error) error {
+func checkForTimeout(err error) error {
 	if strings.Contains(err.Error(), pgLockTimeoutErrCode) {
 		return ErrLockTimeout
 	}

--- a/pkg/framework/lockr/session.go
+++ b/pkg/framework/lockr/session.go
@@ -5,44 +5,82 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
+	"sync/atomic"
 
+	dbsql "database/sql"
+
+	"entgo.io/ent/dialect"
 	"entgo.io/ent/dialect/sql"
 
-	"github.com/openmeterio/openmeter/openmeter/ent/db"
+	"github.com/openmeterio/openmeter/pkg/framework/pgdriver"
 )
 
 var (
-	ErrNoLockAcquired = errors.New("lock could not be acquired")
-	ErrNoLockReleased = errors.New("lock could not be released")
+	ErrNoLockAcquired         = errors.New("lock could not be acquired")
+	ErrNoLockReleased         = errors.New("lock could not be released")
+	ErrSessionLockerDone      = errors.New("session locker is already closed")
+	ErrDatabaseConnectionDown = errors.New("database connection is down")
 )
 
 type Releaser func(context.Context) error
 
 type SessionLockerConfig struct {
-	Logger   *slog.Logger
-	DBClient *db.Client
+	Logger         *slog.Logger
+	PostgresDriver *pgdriver.Driver
 }
 
 type SessionLocker struct {
 	logger *slog.Logger
-	db     *db.Client
+	conn   *dbsql.Conn
+
+	closed atomic.Bool
+	closer func()
 }
 
-func NewSessionLockr(config SessionLockerConfig) *SessionLocker {
+func NewSessionLockr(config SessionLockerConfig) (*SessionLocker, error) {
+	if config.Logger == nil {
+		return nil, errors.New("logger is required")
+	}
+
+	if config.PostgresDriver == nil {
+		return nil, errors.New("postgres driver is required")
+	}
+
+	conn, err := config.PostgresDriver.DB().Conn(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get postgres connection: %w", err)
+	}
+
+	closer := sync.OnceFunc(func() {
+		if err := conn.Close(); err != nil {
+			config.Logger.Error("failed to close postgres connection", "error", err)
+		}
+	})
+
 	return &SessionLocker{
 		logger: config.Logger,
-		db:     config.DBClient,
-	}
+		conn:   conn,
+		closer: closer,
+	}, nil
 }
 
 func (l *SessionLocker) lock(ctx context.Context, key Key, nonblocking bool) (Releaser, error) {
+	if l.closed.Load() {
+		return nil, ErrSessionLockerDone
+	}
+
+	if err := l.conn.PingContext(ctx); err != nil {
+		return nil, ErrDatabaseConnectionDown
+	}
+
 	lockFunc := "pg_advisory_lock"
 
 	if nonblocking {
 		lockFunc = "pg_try_advisory_lock"
 	}
 
-	q, args := sql.Dialect(l.db.GetConfig().Driver.Dialect()).
+	q, args := sql.Dialect(dialect.Postgres).
 		SelectExpr(sql.ExprFunc(func(b *sql.Builder) {
 			b.WriteString(lockFunc)
 			b.WriteString("(")
@@ -51,7 +89,7 @@ func (l *SessionLocker) lock(ctx context.Context, key Key, nonblocking bool) (Re
 		})).
 		Query()
 
-	rows, err := l.db.QueryContext(ctx, q, args...)
+	rows, err := l.conn.QueryContext(ctx, q, args...)
 	defer func() {
 		if rows != nil {
 			if err := rows.Close(); err != nil {
@@ -99,7 +137,7 @@ func (l *SessionLocker) Lock(ctx context.Context, key Key) (Releaser, error) {
 }
 
 func (l *SessionLocker) Release(ctx context.Context, key Key) error {
-	q, args := sql.Dialect(l.db.GetConfig().Driver.Dialect()).
+	q, args := sql.Dialect(dialect.Postgres).
 		SelectExpr(sql.ExprFunc(func(b *sql.Builder) {
 			b.WriteString("pg_advisory_unlock")
 			b.WriteString("(")
@@ -108,7 +146,7 @@ func (l *SessionLocker) Release(ctx context.Context, key Key) error {
 		})).
 		Query()
 
-	rows, err := l.db.QueryContext(ctx, q, args...)
+	rows, err := l.conn.QueryContext(ctx, q, args...)
 	defer func() {
 		if rows != nil {
 			if err = rows.Close(); err != nil {
@@ -134,4 +172,9 @@ func (l *SessionLocker) Release(ctx context.Context, key Key) error {
 	}
 
 	return nil
+}
+
+func (l *SessionLocker) Close() {
+	l.closer()
+	l.closed.Store(true)
 }

--- a/pkg/framework/lockr/session.go
+++ b/pkg/framework/lockr/session.go
@@ -123,8 +123,18 @@ func (l *SessionLocker) lock(ctx context.Context, key Key, nonblocking bool) (Re
 		return nil, checkForTimeout(err)
 	}
 
+	r := &struct {
+		once sync.Once
+	}{}
+
 	return func(rCtx context.Context) error {
-		return l.Release(rCtx, key)
+		var err error
+
+		r.once.Do(func() {
+			err = l.Release(rCtx, key)
+		})
+
+		return err
 	}, nil
 }
 

--- a/pkg/framework/lockr/session.go
+++ b/pkg/framework/lockr/session.go
@@ -2,16 +2,15 @@ package lockr
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
 
-	dbsql "database/sql"
-
 	"entgo.io/ent/dialect"
-	"entgo.io/ent/dialect/sql"
+	entsql "entgo.io/ent/dialect/sql"
 
 	"github.com/openmeterio/openmeter/pkg/framework/pgdriver"
 )
@@ -32,7 +31,7 @@ type SessionLockerConfig struct {
 
 type SessionLocker struct {
 	logger *slog.Logger
-	conn   *dbsql.Conn
+	conn   *sql.Conn
 
 	closed atomic.Bool
 	closer func()
@@ -80,8 +79,8 @@ func (l *SessionLocker) lock(ctx context.Context, key Key, nonblocking bool) (Re
 		lockFunc = "pg_try_advisory_lock"
 	}
 
-	q, args := sql.Dialect(dialect.Postgres).
-		SelectExpr(sql.ExprFunc(func(b *sql.Builder) {
+	q, args := entsql.Dialect(dialect.Postgres).
+		SelectExpr(entsql.ExprFunc(func(b *entsql.Builder) {
 			b.WriteString(lockFunc)
 			b.WriteString("(")
 			b.Arg(int64(key.Hash64()))
@@ -147,8 +146,8 @@ func (l *SessionLocker) Lock(ctx context.Context, key Key) (Releaser, error) {
 }
 
 func (l *SessionLocker) Release(ctx context.Context, key Key) error {
-	q, args := sql.Dialect(dialect.Postgres).
-		SelectExpr(sql.ExprFunc(func(b *sql.Builder) {
+	q, args := entsql.Dialect(dialect.Postgres).
+		SelectExpr(entsql.ExprFunc(func(b *entsql.Builder) {
 			b.WriteString("pg_advisory_unlock")
 			b.WriteString("(")
 			b.Arg(int64(key.Hash64()))

--- a/pkg/framework/lockr/session.go
+++ b/pkg/framework/lockr/session.go
@@ -1,0 +1,137 @@
+package lockr
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"entgo.io/ent/dialect/sql"
+
+	"github.com/openmeterio/openmeter/openmeter/ent/db"
+)
+
+var (
+	ErrNoLockAcquired = errors.New("lock could not be acquired")
+	ErrNoLockReleased = errors.New("lock could not be released")
+)
+
+type Releaser func(context.Context) error
+
+type SessionLockerConfig struct {
+	Logger   *slog.Logger
+	DBClient *db.Client
+}
+
+type SessionLocker struct {
+	logger *slog.Logger
+	db     *db.Client
+}
+
+func NewSessionLockr(config SessionLockerConfig) *SessionLocker {
+	return &SessionLocker{
+		logger: config.Logger,
+		db:     config.DBClient,
+	}
+}
+
+func (l *SessionLocker) lock(ctx context.Context, key Key, nonblocking bool) (Releaser, error) {
+	lockFunc := "pg_advisory_lock"
+
+	if nonblocking {
+		lockFunc = "pg_try_advisory_lock"
+	}
+
+	q, args := sql.Dialect(l.db.GetConfig().Driver.Dialect()).
+		SelectExpr(sql.ExprFunc(func(b *sql.Builder) {
+			b.WriteString(lockFunc)
+			b.WriteString("(")
+			b.Arg(int64(key.Hash64()))
+			b.WriteString(")")
+		})).
+		Query()
+
+	rows, err := l.db.QueryContext(ctx, q, args...)
+	defer func() {
+		if rows != nil {
+			if err := rows.Close(); err != nil {
+				l.logger.Warn("failed to close session-level advisory lock result", "error", err)
+			}
+		}
+	}()
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire session-level advisory lock: %w", checkForTimeout(err))
+	}
+
+	if nonblocking {
+		var locked bool
+
+		for rows.Next() {
+			if err := rows.Scan(&locked); err != nil {
+				return nil, fmt.Errorf("failed to scan session-level advisory lock result: %w", err)
+			}
+		}
+
+		if !locked {
+			return nil, ErrNoLockAcquired
+		}
+	} else {
+		for rows.Next() {
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, checkForTimeout(err)
+	}
+
+	return func(rCtx context.Context) error {
+		return l.Release(rCtx, key)
+	}, nil
+}
+
+func (l *SessionLocker) TryLock(ctx context.Context, key Key) (Releaser, error) {
+	return l.lock(ctx, key, true)
+}
+
+func (l *SessionLocker) Lock(ctx context.Context, key Key) (Releaser, error) {
+	return l.lock(ctx, key, false)
+}
+
+func (l *SessionLocker) Release(ctx context.Context, key Key) error {
+	q, args := sql.Dialect(l.db.GetConfig().Driver.Dialect()).
+		SelectExpr(sql.ExprFunc(func(b *sql.Builder) {
+			b.WriteString("pg_advisory_unlock")
+			b.WriteString("(")
+			b.Arg(int64(key.Hash64()))
+			b.WriteString(")")
+		})).
+		Query()
+
+	rows, err := l.db.QueryContext(ctx, q, args...)
+	defer func() {
+		if rows != nil {
+			if err = rows.Close(); err != nil {
+				l.logger.Warn("failed to close session-level advisory lock result", "error", err)
+			}
+		}
+	}()
+
+	if err != nil {
+		return fmt.Errorf("failed to release session-level advisory lock: %w", checkForTimeout(err))
+	}
+
+	var released bool
+
+	for rows.Next() {
+		if err = rows.Scan(&released); err != nil {
+			return fmt.Errorf("failed to scan session-level advisory lock release result: %w", err)
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		return checkForTimeout(err)
+	}
+
+	return nil
+}

--- a/pkg/framework/lockr/session.go
+++ b/pkg/framework/lockr/session.go
@@ -12,32 +12,67 @@ import (
 	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
 
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/pgdriver"
 )
 
 var (
-	ErrNoLockAcquired         = errors.New("lock could not be acquired")
-	ErrNoLockReleased         = errors.New("lock could not be released")
-	ErrSessionLockerDone      = errors.New("session locker is already closed")
-	ErrDatabaseConnectionDown = errors.New("database connection is down")
+	ErrNoLockAcquired    = errors.New("lock could not be acquired")
+	ErrNoLockReleased    = errors.New("lock could not be released")
+	ErrSessionLockerDone = errors.New("session locker is already closed")
+	ErrSessionLockerBusy = errors.New("session locker is blocked by another lock request")
 )
 
 type Releaser func(context.Context) error
+
+type releaser struct {
+	mu     sync.Mutex
+	done   bool
+	locker *SessionLocker
+	key    Key
+}
+
+func (r *releaser) release(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.done {
+		return nil
+	}
+
+	rErr := r.locker.release(ctx, r.key)
+	if rErr != nil {
+		if !errors.Is(rErr, ErrNoLockReleased) && !errors.Is(rErr, ErrSessionLockerDone) {
+			return rErr
+		}
+	}
+
+	r.done = true
+
+	// Release references to locker and key so they can be GC'd
+	r.locker = nil
+	r.key = nil
+
+	return rErr
+}
 
 type SessionLockerConfig struct {
 	Logger         *slog.Logger
 	PostgresDriver *pgdriver.Driver
 }
 
+// SessionLocker is a locker that uses PostgreSQL advisory locks to acquire locks.
+// It requires a dedicated connection to acquire locks.
 type SessionLocker struct {
 	logger *slog.Logger
 	conn   *sql.Conn
 
 	closed atomic.Bool
 	closer func()
+	mu     sync.Mutex
 }
 
-func NewSessionLockr(config SessionLockerConfig) (*SessionLocker, error) {
+func NewSessionLockr(ctx context.Context, config SessionLockerConfig) (*SessionLocker, error) {
 	if config.Logger == nil {
 		return nil, errors.New("logger is required")
 	}
@@ -46,19 +81,23 @@ func NewSessionLockr(config SessionLockerConfig) (*SessionLocker, error) {
 		return nil, errors.New("postgres driver is required")
 	}
 
-	conn, err := config.PostgresDriver.DB().Conn(context.Background())
+	conn, err := config.PostgresDriver.DB().Conn(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get postgres connection: %w", err)
 	}
 
+	id := clock.Now().UTC().UnixNano()
+
+	logger := config.Logger.With("component", "session-lockr", "id", id)
+
 	closer := sync.OnceFunc(func() {
 		if err := conn.Close(); err != nil {
-			config.Logger.Error("failed to close postgres connection", "error", err)
+			logger.Error("failed to close postgres connection", "error", err)
 		}
 	})
 
 	return &SessionLocker{
-		logger: config.Logger,
+		logger: logger,
 		conn:   conn,
 		closer: closer,
 	}, nil
@@ -67,10 +106,6 @@ func NewSessionLockr(config SessionLockerConfig) (*SessionLocker, error) {
 func (l *SessionLocker) lock(ctx context.Context, key Key, nonblocking bool) (Releaser, error) {
 	if l.closed.Load() {
 		return nil, ErrSessionLockerDone
-	}
-
-	if err := l.conn.PingContext(ctx); err != nil {
-		return nil, ErrDatabaseConnectionDown
 	}
 
 	lockFunc := "pg_advisory_lock"
@@ -101,19 +136,17 @@ func (l *SessionLocker) lock(ctx context.Context, key Key, nonblocking bool) (Re
 		return nil, fmt.Errorf("failed to acquire session-level advisory lock: %w", checkForTimeout(err))
 	}
 
-	if nonblocking {
-		var locked bool
+	var lockAcquired bool
 
+	if nonblocking {
 		for rows.Next() {
-			if err := rows.Scan(&locked); err != nil {
+			if err := rows.Scan(&lockAcquired); err != nil {
 				return nil, fmt.Errorf("failed to scan session-level advisory lock result: %w", err)
 			}
 		}
-
-		if !locked {
-			return nil, ErrNoLockAcquired
-		}
 	} else {
+		lockAcquired = true
+
 		for rows.Next() {
 		}
 	}
@@ -122,30 +155,48 @@ func (l *SessionLocker) lock(ctx context.Context, key Key, nonblocking bool) (Re
 		return nil, checkForTimeout(err)
 	}
 
-	r := &struct {
-		once sync.Once
-	}{}
+	if !lockAcquired {
+		return nil, ErrNoLockAcquired
+	}
 
-	return func(rCtx context.Context) error {
-		var err error
+	r := &releaser{
+		locker: l,
+		key:    key,
+	}
 
-		r.once.Do(func() {
-			err = l.Release(rCtx, key)
-		})
-
-		return err
-	}, nil
+	return r.release, nil
 }
 
+// TryLock attempts to acquire a lock for the given key in a non-blocking way and returns a Releaser that can be used
+// to release the lock if it is successfully acquired. The ErrNoLockAcquired is acquiring the lock is denied by the database server.
+// It may return ErrSessionLockerBusy if the SessionLocker is blocked by another caller, indicating that the lock request may be retried.
+// The ErrSessionLockerDone is returned if SessionLocker is closed, meaning it cannot be used for acquiring locks.
 func (l *SessionLocker) TryLock(ctx context.Context, key Key) (Releaser, error) {
+	mutexLocked := l.mu.TryLock()
+	if !mutexLocked {
+		return nil, ErrSessionLockerBusy
+	}
+
+	defer l.mu.Unlock()
+
 	return l.lock(ctx, key, true)
 }
 
+// Lock blocks until a lock is acquired and returns a Releaser that can be used to release the lock if it is successfully acquired.
+// The ErrNoLockAcquired is acquiring the lock is denied by the database server.
+// The ErrSessionLockerDone is returned if SessionLocker is closed, meaning it cannot be used for acquiring locks.
 func (l *SessionLocker) Lock(ctx context.Context, key Key) (Releaser, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
 	return l.lock(ctx, key, false)
 }
 
-func (l *SessionLocker) Release(ctx context.Context, key Key) error {
+func (l *SessionLocker) release(ctx context.Context, key Key) error {
+	if l.closed.Load() {
+		return ErrSessionLockerDone
+	}
+
 	q, args := entsql.Dialect(dialect.Postgres).
 		SelectExpr(entsql.ExprFunc(func(b *entsql.Builder) {
 			b.WriteString("pg_advisory_unlock")
@@ -168,10 +219,10 @@ func (l *SessionLocker) Release(ctx context.Context, key Key) error {
 		return fmt.Errorf("failed to release session-level advisory lock: %w", checkForTimeout(err))
 	}
 
-	var released bool
+	var lockReleased bool
 
 	for rows.Next() {
-		if err = rows.Scan(&released); err != nil {
+		if err = rows.Scan(&lockReleased); err != nil {
 			return fmt.Errorf("failed to scan session-level advisory lock release result: %w", err)
 		}
 	}
@@ -180,10 +231,25 @@ func (l *SessionLocker) Release(ctx context.Context, key Key) error {
 		return checkForTimeout(err)
 	}
 
+	if !lockReleased {
+		return ErrNoLockReleased
+	}
+
 	return nil
 }
 
+// Close releases all locks held by the SessionLocker and closes the underlying database connection.
 func (l *SessionLocker) Close() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.closed.Load() {
+		return
+	}
+
 	l.closer()
 	l.closed.Store(true)
+
+	// Release references to conn so it can be GC'd
+	l.conn = nil
 }

--- a/pkg/framework/lockr/session_test.go
+++ b/pkg/framework/lockr/session_test.go
@@ -312,6 +312,44 @@ func Test_SessionLocker(t *testing.T) {
 		require.NoError(t, releaser3(t.Context()))
 	})
 
+	t.Run("Releaser only releases lock once", func(t *testing.T) {
+		locker1 := newTestSessionLocker(t, testDB.URL)
+		defer locker1.Close()
+
+		locker2 := newTestSessionLocker(t, testDB.URL)
+		defer locker2.Close()
+
+		k, err := NewKey("test", "release-once")
+		require.NoError(t, err)
+
+		// Session 1 acquires the lock twice (reentrant)
+		releaser1a, err := locker1.Lock(t.Context(), k)
+		require.NoError(t, err)
+
+		releaser1b, err := locker1.Lock(t.Context(), k)
+		require.NoError(t, err)
+
+		// Release the second acquisition
+		require.NoError(t, releaser1b(t.Context()))
+
+		// Call releaser1b again — should be a no-op (sync.Once), so the first
+		// acquisition still holds the lock and session 2 cannot acquire it.
+		require.NoError(t, releaser1b(t.Context()))
+
+		// Session 2 should still be unable to acquire because session 1's first
+		// lock acquisition has not been released yet.
+		_, err = locker2.TryLock(t.Context(), k)
+		require.ErrorIs(t, err, ErrNoLockAcquired)
+
+		// Now release the first acquisition
+		require.NoError(t, releaser1a(t.Context()))
+
+		// Session 2 can now acquire the lock
+		releaser2, err := locker2.TryLock(t.Context(), k)
+		require.NoError(t, err)
+		require.NoError(t, releaser2(t.Context()))
+	})
+
 	t.Run("TryLock succeeds after blocking Lock is released", func(t *testing.T) {
 		locker1 := newTestSessionLocker(t, testDB.URL)
 		defer locker1.Close()

--- a/pkg/framework/lockr/session_test.go
+++ b/pkg/framework/lockr/session_test.go
@@ -1,0 +1,327 @@
+package lockr
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils/entdriver"
+	"github.com/openmeterio/openmeter/pkg/framework/pgdriver"
+)
+
+func newTestSessionLocker(t *testing.T, dbConn string, opts ...pgdriver.Option) *SessionLocker {
+	t.Helper()
+
+	postgresDriver, err := pgdriver.NewPostgresDriver(t.Context(), dbConn, opts...)
+	if err != nil {
+		t.Fatalf("failed to get postgres driver: %s", err)
+	}
+
+	entDriver := entdriver.NewEntPostgresDriver(postgresDriver.DB())
+
+	entClient := entDriver.Client()
+
+	t.Cleanup(func() {
+		if err := entClient.Close(); err != nil {
+			t.Errorf("failed to close ent client: %v", err)
+		}
+
+		if err := entDriver.Close(); err != nil {
+			t.Errorf("failed to close ent driver: %v", err)
+		}
+
+		if err := postgresDriver.Close(); err != nil {
+			t.Errorf("failed to close postgres driver: %v", err)
+		}
+	})
+
+	return NewSessionLockr(SessionLockerConfig{
+		Logger:   testutils.NewLogger(t),
+		DBClient: entClient,
+	})
+}
+
+func Test_SessionLocker(t *testing.T) {
+	testDB := testutils.InitPostgresDB(t)
+	t.Cleanup(func() {
+		testDB.Close(t)
+	})
+
+	t.Run("Lock and release", func(t *testing.T) {
+		locker := newTestSessionLocker(t, testDB.URL)
+
+		k, err := NewKey("test", "lock-release")
+		require.NoError(t, err)
+
+		releaser, err := locker.Lock(t.Context(), k)
+		require.NoError(t, err)
+		require.NotNil(t, releaser)
+
+		err = releaser(t.Context())
+		require.NoError(t, err)
+	})
+
+	t.Run("TryLock and release", func(t *testing.T) {
+		locker := newTestSessionLocker(t, testDB.URL)
+
+		k, err := NewKey("test", "trylock-release")
+		require.NoError(t, err)
+
+		releaser, err := locker.TryLock(t.Context(), k)
+		require.NoError(t, err)
+		require.NotNil(t, releaser)
+
+		err = releaser(t.Context())
+		require.NoError(t, err)
+	})
+
+	t.Run("Same session can acquire the same lock twice", func(t *testing.T) {
+		locker := newTestSessionLocker(t, testDB.URL)
+
+		k, err := NewKey("test", "reentrant")
+		require.NoError(t, err)
+
+		releaser1, err := locker.Lock(t.Context(), k)
+		require.NoError(t, err)
+
+		releaser2, err := locker.Lock(t.Context(), k)
+		require.NoError(t, err)
+
+		// PostgreSQL session-level advisory locks are reentrant: each acquisition
+		// increments a counter and requires a matching unlock to fully release.
+		require.NoError(t, releaser2(t.Context()))
+		require.NoError(t, releaser1(t.Context()))
+	})
+
+	t.Run("TryLock fails when lock is held by another session", func(t *testing.T) {
+		locker1 := newTestSessionLocker(t, testDB.URL)
+		locker2 := newTestSessionLocker(t, testDB.URL)
+
+		k, err := NewKey("test", "trylock-contention")
+		require.NoError(t, err)
+
+		// Session 1 acquires the lock
+		releaser, err := locker1.Lock(t.Context(), k)
+		require.NoError(t, err)
+
+		// Session 2 tries to acquire the same lock non-blocking
+		_, err = locker2.TryLock(t.Context(), k)
+		require.ErrorIs(t, err, ErrNoLockAcquired)
+
+		// After session 1 releases, session 2 can acquire
+		require.NoError(t, releaser(t.Context()))
+
+		releaser2, err := locker2.TryLock(t.Context(), k)
+		require.NoError(t, err)
+		require.NoError(t, releaser2(t.Context()))
+	})
+
+	t.Run("Different keys do not conflict", func(t *testing.T) {
+		locker1 := newTestSessionLocker(t, testDB.URL)
+		locker2 := newTestSessionLocker(t, testDB.URL)
+
+		key1, err := NewKey("test", "key-a")
+		require.NoError(t, err)
+
+		key2, err := NewKey("test", "key-b")
+		require.NoError(t, err)
+
+		// Both sessions acquire different locks concurrently
+		releaser1, err := locker1.Lock(t.Context(), key1)
+		require.NoError(t, err)
+
+		releaser2, err := locker2.Lock(t.Context(), key2)
+		require.NoError(t, err)
+
+		require.NoError(t, releaser1(t.Context()))
+		require.NoError(t, releaser2(t.Context()))
+	})
+
+	t.Run("Lock blocks until released by another session", func(t *testing.T) {
+		locker1 := newTestSessionLocker(t, testDB.URL)
+		locker2 := newTestSessionLocker(t, testDB.URL)
+
+		k, err := NewKey("test", "blocking")
+		require.NoError(t, err)
+
+		// Session 1 acquires the lock
+		releaser1, err := locker1.Lock(t.Context(), k)
+		require.NoError(t, err)
+
+		// Track ordering of operations
+		events := make(chan string, 4)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		waitCh := make(chan int)
+
+		// Session 2 blocks trying to acquire the same lock
+		go func() {
+			defer wg.Done()
+
+			events <- "s2 waiting"
+			time.Sleep(50 * time.Millisecond)
+			close(waitCh)
+
+			releaser2, err := locker2.Lock(t.Context(), k)
+			assert.NoError(t, err)
+			events <- "s2 acquired"
+
+			if releaser2 != nil {
+				assert.NoError(t, releaser2(t.Context()))
+			}
+		}()
+
+		// Wait until session 2 is blocked
+		assert.Eventually(t, func() bool {
+			select {
+			case <-waitCh:
+				return true
+			default:
+				t.Log("waiting for session 2 to block")
+				return false
+			}
+		}, time.Second, 10*time.Millisecond)
+
+		events <- "s1 releasing"
+		require.NoError(t, releaser1(t.Context()))
+
+		wg.Wait()
+		close(events)
+
+		var results []string
+		for e := range events {
+			results = append(results, e)
+		}
+
+		require.Equal(t, []string{"s2 waiting", "s1 releasing", "s2 acquired"}, results)
+	})
+
+	t.Run("Release without lock is a no-op", func(t *testing.T) {
+		locker := newTestSessionLocker(t, testDB.URL)
+
+		key, err := NewKey("test", "release-noop")
+		require.NoError(t, err)
+
+		// Releasing a lock that was never acquired should not error
+		err = locker.Release(t.Context(), key)
+		require.NoError(t, err)
+	})
+
+	t.Run("Lock respects context cancellation", func(t *testing.T) {
+		locker1 := newTestSessionLocker(t, testDB.URL)
+		locker2 := newTestSessionLocker(t, testDB.URL)
+
+		k, err := NewKey("test", "ctx-cancel")
+		require.NoError(t, err)
+
+		// Session 1 holds the lock
+		releaser, err := locker1.Lock(t.Context(), k)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = releaser(t.Context())
+		})
+
+		// Session 2 tries to acquire with a short-lived context
+		ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+		defer cancel()
+
+		_, err = locker2.Lock(ctx, k)
+		require.Error(t, err)
+	})
+
+	t.Run("Lock timeout returns ErrLockTimeout", func(t *testing.T) {
+		lockTimeout := 2 * time.Second
+		opts := []pgdriver.Option{
+			pgdriver.WithLockTimeout(lockTimeout),
+		}
+
+		locker1 := newTestSessionLocker(t, testDB.URL, opts...)
+		locker2 := newTestSessionLocker(t, testDB.URL, opts...)
+
+		k, err := NewKey("test", "timeout")
+		require.NoError(t, err)
+
+		// Session 1 holds the lock
+		releaser, err := locker1.Lock(t.Context(), k)
+		require.NoError(t, err)
+
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+
+			// Session 2 blocks and eventually times out via PostgreSQL lock_timeout
+			_, err := locker2.Lock(t.Context(), k)
+			assert.ErrorIs(t, err, ErrLockTimeout)
+		}()
+
+		// Wait for session 2 to time out, then release
+		assert.Eventually(t, func() bool {
+			select {
+			case <-done:
+				return true
+			default:
+				t.Log("waiting for session 2 to block")
+				return false
+			}
+		}, 3*lockTimeout, lockTimeout)
+		require.NoError(t, releaser(t.Context()))
+	})
+
+	t.Run("Multiple locks held and released independently", func(t *testing.T) {
+		locker := newTestSessionLocker(t, testDB.URL)
+
+		key1, err := NewKey("test", "multi-a")
+		require.NoError(t, err)
+
+		key2, err := NewKey("test", "multi-b")
+		require.NoError(t, err)
+
+		key3, err := NewKey("test", "multi-c")
+		require.NoError(t, err)
+
+		releaser1, err := locker.Lock(t.Context(), key1)
+		require.NoError(t, err)
+
+		releaser2, err := locker.Lock(t.Context(), key2)
+		require.NoError(t, err)
+
+		releaser3, err := locker.Lock(t.Context(), key3)
+		require.NoError(t, err)
+
+		// Release in different order than acquired
+		require.NoError(t, releaser2(t.Context()))
+		require.NoError(t, releaser1(t.Context()))
+		require.NoError(t, releaser3(t.Context()))
+	})
+
+	t.Run("TryLock succeeds after blocking Lock is released", func(t *testing.T) {
+		locker1 := newTestSessionLocker(t, testDB.URL)
+		locker2 := newTestSessionLocker(t, testDB.URL)
+
+		k, err := NewKey("test", "trylock-after-release")
+		require.NoError(t, err)
+
+		// Session 1 acquires with blocking Lock
+		releaser, err := locker1.Lock(t.Context(), k)
+		require.NoError(t, err)
+
+		// Session 2 can't TryLock while held
+		_, err = locker2.TryLock(t.Context(), k)
+		require.ErrorIs(t, err, ErrNoLockAcquired)
+
+		// Release and retry
+		require.NoError(t, releaser(t.Context()))
+
+		releaser2, err := locker2.TryLock(t.Context(), k)
+		require.NoError(t, err)
+		require.NoError(t, releaser2(t.Context()))
+	})
+}

--- a/pkg/framework/lockr/session_test.go
+++ b/pkg/framework/lockr/session_test.go
@@ -27,7 +27,7 @@ func newTestSessionLocker(t *testing.T, dbConn string, opts ...pgdriver.Option) 
 		}
 	})
 
-	locker, err := NewSessionLockr(SessionLockerConfig{
+	locker, err := NewSessionLockr(t.Context(), SessionLockerConfig{
 		Logger:         testutils.NewLogger(t),
 		PostgresDriver: postgresDriver,
 	})
@@ -203,18 +203,6 @@ func Test_SessionLocker(t *testing.T) {
 		}
 
 		require.Equal(t, []string{"s2 waiting", "s1 releasing", "s2 acquired"}, results)
-	})
-
-	t.Run("Release without lock is a no-op", func(t *testing.T) {
-		locker := newTestSessionLocker(t, testDB.URL)
-		defer locker.Close()
-
-		key, err := NewKey("test", "release-noop")
-		require.NoError(t, err)
-
-		// Releasing a lock that was never acquired should not error
-		err = locker.Release(t.Context(), key)
-		require.NoError(t, err)
 	})
 
 	t.Run("Lock respects context cancellation", func(t *testing.T) {

--- a/pkg/framework/lockr/session_test.go
+++ b/pkg/framework/lockr/session_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/testutils"
-	"github.com/openmeterio/openmeter/pkg/framework/entutils/entdriver"
 	"github.com/openmeterio/openmeter/pkg/framework/pgdriver"
 )
 
@@ -22,28 +21,19 @@ func newTestSessionLocker(t *testing.T, dbConn string, opts ...pgdriver.Option) 
 		t.Fatalf("failed to get postgres driver: %s", err)
 	}
 
-	entDriver := entdriver.NewEntPostgresDriver(postgresDriver.DB())
-
-	entClient := entDriver.Client()
-
 	t.Cleanup(func() {
-		if err := entClient.Close(); err != nil {
-			t.Errorf("failed to close ent client: %v", err)
-		}
-
-		if err := entDriver.Close(); err != nil {
-			t.Errorf("failed to close ent driver: %v", err)
-		}
-
 		if err := postgresDriver.Close(); err != nil {
 			t.Errorf("failed to close postgres driver: %v", err)
 		}
 	})
 
-	return NewSessionLockr(SessionLockerConfig{
-		Logger:   testutils.NewLogger(t),
-		DBClient: entClient,
+	locker, err := NewSessionLockr(SessionLockerConfig{
+		Logger:         testutils.NewLogger(t),
+		PostgresDriver: postgresDriver,
 	})
+	require.NoError(t, err)
+
+	return locker
 }
 
 func Test_SessionLocker(t *testing.T) {
@@ -54,6 +44,7 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Lock and release", func(t *testing.T) {
 		locker := newTestSessionLocker(t, testDB.URL)
+		defer locker.Close()
 
 		k, err := NewKey("test", "lock-release")
 		require.NoError(t, err)
@@ -68,6 +59,7 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("TryLock and release", func(t *testing.T) {
 		locker := newTestSessionLocker(t, testDB.URL)
+		defer locker.Close()
 
 		k, err := NewKey("test", "trylock-release")
 		require.NoError(t, err)
@@ -82,6 +74,7 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Same session can acquire the same lock twice", func(t *testing.T) {
 		locker := newTestSessionLocker(t, testDB.URL)
+		defer locker.Close()
 
 		k, err := NewKey("test", "reentrant")
 		require.NoError(t, err)
@@ -100,7 +93,10 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("TryLock fails when lock is held by another session", func(t *testing.T) {
 		locker1 := newTestSessionLocker(t, testDB.URL)
+		defer locker1.Close()
+
 		locker2 := newTestSessionLocker(t, testDB.URL)
+		defer locker2.Close()
 
 		k, err := NewKey("test", "trylock-contention")
 		require.NoError(t, err)
@@ -123,7 +119,10 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Different keys do not conflict", func(t *testing.T) {
 		locker1 := newTestSessionLocker(t, testDB.URL)
+		defer locker1.Close()
+
 		locker2 := newTestSessionLocker(t, testDB.URL)
+		defer locker2.Close()
 
 		key1, err := NewKey("test", "key-a")
 		require.NoError(t, err)
@@ -144,7 +143,10 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Lock blocks until released by another session", func(t *testing.T) {
 		locker1 := newTestSessionLocker(t, testDB.URL)
+		defer locker1.Close()
+
 		locker2 := newTestSessionLocker(t, testDB.URL)
+		defer locker2.Close()
 
 		k, err := NewKey("test", "blocking")
 		require.NoError(t, err)
@@ -205,6 +207,7 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Release without lock is a no-op", func(t *testing.T) {
 		locker := newTestSessionLocker(t, testDB.URL)
+		defer locker.Close()
 
 		key, err := NewKey("test", "release-noop")
 		require.NoError(t, err)
@@ -216,7 +219,10 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Lock respects context cancellation", func(t *testing.T) {
 		locker1 := newTestSessionLocker(t, testDB.URL)
+		defer locker1.Close()
+
 		locker2 := newTestSessionLocker(t, testDB.URL)
+		defer locker2.Close()
 
 		k, err := NewKey("test", "ctx-cancel")
 		require.NoError(t, err)
@@ -243,7 +249,10 @@ func Test_SessionLocker(t *testing.T) {
 		}
 
 		locker1 := newTestSessionLocker(t, testDB.URL, opts...)
+		defer locker1.Close()
+
 		locker2 := newTestSessionLocker(t, testDB.URL, opts...)
+		defer locker2.Close()
 
 		k, err := NewKey("test", "timeout")
 		require.NoError(t, err)
@@ -277,6 +286,7 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("Multiple locks held and released independently", func(t *testing.T) {
 		locker := newTestSessionLocker(t, testDB.URL)
+		defer locker.Close()
 
 		key1, err := NewKey("test", "multi-a")
 		require.NoError(t, err)
@@ -304,7 +314,10 @@ func Test_SessionLocker(t *testing.T) {
 
 	t.Run("TryLock succeeds after blocking Lock is released", func(t *testing.T) {
 		locker1 := newTestSessionLocker(t, testDB.URL)
+		defer locker1.Close()
+
 		locker2 := newTestSessionLocker(t, testDB.URL)
+		defer locker2.Close()
 
 		k, err := NewKey("test", "trylock-after-release")
 		require.NoError(t, err)


### PR DESCRIPTION
## Overview

Add support for session-level advisory lock to `lockr` package. It has slightly different schematics than the transaction-level implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-scoped PostgreSQL advisory locking with blocking/non-blocking acquire, explicit releaser callbacks, idempotent close, and session lifecycle management.
  * Database test utilities updated to support configurable initialization and a test-aware Close.

* **Bug Fixes**
  * Improved detection and handling of lock timeouts across all error paths.

* **Tests**
  * Comprehensive integration tests covering lock lifecycle, contention, reentrancy, cancellation, timeouts, concurrency, and releaser idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->