### PR TITLE
fix: settle promotional credits

### DIFF
--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -231,6 +231,30 @@ func (h *creditPurchaseHandler) issueCreditPurchase(ctx context.Context, charge 
 		})
 	}
 
+	switch charge.Intent.Settlement.Type() {
+	case chargecreditpurchase.SettlementTypePromotional:
+		// Promotional grants settle immediately through wash so the credited FBO balance
+		// does not leave an unsettled receivable behind.
+		templates = append(templates,
+			transactions.FundCustomerReceivableTemplate{
+				At:        charge.CreatedAt,
+				Amount:    charge.Intent.CreditAmount,
+				Currency:  charge.Intent.Currency,
+				CostBasis: &costBasis,
+			},
+			transactions.SettleCustomerReceivablePaymentTemplate{
+				At:        charge.CreatedAt,
+				Amount:    charge.Intent.CreditAmount,
+				Currency:  charge.Intent.Currency,
+				CostBasis: &costBasis,
+			},
+		)
+	case chargecreditpurchase.SettlementTypeExternal, chargecreditpurchase.SettlementTypeInvoice:
+		// Deferred settlement modes are handled by later lifecycle events.
+	default:
+		return ledgertransaction.GroupReference{}, fmt.Errorf("unsupported settlement type: %s", charge.Intent.Settlement.Type())
+	}
+
 	if len(templates) == 0 {
 		return ledgertransaction.GroupReference{}, nil
 	}

--- a/openmeter/ledger/chargeadapter/creditpurchase_test.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase_test.go
@@ -35,7 +35,27 @@ func TestOnPromotionalCreditPurchase(t *testing.T) {
 	)
 
 	require.True(t, env.sumBalance(t, env.fboSubAccount(t, alpacadecimal.Zero)).Equal(alpacadecimal.NewFromInt(100)))
-	require.True(t, env.sumBalance(t, env.receivableSubAccount(t, alpacadecimal.Zero)).Equal(alpacadecimal.NewFromInt(-100)))
+	require.True(t, env.sumBalance(t, env.receivableSubAccount(t, alpacadecimal.Zero)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t, alpacadecimal.Zero)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.washSubAccount(t, alpacadecimal.Zero)).Equal(alpacadecimal.NewFromInt(-100)))
+}
+
+func TestOnPromotionalCreditPurchase_BacksAdvanceBeforeTopUp(t *testing.T) {
+	env := newCreditPurchaseHandlerTestEnv(t)
+	env.createAdvanceExposure(t, alpacadecimal.NewFromInt(40))
+
+	charge := env.newPromotionalCharge(alpacadecimal.NewFromInt(100))
+	ref, err := env.handler.OnPromotionalCreditPurchase(t.Context(), charge)
+	require.NoError(t, err)
+	require.NotEmpty(t, ref.TransactionGroupID)
+
+	require.True(t, env.sumBalance(t, env.receivableSubAccount(t, alpacadecimal.Zero)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t, alpacadecimal.Zero)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.unknownReceivableSubAccount(t)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.unknownAccruedSubAccount(t)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.accruedSubAccount(t, alpacadecimal.Zero)).Equal(alpacadecimal.NewFromInt(40)))
+	require.True(t, env.sumBalance(t, env.fboSubAccount(t, alpacadecimal.Zero)).Equal(alpacadecimal.NewFromInt(60)))
+	require.True(t, env.sumBalance(t, env.washSubAccount(t, alpacadecimal.Zero)).Equal(alpacadecimal.NewFromInt(-100)))
 }
 
 func TestOnCreditPurchaseInitiated(t *testing.T) {

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -886,17 +886,14 @@ func (s *CreditsTestSuite) TestUsageBasedCreditThenInvoicePaymentLifecycle() {
 		s.NotNil(updatedCharge.Realizations[0].InvoiceUsage)
 		s.Equal(float64(7.5), updatedCharge.Realizations[0].InvoiceUsage.Totals.Total.InexactFloat64())
 
-		// Aggregate open receivable still includes the promotional grant route.
-		// At this point:
-		// - promotional grant receivable (cost basis 0) is -5
-		// - invoice-backed receivable (cost basis 1) is -7.5
-		// so the aggregate open receivable is -12.5.
-		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-5)))
+		// Promotional grants settle immediately through wash, so only the
+		// invoice-backed receivable remains open at this point.
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.Zero))
 		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-7.5)))
-		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-12.5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-7.5)))
 		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.Zero))
 		s.True(s.mustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()).Equal(alpacadecimal.NewFromFloat(12.5)))
-		s.True(s.mustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()).Equal(alpacadecimal.Zero))
+		s.True(s.mustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()).Equal(alpacadecimal.NewFromFloat(-5)))
 	})
 
 	s.Run("the payment is authorized", func() {
@@ -914,12 +911,12 @@ func (s *CreditsTestSuite) TestUsageBasedCreditThenInvoicePaymentLifecycle() {
 		s.NotNil(updatedCharge.Realizations[0].Payment.Authorized)
 		s.Nil(updatedCharge.Realizations[0].Payment.Settled)
 
-		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.Zero))
 		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-7.5)))
-		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-12.5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-7.5)))
 		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.NewFromFloat(7.5)))
 		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.NewFromFloat(7.5)))
-		s.True(s.mustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()).Equal(alpacadecimal.NewFromFloat(-7.5)))
+		s.True(s.mustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()).Equal(alpacadecimal.NewFromFloat(-12.5)))
 	})
 
 	s.Run("the payment is settled and the charge reaches final", func() {
@@ -939,12 +936,12 @@ func (s *CreditsTestSuite) TestUsageBasedCreditThenInvoicePaymentLifecycle() {
 		s.Equal(payment.StatusSettled, updatedCharge.Realizations[0].Payment.Status)
 		s.NotNil(updatedCharge.Realizations[0].Payment.Settled)
 
-		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.Zero))
 		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.Zero))
-		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.Zero))
 		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.Zero))
 		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.Zero))
-		s.True(s.mustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()).Equal(alpacadecimal.NewFromFloat(-7.5)))
+		s.True(s.mustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()).Equal(alpacadecimal.NewFromFloat(-12.5)))
 	})
 }
 


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

  Fix promotional credit grants so they settle immediately through wash instead of leaving open customer receivable.

  Previously promotional credit purchases reused the shared issuance flow and stopped after issuing +FBO / -open receivable. Because promotional grants do not have later payment lifecycle events, that left an unsettled balance on the promotional receivable route. This change keeps the shared issuance logic but, for promotional
  settlement types, appends the existing receivable funding and settlement templates so the receivable is cleared immediately.

###  What Changed

  - Updated issueCreditPurchase in openmeter/ledger/chargeadapter/creditpurchase.go
  - Kept the shared issuance path for:
      - advance receivable attribution
      - accrued cost-basis translation
      - new credit issuance
  - Added settlement-type-specific behavior inside that shared function:
      - promotional: append FundCustomerReceivableTemplate and SettleCustomerReceivablePaymentTemplate
      - external/invoice: unchanged deferred behavior
  - Added an inline comment documenting why promotional grants must settle through wash
  - Updated ledger chargeadapter tests to assert:
      - promotional grants no longer leave open receivable
      - wash carries the offset
      - advance-exposure handling still works
  - Updated test/credits/sanity_test.go to reflect the new promotional accounting model

 ### Behavioral Impact

  For promotional credit grants:

  - before: FBO +X, open receivable -X, wash unchanged
  - after: FBO +X, open receivable 0, wash -X

  External and invoice-backed credit purchase flows are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed promotional credit purchase settlement to properly distribute amounts across receivable and settlement accounts based on settlement type.
  * Added validation to detect and reject unsupported settlement types with descriptive error messaging.

* **Tests**
  * Updated test coverage for promotional credit purchase settlement scenarios.
  * Added new test case validating promotional credits with prior advance exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->