### PR TITLE
feat: persist detailed lines

### DIFF
--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -35,7 +35,7 @@ Primary packages:
 
 `openmeter/billing/charges` is the root facade for charge operations.
 
-For charge-owned detailed lines, the shared invoice-agnostic base belongs in `openmeter/billing/models/stddetailedline`. Keep charge wrappers thin by adding only `charge_id` / `run_id`-style ownership fields around `stddetailedline.Base`, and reuse shared detailed-line base mapping helpers instead of duplicating the common field assembly in charge adapters.
+For charge-owned detailed lines, the shared invoice-agnostic base belongs in `openmeter/billing/models/stddetailedline`. Prefer using `type DetailedLine = stddetailedline.Base` in charge packages and keep ownership implicit through containment in the parent aggregate (`flatfee.Realizations` or `usagebased.RealizationRun`) rather than duplicating `charge_id` / `run_id` fields in the domain type. Reuse the shared detailed-line base mapping and create helpers instead of duplicating common field assembly in charge adapters.
 
 Charge-backed invoicing no longer relies on a charges-side `InvoicePendingLines(...)` wrapper. Billing owns invoice creation and dispatches gathering lines by `billing.LineEngineType`, while charge packages provide charge-specific line engines where needed.
 
@@ -73,6 +73,7 @@ Important types:
   - `CreditRealizations`
   - `AccruedUsage`
   - `Payment`
+  - `DetailedLines`
 - `flatfee.Intent.CalculateAmountAfterProration()` computes the prorated amount from `AmountBeforeProration`, `ServicePeriod/FullServicePeriod` ratio, and `ProRating` config, with currency-precision rounding
 - Charge-backed targets do not use invoice-style semantic proration or empty-period filtering; the charge stack materializes and prorates state itself, and the flat fee charge is responsible for omitting empty lines
 - `usagebased.Intent` carries `FeatureKey`, `Price`, `SettlementMode`, `InvoiceAt`, and `ServicePeriod`
@@ -86,6 +87,15 @@ Important types:
   - `CollectionEnd`
   - `MeterValue`
   - `Totals`
+- `usagebased.RealizationRun` can expand:
+  - `DetailedLines`
+
+Detailed-line expansion rules:
+
+- `meta.ExpandDetailedLines` is not standalone for charge reads; it requires `meta.ExpandRealizations`
+- usage-based detailed lines live under `RealizationRun.DetailedLines`
+- flat-fee detailed lines also live under `Charge.Realizations.DetailedLines`, not on the root charge
+- `mo.None()` means detailed lines were not expanded; present options mean expanded data, even when the underlying slice is nil/empty
 
 ## Billing Line Engines
 
@@ -99,7 +109,7 @@ Current engine values:
 
 Current implementations:
 
-- flat fee line engine: `openmeter/billing/charges/flatfee/lineengine`
+- flat fee line engine: `openmeter/billing/charges/flatfee/service/lineengine.go`
 - credit purchase line engine: `openmeter/billing/charges/creditpurchase/lineengine`
 - usage-based line engine: `openmeter/billing/charges/usagebased/service/lineengine.go`
 
@@ -112,6 +122,8 @@ Important rules:
 - charge test setups must also register those engines explicitly; keep this in `openmeter/billing/charges/testutils`
 - if a charge create path stamps a new `LineEngineType`, app wiring and charge test wiring must register a matching implementation in the same change
 - usage-based exposes its billing line engine from `usagebased.Service.GetLineEngine()`; register that returned engine instead of reusing the service type directly
+- flat-fee now follows the same pattern: `flatfee.Service.GetLineEngine()` returns the engine owned by the service package
+- because flat-fee owns its line engine, `flatfee/service.New(...)` requires a `rating.Service`; forgetting that dependency breaks app/test wiring with `rating service cannot be null`
 
 Operational consequence:
 

--- a/app/common/charges.go
+++ b/app/common/charges.go
@@ -13,7 +13,6 @@ import (
 	creditpurchaseservice "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	flatfeeadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/adapter"
-	flatfeelineengine "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/lineengine"
 	flatfeeservice "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	lineageadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/adapter"
@@ -146,13 +145,15 @@ func NewChargesFlatFeeService(
 	lineageService lineage.Service,
 	metaAdapter meta.Adapter,
 	locker *lockr.Locker,
+	ratingService rating.Service,
 ) (flatfee.Service, error) {
 	flatFeeSvc, err := flatfeeservice.New(flatfeeservice.Config{
-		Adapter:     flatFeeAdapter,
-		Handler:     flatFeeHandler,
-		Lineage:     lineageService,
-		MetaAdapter: metaAdapter,
-		Locker:      locker,
+		Adapter:       flatFeeAdapter,
+		Handler:       flatFeeHandler,
+		Lineage:       lineageService,
+		MetaAdapter:   metaAdapter,
+		Locker:        locker,
+		RatingService: ratingService,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create charges flat fee service: %w", err)
@@ -325,20 +326,12 @@ func newChargesRegistry(
 		return nil, err
 	}
 
-	flatFeeSvc, err := NewChargesFlatFeeService(flatFeeAdapter, flatFeeHandler, lineageService, metaAdapter, locker)
+	flatFeeSvc, err := NewChargesFlatFeeService(flatFeeAdapter, flatFeeHandler, lineageService, metaAdapter, locker, ratingService)
 	if err != nil {
 		return nil, err
 	}
 
-	flatFeeLineEngine, err := flatfeelineengine.New(flatfeelineengine.Config{
-		FlatFeeService: flatFeeSvc,
-		RatingService:  ratingService,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create charges flat fee line engine: %w", err)
-	}
-
-	if err := billingService.RegisterLineEngine(flatFeeLineEngine); err != nil {
+	if err := billingService.RegisterLineEngine(flatFeeSvc.GetLineEngine()); err != nil {
 		return nil, fmt.Errorf("failed to register charges flat fee line engine: %w", err)
 	}
 

--- a/openmeter/billing/adapter/stdinvoicelinemapper.go
+++ b/openmeter/billing/adapter/stdinvoicelinemapper.go
@@ -209,43 +209,16 @@ func (a *adapter) mapStandardInvoiceDetailedLineFromDB(dbLine *db.BillingInvoice
 }
 
 func (a *adapter) mapStandardInvoiceDetailedLineV2FromDB(dbLine *db.BillingStandardInvoiceDetailedLine) (billing.DetailedLine, error) {
-	creditsApplied := lo.FromPtr(dbLine.CreditsApplied)
-	if len(creditsApplied) == 0 {
-		creditsApplied = nil
-	}
-
 	detailedLineBase := billing.DetailedLineBase{
 		InvoiceID: dbLine.InvoiceID,
-		Base: stddetailedline.Base{
-			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
-				Namespace:   dbLine.Namespace,
-				ID:          dbLine.ID,
-				CreatedAt:   dbLine.CreatedAt.In(time.UTC),
-				UpdatedAt:   dbLine.UpdatedAt.In(time.UTC),
-				DeletedAt:   convert.TimePtrIn(dbLine.DeletedAt, time.UTC),
-				Name:        dbLine.Name,
-				Description: dbLine.Description,
-			}),
-			ChildUniqueReferenceID: dbLine.ChildUniqueReferenceID,
-			ServicePeriod: timeutil.ClosedPeriod{
-				From: dbLine.ServicePeriodStart.In(time.UTC),
-				To:   dbLine.ServicePeriodEnd.In(time.UTC),
-			},
-			PerUnitAmount:  dbLine.PerUnitAmount,
-			Quantity:       dbLine.Quantity,
-			Category:       dbLine.Category,
-			PaymentTerm:    dbLine.PaymentTerm,
-			Index:          dbLine.Index,
-			Currency:       dbLine.Currency,
-			CreditsApplied: creditsApplied,
-			TaxConfig: backfillTaxConfigReferences(
+		Base: stddetailedline.FromDB(
+			dbLine,
+			backfillTaxConfigReferences(
 				lo.EmptyableToPtr(dbLine.TaxConfig),
 				dbLine.TaxBehavior,
 				taxCodeFromDetailedLineV2Edge(dbLine),
 			),
-			Totals:      totals.FromDB(dbLine),
-			ExternalIDs: externalid.MapLineExternalIDFromDB(dbLine),
-		},
+		),
 	}
 
 	discounts, err := slicesx.MapWithErr(dbLine.Edges.AmountDiscounts, a.mapStandardInvoiceDetailedLineAmountDiscountFromDB)

--- a/openmeter/billing/adapter/stdinvoicelines.go
+++ b/openmeter/billing/adapter/stdinvoicelines.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/externalid"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
@@ -421,22 +422,9 @@ func (a *adapter) upsertDetailedLinesV2(ctx context.Context, in detailedLineDiff
 				SetID(line.ID).
 				SetNamespace(line.Namespace).
 				SetInvoiceID(line.InvoiceID).
-				SetServicePeriodStart(line.ServicePeriod.From.In(time.UTC)).
-				SetServicePeriodEnd(line.ServicePeriod.To.In(time.UTC)).
-				SetParentLineID(lineWithParent.Parent.ID).
-				SetNillableDeletedAt(line.DeletedAt).
-				SetName(line.Name).
-				SetNillableDescription(line.Description).
-				SetCurrency(line.Currency).
-				SetQuantity(line.Quantity).
-				SetPerUnitAmount(line.PerUnitAmount).
-				SetChildUniqueReferenceID(line.ChildUniqueReferenceID).
-				SetCategory(line.Category).
-				SetPaymentTerm(line.PaymentTerm).
-				SetNillableIndex(line.Index)
+				SetParentLineID(lineWithParent.Parent.ID)
 
-			create = externalid.CreateLineExternalID(create, line.ExternalIDs)
-			create = totals.Set(create, line.Totals)
+			create = stddetailedline.Create(create, line.Base)
 
 			if len(line.CreditsApplied) > 0 {
 				create = create.SetCreditsApplied(&line.CreditsApplied)

--- a/openmeter/billing/charges/flatfee/adapter.go
+++ b/openmeter/billing/charges/flatfee/adapter.go
@@ -17,6 +17,7 @@ import (
 
 type Adapter interface {
 	ChargeAdapter
+	ChargeDetailedLineAdapter
 	ChargeCreditAllocationAdapter
 	ChargeInvoicedUsageAdapter
 	ChargePaymentAdapter
@@ -30,6 +31,11 @@ type ChargeAdapter interface {
 	DeleteCharge(ctx context.Context, charge Charge) error
 	GetByIDs(ctx context.Context, ids GetByIDsInput) ([]Charge, error)
 	GetByID(ctx context.Context, id GetByIDInput) (Charge, error)
+}
+
+type ChargeDetailedLineAdapter interface {
+	UpsertDetailedLines(ctx context.Context, chargeID meta.ChargeID, lines DetailedLines) error
+	FetchDetailedLines(ctx context.Context, charge Charge) (Charge, error)
 }
 
 type ChargeInvoicedUsageAdapter interface {
@@ -89,7 +95,7 @@ func (i GetByIDsInput) Validate() error {
 		}
 	}
 
-	if err := i.Expands.Validate(); err != nil {
+	if err := validateExpands(i.Expands); err != nil {
 		errs = append(errs, fmt.Errorf("expands: %w", err))
 	}
 
@@ -107,7 +113,7 @@ func (i GetByIDInput) Validate() error {
 		errs = append(errs, fmt.Errorf("charge ID: %w", err))
 	}
 
-	if err := i.Expands.Validate(); err != nil {
+	if err := validateExpands(i.Expands); err != nil {
 		errs = append(errs, fmt.Errorf("expands: %w", err))
 	}
 
@@ -133,4 +139,16 @@ func (i CreateChargesInput) Validate() error {
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func validateExpands(expands meta.Expands) error {
+	if err := expands.Validate(); err != nil {
+		return err
+	}
+
+	if expands.Has(meta.ExpandDetailedLines) && !expands.Has(meta.ExpandRealizations) {
+		return fmt.Errorf("%q requires %q", meta.ExpandDetailedLines, meta.ExpandRealizations)
+	}
+
+	return nil
 }

--- a/openmeter/billing/charges/flatfee/adapter/charge.go
+++ b/openmeter/billing/charges/flatfee/adapter/charge.go
@@ -195,6 +195,12 @@ func (a *adapter) GetByIDs(ctx context.Context, input flatfee.GetByIDsInput) ([]
 			return nil, err
 		}
 
+		if input.Expands.Has(meta.ExpandDetailedLines) {
+			return slicesx.MapWithErr(out, func(charge flatfee.Charge) (flatfee.Charge, error) {
+				return tx.FetchDetailedLines(ctx, charge)
+			})
+		}
+
 		return out, nil
 	})
 }
@@ -225,6 +231,10 @@ func (a *adapter) GetByID(ctx context.Context, input flatfee.GetByIDInput) (flat
 		charge, err := MapChargeFlatFeeFromDB(entity, input.Expands)
 		if err != nil {
 			return flatfee.Charge{}, err
+		}
+
+		if input.Expands.Has(meta.ExpandDetailedLines) {
+			return tx.FetchDetailedLines(ctx, charge)
 		}
 
 		return charge, nil

--- a/openmeter/billing/charges/flatfee/adapter/detailedline.go
+++ b/openmeter/billing/charges/flatfee/adapter/detailedline.go
@@ -1,0 +1,157 @@
+package adapter
+
+import (
+	"context"
+	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	dbchargeflatfeedetailedline "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeedetailedline"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+)
+
+var _ flatfee.ChargeDetailedLineAdapter = (*adapter)(nil)
+
+func (a *adapter) FetchDetailedLines(ctx context.Context, charge flatfee.Charge) (flatfee.Charge, error) {
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (flatfee.Charge, error) {
+		dbLines, err := tx.db.ChargeFlatFeeDetailedLine.Query().
+			Where(
+				dbchargeflatfeedetailedline.NamespaceEQ(charge.Namespace),
+				dbchargeflatfeedetailedline.ChargeIDEQ(charge.ID),
+				dbchargeflatfeedetailedline.DeletedAtIsNil(),
+			).
+			WithTaxCode().
+			All(ctx)
+		if err != nil {
+			return flatfee.Charge{}, err
+		}
+
+		lines := make(flatfee.DetailedLines, 0, len(dbLines))
+		for _, dbLine := range dbLines {
+			line, err := mapDetailedLineFromDB(dbLine)
+			if err != nil {
+				return flatfee.Charge{}, err
+			}
+
+			lines = append(lines, line)
+		}
+
+		sortDetailedLines(lines)
+		charge.Realizations.DetailedLines = mo.Some(lines)
+
+		return charge, nil
+	})
+}
+
+func (a *adapter) UpsertDetailedLines(ctx context.Context, chargeID meta.ChargeID, lines flatfee.DetailedLines) error {
+	if err := chargeID.Validate(); err != nil {
+		return err
+	}
+
+	if err := lines.Validate(); err != nil {
+		return err
+	}
+
+	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, tx *adapter) error {
+		createBuilders := make([]*entdb.ChargeFlatFeeDetailedLineCreate, 0, len(lines))
+
+		for _, line := range lines {
+			lineToPersist := line.Clone()
+			lineToPersist.Namespace = chargeID.Namespace
+			lineToPersist.DeletedAt = nil
+
+			create, err := buildDetailedLineCreate(tx.db, chargeID, lineToPersist)
+			if err != nil {
+				return err
+			}
+
+			createBuilders = append(createBuilders, create)
+		}
+
+		now := clock.Now().In(time.UTC)
+		deleteQuery := tx.db.ChargeFlatFeeDetailedLine.Update().
+			Where(
+				dbchargeflatfeedetailedline.NamespaceEQ(chargeID.Namespace),
+				dbchargeflatfeedetailedline.ChargeIDEQ(chargeID.ID),
+				dbchargeflatfeedetailedline.DeletedAtIsNil(),
+			).
+			SetDeletedAt(now)
+
+		childRefsToKeep := lo.Map(lines, func(line flatfee.DetailedLine, _ int) string {
+			return line.ChildUniqueReferenceID
+		})
+		if len(childRefsToKeep) > 0 {
+			deleteQuery = deleteQuery.Where(
+				dbchargeflatfeedetailedline.ChildUniqueReferenceIDNotIn(childRefsToKeep...),
+			)
+		}
+
+		if _, err := deleteQuery.Save(ctx); err != nil {
+			return err
+		}
+
+		if len(createBuilders) == 0 {
+			return nil
+		}
+
+		return tx.db.ChargeFlatFeeDetailedLine.CreateBulk(createBuilders...).
+			OnConflict(
+				sql.ConflictColumns(
+					dbchargeflatfeedetailedline.FieldNamespace,
+					dbchargeflatfeedetailedline.FieldChargeID,
+					dbchargeflatfeedetailedline.FieldChildUniqueReferenceID,
+				),
+				sql.ConflictWhere(sql.IsNull(dbchargeflatfeedetailedline.FieldDeletedAt)),
+				sql.ResolveWithNewValues(),
+				sql.ResolveWith(func(u *sql.UpdateSet) {
+					u.SetIgnore(dbchargeflatfeedetailedline.FieldCreatedAt)
+					u.SetIgnore(dbchargeflatfeedetailedline.FieldID)
+				}),
+			).
+			UpdateDescription().
+			UpdateTaxConfig().
+			UpdateTaxCodeID().
+			UpdateTaxBehavior().
+			UpdateIndex().
+			UpdateDeletedAt().
+			UpdateInvoicingAppExternalID().
+			UpdateChildUniqueReferenceID().
+			UpdateCreditsApplied().
+			UpdateAnnotations().
+			UpdateMetadata().
+			Exec(ctx)
+	})
+}
+
+func buildDetailedLineCreate(db *entdb.Client, chargeID meta.ChargeID, line flatfee.DetailedLine) (*entdb.ChargeFlatFeeDetailedLineCreate, error) {
+	if line.ID == "" {
+		line.ID = ulid.Make().String()
+	}
+
+	create := db.ChargeFlatFeeDetailedLine.Create().
+		SetID(line.ID).
+		SetNamespace(chargeID.Namespace).
+		SetChargeID(chargeID.ID)
+
+	create = stddetailedline.Create(create, line)
+
+	if len(line.CreditsApplied) > 0 {
+		create = create.SetCreditsApplied(&line.CreditsApplied)
+	}
+
+	if line.TaxConfig != nil {
+		create = create.SetTaxConfig(*line.TaxConfig).
+			SetNillableTaxCodeID(line.TaxConfig.TaxCodeID).
+			SetNillableTaxBehavior(line.TaxConfig.Behavior)
+	}
+
+	return create, nil
+}

--- a/openmeter/billing/charges/flatfee/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/flatfee/adapter/detailedline_test.go
@@ -1,0 +1,226 @@
+package adapter
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	metaadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/meta/adapter"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	dbchargeflatfeedetailedline "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeedetailedline"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+	"github.com/openmeterio/openmeter/tools/migrate"
+)
+
+func TestFlatFeeDetailedLineAdapter(t *testing.T) {
+	suite.Run(t, new(FlatFeeDetailedLineAdapterSuite))
+}
+
+type FlatFeeDetailedLineAdapterSuite struct {
+	suite.Suite
+
+	testDB   *testutils.TestDB
+	dbClient *entdb.Client
+	adapter  flatfee.Adapter
+}
+
+type newDetailedLineInput struct {
+	Charge                 flatfee.Charge
+	ServicePeriod          timeutil.ClosedPeriod
+	ChildUniqueReferenceID string
+	Quantity               int64
+	Description            *string
+}
+
+func (s *FlatFeeDetailedLineAdapterSuite) SetupSuite() {
+	t := s.T()
+
+	s.testDB = testutils.InitPostgresDB(t)
+	s.dbClient = entdb.NewClient(entdb.Driver(s.testDB.EntDriver.Driver()))
+
+	migrator, err := migrate.New(migrate.MigrateOptions{
+		ConnectionString: s.testDB.URL,
+		Migrations:       migrate.OMMigrationsConfig,
+		Logger:           slog.Default(),
+	})
+	require.NoError(t, err)
+	defer migrator.CloseOrLogError()
+	require.NoError(t, migrator.Up())
+
+	metaAdapter, err := metaadapter.New(metaadapter.Config{
+		Client: s.dbClient,
+		Logger: slog.Default(),
+	})
+	require.NoError(t, err)
+
+	a, err := New(Config{
+		Client:      s.dbClient,
+		Logger:      slog.Default(),
+		MetaAdapter: metaAdapter,
+	})
+	require.NoError(t, err)
+
+	s.adapter = a
+}
+
+func (s *FlatFeeDetailedLineAdapterSuite) TearDownSuite() {
+	s.dbClient.Close()
+	s.testDB.EntDriver.Close()
+	s.testDB.PGDriver.Close()
+}
+
+func (s *FlatFeeDetailedLineAdapterSuite) TestUpsertDetailedLinesReplacesAndSoftDeletesByChildUniqueReferenceID() {
+	ctx := s.T().Context()
+	namespace := "flatfee-detailedline-adapter"
+	customerID := s.createCustomer(namespace)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	createdCharges, err := s.adapter.CreateCharges(ctx, flatfee.CreateChargesInput{
+		Namespace: namespace,
+		Intents: []flatfee.IntentWithInitialStatus{
+			{
+				Intent: flatfee.Intent{
+					Intent: chargesmeta.Intent{
+						Name:              "flat-fee-charge",
+						ManagedBy:         billing.SubscriptionManagedLine,
+						CustomerID:        customerID,
+						Currency:          currencyx.Code("USD"),
+						ServicePeriod:     servicePeriod,
+						FullServicePeriod: servicePeriod,
+						BillingPeriod:     servicePeriod,
+					},
+					InvoiceAt:             servicePeriod.To,
+					SettlementMode:        productcatalog.InvoiceOnlySettlementMode,
+					PaymentTerm:           productcatalog.InAdvancePaymentTerm,
+					AmountBeforeProration: alpacadecimal.NewFromInt(10),
+					ProRating: productcatalog.ProRatingConfig{
+						Enabled: false,
+						Mode:    productcatalog.ProRatingModeProratePrices,
+					},
+				},
+				InitialStatus:        flatfee.StatusActive,
+				AmountAfterProration: alpacadecimal.NewFromInt(10),
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(createdCharges, 1)
+
+	charge := createdCharges[0]
+
+	initialLines := flatfee.DetailedLines{
+		s.newDetailedLine(newDetailedLineInput{
+			Charge:                 charge,
+			ServicePeriod:          servicePeriod,
+			ChildUniqueReferenceID: "keep",
+			Quantity:               1,
+			Description:            lo.ToPtr("old description"),
+		}),
+		s.newDetailedLine(newDetailedLineInput{
+			Charge:                 charge,
+			ServicePeriod:          servicePeriod,
+			ChildUniqueReferenceID: "delete",
+			Quantity:               2,
+			Description:            lo.ToPtr("delete me"),
+		}),
+	}
+	s.Require().NoError(s.adapter.UpsertDetailedLines(ctx, charge.GetChargeID(), initialLines))
+
+	replacementLines := flatfee.DetailedLines{
+		s.newDetailedLine(newDetailedLineInput{
+			Charge:                 charge,
+			ServicePeriod:          servicePeriod,
+			ChildUniqueReferenceID: "keep",
+			Quantity:               3,
+		}),
+		s.newDetailedLine(newDetailedLineInput{
+			Charge:                 charge,
+			ServicePeriod:          servicePeriod,
+			ChildUniqueReferenceID: "new",
+			Quantity:               4,
+			Description:            lo.ToPtr("new description"),
+		}),
+	}
+	s.Require().NoError(s.adapter.UpsertDetailedLines(ctx, charge.GetChargeID(), replacementLines))
+
+	fetchedCharge, err := s.adapter.GetByID(ctx, flatfee.GetByIDInput{
+		ChargeID: charge.GetChargeID(),
+		Expands: chargesmeta.Expands{
+			chargesmeta.ExpandRealizations,
+			chargesmeta.ExpandDetailedLines,
+		},
+	})
+	s.Require().NoError(err)
+	s.True(fetchedCharge.Realizations.DetailedLines.IsPresent())
+	s.Len(fetchedCharge.Realizations.DetailedLines.OrEmpty(), 2)
+	s.Equal("keep", fetchedCharge.Realizations.DetailedLines.OrEmpty()[0].ChildUniqueReferenceID)
+	s.Equal("new", fetchedCharge.Realizations.DetailedLines.OrEmpty()[1].ChildUniqueReferenceID)
+	s.Equal(float64(3), fetchedCharge.Realizations.DetailedLines.OrEmpty()[0].Quantity.InexactFloat64())
+	s.Nil(fetchedCharge.Realizations.DetailedLines.OrEmpty()[0].Description)
+
+	deletedRow, err := s.dbClient.ChargeFlatFeeDetailedLine.Query().
+		Where(
+			dbchargeflatfeedetailedline.NamespaceEQ(namespace),
+			dbchargeflatfeedetailedline.ChargeIDEQ(charge.ID),
+			dbchargeflatfeedetailedline.ChildUniqueReferenceIDEQ("delete"),
+		).
+		Only(ctx)
+	s.Require().NoError(err)
+	s.NotNil(deletedRow.DeletedAt)
+}
+
+func (s *FlatFeeDetailedLineAdapterSuite) createCustomer(namespace string) string {
+	s.T().Helper()
+
+	customer, err := s.dbClient.Customer.Create().
+		SetNamespace(namespace).
+		SetName("test-customer").
+		Save(s.T().Context())
+	s.Require().NoError(err)
+
+	return customer.ID
+}
+
+func (s *FlatFeeDetailedLineAdapterSuite) newDetailedLine(input newDetailedLineInput) flatfee.DetailedLine {
+	s.T().Helper()
+
+	totalAmount := alpacadecimal.NewFromFloat(0.1).Mul(alpacadecimal.NewFromInt(input.Quantity))
+
+	return flatfee.DetailedLine{
+		ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+			Namespace:   input.Charge.Namespace,
+			Name:        "Detailed line",
+			Description: input.Description,
+		}),
+		ServicePeriod:          input.ServicePeriod,
+		Currency:               input.Charge.Intent.Currency,
+		ChildUniqueReferenceID: input.ChildUniqueReferenceID,
+		PaymentTerm:            input.Charge.Intent.PaymentTerm,
+		PerUnitAmount:          alpacadecimal.NewFromFloat(0.1),
+		Quantity:               alpacadecimal.NewFromInt(input.Quantity),
+		Category:               stddetailedline.CategoryRegular,
+		Totals: totals.Totals{
+			Amount:       totalAmount,
+			ChargesTotal: totalAmount,
+			Total:        totalAmount,
+		},
+	}
+}

--- a/openmeter/billing/charges/flatfee/adapter/mapper.go
+++ b/openmeter/billing/charges/flatfee/adapter/mapper.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/samber/lo"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 )
@@ -53,6 +55,31 @@ func MapChargeFlatFeeFromDB(entity *entdb.ChargeFlatFee, expands meta.Expands) (
 	}
 
 	return charge, nil
+}
+
+func mapDetailedLineFromDB(dbLine *entdb.ChargeFlatFeeDetailedLine) (flatfee.DetailedLine, error) {
+	line := stddetailedline.FromDB(
+		dbLine,
+		stddetailedline.BackfillTaxConfig(
+			lo.EmptyableToPtr(dbLine.TaxConfig),
+			dbLine.TaxBehavior,
+			taxCodeIDFromEnt(dbLine.Edges.TaxCode),
+		),
+	)
+
+	return line, line.Validate()
+}
+
+func taxCodeIDFromEnt(resolvedTaxCode *entdb.TaxCode) *string {
+	if resolvedTaxCode == nil {
+		return nil
+	}
+
+	return lo.ToPtr(resolvedTaxCode.ID)
+}
+
+func sortDetailedLines(lines flatfee.DetailedLines) {
+	slices.SortStableFunc(lines, stddetailedline.Compare[flatfee.DetailedLine])
 }
 
 func MapChargeBaseFromDB(entity *entdb.ChargeFlatFee) flatfee.ChargeBase {

--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -229,7 +229,7 @@ type Realizations struct {
 	CreditRealizations creditrealization.Realizations `json:"creditRealizations"`
 	AccruedUsage       *invoicedusage.AccruedUsage    `json:"accruedUsage"`
 	Payment            *payment.Invoiced              `json:"payment"`
-	DetailedLines      mo.Option[DetailedLines]       `json:"detailedLines,omitempty"`
+	DetailedLines      mo.Option[DetailedLines]       `json:"detailedLines,omitzero"`
 }
 
 func (r Realizations) Validate() error {

--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
@@ -228,6 +229,7 @@ type Realizations struct {
 	CreditRealizations creditrealization.Realizations `json:"creditRealizations"`
 	AccruedUsage       *invoicedusage.AccruedUsage    `json:"accruedUsage"`
 	Payment            *payment.Invoiced              `json:"payment"`
+	DetailedLines      mo.Option[DetailedLines]       `json:"detailedLines,omitempty"`
 }
 
 func (r Realizations) Validate() error {
@@ -248,6 +250,12 @@ func (r Realizations) Validate() error {
 	if r.AccruedUsage != nil {
 		if err := r.AccruedUsage.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("accrued usage[id=%s]: %w", r.AccruedUsage.ID, err))
+		}
+	}
+
+	if r.DetailedLines.IsPresent() {
+		if err := r.DetailedLines.OrEmpty().Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("detailed lines: %w", err))
 		}
 	}
 

--- a/openmeter/billing/charges/flatfee/detailedline.go
+++ b/openmeter/billing/charges/flatfee/detailedline.go
@@ -1,0 +1,33 @@
+package flatfee
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type DetailedLine = stddetailedline.Base
+
+type DetailedLines []DetailedLine
+
+func (l DetailedLines) Clone() DetailedLines {
+	return lo.Map(l, func(dl DetailedLine, _ int) DetailedLine {
+		return dl.Clone()
+	})
+}
+
+func (l DetailedLines) Validate() error {
+	var errs []error
+
+	for idx, line := range l {
+		if err := line.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("[%d]: %w", idx, err))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}

--- a/openmeter/billing/charges/flatfee/service.go
+++ b/openmeter/billing/charges/flatfee/service.go
@@ -14,6 +14,7 @@ import (
 
 type Service interface {
 	FlatFeeService
+	GetLineEngine() billing.LineEngine
 	InvoiceLifecycleHooks
 }
 

--- a/openmeter/billing/charges/flatfee/service/helpers.go
+++ b/openmeter/billing/charges/flatfee/service/helpers.go
@@ -1,9 +1,12 @@
-package lineengine
+package service
 
 import (
+	"context"
+
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 )
 
@@ -14,4 +17,10 @@ func convertCreditRealizations(creditRealizations creditrealization.Realizations
 			CreditRealizationID: creditRealization.ID,
 		}
 	})
+}
+
+func (s *service) persistDetailedLines(ctx context.Context, charge flatfee.Charge, line billing.StandardLine) error {
+	return s.adapter.UpsertDetailedLines(ctx, charge.GetChargeID(), lo.Map(line.DetailedLines, func(detailedLine billing.DetailedLine, _ int) flatfee.DetailedLine {
+		return detailedLine.Base.Clone()
+	}))
 }

--- a/openmeter/billing/charges/flatfee/service/invoice.go
+++ b/openmeter/billing/charges/flatfee/service/invoice.go
@@ -63,6 +63,10 @@ func (s *service) PostInvoiceIssued(ctx context.Context, charge flatfee.Charge, 
 			return fmt.Errorf("postInvoiceIssued: line is nil")
 		}
 
+		if err := s.persistDetailedLines(ctx, charge, *lineWithHeader.Line); err != nil {
+			return fmt.Errorf("persisting detailed lines: %w", err)
+		}
+
 		if lineWithHeader.Line.Totals.Total.IsZero() {
 			return nil
 		}

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -1,4 +1,4 @@
-package lineengine
+package service
 
 import (
 	"context"
@@ -7,66 +7,33 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
-	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
-var _ billing.LineEngine = (*Engine)(nil)
+var _ billing.LineEngine = (*LineEngine)(nil)
 
-type Config struct {
-	FlatFeeService flatfee.Service
-	RatingService  rating.Service
+type LineEngine struct {
+	service *service
 }
 
-func (c Config) Validate() error {
-	if c.FlatFeeService == nil {
-		return fmt.Errorf("flat fee service is required")
-	}
-
-	if c.RatingService == nil {
-		return fmt.Errorf("rating service is required")
-	}
-
-	return nil
-}
-
-type Engine struct {
-	flatFeeService flatfee.Service
-	ratingService  rating.Service
-}
-
-// TODO[later]: Most probably we should just implement the LineEngine interface inside the service of flatfee, but let's see how the interface evolves.
-func New(config Config) (*Engine, error) {
-	if err := config.Validate(); err != nil {
-		return nil, err
-	}
-
-	return &Engine{
-		flatFeeService: config.FlatFeeService,
-		ratingService:  config.RatingService,
-	}, nil
-}
-
-func (e *Engine) GetLineEngineType() billing.LineEngineType {
+func (e *LineEngine) GetLineEngineType() billing.LineEngineType {
 	return billing.LineEngineTypeChargeFlatFee
 }
 
-func (e *Engine) IsLineBillableAsOf(_ context.Context, input billing.IsLineBillableAsOfInput) (bool, error) {
+func (e *LineEngine) IsLineBillableAsOf(_ context.Context, input billing.IsLineBillableAsOfInput) (bool, error) {
 	if err := input.Validate(); err != nil {
 		return false, fmt.Errorf("validating input: %w", err)
 	}
 
-	// Billing enforces that flat fees are never progressively billed, so there is no
-	// engine-side partial-period filtering to do here.
 	return true, nil
 }
 
-func (e *Engine) SplitGatheringLine(ctx context.Context, input billing.SplitGatheringLineInput) (billing.SplitGatheringLineResult, error) {
+func (e *LineEngine) SplitGatheringLine(context.Context, billing.SplitGatheringLineInput) (billing.SplitGatheringLineResult, error) {
 	return billing.SplitGatheringLineResult{}, fmt.Errorf("flat fee line is not progressively billed")
 }
 
-func (e *Engine) BuildStandardInvoiceLines(ctx context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
+func (e *LineEngine) BuildStandardInvoiceLines(ctx context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
 	stdLines, err := slicesx.MapWithErr(input.GatheringLines, func(gatheringLine billing.GatheringLine) (*billing.StandardLine, error) {
 		stdLine, err := gatheringLine.AsNewStandardLine(input.Invoice.ID)
 		if err != nil {
@@ -85,18 +52,19 @@ func (e *Engine) BuildStandardInvoiceLines(ctx context.Context, input billing.Bu
 	})
 }
 
-func (e *Engine) OnStandardInvoiceCreated(ctx context.Context, input billing.OnStandardInvoiceCreatedInput) (billing.StandardLines, error) {
+func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing.OnStandardInvoiceCreatedInput) (billing.StandardLines, error) {
 	if err := input.Validate(); err != nil {
 		return nil, fmt.Errorf("validating input: %w", err)
 	}
 
+	chargesByID := make(map[string]flatfee.Charge, len(input.Lines))
 	for _, stdLine := range input.Lines {
 		chargeID := stdLine.ChargeID
 		if chargeID == nil {
 			return nil, fmt.Errorf("flat fee standard line[%s]: charge id is required", stdLine.ID)
 		}
 
-		charge, err := e.flatFeeService.GetByID(ctx, flatfee.GetByIDInput{
+		charge, err := e.service.GetByID(ctx, flatfee.GetByIDInput{
 			ChargeID: meta.ChargeID{
 				Namespace: stdLine.Namespace,
 				ID:        *chargeID,
@@ -108,8 +76,9 @@ func (e *Engine) OnStandardInvoiceCreated(ctx context.Context, input billing.OnS
 		if err != nil {
 			return nil, fmt.Errorf("getting flat fee charge for line[%s]: %w", stdLine.ID, err)
 		}
+		chargesByID[charge.ID] = charge
 
-		realizations, err := e.flatFeeService.PostLineAssignedToInvoice(ctx, charge, *stdLine)
+		realizations, err := e.service.PostLineAssignedToInvoice(ctx, charge, *stdLine)
 		if err != nil {
 			return nil, fmt.Errorf("allocating credits for line[%s]: %w", stdLine.ID, err)
 		}
@@ -119,26 +88,46 @@ func (e *Engine) OnStandardInvoiceCreated(ctx context.Context, input billing.OnS
 		}
 	}
 
-	return e.CalculateLines(billing.CalculateLinesInput(input))
+	lines, err := e.CalculateLines(billing.CalculateLinesInput(input))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, stdLine := range lines {
+		if stdLine.ChargeID == nil {
+			return nil, fmt.Errorf("flat fee standard line[%s]: charge id is required", stdLine.ID)
+		}
+
+		charge, ok := chargesByID[*stdLine.ChargeID]
+		if !ok {
+			return nil, fmt.Errorf("flat fee charge not found for line[%s]: %s", stdLine.ID, *stdLine.ChargeID)
+		}
+
+		if err := e.service.persistDetailedLines(ctx, charge, *stdLine); err != nil {
+			return nil, fmt.Errorf("persisting detailed lines for line[%s]: %w", stdLine.ID, err)
+		}
+	}
+
+	return lines, nil
 }
 
-func (e *Engine) OnCollectionCompleted(_ context.Context, input billing.OnCollectionCompletedInput) (billing.StandardLines, error) {
+func (e *LineEngine) OnCollectionCompleted(_ context.Context, input billing.OnCollectionCompletedInput) (billing.StandardLines, error) {
 	return input.Lines, nil
 }
 
-func (e *Engine) OnInvoiceIssued(_ context.Context, _ billing.OnInvoiceIssuedInput) error {
+func (e *LineEngine) OnInvoiceIssued(_ context.Context, _ billing.OnInvoiceIssuedInput) error {
 	return nil
 }
 
-func (e *Engine) OnPaymentAuthorized(_ context.Context, _ billing.OnPaymentAuthorizedInput) error {
+func (e *LineEngine) OnPaymentAuthorized(_ context.Context, _ billing.OnPaymentAuthorizedInput) error {
 	return nil
 }
 
-func (e *Engine) OnPaymentSettled(_ context.Context, _ billing.OnPaymentSettledInput) error {
+func (e *LineEngine) OnPaymentSettled(_ context.Context, _ billing.OnPaymentSettledInput) error {
 	return nil
 }
 
-func (e *Engine) CalculateLines(input billing.CalculateLinesInput) (billing.StandardLines, error) {
+func (e *LineEngine) CalculateLines(input billing.CalculateLinesInput) (billing.StandardLines, error) {
 	if input.Invoice.ID == "" {
 		return nil, fmt.Errorf("invoice id is required")
 	}
@@ -148,7 +137,7 @@ func (e *Engine) CalculateLines(input billing.CalculateLinesInput) (billing.Stan
 	}
 
 	for _, stdLine := range input.Lines {
-		generatedDetailedLines, err := e.ratingService.GenerateDetailedLines(stdLine)
+		generatedDetailedLines, err := e.service.ratingService.GenerateDetailedLines(stdLine)
 		if err != nil {
 			return nil, fmt.Errorf("generating detailed lines for line[%s]: %w", stdLine.ID, err)
 		}

--- a/openmeter/billing/charges/flatfee/service/service.go
+++ b/openmeter/billing/charges/flatfee/service/service.go
@@ -3,19 +3,22 @@ package service
 import (
 	"errors"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	flatfeerealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
 )
 
 type Config struct {
-	Adapter     flatfee.Adapter
-	Handler     flatfee.Handler
-	Lineage     lineage.Service
-	MetaAdapter meta.Adapter
-	Locker      *lockr.Locker
+	Adapter       flatfee.Adapter
+	Handler       flatfee.Handler
+	Lineage       lineage.Service
+	MetaAdapter   meta.Adapter
+	Locker        *lockr.Locker
+	RatingService rating.Service
 }
 
 func (c Config) Validate() error {
@@ -41,6 +44,10 @@ func (c Config) Validate() error {
 		errs = append(errs, errors.New("locker cannot be null"))
 	}
 
+	if c.RatingService == nil {
+		errs = append(errs, errors.New("rating service cannot be null"))
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -59,18 +66,26 @@ func New(config Config) (flatfee.Service, error) {
 	}
 
 	return &service{
-		adapter:      config.Adapter,
-		handler:      config.Handler,
-		metaAdapter:  config.MetaAdapter,
-		locker:       config.Locker,
-		realizations: realizations,
+		adapter:       config.Adapter,
+		handler:       config.Handler,
+		metaAdapter:   config.MetaAdapter,
+		locker:        config.Locker,
+		realizations:  realizations,
+		ratingService: config.RatingService,
 	}, nil
 }
 
 type service struct {
-	adapter      flatfee.Adapter
-	handler      flatfee.Handler
-	metaAdapter  meta.Adapter
-	locker       *lockr.Locker
-	realizations *flatfeerealizations.Service
+	adapter       flatfee.Adapter
+	handler       flatfee.Handler
+	metaAdapter   meta.Adapter
+	locker        *lockr.Locker
+	realizations  *flatfeerealizations.Service
+	ratingService rating.Service
+}
+
+func (s *service) GetLineEngine() billing.LineEngine {
+	return &LineEngine{
+		service: s,
+	}
 }

--- a/openmeter/billing/charges/meta/charge.go
+++ b/openmeter/billing/charges/meta/charge.go
@@ -69,12 +69,14 @@ type Expand string
 const (
 	ExpandRealizations  Expand = "realizations"
 	ExpandRealtimeUsage Expand = "realtime_usage"
+	ExpandDetailedLines Expand = "detailed_lines"
 )
 
 func (e Expand) Values() []Expand {
 	return []Expand{
 		ExpandRealizations,
 		ExpandRealtimeUsage,
+		ExpandDetailedLines,
 	}
 }
 

--- a/openmeter/billing/charges/service/base_test.go
+++ b/openmeter/billing/charges/service/base_test.go
@@ -18,7 +18,6 @@ import (
 	creditpurchaseservice "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	flatfeeadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/adapter"
-	flatfeelineengine "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/lineengine"
 	flatfeeservice "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service"
 	lineageadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/adapter"
 	lineageservice "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/service"
@@ -85,21 +84,16 @@ func (s *BaseSuite) SetupSuite() {
 	s.NoError(err)
 
 	flatFeeService, err := flatfeeservice.New(flatfeeservice.Config{
-		Adapter:     flatFeeAdapter,
-		Handler:     s.FlatFeeTestHandler,
-		Lineage:     lineageService,
-		MetaAdapter: metaAdapter,
-		Locker:      locker,
+		Adapter:       flatFeeAdapter,
+		Handler:       s.FlatFeeTestHandler,
+		Lineage:       lineageService,
+		MetaAdapter:   metaAdapter,
+		Locker:        locker,
+		RatingService: billingratingservice.New(),
 	})
 	s.NoError(err)
 
-	flatFeeLineEngine, err := flatfeelineengine.New(flatfeelineengine.Config{
-		FlatFeeService: flatFeeService,
-		RatingService:  billingratingservice.New(),
-	})
-	s.NoError(err)
-
-	err = s.BillingService.RegisterLineEngine(flatFeeLineEngine)
+	err = s.BillingService.RegisterLineEngine(flatFeeService.GetLineEngine())
 	s.NoError(err)
 
 	usageBasedAdapter, err := usagebasedadapter.New(usagebasedadapter.Config{

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -122,7 +122,6 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 
 		flatFeeChargeID = flatFeeCharge.GetChargeID()
 	})
-
 	var stdInvoiceID billing.InvoiceID
 	var stdLineID billing.LineID
 	s.Run("invoice pending lines creates partial credit realizations", func() {
@@ -213,11 +212,18 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 		s.Equal(float64(30), creditRealizationDetail.Amount.InexactFloat64())
 		s.Equal(creditRealization.ID, creditRealizationDetail.CreditRealizationID)
 
+		flatFeeWithDetailedLines := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
+		s.True(flatFeeWithDetailedLines.Realizations.DetailedLines.IsPresent())
+		s.Len(flatFeeWithDetailedLines.Realizations.DetailedLines.OrEmpty(), 1)
+		s.Equal(detailedLine.ChildUniqueReferenceID, flatFeeWithDetailedLines.Realizations.DetailedLines.OrEmpty()[0].ChildUniqueReferenceID)
+		s.Equal(detailedLine.Totals.Total.String(), flatFeeWithDetailedLines.Realizations.DetailedLines.OrEmpty()[0].Totals.Total.String())
+		s.Equal(detailedLine.Quantity.String(), flatFeeWithDetailedLines.Realizations.DetailedLines.OrEmpty()[0].Quantity.String())
+		s.Len(flatFeeWithDetailedLines.Realizations.DetailedLines.OrEmpty()[0].CreditsApplied, 1)
+
 		stdInvoiceID = invoice.GetInvoiceID()
 		s.NotEmpty(stdInvoiceID)
 		s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, invoice.Status)
 	})
-
 	s.Run("approve invoice accrues usage without authorizing payment", func() {
 		defer s.FlatFeeTestHandler.Reset()
 
@@ -393,6 +399,10 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 		s.NoError(err)
 		s.Len(updatedFlatFeeCharge.Realizations.CreditRealizations, 1)
 		s.Nil(updatedFlatFeeCharge.Realizations.AccruedUsage)
+
+		flatFeeWithDetailedLines := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
+		s.True(flatFeeWithDetailedLines.Realizations.DetailedLines.IsPresent())
+		s.Len(flatFeeWithDetailedLines.Realizations.DetailedLines.OrEmpty(), len(invoice.Lines.OrEmpty()[0].DetailedLines))
 	})
 
 	s.Run("post invoice issued without invoice usage accrual", func() {
@@ -412,10 +422,10 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 		s.NoError(err)
 		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
 
-		charge = s.mustGetChargeByID(flatFeeChargeID)
-		updatedFlatFeeCharge, err := charge.AsFlatFeeCharge()
-		s.NoError(err)
+		updatedFlatFeeCharge := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
 		s.Nil(updatedFlatFeeCharge.Realizations.AccruedUsage)
+		s.True(updatedFlatFeeCharge.Realizations.DetailedLines.IsPresent())
+		s.Len(updatedFlatFeeCharge.Realizations.DetailedLines.OrEmpty(), len(invoice.Lines.OrEmpty()[0].DetailedLines))
 	})
 }
 
@@ -910,6 +920,15 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTier
 		s.Len(currentRun.CreditsAllocated, 1)
 		s.Equal(creditrealization.TypeAllocation, currentRun.CreditsAllocated[0].Type)
 		s.Equal(float64(20), currentRun.CreditsAllocated[0].Amount.InexactFloat64())
+
+		expandedCharge := s.mustGetUsageBasedChargeByIDWithDetailedLines(usageBasedChargeID)
+		expandedRun, err := expandedCharge.Realizations.GetByID(*expandedCharge.State.CurrentRealizationRunID)
+		s.NoError(err)
+		s.True(expandedRun.DetailedLines.IsPresent())
+		s.Len(expandedRun.DetailedLines.OrEmpty(), 1)
+		s.Equal("volume-tiered-price@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]", expandedRun.DetailedLines.OrEmpty()[0].ChildUniqueReferenceID)
+		s.Equal(float64(10), expandedRun.DetailedLines.OrEmpty()[0].Quantity.InexactFloat64())
+		s.Equal(float64(2), expandedRun.DetailedLines.OrEmpty()[0].PerUnitAmount.InexactFloat64())
 	})
 
 	s.Run("#4 finalize with persisted negative correction", func() {
@@ -993,6 +1012,14 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTier
 		s.Equal(creditrealization.TypeCorrection, finalRun.CreditsAllocated[1].Type)
 		s.Equal(float64(-9), finalRun.CreditsAllocated[1].Amount.InexactFloat64())
 		s.Equal(finalRun.CreditsAllocated[0].ID, lo.FromPtr(finalRun.CreditsAllocated[1].CorrectsRealizationID))
+
+		expandedCharge := s.mustGetUsageBasedChargeByIDWithDetailedLines(usageBasedChargeID)
+		s.Len(expandedCharge.Realizations, 1)
+		s.True(expandedCharge.Realizations[0].DetailedLines.IsPresent())
+		s.Len(expandedCharge.Realizations[0].DetailedLines.OrEmpty(), 1)
+		s.Equal("volume-tiered-price@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]", expandedCharge.Realizations[0].DetailedLines.OrEmpty()[0].ChildUniqueReferenceID)
+		s.Equal(float64(11), expandedCharge.Realizations[0].DetailedLines.OrEmpty()[0].Quantity.InexactFloat64())
+		s.Equal(float64(1), expandedCharge.Realizations[0].DetailedLines.OrEmpty()[0].PerUnitAmount.InexactFloat64())
 	})
 }
 
@@ -1121,6 +1148,15 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() 
 		s.Len(currentRun.CreditsAllocated, 1)
 		s.Equal(float64(5), currentRun.CreditsAllocated[0].Amount.InexactFloat64())
 		s.True((*remainingCredits).IsZero())
+
+		expandedCharge := s.mustGetUsageBasedChargeByIDWithDetailedLines(usageBasedChargeID)
+		expandedRun, err := expandedCharge.GetCurrentRealizationRun()
+		s.NoError(err)
+		s.True(expandedRun.DetailedLines.IsPresent())
+		s.Len(expandedRun.DetailedLines.OrEmpty(), 1)
+		s.Equal("unit-price-usage@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]", expandedRun.DetailedLines.OrEmpty()[0].ChildUniqueReferenceID)
+		s.Equal(float64(100), expandedRun.DetailedLines.OrEmpty()[0].Quantity.InexactFloat64())
+		s.Equal(float64(0.1), expandedRun.DetailedLines.OrEmpty()[0].PerUnitAmount.InexactFloat64())
 	})
 
 	s.Run("#5 advance invoice at collection period end", func() {
@@ -1169,6 +1205,15 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() 
 		s.Equal(float64(5), currentRun.CreditsAllocated[0].Amount.InexactFloat64())
 		s.Equal(float64(3), currentRun.CreditsAllocated[1].Amount.InexactFloat64())
 		s.True((*remainingCredits).IsZero())
+
+		expandedCharge := s.mustGetUsageBasedChargeByIDWithDetailedLines(usageBasedChargeID)
+		expandedRun, err := expandedCharge.GetCurrentRealizationRun()
+		s.NoError(err)
+		s.True(expandedRun.DetailedLines.IsPresent())
+		s.Len(expandedRun.DetailedLines.OrEmpty(), 1)
+		s.Equal("unit-price-usage@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]", expandedRun.DetailedLines.OrEmpty()[0].ChildUniqueReferenceID)
+		s.Equal(float64(125), expandedRun.DetailedLines.OrEmpty()[0].Quantity.InexactFloat64())
+		s.Equal(float64(0.1), expandedRun.DetailedLines.OrEmpty()[0].PerUnitAmount.InexactFloat64())
 	})
 
 	s.Run("#6 approve invoice and finalize the realization run at issuance", func() {
@@ -2073,4 +2118,40 @@ func (s *InvoicableChargesTestSuite) mustGetUsageBasedChargeByID(chargeID meta.C
 	s.NoError(err)
 
 	return usageBasedCharge
+}
+
+func (s *InvoicableChargesTestSuite) mustGetUsageBasedChargeByIDWithDetailedLines(chargeID meta.ChargeID) usagebased.Charge {
+	s.T().Helper()
+
+	charge, err := s.Charges.GetByID(s.T().Context(), charges.GetByIDInput{
+		ChargeID: chargeID,
+		Expands: meta.Expands{
+			meta.ExpandRealizations,
+			meta.ExpandDetailedLines,
+		},
+	})
+	s.NoError(err)
+
+	usageBasedCharge, err := charge.AsUsageBasedCharge()
+	s.NoError(err)
+
+	return usageBasedCharge
+}
+
+func (s *InvoicableChargesTestSuite) mustGetFlatFeeChargeByIDWithDetailedLines(chargeID meta.ChargeID) flatfee.Charge {
+	s.T().Helper()
+
+	charge, err := s.Charges.GetByID(s.T().Context(), charges.GetByIDInput{
+		ChargeID: chargeID,
+		Expands: meta.Expands{
+			meta.ExpandRealizations,
+			meta.ExpandDetailedLines,
+		},
+	})
+	s.NoError(err)
+
+	flatFeeCharge, err := charge.AsFlatFeeCharge()
+	s.NoError(err)
+
+	return flatFeeCharge
 }

--- a/openmeter/billing/charges/testutils/service.go
+++ b/openmeter/billing/charges/testutils/service.go
@@ -15,7 +15,6 @@ import (
 	creditpurchaseservice "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	flatfeeadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/adapter"
-	flatfeelineengine "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/lineengine"
 	flatfeeservice "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service"
 	lineageadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/adapter"
 	lineageservice "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/service"
@@ -137,25 +136,18 @@ func NewServices(t testing.TB, config Config) (*Services, error) {
 	}
 
 	flatFeeService, err := flatfeeservice.New(flatfeeservice.Config{
-		Adapter:     flatFeeAdapter,
-		Handler:     config.FlatFeeHandler,
-		Lineage:     lineageService,
-		MetaAdapter: metaAdapter,
-		Locker:      locker,
+		Adapter:       flatFeeAdapter,
+		Handler:       config.FlatFeeHandler,
+		Lineage:       lineageService,
+		MetaAdapter:   metaAdapter,
+		Locker:        locker,
+		RatingService: billingratingservice.New(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating flat fee service: %w", err)
 	}
 
-	flatFeeLineEngine, err := flatfeelineengine.New(flatfeelineengine.Config{
-		FlatFeeService: flatFeeService,
-		RatingService:  billingratingservice.New(),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating flat fee line engine: %w", err)
-	}
-
-	if err := config.BillingService.RegisterLineEngine(flatFeeLineEngine); err != nil {
+	if err := config.BillingService.RegisterLineEngine(flatFeeService.GetLineEngine()); err != nil {
 		return nil, fmt.Errorf("registering flat fee line engine: %w", err)
 	}
 

--- a/openmeter/billing/charges/usagebased/adapter.go
+++ b/openmeter/billing/charges/usagebased/adapter.go
@@ -31,6 +31,8 @@ type ChargeAdapter interface {
 type RealizationRunAdapter interface {
 	CreateRealizationRun(ctx context.Context, chargeID meta.ChargeID, input CreateRealizationRunInput) (RealizationRunBase, error)
 	UpdateRealizationRun(ctx context.Context, input UpdateRealizationRunInput) (RealizationRunBase, error)
+	UpsertRunDetailedLines(ctx context.Context, chargeID meta.ChargeID, runID RealizationRunID, lines DetailedLines) error
+	FetchDetailedLines(ctx context.Context, charge Charge) (Charge, error)
 }
 
 type RealizationRunCreditAllocationAdapter interface {

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -155,6 +155,15 @@ func (a *adapter) GetByIDs(ctx context.Context, input usagebased.GetByIDsInput) 
 			return nil, err
 		}
 
+		if input.Expands.Has(meta.ExpandDetailedLines) {
+			out, err = slicesx.MapWithErr(out, func(charge usagebased.Charge) (usagebased.Charge, error) {
+				return tx.FetchDetailedLines(ctx, charge)
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		return out, nil
 	})
 }
@@ -185,6 +194,13 @@ func (a *adapter) GetByID(ctx context.Context, input usagebased.GetByIDInput) (u
 		charge, err := MapChargeFromDB(entity, input.Expands)
 		if err != nil {
 			return usagebased.Charge{}, err
+		}
+
+		if input.Expands.Has(meta.ExpandDetailedLines) {
+			charge, err = tx.FetchDetailedLines(ctx, charge)
+			if err != nil {
+				return usagebased.Charge{}, err
+			}
 		}
 
 		return charge, nil

--- a/openmeter/billing/charges/usagebased/adapter/detailedline.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline.go
@@ -1,0 +1,200 @@
+package adapter
+
+import (
+	"context"
+	"slices"
+	"time"
+
+	"entgo.io/ent/dialect/sql"
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+
+	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	dbchargeusagebasedrundetailedline "github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedrundetailedline"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+)
+
+func (a *adapter) FetchDetailedLines(ctx context.Context, charge usagebased.Charge) (usagebased.Charge, error) {
+	if len(charge.Realizations) == 0 {
+		return charge, nil
+	}
+
+	runIDs := lo.Map(charge.Realizations, func(run usagebased.RealizationRun, _ int) string {
+		return run.ID.ID
+	})
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (usagebased.Charge, error) {
+		dbLines, err := tx.db.ChargeUsageBasedRunDetailedLine.Query().
+			Where(
+				dbchargeusagebasedrundetailedline.NamespaceEQ(charge.Namespace),
+				dbchargeusagebasedrundetailedline.ChargeIDEQ(charge.ID),
+				dbchargeusagebasedrundetailedline.RunIDIn(runIDs...),
+				dbchargeusagebasedrundetailedline.DeletedAtIsNil(),
+			).
+			WithTaxCode().
+			All(ctx)
+		if err != nil {
+			return usagebased.Charge{}, err
+		}
+
+		linesByRunID := make(map[string]usagebased.DetailedLines, len(charge.Realizations))
+		for _, dbLine := range dbLines {
+			line, err := mapDetailedLineFromDB(dbLine)
+			if err != nil {
+				return usagebased.Charge{}, err
+			}
+
+			linesByRunID[dbLine.RunID] = append(linesByRunID[dbLine.RunID], line)
+		}
+
+		for idx, run := range charge.Realizations {
+			lines := linesByRunID[run.ID.ID]
+			slices.SortStableFunc(lines, stddetailedline.Compare[usagebased.DetailedLine])
+			charge.Realizations[idx].DetailedLines = mo.Some(lines)
+		}
+
+		return charge, nil
+	})
+}
+
+func (a *adapter) UpsertRunDetailedLines(ctx context.Context, chargeID chargesmeta.ChargeID, runID usagebased.RealizationRunID, lines usagebased.DetailedLines) error {
+	if err := chargeID.Validate(); err != nil {
+		return err
+	}
+
+	if err := runID.Validate(); err != nil {
+		return err
+	}
+
+	if err := lines.Validate(); err != nil {
+		return err
+	}
+
+	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, tx *adapter) error {
+		createBuilders := make([]*entdb.ChargeUsageBasedRunDetailedLineCreate, 0, len(lines))
+
+		for _, line := range lines {
+			lineToPersist := line.Clone()
+			lineToPersist.Namespace = runID.Namespace
+			lineToPersist.DeletedAt = nil
+
+			create, err := buildDetailedLineCreate(tx.db, chargeID, runID, lineToPersist)
+			if err != nil {
+				return err
+			}
+
+			createBuilders = append(createBuilders, create)
+		}
+
+		now := clock.Now().In(time.UTC)
+		deleteQuery := tx.db.ChargeUsageBasedRunDetailedLine.Update().
+			Where(
+				dbchargeusagebasedrundetailedline.NamespaceEQ(runID.Namespace),
+				dbchargeusagebasedrundetailedline.ChargeIDEQ(chargeID.ID),
+				dbchargeusagebasedrundetailedline.RunIDEQ(runID.ID),
+				dbchargeusagebasedrundetailedline.DeletedAtIsNil(),
+			).
+			SetDeletedAt(now)
+
+		childRefsToKeep := lo.FilterMap(lines, func(line usagebased.DetailedLine, _ int) (string, bool) {
+			if line.ChildUniqueReferenceID == "" {
+				return "", false
+			}
+
+			return line.ChildUniqueReferenceID, true
+		})
+		if len(childRefsToKeep) > 0 {
+			deleteQuery = deleteQuery.Where(
+				dbchargeusagebasedrundetailedline.ChildUniqueReferenceIDNotIn(childRefsToKeep...),
+			)
+		}
+
+		if _, err := deleteQuery.Save(ctx); err != nil {
+			return err
+		}
+
+		if len(createBuilders) == 0 {
+			return nil
+		}
+
+		return tx.db.ChargeUsageBasedRunDetailedLine.CreateBulk(createBuilders...).
+			OnConflict(
+				sql.ConflictColumns(
+					dbchargeusagebasedrundetailedline.FieldNamespace,
+					dbchargeusagebasedrundetailedline.FieldChargeID,
+					dbchargeusagebasedrundetailedline.FieldRunID,
+					dbchargeusagebasedrundetailedline.FieldChildUniqueReferenceID,
+				),
+				sql.ConflictWhere(sql.IsNull(dbchargeusagebasedrundetailedline.FieldDeletedAt)),
+				sql.ResolveWithNewValues(),
+				sql.ResolveWith(func(u *sql.UpdateSet) {
+					u.SetIgnore(dbchargeusagebasedrundetailedline.FieldCreatedAt)
+					u.SetIgnore(dbchargeusagebasedrundetailedline.FieldID)
+				}),
+			).
+			UpdateDescription().
+			UpdateTaxConfig().
+			UpdateTaxCodeID().
+			UpdateTaxBehavior().
+			UpdateIndex().
+			UpdateDeletedAt().
+			UpdateInvoicingAppExternalID().
+			UpdateChildUniqueReferenceID().
+			UpdateCreditsApplied().
+			UpdateAnnotations().
+			UpdateMetadata().
+			Exec(ctx)
+	})
+}
+
+func buildDetailedLineCreate(db *entdb.Client, chargeID chargesmeta.ChargeID, runID usagebased.RealizationRunID, line usagebased.DetailedLine) (*entdb.ChargeUsageBasedRunDetailedLineCreate, error) {
+	if line.ID == "" {
+		line.ID = ulid.Make().String()
+	}
+
+	create := db.ChargeUsageBasedRunDetailedLine.Create().
+		SetID(line.ID).
+		SetNamespace(runID.Namespace).
+		SetChargeID(chargeID.ID).
+		SetRunID(runID.ID)
+
+	create = stddetailedline.Create(create, line)
+
+	if len(line.CreditsApplied) > 0 {
+		create = create.SetCreditsApplied(&line.CreditsApplied)
+	}
+
+	if line.TaxConfig != nil {
+		create = create.SetTaxConfig(*line.TaxConfig).
+			SetNillableTaxCodeID(line.TaxConfig.TaxCodeID).
+			SetNillableTaxBehavior(line.TaxConfig.Behavior)
+	}
+
+	return create, nil
+}
+
+func mapDetailedLineFromDB(dbLine *entdb.ChargeUsageBasedRunDetailedLine) (usagebased.DetailedLine, error) {
+	line := stddetailedline.FromDB(
+		dbLine,
+		stddetailedline.BackfillTaxConfig(
+			lo.EmptyableToPtr(dbLine.TaxConfig),
+			dbLine.TaxBehavior,
+			taxCodeIDFromEnt(dbLine.Edges.TaxCode),
+		),
+	)
+
+	return line, line.Validate()
+}
+
+func taxCodeIDFromEnt(resolvedTaxCode *entdb.TaxCode) *string {
+	if resolvedTaxCode == nil {
+		return nil
+	}
+
+	return lo.ToPtr(resolvedTaxCode.ID)
+}

--- a/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
@@ -1,7 +1,6 @@
 package adapter
 
 import (
-	"context"
 	"log/slog"
 	"testing"
 	"time"

--- a/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
@@ -1,0 +1,256 @@
+package adapter
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	metaadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/meta/adapter"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	dbchargeusagebasedrundetailedline "github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedrundetailedline"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+	"github.com/openmeterio/openmeter/tools/migrate"
+)
+
+func TestDetailedLineAdapter(t *testing.T) {
+	suite.Run(t, new(DetailedLineAdapterSuite))
+}
+
+type DetailedLineAdapterSuite struct {
+	suite.Suite
+
+	testDB   *testutils.TestDB
+	dbClient *entdb.Client
+	adapter  usagebased.Adapter
+}
+
+type newDetailedLineInput struct {
+	Charge                 usagebased.Charge
+	RunID                  usagebased.RealizationRunID
+	ServicePeriod          timeutil.ClosedPeriod
+	ChildUniqueReferenceID string
+	Quantity               int64
+	Description            *string
+}
+
+func (s *DetailedLineAdapterSuite) SetupSuite() {
+	t := s.T()
+
+	s.testDB = testutils.InitPostgresDB(t)
+	s.dbClient = entdb.NewClient(entdb.Driver(s.testDB.EntDriver.Driver()))
+
+	migrator, err := migrate.New(migrate.MigrateOptions{
+		ConnectionString: s.testDB.URL,
+		Migrations:       migrate.OMMigrationsConfig,
+		Logger:           slog.Default(),
+	})
+	require.NoError(t, err)
+	defer migrator.CloseOrLogError()
+	require.NoError(t, migrator.Up())
+
+	metaAdapter, err := metaadapter.New(metaadapter.Config{
+		Client: s.dbClient,
+		Logger: slog.Default(),
+	})
+	require.NoError(t, err)
+
+	a, err := New(Config{
+		Client:      s.dbClient,
+		Logger:      slog.Default(),
+		MetaAdapter: metaAdapter,
+	})
+	require.NoError(t, err)
+
+	s.adapter = a
+}
+
+func (s *DetailedLineAdapterSuite) TearDownSuite() {
+	s.dbClient.Close()
+	s.testDB.EntDriver.Close()
+	s.testDB.PGDriver.Close()
+}
+
+func (s *DetailedLineAdapterSuite) TestUpsertRunDetailedLinesReplacesAndSoftDeletesByChildUniqueReferenceID() {
+	ctx := context.Background()
+	namespace := "usagebased-detailedline-adapter"
+	customerID := s.createCustomer(namespace)
+	s.createFeature(namespace, "feature-1")
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	createdCharges, err := s.adapter.CreateCharges(ctx, usagebased.CreateChargesInput{
+		Namespace: namespace,
+		Intents: []usagebased.CreateIntent{
+			{
+				Intent: usagebased.Intent{
+					Intent: chargesmeta.Intent{
+						Name:              "usage-charge",
+						ManagedBy:         billing.SubscriptionManagedLine,
+						UniqueReferenceID: nil,
+						CustomerID:        customerID,
+						Currency:          currencyx.Code("USD"),
+						ServicePeriod:     servicePeriod,
+						FullServicePeriod: servicePeriod,
+						BillingPeriod:     servicePeriod,
+					},
+					InvoiceAt:      servicePeriod.To,
+					SettlementMode: productcatalog.CreditOnlySettlementMode,
+					FeatureKey:     "feature-1",
+					Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromFloat(0.1),
+					}),
+				},
+				FeatureID: "feature-1",
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(createdCharges, 1)
+
+	charge := createdCharges[0]
+	runBase, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunInput{
+		FeatureID:     "feature-1",
+		Type:          usagebased.RealizationRunTypeFinalRealization,
+		AsOf:          servicePeriod.To,
+		CollectionEnd: servicePeriod.To,
+		MeterValue:    alpacadecimal.NewFromInt(10),
+		Totals: totals.Totals{
+			Amount:       alpacadecimal.NewFromInt(1),
+			ChargesTotal: alpacadecimal.NewFromInt(1),
+			Total:        alpacadecimal.NewFromInt(1),
+		},
+	})
+	s.Require().NoError(err)
+
+	initialLines := usagebased.DetailedLines{
+		s.newDetailedLine(newDetailedLineInput{
+			Charge:                 charge,
+			RunID:                  runBase.ID,
+			ServicePeriod:          servicePeriod,
+			ChildUniqueReferenceID: "keep@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
+			Quantity:               1,
+			Description:            lo.ToPtr("old description"),
+		}),
+		s.newDetailedLine(newDetailedLineInput{
+			Charge:                 charge,
+			RunID:                  runBase.ID,
+			ServicePeriod:          servicePeriod,
+			ChildUniqueReferenceID: "delete@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
+			Quantity:               2,
+			Description:            lo.ToPtr("delete me"),
+		}),
+	}
+	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, charge.GetChargeID(), runBase.ID, initialLines))
+
+	replacementLines := usagebased.DetailedLines{
+		s.newDetailedLine(newDetailedLineInput{
+			Charge:                 charge,
+			RunID:                  runBase.ID,
+			ServicePeriod:          servicePeriod,
+			ChildUniqueReferenceID: "keep@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
+			Quantity:               3,
+		}),
+		s.newDetailedLine(newDetailedLineInput{
+			Charge:                 charge,
+			RunID:                  runBase.ID,
+			ServicePeriod:          servicePeriod,
+			ChildUniqueReferenceID: "new@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
+			Quantity:               4,
+			Description:            lo.ToPtr("new description"),
+		}),
+	}
+	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, charge.GetChargeID(), runBase.ID, replacementLines))
+
+	fetchedCharge, err := s.adapter.GetByID(ctx, usagebased.GetByIDInput{
+		ChargeID: charge.GetChargeID(),
+		Expands: chargesmeta.Expands{
+			chargesmeta.ExpandRealizations,
+			chargesmeta.ExpandDetailedLines,
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(fetchedCharge.Realizations, 1)
+	s.True(fetchedCharge.Realizations[0].DetailedLines.IsPresent())
+	s.Len(fetchedCharge.Realizations[0].DetailedLines.OrEmpty(), 2)
+	s.Equal("keep@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]", fetchedCharge.Realizations[0].DetailedLines.OrEmpty()[0].ChildUniqueReferenceID)
+	s.Equal("new@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]", fetchedCharge.Realizations[0].DetailedLines.OrEmpty()[1].ChildUniqueReferenceID)
+	s.Equal(float64(3), fetchedCharge.Realizations[0].DetailedLines.OrEmpty()[0].Quantity.InexactFloat64())
+	s.Nil(fetchedCharge.Realizations[0].DetailedLines.OrEmpty()[0].Description)
+
+	deletedRow, err := s.dbClient.ChargeUsageBasedRunDetailedLine.Query().
+		Where(
+			dbchargeusagebasedrundetailedline.NamespaceEQ(namespace),
+			dbchargeusagebasedrundetailedline.ChargeIDEQ(charge.ID),
+			dbchargeusagebasedrundetailedline.RunIDEQ(runBase.ID.ID),
+			dbchargeusagebasedrundetailedline.ChildUniqueReferenceIDEQ("delete@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]"),
+		).
+		Only(ctx)
+	s.Require().NoError(err)
+	s.NotNil(deletedRow.DeletedAt)
+}
+
+func (s *DetailedLineAdapterSuite) createCustomer(namespace string) string {
+	s.T().Helper()
+
+	customer, err := s.dbClient.Customer.Create().
+		SetNamespace(namespace).
+		SetName("test-customer").
+		Save(s.T().Context())
+	s.Require().NoError(err)
+
+	return customer.ID
+}
+
+func (s *DetailedLineAdapterSuite) createFeature(namespace, featureID string) {
+	s.T().Helper()
+
+	_, err := s.dbClient.Feature.Create().
+		SetNamespace(namespace).
+		SetID(featureID).
+		SetName("test-feature").
+		SetKey(featureID).
+		Save(s.T().Context())
+	s.Require().NoError(err)
+}
+
+func (s *DetailedLineAdapterSuite) newDetailedLine(input newDetailedLineInput) usagebased.DetailedLine {
+	s.T().Helper()
+
+	return usagebased.DetailedLine{
+		ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+			Namespace:   input.Charge.Namespace,
+			Name:        "Detailed line",
+			Description: input.Description,
+		}),
+		ServicePeriod:          input.ServicePeriod,
+		Currency:               input.Charge.Intent.Currency,
+		ChildUniqueReferenceID: input.ChildUniqueReferenceID,
+		PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+		PerUnitAmount:          alpacadecimal.NewFromFloat(0.1),
+		Quantity:               alpacadecimal.NewFromInt(input.Quantity),
+		Category:               stddetailedline.CategoryRegular,
+		Totals: totals.Totals{
+			Amount:       alpacadecimal.NewFromFloat(0.1).Mul(alpacadecimal.NewFromInt(input.Quantity)),
+			ChargesTotal: alpacadecimal.NewFromFloat(0.1).Mul(alpacadecimal.NewFromInt(input.Quantity)),
+			Total:        alpacadecimal.NewFromFloat(0.1).Mul(alpacadecimal.NewFromInt(input.Quantity)),
+		},
+	}
+}

--- a/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
@@ -86,7 +86,7 @@ func (s *DetailedLineAdapterSuite) TearDownSuite() {
 }
 
 func (s *DetailedLineAdapterSuite) TestUpsertRunDetailedLinesReplacesAndSoftDeletesByChildUniqueReferenceID() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	namespace := "usagebased-detailedline-adapter"
 	customerID := s.createCustomer(namespace)
 	s.createFeature(namespace, "feature-1")

--- a/openmeter/billing/charges/usagebased/detailedline.go
+++ b/openmeter/billing/charges/usagebased/detailedline.go
@@ -1,0 +1,33 @@
+package usagebased
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type DetailedLine = stddetailedline.Base
+
+type DetailedLines []DetailedLine
+
+func (l DetailedLines) Clone() DetailedLines {
+	return lo.Map(l, func(dl DetailedLine, _ int) DetailedLine {
+		return dl.Clone()
+	})
+}
+
+func (l DetailedLines) Validate() error {
+	var errs []error
+
+	for idx, line := range l {
+		if err := line.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("[%d]: %w", idx, err))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}

--- a/openmeter/billing/charges/usagebased/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/realizationrun.go
@@ -213,7 +213,7 @@ type RealizationRun struct {
 	CreditsAllocated creditrealization.Realizations `json:"creditsAllocated"`
 	InvoiceUsage     *invoicedusage.AccruedUsage    `json:"invoicedUsage"`
 	Payment          *payment.Invoiced              `json:"payment"`
-	DetailedLines    mo.Option[DetailedLines]       `json:"detailedLines,omitempty"`
+	DetailedLines    mo.Option[DetailedLines]       `json:"detailedLines,omitzero"`
 }
 
 func (r RealizationRun) Validate() error {

--- a/openmeter/billing/charges/usagebased/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/realizationrun.go
@@ -213,6 +213,7 @@ type RealizationRun struct {
 	CreditsAllocated creditrealization.Realizations `json:"creditsAllocated"`
 	InvoiceUsage     *invoicedusage.AccruedUsage    `json:"invoicedUsage"`
 	Payment          *payment.Invoiced              `json:"payment"`
+	DetailedLines    mo.Option[DetailedLines]       `json:"detailedLines,omitempty"`
 }
 
 func (r RealizationRun) Validate() error {
@@ -235,6 +236,12 @@ func (r RealizationRun) Validate() error {
 	if r.Payment != nil {
 		if err := r.Payment.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("payment: %w", err))
+		}
+	}
+
+	if r.DetailedLines.IsPresent() {
+		if err := r.DetailedLines.OrEmpty().Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("detailed lines: %w", err))
 		}
 	}
 
@@ -267,6 +274,12 @@ func (r RealizationRuns) GetByID(id string) (RealizationRun, error) {
 		}
 	}
 	return RealizationRun{}, fmt.Errorf("realization run not found [id=%s]", id)
+}
+
+func (r RealizationRuns) Without(id RealizationRunID) RealizationRuns {
+	return lo.Filter(r, func(run RealizationRun, _ int) bool {
+		return run.ID != id
+	})
 }
 
 func (r *RealizationRuns) SetRealizationRun(updatedRun RealizationRun) error {

--- a/openmeter/billing/charges/usagebased/service.go
+++ b/openmeter/billing/charges/usagebased/service.go
@@ -108,7 +108,7 @@ func (i GetByIDsInput) Validate() error {
 		errs = append(errs, errors.New("namespace is required"))
 	}
 
-	if err := i.Expands.Validate(); err != nil {
+	if err := validateExpands(i.Expands); err != nil {
 		errs = append(errs, fmt.Errorf("expands: %w", err))
 	}
 
@@ -153,7 +153,7 @@ func (i GetByIDInput) Validate() error {
 		errs = append(errs, fmt.Errorf("charge ID: %w", err))
 	}
 
-	if err := i.Expands.Validate(); err != nil {
+	if err := validateExpands(i.Expands); err != nil {
 		errs = append(errs, fmt.Errorf("expands: %w", err))
 	}
 
@@ -175,4 +175,16 @@ func (i GetCurrentTotalsInput) Validate() error {
 type GetCurrentTotalsResult struct {
 	Charge    Charge
 	DueTotals totals.Totals
+}
+
+func validateExpands(expands meta.Expands) error {
+	if err := expands.Validate(); err != nil {
+		return err
+	}
+
+	if expands.Has(meta.ExpandDetailedLines) && !expands.Has(meta.ExpandRealizations) {
+		return fmt.Errorf("%q requires %q", meta.ExpandDetailedLines, meta.ExpandRealizations)
+	}
+
+	return nil
 }

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -176,6 +176,10 @@ func (s *CreditThenInvoiceStateMachine) SnapshotInvoiceUsage(ctx context.Context
 		return fmt.Errorf("no realization run in progress [charge_id=%s]", s.Charge.ID)
 	}
 
+	if err := s.ensureDetailedLinesLoadedForRating(ctx); err != nil {
+		return err
+	}
+
 	currentRun, err := s.Charge.Realizations.GetByID(*s.Charge.State.CurrentRealizationRunID)
 	if err != nil {
 		return fmt.Errorf("get current realization run: %w", err)
@@ -183,8 +187,9 @@ func (s *CreditThenInvoiceStateMachine) SnapshotInvoiceUsage(ctx context.Context
 
 	storedAtOffset := meta.NormalizeTimestamp(currentRun.CollectionEnd)
 
-	ratingResult, err := s.Rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
+	ratingResult, err := s.Rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetDetailedLinesForUsageInput{
 		Charge:         s.Charge,
+		PriorRuns:      s.Charge.Realizations.Without(currentRun.ID),
 		Customer:       s.CustomerOverride,
 		FeatureMeter:   s.FeatureMeter,
 		StoredAtOffset: storedAtOffset,
@@ -210,6 +215,12 @@ func (s *CreditThenInvoiceStateMachine) SnapshotInvoiceUsage(ctx context.Context
 	currentRun.CreditsAllocated = append(currentRun.CreditsAllocated, reconcileResult.Realizations...)
 	currentTotals.CreditsTotal = s.CurrencyCalculator.RoundToPrecision(currentRun.CreditsAllocated.Sum())
 	currentTotals.Total = s.CurrencyCalculator.RoundToPrecision(currentTotals.Total.Sub(currentTotals.CreditsTotal))
+
+	runDetailedLines, err := s.Runs.PersistRunDetailedLines(ctx, s.Charge, currentRun, ratingResult)
+	if err != nil {
+		return err
+	}
+	currentRun.DetailedLines = mo.Some(runDetailedLines)
 
 	currentRunBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
 		ID:         currentRun.ID,

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -174,6 +174,10 @@ func (s *CreditsOnlyStateMachine) FinalizeRealizationRun(ctx context.Context) er
 		return fmt.Errorf("no realization run in progress [charge_id=%s]", s.Charge.ID)
 	}
 
+	if err := s.ensureDetailedLinesLoadedForRating(ctx); err != nil {
+		return err
+	}
+
 	currentRun, err := s.Charge.Realizations.GetByID(*s.Charge.State.CurrentRealizationRunID)
 	if err != nil {
 		return fmt.Errorf("get current realization run: %w", err)
@@ -181,8 +185,9 @@ func (s *CreditsOnlyStateMachine) FinalizeRealizationRun(ctx context.Context) er
 
 	storedAtOffset := meta.NormalizeTimestamp(clock.Now().Add(-usagebased.InternalCollectionPeriod))
 
-	ratingResult, err := s.Rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
+	ratingResult, err := s.Rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetDetailedLinesForUsageInput{
 		Charge:         s.Charge,
+		PriorRuns:      s.Charge.Realizations.Without(currentRun.ID),
 		Customer:       s.CustomerOverride,
 		FeatureMeter:   s.FeatureMeter,
 		StoredAtOffset: storedAtOffset,
@@ -207,6 +212,12 @@ func (s *CreditsOnlyStateMachine) FinalizeRealizationRun(ctx context.Context) er
 
 	currentTotals.CreditsTotal = currentTotals.CreditsTotal.Add(targetCreditsTotal)
 	currentTotals.Total = alpacadecimal.Zero
+
+	runDetailedLines, err := s.Runs.PersistRunDetailedLines(ctx, s.Charge, currentRun, ratingResult)
+	if err != nil {
+		return err
+	}
+	currentRun.DetailedLines = mo.Some(runDetailedLines)
 
 	if _, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
 		ID:         currentRun.ID,

--- a/openmeter/billing/charges/usagebased/service/currenttotals.go
+++ b/openmeter/billing/charges/usagebased/service/currenttotals.go
@@ -48,7 +48,7 @@ func (s *service) GetCurrentTotals(ctx context.Context, input usagebased.GetCurr
 		return usagebased.GetCurrentTotalsResult{}, err
 	}
 
-	dueTotals, err := s.rater.GetTotalsForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
+	dueTotals, err := s.rater.GetTotalsForUsage(ctx, usagebasedrating.GetTotalsForUsageInput{
 		Charge:         charge,
 		Customer:       customerOverride,
 		FeatureMeter:   featureMeter,

--- a/openmeter/billing/charges/usagebased/service/get.go
+++ b/openmeter/billing/charges/usagebased/service/get.go
@@ -143,7 +143,7 @@ func (s *service) expandChargesUsage(ctx context.Context, namespace string, char
 			}()
 
 			var dueTotals totals.Totals
-			dueTotals, err = s.rater.GetTotalsForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
+			dueTotals, err = s.rater.GetTotalsForUsage(ctx, usagebasedrating.GetTotalsForUsageInput{
 				Charge:         charge,
 				Customer:       customerOverridesById[charge.GetCustomerID()],
 				FeatureMeter:   featureMeter,

--- a/openmeter/billing/charges/usagebased/service/rating/details.go
+++ b/openmeter/billing/charges/usagebased/service/rating/details.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"

--- a/openmeter/billing/charges/usagebased/service/rating/details.go
+++ b/openmeter/billing/charges/usagebased/service/rating/details.go
@@ -3,13 +3,61 @@ package rating
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 )
+
+type GetDetailedLinesForUsageInput struct {
+	Charge         usagebased.Charge
+	PriorRuns      usagebased.RealizationRuns
+	Customer       billing.CustomerOverrideWithDetails
+	FeatureMeter   feature.FeatureMeter
+	StoredAtOffset time.Time
+}
+
+func (i GetDetailedLinesForUsageInput) Validate() error {
+	if err := i.Charge.Validate(); err != nil {
+		return fmt.Errorf("charge: %w", err)
+	}
+
+	if i.Customer.Customer == nil {
+		return fmt.Errorf("customer is required")
+	}
+
+	if i.FeatureMeter.Meter == nil {
+		return fmt.Errorf("feature meter is required")
+	}
+
+	if i.StoredAtOffset.IsZero() {
+		return fmt.Errorf("stored at offset is required")
+	}
+
+	if err := i.PriorRuns.Validate(); err != nil {
+		return fmt.Errorf("prior runs: %w", err)
+	}
+
+	for idx, run := range i.PriorRuns {
+		if !run.DetailedLines.IsPresent() {
+			return fmt.Errorf("prior runs[%d]: detailed lines must be expanded", idx)
+		}
+	}
+
+	return nil
+}
+
+type GetRatingForUsageResult struct {
+	billingrating.GenerateDetailedLinesResult
+	Quantity alpacadecimal.Decimal
+}
 
 // GetDetailedLinesForUsage returns the rated detailed lines together with the metered quantity snapshot
 // used to compute them. Prefer GetTotalsForUsage when only totals are needed because it is faster.
-func (s *Service) GetDetailedLinesForUsage(ctx context.Context, in GetRatingForUsageInput) (GetRatingForUsageResult, error) {
+func (s *service) GetDetailedLinesForUsage(ctx context.Context, in GetDetailedLinesForUsageInput) (GetRatingForUsageResult, error) {
 	if err := in.Validate(); err != nil {
 		return GetRatingForUsageResult{}, err
 	}
@@ -31,6 +79,11 @@ func (s *Service) GetDetailedLinesForUsage(ctx context.Context, in GetRatingForU
 	if err != nil {
 		return GetRatingForUsageResult{}, fmt.Errorf("rating: %w", err)
 	}
+
+	ratingResult.DetailedLines = withServicePeriodInDetailedLineChildUniqueReferenceIDs(
+		ratingResult.DetailedLines,
+		in.Charge.Intent.ServicePeriod,
+	)
 
 	return GetRatingForUsageResult{
 		GenerateDetailedLinesResult: ratingResult,

--- a/openmeter/billing/charges/usagebased/service/rating/quantitysnapshot.go
+++ b/openmeter/billing/charges/usagebased/service/rating/quantitysnapshot.go
@@ -38,7 +38,7 @@ func (i snapshotQuantityInput) Validate() error {
 	return nil
 }
 
-func (s *Service) snapshotQuantity(ctx context.Context, in snapshotQuantityInput) (alpacadecimal.Decimal, error) {
+func (s *service) snapshotQuantity(ctx context.Context, in snapshotQuantityInput) (alpacadecimal.Decimal, error) {
 	if err := in.Validate(); err != nil {
 		return alpacadecimal.Zero, billing.ValidationError{
 			Err: err,

--- a/openmeter/billing/charges/usagebased/service/rating/service.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service.go
@@ -1,16 +1,11 @@
 package rating
 
 import (
+	"context"
 	"errors"
-	"fmt"
-	"time"
 
-	"github.com/alpacahq/alpacadecimal"
-
-	"github.com/openmeterio/openmeter/openmeter/billing"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 )
 
@@ -33,50 +28,27 @@ func (c Config) Validate() error {
 	return errors.Join(errs...)
 }
 
-type Service struct {
+type Service interface {
+	// GetTotalsForUsage returns charge totals for a usage snapshot without generating detailed lines.
+	// Prefer this when only totals are required because it is faster than generating detailed lines.
+	GetTotalsForUsage(ctx context.Context, in GetTotalsForUsageInput) (totals.Totals, error)
+	// GetDetailedLinesForUsage returns rated detailed lines and the metered quantity snapshot used to compute them.
+	// Prefer GetTotalsForUsage when only totals are required because it is faster.
+	GetDetailedLinesForUsage(ctx context.Context, in GetDetailedLinesForUsageInput) (GetRatingForUsageResult, error)
+}
+
+type service struct {
 	streamingConnector streaming.Connector
 	ratingService      billingrating.Service
 }
 
-func New(config Config) (*Service, error) {
+func New(config Config) (Service, error) {
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
 
-	return &Service{
+	return &service{
 		streamingConnector: config.StreamingConnector,
 		ratingService:      config.RatingService,
 	}, nil
-}
-
-type GetRatingForUsageResult struct {
-	billingrating.GenerateDetailedLinesResult
-	Quantity alpacadecimal.Decimal
-}
-
-type GetRatingForUsageInput struct {
-	Charge         usagebased.Charge
-	Customer       billing.CustomerOverrideWithDetails
-	FeatureMeter   feature.FeatureMeter
-	StoredAtOffset time.Time
-}
-
-func (i GetRatingForUsageInput) Validate() error {
-	if err := i.Charge.Validate(); err != nil {
-		return fmt.Errorf("charge: %w", err)
-	}
-
-	if i.Customer.Customer == nil {
-		return fmt.Errorf("customer is required")
-	}
-
-	if i.FeatureMeter.Meter == nil {
-		return fmt.Errorf("feature meter is required")
-	}
-
-	if i.StoredAtOffset.IsZero() {
-		return fmt.Errorf("stored at offset is required")
-	}
-
-	return nil
 }

--- a/openmeter/billing/charges/usagebased/service/rating/service_test.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service_test.go
@@ -1,0 +1,164 @@
+package rating
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestFormatDetailedLineChildUniqueReferenceID(t *testing.T) {
+	t.Parallel()
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2025, 1, 1, 12, 30, 45, 0, time.FixedZone("CET", 3600)),
+		To:   time.Date(2025, 2, 1, 1, 2, 3, 0, time.FixedZone("PST", -8*3600)),
+	}
+
+	require.Equal(
+		t,
+		"unit-price-usage@[2025-01-01T11:30:45Z..2025-02-01T09:02:03Z]",
+		formatDetailedLineChildUniqueReferenceID("unit-price-usage", servicePeriod),
+	)
+}
+
+func TestGetRatingForUsageAddsServicePeriodToDetailedLineChildUniqueReferenceIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
+	streamingConnector.AddSimpleEvent("meter-1", 12, servicePeriod.From.Add(30*time.Minute))
+
+	svc, err := New(Config{
+		StreamingConnector: streamingConnector,
+		RatingService: stubRatingService{
+			result: billingrating.GenerateDetailedLinesResult{
+				DetailedLines: billingrating.DetailedLines{
+					{
+						Name:                   "Usage",
+						Quantity:               alpacadecimal.NewFromInt(12),
+						PerUnitAmount:          alpacadecimal.NewFromInt(3),
+						ChildUniqueReferenceID: "unit-price-usage",
+					},
+					{
+						Name:                   "Discount",
+						Quantity:               alpacadecimal.NewFromInt(1),
+						PerUnitAmount:          alpacadecimal.NewFromInt(1),
+						ChildUniqueReferenceID: "rateCardDiscount/correlationID=discount-50pct",
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	out, err := svc.GetDetailedLinesForUsage(ctx, GetDetailedLinesForUsageInput{
+		Charge: usagebased.Charge{
+			ChargeBase: usagebased.ChargeBase{
+				ManagedResource: chargesmeta.ManagedResource{
+					NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+					ManagedModel: models.ManagedModel{
+						CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+						UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+					},
+					ID: "charge-1",
+				},
+				Intent: usagebased.Intent{
+					Intent: chargesmeta.Intent{
+						Name:              "usage-charge",
+						ManagedBy:         billing.SubscriptionManagedLine,
+						CustomerID:        "customer-1",
+						Currency:          currencyx.Code("USD"),
+						ServicePeriod:     servicePeriod,
+						FullServicePeriod: servicePeriod,
+						BillingPeriod:     servicePeriod,
+					},
+					InvoiceAt:      time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+					SettlementMode: productcatalog.InvoiceOnlySettlementMode,
+					FeatureKey:     "feature-1",
+					Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromInt(3),
+					}),
+				},
+				Status: usagebased.StatusCreated,
+				State: usagebased.State{
+					FeatureID: "feature-1",
+				},
+			},
+		},
+		Customer: billing.CustomerOverrideWithDetails{
+			Customer: &customer.Customer{
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Namespace: "ns",
+					ID:        "customer-1",
+					Name:      "Customer 1",
+					CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				}),
+				Key: lo.ToPtr("cust-1"),
+			},
+		},
+		FeatureMeter: feature.FeatureMeter{
+			Feature: feature.Feature{
+				Namespace: "ns",
+				ID:        "feature-1",
+				Name:      "Feature 1",
+				Key:       "feature-1",
+				MeterID:   lo.ToPtr("meter-1"),
+				CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Meter: &meter.Meter{
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Namespace: "ns",
+					ID:        "meter-1",
+					Name:      "Meter 1",
+					CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				}),
+				Key:           "meter-1",
+				Aggregation:   meter.MeterAggregationSum,
+				EventType:     "event.type",
+				ValueProperty: lo.ToPtr("value"),
+			},
+		},
+		StoredAtOffset: time.Date(2025, 2, 2, 0, 0, 0, 0, time.UTC),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "unit-price-usage@[2025-01-01T00:00:00Z..2025-02-01T00:00:00Z]", out.DetailedLines[0].ChildUniqueReferenceID)
+	require.Equal(t, "rateCardDiscount/correlationID=discount-50pct@[2025-01-01T00:00:00Z..2025-02-01T00:00:00Z]", out.DetailedLines[1].ChildUniqueReferenceID)
+}
+
+type stubRatingService struct {
+	result billingrating.GenerateDetailedLinesResult
+}
+
+func (s stubRatingService) ResolveBillablePeriod(in billingrating.ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error) {
+	return nil, nil
+}
+
+func (s stubRatingService) GenerateDetailedLines(in billingrating.StandardLineAccessor) (billingrating.GenerateDetailedLinesResult, error) {
+	return s.result, nil
+}

--- a/openmeter/billing/charges/usagebased/service/rating/totals.go
+++ b/openmeter/billing/charges/usagebased/service/rating/totals.go
@@ -3,14 +3,44 @@ package rating
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 )
+
+type GetTotalsForUsageInput struct {
+	Charge         usagebased.Charge
+	Customer       billing.CustomerOverrideWithDetails
+	FeatureMeter   feature.FeatureMeter
+	StoredAtOffset time.Time
+}
+
+func (i GetTotalsForUsageInput) Validate() error {
+	if err := i.Charge.Validate(); err != nil {
+		return fmt.Errorf("charge: %w", err)
+	}
+
+	if i.Customer.Customer == nil {
+		return fmt.Errorf("customer is required")
+	}
+
+	if i.FeatureMeter.Meter == nil {
+		return fmt.Errorf("feature meter is required")
+	}
+
+	if i.StoredAtOffset.IsZero() {
+		return fmt.Errorf("stored at offset is required")
+	}
+
+	return nil
+}
 
 // GetTotalsForUsage returns the rated totals for the charge at the requested stored-at offset.
 // It avoids generating detailed lines, so prefer it over GetDetailedLinesForUsage when only totals are needed.
-func (s *Service) GetTotalsForUsage(ctx context.Context, in GetRatingForUsageInput) (totals.Totals, error) {
+func (s *service) GetTotalsForUsage(ctx context.Context, in GetTotalsForUsageInput) (totals.Totals, error) {
 	if err := in.Validate(); err != nil {
 		return totals.Totals{}, err
 	}

--- a/openmeter/billing/charges/usagebased/service/rating/uniqueref.go
+++ b/openmeter/billing/charges/usagebased/service/rating/uniqueref.go
@@ -1,0 +1,33 @@
+package rating
+
+import (
+	"fmt"
+	"time"
+
+	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+// formatDetailedLineChildUniqueReferenceID turns a rating-local detailed line key
+// into the persisted child reference by appending the rated service period in UTC.
+func formatDetailedLineChildUniqueReferenceID(id string, servicePeriod timeutil.ClosedPeriod) string {
+	return fmt.Sprintf(
+		"%s@[%s..%s]",
+		id,
+		servicePeriod.From.UTC().Format(time.RFC3339),
+		servicePeriod.To.UTC().Format(time.RFC3339),
+	)
+}
+
+// withServicePeriodInDetailedLineChildUniqueReferenceIDs rewrites the generated
+// detailed lines so each child unique reference carries the charge service period.
+func withServicePeriodInDetailedLineChildUniqueReferenceIDs(lines billingrating.DetailedLines, servicePeriod timeutil.ClosedPeriod) billingrating.DetailedLines {
+	out := make(billingrating.DetailedLines, len(lines))
+
+	for idx, line := range lines {
+		line.ChildUniqueReferenceID = formatDetailedLineChildUniqueReferenceID(line.ChildUniqueReferenceID, servicePeriod)
+		out[idx] = line
+	}
+
+	return out
+}

--- a/openmeter/billing/charges/usagebased/service/run/create.go
+++ b/openmeter/billing/charges/usagebased/service/run/create.go
@@ -109,8 +109,15 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 		return CreateRatedRunResult{}, err
 	}
 
-	ratingResult, err := s.rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetRatingForUsageInput{
+	chargeWithDetailedLines, err := s.ensureDetailedLinesLoadedForRating(ctx, in.Charge)
+	if err != nil {
+		return CreateRatedRunResult{}, err
+	}
+	in.Charge = chargeWithDetailedLines
+
+	ratingResult, err := s.rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetDetailedLinesForUsageInput{
 		Charge:         in.Charge,
+		PriorRuns:      in.Charge.Realizations,
 		Customer:       in.CustomerOverride,
 		FeatureMeter:   in.FeatureMeter,
 		StoredAtOffset: in.AsOf,
@@ -146,6 +153,12 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 		return CreateRatedRunResult{}, err
 	}
 
+	currentRunDetailedLines, err := s.PersistRunDetailedLines(ctx, updatedCharge, currentRun, ratingResult)
+	if err != nil {
+		return CreateRatedRunResult{}, err
+	}
+	currentRun.DetailedLines = mo.Some(currentRunDetailedLines)
+
 	if in.CreditAllocation != CreditAllocationNone {
 		allocationResult, err := s.allocate(ctx, allocateCreditRealizationsInput{
 			Charge:             updatedCharge,
@@ -178,6 +191,10 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 		if err := updatedCharge.Realizations.SetRealizationRun(currentRun); err != nil {
 			return CreateRatedRunResult{}, fmt.Errorf("update realization run: %w", err)
 		}
+	}
+
+	if err := updatedCharge.Realizations.SetRealizationRun(currentRun); err != nil {
+		return CreateRatedRunResult{}, fmt.Errorf("update realization run detailed lines: %w", err)
 	}
 
 	return CreateRatedRunResult{

--- a/openmeter/billing/charges/usagebased/service/run/detailedline.go
+++ b/openmeter/billing/charges/usagebased/service/run/detailedline.go
@@ -1,0 +1,95 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	usagebasedrating "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/rating"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func (s *Service) ensureDetailedLinesLoadedForRating(ctx context.Context, charge usagebased.Charge) (usagebased.Charge, error) {
+	if len(charge.Realizations) == 0 {
+		return charge, nil
+	}
+
+	if lo.EveryBy(charge.Realizations, func(run usagebased.RealizationRun) bool {
+		return run.DetailedLines.IsPresent()
+	}) {
+		return charge, nil
+	}
+
+	expandedCharge, err := s.adapter.FetchDetailedLines(ctx, charge)
+	if err != nil {
+		return usagebased.Charge{}, fmt.Errorf("fetch detailed lines: %w", err)
+	}
+
+	return expandedCharge, nil
+}
+
+func mapRatingResultToRunDetailedLines(
+	charge usagebased.Charge,
+	run usagebased.RealizationRun,
+	ratingResult usagebasedrating.GetRatingForUsageResult,
+) usagebased.DetailedLines {
+	return lo.Map(ratingResult.DetailedLines, func(line billingrating.DetailedLine, _ int) usagebased.DetailedLine {
+		period := charge.Intent.ServicePeriod
+		if line.Period != nil {
+			period = *line.Period
+		}
+
+		category := line.Category
+		if category == "" {
+			category = stddetailedline.CategoryRegular
+		}
+
+		paymentTerm := lo.CoalesceOrEmpty(line.PaymentTerm, productcatalog.InArrearsPaymentTerm)
+
+		return usagebased.DetailedLine{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace: charge.Namespace,
+				Name:      line.Name,
+			}),
+			ServicePeriod:          period,
+			Currency:               charge.Intent.Currency,
+			ChildUniqueReferenceID: line.ChildUniqueReferenceID,
+			PaymentTerm:            paymentTerm,
+			PerUnitAmount:          line.PerUnitAmount,
+			Quantity:               line.Quantity,
+			Category:               category,
+			CreditsApplied:         line.CreditsApplied,
+			Totals:                 line.Totals,
+			TaxConfig:              cloneTaxConfig(charge.Intent.TaxConfig),
+		}
+	})
+}
+
+func cloneTaxConfig(cfg *productcatalog.TaxConfig) *productcatalog.TaxConfig {
+	if cfg == nil {
+		return nil
+	}
+
+	cloned := cfg.Clone()
+	return &cloned
+}
+
+func (s *Service) PersistRunDetailedLines(
+	ctx context.Context,
+	charge usagebased.Charge,
+	run usagebased.RealizationRun,
+	ratingResult usagebasedrating.GetRatingForUsageResult,
+) (usagebased.DetailedLines, error) {
+	detailedLines := mapRatingResultToRunDetailedLines(charge, run, ratingResult)
+
+	if err := s.adapter.UpsertRunDetailedLines(ctx, charge.GetChargeID(), run.ID, detailedLines); err != nil {
+		return nil, fmt.Errorf("upsert run detailed lines: %w", err)
+	}
+
+	return detailedLines, nil
+}

--- a/openmeter/billing/charges/usagebased/service/run/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/service/run/detailedline_test.go
@@ -1,0 +1,79 @@
+package run
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	usagebasedrating "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/rating"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestMapRatingResultToRunDetailedLines(t *testing.T) {
+	t.Parallel()
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	charge := usagebased.Charge{
+		ChargeBase: usagebased.ChargeBase{
+			ManagedResource: chargesmeta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+				ID:              "charge-1",
+			},
+			Intent: usagebased.Intent{
+				Intent: chargesmeta.Intent{
+					Currency:      currencyx.Code("USD"),
+					ServicePeriod: servicePeriod,
+					TaxConfig: &productcatalog.TaxConfig{
+						Behavior: lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
+					},
+				},
+			},
+		},
+	}
+
+	run := usagebased.RealizationRun{
+		RealizationRunBase: usagebased.RealizationRunBase{
+			ID: usagebased.RealizationRunID{
+				Namespace: "ns",
+				ID:        "run-1",
+			},
+		},
+	}
+
+	in := usagebasedrating.GetRatingForUsageResult{
+		GenerateDetailedLinesResult: billingrating.GenerateDetailedLinesResult{
+			DetailedLines: billingrating.DetailedLines{
+				{
+					Name:                   "Usage",
+					Quantity:               alpacadecimal.NewFromInt(12),
+					PerUnitAmount:          alpacadecimal.NewFromInt(3),
+					ChildUniqueReferenceID: "unit-price-usage@[2025-01-01T00:00:00Z..2025-02-01T00:00:00Z]",
+				},
+			},
+		},
+	}
+
+	out := mapRatingResultToRunDetailedLines(charge, run, in)
+	require.Len(t, out, 1)
+	require.Equal(t, "ns", out[0].Namespace)
+	require.Equal(t, servicePeriod, out[0].ServicePeriod)
+	require.Equal(t, currencyx.Code("USD"), out[0].Currency)
+	require.Equal(t, productcatalog.InArrearsPaymentTerm, out[0].PaymentTerm)
+	require.Equal(t, stddetailedline.CategoryRegular, out[0].Category)
+	require.NotNil(t, out[0].TaxConfig)
+	require.NotSame(t, charge.Intent.TaxConfig, out[0].TaxConfig)
+}

--- a/openmeter/billing/charges/usagebased/service/run/service.go
+++ b/openmeter/billing/charges/usagebased/service/run/service.go
@@ -16,14 +16,14 @@ import (
 // statuses to enter, or whether invoice lifecycle events should advance a charge.
 type Service struct {
 	adapter usagebased.Adapter
-	rater   *usagebasedrating.Service
+	rater   usagebasedrating.Service
 	handler usagebased.Handler
 	lineage lineage.Service
 }
 
 type Config struct {
 	Adapter usagebased.Adapter
-	Rater   *usagebasedrating.Service
+	Rater   usagebasedrating.Service
 	Handler usagebased.Handler
 	Lineage lineage.Service
 }

--- a/openmeter/billing/charges/usagebased/service/service.go
+++ b/openmeter/billing/charges/usagebased/service/service.go
@@ -113,7 +113,7 @@ type service struct {
 	featureService          feature.FeatureConnector
 	ratingService           rating.Service
 
-	rater *usagebasedrating.Service
+	rater usagebasedrating.Service
 	runs  *usagebasedrun.Service
 }
 

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -26,7 +26,7 @@ type stateMachine struct {
 	Logger *slog.Logger
 
 	Adapter usagebased.Adapter
-	Rater   *usagebasedrating.Service
+	Rater   usagebasedrating.Service
 	Runs    *usagebasedrun.Service
 
 	CustomerOverride   billing.CustomerOverrideWithDetails
@@ -39,7 +39,7 @@ type StateMachine = chargestatemachine.StateMachine[usagebased.Charge]
 type StateMachineConfig struct {
 	Charge             usagebased.Charge
 	Adapter            usagebased.Adapter
-	Rater              *usagebasedrating.Service
+	Rater              usagebasedrating.Service
 	Runs               *usagebasedrun.Service
 	Logger             *slog.Logger
 	CustomerOverride   billing.CustomerOverrideWithDetails
@@ -184,4 +184,25 @@ func (s *stateMachine) getCurrentRunCollectionEnd() (time.Time, error) {
 	}
 
 	return meta.NormalizeTimestamp(currentRun.CollectionEnd), nil
+}
+
+func (s *stateMachine) ensureDetailedLinesLoadedForRating(ctx context.Context) error {
+	if len(s.Charge.Realizations) == 0 {
+		return nil
+	}
+
+	if lo.EveryBy(s.Charge.Realizations, func(run usagebased.RealizationRun) bool {
+		return run.DetailedLines.IsPresent()
+	}) {
+		return nil
+	}
+
+	expandedCharge, err := s.Adapter.FetchDetailedLines(ctx, s.Charge)
+	if err != nil {
+		return fmt.Errorf("fetch detailed lines: %w", err)
+	}
+
+	s.Charge = expandedCharge
+
+	return nil
 }

--- a/openmeter/billing/charges/usagebased/service_test.go
+++ b/openmeter/billing/charges/usagebased/service_test.go
@@ -1,0 +1,17 @@
+package usagebased
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+)
+
+func TestValidateExpands(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateExpands(meta.Expands{meta.ExpandRealizations}))
+	require.NoError(t, validateExpands(meta.Expands{meta.ExpandRealizations, meta.ExpandDetailedLines}))
+	require.Error(t, validateExpands(meta.Expands{meta.ExpandDetailedLines}))
+}

--- a/openmeter/billing/models/stddetailedline/create.go
+++ b/openmeter/billing/models/stddetailedline/create.go
@@ -1,0 +1,51 @@
+package stddetailedline
+
+import (
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/models/externalid"
+	billingtotals "github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+)
+
+type Creator[T any] interface {
+	externalid.LineExternalIDCreator[T]
+	billingtotals.Setter[T]
+
+	SetName(string) T
+	SetNillableDescription(*string) T
+	SetCurrency(currencyx.Code) T
+	SetServicePeriodStart(time.Time) T
+	SetServicePeriodEnd(time.Time) T
+	SetQuantity(alpacadecimal.Decimal) T
+	SetPerUnitAmount(alpacadecimal.Decimal) T
+	SetCategory(Category) T
+	SetPaymentTerm(productcatalog.PaymentTermType) T
+	SetNillableIndex(*int) T
+	SetChildUniqueReferenceID(string) T
+	SetNillableDeletedAt(*time.Time) T
+}
+
+func Create[T Creator[T]](creator Creator[T], line Base) T {
+	create := creator.
+		SetName(line.Name).
+		SetNillableDescription(line.Description).
+		SetCurrency(line.Currency).
+		SetServicePeriodStart(line.ServicePeriod.From.In(time.UTC)).
+		SetServicePeriodEnd(line.ServicePeriod.To.In(time.UTC)).
+		SetQuantity(line.Quantity).
+		SetPerUnitAmount(line.PerUnitAmount).
+		SetCategory(line.Category).
+		SetPaymentTerm(line.PaymentTerm).
+		SetNillableIndex(line.Index).
+		SetChildUniqueReferenceID(line.ChildUniqueReferenceID).
+		SetNillableDeletedAt(line.DeletedAt)
+
+	create = externalid.CreateLineExternalID(create, line.ExternalIDs)
+	create = billingtotals.Set(create, line.Totals)
+
+	return create
+}

--- a/openmeter/billing/models/stddetailedline/mapping.go
+++ b/openmeter/billing/models/stddetailedline/mapping.go
@@ -1,0 +1,69 @@
+package stddetailedline
+
+import (
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/models/creditsapplied"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/externalid"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/convert"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+type DBGetter interface {
+	GetNamespace() string
+	GetID() string
+	GetCreatedAt() time.Time
+	GetUpdatedAt() time.Time
+	GetDeletedAt() *time.Time
+	GetName() string
+	GetDescription() *string
+	GetCategory() Category
+	GetChildUniqueReferenceID() string
+	GetIndex() *int
+	GetPaymentTerm() productcatalog.PaymentTermType
+	GetServicePeriodStart() time.Time
+	GetServicePeriodEnd() time.Time
+	GetCurrency() currencyx.Code
+	GetPerUnitAmount() alpacadecimal.Decimal
+	GetQuantity() alpacadecimal.Decimal
+	GetCreditsApplied() *creditsapplied.CreditsApplied
+
+	externalid.LineExternalIDGetter
+	totals.TotalsGetter
+}
+
+func FromDB[T DBGetter](dbEntity T, taxConfig *productcatalog.TaxConfig) Base {
+	return Base{
+		ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+			Namespace:   dbEntity.GetNamespace(),
+			ID:          dbEntity.GetID(),
+			CreatedAt:   dbEntity.GetCreatedAt().In(time.UTC),
+			UpdatedAt:   dbEntity.GetUpdatedAt().In(time.UTC),
+			DeletedAt:   convert.TimePtrIn(dbEntity.GetDeletedAt(), time.UTC),
+			Name:        dbEntity.GetName(),
+			Description: dbEntity.GetDescription(),
+		}),
+		Category:               dbEntity.GetCategory(),
+		ChildUniqueReferenceID: dbEntity.GetChildUniqueReferenceID(),
+		Index:                  dbEntity.GetIndex(),
+		PaymentTerm:            dbEntity.GetPaymentTerm(),
+		ServicePeriod: timeutil.ClosedPeriod{
+			From: dbEntity.GetServicePeriodStart().In(time.UTC),
+			To:   dbEntity.GetServicePeriodEnd().In(time.UTC),
+		},
+		Currency:       dbEntity.GetCurrency(),
+		PerUnitAmount:  dbEntity.GetPerUnitAmount(),
+		Quantity:       dbEntity.GetQuantity(),
+		Totals:         totals.FromDB(dbEntity),
+		TaxConfig:      taxConfig,
+		ExternalIDs:    externalid.MapLineExternalIDFromDB(dbEntity),
+		CreditsApplied: lo.FromPtr(dbEntity.GetCreditsApplied()),
+	}
+}

--- a/openmeter/billing/models/stddetailedline/model.go
+++ b/openmeter/billing/models/stddetailedline/model.go
@@ -1,11 +1,14 @@
 package stddetailedline
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/models/creditsapplied"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/externalid"
@@ -116,4 +119,61 @@ func (l Base) Clone() Base {
 
 func (l Base) Equal(other Base) bool {
 	return deriveEqualBase(&l, &other)
+}
+
+func (l Base) GetIndex() *int {
+	return l.Index
+}
+
+func (l Base) GetCreatedAt() time.Time {
+	return l.CreatedAt
+}
+
+func (l Base) GetID() string {
+	return l.ID
+}
+
+type Comparable interface {
+	GetIndex() *int
+	GetCreatedAt() time.Time
+	GetID() string
+}
+
+func Compare[T Comparable](a, b T) int {
+	if a.GetIndex() == nil && b.GetIndex() != nil {
+		return 1
+	}
+	if a.GetIndex() != nil && b.GetIndex() == nil {
+		return -1
+	}
+	if a.GetIndex() != nil && b.GetIndex() != nil {
+		if c := cmp.Compare(*a.GetIndex(), *b.GetIndex()); c != 0 {
+			return c
+		}
+	}
+	if c := a.GetCreatedAt().Compare(b.GetCreatedAt()); c != 0 {
+		return c
+	}
+	return cmp.Compare(a.GetID(), b.GetID())
+}
+
+func BackfillTaxConfig(snapshotted *productcatalog.TaxConfig, behavior *productcatalog.TaxBehavior, resolvedTaxCodeID *string) *productcatalog.TaxConfig {
+	if snapshotted == nil && behavior == nil && resolvedTaxCodeID == nil {
+		return nil
+	}
+
+	var out productcatalog.TaxConfig
+	if snapshotted != nil {
+		out = *snapshotted
+	}
+
+	if behavior != nil {
+		out.Behavior = behavior
+	}
+
+	if resolvedTaxCodeID != nil {
+		out.TaxCodeID = lo.ToPtr(*resolvedTaxCodeID)
+	}
+
+	return &out
 }

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1459,7 +1459,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{BillingStandardInvoiceDetailedLinesColumns[15], BillingStandardInvoiceDetailedLinesColumns[31], BillingStandardInvoiceDetailedLinesColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "child_unique_reference_id IS NOT NULL AND deleted_at IS NULL",
+					Where: "deleted_at IS NULL",
 				},
 			},
 		},
@@ -2167,7 +2167,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{ChargeFlatFeeDetailedLineColumns[15], ChargeFlatFeeDetailedLineColumns[30], ChargeFlatFeeDetailedLineColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "child_unique_reference_id IS NOT NULL AND deleted_at IS NULL",
+					Where: "deleted_at IS NULL",
 				},
 			},
 		},
@@ -2585,7 +2585,7 @@ var (
 				Unique:  true,
 				Columns: []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[15], ChargeUsageBasedRunDetailedLineColumns[30], ChargeUsageBasedRunDetailedLineColumns[31], ChargeUsageBasedRunDetailedLineColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
-					Where: "child_unique_reference_id IS NOT NULL AND deleted_at IS NULL",
+					Where: "deleted_at IS NULL",
 				},
 			},
 		},

--- a/openmeter/ent/schema/billing.go
+++ b/openmeter/ent/schema/billing.go
@@ -891,7 +891,7 @@ func (BillingStandardInvoiceDetailedLine) Indexes() []ent.Index {
 		index.Fields("namespace", "parent_line_id"),
 		index.Fields("namespace", "parent_line_id", "child_unique_reference_id").
 			Annotations(
-				entsql.IndexWhere("child_unique_reference_id IS NOT NULL AND deleted_at IS NULL"),
+				entsql.IndexWhere("deleted_at IS NULL"),
 			).
 			StorageKey("billingstdinvdetailedline_ns_parent_child_id").
 			Unique(),

--- a/openmeter/ent/schema/chargesflatfee.go
+++ b/openmeter/ent/schema/chargesflatfee.go
@@ -163,7 +163,7 @@ func (ChargeFlatFeeDetailedLine) Indexes() []ent.Index {
 		index.Fields("namespace", "charge_id"),
 		index.Fields("namespace", "charge_id", "child_unique_reference_id").
 			Annotations(
-				entsql.IndexWhere("child_unique_reference_id IS NOT NULL AND deleted_at IS NULL"),
+				entsql.IndexWhere("deleted_at IS NULL"),
 			).
 			StorageKey("chargeffdetailedline_ns_charge_child_id").
 			Unique(),

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -272,7 +272,7 @@ func (ChargeUsageBasedRunDetailedLine) Indexes() []ent.Index {
 		index.Fields("namespace", "run_id"),
 		index.Fields("namespace", "charge_id", "run_id", "child_unique_reference_id").
 			Annotations(
-				entsql.IndexWhere("child_unique_reference_id IS NOT NULL AND deleted_at IS NULL"),
+				entsql.IndexWhere("deleted_at IS NULL"),
 			).
 			StorageKey("chargeubdetailedline_ns_charge_run_child_id").
 			Unique(),

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -192,9 +192,10 @@ func newTestEnv(t *testing.T) *testEnv {
 			},
 			collectorService,
 		),
-		Lineage:     lineageService,
-		MetaAdapter: metaAdapter,
-		Locker:      locker,
+		Lineage:       lineageService,
+		MetaAdapter:   metaAdapter,
+		Locker:        locker,
+		RatingService: billingratingservice.New(),
 	})
 	require.NoError(t, err)
 

--- a/tools/migrate/migrations/20260422051837_simplify_mixin_detailed_line_partial_indexes.down.sql
+++ b/tools/migrate/migrations/20260422051837_simplify_mixin_detailed_line_partial_indexes.down.sql
@@ -1,0 +1,12 @@
+-- reverse: create index "chargeubdetailedline_ns_charge_run_child_id" to table: "charge_usage_based_run_detailed_line"
+DROP INDEX "chargeubdetailedline_ns_charge_run_child_id";
+-- reverse: drop index "chargeubdetailedline_ns_charge_run_child_id" from table: "charge_usage_based_run_detailed_line"
+CREATE UNIQUE INDEX "chargeubdetailedline_ns_charge_run_child_id" ON "charge_usage_based_run_detailed_line" ("namespace", "charge_id", "run_id", "child_unique_reference_id") WHERE ((child_unique_reference_id IS NOT NULL) AND (deleted_at IS NULL));
+-- reverse: create index "chargeffdetailedline_ns_charge_child_id" to table: "charge_flat_fee_detailed_line"
+DROP INDEX "chargeffdetailedline_ns_charge_child_id";
+-- reverse: drop index "chargeffdetailedline_ns_charge_child_id" from table: "charge_flat_fee_detailed_line"
+CREATE UNIQUE INDEX "chargeffdetailedline_ns_charge_child_id" ON "charge_flat_fee_detailed_line" ("namespace", "charge_id", "child_unique_reference_id") WHERE ((child_unique_reference_id IS NOT NULL) AND (deleted_at IS NULL));
+-- reverse: create index "billingstdinvdetailedline_ns_parent_child_id" to table: "billing_standard_invoice_detailed_lines"
+DROP INDEX "billingstdinvdetailedline_ns_parent_child_id";
+-- reverse: drop index "billingstdinvdetailedline_ns_parent_child_id" from table: "billing_standard_invoice_detailed_lines"
+CREATE UNIQUE INDEX "billingstdinvdetailedline_ns_parent_child_id" ON "billing_standard_invoice_detailed_lines" ("namespace", "parent_line_id", "child_unique_reference_id") WHERE ((child_unique_reference_id IS NOT NULL) AND (deleted_at IS NULL));

--- a/tools/migrate/migrations/20260422051837_simplify_mixin_detailed_line_partial_indexes.up.sql
+++ b/tools/migrate/migrations/20260422051837_simplify_mixin_detailed_line_partial_indexes.up.sql
@@ -1,0 +1,12 @@
+-- drop index "billingstdinvdetailedline_ns_parent_child_id" from table: "billing_standard_invoice_detailed_lines"
+DROP INDEX "billingstdinvdetailedline_ns_parent_child_id";
+-- create index "billingstdinvdetailedline_ns_parent_child_id" to table: "billing_standard_invoice_detailed_lines"
+CREATE UNIQUE INDEX "billingstdinvdetailedline_ns_parent_child_id" ON "billing_standard_invoice_detailed_lines" ("namespace", "parent_line_id", "child_unique_reference_id") WHERE (deleted_at IS NULL);
+-- drop index "chargeffdetailedline_ns_charge_child_id" from table: "charge_flat_fee_detailed_line"
+DROP INDEX "chargeffdetailedline_ns_charge_child_id";
+-- create index "chargeffdetailedline_ns_charge_child_id" to table: "charge_flat_fee_detailed_line"
+CREATE UNIQUE INDEX "chargeffdetailedline_ns_charge_child_id" ON "charge_flat_fee_detailed_line" ("namespace", "charge_id", "child_unique_reference_id") WHERE (deleted_at IS NULL);
+-- drop index "chargeubdetailedline_ns_charge_run_child_id" from table: "charge_usage_based_run_detailed_line"
+DROP INDEX "chargeubdetailedline_ns_charge_run_child_id";
+-- create index "chargeubdetailedline_ns_charge_run_child_id" to table: "charge_usage_based_run_detailed_line"
+CREATE UNIQUE INDEX "chargeubdetailedline_ns_charge_run_child_id" ON "charge_usage_based_run_detailed_line" ("namespace", "charge_id", "run_id", "child_unique_reference_id") WHERE (deleted_at IS NULL);

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:7oWu3Vp3Cf8pOgfNprqwE0wbgN6yKrkdL3ZX/vwXSUM=
+h1:jVZaT0e/zwkE7IqXTIaK09mrAhXMQyCw/us4mMebQbU=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -183,3 +183,4 @@ h1:7oWu3Vp3Cf8pOgfNprqwE0wbgN6yKrkdL3ZX/vwXSUM=
 20260413154216_usagebased-run-line-id.up.sql h1:QgSUrbXPScmxaeKBMb3pWRlsTzoEUNZ1X3HZRj1krx4=
 20260421111210_add_charge_detailed_line_tables.up.sql h1:gczZY6X34zMiXq1Ph3y3zDWTJr//8aulX3VeYNIuly8=
 20260421150206_require_child_unique_reference_id_on_detailed_lines.up.sql h1:XReNPIrVLZunPJ1vyUTwxBBASZDqgljQO3HBAMMMzqA=
+20260422051837_simplify_mixin_detailed_line_partial_indexes.up.sql h1:3AsRyULK4pPWEcmfDd17bP6o4QuCcdH34ByUKsQdGHg=


### PR DESCRIPTION
  # Summary

  This PR adds durable charge-side detailed-line persistence for usage-based realization runs and flat-fee realizations, and moves flat-fee line-engine ownership behind flatfee.Service to match the usage-based structure.

  The main goal is to preserve the rated/billed detailed-line representation on the charge side, not only on invoice lines. That gives charge lifecycles a stable, queryable view of what was rated for a run or realization,
  which is needed for future rerating, previous-run context, and expand-based read models.

  # Why

  Today, charge lifecycles can rate or bill lines transiently, but the detailed-line output is not consistently persisted as part of the charge aggregate. That creates a few problems:

  - previous rated detail is hard to reuse in later lifecycle steps
  - charge reads cannot expose the same detailed breakdown that billing already produced (credits only esp)
  - replacement semantics are fragile because stale lines are not explicitly reconciled
  - flat-fee and usage-based line-engine ownership were inconsistent, which leaked adapter concerns into wiring and tests
  - invoice lines should be mutable, but for progressive billing we will need a stable history

  This change addresses those by making detailed lines first-class persisted charge data and by pushing line-engine ownership back into the charge services.

  # Why This Shape

  A few design choices were intentional:

  - Detailed lines live under realizations/runs, not on the root charge. This matches ownership semantics. The detailed lines belong to a specific realization context.
  - Domain detailed lines do not carry ChargeID / RunID. Those IDs are persistence concerns and are already implied by containment in the aggregate.
  - Flat-fee now owns its line engine through the service. This matches usage-based, keeps lifecycle logic inside the charge package, and avoids leaking adapter-specific persistence hooks into external wiring.
  - Rating inputs for totals vs detailed lines are split. They will diverge over time, and forcing one shared input would create unnecessary coupling.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detailed-line support for flat‑fee and usage‑based charges, retrievable via a new expansion flag (requires also expanding realizations).
  * Flat‑fee service now exposes a line‑engine for billing registration and persists detailed lines as part of invoice/rating flows.

* **Bug Fixes**
  * Simplified unique‑index behavior for detailed lines to respect soft‑deletes.

* **Tests**
  * New integration tests covering upsert, fetch, ordering, replacement and soft‑delete behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->