### PR TITLE
fix: revert IDs, Keys and Currencies filter options in adapter level

### DIFF
--- a/openmeter/productcatalog/addon/adapter/adapter_test.go
+++ b/openmeter/productcatalog/addon/adapter/adapter_test.go
@@ -123,6 +123,22 @@ func TestPostgresAdapter(t *testing.T) {
 
 			require.NotNilf(t, addonV1, "add-on must not be nil")
 
+			addonV2Input := pctestutils.NewTestAddon(t, namespace, productcatalog.RateCards{
+				&productcatalog.FlatFeeRateCard{
+					RateCardMeta: productcatalog.RateCardMeta{
+						Key:  features[0].Key,
+						Name: features[0].Name,
+					},
+					BillingCadence: lo.ToPtr(MonthPeriod),
+				},
+			}...)
+			addonV2Input.Key += "v2"
+			addonV2Input.Name += "v2"
+			addonV2, err := env.AddonRepository.CreateAddon(ctx, addonV2Input)
+			require.NoErrorf(t, err, "creating new add-on must not fail")
+
+			require.NotNilf(t, addonV2, "add-on must not be nil")
+
 			addon.AssertAddonCreateInputEqual(t, addonV1Input, *addonV1)
 
 			t.Run("Get", func(t *testing.T) {
@@ -194,6 +210,17 @@ func TestPostgresAdapter(t *testing.T) {
 					require.Lenf(t, listAddonV1.Items, 1, "add-ons must not be empty")
 
 					addon.AssertAddonEqual(t, *addonV1, listAddonV1.Items[0])
+				})
+
+				t.Run("ByKeyOrID", func(t *testing.T) {
+					listAddonV1, err := env.AddonRepository.ListAddons(ctx, addon.ListAddonsInput{
+						Namespaces: []string{namespace},
+						IDs:        []string{addonV2.ID},
+						Keys:       []string{addonV1.Key},
+					})
+					assert.NoErrorf(t, err, "getting add-on by key filter must not fail")
+
+					require.Lenf(t, listAddonV1.Items, 2, "add-ons must not be empty")
 				})
 
 				t.Run("ByIdFilter", func(t *testing.T) {

--- a/openmeter/productcatalog/addon/adapter/adapter_test.go
+++ b/openmeter/productcatalog/addon/adapter/adapter_test.go
@@ -172,6 +172,30 @@ func TestPostgresAdapter(t *testing.T) {
 			})
 
 			t.Run("List", func(t *testing.T) {
+				t.Run("ById", func(t *testing.T) {
+					listAddonV1, err := env.AddonRepository.ListAddons(ctx, addon.ListAddonsInput{
+						Namespaces: []string{namespace},
+						IDs:        []string{addonV1.ID},
+					})
+					assert.NoErrorf(t, err, "listing add-on by id filter must not fail")
+
+					require.Lenf(t, listAddonV1.Items, 1, "add-ons must not be empty")
+
+					addon.AssertAddonEqual(t, *addonV1, listAddonV1.Items[0])
+				})
+
+				t.Run("ByKey", func(t *testing.T) {
+					listAddonV1, err := env.AddonRepository.ListAddons(ctx, addon.ListAddonsInput{
+						Namespaces: []string{namespace},
+						Keys:       []string{addonV1Input.Key},
+					})
+					assert.NoErrorf(t, err, "getting add-on by key filter must not fail")
+
+					require.Lenf(t, listAddonV1.Items, 1, "add-ons must not be empty")
+
+					addon.AssertAddonEqual(t, *addonV1, listAddonV1.Items[0])
+				})
+
 				t.Run("ByIdFilter", func(t *testing.T) {
 					listAddonV1, err := env.AddonRepository.ListAddons(ctx, addon.ListAddonsInput{
 						Namespaces: []string{namespace},

--- a/openmeter/productcatalog/addon/adapter/addon.go
+++ b/openmeter/productcatalog/addon/adapter/addon.go
@@ -37,12 +37,27 @@ func (a *adapter) ListAddons(ctx context.Context, params addon.ListAddonsInput) 
 			query = query.Where(addondb.NamespaceIn(params.Namespaces...))
 		}
 
+		var orFilters []predicate.Addon
+		if len(params.IDs) > 0 {
+			orFilters = append(orFilters, addondb.IDIn(params.IDs...))
+		}
+
+		if len(params.Keys) > 0 {
+			orFilters = append(orFilters, addondb.KeyIn(params.Keys...))
+		}
+
 		if len(params.KeyVersions) > 0 {
-			var kvFilters []predicate.Addon
 			for key, version := range params.KeyVersions {
-				kvFilters = append(kvFilters, addondb.And(addondb.Key(key), addondb.VersionIn(version...)))
+				orFilters = append(orFilters, addondb.And(addondb.Key(key), addondb.VersionIn(version...)))
 			}
-			query = query.Where(addondb.Or(kvFilters...))
+		}
+
+		if len(params.Currencies) > 0 {
+			orFilters = append(orFilters, addondb.CurrencyIn(params.Currencies...))
+		}
+
+		if len(orFilters) > 0 {
+			query = query.Where(addondb.Or(orFilters...))
 		}
 
 		query = filter.ApplyToQuery(query, params.ID, addondb.FieldID)

--- a/openmeter/productcatalog/addon/httpdriver/addon.go
+++ b/openmeter/productcatalog/addon/httpdriver/addon.go
@@ -14,7 +14,6 @@ import (
 	productcataloghttp "github.com/openmeterio/openmeter/openmeter/productcatalog/http"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/defaultx"
-	"github.com/openmeterio/openmeter/pkg/filter"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
 	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -53,19 +52,12 @@ func (h *handler) ListAddons() ListAddonsHandler {
 					PageNumber: defaultx.WithDefault(params.Page, notification.DefaultPageNumber),
 				},
 				Namespaces:     []string{ns},
+				IDs:            lo.FromPtr(params.Id),
+				Keys:           lo.FromPtr(params.Key),
 				KeyVersions:    lo.FromPtr(params.KeyVersion),
 				IncludeDeleted: lo.FromPtr(params.IncludeDeleted),
+				Currencies:     lo.FromPtr(params.Currency),
 				Status:         statusFilter,
-			}
-
-			if params.Id != nil {
-				req.ID = &filter.FilterULID{FilterString: filter.FilterString{In: params.Id}}
-			}
-			if params.Key != nil {
-				req.Key = &filter.FilterString{In: params.Key}
-			}
-			if params.Currency != nil {
-				req.Currency = &filter.FilterString{In: params.Currency}
 			}
 
 			return req, nil

--- a/openmeter/productcatalog/addon/service.go
+++ b/openmeter/productcatalog/addon/service.go
@@ -81,6 +81,12 @@ type ListAddonsInput struct {
 	// Namespaces is the list of namespaces to filter by.
 	Namespaces []string
 
+	// IDs is the list of IDs to filter by.
+	IDs []string
+
+	// Keys is the list of keys to filter by.
+	Keys []string
+
 	// KeyVersions is the map of keys to versions to filter by.
 	KeyVersions map[string][]int
 
@@ -89,6 +95,9 @@ type ListAddonsInput struct {
 
 	// Status filter
 	Status []productcatalog.AddonStatus
+
+	// Currencies is the list of currencies to filter by.
+	Currencies []string
 
 	// Filters
 	ID       *filter.FilterULID

--- a/openmeter/productcatalog/addon/service/addon.go
+++ b/openmeter/productcatalog/addon/service/addon.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/pkg/clock"
-	"github.com/openmeterio/openmeter/pkg/filter"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
@@ -293,7 +292,7 @@ func (s service) getAddonVersions(ctx context.Context, namespace, key string) (a
 		OrderBy:        addon.OrderByVersion,
 		Order:          addon.OrderAsc,
 		Namespaces:     []string{namespace},
-		Key:            &filter.FilterString{In: &[]string{key}},
+		Keys:           []string{key},
 		IncludeDeleted: true,
 	})
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced add-on listing: accepts multiple IDs, Keys, and Currencies and applies them together when filtering results.

* **Tests**
  * Expanded test coverage for listing add-ons: filtering by ID, by Key, and combined Key+ID scenarios to validate multi-criteria behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->