### PR TITLE
fix(meteredentitlement): fix extra grant recurrences on in-period activity changes

### DIFF
--- a/openmeter/credit/engine/run.go
+++ b/openmeter/credit/engine/run.go
@@ -168,6 +168,7 @@ func (e *engine) runBetweenResets(ctx context.Context, params inbetweenRunParams
 				}
 				balancesAtPhaseStart.Set(grant.ID, grant.RecurrenceBalance(balancesAtPhaseStart[grantID]))
 			}
+			recurredGrants = nil
 		}
 
 		// get active and inactive grants in the phase

--- a/openmeter/credit/engine/run_test.go
+++ b/openmeter/credit/engine/run_test.go
@@ -777,6 +777,57 @@ func TestEngine(t *testing.T) {
 			},
 		},
 		{
+			name: "Does not reapply recurrence on later activity changes",
+			run: func(t *testing.T, eng engine.Engine, use addUsageFunc, mm meterpkg.Meter) {
+				start := t1
+				recurrence := start.AddDate(0, 0, 1)
+				activityChange := recurrence.Add(time.Hour)
+				end := activityChange.Add(time.Hour)
+
+				use(30, recurrence.Add(30*time.Minute))
+				use(20, activityChange.Add(30*time.Minute))
+
+				g1 := grant1
+				g1.EffectiveAt = start
+				g1.Priority = 1
+				g1.Recurrence = &timeutil.Recurrence{
+					Interval: timeutil.RecurrencePeriodDaily,
+					Anchor:   recurrence,
+				}
+				g1 = makeGrant(g1)
+
+				g2 := grant2
+				g2.EffectiveAt = activityChange
+				g2.Priority = 2
+				g2 = makeGrant(g2)
+
+				res, err := eng.Run(
+					t.Context(),
+					engine.RunParams{
+						Meter:  mm,
+						Grants: []grant.Grant{g1, g2},
+						StartingSnapshot: balance.Snapshot{
+							Balances: balance.Map{
+								g1.ID: 100.0,
+								g2.ID: 0.0,
+							},
+							Overage: 0,
+							At:      start,
+						},
+						Until: end,
+					})
+
+				require.NoError(t, err)
+				assert.Equal(t, 50.0, res.Snapshot.Balances[g1.ID])
+				assert.Equal(t, 100.0, res.Snapshot.Balances[g2.ID])
+
+				segments := res.History.Segments()
+				require.Len(t, segments, 3)
+				assert.Equal(t, 100.0, segments[1].BalanceAtStart[g1.ID])
+				assert.Equal(t, 70.0, segments[2].BalanceAtStart[g1.ID])
+			},
+		},
+		{
 			name: "Return GrantBurnDownHistory",
 			run: func(t *testing.T, eng engine.Engine, use addUsageFunc, mm meterpkg.Meter) {
 				// burn down with usage after grant effectiveAt


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Fixes bug where recurrence was reapplied for other in-period activity changes

### Verification
<details>

<summary> To assess possible impact (exact calc would need usage data as well) something similar to this query can be run </summary>

```sql
BEGIN READ ONLY;
SET LOCAL statement_timeout = '20s';
SET LOCAL lock_timeout = '1s';

WITH params AS (
  SELECT
    now() - interval '90 days' AS since,
    now() AS until
),

activity AS MATERIALIZED (
  -- start with grant creation; add expires/deletes later if needed
  SELECT
    g.namespace,
    g.owner_id AS entitlement_id,
    g.id AS event_grant_id,
    g.effective_at AS event_at,
    g.amount::numeric AS event_grant_amount
  FROM grants g, params p
  WHERE g.effective_at >= p.since
    AND g.effective_at < p.until
),

recurring AS MATERIALIZED (
  SELECT
    rg.namespace,
    rg.owner_id AS entitlement_id,
    rg.id AS recurring_grant_id,
    rg.amount::numeric AS recurring_amount,
    rg.priority AS recurring_priority,
    rg.effective_at,
    rg.expires_at,
    rg.recurrence_anchor,
    rg.recurrence_period,
    CASE rg.recurrence_period
      WHEN 'P1D' THEN interval '1 day'
      WHEN 'P1W' THEN interval '1 week'
      WHEN 'P1M' THEN interval '1 month'
      WHEN 'P1Y' THEN interval '1 year'
      WHEN 'DAY' THEN interval '1 day'
      WHEN 'WEEK' THEN interval '1 week'
      WHEN 'MONTH' THEN interval '1 month'
      WHEN 'YEAR' THEN interval '1 year'
    END AS recurrence_step
  FROM grants rg
  JOIN (SELECT DISTINCT namespace, entitlement_id FROM activity) a
    ON a.namespace = rg.namespace
   AND a.entitlement_id = rg.owner_id
  WHERE rg.recurrence_period IS NOT NULL
    AND rg.recurrence_anchor IS NOT NULL
    AND rg.deleted_at IS NULL
    AND rg.voided_at IS NULL
),

suspect AS (
  SELECT
    a.namespace,
    e.customer_id,
    e.feature_key,
    a.entitlement_id,
    r.recurring_grant_id,
    r.recurring_amount,
    r.recurring_priority,
    a.event_grant_id,
    a.event_at,
    a.event_grant_amount,

    lr.recurred_at,
    lr.recurred_at + r.recurrence_step AS next_recurrence_at
  FROM activity a
  JOIN recurring r
    ON r.namespace = a.namespace
   AND r.entitlement_id = a.entitlement_id
   AND r.recurring_grant_id <> a.event_grant_id
  JOIN entitlements e
    ON e.namespace = a.namespace
   AND e.id = a.entitlement_id

  CROSS JOIN LATERAL (
    SELECT max(x) AS recurred_at
    FROM generate_series(
      r.recurrence_anchor,
      a.event_at,
      r.recurrence_step
    ) AS x
    WHERE x < a.event_at
      AND x >= r.effective_at
  ) lr

  WHERE lr.recurred_at IS NOT NULL
    AND (r.expires_at IS NULL OR lr.recurred_at < r.expires_at)
    AND a.event_at < lr.recurred_at + r.recurrence_step
    AND NOT EXISTS (
      SELECT 1
      FROM usage_resets ur
      WHERE ur.namespace = a.namespace
        AND ur.entitlement_id = a.entitlement_id
        AND ur.reset_time > lr.recurred_at
        AND ur.reset_time <= a.event_at
    )
)

SELECT
  namespace,
  customer_id,
  feature_key,
  entitlement_id,
  recurring_grant_id,
  min(recurred_at) AS first_suspect_recurrence,
  max(event_at) AS latest_suspect_activity,
  count(*) AS suspect_refill_events,
  sum(recurring_amount) AS rough_upper_bound_credits,
  jsonb_agg(
    jsonb_build_object(
      'recurred_at', recurred_at,
      'event_at', event_at,
      'event_grant_id', event_grant_id,
      'event_grant_amount', event_grant_amount,
      'recurring_amount', recurring_amount,
      'next_recurrence_at', next_recurrence_at
    )
    ORDER BY event_at
  ) AS intervals_for_usage_check
FROM suspect
GROUP BY namespace, customer_id, feature_key, entitlement_id, recurring_grant_id
ORDER BY rough_upper_bound_credits DESC
LIMIT 100;

ROLLBACK;


```


</details>

For flagged entitlements clear any balance_snapshots so history can recalculate

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where recurring grant balances were being incorrectly reapplied when activity changes occurred after grant establishment.

* **Tests**
  * Added regression test to prevent recurrence of this issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->