### PR TITLE
fix(entitlement): fix grant recurrence on period start

### DIFF
--- a/openmeter/credit/engine/burnphase.go
+++ b/openmeter/credit/engine/burnphase.go
@@ -17,6 +17,11 @@ type burnPhase struct {
 	priorityChange bool
 }
 
+type phasePlan struct {
+	phases                []burnPhase
+	grantsRecurredAtStart []string
+}
+
 // Calculates the burn phases for the given period.
 // The period is expected not to contain any resets.
 //
@@ -26,11 +31,11 @@ type burnPhase struct {
 //
 // Note that grant balance does not effect the burndown order if we simply ignore grants that don't
 // have balance while burning down.
-func (e *engine) getPhases(grants []grant.Grant, period timeutil.ClosedPeriod) ([]burnPhase, error) {
+func (e *engine) getPhases(grants []grant.Grant, period timeutil.ClosedPeriod) (phasePlan, error) {
 	activityChanges := e.getGrantActivityChanges(grants, period)
 	recurrenceTimes, err := e.getGrantRecurrenceTimes(grants, period)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get grant recurrence times: %w", err)
+		return phasePlan{}, fmt.Errorf("failed to get grant recurrence times: %w", err)
 	}
 	phases := []burnPhase{}
 
@@ -45,13 +50,27 @@ func (e *engine) getPhases(grants []grant.Grant, period timeutil.ClosedPeriod) (
 		}{}
 	}
 
+	grantsRecurredAtStart := []string{}
+	for len(recurrenceTimes) > 0 && recurrenceTimes[0].time.Equal(period.From) {
+		grantsRecurredAtStart = append(grantsRecurredAtStart, recurrenceTimes[0].grantIDs...)
+		recurrenceTimes = recurrenceTimes[1:]
+	}
+
 	// if both are null then return single phase for entire period
 	if len(activityChanges) == 0 && len(recurrenceTimes) == 0 {
-		return []burnPhase{{from: period.From, to: period.To}}, nil
+		return phasePlan{
+			phases:                []burnPhase{{from: period.From, to: period.To}},
+			grantsRecurredAtStart: grantsRecurredAtStart,
+		}, nil
 	}
 
 	acI, rtI := 0, 0
 	phaseFrom := period.From
+
+	appendPhase := func(phase burnPhase) {
+		phases = append(phases, phase)
+		phaseFrom = phase.to
+	}
 
 	var phase burnPhase
 	for len(activityChanges) > acI && len(recurrenceTimes) > rtI {
@@ -85,37 +104,37 @@ func (e *engine) getPhases(grants []grant.Grant, period timeutil.ClosedPeriod) (
 
 		// If it's a valid phase (non-zero duration), we save it and break
 		if phase.to.After(phase.from) {
-			phases = append(phases, phase)
-			phaseFrom = phase.to
+			appendPhase(phase)
 		}
 	}
 
 	// order here doesn't matter as one or both of them is empty
 	// append all activityChanges remaining
 	for _, activityChange := range activityChanges[acI:] {
-		phases = append(phases, burnPhase{
+		appendPhase(burnPhase{
 			from:           phaseFrom,
 			to:             activityChange,
 			priorityChange: true,
 		})
-		phaseFrom = activityChange
 	}
 	// append all recurrenceTimes remaining
 	for _, recurrenceTime := range recurrenceTimes[rtI:] {
-		phases = append(phases, burnPhase{
+		appendPhase(burnPhase{
 			from:                phaseFrom,
 			to:                  recurrenceTime.time,
 			grantsRecurredAtEnd: recurrenceTime.grantIDs,
 		})
-		phaseFrom = recurrenceTime.time
 	}
 
 	if phaseFrom.Before(period.To) {
-		phases = append(phases, burnPhase{
+		appendPhase(burnPhase{
 			from: phaseFrom,
 			to:   period.To,
 		})
 	}
 
-	return phases, nil
+	return phasePlan{
+		phases:                phases,
+		grantsRecurredAtStart: grantsRecurredAtStart,
+	}, nil
 }

--- a/openmeter/credit/engine/grant.go
+++ b/openmeter/credit/engine/grant.go
@@ -86,8 +86,13 @@ func (e *engine) getGrantRecurrenceTimes(grants []grant.Grant, period timeutil.C
 		if err != nil {
 			return nil, err
 		}
-		// writing all reccurence times until grant is active or period ends
-		for it.At.Before(period.To) && grant.ActiveAt(it.At) {
+		// Write all recurrence times in [period.From, period.To).
+		// For a zero-length period [T, T], include T so a recurrence at the
+		// start of that period can still be applied.
+		inPeriod := func(at time.Time) bool {
+			return at.Before(period.To) || (period.From.Equal(period.To) && at.Equal(period.From))
+		}
+		for inPeriod(it.At) && grant.ActiveAt(it.At) {
 			times = append(times, struct {
 				time    time.Time
 				grantID string

--- a/openmeter/credit/engine/reset_test.go
+++ b/openmeter/credit/engine/reset_test.go
@@ -256,6 +256,51 @@ func TestReset(t *testing.T) {
 		assert.False(t, res.History.Segments()[1].TerminationReasons.UsageReset)
 	})
 
+	t.Run("Should include grant recurrence in starting balance", func(t *testing.T) {
+		eng, use := setup(t)
+		use(10.0, t1.Add(time.Hour))
+
+		g1 := grant1
+		g1.Recurrence = &timeutil.Recurrence{
+			Interval: timeutil.RecurrencePeriodDaily,
+			Anchor:   t1,
+		}
+
+		resetTime := t1.AddDate(0, 0, 1)
+
+		res, err := eng.Run(
+			context.Background(),
+			engine.RunParams{
+				Meter:  meter,
+				Grants: []grant.Grant{g1},
+				StartingSnapshot: balance.Snapshot{
+					Balances: balance.Map{
+						g1.ID: 100.0,
+					},
+					Overage: 0,
+					At:      t1,
+				},
+				Until:  resetTime,
+				Resets: timeutil.NewSimpleTimeline([]time.Time{resetTime}),
+			},
+		)
+		assert.NoError(t, err)
+
+		// There cannot be any usage right at reset
+		assert.Equal(t, 0.0, res.Snapshot.Usage.Usage)
+		assert.Equal(t, resetTime, res.Snapshot.Usage.Since)
+
+		// Should have 2 periods, start - reset, reset - end where reset = end, 2nd period is 0 length
+		assert.Equal(t, 2, len(res.History.Segments()), "expected: %+v, got %+v, history: %+v", 2, len(res.History.Segments()), res.History.Segments())
+
+		assert.True(t, res.History.Segments()[0].TerminationReasons.UsageReset)
+		assert.False(t, res.History.Segments()[1].TerminationReasons.UsageReset)
+		assert.Equal(t, 100.0, res.History.Segments()[1].BalanceAtStart[g1.ID])
+
+		// The starting balance should be the amount of the grant
+		assert.Equal(t, 100.0, res.Snapshot.Balances[g1.ID])
+	})
+
 	t.Run("Should error if a reset is provided for the starting snapshot", func(t *testing.T) {
 		eng, use := setup(t)
 		use(10.0, t1.Add(time.Hour))

--- a/openmeter/credit/engine/run.go
+++ b/openmeter/credit/engine/run.go
@@ -123,10 +123,11 @@ func (e *engine) runBetweenResets(ctx context.Context, params inbetweenRunParams
 	grants := make([]grant.Grant, len(params.Grants))
 	copy(grants, params.Grants)
 
-	phases, err := e.getPhases(grants, period)
+	phasePlan, err := e.getPhases(grants, period)
 	if err != nil {
 		return RunResult{}, fmt.Errorf("failed to get burn phases: %w", err)
 	}
+	phases := phasePlan.phases
 
 	err = PrioritizeGrants(grants)
 	if err != nil {
@@ -145,9 +146,26 @@ func (e *engine) runBetweenResets(ctx context.Context, params inbetweenRunParams
 		grantMap[grant.ID] = grant
 	}
 
+	applyRecurrences := func(grantIDs []string) error {
+		for _, grantID := range grantIDs {
+			grant, ok := grantMap[grantID]
+			if !ok {
+				return fmt.Errorf("failed to get grant with id %s", grantID)
+			}
+			balancesAtPhaseStart.Set(grant.ID, grant.RecurrenceBalance(balancesAtPhaseStart[grantID]))
+		}
+		return nil
+	}
+
 	segments := make([]GrantBurnDownHistorySegment, 0, len(phases))
 
 	overage := params.StartingSnapshot.Overage
+
+	if len(phasePlan.grantsRecurredAtStart) > 0 {
+		if err := applyRecurrences(phasePlan.grantsRecurredAtStart); err != nil {
+			return RunResult{}, err
+		}
+	}
 
 	for _, phase := range phases {
 		// reprioritize grants if needed
@@ -161,12 +179,8 @@ func (e *engine) runBetweenResets(ctx context.Context, params inbetweenRunParams
 
 		// reset recurring grant balances
 		if len(recurredGrants) > 0 {
-			for _, grantID := range recurredGrants {
-				grant, ok := grantMap[grantID]
-				if !ok {
-					return RunResult{}, fmt.Errorf("failed to get grant with id %s", grantID)
-				}
-				balancesAtPhaseStart.Set(grant.ID, grant.RecurrenceBalance(balancesAtPhaseStart[grantID]))
+			if err := applyRecurrences(recurredGrants); err != nil {
+				return RunResult{}, err
 			}
 			recurredGrants = nil
 		}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Grants recurring at the period boundary didn't contribute to the starting balance in case it was resolved for the exact period start (at = period.From)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved handling of recurring grant balances during period transitions
  * Optimized recurrence processing for more accurate balance updates at period boundaries

* **Tests**
  * Added test coverage for recurring grant balance verification during resets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->