### PR TITLE
test: create natural language e2e skill and example

### DIFF
--- a/.agents/skills/e2e-nl/SKILL.md
+++ b/.agents/skills/e2e-nl/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: e2e-nl
+description: Generate a natural-language, runner-agnostic e2e test specification from a v3 API endpoint's source files (TypeSpec + handler + domain validator + converter). The output is a Markdown scenario spec that downstream skills translate into Go, Playwright, .http, Hurl, or other runners. Use this skill whenever someone wants to spec, document, or capture API contract behavior for an endpoint family before writing tests — including phrasings like "write an NL spec", "describe the contract for endpoint X", "what scenarios should we test on /foo", or "I want a test plan for the bar API". Reach for it especially when an endpoint has no e2e coverage yet, or when the user wants a runner-neutral plan that multiple downstream generators can consume.
+user-invocable: true
+argument-hint: "[endpoint family | path to TypeSpec file] [optional: scenario id]"
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
+---
+
+# E2E Natural-Language Spec Generator
+
+You produce a natural-language e2e test specification for an API
+endpoint from its code. Output format follows `references/format.md`,
+modeled on the worked examples in `references/examples.md`.
+
+This skill is **step 1 in a pipeline**:
+
+```text
+endpoint code → [e2e-nl] → NL spec → [/e2e or other generator] → executable tests
+```
+
+Your output feeds the next skill. Describe behavior unambiguously
+enough that a downstream generator can emit tests from the NL spec
+alone.
+
+## Before you start — read these
+
+1. `references/format.md` — format rules, vocabulary, contract.
+2. `references/examples.md` — one worked scenario per shape class.
+
+Both files live alongside this SKILL.md inside the skill directory.
+They are the contract. If either is missing, stop and tell the user
+— the skill depends on them and shouldn't improvise.
+
+`e2e_spec_plan.md` (top-level) is the broader pipeline tracker. Read
+it only if the user references pipeline status, open questions, or
+"where we left off." It isn't required for drafting scenarios.
+
+## The consumer-perspective rule
+
+**The NL spec describes API-observable behavior only.** You read up to
+four internal files to understand *what* the API does; you never write
+*how* it does it into the spec.
+
+Concretely:
+
+- ✅ "Posting a plan with `currency: 'ZZZ'` returns 400 with domain
+  code `currency_invalid`." — Consumer-observable.
+- ❌ "The handler calls `validateCurrency()` which iterates ISO-4217
+  codes." — Implementation.
+- ✅ "A plan with a phase that has no rate cards is accepted at create
+  and surfaces `plan_phase_has_no_rate_cards` on GET." — Visible
+  validation moment.
+- ❌ "The service defers rate-card validation to `Plan.Validate()` at
+  publish." — Implementation.
+
+If a behavior is only visible through logs, DB state, or internal
+telemetry, it is **not** in scope. The reader of a generated test —
+and any future generator skill — should be able to verify every
+assertion by issuing HTTP requests and reading responses.
+
+## Inputs — the four source files
+
+Given an endpoint family (e.g. "features") or a TypeSpec path, locate:
+
+1. **TypeSpec** — `api/spec/packages/aip/src/<family>/` (v3) or
+   `api/spec/packages/legacy/src/<family>/` (v1).
+   *Gives:* request/response types, path + method, status codes, error
+   response shapes.
+2. **Handler** — `api/v3/handlers/<family>/` (v3) or
+   `api/handlers/<family>/` (v1).
+   *Gives:* which validators fire, which error shape is used
+   (`HandleIssueIfHTTPStatusKnown` → domain code, `BaseAPIError` →
+   detail substring, schema binder → invalid_parameters rule).
+3. **Domain validator / rules** — `openmeter/<family>/`. Look for
+   `Validate()`, `Publishable()`, validation error codes, predicate
+   packages.
+   *Gives:* the validation moment (create-time vs. GET-time vs.
+   publish-time) and the domain-code vocabulary.
+4. **Converter** — `convert.go` next to the handler.
+   *Gives:* fields that map 1:1 vs. drop vs. reshape; hints at fields
+   that deserve dedicated scenarios.
+
+Report the four paths you found and the primary endpoint(s) under
+test. If one is missing or ambiguous, ask before proceeding — don't
+guess.
+
+## Workflow — three modes
+
+The skill takes an optional `[scenario id]` argument and dispatches
+based on whether a `e2e/specs/<family>.md` file already exists:
+
+| Family file | Scenario id | Action |
+|---|---|---|
+| absent | not given | Draft the **scenario list + Baselines + first p0 scenario** to seed the file. |
+| absent | given | Draft the **scenario list + Baselines + the named scenario**. The scenario list is still required even when a specific scenario is requested first — it's the index. |
+| present | given | Append **only** the named `## Scenario: <id>` section. Do not modify the list, Baselines, or prior scenarios. |
+| present | not given | Ask the user which scenario id to draft next. The list shows what's available. |
+
+When seeding a new family file:
+
+1. Read the four source files.
+2. Extract observable behavior:
+   - Endpoints (method + path).
+   - Request / response types.
+   - Status codes (2xx and 4xx).
+   - Error shapes (`extensions.validationErrors[].code` /
+     `problem.detail` substring / `invalid_parameters[].rule`).
+   - Lifecycle transitions and validation moments.
+   - Matrix branch points (status × status, type × quantity, etc.).
+   - Uniqueness / conflict constraints.
+3. Produce a **scenario list**. Plain bullets, no checkboxes. Format
+   per `references/format.md` ("Scenario list conventions"):
+   ```text
+   - `<id>` — <one-line intent> — shape: <class> — priority: <p0|p1|p2>
+   ```
+   Append `NEEDS-VERIFY: <reason>` for any candidate the code doesn't
+   fully pin down.
+4. Define any **new Baselines** the scenarios will reference. Reuse
+   no baselines from another family file — each family file is
+   self-contained (see Baselines below).
+5. Draft the first scenario in full (per the dispatch table above).
+6. Return to the user with the list + the seeded scenario.
+
+## Done criterion
+
+A family file is **minimally testable** once its `p0` scenarios are
+drafted. p1 scenarios are core validation; drafting them is recommended
+but the user picks the cadence. p2 scenarios are edge cases; draft them
+when a real run hits one.
+
+Don't draft scenarios indefinitely on your own — after each draft,
+hand control back to the user with the list of remaining scenarios,
+not a freshly-drafted one.
+
+## Shape-class signals in the code
+
+| Shape | Code signal | Example |
+|---|---|---|
+| **lifecycle** | Create + update + publish/archive/delete handlers; domain has a `Status` enum and `effective_from/to` semantics. | Plan lifecycle. |
+| **draft-with-errors** | `Validate()` vs. `Publishable()` split; `validation_errors` on the response body. | `plan_invalid_draft_lifecycle`. |
+| **matrix** | Rule branches on two or more state variables. | Attach `plan.status × addon.status`. |
+| **single-request** | One-shot rule at create-time; no lifecycle follow-up. | Invalid currency. |
+
+When in doubt, start with `single-request` and promote if multi-step
+state turns out to be needed.
+
+### Worked dispatch — picking the shape
+
+> The features handler rejects a `feature` whose `key` parses as a
+> ULID. The validator returns immediately at create-time; there is no
+> draft state, no second moment. There is no matrix here either —
+> only one variable (the `key`) decides. → `single-request`.
+>
+> The plans handler accepts a plan with an empty-rate-card phase at
+> create, but `Validate()` populates `validation_errors` on GET and
+> `Publishable()` rejects at publish. → `draft-with-errors` (the
+> three-moment template).
+>
+> Attaching a plan-addon checks both `plan.status` and `addon.status`
+> and rejects every disallowed combination with a different detail
+> substring. Two state variables, several rows. → `matrix`.
+
+## Baselines
+
+Each `e2e/specs/<family>.md` defines its **own** Baselines section. Do
+not import baselines from another family file. The shapes a feature
+spec uses (`CreateFeatureRequest`, `BillingFeatureManualUnitCost`)
+have nothing to do with the shapes a plan spec uses
+(`CreatePlanRequest`, `BillingRateCard`), even when the names rhyme.
+Cross-file baseline imports couple specs together and break the
+"one file per family" rule.
+
+When the endpoint family needs an object shape **not** yet in its
+file's Baselines section, produce **both**:
+
+1. **A proposed new Baseline block** for that file's Baselines
+   section. Name the API schema type (`CreateFeatureRequest`,
+   `Meter`, etc.) and list field defaults.
+2. **An inlined shape** in the scenario's Fixtures block, so the
+   scenario reads standalone.
+
+Present both alternatives to the user and let them pick. Rule of
+thumb: shapes used by ≥2 scenarios in the family earn a Baseline;
+one-offs stay inlined.
+
+See `references/examples.md` for a worked Baselines section.
+
+## Output file
+
+Default path: `e2e/specs/<family>.md`, co-located with the e2e tests
+in the project (e.g. `e2e/specs/features.md`). If the user specifies
+a different path, use that. Create the `e2e/specs/` directory if it
+doesn't exist.
+
+- **If the file doesn't exist** — create with the preamble,
+  scenario list, Baselines section (only with new baselines added
+  here), and the first drafted scenario.
+- **If the file exists** — append only the named `## Scenario: <id>`
+  section. Do not modify the list, Baselines, or prior scenarios.
+  If the new scenario needs an object shape that isn't yet a
+  Baseline, surface that as a separate decision for the user
+  (per the Baselines section above): either inline the shape in the
+  scenario's Fixtures block, or propose a new Baseline as a separate
+  edit. Never add a Baseline silently during append-mode.
+
+Always include a short preamble above the list:
+
+```markdown
+# E2E Scenario Specifications — <Family>
+
+Natural-language, runner-agnostic description of e2e scenarios for
+the `<family>` endpoint(s). Each `## Scenario` describes wire-level
+behavior (HTTP verb, path, status code, response shape,
+`problem+json` error shape) that any downstream runner can translate
+to an executable test.
+
+See the `e2e-nl` skill (`.agents/skills/e2e-nl/`) for format rules
+(`references/format.md`) and worked examples (`references/examples.md`).
+```
+
+## Things to avoid
+
+**Runner-agnosticism — the central rule.** The spec must read the
+same whether the downstream generator is Go, Playwright, `.http`,
+Hurl, or something that doesn't exist yet. Violations:
+
+- **No runner-specific names.** `TestV3<…>`, `validPlanRequest`,
+  `uniqueKey`, `v3helpers_test.go`, `test.describe`, `.http` section
+  markers — none of this belongs in the spec.
+- **No runner-specific construction mechanics.**
+  `FromBillingPriceFlat`, `nullable.NewNullableWithValue`,
+  `new Request(...)` — describe the JSON body shape; every generator
+  handles its own plumbing.
+- **No assumptions about client lifecycle, isolation, parallelism,
+  or fixture cleanup.** Those are runner choices. "Fresh fixtures
+  per row" is an observable behavior; "fresh client per row" is
+  not.
+
+**Consumer perspective:**
+
+- **No internal package paths, service methods, ent queries.** Read
+  them to understand behavior; never write them into the spec.
+- **No inferred behavior ungrounded in the code.** Flag uncertainty
+  with `NEEDS-VERIFY` and probe against a live server — do not
+  fabricate rules.
+
+**Output discipline:**
+
+- **Every 4xx step names a validation moment** (create-time /
+  GET-time / publish-time / update-time) and an error shape (domain
+  code / detail substring / schema rule). Both vocabularies are in
+  `references/format.md`.
+- **Do not modify previously drafted scenarios on follow-up
+  invocations.** Append only. A scenario's presence is its drafted
+  state; there is no checkbox to tick.
+
+## Smoke test
+
+Run the skill against a known-covered endpoint family (plans) and
+diff the produced spec against the worked examples in
+`references/examples.md`. Large overlap confirms grounding;
+systematic differences surface gaps in either the skill or the
+reference.
+
+## Handoff
+
+Once an NL spec is complete (all p0 scenarios drafted, p1/p2 as
+desired), any number of downstream generator skills can consume it:
+
+- The existing `/e2e` skill (`.agents/skills/e2e/SKILL.md`) emits Go
+  e2e tests.
+- Future skills may emit Playwright, `.http`, Hurl, or other runners
+  from the same source file.
+
+The NL spec is the contract between this skill and all consumers —
+no direct interaction, no runner-specific fields added here. If a
+downstream skill needs information the spec doesn't carry (e.g.,
+"where do generated tests live for runner X"), that's the
+downstream skill's business to resolve by its own convention, not
+this skill's to bake in.

--- a/.agents/skills/e2e-nl/references/examples.md
+++ b/.agents/skills/e2e-nl/references/examples.md
@@ -1,0 +1,354 @@
+# Worked Examples — One Per Shape Class
+
+This reference shows each of the four shape classes drafted as a real
+NL scenario. The product-catalog domain provides the context, but the
+patterns generalize to any v3 endpoint family.
+
+Use these as templates when drafting new scenarios. Match the shape
+class to the kind of behavior you're pinning, then mirror the
+structure (Fixtures / Steps / Notes) with the same density of detail.
+
+| Shape | Example | When to reach for it |
+|---|---|---|
+| `lifecycle` | `plan_lifecycle` | A primary CRUD flow with status transitions and side effects (`effective_from`, `archived_at`, …) on each step. |
+| `draft-with-errors` | `plan_invalid_draft_lifecycle` | Defects accepted at create, surfaced on GET via `validation_errors`, rejected at publish. The canonical three-moment flow. |
+| `single-request` | `plan_invalid_currency` | One request, one rule, one assertion. The default for a validation rule that fires at create-time only. |
+| `matrix` | `plan_addon_attach_status_matrix` | A rule that branches on two or more state variables; one row per combination. |
+
+When in doubt, start with `single-request` and promote if multi-step
+state turns out to be needed. The matrix shape is for genuinely
+combinatorial rules — don't reach for it just because there are
+several similar one-shot validations.
+
+---
+
+## Baselines (illustrative)
+
+Named object shapes the example scenarios reference. Each baseline
+names the **API schema type** it instantiates — these are TypeSpec
+types under `api/spec/packages/aip/src/productcatalog/` and appear in
+`api/openapi.yaml` as the stable cross-language contract.
+
+These specific baselines belong to the product-catalog domain. Other
+families (features, meters, …) define their own. The pattern — name
+the API schema type, list field defaults, allow per-scenario
+mutation — is what generalizes.
+
+Keys (`key`) are unique per run. The uniqueness strategy is a runner
+concern, not a spec concern — any suffix that survives re-runs
+against a shared DB is fine.
+
+### Baseline plan — `CreatePlanRequest`
+
+- `key`: unique
+- `name`: `"Test Plan"`
+- `currency`: `"USD"`
+- `billing_cadence`: `"P1M"`
+- `phases`: a list containing one **Baseline phase** (`last = true`)
+
+### Baseline phase — `BillingPlanPhase`
+
+Parameter `last` (boolean) controls the duration:
+
+- `key`: unique
+- `name`: `"Test Phase"`
+- `duration`: `null` when `last = true`; `"P1M"` otherwise — non-last
+  phases must be bounded.
+- `rate_cards`: a list containing one **Baseline flat rate card**
+
+### Baseline flat rate card — `BillingRateCard` with `BillingPriceFlat`
+
+- `key`: unique
+- `name`: `"Test Rate Card"`
+- `price`: `BillingPriceFlat { type: "flat", amount: "10" }`
+- `billing_cadence`: `"P1M"`
+- `payment_term`: `"in_advance"`
+
+### Baseline addon — `CreateAddonRequest`
+
+- `key`: unique
+- `name`: `"Test Addon"`
+- `currency`: `"USD"`
+- `instance_type`: `"single"`
+- `rate_cards`: a list containing one **Baseline flat rate card**
+
+### Baseline plan-addon attach — `CreatePlanAddonRequest`
+
+- `name`: `"Test Plan Addon"`
+- `addon`: `{ id: {addon.id} }` (referencing the addon bound by the
+  scenario's fixtures)
+- `from_plan_phase`: `{plan.phases[0].key}` (or whichever phase key
+  the scenario targets)
+
+---
+
+## Example: `lifecycle` shape — Plan lifecycle
+
+```yaml
+id: plan_lifecycle
+endpoints:
+  - POST /plans
+  - GET /plans/{id}
+  - GET /plans
+  - PUT /plans/{id}
+  - POST /plans/{id}/publish
+  - POST /plans/{id}/archive
+  - DELETE /plans/{id}
+entities: [plan]
+tags: [lifecycle, crud]
+```
+
+**Intent:** A plan moves through the full draft → active → archived →
+deleted lifecycle, and `effective_from` / `effective_to` transition
+predictably at publish and archive.
+
+**Fixtures:**
+- A `CreatePlanRequest` per **Baseline plan**.
+
+**Steps:**
+
+1. **Create plan in draft.** `POST /plans` with the fixture.
+   - Expect `201 Created`.
+   - Expect `key` equals the fixture key.
+   - Expect `version` is `1`.
+   - Expect `status` is `draft`.
+   - Expect `effective_from` and `effective_to` are null.
+
+   Captures:
+   - `plan` ← `response.body`
+
+2. **Get plan (draft).** `GET /plans/{plan.id}`.
+   - Expect `200 OK`.
+   - Expect `id` equals `{plan.id}`.
+   - Expect `status` is `draft`.
+   - Expect `version` is `1`.
+   - Expect `effective_from` is null.
+
+3. **List plans and find the created plan.**
+   `GET /plans?page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect response `data[]` contains an entry with `id == {plan.id}`.
+   - Note: page size 1000 because the shared DB may push fresh rows
+     past the default page-1 window of 20.
+
+4. **Update plan — rename phase and add a second rate card.**
+   `PUT /plans/{plan.id}` with an `UpsertPlanRequest` describing the
+   **full desired state** (PUT is full-replace, not delta):
+   - `name`: unchanged from the create body.
+   - `phases`: a list of one phase with:
+     - `key`: the original phase `key`.
+     - `name`: `"Phase Renamed"`.
+     - `duration`: the original `duration` (`null` for a last phase).
+     - `rate_cards`: the original rate card plus one additional rate
+       card per **Baseline flat rate card** (two total).
+
+   Assertions:
+   - Expect `200 OK`.
+   - Expect `phases[0].key` equals the original phase key (phase keys
+     are immutable).
+   - Expect `phases[0].name` is `"Phase Renamed"`.
+   - Expect `phases[0].rate_cards` has length `2`.
+   - Expect `status` still `draft`.
+
+5. **Get plan (verify update persisted).** `GET /plans/{plan.id}`.
+   - Expect `200 OK`.
+   - Expect `phases[0].name` is `"Phase Renamed"`.
+   - Expect `phases[0].rate_cards` has length `2`.
+
+6. **Publish plan.** `POST /plans/{plan.id}/publish`.
+   - Expect `200 OK`.
+   - Expect `status` is `active`.
+   - Expect `effective_from` is non-null.
+   - Expect `effective_to` is null.
+
+7. **Archive plan.** `POST /plans/{plan.id}/archive`.
+   - Expect `200 OK`.
+   - Expect `status` is `archived`.
+   - Expect `effective_to` is non-null.
+
+8. **Delete plan.** `DELETE /plans/{plan.id}`.
+   - Expect `204 No Content`.
+
+9. **Get plan after deletion.** `GET /plans/{plan.id}`.
+   - Expect `200 OK`.
+   - Expect `deleted_at` is non-null.
+   - Note: deleted plans remain retrievable; they don't 404. Compare
+     with `feature_lifecycle` where delete-then-GET returns 404 — this
+     is a per-resource server choice, pin it scenario-by-scenario.
+
+---
+
+## Example: `draft-with-errors` shape — Plan invalid-draft lifecycle
+
+This is the canonical three-moment flow (create → GET → publish).
+Use it as the template for any new draftable-entity invalid-draft
+test.
+
+```yaml
+id: plan_invalid_draft_lifecycle
+endpoints:
+  - POST /plans
+  - GET /plans/{id}
+  - POST /plans/{id}/publish
+  - PUT /plans/{id}
+entities: [plan]
+tags: [validation, draft, publish-time, canonical-three-moment]
+```
+
+**Intent:** A plan with a phase that has no rate cards is accepted at
+create (stored as draft with validation errors), surfaces its errors
+on GET, is rejected at publish with a domain code, and can be fixed
+via PUT and republished.
+
+**Fixtures:**
+- A `CreatePlanRequest` per **Baseline plan** whose single phase uses
+  **Baseline phase** with `last = true` but **overrides `rate_cards`
+  to `[]`** (the empty list is the defect under test).
+
+**Steps:**
+
+1. **Create accepts the invalid draft.** `POST /plans` with the
+   fixture.
+   - Expect `201 Created`.
+   - Note: this is a validation-moment choice — an empty-rate-card
+     phase is accepted at create, not rejected.
+
+   Captures:
+   - `plan` ← `response.body`
+
+2. **GET surfaces `validation_errors`.** `GET /plans/{plan.id}`.
+   - Expect `200 OK`.
+   - Expect `validation_errors` is non-null and non-empty.
+   - Expect `validation_errors[].code` includes domain code
+     `"plan_phase_has_no_rate_cards"`.
+
+3. **Publish is rejected with the same code.**
+   `POST /plans/{plan.id}/publish`.
+   - Expect `400 Bad Request`.
+   - Expect domain code `"plan_phase_has_no_rate_cards"`.
+
+4. **Fix by adding a rate card.** `PUT /plans/{plan.id}` with an
+   `UpsertPlanRequest` describing the full desired state:
+   - `name`: unchanged from the create body.
+   - `phases`: a list of one phase with the original `key`, `name`,
+     and `duration`, but `rate_cards` now containing one rate card
+     per **Baseline flat rate card** (the empty-rate-cards defect is
+     gone).
+
+   Assertions:
+   - Expect `200 OK`.
+
+5. **Publish succeeds after fix.** `POST /plans/{plan.id}/publish`.
+   - Expect `200 OK`.
+   - Expect `status` is `active`.
+
+**Notes:**
+
+- Three validation moments are exercised in one scenario —
+  create-time accepts, GET-time surfaces, publish-time rejects.
+  Calling out the moment per assertion keeps the generated test
+  honest.
+
+---
+
+## Example: `single-request` shape — Plan invalid currency
+
+The simplest validation scenario — one request, one rule, one
+assertion. Reach for this when a rule is pinned to create-time and
+doesn't carry draft / lifecycle semantics.
+
+```yaml
+id: plan_invalid_currency
+endpoints:
+  - POST /plans
+entities: [plan]
+tags: [validation, create-time, single-request]
+```
+
+**Intent:** A plan submitted with an unknown ISO-4217 currency is
+rejected at create-time with a structured 400 carrying the
+`currency_invalid` domain code.
+
+**Fixtures:**
+- A `CreatePlanRequest` per **Baseline plan** with `currency`
+  overridden to `"ZZZ"` (not a valid ISO-4217 code).
+
+**Steps:**
+
+1. **Create with invalid currency.** `POST /plans` with the fixture.
+   - Expect `400 Bad Request`.
+   - Expect domain code `"currency_invalid"`.
+
+**Notes:**
+
+- This is a **create-time** validation — the handler rejects the
+  request before accepting any draft. Contrast with
+  `plan_invalid_draft_lifecycle`, where defects are accepted at
+  create and only surface on GET / publish.
+
+---
+
+## Example: `matrix` shape — Plan-addon attach status matrix
+
+Use the matrix shape when a rule branches on two or more state
+variables. One Markdown table per row, plus one "Steps per row"
+block.
+
+```yaml
+id: plan_addon_attach_status_matrix
+endpoints:
+  - POST /plans/{id}/addons
+entities: [plan, addon, plan-addon]
+tags: [matrix, validation, attach, status-matrix]
+```
+
+**Intent:** Attaching an addon to a plan is only allowed when
+`plan.status ∈ {draft, scheduled}` **and** `addon.status == active`.
+All other combinations are rejected with a plain BaseAPIError whose
+`detail` carries the reason.
+
+**Fixtures (built fresh per row):**
+- A plan at the row's target `plan.status`. Create from
+  **Baseline plan**, then advance:
+  - `draft` → stop after create.
+  - `active` → create, then `POST /plans/{id}/publish`.
+  - `archived` → create, publish, then `POST /plans/{id}/archive`.
+  - (`scheduled` is not reachable — see Notes.)
+- An addon at the row's target `addon.status`. Create from
+  **Baseline addon**, then advance with the same pattern.
+- A `CreatePlanAddonRequest` per **Baseline plan-addon attach** with
+  `addon.id = {addon.id}` and
+  `from_plan_phase = {plan.phases[0].key}`.
+
+**Rows:**
+
+| # | plan.status | addon.status | Expect | Detail contains |
+|---|---|---|---|---|
+| 1 | draft | active | `201 Created` | — |
+| 2 | active | active | `400 Bad Request` | `"invalid active status, allowed statuses: [draft scheduled]"` |
+| 3 | archived | active | `400 Bad Request` | `"invalid archived status, allowed statuses: [draft scheduled]"` |
+| 4 | draft | draft | `400 Bad Request` | `"invalid draft status, allowed statuses: [active]"` |
+| 5 | draft | archived | `400 Bad Request` | `"invalid archived status, allowed statuses: [active]"` |
+
+**Steps per row:**
+
+1. **Attach.** `POST /plans/{plan.id}/addons` with the fixture body.
+   - Expect the row's `Expect` status.
+   - If 4xx, expect **detail contains** the row's `Detail contains`
+     substring — BaseAPIError shape (`problem.detail`, not
+     `extensions.validationErrors`).
+   - If 2xx, expect the response body parses as a `PlanAddon`.
+
+**Notes:**
+
+- The `scheduled` plan row is intentionally omitted: the v3 publish
+  endpoint hardcodes `effective_from = clock.Now()`, so a plan
+  cannot be driven to `scheduled` via the public API. Add the row if
+  publish takes a future `effective_from` body.
+- Status-mismatch rejections use the **detail substring** shape, not
+  **domain code**. Don't assume every domain rule surfaces through
+  `extensions.validationErrors` — here the `attach` handler wraps
+  the validator error as a BaseAPIError.
+- Row fixtures are built fresh per row — "fresh fixtures" is
+  observable behavior. "Fresh client per row" is a runner choice
+  and stays out of the spec.

--- a/.agents/skills/e2e-nl/references/format.md
+++ b/.agents/skills/e2e-nl/references/format.md
@@ -1,0 +1,340 @@
+# NL Spec Format
+
+How to write a natural-language e2e test specification — runner-neutral,
+contract-only, generator-friendly.
+
+This reference is the format contract for the `e2e-nl` skill. Worked
+examples of every shape class live in `examples.md`.
+
+---
+
+## Goal
+
+A natural-language test specification that:
+
+1. Reads like a design doc — reviewable by non-Go engineers, readable in
+   60 seconds.
+2. Is the **source of truth**: shipped tests map to it, not the other
+   way around.
+3. **Is runner-agnostic by construction.** The spec describes observable
+   HTTP behavior — verbs, paths, status codes, response-body shapes,
+   `problem+json` error shapes. Each downstream generator (Go,
+   Playwright, `.http`, Hurl, …) translates the same spec into its
+   runtime. Language-specific or framework-specific details never belong
+   in the spec.
+4. Is mechanically translatable to executable tests by an LLM or a
+   small generator.
+
+---
+
+## The runner-agnosticism rule
+
+**Central principle.** The NL spec is a test plan against an API
+contract, not against any particular runner. Each scenario describes
+wire-level behavior — HTTP request/response, `problem+json` body shape,
+JSON field assertions. Runner-specific translation is always a
+downstream concern.
+
+### Forbidden in the spec
+
+- **Runner-specific code or helper names** — no `newV3Client`, no
+  `validPlanRequest`, no `test.describe`, no `.http` variables. These
+  are transient scaffolding.
+- **Runner-specific construction mechanics** — no
+  `FromBillingPriceFlat`, no `nullable.NewNullableWithValue`, no
+  `new Request(...)`. Describe the JSON body shape; leave wire-format
+  plumbing to each generator.
+- **Runner-specific naming conventions** — no `TestV3<…>`, no
+  Playwright `test(…)` titles, no `### Section` markers for `.http`.
+  The spec commits to the `id` slug only; each generator derives its
+  own idiomatic name.
+- **Assumptions about test isolation, parallelism, cleanup, or client
+  lifecycle.** These are runner choices. "Fresh fixtures per row" is
+  observable behavior; "fresh client per row" is not.
+
+### Encouraged in the spec
+
+- **JSON-visible vocabulary.** `Expect status is active` (wire-level
+  string), not `Expect plan.Status == BillingPlanStatusActive` (Go
+  type).
+- **HTTP-native verbs and paths.** `POST /plans`, `GET /plans/{id}`.
+- **API schema type names** from TypeSpec / OpenAPI
+  (`CreatePlanRequest`, `BillingRateCard`). These appear in every
+  generator's toolchain.
+
+---
+
+## File layout
+
+One Markdown file per endpoint family — convention is
+`e2e/specs/<family>.md`, co-located with the e2e tests.
+
+```
+# E2E Scenario Specifications — <Family>
+
+<one-paragraph preamble: scope, lifecycle/no-lifecycle, family-wide
+error-shape conventions>
+
+---
+
+## Scenario list
+
+<plain bullets, one per scenario, grouped by priority>
+
+---
+
+## Baselines
+
+<named object shapes scenarios reference by name>
+
+---
+
+## Scenario: <id>
+
+<fenced YAML + Intent + Fixtures + Steps + Notes>
+
+## Scenario: <id>
+…
+```
+
+The `## Scenario: <id>` heading is the canonical drafted marker — the
+heading text is exactly the scenario's `id` slug, not a human title.
+Presence of such a section is ground truth for "this scenario is
+drafted." No checkbox, no status tracker.
+
+---
+
+## The scenario contract
+
+Every scenario **MUST** provide:
+
+- `id` (fenced YAML) — a stable snake_case slug, unique within the
+  spec file.
+- `endpoints` (fenced YAML) — a list of `METHOD /path` entries the
+  scenario exercises.
+- **Intent** — one sentence describing the behavior the scenario pins.
+- **Fixtures** — the API-level preconditions described as Baseline
+  references (or inline JSON when a Baseline isn't warranted).
+- **Steps** — numbered HTTP actions with:
+  - The verb + path + request body reference.
+  - The expected HTTP status code.
+  - Response-field assertions in JSON-visible vocabulary.
+  - For 4xx steps: the expected error shape (**domain code** /
+    **detail substring** / **schema rule**) and the code / substring
+    / rule string.
+
+Every scenario **MAY** provide:
+
+- `entities`, `tags`, `references`, `status` (fenced YAML).
+- Per-step `Captures:` blocks (see below).
+- **Notes** section covering validation-moment choices, omitted rows,
+  caveats, or `NEEDS-VERIFY` items awaiting server confirmation.
+
+Downstream generators own: test file location, language-level test
+function naming, helper / client / fixture-builder code, concurrency
+and isolation strategies, discriminated-union construction, cleanup
+mechanics. None of this belongs in the spec.
+
+---
+
+## Controlled vocabularies
+
+### Error-shape vocabulary
+
+Every expected 4xx names one of three shapes. Which shape a server uses
+is a server-side choice; pinning it in the spec keeps the generated
+test honest.
+
+| Shape | How the server returns it | Spec phrasing |
+|---|---|---|
+| **Domain code** | `extensions.validationErrors[].code` | `Expect domain code "<code>".` |
+| **Detail substring** | `problem.detail` (free text) | `Expect detail contains "<substring>".` |
+| **Schema rule** | `invalid_parameters[].rule` | `Expect schema rule "<rule>".` |
+
+### Validation-moment vocabulary
+
+Draftable entities (plans, addons, plan-addons) can fire validation at
+three moments. Spec each assertion against the moment it fires.
+
+- **create-time** — the POST itself is rejected.
+- **GET-time** — POST accepts as draft; GET returns the entity with
+  `validation_errors` populated.
+- **publish-time** — POST accepts, GET may show errors, and the
+  publish POST is rejected.
+
+Non-draftable entities (e.g. features) fire only at create-time or
+update-time. Pin the moment in the scenario's Notes if it's not
+obvious from the steps.
+
+---
+
+## Captures directive
+
+When a step's response produces state later steps need (typically a
+generated `id`), add a `Captures:` block at the end of the step. Two
+equivalent forms:
+
+```
+# Capture the whole response body as an object (preferred when later
+# steps need multiple fields):
+Captures:
+- `plan` ← `response.body`
+
+# Capture a specific field by JSON path:
+Captures:
+- `plan_id` ← `response.body.id`
+```
+
+The left side is a snake_case local name. The right side is rooted at
+one of:
+
+- `response.body` — the whole response body as an object.
+- `response.body.<json-path>` — a specific field.
+- `response.headers.<header-name>` — a response header value.
+- `response.status` — the numeric status code.
+
+Later steps reference captured values with **braces**: `{plan.id}`
+(dotted field access on an object capture) or `{plan_id}` (a flat
+capture). The braces disambiguate bound values from literal text.
+
+```
+2. **Get plan.** `GET /plans/{plan.id}`.
+```
+
+Fixture-produced values (e.g. "a plan at status `active`") are bound
+by the Fixtures section and referenced the same way — `{plan.id}`,
+`{plan.phases[0].key}`, `{addon.id}`. No explicit `Captures:` block
+is needed; Fixture block names are implicit captures.
+
+Every runner can implement this: Go assigns to a local variable,
+Playwright binds with `const`, `.http` uses `@var = {{response.body.$.id}}`,
+Hurl uses `[Captures]`. The spec stays neutral.
+
+---
+
+## Null vs. absent
+
+JSON distinguishes between `key: null` (present with null value) and
+key-missing (omitted). Pin this explicitly rather than papering over
+it:
+
+- `is null` — the key is present in the body with explicit `null`.
+- `is absent` — the key is not present in the body (server
+  `omitempty`).
+- `is null or absent` — used only when the server is genuinely
+  ambiguous; document in Notes when you reach for it.
+
+Default for optional-field positive assertions: prefer `is absent` for
+this codebase (most Go services omit-when-nil). Downstream generators
+can collapse both to a single nil check when the target language
+doesn't distinguish (e.g. Go pointer types).
+
+---
+
+## The `references:` field
+
+Optional YAML list of freeform strings pointing at generated test
+artifacts in any runner. The list form is canonical even for a single
+entry — generators see one shape regardless of runner count.
+
+```yaml
+references:
+  - e2e/plans_v3_test.go::TestV3PlanLifecycle
+  - tests/plans.spec.ts::"plan lifecycle"
+  - tests/http/plans.http#plan_lifecycle
+```
+
+Each entry is freeform — the path-and-anchor convention is whatever
+each runner finds idiomatic. Omit the field entirely when no test has
+been generated. `references:` is for traceability only, not contract;
+the `id` slug is the stable identifier.
+
+---
+
+## The `status:` field
+
+Optional YAML field that signals to downstream generators whether the
+scenario should be exercised. Omitting it is the default — the
+scenario is in scope for every generator that consumes this spec.
+
+| Value | Meaning |
+|---|---|
+| omitted (default) | Scenario is in scope. Generators emit a test. |
+| `skipped` | Scenario is **not** to be exercised. Generators MUST NOT emit a test. |
+
+`skipped` is for scenarios that describe contract behavior the
+generator can't reach today — typically because of an environmental
+gate (missing seed data, an external service the e2e stack doesn't
+provision, a feature flag off in test). The scenario stays in the
+spec so the contract is documented; the `status: skipped` directive
+suppresses generation.
+
+When marking a scenario `skipped`:
+
+- Explain the gate in the scenario body — usually a leading
+  **Status: SKIPPED.** callout under the YAML — and describe what it
+  takes to re-enable.
+- Do not delete the scenario. The contract is still part of the
+  spec; the marker just defers the test.
+
+```yaml
+id: feature_llm_pricing_enriched_on_get
+endpoints:
+  - GET /features/{id}
+status: skipped
+```
+
+The field is intentionally minimal — only `skipped` is defined.
+Generators encountering an unknown value should treat the scenario
+as in scope (default) and surface a warning rather than fail.
+
+---
+
+## Baselines
+
+Each `e2e/specs/<family>.md` defines its **own** Baselines section.
+Baselines are **not shared across files**: an addons spec and a
+features spec each own their own baselines, even if the names
+collide. Cross-file imports couple specs together and break the
+"one file per family" rule.
+
+A Baseline names an API schema type
+(`CreatePlanRequest`, `CreateFeatureRequest`, `BillingRateCard`, …)
+from TypeSpec / `api/openapi.yaml` and lists the field defaults a
+scenario can mutate. Scenarios reference baselines by name and
+describe per-scenario mutations rather than inlining JSON.
+
+Baselines earn their place when **two or more scenarios** in the same
+family use the shape. One-off shapes stay inlined in the scenario's
+Fixtures block.
+
+See `examples.md` for worked baseline definitions and how scenarios
+reference them.
+
+---
+
+## Scenario list conventions
+
+The Scenario list is a flat enumeration at the top of the file. One
+plain bullet per scenario:
+
+```
+- `<id>` — <one-line intent> — shape: <class> — priority: <p0|p1|p2>
+```
+
+- `id`: stable snake_case slug, unique in the file.
+- shape class: `lifecycle` | `draft-with-errors` | `matrix` |
+  `single-request`. (See `examples.md` for one worked example per
+  class.)
+- priority:
+  - **p0** — happy-path lifecycle or primary CRUD flow.
+  - **p1** — core validation, error-shape proofs, state-matrix rules.
+  - **p2** — edge cases, deprecated paths, rare documented errors.
+- Append `NEEDS-VERIFY: <reason>` to the line for any candidate where
+  a behavior isn't pinned by the code and needs live-server
+  confirmation.
+
+Group by priority with subheadings (`**p0 — happy path**`,
+`**p1 — core validation**`, …) when the list is long enough to scan.
+The `## Scenario: <id>` section that follows in the file is what
+actually marks a scenario as drafted; the list is just an index.

--- a/e2e/specs/features.md
+++ b/e2e/specs/features.md
@@ -1,0 +1,1547 @@
+# E2E Scenario Specifications — Features
+
+Natural-language, runner-neutral description of e2e scenarios for the
+`/openmeter/features` endpoint family (and
+`/openmeter/features/{id}/cost/query` for cost query). Each
+`## Scenario` maps 1:1 to a target test function in any runner that
+consumes this spec.
+
+See the `e2e-nl` skill (`.agents/skills/e2e-nl/`) for format rules
+(`references/format.md`) and worked examples (`references/examples.md`).
+
+Features **do not have a draft/publish/archive lifecycle**. `DELETE` is a
+soft archive, `PATCH` only accepts `unit_cost`, and there is no
+`validation_errors` on the response body — validation rules fire at
+create-time or update-time only. No `draft-with-errors` shape applies.
+
+**Error-shape convention for this family:** almost all 4xx responses
+use the **detail-substring** shape (`problem.detail`), not the
+**domain code** shape. Schema-rule shape (`invalid_parameters[]`) only
+fires for malformed query params / bodies — i.e. requests that fail
+schema validation before the request body is processed.
+
+**GET by id vs. by key.** `GET /features/{featureId}` accepts either an
+id or a key. When the entity is not found, the by-id path returns the
+handler's 404 (`"feature not found: <id>"`), while the by-key path may
+be intercepted at the gateway layer with a different detail
+(`"The requested route was not found"`). For assertions on 4xx
+responses, prefer GET by id; reserve key lookup for positive
+resolution scenarios.
+
+---
+
+## Scenario list
+
+Index of scenarios in this file. Presence of a `## Scenario: <id>`
+section below is the source of truth for "this scenario exists" — the
+list is just a directory. Priority is a scheduling hint, not a
+commitment. Entries marked `NEEDS-VERIFY` have a rule the code doesn't
+fully pin down — confirm behavior against a live server before adding
+the corresponding `## Scenario` section.
+
+**p0 — happy path**
+
+- `feature_lifecycle` — Create static feature, get, list, patch to add/clear manual unit_cost, delete, get-after-delete. — shape: lifecycle — priority: p0
+
+**p1 — core validation**
+
+- `feature_create_duplicate_key_rejected` — Posting twice with the same key returns 409. — shape: single-request — priority: p1
+- `feature_create_key_must_not_be_ulid` — Posting a feature whose key parses as a ULID returns 400. — shape: single-request — priority: p1
+- `feature_create_meter_not_found_rejected` — Posting a feature referencing a non-existent meter returns 404 with detail `"meter not found: <id>"` (detail-substring shape). — shape: single-request — priority: p1
+- `feature_create_invalid_meter_aggregation_rejected` — Creating a feature whose meter aggregation is outside `{sum, count, unique_count, latest}` returns 400. — shape: single-request — priority: p1
+- `feature_create_invalid_meter_filter_key_rejected` — Meter filter key not in meter `group_by` returns 400. — shape: single-request — priority: p1
+- `feature_create_llm_unit_cost_without_meter_rejected` — LLM `unit_cost` with no associated meter returns 400. — shape: single-request — priority: p1
+- `feature_create_llm_property_not_in_meter_rejected` — LLM `provider_property` / `model_property` / `token_type_property` referencing a key absent from the meter's `group_by` returns 400. — shape: single-request — priority: p1
+- `feature_create_unit_cost_validation_matrix` — Matrix over manual/llm validation rules (type/payload mismatch, mutex of `provider` vs. `provider_property`, negative amount, invalid `token_type`). — shape: matrix — priority: p1
+- `feature_update_unit_cost_required` — PATCH with empty body (or without `unit_cost` key) returns 400 — `unit_cost` must be explicitly specified (either a value or `null`). — shape: single-request — priority: p1
+- `feature_update_llm_without_meter_rejected` — PATCH adding LLM `unit_cost` on a feature without a meter returns 400. — shape: single-request — priority: p1
+- `feature_update_nonexistent_rejected` — PATCH on a non-existent feature id returns 404. — shape: single-request — priority: p1
+- `feature_get_nonexistent_returns_404` — GET on a non-existent feature id returns 404. — shape: single-request — priority: p1
+- `feature_delete_nonexistent_returns_404` — DELETE on a non-existent feature id returns 404. — shape: single-request — priority: p1
+- `feature_get_by_key_resolves` — GET with `{featureId}` as the feature's key (not id) resolves to the feature. — shape: single-request — priority: p1
+
+**p1 — list filters, sort, pagination**
+
+- `feature_list_filter_by_meter_id` — `filter[meter_id][eq]=<id>` returns only features on that meter. — shape: single-request — priority: p1
+- `feature_list_filter_by_key` — `filter[key][eq]=<key>` returns matching features. — shape: single-request — priority: p1
+- `feature_list_filter_by_name` — `filter[name][eq]=<name>` returns matching features. — shape: single-request — priority: p1
+- `feature_list_combined_filters` — Combining `filter[meter_id]` + `filter[key]` narrows intersection. — shape: matrix — priority: p1
+- `feature_list_sort_by_supported_fields` — `sort=key`, `sort=name`, `sort=created_at`, `sort=updated_at` (with `:asc` / `:desc`) returns the expected order. — shape: matrix — priority: p1
+- `feature_list_sort_invalid_field_rejected` — `sort=<unknown_field>` returns 400 with schema-rule shape. — shape: single-request — priority: p1
+- `feature_list_filter_malformed_rejected` — Malformed filter value (unknown operator, bad ULID format on `filter[meter_id]`) returns 400 with schema-rule shape. — shape: single-request — priority: p1 — NEEDS-VERIFY: exact `rule` strings the OpenAPI binder emits for ULID-format and unknown-property rejections.
+- `feature_list_pagination` — `page[number]` + `page[size]` return the expected slice and response metadata. — shape: single-request — priority: p1
+
+**p1 — cost query**
+
+- `feature_cost_query_happy_path` — `POST /features/{id}/cost/query` with an empty body on a feature that has a meter and manual unit_cost returns 200 with `data[]` populated (at least one row; zero-usage yields `cost: "0"`, `usage: "0"`, `currency: "USD"`, and the default time window `1970-01-01T00:00:00Z` → `1970-01-01T00:01:00Z`). — shape: single-request — priority: p1
+- `feature_cost_query_nonexistent_feature_returns_404` — `POST /features/{id}/cost/query` on a non-existent id returns 404 with detail `"feature not found: <id>"`. — shape: single-request — priority: p1
+- `feature_cost_query_no_meter_rejected` — `POST /features/{id}/cost/query` on a feature without an associated meter returns 400 with detail `"feature <key> has no meter associated"`. — shape: single-request — priority: p1
+
+**p2 — edge cases**
+
+- `feature_archived_excluded_from_list` — After delete, the feature is not returned by a default list request. — shape: single-request — priority: p2
+- `feature_archived_get_returns_404` — After delete, GET returns 404 with detail `"feature not found: <id>"`. (TypeSpec allows 410 `Common.Gone` but the current server always returns 404.) — shape: single-request — priority: p2
+- `feature_llm_pricing_absent_when_unresolved` — GET of an LLM feature whose provider+model don't resolve in the LLM cost database returns 200 with no `pricing` block (silently absent; no error). — shape: single-request — priority: p2
+- `feature_llm_pricing_enriched_on_get` — GET of an LLM feature whose provider+model resolve returns a `pricing` block populated from the LLM cost database. — shape: single-request — priority: p2 — **SKIPPED:** environment-gated; deferred until the e2e stack seeds the LLM cost DB with a known `(openai, gpt-4)` price. Do not generate a test for this scenario.
+
+---
+
+## Baselines
+
+Named object shapes scenarios reference by name. Each names the API
+schema type (from TypeSpec under
+`api/spec/packages/aip/src/features/`, surfaced in `api/openapi.yaml`).
+
+### Baseline feature — `CreateFeatureRequest`
+
+The minimal valid feature — no meter reference, no unit cost. Scenarios
+mutate this shape per test intent (adding a meter reference, adding a
+`unit_cost`, changing the `key`, etc.).
+
+- `key`: unique; **must not parse as a valid ULID**.
+- `name`: `"Test Feature"`.
+
+Optional fields available for mutation:
+
+- `description`: string.
+- `meter`: `{ id: <meter_id>, filters?: <map of meter group-by key → filter string> }`.
+- `unit_cost`: discriminated union (`manual` | `llm`) — see the two sub-baselines below.
+- `labels`: map.
+
+### Baseline manual unit cost — `BillingFeatureManualUnitCost`
+
+Simplest valid manual cost. Amount is non-negative.
+
+- `type`: `"manual"`.
+- `amount`: `"5"`.
+
+### Baseline LLM unit cost (static) — `BillingFeatureLLMUnitCost`
+
+All three dimensions as static values. Requires the feature to have a
+meter associated. `pricing` is read-only and populated by the server on
+`GET` if the provider + model resolve against the LLM cost database.
+
+- `type`: `"llm"`.
+- `provider`: `"openai"`.
+- `model`: `"gpt-4"`.
+- `token_type`: `"input"`.
+
+### Baseline meter — `CreateMeterRequest`
+
+Minimal `count`-aggregation meter that any feature scenario can use as
+its meter reference. The key is unique per run.
+
+- `key`: unique.
+- `name`: `"Test Meter"`.
+- `event_type`: `"e2e_feature_test"`.
+- `aggregation`: `"count"`.
+- `dimensions`: omitted.
+
+### Baseline LLM-capable meter — `CreateMeterRequest`
+
+A meter with the three group-by dimensions an LLM unit cost may
+reference (`provider`, `model`, `token_type`). Used by scenarios that
+need a feature with `BillingFeatureLLMUnitCost` to validate cleanly.
+
+- `key`: unique.
+- `name`: `"Test LLM Meter"`.
+- `event_type`: `"e2e_llm_test"`.
+- `aggregation`: `"count"`.
+- `dimensions`: `{ provider: "$.provider", model: "$.model", token_type: "$.token_type" }`.
+
+---
+
+## Scenario: feature_lifecycle
+
+```yaml
+id: feature_lifecycle
+endpoints:
+  - POST /features
+  - GET /features/{id}
+  - GET /features
+  - PATCH /features/{id}
+  - DELETE /features/{id}
+entities: [feature]
+tags: [lifecycle, crud]
+```
+
+**Intent:** A feature moves through the CRUD lifecycle — create static
+feature, get, list, patch `unit_cost` to add then clear it, delete, and
+get-after-delete returns 404.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature**.
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created` with a `Feature` body.
+   - Expect `key` equals the fixture key.
+   - Expect `name` is `"Test Feature"`.
+   - Expect `meter` is absent.
+   - Expect `unit_cost` is absent.
+   - Expect `deleted_at` is absent.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Get feature.** `GET /features/{feature.id}`.
+   - Expect `200 OK`.
+   - Expect `id` equals `{feature.id}`.
+   - Expect `key` equals the fixture key.
+   - Expect `name` is `"Test Feature"`.
+
+3. **List features and find the created feature.**
+   `GET /features?page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect response `data[]` contains an entry with `id == {feature.id}`.
+   - Note: page size 1000 because the shared DB may push fresh rows
+     past the default page-1 window of 20.
+
+4. **Patch feature — set manual unit_cost.**
+   `PATCH /features/{feature.id}` with an `UpdateFeatureRequest`:
+   - `unit_cost`: per **Baseline manual unit cost**
+     (`{ type: "manual", amount: "5" }`).
+
+   Assertions:
+   - Expect `200 OK` with a `Feature` body.
+   - Expect `unit_cost.type` is `"manual"`.
+   - Expect `unit_cost.amount` is `"5"` (or a normalized equivalent;
+     the server trims trailing zeros, so `"5.00"` round-trips as
+     `"5"`).
+
+5. **Get feature — verify unit_cost persisted.**
+   `GET /features/{feature.id}`.
+   - Expect `200 OK`.
+   - Expect `unit_cost.type` is `"manual"`.
+   - Expect `unit_cost.amount` matches the value from step 4.
+
+6. **Patch feature — clear unit_cost.**
+   `PATCH /features/{feature.id}` with an `UpdateFeatureRequest`:
+   - `unit_cost`: `null`.
+
+   Assertions:
+   - Expect `200 OK`.
+   - Expect `unit_cost` is absent on the response.
+
+7. **Get feature — verify unit_cost cleared.**
+   `GET /features/{feature.id}`.
+   - Expect `200 OK`.
+   - Expect `unit_cost` is absent.
+
+8. **Delete feature.** `DELETE /features/{feature.id}`.
+   - Expect `204 No Content`.
+
+9. **Get feature after deletion.** `GET /features/{feature.id}`.
+   - Expect `404 Not Found`.
+   - Expect **detail contains** `"feature not found: {feature.id}"`.
+
+**Notes:**
+
+- **Validation moment:** all assertions in this scenario are at
+  `create-time`, `GET-time` (reads), or `update-time` (PATCH). There is
+  no publish or archive flow on features.
+- **`unit_cost` presence semantics.** `UpdateFeatureRequest.unit_cost`
+  uses `specified | value | null` semantics: omitting the key entirely
+  is not allowed (a PATCH without `unit_cost` is rejected, covered in
+  `feature_update_unit_cost_required`). Passing `null` clears the
+  value; passing an object replaces it.
+- **Get-after-delete status code.** The TypeSpec for `get-feature`
+  declares both `Common.NotFound` (404) and `Common.Gone` (410) as
+  possible responses. **Verified against a live server:** the server
+  always returns 404 with detail `"feature not found: <id>"` — the
+  410 path is aspirational. Pin 404 + detail-substring shape.
+- **Decimal normalization.** `amount` strings are normalized on
+  round-trip — trailing zeros trimmed. Assertions on numeric strings
+  should match the normalized form.
+- **No include-archived.** v3 has no `include_archived` query param on
+  list or get; a deleted feature is unreachable via the public API.
+  This is a known parity gap with v1.
+
+---
+
+## Scenario: feature_create_duplicate_key_rejected
+
+```yaml
+id: feature_create_duplicate_key_rejected
+endpoints:
+  - POST /features
+entities: [feature]
+tags: [validation, create-time, single-request, conflict]
+```
+
+**Intent:** Posting two features with the same `key` in the same
+namespace returns `409 Conflict` on the second attempt.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature**.
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Create again with the same key.** `POST /features` with a body
+   reusing the **same `key`** as `{feature.key}` (`name` may differ).
+   - Expect `409 Conflict`.
+   - Expect **detail contains** `"with key {feature.key} already exists"`.
+
+**Notes:**
+
+- **Validation moment:** create-time. The duplicate is detected
+  before any state is committed — there is no partial create.
+- **Error shape:** detail-substring (`problem.detail`).
+
+---
+
+## Scenario: feature_create_key_must_not_be_ulid
+
+```yaml
+id: feature_create_key_must_not_be_ulid
+endpoints:
+  - POST /features
+entities: [feature]
+tags: [validation, create-time, single-request]
+```
+
+**Intent:** A feature whose `key` parses as a ULID is rejected at
+create-time. This protects the GET-by-id-or-key dispatch from
+ambiguity.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature** with `key`
+  overridden to a ULID literal (e.g. `"01HXYZABCDEFGHJKMNPQRSTVWX"`).
+
+**Steps:**
+
+1. **Create with ULID-shaped key.** `POST /features` with the fixture.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains** `"Feature key cannot be a valid ULID"`.
+
+**Notes:**
+
+- **Validation moment:** create-time, before any state is committed.
+- **Error shape:** detail-substring.
+
+---
+
+## Scenario: feature_create_meter_not_found_rejected
+
+```yaml
+id: feature_create_meter_not_found_rejected
+endpoints:
+  - POST /features
+entities: [feature]
+tags: [validation, create-time, single-request, not-found]
+```
+
+**Intent:** Posting a feature whose `meter.id` does not resolve to any
+meter in the namespace returns `404 Not Found`. The handler resolves
+the meter reference before persisting the feature.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature** with `meter`
+  overridden to `{ id: "<random-ULID-not-in-DB>" }`. Use a freshly
+  generated ULID literal to guarantee no collision.
+
+**Steps:**
+
+1. **Create referencing missing meter.** `POST /features` with the
+   fixture.
+   - Expect `404 Not Found`.
+   - Expect **detail contains** `"meter not found: <id>"` (the
+     literal id used in the request body).
+
+**Notes:**
+
+- **Validation moment:** create-time, before any state is committed.
+- **Error shape:** detail-substring at status 404.
+
+---
+
+## Scenario: feature_create_invalid_meter_aggregation_rejected
+
+```yaml
+id: feature_create_invalid_meter_aggregation_rejected
+endpoints:
+  - POST /meters
+  - POST /features
+entities: [feature, meter]
+tags: [validation, create-time, single-request]
+```
+
+**Intent:** Features can only be associated with meters whose
+aggregation is one of `{ sum, count, unique_count, latest }`. Posting
+a feature against a meter with any other aggregation
+(`avg` / `min` / `max`) returns `400 Bad Request`.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline meter** with
+  `aggregation` overridden to `"avg"` and `value_property` set to
+  `"$.value"` (avg requires a value property).
+- A `CreateFeatureRequest` per **Baseline feature** with `meter`
+  overridden to `{ id: {meter.id} }`.
+
+**Steps:**
+
+1. **Create meter with avg aggregation.** `POST /meters` with the
+   meter fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `meter` ← `response.body`
+
+2. **Create feature against the meter.** `POST /features` with the
+   feature fixture (referencing `{meter.id}`).
+   - Expect `400 Bad Request`.
+   - Expect **detail contains** `"features can only be created for"`
+     (the message also enumerates `sum, count, unique_count, latest`
+     in some order).
+
+**Notes:**
+
+- **Validation moment:** create-time. The aggregation check happens
+  after the meter reference resolves but before any feature state
+  is committed.
+- **Error shape:** detail-substring at status 400.
+
+---
+
+## Scenario: feature_create_invalid_meter_filter_key_rejected
+
+```yaml
+id: feature_create_invalid_meter_filter_key_rejected
+endpoints:
+  - POST /meters
+  - POST /features
+entities: [feature, meter]
+tags: [validation, create-time, single-request]
+```
+
+**Intent:** Meter filter keys (`meter.filters`) must reference a key
+that exists in the meter's `dimensions` (group-by). Posting a feature
+whose `meter.filters` references an unknown key returns `400`.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline meter** with `dimensions`
+  overridden to `{ region: "$.region" }`.
+- A `CreateFeatureRequest` per **Baseline feature** with `meter`
+  overridden to:
+  - `id`: `{meter.id}`.
+  - `filters`: `{ unknown_key: { eq: "x" } }`.
+
+**Steps:**
+
+1. **Create meter with a single dimension.** `POST /meters` with the
+   meter fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `meter` ← `response.body`
+
+2. **Create feature with bad filter key.** `POST /features` with the
+   feature fixture.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains** `"filter key \"unknown_key\" is not a
+     valid dimension of meter"`.
+
+**Notes:**
+
+- **Validation moment:** create-time, before any state is committed.
+- **Error shape:** detail-substring.
+
+---
+
+## Scenario: feature_create_llm_unit_cost_without_meter_rejected
+
+```yaml
+id: feature_create_llm_unit_cost_without_meter_rejected
+endpoints:
+  - POST /features
+entities: [feature]
+tags: [validation, create-time, single-request, llm]
+```
+
+**Intent:** Posting a feature with an `llm` unit cost but no `meter`
+reference returns `400`. LLM unit cost requires a meter.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature** with:
+  - `meter`: omitted.
+  - `unit_cost`: per **Baseline LLM unit cost (static)**.
+
+**Steps:**
+
+1. **Create LLM feature without meter.** `POST /features` with the
+   fixture.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains**
+     `"LLM unit cost requires a meter to be associated with the feature"`.
+
+**Notes:**
+
+- **Validation moment:** create-time. Inner unit-cost validation
+  runs first; the meter-presence check fires next.
+- **Error shape:** detail-substring.
+
+---
+
+## Scenario: feature_create_llm_property_not_in_meter_rejected
+
+```yaml
+id: feature_create_llm_property_not_in_meter_rejected
+endpoints:
+  - POST /meters
+  - POST /features
+entities: [feature, meter]
+tags: [validation, create-time, single-request, llm]
+```
+
+**Intent:** When an LLM unit cost uses `*_property` to reference a
+meter group-by key, that key must exist in the meter's `dimensions`.
+Posting a feature whose LLM unit cost references an absent property
+returns `400`.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline meter** with `dimensions`
+  overridden to `{ provider: "$.provider", model: "$.model" }` (note:
+  `token_type` deliberately omitted).
+- A `CreateFeatureRequest` per **Baseline feature** with:
+  - `meter`: `{ id: {meter.id} }`.
+  - `unit_cost`: a `BillingFeatureLLMUnitCost` with:
+    - `type`: `"llm"`.
+    - `provider_property`: `"provider"`.
+    - `model_property`: `"model"`.
+    - `token_type_property`: `"token_type"` (the missing one).
+
+**Steps:**
+
+1. **Create meter without `token_type` dimension.** `POST /meters`.
+   - Expect `201 Created`.
+
+   Captures:
+   - `meter` ← `response.body`
+
+2. **Create LLM feature referencing missing property.**
+   `POST /features` with the feature fixture.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains**
+     `"token_type_property \"token_type\" not found in meter group-by keys"`.
+
+**Notes:**
+
+- **Validation moment:** create-time. `UnitCost.ValidateWithMeter`
+  runs after the basic shape checks pass and the meter is resolved.
+- **Error shape:** detail-substring.
+- The same shape applies symmetrically for `provider_property` and
+  `model_property`. One row covers the family; the matrix scenario
+  exercises the others if needed.
+
+---
+
+## Scenario: feature_create_unit_cost_validation_matrix
+
+```yaml
+id: feature_create_unit_cost_validation_matrix
+endpoints:
+  - POST /meters
+  - POST /features
+entities: [feature, meter]
+tags: [matrix, validation, create-time, llm, manual]
+```
+
+**Intent:** Pin the create-time validation rules for `unit_cost`
+across both manual and LLM shapes — required-field, mutex, range,
+and enum checks — that the public API can actually surface. Each row
+exercises one rule against a fresh fixture.
+
+**Fixtures (built fresh per row):**
+- A `CreateMeterRequest` per **Baseline LLM-capable meter** (created
+  fresh for any row whose feature references a meter).
+- A `CreateFeatureRequest` per **Baseline feature** with:
+  - `meter`: `{ id: {meter.id} }` (every row that needs an LLM
+    unit cost also creates the meter above).
+  - `unit_cost`: per the row's column.
+
+**Rows:**
+
+| # | Mutation from baseline (`type` + payload) | Expect | Detail contains |
+|---|---|---|---|
+| 1 | manual baseline (`type: manual`, `amount: "5"`); no meter | `201 Created` | — |
+| 2 | LLM baseline (static provider/model/token_type); meter attached | `201 Created` | — |
+| 3 | manual with `amount: "-1"`; no meter | `400 Bad Request` | `"manual unit cost amount must be non-negative"` |
+| 4 | LLM with both `provider: "openai"` and `provider_property: "provider"`; meter attached | `400 Bad Request` | `"provider_property and provider are mutually exclusive"` |
+| 5 | LLM with both `model: "gpt-4"` and `model_property: "model"`; meter attached | `400 Bad Request` | `"model_property and model are mutually exclusive"` |
+| 6 | LLM with both `token_type: "input"` and `token_type_property: "token_type"`; meter attached | `400 Bad Request` | `"token_type_property and token_type are mutually exclusive"` |
+| 7 | LLM with no `provider` and no `provider_property` (model + token_type still set); meter attached | `400 Bad Request` | `"either provider_property or provider is required for LLM unit cost"` |
+| 8 | LLM with no `model` and no `model_property` (provider + token_type still set); meter attached | `400 Bad Request` | `"either model_property or model is required for LLM unit cost"` |
+| 9 | LLM with no `token_type` and no `token_type_property` (provider + model still set); meter attached | `400 Bad Request` | `"either token_type_property or token_type is required for LLM unit cost"` |
+| 10 | LLM baseline with `token_type: "banana"`; meter attached | `400 Bad Request` | `"invalid token_type \"banana\""` |
+
+**Steps per row:**
+
+1. **(If the row needs a meter)** `POST /meters` with the meter
+   fixture.
+   - Expect `201 Created`.
+   - Captures: `meter` ← `response.body`.
+2. **Create feature.** `POST /features` with the feature fixture for
+   the row.
+   - Expect the row's `Expect` status.
+   - If 4xx, expect **detail contains** the row's `Detail contains`
+     substring.
+   - If 2xx, expect the response body parses as a `Feature`.
+
+**Notes:**
+
+- **Validation moment:** create-time. All rows fire before insert.
+- **Error shape:** detail-substring. The features family does not
+  use the **domain code** shape (`extensions.validationErrors[]`).
+- **Joined errors.** When a row removes more than one required
+  dimension, the server may surface multiple messages joined into a
+  single `detail`. Detail-substring matches still pass — pin one
+  distinctive substring per row rather than asserting the full
+  message.
+- **Rows intentionally omitted:** the internal "Manual configuration
+  must not be set when type is llm" / "llm must not be set when type
+  is manual" checks. The API discriminator-based converter never
+  produces those mixed-shape inputs, so they aren't reachable through
+  the public surface.
+
+---
+
+## Scenario: feature_update_unit_cost_required
+
+```yaml
+id: feature_update_unit_cost_required
+endpoints:
+  - POST /features
+  - PATCH /features/{id}
+entities: [feature]
+tags: [validation, update-time, single-request]
+```
+
+**Intent:** `PATCH /features/{id}` requires the body to **explicitly
+specify** the `unit_cost` field (either a value or `null`). An empty
+body — or one without `unit_cost` — is rejected.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature**.
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Patch with empty body.** `PATCH /features/{feature.id}` with
+   request body `{}`.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains** `"unitCost is required"`.
+
+**Notes:**
+
+- **Validation moment:** update-time. The body shape is rejected
+  before any state is committed.
+- **Error shape:** detail-substring.
+- **Tri-state semantics:** `unit_cost` uses
+  *unspecified | value | null* tracking. `unspecified` (key absent)
+  is rejected; `null` clears; an object replaces.
+
+---
+
+## Scenario: feature_update_llm_without_meter_rejected
+
+```yaml
+id: feature_update_llm_without_meter_rejected
+endpoints:
+  - POST /features
+  - PATCH /features/{id}
+entities: [feature]
+tags: [validation, update-time, single-request, llm]
+```
+
+**Intent:** PATCHing an LLM `unit_cost` onto a feature that has no
+associated meter returns `400`. Same rule as create-time, applied at
+update.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature** (no meter).
+- An `UpdateFeatureRequest` body with `unit_cost` per **Baseline LLM
+  unit cost (static)**.
+
+**Steps:**
+
+1. **Create static feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Patch with LLM unit cost.** `PATCH /features/{feature.id}` with
+   the update body.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains**
+     `"LLM unit cost requires a meter to be associated with the feature"`.
+
+**Notes:**
+
+- **Validation moment:** update-time, before any state is committed.
+- **Error shape:** detail-substring.
+
+---
+
+## Scenario: feature_update_nonexistent_rejected
+
+```yaml
+id: feature_update_nonexistent_rejected
+endpoints:
+  - PATCH /features/{id}
+entities: [feature]
+tags: [validation, update-time, single-request, not-found]
+```
+
+**Intent:** PATCHing an id that doesn't resolve returns `404`.
+
+**Fixtures:**
+- An `UpdateFeatureRequest` body with `unit_cost: null` (a syntactically
+  valid clear). Use a freshly generated ULID literal in the path —
+  guaranteed not to exist in the DB.
+
+**Steps:**
+
+1. **Patch unknown id.** `PATCH /features/<random-ULID-not-in-DB>` with
+   the body.
+   - Expect `404 Not Found`.
+   - Expect **detail contains** `"feature not found: <id>"` (the
+     literal id used in the path).
+
+**Notes:**
+
+- **Validation moment:** update-time. The feature is resolved before
+  any update is applied; missing → 404.
+- **Error shape:** detail-substring at status 404.
+
+---
+
+## Scenario: feature_get_nonexistent_returns_404
+
+```yaml
+id: feature_get_nonexistent_returns_404
+endpoints:
+  - GET /features/{id}
+entities: [feature]
+tags: [single-request, not-found]
+```
+
+**Intent:** GET on an unknown id returns `404` with the standard
+detail substring.
+
+**Fixtures:** *(none — the request is path-only)*.
+
+**Steps:**
+
+1. **Get unknown id.** `GET /features/<random-ULID-not-in-DB>`.
+   - Expect `404 Not Found`.
+   - Expect **detail contains** `"feature not found: <id>"`.
+
+**Notes:**
+
+- **Error shape:** detail-substring.
+- **GET by id vs. by key.** Lookup by key on a missing feature may
+  surface a different gateway-level detail (`"The requested route
+  was not found"`). This scenario uses a ULID-shaped path segment to
+  exercise the handler's own 404, not the gateway.
+
+---
+
+## Scenario: feature_delete_nonexistent_returns_404
+
+```yaml
+id: feature_delete_nonexistent_returns_404
+endpoints:
+  - DELETE /features/{id}
+entities: [feature]
+tags: [single-request, not-found]
+```
+
+**Intent:** DELETE on an unknown id returns `404`.
+
+**Fixtures:** *(none — the request is path-only)*.
+
+**Steps:**
+
+1. **Delete unknown id.** `DELETE /features/<random-ULID-not-in-DB>`.
+   - Expect `404 Not Found`.
+   - Expect **detail contains** `"feature not found: <id>"`.
+
+**Notes:**
+
+- **Error shape:** detail-substring.
+
+---
+
+## Scenario: feature_get_by_key_resolves
+
+```yaml
+id: feature_get_by_key_resolves
+endpoints:
+  - POST /features
+  - GET /features/{featureId}
+entities: [feature]
+tags: [single-request, lookup-by-key]
+```
+
+**Intent:** `GET /features/{featureId}` accepts either a ULID id or
+the feature's `key` in the path. Lookup by key resolves to the same
+feature.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature**.
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Get by key.** `GET /features/{feature.key}` (the path segment is
+   the feature's `key`, not its `id`).
+   - Expect `200 OK`.
+   - Expect `id` equals `{feature.id}`.
+   - Expect `key` equals `{feature.key}`.
+
+**Notes:**
+
+- **Why ULID-shaped keys are forbidden** (see
+  `feature_create_key_must_not_be_ulid`): if a key parsed as a ULID,
+  the by-id-or-key dispatch in `GetByIdOrKey` would be ambiguous.
+  This scenario is the positive read of the same dispatch.
+
+---
+
+## Scenario: feature_list_filter_by_meter_id
+
+```yaml
+id: feature_list_filter_by_meter_id
+endpoints:
+  - POST /meters
+  - POST /features
+  - GET /features
+entities: [feature, meter]
+tags: [list, filter, single-request]
+```
+
+**Intent:** `GET /features?filter[meter_id][eq]=<id>` returns only
+features whose `meter.id` equals the given ULID.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline meter** (call it meter A).
+- A second `CreateMeterRequest` per **Baseline meter** (meter B).
+- A `CreateFeatureRequest` per **Baseline feature** with
+  `meter: { id: {meter_a.id} }` (feature A).
+- A second `CreateFeatureRequest` per **Baseline feature** with
+  `meter: { id: {meter_b.id} }` (feature B).
+
+**Steps:**
+
+1. **Provision both meters and both features.** Four `POST` calls,
+   capturing each response body. Each `POST` expects `201 Created`.
+
+2. **List filtered by meter A.**
+   `GET /features?filter[meter_id][eq]={meter_a.id}&page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect response `data[]` contains an entry with
+     `id == {feature_a.id}`.
+   - Expect response `data[]` does **not** contain
+     `id == {feature_b.id}`.
+
+**Notes:**
+
+- **Filter operator.** ULID fields support `eq`, `neq`, `oeq`. Bare
+  ULID (`filter[meter_id]=<id>`) is also accepted by the schema.
+  This scenario pins the explicit `eq` form; downstream generators
+  may exercise alternates.
+- Page size is bumped to 1000 to handle a shared-DB drift past
+  page-1.
+
+---
+
+## Scenario: feature_list_filter_by_key
+
+```yaml
+id: feature_list_filter_by_key
+endpoints:
+  - POST /features
+  - GET /features
+entities: [feature]
+tags: [list, filter, single-request]
+```
+
+**Intent:** `GET /features?filter[key][eq]=<key>` returns the matching
+feature.
+
+**Fixtures:**
+- Two `CreateFeatureRequest`s per **Baseline feature**, each with a
+  distinct unique `key`.
+
+**Steps:**
+
+1. **Create both features.** Two `POST /features` calls; each
+   expects `201 Created`. Capture both response bodies as
+   `feature_a` and `feature_b`.
+
+2. **List filtered by feature A's key.**
+   `GET /features?filter[key][eq]={feature_a.key}&page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect `data[]` contains an entry with `id == {feature_a.id}`.
+   - Expect `data[]` does **not** contain `id == {feature_b.id}`.
+
+**Notes:**
+
+- **Filter operator.** `key` is a `StringFieldFilter`; supports `eq`,
+  `neq`, `contains`, `ocontains`, `oeq`, `gt`/`gte`/`lt`/`lte`,
+  `exists`, or a bare string (interpreted as `eq`).
+
+---
+
+## Scenario: feature_list_filter_by_name
+
+```yaml
+id: feature_list_filter_by_name
+endpoints:
+  - POST /features
+  - GET /features
+entities: [feature]
+tags: [list, filter, single-request]
+```
+
+**Intent:** `GET /features?filter[name][eq]=<name>` returns the
+matching feature.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature** with `name`
+  overridden to a unique distinctive value (e.g.
+  `"Test Feature ListByName <unique-suffix>"`).
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **List filtered by name.**
+   `GET /features?filter[name][eq]={feature.name}&page[size]=1000`
+   (URL-encode the name).
+   - Expect `200 OK`.
+   - Expect `data[]` contains exactly the feature with
+     `id == {feature.id}` (the unique-suffix guarantees no other
+     match in a shared DB).
+
+**Notes:**
+
+- The unique suffix on `name` is what keeps the list narrow on a
+  shared DB; without it the assertion would have to allow noise.
+
+---
+
+## Scenario: feature_list_combined_filters
+
+```yaml
+id: feature_list_combined_filters
+endpoints:
+  - POST /meters
+  - POST /features
+  - GET /features
+entities: [feature, meter]
+tags: [list, filter, matrix]
+```
+
+**Intent:** Combining multiple filter fields narrows the result to
+the intersection. `filter[meter_id]` AND `filter[key]` together
+return only features matching both.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline meter** (meter A) and a
+  second one (meter B).
+- Four `CreateFeatureRequest`s per **Baseline feature**:
+  - feature_a1 with meter A and key `"alpha_<suffix1>"`.
+  - feature_a2 with meter A and key `"beta_<suffix2>"`.
+  - feature_b1 with meter B and key `"alpha_<suffix3>"`.
+  - feature_b2 with meter B and key `"beta_<suffix4>"`.
+
+**Rows:**
+
+| # | Filter | Expected ids in `data[]` |
+|---|---|---|
+| 1 | `filter[meter_id][eq]={meter_a.id}` only | `{feature_a1.id}` and `{feature_a2.id}` |
+| 2 | `filter[key][eq]={feature_a1.key}` only | `{feature_a1.id}` only |
+| 3 | both `filter[meter_id][eq]={meter_a.id}` and `filter[key][eq]={feature_b1.key}` | empty (intersection) |
+
+**Steps per row:**
+
+1. **List with row's filters.**
+   `GET /features?<row's query>&page[size]=1000`.
+   - Expect `200 OK`.
+   - For each id listed in the `Expected ids` cell, expect an entry
+     with `id == <captured id>` to be present in `data[]`.
+   - For ids not in the cell that exist in the fixture set, expect
+     them **absent** from `data[]`.
+
+**Notes:**
+
+- The "empty intersection" row pins AND-semantics: filters compose,
+  they don't union.
+- Page size 1000 to absorb shared-DB noise.
+
+---
+
+## Scenario: feature_list_sort_by_supported_fields
+
+```yaml
+id: feature_list_sort_by_supported_fields
+endpoints:
+  - POST /features
+  - GET /features
+entities: [feature]
+tags: [list, sort, matrix]
+```
+
+**Intent:** The `sort` query param accepts `key`, `name`,
+`created_at` (default), and `updated_at`, optionally suffixed with
+`:asc` (default) or `:desc`. Each combination returns features in
+the expected order.
+
+**Fixtures:**
+- Three `CreateFeatureRequest`s per **Baseline feature**, each with
+  distinct unique-suffix `key` and `name` values, **created in
+  predictable order** (e.g. A, then B, then C, far enough apart in
+  time that `created_at` strictly orders them).
+
+**Rows:**
+
+| # | `sort` value | Expected order of fixture entries (by `id`) |
+|---|---|---|
+| 1 | `key` (or `key:asc`) | sorted ascending by `key` |
+| 2 | `key:desc` | sorted descending by `key` |
+| 3 | `name` | sorted ascending by `name` |
+| 4 | `name:desc` | sorted descending by `name` |
+| 5 | `created_at` (or omitted — the default) | A, B, C |
+| 6 | `created_at:desc` | C, B, A |
+| 7 | `updated_at` | sorted ascending by `updated_at` |
+| 8 | `updated_at:desc` | sorted descending by `updated_at` |
+
+**Steps per row:**
+
+1. **List with row's `sort`.**
+   `GET /features?sort=<row's value>&page[size]=1000`.
+   - Expect `200 OK`.
+   - Filter `data[]` to entries whose `id` is in
+     `{ {feature_a.id}, {feature_b.id}, {feature_c.id} }`, then
+     compare the resulting order against the row's expected order.
+
+**Notes:**
+
+- **Why filter the result.** A shared DB carries other features.
+  The row asserts the relative order of the three fixtures, not the
+  absolute contents of `data[]`.
+- **Updated-at ordering.** If `updated_at` rows depend on a known
+  modification time, perform a no-op PATCH (e.g.
+  `unit_cost: null` on a feature with no unit_cost) to bump
+  `updated_at` predictably before the assertion.
+
+---
+
+## Scenario: feature_list_sort_invalid_field_rejected
+
+```yaml
+id: feature_list_sort_invalid_field_rejected
+endpoints:
+  - GET /features
+entities: [feature]
+tags: [list, sort, validation, single-request]
+```
+
+**Intent:** `sort=<unknown_field>` returns `400 Bad Request`.
+
+**Fixtures:** *(none)*.
+
+**Steps:**
+
+1. **List with bad sort field.** `GET /features?sort=banana`.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains** `"invalid feature order by: banana"`.
+
+**Notes:**
+
+- **Error shape:** detail-substring at status 400.
+- The valid set is `{ key, name, created_at, updated_at }`. Suffix
+  `:asc` / `:desc` is parsed and stripped before validation, so
+  `key:zzz` (bad direction) is **schema-rule** territory rather
+  than detail-substring; not pinned by this scenario.
+
+---
+
+## Scenario: feature_list_filter_malformed_rejected
+
+```yaml
+id: feature_list_filter_malformed_rejected
+endpoints:
+  - GET /features
+entities: [feature]
+tags: [list, filter, validation, single-request]
+```
+
+**Intent:** A filter expression the OpenAPI binder cannot parse
+returns `400 Bad Request` with `invalid_parameters[]` populated.
+This is the schema-rule shape, not the domain shape.
+
+**Rows:**
+
+| # | Query | Expect `field` match | Expect `rule` |
+|---|---|---|---|
+| 1 | `filter[meter_id][eq]=not-a-ulid` | `field` references `filter.meter_id.eq` (or its parent `filter.meter_id`) | `"format"` (ULID-format rejection) — `NEEDS-VERIFY: confirm exact rule string against a live server before relying on it` |
+| 2 | `filter[meter_id][zz]=01HXYZ...` | `field` references `filter.meter_id` (or `filter.meter_id.zz`) | `"additionalProperties"` (unknown property) — `NEEDS-VERIFY: confirm exact rule string against a live server before relying on it` |
+
+**Steps per row:**
+
+1. **List with malformed filter.** `GET /features?<row's query>`.
+   - Expect `400 Bad Request`.
+   - Expect `invalid_parameters[]` is present and non-empty.
+   - Expect at least one entry where `field` references the row's
+     bad filter param **and** `rule` matches the row's expected
+     rule string.
+
+**Notes:**
+
+- **Error shape:** schema-rule (`invalid_parameters[]`), not
+  detail-substring. Schema validation rejects before the request
+  body is processed.
+- **Rule strings flagged NEEDS-VERIFY.** Both rule strings above
+  are reasonable defaults from the JSON Schema vocabulary the
+  binder uses, but the exact value is binder-implementation-specific
+  and may differ. Confirm against a live server before generating a
+  test. If a rule turns out to be unstable across releases, fall
+  back to asserting only `field` and drop the `rule` assertion for
+  that row.
+
+---
+
+## Scenario: feature_list_pagination
+
+```yaml
+id: feature_list_pagination
+endpoints:
+  - POST /features
+  - GET /features
+entities: [feature]
+tags: [list, pagination, single-request]
+```
+
+**Intent:** `page[number]` + `page[size]` slice the result and
+populate the response `meta` block. Page size 1 over three fixtures
+yields three pages.
+
+**Fixtures:**
+- Three `CreateFeatureRequest`s per **Baseline feature**, each with
+  a distinct `key` and a **shared `name` prefix** (e.g.
+  `"e2e_pagination_<suffix>"`). The shared prefix makes the per-row
+  filter narrow without depending on absolute DB state.
+
+**Steps:**
+
+1. **Provision three features.** Three `POST /features` calls; each
+   `201 Created`. Capture the three response bodies.
+
+2. **List page 1, size 1, filtered to fixtures.**
+   `GET /features?filter[name][contains]=<shared-prefix>&page[number]=1&page[size]=1`.
+   - Expect `200 OK`.
+   - Expect `data[]` has length `1`.
+   - Expect `meta.page.total` is `3`.
+   - Expect `meta.page.number` is `1`.
+   - Expect `meta.page.size` is `1`.
+
+3. **List page 2.** Same filter, `page[number]=2&page[size]=1`.
+   - Expect `200 OK`.
+   - Expect `data[]` has length `1`.
+   - Expect `meta.page.number` is `2`.
+   - Expect the entry differs from page 1's entry by `id`.
+
+4. **List page 3.** Same filter, `page[number]=3&page[size]=1`.
+   - Expect `200 OK`.
+   - Expect `data[]` has length `1`.
+   - Expect `meta.page.number` is `3`.
+   - Expect the entry differs from pages 1 and 2 by `id`.
+
+5. **Assert union covers fixtures.** The three captured ids equal the
+   union of the three pages' single-entry ids (in some order).
+
+**Notes:**
+
+- **Why `contains` on the name** instead of `eq` per-feature? `eq`
+  collapses to one row (no pagination to test). The shared-prefix
+  `contains` filter narrows to exactly the three fixtures.
+- **Pagination meta shape:** `meta.page.{number, size, total}` per
+  the `PaginatedMeta` / `PageMeta` schema in the OpenAPI spec.
+
+---
+
+## Scenario: feature_cost_query_happy_path
+
+```yaml
+id: feature_cost_query_happy_path
+endpoints:
+  - POST /meters
+  - POST /features
+  - POST /features/{id}/cost/query
+entities: [feature, meter]
+tags: [cost-query, single-request]
+```
+
+**Intent:** `POST /features/{id}/cost/query` with an empty body on a
+metered feature with a manual unit cost returns `200 OK` and a
+`FeatureCostQueryResult` with at least one row. Zero usage yields
+`cost: "0"`, `usage: "0"`, `currency: "USD"`, and the default time
+window `1970-01-01T00:00:00Z` → `1970-01-01T00:01:00Z`.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline meter**.
+- A `CreateFeatureRequest` per **Baseline feature** with:
+  - `meter`: `{ id: {meter.id} }`.
+  - `unit_cost`: per **Baseline manual unit cost**.
+
+**Steps:**
+
+1. **Create meter.** `POST /meters` with the meter fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `meter` ← `response.body`
+
+2. **Create metered feature with manual unit cost.**
+   `POST /features` with the feature fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+3. **Query cost with empty body.**
+   `POST /features/{feature.id}/cost/query` with body `{}`.
+   - Expect `200 OK`.
+   - Expect `data` is a non-empty list (at least one row).
+   - Expect `data[0].cost` is `"0"` (or `null` if the row has no
+     resolved pricing — both are valid for zero usage; pin
+     whichever the live server emits).
+   - Expect `data[0].usage` is `"0"`.
+   - Expect `data[0].currency` is `"USD"`.
+   - Expect `data[0].from` is `"1970-01-01T00:00:00Z"`.
+   - Expect `data[0].to` is `"1970-01-01T00:01:00Z"`.
+
+**Notes:**
+
+- **Validation moment:** none — this is a positive read.
+- **Empty body.** The endpoint accepts a missing body via
+  `request.ParseOptionalBody`; an empty `{}` is the canonical empty
+  shape. The default time window when neither `from` nor `to` is
+  provided is the unix epoch + 60s — confirmed against a live
+  server.
+- **Manual unit cost makes `cost` resolvable.** With an LLM unit
+  cost, `cost` may be `null` for unresolved pricing. Manual costs
+  always resolve as `usage × amount` (here `0 × 5 = 0`).
+
+---
+
+## Scenario: feature_cost_query_nonexistent_feature_returns_404
+
+```yaml
+id: feature_cost_query_nonexistent_feature_returns_404
+endpoints:
+  - POST /features/{id}/cost/query
+entities: [feature]
+tags: [cost-query, single-request, not-found]
+```
+
+**Intent:** `POST /features/{id}/cost/query` on an unknown feature id
+returns `404` with the standard detail substring.
+
+**Fixtures:** *(none — the request is path-only)*.
+
+**Steps:**
+
+1. **Query cost on missing feature.**
+   `POST /features/<random-ULID-not-in-DB>/cost/query` with body `{}`.
+   - Expect `404 Not Found`.
+   - Expect **detail contains** `"feature not found: <id>"`.
+
+**Notes:**
+
+- **Error shape:** detail-substring.
+- The feature is resolved first, so the 404 fires before any meter
+  or query-param processing — body shape doesn't matter for this
+  failure mode.
+
+---
+
+## Scenario: feature_cost_query_no_meter_rejected
+
+```yaml
+id: feature_cost_query_no_meter_rejected
+endpoints:
+  - POST /features
+  - POST /features/{id}/cost/query
+entities: [feature]
+tags: [cost-query, validation, single-request]
+```
+
+**Intent:** `POST /features/{id}/cost/query` on a feature with no
+associated meter returns `400 Bad Request`. Cost is meaningless
+without usage; the handler rejects up front.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature** (no meter).
+
+**Steps:**
+
+1. **Create static feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Query cost on unmetered feature.**
+   `POST /features/{feature.id}/cost/query` with body `{}`.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains**
+     `"feature {feature.key} has no meter associated"`.
+
+**Notes:**
+
+- **Validation moment:** request-time, after feature resolution and
+  before any query processing.
+- **Error shape:** detail-substring at status 400.
+
+---
+
+## Scenario: feature_archived_excluded_from_list
+
+```yaml
+id: feature_archived_excluded_from_list
+endpoints:
+  - POST /features
+  - DELETE /features/{id}
+  - GET /features
+entities: [feature]
+tags: [list, archive, single-request]
+```
+
+**Intent:** After `DELETE`, the feature is not returned by a default
+`GET /features` call. v3 has no `include_archived` query param, so
+archived features are unreachable via the public API.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature**.
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Delete feature.** `DELETE /features/{feature.id}`.
+   - Expect `204 No Content`.
+
+3. **List features and confirm absence.**
+   `GET /features?page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect `data[]` does **not** contain an entry with
+     `id == {feature.id}`.
+
+**Notes:**
+
+- **No include-archived param.** Known parity gap with v1: the v1 list
+  endpoint accepted `include_archived=true`; v3 does not.
+
+---
+
+## Scenario: feature_archived_get_returns_404
+
+```yaml
+id: feature_archived_get_returns_404
+endpoints:
+  - POST /features
+  - DELETE /features/{id}
+  - GET /features/{id}
+entities: [feature]
+tags: [archive, single-request, not-found]
+```
+
+**Intent:** After `DELETE`, `GET /features/{id}` returns `404` with
+the standard detail substring. The TypeSpec declares `Common.Gone`
+(410) as a possible response, but the live server always returns 404.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature**.
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Delete feature.** `DELETE /features/{feature.id}`.
+   - Expect `204 No Content`.
+
+3. **Get archived feature.** `GET /features/{feature.id}`.
+   - Expect `404 Not Found`.
+   - Expect **detail contains**
+     `"feature not found: {feature.id}"`.
+
+**Notes:**
+
+- **404, not 410.** TypeSpec lists both
+  `Common.NotFound` (404) and `Common.Gone` (410); the server pins
+  404. Confirmed against a live server. If the server later starts
+  returning 410, this scenario is the regression test.
+- **Error shape:** detail-substring.
+
+---
+
+## Scenario: feature_llm_pricing_absent_when_unresolved
+
+```yaml
+id: feature_llm_pricing_absent_when_unresolved
+endpoints:
+  - POST /meters
+  - POST /features
+  - GET /features/{id}
+entities: [feature, meter]
+tags: [llm, get, single-request]
+```
+
+**Intent:** GET on an LLM feature whose `provider` + `model` cannot
+be resolved against the LLM cost database returns `200 OK` with the
+`pricing` block silently absent on the feature's `unit_cost`. No
+error, no warning — just an unenriched response.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline LLM-capable meter**.
+- A `CreateFeatureRequest` per **Baseline feature** with:
+  - `meter`: `{ id: {meter.id} }`.
+  - `unit_cost`: a `BillingFeatureLLMUnitCost` with:
+    - `type`: `"llm"`.
+    - `provider`: `"unknown_provider_<unique>"`.
+    - `model`: `"unknown_model_<unique>"`.
+    - `token_type`: `"input"`.
+
+**Steps:**
+
+1. **Create meter.** `POST /meters`.
+   - Expect `201 Created`.
+
+   Captures:
+   - `meter` ← `response.body`
+
+2. **Create LLM feature with unresolvable provider/model.**
+   `POST /features`.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+3. **GET the feature.** `GET /features/{feature.id}`.
+   - Expect `200 OK`.
+   - Expect `unit_cost.type` is `"llm"`.
+   - Expect `unit_cost.provider` equals the fixture provider.
+   - Expect `unit_cost.model` equals the fixture model.
+   - Expect `unit_cost.pricing` is **absent**.
+
+**Notes:**
+
+- **Failure mode is silent.** `resolveLLMPricing` returns `nil` when
+  the provider or model can't be looked up; the response is built
+  without the pricing block.
+- **Error shape:** none — this is a positive scenario over an
+  intentionally unresolvable input.
+
+---
+
+## Scenario: feature_llm_pricing_enriched_on_get
+
+```yaml
+id: feature_llm_pricing_enriched_on_get
+endpoints:
+  - POST /meters
+  - POST /features
+  - GET /features/{id}
+entities: [feature, meter]
+tags: [llm, get, single-request, needs-verify, skipped]
+status: skipped
+```
+
+**Status: SKIPPED.** Environment-gated; deferred until the e2e stack
+provisions a deterministic LLM-cost seed (a known `(openai, gpt-4)`
+price). Do not generate a test from this scenario. Re-enable by
+removing this block once seeding is in place.
+
+**Intent:** GET on an LLM feature whose `provider` + `model` resolve
+against the LLM cost database returns `200 OK` with `unit_cost.pricing`
+populated from the database (`input_per_token`, `output_per_token`, …).
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline LLM-capable meter**.
+- A `CreateFeatureRequest` per **Baseline feature** with:
+  - `meter`: `{ id: {meter.id} }`.
+  - `unit_cost`: per **Baseline LLM unit cost (static)** — that is,
+    `provider: "openai"`, `model: "gpt-4"`, `token_type: "input"`.
+- **Environmental precondition:** the LLM cost database must contain
+  a price for `(provider: openai, model: gpt-4)` in the test
+  namespace. Without that seed the scenario degrades to
+  `feature_llm_pricing_absent_when_unresolved`.
+
+**Steps:**
+
+1. **Create meter.** `POST /meters`.
+   - Expect `201 Created`.
+
+   Captures:
+   - `meter` ← `response.body`
+
+2. **Create LLM feature with resolvable provider/model.**
+   `POST /features`.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+3. **GET the feature.** `GET /features/{feature.id}`.
+   - Expect `200 OK`.
+   - Expect `unit_cost.type` is `"llm"`.
+   - Expect `unit_cost.pricing` is present.
+   - Expect `unit_cost.pricing.input_per_token` parses as a non-negative
+     decimal string.
+   - Expect `unit_cost.pricing.output_per_token` parses as a
+     non-negative decimal string.
+
+**Notes:**
+
+- **NEEDS-VERIFY: requires seed data in the e2e environment's LLM
+  cost DB.** Until the e2e stack provisions a known
+  (`openai`, `gpt-4`) price, this scenario isn't deterministically
+  exercisable from the API alone. Two resolutions:
+  1. Add a fixture step that seeds the price via a public LLM-cost
+     endpoint (if one exists).
+  2. Tag this scenario as environment-gated and skip when the seed
+     is missing.
+- **Error shape:** none — positive scenario.


### PR DESCRIPTION
## Overview

- adds a new `e2e-nl` skill that turns a v3 API endpoint's source files into a natural-language, runner-agnostic e2e test spec. Downstream skills consume the spec to emit tests in Go via `/e2e` today and Playwright / `.http` / Hurl / other runners later, without re specing.
- `e2e/specs/features.md` is included as a worked example covering the `features` endpoints
- an initial run with the existing `/e2e` skill produced comparable tests to the existing product catalog ones 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new natural-language e2e-specification skill and formal format for runner-agnostic API scenario docs.
  * Provided concrete scenario templates and baselines for product-catalog endpoints and feature/cost-query endpoints.
  * Standardized scenario structure, error-shape vocabularies, validation-timing rules, capture semantics, and annotations like NEEDS-VERIFY and status: skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->