### PR TITLE
Chore/e2e httpyac skill

### DIFF
--- a/.agents/skills/e2e-httpyac/SKILL.md
+++ b/.agents/skills/e2e-httpyac/SKILL.md
@@ -1,0 +1,333 @@
+---
+name: e2e-httpyac
+description: Generate executable httpYac `.http` e2e tests from a natural-language scenario specification produced by `/e2e-nl`. The output is one `.http` file per scenario, runnable via `httpyac send` against a live OpenMeter server with JUnit / JSON reporting. Use this skill when an NL spec at `e2e/specs/<family>.md` is in place and you want runnable wire-level tests with a lighter ceremony than the Go e2e suite — particularly useful for exploratory contract tests, manual debugging, and CI smoke runs against deployed environments. Reach for it for phrasings like "translate the features spec to httpYac", "generate `.http` tests for `<scenario>`", "I want runnable contract tests from the NL spec".
+user-invocable: true
+argument-hint: "[family or e2e/specs path] [optional: scenario id]"
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
+---
+
+# E2E httpYac Test Generator
+
+You translate a natural-language e2e scenario specification into an
+executable httpYac `.http` file. Output format follows
+`references/format.md`, modeled on the worked examples in
+`references/examples.md`.
+
+This skill is **step 2 in a pipeline**:
+
+```text
+endpoint code → [/e2e-nl] → NL spec → [/e2e-httpyac] → executable .http
+```
+
+Sibling generators may emit Go (`/e2e`), Playwright, Hurl, etc. The
+contract between every generator and `/e2e-nl` is the NL spec; no
+generator reads any other generator's output.
+
+## Before you start — read these
+
+1. `references/format.md` — format contract for emitted `.http` files
+   (naming convention, assertion vocabulary, capture pattern, error
+   shapes, forbidden directives).
+2. `references/examples.md` — one worked example per shape class.
+
+Both files live alongside this `SKILL.md` inside the skill directory.
+They are the contract. If either is missing, stop and tell the user —
+the skill depends on them and shouldn't improvise.
+
+## What this skill does **not** do
+
+- It doesn't read endpoint code (`api/spec/`, `api/v3/handlers/`, …).
+  That's `/e2e-nl`'s job. If the NL spec is missing, run `/e2e-nl`
+  first.
+- It doesn't write Go e2e tests. That's `/e2e`'s job.
+- It doesn't decide whether a scenario should exist. The NL spec is
+  the source of truth; this skill emits exactly what's drafted there.
+- It doesn't validate execution against a live server. After writing
+  the file, you tell the user the install + run command. The user runs
+  it; debugging the runtime is a separate task.
+
+## Inputs — the NL spec
+
+Given an endpoint family (e.g. "features") or an explicit path:
+
+1. Locate the spec at `e2e/specs/<family>.md`.
+2. Confirm it has a `## Scenario: <id>` heading for the requested
+   scenario id (or, if no id was given, list the available ids and
+   ask).
+3. Read the scenario's YAML, Intent, Fixtures, Steps, and Notes
+   blocks. Read the file's Baselines and family-wide preamble for
+   context.
+
+Report the spec path and the scenario id under translation. If
+either is missing or ambiguous, ask before proceeding — don't guess.
+
+## Workflow — five modes
+
+Two top-level operations: **single-scenario emit** (the default)
+and **family regenerate** (explicit user intent — phrasings like
+"regenerate the features family", "wipe and rebuild the .http files
+for plans", "delete and regenerate"). Modes dispatch on whether the
+project root and target file already exist:
+
+| Mode | Project root | Scenario file | Scenario id | Action |
+|---|---|---|---|---|
+| bootstrap | no | n/a | any | Create `e2e/http/httpyac.config.js`, then continue as below. |
+| draft new | yes | no | given | Emit `e2e/http/<family>/<scenario_id>.http`. |
+| list scenarios | yes | no | not given | List ids from the NL spec and ask which to draft (or whether to regenerate the family). |
+| update existing | yes | yes | given | Refuse to overwrite silently. Diff against what you'd emit; ask whether to update, replace, or skip. |
+| **regenerate family** | yes | any | n/a, **regenerate intent explicit** | Emit every `## Scenario:` heading from the NL spec into `e2e/http/<family>/`, overwriting prior files. **Confirm with the user first** — hand-edits to existing files will be lost. Skipped scenarios still emit (with `# @disabled`); never silently drop. |
+
+Single-scenario emit is the right default for incremental work.
+Family-regenerate is the right move when the NL spec has changed
+materially, when the skill rules change (new error-shape template,
+new naming rule), or when you want a clean reset after
+experimentation.
+
+## Idempotency contract
+
+The skill is designed so that **deleting any subset of `.http`
+files under `e2e/http/<family>/` and re-running family-regenerate
+produces functionally equivalent output**. Equivalence is the
+contract; byte-for-byte identity is not — a careful diff may catch
+trivial formatting variation, but assertions, captures, request
+shapes, and naming will match.
+
+What's deterministic:
+
+- **Region order:** matches NL spec Step order.
+- **Request names** (`r__<scenario>__<step_slug>`): scenario id and
+  step slug both derive from the NL spec verbatim. The step slug
+  is a lowercase-snake-case rendering of the NL spec's Step title
+  text — see `references/format.md` for the exact rule.
+- **Capture variable names** (`v__<scenario>__<capture>`): the
+  capture name matches the NL spec's `Captures:` block label.
+- **Assertion choice:** mechanically driven by NL spec phrasing
+  (see `references/format.md`'s assertion vocabulary table and
+  error-shape templates). No model creativity in the assertion
+  layer.
+- **File header:** scenario id + spec source path comment using
+  the fixed template in `references/format.md`.
+
+What's *runtime* dynamic but *emit-time* deterministic:
+
+- `{{$timestamp}}_{{$randomInt 0 1000000}}` suffixes for unique
+  fixture keys: the literal text in the file is identical across
+  emits; only the resolved value changes per `httpyac send`.
+
+What's *not* idempotent (and how to avoid losing it on regenerate):
+
+- **Hand-edits to a file's assertions or commentary.** If you
+  pinned a `NEEDS-VERIFY` value, tightened an assertion, or added
+  a regression-marker comment, family-regenerate will overwrite
+  those edits. Workflow:
+  1. Pin findings into the NL spec first (the canonical source of
+     truth) — remove `NEEDS-VERIFY` markers, update detail
+     substrings to match observed server output, etc.
+  2. Then regenerate. The regenerate carries the findings forward.
+  - Or, when regenerating, accept the overwrite and re-apply the
+    delta in a follow-up edit pass.
+- **`httpyac.config.js`.** Bootstrapped once; never touched again
+  by the skill. Hand-edits (auth scrubbing hooks, custom default
+  headers) are preserved across regenerates.
+
+## Output file convention
+
+```
+e2e/
+  http/
+    httpyac.config.js              # project root marker
+    features/
+      feature_lifecycle.http
+      feature_create_duplicate_key_rejected.http
+      …                            # one file per ## Scenario: <id> in features.md
+    plans/                         # future families
+```
+
+Rules:
+
+- **One scenario per file.** No `### Scenario` separators packing
+  multiple scenarios into one file. httpYac has no scope on `@name`
+  across imports — collisions are silent and the first match wins.
+  One file per scenario sidesteps this entirely.
+- **File name equals the scenario id verbatim.** `<scenario_id>.http`.
+- **Subdirectory per family** mirrors `e2e/specs/<family>.md`.
+- **Project root** is `e2e/http/`. Do **not** write outside it.
+
+## Project root setup (first run only)
+
+If `e2e/http/httpyac.config.js` doesn't exist, bootstrap:
+
+- `e2e/http/httpyac.config.js` — project-root marker. See
+  `references/format.md` for the canonical content.
+
+Configuration is shell-env based (mirrors the Go e2e convention
+`OPENMETER_ADDRESS=... go test ./e2e/...`). The skill emits
+`@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3` in every file; httpYac resolves
+the value from `process.env` at send time. No env files, no
+`--env <name>` flag, no `package.json`. Those are out of scope; the
+`SKILL.md`'s Handoff section documents the canonical CLI invocation
+that any wrapper can call.
+
+## Naming convention (hard rule)
+
+Every emitted file uses these prefixes, with the **scenario id** as
+the namespace:
+
+| Prefix | Used for | Example |
+|---|---|---|
+| `r__` | Request name (`# @name`) | `r__feature_lifecycle__create_feature` |
+| `v__` | Exported variable (post-response script) | `v__feature_lifecycle__feature_id` |
+| `d__` | File-global immutable data variable | `d__feature_lifecycle__feature_key` |
+| upper-snake | Environment variable (read from `process.env`) | `OPENMETER_ADDRESS` |
+
+All names are valid JavaScript identifiers (lowercase snake_case,
+letters/digits/underscores only). Dynamic values
+(`{{$timestamp}}`, `{{$randomInt}}`, `{{$uuid}}`) appear in **values**,
+never in names.
+
+The `r__` / `v__` / `d__` distinction matters for review: a reader
+should be able to grep an emitted file and see immediately which
+identifiers are requests, which are runtime captures, and which are
+literal fixture data.
+
+## Error-shape triage
+
+Every 4xx step in the NL spec names one of four shapes. Pick the
+emit template by **shape**, not by scenario intent.
+
+| Shape | NL phrasing | Emit template |
+|---|---|---|
+| **Detail equality** | `Expect detail equals "<full>"` | `?? js response.parsedBody.detail == <full>` |
+| **Detail substring** | `Expect detail contains "<sub>"` | `?? js response.parsedBody.detail.includes('<sub>')` |
+| **Domain code** | `Expect domain code "<code>"` | JS `test(...)` block asserting `response.parsedBody.extensions.validationErrors.some(e => e.code === "<code>")` |
+| **Schema rule** | `Expect schema rule "<rule>"` (or `field`/`rule` pinned in spec) | `?? js response.parsedBody.invalid_parameters[0].field == <field>` + `?? js response.parsedBody.invalid_parameters[0].rule == <rule>` |
+
+The NL spec's phrasing is unambiguous; the emit template follows
+mechanically. See `references/format.md` for the full templates,
+the `body contains` caveat (don't use it on
+`application/problem+json` bodies), and the DSL-first principle.
+`references/examples.md` carries one worked scenario per shape.
+
+### Binder layer vs handler — the same input may surface as
+different shapes depending on deployment topology
+
+OpenMeter's API contract is defined by `api/openapi.yaml`. Some
+deployments place an OpenAPI binder gateway (any conformant binder
+— Kong, oapi-codegen middleware, Spectral validator, etc.) in
+front of the handler. When a binder is present, schema-level
+rejections (pattern, enum, format, type) fire **at the binder**
+and surface with the **schema-rule** shape — the handler's domain
+check for the same input never runs.
+
+Practical consequence: a scenario the NL spec describes as
+detail-substring (because that's what the handler emits in
+isolation) may surface as schema-rule when run through a binder
+gateway. Workflow when first generating a scenario:
+
+1. Emit per the NL spec's stated shape.
+2. Run once against the target deployment (`httpyac send …
+   --output-failed response`).
+3. If the response shape doesn't match what the spec said, the
+   binder is intercepting. Re-classify the scenario's shape, pin
+   the actual `field`/`rule` values, and update **both** the NL
+   spec (with a deployment-topology note) and the emitted file.
+4. Document the topology in the scenario's Notes section so
+   future maintainers know the test is binder-shape-pinned.
+
+`references/examples.md` shows this loop applied to
+`feature_list_filter_malformed_rejected` and the matrix scenario's
+row 10.
+
+## Things to avoid
+
+**Format-level:**
+
+- **No `@loop`.** Matrix scenarios emit one request region per row.
+  See `references/format.md` ("Matrix scenarios — N regions, not a
+  loop") for the rationale and template.
+- **No implicit `@name`-as-id captures.** `@name` exposes only the
+  parsed body, not headers or status. Always emit an explicit
+  post-response `exports.v__... = response.parsedBody.id` block.
+- **No editor-only directives.** No `@note`, `@openWith`, `@save`,
+  `$input`, `$password`, `$pick`. They break in CLI/CI runs.
+- **No dynamic `@disabled`.** Static `@disabled` for `status: skipped`
+  scenarios is fine; don't emit conditional disable expressions.
+- **No `@import` of another scenario's file.** Cross-scenario state
+  leaks via the shared first-match-wins `@name` namespace. Each
+  scenario file is self-contained.
+- **No clever lazy-variable chains (`@var := ...`).** Always emit
+  fixed (`=`) values for data variables, and rely on explicit
+  `exports` for runtime state. Lifecycle files become
+  significantly easier to debug this way.
+
+**Spec-fidelity:**
+
+- **Don't invent assertions.** If the NL spec doesn't pin a field,
+  don't assert it. Drift between spec and emitted test is what the
+  pipeline exists to prevent.
+- **Don't tighten `NEEDS-VERIFY` markers.** The spec author left
+  them loose for a reason. Emit a JS assertion that's tolerant of
+  the un-pinned value, and copy the `NEEDS-VERIFY: <reason>` text
+  into a comment in the `.http` file.
+- **Don't skip steps.** A multi-step lifecycle emits every step,
+  including read-backs. Read-backs are how the test proves the
+  mutation persisted; dropping them turns the test into a write-only
+  smoke check.
+- **Don't reorder steps.** httpYac runs requests in file order;
+  reordering breaks captures.
+
+## Handoff — installation and execution
+
+The skill emits the `.http` file. The user runs it. Don't try to
+execute httpYac inside the skill's environment — install the runner
+on the user's machine and document the CLI invocation.
+
+```bash
+# httpYac is provided by the repo's Nix dev shell (see flake.nix).
+# Enter the shell once via direnv (`direnv reload`) or
+# `nix develop --impure .#ci`; `httpyac` will be on PATH.
+# CI uses the same shell (`nix develop --impure .#ci -c httpyac ...`).
+
+# run a single scenario
+OPENMETER_ADDRESS=http://localhost:8888 \
+  httpyac send e2e/http/features/feature_lifecycle.http \
+  --all --output-failed response
+
+# run a family (CI / JUnit)
+OPENMETER_ADDRESS=http://localhost:8888 \
+  httpyac send "e2e/http/features/**/*.http" \
+  --all --bail --junit \
+  --output-failed response --parallel 1 \
+  > reports/features.junit.xml
+```
+
+The `--parallel 1` flag is intentional: lifecycle scenarios depend
+on intra-file ordering. Cross-file parallelism is a CI-wrapper
+concern (e.g. `xargs -P 4`), not a runner concern.
+
+`--output-failed response` is the workaround for the JSON reporter
+stripping `parsedBody` and `rawBody` from response objects — it
+re-includes them on failed assertions for forensic triage.
+
+## Smoke test
+
+Run the skill against `feature_lifecycle` (already drafted in
+`e2e/specs/features.md`) and diff the produced file against the
+worked example in `references/examples.md`. Large overlap confirms
+grounding; systematic differences surface gaps in either the skill
+or the reference.
+
+## Done criterion
+
+A scenario is **emitted** when the file at
+`e2e/http/<family>/<scenario_id>.http` parses (`httpyac` reports no
+syntax errors), and the user has confirmed it runs against a real
+server. The skill itself stops after writing the file; live
+validation is the user's pass.
+
+## Handoff to /e2e-nl
+
+If the user requests a scenario the spec doesn't cover, point them at
+`/e2e-nl` to draft it first. Don't invent NL content from endpoint
+code in this skill — that's the upstream skill's job, and bypassing
+it breaks the pipeline contract.

--- a/.agents/skills/e2e-httpyac/references/examples.md
+++ b/.agents/skills/e2e-httpyac/references/examples.md
@@ -1,0 +1,541 @@
+# Worked Examples — One Per Shape Class
+
+This reference shows each shape class drafted as a real httpYac
+`.http` file emitted from an NL scenario in `e2e/specs/features.md`.
+
+Use these as templates when emitting new files. Match the shape class
+to the kind of behavior the scenario is pinning, then mirror the
+structure with the same density of detail.
+
+| Shape | Example | When to reach for it |
+|---|---|---|
+| `lifecycle` | `feature_lifecycle` | A primary CRUD flow with chained captures, multiple read-back steps, and a final not-found assertion. |
+| `single-request` (detail-substring) | `feature_create_key_must_not_be_ulid` | One request, one rule, one assertion with `?? body contains`. The default for any 4xx with the detail-substring shape. |
+| `single-request` (schema-rule) | `feature_list_filter_malformed_rejected` | A 4xx whose error shape is `invalid_parameters[].rule`. Always uses a JS `test()` block. |
+| `matrix` | `feature_create_unit_cost_validation_matrix` | A rule with multiple rows, each a self-contained request region. Demonstrates the no-`@loop` pattern. |
+
+The `draft-with-errors` shape doesn't have an example here because
+features don't have draft lifecycle semantics. When `plans.md` is
+translated, the worked example for that shape lives in this file's
+peer in the plans family — emit it then, alongside the plan
+scenarios that exercise it.
+
+---
+
+## Project root file (illustrative)
+
+Emitted **once** when bootstrapping `e2e/http/`. Subsequent scenario
+emissions leave it untouched. There is no env file — configuration is
+shell-env based, mirroring the Go e2e convention
+(`OPENMETER_ADDRESS=... go test ./e2e/...`).
+
+### `e2e/http/httpyac.config.js`
+
+```js
+// Project-root marker for httpYac. The presence of this file scopes
+// httpYac's project root to e2e/http/.
+//
+// Configuration is shell-env based. Each .http file references
+// {{process.env.OPENMETER_ADDRESS}}; httpYac resolves it from process.env at
+// send time. No env files, no `--env <name>`.
+//
+// Add response-log scrubbing here if real auth tokens flow through
+// tests. v1 of the skill ships without scrubbing — add intentionally
+// when the auth surface is settled.
+
+module.exports = {};
+```
+
+---
+
+## Example: `lifecycle` shape — `feature_lifecycle`
+
+**NL spec excerpt** (from `e2e/specs/features.md`):
+
+```yaml
+id: feature_lifecycle
+endpoints:
+  - POST /features
+  - GET /features/{id}
+  - GET /features
+  - PATCH /features/{id}
+  - DELETE /features/{id}
+```
+
+Steps: create → get → list → patch (set unit_cost) → get → patch
+(clear unit_cost) → get → delete → get-after-delete (404 with detail
+substring).
+
+**Emitted `.http`** (`e2e/http/features/feature_lifecycle.http`):
+
+```http
+# feature_lifecycle
+#
+# Source: e2e/specs/features.md ## Scenario: feature_lifecycle
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_lifecycle__feature_key = lifecycle_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_lifecycle__create_feature
+# @title create feature
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_lifecycle__feature_key}}",
+  "name": "Test Feature"
+}
+
+?? status == 201
+?? js response.parsedBody.key == {{d__feature_lifecycle__feature_key}}
+?? js response.parsedBody.name == Test Feature
+?? js typeof response.parsedBody.meter == undefined
+?? js typeof response.parsedBody.unit_cost == undefined
+{{
+  exports.v__feature_lifecycle__feature_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_lifecycle__get_feature
+# @title get feature by id
+# @ref r__feature_lifecycle__create_feature
+GET {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+
+?? status == 200
+?? js response.parsedBody.id == {{v__feature_lifecycle__feature_id}}
+?? js response.parsedBody.key == {{d__feature_lifecycle__feature_key}}
+?? js response.parsedBody.name == Test Feature
+
+###
+# @name r__feature_lifecycle__list_features_find_created
+# @title list features and find the created feature
+# @ref r__feature_lifecycle__create_feature
+GET {{api_base}}/openmeter/features?page[size]=1000
+
+?? status == 200
+{{
+  const { ok } = require('assert');
+  test('created feature is present in list', () => {
+    const items = response.parsedBody.data || response.parsedBody.items || [];
+    ok(
+      items.some(f => f.id === v__feature_lifecycle__feature_id),
+      'expected list to contain feature id ' + v__feature_lifecycle__feature_id
+    );
+  });
+}}
+
+###
+# @name r__feature_lifecycle__patch_set_unit_cost
+# @title patch feature - set manual unit_cost
+# @ref r__feature_lifecycle__create_feature
+PATCH {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+Content-Type: application/json
+
+{ "unit_cost": { "type": "manual", "amount": "5" } }
+
+?? status == 200
+?? js response.parsedBody.unit_cost.type == manual
+{{
+  const { ok } = require('assert');
+  test('unit_cost.amount is normalized to "5"', () => {
+    // Server trims trailing zeros: "5.00" round-trips as "5".
+    ok(
+      response.parsedBody.unit_cost.amount === '5',
+      'expected unit_cost.amount === "5", got ' + response.parsedBody.unit_cost.amount
+    );
+  });
+}}
+
+###
+# @name r__feature_lifecycle__get_after_set
+# @title get feature - verify unit_cost persisted
+# @ref r__feature_lifecycle__patch_set_unit_cost
+GET {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+
+?? status == 200
+?? js response.parsedBody.unit_cost.type == manual
+?? js response.parsedBody.unit_cost.amount == 5
+
+###
+# @name r__feature_lifecycle__patch_clear_unit_cost
+# @title patch feature - clear unit_cost
+# @ref r__feature_lifecycle__create_feature
+PATCH {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+Content-Type: application/json
+
+{ "unit_cost": null }
+
+?? status == 200
+?? js typeof response.parsedBody.unit_cost == undefined
+
+###
+# @name r__feature_lifecycle__get_after_clear
+# @title get feature - verify unit_cost cleared
+# @ref r__feature_lifecycle__patch_clear_unit_cost
+GET {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+
+?? status == 200
+?? js typeof response.parsedBody.unit_cost == undefined
+
+###
+# @name r__feature_lifecycle__delete_feature
+# @title delete feature
+# @ref r__feature_lifecycle__create_feature
+DELETE {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+
+?? status == 204
+
+###
+# @name r__feature_lifecycle__get_after_delete
+# @title get feature after delete returns 404
+# @ref r__feature_lifecycle__delete_feature
+GET {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+
+?? status == 404
+?? body contains "feature not found: {{v__feature_lifecycle__feature_id}}"
+```
+
+**Commentary:**
+
+- The file's first comment block names the scenario id and spec
+  source path. A reviewer landing in the file knows where to look
+  for context within ten seconds.
+- `@d__feature_lifecycle__feature_key` is set once at file scope.
+  Every request that needs the key reads the same value, so the
+  asserted-against name persists across the whole lifecycle.
+- The capture is **explicit** — `exports.v__feature_lifecycle__feature_id`
+  in a post-response script — not implicit via `@name`. The newline
+  immediately after `{{` is required.
+- Decimal normalization (`"5.00"` → `"5"`) is asserted via a JS
+  `test()` block with a clear failure message. A naive
+  `?? body contains "amount\":\"5\""` would be too brittle.
+- The list-find step uses a JS `test()` because it's an array
+  membership check — the kind of assertion `??` shapes don't cover
+  cleanly.
+- The final 404 step uses the **detail-substring** shape because the
+  NL spec phrases it as `Expect detail contains "feature not found:
+  {feature.id}"`. The `{feature.id}` placeholder maps to
+  `{{v__feature_lifecycle__feature_id}}`.
+- `# @ref` chains every region back to its prerequisite. httpYac
+  can run this file standalone (`httpyac send … --filter only-failed`)
+  and resolve the ref graph.
+
+---
+
+## Example: `single-request` shape (detail-substring) — `feature_create_key_must_not_be_ulid`
+
+**NL spec excerpt:**
+
+```yaml
+id: feature_create_key_must_not_be_ulid
+endpoints:
+  - POST /features
+```
+
+Step: POST a feature whose `key` is a valid ULID literal — expect
+`400 Bad Request` with detail containing
+`"Feature key cannot be a valid ULID"`.
+
+**Emitted `.http`** (`e2e/http/features/feature_create_key_must_not_be_ulid.http`):
+
+```http
+# feature_create_key_must_not_be_ulid
+#
+# Source: e2e/specs/features.md ## Scenario: feature_create_key_must_not_be_ulid
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_create_key_must_not_be_ulid__ulid_key = 01HXYZABCDEFGHJKMNPQRSTVWX
+
+###
+# @name r__feature_create_key_must_not_be_ulid__create_with_ulid_key
+# @title POST /features with a ULID-shaped key returns 400
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_create_key_must_not_be_ulid__ulid_key}}",
+  "name": "Test Feature"
+}
+
+?? status == 400
+?? body contains "Feature key cannot be a valid ULID"
+```
+
+**Commentary:**
+
+- The simplest shape — one request, one status assertion, one
+  detail-substring assertion. No captures, no `@ref`, no JS blocks.
+- The ULID key is a **fixed literal**, not a dynamic value, because
+  the test wants to exercise a specific shape (a ULID) and any random
+  ULID is equally good. Using a literal makes the test
+  deterministic across runs.
+- The `@d__` prefix still applies — all data variables follow the
+  same naming convention regardless of complexity.
+
+---
+
+## Example: `single-request` shape (schema-rule) — `feature_list_filter_malformed_rejected`
+
+**NL spec excerpt:**
+
+```yaml
+id: feature_list_filter_malformed_rejected
+endpoints:
+  - GET /features
+tags: [list, filter, validation, single-request]
+```
+
+Two rows: a malformed ULID filter (row 1) and an unknown filter
+operator (row 2). Both expect 400 with `invalid_parameters[]`
+populated. Spec pins exact `field` / `rule` values per row; row 2
+also pins a `reason` substring, since its `field` binds at the
+umbrella `filter` level and the offending sub-key only surfaces in
+`reason`.
+
+**Emitted `.http`** (`e2e/http/features/feature_list_filter_malformed_rejected.http`):
+
+```http
+# feature_list_filter_malformed_rejected
+#
+# Source: e2e/specs/features.md ## Scenario: feature_list_filter_malformed_rejected
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+
+###
+# @name r__feature_list_filter_malformed_rejected__row1_bad_ulid
+# @title row 1: filter[meter_id][eq]=not-a-ulid -> 400 with invalid_parameters
+GET {{api_base}}/openmeter/features?filter[meter_id][eq]=not-a-ulid
+
+?? status == 400
+?? js response.parsedBody.invalid_parameters[0].field == meter_id
+?? js response.parsedBody.invalid_parameters[0].rule == anyOf
+
+###
+# @name r__feature_list_filter_malformed_rejected__row2_unknown_operator
+# @title row 2: filter[meter_id][zz]=<ulid> -> 400 with invalid_parameters
+GET {{api_base}}/openmeter/features?filter[meter_id][zz]=01HXYZABCDEFGHJKMNPQRSTVWX
+
+?? status == 400
+?? js response.parsedBody.invalid_parameters[0].field == filter
+?? js response.parsedBody.invalid_parameters[0].rule == format
+?? body contains "filter[meter_id][zz]: unsupported operator"
+```
+
+**Commentary:**
+
+- Two-row scenario, two regions — same pattern as a matrix, just
+  smaller. Each region is independent (no `@ref` between them).
+- DSL-first: indexed `[0].field` / `[0].rule` access via `?? js`
+  beats a `test()` block with `some()` here because the response
+  consistently has a single `invalid_parameters` entry. Each `??`
+  line emits its own JUnit entry. If a future binder version
+  starts emitting multiple entries with non-deterministic
+  ordering, swap to `test()` with `some()` (see `format.md`'s
+  schema-rule example).
+- Row 2 uses `?? body contains "..."` as a **third** assertion to
+  pin the offending sub-key, since `field == "filter"` alone
+  doesn't say "this was about `meter_id`'s operator." The
+  `reason` text carries that detail; substring-on-body is the
+  cheapest way to assert it.
+- Spec started with `NEEDS-VERIFY` markers on both `rule` values.
+  A live run against a deployment with an OpenAPI binder layer in
+  front of OpenMeter pinned the actual values (`anyOf`, `format`)
+  and revealed the umbrella-field binding for row 2 — both
+  observations were fed back into `e2e/specs/features.md`. The
+  spec-loose → run-real → tighten-spec → tighten-emit loop is the
+  canonical workflow when the spec author can't predict the
+  binder's exact rule vocabulary.
+
+---
+
+## Example: `matrix` shape — `feature_create_unit_cost_validation_matrix`
+
+**NL spec excerpt:**
+
+```yaml
+id: feature_create_unit_cost_validation_matrix
+endpoints:
+  - POST /meters
+  - POST /features
+```
+
+10 rows. Rows 4–10 all need an LLM-capable meter; row 1 (manual
+baseline) and row 3 (negative amount) don't. Rows 1–2 are `201
+success`; rows 3–9 are `400` handler rejections with the
+detail-equality shape (`response.parsedBody.detail` equals
+`"validation error: <bare msg>"`); row 10 is a `400` binder
+rejection (the OpenAPI schema validator runs ahead of the handler
+in this deployment) with the schema-rule shape
+(`invalid_parameters[0].rule == "allOf"`).
+
+The full 10-row file is too long to inline here — see
+`e2e/http/features/feature_create_unit_cost_validation_matrix.http`
+for the complete emitted output. Below is the structure plus the
+first three rows and the binder-intercepted final row.
+
+**Emitted `.http`** (excerpt):
+
+```http
+# feature_create_unit_cost_validation_matrix
+#
+# Source: e2e/specs/features.md ## Scenario: feature_create_unit_cost_validation_matrix
+#
+# Rows 4-10 reuse a single shared LLM-capable meter created at the
+# top of the file. The meter is read-only across rows, so sharing
+# is safe. Rows 1 and 3 don't need a meter and run independently.
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__matrix__meter_key = matrix_meter_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__matrix__create_shared_meter
+# @title create shared LLM-capable meter (used by rows 4-10)
+POST {{api_base}}/openmeter/meters
+Content-Type: application/json
+
+{
+  "key": "{{d__matrix__meter_key}}",
+  "name": "Test LLM Meter",
+  "event_type": "e2e_llm_test",
+  "aggregation": "count",
+  "dimensions": {
+    "provider": "$.provider",
+    "model": "$.model",
+    "token_type": "$.token_type"
+  }
+}
+
+?? status == 201
+{{
+  exports.v__matrix__meter_id = response.parsedBody.id;
+}}
+
+###
+# @name r__matrix__row1_manual_baseline_succeeds
+# @title row 1: manual baseline (amount=5, no meter) -> 201
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r1_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "unit_cost": { "type": "manual", "amount": "5" }
+}
+
+?? status == 201
+
+###
+# @name r__matrix__row2_llm_baseline_succeeds
+# @title row 2: LLM baseline with shared meter -> 201
+# @ref r__matrix__create_shared_meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r2_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "meter": { "id": "{{v__matrix__meter_id}}" },
+  "unit_cost": {
+    "type": "llm",
+    "provider": "openai",
+    "model": "gpt-4",
+    "token_type": "input"
+  }
+}
+
+?? status == 201
+
+###
+# @name r__matrix__row3_negative_amount_rejected
+# @title row 3: manual amount=-1 -> 400 (non-negative rule)
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r3_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "unit_cost": { "type": "manual", "amount": "-1" }
+}
+
+?? status == 400
+?? js response.parsedBody.detail == validation error: manual unit cost amount must be non-negative
+
+# … rows 4-9 follow the same handler-rejection pattern, each
+# pinning the full "validation error: <msg>" detail. Row 10 is
+# binder-intercepted and uses the schema-rule shape:
+
+###
+# @name r__matrix__row10_invalid_token_type_rejected
+# @title row 10: LLM with token_type="banana" -> 400 (binder allOf rejection)
+# @ref r__matrix__create_shared_meter
+#
+# The OpenAPI binder validates the enum on token_type before the
+# request reaches the handler; the handler's "invalid token_type"
+# message is unreachable in deployments with a binder gateway in
+# front. Schema-rule shape.
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r10_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "meter": { "id": "{{v__matrix__meter_id}}" },
+  "unit_cost": {
+    "type": "llm",
+    "provider": "openai",
+    "model": "gpt-4",
+    "token_type": "banana"
+  }
+}
+
+?? status == 400
+?? js response.parsedBody.invalid_parameters[0].field == unit_cost
+?? js response.parsedBody.invalid_parameters[0].rule == allOf
+```
+
+**Commentary:**
+
+- **No `@loop`.** Each row is a separate `r__` region with a
+  descriptive slug. The JUnit reporter shows
+  `r__matrix__row3_negative_amount_rejected` as the failing test —
+  not `iteration #3 of POST /features`.
+- **Shared prerequisite.** The LLM-capable meter is created **once**
+  at the top, and rows 4–10 depend on it via `# @ref
+  r__matrix__create_shared_meter`. The NL spec says "every row that
+  needs an LLM unit cost also creates the meter above" — the emit
+  consolidates this to one creation, since the meter is read-only
+  across rows. This is a deliberate deviation from "fresh fixtures
+  per row"; the deviation is documented in the file's preamble
+  comment so a reviewer can spot it.
+- **Heterogeneous bodies, written in full.** Each row's `unit_cost`
+  is a different shape — manual vs LLM, with vs without `meter`,
+  required-field-missing vs mutex-violation. No shared base body,
+  no conditional fields. The cost is verbosity; the benefit is
+  spec-row-to-region 1:1 readability.
+- **Detail-equality, not body-contains, for handler rejections.**
+  Rows 3–9 use `?? js response.parsedBody.detail == validation
+  error: <bare msg>` — pinning the full prefixed string from the
+  domain validator's framework wrapper. Avoid `?? body contains
+  "..."`: it's documented (`format.md`) as unreliable for
+  `application/problem+json` bodies on httpyac 6.16.7.
+- **Row 10 is binder-intercepted.** `token_type: "banana"`
+  violates the OpenAPI enum, so the binder layer's `allOf`
+  validator rejects before the handler runs — the handler's
+  `"invalid token_type"` message is unreachable in deployments
+  that put an OpenAPI schema validator in front of OpenMeter. The
+  row uses the schema-rule shape
+  (`invalid_parameters[0].field == "unit_cost"`,
+  `rule == "allOf"`), matching the canonical pattern in
+  `feature_create_key_must_not_be_ulid` and
+  `feature_list_filter_malformed_rejected`. Re-pin if the test is
+  re-targeted at a deployment that runs the handler directly with
+  no schema validator in front; in that case row 10 reverts to
+  detail-substring shape carrying the handler's
+  `"invalid token_type"` message.
+- **Row 1 has no detail substring** — it's a 201, not a 4xx. Just
+  `?? status == 201`. Don't invent assertions when the spec is
+  silent.
+- **Unique-suffixed keys per row.** Each row's request body uses
+  `{{$timestamp}}_{{$randomInt 0 1000000}}` so re-runs against a
+  shared DB don't collide.

--- a/.agents/skills/e2e-httpyac/references/format.md
+++ b/.agents/skills/e2e-httpyac/references/format.md
@@ -1,0 +1,736 @@
+# Emit Format — httpYac `.http` files
+
+How to emit an httpYac scenario file from an NL spec scenario.
+Runner-aware, format-strict, generator-friendly.
+
+This reference is the format contract for the `e2e-httpyac` skill.
+Worked examples of every shape class live in `examples.md`.
+
+---
+
+## Goal
+
+A `.http` file that:
+
+1. Reads top-to-bottom as the scenario's narrative — every request
+   region maps 1:1 to a numbered Step in the NL spec.
+2. Is **executable as-is** by `httpyac send` against a live OpenMeter
+   server, with no helper scripts, no `package.json`, no fixture
+   loaders.
+3. Produces clean JUnit / JSON output where each `r__` request is its
+   own reporter entry, naming the scenario id and step verbatim.
+4. Is mechanically traceable back to the NL spec — the emitted file's
+   request names embed the scenario id, and the file lives at
+   `e2e/http/<family>/<scenario_id>.http`.
+
+---
+
+## File layout
+
+```http
+# <scenario id>
+#
+# Source: e2e/specs/<family>.md ## Scenario: <scenario id>
+# (any NEEDS-VERIFY markers from the spec, copied here verbatim)
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__<scenario>__<key1> = <literal or {{$dynamic}} value>
+@d__<scenario>__<key2> = …
+
+###
+# @name r__<scenario>__<step1_slug>
+# @title <step 1 title from NL spec>
+<METHOD> {{api_base}}<path>
+<headers>
+
+<body>
+
+?? <assertion 1>
+?? <assertion 2>
+{{
+  exports.v__<scenario>__<capture> = response.parsedBody.<path>;
+}}
+
+###
+# @name r__<scenario>__<step2_slug>
+# @title <step 2 title>
+# @ref r__<scenario>__<step1_slug>
+…
+```
+
+Constraints:
+
+- **First content block** is a comment naming the scenario id and the
+  spec source path.
+- **File-global aliases** (`@<name> = <value>`) live before the first
+  `###`. `@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3` is
+  always present. **`OPENMETER_ADDRESS` stays the bare host** (e.g.
+  `http://localhost:8888`) to match the `/e2e` Go suite's convention
+  exactly. The version prefix `/api/v3` lives in the `.http` file —
+  not in the env var — so a single shell-exported `OPENMETER_ADDRESS`
+  works for both runners.
+- **One request region per Step** in the NL spec. Don't merge or
+  split steps relative to the spec.
+- **Request region order** matches Step order. httpYac runs requests
+  in file order, and captures only flow forward.
+
+---
+
+## Naming convention (hard rule)
+
+| Prefix | Used for | Pattern |
+|---|---|---|
+| `r__` | `# @name` for a request region | `r__<scenario>__<step_slug>` |
+| `v__` | Exported variable from a post-response script | `v__<scenario>__<capture_name>` |
+| `d__` | File-global immutable data variable | `d__<scenario>__<field_name>` |
+| upper-snake | Environment variable from `process.env` | `OPENMETER_ADDRESS`, `OPENMETER_TOKEN` |
+
+`<scenario>` is the spec's `id`, lowercased and snake-cased.
+
+**Step slug derivation rule** (deterministic, so family-regenerate
+is reproducible):
+
+1. Take the NL spec Step's bold leading phrase (the text between
+   `**` markers at the start of the step, e.g.
+   `**Create feature.**` → `Create feature`).
+2. Lowercase, replace any spaces with `_`, drop trailing
+   punctuation, strip articles (`a`, `the`).
+3. Compress to one or two words — drop generic verbs/objects when
+   the meaning stays clear (`Create feature` → `create_feature`;
+   `Get feature after deletion` → `get_after_delete`).
+4. For matrix scenarios, prefix with `row<N>_` and suffix with
+   the row's outcome verb (`row3_negative_amount_rejected`,
+   `row1_manual_baseline_succeeds`).
+
+Same NL spec → same slug. The skill is allowed to ask the user for
+disambiguation when two steps would produce identical slugs, but
+this should be vanishingly rare for sane spec authoring.
+
+All names are valid JavaScript identifiers — letters, digits,
+underscores only. No hyphens. No dynamic content in names; dynamic
+values (`$timestamp`, `$uuid`) appear in **data values**, not in
+identifiers.
+
+Why this is non-negotiable:
+
+- httpYac's `@name` registry has no scope across imports — first
+  match wins. Without scenario-prefixed names, two files importing a
+  shared baseline can silently capture each other's responses.
+- Script variables live on the global scope of the script context —
+  variable names must be unambiguous across all files in a single
+  `httpyac send` invocation.
+- The `r__` / `v__` / `d__` distinction makes a file grep-able: a
+  reviewer can scan one file and see request boundaries, runtime
+  state, and fixture data at a glance.
+
+---
+
+## Capture pattern — explicit `exports`, not implicit `@name`
+
+httpYac's `@name` captures the parsed JSON body of a response and
+exposes it under `{{<name>.<field>}}`. This is **insufficient** for
+this skill: the body alone doesn't carry headers, status, or computed
+values, and the implicit binding is awkward to debug when something
+goes wrong.
+
+**Always emit an explicit post-response script** for any captured
+value:
+
+```http
+###
+# @name r__feature_lifecycle__create_feature
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{ "key": "{{d__feature_lifecycle__feature_key}}", "name": "Test Feature" }
+
+?? status == 201
+{{
+  exports.v__feature_lifecycle__feature_id = response.parsedBody.id;
+}}
+```
+
+Rules:
+
+- **The newline after `{{` is required.** httpYac distinguishes
+  `{{var}}` (substitution) from `{{ block }}` (script) by the line
+  break — emitting `{{exports.foo = …;}}` on one line silently turns
+  the whole thing into a substitution attempt.
+- **Capture only what later steps reference.** Don't pre-emptively
+  export every field — emit one `exports.v__...` per field that
+  appears in a downstream `{{v__...}}` substitution or assertion.
+- **Use `response.parsedBody`** (auto-parsed JSON) for body fields.
+  Use `response.headers` for header values. Use `response.statusCode`
+  for status (rarely needed for captures; assertions cover it).
+- **No async work.** If a capture genuinely requires async, export
+  the Promise (`exports.v__... = (async () => {...})();`); but for
+  v1, every emitted scenario stays synchronous.
+
+### `?? js` is for static expressions only — use `test()` for any runtime value
+
+httpyac 6.16.7's `?? js` line parser is **brittle around runtime
+values**. Two failure modes verified against the runner:
+
+1. **`{{d__...}}` substitution inside `?? js`.** Data variables
+   resolve correctly in request bodies, headers, URLs, and query
+   strings, but `?? js
+   response.parsedBody.detail.includes('with key
+   {{d__scn__feature_key}} already exists')` raises `SyntaxError:
+   Invalid or unexpected token`. In `?? js` context httpyac evaluates
+   the contents of `{{...}}` as a JS expression rather than a string
+   substitution, and `d__...` has no JS-scope binding (only
+   `exports.v__...` values do).
+
+2. **JS `+` concatenation with an exported `v__`.** Even rewriting
+   the assertion to `?? js
+   response.parsedBody.detail.includes('with key ' +
+   v__scn__captured_key + ' already exists')` — which **is** valid
+   JS — still throws `SyntaxError`. The `?? js` parser doesn't reliably
+   forward multi-operator JS expressions into the underlying
+   evaluator.
+
+**Rule.** Reach for `?? js` only when the assertion's right-hand side
+is a **constant literal** (status code, fixed string, fixed number).
+Any time a runtime-captured value participates in the comparison —
+exported `v__`, parsed body field substring containing the captured
+value, computed expression — emit a JS `test()` block instead. This
+is the format's documented fallback (see "Relationship / nested /
+array checks → JS `test()`" below); the brittleness above is what
+makes that fallback non-optional rather than just stylistic.
+
+Canonical pattern when the assertion needs to mention a runtime
+value:
+
+```http
+###
+# @name r__scn__create_feature
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{ "key": "{{d__scn__feature_key}}", "name": "Test Feature" }
+
+?? status == 201
+{{
+  // Echo the data-var into a JS-accessible v__ for downstream
+  // assertions; {{d__...}} does not resolve in ?? js context.
+  exports.v__scn__captured_key = response.parsedBody.key;
+}}
+
+###
+# @name r__scn__check_detail_mentions_key
+# @ref r__scn__create_feature
+…
+?? status == 409
+{{
+  const { ok } = require('assert');
+  test('detail mentions the duplicate key', () => {
+    const detail = response.parsedBody.detail || '';
+    const key = v__scn__captured_key;
+    ok(
+      detail.includes('with key ' + key + ' already exists'),
+      'expected detail to contain "with key <key> already exists", got: ' + detail
+    );
+  });
+}}
+```
+
+`?? js` *does* work fine when the substitution resolves to a real JS
+expression that's effectively constant at parse time — `?? js
+response.parsedBody.id == {{v__scn__feature_id}}` (where the right
+side is just a bare ULID with no spaces or operators) is consistently
+reliable. The brittleness shows up when `?? js` has to forward more
+than one operator or a string-concat chain.
+
+---
+
+## Assertion vocabulary
+
+Every Step in the NL spec maps to a fixed set of `??` lines and at
+most one `{{ test(...) }}` block. Pick by **shape of the assertion**,
+not by intent.
+
+### DSL-first principle
+
+**Prefer the `??` DSL over JS `test()` blocks whenever an idiom
+exists.** The DSL is denser, more grep-able, and the JUnit reporter
+treats each `??` line as a separate test case (a `test()` block
+collapses to one entry per `test(...)` call). Reach for `test()`
+only when the DSL genuinely can't express the check — typically:
+
+- array membership / length / ordering,
+- multi-field invariants (e.g. "field A and field B both present"),
+- assertions that need conditional JS logic,
+- structurally-loose checks for `NEEDS-VERIFY` markers,
+- distinguishing `undefined` from `null` from `false` (where the
+  JS-side semantics matter).
+
+Order of preference, top to bottom:
+
+1. **Plain `??`** (status, body substring, header, duration, hash).
+2. **`?? js <expr> <op> <literal>`** (any field whose value is a
+   primitive, including via `typeof`).
+3. **`{{ test(...) }}` JS block** as a fallback for anything the
+   above can't express.
+
+### Cheap declarative checks → `??`
+
+| NL phrasing | Emitted line |
+|---|---|
+| `Expect 201 Created` | `?? status == 201` |
+| `Expect 204 No Content` | `?? status == 204` |
+| `Expect detail equals "<full>"` | `?? js response.parsedBody.detail == <full>` |
+| `Expect detail contains "<sub>"` | `?? js response.parsedBody.detail.includes('<sub>')` ([see warning](#why-not-body-contains)) |
+| `Expect <field> equals <literal>` (string/number) | `?? js response.parsedBody.<field> == <literal>` |
+| `Expect <field> is absent` | `?? js typeof response.parsedBody.<field> == undefined` |
+| `Expect <field> is null` | **JS `test()` block** — see "Null and strict-equality" below |
+| `Expect <field> is falsy` (any of undefined/null/false/0/"") | `?? js response.parsedBody.<field> isFalse` |
+
+Prefer `?? js response.parsedBody.<path> == <value>` over
+`?? body contains "<value>"` whenever the field is structured —
+substring matches on serialized JSON are brittle (decimal
+normalization, whitespace, key ordering).
+
+#### Why not `body contains`?
+
+`?? body contains "<sub>"` is **unreliable on httpyac 6.16.7 for
+`application/problem+json` response bodies**. Even when the
+substring is verbatim inside the response `detail`, the assertion
+throws an internal stack frame at `httpyac/dist/index.js:2:48611`
+rather than evaluating cleanly. The call site fires for every
+affected row, so it's a code-path quirk, not data-dependent.
+
+**Always reach for `?? js response.parsedBody.<field> == <value>`
+or `.includes('<sub>')` instead.** The DSL-native form is more
+precise (operates on the parsed structured field, not raw bytes),
+DSL-first principle aligned, and the JUnit reporter shows one
+entry per `??` line. `body contains` stays in the table for
+genuinely unstructured bodies (HTML, plain text, non-`+json`
+content types) — but those are rare in this API.
+
+### How the absence idiom works
+
+`?? js typeof response.parsedBody.<field> == undefined` works because
+**both sides are strings** at compare time:
+
+- LHS: `typeof <expr>` evaluates JS-side and returns the string
+  `"undefined"` when the property is missing.
+- RHS: `undefined` is a 9-character literal, parsed as the string
+  `"undefined"`.
+- httpYac compares string `"undefined"` to string `"undefined"`. ✓
+
+This is the DSL-native idiom for absence and avoids a `test()`
+block. The semantics are slightly looser than `assert.strictEqual(x,
+undefined)` — `typeof` returns `"undefined"` for both undeclared
+variables and explicitly-undefined properties — but for response
+bodies that distinction never matters, so the loose form is safe.
+
+### Null and strict-equality checks → JS `test()`
+
+The DSL has no clean idiom for "field is exactly `null`". Writing
+`?? js response.parsedBody.<field> == null` is unsafe: httpYac's
+parser likely treats the right side as the string `"null"`, in
+which case the JS comparison `null == "null"` is `false` and the
+assertion silently fails. Use a `test()` block:
+
+```http
+{{
+  const { strictEqual } = require('assert');
+  test('field is null', () => {
+    strictEqual(response.parsedBody.<field>, null);
+  });
+}}
+```
+
+Same fallback applies any time you need to distinguish `undefined`
+from `null`, or assert anything `===`-strict that the DSL can't
+express. The forbidden directives table flags `?? js <expr> ===
+<value>` directly because httpYac's parser splits operators on the
+first `==` and leaks the trailing `=` into the expected literal,
+making the assertion fail even when the underlying values match.
+
+### Relationship / nested / array checks → JS `test()`
+
+```http
+{{
+  const { ok, strictEqual } = require('assert');
+  test('<human-readable assertion>', () => {
+    const x = response.parsedBody.<path>;
+    ok(<condition>, '<failure message>');
+    strictEqual(<actual>, <expected>);
+  });
+}}
+```
+
+Use a JS block when:
+
+- An assertion checks an array (membership, length, ordering).
+- An assertion combines multiple fields (mutual presence, derived
+  equality).
+- An assertion is conditional (a value is acceptable as either form
+  X or form Y, like `cost: "0"` or `cost: null`).
+- An assertion has a `NEEDS-VERIFY` marker — emit a structurally
+  loose check rather than a literal match.
+
+Don't use a JS block for a single status-or-substring check. Don't
+use a JS block to set up state for the next request — that's what
+post-response `exports` are for.
+
+---
+
+## Error-shape templates
+
+Every 4xx step in the NL spec names one of three shapes. The mapping
+is mechanical.
+
+### Detail substring or equality — `problem.detail`
+
+NL spec (substring):
+```
+- Expect 404 Not Found.
+- Expect detail contains "feature not found: {feature.id}".
+```
+
+Emit (substring):
+```http
+?? status == 404
+?? js response.parsedBody.detail.includes('feature not found: {{v__<scenario>__feature_id}}')
+```
+
+NL spec (equality — preferred when the detail is fully
+deterministic, e.g. the OpenMeter framework's
+`"validation error: <bare msg>"` wrapper):
+```
+- Expect 400 Bad Request.
+- Expect detail equals "validation error: manual unit cost amount must be non-negative".
+```
+
+Emit (equality):
+```http
+?? status == 400
+?? js response.parsedBody.detail == validation error: manual unit cost amount must be non-negative
+```
+
+Notes:
+
+- The spec's `{feature.id}` placeholder maps to the corresponding
+  `{{v__<scenario>__feature_id}}` exported variable. If the spec
+  references a fixture-bound id rather than a captured one, map to
+  the corresponding `{{d__...}}` data variable.
+- **Do not use `?? body contains "<sub>"`** — see the warning in
+  "Cheap declarative checks → `??`" above. Use
+  `?? js response.parsedBody.detail.includes('<sub>')` for
+  substring matching, or `?? js response.parsedBody.detail ==
+  <full>` for full equality. The `==` form parses everything to
+  the right of `==` (until end of line) as a string literal, so
+  no quoting is needed for the right-hand side.
+
+### Domain code — `extensions.validationErrors[].code`
+
+NL spec:
+```
+- Expect 400 Bad Request.
+- Expect domain code "currency_invalid".
+```
+
+Emit:
+```http
+?? status == 400
+{{
+  const { ok } = require('assert');
+  test('domain code currency_invalid is present', () => {
+    const errors = (response.parsedBody.extensions || {}).validationErrors || [];
+    ok(
+      errors.some(e => e.code === 'currency_invalid'),
+      'expected validationErrors[].code to include "currency_invalid", got: ' + JSON.stringify(errors)
+    );
+  });
+}}
+```
+
+### Schema rule — `invalid_parameters[].rule`
+
+NL spec:
+```
+- Expect 400 Bad Request.
+- Expect schema rule "format" on field referencing "meter_id".
+```
+
+Emit:
+```http
+?? status == 400
+{{
+  const { ok } = require('assert');
+  test('invalid_parameters references meter_id with format rule', () => {
+    const ips = response.parsedBody.invalid_parameters || [];
+    ok(ips.length > 0, 'invalid_parameters must be non-empty');
+    ok(
+      ips.some(p => (p.field || '').includes('meter_id') && p.rule === 'format'),
+      'expected invalid_parameters[] entry with field~"meter_id" and rule="format", got: ' + JSON.stringify(ips)
+    );
+  });
+}}
+```
+
+If the NL spec marks the rule string `NEEDS-VERIFY`, drop the
+`p.rule === 'format'` condition and assert only field presence —
+plus a `# NEEDS-VERIFY: <reason>` comment line above the JS block.
+
+#### DSL-first form for single-element arrays
+
+When the response consistently has exactly one
+`invalid_parameters[]` entry (which is the common case for current
+OpenMeter rejection responses), prefer the DSL-first form with
+indexed access — terser, one JUnit entry per assertion, no
+`test()` block needed:
+
+```http
+?? status == 400
+?? js response.parsedBody.invalid_parameters[0].field == <field>
+?? js response.parsedBody.invalid_parameters[0].rule == <rule>
+```
+
+Use the `test()` + `some()` form (above) when the response can
+return multiple entries and ordering isn't guaranteed.
+
+#### Common binder-rejection patterns spec authors should expect
+
+When the NL spec pins a `field` or `rule` value and a real run
+surfaces something different, the deviation is usually one of two
+recurring patterns. Both arise from how TypeSpec compiles to the
+OpenAPI schema the binder layer enforces.
+
+**Pattern 1 — TypeSpec `union` → OpenAPI `anyOf`.** If the API
+field is typed as a TypeSpec `union` (e.g., a filter that accepts
+either a bare ULID or an `{eq?, neq?, ...}` operator object), the
+generated schema uses `anyOf`. When the input matches no branch,
+the binder reports `rule: "anyOf"` — *not* the more specific
+format/pattern rule that an individual branch carries. The binder
+can't tell you which branch was closest; that's by design of
+`anyOf`.
+
+If the spec guessed `"format"` or `"pattern"` for a union-typed
+field and the run shows `"anyOf"`, this is the cause. Pin
+`"anyOf"` and add a one-line note in the scenario's Notes section.
+
+**Pattern 2 — umbrella-field binding for unknown sub-operators.**
+For deep-object query params (e.g.
+`filter[meter_id][zz]=<value>`), an unknown sub-operator (`zz`)
+binds the rejection at the **umbrella query parameter** (`field:
+"filter"`), not at the sub-key (`field: "meter_id"`). The
+offending sub-key surfaces only in `reason` (a string like
+`"filter[meter_id][zz]: unsupported operator"`).
+
+If the spec assumed `field: "meter_id"` and the run shows `field:
+"filter"`, this is the cause. Pin `field: "filter"` plus a
+`?? body contains "<sub-key reference>"` (or
+`?? js response.parsedBody.invalid_parameters[0].reason.includes(...)`)
+to anchor the assertion to the right sub-key.
+
+Both patterns also belong in the `/e2e-nl` skill's spec-authoring
+guidance — once the spec gets them right at draft time, the emit
+side becomes mechanical.
+
+---
+
+## Matrix scenarios — N regions, not a loop
+
+The NL spec's matrix shape uses a Markdown rows table. Each row
+becomes its own request region. **Do not emit `# @loop`** — it
+collapses every row into a single reporter entry, masks per-row
+failure details, and has historical bugs in the JUnit emitter.
+
+Pattern:
+
+```http
+# Shared prerequisite (created once, referenced by every row that needs it)
+###
+# @name r__<scenario>__create_shared_<dep>
+…
+
+###
+# @name r__<scenario>__row1_<descriptive_slug>
+# @title row 1: <row's intent> → <expected outcome>
+<request>
+?? status == <row's expected status>
+[?? js response.parsedBody.detail == <full detail> if 4xx with detail-equality shape]
+[?? js response.parsedBody.detail.includes('<sub>') if 4xx with detail-substring shape]
+[?? js response.parsedBody.invalid_parameters[0].field == <field> if 4xx with schema-rule shape]
+[?? js response.parsedBody.invalid_parameters[0].rule == <rule> if 4xx with schema-rule shape]
+
+###
+# @name r__<scenario>__row2_<descriptive_slug>
+…
+```
+
+Rules:
+
+- Row slugs are descriptive, not numeric — `row3_negative_amount_rejected`,
+  not `row3`. The JUnit reporter shows the slug; numeric-only row
+  names tell the reader nothing on failure.
+- Shared prerequisites (a meter the matrix re-uses, an addon the
+  matrix mutates against) are created once at the top of the file
+  and referenced via `# @ref` on each row that needs them.
+- Heterogeneous bodies are written out fully per row. Do not try
+  to share a base body and merge per-row deltas — JSON's lack of
+  trailing-comma tolerance turns conditional fields into a
+  template-engine nightmare.
+- If the NL spec lists a row without an explicit detail substring
+  (a 2xx success row), emit only `?? status == 201` (or whatever
+  the row expects). Don't invent assertions.
+
+The cost is verbosity — a 10-row matrix is ~150 lines of `.http`.
+The benefit is per-row clarity in failure reports and a 1:1 mapping
+between NL spec rows and emitted regions, which makes spec drift
+trivial to spot.
+
+---
+
+## Skipped scenarios
+
+NL spec scenarios with `status: skipped` in their YAML frontmatter
+become `# @disabled` regions plus a comment explaining the gate.
+Every step is still emitted — the skill never silently drops
+content — but every region carries `# @disabled`.
+
+```http
+# Source: e2e/specs/<family>.md ## Scenario: <id>
+#
+# STATUS: SKIPPED — <reason copied verbatim from the spec>
+# Re-enable by removing the @disabled lines once <gate condition> is met.
+
+###
+# @disabled
+# @name r__<scenario>__<step>
+…
+```
+
+`@disabled` is static. Do not emit conditional disable expressions
+(`# @disabled !{{env_seed_present}}`) — they're brittle and tend to
+silently re-enable on env changes.
+
+---
+
+## NEEDS-VERIFY markers
+
+When the NL spec annotates a row or step with `NEEDS-VERIFY: <reason>`,
+emit:
+
+1. A comment in the `.http` directly above the relevant assertion(s),
+   copying the `NEEDS-VERIFY:` text verbatim.
+2. A **structurally loose** assertion that pins what's verifiable
+   (field presence, status code) without locking in the un-pinned
+   detail.
+
+Example — schema rule with un-pinned `rule` string:
+
+```http
+###
+# @name r__<scenario>__<row_slug>
+GET {{api_base}}/openmeter/features?filter[meter_id][eq]=not-a-ulid
+
+?? status == 400
+# NEEDS-VERIFY: confirm exact `rule` string against a live server.
+# Tighten the JS block below once pinned.
+{{
+  const { ok } = require('assert');
+  test('invalid_parameters references meter_id', () => {
+    const ips = response.parsedBody.invalid_parameters || [];
+    ok(ips.length > 0, 'invalid_parameters must be non-empty');
+    ok(
+      ips.some(p => (p.field || '').includes('meter_id')),
+      'expected invalid_parameters[] entry referencing meter_id'
+    );
+  });
+}}
+```
+
+When the user pins the value via a real run, they (or a follow-up
+skill invocation) tighten the assertion and remove the comment.
+
+---
+
+## Cleanup ordering
+
+The NL spec is the source of truth on cleanup. If the spec includes
+explicit delete steps (e.g. the lifecycle scenario's "Delete
+feature"), emit them in the order the spec lists them. If the spec
+doesn't include cleanup, **don't invent it** — the OpenMeter e2e DB
+is shared and unique-suffixed keys make orphaned records benign.
+
+If a scenario creates resources for setup but doesn't clean them up
+in the spec (a common pattern for matrix rows), emit the file as-is.
+A future cleanup convention can be added without revisiting every
+existing file.
+
+---
+
+## Forbidden directives (v1)
+
+These are off-limits in emitted files. They either break in CLI
+mode, introduce non-determinism, or have unresolved reporter bugs.
+
+| Directive | Why forbidden |
+|---|---|
+| `# @loop` | Collapses matrix rows into a single reporter entry; historical JUnit emitter bugs. Use N regions instead. |
+| `# @disabled <expression>` (dynamic) | Conditional disabling tends to silently re-enable on env changes. Use static `@disabled` only. |
+| `# @note` | Pops a confirmation dialog in editor mode; behavior in CLI is undefined. |
+| `# @openWith`, `# @save`, `# @extension` | Editor-only output controls; ignored or warning in CLI. |
+| `$input`, `$password`, `$pick` | Interactive prompts; deadlock CLI runs. |
+| `exports.$cancel`, `$httpyac.cancel(…)` | Dynamic cancellation; surprises reporters. |
+| `# @import <other-scenario>.http` | Cross-scenario state leaks via the shared `@name` namespace. Each scenario file is self-contained. |
+| `@<var> := <expr>` (lazy) | Lazy variables resolve at last-possible moment, which makes debug-by-grepping harder. Use fixed `@<var> = <value>` plus explicit `exports`. |
+| `?? js <expr> === <value>` (triple-equals) | httpYac's `??` DSL parses the right side as a literal, so `=== undefined` becomes `== "= undefined"`. Always use a JS `test()` block for strict comparisons (see "Absence and strict-equality checks"). |
+
+`# @ref <name>` and `# @forceRef <name>` **are** allowed and
+encouraged when one region depends on another's setup running first.
+Use them on every region that references a `v__...` exported by an
+earlier region.
+
+---
+
+## Project root files
+
+The skill bootstraps these on first run if they don't exist.
+
+### `e2e/http/httpyac.config.js`
+
+```js
+// Project-root marker for httpYac. The presence of this file scopes
+// httpYac's project root to e2e/http/.
+//
+// Configuration is shell-env based, mirroring the Go e2e convention
+// (`OPENMETER_ADDRESS=... go test ./e2e/...`). Each .http file
+// references {{process.env.OPENMETER_ADDRESS}}; httpYac resolves it from
+// process.env at send time. No env files, no `--env <name>`.
+//
+// Add response-log scrubbing here if real auth tokens ever flow
+// through tests. The skill does not bake auth scrubbing into v1 —
+// add it intentionally when the auth surface is settled.
+
+module.exports = {};
+```
+
+The skill emits this file **once**. Subsequent runs leave it
+untouched — it is user-edited configuration, not generated output.
+
+---
+
+## Emit checklist
+
+Before declaring a scenario file done:
+
+- [ ] First-line comment names the scenario id and spec source path.
+- [ ] `@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3` is present.
+- [ ] Every `# @name` follows `r__<scenario>__<step_slug>`.
+- [ ] Every captured value uses `exports.v__<scenario>__<name>`,
+      with the required newline after `{{`.
+- [ ] Every Step in the NL spec maps to exactly one request region.
+- [ ] Every 4xx step has a status assertion **and** an error-shape
+      assertion matching the spec's named shape.
+- [ ] No forbidden directives (see table above).
+- [ ] Skipped scenarios (`status: skipped`) emit `# @disabled`
+      regions, not redacted bodies.
+- [ ] `NEEDS-VERIFY` markers carry over as comments + loose
+      assertions.
+- [ ] File parses with `httpyac send --dry-run` (when the user
+      validates).

--- a/.agents/skills/e2e-nl/SKILL.md
+++ b/.agents/skills/e2e-nl/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: e2e-nl
+description: Generate a natural-language, runner-agnostic e2e test specification from a v3 API endpoint's source files (TypeSpec + handler + domain validator + converter). The output is a Markdown scenario spec that downstream skills translate into Go, Playwright, .http, Hurl, or other runners. Use this skill whenever someone wants to spec, document, or capture API contract behavior for an endpoint family before writing tests — including phrasings like "write an NL spec", "describe the contract for endpoint X", "what scenarios should we test on /foo", or "I want a test plan for the bar API". Reach for it especially when an endpoint has no e2e coverage yet, or when the user wants a runner-neutral plan that multiple downstream generators can consume.
+user-invocable: true
+argument-hint: "[endpoint family | path to TypeSpec file] [optional: scenario id]"
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
+---
+
+# E2E Natural-Language Spec Generator
+
+You produce a natural-language e2e test specification for an API
+endpoint from its code. Output format follows `references/format.md`,
+modeled on the worked examples in `references/examples.md`.
+
+This skill is **step 1 in a pipeline**:
+
+```text
+endpoint code → [e2e-nl] → NL spec → [/e2e or other generator] → executable tests
+```
+
+Your output feeds the next skill. Describe behavior unambiguously
+enough that a downstream generator can emit tests from the NL spec
+alone.
+
+## Before you start — read these
+
+1. `references/format.md` — format rules, vocabulary, contract.
+2. `references/examples.md` — one worked scenario per shape class.
+
+Both files live alongside this SKILL.md inside the skill directory.
+They are the contract. If either is missing, stop and tell the user
+— the skill depends on them and shouldn't improvise.
+
+`e2e_spec_plan.md` (top-level) is the broader pipeline tracker. Read
+it only if the user references pipeline status, open questions, or
+"where we left off." It isn't required for drafting scenarios.
+
+## The consumer-perspective rule
+
+**The NL spec describes API-observable behavior only.** You read up to
+four internal files to understand *what* the API does; you never write
+*how* it does it into the spec.
+
+Concretely:
+
+- ✅ "Posting a plan with `currency: 'ZZZ'` returns 400 with domain
+  code `currency_invalid`." — Consumer-observable.
+- ❌ "The handler calls `validateCurrency()` which iterates ISO-4217
+  codes." — Implementation.
+- ✅ "A plan with a phase that has no rate cards is accepted at create
+  and surfaces `plan_phase_has_no_rate_cards` on GET." — Visible
+  validation moment.
+- ❌ "The service defers rate-card validation to `Plan.Validate()` at
+  publish." — Implementation.
+
+If a behavior is only visible through logs, DB state, or internal
+telemetry, it is **not** in scope. The reader of a generated test —
+and any future generator skill — should be able to verify every
+assertion by issuing HTTP requests and reading responses.
+
+## Inputs — the four source files
+
+Given an endpoint family (e.g. "features") or a TypeSpec path, locate:
+
+1. **TypeSpec** — `api/spec/packages/aip/src/<family>/` (v3) or
+   `api/spec/packages/legacy/src/<family>/` (v1).
+   *Gives:* request/response types, path + method, status codes, error
+   response shapes.
+2. **Handler** — `api/v3/handlers/<family>/` (v3) or
+   `api/handlers/<family>/` (v1).
+   *Gives:* which validators fire, which error shape is used
+   (`HandleIssueIfHTTPStatusKnown` → domain code, `BaseAPIError` →
+   detail substring, schema binder → invalid_parameters rule).
+3. **Domain validator / rules** — `openmeter/<family>/`. Look for
+   `Validate()`, `Publishable()`, validation error codes, predicate
+   packages.
+   *Gives:* the validation moment (create-time vs. GET-time vs.
+   publish-time) and the domain-code vocabulary.
+4. **Converter** — `convert.go` next to the handler.
+   *Gives:* fields that map 1:1 vs. drop vs. reshape; hints at fields
+   that deserve dedicated scenarios.
+
+Report the four paths you found and the primary endpoint(s) under
+test. If one is missing or ambiguous, ask before proceeding — don't
+guess.
+
+## Workflow — three modes
+
+The skill takes an optional `[scenario id]` argument and dispatches
+based on whether a `e2e/specs/<family>.md` file already exists:
+
+| Family file | Scenario id | Action |
+|---|---|---|
+| absent | not given | Draft the **scenario list + Baselines + first p0 scenario** to seed the file. |
+| absent | given | Draft the **scenario list + Baselines + the named scenario**. The scenario list is still required even when a specific scenario is requested first — it's the index. |
+| present | given | Append **only** the named `## Scenario: <id>` section. Do not modify the list, Baselines, or prior scenarios. |
+| present | not given | Ask the user which scenario id to draft next. The list shows what's available. |
+
+When seeding a new family file:
+
+1. Read the four source files.
+2. Extract observable behavior:
+   - Endpoints (method + path).
+   - Request / response types.
+   - Status codes (2xx and 4xx).
+   - Error shapes (`extensions.validationErrors[].code` /
+     `problem.detail` substring / `invalid_parameters[].rule`).
+   - Lifecycle transitions and validation moments.
+   - Matrix branch points (status × status, type × quantity, etc.).
+   - Uniqueness / conflict constraints.
+3. Produce a **scenario list**. Plain bullets, no checkboxes. Format
+   per `references/format.md` ("Scenario list conventions"):
+   ```text
+   - `<id>` — <one-line intent> — shape: <class> — priority: <p0|p1|p2>
+   ```
+   Append `NEEDS-VERIFY: <reason>` for any candidate the code doesn't
+   fully pin down.
+4. Define any **new Baselines** the scenarios will reference. Reuse
+   no baselines from another family file — each family file is
+   self-contained (see Baselines below).
+5. Draft the first scenario in full (per the dispatch table above).
+6. Return to the user with the list + the seeded scenario.
+
+## Done criterion
+
+A family file is **minimally testable** once its `p0` scenarios are
+drafted. p1 scenarios are core validation; drafting them is recommended
+but the user picks the cadence. p2 scenarios are edge cases; draft them
+when a real run hits one.
+
+Don't draft scenarios indefinitely on your own — after each draft,
+hand control back to the user with the list of remaining scenarios,
+not a freshly-drafted one.
+
+## Shape-class signals in the code
+
+| Shape | Code signal | Example |
+|---|---|---|
+| **lifecycle** | Create + update + publish/archive/delete handlers; domain has a `Status` enum and `effective_from/to` semantics. | Plan lifecycle. |
+| **draft-with-errors** | `Validate()` vs. `Publishable()` split; `validation_errors` on the response body. | `plan_invalid_draft_lifecycle`. |
+| **matrix** | Rule branches on two or more state variables. | Attach `plan.status × addon.status`. |
+| **single-request** | One-shot rule at create-time; no lifecycle follow-up. | Invalid currency. |
+
+When in doubt, start with `single-request` and promote if multi-step
+state turns out to be needed.
+
+### Worked dispatch — picking the shape
+
+> The features handler rejects a `feature` whose `key` parses as a
+> ULID. The validator returns immediately at create-time; there is no
+> draft state, no second moment. There is no matrix here either —
+> only one variable (the `key`) decides. → `single-request`.
+>
+> The plans handler accepts a plan with an empty-rate-card phase at
+> create, but `Validate()` populates `validation_errors` on GET and
+> `Publishable()` rejects at publish. → `draft-with-errors` (the
+> three-moment template).
+>
+> Attaching a plan-addon checks both `plan.status` and `addon.status`
+> and rejects every disallowed combination with a different detail
+> substring. Two state variables, several rows. → `matrix`.
+
+## Baselines
+
+Each `e2e/specs/<family>.md` defines its **own** Baselines section. Do
+not import baselines from another family file. The shapes a feature
+spec uses (`CreateFeatureRequest`, `BillingFeatureManualUnitCost`)
+have nothing to do with the shapes a plan spec uses
+(`CreatePlanRequest`, `BillingRateCard`), even when the names rhyme.
+Cross-file baseline imports couple specs together and break the
+"one file per family" rule.
+
+When the endpoint family needs an object shape **not** yet in its
+file's Baselines section, produce **both**:
+
+1. **A proposed new Baseline block** for that file's Baselines
+   section. Name the API schema type (`CreateFeatureRequest`,
+   `Meter`, etc.) and list field defaults.
+2. **An inlined shape** in the scenario's Fixtures block, so the
+   scenario reads standalone.
+
+Present both alternatives to the user and let them pick. Rule of
+thumb: shapes used by ≥2 scenarios in the family earn a Baseline;
+one-offs stay inlined.
+
+See `references/examples.md` for a worked Baselines section.
+
+## Output file
+
+Default path: `e2e/specs/<family>.md`, co-located with the e2e tests
+in the project (e.g. `e2e/specs/features.md`). If the user specifies
+a different path, use that. Create the `e2e/specs/` directory if it
+doesn't exist.
+
+- **If the file doesn't exist** — create with the preamble,
+  scenario list, Baselines section (only with new baselines added
+  here), and the first drafted scenario.
+- **If the file exists** — append only the named `## Scenario: <id>`
+  section. Do not modify the list, Baselines, or prior scenarios.
+  If the new scenario needs an object shape that isn't yet a
+  Baseline, surface that as a separate decision for the user
+  (per the Baselines section above): either inline the shape in the
+  scenario's Fixtures block, or propose a new Baseline as a separate
+  edit. Never add a Baseline silently during append-mode.
+
+Always include a short preamble above the list:
+
+```markdown
+# E2E Scenario Specifications — <Family>
+
+Natural-language, runner-agnostic description of e2e scenarios for
+the `<family>` endpoint(s). Each `## Scenario` describes wire-level
+behavior (HTTP verb, path, status code, response shape,
+`problem+json` error shape) that any downstream runner can translate
+to an executable test.
+
+See the `e2e-nl` skill (`.agents/skills/e2e-nl/`) for format rules
+(`references/format.md`) and worked examples (`references/examples.md`).
+```
+
+## Things to avoid
+
+**Runner-agnosticism — the central rule.** The spec must read the
+same whether the downstream generator is Go, Playwright, `.http`,
+Hurl, or something that doesn't exist yet. Violations:
+
+- **No runner-specific names.** `TestV3<…>`, `validPlanRequest`,
+  `uniqueKey`, `v3helpers_test.go`, `test.describe`, `.http` section
+  markers — none of this belongs in the spec.
+- **No runner-specific construction mechanics.**
+  `FromBillingPriceFlat`, `nullable.NewNullableWithValue`,
+  `new Request(...)` — describe the JSON body shape; every generator
+  handles its own plumbing.
+- **No assumptions about client lifecycle, isolation, parallelism,
+  or fixture cleanup.** Those are runner choices. "Fresh fixtures
+  per row" is an observable behavior; "fresh client per row" is
+  not.
+
+**Consumer perspective:**
+
+- **No internal package paths, service methods, ent queries.** Read
+  them to understand behavior; never write them into the spec.
+- **No inferred behavior ungrounded in the code.** Flag uncertainty
+  with `NEEDS-VERIFY` and probe against a live server — do not
+  fabricate rules.
+
+**Output discipline:**
+
+- **Every 4xx step names a validation moment** (create-time /
+  GET-time / publish-time / update-time) and an error shape (domain
+  code / detail substring / schema rule). Both vocabularies are in
+  `references/format.md`.
+- **Do not modify previously drafted scenarios on follow-up
+  invocations.** Append only. A scenario's presence is its drafted
+  state; there is no checkbox to tick.
+
+## Smoke test
+
+Run the skill against a known-covered endpoint family (plans) and
+diff the produced spec against the worked examples in
+`references/examples.md`. Large overlap confirms grounding;
+systematic differences surface gaps in either the skill or the
+reference.
+
+## Handoff
+
+Once an NL spec is complete (all p0 scenarios drafted, p1/p2 as
+desired), any number of downstream generator skills can consume it:
+
+- The existing `/e2e` skill (`.agents/skills/e2e/SKILL.md`) emits Go
+  e2e tests.
+- Future skills may emit Playwright, `.http`, Hurl, or other runners
+  from the same source file.
+
+The NL spec is the contract between this skill and all consumers —
+no direct interaction, no runner-specific fields added here. If a
+downstream skill needs information the spec doesn't carry (e.g.,
+"where do generated tests live for runner X"), that's the
+downstream skill's business to resolve by its own convention, not
+this skill's to bake in.

--- a/.agents/skills/e2e-nl/references/examples.md
+++ b/.agents/skills/e2e-nl/references/examples.md
@@ -1,0 +1,354 @@
+# Worked Examples — One Per Shape Class
+
+This reference shows each of the four shape classes drafted as a real
+NL scenario. The product-catalog domain provides the context, but the
+patterns generalize to any v3 endpoint family.
+
+Use these as templates when drafting new scenarios. Match the shape
+class to the kind of behavior you're pinning, then mirror the
+structure (Fixtures / Steps / Notes) with the same density of detail.
+
+| Shape | Example | When to reach for it |
+|---|---|---|
+| `lifecycle` | `plan_lifecycle` | A primary CRUD flow with status transitions and side effects (`effective_from`, `archived_at`, …) on each step. |
+| `draft-with-errors` | `plan_invalid_draft_lifecycle` | Defects accepted at create, surfaced on GET via `validation_errors`, rejected at publish. The canonical three-moment flow. |
+| `single-request` | `plan_invalid_currency` | One request, one rule, one assertion. The default for a validation rule that fires at create-time only. |
+| `matrix` | `plan_addon_attach_status_matrix` | A rule that branches on two or more state variables; one row per combination. |
+
+When in doubt, start with `single-request` and promote if multi-step
+state turns out to be needed. The matrix shape is for genuinely
+combinatorial rules — don't reach for it just because there are
+several similar one-shot validations.
+
+---
+
+## Baselines (illustrative)
+
+Named object shapes the example scenarios reference. Each baseline
+names the **API schema type** it instantiates — these are TypeSpec
+types under `api/spec/packages/aip/src/productcatalog/` and appear in
+`api/openapi.yaml` as the stable cross-language contract.
+
+These specific baselines belong to the product-catalog domain. Other
+families (features, meters, …) define their own. The pattern — name
+the API schema type, list field defaults, allow per-scenario
+mutation — is what generalizes.
+
+Keys (`key`) are unique per run. The uniqueness strategy is a runner
+concern, not a spec concern — any suffix that survives re-runs
+against a shared DB is fine.
+
+### Baseline plan — `CreatePlanRequest`
+
+- `key`: unique
+- `name`: `"Test Plan"`
+- `currency`: `"USD"`
+- `billing_cadence`: `"P1M"`
+- `phases`: a list containing one **Baseline phase** (`last = true`)
+
+### Baseline phase — `BillingPlanPhase`
+
+Parameter `last` (boolean) controls the duration:
+
+- `key`: unique
+- `name`: `"Test Phase"`
+- `duration`: `null` when `last = true`; `"P1M"` otherwise — non-last
+  phases must be bounded.
+- `rate_cards`: a list containing one **Baseline flat rate card**
+
+### Baseline flat rate card — `BillingRateCard` with `BillingPriceFlat`
+
+- `key`: unique
+- `name`: `"Test Rate Card"`
+- `price`: `BillingPriceFlat { type: "flat", amount: "10" }`
+- `billing_cadence`: `"P1M"`
+- `payment_term`: `"in_advance"`
+
+### Baseline addon — `CreateAddonRequest`
+
+- `key`: unique
+- `name`: `"Test Addon"`
+- `currency`: `"USD"`
+- `instance_type`: `"single"`
+- `rate_cards`: a list containing one **Baseline flat rate card**
+
+### Baseline plan-addon attach — `CreatePlanAddonRequest`
+
+- `name`: `"Test Plan Addon"`
+- `addon`: `{ id: {addon.id} }` (referencing the addon bound by the
+  scenario's fixtures)
+- `from_plan_phase`: `{plan.phases[0].key}` (or whichever phase key
+  the scenario targets)
+
+---
+
+## Example: `lifecycle` shape — Plan lifecycle
+
+```yaml
+id: plan_lifecycle
+endpoints:
+  - POST /plans
+  - GET /plans/{id}
+  - GET /plans
+  - PUT /plans/{id}
+  - POST /plans/{id}/publish
+  - POST /plans/{id}/archive
+  - DELETE /plans/{id}
+entities: [plan]
+tags: [lifecycle, crud]
+```
+
+**Intent:** A plan moves through the full draft → active → archived →
+deleted lifecycle, and `effective_from` / `effective_to` transition
+predictably at publish and archive.
+
+**Fixtures:**
+- A `CreatePlanRequest` per **Baseline plan**.
+
+**Steps:**
+
+1. **Create plan in draft.** `POST /plans` with the fixture.
+   - Expect `201 Created`.
+   - Expect `key` equals the fixture key.
+   - Expect `version` is `1`.
+   - Expect `status` is `draft`.
+   - Expect `effective_from` and `effective_to` are null.
+
+   Captures:
+   - `plan` ← `response.body`
+
+2. **Get plan (draft).** `GET /plans/{plan.id}`.
+   - Expect `200 OK`.
+   - Expect `id` equals `{plan.id}`.
+   - Expect `status` is `draft`.
+   - Expect `version` is `1`.
+   - Expect `effective_from` is null.
+
+3. **List plans and find the created plan.**
+   `GET /plans?page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect response `data[]` contains an entry with `id == {plan.id}`.
+   - Note: page size 1000 because the shared DB may push fresh rows
+     past the default page-1 window of 20.
+
+4. **Update plan — rename phase and add a second rate card.**
+   `PUT /plans/{plan.id}` with an `UpsertPlanRequest` describing the
+   **full desired state** (PUT is full-replace, not delta):
+   - `name`: unchanged from the create body.
+   - `phases`: a list of one phase with:
+     - `key`: the original phase `key`.
+     - `name`: `"Phase Renamed"`.
+     - `duration`: the original `duration` (`null` for a last phase).
+     - `rate_cards`: the original rate card plus one additional rate
+       card per **Baseline flat rate card** (two total).
+
+   Assertions:
+   - Expect `200 OK`.
+   - Expect `phases[0].key` equals the original phase key (phase keys
+     are immutable).
+   - Expect `phases[0].name` is `"Phase Renamed"`.
+   - Expect `phases[0].rate_cards` has length `2`.
+   - Expect `status` still `draft`.
+
+5. **Get plan (verify update persisted).** `GET /plans/{plan.id}`.
+   - Expect `200 OK`.
+   - Expect `phases[0].name` is `"Phase Renamed"`.
+   - Expect `phases[0].rate_cards` has length `2`.
+
+6. **Publish plan.** `POST /plans/{plan.id}/publish`.
+   - Expect `200 OK`.
+   - Expect `status` is `active`.
+   - Expect `effective_from` is non-null.
+   - Expect `effective_to` is null.
+
+7. **Archive plan.** `POST /plans/{plan.id}/archive`.
+   - Expect `200 OK`.
+   - Expect `status` is `archived`.
+   - Expect `effective_to` is non-null.
+
+8. **Delete plan.** `DELETE /plans/{plan.id}`.
+   - Expect `204 No Content`.
+
+9. **Get plan after deletion.** `GET /plans/{plan.id}`.
+   - Expect `200 OK`.
+   - Expect `deleted_at` is non-null.
+   - Note: deleted plans remain retrievable; they don't 404. Compare
+     with `feature_lifecycle` where delete-then-GET returns 404 — this
+     is a per-resource server choice, pin it scenario-by-scenario.
+
+---
+
+## Example: `draft-with-errors` shape — Plan invalid-draft lifecycle
+
+This is the canonical three-moment flow (create → GET → publish).
+Use it as the template for any new draftable-entity invalid-draft
+test.
+
+```yaml
+id: plan_invalid_draft_lifecycle
+endpoints:
+  - POST /plans
+  - GET /plans/{id}
+  - POST /plans/{id}/publish
+  - PUT /plans/{id}
+entities: [plan]
+tags: [validation, draft, publish-time, canonical-three-moment]
+```
+
+**Intent:** A plan with a phase that has no rate cards is accepted at
+create (stored as draft with validation errors), surfaces its errors
+on GET, is rejected at publish with a domain code, and can be fixed
+via PUT and republished.
+
+**Fixtures:**
+- A `CreatePlanRequest` per **Baseline plan** whose single phase uses
+  **Baseline phase** with `last = true` but **overrides `rate_cards`
+  to `[]`** (the empty list is the defect under test).
+
+**Steps:**
+
+1. **Create accepts the invalid draft.** `POST /plans` with the
+   fixture.
+   - Expect `201 Created`.
+   - Note: this is a validation-moment choice — an empty-rate-card
+     phase is accepted at create, not rejected.
+
+   Captures:
+   - `plan` ← `response.body`
+
+2. **GET surfaces `validation_errors`.** `GET /plans/{plan.id}`.
+   - Expect `200 OK`.
+   - Expect `validation_errors` is non-null and non-empty.
+   - Expect `validation_errors[].code` includes domain code
+     `"plan_phase_has_no_rate_cards"`.
+
+3. **Publish is rejected with the same code.**
+   `POST /plans/{plan.id}/publish`.
+   - Expect `400 Bad Request`.
+   - Expect domain code `"plan_phase_has_no_rate_cards"`.
+
+4. **Fix by adding a rate card.** `PUT /plans/{plan.id}` with an
+   `UpsertPlanRequest` describing the full desired state:
+   - `name`: unchanged from the create body.
+   - `phases`: a list of one phase with the original `key`, `name`,
+     and `duration`, but `rate_cards` now containing one rate card
+     per **Baseline flat rate card** (the empty-rate-cards defect is
+     gone).
+
+   Assertions:
+   - Expect `200 OK`.
+
+5. **Publish succeeds after fix.** `POST /plans/{plan.id}/publish`.
+   - Expect `200 OK`.
+   - Expect `status` is `active`.
+
+**Notes:**
+
+- Three validation moments are exercised in one scenario —
+  create-time accepts, GET-time surfaces, publish-time rejects.
+  Calling out the moment per assertion keeps the generated test
+  honest.
+
+---
+
+## Example: `single-request` shape — Plan invalid currency
+
+The simplest validation scenario — one request, one rule, one
+assertion. Reach for this when a rule is pinned to create-time and
+doesn't carry draft / lifecycle semantics.
+
+```yaml
+id: plan_invalid_currency
+endpoints:
+  - POST /plans
+entities: [plan]
+tags: [validation, create-time, single-request]
+```
+
+**Intent:** A plan submitted with an unknown ISO-4217 currency is
+rejected at create-time with a structured 400 carrying the
+`currency_invalid` domain code.
+
+**Fixtures:**
+- A `CreatePlanRequest` per **Baseline plan** with `currency`
+  overridden to `"ZZZ"` (not a valid ISO-4217 code).
+
+**Steps:**
+
+1. **Create with invalid currency.** `POST /plans` with the fixture.
+   - Expect `400 Bad Request`.
+   - Expect domain code `"currency_invalid"`.
+
+**Notes:**
+
+- This is a **create-time** validation — the handler rejects the
+  request before accepting any draft. Contrast with
+  `plan_invalid_draft_lifecycle`, where defects are accepted at
+  create and only surface on GET / publish.
+
+---
+
+## Example: `matrix` shape — Plan-addon attach status matrix
+
+Use the matrix shape when a rule branches on two or more state
+variables. One Markdown table per row, plus one "Steps per row"
+block.
+
+```yaml
+id: plan_addon_attach_status_matrix
+endpoints:
+  - POST /plans/{id}/addons
+entities: [plan, addon, plan-addon]
+tags: [matrix, validation, attach, status-matrix]
+```
+
+**Intent:** Attaching an addon to a plan is only allowed when
+`plan.status ∈ {draft, scheduled}` **and** `addon.status == active`.
+All other combinations are rejected with a plain BaseAPIError whose
+`detail` carries the reason.
+
+**Fixtures (built fresh per row):**
+- A plan at the row's target `plan.status`. Create from
+  **Baseline plan**, then advance:
+  - `draft` → stop after create.
+  - `active` → create, then `POST /plans/{id}/publish`.
+  - `archived` → create, publish, then `POST /plans/{id}/archive`.
+  - (`scheduled` is not reachable — see Notes.)
+- An addon at the row's target `addon.status`. Create from
+  **Baseline addon**, then advance with the same pattern.
+- A `CreatePlanAddonRequest` per **Baseline plan-addon attach** with
+  `addon.id = {addon.id}` and
+  `from_plan_phase = {plan.phases[0].key}`.
+
+**Rows:**
+
+| # | plan.status | addon.status | Expect | Detail contains |
+|---|---|---|---|---|
+| 1 | draft | active | `201 Created` | — |
+| 2 | active | active | `400 Bad Request` | `"invalid active status, allowed statuses: [draft scheduled]"` |
+| 3 | archived | active | `400 Bad Request` | `"invalid archived status, allowed statuses: [draft scheduled]"` |
+| 4 | draft | draft | `400 Bad Request` | `"invalid draft status, allowed statuses: [active]"` |
+| 5 | draft | archived | `400 Bad Request` | `"invalid archived status, allowed statuses: [active]"` |
+
+**Steps per row:**
+
+1. **Attach.** `POST /plans/{plan.id}/addons` with the fixture body.
+   - Expect the row's `Expect` status.
+   - If 4xx, expect **detail contains** the row's `Detail contains`
+     substring — BaseAPIError shape (`problem.detail`, not
+     `extensions.validationErrors`).
+   - If 2xx, expect the response body parses as a `PlanAddon`.
+
+**Notes:**
+
+- The `scheduled` plan row is intentionally omitted: the v3 publish
+  endpoint hardcodes `effective_from = clock.Now()`, so a plan
+  cannot be driven to `scheduled` via the public API. Add the row if
+  publish takes a future `effective_from` body.
+- Status-mismatch rejections use the **detail substring** shape, not
+  **domain code**. Don't assume every domain rule surfaces through
+  `extensions.validationErrors` — here the `attach` handler wraps
+  the validator error as a BaseAPIError.
+- Row fixtures are built fresh per row — "fresh fixtures" is
+  observable behavior. "Fresh client per row" is a runner choice
+  and stays out of the spec.

--- a/.agents/skills/e2e-nl/references/format.md
+++ b/.agents/skills/e2e-nl/references/format.md
@@ -1,0 +1,340 @@
+# NL Spec Format
+
+How to write a natural-language e2e test specification — runner-neutral,
+contract-only, generator-friendly.
+
+This reference is the format contract for the `e2e-nl` skill. Worked
+examples of every shape class live in `examples.md`.
+
+---
+
+## Goal
+
+A natural-language test specification that:
+
+1. Reads like a design doc — reviewable by non-Go engineers, readable in
+   60 seconds.
+2. Is the **source of truth**: shipped tests map to it, not the other
+   way around.
+3. **Is runner-agnostic by construction.** The spec describes observable
+   HTTP behavior — verbs, paths, status codes, response-body shapes,
+   `problem+json` error shapes. Each downstream generator (Go,
+   Playwright, `.http`, Hurl, …) translates the same spec into its
+   runtime. Language-specific or framework-specific details never belong
+   in the spec.
+4. Is mechanically translatable to executable tests by an LLM or a
+   small generator.
+
+---
+
+## The runner-agnosticism rule
+
+**Central principle.** The NL spec is a test plan against an API
+contract, not against any particular runner. Each scenario describes
+wire-level behavior — HTTP request/response, `problem+json` body shape,
+JSON field assertions. Runner-specific translation is always a
+downstream concern.
+
+### Forbidden in the spec
+
+- **Runner-specific code or helper names** — no `newV3Client`, no
+  `validPlanRequest`, no `test.describe`, no `.http` variables. These
+  are transient scaffolding.
+- **Runner-specific construction mechanics** — no
+  `FromBillingPriceFlat`, no `nullable.NewNullableWithValue`, no
+  `new Request(...)`. Describe the JSON body shape; leave wire-format
+  plumbing to each generator.
+- **Runner-specific naming conventions** — no `TestV3<…>`, no
+  Playwright `test(…)` titles, no `### Section` markers for `.http`.
+  The spec commits to the `id` slug only; each generator derives its
+  own idiomatic name.
+- **Assumptions about test isolation, parallelism, cleanup, or client
+  lifecycle.** These are runner choices. "Fresh fixtures per row" is
+  observable behavior; "fresh client per row" is not.
+
+### Encouraged in the spec
+
+- **JSON-visible vocabulary.** `Expect status is active` (wire-level
+  string), not `Expect plan.Status == BillingPlanStatusActive` (Go
+  type).
+- **HTTP-native verbs and paths.** `POST /plans`, `GET /plans/{id}`.
+- **API schema type names** from TypeSpec / OpenAPI
+  (`CreatePlanRequest`, `BillingRateCard`). These appear in every
+  generator's toolchain.
+
+---
+
+## File layout
+
+One Markdown file per endpoint family — convention is
+`e2e/specs/<family>.md`, co-located with the e2e tests.
+
+```
+# E2E Scenario Specifications — <Family>
+
+<one-paragraph preamble: scope, lifecycle/no-lifecycle, family-wide
+error-shape conventions>
+
+---
+
+## Scenario list
+
+<plain bullets, one per scenario, grouped by priority>
+
+---
+
+## Baselines
+
+<named object shapes scenarios reference by name>
+
+---
+
+## Scenario: <id>
+
+<fenced YAML + Intent + Fixtures + Steps + Notes>
+
+## Scenario: <id>
+…
+```
+
+The `## Scenario: <id>` heading is the canonical drafted marker — the
+heading text is exactly the scenario's `id` slug, not a human title.
+Presence of such a section is ground truth for "this scenario is
+drafted." No checkbox, no status tracker.
+
+---
+
+## The scenario contract
+
+Every scenario **MUST** provide:
+
+- `id` (fenced YAML) — a stable snake_case slug, unique within the
+  spec file.
+- `endpoints` (fenced YAML) — a list of `METHOD /path` entries the
+  scenario exercises.
+- **Intent** — one sentence describing the behavior the scenario pins.
+- **Fixtures** — the API-level preconditions described as Baseline
+  references (or inline JSON when a Baseline isn't warranted).
+- **Steps** — numbered HTTP actions with:
+  - The verb + path + request body reference.
+  - The expected HTTP status code.
+  - Response-field assertions in JSON-visible vocabulary.
+  - For 4xx steps: the expected error shape (**domain code** /
+    **detail substring** / **schema rule**) and the code / substring
+    / rule string.
+
+Every scenario **MAY** provide:
+
+- `entities`, `tags`, `references`, `status` (fenced YAML).
+- Per-step `Captures:` blocks (see below).
+- **Notes** section covering validation-moment choices, omitted rows,
+  caveats, or `NEEDS-VERIFY` items awaiting server confirmation.
+
+Downstream generators own: test file location, language-level test
+function naming, helper / client / fixture-builder code, concurrency
+and isolation strategies, discriminated-union construction, cleanup
+mechanics. None of this belongs in the spec.
+
+---
+
+## Controlled vocabularies
+
+### Error-shape vocabulary
+
+Every expected 4xx names one of three shapes. Which shape a server uses
+is a server-side choice; pinning it in the spec keeps the generated
+test honest.
+
+| Shape | How the server returns it | Spec phrasing |
+|---|---|---|
+| **Domain code** | `extensions.validationErrors[].code` | `Expect domain code "<code>".` |
+| **Detail substring** | `problem.detail` (free text) | `Expect detail contains "<substring>".` |
+| **Schema rule** | `invalid_parameters[].rule` | `Expect schema rule "<rule>".` |
+
+### Validation-moment vocabulary
+
+Draftable entities (plans, addons, plan-addons) can fire validation at
+three moments. Spec each assertion against the moment it fires.
+
+- **create-time** — the POST itself is rejected.
+- **GET-time** — POST accepts as draft; GET returns the entity with
+  `validation_errors` populated.
+- **publish-time** — POST accepts, GET may show errors, and the
+  publish POST is rejected.
+
+Non-draftable entities (e.g. features) fire only at create-time or
+update-time. Pin the moment in the scenario's Notes if it's not
+obvious from the steps.
+
+---
+
+## Captures directive
+
+When a step's response produces state later steps need (typically a
+generated `id`), add a `Captures:` block at the end of the step. Two
+equivalent forms:
+
+```
+# Capture the whole response body as an object (preferred when later
+# steps need multiple fields):
+Captures:
+- `plan` ← `response.body`
+
+# Capture a specific field by JSON path:
+Captures:
+- `plan_id` ← `response.body.id`
+```
+
+The left side is a snake_case local name. The right side is rooted at
+one of:
+
+- `response.body` — the whole response body as an object.
+- `response.body.<json-path>` — a specific field.
+- `response.headers.<header-name>` — a response header value.
+- `response.status` — the numeric status code.
+
+Later steps reference captured values with **braces**: `{plan.id}`
+(dotted field access on an object capture) or `{plan_id}` (a flat
+capture). The braces disambiguate bound values from literal text.
+
+```
+2. **Get plan.** `GET /plans/{plan.id}`.
+```
+
+Fixture-produced values (e.g. "a plan at status `active`") are bound
+by the Fixtures section and referenced the same way — `{plan.id}`,
+`{plan.phases[0].key}`, `{addon.id}`. No explicit `Captures:` block
+is needed; Fixture block names are implicit captures.
+
+Every runner can implement this: Go assigns to a local variable,
+Playwright binds with `const`, `.http` uses `@var = {{response.body.$.id}}`,
+Hurl uses `[Captures]`. The spec stays neutral.
+
+---
+
+## Null vs. absent
+
+JSON distinguishes between `key: null` (present with null value) and
+key-missing (omitted). Pin this explicitly rather than papering over
+it:
+
+- `is null` — the key is present in the body with explicit `null`.
+- `is absent` — the key is not present in the body (server
+  `omitempty`).
+- `is null or absent` — used only when the server is genuinely
+  ambiguous; document in Notes when you reach for it.
+
+Default for optional-field positive assertions: prefer `is absent` for
+this codebase (most Go services omit-when-nil). Downstream generators
+can collapse both to a single nil check when the target language
+doesn't distinguish (e.g. Go pointer types).
+
+---
+
+## The `references:` field
+
+Optional YAML list of freeform strings pointing at generated test
+artifacts in any runner. The list form is canonical even for a single
+entry — generators see one shape regardless of runner count.
+
+```yaml
+references:
+  - e2e/plans_v3_test.go::TestV3PlanLifecycle
+  - tests/plans.spec.ts::"plan lifecycle"
+  - tests/http/plans.http#plan_lifecycle
+```
+
+Each entry is freeform — the path-and-anchor convention is whatever
+each runner finds idiomatic. Omit the field entirely when no test has
+been generated. `references:` is for traceability only, not contract;
+the `id` slug is the stable identifier.
+
+---
+
+## The `status:` field
+
+Optional YAML field that signals to downstream generators whether the
+scenario should be exercised. Omitting it is the default — the
+scenario is in scope for every generator that consumes this spec.
+
+| Value | Meaning |
+|---|---|
+| omitted (default) | Scenario is in scope. Generators emit a test. |
+| `skipped` | Scenario is **not** to be exercised. Generators MUST NOT emit a test. |
+
+`skipped` is for scenarios that describe contract behavior the
+generator can't reach today — typically because of an environmental
+gate (missing seed data, an external service the e2e stack doesn't
+provision, a feature flag off in test). The scenario stays in the
+spec so the contract is documented; the `status: skipped` directive
+suppresses generation.
+
+When marking a scenario `skipped`:
+
+- Explain the gate in the scenario body — usually a leading
+  **Status: SKIPPED.** callout under the YAML — and describe what it
+  takes to re-enable.
+- Do not delete the scenario. The contract is still part of the
+  spec; the marker just defers the test.
+
+```yaml
+id: feature_llm_pricing_enriched_on_get
+endpoints:
+  - GET /features/{id}
+status: skipped
+```
+
+The field is intentionally minimal — only `skipped` is defined.
+Generators encountering an unknown value should treat the scenario
+as in scope (default) and surface a warning rather than fail.
+
+---
+
+## Baselines
+
+Each `e2e/specs/<family>.md` defines its **own** Baselines section.
+Baselines are **not shared across files**: an addons spec and a
+features spec each own their own baselines, even if the names
+collide. Cross-file imports couple specs together and break the
+"one file per family" rule.
+
+A Baseline names an API schema type
+(`CreatePlanRequest`, `CreateFeatureRequest`, `BillingRateCard`, …)
+from TypeSpec / `api/openapi.yaml` and lists the field defaults a
+scenario can mutate. Scenarios reference baselines by name and
+describe per-scenario mutations rather than inlining JSON.
+
+Baselines earn their place when **two or more scenarios** in the same
+family use the shape. One-off shapes stay inlined in the scenario's
+Fixtures block.
+
+See `examples.md` for worked baseline definitions and how scenarios
+reference them.
+
+---
+
+## Scenario list conventions
+
+The Scenario list is a flat enumeration at the top of the file. One
+plain bullet per scenario:
+
+```
+- `<id>` — <one-line intent> — shape: <class> — priority: <p0|p1|p2>
+```
+
+- `id`: stable snake_case slug, unique in the file.
+- shape class: `lifecycle` | `draft-with-errors` | `matrix` |
+  `single-request`. (See `examples.md` for one worked example per
+  class.)
+- priority:
+  - **p0** — happy-path lifecycle or primary CRUD flow.
+  - **p1** — core validation, error-shape proofs, state-matrix rules.
+  - **p2** — edge cases, deprecated paths, rare documented errors.
+- Append `NEEDS-VERIFY: <reason>` to the line for any candidate where
+  a behavior isn't pinned by the code and needs live-server
+  confirmation.
+
+Group by priority with subheadings (`**p0 — happy path**`,
+`**p1 — core validation**`, …) when the list is long enough to scan.
+The `## Scenario: <id>` section that follows in the file is what
+actually marks a scenario as drafted; the list is just an index.

--- a/e2e/http/features/feature_archived_excluded_from_list.http
+++ b/e2e/http/features/feature_archived_excluded_from_list.http
@@ -1,0 +1,48 @@
+# feature_archived_excluded_from_list
+#
+# Source: e2e/specs/features.md ## Scenario: feature_archived_excluded_from_list
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_archived_excluded_from_list__feature_key = archived_list_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_archived_excluded_from_list__create_feature
+# @title create feature
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_archived_excluded_from_list__feature_key}}",
+  "name": "Test Feature"
+}
+
+?? status == 201
+{{
+  exports.v__feature_archived_excluded_from_list__feature_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_archived_excluded_from_list__delete_feature
+# @title delete feature
+# @ref r__feature_archived_excluded_from_list__create_feature
+DELETE {{api_base}}/openmeter/features/{{v__feature_archived_excluded_from_list__feature_id}}
+
+?? status == 204
+
+###
+# @name r__feature_archived_excluded_from_list__list_excludes_archived
+# @title list features and confirm archived feature is absent
+# @ref r__feature_archived_excluded_from_list__delete_feature
+GET {{api_base}}/openmeter/features?page[size]=1000
+
+?? status == 200
+{{
+  const { ok } = require('assert');
+  test('archived feature is not present in default list', () => {
+    const items = response.parsedBody.data || response.parsedBody.items || [];
+    ok(
+      !items.some(f => f.id === v__feature_archived_excluded_from_list__feature_id),
+      'expected list NOT to contain archived feature id ' + v__feature_archived_excluded_from_list__feature_id
+    );
+  });
+}}

--- a/e2e/http/features/feature_archived_get_returns_404.http
+++ b/e2e/http/features/feature_archived_get_returns_404.http
@@ -1,0 +1,39 @@
+# feature_archived_get_returns_404
+#
+# Source: e2e/specs/features.md ## Scenario: feature_archived_get_returns_404
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_archived_get_returns_404__feature_key = archived_get_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_archived_get_returns_404__create_feature
+# @title create feature
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_archived_get_returns_404__feature_key}}",
+  "name": "Test Feature"
+}
+
+?? status == 201
+{{
+  exports.v__feature_archived_get_returns_404__feature_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_archived_get_returns_404__delete_feature
+# @title delete feature
+# @ref r__feature_archived_get_returns_404__create_feature
+DELETE {{api_base}}/openmeter/features/{{v__feature_archived_get_returns_404__feature_id}}
+
+?? status == 204
+
+###
+# @name r__feature_archived_get_returns_404__get_archived_feature
+# @title GET archived feature returns 404 with feature-not-found detail
+# @ref r__feature_archived_get_returns_404__delete_feature
+GET {{api_base}}/openmeter/features/{{v__feature_archived_get_returns_404__feature_id}}
+
+?? status == 404
+?? js response.parsedBody.detail.includes('feature not found: {{v__feature_archived_get_returns_404__feature_id}}')

--- a/e2e/http/features/feature_cost_query_happy_path.http
+++ b/e2e/http/features/feature_cost_query_happy_path.http
@@ -1,0 +1,72 @@
+# feature_cost_query_happy_path
+#
+# Source: e2e/specs/features.md ## Scenario: feature_cost_query_happy_path
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_cost_query_happy_path__meter_key = cost_query_meter_{{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_cost_query_happy_path__feature_key = cost_query_feature_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_cost_query_happy_path__create_meter
+# @title create baseline meter
+POST {{api_base}}/openmeter/meters
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_cost_query_happy_path__meter_key}}",
+  "name": "Test Meter",
+  "event_type": "e2e_feature_test",
+  "aggregation": "count"
+}
+
+?? status == 201
+{{
+  exports.v__feature_cost_query_happy_path__meter_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_cost_query_happy_path__create_feature
+# @title create metered feature with manual unit cost
+# @ref r__feature_cost_query_happy_path__create_meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_cost_query_happy_path__feature_key}}",
+  "name": "Test Feature",
+  "meter": { "id": "{{v__feature_cost_query_happy_path__meter_id}}" },
+  "unit_cost": { "type": "manual", "amount": "5" }
+}
+
+?? status == 201
+{{
+  exports.v__feature_cost_query_happy_path__feature_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_cost_query_happy_path__cost_query_empty_body
+# @title POST cost/query with empty body returns default-window zero-usage row
+# @ref r__feature_cost_query_happy_path__create_feature
+POST {{api_base}}/openmeter/features/{{v__feature_cost_query_happy_path__feature_id}}/cost/query
+Content-Type: application/json
+
+{}
+
+?? status == 200
+{{
+  const { ok, strictEqual } = require('assert');
+  test('data[] is non-empty and the first row has zero-usage shape', () => {
+    const data = response.parsedBody.data || [];
+    ok(data.length >= 1, 'expected data[] to be non-empty, got ' + JSON.stringify(data));
+    const row = data[0];
+    // cost is "0" with manual unit_cost (usage * amount = 0 * 5 = 0).
+    // The spec allows null for unresolved-pricing rows; pin "0" since
+    // manual unit cost always resolves. Adjust if a future deployment
+    // emits null for zero-usage manual rows.
+    strictEqual(row.cost, '0', 'cost should be "0" for zero-usage manual unit_cost, got ' + JSON.stringify(row.cost));
+    strictEqual(row.usage, '0', 'usage should be "0" for zero usage, got ' + JSON.stringify(row.usage));
+    strictEqual(row.currency, 'USD', 'currency should be "USD", got ' + JSON.stringify(row.currency));
+    strictEqual(row.from, '1970-01-01T00:00:00Z', 'default from should be epoch, got ' + JSON.stringify(row.from));
+    strictEqual(row.to, '1970-01-01T00:01:00Z', 'default to should be epoch+60s, got ' + JSON.stringify(row.to));
+  });
+}}

--- a/e2e/http/features/feature_cost_query_no_meter_rejected.http
+++ b/e2e/http/features/feature_cost_query_no_meter_rejected.http
@@ -1,0 +1,34 @@
+# feature_cost_query_no_meter_rejected
+#
+# Source: e2e/specs/features.md ## Scenario: feature_cost_query_no_meter_rejected
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_cost_query_no_meter_rejected__feature_key = cost_query_no_meter_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_cost_query_no_meter_rejected__create_static_feature
+# @title create feature with no meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_cost_query_no_meter_rejected__feature_key}}",
+  "name": "Test Feature"
+}
+
+?? status == 201
+{{
+  exports.v__feature_cost_query_no_meter_rejected__feature_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_cost_query_no_meter_rejected__cost_query_unmetered_feature
+# @title POST cost/query on unmetered feature returns 400
+# @ref r__feature_cost_query_no_meter_rejected__create_static_feature
+POST {{api_base}}/openmeter/features/{{v__feature_cost_query_no_meter_rejected__feature_id}}/cost/query
+Content-Type: application/json
+
+{}
+
+?? status == 400
+?? js response.parsedBody.detail.includes('feature {{d__feature_cost_query_no_meter_rejected__feature_key}} has no meter associated')

--- a/e2e/http/features/feature_cost_query_nonexistent_feature_returns_404.http
+++ b/e2e/http/features/feature_cost_query_nonexistent_feature_returns_404.http
@@ -1,0 +1,17 @@
+# feature_cost_query_nonexistent_feature_returns_404
+#
+# Source: e2e/specs/features.md ## Scenario: feature_cost_query_nonexistent_feature_returns_404
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_cost_query_nonexistent_feature_returns_404__missing_id = 01HXYZABCDEFGHJKMNPQRSTV04
+
+###
+# @name r__feature_cost_query_nonexistent_feature_returns_404__cost_query_unknown_id
+# @title POST /features/<random-ULID-not-in-DB>/cost/query returns 404
+POST {{api_base}}/openmeter/features/{{d__feature_cost_query_nonexistent_feature_returns_404__missing_id}}/cost/query
+Content-Type: application/json
+
+{}
+
+?? status == 404
+?? js response.parsedBody.detail.includes('feature not found: {{d__feature_cost_query_nonexistent_feature_returns_404__missing_id}}')

--- a/e2e/http/features/feature_create_duplicate_key_rejected.http
+++ b/e2e/http/features/feature_create_duplicate_key_rejected.http
@@ -1,0 +1,54 @@
+# feature_create_duplicate_key_rejected
+#
+# Source: e2e/specs/features.md ## Scenario: feature_create_duplicate_key_rejected
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_create_duplicate_key_rejected__feature_key = duplicate_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_create_duplicate_key_rejected__create_feature
+# @title create feature with unique key
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_create_duplicate_key_rejected__feature_key}}",
+  "name": "Test Feature"
+}
+
+?? status == 201
+{{
+  // Captured here so the next step's ?? js assertion can reference the
+  // key as a real JS identifier — {{d__...}} substitution does not
+  // resolve inside ?? js (data vars are body/header-scoped only).
+  exports.v__feature_create_duplicate_key_rejected__captured_key = response.parsedBody.key;
+}}
+
+###
+# @name r__feature_create_duplicate_key_rejected__create_again_same_key
+# @title create again with same key returns 409
+# @ref r__feature_create_duplicate_key_rejected__create_feature
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_create_duplicate_key_rejected__feature_key}}",
+  "name": "Test Feature Duplicate"
+}
+
+?? status == 409
+{{
+  // ?? js with JS-side string concatenation throws SyntaxError on
+  // httpyac 6.16.7 (verified 2026-04-28). test() block is the
+  // documented fallback for assertions the ?? DSL can't express
+  // cleanly — see references/format.md, "Capture pattern".
+  const { ok } = require('assert');
+  test('detail mentions the duplicate key', () => {
+    const detail = response.parsedBody.detail || '';
+    const key = v__feature_create_duplicate_key_rejected__captured_key;
+    ok(
+      detail.includes('with key ' + key + ' already exists'),
+      'expected detail to contain "with key <key> already exists", got: ' + detail
+    );
+  });
+}}

--- a/e2e/http/features/feature_create_invalid_meter_aggregation_rejected.http
+++ b/e2e/http/features/feature_create_invalid_meter_aggregation_rejected.http
@@ -1,0 +1,42 @@
+# feature_create_invalid_meter_aggregation_rejected
+#
+# Source: e2e/specs/features.md ## Scenario: feature_create_invalid_meter_aggregation_rejected
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_create_invalid_meter_aggregation_rejected__meter_key = avg_meter_{{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_create_invalid_meter_aggregation_rejected__feature_key = avg_feature_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_create_invalid_meter_aggregation_rejected__create_avg_meter
+# @title create meter with avg aggregation
+POST {{api_base}}/openmeter/meters
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_create_invalid_meter_aggregation_rejected__meter_key}}",
+  "name": "Test Meter",
+  "event_type": "e2e_feature_test",
+  "aggregation": "avg",
+  "value_property": "$.value"
+}
+
+?? status == 201
+{{
+  exports.v__feature_create_invalid_meter_aggregation_rejected__meter_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_create_invalid_meter_aggregation_rejected__create_feature_against_avg_meter
+# @title POST /features against avg meter returns 400
+# @ref r__feature_create_invalid_meter_aggregation_rejected__create_avg_meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_create_invalid_meter_aggregation_rejected__feature_key}}",
+  "name": "Test Feature",
+  "meter": { "id": "{{v__feature_create_invalid_meter_aggregation_rejected__meter_id}}" }
+}
+
+?? status == 400
+?? js response.parsedBody.detail.includes('features can only be created for')

--- a/e2e/http/features/feature_create_invalid_meter_filter_key_rejected.http
+++ b/e2e/http/features/feature_create_invalid_meter_filter_key_rejected.http
@@ -1,0 +1,45 @@
+# feature_create_invalid_meter_filter_key_rejected
+#
+# Source: e2e/specs/features.md ## Scenario: feature_create_invalid_meter_filter_key_rejected
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_create_invalid_meter_filter_key_rejected__meter_key = filter_meter_{{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_create_invalid_meter_filter_key_rejected__feature_key = filter_feature_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_create_invalid_meter_filter_key_rejected__create_meter_with_region_dim
+# @title create meter with single region dimension
+POST {{api_base}}/openmeter/meters
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_create_invalid_meter_filter_key_rejected__meter_key}}",
+  "name": "Test Meter",
+  "event_type": "e2e_feature_test",
+  "aggregation": "count",
+  "dimensions": { "region": "$.region" }
+}
+
+?? status == 201
+{{
+  exports.v__feature_create_invalid_meter_filter_key_rejected__meter_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_create_invalid_meter_filter_key_rejected__create_feature_with_bad_filter_key
+# @title POST /features with meter.filters.unknown_key returns 400
+# @ref r__feature_create_invalid_meter_filter_key_rejected__create_meter_with_region_dim
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_create_invalid_meter_filter_key_rejected__feature_key}}",
+  "name": "Test Feature",
+  "meter": {
+    "id": "{{v__feature_create_invalid_meter_filter_key_rejected__meter_id}}",
+    "filters": { "unknown_key": { "eq": "x" } }
+  }
+}
+
+?? status == 400
+?? js response.parsedBody.detail.includes('filter key "unknown_key" is not a valid dimension of meter')

--- a/e2e/http/features/feature_create_key_must_not_be_ulid.http
+++ b/e2e/http/features/feature_create_key_must_not_be_ulid.http
@@ -1,0 +1,20 @@
+# feature_create_key_must_not_be_ulid
+#
+# Source: e2e/specs/features.md ## Scenario: feature_create_key_must_not_be_ulid
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_create_key_must_not_be_ulid__ulid_key = 01HXYZABCDEFGHJKMNPQRSTVWX
+
+###
+# @name r__feature_create_key_must_not_be_ulid__create_with_ulid_key
+# @title POST /features with a ULID-shaped key returns 400
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_create_key_must_not_be_ulid__ulid_key}}",
+  "name": "Test Feature"
+}
+
+?? status == 400
+?? js response.parsedBody.detail.includes('Feature key cannot be a valid ULID')

--- a/e2e/http/features/feature_create_llm_property_not_in_meter_rejected.http
+++ b/e2e/http/features/feature_create_llm_property_not_in_meter_rejected.http
@@ -1,0 +1,51 @@
+# feature_create_llm_property_not_in_meter_rejected
+#
+# Source: e2e/specs/features.md ## Scenario: feature_create_llm_property_not_in_meter_rejected
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_create_llm_property_not_in_meter_rejected__meter_key = llm_prop_meter_{{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_create_llm_property_not_in_meter_rejected__feature_key = llm_prop_feature_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_create_llm_property_not_in_meter_rejected__create_meter_without_token_type
+# @title create meter with provider + model dimensions only
+POST {{api_base}}/openmeter/meters
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_create_llm_property_not_in_meter_rejected__meter_key}}",
+  "name": "Test LLM Meter",
+  "event_type": "e2e_llm_test",
+  "aggregation": "count",
+  "dimensions": {
+    "provider": "$.provider",
+    "model": "$.model"
+  }
+}
+
+?? status == 201
+{{
+  exports.v__feature_create_llm_property_not_in_meter_rejected__meter_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_create_llm_property_not_in_meter_rejected__create_feature_referencing_missing_property
+# @title POST /features with token_type_property absent from meter returns 400
+# @ref r__feature_create_llm_property_not_in_meter_rejected__create_meter_without_token_type
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_create_llm_property_not_in_meter_rejected__feature_key}}",
+  "name": "Test Feature",
+  "meter": { "id": "{{v__feature_create_llm_property_not_in_meter_rejected__meter_id}}" },
+  "unit_cost": {
+    "type": "llm",
+    "provider_property": "provider",
+    "model_property": "model",
+    "token_type_property": "token_type"
+  }
+}
+
+?? status == 400
+?? js response.parsedBody.detail.includes('token_type_property "token_type" not found in meter group-by keys')

--- a/e2e/http/features/feature_create_llm_unit_cost_without_meter_rejected.http
+++ b/e2e/http/features/feature_create_llm_unit_cost_without_meter_rejected.http
@@ -1,0 +1,26 @@
+# feature_create_llm_unit_cost_without_meter_rejected
+#
+# Source: e2e/specs/features.md ## Scenario: feature_create_llm_unit_cost_without_meter_rejected
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_create_llm_unit_cost_without_meter_rejected__feature_key = llm_no_meter_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_create_llm_unit_cost_without_meter_rejected__create_llm_without_meter
+# @title POST /features with LLM unit_cost and no meter returns 400
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_create_llm_unit_cost_without_meter_rejected__feature_key}}",
+  "name": "Test Feature",
+  "unit_cost": {
+    "type": "llm",
+    "provider": "openai",
+    "model": "gpt-4",
+    "token_type": "input"
+  }
+}
+
+?? status == 400
+?? js response.parsedBody.detail.includes('LLM unit cost requires a meter to be associated with the feature')

--- a/e2e/http/features/feature_create_meter_not_found_rejected.http
+++ b/e2e/http/features/feature_create_meter_not_found_rejected.http
@@ -1,0 +1,22 @@
+# feature_create_meter_not_found_rejected
+#
+# Source: e2e/specs/features.md ## Scenario: feature_create_meter_not_found_rejected
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_create_meter_not_found_rejected__feature_key = meter_not_found_{{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_create_meter_not_found_rejected__missing_meter_id = 01HXYZABCDEFGHJKMNPQRSTV05
+
+###
+# @name r__feature_create_meter_not_found_rejected__create_with_missing_meter
+# @title POST /features with non-existent meter id returns 404
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_create_meter_not_found_rejected__feature_key}}",
+  "name": "Test Feature",
+  "meter": { "id": "{{d__feature_create_meter_not_found_rejected__missing_meter_id}}" }
+}
+
+?? status == 404
+?? js response.parsedBody.detail.includes('meter not found: {{d__feature_create_meter_not_found_rejected__missing_meter_id}}')

--- a/e2e/http/features/feature_create_unit_cost_validation_matrix.http
+++ b/e2e/http/features/feature_create_unit_cost_validation_matrix.http
@@ -1,0 +1,253 @@
+# feature_create_unit_cost_validation_matrix
+#
+# Source: e2e/specs/features.md ## Scenario: feature_create_unit_cost_validation_matrix
+#
+# Rows 2 and 4-10 reuse a single shared LLM-capable meter created at
+# the top of the file. The meter is read-only across rows, so sharing
+# is safe. Rows 1 and 3 don't need a meter.
+#
+# Pinned 2026-04-28 against an OpenMeter deployment running behind an
+# OpenAPI binder gateway:
+#   - Rows 3-9: handler rejections; detail-equality on the framework's
+#     `"validation error: <bare msg>"` wrapper.
+#   - Row 10: binder-layer rejection; schema-rule shape with rule
+#     `"allOf"`. Re-pin (revert to detail-substring carrying
+#     `"invalid token_type"`) if the deployment ever runs the handler
+#     directly with no schema validator in front.
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_create_unit_cost_validation_matrix__suffix = {{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_create_unit_cost_validation_matrix__meter_key = matrix_meter_{{d__feature_create_unit_cost_validation_matrix__suffix}}
+
+###
+# @name r__feature_create_unit_cost_validation_matrix__create_shared_meter
+# @title create shared LLM-capable meter (used by rows 2, 4-10)
+POST {{api_base}}/openmeter/meters
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_create_unit_cost_validation_matrix__meter_key}}",
+  "name": "Test LLM Meter",
+  "event_type": "e2e_llm_test",
+  "aggregation": "count",
+  "dimensions": {
+    "provider": "$.provider",
+    "model": "$.model",
+    "token_type": "$.token_type"
+  }
+}
+
+?? status == 201
+{{
+  exports.v__feature_create_unit_cost_validation_matrix__meter_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_create_unit_cost_validation_matrix__row1_manual_baseline_succeeds
+# @title row 1: manual baseline (amount=5, no meter) -> 201
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r1_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "unit_cost": { "type": "manual", "amount": "5" }
+}
+
+?? status == 201
+
+###
+# @name r__feature_create_unit_cost_validation_matrix__row2_llm_baseline_succeeds
+# @title row 2: LLM baseline with shared meter -> 201
+# @ref r__feature_create_unit_cost_validation_matrix__create_shared_meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r2_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "meter": { "id": "{{v__feature_create_unit_cost_validation_matrix__meter_id}}" },
+  "unit_cost": {
+    "type": "llm",
+    "provider": "openai",
+    "model": "gpt-4",
+    "token_type": "input"
+  }
+}
+
+?? status == 201
+
+###
+# @name r__feature_create_unit_cost_validation_matrix__row3_negative_amount_rejected
+# @title row 3: manual amount=-1 -> 400 (non-negative rule)
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r3_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "unit_cost": { "type": "manual", "amount": "-1" }
+}
+
+?? status == 400
+?? js response.parsedBody.detail == validation error: manual unit cost amount must be non-negative
+
+###
+# @name r__feature_create_unit_cost_validation_matrix__row4_provider_and_provider_property_mutex
+# @title row 4: LLM with provider AND provider_property -> 400 (mutex)
+# @ref r__feature_create_unit_cost_validation_matrix__create_shared_meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r4_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "meter": { "id": "{{v__feature_create_unit_cost_validation_matrix__meter_id}}" },
+  "unit_cost": {
+    "type": "llm",
+    "provider": "openai",
+    "provider_property": "provider",
+    "model": "gpt-4",
+    "token_type": "input"
+  }
+}
+
+?? status == 400
+?? js response.parsedBody.detail == validation error: provider_property and provider are mutually exclusive
+
+###
+# @name r__feature_create_unit_cost_validation_matrix__row5_model_and_model_property_mutex
+# @title row 5: LLM with model AND model_property -> 400 (mutex)
+# @ref r__feature_create_unit_cost_validation_matrix__create_shared_meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r5_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "meter": { "id": "{{v__feature_create_unit_cost_validation_matrix__meter_id}}" },
+  "unit_cost": {
+    "type": "llm",
+    "provider": "openai",
+    "model": "gpt-4",
+    "model_property": "model",
+    "token_type": "input"
+  }
+}
+
+?? status == 400
+?? js response.parsedBody.detail == validation error: model_property and model are mutually exclusive
+
+###
+# @name r__feature_create_unit_cost_validation_matrix__row6_token_type_and_token_type_property_mutex
+# @title row 6: LLM with token_type AND token_type_property -> 400 (mutex)
+# @ref r__feature_create_unit_cost_validation_matrix__create_shared_meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r6_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "meter": { "id": "{{v__feature_create_unit_cost_validation_matrix__meter_id}}" },
+  "unit_cost": {
+    "type": "llm",
+    "provider": "openai",
+    "model": "gpt-4",
+    "token_type": "input",
+    "token_type_property": "token_type"
+  }
+}
+
+?? status == 400
+?? js response.parsedBody.detail == validation error: token_type_property and token_type are mutually exclusive
+
+###
+# @name r__feature_create_unit_cost_validation_matrix__row7_provider_required
+# @title row 7: LLM with no provider and no provider_property -> 400 (required)
+# @ref r__feature_create_unit_cost_validation_matrix__create_shared_meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r7_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "meter": { "id": "{{v__feature_create_unit_cost_validation_matrix__meter_id}}" },
+  "unit_cost": {
+    "type": "llm",
+    "model": "gpt-4",
+    "token_type": "input"
+  }
+}
+
+?? status == 400
+?? js response.parsedBody.detail == validation error: either provider_property or provider is required for LLM unit cost
+
+###
+# @name r__feature_create_unit_cost_validation_matrix__row8_model_required
+# @title row 8: LLM with no model and no model_property -> 400 (required)
+# @ref r__feature_create_unit_cost_validation_matrix__create_shared_meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r8_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "meter": { "id": "{{v__feature_create_unit_cost_validation_matrix__meter_id}}" },
+  "unit_cost": {
+    "type": "llm",
+    "provider": "openai",
+    "token_type": "input"
+  }
+}
+
+?? status == 400
+?? js response.parsedBody.detail == validation error: either model_property or model is required for LLM unit cost
+
+###
+# @name r__feature_create_unit_cost_validation_matrix__row9_token_type_required
+# @title row 9: LLM with no token_type and no token_type_property -> 400 (required)
+# @ref r__feature_create_unit_cost_validation_matrix__create_shared_meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r9_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "meter": { "id": "{{v__feature_create_unit_cost_validation_matrix__meter_id}}" },
+  "unit_cost": {
+    "type": "llm",
+    "provider": "openai",
+    "model": "gpt-4"
+  }
+}
+
+?? status == 400
+?? js response.parsedBody.detail == validation error: either token_type_property or token_type is required for LLM unit cost
+
+###
+# @name r__feature_create_unit_cost_validation_matrix__row10_invalid_token_type_rejected
+# @title row 10: LLM with token_type="banana" -> 400 (binder allOf rejection)
+# @ref r__feature_create_unit_cost_validation_matrix__create_shared_meter
+#
+# The OpenAPI binder validates the enum on token_type before the
+# request reaches the handler; the handler's "invalid token_type"
+# message is unreachable in deployments with a binder gateway in
+# front. Schema-rule shape.
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "matrix_r10_{{$timestamp}}_{{$randomInt 0 1000000}}",
+  "name": "matrix",
+  "meter": { "id": "{{v__feature_create_unit_cost_validation_matrix__meter_id}}" },
+  "unit_cost": {
+    "type": "llm",
+    "provider": "openai",
+    "model": "gpt-4",
+    "token_type": "banana"
+  }
+}
+
+?? status == 400
+?? js response.parsedBody.invalid_parameters[0].field == unit_cost
+?? js response.parsedBody.invalid_parameters[0].rule == allOf

--- a/e2e/http/features/feature_delete_nonexistent_returns_404.http
+++ b/e2e/http/features/feature_delete_nonexistent_returns_404.http
@@ -1,0 +1,14 @@
+# feature_delete_nonexistent_returns_404
+#
+# Source: e2e/specs/features.md ## Scenario: feature_delete_nonexistent_returns_404
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_delete_nonexistent_returns_404__missing_id = 01HXYZABCDEFGHJKMNPQRSTV02
+
+###
+# @name r__feature_delete_nonexistent_returns_404__delete_unknown_id
+# @title DELETE /features/<random-ULID-not-in-DB> returns 404
+DELETE {{api_base}}/openmeter/features/{{d__feature_delete_nonexistent_returns_404__missing_id}}
+
+?? status == 404
+?? js response.parsedBody.detail.includes('feature not found: {{d__feature_delete_nonexistent_returns_404__missing_id}}')

--- a/e2e/http/features/feature_get_by_key_resolves.http
+++ b/e2e/http/features/feature_get_by_key_resolves.http
@@ -1,0 +1,42 @@
+# feature_get_by_key_resolves
+#
+# Source: e2e/specs/features.md ## Scenario: feature_get_by_key_resolves
+#
+# STATUS: SKIPPED — Deployment-gated. Verified 2026-04-28: a Kong
+# gateway in front of OpenMeter rejects GET /features/<bare-key>
+# with its own 404 ("The requested entity was not found") because
+# the route pattern requires a ULID-shaped {featureId}. The
+# handler's by-id-or-key dispatch is unreachable in that topology.
+# Re-enable by removing the @disabled lines once running against a
+# deployment that forwards arbitrary path segments to the handler.
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_get_by_key_resolves__feature_key = lookup_by_key_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @disabled
+# @name r__feature_get_by_key_resolves__create_feature
+# @title create feature
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_get_by_key_resolves__feature_key}}",
+  "name": "Test Feature"
+}
+
+?? status == 201
+{{
+  exports.v__feature_get_by_key_resolves__feature_id = response.parsedBody.id;
+}}
+
+###
+# @disabled
+# @name r__feature_get_by_key_resolves__get_by_key
+# @title GET /features/{key} resolves to the same feature
+# @ref r__feature_get_by_key_resolves__create_feature
+GET {{api_base}}/openmeter/features/{{d__feature_get_by_key_resolves__feature_key}}
+
+?? status == 200
+?? js response.parsedBody.id == {{v__feature_get_by_key_resolves__feature_id}}
+?? js response.parsedBody.key == {{d__feature_get_by_key_resolves__feature_key}}

--- a/e2e/http/features/feature_get_nonexistent_returns_404.http
+++ b/e2e/http/features/feature_get_nonexistent_returns_404.http
@@ -1,0 +1,14 @@
+# feature_get_nonexistent_returns_404
+#
+# Source: e2e/specs/features.md ## Scenario: feature_get_nonexistent_returns_404
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_get_nonexistent_returns_404__missing_id = 01HXYZABCDEFGHJKMNPQRSTV01
+
+###
+# @name r__feature_get_nonexistent_returns_404__get_unknown_id
+# @title GET /features/<random-ULID-not-in-DB> returns 404
+GET {{api_base}}/openmeter/features/{{d__feature_get_nonexistent_returns_404__missing_id}}
+
+?? status == 404
+?? js response.parsedBody.detail.includes('feature not found: {{d__feature_get_nonexistent_returns_404__missing_id}}')

--- a/e2e/http/features/feature_lifecycle.http
+++ b/e2e/http/features/feature_lifecycle.http
@@ -1,0 +1,126 @@
+# feature_lifecycle
+#
+# Source: e2e/specs/features.md ## Scenario: feature_lifecycle
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_lifecycle__feature_key = lifecycle_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_lifecycle__create_feature
+# @title create feature
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_lifecycle__feature_key}}",
+  "name": "Test Feature"
+}
+
+?? status == 201
+?? js response.parsedBody.key == {{d__feature_lifecycle__feature_key}}
+?? js response.parsedBody.name == Test Feature
+?? js typeof response.parsedBody.meter == undefined
+?? js typeof response.parsedBody.unit_cost == undefined
+?? js typeof response.parsedBody.deleted_at == undefined
+{{
+  exports.v__feature_lifecycle__feature_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_lifecycle__get_feature
+# @title get feature by id
+# @ref r__feature_lifecycle__create_feature
+GET {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+
+?? status == 200
+?? js response.parsedBody.id == {{v__feature_lifecycle__feature_id}}
+?? js response.parsedBody.key == {{d__feature_lifecycle__feature_key}}
+?? js response.parsedBody.name == Test Feature
+
+###
+# @name r__feature_lifecycle__list_features_find_created
+# @title list features and find the created feature
+# @ref r__feature_lifecycle__create_feature
+GET {{api_base}}/openmeter/features?page[size]=1000
+
+?? status == 200
+{{
+  const { ok } = require('assert');
+  test('created feature is present in list', () => {
+    const items = response.parsedBody.data || response.parsedBody.items || [];
+    ok(
+      items.some(f => f.id === v__feature_lifecycle__feature_id),
+      'expected list to contain feature id ' + v__feature_lifecycle__feature_id
+    );
+  });
+}}
+
+###
+# @name r__feature_lifecycle__patch_set_unit_cost
+# @title patch feature - set manual unit_cost
+# @ref r__feature_lifecycle__create_feature
+PATCH {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+Content-Type: application/json
+
+{ "unit_cost": { "type": "manual", "amount": "5" } }
+
+?? status == 200
+?? js response.parsedBody.unit_cost.type == manual
+{{
+  const { strictEqual } = require('assert');
+  test('unit_cost.amount is normalized to "5"', () => {
+    // Server trims trailing zeros: "5.00" round-trips as "5".
+    strictEqual(
+      response.parsedBody.unit_cost.amount, '5',
+      'expected unit_cost.amount === "5", got ' + JSON.stringify(response.parsedBody.unit_cost.amount)
+    );
+  });
+}}
+
+###
+# @name r__feature_lifecycle__get_after_set
+# @title get feature - verify unit_cost persisted
+# @ref r__feature_lifecycle__patch_set_unit_cost
+GET {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+
+?? status == 200
+?? js response.parsedBody.unit_cost.type == manual
+?? js response.parsedBody.unit_cost.amount == 5
+
+###
+# @name r__feature_lifecycle__patch_clear_unit_cost
+# @title patch feature - clear unit_cost
+# @ref r__feature_lifecycle__create_feature
+PATCH {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+Content-Type: application/json
+
+{ "unit_cost": null }
+
+?? status == 200
+?? js typeof response.parsedBody.unit_cost == undefined
+
+###
+# @name r__feature_lifecycle__get_after_clear
+# @title get feature - verify unit_cost cleared
+# @ref r__feature_lifecycle__patch_clear_unit_cost
+GET {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+
+?? status == 200
+?? js typeof response.parsedBody.unit_cost == undefined
+
+###
+# @name r__feature_lifecycle__delete_feature
+# @title delete feature
+# @ref r__feature_lifecycle__create_feature
+DELETE {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+
+?? status == 204
+
+###
+# @name r__feature_lifecycle__get_after_delete
+# @title get feature after delete returns 404
+# @ref r__feature_lifecycle__delete_feature
+GET {{api_base}}/openmeter/features/{{v__feature_lifecycle__feature_id}}
+
+?? status == 404
+?? js response.parsedBody.detail.includes('feature not found: {{v__feature_lifecycle__feature_id}}')

--- a/e2e/http/features/feature_list_combined_filters.http
+++ b/e2e/http/features/feature_list_combined_filters.http
@@ -1,0 +1,214 @@
+# feature_list_combined_filters
+#
+# Source: e2e/specs/features.md ## Scenario: feature_list_combined_filters
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_list_combined_filters__suffix = {{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_list_combined_filters__meter_a_key = combined_meter_a_{{d__feature_list_combined_filters__suffix}}
+@d__feature_list_combined_filters__meter_b_key = combined_meter_b_{{d__feature_list_combined_filters__suffix}}
+@d__feature_list_combined_filters__feature_a1_key = alpha_a1_{{d__feature_list_combined_filters__suffix}}
+@d__feature_list_combined_filters__feature_a2_key = beta_a2_{{d__feature_list_combined_filters__suffix}}
+@d__feature_list_combined_filters__feature_b1_key = alpha_b1_{{d__feature_list_combined_filters__suffix}}
+@d__feature_list_combined_filters__feature_b2_key = beta_b2_{{d__feature_list_combined_filters__suffix}}
+
+###
+# @name r__feature_list_combined_filters__create_meter_a
+# @title create meter A
+POST {{api_base}}/openmeter/meters
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_combined_filters__meter_a_key}}",
+  "name": "Test Meter A",
+  "event_type": "e2e_feature_test",
+  "aggregation": "count"
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_combined_filters__meter_a_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_combined_filters__create_meter_b
+# @title create meter B
+POST {{api_base}}/openmeter/meters
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_combined_filters__meter_b_key}}",
+  "name": "Test Meter B",
+  "event_type": "e2e_feature_test",
+  "aggregation": "count"
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_combined_filters__meter_b_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_combined_filters__create_feature_a1
+# @title create feature_a1 on meter A
+# @ref r__feature_list_combined_filters__create_meter_a
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_combined_filters__feature_a1_key}}",
+  "name": "Test Feature",
+  "meter": { "id": "{{v__feature_list_combined_filters__meter_a_id}}" }
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_combined_filters__feature_a1_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_combined_filters__create_feature_a2
+# @title create feature_a2 on meter A
+# @ref r__feature_list_combined_filters__create_meter_a
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_combined_filters__feature_a2_key}}",
+  "name": "Test Feature",
+  "meter": { "id": "{{v__feature_list_combined_filters__meter_a_id}}" }
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_combined_filters__feature_a2_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_combined_filters__create_feature_b1
+# @title create feature_b1 on meter B
+# @ref r__feature_list_combined_filters__create_meter_b
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_combined_filters__feature_b1_key}}",
+  "name": "Test Feature",
+  "meter": { "id": "{{v__feature_list_combined_filters__meter_b_id}}" }
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_combined_filters__feature_b1_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_combined_filters__create_feature_b2
+# @title create feature_b2 on meter B
+# @ref r__feature_list_combined_filters__create_meter_b
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_combined_filters__feature_b2_key}}",
+  "name": "Test Feature",
+  "meter": { "id": "{{v__feature_list_combined_filters__meter_b_id}}" }
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_combined_filters__feature_b2_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_combined_filters__row1_filter_meter_a_only
+# @title row 1: filter[meter_id]=A returns a1 and a2 only
+# @ref r__feature_list_combined_filters__create_feature_a1
+# @ref r__feature_list_combined_filters__create_feature_a2
+# @ref r__feature_list_combined_filters__create_feature_b1
+# @ref r__feature_list_combined_filters__create_feature_b2
+GET {{api_base}}/openmeter/features?filter[meter_id][eq]={{v__feature_list_combined_filters__meter_a_id}}&page[size]=1000
+
+?? status == 200
+{{
+  const { ok } = require('assert');
+  test('row 1: a1 and a2 present, b1 and b2 absent', () => {
+    const items = response.parsedBody.data || response.parsedBody.items || [];
+    ok(
+      items.some(f => f.id === v__feature_list_combined_filters__feature_a1_id),
+      'expected a1 to be present'
+    );
+    ok(
+      items.some(f => f.id === v__feature_list_combined_filters__feature_a2_id),
+      'expected a2 to be present'
+    );
+    ok(
+      !items.some(f => f.id === v__feature_list_combined_filters__feature_b1_id),
+      'expected b1 to be absent'
+    );
+    ok(
+      !items.some(f => f.id === v__feature_list_combined_filters__feature_b2_id),
+      'expected b2 to be absent'
+    );
+  });
+}}
+
+###
+# @name r__feature_list_combined_filters__row2_filter_key_a1_only
+# @title row 2: filter[key]=a1.key returns a1 only
+# @ref r__feature_list_combined_filters__create_feature_a1
+# @ref r__feature_list_combined_filters__create_feature_a2
+# @ref r__feature_list_combined_filters__create_feature_b1
+# @ref r__feature_list_combined_filters__create_feature_b2
+GET {{api_base}}/openmeter/features?filter[key][eq]={{d__feature_list_combined_filters__feature_a1_key}}&page[size]=1000
+
+?? status == 200
+{{
+  const { ok } = require('assert');
+  test('row 2: a1 present, others absent', () => {
+    const items = response.parsedBody.data || response.parsedBody.items || [];
+    ok(
+      items.some(f => f.id === v__feature_list_combined_filters__feature_a1_id),
+      'expected a1 to be present'
+    );
+    ok(
+      !items.some(f => f.id === v__feature_list_combined_filters__feature_a2_id),
+      'expected a2 to be absent'
+    );
+    ok(
+      !items.some(f => f.id === v__feature_list_combined_filters__feature_b1_id),
+      'expected b1 to be absent'
+    );
+    ok(
+      !items.some(f => f.id === v__feature_list_combined_filters__feature_b2_id),
+      'expected b2 to be absent'
+    );
+  });
+}}
+
+###
+# @name r__feature_list_combined_filters__row3_meter_a_and_key_b1_intersection_empty
+# @title row 3: filter[meter_id]=A AND filter[key]=b1.key returns empty intersection
+# @ref r__feature_list_combined_filters__create_feature_a1
+# @ref r__feature_list_combined_filters__create_feature_a2
+# @ref r__feature_list_combined_filters__create_feature_b1
+# @ref r__feature_list_combined_filters__create_feature_b2
+GET {{api_base}}/openmeter/features?filter[meter_id][eq]={{v__feature_list_combined_filters__meter_a_id}}&filter[key][eq]={{d__feature_list_combined_filters__feature_b1_key}}&page[size]=1000
+
+?? status == 200
+{{
+  const { ok } = require('assert');
+  test('row 3: intersection of meter A and b1 key is empty', () => {
+    const items = response.parsedBody.data || response.parsedBody.items || [];
+    const fixtureIds = new Set([
+      v__feature_list_combined_filters__feature_a1_id,
+      v__feature_list_combined_filters__feature_a2_id,
+      v__feature_list_combined_filters__feature_b1_id,
+      v__feature_list_combined_filters__feature_b2_id,
+    ]);
+    const matchingFixtures = items.filter(f => fixtureIds.has(f.id));
+    ok(
+      matchingFixtures.length === 0,
+      'expected no fixture entries in intersection result, got ' + JSON.stringify(matchingFixtures.map(f => f.id))
+    );
+  });
+}}

--- a/e2e/http/features/feature_list_filter_by_key.http
+++ b/e2e/http/features/feature_list_filter_by_key.http
@@ -1,0 +1,63 @@
+# feature_list_filter_by_key
+#
+# Source: e2e/specs/features.md ## Scenario: feature_list_filter_by_key
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_list_filter_by_key__suffix = {{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_list_filter_by_key__feature_a_key = filter_by_key_a_{{d__feature_list_filter_by_key__suffix}}
+@d__feature_list_filter_by_key__feature_b_key = filter_by_key_b_{{d__feature_list_filter_by_key__suffix}}
+
+###
+# @name r__feature_list_filter_by_key__create_feature_a
+# @title create feature A
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_filter_by_key__feature_a_key}}",
+  "name": "Test Feature"
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_filter_by_key__feature_a_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_filter_by_key__create_feature_b
+# @title create feature B
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_filter_by_key__feature_b_key}}",
+  "name": "Test Feature"
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_filter_by_key__feature_b_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_filter_by_key__list_filtered_by_key_a
+# @title list filtered by feature A's key returns A only
+# @ref r__feature_list_filter_by_key__create_feature_a
+# @ref r__feature_list_filter_by_key__create_feature_b
+GET {{api_base}}/openmeter/features?filter[key][eq]={{d__feature_list_filter_by_key__feature_a_key}}&page[size]=1000
+
+?? status == 200
+{{
+  const { ok } = require('assert');
+  test('feature A is present, feature B is absent under key-A filter', () => {
+    const items = response.parsedBody.data || response.parsedBody.items || [];
+    ok(
+      items.some(f => f.id === v__feature_list_filter_by_key__feature_a_id),
+      'expected list to contain feature A id ' + v__feature_list_filter_by_key__feature_a_id
+    );
+    ok(
+      !items.some(f => f.id === v__feature_list_filter_by_key__feature_b_id),
+      'expected list NOT to contain feature B id ' + v__feature_list_filter_by_key__feature_b_id
+    );
+  });
+}}

--- a/e2e/http/features/feature_list_filter_by_meter_id.http
+++ b/e2e/http/features/feature_list_filter_by_meter_id.http
@@ -1,0 +1,105 @@
+# feature_list_filter_by_meter_id
+#
+# Source: e2e/specs/features.md ## Scenario: feature_list_filter_by_meter_id
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_list_filter_by_meter_id__suffix = {{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_list_filter_by_meter_id__meter_a_key = filter_meter_a_{{d__feature_list_filter_by_meter_id__suffix}}
+@d__feature_list_filter_by_meter_id__meter_b_key = filter_meter_b_{{d__feature_list_filter_by_meter_id__suffix}}
+@d__feature_list_filter_by_meter_id__feature_a_key = filter_feature_a_{{d__feature_list_filter_by_meter_id__suffix}}
+@d__feature_list_filter_by_meter_id__feature_b_key = filter_feature_b_{{d__feature_list_filter_by_meter_id__suffix}}
+
+###
+# @name r__feature_list_filter_by_meter_id__create_meter_a
+# @title create meter A
+POST {{api_base}}/openmeter/meters
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_filter_by_meter_id__meter_a_key}}",
+  "name": "Test Meter A",
+  "event_type": "e2e_feature_test",
+  "aggregation": "count"
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_filter_by_meter_id__meter_a_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_filter_by_meter_id__create_meter_b
+# @title create meter B
+POST {{api_base}}/openmeter/meters
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_filter_by_meter_id__meter_b_key}}",
+  "name": "Test Meter B",
+  "event_type": "e2e_feature_test",
+  "aggregation": "count"
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_filter_by_meter_id__meter_b_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_filter_by_meter_id__create_feature_a
+# @title create feature A on meter A
+# @ref r__feature_list_filter_by_meter_id__create_meter_a
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_filter_by_meter_id__feature_a_key}}",
+  "name": "Test Feature",
+  "meter": { "id": "{{v__feature_list_filter_by_meter_id__meter_a_id}}" }
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_filter_by_meter_id__feature_a_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_filter_by_meter_id__create_feature_b
+# @title create feature B on meter B
+# @ref r__feature_list_filter_by_meter_id__create_meter_b
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_filter_by_meter_id__feature_b_key}}",
+  "name": "Test Feature",
+  "meter": { "id": "{{v__feature_list_filter_by_meter_id__meter_b_id}}" }
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_filter_by_meter_id__feature_b_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_filter_by_meter_id__list_filtered_by_meter_a
+# @title list filtered by meter A returns feature A only
+# @ref r__feature_list_filter_by_meter_id__create_feature_a
+# @ref r__feature_list_filter_by_meter_id__create_feature_b
+GET {{api_base}}/openmeter/features?filter[meter_id][eq]={{v__feature_list_filter_by_meter_id__meter_a_id}}&page[size]=1000
+
+?? status == 200
+{{
+  const { ok } = require('assert');
+  test('feature A is present, feature B is absent under meter-A filter', () => {
+    const items = response.parsedBody.data || response.parsedBody.items || [];
+    ok(
+      items.some(f => f.id === v__feature_list_filter_by_meter_id__feature_a_id),
+      'expected list to contain feature A id ' + v__feature_list_filter_by_meter_id__feature_a_id
+    );
+    ok(
+      !items.some(f => f.id === v__feature_list_filter_by_meter_id__feature_b_id),
+      'expected list NOT to contain feature B id ' + v__feature_list_filter_by_meter_id__feature_b_id
+    );
+  });
+}}

--- a/e2e/http/features/feature_list_filter_by_name.http
+++ b/e2e/http/features/feature_list_filter_by_name.http
@@ -1,0 +1,44 @@
+# feature_list_filter_by_name
+#
+# Source: e2e/specs/features.md ## Scenario: feature_list_filter_by_name
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+# Use an underscore-joined distinctive name to avoid URL-encoding the
+# space character in the filter[name][eq] query parameter.
+@d__feature_list_filter_by_name__suffix = {{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_list_filter_by_name__feature_key = filter_by_name_{{d__feature_list_filter_by_name__suffix}}
+@d__feature_list_filter_by_name__feature_name = E2E_filter_by_name_{{d__feature_list_filter_by_name__suffix}}
+
+###
+# @name r__feature_list_filter_by_name__create_feature
+# @title create feature with unique distinctive name
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_filter_by_name__feature_key}}",
+  "name": "{{d__feature_list_filter_by_name__feature_name}}"
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_filter_by_name__feature_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_filter_by_name__list_filtered_by_name
+# @title list filtered by name returns the feature
+# @ref r__feature_list_filter_by_name__create_feature
+GET {{api_base}}/openmeter/features?filter[name][eq]={{d__feature_list_filter_by_name__feature_name}}&page[size]=1000
+
+?? status == 200
+{{
+  const { ok, strictEqual } = require('assert');
+  test('list filtered by unique name contains exactly the created feature', () => {
+    const items = response.parsedBody.data || response.parsedBody.items || [];
+    const matching = items.filter(f => f.id === v__feature_list_filter_by_name__feature_id);
+    ok(matching.length === 1, 'expected exactly one match by id, got ' + matching.length);
+    // Unique-suffix name guarantees no other feature in shared DB matches.
+    strictEqual(items.length, 1, 'expected exactly one item under unique-name filter, got ' + items.length);
+  });
+}}

--- a/e2e/http/features/feature_list_filter_malformed_rejected.http
+++ b/e2e/http/features/feature_list_filter_malformed_rejected.http
@@ -1,0 +1,29 @@
+# feature_list_filter_malformed_rejected
+#
+# Source: e2e/specs/features.md ## Scenario: feature_list_filter_malformed_rejected
+#
+# Pinned 2026-04-28 against an OpenMeter deployment running behind an
+# OpenAPI binder gateway. Re-pin if the binder layer is replaced or
+# upgraded — the rule strings (`anyOf` / `format`) and the
+# umbrella-field binding are binder-topology dependent.
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+
+###
+# @name r__feature_list_filter_malformed_rejected__row1_bad_ulid
+# @title row 1: filter[meter_id][eq]=not-a-ulid -> 400 with invalid_parameters
+GET {{api_base}}/openmeter/features?filter[meter_id][eq]=not-a-ulid
+
+?? status == 400
+?? js response.parsedBody.invalid_parameters[0].field == meter_id
+?? js response.parsedBody.invalid_parameters[0].rule == anyOf
+
+###
+# @name r__feature_list_filter_malformed_rejected__row2_unknown_operator
+# @title row 2: filter[meter_id][zz]=<ulid> -> 400 with invalid_parameters
+GET {{api_base}}/openmeter/features?filter[meter_id][zz]=01HXYZABCDEFGHJKMNPQRSTVWX
+
+?? status == 400
+?? js response.parsedBody.invalid_parameters[0].field == filter
+?? js response.parsedBody.invalid_parameters[0].rule == format
+?? js response.parsedBody.invalid_parameters[0].reason.includes('filter[meter_id][zz]: unsupported operator')

--- a/e2e/http/features/feature_list_pagination.http
+++ b/e2e/http/features/feature_list_pagination.http
@@ -1,0 +1,146 @@
+# feature_list_pagination
+#
+# Source: e2e/specs/features.md ## Scenario: feature_list_pagination
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+# Shared name prefix narrows the per-page filter to exactly the three
+# fixtures, regardless of unrelated rows in a shared DB.
+@d__feature_list_pagination__suffix = {{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_list_pagination__name_prefix = pagination_test_{{d__feature_list_pagination__suffix}}
+@d__feature_list_pagination__feature_a_key = pagination_a_{{d__feature_list_pagination__suffix}}
+@d__feature_list_pagination__feature_b_key = pagination_b_{{d__feature_list_pagination__suffix}}
+@d__feature_list_pagination__feature_c_key = pagination_c_{{d__feature_list_pagination__suffix}}
+
+###
+# @name r__feature_list_pagination__create_feature_a
+# @title create feature A
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_pagination__feature_a_key}}",
+  "name": "{{d__feature_list_pagination__name_prefix}}_a"
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_pagination__feature_a_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_pagination__create_feature_b
+# @title create feature B
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_pagination__feature_b_key}}",
+  "name": "{{d__feature_list_pagination__name_prefix}}_b"
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_pagination__feature_b_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_pagination__create_feature_c
+# @title create feature C
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_pagination__feature_c_key}}",
+  "name": "{{d__feature_list_pagination__name_prefix}}_c"
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_pagination__feature_c_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_pagination__page_1
+# @title list page 1 size 1 filtered to fixtures
+# @ref r__feature_list_pagination__create_feature_a
+# @ref r__feature_list_pagination__create_feature_b
+# @ref r__feature_list_pagination__create_feature_c
+GET {{api_base}}/openmeter/features?filter[name][contains]={{d__feature_list_pagination__name_prefix}}&page[number]=1&page[size]=1
+
+?? status == 200
+{{
+  const { strictEqual, ok } = require('assert');
+  test('page 1: meta + length', () => {
+    const data = response.parsedBody.data || response.parsedBody.items || [];
+    strictEqual(data.length, 1, 'page 1 must contain exactly one entry');
+    const meta = (response.parsedBody.meta && response.parsedBody.meta.page) || {};
+    strictEqual(meta.total, 3, 'meta.page.total must be 3');
+    strictEqual(meta.number, 1, 'meta.page.number must be 1');
+    strictEqual(meta.size, 1, 'meta.page.size must be 1');
+    exports.v__feature_list_pagination__page_1_id = data[0].id;
+    const fixtureIds = new Set([
+      v__feature_list_pagination__feature_a_id,
+      v__feature_list_pagination__feature_b_id,
+      v__feature_list_pagination__feature_c_id,
+    ]);
+    ok(fixtureIds.has(data[0].id), 'page 1 entry must be one of the fixtures');
+  });
+}}
+
+###
+# @name r__feature_list_pagination__page_2
+# @title list page 2 size 1 filtered to fixtures
+# @ref r__feature_list_pagination__page_1
+GET {{api_base}}/openmeter/features?filter[name][contains]={{d__feature_list_pagination__name_prefix}}&page[number]=2&page[size]=1
+
+?? status == 200
+{{
+  const { strictEqual, ok, notStrictEqual } = require('assert');
+  test('page 2: meta + length + differs from page 1', () => {
+    const data = response.parsedBody.data || response.parsedBody.items || [];
+    strictEqual(data.length, 1, 'page 2 must contain exactly one entry');
+    const meta = (response.parsedBody.meta && response.parsedBody.meta.page) || {};
+    strictEqual(meta.number, 2, 'meta.page.number must be 2');
+    notStrictEqual(data[0].id, v__feature_list_pagination__page_1_id, 'page 2 entry must differ from page 1');
+    exports.v__feature_list_pagination__page_2_id = data[0].id;
+    const fixtureIds = new Set([
+      v__feature_list_pagination__feature_a_id,
+      v__feature_list_pagination__feature_b_id,
+      v__feature_list_pagination__feature_c_id,
+    ]);
+    ok(fixtureIds.has(data[0].id), 'page 2 entry must be one of the fixtures');
+  });
+}}
+
+###
+# @name r__feature_list_pagination__page_3
+# @title list page 3 size 1 filtered to fixtures and union covers fixtures
+# @ref r__feature_list_pagination__page_2
+GET {{api_base}}/openmeter/features?filter[name][contains]={{d__feature_list_pagination__name_prefix}}&page[number]=3&page[size]=1
+
+?? status == 200
+{{
+  const { strictEqual, ok, notStrictEqual } = require('assert');
+  test('page 3: meta + length + differs from pages 1/2 + union covers fixtures', () => {
+    const data = response.parsedBody.data || response.parsedBody.items || [];
+    strictEqual(data.length, 1, 'page 3 must contain exactly one entry');
+    const meta = (response.parsedBody.meta && response.parsedBody.meta.page) || {};
+    strictEqual(meta.number, 3, 'meta.page.number must be 3');
+    notStrictEqual(data[0].id, v__feature_list_pagination__page_1_id, 'page 3 must differ from page 1');
+    notStrictEqual(data[0].id, v__feature_list_pagination__page_2_id, 'page 3 must differ from page 2');
+    const seen = new Set([
+      v__feature_list_pagination__page_1_id,
+      v__feature_list_pagination__page_2_id,
+      data[0].id,
+    ]);
+    const fixtureIds = new Set([
+      v__feature_list_pagination__feature_a_id,
+      v__feature_list_pagination__feature_b_id,
+      v__feature_list_pagination__feature_c_id,
+    ]);
+    strictEqual(seen.size, 3, 'three pages must yield three distinct ids');
+    for (const id of fixtureIds) {
+      ok(seen.has(id), 'fixture id ' + id + ' must appear across the three pages');
+    }
+  });
+}}

--- a/e2e/http/features/feature_list_sort_by_supported_fields.http
+++ b/e2e/http/features/feature_list_sort_by_supported_fields.http
@@ -1,0 +1,188 @@
+# feature_list_sort_by_supported_fields
+#
+# Source: e2e/specs/features.md ## Scenario: feature_list_sort_by_supported_fields
+#
+# Three fixtures created in order A, B, C with letter-first keys and
+# names so that alphabetical key/name ordering matches creation order.
+# After creation, no-op PATCHes (unit_cost: null on a feature without
+# unit_cost) bump updated_at predictably in the same order, so
+# updated_at ordering also matches A < B < C.
+#
+# Verified 2026-04-28: the server does not parse `:asc` / `:desc`
+# suffixes — `sort=key:desc` returns 400 with detail "invalid
+# feature order by: key:desc". Descending rows are dropped until the
+# server grows syntax for it.
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_list_sort_by_supported_fields__suffix = {{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_list_sort_by_supported_fields__feature_a_key = sort_a_{{d__feature_list_sort_by_supported_fields__suffix}}
+@d__feature_list_sort_by_supported_fields__feature_b_key = sort_b_{{d__feature_list_sort_by_supported_fields__suffix}}
+@d__feature_list_sort_by_supported_fields__feature_c_key = sort_c_{{d__feature_list_sort_by_supported_fields__suffix}}
+@d__feature_list_sort_by_supported_fields__feature_a_name = e2e_sort_a_{{d__feature_list_sort_by_supported_fields__suffix}}
+@d__feature_list_sort_by_supported_fields__feature_b_name = e2e_sort_b_{{d__feature_list_sort_by_supported_fields__suffix}}
+@d__feature_list_sort_by_supported_fields__feature_c_name = e2e_sort_c_{{d__feature_list_sort_by_supported_fields__suffix}}
+
+###
+# @name r__feature_list_sort_by_supported_fields__create_feature_a
+# @title create feature A (first)
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_sort_by_supported_fields__feature_a_key}}",
+  "name": "{{d__feature_list_sort_by_supported_fields__feature_a_name}}"
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_sort_by_supported_fields__feature_a_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_sort_by_supported_fields__create_feature_b
+# @title create feature B (second)
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_sort_by_supported_fields__feature_b_key}}",
+  "name": "{{d__feature_list_sort_by_supported_fields__feature_b_name}}"
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_sort_by_supported_fields__feature_b_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_sort_by_supported_fields__create_feature_c
+# @title create feature C (third)
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_list_sort_by_supported_fields__feature_c_key}}",
+  "name": "{{d__feature_list_sort_by_supported_fields__feature_c_name}}"
+}
+
+?? status == 201
+{{
+  exports.v__feature_list_sort_by_supported_fields__feature_c_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_list_sort_by_supported_fields__bump_updated_at_a
+# @title no-op patch on A to bump updated_at first
+# @ref r__feature_list_sort_by_supported_fields__create_feature_a
+PATCH {{api_base}}/openmeter/features/{{v__feature_list_sort_by_supported_fields__feature_a_id}}
+Content-Type: application/json
+
+{ "unit_cost": null }
+
+?? status == 200
+
+###
+# @name r__feature_list_sort_by_supported_fields__bump_updated_at_b
+# @title no-op patch on B to bump updated_at second
+# @ref r__feature_list_sort_by_supported_fields__bump_updated_at_a
+PATCH {{api_base}}/openmeter/features/{{v__feature_list_sort_by_supported_fields__feature_b_id}}
+Content-Type: application/json
+
+{ "unit_cost": null }
+
+?? status == 200
+
+###
+# @name r__feature_list_sort_by_supported_fields__bump_updated_at_c
+# @title no-op patch on C to bump updated_at third
+# @ref r__feature_list_sort_by_supported_fields__bump_updated_at_b
+PATCH {{api_base}}/openmeter/features/{{v__feature_list_sort_by_supported_fields__feature_c_id}}
+Content-Type: application/json
+
+{ "unit_cost": null }
+
+?? status == 200
+
+###
+# @name r__feature_list_sort_by_supported_fields__row1_sort_key
+# @title row 1: sort=key -> A, B, C
+# @ref r__feature_list_sort_by_supported_fields__bump_updated_at_c
+GET {{api_base}}/openmeter/features?sort=key&page[size]=1000
+
+?? status == 200
+{{
+  const { deepStrictEqual } = require('assert');
+  test('sort=key returns A, B, C', () => {
+    const items = response.parsedBody.data || response.parsedBody.items || [];
+    const fixtureIds = [
+      v__feature_list_sort_by_supported_fields__feature_a_id,
+      v__feature_list_sort_by_supported_fields__feature_b_id,
+      v__feature_list_sort_by_supported_fields__feature_c_id,
+    ];
+    const observed = items.filter(f => fixtureIds.includes(f.id)).map(f => f.id);
+    deepStrictEqual(observed, fixtureIds);
+  });
+}}
+
+###
+# @name r__feature_list_sort_by_supported_fields__row2_sort_name
+# @title row 2: sort=name -> A, B, C
+# @ref r__feature_list_sort_by_supported_fields__bump_updated_at_c
+GET {{api_base}}/openmeter/features?sort=name&page[size]=1000
+
+?? status == 200
+{{
+  const { deepStrictEqual } = require('assert');
+  test('sort=name returns A, B, C', () => {
+    const items = response.parsedBody.data || response.parsedBody.items || [];
+    const fixtureIds = [
+      v__feature_list_sort_by_supported_fields__feature_a_id,
+      v__feature_list_sort_by_supported_fields__feature_b_id,
+      v__feature_list_sort_by_supported_fields__feature_c_id,
+    ];
+    const observed = items.filter(f => fixtureIds.includes(f.id)).map(f => f.id);
+    deepStrictEqual(observed, fixtureIds);
+  });
+}}
+
+###
+# @name r__feature_list_sort_by_supported_fields__row3_sort_created_at
+# @title row 3: sort=created_at -> A, B, C
+# @ref r__feature_list_sort_by_supported_fields__bump_updated_at_c
+GET {{api_base}}/openmeter/features?sort=created_at&page[size]=1000
+
+?? status == 200
+{{
+  const { deepStrictEqual } = require('assert');
+  test('sort=created_at returns A, B, C', () => {
+    const items = response.parsedBody.data || response.parsedBody.items || [];
+    const fixtureIds = [
+      v__feature_list_sort_by_supported_fields__feature_a_id,
+      v__feature_list_sort_by_supported_fields__feature_b_id,
+      v__feature_list_sort_by_supported_fields__feature_c_id,
+    ];
+    const observed = items.filter(f => fixtureIds.includes(f.id)).map(f => f.id);
+    deepStrictEqual(observed, fixtureIds);
+  });
+}}
+
+###
+# @name r__feature_list_sort_by_supported_fields__row4_sort_updated_at
+# @title row 4: sort=updated_at -> A, B, C
+# @ref r__feature_list_sort_by_supported_fields__bump_updated_at_c
+GET {{api_base}}/openmeter/features?sort=updated_at&page[size]=1000
+
+?? status == 200
+{{
+  const { deepStrictEqual } = require('assert');
+  test('sort=updated_at returns A, B, C', () => {
+    const items = response.parsedBody.data || response.parsedBody.items || [];
+    const fixtureIds = [
+      v__feature_list_sort_by_supported_fields__feature_a_id,
+      v__feature_list_sort_by_supported_fields__feature_b_id,
+      v__feature_list_sort_by_supported_fields__feature_c_id,
+    ];
+    const observed = items.filter(f => fixtureIds.includes(f.id)).map(f => f.id);
+    deepStrictEqual(observed, fixtureIds);
+  });
+}}

--- a/e2e/http/features/feature_list_sort_invalid_field_rejected.http
+++ b/e2e/http/features/feature_list_sort_invalid_field_rejected.http
@@ -1,0 +1,13 @@
+# feature_list_sort_invalid_field_rejected
+#
+# Source: e2e/specs/features.md ## Scenario: feature_list_sort_invalid_field_rejected
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+
+###
+# @name r__feature_list_sort_invalid_field_rejected__bad_sort_field
+# @title GET /features?sort=banana returns 400
+GET {{api_base}}/openmeter/features?sort=banana
+
+?? status == 400
+?? js response.parsedBody.detail.includes('invalid feature order by: banana')

--- a/e2e/http/features/feature_llm_pricing_absent_when_unresolved.http
+++ b/e2e/http/features/feature_llm_pricing_absent_when_unresolved.http
@@ -1,0 +1,68 @@
+# feature_llm_pricing_absent_when_unresolved
+#
+# Source: e2e/specs/features.md ## Scenario: feature_llm_pricing_absent_when_unresolved
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_llm_pricing_absent_when_unresolved__meter_key = llm_unresolved_meter_{{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_llm_pricing_absent_when_unresolved__feature_key = llm_unresolved_feature_{{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_llm_pricing_absent_when_unresolved__provider = unknown_provider_{{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_llm_pricing_absent_when_unresolved__model = unknown_model_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_llm_pricing_absent_when_unresolved__create_meter
+# @title create LLM-capable meter
+POST {{api_base}}/openmeter/meters
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_llm_pricing_absent_when_unresolved__meter_key}}",
+  "name": "Test LLM Meter",
+  "event_type": "e2e_llm_test",
+  "aggregation": "count",
+  "dimensions": {
+    "provider": "$.provider",
+    "model": "$.model",
+    "token_type": "$.token_type"
+  }
+}
+
+?? status == 201
+{{
+  exports.v__feature_llm_pricing_absent_when_unresolved__meter_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_llm_pricing_absent_when_unresolved__create_llm_feature
+# @title create LLM feature with unresolvable provider/model
+# @ref r__feature_llm_pricing_absent_when_unresolved__create_meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_llm_pricing_absent_when_unresolved__feature_key}}",
+  "name": "Test Feature",
+  "meter": { "id": "{{v__feature_llm_pricing_absent_when_unresolved__meter_id}}" },
+  "unit_cost": {
+    "type": "llm",
+    "provider": "{{d__feature_llm_pricing_absent_when_unresolved__provider}}",
+    "model": "{{d__feature_llm_pricing_absent_when_unresolved__model}}",
+    "token_type": "input"
+  }
+}
+
+?? status == 201
+{{
+  exports.v__feature_llm_pricing_absent_when_unresolved__feature_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_llm_pricing_absent_when_unresolved__get_feature_pricing_absent
+# @title GET LLM feature returns 200 with unit_cost.pricing absent
+# @ref r__feature_llm_pricing_absent_when_unresolved__create_llm_feature
+GET {{api_base}}/openmeter/features/{{v__feature_llm_pricing_absent_when_unresolved__feature_id}}
+
+?? status == 200
+?? js response.parsedBody.unit_cost.type == llm
+?? js response.parsedBody.unit_cost.provider == {{d__feature_llm_pricing_absent_when_unresolved__provider}}
+?? js response.parsedBody.unit_cost.model == {{d__feature_llm_pricing_absent_when_unresolved__model}}
+?? js typeof response.parsedBody.unit_cost.pricing == undefined

--- a/e2e/http/features/feature_llm_pricing_enriched_on_get.http
+++ b/e2e/http/features/feature_llm_pricing_enriched_on_get.http
@@ -1,0 +1,83 @@
+# feature_llm_pricing_enriched_on_get
+#
+# Source: e2e/specs/features.md ## Scenario: feature_llm_pricing_enriched_on_get
+#
+# STATUS: SKIPPED — Environment-gated; deferred until the e2e stack
+# provisions a deterministic LLM-cost seed (a known (openai, gpt-4)
+# price). Without that seed the scenario degrades to
+# feature_llm_pricing_absent_when_unresolved.
+# Re-enable by removing the @disabled lines once seeding is in place.
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_llm_pricing_enriched_on_get__meter_key = llm_enriched_meter_{{$timestamp}}_{{$randomInt 0 1000000}}
+@d__feature_llm_pricing_enriched_on_get__feature_key = llm_enriched_feature_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @disabled
+# @name r__feature_llm_pricing_enriched_on_get__create_meter
+# @title create LLM-capable meter
+POST {{api_base}}/openmeter/meters
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_llm_pricing_enriched_on_get__meter_key}}",
+  "name": "Test LLM Meter",
+  "event_type": "e2e_llm_test",
+  "aggregation": "count",
+  "dimensions": {
+    "provider": "$.provider",
+    "model": "$.model",
+    "token_type": "$.token_type"
+  }
+}
+
+?? status == 201
+{{
+  exports.v__feature_llm_pricing_enriched_on_get__meter_id = response.parsedBody.id;
+}}
+
+###
+# @disabled
+# @name r__feature_llm_pricing_enriched_on_get__create_llm_feature
+# @title create LLM feature with resolvable provider/model
+# @ref r__feature_llm_pricing_enriched_on_get__create_meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_llm_pricing_enriched_on_get__feature_key}}",
+  "name": "Test Feature",
+  "meter": { "id": "{{v__feature_llm_pricing_enriched_on_get__meter_id}}" },
+  "unit_cost": {
+    "type": "llm",
+    "provider": "openai",
+    "model": "gpt-4",
+    "token_type": "input"
+  }
+}
+
+?? status == 201
+{{
+  exports.v__feature_llm_pricing_enriched_on_get__feature_id = response.parsedBody.id;
+}}
+
+###
+# @disabled
+# @name r__feature_llm_pricing_enriched_on_get__get_feature_pricing_enriched
+# @title GET LLM feature returns 200 with unit_cost.pricing populated
+# @ref r__feature_llm_pricing_enriched_on_get__create_llm_feature
+GET {{api_base}}/openmeter/features/{{v__feature_llm_pricing_enriched_on_get__feature_id}}
+
+?? status == 200
+?? js response.parsedBody.unit_cost.type == llm
+{{
+  const { ok } = require('assert');
+  test('unit_cost.pricing is present and per-token fields parse as non-negative decimals', () => {
+    const pricing = response.parsedBody.unit_cost.pricing;
+    ok(pricing && typeof pricing === 'object', 'expected unit_cost.pricing to be present, got ' + JSON.stringify(pricing));
+    const inp = pricing.input_per_token;
+    const out = pricing.output_per_token;
+    ok(typeof inp === 'string' && Number.parseFloat(inp) >= 0, 'input_per_token must be a non-negative decimal string, got ' + JSON.stringify(inp));
+    ok(typeof out === 'string' && Number.parseFloat(out) >= 0, 'output_per_token must be a non-negative decimal string, got ' + JSON.stringify(out));
+  });
+}}

--- a/e2e/http/features/feature_update_llm_without_meter_rejected.http
+++ b/e2e/http/features/feature_update_llm_without_meter_rejected.http
@@ -1,0 +1,41 @@
+# feature_update_llm_without_meter_rejected
+#
+# Source: e2e/specs/features.md ## Scenario: feature_update_llm_without_meter_rejected
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_update_llm_without_meter_rejected__feature_key = patch_llm_no_meter_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_update_llm_without_meter_rejected__create_feature
+# @title create baseline feature without meter
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_update_llm_without_meter_rejected__feature_key}}",
+  "name": "Test Feature"
+}
+
+?? status == 201
+{{
+  exports.v__feature_update_llm_without_meter_rejected__feature_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_update_llm_without_meter_rejected__patch_with_llm_unit_cost
+# @title PATCH with LLM unit_cost on unmetered feature returns 400
+# @ref r__feature_update_llm_without_meter_rejected__create_feature
+PATCH {{api_base}}/openmeter/features/{{v__feature_update_llm_without_meter_rejected__feature_id}}
+Content-Type: application/json
+
+{
+  "unit_cost": {
+    "type": "llm",
+    "provider": "openai",
+    "model": "gpt-4",
+    "token_type": "input"
+  }
+}
+
+?? status == 400
+?? js response.parsedBody.detail.includes('LLM unit cost requires a meter to be associated with the feature')

--- a/e2e/http/features/feature_update_nonexistent_rejected.http
+++ b/e2e/http/features/feature_update_nonexistent_rejected.http
@@ -1,0 +1,17 @@
+# feature_update_nonexistent_rejected
+#
+# Source: e2e/specs/features.md ## Scenario: feature_update_nonexistent_rejected
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_update_nonexistent_rejected__missing_id = 01HXYZABCDEFGHJKMNPQRSTV03
+
+###
+# @name r__feature_update_nonexistent_rejected__patch_unknown_id
+# @title PATCH /features/<random-ULID-not-in-DB> returns 404
+PATCH {{api_base}}/openmeter/features/{{d__feature_update_nonexistent_rejected__missing_id}}
+Content-Type: application/json
+
+{ "unit_cost": null }
+
+?? status == 404
+?? js response.parsedBody.detail.includes('feature not found: {{d__feature_update_nonexistent_rejected__missing_id}}')

--- a/e2e/http/features/feature_update_unit_cost_required.http
+++ b/e2e/http/features/feature_update_unit_cost_required.http
@@ -1,0 +1,34 @@
+# feature_update_unit_cost_required
+#
+# Source: e2e/specs/features.md ## Scenario: feature_update_unit_cost_required
+
+@api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+@d__feature_update_unit_cost_required__feature_key = patch_required_{{$timestamp}}_{{$randomInt 0 1000000}}
+
+###
+# @name r__feature_update_unit_cost_required__create_feature
+# @title create baseline feature
+POST {{api_base}}/openmeter/features
+Content-Type: application/json
+
+{
+  "key": "{{d__feature_update_unit_cost_required__feature_key}}",
+  "name": "Test Feature"
+}
+
+?? status == 201
+{{
+  exports.v__feature_update_unit_cost_required__feature_id = response.parsedBody.id;
+}}
+
+###
+# @name r__feature_update_unit_cost_required__patch_empty_body
+# @title PATCH with empty body is rejected
+# @ref r__feature_update_unit_cost_required__create_feature
+PATCH {{api_base}}/openmeter/features/{{v__feature_update_unit_cost_required__feature_id}}
+Content-Type: application/json
+
+{}
+
+?? status == 400
+?? js response.parsedBody.detail.includes('unitCost is required')

--- a/e2e/http/httpyac.config.js
+++ b/e2e/http/httpyac.config.js
@@ -1,0 +1,19 @@
+// Project-root marker for httpYac. The presence of this file scopes
+// httpYac's project root to e2e/http/.
+//
+// Configuration is intentionally shell-env based, mirroring the Go
+// e2e convention (`OPENMETER_ADDRESS=http://localhost:8888 go test
+// ./e2e/...`). Each .http file declares
+//   @api_base = {{process.env.OPENMETER_ADDRESS}}/api/v3
+// at the top — `OPENMETER_ADDRESS` stays the bare host (matches the
+// /e2e Go suite exactly) and the version prefix `/api/v3` lives in
+// the file. httpYac evaluates `{{...}}` as a JS expression when no
+// variable matches by name, so `process.env.X` resolves to the
+// shell-exported value at send time. Bare `{{OPENMETER_ADDRESS}}`
+// would throw ReferenceError.
+//
+// Add response-log scrubbing here if real auth tokens flow through
+// tests. v1 ships without scrubbing; add intentionally when the auth
+// surface is settled.
+
+module.exports = {};

--- a/e2e/specs/features.md
+++ b/e2e/specs/features.md
@@ -68,7 +68,7 @@ the corresponding `## Scenario` section.
 - `feature_list_combined_filters` — Combining `filter[meter_id]` + `filter[key]` narrows intersection. — shape: matrix — priority: p1
 - `feature_list_sort_by_supported_fields` — `sort=key`, `sort=name`, `sort=created_at`, `sort=updated_at` (with `:asc` / `:desc`) returns the expected order. — shape: matrix — priority: p1
 - `feature_list_sort_invalid_field_rejected` — `sort=<unknown_field>` returns 400 with schema-rule shape. — shape: single-request — priority: p1
-- `feature_list_filter_malformed_rejected` — Malformed filter value (unknown operator, bad ULID format on `filter[meter_id]`) returns 400 with schema-rule shape. — shape: single-request — priority: p1 — NEEDS-VERIFY: exact `rule` strings the OpenAPI binder emits for ULID-format and unknown-property rejections.
+- `feature_list_filter_malformed_rejected` — Malformed filter value (unknown operator, bad ULID format on `filter[meter_id]`) returns 400 with schema-rule shape. — shape: single-request — priority: p1
 - `feature_list_pagination` — `page[number]` + `page[size]` return the expected slice and response metadata. — shape: single-request — priority: p1
 
 **p1 — cost query**
@@ -568,18 +568,18 @@ exercises one rule against a fresh fixture.
 
 **Rows:**
 
-| # | Mutation from baseline (`type` + payload) | Expect | Detail contains |
+| # | Mutation from baseline (`type` + payload) | Expect | Shape |
 |---|---|---|---|
 | 1 | manual baseline (`type: manual`, `amount: "5"`); no meter | `201 Created` | — |
 | 2 | LLM baseline (static provider/model/token_type); meter attached | `201 Created` | — |
-| 3 | manual with `amount: "-1"`; no meter | `400 Bad Request` | `"manual unit cost amount must be non-negative"` |
-| 4 | LLM with both `provider: "openai"` and `provider_property: "provider"`; meter attached | `400 Bad Request` | `"provider_property and provider are mutually exclusive"` |
-| 5 | LLM with both `model: "gpt-4"` and `model_property: "model"`; meter attached | `400 Bad Request` | `"model_property and model are mutually exclusive"` |
-| 6 | LLM with both `token_type: "input"` and `token_type_property: "token_type"`; meter attached | `400 Bad Request` | `"token_type_property and token_type are mutually exclusive"` |
-| 7 | LLM with no `provider` and no `provider_property` (model + token_type still set); meter attached | `400 Bad Request` | `"either provider_property or provider is required for LLM unit cost"` |
-| 8 | LLM with no `model` and no `model_property` (provider + token_type still set); meter attached | `400 Bad Request` | `"either model_property or model is required for LLM unit cost"` |
-| 9 | LLM with no `token_type` and no `token_type_property` (provider + model still set); meter attached | `400 Bad Request` | `"either token_type_property or token_type is required for LLM unit cost"` |
-| 10 | LLM baseline with `token_type: "banana"`; meter attached | `400 Bad Request` | `"invalid token_type \"banana\""` |
+| 3 | manual with `amount: "-1"`; no meter | `400 Bad Request` | detail equals `"validation error: manual unit cost amount must be non-negative"` |
+| 4 | LLM with both `provider: "openai"` and `provider_property: "provider"`; meter attached | `400 Bad Request` | detail equals `"validation error: provider_property and provider are mutually exclusive"` |
+| 5 | LLM with both `model: "gpt-4"` and `model_property: "model"`; meter attached | `400 Bad Request` | detail equals `"validation error: model_property and model are mutually exclusive"` |
+| 6 | LLM with both `token_type: "input"` and `token_type_property: "token_type"`; meter attached | `400 Bad Request` | detail equals `"validation error: token_type_property and token_type are mutually exclusive"` |
+| 7 | LLM with no `provider` and no `provider_property` (model + token_type still set); meter attached | `400 Bad Request` | detail equals `"validation error: either provider_property or provider is required for LLM unit cost"` |
+| 8 | LLM with no `model` and no `model_property` (provider + token_type still set); meter attached | `400 Bad Request` | detail equals `"validation error: either model_property or model is required for LLM unit cost"` |
+| 9 | LLM with no `token_type` and no `token_type_property` (provider + model still set); meter attached | `400 Bad Request` | detail equals `"validation error: either token_type_property or token_type is required for LLM unit cost"` |
+| 10 | LLM baseline with `token_type: "banana"`; meter attached | `400 Bad Request` | schema-rule: `invalid_parameters[0].field == "unit_cost"`, `rule == "allOf"` |
 
 **Steps per row:**
 
@@ -590,25 +590,54 @@ exercises one rule against a fresh fixture.
 2. **Create feature.** `POST /features` with the feature fixture for
    the row.
    - Expect the row's `Expect` status.
-   - If 4xx, expect **detail contains** the row's `Detail contains`
-     substring.
+   - If 4xx and the row's shape is **detail-equality** (rows 3–9),
+     expect `response.parsedBody.detail` to equal the full pinned
+     string (including the `"validation error: "` prefix).
+   - If 4xx and the row's shape is **schema-rule** (row 10), expect
+     `response.parsedBody.invalid_parameters[0].field` and `.rule` to
+     match the pinned values.
    - If 2xx, expect the response body parses as a `Feature`.
 
 **Notes:**
 
 - **Validation moment:** create-time. All rows fire before insert.
-- **Error shape:** detail-substring. The features family does not
-  use the **domain code** shape (`extensions.validationErrors[]`).
-- **Joined errors.** When a row removes more than one required
-  dimension, the server may surface multiple messages joined into a
-  single `detail`. Detail-substring matches still pass — pin one
-  distinctive substring per row rather than asserting the full
-  message.
+- **Two error shapes in this matrix.**
+  - Rows 3–9 are **handler rejections.** The OpenAPI binder layer
+    (when present) forwards the request — the body schema is
+    structurally valid — and the OpenMeter handler runs the
+    mutex / required / range rules, returning a domain error. The
+    framework wraps the bare message in a `"validation error:
+    <msg>"` detail field — pin the **full prefixed string** via
+    equality, since each row triggers exactly one rule and the
+    detail is deterministic.
+  - Row 10 is a **binder-layer rejection** in deployments where an
+    OpenAPI schema validator runs ahead of the handler.
+    `token_type` is constrained by an OpenAPI enum; the binder's
+    `allOf` validator rejects before the handler runs. The
+    handler's `"invalid token_type"` message is **unreachable** in
+    that topology. The expected shape is schema-rule
+    (`invalid_parameters[].rule == "allOf"`), not detail-equality.
+    In a deployment that runs the handler directly with no schema
+    validator in front, row 10 reverts to detail-substring shape
+    carrying the handler's `"invalid token_type"` message —
+    re-pin per deployment topology.
+- **Joined errors.** If a future row removes more than one required
+  dimension, the server may join multiple messages into a single
+  `detail`, breaking the equality assertion. Either split into
+  separate rows (one rule per row) or fall back to a
+  `detail.includes('<distinctive substring>')` check — but **not**
+  `?? body contains "..."`, which is unreliable on httpyac 6.16.7
+  for `application/problem+json` bodies (see
+  `e2e-httpyac/references/format.md`).
 - **Rows intentionally omitted:** the internal "Manual configuration
   must not be set when type is llm" / "llm must not be set when type
   is manual" checks. The API discriminator-based converter never
   produces those mixed-shape inputs, so they aren't reachable through
   the public surface.
+- **Pinned 2026-04-28** against an OpenMeter deployment running
+  behind an OpenAPI binder gateway. Re-pin if the deployment
+  topology changes (binder added, removed, or upgraded) or the
+  framework wrapper is upgraded.
 
 ---
 
@@ -793,8 +822,19 @@ endpoints:
   - POST /features
   - GET /features/{featureId}
 entities: [feature]
-tags: [single-request, lookup-by-key]
+tags: [single-request, lookup-by-key, deployment-gated, skipped]
+status: skipped
 ```
+
+**Status: SKIPPED.** Deployment-gated. Verified 2026-04-28: in
+deployments fronted by Kong (or any gateway whose route patterns
+require `{featureId}` to look like a ULID), a `GET
+/features/<bare-key>` request is rejected at the gateway with `404
+"The requested entity was not found"` and never reaches the OpenMeter
+handler. The handler's by-id-or-key dispatch is therefore unreachable
+through the public surface in those topologies. Re-enable when
+running against a deployment that routes arbitrary path segments to
+the handler.
 
 **Intent:** `GET /features/{featureId}` accepts either a ULID id or
 the feature's `key` in the path. Lookup by key resolves to the same
@@ -823,6 +863,11 @@ feature.
   `feature_create_key_must_not_be_ulid`): if a key parsed as a ULID,
   the by-id-or-key dispatch in `GetByIdOrKey` would be ambiguous.
   This scenario is the positive read of the same dispatch.
+- **Gateway-routing dependency.** The Kong-fronted deployment we
+  pin tests against returns `404 "The requested entity was not
+  found"` (Kong's own response) for `GET /features/<bare-key>`. The
+  handler-level 404 (`"feature not found: <id>"`) is reachable only
+  via a ULID-shaped path segment.
 
 ---
 
@@ -1016,9 +1061,8 @@ tags: [list, sort, matrix]
 ```
 
 **Intent:** The `sort` query param accepts `key`, `name`,
-`created_at` (default), and `updated_at`, optionally suffixed with
-`:asc` (default) or `:desc`. Each combination returns features in
-the expected order.
+`created_at` (default), and `updated_at`. Each value returns features
+in ascending order on the named field.
 
 **Fixtures:**
 - Three `CreateFeatureRequest`s per **Baseline feature**, each with
@@ -1030,14 +1074,10 @@ the expected order.
 
 | # | `sort` value | Expected order of fixture entries (by `id`) |
 |---|---|---|
-| 1 | `key` (or `key:asc`) | sorted ascending by `key` |
-| 2 | `key:desc` | sorted descending by `key` |
-| 3 | `name` | sorted ascending by `name` |
-| 4 | `name:desc` | sorted descending by `name` |
-| 5 | `created_at` (or omitted — the default) | A, B, C |
-| 6 | `created_at:desc` | C, B, A |
-| 7 | `updated_at` | sorted ascending by `updated_at` |
-| 8 | `updated_at:desc` | sorted descending by `updated_at` |
+| 1 | `key` | sorted ascending by `key` |
+| 2 | `name` | sorted ascending by `name` |
+| 3 | `created_at` (or omitted — the default) | A, B, C |
+| 4 | `updated_at` | sorted ascending by `updated_at` |
 
 **Steps per row:**
 
@@ -1057,6 +1097,13 @@ the expected order.
   modification time, perform a no-op PATCH (e.g.
   `unit_cost: null` on a feature with no unit_cost) to bump
   `updated_at` predictably before the assertion.
+- **No `:asc` / `:desc` suffix.** Verified 2026-04-28 against a live
+  server: `sort=key:desc` (and the other `:desc` permutations)
+  returns 400 `"invalid feature order by: key:desc"` — the suffix is
+  not parsed and the entire string is treated as the field name.
+  Descending-sort scenarios are deferred until the server grows
+  syntax for it (whether `:desc` suffix, `-key` prefix, or a separate
+  `order` query param). Re-add rows once the syntax is pinned.
 
 ---
 
@@ -1083,10 +1130,10 @@ tags: [list, sort, validation, single-request]
 **Notes:**
 
 - **Error shape:** detail-substring at status 400.
-- The valid set is `{ key, name, created_at, updated_at }`. Suffix
-  `:asc` / `:desc` is parsed and stripped before validation, so
-  `key:zzz` (bad direction) is **schema-rule** territory rather
-  than detail-substring; not pinned by this scenario.
+- The valid set is `{ key, name, created_at, updated_at }`. The
+  server does not parse a direction suffix — it treats the entire
+  `sort` value as a field name (verified 2026-04-28). See
+  `feature_list_sort_by_supported_fields` for context.
 
 ---
 
@@ -1106,32 +1153,42 @@ This is the schema-rule shape, not the domain shape.
 
 **Rows:**
 
-| # | Query | Expect `field` match | Expect `rule` |
-|---|---|---|---|
-| 1 | `filter[meter_id][eq]=not-a-ulid` | `field` references `filter.meter_id.eq` (or its parent `filter.meter_id`) | `"format"` (ULID-format rejection) — `NEEDS-VERIFY: confirm exact rule string against a live server before relying on it` |
-| 2 | `filter[meter_id][zz]=01HXYZ...` | `field` references `filter.meter_id` (or `filter.meter_id.zz`) | `"additionalProperties"` (unknown property) — `NEEDS-VERIFY: confirm exact rule string against a live server before relying on it` |
+| # | Query | Expect `field` | Expect `rule` | Expect `reason` (substring) |
+|---|---|---|---|---|
+| 1 | `filter[meter_id][eq]=not-a-ulid` | `"meter_id"` | `"anyOf"` | — |
+| 2 | `filter[meter_id][zz]=01HXYZ...` | `"filter"` | `"format"` | `"filter[meter_id][zz]: unsupported operator"` |
 
 **Steps per row:**
 
 1. **List with malformed filter.** `GET /features?<row's query>`.
    - Expect `400 Bad Request`.
-   - Expect `invalid_parameters[]` is present and non-empty.
-   - Expect at least one entry where `field` references the row's
-     bad filter param **and** `rule` matches the row's expected
-     rule string.
+   - Expect `invalid_parameters[0].field` matches the row's expected
+     value, `invalid_parameters[0].rule` matches the row's expected
+     rule string, and (row 2 only) the response body contains the
+     row's expected reason substring.
 
 **Notes:**
 
 - **Error shape:** schema-rule (`invalid_parameters[]`), not
   detail-substring. Schema validation rejects before the request
   body is processed.
-- **Rule strings flagged NEEDS-VERIFY.** Both rule strings above
-  are reasonable defaults from the JSON Schema vocabulary the
-  binder uses, but the exact value is binder-implementation-specific
-  and may differ. Confirm against a live server before generating a
-  test. If a rule turns out to be unstable across releases, fall
-  back to asserting only `field` and drop the `rule` assertion for
-  that row.
+- **Why `anyOf` for row 1.** `filter[meter_id]` is typed as
+  `ULIDFieldFilter` — a TypeSpec union of either a bare ULID string
+  or an operator object (`{eq?, neq?, ...}`). Unions compile to
+  OpenAPI `anyOf`. When the value matches neither branch, the
+  binder reports the umbrella rule `anyOf` rather than which
+  branch was closest — by design, `anyOf` rejections don't say
+  "you almost matched branch 2."
+- **Umbrella-field binding for row 2.** When a sub-operator under
+  `filter[<key>]` is unknown, the binder reports the rejection at
+  the **umbrella `filter` field**, not at `filter.meter_id`. The
+  offending sub-key (e.g. `filter[meter_id][zz]`) only appears in
+  the `reason` string. Assertions that want to pin "this rejection
+  was about meter_id" must look at `reason` (or `body contains`),
+  not `field`.
+- **Pinned 2026-04-28** against an OpenMeter deployment running
+  behind an OpenAPI binder gateway. Re-pin if the binder layer is
+  replaced or upgraded.
 
 ---
 

--- a/e2e/specs/features.md
+++ b/e2e/specs/features.md
@@ -1,0 +1,1547 @@
+# E2E Scenario Specifications — Features
+
+Natural-language, runner-neutral description of e2e scenarios for the
+`/openmeter/features` endpoint family (and
+`/openmeter/features/{id}/cost/query` for cost query). Each
+`## Scenario` maps 1:1 to a target test function in any runner that
+consumes this spec.
+
+See the `e2e-nl` skill (`.agents/skills/e2e-nl/`) for format rules
+(`references/format.md`) and worked examples (`references/examples.md`).
+
+Features **do not have a draft/publish/archive lifecycle**. `DELETE` is a
+soft archive, `PATCH` only accepts `unit_cost`, and there is no
+`validation_errors` on the response body — validation rules fire at
+create-time or update-time only. No `draft-with-errors` shape applies.
+
+**Error-shape convention for this family:** almost all 4xx responses
+use the **detail-substring** shape (`problem.detail`), not the
+**domain code** shape. Schema-rule shape (`invalid_parameters[]`) only
+fires for malformed query params / bodies — i.e. requests that fail
+schema validation before the request body is processed.
+
+**GET by id vs. by key.** `GET /features/{featureId}` accepts either an
+id or a key. When the entity is not found, the by-id path returns the
+handler's 404 (`"feature not found: <id>"`), while the by-key path may
+be intercepted at the gateway layer with a different detail
+(`"The requested route was not found"`). For assertions on 4xx
+responses, prefer GET by id; reserve key lookup for positive
+resolution scenarios.
+
+---
+
+## Scenario list
+
+Index of scenarios in this file. Presence of a `## Scenario: <id>`
+section below is the source of truth for "this scenario exists" — the
+list is just a directory. Priority is a scheduling hint, not a
+commitment. Entries marked `NEEDS-VERIFY` have a rule the code doesn't
+fully pin down — confirm behavior against a live server before adding
+the corresponding `## Scenario` section.
+
+**p0 — happy path**
+
+- `feature_lifecycle` — Create static feature, get, list, patch to add/clear manual unit_cost, delete, get-after-delete. — shape: lifecycle — priority: p0
+
+**p1 — core validation**
+
+- `feature_create_duplicate_key_rejected` — Posting twice with the same key returns 409. — shape: single-request — priority: p1
+- `feature_create_key_must_not_be_ulid` — Posting a feature whose key parses as a ULID returns 400. — shape: single-request — priority: p1
+- `feature_create_meter_not_found_rejected` — Posting a feature referencing a non-existent meter returns 404 with detail `"meter not found: <id>"` (detail-substring shape). — shape: single-request — priority: p1
+- `feature_create_invalid_meter_aggregation_rejected` — Creating a feature whose meter aggregation is outside `{sum, count, unique_count, latest}` returns 400. — shape: single-request — priority: p1
+- `feature_create_invalid_meter_filter_key_rejected` — Meter filter key not in meter `group_by` returns 400. — shape: single-request — priority: p1
+- `feature_create_llm_unit_cost_without_meter_rejected` — LLM `unit_cost` with no associated meter returns 400. — shape: single-request — priority: p1
+- `feature_create_llm_property_not_in_meter_rejected` — LLM `provider_property` / `model_property` / `token_type_property` referencing a key absent from the meter's `group_by` returns 400. — shape: single-request — priority: p1
+- `feature_create_unit_cost_validation_matrix` — Matrix over manual/llm validation rules (type/payload mismatch, mutex of `provider` vs. `provider_property`, negative amount, invalid `token_type`). — shape: matrix — priority: p1
+- `feature_update_unit_cost_required` — PATCH with empty body (or without `unit_cost` key) returns 400 — `unit_cost` must be explicitly specified (either a value or `null`). — shape: single-request — priority: p1
+- `feature_update_llm_without_meter_rejected` — PATCH adding LLM `unit_cost` on a feature without a meter returns 400. — shape: single-request — priority: p1
+- `feature_update_nonexistent_rejected` — PATCH on a non-existent feature id returns 404. — shape: single-request — priority: p1
+- `feature_get_nonexistent_returns_404` — GET on a non-existent feature id returns 404. — shape: single-request — priority: p1
+- `feature_delete_nonexistent_returns_404` — DELETE on a non-existent feature id returns 404. — shape: single-request — priority: p1
+- `feature_get_by_key_resolves` — GET with `{featureId}` as the feature's key (not id) resolves to the feature. — shape: single-request — priority: p1
+
+**p1 — list filters, sort, pagination**
+
+- `feature_list_filter_by_meter_id` — `filter[meter_id][eq]=<id>` returns only features on that meter. — shape: single-request — priority: p1
+- `feature_list_filter_by_key` — `filter[key][eq]=<key>` returns matching features. — shape: single-request — priority: p1
+- `feature_list_filter_by_name` — `filter[name][eq]=<name>` returns matching features. — shape: single-request — priority: p1
+- `feature_list_combined_filters` — Combining `filter[meter_id]` + `filter[key]` narrows intersection. — shape: matrix — priority: p1
+- `feature_list_sort_by_supported_fields` — `sort=key`, `sort=name`, `sort=created_at`, `sort=updated_at` (with `:asc` / `:desc`) returns the expected order. — shape: matrix — priority: p1
+- `feature_list_sort_invalid_field_rejected` — `sort=<unknown_field>` returns 400 with schema-rule shape. — shape: single-request — priority: p1
+- `feature_list_filter_malformed_rejected` — Malformed filter value (unknown operator, bad ULID format on `filter[meter_id]`) returns 400 with schema-rule shape. — shape: single-request — priority: p1 — NEEDS-VERIFY: exact `rule` strings the OpenAPI binder emits for ULID-format and unknown-property rejections.
+- `feature_list_pagination` — `page[number]` + `page[size]` return the expected slice and response metadata. — shape: single-request — priority: p1
+
+**p1 — cost query**
+
+- `feature_cost_query_happy_path` — `POST /features/{id}/cost/query` with an empty body on a feature that has a meter and manual unit_cost returns 200 with `data[]` populated (at least one row; zero-usage yields `cost: "0"`, `usage: "0"`, `currency: "USD"`, and the default time window `1970-01-01T00:00:00Z` → `1970-01-01T00:01:00Z`). — shape: single-request — priority: p1
+- `feature_cost_query_nonexistent_feature_returns_404` — `POST /features/{id}/cost/query` on a non-existent id returns 404 with detail `"feature not found: <id>"`. — shape: single-request — priority: p1
+- `feature_cost_query_no_meter_rejected` — `POST /features/{id}/cost/query` on a feature without an associated meter returns 400 with detail `"feature <key> has no meter associated"`. — shape: single-request — priority: p1
+
+**p2 — edge cases**
+
+- `feature_archived_excluded_from_list` — After delete, the feature is not returned by a default list request. — shape: single-request — priority: p2
+- `feature_archived_get_returns_404` — After delete, GET returns 404 with detail `"feature not found: <id>"`. (TypeSpec allows 410 `Common.Gone` but the current server always returns 404.) — shape: single-request — priority: p2
+- `feature_llm_pricing_absent_when_unresolved` — GET of an LLM feature whose provider+model don't resolve in the LLM cost database returns 200 with no `pricing` block (silently absent; no error). — shape: single-request — priority: p2
+- `feature_llm_pricing_enriched_on_get` — GET of an LLM feature whose provider+model resolve returns a `pricing` block populated from the LLM cost database. — shape: single-request — priority: p2 — **SKIPPED:** environment-gated; deferred until the e2e stack seeds the LLM cost DB with a known `(openai, gpt-4)` price. Do not generate a test for this scenario.
+
+---
+
+## Baselines
+
+Named object shapes scenarios reference by name. Each names the API
+schema type (from TypeSpec under
+`api/spec/packages/aip/src/features/`, surfaced in `api/openapi.yaml`).
+
+### Baseline feature — `CreateFeatureRequest`
+
+The minimal valid feature — no meter reference, no unit cost. Scenarios
+mutate this shape per test intent (adding a meter reference, adding a
+`unit_cost`, changing the `key`, etc.).
+
+- `key`: unique; **must not parse as a valid ULID**.
+- `name`: `"Test Feature"`.
+
+Optional fields available for mutation:
+
+- `description`: string.
+- `meter`: `{ id: <meter_id>, filters?: <map of meter group-by key → filter string> }`.
+- `unit_cost`: discriminated union (`manual` | `llm`) — see the two sub-baselines below.
+- `labels`: map.
+
+### Baseline manual unit cost — `BillingFeatureManualUnitCost`
+
+Simplest valid manual cost. Amount is non-negative.
+
+- `type`: `"manual"`.
+- `amount`: `"5"`.
+
+### Baseline LLM unit cost (static) — `BillingFeatureLLMUnitCost`
+
+All three dimensions as static values. Requires the feature to have a
+meter associated. `pricing` is read-only and populated by the server on
+`GET` if the provider + model resolve against the LLM cost database.
+
+- `type`: `"llm"`.
+- `provider`: `"openai"`.
+- `model`: `"gpt-4"`.
+- `token_type`: `"input"`.
+
+### Baseline meter — `CreateMeterRequest`
+
+Minimal `count`-aggregation meter that any feature scenario can use as
+its meter reference. The key is unique per run.
+
+- `key`: unique.
+- `name`: `"Test Meter"`.
+- `event_type`: `"e2e_feature_test"`.
+- `aggregation`: `"count"`.
+- `dimensions`: omitted.
+
+### Baseline LLM-capable meter — `CreateMeterRequest`
+
+A meter with the three group-by dimensions an LLM unit cost may
+reference (`provider`, `model`, `token_type`). Used by scenarios that
+need a feature with `BillingFeatureLLMUnitCost` to validate cleanly.
+
+- `key`: unique.
+- `name`: `"Test LLM Meter"`.
+- `event_type`: `"e2e_llm_test"`.
+- `aggregation`: `"count"`.
+- `dimensions`: `{ provider: "$.provider", model: "$.model", token_type: "$.token_type" }`.
+
+---
+
+## Scenario: feature_lifecycle
+
+```yaml
+id: feature_lifecycle
+endpoints:
+  - POST /features
+  - GET /features/{id}
+  - GET /features
+  - PATCH /features/{id}
+  - DELETE /features/{id}
+entities: [feature]
+tags: [lifecycle, crud]
+```
+
+**Intent:** A feature moves through the CRUD lifecycle — create static
+feature, get, list, patch `unit_cost` to add then clear it, delete, and
+get-after-delete returns 404.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature**.
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created` with a `Feature` body.
+   - Expect `key` equals the fixture key.
+   - Expect `name` is `"Test Feature"`.
+   - Expect `meter` is absent.
+   - Expect `unit_cost` is absent.
+   - Expect `deleted_at` is absent.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Get feature.** `GET /features/{feature.id}`.
+   - Expect `200 OK`.
+   - Expect `id` equals `{feature.id}`.
+   - Expect `key` equals the fixture key.
+   - Expect `name` is `"Test Feature"`.
+
+3. **List features and find the created feature.**
+   `GET /features?page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect response `data[]` contains an entry with `id == {feature.id}`.
+   - Note: page size 1000 because the shared DB may push fresh rows
+     past the default page-1 window of 20.
+
+4. **Patch feature — set manual unit_cost.**
+   `PATCH /features/{feature.id}` with an `UpdateFeatureRequest`:
+   - `unit_cost`: per **Baseline manual unit cost**
+     (`{ type: "manual", amount: "5" }`).
+
+   Assertions:
+   - Expect `200 OK` with a `Feature` body.
+   - Expect `unit_cost.type` is `"manual"`.
+   - Expect `unit_cost.amount` is `"5"` (or a normalized equivalent;
+     the server trims trailing zeros, so `"5.00"` round-trips as
+     `"5"`).
+
+5. **Get feature — verify unit_cost persisted.**
+   `GET /features/{feature.id}`.
+   - Expect `200 OK`.
+   - Expect `unit_cost.type` is `"manual"`.
+   - Expect `unit_cost.amount` matches the value from step 4.
+
+6. **Patch feature — clear unit_cost.**
+   `PATCH /features/{feature.id}` with an `UpdateFeatureRequest`:
+   - `unit_cost`: `null`.
+
+   Assertions:
+   - Expect `200 OK`.
+   - Expect `unit_cost` is absent on the response.
+
+7. **Get feature — verify unit_cost cleared.**
+   `GET /features/{feature.id}`.
+   - Expect `200 OK`.
+   - Expect `unit_cost` is absent.
+
+8. **Delete feature.** `DELETE /features/{feature.id}`.
+   - Expect `204 No Content`.
+
+9. **Get feature after deletion.** `GET /features/{feature.id}`.
+   - Expect `404 Not Found`.
+   - Expect **detail contains** `"feature not found: {feature.id}"`.
+
+**Notes:**
+
+- **Validation moment:** all assertions in this scenario are at
+  `create-time`, `GET-time` (reads), or `update-time` (PATCH). There is
+  no publish or archive flow on features.
+- **`unit_cost` presence semantics.** `UpdateFeatureRequest.unit_cost`
+  uses `specified | value | null` semantics: omitting the key entirely
+  is not allowed (a PATCH without `unit_cost` is rejected, covered in
+  `feature_update_unit_cost_required`). Passing `null` clears the
+  value; passing an object replaces it.
+- **Get-after-delete status code.** The TypeSpec for `get-feature`
+  declares both `Common.NotFound` (404) and `Common.Gone` (410) as
+  possible responses. **Verified against a live server:** the server
+  always returns 404 with detail `"feature not found: <id>"` — the
+  410 path is aspirational. Pin 404 + detail-substring shape.
+- **Decimal normalization.** `amount` strings are normalized on
+  round-trip — trailing zeros trimmed. Assertions on numeric strings
+  should match the normalized form.
+- **No include-archived.** v3 has no `include_archived` query param on
+  list or get; a deleted feature is unreachable via the public API.
+  This is a known parity gap with v1.
+
+---
+
+## Scenario: feature_create_duplicate_key_rejected
+
+```yaml
+id: feature_create_duplicate_key_rejected
+endpoints:
+  - POST /features
+entities: [feature]
+tags: [validation, create-time, single-request, conflict]
+```
+
+**Intent:** Posting two features with the same `key` in the same
+namespace returns `409 Conflict` on the second attempt.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature**.
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Create again with the same key.** `POST /features` with a body
+   reusing the **same `key`** as `{feature.key}` (`name` may differ).
+   - Expect `409 Conflict`.
+   - Expect **detail contains** `"with key {feature.key} already exists"`.
+
+**Notes:**
+
+- **Validation moment:** create-time. The duplicate is detected
+  before any state is committed — there is no partial create.
+- **Error shape:** detail-substring (`problem.detail`).
+
+---
+
+## Scenario: feature_create_key_must_not_be_ulid
+
+```yaml
+id: feature_create_key_must_not_be_ulid
+endpoints:
+  - POST /features
+entities: [feature]
+tags: [validation, create-time, single-request]
+```
+
+**Intent:** A feature whose `key` parses as a ULID is rejected at
+create-time. This protects the GET-by-id-or-key dispatch from
+ambiguity.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature** with `key`
+  overridden to a ULID literal (e.g. `"01HXYZABCDEFGHJKMNPQRSTVWX"`).
+
+**Steps:**
+
+1. **Create with ULID-shaped key.** `POST /features` with the fixture.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains** `"Feature key cannot be a valid ULID"`.
+
+**Notes:**
+
+- **Validation moment:** create-time, before any state is committed.
+- **Error shape:** detail-substring.
+
+---
+
+## Scenario: feature_create_meter_not_found_rejected
+
+```yaml
+id: feature_create_meter_not_found_rejected
+endpoints:
+  - POST /features
+entities: [feature]
+tags: [validation, create-time, single-request, not-found]
+```
+
+**Intent:** Posting a feature whose `meter.id` does not resolve to any
+meter in the namespace returns `404 Not Found`. The handler resolves
+the meter reference before persisting the feature.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature** with `meter`
+  overridden to `{ id: "<random-ULID-not-in-DB>" }`. Use a freshly
+  generated ULID literal to guarantee no collision.
+
+**Steps:**
+
+1. **Create referencing missing meter.** `POST /features` with the
+   fixture.
+   - Expect `404 Not Found`.
+   - Expect **detail contains** `"meter not found: <id>"` (the
+     literal id used in the request body).
+
+**Notes:**
+
+- **Validation moment:** create-time, before any state is committed.
+- **Error shape:** detail-substring at status 404.
+
+---
+
+## Scenario: feature_create_invalid_meter_aggregation_rejected
+
+```yaml
+id: feature_create_invalid_meter_aggregation_rejected
+endpoints:
+  - POST /meters
+  - POST /features
+entities: [feature, meter]
+tags: [validation, create-time, single-request]
+```
+
+**Intent:** Features can only be associated with meters whose
+aggregation is one of `{ sum, count, unique_count, latest }`. Posting
+a feature against a meter with any other aggregation
+(`avg` / `min` / `max`) returns `400 Bad Request`.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline meter** with
+  `aggregation` overridden to `"avg"` and `value_property` set to
+  `"$.value"` (avg requires a value property).
+- A `CreateFeatureRequest` per **Baseline feature** with `meter`
+  overridden to `{ id: {meter.id} }`.
+
+**Steps:**
+
+1. **Create meter with avg aggregation.** `POST /meters` with the
+   meter fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `meter` ← `response.body`
+
+2. **Create feature against the meter.** `POST /features` with the
+   feature fixture (referencing `{meter.id}`).
+   - Expect `400 Bad Request`.
+   - Expect **detail contains** `"features can only be created for"`
+     (the message also enumerates `sum, count, unique_count, latest`
+     in some order).
+
+**Notes:**
+
+- **Validation moment:** create-time. The aggregation check happens
+  after the meter reference resolves but before any feature state
+  is committed.
+- **Error shape:** detail-substring at status 400.
+
+---
+
+## Scenario: feature_create_invalid_meter_filter_key_rejected
+
+```yaml
+id: feature_create_invalid_meter_filter_key_rejected
+endpoints:
+  - POST /meters
+  - POST /features
+entities: [feature, meter]
+tags: [validation, create-time, single-request]
+```
+
+**Intent:** Meter filter keys (`meter.filters`) must reference a key
+that exists in the meter's `dimensions` (group-by). Posting a feature
+whose `meter.filters` references an unknown key returns `400`.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline meter** with `dimensions`
+  overridden to `{ region: "$.region" }`.
+- A `CreateFeatureRequest` per **Baseline feature** with `meter`
+  overridden to:
+  - `id`: `{meter.id}`.
+  - `filters`: `{ unknown_key: { eq: "x" } }`.
+
+**Steps:**
+
+1. **Create meter with a single dimension.** `POST /meters` with the
+   meter fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `meter` ← `response.body`
+
+2. **Create feature with bad filter key.** `POST /features` with the
+   feature fixture.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains** `"filter key \"unknown_key\" is not a
+     valid dimension of meter"`.
+
+**Notes:**
+
+- **Validation moment:** create-time, before any state is committed.
+- **Error shape:** detail-substring.
+
+---
+
+## Scenario: feature_create_llm_unit_cost_without_meter_rejected
+
+```yaml
+id: feature_create_llm_unit_cost_without_meter_rejected
+endpoints:
+  - POST /features
+entities: [feature]
+tags: [validation, create-time, single-request, llm]
+```
+
+**Intent:** Posting a feature with an `llm` unit cost but no `meter`
+reference returns `400`. LLM unit cost requires a meter.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature** with:
+  - `meter`: omitted.
+  - `unit_cost`: per **Baseline LLM unit cost (static)**.
+
+**Steps:**
+
+1. **Create LLM feature without meter.** `POST /features` with the
+   fixture.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains**
+     `"LLM unit cost requires a meter to be associated with the feature"`.
+
+**Notes:**
+
+- **Validation moment:** create-time. Inner unit-cost validation
+  runs first; the meter-presence check fires next.
+- **Error shape:** detail-substring.
+
+---
+
+## Scenario: feature_create_llm_property_not_in_meter_rejected
+
+```yaml
+id: feature_create_llm_property_not_in_meter_rejected
+endpoints:
+  - POST /meters
+  - POST /features
+entities: [feature, meter]
+tags: [validation, create-time, single-request, llm]
+```
+
+**Intent:** When an LLM unit cost uses `*_property` to reference a
+meter group-by key, that key must exist in the meter's `dimensions`.
+Posting a feature whose LLM unit cost references an absent property
+returns `400`.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline meter** with `dimensions`
+  overridden to `{ provider: "$.provider", model: "$.model" }` (note:
+  `token_type` deliberately omitted).
+- A `CreateFeatureRequest` per **Baseline feature** with:
+  - `meter`: `{ id: {meter.id} }`.
+  - `unit_cost`: a `BillingFeatureLLMUnitCost` with:
+    - `type`: `"llm"`.
+    - `provider_property`: `"provider"`.
+    - `model_property`: `"model"`.
+    - `token_type_property`: `"token_type"` (the missing one).
+
+**Steps:**
+
+1. **Create meter without `token_type` dimension.** `POST /meters`.
+   - Expect `201 Created`.
+
+   Captures:
+   - `meter` ← `response.body`
+
+2. **Create LLM feature referencing missing property.**
+   `POST /features` with the feature fixture.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains**
+     `"token_type_property \"token_type\" not found in meter group-by keys"`.
+
+**Notes:**
+
+- **Validation moment:** create-time. `UnitCost.ValidateWithMeter`
+  runs after the basic shape checks pass and the meter is resolved.
+- **Error shape:** detail-substring.
+- The same shape applies symmetrically for `provider_property` and
+  `model_property`. One row covers the family; the matrix scenario
+  exercises the others if needed.
+
+---
+
+## Scenario: feature_create_unit_cost_validation_matrix
+
+```yaml
+id: feature_create_unit_cost_validation_matrix
+endpoints:
+  - POST /meters
+  - POST /features
+entities: [feature, meter]
+tags: [matrix, validation, create-time, llm, manual]
+```
+
+**Intent:** Pin the create-time validation rules for `unit_cost`
+across both manual and LLM shapes — required-field, mutex, range,
+and enum checks — that the public API can actually surface. Each row
+exercises one rule against a fresh fixture.
+
+**Fixtures (built fresh per row):**
+- A `CreateMeterRequest` per **Baseline LLM-capable meter** (created
+  fresh for any row whose feature references a meter).
+- A `CreateFeatureRequest` per **Baseline feature** with:
+  - `meter`: `{ id: {meter.id} }` (every row that needs an LLM
+    unit cost also creates the meter above).
+  - `unit_cost`: per the row's column.
+
+**Rows:**
+
+| # | Mutation from baseline (`type` + payload) | Expect | Detail contains |
+|---|---|---|---|
+| 1 | manual baseline (`type: manual`, `amount: "5"`); no meter | `201 Created` | — |
+| 2 | LLM baseline (static provider/model/token_type); meter attached | `201 Created` | — |
+| 3 | manual with `amount: "-1"`; no meter | `400 Bad Request` | `"manual unit cost amount must be non-negative"` |
+| 4 | LLM with both `provider: "openai"` and `provider_property: "provider"`; meter attached | `400 Bad Request` | `"provider_property and provider are mutually exclusive"` |
+| 5 | LLM with both `model: "gpt-4"` and `model_property: "model"`; meter attached | `400 Bad Request` | `"model_property and model are mutually exclusive"` |
+| 6 | LLM with both `token_type: "input"` and `token_type_property: "token_type"`; meter attached | `400 Bad Request` | `"token_type_property and token_type are mutually exclusive"` |
+| 7 | LLM with no `provider` and no `provider_property` (model + token_type still set); meter attached | `400 Bad Request` | `"either provider_property or provider is required for LLM unit cost"` |
+| 8 | LLM with no `model` and no `model_property` (provider + token_type still set); meter attached | `400 Bad Request` | `"either model_property or model is required for LLM unit cost"` |
+| 9 | LLM with no `token_type` and no `token_type_property` (provider + model still set); meter attached | `400 Bad Request` | `"either token_type_property or token_type is required for LLM unit cost"` |
+| 10 | LLM baseline with `token_type: "banana"`; meter attached | `400 Bad Request` | `"invalid token_type \"banana\""` |
+
+**Steps per row:**
+
+1. **(If the row needs a meter)** `POST /meters` with the meter
+   fixture.
+   - Expect `201 Created`.
+   - Captures: `meter` ← `response.body`.
+2. **Create feature.** `POST /features` with the feature fixture for
+   the row.
+   - Expect the row's `Expect` status.
+   - If 4xx, expect **detail contains** the row's `Detail contains`
+     substring.
+   - If 2xx, expect the response body parses as a `Feature`.
+
+**Notes:**
+
+- **Validation moment:** create-time. All rows fire before insert.
+- **Error shape:** detail-substring. The features family does not
+  use the **domain code** shape (`extensions.validationErrors[]`).
+- **Joined errors.** When a row removes more than one required
+  dimension, the server may surface multiple messages joined into a
+  single `detail`. Detail-substring matches still pass — pin one
+  distinctive substring per row rather than asserting the full
+  message.
+- **Rows intentionally omitted:** the internal "Manual configuration
+  must not be set when type is llm" / "llm must not be set when type
+  is manual" checks. The API discriminator-based converter never
+  produces those mixed-shape inputs, so they aren't reachable through
+  the public surface.
+
+---
+
+## Scenario: feature_update_unit_cost_required
+
+```yaml
+id: feature_update_unit_cost_required
+endpoints:
+  - POST /features
+  - PATCH /features/{id}
+entities: [feature]
+tags: [validation, update-time, single-request]
+```
+
+**Intent:** `PATCH /features/{id}` requires the body to **explicitly
+specify** the `unit_cost` field (either a value or `null`). An empty
+body — or one without `unit_cost` — is rejected.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature**.
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Patch with empty body.** `PATCH /features/{feature.id}` with
+   request body `{}`.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains** `"unitCost is required"`.
+
+**Notes:**
+
+- **Validation moment:** update-time. The body shape is rejected
+  before any state is committed.
+- **Error shape:** detail-substring.
+- **Tri-state semantics:** `unit_cost` uses
+  *unspecified | value | null* tracking. `unspecified` (key absent)
+  is rejected; `null` clears; an object replaces.
+
+---
+
+## Scenario: feature_update_llm_without_meter_rejected
+
+```yaml
+id: feature_update_llm_without_meter_rejected
+endpoints:
+  - POST /features
+  - PATCH /features/{id}
+entities: [feature]
+tags: [validation, update-time, single-request, llm]
+```
+
+**Intent:** PATCHing an LLM `unit_cost` onto a feature that has no
+associated meter returns `400`. Same rule as create-time, applied at
+update.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature** (no meter).
+- An `UpdateFeatureRequest` body with `unit_cost` per **Baseline LLM
+  unit cost (static)**.
+
+**Steps:**
+
+1. **Create static feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Patch with LLM unit cost.** `PATCH /features/{feature.id}` with
+   the update body.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains**
+     `"LLM unit cost requires a meter to be associated with the feature"`.
+
+**Notes:**
+
+- **Validation moment:** update-time, before any state is committed.
+- **Error shape:** detail-substring.
+
+---
+
+## Scenario: feature_update_nonexistent_rejected
+
+```yaml
+id: feature_update_nonexistent_rejected
+endpoints:
+  - PATCH /features/{id}
+entities: [feature]
+tags: [validation, update-time, single-request, not-found]
+```
+
+**Intent:** PATCHing an id that doesn't resolve returns `404`.
+
+**Fixtures:**
+- An `UpdateFeatureRequest` body with `unit_cost: null` (a syntactically
+  valid clear). Use a freshly generated ULID literal in the path —
+  guaranteed not to exist in the DB.
+
+**Steps:**
+
+1. **Patch unknown id.** `PATCH /features/<random-ULID-not-in-DB>` with
+   the body.
+   - Expect `404 Not Found`.
+   - Expect **detail contains** `"feature not found: <id>"` (the
+     literal id used in the path).
+
+**Notes:**
+
+- **Validation moment:** update-time. The feature is resolved before
+  any update is applied; missing → 404.
+- **Error shape:** detail-substring at status 404.
+
+---
+
+## Scenario: feature_get_nonexistent_returns_404
+
+```yaml
+id: feature_get_nonexistent_returns_404
+endpoints:
+  - GET /features/{id}
+entities: [feature]
+tags: [single-request, not-found]
+```
+
+**Intent:** GET on an unknown id returns `404` with the standard
+detail substring.
+
+**Fixtures:** *(none — the request is path-only)*.
+
+**Steps:**
+
+1. **Get unknown id.** `GET /features/<random-ULID-not-in-DB>`.
+   - Expect `404 Not Found`.
+   - Expect **detail contains** `"feature not found: <id>"`.
+
+**Notes:**
+
+- **Error shape:** detail-substring.
+- **GET by id vs. by key.** Lookup by key on a missing feature may
+  surface a different gateway-level detail (`"The requested route
+  was not found"`). This scenario uses a ULID-shaped path segment to
+  exercise the handler's own 404, not the gateway.
+
+---
+
+## Scenario: feature_delete_nonexistent_returns_404
+
+```yaml
+id: feature_delete_nonexistent_returns_404
+endpoints:
+  - DELETE /features/{id}
+entities: [feature]
+tags: [single-request, not-found]
+```
+
+**Intent:** DELETE on an unknown id returns `404`.
+
+**Fixtures:** *(none — the request is path-only)*.
+
+**Steps:**
+
+1. **Delete unknown id.** `DELETE /features/<random-ULID-not-in-DB>`.
+   - Expect `404 Not Found`.
+   - Expect **detail contains** `"feature not found: <id>"`.
+
+**Notes:**
+
+- **Error shape:** detail-substring.
+
+---
+
+## Scenario: feature_get_by_key_resolves
+
+```yaml
+id: feature_get_by_key_resolves
+endpoints:
+  - POST /features
+  - GET /features/{featureId}
+entities: [feature]
+tags: [single-request, lookup-by-key]
+```
+
+**Intent:** `GET /features/{featureId}` accepts either a ULID id or
+the feature's `key` in the path. Lookup by key resolves to the same
+feature.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature**.
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Get by key.** `GET /features/{feature.key}` (the path segment is
+   the feature's `key`, not its `id`).
+   - Expect `200 OK`.
+   - Expect `id` equals `{feature.id}`.
+   - Expect `key` equals `{feature.key}`.
+
+**Notes:**
+
+- **Why ULID-shaped keys are forbidden** (see
+  `feature_create_key_must_not_be_ulid`): if a key parsed as a ULID,
+  the by-id-or-key dispatch in `GetByIdOrKey` would be ambiguous.
+  This scenario is the positive read of the same dispatch.
+
+---
+
+## Scenario: feature_list_filter_by_meter_id
+
+```yaml
+id: feature_list_filter_by_meter_id
+endpoints:
+  - POST /meters
+  - POST /features
+  - GET /features
+entities: [feature, meter]
+tags: [list, filter, single-request]
+```
+
+**Intent:** `GET /features?filter[meter_id][eq]=<id>` returns only
+features whose `meter.id` equals the given ULID.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline meter** (call it meter A).
+- A second `CreateMeterRequest` per **Baseline meter** (meter B).
+- A `CreateFeatureRequest` per **Baseline feature** with
+  `meter: { id: {meter_a.id} }` (feature A).
+- A second `CreateFeatureRequest` per **Baseline feature** with
+  `meter: { id: {meter_b.id} }` (feature B).
+
+**Steps:**
+
+1. **Provision both meters and both features.** Four `POST` calls,
+   capturing each response body. Each `POST` expects `201 Created`.
+
+2. **List filtered by meter A.**
+   `GET /features?filter[meter_id][eq]={meter_a.id}&page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect response `data[]` contains an entry with
+     `id == {feature_a.id}`.
+   - Expect response `data[]` does **not** contain
+     `id == {feature_b.id}`.
+
+**Notes:**
+
+- **Filter operator.** ULID fields support `eq`, `neq`, `oeq`. Bare
+  ULID (`filter[meter_id]=<id>`) is also accepted by the schema.
+  This scenario pins the explicit `eq` form; downstream generators
+  may exercise alternates.
+- Page size is bumped to 1000 to handle a shared-DB drift past
+  page-1.
+
+---
+
+## Scenario: feature_list_filter_by_key
+
+```yaml
+id: feature_list_filter_by_key
+endpoints:
+  - POST /features
+  - GET /features
+entities: [feature]
+tags: [list, filter, single-request]
+```
+
+**Intent:** `GET /features?filter[key][eq]=<key>` returns the matching
+feature.
+
+**Fixtures:**
+- Two `CreateFeatureRequest`s per **Baseline feature**, each with a
+  distinct unique `key`.
+
+**Steps:**
+
+1. **Create both features.** Two `POST /features` calls; each
+   expects `201 Created`. Capture both response bodies as
+   `feature_a` and `feature_b`.
+
+2. **List filtered by feature A's key.**
+   `GET /features?filter[key][eq]={feature_a.key}&page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect `data[]` contains an entry with `id == {feature_a.id}`.
+   - Expect `data[]` does **not** contain `id == {feature_b.id}`.
+
+**Notes:**
+
+- **Filter operator.** `key` is a `StringFieldFilter`; supports `eq`,
+  `neq`, `contains`, `ocontains`, `oeq`, `gt`/`gte`/`lt`/`lte`,
+  `exists`, or a bare string (interpreted as `eq`).
+
+---
+
+## Scenario: feature_list_filter_by_name
+
+```yaml
+id: feature_list_filter_by_name
+endpoints:
+  - POST /features
+  - GET /features
+entities: [feature]
+tags: [list, filter, single-request]
+```
+
+**Intent:** `GET /features?filter[name][eq]=<name>` returns the
+matching feature.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature** with `name`
+  overridden to a unique distinctive value (e.g.
+  `"Test Feature ListByName <unique-suffix>"`).
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **List filtered by name.**
+   `GET /features?filter[name][eq]={feature.name}&page[size]=1000`
+   (URL-encode the name).
+   - Expect `200 OK`.
+   - Expect `data[]` contains exactly the feature with
+     `id == {feature.id}` (the unique-suffix guarantees no other
+     match in a shared DB).
+
+**Notes:**
+
+- The unique suffix on `name` is what keeps the list narrow on a
+  shared DB; without it the assertion would have to allow noise.
+
+---
+
+## Scenario: feature_list_combined_filters
+
+```yaml
+id: feature_list_combined_filters
+endpoints:
+  - POST /meters
+  - POST /features
+  - GET /features
+entities: [feature, meter]
+tags: [list, filter, matrix]
+```
+
+**Intent:** Combining multiple filter fields narrows the result to
+the intersection. `filter[meter_id]` AND `filter[key]` together
+return only features matching both.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline meter** (meter A) and a
+  second one (meter B).
+- Four `CreateFeatureRequest`s per **Baseline feature**:
+  - feature_a1 with meter A and key `"alpha_<suffix1>"`.
+  - feature_a2 with meter A and key `"beta_<suffix2>"`.
+  - feature_b1 with meter B and key `"alpha_<suffix3>"`.
+  - feature_b2 with meter B and key `"beta_<suffix4>"`.
+
+**Rows:**
+
+| # | Filter | Expected ids in `data[]` |
+|---|---|---|
+| 1 | `filter[meter_id][eq]={meter_a.id}` only | `{feature_a1.id}` and `{feature_a2.id}` |
+| 2 | `filter[key][eq]={feature_a1.key}` only | `{feature_a1.id}` only |
+| 3 | both `filter[meter_id][eq]={meter_a.id}` and `filter[key][eq]={feature_b1.key}` | empty (intersection) |
+
+**Steps per row:**
+
+1. **List with row's filters.**
+   `GET /features?<row's query>&page[size]=1000`.
+   - Expect `200 OK`.
+   - For each id listed in the `Expected ids` cell, expect an entry
+     with `id == <captured id>` to be present in `data[]`.
+   - For ids not in the cell that exist in the fixture set, expect
+     them **absent** from `data[]`.
+
+**Notes:**
+
+- The "empty intersection" row pins AND-semantics: filters compose,
+  they don't union.
+- Page size 1000 to absorb shared-DB noise.
+
+---
+
+## Scenario: feature_list_sort_by_supported_fields
+
+```yaml
+id: feature_list_sort_by_supported_fields
+endpoints:
+  - POST /features
+  - GET /features
+entities: [feature]
+tags: [list, sort, matrix]
+```
+
+**Intent:** The `sort` query param accepts `key`, `name`,
+`created_at` (default), and `updated_at`, optionally suffixed with
+`:asc` (default) or `:desc`. Each combination returns features in
+the expected order.
+
+**Fixtures:**
+- Three `CreateFeatureRequest`s per **Baseline feature**, each with
+  distinct unique-suffix `key` and `name` values, **created in
+  predictable order** (e.g. A, then B, then C, far enough apart in
+  time that `created_at` strictly orders them).
+
+**Rows:**
+
+| # | `sort` value | Expected order of fixture entries (by `id`) |
+|---|---|---|
+| 1 | `key` (or `key:asc`) | sorted ascending by `key` |
+| 2 | `key:desc` | sorted descending by `key` |
+| 3 | `name` | sorted ascending by `name` |
+| 4 | `name:desc` | sorted descending by `name` |
+| 5 | `created_at` (or omitted — the default) | A, B, C |
+| 6 | `created_at:desc` | C, B, A |
+| 7 | `updated_at` | sorted ascending by `updated_at` |
+| 8 | `updated_at:desc` | sorted descending by `updated_at` |
+
+**Steps per row:**
+
+1. **List with row's `sort`.**
+   `GET /features?sort=<row's value>&page[size]=1000`.
+   - Expect `200 OK`.
+   - Filter `data[]` to entries whose `id` is in
+     `{ {feature_a.id}, {feature_b.id}, {feature_c.id} }`, then
+     compare the resulting order against the row's expected order.
+
+**Notes:**
+
+- **Why filter the result.** A shared DB carries other features.
+  The row asserts the relative order of the three fixtures, not the
+  absolute contents of `data[]`.
+- **Updated-at ordering.** If `updated_at` rows depend on a known
+  modification time, perform a no-op PATCH (e.g.
+  `unit_cost: null` on a feature with no unit_cost) to bump
+  `updated_at` predictably before the assertion.
+
+---
+
+## Scenario: feature_list_sort_invalid_field_rejected
+
+```yaml
+id: feature_list_sort_invalid_field_rejected
+endpoints:
+  - GET /features
+entities: [feature]
+tags: [list, sort, validation, single-request]
+```
+
+**Intent:** `sort=<unknown_field>` returns `400 Bad Request`.
+
+**Fixtures:** *(none)*.
+
+**Steps:**
+
+1. **List with bad sort field.** `GET /features?sort=banana`.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains** `"invalid feature order by: banana"`.
+
+**Notes:**
+
+- **Error shape:** detail-substring at status 400.
+- The valid set is `{ key, name, created_at, updated_at }`. Suffix
+  `:asc` / `:desc` is parsed and stripped before validation, so
+  `key:zzz` (bad direction) is **schema-rule** territory rather
+  than detail-substring; not pinned by this scenario.
+
+---
+
+## Scenario: feature_list_filter_malformed_rejected
+
+```yaml
+id: feature_list_filter_malformed_rejected
+endpoints:
+  - GET /features
+entities: [feature]
+tags: [list, filter, validation, single-request]
+```
+
+**Intent:** A filter expression the OpenAPI binder cannot parse
+returns `400 Bad Request` with `invalid_parameters[]` populated.
+This is the schema-rule shape, not the domain shape.
+
+**Rows:**
+
+| # | Query | Expect `field` match | Expect `rule` |
+|---|---|---|---|
+| 1 | `filter[meter_id][eq]=not-a-ulid` | `field` references `filter.meter_id.eq` (or its parent `filter.meter_id`) | `"format"` (ULID-format rejection) — `NEEDS-VERIFY: confirm exact rule string against a live server before relying on it` |
+| 2 | `filter[meter_id][zz]=01HXYZ...` | `field` references `filter.meter_id` (or `filter.meter_id.zz`) | `"additionalProperties"` (unknown property) — `NEEDS-VERIFY: confirm exact rule string against a live server before relying on it` |
+
+**Steps per row:**
+
+1. **List with malformed filter.** `GET /features?<row's query>`.
+   - Expect `400 Bad Request`.
+   - Expect `invalid_parameters[]` is present and non-empty.
+   - Expect at least one entry where `field` references the row's
+     bad filter param **and** `rule` matches the row's expected
+     rule string.
+
+**Notes:**
+
+- **Error shape:** schema-rule (`invalid_parameters[]`), not
+  detail-substring. Schema validation rejects before the request
+  body is processed.
+- **Rule strings flagged NEEDS-VERIFY.** Both rule strings above
+  are reasonable defaults from the JSON Schema vocabulary the
+  binder uses, but the exact value is binder-implementation-specific
+  and may differ. Confirm against a live server before generating a
+  test. If a rule turns out to be unstable across releases, fall
+  back to asserting only `field` and drop the `rule` assertion for
+  that row.
+
+---
+
+## Scenario: feature_list_pagination
+
+```yaml
+id: feature_list_pagination
+endpoints:
+  - POST /features
+  - GET /features
+entities: [feature]
+tags: [list, pagination, single-request]
+```
+
+**Intent:** `page[number]` + `page[size]` slice the result and
+populate the response `meta` block. Page size 1 over three fixtures
+yields three pages.
+
+**Fixtures:**
+- Three `CreateFeatureRequest`s per **Baseline feature**, each with
+  a distinct `key` and a **shared `name` prefix** (e.g.
+  `"e2e_pagination_<suffix>"`). The shared prefix makes the per-row
+  filter narrow without depending on absolute DB state.
+
+**Steps:**
+
+1. **Provision three features.** Three `POST /features` calls; each
+   `201 Created`. Capture the three response bodies.
+
+2. **List page 1, size 1, filtered to fixtures.**
+   `GET /features?filter[name][contains]=<shared-prefix>&page[number]=1&page[size]=1`.
+   - Expect `200 OK`.
+   - Expect `data[]` has length `1`.
+   - Expect `meta.page.total` is `3`.
+   - Expect `meta.page.number` is `1`.
+   - Expect `meta.page.size` is `1`.
+
+3. **List page 2.** Same filter, `page[number]=2&page[size]=1`.
+   - Expect `200 OK`.
+   - Expect `data[]` has length `1`.
+   - Expect `meta.page.number` is `2`.
+   - Expect the entry differs from page 1's entry by `id`.
+
+4. **List page 3.** Same filter, `page[number]=3&page[size]=1`.
+   - Expect `200 OK`.
+   - Expect `data[]` has length `1`.
+   - Expect `meta.page.number` is `3`.
+   - Expect the entry differs from pages 1 and 2 by `id`.
+
+5. **Assert union covers fixtures.** The three captured ids equal the
+   union of the three pages' single-entry ids (in some order).
+
+**Notes:**
+
+- **Why `contains` on the name** instead of `eq` per-feature? `eq`
+  collapses to one row (no pagination to test). The shared-prefix
+  `contains` filter narrows to exactly the three fixtures.
+- **Pagination meta shape:** `meta.page.{number, size, total}` per
+  the `PaginatedMeta` / `PageMeta` schema in the OpenAPI spec.
+
+---
+
+## Scenario: feature_cost_query_happy_path
+
+```yaml
+id: feature_cost_query_happy_path
+endpoints:
+  - POST /meters
+  - POST /features
+  - POST /features/{id}/cost/query
+entities: [feature, meter]
+tags: [cost-query, single-request]
+```
+
+**Intent:** `POST /features/{id}/cost/query` with an empty body on a
+metered feature with a manual unit cost returns `200 OK` and a
+`FeatureCostQueryResult` with at least one row. Zero usage yields
+`cost: "0"`, `usage: "0"`, `currency: "USD"`, and the default time
+window `1970-01-01T00:00:00Z` → `1970-01-01T00:01:00Z`.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline meter**.
+- A `CreateFeatureRequest` per **Baseline feature** with:
+  - `meter`: `{ id: {meter.id} }`.
+  - `unit_cost`: per **Baseline manual unit cost**.
+
+**Steps:**
+
+1. **Create meter.** `POST /meters` with the meter fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `meter` ← `response.body`
+
+2. **Create metered feature with manual unit cost.**
+   `POST /features` with the feature fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+3. **Query cost with empty body.**
+   `POST /features/{feature.id}/cost/query` with body `{}`.
+   - Expect `200 OK`.
+   - Expect `data` is a non-empty list (at least one row).
+   - Expect `data[0].cost` is `"0"` (or `null` if the row has no
+     resolved pricing — both are valid for zero usage; pin
+     whichever the live server emits).
+   - Expect `data[0].usage` is `"0"`.
+   - Expect `data[0].currency` is `"USD"`.
+   - Expect `data[0].from` is `"1970-01-01T00:00:00Z"`.
+   - Expect `data[0].to` is `"1970-01-01T00:01:00Z"`.
+
+**Notes:**
+
+- **Validation moment:** none — this is a positive read.
+- **Empty body.** The endpoint accepts a missing body via
+  `request.ParseOptionalBody`; an empty `{}` is the canonical empty
+  shape. The default time window when neither `from` nor `to` is
+  provided is the unix epoch + 60s — confirmed against a live
+  server.
+- **Manual unit cost makes `cost` resolvable.** With an LLM unit
+  cost, `cost` may be `null` for unresolved pricing. Manual costs
+  always resolve as `usage × amount` (here `0 × 5 = 0`).
+
+---
+
+## Scenario: feature_cost_query_nonexistent_feature_returns_404
+
+```yaml
+id: feature_cost_query_nonexistent_feature_returns_404
+endpoints:
+  - POST /features/{id}/cost/query
+entities: [feature]
+tags: [cost-query, single-request, not-found]
+```
+
+**Intent:** `POST /features/{id}/cost/query` on an unknown feature id
+returns `404` with the standard detail substring.
+
+**Fixtures:** *(none — the request is path-only)*.
+
+**Steps:**
+
+1. **Query cost on missing feature.**
+   `POST /features/<random-ULID-not-in-DB>/cost/query` with body `{}`.
+   - Expect `404 Not Found`.
+   - Expect **detail contains** `"feature not found: <id>"`.
+
+**Notes:**
+
+- **Error shape:** detail-substring.
+- The feature is resolved first, so the 404 fires before any meter
+  or query-param processing — body shape doesn't matter for this
+  failure mode.
+
+---
+
+## Scenario: feature_cost_query_no_meter_rejected
+
+```yaml
+id: feature_cost_query_no_meter_rejected
+endpoints:
+  - POST /features
+  - POST /features/{id}/cost/query
+entities: [feature]
+tags: [cost-query, validation, single-request]
+```
+
+**Intent:** `POST /features/{id}/cost/query` on a feature with no
+associated meter returns `400 Bad Request`. Cost is meaningless
+without usage; the handler rejects up front.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature** (no meter).
+
+**Steps:**
+
+1. **Create static feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Query cost on unmetered feature.**
+   `POST /features/{feature.id}/cost/query` with body `{}`.
+   - Expect `400 Bad Request`.
+   - Expect **detail contains**
+     `"feature {feature.key} has no meter associated"`.
+
+**Notes:**
+
+- **Validation moment:** request-time, after feature resolution and
+  before any query processing.
+- **Error shape:** detail-substring at status 400.
+
+---
+
+## Scenario: feature_archived_excluded_from_list
+
+```yaml
+id: feature_archived_excluded_from_list
+endpoints:
+  - POST /features
+  - DELETE /features/{id}
+  - GET /features
+entities: [feature]
+tags: [list, archive, single-request]
+```
+
+**Intent:** After `DELETE`, the feature is not returned by a default
+`GET /features` call. v3 has no `include_archived` query param, so
+archived features are unreachable via the public API.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature**.
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Delete feature.** `DELETE /features/{feature.id}`.
+   - Expect `204 No Content`.
+
+3. **List features and confirm absence.**
+   `GET /features?page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect `data[]` does **not** contain an entry with
+     `id == {feature.id}`.
+
+**Notes:**
+
+- **No include-archived param.** Known parity gap with v1: the v1 list
+  endpoint accepted `include_archived=true`; v3 does not.
+
+---
+
+## Scenario: feature_archived_get_returns_404
+
+```yaml
+id: feature_archived_get_returns_404
+endpoints:
+  - POST /features
+  - DELETE /features/{id}
+  - GET /features/{id}
+entities: [feature]
+tags: [archive, single-request, not-found]
+```
+
+**Intent:** After `DELETE`, `GET /features/{id}` returns `404` with
+the standard detail substring. The TypeSpec declares `Common.Gone`
+(410) as a possible response, but the live server always returns 404.
+
+**Fixtures:**
+- A `CreateFeatureRequest` per **Baseline feature**.
+
+**Steps:**
+
+1. **Create feature.** `POST /features` with the fixture.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+2. **Delete feature.** `DELETE /features/{feature.id}`.
+   - Expect `204 No Content`.
+
+3. **Get archived feature.** `GET /features/{feature.id}`.
+   - Expect `404 Not Found`.
+   - Expect **detail contains**
+     `"feature not found: {feature.id}"`.
+
+**Notes:**
+
+- **404, not 410.** TypeSpec lists both
+  `Common.NotFound` (404) and `Common.Gone` (410); the server pins
+  404. Confirmed against a live server. If the server later starts
+  returning 410, this scenario is the regression test.
+- **Error shape:** detail-substring.
+
+---
+
+## Scenario: feature_llm_pricing_absent_when_unresolved
+
+```yaml
+id: feature_llm_pricing_absent_when_unresolved
+endpoints:
+  - POST /meters
+  - POST /features
+  - GET /features/{id}
+entities: [feature, meter]
+tags: [llm, get, single-request]
+```
+
+**Intent:** GET on an LLM feature whose `provider` + `model` cannot
+be resolved against the LLM cost database returns `200 OK` with the
+`pricing` block silently absent on the feature's `unit_cost`. No
+error, no warning — just an unenriched response.
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline LLM-capable meter**.
+- A `CreateFeatureRequest` per **Baseline feature** with:
+  - `meter`: `{ id: {meter.id} }`.
+  - `unit_cost`: a `BillingFeatureLLMUnitCost` with:
+    - `type`: `"llm"`.
+    - `provider`: `"unknown_provider_<unique>"`.
+    - `model`: `"unknown_model_<unique>"`.
+    - `token_type`: `"input"`.
+
+**Steps:**
+
+1. **Create meter.** `POST /meters`.
+   - Expect `201 Created`.
+
+   Captures:
+   - `meter` ← `response.body`
+
+2. **Create LLM feature with unresolvable provider/model.**
+   `POST /features`.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+3. **GET the feature.** `GET /features/{feature.id}`.
+   - Expect `200 OK`.
+   - Expect `unit_cost.type` is `"llm"`.
+   - Expect `unit_cost.provider` equals the fixture provider.
+   - Expect `unit_cost.model` equals the fixture model.
+   - Expect `unit_cost.pricing` is **absent**.
+
+**Notes:**
+
+- **Failure mode is silent.** `resolveLLMPricing` returns `nil` when
+  the provider or model can't be looked up; the response is built
+  without the pricing block.
+- **Error shape:** none — this is a positive scenario over an
+  intentionally unresolvable input.
+
+---
+
+## Scenario: feature_llm_pricing_enriched_on_get
+
+```yaml
+id: feature_llm_pricing_enriched_on_get
+endpoints:
+  - POST /meters
+  - POST /features
+  - GET /features/{id}
+entities: [feature, meter]
+tags: [llm, get, single-request, needs-verify, skipped]
+status: skipped
+```
+
+**Status: SKIPPED.** Environment-gated; deferred until the e2e stack
+provisions a deterministic LLM-cost seed (a known `(openai, gpt-4)`
+price). Do not generate a test from this scenario. Re-enable by
+removing this block once seeding is in place.
+
+**Intent:** GET on an LLM feature whose `provider` + `model` resolve
+against the LLM cost database returns `200 OK` with `unit_cost.pricing`
+populated from the database (`input_per_token`, `output_per_token`, …).
+
+**Fixtures:**
+- A `CreateMeterRequest` per **Baseline LLM-capable meter**.
+- A `CreateFeatureRequest` per **Baseline feature** with:
+  - `meter`: `{ id: {meter.id} }`.
+  - `unit_cost`: per **Baseline LLM unit cost (static)** — that is,
+    `provider: "openai"`, `model: "gpt-4"`, `token_type: "input"`.
+- **Environmental precondition:** the LLM cost database must contain
+  a price for `(provider: openai, model: gpt-4)` in the test
+  namespace. Without that seed the scenario degrades to
+  `feature_llm_pricing_absent_when_unresolved`.
+
+**Steps:**
+
+1. **Create meter.** `POST /meters`.
+   - Expect `201 Created`.
+
+   Captures:
+   - `meter` ← `response.body`
+
+2. **Create LLM feature with resolvable provider/model.**
+   `POST /features`.
+   - Expect `201 Created`.
+
+   Captures:
+   - `feature` ← `response.body`
+
+3. **GET the feature.** `GET /features/{feature.id}`.
+   - Expect `200 OK`.
+   - Expect `unit_cost.type` is `"llm"`.
+   - Expect `unit_cost.pricing` is present.
+   - Expect `unit_cost.pricing.input_per_token` parses as a non-negative
+     decimal string.
+   - Expect `unit_cost.pricing.output_per_token` parses as a
+     non-negative decimal string.
+
+**Notes:**
+
+- **NEEDS-VERIFY: requires seed data in the e2e environment's LLM
+  cost DB.** Until the e2e stack provisions a known
+  (`openai`, `gpt-4`) price, this scenario isn't deterministically
+  exercisable from the API alone. Two resolutions:
+  1. Add a fixture step that seeds the price via a public LLM-cost
+     endpoint (if one exists).
+  2. Tag this scenario as environment-gated and skip when the seed
+     is missing.
+- **Error shape:** none — positive scenario.

--- a/flake.nix
+++ b/flake.nix
@@ -117,6 +117,10 @@
                 exec ${pkgs.nodejs_24}/bin/npx -y @colbymchenry/codegraph@0.7.3 "$@"
               '')
 
+              # httpYac runner for wire-level e2e tests under e2e/http/.
+              # Available as a first-class nixpkgs package, so no npx wrapper needed.
+              httpyac
+
               # python
               poetry
 


### PR DESCRIPTION
## Overview

This is an experiment for creating a httpyac `.http` file  e2e solution with a dedicated skill that would take the `e2e-nl` natural language testing representation as an input and produce an output for httpYac. 

