### PR TITLE
feat: prior run values

### DIFF
--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -459,6 +459,9 @@ Important behavior:
 - stored-at filtering uses `stored_at < cutoff`
 - the cutoff is the run's `StoredAtLT`
 - the service-period end is expected to behave as exclusive in lifecycle tests
+- `GetDetailedRatingForUsage(...)` owns the current-run filtering rule: only realization runs with `ServicePeriodTo < input.ServicePeriodTo` are prior runs; a current run already present on the charge must be ignored rather than stripped by mutating the charge in the caller
+- minimum commitment is final-only for usage-based snapshots; detailed rating ignores it when the current service-period end is before the charge intent service-period end
+- realtime/current totals should ignore minimum commitment before the charge intent service-period end and include it at/after the service-period end
 
 This means late-arriving events can become eligible in later advances if their `stored_at` was previously too new but later falls before the next cutoff.
 
@@ -511,6 +514,7 @@ Use these conventions for lifecycle tests:
 - use `streaming/testutils.WithStoredAt(...)` to simulate late events
 - when testing stored-at cutoffs, remember the predicate is exclusive: an event with `stored_at == StoredAtLT` is excluded, and an event with `stored_at` before `StoredAtLT` is included
 - when testing service-period cutoffs, remember the event-time window is half-open: an event with `event_time == ServicePeriodTo` is excluded
+- prefer `streamingtestutils.NewMockStreamingConnector(...)` plus the real billing rating service when a usage-based rating test should exercise production quantity lookup, pricing, discounts, or commitments end-to-end
 - prefer `clock.FreezeTime(...)` for exact `StoredAtLT` / `AllocateAt` assertions
 - rely on the default billing profile unless the test explicitly needs customer-specific override behavior
 - for credit-only charges (usage-based or flat fee), `Create(...)` itself may return an already-advanced charge — assert the returned charge's status, do not assume it will be `created`

--- a/openmeter/billing/charges/usagebased/rating.go
+++ b/openmeter/billing/charges/usagebased/rating.go
@@ -16,6 +16,7 @@ var _ rating.StandardLineAccessor = (*RateableIntent)(nil)
 type RateableIntent struct {
 	Intent
 
+	ServicePeriod  timeutil.ClosedPeriod
 	MeterValue     alpacadecimal.Decimal
 	CreditsApplied billing.CreditsApplied
 }

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -248,16 +248,15 @@ func (s *CreditThenInvoiceStateMachine) startInvoiceCreatedRun(
 	}
 
 	result, err := s.Runs.CreateRatedRun(ctx, usagebasedrun.CreateRatedRunInput{
-		Charge:                  s.Charge,
-		CustomerOverride:        s.CustomerOverride,
-		FeatureMeter:            s.FeatureMeter,
-		Type:                    runType,
-		StoredAtLT:              storedAtLT,
-		ServicePeriodTo:         servicePeriodTo,
-		LineID:                  lo.ToPtr(input.LineID),
-		IgnoreMinimumCommitment: ignoreMinimumCommitmentForRunType(runType),
-		CreditAllocation:        usagebasedrun.CreditAllocationAvailable,
-		CurrencyCalculator:      s.CurrencyCalculator,
+		Charge:             s.Charge,
+		CustomerOverride:   s.CustomerOverride,
+		FeatureMeter:       s.FeatureMeter,
+		Type:               runType,
+		StoredAtLT:         storedAtLT,
+		ServicePeriodTo:    servicePeriodTo,
+		LineID:             lo.ToPtr(input.LineID),
+		CreditAllocation:   usagebasedrun.CreditAllocationAvailable,
+		CurrencyCalculator: s.CurrencyCalculator,
 	})
 	if err != nil {
 		return err
@@ -273,12 +272,6 @@ func (s *CreditThenInvoiceStateMachine) StartPartialInvoiceRun(ctx context.Conte
 
 func (s *CreditThenInvoiceStateMachine) StartFinalInvoiceRun(ctx context.Context, input invoiceCreatedInput) error {
 	return s.startInvoiceCreatedRun(ctx, input, usagebased.RealizationRunTypeFinalRealization)
-}
-
-func ignoreMinimumCommitmentForRunType(runType usagebased.RealizationRunType) bool {
-	// Partial invoice runs are interim cumulative checkpoints. Minimum commitment is billed only on the
-	// final realization, so partial runs must suppress it during both creation and later snapshotting.
-	return runType == usagebased.RealizationRunTypePartialInvoice
 }
 
 func resolveInvoiceCreatedTrigger(charge usagebased.Charge, billedPeriod timeutil.ClosedPeriod) meta.Trigger {
@@ -309,17 +302,15 @@ func (s *CreditThenInvoiceStateMachine) SnapshotInvoiceUsage(ctx context.Context
 
 	storedAtLT := meta.NormalizeTimestamp(currentRun.StoredAtLT)
 
-	ratingResult, err := s.Rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetDetailedLinesForUsageInput{
-		Charge:                  s.Charge,
-		PriorRuns:               s.Charge.Realizations.Without(currentRun.ID),
-		Customer:                s.CustomerOverride,
-		FeatureMeter:            s.FeatureMeter,
-		ServicePeriodTo:         currentRun.ServicePeriodTo,
-		StoredAtLT:              storedAtLT,
-		IgnoreMinimumCommitment: ignoreMinimumCommitmentForRunType(currentRun.Type),
+	ratingResult, err := s.Rater.GetDetailedRatingForUsage(ctx, usagebasedrating.GetDetailedRatingForUsageInput{
+		Charge:          s.Charge,
+		StoredAtLT:      storedAtLT,
+		ServicePeriodTo: currentRun.ServicePeriodTo,
+		Customer:        s.CustomerOverride,
+		FeatureMeter:    s.FeatureMeter,
 	})
 	if err != nil {
-		return fmt.Errorf("get rating for usage: %w", err)
+		return fmt.Errorf("get detailed rating for usage: %w", err)
 	}
 
 	currentTotals := ratingResult.Totals.RoundToPrecision(s.CurrencyCalculator)

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -58,13 +58,3 @@ func TestResolveInvoiceCreatedTrigger(t *testing.T) {
 		require.Equal(t, meta.TriggerFinalInvoiceCreated, trigger)
 	})
 }
-
-func TestIgnoreMinimumCommitmentForRunType(t *testing.T) {
-	t.Run("partial invoice run", func(t *testing.T) {
-		require.True(t, ignoreMinimumCommitmentForRunType(usagebased.RealizationRunTypePartialInvoice))
-	})
-
-	t.Run("final realization run", func(t *testing.T) {
-		require.False(t, ignoreMinimumCommitmentForRunType(usagebased.RealizationRunTypeFinalRealization))
-	})
-}

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -184,16 +184,15 @@ func (s *CreditsOnlyStateMachine) FinalizeRealizationRun(ctx context.Context) er
 
 	storedAtLT := meta.NormalizeTimestamp(currentRun.StoredAtLT)
 
-	ratingResult, err := s.Rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetDetailedLinesForUsageInput{
+	ratingResult, err := s.Rater.GetDetailedRatingForUsage(ctx, usagebasedrating.GetDetailedRatingForUsageInput{
 		Charge:          s.Charge,
-		PriorRuns:       s.Charge.Realizations.Without(currentRun.ID),
+		StoredAtLT:      storedAtLT,
+		ServicePeriodTo: currentRun.ServicePeriodTo,
 		Customer:        s.CustomerOverride,
 		FeatureMeter:    s.FeatureMeter,
-		ServicePeriodTo: currentRun.ServicePeriodTo,
-		StoredAtLT:      storedAtLT,
 	})
 	if err != nil {
-		return fmt.Errorf("get rating for usage: %w", err)
+		return fmt.Errorf("get detailed rating for usage: %w", err)
 	}
 
 	currentTotals := ratingResult.Totals.RoundToPrecision(s.CurrencyCalculator)
@@ -219,12 +218,18 @@ func (s *CreditsOnlyStateMachine) FinalizeRealizationRun(ctx context.Context) er
 	}
 	currentRun.DetailedLines = mo.Some(runDetailedLines)
 
-	if _, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
+	currentRunBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
 		ID:              currentRun.ID,
 		StoredAtLT:      mo.Some(storedAtLT),
 		MeteredQuantity: mo.Some(ratingResult.Quantity),
 		Totals:          mo.Some(currentTotals),
-	}); err != nil {
+	})
+	if err != nil {
+		return fmt.Errorf("update realization run: %w", err)
+	}
+	currentRun.RealizationRunBase = currentRunBase
+
+	if err := s.Charge.Realizations.SetRealizationRun(currentRun); err != nil {
 		return fmt.Errorf("update realization run: %w", err)
 	}
 

--- a/openmeter/billing/charges/usagebased/service/currenttotals.go
+++ b/openmeter/billing/charges/usagebased/service/currenttotals.go
@@ -48,11 +48,14 @@ func (s *service) GetCurrentTotals(ctx context.Context, input usagebased.GetCurr
 		return usagebased.GetCurrentTotalsResult{}, err
 	}
 
+	now := clock.Now()
+
 	dueTotals, err := s.rater.GetTotalsForUsage(ctx, usagebasedrating.GetTotalsForUsageInput{
-		Charge:       charge,
-		Customer:     customerOverride,
-		FeatureMeter: featureMeter,
-		StoredAtLT:   clock.Now(),
+		Charge:                  charge,
+		Customer:                customerOverride,
+		FeatureMeter:            featureMeter,
+		StoredAtLT:              now,
+		IgnoreMinimumCommitment: now.Before(charge.Intent.ServicePeriod.To),
 	})
 	if err != nil {
 		return usagebased.GetCurrentTotalsResult{}, fmt.Errorf("get totals for usage: %w", err)

--- a/openmeter/billing/charges/usagebased/service/get.go
+++ b/openmeter/billing/charges/usagebased/service/get.go
@@ -144,10 +144,11 @@ func (s *service) expandChargesUsage(ctx context.Context, namespace string, char
 
 			var dueTotals totals.Totals
 			dueTotals, err = s.rater.GetTotalsForUsage(ctx, usagebasedrating.GetTotalsForUsageInput{
-				Charge:       charge,
-				Customer:     customerOverridesById[charge.GetCustomerID()],
-				FeatureMeter: featureMeter,
-				StoredAtLT:   storedAt,
+				Charge:                  charge,
+				Customer:                customerOverridesById[charge.GetCustomerID()],
+				FeatureMeter:            featureMeter,
+				StoredAtLT:              storedAt,
+				IgnoreMinimumCommitment: storedAt.Before(charge.Intent.ServicePeriod.To),
 			})
 			if err != nil {
 				err = fmt.Errorf("get totals for charge %s: %w", charge.ID, err)

--- a/openmeter/billing/charges/usagebased/service/rating/details.go
+++ b/openmeter/billing/charges/usagebased/service/rating/details.go
@@ -1,30 +1,44 @@
 package rating
 
 import (
+	"cmp"
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-type GetDetailedLinesForUsageInput struct {
-	Charge          usagebased.Charge
-	PriorRuns       usagebased.RealizationRuns
-	Customer        billing.CustomerOverrideWithDetails
-	FeatureMeter    feature.FeatureMeter
+type GetDetailedRatingForUsageInput struct {
+	// Charge general data
+
+	// Charge contains the charge intent and the prior runs with detailed lines expanded.
+	Charge usagebased.Charge
+
+	// Current run's data
+
+	// ServicePeriodTo defines the rated event-time upper bound for the current run.
 	ServicePeriodTo time.Time
-	StoredAtLT      time.Time
-	// IgnoreMinimumCommitment suppresses minimum commitment while still applying the rest of the billing mutators.
-	IgnoreMinimumCommitment bool
+	// StoredAtLT defines the stored-at cutoff for current and prior snapshots.
+	StoredAtLT time.Time
+
+	// Metering values
+
+	Customer     billing.CustomerOverrideWithDetails
+	FeatureMeter feature.FeatureMeter
 }
 
-func (i GetDetailedLinesForUsageInput) Validate() error {
+func (i GetDetailedRatingForUsageInput) Validate() error {
 	if err := i.Charge.Validate(); err != nil {
 		return fmt.Errorf("charge: %w", err)
 	}
@@ -37,11 +51,11 @@ func (i GetDetailedLinesForUsageInput) Validate() error {
 		return fmt.Errorf("feature meter is required")
 	}
 
+	period := i.Charge.Intent.ServicePeriod
 	if i.ServicePeriodTo.IsZero() {
 		return fmt.Errorf("service period to is required")
 	}
 
-	period := i.Charge.Intent.ServicePeriod
 	if !i.ServicePeriodTo.After(period.From) {
 		return fmt.Errorf("service period to must be after charge service period from")
 	}
@@ -54,12 +68,10 @@ func (i GetDetailedLinesForUsageInput) Validate() error {
 		return fmt.Errorf("stored at lt is required")
 	}
 
-	if err := i.PriorRuns.Validate(); err != nil {
-		return fmt.Errorf("prior runs: %w", err)
-	}
-
-	for idx, run := range i.PriorRuns {
-		if !run.DetailedLines.IsPresent() {
+	for idx, run := range i.Charge.Realizations {
+		// Only runs before the requested service-period boundary are prior runs;
+		// the current run, if already present on the charge, is ignored.
+		if run.ServicePeriodTo.Before(i.ServicePeriodTo) && !run.DetailedLines.IsPresent() {
 			return fmt.Errorf("prior runs[%d]: detailed lines must be expanded", idx)
 		}
 	}
@@ -67,54 +79,184 @@ func (i GetDetailedLinesForUsageInput) Validate() error {
 	return nil
 }
 
-type GetRatingForUsageResult struct {
+type GetDetailedRatingForUsageResult struct {
 	billingrating.GenerateDetailedLinesResult
+	// Quantity is the current run's meter value between [Charge.Intent.ServicePeriod.From, ServicePeriodTo)
+	// capped at StoredAtLT.
 	Quantity alpacadecimal.Decimal
 }
 
-// GetDetailedLinesForUsage returns the rated detailed lines together with the metered quantity snapshot
-// used to compute them. Prefer GetTotalsForUsage when only totals are needed because it is faster.
-func (s *service) GetDetailedLinesForUsage(ctx context.Context, in GetDetailedLinesForUsageInput) (GetRatingForUsageResult, error) {
+func (s *service) GetDetailedRatingForUsage(ctx context.Context, in GetDetailedRatingForUsageInput) (GetDetailedRatingForUsageResult, error) {
 	if err := in.Validate(); err != nil {
-		return GetRatingForUsageResult{}, err
+		return GetDetailedRatingForUsageResult{}, err
 	}
 
-	servicePeriod := in.Charge.Intent.ServicePeriod
-	servicePeriod.To = in.ServicePeriodTo
+	currentRunServicePeriod := timeutil.ClosedPeriod{
+		From: in.Charge.Intent.ServicePeriod.From,
+		To:   in.ServicePeriodTo,
+	}
 
-	snapshotQuantity, err := s.snapshotQuantity(ctx, snapshotQuantityInput{
+	currentQuantity, err := s.snapshotQuantity(ctx, snapshotQuantityInput{
 		Customer:      in.Customer.Customer,
 		FeatureMeter:  in.FeatureMeter,
-		ServicePeriod: servicePeriod,
+		ServicePeriod: currentRunServicePeriod,
 		StoredAtLT:    in.StoredAtLT,
 	})
 	if err != nil {
-		return GetRatingForUsageResult{}, fmt.Errorf("get snapshot quantity: %w", err)
+		return GetDetailedRatingForUsageResult{}, fmt.Errorf("get current quantity: %w", err)
+	}
+
+	// Let's fetch invoice based realizations that are before the current run's service period to
+	eligibleRealizations := lo.Filter(in.Charge.Realizations, func(run usagebased.RealizationRun, _ int) bool {
+		if run.Type != usagebased.RealizationRunTypeFinalRealization && run.Type != usagebased.RealizationRunTypePartialInvoice {
+			return false
+		}
+
+		return run.ServicePeriodTo.Before(in.ServicePeriodTo)
+	})
+
+	// Let's sort the eligible realizations by service period to
+	slices.SortStableFunc(eligibleRealizations, func(a, b usagebased.RealizationRun) int {
+		return cmp.Compare(a.ServicePeriodTo.UnixNano(), b.ServicePeriodTo.UnixNano())
+	})
+
+	servicePeriodFrom := in.Charge.Intent.ServicePeriod.From
+	priorPeriods := make([]ratingPriorPeriod, 0, len(eligibleRealizations))
+
+	for _, realization := range eligibleRealizations {
+		servicePeriod := timeutil.ClosedPeriod{
+			From: servicePeriodFrom,
+			To:   realization.ServicePeriodTo,
+		}
+
+		// TODO: Later persist prior-period value snapshots for previous runs to avoid re-querying them. This only
+		// helps if we have customers with a lot of interim invoices.
+		//
+		// The future optimization should snapshot prior runs as follows:
+		//
+		// - Determine the previous run as the latest non-current run with `ServicePeriodTo < current ServicePeriodTo`.
+		// - For monotonic-compatible meters (monotonic + SUM), load that previous run's stored prior-period values.
+		// - Re-query prior run quantities using the current run's `StoredAtLT`.
+		// - Iterate prior runs from newest to oldest.
+		// - Once a freshly queried prior quantity matches the value stored by the previous run, stop querying older periods.
+		// - Copy the remaining older prior-period values from the previous run instead.
+		// - This avoids expensive meter queries for older periods when the previous snapshot already proves they have not changed.
+		//
+		// An alternative approach is to do two queries and aggregate from there (for SUM, COUNT, MIN, MAX, etc.).
+		//
+		// - Query the meter between [intent.ServicePeriodFrom ... servicePeriod.To) capped by [previousStoredAtLT ... currentStoredAtLT)
+		// - Query the meter between [servicePeriod.To ... currentServicePeriod.To) capped by currentStoredAtLT
+		// - Aggregate the two results
+
+		priorPeriodQty, err := s.snapshotQuantity(ctx, snapshotQuantityInput{
+			Customer:      in.Customer.Customer,
+			FeatureMeter:  in.FeatureMeter,
+			ServicePeriod: servicePeriod,
+			StoredAtLT:    in.StoredAtLT,
+		})
+		if err != nil {
+			return GetDetailedRatingForUsageResult{}, fmt.Errorf("get prior period quantity: %w", err)
+		}
+
+		priorPeriods = append(priorPeriods, ratingPriorPeriod{
+			MeteredQuantity: priorPeriodQty,
+			ServicePeriod:   servicePeriod,
+			DetailedLines:   realization.DetailedLines.OrEmpty(),
+		})
+
+		servicePeriodFrom = servicePeriod.To
+	}
+
+	return s.rateWithLateEvents(ctx, rateWithLateEventsInput{
+		Intent: in.Charge.Intent,
+		CurrentPeriod: ratingCurrentPeriod{
+			MeteredQuantity: currentQuantity,
+			ServicePeriod:   currentRunServicePeriod,
+		},
+		PriorPeriod: priorPeriods,
+	})
+}
+
+type rateWithLateEventsInput struct {
+	Intent usagebased.Intent
+
+	CurrentPeriod ratingCurrentPeriod
+	PriorPeriod   []ratingPriorPeriod
+}
+
+func (i rateWithLateEventsInput) Validate() error {
+	var errs []error
+	if err := i.Intent.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("intent: %w", err))
+	}
+
+	intentServicePeriod := i.Intent.ServicePeriod
+	if !intentServicePeriod.ContainsPeriodInclusive(i.CurrentPeriod.ServicePeriod) {
+		errs = append(errs, fmt.Errorf("current period service period must be contained in intent service period: [%s..%s] vs [%s..%s]",
+			intentServicePeriod.From.Format(time.RFC3339), intentServicePeriod.To.Format(time.RFC3339),
+			i.CurrentPeriod.ServicePeriod.From.Format(time.RFC3339), i.CurrentPeriod.ServicePeriod.To.Format(time.RFC3339)))
+	}
+
+	for _, priorPeriod := range i.PriorPeriod {
+		if !intentServicePeriod.ContainsPeriodInclusive(priorPeriod.ServicePeriod) {
+			errs = append(errs, fmt.Errorf("prior period service period must be contained in intent service period: [%s..%s] vs [%s..%s]",
+				intentServicePeriod.From.Format(time.RFC3339), intentServicePeriod.To.Format(time.RFC3339),
+				priorPeriod.ServicePeriod.From.Format(time.RFC3339), priorPeriod.ServicePeriod.To.Format(time.RFC3339)))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type ratingCurrentPeriod struct {
+	// MeteredQuantity is the metered quantity for [intent.ServicePeriodFrom ... servicePeriod.To) capped by StoredAtLT of the current run
+	MeteredQuantity alpacadecimal.Decimal
+
+	// ServicePeriod is the service period for the current period (from is intent.ServicePeriod.From if this is the first run or
+	// the previous run's servicePeriod.To if this is not the first run)
+	ServicePeriod timeutil.ClosedPeriod
+}
+
+type ratingPriorPeriod struct {
+	// MeteredQuantity is the metered quantity for [intent.ServicePeriodFrom ... servicePeriod.To) capped by StoredAtLT of the current run
+	MeteredQuantity alpacadecimal.Decimal
+
+	// ServicePeriod is the service period for the prior period (from is intent.ServicePeriod.From, for the first item or
+	// servicePeriod.From of the previous item)
+	ServicePeriod timeutil.ClosedPeriod
+
+	// DetailedLines are the detailed lines billed for the prior period
+	DetailedLines usagebased.DetailedLines
+}
+
+func (s *service) rateWithLateEvents(ctx context.Context, in rateWithLateEventsInput) (GetDetailedRatingForUsageResult, error) {
+	if err := in.Validate(); err != nil {
+		return GetDetailedRatingForUsageResult{}, err
 	}
 
 	var opts []billingrating.GenerateDetailedLinesOption
-	if in.IgnoreMinimumCommitment {
+	// Minimum commitment is charged only on the final run, not on interim snapshots.
+	if in.CurrentPeriod.ServicePeriod.To.Before(in.Intent.ServicePeriod.To) {
 		opts = append(opts, billingrating.WithMinimumCommitmentIgnored())
 	}
 
-	intent := in.Charge.Intent
-	intent.ServicePeriod = servicePeriod
-
+	// TODO[later]: Implement the proper rating logic using prior period usage qtys for late event processing
 	ratingResult, err := s.ratingService.GenerateDetailedLines(usagebased.RateableIntent{
-		Intent:     intent,
-		MeterValue: snapshotQuantity,
+		Intent:        in.Intent,
+		ServicePeriod: in.CurrentPeriod.ServicePeriod,
+		MeterValue:    in.CurrentPeriod.MeteredQuantity,
 	}, opts...)
 	if err != nil {
-		return GetRatingForUsageResult{}, fmt.Errorf("rating: %w", err)
+		return GetDetailedRatingForUsageResult{}, fmt.Errorf("rating: %w", err)
 	}
 
 	ratingResult.DetailedLines = withServicePeriodInDetailedLineChildUniqueReferenceIDs(
 		ratingResult.DetailedLines,
-		servicePeriod,
+		in.CurrentPeriod.ServicePeriod,
 	)
 
-	return GetRatingForUsageResult{
+	return GetDetailedRatingForUsageResult{
 		GenerateDetailedLinesResult: ratingResult,
-		Quantity:                    snapshotQuantity,
+		Quantity:                    in.CurrentPeriod.MeteredQuantity,
 	}, nil
 }

--- a/openmeter/billing/charges/usagebased/service/rating/quantitysnapshot.go
+++ b/openmeter/billing/charges/usagebased/service/rating/quantitysnapshot.go
@@ -8,12 +8,70 @@ import (
 	"github.com/alpacahq/alpacadecimal"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/filter"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
+
+type getQuantityForUsageInput struct {
+	Charge          usagebased.Charge
+	Customer        billing.CustomerOverrideWithDetails
+	FeatureMeter    feature.FeatureMeter
+	ServicePeriodTo time.Time
+	StoredAtLT      time.Time
+}
+
+func (i getQuantityForUsageInput) Validate() error {
+	if err := i.Charge.Validate(); err != nil {
+		return fmt.Errorf("charge: %w", err)
+	}
+
+	if i.Customer.Customer == nil {
+		return fmt.Errorf("customer is required")
+	}
+
+	if i.FeatureMeter.Meter == nil {
+		return fmt.Errorf("feature meter is required")
+	}
+
+	if i.ServicePeriodTo.IsZero() {
+		return fmt.Errorf("service period to is required")
+	}
+
+	period := i.Charge.Intent.ServicePeriod
+	if !i.ServicePeriodTo.After(period.From) {
+		return fmt.Errorf("service period to must be after charge service period from")
+	}
+
+	if i.ServicePeriodTo.After(period.To) {
+		return fmt.Errorf("service period to must not be after charge service period to")
+	}
+
+	if i.StoredAtLT.IsZero() {
+		return fmt.Errorf("stored at lt is required")
+	}
+
+	return nil
+}
+
+func (s *service) getQuantityForUsage(ctx context.Context, in getQuantityForUsageInput) (alpacadecimal.Decimal, error) {
+	if err := in.Validate(); err != nil {
+		return alpacadecimal.Zero, err
+	}
+
+	servicePeriod := in.Charge.Intent.ServicePeriod
+	servicePeriod.To = in.ServicePeriodTo
+
+	return s.snapshotQuantity(ctx, snapshotQuantityInput{
+		Customer:      in.Customer.Customer,
+		FeatureMeter:  in.FeatureMeter,
+		ServicePeriod: servicePeriod,
+		StoredAtLT:    in.StoredAtLT,
+	})
+}
 
 type snapshotQuantityInput struct {
 	Customer      streaming.Customer

--- a/openmeter/billing/charges/usagebased/service/rating/service.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service.go
@@ -32,9 +32,9 @@ type Service interface {
 	// GetTotalsForUsage returns charge totals for a usage snapshot without generating detailed lines.
 	// Prefer this when only totals are required because it is faster than generating detailed lines.
 	GetTotalsForUsage(ctx context.Context, in GetTotalsForUsageInput) (totals.Totals, error)
-	// GetDetailedLinesForUsage returns rated detailed lines and the metered quantity snapshot used to compute them.
+	// GetDetailedRatingForUsage returns rated detailed lines and the metered quantity snapshot used to compute them.
 	// Prefer GetTotalsForUsage when only totals are required because it is faster.
-	GetDetailedLinesForUsage(ctx context.Context, in GetDetailedLinesForUsageInput) (GetRatingForUsageResult, error)
+	GetDetailedRatingForUsage(ctx context.Context, in GetDetailedRatingForUsageInput) (GetDetailedRatingForUsageResult, error)
 }
 
 type service struct {

--- a/openmeter/billing/charges/usagebased/service/rating/service_test.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
+	billingratingservice "github.com/openmeterio/openmeter/openmeter/billing/rating/service"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
@@ -22,9 +24,9 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-type getDetailedLinesForUsageFixture struct {
+type getDetailedRatingForUsageFixture struct {
 	config Config
-	input  GetDetailedLinesForUsageInput
+	input  GetDetailedRatingForUsageInput
 	rater  *stubRatingService
 }
 
@@ -43,12 +45,10 @@ func TestFormatDetailedLineChildUniqueReferenceID(t *testing.T) {
 	)
 }
 
-func TestGetRatingForUsageAddsServicePeriodToDetailedLineChildUniqueReferenceIDs(t *testing.T) {
+func TestGetDetailedRatingForUsageAddsServicePeriodToDetailedLineChildUniqueReferenceIDs(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
-
-	fixture := newGetDetailedLinesForUsageFixture(t, billingrating.GenerateDetailedLinesResult{
+	fixture := newGetDetailedRatingForUsageFixture(t, billingrating.GenerateDetailedLinesResult{
 		DetailedLines: billingrating.DetailedLines{
 			{
 				Name:                   "Usage",
@@ -68,30 +68,139 @@ func TestGetRatingForUsageAddsServicePeriodToDetailedLineChildUniqueReferenceIDs
 	svc, err := New(fixture.config)
 	require.NoError(t, err)
 
-	out, err := svc.GetDetailedLinesForUsage(ctx, fixture.input)
+	out, err := svc.GetDetailedRatingForUsage(t.Context(), fixture.input)
 	require.NoError(t, err)
 
 	require.Equal(t, "unit-price-usage@[2025-01-01T00:00:00Z..2025-02-01T00:00:00Z]", out.DetailedLines[0].ChildUniqueReferenceID)
 	require.Equal(t, "rateCardDiscount/correlationID=discount-50pct@[2025-01-01T00:00:00Z..2025-02-01T00:00:00Z]", out.DetailedLines[1].ChildUniqueReferenceID)
+	require.Equal(t, float64(12), out.Quantity.InexactFloat64())
 	require.False(t, fixture.rater.lastOpts.IgnoreMinimumCommitment)
 }
 
-func TestGetRatingForUsageCanIgnoreMinimumCommitment(t *testing.T) {
+func TestGetDetailedRatingForUsageIgnoresMinimumCommitmentForPartialRun(t *testing.T) {
 	t.Parallel()
 
-	ctx := t.Context()
-	fixture := newGetDetailedLinesForUsageFixture(t, billingrating.GenerateDetailedLinesResult{})
-	fixture.input.IgnoreMinimumCommitment = true
+	fixture := newGetDetailedRatingForUsageFixture(t, billingrating.GenerateDetailedLinesResult{})
+	partialServicePeriodTo := fixture.input.Charge.Intent.ServicePeriod.From.Add(24 * time.Hour)
+	fixture.input.ServicePeriodTo = partialServicePeriodTo
 
 	svc, err := New(fixture.config)
 	require.NoError(t, err)
 
-	_, err = svc.GetDetailedLinesForUsage(ctx, fixture.input)
+	_, err = svc.GetDetailedRatingForUsage(t.Context(), fixture.input)
 	require.NoError(t, err)
 	require.True(t, fixture.rater.lastOpts.IgnoreMinimumCommitment)
 }
 
-func newGetDetailedLinesForUsageFixture(t *testing.T, result billingrating.GenerateDetailedLinesResult) getDetailedLinesForUsageFixture {
+func TestGetDetailedRatingForUsageIgnoresCurrentRunOnCharge(t *testing.T) {
+	t.Parallel()
+
+	fixture := newGetDetailedRatingForUsageFixture(t, billingrating.GenerateDetailedLinesResult{})
+	currentRun := newDetailedRatingTestRun("current", fixture.input.ServicePeriodTo, 0)
+	fixture.input.Charge.Realizations = usagebased.RealizationRuns{currentRun}
+
+	svc, err := New(fixture.config)
+	require.NoError(t, err)
+
+	_, err = svc.GetDetailedRatingForUsage(t.Context(), fixture.input)
+	require.NoError(t, err)
+}
+
+func TestGetDetailedRatingForUsageFiltersQuantityByServicePeriodToAndStoredAtLT(t *testing.T) {
+	t.Parallel()
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	servicePeriodTo := servicePeriod.From.Add(24 * time.Hour)
+	storedAtLT := servicePeriod.From.Add(48 * time.Hour)
+
+	streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
+	streamingConnector.AddSimpleEvent("meter-1", 2, servicePeriod.From.Add(time.Hour), streamingtestutils.WithStoredAt(storedAtLT.Add(-time.Second)))
+	streamingConnector.AddSimpleEvent("meter-1", 3, servicePeriod.From.Add(2*time.Hour), streamingtestutils.WithStoredAt(storedAtLT))
+	streamingConnector.AddSimpleEvent("meter-1", 5, servicePeriodTo, streamingtestutils.WithStoredAt(storedAtLT.Add(-time.Second)))
+	streamingConnector.AddSimpleEvent("meter-1", 7, servicePeriodTo.Add(time.Hour), streamingtestutils.WithStoredAt(storedAtLT.Add(-time.Second)))
+
+	svc, err := New(Config{
+		StreamingConnector: streamingConnector,
+		RatingService:      &stubRatingService{},
+	})
+	require.NoError(t, err)
+
+	out, err := svc.GetDetailedRatingForUsage(t.Context(), GetDetailedRatingForUsageInput{
+		Charge:          newDetailedRatingTestCharge(servicePeriod, usagebased.RealizationRuns{}),
+		ServicePeriodTo: servicePeriodTo,
+		StoredAtLT:      storedAtLT,
+		Customer:        newDetailedRatingTestCustomer(),
+		FeatureMeter:    newDetailedRatingTestFeatureMeter(),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, float64(2), out.Quantity.InexactFloat64())
+}
+
+func TestGetTotalsForUsageMinimumCommitment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                    string
+		ignoreMinimumCommitment bool
+		expectTotal             float64
+	}{
+		{
+			name:                    "ignored",
+			ignoreMinimumCommitment: true,
+			expectTotal:             36,
+		},
+		{
+			name:                    "included",
+			ignoreMinimumCommitment: false,
+			expectTotal:             100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			servicePeriod := timeutil.ClosedPeriod{
+				From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+			}
+
+			streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
+			streamingConnector.AddSimpleEvent("meter-1", 12, servicePeriod.From.Add(30*time.Minute))
+
+			svc, err := New(Config{
+				StreamingConnector: streamingConnector,
+				RatingService:      billingratingservice.New(),
+			})
+			require.NoError(t, err)
+
+			charge := newDetailedRatingTestCharge(servicePeriod, usagebased.RealizationRuns{})
+			charge.Intent.Price = *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromInt(3),
+				Commitments: productcatalog.Commitments{
+					MinimumAmount: lo.ToPtr(alpacadecimal.NewFromInt(100)),
+				},
+			})
+
+			out, err := svc.GetTotalsForUsage(t.Context(), GetTotalsForUsageInput{
+				Charge:                  charge,
+				Customer:                newDetailedRatingTestCustomer(),
+				FeatureMeter:            newDetailedRatingTestFeatureMeter(),
+				StoredAtLT:              servicePeriod.To,
+				IgnoreMinimumCommitment: tt.ignoreMinimumCommitment,
+			})
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expectTotal, out.Total.InexactFloat64())
+		})
+	}
+}
+
+func newGetDetailedRatingForUsageFixture(t *testing.T, result billingrating.GenerateDetailedLinesResult) getDetailedRatingForUsageFixture {
 	t.Helper()
 
 	servicePeriod := timeutil.ClosedPeriod{
@@ -103,86 +212,123 @@ func newGetDetailedLinesForUsageFixture(t *testing.T, result billingrating.Gener
 	streamingConnector.AddSimpleEvent("meter-1", 12, servicePeriod.From.Add(30*time.Minute))
 
 	ratingService := &stubRatingService{result: result}
+	currentRun := newDetailedRatingTestRun("current", servicePeriod.To, 0)
 
-	return getDetailedLinesForUsageFixture{
+	return getDetailedRatingForUsageFixture{
 		config: Config{
 			StreamingConnector: streamingConnector,
 			RatingService:      ratingService,
 		},
-		input: GetDetailedLinesForUsageInput{
-			Charge: usagebased.Charge{
-				ChargeBase: usagebased.ChargeBase{
-					ManagedResource: chargesmeta.ManagedResource{
-						NamespacedModel: models.NamespacedModel{Namespace: "ns"},
-						ManagedModel: models.ManagedModel{
-							CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-							UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-						},
-						ID: "charge-1",
-					},
-					Intent: usagebased.Intent{
-						Intent: chargesmeta.Intent{
-							Name:              "usage-charge",
-							ManagedBy:         billing.SubscriptionManagedLine,
-							CustomerID:        "customer-1",
-							Currency:          currencyx.Code("USD"),
-							ServicePeriod:     servicePeriod,
-							FullServicePeriod: servicePeriod,
-							BillingPeriod:     servicePeriod,
-						},
-						InvoiceAt:      time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
-						SettlementMode: productcatalog.InvoiceOnlySettlementMode,
-						FeatureKey:     "feature-1",
-						Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
-							Amount: alpacadecimal.NewFromInt(3),
-						}),
-					},
-					Status: usagebased.StatusCreated,
-					State: usagebased.State{
-						FeatureID: "feature-1",
-					},
-				},
-			},
-			Customer: billing.CustomerOverrideWithDetails{
-				Customer: &customer.Customer{
-					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
-						Namespace: "ns",
-						ID:        "customer-1",
-						Name:      "Customer 1",
-						CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-						UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-					}),
-					Key: lo.ToPtr("cust-1"),
-				},
-			},
-			FeatureMeter: feature.FeatureMeter{
-				Feature: feature.Feature{
-					Namespace: "ns",
-					ID:        "feature-1",
-					Name:      "Feature 1",
-					Key:       "feature-1",
-					MeterID:   lo.ToPtr("meter-1"),
-					CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-					UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-				},
-				Meter: &meter.Meter{
-					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
-						Namespace: "ns",
-						ID:        "meter-1",
-						Name:      "Meter 1",
-						CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-						UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-					}),
-					Key:           "meter-1",
-					Aggregation:   meter.MeterAggregationSum,
-					EventType:     "event.type",
-					ValueProperty: lo.ToPtr("value"),
-				},
-			},
+		input: GetDetailedRatingForUsageInput{
+			Charge:          newDetailedRatingTestCharge(servicePeriod, usagebased.RealizationRuns{}),
 			ServicePeriodTo: servicePeriod.To,
-			StoredAtLT:      time.Date(2025, 2, 2, 0, 0, 0, 0, time.UTC),
+			StoredAtLT:      currentRun.StoredAtLT,
+			Customer:        newDetailedRatingTestCustomer(),
+			FeatureMeter:    newDetailedRatingTestFeatureMeter(),
 		},
 		rater: ratingService,
+	}
+}
+
+func newDetailedRatingTestRun(id string, servicePeriodTo time.Time, meteredQuantity int64) usagebased.RealizationRun {
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	return usagebased.RealizationRun{
+		RealizationRunBase: usagebased.RealizationRunBase{
+			ID: usagebased.RealizationRunID{
+				Namespace: "ns",
+				ID:        id,
+			},
+			ManagedModel:    models.ManagedModel{CreatedAt: now, UpdatedAt: now},
+			FeatureID:       "feature-1",
+			Type:            usagebased.RealizationRunTypeFinalRealization,
+			StoredAtLT:      time.Date(2025, 2, 2, 0, 0, 0, 0, time.UTC),
+			ServicePeriodTo: servicePeriodTo,
+			MeteredQuantity: alpacadecimal.NewFromInt(meteredQuantity),
+			Totals: totals.Totals{
+				Amount: alpacadecimal.NewFromInt(meteredQuantity),
+				Total:  alpacadecimal.NewFromInt(meteredQuantity),
+			},
+		},
+	}
+}
+
+func newDetailedRatingTestCharge(period timeutil.ClosedPeriod, runs usagebased.RealizationRuns) usagebased.Charge {
+	return usagebased.Charge{
+		ChargeBase: usagebased.ChargeBase{
+			ManagedResource: chargesmeta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+				ManagedModel: models.ManagedModel{
+					CreatedAt: period.From,
+					UpdatedAt: period.From,
+				},
+				ID: "charge-1",
+			},
+			Intent: usagebased.Intent{
+				Intent: chargesmeta.Intent{
+					Name:              "usage-charge",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					CustomerID:        "customer-1",
+					Currency:          currencyx.Code("USD"),
+					ServicePeriod:     period,
+					FullServicePeriod: period,
+					BillingPeriod:     period,
+				},
+				InvoiceAt:      period.To,
+				SettlementMode: productcatalog.InvoiceOnlySettlementMode,
+				FeatureKey:     "feature-1",
+				Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(3),
+				}),
+			},
+			Status: usagebased.StatusCreated,
+			State: usagebased.State{
+				FeatureID: "feature-1",
+			},
+		},
+		Realizations: runs,
+	}
+}
+
+func newDetailedRatingTestCustomer() billing.CustomerOverrideWithDetails {
+	return billing.CustomerOverrideWithDetails{
+		Customer: &customer.Customer{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace: "ns",
+				ID:        "customer-1",
+				Name:      "Customer 1",
+				CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			}),
+			Key: lo.ToPtr("cust-1"),
+		},
+	}
+}
+
+func newDetailedRatingTestFeatureMeter() feature.FeatureMeter {
+	return feature.FeatureMeter{
+		Feature: feature.Feature{
+			Namespace: "ns",
+			ID:        "feature-1",
+			Name:      "Feature 1",
+			Key:       "feature-1",
+			MeterID:   lo.ToPtr("meter-1"),
+			CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		Meter: &meter.Meter{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace: "ns",
+				ID:        "meter-1",
+				Name:      "Meter 1",
+				CreatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			}),
+			Key:           "meter-1",
+			Aggregation:   meter.MeterAggregationSum,
+			EventType:     "event.type",
+			ValueProperty: lo.ToPtr("value"),
+		},
 	}
 }
 

--- a/openmeter/billing/charges/usagebased/service/rating/totals.go
+++ b/openmeter/billing/charges/usagebased/service/rating/totals.go
@@ -8,14 +8,16 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 )
 
 type GetTotalsForUsageInput struct {
-	Charge       usagebased.Charge
-	Customer     billing.CustomerOverrideWithDetails
-	FeatureMeter feature.FeatureMeter
-	StoredAtLT   time.Time
+	Charge                  usagebased.Charge
+	Customer                billing.CustomerOverrideWithDetails
+	FeatureMeter            feature.FeatureMeter
+	StoredAtLT              time.Time
+	IgnoreMinimumCommitment bool
 }
 
 func (i GetTotalsForUsageInput) Validate() error {
@@ -39,7 +41,7 @@ func (i GetTotalsForUsageInput) Validate() error {
 }
 
 // GetTotalsForUsage returns the rated totals for the charge at the requested stored-at offset.
-// It avoids generating detailed lines, so prefer it over GetDetailedLinesForUsage when only totals are needed.
+// It avoids generating detailed lines, so prefer it over GetDetailedRatingForUsage when only totals are needed.
 func (s *service) GetTotalsForUsage(ctx context.Context, in GetTotalsForUsageInput) (totals.Totals, error) {
 	if err := in.Validate(); err != nil {
 		return totals.Totals{}, err
@@ -55,10 +57,16 @@ func (s *service) GetTotalsForUsage(ctx context.Context, in GetTotalsForUsageInp
 		return totals.Totals{}, fmt.Errorf("get snapshot quantity: %w", err)
 	}
 
+	opts := []billingrating.GenerateDetailedLinesOption{}
+	if in.IgnoreMinimumCommitment {
+		opts = append(opts, billingrating.WithMinimumCommitmentIgnored())
+	}
+
 	ratingResult, err := s.ratingService.GenerateDetailedLines(usagebased.RateableIntent{
-		Intent:     in.Charge.Intent,
-		MeterValue: snapshotQuantity,
-	})
+		Intent:        in.Charge.Intent,
+		MeterValue:    snapshotQuantity,
+		ServicePeriod: in.Charge.Intent.ServicePeriod,
+	}, opts...)
 	if err != nil {
 		return totals.Totals{}, fmt.Errorf("rating totals: %w", err)
 	}

--- a/openmeter/billing/charges/usagebased/service/run/create.go
+++ b/openmeter/billing/charges/usagebased/service/run/create.go
@@ -17,17 +17,15 @@ import (
 )
 
 type CreateRatedRunInput struct {
-	Charge           usagebased.Charge
-	CustomerOverride billing.CustomerOverrideWithDetails
-	FeatureMeter     feature.FeatureMeter
-	Type             usagebased.RealizationRunType
-	StoredAtLT       time.Time
-	ServicePeriodTo  time.Time
-	LineID           *string
-	// IgnoreMinimumCommitment keeps interim realization runs from booking final-only minimum commitment.
-	IgnoreMinimumCommitment bool
-	CreditAllocation        CreditAllocationMode
-	CurrencyCalculator      currencyx.Calculator
+	Charge             usagebased.Charge
+	CustomerOverride   billing.CustomerOverrideWithDetails
+	FeatureMeter       feature.FeatureMeter
+	Type               usagebased.RealizationRunType
+	StoredAtLT         time.Time
+	ServicePeriodTo    time.Time
+	LineID             *string
+	CreditAllocation   CreditAllocationMode
+	CurrencyCalculator currencyx.Calculator
 }
 
 func (i CreateRatedRunInput) Validate() error {
@@ -86,7 +84,7 @@ func (i CreateRatedRunInput) Validate() error {
 type CreateRatedRunResult struct {
 	Charge usagebased.Charge
 	Run    usagebased.RealizationRun
-	Rating usagebasedrating.GetRatingForUsageResult
+	Rating usagebasedrating.GetDetailedRatingForUsageResult
 }
 
 func (s *Service) createNewRealizationRun(ctx context.Context, charge usagebased.Charge, in usagebased.CreateRealizationRunInput) (usagebased.Charge, error) {
@@ -130,17 +128,15 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 	}
 	in.Charge = chargeWithDetailedLines
 
-	ratingResult, err := s.rater.GetDetailedLinesForUsage(ctx, usagebasedrating.GetDetailedLinesForUsageInput{
-		Charge:                  in.Charge,
-		PriorRuns:               in.Charge.Realizations,
-		Customer:                in.CustomerOverride,
-		FeatureMeter:            in.FeatureMeter,
-		ServicePeriodTo:         in.ServicePeriodTo,
-		StoredAtLT:              in.StoredAtLT,
-		IgnoreMinimumCommitment: in.IgnoreMinimumCommitment,
+	ratingResult, err := s.rater.GetDetailedRatingForUsage(ctx, usagebasedrating.GetDetailedRatingForUsageInput{
+		Charge:          in.Charge,
+		StoredAtLT:      in.StoredAtLT,
+		ServicePeriodTo: in.ServicePeriodTo,
+		Customer:        in.CustomerOverride,
+		FeatureMeter:    in.FeatureMeter,
 	})
 	if err != nil {
-		return CreateRatedRunResult{}, fmt.Errorf("get rating for usage: %w", err)
+		return CreateRatedRunResult{}, fmt.Errorf("get detailed rating for usage: %w", err)
 	}
 
 	runTotals := ratingResult.Totals.RoundToPrecision(in.CurrencyCalculator)
@@ -194,10 +190,8 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 		runTotals.Total = in.CurrencyCalculator.RoundToPrecision(runTotals.Total.Sub(allocationResult.Allocated))
 
 		currentRunBase, err := s.adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
-			ID:              currentRun.ID,
-			StoredAtLT:      mo.Some(in.StoredAtLT),
-			MeteredQuantity: mo.Some(ratingResult.Quantity),
-			Totals:          mo.Some(runTotals),
+			ID:     currentRun.ID,
+			Totals: mo.Some(runTotals),
 		})
 		if err != nil {
 			return CreateRatedRunResult{}, fmt.Errorf("update realization run: %w", err)

--- a/openmeter/billing/charges/usagebased/service/run/detailedline.go
+++ b/openmeter/billing/charges/usagebased/service/run/detailedline.go
@@ -36,7 +36,7 @@ func (s *Service) ensureDetailedLinesLoadedForRating(ctx context.Context, charge
 func mapRatingResultToRunDetailedLines(
 	charge usagebased.Charge,
 	run usagebased.RealizationRun,
-	ratingResult usagebasedrating.GetRatingForUsageResult,
+	ratingResult usagebasedrating.GetDetailedRatingForUsageResult,
 ) usagebased.DetailedLines {
 	return lo.Map(ratingResult.DetailedLines, func(line billingrating.DetailedLine, _ int) usagebased.DetailedLine {
 		period := charge.Intent.ServicePeriod
@@ -83,7 +83,7 @@ func (s *Service) PersistRunDetailedLines(
 	ctx context.Context,
 	charge usagebased.Charge,
 	run usagebased.RealizationRun,
-	ratingResult usagebasedrating.GetRatingForUsageResult,
+	ratingResult usagebasedrating.GetDetailedRatingForUsageResult,
 ) (usagebased.DetailedLines, error) {
 	detailedLines := mapRatingResultToRunDetailedLines(charge, run, ratingResult)
 

--- a/openmeter/billing/charges/usagebased/service/run/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/service/run/detailedline_test.go
@@ -54,7 +54,7 @@ func TestMapRatingResultToRunDetailedLines(t *testing.T) {
 		},
 	}
 
-	in := usagebasedrating.GetRatingForUsageResult{
+	in := usagebasedrating.GetDetailedRatingForUsageResult{
 		GenerateDetailedLinesResult: billingrating.GenerateDetailedLinesResult{
 			DetailedLines: billingrating.DetailedLines{
 				{

--- a/pkg/timeutil/closedperiod.go
+++ b/pkg/timeutil/closedperiod.go
@@ -49,6 +49,11 @@ func (p ClosedPeriod) Overlaps(other ClosedPeriod) bool {
 	}
 }
 
+// Returns true if p contains other (both ends inclusive)
+func (p ClosedPeriod) ContainsPeriodInclusive(other ClosedPeriod) bool {
+	return p.ContainsInclusive(other.From) && p.ContainsInclusive(other.To)
+}
+
 // Returns true if the two periods overlap at any point
 // Returns true if the periods are exactly sequential, e.g.: [1, 2] and [2, 3]
 func (p ClosedPeriod) OverlapsInclusive(other ClosedPeriod) bool {


### PR DESCRIPTION
## Overview

  This PR refactors usage-based charge rating around explicit run snapshot semantics. Detailed rating now treats `ServicePeriodTo` as the current  run boundary and lets the rating layer decide which realization runs are prior runs. A realization is considered prior only when its  `ServicePeriodTo` is before the requested rating boundary, so callers no longer need to mutate the charge by removing the current run before  rating.

  The usage snapshot query model is now clearer: metered quantity is calculated from the charge intent service-period start up to the requested  `ServicePeriodTo`, capped by `StoredAtLT` using an exclusive `stored_at < StoredAtLT` filter. `RateableIntent` now carries the concrete service  period being rated so generated detailed lines and commitment logic operate on the same period boundary as the run.

  Minimum commitment handling is aligned with the run lifecycle. Detailed rating suppresses minimum commitment for interim snapshots and includes  it only for final-period rating. Realtime/current totals also ignore minimum commitment before the charge service period ends and include it at  or after the service-period end.

  The PR also lays groundwork for late-event support by collecting prior run period snapshots in the rating flow. The actual late-event delta  rating is intentionally left as a TODO, with the current implementation preserving existing rating behavior while making the future extension  point explicit.

  ## Testing

  Added usage-based rating tests backed by the mock streaming connector to cover:

  - `ServicePeriodTo` as the exclusive event-time upper bound.
  - `StoredAtLT` as the exclusive stored-at cutoff.
  - Current-run filtering when the current run is already present on the charge.
  - Minimum commitment inclusion/exclusion in `GetTotalsForUsage` using the real billing rating service.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured usage-based billing calculations to improve clarity around how service periods and minimum commitments are handled during rating operations.

* **Tests**
  * Enhanced test coverage for quantity snapshots, service period handling, and minimum commitment inclusion/exclusion scenarios in billing computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->