### PR TITLE
chore: fix npm publishing

### DIFF
--- a/.github/workflows/npm-release.yaml
+++ b/.github/workflows/npm-release.yaml
@@ -26,7 +26,8 @@ permissions:
 jobs:
   publish:
     name: Publish @openmeter/sdk
-    runs-on: depot-ubuntu-latest-8
+    # npm trusted publishing with provenance currently requires a GitHub-hosted runner.
+    runs-on: ubuntu-latest
     environment: prod
 
     # npm Trusted Publishing: GitHub mints a short-lived OIDC token that npm


### PR DESCRIPTION


## Overview

npm trusted publishing with provenance currently requires a GitHub-hosted runner.

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publishing workflow configuration to use GitHub-hosted runner infrastructure, ensuring npm package distribution security and reliability standards are properly maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->