### PR TITLE
fix: collection period behavior should match API docs

### DIFF
--- a/.agents/skills/billing/SKILL.md
+++ b/.agents/skills/billing/SKILL.md
@@ -86,7 +86,8 @@ Rules:
 
 - `Period`: when the service was actually rendered (usage window)
 - `InvoiceAt`: when the line should appear on an invoice (may be delayed)
-- `CollectionAt`: when the invoice entered collection (drives due-date calculation)
+- `GatheringInvoice.NextCollectionAt` / DB `collection_at`: when pending lines become eligible for automatic collection into a draft invoice
+- `StandardInvoice.CollectionAt`: the post-creation collection / quantity-snapshot cutoff for metered standard-invoice lines
 
 These are distinct fields and must not be conflated.
 
@@ -243,9 +244,19 @@ The billing line-engine contract lives in `openmeter/billing/lineengine.go`. Bil
 Use those tests as the template for new billing line-engine lifecycle behavior.
 ## Gathering vs Standard Invoices
 
-**Gathering invoice**: one per customer per currency, never advances through states. Collects pending lines (from subscription sync). When lines become due (`CollectionAt <= now`), the `InvoiceCollector` cron calls `InvoicePendingLines` to move them into a new `StandardInvoice`. The gathering invoice is soft-deleted when it has no remaining lines.
+**Gathering invoice**: one per customer per currency, never advances through states. Collects pending lines (from subscription sync). Automatic standard-invoice creation is gated here by the billing profile's `workflow.collection.alignment`: `NextCollectionAt` is the next wake-up time for the collector, and `InvoicePendingLines` honors alignment by default. The gathering invoice is soft-deleted when it has no remaining lines.
 
-**Standard invoice**: goes through the full state machine. Created from gathering lines by `CreateStandardInvoiceFromGatheringLines`.
+**Standard invoice**: goes through the full state machine. Created from gathering lines by `CreateStandardInvoiceFromGatheringLines`. `CollectionAt` on a standard invoice is no longer the primary place where alignment lives; it is the post-creation cutoff used by quantity snapshotting / collection-completed processing for metered lines.
+
+**Alignment placement**:
+- Billing-profile `workflow.collection.alignment` is a pending-line collection policy, so automatic `InvoicePendingLines` paths should honor it before standard-invoice creation.
+- Explicit/manual invoicing paths may bypass alignment intentionally via `WithBypassCollectionAlignment()`.
+- `StandardInvoiceCollectionAt` should not re-implement anchored alignment; it should derive from metered standard lines only.
+
+**Flat-fee standard invoices**:
+- `StandardInvoiceCollectionAt` only considers non-deleted lines where `DependsOnMeteredQuantity() == true`.
+- Flat-fee-only standard invoices therefore have domain `CollectionAt == nil`.
+- The V3 HTTP mapping currently emulates `collectionAt` as `CreatedAt` for standard invoices when the domain field is nil, to preserve the historic API shape. Do not confuse this API compatibility shim with the domain semantics.
 
 **Line splitting (progressive billing)**: when a usage-based line must be billed mid-period, the original line gets `status=split` and two children are created. The parent's `SplitLineGroupID` connects them. `SplitLineHierarchy` carries all siblings for computing `GetPreviouslyBilledAmount()`.
 

--- a/openmeter/billing/adapter/gatheringinvoice.go
+++ b/openmeter/billing/adapter/gatheringinvoice.go
@@ -135,13 +135,8 @@ func (a *adapter) UpdateGatheringInvoice(ctx context.Context, in billing.Gatheri
 			SetTaxesTotal(alpacadecimal.Zero).
 			SetTaxesExclusiveTotal(alpacadecimal.Zero).
 			SetTaxesInclusiveTotal(alpacadecimal.Zero).
-			SetTotal(alpacadecimal.Zero)
-
-		if !in.NextCollectionAt.IsZero() {
-			updateQuery = updateQuery.SetCollectionAt(in.NextCollectionAt.In(time.UTC))
-		} else {
-			updateQuery = updateQuery.ClearCollectionAt()
-		}
+			SetTotal(alpacadecimal.Zero).
+			SetOrClearCollectionAt(convert.SafeToUTC(in.NextCollectionAt))
 
 		// Clear period when the invoice is soft-deleted
 		if in.DeletedAt != nil {
@@ -420,7 +415,7 @@ func (a *adapter) mapGatheringInvoiceFromDB(ctx context.Context, invoice *db.Bil
 			CustomerID:       invoice.CustomerID,
 			Currency:         invoice.Currency,
 			ServicePeriod:    period,
-			NextCollectionAt: invoice.CollectionAt.In(time.UTC),
+			NextCollectionAt: convert.TimePtrIn(invoice.CollectionAt, time.UTC),
 			SchemaLevel:      invoice.SchemaLevel,
 		},
 

--- a/openmeter/billing/adapter/invoice.go
+++ b/openmeter/billing/adapter/invoice.go
@@ -349,7 +349,7 @@ func (a *adapter) CreateInvoice(ctx context.Context, input billing.CreateInvoice
 			SetNillableSupplierAddressPhoneNumber(supplier.Address.PhoneNumber).
 			SetSupplierName(supplier.Name).
 			SetNillableSupplierTaxCode(supplier.TaxCode).
-			SetNillableCollectionAt(input.CollectionAt).
+			SetNillableCollectionAt(normalizeOptionalTime(input.CollectionAt)).
 			SetSchemaLevel(currentSchemaLevel)
 
 		createMut = totals.Set(createMut, input.Totals)
@@ -477,7 +477,7 @@ func (a *adapter) UpdateStandardInvoice(ctx context.Context, in billing.UpdateSt
 			SetNumber(in.Number).
 			SetOrClearDescription(in.Description).
 			SetOrClearDueAt(convert.SafeToUTC(in.DueAt)).
-			SetOrClearCollectionAt(convert.SafeToUTC(in.CollectionAt)).
+			SetOrClearCollectionAt(normalizeOptionalTime(in.CollectionAt)).
 			SetOrClearPaymentProcessingEnteredAt(convert.SafeToUTC(in.PaymentProcessingEnteredAt)).
 			SetOrClearDraftUntil(convert.SafeToUTC(in.DraftUntil)).
 			SetOrClearIssuedAt(convert.SafeToUTC(in.IssuedAt)).
@@ -694,13 +694,26 @@ func (a *adapter) mapStandardInvoiceBaseFromDB(invoice *db.BillingInvoice) billi
 		UpdatedAt: invoice.UpdatedAt.In(time.UTC),
 		DeletedAt: convert.TimePtrIn(invoice.DeletedAt, time.UTC),
 
-		CollectionAt:               lo.ToPtr(invoice.CollectionAt.In(time.UTC)),
+		CollectionAt:               normalizeOptionalTime(invoice.CollectionAt),
 		PaymentProcessingEnteredAt: convert.TimePtrIn(invoice.PaymentProcessingEnteredAt, time.UTC),
 
 		ExternalIDs: externalid.MapInvoiceExternalIDFromDB(invoice),
 
 		SchemaLevel: invoice.SchemaLevel,
 	}
+}
+
+func normalizeOptionalTime(t *time.Time) *time.Time {
+	// collection_at was historically stored through a non-nillable Ent field, so older rows
+	// can rehydrate as zero time instead of nil. Normalize that legacy representation here so
+	// nil consistently means "no collection required" in the domain model.
+	if t == nil || t.IsZero() {
+		return nil
+	}
+
+	normalized := t.In(time.UTC)
+
+	return &normalized
 }
 
 func (a *adapter) mapStandardInvoiceFromDB(ctx context.Context, invoice *db.BillingInvoice, expand billing.StandardInvoiceExpands) (billing.StandardInvoice, error) {

--- a/openmeter/billing/charges/service/create.go
+++ b/openmeter/billing/charges/service/create.go
@@ -22,8 +22,8 @@ import (
 )
 
 type chargesWithInvoiceNowActions struct {
-	charges         charges.Charges
-	invoiceNowLines []invoicePendingLinesInput
+	charges                          charges.Charges
+	collectionAlignmentBypassedLines []invoicePendingLinesInput
 }
 
 func (s *service) Create(ctx context.Context, input charges.CreateInput) (charges.Charges, error) {
@@ -132,9 +132,13 @@ func (s *service) Create(ctx context.Context, input charges.CreateInput) (charge
 
 			// For invoice settlement, prepare the gathering line (actual invoicing happens after TX commits)
 			if result.GatheringLineToCreate != nil {
-				shouldInvoiceNow := false
+				bypassCollectionAlignment := false
 				if !result.Charge.Intent.ServicePeriod.From.After(clock.Now()) {
-					shouldInvoiceNow = true
+					// Credit purchases are not standard invoices, so for now we bypass the collection
+					// period here to make sure they are billed immediately once effective. Gathering
+					// line collection will not behave the same way. If we get customer feedback, we can
+					// later fine-tune this behavior.
+					bypassCollectionAlignment = true
 				}
 
 				gatheringLinesToCreate = append(gatheringLinesToCreate, gatheringLineWithCustomerID{
@@ -143,7 +147,7 @@ func (s *service) Create(ctx context.Context, input charges.CreateInput) (charge
 						Namespace: input.Namespace,
 						ID:        result.Charge.Intent.CustomerID,
 					},
-					ShouldInvoiceNow: shouldInvoiceNow,
+					BypassCollectionAlignment: bypassCollectionAlignment,
 				})
 			}
 
@@ -154,7 +158,7 @@ func (s *service) Create(ctx context.Context, input charges.CreateInput) (charge
 		}
 
 		// Let's generate the gathering lines for the flat fees
-		invoiceNowLines, err := s.createGatheringLines(ctx, gatheringLinesToCreate)
+		collectionAlignmentBypassedLines, err := s.createGatheringLines(ctx, gatheringLinesToCreate)
 		if err != nil {
 			return nil, err
 		}
@@ -166,8 +170,8 @@ func (s *service) Create(ctx context.Context, input charges.CreateInput) (charge
 		}
 
 		return &chargesWithInvoiceNowActions{
-			charges:         result,
-			invoiceNowLines: invoiceNowLines,
+			charges:                          result,
+			collectionAlignmentBypassedLines: collectionAlignmentBypassedLines,
 		}, nil
 	})
 	if err != nil {
@@ -180,8 +184,8 @@ func (s *service) Create(ctx context.Context, input charges.CreateInput) (charge
 
 	// TODO: once we have proper state machine for credit purchases, we can remove this and mek the
 	// autoAdvanceCreatedCharges handle the invoice now actions.
-	if len(result.invoiceNowLines) > 0 {
-		if err := s.invokeInvoiceNowOnCreate(ctx, result.invoiceNowLines); err != nil {
+	if len(result.collectionAlignmentBypassedLines) > 0 {
+		if err := s.invokeInvoiceNowOnCreate(ctx, result.collectionAlignmentBypassedLines); err != nil {
 			return nil, fmt.Errorf("invoking invoice now on create: %w", err)
 		}
 	}
@@ -273,9 +277,9 @@ type currencyAndCustomerID struct {
 }
 
 type gatheringLineWithCustomerID struct {
-	gatheringLine    billing.GatheringLine
-	customerID       customer.CustomerID
-	ShouldInvoiceNow bool
+	gatheringLine             billing.GatheringLine
+	customerID                customer.CustomerID
+	BypassCollectionAlignment bool
 }
 
 func (s *service) invokeInvoiceNowOnCreate(ctx context.Context, invoiceNowLines []invoicePendingLinesInput) error {
@@ -288,25 +292,20 @@ func (s *service) invokeInvoiceNowOnCreate(ctx context.Context, invoiceNowLines 
 	})
 
 	for customerID, lines := range invoiceNowArgs {
-		if _, err := s.billingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
-			Customer:            customerID,
-			IncludePendingLines: mo.Some(lines),
-			AsOf:                lo.ToPtr(clock.Now()),
-		}); err != nil {
+		if _, err := s.billingService.InvoicePendingLines(
+			ctx,
+			billing.InvoicePendingLinesInput{
+				Customer:            customerID,
+				IncludePendingLines: mo.Some(lines),
+				AsOf:                lo.ToPtr(clock.Now()),
+			},
+			billing.WithBypassCollectionAlignment(),
+		); err != nil {
 			return fmt.Errorf("invoking invoice now on create: %w", err)
 		}
 	}
 
 	return nil
-}
-
-// creditPurchaseWithPendingGatheringLine holds a credit purchase charge and its associated gathering line
-// for deferred invoicing after the Create transaction commits.
-type creditPurchaseWithPendingGatheringLine struct {
-	charge        creditpurchase.Charge
-	gatheringLine billing.GatheringLine
-	customerID    customer.CustomerID
-	currency      currencyx.Code
 }
 
 type invoicePendingLinesInput struct {
@@ -342,7 +341,7 @@ func (s *service) createGatheringLines(ctx context.Context, gatheringLinesToCrea
 		}
 
 		for idx, line := range result.Lines {
-			if lines[idx].ShouldInvoiceNow {
+			if lines[idx].BypassCollectionAlignment {
 				invoiceNowLines = append(invoiceNowLines, invoicePendingLinesInput{
 					CustomerID: custAndCurrency.customerID,
 					LineID:     line.ID,

--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -32,7 +32,7 @@ type GatheringInvoiceBase struct {
 	Currency      currencyx.Code        `json:"currency"`
 	ServicePeriod timeutil.ClosedPeriod `json:"servicePeriod"`
 
-	NextCollectionAt time.Time `json:"nextCollectionAt"`
+	NextCollectionAt *time.Time `json:"nextCollectionAt,omitempty"`
 
 	SchemaLevel int `json:"schemaLevel"`
 }
@@ -262,6 +262,12 @@ func (l *GatheringInvoiceLines) Sort() {
 
 func (l GatheringInvoiceLines) NonDeletedLineCount() int {
 	return lo.CountBy(l.OrEmpty(), func(l GatheringLine) bool {
+		return l.DeletedAt == nil
+	})
+}
+
+func (l GatheringInvoiceLines) NonDeletedLines() GatheringLines {
+	return lo.Filter(l.OrEmpty(), func(l GatheringLine, _ int) bool {
 		return l.DeletedAt == nil
 	})
 }

--- a/openmeter/billing/httpdriver/gatheringinvoice.go
+++ b/openmeter/billing/httpdriver/gatheringinvoice.go
@@ -43,7 +43,7 @@ func MapGatheringInvoiceToAPI(invoice billing.GatheringInvoice, customer *custom
 		CreatedAt:    invoice.CreatedAt,
 		UpdatedAt:    invoice.UpdatedAt,
 		DeletedAt:    invoice.DeletedAt,
-		CollectionAt: lo.ToPtr(invoice.NextCollectionAt),
+		CollectionAt: invoice.NextCollectionAt,
 		Period:       mapServicePeriodToAPI(invoice.ServicePeriod),
 
 		Currency: string(invoice.Currency),

--- a/openmeter/billing/httpdriver/invoice.go
+++ b/openmeter/billing/httpdriver/invoice.go
@@ -121,7 +121,10 @@ func (h *handler) ListInvoices() ListInvoicesHandler {
 }
 
 type (
-	InvoicePendingLinesActionRequest  = billing.InvoicePendingLinesInput
+	InvoicePendingLinesActionRequest struct {
+		billing.InvoicePendingLinesInput
+		Options []billing.InvoicePendingLinesOption
+	}
 	InvoicePendingLinesActionResponse = []api.Invoice
 	InvoicePendingLinesActionHandler  httptransport.Handler[InvoicePendingLinesActionRequest, InvoicePendingLinesActionResponse]
 )
@@ -145,19 +148,33 @@ func (h *handler) InvoicePendingLinesAction() InvoicePendingLinesActionHandler {
 				pendingLinesFilter = mo.PointerToOption(body.Filters.LineIds)
 			}
 
-			return InvoicePendingLinesActionRequest{
-				Customer: customer.CustomerID{
-					ID:        body.CustomerId,
-					Namespace: ns,
+			req := InvoicePendingLinesActionRequest{
+				InvoicePendingLinesInput: billing.InvoicePendingLinesInput{
+					Customer: customer.CustomerID{
+						ID:        body.CustomerId,
+						Namespace: ns,
+					},
+					IncludePendingLines: pendingLinesFilter,
+					AsOf:                body.AsOf,
 				},
+			}
 
-				IncludePendingLines:        pendingLinesFilter,
-				AsOf:                       body.AsOf,
-				ProgressiveBillingOverride: body.ProgressiveBillingOverride,
-			}, nil
+			opts := make([]billing.InvoicePendingLinesOption, 0, 2)
+			opts = append(opts, billing.WithBypassCollectionAlignment())
+			if body.ProgressiveBillingOverride != nil {
+				if *body.ProgressiveBillingOverride {
+					opts = append(opts, billing.WithPartialInvoiceLinesEnabled())
+				} else {
+					opts = append(opts, billing.WithPartialInvoiceLinesDisabled())
+				}
+			}
+
+			req.Options = opts
+
+			return req, nil
 		},
 		func(ctx context.Context, request InvoicePendingLinesActionRequest) (InvoicePendingLinesActionResponse, error) {
-			invoices, err := h.service.InvoicePendingLines(ctx, request)
+			invoices, err := h.service.InvoicePendingLines(ctx, request.InvoicePendingLinesInput, request.Options...)
 			if err != nil {
 				return nil, err
 			}

--- a/openmeter/billing/httpdriver/invoice.go
+++ b/openmeter/billing/httpdriver/invoice.go
@@ -577,6 +577,13 @@ func (h *handler) MapInvoiceToAPI(ctx context.Context, invoice billing.Invoice) 
 func MapStandardInvoiceToAPI(invoice billing.StandardInvoice) (api.Invoice, error) {
 	var apps *api.BillingProfileAppsOrReference
 	var err error
+	collectionAt := invoice.CollectionAt
+
+	// Preserve the historic API shape for standard invoices by emulating collectionAt when the
+	// domain model intentionally leaves it nil (for example, flat-fee-only invoices).
+	if collectionAt == nil {
+		collectionAt = lo.ToPtr(invoice.CreatedAt)
+	}
 
 	// Sort the lines to make the response more consistent (internally we don't care about the order)
 	invoice.SortLines()
@@ -602,7 +609,7 @@ func MapStandardInvoiceToAPI(invoice billing.StandardInvoice) (api.Invoice, erro
 		IssuedAt:             invoice.IssuedAt,
 		VoidedAt:             invoice.VoidedAt,
 		DueAt:                invoice.DueAt,
-		CollectionAt:         invoice.CollectionAt,
+		CollectionAt:         collectionAt,
 		DraftUntil:           invoice.DraftUntil,
 		SentToCustomerAt:     invoice.SentToCustomerAt,
 		QuantitySnapshotedAt: invoice.QuantitySnapshotedAt,

--- a/openmeter/billing/invoice.go
+++ b/openmeter/billing/invoice.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/api"
@@ -430,10 +431,6 @@ type InvoicePendingLinesInput struct {
 
 	IncludePendingLines mo.Option[[]string]
 	AsOf                *time.Time
-
-	// ProgressiveBillingOverride allows to override the progressive billing setting of the customer.
-	// This is used to make sure that system collection does not use progressive billing.
-	ProgressiveBillingOverride *bool
 }
 
 func (i InvoicePendingLinesInput) Validate() error {
@@ -452,6 +449,47 @@ func (i InvoicePendingLinesInput) Validate() error {
 	}
 
 	return nil
+}
+
+type InvoicePendingLinesOptions struct {
+	BypassCollectionAlignment bool
+
+	// PartialInvoiceLinesEnabled overrides the billing profile's progressive billing setting
+	// for this invocation:
+	// - nil: use the billing profile setting
+	// - true: include progressively billable partial lines
+	// - false: ignore progressively billable partial lines
+	PartialInvoiceLinesEnabled *bool
+}
+
+type InvoicePendingLinesOption func(*InvoicePendingLinesOptions)
+
+func NewInvoicePendingLinesOptions(opts ...InvoicePendingLinesOption) InvoicePendingLinesOptions {
+	var out InvoicePendingLinesOptions
+
+	for _, opt := range opts {
+		opt(&out)
+	}
+
+	return out
+}
+
+func WithBypassCollectionAlignment() InvoicePendingLinesOption {
+	return func(o *InvoicePendingLinesOptions) {
+		o.BypassCollectionAlignment = true
+	}
+}
+
+func WithPartialInvoiceLinesDisabled() InvoicePendingLinesOption {
+	return func(o *InvoicePendingLinesOptions) {
+		o.PartialInvoiceLinesEnabled = lo.ToPtr(false)
+	}
+}
+
+func WithPartialInvoiceLinesEnabled() InvoicePendingLinesOption {
+	return func(o *InvoicePendingLinesOptions) {
+		o.PartialInvoiceLinesEnabled = lo.ToPtr(true)
+	}
 }
 
 type UpdateInvoiceInput struct {

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -72,7 +72,7 @@ type SplitLineGroupService interface {
 }
 
 type InvoiceService interface {
-	InvoicePendingLines(ctx context.Context, input InvoicePendingLinesInput) ([]StandardInvoice, error)
+	InvoicePendingLines(ctx context.Context, input InvoicePendingLinesInput, opts ...InvoicePendingLinesOption) ([]StandardInvoice, error)
 
 	ListInvoices(ctx context.Context, input ListInvoicesInput) (ListInvoicesResponse, error)
 	// GetInvoiceById returns the invoice by its ID using the Invoice union type.
@@ -118,9 +118,6 @@ type StandardInvoiceService interface {
 type GatheringInvoiceService interface {
 	// CreatePendingInvoiceLines creates pending invoice lines for a customer, if the lines are zero valued, the response is nil
 	CreatePendingInvoiceLines(ctx context.Context, input CreatePendingInvoiceLinesInput) (*CreatePendingInvoiceLinesResult, error)
-
-	// PrepareBillableLines prepares the billable lines for a customer, if the lines are zero valued, the response is nil
-	PrepareBillableLines(ctx context.Context, input PrepareBillableLinesInput) (*PrepareBillableLinesResult, error)
 
 	ListGatheringInvoices(ctx context.Context, input ListGatheringInvoicesInput) (pagination.Result[GatheringInvoice], error)
 	GetGatheringInvoiceById(ctx context.Context, input GetGatheringInvoiceByIdInput) (GatheringInvoice, error)

--- a/openmeter/billing/service/gatheringinvoice.go
+++ b/openmeter/billing/service/gatheringinvoice.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/pagination"
@@ -65,7 +66,16 @@ func (s *Service) UpdateGatheringInvoice(ctx context.Context, input billing.Upda
 			return fmt.Errorf("normalizing lines: %w", err)
 		}
 
-		if err := s.invoiceCalculator.CalculateGatheringInvoice(&invoice); err != nil {
+		customerProfile, err := s.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
+			Customer: invoice.GetCustomerID(),
+		})
+		if err != nil {
+			return fmt.Errorf("fetching profile: %w", err)
+		}
+
+		if err := s.invoiceCalculator.CalculateGatheringInvoice(&invoice, invoicecalc.GatheringInvoiceCalculatorDependencies{
+			Collection: customerProfile.MergedProfile.WorkflowConfig.Collection,
+		}); err != nil {
 			return fmt.Errorf("calculating invoice[%s]: %w", invoice.ID, err)
 		}
 
@@ -78,13 +88,6 @@ func (s *Service) UpdateGatheringInvoice(ctx context.Context, input billing.Upda
 		featureMeters, err := s.resolveFeatureMeters(ctx, invoice.Namespace, invoice.Lines)
 		if err != nil {
 			return fmt.Errorf("resolving feature meters: %w", err)
-		}
-
-		customerProfile, err := s.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
-			Customer: invoice.GetCustomerID(),
-		})
-		if err != nil {
-			return fmt.Errorf("fetching profile: %w", err)
 		}
 
 		// Check if the new lines are still invoicable

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -46,7 +46,7 @@ import (
 // 5) We publish the invoice created event.
 //
 // 6) We return the created invoices.
-func (s *Service) InvoicePendingLines(ctx context.Context, input billing.InvoicePendingLinesInput) ([]billing.StandardInvoice, error) {
+func (s *Service) InvoicePendingLines(ctx context.Context, input billing.InvoicePendingLinesInput, opts ...billing.InvoicePendingLinesOption) ([]billing.StandardInvoice, error) {
 	if err := input.Validate(); err != nil {
 		return nil, billing.ValidationError{
 			Err: err,
@@ -64,7 +64,9 @@ func (s *Service) InvoicePendingLines(ctx context.Context, input billing.Invoice
 		s,
 		input.Customer,
 		func(ctx context.Context) ([]billing.StandardInvoice, error) {
-			billableLines, err := s.PrepareBillableLines(ctx, input)
+			options := billing.NewInvoicePendingLinesOptions(opts...)
+
+			billableLines, err := s.prepareBillableLines(ctx, input, options)
 			if err != nil {
 				return nil, fmt.Errorf("preparing billable lines: %w", err)
 			}
@@ -93,7 +95,7 @@ func (s *Service) InvoicePendingLines(ctx context.Context, input billing.Invoice
 		})
 }
 
-func (s *Service) PrepareBillableLines(ctx context.Context, input billing.PrepareBillableLinesInput) (*billing.PrepareBillableLinesResult, error) {
+func (s *Service) prepareBillableLines(ctx context.Context, input billing.PrepareBillableLinesInput, options billing.InvoicePendingLinesOptions) (*billing.PrepareBillableLinesResult, error) {
 	if err := input.Validate(); err != nil {
 		return nil, billing.ValidationError{
 			Err: err,
@@ -124,6 +126,16 @@ func (s *Service) PrepareBillableLines(ctx context.Context, input billing.Prepar
 			}
 
 			asOf := lo.FromPtrOr(input.AsOf, clock.Now())
+
+			progressiveBilling := customerProfile.MergedProfile.WorkflowConfig.Invoicing.ProgressiveBilling
+			if options.PartialInvoiceLinesEnabled != nil {
+				progressiveBilling = *options.PartialInvoiceLinesEnabled
+			}
+
+			asOf, err = resolvePendingLineCollectionCutoff(options, customerProfile.MergedProfile.WorkflowConfig.Collection, asOf)
+			if err != nil {
+				return nil, fmt.Errorf("resolving collection asOf: %w", err)
+			}
 
 			// let's fetch the existing gathering invoices for the customer
 			existingGatheringInvoices, err := s.adapter.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
@@ -172,10 +184,7 @@ func (s *Service) PrepareBillableLines(ctx context.Context, input billing.Prepar
 				GatheringInvoicesByCurrency: invoicesByCurrency,
 				LinesToInclude:              input.IncludePendingLines,
 				AsOf:                        asOf,
-				ProgressiveBilling: lo.FromPtrOr(
-					input.ProgressiveBillingOverride,
-					customerProfile.MergedProfile.WorkflowConfig.Invoicing.ProgressiveBilling,
-				),
+				ProgressiveBilling:          progressiveBilling,
 			})
 			if err != nil {
 				return nil, err
@@ -228,6 +237,47 @@ func (s *Service) PrepareBillableLines(ctx context.Context, input billing.Prepar
 				LinesByCurrency: linesToBeBilledByCurrency,
 			}, nil
 		})
+}
+
+// resolvePendingLineCollectionCutoff returns the effective AsOf cutoff used when selecting
+// gathering lines to invoice.
+//
+// Rules:
+//   - invoicing that bypasses collection alignment keeps the caller-provided cutoff unchanged
+//   - subscription alignment also keeps the cutoff unchanged
+//   - anchored alignment snaps the cutoff back to the latest anchor
+//     at or before the requested cutoff
+func resolvePendingLineCollectionCutoff(options billing.InvoicePendingLinesOptions, collection billing.CollectionConfig, asOf time.Time) (time.Time, error) {
+	if options.BypassCollectionAlignment {
+		return asOf, nil
+	}
+
+	switch collection.Alignment {
+	case billing.AlignmentKindSubscription:
+		return asOf, nil
+	case billing.AlignmentKindAnchored:
+		return latestAnchorAtOrBefore(collection.AnchoredAlignmentDetail, asOf)
+	default:
+		return time.Time{}, fmt.Errorf("unsupported collection alignment: %s", collection.Alignment)
+	}
+}
+
+func latestAnchorAtOrBefore(detail *billing.AnchoredAlignmentDetail, asOf time.Time) (time.Time, error) {
+	if detail == nil {
+		return time.Time{}, errors.New("anchored alignment detail is required")
+	}
+
+	recurrence, err := timeutil.NewRecurrenceFromISODuration(detail.Interval, detail.Anchor)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("creating anchored alignment recurrence: %w", err)
+	}
+
+	at, err := recurrence.PrevBefore(asOf, timeutil.Inclusive)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("resolving anchored alignment recurrence: %w", err)
+	}
+
+	return at, nil
 }
 
 type gatheringLineWithBillablePeriod struct {
@@ -835,7 +885,7 @@ func (s *Service) recalculateStandardInvoice(ctx context.Context, invoice billin
 		return billing.StandardInvoice{}, fmt.Errorf("resolving tax codes: %w", err)
 	}
 
-	if err := s.invoiceCalculator.Calculate(&invoice, invoicecalc.CalculatorDependencies{
+	if err := s.invoiceCalculator.Calculate(&invoice, invoicecalc.StandardInvoiceCalculatorDependencies{
 		FeatureMeters: featureMeters,
 		RatingService: s.ratingService,
 		TaxCodes:      taxCodes,
@@ -905,7 +955,16 @@ func (s *Service) removeLinesFromGatheringInvoice(ctx context.Context, invoice b
 	}
 
 	// Let's update the invoice's state
-	if err := s.invoiceCalculator.CalculateGatheringInvoice(&invoice); err != nil {
+	customerProfile, err := s.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
+		Customer: invoice.GetCustomerID(),
+	})
+	if err != nil {
+		return fmt.Errorf("fetching customer profile: %w", err)
+	}
+
+	if err := s.invoiceCalculator.CalculateGatheringInvoice(&invoice, invoicecalc.GatheringInvoiceCalculatorDependencies{
+		Collection: customerProfile.MergedProfile.WorkflowConfig.Collection,
+	}); err != nil {
 		return fmt.Errorf("calculating gathering invoice: %w", err)
 	}
 
@@ -914,7 +973,7 @@ func (s *Service) removeLinesFromGatheringInvoice(ctx context.Context, invoice b
 		invoice.DeletedAt = lo.ToPtr(clock.Now())
 	}
 
-	err := s.adapter.UpdateGatheringInvoice(ctx, invoice)
+	err = s.adapter.UpdateGatheringInvoice(ctx, invoice)
 	if err != nil {
 		return fmt.Errorf("updating gathering invoice: %w", err)
 	}

--- a/openmeter/billing/service/gatheringinvoicependinglines_test.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines_test.go
@@ -1,0 +1,159 @@
+package billingservice
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+)
+
+func TestResolvePendingLineCollectionCutoff(t *testing.T) {
+	asOf := mustTime(t, "2025-06-15T12:00:00Z")
+	anchor := mustTime(t, "2025-06-01T00:00:00Z")
+	monthly := datetime.MustParseDuration(t, "P1M")
+
+	tests := []struct {
+		name       string
+		opts       []billing.InvoicePendingLinesOption
+		collection billing.CollectionConfig
+		asOf       time.Time
+		want       time.Time
+		wantErr    string
+	}{
+		{
+			name: "bypassing alignment returns as of unchanged for subscription alignment",
+			opts: []billing.InvoicePendingLinesOption{
+				billing.WithBypassCollectionAlignment(),
+			},
+			collection: billing.CollectionConfig{
+				Alignment: billing.AlignmentKindSubscription,
+				Interval:  datetime.MustParseDuration(t, "PT1H"),
+			},
+			asOf: asOf,
+			want: asOf,
+		},
+		{
+			name: "bypassing alignment returns as of unchanged for anchored alignment",
+			opts: []billing.InvoicePendingLinesOption{
+				billing.WithBypassCollectionAlignment(),
+			},
+			collection: billing.CollectionConfig{
+				Alignment: billing.AlignmentKindAnchored,
+				AnchoredAlignmentDetail: &billing.AnchoredAlignmentDetail{
+					Interval: monthly,
+					Anchor:   anchor,
+				},
+				Interval: datetime.MustParseDuration(t, "PT1H"),
+			},
+			asOf: asOf,
+			want: asOf,
+		},
+		{
+			name: "subscription alignment returns as of unchanged",
+			collection: billing.CollectionConfig{
+				Alignment: billing.AlignmentKindSubscription,
+				Interval:  datetime.MustParseDuration(t, "PT1H"),
+			},
+			asOf: asOf,
+			want: asOf,
+		},
+		{
+			name: "anchored alignment returns previous anchor before as of",
+			collection: billing.CollectionConfig{
+				Alignment: billing.AlignmentKindAnchored,
+				AnchoredAlignmentDetail: &billing.AnchoredAlignmentDetail{
+					Interval: monthly,
+					Anchor:   anchor,
+				},
+				Interval: datetime.MustParseDuration(t, "PT1H"),
+			},
+			asOf: mustTime(t, "2025-06-15T12:00:00Z"),
+			want: mustTime(t, "2025-06-01T00:00:00Z"),
+		},
+		{
+			name: "anchored alignment returns exact anchor when as of lands on anchor",
+			collection: billing.CollectionConfig{
+				Alignment: billing.AlignmentKindAnchored,
+				AnchoredAlignmentDetail: &billing.AnchoredAlignmentDetail{
+					Interval: monthly,
+					Anchor:   anchor,
+				},
+				Interval: datetime.MustParseDuration(t, "PT1H"),
+			},
+			asOf: mustTime(t, "2025-07-01T00:00:00Z"),
+			want: mustTime(t, "2025-07-01T00:00:00Z"),
+		},
+		{
+			name: "anchored alignment can walk backwards from future anchor",
+			collection: billing.CollectionConfig{
+				Alignment: billing.AlignmentKindAnchored,
+				AnchoredAlignmentDetail: &billing.AnchoredAlignmentDetail{
+					Interval: monthly,
+					Anchor:   mustTime(t, "2025-08-01T00:00:00Z"),
+				},
+				Interval: datetime.MustParseDuration(t, "PT1H"),
+			},
+			asOf: mustTime(t, "2025-06-15T12:00:00Z"),
+			want: mustTime(t, "2025-06-01T00:00:00Z"),
+		},
+		{
+			name: "anchored alignment errors without detail",
+			collection: billing.CollectionConfig{
+				Alignment: billing.AlignmentKindAnchored,
+				Interval:  datetime.MustParseDuration(t, "PT1H"),
+			},
+			asOf:    asOf,
+			wantErr: "anchored alignment detail is required",
+		},
+		{
+			name: "anchored alignment errors for invalid recurrence interval",
+			collection: billing.CollectionConfig{
+				Alignment: billing.AlignmentKindAnchored,
+				AnchoredAlignmentDetail: &billing.AnchoredAlignmentDetail{
+					Interval: datetime.ISODuration{},
+					Anchor:   anchor,
+				},
+				Interval: datetime.MustParseDuration(t, "PT1H"),
+			},
+			asOf:    asOf,
+			wantErr: "creating anchored alignment recurrence",
+		},
+		{
+			name: "errors for unsupported alignment",
+			collection: billing.CollectionConfig{
+				Alignment: billing.AlignmentKind("invalid"),
+				Interval:  datetime.MustParseDuration(t, "PT1H"),
+			},
+			asOf:    asOf,
+			wantErr: "unsupported collection alignment: invalid",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := resolvePendingLineCollectionCutoff(billing.NewInvoicePendingLinesOptions(test.opts...), test.collection, test.asOf)
+
+			if test.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), test.wantErr)
+				require.True(t, got.IsZero())
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func mustTime(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	require.NoError(t, err)
+
+	return parsed
+}

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -939,17 +939,15 @@ func (s *Service) RecalculateGatheringInvoices(ctx context.Context, input billin
 			return fmt.Errorf("listing gathering invoices: %w", err)
 		}
 
+		customerProfile, err := s.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
+			Customer: input,
+		})
+		if err != nil {
+			return fmt.Errorf("fetching customer profile: %w", err)
+		}
+
 		for _, invoice := range gatheringInvoices.Items {
-			var err error
-
-			customerProfile, err := s.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
-				Customer: invoice.GetCustomerID(),
-			})
-			if err != nil {
-				return fmt.Errorf("fetching customer profile: %w", err)
-			}
-
-			if err = s.invoiceCalculator.CalculateGatheringInvoice(&invoice, invoicecalc.GatheringInvoiceCalculatorDependencies{
+			if err := s.invoiceCalculator.CalculateGatheringInvoice(&invoice, invoicecalc.GatheringInvoiceCalculatorDependencies{
 				Collection: customerProfile.MergedProfile.WorkflowConfig.Collection,
 			}); err != nil {
 				return fmt.Errorf("calculating gathering invoice: %w", err)
@@ -957,8 +955,7 @@ func (s *Service) RecalculateGatheringInvoices(ctx context.Context, input billin
 
 			invoiceID := invoice.ID
 
-			err = s.adapter.UpdateGatheringInvoice(ctx, invoice)
-			if err != nil {
+			if err := s.adapter.UpdateGatheringInvoice(ctx, invoice); err != nil {
 				return fmt.Errorf("updating gathering invoice[%s]: %w", invoiceID, err)
 			}
 

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -250,7 +250,7 @@ func (s *Service) calculateGatheringInvoiceAsStandardInvoice(ctx context.Context
 		return nil, fmt.Errorf("resolving tax codes: %w", err)
 	}
 
-	if err := s.invoiceCalculator.CalculateGatheringInvoiceWithLiveData(out, invoicecalc.CalculatorDependencies{
+	if err := s.invoiceCalculator.CalculateGatheringInvoiceWithLiveData(out, invoicecalc.StandardInvoiceCalculatorDependencies{
 		FeatureMeters: featureMeters,
 		RatingService: s.ratingService,
 		TaxCodes:      taxCodes,
@@ -863,7 +863,7 @@ func (s Service) SimulateInvoice(ctx context.Context, input billing.SimulateInvo
 	}
 
 	// Let's simulate a recalculation of the invoice
-	if err := s.invoiceCalculator.Calculate(&invoice, invoicecalc.CalculatorDependencies{
+	if err := s.invoiceCalculator.Calculate(&invoice, invoicecalc.StandardInvoiceCalculatorDependencies{
 		FeatureMeters: featureMeters,
 		RatingService: s.ratingService,
 		TaxCodes:      taxCodes,
@@ -942,7 +942,16 @@ func (s *Service) RecalculateGatheringInvoices(ctx context.Context, input billin
 		for _, invoice := range gatheringInvoices.Items {
 			var err error
 
-			if err = s.invoiceCalculator.CalculateGatheringInvoice(&invoice); err != nil {
+			customerProfile, err := s.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
+				Customer: invoice.GetCustomerID(),
+			})
+			if err != nil {
+				return fmt.Errorf("fetching customer profile: %w", err)
+			}
+
+			if err = s.invoiceCalculator.CalculateGatheringInvoice(&invoice, invoicecalc.GatheringInvoiceCalculatorDependencies{
+				Collection: customerProfile.MergedProfile.WorkflowConfig.Collection,
+			}); err != nil {
 				return fmt.Errorf("calculating gathering invoice: %w", err)
 			}
 

--- a/openmeter/billing/service/invoicecalc/calculator.go
+++ b/openmeter/billing/service/invoicecalc/calculator.go
@@ -10,14 +10,13 @@ import (
 )
 
 type invoiceCalculatorsByType struct {
-	LegacyGatheringInvoice       []Calculation
-	GatheringInvoice             []GatheringCalculation
-	GatheringInvoiceWithLiveData []Calculation
-	Invoice                      []Calculation
+	GatheringInvoice             []GatheringInvoiceCalculation
+	GatheringInvoiceWithLiveData []StandardInvoiceCalculation
+	Invoice                      []StandardInvoiceCalculation
 }
 
 var InvoiceCalculations = invoiceCalculatorsByType{
-	Invoice: []Calculation{
+	Invoice: []StandardInvoiceCalculation{
 		WithNoDependencies(StandardInvoiceCollectionAt),
 		WithNoDependencies(CalculateDraftUntil),
 		WithNoDependencies(CalculateDueAt),
@@ -26,20 +25,15 @@ var InvoiceCalculations = invoiceCalculatorsByType{
 		WithNoDependencies(CalculateStandardInvoiceServicePeriod),
 		SnapshotTaxConfigIntoLines,
 	},
-	LegacyGatheringInvoice: []Calculation{
-		WithNoDependencies(UpsertDiscountCorrelationIDs),
-		WithNoDependencies(LegacyGatheringInvoiceCollectionAt),
-		WithNoDependencies(CalculateStandardInvoiceServicePeriod),
-	},
-	GatheringInvoice: []GatheringCalculation{
-		UpsertGatheringInvoiceDiscountCorrelationIDs,
+	GatheringInvoice: []GatheringInvoiceCalculation{
+		WithNoGatheringDependencies(UpsertGatheringInvoiceDiscountCorrelationIDs),
 		GatheringInvoiceCollectionAt,
-		CalculateGatheringInvoiceServicePeriod,
+		WithNoGatheringDependencies(CalculateGatheringInvoiceServicePeriod),
 	},
 	// Calculations that should be running on a gathering invoice to populate line items
-	GatheringInvoiceWithLiveData: []Calculation{
+	GatheringInvoiceWithLiveData: []StandardInvoiceCalculation{
 		WithNoDependencies(UpsertDiscountCorrelationIDs),
-		WithNoDependencies(LegacyGatheringInvoiceCollectionAt),
+		WithNoDependencies(StandardInvoiceCollectionAt),
 		RecalculateDetailedLinesAndTotals,
 		WithNoDependencies(CalculateStandardInvoiceServicePeriod),
 		SnapshotTaxConfigIntoLines,
@@ -48,15 +42,14 @@ var InvoiceCalculations = invoiceCalculatorsByType{
 }
 
 type (
-	Calculation          func(*billing.StandardInvoice, CalculatorDependencies) error
-	GatheringCalculation func(*billing.GatheringInvoice) error
+	StandardInvoiceCalculation  func(*billing.StandardInvoice, StandardInvoiceCalculatorDependencies) error
+	GatheringInvoiceCalculation func(*billing.GatheringInvoice, GatheringInvoiceCalculatorDependencies) error
 )
 
 type Calculator interface {
-	Calculate(*billing.StandardInvoice, CalculatorDependencies) error
-	CalculateLegacyGatheringInvoice(*billing.StandardInvoice) error
-	CalculateGatheringInvoice(*billing.GatheringInvoice) error
-	CalculateGatheringInvoiceWithLiveData(*billing.StandardInvoice, CalculatorDependencies) error
+	Calculate(*billing.StandardInvoice, StandardInvoiceCalculatorDependencies) error
+	CalculateGatheringInvoice(*billing.GatheringInvoice, GatheringInvoiceCalculatorDependencies) error
+	CalculateGatheringInvoiceWithLiveData(*billing.StandardInvoice, StandardInvoiceCalculatorDependencies) error
 }
 
 // TaxCodes is a pre-resolved map of Stripe tax codes keyed by their Stripe code string.
@@ -76,11 +69,15 @@ func (t TaxCodes) Get(stripeCode string) (*taxcode.TaxCode, bool) {
 	return &tc, true
 }
 
-type CalculatorDependencies struct {
+type StandardInvoiceCalculatorDependencies struct {
 	FeatureMeters feature.FeatureMeters
 	RatingService rating.Service
 	TaxCodes      TaxCodes
 	LineEngines   LineEngineResolver
+}
+
+type GatheringInvoiceCalculatorDependencies struct {
+	Collection billing.CollectionConfig
 }
 
 type LineEngineResolver interface {
@@ -93,11 +90,11 @@ func New() Calculator {
 	return &calculator{}
 }
 
-func (c *calculator) Calculate(invoice *billing.StandardInvoice, deps CalculatorDependencies) error {
+func (c *calculator) Calculate(invoice *billing.StandardInvoice, deps StandardInvoiceCalculatorDependencies) error {
 	return c.applyCalculations(invoice, InvoiceCalculations.Invoice, deps)
 }
 
-func (c *calculator) applyCalculations(invoice *billing.StandardInvoice, calculators []Calculation, deps CalculatorDependencies) error {
+func (c *calculator) applyCalculations(invoice *billing.StandardInvoice, calculators []StandardInvoiceCalculation, deps StandardInvoiceCalculatorDependencies) error {
 	var outErr error
 	for _, calc := range calculators {
 		err := calc(invoice, deps)
@@ -113,15 +110,7 @@ func (c *calculator) applyCalculations(invoice *billing.StandardInvoice, calcula
 		billing.ValidationComponentOpenMeter)
 }
 
-func (c *calculator) CalculateLegacyGatheringInvoice(invoice *billing.StandardInvoice) error {
-	if invoice.Status != billing.StandardInvoiceStatusGathering {
-		return errors.New("invoice is not a gathering invoice")
-	}
-
-	return c.applyCalculations(invoice, InvoiceCalculations.LegacyGatheringInvoice, CalculatorDependencies{})
-}
-
-func (c *calculator) CalculateGatheringInvoiceWithLiveData(invoice *billing.StandardInvoice, deps CalculatorDependencies) error {
+func (c *calculator) CalculateGatheringInvoiceWithLiveData(invoice *billing.StandardInvoice, deps StandardInvoiceCalculatorDependencies) error {
 	if invoice.Status != billing.StandardInvoiceStatusGathering {
 		return errors.New("invoice is not a gathering invoice")
 	}
@@ -129,12 +118,12 @@ func (c *calculator) CalculateGatheringInvoiceWithLiveData(invoice *billing.Stan
 	return c.applyCalculations(invoice, InvoiceCalculations.GatheringInvoiceWithLiveData, deps)
 }
 
-func (c *calculator) CalculateGatheringInvoice(invoice *billing.GatheringInvoice) error {
+func (c *calculator) CalculateGatheringInvoice(invoice *billing.GatheringInvoice, deps GatheringInvoiceCalculatorDependencies) error {
 	var errs []error
 
 	// Note: GatheringInvoice has no ValidationIssues, so we should just return the error as is
 	for _, calc := range InvoiceCalculations.GatheringInvoice {
-		err := calc(invoice)
+		err := calc(invoice, deps)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -143,8 +132,14 @@ func (c *calculator) CalculateGatheringInvoice(invoice *billing.GatheringInvoice
 	return errors.Join(errs...)
 }
 
-func WithNoDependencies(cb func(inv *billing.StandardInvoice) error) Calculation {
-	return func(inv *billing.StandardInvoice, _ CalculatorDependencies) error {
+func WithNoDependencies(cb func(inv *billing.StandardInvoice) error) StandardInvoiceCalculation {
+	return func(inv *billing.StandardInvoice, _ StandardInvoiceCalculatorDependencies) error {
+		return cb(inv)
+	}
+}
+
+func WithNoGatheringDependencies(cb func(inv *billing.GatheringInvoice) error) GatheringInvoiceCalculation {
+	return func(inv *billing.GatheringInvoice, _ GatheringInvoiceCalculatorDependencies) error {
 		return cb(inv)
 	}
 }

--- a/openmeter/billing/service/invoicecalc/collectionat.go
+++ b/openmeter/billing/service/invoicecalc/collectionat.go
@@ -8,95 +8,93 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func LegacyGatheringInvoiceCollectionAt(i *billing.StandardInvoice) error {
+func GatheringInvoiceCollectionAt(i *billing.GatheringInvoice, deps GatheringInvoiceCalculatorDependencies) error {
+	i.NextCollectionAt = nil
+
+	if !i.Lines.IsPresent() {
+		return errors.New("lines must be expanded")
+	}
+
+	nonDeletedLines := i.Lines.NonDeletedLines()
+
+	// Cannot determine next collection at without any non-deleted lines
+	if len(nonDeletedLines) == 0 {
+		return nil
+	}
+
+	minInvoiceAt := lo.MinBy(nonDeletedLines, func(a, b billing.GatheringLine) bool {
+		return a.InvoiceAt.Before(b.InvoiceAt)
+	})
+
+	nextCollectionAt, err := calculateGatheringInvoiceNextCollectionAt(deps.Collection, minInvoiceAt.InvoiceAt)
+	if err != nil {
+		return fmt.Errorf("calculating next collection at: %w", err)
+	}
+
+	i.NextCollectionAt = lo.ToPtr(nextCollectionAt)
+
+	return nil
+}
+
+func calculateGatheringInvoiceNextCollectionAt(collectionConfig billing.CollectionConfig, minInvoiceAt time.Time) (time.Time, error) {
+	if err := collectionConfig.Validate(); err != nil {
+		return time.Time{}, fmt.Errorf("invalid collection config: %w", err)
+	}
+
+	if minInvoiceAt.IsZero() {
+		// Cannot determine next collection at without a min invoice at
+		return time.Time{}, fmt.Errorf("cannot determine next collection at without a min invoice at")
+	}
+
+	if collectionConfig.Alignment == billing.AlignmentKindSubscription {
+		return minInvoiceAt, nil
+	}
+
+	if collectionConfig.AnchoredAlignmentDetail == nil {
+		return time.Time{}, errors.New("anchored alignment detail is required, when alignment is anchored")
+	}
+
+	recurrence, err := timeutil.NewRecurrenceFromISODuration(collectionConfig.AnchoredAlignmentDetail.Interval, collectionConfig.AnchoredAlignmentDetail.Anchor)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("creating anchored alignment recurrence: %w", err)
+	}
+
+	next, err := recurrence.NextAfter(minInvoiceAt, timeutil.Inclusive)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("resolving anchored alignment recurrence: %w", err)
+	}
+
+	return next, nil
+}
+
+func StandardInvoiceCollectionAt(i *billing.StandardInvoice) error {
 	i.CollectionAt = nil
 
 	if !i.Lines.IsPresent() {
 		return errors.New("lines must be expanded")
 	}
 
-	for _, line := range i.Lines.OrEmpty() {
-		if i.CollectionAt == nil {
-			i.CollectionAt = lo.ToPtr(line.InvoiceAt)
-			continue
-		}
+	collectableLines := lo.Filter(i.Lines.OrEmpty(), func(line *billing.StandardLine, _ int) bool {
+		return line.DeletedAt == nil && line.DependsOnMeteredQuantity()
+	})
 
-		if i.CollectionAt.After(line.InvoiceAt) {
-			i.CollectionAt = lo.ToPtr(line.InvoiceAt)
-		}
+	if len(collectableLines) == 0 {
+		return nil
 	}
 
-	return nil
-}
+	maxInvoiceAt := lo.MaxBy(collectableLines, func(a, b *billing.StandardLine) bool {
+		return a.InvoiceAt.After(b.InvoiceAt)
+	})
 
-func GatheringInvoiceCollectionAt(i *billing.GatheringInvoice) error {
-	i.NextCollectionAt = time.Time{}
-
-	if !i.Lines.IsPresent() {
-		return errors.New("lines must be expanded")
-	}
-
-	for _, line := range i.Lines.OrEmpty() {
-		if i.NextCollectionAt.IsZero() {
-			i.NextCollectionAt = line.InvoiceAt
-			continue
-		}
-
-		if i.NextCollectionAt.After(line.InvoiceAt) {
-			i.NextCollectionAt = line.InvoiceAt
-		}
-	}
-
-	return nil
-}
-
-func StandardInvoiceCollectionAt(i *billing.StandardInvoice) error {
-	if !i.Lines.IsPresent() {
-		return errors.New("lines must be expanded")
-	}
-
-	maxInvoiceAt := time.Time{}
-	for _, line := range i.Lines.OrEmpty() {
-		if !line.DependsOnMeteredQuantity() {
-			// No collection required for non-usage based lines
-			continue
-		}
-
-		if line.InvoiceAt.After(maxInvoiceAt) {
-			maxInvoiceAt = line.InvoiceAt
-		}
-	}
-
-	// By default we can collect as soon as all lines are closed (which is driven by subscription sync)
-	// (i.CreatedAt stubs in for current timestamp clock.Now(), effectively backdating for processing latency)
-	collectionAt, _ := lo.Coalesce(maxInvoiceAt, i.CreatedAt)
-
-	switch i.Workflow.Config.Collection.Alignment {
-	case billing.AlignmentKindSubscription:
-		// This is the trivial case
-	case billing.AlignmentKindAnchored:
-		// Let's calculate the next first day of month after the invoice was created
-		startOfMonth := time.Date(collectionAt.Year(), collectionAt.Month(), 1, 0, 0, 0, 0, collectionAt.Location()) // FIXME: where should we get the Location from?
-		collectionAt = startOfMonth.AddDate(0, 1, 0)
-	default:
-		return fmt.Errorf("unsupported collection alignment: %s", i.Workflow.Config.Collection.Alignment)
-	}
-
-	if collectionAt.IsZero() {
-		return errors.New("failed to calculate default collection time")
-	}
+	collectionAt := maxInvoiceAt.InvoiceAt
 
 	// If we have an intended collection period, we should try to honor that
-	if i.Workflow.Config.Collection.Interval.IsPositive() && !maxInvoiceAt.IsZero() {
+	if i.Workflow.Config.Collection.Interval.IsPositive() {
 		collectionAt, _ = i.Workflow.Config.Collection.Interval.AddTo(collectionAt)
 	}
-
-	// We push out collectionAt until invoice creation so we're always able to honor the user intent to have a draft period
-	// if collectionAt.Before(i.CreatedAt) {
-	// 	collectionAt = i.CreatedAt
-	// }
 
 	i.CollectionAt = lo.ToPtr(collectionAt)
 

--- a/openmeter/billing/service/invoicecalc/collectionat_test.go
+++ b/openmeter/billing/service/invoicecalc/collectionat_test.go
@@ -1,0 +1,395 @@
+package invoicecalc
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestGatheringInvoiceCollectionAt(t *testing.T) {
+	anchor := mustTime(t, "2025-06-01T00:00:00Z")
+	monthly := datetime.MustParseDuration(t, "P1M")
+
+	tests := []struct {
+		name    string
+		invoice billing.GatheringInvoice
+		deps    GatheringInvoiceCalculatorDependencies
+		want    time.Time
+		wantErr string
+	}{
+		{
+			name: "subscription alignment uses earliest invoice at",
+			invoice: newGatheringInvoice(
+				newGatheringLine(t, "2025-06-15T12:00:00Z"),
+				newGatheringLine(t, "2025-06-05T08:00:00Z"),
+			),
+			deps: GatheringInvoiceCalculatorDependencies{
+				Collection: billing.CollectionConfig{
+					Alignment: billing.AlignmentKindSubscription,
+					Interval:  datetime.MustParseDuration(t, "PT1H"),
+				},
+			},
+			want: mustTime(t, "2025-06-05T08:00:00Z"),
+		},
+		{
+			name: "anchored alignment snaps to next anchor after earliest invoice at",
+			invoice: newGatheringInvoice(
+				newGatheringLine(t, "2025-06-15T12:00:00Z"),
+				newGatheringLine(t, "2025-06-05T08:00:00Z"),
+			),
+			deps: GatheringInvoiceCalculatorDependencies{
+				Collection: billing.CollectionConfig{
+					Alignment: billing.AlignmentKindAnchored,
+					AnchoredAlignmentDetail: &billing.AnchoredAlignmentDetail{
+						Interval: monthly,
+						Anchor:   anchor,
+					},
+					Interval: datetime.MustParseDuration(t, "PT1H"),
+				},
+			},
+			want: mustTime(t, "2025-07-01T00:00:00Z"),
+		},
+		{
+			name: "anchored alignment keeps exact anchor",
+			invoice: newGatheringInvoice(
+				newGatheringLine(t, "2025-07-01T00:00:00Z"),
+			),
+			deps: GatheringInvoiceCalculatorDependencies{
+				Collection: billing.CollectionConfig{
+					Alignment: billing.AlignmentKindAnchored,
+					AnchoredAlignmentDetail: &billing.AnchoredAlignmentDetail{
+						Interval: monthly,
+						Anchor:   anchor,
+					},
+					Interval: datetime.MustParseDuration(t, "PT1H"),
+				},
+			},
+			want: mustTime(t, "2025-07-01T00:00:00Z"),
+		},
+		{
+			name: "anchored alignment can walk forward from future anchor basis",
+			invoice: newGatheringInvoice(
+				newGatheringLine(t, "2025-06-15T12:00:00Z"),
+			),
+			deps: GatheringInvoiceCalculatorDependencies{
+				Collection: billing.CollectionConfig{
+					Alignment: billing.AlignmentKindAnchored,
+					AnchoredAlignmentDetail: &billing.AnchoredAlignmentDetail{
+						Interval: monthly,
+						Anchor:   mustTime(t, "2025-08-01T00:00:00Z"),
+					},
+					Interval: datetime.MustParseDuration(t, "PT1H"),
+				},
+			},
+			want: mustTime(t, "2025-07-01T00:00:00Z"),
+		},
+		{
+			name: "deleted lines are ignored",
+			invoice: newGatheringInvoice(
+				newDeletedGatheringLine(t, "2025-06-05T08:00:00Z"),
+				newGatheringLine(t, "2025-06-15T12:00:00Z"),
+			),
+			deps: GatheringInvoiceCalculatorDependencies{
+				Collection: billing.CollectionConfig{
+					Alignment: billing.AlignmentKindSubscription,
+					Interval:  datetime.MustParseDuration(t, "PT1H"),
+				},
+			},
+			want: mustTime(t, "2025-06-15T12:00:00Z"),
+		},
+		{
+			name:    "empty lines leaves zero collection at",
+			invoice: billing.GatheringInvoice{Lines: billing.NewGatheringInvoiceLines([]billing.GatheringLine{})},
+			deps: GatheringInvoiceCalculatorDependencies{
+				Collection: billing.CollectionConfig{
+					Alignment: billing.AlignmentKindSubscription,
+					Interval:  datetime.MustParseDuration(t, "PT1H"),
+				},
+			},
+			want: time.Time{},
+		},
+		{
+			name: "errors when lines are not expanded",
+			deps: GatheringInvoiceCalculatorDependencies{
+				Collection: billing.CollectionConfig{
+					Alignment: billing.AlignmentKindSubscription,
+					Interval:  datetime.MustParseDuration(t, "PT1H"),
+				},
+			},
+			wantErr: "lines must be expanded",
+		},
+		{
+			name: "errors on anchored alignment without detail",
+			invoice: newGatheringInvoice(
+				newGatheringLine(t, "2025-06-15T12:00:00Z"),
+			),
+			deps: GatheringInvoiceCalculatorDependencies{
+				Collection: billing.CollectionConfig{
+					Alignment: billing.AlignmentKindAnchored,
+					Interval:  datetime.MustParseDuration(t, "PT1H"),
+				},
+			},
+			wantErr: "invalid collection config: anchored alignment detail must be set",
+		},
+		{
+			name: "errors on invalid anchored recurrence",
+			invoice: newGatheringInvoice(
+				newGatheringLine(t, "2025-06-15T12:00:00Z"),
+			),
+			deps: GatheringInvoiceCalculatorDependencies{
+				Collection: billing.CollectionConfig{
+					Alignment: billing.AlignmentKindAnchored,
+					AnchoredAlignmentDetail: &billing.AnchoredAlignmentDetail{
+						Interval: datetime.ISODuration{},
+						Anchor:   anchor,
+					},
+					Interval: datetime.MustParseDuration(t, "PT1H"),
+				},
+			},
+			wantErr: "creating anchored alignment recurrence",
+		},
+		{
+			name: "errors on unsupported alignment",
+			invoice: newGatheringInvoice(
+				newGatheringLine(t, "2025-06-15T12:00:00Z"),
+			),
+			deps: GatheringInvoiceCalculatorDependencies{
+				Collection: billing.CollectionConfig{
+					Alignment: billing.AlignmentKind("invalid"),
+					Interval:  datetime.MustParseDuration(t, "PT1H"),
+				},
+			},
+			wantErr: "invalid collection config: invalid alignment: invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := GatheringInvoiceCollectionAt(&tt.invoice, tt.deps)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.want.IsZero() {
+				require.Nil(t, tt.invoice.NextCollectionAt)
+				return
+			}
+
+			require.NotNil(t, tt.invoice.NextCollectionAt)
+			require.Equal(t, tt.want, *tt.invoice.NextCollectionAt)
+		})
+	}
+}
+
+func TestStandardInvoiceCollectionAt(t *testing.T) {
+	tests := []struct {
+		name    string
+		invoice billing.StandardInvoice
+		want    time.Time
+		wantErr string
+	}{
+		{
+			name: "uses latest non deleted invoice at and adds collection interval",
+			invoice: newStandardInvoice(
+				mustTime(t, "2025-06-10T00:00:00Z"),
+				datetime.MustParseDuration(t, "PT1H"),
+				newStandardLine(t, "2025-06-05T08:00:00Z"),
+				newStandardLine(t, "2025-06-15T12:00:00Z"),
+			),
+			want: mustTime(t, "2025-06-15T13:00:00Z"),
+		},
+		{
+			name: "ignores flat fee lines when resolving collection at",
+			invoice: newStandardInvoice(
+				mustTime(t, "2025-06-10T00:00:00Z"),
+				datetime.MustParseDuration(t, "PT1H"),
+				newFlatFeeStandardLine(t, "2025-06-20T12:00:00Z"),
+				newStandardLine(t, "2025-06-15T12:00:00Z"),
+			),
+			want: mustTime(t, "2025-06-15T13:00:00Z"),
+		},
+		{
+			name: "ignores deleted lines when resolving latest invoice at",
+			invoice: newStandardInvoice(
+				mustTime(t, "2025-06-10T00:00:00Z"),
+				datetime.MustParseDuration(t, "PT1H"),
+				newDeletedStandardLine(t, "2025-06-20T12:00:00Z"),
+				newStandardLine(t, "2025-06-15T12:00:00Z"),
+			),
+			want: mustTime(t, "2025-06-15T13:00:00Z"),
+		},
+		{
+			name: "returns nil collection at when there are no non deleted metered lines",
+			invoice: newStandardInvoice(
+				mustTime(t, "2025-06-10T00:00:00Z"),
+				datetime.MustParseDuration(t, "PT1H"),
+				newDeletedStandardLine(t, "2025-06-20T12:00:00Z"),
+			),
+			want: time.Time{},
+		},
+		{
+			name: "uses latest non deleted metered invoice at without interval when interval is zero",
+			invoice: newStandardInvoice(
+				mustTime(t, "2025-06-10T00:00:00Z"),
+				datetime.ISODuration{},
+				newStandardLine(t, "2025-06-05T08:00:00Z"),
+				newStandardLine(t, "2025-06-15T12:00:00Z"),
+			),
+			want: mustTime(t, "2025-06-15T12:00:00Z"),
+		},
+		{
+			name:    "errors when lines are not expanded",
+			invoice: billing.StandardInvoice{},
+			wantErr: "lines must be expanded",
+		},
+		{
+			name: "returns nil collection at for flat fee only invoices",
+			invoice: newStandardInvoice(
+				mustTime(t, "2025-06-10T00:00:00Z"),
+				datetime.MustParseDuration(t, "PT1H"),
+				newFlatFeeStandardLine(t, "2025-06-20T12:00:00Z"),
+			),
+			want: time.Time{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := StandardInvoiceCollectionAt(&tt.invoice)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.want.IsZero() {
+				require.Nil(t, tt.invoice.CollectionAt)
+				return
+			}
+
+			require.NotNil(t, tt.invoice.CollectionAt)
+			require.Equal(t, tt.want, *tt.invoice.CollectionAt)
+		})
+	}
+}
+
+func newGatheringInvoice(lines ...billing.GatheringLine) billing.GatheringInvoice {
+	return billing.GatheringInvoice{
+		Lines: billing.NewGatheringInvoiceLines(lines),
+	}
+}
+
+func newGatheringLine(t *testing.T, invoiceAt string) billing.GatheringLine {
+	t.Helper()
+
+	at := mustTime(t, invoiceAt)
+
+	return billing.GatheringLine{
+		GatheringLineBase: billing.GatheringLineBase{
+			InvoiceAt: at,
+		},
+	}
+}
+
+func newDeletedGatheringLine(t *testing.T, invoiceAt string) billing.GatheringLine {
+	t.Helper()
+
+	line := newGatheringLine(t, invoiceAt)
+	deletedAt := mustTime(t, "2025-07-15T12:00:00Z")
+	line.DeletedAt = &deletedAt
+
+	return line
+}
+
+func newStandardInvoice(createdAt time.Time, interval datetime.ISODuration, lines ...*billing.StandardLine) billing.StandardInvoice {
+	return billing.StandardInvoice{
+		StandardInvoiceBase: billing.StandardInvoiceBase{
+			CreatedAt: createdAt,
+			Workflow: billing.InvoiceWorkflow{
+				Config: billing.WorkflowConfig{
+					Collection: billing.CollectionConfig{
+						Alignment: billing.AlignmentKindSubscription,
+						Interval:  interval,
+					},
+				},
+			},
+		},
+		Lines: billing.NewStandardInvoiceLines(lines),
+	}
+}
+
+func newStandardLine(t *testing.T, invoiceAt string) *billing.StandardLine {
+	t.Helper()
+
+	at := mustTime(t, invoiceAt)
+
+	return &billing.StandardLine{
+		StandardLineBase: billing.StandardLineBase{
+			ManagedResource: billing.GatheringLineBase{}.ManagedResource,
+			Currency:        currencyx.Code("USD"),
+			ManagedBy:       billing.ManuallyManagedLine,
+			InvoiceAt:       at,
+			Period: timeutil.ClosedPeriod{
+				From: at,
+				To:   at,
+			},
+		},
+		UsageBased: &billing.UsageBasedLine{
+			Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromFloat(10),
+			}),
+		},
+	}
+}
+
+func newDeletedStandardLine(t *testing.T, invoiceAt string) *billing.StandardLine {
+	t.Helper()
+
+	line := newStandardLine(t, invoiceAt)
+	deletedAt := mustTime(t, "2025-07-15T12:00:00Z")
+	line.DeletedAt = &deletedAt
+
+	return line
+}
+
+func newFlatFeeStandardLine(t *testing.T, invoiceAt string) *billing.StandardLine {
+	t.Helper()
+
+	at := mustTime(t, invoiceAt)
+
+	return billing.NewFlatFeeLine(billing.NewFlatFeeLineInput{
+		Namespace: "ns",
+		InvoiceAt: at,
+		Period: timeutil.ClosedPeriod{
+			From: at,
+			To:   at,
+		},
+		Name:      "Flat fee",
+		Currency:  currencyx.Code("USD"),
+		ManagedBy: billing.ManuallyManagedLine,
+
+		PerUnitAmount: alpacadecimal.NewFromFloat(10),
+		PaymentTerm:   productcatalog.InArrearsPaymentTerm,
+	})
+}
+
+func mustTime(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	require.NoError(t, err)
+
+	return parsed
+}

--- a/openmeter/billing/service/invoicecalc/details.go
+++ b/openmeter/billing/service/invoicecalc/details.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func RecalculateDetailedLinesAndTotals(invoice *billing.StandardInvoice, deps CalculatorDependencies) error {
+func RecalculateDetailedLinesAndTotals(invoice *billing.StandardInvoice, deps StandardInvoiceCalculatorDependencies) error {
 	if invoice.Lines.IsAbsent() {
 		return errors.New("cannot recaulculate invoice without expanded lines")
 	}

--- a/openmeter/billing/service/invoicecalc/mock.go
+++ b/openmeter/billing/service/invoicecalc/mock.go
@@ -19,9 +19,6 @@ type mockCalculator struct {
 	calculateResult       mo.Option[error]
 	calculateResultCalled bool
 
-	calculateLegacyGatheringInvoiceResult       mo.Option[error]
-	calculateLegacyGatheringInvoiceResultCalled bool
-
 	calculateGatheringInvoiceWithLiveDataResult       mo.Option[error]
 	calculateGatheringInvoiceWithLiveDataResultCalled bool
 
@@ -29,7 +26,7 @@ type mockCalculator struct {
 	calculateGatheringInvoiceResultCalled bool
 }
 
-func (m *mockCalculator) Calculate(i *billing.StandardInvoice, deps CalculatorDependencies) error {
+func (m *mockCalculator) Calculate(i *billing.StandardInvoice, deps StandardInvoiceCalculatorDependencies) error {
 	m.calculateResultCalled = true
 
 	res := m.calculateResult.MustGet()
@@ -44,22 +41,7 @@ func (m *mockCalculator) Calculate(i *billing.StandardInvoice, deps CalculatorDe
 		billing.ValidationComponentOpenMeter)
 }
 
-func (m *mockCalculator) CalculateLegacyGatheringInvoice(i *billing.StandardInvoice) error {
-	m.calculateLegacyGatheringInvoiceResultCalled = true
-
-	res := m.calculateLegacyGatheringInvoiceResult.MustGet()
-
-	// This simulates the same behavior as the calculate method for the original
-	// implementation. This way the mock can be used to inject calculation errors
-	// as if they were coming from a calculate callback.
-	return i.MergeValidationIssues(
-		billing.ValidationWithComponent(
-			billing.ValidationComponentOpenMeter,
-			res),
-		billing.ValidationComponentOpenMeter)
-}
-
-func (m *mockCalculator) CalculateGatheringInvoiceWithLiveData(i *billing.StandardInvoice, deps CalculatorDependencies) error {
+func (m *mockCalculator) CalculateGatheringInvoiceWithLiveData(i *billing.StandardInvoice, deps StandardInvoiceCalculatorDependencies) error {
 	m.calculateGatheringInvoiceWithLiveDataResultCalled = true
 
 	res := m.calculateGatheringInvoiceWithLiveDataResult.MustGet()
@@ -74,7 +56,7 @@ func (m *mockCalculator) CalculateGatheringInvoiceWithLiveData(i *billing.Standa
 		billing.ValidationComponentOpenMeter)
 }
 
-func (m *mockCalculator) CalculateGatheringInvoice(i *billing.GatheringInvoice) error {
+func (m *mockCalculator) CalculateGatheringInvoice(i *billing.GatheringInvoice, _ GatheringInvoiceCalculatorDependencies) error {
 	m.calculateGatheringInvoiceResultCalled = true
 
 	res := m.calculateGatheringInvoiceResult.MustGet()
@@ -84,10 +66,6 @@ func (m *mockCalculator) CalculateGatheringInvoice(i *billing.GatheringInvoice) 
 
 func (m *mockCalculator) OnCalculate(err error) {
 	m.calculateResult = mo.Some(err)
-}
-
-func (m *mockCalculator) OnCalculateLegacyGatheringInvoice(err error) {
-	m.calculateLegacyGatheringInvoiceResult = mo.Some(err)
 }
 
 func (m *mockCalculator) OnCalculateGatheringInvoiceWithLiveData(err error) {
@@ -103,10 +81,6 @@ func (m *mockCalculator) AssertExpectations(t *testing.T) {
 
 	if m.calculateResult.IsPresent() && !m.calculateResultCalled {
 		t.Errorf("expected Calculate to be called")
-	}
-
-	if m.calculateLegacyGatheringInvoiceResult.IsPresent() && !m.calculateLegacyGatheringInvoiceResultCalled {
-		t.Errorf("expected CalculateLegacyGatheringInvoice to be called")
 	}
 
 	if m.calculateGatheringInvoiceResult.IsPresent() && !m.calculateGatheringInvoiceResultCalled {
@@ -126,9 +100,6 @@ func (m *mockCalculator) Reset(t *testing.T) {
 	m.calculateResult = mo.None[error]()
 	m.calculateResultCalled = false
 
-	m.calculateLegacyGatheringInvoiceResult = mo.None[error]()
-	m.calculateLegacyGatheringInvoiceResultCalled = false
-
 	m.calculateGatheringInvoiceResult = mo.None[error]()
 	m.calculateGatheringInvoiceResultCalled = false
 
@@ -142,7 +113,7 @@ func NewMockableCalculator(_ *testing.T, upstream Calculator) *MockableInvoiceCa
 	}
 }
 
-func (m *MockableInvoiceCalculator) Calculate(i *billing.StandardInvoice, deps CalculatorDependencies) error {
+func (m *MockableInvoiceCalculator) Calculate(i *billing.StandardInvoice, deps StandardInvoiceCalculatorDependencies) error {
 	outErr := m.upstream.Calculate(i, deps)
 
 	if m.mock != nil {
@@ -155,11 +126,11 @@ func (m *MockableInvoiceCalculator) Calculate(i *billing.StandardInvoice, deps C
 	return outErr
 }
 
-func (m *MockableInvoiceCalculator) CalculateLegacyGatheringInvoice(i *billing.StandardInvoice) error {
-	outErr := m.upstream.CalculateLegacyGatheringInvoice(i)
+func (m *MockableInvoiceCalculator) CalculateGatheringInvoice(i *billing.GatheringInvoice, deps GatheringInvoiceCalculatorDependencies) error {
+	outErr := m.upstream.CalculateGatheringInvoice(i, deps)
 
 	if m.mock != nil {
-		err := m.mock.CalculateLegacyGatheringInvoice(i)
+		err := m.mock.CalculateGatheringInvoice(i, deps)
 		if err != nil {
 			outErr = errors.Join(outErr, err)
 		}
@@ -168,20 +139,7 @@ func (m *MockableInvoiceCalculator) CalculateLegacyGatheringInvoice(i *billing.S
 	return outErr
 }
 
-func (m *MockableInvoiceCalculator) CalculateGatheringInvoice(i *billing.GatheringInvoice) error {
-	outErr := m.upstream.CalculateGatheringInvoice(i)
-
-	if m.mock != nil {
-		err := m.mock.CalculateGatheringInvoice(i)
-		if err != nil {
-			outErr = errors.Join(outErr, err)
-		}
-	}
-
-	return outErr
-}
-
-func (m *MockableInvoiceCalculator) CalculateGatheringInvoiceWithLiveData(i *billing.StandardInvoice, deps CalculatorDependencies) error {
+func (m *MockableInvoiceCalculator) CalculateGatheringInvoiceWithLiveData(i *billing.StandardInvoice, deps StandardInvoiceCalculatorDependencies) error {
 	outErr := m.upstream.CalculateGatheringInvoiceWithLiveData(i, deps)
 
 	if m.mock != nil {

--- a/openmeter/billing/service/invoicecalc/taxconfig.go
+++ b/openmeter/billing/service/invoicecalc/taxconfig.go
@@ -10,7 +10,7 @@ import (
 // SnapshotTaxConfigIntoLines merges the invoice's DefaultTaxConfig into each line and
 // stamps the resolved TaxCode entity (and its ID) onto the line's TaxConfig.
 // Skipped for gathering invoices — snapshotting only applies to standard invoices.
-func SnapshotTaxConfigIntoLines(invoice *billing.StandardInvoice, deps CalculatorDependencies) error {
+func SnapshotTaxConfigIntoLines(invoice *billing.StandardInvoice, deps StandardInvoiceCalculatorDependencies) error {
 	if invoice.Status == billing.StandardInvoiceStatusGathering {
 		return nil
 	}

--- a/openmeter/billing/service/invoicecalc/taxconfig_test.go
+++ b/openmeter/billing/service/invoicecalc/taxconfig_test.go
@@ -55,7 +55,7 @@ func TestSnapshotTaxConfigIntoLines(t *testing.T) {
 	tests := []struct {
 		name      string
 		invoice   billing.StandardInvoice
-		deps      CalculatorDependencies
+		deps      StandardInvoiceCalculatorDependencies
 		wantTC    *productcatalog.TaxConfig
 		wantNoErr bool
 	}{
@@ -68,7 +68,7 @@ func TestSnapshotTaxConfigIntoLines(t *testing.T) {
 					Stripe: &productcatalog.StripeTaxConfig{Code: "txcd_10000000"},
 				}),
 			),
-			deps:      CalculatorDependencies{TaxCodes: TaxCodes{"txcd_10000000": tc1}},
+			deps:      StandardInvoiceCalculatorDependencies{TaxCodes: TaxCodes{"txcd_10000000": tc1}},
 			wantTC:    &productcatalog.TaxConfig{Stripe: &productcatalog.StripeTaxConfig{Code: "txcd_10000000"}},
 			wantNoErr: true,
 		},
@@ -81,7 +81,7 @@ func TestSnapshotTaxConfigIntoLines(t *testing.T) {
 					Stripe: &productcatalog.StripeTaxConfig{Code: "txcd_10000000"},
 				}),
 			),
-			deps: CalculatorDependencies{TaxCodes: TaxCodes{"txcd_10000000": tc1}},
+			deps: StandardInvoiceCalculatorDependencies{TaxCodes: TaxCodes{"txcd_10000000": tc1}},
 			wantTC: &productcatalog.TaxConfig{
 				Stripe:    &productcatalog.StripeTaxConfig{Code: "txcd_10000000"},
 				TaxCodeID: lo.ToPtr("tc-1"),
@@ -99,7 +99,7 @@ func TestSnapshotTaxConfigIntoLines(t *testing.T) {
 					TaxCodeID: lo.ToPtr("already-set"),
 				}),
 			),
-			deps: CalculatorDependencies{TaxCodes: TaxCodes{"txcd_10000000": tc1}},
+			deps: StandardInvoiceCalculatorDependencies{TaxCodes: TaxCodes{"txcd_10000000": tc1}},
 			wantTC: &productcatalog.TaxConfig{
 				Stripe:    &productcatalog.StripeTaxConfig{Code: "txcd_10000000"},
 				TaxCodeID: lo.ToPtr("already-set"),
@@ -116,7 +116,7 @@ func TestSnapshotTaxConfigIntoLines(t *testing.T) {
 					Stripe: &productcatalog.StripeTaxConfig{Code: "txcd_10000000"},
 				}),
 			),
-			deps: CalculatorDependencies{TaxCodes: TaxCodes{}},
+			deps: StandardInvoiceCalculatorDependencies{TaxCodes: TaxCodes{}},
 			wantTC: &productcatalog.TaxConfig{
 				Stripe: &productcatalog.StripeTaxConfig{Code: "txcd_10000000"},
 			},
@@ -132,7 +132,7 @@ func TestSnapshotTaxConfigIntoLines(t *testing.T) {
 				},
 				newLine(nil),
 			),
-			deps: CalculatorDependencies{TaxCodes: TaxCodes{"txcd_10000000": tc1}},
+			deps: StandardInvoiceCalculatorDependencies{TaxCodes: TaxCodes{"txcd_10000000": tc1}},
 			wantTC: &productcatalog.TaxConfig{
 				Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
 				Stripe:    &productcatalog.StripeTaxConfig{Code: "txcd_10000000"},
@@ -152,7 +152,7 @@ func TestSnapshotTaxConfigIntoLines(t *testing.T) {
 					Stripe: &productcatalog.StripeTaxConfig{Code: "txcd_20000000"},
 				}),
 			),
-			deps: CalculatorDependencies{TaxCodes: TaxCodes{
+			deps: StandardInvoiceCalculatorDependencies{TaxCodes: TaxCodes{
 				"txcd_10000000": tc1,
 				"txcd_20000000": tc2,
 			}},
@@ -172,7 +172,7 @@ func TestSnapshotTaxConfigIntoLines(t *testing.T) {
 					Behavior: lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
 				}),
 			),
-			deps: CalculatorDependencies{TaxCodes: TaxCodes{"txcd_10000000": tc1}},
+			deps: StandardInvoiceCalculatorDependencies{TaxCodes: TaxCodes{"txcd_10000000": tc1}},
 			wantTC: &productcatalog.TaxConfig{
 				Behavior: lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
 			},
@@ -185,7 +185,7 @@ func TestSnapshotTaxConfigIntoLines(t *testing.T) {
 				nil,
 				newLine(nil),
 			),
-			deps:      CalculatorDependencies{},
+			deps:      StandardInvoiceCalculatorDependencies{},
 			wantTC:    nil,
 			wantNoErr: true,
 		},

--- a/openmeter/billing/service/stdinvoiceline.go
+++ b/openmeter/billing/service/stdinvoiceline.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openmeterio/openmeter/api"
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -126,7 +127,9 @@ func (s *Service) CreatePendingInvoiceLines(ctx context.Context, input billing.C
 			return nil, fmt.Errorf("validating gathering invoice: %w", err)
 		}
 
-		if err := s.invoiceCalculator.CalculateGatheringInvoice(&gatheringInvoice); err != nil {
+		if err := s.invoiceCalculator.CalculateGatheringInvoice(&gatheringInvoice, invoicecalc.GatheringInvoiceCalculatorDependencies{
+			Collection: customerProfile.MergedProfile.WorkflowConfig.Collection,
+		}); err != nil {
 			return nil, fmt.Errorf("calculating invoice[%s]: %w", gatheringInvoiceID, err)
 		}
 

--- a/openmeter/billing/service/stdinvoicestate.go
+++ b/openmeter/billing/service/stdinvoicestate.go
@@ -763,7 +763,7 @@ func (m *InvoiceStateMachine) calculateInvoice(ctx context.Context) error {
 		return fmt.Errorf("resolving tax codes: %w", err)
 	}
 
-	return m.Calculator.Calculate(&m.Invoice, invoicecalc.CalculatorDependencies{
+	return m.Calculator.Calculate(&m.Invoice, invoicecalc.StandardInvoiceCalculatorDependencies{
 		FeatureMeters: featureMeters,
 		RatingService: m.Service.ratingService,
 		TaxCodes:      taxCodes,

--- a/openmeter/billing/worker/collect/collect.go
+++ b/openmeter/billing/worker/collect/collect.go
@@ -84,11 +84,14 @@ func (a *InvoiceCollector) CollectCustomerInvoice(ctx context.Context, params Co
 
 	a.logger.DebugContext(ctx, "collecting customer invoices", "customer", params.CustomerID)
 
-	invoices, err := a.billingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
-		Customer: params.CustomerID,
+	invoices, err := a.billingService.InvoicePendingLines(
+		ctx,
+		billing.InvoicePendingLinesInput{
+			Customer: params.CustomerID,
+		},
 		// We want to make sure that system collection does not use progressive billing.
-		ProgressiveBillingOverride: lo.ToPtr(false),
-	})
+		billing.WithPartialInvoiceLinesDisabled(),
+	)
 	if err != nil {
 		if errors.Is(err, billing.ErrNamespaceLocked) {
 			a.logger.WarnContext(ctx, "namespace is locked, skipping collection", "customer", params.CustomerID)

--- a/openmeter/billing/worker/subscriptionsync/service/sync.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync.go
@@ -31,10 +31,13 @@ func (s *Service) invoicePendingLines(ctx context.Context, customer customer.Cus
 	))
 
 	return span.Wrap(func(ctx context.Context) error {
-		_, err := s.billingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
-			Customer:                   customer,
-			ProgressiveBillingOverride: lo.ToPtr(false),
-		})
+		_, err := s.billingService.InvoicePendingLines(
+			ctx,
+			billing.InvoicePendingLinesInput{
+				Customer: customer,
+			},
+			billing.WithPartialInvoiceLinesDisabled(),
+		)
 		if err != nil {
 			if errors.Is(err, billing.ErrInvoiceCreateNoLines) {
 				return nil

--- a/openmeter/ent/db/billinginvoice.go
+++ b/openmeter/ent/db/billinginvoice.go
@@ -137,7 +137,7 @@ type BillingInvoice struct {
 	// PeriodEnd holds the value of the "period_end" field.
 	PeriodEnd *time.Time `json:"period_end,omitempty"`
 	// CollectionAt holds the value of the "collection_at" field.
-	CollectionAt time.Time `json:"collection_at,omitempty"`
+	CollectionAt *time.Time `json:"collection_at,omitempty"`
 	// PaymentProcessingEnteredAt holds the value of the "payment_processing_entered_at" field.
 	PaymentProcessingEnteredAt *time.Time `json:"payment_processing_entered_at,omitempty"`
 	// SchemaLevel holds the value of the "schema_level" field.
@@ -671,7 +671,8 @@ func (_m *BillingInvoice) assignValues(columns []string, values []any) error {
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field collection_at", values[i])
 			} else if value.Valid {
-				_m.CollectionAt = value.Time
+				_m.CollectionAt = new(time.Time)
+				*_m.CollectionAt = value.Time
 			}
 		case billinginvoice.FieldPaymentProcessingEnteredAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -990,8 +991,10 @@ func (_m *BillingInvoice) String() string {
 		builder.WriteString(v.Format(time.ANSIC))
 	}
 	builder.WriteString(", ")
-	builder.WriteString("collection_at=")
-	builder.WriteString(_m.CollectionAt.Format(time.ANSIC))
+	if v := _m.CollectionAt; v != nil {
+		builder.WriteString("collection_at=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
 	builder.WriteString(", ")
 	if v := _m.PaymentProcessingEnteredAt; v != nil {
 		builder.WriteString("payment_processing_entered_at=")

--- a/openmeter/ent/db/billinginvoice/billinginvoice.go
+++ b/openmeter/ent/db/billinginvoice/billinginvoice.go
@@ -313,8 +313,6 @@ var (
 	SourceBillingProfileIDValidator func(string) error
 	// CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
 	CurrencyValidator func(string) error
-	// DefaultCollectionAt holds the default value on creation for the "collection_at" field.
-	DefaultCollectionAt func() time.Time
 	// DefaultSchemaLevel holds the default value on creation for the "schema_level" field.
 	DefaultSchemaLevel int
 	// DefaultID holds the default value on creation for the "id" field.

--- a/openmeter/ent/db/billinginvoice_create.go
+++ b/openmeter/ent/db/billinginvoice_create.go
@@ -806,10 +806,6 @@ func (_c *BillingInvoiceCreate) defaults() {
 		v := billinginvoice.DefaultUpdatedAt()
 		_c.mutation.SetUpdatedAt(v)
 	}
-	if _, ok := _c.mutation.CollectionAt(); !ok {
-		v := billinginvoice.DefaultCollectionAt()
-		_c.mutation.SetCollectionAt(v)
-	}
 	if _, ok := _c.mutation.SchemaLevel(); !ok {
 		v := billinginvoice.DefaultSchemaLevel
 		_c.mutation.SetSchemaLevel(v)
@@ -1201,7 +1197,7 @@ func (_c *BillingInvoiceCreate) createSpec() (*BillingInvoice, *sqlgraph.CreateS
 	}
 	if value, ok := _c.mutation.CollectionAt(); ok {
 		_spec.SetField(billinginvoice.FieldCollectionAt, field.TypeTime, value)
-		_node.CollectionAt = value
+		_node.CollectionAt = &value
 	}
 	if value, ok := _c.mutation.PaymentProcessingEnteredAt(); ok {
 		_spec.SetField(billinginvoice.FieldPaymentProcessingEnteredAt, field.TypeTime, value)

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -14474,7 +14474,7 @@ func (m *BillingInvoiceMutation) CollectionAt() (r time.Time, exists bool) {
 // OldCollectionAt returns the old "collection_at" field's value of the BillingInvoice entity.
 // If the BillingInvoice object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *BillingInvoiceMutation) OldCollectionAt(ctx context.Context) (v time.Time, err error) {
+func (m *BillingInvoiceMutation) OldCollectionAt(ctx context.Context) (v *time.Time, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldCollectionAt is only allowed on UpdateOne operations")
 	}

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -521,10 +521,6 @@ func init() {
 	billinginvoiceDescCurrency := billinginvoiceFields[15].Descriptor()
 	// billinginvoice.CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
 	billinginvoice.CurrencyValidator = billinginvoiceDescCurrency.Validators[0].(func(string) error)
-	// billinginvoiceDescCollectionAt is the schema descriptor for collection_at field.
-	billinginvoiceDescCollectionAt := billinginvoiceFields[25].Descriptor()
-	// billinginvoice.DefaultCollectionAt holds the default value on creation for the collection_at field.
-	billinginvoice.DefaultCollectionAt = billinginvoiceDescCollectionAt.Default.(func() time.Time)
 	// billinginvoiceDescSchemaLevel is the schema descriptor for schema_level field.
 	billinginvoiceDescSchemaLevel := billinginvoiceFields[27].Descriptor()
 	// billinginvoice.DefaultSchemaLevel holds the default value on creation for the schema_level field.

--- a/openmeter/ent/schema/billing.go
+++ b/openmeter/ent/schema/billing.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
@@ -1118,10 +1117,10 @@ func (BillingInvoice) Fields() []ent.Field {
 			Nillable(),
 
 		// The timestamp set in the collection_at field defines when new draft invoice is need to be created
-		// from line-items available on the gathering invoice. It is defaulted to time.Now() on creation.
+		// from line-items available on the gathering invoice.
 		field.Time("collection_at").
 			Optional().
-			Default(clock.Now),
+			Nillable(),
 
 		// This is the timestamp the invoice first entered the Payment Processing State (InvoiceStatusPaymentProcessingPending).
 		// This is relevant as we later use this to determine stale-ness and guard against fraud.

--- a/openmeter/ent/schema/billing.go
+++ b/openmeter/ent/schema/billing.go
@@ -1116,8 +1116,12 @@ func (BillingInvoice) Fields() []ent.Field {
 			Optional().
 			Nillable(),
 
-		// The timestamp set in the collection_at field defines when new draft invoice is need to be created
-		// from line-items available on the gathering invoice.
+		// The timestamp stored in the collection_at field has a dual purpose:
+		// - on gathering invoices, it defines when pending line-items should be collected into a new draft invoice
+		// - on standard invoices, it defines the post-creation collection/snapshot cutoff for metered lines
+		//
+		// The collection_at column is intentionally Optional().Nillable() so NULL can round-trip to a domain
+		// *time.Time nil value after the migration away from non-null/default-backed semantics.
 		field.Time("collection_at").
 			Optional().
 			Nillable(),

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1919,12 +1919,8 @@ func (n NoopBillingService) RegisterStandardInvoiceHooks(hooks ...billing.Standa
 }
 
 // GatheringInvoiceService methods
-func (n NoopBillingService) InvoicePendingLines(ctx context.Context, input billing.InvoicePendingLinesInput) ([]billing.StandardInvoice, error) {
+func (n NoopBillingService) InvoicePendingLines(ctx context.Context, input billing.InvoicePendingLinesInput, opts ...billing.InvoicePendingLinesOption) ([]billing.StandardInvoice, error) {
 	return []billing.StandardInvoice{}, nil
-}
-
-func (n NoopBillingService) PrepareBillableLines(ctx context.Context, input billing.PrepareBillableLinesInput) (*billing.PrepareBillableLinesResult, error) {
-	return nil, nil
 }
 
 func (n NoopBillingService) ListGatheringInvoices(ctx context.Context, input billing.ListGatheringInvoicesInput) (pagination.Result[billing.GatheringInvoice], error) {

--- a/test/billing/collection_test.go
+++ b/test/billing/collection_test.go
@@ -509,7 +509,7 @@ func (s *CollectionTestSuite) TestAnchoredAlignment_StandardInvoiceUsesLateEvent
 
 		s.Equal(billing.AlignmentKindAnchored, inv.Workflow.Config.Collection.Alignment)
 		s.NotNil(inv.Workflow.Config.Collection.AnchoredAlignmentDetail)
-		s.Equal("P1M", inv.Workflow.Config.Collection.AnchoredAlignmentDetail.Interval.String())
+		s.Equal("P1D", inv.Workflow.Config.Collection.AnchoredAlignmentDetail.Interval.String())
 	})
 }
 

--- a/test/billing/collection_test.go
+++ b/test/billing/collection_test.go
@@ -405,7 +405,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeEditing() {
 
 func (s *CollectionTestSuite) TestAnchoredAlignment_StandardInvoiceUsesLateEventWindow() {
 	namespace := "ns-anchored-standard-invoice-late-event-window"
-	ctx := context.Background()
+	ctx := s.T().Context()
 	defer clock.ResetTime()
 
 	now := lo.Must(time.Parse(time.RFC3339, "2025-06-15T12:00:00Z"))
@@ -515,7 +515,7 @@ func (s *CollectionTestSuite) TestAnchoredAlignment_StandardInvoiceUsesLateEvent
 
 func (s *CollectionTestSuite) TestAnchoredAlignment_AutomaticCollectionWaitsForAnchor() {
 	namespace := "ns-anchored-automatic-collection"
-	ctx := context.Background()
+	ctx := s.T().Context()
 	defer clock.ResetTime()
 
 	now := lo.Must(time.Parse(time.RFC3339, "2025-06-15T12:00:00Z"))
@@ -572,7 +572,7 @@ func (s *CollectionTestSuite) TestAnchoredAlignment_AutomaticCollectionWaitsForA
 
 func (s *CollectionTestSuite) TestAnchoredAlignment_StandardInvoiceWaitsForLateEventWindowEvenPastAnchor() {
 	namespace := "ns-anchored-standard-invoice-waits-for-late-event-window"
-	ctx := context.Background()
+	ctx := s.T().Context()
 	defer clock.ResetTime()
 
 	initialTime := lo.Must(time.Parse(time.RFC3339, "2025-06-15T00:00:00Z"))

--- a/test/billing/collection_test.go
+++ b/test/billing/collection_test.go
@@ -126,7 +126,7 @@ func (s *CollectionTestSuite) TestCollectionFlow() {
 
 		// Validate collection_at calculation
 		s.NotNil(res.Invoice.NextCollectionAt)
-		s.Equal(periodEnd, res.Invoice.NextCollectionAt, "collection_at should be the min of the invoice_at of the lines")
+		s.Equal(periodEnd, *res.Invoice.NextCollectionAt, "collection_at should be the min of the invoice_at of the lines")
 	})
 
 	// Given a gatherting invoice exists
@@ -142,8 +142,8 @@ func (s *CollectionTestSuite) TestCollectionFlow() {
 		})
 		s.NoError(err)
 
-		s.NotEqual(time.Time{}, gatheringInvoice.NextCollectionAt)
-		s.Equal(periodEnd, gatheringInvoice.NextCollectionAt, "collection_at should be the min of the invoice_at of the lines")
+		s.NotNil(gatheringInvoice.NextCollectionAt)
+		s.Equal(periodEnd, *gatheringInvoice.NextCollectionAt, "collection_at should be the min of the invoice_at of the lines")
 	})
 
 	s.NotEmpty(gatheringInvoiceID)
@@ -296,9 +296,8 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeOnly() {
 			invoice := invoices[0]
 
 			// Then
-			s.NotNil(invoice.CollectionAt)
+			s.Nil(invoice.CollectionAt)
 			s.NotNil(invoice.QuantitySnapshotedAt)
-			s.Equal(invoice.CreatedAt, *invoice.CollectionAt)
 			s.Equal(billing.StandardInvoiceStatusDraftWaitingAutoApproval, invoice.Status)
 		})
 	}
@@ -395,7 +394,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeEditing() {
 	})
 	s.NoError(err)
 
-	// Then
+	// Then the flat fee line does not affect collectionAt, so the invoice remains advanceable.
 	s.Equal(billing.StandardInvoiceStatusDraftWaitingAutoApproval, invoice.Status)
 
 	// No new snapshot should happen
@@ -404,8 +403,8 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeEditing() {
 	s.Equal(previousSnapshot, *invoice.QuantitySnapshotedAt)
 }
 
-func (s *CollectionTestSuite) TestAnchoredAlignment_SetsCollectionAtToNextAnchor() {
-	namespace := "ns-anchored-collection-at"
+func (s *CollectionTestSuite) TestAnchoredAlignment_StandardInvoiceUsesLateEventWindow() {
+	namespace := "ns-anchored-standard-invoice-late-event-window"
 	ctx := context.Background()
 	defer clock.ResetTime()
 
@@ -414,14 +413,20 @@ func (s *CollectionTestSuite) TestAnchoredAlignment_SetsCollectionAtToNextAnchor
 
 	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
 
-	// Billing profile with anchored alignment to first of month
-	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), WithBillingProfileEditFn(func(profile *billing.CreateProfileInput) {
-		profile.WorkflowConfig.Collection.Alignment = billing.AlignmentKindAnchored
-		profile.WorkflowConfig.Collection.AnchoredAlignmentDetail = lo.ToPtr(billing.AnchoredAlignmentDetail{
-			Interval: lo.Must(datetime.ISODurationString("P1M").Parse()),
-			Anchor:   time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),
-		})
-	}))
+	// Billing profile with anchored daily alignment and a one-hour late-event window.
+	s.ProvisionBillingProfile(
+		ctx,
+		namespace,
+		sandboxApp.GetID(),
+		WithCollectionInterval(lo.Must(datetime.ISODurationString("PT1H").Parse())),
+		WithBillingProfileEditFn(func(profile *billing.CreateProfileInput) {
+			profile.WorkflowConfig.Collection.Alignment = billing.AlignmentKindAnchored
+			profile.WorkflowConfig.Collection.AnchoredAlignmentDetail = lo.ToPtr(billing.AnchoredAlignmentDetail{
+				Interval: lo.Must(datetime.ISODurationString("P1D").Parse()),
+				Anchor:   time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC),
+			})
+		}),
+	)
 
 	// Create customer
 	customerEntity, err := s.CustomerService.CreateCustomer(ctx, customer.CreateCustomerInput{
@@ -434,7 +439,7 @@ func (s *CollectionTestSuite) TestAnchoredAlignment_SetsCollectionAtToNextAnchor
 			},
 		},
 	})
-	s.Require().NoError(err)
+	s.NoError(err)
 
 	// Create a minimal pending usage-based line that invoices at end of day
 	periodStart := now
@@ -455,28 +460,202 @@ func (s *CollectionTestSuite) TestAnchoredAlignment_SetsCollectionAtToNextAnchor
 			},
 		},
 	})
-	s.Require().NoError(err)
+	s.NoError(err)
 
-	// Let's advance time
-	clock.SetTime(periodEnd.Add(time.Hour * 1))
+	s.Run("mid period automatic collection does not create invoice", func() {
+		// Given:
+		// - anchored collection alignment is configured
+		// - a usage-based gathering line exists for a period ending at periodEnd
+		// When:
+		// - invoice pending lines is called automatically before invoice_at
+		// Then:
+		// - no invoice is created
+		clock.SetTime(periodStart.Add(6 * time.Hour))
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: customerEntity.GetID(),
+		})
+		s.ErrorIs(err, billing.ErrInvoiceCreateNoLines)
+		s.Nil(invoices)
+	})
+
+	s.Run("automatic collection creates invoice once anchor and late event window both passed", func() {
+		// Given:
+		// - anchored collection alignment is configured on the customer
+		// - the usage-based line's late-event window is one hour
+		// - invoice_at plus the late-event window is already in the past
+		// - the next anchored collection point is also in the past
+		// When:
+		// - invoice pending lines is called automatically after the anchor passed
+		// Then:
+		// - the invoice is created
+		// - collection_at is invoice_at plus the late-event window
+		// - the invoice is immediately ready for collection
+		// - the anchored workflow snapshot is preserved on the invoice
+		clock.SetTime(time.Date(now.Year(), now.Month(), now.Day()+1, 2, 0, 0, 0, time.UTC))
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: customerEntity.GetID(),
+		})
+		s.NoError(err)
+		s.Len(invoices, 1)
+
+		inv := invoices[0]
+		s.NoError(err)
+		s.NotNil(inv.CollectionAt)
+		s.Equal(periodEnd.Add(time.Hour), *inv.CollectionAt)
+		s.NotNil(inv.QuantitySnapshotedAt)
+		s.Equal(billing.StandardInvoiceStatusDraftWaitingAutoApproval, inv.Status)
+
+		s.Equal(billing.AlignmentKindAnchored, inv.Workflow.Config.Collection.Alignment)
+		s.NotNil(inv.Workflow.Config.Collection.AnchoredAlignmentDetail)
+		s.Equal("P1M", inv.Workflow.Config.Collection.AnchoredAlignmentDetail.Interval.String())
+	})
+}
+
+func (s *CollectionTestSuite) TestAnchoredAlignment_AutomaticCollectionWaitsForAnchor() {
+	namespace := "ns-anchored-automatic-collection"
+	ctx := context.Background()
 	defer clock.ResetTime()
 
-	// Create standard invoice from pending lines; collectionAt should be next anchor (1st of next month)
+	now := lo.Must(time.Parse(time.RFC3339, "2025-06-15T12:00:00Z"))
+	clock.SetTime(now)
+
+	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+
+	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), WithBillingProfileEditFn(func(profile *billing.CreateProfileInput) {
+		profile.WorkflowConfig.Collection.Alignment = billing.AlignmentKindAnchored
+		profile.WorkflowConfig.Collection.AnchoredAlignmentDetail = lo.ToPtr(billing.AnchoredAlignmentDetail{
+			Interval: lo.Must(datetime.ISODurationString("P1M").Parse()),
+			Anchor:   time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		})
+	}))
+
+	customerEntity, err := s.CustomerService.CreateCustomer(ctx, customer.CreateCustomerInput{
+		Namespace: namespace,
+		CustomerMutate: customer.CustomerMutate{
+			Name:             "Test Customer",
+			BillingAddress:   &models.Address{Country: lo.ToPtr(models.CountryCode("US"))},
+			UsageAttribution: &customer.CustomerUsageAttribution{SubjectKeys: []string{"test-subject-1"}},
+		},
+	})
+	s.NoError(err)
+
+	periodStart := now
+	periodEnd := now.Add(12 * time.Hour)
+	_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+		Customer: customerEntity.GetID(),
+		Currency: currencyx.Code(currency.USD),
+		Lines: []billing.GatheringLine{
+			{
+				GatheringLineBase: billing.GatheringLineBase{
+					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{Name: "UBP - unit"}),
+					ServicePeriod:   timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
+					InvoiceAt:       periodEnd,
+					ManagedBy:       billing.ManuallyManagedLine,
+					FeatureKey:      s.SetupApiRequestsTotalFeature(ctx, namespace).Feature.Key,
+					Price:           *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromFloat(1)}),
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	clock.SetTime(periodEnd.Add(time.Hour))
+
 	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 		Customer: customerEntity.GetID(),
 	})
-	s.Require().NoError(err)
-	s.Require().Len(invoices, 1)
+	s.ErrorIs(err, billing.ErrInvoiceCreateNoLines)
+	s.Nil(invoices)
+}
 
-	inv := invoices[0]
-	s.Require().NotNil(inv.CollectionAt)
-	nextAnchor := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, 1, 0)
-	s.Equal(nextAnchor, *inv.CollectionAt)
+func (s *CollectionTestSuite) TestAnchoredAlignment_StandardInvoiceWaitsForLateEventWindowEvenPastAnchor() {
+	namespace := "ns-anchored-standard-invoice-waits-for-late-event-window"
+	ctx := context.Background()
+	defer clock.ResetTime()
 
-	// Assert the workflow collection alignment is snapshotted on the invoice
-	s.Equal(billing.AlignmentKindAnchored, inv.Workflow.Config.Collection.Alignment)
-	s.Require().NotNil(inv.Workflow.Config.Collection.AnchoredAlignmentDetail)
-	s.Equal("P1M", inv.Workflow.Config.Collection.AnchoredAlignmentDetail.Interval.String())
+	initialTime := lo.Must(time.Parse(time.RFC3339, "2025-06-15T00:00:00Z"))
+	clock.SetTime(initialTime)
+
+	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+
+	s.ProvisionBillingProfile(
+		ctx,
+		namespace,
+		sandboxApp.GetID(),
+		WithCollectionInterval(lo.Must(datetime.ISODurationString("P1D").Parse())),
+		WithBillingProfileEditFn(func(profile *billing.CreateProfileInput) {
+			profile.WorkflowConfig.Collection.Alignment = billing.AlignmentKindAnchored
+			profile.WorkflowConfig.Collection.AnchoredAlignmentDetail = lo.ToPtr(billing.AnchoredAlignmentDetail{
+				Interval: lo.Must(datetime.ISODurationString("P1D").Parse()),
+				Anchor:   time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC),
+			})
+		}),
+	)
+
+	customerEntity, err := s.CustomerService.CreateCustomer(ctx, customer.CreateCustomerInput{
+		Namespace: namespace,
+		CustomerMutate: customer.CustomerMutate{
+			Name:             "Test Customer",
+			BillingAddress:   &models.Address{Country: lo.ToPtr(models.CountryCode("US"))},
+			UsageAttribution: &customer.CustomerUsageAttribution{SubjectKeys: []string{"test-subject-1"}},
+		},
+	})
+	s.NoError(err)
+
+	periodStart := lo.Must(time.Parse(time.RFC3339, "2025-06-15T00:00:00Z"))
+	periodEnd := lo.Must(time.Parse(time.RFC3339, "2025-06-15T12:00:00Z"))
+	_, err = s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+		Customer: customerEntity.GetID(),
+		Currency: currencyx.Code(currency.USD),
+		Lines: []billing.GatheringLine{
+			{
+				GatheringLineBase: billing.GatheringLineBase{
+					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{Name: "UBP - unit"}),
+					ServicePeriod:   timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
+					InvoiceAt:       periodEnd,
+					ManagedBy:       billing.ManuallyManagedLine,
+					FeatureKey:      s.SetupApiRequestsTotalFeature(ctx, namespace).Feature.Key,
+					Price:           *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromFloat(1)}),
+				},
+			},
+		},
+	})
+	s.NoError(err)
+
+	// Given:
+	// - anchored collection alignment is configured with a daily anchor on the customer
+	// - a standard invoice is created directly from an existing gathering line
+	// - the usage-based line has a one-day late-event window
+	// - invoice_at plus the late-event window is after the next anchor
+	// When:
+	// - the standard invoice is created after invoice_at but before invoice_at plus the late-event window
+	// Then:
+	// - collection_at is still invoice_at plus the late-event window
+	// - the invoice waits for quantity snapshotting until collection is actually over
+	clock.SetTime(lo.Must(time.Parse(time.RFC3339, "2025-06-15T13:00:00Z")))
+	expectedCollectionAt := lo.Must(time.Parse(time.RFC3339, "2025-06-16T12:00:00Z"))
+
+	invoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+		Namespaces: []string{namespace},
+		Customers:  []string{customerEntity.ID},
+		Expand:     billing.GatheringInvoiceExpandAll,
+	})
+	s.NoError(err)
+	s.Len(invoices.Items, 1)
+	s.Len(invoices.Items[0].Lines.OrEmpty(), 1)
+
+	inv, err := s.BillingService.CreateStandardInvoiceFromGatheringLines(ctx, billing.CreateStandardInvoiceFromGatheringLinesInput{
+		Customer: customerEntity.GetID(),
+		Currency: currencyx.Code(currency.USD),
+		Lines:    invoices.Items[0].Lines.OrEmpty(),
+	})
+	s.NoError(err)
+	s.NotNil(inv.CollectionAt)
+	s.Equal(expectedCollectionAt, *inv.CollectionAt)
+	s.Nil(inv.QuantitySnapshotedAt)
+	s.Equal(billing.StandardInvoiceStatusDraftWaitingForCollection, inv.Status)
 }
 
 func (s *CollectionTestSuite) TestCollectionFlowWithUBPEditingExtendingCollectionPeriod() {

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -291,7 +291,12 @@ func (s *InvoicingTestSuite) TestPendingLineCreation() {
 			Expands: []billing.GatheringInvoiceExpand{billing.GatheringInvoiceExpandLines},
 		}
 
-		s.NoError(invoicecalc.GatheringInvoiceCollectionAt(&expectedInvoice))
+		s.NoError(invoicecalc.GatheringInvoiceCollectionAt(&expectedInvoice, invoicecalc.GatheringInvoiceCalculatorDependencies{
+			Collection: billing.CollectionConfig{
+				Alignment: billing.AlignmentKindSubscription,
+				Interval:  datetime.MustParseDuration(s.T(), "PT1H"),
+			},
+		}))
 
 		ExpectJSONEqual(s.T(),
 			lo.Must(expectedInvoice.WithoutDBState()),
@@ -3678,7 +3683,7 @@ func (s *InvoicingTestSuite) TestProgressiveBillLate() {
 	s.True(line.Period.Equal(timeutil.ClosedPeriod{From: periodStart, To: periodEnd}), "periods should equal")
 }
 
-func (s *InvoicingTestSuite) TestProgressiveBillingOverride() {
+func (s *InvoicingTestSuite) TestPartialInvoiceLinesOptions() {
 	namespace := "ns-progressive-bill-override"
 	ctx := context.Background()
 
@@ -3770,9 +3775,8 @@ func (s *InvoicingTestSuite) TestProgressiveBillingOverride() {
 	clock.SetTime(collecitonDoneAt)
 
 	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
-		Customer:                   customer.GetID(),
-		ProgressiveBillingOverride: lo.ToPtr(false),
-	})
+		Customer: customer.GetID(),
+	}, billing.WithPartialInvoiceLinesDisabled())
 	s.NoError(err)
 	s.Len(invoices, 1)
 
@@ -3875,9 +3879,8 @@ func (s *InvoicingTestSuite) TestSortLines() {
 	clock.SetTime(periodEnd)
 
 	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
-		Customer:                   customer.GetID(),
-		ProgressiveBillingOverride: lo.ToPtr(false),
-	})
+		Customer: customer.GetID(),
+	}, billing.WithPartialInvoiceLinesDisabled())
 	s.NoError(err)
 	s.Len(invoices, 1)
 
@@ -4010,9 +4013,8 @@ func (s *InvoicingTestSuite) TestGatheringInvoicePeriodPersisting() {
 
 	clock.SetTime(newPeriodEnd)
 	res, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
-		Customer:                   customer.GetID(),
-		ProgressiveBillingOverride: lo.ToPtr(false),
-	})
+		Customer: customer.GetID(),
+	}, billing.WithPartialInvoiceLinesDisabled())
 	s.NoError(err)
 	s.Len(res, 1)
 
@@ -4076,9 +4078,8 @@ func (s *InvoicingTestSuite) TestCreatePendingInvoiceLinesForDeletedCustomers() 
 
 	// Create the invoice
 	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
-		Customer:                   customer.GetID(),
-		ProgressiveBillingOverride: lo.ToPtr(false),
-	})
+		Customer: customer.GetID(),
+	}, billing.WithPartialInvoiceLinesDisabled())
 	s.NoError(err)
 	s.Len(invoices, 1)
 

--- a/test/billing/ubpflatfee_test.go
+++ b/test/billing/ubpflatfee_test.go
@@ -35,7 +35,7 @@ func (s *UBPFlatFeeLineTestSuite) TestPendingLineCreation() {
 	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
 
 	cust := s.CreateTestCustomer(namespace, "test")
-	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
+	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), WithProgressiveBilling())
 
 	// Given we have a customer
 	// When we create a pending fee line using the usage based flat fee line
@@ -91,8 +91,7 @@ func (s *UBPFlatFeeLineTestSuite) TestPendingLineCreation() {
 	// Then the line should not be created
 	s.Run("should not create a progressively billed line", func() {
 		_, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
-			Customer:                   cust.GetID(),
-			ProgressiveBillingOverride: lo.ToPtr(true),
+			Customer: cust.GetID(),
 		})
 		s.Error(err)
 		s.ErrorIs(err, billing.ErrInvoiceCreateNoLines)

--- a/test/subscription/scenario_firstofmonth_test.go
+++ b/test/subscription/scenario_firstofmonth_test.go
@@ -433,12 +433,16 @@ func TestAnchoredAlignment_MidMonthStart_EarlyCancel_IssueNextAnchor(t *testing.
 	standardInvoice, err := invoice.AsStandardInvoice()
 	require.NoError(t, err)
 
-	// We should have a standard invoice with lines invoiceAt at end of June and collectionAt at July 1st (due to anchored alignment)
-	require.Equal(t, firstOfNextMonth, *standardInvoice.CollectionAt)
-
 	lns, ok := standardInvoice.Lines.Get()
 	require.True(t, ok)
 	for _, l := range lns {
-		require.True(t, l.InvoiceAt.Before(*standardInvoice.CollectionAt))
+		require.NotNil(t, l.UsageBased)
+		require.NotNil(t, l.UsageBased.Price)
+	}
+
+	require.Nil(t, standardInvoice.CollectionAt)
+
+	for _, l := range lns {
+		require.Equal(t, productcatalog.FlatPriceType, l.UsageBased.Price.Type())
 	}
 }

--- a/test/subscription/scenario_firstofmonth_test.go
+++ b/test/subscription/scenario_firstofmonth_test.go
@@ -424,25 +424,6 @@ func TestAnchoredAlignment_MidMonthStart_EarlyCancel_IssueNextAnchor(t *testing.
 	})
 	require.NoError(t, err)
 
-	// Gathering and Standard, let's get the standard
-	require.Len(t, invoices.Items, 2)
-	invoice, ok := lo.Find(invoices.Items, func(i billing.Invoice) bool {
-		return i.Type() != billing.InvoiceTypeGathering
-	})
-	require.True(t, ok)
-	standardInvoice, err := invoice.AsStandardInvoice()
-	require.NoError(t, err)
-
-	lns, ok := standardInvoice.Lines.Get()
-	require.True(t, ok)
-	for _, l := range lns {
-		require.NotNil(t, l.UsageBased)
-		require.NotNil(t, l.UsageBased.Price)
-	}
-
-	require.Nil(t, standardInvoice.CollectionAt)
-
-	for _, l := range lns {
-		require.Equal(t, productcatalog.FlatPriceType, l.UsageBased.Price.Type())
-	}
+	require.Len(t, invoices.Items, 1)
+	require.Equal(t, billing.InvoiceTypeGathering, invoices.Items[0].Type())
 }


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Summary

  This change aligns invoice collection behavior with the billing profile API contract, where `workflow.collection.alignment` is described as controlling when pending line items are collected into an invoice. 

### Bug

Previously, alignment was effectively applied on already-created standard invoices through `StandardInvoice.CollectionAt`,
  which made the **runtime behavior diverge from the API semantics**. The implementation now moves that policy to the gathering-invoice side, so automatic `InvoicePendingLines` collection honors alignment before a standard invoice is created. Explicit/manual invoicing paths can still bypass that gate when needed.

### Current implementation

  On the standard-invoice side, `CollectionAt` is now narrowed to its actual remaining role: the post-creation collection/snapshot cutoff for metered lines. Anchored alignment is no longer interpreted there; instead, `StandardInvoiceCollectionAt` is based on the latest metered line `InvoiceAt` plus the configured collection
  interval. Flat-fee-only standard invoices no longer get a synthetic collection timestamp, which better matches the model that they are not subject to usage snapshot collection. 

To support that consistently, `collection_at` is now treated as truly nullable in the domain and Ent schema, with legacy zero-time values normalized
  back to `nil`.

### Other cleanups

  The patch also cleans up the `InvoicePendingLines` API to make the default behavior aligned with the billing profile and make bypasses explicit. 

Tests were updated to reflect the intended product semantics: anchored alignment delays automatic invoice creation, while late-event / collection windows on created standard invoices
  still control when metered usage is finally snapshotted. Overall, the result is a billing flow that matches the API spec more closely and separates “when do we create the invoice?” from “until when do we wait for late metered data?”.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Collection timestamps are now nullable and normalized (zero-times treated as unset); API responses preserve historical shape when domain fields are nil.

* **Refactor**
  * Pending-line invoicing moved to option-based controls; invoice calculation split into distinct typed flows and legacy paths removed.
  * Collection calculations clarified and now receive explicit dependencies.

* **New Features**
  * Helper to exclude deleted invoice lines from collection computations.

* **Tests**
  * New comprehensive tests for collection timing, cutoff resolution, and calculation behavior.

* **Documentation**
  * Clarified collection-timing semantics for gathering vs standard invoices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->