### PR TITLE
fix(productcatalog): rate card validation

### DIFF
--- a/e2e/addons_v3_test.go
+++ b/e2e/addons_v3_test.go
@@ -293,9 +293,9 @@ func TestV3AddonInstanceTypePriceCompatibility(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			name:         "multiple + flat rate card → 201",
-			instanceType: apiv3.AddonInstanceTypeMultiple,
-			rateCardFn:   func(t *testing.T) apiv3.BillingRateCard { return validFlatRateCard("multi_flat") },
+			name:           "multiple + flat rate card → 201",
+			instanceType:   apiv3.AddonInstanceTypeMultiple,
+			rateCardFn:     func(t *testing.T) apiv3.BillingRateCard { return validFlatRateCard("multi_flat") },
 			expectedStatus: http.StatusCreated,
 		},
 		{

--- a/e2e/addons_v3_test.go
+++ b/e2e/addons_v3_test.go
@@ -132,14 +132,14 @@ func TestV3Addon(t *testing.T) {
 func TestV3AddonMixedRateCardRoundTrip(t *testing.T) {
 	c := newV3Client(t)
 
-	unitFeatureID := createTestFeature(t, "mix_unit")
-	graduatedFeatureID := createTestFeature(t, "mix_graduated")
+	unitFeatureID, unitFeatureKey := createTestFeature(t, "mix_unit")
+	graduatedFeatureID, graduatedFeatureKey := createTestFeature(t, "mix_graduated")
 
 	flat := validFlatRateCard("mix_flat")
-	unit := validUnitRateCard("mix_unit", unitFeatureID)
+	unit := validUnitRateCard(unitFeatureID, unitFeatureKey)
 	percent := float32(10)
 	unit.Discounts = &apiv3.BillingRateCardDiscounts{Percentage: &percent}
-	graduated := validGraduatedRateCard("mix_graduated", graduatedFeatureID)
+	graduated := validGraduatedRateCard(graduatedFeatureID, graduatedFeatureKey)
 
 	body := validAddonRequest("mixed_rc")
 	body.RateCards = []apiv3.BillingRateCard{flat, unit, graduated}
@@ -302,8 +302,8 @@ func TestV3AddonInstanceTypePriceCompatibility(t *testing.T) {
 			name:         "single + unit rate card → 201",
 			instanceType: apiv3.AddonInstanceTypeSingle,
 			rateCardFn: func(t *testing.T) apiv3.BillingRateCard {
-				featureID := createTestFeature(t, "single_unit")
-				return validUnitRateCard("single_unit", featureID)
+				featureID, featureKey := createTestFeature(t, "single_unit")
+				return validUnitRateCard(featureID, featureKey)
 			},
 			expectedStatus: http.StatusCreated,
 		},

--- a/e2e/addons_v3_test.go
+++ b/e2e/addons_v3_test.go
@@ -132,11 +132,14 @@ func TestV3Addon(t *testing.T) {
 func TestV3AddonMixedRateCardRoundTrip(t *testing.T) {
 	c := newV3Client(t)
 
+	unitFeatureID := createTestFeature(t, "mix_unit")
+	graduatedFeatureID := createTestFeature(t, "mix_graduated")
+
 	flat := validFlatRateCard("mix_flat")
-	unit := validUnitRateCard("mix_unit")
+	unit := validUnitRateCard("mix_unit", unitFeatureID)
 	percent := float32(10)
 	unit.Discounts = &apiv3.BillingRateCardDiscounts{Percentage: &percent}
-	graduated := validGraduatedRateCard("mix_graduated")
+	graduated := validGraduatedRateCard("mix_graduated", graduatedFeatureID)
 
 	body := validAddonRequest("mixed_rc")
 	body.RateCards = []apiv3.BillingRateCard{flat, unit, graduated}
@@ -286,19 +289,22 @@ func TestV3AddonInstanceTypePriceCompatibility(t *testing.T) {
 	cases := []struct {
 		name           string
 		instanceType   apiv3.AddonInstanceType
-		rateCard       apiv3.BillingRateCard
+		rateCardFn     func(t *testing.T) apiv3.BillingRateCard
 		expectedStatus int
 	}{
 		{
-			name:           "multiple + flat rate card → 201",
-			instanceType:   apiv3.AddonInstanceTypeMultiple,
-			rateCard:       validFlatRateCard("multi_flat"),
+			name:         "multiple + flat rate card → 201",
+			instanceType: apiv3.AddonInstanceTypeMultiple,
+			rateCardFn:   func(t *testing.T) apiv3.BillingRateCard { return validFlatRateCard("multi_flat") },
 			expectedStatus: http.StatusCreated,
 		},
 		{
-			name:           "single + unit rate card → 201",
-			instanceType:   apiv3.AddonInstanceTypeSingle,
-			rateCard:       validUnitRateCard("single_unit"),
+			name:         "single + unit rate card → 201",
+			instanceType: apiv3.AddonInstanceTypeSingle,
+			rateCardFn: func(t *testing.T) apiv3.BillingRateCard {
+				featureID := createTestFeature(t, "single_unit")
+				return validUnitRateCard("single_unit", featureID)
+			},
 			expectedStatus: http.StatusCreated,
 		},
 	}
@@ -309,7 +315,7 @@ func TestV3AddonInstanceTypePriceCompatibility(t *testing.T) {
 
 			body := validAddonRequest("instance_type_price")
 			body.InstanceType = tc.instanceType
-			body.RateCards = []apiv3.BillingRateCard{tc.rateCard}
+			body.RateCards = []apiv3.BillingRateCard{tc.rateCardFn(t)}
 
 			status, addon, problem := c.CreateAddon(body)
 			assert.Equal(t, tc.expectedStatus, status, "problem: %+v", problem)

--- a/e2e/config.yaml
+++ b/e2e/config.yaml
@@ -106,6 +106,11 @@ meters:
     eventType: plan_meter
     aggregation: SUM
     valueProperty: $.value
+  - slug: addon_meter
+    description: Meter for testing addon metered features
+    eventType: addon_meter
+    aggregation: SUM
+    valueProperty: $.value
   - slug: multi_subject_meter
     description: Meter for testing multi subject
     eventType: multi_subject

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1560,7 +1560,9 @@ func TestCredit(t *testing.T) {
 		require.Len(t, *grantListResp.JSON200, 1)
 
 		// Get feature
-		featureListResp, err := client.ListFeaturesWithResponse(context.Background(), nil)
+		featureListResp, err := client.ListFeaturesWithResponse(context.Background(), &api.ListFeaturesParams{
+			MeterSlug: &[]string{meterSlug},
+		})
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, featureListResp.StatusCode())
 		require.NotNil(t, featureListResp.JSON200)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1560,7 +1560,7 @@ func TestCredit(t *testing.T) {
 		require.Len(t, *grantListResp.JSON200, 1)
 
 		// Get feature
-		featureListResp, err := client.ListFeaturesWithResponse(context.Background(), &api.ListFeaturesParams{
+		featureListResp, err := client.ListFeaturesWithResponse(t.Context(), &api.ListFeaturesParams{
 			MeterSlug: &[]string{meterSlug},
 		})
 		require.NoError(t, err)

--- a/e2e/v3helpers_test.go
+++ b/e2e/v3helpers_test.go
@@ -364,10 +364,12 @@ func validFlatRateCard(keyPrefix string) apiv3.BillingRateCard {
 // It must exist in the e2e server config (e2e/config.yaml).
 const addonMeterSlug = "addon_meter"
 
-// createTestFeature creates a metered feature via the v1 API and returns its ID.
-// The feature references the pre-configured addon_meter so that non-flat rate cards
-// referencing it pass the "feature must be metered" validation.
-func createTestFeature(t *testing.T, keyPrefix string) string {
+// createTestFeature creates a metered feature via the v1 API and returns its
+// (id, key). The feature references the pre-configured addon_meter so that
+// non-flat rate cards referencing it pass the "feature must be metered"
+// validation. The rate card Key must equal the feature Key, so callers should
+// use the returned key as the rate card key.
+func createTestFeature(t *testing.T, keyPrefix string) (id, key string) {
 	t.Helper()
 
 	client := initClient(t)
@@ -375,7 +377,7 @@ func createTestFeature(t *testing.T, keyPrefix string) string {
 	ctx, cancel := context.WithTimeout(t.Context(), v3RequestTimeout)
 	defer cancel()
 
-	key := uniqueKey(keyPrefix + "_feature")
+	key = uniqueKey(keyPrefix + "_feature")
 	meterSlug := addonMeterSlug
 	resp, err := client.CreateFeatureWithResponse(ctx, api.CreateFeatureJSONRequestBody{
 		Key:       key,
@@ -386,14 +388,15 @@ func createTestFeature(t *testing.T, keyPrefix string) string {
 	require.Equal(t, http.StatusCreated, resp.StatusCode(), "create feature: %s", resp.Body)
 	require.NotNil(t, resp.JSON201)
 
-	return resp.JSON201.Id
+	return resp.JSON201.Id, key
 }
 
 // validUnitRateCard returns a usage-based unit-priced rate card. Unit prices
 // cannot use payment_term=in_advance (that's flat-only), so this uses
-// in_arrears. featureID must reference an existing feature (non-flat prices
-// require a feature).
-func validUnitRateCard(keyPrefix string, featureID string) apiv3.BillingRateCard {
+// in_arrears. featureID and featureKey must reference an existing metered
+// feature; the rate card Key is set to featureKey (Key == FeatureKey is
+// required by server validation).
+func validUnitRateCard(featureID, featureKey string) apiv3.BillingRateCard {
 	cadence := apiv3.ISO8601Duration("P1M")
 	term := apiv3.BillingPricePaymentTermInArrears
 
@@ -406,8 +409,8 @@ func validUnitRateCard(keyPrefix string, featureID string) apiv3.BillingRateCard
 	}
 
 	return apiv3.BillingRateCard{
-		Key:            uniqueKey(keyPrefix),
-		Name:           "Test Unit Rate Card " + keyPrefix,
+		Key:            featureKey,
+		Name:           "Test Unit Rate Card",
 		Price:          price,
 		BillingCadence: &cadence,
 		PaymentTerm:    &term,
@@ -416,9 +419,10 @@ func validUnitRateCard(keyPrefix string, featureID string) apiv3.BillingRateCard
 }
 
 // validGraduatedRateCard returns a graduated tiered rate card with two tiers:
-// 0–100 units at $0.10/unit and 100+ units at $0.05/unit. featureID must
-// reference an existing feature (non-flat prices require a feature).
-func validGraduatedRateCard(keyPrefix string, featureID string) apiv3.BillingRateCard {
+// 0–100 units at $0.10/unit and 100+ units at $0.05/unit. featureID and
+// featureKey must reference an existing metered feature; the rate card Key is
+// set to featureKey (Key == FeatureKey is required by server validation).
+func validGraduatedRateCard(featureID, featureKey string) apiv3.BillingRateCard {
 	cadence := apiv3.ISO8601Duration("P1M")
 	term := apiv3.BillingPricePaymentTermInArrears
 
@@ -446,8 +450,8 @@ func validGraduatedRateCard(keyPrefix string, featureID string) apiv3.BillingRat
 	}
 
 	return apiv3.BillingRateCard{
-		Key:            uniqueKey(keyPrefix),
-		Name:           "Test Graduated Rate Card " + keyPrefix,
+		Key:            featureKey,
+		Name:           "Test Graduated Rate Card",
 		Price:          price,
 		BillingCadence: &cadence,
 		PaymentTerm:    &term,

--- a/e2e/v3helpers_test.go
+++ b/e2e/v3helpers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	api "github.com/openmeterio/openmeter/api/client/go"
 	apiv3 "github.com/openmeterio/openmeter/api/v3"
 )
 
@@ -359,10 +360,40 @@ func validFlatRateCard(keyPrefix string) apiv3.BillingRateCard {
 	}
 }
 
+// addonMeterSlug is the pre-configured meter used for addon metered features.
+// It must exist in the e2e server config (e2e/config.yaml).
+const addonMeterSlug = "addon_meter"
+
+// createTestFeature creates a metered feature via the v1 API and returns its ID.
+// The feature references the pre-configured addon_meter so that non-flat rate cards
+// referencing it pass the "feature must be metered" validation.
+func createTestFeature(t *testing.T, keyPrefix string) string {
+	t.Helper()
+
+	client := initClient(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), v3RequestTimeout)
+	defer cancel()
+
+	key := uniqueKey(keyPrefix + "_feature")
+	meterSlug := addonMeterSlug
+	resp, err := client.CreateFeatureWithResponse(ctx, api.CreateFeatureJSONRequestBody{
+		Key:       key,
+		Name:      "Test Feature " + keyPrefix,
+		MeterSlug: &meterSlug,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, resp.StatusCode(), "create feature: %s", resp.Body)
+	require.NotNil(t, resp.JSON201)
+
+	return resp.JSON201.Id
+}
+
 // validUnitRateCard returns a usage-based unit-priced rate card. Unit prices
 // cannot use payment_term=in_advance (that's flat-only), so this uses
-// in_arrears.
-func validUnitRateCard(keyPrefix string) apiv3.BillingRateCard {
+// in_arrears. featureID must reference an existing feature (non-flat prices
+// require a feature).
+func validUnitRateCard(keyPrefix string, featureID string) apiv3.BillingRateCard {
 	cadence := apiv3.ISO8601Duration("P1M")
 	term := apiv3.BillingPricePaymentTermInArrears
 
@@ -380,12 +411,14 @@ func validUnitRateCard(keyPrefix string) apiv3.BillingRateCard {
 		Price:          price,
 		BillingCadence: &cadence,
 		PaymentTerm:    &term,
+		Feature:        &apiv3.FeatureReferenceItem{Id: featureID},
 	}
 }
 
 // validGraduatedRateCard returns a graduated tiered rate card with two tiers:
-// 0–100 units at $0.10/unit and 100+ units at $0.05/unit.
-func validGraduatedRateCard(keyPrefix string) apiv3.BillingRateCard {
+// 0–100 units at $0.10/unit and 100+ units at $0.05/unit. featureID must
+// reference an existing feature (non-flat prices require a feature).
+func validGraduatedRateCard(keyPrefix string, featureID string) apiv3.BillingRateCard {
 	cadence := apiv3.ISO8601Duration("P1M")
 	term := apiv3.BillingPricePaymentTermInArrears
 
@@ -418,6 +451,7 @@ func validGraduatedRateCard(keyPrefix string) apiv3.BillingRateCard {
 		Price:          price,
 		BillingCadence: &cadence,
 		PaymentTerm:    &term,
+		Feature:        &apiv3.FeatureReferenceItem{Id: featureID},
 	}
 }
 

--- a/openmeter/productcatalog/addon/service/addon.go
+++ b/openmeter/productcatalog/addon/service/addon.go
@@ -110,10 +110,20 @@ func (s service) resolveFeatures(ctx context.Context, namespace string, rateCard
 			if featureByID.Key != *fK {
 				return models.NewGenericNotFoundError(fmt.Errorf("feature with ID %s has key %s, but expected %s", *fID, featureByID.Key, *fK))
 			}
+
+			price := rateCard.AsMeta().Price
+			if price != nil && price.Type() != productcatalog.FlatPriceType && featureByID.MeterID == nil {
+				return models.NewGenericValidationError(productcatalog.ErrRateCardUsageBasedPriceRequiresMeteredFeature)
+			}
 		} else if fID != nil && fK == nil {
 			// We need to populate FeatureKey
 			if !featureByIDOk {
 				return models.NewGenericNotFoundError(fmt.Errorf("feature with ID %s not found", *fID))
+			}
+
+			price := rateCard.AsMeta().Price
+			if price != nil && price.Type() != productcatalog.FlatPriceType && featureByID.MeterID == nil {
+				return models.NewGenericValidationError(productcatalog.ErrRateCardUsageBasedPriceRequiresMeteredFeature)
 			}
 
 			// FIXME: merging like this is a pain, we should just use pointers...
@@ -148,6 +158,11 @@ func (s service) resolveFeatures(ctx context.Context, namespace string, rateCard
 			// We need to populate FeatureID
 			if !featureByKeyOk {
 				return models.NewGenericNotFoundError(fmt.Errorf("feature with key %s not found", *fK))
+			}
+
+			price := rateCard.AsMeta().Price
+			if price != nil && price.Type() != productcatalog.FlatPriceType && featureByKey.MeterID == nil {
+				return models.NewGenericValidationError(productcatalog.ErrRateCardUsageBasedPriceRequiresMeteredFeature)
 			}
 
 			// FIXME: merging like this is a pain, we should just use pointers...

--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -317,6 +317,16 @@ var ErrRateCardUsageBasedPriceRequiresFeatureKey = models.NewValidationIssue(
 	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
 )
 
+const ErrCodeRateCardUsageBasedPriceRequiresMeteredFeature models.ErrorCode = "rate_card_usage_based_price_requires_metered_feature"
+
+var ErrRateCardUsageBasedPriceRequiresMeteredFeature = models.NewValidationIssue(
+	ErrCodeRateCardUsageBasedPriceRequiresMeteredFeature,
+	"non-flat prices require a metered feature (feature must have a meter)",
+	models.WithFieldString("featureKey"),
+	models.WithCriticalSeverity(),
+	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
+)
+
 const ErrCodePercentageDiscountInvalidValue models.ErrorCode = "percentage_discount_invalid_value"
 
 var ErrPercentageDiscountInvalidValue = models.NewValidationIssue(

--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -307,6 +307,16 @@ var ErrRateCardKeyFeatureKeyMismatch = models.NewValidationIssue(
 	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
 )
 
+const ErrCodeRateCardUsageBasedPriceRequiresFeatureKey models.ErrorCode = "rate_card_usage_based_price_requires_feature_key"
+
+var ErrRateCardUsageBasedPriceRequiresFeatureKey = models.NewValidationIssue(
+	ErrCodeRateCardUsageBasedPriceRequiresFeatureKey,
+	"featureKey is required for non-flat prices",
+	models.WithFieldString("featureKey"),
+	models.WithCriticalSeverity(),
+	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
+)
+
 const ErrCodePercentageDiscountInvalidValue models.ErrorCode = "percentage_discount_invalid_value"
 
 var ErrPercentageDiscountInvalidValue = models.NewValidationIssue(

--- a/openmeter/productcatalog/plan/adapter/adapter_test.go
+++ b/openmeter/productcatalog/plan/adapter/adapter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	pctestutils "github.com/openmeterio/openmeter/openmeter/productcatalog/testutils"
@@ -17,9 +18,12 @@ import (
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
 )
 
 var MonthPeriod = datetime.NewISODuration(0, 1, 0, 0, 0, 0, 0)
+
+const proRateCardFeatureKey = "api_requests_total"
 
 var planPhases = []productcatalog.Phase{
 	{
@@ -65,11 +69,11 @@ var planPhases = []productcatalog.Phase{
 		RateCards: []productcatalog.RateCard{
 			&productcatalog.UsageBasedRateCard{
 				RateCardMeta: productcatalog.RateCardMeta{
-					Key:                 "pro-ratecard-1",
+					Key:                 proRateCardFeatureKey,
 					Name:                "Pro RateCard 1",
 					Description:         lo.ToPtr("Pro RateCard 1"),
 					Metadata:            models.Metadata{"name": "pro-ratecard-1"},
-					FeatureKey:          nil,
+					FeatureKey:          lo.ToPtr(proRateCardFeatureKey),
 					FeatureID:           nil,
 					EntitlementTemplate: nil,
 					TaxConfig: &productcatalog.TaxConfig{
@@ -124,6 +128,31 @@ func TestPostgresAdapter(t *testing.T) {
 
 	// Get new namespace ID
 	namespace := pctestutils.NewTestNamespace(t)
+
+	err := env.Meter.ReplaceMeters(ctx, pctestutils.NewTestMeters(t, namespace))
+	require.NoErrorf(t, err, "replacing meters must not fail")
+
+	result, err := env.Meter.ListMeters(ctx, meter.ListMetersParams{
+		Page: pagination.Page{
+			PageSize:   1000,
+			PageNumber: 1,
+		},
+		Namespace: namespace,
+	})
+	require.NoErrorf(t, err, "listing meters must not fail")
+
+	var proMeter *meter.Meter
+	for _, m := range result.Items {
+		if m.Key == proRateCardFeatureKey {
+			mm := m
+			proMeter = &mm
+			break
+		}
+	}
+	require.NotNilf(t, proMeter, "meter with key %s must exist", proRateCardFeatureKey)
+
+	_, err = env.Feature.CreateFeature(ctx, pctestutils.NewTestFeatureFromMeter(t, proMeter))
+	require.NoErrorf(t, err, "creating pro rate card feature must not fail")
 
 	planV1Input := pctestutils.NewTestPlan(t, namespace, planPhases...)
 

--- a/openmeter/productcatalog/plan/adapter/mapping.go
+++ b/openmeter/productcatalog/plan/adapter/mapping.go
@@ -185,6 +185,14 @@ func FromAddonRateCardRow(r entdb.AddonRateCard) (productcatalog.RateCard, error
 		Discounts:           lo.FromPtr(r.Discounts),
 	}
 
+	// Backfill FeatureKey from eagerly loaded feature edge when the column is NULL.
+	// This handles rate cards created before FeatureKey was made required for non-flat prices.
+	if meta.FeatureKey == nil {
+		if feat, err := r.Edges.FeaturesOrErr(); err == nil && feat != nil {
+			meta.FeatureKey = &feat.Key
+		}
+	}
+
 	// Map TaxCode if eagerly loaded.
 	taxCodeRow, err := r.Edges.TaxCodeOrErr()
 	if err == nil {
@@ -292,6 +300,14 @@ func fromPlanRateCardRow(r entdb.PlanRateCard) (productcatalog.RateCard, error) 
 		TaxConfig:           r.TaxConfig,
 		Price:               r.Price,
 		Discounts:           lo.FromPtr(r.Discounts),
+	}
+
+	// Backfill FeatureKey from eagerly loaded feature edge when the column is NULL.
+	// This handles rate cards created before FeatureKey was made required for non-flat prices.
+	if meta.FeatureKey == nil {
+		if feat, err := r.Edges.FeaturesOrErr(); err == nil && feat != nil {
+			meta.FeatureKey = &feat.Key
+		}
 	}
 
 	// Map TaxCode if eagerly loaded.

--- a/openmeter/productcatalog/plan/service/plan.go
+++ b/openmeter/productcatalog/plan/service/plan.go
@@ -104,10 +104,20 @@ func (s service) resolveFeatures(ctx context.Context, namespace string, rateCard
 			if featureByID.Key != *fK {
 				return models.NewGenericNotFoundError(fmt.Errorf("feature with ID %s has key %s, but expected %s", *fID, featureByID.Key, *fK))
 			}
+
+			price := rateCard.AsMeta().Price
+			if price != nil && price.Type() != productcatalog.FlatPriceType && featureByID.MeterID == nil {
+				return models.NewGenericValidationError(productcatalog.ErrRateCardUsageBasedPriceRequiresMeteredFeature)
+			}
 		} else if fID != nil && fK == nil {
 			// We need to populate FeatureKey
 			if !featureByIDOk {
 				return models.NewGenericNotFoundError(fmt.Errorf("feature with ID %s not found", *fID))
+			}
+
+			price := rateCard.AsMeta().Price
+			if price != nil && price.Type() != productcatalog.FlatPriceType && featureByID.MeterID == nil {
+				return models.NewGenericValidationError(productcatalog.ErrRateCardUsageBasedPriceRequiresMeteredFeature)
 			}
 
 			// FIXME: merging like this is a pain, we should just use pointers...
@@ -142,6 +152,11 @@ func (s service) resolveFeatures(ctx context.Context, namespace string, rateCard
 			// We need to populate FeatureID
 			if !featureByKeyOk {
 				return models.NewGenericNotFoundError(fmt.Errorf("feature with key %s not found", *fK))
+			}
+
+			price := rateCard.AsMeta().Price
+			if price != nil && price.Type() != productcatalog.FlatPriceType && featureByKey.MeterID == nil {
+				return models.NewGenericValidationError(productcatalog.ErrRateCardUsageBasedPriceRequiresMeteredFeature)
 			}
 
 			// FIXME: merging like this is a pain, we should just use pointers...

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -225,7 +225,7 @@ func (r RateCardMeta) Validate() error {
 			))
 		}
 
-		if r.Price.Type() != FlatPriceType && r.FeatureKey == nil {
+		if r.Price.Type() != FlatPriceType && r.FeatureKey == nil && r.FeatureID == nil {
 			errs = append(errs, ErrRateCardUsageBasedPriceRequiresFeatureKey)
 		}
 	}

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -224,6 +224,10 @@ func (r RateCardMeta) Validate() error {
 					err),
 			))
 		}
+
+		if r.Price.Type() != FlatPriceType && r.FeatureKey == nil {
+			errs = append(errs, ErrRateCardUsageBasedPriceRequiresFeatureKey)
+		}
 	}
 
 	if r.FeatureKey != nil {

--- a/openmeter/productcatalog/ratecard_test.go
+++ b/openmeter/productcatalog/ratecard_test.go
@@ -141,6 +141,21 @@ func TestFlatFeeRateCard(t *testing.T) {
 				},
 				ExpectedError: true,
 			},
+			{
+				Name: "valid, flat price without featureKey",
+				RateCard: FlatFeeRateCard{
+					RateCardMeta: RateCardMeta{
+						Key:  "flat-no-feature",
+						Name: "Flat no feature",
+						Price: NewPriceFrom(FlatPrice{
+							Amount:      decimal.NewFromInt(500),
+							PaymentTerm: InArrearsPaymentTerm,
+						}),
+					},
+					BillingCadence: lo.ToPtr(datetime.MustParseDuration(t, "P1M")),
+				},
+				ExpectedError: false,
+			},
 		}
 
 		for _, test := range tests {
@@ -331,6 +346,20 @@ func TestUsageBasedRateCard(t *testing.T) {
 								Quantity: decimal.NewFromInt(100),
 							},
 						},
+					},
+					BillingCadence: datetime.MustParseDuration(t, "P1M"),
+				},
+				ExpectedError: true,
+			},
+			{
+				Name: "invalid, non-flat price without featureKey",
+				RateCard: UsageBasedRateCard{
+					RateCardMeta: RateCardMeta{
+						Key:  "usage-no-feature",
+						Name: "Usage no feature",
+						Price: NewPriceFrom(UnitPrice{
+							Amount: decimal.NewFromInt(1000),
+						}),
 					},
 					BillingCadence: datetime.MustParseDuration(t, "P1M"),
 				},

--- a/openmeter/subscription/addon/diff/restore_test.go
+++ b/openmeter/subscription/addon/diff/restore_test.go
@@ -573,8 +573,9 @@ func TestRestore(t *testing.T) {
 					subscriptiontestutils.ExampleRateCard1.Clone(), // Flat price
 					&productcatalog.UsageBasedRateCard{ // Dynamic price
 						RateCardMeta: productcatalog.RateCardMeta{
-							Key:  "dynamic_rc_1",
-							Name: "Dynamic Rate Card 1",
+							Key:        subscriptiontestutils.ExampleFeatureKey3,
+							Name:       "Dynamic Rate Card 1",
+							FeatureKey: lo.ToPtr(subscriptiontestutils.ExampleFeatureKey3),
 							Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
 								Mode: productcatalog.VolumeTieredPrice,
 								Tiers: []productcatalog.PriceTier{
@@ -605,8 +606,9 @@ func TestRestore(t *testing.T) {
 				productcatalog.AddonInstanceTypeSingle,
 				&productcatalog.UsageBasedRateCard{ // Dynamic price for addon
 					RateCardMeta: productcatalog.RateCardMeta{
-						Key:  "addon_dynamic_rc",
-						Name: "Addon Dynamic Rate Card",
+						Key:        subscriptiontestutils.ExampleFeatureKey2,
+						Name:       "Addon Dynamic Rate Card",
+						FeatureKey: lo.ToPtr(subscriptiontestutils.ExampleFeatureKey2),
 						Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
 							Mode: productcatalog.VolumeTieredPrice,
 							Tiers: []productcatalog.PriceTier{

--- a/openmeter/subscription/repo/mapping.go
+++ b/openmeter/subscription/repo/mapping.go
@@ -128,16 +128,23 @@ func MapDBSubscriptionItem(item *db.SubscriptionItem) (subscription.Subscription
 	}
 
 	var rc productcatalog.RateCard
+	featureKey := item.FeatureKey
+	// Backfill FeatureKey from Key when the column is NULL: subscription items
+	// predate the FeatureKey-required invariant, and Key == FeatureKey for all
+	// plan-derived items, so Key is a safe fallback.
+	if featureKey == nil && item.Price != nil && item.Price.Type() != productcatalog.FlatPriceType {
+		featureKey = &item.Key
+	}
 	rcMeta := productcatalog.RateCardMeta{
 		Name:                item.Name,
 		Description:         item.Description,
-		FeatureKey:          item.FeatureKey,
+		FeatureKey:          featureKey,
 		EntitlementTemplate: item.EntitlementTemplate,
 		TaxConfig:           item.TaxConfig,
 		Price:               item.Price,
 		Discounts:           lo.FromPtr(item.Discounts),
 		Key:                 item.Key,
-		FeatureID:           nil, // FIXME: is this an issue?
+		FeatureID:           nil,
 	}
 
 	// Map TaxCode if eagerly loaded.

--- a/openmeter/subscription/workflow/service/addon_test.go
+++ b/openmeter/subscription/workflow/service/addon_test.go
@@ -688,8 +688,9 @@ func TestAddonCombinations(t *testing.T) {
 				subscriptiontestutils.ExampleRateCard1.Clone(), // Flat price
 				&productcatalog.UsageBasedRateCard{ // Dynamic price
 					RateCardMeta: productcatalog.RateCardMeta{
-						Key:  "dynamic_rc_1",
-						Name: "Dynamic Rate Card 1",
+						Key:        subscriptiontestutils.ExampleFeatureKey3,
+						Name:       "Dynamic Rate Card 1",
+						FeatureKey: lo.ToPtr(subscriptiontestutils.ExampleFeatureKey3),
 						Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
 							Mode: productcatalog.VolumeTieredPrice,
 							Tiers: []productcatalog.PriceTier{
@@ -724,8 +725,9 @@ func TestAddonCombinations(t *testing.T) {
 				productcatalog.AddonInstanceTypeSingle,
 				&productcatalog.UsageBasedRateCard{ // Dynamic price for addon
 					RateCardMeta: productcatalog.RateCardMeta{
-						Key:  "addon_dynamic_rc",
-						Name: "Addon Dynamic Rate Card",
+						Key:        subscriptiontestutils.ExampleFeatureKey2,
+						Name:       "Addon Dynamic Rate Card",
+						FeatureKey: lo.ToPtr(subscriptiontestutils.ExampleFeatureKey2),
 						Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
 							Mode: productcatalog.VolumeTieredPrice,
 							Tiers: []productcatalog.PriceTier{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Usage-based (non-flat) rate cards now require a feature key and reject references to non-metered features with clear validation errors.
  * Flat-fee rate cards remain valid without a feature key.
  * Mapping/backfill now populates missing rate-card feature keys from related feature data to ensure consistent validation.

* **Tests**
  * Updated unit and end-to-end tests, fixtures, and e2e meter config to cover feature-bound rate cards, metered-feature validation, and addon/plan compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->