### PR TITLE
refactor(ledger): correct settlement accounting

### DIFF
--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -67,7 +67,7 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentAuthorized(ctx context.Co
 			CustomerID: customerID,
 			Namespace:  charge.Namespace,
 		},
-		transactions.FundCustomerReceivableTemplate{
+		transactions.AuthorizeCustomerReceivablePaymentTemplate{
 			At:        charge.CreatedAt,
 			Amount:    charge.Intent.CreditAmount,
 			Currency:  charge.Intent.Currency,
@@ -121,7 +121,7 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentSettled(ctx context.Conte
 			CustomerID: customerID,
 			Namespace:  charge.Namespace,
 		},
-		transactions.SettleCustomerReceivablePaymentTemplate{
+		transactions.SettleCustomerReceivableFromPaymentTemplate{
 			At:        charge.CreatedAt,
 			Amount:    charge.Intent.CreditAmount,
 			Currency:  charge.Intent.Currency,
@@ -236,13 +236,13 @@ func (h *creditPurchaseHandler) issueCreditPurchase(ctx context.Context, charge 
 		// Promotional grants settle immediately through wash so the credited FBO balance
 		// does not leave an unsettled receivable behind.
 		templates = append(templates,
-			transactions.FundCustomerReceivableTemplate{
+			transactions.AuthorizeCustomerReceivablePaymentTemplate{
 				At:        charge.CreatedAt,
 				Amount:    charge.Intent.CreditAmount,
 				Currency:  charge.Intent.Currency,
 				CostBasis: &costBasis,
 			},
-			transactions.SettleCustomerReceivablePaymentTemplate{
+			transactions.SettleCustomerReceivableFromPaymentTemplate{
 				At:        charge.CreatedAt,
 				Amount:    charge.Intent.CreditAmount,
 				Currency:  charge.Intent.Currency,

--- a/openmeter/ledger/chargeadapter/creditpurchase_test.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase_test.go
@@ -136,9 +136,9 @@ func TestOnCreditPurchasePaymentAuthorized(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, ref.TransactionGroupID)
 
-	require.True(t, env.sumBalance(t, env.receivableSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(-100)))
-	require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(100)))
-	require.True(t, env.sumBalance(t, env.washSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(-100)))
+	require.True(t, env.sumBalance(t, env.receivableSubAccount(t, costBasis)).Equal(alpacadecimal.Zero))
+	require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(-100)))
+	require.True(t, env.sumBalance(t, env.washSubAccount(t, costBasis)).Equal(alpacadecimal.Zero))
 	require.True(t, env.sumBalance(t, env.fboSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(100)))
 }
 

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -205,8 +205,8 @@ func (h *flatFeeHandler) OnCreditsOnlyUsageAccruedCorrection(ctx context.Context
 	})
 }
 
-// OnFlatFeePaymentAuthorized currently only stages receivable funding from wash
-// for the directly-invoiced portion. Revenue recognition is handled elsewhere.
+// OnFlatFeePaymentAuthorized stages the directly-invoiced receivable as
+// authorized. Revenue recognition is handled elsewhere.
 func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, charge flatfee.Charge) (ledgertransaction.GroupReference, error) {
 	if err := charge.Validate(); err != nil {
 		return ledgertransaction.GroupReference{}, err
@@ -234,7 +234,7 @@ func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, charge flatfee
 			CustomerID: customerID,
 			Namespace:  charge.Namespace,
 		},
-		transactions.FundCustomerReceivableTemplate{
+		transactions.AuthorizeCustomerReceivablePaymentTemplate{
 			At:        charge.Intent.InvoiceAt,
 			Amount:    receivableReplenishment,
 			Currency:  charge.Intent.Currency,
@@ -287,7 +287,7 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, charge flatfee.Ch
 			CustomerID: customerID,
 			Namespace:  charge.Namespace,
 		},
-		transactions.SettleCustomerReceivablePaymentTemplate{
+		transactions.SettleCustomerReceivableFromPaymentTemplate{
 			At:        charge.Intent.InvoiceAt,
 			Amount:    charge.Realizations.AccruedUsage.Totals.Total,
 			Currency:  charge.Intent.Currency,

--- a/openmeter/ledger/chargeadapter/flatfee_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_test.go
@@ -306,7 +306,7 @@ func TestOnFlatFeeStandardInvoiceUsageAccrued(t *testing.T) {
 }
 
 func TestOnFlatFeePaymentAuthorized(t *testing.T) {
-	t.Run("credit_then_invoice stages receivable funding from receivable-backed accrued", func(t *testing.T) {
+	t.Run("credit_then_invoice stages open receivable as authorized", func(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 
 		// First accrue usage: receivable → accrued
@@ -319,16 +319,16 @@ func TestOnFlatFeePaymentAuthorized(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, ref.TransactionGroupID)
 
-		// Receivable is only funded into the authorized staging bucket at authorization time.
-		require.True(t, env.sumBalance(t, env.receivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(-75)))
-		require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(75)))
-		require.True(t, env.sumBalance(t, env.washSubAccount(t)).Equal(alpacadecimal.NewFromInt(-75)))
+		// Authorization only moves the receivable between status buckets.
+		require.True(t, env.sumBalance(t, env.receivableSubAccount(t)).Equal(alpacadecimal.Zero))
+		require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(-75)))
+		require.True(t, env.sumBalance(t, env.washSubAccount(t)).Equal(alpacadecimal.Zero))
 		// No revenue recognition happens here anymore.
 		require.True(t, env.sumBalance(t, env.invoiceAccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(75)))
 		require.True(t, env.sumBalance(t, env.invoiceEarningsSubAccount(t)).Equal(alpacadecimal.Zero))
 	})
 
-	t.Run("credit_then_invoice mixed FBO and receivable only stages receivable funding", func(t *testing.T) {
+	t.Run("credit_then_invoice mixed FBO and receivable only authorizes receivable", func(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 
 		// Fund FBO with 40
@@ -355,9 +355,9 @@ func TestOnFlatFeePaymentAuthorized(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, ref.TransactionGroupID)
 
-		// Receivable funding stays staged until settlement.
-		require.True(t, env.sumBalance(t, env.receivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(-20)))
-		require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(20)))
+		// Cash movement stays deferred until settlement.
+		require.True(t, env.sumBalance(t, env.receivableSubAccount(t)).Equal(alpacadecimal.Zero))
+		require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(-20)))
 		// Existing accrued balances stay untouched until a later recognition flow.
 		require.True(t, env.sumBalance(t, env.creditAccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(40)))
 		require.True(t, env.sumBalance(t, env.invoiceAccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(20)))
@@ -376,9 +376,9 @@ func TestOnFlatFeePaymentAuthorized(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, ref.TransactionGroupID)
 
-		require.True(t, env.sumBalance(t, env.receivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(-30)))
-		require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(75)))
-		require.True(t, env.sumBalance(t, env.washSubAccount(t)).Equal(alpacadecimal.NewFromInt(-75)))
+		require.True(t, env.sumBalance(t, env.receivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(45)))
+		require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(-75)))
+		require.True(t, env.sumBalance(t, env.washSubAccount(t)).Equal(alpacadecimal.Zero))
 		require.True(t, env.sumBalance(t, env.invoiceAccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(30)))
 		require.True(t, env.sumBalance(t, env.invoiceEarningsSubAccount(t)).Equal(alpacadecimal.Zero))
 	})
@@ -412,7 +412,7 @@ func TestOnFlatFeePaymentAuthorized(t *testing.T) {
 }
 
 func TestOnFlatFeePaymentSettled(t *testing.T) {
-	t.Run("credit_then_invoice settles authorized receivable into open receivable", func(t *testing.T) {
+	t.Run("credit_then_invoice settles authorized receivable from wash", func(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 
 		total := alpacadecimal.NewFromInt(40)
@@ -583,13 +583,13 @@ func (e *flatFeeHandlerTestEnv) fundPriority(t *testing.T, priority int, amount 
 			CostBasis:      &costBasis,
 			CreditPriority: &priority,
 		},
-		transactions.FundCustomerReceivableTemplate{
+		transactions.AuthorizeCustomerReceivablePaymentTemplate{
 			At:        e.Now(),
 			Amount:    alpacadecimal.NewFromInt(amount),
 			Currency:  e.Currency,
 			CostBasis: &costBasis,
 		},
-		transactions.SettleCustomerReceivablePaymentTemplate{
+		transactions.SettleCustomerReceivableFromPaymentTemplate{
 			At:        e.Now(),
 			Amount:    alpacadecimal.NewFromInt(amount),
 			Currency:  e.Currency,

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -129,7 +129,7 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 			CustomerID: customerID,
 			Namespace:  input.Charge.Namespace,
 		},
-		transactions.FundCustomerReceivableTemplate{
+		transactions.AuthorizeCustomerReceivablePaymentTemplate{
 			At:        eventTime,
 			Amount:    receivableReplenishment,
 			Currency:  input.Charge.Intent.Currency,
@@ -191,7 +191,7 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 			CustomerID: customerID,
 			Namespace:  input.Charge.Namespace,
 		},
-		transactions.SettleCustomerReceivablePaymentTemplate{
+		transactions.SettleCustomerReceivableFromPaymentTemplate{
 			At:        eventTime,
 			Amount:    input.Run.InvoiceUsage.Totals.Total,
 			Currency:  input.Charge.Intent.Currency,

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -253,10 +253,10 @@ func TestOnUsageBasedPaymentAuthorized(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, ref.TransactionGroupID)
 
-		// Receivable is only funded into the authorized staging bucket at authorization time.
-		require.True(t, env.sumBalance(t, env.receivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(-40)))
-		require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(40)))
-		require.True(t, env.sumBalance(t, env.washSubAccount(t)).Equal(alpacadecimal.NewFromInt(-40)))
+		// Authorization only moves the receivable between status buckets.
+		require.True(t, env.sumBalance(t, env.receivableSubAccount(t)).Equal(alpacadecimal.Zero))
+		require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(-40)))
+		require.True(t, env.sumBalance(t, env.washSubAccount(t)).Equal(alpacadecimal.Zero))
 		// No revenue recognition happens here anymore.
 		require.True(t, env.sumBalance(t, env.invoiceAccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(40)))
 		require.True(t, env.sumBalance(t, env.invoiceEarningsSubAccount(t)).Equal(alpacadecimal.Zero))
@@ -280,7 +280,7 @@ func TestOnUsageBasedPaymentAuthorized(t *testing.T) {
 }
 
 func TestOnUsageBasedPaymentSettled(t *testing.T) {
-	t.Run("credit_then_invoice settles authorized receivable", func(t *testing.T) {
+	t.Run("credit_then_invoice settles authorized receivable from wash", func(t *testing.T) {
 		env := newUsageBasedHandlerTestEnv(t)
 
 		total := alpacadecimal.NewFromInt(25)
@@ -517,13 +517,13 @@ func (e *usageBasedHandlerTestEnv) fundPriority(t *testing.T, priority int, amou
 			CostBasis:      &costBasis,
 			CreditPriority: &priority,
 		},
-		transactions.FundCustomerReceivableTemplate{
+		transactions.AuthorizeCustomerReceivablePaymentTemplate{
 			At:        e.Now(),
 			Amount:    alpacadecimal.NewFromInt(amount),
 			Currency:  e.Currency,
 			CostBasis: &costBasis,
 		},
-		transactions.SettleCustomerReceivablePaymentTemplate{
+		transactions.SettleCustomerReceivableFromPaymentTemplate{
 			At:        e.Now(),
 			Amount:    alpacadecimal.NewFromInt(amount),
 			Currency:  e.Currency,

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -324,12 +324,12 @@ func (e *testEnv) fundOpenReceivableInCurrency(t *testing.T, amount alpacadecima
 			CustomerID: e.CustomerID,
 			Namespace:  e.Namespace,
 		},
-		transactions.FundCustomerReceivableTemplate{
+		transactions.AuthorizeCustomerReceivablePaymentTemplate{
 			At:       e.Now(),
 			Amount:   amount,
 			Currency: currency,
 		},
-		transactions.SettleCustomerReceivablePaymentTemplate{
+		transactions.SettleCustomerReceivableFromPaymentTemplate{
 			At:       e.Now(),
 			Amount:   amount,
 			Currency: currency,

--- a/openmeter/ledger/routingrules/routingrules_test.go
+++ b/openmeter/ledger/routingrules/routingrules_test.go
@@ -123,7 +123,7 @@ func TestDefaultValidator_RejectsMismatchedReceivableAndFBORoute(t *testing.T) {
 	require.ErrorContains(t, err, "ledger routing rule violated")
 }
 
-func TestDefaultValidator_AllowsReceivableAuthorizationStageTransition(t *testing.T) {
+func TestDefaultValidator_AllowsReceivableAuthorizationTransition(t *testing.T) {
 	validator := routingrules.DefaultValidator
 	openStatus := ledger.TransactionAuthorizationStatusOpen
 	status := ledger.TransactionAuthorizationStatusAuthorized
@@ -148,7 +148,7 @@ func TestDefaultValidator_AllowsReceivableAuthorizationStageTransition(t *testin
 	require.NoError(t, err)
 }
 
-func TestDefaultValidator_RejectsReceivableAuthorizationStageWithWrongDirection(t *testing.T) {
+func TestDefaultValidator_RejectsReceivableAuthorizationTransitionWithWrongDirection(t *testing.T) {
 	validator := routingrules.DefaultValidator
 	openStatus := ledger.TransactionAuthorizationStatusOpen
 	status := ledger.TransactionAuthorizationStatusAuthorized

--- a/openmeter/ledger/transactions/correction.go
+++ b/openmeter/ledger/transactions/correction.go
@@ -85,6 +85,10 @@ func transactionTemplateByName(name string) (TransactionTemplate, error) {
 		return FundCustomerReceivableTemplate{}, nil
 	case templateName(SettleCustomerReceivablePaymentTemplate{}):
 		return SettleCustomerReceivablePaymentTemplate{}, nil
+	case templateName(AuthorizeCustomerReceivablePaymentTemplate{}):
+		return AuthorizeCustomerReceivablePaymentTemplate{}, nil
+	case templateName(SettleCustomerReceivableFromPaymentTemplate{}):
+		return SettleCustomerReceivableFromPaymentTemplate{}, nil
 	case templateName(AttributeCustomerAdvanceReceivableCostBasisTemplate{}):
 		return AttributeCustomerAdvanceReceivableCostBasisTemplate{}, nil
 	case templateName(CoverCustomerReceivableTemplate{}):

--- a/openmeter/ledger/transactions/correction_test.go
+++ b/openmeter/ledger/transactions/correction_test.go
@@ -70,11 +70,52 @@ func TestCorrectTransactionDispatchesTemplateStub(t *testing.T) {
 		OriginalTransaction: &correctionTestTransaction{
 			id: models.NamespacedID{Namespace: "ns", ID: "tx"},
 			annotations: ledger.TransactionAnnotations(
-				templateName(FundCustomerReceivableTemplate{}),
+				templateName(SettleCustomerReceivableFromPaymentTemplate{}),
 				ledger.TransactionDirectionForward,
 			),
 		},
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "FundCustomerReceivableTemplate correction is not implemented")
+	require.Contains(t, err.Error(), "SettleCustomerReceivableFromPaymentTemplate correction is not implemented")
+}
+
+func TestCorrectTransactionDispatchesArchivedReceivablePaymentTemplates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		templateName  string
+		expectedError string
+	}{
+		{
+			name:          "legacy fund means settlement funding",
+			templateName:  templateName(FundCustomerReceivableTemplate{}),
+			expectedError: "FundCustomerReceivableTemplate correction is not implemented",
+		},
+		{
+			name:          "legacy settle means authorization status transfer",
+			templateName:  templateName(SettleCustomerReceivablePaymentTemplate{}),
+			expectedError: "SettleCustomerReceivablePaymentTemplate correction is not implemented",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := CorrectTransaction(t.Context(), ResolverDependencies{}, CorrectionInput{
+				At:     time.Now(),
+				Amount: alpacadecimal.NewFromInt(1),
+				OriginalTransaction: &correctionTestTransaction{
+					id: models.NamespacedID{Namespace: "ns", ID: "tx"},
+					annotations: ledger.TransactionAnnotations(
+						tt.templateName,
+						ledger.TransactionDirectionForward,
+					),
+				},
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.expectedError)
+		})
+	}
 }

--- a/openmeter/ledger/transactions/customer.go
+++ b/openmeter/ledger/transactions/customer.go
@@ -143,15 +143,16 @@ func (t IssueCustomerReceivableTemplate) resolve(ctx context.Context, customerID
 	}, nil
 }
 
-// FundCustomerReceivableTemplate funds the authorized receivable sub-account from wash.
-type FundCustomerReceivableTemplate struct {
+// SettleCustomerReceivableFromPaymentTemplate records settled payment funds by
+// clearing authorized receivable from wash.
+type SettleCustomerReceivableFromPaymentTemplate struct {
 	At        time.Time
 	Amount    alpacadecimal.Decimal
 	Currency  currencyx.Code
 	CostBasis *alpacadecimal.Decimal
 }
 
-func (t FundCustomerReceivableTemplate) Validate() error {
+func (t SettleCustomerReceivableFromPaymentTemplate) Validate() error {
 	if t.At.IsZero() {
 		return fmt.Errorf("at is required")
 	}
@@ -173,17 +174,17 @@ func (t FundCustomerReceivableTemplate) Validate() error {
 	return nil
 }
 
-var _ CustomerTransactionTemplate = (FundCustomerReceivableTemplate{})
+var _ CustomerTransactionTemplate = (SettleCustomerReceivableFromPaymentTemplate{})
 
-func (t FundCustomerReceivableTemplate) correct(CorrectionInput) ([]ledger.TransactionInput, error) {
+func (t SettleCustomerReceivableFromPaymentTemplate) correct(CorrectionInput) ([]ledger.TransactionInput, error) {
 	return nil, templateCorrectionNotImplemented(templateName(t))
 }
 
-func (t FundCustomerReceivableTemplate) typeGuard() guard {
+func (t SettleCustomerReceivableFromPaymentTemplate) typeGuard() guard {
 	return true
 }
 
-func (t FundCustomerReceivableTemplate) resolve(ctx context.Context, customerID customer.CustomerID, resolvers ResolverDependencies) (ledger.TransactionInput, error) {
+func (t SettleCustomerReceivableFromPaymentTemplate) resolve(ctx context.Context, customerID customer.CustomerID, resolvers ResolverDependencies) (ledger.TransactionInput, error) {
 	customerAccounts, err := resolvers.AccountService.GetCustomerAccounts(ctx, customerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get customer accounts: %w", err)
@@ -226,15 +227,16 @@ func (t FundCustomerReceivableTemplate) resolve(ctx context.Context, customerID 
 	}, nil
 }
 
-// SettleCustomerReceivablePaymentTemplate moves authorized receivable staging into the open receivable route.
-type SettleCustomerReceivablePaymentTemplate struct {
+// AuthorizeCustomerReceivablePaymentTemplate moves open receivable into the
+// authorized receivable route without moving funds across the external cash boundary.
+type AuthorizeCustomerReceivablePaymentTemplate struct {
 	At        time.Time
 	Amount    alpacadecimal.Decimal
 	Currency  currencyx.Code
 	CostBasis *alpacadecimal.Decimal
 }
 
-func (t SettleCustomerReceivablePaymentTemplate) Validate() error {
+func (t AuthorizeCustomerReceivablePaymentTemplate) Validate() error {
 	if t.At.IsZero() {
 		return fmt.Errorf("at is required")
 	}
@@ -256,17 +258,17 @@ func (t SettleCustomerReceivablePaymentTemplate) Validate() error {
 	return nil
 }
 
-func (t SettleCustomerReceivablePaymentTemplate) typeGuard() guard {
+func (t AuthorizeCustomerReceivablePaymentTemplate) typeGuard() guard {
 	return true
 }
 
-var _ CustomerTransactionTemplate = (SettleCustomerReceivablePaymentTemplate{})
+var _ CustomerTransactionTemplate = (AuthorizeCustomerReceivablePaymentTemplate{})
 
-func (t SettleCustomerReceivablePaymentTemplate) correct(CorrectionInput) ([]ledger.TransactionInput, error) {
+func (t AuthorizeCustomerReceivablePaymentTemplate) correct(CorrectionInput) ([]ledger.TransactionInput, error) {
 	return nil, templateCorrectionNotImplemented(templateName(t))
 }
 
-func (t SettleCustomerReceivablePaymentTemplate) resolve(ctx context.Context, customerID customer.CustomerID, resolvers ResolverDependencies) (ledger.TransactionInput, error) {
+func (t AuthorizeCustomerReceivablePaymentTemplate) resolve(ctx context.Context, customerID customer.CustomerID, resolvers ResolverDependencies) (ledger.TransactionInput, error) {
 	customerAccounts, err := resolvers.AccountService.GetCustomerAccounts(ctx, customerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get customer accounts: %w", err)

--- a/openmeter/ledger/transactions/customer_test.go
+++ b/openmeter/ledger/transactions/customer_test.go
@@ -45,7 +45,7 @@ func TestIssueCustomerReceivableTemplate_DefaultPriority(t *testing.T) {
 	require.True(t, env.SumBalance(t, env.ReceivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(-15)))
 }
 
-func TestFundCustomerReceivableTemplate(t *testing.T) {
+func TestAuthorizeCustomerReceivablePaymentTemplate(t *testing.T) {
 	env := newTransactionsTestEnv(t)
 
 	env.resolveAndCommit(
@@ -59,7 +59,7 @@ func TestFundCustomerReceivableTemplate(t *testing.T) {
 
 	inputs := env.resolveAndCommit(
 		t,
-		FundCustomerReceivableTemplate{
+		AuthorizeCustomerReceivablePaymentTemplate{
 			At:       env.Now(),
 			Amount:   alpacadecimal.NewFromInt(40),
 			Currency: env.Currency,
@@ -67,9 +67,9 @@ func TestFundCustomerReceivableTemplate(t *testing.T) {
 	)
 	require.Len(t, inputs, 1)
 
-	require.True(t, env.SumBalance(t, env.ReceivableSubAccount(t)).Equal(alpacadecimal.NewFromInt(-40)))
-	require.True(t, env.SumBalance(t, env.ReceivableSubAccountWithStatus(t, ledger.TransactionAuthorizationStatusAuthorized)).Equal(alpacadecimal.NewFromInt(40)))
-	require.True(t, env.SumBalance(t, env.WashSubAccount(t)).Equal(alpacadecimal.NewFromInt(-40)))
+	require.True(t, env.SumBalance(t, env.ReceivableSubAccount(t)).Equal(alpacadecimal.Zero))
+	require.True(t, env.SumBalance(t, env.ReceivableSubAccountWithStatus(t, ledger.TransactionAuthorizationStatusAuthorized)).Equal(alpacadecimal.NewFromInt(-40)))
+	require.True(t, env.SumBalance(t, env.WashSubAccount(t)).Equal(alpacadecimal.Zero))
 	require.True(t, env.SumBalance(t, env.FBOSubAccount(t, ledger.DefaultCustomerFBOPriority)).Equal(alpacadecimal.NewFromInt(40)))
 }
 
@@ -102,7 +102,7 @@ func TestCoverCustomerReceivableTemplate(t *testing.T) {
 	require.True(t, env.SumBalance(t, env.ReceivableSubAccount(t)).Equal(alpacadecimal.Zero))
 }
 
-func TestSettleCustomerReceivablePaymentTemplate(t *testing.T) {
+func TestSettleCustomerReceivableFromPaymentTemplate(t *testing.T) {
 	env := newTransactionsTestEnv(t)
 
 	env.resolveAndCommit(
@@ -112,7 +112,7 @@ func TestSettleCustomerReceivablePaymentTemplate(t *testing.T) {
 			Amount:   alpacadecimal.NewFromInt(40),
 			Currency: env.Currency,
 		},
-		FundCustomerReceivableTemplate{
+		AuthorizeCustomerReceivablePaymentTemplate{
 			At:       env.Now(),
 			Amount:   alpacadecimal.NewFromInt(40),
 			Currency: env.Currency,
@@ -121,7 +121,7 @@ func TestSettleCustomerReceivablePaymentTemplate(t *testing.T) {
 
 	inputs := env.resolveAndCommit(
 		t,
-		SettleCustomerReceivablePaymentTemplate{
+		SettleCustomerReceivableFromPaymentTemplate{
 			At:       env.Now(),
 			Amount:   alpacadecimal.NewFromInt(40),
 			Currency: env.Currency,
@@ -144,12 +144,6 @@ func TestAttributeCustomerAdvanceReceivableCostBasisTemplate(t *testing.T) {
 			At:       env.Now(),
 			Amount:   alpacadecimal.NewFromInt(40),
 			Currency: env.Currency,
-		},
-		FundCustomerReceivableTemplate{
-			At:        env.Now(),
-			Amount:    alpacadecimal.NewFromInt(40),
-			Currency:  env.Currency,
-			CostBasis: &purchasedCostBasis,
 		},
 	)
 

--- a/openmeter/ledger/transactions/legacy.go
+++ b/openmeter/ledger/transactions/legacy.go
@@ -1,0 +1,184 @@
+package transactions
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+)
+
+// FundCustomerReceivableTemplate is an archived template name kept for
+// persisted ledger annotations. New payment flows should use
+// SettleCustomerReceivableFromPaymentTemplate.
+//
+// Original semantics: funds the authorized receivable sub-account from wash.
+type FundCustomerReceivableTemplate struct {
+	At        time.Time
+	Amount    alpacadecimal.Decimal
+	Currency  currencyx.Code
+	CostBasis *alpacadecimal.Decimal
+}
+
+func (t FundCustomerReceivableTemplate) Validate() error {
+	if t.At.IsZero() {
+		return fmt.Errorf("at is required")
+	}
+
+	if err := ledger.ValidateTransactionAmount(t.Amount); err != nil {
+		return fmt.Errorf("amount: %w", err)
+	}
+
+	if err := ledger.ValidateCurrency(t.Currency); err != nil {
+		return fmt.Errorf("currency: %w", err)
+	}
+
+	if t.CostBasis != nil {
+		if err := ledger.ValidateCostBasis(*t.CostBasis); err != nil {
+			return fmt.Errorf("cost basis: %w", err)
+		}
+	}
+
+	return nil
+}
+
+var _ CustomerTransactionTemplate = (FundCustomerReceivableTemplate{})
+
+func (t FundCustomerReceivableTemplate) correct(CorrectionInput) ([]ledger.TransactionInput, error) {
+	return nil, templateCorrectionNotImplemented(templateName(t))
+}
+
+func (t FundCustomerReceivableTemplate) typeGuard() guard {
+	return true
+}
+
+func (t FundCustomerReceivableTemplate) resolve(ctx context.Context, customerID customer.CustomerID, resolvers ResolverDependencies) (ledger.TransactionInput, error) {
+	customerAccounts, err := resolvers.AccountService.GetCustomerAccounts(ctx, customerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get customer accounts: %w", err)
+	}
+
+	rec, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
+		Currency:                       t.Currency,
+		CostBasis:                      t.CostBasis,
+		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusAuthorized,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get receivable sub-account: %w", err)
+	}
+
+	businessAccounts, err := resolvers.AccountService.GetBusinessAccounts(ctx, customerID.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get business accounts: %w", err)
+	}
+
+	wash, err := businessAccounts.WashAccount.GetSubAccountForRoute(ctx, ledger.BusinessRouteParams{
+		Currency:  t.Currency,
+		CostBasis: t.CostBasis,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get wash sub-account: %w", err)
+	}
+
+	return &TransactionInput{
+		bookedAt: t.At,
+		entryInputs: []*EntryInput{
+			{
+				address: wash.Address(),
+				amount:  t.Amount.Neg(),
+			},
+			{
+				address: rec.Address(),
+				amount:  t.Amount,
+			},
+		},
+	}, nil
+}
+
+// SettleCustomerReceivablePaymentTemplate is an archived template name kept for
+// persisted ledger annotations. New payment flows should use
+// AuthorizeCustomerReceivablePaymentTemplate.
+//
+// Original semantics: moves authorized receivable staging into the open
+// receivable route.
+type SettleCustomerReceivablePaymentTemplate struct {
+	At        time.Time
+	Amount    alpacadecimal.Decimal
+	Currency  currencyx.Code
+	CostBasis *alpacadecimal.Decimal
+}
+
+func (t SettleCustomerReceivablePaymentTemplate) Validate() error {
+	if t.At.IsZero() {
+		return fmt.Errorf("at is required")
+	}
+
+	if err := ledger.ValidateTransactionAmount(t.Amount); err != nil {
+		return fmt.Errorf("amount: %w", err)
+	}
+
+	if err := ledger.ValidateCurrency(t.Currency); err != nil {
+		return fmt.Errorf("currency: %w", err)
+	}
+
+	if t.CostBasis != nil {
+		if err := ledger.ValidateCostBasis(*t.CostBasis); err != nil {
+			return fmt.Errorf("cost basis: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (t SettleCustomerReceivablePaymentTemplate) typeGuard() guard {
+	return true
+}
+
+var _ CustomerTransactionTemplate = (SettleCustomerReceivablePaymentTemplate{})
+
+func (t SettleCustomerReceivablePaymentTemplate) correct(CorrectionInput) ([]ledger.TransactionInput, error) {
+	return nil, templateCorrectionNotImplemented(templateName(t))
+}
+
+func (t SettleCustomerReceivablePaymentTemplate) resolve(ctx context.Context, customerID customer.CustomerID, resolvers ResolverDependencies) (ledger.TransactionInput, error) {
+	customerAccounts, err := resolvers.AccountService.GetCustomerAccounts(ctx, customerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get customer accounts: %w", err)
+	}
+
+	authorizedReceivable, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
+		Currency:                       t.Currency,
+		CostBasis:                      t.CostBasis,
+		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusAuthorized,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get authorized receivable sub-account: %w", err)
+	}
+
+	openReceivable, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
+		Currency:                       t.Currency,
+		CostBasis:                      t.CostBasis,
+		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get receivable sub-account: %w", err)
+	}
+
+	return &TransactionInput{
+		bookedAt: t.At,
+		entryInputs: []*EntryInput{
+			{
+				address: authorizedReceivable.Address(),
+				amount:  t.Amount.Neg(),
+			},
+			{
+				address: openReceivable.Address(),
+				amount:  t.Amount,
+			},
+		},
+	}, nil
+}

--- a/openmeter/ledger/transactions/testenv_test.go
+++ b/openmeter/ledger/transactions/testenv_test.go
@@ -84,13 +84,13 @@ func (e *transactionsTestEnv) fundPriorityWithCostBasis(t *testing.T, priority i
 			CostBasis:      costBasis,
 			CreditPriority: &priority,
 		},
-		FundCustomerReceivableTemplate{
+		AuthorizeCustomerReceivablePaymentTemplate{
 			At:        e.Now(),
 			Amount:    alpacadecimal.NewFromInt(amount),
 			Currency:  e.Currency,
 			CostBasis: costBasis,
 		},
-		SettleCustomerReceivablePaymentTemplate{
+		SettleCustomerReceivableFromPaymentTemplate{
 			At:        e.Now(),
 			Amount:    alpacadecimal.NewFromInt(amount),
 			Currency:  e.Currency,

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -486,7 +486,8 @@ func (s *CreditsTestSuite) TestFlatFeeCreditThenInvoiceSanity() {
 
 		costBasis := alpacadecimal.NewFromFloat(0.5)
 		s.Equal(payment.StatusAuthorized, updatedCharge.Realizations.ExternalPaymentSettlement.Status)
-		s.Equal(float64(-50), s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusOpen).InexactFloat64())
+		s.Equal(float64(0), s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusOpen).InexactFloat64())
+		s.Equal(float64(-50), s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusAuthorized).InexactFloat64())
 	})
 
 	s.Run("the customer settles the credit purchase payment", func() {
@@ -679,10 +680,10 @@ func (s *CreditsTestSuite) TestFlatFeeCreditThenInvoiceSanity() {
 
 		assertDelta("promo receivable after payment authorization", flatFeeStart.promoReceivable, alpacadecimal.Zero, s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen))
 		assertDelta("external receivable after payment authorization", flatFeeStart.externalReceivable, alpacadecimal.Zero, s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&externalCostBasis), ledger.TransactionAuthorizationStatusOpen))
-		assertDelta("total open receivable after payment authorization", flatFeeStart.totalOpenReceivable, alpacadecimal.NewFromInt(-20), s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen))
-		assertDelta("authorized receivable after payment authorization", flatFeeStart.authorizedReceivable, alpacadecimal.NewFromInt(20), s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized))
+		assertDelta("total open receivable after payment authorization", flatFeeStart.totalOpenReceivable, alpacadecimal.Zero, s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen))
+		assertDelta("authorized receivable after payment authorization", flatFeeStart.authorizedReceivable, alpacadecimal.NewFromInt(-20), s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized))
 		assertDelta("accrued after payment authorization", flatFeeStart.accrued, alpacadecimal.NewFromInt(100), s.mustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()))
-		assertDelta("total wash after payment authorization", flatFeeStart.totalWash, alpacadecimal.NewFromInt(-20), s.mustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()))
+		assertDelta("total wash after payment authorization", flatFeeStart.totalWash, alpacadecimal.Zero, s.mustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()))
 		assertDelta("external wash after payment authorization", flatFeeStart.externalWash, alpacadecimal.Zero, s.mustWashBalance(ns, USD, mo.Some(&externalCostBasis)))
 		assertDelta("earnings after payment authorization", flatFeeStart.earnings, alpacadecimal.Zero, s.mustEarningsBalance(ns, USD))
 	})
@@ -912,11 +913,11 @@ func (s *CreditsTestSuite) TestUsageBasedCreditThenInvoicePaymentLifecycle() {
 		s.Nil(updatedCharge.Realizations[0].Payment.Settled)
 
 		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.Zero))
-		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-7.5)))
-		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.NewFromFloat(-7.5)))
-		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.NewFromFloat(7.5)))
-		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.NewFromFloat(7.5)))
-		s.True(s.mustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()).Equal(alpacadecimal.NewFromFloat(-12.5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.Zero))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.Zero))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.NewFromFloat(-7.5)))
+		s.True(s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.NewFromFloat(-7.5)))
+		s.True(s.mustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()).Equal(alpacadecimal.NewFromFloat(-5)))
 	})
 
 	s.Run("the payment is settled and the charge reaches final", func() {
@@ -1054,7 +1055,8 @@ func (s *CreditsTestSuite) TestFlatFeeCreditOnlySanity() {
 
 		costBasis := alpacadecimal.NewFromFloat(0.5)
 		s.Equal(payment.StatusAuthorized, updatedCharge.Realizations.ExternalPaymentSettlement.Status)
-		s.Equal(float64(-50), s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusOpen).InexactFloat64())
+		s.Equal(float64(0), s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusOpen).InexactFloat64())
+		s.Equal(float64(-50), s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusAuthorized).InexactFloat64())
 	})
 
 	s.Run("the customer settles the credit purchase payment", func() {
@@ -1294,9 +1296,10 @@ func (s *CreditsTestSuite) TestFlatFeeCreditOnlySanity() {
 		s.NoError(err)
 		s.Equal(payment.StatusAuthorized, updatedCharge.Realizations.ExternalPaymentSettlement.Status)
 
-		// Authorization now only stages settlement funding; attribution already happened during purchase initiation.
+		// Authorization only moves the purchased receivable into the authorized bucket;
+		// attribution already happened during purchase initiation.
 		s.True(
-			s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&externalCostBasis), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.NewFromInt(50)),
+			s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&externalCostBasis), ledger.TransactionAuthorizationStatusAuthorized).Equal(alpacadecimal.NewFromInt(-50)),
 			"the purchased amount should be visible in the exact authorized receivable route before settlement",
 		)
 		s.True(
@@ -1311,7 +1314,7 @@ func (s *CreditsTestSuite) TestFlatFeeCreditOnlySanity() {
 		s.NoError(err)
 		s.Equal(payment.StatusSettled, updatedCharge.Realizations.ExternalPaymentSettlement.Status)
 
-		// Settlement is now just the normal authorized -> open move in the purchased cost-basis bucket.
+		// Settlement is the cash movement from wash that clears the authorized receivable.
 		// The earlier attribution stays intact, and the purchased receivable fully nets out here.
 		s.True(
 			s.mustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen).Equal(alpacadecimal.Zero),


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

- Authorization now only moves receivable from open to authorized.
- Settlement now records the actual cash movement from wash to authorized receivable.
- Adds new transaction templates for the corrected semantics:
  - AuthorizeCustomerReceivablePaymentTemplate
  - SettleCustomerReceivableFromPaymentTemplate
- Keeps old transaction template names archived in legacy.go with their original implementations, so persisted annotations remain resolvable without reusing old names for new behavior.

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Refactored payment authorization and settlement workflows for credit purchases, flat fees, and usage-based charges to improve ledger accuracy and account balance tracking.
  * Enhanced receivable status transitions during payment processing to provide more granular tracking of authorized and settled amounts.

* **Chores**
  * Reorganized internal ledger transaction templates for better maintainability; legacy templates archived with backward compatibility preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->