### PR TITLE
feat(usagebased-charge): ignore minimum commitment on partial runs

### DIFF
--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -234,15 +234,16 @@ func (s *CreditThenInvoiceStateMachine) startInvoiceCreatedRun(
 	}
 
 	result, err := s.Runs.CreateRatedRun(ctx, usagebasedrun.CreateRatedRunInput{
-		Charge:             s.Charge,
-		CustomerOverride:   s.CustomerOverride,
-		FeatureMeter:       s.FeatureMeter,
-		Type:               runType,
-		AsOf:               storedAtOffset,
-		CollectionEnd:      collectionEnd,
-		LineID:             lo.ToPtr(input.LineID),
-		CreditAllocation:   usagebasedrun.CreditAllocationAvailable,
-		CurrencyCalculator: s.CurrencyCalculator,
+		Charge:                  s.Charge,
+		CustomerOverride:        s.CustomerOverride,
+		FeatureMeter:            s.FeatureMeter,
+		Type:                    runType,
+		AsOf:                    storedAtOffset,
+		CollectionEnd:           collectionEnd,
+		LineID:                  lo.ToPtr(input.LineID),
+		IgnoreMinimumCommitment: ignoreMinimumCommitmentForRunType(runType),
+		CreditAllocation:        usagebasedrun.CreditAllocationAvailable,
+		CurrencyCalculator:      s.CurrencyCalculator,
 	})
 	if err != nil {
 		return err
@@ -258,6 +259,12 @@ func (s *CreditThenInvoiceStateMachine) StartPartialInvoiceRun(ctx context.Conte
 
 func (s *CreditThenInvoiceStateMachine) StartFinalInvoiceRun(ctx context.Context, input invoiceCreatedInput) error {
 	return s.startInvoiceCreatedRun(ctx, input, usagebased.RealizationRunTypeFinalRealization)
+}
+
+func ignoreMinimumCommitmentForRunType(runType usagebased.RealizationRunType) bool {
+	// Partial invoice runs are interim cumulative checkpoints. Minimum commitment is billed only on the
+	// final realization, so partial runs must suppress it during both creation and later snapshotting.
+	return runType == usagebased.RealizationRunTypePartialInvoice
 }
 
 func resolveInvoiceCreatedTrigger(charge usagebased.Charge, billedPeriod timeutil.ClosedPeriod) meta.Trigger {
@@ -289,11 +296,12 @@ func (s *CreditThenInvoiceStateMachine) SnapshotInvoiceUsage(ctx context.Context
 	storedAtOffset := meta.NormalizeTimestamp(currentRun.CollectionEnd)
 
 	ratingResult, err := s.Rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetDetailedLinesForUsageInput{
-		Charge:         s.Charge,
-		PriorRuns:      s.Charge.Realizations.Without(currentRun.ID),
-		Customer:       s.CustomerOverride,
-		FeatureMeter:   s.FeatureMeter,
-		StoredAtOffset: storedAtOffset,
+		Charge:                  s.Charge,
+		PriorRuns:               s.Charge.Realizations.Without(currentRun.ID),
+		Customer:                s.CustomerOverride,
+		FeatureMeter:            s.FeatureMeter,
+		StoredAtOffset:          storedAtOffset,
+		IgnoreMinimumCommitment: ignoreMinimumCommitmentForRunType(currentRun.Type),
 	})
 	if err != nil {
 		return fmt.Errorf("get rating for usage: %w", err)

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -42,3 +42,13 @@ func TestResolveInvoiceCreatedTrigger(t *testing.T) {
 		require.Equal(t, meta.TriggerFinalInvoiceCreated, trigger)
 	})
 }
+
+func TestIgnoreMinimumCommitmentForRunType(t *testing.T) {
+	t.Run("partial invoice run", func(t *testing.T) {
+		require.True(t, ignoreMinimumCommitmentForRunType(usagebased.RealizationRunTypePartialInvoice))
+	})
+
+	t.Run("final realization run", func(t *testing.T) {
+		require.False(t, ignoreMinimumCommitmentForRunType(usagebased.RealizationRunTypeFinalRealization))
+	})
+}

--- a/openmeter/billing/charges/usagebased/service/rating/details.go
+++ b/openmeter/billing/charges/usagebased/service/rating/details.go
@@ -19,6 +19,8 @@ type GetDetailedLinesForUsageInput struct {
 	Customer       billing.CustomerOverrideWithDetails
 	FeatureMeter   feature.FeatureMeter
 	StoredAtOffset time.Time
+	// IgnoreMinimumCommitment suppresses minimum commitment while still applying the rest of the billing mutators.
+	IgnoreMinimumCommitment bool
 }
 
 func (i GetDetailedLinesForUsageInput) Validate() error {
@@ -73,10 +75,15 @@ func (s *service) GetDetailedLinesForUsage(ctx context.Context, in GetDetailedLi
 		return GetRatingForUsageResult{}, fmt.Errorf("get snapshot quantity: %w", err)
 	}
 
+	var opts []billingrating.GenerateDetailedLinesOption
+	if in.IgnoreMinimumCommitment {
+		opts = append(opts, billingrating.WithMinimumCommitmentIgnored())
+	}
+
 	ratingResult, err := s.ratingService.GenerateDetailedLines(usagebased.RateableIntent{
 		Intent:     in.Charge.Intent,
 		MeterValue: snapshotQuantity,
-	})
+	}, opts...)
 	if err != nil {
 		return GetRatingForUsageResult{}, fmt.Errorf("rating: %w", err)
 	}

--- a/openmeter/billing/charges/usagebased/service/rating/service_test.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service_test.go
@@ -22,6 +22,12 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
+type getDetailedLinesForUsageFixture struct {
+	config Config
+	input  GetDetailedLinesForUsageInput
+	rater  *stubRatingService
+}
+
 func TestFormatDetailedLineChildUniqueReferenceID(t *testing.T) {
 	t.Parallel()
 
@@ -42,122 +48,51 @@ func TestGetRatingForUsageAddsServicePeriodToDetailedLineChildUniqueReferenceIDs
 
 	ctx := t.Context()
 
-	servicePeriod := timeutil.ClosedPeriod{
-		From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-		To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
-	}
-
-	streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
-	streamingConnector.AddSimpleEvent("meter-1", 12, servicePeriod.From.Add(30*time.Minute))
-
-	ratingService := &stubRatingService{
-		result: billingrating.GenerateDetailedLinesResult{
-			DetailedLines: billingrating.DetailedLines{
-				{
-					Name:                   "Usage",
-					Quantity:               alpacadecimal.NewFromInt(12),
-					PerUnitAmount:          alpacadecimal.NewFromInt(3),
-					ChildUniqueReferenceID: "unit-price-usage",
-				},
-				{
-					Name:                   "Discount",
-					Quantity:               alpacadecimal.NewFromInt(1),
-					PerUnitAmount:          alpacadecimal.NewFromInt(1),
-					ChildUniqueReferenceID: "rateCardDiscount/correlationID=discount-50pct",
-				},
+	fixture := newGetDetailedLinesForUsageFixture(t, billingrating.GenerateDetailedLinesResult{
+		DetailedLines: billingrating.DetailedLines{
+			{
+				Name:                   "Usage",
+				Quantity:               alpacadecimal.NewFromInt(12),
+				PerUnitAmount:          alpacadecimal.NewFromInt(3),
+				ChildUniqueReferenceID: "unit-price-usage",
+			},
+			{
+				Name:                   "Discount",
+				Quantity:               alpacadecimal.NewFromInt(1),
+				PerUnitAmount:          alpacadecimal.NewFromInt(1),
+				ChildUniqueReferenceID: "rateCardDiscount/correlationID=discount-50pct",
 			},
 		},
-	}
-
-	svc, err := New(Config{
-		StreamingConnector: streamingConnector,
-		RatingService:      ratingService,
 	})
+
+	svc, err := New(fixture.config)
 	require.NoError(t, err)
 
-	out, err := svc.GetDetailedLinesForUsage(ctx, GetDetailedLinesForUsageInput{
-		Charge: usagebased.Charge{
-			ChargeBase: usagebased.ChargeBase{
-				ManagedResource: chargesmeta.ManagedResource{
-					NamespacedModel: models.NamespacedModel{Namespace: "ns"},
-					ManagedModel: models.ManagedModel{
-						CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-						UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-					},
-					ID: "charge-1",
-				},
-				Intent: usagebased.Intent{
-					Intent: chargesmeta.Intent{
-						Name:              "usage-charge",
-						ManagedBy:         billing.SubscriptionManagedLine,
-						CustomerID:        "customer-1",
-						Currency:          currencyx.Code("USD"),
-						ServicePeriod:     servicePeriod,
-						FullServicePeriod: servicePeriod,
-						BillingPeriod:     servicePeriod,
-					},
-					InvoiceAt:      time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
-					SettlementMode: productcatalog.InvoiceOnlySettlementMode,
-					FeatureKey:     "feature-1",
-					Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
-						Amount: alpacadecimal.NewFromInt(3),
-					}),
-				},
-				Status: usagebased.StatusCreated,
-				State: usagebased.State{
-					FeatureID: "feature-1",
-				},
-			},
-		},
-		Customer: billing.CustomerOverrideWithDetails{
-			Customer: &customer.Customer{
-				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
-					Namespace: "ns",
-					ID:        "customer-1",
-					Name:      "Customer 1",
-					CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-				}),
-				Key: lo.ToPtr("cust-1"),
-			},
-		},
-		FeatureMeter: feature.FeatureMeter{
-			Feature: feature.Feature{
-				Namespace: "ns",
-				ID:        "feature-1",
-				Name:      "Feature 1",
-				Key:       "feature-1",
-				MeterID:   lo.ToPtr("meter-1"),
-				CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-				UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-			},
-			Meter: &meter.Meter{
-				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
-					Namespace: "ns",
-					ID:        "meter-1",
-					Name:      "Meter 1",
-					CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-				}),
-				Key:           "meter-1",
-				Aggregation:   meter.MeterAggregationSum,
-				EventType:     "event.type",
-				ValueProperty: lo.ToPtr("value"),
-			},
-		},
-		StoredAtOffset: time.Date(2025, 2, 2, 0, 0, 0, 0, time.UTC),
-	})
+	out, err := svc.GetDetailedLinesForUsage(ctx, fixture.input)
 	require.NoError(t, err)
 
 	require.Equal(t, "unit-price-usage@[2025-01-01T00:00:00Z..2025-02-01T00:00:00Z]", out.DetailedLines[0].ChildUniqueReferenceID)
 	require.Equal(t, "rateCardDiscount/correlationID=discount-50pct@[2025-01-01T00:00:00Z..2025-02-01T00:00:00Z]", out.DetailedLines[1].ChildUniqueReferenceID)
-	require.False(t, ratingService.lastOpts.IgnoreMinimumCommitment)
+	require.False(t, fixture.rater.lastOpts.IgnoreMinimumCommitment)
 }
 
 func TestGetRatingForUsageCanIgnoreMinimumCommitment(t *testing.T) {
 	t.Parallel()
 
 	ctx := t.Context()
+	fixture := newGetDetailedLinesForUsageFixture(t, billingrating.GenerateDetailedLinesResult{})
+	fixture.input.IgnoreMinimumCommitment = true
+
+	svc, err := New(fixture.config)
+	require.NoError(t, err)
+
+	_, err = svc.GetDetailedLinesForUsage(ctx, fixture.input)
+	require.NoError(t, err)
+	require.True(t, fixture.rater.lastOpts.IgnoreMinimumCommitment)
+}
+
+func newGetDetailedLinesForUsageFixture(t *testing.T, result billingrating.GenerateDetailedLinesResult) getDetailedLinesForUsageFixture {
+	t.Helper()
 
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -167,91 +102,87 @@ func TestGetRatingForUsageCanIgnoreMinimumCommitment(t *testing.T) {
 	streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
 	streamingConnector.AddSimpleEvent("meter-1", 12, servicePeriod.From.Add(30*time.Minute))
 
-	ratingService := &stubRatingService{
-		result: billingrating.GenerateDetailedLinesResult{},
-	}
+	ratingService := &stubRatingService{result: result}
 
-	svc, err := New(Config{
-		StreamingConnector: streamingConnector,
-		RatingService:      ratingService,
-	})
-	require.NoError(t, err)
-
-	_, err = svc.GetDetailedLinesForUsage(ctx, GetDetailedLinesForUsageInput{
-		Charge: usagebased.Charge{
-			ChargeBase: usagebased.ChargeBase{
-				ManagedResource: chargesmeta.ManagedResource{
-					NamespacedModel: models.NamespacedModel{Namespace: "ns"},
-					ManagedModel: models.ManagedModel{
+	return getDetailedLinesForUsageFixture{
+		config: Config{
+			StreamingConnector: streamingConnector,
+			RatingService:      ratingService,
+		},
+		input: GetDetailedLinesForUsageInput{
+			Charge: usagebased.Charge{
+				ChargeBase: usagebased.ChargeBase{
+					ManagedResource: chargesmeta.ManagedResource{
+						NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+						ManagedModel: models.ManagedModel{
+							CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+							UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+						},
+						ID: "charge-1",
+					},
+					Intent: usagebased.Intent{
+						Intent: chargesmeta.Intent{
+							Name:              "usage-charge",
+							ManagedBy:         billing.SubscriptionManagedLine,
+							CustomerID:        "customer-1",
+							Currency:          currencyx.Code("USD"),
+							ServicePeriod:     servicePeriod,
+							FullServicePeriod: servicePeriod,
+							BillingPeriod:     servicePeriod,
+						},
+						InvoiceAt:      time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+						SettlementMode: productcatalog.InvoiceOnlySettlementMode,
+						FeatureKey:     "feature-1",
+						Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+							Amount: alpacadecimal.NewFromInt(3),
+						}),
+					},
+					Status: usagebased.StatusCreated,
+					State: usagebased.State{
+						FeatureID: "feature-1",
+					},
+				},
+			},
+			Customer: billing.CustomerOverrideWithDetails{
+				Customer: &customer.Customer{
+					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+						Namespace: "ns",
+						ID:        "customer-1",
+						Name:      "Customer 1",
 						CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 						UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-					},
-					ID: "charge-1",
-				},
-				Intent: usagebased.Intent{
-					Intent: chargesmeta.Intent{
-						Name:              "usage-charge",
-						ManagedBy:         billing.SubscriptionManagedLine,
-						CustomerID:        "customer-1",
-						Currency:          currencyx.Code("USD"),
-						ServicePeriod:     servicePeriod,
-						FullServicePeriod: servicePeriod,
-						BillingPeriod:     servicePeriod,
-					},
-					InvoiceAt:      time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
-					SettlementMode: productcatalog.InvoiceOnlySettlementMode,
-					FeatureKey:     "feature-1",
-					Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
-						Amount: alpacadecimal.NewFromInt(3),
 					}),
-				},
-				Status: usagebased.StatusCreated,
-				State: usagebased.State{
-					FeatureID: "feature-1",
+					Key: lo.ToPtr("cust-1"),
 				},
 			},
-		},
-		Customer: billing.CustomerOverrideWithDetails{
-			Customer: &customer.Customer{
-				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+			FeatureMeter: feature.FeatureMeter{
+				Feature: feature.Feature{
 					Namespace: "ns",
-					ID:        "customer-1",
-					Name:      "Customer 1",
+					ID:        "feature-1",
+					Name:      "Feature 1",
+					Key:       "feature-1",
+					MeterID:   lo.ToPtr("meter-1"),
 					CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 					UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-				}),
-				Key: lo.ToPtr("cust-1"),
+				},
+				Meter: &meter.Meter{
+					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+						Namespace: "ns",
+						ID:        "meter-1",
+						Name:      "Meter 1",
+						CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+						UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+					}),
+					Key:           "meter-1",
+					Aggregation:   meter.MeterAggregationSum,
+					EventType:     "event.type",
+					ValueProperty: lo.ToPtr("value"),
+				},
 			},
+			StoredAtOffset: time.Date(2025, 2, 2, 0, 0, 0, 0, time.UTC),
 		},
-		FeatureMeter: feature.FeatureMeter{
-			Feature: feature.Feature{
-				Namespace: "ns",
-				ID:        "feature-1",
-				Name:      "Feature 1",
-				Key:       "feature-1",
-				MeterID:   lo.ToPtr("meter-1"),
-				CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-				UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-			},
-			Meter: &meter.Meter{
-				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
-					Namespace: "ns",
-					ID:        "meter-1",
-					Name:      "Meter 1",
-					CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-				}),
-				Key:           "meter-1",
-				Aggregation:   meter.MeterAggregationSum,
-				EventType:     "event.type",
-				ValueProperty: lo.ToPtr("value"),
-			},
-		},
-		StoredAtOffset:          time.Date(2025, 2, 2, 0, 0, 0, 0, time.UTC),
-		IgnoreMinimumCommitment: true,
-	})
-	require.NoError(t, err)
-	require.True(t, ratingService.lastOpts.IgnoreMinimumCommitment)
+		rater: ratingService,
+	}
 }
 
 type stubRatingService struct {

--- a/openmeter/billing/charges/usagebased/service/rating/service_test.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service_test.go
@@ -50,26 +50,28 @@ func TestGetRatingForUsageAddsServicePeriodToDetailedLineChildUniqueReferenceIDs
 	streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
 	streamingConnector.AddSimpleEvent("meter-1", 12, servicePeriod.From.Add(30*time.Minute))
 
-	svc, err := New(Config{
-		StreamingConnector: streamingConnector,
-		RatingService: stubRatingService{
-			result: billingrating.GenerateDetailedLinesResult{
-				DetailedLines: billingrating.DetailedLines{
-					{
-						Name:                   "Usage",
-						Quantity:               alpacadecimal.NewFromInt(12),
-						PerUnitAmount:          alpacadecimal.NewFromInt(3),
-						ChildUniqueReferenceID: "unit-price-usage",
-					},
-					{
-						Name:                   "Discount",
-						Quantity:               alpacadecimal.NewFromInt(1),
-						PerUnitAmount:          alpacadecimal.NewFromInt(1),
-						ChildUniqueReferenceID: "rateCardDiscount/correlationID=discount-50pct",
-					},
+	ratingService := &stubRatingService{
+		result: billingrating.GenerateDetailedLinesResult{
+			DetailedLines: billingrating.DetailedLines{
+				{
+					Name:                   "Usage",
+					Quantity:               alpacadecimal.NewFromInt(12),
+					PerUnitAmount:          alpacadecimal.NewFromInt(3),
+					ChildUniqueReferenceID: "unit-price-usage",
+				},
+				{
+					Name:                   "Discount",
+					Quantity:               alpacadecimal.NewFromInt(1),
+					PerUnitAmount:          alpacadecimal.NewFromInt(1),
+					ChildUniqueReferenceID: "rateCardDiscount/correlationID=discount-50pct",
 				},
 			},
 		},
+	}
+
+	svc, err := New(Config{
+		StreamingConnector: streamingConnector,
+		RatingService:      ratingService,
 	})
 	require.NoError(t, err)
 
@@ -149,16 +151,119 @@ func TestGetRatingForUsageAddsServicePeriodToDetailedLineChildUniqueReferenceIDs
 
 	require.Equal(t, "unit-price-usage@[2025-01-01T00:00:00Z..2025-02-01T00:00:00Z]", out.DetailedLines[0].ChildUniqueReferenceID)
 	require.Equal(t, "rateCardDiscount/correlationID=discount-50pct@[2025-01-01T00:00:00Z..2025-02-01T00:00:00Z]", out.DetailedLines[1].ChildUniqueReferenceID)
+	require.False(t, ratingService.lastOpts.IgnoreMinimumCommitment)
+}
+
+func TestGetRatingForUsageCanIgnoreMinimumCommitment(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
+	streamingConnector.AddSimpleEvent("meter-1", 12, servicePeriod.From.Add(30*time.Minute))
+
+	ratingService := &stubRatingService{
+		result: billingrating.GenerateDetailedLinesResult{},
+	}
+
+	svc, err := New(Config{
+		StreamingConnector: streamingConnector,
+		RatingService:      ratingService,
+	})
+	require.NoError(t, err)
+
+	_, err = svc.GetDetailedLinesForUsage(ctx, GetDetailedLinesForUsageInput{
+		Charge: usagebased.Charge{
+			ChargeBase: usagebased.ChargeBase{
+				ManagedResource: chargesmeta.ManagedResource{
+					NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+					ManagedModel: models.ManagedModel{
+						CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+						UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+					},
+					ID: "charge-1",
+				},
+				Intent: usagebased.Intent{
+					Intent: chargesmeta.Intent{
+						Name:              "usage-charge",
+						ManagedBy:         billing.SubscriptionManagedLine,
+						CustomerID:        "customer-1",
+						Currency:          currencyx.Code("USD"),
+						ServicePeriod:     servicePeriod,
+						FullServicePeriod: servicePeriod,
+						BillingPeriod:     servicePeriod,
+					},
+					InvoiceAt:      time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+					SettlementMode: productcatalog.InvoiceOnlySettlementMode,
+					FeatureKey:     "feature-1",
+					Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromInt(3),
+					}),
+				},
+				Status: usagebased.StatusCreated,
+				State: usagebased.State{
+					FeatureID: "feature-1",
+				},
+			},
+		},
+		Customer: billing.CustomerOverrideWithDetails{
+			Customer: &customer.Customer{
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Namespace: "ns",
+					ID:        "customer-1",
+					Name:      "Customer 1",
+					CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				}),
+				Key: lo.ToPtr("cust-1"),
+			},
+		},
+		FeatureMeter: feature.FeatureMeter{
+			Feature: feature.Feature{
+				Namespace: "ns",
+				ID:        "feature-1",
+				Name:      "Feature 1",
+				Key:       "feature-1",
+				MeterID:   lo.ToPtr("meter-1"),
+				CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Meter: &meter.Meter{
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Namespace: "ns",
+					ID:        "meter-1",
+					Name:      "Meter 1",
+					CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+					UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				}),
+				Key:           "meter-1",
+				Aggregation:   meter.MeterAggregationSum,
+				EventType:     "event.type",
+				ValueProperty: lo.ToPtr("value"),
+			},
+		},
+		StoredAtOffset:          time.Date(2025, 2, 2, 0, 0, 0, 0, time.UTC),
+		IgnoreMinimumCommitment: true,
+	})
+	require.NoError(t, err)
+	require.True(t, ratingService.lastOpts.IgnoreMinimumCommitment)
 }
 
 type stubRatingService struct {
-	result billingrating.GenerateDetailedLinesResult
+	result   billingrating.GenerateDetailedLinesResult
+	lastOpts billingrating.GenerateDetailedLinesOptions
 }
 
-func (s stubRatingService) ResolveBillablePeriod(in billingrating.ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error) {
+func (s *stubRatingService) ResolveBillablePeriod(in billingrating.ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error) {
 	return nil, nil
 }
 
-func (s stubRatingService) GenerateDetailedLines(in billingrating.StandardLineAccessor) (billingrating.GenerateDetailedLinesResult, error) {
+func (s *stubRatingService) GenerateDetailedLines(in billingrating.StandardLineAccessor, opts ...billingrating.GenerateDetailedLinesOption) (billingrating.GenerateDetailedLinesResult, error) {
+	s.lastOpts = billingrating.NewGenerateDetailedLinesOptions(opts...)
 	return s.result, nil
 }

--- a/openmeter/billing/charges/usagebased/service/run/create.go
+++ b/openmeter/billing/charges/usagebased/service/run/create.go
@@ -17,15 +17,17 @@ import (
 )
 
 type CreateRatedRunInput struct {
-	Charge             usagebased.Charge
-	CustomerOverride   billing.CustomerOverrideWithDetails
-	FeatureMeter       feature.FeatureMeter
-	Type               usagebased.RealizationRunType
-	AsOf               time.Time
-	CollectionEnd      time.Time
-	LineID             *string
-	CreditAllocation   CreditAllocationMode
-	CurrencyCalculator currencyx.Calculator
+	Charge           usagebased.Charge
+	CustomerOverride billing.CustomerOverrideWithDetails
+	FeatureMeter     feature.FeatureMeter
+	Type             usagebased.RealizationRunType
+	AsOf             time.Time
+	CollectionEnd    time.Time
+	LineID           *string
+	// IgnoreMinimumCommitment keeps interim realization runs from booking final-only minimum commitment.
+	IgnoreMinimumCommitment bool
+	CreditAllocation        CreditAllocationMode
+	CurrencyCalculator      currencyx.Calculator
 }
 
 func (i CreateRatedRunInput) Validate() error {
@@ -120,11 +122,12 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 	in.Charge = chargeWithDetailedLines
 
 	ratingResult, err := s.rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetDetailedLinesForUsageInput{
-		Charge:         in.Charge,
-		PriorRuns:      in.Charge.Realizations,
-		Customer:       in.CustomerOverride,
-		FeatureMeter:   in.FeatureMeter,
-		StoredAtOffset: in.AsOf,
+		Charge:                  in.Charge,
+		PriorRuns:               in.Charge.Realizations,
+		Customer:                in.CustomerOverride,
+		FeatureMeter:            in.FeatureMeter,
+		StoredAtOffset:          in.AsOf,
+		IgnoreMinimumCommitment: in.IgnoreMinimumCommitment,
 	})
 	if err != nil {
 		return CreateRatedRunResult{}, fmt.Errorf("get rating for usage: %w", err)

--- a/openmeter/billing/rating/service.go
+++ b/openmeter/billing/rating/service.go
@@ -14,7 +14,29 @@ import (
 
 type Service interface {
 	ResolveBillablePeriod(in ResolveBillablePeriodInput) (*timeutil.ClosedPeriod, error)
-	GenerateDetailedLines(in StandardLineAccessor) (GenerateDetailedLinesResult, error)
+	GenerateDetailedLines(in StandardLineAccessor, opts ...GenerateDetailedLinesOption) (GenerateDetailedLinesResult, error)
+}
+
+type GenerateDetailedLinesOptions struct {
+	IgnoreMinimumCommitment bool
+}
+
+type GenerateDetailedLinesOption func(*GenerateDetailedLinesOptions)
+
+func NewGenerateDetailedLinesOptions(opts ...GenerateDetailedLinesOption) GenerateDetailedLinesOptions {
+	var out GenerateDetailedLinesOptions
+
+	for _, opt := range opts {
+		opt(&out)
+	}
+
+	return out
+}
+
+func WithMinimumCommitmentIgnored() GenerateDetailedLinesOption {
+	return func(o *GenerateDetailedLinesOptions) {
+		o.IgnoreMinimumCommitment = true
+	}
 }
 
 type Usage struct {

--- a/openmeter/billing/rating/service/billableperiod.go
+++ b/openmeter/billing/rating/service/billableperiod.go
@@ -14,7 +14,7 @@ func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (*
 		return nil, err
 	}
 
-	linePricer, err := getPricerFor(in.Line)
+	linePricer, err := getPricerFor(in.Line, rating.GenerateDetailedLinesOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/openmeter/billing/rating/service/detailedline.go
+++ b/openmeter/billing/rating/service/detailedline.go
@@ -38,7 +38,7 @@ func validateStandardLine(in rating.StandardLineAccessor) error {
 	return nil
 }
 
-func (s *service) GenerateDetailedLines(in rating.StandardLineAccessor) (rating.GenerateDetailedLinesResult, error) {
+func (s *service) GenerateDetailedLines(in rating.StandardLineAccessor, opts ...rating.GenerateDetailedLinesOption) (rating.GenerateDetailedLinesResult, error) {
 	if err := validateStandardLine(in); err != nil {
 		return rating.GenerateDetailedLinesResult{}, fmt.Errorf("validating billable line: %w", err)
 	}
@@ -48,7 +48,9 @@ func (s *service) GenerateDetailedLines(in rating.StandardLineAccessor) (rating.
 		return rating.GenerateDetailedLinesResult{}, fmt.Errorf("creating currency calculator: %w", err)
 	}
 
-	linePricer, err := getPricerFor(in)
+	generateOpts := rating.NewGenerateDetailedLinesOptions(opts...)
+
+	linePricer, err := getPricerFor(in, generateOpts)
 	if err != nil {
 		return rating.GenerateDetailedLinesResult{}, fmt.Errorf("creating pricer: %w", err)
 	}

--- a/openmeter/billing/rating/service/pricer.go
+++ b/openmeter/billing/rating/service/pricer.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func getPricerFor(line rating.PriceAccessor) (*priceMutator, error) {
+func getPricerFor(line rating.PriceAccessor, opts rating.GenerateDetailedLinesOptions) (*priceMutator, error) {
 	if line == nil {
 		return nil, errors.New("line is nil")
 	}
@@ -50,18 +50,26 @@ func getPricerFor(line rating.PriceAccessor) (*priceMutator, error) {
 		return nil, fmt.Errorf("unsupported price type: %s", linePrice.Type())
 	}
 
+	postCalculationMutators := []mutator.PostCalculationMutator{
+		&mutator.DiscountPercentage{},
+		&mutator.MaxAmountCommitment{},
+	}
+
+	// Charges pricing needs control over the minimum commitment as it should only be included for any
+	// calculation that is after the service period end.
+	if !opts.IgnoreMinimumCommitment {
+		postCalculationMutators = append(postCalculationMutators, &mutator.MinAmountCommitment{})
+	}
+
+	postCalculationMutators = append(postCalculationMutators, &mutator.Credits{})
+
 	// This priceMutator captures the calculation flow for discounts and commitments:
 	return &priceMutator{
 		PreCalculation: []mutator.PreCalculationMutator{
 			&mutator.DiscountUsage{},
 		},
-		Pricer: basePricer,
-		PostCalculation: []mutator.PostCalculationMutator{
-			&mutator.DiscountPercentage{},
-			&mutator.MaxAmountCommitment{},
-			&mutator.MinAmountCommitment{},
-			&mutator.Credits{},
-		},
+		Pricer:          basePricer,
+		PostCalculation: postCalculationMutators,
 	}, nil
 }
 


### PR DESCRIPTION

## Overview

Minimum commitment is accounted for at the end of the billing period.

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to ignore minimum commitment charges for partial invoice runs while preserving them for final realizations.
* **Behavioral Changes**
  * Minimum-commitment handling can be toggled through the rating flow so downstream pricing omits minimums when requested.
* **Tests**
  * Added unit tests validating ignoring vs. preserving minimum commitment behavior and its propagation through rating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->