### PR TITLE
refactor: list entitlements for ingested events

### DIFF
--- a/openmeter/entitlement/adapter/entitlement.go
+++ b/openmeter/entitlement/adapter/entitlement.go
@@ -334,7 +334,7 @@ func (a *entitlementDBAdapter) ListEntitlementsAffectedByIngestEvents(ctx contex
 			}
 
 			defer func() {
-				// FIXME: it would be great to log this erro but the adapter has not logger.
+				// FIXME: it would be great to log this error but the adapter has no logger.
 				_ = rows.Close()
 			}()
 
@@ -355,6 +355,7 @@ func (a *entitlementDBAdapter) ListEntitlementsAffectedByIngestEvents(ctx contex
 					return nil, fmt.Errorf("failed to scan entitlement row: %w", err)
 				}
 
+				r.CreatedAt = r.CreatedAt.UTC()
 				r.DeletedAt = convert.SafeToUTC(r.DeletedAt)
 				r.ActiveFrom = convert.SafeToUTC(r.ActiveFrom)
 				r.ActiveTo = convert.SafeToUTC(r.ActiveTo)

--- a/openmeter/entitlement/adapter/entitlement.go
+++ b/openmeter/entitlement/adapter/entitlement.go
@@ -238,6 +238,82 @@ func (a *entitlementDBAdapter) DeactivateEntitlement(ctx context.Context, entitl
 	return err
 }
 
+func EntitlementsByIngestedEventsQuery(dialect, ns, subject string, meters ...string) (string, []any) {
+	ct := sql.Table(customerdb.Table).As("c")
+	cst := sql.Table(customersubjectsdb.Table).As("cs")
+	ft := sql.Table(db_feature.Table).As("f")
+	mt := sql.Table(db_meter.Table).As("m")
+
+	withCustomers := "customers"
+	withFeatures := "features"
+
+	with := sql.Dialect(dialect).
+		With(withCustomers).
+		As(
+			sql.Select(
+				ct.C(customerdb.FieldID),
+			).
+				From(ct).
+				Where(
+					sql.And(
+						sql.EQ(ct.C(customerdb.FieldNamespace), ns),
+						sql.EQ(ct.C(customerdb.FieldKey), subject),
+						sql.IsNull(ct.C(customerdb.FieldDeletedAt)),
+					),
+				).
+				Union(
+					sql.Select(
+						cst.C(customersubjectsdb.FieldCustomerID),
+					).
+						From(cst).
+						Join(ct).On(ct.C(customerdb.FieldID), cst.C(customersubjectsdb.FieldCustomerID)).
+						Where(
+							sql.And(
+								sql.EQ(cst.C(customersubjectsdb.FieldNamespace), ns),
+								sql.EQ(cst.C(customersubjectsdb.FieldSubjectKey), subject),
+								sql.IsNull(ct.C(customerdb.FieldDeletedAt)),
+								sql.IsNull(cst.C(customerdb.FieldDeletedAt)),
+							),
+						)),
+		).
+		With(withFeatures).
+		As(
+			sql.Select(
+				ft.C(db_feature.FieldID),
+			).From(ft).
+				Join(mt).On(mt.C(db_meter.FieldID), ft.C(db_feature.FieldMeterID)).
+				Where(sql.And(
+					sql.EQ(ft.C(db_feature.FieldNamespace), ns),
+					sql.IsNull(ft.C(db_feature.FieldArchivedAt)),
+					sql.IsNull(ft.C(db_feature.FieldDeletedAt)),
+					sql.In(mt.C(db_meter.FieldKey), lo.ToAnySlice(meters)...),
+				)),
+		)
+
+	et := sql.Table(db_entitlement.Table).As("e")
+
+	cbs := sql.Table(withCustomers).As("cbs")
+	fbm := sql.Table(withFeatures).As("fbm")
+
+	q := sql.Dialect(dialect).
+		Select(
+			et.C(db_entitlement.FieldNamespace),
+			et.C(db_entitlement.FieldID),
+			et.C(db_entitlement.FieldCreatedAt),
+			et.C(db_entitlement.FieldDeletedAt),
+			et.C(db_entitlement.FieldActiveFrom),
+			et.C(db_entitlement.FieldActiveTo),
+		).From(et).
+		Join(cbs).On(et.C(db_entitlement.FieldCustomerID), cbs.C("id")).
+		Join(fbm).On(et.C(db_entitlement.FieldFeatureID), fbm.C("id")).
+		Where(sql.And(
+			sql.EQ(et.C(db_entitlement.FieldNamespace), ns),
+			sql.IsNull(et.C(db_entitlement.FieldDeletedAt)))).
+		Prefix(with)
+
+	return q.Query()
+}
+
 // TODO[OM-1009]: This returns all the entitlements even the expired ones, for billing we would need to have a range for
 // the batch ingested events. Let's narrow down the list of entitlements active during that period.
 func (a *entitlementDBAdapter) ListEntitlementsAffectedByIngestEvents(ctx context.Context, eventFilter balanceworker.IngestEventQueryFilter) ([]balanceworker.ListAffectedEntitlementsResponse, error) {
@@ -245,62 +321,49 @@ func (a *entitlementDBAdapter) ListEntitlementsAffectedByIngestEvents(ctx contex
 		ctx,
 		a,
 		func(ctx context.Context, repo *entitlementDBAdapter) ([]balanceworker.ListAffectedEntitlementsResponse, error) {
+			query, args := EntitlementsByIngestedEventsQuery(
+				repo.db.GetConfig().Driver.Dialect(),
+				eventFilter.Namespace,
+				eventFilter.EventSubject,
+				eventFilter.MeterSlugs...,
+			)
+
+			rows, err := repo.db.QueryContext(ctx, query, args...)
+			if err != nil {
+				return nil, err
+			}
+
+			defer func() {
+				// FIXME: it would be great to log this erro but the adapter has not logger.
+				_ = rows.Close()
+			}()
+
 			result := make([]balanceworker.ListAffectedEntitlementsResponse, 0)
 
-			// Resolve event subject to customer IDs
-			customers, err := repo.db.Customer.Query().Where(
-				customerdb.Namespace(eventFilter.Namespace),
-				customerNotDeletedAt(clock.Now()),
-				customerdb.Or(
-					customerdb.Key(eventFilter.EventSubject),
-					customerdb.HasSubjectsWith(
-						customersubjectsdb.SubjectKey(eventFilter.EventSubject),
-						customersubjectsdb.DeletedAtIsNil(),
-					),
-				),
-			).All(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to query customers: %w", err)
+			for rows.Next() {
+				r := balanceworker.ListAffectedEntitlementsResponse{}
+
+				err = rows.Scan(
+					&r.Namespace,
+					&r.EntitlementID,
+					&r.CreatedAt,
+					&r.DeletedAt,
+					&r.ActiveFrom,
+					&r.ActiveTo,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("failed to scan entitlement row: %w", err)
+				}
+
+				r.DeletedAt = convert.SafeToUTC(r.DeletedAt)
+				r.ActiveFrom = convert.SafeToUTC(r.ActiveFrom)
+				r.ActiveTo = convert.SafeToUTC(r.ActiveTo)
+
+				result = append(result, r)
 			}
 
-			// resolve feature IDs via meter edge (ingest pipeline provides meter keys)
-			features, err := repo.db.Feature.Query().Where(
-				db_feature.Namespace(eventFilter.Namespace),
-				db_feature.HasMeterWith(db_meter.KeyIn(eventFilter.MeterSlugs...)),
-				db_feature.ArchivedAtIsNil(),
-			).All(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to query features by meters: %w", err)
-			}
-
-			if len(customers) == 0 || len(features) == 0 {
-				return result, nil
-			}
-
-			entitlements, err := repo.db.Entitlement.Query().
-				Where(
-					db_entitlement.Namespace(eventFilter.Namespace),
-					db_entitlement.CustomerIDIn(lo.Uniq(lo.Map(customers, func(item *db.Customer, _ int) string {
-						return item.ID
-					}))...),
-					db_entitlement.FeatureIDIn(lo.Map(features, func(item *db.Feature, _ int) string {
-						return item.ID
-					})...),
-				).
-				All(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to query entitlements: %w", err)
-			}
-
-			for _, e := range entitlements {
-				result = append(result, balanceworker.ListAffectedEntitlementsResponse{
-					Namespace:     e.Namespace,
-					EntitlementID: e.ID,
-					CreatedAt:     e.CreatedAt.UTC(),
-					DeletedAt:     convert.SafeToUTC(e.DeletedAt),
-					ActiveFrom:    convert.SafeToUTC(e.ActiveFrom),
-					ActiveTo:      convert.SafeToUTC(e.ActiveTo),
-				})
+			if err = rows.Err(); err != nil {
+				return nil, fmt.Errorf("failed to iterate over entitlement rows: %w", err)
 			}
 
 			return result, nil

--- a/openmeter/entitlement/adapter/entitlement.go
+++ b/openmeter/entitlement/adapter/entitlement.go
@@ -244,11 +244,11 @@ func EntitlementsByIngestedEventsQuery(dialect, ns, subject string, meters ...st
 	ft := sql.Table(db_feature.Table).As("f")
 	mt := sql.Table(db_meter.Table).As("m")
 
-	withCustomers := "customers"
-	withFeatures := "features"
+	withCustomerBySubject := "customer_by_subject"
+	withFeatureByMeter := "feature_by_meter"
 
 	with := sql.Dialect(dialect).
-		With(withCustomers).
+		With(withCustomerBySubject).
 		As(
 			sql.Select(
 				ct.C(customerdb.FieldID),
@@ -258,7 +258,7 @@ func EntitlementsByIngestedEventsQuery(dialect, ns, subject string, meters ...st
 					sql.And(
 						sql.EQ(ct.C(customerdb.FieldNamespace), ns),
 						sql.EQ(ct.C(customerdb.FieldKey), subject),
-						sql.IsNull(ct.C(customerdb.FieldDeletedAt)),
+						sql.IsNull(ct.C(customersubjectsdb.FieldDeletedAt)),
 					),
 				).
 				Union(
@@ -272,11 +272,11 @@ func EntitlementsByIngestedEventsQuery(dialect, ns, subject string, meters ...st
 								sql.EQ(cst.C(customersubjectsdb.FieldNamespace), ns),
 								sql.EQ(cst.C(customersubjectsdb.FieldSubjectKey), subject),
 								sql.IsNull(ct.C(customerdb.FieldDeletedAt)),
-								sql.IsNull(cst.C(customerdb.FieldDeletedAt)),
+								sql.IsNull(cst.C(customersubjectsdb.FieldDeletedAt)),
 							),
 						)),
 		).
-		With(withFeatures).
+		With(withFeatureByMeter).
 		As(
 			sql.Select(
 				ft.C(db_feature.FieldID),
@@ -286,14 +286,14 @@ func EntitlementsByIngestedEventsQuery(dialect, ns, subject string, meters ...st
 					sql.EQ(ft.C(db_feature.FieldNamespace), ns),
 					sql.IsNull(ft.C(db_feature.FieldArchivedAt)),
 					sql.IsNull(ft.C(db_feature.FieldDeletedAt)),
+					sql.IsNull(mt.C(db_meter.FieldDeletedAt)),
 					sql.In(mt.C(db_meter.FieldKey), lo.ToAnySlice(meters)...),
 				)),
 		)
 
 	et := sql.Table(db_entitlement.Table).As("e")
-
-	cbs := sql.Table(withCustomers).As("cbs")
-	fbm := sql.Table(withFeatures).As("fbm")
+	cbs := sql.Table(withCustomerBySubject).As("cbs")
+	fbm := sql.Table(withFeatureByMeter).As("fbm")
 
 	q := sql.Dialect(dialect).
 		Select(
@@ -321,6 +321,10 @@ func (a *entitlementDBAdapter) ListEntitlementsAffectedByIngestEvents(ctx contex
 		ctx,
 		a,
 		func(ctx context.Context, repo *entitlementDBAdapter) ([]balanceworker.ListAffectedEntitlementsResponse, error) {
+			if err := eventFilter.Validate(); err != nil {
+				return nil, fmt.Errorf("invalid event filter: %w", err)
+			}
+
 			query, args := EntitlementsByIngestedEventsQuery(
 				repo.db.GetConfig().Driver.Dialect(),
 				eventFilter.Namespace,
@@ -330,7 +334,7 @@ func (a *entitlementDBAdapter) ListEntitlementsAffectedByIngestEvents(ctx contex
 
 			rows, err := repo.db.QueryContext(ctx, query, args...)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to query entitlements affected by ingest events: %w", err)
 			}
 
 			defer func() {

--- a/openmeter/entitlement/adapter/entitlement_test.go
+++ b/openmeter/entitlement/adapter/entitlement_test.go
@@ -651,7 +651,7 @@ func TestListEntitlementsByIngestedEventsQuery(t *testing.T) {
 			namespace:     "namespace-1",
 			subject:       "subject-1",
 			meters:        []string{"meter-1", "meter-2"},
-			expectedQuery: `WITH "customers" AS (SELECT "c"."id" FROM "customers" AS "c" WHERE "c"."namespace" = $1 AND "c"."key" = $2 AND "c"."deleted_at" IS NULL UNION SELECT "cs"."customer_id" FROM "customer_subjects" AS "cs" JOIN "customers" AS "c" ON "c"."id" = "cs"."customer_id" WHERE "cs"."namespace" = $3 AND "cs"."subject_key" = $4 AND "c"."deleted_at" IS NULL AND "cs"."deleted_at" IS NULL), "features" AS (SELECT "f"."id" FROM "features" AS "f" JOIN "meters" AS "m" ON "m"."id" = "f"."meter_id" WHERE "f"."namespace" = $5 AND "f"."archived_at" IS NULL AND "f"."deleted_at" IS NULL AND "m"."key" IN ($6, $7)) SELECT "e"."namespace", "e"."id", "e"."created_at", "e"."deleted_at", "e"."active_from", "e"."active_to" FROM "entitlements" AS "e" JOIN "customers" AS "cbs" ON "e"."customer_id" = "cbs"."id" JOIN "features" AS "fbm" ON "e"."feature_id" = "fbm"."id" WHERE "e"."namespace" = $8 AND "e"."deleted_at" IS NULL`,
+			expectedQuery: `WITH "customer_by_subject" AS (SELECT "c"."id" FROM "customers" AS "c" WHERE "c"."namespace" = $1 AND "c"."key" = $2 AND "c"."deleted_at" IS NULL UNION SELECT "cs"."customer_id" FROM "customer_subjects" AS "cs" JOIN "customers" AS "c" ON "c"."id" = "cs"."customer_id" WHERE "cs"."namespace" = $3 AND "cs"."subject_key" = $4 AND "c"."deleted_at" IS NULL AND "cs"."deleted_at" IS NULL), "feature_by_meter" AS (SELECT "f"."id" FROM "features" AS "f" JOIN "meters" AS "m" ON "m"."id" = "f"."meter_id" WHERE "f"."namespace" = $5 AND "f"."archived_at" IS NULL AND "f"."deleted_at" IS NULL AND "m"."deleted_at" IS NULL AND "m"."key" IN ($6, $7)) SELECT "e"."namespace", "e"."id", "e"."created_at", "e"."deleted_at", "e"."active_from", "e"."active_to" FROM "entitlements" AS "e" JOIN "customer_by_subject" AS "cbs" ON "e"."customer_id" = "cbs"."id" JOIN "feature_by_meter" AS "fbm" ON "e"."feature_id" = "fbm"."id" WHERE "e"."namespace" = $8 AND "e"."deleted_at" IS NULL`,
 			expectedArgs: []any{
 				"namespace-1",
 				"subject-1",
@@ -668,7 +668,7 @@ func TestListEntitlementsByIngestedEventsQuery(t *testing.T) {
 			namespace:     "namespace-1",
 			subject:       "subject-1",
 			meters:        []string{"meter-1"},
-			expectedQuery: `WITH "customers" AS (SELECT "c"."id" FROM "customers" AS "c" WHERE "c"."namespace" = $1 AND "c"."key" = $2 AND "c"."deleted_at" IS NULL UNION SELECT "cs"."customer_id" FROM "customer_subjects" AS "cs" JOIN "customers" AS "c" ON "c"."id" = "cs"."customer_id" WHERE "cs"."namespace" = $3 AND "cs"."subject_key" = $4 AND "c"."deleted_at" IS NULL AND "cs"."deleted_at" IS NULL), "features" AS (SELECT "f"."id" FROM "features" AS "f" JOIN "meters" AS "m" ON "m"."id" = "f"."meter_id" WHERE "f"."namespace" = $5 AND "f"."archived_at" IS NULL AND "f"."deleted_at" IS NULL AND "m"."key" IN ($6)) SELECT "e"."namespace", "e"."id", "e"."created_at", "e"."deleted_at", "e"."active_from", "e"."active_to" FROM "entitlements" AS "e" JOIN "customers" AS "cbs" ON "e"."customer_id" = "cbs"."id" JOIN "features" AS "fbm" ON "e"."feature_id" = "fbm"."id" WHERE "e"."namespace" = $7 AND "e"."deleted_at" IS NULL`,
+			expectedQuery: `WITH "customer_by_subject" AS (SELECT "c"."id" FROM "customers" AS "c" WHERE "c"."namespace" = $1 AND "c"."key" = $2 AND "c"."deleted_at" IS NULL UNION SELECT "cs"."customer_id" FROM "customer_subjects" AS "cs" JOIN "customers" AS "c" ON "c"."id" = "cs"."customer_id" WHERE "cs"."namespace" = $3 AND "cs"."subject_key" = $4 AND "c"."deleted_at" IS NULL AND "cs"."deleted_at" IS NULL), "feature_by_meter" AS (SELECT "f"."id" FROM "features" AS "f" JOIN "meters" AS "m" ON "m"."id" = "f"."meter_id" WHERE "f"."namespace" = $5 AND "f"."archived_at" IS NULL AND "f"."deleted_at" IS NULL AND "m"."deleted_at" IS NULL AND "m"."key" IN ($6)) SELECT "e"."namespace", "e"."id", "e"."created_at", "e"."deleted_at", "e"."active_from", "e"."active_to" FROM "entitlements" AS "e" JOIN "customer_by_subject" AS "cbs" ON "e"."customer_id" = "cbs"."id" JOIN "feature_by_meter" AS "fbm" ON "e"."feature_id" = "fbm"."id" WHERE "e"."namespace" = $7 AND "e"."deleted_at" IS NULL`,
 			expectedArgs: []any{
 				"namespace-1",
 				"subject-1",
@@ -810,7 +810,7 @@ func TestListEntitlementsByIngestedEvents(t *testing.T) {
 		return result
 	}
 
-	t.Run("Should return entitlements for Customer key and meters", func(t *testing.T) {
+	t.Run("Should return entitlements for customer key and meter", func(t *testing.T) {
 		entitlements, err := balanceWorkerRepo.ListEntitlementsAffectedByIngestEvents(t.Context(), balanceworker.IngestEventQueryFilter{
 			Namespace:    ns,
 			EventSubject: lo.FromPtr(c1.Key),
@@ -822,7 +822,7 @@ func TestListEntitlementsByIngestedEvents(t *testing.T) {
 		assert.ElementsMatchf(t, expectedEntitlementIDs, toEntitlementIDs(t, entitlements), "entitlement IDs should match expected entitlement IDs")
 	})
 
-	t.Run("Should return entitlements for Customer key and meters", func(t *testing.T) {
+	t.Run("Should return entitlements for subject key and meters", func(t *testing.T) {
 		entitlements, err := balanceWorkerRepo.ListEntitlementsAffectedByIngestEvents(t.Context(), balanceworker.IngestEventQueryFilter{
 			Namespace:    ns,
 			EventSubject: lo.FromPtr(c1.UsageAttribution).SubjectKeys[0],
@@ -832,5 +832,49 @@ func TestListEntitlementsByIngestedEvents(t *testing.T) {
 		assert.NotEmptyf(t, entitlements, "entitlements should not be empty")
 
 		assert.ElementsMatchf(t, expectedEntitlementIDs, toEntitlementIDs(t, entitlements), "entitlement IDs should match expected entitlement IDs")
+	})
+
+	t.Run("Should return no entitlements for non-existing features", func(t *testing.T) {
+		entitlements, err := balanceWorkerRepo.ListEntitlementsAffectedByIngestEvents(t.Context(), balanceworker.IngestEventQueryFilter{
+			Namespace:    ns,
+			EventSubject: lo.FromPtr(c1.UsageAttribution).SubjectKeys[0],
+			MeterSlugs:   []string{"non-existent-meter"},
+		})
+		require.NoErrorf(t, err, "entitlements should be fetched successfully")
+		assert.Emptyf(t, entitlements, "entitlements should be empty")
+	})
+
+	t.Run("Should return only non-deleted entitlements", func(t *testing.T) {
+		err = repo.entRepo.DeleteEntitlement(t.Context(), models.NamespacedID{
+			Namespace: e2.Namespace,
+			ID:        e2.ID,
+		}, clock.Now())
+		require.NoErrorf(t, err, "deleting entitlement should not fail")
+
+		entitlements, err := balanceWorkerRepo.ListEntitlementsAffectedByIngestEvents(t.Context(), balanceworker.IngestEventQueryFilter{
+			Namespace:    ns,
+			EventSubject: lo.FromPtr(c1.UsageAttribution).SubjectKeys[0],
+			MeterSlugs:   []string{m1.Key, m2.Key},
+		})
+		require.NoErrorf(t, err, "entitlements should be fetched successfully")
+		assert.NotEmptyf(t, entitlements, "entitlements should not be empty")
+
+		assert.ElementsMatchf(t, []string{e1.ID}, toEntitlementIDs(t, entitlements), "entitlement IDs should match expected entitlement IDs")
+	})
+
+	t.Run("Should return no entitlements for deleted customer", func(t *testing.T) {
+		err = repo.customerRepo.DeleteCustomer(t.Context(), customer.DeleteCustomerInput{
+			Namespace: c1.Namespace,
+			ID:        c1.ID,
+		})
+		require.NoErrorf(t, err, "deleting entitlement should not fail")
+
+		entitlements, err := balanceWorkerRepo.ListEntitlementsAffectedByIngestEvents(t.Context(), balanceworker.IngestEventQueryFilter{
+			Namespace:    ns,
+			EventSubject: lo.FromPtr(c1.UsageAttribution).SubjectKeys[0],
+			MeterSlugs:   []string{m1.Key, m2.Key},
+		})
+		require.NoErrorf(t, err, "entitlements should be fetched successfully")
+		assert.Emptyf(t, entitlements, "entitlements should be empty")
 	})
 }

--- a/openmeter/entitlement/adapter/entitlement_test.go
+++ b/openmeter/entitlement/adapter/entitlement_test.go
@@ -7,16 +7,21 @@ import (
 	"testing"
 	"time"
 
+	"entgo.io/ent/dialect"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customeradapter "github.com/openmeterio/openmeter/openmeter/customer/adapter"
 	"github.com/openmeterio/openmeter/openmeter/entitlement"
 	"github.com/openmeterio/openmeter/openmeter/entitlement/adapter"
+	"github.com/openmeterio/openmeter/openmeter/entitlement/balanceworker"
 	booleanentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/boolean"
 	meteredentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/metered"
 	staticentitlement "github.com/openmeterio/openmeter/openmeter/entitlement/static"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	meteradapter "github.com/openmeterio/openmeter/openmeter/meter/adapter"
 	featureadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/adapter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/subject"
@@ -36,6 +41,7 @@ type deps struct {
 	featureRepo  feature.FeatureRepo
 	subjectRepo  subject.Service
 	customerRepo customer.Adapter
+	meterRepo    *meteradapter.Adapter
 }
 
 func setup(t *testing.T) (deps deps, cleanup func()) {
@@ -56,6 +62,16 @@ func setup(t *testing.T) (deps deps, cleanup func()) {
 		entDriver.Close()
 		pgDriver.Close()
 	}
+
+	var err error
+
+	// Init meter service
+	deps.meterRepo, err = meteradapter.New(meteradapter.Config{
+		Client: dbClient,
+		Logger: logger,
+	})
+	require.NoErrorf(t, err, "initializing meter adapter must not fail")
+	require.NotNilf(t, deps.meterRepo, "meter adapter must not be nil")
 
 	deps.entRepo = adapter.NewPostgresEntitlementRepo(dbClient)
 	deps.featureRepo = featureadapter.NewPostgresFeatureRepo(dbClient, logger)
@@ -618,5 +634,203 @@ func TestListEntitlementsFiltersByCustomerKeysAndFeatureIDsOrKeys(t *testing.T) 
 		require.NoError(t, err)
 		require.Empty(t, res.Items)
 		require.Zero(t, res.TotalCount)
+	})
+}
+
+func TestListEntitlementsByIngestedEventsQuery(t *testing.T) {
+	tests := []struct {
+		name          string
+		namespace     string
+		subject       string
+		meters        []string
+		expectedQuery string
+		expectedArgs  []any
+	}{
+		{
+			name:          "Should return entitlements for a subject",
+			namespace:     "namespace-1",
+			subject:       "subject-1",
+			meters:        []string{"meter-1", "meter-2"},
+			expectedQuery: `WITH "customers" AS (SELECT "c"."id" FROM "customers" AS "c" WHERE "c"."namespace" = $1 AND "c"."key" = $2 AND "c"."deleted_at" IS NULL UNION SELECT "cs"."customer_id" FROM "customer_subjects" AS "cs" JOIN "customers" AS "c" ON "c"."id" = "cs"."customer_id" WHERE "cs"."namespace" = $3 AND "cs"."subject_key" = $4 AND "c"."deleted_at" IS NULL AND "cs"."deleted_at" IS NULL), "features" AS (SELECT "f"."id" FROM "features" AS "f" JOIN "meters" AS "m" ON "m"."id" = "f"."meter_id" WHERE "f"."namespace" = $5 AND "f"."archived_at" IS NULL AND "f"."deleted_at" IS NULL AND "m"."key" IN ($6, $7)) SELECT "e"."namespace", "e"."id", "e"."created_at", "e"."deleted_at", "e"."active_from", "e"."active_to" FROM "entitlements" AS "e" JOIN "customers" AS "cbs" ON "e"."customer_id" = "cbs"."id" JOIN "features" AS "fbm" ON "e"."feature_id" = "fbm"."id" WHERE "e"."namespace" = $8 AND "e"."deleted_at" IS NULL`,
+			expectedArgs: []any{
+				"namespace-1",
+				"subject-1",
+				"namespace-1",
+				"subject-1",
+				"namespace-1",
+				"meter-1",
+				"meter-2",
+				"namespace-1",
+			},
+		},
+		{
+			name:          "Should return entitlements for a subject and meter",
+			namespace:     "namespace-1",
+			subject:       "subject-1",
+			meters:        []string{"meter-1"},
+			expectedQuery: `WITH "customers" AS (SELECT "c"."id" FROM "customers" AS "c" WHERE "c"."namespace" = $1 AND "c"."key" = $2 AND "c"."deleted_at" IS NULL UNION SELECT "cs"."customer_id" FROM "customer_subjects" AS "cs" JOIN "customers" AS "c" ON "c"."id" = "cs"."customer_id" WHERE "cs"."namespace" = $3 AND "cs"."subject_key" = $4 AND "c"."deleted_at" IS NULL AND "cs"."deleted_at" IS NULL), "features" AS (SELECT "f"."id" FROM "features" AS "f" JOIN "meters" AS "m" ON "m"."id" = "f"."meter_id" WHERE "f"."namespace" = $5 AND "f"."archived_at" IS NULL AND "f"."deleted_at" IS NULL AND "m"."key" IN ($6)) SELECT "e"."namespace", "e"."id", "e"."created_at", "e"."deleted_at", "e"."active_from", "e"."active_to" FROM "entitlements" AS "e" JOIN "customers" AS "cbs" ON "e"."customer_id" = "cbs"."id" JOIN "features" AS "fbm" ON "e"."feature_id" = "fbm"."id" WHERE "e"."namespace" = $7 AND "e"."deleted_at" IS NULL`,
+			expectedArgs: []any{
+				"namespace-1",
+				"subject-1",
+				"namespace-1",
+				"subject-1",
+				"namespace-1",
+				"meter-1",
+				"namespace-1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q, args := adapter.EntitlementsByIngestedEventsQuery(dialect.Postgres, tt.namespace, tt.subject, tt.meters...)
+			assert.Equal(t, tt.expectedQuery, q)
+			assert.Equal(t, tt.expectedArgs, args)
+		})
+	}
+}
+
+func TestListEntitlementsByIngestedEvents(t *testing.T) {
+	repo, cleanup := setup(t)
+	defer cleanup()
+
+	ns := "namespace-1"
+
+	m1, err := repo.meterRepo.CreateMeter(t.Context(), meter.CreateMeterInput{
+		Namespace:   ns,
+		Name:        "API Requests",
+		Key:         "api_requests_total",
+		Aggregation: meter.MeterAggregationCount,
+		EventType:   "api-request",
+		GroupBy: map[string]string{
+			"method": "$.method",
+			"path":   "$.path",
+		},
+	})
+	require.NoErrorf(t, err, "meter creation should not fail")
+	assert.NotEmptyf(t, m1.ID, "meter ID should not be empty")
+
+	m2, err := repo.meterRepo.CreateMeter(t.Context(), meter.CreateMeterInput{
+		Namespace:     ns,
+		Name:          "Tokens",
+		Key:           "tokens_total",
+		Aggregation:   meter.MeterAggregationSum,
+		EventType:     "prompt",
+		ValueProperty: lo.ToPtr("$.tokens"),
+		GroupBy: map[string]string{
+			"model": "$.model",
+			"type":  "$.type",
+		},
+	})
+	require.NoErrorf(t, err, "meter creation should not fail")
+	assert.NotEmptyf(t, m2.ID, "meter ID should not be empty")
+
+	f1, err := repo.featureRepo.CreateFeature(t.Context(), feature.CreateFeatureInputs{
+		Name:                m1.Name,
+		Key:                 m1.Key,
+		Namespace:           m1.Namespace,
+		MeterID:             lo.ToPtr(m1.ID),
+		MeterGroupByFilters: feature.ConvertMapStringToMeterGroupByFilters(m1.GroupBy),
+	})
+	require.NoErrorf(t, err, "feature creation should not fail")
+	assert.NotEmptyf(t, f1.ID, "feature ID should not be empty")
+
+	f2, err := repo.featureRepo.CreateFeature(t.Context(), feature.CreateFeatureInputs{
+		Name:                m2.Name,
+		Key:                 m2.Key,
+		Namespace:           m2.Namespace,
+		MeterID:             lo.ToPtr(m2.ID),
+		MeterGroupByFilters: feature.ConvertMapStringToMeterGroupByFilters(m2.GroupBy),
+	})
+	require.NoErrorf(t, err, "feature creation should not fail")
+	assert.NotEmptyf(t, f2.ID, "feature ID should not be empty")
+
+	c1, err := repo.customerRepo.CreateCustomer(t.Context(), customer.CreateCustomerInput{
+		Namespace: ns,
+		CustomerMutate: customer.CustomerMutate{
+			Key:  lo.ToPtr("customer-1"),
+			Name: "Customer 1",
+			UsageAttribution: &customer.CustomerUsageAttribution{
+				SubjectKeys: []string{"subject-1"},
+			},
+		},
+	})
+	require.NoErrorf(t, err, "customer creation should not fail")
+	assert.NotEmptyf(t, c1.ID, "customer ID should not be empty")
+	require.NotEmptyf(t, c1.Key, "customer key should not be empty")
+	require.NotEmptyf(t, c1.UsageAttribution, "customer usage attribution should not be empty")
+
+	e1, err := repo.entRepo.CreateEntitlement(t.Context(), entitlement.CreateEntitlementRepoInputs{
+		Namespace:        ns,
+		FeatureID:        f1.ID,
+		FeatureKey:       f1.Key,
+		UsageAttribution: c1.GetUsageAttribution(),
+		EntitlementType:  entitlement.EntitlementTypeMetered,
+		MeasureUsageFrom: lo.ToPtr(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		UsagePeriod: lo.ToPtr(entitlement.NewUsagePeriodInputFromRecurrence(timeutil.Recurrence{
+			Interval: timeutil.RecurrencePeriodMonth,
+			Anchor:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		})),
+		IsSoftLimit: lo.ToPtr(true),
+	})
+	require.NoErrorf(t, err, "entitlement creation should not fail")
+	assert.NotEmptyf(t, e1.ID, "entitlement ID should not be empty")
+
+	e2, err := repo.entRepo.CreateEntitlement(t.Context(), entitlement.CreateEntitlementRepoInputs{
+		Namespace:        ns,
+		FeatureID:        f2.ID,
+		FeatureKey:       f2.Key,
+		UsageAttribution: c1.GetUsageAttribution(),
+		EntitlementType:  entitlement.EntitlementTypeMetered,
+		MeasureUsageFrom: lo.ToPtr(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		UsagePeriod: lo.ToPtr(entitlement.NewUsagePeriodInputFromRecurrence(timeutil.Recurrence{
+			Interval: timeutil.RecurrencePeriodMonth,
+			Anchor:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		})),
+		IsSoftLimit: lo.ToPtr(true),
+	})
+	require.NoErrorf(t, err, "entitlement creation should not fail")
+	assert.NotEmptyf(t, e2.ID, "entitlement ID should not be empty")
+
+	balanceWorkerRepo, ok := repo.entRepo.(balanceworker.BalanceWorkerRepository)
+	require.Truef(t, ok, "entitlement repository should implement BalanceWorkerRepository")
+	require.NotNilf(t, balanceWorkerRepo, "balanceWorkerRepo should not be nil")
+
+	expectedEntitlementIDs := []string{e1.ID, e2.ID}
+
+	toEntitlementIDs := func(t *testing.T, entitlements []balanceworker.ListAffectedEntitlementsResponse) []string {
+		t.Helper()
+
+		result := make([]string, 0, len(entitlements))
+
+		for _, e := range entitlements {
+			result = append(result, e.EntitlementID)
+		}
+
+		return result
+	}
+
+	t.Run("Should return entitlements for Customer key and meters", func(t *testing.T) {
+		entitlements, err := balanceWorkerRepo.ListEntitlementsAffectedByIngestEvents(t.Context(), balanceworker.IngestEventQueryFilter{
+			Namespace:    ns,
+			EventSubject: lo.FromPtr(c1.Key),
+			MeterSlugs:   []string{m1.Key, m2.Key},
+		})
+		require.NoErrorf(t, err, "entitlements should be fetched successfully")
+		assert.NotEmptyf(t, entitlements, "entitlements should not be empty")
+
+		assert.ElementsMatchf(t, expectedEntitlementIDs, toEntitlementIDs(t, entitlements), "entitlement IDs should match expected entitlement IDs")
+	})
+
+	t.Run("Should return entitlements for Customer key and meters", func(t *testing.T) {
+		entitlements, err := balanceWorkerRepo.ListEntitlementsAffectedByIngestEvents(t.Context(), balanceworker.IngestEventQueryFilter{
+			Namespace:    ns,
+			EventSubject: lo.FromPtr(c1.UsageAttribution).SubjectKeys[0],
+			MeterSlugs:   []string{m1.Key, m2.Key},
+		})
+		require.NoErrorf(t, err, "entitlements should be fetched successfully")
+		assert.NotEmptyf(t, entitlements, "entitlements should not be empty")
+
+		assert.ElementsMatchf(t, expectedEntitlementIDs, toEntitlementIDs(t, entitlements), "entitlement IDs should match expected entitlement IDs")
 	})
 }

--- a/openmeter/entitlement/balanceworker/repository.go
+++ b/openmeter/entitlement/balanceworker/repository.go
@@ -2,10 +2,12 @@ package balanceworker
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/samber/lo"
 
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -17,6 +19,24 @@ type IngestEventQueryFilter struct {
 	Namespace    string
 	EventSubject string
 	MeterSlugs   []string
+}
+
+func (f IngestEventQueryFilter) Validate() error {
+	var errs []error
+
+	if f.Namespace == "" {
+		errs = append(errs, errors.New("namespace is required"))
+	}
+
+	if f.EventSubject == "" {
+		errs = append(errs, errors.New("subject is required"))
+	}
+
+	if len(f.MeterSlugs) == 0 {
+		errs = append(errs, errors.New("at least one meter key is required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type ListAffectedEntitlementsResponse struct {


### PR DESCRIPTION
## Overview

Improve fetching entitlements affected by ingested events. It combines 3 separate database calls into one reducing the time/resources to get affected entitlements. This helps with improving the overall performance of the balance worker which heavily relies on this call in order to figure out which entitlements need to be tracked/their balance updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated entitlement lookup into a single, database-optimized query for improved performance.
  * Normalized timestamp fields to UTC and centralized error handling around query execution and row scanning.

* **New Features**
  * Added structured validation for ingest-event filters to ensure required fields and meter selection.

* **Tests**
  * Added unit and integration tests covering query generation, SQL argument ordering, and end-to-end behavior for entitlement lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->