### PR TITLE
feat(test) Charge tax config carryover

### DIFF
--- a/openmeter/billing/charges/service/taxcode_test.go
+++ b/openmeter/billing/charges/service/taxcode_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 	billingtest "github.com/openmeterio/openmeter/test/billing"
@@ -886,6 +887,427 @@ func (s *TaxCodePersistenceTestSuite) TestTaxConfigInListCharges() {
 			s.Failf("unexpected charge type", "type=%s", string(charge.Type()))
 		}
 	}
+}
+
+// TestFlatFeeInvoiceSettlementPropagatesTaxConfigToGatheringLine verifies that TaxConfig set on a
+// flat-fee CreditThenInvoice intent is propagated to the gathering invoice line built by
+// gatheringLineFromFlatFeeCharge. Guards the single-source-of-truth contract: gathering line reads
+// TaxConfig from intent.TaxConfig, and Stripe.Code is backfilled via the TaxCode entity edge.
+func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementPropagatesTaxConfigToGatheringLine() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-gathering")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithManualApproval(),
+	)
+	cust := s.CreateTestCustomer(ns, "test-subject")
+
+	const stripeCode = "txcd_30000001"
+	tc := s.createTestTaxCodeWithStripeMapping(ctx, ns, "txcd-30000001", stripeCode)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	// Clock before invoiceAt (= servicePeriod.From for InAdvance) keeps the gathering line
+	// pending so ListGatheringInvoices can observe it without invoicing.
+	clock.SetTime(time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC))
+
+	_, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromFloat(100),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				name:              "flat-fee-gathering-taxcode",
+				managedBy:         billing.ManuallyManagedLine,
+				uniqueReferenceID: "flat-fee-gathering-taxcode",
+				taxConfig: &productcatalog.TaxCodeConfig{
+					Behavior:  lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
+					TaxCodeID: &tc.ID,
+				},
+			}),
+		},
+	})
+	s.NoError(err)
+
+	gatheringInvoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+		Namespaces: []string{ns},
+		Customers:  []string{cust.ID},
+		Currencies: []currencyx.Code{USD},
+		Expand:     []billing.GatheringInvoiceExpand{billing.GatheringInvoiceExpandLines},
+	})
+	s.NoError(err)
+	s.Require().Len(gatheringInvoices.Items, 1)
+
+	lines := gatheringInvoices.Items[0].Lines.OrEmpty()
+	s.Require().Len(lines, 1)
+	gatheringLine := lines[0]
+
+	s.Require().NotNil(gatheringLine.TaxConfig, "gathering line TaxConfig must be set from intent")
+	s.Require().NotNil(gatheringLine.TaxConfig.Behavior, "TaxBehavior must propagate to gathering line")
+	s.Equal(productcatalog.ExclusiveTaxBehavior, *gatheringLine.TaxConfig.Behavior)
+	s.Require().NotNil(gatheringLine.TaxConfig.TaxCodeID, "TaxCodeID must propagate to gathering line")
+	s.Equal(tc.ID, *gatheringLine.TaxConfig.TaxCodeID)
+	s.Require().NotNil(gatheringLine.TaxConfig.Stripe, "Stripe.Code must be backfilled on gathering line via TaxCode edge")
+	s.Equal(stripeCode, gatheringLine.TaxConfig.Stripe.Code)
+}
+
+// TestFlatFeeInvoiceSettlementNilTaxConfigDoesNotPropagateToGatheringLine verifies that when
+// Intent.TaxConfig is nil the flat-fee CreditThenInvoice gathering line's TaxConfig is also nil.
+func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementNilTaxConfigDoesNotPropagateToGatheringLine() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-gathering-nil")
+
+	sandboxApp := s.InstallSandboxApp(s.T(), ns)
+	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
+	cust := s.CreateTestCustomer(ns, "test-subject")
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	clock.SetTime(time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC))
+
+	_, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromFloat(100),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				name:              "flat-fee-gathering-nil-taxcode",
+				managedBy:         billing.ManuallyManagedLine,
+				uniqueReferenceID: "flat-fee-gathering-nil-taxcode",
+			}),
+		},
+	})
+	s.NoError(err)
+
+	gatheringInvoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+		Namespaces: []string{ns},
+		Customers:  []string{cust.ID},
+		Currencies: []currencyx.Code{USD},
+		Expand:     []billing.GatheringInvoiceExpand{billing.GatheringInvoiceExpandLines},
+	})
+	s.NoError(err)
+	s.Require().Len(gatheringInvoices.Items, 1)
+
+	lines := gatheringInvoices.Items[0].Lines.OrEmpty()
+	s.Require().Len(lines, 1)
+	s.Nil(lines[0].TaxConfig, "gathering line TaxConfig must be nil when Intent.TaxConfig is nil")
+}
+
+// TestUsageBasedCreditThenInvoicePropagatesTaxConfigToGatheringLine verifies that TaxConfig set on
+// a usage-based CreditThenInvoice intent is propagated to the gathering invoice line built by
+// gatheringLineFromUsageBasedCharge. Guards the same single-source-of-truth contract as the flat-fee
+// equivalent, covering the usage-based charge type path.
+func (s *TaxCodePersistenceTestSuite) TestUsageBasedCreditThenInvoicePropagatesTaxConfigToGatheringLine() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-taxcode-usagebased-gathering")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithManualApproval(),
+	)
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	const stripeCode = "txcd_30000002"
+	tc := s.createTestTaxCodeWithStripeMapping(ctx, ns, "txcd-30000002", stripeCode)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	// Clock before service period keeps the gathering line pending.
+	clock.SetTime(time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC))
+
+	_, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromFloat(1),
+				}),
+				featureKey:        apiRequestsTotal.Feature.Key,
+				name:              "usage-based-gathering-taxcode",
+				managedBy:         billing.ManuallyManagedLine,
+				uniqueReferenceID: "usage-based-gathering-taxcode",
+				taxConfig: &productcatalog.TaxCodeConfig{
+					Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+					TaxCodeID: &tc.ID,
+				},
+			}),
+		},
+	})
+	s.NoError(err)
+
+	gatheringInvoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+		Namespaces: []string{ns},
+		Customers:  []string{cust.ID},
+		Currencies: []currencyx.Code{USD},
+		Expand:     []billing.GatheringInvoiceExpand{billing.GatheringInvoiceExpandLines},
+	})
+	s.NoError(err)
+	s.Require().Len(gatheringInvoices.Items, 1)
+
+	lines := gatheringInvoices.Items[0].Lines.OrEmpty()
+	s.Require().Len(lines, 1)
+	gatheringLine := lines[0]
+
+	s.Require().NotNil(gatheringLine.TaxConfig, "gathering line TaxConfig must be set from intent")
+	s.Require().NotNil(gatheringLine.TaxConfig.Behavior, "TaxBehavior must propagate to gathering line")
+	s.Equal(productcatalog.InclusiveTaxBehavior, *gatheringLine.TaxConfig.Behavior)
+	s.Require().NotNil(gatheringLine.TaxConfig.TaxCodeID, "TaxCodeID must propagate to gathering line")
+	s.Equal(tc.ID, *gatheringLine.TaxConfig.TaxCodeID)
+	s.Require().NotNil(gatheringLine.TaxConfig.Stripe, "Stripe.Code must be backfilled on gathering line via TaxCode edge")
+	s.Equal(stripeCode, gatheringLine.TaxConfig.Stripe.Code)
+}
+
+// TestUsageBasedInvoiceSettlementPopulatesStripeCodeOnStandardInvoice verifies the dual-write
+// invariant for usage-based credit_then_invoice charges: after payment is settled, the standard
+// invoice line carries both TaxCodeID (FK) and Stripe.Code resolved from the TaxCode entity.
+// Mirrors TestFlatFeeInvoiceSettlementPopulatesStripeCodeOnStandardInvoice for the usage-based path.
+func (s *TaxCodePersistenceTestSuite) TestUsageBasedInvoiceSettlementPopulatesStripeCodeOnStandardInvoice() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-taxcode-usagebased-invoice-settled")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+	meterSlug := apiRequestsTotal.Feature.Key
+
+	const stripeCode = "txcd_30000010"
+	tc := s.createTestTaxCodeWithStripeMapping(ctx, ns, "txcd-30000010", stripeCode)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	clock.SetTime(time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC))
+
+	_, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:          cust.GetID(),
+				currency:          USD,
+				servicePeriod:     servicePeriod,
+				settlementMode:    productcatalog.CreditThenInvoiceSettlementMode,
+				price:             productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromFloat(1)}),
+				featureKey:        meterSlug,
+				name:              "usage-based-invoice-stripe-taxcode",
+				managedBy:         billing.ManuallyManagedLine,
+				uniqueReferenceID: "usage-based-invoice-stripe-taxcode",
+				taxConfig: &productcatalog.TaxCodeConfig{
+					Behavior:  lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
+					TaxCodeID: &tc.ID,
+				},
+			}),
+		},
+	})
+	s.NoError(err)
+
+	// Return empty allocations — no credits in balance, so nothing to apply.
+	s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued = func(_ context.Context, _ usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
+		return creditrealization.CreateAllocationInputs{}, nil
+	}
+
+	s.MockStreamingConnector.AddSimpleEvent(meterSlug, 5, time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC))
+
+	clock.SetTime(servicePeriod.To.Add(time.Second))
+	createdInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: cust.GetID(),
+		AsOf:     lo.ToPtr(servicePeriod.To),
+	})
+	s.NoError(err)
+	s.Require().Len(createdInvoices, 1)
+	invoice := createdInvoices[0]
+	invoiceID := invoice.GetInvoiceID()
+
+	clock.SetTime(invoice.DefaultCollectionAtForStandardInvoice())
+	_, err = s.BillingService.AdvanceInvoice(ctx, invoiceID)
+	s.NoError(err)
+
+	s.UsageBasedTestHandler.onInvoiceUsageAccrued = func(_ context.Context, _ usagebased.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error) {
+		return ledgertransaction.GroupReference{TransactionGroupID: ulid.Make().String()}, nil
+	}
+	s.UsageBasedTestHandler.onPaymentAuthorized = func(_ context.Context, _ usagebased.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {
+		return ledgertransaction.GroupReference{TransactionGroupID: ulid.Make().String()}, nil
+	}
+	s.UsageBasedTestHandler.onPaymentSettled = func(_ context.Context, _ usagebased.OnPaymentSettledInput) (ledgertransaction.GroupReference, error) {
+		return ledgertransaction.GroupReference{TransactionGroupID: ulid.Make().String()}, nil
+	}
+
+	_, err = s.BillingService.ApproveInvoice(ctx, invoiceID)
+	s.NoError(err)
+
+	_, err = s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{
+		InvoiceID: invoiceID,
+		Trigger:   billing.TriggerPaid,
+	})
+	s.NoError(err)
+
+	finalInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+		Invoice: invoiceID,
+		Expand:  billing.StandardInvoiceExpandAll,
+	})
+	s.NoError(err)
+
+	lines := finalInvoice.Lines.OrEmpty()
+	s.Require().Len(lines, 1)
+	line := lines[0]
+
+	s.Require().NotNil(line.TaxConfig, "standard invoice line must have TaxConfig")
+	s.Require().NotNil(line.TaxConfig.Behavior, "TaxBehavior must be on standard invoice line")
+	s.Equal(productcatalog.ExclusiveTaxBehavior, *line.TaxConfig.Behavior)
+	s.Require().NotNil(line.TaxConfig.TaxCodeID, "TaxCodeID must be on standard invoice line")
+	s.Equal(tc.ID, *line.TaxConfig.TaxCodeID)
+	s.Require().NotNil(line.TaxConfig.Stripe, "Stripe.Code must be backfilled on standard invoice line via TaxCode edge")
+	s.Equal(stripeCode, line.TaxConfig.Stripe.Code)
+}
+
+// TestFlatFeeBehaviorOnlyTaxConfigPropagatesToGatheringLine verifies that a TaxCodeConfig with only
+// Behavior set (no TaxCodeID) propagates correctly to the flat-fee gathering line. Guards against
+// regressions that drop Behavior when TaxCodeID is nil.
+func (s *TaxCodePersistenceTestSuite) TestFlatFeeBehaviorOnlyTaxConfigPropagatesToGatheringLine() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-gathering-behavior-only")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithManualApproval(),
+	)
+	cust := s.CreateTestCustomer(ns, "test-subject")
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	clock.SetTime(time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC))
+
+	_, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromFloat(100),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				name:              "flat-fee-gathering-behavior-only",
+				managedBy:         billing.ManuallyManagedLine,
+				uniqueReferenceID: "flat-fee-gathering-behavior-only",
+				taxConfig:         &productcatalog.TaxCodeConfig{Behavior: lo.ToPtr(productcatalog.InclusiveTaxBehavior)},
+			}),
+		},
+	})
+	s.NoError(err)
+
+	gatheringInvoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+		Namespaces: []string{ns},
+		Customers:  []string{cust.ID},
+		Currencies: []currencyx.Code{USD},
+		Expand:     []billing.GatheringInvoiceExpand{billing.GatheringInvoiceExpandLines},
+	})
+	s.NoError(err)
+	s.Require().Len(gatheringInvoices.Items, 1)
+
+	lines := gatheringInvoices.Items[0].Lines.OrEmpty()
+	s.Require().Len(lines, 1)
+	gatheringLine := lines[0]
+
+	s.Require().NotNil(gatheringLine.TaxConfig, "gathering line TaxConfig must be set")
+	s.Require().NotNil(gatheringLine.TaxConfig.Behavior, "TaxBehavior must propagate to gathering line")
+	s.Equal(productcatalog.InclusiveTaxBehavior, *gatheringLine.TaxConfig.Behavior)
+	s.Nil(gatheringLine.TaxConfig.TaxCodeID, "TaxCodeID must be nil for behavior-only TaxConfig")
+	s.Nil(gatheringLine.TaxConfig.Stripe, "Stripe must be nil when no TaxCodeID to resolve")
+}
+
+// TestUsageBasedBehaviorOnlyTaxConfigPropagatesToGatheringLine verifies that a TaxCodeConfig with
+// only Behavior set (no TaxCodeID) propagates correctly to the usage-based gathering line. Guards
+// against regressions that drop Behavior when TaxCodeID is nil.
+func (s *TaxCodePersistenceTestSuite) TestUsageBasedBehaviorOnlyTaxConfigPropagatesToGatheringLine() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-taxcode-usagebased-gathering-behavior-only")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithManualApproval(),
+	)
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	defer apiRequestsTotal.Cleanup()
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	clock.SetTime(time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC))
+
+	_, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:          cust.GetID(),
+				currency:          USD,
+				servicePeriod:     servicePeriod,
+				settlementMode:    productcatalog.CreditThenInvoiceSettlementMode,
+				price:             productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromFloat(1)}),
+				featureKey:        apiRequestsTotal.Feature.Key,
+				name:              "usage-based-gathering-behavior-only",
+				managedBy:         billing.ManuallyManagedLine,
+				uniqueReferenceID: "usage-based-gathering-behavior-only",
+				taxConfig:         &productcatalog.TaxCodeConfig{Behavior: lo.ToPtr(productcatalog.ExclusiveTaxBehavior)},
+			}),
+		},
+	})
+	s.NoError(err)
+
+	gatheringInvoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+		Namespaces: []string{ns},
+		Customers:  []string{cust.ID},
+		Currencies: []currencyx.Code{USD},
+		Expand:     []billing.GatheringInvoiceExpand{billing.GatheringInvoiceExpandLines},
+	})
+	s.NoError(err)
+	s.Require().Len(gatheringInvoices.Items, 1)
+
+	lines := gatheringInvoices.Items[0].Lines.OrEmpty()
+	s.Require().Len(lines, 1)
+	gatheringLine := lines[0]
+
+	s.Require().NotNil(gatheringLine.TaxConfig, "gathering line TaxConfig must be set")
+	s.Require().NotNil(gatheringLine.TaxConfig.Behavior, "TaxBehavior must propagate to gathering line")
+	s.Equal(productcatalog.ExclusiveTaxBehavior, *gatheringLine.TaxConfig.Behavior)
+	s.Nil(gatheringLine.TaxConfig.TaxCodeID, "TaxCodeID must be nil for behavior-only TaxConfig")
+	s.Nil(gatheringLine.TaxConfig.Stripe, "Stripe must be nil when no TaxCodeID to resolve")
 }
 
 func (s *TaxCodePersistenceTestSuite) createTestTaxCode(ctx context.Context, ns, key string) taxcode.TaxCode {

--- a/test/credits/creditgrant_test.go
+++ b/test/credits/creditgrant_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	creditpurchaseadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/adapter"
@@ -21,6 +22,8 @@ import (
 	creditgrantservice "github.com/openmeterio/openmeter/openmeter/billing/creditgrant/service"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	ledgerchargeadapter "github.com/openmeterio/openmeter/openmeter/ledger/chargeadapter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	omtestutils "github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -260,6 +263,217 @@ func (s *CreditGrantTestSuite) TestListCreditGrants() {
 	})
 	s.Contains(ids, firstGrant.ID)
 	s.Contains(ids, secondGrant.ID)
+}
+
+// TestCreateInvoiceFundedGrantPropagatesTaxConfigToInvoiceLine verifies that TaxConfig set on
+// creditgrant.CreateInput is propagated to the standard invoice line. Credit purchases always bypass
+// collection alignment (ServicePeriod = {Now, Now}), so the line is immediately converted from
+// gathering to a standard invoice — the test checks the standard invoice line, not a gathering line.
+func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantPropagatesTaxConfigToInvoiceLine() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("creditgrant-taxconfig-propagation")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.createLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithProgressiveBilling(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "PT1H")),
+		billingtest.WithManualApproval(),
+	)
+
+	now := datetime.MustParseTimeInLocation(s.T(), "2026-04-17T11:23:53Z", time.UTC).AsTime()
+	clock.SetTime(now)
+
+	tc, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "txcd-40000001",
+		Name:      "Test Tax Code txcd-40000001",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000001"},
+		},
+	})
+	s.Require().NoError(err)
+
+	grant, err := s.CreditGrantService.Create(ctx, creditgrant.CreateInput{
+		Namespace:     ns,
+		CustomerID:    cust.ID,
+		Name:          "$10.00 grant with tax config",
+		Currency:      USD,
+		Amount:        alpacadecimal.NewFromInt(10),
+		Priority:      lo.ToPtr(int16(10)),
+		FundingMethod: creditgrant.FundingMethodInvoice,
+		Purchase: &creditgrant.PurchaseTerms{
+			Currency:         USD,
+			PerUnitCostBasis: lo.ToPtr(alpacadecimal.NewFromInt(1)),
+		},
+		TaxConfig: &productcatalog.TaxConfig{
+			Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+			TaxCodeID: &tc.ID,
+		},
+	})
+	s.Require().NoError(err)
+	s.Equal(creditpurchase.StatusActive, grant.Status)
+
+	standardInvoices, err := s.BillingService.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{
+		Namespaces: []string{ns},
+		Expand:     billing.StandardInvoiceExpandAll,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(standardInvoices.Items, 1)
+
+	lines := standardInvoices.Items[0].Lines.OrEmpty()
+	s.Require().Len(lines, 1)
+	line := lines[0]
+
+	s.Require().NotNil(line.TaxConfig, "standard invoice line TaxConfig must be set from grant TaxConfig")
+	s.Require().NotNil(line.TaxConfig.Behavior, "TaxBehavior must propagate to invoice line")
+	s.Equal(productcatalog.InclusiveTaxBehavior, *line.TaxConfig.Behavior)
+	s.Require().NotNil(line.TaxConfig.TaxCodeID, "TaxCodeID must propagate to invoice line")
+	s.Equal(tc.ID, *line.TaxConfig.TaxCodeID)
+	s.Require().NotNil(line.TaxConfig.Stripe, "Stripe.Code must be backfilled on invoice line via TaxCode edge")
+	s.Equal("txcd_40000001", line.TaxConfig.Stripe.Code)
+}
+
+// TestCreateInvoiceFundedGrantNilTaxConfigInvoiceLineNil verifies that when TaxConfig is omitted
+// from creditgrant.CreateInput the resulting standard invoice line has nil TaxConfig.
+func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantNilTaxConfigInvoiceLineNil() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("creditgrant-taxconfig-nil")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.createLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithProgressiveBilling(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "PT1H")),
+		billingtest.WithManualApproval(),
+	)
+
+	now := datetime.MustParseTimeInLocation(s.T(), "2026-04-17T11:23:53Z", time.UTC).AsTime()
+	clock.SetTime(now)
+
+	_, err := s.CreditGrantService.Create(ctx, creditgrant.CreateInput{
+		Namespace:     ns,
+		CustomerID:    cust.ID,
+		Name:          "$10.00 grant without tax config",
+		Currency:      USD,
+		Amount:        alpacadecimal.NewFromInt(10),
+		Priority:      lo.ToPtr(int16(10)),
+		FundingMethod: creditgrant.FundingMethodInvoice,
+		Purchase: &creditgrant.PurchaseTerms{
+			Currency:         USD,
+			PerUnitCostBasis: lo.ToPtr(alpacadecimal.NewFromInt(1)),
+		},
+	})
+	s.Require().NoError(err)
+
+	standardInvoices, err := s.BillingService.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{
+		Namespaces: []string{ns},
+		Expand:     billing.StandardInvoiceExpandAll,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(standardInvoices.Items, 1)
+
+	lines := standardInvoices.Items[0].Lines.OrEmpty()
+	s.Require().Len(lines, 1)
+	s.Nil(lines[0].TaxConfig, "standard invoice line TaxConfig must be nil when grant has no TaxConfig")
+}
+
+// TestCreateExternalGrantPropagatesTaxConfigToCharge verifies that TaxConfig set on
+// creditgrant.CreateInput is carried through Service.Create → toIntent → charge persistence for
+// external-funded grants. External grants produce no invoice line, so only the charge-level
+// TaxConfig is asserted.
+func (s *CreditGrantTestSuite) TestCreateExternalGrantPropagatesTaxConfigToCharge() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("creditgrant-external-taxconfig")
+
+	cust := s.createLedgerBackedCustomer(ns, "test-subject")
+	sandboxApp := s.InstallSandboxApp(s.T(), ns)
+	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
+
+	now := time.Date(2026, 4, 17, 11, 23, 53, 0, time.UTC)
+	clock.SetTime(now)
+
+	tc, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "txcd-50000001",
+		Name:      "Test Tax Code txcd-50000001",
+	})
+	s.Require().NoError(err)
+
+	grant, err := s.CreditGrantService.Create(ctx, creditgrant.CreateInput{
+		Namespace:     ns,
+		CustomerID:    cust.ID,
+		Name:          "External grant with tax config",
+		Currency:      USD,
+		Amount:        alpacadecimal.NewFromInt(30),
+		Priority:      lo.ToPtr(int16(20)),
+		FundingMethod: creditgrant.FundingMethodExternal,
+		Purchase: &creditgrant.PurchaseTerms{
+			Currency:           USD,
+			PerUnitCostBasis:   lo.ToPtr(alpacadecimal.NewFromFloat(0.5)),
+			AvailabilityPolicy: lo.ToPtr(creditpurchase.CreatedInitialPaymentSettlementStatus),
+		},
+		TaxConfig: &productcatalog.TaxConfig{
+			Behavior:  lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
+			TaxCodeID: &tc.ID,
+		},
+	})
+	s.Require().NoError(err)
+	s.Equal(creditpurchase.SettlementTypeExternal, grant.Intent.Settlement.Type())
+
+	s.Require().NotNil(grant.Intent.TaxConfig, "charge intent TaxConfig must be set from CreateInput")
+	s.Require().NotNil(grant.Intent.TaxConfig.Behavior, "TaxBehavior must propagate through toIntent to charge")
+	s.Equal(productcatalog.ExclusiveTaxBehavior, *grant.Intent.TaxConfig.Behavior)
+	s.Require().NotNil(grant.Intent.TaxConfig.TaxCodeID, "TaxCodeID must propagate through toIntent to charge")
+	s.Equal(tc.ID, *grant.Intent.TaxConfig.TaxCodeID)
+}
+
+// TestCreatePromotionalGrantPropagatesTaxConfigToCharge verifies that TaxConfig set on
+// creditgrant.CreateInput is carried through Service.Create → toIntent → charge persistence for
+// promotional (FundingMethodNone) grants. Promotional grants produce no invoice line, so only the
+// charge-level TaxConfig is asserted.
+func (s *CreditGrantTestSuite) TestCreatePromotionalGrantPropagatesTaxConfigToCharge() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("creditgrant-promotional-taxconfig")
+
+	cust := s.createLedgerBackedCustomer(ns, "test-subject")
+	sandboxApp := s.InstallSandboxApp(s.T(), ns)
+	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
+
+	now := time.Date(2026, 4, 17, 11, 23, 53, 0, time.UTC)
+	clock.SetTime(now)
+
+	tc, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "txcd-50000002",
+		Name:      "Test Tax Code txcd-50000002",
+	})
+	s.Require().NoError(err)
+
+	grant, err := s.CreditGrantService.Create(ctx, creditgrant.CreateInput{
+		Namespace:     ns,
+		CustomerID:    cust.ID,
+		Name:          "Promotional grant with tax config",
+		Currency:      USD,
+		Amount:        alpacadecimal.NewFromInt(25),
+		Priority:      lo.ToPtr(int16(15)),
+		FundingMethod: creditgrant.FundingMethodNone,
+		TaxConfig: &productcatalog.TaxConfig{
+			Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+			TaxCodeID: &tc.ID,
+		},
+	})
+	s.Require().NoError(err)
+	s.Equal(creditpurchase.SettlementTypePromotional, grant.Intent.Settlement.Type())
+	s.Equal(creditpurchase.StatusFinal, grant.Status)
+
+	s.Require().NotNil(grant.Intent.TaxConfig, "charge intent TaxConfig must be set from CreateInput")
+	s.Require().NotNil(grant.Intent.TaxConfig.Behavior, "TaxBehavior must propagate through toIntent to charge")
+	s.Equal(productcatalog.InclusiveTaxBehavior, *grant.Intent.TaxConfig.Behavior)
+	s.Require().NotNil(grant.Intent.TaxConfig.TaxCodeID, "TaxCodeID must propagate through toIntent to charge")
+	s.Equal(tc.ID, *grant.Intent.TaxConfig.TaxCodeID)
 }
 
 func (s *CreditGrantTestSuite) mustCreatePromotionalCreditGrant(ctx context.Context, namespace string, customerID customer.CustomerID, name string, amount alpacadecimal.Decimal) creditpurchase.Charge {


### PR DESCRIPTION
@coderabbitai


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for tax configuration propagation in billing: verifies TaxConfig (Behavior, TaxCodeID, and resolved Stripe code/backfill) across credit-then-invoice and standard invoice flows for flat-fee and usage-based lines, including behavior-only and nil-TaxConfig cases.
  * Added integration-style tests ensuring TaxConfig propagates to gathering and standard invoice lines, and that ledger handlers receive TaxConfig after DB round-trips.
  * Added tests validating TaxConfig propagation for credit grants across invoice-funded, external-funded, and promotional grant scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->