### PR TITLE
chore: fix-unique reference

### DIFF
--- a/.agents/skills/ent/SKILL.md
+++ b/.agents/skills/ent/SKILL.md
@@ -33,6 +33,7 @@ After any schema change, regenerate with `make generate` before running tests.
 - **Foreign keys** use `char(26)` schema type to match ULID IDs.
 - **Cascade deletes** use `entsql.OnDelete(entsql.Cascade)` on the parent edge.
 - **JSONB fields** use `entutils.JSONStringValueScanner` — see `openmeter/ent/schema/llmcostprice.go`.
+- **Non-empty strings at the DB layer**: `field.String(...).NotEmpty()` enforces Ent-side validation, but Atlas may still diff only `SET NOT NULL` for existing tables. If the database must reject empty strings too, add an explicit `entsql.Checks(...)` annotation in the schema or mixin alongside `NotEmpty()`.
 
 ## Regeneration
 

--- a/openmeter/billing/adapter/stdinvoicelinemapper.go
+++ b/openmeter/billing/adapter/stdinvoicelinemapper.go
@@ -175,7 +175,7 @@ func (a *adapter) mapStandardInvoiceDetailedLineFromDB(dbLine *db.BillingInvoice
 				Name:        dbLine.Name,
 				Description: dbLine.Description,
 			}),
-			ChildUniqueReferenceID: dbLine.ChildUniqueReferenceID,
+			ChildUniqueReferenceID: lo.FromPtr(dbLine.ChildUniqueReferenceID),
 			ServicePeriod: timeutil.ClosedPeriod{
 				From: dbLine.PeriodStart.In(time.UTC),
 				To:   dbLine.PeriodEnd.In(time.UTC),

--- a/openmeter/billing/adapter/stdinvoicelines.go
+++ b/openmeter/billing/adapter/stdinvoicelines.go
@@ -318,7 +318,7 @@ func (a *adapter) upsertDetailedLines(ctx context.Context, in detailedLineDiff) 
 				SetName(line.Name).
 				SetNillableDescription(line.Description).
 				SetCurrency(line.Currency).
-				SetNillableChildUniqueReferenceID(line.ChildUniqueReferenceID)
+				SetNillableChildUniqueReferenceID(lo.EmptyableToPtr(line.ChildUniqueReferenceID))
 
 			create = externalid.CreateLineExternalID(create, line.ExternalIDs)
 			create = totals.Set(create, line.Totals)
@@ -430,7 +430,7 @@ func (a *adapter) upsertDetailedLinesV2(ctx context.Context, in detailedLineDiff
 				SetCurrency(line.Currency).
 				SetQuantity(line.Quantity).
 				SetPerUnitAmount(line.PerUnitAmount).
-				SetNillableChildUniqueReferenceID(line.ChildUniqueReferenceID).
+				SetChildUniqueReferenceID(line.ChildUniqueReferenceID).
 				SetCategory(line.Category).
 				SetPaymentTerm(line.PaymentTerm).
 				SetNillableIndex(line.Index)

--- a/openmeter/billing/invoicedetailedline.go
+++ b/openmeter/billing/invoicedetailedline.go
@@ -123,7 +123,7 @@ func (l DetailedLines) Validate() error {
 
 func (l DetailedLines) GetByChildUniqueReferenceID(id string) *DetailedLine {
 	for _, dl := range l {
-		if lo.FromPtr(dl.ChildUniqueReferenceID) == id {
+		if dl.ChildUniqueReferenceID == id {
 			return &dl
 		}
 	}

--- a/openmeter/billing/models/stddetailedline/derived.gen.go
+++ b/openmeter/billing/models/stddetailedline/derived.gen.go
@@ -14,7 +14,7 @@ func deriveEqualBase(this, that *Base) bool {
 		this != nil && that != nil &&
 			deriveEqual(&this.ManagedResource, &that.ManagedResource) &&
 			this.Category == that.Category &&
-			((this.ChildUniqueReferenceID == nil && that.ChildUniqueReferenceID == nil) || (this.ChildUniqueReferenceID != nil && that.ChildUniqueReferenceID != nil && *(this.ChildUniqueReferenceID) == *(that.ChildUniqueReferenceID))) &&
+			this.ChildUniqueReferenceID == that.ChildUniqueReferenceID &&
 			((this.Index == nil && that.Index == nil) || (this.Index != nil && that.Index != nil && *(this.Index) == *(that.Index))) &&
 			this.PaymentTerm == that.PaymentTerm &&
 			this.ServicePeriod.Equal(that.ServicePeriod) &&

--- a/openmeter/billing/models/stddetailedline/mixin.go
+++ b/openmeter/billing/models/stddetailedline/mixin.go
@@ -3,6 +3,8 @@ package stddetailedline
 import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect"
+	"entgo.io/ent/dialect/entsql"
+	"entgo.io/ent/schema"
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
 	"entgo.io/ent/schema/mixin"
@@ -78,8 +80,7 @@ func (mixinBase) Fields() []ent.Field {
 		// and identifying lines created for the same reason (e.g. tiered price tier)
 		// between different invoices.
 		field.String("child_unique_reference_id").
-			Optional().
-			Nillable(),
+			NotEmpty(),
 
 		field.Other("per_unit_amount", alpacadecimal.Decimal{}).
 			SchemaType(map[string]string{
@@ -107,5 +108,13 @@ func (mixinBase) Fields() []ent.Field {
 func (mixinBase) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("tax_code_id"),
+	}
+}
+
+func (mixinBase) Annotations() []schema.Annotation {
+	return []schema.Annotation{
+		entsql.Checks(map[string]string{
+			"child_unique_reference_id_not_empty": `child_unique_reference_id <> ''`,
+		}),
 	}
 }

--- a/openmeter/billing/models/stddetailedline/model.go
+++ b/openmeter/billing/models/stddetailedline/model.go
@@ -46,7 +46,7 @@ type Base struct {
 	models.ManagedResource
 
 	Category               Category                       `json:"category"`
-	ChildUniqueReferenceID *string                        `json:"childUniqueReferenceID,omitempty"`
+	ChildUniqueReferenceID string                         `json:"childUniqueReferenceID"`
 	Index                  *int                           `json:"index,omitempty"`
 	PaymentTerm            productcatalog.PaymentTermType `json:"paymentTerm"`
 	ServicePeriod          timeutil.ClosedPeriod          `json:"servicePeriod"`
@@ -68,6 +68,10 @@ func (l Base) Validate() error {
 
 	if err := l.Category.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("category: %w", err))
+	}
+
+	if l.ChildUniqueReferenceID == "" {
+		errs = append(errs, errors.New("child unique reference id is required"))
 	}
 
 	if l.PerUnitAmount.IsNegative() {

--- a/openmeter/billing/service/invoicecalc/details.go
+++ b/openmeter/billing/service/invoicecalc/details.go
@@ -110,7 +110,7 @@ func newDetailedLines(line *billing.StandardLine, inputs ...rating.DetailedLine)
 					}),
 					ServicePeriod:          period,
 					Currency:               line.Currency,
-					ChildUniqueReferenceID: &in.ChildUniqueReferenceID,
+					ChildUniqueReferenceID: in.ChildUniqueReferenceID,
 					TaxConfig:              line.TaxConfig,
 					PaymentTerm:            lo.CoalesceOrEmpty(in.PaymentTerm, productcatalog.InArrearsPaymentTerm),
 					PerUnitAmount:          in.PerUnitAmount,

--- a/openmeter/billing/stdinvoiceline.go
+++ b/openmeter/billing/stdinvoiceline.go
@@ -815,7 +815,7 @@ func (c StandardLine) DetailedLinesWithIDReuse(l DetailedLines) DetailedLines {
 	childrenRefToLine := make(map[string]DetailedLine, len(existingItems))
 
 	for _, child := range existingItems {
-		if child.ChildUniqueReferenceID == nil {
+		if child.ChildUniqueReferenceID == "" {
 			continue
 		}
 
@@ -824,17 +824,17 @@ func (c StandardLine) DetailedLinesWithIDReuse(l DetailedLines) DetailedLines {
 			continue
 		}
 
-		childrenRefToLine[*child.ChildUniqueReferenceID] = child
+		childrenRefToLine[child.ChildUniqueReferenceID] = child
 	}
 
 	for idx := range clonedNewLines {
 		newChild := &clonedNewLines[idx]
 
-		if newChild.ChildUniqueReferenceID == nil {
+		if newChild.ChildUniqueReferenceID == "" {
 			continue
 		}
 
-		if existing, ok := childrenRefToLine[*newChild.ChildUniqueReferenceID]; ok {
+		if existing, ok := childrenRefToLine[newChild.ChildUniqueReferenceID]; ok {
 			// Let's retain the database ID to achieve an update instead of a delete/create
 			newChild.ID = existing.ID
 			newChild.FeeLineConfigID = existing.FeeLineConfigID

--- a/openmeter/ent/db/billingstandardinvoicedetailedline.go
+++ b/openmeter/ent/db/billingstandardinvoicedetailedline.go
@@ -44,7 +44,7 @@ type BillingStandardInvoiceDetailedLine struct {
 	// InvoicingAppExternalID holds the value of the "invoicing_app_external_id" field.
 	InvoicingAppExternalID *string `json:"invoicing_app_external_id,omitempty"`
 	// ChildUniqueReferenceID holds the value of the "child_unique_reference_id" field.
-	ChildUniqueReferenceID *string `json:"child_unique_reference_id,omitempty"`
+	ChildUniqueReferenceID string `json:"child_unique_reference_id,omitempty"`
 	// PerUnitAmount holds the value of the "per_unit_amount" field.
 	PerUnitAmount alpacadecimal.Decimal `json:"per_unit_amount,omitempty"`
 	// Category holds the value of the "category" field.
@@ -247,8 +247,7 @@ func (_m *BillingStandardInvoiceDetailedLine) assignValues(columns []string, val
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field child_unique_reference_id", values[i])
 			} else if value.Valid {
-				_m.ChildUniqueReferenceID = new(string)
-				*_m.ChildUniqueReferenceID = value.String
+				_m.ChildUniqueReferenceID = value.String
 			}
 		case billingstandardinvoicedetailedline.FieldPerUnitAmount:
 			if value, ok := values[i].(*alpacadecimal.Decimal); !ok {
@@ -483,10 +482,8 @@ func (_m *BillingStandardInvoiceDetailedLine) String() string {
 		builder.WriteString(*v)
 	}
 	builder.WriteString(", ")
-	if v := _m.ChildUniqueReferenceID; v != nil {
-		builder.WriteString("child_unique_reference_id=")
-		builder.WriteString(*v)
-	}
+	builder.WriteString("child_unique_reference_id=")
+	builder.WriteString(_m.ChildUniqueReferenceID)
 	builder.WriteString(", ")
 	builder.WriteString("per_unit_amount=")
 	builder.WriteString(fmt.Sprintf("%v", _m.PerUnitAmount))

--- a/openmeter/ent/db/billingstandardinvoicedetailedline/billingstandardinvoicedetailedline.go
+++ b/openmeter/ent/db/billingstandardinvoicedetailedline/billingstandardinvoicedetailedline.go
@@ -171,6 +171,8 @@ func ValidColumn(column string) bool {
 var (
 	// CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
 	CurrencyValidator func(string) error
+	// ChildUniqueReferenceIDValidator is a validator for the "child_unique_reference_id" field. It is called by the builders before save.
+	ChildUniqueReferenceIDValidator func(string) error
 	// NamespaceValidator is a validator for the "namespace" field. It is called by the builders before save.
 	NamespaceValidator func(string) error
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/openmeter/ent/db/billingstandardinvoicedetailedline/where.go
+++ b/openmeter/ent/db/billingstandardinvoicedetailedline/where.go
@@ -654,16 +654,6 @@ func ChildUniqueReferenceIDHasSuffix(v string) predicate.BillingStandardInvoiceD
 	return predicate.BillingStandardInvoiceDetailedLine(sql.FieldHasSuffix(FieldChildUniqueReferenceID, v))
 }
 
-// ChildUniqueReferenceIDIsNil applies the IsNil predicate on the "child_unique_reference_id" field.
-func ChildUniqueReferenceIDIsNil() predicate.BillingStandardInvoiceDetailedLine {
-	return predicate.BillingStandardInvoiceDetailedLine(sql.FieldIsNull(FieldChildUniqueReferenceID))
-}
-
-// ChildUniqueReferenceIDNotNil applies the NotNil predicate on the "child_unique_reference_id" field.
-func ChildUniqueReferenceIDNotNil() predicate.BillingStandardInvoiceDetailedLine {
-	return predicate.BillingStandardInvoiceDetailedLine(sql.FieldNotNull(FieldChildUniqueReferenceID))
-}
-
 // ChildUniqueReferenceIDEqualFold applies the EqualFold predicate on the "child_unique_reference_id" field.
 func ChildUniqueReferenceIDEqualFold(v string) predicate.BillingStandardInvoiceDetailedLine {
 	return predicate.BillingStandardInvoiceDetailedLine(sql.FieldEqualFold(FieldChildUniqueReferenceID, v))

--- a/openmeter/ent/db/billingstandardinvoicedetailedline_create.go
+++ b/openmeter/ent/db/billingstandardinvoicedetailedline_create.go
@@ -119,14 +119,6 @@ func (_c *BillingStandardInvoiceDetailedLineCreate) SetChildUniqueReferenceID(v 
 	return _c
 }
 
-// SetNillableChildUniqueReferenceID sets the "child_unique_reference_id" field if the given value is not nil.
-func (_c *BillingStandardInvoiceDetailedLineCreate) SetNillableChildUniqueReferenceID(v *string) *BillingStandardInvoiceDetailedLineCreate {
-	if v != nil {
-		_c.SetChildUniqueReferenceID(*v)
-	}
-	return _c
-}
-
 // SetPerUnitAmount sets the "per_unit_amount" field.
 func (_c *BillingStandardInvoiceDetailedLineCreate) SetPerUnitAmount(v alpacadecimal.Decimal) *BillingStandardInvoiceDetailedLineCreate {
 	_c.mutation.SetPerUnitAmount(v)
@@ -463,6 +455,14 @@ func (_c *BillingStandardInvoiceDetailedLineCreate) check() error {
 	if _, ok := _c.mutation.Quantity(); !ok {
 		return &ValidationError{Name: "quantity", err: errors.New(`db: missing required field "BillingStandardInvoiceDetailedLine.quantity"`)}
 	}
+	if _, ok := _c.mutation.ChildUniqueReferenceID(); !ok {
+		return &ValidationError{Name: "child_unique_reference_id", err: errors.New(`db: missing required field "BillingStandardInvoiceDetailedLine.child_unique_reference_id"`)}
+	}
+	if v, ok := _c.mutation.ChildUniqueReferenceID(); ok {
+		if err := billingstandardinvoicedetailedline.ChildUniqueReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "child_unique_reference_id", err: fmt.Errorf(`db: validator failed for field "BillingStandardInvoiceDetailedLine.child_unique_reference_id": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.PerUnitAmount(); !ok {
 		return &ValidationError{Name: "per_unit_amount", err: errors.New(`db: missing required field "BillingStandardInvoiceDetailedLine.per_unit_amount"`)}
 	}
@@ -606,7 +606,7 @@ func (_c *BillingStandardInvoiceDetailedLineCreate) createSpec() (*BillingStanda
 	}
 	if value, ok := _c.mutation.ChildUniqueReferenceID(); ok {
 		_spec.SetField(billingstandardinvoicedetailedline.FieldChildUniqueReferenceID, field.TypeString, value)
-		_node.ChildUniqueReferenceID = &value
+		_node.ChildUniqueReferenceID = value
 	}
 	if value, ok := _c.mutation.PerUnitAmount(); ok {
 		_spec.SetField(billingstandardinvoicedetailedline.FieldPerUnitAmount, field.TypeOther, value)
@@ -928,12 +928,6 @@ func (u *BillingStandardInvoiceDetailedLineUpsert) SetChildUniqueReferenceID(v s
 // UpdateChildUniqueReferenceID sets the "child_unique_reference_id" field to the value that was provided on create.
 func (u *BillingStandardInvoiceDetailedLineUpsert) UpdateChildUniqueReferenceID() *BillingStandardInvoiceDetailedLineUpsert {
 	u.SetExcluded(billingstandardinvoicedetailedline.FieldChildUniqueReferenceID)
-	return u
-}
-
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (u *BillingStandardInvoiceDetailedLineUpsert) ClearChildUniqueReferenceID() *BillingStandardInvoiceDetailedLineUpsert {
-	u.SetNull(billingstandardinvoicedetailedline.FieldChildUniqueReferenceID)
 	return u
 }
 
@@ -1425,13 +1419,6 @@ func (u *BillingStandardInvoiceDetailedLineUpsertOne) SetChildUniqueReferenceID(
 func (u *BillingStandardInvoiceDetailedLineUpsertOne) UpdateChildUniqueReferenceID() *BillingStandardInvoiceDetailedLineUpsertOne {
 	return u.Update(func(s *BillingStandardInvoiceDetailedLineUpsert) {
 		s.UpdateChildUniqueReferenceID()
-	})
-}
-
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (u *BillingStandardInvoiceDetailedLineUpsertOne) ClearChildUniqueReferenceID() *BillingStandardInvoiceDetailedLineUpsertOne {
-	return u.Update(func(s *BillingStandardInvoiceDetailedLineUpsert) {
-		s.ClearChildUniqueReferenceID()
 	})
 }
 
@@ -2139,13 +2126,6 @@ func (u *BillingStandardInvoiceDetailedLineUpsertBulk) SetChildUniqueReferenceID
 func (u *BillingStandardInvoiceDetailedLineUpsertBulk) UpdateChildUniqueReferenceID() *BillingStandardInvoiceDetailedLineUpsertBulk {
 	return u.Update(func(s *BillingStandardInvoiceDetailedLineUpsert) {
 		s.UpdateChildUniqueReferenceID()
-	})
-}
-
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (u *BillingStandardInvoiceDetailedLineUpsertBulk) ClearChildUniqueReferenceID() *BillingStandardInvoiceDetailedLineUpsertBulk {
-	return u.Update(func(s *BillingStandardInvoiceDetailedLineUpsert) {
-		s.ClearChildUniqueReferenceID()
 	})
 }
 

--- a/openmeter/ent/db/billingstandardinvoicedetailedline_update.go
+++ b/openmeter/ent/db/billingstandardinvoicedetailedline_update.go
@@ -173,12 +173,6 @@ func (_u *BillingStandardInvoiceDetailedLineUpdate) SetNillableChildUniqueRefere
 	return _u
 }
 
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (_u *BillingStandardInvoiceDetailedLineUpdate) ClearChildUniqueReferenceID() *BillingStandardInvoiceDetailedLineUpdate {
-	_u.mutation.ClearChildUniqueReferenceID()
-	return _u
-}
-
 // SetPerUnitAmount sets the "per_unit_amount" field.
 func (_u *BillingStandardInvoiceDetailedLineUpdate) SetPerUnitAmount(v alpacadecimal.Decimal) *BillingStandardInvoiceDetailedLineUpdate {
 	_u.mutation.SetPerUnitAmount(v)
@@ -618,6 +612,11 @@ func (_u *BillingStandardInvoiceDetailedLineUpdate) check() error {
 			return &ValidationError{Name: "tax_behavior", err: fmt.Errorf(`db: validator failed for field "BillingStandardInvoiceDetailedLine.tax_behavior": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.ChildUniqueReferenceID(); ok {
+		if err := billingstandardinvoicedetailedline.ChildUniqueReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "child_unique_reference_id", err: fmt.Errorf(`db: validator failed for field "BillingStandardInvoiceDetailedLine.child_unique_reference_id": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Category(); ok {
 		if err := billingstandardinvoicedetailedline.CategoryValidator(v); err != nil {
 			return &ValidationError{Name: "category", err: fmt.Errorf(`db: validator failed for field "BillingStandardInvoiceDetailedLine.category": %w`, err)}
@@ -683,9 +682,6 @@ func (_u *BillingStandardInvoiceDetailedLineUpdate) sqlSave(ctx context.Context)
 	}
 	if value, ok := _u.mutation.ChildUniqueReferenceID(); ok {
 		_spec.SetField(billingstandardinvoicedetailedline.FieldChildUniqueReferenceID, field.TypeString, value)
-	}
-	if _u.mutation.ChildUniqueReferenceIDCleared() {
-		_spec.ClearField(billingstandardinvoicedetailedline.FieldChildUniqueReferenceID, field.TypeString)
 	}
 	if value, ok := _u.mutation.PerUnitAmount(); ok {
 		_spec.SetField(billingstandardinvoicedetailedline.FieldPerUnitAmount, field.TypeOther, value)
@@ -1050,12 +1046,6 @@ func (_u *BillingStandardInvoiceDetailedLineUpdateOne) SetNillableChildUniqueRef
 	if v != nil {
 		_u.SetChildUniqueReferenceID(*v)
 	}
-	return _u
-}
-
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (_u *BillingStandardInvoiceDetailedLineUpdateOne) ClearChildUniqueReferenceID() *BillingStandardInvoiceDetailedLineUpdateOne {
-	_u.mutation.ClearChildUniqueReferenceID()
 	return _u
 }
 
@@ -1511,6 +1501,11 @@ func (_u *BillingStandardInvoiceDetailedLineUpdateOne) check() error {
 			return &ValidationError{Name: "tax_behavior", err: fmt.Errorf(`db: validator failed for field "BillingStandardInvoiceDetailedLine.tax_behavior": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.ChildUniqueReferenceID(); ok {
+		if err := billingstandardinvoicedetailedline.ChildUniqueReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "child_unique_reference_id", err: fmt.Errorf(`db: validator failed for field "BillingStandardInvoiceDetailedLine.child_unique_reference_id": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Category(); ok {
 		if err := billingstandardinvoicedetailedline.CategoryValidator(v); err != nil {
 			return &ValidationError{Name: "category", err: fmt.Errorf(`db: validator failed for field "BillingStandardInvoiceDetailedLine.category": %w`, err)}
@@ -1593,9 +1588,6 @@ func (_u *BillingStandardInvoiceDetailedLineUpdateOne) sqlSave(ctx context.Conte
 	}
 	if value, ok := _u.mutation.ChildUniqueReferenceID(); ok {
 		_spec.SetField(billingstandardinvoicedetailedline.FieldChildUniqueReferenceID, field.TypeString, value)
-	}
-	if _u.mutation.ChildUniqueReferenceIDCleared() {
-		_spec.ClearField(billingstandardinvoicedetailedline.FieldChildUniqueReferenceID, field.TypeString)
 	}
 	if value, ok := _u.mutation.PerUnitAmount(); ok {
 		_spec.SetField(billingstandardinvoicedetailedline.FieldPerUnitAmount, field.TypeOther, value)

--- a/openmeter/ent/db/chargeflatfeedetailedline.go
+++ b/openmeter/ent/db/chargeflatfeedetailedline.go
@@ -43,7 +43,7 @@ type ChargeFlatFeeDetailedLine struct {
 	// InvoicingAppExternalID holds the value of the "invoicing_app_external_id" field.
 	InvoicingAppExternalID *string `json:"invoicing_app_external_id,omitempty"`
 	// ChildUniqueReferenceID holds the value of the "child_unique_reference_id" field.
-	ChildUniqueReferenceID *string `json:"child_unique_reference_id,omitempty"`
+	ChildUniqueReferenceID string `json:"child_unique_reference_id,omitempty"`
 	// PerUnitAmount holds the value of the "per_unit_amount" field.
 	PerUnitAmount alpacadecimal.Decimal `json:"per_unit_amount,omitempty"`
 	// Category holds the value of the "category" field.
@@ -220,8 +220,7 @@ func (_m *ChargeFlatFeeDetailedLine) assignValues(columns []string, values []any
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field child_unique_reference_id", values[i])
 			} else if value.Valid {
-				_m.ChildUniqueReferenceID = new(string)
-				*_m.ChildUniqueReferenceID = value.String
+				_m.ChildUniqueReferenceID = value.String
 			}
 		case chargeflatfeedetailedline.FieldPerUnitAmount:
 			if value, ok := values[i].(*alpacadecimal.Decimal); !ok {
@@ -440,10 +439,8 @@ func (_m *ChargeFlatFeeDetailedLine) String() string {
 		builder.WriteString(*v)
 	}
 	builder.WriteString(", ")
-	if v := _m.ChildUniqueReferenceID; v != nil {
-		builder.WriteString("child_unique_reference_id=")
-		builder.WriteString(*v)
-	}
+	builder.WriteString("child_unique_reference_id=")
+	builder.WriteString(_m.ChildUniqueReferenceID)
 	builder.WriteString(", ")
 	builder.WriteString("per_unit_amount=")
 	builder.WriteString(fmt.Sprintf("%v", _m.PerUnitAmount))

--- a/openmeter/ent/db/chargeflatfeedetailedline/chargeflatfeedetailedline.go
+++ b/openmeter/ent/db/chargeflatfeedetailedline/chargeflatfeedetailedline.go
@@ -150,6 +150,8 @@ func ValidColumn(column string) bool {
 var (
 	// CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
 	CurrencyValidator func(string) error
+	// ChildUniqueReferenceIDValidator is a validator for the "child_unique_reference_id" field. It is called by the builders before save.
+	ChildUniqueReferenceIDValidator func(string) error
 	// NamespaceValidator is a validator for the "namespace" field. It is called by the builders before save.
 	NamespaceValidator func(string) error
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/openmeter/ent/db/chargeflatfeedetailedline/where.go
+++ b/openmeter/ent/db/chargeflatfeedetailedline/where.go
@@ -649,16 +649,6 @@ func ChildUniqueReferenceIDHasSuffix(v string) predicate.ChargeFlatFeeDetailedLi
 	return predicate.ChargeFlatFeeDetailedLine(sql.FieldHasSuffix(FieldChildUniqueReferenceID, v))
 }
 
-// ChildUniqueReferenceIDIsNil applies the IsNil predicate on the "child_unique_reference_id" field.
-func ChildUniqueReferenceIDIsNil() predicate.ChargeFlatFeeDetailedLine {
-	return predicate.ChargeFlatFeeDetailedLine(sql.FieldIsNull(FieldChildUniqueReferenceID))
-}
-
-// ChildUniqueReferenceIDNotNil applies the NotNil predicate on the "child_unique_reference_id" field.
-func ChildUniqueReferenceIDNotNil() predicate.ChargeFlatFeeDetailedLine {
-	return predicate.ChargeFlatFeeDetailedLine(sql.FieldNotNull(FieldChildUniqueReferenceID))
-}
-
 // ChildUniqueReferenceIDEqualFold applies the EqualFold predicate on the "child_unique_reference_id" field.
 func ChildUniqueReferenceIDEqualFold(v string) predicate.ChargeFlatFeeDetailedLine {
 	return predicate.ChargeFlatFeeDetailedLine(sql.FieldEqualFold(FieldChildUniqueReferenceID, v))

--- a/openmeter/ent/db/chargeflatfeedetailedline_create.go
+++ b/openmeter/ent/db/chargeflatfeedetailedline_create.go
@@ -117,14 +117,6 @@ func (_c *ChargeFlatFeeDetailedLineCreate) SetChildUniqueReferenceID(v string) *
 	return _c
 }
 
-// SetNillableChildUniqueReferenceID sets the "child_unique_reference_id" field if the given value is not nil.
-func (_c *ChargeFlatFeeDetailedLineCreate) SetNillableChildUniqueReferenceID(v *string) *ChargeFlatFeeDetailedLineCreate {
-	if v != nil {
-		_c.SetChildUniqueReferenceID(*v)
-	}
-	return _c
-}
-
 // SetPerUnitAmount sets the "per_unit_amount" field.
 func (_c *ChargeFlatFeeDetailedLineCreate) SetPerUnitAmount(v alpacadecimal.Decimal) *ChargeFlatFeeDetailedLineCreate {
 	_c.mutation.SetPerUnitAmount(v)
@@ -423,6 +415,14 @@ func (_c *ChargeFlatFeeDetailedLineCreate) check() error {
 	if _, ok := _c.mutation.Quantity(); !ok {
 		return &ValidationError{Name: "quantity", err: errors.New(`db: missing required field "ChargeFlatFeeDetailedLine.quantity"`)}
 	}
+	if _, ok := _c.mutation.ChildUniqueReferenceID(); !ok {
+		return &ValidationError{Name: "child_unique_reference_id", err: errors.New(`db: missing required field "ChargeFlatFeeDetailedLine.child_unique_reference_id"`)}
+	}
+	if v, ok := _c.mutation.ChildUniqueReferenceID(); ok {
+		if err := chargeflatfeedetailedline.ChildUniqueReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "child_unique_reference_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeDetailedLine.child_unique_reference_id": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.PerUnitAmount(); !ok {
 		return &ValidationError{Name: "per_unit_amount", err: errors.New(`db: missing required field "ChargeFlatFeeDetailedLine.per_unit_amount"`)}
 	}
@@ -560,7 +560,7 @@ func (_c *ChargeFlatFeeDetailedLineCreate) createSpec() (*ChargeFlatFeeDetailedL
 	}
 	if value, ok := _c.mutation.ChildUniqueReferenceID(); ok {
 		_spec.SetField(chargeflatfeedetailedline.FieldChildUniqueReferenceID, field.TypeString, value)
-		_node.ChildUniqueReferenceID = &value
+		_node.ChildUniqueReferenceID = value
 	}
 	if value, ok := _c.mutation.PerUnitAmount(); ok {
 		_spec.SetField(chargeflatfeedetailedline.FieldPerUnitAmount, field.TypeOther, value)
@@ -849,12 +849,6 @@ func (u *ChargeFlatFeeDetailedLineUpsert) SetChildUniqueReferenceID(v string) *C
 // UpdateChildUniqueReferenceID sets the "child_unique_reference_id" field to the value that was provided on create.
 func (u *ChargeFlatFeeDetailedLineUpsert) UpdateChildUniqueReferenceID() *ChargeFlatFeeDetailedLineUpsert {
 	u.SetExcluded(chargeflatfeedetailedline.FieldChildUniqueReferenceID)
-	return u
-}
-
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (u *ChargeFlatFeeDetailedLineUpsert) ClearChildUniqueReferenceID() *ChargeFlatFeeDetailedLineUpsert {
-	u.SetNull(chargeflatfeedetailedline.FieldChildUniqueReferenceID)
 	return u
 }
 
@@ -1334,13 +1328,6 @@ func (u *ChargeFlatFeeDetailedLineUpsertOne) SetChildUniqueReferenceID(v string)
 func (u *ChargeFlatFeeDetailedLineUpsertOne) UpdateChildUniqueReferenceID() *ChargeFlatFeeDetailedLineUpsertOne {
 	return u.Update(func(s *ChargeFlatFeeDetailedLineUpsert) {
 		s.UpdateChildUniqueReferenceID()
-	})
-}
-
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (u *ChargeFlatFeeDetailedLineUpsertOne) ClearChildUniqueReferenceID() *ChargeFlatFeeDetailedLineUpsertOne {
-	return u.Update(func(s *ChargeFlatFeeDetailedLineUpsert) {
-		s.ClearChildUniqueReferenceID()
 	})
 }
 
@@ -2034,13 +2021,6 @@ func (u *ChargeFlatFeeDetailedLineUpsertBulk) SetChildUniqueReferenceID(v string
 func (u *ChargeFlatFeeDetailedLineUpsertBulk) UpdateChildUniqueReferenceID() *ChargeFlatFeeDetailedLineUpsertBulk {
 	return u.Update(func(s *ChargeFlatFeeDetailedLineUpsert) {
 		s.UpdateChildUniqueReferenceID()
-	})
-}
-
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (u *ChargeFlatFeeDetailedLineUpsertBulk) ClearChildUniqueReferenceID() *ChargeFlatFeeDetailedLineUpsertBulk {
-	return u.Update(func(s *ChargeFlatFeeDetailedLineUpsert) {
-		s.ClearChildUniqueReferenceID()
 	})
 }
 

--- a/openmeter/ent/db/chargeflatfeedetailedline_update.go
+++ b/openmeter/ent/db/chargeflatfeedetailedline_update.go
@@ -171,12 +171,6 @@ func (_u *ChargeFlatFeeDetailedLineUpdate) SetNillableChildUniqueReferenceID(v *
 	return _u
 }
 
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (_u *ChargeFlatFeeDetailedLineUpdate) ClearChildUniqueReferenceID() *ChargeFlatFeeDetailedLineUpdate {
-	_u.mutation.ClearChildUniqueReferenceID()
-	return _u
-}
-
 // SetPerUnitAmount sets the "per_unit_amount" field.
 func (_u *ChargeFlatFeeDetailedLineUpdate) SetPerUnitAmount(v alpacadecimal.Decimal) *ChargeFlatFeeDetailedLineUpdate {
 	_u.mutation.SetPerUnitAmount(v)
@@ -543,6 +537,11 @@ func (_u *ChargeFlatFeeDetailedLineUpdate) check() error {
 			return &ValidationError{Name: "tax_behavior", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeDetailedLine.tax_behavior": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.ChildUniqueReferenceID(); ok {
+		if err := chargeflatfeedetailedline.ChildUniqueReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "child_unique_reference_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeDetailedLine.child_unique_reference_id": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Category(); ok {
 		if err := chargeflatfeedetailedline.CategoryValidator(v); err != nil {
 			return &ValidationError{Name: "category", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeDetailedLine.category": %w`, err)}
@@ -605,9 +604,6 @@ func (_u *ChargeFlatFeeDetailedLineUpdate) sqlSave(ctx context.Context) (_node i
 	}
 	if value, ok := _u.mutation.ChildUniqueReferenceID(); ok {
 		_spec.SetField(chargeflatfeedetailedline.FieldChildUniqueReferenceID, field.TypeString, value)
-	}
-	if _u.mutation.ChildUniqueReferenceIDCleared() {
-		_spec.ClearField(chargeflatfeedetailedline.FieldChildUniqueReferenceID, field.TypeString)
 	}
 	if value, ok := _u.mutation.PerUnitAmount(); ok {
 		_spec.SetField(chargeflatfeedetailedline.FieldPerUnitAmount, field.TypeOther, value)
@@ -898,12 +894,6 @@ func (_u *ChargeFlatFeeDetailedLineUpdateOne) SetNillableChildUniqueReferenceID(
 	if v != nil {
 		_u.SetChildUniqueReferenceID(*v)
 	}
-	return _u
-}
-
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (_u *ChargeFlatFeeDetailedLineUpdateOne) ClearChildUniqueReferenceID() *ChargeFlatFeeDetailedLineUpdateOne {
-	_u.mutation.ClearChildUniqueReferenceID()
 	return _u
 }
 
@@ -1286,6 +1276,11 @@ func (_u *ChargeFlatFeeDetailedLineUpdateOne) check() error {
 			return &ValidationError{Name: "tax_behavior", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeDetailedLine.tax_behavior": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.ChildUniqueReferenceID(); ok {
+		if err := chargeflatfeedetailedline.ChildUniqueReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "child_unique_reference_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeDetailedLine.child_unique_reference_id": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Category(); ok {
 		if err := chargeflatfeedetailedline.CategoryValidator(v); err != nil {
 			return &ValidationError{Name: "category", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeDetailedLine.category": %w`, err)}
@@ -1365,9 +1360,6 @@ func (_u *ChargeFlatFeeDetailedLineUpdateOne) sqlSave(ctx context.Context) (_nod
 	}
 	if value, ok := _u.mutation.ChildUniqueReferenceID(); ok {
 		_spec.SetField(chargeflatfeedetailedline.FieldChildUniqueReferenceID, field.TypeString, value)
-	}
-	if _u.mutation.ChildUniqueReferenceIDCleared() {
-		_spec.ClearField(chargeflatfeedetailedline.FieldChildUniqueReferenceID, field.TypeString)
 	}
 	if value, ok := _u.mutation.PerUnitAmount(); ok {
 		_spec.SetField(chargeflatfeedetailedline.FieldPerUnitAmount, field.TypeOther, value)

--- a/openmeter/ent/db/chargeusagebasedrundetailedline.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline.go
@@ -44,7 +44,7 @@ type ChargeUsageBasedRunDetailedLine struct {
 	// InvoicingAppExternalID holds the value of the "invoicing_app_external_id" field.
 	InvoicingAppExternalID *string `json:"invoicing_app_external_id,omitempty"`
 	// ChildUniqueReferenceID holds the value of the "child_unique_reference_id" field.
-	ChildUniqueReferenceID *string `json:"child_unique_reference_id,omitempty"`
+	ChildUniqueReferenceID string `json:"child_unique_reference_id,omitempty"`
 	// PerUnitAmount holds the value of the "per_unit_amount" field.
 	PerUnitAmount alpacadecimal.Decimal `json:"per_unit_amount,omitempty"`
 	// Category holds the value of the "category" field.
@@ -236,8 +236,7 @@ func (_m *ChargeUsageBasedRunDetailedLine) assignValues(columns []string, values
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field child_unique_reference_id", values[i])
 			} else if value.Valid {
-				_m.ChildUniqueReferenceID = new(string)
-				*_m.ChildUniqueReferenceID = value.String
+				_m.ChildUniqueReferenceID = value.String
 			}
 		case chargeusagebasedrundetailedline.FieldPerUnitAmount:
 			if value, ok := values[i].(*alpacadecimal.Decimal); !ok {
@@ -467,10 +466,8 @@ func (_m *ChargeUsageBasedRunDetailedLine) String() string {
 		builder.WriteString(*v)
 	}
 	builder.WriteString(", ")
-	if v := _m.ChildUniqueReferenceID; v != nil {
-		builder.WriteString("child_unique_reference_id=")
-		builder.WriteString(*v)
-	}
+	builder.WriteString("child_unique_reference_id=")
+	builder.WriteString(_m.ChildUniqueReferenceID)
 	builder.WriteString(", ")
 	builder.WriteString("per_unit_amount=")
 	builder.WriteString(fmt.Sprintf("%v", _m.PerUnitAmount))

--- a/openmeter/ent/db/chargeusagebasedrundetailedline/chargeusagebasedrundetailedline.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline/chargeusagebasedrundetailedline.go
@@ -162,6 +162,8 @@ func ValidColumn(column string) bool {
 var (
 	// CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
 	CurrencyValidator func(string) error
+	// ChildUniqueReferenceIDValidator is a validator for the "child_unique_reference_id" field. It is called by the builders before save.
+	ChildUniqueReferenceIDValidator func(string) error
 	// NamespaceValidator is a validator for the "namespace" field. It is called by the builders before save.
 	NamespaceValidator func(string) error
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.

--- a/openmeter/ent/db/chargeusagebasedrundetailedline/where.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline/where.go
@@ -654,16 +654,6 @@ func ChildUniqueReferenceIDHasSuffix(v string) predicate.ChargeUsageBasedRunDeta
 	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldHasSuffix(FieldChildUniqueReferenceID, v))
 }
 
-// ChildUniqueReferenceIDIsNil applies the IsNil predicate on the "child_unique_reference_id" field.
-func ChildUniqueReferenceIDIsNil() predicate.ChargeUsageBasedRunDetailedLine {
-	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldIsNull(FieldChildUniqueReferenceID))
-}
-
-// ChildUniqueReferenceIDNotNil applies the NotNil predicate on the "child_unique_reference_id" field.
-func ChildUniqueReferenceIDNotNil() predicate.ChargeUsageBasedRunDetailedLine {
-	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldNotNull(FieldChildUniqueReferenceID))
-}
-
 // ChildUniqueReferenceIDEqualFold applies the EqualFold predicate on the "child_unique_reference_id" field.
 func ChildUniqueReferenceIDEqualFold(v string) predicate.ChargeUsageBasedRunDetailedLine {
 	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldEqualFold(FieldChildUniqueReferenceID, v))

--- a/openmeter/ent/db/chargeusagebasedrundetailedline_create.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline_create.go
@@ -118,14 +118,6 @@ func (_c *ChargeUsageBasedRunDetailedLineCreate) SetChildUniqueReferenceID(v str
 	return _c
 }
 
-// SetNillableChildUniqueReferenceID sets the "child_unique_reference_id" field if the given value is not nil.
-func (_c *ChargeUsageBasedRunDetailedLineCreate) SetNillableChildUniqueReferenceID(v *string) *ChargeUsageBasedRunDetailedLineCreate {
-	if v != nil {
-		_c.SetChildUniqueReferenceID(*v)
-	}
-	return _c
-}
-
 // SetPerUnitAmount sets the "per_unit_amount" field.
 func (_c *ChargeUsageBasedRunDetailedLineCreate) SetPerUnitAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunDetailedLineCreate {
 	_c.mutation.SetPerUnitAmount(v)
@@ -435,6 +427,14 @@ func (_c *ChargeUsageBasedRunDetailedLineCreate) check() error {
 	if _, ok := _c.mutation.Quantity(); !ok {
 		return &ValidationError{Name: "quantity", err: errors.New(`db: missing required field "ChargeUsageBasedRunDetailedLine.quantity"`)}
 	}
+	if _, ok := _c.mutation.ChildUniqueReferenceID(); !ok {
+		return &ValidationError{Name: "child_unique_reference_id", err: errors.New(`db: missing required field "ChargeUsageBasedRunDetailedLine.child_unique_reference_id"`)}
+	}
+	if v, ok := _c.mutation.ChildUniqueReferenceID(); ok {
+		if err := chargeusagebasedrundetailedline.ChildUniqueReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "child_unique_reference_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.child_unique_reference_id": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.PerUnitAmount(); !ok {
 		return &ValidationError{Name: "per_unit_amount", err: errors.New(`db: missing required field "ChargeUsageBasedRunDetailedLine.per_unit_amount"`)}
 	}
@@ -578,7 +578,7 @@ func (_c *ChargeUsageBasedRunDetailedLineCreate) createSpec() (*ChargeUsageBased
 	}
 	if value, ok := _c.mutation.ChildUniqueReferenceID(); ok {
 		_spec.SetField(chargeusagebasedrundetailedline.FieldChildUniqueReferenceID, field.TypeString, value)
-		_node.ChildUniqueReferenceID = &value
+		_node.ChildUniqueReferenceID = value
 	}
 	if value, ok := _c.mutation.PerUnitAmount(); ok {
 		_spec.SetField(chargeusagebasedrundetailedline.FieldPerUnitAmount, field.TypeOther, value)
@@ -884,12 +884,6 @@ func (u *ChargeUsageBasedRunDetailedLineUpsert) SetChildUniqueReferenceID(v stri
 // UpdateChildUniqueReferenceID sets the "child_unique_reference_id" field to the value that was provided on create.
 func (u *ChargeUsageBasedRunDetailedLineUpsert) UpdateChildUniqueReferenceID() *ChargeUsageBasedRunDetailedLineUpsert {
 	u.SetExcluded(chargeusagebasedrundetailedline.FieldChildUniqueReferenceID)
-	return u
-}
-
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (u *ChargeUsageBasedRunDetailedLineUpsert) ClearChildUniqueReferenceID() *ChargeUsageBasedRunDetailedLineUpsert {
-	u.SetNull(chargeusagebasedrundetailedline.FieldChildUniqueReferenceID)
 	return u
 }
 
@@ -1381,13 +1375,6 @@ func (u *ChargeUsageBasedRunDetailedLineUpsertOne) SetChildUniqueReferenceID(v s
 func (u *ChargeUsageBasedRunDetailedLineUpsertOne) UpdateChildUniqueReferenceID() *ChargeUsageBasedRunDetailedLineUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
 		s.UpdateChildUniqueReferenceID()
-	})
-}
-
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (u *ChargeUsageBasedRunDetailedLineUpsertOne) ClearChildUniqueReferenceID() *ChargeUsageBasedRunDetailedLineUpsertOne {
-	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
-		s.ClearChildUniqueReferenceID()
 	})
 }
 
@@ -2095,13 +2082,6 @@ func (u *ChargeUsageBasedRunDetailedLineUpsertBulk) SetChildUniqueReferenceID(v 
 func (u *ChargeUsageBasedRunDetailedLineUpsertBulk) UpdateChildUniqueReferenceID() *ChargeUsageBasedRunDetailedLineUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
 		s.UpdateChildUniqueReferenceID()
-	})
-}
-
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (u *ChargeUsageBasedRunDetailedLineUpsertBulk) ClearChildUniqueReferenceID() *ChargeUsageBasedRunDetailedLineUpsertBulk {
-	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
-		s.ClearChildUniqueReferenceID()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebasedrundetailedline_update.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline_update.go
@@ -172,12 +172,6 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdate) SetNillableChildUniqueReference
 	return _u
 }
 
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (_u *ChargeUsageBasedRunDetailedLineUpdate) ClearChildUniqueReferenceID() *ChargeUsageBasedRunDetailedLineUpdate {
-	_u.mutation.ClearChildUniqueReferenceID()
-	return _u
-}
-
 // SetPerUnitAmount sets the "per_unit_amount" field.
 func (_u *ChargeUsageBasedRunDetailedLineUpdate) SetPerUnitAmount(v alpacadecimal.Decimal) *ChargeUsageBasedRunDetailedLineUpdate {
 	_u.mutation.SetPerUnitAmount(v)
@@ -569,6 +563,11 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdate) check() error {
 			return &ValidationError{Name: "tax_behavior", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.tax_behavior": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.ChildUniqueReferenceID(); ok {
+		if err := chargeusagebasedrundetailedline.ChildUniqueReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "child_unique_reference_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.child_unique_reference_id": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Category(); ok {
 		if err := chargeusagebasedrundetailedline.CategoryValidator(v); err != nil {
 			return &ValidationError{Name: "category", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.category": %w`, err)}
@@ -634,9 +633,6 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdate) sqlSave(ctx context.Context) (_
 	}
 	if value, ok := _u.mutation.ChildUniqueReferenceID(); ok {
 		_spec.SetField(chargeusagebasedrundetailedline.FieldChildUniqueReferenceID, field.TypeString, value)
-	}
-	if _u.mutation.ChildUniqueReferenceIDCleared() {
-		_spec.ClearField(chargeusagebasedrundetailedline.FieldChildUniqueReferenceID, field.TypeString)
 	}
 	if value, ok := _u.mutation.PerUnitAmount(); ok {
 		_spec.SetField(chargeusagebasedrundetailedline.FieldPerUnitAmount, field.TypeOther, value)
@@ -956,12 +952,6 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) SetNillableChildUniqueRefere
 	if v != nil {
 		_u.SetChildUniqueReferenceID(*v)
 	}
-	return _u
-}
-
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) ClearChildUniqueReferenceID() *ChargeUsageBasedRunDetailedLineUpdateOne {
-	_u.mutation.ClearChildUniqueReferenceID()
 	return _u
 }
 
@@ -1369,6 +1359,11 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) check() error {
 			return &ValidationError{Name: "tax_behavior", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.tax_behavior": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.ChildUniqueReferenceID(); ok {
+		if err := chargeusagebasedrundetailedline.ChildUniqueReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "child_unique_reference_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.child_unique_reference_id": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Category(); ok {
 		if err := chargeusagebasedrundetailedline.CategoryValidator(v); err != nil {
 			return &ValidationError{Name: "category", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.category": %w`, err)}
@@ -1451,9 +1446,6 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) sqlSave(ctx context.Context)
 	}
 	if value, ok := _u.mutation.ChildUniqueReferenceID(); ok {
 		_spec.SetField(chargeusagebasedrundetailedline.FieldChildUniqueReferenceID, field.TypeString, value)
-	}
-	if _u.mutation.ChildUniqueReferenceIDCleared() {
-		_spec.ClearField(chargeusagebasedrundetailedline.FieldChildUniqueReferenceID, field.TypeString)
 	}
 	if value, ok := _u.mutation.PerUnitAmount(); ok {
 		_spec.SetField(chargeusagebasedrundetailedline.FieldPerUnitAmount, field.TypeOther, value)

--- a/openmeter/ent/db/entmixinaccessor.go
+++ b/openmeter/ent/db/entmixinaccessor.go
@@ -749,7 +749,7 @@ func (e *BillingStandardInvoiceDetailedLine) GetInvoicingAppExternalID() *string
 	return e.InvoicingAppExternalID
 }
 
-func (e *BillingStandardInvoiceDetailedLine) GetChildUniqueReferenceID() *string {
+func (e *BillingStandardInvoiceDetailedLine) GetChildUniqueReferenceID() string {
 	return e.ChildUniqueReferenceID
 }
 
@@ -1337,7 +1337,7 @@ func (e *ChargeFlatFeeDetailedLine) GetInvoicingAppExternalID() *string {
 	return e.InvoicingAppExternalID
 }
 
-func (e *ChargeFlatFeeDetailedLine) GetChildUniqueReferenceID() *string {
+func (e *ChargeFlatFeeDetailedLine) GetChildUniqueReferenceID() string {
 	return e.ChildUniqueReferenceID
 }
 
@@ -1753,7 +1753,7 @@ func (e *ChargeUsageBasedRunDetailedLine) GetInvoicingAppExternalID() *string {
 	return e.InvoicingAppExternalID
 }
 
-func (e *ChargeUsageBasedRunDetailedLine) GetChildUniqueReferenceID() *string {
+func (e *ChargeUsageBasedRunDetailedLine) GetChildUniqueReferenceID() string {
 	return e.ChildUniqueReferenceID
 }
 

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1362,7 +1362,7 @@ var (
 		{Name: "service_period_end", Type: field.TypeTime},
 		{Name: "quantity", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "invoicing_app_external_id", Type: field.TypeString, Nullable: true},
-		{Name: "child_unique_reference_id", Type: field.TypeString, Nullable: true},
+		{Name: "child_unique_reference_id", Type: field.TypeString},
 		{Name: "per_unit_amount", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "category", Type: field.TypeEnum, Enums: []string{"regular", "commitment"}, Default: "regular"},
 		{Name: "payment_term", Type: field.TypeEnum, Enums: []string{"in_advance", "in_arrears"}, Default: "in_advance"},
@@ -2082,7 +2082,7 @@ var (
 		{Name: "service_period_end", Type: field.TypeTime},
 		{Name: "quantity", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "invoicing_app_external_id", Type: field.TypeString, Nullable: true},
-		{Name: "child_unique_reference_id", Type: field.TypeString, Nullable: true},
+		{Name: "child_unique_reference_id", Type: field.TypeString},
 		{Name: "per_unit_amount", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "category", Type: field.TypeEnum, Enums: []string{"regular", "commitment"}, Default: "regular"},
 		{Name: "payment_term", Type: field.TypeEnum, Enums: []string{"in_advance", "in_arrears"}, Default: "in_advance"},
@@ -2488,7 +2488,7 @@ var (
 		{Name: "service_period_end", Type: field.TypeTime},
 		{Name: "quantity", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "invoicing_app_external_id", Type: field.TypeString, Nullable: true},
-		{Name: "child_unique_reference_id", Type: field.TypeString, Nullable: true},
+		{Name: "child_unique_reference_id", Type: field.TypeString},
 		{Name: "per_unit_amount", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "category", Type: field.TypeEnum, Enums: []string{"regular", "commitment"}, Default: "regular"},
 		{Name: "payment_term", Type: field.TypeEnum, Enums: []string{"in_advance", "in_arrears"}, Default: "in_advance"},
@@ -5035,6 +5035,10 @@ func init() {
 	BillingStandardInvoiceDetailedLinesTable.ForeignKeys[0].RefTable = BillingInvoicesTable
 	BillingStandardInvoiceDetailedLinesTable.ForeignKeys[1].RefTable = BillingInvoiceLinesTable
 	BillingStandardInvoiceDetailedLinesTable.ForeignKeys[2].RefTable = TaxCodesTable
+	BillingStandardInvoiceDetailedLinesTable.Annotation = &entsql.Annotation{}
+	BillingStandardInvoiceDetailedLinesTable.Annotation.Checks = map[string]string{
+		"child_unique_reference_id_not_empty": "child_unique_reference_id <> ''",
+	}
 	BillingStandardInvoiceDetailedLineAmountDiscountsTable.ForeignKeys[0].RefTable = BillingStandardInvoiceDetailedLinesTable
 	BillingWorkflowConfigsTable.ForeignKeys[0].RefTable = TaxCodesTable
 	ChargesTable.ForeignKeys[0].RefTable = ChargeCreditPurchasesTable
@@ -5061,6 +5065,9 @@ func init() {
 	ChargeFlatFeeDetailedLineTable.Annotation = &entsql.Annotation{
 		Table: "charge_flat_fee_detailed_line",
 	}
+	ChargeFlatFeeDetailedLineTable.Annotation.Checks = map[string]string{
+		"child_unique_reference_id_not_empty": "child_unique_reference_id <> ''",
+	}
 	ChargeFlatFeeInvoicedUsagesTable.ForeignKeys[0].RefTable = BillingInvoiceLinesTable
 	ChargeFlatFeeInvoicedUsagesTable.ForeignKeys[1].RefTable = ChargeFlatFeesTable
 	ChargeFlatFeePaymentsTable.ForeignKeys[0].RefTable = BillingInvoiceLinesTable
@@ -5081,6 +5088,9 @@ func init() {
 	ChargeUsageBasedRunDetailedLineTable.ForeignKeys[2].RefTable = TaxCodesTable
 	ChargeUsageBasedRunDetailedLineTable.Annotation = &entsql.Annotation{
 		Table: "charge_usage_based_run_detailed_line",
+	}
+	ChargeUsageBasedRunDetailedLineTable.Annotation.Checks = map[string]string{
+		"child_unique_reference_id_not_empty": "child_unique_reference_id <> ''",
 	}
 	ChargeUsageBasedRunInvoicedUsagesTable.ForeignKeys[0].RefTable = ChargeUsageBasedRunsTable
 	ChargeUsageBasedRunPaymentsTable.ForeignKeys[0].RefTable = ChargeUsageBasedRunsTable

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -30868,7 +30868,7 @@ func (m *BillingStandardInvoiceDetailedLineMutation) ChildUniqueReferenceID() (r
 // OldChildUniqueReferenceID returns the old "child_unique_reference_id" field's value of the BillingStandardInvoiceDetailedLine entity.
 // If the BillingStandardInvoiceDetailedLine object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *BillingStandardInvoiceDetailedLineMutation) OldChildUniqueReferenceID(ctx context.Context) (v *string, err error) {
+func (m *BillingStandardInvoiceDetailedLineMutation) OldChildUniqueReferenceID(ctx context.Context) (v string, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldChildUniqueReferenceID is only allowed on UpdateOne operations")
 	}
@@ -30882,22 +30882,9 @@ func (m *BillingStandardInvoiceDetailedLineMutation) OldChildUniqueReferenceID(c
 	return oldValue.ChildUniqueReferenceID, nil
 }
 
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (m *BillingStandardInvoiceDetailedLineMutation) ClearChildUniqueReferenceID() {
-	m.child_unique_reference_id = nil
-	m.clearedFields[billingstandardinvoicedetailedline.FieldChildUniqueReferenceID] = struct{}{}
-}
-
-// ChildUniqueReferenceIDCleared returns if the "child_unique_reference_id" field was cleared in this mutation.
-func (m *BillingStandardInvoiceDetailedLineMutation) ChildUniqueReferenceIDCleared() bool {
-	_, ok := m.clearedFields[billingstandardinvoicedetailedline.FieldChildUniqueReferenceID]
-	return ok
-}
-
 // ResetChildUniqueReferenceID resets all changes to the "child_unique_reference_id" field.
 func (m *BillingStandardInvoiceDetailedLineMutation) ResetChildUniqueReferenceID() {
 	m.child_unique_reference_id = nil
-	delete(m.clearedFields, billingstandardinvoicedetailedline.FieldChildUniqueReferenceID)
 }
 
 // SetPerUnitAmount sets the "per_unit_amount" field.
@@ -32554,9 +32541,6 @@ func (m *BillingStandardInvoiceDetailedLineMutation) ClearedFields() []string {
 	if m.FieldCleared(billingstandardinvoicedetailedline.FieldInvoicingAppExternalID) {
 		fields = append(fields, billingstandardinvoicedetailedline.FieldInvoicingAppExternalID)
 	}
-	if m.FieldCleared(billingstandardinvoicedetailedline.FieldChildUniqueReferenceID) {
-		fields = append(fields, billingstandardinvoicedetailedline.FieldChildUniqueReferenceID)
-	}
 	if m.FieldCleared(billingstandardinvoicedetailedline.FieldIndex) {
 		fields = append(fields, billingstandardinvoicedetailedline.FieldIndex)
 	}
@@ -32600,9 +32584,6 @@ func (m *BillingStandardInvoiceDetailedLineMutation) ClearField(name string) err
 		return nil
 	case billingstandardinvoicedetailedline.FieldInvoicingAppExternalID:
 		m.ClearInvoicingAppExternalID()
-		return nil
-	case billingstandardinvoicedetailedline.FieldChildUniqueReferenceID:
-		m.ClearChildUniqueReferenceID()
 		return nil
 	case billingstandardinvoicedetailedline.FieldIndex:
 		m.ClearIndex()
@@ -47303,7 +47284,7 @@ func (m *ChargeFlatFeeDetailedLineMutation) ChildUniqueReferenceID() (r string, 
 // OldChildUniqueReferenceID returns the old "child_unique_reference_id" field's value of the ChargeFlatFeeDetailedLine entity.
 // If the ChargeFlatFeeDetailedLine object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ChargeFlatFeeDetailedLineMutation) OldChildUniqueReferenceID(ctx context.Context) (v *string, err error) {
+func (m *ChargeFlatFeeDetailedLineMutation) OldChildUniqueReferenceID(ctx context.Context) (v string, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldChildUniqueReferenceID is only allowed on UpdateOne operations")
 	}
@@ -47317,22 +47298,9 @@ func (m *ChargeFlatFeeDetailedLineMutation) OldChildUniqueReferenceID(ctx contex
 	return oldValue.ChildUniqueReferenceID, nil
 }
 
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (m *ChargeFlatFeeDetailedLineMutation) ClearChildUniqueReferenceID() {
-	m.child_unique_reference_id = nil
-	m.clearedFields[chargeflatfeedetailedline.FieldChildUniqueReferenceID] = struct{}{}
-}
-
-// ChildUniqueReferenceIDCleared returns if the "child_unique_reference_id" field was cleared in this mutation.
-func (m *ChargeFlatFeeDetailedLineMutation) ChildUniqueReferenceIDCleared() bool {
-	_, ok := m.clearedFields[chargeflatfeedetailedline.FieldChildUniqueReferenceID]
-	return ok
-}
-
 // ResetChildUniqueReferenceID resets all changes to the "child_unique_reference_id" field.
 func (m *ChargeFlatFeeDetailedLineMutation) ResetChildUniqueReferenceID() {
 	m.child_unique_reference_id = nil
-	delete(m.clearedFields, chargeflatfeedetailedline.FieldChildUniqueReferenceID)
 }
 
 // SetPerUnitAmount sets the "per_unit_amount" field.
@@ -48832,9 +48800,6 @@ func (m *ChargeFlatFeeDetailedLineMutation) ClearedFields() []string {
 	if m.FieldCleared(chargeflatfeedetailedline.FieldInvoicingAppExternalID) {
 		fields = append(fields, chargeflatfeedetailedline.FieldInvoicingAppExternalID)
 	}
-	if m.FieldCleared(chargeflatfeedetailedline.FieldChildUniqueReferenceID) {
-		fields = append(fields, chargeflatfeedetailedline.FieldChildUniqueReferenceID)
-	}
 	if m.FieldCleared(chargeflatfeedetailedline.FieldIndex) {
 		fields = append(fields, chargeflatfeedetailedline.FieldIndex)
 	}
@@ -48878,9 +48843,6 @@ func (m *ChargeFlatFeeDetailedLineMutation) ClearField(name string) error {
 		return nil
 	case chargeflatfeedetailedline.FieldInvoicingAppExternalID:
 		m.ClearInvoicingAppExternalID()
-		return nil
-	case chargeflatfeedetailedline.FieldChildUniqueReferenceID:
-		m.ClearChildUniqueReferenceID()
 		return nil
 	case chargeflatfeedetailedline.FieldIndex:
 		m.ClearIndex()
@@ -56535,7 +56497,7 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) ChildUniqueReferenceID() (r st
 // OldChildUniqueReferenceID returns the old "child_unique_reference_id" field's value of the ChargeUsageBasedRunDetailedLine entity.
 // If the ChargeUsageBasedRunDetailedLine object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ChargeUsageBasedRunDetailedLineMutation) OldChildUniqueReferenceID(ctx context.Context) (v *string, err error) {
+func (m *ChargeUsageBasedRunDetailedLineMutation) OldChildUniqueReferenceID(ctx context.Context) (v string, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldChildUniqueReferenceID is only allowed on UpdateOne operations")
 	}
@@ -56549,22 +56511,9 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) OldChildUniqueReferenceID(ctx 
 	return oldValue.ChildUniqueReferenceID, nil
 }
 
-// ClearChildUniqueReferenceID clears the value of the "child_unique_reference_id" field.
-func (m *ChargeUsageBasedRunDetailedLineMutation) ClearChildUniqueReferenceID() {
-	m.child_unique_reference_id = nil
-	m.clearedFields[chargeusagebasedrundetailedline.FieldChildUniqueReferenceID] = struct{}{}
-}
-
-// ChildUniqueReferenceIDCleared returns if the "child_unique_reference_id" field was cleared in this mutation.
-func (m *ChargeUsageBasedRunDetailedLineMutation) ChildUniqueReferenceIDCleared() bool {
-	_, ok := m.clearedFields[chargeusagebasedrundetailedline.FieldChildUniqueReferenceID]
-	return ok
-}
-
 // ResetChildUniqueReferenceID resets all changes to the "child_unique_reference_id" field.
 func (m *ChargeUsageBasedRunDetailedLineMutation) ResetChildUniqueReferenceID() {
 	m.child_unique_reference_id = nil
-	delete(m.clearedFields, chargeusagebasedrundetailedline.FieldChildUniqueReferenceID)
 }
 
 // SetPerUnitAmount sets the "per_unit_amount" field.
@@ -58141,9 +58090,6 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) ClearedFields() []string {
 	if m.FieldCleared(chargeusagebasedrundetailedline.FieldInvoicingAppExternalID) {
 		fields = append(fields, chargeusagebasedrundetailedline.FieldInvoicingAppExternalID)
 	}
-	if m.FieldCleared(chargeusagebasedrundetailedline.FieldChildUniqueReferenceID) {
-		fields = append(fields, chargeusagebasedrundetailedline.FieldChildUniqueReferenceID)
-	}
 	if m.FieldCleared(chargeusagebasedrundetailedline.FieldIndex) {
 		fields = append(fields, chargeusagebasedrundetailedline.FieldIndex)
 	}
@@ -58187,9 +58133,6 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) ClearField(name string) error 
 		return nil
 	case chargeusagebasedrundetailedline.FieldInvoicingAppExternalID:
 		m.ClearInvoicingAppExternalID()
-		return nil
-	case chargeusagebasedrundetailedline.FieldChildUniqueReferenceID:
-		m.ClearChildUniqueReferenceID()
 		return nil
 	case chargeusagebasedrundetailedline.FieldIndex:
 		m.ClearIndex()

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -828,6 +828,10 @@ func init() {
 	billingstandardinvoicedetailedlineDescCurrency := billingstandardinvoicedetailedlineMixinFields0[0].Descriptor()
 	// billingstandardinvoicedetailedline.CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
 	billingstandardinvoicedetailedline.CurrencyValidator = billingstandardinvoicedetailedlineDescCurrency.Validators[0].(func(string) error)
+	// billingstandardinvoicedetailedlineDescChildUniqueReferenceID is the schema descriptor for child_unique_reference_id field.
+	billingstandardinvoicedetailedlineDescChildUniqueReferenceID := billingstandardinvoicedetailedlineMixinFields0[8].Descriptor()
+	// billingstandardinvoicedetailedline.ChildUniqueReferenceIDValidator is a validator for the "child_unique_reference_id" field. It is called by the builders before save.
+	billingstandardinvoicedetailedline.ChildUniqueReferenceIDValidator = billingstandardinvoicedetailedlineDescChildUniqueReferenceID.Validators[0].(func(string) error)
 	// billingstandardinvoicedetailedlineDescNamespace is the schema descriptor for namespace field.
 	billingstandardinvoicedetailedlineDescNamespace := billingstandardinvoicedetailedlineMixinFields0[16].Descriptor()
 	// billingstandardinvoicedetailedline.NamespaceValidator is a validator for the "namespace" field. It is called by the builders before save.
@@ -1147,6 +1151,10 @@ func init() {
 	chargeflatfeedetailedlineDescCurrency := chargeflatfeedetailedlineMixinFields0[0].Descriptor()
 	// chargeflatfeedetailedline.CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
 	chargeflatfeedetailedline.CurrencyValidator = chargeflatfeedetailedlineDescCurrency.Validators[0].(func(string) error)
+	// chargeflatfeedetailedlineDescChildUniqueReferenceID is the schema descriptor for child_unique_reference_id field.
+	chargeflatfeedetailedlineDescChildUniqueReferenceID := chargeflatfeedetailedlineMixinFields0[8].Descriptor()
+	// chargeflatfeedetailedline.ChildUniqueReferenceIDValidator is a validator for the "child_unique_reference_id" field. It is called by the builders before save.
+	chargeflatfeedetailedline.ChildUniqueReferenceIDValidator = chargeflatfeedetailedlineDescChildUniqueReferenceID.Validators[0].(func(string) error)
 	// chargeflatfeedetailedlineDescNamespace is the schema descriptor for namespace field.
 	chargeflatfeedetailedlineDescNamespace := chargeflatfeedetailedlineMixinFields0[16].Descriptor()
 	// chargeflatfeedetailedline.NamespaceValidator is a validator for the "namespace" field. It is called by the builders before save.
@@ -1316,6 +1324,10 @@ func init() {
 	chargeusagebasedrundetailedlineDescCurrency := chargeusagebasedrundetailedlineMixinFields0[0].Descriptor()
 	// chargeusagebasedrundetailedline.CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
 	chargeusagebasedrundetailedline.CurrencyValidator = chargeusagebasedrundetailedlineDescCurrency.Validators[0].(func(string) error)
+	// chargeusagebasedrundetailedlineDescChildUniqueReferenceID is the schema descriptor for child_unique_reference_id field.
+	chargeusagebasedrundetailedlineDescChildUniqueReferenceID := chargeusagebasedrundetailedlineMixinFields0[8].Descriptor()
+	// chargeusagebasedrundetailedline.ChildUniqueReferenceIDValidator is a validator for the "child_unique_reference_id" field. It is called by the builders before save.
+	chargeusagebasedrundetailedline.ChildUniqueReferenceIDValidator = chargeusagebasedrundetailedlineDescChildUniqueReferenceID.Validators[0].(func(string) error)
 	// chargeusagebasedrundetailedlineDescNamespace is the schema descriptor for namespace field.
 	chargeusagebasedrundetailedlineDescNamespace := chargeusagebasedrundetailedlineMixinFields0[16].Descriptor()
 	// chargeusagebasedrundetailedline.NamespaceValidator is a validator for the "namespace" field. It is called by the builders before save.

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -2034,20 +2034,6 @@ func (u *BillingStandardInvoiceDetailedLineUpdateOne) SetOrClearInvoicingAppExte
 	return u.SetInvoicingAppExternalID(*value)
 }
 
-func (u *BillingStandardInvoiceDetailedLineUpdate) SetOrClearChildUniqueReferenceID(value *string) *BillingStandardInvoiceDetailedLineUpdate {
-	if value == nil {
-		return u.ClearChildUniqueReferenceID()
-	}
-	return u.SetChildUniqueReferenceID(*value)
-}
-
-func (u *BillingStandardInvoiceDetailedLineUpdateOne) SetOrClearChildUniqueReferenceID(value *string) *BillingStandardInvoiceDetailedLineUpdateOne {
-	if value == nil {
-		return u.ClearChildUniqueReferenceID()
-	}
-	return u.SetChildUniqueReferenceID(*value)
-}
-
 func (u *BillingStandardInvoiceDetailedLineUpdate) SetOrClearIndex(value *int) *BillingStandardInvoiceDetailedLineUpdate {
 	if value == nil {
 		return u.ClearIndex()
@@ -2776,20 +2762,6 @@ func (u *ChargeFlatFeeDetailedLineUpdateOne) SetOrClearInvoicingAppExternalID(va
 	return u.SetInvoicingAppExternalID(*value)
 }
 
-func (u *ChargeFlatFeeDetailedLineUpdate) SetOrClearChildUniqueReferenceID(value *string) *ChargeFlatFeeDetailedLineUpdate {
-	if value == nil {
-		return u.ClearChildUniqueReferenceID()
-	}
-	return u.SetChildUniqueReferenceID(*value)
-}
-
-func (u *ChargeFlatFeeDetailedLineUpdateOne) SetOrClearChildUniqueReferenceID(value *string) *ChargeFlatFeeDetailedLineUpdateOne {
-	if value == nil {
-		return u.ClearChildUniqueReferenceID()
-	}
-	return u.SetChildUniqueReferenceID(*value)
-}
-
 func (u *ChargeFlatFeeDetailedLineUpdate) SetOrClearIndex(value *int) *ChargeFlatFeeDetailedLineUpdate {
 	if value == nil {
 		return u.ClearIndex()
@@ -3222,20 +3194,6 @@ func (u *ChargeUsageBasedRunDetailedLineUpdateOne) SetOrClearInvoicingAppExterna
 		return u.ClearInvoicingAppExternalID()
 	}
 	return u.SetInvoicingAppExternalID(*value)
-}
-
-func (u *ChargeUsageBasedRunDetailedLineUpdate) SetOrClearChildUniqueReferenceID(value *string) *ChargeUsageBasedRunDetailedLineUpdate {
-	if value == nil {
-		return u.ClearChildUniqueReferenceID()
-	}
-	return u.SetChildUniqueReferenceID(*value)
-}
-
-func (u *ChargeUsageBasedRunDetailedLineUpdateOne) SetOrClearChildUniqueReferenceID(value *string) *ChargeUsageBasedRunDetailedLineUpdateOne {
-	if value == nil {
-		return u.ClearChildUniqueReferenceID()
-	}
-	return u.SetChildUniqueReferenceID(*value)
 }
 
 func (u *ChargeUsageBasedRunDetailedLineUpdate) SetOrClearIndex(value *int) *ChargeUsageBasedRunDetailedLineUpdate {

--- a/test/billing/adapter_test.go
+++ b/test/billing/adapter_test.go
@@ -139,7 +139,7 @@ func newDetailedLine(in newLineInput) billing.DetailedLine {
 				}),
 				Currency:               in.Invoice.Currency,
 				ServicePeriod:          in.Period,
-				ChildUniqueReferenceID: lo.EmptyableToPtr(in.ChildUniqueReferenceID),
+				ChildUniqueReferenceID: in.ChildUniqueReferenceID,
 				PerUnitAmount:          alpacadecimal.NewFromFloat(100),
 				Quantity:               alpacadecimal.NewFromFloat(1),
 				PaymentTerm:            productcatalog.InArrearsPaymentTerm,
@@ -255,7 +255,7 @@ func (s *BillingAdapterTestSuite) TestDetailedLineHandling() {
 		unchangedDetailedLineUpdatedAt := lo.FindOrElse[billing.DetailedLine](lines[0].DetailedLines,
 			billing.DetailedLine{},
 			func(l billing.DetailedLine) bool {
-				return *l.ChildUniqueReferenceID == "ref1"
+				return l.ChildUniqueReferenceID == "ref1"
 			},
 		).UpdatedAt.Unix()
 
@@ -300,7 +300,7 @@ func (s *BillingAdapterTestSuite) TestDetailedLineHandling() {
 		require.Equal(s.T(), unchangedDetailedLineUpdatedAt, lo.FindOrElse(lines[0].DetailedLines,
 			billing.DetailedLine{},
 			func(l billing.DetailedLine) bool {
-				return *l.ChildUniqueReferenceID == "ref1"
+				return l.ChildUniqueReferenceID == "ref1"
 			}).UpdatedAt.Unix())
 
 		require.Len(s.T(), lines[1].DetailedLines, 0)
@@ -312,11 +312,11 @@ func (s *BillingAdapterTestSuite) TestDetailedLineHandling() {
 		detailedLines := lines[0].DetailedLines
 
 		slices.SortFunc(detailedLines, func(a, b billing.DetailedLine) int {
-			return strings.Compare(*a.ChildUniqueReferenceID, *b.ChildUniqueReferenceID)
+			return strings.Compare(a.ChildUniqueReferenceID, b.ChildUniqueReferenceID)
 		})
 
 		require.Len(s.T(), detailedLines, 3)
-		require.Equal(s.T(), "ref1", *detailedLines[0].ChildUniqueReferenceID)
+		require.Equal(s.T(), "ref1", detailedLines[0].ChildUniqueReferenceID)
 
 		// Replace the first detailed line with a new child
 		detailedLines[0] = newDetailedLine(newLineInput{
@@ -371,7 +371,7 @@ func (s *BillingAdapterTestSuite) TestDetailedLineHandling() {
 
 func getUniqReferenceNames(lines []billing.DetailedLine) []string {
 	return lo.Map(lines, func(l billing.DetailedLine, _ int) string {
-		return *l.ChildUniqueReferenceID
+		return l.ChildUniqueReferenceID
 	})
 }
 

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -3041,7 +3041,7 @@ func requireDetailedLines(t *testing.T, line *billing.StandardLine, expectations
 	require.Len(t, detailedLines, len(expectations.Details))
 
 	detailsById := lo.GroupBy(detailedLines, func(l billing.DetailedLine) string {
-		return *l.ChildUniqueReferenceID
+		return l.ChildUniqueReferenceID
 	})
 
 	for key, expect := range expectations.Details {

--- a/tools/migrate/migrations/20260421150206_require_child_unique_reference_id_on_detailed_lines.down.sql
+++ b/tools/migrate/migrations/20260421150206_require_child_unique_reference_id_on_detailed_lines.down.sql
@@ -1,6 +1,6 @@
 -- reverse: modify "charge_usage_based_run_detailed_line" table
-ALTER TABLE "charge_usage_based_run_detailed_line" ALTER COLUMN "child_unique_reference_id" DROP NOT NULL, DROP CONSTRAINT "child_unique_reference_id_not_empty";
+ALTER TABLE "charge_usage_based_run_detailed_line" ALTER COLUMN "child_unique_reference_id" DROP NOT NULL, DROP CONSTRAINT IF EXISTS "child_unique_reference_id_not_empty";
 -- reverse: modify "charge_flat_fee_detailed_line" table
-ALTER TABLE "charge_flat_fee_detailed_line" ALTER COLUMN "child_unique_reference_id" DROP NOT NULL, DROP CONSTRAINT "child_unique_reference_id_not_empty";
+ALTER TABLE "charge_flat_fee_detailed_line" ALTER COLUMN "child_unique_reference_id" DROP NOT NULL, DROP CONSTRAINT IF EXISTS "child_unique_reference_id_not_empty";
 -- reverse: modify "billing_standard_invoice_detailed_lines" table
-ALTER TABLE "billing_standard_invoice_detailed_lines" ALTER COLUMN "child_unique_reference_id" DROP NOT NULL, DROP CONSTRAINT "child_unique_reference_id_not_empty";
+ALTER TABLE "billing_standard_invoice_detailed_lines" ALTER COLUMN "child_unique_reference_id" DROP NOT NULL, DROP CONSTRAINT IF EXISTS "child_unique_reference_id_not_empty";

--- a/tools/migrate/migrations/20260421150206_require_child_unique_reference_id_on_detailed_lines.down.sql
+++ b/tools/migrate/migrations/20260421150206_require_child_unique_reference_id_on_detailed_lines.down.sql
@@ -1,0 +1,6 @@
+-- reverse: modify "charge_usage_based_run_detailed_line" table
+ALTER TABLE "charge_usage_based_run_detailed_line" ALTER COLUMN "child_unique_reference_id" DROP NOT NULL, DROP CONSTRAINT "child_unique_reference_id_not_empty";
+-- reverse: modify "charge_flat_fee_detailed_line" table
+ALTER TABLE "charge_flat_fee_detailed_line" ALTER COLUMN "child_unique_reference_id" DROP NOT NULL, DROP CONSTRAINT "child_unique_reference_id_not_empty";
+-- reverse: modify "billing_standard_invoice_detailed_lines" table
+ALTER TABLE "billing_standard_invoice_detailed_lines" ALTER COLUMN "child_unique_reference_id" DROP NOT NULL, DROP CONSTRAINT "child_unique_reference_id_not_empty";

--- a/tools/migrate/migrations/20260421150206_require_child_unique_reference_id_on_detailed_lines.up.sql
+++ b/tools/migrate/migrations/20260421150206_require_child_unique_reference_id_on_detailed_lines.up.sql
@@ -1,0 +1,18 @@
+-- modify "billing_standard_invoice_detailed_lines" table
+UPDATE "billing_standard_invoice_detailed_lines"
+SET "child_unique_reference_id" = "id"
+WHERE "child_unique_reference_id" IS NULL OR "child_unique_reference_id" = '';
+-- atlas:nolint MF104
+ALTER TABLE "billing_standard_invoice_detailed_lines" ADD CONSTRAINT "child_unique_reference_id_not_empty" CHECK ((child_unique_reference_id)::text <> ''::text), ALTER COLUMN "child_unique_reference_id" SET NOT NULL;
+-- modify "charge_flat_fee_detailed_line" table
+UPDATE "charge_flat_fee_detailed_line"
+SET "child_unique_reference_id" = "id"
+WHERE "child_unique_reference_id" IS NULL OR "child_unique_reference_id" = '';
+-- atlas:nolint MF104
+ALTER TABLE "charge_flat_fee_detailed_line" ADD CONSTRAINT "child_unique_reference_id_not_empty" CHECK ((child_unique_reference_id)::text <> ''::text), ALTER COLUMN "child_unique_reference_id" SET NOT NULL;
+-- modify "charge_usage_based_run_detailed_line" table
+UPDATE "charge_usage_based_run_detailed_line"
+SET "child_unique_reference_id" = "id"
+WHERE "child_unique_reference_id" IS NULL OR "child_unique_reference_id" = '';
+-- atlas:nolint MF104
+ALTER TABLE "charge_usage_based_run_detailed_line" ADD CONSTRAINT "child_unique_reference_id_not_empty" CHECK ((child_unique_reference_id)::text <> ''::text), ALTER COLUMN "child_unique_reference_id" SET NOT NULL;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ZU4ZrqVJMDY0BNijlXkrnVgOtUIWMrfFZNqnVKZ6Fmo=
+h1:7oWu3Vp3Cf8pOgfNprqwE0wbgN6yKrkdL3ZX/vwXSUM=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -182,3 +182,4 @@ h1:ZU4ZrqVJMDY0BNijlXkrnVgOtUIWMrfFZNqnVKZ6Fmo=
 20260410144542_credit_purchase_refactor.up.sql h1:QenJqbZelTciUcobFAp5sf3KshhSWDTRl9XGsRz/DDc=
 20260413154216_usagebased-run-line-id.up.sql h1:QgSUrbXPScmxaeKBMb3pWRlsTzoEUNZ1X3HZRj1krx4=
 20260421111210_add_charge_detailed_line_tables.up.sql h1:gczZY6X34zMiXq1Ph3y3zDWTJr//8aulX3VeYNIuly8=
+20260421150206_require_child_unique_reference_id_on_detailed_lines.up.sql h1:XReNPIrVLZunPJ1vyUTwxBBASZDqgljQO3HBAMMMzqA=


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

This change makes `child_unique_reference_id` required and non-empty for shared detailed-line models, updates the billing adapters and detailed-line domain type so upstream detailed lines use a plain `string`, and
  regenerates the affected Ent code and derived helpers. 

It adds a migration that backfills missing detailed-line reference IDs, enforces `NOT NULL`, and adds an explicit database `CHECK` for non-empty values, with targeted  Atlas `MF104` lint exclusions because the migration performs its own backfill before tightening the column. 

Right now the detailed lines table is empty, so there's no regression.

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized handling of ChildUniqueReferenceID across billing flows to treat empty strings as missing, enforce non-empty values, and simplify equality/lookup behavior—improves invoice line consistency and reuse logic.
  * Added database migrations to backfill and enforce non-empty child reference values.

* **Documentation**
  * Updated ORM guidance to document schema-level non-empty validation and when to apply DB-level checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->