### PR TITLE
feat: detailed line persisted flag

### DIFF
--- a/openmeter/billing/charges/usagebased/adapter/detailedline.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	dbchargeusagebasedrundetailedline "github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedrundetailedline"
+	dbchargeusagebasedruns "github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 )
@@ -42,6 +43,22 @@ func (a *adapter) FetchDetailedLines(ctx context.Context, charge usagebased.Char
 			return usagebased.Charge{}, err
 		}
 
+		dbRuns, err := tx.db.ChargeUsageBasedRuns.Query().
+			Where(
+				dbchargeusagebasedruns.NamespaceEQ(charge.Namespace),
+				dbchargeusagebasedruns.ChargeIDEQ(charge.ID),
+				dbchargeusagebasedruns.IDIn(runIDs...),
+			).
+			All(ctx)
+		if err != nil {
+			return usagebased.Charge{}, err
+		}
+
+		detailedLinesPresentByRunID := make(map[string]bool, len(dbRuns))
+		for _, dbRun := range dbRuns {
+			detailedLinesPresentByRunID[dbRun.ID] = dbRun.DetailedLinesPresent
+		}
+
 		linesByRunID := make(map[string]usagebased.DetailedLines, len(charge.Realizations))
 		for _, dbLine := range dbLines {
 			line, err := mapDetailedLineFromDB(dbLine)
@@ -55,7 +72,21 @@ func (a *adapter) FetchDetailedLines(ctx context.Context, charge usagebased.Char
 		for idx, run := range charge.Realizations {
 			lines := linesByRunID[run.ID.ID]
 			slices.SortStableFunc(lines, stddetailedline.Compare[usagebased.DetailedLine])
-			charge.Realizations[idx].DetailedLines = mo.Some(lines)
+
+			detailedLinesPresent, found := detailedLinesPresentByRunID[run.ID.ID]
+			if !found {
+				continue
+			}
+
+			// Safety measure: only mark detailed lines as expanded when the persisted
+			// run records that detailed lines were written at least once. Treating
+			// unknown detailed lines as an empty set can make
+			// late-event rating overcharge.
+			if detailedLinesPresent {
+				charge.Realizations[idx].DetailedLines = mo.Some(lines)
+			} else {
+				charge.Realizations[idx].DetailedLines = mo.None[usagebased.DetailedLines]()
+			}
 		}
 
 		return charge, nil
@@ -115,6 +146,17 @@ func (a *adapter) UpsertRunDetailedLines(ctx context.Context, chargeID chargesme
 		}
 
 		if _, err := deleteQuery.Save(ctx); err != nil {
+			return err
+		}
+
+		if _, err := tx.db.ChargeUsageBasedRuns.Update().
+			Where(
+				dbchargeusagebasedruns.NamespaceEQ(runID.Namespace),
+				dbchargeusagebasedruns.ChargeIDEQ(chargeID.ID),
+				dbchargeusagebasedruns.ID(runID.ID),
+			).
+			SetDetailedLinesPresent(true).
+			Save(ctx); err != nil {
 			return err
 		}
 

--- a/openmeter/billing/charges/usagebased/adapter/detailedline.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline.go
@@ -75,6 +75,7 @@ func (a *adapter) FetchDetailedLines(ctx context.Context, charge usagebased.Char
 
 			detailedLinesPresent, found := detailedLinesPresentByRunID[run.ID.ID]
 			if !found {
+				charge.Realizations[idx].DetailedLines = mo.None[usagebased.DetailedLines]()
 				continue
 			}
 

--- a/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/oklog/ulid/v2"
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -18,6 +20,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	dbchargeusagebasedrundetailedline "github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedrundetailedline"
+	dbchargeusagebasedruns "github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -204,6 +207,190 @@ func (s *DetailedLineAdapterSuite) TestUpsertRunDetailedLinesReplacesAndSoftDele
 		Only(ctx)
 	s.Require().NoError(err)
 	s.NotNil(deletedRow.DeletedAt)
+}
+
+func (s *DetailedLineAdapterSuite) TestFetchDetailedLinesUsesDetailedLinesPresentFlag() {
+	ctx := s.T().Context()
+	namespace := "usagebased-detailedline-adapter-fetch-flag"
+	charge, runBase, _ := s.createChargeWithRun(namespace)
+
+	fetchedWithoutMaterializedLines, err := s.adapter.GetByID(ctx, usagebased.GetByIDInput{
+		ChargeID: charge.GetChargeID(),
+		Expands: chargesmeta.Expands{
+			chargesmeta.ExpandRealizations,
+			chargesmeta.ExpandDetailedLines,
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(fetchedWithoutMaterializedLines.Realizations, 1)
+	s.False(fetchedWithoutMaterializedLines.Realizations[0].DetailedLines.IsPresent())
+
+	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, charge.GetChargeID(), runBase.ID, nil))
+
+	fetchedWithMaterializedEmptyLines, err := s.adapter.GetByID(ctx, usagebased.GetByIDInput{
+		ChargeID: charge.GetChargeID(),
+		Expands: chargesmeta.Expands{
+			chargesmeta.ExpandRealizations,
+			chargesmeta.ExpandDetailedLines,
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(fetchedWithMaterializedEmptyLines.Realizations, 1)
+	s.True(fetchedWithMaterializedEmptyLines.Realizations[0].DetailedLines.IsPresent())
+	s.Empty(fetchedWithMaterializedEmptyLines.Realizations[0].DetailedLines.OrEmpty())
+
+	dbRun, err := s.dbClient.ChargeUsageBasedRuns.Query().
+		Where(
+			dbchargeusagebasedruns.NamespaceEQ(namespace),
+			dbchargeusagebasedruns.ID(runBase.ID.ID),
+		).
+		Only(ctx)
+	s.Require().NoError(err)
+	s.True(dbRun.DetailedLinesPresent)
+}
+
+func (s *DetailedLineAdapterSuite) TestFetchDetailedLinesDoesNotRepairDetailedLinesPresentFlagWhenRowsExist() {
+	ctx := s.T().Context()
+	namespace := "usagebased-detailedline-adapter-fetch-does-not-repair-flag"
+	charge, runBase, servicePeriod := s.createChargeWithRun(namespace)
+
+	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, charge.GetChargeID(), runBase.ID, usagebased.DetailedLines{
+		s.newDetailedLine(newDetailedLineInput{
+			Charge:                 charge,
+			RunID:                  runBase.ID,
+			ServicePeriod:          servicePeriod,
+			ChildUniqueReferenceID: "existing@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
+			Quantity:               1,
+		}),
+	}))
+
+	_, err := s.dbClient.ChargeUsageBasedRuns.UpdateOneID(runBase.ID.ID).
+		Where(dbchargeusagebasedruns.NamespaceEQ(namespace)).
+		SetDetailedLinesPresent(false).
+		Save(ctx)
+	s.Require().NoError(err)
+
+	fetchedCharge, err := s.adapter.GetByID(ctx, usagebased.GetByIDInput{
+		ChargeID: charge.GetChargeID(),
+		Expands: chargesmeta.Expands{
+			chargesmeta.ExpandRealizations,
+			chargesmeta.ExpandDetailedLines,
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(fetchedCharge.Realizations, 1)
+	s.False(fetchedCharge.Realizations[0].DetailedLines.IsPresent())
+
+	dbRun, err := s.dbClient.ChargeUsageBasedRuns.Query().
+		Where(
+			dbchargeusagebasedruns.NamespaceEQ(namespace),
+			dbchargeusagebasedruns.ID(runBase.ID.ID),
+		).
+		Only(ctx)
+	s.Require().NoError(err)
+	s.False(dbRun.DetailedLinesPresent)
+}
+
+func (s *DetailedLineAdapterSuite) TestFetchDetailedLinesUsesPersistedDetailedLinesPresentFlag() {
+	ctx := s.T().Context()
+	namespace := "usagebased-detailedline-adapter-fetch-uses-persisted-flag"
+	charge, runBase, servicePeriod := s.createChargeWithRun(namespace)
+
+	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, charge.GetChargeID(), runBase.ID, usagebased.DetailedLines{
+		s.newDetailedLine(newDetailedLineInput{
+			Charge:                 charge,
+			RunID:                  runBase.ID,
+			ServicePeriod:          servicePeriod,
+			ChildUniqueReferenceID: "persisted@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
+			Quantity:               1,
+		}),
+	}))
+
+	_, err := s.dbClient.ChargeUsageBasedRuns.UpdateOneID(runBase.ID.ID).
+		Where(dbchargeusagebasedruns.NamespaceEQ(namespace)).
+		SetDetailedLinesPresent(false).
+		Save(ctx)
+	s.Require().NoError(err)
+
+	staleCharge := charge
+	staleCharge.Realizations = usagebased.RealizationRuns{
+		{
+			RealizationRunBase: runBase,
+		},
+	}
+	staleCharge.Realizations[0].DetailedLines = mo.Some(usagebased.DetailedLines{
+		s.newDetailedLine(newDetailedLineInput{
+			Charge:                 charge,
+			RunID:                  runBase.ID,
+			ServicePeriod:          servicePeriod,
+			ChildUniqueReferenceID: "stale@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
+			Quantity:               1,
+		}),
+	})
+
+	fetchedCharge, err := s.adapter.FetchDetailedLines(ctx, staleCharge)
+	s.Require().NoError(err)
+	s.Require().Len(fetchedCharge.Realizations, 1)
+	s.False(fetchedCharge.Realizations[0].DetailedLines.IsPresent())
+}
+
+func (s *DetailedLineAdapterSuite) createChargeWithRun(namespace string) (usagebased.Charge, usagebased.RealizationRunBase, timeutil.ClosedPeriod) {
+	s.T().Helper()
+
+	featureID := ulid.Make().String()
+	customerID := s.createCustomer(namespace)
+	s.createFeature(namespace, featureID)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	createdCharges, err := s.adapter.CreateCharges(s.T().Context(), usagebased.CreateChargesInput{
+		Namespace: namespace,
+		Intents: []usagebased.CreateIntent{
+			{
+				Intent: usagebased.Intent{
+					Intent: chargesmeta.Intent{
+						Name:              "usage-charge",
+						ManagedBy:         billing.SubscriptionManagedLine,
+						UniqueReferenceID: nil,
+						CustomerID:        customerID,
+						Currency:          currencyx.Code("USD"),
+						ServicePeriod:     servicePeriod,
+						FullServicePeriod: servicePeriod,
+						BillingPeriod:     servicePeriod,
+					},
+					InvoiceAt:      servicePeriod.To,
+					SettlementMode: productcatalog.CreditOnlySettlementMode,
+					FeatureKey:     featureID,
+					Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromFloat(0.1),
+					}),
+				},
+				FeatureID: featureID,
+			},
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(createdCharges, 1)
+
+	charge := createdCharges[0]
+	runBase, err := s.adapter.CreateRealizationRun(s.T().Context(), charge.GetChargeID(), usagebased.CreateRealizationRunInput{
+		FeatureID:       featureID,
+		Type:            usagebased.RealizationRunTypeFinalRealization,
+		StoredAtLT:      servicePeriod.To,
+		ServicePeriodTo: servicePeriod.To,
+		MeteredQuantity: alpacadecimal.NewFromInt(10),
+		Totals: totals.Totals{
+			Amount:       alpacadecimal.NewFromInt(1),
+			ChargesTotal: alpacadecimal.NewFromInt(1),
+			Total:        alpacadecimal.NewFromInt(1),
+		},
+	})
+	s.Require().NoError(err)
+
+	return charge, runBase, servicePeriod
 }
 
 func (s *DetailedLineAdapterSuite) createCustomer(namespace string) string {

--- a/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
@@ -334,6 +334,36 @@ func (s *DetailedLineAdapterSuite) TestFetchDetailedLinesUsesPersistedDetailedLi
 	s.False(fetchedCharge.Realizations[0].DetailedLines.IsPresent())
 }
 
+func (s *DetailedLineAdapterSuite) TestFetchDetailedLinesClearsStaleDetailedLinesWhenRunMetadataIsMissing() {
+	ctx := s.T().Context()
+	namespace := "usagebased-detailedline-adapter-fetch-missing-run-metadata"
+	charge, runBase, servicePeriod := s.createChargeWithRun(namespace)
+
+	missingRunBase := runBase
+	missingRunBase.ID.ID = ulid.Make().String()
+
+	staleCharge := charge
+	staleCharge.Realizations = usagebased.RealizationRuns{
+		{
+			RealizationRunBase: missingRunBase,
+			DetailedLines: mo.Some(usagebased.DetailedLines{
+				s.newDetailedLine(newDetailedLineInput{
+					Charge:                 charge,
+					RunID:                  missingRunBase.ID,
+					ServicePeriod:          servicePeriod,
+					ChildUniqueReferenceID: "stale@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
+					Quantity:               1,
+				}),
+			}),
+		},
+	}
+
+	fetchedCharge, err := s.adapter.FetchDetailedLines(ctx, staleCharge)
+	s.Require().NoError(err)
+	s.Require().Len(fetchedCharge.Realizations, 1)
+	s.False(fetchedCharge.Realizations[0].DetailedLines.IsPresent())
+}
+
 func (s *DetailedLineAdapterSuite) createChargeWithRun(namespace string) (usagebased.Charge, usagebased.RealizationRunBase, timeutil.ClosedPeriod) {
 	s.T().Helper()
 

--- a/openmeter/billing/charges/usagebased/adapter/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/adapter/realizationrun.go
@@ -29,6 +29,7 @@ func (a *adapter) CreateRealizationRun(ctx context.Context, chargeID meta.Charge
 			SetType(input.Type).
 			SetStoredAtLt(meta.NormalizeTimestamp(input.StoredAtLT)).
 			SetServicePeriodTo(meta.NormalizeTimestamp(input.ServicePeriodTo)).
+			SetDetailedLinesPresent(false).
 			SetNillableBillingInvoiceLineID(input.LineID).
 			SetMeteredQuantity(input.MeteredQuantity)
 

--- a/openmeter/billing/charges/usagebased/service/rating/details.go
+++ b/openmeter/billing/charges/usagebased/service/rating/details.go
@@ -81,12 +81,6 @@ type GetDetailedRatingForUsageResult struct {
 }
 
 func (s *service) GetDetailedRatingForUsage(ctx context.Context, in GetDetailedRatingForUsageInput) (GetDetailedRatingForUsageResult, error) {
-	chargeWithDetailedLines, err := s.ensureDetailedLinesLoadedForRating(ctx, in.Charge, in.ServicePeriodTo)
-	if err != nil {
-		return GetDetailedRatingForUsageResult{}, err
-	}
-	in.Charge = chargeWithDetailedLines
-
 	if err := in.Validate(); err != nil {
 		return GetDetailedRatingForUsageResult{}, err
 	}

--- a/openmeter/billing/charges/usagebased/service/rating/details.go
+++ b/openmeter/billing/charges/usagebased/service/rating/details.go
@@ -81,6 +81,12 @@ type GetDetailedRatingForUsageResult struct {
 }
 
 func (s *service) GetDetailedRatingForUsage(ctx context.Context, in GetDetailedRatingForUsageInput) (GetDetailedRatingForUsageResult, error) {
+	chargeWithDetailedLines, err := s.ensureDetailedLinesLoadedForRating(ctx, in.Charge, in.ServicePeriodTo)
+	if err != nil {
+		return GetDetailedRatingForUsageResult{}, err
+	}
+	in.Charge = chargeWithDetailedLines
+
 	if err := in.Validate(); err != nil {
 		return GetDetailedRatingForUsageResult{}, err
 	}

--- a/openmeter/ent/db/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns.go
@@ -58,6 +58,8 @@ type ChargeUsageBasedRuns struct {
 	StoredAtLt time.Time `json:"stored_at_lt,omitempty"`
 	// ServicePeriodTo holds the value of the "service_period_to" field.
 	ServicePeriodTo time.Time `json:"service_period_to,omitempty"`
+	// DetailedLinesPresent holds the value of the "detailed_lines_present" field.
+	DetailedLinesPresent bool `json:"detailed_lines_present,omitempty"`
 	// LineID holds the value of the "line_id" field.
 	LineID *string `json:"line_id,omitempty"`
 	// MeteredQuantity holds the value of the "metered_quantity" field.
@@ -169,6 +171,8 @@ func (*ChargeUsageBasedRuns) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargeusagebasedruns.FieldAmount, chargeusagebasedruns.FieldTaxesTotal, chargeusagebasedruns.FieldTaxesInclusiveTotal, chargeusagebasedruns.FieldTaxesExclusiveTotal, chargeusagebasedruns.FieldChargesTotal, chargeusagebasedruns.FieldDiscountsTotal, chargeusagebasedruns.FieldCreditsTotal, chargeusagebasedruns.FieldTotal, chargeusagebasedruns.FieldMeteredQuantity:
 			values[i] = new(alpacadecimal.Decimal)
+		case chargeusagebasedruns.FieldDetailedLinesPresent:
+			values[i] = new(sql.NullBool)
 		case chargeusagebasedruns.FieldID, chargeusagebasedruns.FieldNamespace, chargeusagebasedruns.FieldChargeID, chargeusagebasedruns.FieldFeatureID, chargeusagebasedruns.FieldType, chargeusagebasedruns.FieldLineID:
 			values[i] = new(sql.NullString)
 		case chargeusagebasedruns.FieldCreatedAt, chargeusagebasedruns.FieldUpdatedAt, chargeusagebasedruns.FieldDeletedAt, chargeusagebasedruns.FieldStoredAtLt, chargeusagebasedruns.FieldServicePeriodTo:
@@ -296,6 +300,12 @@ func (_m *ChargeUsageBasedRuns) assignValues(columns []string, values []any) err
 				return fmt.Errorf("unexpected type %T for field service_period_to", values[i])
 			} else if value.Valid {
 				_m.ServicePeriodTo = value.Time
+			}
+		case chargeusagebasedruns.FieldDetailedLinesPresent:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field detailed_lines_present", values[i])
+			} else if value.Valid {
+				_m.DetailedLinesPresent = value.Bool
 			}
 		case chargeusagebasedruns.FieldLineID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -433,6 +443,9 @@ func (_m *ChargeUsageBasedRuns) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("service_period_to=")
 	builder.WriteString(_m.ServicePeriodTo.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("detailed_lines_present=")
+	builder.WriteString(fmt.Sprintf("%v", _m.DetailedLinesPresent))
 	builder.WriteString(", ")
 	if v := _m.LineID; v != nil {
 		builder.WriteString("line_id=")

--- a/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
@@ -50,6 +50,8 @@ const (
 	FieldStoredAtLt = "stored_at_lt"
 	// FieldServicePeriodTo holds the string denoting the service_period_to field in the database.
 	FieldServicePeriodTo = "service_period_to"
+	// FieldDetailedLinesPresent holds the string denoting the detailed_lines_present field in the database.
+	FieldDetailedLinesPresent = "detailed_lines_present"
 	// FieldLineID holds the string denoting the line_id field in the database.
 	FieldLineID = "line_id"
 	// FieldMeteredQuantity holds the string denoting the metered_quantity field in the database.
@@ -141,6 +143,7 @@ var Columns = []string{
 	FieldType,
 	FieldStoredAtLt,
 	FieldServicePeriodTo,
+	FieldDetailedLinesPresent,
 	FieldLineID,
 	FieldMeteredQuantity,
 }
@@ -273,6 +276,11 @@ func ByStoredAtLt(opts ...sql.OrderTermOption) OrderOption {
 // ByServicePeriodTo orders the results by the service_period_to field.
 func ByServicePeriodTo(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldServicePeriodTo, opts...).ToFunc()
+}
+
+// ByDetailedLinesPresent orders the results by the detailed_lines_present field.
+func ByDetailedLinesPresent(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDetailedLinesPresent, opts...).ToFunc()
 }
 
 // ByLineID orders the results by the line_id field.

--- a/openmeter/ent/db/chargeusagebasedruns/where.go
+++ b/openmeter/ent/db/chargeusagebasedruns/where.go
@@ -147,6 +147,11 @@ func ServicePeriodTo(v time.Time) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldServicePeriodTo, v))
 }
 
+// DetailedLinesPresent applies equality check predicate on the "detailed_lines_present" field. It's identical to DetailedLinesPresentEQ.
+func DetailedLinesPresent(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldDetailedLinesPresent, v))
+}
+
 // LineID applies equality check predicate on the "line_id" field. It's identical to LineIDEQ.
 func LineID(v string) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldLineID, v))
@@ -910,6 +915,16 @@ func ServicePeriodToLT(v time.Time) predicate.ChargeUsageBasedRuns {
 // ServicePeriodToLTE applies the LTE predicate on the "service_period_to" field.
 func ServicePeriodToLTE(v time.Time) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldLTE(FieldServicePeriodTo, v))
+}
+
+// DetailedLinesPresentEQ applies the EQ predicate on the "detailed_lines_present" field.
+func DetailedLinesPresentEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldDetailedLinesPresent, v))
+}
+
+// DetailedLinesPresentNEQ applies the NEQ predicate on the "detailed_lines_present" field.
+func DetailedLinesPresentNEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldDetailedLinesPresent, v))
 }
 
 // LineIDEQ applies the EQ predicate on the "line_id" field.

--- a/openmeter/ent/db/chargeusagebasedruns_create.go
+++ b/openmeter/ent/db/chargeusagebasedruns_create.go
@@ -158,6 +158,12 @@ func (_c *ChargeUsageBasedRunsCreate) SetServicePeriodTo(v time.Time) *ChargeUsa
 	return _c
 }
 
+// SetDetailedLinesPresent sets the "detailed_lines_present" field.
+func (_c *ChargeUsageBasedRunsCreate) SetDetailedLinesPresent(v bool) *ChargeUsageBasedRunsCreate {
+	_c.mutation.SetDetailedLinesPresent(v)
+	return _c
+}
+
 // SetLineID sets the "line_id" field.
 func (_c *ChargeUsageBasedRunsCreate) SetLineID(v string) *ChargeUsageBasedRunsCreate {
 	_c.mutation.SetLineID(v)
@@ -409,6 +415,9 @@ func (_c *ChargeUsageBasedRunsCreate) check() error {
 	if _, ok := _c.mutation.ServicePeriodTo(); !ok {
 		return &ValidationError{Name: "service_period_to", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.service_period_to"`)}
 	}
+	if _, ok := _c.mutation.DetailedLinesPresent(); !ok {
+		return &ValidationError{Name: "detailed_lines_present", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.detailed_lines_present"`)}
+	}
 	if v, ok := _c.mutation.LineID(); ok {
 		if err := chargeusagebasedruns.LineIDValidator(v); err != nil {
 			return &ValidationError{Name: "line_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRuns.line_id": %w`, err)}
@@ -518,6 +527,10 @@ func (_c *ChargeUsageBasedRunsCreate) createSpec() (*ChargeUsageBasedRuns, *sqlg
 	if value, ok := _c.mutation.ServicePeriodTo(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldServicePeriodTo, field.TypeTime, value)
 		_node.ServicePeriodTo = value
+	}
+	if value, ok := _c.mutation.DetailedLinesPresent(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldDetailedLinesPresent, field.TypeBool, value)
+		_node.DetailedLinesPresent = value
 	}
 	if value, ok := _c.mutation.MeteredQuantity(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldMeteredQuantity, field.TypeOther, value)
@@ -828,6 +841,18 @@ func (u *ChargeUsageBasedRunsUpsert) UpdateStoredAtLt() *ChargeUsageBasedRunsUps
 	return u
 }
 
+// SetDetailedLinesPresent sets the "detailed_lines_present" field.
+func (u *ChargeUsageBasedRunsUpsert) SetDetailedLinesPresent(v bool) *ChargeUsageBasedRunsUpsert {
+	u.Set(chargeusagebasedruns.FieldDetailedLinesPresent, v)
+	return u
+}
+
+// UpdateDetailedLinesPresent sets the "detailed_lines_present" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsert) UpdateDetailedLinesPresent() *ChargeUsageBasedRunsUpsert {
+	u.SetExcluded(chargeusagebasedruns.FieldDetailedLinesPresent)
+	return u
+}
+
 // SetLineID sets the "line_id" field.
 func (u *ChargeUsageBasedRunsUpsert) SetLineID(v string) *ChargeUsageBasedRunsUpsert {
 	u.Set(chargeusagebasedruns.FieldLineID, v)
@@ -1082,6 +1107,20 @@ func (u *ChargeUsageBasedRunsUpsertOne) SetStoredAtLt(v time.Time) *ChargeUsageB
 func (u *ChargeUsageBasedRunsUpsertOne) UpdateStoredAtLt() *ChargeUsageBasedRunsUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateStoredAtLt()
+	})
+}
+
+// SetDetailedLinesPresent sets the "detailed_lines_present" field.
+func (u *ChargeUsageBasedRunsUpsertOne) SetDetailedLinesPresent(v bool) *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetDetailedLinesPresent(v)
+	})
+}
+
+// UpdateDetailedLinesPresent sets the "detailed_lines_present" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertOne) UpdateDetailedLinesPresent() *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateDetailedLinesPresent()
 	})
 }
 
@@ -1511,6 +1550,20 @@ func (u *ChargeUsageBasedRunsUpsertBulk) SetStoredAtLt(v time.Time) *ChargeUsage
 func (u *ChargeUsageBasedRunsUpsertBulk) UpdateStoredAtLt() *ChargeUsageBasedRunsUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateStoredAtLt()
+	})
+}
+
+// SetDetailedLinesPresent sets the "detailed_lines_present" field.
+func (u *ChargeUsageBasedRunsUpsertBulk) SetDetailedLinesPresent(v bool) *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetDetailedLinesPresent(v)
+	})
+}
+
+// UpdateDetailedLinesPresent sets the "detailed_lines_present" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertBulk) UpdateDetailedLinesPresent() *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateDetailedLinesPresent()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebasedruns_update.go
+++ b/openmeter/ent/db/chargeusagebasedruns_update.go
@@ -186,6 +186,20 @@ func (_u *ChargeUsageBasedRunsUpdate) SetNillableStoredAtLt(v *time.Time) *Charg
 	return _u
 }
 
+// SetDetailedLinesPresent sets the "detailed_lines_present" field.
+func (_u *ChargeUsageBasedRunsUpdate) SetDetailedLinesPresent(v bool) *ChargeUsageBasedRunsUpdate {
+	_u.mutation.SetDetailedLinesPresent(v)
+	return _u
+}
+
+// SetNillableDetailedLinesPresent sets the "detailed_lines_present" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdate) SetNillableDetailedLinesPresent(v *bool) *ChargeUsageBasedRunsUpdate {
+	if v != nil {
+		_u.SetDetailedLinesPresent(*v)
+	}
+	return _u
+}
+
 // SetLineID sets the "line_id" field.
 func (_u *ChargeUsageBasedRunsUpdate) SetLineID(v string) *ChargeUsageBasedRunsUpdate {
 	_u.mutation.SetLineID(v)
@@ -471,6 +485,9 @@ func (_u *ChargeUsageBasedRunsUpdate) sqlSave(ctx context.Context) (_node int, e
 	}
 	if value, ok := _u.mutation.StoredAtLt(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldStoredAtLt, field.TypeTime, value)
+	}
+	if value, ok := _u.mutation.DetailedLinesPresent(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldDetailedLinesPresent, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.MeteredQuantity(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldMeteredQuantity, field.TypeOther, value)
@@ -824,6 +841,20 @@ func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableStoredAtLt(v *time.Time) *Ch
 	return _u
 }
 
+// SetDetailedLinesPresent sets the "detailed_lines_present" field.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetDetailedLinesPresent(v bool) *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.SetDetailedLinesPresent(v)
+	return _u
+}
+
+// SetNillableDetailedLinesPresent sets the "detailed_lines_present" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableDetailedLinesPresent(v *bool) *ChargeUsageBasedRunsUpdateOne {
+	if v != nil {
+		_u.SetDetailedLinesPresent(*v)
+	}
+	return _u
+}
+
 // SetLineID sets the "line_id" field.
 func (_u *ChargeUsageBasedRunsUpdateOne) SetLineID(v string) *ChargeUsageBasedRunsUpdateOne {
 	_u.mutation.SetLineID(v)
@@ -1139,6 +1170,9 @@ func (_u *ChargeUsageBasedRunsUpdateOne) sqlSave(ctx context.Context) (_node *Ch
 	}
 	if value, ok := _u.mutation.StoredAtLt(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldStoredAtLt, field.TypeTime, value)
+	}
+	if value, ok := _u.mutation.DetailedLinesPresent(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldDetailedLinesPresent, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.MeteredQuantity(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldMeteredQuantity, field.TypeOther, value)

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -2724,6 +2724,7 @@ var (
 		{Name: "type", Type: field.TypeEnum, Enums: []string{"final_realization", "partial_invoice"}},
 		{Name: "stored_at_lt", Type: field.TypeTime},
 		{Name: "service_period_to", Type: field.TypeTime},
+		{Name: "detailed_lines_present", Type: field.TypeBool},
 		{Name: "metered_quantity", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "line_id", Type: field.TypeString, Unique: true, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "charge_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -2737,19 +2738,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoice_lines_charge_usage_based_run",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[17]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[18]},
 				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[18]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[19]},
 				RefColumns: []*schema.Column{ChargeUsageBasedColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_features_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[19]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[20]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -2768,7 +2769,7 @@ var (
 			{
 				Name:    "chargeusagebasedruns_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[18]},
+				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[19]},
 			},
 		},
 	}

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -61214,6 +61214,7 @@ type ChargeUsageBasedRunsMutation struct {
 	_type                       *usagebased.RealizationRunType
 	stored_at_lt                *time.Time
 	service_period_to           *time.Time
+	detailed_lines_present      *bool
 	metered_quantity            *alpacadecimal.Decimal
 	clearedFields               map[string]struct{}
 	usage_based                 *string
@@ -61966,6 +61967,42 @@ func (m *ChargeUsageBasedRunsMutation) ResetServicePeriodTo() {
 	m.service_period_to = nil
 }
 
+// SetDetailedLinesPresent sets the "detailed_lines_present" field.
+func (m *ChargeUsageBasedRunsMutation) SetDetailedLinesPresent(b bool) {
+	m.detailed_lines_present = &b
+}
+
+// DetailedLinesPresent returns the value of the "detailed_lines_present" field in the mutation.
+func (m *ChargeUsageBasedRunsMutation) DetailedLinesPresent() (r bool, exists bool) {
+	v := m.detailed_lines_present
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDetailedLinesPresent returns the old "detailed_lines_present" field's value of the ChargeUsageBasedRuns entity.
+// If the ChargeUsageBasedRuns object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedRunsMutation) OldDetailedLinesPresent(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDetailedLinesPresent is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDetailedLinesPresent requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDetailedLinesPresent: %w", err)
+	}
+	return oldValue.DetailedLinesPresent, nil
+}
+
+// ResetDetailedLinesPresent resets all changes to the "detailed_lines_present" field.
+func (m *ChargeUsageBasedRunsMutation) ResetDetailedLinesPresent() {
+	m.detailed_lines_present = nil
+}
+
 // SetLineID sets the "line_id" field.
 func (m *ChargeUsageBasedRunsMutation) SetLineID(s string) {
 	m.billing_invoice_line = &s
@@ -62378,7 +62415,7 @@ func (m *ChargeUsageBasedRunsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedRunsMutation) Fields() []string {
-	fields := make([]string, 0, 19)
+	fields := make([]string, 0, 20)
 	if m.namespace != nil {
 		fields = append(fields, chargeusagebasedruns.FieldNamespace)
 	}
@@ -62430,6 +62467,9 @@ func (m *ChargeUsageBasedRunsMutation) Fields() []string {
 	if m.service_period_to != nil {
 		fields = append(fields, chargeusagebasedruns.FieldServicePeriodTo)
 	}
+	if m.detailed_lines_present != nil {
+		fields = append(fields, chargeusagebasedruns.FieldDetailedLinesPresent)
+	}
 	if m.billing_invoice_line != nil {
 		fields = append(fields, chargeusagebasedruns.FieldLineID)
 	}
@@ -62478,6 +62518,8 @@ func (m *ChargeUsageBasedRunsMutation) Field(name string) (ent.Value, bool) {
 		return m.StoredAtLt()
 	case chargeusagebasedruns.FieldServicePeriodTo:
 		return m.ServicePeriodTo()
+	case chargeusagebasedruns.FieldDetailedLinesPresent:
+		return m.DetailedLinesPresent()
 	case chargeusagebasedruns.FieldLineID:
 		return m.LineID()
 	case chargeusagebasedruns.FieldMeteredQuantity:
@@ -62525,6 +62567,8 @@ func (m *ChargeUsageBasedRunsMutation) OldField(ctx context.Context, name string
 		return m.OldStoredAtLt(ctx)
 	case chargeusagebasedruns.FieldServicePeriodTo:
 		return m.OldServicePeriodTo(ctx)
+	case chargeusagebasedruns.FieldDetailedLinesPresent:
+		return m.OldDetailedLinesPresent(ctx)
 	case chargeusagebasedruns.FieldLineID:
 		return m.OldLineID(ctx)
 	case chargeusagebasedruns.FieldMeteredQuantity:
@@ -62657,6 +62701,13 @@ func (m *ChargeUsageBasedRunsMutation) SetField(name string, value ent.Value) er
 		}
 		m.SetServicePeriodTo(v)
 		return nil
+	case chargeusagebasedruns.FieldDetailedLinesPresent:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDetailedLinesPresent(v)
+		return nil
 	case chargeusagebasedruns.FieldLineID:
 		v, ok := value.(string)
 		if !ok {
@@ -62785,6 +62836,9 @@ func (m *ChargeUsageBasedRunsMutation) ResetField(name string) error {
 		return nil
 	case chargeusagebasedruns.FieldServicePeriodTo:
 		m.ResetServicePeriodTo()
+		return nil
+	case chargeusagebasedruns.FieldDetailedLinesPresent:
+		m.ResetDetailedLinesPresent()
 		return nil
 	case chargeusagebasedruns.FieldLineID:
 		m.ResetLineID()

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -1432,7 +1432,7 @@ func init() {
 	// chargeusagebasedruns.FeatureIDValidator is a validator for the "feature_id" field. It is called by the builders before save.
 	chargeusagebasedruns.FeatureIDValidator = chargeusagebasedrunsDescFeatureID.Validators[0].(func(string) error)
 	// chargeusagebasedrunsDescLineID is the schema descriptor for line_id field.
-	chargeusagebasedrunsDescLineID := chargeusagebasedrunsFields[5].Descriptor()
+	chargeusagebasedrunsDescLineID := chargeusagebasedrunsFields[6].Descriptor()
 	// chargeusagebasedruns.LineIDValidator is a validator for the "line_id" field. It is called by the builders before save.
 	chargeusagebasedruns.LineIDValidator = chargeusagebasedrunsDescLineID.Validators[0].(func(string) error)
 	// chargeusagebasedrunsDescID is the schema descriptor for id field.

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -169,6 +169,8 @@ func (ChargeUsageBasedRuns) Fields() []ent.Field {
 		field.Time("service_period_to").
 			Immutable(),
 
+		field.Bool("detailed_lines_present"),
+
 		field.String("line_id").
 			SchemaType(map[string]string{
 				dialect.Postgres: "char(26)",

--- a/tools/migrate/migrations/20260429140129_add_usage_based_run_detailed_lines_present.down.sql
+++ b/tools/migrate/migrations/20260429140129_add_usage_based_run_detailed_lines_present.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" DROP COLUMN "detailed_lines_present";

--- a/tools/migrate/migrations/20260429140129_add_usage_based_run_detailed_lines_present.up.sql
+++ b/tools/migrate/migrations/20260429140129_add_usage_based_run_detailed_lines_present.up.sql
@@ -1,0 +1,19 @@
+-- modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" ADD COLUMN "detailed_lines_present" boolean NOT NULL DEFAULT false;
+UPDATE "charge_usage_based_runs" AS "runs"
+SET "detailed_lines_present" = true
+WHERE EXISTS (
+  SELECT 1
+  FROM "charge_usage_based_run_detailed_line" AS "lines"
+  WHERE "lines"."namespace" = "runs"."namespace"
+    AND "lines"."charge_id" = "runs"."charge_id"
+    AND "lines"."run_id" = "runs"."id"
+    AND "lines"."deleted_at" IS NULL
+);
+UPDATE "charge_usage_based_runs" AS "runs"
+SET "detailed_lines_present" = true
+FROM "charge_usage_based" AS "charges"
+WHERE "charges"."namespace" = "runs"."namespace"
+  AND "charges"."id" = "runs"."charge_id"
+  AND "charges"."status_detailed" = 'final';
+ALTER TABLE "charge_usage_based_runs" ALTER COLUMN "detailed_lines_present" DROP DEFAULT;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:LQIt5iDD5CEbAfy4XW82C/KUc8Kb9OyoMUxusGhIU48=
+h1:FSngyul/qgOLTWXcs8Qx0bqB6qoOrXia8ovPx+wbqQQ=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -186,3 +186,4 @@ h1:LQIt5iDD5CEbAfy4XW82C/KUc8Kb9OyoMUxusGhIU48=
 20260422051837_simplify_mixin_detailed_line_partial_indexes.up.sql h1:3AsRyULK4pPWEcmfDd17bP6o4QuCcdH34ByUKsQdGHg=
 20260422140242_add_standard_invoice_line_override_collection_period_end.up.sql h1:V70I7Jj6NNZOwAunNXZub7V8PUoJtAaVt0I9s+RLLY8=
 20260424091352_usagebased_run_data_structure.up.sql h1:ZsdIVq5+DCj/qTL3xxDFcegVc83WudhnfSOHcFIxGe0=
+20260429140129_add_usage_based_run_detailed_lines_present.up.sql h1:CUxta1o9vb2RZnSQnDCutMGc6AY2I5mYffRK83M6I34=


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Safety measure: only mark detailed lines as expanded when the persisted
run records that detailed lines were written at least once. Treating
unknown detailed lines as an empty set can make
late-event rating overcharge.

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking of detailed billing line presence for usage-based charges; new runs explicitly start with "no detailed lines".

* **Bug Fixes**
  * Fetching and upserting now honor the persisted presence flag and clear stale detailed lines when run metadata is missing.
  * Upserts now mark presence when detailed lines are persisted.

* **Tests**
  * Expanded coverage validating presence-flag behavior across create, upsert, fetch, and missing-run scenarios.

* **Chores**
  * Database migration to add and backfill the presence flag for existing runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->