### PR TITLE
chore: add end-to-end testing with hurl

### DIFF
--- a/.agents/skills/create-hurl-test/SKILL.md
+++ b/.agents/skills/create-hurl-test/SKILL.md
@@ -1,0 +1,420 @@
+---
+name: create-hurl-test
+description: Generate a Hurl (.hurl) end-to-end test for an OpenMeter API endpoint. Covers both v3 (AIP-style filtering, api/v3/openapi.yaml) and v1 (api/openapi.yaml, api/spec/packages/legacy/) APIs. Output files go in e2e/hurl/ named openmeter-<api-version>-<domain>.hurl. Use this when someone wants to create an HTTP-level e2e test using the Hurl tool.
+user-invocable: true
+argument-hint: "<test name> <description>"
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
+---
+
+# Create Hurl E2E Test
+
+Generate a [Hurl](https://hurl.dev/) end-to-end test for an OpenMeter API endpoint.
+
+**Args:**
+- `$1` — test name (e.g. `"Meter Lifecycle"`)
+- `$2` — description of what to test (e.g. `"create, get, list, update, delete a meter"`)
+
+Parse both from `args`. If unclear, ask once.
+
+## Hurl Format Primer
+
+A `.hurl` file is a sequence of HTTP entries separated by blank lines. Each entry has:
+
+```hurl
+# Optional comment
+METHOD url
+[Headers]
+Header-Name: value
+
+[Request body — for POST/PUT]
+```json
+{ "key": "value" }
+```
+
+HTTP status_code
+[Asserts]
+jsonpath "$.field" == "value"
+
+[Captures]
+var_name: jsonpath "$.id"
+```
+
+Key syntax rules:
+- Variables: `{{variable_name}}` — injected via CLI `--variable key=value` or captured from previous responses
+- `[QueryStringParams]` section handles `deepObject` style filters (`filter[key]=value`) — always prefer this over URL encoding
+- `[Captures]` binds response values to variables for later requests
+- `[Asserts]` holds multiple assertions; jsonpath queries use `$.field` syntax
+- Requests within one file run sequentially; blank lines between entries
+- Comments: `#` prefix
+
+## File Location and Naming
+
+```
+e2e/hurl/openmeter-v3-<domain>.hurl    # v3 API (api/v3/openapi.yaml)
+e2e/hurl/openmeter-v1-<domain>.hurl    # v1 API (api/openapi.yaml)
+```
+
+Create `e2e/hurl/` if it doesn't exist.
+
+## Unique Keys / Run Isolation
+
+Hurl has no built-in random generation. Pass a unique suffix at CLI time:
+
+```bash
+hurl --test \
+  --variable base_url=http://localhost:8888 \
+  --variable api_key="" \
+  --variable run_id=$(date +%s%N | head -c 13) \
+  e2e/hurl/openmeter-v3-meters.hurl
+```
+
+In the `.hurl` file, append `{{run_id}}` to any field that must be unique per run:
+
+```
+"key": "test_meter_{{run_id}}"
+"name": "Test Meter {{run_id}}"
+```
+
+## Standard Variables
+
+Every test file uses these variables (passed via CLI `--variable`):
+
+| Variable | Default at CLI | Purpose |
+|---|---|---|
+| `base_url` | `http://localhost:8888` | Server base URL (no trailing slash) |
+| `api_key` | `""` (empty = no auth) | Bearer token; empty value omits auth effectively |
+| `run_id` | `$(date +%s%N \| head -c 13)` | Unique suffix to avoid key collisions |
+
+Auth header in every request (empty value is a valid no-op for local dev):
+
+```hurl
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```
+
+## Step 1 — Research the Endpoint
+
+Read sources in this order before writing any Hurl code:
+
+### 1a. OpenAPI spec
+
+**v3:** `api/v3/openapi.yaml`
+**v1:** `api/openapi.yaml`
+
+Extract:
+- Path (e.g. `/openmeter/meters`) → append to `{{base_url}}/api/v3`
+- Methods + status codes (POST→201, GET→200, PUT→200, DELETE→204, etc.)
+- Required fields and their types
+- Filter params and their `style` (deepObject for v3 AIP filters)
+- Pagination shape: always `{ data: [...], meta: { page: { ... } } }` for v3 list responses
+
+```bash
+# Find paths for a domain
+grep -n '/openmeter/meters' api/v3/openapi.yaml
+
+# Find schema
+grep -n -A 30 'CreateMeterRequest:' api/v3/openapi.yaml
+```
+
+### 1b. TypeSpec source
+
+**v3:** `api/spec/packages/aip/src/<domain>/`
+**v1:** `api/spec/packages/legacy/src/<domain>/`
+
+Read when OpenAPI field semantics are unclear.
+
+### 1c. Handler
+
+**v3:** `api/v3/handlers/<domain>/`
+
+Key files: `create.go`, `list.go`, `get.go`, `update.go`, `delete.go`, `convert.go`, `errors.go`
+
+Tells you:
+- Which validators fire (look for `validateDimensions*`, `request.ParseBody`, etc.)
+- Error shape used: `apierrors.GenericErrorEncoder()` → domain code via `extensions.validationErrors[].code`; `BaseAPIError` → detail substring via `problem.detail`; schema binder → `invalid_parameters[].rule`
+- Which fields are accepted vs. ignored
+
+### 1d. Domain module
+
+`openmeter/<domain>/`
+
+Look for `Validate()`, validation error codes, enum values, constraint logic.
+
+## Step 2 — Choose or Create the Hurl File
+
+| Scenario | Action |
+|---|---|
+| Domain has no `.hurl` file yet | Create `e2e/hurl/openmeter-v3-<domain>.hurl` |
+| File exists, adding a new test | Append below the last entry (blank line separator) |
+
+## Step 3 — Write the Hurl Test
+
+### Base URL Path
+
+v3 path = `{{base_url}}/api/v3` + OpenAPI path suffix without `/openmeter` prefix:
+
+> `/openmeter/meters` → `{{base_url}}/api/v3/openmeter/meters`
+
+### Lifecycle Template (v3)
+
+```hurl
+# ── 1. Create ─────────────────────────────────────────────────────────────────
+POST {{base_url}}/api/v3/openmeter/meters
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "key": "test_meter_{{run_id}}",
+  "name": "Test Meter {{run_id}}",
+  "aggregation": "sum",
+  "event_type": "api_request",
+  "value_property": "$.duration_ms"
+}
+```
+HTTP 201
+[Captures]
+meter_id: jsonpath "$.id"
+meter_key: jsonpath "$.key"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.key" == "test_meter_{{run_id}}"
+jsonpath "$.status" == "active"
+jsonpath "$.deleted_at" not exists
+
+# ── 2. Get by ID ──────────────────────────────────────────────────────────────
+GET {{base_url}}/api/v3/openmeter/meters/{{meter_id}}
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{meter_id}}"
+jsonpath "$.key" == "test_meter_{{run_id}}"
+
+# ── 3. List — verify appears ──────────────────────────────────────────────────
+# Use JSONPath filter expression, NOT $.data[*].id contains "{{id}}"
+# $.data[*].id returns a bare string (not array) when exactly 1 item exists,
+# making the contains predicate do a substring check instead of membership check.
+GET {{base_url}}/api/v3/openmeter/meters
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+page[size]: 1000
+HTTP 200
+[Asserts]
+jsonpath "$.data" isCollection
+jsonpath "$.data[?(@.id=='{{meter_id}}')].id" == "{{meter_id}}"
+
+# ── 4. List — filter by key ───────────────────────────────────────────────────
+GET {{base_url}}/api/v3/openmeter/meters
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+filter[key]: test_meter_{{run_id}}
+page[size]: 10
+HTTP 200
+[Asserts]
+jsonpath "$.data" count == 1
+jsonpath "$.data[0].id" == "{{meter_id}}"
+
+# ── 5. Update ─────────────────────────────────────────────────────────────────
+PUT {{base_url}}/api/v3/openmeter/meters/{{meter_id}}
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "name": "Updated Meter {{run_id}}"
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.name" == "Updated Meter {{run_id}}"
+jsonpath "$.key" == "test_meter_{{run_id}}"
+
+# ── 6. Delete ─────────────────────────────────────────────────────────────────
+DELETE {{base_url}}/api/v3/openmeter/meters/{{meter_id}}
+Authorization: Bearer {{api_key}}
+HTTP 204
+
+# ── 7. Get after delete — soft delete returns 200 + deleted_at ───────────────
+GET {{base_url}}/api/v3/openmeter/meters/{{meter_id}}
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.deleted_at" isString
+```
+
+### Validation Test Template (single-request)
+
+```hurl
+# ── Validation: count aggregation must not have value_property ───────────────
+POST {{base_url}}/api/v3/openmeter/meters
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "key": "test_count_bad_{{run_id}}",
+  "name": "Count Bad {{run_id}}",
+  "aggregation": "count",
+  "event_type": "api_request",
+  "value_property": "$.duration_ms"
+}
+```
+HTTP 400
+```
+
+### Asserting Error Shapes
+
+v3 uses three error shapes — pick the right one per handler:
+
+| Shape | How server returns it | Hurl assertion |
+|---|---|---|
+| Domain code | `extensions.validationErrors[].code` | `jsonpath "$.extensions.validationErrors[0].code" == "reserved_dimension"` |
+| Detail substring | `problem.detail` (free text) | `jsonpath "$.detail" contains "reserved"` |
+| Schema rule | `invalid_parameters[].rule` | `jsonpath "$.extensions.invalidParameters[0].rule" == "pattern"` |
+
+Check the handler's `errors.go` for defined error codes (e.g. `ErrCodeReservedDimension = "reserved_dimension"`).
+
+**Detail substring gotcha:** `apierrors.NewConflictError(ctx, err, "message")` — the second string argument is NOT the `problem.detail` value. The actual `detail` comes from the underlying error's `Error()` string (e.g. `"conflict error: currency with code X already exists"`). Always use a short substring that appears in the real error, not the handler's label string. When in doubt, run the request once and read the actual `detail` before asserting.
+
+### Asserting List Membership
+
+**Never use `$.data[*].id contains "{{id}}"`.** When the array has exactly 1 element,
+jsonpath returns a bare string (not a collection), making `contains` do a substring check
+instead of a membership check — it silently passes or fails for the wrong reason.
+
+Use a JSONPath filter expression instead:
+
+```hurl
+# ✅ Correct — assert field on filtered result; works regardless of array size
+# 0 matches → null → fails; 1 match → string → passes; N matches → array → == fails
+jsonpath "$.data[?(@.id=='{{resource_id}}')].id" == "{{resource_id}}"
+
+# ✅ Also correct when you know position (e.g. filter already narrowed to 1 result)
+jsonpath "$.data[0].id" == "{{resource_id}}"
+
+# ❌ count predicate on filter result — fails when filter returns single object (not list)
+jsonpath "$.data[?(@.id=='{{resource_id}}')]" count == 1
+
+# ❌ Broken for single-item arrays — DO NOT USE
+jsonpath "$.data[*].id" contains "{{resource_id}}"
+```
+
+Also note: `includes` predicate is deprecated in favour of `contains` — always use `contains`.
+
+## Step 4 — Run Command
+
+Add a run command comment at the top of each new file:
+
+```hurl
+# Run: hurl --test \
+#   --variable base_url=http://localhost:8888 \
+#   --variable api_key="" \
+#   --variable run_id=$(date +%s%N | head -c 13) \
+#   e2e/hurl/openmeter-v3-meters.hurl
+```
+
+Run the test:
+
+```bash
+hurl --test \
+  --variable base_url=http://localhost:8888 \
+  --variable api_key="" \
+  --variable run_id=$(date +%s%N | head -c 13) \
+  e2e/hurl/openmeter-v3-<domain>.hurl
+```
+
+Run all hurl files:
+
+```bash
+hurl --test \
+  --variable base_url=http://localhost:8888 \
+  --variable api_key="" \
+  --variable run_id=$(date +%s%N | head -c 13) \
+  e2e/hurl/*.hurl
+```
+
+## Domain-Specific Knowledge
+
+### Meters (v3) — `POST /openmeter/meters`
+
+Required fields: `key`, `name`, `aggregation`, `event_type`
+
+| Aggregation | `value_property` |
+|---|---|
+| `count` | Must be absent/omitted — error if present |
+| `sum`, `avg`, `min`, `max`, `unique_count`, `latest` | Required — error if absent |
+
+Reserved dimensions (rejected at create and update — domain code `reserved_dimension`):
+- `subject`
+- `customer_id`
+
+Updatable fields: `name`, `description`, `dimensions`, `labels` (key/aggregation/event_type/value_property are immutable).
+
+**Soft-delete:** `DELETE` returns 204, subsequent `GET` returns 200 with `deleted_at` non-null. Does NOT return 404.
+
+### Plans (v3) — `POST /openmeter/plans`
+
+Soft-delete: same as meters — GET after DELETE returns 200 + `deleted_at`.
+
+Draft/publish lifecycle: plans have `status: draft/active/archived`. Publish via `POST /openmeter/plans/{id}/publish`.
+
+Validation errors surface via `validation_errors[]` on GET (draft-with-errors shape).
+
+### Features (v3) — `POST /openmeter/features`
+
+**Hard-delete:** GET after DELETE returns 404. Contrast with meters/plans.
+
+### Filter Params (v3 AIP style)
+
+Use `[QueryStringParams]` section — not inline URL query string — for deepObject style params:
+
+```hurl
+GET {{base_url}}/api/v3/openmeter/meters
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+filter[key]: my-meter-key
+filter[name]: My Meter
+page[size]: 20
+page[number]: 1
+```
+
+Named string type fields (`*BillingCurrencyType`, etc.) use `parseStringPtrTyped` in the filter parser — they work the same as `*string` from the wire perspective.
+
+### Pagination (v3)
+
+All v3 list responses:
+```json
+{
+  "data": [...],
+  "meta": {
+    "page": { "size": 20, "number": 1, "total": 42 }
+  }
+}
+```
+
+Default page size is 20. Use `page[size]=1000` when checking if a specific item appears in a potentially large shared dataset.
+
+### Error Response Shape (v3)
+
+```json
+{
+  "type": "about:blank",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "human readable message",
+  "extensions": {
+    "validationErrors": [
+      { "code": "reserved_dimension", "field": "dimensions.subject" }
+    ]
+  }
+}
+```
+
+## Checklist
+
+1. Read `api/v3/openapi.yaml` (or `api/openapi.yaml` for v1) — paths, methods, fields, status codes
+2. Read `api/v3/handlers/<domain>/` — error shapes, which validators fire, convert.go
+3. Read `openmeter/<domain>/` — Validate() constraints not always visible in OpenAPI
+4. Check for existing `.hurl` file in `e2e/hurl/`; append or create
+5. Use `{{run_id}}` suffix on all unique fields
+6. Use `[QueryStringParams]` for all filter/pagination params (deepObject style)
+7. Assert correct soft-delete vs hard-delete behavior per resource type
+8. Validate JSON syntax: `hurl --check <file>`
+9. Add run command comment at top of file

--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,18 @@ etoe-slow: ## Run e2e tests with slow tests enabled
 	export RUN_SLOW_TESTS=1
 	$(MAKE) -C e2e test-local
 
+HURL_BASE_URL ?= http://localhost:8888
+HURL_API_KEY ?=
+
+.PHONY: etoe-hurl
+etoe-hurl: ## Run Hurl e2e tests (requires server running; set HURL_BASE_URL and HURL_API_KEY as needed)
+	$(call print-target)
+	hurl --test \
+		--variable base_url=$(HURL_BASE_URL) \
+		--variable api_key=$(HURL_API_KEY) \
+		--variable run_id=$$(date +%s%N | head -c 13) \
+		e2e/hurl/*.hurl
+
 
 .PHONY: test
 test: ## Run tests

--- a/e2e/hurl/openmeter-v3-currencies.hurl
+++ b/e2e/hurl/openmeter-v3-currencies.hurl
@@ -1,0 +1,114 @@
+# Currencies E2E — custom currency lifecycle + cost bases
+#
+# Covers: currency_custom_lifecycle (p0)
+#   POST /openmeter/currencies/custom
+#   GET  /openmeter/currencies
+#   POST /openmeter/currencies/custom/{id}/cost-bases
+#   GET  /openmeter/currencies/custom/{id}/cost-bases
+#
+# Run:
+#   hurl --test \
+#     --variable base_url=http://localhost:8888 \
+#     --variable api_key="" \
+#     --variable run_id=$(date +%s%N | head -c 13) \
+#     e2e/hurl/openmeter-v3-currencies.hurl
+
+# ── 1. Create custom currency ─────────────────────────────────────────────────
+POST {{base_url}}/api/v3/openmeter/currencies/custom
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "code": "TC{{run_id}}",
+  "name": "Test Currency {{run_id}}",
+  "symbol": "T$"
+}
+```
+HTTP 201
+[Captures]
+currency_id: jsonpath "$.id"
+currency_code: jsonpath "$.code"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.type" == "custom"
+jsonpath "$.code" == "TC{{run_id}}"
+jsonpath "$.name" == "Test Currency {{run_id}}"
+jsonpath "$.symbol" == "T$"
+
+# ── 2. List all currencies — custom currency present ─────────────────────────
+# Use JSONPath filter expression — avoids $.data[*].id type inconsistency
+# (returns string for 1-item arrays, breaking contains predicate)
+GET {{base_url}}/api/v3/openmeter/currencies
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+page[size]: 1000
+HTTP 200
+[Asserts]
+jsonpath "$.data" isCollection
+jsonpath "$.data[?(@.id=='{{currency_id}}')].id" == "{{currency_id}}"
+
+# ── 3. List filtered by type=custom — currency present, all entries custom ───
+GET {{base_url}}/api/v3/openmeter/currencies
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+filter[type]: custom
+page[size]: 1000
+HTTP 200
+[Asserts]
+jsonpath "$.data[?(@.id=='{{currency_id}}')].id" == "{{currency_id}}"
+jsonpath "$.data[0].type" == "custom"
+
+# ── 4. List filtered by type=fiat — only fiat currencies returned ─────────────
+# Fiat currencies have no id field; assert type of first result is fiat
+GET {{base_url}}/api/v3/openmeter/currencies
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+filter[type]: fiat
+page[size]: 10
+HTTP 200
+[Asserts]
+jsonpath "$.data" isCollection
+jsonpath "$.data[0].type" == "fiat"
+
+# ── 5. Create cost basis ──────────────────────────────────────────────────────
+POST {{base_url}}/api/v3/openmeter/currencies/custom/{{currency_id}}/cost-bases
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "fiat_code": "USD",
+  "rate": "1.5"
+}
+```
+HTTP 201
+[Captures]
+cost_basis_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.fiat_code" == "USD"
+jsonpath "$.rate" == "1.5"
+
+# ── 6. List cost bases — cost basis present ───────────────────────────────────
+GET {{base_url}}/api/v3/openmeter/currencies/custom/{{currency_id}}/cost-bases
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.data" isCollection
+jsonpath "$.data[?(@.id=='{{cost_basis_id}}')].id" == "{{cost_basis_id}}"
+jsonpath "$.data[0].fiat_code" == "USD"
+jsonpath "$.data[0].rate" == "1.5"
+
+# ── 7. Duplicate code rejected with 409 ──────────────────────────────────────
+POST {{base_url}}/api/v3/openmeter/currencies/custom
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "code": "TC{{run_id}}",
+  "name": "Duplicate Currency",
+  "symbol": "D$"
+}
+```
+HTTP 409
+[Asserts]
+jsonpath "$.detail" contains "already exists"

--- a/e2e/hurl/openmeter-v3-currencies.hurl
+++ b/e2e/hurl/openmeter-v3-currencies.hurl
@@ -45,7 +45,7 @@ page[size]: 1000
 HTTP 200
 [Asserts]
 jsonpath "$.data" isCollection
-jsonpath "$.data[?(@.id=='{{currency_id}}')].id" == "{{currency_id}}"
+jsonpath "$.data[?(@.id=='{{currency_id}}')].id" contains "{{currency_id}}"
 
 # ── 3. List filtered by type=custom — currency present, all entries custom ───
 GET {{base_url}}/api/v3/openmeter/currencies
@@ -55,7 +55,7 @@ filter[type]: custom
 page[size]: 1000
 HTTP 200
 [Asserts]
-jsonpath "$.data[?(@.id=='{{currency_id}}')].id" == "{{currency_id}}"
+jsonpath "$.data[?(@.id=='{{currency_id}}')].id" contains "{{currency_id}}"
 jsonpath "$.data[0].type" == "custom"
 
 # ── 4. List filtered by type=fiat — only fiat currencies returned ─────────────
@@ -94,7 +94,7 @@ Authorization: Bearer {{api_key}}
 HTTP 200
 [Asserts]
 jsonpath "$.data" isCollection
-jsonpath "$.data[?(@.id=='{{cost_basis_id}}')].id" == "{{cost_basis_id}}"
+jsonpath "$.data[?(@.id=='{{cost_basis_id}}')].id" contains "{{cost_basis_id}}"
 jsonpath "$.data[0].fiat_code" == "USD"
 jsonpath "$.data[0].rate" == "1.5"
 

--- a/e2e/hurl/openmeter-v3-features.hurl
+++ b/e2e/hurl/openmeter-v3-features.hurl
@@ -1,0 +1,125 @@
+# Features E2E — feature lifecycle (p0)
+#
+# Covers: feature_lifecycle (p0) — see e2e/specs/features.md
+#   POST   /openmeter/features
+#   GET    /openmeter/features/{id}
+#   GET    /openmeter/features
+#   PATCH  /openmeter/features/{id}     (set unit_cost)
+#   PATCH  /openmeter/features/{id}     (clear unit_cost = null)
+#   DELETE /openmeter/features/{id}
+#   GET    /openmeter/features/{id}     (404 after delete — features are hard-deleted)
+#
+# Run:
+#   hurl --test \
+#     --variable base_url=http://localhost:8888 \
+#     --variable api_key="" \
+#     --variable run_id=$(date +%s%N | head -c 13) \
+#     e2e/hurl/openmeter-v3-features.hurl
+
+# ── 1. Create static feature ──────────────────────────────────────────────────
+# Baseline: no meter, no unit_cost. Key must NOT parse as a ULID — prefix with
+# "feat_" to guarantee that.
+POST {{base_url}}/api/v3/openmeter/features
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "key": "feat_{{run_id}}",
+  "name": "Test Feature"
+}
+```
+HTTP 201
+[Captures]
+feature_id: jsonpath "$.id"
+feature_key: jsonpath "$.key"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.key" == "feat_{{run_id}}"
+jsonpath "$.name" == "Test Feature"
+jsonpath "$.meter" not exists
+jsonpath "$.unit_cost" not exists
+jsonpath "$.deleted_at" not exists
+
+# ── 2. Get feature by id ──────────────────────────────────────────────────────
+GET {{base_url}}/api/v3/openmeter/features/{{feature_id}}
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{feature_id}}"
+jsonpath "$.key" == "feat_{{run_id}}"
+jsonpath "$.name" == "Test Feature"
+
+# ── 3. List features — created feature appears ───────────────────────────────
+# Page size 1000 because the shared DB may push fresh rows past page-1 default.
+GET {{base_url}}/api/v3/openmeter/features
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+page[size]: 1000
+HTTP 200
+[Asserts]
+jsonpath "$.data" isCollection
+jsonpath "$.data[?(@.id=='{{feature_id}}')].id" contains "{{feature_id}}"
+
+# ── 4. Patch — set manual unit_cost ──────────────────────────────────────────
+# UpdateFeatureRequest.unit_cost uses tri-state semantics: omitting the key is
+# rejected (covered by feature_update_unit_cost_required scenario). Here we set
+# a manual cost.
+PATCH {{base_url}}/api/v3/openmeter/features/{{feature_id}}
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "unit_cost": {
+    "type": "manual",
+    "amount": "5"
+  }
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{feature_id}}"
+jsonpath "$.unit_cost.type" == "manual"
+jsonpath "$.unit_cost.amount" == "5"
+
+# ── 5. Get — verify unit_cost persisted ──────────────────────────────────────
+GET {{base_url}}/api/v3/openmeter/features/{{feature_id}}
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.unit_cost.type" == "manual"
+jsonpath "$.unit_cost.amount" == "5"
+
+# ── 6. Patch — clear unit_cost (null) ────────────────────────────────────────
+# Passing null clears the unit_cost. Response should have unit_cost absent.
+PATCH {{base_url}}/api/v3/openmeter/features/{{feature_id}}
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "unit_cost": null
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{feature_id}}"
+jsonpath "$.unit_cost" not exists
+
+# ── 7. Get — verify unit_cost cleared ────────────────────────────────────────
+GET {{base_url}}/api/v3/openmeter/features/{{feature_id}}
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.unit_cost" not exists
+
+# ── 8. Delete feature ────────────────────────────────────────────────────────
+DELETE {{base_url}}/api/v3/openmeter/features/{{feature_id}}
+Authorization: Bearer {{api_key}}
+HTTP 204
+
+# ── 9. Get after delete — 404 (features are hard-deleted) ────────────────────
+# Contrast with meters/plans, which soft-delete and return 200 + deleted_at.
+GET {{base_url}}/api/v3/openmeter/features/{{feature_id}}
+Authorization: Bearer {{api_key}}
+HTTP 404
+[Asserts]
+jsonpath "$.detail" contains "feature not found: {{feature_id}}"

--- a/e2e/specs/currencies.md
+++ b/e2e/specs/currencies.md
@@ -1,0 +1,141 @@
+# E2E Scenario Specifications — Currencies
+
+Natural-language, runner-agnostic description of e2e scenarios for the
+`currencies` endpoint family. Each `## Scenario` describes wire-level
+behavior (HTTP verb, path, status code, response shape,
+`problem+json` error shape) that any downstream runner can translate
+to an executable test.
+
+See the `e2e-nl` skill (`.agents/skills/e2e-nl/`) for format rules
+(`references/format.md`) and worked examples (`references/examples.md`).
+
+**Endpoints covered:**
+- `GET /openmeter/currencies` — list all currencies (fiat + custom)
+- `POST /openmeter/currencies/custom` — create a custom currency
+- `POST /openmeter/currencies/custom/{currencyId}/cost-bases` — create a cost basis for a custom currency
+- `GET /openmeter/currencies/custom/{currencyId}/cost-bases` — list cost bases for a custom currency
+
+**Custom vs fiat currencies:** Custom currencies have an `id` and `type: "custom"` in responses.
+Fiat currencies (ISO-4217) are built-in — no `id` field. The list endpoint returns both unless filtered by `filter[type]`.
+
+**Error-shape convention:** The `create-custom-currency` handler wraps ALL service errors as
+`ConflictError`, but validation errors still resolve to `400` because `BaseAPIError.Unwrap()`
+exposes the underlying `GenericValidationError` through the error encoder. Only genuine
+duplicate-code conflicts return `409`. All other 4xx use `apierrors.GenericErrorEncoder()` → standard
+`problem+json` shape.
+
+**No lifecycle (no draft/publish/archive):** Custom currencies have no status transitions.
+There is no delete endpoint — custom currencies persist indefinitely.
+
+---
+
+## Scenario list
+
+**p0 — happy path**
+
+- `currency_custom_lifecycle` — Create a custom currency, verify it appears in the list, filter by type, create a cost basis, list cost bases. — shape: lifecycle — priority: p0
+
+**p1 — core validation**
+
+- `currency_create_duplicate_code_rejected` — Creating a second custom currency with the same `code` returns 409 with detail containing `"Currency already exists"`. — shape: single-request — priority: p1
+- `currency_create_missing_required_fields` — Creating a custom currency without `name` or `code` returns 400 (schema rule shape from OpenAPI binder). — shape: single-request — priority: p1
+- `currency_create_symbol_required_by_domain` — Creating a custom currency without `symbol` returns 400 (domain validation; symbol is required by `CreateCurrencyInput.Validate()` even though the OpenAPI schema marks it optional). — shape: single-request — priority: p1 — NEEDS-VERIFY: confirm 400 vs pass-through when symbol absent
+- `currency_cost_basis_rate_must_be_positive` — Creating a cost basis with `rate: "0"` or negative rate returns 400. — shape: single-request — priority: p1
+- `currency_cost_basis_invalid_fiat_code` — Creating a cost basis with an unknown fiat code returns 400. — shape: single-request — priority: p1 — NEEDS-VERIFY: confirm error detail/code from server
+- `currency_list_filter_by_type_custom` — `filter[type]=custom` returns only custom currencies (no fiat entries in `data[]`). — shape: single-request — priority: p1
+- `currency_list_filter_by_type_fiat` — `filter[type]=fiat` returns only fiat currencies (no custom entry in `data[]`). — shape: single-request — priority: p1
+- `currency_cost_bases_list_filter_by_fiat_code` — `filter[fiat_code]=USD` on the cost-bases list returns only cost bases with `fiat_code == "USD"`. — shape: single-request — priority: p1
+
+**p2 — edge cases**
+
+- `currency_list_pagination` — `page[number]` + `page[size]` return the expected slice and `meta.page.total`. — shape: single-request — priority: p2
+- `currency_cost_basis_effective_from` — Cost basis created with an explicit `effective_from` timestamp returns that timestamp in the response. — shape: single-request — priority: p2
+- `currency_cost_basis_nonexistent_currency` — Creating a cost basis for a non-existent `currencyId` returns 404 or 400. — shape: single-request — priority: p2 — NEEDS-VERIFY: confirm status code from server
+
+---
+
+## Baselines
+
+### Baseline custom currency — `CreateCurrencyCustomRequest`
+
+- `code`: unique per run (3–24 chars, must not conflict with ISO-4217 codes)
+- `name`: `"Test Currency"`
+- `symbol`: `"TC"` (symbol is required by domain `Validate()` even though OpenAPI schema marks it optional)
+
+### Baseline cost basis — `CreateCostBasisRequest`
+
+- `fiat_code`: `"USD"` (valid ISO-4217 code)
+- `rate`: `"1.5"` (positive decimal string)
+- `effective_from`: omitted (server sets to now)
+
+---
+
+## Scenario: currency_custom_lifecycle
+
+```yaml
+id: currency_custom_lifecycle
+endpoints:
+  - POST /openmeter/currencies/custom
+  - GET /openmeter/currencies
+  - POST /openmeter/currencies/custom/{currencyId}/cost-bases
+  - GET /openmeter/currencies/custom/{currencyId}/cost-bases
+entities: [currency, cost-basis]
+tags: [lifecycle, crud, p0]
+```
+
+**Intent:** A custom currency is created, appears in the list (filterable by type), and can have a cost basis attached and listed.
+
+**Fixtures:**
+- A `CreateCurrencyCustomRequest` per **Baseline custom currency**.
+- A `CreateCostBasisRequest` per **Baseline cost basis**.
+
+**Steps:**
+
+1. **Create custom currency.** `POST /openmeter/currencies/custom` with the fixture.
+   - Expect `201 Created`.
+   - Expect `id` is non-null.
+   - Expect `type` is `"custom"`.
+   - Expect `code` equals the fixture code.
+   - Expect `name` equals the fixture name.
+   - Expect `symbol` equals the fixture symbol.
+
+   Captures:
+   - `currency` ← `response.body`
+
+2. **List all currencies — verify custom currency appears.**
+   `GET /openmeter/currencies?page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect `data[]` contains an entry with `id == {currency.id}`.
+
+3. **List filtered by type `custom` — only custom currencies returned.**
+   `GET /openmeter/currencies` with `filter[type]=custom` and `page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect `data[]` contains an entry with `id == {currency.id}`.
+   - Expect every item in `data[]` has `type == "custom"`.
+
+4. **List filtered by type `fiat` — custom currency not in results.**
+   `GET /openmeter/currencies` with `filter[type]=fiat` and `page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect `data[]` does NOT contain an entry with `id == {currency.id}`.
+   - Expect every item in `data[]` has `type == "fiat"`.
+
+5. **Create cost basis.** `POST /openmeter/currencies/custom/{currency.id}/cost-bases`
+   with the cost basis fixture.
+   - Expect `201 Created`.
+   - Expect `id` is non-null.
+   - Expect `fiat_code` equals `"USD"`.
+   - Expect `rate` equals `"1.5"`.
+
+   Captures:
+   - `cost_basis` ← `response.body`
+
+6. **List cost bases.** `GET /openmeter/currencies/custom/{currency.id}/cost-bases`.
+   - Expect `200 OK`.
+   - Expect `data[]` contains an entry with `id == {cost_basis.id}`.
+
+**Notes:**
+
+- There is no DELETE endpoint for custom currencies — they persist indefinitely. No cleanup step.
+- `symbol` is required by the domain `Validate()` even though the OpenAPI schema marks it optional in `CreateCurrencyCustomRequest`. Always include `symbol` in create requests.
+- The create handler wraps ALL errors as `ConflictError`. Validation errors (missing fields, etc.) still resolve to `400` because the error encoder unwraps through `BaseAPIError.Unwrap()`. Only genuine duplicate-code conflicts return `409`.
+- Fiat currencies returned from `GET /openmeter/currencies` have no `id` field in the response body (`id` is absent, not null).

--- a/flake.nix
+++ b/flake.nix
@@ -94,6 +94,7 @@
 
               curl
               jq
+              hurl
               minikube
               kind
               kubectl


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Hurl-based E2E test runner target with configurable base URL/API key
  * Added Hurl E2E tests for currencies (lifecycle, listings, cost-basis, conflict) and features (lifecycle, unit_cost tri-state, hard-delete)

* **Documentation**
  * Added runner-agnostic E2E specification for currencies with scenarios/payloads
  * Added a skill guide for consistently generating Hurl E2E tests

* **Chores**
  * Included Hurl in the development environment toolset
<!-- end of auto-generated comment: release notes by coderabbit.ai -->