### PR TITLE
feat(ledger): add tax code and tax behavior to ledger types

### DIFF
--- a/openmeter/ent/db/ledgersubaccountroute.go
+++ b/openmeter/ent/db/ledgersubaccountroute.go
@@ -39,6 +39,8 @@ type LedgerSubAccountRoute struct {
 	Currency string `json:"currency,omitempty"`
 	// TaxCode holds the value of the "tax_code" field.
 	TaxCode *string `json:"tax_code,omitempty"`
+	// TaxBehavior holds the value of the "tax_behavior" field.
+	TaxBehavior *ledger.TaxBehavior `json:"tax_behavior,omitempty"`
 	// Features holds the value of the "features" field.
 	Features []string `json:"features,omitempty"`
 	// CostBasis holds the value of the "cost_basis" field.
@@ -95,7 +97,7 @@ func (*LedgerSubAccountRoute) scanValues(columns []string) ([]any, error) {
 			values[i] = new([]byte)
 		case ledgersubaccountroute.FieldCreditPriority:
 			values[i] = new(sql.NullInt64)
-		case ledgersubaccountroute.FieldID, ledgersubaccountroute.FieldNamespace, ledgersubaccountroute.FieldAccountID, ledgersubaccountroute.FieldRoutingKeyVersion, ledgersubaccountroute.FieldRoutingKey, ledgersubaccountroute.FieldCurrency, ledgersubaccountroute.FieldTaxCode, ledgersubaccountroute.FieldTransactionAuthorizationStatus:
+		case ledgersubaccountroute.FieldID, ledgersubaccountroute.FieldNamespace, ledgersubaccountroute.FieldAccountID, ledgersubaccountroute.FieldRoutingKeyVersion, ledgersubaccountroute.FieldRoutingKey, ledgersubaccountroute.FieldCurrency, ledgersubaccountroute.FieldTaxCode, ledgersubaccountroute.FieldTaxBehavior, ledgersubaccountroute.FieldTransactionAuthorizationStatus:
 			values[i] = new(sql.NullString)
 		case ledgersubaccountroute.FieldCreatedAt, ledgersubaccountroute.FieldUpdatedAt, ledgersubaccountroute.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -175,6 +177,13 @@ func (_m *LedgerSubAccountRoute) assignValues(columns []string, values []any) er
 			} else if value.Valid {
 				_m.TaxCode = new(string)
 				*_m.TaxCode = value.String
+			}
+		case ledgersubaccountroute.FieldTaxBehavior:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field tax_behavior", values[i])
+			} else if value.Valid {
+				_m.TaxBehavior = new(ledger.TaxBehavior)
+				*_m.TaxBehavior = ledger.TaxBehavior(value.String)
 			}
 		case ledgersubaccountroute.FieldFeatures:
 			if value, ok := values[i].(*[]byte); !ok {
@@ -280,6 +289,11 @@ func (_m *LedgerSubAccountRoute) String() string {
 	if v := _m.TaxCode; v != nil {
 		builder.WriteString("tax_code=")
 		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	if v := _m.TaxBehavior; v != nil {
+		builder.WriteString("tax_behavior=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
 	}
 	builder.WriteString(", ")
 	builder.WriteString("features=")

--- a/openmeter/ent/db/ledgersubaccountroute/ledgersubaccountroute.go
+++ b/openmeter/ent/db/ledgersubaccountroute/ledgersubaccountroute.go
@@ -32,6 +32,8 @@ const (
 	FieldCurrency = "currency"
 	// FieldTaxCode holds the string denoting the tax_code field in the database.
 	FieldTaxCode = "tax_code"
+	// FieldTaxBehavior holds the string denoting the tax_behavior field in the database.
+	FieldTaxBehavior = "tax_behavior"
 	// FieldFeatures holds the string denoting the features field in the database.
 	FieldFeatures = "features"
 	// FieldCostBasis holds the string denoting the cost_basis field in the database.
@@ -74,6 +76,7 @@ var Columns = []string{
 	FieldRoutingKey,
 	FieldCurrency,
 	FieldTaxCode,
+	FieldTaxBehavior,
 	FieldFeatures,
 	FieldCostBasis,
 	FieldCreditPriority,
@@ -154,6 +157,11 @@ func ByCurrency(opts ...sql.OrderTermOption) OrderOption {
 // ByTaxCode orders the results by the tax_code field.
 func ByTaxCode(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTaxCode, opts...).ToFunc()
+}
+
+// ByTaxBehavior orders the results by the tax_behavior field.
+func ByTaxBehavior(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldTaxBehavior, opts...).ToFunc()
 }
 
 // ByCostBasis orders the results by the cost_basis field.

--- a/openmeter/ent/db/ledgersubaccountroute/where.go
+++ b/openmeter/ent/db/ledgersubaccountroute/where.go
@@ -113,6 +113,12 @@ func TaxCode(v string) predicate.LedgerSubAccountRoute {
 	return predicate.LedgerSubAccountRoute(sql.FieldEQ(FieldTaxCode, v))
 }
 
+// TaxBehavior applies equality check predicate on the "tax_behavior" field. It's identical to TaxBehaviorEQ.
+func TaxBehavior(v ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	vc := string(v)
+	return predicate.LedgerSubAccountRoute(sql.FieldEQ(FieldTaxBehavior, vc))
+}
+
 // CostBasis applies equality check predicate on the "cost_basis" field. It's identical to CostBasisEQ.
 func CostBasis(v alpacadecimal.Decimal) predicate.LedgerSubAccountRoute {
 	return predicate.LedgerSubAccountRoute(sql.FieldEQ(FieldCostBasis, v))
@@ -676,6 +682,100 @@ func TaxCodeEqualFold(v string) predicate.LedgerSubAccountRoute {
 // TaxCodeContainsFold applies the ContainsFold predicate on the "tax_code" field.
 func TaxCodeContainsFold(v string) predicate.LedgerSubAccountRoute {
 	return predicate.LedgerSubAccountRoute(sql.FieldContainsFold(FieldTaxCode, v))
+}
+
+// TaxBehaviorEQ applies the EQ predicate on the "tax_behavior" field.
+func TaxBehaviorEQ(v ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	vc := string(v)
+	return predicate.LedgerSubAccountRoute(sql.FieldEQ(FieldTaxBehavior, vc))
+}
+
+// TaxBehaviorNEQ applies the NEQ predicate on the "tax_behavior" field.
+func TaxBehaviorNEQ(v ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	vc := string(v)
+	return predicate.LedgerSubAccountRoute(sql.FieldNEQ(FieldTaxBehavior, vc))
+}
+
+// TaxBehaviorIn applies the In predicate on the "tax_behavior" field.
+func TaxBehaviorIn(vs ...ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = string(vs[i])
+	}
+	return predicate.LedgerSubAccountRoute(sql.FieldIn(FieldTaxBehavior, v...))
+}
+
+// TaxBehaviorNotIn applies the NotIn predicate on the "tax_behavior" field.
+func TaxBehaviorNotIn(vs ...ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = string(vs[i])
+	}
+	return predicate.LedgerSubAccountRoute(sql.FieldNotIn(FieldTaxBehavior, v...))
+}
+
+// TaxBehaviorGT applies the GT predicate on the "tax_behavior" field.
+func TaxBehaviorGT(v ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	vc := string(v)
+	return predicate.LedgerSubAccountRoute(sql.FieldGT(FieldTaxBehavior, vc))
+}
+
+// TaxBehaviorGTE applies the GTE predicate on the "tax_behavior" field.
+func TaxBehaviorGTE(v ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	vc := string(v)
+	return predicate.LedgerSubAccountRoute(sql.FieldGTE(FieldTaxBehavior, vc))
+}
+
+// TaxBehaviorLT applies the LT predicate on the "tax_behavior" field.
+func TaxBehaviorLT(v ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	vc := string(v)
+	return predicate.LedgerSubAccountRoute(sql.FieldLT(FieldTaxBehavior, vc))
+}
+
+// TaxBehaviorLTE applies the LTE predicate on the "tax_behavior" field.
+func TaxBehaviorLTE(v ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	vc := string(v)
+	return predicate.LedgerSubAccountRoute(sql.FieldLTE(FieldTaxBehavior, vc))
+}
+
+// TaxBehaviorContains applies the Contains predicate on the "tax_behavior" field.
+func TaxBehaviorContains(v ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	vc := string(v)
+	return predicate.LedgerSubAccountRoute(sql.FieldContains(FieldTaxBehavior, vc))
+}
+
+// TaxBehaviorHasPrefix applies the HasPrefix predicate on the "tax_behavior" field.
+func TaxBehaviorHasPrefix(v ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	vc := string(v)
+	return predicate.LedgerSubAccountRoute(sql.FieldHasPrefix(FieldTaxBehavior, vc))
+}
+
+// TaxBehaviorHasSuffix applies the HasSuffix predicate on the "tax_behavior" field.
+func TaxBehaviorHasSuffix(v ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	vc := string(v)
+	return predicate.LedgerSubAccountRoute(sql.FieldHasSuffix(FieldTaxBehavior, vc))
+}
+
+// TaxBehaviorIsNil applies the IsNil predicate on the "tax_behavior" field.
+func TaxBehaviorIsNil() predicate.LedgerSubAccountRoute {
+	return predicate.LedgerSubAccountRoute(sql.FieldIsNull(FieldTaxBehavior))
+}
+
+// TaxBehaviorNotNil applies the NotNil predicate on the "tax_behavior" field.
+func TaxBehaviorNotNil() predicate.LedgerSubAccountRoute {
+	return predicate.LedgerSubAccountRoute(sql.FieldNotNull(FieldTaxBehavior))
+}
+
+// TaxBehaviorEqualFold applies the EqualFold predicate on the "tax_behavior" field.
+func TaxBehaviorEqualFold(v ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	vc := string(v)
+	return predicate.LedgerSubAccountRoute(sql.FieldEqualFold(FieldTaxBehavior, vc))
+}
+
+// TaxBehaviorContainsFold applies the ContainsFold predicate on the "tax_behavior" field.
+func TaxBehaviorContainsFold(v ledger.TaxBehavior) predicate.LedgerSubAccountRoute {
+	vc := string(v)
+	return predicate.LedgerSubAccountRoute(sql.FieldContainsFold(FieldTaxBehavior, vc))
 }
 
 // FeaturesIsNil applies the IsNil predicate on the "features" field.

--- a/openmeter/ent/db/ledgersubaccountroute_create.go
+++ b/openmeter/ent/db/ledgersubaccountroute_create.go
@@ -113,6 +113,20 @@ func (_c *LedgerSubAccountRouteCreate) SetNillableTaxCode(v *string) *LedgerSubA
 	return _c
 }
 
+// SetTaxBehavior sets the "tax_behavior" field.
+func (_c *LedgerSubAccountRouteCreate) SetTaxBehavior(v ledger.TaxBehavior) *LedgerSubAccountRouteCreate {
+	_c.mutation.SetTaxBehavior(v)
+	return _c
+}
+
+// SetNillableTaxBehavior sets the "tax_behavior" field if the given value is not nil.
+func (_c *LedgerSubAccountRouteCreate) SetNillableTaxBehavior(v *ledger.TaxBehavior) *LedgerSubAccountRouteCreate {
+	if v != nil {
+		_c.SetTaxBehavior(*v)
+	}
+	return _c
+}
+
 // SetFeatures sets the "features" field.
 func (_c *LedgerSubAccountRouteCreate) SetFeatures(v []string) *LedgerSubAccountRouteCreate {
 	_c.mutation.SetFeatures(v)
@@ -277,6 +291,11 @@ func (_c *LedgerSubAccountRouteCreate) check() error {
 	if _, ok := _c.mutation.Currency(); !ok {
 		return &ValidationError{Name: "currency", err: errors.New(`db: missing required field "LedgerSubAccountRoute.currency"`)}
 	}
+	if v, ok := _c.mutation.TaxBehavior(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "tax_behavior", err: fmt.Errorf(`db: validator failed for field "LedgerSubAccountRoute.tax_behavior": %w`, err)}
+		}
+	}
 	if v, ok := _c.mutation.TransactionAuthorizationStatus(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "transaction_authorization_status", err: fmt.Errorf(`db: validator failed for field "LedgerSubAccountRoute.transaction_authorization_status": %w`, err)}
@@ -352,6 +371,10 @@ func (_c *LedgerSubAccountRouteCreate) createSpec() (*LedgerSubAccountRoute, *sq
 	if value, ok := _c.mutation.TaxCode(); ok {
 		_spec.SetField(ledgersubaccountroute.FieldTaxCode, field.TypeString, value)
 		_node.TaxCode = &value
+	}
+	if value, ok := _c.mutation.TaxBehavior(); ok {
+		_spec.SetField(ledgersubaccountroute.FieldTaxBehavior, field.TypeString, value)
+		_node.TaxBehavior = &value
 	}
 	if value, ok := _c.mutation.Features(); ok {
 		_spec.SetField(ledgersubaccountroute.FieldFeatures, field.TypeJSON, value)
@@ -521,6 +544,9 @@ func (u *LedgerSubAccountRouteUpsertOne) UpdateNewValues() *LedgerSubAccountRout
 		}
 		if _, exists := u.create.mutation.TaxCode(); exists {
 			s.SetIgnore(ledgersubaccountroute.FieldTaxCode)
+		}
+		if _, exists := u.create.mutation.TaxBehavior(); exists {
+			s.SetIgnore(ledgersubaccountroute.FieldTaxBehavior)
 		}
 		if _, exists := u.create.mutation.Features(); exists {
 			s.SetIgnore(ledgersubaccountroute.FieldFeatures)
@@ -803,6 +829,9 @@ func (u *LedgerSubAccountRouteUpsertBulk) UpdateNewValues() *LedgerSubAccountRou
 			}
 			if _, exists := b.mutation.TaxCode(); exists {
 				s.SetIgnore(ledgersubaccountroute.FieldTaxCode)
+			}
+			if _, exists := b.mutation.TaxBehavior(); exists {
+				s.SetIgnore(ledgersubaccountroute.FieldTaxBehavior)
 			}
 			if _, exists := b.mutation.Features(); exists {
 				s.SetIgnore(ledgersubaccountroute.FieldFeatures)

--- a/openmeter/ent/db/ledgersubaccountroute_update.go
+++ b/openmeter/ent/db/ledgersubaccountroute_update.go
@@ -164,6 +164,9 @@ func (_u *LedgerSubAccountRouteUpdate) sqlSave(ctx context.Context) (_node int, 
 	if _u.mutation.TaxCodeCleared() {
 		_spec.ClearField(ledgersubaccountroute.FieldTaxCode, field.TypeString)
 	}
+	if _u.mutation.TaxBehaviorCleared() {
+		_spec.ClearField(ledgersubaccountroute.FieldTaxBehavior, field.TypeString)
+	}
 	if _u.mutation.FeaturesCleared() {
 		_spec.ClearField(ledgersubaccountroute.FieldFeatures, field.TypeJSON)
 	}
@@ -405,6 +408,9 @@ func (_u *LedgerSubAccountRouteUpdateOne) sqlSave(ctx context.Context) (_node *L
 	}
 	if _u.mutation.TaxCodeCleared() {
 		_spec.ClearField(ledgersubaccountroute.FieldTaxCode, field.TypeString)
+	}
+	if _u.mutation.TaxBehaviorCleared() {
+		_spec.ClearField(ledgersubaccountroute.FieldTaxBehavior, field.TypeString)
 	}
 	if _u.mutation.FeaturesCleared() {
 		_spec.ClearField(ledgersubaccountroute.FieldFeatures, field.TypeJSON)

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -3845,6 +3845,7 @@ var (
 		{Name: "routing_key", Type: field.TypeString},
 		{Name: "currency", Type: field.TypeString},
 		{Name: "tax_code", Type: field.TypeString, Nullable: true},
+		{Name: "tax_behavior", Type: field.TypeString, Nullable: true},
 		{Name: "features", Type: field.TypeJSON, Nullable: true},
 		{Name: "cost_basis", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "credit_priority", Type: field.TypeInt, Nullable: true},
@@ -3859,7 +3860,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "ledger_sub_account_routes_ledger_accounts_sub_account_routes",
-				Columns:    []*schema.Column{LedgerSubAccountRoutesColumns[13]},
+				Columns:    []*schema.Column{LedgerSubAccountRoutesColumns[14]},
 				RefColumns: []*schema.Column{LedgerAccountsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -3878,7 +3879,7 @@ var (
 			{
 				Name:    "ledgersubaccountroute_namespace_account_id_routing_key_version_routing_key",
 				Unique:  true,
-				Columns: []*schema.Column{LedgerSubAccountRoutesColumns[1], LedgerSubAccountRoutesColumns[13], LedgerSubAccountRoutesColumns[5], LedgerSubAccountRoutesColumns[6]},
+				Columns: []*schema.Column{LedgerSubAccountRoutesColumns[1], LedgerSubAccountRoutesColumns[14], LedgerSubAccountRoutesColumns[5], LedgerSubAccountRoutesColumns[6]},
 			},
 		},
 	}

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -84420,6 +84420,7 @@ type LedgerSubAccountRouteMutation struct {
 	routing_key                      *string
 	currency                         *string
 	tax_code                         *string
+	tax_behavior                     *ledger.TaxBehavior
 	features                         *[]string
 	appendfeatures                   []string
 	cost_basis                       *alpacadecimal.Decimal
@@ -84891,6 +84892,55 @@ func (m *LedgerSubAccountRouteMutation) ResetTaxCode() {
 	delete(m.clearedFields, ledgersubaccountroute.FieldTaxCode)
 }
 
+// SetTaxBehavior sets the "tax_behavior" field.
+func (m *LedgerSubAccountRouteMutation) SetTaxBehavior(lb ledger.TaxBehavior) {
+	m.tax_behavior = &lb
+}
+
+// TaxBehavior returns the value of the "tax_behavior" field in the mutation.
+func (m *LedgerSubAccountRouteMutation) TaxBehavior() (r ledger.TaxBehavior, exists bool) {
+	v := m.tax_behavior
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldTaxBehavior returns the old "tax_behavior" field's value of the LedgerSubAccountRoute entity.
+// If the LedgerSubAccountRoute object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *LedgerSubAccountRouteMutation) OldTaxBehavior(ctx context.Context) (v *ledger.TaxBehavior, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldTaxBehavior is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldTaxBehavior requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldTaxBehavior: %w", err)
+	}
+	return oldValue.TaxBehavior, nil
+}
+
+// ClearTaxBehavior clears the value of the "tax_behavior" field.
+func (m *LedgerSubAccountRouteMutation) ClearTaxBehavior() {
+	m.tax_behavior = nil
+	m.clearedFields[ledgersubaccountroute.FieldTaxBehavior] = struct{}{}
+}
+
+// TaxBehaviorCleared returns if the "tax_behavior" field was cleared in this mutation.
+func (m *LedgerSubAccountRouteMutation) TaxBehaviorCleared() bool {
+	_, ok := m.clearedFields[ledgersubaccountroute.FieldTaxBehavior]
+	return ok
+}
+
+// ResetTaxBehavior resets all changes to the "tax_behavior" field.
+func (m *LedgerSubAccountRouteMutation) ResetTaxBehavior() {
+	m.tax_behavior = nil
+	delete(m.clearedFields, ledgersubaccountroute.FieldTaxBehavior)
+}
+
 // SetFeatures sets the "features" field.
 func (m *LedgerSubAccountRouteMutation) SetFeatures(s []string) {
 	m.features = &s
@@ -85239,7 +85289,7 @@ func (m *LedgerSubAccountRouteMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *LedgerSubAccountRouteMutation) Fields() []string {
-	fields := make([]string, 0, 13)
+	fields := make([]string, 0, 14)
 	if m.namespace != nil {
 		fields = append(fields, ledgersubaccountroute.FieldNamespace)
 	}
@@ -85266,6 +85316,9 @@ func (m *LedgerSubAccountRouteMutation) Fields() []string {
 	}
 	if m.tax_code != nil {
 		fields = append(fields, ledgersubaccountroute.FieldTaxCode)
+	}
+	if m.tax_behavior != nil {
+		fields = append(fields, ledgersubaccountroute.FieldTaxBehavior)
 	}
 	if m.features != nil {
 		fields = append(fields, ledgersubaccountroute.FieldFeatures)
@@ -85305,6 +85358,8 @@ func (m *LedgerSubAccountRouteMutation) Field(name string) (ent.Value, bool) {
 		return m.Currency()
 	case ledgersubaccountroute.FieldTaxCode:
 		return m.TaxCode()
+	case ledgersubaccountroute.FieldTaxBehavior:
+		return m.TaxBehavior()
 	case ledgersubaccountroute.FieldFeatures:
 		return m.Features()
 	case ledgersubaccountroute.FieldCostBasis:
@@ -85340,6 +85395,8 @@ func (m *LedgerSubAccountRouteMutation) OldField(ctx context.Context, name strin
 		return m.OldCurrency(ctx)
 	case ledgersubaccountroute.FieldTaxCode:
 		return m.OldTaxCode(ctx)
+	case ledgersubaccountroute.FieldTaxBehavior:
+		return m.OldTaxBehavior(ctx)
 	case ledgersubaccountroute.FieldFeatures:
 		return m.OldFeatures(ctx)
 	case ledgersubaccountroute.FieldCostBasis:
@@ -85420,6 +85477,13 @@ func (m *LedgerSubAccountRouteMutation) SetField(name string, value ent.Value) e
 		}
 		m.SetTaxCode(v)
 		return nil
+	case ledgersubaccountroute.FieldTaxBehavior:
+		v, ok := value.(ledger.TaxBehavior)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetTaxBehavior(v)
+		return nil
 	case ledgersubaccountroute.FieldFeatures:
 		v, ok := value.([]string)
 		if !ok {
@@ -85499,6 +85563,9 @@ func (m *LedgerSubAccountRouteMutation) ClearedFields() []string {
 	if m.FieldCleared(ledgersubaccountroute.FieldTaxCode) {
 		fields = append(fields, ledgersubaccountroute.FieldTaxCode)
 	}
+	if m.FieldCleared(ledgersubaccountroute.FieldTaxBehavior) {
+		fields = append(fields, ledgersubaccountroute.FieldTaxBehavior)
+	}
 	if m.FieldCleared(ledgersubaccountroute.FieldFeatures) {
 		fields = append(fields, ledgersubaccountroute.FieldFeatures)
 	}
@@ -85530,6 +85597,9 @@ func (m *LedgerSubAccountRouteMutation) ClearField(name string) error {
 		return nil
 	case ledgersubaccountroute.FieldTaxCode:
 		m.ClearTaxCode()
+		return nil
+	case ledgersubaccountroute.FieldTaxBehavior:
+		m.ClearTaxBehavior()
 		return nil
 	case ledgersubaccountroute.FieldFeatures:
 		m.ClearFeatures()
@@ -85577,6 +85647,9 @@ func (m *LedgerSubAccountRouteMutation) ResetField(name string) error {
 		return nil
 	case ledgersubaccountroute.FieldTaxCode:
 		m.ResetTaxCode()
+		return nil
+	case ledgersubaccountroute.FieldTaxBehavior:
+		m.ResetTaxBehavior()
 		return nil
 	case ledgersubaccountroute.FieldFeatures:
 		m.ResetFeatures()

--- a/openmeter/ent/schema/ledger_account.go
+++ b/openmeter/ent/schema/ledger_account.go
@@ -113,9 +113,13 @@ func (LedgerSubAccountRoute) Fields() []ent.Field {
 			GoType(ledger.RoutingKeyVersion("")).
 			Immutable(),
 		field.String("routing_key").Immutable(),
-		// Literal routing values
+		// Literal routing values (denormalized from routing_key for query filtering; not FKs).
 		field.String("currency").Immutable(),
+		// tax_code stores the TaxCode.Key string used as a routing dimension, not a FK to the tax_codes table.
 		field.String("tax_code").Optional().Nillable().Immutable(),
+		field.String("tax_behavior").
+			GoType(ledger.TaxBehavior("")).
+			Optional().Nillable().Immutable(),
 		field.Strings("features").Optional().Immutable(),
 		field.Other("cost_basis", alpacadecimal.Decimal{}).
 			Optional().Nillable().Immutable().

--- a/openmeter/ledger/account/adapter/repo_test.go
+++ b/openmeter/ledger/account/adapter/repo_test.go
@@ -251,7 +251,7 @@ func TestRepo_SubAccountRouteUniquenessConstraints(t *testing.T) {
 	require.NoError(t, err)
 
 	createRoute := func(accountID string, creditPriority *int, costBasis *alpacadecimal.Decimal) error {
-		key, err := ledger.BuildRoutingKey(ledger.RoutingKeyVersionV1, ledger.Route{
+		key, err := ledger.BuildRoutingKey(ledger.Route{
 			Currency:       currencyx.Code("USD"),
 			CostBasis:      costBasis,
 			CreditPriority: creditPriority,

--- a/openmeter/ledger/account/adapter/subaccount.go
+++ b/openmeter/ledger/account/adapter/subaccount.go
@@ -74,7 +74,7 @@ func (r *repo) resolveOrCreateRoute(ctx context.Context, input ledgeraccount.Cre
 		return nil, fmt.Errorf("failed to normalize route: %w", err)
 	}
 
-	routeKey, err := ledger.BuildRoutingKey(ledger.RoutingKeyVersionV1, normalizedRoute)
+	routeKey, err := ledger.BuildRoutingKey(normalizedRoute)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build routing key: %w", err)
 	}
@@ -86,6 +86,7 @@ func (r *repo) resolveOrCreateRoute(ctx context.Context, input ledgeraccount.Cre
 		SetRoutingKey(routeKey.Value()).
 		SetCurrency(string(normalizedRoute.Currency)).
 		SetNillableTaxCode(normalizedRoute.TaxCode).
+		SetNillableTaxBehavior(normalizedRoute.TaxBehavior).
 		SetFeatures(normalizedRoute.Features).
 		SetNillableCostBasis(normalizedRoute.CostBasis).
 		SetNillableCreditPriority(normalizedRoute.CreditPriority).
@@ -154,7 +155,7 @@ func (r *repo) ListSubAccounts(ctx context.Context, input ledgeraccount.ListSubA
 			return nil, fmt.Errorf("failed to normalize route filter: %w", err)
 		}
 
-		routePredicates := make([]predicate.LedgerSubAccountRoute, 0, 6)
+		routePredicates := make([]predicate.LedgerSubAccountRoute, 0, 7)
 		if normalizedRoute.Currency != "" {
 			routePredicates = append(routePredicates, dbledgersubaccountroute.Currency(string(normalizedRoute.Currency)))
 		}
@@ -163,9 +164,13 @@ func (r *repo) ListSubAccounts(ctx context.Context, input ledgeraccount.ListSubA
 				dbledgersubaccountroute.CreditPriority(*normalizedRoute.CreditPriority),
 			)
 		}
-		// DEFERRED: tax/feature route filters are not active yet but plumbing is in place.
-		if normalizedRoute.TaxCode != nil {
-			routePredicates = append(routePredicates, dbledgersubaccountroute.TaxCode(*normalizedRoute.TaxCode))
+		if normalizedRoute.TaxCode.IsPresent() {
+			tc, _ := normalizedRoute.TaxCode.Get()
+			if tc != nil {
+				routePredicates = append(routePredicates, dbledgersubaccountroute.TaxCode(*tc))
+			} else {
+				routePredicates = append(routePredicates, dbledgersubaccountroute.TaxCodeIsNil())
+			}
 		}
 		if len(normalizedRoute.Features) > 0 {
 			// DB stores features as a sorted jsonb array; filter value is also sorted for canonical comparison.
@@ -179,6 +184,14 @@ func (r *repo) ListSubAccounts(ctx context.Context, input ledgeraccount.ListSubA
 				routePredicates = append(routePredicates, dbledgersubaccountroute.CostBasis(*costBasis))
 			} else {
 				routePredicates = append(routePredicates, dbledgersubaccountroute.CostBasisIsNil())
+			}
+		}
+		if normalizedRoute.TaxBehavior.IsPresent() {
+			tb, _ := normalizedRoute.TaxBehavior.Get()
+			if tb != nil {
+				routePredicates = append(routePredicates, dbledgersubaccountroute.TaxBehavior(*tb))
+			} else {
+				routePredicates = append(routePredicates, dbledgersubaccountroute.TaxBehaviorIsNil())
 			}
 		}
 		if normalizedRoute.TransactionAuthorizationStatus != nil {
@@ -230,6 +243,7 @@ func MapSubAccountData(entity *db.LedgerSubAccount) (ledgeraccount.SubAccountDat
 		Route: ledger.Route{
 			Currency:                       currencyx.Code(dbRoute.Currency),
 			TaxCode:                        dbRoute.TaxCode,
+			TaxBehavior:                    dbRoute.TaxBehavior,
 			Features:                       dbRoute.Features,
 			CostBasis:                      dbRoute.CostBasis,
 			CreditPriority:                 dbRoute.CreditPriority,

--- a/openmeter/ledger/accounts.go
+++ b/openmeter/ledger/accounts.go
@@ -31,6 +31,7 @@ type CustomerFBORouteParams struct {
 	Currency       currencyx.Code
 	CreditPriority int
 	TaxCode        *string
+	TaxBehavior    *TaxBehavior
 	Features       []string
 	CostBasis      *alpacadecimal.Decimal
 }
@@ -51,6 +52,7 @@ func (p CustomerFBORouteParams) Route() Route {
 	return Route{
 		Currency:       p.Currency,
 		TaxCode:        p.TaxCode,
+		TaxBehavior:    p.TaxBehavior,
 		Features:       p.Features,
 		CostBasis:      p.CostBasis,
 		CreditPriority: &p.CreditPriority,
@@ -68,8 +70,11 @@ type CustomerReceivableAccount interface {
 
 // CustomerReceivableRouteParams are routing parameters specific to customer receivable sub-accounts.
 // TransactionAuthorizationStatus is required; callers must explicitly select the open or authorized route.
+// TaxBehavior is intentionally absent: it is an FBO-only routing dimension and receivable sub-accounts
+// never carry it.
 type CustomerReceivableRouteParams struct {
 	Currency                       currencyx.Code
+	TaxCode                        *string
 	CostBasis                      *alpacadecimal.Decimal
 	TransactionAuthorizationStatus TransactionAuthorizationStatus
 }
@@ -85,6 +90,7 @@ func (p CustomerReceivableRouteParams) Validate() error {
 func (p CustomerReceivableRouteParams) Route() Route {
 	return Route{
 		Currency:                       p.Currency,
+		TaxCode:                        p.TaxCode,
 		CostBasis:                      p.CostBasis,
 		TransactionAuthorizationStatus: &p.TransactionAuthorizationStatus,
 	}
@@ -99,9 +105,9 @@ type CustomerAccruedAccount interface {
 }
 
 // CustomerAccruedRouteParams are routing parameters specific to customer accrued sub-accounts.
-// Routed by currency only for now.
 type CustomerAccruedRouteParams struct {
 	Currency  currencyx.Code
+	TaxCode   *string
 	CostBasis *alpacadecimal.Decimal
 }
 
@@ -112,6 +118,7 @@ func (p CustomerAccruedRouteParams) Validate() error {
 func (p CustomerAccruedRouteParams) Route() Route {
 	return Route{
 		Currency:  p.Currency,
+		TaxCode:   p.TaxCode,
 		CostBasis: p.CostBasis,
 	}
 }
@@ -129,6 +136,7 @@ type BusinessAccount interface {
 
 type BusinessRouteParams struct {
 	Currency  currencyx.Code
+	TaxCode   *string
 	CostBasis *alpacadecimal.Decimal
 }
 
@@ -139,6 +147,7 @@ func (p BusinessRouteParams) Validate() error {
 func (p BusinessRouteParams) Route() Route {
 	return Route{
 		Currency:  p.Currency,
+		TaxCode:   p.TaxCode,
 		CostBasis: p.CostBasis,
 	}
 }

--- a/openmeter/ledger/accounts.go
+++ b/openmeter/ledger/accounts.go
@@ -30,8 +30,6 @@ type CustomerFBOAccount interface {
 type CustomerFBORouteParams struct {
 	Currency       currencyx.Code
 	CreditPriority int
-	TaxCode        *string
-	TaxBehavior    *TaxBehavior
 	Features       []string
 	CostBasis      *alpacadecimal.Decimal
 }
@@ -51,8 +49,6 @@ func (p CustomerFBORouteParams) Validate() error {
 func (p CustomerFBORouteParams) Route() Route {
 	return Route{
 		Currency:       p.Currency,
-		TaxCode:        p.TaxCode,
-		TaxBehavior:    p.TaxBehavior,
 		Features:       p.Features,
 		CostBasis:      p.CostBasis,
 		CreditPriority: &p.CreditPriority,
@@ -70,8 +66,6 @@ type CustomerReceivableAccount interface {
 
 // CustomerReceivableRouteParams are routing parameters specific to customer receivable sub-accounts.
 // TransactionAuthorizationStatus is required; callers must explicitly select the open or authorized route.
-// TaxBehavior is intentionally absent: it is an FBO-only routing dimension and receivable sub-accounts
-// never carry it.
 type CustomerReceivableRouteParams struct {
 	Currency                       currencyx.Code
 	TaxCode                        *string
@@ -106,9 +100,10 @@ type CustomerAccruedAccount interface {
 
 // CustomerAccruedRouteParams are routing parameters specific to customer accrued sub-accounts.
 type CustomerAccruedRouteParams struct {
-	Currency  currencyx.Code
-	TaxCode   *string
-	CostBasis *alpacadecimal.Decimal
+	Currency    currencyx.Code
+	TaxCode     *string
+	TaxBehavior *TaxBehavior
+	CostBasis   *alpacadecimal.Decimal
 }
 
 func (p CustomerAccruedRouteParams) Validate() error {
@@ -117,9 +112,10 @@ func (p CustomerAccruedRouteParams) Validate() error {
 
 func (p CustomerAccruedRouteParams) Route() Route {
 	return Route{
-		Currency:  p.Currency,
-		TaxCode:   p.TaxCode,
-		CostBasis: p.CostBasis,
+		Currency:    p.Currency,
+		TaxCode:     p.TaxCode,
+		TaxBehavior: p.TaxBehavior,
+		CostBasis:   p.CostBasis,
 	}
 }
 
@@ -135,9 +131,10 @@ type BusinessAccount interface {
 }
 
 type BusinessRouteParams struct {
-	Currency  currencyx.Code
-	TaxCode   *string
-	CostBasis *alpacadecimal.Decimal
+	Currency    currencyx.Code
+	TaxCode     *string
+	TaxBehavior *TaxBehavior
+	CostBasis   *alpacadecimal.Decimal
 }
 
 func (p BusinessRouteParams) Validate() error {
@@ -146,8 +143,9 @@ func (p BusinessRouteParams) Validate() error {
 
 func (p BusinessRouteParams) Route() Route {
 	return Route{
-		Currency:  p.Currency,
-		TaxCode:   p.TaxCode,
-		CostBasis: p.CostBasis,
+		Currency:    p.Currency,
+		TaxCode:     p.TaxCode,
+		TaxBehavior: p.TaxBehavior,
+		CostBasis:   p.CostBasis,
 	}
 }

--- a/openmeter/ledger/breakage/service.go
+++ b/openmeter/ledger/breakage/service.go
@@ -639,8 +639,6 @@ func (s *service) resolvePlanAddresses(ctx context.Context, input PlanIssuanceIn
 
 	fboSubAccount, err := customerAccounts.FBOAccount.GetSubAccountForRoute(ctx, ledger.CustomerFBORouteParams{
 		Currency:       input.Currency,
-		TaxCode:        input.TaxCode,
-		TaxBehavior:    input.TaxBehavior,
 		CostBasis:      input.CostBasis,
 		CreditPriority: resolveCreditPriority(input.CreditPriority),
 	})

--- a/openmeter/ledger/breakage/service.go
+++ b/openmeter/ledger/breakage/service.go
@@ -103,6 +103,8 @@ type PlanIssuanceInput struct {
 	Amount                 alpacadecimal.Decimal
 	ImmediateReleaseAmount alpacadecimal.Decimal
 	Currency               currencyx.Code
+	TaxCode                *string
+	TaxBehavior            *ledger.TaxBehavior
 	CostBasis              *alpacadecimal.Decimal
 	CreditPriority         *int
 	ExpiresAt              time.Time
@@ -140,6 +142,12 @@ func (i PlanIssuanceInput) Validate() error {
 	if i.CreditPriority != nil {
 		if err := ledger.ValidateCreditPriority(*i.CreditPriority); err != nil {
 			errs = append(errs, fmt.Errorf("credit priority: %w", err))
+		}
+	}
+
+	if i.TaxBehavior != nil {
+		if err := i.TaxBehavior.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("tax behavior: %w", err))
 		}
 	}
 
@@ -631,6 +639,8 @@ func (s *service) resolvePlanAddresses(ctx context.Context, input PlanIssuanceIn
 
 	fboSubAccount, err := customerAccounts.FBOAccount.GetSubAccountForRoute(ctx, ledger.CustomerFBORouteParams{
 		Currency:       input.Currency,
+		TaxCode:        input.TaxCode,
+		TaxBehavior:    input.TaxBehavior,
 		CostBasis:      input.CostBasis,
 		CreditPriority: resolveCreditPriority(input.CreditPriority),
 	})

--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -226,10 +226,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 		issuableAmount = alpacadecimal.Zero
 	}
 
-	var taxCodeID *string
-	if charge.Intent.TaxConfig != nil {
-		taxCodeID = charge.Intent.TaxConfig.TaxCodeID
-	}
+	taxCodeID := taxCodeIDFromIntent(charge.Intent.TaxConfig)
 
 	var templates []transactions.TransactionTemplate
 

--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -353,6 +353,7 @@ type advanceAttribution struct {
 }
 
 type unattributedAccruedBalance struct {
+	key         taxDimensionKey
 	taxCode     *string
 	taxBehavior *ledger.TaxBehavior
 	amount      alpacadecimal.Decimal
@@ -389,6 +390,11 @@ func (h *creditPurchaseHandler) advanceAttributions(ctx context.Context, custome
 		return nil, err
 	}
 
+	calculator, err := currency.Calculator()
+	if err != nil {
+		return nil, fmt.Errorf("get currency calculator: %w", err)
+	}
+
 	remaining := amount
 	attributions := make([]advanceAttribution, 0, len(advanceReceivables))
 	for _, advanceReceivable := range advanceReceivables {
@@ -409,33 +415,40 @@ func (h *creditPurchaseHandler) advanceAttributions(ctx context.Context, custome
 			attributed = remaining
 		}
 
-		accruedRemaining := attributed
-		for i := range unattributedAccrued {
-			if !accruedRemaining.IsPositive() {
-				break
-			}
-
-			accrued := unattributedAccrued[i].amount
-			if !accrued.IsPositive() {
-				continue
-			}
-			if accrued.GreaterThan(accruedRemaining) {
-				accrued = accruedRemaining
-			}
-
-			attributions = append(attributions, advanceAttribution{
-				taxCode:       unattributedAccrued[i].taxCode,
-				taxBehavior:   unattributedAccrued[i].taxBehavior,
-				advanceAmount: accrued,
-				accruedAmount: accrued,
-			})
-			unattributedAccrued[i].amount = unattributedAccrued[i].amount.Sub(accrued)
-			accruedRemaining = accruedRemaining.Sub(accrued)
+		accruedAttributable := attributed
+		totalUnattributedAccrued := totalUnattributedAccruedBalance(unattributedAccrued)
+		if accruedAttributable.GreaterThan(totalUnattributedAccrued) {
+			accruedAttributable = totalUnattributedAccrued
 		}
 
-		if accruedRemaining.IsPositive() {
+		if accruedAttributable.IsPositive() {
+			accruedAttributions, err := allocateAccruedAttribution(calculator, accruedAttributable, unattributedAccrued)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, allocation := range accruedAttributions {
+				for i := range unattributedAccrued {
+					if unattributedAccrued[i].key != allocation.Key {
+						continue
+					}
+
+					attributions = append(attributions, advanceAttribution{
+						taxCode:       unattributedAccrued[i].taxCode,
+						taxBehavior:   unattributedAccrued[i].taxBehavior,
+						advanceAmount: allocation.Amount,
+						accruedAmount: allocation.Amount,
+					})
+					unattributedAccrued[i].amount = unattributedAccrued[i].amount.Sub(allocation.Amount)
+					break
+				}
+			}
+		}
+
+		unattributedAdvanceAmount := attributed.Sub(accruedAttributable)
+		if unattributedAdvanceAmount.IsPositive() {
 			attributions = append(attributions, advanceAttribution{
-				advanceAmount: accruedRemaining,
+				advanceAmount: unattributedAdvanceAmount,
 			})
 		}
 		remaining = remaining.Sub(attributed)
@@ -473,6 +486,7 @@ func (h *creditPurchaseHandler) unattributedAccruedBalances(ctx context.Context,
 		if _, ok := balancesByKey[key]; !ok {
 			keys = append(keys, key)
 			balancesByKey[key] = unattributedAccruedBalance{
+				key:         key,
 				taxCode:     route.TaxCode,
 				taxBehavior: route.TaxBehavior,
 			}
@@ -488,6 +502,46 @@ func (h *creditPurchaseHandler) unattributedAccruedBalances(ctx context.Context,
 	return lo.Map(keys, func(key taxDimensionKey, _ int) unattributedAccruedBalance {
 		return balancesByKey[key]
 	}), nil
+}
+
+func allocateAccruedAttribution(
+	calculator currencyx.Calculator,
+	amount alpacadecimal.Decimal,
+	unattributedAccrued []unattributedAccruedBalance,
+) ([]currencyx.AmountAllocation[taxDimensionKey], error) {
+	items := make([]currencyx.AmountAllocationItem[taxDimensionKey], 0, len(unattributedAccrued))
+	for _, balance := range unattributedAccrued {
+		if !balance.amount.IsPositive() {
+			continue
+		}
+
+		items = append(items, currencyx.AmountAllocationItem[taxDimensionKey]{
+			Key:    balance.key,
+			Amount: balance.amount,
+		})
+	}
+
+	allocations, err := currencyx.AllocateByAmount(calculator, currencyx.AmountAllocationInput[taxDimensionKey]{
+		Amount:     amount,
+		Items:      items,
+		CompareKey: compareTaxDimensionKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("allocate accrued attribution: %w", err)
+	}
+
+	return allocations, nil
+}
+
+func totalUnattributedAccruedBalance(unattributedAccrued []unattributedAccruedBalance) alpacadecimal.Decimal {
+	total := alpacadecimal.Zero
+	for _, balance := range unattributedAccrued {
+		if balance.amount.IsPositive() {
+			total = total.Add(balance.amount)
+		}
+	}
+
+	return total
 }
 
 func taxDimensionRouteKey(route ledger.Route) taxDimensionKey {

--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
 
 	chargecreditpurchase "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
@@ -201,24 +203,14 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 	}
 	annotations := chargeAnnotationsForCreditPurchaseCharge(charge)
 
-	advanceOutstanding, err := h.outstandingAdvanceBalance(ctx, customerID, charge.Intent.Currency)
+	advanceAttributions, err := h.advanceAttributions(ctx, customerID, charge.Intent.Currency, charge.Intent.CreditAmount)
 	if err != nil {
-		return ledgertransaction.GroupReference{}, fmt.Errorf("get outstanding advance balance: %w", err)
+		return ledgertransaction.GroupReference{}, fmt.Errorf("get advance attributions: %w", err)
 	}
 
-	unattributedAccrued, err := h.unattributedAccruedBalance(ctx, customerID, charge.Intent.Currency)
-	if err != nil {
-		return ledgertransaction.GroupReference{}, fmt.Errorf("get unattributed accrued balance: %w", err)
-	}
-
-	advanceAttributionAmount := charge.Intent.CreditAmount
-	if advanceAttributionAmount.GreaterThan(advanceOutstanding) {
-		advanceAttributionAmount = advanceOutstanding
-	}
-
-	accruedAttributionAmount := advanceAttributionAmount
-	if accruedAttributionAmount.GreaterThan(unattributedAccrued) {
-		accruedAttributionAmount = unattributedAccrued
+	advanceAttributionAmount := alpacadecimal.Zero
+	for _, attribution := range advanceAttributions {
+		advanceAttributionAmount = advanceAttributionAmount.Add(attribution.advanceAmount)
 	}
 
 	issuableAmount := charge.Intent.CreditAmount.Sub(advanceAttributionAmount)
@@ -230,25 +222,25 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 
 	var templates []transactions.TransactionTemplate
 
-	if advanceAttributionAmount.IsPositive() {
+	for _, attribution := range advanceAttributions {
 		templates = append(templates, transactions.AttributeCustomerAdvanceReceivableCostBasisTemplate{
 			At:        charge.CreatedAt,
-			Amount:    advanceAttributionAmount,
+			Amount:    attribution.advanceAmount,
 			Currency:  charge.Intent.Currency,
-			TaxCode:   taxCodeID,
+			TaxCode:   attribution.taxCode,
 			CostBasis: &costBasis,
 		})
-	}
 
-	if accruedAttributionAmount.IsPositive() {
-		templates = append(templates, transactions.TranslateCustomerAccruedCostBasisTemplate{
-			At:            charge.CreatedAt,
-			Amount:        accruedAttributionAmount,
-			Currency:      charge.Intent.Currency,
-			TaxCode:       taxCodeID,
-			FromCostBasis: nil,
-			ToCostBasis:   &costBasis,
-		})
+		if attribution.accruedAmount.IsPositive() {
+			templates = append(templates, transactions.TranslateCustomerAccruedCostBasisTemplate{
+				At:            charge.CreatedAt,
+				Amount:        attribution.accruedAmount,
+				Currency:      charge.Intent.Currency,
+				TaxCode:       attribution.taxCode,
+				FromCostBasis: nil,
+				ToCostBasis:   &costBasis,
+			})
+		}
 	}
 
 	if issuableAmount.IsPositive() {
@@ -310,6 +302,8 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 			Amount:                 charge.Intent.CreditAmount,
 			ImmediateReleaseAmount: advanceAttributionAmount,
 			Currency:               charge.Intent.Currency,
+			TaxCode:                taxCodeID,
+			TaxBehavior:            taxBehaviorFromIntent(charge.Intent.TaxConfig),
 			CostBasis:              &costBasis,
 			CreditPriority:         charge.Intent.Priority,
 			ExpiresAt:              *charge.Intent.ExpiresAt,
@@ -358,55 +352,100 @@ func (h *creditPurchaseHandler) resolverDependencies() transactions.ResolverDepe
 	}
 }
 
-func (h *creditPurchaseHandler) outstandingAdvanceBalance(ctx context.Context, customerID customer.CustomerID, currency currencyx.Code) (alpacadecimal.Decimal, error) {
-	customerAccounts, err := h.accountResolver.GetCustomerAccounts(ctx, customerID)
-	if err != nil {
-		return alpacadecimal.Decimal{}, fmt.Errorf("get customer accounts: %w", err)
-	}
-
-	advanceReceivable, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
-		Currency:                       currency,
-		CostBasis:                      nil,
-		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
-	})
-	if err != nil {
-		return alpacadecimal.Decimal{}, fmt.Errorf("get advance receivable sub-account: %w", err)
-	}
-
-	balance, err := settledBalanceForSubAccount(ctx, h.balanceQuerier, advanceReceivable)
-	if err != nil {
-		return alpacadecimal.Decimal{}, err
-	}
-
-	if balance.IsNegative() {
-		return balance.Neg(), nil
-	}
-
-	return alpacadecimal.Zero, nil
+type advanceAttribution struct {
+	taxCode       *string
+	advanceAmount alpacadecimal.Decimal
+	accruedAmount alpacadecimal.Decimal
 }
 
-func (h *creditPurchaseHandler) unattributedAccruedBalance(ctx context.Context, customerID customer.CustomerID, currency currencyx.Code) (alpacadecimal.Decimal, error) {
+func (h *creditPurchaseHandler) advanceAttributions(ctx context.Context, customerID customer.CustomerID, currency currencyx.Code, amount alpacadecimal.Decimal) ([]advanceAttribution, error) {
 	customerAccounts, err := h.accountResolver.GetCustomerAccounts(ctx, customerID)
 	if err != nil {
-		return alpacadecimal.Decimal{}, fmt.Errorf("get customer accounts: %w", err)
+		return nil, fmt.Errorf("get customer accounts: %w", err)
 	}
 
-	unknownAccrued, err := customerAccounts.AccruedAccount.GetSubAccountForRoute(ctx, ledger.CustomerAccruedRouteParams{
-		Currency:  currency,
-		CostBasis: nil,
+	openStatus := ledger.TransactionAuthorizationStatusOpen
+	advanceReceivables, err := h.accountCatalog.ListSubAccounts(ctx, ledger.ListSubAccountsInput{
+		Namespace: customerAccounts.ReceivableAccount.ID().Namespace,
+		AccountID: customerAccounts.ReceivableAccount.ID().ID,
+		Route: ledger.RouteFilter{
+			Currency:                       currency,
+			CostBasis:                      mo.Some[*alpacadecimal.Decimal](nil),
+			TransactionAuthorizationStatus: &openStatus,
+		},
 	})
 	if err != nil {
-		return alpacadecimal.Decimal{}, fmt.Errorf("get unattributed accrued sub-account: %w", err)
+		return nil, fmt.Errorf("list advance receivable sub-accounts: %w", err)
 	}
 
-	balance, err := settledBalanceForSubAccount(ctx, h.balanceQuerier, unknownAccrued)
+	unattributedAccrued, err := h.unattributedAccruedByTaxCode(ctx, customerAccounts.AccruedAccount, currency)
 	if err != nil {
-		return alpacadecimal.Decimal{}, err
+		return nil, err
 	}
 
-	if balance.IsPositive() {
-		return balance, nil
+	remaining := amount
+	attributions := make([]advanceAttribution, 0, len(advanceReceivables))
+	for _, advanceReceivable := range advanceReceivables {
+		if !remaining.IsPositive() {
+			break
+		}
+
+		balance, err := settledBalanceForSubAccount(ctx, h.balanceQuerier, advanceReceivable)
+		if err != nil {
+			return nil, err
+		}
+		if !balance.IsNegative() {
+			continue
+		}
+
+		attributed := balance.Neg()
+		if attributed.GreaterThan(remaining) {
+			attributed = remaining
+		}
+
+		taxCode := advanceReceivable.Route().TaxCode
+		accrued := unattributedAccrued[lo.FromPtrOr(taxCode, "null")]
+		if accrued.GreaterThan(attributed) {
+			accrued = attributed
+		}
+
+		attributions = append(attributions, advanceAttribution{
+			taxCode:       taxCode,
+			advanceAmount: attributed,
+			accruedAmount: accrued,
+		})
+		remaining = remaining.Sub(attributed)
 	}
 
-	return alpacadecimal.Zero, nil
+	return attributions, nil
+}
+
+func (h *creditPurchaseHandler) unattributedAccruedByTaxCode(ctx context.Context, accruedAccount ledger.CustomerAccruedAccount, currency currencyx.Code) (map[string]alpacadecimal.Decimal, error) {
+	subAccounts, err := h.accountCatalog.ListSubAccounts(ctx, ledger.ListSubAccountsInput{
+		Namespace: accruedAccount.ID().Namespace,
+		AccountID: accruedAccount.ID().ID,
+		Route: ledger.RouteFilter{
+			Currency:  currency,
+			CostBasis: mo.Some[*alpacadecimal.Decimal](nil),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list unattributed accrued sub-accounts: %w", err)
+	}
+
+	balances := make(map[string]alpacadecimal.Decimal, len(subAccounts))
+	for _, subAccount := range subAccounts {
+		balance, err := settledBalanceForSubAccount(ctx, h.balanceQuerier, subAccount)
+		if err != nil {
+			return nil, err
+		}
+		if !balance.IsPositive() {
+			continue
+		}
+
+		key := lo.FromPtrOr(subAccount.Route().TaxCode, "null")
+		balances[key] = balances[key].Add(balance)
+	}
+
+	return balances, nil
 }

--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -244,16 +244,14 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 	}
 
 	if issuableAmount.IsPositive() {
-		tmpl := transactions.IssueCustomerReceivableTemplate{
+		templates = append(templates, transactions.IssueCustomerReceivableTemplate{
 			At:             charge.CreatedAt,
 			Amount:         issuableAmount,
 			Currency:       charge.Intent.Currency,
 			TaxCode:        taxCodeID,
 			CostBasis:      &costBasis,
 			CreditPriority: charge.Intent.Priority,
-		}
-		tmpl.TaxBehavior = taxBehaviorFromIntent(charge.Intent.TaxConfig)
-		templates = append(templates, tmpl)
+		})
 	}
 
 	switch charge.Intent.Settlement.Type() {

--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -226,6 +226,11 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 		issuableAmount = alpacadecimal.Zero
 	}
 
+	var taxCodeID *string
+	if charge.Intent.TaxConfig != nil {
+		taxCodeID = charge.Intent.TaxConfig.TaxCodeID
+	}
+
 	var templates []transactions.TransactionTemplate
 
 	if advanceAttributionAmount.IsPositive() {
@@ -233,6 +238,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 			At:        charge.CreatedAt,
 			Amount:    advanceAttributionAmount,
 			Currency:  charge.Intent.Currency,
+			TaxCode:   taxCodeID,
 			CostBasis: &costBasis,
 		})
 	}
@@ -242,19 +248,26 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 			At:            charge.CreatedAt,
 			Amount:        accruedAttributionAmount,
 			Currency:      charge.Intent.Currency,
+			TaxCode:       taxCodeID,
 			FromCostBasis: nil,
 			ToCostBasis:   &costBasis,
 		})
 	}
 
 	if issuableAmount.IsPositive() {
-		templates = append(templates, transactions.IssueCustomerReceivableTemplate{
+		tmpl := transactions.IssueCustomerReceivableTemplate{
 			At:             charge.CreatedAt,
 			Amount:         issuableAmount,
 			Currency:       charge.Intent.Currency,
+			TaxCode:        taxCodeID,
 			CostBasis:      &costBasis,
 			CreditPriority: charge.Intent.Priority,
-		})
+		}
+		if charge.Intent.TaxConfig != nil && charge.Intent.TaxConfig.Behavior != nil {
+			b := ledger.TaxBehavior(*charge.Intent.TaxConfig.Behavior)
+			tmpl.TaxBehavior = &b
+		}
+		templates = append(templates, tmpl)
 	}
 
 	switch charge.Intent.Settlement.Type() {
@@ -266,12 +279,14 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 				At:        charge.CreatedAt,
 				Amount:    charge.Intent.CreditAmount,
 				Currency:  charge.Intent.Currency,
+				TaxCode:   taxCodeID,
 				CostBasis: &costBasis,
 			},
 			transactions.SettleCustomerReceivableFromPaymentTemplate{
 				At:        charge.CreatedAt,
 				Amount:    charge.Intent.CreditAmount,
 				Currency:  charge.Intent.Currency,
+				TaxCode:   taxCodeID,
 				CostBasis: &costBasis,
 			},
 		)

--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -1,8 +1,10 @@
 package chargeadapter
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
@@ -380,6 +382,7 @@ func (h *creditPurchaseHandler) advanceAttributions(ctx context.Context, custome
 	if err != nil {
 		return nil, fmt.Errorf("list advance receivable sub-accounts: %w", err)
 	}
+	slices.SortStableFunc(advanceReceivables, compareSubAccountRoute)
 
 	unattributedAccrued, err := h.unattributedAccruedBalances(ctx, customerAccounts.AccruedAccount, currency)
 	if err != nil {
@@ -480,6 +483,8 @@ func (h *creditPurchaseHandler) unattributedAccruedBalances(ctx context.Context,
 		balancesByKey[key] = current
 	}
 
+	slices.SortFunc(keys, compareTaxDimensionKey)
+
 	return lo.Map(keys, func(key taxDimensionKey, _ int) unattributedAccruedBalance {
 		return balancesByKey[key]
 	}), nil
@@ -490,4 +495,20 @@ func taxDimensionRouteKey(route ledger.Route) taxDimensionKey {
 		taxCode:     lo.FromPtrOr(route.TaxCode, "null"),
 		taxBehavior: string(lo.FromPtrOr(route.TaxBehavior, "null")),
 	}
+}
+
+func compareTaxDimensionKey(left, right taxDimensionKey) int {
+	if c := cmp.Compare(left.taxCode, right.taxCode); c != 0 {
+		return c
+	}
+
+	return cmp.Compare(left.taxBehavior, right.taxBehavior)
+}
+
+func compareSubAccountRoute(left, right ledger.SubAccount) int {
+	if c := cmp.Compare(left.Address().Route().RoutingKey().Value(), right.Address().Route().RoutingKey().Value()); c != 0 {
+		return c
+	}
+
+	return cmp.Compare(left.Address().SubAccountID(), right.Address().SubAccountID())
 }

--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -218,8 +218,6 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 		issuableAmount = alpacadecimal.Zero
 	}
 
-	taxCodeID := taxCodeIDFromIntent(charge.Intent.TaxConfig)
-
 	var templates []transactions.TransactionTemplate
 
 	for _, attribution := range advanceAttributions {
@@ -227,7 +225,6 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 			At:        charge.CreatedAt,
 			Amount:    attribution.advanceAmount,
 			Currency:  charge.Intent.Currency,
-			TaxCode:   attribution.taxCode,
 			CostBasis: &costBasis,
 		})
 
@@ -237,6 +234,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 				Amount:        attribution.accruedAmount,
 				Currency:      charge.Intent.Currency,
 				TaxCode:       attribution.taxCode,
+				TaxBehavior:   attribution.taxBehavior,
 				FromCostBasis: nil,
 				ToCostBasis:   &costBasis,
 			})
@@ -248,7 +246,6 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 			At:             charge.CreatedAt,
 			Amount:         issuableAmount,
 			Currency:       charge.Intent.Currency,
-			TaxCode:        taxCodeID,
 			CostBasis:      &costBasis,
 			CreditPriority: charge.Intent.Priority,
 		})
@@ -263,14 +260,12 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 				At:        charge.CreatedAt,
 				Amount:    charge.Intent.CreditAmount,
 				Currency:  charge.Intent.Currency,
-				TaxCode:   taxCodeID,
 				CostBasis: &costBasis,
 			},
 			transactions.SettleCustomerReceivableFromPaymentTemplate{
 				At:        charge.CreatedAt,
 				Amount:    charge.Intent.CreditAmount,
 				Currency:  charge.Intent.Currency,
-				TaxCode:   taxCodeID,
 				CostBasis: &costBasis,
 			},
 		)
@@ -300,8 +295,6 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 			Amount:                 charge.Intent.CreditAmount,
 			ImmediateReleaseAmount: advanceAttributionAmount,
 			Currency:               charge.Intent.Currency,
-			TaxCode:                taxCodeID,
-			TaxBehavior:            taxBehaviorFromIntent(charge.Intent.TaxConfig),
 			CostBasis:              &costBasis,
 			CreditPriority:         charge.Intent.Priority,
 			ExpiresAt:              *charge.Intent.ExpiresAt,
@@ -352,8 +345,20 @@ func (h *creditPurchaseHandler) resolverDependencies() transactions.ResolverDepe
 
 type advanceAttribution struct {
 	taxCode       *string
+	taxBehavior   *ledger.TaxBehavior
 	advanceAmount alpacadecimal.Decimal
 	accruedAmount alpacadecimal.Decimal
+}
+
+type unattributedAccruedBalance struct {
+	taxCode     *string
+	taxBehavior *ledger.TaxBehavior
+	amount      alpacadecimal.Decimal
+}
+
+type taxDimensionKey struct {
+	taxCode     string
+	taxBehavior string
 }
 
 func (h *creditPurchaseHandler) advanceAttributions(ctx context.Context, customerID customer.CustomerID, currency currencyx.Code, amount alpacadecimal.Decimal) ([]advanceAttribution, error) {
@@ -376,7 +381,7 @@ func (h *creditPurchaseHandler) advanceAttributions(ctx context.Context, custome
 		return nil, fmt.Errorf("list advance receivable sub-accounts: %w", err)
 	}
 
-	unattributedAccrued, err := h.unattributedAccruedByTaxCode(ctx, customerAccounts.AccruedAccount, currency)
+	unattributedAccrued, err := h.unattributedAccruedBalances(ctx, customerAccounts.AccruedAccount, currency)
 	if err != nil {
 		return nil, err
 	}
@@ -401,24 +406,42 @@ func (h *creditPurchaseHandler) advanceAttributions(ctx context.Context, custome
 			attributed = remaining
 		}
 
-		taxCode := advanceReceivable.Route().TaxCode
-		accrued := unattributedAccrued[lo.FromPtrOr(taxCode, "null")]
-		if accrued.GreaterThan(attributed) {
-			accrued = attributed
+		accruedRemaining := attributed
+		for i := range unattributedAccrued {
+			if !accruedRemaining.IsPositive() {
+				break
+			}
+
+			accrued := unattributedAccrued[i].amount
+			if !accrued.IsPositive() {
+				continue
+			}
+			if accrued.GreaterThan(accruedRemaining) {
+				accrued = accruedRemaining
+			}
+
+			attributions = append(attributions, advanceAttribution{
+				taxCode:       unattributedAccrued[i].taxCode,
+				taxBehavior:   unattributedAccrued[i].taxBehavior,
+				advanceAmount: accrued,
+				accruedAmount: accrued,
+			})
+			unattributedAccrued[i].amount = unattributedAccrued[i].amount.Sub(accrued)
+			accruedRemaining = accruedRemaining.Sub(accrued)
 		}
 
-		attributions = append(attributions, advanceAttribution{
-			taxCode:       taxCode,
-			advanceAmount: attributed,
-			accruedAmount: accrued,
-		})
+		if accruedRemaining.IsPositive() {
+			attributions = append(attributions, advanceAttribution{
+				advanceAmount: accruedRemaining,
+			})
+		}
 		remaining = remaining.Sub(attributed)
 	}
 
 	return attributions, nil
 }
 
-func (h *creditPurchaseHandler) unattributedAccruedByTaxCode(ctx context.Context, accruedAccount ledger.CustomerAccruedAccount, currency currencyx.Code) (map[string]alpacadecimal.Decimal, error) {
+func (h *creditPurchaseHandler) unattributedAccruedBalances(ctx context.Context, accruedAccount ledger.CustomerAccruedAccount, currency currencyx.Code) ([]unattributedAccruedBalance, error) {
 	subAccounts, err := h.accountCatalog.ListSubAccounts(ctx, ledger.ListSubAccountsInput{
 		Namespace: accruedAccount.ID().Namespace,
 		AccountID: accruedAccount.ID().ID,
@@ -431,7 +454,8 @@ func (h *creditPurchaseHandler) unattributedAccruedByTaxCode(ctx context.Context
 		return nil, fmt.Errorf("list unattributed accrued sub-accounts: %w", err)
 	}
 
-	balances := make(map[string]alpacadecimal.Decimal, len(subAccounts))
+	balancesByKey := make(map[taxDimensionKey]unattributedAccruedBalance, len(subAccounts))
+	keys := make([]taxDimensionKey, 0, len(subAccounts))
 	for _, subAccount := range subAccounts {
 		balance, err := settledBalanceForSubAccount(ctx, h.balanceQuerier, subAccount)
 		if err != nil {
@@ -441,9 +465,29 @@ func (h *creditPurchaseHandler) unattributedAccruedByTaxCode(ctx context.Context
 			continue
 		}
 
-		key := lo.FromPtrOr(subAccount.Route().TaxCode, "null")
-		balances[key] = balances[key].Add(balance)
+		route := subAccount.Route()
+		key := taxDimensionRouteKey(route)
+		if _, ok := balancesByKey[key]; !ok {
+			keys = append(keys, key)
+			balancesByKey[key] = unattributedAccruedBalance{
+				taxCode:     route.TaxCode,
+				taxBehavior: route.TaxBehavior,
+			}
+		}
+
+		current := balancesByKey[key]
+		current.amount = current.amount.Add(balance)
+		balancesByKey[key] = current
 	}
 
-	return balances, nil
+	return lo.Map(keys, func(key taxDimensionKey, _ int) unattributedAccruedBalance {
+		return balancesByKey[key]
+	}), nil
+}
+
+func taxDimensionRouteKey(route ledger.Route) taxDimensionKey {
+	return taxDimensionKey{
+		taxCode:     lo.FromPtrOr(route.TaxCode, "null"),
+		taxBehavior: string(lo.FromPtrOr(route.TaxBehavior, "null")),
+	}
 }

--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -260,10 +260,7 @@ func (h *creditPurchaseHandler) issueCreditPurchaseGroup(ctx context.Context, ch
 			CostBasis:      &costBasis,
 			CreditPriority: charge.Intent.Priority,
 		}
-		if charge.Intent.TaxConfig != nil && charge.Intent.TaxConfig.Behavior != nil {
-			b := ledger.TaxBehavior(*charge.Intent.TaxConfig.Behavior)
-			tmpl.TaxBehavior = &b
-		}
+		tmpl.TaxBehavior = taxBehaviorFromIntent(charge.Intent.TaxConfig)
 		templates = append(templates, tmpl)
 	}
 

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -196,7 +196,6 @@ func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, input flatfee.
 			At:        input.EventAt,
 			Amount:    input.Amount,
 			Currency:  input.Charge.Intent.Currency,
-			TaxCode:   taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
 			CostBasis: invoiceCostBasis,
 		},
 	)
@@ -250,7 +249,6 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, input flatfee.OnP
 			At:        input.EventAt,
 			Amount:    input.Amount,
 			Currency:  input.Charge.Intent.Currency,
-			TaxCode:   taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
 			CostBasis: invoiceCostBasis,
 		},
 	)

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -115,11 +115,12 @@ func (h *flatFeeHandler) OnInvoiceUsageAccrued(ctx context.Context, input flatfe
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.TransferCustomerReceivableToAccruedTemplate{
-			At:        input.BookedAt,
-			Amount:    amount,
-			Currency:  input.Charge.Intent.Currency,
-			TaxCode:   taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
-			CostBasis: invoiceCostBasis,
+			At:          input.BookedAt,
+			Amount:      amount,
+			Currency:    input.Charge.Intent.Currency,
+			TaxCode:     taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
+			TaxBehavior: taxBehaviorFromIntent(input.Charge.Intent.TaxConfig),
+			CostBasis:   invoiceCostBasis,
 		},
 	)
 	if err != nil {

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -65,6 +65,8 @@ func (h *flatFeeHandler) OnAllocateCredits(ctx context.Context, input flatfee.On
 		BookedAt:          input.BookedAt,
 		SourceBalanceAsOf: input.Charge.Intent.InvoiceAt,
 		Currency:          input.Charge.Intent.Currency,
+		TaxCode:           taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
+		TaxBehavior:       taxBehaviorFromIntent(input.Charge.Intent.TaxConfig),
 		SettlementMode:    input.Charge.Intent.SettlementMode,
 		ServicePeriod:     input.ServicePeriod,
 		Amount:            input.PreTaxAmountToAllocate,
@@ -116,6 +118,7 @@ func (h *flatFeeHandler) OnInvoiceUsageAccrued(ctx context.Context, input flatfe
 			At:        input.BookedAt,
 			Amount:    amount,
 			Currency:  input.Charge.Intent.Currency,
+			TaxCode:   taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
 			CostBasis: invoiceCostBasis,
 		},
 	)
@@ -192,6 +195,7 @@ func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, input flatfee.
 			At:        input.EventAt,
 			Amount:    input.Amount,
 			Currency:  input.Charge.Intent.Currency,
+			TaxCode:   taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
 			CostBasis: invoiceCostBasis,
 		},
 	)
@@ -245,6 +249,7 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, input flatfee.OnP
 			At:        input.EventAt,
 			Amount:    input.Amount,
 			Currency:  input.Charge.Intent.Currency,
+			TaxCode:   taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
 			CostBasis: invoiceCostBasis,
 		},
 	)

--- a/openmeter/ledger/chargeadapter/helpers.go
+++ b/openmeter/ledger/chargeadapter/helpers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/alpacahq/alpacadecimal"
 
 	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 )
 
 func settledBalanceForSubAccount(ctx context.Context, querier ledger.BalanceQuerier, subAccount ledger.SubAccount) (alpacadecimal.Decimal, error) {
@@ -16,4 +17,11 @@ func settledBalanceForSubAccount(ctx context.Context, querier ledger.BalanceQuer
 	}
 
 	return balance.Settled(), nil
+}
+
+func taxCodeIDFromIntent(taxConfig *productcatalog.TaxCodeConfig) *string {
+	if taxConfig == nil {
+		return nil
+	}
+	return taxConfig.TaxCodeID
 }

--- a/openmeter/ledger/chargeadapter/helpers.go
+++ b/openmeter/ledger/chargeadapter/helpers.go
@@ -25,3 +25,12 @@ func taxCodeIDFromIntent(taxConfig *productcatalog.TaxCodeConfig) *string {
 	}
 	return taxConfig.TaxCodeID
 }
+
+func taxBehaviorFromIntent(taxConfig *productcatalog.TaxCodeConfig) *ledger.TaxBehavior {
+	if taxConfig == nil || taxConfig.Behavior == nil {
+		return nil
+	}
+
+	behavior := ledger.TaxBehavior(*taxConfig.Behavior)
+	return &behavior
+}

--- a/openmeter/ledger/chargeadapter/helpers.go
+++ b/openmeter/ledger/chargeadapter/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
@@ -31,6 +32,5 @@ func taxBehaviorFromIntent(taxConfig *productcatalog.TaxCodeConfig) *ledger.TaxB
 		return nil
 	}
 
-	behavior := ledger.TaxBehavior(*taxConfig.Behavior)
-	return &behavior
+	return lo.ToPtr(ledger.TaxBehavior(*taxConfig.Behavior))
 }

--- a/openmeter/ledger/chargeadapter/helpers.go
+++ b/openmeter/ledger/chargeadapter/helpers.go
@@ -21,14 +21,14 @@ func settledBalanceForSubAccount(ctx context.Context, querier ledger.BalanceQuer
 }
 
 func taxCodeIDFromIntent(taxConfig *productcatalog.TaxCodeConfig) *string {
-	if taxConfig == nil {
+	if taxConfig == nil || taxConfig.TaxCodeID == nil || taxConfig.Behavior == nil {
 		return nil
 	}
 	return taxConfig.TaxCodeID
 }
 
 func taxBehaviorFromIntent(taxConfig *productcatalog.TaxCodeConfig) *ledger.TaxBehavior {
-	if taxConfig == nil || taxConfig.Behavior == nil {
+	if taxConfig == nil || taxConfig.TaxCodeID == nil || taxConfig.Behavior == nil {
 		return nil
 	}
 

--- a/openmeter/ledger/chargeadapter/helpers.go
+++ b/openmeter/ledger/chargeadapter/helpers.go
@@ -21,7 +21,7 @@ func settledBalanceForSubAccount(ctx context.Context, querier ledger.BalanceQuer
 }
 
 func taxCodeIDFromIntent(taxConfig *productcatalog.TaxCodeConfig) *string {
-	if taxConfig == nil || taxConfig.TaxCodeID == nil || taxConfig.Behavior == nil {
+	if taxConfig == nil {
 		return nil
 	}
 	return taxConfig.TaxCodeID

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -68,11 +68,12 @@ func (h *usageBasedHandler) OnInvoiceUsageAccrued(ctx context.Context, input usa
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.TransferCustomerReceivableToAccruedTemplate{
-			At:        input.BookedAt,
-			Amount:    amount,
-			Currency:  input.Charge.Intent.Currency,
-			TaxCode:   taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
-			CostBasis: invoiceCostBasis,
+			At:          input.BookedAt,
+			Amount:      amount,
+			Currency:    input.Charge.Intent.Currency,
+			TaxCode:     taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
+			TaxBehavior: taxBehaviorFromIntent(input.Charge.Intent.TaxConfig),
+			CostBasis:   invoiceCostBasis,
 		},
 	)
 	if err != nil {

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -71,6 +71,7 @@ func (h *usageBasedHandler) OnInvoiceUsageAccrued(ctx context.Context, input usa
 			At:        input.BookedAt,
 			Amount:    amount,
 			Currency:  input.Charge.Intent.Currency,
+			TaxCode:   taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
 			CostBasis: invoiceCostBasis,
 		},
 	)
@@ -130,6 +131,7 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 			At:        input.EventAt,
 			Amount:    receivableReplenishment,
 			Currency:  input.Charge.Intent.Currency,
+			TaxCode:   taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
 			CostBasis: invoiceCostBasis,
 		},
 	)
@@ -190,6 +192,7 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 			At:        input.EventAt,
 			Amount:    input.Run.InvoiceUsage.Totals.Total,
 			Currency:  input.Charge.Intent.Currency,
+			TaxCode:   taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
 			CostBasis: invoiceCostBasis,
 		},
 	)
@@ -242,6 +245,8 @@ func (h *usageBasedHandler) OnCreditsOnlyUsageAccrued(ctx context.Context, input
 		BookedAt:          input.BookedAt,
 		SourceBalanceAsOf: clock.Now(),
 		Currency:          input.Charge.Intent.Currency,
+		TaxCode:           taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
+		TaxBehavior:       taxBehaviorFromIntent(input.Charge.Intent.TaxConfig),
 		SettlementMode:    input.Charge.Intent.SettlementMode,
 		ServicePeriod:     input.Charge.Intent.ServicePeriod,
 		Amount:            input.AmountToAllocate,

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -132,7 +132,6 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 			At:        input.EventAt,
 			Amount:    receivableReplenishment,
 			Currency:  input.Charge.Intent.Currency,
-			TaxCode:   taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
 			CostBasis: invoiceCostBasis,
 		},
 	)
@@ -193,7 +192,6 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 			At:        input.EventAt,
 			Amount:    input.Run.InvoiceUsage.Totals.Total,
 			Currency:  input.Charge.Intent.Currency,
-			TaxCode:   taxCodeIDFromIntent(input.Charge.Intent.TaxConfig),
 			CostBasis: invoiceCostBasis,
 		},
 	)

--- a/openmeter/ledger/collector/collect.go
+++ b/openmeter/ledger/collector/collect.go
@@ -170,7 +170,6 @@ func (c *accrualCollector) resolveAdvanceInputs(ctx context.Context, input Colle
 			At:       input.BookedAt,
 			Amount:   amount,
 			Currency: input.Currency,
-			TaxCode:  input.TaxCode,
 		},
 		transactions.TransferCustomerFBOAdvanceToAccruedTemplate{
 			At:          input.BookedAt,

--- a/openmeter/ledger/collector/collect.go
+++ b/openmeter/ledger/collector/collect.go
@@ -122,9 +122,11 @@ func (c *accrualCollector) resolveCollectedInputs(ctx context.Context, input Col
 		c.deps,
 		c.resolutionScope(input),
 		transactions.TransferCustomerFBOToAccruedTemplate{
-			At:       input.BookedAt,
-			Currency: input.Currency,
-			Sources:  sources,
+			At:          input.BookedAt,
+			Currency:    input.Currency,
+			TaxCode:     input.TaxCode,
+			TaxBehavior: input.TaxBehavior,
+			Sources:     sources,
 		},
 	)
 	if err != nil {
@@ -165,11 +167,10 @@ func (c *accrualCollector) resolveAdvanceInputs(ctx context.Context, input Colle
 		c.deps,
 		c.resolutionScope(input),
 		transactions.IssueCustomerReceivableTemplate{
-			At:          input.BookedAt,
-			Amount:      amount,
-			Currency:    input.Currency,
-			TaxCode:     input.TaxCode,
-			TaxBehavior: input.TaxBehavior,
+			At:       input.BookedAt,
+			Amount:   amount,
+			Currency: input.Currency,
+			TaxCode:  input.TaxCode,
 		},
 		transactions.TransferCustomerFBOAdvanceToAccruedTemplate{
 			At:          input.BookedAt,

--- a/openmeter/ledger/collector/collect.go
+++ b/openmeter/ledger/collector/collect.go
@@ -165,14 +165,18 @@ func (c *accrualCollector) resolveAdvanceInputs(ctx context.Context, input Colle
 		c.deps,
 		c.resolutionScope(input),
 		transactions.IssueCustomerReceivableTemplate{
-			At:       input.BookedAt,
-			Amount:   amount,
-			Currency: input.Currency,
+			At:          input.BookedAt,
+			Amount:      amount,
+			Currency:    input.Currency,
+			TaxCode:     input.TaxCode,
+			TaxBehavior: input.TaxBehavior,
 		},
 		transactions.TransferCustomerFBOAdvanceToAccruedTemplate{
-			At:       input.BookedAt,
-			Amount:   amount,
-			Currency: input.Currency,
+			At:          input.BookedAt,
+			Amount:      amount,
+			Currency:    input.Currency,
+			TaxCode:     input.TaxCode,
+			TaxBehavior: input.TaxBehavior,
 		},
 	)
 	if err != nil {

--- a/openmeter/ledger/collector/service.go
+++ b/openmeter/ledger/collector/service.go
@@ -45,6 +45,8 @@ type CollectToAccruedInput struct {
 	SettlementMode    productcatalog.SettlementMode
 	ServicePeriod     timeutil.ClosedPeriod
 	Amount            alpacadecimal.Decimal
+	TaxCode           *string
+	TaxBehavior       *ledger.TaxBehavior
 }
 
 type CorrectCollectedAccruedInput struct {

--- a/openmeter/ledger/customerbalance/transactions_test.go
+++ b/openmeter/ledger/customerbalance/transactions_test.go
@@ -178,7 +178,7 @@ func mustEntryData(t *testing.T, id string, accountType ledger.AccountType, curr
 	t.Helper()
 
 	route := ledger.Route{Currency: currency}
-	key, err := ledger.BuildRoutingKey(ledger.RoutingKeyVersionV1, route)
+	key, err := ledger.BuildRoutingKey(route)
 	require.NoError(t, err)
 
 	return ledgerhistorical.EntryData{

--- a/openmeter/ledger/errors.go
+++ b/openmeter/ledger/errors.go
@@ -136,3 +136,10 @@ var ErrRoutingRuleViolated = models.NewValidationIssue(
 	ErrCodeRoutingRuleViolated,
 	"ledger routing rule violated",
 )
+
+const ErrCodeTaxBehaviorInvalid models.ErrorCode = "ledger_tax_behavior_invalid"
+
+var ErrTaxBehaviorInvalid = models.NewValidationIssue(
+	ErrCodeTaxBehaviorInvalid,
+	"ledger tax behavior is invalid",
+)

--- a/openmeter/ledger/historical/adapter/sumentries_query.go
+++ b/openmeter/ledger/historical/adapter/sumentries_query.go
@@ -118,7 +118,7 @@ func (b *sumEntriesQuery) subAccountPredicates() ([]predicate.LedgerSubAccount, 
 		})
 	}
 
-	routePredicates := make([]predicate.LedgerSubAccountRoute, 0, 6)
+	routePredicates := make([]predicate.LedgerSubAccountRoute, 0, 7)
 	if normalizedRoute.Currency != "" {
 		routePredicates = append(routePredicates, ledgersubaccountroutedb.Currency(string(normalizedRoute.Currency)))
 	}
@@ -127,9 +127,13 @@ func (b *sumEntriesQuery) subAccountPredicates() ([]predicate.LedgerSubAccount, 
 			ledgersubaccountroutedb.CreditPriority(*normalizedRoute.CreditPriority),
 		)
 	}
-	// DEFERRED: tax/feature route filters are not active yet but plumbing is in place.
-	if normalizedRoute.TaxCode != nil {
-		routePredicates = append(routePredicates, ledgersubaccountroutedb.TaxCode(*normalizedRoute.TaxCode))
+	if normalizedRoute.TaxCode.IsPresent() {
+		tc, _ := normalizedRoute.TaxCode.Get()
+		if tc != nil {
+			routePredicates = append(routePredicates, ledgersubaccountroutedb.TaxCode(*tc))
+		} else {
+			routePredicates = append(routePredicates, ledgersubaccountroutedb.TaxCodeIsNil())
+		}
 	}
 	if len(normalizedRoute.Features) > 0 {
 		// DB stores features as a sorted jsonb array; filter value is also sorted for canonical comparison.
@@ -143,6 +147,14 @@ func (b *sumEntriesQuery) subAccountPredicates() ([]predicate.LedgerSubAccount, 
 			routePredicates = append(routePredicates, ledgersubaccountroutedb.CostBasis(*costBasis))
 		} else {
 			routePredicates = append(routePredicates, ledgersubaccountroutedb.CostBasisIsNil())
+		}
+	}
+	if normalizedRoute.TaxBehavior.IsPresent() {
+		tb, _ := normalizedRoute.TaxBehavior.Get()
+		if tb != nil {
+			routePredicates = append(routePredicates, ledgersubaccountroutedb.TaxBehavior(*tb))
+		} else {
+			routePredicates = append(routePredicates, ledgersubaccountroutedb.TaxBehaviorIsNil())
 		}
 	}
 	if normalizedRoute.TransactionAuthorizationStatus != nil {

--- a/openmeter/ledger/impact.go
+++ b/openmeter/ledger/impact.go
@@ -28,8 +28,27 @@ func EntryMatchesImpactFilter(entry Entry, filter ImpactFilter) bool {
 	if routeFilter.Currency != "" && route.Currency != routeFilter.Currency {
 		return false
 	}
-	if routeFilter.TaxCode != nil && (route.TaxCode == nil || *route.TaxCode != *routeFilter.TaxCode) {
-		return false
+	if routeFilter.TaxCode.IsPresent() {
+		taxCode, _ := routeFilter.TaxCode.Get()
+		switch {
+		case taxCode == nil && route.TaxCode != nil:
+			return false
+		case taxCode != nil && route.TaxCode == nil:
+			return false
+		case taxCode != nil && route.TaxCode != nil && *taxCode != *route.TaxCode:
+			return false
+		}
+	}
+	if routeFilter.TaxBehavior.IsPresent() {
+		taxBehavior, _ := routeFilter.TaxBehavior.Get()
+		switch {
+		case taxBehavior == nil && route.TaxBehavior != nil:
+			return false
+		case taxBehavior != nil && route.TaxBehavior == nil:
+			return false
+		case taxBehavior != nil && route.TaxBehavior != nil && *taxBehavior != *route.TaxBehavior:
+			return false
+		}
 	}
 	if len(routeFilter.Features) > 0 && !slices.Equal(route.Features, SortedFeatures(routeFilter.Features)) {
 		return false

--- a/openmeter/ledger/impact_test.go
+++ b/openmeter/ledger/impact_test.go
@@ -18,6 +18,8 @@ func TestEntryMatchesImpactFilter(t *testing.T) {
 
 	taxCode := "tax-standard"
 	otherTaxCode := "tax-reduced"
+	taxBehavior := ledger.TaxBehaviorInclusive
+	otherTaxBehavior := ledger.TaxBehaviorExclusive
 	priority := 10
 	otherPriority := 20
 	costBasis := alpacadecimal.NewFromInt(1)
@@ -28,6 +30,7 @@ func TestEntryMatchesImpactFilter(t *testing.T) {
 	entry := mustImpactTestEntry(t, ledger.AccountTypeCustomerFBO, ledger.Route{
 		Currency:                       currencyx.Code("USD"),
 		TaxCode:                        &taxCode,
+		TaxBehavior:                    &taxBehavior,
 		Features:                       []string{"feature-a", "feature-b"},
 		CostBasis:                      &costBasis,
 		CreditPriority:                 &priority,
@@ -72,14 +75,39 @@ func TestEntryMatchesImpactFilter(t *testing.T) {
 		{
 			name: "tax code matches",
 			filter: ledger.ImpactFilter{
-				Route: ledger.RouteFilter{TaxCode: &taxCode},
+				Route: ledger.RouteFilter{TaxCode: mo.Some(&taxCode)},
 			},
 			want: true,
 		},
 		{
 			name: "tax code mismatch",
 			filter: ledger.ImpactFilter{
-				Route: ledger.RouteFilter{TaxCode: &otherTaxCode},
+				Route: ledger.RouteFilter{TaxCode: mo.Some(&otherTaxCode)},
+			},
+		},
+		{
+			name: "nil tax code required rejects non-nil route tax code",
+			filter: ledger.ImpactFilter{
+				Route: ledger.RouteFilter{TaxCode: mo.Some[*string](nil)},
+			},
+		},
+		{
+			name: "tax behavior matches",
+			filter: ledger.ImpactFilter{
+				Route: ledger.RouteFilter{TaxBehavior: mo.Some(&taxBehavior)},
+			},
+			want: true,
+		},
+		{
+			name: "tax behavior mismatch",
+			filter: ledger.ImpactFilter{
+				Route: ledger.RouteFilter{TaxBehavior: mo.Some(&otherTaxBehavior)},
+			},
+		},
+		{
+			name: "nil tax behavior required rejects non-nil route tax behavior",
+			filter: ledger.ImpactFilter{
+				Route: ledger.RouteFilter{TaxBehavior: mo.Some[*ledger.TaxBehavior](nil)},
 			},
 		},
 		{
@@ -153,7 +181,8 @@ func TestEntryMatchesImpactFilter(t *testing.T) {
 				AccountType: ledger.AccountTypeCustomerFBO,
 				Route: ledger.RouteFilter{
 					Currency:       currencyx.Code("USD"),
-					TaxCode:        &taxCode,
+					TaxCode:        mo.Some(&taxCode),
+					TaxBehavior:    mo.Some(&taxBehavior),
 					Features:       []string{"feature-b", "feature-a"},
 					CostBasis:      mo.Some(&costBasis),
 					CreditPriority: &priority,
@@ -176,6 +205,7 @@ func TestEntryMatchesImpactFilter_NilRouteFields(t *testing.T) {
 	t.Parallel()
 
 	taxCode := "tax-standard"
+	taxBehavior := ledger.TaxBehaviorInclusive
 	priority := 10
 	authStatus := ledger.TransactionAuthorizationStatusOpen
 
@@ -191,8 +221,28 @@ func TestEntryMatchesImpactFilter_NilRouteFields(t *testing.T) {
 		{
 			name: "tax code required but route has nil",
 			filter: ledger.ImpactFilter{
-				Route: ledger.RouteFilter{TaxCode: &taxCode},
+				Route: ledger.RouteFilter{TaxCode: mo.Some(&taxCode)},
 			},
+		},
+		{
+			name: "nil tax code required and route has nil",
+			filter: ledger.ImpactFilter{
+				Route: ledger.RouteFilter{TaxCode: mo.Some[*string](nil)},
+			},
+			want: true,
+		},
+		{
+			name: "tax behavior required but route has nil",
+			filter: ledger.ImpactFilter{
+				Route: ledger.RouteFilter{TaxBehavior: mo.Some(&taxBehavior)},
+			},
+		},
+		{
+			name: "nil tax behavior required and route has nil",
+			filter: ledger.ImpactFilter{
+				Route: ledger.RouteFilter{TaxBehavior: mo.Some[*ledger.TaxBehavior](nil)},
+			},
+			want: true,
 		},
 		{
 			name: "nil cost basis required and route has nil",
@@ -393,7 +443,7 @@ func mustImpactTestEntry(t *testing.T, accountType ledger.AccountType, route led
 	normalizedRoute, err := route.Normalize()
 	require.NoError(t, err)
 
-	routingKey, err := ledger.BuildRoutingKey(ledger.RoutingKeyVersionV1, normalizedRoute)
+	routingKey, err := ledger.BuildRoutingKey(normalizedRoute)
 	require.NoError(t, err)
 
 	subAccountRoute, err := ledger.NewSubAccountRouteFromData("route-id", routingKey, normalizedRoute)

--- a/openmeter/ledger/noop/noop.go
+++ b/openmeter/ledger/noop/noop.go
@@ -269,7 +269,7 @@ func newSubAccount(namespace, accountID string, route ledger.Route) *ledgeraccou
 	}
 
 	accountType := accountTypeForRoute(normalizedRoute)
-	routingKey, err := ledger.BuildRoutingKey(ledger.RoutingKeyVersionV1, normalizedRoute)
+	routingKey, err := ledger.BuildRoutingKey(normalizedRoute)
 	if err != nil {
 		return &ledgeraccount.SubAccount{}
 	}

--- a/openmeter/ledger/primitives.go
+++ b/openmeter/ledger/primitives.go
@@ -49,11 +49,11 @@ type SubAccount interface {
 type RouteFilter struct {
 	Currency currencyx.Code
 
-	// DEFERRED: tax/feature not active yet.
 	// Non-currency fields are retained for near-future expansion.
-	TaxCode   *string
-	Features  []string
-	CostBasis mo.Option[*alpacadecimal.Decimal]
+	TaxCode     mo.Option[*string]
+	TaxBehavior mo.Option[*TaxBehavior]
+	Features    []string
+	CostBasis   mo.Option[*alpacadecimal.Decimal]
 
 	// CreditPriority is only meaningful for customer_fbo queries.
 	CreditPriority *int

--- a/openmeter/ledger/routing.go
+++ b/openmeter/ledger/routing.go
@@ -16,13 +16,26 @@ import (
 
 type RoutingKeyVersion string
 
-const RoutingKeyVersionV1 RoutingKeyVersion = "v1"
+const (
+	RoutingKeyVersionV1 RoutingKeyVersion = "v1"
+	// RoutingKeyVersionV2 extends V1 by adding the tax_behavior segment.
+	// Use V2 when a route has a non-nil TaxBehavior; otherwise use V1 for
+	// backward compatibility with sub-accounts created before tax_behavior existed.
+	RoutingKeyVersionV2 RoutingKeyVersion = "v2"
+)
 
 type TransactionAuthorizationStatus string
 
 const (
 	TransactionAuthorizationStatusOpen       TransactionAuthorizationStatus = "open"
 	TransactionAuthorizationStatusAuthorized TransactionAuthorizationStatus = "authorized"
+)
+
+type TaxBehavior string
+
+const (
+	TaxBehaviorInclusive TaxBehavior = "inclusive"
+	TaxBehaviorExclusive TaxBehavior = "exclusive"
 )
 
 func (s TransactionAuthorizationStatus) Validate() error {
@@ -40,11 +53,24 @@ func (s TransactionAuthorizationStatus) Validate() error {
 
 func (v RoutingKeyVersion) Validate() error {
 	switch v {
-	case RoutingKeyVersionV1:
+	case RoutingKeyVersionV1, RoutingKeyVersionV2:
 		return nil
 	default:
 		return ErrRoutingKeyVersionInvalid.WithAttrs(models.Attributes{
 			"routing_key_version": v,
+		})
+	}
+}
+
+func (b TaxBehavior) Validate() error {
+	switch b {
+	case TaxBehaviorInclusive:
+		return nil
+	case TaxBehaviorExclusive:
+		return nil
+	default:
+		return ErrTaxBehaviorInvalid.WithAttrs(models.Attributes{
+			"tax_behavior": b,
 		})
 	}
 }
@@ -83,7 +109,8 @@ type SubAccountRoute struct {
 }
 
 // NewSubAccountRouteFromData hydrates a sub-account route from persisted data.
-// Does not enforce Route & RoutingKey equality due to possible version mismatch
+// Does not enforce Route & RoutingKey equality due to possible version mismatch.
+// Sets route.Version from the stored routing key so the round-trip is transparent.
 func NewSubAccountRouteFromData(id string, key RoutingKey, route Route) (SubAccountRoute, error) {
 	if id == "" {
 		return SubAccountRoute{}, errors.New("route id is required")
@@ -97,31 +124,7 @@ func NewSubAccountRouteFromData(id string, key RoutingKey, route Route) (SubAcco
 		return SubAccountRoute{}, fmt.Errorf("normalize route: %w", err)
 	}
 
-	return SubAccountRoute{
-		id:    id,
-		key:   key,
-		route: normalizedRoute,
-	}, nil
-}
-
-// NewSubAccountRouteFromRoute creates a new sub-account route from a literal route
-func NewSubAccountRouteFromRoute(id string, version RoutingKeyVersion, route Route) (SubAccountRoute, error) {
-	if id == "" {
-		return SubAccountRoute{}, errors.New("route id is required")
-	}
-	if err := route.Validate(); err != nil {
-		return SubAccountRoute{}, fmt.Errorf("route: %w", err)
-	}
-
-	normalizedRoute, err := route.Normalize()
-	if err != nil {
-		return SubAccountRoute{}, fmt.Errorf("normalize route: %w", err)
-	}
-
-	key, err := BuildRoutingKey(version, normalizedRoute)
-	if err != nil {
-		return SubAccountRoute{}, fmt.Errorf("build routing key from route: %w", err)
-	}
+	normalizedRoute.Version = key.Version()
 
 	return SubAccountRoute{
 		id:    id,
@@ -148,9 +151,12 @@ func (r SubAccountRoute) Route() Route {
 
 // Route holds the literal values that identify a sub-account's routing path.
 // It is used for creation, persistence, and routing key generation.
+// Version is set automatically by Normalize() based on which fields are present.
 type Route struct {
+	Version                        RoutingKeyVersion
 	Currency                       currencyx.Code
 	TaxCode                        *string
+	TaxBehavior                    *TaxBehavior
 	Features                       []string
 	CostBasis                      *alpacadecimal.Decimal
 	CreditPriority                 *int
@@ -180,14 +186,22 @@ func (r Route) Validate() error {
 		}
 	}
 
+	if r.TaxBehavior != nil {
+		if err := r.TaxBehavior.Validate(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
 // Filter converts a Route to a RouteFilter for use in queries.
+// All present route fields are pinned as exact-match filters (including nil values).
 func (r Route) Filter() RouteFilter {
 	return RouteFilter{
 		Currency:                       r.Currency,
-		TaxCode:                        r.TaxCode,
+		TaxCode:                        mo.Some(r.TaxCode),
+		TaxBehavior:                    mo.Some(r.TaxBehavior),
 		Features:                       r.Features,
 		CostBasis:                      mo.Some(r.CostBasis),
 		CreditPriority:                 r.CreditPriority,
@@ -196,7 +210,8 @@ func (r Route) Filter() RouteFilter {
 }
 
 // Normalize canonicalizes route values so semantically equivalent routes share
-// the same stored literals and routing keys.
+// the same stored literals and routing keys. It also sets Version based on the
+// fields present in the route.
 func (r Route) Normalize() (Route, error) {
 	if err := r.Validate(); err != nil {
 		return Route{}, err
@@ -204,20 +219,24 @@ func (r Route) Normalize() (Route, error) {
 
 	normalized := r
 	normalized.Features = SortedFeatures(r.Features)
+	normalized.Version = selectRoutingKeyVersion(r)
 
 	return normalized, nil
 }
 
 // Normalize canonicalizes route filter values before querying.
 func (f RouteFilter) Normalize() (RouteFilter, error) {
-	if f.Currency == "" && f.TaxCode == nil && len(f.Features) == 0 && f.CostBasis.IsAbsent() && f.CreditPriority == nil && f.TransactionAuthorizationStatus == nil {
+	if f.Currency == "" && f.TaxCode.IsAbsent() && len(f.Features) == 0 && f.CostBasis.IsAbsent() && f.CreditPriority == nil && f.TransactionAuthorizationStatus == nil && f.TaxBehavior.IsAbsent() {
 		return f, nil
 	}
 
+	taxCode, _ := f.TaxCode.Get()
+	taxBehavior, _ := f.TaxBehavior.Get()
 	costBasis, _ := f.CostBasis.Get()
 	normalized, err := Route{
 		Currency:                       f.Currency,
-		TaxCode:                        f.TaxCode,
+		TaxCode:                        taxCode,
+		TaxBehavior:                    taxBehavior,
 		Features:                       f.Features,
 		CostBasis:                      costBasis,
 		CreditPriority:                 f.CreditPriority,
@@ -232,9 +251,20 @@ func (f RouteFilter) Normalize() (RouteFilter, error) {
 		normalizedCostBasis = mo.Some(normalized.CostBasis)
 	}
 
+	normalizedTaxCode := mo.None[*string]()
+	if f.TaxCode.IsPresent() {
+		normalizedTaxCode = mo.Some(normalized.TaxCode)
+	}
+
+	normalizedTaxBehavior := mo.None[*TaxBehavior]()
+	if f.TaxBehavior.IsPresent() {
+		normalizedTaxBehavior = mo.Some(normalized.TaxBehavior)
+	}
+
 	return RouteFilter{
 		Currency:                       normalized.Currency,
-		TaxCode:                        normalized.TaxCode,
+		TaxCode:                        normalizedTaxCode,
+		TaxBehavior:                    normalizedTaxBehavior,
 		Features:                       normalized.Features,
 		CostBasis:                      normalizedCostBasis,
 		CreditPriority:                 normalized.CreditPriority,
@@ -246,37 +276,100 @@ func (f RouteFilter) Normalize() (RouteFilter, error) {
 // Routing key generation
 // ----------------------------------------------------------------------------
 
-func BuildRoutingKey(version RoutingKeyVersion, route Route) (RoutingKey, error) {
-	if err := route.Validate(); err != nil {
-		return RoutingKey{}, err
-	}
-
-	switch version {
-	case RoutingKeyVersionV1:
-		return BuildRoutingKeyV1(route)
-	default:
-		return RoutingKey{}, ErrRoutingKeyVersionUnsupported.WithAttrs(models.Attributes{
-			"routing_key_version": version,
-		})
-	}
+// routingVersionRequirement pairs a version with the route condition that requires it.
+type routingVersionRequirement struct {
+	version  RoutingKeyVersion
+	requires func(Route) bool
 }
 
-func BuildRoutingKeyV1(route Route) (RoutingKey, error) {
+// routingVersionRequirements lists versions above V1 with the conditions that trigger them.
+// Ordered highest to lowest; selectRoutingKeyVersion returns the first match, V1 otherwise.
+var routingVersionRequirements = []routingVersionRequirement{
+	{version: RoutingKeyVersionV2, requires: func(r Route) bool { return r.TaxBehavior != nil }},
+}
+
+// selectRoutingKeyVersion returns the minimum routing key version required to
+// encode all fields present in route. V1 is the baseline; higher versions are
+// selected when the route uses fields that V1 does not include.
+func selectRoutingKeyVersion(route Route) RoutingKeyVersion {
+	for _, req := range routingVersionRequirements {
+		if req.requires(route) {
+			return req.version
+		}
+	}
+	return RoutingKeyVersionV1
+}
+
+// BuildRoutingKey normalizes route and encodes it as a RoutingKey.
+// The version is determined automatically from the route fields present.
+func BuildRoutingKey(route Route) (RoutingKey, error) {
 	normalizedRoute, err := route.Normalize()
 	if err != nil {
 		return RoutingKey{}, err
 	}
 
+	switch normalizedRoute.Version {
+	case RoutingKeyVersionV1:
+		return buildRoutingKeyV1Normalized(normalizedRoute)
+	case RoutingKeyVersionV2:
+		return buildRoutingKeyV2Normalized(normalizedRoute)
+	default:
+		return RoutingKey{}, ErrRoutingKeyVersionUnsupported.WithAttrs(models.Attributes{
+			"routing_key_version": normalizedRoute.Version,
+		})
+	}
+}
+
+// BuildRoutingKeyV1 encodes route as a V1 routing key.
+// Returns an error if route.TaxBehavior is non-nil; use BuildRoutingKey to
+// select the correct version automatically based on route fields.
+func BuildRoutingKeyV1(route Route) (RoutingKey, error) {
+	if route.TaxBehavior != nil {
+		return RoutingKey{}, fmt.Errorf("TaxBehavior requires a V2 routing key; use BuildRoutingKey to select the version automatically")
+	}
+	normalizedRoute, err := route.Normalize()
+	if err != nil {
+		return RoutingKey{}, err
+	}
+	return buildRoutingKeyV1Normalized(normalizedRoute)
+}
+
+// BuildRoutingKeyV2 encodes route as a V2 routing key.
+func BuildRoutingKeyV2(route Route) (RoutingKey, error) {
+	normalizedRoute, err := route.Normalize()
+	if err != nil {
+		return RoutingKey{}, err
+	}
+	return buildRoutingKeyV2Normalized(normalizedRoute)
+}
+
+// buildRoutingKeyV1Normalized encodes an already-normalized route as a V1 key.
+func buildRoutingKeyV1Normalized(route Route) (RoutingKey, error) {
 	value := strings.Join([]string{
-		"currency:" + string(normalizedRoute.Currency),
-		"tax_code:" + optionalStringValue(normalizedRoute.TaxCode),
-		"features:" + canonicalFeatures(normalizedRoute.Features),
-		"cost_basis:" + optionalDecimalValue(normalizedRoute.CostBasis),
-		"credit_priority:" + optionalIntValue(normalizedRoute.CreditPriority),
-		"transaction_authorization_status:" + optionalTransactionAuthorizationStatusValue(normalizedRoute.TransactionAuthorizationStatus),
+		"currency:" + string(route.Currency),
+		"tax_code:" + optionalStringValue(route.TaxCode),
+		"features:" + canonicalFeatures(route.Features),
+		"cost_basis:" + optionalDecimalValue(route.CostBasis),
+		"credit_priority:" + optionalIntValue(route.CreditPriority),
+		"transaction_authorization_status:" + optionalTransactionAuthorizationStatusValue(route.TransactionAuthorizationStatus),
 	}, "|")
 
 	return NewRoutingKey(RoutingKeyVersionV1, value)
+}
+
+// buildRoutingKeyV2Normalized encodes an already-normalized route as a V2 key.
+func buildRoutingKeyV2Normalized(route Route) (RoutingKey, error) {
+	value := strings.Join([]string{
+		"currency:" + string(route.Currency),
+		"tax_code:" + optionalStringValue(route.TaxCode),
+		"tax_behavior:" + optionalTaxBehaviorValue(route.TaxBehavior),
+		"features:" + canonicalFeatures(route.Features),
+		"cost_basis:" + optionalDecimalValue(route.CostBasis),
+		"credit_priority:" + optionalIntValue(route.CreditPriority),
+		"transaction_authorization_status:" + optionalTransactionAuthorizationStatusValue(route.TransactionAuthorizationStatus),
+	}, "|")
+
+	return NewRoutingKey(RoutingKeyVersionV2, value)
 }
 
 // ----------------------------------------------------------------------------
@@ -380,4 +473,11 @@ func optionalDecimalValue(v *alpacadecimal.Decimal) string {
 		return "null"
 	}
 	return v.String()
+}
+
+func optionalTaxBehaviorValue(v *TaxBehavior) string {
+	if v == nil {
+		return "null"
+	}
+	return string(*v)
 }

--- a/openmeter/ledger/routing.go
+++ b/openmeter/ledger/routing.go
@@ -151,11 +151,16 @@ func (r SubAccountRoute) Route() Route {
 
 // Route holds the literal values that identify a sub-account's routing path.
 // It is used for creation, persistence, and routing key generation.
-// Version is set automatically by Normalize() based on which fields are present.
 type Route struct {
-	Version                        RoutingKeyVersion
-	Currency                       currencyx.Code
-	TaxCode                        *string
+	// Version is auto-derived by Normalize() based on which fields are present.
+	// Direct assignment is overwritten on the next Normalize call. Do not set
+	// manually except for testing edge cases.
+	Version  RoutingKeyVersion
+	Currency currencyx.Code
+	TaxCode  *string
+	// TaxBehavior is an FBO-only routing dimension. Receivable, Accrued,
+	// and Earnings sub-accounts do not carry it. Only IssueCustomerReceivable*
+	// transactions thread it via CustomerFBORouteParams.
 	TaxBehavior                    *TaxBehavior
 	Features                       []string
 	CostBasis                      *alpacadecimal.Decimal

--- a/openmeter/ledger/routing.go
+++ b/openmeter/ledger/routing.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -158,9 +159,9 @@ type Route struct {
 	Version  RoutingKeyVersion
 	Currency currencyx.Code
 	TaxCode  *string
-	// TaxBehavior is an FBO-only routing dimension. Receivable, Accrued,
-	// and Earnings sub-accounts do not carry it. Only IssueCustomerReceivable*
-	// transactions thread it via CustomerFBORouteParams.
+	// TaxBehavior distinguishes taxable accrued and earnings buckets.
+	// Customer FBO routes do not carry tax dimensions; credit sources are
+	// attributed to charge tax configuration when they accrue.
 	TaxBehavior                    *TaxBehavior
 	Features                       []string
 	CostBasis                      *alpacadecimal.Decimal
@@ -356,7 +357,7 @@ func buildRoutingKeyV1Normalized(route Route) (RoutingKey, error) {
 		"features:" + canonicalFeatures(route.Features),
 		"cost_basis:" + optionalDecimalValue(route.CostBasis),
 		"credit_priority:" + optionalIntValue(route.CreditPriority),
-		"transaction_authorization_status:" + optionalTransactionAuthorizationStatusValue(route.TransactionAuthorizationStatus),
+		"transaction_authorization_status:" + string(lo.FromPtrOr(route.TransactionAuthorizationStatus, "null")),
 	}, "|")
 
 	return NewRoutingKey(RoutingKeyVersionV1, value)
@@ -367,11 +368,11 @@ func buildRoutingKeyV2Normalized(route Route) (RoutingKey, error) {
 	value := strings.Join([]string{
 		"currency:" + string(route.Currency),
 		"tax_code:" + optionalStringValue(route.TaxCode),
-		"tax_behavior:" + optionalTaxBehaviorValue(route.TaxBehavior),
+		"tax_behavior:" + string(lo.FromPtrOr(route.TaxBehavior, "null")),
 		"features:" + canonicalFeatures(route.Features),
 		"cost_basis:" + optionalDecimalValue(route.CostBasis),
 		"credit_priority:" + optionalIntValue(route.CreditPriority),
-		"transaction_authorization_status:" + optionalTransactionAuthorizationStatusValue(route.TransactionAuthorizationStatus),
+		"transaction_authorization_status:" + string(lo.FromPtrOr(route.TransactionAuthorizationStatus, "null")),
 	}, "|")
 
 	return NewRoutingKey(RoutingKeyVersionV2, value)
@@ -466,23 +467,9 @@ func optionalIntValue(v *int) string {
 	return strconv.Itoa(*v)
 }
 
-func optionalTransactionAuthorizationStatusValue(v *TransactionAuthorizationStatus) string {
-	if v == nil {
-		return "null"
-	}
-	return string(*v)
-}
-
 func optionalDecimalValue(v *alpacadecimal.Decimal) string {
 	if v == nil {
 		return "null"
 	}
 	return v.String()
-}
-
-func optionalTaxBehaviorValue(v *TaxBehavior) string {
-	if v == nil {
-		return "null"
-	}
-	return string(*v)
 }

--- a/openmeter/ledger/routing_test.go
+++ b/openmeter/ledger/routing_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -13,15 +14,17 @@ import (
 func TestBuildRoutingKeyV1(t *testing.T) {
 	priority := 7
 	costBasis := mustDecimal(t, "0.7")
+	taxcode := "GST10"
 
 	key, err := BuildRoutingKeyV1(Route{
+		TaxCode:        &taxcode,
 		Currency:       currencyx.Code("USD"),
 		CostBasis:      &costBasis,
 		CreditPriority: &priority,
 	})
 	require.NoError(t, err)
 	require.Equal(t, RoutingKeyVersionV1, key.Version())
-	require.Equal(t, "currency:USD|tax_code:null|features:null|cost_basis:0.7|credit_priority:7|transaction_authorization_status:null", key.Value())
+	require.Equal(t, "currency:USD|tax_code:GST10|features:null|cost_basis:0.7|credit_priority:7|transaction_authorization_status:null", key.Value())
 }
 
 func TestBuildRoutingKeyV1_Nulls(t *testing.T) {
@@ -109,6 +112,115 @@ func TestBuildRoutingKeyV1_DifferentAuthorizationStatus_DifferentKey(t *testing.
 	require.Equal(t, "currency:USD|tax_code:null|features:null|cost_basis:null|credit_priority:null|transaction_authorization_status:authorized", key2.Value())
 }
 
+func TestBuildRoutingKeyV2_DifferentTaxBehavior_DifferentKey(t *testing.T) {
+	base := Route{Currency: currencyx.Code("USD"), TaxCode: lo.ToPtr("GST10"), TaxBehavior: lo.ToPtr(TaxBehaviorInclusive)}
+
+	k1, err := BuildRoutingKeyV2(base)
+	require.NoError(t, err)
+	require.Equal(t, RoutingKeyVersionV2, k1.Version())
+
+	exclusive := base
+	exclusive.TaxBehavior = lo.ToPtr(TaxBehaviorExclusive)
+	k2, err := BuildRoutingKeyV2(exclusive)
+	require.NoError(t, err)
+
+	require.NotEqual(t, k1.Value(), k2.Value())
+}
+
+func TestTaxBehaviorValidate(t *testing.T) {
+	require.NoError(t, TaxBehaviorInclusive.Validate())
+	require.NoError(t, TaxBehaviorExclusive.Validate())
+	require.Error(t, TaxBehavior("bogus").Validate())
+	require.Error(t, TaxBehavior("").Validate())
+}
+
+func TestRouteValidate_InvalidTaxBehavior(t *testing.T) {
+	r := Route{
+		Currency:    currencyx.Code("USD"),
+		TaxBehavior: lo.ToPtr(TaxBehavior("bogus")),
+	}
+	require.Error(t, r.Validate())
+}
+
+func TestRouteFilter_NormalizePreservesTaxCode(t *testing.T) {
+	tc := "VAT20"
+	f := RouteFilter{
+		Currency: currencyx.Code("USD"),
+		TaxCode:  mo.Some[*string](&tc),
+	}
+	norm, err := f.Normalize()
+	require.NoError(t, err)
+	require.True(t, norm.TaxCode.IsPresent())
+	got, _ := norm.TaxCode.Get()
+	require.Equal(t, &tc, got)
+}
+
+func TestRouteFilter_NormalizePreservesTaxBehavior(t *testing.T) {
+	b := TaxBehaviorExclusive
+	f := RouteFilter{
+		Currency:    currencyx.Code("USD"),
+		TaxBehavior: mo.Some[*TaxBehavior](&b),
+	}
+	norm, err := f.Normalize()
+	require.NoError(t, err)
+	require.True(t, norm.TaxBehavior.IsPresent())
+	got, _ := norm.TaxBehavior.Get()
+	require.Equal(t, &b, got)
+}
+
+func TestRouteFilter_NormalizeAbsentTaxFieldsStayAbsent(t *testing.T) {
+	f := RouteFilter{Currency: currencyx.Code("USD")}
+	norm, err := f.Normalize()
+	require.NoError(t, err)
+	require.True(t, norm.TaxCode.IsAbsent())
+	require.True(t, norm.TaxBehavior.IsAbsent())
+}
+
+func TestRouteFilter_NormalizeSomeNilTaxCodePreserved(t *testing.T) {
+	f := RouteFilter{
+		Currency: currencyx.Code("USD"),
+		TaxCode:  mo.Some[*string](nil),
+	}
+	norm, err := f.Normalize()
+	require.NoError(t, err)
+	require.True(t, norm.TaxCode.IsPresent())
+	got, _ := norm.TaxCode.Get()
+	require.Nil(t, got)
+}
+
+func TestRouteToFilter_TaxFieldsPinned(t *testing.T) {
+	tc := "GST10"
+	b := TaxBehaviorInclusive
+	r := Route{
+		Currency:    currencyx.Code("USD"),
+		TaxCode:     &tc,
+		TaxBehavior: &b,
+	}
+	f := r.Filter()
+
+	require.True(t, f.TaxCode.IsPresent())
+	gotCode, _ := f.TaxCode.Get()
+	require.Equal(t, &tc, gotCode)
+
+	require.True(t, f.TaxBehavior.IsPresent())
+	gotBehavior, _ := f.TaxBehavior.Get()
+	require.Equal(t, &b, gotBehavior)
+}
+
+func TestRouteToFilter_NilTaxFieldsPinnedAsPresent(t *testing.T) {
+	r := Route{Currency: currencyx.Code("USD")}
+	f := r.Filter()
+
+	// nil Route fields become Some(nil) in filter — "filter for null", not "don't care"
+	require.True(t, f.TaxCode.IsPresent())
+	tc, _ := f.TaxCode.Get()
+	require.Nil(t, tc)
+
+	require.True(t, f.TaxBehavior.IsPresent())
+	tb, _ := f.TaxBehavior.Get()
+	require.Nil(t, tb)
+}
+
 func mustDecimal(t *testing.T, raw string) alpacadecimal.Decimal {
 	t.Helper()
 
@@ -116,4 +228,15 @@ func mustDecimal(t *testing.T, raw string) alpacadecimal.Decimal {
 	require.NoError(t, err)
 
 	return value
+}
+
+func TestBuildRoutingKeyV2_WithTaxBehaviorAndTaxCode(t *testing.T) {
+	key, err := BuildRoutingKeyV2(Route{
+		Currency:    currencyx.Code("USD"),
+		TaxCode:     lo.ToPtr("GST10"),
+		TaxBehavior: lo.ToPtr(TaxBehaviorExclusive),
+	})
+	require.NoError(t, err)
+	require.Equal(t, RoutingKeyVersionV2, key.Version())
+	require.Equal(t, "currency:USD|tax_code:GST10|tax_behavior:exclusive|features:null|cost_basis:null|credit_priority:null|transaction_authorization_status:null", key.Value())
 }

--- a/openmeter/ledger/routingrules/defaults.go
+++ b/openmeter/ledger/routingrules/defaults.go
@@ -65,6 +65,7 @@ var DefaultValidator = Validator{
 			Right: ledger.AccountTypeCustomerAccrued,
 			Fields: []RouteField{
 				RouteFieldCurrency,
+				RouteFieldTaxCode,
 				RouteFieldCostBasis,
 			},
 		},
@@ -73,6 +74,7 @@ var DefaultValidator = Validator{
 			Right: ledger.AccountTypeCustomerAccrued,
 			Fields: []RouteField{
 				RouteFieldCurrency,
+				RouteFieldTaxCode,
 				RouteFieldCostBasis,
 			},
 		},
@@ -81,6 +83,7 @@ var DefaultValidator = Validator{
 			Right: ledger.AccountTypeEarnings,
 			Fields: []RouteField{
 				RouteFieldCurrency,
+				RouteFieldTaxCode,
 				RouteFieldCostBasis,
 			},
 		},

--- a/openmeter/ledger/routingrules/defaults.go
+++ b/openmeter/ledger/routingrules/defaults.go
@@ -5,6 +5,7 @@ import "github.com/openmeterio/openmeter/openmeter/ledger"
 var DefaultValidator = Validator{
 	Rules: []RoutingRule{
 		RequireUniqueSubAccountsRule{},
+		RequireTaxBehaviorScopeRule{},
 		AllowedAccountSetsRule{
 			Sets: [][]ledger.AccountType{
 				{ledger.AccountTypeCustomerFBO, ledger.AccountTypeCustomerReceivable},

--- a/openmeter/ledger/routingrules/defaults.go
+++ b/openmeter/ledger/routingrules/defaults.go
@@ -5,7 +5,7 @@ import "github.com/openmeterio/openmeter/openmeter/ledger"
 var DefaultValidator = Validator{
 	Rules: []RoutingRule{
 		RequireUniqueSubAccountsRule{},
-		RequireTaxBehaviorScopeRule{},
+		RequireTaxDimensionScopeRule{},
 		AllowedAccountSetsRule{
 			Sets: [][]ledger.AccountType{
 				{ledger.AccountTypeCustomerFBO, ledger.AccountTypeCustomerReceivable},
@@ -56,7 +56,6 @@ var DefaultValidator = Validator{
 			Right: ledger.AccountTypeCustomerReceivable,
 			Fields: []RouteField{
 				RouteFieldCurrency,
-				RouteFieldTaxCode,
 				RouteFieldFeatures,
 				RouteFieldCostBasis,
 			},
@@ -66,7 +65,6 @@ var DefaultValidator = Validator{
 			Right: ledger.AccountTypeCustomerAccrued,
 			Fields: []RouteField{
 				RouteFieldCurrency,
-				RouteFieldTaxCode,
 				RouteFieldCostBasis,
 			},
 		},
@@ -85,6 +83,7 @@ var DefaultValidator = Validator{
 			Fields: []RouteField{
 				RouteFieldCurrency,
 				RouteFieldTaxCode,
+				RouteFieldTaxBehavior,
 				RouteFieldCostBasis,
 			},
 		},

--- a/openmeter/ledger/routingrules/defaults.go
+++ b/openmeter/ledger/routingrules/defaults.go
@@ -73,7 +73,6 @@ var DefaultValidator = Validator{
 			Right: ledger.AccountTypeCustomerAccrued,
 			Fields: []RouteField{
 				RouteFieldCurrency,
-				RouteFieldTaxCode,
 				RouteFieldCostBasis,
 			},
 		},

--- a/openmeter/ledger/routingrules/routingrules.go
+++ b/openmeter/ledger/routingrules/routingrules.go
@@ -198,13 +198,25 @@ func (r RequireSameRouteRule) Validate(tx TxView) error {
 	return requireMatchingRouteFields(tx.EntriesOf(r.Left), tx.EntriesOf(r.Right), r.Left, r.Right, r.Fields)
 }
 
-type RequireTaxBehaviorScopeRule struct{}
+type RequireTaxDimensionScopeRule struct{}
 
-func (r RequireTaxBehaviorScopeRule) Validate(tx TxView) error {
+func (r RequireTaxDimensionScopeRule) Validate(tx TxView) error {
 	for _, entry := range tx.Entries() {
-		if entry.AccountType() != ledger.AccountTypeCustomerFBO && entry.Route().TaxBehavior != nil {
+		if entry.AccountType() == ledger.AccountTypeCustomerFBO && entry.Route().TaxCode != nil {
 			return ledger.ErrRoutingRuleViolated.WithAttrs(models.Attributes{
-				"reason":       "tax_behavior_only_allowed_on_customer_fbo",
+				"reason":       "tax_code_not_allowed_on_customer_fbo",
+				"account_type": entry.AccountType(),
+			})
+		}
+
+		switch entry.AccountType() {
+		case ledger.AccountTypeCustomerAccrued, ledger.AccountTypeEarnings:
+			continue
+		}
+
+		if entry.Route().TaxBehavior != nil {
+			return ledger.ErrRoutingRuleViolated.WithAttrs(models.Attributes{
+				"reason":       "tax_behavior_only_allowed_on_accrued_or_earnings",
 				"account_type": entry.AccountType(),
 			})
 		}
@@ -330,6 +342,8 @@ func (r RequireAccruedCostBasisTranslationRule) Validate(tx TxView) error {
 		ledger.AccountTypeCustomerAccrued,
 		[]RouteField{
 			RouteFieldCurrency,
+			RouteFieldTaxCode,
+			RouteFieldTaxBehavior,
 		},
 	)
 }
@@ -356,8 +370,6 @@ func (r RequireFBOCostBasisTranslationRule) Validate(tx TxView) error {
 		ledger.AccountTypeCustomerFBO,
 		[]RouteField{
 			RouteFieldCurrency,
-			RouteFieldTaxCode,
-			RouteFieldTaxBehavior,
 			RouteFieldFeatures,
 			RouteFieldCreditPriority,
 		},

--- a/openmeter/ledger/routingrules/routingrules.go
+++ b/openmeter/ledger/routingrules/routingrules.go
@@ -202,23 +202,21 @@ type RequireTaxDimensionScopeRule struct{}
 
 func (r RequireTaxDimensionScopeRule) Validate(tx TxView) error {
 	for _, entry := range tx.Entries() {
-		if entry.AccountType() == ledger.AccountTypeCustomerFBO && entry.Route().TaxCode != nil {
-			return ledger.ErrRoutingRuleViolated.WithAttrs(models.Attributes{
-				"reason":       "tax_code_not_allowed_on_customer_fbo",
-				"account_type": entry.AccountType(),
-			})
-		}
-
 		switch entry.AccountType() {
 		case ledger.AccountTypeCustomerAccrued, ledger.AccountTypeEarnings:
-			continue
-		}
-
-		if entry.Route().TaxBehavior != nil {
-			return ledger.ErrRoutingRuleViolated.WithAttrs(models.Attributes{
-				"reason":       "tax_behavior_only_allowed_on_accrued_or_earnings",
-				"account_type": entry.AccountType(),
-			})
+			if (entry.Route().TaxCode == nil) != (entry.Route().TaxBehavior == nil) {
+				return ledger.ErrRoutingRuleViolated.WithAttrs(models.Attributes{
+					"reason":       "tax_dimensions_must_be_complete_on_accrued_or_earnings",
+					"account_type": entry.AccountType(),
+				})
+			}
+		default:
+			if entry.Route().TaxCode != nil || entry.Route().TaxBehavior != nil {
+				return ledger.ErrRoutingRuleViolated.WithAttrs(models.Attributes{
+					"reason":       "tax_dimensions_only_allowed_on_accrued_or_earnings",
+					"account_type": entry.AccountType(),
+				})
+			}
 		}
 	}
 

--- a/openmeter/ledger/routingrules/routingrules.go
+++ b/openmeter/ledger/routingrules/routingrules.go
@@ -204,9 +204,9 @@ func (r RequireTaxDimensionScopeRule) Validate(tx TxView) error {
 	for _, entry := range tx.Entries() {
 		switch entry.AccountType() {
 		case ledger.AccountTypeCustomerAccrued, ledger.AccountTypeEarnings:
-			if (entry.Route().TaxCode == nil) != (entry.Route().TaxBehavior == nil) {
+			if entry.Route().TaxCode == nil && entry.Route().TaxBehavior != nil {
 				return ledger.ErrRoutingRuleViolated.WithAttrs(models.Attributes{
-					"reason":       "tax_dimensions_must_be_complete_on_accrued_or_earnings",
+					"reason":       "tax_behavior_requires_tax_code_on_accrued_or_earnings",
 					"account_type": entry.AccountType(),
 				})
 			}

--- a/openmeter/ledger/routingrules/routingrules.go
+++ b/openmeter/ledger/routingrules/routingrules.go
@@ -177,6 +177,7 @@ type RouteField string
 const (
 	RouteFieldCurrency                       RouteField = "currency"
 	RouteFieldTaxCode                        RouteField = "tax_code"
+	RouteFieldTaxBehavior                    RouteField = "tax_behavior"
 	RouteFieldFeatures                       RouteField = "features"
 	RouteFieldCostBasis                      RouteField = "cost_basis"
 	RouteFieldCreditPriority                 RouteField = "credit_priority"
@@ -195,6 +196,21 @@ func (r RequireSameRouteRule) Validate(tx TxView) error {
 	}
 
 	return requireMatchingRouteFields(tx.EntriesOf(r.Left), tx.EntriesOf(r.Right), r.Left, r.Right, r.Fields)
+}
+
+type RequireTaxBehaviorScopeRule struct{}
+
+func (r RequireTaxBehaviorScopeRule) Validate(tx TxView) error {
+	for _, entry := range tx.entries {
+		if entry.AccountType() != ledger.AccountTypeCustomerFBO && entry.Route().TaxBehavior != nil {
+			return ledger.ErrRoutingRuleViolated.WithAttrs(models.Attributes{
+				"reason":       "tax_behavior_only_allowed_on_customer_fbo",
+				"account_type": entry.AccountType(),
+			})
+		}
+	}
+
+	return nil
 }
 
 type RequireAccountAuthorizationStatusRule struct {
@@ -217,6 +233,8 @@ func sameRouteField(left ledger.Route, right ledger.Route, field RouteField) (bo
 		return left.Currency == right.Currency, nil
 	case RouteFieldTaxCode:
 		return optionalStringEqual(left.TaxCode, right.TaxCode), nil
+	case RouteFieldTaxBehavior:
+		return optionalTaxBehaviorEqual(left.TaxBehavior, right.TaxBehavior), nil
 	case RouteFieldFeatures:
 		return stringSliceEqual(left.Features, right.Features), nil
 	case RouteFieldCostBasis:
@@ -339,6 +357,7 @@ func (r RequireFBOCostBasisTranslationRule) Validate(tx TxView) error {
 		[]RouteField{
 			RouteFieldCurrency,
 			RouteFieldTaxCode,
+			RouteFieldTaxBehavior,
 			RouteFieldFeatures,
 			RouteFieldCreditPriority,
 		},

--- a/openmeter/ledger/routingrules/routingrules.go
+++ b/openmeter/ledger/routingrules/routingrules.go
@@ -201,7 +201,7 @@ func (r RequireSameRouteRule) Validate(tx TxView) error {
 type RequireTaxBehaviorScopeRule struct{}
 
 func (r RequireTaxBehaviorScopeRule) Validate(tx TxView) error {
-	for _, entry := range tx.entries {
+	for _, entry := range tx.Entries() {
 		if entry.AccountType() != ledger.AccountTypeCustomerFBO && entry.Route().TaxBehavior != nil {
 			return ledger.ErrRoutingRuleViolated.WithAttrs(models.Attributes{
 				"reason":       "tax_behavior_only_allowed_on_customer_fbo",

--- a/openmeter/ledger/routingrules/routingrules_test.go
+++ b/openmeter/ledger/routingrules/routingrules_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/ledger"
@@ -422,11 +423,11 @@ func TestDefaultValidator_AllowsFBOToTaxedAccrued(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDefaultValidator_RejectsReceivableToAccruedTaxCodeMismatch(t *testing.T) {
+func TestDefaultValidator_RejectsTaxCodeOnReceivable(t *testing.T) {
 	validator := routingrules.DefaultValidator
 	openStatus := ledger.TransactionAuthorizationStatusOpen
 	taxA := "tax_A"
-	taxB := "tax_B"
+	taxBehavior := ledger.TaxBehaviorInclusive
 
 	err := validator.ValidateEntries([]ledger.EntryInput{
 		&transactionstestutils.AnyEntryInput{
@@ -438,9 +439,10 @@ func TestDefaultValidator_RejectsReceivableToAccruedTaxCodeMismatch(t *testing.T
 			AmountValue: alpacadecimal.NewFromInt(-50),
 		},
 		&transactionstestutils.AnyEntryInput{
-			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-taxB", ledger.Route{
-				Currency: currencyx.Code("USD"),
-				TaxCode:  &taxB,
+			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-taxA", ledger.Route{
+				Currency:    currencyx.Code("USD"),
+				TaxCode:     &taxA,
+				TaxBehavior: &taxBehavior,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(50),
 		},
@@ -454,19 +456,22 @@ func TestDefaultValidator_RejectsAccruedToEarningsTaxCodeMismatch(t *testing.T) 
 	validator := routingrules.DefaultValidator
 	taxA := "tax_A"
 	taxB := "tax_B"
+	taxBehavior := ledger.TaxBehaviorInclusive
 
 	err := validator.ValidateEntries([]ledger.EntryInput{
 		&transactionstestutils.AnyEntryInput{
 			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-taxA", ledger.Route{
-				Currency: currencyx.Code("USD"),
-				TaxCode:  &taxA,
+				Currency:    currencyx.Code("USD"),
+				TaxCode:     &taxA,
+				TaxBehavior: &taxBehavior,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(-50),
 		},
 		&transactionstestutils.AnyEntryInput{
 			Address: addressForRoute(t, ledger.AccountTypeEarnings, "sub-earn-taxB", ledger.Route{
-				Currency: currencyx.Code("USD"),
-				TaxCode:  &taxB,
+				Currency:    currencyx.Code("USD"),
+				TaxCode:     &taxB,
+				TaxBehavior: &taxBehavior,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(50),
 		},
@@ -485,6 +490,7 @@ func TestDefaultValidator_RejectsAccruedToEarningsTaxBehaviorMismatch(t *testing
 		&transactionstestutils.AnyEntryInput{
 			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-inclusive", ledger.Route{
 				Currency:    currencyx.Code("USD"),
+				TaxCode:     lo.ToPtr("tax_A"),
 				TaxBehavior: &inclusive,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(-50),
@@ -492,6 +498,7 @@ func TestDefaultValidator_RejectsAccruedToEarningsTaxBehaviorMismatch(t *testing
 		&transactionstestutils.AnyEntryInput{
 			Address: addressForRoute(t, ledger.AccountTypeEarnings, "sub-earn-exclusive", ledger.Route{
 				Currency:    currencyx.Code("USD"),
+				TaxCode:     lo.ToPtr("tax_A"),
 				TaxBehavior: &exclusive,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(50),
@@ -506,20 +513,21 @@ func TestDefaultValidator_AllowsReceivableToAccruedMatchingTaxCode(t *testing.T)
 	validator := routingrules.DefaultValidator
 	openStatus := ledger.TransactionAuthorizationStatusOpen
 	tax := "tax_A"
+	taxBehavior := ledger.TaxBehaviorInclusive
 
 	err := validator.ValidateEntries([]ledger.EntryInput{
 		&transactionstestutils.AnyEntryInput{
-			Address: addressForRoute(t, ledger.AccountTypeCustomerReceivable, "sub-rec-tax", ledger.Route{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerReceivable, "sub-rec", ledger.Route{
 				Currency:                       currencyx.Code("USD"),
-				TaxCode:                        &tax,
 				TransactionAuthorizationStatus: &openStatus,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(-50),
 		},
 		&transactionstestutils.AnyEntryInput{
 			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-tax", ledger.Route{
-				Currency: currencyx.Code("USD"),
-				TaxCode:  &tax,
+				Currency:    currencyx.Code("USD"),
+				TaxCode:     &tax,
+				TaxBehavior: &taxBehavior,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(50),
 		},
@@ -531,19 +539,22 @@ func TestDefaultValidator_AllowsReceivableToAccruedMatchingTaxCode(t *testing.T)
 func TestDefaultValidator_AllowsAccruedToEarningsMatchingTaxCode(t *testing.T) {
 	validator := routingrules.DefaultValidator
 	tax := "tax_A"
+	taxBehavior := ledger.TaxBehaviorInclusive
 
 	err := validator.ValidateEntries([]ledger.EntryInput{
 		&transactionstestutils.AnyEntryInput{
 			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-tax", ledger.Route{
-				Currency: currencyx.Code("USD"),
-				TaxCode:  &tax,
+				Currency:    currencyx.Code("USD"),
+				TaxCode:     &tax,
+				TaxBehavior: &taxBehavior,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(-50),
 		},
 		&transactionstestutils.AnyEntryInput{
 			Address: addressForRoute(t, ledger.AccountTypeEarnings, "sub-earn-tax", ledger.Route{
-				Currency: currencyx.Code("USD"),
-				TaxCode:  &tax,
+				Currency:    currencyx.Code("USD"),
+				TaxCode:     &tax,
+				TaxBehavior: &taxBehavior,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(50),
 		},

--- a/openmeter/ledger/routingrules/routingrules_test.go
+++ b/openmeter/ledger/routingrules/routingrules_test.go
@@ -160,15 +160,33 @@ func TestDefaultValidator_AllowsDuplicateSubAccountEntriesWithUniqueIdentities(t
 	require.NoError(t, err)
 }
 
-func TestDefaultValidator_RejectsTaxBehaviorOutsideFBO(t *testing.T) {
+func TestDefaultValidator_RejectsTaxBehaviorOutsideAccruedOrEarnings(t *testing.T) {
 	validator := routingrules.DefaultValidator
 	taxBehavior := ledger.TaxBehaviorExclusive
 
 	err := validator.ValidateEntries([]ledger.EntryInput{
 		&transactionstestutils.AnyEntryInput{
-			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-tax-behavior", ledger.Route{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerFBO, "sub-fbo-tax-behavior", ledger.Route{
 				Currency:    currencyx.Code("USD"),
 				TaxBehavior: &taxBehavior,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(50),
+		},
+	})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ledger routing rule violated")
+}
+
+func TestDefaultValidator_RejectsTaxCodeOnFBO(t *testing.T) {
+	validator := routingrules.DefaultValidator
+	taxCode := "tax_A"
+
+	err := validator.ValidateEntries([]ledger.EntryInput{
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerFBO, "sub-fbo-tax-code", ledger.Route{
+				Currency: currencyx.Code("USD"),
+				TaxCode:  &taxCode,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(50),
 		},
@@ -379,30 +397,29 @@ func TestDefaultValidator_AllowsWashToAuthorizedReceivable(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDefaultValidator_RejectsFBOToAccruedTaxCodeMismatch(t *testing.T) {
+func TestDefaultValidator_AllowsFBOToTaxedAccrued(t *testing.T) {
 	validator := routingrules.DefaultValidator
-	taxA := "tax_A"
-	taxB := "tax_B"
+	tax := "tax_A"
+	taxBehavior := ledger.TaxBehaviorInclusive
 
 	err := validator.ValidateEntries([]ledger.EntryInput{
 		&transactionstestutils.AnyEntryInput{
-			Address: addressForRoute(t, ledger.AccountTypeCustomerFBO, "sub-fbo-taxA", ledger.Route{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerFBO, "sub-fbo", ledger.Route{
 				Currency: currencyx.Code("USD"),
-				TaxCode:  &taxA,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(-50),
 		},
 		&transactionstestutils.AnyEntryInput{
-			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-taxB", ledger.Route{
-				Currency: currencyx.Code("USD"),
-				TaxCode:  &taxB,
+			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-tax", ledger.Route{
+				Currency:    currencyx.Code("USD"),
+				TaxCode:     &tax,
+				TaxBehavior: &taxBehavior,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(50),
 		},
 	})
 
-	require.Error(t, err)
-	require.ErrorContains(t, err, "ledger routing rule violated")
+	require.NoError(t, err)
 }
 
 func TestDefaultValidator_RejectsReceivableToAccruedTaxCodeMismatch(t *testing.T) {
@@ -459,28 +476,30 @@ func TestDefaultValidator_RejectsAccruedToEarningsTaxCodeMismatch(t *testing.T) 
 	require.ErrorContains(t, err, "ledger routing rule violated")
 }
 
-func TestDefaultValidator_AllowsFBOToAccruedMatchingTaxCode(t *testing.T) {
+func TestDefaultValidator_RejectsAccruedToEarningsTaxBehaviorMismatch(t *testing.T) {
 	validator := routingrules.DefaultValidator
-	tax := "tax_A"
+	inclusive := ledger.TaxBehaviorInclusive
+	exclusive := ledger.TaxBehaviorExclusive
 
 	err := validator.ValidateEntries([]ledger.EntryInput{
 		&transactionstestutils.AnyEntryInput{
-			Address: addressForRoute(t, ledger.AccountTypeCustomerFBO, "sub-fbo-tax", ledger.Route{
-				Currency: currencyx.Code("USD"),
-				TaxCode:  &tax,
+			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-inclusive", ledger.Route{
+				Currency:    currencyx.Code("USD"),
+				TaxBehavior: &inclusive,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(-50),
 		},
 		&transactionstestutils.AnyEntryInput{
-			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-tax", ledger.Route{
-				Currency: currencyx.Code("USD"),
-				TaxCode:  &tax,
+			Address: addressForRoute(t, ledger.AccountTypeEarnings, "sub-earn-exclusive", ledger.Route{
+				Currency:    currencyx.Code("USD"),
+				TaxBehavior: &exclusive,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(50),
 		},
 	})
 
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ledger routing rule violated")
 }
 
 func TestDefaultValidator_AllowsReceivableToAccruedMatchingTaxCode(t *testing.T) {

--- a/openmeter/ledger/routingrules/routingrules_test.go
+++ b/openmeter/ledger/routingrules/routingrules_test.go
@@ -434,6 +434,32 @@ func TestDefaultValidator_AllowsFBOToAccruedMatchingTaxCode(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDefaultValidator_AllowsReceivableToAccruedMatchingTaxCode(t *testing.T) {
+	validator := routingrules.DefaultValidator
+	openStatus := ledger.TransactionAuthorizationStatusOpen
+	tax := "tax_A"
+
+	err := validator.ValidateEntries([]ledger.EntryInput{
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerReceivable, "sub-rec-tax", ledger.Route{
+				Currency:                       currencyx.Code("USD"),
+				TaxCode:                        &tax,
+				TransactionAuthorizationStatus: &openStatus,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(-50),
+		},
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-tax", ledger.Route{
+				Currency: currencyx.Code("USD"),
+				TaxCode:  &tax,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(50),
+		},
+	})
+
+	require.NoError(t, err)
+}
+
 func TestDefaultValidator_AllowsAccruedToEarningsMatchingTaxCode(t *testing.T) {
 	validator := routingrules.DefaultValidator
 	tax := "tax_A"

--- a/openmeter/ledger/routingrules/routingrules_test.go
+++ b/openmeter/ledger/routingrules/routingrules_test.go
@@ -160,6 +160,24 @@ func TestDefaultValidator_AllowsDuplicateSubAccountEntriesWithUniqueIdentities(t
 	require.NoError(t, err)
 }
 
+func TestDefaultValidator_RejectsTaxBehaviorOutsideFBO(t *testing.T) {
+	validator := routingrules.DefaultValidator
+	taxBehavior := ledger.TaxBehaviorExclusive
+
+	err := validator.ValidateEntries([]ledger.EntryInput{
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-tax-behavior", ledger.Route{
+				Currency:    currencyx.Code("USD"),
+				TaxBehavior: &taxBehavior,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(50),
+		},
+	})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ledger routing rule violated")
+}
+
 func TestDefaultValidator_RejectsMismatchedReceivableAndFBORoute(t *testing.T) {
 	validator := routingrules.DefaultValidator
 
@@ -247,6 +265,37 @@ func TestDefaultValidator_RejectsFBOCostBasisTranslationWithMismatchedPriority(t
 				Currency:       currencyx.Code("USD"),
 				CostBasis:      &costBasis,
 				CreditPriority: &knownPriority,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(50),
+		},
+	})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ledger routing rule violated")
+}
+
+func TestDefaultValidator_RejectsFBOCostBasisTranslationWithMismatchedTaxBehavior(t *testing.T) {
+	validator := routingrules.DefaultValidator
+	priority := ledger.DefaultCustomerFBOPriority
+	costBasis := alpacadecimal.NewFromInt(1)
+	inclusive := ledger.TaxBehaviorInclusive
+	exclusive := ledger.TaxBehaviorExclusive
+
+	err := validator.ValidateEntries([]ledger.EntryInput{
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerFBO, "sub-fbo-unknown", ledger.Route{
+				Currency:       currencyx.Code("USD"),
+				CreditPriority: &priority,
+				TaxBehavior:    &inclusive,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(-50),
+		},
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerFBO, "sub-fbo-known", ledger.Route{
+				Currency:       currencyx.Code("USD"),
+				CostBasis:      &costBasis,
+				CreditPriority: &priority,
+				TaxBehavior:    &exclusive,
 			}),
 			AmountValue: alpacadecimal.NewFromInt(50),
 		},

--- a/openmeter/ledger/routingrules/routingrules_test.go
+++ b/openmeter/ledger/routingrules/routingrules_test.go
@@ -330,6 +330,155 @@ func TestDefaultValidator_AllowsWashToAuthorizedReceivable(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDefaultValidator_RejectsFBOToAccruedTaxCodeMismatch(t *testing.T) {
+	validator := routingrules.DefaultValidator
+	taxA := "tax_A"
+	taxB := "tax_B"
+
+	err := validator.ValidateEntries([]ledger.EntryInput{
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerFBO, "sub-fbo-taxA", ledger.Route{
+				Currency: currencyx.Code("USD"),
+				TaxCode:  &taxA,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(-50),
+		},
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-taxB", ledger.Route{
+				Currency: currencyx.Code("USD"),
+				TaxCode:  &taxB,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(50),
+		},
+	})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ledger routing rule violated")
+}
+
+func TestDefaultValidator_RejectsReceivableToAccruedTaxCodeMismatch(t *testing.T) {
+	validator := routingrules.DefaultValidator
+	openStatus := ledger.TransactionAuthorizationStatusOpen
+	taxA := "tax_A"
+	taxB := "tax_B"
+
+	err := validator.ValidateEntries([]ledger.EntryInput{
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerReceivable, "sub-rec-taxA", ledger.Route{
+				Currency:                       currencyx.Code("USD"),
+				TaxCode:                        &taxA,
+				TransactionAuthorizationStatus: &openStatus,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(-50),
+		},
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-taxB", ledger.Route{
+				Currency: currencyx.Code("USD"),
+				TaxCode:  &taxB,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(50),
+		},
+	})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ledger routing rule violated")
+}
+
+func TestDefaultValidator_RejectsAccruedToEarningsTaxCodeMismatch(t *testing.T) {
+	validator := routingrules.DefaultValidator
+	taxA := "tax_A"
+	taxB := "tax_B"
+
+	err := validator.ValidateEntries([]ledger.EntryInput{
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-taxA", ledger.Route{
+				Currency: currencyx.Code("USD"),
+				TaxCode:  &taxA,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(-50),
+		},
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeEarnings, "sub-earn-taxB", ledger.Route{
+				Currency: currencyx.Code("USD"),
+				TaxCode:  &taxB,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(50),
+		},
+	})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ledger routing rule violated")
+}
+
+func TestDefaultValidator_AllowsFBOToAccruedMatchingTaxCode(t *testing.T) {
+	validator := routingrules.DefaultValidator
+	tax := "tax_A"
+
+	err := validator.ValidateEntries([]ledger.EntryInput{
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerFBO, "sub-fbo-tax", ledger.Route{
+				Currency: currencyx.Code("USD"),
+				TaxCode:  &tax,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(-50),
+		},
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-tax", ledger.Route{
+				Currency: currencyx.Code("USD"),
+				TaxCode:  &tax,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(50),
+		},
+	})
+
+	require.NoError(t, err)
+}
+
+func TestDefaultValidator_AllowsAccruedToEarningsMatchingTaxCode(t *testing.T) {
+	validator := routingrules.DefaultValidator
+	tax := "tax_A"
+
+	err := validator.ValidateEntries([]ledger.EntryInput{
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-tax", ledger.Route{
+				Currency: currencyx.Code("USD"),
+				TaxCode:  &tax,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(-50),
+		},
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeEarnings, "sub-earn-tax", ledger.Route{
+				Currency: currencyx.Code("USD"),
+				TaxCode:  &tax,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(50),
+		},
+	})
+
+	require.NoError(t, err)
+}
+
+func TestDefaultValidator_AllowsAccruedToEarningsNilTaxCodeBothSides(t *testing.T) {
+	validator := routingrules.DefaultValidator
+
+	err := validator.ValidateEntries([]ledger.EntryInput{
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-nil", ledger.Route{
+				Currency: currencyx.Code("USD"),
+			}),
+			AmountValue: alpacadecimal.NewFromInt(-50),
+		},
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeEarnings, "sub-earn-nil", ledger.Route{
+				Currency: currencyx.Code("USD"),
+			}),
+			AmountValue: alpacadecimal.NewFromInt(50),
+		},
+	})
+
+	require.NoError(t, err)
+}
+
 func TestDefaultValidator_RejectsWashToOpenReceivable(t *testing.T) {
 	validator := routingrules.DefaultValidator
 	status := ledger.TransactionAuthorizationStatusOpen
@@ -357,7 +506,7 @@ func TestDefaultValidator_RejectsWashToOpenReceivable(t *testing.T) {
 func addressForRoute(t *testing.T, accountType ledger.AccountType, subAccountID string, route ledger.Route) ledger.PostingAddress {
 	t.Helper()
 
-	key, err := ledger.BuildRoutingKey(ledger.RoutingKeyVersionV1, route)
+	key, err := ledger.BuildRoutingKey(route)
 	require.NoError(t, err)
 
 	addr, err := ledgeraccount.NewAddressFromData(ledgeraccount.AddressData{

--- a/openmeter/ledger/routingrules/routingrules_test.go
+++ b/openmeter/ledger/routingrules/routingrules_test.go
@@ -563,6 +563,55 @@ func TestDefaultValidator_AllowsAccruedToEarningsMatchingTaxCode(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDefaultValidator_AllowsAccruedToEarningsTaxCodeWithoutTaxBehavior(t *testing.T) {
+	validator := routingrules.DefaultValidator
+	tax := "tax_A"
+
+	err := validator.ValidateEntries([]ledger.EntryInput{
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-tax-only", ledger.Route{
+				Currency: currencyx.Code("USD"),
+				TaxCode:  &tax,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(-50),
+		},
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeEarnings, "sub-earn-tax-only", ledger.Route{
+				Currency: currencyx.Code("USD"),
+				TaxCode:  &tax,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(50),
+		},
+	})
+
+	require.NoError(t, err)
+}
+
+func TestDefaultValidator_RejectsTaxBehaviorWithoutTaxCode(t *testing.T) {
+	validator := routingrules.DefaultValidator
+	taxBehavior := ledger.TaxBehaviorInclusive
+
+	err := validator.ValidateEntries([]ledger.EntryInput{
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeCustomerAccrued, "sub-accrued-behavior-only", ledger.Route{
+				Currency:    currencyx.Code("USD"),
+				TaxBehavior: &taxBehavior,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(-50),
+		},
+		&transactionstestutils.AnyEntryInput{
+			Address: addressForRoute(t, ledger.AccountTypeEarnings, "sub-earn-behavior-only", ledger.Route{
+				Currency:    currencyx.Code("USD"),
+				TaxBehavior: &taxBehavior,
+			}),
+			AmountValue: alpacadecimal.NewFromInt(50),
+		},
+	})
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "ledger routing rule violated")
+}
+
 func TestDefaultValidator_AllowsAccruedToEarningsNilTaxCodeBothSides(t *testing.T) {
 	validator := routingrules.DefaultValidator
 

--- a/openmeter/ledger/routingrules/view.go
+++ b/openmeter/ledger/routingrules/view.go
@@ -136,6 +136,14 @@ func optionalTransactionAuthorizationStatusEqual(left *ledger.TransactionAuthori
 	return *left == *right
 }
 
+func optionalTaxBehaviorEqual(left *ledger.TaxBehavior, right *ledger.TaxBehavior) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+
+	return *left == *right
+}
+
 func optionalDecimalEqual(left *alpacadecimal.Decimal, right *alpacadecimal.Decimal) bool {
 	if left == nil || right == nil {
 		return left == nil && right == nil

--- a/openmeter/ledger/testutils/integration.go
+++ b/openmeter/ledger/testutils/integration.go
@@ -145,8 +145,15 @@ func (e *IntegrationEnv) AccruedSubAccount(t *testing.T) ledger.SubAccount {
 func (e *IntegrationEnv) AccruedSubAccountWithCostBasis(t *testing.T, costBasis *alpacadecimal.Decimal) ledger.SubAccount {
 	t.Helper()
 
+	return e.AccruedSubAccountWithCostBasisAndTaxCode(t, costBasis, nil)
+}
+
+func (e *IntegrationEnv) AccruedSubAccountWithCostBasisAndTaxCode(t *testing.T, costBasis *alpacadecimal.Decimal, taxCode *string) ledger.SubAccount {
+	t.Helper()
+
 	subAccount, err := e.CustomerAccounts.AccruedAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerAccruedRouteParams{
 		Currency:  e.Currency,
+		TaxCode:   taxCode,
 		CostBasis: costBasis,
 	})
 	require.NoError(t, err)

--- a/openmeter/ledger/transactions/accrual.go
+++ b/openmeter/ledger/transactions/accrual.go
@@ -441,7 +441,6 @@ func (t TransferCustomerReceivableToAccruedTemplate) resolve(ctx context.Context
 
 	receivable, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
-		TaxCode:                        t.TaxCode,
 		CostBasis:                      t.CostBasis,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
 	})

--- a/openmeter/ledger/transactions/accrual.go
+++ b/openmeter/ledger/transactions/accrual.go
@@ -157,6 +157,21 @@ func (t TransferCustomerFBOToAccruedTemplate) resolve(ctx context.Context, custo
 	}, nil
 }
 
+// resolveAccruedSubAccByRoutePairingKey routes each FBO source to its
+// matching accrued sub-account using the SOURCE route's TaxCode and
+// CostBasis. Charge intent TaxConfig does NOT override the destination
+// bucket on this path: accrual preserves funding-source attribution by
+// design (credit-only flows do not translate TaxCode at consumption).
+//
+// If charge.Intent.TaxConfig diverges from FBO source TaxCode, the
+// resulting accrued posting lands in the FUNDING source bucket. The
+// FBO-to-Accrued routing rule (defaults.go) enforces TaxCode match between
+// source and destination entries within a single transaction.
+//
+// To override accrued TaxCode based on charge intent, a separate Accrued-to-
+// Accrued translation template (modeled after
+// TranslateCustomerAccruedCostBasisTemplate) plus a matching routing rule
+// (modeled after RequireAccruedCostBasisTranslationRule) would be required.
 func (t TransferCustomerFBOToAccruedTemplate) resolveAccruedSubAccByRoutePairingKey(
 	ctx context.Context,
 	accruedAccount ledger.CustomerAccruedAccount,

--- a/openmeter/ledger/transactions/accrual.go
+++ b/openmeter/ledger/transactions/accrual.go
@@ -102,6 +102,7 @@ func (t TransferCustomerFBOToAccruedTemplate) routePairingKey(address ledger.Pos
 
 	return routePairingKey{
 		currency:  route.Currency,
+		taxCode:   taxCodeKey(route.TaxCode),
 		costBasis: costBasisKey(route.CostBasis),
 	}
 }
@@ -169,6 +170,7 @@ func (t TransferCustomerFBOToAccruedTemplate) resolveAccruedSubAccByRoutePairing
 		if current.Address == nil {
 			accruedSubAccount, err := accruedAccount.GetSubAccountForRoute(ctx, ledger.CustomerAccruedRouteParams{
 				Currency:  t.Currency,
+				TaxCode:   source.Address.Route().Route().TaxCode,
 				CostBasis: source.Address.Route().Route().CostBasis,
 			})
 			if err != nil {
@@ -225,12 +227,20 @@ func costBasisKey(costBasis *alpacadecimal.Decimal) string {
 	return costBasis.String()
 }
 
+func taxCodeKey(taxCode *string) string {
+	if taxCode == nil {
+		return "null"
+	}
+	return *taxCode
+}
+
 // TransferCustomerFBOAdvanceToAccruedTemplate moves value from the synthetic advance-backed
 // customer FBO route into the matching accrued route.
 type TransferCustomerFBOAdvanceToAccruedTemplate struct {
 	At             time.Time
 	Amount         alpacadecimal.Decimal
 	Currency       currencyx.Code
+	TaxCode        *string
 	CostBasis      *alpacadecimal.Decimal
 	CreditPriority *int
 }
@@ -325,6 +335,7 @@ func (t TransferCustomerFBOAdvanceToAccruedTemplate) resolve(ctx context.Context
 
 	fbo, err := customerAccounts.FBOAccount.GetSubAccountForRoute(ctx, ledger.CustomerFBORouteParams{
 		Currency:       t.Currency,
+		TaxCode:        t.TaxCode,
 		CostBasis:      t.CostBasis,
 		CreditPriority: priority,
 	})
@@ -334,6 +345,7 @@ func (t TransferCustomerFBOAdvanceToAccruedTemplate) resolve(ctx context.Context
 
 	accrued, err := customerAccounts.AccruedAccount.GetSubAccountForRoute(ctx, ledger.CustomerAccruedRouteParams{
 		Currency:  t.Currency,
+		TaxCode:   t.TaxCode,
 		CostBasis: t.CostBasis,
 	})
 	if err != nil {
@@ -361,6 +373,7 @@ type TransferCustomerReceivableToAccruedTemplate struct {
 	At        time.Time
 	Amount    alpacadecimal.Decimal
 	Currency  currencyx.Code
+	TaxCode   *string
 	CostBasis *alpacadecimal.Decimal
 }
 
@@ -410,6 +423,7 @@ func (t TransferCustomerReceivableToAccruedTemplate) resolve(ctx context.Context
 
 	receivable, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
+		TaxCode:                        t.TaxCode,
 		CostBasis:                      t.CostBasis,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
 	})
@@ -419,6 +433,7 @@ func (t TransferCustomerReceivableToAccruedTemplate) resolve(ctx context.Context
 
 	accrued, err := customerAccounts.AccruedAccount.GetSubAccountForRoute(ctx, ledger.CustomerAccruedRouteParams{
 		Currency:  t.Currency,
+		TaxCode:   t.TaxCode,
 		CostBasis: t.CostBasis,
 	})
 	if err != nil {
@@ -446,6 +461,7 @@ type TranslateCustomerAccruedCostBasisTemplate struct {
 	At            time.Time
 	Amount        alpacadecimal.Decimal
 	Currency      currencyx.Code
+	TaxCode       *string
 	FromCostBasis *alpacadecimal.Decimal
 	ToCostBasis   *alpacadecimal.Decimal
 }
@@ -546,6 +562,7 @@ func (t TranslateCustomerAccruedCostBasisTemplate) resolve(ctx context.Context, 
 
 	fromAccrued, err := customerAccounts.AccruedAccount.GetSubAccountForRoute(ctx, ledger.CustomerAccruedRouteParams{
 		Currency:  t.Currency,
+		TaxCode:   t.TaxCode,
 		CostBasis: t.FromCostBasis,
 	})
 	if err != nil {
@@ -554,6 +571,7 @@ func (t TranslateCustomerAccruedCostBasisTemplate) resolve(ctx context.Context, 
 
 	toAccrued, err := customerAccounts.AccruedAccount.GetSubAccountForRoute(ctx, ledger.CustomerAccruedRouteParams{
 		Currency:  t.Currency,
+		TaxCode:   t.TaxCode,
 		CostBasis: t.ToCostBasis,
 	})
 	if err != nil {

--- a/openmeter/ledger/transactions/accrual.go
+++ b/openmeter/ledger/transactions/accrual.go
@@ -17,9 +17,11 @@ import (
 // TransferCustomerFBOToAccruedTemplate moves preselected customer FBO value
 // into the customer's accrued account.
 type TransferCustomerFBOToAccruedTemplate struct {
-	At       time.Time
-	Currency currencyx.Code
-	Sources  []PostingAmount
+	At          time.Time
+	Currency    currencyx.Code
+	TaxCode     *string
+	TaxBehavior *ledger.TaxBehavior
+	Sources     []PostingAmount
 }
 
 func (t TransferCustomerFBOToAccruedTemplate) Validate() error {
@@ -29,6 +31,12 @@ func (t TransferCustomerFBOToAccruedTemplate) Validate() error {
 
 	if err := ledger.ValidateCurrency(t.Currency); err != nil {
 		return fmt.Errorf("currency: %w", err)
+	}
+
+	if t.TaxBehavior != nil {
+		if err := t.TaxBehavior.Validate(); err != nil {
+			return fmt.Errorf("tax behavior: %w", err)
+		}
 	}
 
 	for i, source := range t.Sources {
@@ -102,7 +110,6 @@ func (t TransferCustomerFBOToAccruedTemplate) routePairingKey(address ledger.Pos
 
 	return routePairingKey{
 		currency:  route.Currency,
-		taxCode:   taxCodeKey(route.TaxCode),
 		costBasis: costBasisKey(route.CostBasis),
 	}
 }
@@ -157,8 +164,9 @@ func (t TransferCustomerFBOToAccruedTemplate) resolve(ctx context.Context, custo
 	}, nil
 }
 
-// resolveAccruedSubAccByRoutePairingKey preserves source attribution: each FBO
-// source routes to the accrued bucket with the same TaxCode and CostBasis.
+// resolveAccruedSubAccByRoutePairingKey preserves source cost attribution while
+// applying the charge tax dimensions to accrued. Customer FBO sources do not
+// carry tax dimensions.
 func (t TransferCustomerFBOToAccruedTemplate) resolveAccruedSubAccByRoutePairingKey(
 	ctx context.Context,
 	accruedAccount ledger.CustomerAccruedAccount,
@@ -171,9 +179,10 @@ func (t TransferCustomerFBOToAccruedTemplate) resolveAccruedSubAccByRoutePairing
 		current := accruedSubAccByKey[key]
 		if current.Address == nil {
 			accruedSubAccount, err := accruedAccount.GetSubAccountForRoute(ctx, ledger.CustomerAccruedRouteParams{
-				Currency:  t.Currency,
-				TaxCode:   source.Address.Route().Route().TaxCode,
-				CostBasis: source.Address.Route().Route().CostBasis,
+				Currency:    t.Currency,
+				TaxCode:     t.TaxCode,
+				TaxBehavior: t.TaxBehavior,
+				CostBasis:   source.Address.Route().Route().CostBasis,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("failed to get accrued sub-account: %w", err)
@@ -227,13 +236,6 @@ func costBasisKey(costBasis *alpacadecimal.Decimal) string {
 	}
 
 	return costBasis.String()
-}
-
-func taxCodeKey(taxCode *string) string {
-	if taxCode == nil {
-		return "null"
-	}
-	return *taxCode
 }
 
 // TransferCustomerFBOAdvanceToAccruedTemplate moves value from the synthetic advance-backed
@@ -344,8 +346,6 @@ func (t TransferCustomerFBOAdvanceToAccruedTemplate) resolve(ctx context.Context
 
 	fbo, err := customerAccounts.FBOAccount.GetSubAccountForRoute(ctx, ledger.CustomerFBORouteParams{
 		Currency:       t.Currency,
-		TaxCode:        t.TaxCode,
-		TaxBehavior:    t.TaxBehavior,
 		CostBasis:      t.CostBasis,
 		CreditPriority: priority,
 	})
@@ -354,9 +354,10 @@ func (t TransferCustomerFBOAdvanceToAccruedTemplate) resolve(ctx context.Context
 	}
 
 	accrued, err := customerAccounts.AccruedAccount.GetSubAccountForRoute(ctx, ledger.CustomerAccruedRouteParams{
-		Currency:  t.Currency,
-		TaxCode:   t.TaxCode,
-		CostBasis: t.CostBasis,
+		Currency:    t.Currency,
+		TaxCode:     t.TaxCode,
+		TaxBehavior: t.TaxBehavior,
+		CostBasis:   t.CostBasis,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get accrued sub-account: %w", err)
@@ -380,11 +381,12 @@ func (t TransferCustomerFBOAdvanceToAccruedTemplate) resolve(ctx context.Context
 // TransferCustomerReceivableToAccruedTemplate acknowledges usage by moving it
 // from receivable into the customer's accrued account.
 type TransferCustomerReceivableToAccruedTemplate struct {
-	At        time.Time
-	Amount    alpacadecimal.Decimal
-	Currency  currencyx.Code
-	TaxCode   *string
-	CostBasis *alpacadecimal.Decimal
+	At          time.Time
+	Amount      alpacadecimal.Decimal
+	Currency    currencyx.Code
+	TaxCode     *string
+	TaxBehavior *ledger.TaxBehavior
+	CostBasis   *alpacadecimal.Decimal
 }
 
 func (t TransferCustomerReceivableToAccruedTemplate) Validate() error {
@@ -406,6 +408,12 @@ func (t TransferCustomerReceivableToAccruedTemplate) Validate() error {
 
 	if err := ledger.ValidateCostBasis(*t.CostBasis); err != nil {
 		return fmt.Errorf("cost basis: %w", err)
+	}
+
+	if t.TaxBehavior != nil {
+		if err := t.TaxBehavior.Validate(); err != nil {
+			return fmt.Errorf("tax behavior: %w", err)
+		}
 	}
 
 	return nil
@@ -442,9 +450,10 @@ func (t TransferCustomerReceivableToAccruedTemplate) resolve(ctx context.Context
 	}
 
 	accrued, err := customerAccounts.AccruedAccount.GetSubAccountForRoute(ctx, ledger.CustomerAccruedRouteParams{
-		Currency:  t.Currency,
-		TaxCode:   t.TaxCode,
-		CostBasis: t.CostBasis,
+		Currency:    t.Currency,
+		TaxCode:     t.TaxCode,
+		TaxBehavior: t.TaxBehavior,
+		CostBasis:   t.CostBasis,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get accrued sub-account: %w", err)
@@ -472,6 +481,7 @@ type TranslateCustomerAccruedCostBasisTemplate struct {
 	Amount        alpacadecimal.Decimal
 	Currency      currencyx.Code
 	TaxCode       *string
+	TaxBehavior   *ledger.TaxBehavior
 	FromCostBasis *alpacadecimal.Decimal
 	ToCostBasis   *alpacadecimal.Decimal
 }
@@ -501,6 +511,12 @@ func (t TranslateCustomerAccruedCostBasisTemplate) Validate() error {
 
 	if err := ledger.ValidateCostBasis(*t.ToCostBasis); err != nil {
 		return fmt.Errorf("to cost basis: %w", err)
+	}
+
+	if t.TaxBehavior != nil {
+		if err := t.TaxBehavior.Validate(); err != nil {
+			return fmt.Errorf("tax behavior: %w", err)
+		}
 	}
 
 	if decimalPointersEqual(t.FromCostBasis, t.ToCostBasis) {
@@ -571,18 +587,20 @@ func (t TranslateCustomerAccruedCostBasisTemplate) resolve(ctx context.Context, 
 	}
 
 	fromAccrued, err := customerAccounts.AccruedAccount.GetSubAccountForRoute(ctx, ledger.CustomerAccruedRouteParams{
-		Currency:  t.Currency,
-		TaxCode:   t.TaxCode,
-		CostBasis: t.FromCostBasis,
+		Currency:    t.Currency,
+		TaxCode:     t.TaxCode,
+		TaxBehavior: t.TaxBehavior,
+		CostBasis:   t.FromCostBasis,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get source accrued sub-account: %w", err)
 	}
 
 	toAccrued, err := customerAccounts.AccruedAccount.GetSubAccountForRoute(ctx, ledger.CustomerAccruedRouteParams{
-		Currency:  t.Currency,
-		TaxCode:   t.TaxCode,
-		CostBasis: t.ToCostBasis,
+		Currency:    t.Currency,
+		TaxCode:     t.TaxCode,
+		TaxBehavior: t.TaxBehavior,
+		CostBasis:   t.ToCostBasis,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get target accrued sub-account: %w", err)

--- a/openmeter/ledger/transactions/accrual.go
+++ b/openmeter/ledger/transactions/accrual.go
@@ -157,21 +157,8 @@ func (t TransferCustomerFBOToAccruedTemplate) resolve(ctx context.Context, custo
 	}, nil
 }
 
-// resolveAccruedSubAccByRoutePairingKey routes each FBO source to its
-// matching accrued sub-account using the SOURCE route's TaxCode and
-// CostBasis. Charge intent TaxConfig does NOT override the destination
-// bucket on this path: accrual preserves funding-source attribution by
-// design (credit-only flows do not translate TaxCode at consumption).
-//
-// If charge.Intent.TaxConfig diverges from FBO source TaxCode, the
-// resulting accrued posting lands in the FUNDING source bucket. The
-// FBO-to-Accrued routing rule (defaults.go) enforces TaxCode match between
-// source and destination entries within a single transaction.
-//
-// To override accrued TaxCode based on charge intent, a separate Accrued-to-
-// Accrued translation template (modeled after
-// TranslateCustomerAccruedCostBasisTemplate) plus a matching routing rule
-// (modeled after RequireAccruedCostBasisTranslationRule) would be required.
+// resolveAccruedSubAccByRoutePairingKey preserves source attribution: each FBO
+// source routes to the accrued bucket with the same TaxCode and CostBasis.
 func (t TransferCustomerFBOToAccruedTemplate) resolveAccruedSubAccByRoutePairingKey(
 	ctx context.Context,
 	accruedAccount ledger.CustomerAccruedAccount,
@@ -256,6 +243,7 @@ type TransferCustomerFBOAdvanceToAccruedTemplate struct {
 	Amount         alpacadecimal.Decimal
 	Currency       currencyx.Code
 	TaxCode        *string
+	TaxBehavior    *ledger.TaxBehavior
 	CostBasis      *alpacadecimal.Decimal
 	CreditPriority *int
 }
@@ -282,6 +270,12 @@ func (t TransferCustomerFBOAdvanceToAccruedTemplate) Validate() error {
 	if t.CreditPriority != nil {
 		if err := ledger.ValidateCreditPriority(*t.CreditPriority); err != nil {
 			return fmt.Errorf("credit priority: %w", err)
+		}
+	}
+
+	if t.TaxBehavior != nil {
+		if err := t.TaxBehavior.Validate(); err != nil {
+			return fmt.Errorf("tax behavior: %w", err)
 		}
 	}
 
@@ -351,6 +345,7 @@ func (t TransferCustomerFBOAdvanceToAccruedTemplate) resolve(ctx context.Context
 	fbo, err := customerAccounts.FBOAccount.GetSubAccountForRoute(ctx, ledger.CustomerFBORouteParams{
 		Currency:       t.Currency,
 		TaxCode:        t.TaxCode,
+		TaxBehavior:    t.TaxBehavior,
 		CostBasis:      t.CostBasis,
 		CreditPriority: priority,
 	})

--- a/openmeter/ledger/transactions/accrual_test.go
+++ b/openmeter/ledger/transactions/accrual_test.go
@@ -157,6 +157,70 @@ func TestTransferCustomerFBOAdvanceToAccruedTemplate_UnknownCostBasisAdvanceNetE
 	require.True(t, env.SumBalance(t, env.AccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(30)))
 }
 
+func TestTransferCustomerFBOToAccruedTemplate_SeparatesTaxCodeBuckets(t *testing.T) {
+	env := newTransactionsTestEnv(t)
+	costBasis := alpacadecimal.NewFromInt(1)
+
+	taxA := "tax_A"
+	taxB := "tax_B"
+
+	// Fund two FBO sub-accounts: same priority+costBasis but different TaxCodes.
+	fboTaxA := env.fundPriorityWithCostBasisAndTaxCode(t, 1, 30, &costBasis, &taxA)
+	fboTaxB := env.fundPriorityWithCostBasisAndTaxCode(t, 1, 50, &costBasis, &taxB)
+
+	inputs := env.resolveAndCommit(
+		t,
+		TransferCustomerFBOToAccruedTemplate{
+			At:       env.Now(),
+			Currency: env.Currency,
+			Sources: []PostingAmount{
+				{Address: fboTaxA.Address(), Amount: alpacadecimal.NewFromInt(30)},
+				{Address: fboTaxB.Address(), Amount: alpacadecimal.NewFromInt(50)},
+			},
+		},
+	)
+	require.Len(t, inputs, 1)
+
+	// Both FBO sources fully drained.
+	require.True(t, env.SumBalance(t, fboTaxA).Equal(alpacadecimal.Zero))
+	require.True(t, env.SumBalance(t, fboTaxB).Equal(alpacadecimal.Zero))
+
+	// Each TaxCode lands in its own accrued bucket.
+	require.True(t, env.AccruedSubAccountWithCostBasisAndTaxCode(t, &costBasis, &taxA) != env.AccruedSubAccountWithCostBasisAndTaxCode(t, &costBasis, &taxB))
+	require.True(t, env.SumBalance(t, env.AccruedSubAccountWithCostBasisAndTaxCode(t, &costBasis, &taxA)).Equal(alpacadecimal.NewFromInt(30)))
+	require.True(t, env.SumBalance(t, env.AccruedSubAccountWithCostBasisAndTaxCode(t, &costBasis, &taxB)).Equal(alpacadecimal.NewFromInt(50)))
+}
+
+func TestTransferCustomerFBOToAccruedTemplate_NilTaxCodeIsolatedFromNonNil(t *testing.T) {
+	env := newTransactionsTestEnv(t)
+
+	taxA := "tax_A"
+
+	// One FBO with nil TaxCode, one with non-nil TaxCode.
+	fboNilTax := env.fundPriorityWithCostBasisAndTaxCode(t, 1, 40, nil, nil)
+	fboTaxA := env.fundPriorityWithCostBasisAndTaxCode(t, 2, 20, nil, &taxA)
+
+	inputs := env.resolveAndCommit(
+		t,
+		TransferCustomerFBOToAccruedTemplate{
+			At:       env.Now(),
+			Currency: env.Currency,
+			Sources: []PostingAmount{
+				{Address: fboNilTax.Address(), Amount: alpacadecimal.NewFromInt(40)},
+				{Address: fboTaxA.Address(), Amount: alpacadecimal.NewFromInt(20)},
+			},
+		},
+	)
+	require.Len(t, inputs, 1)
+
+	require.True(t, env.SumBalance(t, fboNilTax).Equal(alpacadecimal.Zero))
+	require.True(t, env.SumBalance(t, fboTaxA).Equal(alpacadecimal.Zero))
+
+	// Nil TaxCode and non-nil TaxCode land in separate accrued buckets.
+	require.True(t, env.SumBalance(t, env.AccruedSubAccountWithCostBasisAndTaxCode(t, nil, nil)).Equal(alpacadecimal.NewFromInt(40)))
+	require.True(t, env.SumBalance(t, env.AccruedSubAccountWithCostBasisAndTaxCode(t, nil, &taxA)).Equal(alpacadecimal.NewFromInt(20)))
+}
+
 func TestTranslateCustomerAccruedCostBasisTemplate(t *testing.T) {
 	env := newTransactionsTestEnv(t)
 	purchasedCostBasis := alpacadecimal.NewFromInt(1)

--- a/openmeter/ledger/transactions/accrual_test.go
+++ b/openmeter/ledger/transactions/accrual_test.go
@@ -157,17 +157,16 @@ func TestTransferCustomerFBOAdvanceToAccruedTemplate_UnknownCostBasisAdvanceNetE
 	require.True(t, env.SumBalance(t, env.AccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(30)))
 }
 
-func TestTransferCustomerFBOAdvanceToAccruedTemplate_PreservesFBOTaxBehavior(t *testing.T) {
+func TestTransferCustomerFBOAdvanceToAccruedTemplate_AppliesTaxBehaviorToAccrued(t *testing.T) {
 	env := newTransactionsTestEnv(t)
 	taxBehavior := ledger.TaxBehaviorExclusive
 
 	inputs := env.resolveAndCommit(
 		t,
 		IssueCustomerReceivableTemplate{
-			At:          env.Now(),
-			Amount:      alpacadecimal.NewFromInt(30),
-			Currency:    env.Currency,
-			TaxBehavior: &taxBehavior,
+			At:       env.Now(),
+			Amount:   alpacadecimal.NewFromInt(30),
+			Currency: env.Currency,
 		},
 		TransferCustomerFBOAdvanceToAccruedTemplate{
 			At:          env.Now(),
@@ -178,60 +177,62 @@ func TestTransferCustomerFBOAdvanceToAccruedTemplate_PreservesFBOTaxBehavior(t *
 	)
 	require.Len(t, inputs, 2)
 
-	fboWithTaxBehavior, err := env.CustomerAccounts.FBOAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerFBORouteParams{
-		Currency:       env.Currency,
-		CreditPriority: ledger.DefaultCustomerFBOPriority,
-		TaxBehavior:    &taxBehavior,
+	accruedWithTaxBehavior, err := env.CustomerAccounts.AccruedAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerAccruedRouteParams{
+		Currency:    env.Currency,
+		TaxBehavior: &taxBehavior,
 	})
 	require.NoError(t, err)
 
-	require.True(t, env.SumBalance(t, fboWithTaxBehavior).Equal(alpacadecimal.Zero))
 	require.True(t, env.SumBalance(t, env.FBOSubAccount(t, ledger.DefaultCustomerFBOPriority)).Equal(alpacadecimal.Zero))
-	require.True(t, env.SumBalance(t, env.AccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(30)))
+	require.True(t, env.SumBalance(t, accruedWithTaxBehavior).Equal(alpacadecimal.NewFromInt(30)))
+	require.True(t, env.SumBalance(t, env.AccruedSubAccount(t)).Equal(alpacadecimal.Zero))
 }
 
-func TestTransferCustomerFBOToAccruedTemplate_SeparatesTaxCodeBuckets(t *testing.T) {
+func TestTransferCustomerFBOToAccruedTemplate_AppliesTaxConfigToAccrued(t *testing.T) {
 	env := newTransactionsTestEnv(t)
 	costBasis := alpacadecimal.NewFromInt(1)
 
 	taxA := "tax_A"
-	taxB := "tax_B"
+	taxBehavior := ledger.TaxBehaviorInclusive
 
-	// Fund two FBO sub-accounts: same priority+costBasis but different TaxCodes.
-	fboTaxA := env.fundPriorityWithCostBasisAndTaxCode(t, 1, 30, &costBasis, &taxA)
-	fboTaxB := env.fundPriorityWithCostBasisAndTaxCode(t, 1, 50, &costBasis, &taxB)
+	// Tax dimensions come from accrual, not from selected FBO sources.
+	fboA := env.fundPriorityWithCostBasis(t, 1, 30, &costBasis)
+	fboB := env.fundPriorityWithCostBasis(t, 2, 50, &costBasis)
 
 	inputs := env.resolveAndCommit(
 		t,
 		TransferCustomerFBOToAccruedTemplate{
-			At:       env.Now(),
-			Currency: env.Currency,
+			At:          env.Now(),
+			Currency:    env.Currency,
+			TaxCode:     &taxA,
+			TaxBehavior: &taxBehavior,
 			Sources: []PostingAmount{
-				{Address: fboTaxA.Address(), Amount: alpacadecimal.NewFromInt(30)},
-				{Address: fboTaxB.Address(), Amount: alpacadecimal.NewFromInt(50)},
+				{Address: fboA.Address(), Amount: alpacadecimal.NewFromInt(30)},
+				{Address: fboB.Address(), Amount: alpacadecimal.NewFromInt(50)},
 			},
 		},
 	)
 	require.Len(t, inputs, 1)
 
 	// Both FBO sources fully drained.
-	require.True(t, env.SumBalance(t, fboTaxA).Equal(alpacadecimal.Zero))
-	require.True(t, env.SumBalance(t, fboTaxB).Equal(alpacadecimal.Zero))
+	require.True(t, env.SumBalance(t, fboA).Equal(alpacadecimal.Zero))
+	require.True(t, env.SumBalance(t, fboB).Equal(alpacadecimal.Zero))
 
-	// Each TaxCode lands in its own accrued bucket.
-	require.True(t, env.AccruedSubAccountWithCostBasisAndTaxCode(t, &costBasis, &taxA) != env.AccruedSubAccountWithCostBasisAndTaxCode(t, &costBasis, &taxB))
-	require.True(t, env.SumBalance(t, env.AccruedSubAccountWithCostBasisAndTaxCode(t, &costBasis, &taxA)).Equal(alpacadecimal.NewFromInt(30)))
-	require.True(t, env.SumBalance(t, env.AccruedSubAccountWithCostBasisAndTaxCode(t, &costBasis, &taxB)).Equal(alpacadecimal.NewFromInt(50)))
+	accrued, err := env.CustomerAccounts.AccruedAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerAccruedRouteParams{
+		Currency:    env.Currency,
+		CostBasis:   &costBasis,
+		TaxCode:     &taxA,
+		TaxBehavior: &taxBehavior,
+	})
+	require.NoError(t, err)
+	require.True(t, env.SumBalance(t, accrued).Equal(alpacadecimal.NewFromInt(80)))
 }
 
-func TestTransferCustomerFBOToAccruedTemplate_NilTaxCodeIsolatedFromNonNil(t *testing.T) {
+func TestTransferCustomerFBOToAccruedTemplate_NilTaxConfigUsesNilAccruedRoute(t *testing.T) {
 	env := newTransactionsTestEnv(t)
 
-	taxA := "tax_A"
-
-	// One FBO with nil TaxCode, one with non-nil TaxCode.
-	fboNilTax := env.fundPriorityWithCostBasisAndTaxCode(t, 1, 40, nil, nil)
-	fboTaxA := env.fundPriorityWithCostBasisAndTaxCode(t, 2, 20, nil, &taxA)
+	fboA := env.fundPriority(t, 1, 40)
+	fboB := env.fundPriority(t, 2, 20)
 
 	inputs := env.resolveAndCommit(
 		t,
@@ -239,19 +240,16 @@ func TestTransferCustomerFBOToAccruedTemplate_NilTaxCodeIsolatedFromNonNil(t *te
 			At:       env.Now(),
 			Currency: env.Currency,
 			Sources: []PostingAmount{
-				{Address: fboNilTax.Address(), Amount: alpacadecimal.NewFromInt(40)},
-				{Address: fboTaxA.Address(), Amount: alpacadecimal.NewFromInt(20)},
+				{Address: fboA.Address(), Amount: alpacadecimal.NewFromInt(40)},
+				{Address: fboB.Address(), Amount: alpacadecimal.NewFromInt(20)},
 			},
 		},
 	)
 	require.Len(t, inputs, 1)
 
-	require.True(t, env.SumBalance(t, fboNilTax).Equal(alpacadecimal.Zero))
-	require.True(t, env.SumBalance(t, fboTaxA).Equal(alpacadecimal.Zero))
-
-	// Nil TaxCode and non-nil TaxCode land in separate accrued buckets.
-	require.True(t, env.SumBalance(t, env.AccruedSubAccountWithCostBasisAndTaxCode(t, nil, nil)).Equal(alpacadecimal.NewFromInt(40)))
-	require.True(t, env.SumBalance(t, env.AccruedSubAccountWithCostBasisAndTaxCode(t, nil, &taxA)).Equal(alpacadecimal.NewFromInt(20)))
+	require.True(t, env.SumBalance(t, fboA).Equal(alpacadecimal.Zero))
+	require.True(t, env.SumBalance(t, fboB).Equal(alpacadecimal.Zero))
+	require.True(t, env.SumBalance(t, env.AccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(60)))
 }
 
 func TestTranslateCustomerAccruedCostBasisTemplate(t *testing.T) {

--- a/openmeter/ledger/transactions/accrual_test.go
+++ b/openmeter/ledger/transactions/accrual_test.go
@@ -157,6 +157,39 @@ func TestTransferCustomerFBOAdvanceToAccruedTemplate_UnknownCostBasisAdvanceNetE
 	require.True(t, env.SumBalance(t, env.AccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(30)))
 }
 
+func TestTransferCustomerFBOAdvanceToAccruedTemplate_PreservesFBOTaxBehavior(t *testing.T) {
+	env := newTransactionsTestEnv(t)
+	taxBehavior := ledger.TaxBehaviorExclusive
+
+	inputs := env.resolveAndCommit(
+		t,
+		IssueCustomerReceivableTemplate{
+			At:          env.Now(),
+			Amount:      alpacadecimal.NewFromInt(30),
+			Currency:    env.Currency,
+			TaxBehavior: &taxBehavior,
+		},
+		TransferCustomerFBOAdvanceToAccruedTemplate{
+			At:          env.Now(),
+			Amount:      alpacadecimal.NewFromInt(30),
+			Currency:    env.Currency,
+			TaxBehavior: &taxBehavior,
+		},
+	)
+	require.Len(t, inputs, 2)
+
+	fboWithTaxBehavior, err := env.CustomerAccounts.FBOAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerFBORouteParams{
+		Currency:       env.Currency,
+		CreditPriority: ledger.DefaultCustomerFBOPriority,
+		TaxBehavior:    &taxBehavior,
+	})
+	require.NoError(t, err)
+
+	require.True(t, env.SumBalance(t, fboWithTaxBehavior).Equal(alpacadecimal.Zero))
+	require.True(t, env.SumBalance(t, env.FBOSubAccount(t, ledger.DefaultCustomerFBOPriority)).Equal(alpacadecimal.Zero))
+	require.True(t, env.SumBalance(t, env.AccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(30)))
+}
+
 func TestTransferCustomerFBOToAccruedTemplate_SeparatesTaxCodeBuckets(t *testing.T) {
 	env := newTransactionsTestEnv(t)
 	costBasis := alpacadecimal.NewFromInt(1)

--- a/openmeter/ledger/transactions/accrual_test.go
+++ b/openmeter/ledger/transactions/accrual_test.go
@@ -159,6 +159,7 @@ func TestTransferCustomerFBOAdvanceToAccruedTemplate_UnknownCostBasisAdvanceNetE
 
 func TestTransferCustomerFBOAdvanceToAccruedTemplate_AppliesTaxBehaviorToAccrued(t *testing.T) {
 	env := newTransactionsTestEnv(t)
+	taxCode := "tax_A"
 	taxBehavior := ledger.TaxBehaviorExclusive
 
 	inputs := env.resolveAndCommit(
@@ -172,6 +173,7 @@ func TestTransferCustomerFBOAdvanceToAccruedTemplate_AppliesTaxBehaviorToAccrued
 			At:          env.Now(),
 			Amount:      alpacadecimal.NewFromInt(30),
 			Currency:    env.Currency,
+			TaxCode:     &taxCode,
 			TaxBehavior: &taxBehavior,
 		},
 	)
@@ -179,6 +181,7 @@ func TestTransferCustomerFBOAdvanceToAccruedTemplate_AppliesTaxBehaviorToAccrued
 
 	accruedWithTaxBehavior, err := env.CustomerAccounts.AccruedAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerAccruedRouteParams{
 		Currency:    env.Currency,
+		TaxCode:     &taxCode,
 		TaxBehavior: &taxBehavior,
 	})
 	require.NoError(t, err)

--- a/openmeter/ledger/transactions/correction_leg.go
+++ b/openmeter/ledger/transactions/correction_leg.go
@@ -10,13 +10,18 @@ import (
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 )
 
+// routePairingKey pairs source and counterpart sub-accounts during accrual and
+// earnings correction. TaxBehavior is deliberately excluded: it is an FBO-only
+// routing dimension. Accrued and earnings sub-accounts never carry TaxBehavior,
+// so it cannot be used to pair entries across those account types.
 type routePairingKey struct {
 	currency  currencyx.Code
+	taxCode   string
 	costBasis string
 }
 
 func (k routePairingKey) String() string {
-	return fmt.Sprintf("currency=%s,cost_basis=%s", k.currency, k.costBasis)
+	return fmt.Sprintf("currency=%s,tax_code=%s,cost_basis=%s", k.currency, k.taxCode, k.costBasis)
 }
 
 type correctionLeg struct {

--- a/openmeter/ledger/transactions/correction_leg.go
+++ b/openmeter/ledger/transactions/correction_leg.go
@@ -11,17 +11,16 @@ import (
 )
 
 // routePairingKey pairs source and counterpart sub-accounts during accrual and
-// earnings correction. TaxBehavior is deliberately excluded: it is an FBO-only
-// routing dimension. Accrued and earnings sub-accounts never carry TaxBehavior,
-// so it cannot be used to pair entries across those account types.
+// earnings correction.
 type routePairingKey struct {
-	currency  currencyx.Code
-	taxCode   string
-	costBasis string
+	currency    currencyx.Code
+	taxCode     string
+	taxBehavior string
+	costBasis   string
 }
 
 func (k routePairingKey) String() string {
-	return fmt.Sprintf("currency=%s,tax_code=%s,cost_basis=%s", k.currency, k.taxCode, k.costBasis)
+	return fmt.Sprintf("currency=%s,tax_code=%s,tax_behavior=%s,cost_basis=%s", k.currency, k.taxCode, k.taxBehavior, k.costBasis)
 }
 
 type correctionLeg struct {

--- a/openmeter/ledger/transactions/correction_leg_test.go
+++ b/openmeter/ledger/transactions/correction_leg_test.go
@@ -1,0 +1,73 @@
+package transactions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+)
+
+func TestRoutePairingKeyEquality(t *testing.T) {
+	usd := currencyx.Code("USD")
+	taxA := "tax_A"
+	taxB := "tax_B"
+
+	t.Run("same fields are equal", func(t *testing.T) {
+		k1 := routePairingKey{currency: usd, taxCode: taxCodeKey(&taxA), costBasis: "null"}
+		k2 := routePairingKey{currency: usd, taxCode: taxCodeKey(&taxA), costBasis: "null"}
+		assert.Equal(t, k1, k2)
+	})
+
+	t.Run("different taxCode are not equal", func(t *testing.T) {
+		k1 := routePairingKey{currency: usd, taxCode: taxCodeKey(&taxA), costBasis: "null"}
+		k2 := routePairingKey{currency: usd, taxCode: taxCodeKey(&taxB), costBasis: "null"}
+		assert.NotEqual(t, k1, k2)
+	})
+
+	t.Run("nil taxCode differs from non-nil", func(t *testing.T) {
+		k1 := routePairingKey{currency: usd, taxCode: taxCodeKey(nil), costBasis: "null"}
+		k2 := routePairingKey{currency: usd, taxCode: taxCodeKey(&taxA), costBasis: "null"}
+		assert.NotEqual(t, k1, k2)
+	})
+
+	t.Run("nil taxCode keys are equal", func(t *testing.T) {
+		k1 := routePairingKey{currency: usd, taxCode: taxCodeKey(nil), costBasis: "null"}
+		k2 := routePairingKey{currency: usd, taxCode: taxCodeKey(nil), costBasis: "null"}
+		assert.Equal(t, k1, k2)
+	})
+}
+
+func TestRoutePairingKeyString(t *testing.T) {
+	usd := currencyx.Code("USD")
+	tax := "tax_A"
+
+	t.Run("includes taxCode field", func(t *testing.T) {
+		k := routePairingKey{currency: usd, taxCode: taxCodeKey(&tax), costBasis: "null"}
+		s := k.String()
+		assert.Contains(t, s, "tax_code=tax_A")
+		assert.Contains(t, s, "currency=USD")
+		assert.Contains(t, s, "cost_basis=null")
+	})
+
+	t.Run("null taxCode renders as null", func(t *testing.T) {
+		k := routePairingKey{currency: usd, taxCode: taxCodeKey(nil), costBasis: "null"}
+		assert.Contains(t, k.String(), "tax_code=null")
+	})
+}
+
+func TestTaxCodeKey(t *testing.T) {
+	t.Run("nil pointer returns null", func(t *testing.T) {
+		assert.Equal(t, "null", taxCodeKey(nil))
+	})
+
+	t.Run("non-nil pointer returns value", func(t *testing.T) {
+		v := "tax_digital_services"
+		assert.Equal(t, "tax_digital_services", taxCodeKey(&v))
+	})
+
+	t.Run("empty string returns empty string", func(t *testing.T) {
+		v := ""
+		assert.Equal(t, "", taxCodeKey(&v))
+	})
+}

--- a/openmeter/ledger/transactions/correction_leg_test.go
+++ b/openmeter/ledger/transactions/correction_leg_test.go
@@ -3,6 +3,7 @@ package transactions
 import (
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -14,26 +15,26 @@ func TestRoutePairingKeyEquality(t *testing.T) {
 	taxB := "tax_B"
 
 	t.Run("same fields are equal", func(t *testing.T) {
-		k1 := routePairingKey{currency: usd, taxCode: taxCodeKey(&taxA), costBasis: "null"}
-		k2 := routePairingKey{currency: usd, taxCode: taxCodeKey(&taxA), costBasis: "null"}
+		k1 := routePairingKey{currency: usd, taxCode: lo.FromPtrOr(&taxA, "null"), costBasis: "null"}
+		k2 := routePairingKey{currency: usd, taxCode: lo.FromPtrOr(&taxA, "null"), costBasis: "null"}
 		assert.Equal(t, k1, k2)
 	})
 
 	t.Run("different taxCode are not equal", func(t *testing.T) {
-		k1 := routePairingKey{currency: usd, taxCode: taxCodeKey(&taxA), costBasis: "null"}
-		k2 := routePairingKey{currency: usd, taxCode: taxCodeKey(&taxB), costBasis: "null"}
+		k1 := routePairingKey{currency: usd, taxCode: lo.FromPtrOr(&taxA, "null"), costBasis: "null"}
+		k2 := routePairingKey{currency: usd, taxCode: lo.FromPtrOr(&taxB, "null"), costBasis: "null"}
 		assert.NotEqual(t, k1, k2)
 	})
 
 	t.Run("nil taxCode differs from non-nil", func(t *testing.T) {
-		k1 := routePairingKey{currency: usd, taxCode: taxCodeKey(nil), costBasis: "null"}
-		k2 := routePairingKey{currency: usd, taxCode: taxCodeKey(&taxA), costBasis: "null"}
+		k1 := routePairingKey{currency: usd, taxCode: lo.FromPtrOr[string](nil, "null"), costBasis: "null"}
+		k2 := routePairingKey{currency: usd, taxCode: lo.FromPtrOr(&taxA, "null"), costBasis: "null"}
 		assert.NotEqual(t, k1, k2)
 	})
 
 	t.Run("nil taxCode keys are equal", func(t *testing.T) {
-		k1 := routePairingKey{currency: usd, taxCode: taxCodeKey(nil), costBasis: "null"}
-		k2 := routePairingKey{currency: usd, taxCode: taxCodeKey(nil), costBasis: "null"}
+		k1 := routePairingKey{currency: usd, taxCode: lo.FromPtrOr[string](nil, "null"), costBasis: "null"}
+		k2 := routePairingKey{currency: usd, taxCode: lo.FromPtrOr[string](nil, "null"), costBasis: "null"}
 		assert.Equal(t, k1, k2)
 	})
 }
@@ -43,7 +44,7 @@ func TestRoutePairingKeyString(t *testing.T) {
 	tax := "tax_A"
 
 	t.Run("includes taxCode field", func(t *testing.T) {
-		k := routePairingKey{currency: usd, taxCode: taxCodeKey(&tax), costBasis: "null"}
+		k := routePairingKey{currency: usd, taxCode: lo.FromPtrOr(&tax, "null"), costBasis: "null"}
 		s := k.String()
 		assert.Contains(t, s, "tax_code=tax_A")
 		assert.Contains(t, s, "currency=USD")
@@ -51,23 +52,7 @@ func TestRoutePairingKeyString(t *testing.T) {
 	})
 
 	t.Run("null taxCode renders as null", func(t *testing.T) {
-		k := routePairingKey{currency: usd, taxCode: taxCodeKey(nil), costBasis: "null"}
+		k := routePairingKey{currency: usd, taxCode: lo.FromPtrOr[string](nil, "null"), costBasis: "null"}
 		assert.Contains(t, k.String(), "tax_code=null")
-	})
-}
-
-func TestTaxCodeKey(t *testing.T) {
-	t.Run("nil pointer returns null", func(t *testing.T) {
-		assert.Equal(t, "null", taxCodeKey(nil))
-	})
-
-	t.Run("non-nil pointer returns value", func(t *testing.T) {
-		v := "tax_digital_services"
-		assert.Equal(t, "tax_digital_services", taxCodeKey(&v))
-	})
-
-	t.Run("empty string returns empty string", func(t *testing.T) {
-		v := ""
-		assert.Equal(t, "", taxCodeKey(&v))
 	})
 }

--- a/openmeter/ledger/transactions/customer.go
+++ b/openmeter/ledger/transactions/customer.go
@@ -14,10 +14,12 @@ import (
 
 // IssueCustomerReceivableTemplate is a transaction increasing the customer's balance against an outstanding receivable account
 type IssueCustomerReceivableTemplate struct {
-	At        time.Time
-	Amount    alpacadecimal.Decimal
-	Currency  currencyx.Code
-	CostBasis *alpacadecimal.Decimal
+	At          time.Time
+	Amount      alpacadecimal.Decimal
+	Currency    currencyx.Code
+	TaxCode     *string
+	TaxBehavior *ledger.TaxBehavior
+	CostBasis   *alpacadecimal.Decimal
 	// Optional, defaults to ledger.DefaultCustomerFBOPriority.
 	CreditPriority *int
 }
@@ -116,6 +118,8 @@ func (t IssueCustomerReceivableTemplate) resolve(ctx context.Context, customerID
 
 	fbo, err := customerAccounts.FBOAccount.GetSubAccountForRoute(ctx, ledger.CustomerFBORouteParams{
 		Currency:       t.Currency,
+		TaxCode:        t.TaxCode,
+		TaxBehavior:    t.TaxBehavior,
 		CostBasis:      t.CostBasis,
 		CreditPriority: priority,
 	})
@@ -125,6 +129,7 @@ func (t IssueCustomerReceivableTemplate) resolve(ctx context.Context, customerID
 
 	rec, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
+		TaxCode:                        t.TaxCode,
 		CostBasis:                      t.CostBasis,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
 	})
@@ -153,6 +158,7 @@ type SettleCustomerReceivableFromPaymentTemplate struct {
 	At        time.Time
 	Amount    alpacadecimal.Decimal
 	Currency  currencyx.Code
+	TaxCode   *string
 	CostBasis *alpacadecimal.Decimal
 }
 
@@ -200,6 +206,7 @@ func (t SettleCustomerReceivableFromPaymentTemplate) resolve(ctx context.Context
 
 	rec, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
+		TaxCode:                        t.TaxCode,
 		CostBasis:                      t.CostBasis,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusAuthorized,
 	})
@@ -241,6 +248,7 @@ type AuthorizeCustomerReceivablePaymentTemplate struct {
 	At        time.Time
 	Amount    alpacadecimal.Decimal
 	Currency  currencyx.Code
+	TaxCode   *string
 	CostBasis *alpacadecimal.Decimal
 }
 
@@ -288,6 +296,7 @@ func (t AuthorizeCustomerReceivablePaymentTemplate) resolve(ctx context.Context,
 
 	authorizedReceivable, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
+		TaxCode:                        t.TaxCode,
 		CostBasis:                      t.CostBasis,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusAuthorized,
 	})
@@ -297,6 +306,7 @@ func (t AuthorizeCustomerReceivablePaymentTemplate) resolve(ctx context.Context,
 
 	openReceivable, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
+		TaxCode:                        t.TaxCode,
 		CostBasis:                      t.CostBasis,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
 	})
@@ -325,6 +335,7 @@ type AttributeCustomerAdvanceReceivableCostBasisTemplate struct {
 	At        time.Time
 	Amount    alpacadecimal.Decimal
 	Currency  currencyx.Code
+	TaxCode   *string
 	CostBasis *alpacadecimal.Decimal
 }
 
@@ -414,6 +425,7 @@ func (t AttributeCustomerAdvanceReceivableCostBasisTemplate) resolve(ctx context
 
 	advanceReceivable, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
+		TaxCode:                        t.TaxCode,
 		CostBasis:                      nil,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
 	})
@@ -423,6 +435,7 @@ func (t AttributeCustomerAdvanceReceivableCostBasisTemplate) resolve(ctx context
 
 	attributedReceivable, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
+		TaxCode:                        t.TaxCode,
 		CostBasis:                      t.CostBasis,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
 	})

--- a/openmeter/ledger/transactions/customer.go
+++ b/openmeter/ledger/transactions/customer.go
@@ -14,12 +14,11 @@ import (
 
 // IssueCustomerReceivableTemplate is a transaction increasing the customer's balance against an outstanding receivable account
 type IssueCustomerReceivableTemplate struct {
-	At          time.Time
-	Amount      alpacadecimal.Decimal
-	Currency    currencyx.Code
-	TaxCode     *string
-	TaxBehavior *ledger.TaxBehavior
-	CostBasis   *alpacadecimal.Decimal
+	At        time.Time
+	Amount    alpacadecimal.Decimal
+	Currency  currencyx.Code
+	TaxCode   *string
+	CostBasis *alpacadecimal.Decimal
 	// Optional, defaults to ledger.DefaultCustomerFBOPriority.
 	CreditPriority *int
 }
@@ -118,8 +117,6 @@ func (t IssueCustomerReceivableTemplate) resolve(ctx context.Context, customerID
 
 	fbo, err := customerAccounts.FBOAccount.GetSubAccountForRoute(ctx, ledger.CustomerFBORouteParams{
 		Currency:       t.Currency,
-		TaxCode:        t.TaxCode,
-		TaxBehavior:    t.TaxBehavior,
 		CostBasis:      t.CostBasis,
 		CreditPriority: priority,
 	})

--- a/openmeter/ledger/transactions/customer.go
+++ b/openmeter/ledger/transactions/customer.go
@@ -126,7 +126,6 @@ func (t IssueCustomerReceivableTemplate) resolve(ctx context.Context, customerID
 
 	rec, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
-		TaxCode:                        t.TaxCode,
 		CostBasis:                      t.CostBasis,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
 	})
@@ -203,7 +202,6 @@ func (t SettleCustomerReceivableFromPaymentTemplate) resolve(ctx context.Context
 
 	rec, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
-		TaxCode:                        t.TaxCode,
 		CostBasis:                      t.CostBasis,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusAuthorized,
 	})
@@ -293,7 +291,6 @@ func (t AuthorizeCustomerReceivablePaymentTemplate) resolve(ctx context.Context,
 
 	authorizedReceivable, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
-		TaxCode:                        t.TaxCode,
 		CostBasis:                      t.CostBasis,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusAuthorized,
 	})
@@ -303,7 +300,6 @@ func (t AuthorizeCustomerReceivablePaymentTemplate) resolve(ctx context.Context,
 
 	openReceivable, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
-		TaxCode:                        t.TaxCode,
 		CostBasis:                      t.CostBasis,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
 	})
@@ -422,7 +418,6 @@ func (t AttributeCustomerAdvanceReceivableCostBasisTemplate) resolve(ctx context
 
 	advanceReceivable, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
-		TaxCode:                        t.TaxCode,
 		CostBasis:                      nil,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
 	})
@@ -432,7 +427,6 @@ func (t AttributeCustomerAdvanceReceivableCostBasisTemplate) resolve(ctx context
 
 	attributedReceivable, err := customerAccounts.ReceivableAccount.GetSubAccountForRoute(ctx, ledger.CustomerReceivableRouteParams{
 		Currency:                       t.Currency,
-		TaxCode:                        t.TaxCode,
 		CostBasis:                      t.CostBasis,
 		TransactionAuthorizationStatus: ledger.TransactionAuthorizationStatusOpen,
 	})

--- a/openmeter/ledger/transactions/earnings.go
+++ b/openmeter/ledger/transactions/earnings.go
@@ -92,6 +92,7 @@ func (t RecognizeEarningsFromAttributableAccruedTemplate) routePairingKey(addres
 
 	return routePairingKey{
 		currency:  route.Currency,
+		taxCode:   taxCodeKey(route.TaxCode),
 		costBasis: costBasisKey(route.CostBasis),
 	}
 }
@@ -136,6 +137,7 @@ func (t RecognizeEarningsFromAttributableAccruedTemplate) resolveEarningsSubAccB
 			// same route. Recognition only needs one earnings destination per route.
 			earnings, err := earningsAccount.GetSubAccountForRoute(ctx, ledger.BusinessRouteParams{
 				Currency:  t.Currency,
+				TaxCode:   collection.subAccount.Route().TaxCode,
 				CostBasis: collection.subAccount.Route().CostBasis,
 			})
 			if err != nil {

--- a/openmeter/ledger/transactions/earnings.go
+++ b/openmeter/ledger/transactions/earnings.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
@@ -91,9 +92,10 @@ func (t RecognizeEarningsFromAttributableAccruedTemplate) routePairingKey(addres
 	route := address.Route().Route()
 
 	return routePairingKey{
-		currency:  route.Currency,
-		taxCode:   taxCodeKey(route.TaxCode),
-		costBasis: costBasisKey(route.CostBasis),
+		currency:    route.Currency,
+		taxCode:     lo.FromPtrOr(route.TaxCode, "null"),
+		taxBehavior: string(lo.FromPtrOr(route.TaxBehavior, "null")),
+		costBasis:   costBasisKey(route.CostBasis),
 	}
 }
 
@@ -136,9 +138,10 @@ func (t RecognizeEarningsFromAttributableAccruedTemplate) resolveEarningsSubAccB
 			// Accrued collection can touch multiple source sub-accounts for the
 			// same route. Recognition only needs one earnings destination per route.
 			earnings, err := earningsAccount.GetSubAccountForRoute(ctx, ledger.BusinessRouteParams{
-				Currency:  t.Currency,
-				TaxCode:   collection.subAccount.Route().TaxCode,
-				CostBasis: collection.subAccount.Route().CostBasis,
+				Currency:    t.Currency,
+				TaxCode:     collection.subAccount.Route().TaxCode,
+				TaxBehavior: collection.subAccount.Route().TaxBehavior,
+				CostBasis:   collection.subAccount.Route().CostBasis,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("failed to get earnings sub-account: %w", err)

--- a/openmeter/ledger/transactions/testenv_test.go
+++ b/openmeter/ledger/transactions/testenv_test.go
@@ -69,10 +69,30 @@ func (e *transactionsTestEnv) fundPriority(t *testing.T, priority int, amount in
 func (e *transactionsTestEnv) fundPriorityWithCostBasis(t *testing.T, priority int, amount int64, costBasis *alpacadecimal.Decimal) ledger.SubAccount {
 	t.Helper()
 
+	return e.fundPriorityWithTaxParams(t, priority, amount, costBasis, nil, nil)
+}
+
+func (e *transactionsTestEnv) fundPriorityWithCostBasisAndTaxCode(t *testing.T, priority int, amount int64, costBasis *alpacadecimal.Decimal, taxCode *string) ledger.SubAccount {
+	t.Helper()
+
+	return e.fundPriorityWithTaxParams(t, priority, amount, costBasis, taxCode, nil)
+}
+
+func (e *transactionsTestEnv) fundPriorityWithCostBasisAndTaxBehavior(t *testing.T, priority int, amount int64, costBasis *alpacadecimal.Decimal, taxBehavior *ledger.TaxBehavior) ledger.SubAccount {
+	t.Helper()
+
+	return e.fundPriorityWithTaxParams(t, priority, amount, costBasis, nil, taxBehavior)
+}
+
+func (e *transactionsTestEnv) fundPriorityWithTaxParams(t *testing.T, priority int, amount int64, costBasis *alpacadecimal.Decimal, taxCode *string, taxBehavior *ledger.TaxBehavior) ledger.SubAccount {
+	t.Helper()
+
 	subAccount, err := e.CustomerAccounts.FBOAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerFBORouteParams{
 		Currency:       e.Currency,
 		CostBasis:      costBasis,
 		CreditPriority: priority,
+		TaxCode:        taxCode,
+		TaxBehavior:    taxBehavior,
 	})
 	require.NoError(t, err)
 
@@ -82,6 +102,8 @@ func (e *transactionsTestEnv) fundPriorityWithCostBasis(t *testing.T, priority i
 			At:             e.Now(),
 			Amount:         alpacadecimal.NewFromInt(amount),
 			Currency:       e.Currency,
+			TaxCode:        taxCode,
+			TaxBehavior:    taxBehavior,
 			CostBasis:      costBasis,
 			CreditPriority: &priority,
 		},
@@ -89,12 +111,14 @@ func (e *transactionsTestEnv) fundPriorityWithCostBasis(t *testing.T, priority i
 			At:        e.Now(),
 			Amount:    alpacadecimal.NewFromInt(amount),
 			Currency:  e.Currency,
+			TaxCode:   taxCode,
 			CostBasis: costBasis,
 		},
 		SettleCustomerReceivableFromPaymentTemplate{
 			At:        e.Now(),
 			Amount:    alpacadecimal.NewFromInt(amount),
 			Currency:  e.Currency,
+			TaxCode:   taxCode,
 			CostBasis: costBasis,
 		},
 	)

--- a/openmeter/ledger/transactions/testenv_test.go
+++ b/openmeter/ledger/transactions/testenv_test.go
@@ -69,30 +69,10 @@ func (e *transactionsTestEnv) fundPriority(t *testing.T, priority int, amount in
 func (e *transactionsTestEnv) fundPriorityWithCostBasis(t *testing.T, priority int, amount int64, costBasis *alpacadecimal.Decimal) ledger.SubAccount {
 	t.Helper()
 
-	return e.fundPriorityWithTaxParams(t, priority, amount, costBasis, nil, nil)
-}
-
-func (e *transactionsTestEnv) fundPriorityWithCostBasisAndTaxCode(t *testing.T, priority int, amount int64, costBasis *alpacadecimal.Decimal, taxCode *string) ledger.SubAccount {
-	t.Helper()
-
-	return e.fundPriorityWithTaxParams(t, priority, amount, costBasis, taxCode, nil)
-}
-
-func (e *transactionsTestEnv) fundPriorityWithCostBasisAndTaxBehavior(t *testing.T, priority int, amount int64, costBasis *alpacadecimal.Decimal, taxBehavior *ledger.TaxBehavior) ledger.SubAccount {
-	t.Helper()
-
-	return e.fundPriorityWithTaxParams(t, priority, amount, costBasis, nil, taxBehavior)
-}
-
-func (e *transactionsTestEnv) fundPriorityWithTaxParams(t *testing.T, priority int, amount int64, costBasis *alpacadecimal.Decimal, taxCode *string, taxBehavior *ledger.TaxBehavior) ledger.SubAccount {
-	t.Helper()
-
 	subAccount, err := e.CustomerAccounts.FBOAccount.GetSubAccountForRoute(t.Context(), ledger.CustomerFBORouteParams{
 		Currency:       e.Currency,
 		CostBasis:      costBasis,
 		CreditPriority: priority,
-		TaxCode:        taxCode,
-		TaxBehavior:    taxBehavior,
 	})
 	require.NoError(t, err)
 
@@ -102,8 +82,6 @@ func (e *transactionsTestEnv) fundPriorityWithTaxParams(t *testing.T, priority i
 			At:             e.Now(),
 			Amount:         alpacadecimal.NewFromInt(amount),
 			Currency:       e.Currency,
-			TaxCode:        taxCode,
-			TaxBehavior:    taxBehavior,
 			CostBasis:      costBasis,
 			CreditPriority: &priority,
 		},
@@ -111,14 +89,12 @@ func (e *transactionsTestEnv) fundPriorityWithTaxParams(t *testing.T, priority i
 			At:        e.Now(),
 			Amount:    alpacadecimal.NewFromInt(amount),
 			Currency:  e.Currency,
-			TaxCode:   taxCode,
 			CostBasis: costBasis,
 		},
 		SettleCustomerReceivableFromPaymentTemplate{
 			At:        e.Now(),
 			Amount:    alpacadecimal.NewFromInt(amount),
 			Currency:  e.Currency,
-			TaxCode:   taxCode,
 			CostBasis: costBasis,
 		},
 	)

--- a/openmeter/ledger/validations_test.go
+++ b/openmeter/ledger/validations_test.go
@@ -95,7 +95,7 @@ func mustPostingAddress(t *testing.T, currency currencyx.Code) ledger.PostingAdd
 	t.Helper()
 
 	route := ledger.Route{Currency: currency}
-	key, err := ledger.BuildRoutingKey(ledger.RoutingKeyVersionV1, route)
+	key, err := ledger.BuildRoutingKey(route)
 	require.NoError(t, err)
 
 	address, err := ledgeraccount.NewAddressFromData(ledgeraccount.AddressData{

--- a/pkg/currencyx/allocation.go
+++ b/pkg/currencyx/allocation.go
@@ -201,6 +201,10 @@ func AllocateByAmount[T any](calculator Calculator, input AmountAllocationInput[
 		distributed := false
 
 		for i := range candidates {
+			if remaining.LessThan(unit) {
+				break
+			}
+
 			next := candidates[i].allocated.Add(unit)
 			if next.GreaterThan(candidates[i].amount) {
 				continue
@@ -209,7 +213,6 @@ func AllocateByAmount[T any](calculator Calculator, input AmountAllocationInput[
 			candidates[i].allocated = next
 			remaining = remaining.Sub(unit)
 			distributed = true
-			break
 		}
 
 		if !distributed {

--- a/pkg/currencyx/allocation.go
+++ b/pkg/currencyx/allocation.go
@@ -1,0 +1,313 @@
+package currencyx
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/alpacahq/alpacadecimal"
+)
+
+// WeightedAllocationItem defines one key that can receive a proportional
+// allocation from a currency amount. Weight is dimensionless; it does not need
+// to be a currency amount.
+type WeightedAllocationItem[T any] struct {
+	Key    T
+	Weight alpacadecimal.Decimal
+}
+
+// WeightedAllocation is the allocated currency amount for one key.
+type WeightedAllocation[T any] struct {
+	Key    T
+	Amount alpacadecimal.Decimal
+}
+
+// AmountAllocationItem defines one currency amount bucket that can receive a
+// proportional allocation. The amount is both the allocation weight and the
+// maximum amount that can be allocated to the key.
+type AmountAllocationItem[T any] struct {
+	Key    T
+	Amount alpacadecimal.Decimal
+}
+
+// AmountAllocation is the allocated currency amount for one key.
+type AmountAllocation[T any] struct {
+	Key    T
+	Amount alpacadecimal.Decimal
+}
+
+// WeightedAllocationInput defines a proportional currency allocation.
+type WeightedAllocationInput[T any] struct {
+	Amount alpacadecimal.Decimal
+	Items  []WeightedAllocationItem[T]
+
+	// CompareKey is used as a deterministic tie-breaker when two items have
+	// the same fractional remainder. If nil, the original item order is used.
+	CompareKey func(left, right T) int
+}
+
+// AmountAllocationInput defines a proportional allocation across currency
+// amount buckets.
+type AmountAllocationInput[T any] struct {
+	Amount alpacadecimal.Decimal
+	Items  []AmountAllocationItem[T]
+
+	// CompareKey is used as a deterministic tie-breaker when two buckets have
+	// the same fractional remainder. If nil, the original item order is used.
+	CompareKey func(left, right T) int
+}
+
+// AllocateByWeight allocates a currency amount across keys using their
+// weights and the largest remainder quota method at the currency precision.
+func AllocateByWeight[T any](calculator Calculator, input WeightedAllocationInput[T]) ([]WeightedAllocation[T], error) {
+	if err := validateWeightedAllocationInput(calculator, input); err != nil {
+		return nil, err
+	}
+
+	if input.Amount.IsZero() {
+		return nil, nil
+	}
+
+	totalWeight := alpacadecimal.Zero
+	for _, item := range input.Items {
+		totalWeight = totalWeight.Add(item.Weight)
+	}
+
+	type allocationCandidate struct {
+		index     int
+		key       T
+		amount    alpacadecimal.Decimal
+		remainder alpacadecimal.Decimal
+	}
+
+	candidates := make([]allocationCandidate, 0, len(input.Items))
+	allocated := alpacadecimal.Zero
+	for i, item := range input.Items {
+		share := input.Amount.Mul(item.Weight).Div(totalWeight)
+		amount := share.RoundDown(int32(calculator.Def.Subunits))
+
+		candidates = append(candidates, allocationCandidate{
+			index:     i,
+			key:       item.Key,
+			amount:    amount,
+			remainder: share.Sub(amount),
+		})
+		allocated = allocated.Add(amount)
+	}
+
+	slices.SortStableFunc(candidates, func(left, right allocationCandidate) int {
+		if remainderCmp := right.remainder.Cmp(left.remainder); remainderCmp != 0 {
+			return remainderCmp
+		}
+
+		if input.CompareKey != nil {
+			if keyCmp := input.CompareKey(left.key, right.key); keyCmp != 0 {
+				return keyCmp
+			}
+		}
+
+		return cmp.Compare(left.index, right.index)
+	})
+
+	unit := currencyUnit(calculator)
+	remaining := input.Amount.Sub(allocated)
+	for i := range candidates {
+		if remaining.LessThan(unit) {
+			break
+		}
+
+		candidates[i].amount = candidates[i].amount.Add(unit)
+		remaining = remaining.Sub(unit)
+	}
+
+	slices.SortFunc(candidates, func(left, right allocationCandidate) int {
+		return cmp.Compare(left.index, right.index)
+	})
+
+	allocations := make([]WeightedAllocation[T], 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.amount.IsZero() {
+			continue
+		}
+
+		allocations = append(allocations, WeightedAllocation[T]{
+			Key:    candidate.key,
+			Amount: candidate.amount,
+		})
+	}
+
+	return allocations, nil
+}
+
+// AllocateByAmount allocates a currency amount across currency amount buckets
+// using the largest remainder quota method. Each item amount is both its
+// proportional weight and its allocation cap.
+func AllocateByAmount[T any](calculator Calculator, input AmountAllocationInput[T]) ([]AmountAllocation[T], error) {
+	if err := validateAmountAllocationInput(calculator, input); err != nil {
+		return nil, err
+	}
+
+	if input.Amount.IsZero() {
+		return nil, nil
+	}
+
+	totalAmount := alpacadecimal.Zero
+	for _, item := range input.Items {
+		totalAmount = totalAmount.Add(item.Amount)
+	}
+
+	type allocationCandidate struct {
+		index     int
+		key       T
+		amount    alpacadecimal.Decimal
+		allocated alpacadecimal.Decimal
+		remainder alpacadecimal.Decimal
+	}
+
+	candidates := make([]allocationCandidate, 0, len(input.Items))
+	allocated := alpacadecimal.Zero
+	for i, item := range input.Items {
+		share := input.Amount.Mul(item.Amount).Div(totalAmount)
+		floor := share.RoundDown(int32(calculator.Def.Subunits))
+
+		candidates = append(candidates, allocationCandidate{
+			index:     i,
+			key:       item.Key,
+			amount:    item.Amount,
+			allocated: floor,
+			remainder: share.Sub(floor),
+		})
+		allocated = allocated.Add(floor)
+	}
+
+	slices.SortStableFunc(candidates, func(left, right allocationCandidate) int {
+		if remainderCmp := right.remainder.Cmp(left.remainder); remainderCmp != 0 {
+			return remainderCmp
+		}
+
+		if input.CompareKey != nil {
+			if keyCmp := input.CompareKey(left.key, right.key); keyCmp != 0 {
+				return keyCmp
+			}
+		}
+
+		return cmp.Compare(left.index, right.index)
+	})
+
+	unit := currencyUnit(calculator)
+	remaining := input.Amount.Sub(allocated)
+	for remaining.GreaterThanOrEqual(unit) {
+		distributed := false
+
+		for i := range candidates {
+			next := candidates[i].allocated.Add(unit)
+			if next.GreaterThan(candidates[i].amount) {
+				continue
+			}
+
+			candidates[i].allocated = next
+			remaining = remaining.Sub(unit)
+			distributed = true
+			break
+		}
+
+		if !distributed {
+			return nil, errors.New("cannot distribute remaining allocation without exceeding item amounts")
+		}
+	}
+
+	slices.SortFunc(candidates, func(left, right allocationCandidate) int {
+		return cmp.Compare(left.index, right.index)
+	})
+
+	allocations := make([]AmountAllocation[T], 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.allocated.IsZero() {
+			continue
+		}
+
+		allocations = append(allocations, AmountAllocation[T]{
+			Key:    candidate.key,
+			Amount: candidate.allocated,
+		})
+	}
+
+	return allocations, nil
+}
+
+func validateWeightedAllocationInput[T any](calculator Calculator, input WeightedAllocationInput[T]) error {
+	var errs []error
+
+	if err := calculator.Validate(); err != nil {
+		return err
+	}
+
+	if input.Amount.Sign() < 0 {
+		errs = append(errs, errors.New("amount must be non-negative"))
+	}
+
+	if !calculator.IsRoundedToPrecision(input.Amount) {
+		errs = append(errs, errors.New("amount must be rounded to currency precision"))
+	}
+
+	if len(input.Items) == 0 && !input.Amount.IsZero() {
+		errs = append(errs, errors.New("items are required for a non-zero amount"))
+	}
+
+	totalWeight := alpacadecimal.Zero
+	for i, item := range input.Items {
+		if item.Weight.Sign() <= 0 {
+			errs = append(errs, fmt.Errorf("items[%d].weight must be positive", i))
+			continue
+		}
+
+		totalWeight = totalWeight.Add(item.Weight)
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateAmountAllocationInput[T any](calculator Calculator, input AmountAllocationInput[T]) error {
+	var errs []error
+
+	if err := calculator.Validate(); err != nil {
+		return err
+	}
+
+	if input.Amount.Sign() < 0 {
+		errs = append(errs, errors.New("amount must be non-negative"))
+	}
+
+	if !calculator.IsRoundedToPrecision(input.Amount) {
+		errs = append(errs, errors.New("amount must be rounded to currency precision"))
+	}
+
+	if len(input.Items) == 0 && !input.Amount.IsZero() {
+		errs = append(errs, errors.New("items are required for a non-zero amount"))
+	}
+
+	totalAmount := alpacadecimal.Zero
+	for i, item := range input.Items {
+		if item.Amount.Sign() <= 0 {
+			errs = append(errs, fmt.Errorf("items[%d].amount must be positive", i))
+			continue
+		}
+
+		if !calculator.IsRoundedToPrecision(item.Amount) {
+			errs = append(errs, fmt.Errorf("items[%d].amount must be rounded to currency precision", i))
+		}
+
+		totalAmount = totalAmount.Add(item.Amount)
+	}
+
+	if input.Amount.GreaterThan(totalAmount) {
+		errs = append(errs, errors.New("amount must not exceed total item amount"))
+	}
+
+	return errors.Join(errs...)
+}
+
+func currencyUnit(calculator Calculator) alpacadecimal.Decimal {
+	return alpacadecimal.NewFromInt(1).Shift(-int32(calculator.Def.Subunits))
+}

--- a/pkg/currencyx/allocation_test.go
+++ b/pkg/currencyx/allocation_test.go
@@ -1,0 +1,400 @@
+package currencyx_test
+
+import (
+	"cmp"
+	"strings"
+	"testing"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+)
+
+func TestAllocateByWeight(t *testing.T) {
+	usd := testCalculator(t, "USD")
+
+	t.Run("allocates exact proportional shares", func(t *testing.T) {
+		allocations, err := currencyx.AllocateByWeight(usd, currencyx.WeightedAllocationInput[string]{
+			Amount: dec("6.00"),
+			Items: []currencyx.WeightedAllocationItem[string]{
+				{Key: "A", Weight: dec("10")},
+				{Key: "B", Weight: dec("5")},
+			},
+		})
+		require.NoError(t, err)
+
+		requireAllocationsEqual(t, []currencyx.WeightedAllocation[string]{
+			{Key: "A", Amount: dec("4.00")},
+			{Key: "B", Amount: dec("2.00")},
+		}, allocations)
+	})
+
+	t.Run("distributes rounded remainder by largest remainder", func(t *testing.T) {
+		allocations, err := currencyx.AllocateByWeight(usd, currencyx.WeightedAllocationInput[string]{
+			Amount: dec("0.05"),
+			Items: []currencyx.WeightedAllocationItem[string]{
+				{Key: "A", Weight: dec("1")},
+				{Key: "B", Weight: dec("1")},
+				{Key: "C", Weight: dec("1")},
+			},
+		})
+		require.NoError(t, err)
+
+		requireAllocationsEqual(t, []currencyx.WeightedAllocation[string]{
+			{Key: "A", Amount: dec("0.02")},
+			{Key: "B", Amount: dec("0.02")},
+			{Key: "C", Amount: dec("0.01")},
+		}, allocations)
+	})
+
+	t.Run("uses key comparator as deterministic remainder tie-breaker", func(t *testing.T) {
+		allocations, err := currencyx.AllocateByWeight(usd, currencyx.WeightedAllocationInput[string]{
+			Amount: dec("0.05"),
+			Items: []currencyx.WeightedAllocationItem[string]{
+				{Key: "C", Weight: dec("1")},
+				{Key: "A", Weight: dec("1")},
+				{Key: "B", Weight: dec("1")},
+			},
+			CompareKey: cmp.Compare[string],
+		})
+		require.NoError(t, err)
+
+		requireAllocationsEqual(t, []currencyx.WeightedAllocation[string]{
+			{Key: "C", Amount: dec("0.01")},
+			{Key: "A", Amount: dec("0.02")},
+			{Key: "B", Amount: dec("0.02")},
+		}, allocations)
+	})
+
+	t.Run("uses currency precision", func(t *testing.T) {
+		jpy := testCalculator(t, "JPY")
+
+		allocations, err := currencyx.AllocateByWeight(jpy, currencyx.WeightedAllocationInput[string]{
+			Amount: dec("5"),
+			Items: []currencyx.WeightedAllocationItem[string]{
+				{Key: "A", Weight: dec("1")},
+				{Key: "B", Weight: dec("1")},
+				{Key: "C", Weight: dec("1")},
+			},
+		})
+		require.NoError(t, err)
+
+		requireAllocationsEqual(t, []currencyx.WeightedAllocation[string]{
+			{Key: "A", Amount: dec("2")},
+			{Key: "B", Amount: dec("2")},
+			{Key: "C", Amount: dec("1")},
+		}, allocations)
+	})
+
+	t.Run("omits zero allocations", func(t *testing.T) {
+		allocations, err := currencyx.AllocateByWeight(usd, currencyx.WeightedAllocationInput[string]{
+			Amount: dec("0.01"),
+			Items: []currencyx.WeightedAllocationItem[string]{
+				{Key: "A", Weight: dec("100")},
+				{Key: "B", Weight: dec("1")},
+			},
+		})
+		require.NoError(t, err)
+
+		requireAllocationsEqual(t, []currencyx.WeightedAllocation[string]{
+			{Key: "A", Amount: dec("0.01")},
+		}, allocations)
+	})
+
+	t.Run("supports dimensionless weights", func(t *testing.T) {
+		allocations, err := currencyx.AllocateByWeight(usd, currencyx.WeightedAllocationInput[string]{
+			Amount: dec("100.00"),
+			Items: []currencyx.WeightedAllocationItem[string]{
+				{Key: "A", Weight: dec("1")},
+				{Key: "B", Weight: dec("2")},
+				{Key: "C", Weight: dec("3")},
+			},
+		})
+		require.NoError(t, err)
+
+		requireAllocationsEqual(t, []currencyx.WeightedAllocation[string]{
+			{Key: "A", Amount: dec("16.67")},
+			{Key: "B", Amount: dec("33.33")},
+			{Key: "C", Amount: dec("50.00")},
+		}, allocations)
+	})
+}
+
+func TestAllocateByWeightValidation(t *testing.T) {
+	usd := testCalculator(t, "USD")
+
+	cases := []struct {
+		name     string
+		input    currencyx.WeightedAllocationInput[string]
+		contains string
+	}{
+		{
+			name: "amount must be rounded",
+			input: currencyx.WeightedAllocationInput[string]{
+				Amount: dec("1.001"),
+				Items: []currencyx.WeightedAllocationItem[string]{
+					{Key: "A", Weight: dec("2.00")},
+				},
+			},
+			contains: "amount must be rounded to currency precision",
+		},
+		{
+			name: "weight must be positive",
+			input: currencyx.WeightedAllocationInput[string]{
+				Amount: dec("1.00"),
+				Items: []currencyx.WeightedAllocationItem[string]{
+					{Key: "A", Weight: dec("0.00")},
+				},
+			},
+			contains: "items[0].weight must be positive",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := currencyx.AllocateByWeight(usd, tc.input)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.contains)
+		})
+	}
+
+	t.Run("zero amount does not require items", func(t *testing.T) {
+		allocations, err := currencyx.AllocateByWeight(usd, currencyx.WeightedAllocationInput[string]{
+			Amount: dec("0.00"),
+		})
+		require.NoError(t, err)
+		require.Empty(t, allocations)
+	})
+
+	t.Run("invalid calculator returns error", func(t *testing.T) {
+		_, err := currencyx.AllocateByWeight(currencyx.Calculator{}, currencyx.WeightedAllocationInput[string]{
+			Amount: dec("1.00"),
+			Items: []currencyx.WeightedAllocationItem[string]{
+				{Key: "A", Weight: dec("1")},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "currency code is required")
+	})
+
+	t.Run("weight does not need currency precision", func(t *testing.T) {
+		allocations, err := currencyx.AllocateByWeight(usd, currencyx.WeightedAllocationInput[string]{
+			Amount: dec("1.00"),
+			Items: []currencyx.WeightedAllocationItem[string]{
+				{Key: "A", Weight: dec("0.001")},
+				{Key: "B", Weight: dec("0.002")},
+			},
+		})
+		require.NoError(t, err)
+
+		requireAllocationsEqual(t, []currencyx.WeightedAllocation[string]{
+			{Key: "A", Amount: dec("0.33")},
+			{Key: "B", Amount: dec("0.67")},
+		}, allocations)
+	})
+}
+
+func TestAllocateByAmount(t *testing.T) {
+	usd := testCalculator(t, "USD")
+
+	t.Run("allocates exact proportional shares", func(t *testing.T) {
+		allocations, err := currencyx.AllocateByAmount(usd, currencyx.AmountAllocationInput[string]{
+			Amount: dec("6.00"),
+			Items: []currencyx.AmountAllocationItem[string]{
+				{Key: "A", Amount: dec("10.00")},
+				{Key: "B", Amount: dec("5.00")},
+			},
+		})
+		require.NoError(t, err)
+
+		requireAmountAllocationsEqual(t, []currencyx.AmountAllocation[string]{
+			{Key: "A", Amount: dec("4.00")},
+			{Key: "B", Amount: dec("2.00")},
+		}, allocations)
+	})
+
+	t.Run("allocates rounded shares by largest remainder", func(t *testing.T) {
+		allocations, err := currencyx.AllocateByAmount(usd, currencyx.AmountAllocationInput[string]{
+			Amount: dec("5.00"),
+			Items: []currencyx.AmountAllocationItem[string]{
+				{Key: "A", Amount: dec("10.00")},
+				{Key: "B", Amount: dec("5.00")},
+			},
+		})
+		require.NoError(t, err)
+
+		requireAmountAllocationsEqual(t, []currencyx.AmountAllocation[string]{
+			{Key: "A", Amount: dec("3.33")},
+			{Key: "B", Amount: dec("1.67")},
+		}, allocations)
+	})
+
+	t.Run("uses key comparator as deterministic remainder tie-breaker", func(t *testing.T) {
+		allocations, err := currencyx.AllocateByAmount(usd, currencyx.AmountAllocationInput[string]{
+			Amount: dec("0.05"),
+			Items: []currencyx.AmountAllocationItem[string]{
+				{Key: "C", Amount: dec("1.00")},
+				{Key: "A", Amount: dec("1.00")},
+				{Key: "B", Amount: dec("1.00")},
+			},
+			CompareKey: cmp.Compare[string],
+		})
+		require.NoError(t, err)
+
+		requireAmountAllocationsEqual(t, []currencyx.AmountAllocation[string]{
+			{Key: "C", Amount: dec("0.01")},
+			{Key: "A", Amount: dec("0.03")},
+			{Key: "B", Amount: dec("0.01")},
+		}, allocations)
+	})
+
+	t.Run("uses currency precision", func(t *testing.T) {
+		jpy := testCalculator(t, "JPY")
+
+		allocations, err := currencyx.AllocateByAmount(jpy, currencyx.AmountAllocationInput[string]{
+			Amount: dec("5"),
+			Items: []currencyx.AmountAllocationItem[string]{
+				{Key: "A", Amount: dec("10")},
+				{Key: "B", Amount: dec("10")},
+				{Key: "C", Amount: dec("10")},
+			},
+		})
+		require.NoError(t, err)
+
+		requireAmountAllocationsEqual(t, []currencyx.AmountAllocation[string]{
+			{Key: "A", Amount: dec("3")},
+			{Key: "B", Amount: dec("1")},
+			{Key: "C", Amount: dec("1")},
+		}, allocations)
+	})
+
+	t.Run("omits zero allocations", func(t *testing.T) {
+		allocations, err := currencyx.AllocateByAmount(usd, currencyx.AmountAllocationInput[string]{
+			Amount: dec("0.01"),
+			Items: []currencyx.AmountAllocationItem[string]{
+				{Key: "A", Amount: dec("100.00")},
+				{Key: "B", Amount: dec("1.00")},
+			},
+		})
+		require.NoError(t, err)
+
+		requireAmountAllocationsEqual(t, []currencyx.AmountAllocation[string]{
+			{Key: "A", Amount: dec("0.01")},
+		}, allocations)
+	})
+}
+
+func TestAllocateByAmountValidation(t *testing.T) {
+	usd := testCalculator(t, "USD")
+
+	cases := []struct {
+		name     string
+		input    currencyx.AmountAllocationInput[string]
+		contains string
+	}{
+		{
+			name: "amount must be rounded",
+			input: currencyx.AmountAllocationInput[string]{
+				Amount: dec("1.001"),
+				Items: []currencyx.AmountAllocationItem[string]{
+					{Key: "A", Amount: dec("2.00")},
+				},
+			},
+			contains: "amount must be rounded to currency precision",
+		},
+		{
+			name: "item amount must be positive",
+			input: currencyx.AmountAllocationInput[string]{
+				Amount: dec("1.00"),
+				Items: []currencyx.AmountAllocationItem[string]{
+					{Key: "A", Amount: dec("0.00")},
+				},
+			},
+			contains: "items[0].amount must be positive",
+		},
+		{
+			name: "item amount must be rounded",
+			input: currencyx.AmountAllocationInput[string]{
+				Amount: dec("1.00"),
+				Items: []currencyx.AmountAllocationItem[string]{
+					{Key: "A", Amount: dec("2.001")},
+				},
+			},
+			contains: "items[0].amount must be rounded to currency precision",
+		},
+		{
+			name: "amount must not exceed total item amount",
+			input: currencyx.AmountAllocationInput[string]{
+				Amount: dec("3.00"),
+				Items: []currencyx.AmountAllocationItem[string]{
+					{Key: "A", Amount: dec("2.00")},
+				},
+			},
+			contains: "amount must not exceed total item amount",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := currencyx.AllocateByAmount(usd, tc.input)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.contains)
+		})
+	}
+
+	t.Run("zero amount does not require items", func(t *testing.T) {
+		allocations, err := currencyx.AllocateByAmount(usd, currencyx.AmountAllocationInput[string]{
+			Amount: dec("0.00"),
+		})
+		require.NoError(t, err)
+		require.Empty(t, allocations)
+	})
+}
+
+func testCalculator(t *testing.T, code string) currencyx.Calculator {
+	t.Helper()
+
+	calculator, err := currencyx.Code(code).Calculator()
+	require.NoError(t, err)
+
+	return calculator
+}
+
+func requireAllocationsEqual[T comparable](t *testing.T, expected, actual []currencyx.WeightedAllocation[T]) {
+	t.Helper()
+
+	require.Len(t, actual, len(expected))
+	for i, expectedAllocation := range expected {
+		require.Equal(t, expectedAllocation.Key, actual[i].Key)
+		require.Truef(
+			t,
+			expectedAllocation.Amount.Equal(actual[i].Amount),
+			"expected allocation %d amount %s, got %s",
+			i,
+			expectedAllocation.Amount.String(),
+			actual[i].Amount.String(),
+		)
+	}
+}
+
+func requireAmountAllocationsEqual[T comparable](t *testing.T, expected, actual []currencyx.AmountAllocation[T]) {
+	t.Helper()
+
+	require.Len(t, actual, len(expected))
+	for i, expectedAllocation := range expected {
+		require.Equal(t, expectedAllocation.Key, actual[i].Key)
+		require.Truef(
+			t,
+			expectedAllocation.Amount.Equal(actual[i].Amount),
+			"expected allocation %d amount %s, got %s",
+			i,
+			expectedAllocation.Amount.String(),
+			actual[i].Amount.String(),
+		)
+	}
+}
+
+func dec(value string) alpacadecimal.Decimal {
+	return alpacadecimal.RequireFromString(strings.TrimSpace(value))
+}

--- a/pkg/currencyx/allocation_test.go
+++ b/pkg/currencyx/allocation_test.go
@@ -244,8 +244,8 @@ func TestAllocateByAmount(t *testing.T) {
 
 		requireAmountAllocationsEqual(t, []currencyx.AmountAllocation[string]{
 			{Key: "C", Amount: dec("0.01")},
-			{Key: "A", Amount: dec("0.03")},
-			{Key: "B", Amount: dec("0.01")},
+			{Key: "A", Amount: dec("0.02")},
+			{Key: "B", Amount: dec("0.02")},
 		}, allocations)
 	})
 
@@ -263,8 +263,8 @@ func TestAllocateByAmount(t *testing.T) {
 		require.NoError(t, err)
 
 		requireAmountAllocationsEqual(t, []currencyx.AmountAllocation[string]{
-			{Key: "A", Amount: dec("3")},
-			{Key: "B", Amount: dec("1")},
+			{Key: "A", Amount: dec("2")},
+			{Key: "B", Amount: dec("2")},
 			{Key: "C", Amount: dec("1")},
 		}, allocations)
 	})

--- a/test/credits/base.go
+++ b/test/credits/base.go
@@ -22,12 +22,6 @@ import (
 	chargestestutils "github.com/openmeterio/openmeter/openmeter/billing/charges/testutils"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/customer"
-	ledgeraccountdb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgeraccount"
-	ledgerentrydb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgerentry"
-	ledgersubaccountdb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgersubaccount"
-	ledgersubaccountroutedb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgersubaccountroute"
-	ledgertransactiondb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransaction"
-	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	ledgeraccount "github.com/openmeterio/openmeter/openmeter/ledger/account"
@@ -328,69 +322,6 @@ func (s *BaseSuite) MustCustomerFBOBalanceWithPriorityAsOf(customerID customer.C
 	return balance.Settled()
 }
 
-// MustCustomerFBOBalanceForTaxCode returns customer FBO balance filtered by cost basis and tax code.
-// Pass mo.None() for all tax codes, mo.Some(nil) for nil-TaxCode routes, or mo.Some(&id) for one TaxCode.
-func (s *BaseSuite) MustCustomerFBOBalanceForTaxCode(customerID customer.CustomerID, code currencyx.Code, costBasis mo.Option[*alpacadecimal.Decimal], taxCode mo.Option[*string]) alpacadecimal.Decimal {
-	s.T().Helper()
-
-	customerAccounts, err := s.LedgerResolver.GetCustomerAccounts(s.T().Context(), customerID)
-	s.NoError(err)
-
-	balance, err := s.BalanceQuerier.GetAccountBalance(s.T().Context(), customerAccounts.FBOAccount, ledger.RouteFilter{
-		Currency:       code,
-		CostBasis:      costBasis,
-		TaxCode:        taxCode,
-		CreditPriority: lo.ToPtr(ledger.DefaultCustomerFBOPriority),
-	}, ledger.BalanceQuery{})
-	s.NoError(err)
-
-	return balance.Settled()
-}
-
-// MustCustomerFBOBalanceForTaxConfig returns customer FBO balance filtered by cost basis,
-// tax code, and tax behavior.
-func (s *BaseSuite) MustCustomerFBOBalanceForTaxConfig(customerID customer.CustomerID, code currencyx.Code, costBasis mo.Option[*alpacadecimal.Decimal], taxCode mo.Option[*string], taxBehavior mo.Option[*ledger.TaxBehavior]) alpacadecimal.Decimal {
-	s.T().Helper()
-
-	customerAccounts, err := s.LedgerResolver.GetCustomerAccounts(s.T().Context(), customerID)
-	s.NoError(err)
-
-	balance, err := s.BalanceQuerier.GetAccountBalance(s.T().Context(), customerAccounts.FBOAccount, ledger.RouteFilter{
-		Currency:       code,
-		CostBasis:      costBasis,
-		TaxCode:        taxCode,
-		TaxBehavior:    taxBehavior,
-		CreditPriority: lo.ToPtr(ledger.DefaultCustomerFBOPriority),
-	}, ledger.BalanceQuery{})
-	s.NoError(err)
-
-	return balance.Settled()
-}
-
-func (s *BaseSuite) MustFBOEntryCountForTaxBehavior(transactionGroupID string, taxBehavior *ledger.TaxBehavior) int {
-	s.T().Helper()
-
-	routePredicates := []predicate.LedgerSubAccountRoute{}
-	if taxBehavior == nil {
-		routePredicates = append(routePredicates, ledgersubaccountroutedb.TaxBehaviorIsNil())
-	} else {
-		routePredicates = append(routePredicates, ledgersubaccountroutedb.TaxBehavior(*taxBehavior))
-	}
-
-	count, err := s.DBClient.LedgerEntry.Query().
-		Where(
-			ledgerentrydb.HasTransactionWith(ledgertransactiondb.GroupID(transactionGroupID)),
-			ledgerentrydb.HasSubAccountWith(
-				ledgersubaccountdb.HasAccountWith(ledgeraccountdb.AccountType(ledger.AccountTypeCustomerFBO)),
-				ledgersubaccountdb.HasRouteWith(routePredicates...),
-			),
-		).
-		Count(s.T().Context())
-	s.NoError(err)
-
-	return count
-}
-
 // MustCustomerReceivableBalance returns customer receivable balance in a currency
 // for one authorization state. Pass mo.None() for all cost bases, mo.Some(nil)
 // for the explicit nil-cost-basis route, or mo.Some(&costBasis) for one concrete route.
@@ -440,6 +371,25 @@ func (s *BaseSuite) MustCustomerAccruedBalanceForTaxCode(customerID customer.Cus
 		Currency:  code,
 		CostBasis: costBasis,
 		TaxCode:   taxCode,
+	}, ledger.BalanceQuery{})
+	s.NoError(err)
+
+	return balance.Settled()
+}
+
+// MustCustomerAccruedBalanceForTaxConfig returns accrued balance filtered by
+// cost basis, tax code, and tax behavior.
+func (s *BaseSuite) MustCustomerAccruedBalanceForTaxConfig(customerID customer.CustomerID, code currencyx.Code, costBasis mo.Option[*alpacadecimal.Decimal], taxCode mo.Option[*string], taxBehavior mo.Option[*ledger.TaxBehavior]) alpacadecimal.Decimal {
+	s.T().Helper()
+
+	customerAccounts, err := s.LedgerResolver.GetCustomerAccounts(s.T().Context(), customerID)
+	s.NoError(err)
+
+	balance, err := s.BalanceQuerier.GetAccountBalance(s.T().Context(), customerAccounts.AccruedAccount, ledger.RouteFilter{
+		Currency:    code,
+		CostBasis:   costBasis,
+		TaxCode:     taxCode,
+		TaxBehavior: taxBehavior,
 	}, ledger.BalanceQuery{})
 	s.NoError(err)
 

--- a/test/credits/base.go
+++ b/test/credits/base.go
@@ -185,6 +185,7 @@ type CreateMockChargeIntentInput struct {
 	ManagedBy         billing.InvoiceLineManagedBy
 	UniqueReferenceID string
 	ProRating         productcatalog.ProRatingConfig
+	TaxConfig         *productcatalog.TaxCodeConfig
 }
 
 func (i *CreateMockChargeIntentInput) Validate() error {
@@ -237,6 +238,7 @@ func (s *BaseSuite) CreateMockChargeIntent(input CreateMockChargeIntentInput) ch
 		UniqueReferenceID: lo.EmptyableToPtr(input.UniqueReferenceID),
 		CustomerID:        input.Customer.ID,
 		Currency:          input.Currency,
+		TaxConfig:         input.TaxConfig,
 	}
 
 	if isFlatFee {
@@ -320,6 +322,25 @@ func (s *BaseSuite) MustCustomerFBOBalanceWithPriorityAsOf(customerID customer.C
 	return balance.Settled()
 }
 
+// MustCustomerFBOBalanceForTaxCode returns customer FBO balance filtered by cost basis and tax code.
+// Pass mo.None() for all tax codes, mo.Some(nil) for nil-TaxCode routes, or mo.Some(&id) for one TaxCode.
+func (s *BaseSuite) MustCustomerFBOBalanceForTaxCode(customerID customer.CustomerID, code currencyx.Code, costBasis mo.Option[*alpacadecimal.Decimal], taxCode mo.Option[*string]) alpacadecimal.Decimal {
+	s.T().Helper()
+
+	customerAccounts, err := s.LedgerResolver.GetCustomerAccounts(s.T().Context(), customerID)
+	s.NoError(err)
+
+	balance, err := s.BalanceQuerier.GetAccountBalance(s.T().Context(), customerAccounts.FBOAccount, ledger.RouteFilter{
+		Currency:       code,
+		CostBasis:      costBasis,
+		TaxCode:        taxCode,
+		CreditPriority: lo.ToPtr(ledger.DefaultCustomerFBOPriority),
+	}, nil)
+	s.NoError(err)
+
+	return balance.Settled()
+}
+
 // MustCustomerReceivableBalance returns customer receivable balance in a currency
 // for one authorization state. Pass mo.None() for all cost bases, mo.Some(nil)
 // for the explicit nil-cost-basis route, or mo.Some(&costBasis) for one concrete route.
@@ -334,6 +355,42 @@ func (s *BaseSuite) MustCustomerReceivableBalance(customerID customer.CustomerID
 		CostBasis:                      costBasis,
 		TransactionAuthorizationStatus: lo.ToPtr(status),
 	}, ledger.BalanceQuery{})
+	s.NoError(err)
+
+	return balance.Settled()
+}
+
+// MustCustomerReceivableBalanceForTaxCode returns customer receivable balance filtered by
+// cost basis, authorization status, and tax code.
+func (s *BaseSuite) MustCustomerReceivableBalanceForTaxCode(customerID customer.CustomerID, code currencyx.Code, costBasis mo.Option[*alpacadecimal.Decimal], status ledger.TransactionAuthorizationStatus, taxCode mo.Option[*string]) alpacadecimal.Decimal {
+	s.T().Helper()
+
+	customerAccounts, err := s.LedgerResolver.GetCustomerAccounts(s.T().Context(), customerID)
+	s.NoError(err)
+
+	balance, err := s.BalanceQuerier.GetAccountBalance(s.T().Context(), customerAccounts.ReceivableAccount, ledger.RouteFilter{
+		Currency:                       code,
+		CostBasis:                      costBasis,
+		TaxCode:                        taxCode,
+		TransactionAuthorizationStatus: lo.ToPtr(status),
+	}, nil)
+	s.NoError(err)
+
+	return balance.Settled()
+}
+
+// MustCustomerAccruedBalanceForTaxCode returns accrued balance filtered by cost basis and tax code.
+func (s *BaseSuite) MustCustomerAccruedBalanceForTaxCode(customerID customer.CustomerID, code currencyx.Code, costBasis mo.Option[*alpacadecimal.Decimal], taxCode mo.Option[*string]) alpacadecimal.Decimal {
+	s.T().Helper()
+
+	customerAccounts, err := s.LedgerResolver.GetCustomerAccounts(s.T().Context(), customerID)
+	s.NoError(err)
+
+	balance, err := s.BalanceQuerier.GetAccountBalance(s.T().Context(), customerAccounts.AccruedAccount, ledger.RouteFilter{
+		Currency:  code,
+		CostBasis: costBasis,
+		TaxCode:   taxCode,
+	}, nil)
 	s.NoError(err)
 
 	return balance.Settled()
@@ -407,6 +464,23 @@ func (s *BaseSuite) MustBreakageBalanceAsOf(namespace string, code currencyx.Cod
 		Currency:  code,
 		CostBasis: costBasis,
 	}, ledger.BalanceQuery{AsOf: &asOf})
+	s.NoError(err)
+
+	return balance.Settled()
+}
+
+// MustEarningsBalanceForTaxCode returns earnings balance filtered by both cost basis and tax code.
+func (s *BaseSuite) MustEarningsBalanceForTaxCode(namespace string, code currencyx.Code, costBasis mo.Option[*alpacadecimal.Decimal], taxCode mo.Option[*string]) alpacadecimal.Decimal {
+	s.T().Helper()
+
+	businessAccounts, err := s.LedgerResolver.GetBusinessAccounts(s.T().Context(), namespace)
+	s.NoError(err)
+
+	balance, err := s.BalanceQuerier.GetAccountBalance(s.T().Context(), businessAccounts.EarningsAccount, ledger.RouteFilter{
+		Currency:  code,
+		CostBasis: costBasis,
+		TaxCode:   taxCode,
+	}, nil)
 	s.NoError(err)
 
 	return balance.Settled()
@@ -491,6 +565,7 @@ type CreateCreditPurchaseIntentInput struct {
 	Priority      *int
 	ServicePeriod timeutil.ClosedPeriod
 	Settlement    creditpurchase.Settlement
+	TaxConfig     *productcatalog.TaxCodeConfig
 }
 
 func (i CreateCreditPurchaseIntentInput) Validate() error {
@@ -530,6 +605,7 @@ func (s *BaseSuite) CreateCreditPurchaseIntent(input CreateCreditPurchaseIntentI
 			ServicePeriod:     input.ServicePeriod,
 			BillingPeriod:     input.ServicePeriod,
 			FullServicePeriod: input.ServicePeriod,
+			TaxConfig:         input.TaxConfig,
 		},
 		CreditAmount: input.Amount,
 		EffectiveAt:  input.EffectiveAt,
@@ -547,6 +623,7 @@ type CreatePromotionalCreditFundingInput struct {
 	ExpiresAt *time.Time
 	CostBasis alpacadecimal.Decimal
 	Priority  *int
+	TaxConfig *productcatalog.TaxCodeConfig
 }
 
 type CreatePromotionalCreditFundingResult struct {
@@ -568,6 +645,7 @@ func (s *BaseSuite) CreatePromotionalCreditFunding(ctx context.Context, input Cr
 				Priority:      input.Priority,
 				ServicePeriod: timeutil.ClosedPeriod{From: input.At, To: input.At},
 				Settlement:    creditpurchase.NewSettlement(creditpurchase.PromotionalSettlement{}),
+				TaxConfig:     input.TaxConfig,
 			}),
 		},
 	})

--- a/test/credits/base.go
+++ b/test/credits/base.go
@@ -341,7 +341,7 @@ func (s *BaseSuite) MustCustomerFBOBalanceForTaxCode(customerID customer.Custome
 		CostBasis:      costBasis,
 		TaxCode:        taxCode,
 		CreditPriority: lo.ToPtr(ledger.DefaultCustomerFBOPriority),
-	}, nil)
+	}, ledger.BalanceQuery{})
 	s.NoError(err)
 
 	return balance.Settled()
@@ -361,7 +361,7 @@ func (s *BaseSuite) MustCustomerFBOBalanceForTaxConfig(customerID customer.Custo
 		TaxCode:        taxCode,
 		TaxBehavior:    taxBehavior,
 		CreditPriority: lo.ToPtr(ledger.DefaultCustomerFBOPriority),
-	}, nil)
+	}, ledger.BalanceQuery{})
 	s.NoError(err)
 
 	return balance.Settled()
@@ -423,7 +423,7 @@ func (s *BaseSuite) MustCustomerReceivableBalanceForTaxCode(customerID customer.
 		CostBasis:                      costBasis,
 		TaxCode:                        taxCode,
 		TransactionAuthorizationStatus: lo.ToPtr(status),
-	}, nil)
+	}, ledger.BalanceQuery{})
 	s.NoError(err)
 
 	return balance.Settled()
@@ -440,7 +440,7 @@ func (s *BaseSuite) MustCustomerAccruedBalanceForTaxCode(customerID customer.Cus
 		Currency:  code,
 		CostBasis: costBasis,
 		TaxCode:   taxCode,
-	}, nil)
+	}, ledger.BalanceQuery{})
 	s.NoError(err)
 
 	return balance.Settled()
@@ -530,7 +530,7 @@ func (s *BaseSuite) MustEarningsBalanceForTaxCode(namespace string, code currenc
 		Currency:  code,
 		CostBasis: costBasis,
 		TaxCode:   taxCode,
-	}, nil)
+	}, ledger.BalanceQuery{})
 	s.NoError(err)
 
 	return balance.Settled()

--- a/test/credits/base.go
+++ b/test/credits/base.go
@@ -22,6 +22,12 @@ import (
 	chargestestutils "github.com/openmeterio/openmeter/openmeter/billing/charges/testutils"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	ledgeraccountdb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgeraccount"
+	ledgerentrydb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgerentry"
+	ledgersubaccountdb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgersubaccount"
+	ledgersubaccountroutedb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgersubaccountroute"
+	ledgertransactiondb "github.com/openmeterio/openmeter/openmeter/ent/db/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	ledgeraccount "github.com/openmeterio/openmeter/openmeter/ledger/account"
@@ -339,6 +345,50 @@ func (s *BaseSuite) MustCustomerFBOBalanceForTaxCode(customerID customer.Custome
 	s.NoError(err)
 
 	return balance.Settled()
+}
+
+// MustCustomerFBOBalanceForTaxConfig returns customer FBO balance filtered by cost basis,
+// tax code, and tax behavior.
+func (s *BaseSuite) MustCustomerFBOBalanceForTaxConfig(customerID customer.CustomerID, code currencyx.Code, costBasis mo.Option[*alpacadecimal.Decimal], taxCode mo.Option[*string], taxBehavior mo.Option[*ledger.TaxBehavior]) alpacadecimal.Decimal {
+	s.T().Helper()
+
+	customerAccounts, err := s.LedgerResolver.GetCustomerAccounts(s.T().Context(), customerID)
+	s.NoError(err)
+
+	balance, err := s.BalanceQuerier.GetAccountBalance(s.T().Context(), customerAccounts.FBOAccount, ledger.RouteFilter{
+		Currency:       code,
+		CostBasis:      costBasis,
+		TaxCode:        taxCode,
+		TaxBehavior:    taxBehavior,
+		CreditPriority: lo.ToPtr(ledger.DefaultCustomerFBOPriority),
+	}, nil)
+	s.NoError(err)
+
+	return balance.Settled()
+}
+
+func (s *BaseSuite) MustFBOEntryCountForTaxBehavior(transactionGroupID string, taxBehavior *ledger.TaxBehavior) int {
+	s.T().Helper()
+
+	routePredicates := []predicate.LedgerSubAccountRoute{}
+	if taxBehavior == nil {
+		routePredicates = append(routePredicates, ledgersubaccountroutedb.TaxBehaviorIsNil())
+	} else {
+		routePredicates = append(routePredicates, ledgersubaccountroutedb.TaxBehavior(*taxBehavior))
+	}
+
+	count, err := s.DBClient.LedgerEntry.Query().
+		Where(
+			ledgerentrydb.HasTransactionWith(ledgertransactiondb.GroupID(transactionGroupID)),
+			ledgerentrydb.HasSubAccountWith(
+				ledgersubaccountdb.HasAccountWith(ledgeraccountdb.AccountType(ledger.AccountTypeCustomerFBO)),
+				ledgersubaccountdb.HasRouteWith(routePredicates...),
+			),
+		).
+		Count(s.T().Context())
+	s.NoError(err)
+
+	return count
 }
 
 // MustCustomerReceivableBalance returns customer receivable balance in a currency

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -2697,7 +2697,7 @@ func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets()
 	s.NoError(err)
 
 	// then:
-	// - partial attribution chooses the first TaxCode/TaxBehavior bucket deterministically
+	// - partial attribution is split proportionally across TaxCode/TaxBehavior buckets
 	// - the purchased grant is fully consumed by advance backfill
 	templateCounts := map[string]int{}
 	for _, tx := range backingGroup.Transactions() {
@@ -2706,27 +2706,17 @@ func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets()
 		templateCounts[code]++
 	}
 
-	s.Equal(1, templateCounts[transactions.TemplateCode(transactions.AttributeCustomerAdvanceReceivableCostBasisTemplate{})])
-	s.Equal(1, templateCounts[transactions.TemplateCode(transactions.TranslateCustomerAccruedCostBasisTemplate{})])
+	s.Equal(2, templateCounts[transactions.TemplateCode(transactions.AttributeCustomerAdvanceReceivableCostBasisTemplate{})])
+	s.Equal(2, templateCounts[transactions.TemplateCode(transactions.TranslateCustomerAccruedCostBasisTemplate{})])
 	s.Equal(0, templateCounts[transactions.TemplateCode(transactions.IssueCustomerReceivableTemplate{})])
 
-	expectedBackfilledTaxID := taxA.ID
-	expectedBackfilledBehavior := taxABehavior
-	expectedRemainingTaxA := float64(5)
-	expectedRemainingTaxB := float64(5)
-	if taxB.ID < taxA.ID {
-		expectedBackfilledTaxID = taxB.ID
-		expectedBackfilledBehavior = taxBBehavior
-		expectedRemainingTaxA = float64(10)
-		expectedRemainingTaxB = float64(0)
-	}
-
 	s.Equal(float64(-10), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen).InexactFloat64())
-	s.Equal(float64(purchaseAmount), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&expectedBackfilledTaxID), mo.Some(&expectedBackfilledBehavior)).InexactFloat64())
+	s.Equal(float64(3.33), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxA.ID), mo.Some(&taxABehavior)).InexactFloat64())
+	s.Equal(float64(1.67), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxB.ID), mo.Some(&taxBBehavior)).InexactFloat64())
 	s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxA.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
 	s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxB.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
-	s.Equal(expectedRemainingTaxA, s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&taxA.ID), mo.Some(&taxABehavior)).InexactFloat64())
-	s.Equal(expectedRemainingTaxB, s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&taxB.ID), mo.Some(&taxBBehavior)).InexactFloat64())
+	s.Equal(float64(6.67), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&taxA.ID), mo.Some(&taxABehavior)).InexactFloat64())
+	s.Equal(float64(3.33), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&taxB.ID), mo.Some(&taxBBehavior)).InexactFloat64())
 	s.Equal(float64(0), s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&purchaseCostBasis), ledger.DefaultCustomerFBOPriority).InexactFloat64())
 }
 

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -24,6 +24,7 @@ import (
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	dbledgerbreakagerecord "github.com/openmeterio/openmeter/openmeter/ent/db/ledgerbreakagerecord"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
@@ -2562,6 +2563,150 @@ func (s *SanitySuite) TestFlatFeeCreditOnlySanity() {
 	})
 }
 
+func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("credit-purchase-multi-taxcode-advance")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	taxA, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "txcd-40000007",
+		Name:      "Advance Tax Code A",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000007"},
+		},
+	})
+	s.Require().NoError(err)
+
+	taxB, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "txcd-40000008",
+		Name:      "Advance Tax Code B",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000008"},
+		},
+	})
+	s.Require().NoError(err)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.SetTime(servicePeriod.From.Add(-time.Hour))
+	defer clock.UnFreeze()
+
+	// given:
+	// - credit-only charges create advance receivable and accrued exposure in two TaxCode buckets
+	for _, input := range []struct {
+		name   string
+		amount int64
+		taxID  string
+	}{
+		{name: "tax-a-advance", amount: 10, taxID: taxA.ID},
+		{name: "tax-b-advance", amount: 5, taxID: taxB.ID},
+	} {
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditOnlySettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(input.amount),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					Name:              input.name,
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: input.name,
+					TaxConfig:         &productcatalog.TaxCodeConfig{TaxCodeID: &input.taxID},
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+	}
+
+	clock.FreezeTime(servicePeriod.From)
+	advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+		Customer: cust.GetID(),
+	})
+	s.NoError(err)
+	s.Len(advancedCharges, 2)
+
+	s.Equal(float64(-10), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen, mo.Some(&taxA.ID)).InexactFloat64())
+	s.Equal(float64(-5), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen, mo.Some(&taxB.ID)).InexactFloat64())
+	s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&taxA.ID)).InexactFloat64())
+	s.Equal(float64(5), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&taxB.ID)).InexactFloat64())
+
+	// when:
+	// - a larger purchased grant backfills both advance buckets
+	purchaseCostBasis := alpacadecimal.NewFromFloat(0.5)
+	purchaseAt := servicePeriod.From.Add(time.Hour)
+	clock.FreezeTime(purchaseAt)
+	purchaseRes, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateCreditPurchaseIntent(CreateCreditPurchaseIntentInput{
+				Customer: cust.GetID(),
+				Currency: USD,
+				Amount:   alpacadecimal.NewFromInt(20),
+				ServicePeriod: timeutil.ClosedPeriod{
+					From: purchaseAt,
+					To:   purchaseAt,
+				},
+				Settlement: creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{
+					GenericSettlement: creditpurchase.GenericSettlement{
+						Currency:  USD,
+						CostBasis: purchaseCostBasis,
+					},
+					InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
+				}),
+				TaxConfig: &productcatalog.TaxCodeConfig{TaxCodeID: &taxA.ID},
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Len(purchaseRes, 1)
+
+	purchase, err := purchaseRes[0].AsCreditPurchaseCharge()
+	s.NoError(err)
+	backingGroup, err := s.Ledger.GetTransactionGroup(ctx, models.NamespacedID{
+		Namespace: ns,
+		ID:        purchase.Realizations.CreditGrantRealization.TransactionGroupID,
+	})
+	s.NoError(err)
+
+	// then:
+	// - attribution and accrued translation stay split by source TaxCode
+	// - only the purchased remainder is newly issued
+	templateCounts := map[string]int{}
+	for _, tx := range backingGroup.Transactions() {
+		code, err := ledger.TransactionTemplateCodeFromAnnotations(tx.Annotations())
+		s.NoError(err)
+		templateCounts[code]++
+	}
+
+	s.Equal(2, templateCounts[transactions.TemplateCode(transactions.AttributeCustomerAdvanceReceivableCostBasisTemplate{})])
+	s.Equal(2, templateCounts[transactions.TemplateCode(transactions.TranslateCustomerAccruedCostBasisTemplate{})])
+	s.Equal(1, templateCounts[transactions.TemplateCode(transactions.IssueCustomerReceivableTemplate{})])
+
+	s.Equal(float64(0), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen, mo.Some(&taxA.ID)).InexactFloat64())
+	s.Equal(float64(0), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen, mo.Some(&taxB.ID)).InexactFloat64())
+	s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxA.ID)).InexactFloat64())
+	s.Equal(float64(5), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxB.ID)).InexactFloat64())
+	s.Equal(float64(5), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxA.ID)).InexactFloat64())
+}
+
 // TestTaxCodeFlowsFromCreditPurchaseToEarnings verifies the end-to-end routing of
 // TaxCode: credit purchase → FBO sub-account → accrued → earnings.
 // Credits funded with a TaxCode must land in a TaxCode-keyed earnings sub-account
@@ -2569,6 +2714,7 @@ func (s *SanitySuite) TestFlatFeeCreditOnlySanity() {
 func (s *SanitySuite) TestTaxCodeFlowsFromCreditPurchaseToEarnings() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("taxcode-earnings-flow")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -2607,12 +2607,13 @@ func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets()
 	// given:
 	// - credit-only charges create advance receivable and accrued exposure in two TaxCode buckets
 	for _, input := range []struct {
-		name   string
-		amount int64
-		taxID  string
+		name     string
+		amount   int64
+		taxID    string
+		behavior productcatalog.TaxBehavior
 	}{
-		{name: "tax-a-advance", amount: 10, taxID: taxA.ID},
-		{name: "tax-b-advance", amount: 5, taxID: taxB.ID},
+		{name: "tax-a-advance", amount: 10, taxID: taxA.ID, behavior: productcatalog.InclusiveTaxBehavior},
+		{name: "tax-b-advance", amount: 5, taxID: taxB.ID, behavior: productcatalog.ExclusiveTaxBehavior},
 	} {
 		res, err := s.Charges.Create(ctx, charges.CreateInput{
 			Namespace: ns,
@@ -2629,7 +2630,10 @@ func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets()
 					Name:              input.name,
 					ManagedBy:         billing.SubscriptionManagedLine,
 					UniqueReferenceID: input.name,
-					TaxConfig:         &productcatalog.TaxCodeConfig{TaxCodeID: &input.taxID},
+					TaxConfig: &productcatalog.TaxCodeConfig{
+						TaxCodeID: &input.taxID,
+						Behavior:  lo.ToPtr(input.behavior),
+					},
 				}),
 			},
 		})
@@ -2644,10 +2648,11 @@ func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets()
 	s.NoError(err)
 	s.Len(advancedCharges, 2)
 
-	s.Equal(float64(-10), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen, mo.Some(&taxA.ID)).InexactFloat64())
-	s.Equal(float64(-5), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen, mo.Some(&taxB.ID)).InexactFloat64())
-	s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&taxA.ID)).InexactFloat64())
-	s.Equal(float64(5), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&taxB.ID)).InexactFloat64())
+	taxABehavior := ledger.TaxBehaviorInclusive
+	taxBBehavior := ledger.TaxBehaviorExclusive
+	s.Equal(float64(-15), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen).InexactFloat64())
+	s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&taxA.ID), mo.Some(&taxABehavior)).InexactFloat64())
+	s.Equal(float64(5), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&taxB.ID), mo.Some(&taxBBehavior)).InexactFloat64())
 
 	// when:
 	// - a larger purchased grant backfills both advance buckets
@@ -2672,7 +2677,10 @@ func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets()
 					},
 					InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
 				}),
-				TaxConfig: &productcatalog.TaxCodeConfig{TaxCodeID: &taxA.ID},
+				TaxConfig: &productcatalog.TaxCodeConfig{
+					TaxCodeID: &taxA.ID,
+					Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+				},
 			}),
 		},
 	})
@@ -2701,10 +2709,11 @@ func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets()
 	s.Equal(2, templateCounts[transactions.TemplateCode(transactions.TranslateCustomerAccruedCostBasisTemplate{})])
 	s.Equal(1, templateCounts[transactions.TemplateCode(transactions.IssueCustomerReceivableTemplate{})])
 
-	s.Equal(float64(0), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen, mo.Some(&taxA.ID)).InexactFloat64())
-	s.Equal(float64(0), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen, mo.Some(&taxB.ID)).InexactFloat64())
-	s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxA.ID)).InexactFloat64())
-	s.Equal(float64(5), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxB.ID)).InexactFloat64())
+	s.Equal(float64(0), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen).InexactFloat64())
+	s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxA.ID), mo.Some(&taxABehavior)).InexactFloat64())
+	s.Equal(float64(5), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxB.ID), mo.Some(&taxBBehavior)).InexactFloat64())
+	s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxA.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
+	s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxB.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
 	s.Equal(float64(5), s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&purchaseCostBasis), ledger.DefaultCustomerFBOPriority).InexactFloat64())
 }
 
@@ -2784,13 +2793,16 @@ func (s *SanitySuite) TestFlatFeeCreditOnlyTaxConfigFlowsToEarnings() {
 	s.Require().NotNil(advancedCharge.Realizations.CurrentRun)
 	s.Len(advancedCharge.Realizations.CurrentRun.CreditRealizations, 1)
 
+	costBasis := alpacadecimal.Zero
+	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
+	s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&costBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
+	s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&costBasis), mo.Some(&tc.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
+
 	clock.FreezeTime(servicePeriod.To)
 	s.MustRecognizeRevenue(cust.GetID(), USD, alpacadecimal.NewFromInt(amount))
 
 	// then:
 	// - earnings keep the full tax route expected by the charge
-	costBasis := alpacadecimal.Zero
-	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
 	s.Equal(float64(amount), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&costBasis), mo.Some(&tc.ID)).InexactFloat64())
 	s.Equal(float64(0), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&costBasis), mo.Some[*string](nil)).InexactFloat64())
 	s.Equal(float64(amount), s.mustEarningsBalanceForTaxConfig(ns, USD, mo.Some(&costBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
@@ -2882,12 +2894,15 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceTaxConfigFlowsToEarnings() {
 	s.Equal(flatfee.StatusFinal, finalCharge.Status)
 	s.requireChargeTaxConfig(finalCharge.Intent.TaxConfig, tc.ID, productcatalog.InclusiveTaxBehavior)
 
+	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
+	s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
+	s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
+
 	clock.FreezeTime(servicePeriod.To)
 	s.mustRecognizeAttributableAccrued(cust.GetID(), USD, alpacadecimal.NewFromInt(amount))
 
 	// then:
 	// - earnings keep the full tax route expected by the charge
-	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
 	s.Equal(float64(amount), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID)).InexactFloat64())
 	s.Equal(float64(0), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&invoiceCostBasis), mo.Some[*string](nil)).InexactFloat64())
 	s.Equal(float64(amount), s.mustEarningsBalanceForTaxConfig(ns, USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
@@ -2988,12 +3003,15 @@ func (s *SanitySuite) TestUsageBasedCreditOnlyTaxConfigFlowsToEarnings() {
 	s.Len(advancedCharge.Realizations, 1)
 	s.Len(advancedCharge.Realizations[0].CreditsAllocated, 1)
 
+	costBasis := alpacadecimal.Zero
+	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
+	s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&costBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
+	s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&costBasis), mo.Some(&tc.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
+
 	s.MustRecognizeRevenue(cust.GetID(), USD, alpacadecimal.NewFromInt(amount))
 
 	// then:
 	// - earnings keep the full tax route expected by the charge
-	costBasis := alpacadecimal.Zero
-	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
 	s.Equal(float64(amount), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&costBasis), mo.Some(&tc.ID)).InexactFloat64())
 	s.Equal(float64(0), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&costBasis), mo.Some[*string](nil)).InexactFloat64())
 	s.Equal(float64(amount), s.mustEarningsBalanceForTaxConfig(ns, USD, mo.Some(&costBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
@@ -3094,11 +3112,14 @@ func (s *SanitySuite) TestUsageBasedCreditThenInvoiceTaxConfigFlowsToEarnings() 
 	s.Equal(usagebased.StatusFinal, finalCharge.Status)
 	s.requireChargeTaxConfig(finalCharge.Intent.TaxConfig, tc.ID, productcatalog.InclusiveTaxBehavior)
 
+	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
+	s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
+	s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
+
 	s.mustRecognizeAttributableAccrued(cust.GetID(), USD, alpacadecimal.NewFromInt(amount))
 
 	// then:
 	// - earnings keep the full tax route expected by the charge
-	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
 	s.Equal(float64(amount), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID)).InexactFloat64())
 	s.Equal(float64(0), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&invoiceCostBasis), mo.Some[*string](nil)).InexactFloat64())
 	s.Equal(float64(amount), s.mustEarningsBalanceForTaxConfig(ns, USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
@@ -3218,7 +3239,10 @@ func (s *SanitySuite) TestTaxCodeFlowsFromCreditPurchaseToEarnings() {
 			Amount:    alpacadecimal.NewFromInt(amount),
 			At:        setupAt,
 			CostBasis: alpacadecimal.Zero,
-			TaxConfig: &productcatalog.TaxCodeConfig{TaxCodeID: &tc.ID},
+			TaxConfig: &productcatalog.TaxCodeConfig{
+				TaxCodeID: &tc.ID,
+				Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+			},
 		})
 		s.NotEmpty(result.Charge.Realizations.CreditGrantRealization.TransactionGroupID)
 
@@ -3244,7 +3268,10 @@ func (s *SanitySuite) TestTaxCodeFlowsFromCreditPurchaseToEarnings() {
 					Name:              "flat-fee-taxcode-test",
 					ManagedBy:         billing.SubscriptionManagedLine,
 					UniqueReferenceID: "flat-fee-taxcode-test",
-					TaxConfig:         &productcatalog.TaxCodeConfig{TaxCodeID: &tc.ID},
+					TaxConfig: &productcatalog.TaxCodeConfig{
+						TaxCodeID: &tc.ID,
+						Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+					},
 				}),
 			},
 		})
@@ -3340,7 +3367,10 @@ func (s *SanitySuite) TestChargeIntentTaxConfigFlowsToEarnings() {
 			Amount:    alpacadecimal.NewFromInt(amount),
 			At:        setupAt,
 			CostBasis: alpacadecimal.Zero,
-			TaxConfig: &productcatalog.TaxCodeConfig{TaxCodeID: &tc.ID},
+			TaxConfig: &productcatalog.TaxCodeConfig{
+				TaxCodeID: &tc.ID,
+				Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+			},
 		})
 		s.NotEmpty(result.Charge.Realizations.CreditGrantRealization.TransactionGroupID)
 
@@ -3365,7 +3395,10 @@ func (s *SanitySuite) TestChargeIntentTaxConfigFlowsToEarnings() {
 					Name:              "flat-fee-charge-intent-tax",
 					ManagedBy:         billing.SubscriptionManagedLine,
 					UniqueReferenceID: "flat-fee-charge-intent-tax",
-					TaxConfig:         &productcatalog.TaxCodeConfig{TaxCodeID: &tc.ID}, // tax on the charge intent
+					TaxConfig: &productcatalog.TaxCodeConfig{
+						TaxCodeID: &tc.ID,
+						Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+					}, // tax on the charge intent
 				}),
 			},
 		})
@@ -3541,7 +3574,10 @@ func (s *SanitySuite) TestChargeIntentTaxConfigOverridesFundingTaxCodeCreditOnly
 			Amount:    alpacadecimal.NewFromInt(amount),
 			At:        setupAt,
 			CostBasis: alpacadecimal.Zero,
-			TaxConfig: &productcatalog.TaxCodeConfig{TaxCodeID: &taxA.ID},
+			TaxConfig: &productcatalog.TaxCodeConfig{
+				TaxCodeID: &taxA.ID,
+				Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+			},
 		})
 
 		nilCostBasis := alpacadecimal.Zero
@@ -3565,7 +3601,10 @@ func (s *SanitySuite) TestChargeIntentTaxConfigOverridesFundingTaxCodeCreditOnly
 					Name:              "flat-fee-mismatched-taxconfig",
 					ManagedBy:         billing.SubscriptionManagedLine,
 					UniqueReferenceID: "flat-fee-mismatched-taxconfig",
-					TaxConfig:         &productcatalog.TaxCodeConfig{TaxCodeID: &taxB.ID},
+					TaxConfig: &productcatalog.TaxCodeConfig{
+						TaxCodeID: &taxB.ID,
+						Behavior:  lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
+					},
 				}),
 			},
 		})
@@ -3678,7 +3717,10 @@ func (s *SanitySuite) TestTaxCodeFlowsFromInvoicedChargeToAccrued() {
 					ManagedBy:         billing.SubscriptionManagedLine,
 					UniqueReferenceID: "usage-based-invoice-tax",
 					FeatureKey:        apiRequestsTotal.Feature.Key,
-					TaxConfig:         &productcatalog.TaxCodeConfig{TaxCodeID: &tc.ID},
+					TaxConfig: &productcatalog.TaxCodeConfig{
+						TaxCodeID: &tc.ID,
+						Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+					},
 				}),
 			},
 		})
@@ -3706,15 +3748,16 @@ func (s *SanitySuite) TestTaxCodeFlowsFromInvoicedChargeToAccrued() {
 		s.NoError(err)
 		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
 
-		// Accrual leg must place balance in TaxCode-keyed accrued bucket
-		s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
-			"accrued must land in TaxCode bucket for invoice-backed usage charge")
-		s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some[*string](nil)).InexactFloat64(),
-			"nil-TaxCode accrued must remain zero")
+		// Accrual leg must place balance in the charge TaxCode/TaxBehavior bucket.
+		ledgerTaxBehavior := ledger.TaxBehaviorInclusive
+		s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64(),
+			"accrued must land in TaxCode/TaxBehavior bucket for invoice-backed usage charge")
+		s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64(),
+			"nil-TaxBehavior accrued must remain zero")
 
-		// Receivable funded in TaxCode bucket
-		s.Equal(float64(-10), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen, mo.Some(&tc.ID)).InexactFloat64(),
-			"open receivable must sit in TaxCode bucket")
+		// Receivable stays tax-neutral; tax dimensions enter when usage accrues.
+		s.Equal(float64(-10), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen).InexactFloat64(),
+			"open receivable must sit in tax-neutral route")
 	})
 
 	s.Run("payment authorized and settled", func() {
@@ -3723,11 +3766,11 @@ func (s *SanitySuite) TestTaxCodeFlowsFromInvoicedChargeToAccrued() {
 		s.NoError(err)
 		s.Equal(billing.StandardInvoiceStatusPaymentProcessingAuthorized, invoice.Status)
 
-		// After auth, open receivable in TaxCode bucket drained, authorized receivable in TaxCode bucket holds -10
-		s.Equal(float64(0), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen, mo.Some(&tc.ID)).InexactFloat64(),
-			"open receivable in TaxCode bucket must reconcile to zero after auth")
-		s.Equal(float64(-10), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusAuthorized, mo.Some(&tc.ID)).InexactFloat64(),
-			"authorized receivable must sit in TaxCode bucket")
+		// After auth, open receivable drains and authorized receivable holds the invoice amount.
+		s.Equal(float64(0), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen).InexactFloat64(),
+			"open receivable must reconcile to zero after auth")
+		s.Equal(float64(-10), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusAuthorized).InexactFloat64(),
+			"authorized receivable must sit in tax-neutral route")
 
 		invoice, err = s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{
 			InvoiceID: invoice.GetInvoiceID(),
@@ -3736,15 +3779,16 @@ func (s *SanitySuite) TestTaxCodeFlowsFromInvoicedChargeToAccrued() {
 		s.NoError(err)
 		s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
 
-		// After settle, authorized receivable in TaxCode bucket clears
-		s.Equal(float64(0), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusAuthorized, mo.Some(&tc.ID)).InexactFloat64(),
-			"authorized receivable in TaxCode bucket must clear after settle")
+		// After settle, authorized receivable clears.
+		s.Equal(float64(0), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusAuthorized).InexactFloat64(),
+			"authorized receivable must clear after settle")
 	})
 
 	s.Run("accrued in TaxCode bucket survives through final settlement", func() {
-		s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
-			"accrued must remain in TaxCode bucket after settlement")
-		s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some[*string](nil)).InexactFloat64(),
-			"nil-TaxCode accrued must remain zero")
+		ledgerTaxBehavior := ledger.TaxBehaviorInclusive
+		s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64(),
+			"accrued must remain in TaxCode/TaxBehavior bucket after settlement")
+		s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64(),
+			"nil-TaxBehavior accrued must remain zero")
 	})
 }

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -2,6 +2,7 @@ package credits
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -2704,13 +2705,479 @@ func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets()
 	s.Equal(float64(0), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen, mo.Some(&taxB.ID)).InexactFloat64())
 	s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxA.ID)).InexactFloat64())
 	s.Equal(float64(5), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxB.ID)).InexactFloat64())
-	s.Equal(float64(5), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxA.ID)).InexactFloat64())
+	s.Equal(float64(5), s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&purchaseCostBasis), ledger.DefaultCustomerFBOPriority).InexactFloat64())
 }
 
-// TestTaxCodeFlowsFromCreditPurchaseToEarnings verifies the end-to-end routing of
-// TaxCode: credit purchase → FBO sub-account → accrued → earnings.
-// Credits funded with a TaxCode must land in a TaxCode-keyed earnings sub-account
-// after charge collection and revenue recognition.
+func (s *SanitySuite) TestFlatFeeCreditOnlyTaxConfigFlowsToEarnings() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("flatfee-credit-taxconfig-earnings")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	tc := s.createTaxCodeForEarningsFlow(ctx, ns, "txcd-41000001", "Flat Fee Credit Tax")
+	taxConfig := &productcatalog.TaxCodeConfig{
+		TaxCodeID: &tc.ID,
+		Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+	}
+
+	const amount = 30
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-31T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	// given:
+	// - a charge is created before tax-configured credit is available
+	createdCharges, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  servicePeriod,
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(amount),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				Name:              "flatfee-credit-taxconfig-earnings",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "flatfee-credit-taxconfig-earnings",
+				TaxConfig:         taxConfig,
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Len(createdCharges, 1)
+
+	s.CreatePromotionalCreditFunding(ctx, CreatePromotionalCreditFundingInput{
+		Namespace: ns,
+		Customer:  cust.GetID(),
+		Amount:    alpacadecimal.NewFromInt(amount),
+		At:        createAt,
+		CostBasis: alpacadecimal.Zero,
+		TaxConfig: taxConfig,
+	})
+
+	// when:
+	// - the flat fee is paid with credit and its accrued amount is recognized
+	clock.FreezeTime(servicePeriod.From)
+	advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+		Customer: cust.GetID(),
+	})
+	s.NoError(err)
+	s.Len(advancedCharges, 1)
+
+	advancedCharge, err := advancedCharges[0].AsFlatFeeCharge()
+	s.NoError(err)
+	s.Equal(flatfee.StatusFinal, advancedCharge.Status)
+	s.requireChargeTaxConfig(advancedCharge.Intent.TaxConfig, tc.ID, productcatalog.InclusiveTaxBehavior)
+	s.Require().NotNil(advancedCharge.Realizations.CurrentRun)
+	s.Len(advancedCharge.Realizations.CurrentRun.CreditRealizations, 1)
+
+	clock.FreezeTime(servicePeriod.To)
+	s.MustRecognizeRevenue(cust.GetID(), USD, alpacadecimal.NewFromInt(amount))
+
+	// then:
+	// - earnings keep the full tax route expected by the charge
+	costBasis := alpacadecimal.Zero
+	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
+	s.Equal(float64(amount), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&costBasis), mo.Some(&tc.ID)).InexactFloat64())
+	s.Equal(float64(0), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&costBasis), mo.Some[*string](nil)).InexactFloat64())
+	s.Equal(float64(amount), s.mustEarningsBalanceForTaxConfig(ns, USD, mo.Some(&costBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
+	s.Equal(float64(0), s.mustEarningsBalanceForTaxConfig(ns, USD, mo.Some(&costBasis), mo.Some(&tc.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
+}
+
+func (s *SanitySuite) TestFlatFeeCreditThenInvoiceTaxConfigFlowsToEarnings() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("flatfee-invoice-taxconfig-earnings")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	tc := s.createTaxCodeForEarningsFlow(ctx, ns, "txcd-41000002", "Flat Fee Invoice Tax")
+	taxConfig := &productcatalog.TaxCodeConfig{
+		TaxCodeID: &tc.ID,
+		Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+	}
+
+	const amount = 30
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-31T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	invoiceCostBasis := alpacadecimal.NewFromInt(1)
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	// given:
+	// - a tax-configured flat-fee charge starts the invoice flow
+	createdCharges, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  servicePeriod,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(amount),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				Name:              "flatfee-invoice-taxconfig-earnings",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "flatfee-invoice-taxconfig-earnings",
+				TaxConfig:         taxConfig,
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Len(createdCharges, 1)
+	chargeID, err := createdCharges[0].GetChargeID()
+	s.NoError(err)
+
+	// when:
+	// - the invoice is paid and the accrued usage is recognized
+	clock.FreezeTime(servicePeriod.From)
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: cust.GetID(),
+		AsOf:     lo.ToPtr(servicePeriod.From),
+	})
+	s.NoError(err)
+	s.Len(invoices, 1)
+	invoice := invoices[0]
+
+	invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
+
+	invoice, err = s.BillingService.PaymentAuthorized(ctx, invoice.GetInvoiceID())
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusPaymentProcessingAuthorized, invoice.Status)
+
+	invoice, err = s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{
+		InvoiceID: invoice.GetInvoiceID(),
+		Trigger:   billing.TriggerPaid,
+	})
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
+
+	finalCharge, err := s.MustGetChargeByID(chargeID).AsFlatFeeCharge()
+	s.NoError(err)
+	s.Equal(flatfee.StatusFinal, finalCharge.Status)
+	s.requireChargeTaxConfig(finalCharge.Intent.TaxConfig, tc.ID, productcatalog.InclusiveTaxBehavior)
+
+	clock.FreezeTime(servicePeriod.To)
+	s.mustRecognizeAttributableAccrued(cust.GetID(), USD, alpacadecimal.NewFromInt(amount))
+
+	// then:
+	// - earnings keep the full tax route expected by the charge
+	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
+	s.Equal(float64(amount), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID)).InexactFloat64())
+	s.Equal(float64(0), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&invoiceCostBasis), mo.Some[*string](nil)).InexactFloat64())
+	s.Equal(float64(amount), s.mustEarningsBalanceForTaxConfig(ns, USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
+	s.Equal(float64(0), s.mustEarningsBalanceForTaxConfig(ns, USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
+}
+
+func (s *SanitySuite) TestUsageBasedCreditOnlyTaxConfigFlowsToEarnings() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("usage-credit-taxconfig-earnings")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+
+	tc := s.createTaxCodeForEarningsFlow(ctx, ns, "txcd-41000003", "Usage Credit Tax")
+	taxConfig := &productcatalog.TaxCodeConfig{
+		TaxCodeID: &tc.ID,
+		Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+	}
+
+	const amount = 10
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	// given:
+	// - a usage-based charge is created before credit funding and meter realization
+	createdCharges, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  servicePeriod,
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromFloat(0.1),
+				}),
+				Name:              "usage-credit-taxconfig-earnings",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "usage-credit-taxconfig-earnings",
+				FeatureKey:        apiRequestsTotal.Feature.Key,
+				TaxConfig:         taxConfig,
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Len(createdCharges, 1)
+
+	s.CreatePromotionalCreditFunding(ctx, CreatePromotionalCreditFundingInput{
+		Namespace: ns,
+		Customer:  cust.GetID(),
+		Amount:    alpacadecimal.NewFromInt(amount),
+		At:        createAt,
+		CostBasis: alpacadecimal.Zero,
+		TaxConfig: taxConfig,
+	})
+	s.MockStreamingConnector.AddSimpleEvent(
+		apiRequestsTotal.Feature.Key,
+		100,
+		datetime.MustParseTimeInLocation(s.T(), "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+	)
+
+	// when:
+	// - usage is paid with credit and recognized as earnings
+	clock.FreezeTime(servicePeriod.To.Add(time.Second))
+	advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+		Customer: cust.GetID(),
+	})
+	s.NoError(err)
+	s.Len(advancedCharges, 1)
+
+	advancedCharge, err := advancedCharges[0].AsUsageBasedCharge()
+	s.NoError(err)
+	s.Equal(usagebased.StatusActiveFinalRealizationWaitingForCollection, advancedCharge.Status)
+	s.Require().NotNil(advancedCharge.State.AdvanceAfter)
+
+	clock.FreezeTime(advancedCharge.State.AdvanceAfter.Add(time.Second))
+	advancedCharges, err = s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+		Customer: cust.GetID(),
+	})
+	s.NoError(err)
+	s.Len(advancedCharges, 1)
+
+	advancedCharge, err = advancedCharges[0].AsUsageBasedCharge()
+	s.NoError(err)
+	s.Equal(usagebased.StatusFinal, advancedCharge.Status)
+	s.requireChargeTaxConfig(advancedCharge.Intent.TaxConfig, tc.ID, productcatalog.InclusiveTaxBehavior)
+	s.Len(advancedCharge.Realizations, 1)
+	s.Len(advancedCharge.Realizations[0].CreditsAllocated, 1)
+
+	s.MustRecognizeRevenue(cust.GetID(), USD, alpacadecimal.NewFromInt(amount))
+
+	// then:
+	// - earnings keep the full tax route expected by the charge
+	costBasis := alpacadecimal.Zero
+	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
+	s.Equal(float64(amount), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&costBasis), mo.Some(&tc.ID)).InexactFloat64())
+	s.Equal(float64(0), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&costBasis), mo.Some[*string](nil)).InexactFloat64())
+	s.Equal(float64(amount), s.mustEarningsBalanceForTaxConfig(ns, USD, mo.Some(&costBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
+	s.Equal(float64(0), s.mustEarningsBalanceForTaxConfig(ns, USD, mo.Some(&costBasis), mo.Some(&tc.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
+}
+
+func (s *SanitySuite) TestUsageBasedCreditThenInvoiceTaxConfigFlowsToEarnings() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("usage-invoice-taxconfig-earnings")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+
+	tc := s.createTaxCodeForEarningsFlow(ctx, ns, "txcd-41000004", "Usage Invoice Tax")
+	taxConfig := &productcatalog.TaxCodeConfig{
+		TaxCodeID: &tc.ID,
+		Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+	}
+
+	const amount = 10
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	invoiceCostBasis := alpacadecimal.NewFromInt(1)
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	// given:
+	// - a tax-configured usage-based charge starts the invoice flow
+	s.MockStreamingConnector.AddSimpleEvent(
+		apiRequestsTotal.Feature.Key,
+		100,
+		datetime.MustParseTimeInLocation(s.T(), "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+	)
+	createdCharges, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  servicePeriod,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromFloat(0.1),
+				}),
+				Name:              "usage-invoice-taxconfig-earnings",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "usage-invoice-taxconfig-earnings",
+				FeatureKey:        apiRequestsTotal.Feature.Key,
+				TaxConfig:         taxConfig,
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Len(createdCharges, 1)
+	chargeID, err := createdCharges[0].GetChargeID()
+	s.NoError(err)
+
+	// when:
+	// - the invoice is paid and the accrued usage is recognized
+	clock.FreezeTime(servicePeriod.To.Add(time.Second))
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: cust.GetID(),
+		AsOf:     lo.ToPtr(servicePeriod.To),
+	})
+	s.NoError(err)
+	s.Len(invoices, 1)
+	invoice := invoices[0]
+
+	clock.FreezeTime(invoice.DefaultCollectionAtForStandardInvoice())
+	invoice, err = s.BillingService.AdvanceInvoice(ctx, invoice.GetInvoiceID())
+	s.NoError(err)
+	invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
+
+	invoice, err = s.BillingService.PaymentAuthorized(ctx, invoice.GetInvoiceID())
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusPaymentProcessingAuthorized, invoice.Status)
+
+	invoice, err = s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{
+		InvoiceID: invoice.GetInvoiceID(),
+		Trigger:   billing.TriggerPaid,
+	})
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
+
+	finalCharge, err := s.MustGetChargeByID(chargeID).AsUsageBasedCharge()
+	s.NoError(err)
+	s.Equal(usagebased.StatusFinal, finalCharge.Status)
+	s.requireChargeTaxConfig(finalCharge.Intent.TaxConfig, tc.ID, productcatalog.InclusiveTaxBehavior)
+
+	s.mustRecognizeAttributableAccrued(cust.GetID(), USD, alpacadecimal.NewFromInt(amount))
+
+	// then:
+	// - earnings keep the full tax route expected by the charge
+	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
+	s.Equal(float64(amount), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID)).InexactFloat64())
+	s.Equal(float64(0), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&invoiceCostBasis), mo.Some[*string](nil)).InexactFloat64())
+	s.Equal(float64(amount), s.mustEarningsBalanceForTaxConfig(ns, USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
+	s.Equal(float64(0), s.mustEarningsBalanceForTaxConfig(ns, USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
+}
+
+func (s *SanitySuite) createTaxCodeForEarningsFlow(ctx context.Context, namespace string, key string, name string) taxcode.TaxCode {
+	s.T().Helper()
+
+	tc, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       key,
+		Name:      name,
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: strings.Replace(key, "-", "_", 1)},
+		},
+	})
+	s.Require().NoError(err)
+
+	return tc
+}
+
+func (s *SanitySuite) requireChargeTaxConfig(config *productcatalog.TaxCodeConfig, taxCodeID string, behavior productcatalog.TaxBehavior) {
+	s.T().Helper()
+
+	s.Require().NotNil(config)
+	s.Require().NotNil(config.TaxCodeID)
+	s.Equal(taxCodeID, *config.TaxCodeID)
+	s.Require().NotNil(config.Behavior)
+	s.Equal(behavior, *config.Behavior)
+}
+
+func (s *SanitySuite) mustRecognizeAttributableAccrued(customerID customer.CustomerID, currency currencyx.Code, amount alpacadecimal.Decimal) {
+	s.T().Helper()
+
+	inputs, err := transactions.ResolveTransactions(
+		s.T().Context(),
+		transactions.ResolverDependencies{
+			AccountService: s.LedgerResolver,
+			AccountCatalog: s.LedgerAccountService,
+			BalanceQuerier: s.BalanceQuerier,
+		},
+		transactions.ResolutionScope{
+			CustomerID: customerID,
+			Namespace:  customerID.Namespace,
+		},
+		transactions.RecognizeEarningsFromAttributableAccruedTemplate{
+			At:       clock.Now(),
+			Amount:   amount,
+			Currency: currency,
+		},
+	)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(inputs)
+
+	_, err = s.Ledger.CommitGroup(s.T().Context(), transactions.GroupInputs(customerID.Namespace, nil, inputs...))
+	s.Require().NoError(err)
+}
+
+func (s *SanitySuite) mustEarningsBalanceForTaxConfig(namespace string, code currencyx.Code, costBasis mo.Option[*alpacadecimal.Decimal], taxCode mo.Option[*string], taxBehavior mo.Option[*ledger.TaxBehavior]) alpacadecimal.Decimal {
+	s.T().Helper()
+
+	businessAccounts, err := s.LedgerResolver.GetBusinessAccounts(s.T().Context(), namespace)
+	s.Require().NoError(err)
+
+	balance, err := s.BalanceQuerier.GetAccountBalance(s.T().Context(), businessAccounts.EarningsAccount, ledger.RouteFilter{
+		Currency:    code,
+		CostBasis:   costBasis,
+		TaxCode:     taxCode,
+		TaxBehavior: taxBehavior,
+	}, ledger.BalanceQuery{})
+	s.Require().NoError(err)
+
+	return balance.Settled()
+}
+
+// TestTaxCodeFlowsFromCreditPurchaseToEarnings verifies that credits funded by a
+// credit purchase can settle a tax-configured charge. Tax routing starts when
+// charge usage accrues; customer FBO sources are not tax buckets.
 func (s *SanitySuite) TestTaxCodeFlowsFromCreditPurchaseToEarnings() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("taxcode-earnings-flow")
@@ -2755,12 +3222,9 @@ func (s *SanitySuite) TestTaxCodeFlowsFromCreditPurchaseToEarnings() {
 		})
 		s.NotEmpty(result.Charge.Realizations.CreditGrantRealization.TransactionGroupID)
 
-		// FBO sub-account is keyed by TaxCode; nil-TaxCode FBO must be zero
 		nilCostBasis := alpacadecimal.Zero
-		s.Equal(float64(amount), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
-			"FBO balance in TaxCode sub-account must equal funded amount")
-		s.Equal(float64(0), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some[*string](nil)).InexactFloat64(),
-			"nil-TaxCode FBO sub-account must be untouched")
+		s.Equal(float64(amount), s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&nilCostBasis), ledger.DefaultCustomerFBOPriority).InexactFloat64(),
+			"FBO balance must equal funded amount")
 	})
 
 	var flatFeeChargeID string
@@ -2780,6 +3244,7 @@ func (s *SanitySuite) TestTaxCodeFlowsFromCreditPurchaseToEarnings() {
 					Name:              "flat-fee-taxcode-test",
 					ManagedBy:         billing.SubscriptionManagedLine,
 					UniqueReferenceID: "flat-fee-taxcode-test",
+					TaxConfig:         &productcatalog.TaxCodeConfig{TaxCodeID: &tc.ID},
 				}),
 			},
 		})
@@ -2806,12 +3271,10 @@ func (s *SanitySuite) TestTaxCodeFlowsFromCreditPurchaseToEarnings() {
 
 		// Accrued must hold the consumed amount; FBO must be drained
 		nilCostBasis := alpacadecimal.Zero
-		s.Equal(float64(0), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
-			"TaxCode FBO sub-account must be drained after charge collection")
-		s.Equal(float64(0), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some[*string](nil)).InexactFloat64(),
-			"nil-TaxCode FBO sub-account must remain zero")
-		s.Equal(float64(amount), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&nilCostBasis)).InexactFloat64(),
-			"accrued must hold the collected amount")
+		s.Equal(float64(0), s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&nilCostBasis), ledger.DefaultCustomerFBOPriority).InexactFloat64(),
+			"FBO balance must be drained after charge collection")
+		s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
+			"accrued must hold the collected amount in the charge TaxCode bucket")
 	})
 
 	_ = flatFeeChargeID
@@ -2835,14 +3298,9 @@ func (s *SanitySuite) TestTaxCodeFlowsFromCreditPurchaseToEarnings() {
 	})
 }
 
-// TestChargeIntentTaxConfigFlowsToEarnings verifies the end-to-end tax-coded
-// funded credit-only path when funding and charge intent use the same TaxCode.
-//
-// Setup: fund FBO with TaxCode=X via promotional credit; create flat-fee
-// credit-only charge with Intent.TaxConfig=X. Expected behavior:
-//   - charge consumption drains TaxCode(X) FBO
-//   - accrued lands in TaxCode(X) bucket
-//   - earnings land in TaxCode(X) bucket on revenue recognition
+// TestChargeIntentTaxConfigFlowsToEarnings verifies the credit-only charge tax
+// config is applied when value leaves customer FBO and reaches accrued and
+// earnings.
 func (s *SanitySuite) TestChargeIntentTaxConfigFlowsToEarnings() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charge-intent-taxconfig-earnings")
@@ -2887,8 +3345,8 @@ func (s *SanitySuite) TestChargeIntentTaxConfigFlowsToEarnings() {
 		s.NotEmpty(result.Charge.Realizations.CreditGrantRealization.TransactionGroupID)
 
 		nilCostBasis := alpacadecimal.Zero
-		s.Equal(float64(amount), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
-			"FBO balance in TaxCode bucket must equal funded amount")
+		s.Equal(float64(amount), s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&nilCostBasis), ledger.DefaultCustomerFBOPriority).InexactFloat64(),
+			"FBO balance must equal funded amount")
 	})
 
 	s.Run("create and advance flat-fee credit-only charge with matching TaxConfig on intent", func() {
@@ -2927,8 +3385,8 @@ func (s *SanitySuite) TestChargeIntentTaxConfigFlowsToEarnings() {
 		s.Equal(flatfee.StatusFinal, advancedCharge.Status)
 
 		nilCostBasis := alpacadecimal.Zero
-		s.Equal(float64(0), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
-			"TaxCode FBO must be drained")
+		s.Equal(float64(0), s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&nilCostBasis), ledger.DefaultCustomerFBOPriority).InexactFloat64(),
+			"FBO balance must be drained")
 		s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
 			"accrued must land in TaxCode bucket")
 	})
@@ -3024,34 +3482,17 @@ func (s *SanitySuite) TestChargeIntentTaxBehaviorFlowsToAdvanceAccrualCreditOnly
 	s.Require().NotNil(advancedCharge.Realizations.CurrentRun)
 	s.Len(advancedCharge.Realizations.CurrentRun.CreditRealizations, 1)
 
-	realization := advancedCharge.Realizations.CurrentRun.CreditRealizations[0]
 	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
-	s.Equal(2, s.MustFBOEntryCountForTaxBehavior(realization.LedgerTransaction.TransactionGroupID, &ledgerTaxBehavior),
-		"advance-backed collection must post both FBO legs with charge TaxBehavior")
-	s.Equal(0, s.MustFBOEntryCountForTaxBehavior(realization.LedgerTransaction.TransactionGroupID, nil),
-		"advance-backed collection must not use nil-TaxBehavior FBO routes")
-
-	s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&tc.ID)).InexactFloat64(),
-		"advance-backed accrued balance must still land in charge TaxCode bucket")
+	s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64(),
+		"advance-backed accrued balance must land in charge tax bucket")
+	s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&tc.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64(),
+		"advance-backed accrued balance must not use nil-TaxBehavior routes")
 }
 
-// TestChargeIntentTaxConfigDoesNotOverrideFundingTaxCodeCreditOnly locks the
-// current contract: for credit-only consumption, FBO→Accrued is source-driven.
-// The charge intent's TaxConfig is metadata on the charge entity; it does NOT
-// override the funding TaxCode bucket at routing.
-//
-// Setup: fund FBO with TaxCode=A; create flat-fee credit-only charge with
-// Intent.TaxConfig=B (different). Expected current behavior:
-//   - charge consumes FBO at TaxCode=A
-//   - accrued lands in TaxCode=A bucket (funding source wins)
-//   - earnings land in TaxCode=A bucket
-//   - TaxCode=B accrued and earnings buckets remain zero
-//
-// If future product semantics require charge.TaxConfig to override funding
-// TaxCode for credit-only flows, this test must be updated alongside the
-// addition of a TaxCode translation transaction template + matching routing
-// rule (see TranslateCustomerAccruedCostBasisTemplate for the pattern).
-func (s *SanitySuite) TestChargeIntentTaxConfigDoesNotOverrideFundingTaxCodeCreditOnly() {
+// TestChargeIntentTaxConfigOverridesFundingTaxCodeCreditOnly locks the
+// credit-only contract: customer FBO is not tax-routed. Charge tax config is
+// applied when value accrues and is preserved into earnings.
+func (s *SanitySuite) TestChargeIntentTaxConfigOverridesFundingTaxCodeCreditOnly() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charge-intent-taxconfig-contract")
 
@@ -3104,8 +3545,8 @@ func (s *SanitySuite) TestChargeIntentTaxConfigDoesNotOverrideFundingTaxCodeCred
 		})
 
 		nilCostBasis := alpacadecimal.Zero
-		s.Equal(float64(amount), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&taxA.ID)).InexactFloat64(),
-			"FBO funded in TaxCode=A bucket")
+		s.Equal(float64(amount), s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&nilCostBasis), ledger.DefaultCustomerFBOPriority).InexactFloat64(),
+			"FBO balance must equal funded amount")
 	})
 
 	s.Run("create and advance flat-fee credit-only charge with TaxConfig=B (different from funding)", func() {
@@ -3146,30 +3587,28 @@ func (s *SanitySuite) TestChargeIntentTaxConfigDoesNotOverrideFundingTaxCodeCred
 		// Charge entity preserves Intent.TaxConfig=B (metadata survives)
 		s.Require().NotNil(advancedCharge.Intent.TaxConfig)
 		s.Require().NotNil(advancedCharge.Intent.TaxConfig.TaxCodeID)
-		s.Equal(taxB.ID, *advancedCharge.Intent.TaxConfig.TaxCodeID,
-			"charge intent must preserve TaxConfig=B (intent is metadata, not routing override)")
+		s.Equal(taxB.ID, *advancedCharge.Intent.TaxConfig.TaxCodeID)
 
 		nilCostBasis := alpacadecimal.Zero
-		// Routing follows the funding source TaxCode=A, not charge TaxConfig=B
-		s.Equal(float64(0), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&taxA.ID)).InexactFloat64(),
-			"FBO TaxCode=A must be drained")
-		s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&taxA.ID)).InexactFloat64(),
-			"accrued must land in funding TaxCode=A bucket (source-driven routing)")
-		s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&taxB.ID)).InexactFloat64(),
-			"charge TaxCode=B accrued bucket must remain zero")
+		s.Equal(float64(0), s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&nilCostBasis), ledger.DefaultCustomerFBOPriority).InexactFloat64(),
+			"FBO balance must be drained")
+		s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&taxA.ID)).InexactFloat64(),
+			"funding TaxCode must not define accrued routing")
+		s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&taxB.ID)).InexactFloat64(),
+			"charge TaxCode must define accrued routing")
 	})
 
-	s.Run("recognize revenue and confirm earnings follow funding TaxCode=A, not charge TaxCode=B", func() {
+	s.Run("recognize revenue and confirm earnings follow charge TaxCode=B", func() {
 		clock.FreezeTime(servicePeriod.To)
 
 		s.MustRecognizeRevenue(cust.GetID(), USD, alpacadecimal.NewFromInt(amount))
 
 		nilCostBasis := alpacadecimal.Zero
 
-		s.Equal(float64(amount), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&nilCostBasis), mo.Some(&taxA.ID)).InexactFloat64(),
-			"earnings must land in funding TaxCode=A bucket")
-		s.Equal(float64(0), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&nilCostBasis), mo.Some(&taxB.ID)).InexactFloat64(),
-			"earnings must NOT land in charge intent TaxCode=B bucket")
+		s.Equal(float64(0), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&nilCostBasis), mo.Some(&taxA.ID)).InexactFloat64(),
+			"funding TaxCode must not define earnings routing")
+		s.Equal(float64(amount), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&nilCostBasis), mo.Some(&taxB.ID)).InexactFloat64(),
+			"charge TaxCode must define earnings routing")
 	})
 }
 

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -2804,6 +2804,91 @@ func (s *SanitySuite) TestChargeIntentTaxConfigFlowsToEarnings() {
 	})
 }
 
+func (s *SanitySuite) TestChargeIntentTaxBehaviorFlowsToAdvanceAccrualCreditOnly() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charge-intent-taxbehavior-advance")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	tc, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "txcd-40000006",
+		Name:      "Charge Intent Tax Behavior",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000006"},
+		},
+	})
+	s.Require().NoError(err)
+
+	const amount = 30
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-31T00:00:00Z", time.UTC).AsTime()
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	res, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+				Customer:       cust.GetID(),
+				Currency:       USD,
+				ServicePeriod:  servicePeriod,
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(amount),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				Name:              "flat-fee-charge-intent-taxbehavior",
+				ManagedBy:         billing.SubscriptionManagedLine,
+				UniqueReferenceID: "flat-fee-charge-intent-taxbehavior",
+				TaxConfig: &productcatalog.TaxCodeConfig{
+					TaxCodeID: &tc.ID,
+					Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+				},
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Len(res, 1)
+
+	clock.FreezeTime(servicePeriod.From)
+
+	advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+		Customer: cust.GetID(),
+	})
+	s.NoError(err)
+	s.Len(advancedCharges, 1)
+
+	advancedCharge, err := advancedCharges[0].AsFlatFeeCharge()
+	s.NoError(err)
+	s.Equal(flatfee.StatusFinal, advancedCharge.Status)
+	s.Require().NotNil(advancedCharge.Intent.TaxConfig)
+	s.Require().NotNil(advancedCharge.Intent.TaxConfig.Behavior)
+	s.Equal(productcatalog.InclusiveTaxBehavior, *advancedCharge.Intent.TaxConfig.Behavior)
+	s.Require().NotNil(advancedCharge.Realizations.CurrentRun)
+	s.Len(advancedCharge.Realizations.CurrentRun.CreditRealizations, 1)
+
+	realization := advancedCharge.Realizations.CurrentRun.CreditRealizations[0]
+	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
+	s.Equal(2, s.MustFBOEntryCountForTaxBehavior(realization.LedgerTransaction.TransactionGroupID, &ledgerTaxBehavior),
+		"advance-backed collection must post both FBO legs with charge TaxBehavior")
+	s.Equal(0, s.MustFBOEntryCountForTaxBehavior(realization.LedgerTransaction.TransactionGroupID, nil),
+		"advance-backed collection must not use nil-TaxBehavior FBO routes")
+
+	s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&tc.ID)).InexactFloat64(),
+		"advance-backed accrued balance must still land in charge TaxCode bucket")
+}
+
 // TestChargeIntentTaxConfigDoesNotOverrideFundingTaxCodeCreditOnly locks the
 // current contract: for credit-only consumption, FBO→Accrued is source-driven.
 // The charge intent's TaxConfig is metadata on the charge entity; it does NOT

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/samber/mo"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/openmeterio/openmeter/openmeter/app"
 	appcustominvoicing "github.com/openmeterio/openmeter/openmeter/app/custominvoicing"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
@@ -25,6 +26,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -2557,5 +2559,522 @@ func (s *SanitySuite) TestFlatFeeCreditOnlySanity() {
 			"settlement should only translate accrued between buckets, not change the total accrued amount",
 		)
 		assertDelta("external wash after later purchase settlement", start.externalWash, alpacadecimal.NewFromInt(-50), s.MustWashBalance(ns, USD, mo.Some(&externalCostBasis)))
+	})
+}
+
+// TestTaxCodeFlowsFromCreditPurchaseToEarnings verifies the end-to-end routing of
+// TaxCode: credit purchase → FBO sub-account → accrued → earnings.
+// Credits funded with a TaxCode must land in a TaxCode-keyed earnings sub-account
+// after charge collection and revenue recognition.
+func (s *SanitySuite) TestTaxCodeFlowsFromCreditPurchaseToEarnings() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("taxcode-earnings-flow")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	tc, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "txcd-40000001",
+		Name:      "Test Tax Code",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000001"},
+		},
+	})
+	s.Require().NoError(err)
+
+	const amount = 30
+
+	setupAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-31T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.SetTime(setupAt)
+
+	s.Run("fund customer FBO with TaxCode via promotional credit", func() {
+		result := s.CreatePromotionalCreditFunding(ctx, CreatePromotionalCreditFundingInput{
+			Namespace: ns,
+			Customer:  cust.GetID(),
+			Amount:    alpacadecimal.NewFromInt(amount),
+			At:        setupAt,
+			CostBasis: alpacadecimal.Zero,
+			TaxConfig: &productcatalog.TaxCodeConfig{TaxCodeID: &tc.ID},
+		})
+		s.NotEmpty(result.Charge.Realizations.CreditGrantRealization.TransactionGroupID)
+
+		// FBO sub-account is keyed by TaxCode; nil-TaxCode FBO must be zero
+		nilCostBasis := alpacadecimal.Zero
+		s.Equal(float64(amount), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
+			"FBO balance in TaxCode sub-account must equal funded amount")
+		s.Equal(float64(0), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some[*string](nil)).InexactFloat64(),
+			"nil-TaxCode FBO sub-account must be untouched")
+	})
+
+	var flatFeeChargeID string
+	s.Run("create and advance flat fee credit-only charge", func() {
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditOnlySettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(amount),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					Name:              "flat-fee-taxcode-test",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flat-fee-taxcode-test",
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		chargeID, err := res[0].GetChargeID()
+		s.NoError(err)
+		flatFeeChargeID = chargeID.ID
+
+		clock.FreezeTime(servicePeriod.From)
+
+		advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+			Customer: cust.GetID(),
+		})
+		s.NoError(err)
+		s.Len(advancedCharges, 1)
+
+		advancedCharge, err := advancedCharges[0].AsFlatFeeCharge()
+		s.NoError(err)
+		s.Equal(flatfee.StatusFinal, advancedCharge.Status)
+		s.Require().NotNil(advancedCharge.Realizations.CurrentRun)
+		s.Len(advancedCharge.Realizations.CurrentRun.CreditRealizations, 1)
+
+		// Accrued must hold the consumed amount; FBO must be drained
+		nilCostBasis := alpacadecimal.Zero
+		s.Equal(float64(0), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
+			"TaxCode FBO sub-account must be drained after charge collection")
+		s.Equal(float64(0), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some[*string](nil)).InexactFloat64(),
+			"nil-TaxCode FBO sub-account must remain zero")
+		s.Equal(float64(amount), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&nilCostBasis)).InexactFloat64(),
+			"accrued must hold the collected amount")
+	})
+
+	_ = flatFeeChargeID
+
+	s.Run("recognize revenue and assert earnings land in TaxCode sub-account", func() {
+		clock.FreezeTime(servicePeriod.To)
+
+		s.MustRecognizeRevenue(cust.GetID(), USD, alpacadecimal.NewFromInt(amount))
+
+		nilCostBasis := alpacadecimal.Zero
+
+		// Earnings keyed by TaxCode must receive the full amount
+		taxCodeEarnings := s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&nilCostBasis), mo.Some(&tc.ID))
+		s.Equal(float64(amount), taxCodeEarnings.InexactFloat64(),
+			"earnings for TaxCode sub-account must equal recognized amount")
+
+		// Nil-TaxCode earnings sub-account must remain zero
+		nilTaxCodeEarnings := s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&nilCostBasis), mo.Some[*string](nil))
+		s.Equal(float64(0), nilTaxCodeEarnings.InexactFloat64(),
+			"nil-TaxCode earnings sub-account must be untouched")
+	})
+}
+
+// TestChargeIntentTaxConfigFlowsToEarnings verifies the end-to-end tax-coded
+// funded credit-only path when funding and charge intent use the same TaxCode.
+//
+// Setup: fund FBO with TaxCode=X via promotional credit; create flat-fee
+// credit-only charge with Intent.TaxConfig=X. Expected behavior:
+//   - charge consumption drains TaxCode(X) FBO
+//   - accrued lands in TaxCode(X) bucket
+//   - earnings land in TaxCode(X) bucket on revenue recognition
+func (s *SanitySuite) TestChargeIntentTaxConfigFlowsToEarnings() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charge-intent-taxconfig-earnings")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	tc, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "txcd-40000002",
+		Name:      "Charge Intent Tax Code",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000002"},
+		},
+	})
+	s.Require().NoError(err)
+
+	const amount = 30
+
+	setupAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-31T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.SetTime(setupAt)
+
+	s.Run("fund customer FBO with TaxCode via promotional credit", func() {
+		result := s.CreatePromotionalCreditFunding(ctx, CreatePromotionalCreditFundingInput{
+			Namespace: ns,
+			Customer:  cust.GetID(),
+			Amount:    alpacadecimal.NewFromInt(amount),
+			At:        setupAt,
+			CostBasis: alpacadecimal.Zero,
+			TaxConfig: &productcatalog.TaxCodeConfig{TaxCodeID: &tc.ID},
+		})
+		s.NotEmpty(result.Charge.Realizations.CreditGrantRealization.TransactionGroupID)
+
+		nilCostBasis := alpacadecimal.Zero
+		s.Equal(float64(amount), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
+			"FBO balance in TaxCode bucket must equal funded amount")
+	})
+
+	s.Run("create and advance flat-fee credit-only charge with matching TaxConfig on intent", func() {
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditOnlySettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(amount),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					Name:              "flat-fee-charge-intent-tax",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flat-fee-charge-intent-tax",
+					TaxConfig:         &productcatalog.TaxCodeConfig{TaxCodeID: &tc.ID}, // tax on the charge intent
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		clock.FreezeTime(servicePeriod.From)
+
+		advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+			Customer: cust.GetID(),
+		})
+		s.NoError(err)
+		s.Len(advancedCharges, 1)
+
+		advancedCharge, err := advancedCharges[0].AsFlatFeeCharge()
+		s.NoError(err)
+		s.Equal(flatfee.StatusFinal, advancedCharge.Status)
+
+		nilCostBasis := alpacadecimal.Zero
+		s.Equal(float64(0), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
+			"TaxCode FBO must be drained")
+		s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
+			"accrued must land in TaxCode bucket")
+	})
+
+	s.Run("recognize revenue and assert earnings land in TaxCode bucket", func() {
+		clock.FreezeTime(servicePeriod.To)
+
+		s.MustRecognizeRevenue(cust.GetID(), USD, alpacadecimal.NewFromInt(amount))
+
+		nilCostBasis := alpacadecimal.Zero
+
+		taxCodeEarnings := s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&nilCostBasis), mo.Some(&tc.ID))
+		s.Equal(float64(amount), taxCodeEarnings.InexactFloat64(),
+			"earnings must land in TaxCode bucket")
+
+		nilTaxCodeEarnings := s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&nilCostBasis), mo.Some[*string](nil))
+		s.Equal(float64(0), nilTaxCodeEarnings.InexactFloat64(),
+			"nil-TaxCode earnings must remain zero")
+	})
+}
+
+// TestChargeIntentTaxConfigDoesNotOverrideFundingTaxCodeCreditOnly locks the
+// current contract: for credit-only consumption, FBO→Accrued is source-driven.
+// The charge intent's TaxConfig is metadata on the charge entity; it does NOT
+// override the funding TaxCode bucket at routing.
+//
+// Setup: fund FBO with TaxCode=A; create flat-fee credit-only charge with
+// Intent.TaxConfig=B (different). Expected current behavior:
+//   - charge consumes FBO at TaxCode=A
+//   - accrued lands in TaxCode=A bucket (funding source wins)
+//   - earnings land in TaxCode=A bucket
+//   - TaxCode=B accrued and earnings buckets remain zero
+//
+// If future product semantics require charge.TaxConfig to override funding
+// TaxCode for credit-only flows, this test must be updated alongside the
+// addition of a TaxCode translation transaction template + matching routing
+// rule (see TranslateCustomerAccruedCostBasisTemplate for the pattern).
+func (s *SanitySuite) TestChargeIntentTaxConfigDoesNotOverrideFundingTaxCodeCreditOnly() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charge-intent-taxconfig-contract")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	taxA, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "txcd-40000004",
+		Name:      "Funding Tax Code A",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000004"},
+		},
+	})
+	s.Require().NoError(err)
+
+	taxB, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "txcd-40000005",
+		Name:      "Charge Intent Tax Code B",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000005"},
+		},
+	})
+	s.Require().NoError(err)
+
+	const amount = 30
+
+	setupAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-31T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.SetTime(setupAt)
+
+	s.Run("fund FBO with TaxCode=A", func() {
+		s.CreatePromotionalCreditFunding(ctx, CreatePromotionalCreditFundingInput{
+			Namespace: ns,
+			Customer:  cust.GetID(),
+			Amount:    alpacadecimal.NewFromInt(amount),
+			At:        setupAt,
+			CostBasis: alpacadecimal.Zero,
+			TaxConfig: &productcatalog.TaxCodeConfig{TaxCodeID: &taxA.ID},
+		})
+
+		nilCostBasis := alpacadecimal.Zero
+		s.Equal(float64(amount), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&taxA.ID)).InexactFloat64(),
+			"FBO funded in TaxCode=A bucket")
+	})
+
+	s.Run("create and advance flat-fee credit-only charge with TaxConfig=B (different from funding)", func() {
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditOnlySettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(amount),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					Name:              "flat-fee-mismatched-taxconfig",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flat-fee-mismatched-taxconfig",
+					TaxConfig:         &productcatalog.TaxCodeConfig{TaxCodeID: &taxB.ID},
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		clock.FreezeTime(servicePeriod.From)
+
+		advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+			Customer: cust.GetID(),
+		})
+		s.NoError(err)
+		s.Len(advancedCharges, 1)
+
+		advancedCharge, err := advancedCharges[0].AsFlatFeeCharge()
+		s.NoError(err)
+		s.Equal(flatfee.StatusFinal, advancedCharge.Status)
+
+		// Charge entity preserves Intent.TaxConfig=B (metadata survives)
+		s.Require().NotNil(advancedCharge.Intent.TaxConfig)
+		s.Require().NotNil(advancedCharge.Intent.TaxConfig.TaxCodeID)
+		s.Equal(taxB.ID, *advancedCharge.Intent.TaxConfig.TaxCodeID,
+			"charge intent must preserve TaxConfig=B (intent is metadata, not routing override)")
+
+		nilCostBasis := alpacadecimal.Zero
+		// Routing follows the funding source TaxCode=A, not charge TaxConfig=B
+		s.Equal(float64(0), s.MustCustomerFBOBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&taxA.ID)).InexactFloat64(),
+			"FBO TaxCode=A must be drained")
+		s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&taxA.ID)).InexactFloat64(),
+			"accrued must land in funding TaxCode=A bucket (source-driven routing)")
+		s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&nilCostBasis), mo.Some(&taxB.ID)).InexactFloat64(),
+			"charge TaxCode=B accrued bucket must remain zero")
+	})
+
+	s.Run("recognize revenue and confirm earnings follow funding TaxCode=A, not charge TaxCode=B", func() {
+		clock.FreezeTime(servicePeriod.To)
+
+		s.MustRecognizeRevenue(cust.GetID(), USD, alpacadecimal.NewFromInt(amount))
+
+		nilCostBasis := alpacadecimal.Zero
+
+		s.Equal(float64(amount), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&nilCostBasis), mo.Some(&taxA.ID)).InexactFloat64(),
+			"earnings must land in funding TaxCode=A bucket")
+		s.Equal(float64(0), s.MustEarningsBalanceForTaxCode(ns, USD, mo.Some(&nilCostBasis), mo.Some(&taxB.ID)).InexactFloat64(),
+			"earnings must NOT land in charge intent TaxCode=B bucket")
+	})
+}
+
+// TestTaxCodeFlowsFromInvoicedChargeToAccrued verifies that charge.Intent.TaxConfig
+// flows through the credit-then-invoice path: accrual → payment authorization →
+// settlement. Receivable and accrued buckets must reconcile cleanly within the
+// TaxCode-keyed routes.
+//
+// This test covers the invoice variant GAlexIHU asked about (comment #3249148560)
+// and the route-split bug flagged on chargeadapter/usagebased.go:134
+// (#3249298648).
+func (s *SanitySuite) TestTaxCodeFlowsFromInvoicedChargeToAccrued() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("invoice-charge-taxconfig-earnings")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	tc, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "txcd-40000003",
+		Name:      "Invoice Tax Code",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000003"},
+		},
+	})
+	s.Require().NoError(err)
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	invoiceCostBasis := alpacadecimal.NewFromInt(1)
+
+	var invoice billing.StandardInvoice
+
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	s.Run("create credit-then-invoice usage-based charge with TaxConfig on intent", func() {
+		s.MockStreamingConnector.AddSimpleEvent(
+			apiRequestsTotal.Feature.Key,
+			100,
+			datetime.MustParseTimeInLocation(s.T(), "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+		)
+
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+						Amount: alpacadecimal.NewFromFloat(0.1),
+					}),
+					Name:              "usage-based-invoice-tax",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "usage-based-invoice-tax",
+					FeatureKey:        apiRequestsTotal.Feature.Key,
+					TaxConfig:         &productcatalog.TaxCodeConfig{TaxCodeID: &tc.ID},
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+	})
+
+	s.Run("invoice is created, advanced, approved into payment pending", func() {
+		clock.FreezeTime(servicePeriod.To.Add(time.Second))
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.To),
+		})
+		s.NoError(err)
+		s.Len(invoices, 1)
+		invoice = invoices[0]
+
+		clock.FreezeTime(invoice.DefaultCollectionAtForStandardInvoice())
+
+		invoice, err = s.BillingService.AdvanceInvoice(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+
+		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
+
+		// Accrual leg must place balance in TaxCode-keyed accrued bucket
+		s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
+			"accrued must land in TaxCode bucket for invoice-backed usage charge")
+		s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some[*string](nil)).InexactFloat64(),
+			"nil-TaxCode accrued must remain zero")
+
+		// Receivable funded in TaxCode bucket
+		s.Equal(float64(-10), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen, mo.Some(&tc.ID)).InexactFloat64(),
+			"open receivable must sit in TaxCode bucket")
+	})
+
+	s.Run("payment authorized and settled", func() {
+		var err error
+		invoice, err = s.BillingService.PaymentAuthorized(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingAuthorized, invoice.Status)
+
+		// After auth, open receivable in TaxCode bucket drained, authorized receivable in TaxCode bucket holds -10
+		s.Equal(float64(0), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusOpen, mo.Some(&tc.ID)).InexactFloat64(),
+			"open receivable in TaxCode bucket must reconcile to zero after auth")
+		s.Equal(float64(-10), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusAuthorized, mo.Some(&tc.ID)).InexactFloat64(),
+			"authorized receivable must sit in TaxCode bucket")
+
+		invoice, err = s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{
+			InvoiceID: invoice.GetInvoiceID(),
+			Trigger:   billing.TriggerPaid,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
+
+		// After settle, authorized receivable in TaxCode bucket clears
+		s.Equal(float64(0), s.MustCustomerReceivableBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), ledger.TransactionAuthorizationStatusAuthorized, mo.Some(&tc.ID)).InexactFloat64(),
+			"authorized receivable in TaxCode bucket must clear after settle")
+	})
+
+	s.Run("accrued in TaxCode bucket survives through final settlement", func() {
+		s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID)).InexactFloat64(),
+			"accrued must remain in TaxCode bucket after settlement")
+		s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxCode(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some[*string](nil)).InexactFloat64(),
+			"nil-TaxCode accrued must remain zero")
 	})
 }

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -2655,9 +2655,10 @@ func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets()
 	s.Equal(float64(5), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&taxB.ID), mo.Some(&taxBBehavior)).InexactFloat64())
 
 	// when:
-	// - a larger purchased grant backfills both advance buckets
+	// - a smaller purchased grant partially backfills the first deterministic advance bucket
 	purchaseCostBasis := alpacadecimal.NewFromFloat(0.5)
 	purchaseAt := servicePeriod.From.Add(time.Hour)
+	purchaseAmount := int64(5)
 	clock.FreezeTime(purchaseAt)
 	purchaseRes, err := s.Charges.Create(ctx, charges.CreateInput{
 		Namespace: ns,
@@ -2665,7 +2666,7 @@ func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets()
 			s.CreateCreditPurchaseIntent(CreateCreditPurchaseIntentInput{
 				Customer: cust.GetID(),
 				Currency: USD,
-				Amount:   alpacadecimal.NewFromInt(20),
+				Amount:   alpacadecimal.NewFromInt(purchaseAmount),
 				ServicePeriod: timeutil.ClosedPeriod{
 					From: purchaseAt,
 					To:   purchaseAt,
@@ -2696,8 +2697,8 @@ func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets()
 	s.NoError(err)
 
 	// then:
-	// - attribution and accrued translation stay split by source TaxCode
-	// - only the purchased remainder is newly issued
+	// - partial attribution chooses the first TaxCode/TaxBehavior bucket deterministically
+	// - the purchased grant is fully consumed by advance backfill
 	templateCounts := map[string]int{}
 	for _, tx := range backingGroup.Transactions() {
 		code, err := ledger.TransactionTemplateCodeFromAnnotations(tx.Annotations())
@@ -2705,16 +2706,28 @@ func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets()
 		templateCounts[code]++
 	}
 
-	s.Equal(2, templateCounts[transactions.TemplateCode(transactions.AttributeCustomerAdvanceReceivableCostBasisTemplate{})])
-	s.Equal(2, templateCounts[transactions.TemplateCode(transactions.TranslateCustomerAccruedCostBasisTemplate{})])
-	s.Equal(1, templateCounts[transactions.TemplateCode(transactions.IssueCustomerReceivableTemplate{})])
+	s.Equal(1, templateCounts[transactions.TemplateCode(transactions.AttributeCustomerAdvanceReceivableCostBasisTemplate{})])
+	s.Equal(1, templateCounts[transactions.TemplateCode(transactions.TranslateCustomerAccruedCostBasisTemplate{})])
+	s.Equal(0, templateCounts[transactions.TemplateCode(transactions.IssueCustomerReceivableTemplate{})])
 
-	s.Equal(float64(0), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen).InexactFloat64())
-	s.Equal(float64(10), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxA.ID), mo.Some(&taxABehavior)).InexactFloat64())
-	s.Equal(float64(5), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxB.ID), mo.Some(&taxBBehavior)).InexactFloat64())
+	expectedBackfilledTaxID := taxA.ID
+	expectedBackfilledBehavior := taxABehavior
+	expectedRemainingTaxA := float64(5)
+	expectedRemainingTaxB := float64(5)
+	if taxB.ID < taxA.ID {
+		expectedBackfilledTaxID = taxB.ID
+		expectedBackfilledBehavior = taxBBehavior
+		expectedRemainingTaxA = float64(10)
+		expectedRemainingTaxB = float64(0)
+	}
+
+	s.Equal(float64(-10), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), ledger.TransactionAuthorizationStatusOpen).InexactFloat64())
+	s.Equal(float64(purchaseAmount), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&expectedBackfilledTaxID), mo.Some(&expectedBackfilledBehavior)).InexactFloat64())
 	s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxA.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
 	s.Equal(float64(0), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&purchaseCostBasis), mo.Some(&taxB.ID), mo.Some[*ledger.TaxBehavior](nil)).InexactFloat64())
-	s.Equal(float64(5), s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&purchaseCostBasis), ledger.DefaultCustomerFBOPriority).InexactFloat64())
+	s.Equal(expectedRemainingTaxA, s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&taxA.ID), mo.Some(&taxABehavior)).InexactFloat64())
+	s.Equal(expectedRemainingTaxB, s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some[*alpacadecimal.Decimal](nil), mo.Some(&taxB.ID), mo.Some(&taxBBehavior)).InexactFloat64())
+	s.Equal(float64(0), s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&purchaseCostBasis), ledger.DefaultCustomerFBOPriority).InexactFloat64())
 }
 
 func (s *SanitySuite) TestFlatFeeCreditOnlyTaxConfigFlowsToEarnings() {

--- a/tools/migrate/ledger_tax_behavior_test.go
+++ b/tools/migrate/ledger_tax_behavior_test.go
@@ -1,0 +1,105 @@
+package migrate_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLedgerTaxBehaviorMigrationRollback documents the known data-loss scenario
+// when rolling back 20260506103900_add_ledger_tax_behavior:
+//
+//   - A sub-account route created with TaxBehavior (V2 routing key) has its
+//     routing_key column encoding tax_behavior:exclusive.
+//   - After rollback, the tax_behavior column is dropped but the row persists.
+//   - The stored routing_key still encodes the V2 format, making the row
+//     unresolvable by the application until the migration is re-applied.
+func TestLedgerTaxBehaviorMigrationRollback(t *testing.T) {
+	accountID := ulid.Make().String()
+	routeID := ulid.Make().String()
+
+	const (
+		namespace = "test-ledger-tax-behavior-rollback"
+
+		// V2 routing key: currency + tax_code + tax_behavior + remaining segments.
+		v2KeyVersion = "v2"
+		v2KeyValue   = "currency:USD|tax_code:|tax_behavior:exclusive|features:|cost_basis:|credit_priority:|transaction_authorization_status:"
+	)
+
+	runner{
+		stops: stops{
+			{
+				// After 20260506103900 is applied: tax_behavior column exists.
+				// Insert a V2-keyed route row to simulate a live sub-account.
+				version:   20260506103900,
+				direction: directionUp,
+				action: func(t *testing.T, db *sql.DB) {
+					_, err := db.Exec(`
+						INSERT INTO ledger_accounts (id, namespace, created_at, updated_at, account_type)
+						VALUES ($1, $2, NOW(), NOW(), 'customer_fbo')
+					`, accountID, namespace)
+					require.NoError(t, err)
+
+					_, err = db.Exec(`
+						INSERT INTO ledger_sub_account_routes (
+							id, namespace, created_at, updated_at,
+							routing_key_version, routing_key,
+							account_id, currency, tax_behavior
+						) VALUES ($1, $2, NOW(), NOW(), $3, $4, $5, $6, $7)
+					`, routeID, namespace, v2KeyVersion, v2KeyValue, accountID, "USD", "exclusive")
+					require.NoError(t, err)
+
+					var (
+						gotVersion     string
+						gotKey         string
+						gotTaxBehavior string
+					)
+					err = db.QueryRow(`
+						SELECT routing_key_version, routing_key, tax_behavior
+						FROM ledger_sub_account_routes WHERE id = $1
+					`, routeID).Scan(&gotVersion, &gotKey, &gotTaxBehavior)
+					require.NoError(t, err)
+					require.Equal(t, v2KeyVersion, gotVersion)
+					require.Equal(t, v2KeyValue, gotKey)
+					require.Equal(t, "exclusive", gotTaxBehavior)
+				},
+			},
+			{
+				// After rolling back to 20260506102300 (one step before 20260506103900):
+				// tax_behavior column is dropped. The V2 route row is now orphaned:
+				// routing_key still encodes "tax_behavior:exclusive" but the column is gone.
+				// The row cannot be fully reconstructed until the migration is re-applied.
+				version:   20260506102300,
+				direction: directionDown,
+				action: func(t *testing.T, db *sql.DB) {
+					// Row must survive the rollback — the down migration only drops the column.
+					var gotID string
+					err := db.QueryRow(`SELECT id FROM ledger_sub_account_routes WHERE id = $1`, routeID).Scan(&gotID)
+					require.NoError(t, err, "orphaned V2 route row must survive down migration")
+					require.Equal(t, routeID, gotID)
+
+					// The routing key still encodes the V2 format with tax_behavior segment.
+					var gotVersion, gotKey string
+					err = db.QueryRow(`
+						SELECT routing_key_version, routing_key
+						FROM ledger_sub_account_routes WHERE id = $1
+					`, routeID).Scan(&gotVersion, &gotKey)
+					require.NoError(t, err)
+					require.Equal(t, v2KeyVersion, gotVersion,
+						"routing_key_version must remain v2 — orphaned row cannot self-downgrade")
+					require.True(t, strings.Contains(gotKey, "tax_behavior:exclusive"),
+						"routing_key must still encode tax_behavior segment — column gone but key string persists")
+
+					// tax_behavior column must no longer exist.
+					_, err = db.Exec(`SELECT tax_behavior FROM ledger_sub_account_routes LIMIT 1`)
+					require.Error(t, err, "tax_behavior column must not exist after rollback")
+					require.Contains(t, err.Error(), "tax_behavior",
+						"postgres error must mention the missing column name")
+				},
+			},
+		},
+	}.Test(t)
+}

--- a/tools/migrate/ledger_tax_behavior_test.go
+++ b/tools/migrate/ledger_tax_behavior_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // TestLedgerTaxBehaviorMigrationRollback documents the rollback guard in
-// 20260506103900_add_ledger_tax_behavior:
+// 20260520130500_add_ledger_tax_behavior:
 //
 //   - A sub-account route created with TaxBehavior (V2 routing key) has its
 //     routing_key column encoding tax_behavior:exclusive.
@@ -36,7 +36,7 @@ func TestLedgerTaxBehaviorMigrationRollback(t *testing.T) {
 		require.NoError(t, err2)
 	}()
 
-	require.NoError(t, migrator.Migrate(20260506103900))
+	require.NoError(t, migrator.Migrate(20260520130500))
 
 	db := testDB.PGDriver.DB()
 	accountID := ulid.Make().String()
@@ -52,7 +52,7 @@ func TestLedgerTaxBehaviorMigrationRollback(t *testing.T) {
 
 	insertTaxBehaviorRoute(t, db, accountID, routeID, namespace, v2KeyVersion, v2KeyValue)
 
-	err = migrator.Migrate(20260506102300)
+	err = migrator.Migrate(20260519132345)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot rollback: V2 routing key rows exist; downgrade routes first")
 

--- a/tools/migrate/ledger_tax_behavior_test.go
+++ b/tools/migrate/ledger_tax_behavior_test.go
@@ -2,22 +2,43 @@ package migrate_test
 
 import (
 	"database/sql"
-	"strings"
 	"testing"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/tools/migrate"
 )
 
-// TestLedgerTaxBehaviorMigrationRollback documents the known data-loss scenario
-// when rolling back 20260506103900_add_ledger_tax_behavior:
+// TestLedgerTaxBehaviorMigrationRollback documents the rollback guard in
+// 20260506103900_add_ledger_tax_behavior:
 //
 //   - A sub-account route created with TaxBehavior (V2 routing key) has its
 //     routing_key column encoding tax_behavior:exclusive.
-//   - After rollback, the tax_behavior column is dropped but the row persists.
-//   - The stored routing_key still encodes the V2 format, making the row
-//     unresolvable by the application until the migration is re-applied.
+//   - Rolling back while that row exists would leave a V2 route pointing to a
+//     column that no longer exists.
+//   - The down migration fails loudly instead; callers must downgrade/remove V2
+//     routes before retrying rollback.
 func TestLedgerTaxBehaviorMigrationRollback(t *testing.T) {
+	testDB := testutils.InitPostgresDB(t)
+	defer testDB.PGDriver.Close()
+
+	migrator, err := migrate.New(migrate.MigrateOptions{
+		ConnectionString: testDB.URL,
+		Migrations:       migrate.OMMigrationsConfig,
+		Logger:           testutils.NewLogger(t),
+	})
+	require.NoError(t, err)
+	defer func() {
+		err1, err2 := migrator.Close()
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+	}()
+
+	require.NoError(t, migrator.Migrate(20260506103900))
+
+	db := testDB.PGDriver.DB()
 	accountID := ulid.Make().String()
 	routeID := ulid.Make().String()
 
@@ -29,77 +50,50 @@ func TestLedgerTaxBehaviorMigrationRollback(t *testing.T) {
 		v2KeyValue   = "currency:USD|tax_code:|tax_behavior:exclusive|features:|cost_basis:|credit_priority:|transaction_authorization_status:"
 	)
 
-	runner{
-		stops: stops{
-			{
-				// After 20260506103900 is applied: tax_behavior column exists.
-				// Insert a V2-keyed route row to simulate a live sub-account.
-				version:   20260506103900,
-				direction: directionUp,
-				action: func(t *testing.T, db *sql.DB) {
-					_, err := db.Exec(`
-						INSERT INTO ledger_accounts (id, namespace, created_at, updated_at, account_type)
-						VALUES ($1, $2, NOW(), NOW(), 'customer_fbo')
-					`, accountID, namespace)
-					require.NoError(t, err)
+	insertTaxBehaviorRoute(t, db, accountID, routeID, namespace, v2KeyVersion, v2KeyValue)
 
-					_, err = db.Exec(`
-						INSERT INTO ledger_sub_account_routes (
-							id, namespace, created_at, updated_at,
-							routing_key_version, routing_key,
-							account_id, currency, tax_behavior
-						) VALUES ($1, $2, NOW(), NOW(), $3, $4, $5, $6, $7)
-					`, routeID, namespace, v2KeyVersion, v2KeyValue, accountID, "USD", "exclusive")
-					require.NoError(t, err)
+	err = migrator.Migrate(20260506102300)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot rollback: V2 routing key rows exist; downgrade routes first")
 
-					var (
-						gotVersion     string
-						gotKey         string
-						gotTaxBehavior string
-					)
-					err = db.QueryRow(`
-						SELECT routing_key_version, routing_key, tax_behavior
-						FROM ledger_sub_account_routes WHERE id = $1
-					`, routeID).Scan(&gotVersion, &gotKey, &gotTaxBehavior)
-					require.NoError(t, err)
-					require.Equal(t, v2KeyVersion, gotVersion)
-					require.Equal(t, v2KeyValue, gotKey)
-					require.Equal(t, "exclusive", gotTaxBehavior)
-				},
-			},
-			{
-				// After rolling back to 20260506102300 (one step before 20260506103900):
-				// tax_behavior column is dropped. The V2 route row is now orphaned:
-				// routing_key still encodes "tax_behavior:exclusive" but the column is gone.
-				// The row cannot be fully reconstructed until the migration is re-applied.
-				version:   20260506102300,
-				direction: directionDown,
-				action: func(t *testing.T, db *sql.DB) {
-					// Row must survive the rollback — the down migration only drops the column.
-					var gotID string
-					err := db.QueryRow(`SELECT id FROM ledger_sub_account_routes WHERE id = $1`, routeID).Scan(&gotID)
-					require.NoError(t, err, "orphaned V2 route row must survive down migration")
-					require.Equal(t, routeID, gotID)
+	var (
+		gotVersion     string
+		gotKey         string
+		gotTaxBehavior string
+	)
+	err = db.QueryRow(`
+		SELECT routing_key_version, routing_key, tax_behavior
+		FROM ledger_sub_account_routes WHERE id = $1
+	`, routeID).Scan(&gotVersion, &gotKey, &gotTaxBehavior)
+	require.NoError(t, err)
+	require.Equal(t, v2KeyVersion, gotVersion)
+	require.Equal(t, v2KeyValue, gotKey)
+	require.Equal(t, "exclusive", gotTaxBehavior)
+}
 
-					// The routing key still encodes the V2 format with tax_behavior segment.
-					var gotVersion, gotKey string
-					err = db.QueryRow(`
-						SELECT routing_key_version, routing_key
-						FROM ledger_sub_account_routes WHERE id = $1
-					`, routeID).Scan(&gotVersion, &gotKey)
-					require.NoError(t, err)
-					require.Equal(t, v2KeyVersion, gotVersion,
-						"routing_key_version must remain v2 — orphaned row cannot self-downgrade")
-					require.True(t, strings.Contains(gotKey, "tax_behavior:exclusive"),
-						"routing_key must still encode tax_behavior segment — column gone but key string persists")
+func insertTaxBehaviorRoute(
+	t *testing.T,
+	db *sql.DB,
+	accountID string,
+	routeID string,
+	namespace string,
+	v2KeyVersion string,
+	v2KeyValue string,
+) {
+	t.Helper()
 
-					// tax_behavior column must no longer exist.
-					_, err = db.Exec(`SELECT tax_behavior FROM ledger_sub_account_routes LIMIT 1`)
-					require.Error(t, err, "tax_behavior column must not exist after rollback")
-					require.Contains(t, err.Error(), "tax_behavior",
-						"postgres error must mention the missing column name")
-				},
-			},
-		},
-	}.Test(t)
+	_, err := db.Exec(`
+		INSERT INTO ledger_accounts (id, namespace, created_at, updated_at, account_type)
+		VALUES ($1, $2, NOW(), NOW(), 'customer_fbo')
+	`, accountID, namespace)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		INSERT INTO ledger_sub_account_routes (
+			id, namespace, created_at, updated_at,
+			routing_key_version, routing_key,
+			account_id, currency, tax_behavior
+		) VALUES ($1, $2, NOW(), NOW(), $3, $4, $5, $6, $7)
+	`, routeID, namespace, v2KeyVersion, v2KeyValue, accountID, "USD", "exclusive")
+	require.NoError(t, err)
 }

--- a/tools/migrate/migrations/20260520130500_add_ledger_tax_behavior.down.sql
+++ b/tools/migrate/migrations/20260520130500_add_ledger_tax_behavior.down.sql
@@ -1,0 +1,15 @@
+-- reverse: modify "ledger_sub_account_routes" table
+-- Fail loudly if V2 routing rows exist. Dropping tax_behavior while V2 routing keys
+-- remain would leave rows whose routing_key references a dimension no longer stored
+-- in the table.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM ledger_sub_account_routes
+        WHERE routing_key_version = 'v2'
+    ) THEN
+        RAISE EXCEPTION 'cannot rollback: V2 routing key rows exist; downgrade routes first';
+    END IF;
+END $$;
+
+ALTER TABLE "ledger_sub_account_routes" DROP COLUMN "tax_behavior";

--- a/tools/migrate/migrations/20260520130500_add_ledger_tax_behavior.up.sql
+++ b/tools/migrate/migrations/20260520130500_add_ledger_tax_behavior.up.sql
@@ -1,0 +1,2 @@
+-- modify "ledger_sub_account_routes" table
+ALTER TABLE "ledger_sub_account_routes" ADD COLUMN "tax_behavior" character varying NULL;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ydrLtz6PbiQeKpU+44BMXc3AaYZbqukht/N/uMMmoJQ=
+h1:gSQes9wG0XKT/ue8LFsMTxUNkdkK1Mvn9pk39x933b8=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -204,3 +204,4 @@ h1:ydrLtz6PbiQeKpU+44BMXc3AaYZbqukht/N/uMMmoJQ=
 20260517121831_add_credit_expiration_breakage.up.sql h1:sqRiyAM1cB3PHAmS7H2tdWHgOoqolo70S9i7v7VChxM=
 20260519132345_reset-sync-state.up.sql h1:R8ekG92vwXQbtqmh+R3ZTTRMCM0VqPoLzJG3VIKlG4k=
 20260520130000_repair_rebased_migrations.up.sql h1:XJhbK1CCplq5BEJi+VvHDVAcLUBJqHNF1LFGhaSa2Oo=
+20260520130500_add_ledger_tax_behavior.up.sql h1:M8Lq8lE/O+RwPLJ/7qe5tVddruuAxOcBAeJ1usFEveg=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional tax behavior (inclusive/exclusive) on routes, persisted and incorporated into routing keys; tax code and tax behavior now propagate through routing and transaction flows.

* **Refactor**
  * Routing/filter types now preserve presence semantics to distinguish absent vs explicitly null tax fields.

* **Bug Fixes**
  * Sub-account resolution and routing correctly differentiate nil vs non-nil tax codes and tax behavior.

* **Tests**
  * Added coverage for tax behavior validation, routing-key variants, normalization, pairing keys, and tax-code isolation.

* **Chores**
  * DB migration to add nullable tax_behavior and backfill routing keys; down-migration removes added segment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4291)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->