### PR TITLE
fix(api): v3 meter query path

### DIFF
--- a/api/spec/packages/aip/src/konnect.tsp
+++ b/api/spec/packages/aip/src/konnect.tsp
@@ -59,6 +59,10 @@ interface EventsEndpoints extends Events.EventsOperations {}
 @tag(Shared.MetersTag)
 interface MetersEndpoints extends Meters.MetersOperations {}
 
+@route("/openmeter/meters/{meterId}/query")
+@tag(Shared.MetersTag)
+interface MetersQueryEndpoints extends Meters.MetersQueryOperations {}
+
 @route("/openmeter/customers")
 @tag(Shared.CustomersTag)
 interface CustomersEndpoints extends Customers.CustomersOperations {}

--- a/api/spec/packages/aip/src/meters/operations.tsp
+++ b/api/spec/packages/aip/src/meters/operations.tsp
@@ -92,7 +92,9 @@ interface MetersOperations {
   delete(
     @path meterId: Shared.ULID,
   ): Shared.DeleteResponse | Common.NotFound | Common.ErrorResponses;
+}
 
+interface MetersQueryOperations {
   /**
    * Query a meter for usage.
    *

--- a/api/spec/packages/aip/src/openmeter.tsp
+++ b/api/spec/packages/aip/src/openmeter.tsp
@@ -68,6 +68,10 @@ interface EventsEndpoints extends Events.EventsOperations {}
 @tag(Shared.MetersTag)
 interface MetersEndpoints extends Meters.MetersOperations {}
 
+@route("/openmeter/meters/{meterId}/query")
+@tag(Shared.MetersTag)
+interface MetersQueryEndpoints extends Meters.MetersQueryOperations {}
+
 @route("/openmeter/customers")
 @tag(Shared.CustomersTag)
 interface CustomersEndpoints extends Customers.CustomersOperations {}

--- a/api/v3/api.gen.go
+++ b/api/v3/api.gen.go
@@ -5242,11 +5242,11 @@ type CreateLlmCostOverrideJSONRequestBody = LLMCostOverrideCreate
 // CreateMeterJSONRequestBody defines body for CreateMeter for application/json ContentType.
 type CreateMeterJSONRequestBody = CreateMeterRequest
 
-// QueryMeterJSONRequestBody defines body for QueryMeter for application/json ContentType.
-type QueryMeterJSONRequestBody = MeterQueryRequest
-
 // UpdateMeterJSONRequestBody defines body for UpdateMeter for application/json ContentType.
 type UpdateMeterJSONRequestBody = UpdateMeterRequest
+
+// QueryMeterJSONRequestBody defines body for QueryMeter for application/json ContentType.
+type QueryMeterJSONRequestBody = MeterQueryRequest
 
 // CreatePlanJSONRequestBody defines body for CreatePlan for application/json ContentType.
 type CreatePlanJSONRequestBody = CreatePlanRequest
@@ -6733,12 +6733,12 @@ type ServerInterface interface {
 	// Get meter
 	// (GET /openmeter/meters/{meterId})
 	GetMeter(w http.ResponseWriter, r *http.Request, meterId ULID)
-	// Query meter
-	// (POST /openmeter/meters/{meterId})
-	QueryMeter(w http.ResponseWriter, r *http.Request, meterId ULID)
 	// Update meter
 	// (PUT /openmeter/meters/{meterId})
 	UpdateMeter(w http.ResponseWriter, r *http.Request, meterId ULID)
+	// Query meter
+	// (POST /openmeter/meters/{meterId}/query)
+	QueryMeter(w http.ResponseWriter, r *http.Request, meterId ULID)
 	// List plans
 	// (GET /openmeter/plans)
 	ListPlans(w http.ResponseWriter, r *http.Request, params ListPlansParams)
@@ -7117,15 +7117,15 @@ func (_ Unimplemented) GetMeter(w http.ResponseWriter, r *http.Request, meterId 
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// Query meter
-// (POST /openmeter/meters/{meterId})
-func (_ Unimplemented) QueryMeter(w http.ResponseWriter, r *http.Request, meterId ULID) {
-	w.WriteHeader(http.StatusNotImplemented)
-}
-
 // Update meter
 // (PUT /openmeter/meters/{meterId})
 func (_ Unimplemented) UpdateMeter(w http.ResponseWriter, r *http.Request, meterId ULID) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Query meter
+// (POST /openmeter/meters/{meterId}/query)
+func (_ Unimplemented) QueryMeter(w http.ResponseWriter, r *http.Request, meterId ULID) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -8630,31 +8630,6 @@ func (siw *ServerInterfaceWrapper) GetMeter(w http.ResponseWriter, r *http.Reque
 	handler.ServeHTTP(w, r)
 }
 
-// QueryMeter operation middleware
-func (siw *ServerInterfaceWrapper) QueryMeter(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-
-	// ------------- Path parameter "meterId" -------------
-	var meterId ULID
-
-	err = runtime.BindStyledParameterWithOptions("simple", "meterId", chi.URLParam(r, "meterId"), &meterId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "meterId", Err: err})
-		return
-	}
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.QueryMeter(w, r, meterId)
-	}))
-
-	for i := len(siw.HandlerMiddlewares) - 1; i >= 0; i-- {
-		handler = siw.HandlerMiddlewares[i](handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
 // UpdateMeter operation middleware
 func (siw *ServerInterfaceWrapper) UpdateMeter(w http.ResponseWriter, r *http.Request) {
 
@@ -8671,6 +8646,31 @@ func (siw *ServerInterfaceWrapper) UpdateMeter(w http.ResponseWriter, r *http.Re
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.UpdateMeter(w, r, meterId)
+	}))
+
+	for i := len(siw.HandlerMiddlewares) - 1; i >= 0; i-- {
+		handler = siw.HandlerMiddlewares[i](handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// QueryMeter operation middleware
+func (siw *ServerInterfaceWrapper) QueryMeter(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "meterId" -------------
+	var meterId ULID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "meterId", chi.URLParam(r, "meterId"), &meterId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "meterId", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.QueryMeter(w, r, meterId)
 	}))
 
 	for i := len(siw.HandlerMiddlewares) - 1; i >= 0; i-- {
@@ -9656,10 +9656,10 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/openmeter/meters/{meterId}", wrapper.GetMeter)
 	})
 	r.Group(func(r chi.Router) {
-		r.Post(options.BaseURL+"/openmeter/meters/{meterId}", wrapper.QueryMeter)
+		r.Put(options.BaseURL+"/openmeter/meters/{meterId}", wrapper.UpdateMeter)
 	})
 	r.Group(func(r chi.Router) {
-		r.Put(options.BaseURL+"/openmeter/meters/{meterId}", wrapper.UpdateMeter)
+		r.Post(options.BaseURL+"/openmeter/meters/{meterId}/query", wrapper.QueryMeter)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/openmeter/plans", wrapper.ListPlans)
@@ -10191,138 +10191,138 @@ var swaggerSpec = []string{
 	"QoqRKLPs/v8bfYgwdVGkBp3ZCqZwXClc6K7hcUUWMKcFpiTr4mDGbnkiFwXNlzyxwXUszstFLNlAvDdZ",
 	"OM1MHqLnrG+YGVPqYGPMesdYdXXgAYrudRpRdbdcprJ7e72xXh3wLoYej1QT2E0jBwCz/n/Y+/Ylt22k",
 	"31dB6Z/NnqPL+JKzWZ/KH5OJk/WuE/tk7E1toqkZiIQkrCmAC4DjUaZcdR7ie8LvSb5CAyBBEpQoW5Rm",
-	"JFWlamIRlwbQ3egGGr8ucrcvFngQk4QuKORSmQvAs7QWvfVui0yneejjuTYfX7KIgwaFZr53raw0o+tD",
-	"Cc1PeBDkDkcKPbxBBCKymt4x8gArG9VgOGuyRISqORF2sFwgTxEOx+w8SVChaeEYwe13/9ftNqauPUfw",
-	"dg87WfaN7RBCbGZ8YGm3rsiw5Et4RQZ0kXKhTBiQNq96M6rm2QQi03hKGMRxUV78/windHT7bORehn4K",
-	"bSsG0rbxZXSbCSvYYusTVN7UOtlyulEQByhV69nV8NL2edYzXx/ClbFPz36uTd/huwsek4cwGZaUvc5D",
-	"OTyv7qSYUih/KzBsQM9fH/ZUjwAJkQVla2ToX9FX7xm9JUKCG2lTbLz2rRn4oD0DuM0sEPwrYforHxT6",
-	"XvfZ4C9XvwOC/d/+/o+ffn47ePfPwW9X90+//uQ73kBxQI9VwTpLPsj66dqbW/JFmU/WbSmwkO5Z3EPy",
-	"WdjWBt+481XG3pUhbNbzkRvCeq62OIQW4rYtyxhW+UHaxVZRbdnCeM9wpuZc0D9I129cbOZZQG/XXIVN",
-	"LOw2Xrs8Cb928Qe38YOXJ00PXt5DrKeXN+Dlnd5zcHJJlEUlb0TPsR/QhMdLuLuFwFH3korYhlCKlwCT",
-	"LvMWba4B8xLfT0Tw5bk+Shj8b2008VtDQTGkxuQI7+YEMfKxmeb6C2pLYdCAgMm1WN2fMY3YhTUNx+wi",
-	"z6fG3cPZjFF1DaDYRsZdLhqbKrI2l3n5jafTDuE9o5BlJJRg1J0Wp0QMdEcGrbuEpmtQF9HYHm2PezbK",
-	"aUrvTALaoqLNTpMki3FP65iE8w8oS+HbmOVgejkqeOwAZSYQPM6ZBXgAHJ2BwYG2MxF86ezsJ9d/GHDF",
-	"rCe8s2tcTQO5YkOoPUSpqko5QaI+PEjUxwijGeZTSYSyT56aoM/gSVcGJR80n7ot9XqznCQwvle2bkNG",
-	"Eq3t/SKOePeSBF0YjTrumbcm455RSwt7XWXzn1nlsY3WHi2Wq8CKXEOocPh2UX9H8L08LZtmS/lFWytY",
-	"GAvI3X/mba976mFfeZRZqkT8VbM4panLovI9VrhZsMrl1oqYs5OuKbvlG2bGtJNS6dKZcK/yBgNpQfU2",
-	"Sa3D4xLlzLFEGCWUfYDsY9Z+y+lCOE19hn9ZK2FsWkE/I3lQZQyXppXPIdxUrRLrGmzWl+4lieBTmjSb",
-	"a+ViLTSoxacInCuAJwZ5O2n5jj01jYePBx6ATn6cOkpmaZrQTXKNuLXGohFYEoi3BorSxo738Dt/xOh6",
-	"Nos9Ma26VfbeVWsqP3LxYZoYMLONqPzVVQwT6np17YNvA6czhkrIHgsENanNfP48Ivs5gzdrTifXls6V",
-	"2jNQdq2I4TS9zgGTvkDnhALe0rTQMi5XWB6qVv2oh2yn+drN5ca85tSPA8RZvZqOhxynOXqGNs0k4yqP",
-	"numXdEy1hRrypR3ld+VyqzSom8y1q7t2Sd0s4jjWDsXmK2vrrZ4823p+8FfM3fv8CTK+A+nOt7jQ1OS9",
-	"dZlWfQWRdjz91dS6lk57yBfsIbV8cIHndX4Ot0Ye8xbmra3wEtoMvQmXeEauXbzaRslw8tSMplvIH3Tu",
-	"NVRnuJ9wmsIZHveivuE0hcQWrNOG9OS6z0YyGk/eIhP5A4ReUanb0A7TvIPkj5wbNUuBUvIIXNpDwJo4",
-	"oUTs9cwnYJ61wSwoxGmlJD0GIXqk+4demoYzkkLAHH66feVivG+BF6l7F+zHjI/ZuRVz+ZGqaG6g6aQ9",
-	"KVUWmD42ty251Wcg6sfsXKGEYGle9JhmAMbasNemxzMAB+FURPnBjNvsikH26rEmqeDXAi4/rgnTMhyX",
-	"fGhzWh/2o1PBB6aqHoCt7fk2RkOM2bs33795gX599Rb99///L7/WgsfGkzN3o5IstBqIZG4Ze5j2GCUQ",
-	"y0sVETl+bbGf5226QdT9+LAM24lpFt08VKZBel2QTBufaWF2+gA3OhtAs0yaAigiHOhr+zLiMdk4ybEl",
-	"6zxNbdP++d257cLvAeXE1ZnkpHy2uGuUGCHIdxWT8dLYd8HXSfabSfe5jhw425/y0BIS9pOXkTPhWYwY",
-	"VvTWocUvHNSlnhan0iy+rH2IUjRy/vaVefor0ZJnJpndjEhls7j17Rtkc2EI7bvkWkz35RYEJjyhEbHB",
-	"eTYJ5nmKozlBTwEZNhOJvYe3OS0wfIWsFraqHL1+dfHy58uXg6fDs+FcLRIQBSIW8s300gzBu8vP4x2G",
-	"MA0jKDjg04Edrad2SiPu9XslsOohxBtAotuU9l70nsFPEGM2Bz72IysAAET/OCOqAdsJJ4lvSpln1pSz",
-	"V3HvRS+hUg1sK7oLB07ZaN8WRUZeMCTlzLyrMTBlJtwR6Hp6dubC0CwGeQ3r+cV9r8BxXntRFA7B/FR/",
-	"sd4YhPmp33tuqAp1llM/+g7HTnlDlSfrq1QjP56fPVtf6QcuJvCyDQRfZgvtYjasnsJ6E/jd4yAL6IMs",
-	"oo9WDHcDeLXIcOL24btBKugtVqT4IdNmdn6xrjd0HjwHgqcwCEOsRXERVOYi8+Jq4CC57Fb2HY+XW1t7",
-	"Q0fJs/xU1pN2GBXue7Jd7gsxmnFm7auzR8hnDUvcGat96tdV2Oge/r6KPxkWTEjo8dIlnyqDUVl4xktE",
-	"4zpHmkI5R1YUG9WNQfRaniHZdt+rclS/JXfYaOW6+nseQhcHjM/HwSq6xvP1NRxgdYW3Vq1Yh7osuBv+",
-	"SNQarpkR9RBY5mxXOuswGbDfe/6kxVB+5IxUuDXEIV3uuFmAS03kWgHK3MSrJm5tT+y6/f09EAjVan/f",
-	"mazkbvpJZHyRaWbXPdkPIyyiOb0F6yFs0p6bAh7N1v+qC5lt66g2BRuUfAzWyUpO2Bf/ptkkoXLezL9v",
-	"TYE2/GvbOvHvYfLvSk7YFf+m6ZoDKLjQSxISI1226QxKN/PwT6DS9NjOn8y61JnpXH+4CjDD6B6nqXXk",
-	"m/0wVmaLBl8sTdspLd3hQ1ZZRRRbUG+l6TFoK1h3WNGW3GQjtOw9WLOCKcoVGfRdpEt+5WBQv8LKx+to",
-	"KyqoHwb38Al1yZ28jLdm/eHik7vXq14NPaBlCsco5n1rnq7Tyyz1wlb8XRe9+tbE/fQM4mbvPxb6ykrN",
-	"1CEdtuNhPdUXOTlvdW/SPlKHWPIlXG3EhKRviqevnUmUC5E7MnVc4tS6GFk9s52dvehrZPmo0STNj5BN",
-	"QUfmEm74AKHOypy73oMLes27S54JxD+yak0/WhKlmUi5TfEYvHkwlQd5SGeXdxB5FCj0uafLiDxY0Kcl",
-	"xPblEo//lqLCJnuQgtG961x7axGXajBxkUIr9iguFTx5lTYwyBORH7iojIsSCSHggrhAOvf0zG8I4GVj",
-	"OoX4c4VuyHRKIkVvyfVU8MUNIMA22dse3W0srGLIX2pmNe6Nxbja7o1FjckSTSlWhfaAwJR2O6WueK3L",
-	"X337/vL7Le6VXKrvNHVttsr+w/N1LP1UHvQW+2UmbUW0u9BGay/mXfe0plkad0sr+3TXsn/V6b7s+HXP",
-	"W7IjI7gbu48HsBHnbLeLPdg8X/D32KAb54p148VdcqHypxQrt6nL3A2twiRjQQz2NY1v4K8Wshv0lQ2c",
-	"/TP8ViAY38CWt1fMZ4BmSBNImmWwsoI7pO649f5YADF7++GUi8Uq37nFvJddZ1fBZJpqaQ58IMurbxfL",
-	"QTwxCdm35jlbavbvOBtCjs5xLnRDXVvlq9O78jbcFa4mrH6XPmb5eea+vEs71KBfaV+UHYhHaVJ+rGSM",
-	"hj1J+4Pmf2vRa8GYNK+/NraXa/oUmbZd090Mtf3q98OGx4yoh7OiZ3vRAEdydbEBp9jArmrAliRiv8zS",
-	"VdjWZ21X+2HWUxhXQxgXTMtW98KRPb5vdNp83TlwhQ9WhxrckmbW9HFUjkyl5hc9Fn78M/Vr7Nvn+2So",
-	"rvVsAJ5nvyp3E94+aeBVgbSfJxKbqOMRTtOBA2HaRJIGecUDEqkGrMD9iFMN5SoYKxTGLDxJUxtpwmna",
-	"gUQZIMVRNCfRB56pgbTIui0CJn63GIgXti66NHWvvnLvimMeyaHpASDCLeC1zLv7cxhSzHQhEa61DeUj",
-	"niQkAugDB6G9IGrO4zIsnoBLaTt6e4psh2ejOkyKnHFPEpWl4x6AM/QthI3tROZdGIB2c3WtKYrmWMwo",
-	"m41ZCaaILhYkpliRZDmErIy2IRJXiXVI2g5iZpqpTJAx83E33OrDtPzABZpzqZtyE+gGJPtIkJgKEvnH",
-	"/BZCKT91fv/L6yHSrZDFhMQxicesqJ/Z/KpRQglT15JEgijzkJ0qihP6B7Gol8N/w7xB/IunONaEuBAx",
-	"MKwwqDLbYSjlil1hpsqeidoBWybe79HoeZqupE1miQoaRFDcVg1VelznqTvU6FZjNqjLTvR5yoXCSXtt",
-	"7mhzWuwt1HckgvZ5L8k0g0yLuaYpKT6rbBpaUtxBXag5oaKiC2V/zKI5ZvnnKngi5J+OIpP4URcw4IME",
-	"zalUXCyHY/aGJUur6qTWdDX83ioWJZUOzFdxhJHMEX0N0qqHoddKq5Wn/PB1mruMg2E/SM0WprCVfmuu",
-	"etJyrbRcLnVGLJDcprID02t9aL275jOlQYm5HE2+YviTdEVMxiYsPLRkEiMsXT6jaYIVmhKCuMXwGZhM",
-	"IK6HphB9qygc2dsK8ehUozSEkNiJWhnIsEEISSlcZIBuLODQtUWOg2BQ+JAjHnsfHkp4h8dfXgyHnanJ",
-	"0iUiWhPEcWOjOEzpq985+c/Vt3Z++hiCY2+2GNRhyGsZ4Fke98u7FDPIgxAihsDXEjGbgLhZwkwfoUyR",
-	"5UXpNN4ESDnFkK6JIa3o2dUxdS0VPGTWkiMc/zuTCs4MVjyKd9m9itIl3xpMzw8EmYRQXilpDD9/HzAN",
-	"TXCCWVRVZpkkgwhLIkGFGbjhiAttCZudLWwmQpODotfDsAytiQWDO8/Htuegnwo1DVZeqcyBm3NhtKya",
-	"vGzJLLNSa8Vn9SvaqqwFX9EWppORItfybkXImVpftuv+SJRhvu/MIPYdTVkSGkuTbBYZV+Jonvs27wvb",
-	"lRbISbnOl/HSVza6GUZEbHM7l5CtPjb2h9vsa2zRGi5Sk+4/yrmg5WR6rjE9fT7ZIDp6BU5oKVHsmJ2X",
-	"fvCSKAFwSZJws8SIT1EqSIptsl5atS2Ha8xDaP7wLEPg4odgFAIhzZsbfD5KU7DK813sbaP7qJjltfAq",
-	"tVzNAbNwf0LTcOzmj+8xBPa1F4rjMfd2LAWjIu33yKXBbD7ksFEhkKpjZapzlufUTJZomrGYxNVNzWTI",
-	"hoQVhMUppwzu+eWSRXPBGf2j0o/SPZfbdh/HDF7yQ/pBgKlBkptTdEFuCcu0tRbxGaMGQYPltNh0QDSh",
-	"agnZAuGY/S6FSIlGyFBf8AeOlkExEQeqDLqIIGudkX9P4ZntNdQRoea52DDfJs1FsqYPtqvFlMBMYjjr",
-	"bOet+hXy9/1elJe7i8MM0cUigzfUfQQqiCd8RiOcgPYQJqtQkriGF/wWhilfjJn1EY2i6+fGd8SZzBb6",
-	"F3KXUqNIZB/dchpLk3jDOwYejtk7n1ZzAVg4nVqVCUkqpJmXypOle7+82i0vzd4hOOel1d2Zi+6v08Nw",
-	"1D2KTu56K3e9IgpbUFGEQXoaLcwDEyXUDm1hEKh4OI94/Lf7L4uBnsM4HXs2BWvDglWiJMwlNJoSrDJB",
-	"TFCWicYyc3c0N50e26Ccbep87E16nZVNXqhmg/8VpI+C3dGkPOUCTTBk3pvapFJeJIFeqYuEZ/FL88WA",
-	"YjQG5prcVAOX4WpgiWlra0KWKFPnf2/Gkz/ZHoFMmOOGdgcw1kDrrWIJKt1Ugwgq3dY7wWzZIlFqtZft",
-	"EHfVyuB+Gs7uaBljjm8JmhDCbBYyEhubR+hfbQykZluIbrJuH89ksnw8EAhGPookbTkLOzl004yMSNQE",
-	"0Kmx9SnIXMkGCy9vqFMA1lzrtsSQyctPbNa5axq3xJFxxW0M0jg7O3sW0Rj+ku1ZdD8YCvdtxuVkHBWo",
-	"jMe09Y3rB/exK+A323vjrYj93ilQjR3knm4nbO8hBrOfDiEtm7fO2+eysDof3dv/W5OQzYKo5DSuScdW",
-	"cOR69yAn4AR80wnwTWDNutBhK66o1vDMjKiHwjBnu9RYpycRoYulnTBrqt2l5pRsFSLGzIBrq2RpMrhr",
-	"ozBjVF0DNuaUkqR4n2qO1xvvZPbH6F1di3yOZbBTOTu+G4+dSNF6gwIw00fG9Wk8uQFHzpydaWHi01UG",
-	"L7TlZAjgjQ9CkGBBYCI8KdqB1FxwqWy3Te/83oHPDEShOZZIZlFESKw13MFKkWFJJ0KWy7oWoCRZAEOP",
-	"+C0RgsbrjlpSIgaavWWKI4JSQSOC8qoNZy+uj0HRR1h8vvy44vXrnzR3vdV0PVZgfCD+yE46Xr/+ySpi",
-	"j0XqvK+L6fXt7MxjFXs3HoTU+LujIxHL3G9sL4boXZ+J+BIW5EeYs0d/LFJjyE74cZ0uHt0DC7Y9JdmM",
-	"e+2hSYh719s2lq7T4Uknhyd75T5Y2jVmwCzhE5wUdJo6wyJeyPxgUgjl7GyAiEiM6BRhtlxnLlhCauwY",
-	"vHqxFGzv5uNzTInAY3w7EdtJ5pAKfktjIobuhwWPSaL/VcnwUEnVVPlN8aPM+3Ay9B6QoZcL9471WnlL",
-	"XXF87KIzKiSjyRK9+n5YRikxXzZUdjNS1XX73XnPdmYjHqN3r5mqzEk74H3HSau2clOmYS+2DXQaNGHq",
-	"tA2ZsKU/K+cO1B18IMvtWQmwanuPcgUqjmwnyVmzFEvU6g0pVG105+Frp1ENQOmeYhqg7xBXGP3z6B13",
-	"t3o1rghpxtE9/G3rXzfwjXWkXc/rt3Db6cl57sR5buSAldECUMsad0FT7QEs79mutMCRvCddwSmrbg0d",
-	"s0wdwqDBoCIK3ZxHEUnVC1RdmRv0ledN/1m7xjPjZSiRRSoTJEZ/v3zzc+lcwG9QkTs1iuTtja4a848s",
-	"4diYPhIvCGCOa5cdo4vLfyJATpUZBcNQkzlmMhUEx3JOiJIG8loXjHiSLZjsa5sLvPK+PXMYs5up4Is+",
-	"UryPfpcZ2DD9K/S7C6+/pnE/j7W//kCW3r+0GPSvkAlJjemCMMC3HQ6HJjq1j25xkpHiDMK2f2PpQVQi",
-	"sqBKqy0IfPg4J8wrRaWzEcF++5Mcs5uZ4Fl6PVleF/3d2MMJNReEoJucvP/l+jGPyFxPis8IAEh6XXqj",
-	"vRmzWr8o3G3D/fF+FMiOro13GXzhE2AvkPs9JyC6MrnDizQxHf+oV4jEWrPnT0Mwi1GxYNBxoRfWl+/3",
-	"gH+1w6BlRPG+LxUloSjLBJzW9dUyJX1oYcyenj19Njh7Mjh78u7s7AX891u/8uMT+PHsyY//5+vf/vL1",
-	"1+c//Hr+j7+9fPL053+dXfy/v/7wtz6OFmRAWdQ/jxYEvWLRsD9L1eD5QGViwvuUpZnqP3la6+1JqLen",
-	"W+nt6Vmtt6eh3p6Ve/vu2b9+e/KPX87/+us3//zL28un3/dnCZ+Qu/6P8AddcJGWeuOZ0t0917vBzxyB",
-	"OA4my8bVbShTX9GN12ez+d1sfp6bvSsXDvsWRSpB2ex0wOKHTzRt6Z99X5ypFQF7DQ6BDbo7FIVvhru5",
-	"07ozc/X4Qu22y+Zl1zhNMGvx4AqKNRwbmia2cmrY6QVMgtmRnZq5lamfPL8VPM4ihS6wwgmfdRZiw8hH",
-	"oKLx/E1/7PT4TS/7fvHONAVBHkswO4QnRf4ad8ZpAa01utd/WofL6Nle/aLI8mKLWzno93Si19FbovJS",
-	"dai8VpwQrmKXGVH755Wznaqp0zui0DuinTHqasdkFa9a72Qf7NpVls2Nd/TdisopieaqJJo7E5pVBsMI",
-	"x/FazDQcxwPAHpOSRxSMNIj5wQ0Gbe4LDWzruxO3/sP0ts71PJwguFZDGDk2M3B8ndvRTR7beRwDgDZQ",
-	"Y5Cy1/pthtEf/7ZSOIrAsXvyFvP+m3YW+HhMkNgreHKf24b5N6zGGufzF7Lgt8QbA2RAbpIszwvduWT1",
-	"G9u24zw5u9vl7XWssRevNyfG2Twuv3cTyzpP+Bj49WzXmv5YcN5bcN2+XOuNBcJztw9UJrr06jc3v3Yu",
-	"lAft3Qcd9n2K52prTERzektWpKE0BdyZwy0RMoi9ahs6tjPdI7pIb+aE/bBumk0SKufNrPvWFFjLurah",
-	"E+seLOs2c8KuWFfwKU3WvRG32cCRK91wPmqLDfJGH3zYiGNHQ/CRBZBUV3VNJulW4SCVNiGc/rtKP0gv",
-	"Hbbx15IoRdnMHJG62pC4iDMleCIRZbecRgTNCLMcNxyzc4a4mGFG/zAmS4SZQeFeZImiaUJqo0MxmVJG",
-	"YsgyWPmIqEQJZR/MS3fvwTBO0yF6N6eyZB9RiQjIFJVzEqM4Ew4TvtKuSWWK82RMgiwwZbLIv9J4AlsR",
-	"pU6DaMpCsOdwGjvegNCVSxxKbE2FYzbK5u5Ye3RPW8bJhMTzDUuWSGbRvC4yFpIytid3kGjMIVkwrkqw",
-	"EraS+5RSxqw4MS/+PpO6g/yf+RN7XQ1ea4AQTynDiZ5rJ/yy6Ty1LifrrSR6Ou/sKrhnM25eGaNTZdXg",
-	"8eRDWf6z/enBo0kYuSlvrQ6rWcte9rBvjxzW1WHcF+z3e+TzYwTh/RLjQGaTfDbX5OcqF+0UIaTU1QYQ",
-	"X6nQdCtqGNF7pAdcmCQt0gcZ0brqtyCs9GTw1fdD8yzRPNXiDiNs59Aglx6Jp8Cb1YE3VZauy81lqYTv",
-	"3gYdMr/BjrwxK8k+YfsBBg0QEmIt//uBR67oCn9dX+GCs2lCIxV2+CostJ4lVyj00b3/zzIEWt1MrvS8",
-	"3oIpN/4I7OWNePVITOZO+W0UYRaRFRnUL+C7AdXz6w7H7FeaJHoRskQhyhBGejHjDEydyIoQolNdVRBA",
-	"duAA51Deo20li06psFAIT/WwIBUA9G5O3hRdhA7aoMSDEI3dbCVmvfZj5m8knodt6X/hVgKr2LVozzGb",
-	"rbh6v0i4JBJhJDLGtND6DcBBN4ijtEecnBGEo4gLgIxV3KiEUsbUsWZPyH4jSWzQeNKZwDGRfYDIcf+v",
-	"24abMkNi4CLKfDgisTZrtX+xNoSsckWOBMriCwUcprFjAc+Y2zwH3kbZLPDv8/L1/dzfagOnaOGeTjbo",
-	"aZNrloGC3Ro57TNkQuG7QcTLaXECh2FFsW4Owl6xKMli71IN3yHor4aW2xJWnZoGr22DvQC80ITzhGBW",
-	"h1LvUire4bsLHh9bUEW+nEEOfYfvvvxtV/B8yrFtp5ECdkn3GyJgiQhaGObT448NcFy0bSZq0Iije2Vm",
-	"rvbkKXjp7vHa+m08b/l06d7JpXtXrNJvPk58KOt/tgfVciRnh91xlb2Wr162SyL2ylhdXbZ/zpa5D74+",
-	"AVs0AFvAtHS2H+vOiLgN58N6zSOc9Pq9TCS9F725UumL0SjRP865VC/uUy7UpxFO6ej2GQCfCqrblsaR",
-	"F9aRh/C83oveN9988w1wQOA4L4tL3cgXo8JMGEb6u+tGS4udgtqzBhugHpkAdbTADM+INEB1fYeFYA7x",
-	"1JxQ4QfVmgBg390bTLAksYuBGBaC3xwSXx9bnqclxgrrBpFJvEXZDDEuFjbMMBU00j8B+LYmJMFslmmH",
-	"BIB+JcKR4FIil7VLDpHJJga3E3LJIhKbR755/DG5M8yAJM8ElGQxwpnig4izKRULEhtoajUnS4RngpDg",
-	"GPM0MoGYCps/FgmSCiIJgyhMuwYpntCEKkokmuDog8FBNhq1b/MbuQRhKRGDjFFlZgrIm2UiP9GpkZTn",
-	"ra2T9C73ZvXEuNxhEU6iLLGGLTFL7eIrZLALLVP11l0kueOsQMi17KMIcq1HFP5fj0ivu+U7F0/aggQX",
-	"WFMn4zxNJSIMINmXPNMj1Kut15fFtlX6BymFswO6PPrIxYdpwj9ChIlWFzM9zWxmFqRgmaVUZGFYRqsH",
-	"yIeHoNsIM+CihXm+FyPC5phFQEgRQE8ibtrQ/UiTlQ5u13y2gJhfLIF954Iz+ocuYggFQQCi1JyKeJBi",
-	"oZZaktWUi4WeWLukcKSvF7WfB+jbEcckobcEQuPdrPfRHLPYLBdeLjTDRjxJSKQn1iyQuelzUXeCJNgc",
-	"ksgP4VXSkxJYopdMUZUQ3UWFFc2zAoSjiEipf3GJx1uwhN9qKEtg6X7S71UJHH2wU8unZq2cqGq1Z9Z4",
-	"WD7BcuHXlMX0lsYZTqQu7L97kCYmWxe0qnNCdH+gcmE+IZ66Ptjg8MrnZ4GNwk3OZ42tqL3rceU9B8YE",
-	"JUBkbmu80nZkL4uqqeCaJBIj7MSKZzJZajnU2sopYMmN3l/gJYTL6+lYLEhMsSLJEuFbTBOX8sHkKCjv",
-	"gTnZpu+mgck8beOcf4Rg/NlMkJnWHXa81Wc3mOFkqWgkUZqJlEuteGxTdtnc/uAgs/Idz7VNOdPjnPPY",
-	"LBXAtFM20y25sotyk/a8RhOTJ8IAAhFA7Btlq0mcJuSOTlwDcPcYEYYF5bI6O7L36erT/wQAAP//Tu22",
-	"YceQAwA=",
+	"JFWlamIRlwbQ3WgA3b8ucrcvFngQk4QuKORSmQvAs7QWvT3dFplOc9fHc20+vmQRBw0KzXzvWllpRteH",
+	"Epqf8CDIHY4UeniDCHhkNcUx8gArG9VgOGuyRISqORF2sFwgTxEOx+w8SVChaeEawe13/9ftNqauvUfw",
+	"dg87WTbGdgguNjM+sLTbo8iwdJbwigzoIuVCGTcgbV71ZlTNswl4pvGUMPDjorz4/xFO6ej22chFhn4K",
+	"bSsG0rYxMrrNhBVssfUJKm9qnWw53SiIA5Sq9exqeGn7POuZrw/hydinZz/Ppu/w3QWPyUOYDEvKXueh",
+	"7J5XP6SYUiiPFRg2oOevd3uqe4CEyIKyNTL0r+ir94zeEiHhGGlTbLz2rRn4oE8G8JpZIPhX3PRXBhT6",
+	"p+6zwV+ufgcE+7/9/R8//fx28O6fg9+u7p9+/ck/eAPFAT1WBessnUHWT9fejiVflPlk3ZYCC+nC4h7S",
+	"mYVtbfCNO19l7F0ZwmY9H7khrOdqi0NoIW7bsoxhlR+kXWwV1ZYtjPcMZ2rOBf2DdB3jYjPPAnq75ips",
+	"fGG3Ee3yJBzt4g9u44CXJ00BL+/B19PLG/DyTu85OLkkyqKSN6Ln2A9owuMlvN2C46iLpCK2IZTiJcCk",
+	"y7xFm2vAROL7iQi+PNdHCYP/rfUmfmsoKIbUmBzh3ZwgRj4201yPoLYUBg0ImFyL1f0Z04idW9NwzC7y",
+	"fGrcBc5mjKprAMU2Mu5y0dhUkbW5zMtvPJ12CO8ZhSwjoQSj7rY4JWKgOzJo3SU0XYO6iMb2anvcs15O",
+	"U3pnEtAWFW12miRZjHtaxyScf0BZCt/GLAfTy1HBYwcoMwHncc4swAPg6AwMDrSdiWCks7OfXP9hwBWz",
+	"nhBn17iaBnLFulB7iFJVlXKCRH14kKiPEUYzzKeSCGVDnpqgzyCkK4OSD5pP3ZZ6vVlOEhjfK1u3ISOJ",
+	"1vZ+EUe8iyRBF0ajjnsm1mTcM2ppYZ+rbP4zqzy20dqjxXIVWJFrcBUOvy7q7wi+l6dl02wpv2hrBQtj",
+	"Abn3z7ztdaEeNsqjzFIl4q+axSlNXRaV77HCzYJVLrdWxJyddE3ZLd8wM6adlEqXzoR7lTcYSAuqt0lq",
+	"DzwuUc4cS4RRQtkHyD5m7becLoTT1Gf4l7USxqYV9DOSB1XGcGla+RzCTdUqsa7BZn3pIkkEn9Kk2Vwr",
+	"F2uhQS0+ReBeAU5ikLeTlt/YU9N4+HrgAejkx6mjZJamCd0k14hbaywagSWBeGugKG3seIHfeRCj69ks",
+	"9sS06lbZi6vWVH7k4sM0MWBmG1H5q6sYJtT16tqHsw3czhgqIXssENSkNvP584js5wzerDmdXFs6V2rP",
+	"QNm1IobT9DoHTPoCnRNyeEvTQsu4XGG5q1r1ox6yneZrN5cb85pTPw4QZ/VqOh5ynOboGdo0k4yr3Hum",
+	"X9Ix1RZqyJd2lN+Vy63SoG4y167u2iV1s4jjWB8oNl9ZW2/15NnW84u/Yu7e5yHI+A6kO9/iQlOT99Zl",
+	"WvUVRNrx9FdT61o67SFfsIfU8sEFwuv8HG6NPOYtzFtb4SW0GYoJl3hGrp2/2kbJcPLUjKZbyB907jVU",
+	"Z7ifcJrCHR73vL7hNoXEFqzTuvTkus96MpqTvEUm8gcIvaJSt6EdpnkHyYOcGzVLgVLyCI60h4A1cUKJ",
+	"2OudT8A8a4NZUIjTSkl6DEL0SPcPvTQNdySFgDn8dBvlYk7fAi9SFxfs+4yP2bkVc/mRqmhuoOmkvSlV",
+	"Fpg+Nq8tudVnIOrH7FyhhGBpInpMMwBjbdhr0+sZgINwKqIcMOM2u2KQvbqvSSr4tYDHj2vCtAzHpTO0",
+	"ua0Pn6NTwQemqh6Are2dbYyGGLN3b75/8wL9+uot+u///19+rQWPzUnOvI1KstBqIJK5Zexh2mOUgC8v",
+	"VUTk+LXFfp636QZRP8eHZdhOTLPo5q4yDdLrnGTanJkWZqcPcKOzATTLpCmAIsKFvrYvIx6TjZMcW7LO",
+	"09Q27d/fndsu/B5QTlydSU7KZ4u7RokRgnxXMRkvjX0XjE6y30y6z3XkwN3+lIeWkLCfvIycCc9ixLCi",
+	"tw4tfuGgLvW0OJVm8WVtIErRyPnbVyb0V6Ilz0wyuxmRymZx69sYZPNgCO275FpM9+UWBCY8oRGxznk2",
+	"CeZ5iqM5QU8BGTYTiX2HtzktMHyFrBa2qhy9fnXx8ufLl4Onw7PhXC0SEAUiFvLN9NIMwXvLz/0dhjAN",
+	"Iyg44NOBHa2ndkoj7vV7JbDqIfgbQKLblPZe9J7BT+BjNgc+9j0rAABE/zgjqgHbCSeJb0qZMGvK2au4",
+	"96KXUKkGthXdhQOnbLRviyIjzxmScmbiagxMmXF3BLqenp05NzSLQV7Den5x3ytwnNc+FIVdMD/VI9Yb",
+	"nTA/9XvPDVWhznLqR9/h2ClvqPJkfZWq58fzs2frK/3AxQQi20DwZbbQR8yG1VNYbwK/exxkAX2QRfTR",
+	"iuFuAFGLDCduH74bpILeYkWKHzJtZucP63pD58F7IAiFQRh8LYqHoDIXmYirgYPkslvZdzxebm3tDR2l",
+	"k+Wnsp60w6hw35Ptcl+I0cxh1kadPUI+a1jizljtU7+uwkb38PdV/MmwYEJCwUuXfKoMRmVxMl4iGtc5",
+	"0hTKObKi2KhuDLzX8gzJtvtelaP6LbnDeivX1d/zELo4YHw+DlbRNZ6vr+EAqyu8tWrFOtRlwd3wR6LW",
+	"cM2MqIfAMme70lmHyYD93vMnLYbyI2ekwq0hDulyx80CXGo81wpQ5iZeNX5re2LX7e/vAUeoVvv7zmQl",
+	"P6afRMYXmWZ23ZP9MMIimtNbsB7CJu25KeDRbM9fdSGzbR3VpmCdko/BOlnJCfvi3zSbJFTOm/n3rSnQ",
+	"hn9tWyf+PUz+XckJu+LfNF1zAQUPeklCYqTLNt1B6WYe/g1Umh7b/ZNZlzoznesPVwFmGN3jNLUH+eZz",
+	"GCuzRcNZLE3bKS3d4UNWWYUXW1BvpekxaCtYd1jRltxkPbTsO1izginKFRn0nadL/uRgUL/CysfraCsq",
+	"qB8G9/AJdcmdvIy3Zv3h4ZO76FWvhh7QMoVrFBPfmqfr9DJLvbAVf9dFr741fj89g7jZ+4+FvrJSM3VI",
+	"h+14WE/1RU7OW92btEHq4Eu+hKeNmJD0TRH62plEORe5I1PHJU6ti5HVM9vZ2Yu+RpaPGk3S/ArZFHRk",
+	"LuGFDxDqrMy55z14oNe8u+SZQPwjq9b0vSVRmomU2xSPwZcHU3mQu3R2+QaRe4FCn3t6jMidBX1aQmxf",
+	"LvH4XykqbLIHKRjdu871aS3iUg0mzlNoxR7FpYKQV2kdgzwR+YGLyrgokeACLohzpHOhZ35DAC8b0yn4",
+	"nyt0Q6ZTEil6S66ngi9uAAG2yd726G5jYRVD/lIzq3FvLMbVdm8sakyWaEqxKrQHOKa02yl1xWtd/urb",
+	"95ffb3Gv5FJ9p6lrs1X2H95Zx9JP5UFvsV9m0lZEuwtttPZh3nVPa5qlcbe0sk93LftXne7Ljl/3vCU7",
+	"MoK7sft4ABtxzna72INN+IK/xwaPca5YN6e4Sy5UHkqxcpu6zI+hVZhkLIjBvqbxDfzVQnaDvrKOs3+G",
+	"3woE4xvY8vaK+QzQDGkCSbMMVlZwh9Qdt94fCyBmbz+ccrFYdXZuMe/lo7OrYDJNtTQHPpDl1beL5SCe",
+	"mITsWzs5W2r2f3A2hBzdwbnQDXVtla9O78rbcFccNWH1uzxjlsMz93W6tEMNnittRNmBnChNyo+VjNGw",
+	"J+nzoPnfmvda0CfN66+N7eWaPnmmbdd0N0Ntv/r9sOExI+rhrOjZXjTAkTxdbMAp1rGr6rAlidgvs3Tl",
+	"tvVZ29V+mPXkxtXgxgXTstW9cGSv7xsPbb7uHLjCB6tDDW5JM2v6OCpHplLzhx4LP/6Z+jX27fN9MlTX",
+	"ejYAz7NflbsJb5808CpH2s8TiU3U8Qin6cCBMG0iSYO84gGJVANW4H7EqYZyFfQVCmMWnqSpjTThNO1A",
+	"ogyQ4iiak+gDz9RAWmTdFg4Tv1sMxAtbF12auldfubjimEdyaHoAiHALeC3z7v4chhQzXUiEa21D+Ygn",
+	"CYkA+sBBaC+ImvO4DIsn4FHajt7eItvhWa8OkyJn3JNEZem4B+AMfQthYzuReRcGoN08XWuKojkWM8pm",
+	"Y1aCKaKLBYkpViRZDiEro22IxFViHZK2g5iZZioTZMx83A23+jAtP3CB5lzqptwEugHJPhIkpoJE/jW/",
+	"hVDKb53f//J6iHQrZDEhcUziMSvqZza/apRQwtS1JJEgygSyU0VxQv8gFvVy+G+YN/B/8RTHGhcXIgaG",
+	"FQZVZjsMpVyxK8xU2TtRO2DLxPu9Gj1P05W0ySxRQYMIituqoUqP6z51hxrdaswGddmJPk+5UDhpr80d",
+	"bU6LvYX6jkTQPu8lmWaQaTHXNCXFZ5VNQ0uKO6gLNSdUVHSh7I9ZNMcs/1wFT4T801FkEj/qAgZ8kKA5",
+	"lYqL5XDM3rBkaVWd1Jquht9bxaKk0oH5Ko4wkjmir0Fa9TD0Wmm18pQfvk5zj3Ew7Aep2cIUttJvzVVP",
+	"Wq6VlsulzogFkttUdmB6rXetd898pjQoMZejyVcMf5KuiMnYhIWHlkxihKXLZzRNsEJTQhC3GD4DkwnE",
+	"9dDkom8VhSN7Wy4enWqUBhcSO1ErHRk2cCEpuYsM0I0FHLq2yHHgDAofcsRj78NDce/w+Mvz4bAzNVm6",
+	"RERrnDhurBeHKX31Oyf/ufrWzk8fg3PszRadOgx5LR08y+N+eZdiBnkQQsQQ+FoiZhMQN0uY6SOUKbK8",
+	"KJ36mwApJx/SNT6kFT272qeupYKHzFpyhON/Z1LBncGKoHiX3asoXTpbg+n5gSCTEMorJY3h5+8DpqEJ",
+	"TjCLqsosk2QQYUkkqDADNxxxoS1hs7OFzURoclD0ehiWoTWxYHDn+dj27PRToabByiuVOXBzLoyWVZOX",
+	"LZllVmqt+KyOoq3KWjCKtjCdjBS5lncrQs7U+rJd90eiDPN9Zwaxb2/KktBYmmSzyLgSRxPu27wvbFda",
+	"ICflurOMl76y8ZhhRMQ2t3MJ2WqwsT/c5rPGFq3hIjXp/r2cC1pOpuca09Pnkw28o1fghJYSxY7ZeekH",
+	"L4kSAJckCTdLjPgUpYKk2CbrpVXbcrjGPITmD88yBC5+CEYhENK8ucHnozQFqzzfxd42uo+KWV4Lr1LL",
+	"1RwwC/cnNA3Xbv74HoNjX3uhOB5zb8dSMCrSfo9cGszmSw7rFQKpOlamOmd5Ts1kiaYZi0lc3dRMhmxI",
+	"WEFYnHLK4J1fLlk0F5zRPyr9KN1zuW33ccwgkh/SDwJMDZLc3KILcktYpq21iM8YNQgaLKfFpgOiCVVL",
+	"yBYI1+x3KXhKNEKG+oI/cLQMiok4UGXQhQdZ64z8e3LPbK+hjgg1z/mG+TZpLpI1fbBdLaYEZhLDXWe7",
+	"06pfIY/v97y83FscZoguFhnEUPcRqCCe8BmNcALaQ5isQkniGl7wWximfDFm9oxoFF0/N74jzmS20L+Q",
+	"u5QaRSL76JbTWJrEG9418HDM3vm0mgfA4tCpVZmQpEKaiVSeLF388upjeWn2DuFwXlrdnR3R/XV6GAd1",
+	"j6LTcb3Vcb0iCltQUYRBehotzAPjJdQObWEQqHg4QTx+7P7LYqDnME7Hnk3O2rBgFS8J8wiNpgSrTBDj",
+	"lGW8sczcHc1Lp8c2KGebOh97k15nZZMXqtngfwXpo2B3NClPuUATDJn3pjaplOdJoFfqIuFZ/NJ8MaAY",
+	"jY65JjfVwGW4Glhi2tqakCXK1Pnfm/HkT7ZHIBPmuKHdAYw10HorX4JKN1Ungkq39U4wW7ZIlFrtZTvE",
+	"XbUyuJ+GsztaxpjjW4ImhDCbhYzExuYR+lfrA6nZFryb7LGPZzJZPh4IBCMfRZK2nIWdHLppRkYkagLo",
+	"1Nj6FGSuZIOFlzfUKQBrrnVbYsjk5Sc269w1jVviyLji1gdpnJ2dPYtoDH/J9iy6HwyF+zbjcjKOClTG",
+	"Y9r6xvWD+9gV8JvtvfFVxH7vFKjGDnJPrxO29xCD2U+HkJbNW+ftc1lYnY/u7f+tSchmQVRyGtekYys4",
+	"cv3xICfgBHzTCfBNYM260GErnqjW8MyMqIfCMGe71FinkIjQw9JOmDXVx6XmlGwVIsbMgGurZGkyuGuj",
+	"MGNUXQM25pSSpIhPNdfrjW8y+2P0rp5FPscy2KmcHd+Lx06kaL1BAZjpI3P0aby5gYOcuTvTwsSnqwxe",
+	"aMvJEMAbH4QgwYLARHhStAOpueBS2W6b4vzewZkZiEJzLJHMooiQWGu4g5Uiw5JOhCyXdS1ASbIAhh7x",
+	"WyIEjdddtaREDDR7yxRHBKWCRgTlVRvuXlwfg6KPsPh8+XXF69c/ae56q+l6rMD4QPyR3XS8fv2TVcQe",
+	"i9R5XxfT69vZnccq9m68CKnxd0dXIpa539heDNG7vhPxJSzIjzBnj/5apMaQnfDjOl08ugcWbHtLshn3",
+	"2kuTEPeut20sXafLk04uT/bKfbC0a8yAWcInOCnoNHWGhb+Q+cGkEMrZ2QARkRjRKcJsuc5csITU2DH4",
+	"9GIp2N7Lx+eYEoFgfDsR20nmkAp+S2Mihu6HBY9Jov9VyfBQSdVU+U3xo8z7cDL0HpChlwv3jvVaeUtd",
+	"cX3svDMqJKPJEr36flhGKTFfNlR2M1LVdfvdec92ZiMe4+leM1WZk3bA+46TVm3lpkzDXmwb6NRpwtRp",
+	"6zJhS39Wzh2oO/hAltuzEmDV9u7lClQc2U6Ss2bJl6hVDClUbTzOw9dOvRqA0j35NEDfIa4w+ufRH9zd",
+	"6tW4IqQZR/fwt+35uoFv7EHa9bx+C7edng7PnRyeGzlgpbcA1LLGXdBUewDLe7YrLXAk8aQrOMUC1zc8",
+	"1DcoAvvYvh9O6eqhffPNamdsenxP7E0cu73DQrEltntCd5pz6uA2DSAbUejmPIpIql6g6vrfoK+8q6U/",
+	"I8XRzBy5lcgilQkSo79fvvm5dEnmN6jInRpF8vZGV435R5ZwbM4BEi8IAPAjDMj0l/9EACMsMwoD12SO",
+	"mUwFwbGcE6KkwX/XBSOeZAsm+/oAAldUfXsBN2Y3U8EXfaR4H/0uMzDo+1fodxdrck3jfh54cv2BLL1/",
+	"aUnvXyHjnx3TBWEA9jwcDo2rdh/d4iQjxYWcbf/G0oOoRGRBleZz8AL6OCfMK0WlOzDBcv1JjtnNTPAs",
+	"vZ4sr4v+buxNnZoLQtBNTt7/cv2YiErXk+IzAmiqXpfeaG/GrNYvCnfb4ExxKDoy6EOxcxVZ9qbo95yA",
+	"6MrkDi/SxHT8o14hEmszJ4+TwixGxYJBx8Umub58vwf8q0/PWkYU7/tSURKKskzA1XVfLVPShxbG7OnZ",
+	"02eDsyeDsyfvzs5ewH+/9Ss/PoEfz578+H++/u0vX399/sOv5//428snT3/+19nF//vrD3/r42hBBpRF",
+	"/fNoQdArFg37s1QNng9UJia8T1maqf6Tp7XenoR6e7qV3p6e1Xp7GurtWbm3757967cn//jl/K+/fvPP",
+	"v7y9fPp9f5bwCbnr/wh/0AUXaak3nind3XO91/zMEYjjYLJsXN2GMvUV3Xh9NpvfzebnudkZc+GwgVlS",
+	"Ccpmp9tG35eoS2shTTBrEZYFxRouF00TW7lb7PSZJsHsyO7W3MrU76ffCh5nkUIXWOGEzzpzxGHkI1DR",
+	"eEunP3Z6SaeXfb+oaJqCII8lmB1C4JG/xp1xWkBrje71n9ZONXq2V8cdWV5s8XYH/Z7u/TqKOCovVYfK",
+	"a8U94ip2mRG1f14526maOkUbhaKNdsaoq68xV/GqvcvcB7t2lYtz4x19t6JySrW5KtXmzoRmlcEwwnG8",
+	"FlkNx/EAEMqk5BEFIw08g3CDQZufhQa29d2JW/9hnrbO9TycgLpWAx05NjOgfZ3b0U0ntvM4BphtoMbg",
+	"aa89txlGf/zbSnFQBI7d02kx779pZ4GPxwScvYIn97ltmH/Daqw5fP5CFvyWeGOAPMlNkuWdQncuWf3G",
+	"tu04T4fd7fL2OtbYy6k3J8bZPC4LeBPLupPwMfDr2a41/bGgwbfgun0drTcWCO+4faAy0eWpfnPza+dC",
+	"edCn++CBfZ/iudoaE9Gc3pIVySpNAXfncEuEDCK02oaO7U73iNzumjlhP6ybZpOEynkz6741Bdayrm3o",
+	"xLoHy7rNnLAr1hV8SpN1keQ2ZzhypRvuR22xQd7og3cbcexoCD4yB5Lqqq7JN93KHaTSJvgZf1fpB+ml",
+	"w9YxVRKlKJuZK1JXG9IbcaYETySi7JbTiKAZYZbjhmN2zhAXM8zoH8ZkiTAzWN2LLFE0TUhtdCgmU8pI",
+	"DLkIKx8RlSih7IOJh/fCinGaDtG7OZUl+4hKRECmqJyTGMWZcMjxlXZNwlOcp2wSZIEpk0WWlsYb2Ioo",
+	"depEUxaCPbvT2PEGhK5c4lB8ayocs1HOd8fao3va0k8mJJ5vWLJEMovmdZGxwJWxvbmDdGQO74JxVQKf",
+	"sJXcp5QyZsWJeY7JmdQd5P/MA/F1NXBjByGeUoYTPddO+GXTfWpdTtZbSfR039mVc89m3LzSR6fKqsHr",
+	"yYey/Gf704NHk1ZyU95a7Vazlr3sZd8eOayry7gv2O/3yOfHCNX7JcaBzCb5bK7J4lUu2imOSKmrDYDA",
+	"UqHpVtQwohe9BFyYJC2SDBnRuuq3IKwUS/Xq+6GJ1zIxLNwhie0cQOTSI/HkeLPa8abK0nW5uSyV8I+3",
+	"wQOZ32BHpzEryT5h+4EPDRASYi3/+4F7rugKf11f4YKzaUIjFT7wVVhoPUuuUOije/+fZaC0uplc6Xm9",
+	"BVNu/BHYyxvx6pGYzJ3y2yjCLCIr8qxfwHcDvefXHY7ZrzRJ9CJkiUKUIYz0YsYZmDqRFSFEp7qqIBDy",
+	"ziHOvbxH20oWw1JhoRCe6mFBwgDo3dy8KboIXbRBiQchGrvZSsx67cfM30g8D9vS/8KtBFaxa9GeYzZb",
+	"8fR+kXBJJMJIZIxpofUbgItuEEdprzg5IwhHERcALKu4UQmlvKpjzZ6QI0eS2MCUpDOBYyL7gB3i/l+3",
+	"DS9lhsTAQ5T5cERibdZq/2JtCFl1FDmSGP8vFHCYxo4FPGNu8xx4G2WzwL/Py9f3c3+rDdyihXs62aCn",
+	"Ta5ZBgp2a+S0z5AJhe8GES8nzwlchhXFurkIe8WiJIu9RzV8h6C/GqZuS/B1ahq8tg32ArgrE84Tglkd",
+	"cL1LqXiH7y54fGxOFflyBjn0Hb778tiu4P2UY9tOPQXsku7XRcASEbQwzKfH7xvguGjbTNSgEUf3ysxc",
+	"LeQp+Oju8dr6bTxv+fTo3smje1es0m++Tnwo63+2B9VyJHeH3XGVfZavPrZLIvbKWF09tn/OlrkPvj4B",
+	"WzQAW8C0dLYf686IuA1nzXrNI5z0+r1MJL0XvblS6YvRKNE/zrlUL+5TLtSnEU7p6PYZIEIKqtuW5iAv",
+	"7EEe3PN6L3rffPPNN8ABgeu8LC51I1+MCjNhGOnvrhstLXYKamEN1kE9Mg7qaIEZnhFpgOr6DgvBXOKp",
+	"OaHCd6o1DsD+cW8wwZLEzgdiWAh+s0t8fWx5NpcYK6wbRCY9F2UzxLhYWDfDVNBI/wSoxJqQBLNZpg8k",
+	"gIAqEY4ElxK53F5yiEzOMXidkEsWkdgE+eb+x+TOMAOSPBNQksUIZ4oPIs6mVCxIbDB71ZwsEZ4JQoJj",
+	"zJPNBHwqbJZZJEgqiCQMvDDtGqR4QhOqKJFogqMPBiDWaNS+zYLk0oilRAwyRpWZKSBvlon8RqdGUp7d",
+	"tk7Su/w0qyfGZRiLcBJliTVsiVlq518hg11omaq37jzJHWcFXK5lH0WQkT2i8P96RHrdLd85f9IWJDjH",
+	"mjoZ52kqEWGAVb3kmR6hXm29viy2rdI/SMmdHWC30UcuPkwT/hE8TLS6mOlpZjOzIAXLLKUiC8MyWj1A",
+	"1jwE3UaYARctTPhejAibYxYBIYUDPYm4aUP3I03uOnhd89kCfH6xBPadC87oH7qIIRQEAYhScyriQYqF",
+	"WmpJVlMuFnpi7ZLClb5e1H7uoG9HHJOE3hJwjXez3kdzzGKzXHi50Awb8SQhkZ5Ys0Dmpc953QmSYHNJ",
+	"Ij+EV0lPSmCJXjJFVUJ0FxVWNGEFCEcRkVL/4tKTt2AJv9VQLsHS+6TfqxI4+mCnlk/NWjlR1WrPrPGw",
+	"fIPl3K8pi+ktjTOcSF3Yj3uQxidbF7Sqc0J0f6ByYT7Bn7o+2ODwyvdngY3CTc5nja2ovetx5T0HxgQl",
+	"QGRua7zSdmQvi6qp4JokEiPsxIpnMllqOdTayilgyY3eX+AluMvr6VgsSEyxIskS4VtME4eFb8Dby3tg",
+	"Trbpu2lgMk/uOOcfwRl/NhNkpnWHHW817AYznCwVjSRKM5FyqRWPbcoum9sfHGRWvuO5tilnepxzHpul",
+	"Avxqyma6JVd2UW7S3tdoYvIMAUAgAuxxo2w1idOE3NGJawDeHiPCsKBcVmdH9j5dffqfAAAA//8SYDPC",
+	"7ZADAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/api/v3/openapi.yaml
+++ b/api/v3/openapi.yaml
@@ -1683,6 +1683,7 @@ paths:
           $ref: '#/components/responses/NotFound'
       tags:
         - Meters
+  /openmeter/meters/{meterId}/query:
     post:
       operationId: query-meter
       parameters:

--- a/e2e/helpers.go
+++ b/e2e/helpers.go
@@ -80,7 +80,7 @@ func QueryMeterV3(t *testing.T, meterID string, body apiv3.MeterQueryRequest) (i
 	req, err := http.NewRequestWithContext(
 		context.Background(),
 		http.MethodPost,
-		strings.TrimRight(address, "/")+"/api/v3/openmeter/meters/"+meterID,
+		strings.TrimRight(address, "/")+"/api/v3/openmeter/meters/"+meterID+"/query",
 		bytes.NewReader(payload),
 	)
 	if err != nil {

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -240,7 +240,7 @@ func TestRoutes(t *testing.T) {
 			req: testRequest{
 				method:      http.MethodPost,
 				contentType: "application/json",
-				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID,
+				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID + "/query",
 				body:        apiv3.MeterQueryRequest{},
 			},
 			res: testResponse{
@@ -273,7 +273,7 @@ func TestRoutes(t *testing.T) {
 			req: testRequest{
 				method:      http.MethodPost,
 				contentType: "application/json",
-				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID,
+				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID + "/query",
 				body: apiv3.MeterQueryRequest{
 					GroupByDimensions: &[]string{"path", "method"},
 				},
@@ -303,7 +303,7 @@ func TestRoutes(t *testing.T) {
 			req: testRequest{
 				method:      http.MethodPost,
 				contentType: "application/json",
-				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID,
+				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID + "/query",
 				body: apiv3.MeterQueryRequest{
 					GroupByDimensions: &[]string{"subject"},
 				},
@@ -322,7 +322,7 @@ func TestRoutes(t *testing.T) {
 			req: testRequest{
 				method:      http.MethodPost,
 				contentType: "application/json",
-				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID,
+				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID + "/query",
 				body: apiv3.MeterQueryRequest{
 					Filters: &apiv3.MeterQueryFilters{
 						Dimensions: &map[string]apiv3.QueryFilterStringMapItem{
@@ -360,7 +360,7 @@ func TestRoutes(t *testing.T) {
 			req: testRequest{
 				method:      http.MethodPost,
 				contentType: "application/json",
-				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID,
+				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID + "/query",
 				body: apiv3.MeterQueryRequest{
 					GroupByDimensions: &[]string{"foo"},
 				},
@@ -392,7 +392,7 @@ func TestRoutes(t *testing.T) {
 			req: testRequest{
 				method:      http.MethodPost,
 				contentType: "application/json",
-				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID,
+				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID + "/query",
 				body: apiv3.MeterQueryRequest{
 					Filters: &apiv3.MeterQueryFilters{
 						Dimensions: &map[string]apiv3.QueryFilterStringMapItem{
@@ -447,7 +447,7 @@ func TestRoutes(t *testing.T) {
 			req: testRequest{
 				method:      http.MethodPost,
 				contentType: "application/json",
-				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID,
+				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID + "/query",
 				body: apiv3.MeterQueryRequest{
 					Filters: &apiv3.MeterQueryFilters{
 						Dimensions: &map[string]apiv3.QueryFilterStringMapItem{
@@ -497,7 +497,7 @@ func TestRoutes(t *testing.T) {
 			req: testRequest{
 				method:      http.MethodPost,
 				contentType: "application/json",
-				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID,
+				path:        "/api/v3/openmeter/meters/" + mockMeters[0].ID + "/query",
 				body: apiv3.MeterQueryRequest{
 					Filters: &apiv3.MeterQueryFilters{
 						Dimensions: &map[string]apiv3.QueryFilterStringMapItem{

--- a/quickstart/quickstart_test.go
+++ b/quickstart/quickstart_test.go
@@ -93,7 +93,7 @@ func queryMeterV3(t require.TestingT, address string, meterID string, body apiv3
 	req, err := http.NewRequestWithContext(
 		context.Background(),
 		http.MethodPost,
-		address+"/openmeter/meters/"+meterID,
+		address+"/openmeter/meters/"+meterID+"/query",
 		bytes.NewReader(payload),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Meter query operations moved to a dedicated endpoint: POST /openmeter/meters/{meterId}/query (same request/response behavior).
* **Tests**
  * End-to-end and unit tests updated to exercise the new /query path.
* **Chores**
  * Server routing and generated API specification updated to reflect the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->