### PR TITLE
chore: split rating service

### DIFF
--- a/openmeter/billing/charges/service/featureid_test.go
+++ b/openmeter/billing/charges/service/featureid_test.go
@@ -196,7 +196,7 @@ func (s *ChargeFeatureIDTestSuite) TestUsageBasedActivationRecalculatesFeatureID
 		ChargeID: activatedCharge.GetChargeID(),
 	})
 	s.NoError(err)
-	s.True(alpacadecimal.NewFromInt(7).Equal(currentTotals.Quantity))
+	s.True(alpacadecimal.NewFromInt(21).Equal(currentTotals.DueTotals.Total))
 
 	clock.SetTime(servicePeriod.To.Add(2 * time.Hour))
 	s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued = func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {

--- a/openmeter/billing/charges/usagebased/service.go
+++ b/openmeter/billing/charges/usagebased/service.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/alpacahq/alpacadecimal"
-
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
@@ -176,6 +174,5 @@ func (i GetCurrentTotalsInput) Validate() error {
 
 type GetCurrentTotalsResult struct {
 	Charge    Charge
-	Quantity  alpacadecimal.Decimal
 	DueTotals totals.Totals
 }

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -183,7 +183,7 @@ func (s *CreditThenInvoiceStateMachine) SnapshotInvoiceUsage(ctx context.Context
 
 	storedAtOffset := meta.NormalizeTimestamp(currentRun.CollectionEnd)
 
-	ratingResult, err := s.Rater.GetRatingForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
+	ratingResult, err := s.Rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
 		Charge:         s.Charge,
 		Customer:       s.CustomerOverride,
 		FeatureMeter:   s.FeatureMeter,

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -181,7 +181,7 @@ func (s *CreditsOnlyStateMachine) FinalizeRealizationRun(ctx context.Context) er
 
 	storedAtOffset := meta.NormalizeTimestamp(clock.Now().Add(-usagebased.InternalCollectionPeriod))
 
-	ratingResult, err := s.Rater.GetRatingForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
+	ratingResult, err := s.Rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
 		Charge:         s.Charge,
 		Customer:       s.CustomerOverride,
 		FeatureMeter:   s.FeatureMeter,

--- a/openmeter/billing/charges/usagebased/service/currenttotals.go
+++ b/openmeter/billing/charges/usagebased/service/currenttotals.go
@@ -48,19 +48,18 @@ func (s *service) GetCurrentTotals(ctx context.Context, input usagebased.GetCurr
 		return usagebased.GetCurrentTotalsResult{}, err
 	}
 
-	ratingResult, err := s.rater.GetRatingForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
+	dueTotals, err := s.rater.GetTotalsForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
 		Charge:         charge,
 		Customer:       customerOverride,
 		FeatureMeter:   featureMeter,
 		StoredAtOffset: clock.Now(),
 	})
 	if err != nil {
-		return usagebased.GetCurrentTotalsResult{}, fmt.Errorf("get rating for usage: %w", err)
+		return usagebased.GetCurrentTotalsResult{}, fmt.Errorf("get totals for usage: %w", err)
 	}
 
 	return usagebased.GetCurrentTotalsResult{
 		Charge:    charge,
-		Quantity:  ratingResult.Quantity,
-		DueTotals: ratingResult.Totals,
+		DueTotals: dueTotals,
 	}, nil
 }

--- a/openmeter/billing/charges/usagebased/service/get.go
+++ b/openmeter/billing/charges/usagebased/service/get.go
@@ -182,7 +182,7 @@ func (s *service) expandChargesUsage(ctx context.Context, namespace string, char
 
 		dueTotals, ok := dueTotalsAny.(totals.Totals)
 		if !ok {
-			return charge, fmt.Errorf("totals result not found for charge %s", charge.ID)
+			return charge, fmt.Errorf("invalid totals type for charge %s", charge.ID)
 		}
 
 		charge.Expands.RealtimeUsage = &dueTotals

--- a/openmeter/billing/charges/usagebased/service/get.go
+++ b/openmeter/billing/charges/usagebased/service/get.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	usagebasedrating "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/rating"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
@@ -141,19 +142,19 @@ func (s *service) expandChargesUsage(ctx context.Context, namespace string, char
 				}
 			}()
 
-			var ratingResult usagebasedrating.GetRatingForUsageResult
-			ratingResult, err = s.rater.GetRatingForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
+			var dueTotals totals.Totals
+			dueTotals, err = s.rater.GetTotalsForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
 				Charge:         charge,
 				Customer:       customerOverridesById[charge.GetCustomerID()],
 				FeatureMeter:   featureMeter,
 				StoredAtOffset: storedAt,
 			})
 			if err != nil {
-				err = fmt.Errorf("rating charge %s: %w", charge.ID, err)
+				err = fmt.Errorf("get totals for charge %s: %w", charge.ID, err)
 				return
 			}
 
-			ratingResults.Store(charge.GetChargeID(), ratingResult)
+			ratingResults.Store(charge.GetChargeID(), dueTotals)
 		})
 	}
 
@@ -174,17 +175,17 @@ func (s *service) expandChargesUsage(ctx context.Context, namespace string, char
 	}
 
 	return slicesx.MapWithErr(charges, func(charge usagebased.Charge) (usagebased.Charge, error) {
-		ratingResultAny, ok := ratingResults.Load(charge.GetChargeID())
+		dueTotalsAny, ok := ratingResults.Load(charge.GetChargeID())
 		if !ok {
-			return charge, fmt.Errorf("rating result not found for charge %s", charge.ID)
+			return charge, fmt.Errorf("totals result not found for charge %s", charge.ID)
 		}
 
-		ratingResult, ok := ratingResultAny.(usagebasedrating.GetRatingForUsageResult)
+		dueTotals, ok := dueTotalsAny.(totals.Totals)
 		if !ok {
-			return charge, fmt.Errorf("rating result not found for charge %s", charge.ID)
+			return charge, fmt.Errorf("totals result not found for charge %s", charge.ID)
 		}
 
-		charge.Expands.RealtimeUsage = &ratingResult.Totals
+		charge.Expands.RealtimeUsage = &dueTotals
 		return charge, nil
 	})
 }

--- a/openmeter/billing/charges/usagebased/service/rating/details.go
+++ b/openmeter/billing/charges/usagebased/service/rating/details.go
@@ -1,0 +1,39 @@
+package rating
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+)
+
+// GetDetailedLinesForUsage returns the rated detailed lines together with the metered quantity snapshot
+// used to compute them. Prefer GetTotalsForUsage when only totals are needed because it is faster.
+func (s *Service) GetDetailedLinesForUsage(ctx context.Context, in GetRatingForUsageInput) (GetRatingForUsageResult, error) {
+	if err := in.Validate(); err != nil {
+		return GetRatingForUsageResult{}, err
+	}
+
+	snapshotQuantity, err := s.snapshotQuantity(ctx, snapshotQuantityInput{
+		Customer:       in.Customer.Customer,
+		FeatureMeter:   in.FeatureMeter,
+		ServicePeriod:  in.Charge.Intent.ServicePeriod,
+		StoredAtOffset: in.StoredAtOffset,
+	})
+	if err != nil {
+		return GetRatingForUsageResult{}, fmt.Errorf("get snapshot quantity: %w", err)
+	}
+
+	ratingResult, err := s.ratingService.GenerateDetailedLines(usagebased.RateableIntent{
+		Intent:     in.Charge.Intent,
+		MeterValue: snapshotQuantity,
+	})
+	if err != nil {
+		return GetRatingForUsageResult{}, fmt.Errorf("rating: %w", err)
+	}
+
+	return GetRatingForUsageResult{
+		GenerateDetailedLinesResult: ratingResult,
+		Quantity:                    snapshotQuantity,
+	}, nil
+}

--- a/openmeter/billing/charges/usagebased/service/rating/service.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service.go
@@ -1,7 +1,6 @@
 package rating
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -80,33 +79,4 @@ func (i GetRatingForUsageInput) Validate() error {
 	}
 
 	return nil
-}
-
-func (s *Service) GetRatingForUsage(ctx context.Context, in GetRatingForUsageInput) (GetRatingForUsageResult, error) {
-	if err := in.Validate(); err != nil {
-		return GetRatingForUsageResult{}, err
-	}
-
-	snapshotQuantity, err := s.snapshotQuantity(ctx, snapshotQuantityInput{
-		Customer:       in.Customer.Customer,
-		FeatureMeter:   in.FeatureMeter,
-		ServicePeriod:  in.Charge.Intent.ServicePeriod,
-		StoredAtOffset: in.StoredAtOffset,
-	})
-	if err != nil {
-		return GetRatingForUsageResult{}, fmt.Errorf("get snapshot quantity: %w", err)
-	}
-
-	ratingResult, err := s.ratingService.GenerateDetailedLines(usagebased.RateableIntent{
-		Intent:     in.Charge.Intent,
-		MeterValue: snapshotQuantity,
-	})
-	if err != nil {
-		return GetRatingForUsageResult{}, fmt.Errorf("rating: %w", err)
-	}
-
-	return GetRatingForUsageResult{
-		GenerateDetailedLinesResult: ratingResult,
-		Quantity:                    snapshotQuantity,
-	}, nil
 }

--- a/openmeter/billing/charges/usagebased/service/rating/totals.go
+++ b/openmeter/billing/charges/usagebased/service/rating/totals.go
@@ -1,0 +1,37 @@
+package rating
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+)
+
+// GetTotalsForUsage returns the rated totals for the charge at the requested stored-at offset.
+// It avoids generating detailed lines, so prefer it over GetDetailedLinesForUsage when only totals are needed.
+func (s *Service) GetTotalsForUsage(ctx context.Context, in GetRatingForUsageInput) (totals.Totals, error) {
+	if err := in.Validate(); err != nil {
+		return totals.Totals{}, err
+	}
+
+	snapshotQuantity, err := s.snapshotQuantity(ctx, snapshotQuantityInput{
+		Customer:       in.Customer.Customer,
+		FeatureMeter:   in.FeatureMeter,
+		ServicePeriod:  in.Charge.Intent.ServicePeriod,
+		StoredAtOffset: in.StoredAtOffset,
+	})
+	if err != nil {
+		return totals.Totals{}, fmt.Errorf("get snapshot quantity: %w", err)
+	}
+
+	ratingResult, err := s.ratingService.GenerateDetailedLines(usagebased.RateableIntent{
+		Intent:     in.Charge.Intent,
+		MeterValue: snapshotQuantity,
+	})
+	if err != nil {
+		return totals.Totals{}, fmt.Errorf("rating totals: %w", err)
+	}
+
+	return ratingResult.Totals, nil
+}

--- a/openmeter/billing/charges/usagebased/service/run/create.go
+++ b/openmeter/billing/charges/usagebased/service/run/create.go
@@ -109,7 +109,7 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 		return CreateRatedRunResult{}, err
 	}
 
-	ratingResult, err := s.rater.GetRatingForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
+	ratingResult, err := s.rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
 		Charge:         in.Charge,
 		Customer:       in.CustomerOverride,
 		FeatureMeter:   in.FeatureMeter,


### PR DESCRIPTION


## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

**Note**: code duplication is intentional, these two methods will diverge over time.

Split `openmeter/billing/charges/usagebased/service/rating` into `GetTotalsForUsage` in `totals.go` and `GetDetailedLinesForUsage` in `details.go`, with comments documenting the return values and that totals-only lookup
  should be preferred because it is faster.

  Refactored the totals-only consumers to use `GetTotalsForUsage` in realtime expand (`openmeter/billing/charges/usagebased/service/get.go`) and `GetCurrentTotals` (`openmeter/billing/charges/usagebased/service/
  currenttotals.go`), while state-machine/run paths now call `GetDetailedLinesForUsage`, and I reverted the temporary ledger API changes.

  Updated `openmeter/billing/charges/service/featureid_test.go` to assert on due totals instead of quantity, then ran focused verification successfully: `go test -count=1 -tags=dynamic ./openmeter/billing/charges/service ./
  openmeter/billing/charges/usagebased/service ./openmeter/billing/charges/usagebased/service/run ./openmeter/billing/charges/usagebased/service/rating`.
## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal billing/rating reorganized to separate detailed line generation from totals computation for clearer calculations.
* **Behavioral**
  * Usage responses now emphasize aggregated monetary totals (due totals/charge) and no longer include raw quantity in current totals.
* **Tests**
  * Updated a usage-based activation test to assert monetary totals instead of quantity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->