### PR TITLE
fix: lock handling for event handler

### DIFF
--- a/openmeter/notification/eventhandler/handler.go
+++ b/openmeter/notification/eventhandler/handler.go
@@ -92,12 +92,6 @@ func (h *Handler) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := h.lockr.Start(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to start session lockr: %w", err)
-	}
-	defer h.lockr.Close()
-
 	ticker := time.NewTicker(h.reconcileInterval)
 	defer ticker.Stop()
 

--- a/openmeter/notification/eventhandler/reconcile.go
+++ b/openmeter/notification/eventhandler/reconcile.go
@@ -73,6 +73,12 @@ func (h *Handler) Reconcile(ctx context.Context) error {
 
 		span.AddEvent("acquiring lock")
 
+		err := h.lockr.Start(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to start session lockr: %w", err)
+		}
+		defer h.lockr.Close()
+
 		releaser, err := h.lockr.TryLockWithScopes(ctx, reconcileLockKey)
 		if err != nil {
 			if errors.Is(err, lockr.ErrNoLockAcquired) {

--- a/pkg/framework/lockr/session.go
+++ b/pkg/framework/lockr/session.go
@@ -17,10 +17,11 @@ import (
 )
 
 var (
-	ErrNoLockAcquired    = errors.New("lock could not be acquired")
-	ErrNoLockReleased    = errors.New("lock could not be released")
-	ErrSessionLockerDone = errors.New("session locker is already closed")
-	ErrSessionLockerBusy = errors.New("session locker is blocked by another lock request")
+	ErrNoLockAcquired     = errors.New("lock could not be acquired")
+	ErrNoLockReleased     = errors.New("lock could not be released")
+	ErrSessionLockerDone  = errors.New("session locker is already closed")
+	ErrSessionLockerBusy  = errors.New("session locker is blocked by another lock request")
+	ErrDatabaseConnClosed = errors.New("database connection is closed")
 )
 
 type Releaser func(context.Context) error
@@ -42,7 +43,7 @@ func (r *releaser) release(ctx context.Context) error {
 
 	rErr := r.locker.release(ctx, r.key)
 	if rErr != nil {
-		if !errors.Is(rErr, ErrNoLockReleased) && !errors.Is(rErr, ErrSessionLockerDone) {
+		if !errors.Is(rErr, ErrNoLockReleased) && !errors.Is(rErr, ErrSessionLockerDone) && !errors.Is(rErr, ErrDatabaseConnClosed) {
 			return rErr
 		}
 	}
@@ -108,11 +109,31 @@ func (l *SessionLocker) Start(ctx context.Context) error {
 		}
 	}
 
+	if err = l.conn.PingContext(ctx); err != nil {
+		l.logger.WarnContext(ctx, "recreating connection", "error", err)
+
+		// Close the existing connection and create a new one
+		l.closer()
+
+		l.conn, err = l.driver.DB().Conn(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get postgres connection: %w", err)
+		}
+	}
+
 	l.closer = sync.OnceFunc(func() {
-		if err := l.conn.Close(); err != nil {
-			l.logger.Error("failed to close postgres connection: some session-level advisory locks might be dangling", "error", err)
+		if l.conn == nil {
+			return
+		}
+
+		if cErr := l.conn.Close(); cErr != nil {
+			if !errors.Is(cErr, sql.ErrConnDone) {
+				l.logger.Error("failed to close postgres connection: some session-level advisory locks might be dangling", "error", cErr)
+			}
 		}
 	})
+
+	l.closed.Store(false)
 
 	return err
 }
@@ -120,6 +141,10 @@ func (l *SessionLocker) Start(ctx context.Context) error {
 func (l *SessionLocker) lock(ctx context.Context, key Key, nonblocking bool) (Releaser, error) {
 	if l.closed.Load() {
 		return nil, ErrSessionLockerDone
+	}
+
+	if err := l.conn.PingContext(ctx); err != nil {
+		return nil, ErrDatabaseConnClosed
 	}
 
 	lockFunc := "pg_advisory_lock"
@@ -229,6 +254,10 @@ func (l *SessionLocker) release(ctx context.Context, key Key) error {
 		return ErrSessionLockerDone
 	}
 
+	if err := l.conn.PingContext(ctx); err != nil {
+		return ErrDatabaseConnClosed
+	}
+
 	q, args := entsql.Dialect(dialect.Postgres).
 		SelectExpr(entsql.ExprFunc(func(b *entsql.Builder) {
 			b.WriteString("pg_advisory_unlock")
@@ -279,7 +308,9 @@ func (l *SessionLocker) Close() {
 		return
 	}
 
-	l.closer()
+	if l.closer == nil {
+		l.closer()
+	}
 	l.closed.Store(true)
 
 	// Release references to conn and closer so it can be GC'd

--- a/pkg/framework/lockr/session_test.go
+++ b/pkg/framework/lockr/session_test.go
@@ -419,4 +419,35 @@ func Test_SessionLocker(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, releaser2(t.Context()))
 	})
+
+	t.Run("Reuse lockr", func(t *testing.T) {
+		locker1 := newTestSessionLocker(t, testDB.URL)
+		err := locker1.Start(t.Context())
+		require.NoError(t, err)
+		defer locker1.Close()
+
+		k, err := NewKey("test", "reuse-lockr")
+		require.NoError(t, err)
+
+		// Session acquires with blocking Lock
+		releaser, err := locker1.Lock(t.Context(), k)
+		require.NoError(t, err)
+
+		// Release
+		require.NoError(t, releaser(t.Context()))
+
+		// Close Lockr
+		locker1.Close()
+
+		err = locker1.Start(t.Context())
+		require.NoError(t, err)
+		defer locker1.Close()
+
+		// Session acquires with blocking Lock
+		releaser, err = locker1.Lock(t.Context(), k)
+		require.NoError(t, err)
+
+		// Release
+		require.NoError(t, releaser(t.Context()))
+	})
 }


### PR DESCRIPTION
## Overview

Initialize session lock for each reconcile run as underlying database connection might be closed due maximum connection lifetime configuration of the database driver.

Session lockr will be reworked to support only "short" lived locking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved session lifecycle handling into the reconciliation flow to improve startup sequencing and resource management.

* **Bug Fixes**
  * Detects and recreates unhealthy database connections to prevent stale connection failures.
  * Suppresses benign "connection already closed" noise during shutdown.
  * Aborts reconciliation early when session startup fails to avoid futile lock attempts.

* **Tests**
  * Added a test verifying a session can be restarted and reused reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->