### PR TITLE
fix(balanceworker): skip events that dont match meters

### DIFF
--- a/openmeter/entitlement/balanceworker/ingesthandler.go
+++ b/openmeter/entitlement/balanceworker/ingesthandler.go
@@ -20,7 +20,7 @@ import (
 func (w *Worker) handleBatchedIngestEvent(ctx context.Context, event ingestevents.EventBatchedIngest) error {
 	if len(event.MeterSlugs) == 0 {
 		// This is possible as you can ingest events that don't match any meters
-		w.opts.Logger.InfoContext(ctx, "no meter slugs found in batched ingest event, skipping entitlement recalculation", "event", event)
+		w.opts.Logger.InfoContext(ctx, "no meter slugs found in batched ingest event, skipping entitlement recalculation", "event_id", event.EventMetadata().ID)
 
 		return nil
 	}

--- a/openmeter/entitlement/balanceworker/ingesthandler.go
+++ b/openmeter/entitlement/balanceworker/ingesthandler.go
@@ -18,6 +18,13 @@ import (
 )
 
 func (w *Worker) handleBatchedIngestEvent(ctx context.Context, event ingestevents.EventBatchedIngest) error {
+	if len(event.MeterSlugs) == 0 {
+		// This is possible as you can ingest events that don't match any meters
+		w.opts.Logger.InfoContext(ctx, "no meter slugs found in batched ingest event, skipping entitlement recalculation", "event", event)
+
+		return nil
+	}
+
 	affectedEntitlements, err := w.opts.Repo.ListEntitlementsAffectedByIngestEvents(ctx, IngestEventQueryFilter{
 		Namespace:    event.Namespace.ID,
 		EventSubject: event.SubjectKey,


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Events can be ingested that don't match any meters

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch ingest efficiency: when a batched ingest event contains no meter identifiers, the system logs this and skips the lookup and entitlement recalculation steps, avoiding unnecessary work and reducing processing overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->