### PR TITLE
feat(billing): scaffold usage based charge lifecycle mapping

### DIFF
--- a/.agents/skills/billing/SKILL.md
+++ b/.agents/skills/billing/SKILL.md
@@ -91,6 +91,17 @@ Rules:
 
 These are distinct fields and must not be conflated.
 
+### Usage-Based Quantities
+
+`StandardLine.UsageBased.MeteredQuantity` and `Quantity` represent the quantity for the standard line's own billing period, not a cumulative service-period quantity. For progressively billed lines, `PreLinePeriodQuantity` and `MeteredPreLinePeriodQuantity` carry the quantity already represented before the current standard line.
+
+Billing's quantity snapshot path (`service/quantitysnapshot.go`) calculates this as:
+
+- `PreLinePeriodQty`: usage from the split/progressive group service-period start up to the current line start
+- `LinePeriodQty`: usage up to the current line end minus `PreLinePeriodQty`
+
+Charge-backed usage-based lines must follow the same standard-line semantics when lifecycle hooks update line contents. Usage-based charge runs store cumulative `RealizationRun.MeteredQuantity`; charge mappers must translate it to billing line-period/pre-line-period quantities before setting `StandardLine.UsageBased` fields.
+
 ## Service / Adapter Pattern
 
 `billing.Service` is a **composite interface** of 10 sub-interfaces defined in `service.go`:

--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -42,7 +42,7 @@ the same change. The calculation contracts are documented in:
 
 `openmeter/billing/charges` is the root facade for charge operations.
 
-For charge-owned detailed lines, the shared invoice-agnostic base belongs in `openmeter/billing/models/stddetailedline`. Prefer using `type DetailedLine = stddetailedline.Base` in charge packages and keep ownership implicit through containment in the parent aggregate (`flatfee.Realizations` or `usagebased.RealizationRun`) rather than duplicating `charge_id` / `run_id` fields in the domain type. Reuse the shared detailed-line base mapping and create helpers instead of duplicating common field assembly in charge adapters.
+For charge-owned detailed lines, the shared invoice-agnostic base belongs in `openmeter/billing/models/stddetailedline`. Prefer reusing `stddetailedline.Base` for invoice-agnostic base lines, or define a concrete charge-owned type that embeds/composes `stddetailedline.Base` when the package needs additional fields (for example `usagebased.DetailedLine`). Keep ownership implicit through containment in the parent aggregate (`flatfee.Realizations` or `usagebased.RealizationRun`) rather than duplicating `charge_id` / `run_id` fields in the domain type. Reuse the shared detailed-line base mapping and create helpers instead of duplicating common field assembly in charge adapters.
 
 Charge-backed invoicing no longer relies on a charges-side `InvoicePendingLines(...)` wrapper. Billing owns invoice creation and dispatches gathering lines by `billing.LineEngineType`, while charge packages provide charge-specific line engines where needed.
 

--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -31,6 +31,13 @@ Primary packages:
 - `openmeter/billing/charges/service/invoicable_test.go`
 - `openmeter/billing/charges/service/advance_test.go`
 
+When changing usage-based rating algorithms, update the package documentation in
+the same change. The calculation contracts are documented in:
+
+- `openmeter/billing/charges/usagebased/service/rating/delta/README.md`
+- `openmeter/billing/charges/usagebased/service/rating/periodpreserving/README.md`
+- `openmeter/billing/charges/usagebased/service/rating/subtract/README.md`
+
 ## Current Design
 
 `openmeter/billing/charges` is the root facade for charge operations.
@@ -87,8 +94,21 @@ Important types:
   - `ServicePeriodTo`
   - `MeteredQuantity`
   - `Totals`
+- `usagebased.RealizationRunBase.MeteredQuantity` is a cumulative charge snapshot for `[intent.ServicePeriod.From, ServicePeriodTo)` capped by that run's `StoredAtLT`. Do not copy it directly into `billing.StandardLine.UsageBased.MeteredQuantity` for progressive billing: billing standard lines expect line-period quantity. Use `usagebased.RealizationRuns.MapToBillingMeteredQuantity(currentRun)` when mapping a run into a standard invoice line, and map `LinePeriod` to `Quantity` / `MeteredQuantity`, and `PreLinePeriod` to `PreLinePeriodQuantity` / `MeteredPreLinePeriodQuantity`.
+- `MapToBillingMeteredQuantity` intentionally uses the latest prior invoice-backed run's persisted cumulative `MeteredQuantity` as `PreLinePeriod`. That prior value may have been captured with an older `StoredAtLT` than the current run. This differs from period-preserving rating internals, which may freshly snapshot prior event-time periods with the current `StoredAtLT` for correction calculations; standard invoice line quantities should reflect what was previously billed.
 - `usagebased.RealizationRun` can expand:
   - `DetailedLines`
+
+## Usage-Based Invoice Line Mapping
+
+Usage-based charge realization runs are not billing standard lines. When mapping a run back to `billing.StandardLine` in `openmeter/billing/charges/usagebased/service/linemapper.go`, preserve the billing-facing semantics:
+
+- `MeteredQuantity` and `MeteredPreLinePeriodQuantity` are raw metered usage for the current line period and prior line periods.
+- `Quantity` and `PreLinePeriodQuantity` are net billable usage after rate-card usage discounts.
+- Reuse the standard billing usage-discount mutator contract (`billing/rating/service/mutator.ApplyUsageDiscount`) instead of reimplementing discount math in charges. This keeps usage-based charges compatible with standard billing's `discounts.usage.quantity` and `discounts.usage.preLinePeriodQuantity` API behavior.
+- Use the standard line's real `RateCardDiscounts` when mapping invoice-line discount metadata. Do not use usage-based rating's synthetic `"usagebased-ratecard-*"` correlation IDs for persisted invoice-line discount communication.
+
+Do not emulate every billing rating mutator in the line mapper. Usage discounts are special because they mutate line-header quantities and `StandardLineDiscounts.Usage`. Percentage discounts and maximum-spend discounts are amount discounts on detailed lines; if API parity is required for those, preserve amount-discount metadata through usage-based charge detailed lines instead of recalculating discounts during mapping. Minimum-spend commitments already materialize as commitment detailed lines during rating. Credits are owned by charge credit allocation and should be mapped from run credit realizations, not reapplied through the standard billing credits mutator.
 
 Detailed-line expansion rules:
 
@@ -232,6 +252,8 @@ Current expected behavior:
 - usage-based and flat-fee service/orchestration layers should skip invoice-accrual persistence when the invoice line total is zero
 - ledger handlers may still defensively tolerate zero and return `ledgertransaction.GroupReference{}`
 - when a service proceeds with non-zero invoice accrual, it must require a non-empty transaction group reference before storing accrued usage
+
+Zero invoice accrual is different from payment booking. Usage-based invoice payment records (`charges/models/payment`) require a positive amount and a real ledger transaction reference. A fully credit-covered standard invoice can reach `payment_processing.pending` with `Totals.Total == 0`, but blindly sending `TriggerPaid` through the normal payment authorization/settlement path can fail with validation errors such as `amount must be positive` and `transaction group ID is required`. Add an explicit zero-total payment no-op path before expecting fully credited invoice-backed usage runs to reach settled payment state.
 
 ## HTTP/API Conversion
 

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -116,7 +116,7 @@ Apps can choose to synchronize the original line (if the upstream system underst
 
 When we are dealing with a split line, the calculation of the quantity is by taking the meter's quantity for the whole line period ([`parent.period.start`, `splitline.period.end`]) and the amount before the period (`parent.period.start`, `splitline.period.start`).
 
-When substracting the two we get the delta for the period (this gets the delta for all supported meter types except of Min and Avg).
+When subtracting the two we get the delta for the period (this gets the delta for all supported meter types except of Min and Avg).
 
 We execute the pricing logic (e.g. tiered pricing) for the line qty, while considering the before usage, as it reflects the already billed for items.
 

--- a/openmeter/billing/README.md
+++ b/openmeter/billing/README.md
@@ -116,7 +116,7 @@ Apps can choose to synchronize the original line (if the upstream system underst
 
 When we are dealing with a split line, the calculation of the quantity is by taking the meter's quantity for the whole line period ([`parent.period.start`, `splitline.period.end`]) and the amount before the period (`parent.period.start`, `splitline.period.start`).
 
-When subtracting the two we get the delta for the period (this gets the delta for all supported meter types except of Min and Avg).
+When subtracting the two we get the delta for the period (this gets the delta for all supported meter types except Min and Avg).
 
 We execute the pricing logic (e.g. tiered pricing) for the line qty, while considering the before usage, as it reflects the already billed for items.
 

--- a/openmeter/billing/charges/creditpurchase/lineengine/engine.go
+++ b/openmeter/billing/charges/creditpurchase/lineengine/engine.go
@@ -10,7 +10,10 @@ import (
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
-var _ billing.LineEngine = (*Engine)(nil)
+var (
+	_ billing.LineEngine     = (*Engine)(nil)
+	_ billing.LineCalculator = (*Engine)(nil)
+)
 
 type Config struct {
 	RatingService rating.Service

--- a/openmeter/billing/charges/flatfee/adapter/detailedline.go
+++ b/openmeter/billing/charges/flatfee/adapter/detailedline.go
@@ -121,6 +121,7 @@ func (a *adapter) UpsertDetailedLines(ctx context.Context, chargeID meta.ChargeI
 			UpdateTaxCodeID().
 			UpdateTaxBehavior().
 			UpdateIndex().
+			UpdatePricerReferenceID().
 			UpdateDeletedAt().
 			UpdateInvoicingAppExternalID().
 			UpdateChildUniqueReferenceID().
@@ -139,7 +140,8 @@ func buildDetailedLineCreate(db *entdb.Client, chargeID meta.ChargeID, line flat
 	create := db.ChargeFlatFeeDetailedLine.Create().
 		SetID(line.ID).
 		SetNamespace(chargeID.Namespace).
-		SetChargeID(chargeID.ID)
+		SetChargeID(chargeID.ID).
+		SetPricerReferenceID(line.ChildUniqueReferenceID)
 
 	create = stddetailedline.Create(create, line)
 

--- a/openmeter/billing/charges/flatfee/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/flatfee/adapter/detailedline_test.go
@@ -176,6 +176,28 @@ func (s *FlatFeeDetailedLineAdapterSuite) TestUpsertDetailedLinesReplacesAndSoft
 	s.Equal(float64(3), fetchedCharge.Realizations.DetailedLines.OrEmpty()[0].Quantity.InexactFloat64())
 	s.Nil(fetchedCharge.Realizations.DetailedLines.OrEmpty()[0].Description)
 
+	keptRow, err := s.dbClient.ChargeFlatFeeDetailedLine.Query().
+		Where(
+			dbchargeflatfeedetailedline.NamespaceEQ(namespace),
+			dbchargeflatfeedetailedline.ChargeIDEQ(charge.ID),
+			dbchargeflatfeedetailedline.ChildUniqueReferenceIDEQ("keep"),
+			dbchargeflatfeedetailedline.DeletedAtIsNil(),
+		).
+		Only(ctx)
+	s.Require().NoError(err)
+	s.Equal("keep", keptRow.PricerReferenceID)
+
+	newRow, err := s.dbClient.ChargeFlatFeeDetailedLine.Query().
+		Where(
+			dbchargeflatfeedetailedline.NamespaceEQ(namespace),
+			dbchargeflatfeedetailedline.ChargeIDEQ(charge.ID),
+			dbchargeflatfeedetailedline.ChildUniqueReferenceIDEQ("new"),
+			dbchargeflatfeedetailedline.DeletedAtIsNil(),
+		).
+		Only(ctx)
+	s.Require().NoError(err)
+	s.Equal("new", newRow.PricerReferenceID)
+
 	deletedRow, err := s.dbClient.ChargeFlatFeeDetailedLine.Query().
 		Where(
 			dbchargeflatfeedetailedline.NamespaceEQ(namespace),

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -11,7 +11,10 @@ import (
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
-var _ billing.LineEngine = (*LineEngine)(nil)
+var (
+	_ billing.LineEngine     = (*LineEngine)(nil)
+	_ billing.LineCalculator = (*LineEngine)(nil)
+)
 
 type LineEngine struct {
 	service *service

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -1477,7 +1477,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCredite
 		s.Equal(float64(10), currentRun.CreditsAllocated[0].Amount.InexactFloat64())
 	})
 
-	s.Run("#5 approve invoice without invoice usage accrual", func() {
+	s.Run("#5 approve invoice with no fiat invoice usage accrual", func() {
 		defer s.UsageBasedTestHandler.Reset()
 
 		invoiceUsageAccruedCallback := newCountedLedgerTransactionCallback[usagebased.OnInvoiceUsageAccruedInput]()
@@ -1498,7 +1498,15 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCredite
 		s.Equal(float64(100), finalRun.MeteredQuantity.InexactFloat64())
 		s.NotNil(finalRun.LineID)
 		s.Equal(stdLineID.ID, *finalRun.LineID)
-		s.Nil(finalRun.InvoiceUsage)
+		s.True(finalRun.NoFiatTransactionRequired)
+		s.NotNil(finalRun.InvoiceUsage)
+		s.NotNil(finalRun.InvoiceUsage.LineID)
+		s.Equal(stdLineID.ID, *finalRun.InvoiceUsage.LineID)
+		s.Nil(finalRun.InvoiceUsage.LedgerTransaction)
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount:       10,
+			CreditsTotal: 10,
+		}, finalRun.InvoiceUsage.Totals)
 	})
 }
 

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -35,6 +35,7 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge usagebased.ChargeBase
 			Where(dbchargeusagebased.NamespaceEQ(charge.Namespace)).
 			SetDiscounts(&charge.Intent.Discounts).
 			SetFeatureID(charge.State.FeatureID).
+			SetRatingEngine(charge.State.RatingEngine).
 			SetStatus(metaStatus).
 			SetStatusDetailed(charge.Status).
 			SetOrClearCurrentRealizationRunID(charge.State.CurrentRealizationRunID)
@@ -221,6 +222,7 @@ func (a *adapter) buildCreateUsageBasedCharge(ctx context.Context, ns string, in
 	create := a.db.ChargeUsageBased.Create().
 		SetDiscounts(&intent.Discounts).
 		SetFeatureID(intent.FeatureID).
+		SetRatingEngine(intent.RatingEngine).
 		SetPrice(&intent.Price).
 		SetStatusDetailed(usagebased.Status(meta.ChargeStatusCreated)).
 		SetFeatureKey(intent.FeatureKey).

--- a/openmeter/billing/charges/usagebased/adapter/detailedline.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline.go
@@ -185,6 +185,8 @@ func (a *adapter) UpsertRunDetailedLines(ctx context.Context, chargeID chargesme
 			UpdateTaxCodeID().
 			UpdateTaxBehavior().
 			UpdateIndex().
+			UpdatePricerReferenceID().
+			UpdateCorrectsRunID().
 			UpdateDeletedAt().
 			UpdateInvoicingAppExternalID().
 			UpdateChildUniqueReferenceID().
@@ -204,9 +206,11 @@ func buildDetailedLineCreate(db *entdb.Client, chargeID chargesmeta.ChargeID, ru
 		SetID(line.ID).
 		SetNamespace(runID.Namespace).
 		SetChargeID(chargeID.ID).
-		SetRunID(runID.ID)
+		SetRunID(runID.ID).
+		SetPricerReferenceID(lo.CoalesceOrEmpty(line.PricerReferenceID, line.ChildUniqueReferenceID)).
+		SetNillableCorrectsRunID(line.CorrectsRunID)
 
-	create = stddetailedline.Create(create, line)
+	create = stddetailedline.Create(create, line.Base)
 
 	if len(line.CreditsApplied) > 0 {
 		create = create.SetCreditsApplied(&line.CreditsApplied)
@@ -222,14 +226,18 @@ func buildDetailedLineCreate(db *entdb.Client, chargeID chargesmeta.ChargeID, ru
 }
 
 func mapDetailedLineFromDB(dbLine *entdb.ChargeUsageBasedRunDetailedLine) (usagebased.DetailedLine, error) {
-	line := stddetailedline.FromDB(
-		dbLine,
-		stddetailedline.BackfillTaxConfig(
-			lo.EmptyableToPtr(dbLine.TaxConfig),
-			dbLine.TaxBehavior,
-			taxCodeIDFromEnt(dbLine.Edges.TaxCode),
+	line := usagebased.DetailedLine{
+		Base: stddetailedline.FromDB(
+			dbLine,
+			stddetailedline.BackfillTaxConfig(
+				lo.EmptyableToPtr(dbLine.TaxConfig),
+				dbLine.TaxBehavior,
+				taxCodeIDFromEnt(dbLine.Edges.TaxCode),
+			),
 		),
-	)
+		PricerReferenceID: dbLine.PricerReferenceID,
+		CorrectsRunID:     dbLine.CorrectsRunID,
+	}
 
 	return line, line.Validate()
 }

--- a/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
@@ -46,6 +46,8 @@ type newDetailedLineInput struct {
 	RunID                  usagebased.RealizationRunID
 	ServicePeriod          timeutil.ClosedPeriod
 	ChildUniqueReferenceID string
+	PricerReferenceID      string
+	CorrectsRunID          *string
 	Quantity               int64
 	Description            *string
 }
@@ -120,14 +122,26 @@ func (s *DetailedLineAdapterSuite) TestUpsertRunDetailedLinesReplacesAndSoftDele
 						Amount: alpacadecimal.NewFromFloat(0.1),
 					}),
 				},
-				FeatureID: "feature-1",
+				FeatureID:    "feature-1",
+				RatingEngine: usagebased.RatingEngineDelta,
 			},
 		},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(createdCharges, 1)
+	s.Require().Equal(usagebased.RatingEngineDelta, createdCharges[0].State.RatingEngine)
 
 	charge := createdCharges[0]
+	correctedRunBase, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunInput{
+		FeatureID:       "feature-1",
+		Type:            usagebased.RealizationRunTypePartialInvoice,
+		StoredAtLT:      servicePeriod.From,
+		ServicePeriodTo: servicePeriod.From,
+		MeteredQuantity: alpacadecimal.NewFromInt(0),
+		Totals:          totals.Totals{},
+	})
+	s.Require().NoError(err)
+
 	runBase, err := s.adapter.CreateRealizationRun(ctx, charge.GetChargeID(), usagebased.CreateRealizationRunInput{
 		FeatureID:       "feature-1",
 		Type:            usagebased.RealizationRunTypeFinalRealization,
@@ -162,12 +176,24 @@ func (s *DetailedLineAdapterSuite) TestUpsertRunDetailedLinesReplacesAndSoftDele
 	}
 	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, charge.GetChargeID(), runBase.ID, initialLines))
 
+	initialKeepRow, err := s.dbClient.ChargeUsageBasedRunDetailedLine.Query().
+		Where(
+			dbchargeusagebasedrundetailedline.NamespaceEQ(namespace),
+			dbchargeusagebasedrundetailedline.ChargeIDEQ(charge.ID),
+			dbchargeusagebasedrundetailedline.RunIDEQ(runBase.ID.ID),
+			dbchargeusagebasedrundetailedline.ChildUniqueReferenceIDEQ("keep@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]"),
+			dbchargeusagebasedrundetailedline.DeletedAtIsNil(),
+		).
+		Only(ctx)
+	s.Require().NoError(err)
+
 	replacementLines := usagebased.DetailedLines{
 		s.newDetailedLine(newDetailedLineInput{
 			Charge:                 charge,
 			RunID:                  runBase.ID,
 			ServicePeriod:          servicePeriod,
 			ChildUniqueReferenceID: "keep@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
+			PricerReferenceID:      "keep-pricer-reference",
 			Quantity:               3,
 		}),
 		s.newDetailedLine(newDetailedLineInput{
@@ -175,11 +201,24 @@ func (s *DetailedLineAdapterSuite) TestUpsertRunDetailedLinesReplacesAndSoftDele
 			RunID:                  runBase.ID,
 			ServicePeriod:          servicePeriod,
 			ChildUniqueReferenceID: "new@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]",
-			Quantity:               4,
+			CorrectsRunID:          lo.ToPtr(correctedRunBase.ID.ID),
+			Quantity:               -4,
 			Description:            lo.ToPtr("new description"),
 		}),
 	}
 	s.Require().NoError(s.adapter.UpsertRunDetailedLines(ctx, charge.GetChargeID(), runBase.ID, replacementLines))
+
+	replacedKeepRow, err := s.dbClient.ChargeUsageBasedRunDetailedLine.Query().
+		Where(
+			dbchargeusagebasedrundetailedline.NamespaceEQ(namespace),
+			dbchargeusagebasedrundetailedline.ChargeIDEQ(charge.ID),
+			dbchargeusagebasedrundetailedline.RunIDEQ(runBase.ID.ID),
+			dbchargeusagebasedrundetailedline.ChildUniqueReferenceIDEQ("keep@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]"),
+			dbchargeusagebasedrundetailedline.DeletedAtIsNil(),
+		).
+		Only(ctx)
+	s.Require().NoError(err)
+	s.Equal(initialKeepRow.ID, replacedKeepRow.ID)
 
 	fetchedCharge, err := s.adapter.GetByID(ctx, usagebased.GetByIDInput{
 		ChargeID: charge.GetChargeID(),
@@ -189,13 +228,21 @@ func (s *DetailedLineAdapterSuite) TestUpsertRunDetailedLinesReplacesAndSoftDele
 		},
 	})
 	s.Require().NoError(err)
-	s.Require().Len(fetchedCharge.Realizations, 1)
-	s.True(fetchedCharge.Realizations[0].DetailedLines.IsPresent())
-	s.Len(fetchedCharge.Realizations[0].DetailedLines.OrEmpty(), 2)
-	s.Equal("keep@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]", fetchedCharge.Realizations[0].DetailedLines.OrEmpty()[0].ChildUniqueReferenceID)
-	s.Equal("new@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]", fetchedCharge.Realizations[0].DetailedLines.OrEmpty()[1].ChildUniqueReferenceID)
-	s.Equal(float64(3), fetchedCharge.Realizations[0].DetailedLines.OrEmpty()[0].Quantity.InexactFloat64())
-	s.Nil(fetchedCharge.Realizations[0].DetailedLines.OrEmpty()[0].Description)
+	fetchedRun, ok := lo.Find(fetchedCharge.Realizations, func(run usagebased.RealizationRun) bool {
+		return run.ID.ID == runBase.ID.ID
+	})
+	s.Require().True(ok)
+	s.True(fetchedRun.DetailedLines.IsPresent())
+	s.Len(fetchedRun.DetailedLines.OrEmpty(), 2)
+	s.Equal("keep@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]", fetchedRun.DetailedLines.OrEmpty()[0].ChildUniqueReferenceID)
+	s.Equal("new@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]", fetchedRun.DetailedLines.OrEmpty()[1].ChildUniqueReferenceID)
+	s.Equal("keep-pricer-reference", fetchedRun.DetailedLines.OrEmpty()[0].PricerReferenceID)
+	s.Equal("new@[2026-01-01T00:00:00Z..2026-02-01T00:00:00Z]", fetchedRun.DetailedLines.OrEmpty()[1].PricerReferenceID)
+	s.Equal(float64(3), fetchedRun.DetailedLines.OrEmpty()[0].Quantity.InexactFloat64())
+	s.Nil(fetchedRun.DetailedLines.OrEmpty()[0].Description)
+	s.Nil(fetchedRun.DetailedLines.OrEmpty()[0].CorrectsRunID)
+	s.Equal(float64(-4), fetchedRun.DetailedLines.OrEmpty()[1].Quantity.InexactFloat64())
+	s.Equal(lo.ToPtr(correctedRunBase.ID.ID), fetchedRun.DetailedLines.OrEmpty()[1].CorrectsRunID)
 
 	deletedRow, err := s.dbClient.ChargeUsageBasedRunDetailedLine.Query().
 		Where(
@@ -398,12 +445,14 @@ func (s *DetailedLineAdapterSuite) createChargeWithRun(namespace string) (usageb
 						Amount: alpacadecimal.NewFromFloat(0.1),
 					}),
 				},
-				FeatureID: featureID,
+				FeatureID:    featureID,
+				RatingEngine: usagebased.RatingEngineDelta,
 			},
 		},
 	})
 	s.Require().NoError(err)
 	s.Require().Len(createdCharges, 1)
+	s.Require().Equal(usagebased.RatingEngineDelta, createdCharges[0].State.RatingEngine)
 
 	charge := createdCharges[0]
 	runBase, err := s.adapter.CreateRealizationRun(s.T().Context(), charge.GetChargeID(), usagebased.CreateRealizationRunInput{
@@ -451,22 +500,26 @@ func (s *DetailedLineAdapterSuite) newDetailedLine(input newDetailedLineInput) u
 	s.T().Helper()
 
 	return usagebased.DetailedLine{
-		ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
-			Namespace:   input.Charge.Namespace,
-			Name:        "Detailed line",
-			Description: input.Description,
-		}),
-		ServicePeriod:          input.ServicePeriod,
-		Currency:               input.Charge.Intent.Currency,
-		ChildUniqueReferenceID: input.ChildUniqueReferenceID,
-		PaymentTerm:            productcatalog.InArrearsPaymentTerm,
-		PerUnitAmount:          alpacadecimal.NewFromFloat(0.1),
-		Quantity:               alpacadecimal.NewFromInt(input.Quantity),
-		Category:               stddetailedline.CategoryRegular,
-		Totals: totals.Totals{
-			Amount:       alpacadecimal.NewFromFloat(0.1).Mul(alpacadecimal.NewFromInt(input.Quantity)),
-			ChargesTotal: alpacadecimal.NewFromFloat(0.1).Mul(alpacadecimal.NewFromInt(input.Quantity)),
-			Total:        alpacadecimal.NewFromFloat(0.1).Mul(alpacadecimal.NewFromInt(input.Quantity)),
+		PricerReferenceID: lo.CoalesceOrEmpty(input.PricerReferenceID, input.ChildUniqueReferenceID),
+		Base: stddetailedline.Base{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace:   input.Charge.Namespace,
+				Name:        "Detailed line",
+				Description: input.Description,
+			}),
+			ServicePeriod:          input.ServicePeriod,
+			Currency:               input.Charge.Intent.Currency,
+			ChildUniqueReferenceID: input.ChildUniqueReferenceID,
+			PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+			PerUnitAmount:          alpacadecimal.NewFromFloat(0.1),
+			Quantity:               alpacadecimal.NewFromInt(input.Quantity),
+			Category:               stddetailedline.CategoryRegular,
+			Totals: totals.Totals{
+				Amount:       alpacadecimal.NewFromFloat(0.1).Mul(alpacadecimal.NewFromInt(input.Quantity)),
+				ChargesTotal: alpacadecimal.NewFromFloat(0.1).Mul(alpacadecimal.NewFromInt(input.Quantity)),
+				Total:        alpacadecimal.NewFromFloat(0.1).Mul(alpacadecimal.NewFromInt(input.Quantity)),
+			},
 		},
+		CorrectsRunID: input.CorrectsRunID,
 	}
 }

--- a/openmeter/billing/charges/usagebased/adapter/mapper.go
+++ b/openmeter/billing/charges/usagebased/adapter/mapper.go
@@ -56,6 +56,7 @@ func MapChargeBaseFromDB(entity *entdb.ChargeUsageBased) usagebased.ChargeBase {
 			CurrentRealizationRunID: entity.CurrentRealizationRunID,
 			AdvanceAfter:            entity.AdvanceAfter,
 			FeatureID:               entity.FeatureID,
+			RatingEngine:            entity.RatingEngine,
 		},
 	}
 }
@@ -95,13 +96,14 @@ func MapRealizationRunBaseFromDB(dbRun *entdb.ChargeUsageBasedRuns) usagebased.R
 		},
 		ManagedModel: entutils.MapTimeMixinFromDB(dbRun),
 
-		FeatureID:       dbRun.FeatureID,
-		LineID:          dbRun.LineID,
-		Type:            dbRun.Type,
-		StoredAtLT:      dbRun.StoredAtLt.UTC(),
-		ServicePeriodTo: dbRun.ServicePeriodTo.UTC(),
-		MeteredQuantity: dbRun.MeteredQuantity,
-		Totals:          totals.FromDB(dbRun),
+		FeatureID:                 dbRun.FeatureID,
+		LineID:                    dbRun.LineID,
+		Type:                      dbRun.Type,
+		StoredAtLT:                dbRun.StoredAtLt.UTC(),
+		ServicePeriodTo:           dbRun.ServicePeriodTo.UTC(),
+		MeteredQuantity:           dbRun.MeteredQuantity,
+		Totals:                    totals.FromDB(dbRun),
+		NoFiatTransactionRequired: dbRun.NoFiatTransactionRequired,
 	}
 }
 

--- a/openmeter/billing/charges/usagebased/adapter/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/adapter/realizationrun.go
@@ -31,7 +31,8 @@ func (a *adapter) CreateRealizationRun(ctx context.Context, chargeID meta.Charge
 			SetServicePeriodTo(meta.NormalizeTimestamp(input.ServicePeriodTo)).
 			SetDetailedLinesPresent(false).
 			SetNillableBillingInvoiceLineID(input.LineID).
-			SetMeteredQuantity(input.MeteredQuantity)
+			SetMeteredQuantity(input.MeteredQuantity).
+			SetNoFiatTransactionRequired(input.NoFiatTransactionRequired)
 
 		create = totals.Set(create, input.Totals)
 
@@ -67,6 +68,10 @@ func (a *adapter) UpdateRealizationRun(ctx context.Context, input usagebased.Upd
 
 		if input.Totals.IsPresent() {
 			update = totals.Set(update, input.Totals.OrEmpty())
+		}
+
+		if input.NoFiatTransactionRequired.IsPresent() {
+			update = update.SetNoFiatTransactionRequired(input.NoFiatTransactionRequired.OrEmpty())
 		}
 
 		dbRun, err := update.Save(ctx)

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -233,9 +233,10 @@ func (i Intent) Validate() error {
 }
 
 type State struct {
-	CurrentRealizationRunID *string    `json:"currentRealizationRunId"`
-	AdvanceAfter            *time.Time `json:"advanceAfter"`
-	FeatureID               string     `json:"featureId"`
+	CurrentRealizationRunID *string      `json:"currentRealizationRunId"`
+	AdvanceAfter            *time.Time   `json:"advanceAfter"`
+	FeatureID               string       `json:"featureId"`
+	RatingEngine            RatingEngine `json:"ratingEngine"`
 }
 
 func (s State) Normalized() State {
@@ -253,6 +254,10 @@ func (s State) Validate() error {
 
 	if s.FeatureID == "" {
 		errs = append(errs, fmt.Errorf("feature id must be set"))
+	}
+
+	if err := s.RatingEngine.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("rating engine: %w", err))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/billing/charges/usagebased/detailedline.go
+++ b/openmeter/billing/charges/usagebased/detailedline.go
@@ -1,23 +1,140 @@
 package usagebased
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-type DetailedLine = stddetailedline.Base
+type DetailedLine struct {
+	stddetailedline.Base
+
+	PricerReferenceID string  `json:"pricerReferenceID"`
+	CorrectsRunID     *string `json:"correctsRunId,omitempty"`
+}
+
+func (l DetailedLine) Clone() DetailedLine {
+	l.Base = l.Base.Clone()
+
+	if l.CorrectsRunID != nil {
+		l.CorrectsRunID = lo.ToPtr(*l.CorrectsRunID)
+	}
+
+	return l
+}
+
+func (l DetailedLine) Validate() error {
+	var errs []error
+
+	if err := l.Base.Validate(stddetailedline.IgnoreQuantityChecks()); err != nil {
+		errs = append(errs, err)
+	}
+
+	if l.PricerReferenceID == "" {
+		errs = append(errs, errors.New("pricer reference id must not be empty"))
+	}
+
+	if l.CorrectsRunID != nil && *l.CorrectsRunID == "" {
+		errs = append(errs, errors.New("corrects run id must not be empty"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
 
 type DetailedLines []DetailedLine
+
+func NewDetailedLinesFromBilling(
+	intent Intent,
+	defaultServicePeriod timeutil.ClosedPeriod,
+	lines billingrating.DetailedLines,
+) DetailedLines {
+	return lo.Map(lines, func(line billingrating.DetailedLine, idx int) DetailedLine {
+		period := defaultServicePeriod
+		if line.Period != nil {
+			period = *line.Period
+		}
+
+		category := line.Category
+		if category == "" {
+			category = stddetailedline.CategoryRegular
+		}
+
+		return DetailedLine{
+			PricerReferenceID: line.ChildUniqueReferenceID,
+			Base: stddetailedline.Base{
+				ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+					Name: line.Name,
+				}),
+				ServicePeriod:          period,
+				Index:                  lo.ToPtr(idx),
+				Currency:               intent.Currency,
+				ChildUniqueReferenceID: line.ChildUniqueReferenceID,
+				PaymentTerm:            lo.CoalesceOrEmpty(line.PaymentTerm, productcatalog.InArrearsPaymentTerm),
+				PerUnitAmount:          line.PerUnitAmount,
+				Quantity:               line.Quantity,
+				Category:               category,
+				CreditsApplied:         line.CreditsApplied,
+				Totals:                 line.Totals,
+				TaxConfig:              intent.TaxConfig.ToTaxConfig(),
+			},
+		}
+	})
+}
 
 func (l DetailedLines) Clone() DetailedLines {
 	return lo.Map(l, func(dl DetailedLine, _ int) DetailedLine {
 		return dl.Clone()
 	})
+}
+
+func (l DetailedLines) Sort() {
+	slices.SortStableFunc(l, compareDetailedLineForOutput)
+}
+
+func compareDetailedLineForOutput(a, b DetailedLine) int {
+	if c := a.ServicePeriod.From.Compare(b.ServicePeriod.From); c != 0 {
+		return c
+	}
+
+	if a.Index != nil && b.Index == nil {
+		return -1
+	}
+
+	if a.Index == nil && b.Index != nil {
+		return 1
+	}
+
+	if a.Index != nil && b.Index != nil {
+		if c := cmp.Compare(*a.Index, *b.Index); c != 0 {
+			return c
+		}
+	}
+
+	if c := cmp.Compare(a.ChildUniqueReferenceID, b.ChildUniqueReferenceID); c != 0 {
+		return c
+	}
+
+	return 0
+}
+
+func (l DetailedLines) SumTotals() totals.Totals {
+	out := totals.Totals{}
+
+	for _, line := range l {
+		out = out.Add(line.Totals)
+	}
+
+	return out
 }
 
 func (l DetailedLines) Validate() error {

--- a/openmeter/billing/charges/usagebased/detailedline.go
+++ b/openmeter/billing/charges/usagebased/detailedline.go
@@ -20,7 +20,7 @@ type DetailedLine struct {
 	stddetailedline.Base
 
 	PricerReferenceID string  `json:"pricerReferenceID"`
-	CorrectsRunID     *string `json:"correctsRunId,omitempty"`
+	CorrectsRunID     *string `json:"correctsRunID,omitempty"`
 }
 
 func (l DetailedLine) Clone() DetailedLine {

--- a/openmeter/billing/charges/usagebased/detailedline_uniqueref.go
+++ b/openmeter/billing/charges/usagebased/detailedline_uniqueref.go
@@ -1,0 +1,64 @@
+package usagebased
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/pkg/slicesx"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+// StripServicePeriodFromUniqueReferenceID returns cloned detailed lines where
+// ChildUniqueReferenceID is stripped at the first service-period suffix marker.
+func (l DetailedLines) StripServicePeriodFromUniqueReferenceID() (DetailedLines, error) {
+	return slicesx.MapWithErr(l, func(line DetailedLine) (DetailedLine, error) {
+		referenceID, err := stripServicePeriodFromUniqueReferenceID(line.ChildUniqueReferenceID)
+		if err != nil {
+			return DetailedLine{}, fmt.Errorf("stripping service period from unique reference id: %w", err)
+		}
+
+		line = line.Clone()
+		line.ChildUniqueReferenceID = referenceID
+		return line, nil
+	})
+}
+
+// WithServicePeriodFromUniqueReferenceID returns cloned detailed lines where
+// ChildUniqueReferenceID contains the line's ServicePeriod persistence suffix.
+func (l DetailedLines) WithServicePeriodFromUniqueReferenceID() (DetailedLines, error) {
+	lines, err := l.StripServicePeriodFromUniqueReferenceID()
+	if err != nil {
+		return nil, err
+	}
+
+	return lo.Map(lines, func(line DetailedLine, _ int) DetailedLine {
+		line.ChildUniqueReferenceID = formatServicePeriodInUniqueReferenceID(line.ChildUniqueReferenceID, line.ServicePeriod)
+		return line
+	}), nil
+}
+
+func stripServicePeriodFromUniqueReferenceID(id string) (string, error) {
+	idx := strings.Index(id, "@[")
+	if idx < 0 {
+		return id, nil
+	}
+
+	base := id[:idx]
+	if base == "" {
+		return "", fmt.Errorf("child unique reference id %q is missing base reference id", id)
+	}
+
+	return base, nil
+}
+
+func formatServicePeriodInUniqueReferenceID(id string, servicePeriod timeutil.ClosedPeriod) string {
+	return fmt.Sprintf(
+		"%s@[%s..%s]",
+		id,
+		servicePeriod.From.UTC().Format(time.RFC3339),
+		servicePeriod.To.UTC().Format(time.RFC3339),
+	)
+}

--- a/openmeter/billing/charges/usagebased/rating.go
+++ b/openmeter/billing/charges/usagebased/rating.go
@@ -55,12 +55,16 @@ func (r RateableIntent) GetRateCardDiscounts() billing.Discounts {
 	if r.Discounts.Usage != nil {
 		out.Usage = &billing.UsageDiscount{
 			UsageDiscount: *r.Discounts.Usage,
+			// Note: given we are not using splitlinegroups this correlation ID is not used for anything in charges.
+			CorrelationID: "usagebased-ratecard-usage",
 		}
 	}
 
 	if r.Discounts.Percentage != nil {
 		out.Percentage = &billing.PercentageDiscount{
 			PercentageDiscount: *r.Discounts.Percentage,
+			// Note: given we are not using splitlinegroups this correlation ID is not used for anything in charges.
+			CorrelationID: "usagebased-ratecard-percentage",
 		}
 	}
 

--- a/openmeter/billing/charges/usagebased/ratingengine.go
+++ b/openmeter/billing/charges/usagebased/ratingengine.go
@@ -1,0 +1,35 @@
+package usagebased
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type RatingEngine string
+
+const (
+	// RatingEngineDelta rates the current cumulative meter snapshot, subtracts
+	// already booked detailed lines, and books the remainder on the current run
+	// service period.
+	RatingEngineDelta RatingEngine = "delta"
+	// RatingEnginePeriodPreserving rates cumulative snapshots per service
+	// period and preserves correction lines on their original service periods.
+	RatingEnginePeriodPreserving RatingEngine = "period_preserving"
+)
+
+func (e RatingEngine) Values() []string {
+	return []string{
+		string(RatingEngineDelta),
+		string(RatingEnginePeriodPreserving),
+	}
+}
+
+func (e RatingEngine) Validate() error {
+	if !slices.Contains(e.Values(), string(e)) {
+		return models.NewGenericValidationError(fmt.Errorf("invalid rating engine: %s", e))
+	}
+
+	return nil
+}

--- a/openmeter/billing/charges/usagebased/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/realizationrun.go
@@ -45,14 +45,29 @@ func (i RealizationRunID) Validate() error {
 	return models.NamespacedID(i).Validate()
 }
 
+// BillingMeteredQuantity maps a cumulative charge run quantity to the quantity
+// semantics expected by billing.StandardLine. RealizationRun.MeteredQuantity is
+// cumulative from the charge service-period start to the run's ServicePeriodTo,
+// while standard invoice lines need the current line-period quantity plus the
+// quantity already represented by earlier billed lines.
+type BillingMeteredQuantity struct {
+	// PreLinePeriod is the cumulative quantity already represented by earlier
+	// billed runs.
+	PreLinePeriod alpacadecimal.Decimal
+	// LinePeriod is the quantity represented by the current standard invoice
+	// line.
+	LinePeriod alpacadecimal.Decimal
+}
+
 type CreateRealizationRunInput struct {
-	FeatureID       string                `json:"featureId"`
-	Type            RealizationRunType    `json:"type"`
-	StoredAtLT      time.Time             `json:"storedAtLT"`
-	ServicePeriodTo time.Time             `json:"servicePeriodTo"`
-	LineID          *string               `json:"lineId,omitempty"`
-	MeteredQuantity alpacadecimal.Decimal `json:"meteredQuantity"`
-	Totals          totals.Totals         `json:"totals"`
+	FeatureID                 string                `json:"featureId"`
+	Type                      RealizationRunType    `json:"type"`
+	StoredAtLT                time.Time             `json:"storedAtLT"`
+	ServicePeriodTo           time.Time             `json:"servicePeriodTo"`
+	LineID                    *string               `json:"lineId,omitempty"`
+	MeteredQuantity           alpacadecimal.Decimal `json:"meteredQuantity"`
+	Totals                    totals.Totals         `json:"totals"`
+	NoFiatTransactionRequired bool                  `json:"noFiatTransactionRequired"`
 }
 
 func (r CreateRealizationRunInput) Normalized() CreateRealizationRunInput {
@@ -99,10 +114,11 @@ func (r CreateRealizationRunInput) Validate() error {
 type UpdateRealizationRunInput struct {
 	ID RealizationRunID
 
-	StoredAtLT      mo.Option[time.Time]             `json:"storedAtLT"`
-	LineID          mo.Option[*string]               `json:"lineId,omitempty"`
-	MeteredQuantity mo.Option[alpacadecimal.Decimal] `json:"meteredQuantity"`
-	Totals          mo.Option[totals.Totals]         `json:"totals"`
+	StoredAtLT                mo.Option[time.Time]             `json:"storedAtLT"`
+	LineID                    mo.Option[*string]               `json:"lineId,omitempty"`
+	MeteredQuantity           mo.Option[alpacadecimal.Decimal] `json:"meteredQuantity"`
+	Totals                    mo.Option[totals.Totals]         `json:"totals"`
+	NoFiatTransactionRequired mo.Option[bool]                  `json:"noFiatTransactionRequired"`
 }
 
 func (r UpdateRealizationRunInput) Normalized() UpdateRealizationRunInput {
@@ -157,8 +173,9 @@ type RealizationRunBase struct {
 	// ServicePeriodTo is the end of the service period for the realization run.
 	ServicePeriodTo time.Time `json:"servicePeriodTo"`
 	// MeteredQuantity is the metered quantity for time IN [intent.servicePeriod.from, servicePeriodTo) capped by stored_at < StoredAtLT.
-	MeteredQuantity alpacadecimal.Decimal `json:"meteredQuantity"`
-	Totals          totals.Totals         `json:"totals"`
+	MeteredQuantity           alpacadecimal.Decimal `json:"meteredQuantity"`
+	Totals                    totals.Totals         `json:"totals"`
+	NoFiatTransactionRequired bool                  `json:"noFiatTransactionRequired"`
 }
 
 func (r RealizationRunBase) Normalized() RealizationRunBase {
@@ -253,6 +270,49 @@ func (r RealizationRun) Validate() error {
 }
 
 type RealizationRuns []RealizationRun
+
+func (r RealizationRuns) MapToBillingMeteredQuantity(currentRun RealizationRun) (BillingMeteredQuantity, error) {
+	preLinePeriod := alpacadecimal.Zero
+	var latestPriorRun *RealizationRun
+
+	for idx := range r {
+		if r[idx].Type != RealizationRunTypeFinalRealization && r[idx].Type != RealizationRunTypePartialInvoice {
+			continue
+		}
+
+		if !r[idx].ServicePeriodTo.Before(currentRun.ServicePeriodTo) {
+			continue
+		}
+
+		if latestPriorRun == nil || r[idx].ServicePeriodTo.After(latestPriorRun.ServicePeriodTo) {
+			latestPriorRun = &r[idx]
+		}
+	}
+
+	if latestPriorRun != nil {
+		// Standard invoice line quantities intentionally use the prior run's
+		// persisted cumulative quantity. That value may have been captured with
+		// an older StoredAtLT than the current run. Period-preserving rating may
+		// still freshly snapshot prior event-time periods with the current
+		// StoredAtLT for correction calculation, but invoice line quantities
+		// should reflect what was previously billed.
+		preLinePeriod = latestPriorRun.MeteredQuantity
+	}
+
+	linePeriod := currentRun.MeteredQuantity.Sub(preLinePeriod)
+	if linePeriod.IsNegative() {
+		return BillingMeteredQuantity{}, fmt.Errorf(
+			"line period metered quantity is negative: current=%s pre_line=%s",
+			currentRun.MeteredQuantity.String(),
+			preLinePeriod.String(),
+		)
+	}
+
+	return BillingMeteredQuantity{
+		PreLinePeriod: preLinePeriod,
+		LinePeriod:    linePeriod,
+	}, nil
+}
 
 func (r RealizationRuns) Validate() error {
 	var errs []error

--- a/openmeter/billing/charges/usagebased/realizationrun_test.go
+++ b/openmeter/billing/charges/usagebased/realizationrun_test.go
@@ -1,0 +1,105 @@
+package usagebased
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRealizationRuns_MapToBillingMeteredQuantity(t *testing.T) {
+	periodStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		runs        RealizationRuns
+		currentRun  RealizationRun
+		wantLine    float64
+		wantPreLine float64
+		wantErr     bool
+	}{
+		{
+			name: "first run has no pre-line period quantity",
+			currentRun: newRealizationRunForBillingMeteredQuantityTest(
+				"current",
+				RealizationRunTypePartialInvoice,
+				periodStart.Add(24*time.Hour),
+				5,
+			),
+			wantLine:    5,
+			wantPreLine: 0,
+		},
+		{
+			name: "uses latest prior persisted cumulative quantity",
+			runs: RealizationRuns{
+				newRealizationRunForBillingMeteredQuantityTest(
+					"run-1",
+					RealizationRunTypePartialInvoice,
+					periodStart.Add(24*time.Hour),
+					5,
+				),
+				newRealizationRunForBillingMeteredQuantityTest(
+					"run-2",
+					RealizationRunTypePartialInvoice,
+					periodStart.Add(48*time.Hour),
+					8,
+				),
+			},
+			currentRun: newRealizationRunForBillingMeteredQuantityTest(
+				"current",
+				RealizationRunTypeFinalRealization,
+				periodStart.Add(72*time.Hour),
+				20,
+			),
+			wantLine:    12,
+			wantPreLine: 8,
+		},
+		{
+			name: "errors when current cumulative quantity is below prior billed quantity",
+			runs: RealizationRuns{
+				newRealizationRunForBillingMeteredQuantityTest(
+					"run-1",
+					RealizationRunTypePartialInvoice,
+					periodStart.Add(24*time.Hour),
+					10,
+				),
+			},
+			currentRun: newRealizationRunForBillingMeteredQuantityTest(
+				"current",
+				RealizationRunTypeFinalRealization,
+				periodStart.Add(48*time.Hour),
+				5,
+			),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			billingMeteredQuantity, err := tt.runs.MapToBillingMeteredQuantity(tt.currentRun)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantLine, billingMeteredQuantity.LinePeriod.InexactFloat64())
+			require.Equal(t, tt.wantPreLine, billingMeteredQuantity.PreLinePeriod.InexactFloat64())
+		})
+	}
+}
+
+func newRealizationRunForBillingMeteredQuantityTest(id string, typ RealizationRunType, servicePeriodTo time.Time, meteredQuantity int64) RealizationRun {
+	return RealizationRun{
+		RealizationRunBase: RealizationRunBase{
+			ID: RealizationRunID{
+				Namespace: "namespace",
+				ID:        id,
+			},
+			Type:            typ,
+			ServicePeriodTo: servicePeriodTo,
+			MeteredQuantity: alpacadecimal.NewFromInt(meteredQuantity),
+		},
+	}
+}

--- a/openmeter/billing/charges/usagebased/service.go
+++ b/openmeter/billing/charges/usagebased/service.go
@@ -57,7 +57,8 @@ type ChargeWithGatheringLine struct {
 
 type CreateIntent struct {
 	Intent
-	FeatureID string
+	FeatureID    string
+	RatingEngine RatingEngine
 }
 
 func (i CreateIntent) Validate() error {
@@ -69,6 +70,10 @@ func (i CreateIntent) Validate() error {
 
 	if i.FeatureID == "" {
 		errs = append(errs, errors.New("feature id is required"))
+	}
+
+	if err := i.RatingEngine.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("rating engine: %w", err))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/billing/charges/usagebased/service/create.go
+++ b/openmeter/billing/charges/usagebased/service/create.go
@@ -35,8 +35,9 @@ func (s *service) Create(ctx context.Context, input usagebased.CreateInput) ([]u
 			}
 
 			return usagebased.CreateIntent{
-				Intent:    intent,
-				FeatureID: featureMeter.Feature.ID,
+				Intent:       intent,
+				FeatureID:    featureMeter.Feature.ID,
+				RatingEngine: s.rater.GetPreferredRatingEngineFor(intent),
 			}, nil
 		})
 		if err != nil {

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -333,10 +333,11 @@ func (s *CreditThenInvoiceStateMachine) SnapshotInvoiceUsage(ctx context.Context
 	currentRun.DetailedLines = mo.Some(ratingResult.DetailedLines)
 
 	currentRunBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
-		ID:              currentRun.ID,
-		StoredAtLT:      mo.Some(storedAtLT),
-		MeteredQuantity: mo.Some(ratingResult.Quantity),
-		Totals:          mo.Some(currentTotals),
+		ID:                        currentRun.ID,
+		StoredAtLT:                mo.Some(storedAtLT),
+		MeteredQuantity:           mo.Some(ratingResult.Quantity),
+		Totals:                    mo.Some(currentTotals),
+		NoFiatTransactionRequired: mo.Some(currentTotals.Total.IsZero()),
 	})
 	if err != nil {
 		return fmt.Errorf("update realization run: %w", err)

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -151,14 +151,15 @@ func (s *CreditsOnlyStateMachine) StartFinalRealizationRun(ctx context.Context) 
 	}
 
 	result, err := s.Runs.CreateRatedRun(ctx, usagebasedrun.CreateRatedRunInput{
-		Charge:             s.Charge,
-		CustomerOverride:   s.CustomerOverride,
-		FeatureMeter:       s.FeatureMeter,
-		Type:               usagebased.RealizationRunTypeFinalRealization,
-		StoredAtLT:         storedAtLT,
-		ServicePeriodTo:    meta.NormalizeTimestamp(s.Charge.Intent.ServicePeriod.To),
-		CreditAllocation:   usagebasedrun.CreditAllocationExact,
-		CurrencyCalculator: s.CurrencyCalculator,
+		Charge:                    s.Charge,
+		CustomerOverride:          s.CustomerOverride,
+		FeatureMeter:              s.FeatureMeter,
+		Type:                      usagebased.RealizationRunTypeFinalRealization,
+		StoredAtLT:                storedAtLT,
+		ServicePeriodTo:           meta.NormalizeTimestamp(s.Charge.Intent.ServicePeriod.To),
+		CreditAllocation:          usagebasedrun.CreditAllocationExact,
+		CurrencyCalculator:        s.CurrencyCalculator,
+		NoFiatTransactionRequired: true,
 	})
 	if err != nil {
 		return err
@@ -214,10 +215,11 @@ func (s *CreditsOnlyStateMachine) FinalizeRealizationRun(ctx context.Context) er
 	currentRun.DetailedLines = mo.Some(ratingResult.DetailedLines)
 
 	currentRunBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
-		ID:              currentRun.ID,
-		StoredAtLT:      mo.Some(storedAtLT),
-		MeteredQuantity: mo.Some(ratingResult.Quantity),
-		Totals:          mo.Some(currentTotals),
+		ID:                        currentRun.ID,
+		StoredAtLT:                mo.Some(storedAtLT),
+		MeteredQuantity:           mo.Some(ratingResult.Quantity),
+		Totals:                    mo.Some(currentTotals),
+		NoFiatTransactionRequired: mo.Some(true),
 	})
 	if err != nil {
 		return fmt.Errorf("update realization run: %w", err)

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
-	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -160,13 +158,14 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 			return nil, fmt.Errorf("advancing usage based charge[%s] after %s: %w", stateMachine.GetCharge().ID, trigger, err)
 		}
 
-		currentRun, err := stateMachine.GetCharge().GetCurrentRealizationRun()
+		charge := stateMachine.GetCharge()
+		currentRun, err := charge.GetCurrentRealizationRun()
 		if err != nil {
-			return nil, fmt.Errorf("getting current realization run for charge[%s]: %w", stateMachine.GetCharge().ID, err)
+			return nil, fmt.Errorf("getting current realization run for charge[%s]: %w", charge.ID, err)
 		}
 
-		if err := populateUsageBasedStandardLineFromRun(stdLine, currentRun); err != nil {
-			return nil, fmt.Errorf("populating standard line from run for charge[%s]: %w", stateMachine.GetCharge().ID, err)
+		if err := populateUsageBasedStandardLineFromRun(stdLine, currentRun, charge.Realizations); err != nil {
+			return nil, fmt.Errorf("populating standard line from run for charge[%s]: %w", charge.ID, err)
 		}
 
 		if err := stdLine.Validate(); err != nil {
@@ -179,10 +178,7 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 		return nil, err
 	}
 
-	return e.CalculateLines(billing.CalculateLinesInput{
-		Invoice: input.Invoice,
-		Lines:   stdLines,
-	})
+	return stdLines, nil
 }
 
 func (e *LineEngine) OnCollectionCompleted(ctx context.Context, input billing.OnCollectionCompletedInput) (billing.StandardLines, error) {
@@ -213,13 +209,18 @@ func (e *LineEngine) OnCollectionCompleted(ctx context.Context, input billing.On
 			return nil, fmt.Errorf("advancing usage based charge[%s] after collection_completed: %w", stateMachine.GetCharge().ID, err)
 		}
 
-		currentRun, err := stateMachine.GetCharge().GetCurrentRealizationRun()
+		charge := stateMachine.GetCharge()
+		currentRun, err := charge.GetCurrentRealizationRun()
 		if err != nil {
-			return nil, fmt.Errorf("getting current realization run for charge[%s]: %w", stateMachine.GetCharge().ID, err)
+			return nil, fmt.Errorf("getting current realization run for charge[%s]: %w", charge.ID, err)
 		}
 
-		if err := populateUsageBasedStandardLineFromRun(stdLine, currentRun); err != nil {
-			return nil, fmt.Errorf("populating standard line from run for charge[%s]: %w", stateMachine.GetCharge().ID, err)
+		if err := populateUsageBasedStandardLineFromRun(stdLine, currentRun, charge.Realizations); err != nil {
+			return nil, fmt.Errorf("populating standard line from run for charge[%s]: %w", charge.ID, err)
+		}
+
+		if err := stdLine.Validate(); err != nil {
+			return nil, fmt.Errorf("validating standard line[%s]: %w", stdLine.ID, err)
 		}
 	}
 
@@ -266,58 +267,6 @@ func (e *LineEngine) OnPaymentSettled(ctx context.Context, input billing.OnPayme
 		Invoice:  input.Invoice,
 		RecordFn: e.recordPaymentSettled,
 	})
-}
-
-func (e *LineEngine) CalculateLines(input billing.CalculateLinesInput) (billing.StandardLines, error) {
-	if input.Invoice.ID == "" {
-		return nil, fmt.Errorf("invoice id is required")
-	}
-
-	if len(input.Lines) == 0 {
-		return nil, fmt.Errorf("lines are required")
-	}
-
-	for _, stdLine := range input.Lines {
-		if stdLine.ChargeID == nil {
-			return nil, fmt.Errorf("usage based standard line[%s]: charge id is required", stdLine.ID)
-		}
-
-		generatedDetailedLines, err := e.service.ratingService.GenerateDetailedLines(stdLine)
-		if err != nil {
-			return nil, fmt.Errorf("generating detailed lines for line[%s]: %w", stdLine.ID, err)
-		}
-
-		if err := invoicecalc.MergeGeneratedDetailedLines(stdLine, generatedDetailedLines); err != nil {
-			return nil, fmt.Errorf("merging detailed lines for line[%s]: %w", stdLine.ID, err)
-		}
-
-		if err := stdLine.Validate(); err != nil {
-			return nil, fmt.Errorf("validating standard line[%s]: %w", stdLine.ID, err)
-		}
-	}
-
-	return input.Lines, nil
-}
-
-func populateUsageBasedStandardLineFromRun(stdLine *billing.StandardLine, run usagebased.RealizationRun) error {
-	if stdLine.UsageBased == nil {
-		stdLine.UsageBased = &billing.UsageBasedLine{}
-	}
-
-	stdLine.OverrideCollectionPeriodEnd = lo.ToPtr(run.StoredAtLT.Add(usagebased.InternalCollectionPeriod))
-	stdLine.UsageBased.Quantity = lo.ToPtr(run.MeteredQuantity)
-	stdLine.UsageBased.MeteredQuantity = lo.ToPtr(run.MeteredQuantity)
-	stdLine.UsageBased.PreLinePeriodQuantity = lo.ToPtr(alpacadecimal.Zero)
-	stdLine.UsageBased.MeteredPreLinePeriodQuantity = lo.ToPtr(alpacadecimal.Zero)
-
-	creditsApplied, err := run.CreditsAllocated.AsCreditsApplied()
-	if err != nil {
-		return err
-	}
-
-	stdLine.CreditsApplied = creditsApplied
-
-	return nil
 }
 
 type fireLineTriggerInput struct {

--- a/openmeter/billing/charges/usagebased/service/linemapper.go
+++ b/openmeter/billing/charges/usagebased/service/linemapper.go
@@ -1,0 +1,154 @@
+package service
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating/service/mutator"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+)
+
+func populateUsageBasedStandardLineFromRun(stdLine *billing.StandardLine, run usagebased.RealizationRun, runs usagebased.RealizationRuns) error {
+	if stdLine.UsageBased == nil {
+		stdLine.UsageBased = &billing.UsageBasedLine{}
+	}
+
+	currencyCalculator, err := stdLine.Currency.Calculator()
+	if err != nil {
+		return fmt.Errorf("creating currency calculator: %w", err)
+	}
+
+	billingMeteredQuantity, err := runs.MapToBillingMeteredQuantity(run)
+	if err != nil {
+		return fmt.Errorf("mapping run metered quantity to billing: %w", err)
+	}
+
+	stdLine.OverrideCollectionPeriodEnd = lo.ToPtr(run.StoredAtLT.Add(usagebased.InternalCollectionPeriod))
+	stdLine.UsageBased.MeteredQuantity = lo.ToPtr(billingMeteredQuantity.LinePeriod)
+	stdLine.UsageBased.MeteredPreLinePeriodQuantity = lo.ToPtr(billingMeteredQuantity.PreLinePeriod)
+
+	// Charge runs store cumulative raw metered quantity. Billing lines expose the raw
+	// metered values separately from net billable quantities and consumed usage discounts,
+	// so reuse the standard billing usage-discount mutator contract here.
+	discountedUsage, err := mutator.ApplyUsageDiscount(mutator.ApplyUsageDiscountInput{
+		Usage: billingrating.Usage{
+			Quantity:              billingMeteredQuantity.LinePeriod,
+			PreLinePeriodQuantity: billingMeteredQuantity.PreLinePeriod,
+		},
+		RateCardDiscounts:     stdLine.RateCardDiscounts,
+		StandardLineDiscounts: stdLine.Discounts,
+	})
+	if err != nil {
+		return fmt.Errorf("applying usage discount: %w", err)
+	}
+
+	stdLine.UsageBased.Quantity = lo.ToPtr(discountedUsage.Usage.Quantity)
+	stdLine.UsageBased.PreLinePeriodQuantity = lo.ToPtr(discountedUsage.Usage.PreLinePeriodQuantity)
+	stdLine.Discounts = discountedUsage.StandardLineDiscounts
+
+	creditsApplied, err := run.CreditsAllocated.AsCreditsApplied()
+	if err != nil {
+		return err
+	}
+
+	stdLine.CreditsApplied = creditsApplied
+
+	projectedDetailedLines, err := projectUsageBasedDetailedLines(stdLine, run, currencyCalculator)
+	if err != nil {
+		return fmt.Errorf("projecting run detailed lines: %w", err)
+	}
+
+	stdLine.DetailedLines = stdLine.DetailedLinesWithIDReuse(projectedDetailedLines)
+	stdLine.Totals = stdLine.DetailedLines.SumTotals().RoundToPrecision(currencyCalculator)
+
+	expectedTotals := run.Totals.RoundToPrecision(currencyCalculator)
+	if !stdLine.Totals.Equal(expectedTotals) {
+		return fmt.Errorf("projected line totals do not match run totals [line_id=%s run_id=%s line_total=%s run_total=%s]",
+			stdLine.ID, run.ID.ID, stdLine.Totals.Total.String(), expectedTotals.Total.String())
+	}
+
+	return nil
+}
+
+func projectUsageBasedDetailedLines(
+	stdLine *billing.StandardLine,
+	run usagebased.RealizationRun,
+	currencyCalculator currencyx.Calculator,
+) (billing.DetailedLines, error) {
+	if run.DetailedLines.IsAbsent() {
+		return nil, fmt.Errorf("run %s detailed lines must be expanded", run.ID.ID)
+	}
+
+	detailedLines := lo.Map(run.DetailedLines.OrEmpty(), func(line usagebased.DetailedLine, _ int) billing.DetailedLine {
+		base := line.Base.Clone()
+		base.Namespace = stdLine.Namespace
+		base.ID = ""
+		base.CreatedAt = time.Time{}
+		base.UpdatedAt = time.Time{}
+		base.DeletedAt = nil
+		// Extra logic to reset credits applied before credits are applied. The rating output should not contain credits, but let's make sure.
+		base.CreditsApplied = nil
+		base.Totals.CreditsTotal = alpacadecimal.Zero
+		base.Totals.Total = base.Totals.CalculateTotal()
+
+		return billing.DetailedLine{
+			DetailedLineBase: billing.DetailedLineBase{
+				Base:      base,
+				InvoiceID: stdLine.InvoiceID,
+			},
+		}
+	})
+
+	detailedLines, err := applyUsageBasedRunCreditsToDetailedLines(detailedLines, stdLine.CreditsApplied, currencyCalculator)
+	if err != nil {
+		return nil, err
+	}
+
+	return detailedLines, nil
+}
+
+func applyUsageBasedRunCreditsToDetailedLines(
+	detailedLines billing.DetailedLines,
+	creditsApplied billing.CreditsApplied,
+	currencyCalculator currencyx.Calculator,
+) (billing.DetailedLines, error) {
+	for _, creditToApply := range creditsApplied {
+		creditValueRemaining := currencyCalculator.RoundToPrecision(creditToApply.Amount)
+
+		for idx := range detailedLines {
+			if creditValueRemaining.IsZero() {
+				break
+			}
+
+			totalAmount := currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.Total)
+			if !totalAmount.IsPositive() {
+				continue
+			}
+
+			if totalAmount.LessThanOrEqual(creditValueRemaining) {
+				creditValueRemaining = currencyCalculator.RoundToPrecision(creditValueRemaining.Sub(totalAmount))
+				detailedLines[idx].CreditsApplied = append(detailedLines[idx].CreditsApplied, creditToApply.CloneWithAmount(totalAmount))
+				detailedLines[idx].Totals.CreditsTotal = currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.CreditsTotal.Add(totalAmount))
+				detailedLines[idx].Totals.Total = currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.Total.Sub(totalAmount))
+			} else {
+				detailedLines[idx].CreditsApplied = append(detailedLines[idx].CreditsApplied, creditToApply.CloneWithAmount(creditValueRemaining))
+				detailedLines[idx].Totals.CreditsTotal = currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.CreditsTotal.Add(creditValueRemaining))
+				detailedLines[idx].Totals.Total = currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.Total.Sub(creditValueRemaining))
+				creditValueRemaining = alpacadecimal.Zero
+				break
+			}
+		}
+
+		if creditValueRemaining.IsPositive() {
+			return nil, billing.ErrInvoiceLineCreditsNotConsumedFully
+		}
+	}
+
+	return detailedLines, nil
+}

--- a/openmeter/billing/charges/usagebased/service/linemapper_test.go
+++ b/openmeter/billing/charges/usagebased/service/linemapper_test.go
@@ -1,0 +1,262 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestPopulateUsageBasedStandardLineFromRunProjectsDetailsAndCredits(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	line := newUsageBasedStandardLineForTest(period)
+	line.DetailedLines = billing.DetailedLines{
+		{
+			DetailedLineBase: billing.DetailedLineBase{
+				Base: stddetailedline.Base{
+					ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+						ID:        "existing-detail-id",
+						Namespace: line.Namespace,
+						Name:      "existing",
+					}),
+					ChildUniqueReferenceID: "usage-a",
+				},
+			},
+		},
+	}
+
+	run := usagebased.RealizationRun{
+		RealizationRunBase: usagebased.RealizationRunBase{
+			ID: usagebased.RealizationRunID{
+				Namespace: line.Namespace,
+				ID:        "run-id",
+			},
+			StoredAtLT:      period.To,
+			ServicePeriodTo: period.To,
+			MeteredQuantity: alpacadecimal.NewFromInt(20),
+			Totals: totals.Totals{
+				Amount:       alpacadecimal.NewFromInt(20),
+				CreditsTotal: alpacadecimal.NewFromInt(7),
+				Total:        alpacadecimal.NewFromInt(13),
+			},
+		},
+		CreditsAllocated: creditrealization.Realizations{
+			{
+				NamespacedModel: models.NamespacedModel{
+					Namespace: line.Namespace,
+				},
+				CreateInput: creditrealization.CreateInput{
+					ID: "credit-realization-id",
+					LedgerTransaction: ledgertransaction.GroupReference{
+						TransactionGroupID: "ledger-transaction-id",
+					},
+					ServicePeriod: period,
+					Amount:        alpacadecimal.NewFromInt(7),
+					Type:          creditrealization.TypeAllocation,
+				},
+			},
+		},
+		DetailedLines: mo.Some(usagebased.DetailedLines{
+			newUsageBasedDetailedLineForTest("usage-a", period, alpacadecimal.NewFromInt(10)),
+			newUsageBasedDetailedLineForTest("usage-b", period, alpacadecimal.NewFromInt(10)),
+		}),
+	}
+
+	priorRun := usagebased.RealizationRun{
+		RealizationRunBase: usagebased.RealizationRunBase{
+			ID: usagebased.RealizationRunID{
+				Namespace: line.Namespace,
+				ID:        "prior-run-id",
+			},
+			Type:            usagebased.RealizationRunTypePartialInvoice,
+			StoredAtLT:      period.From,
+			ServicePeriodTo: period.From.Add(24 * time.Hour),
+			MeteredQuantity: alpacadecimal.NewFromInt(5),
+			Totals: totals.Totals{
+				Amount: alpacadecimal.NewFromInt(5),
+				Total:  alpacadecimal.NewFromInt(5),
+			},
+		},
+	}
+
+	err := populateUsageBasedStandardLineFromRun(line, run, usagebased.RealizationRuns{priorRun, run})
+	require.NoError(t, err)
+
+	require.Len(t, line.DetailedLines, 2)
+	require.Equal(t, "existing-detail-id", line.DetailedLines[0].ID)
+	require.Equal(t, line.InvoiceID, line.DetailedLines[0].InvoiceID)
+	require.Equal(t, line.Namespace, line.DetailedLines[0].Namespace)
+	require.Len(t, line.DetailedLines[0].CreditsApplied, 1)
+	require.Equal(t, float64(7), line.DetailedLines[0].CreditsApplied[0].Amount.InexactFloat64())
+	require.Equal(t, float64(3), line.DetailedLines[0].Totals.Total.InexactFloat64())
+	require.Empty(t, line.DetailedLines[1].CreditsApplied)
+	require.Equal(t, float64(10), line.DetailedLines[1].Totals.Total.InexactFloat64())
+	require.Len(t, line.CreditsApplied, 1)
+	require.Equal(t, float64(13), line.Totals.Total.InexactFloat64())
+	require.Equal(t, float64(15), lo.FromPtr(line.UsageBased.Quantity).InexactFloat64())
+	require.Equal(t, float64(15), lo.FromPtr(line.UsageBased.MeteredQuantity).InexactFloat64())
+	require.Equal(t, float64(5), lo.FromPtr(line.UsageBased.PreLinePeriodQuantity).InexactFloat64())
+	require.Equal(t, float64(5), lo.FromPtr(line.UsageBased.MeteredPreLinePeriodQuantity).InexactFloat64())
+}
+
+func TestPopulateUsageBasedStandardLineFromRunAppliesUsageDiscount(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	line := newUsageBasedStandardLineForTest(period)
+	line.RateCardDiscounts.Usage = &billing.UsageDiscount{
+		UsageDiscount: productcatalog.UsageDiscount{
+			Quantity: alpacadecimal.NewFromInt(10),
+		},
+		CorrelationID: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+	}
+
+	run := usagebased.RealizationRun{
+		RealizationRunBase: usagebased.RealizationRunBase{
+			ID: usagebased.RealizationRunID{
+				Namespace: line.Namespace,
+				ID:        "run-id",
+			},
+			StoredAtLT:      period.To,
+			ServicePeriodTo: period.To,
+			MeteredQuantity: alpacadecimal.NewFromInt(20),
+			Totals: totals.Totals{
+				Amount: alpacadecimal.NewFromInt(10),
+				Total:  alpacadecimal.NewFromInt(10),
+			},
+		},
+		DetailedLines: mo.Some(usagebased.DetailedLines{
+			newUsageBasedDetailedLineForTest("usage-a", period, alpacadecimal.NewFromInt(10)),
+		}),
+	}
+
+	priorRun := usagebased.RealizationRun{
+		RealizationRunBase: usagebased.RealizationRunBase{
+			ID: usagebased.RealizationRunID{
+				Namespace: line.Namespace,
+				ID:        "prior-run-id",
+			},
+			Type:            usagebased.RealizationRunTypePartialInvoice,
+			StoredAtLT:      period.From,
+			ServicePeriodTo: period.From.Add(24 * time.Hour),
+			MeteredQuantity: alpacadecimal.NewFromInt(5),
+		},
+	}
+
+	err := populateUsageBasedStandardLineFromRun(line, run, usagebased.RealizationRuns{priorRun, run})
+	require.NoError(t, err)
+
+	require.Equal(t, float64(10), lo.FromPtr(line.UsageBased.Quantity).InexactFloat64())
+	require.Equal(t, float64(15), lo.FromPtr(line.UsageBased.MeteredQuantity).InexactFloat64())
+	require.Equal(t, float64(0), lo.FromPtr(line.UsageBased.PreLinePeriodQuantity).InexactFloat64())
+	require.Equal(t, float64(5), lo.FromPtr(line.UsageBased.MeteredPreLinePeriodQuantity).InexactFloat64())
+
+	require.Len(t, line.Discounts.Usage, 1)
+	usageDiscount := line.Discounts.Usage[0]
+	require.Equal(t, "rateCardDiscount/correlationID=01ARZ3NDEKTSV4RRFFQ69G5FAV", lo.FromPtr(usageDiscount.ChildUniqueReferenceID))
+	require.Equal(t, float64(5), usageDiscount.Quantity.InexactFloat64())
+	require.Equal(t, float64(5), lo.FromPtr(usageDiscount.PreLinePeriodQuantity).InexactFloat64())
+
+	reason, err := usageDiscount.Reason.AsRatecardUsage()
+	require.NoError(t, err)
+	require.Equal(t, "01ARZ3NDEKTSV4RRFFQ69G5FAV", reason.CorrelationID)
+	require.Equal(t, float64(10), reason.Quantity.InexactFloat64())
+}
+
+func TestPopulateUsageBasedStandardLineFromRunRequiresExpandedDetails(t *testing.T) {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	line := newUsageBasedStandardLineForTest(period)
+	run := usagebased.RealizationRun{
+		RealizationRunBase: usagebased.RealizationRunBase{
+			ID: usagebased.RealizationRunID{
+				Namespace: line.Namespace,
+				ID:        "run-id",
+			},
+			StoredAtLT:      period.To,
+			ServicePeriodTo: period.To,
+			MeteredQuantity: alpacadecimal.NewFromInt(20),
+			Totals: totals.Totals{
+				Amount: alpacadecimal.NewFromInt(20),
+				Total:  alpacadecimal.NewFromInt(20),
+			},
+		},
+	}
+
+	err := populateUsageBasedStandardLineFromRun(line, run, usagebased.RealizationRuns{run})
+	require.ErrorContains(t, err, "detailed lines must be expanded")
+}
+
+func newUsageBasedStandardLineForTest(period timeutil.ClosedPeriod) *billing.StandardLine {
+	price := productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+		Amount: alpacadecimal.NewFromInt(1),
+	})
+
+	return &billing.StandardLine{
+		StandardLineBase: billing.StandardLineBase{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				ID:        "line-id",
+				Namespace: "namespace",
+				Name:      "line",
+			}),
+			ManagedBy: billing.SystemManagedLine,
+			Engine:    billing.LineEngineTypeChargeUsageBased,
+			InvoiceID: "invoice-id",
+			Currency:  currencyx.Code("USD"),
+			Period:    period,
+			InvoiceAt: period.To,
+			ChargeID:  lo.ToPtr("charge-id"),
+		},
+		UsageBased: &billing.UsageBasedLine{
+			Price:      price,
+			FeatureKey: "feature",
+		},
+	}
+}
+
+func newUsageBasedDetailedLineForTest(ref string, period timeutil.ClosedPeriod, amount alpacadecimal.Decimal) usagebased.DetailedLine {
+	return usagebased.DetailedLine{
+		PricerReferenceID: ref,
+		Base: stddetailedline.Base{
+			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
+				Namespace: "namespace",
+				Name:      ref,
+			}),
+			Category:               stddetailedline.CategoryRegular,
+			ChildUniqueReferenceID: ref,
+			Index:                  lo.ToPtr(0),
+			PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+			ServicePeriod:          period,
+			Currency:               currencyx.Code("USD"),
+			PerUnitAmount:          amount,
+			Quantity:               alpacadecimal.NewFromInt(1),
+			Totals: totals.Totals{
+				Amount: amount,
+				Total:  amount,
+			},
+		},
+	}
+}

--- a/openmeter/billing/charges/usagebased/service/payments.go
+++ b/openmeter/billing/charges/usagebased/service/payments.go
@@ -132,6 +132,10 @@ func areAllInvoicedRunsSettled(charge usagebased.Charge) bool {
 			continue
 		}
 
+		if run.NoFiatTransactionRequired {
+			continue
+		}
+
 		if run.Payment == nil || run.Payment.Status != payment.StatusSettled {
 			return false
 		}

--- a/openmeter/billing/charges/usagebased/service/rating/detailedline.go
+++ b/openmeter/billing/charges/usagebased/service/rating/detailedline.go
@@ -8,10 +8,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
-	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
 	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -20,33 +17,7 @@ func mapBillingRatingDetailedLinesToUsageBasedDetailedLines(
 	defaultServicePeriod timeutil.ClosedPeriod,
 	lines billingrating.DetailedLines,
 ) usagebased.DetailedLines {
-	return lo.Map(lines, func(line billingrating.DetailedLine, _ int) usagebased.DetailedLine {
-		period := defaultServicePeriod
-		if line.Period != nil {
-			period = *line.Period
-		}
-
-		category := line.Category
-		if category == "" {
-			category = stddetailedline.CategoryRegular
-		}
-
-		return usagebased.DetailedLine{
-			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
-				Name: line.Name,
-			}),
-			ServicePeriod:          period,
-			Currency:               intent.Currency,
-			ChildUniqueReferenceID: line.ChildUniqueReferenceID,
-			PaymentTerm:            lo.CoalesceOrEmpty(line.PaymentTerm, productcatalog.InArrearsPaymentTerm),
-			PerUnitAmount:          line.PerUnitAmount,
-			Quantity:               line.Quantity,
-			Category:               category,
-			CreditsApplied:         line.CreditsApplied,
-			Totals:                 line.Totals,
-			TaxConfig:              intent.TaxConfig.ToTaxConfig(),
-		}
-	})
+	return usagebased.NewDetailedLinesFromBilling(intent, defaultServicePeriod, lines)
 }
 
 func (s *service) ensureDetailedLinesLoadedForRating(ctx context.Context, charge usagebased.Charge, servicePeriodTo time.Time) (usagebased.Charge, error) {

--- a/openmeter/billing/charges/usagebased/service/rating/service.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service.go
@@ -45,6 +45,12 @@ type Service interface {
 	// GetDetailedRatingForUsage returns rated detailed lines and the metered quantity snapshot used to compute them.
 	// Prefer GetTotalsForUsage when only totals are required because it is faster.
 	GetDetailedRatingForUsage(ctx context.Context, in GetDetailedRatingForUsageInput) (GetDetailedRatingForUsageResult, error)
+	// GetPreferredRatingEngineFor returns the preferred rating engine for a given intent.
+	GetPreferredRatingEngineFor(intent usagebased.Intent) usagebased.RatingEngine
+}
+
+func (s *service) GetPreferredRatingEngineFor(_ usagebased.Intent) usagebased.RatingEngine {
+	return usagebased.RatingEngineDelta
 }
 
 type service struct {

--- a/openmeter/billing/charges/usagebased/service/rating/service_test.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service_test.go
@@ -413,7 +413,8 @@ func newDetailedRatingTestCharge(period timeutil.ClosedPeriod, runs usagebased.R
 			},
 			Status: usagebased.StatusCreated,
 			State: usagebased.State{
-				FeatureID: "feature-1",
+				FeatureID:    "feature-1",
+				RatingEngine: usagebased.RatingEngineDelta,
 			},
 		},
 		Realizations: runs,

--- a/openmeter/billing/charges/usagebased/service/rating/totals.go
+++ b/openmeter/billing/charges/usagebased/service/rating/totals.go
@@ -57,6 +57,7 @@ func (s *service) GetTotalsForUsage(ctx context.Context, in GetTotalsForUsageInp
 		return totals.Totals{}, fmt.Errorf("get snapshot quantity: %w", err)
 	}
 
+	// Totals must stay gross before charge credit allocation; run creation applies credits later and expects gross rating totals here.
 	opts := []billingrating.GenerateDetailedLinesOption{
 		billingrating.WithCreditsMutatorDisabled(),
 	}

--- a/openmeter/billing/charges/usagebased/service/rating/totals.go
+++ b/openmeter/billing/charges/usagebased/service/rating/totals.go
@@ -57,7 +57,9 @@ func (s *service) GetTotalsForUsage(ctx context.Context, in GetTotalsForUsageInp
 		return totals.Totals{}, fmt.Errorf("get snapshot quantity: %w", err)
 	}
 
-	opts := []billingrating.GenerateDetailedLinesOption{}
+	opts := []billingrating.GenerateDetailedLinesOption{
+		billingrating.WithCreditsMutatorDisabled(),
+	}
 	if in.IgnoreMinimumCommitment {
 		opts = append(opts, billingrating.WithMinimumCommitmentIgnored())
 	}

--- a/openmeter/billing/charges/usagebased/service/run/create.go
+++ b/openmeter/billing/charges/usagebased/service/run/create.go
@@ -26,6 +26,9 @@ type CreateRatedRunInput struct {
 	LineID             *string
 	CreditAllocation   CreditAllocationMode
 	CurrencyCalculator currencyx.Calculator
+	// NoFiatTransactionRequired is set if either there's no fiat-based
+	// settlement is expected (credits_only) or if the run totals are zero.
+	NoFiatTransactionRequired bool
 }
 
 func (i CreateRatedRunInput) Validate() error {
@@ -141,15 +144,17 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 				"charge_id": in.Charge.ID,
 			})
 	}
+	noFiatTransactionRequired := in.NoFiatTransactionRequired || runTotals.Total.IsZero()
 
 	updatedCharge, err := s.createNewRealizationRun(ctx, in.Charge, usagebased.CreateRealizationRunInput{
-		FeatureID:       in.Charge.State.FeatureID,
-		Type:            in.Type,
-		StoredAtLT:      in.StoredAtLT,
-		ServicePeriodTo: in.ServicePeriodTo,
-		LineID:          in.LineID,
-		MeteredQuantity: ratingResult.Quantity,
-		Totals:          runTotals,
+		FeatureID:                 in.Charge.State.FeatureID,
+		Type:                      in.Type,
+		StoredAtLT:                in.StoredAtLT,
+		ServicePeriodTo:           in.ServicePeriodTo,
+		LineID:                    in.LineID,
+		MeteredQuantity:           ratingResult.Quantity,
+		Totals:                    runTotals,
+		NoFiatTransactionRequired: noFiatTransactionRequired,
 	})
 	if err != nil {
 		return CreateRatedRunResult{}, fmt.Errorf("create new realization run: %w", err)
@@ -181,10 +186,12 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 		currentRun.CreditsAllocated = allocationResult.Realizations
 		runTotals.CreditsTotal = runTotals.CreditsTotal.Add(allocationResult.Allocated)
 		runTotals.Total = in.CurrencyCalculator.RoundToPrecision(runTotals.Total.Sub(allocationResult.Allocated))
+		noFiatTransactionRequired = in.NoFiatTransactionRequired || runTotals.Total.IsZero()
 
 		currentRunBase, err := s.adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
-			ID:     currentRun.ID,
-			Totals: mo.Some(runTotals),
+			ID:                        currentRun.ID,
+			Totals:                    mo.Some(runTotals),
+			NoFiatTransactionRequired: mo.Some(noFiatTransactionRequired),
 		})
 		if err != nil {
 			return CreateRatedRunResult{}, fmt.Errorf("update realization run: %w", err)

--- a/openmeter/billing/charges/usagebased/service/run/invoice.go
+++ b/openmeter/billing/charges/usagebased/service/run/invoice.go
@@ -40,6 +40,14 @@ func (i BookAccruedInvoiceUsageInput) Validate() error {
 		return fmt.Errorf("run %s already has an invoice usage", i.Run.ID.ID)
 	}
 
+	if i.Run.NoFiatTransactionRequired && !i.Line.Totals.Total.IsZero() {
+		return fmt.Errorf("run %s requires no fiat transaction but line total is non-zero", i.Run.ID.ID)
+	}
+
+	if !i.Run.NoFiatTransactionRequired && i.Line.Totals.Total.IsZero() {
+		return fmt.Errorf("run %s has zero line total but requires a fiat transaction", i.Run.ID.ID)
+	}
+
 	return nil
 }
 
@@ -53,9 +61,22 @@ func (s *Service) BookAccruedInvoiceUsage(ctx context.Context, in BookAccruedInv
 		return BookAccruedInvoiceUsageResult{}, err
 	}
 
-	if in.Line.Totals.Total.IsZero() {
+	if in.Run.NoFiatTransactionRequired {
+		accruedUsage, err := s.adapter.CreateRunInvoicedUsage(ctx, in.Run.ID, invoicedusage.AccruedUsage{
+			LineID:        in.Run.LineID,
+			ServicePeriod: in.Line.Period,
+			Mutable:       false,
+			Totals:        in.Line.Totals,
+		})
+		if err != nil {
+			return BookAccruedInvoiceUsageResult{}, fmt.Errorf("create invoiced usage for run %s: %w", in.Run.ID.ID, err)
+		}
+
+		in.Run.InvoiceUsage = &accruedUsage
+
 		return BookAccruedInvoiceUsageResult{
-			Run: in.Run,
+			Run:          in.Run,
+			InvoiceUsage: &accruedUsage,
 		}, nil
 	}
 

--- a/openmeter/billing/charges/usagebased/service/run/payment.go
+++ b/openmeter/billing/charges/usagebased/service/run/payment.go
@@ -60,6 +60,12 @@ func (s *Service) BookInvoicedPaymentAuthorized(ctx context.Context, in BookInvo
 		return BookInvoicedPaymentAuthorizedResult{}, err
 	}
 
+	if in.Run.NoFiatTransactionRequired {
+		return BookInvoicedPaymentAuthorizedResult{
+			Run: in.Run,
+		}, nil
+	}
+
 	input := usagebased.OnPaymentAuthorizedInput{
 		Charge: in.Charge,
 		Run:    in.Run,
@@ -133,6 +139,10 @@ func (i SettleInvoicedPaymentInput) Validate() error {
 		return fmt.Errorf("run %s already linked to a different line", i.Run.ID.ID)
 	}
 
+	if i.Run.NoFiatTransactionRequired {
+		return nil
+	}
+
 	if i.Run.Payment == nil {
 		return payment.ErrCannotSettleNotAuthorizedPayment.WithAttrs(i.Charge.ErrorAttributes())
 	}
@@ -156,6 +166,12 @@ type SettleInvoicedPaymentResult struct {
 func (s *Service) SettleInvoicedPayment(ctx context.Context, in SettleInvoicedPaymentInput) (SettleInvoicedPaymentResult, error) {
 	if err := in.Validate(); err != nil {
 		return SettleInvoicedPaymentResult{}, err
+	}
+
+	if in.Run.NoFiatTransactionRequired {
+		return SettleInvoicedPaymentResult{
+			Run: in.Run,
+		}, nil
 	}
 
 	input := usagebased.OnPaymentSettledInput{

--- a/openmeter/billing/charges/usagebased/service/run/payment_test.go
+++ b/openmeter/billing/charges/usagebased/service/run/payment_test.go
@@ -67,6 +67,13 @@ func TestSettleInvoicedPaymentInputValidate(t *testing.T) {
 		require.ErrorContains(t, in.Validate(), "cannot settle an unauthorized payment")
 	})
 
+	t.Run("allows missing payment when no fiat transaction is required", func(t *testing.T) {
+		in := newSettlePaymentInput()
+		in.Run.Payment = nil
+		in.Run.NoFiatTransactionRequired = true
+		require.NoError(t, in.Validate())
+	})
+
 	t.Run("rejects mismatched payment line id", func(t *testing.T) {
 		in := newSettlePaymentInput()
 		in.Run.Payment.LineID = "other-line"
@@ -187,7 +194,8 @@ func newUsageBasedCharge() usagebased.Charge {
 			},
 			Status: usagebased.StatusActiveAwaitingPaymentSettlement,
 			State: usagebased.State{
-				FeatureID: "feature-1",
+				FeatureID:    "feature-1",
+				RatingEngine: usagebased.RatingEngineDelta,
 			},
 		},
 	}

--- a/openmeter/billing/charges/usagebased/service_test.go
+++ b/openmeter/billing/charges/usagebased/service_test.go
@@ -15,3 +15,12 @@ func TestValidateExpands(t *testing.T) {
 	require.NoError(t, validateExpands(meta.Expands{meta.ExpandRealizations, meta.ExpandDetailedLines}))
 	require.Error(t, validateExpands(meta.Expands{meta.ExpandDetailedLines}))
 }
+
+func TestRatingEngineValidate(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, RatingEngineDelta.Validate())
+	require.NoError(t, RatingEnginePeriodPreserving.Validate())
+	require.Error(t, RatingEngine("").Validate())
+	require.Error(t, RatingEngine("unknown").Validate())
+}

--- a/openmeter/billing/derived.gen.go
+++ b/openmeter/billing/derived.gen.go
@@ -4,7 +4,6 @@ package billing
 
 import (
 	creditsapplied "github.com/openmeterio/openmeter/openmeter/billing/models/creditsapplied"
-	totals "github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	models "github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -99,7 +98,7 @@ func deriveEqualLineBase(this, that *StandardLineBase) bool {
 			deriveEqual_3(this.CreditsApplied, that.CreditsApplied) &&
 			this.ExternalIDs.Equal(that.ExternalIDs) &&
 			deriveEqual_1(this.Subscription, that.Subscription) &&
-			deriveEqual_4(&this.Totals, &that.Totals)
+			this.Totals.Equal(that.Totals)
 }
 
 // deriveEqualUsageBasedLine returns whether this and that are equal.
@@ -162,7 +161,7 @@ func deriveEqual_3(this, that []creditsapplied.CreditApplied) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveEqual_5(&this[i], &that[i])) {
+		if !(deriveEqual_4(&this[i], &that[i])) {
 			return false
 		}
 	}
@@ -170,21 +169,7 @@ func deriveEqual_3(this, that []creditsapplied.CreditApplied) bool {
 }
 
 // deriveEqual_4 returns whether this and that are equal.
-func deriveEqual_4(this, that *totals.Totals) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.Amount.Equal(that.Amount) &&
-			this.ChargesTotal.Equal(that.ChargesTotal) &&
-			this.DiscountsTotal.Equal(that.DiscountsTotal) &&
-			this.TaxesInclusiveTotal.Equal(that.TaxesInclusiveTotal) &&
-			this.TaxesExclusiveTotal.Equal(that.TaxesExclusiveTotal) &&
-			this.TaxesTotal.Equal(that.TaxesTotal) &&
-			this.CreditsTotal.Equal(that.CreditsTotal) &&
-			this.Total.Equal(that.Total)
-}
-
-// deriveEqual_5 returns whether this and that are equal.
-func deriveEqual_5(this, that *creditsapplied.CreditApplied) bool {
+func deriveEqual_4(this, that *creditsapplied.CreditApplied) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Amount.Equal(that.Amount) &&

--- a/openmeter/billing/invoicedetailedline.go
+++ b/openmeter/billing/invoicedetailedline.go
@@ -7,6 +7,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -107,6 +108,12 @@ func (l DetailedLines) Clone() DetailedLines {
 	return l.Map(func(dl DetailedLine) DetailedLine {
 		return dl.Clone()
 	})
+}
+
+func (l DetailedLines) SumTotals() totals.Totals {
+	return totals.Sum(lo.Map(l, func(line DetailedLine, _ int) totals.Totals {
+		return line.Totals
+	})...)
 }
 
 func (l DetailedLines) Validate() error {

--- a/openmeter/billing/lineengine.go
+++ b/openmeter/billing/lineengine.go
@@ -217,14 +217,17 @@ type LineEngine interface {
 	OnStandardInvoiceCreated(ctx context.Context, input OnStandardInvoiceCreatedInput) (StandardLines, error)
 	// OnCollectionCompleted is invoked when a standard invoice collection window closes.
 	OnCollectionCompleted(ctx context.Context, input OnCollectionCompletedInput) (StandardLines, error)
-	// CalculateLines recalculates detailed lines and totals for standard-invoice lines owned by this engine.
-	CalculateLines(input CalculateLinesInput) (StandardLines, error)
 	// OnInvoiceIssued is invoked when a standard invoice reaches the issued state.
 	OnInvoiceIssued(ctx context.Context, input OnInvoiceIssuedInput) error
 	// OnPaymentAuthorized is invoked when a standard invoice reaches the payment authorized state.
 	OnPaymentAuthorized(ctx context.Context, input OnPaymentAuthorizedInput) error
 	// OnPaymentSettled is invoked when a standard invoice reaches the paid state.
 	OnPaymentSettled(ctx context.Context, input OnPaymentSettledInput) error
+}
+
+type LineCalculator interface {
+	// CalculateLines recalculates detailed lines and totals for standard-invoice lines owned by this engine.
+	CalculateLines(input CalculateLinesInput) (StandardLines, error)
 }
 
 func LineEngineValidationComponent(engineType LineEngineType) ComponentName {

--- a/openmeter/billing/lineengine/engine.go
+++ b/openmeter/billing/lineengine/engine.go
@@ -11,7 +11,10 @@ import (
 	"github.com/openmeterio/openmeter/pkg/clock"
 )
 
-var _ billing.LineEngine = (*Engine)(nil)
+var (
+	_ billing.LineEngine     = (*Engine)(nil)
+	_ billing.LineCalculator = (*Engine)(nil)
+)
 
 type Config struct {
 	SplitLineGroupAdapter SplitLineGroupAdapter

--- a/openmeter/billing/models/stddetailedline/derived.gen.go
+++ b/openmeter/billing/models/stddetailedline/derived.gen.go
@@ -4,7 +4,6 @@ package stddetailedline
 
 import (
 	creditsapplied "github.com/openmeterio/openmeter/openmeter/billing/models/creditsapplied"
-	totals "github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	models "github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -21,10 +20,10 @@ func deriveEqualBase(this, that *Base) bool {
 			this.Currency == that.Currency &&
 			this.PerUnitAmount.Equal(that.PerUnitAmount) &&
 			this.Quantity.Equal(that.Quantity) &&
-			deriveEqual_(&this.Totals, &that.Totals) &&
+			this.Totals.Equal(that.Totals) &&
 			this.TaxConfig.Equal(that.TaxConfig) &&
 			this.ExternalIDs.Equal(that.ExternalIDs) &&
-			deriveEqual_1(this.CreditsApplied, that.CreditsApplied)
+			deriveEqual_(this.CreditsApplied, that.CreditsApplied)
 }
 
 // deriveEqual returns whether this and that are equal.
@@ -39,21 +38,7 @@ func deriveEqual(this, that *models.ManagedResource) bool {
 }
 
 // deriveEqual_ returns whether this and that are equal.
-func deriveEqual_(this, that *totals.Totals) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.Amount.Equal(that.Amount) &&
-			this.ChargesTotal.Equal(that.ChargesTotal) &&
-			this.DiscountsTotal.Equal(that.DiscountsTotal) &&
-			this.TaxesInclusiveTotal.Equal(that.TaxesInclusiveTotal) &&
-			this.TaxesExclusiveTotal.Equal(that.TaxesExclusiveTotal) &&
-			this.TaxesTotal.Equal(that.TaxesTotal) &&
-			this.CreditsTotal.Equal(that.CreditsTotal) &&
-			this.Total.Equal(that.Total)
-}
-
-// deriveEqual_1 returns whether this and that are equal.
-func deriveEqual_1(this, that []creditsapplied.CreditApplied) bool {
+func deriveEqual_(this, that []creditsapplied.CreditApplied) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -61,15 +46,15 @@ func deriveEqual_1(this, that []creditsapplied.CreditApplied) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveEqual_2(&this[i], &that[i])) {
+		if !(deriveEqual_1(&this[i], &that[i])) {
 			return false
 		}
 	}
 	return true
 }
 
-// deriveEqual_2 returns whether this and that are equal.
-func deriveEqual_2(this, that *creditsapplied.CreditApplied) bool {
+// deriveEqual_1 returns whether this and that are equal.
+func deriveEqual_1(this, that *creditsapplied.CreditApplied) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Amount.Equal(that.Amount) &&

--- a/openmeter/billing/models/stddetailedline/model.go
+++ b/openmeter/billing/models/stddetailedline/model.go
@@ -64,9 +64,24 @@ type Base struct {
 	CreditsApplied creditsapplied.CreditsApplied `json:"creditsApplied,omitempty"`
 }
 
-var _ models.Validator = (*Base)(nil)
+type validateOptions struct {
+	ignoreQuantityChecks bool
+}
 
-func (l Base) Validate() error {
+type ValidateOption func(*validateOptions)
+
+func IgnoreQuantityChecks() ValidateOption {
+	return func(o *validateOptions) {
+		o.ignoreQuantityChecks = true
+	}
+}
+
+func (l Base) Validate(opts ...ValidateOption) error {
+	options := validateOptions{}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	errs := []error{}
 
 	if err := l.Category.Validate(); err != nil {
@@ -81,7 +96,7 @@ func (l Base) Validate() error {
 		errs = append(errs, errors.New("price should be positive or zero"))
 	}
 
-	if l.Quantity.IsNegative() {
+	if !options.ignoreQuantityChecks && l.Quantity.IsNegative() {
 		errs = append(errs, errors.New("quantity should be positive or zero"))
 	}
 

--- a/openmeter/billing/models/totals/model.go
+++ b/openmeter/billing/models/totals/model.go
@@ -83,6 +83,58 @@ func (t Totals) Add(others ...Totals) Totals {
 	return res
 }
 
+func (t Totals) Sub(others ...Totals) Totals {
+	res := t
+
+	for _, other := range others {
+		res.Amount = res.Amount.Sub(other.Amount)
+		res.ChargesTotal = res.ChargesTotal.Sub(other.ChargesTotal)
+		res.DiscountsTotal = res.DiscountsTotal.Sub(other.DiscountsTotal)
+		res.TaxesInclusiveTotal = res.TaxesInclusiveTotal.Sub(other.TaxesInclusiveTotal)
+		res.TaxesExclusiveTotal = res.TaxesExclusiveTotal.Sub(other.TaxesExclusiveTotal)
+		res.TaxesTotal = res.TaxesTotal.Sub(other.TaxesTotal)
+		res.CreditsTotal = res.CreditsTotal.Sub(other.CreditsTotal)
+		res.Total = res.Total.Sub(other.Total)
+	}
+
+	return res
+}
+
+func (t Totals) Neg() Totals {
+	return Totals{
+		Amount:              t.Amount.Neg(),
+		ChargesTotal:        t.ChargesTotal.Neg(),
+		DiscountsTotal:      t.DiscountsTotal.Neg(),
+		TaxesInclusiveTotal: t.TaxesInclusiveTotal.Neg(),
+		TaxesExclusiveTotal: t.TaxesExclusiveTotal.Neg(),
+		TaxesTotal:          t.TaxesTotal.Neg(),
+		CreditsTotal:        t.CreditsTotal.Neg(),
+		Total:               t.Total.Neg(),
+	}
+}
+
+func (t Totals) IsZero() bool {
+	return t.Amount.IsZero() &&
+		t.ChargesTotal.IsZero() &&
+		t.DiscountsTotal.IsZero() &&
+		t.TaxesInclusiveTotal.IsZero() &&
+		t.TaxesExclusiveTotal.IsZero() &&
+		t.TaxesTotal.IsZero() &&
+		t.CreditsTotal.IsZero() &&
+		t.Total.IsZero()
+}
+
+func (t Totals) Equal(other Totals) bool {
+	return t.Amount.Equal(other.Amount) &&
+		t.ChargesTotal.Equal(other.ChargesTotal) &&
+		t.DiscountsTotal.Equal(other.DiscountsTotal) &&
+		t.TaxesInclusiveTotal.Equal(other.TaxesInclusiveTotal) &&
+		t.TaxesExclusiveTotal.Equal(other.TaxesExclusiveTotal) &&
+		t.TaxesTotal.Equal(other.TaxesTotal) &&
+		t.CreditsTotal.Equal(other.CreditsTotal) &&
+		t.Total.Equal(other.Total)
+}
+
 func Sum(others ...Totals) Totals {
 	res := Totals{}
 

--- a/openmeter/billing/models/totals/model_test.go
+++ b/openmeter/billing/models/totals/model_test.go
@@ -47,3 +47,24 @@ func TestTotalsRoundToPrecision(t *testing.T) {
 	require.Equal(t, "2.78", got.CreditsTotal.String())
 	require.Equal(t, "7.34", got.Total.String())
 }
+
+func TestTotalsEqual(t *testing.T) {
+	t.Parallel()
+
+	in := Totals{
+		Amount:              alpacadecimal.NewFromInt(1),
+		ChargesTotal:        alpacadecimal.NewFromInt(2),
+		DiscountsTotal:      alpacadecimal.NewFromInt(3),
+		TaxesInclusiveTotal: alpacadecimal.NewFromInt(4),
+		TaxesExclusiveTotal: alpacadecimal.NewFromInt(5),
+		TaxesTotal:          alpacadecimal.NewFromInt(6),
+		CreditsTotal:        alpacadecimal.NewFromInt(7),
+		Total:               alpacadecimal.NewFromInt(8),
+	}
+
+	require.True(t, in.Equal(in))
+
+	other := in
+	other.Total = alpacadecimal.NewFromInt(9)
+	require.False(t, in.Equal(other))
+}

--- a/openmeter/billing/rating/service.go
+++ b/openmeter/billing/rating/service.go
@@ -19,6 +19,7 @@ type Service interface {
 
 type GenerateDetailedLinesOptions struct {
 	IgnoreMinimumCommitment bool
+	DisableCreditsMutator   bool
 }
 
 type GenerateDetailedLinesOption func(*GenerateDetailedLinesOptions)
@@ -36,6 +37,12 @@ func NewGenerateDetailedLinesOptions(opts ...GenerateDetailedLinesOption) Genera
 func WithMinimumCommitmentIgnored() GenerateDetailedLinesOption {
 	return func(o *GenerateDetailedLinesOptions) {
 		o.IgnoreMinimumCommitment = true
+	}
+}
+
+func WithCreditsMutatorDisabled() GenerateDetailedLinesOption {
+	return func(o *GenerateDetailedLinesOptions) {
+		o.DisableCreditsMutator = true
 	}
 }
 

--- a/openmeter/billing/rating/service/billableperiod.go
+++ b/openmeter/billing/rating/service/billableperiod.go
@@ -14,7 +14,7 @@ func (s *service) ResolveBillablePeriod(in rating.ResolveBillablePeriodInput) (*
 		return nil, err
 	}
 
-	linePricer, err := getPricerFor(in.Line, rating.GenerateDetailedLinesOptions{})
+	linePricer, err := getPricerFor(in.Line, rating.NewGenerateDetailedLinesOptions())
 	if err != nil {
 		return nil, err
 	}

--- a/openmeter/billing/rating/service/mutator/credits.go
+++ b/openmeter/billing/rating/service/mutator/credits.go
@@ -12,6 +12,8 @@ type Credits struct{}
 
 var _ PostCalculationMutator = (*Credits)(nil)
 
+// TODO: Deprecate this mutator for charge-backed invoice flows once charge line mappers
+// own credit projection there.
 func (m *Credits) Mutate(i rate.PricerCalculateInput, pricerResult rating.DetailedLines) (rating.DetailedLines, error) {
 	for _, creditToApply := range i.GetCreditsApplied() {
 		creditValueRemaining := i.CurrencyCalculator.RoundToPrecision(creditToApply.Amount)
@@ -22,12 +24,12 @@ func (m *Credits) Mutate(i rate.PricerCalculateInput, pricerResult rating.Detail
 			}
 
 			totalAmount := pricerResult[idx].TotalAmount(i.CurrencyCalculator)
-			if totalAmount.IsZero() {
+			if !totalAmount.IsPositive() {
 				continue
 			}
 
 			if totalAmount.LessThanOrEqual(creditValueRemaining) {
-				creditValueRemaining = creditValueRemaining.Sub(totalAmount)
+				creditValueRemaining = i.CurrencyCalculator.RoundToPrecision(creditValueRemaining.Sub(totalAmount))
 				pricerResult[idx].CreditsApplied = append(pricerResult[idx].CreditsApplied, creditToApply.CloneWithAmount(totalAmount))
 			} else {
 				pricerResult[idx].CreditsApplied = append(pricerResult[idx].CreditsApplied, creditToApply.CloneWithAmount(creditValueRemaining))

--- a/openmeter/billing/rating/service/mutator/credits_test.go
+++ b/openmeter/billing/rating/service/mutator/credits_test.go
@@ -5,13 +5,17 @@ import (
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating/service/mutator"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating/service/rate"
 	"github.com/openmeterio/openmeter/openmeter/billing/rating/service/testutil"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 )
 
 func TestCreditsMutator(t *testing.T) {
@@ -392,4 +396,79 @@ func TestCreditsMutator(t *testing.T) {
 			ExpectErrorIs: billing.ErrInvoiceLineCreditsNotConsumedFully,
 		})
 	})
+}
+
+func TestCreditsMutatorSkipsNonPositiveDetailedLineTotals(t *testing.T) {
+	calc, err := currencyx.Code("USD").Calculator()
+	require.NoError(t, err)
+
+	out, err := (&mutator.Credits{}).Mutate(rate.PricerCalculateInput{
+		StandardLineAccessor: &billing.StandardLine{
+			StandardLineBase: billing.StandardLineBase{
+				CreditsApplied: billing.CreditsApplied{
+					{
+						Amount: alpacadecimal.NewFromFloat(25),
+					},
+				},
+			},
+		},
+		CurrencyCalculator: calc,
+	}, rating.DetailedLines{
+		{
+			Name:                   "negative correction",
+			PerUnitAmount:          alpacadecimal.NewFromFloat(10),
+			Quantity:               alpacadecimal.NewFromFloat(1),
+			ChildUniqueReferenceID: "negative-correction",
+			CreditsApplied: billing.CreditsApplied{
+				{
+					Amount: alpacadecimal.NewFromFloat(15),
+				},
+			},
+		},
+		{
+			Name:                   "positive line",
+			PerUnitAmount:          alpacadecimal.NewFromFloat(50),
+			Quantity:               alpacadecimal.NewFromFloat(1),
+			ChildUniqueReferenceID: "positive-line",
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, out[0].CreditsApplied, 1)
+	require.Len(t, out[1].CreditsApplied, 1)
+	require.Equal(t, float64(25), out[1].CreditsApplied[0].Amount.InexactFloat64())
+}
+
+func TestCreditsMutatorAllocatesOnlyRemainingPayableAmount(t *testing.T) {
+	calc, err := currencyx.Code("USD").Calculator()
+	require.NoError(t, err)
+
+	out, err := (&mutator.Credits{}).Mutate(rate.PricerCalculateInput{
+		StandardLineAccessor: &billing.StandardLine{
+			StandardLineBase: billing.StandardLineBase{
+				CreditsApplied: billing.CreditsApplied{
+					{
+						Amount: alpacadecimal.NewFromFloat(30),
+					},
+				},
+			},
+		},
+		CurrencyCalculator: calc,
+	}, rating.DetailedLines{
+		{
+			Name:                   "partially credited line",
+			PerUnitAmount:          alpacadecimal.NewFromFloat(50),
+			Quantity:               alpacadecimal.NewFromFloat(1),
+			ChildUniqueReferenceID: "partially-credited-line",
+			CreditsApplied: billing.CreditsApplied{
+				{
+					Amount: alpacadecimal.NewFromFloat(20),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, out[0].CreditsApplied, 2)
+	require.Equal(t, float64(30), out[0].CreditsApplied[1].Amount.InexactFloat64())
 }

--- a/openmeter/billing/rating/service/mutator/discountusage.go
+++ b/openmeter/billing/rating/service/mutator/discountusage.go
@@ -27,43 +27,68 @@ func (m *DiscountUsage) Mutate(l rate.PricerCalculateInput) (rate.PricerCalculat
 		return l, err
 	}
 
-	usageDiscount, err := m.getUsageDiscount(l)
+	discountedUsage, err := ApplyUsageDiscount(ApplyUsageDiscountInput{
+		Usage:                 usage,
+		RateCardDiscounts:     l.GetRateCardDiscounts(),
+		StandardLineDiscounts: l.StandardLineDiscounts,
+	})
 	if err != nil {
 		return l, err
 	}
 
+	l.Usage = &discountedUsage.Usage
+	l.StandardLineDiscounts = discountedUsage.StandardLineDiscounts
+
+	return l, nil
+}
+
+// ApplyUsageDiscountInput describes the raw usage and discounts before usage discount application.
+type ApplyUsageDiscountInput struct {
+	Usage                 rating.Usage
+	RateCardDiscounts     billing.Discounts
+	StandardLineDiscounts billing.StandardLineDiscounts
+}
+
+// ApplyUsageDiscountResult contains net usage and line-level discount metadata after usage discount application.
+type ApplyUsageDiscountResult struct {
+	Usage                 rating.Usage
+	StandardLineDiscounts billing.StandardLineDiscounts
+}
+
+// ApplyUsageDiscount applies the rate card usage discount contract shared by standard billing and charge line projection.
+func ApplyUsageDiscount(in ApplyUsageDiscountInput) (ApplyUsageDiscountResult, error) {
+	out := ApplyUsageDiscountResult{
+		Usage:                 in.Usage,
+		StandardLineDiscounts: in.StandardLineDiscounts.Clone(),
+	}
+
+	usageDiscount := in.RateCardDiscounts.Usage
 	if usageDiscount == nil {
-		// If there is no usage discount intent, let's remove all the usage discounts from the line (in case there are any)
-
-		return m.removeUsageDiscounts(l), nil
+		out.StandardLineDiscounts = removeRateCardUsageDiscounts(out.StandardLineDiscounts)
+		return out, nil
 	}
 
-	discountLimit := usageDiscount.UsageDiscount.Quantity
+	if usageDiscount.CorrelationID == "" {
+		return ApplyUsageDiscountResult{}, fmt.Errorf("discount has no correlation ID")
+	}
 
-	previouslyAppliedDiscount := applyDiscount(discountLimit, usage.PreLinePeriodQuantity)
-	// Let's apply any previous applied discounts to the pre line period quantity
-	l.Usage.PreLinePeriodQuantity = usage.PreLinePeriodQuantity.Sub(previouslyAppliedDiscount.discountApplied)
+	previouslyAppliedDiscount := applyDiscount(usageDiscount.UsageDiscount.Quantity, in.Usage.PreLinePeriodQuantity)
+	out.Usage.PreLinePeriodQuantity = in.Usage.PreLinePeriodQuantity.Sub(previouslyAppliedDiscount.discountApplied)
 
-	// Let's apply the discount to the current line
-	discountAppliedToCurrentLine := applyDiscount(previouslyAppliedDiscount.discountRemaining, usage.Quantity)
-
+	discountAppliedToCurrentLine := applyDiscount(previouslyAppliedDiscount.discountRemaining, in.Usage.Quantity)
 	if discountAppliedToCurrentLine.discountApplied.IsZero() {
-		// We have no discount to apply, let's remove the usage discount from the line
-
-		return m.removeUsageDiscounts(l), nil
+		out.StandardLineDiscounts = removeRateCardUsageDiscounts(out.StandardLineDiscounts)
+		return out, nil
 	}
 
-	// We have discounts to apply
-	l = m.removeUsageDiscounts(l)
-
-	l.Usage.Quantity = usage.Quantity.Sub(discountAppliedToCurrentLine.discountApplied)
-
-	l.StandardLineDiscounts.Usage = l.StandardLineDiscounts.Usage.MergeDiscountsByChildUniqueReferenceID(
+	out.StandardLineDiscounts = removeRateCardUsageDiscounts(out.StandardLineDiscounts)
+	out.Usage.Quantity = in.Usage.Quantity.Sub(discountAppliedToCurrentLine.discountApplied)
+	out.StandardLineDiscounts.Usage = out.StandardLineDiscounts.Usage.MergeDiscountsByChildUniqueReferenceID(
 		billing.UsageLineDiscountManaged{
 			UsageLineDiscount: billing.UsageLineDiscount{
 				LineDiscountBase: billing.LineDiscountBase{
-					ChildUniqueReferenceID: lo.ToPtr(usageDiscount.childUniqueReferenceID),
-					Reason:                 billing.NewDiscountReasonFrom(usageDiscount.UsageDiscount),
+					ChildUniqueReferenceID: lo.ToPtr(fmt.Sprintf(rating.RateCardDiscountChildUniqueReferenceID, usageDiscount.CorrelationID)),
+					Reason:                 billing.NewDiscountReasonFrom(*usageDiscount),
 				},
 				Quantity:              discountAppliedToCurrentLine.discountApplied,
 				PreLinePeriodQuantity: lo.EmptyableToPtr(previouslyAppliedDiscount.discountApplied),
@@ -71,38 +96,15 @@ func (m *DiscountUsage) Mutate(l rate.PricerCalculateInput) (rate.PricerCalculat
 		},
 	)
 
-	return l, nil
+	return out, nil
 }
 
-func (m *DiscountUsage) removeUsageDiscounts(l rate.PricerCalculateInput) rate.PricerCalculateInput {
-	l.StandardLineDiscounts.Usage = lo.Filter(l.StandardLineDiscounts.Usage, func(item billing.UsageLineDiscountManaged, _ int) bool {
+func removeRateCardUsageDiscounts(discounts billing.StandardLineDiscounts) billing.StandardLineDiscounts {
+	discounts.Usage = lo.Filter(discounts.Usage, func(item billing.UsageLineDiscountManaged, _ int) bool {
 		return item.Reason.Type() != billing.RatecardUsageDiscountReason
 	})
 
-	return l
-}
-
-type usageDiscountWithChildUniqueReferenceID struct {
-	billing.UsageDiscount
-	childUniqueReferenceID string
-}
-
-func (m *DiscountUsage) getUsageDiscount(l rate.PricerCalculateInput) (*usageDiscountWithChildUniqueReferenceID, error) {
-	discounts := l.GetRateCardDiscounts()
-	if discounts.Usage == nil {
-		return nil, nil
-	}
-
-	rcUsageDiscount := discounts.Usage
-
-	if rcUsageDiscount.CorrelationID == "" {
-		return nil, fmt.Errorf("discount has no correlation ID")
-	}
-
-	return &usageDiscountWithChildUniqueReferenceID{
-		UsageDiscount:          *rcUsageDiscount,
-		childUniqueReferenceID: fmt.Sprintf(rating.RateCardDiscountChildUniqueReferenceID, rcUsageDiscount.CorrelationID),
-	}, nil
+	return discounts
 }
 
 type applyDiscountResult struct {

--- a/openmeter/billing/rating/service/mutator/discountusage_test.go
+++ b/openmeter/billing/rating/service/mutator/discountusage_test.go
@@ -1,0 +1,62 @@
+package mutator
+
+import (
+	"testing"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+)
+
+func TestApplyUsageDiscount(t *testing.T) {
+	out, err := ApplyUsageDiscount(ApplyUsageDiscountInput{
+		Usage: rating.Usage{
+			Quantity:              alpacadecimal.NewFromInt(15),
+			PreLinePeriodQuantity: alpacadecimal.NewFromInt(5),
+		},
+		RateCardDiscounts: billing.Discounts{
+			Usage: &billing.UsageDiscount{
+				UsageDiscount: productcatalog.UsageDiscount{
+					Quantity: alpacadecimal.NewFromInt(10),
+				},
+				CorrelationID: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, float64(10), out.Usage.Quantity.InexactFloat64())
+	require.Equal(t, float64(0), out.Usage.PreLinePeriodQuantity.InexactFloat64())
+
+	require.Len(t, out.StandardLineDiscounts.Usage, 1)
+	usageDiscount := out.StandardLineDiscounts.Usage[0]
+	require.Equal(t, "rateCardDiscount/correlationID=01ARZ3NDEKTSV4RRFFQ69G5FAV", lo.FromPtr(usageDiscount.ChildUniqueReferenceID))
+	require.Equal(t, float64(5), usageDiscount.Quantity.InexactFloat64())
+	require.Equal(t, float64(5), lo.FromPtr(usageDiscount.PreLinePeriodQuantity).InexactFloat64())
+}
+
+func TestApplyUsageDiscountWhenDiscountAlreadyConsumed(t *testing.T) {
+	out, err := ApplyUsageDiscount(ApplyUsageDiscountInput{
+		Usage: rating.Usage{
+			Quantity:              alpacadecimal.NewFromInt(15),
+			PreLinePeriodQuantity: alpacadecimal.NewFromInt(20),
+		},
+		RateCardDiscounts: billing.Discounts{
+			Usage: &billing.UsageDiscount{
+				UsageDiscount: productcatalog.UsageDiscount{
+					Quantity: alpacadecimal.NewFromInt(10),
+				},
+				CorrelationID: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, float64(15), out.Usage.Quantity.InexactFloat64())
+	require.Equal(t, float64(10), out.Usage.PreLinePeriodQuantity.InexactFloat64())
+	require.Empty(t, out.StandardLineDiscounts.Usage)
+}

--- a/openmeter/billing/rating/service/options_test.go
+++ b/openmeter/billing/rating/service/options_test.go
@@ -1,0 +1,184 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating"
+	"github.com/openmeterio/openmeter/openmeter/billing/rating/service/testutil"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+)
+
+func TestGenerateDetailedLinesMinimumCommitmentOptions(t *testing.T) {
+	t.Run("minimum commitment applied by default", func(t *testing.T) {
+		testutil.RunCalculationTestCase(t, testutil.CalculationTestCase{
+			Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromFloat(10),
+				Commitments: productcatalog.Commitments{
+					MinimumAmount: lo.ToPtr(alpacadecimal.NewFromFloat(100)),
+				},
+			}),
+			LineMode: testutil.SinglePerPeriodLineMode,
+			Usage: testutil.FeatureUsageResponse{
+				LinePeriodQty: alpacadecimal.NewFromFloat(0),
+			},
+			Expect: rating.DetailedLines{
+				{
+					Name:                   "feature: minimum spend",
+					PerUnitAmount:          alpacadecimal.NewFromFloat(100),
+					Quantity:               alpacadecimal.NewFromFloat(1),
+					ChildUniqueReferenceID: rating.MinSpendChildUniqueReferenceID,
+					Period:                 lo.ToPtr(testutil.TestFullPeriod),
+					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+					Category:               stddetailedline.CategoryCommitment,
+					Totals: totals.Totals{
+						ChargesTotal: alpacadecimal.NewFromFloat(100),
+						Total:        alpacadecimal.NewFromFloat(100),
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("minimum commitment ignored when requested", func(t *testing.T) {
+		testutil.RunCalculationTestCase(t, testutil.CalculationTestCase{
+			Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromFloat(10),
+				Commitments: productcatalog.Commitments{
+					MinimumAmount: lo.ToPtr(alpacadecimal.NewFromFloat(100)),
+				},
+			}),
+			LineMode: testutil.SinglePerPeriodLineMode,
+			Usage: testutil.FeatureUsageResponse{
+				LinePeriodQty: alpacadecimal.NewFromFloat(0),
+			},
+			Options: []rating.GenerateDetailedLinesOption{
+				rating.WithMinimumCommitmentIgnored(),
+			},
+			Expect: rating.DetailedLines{},
+		})
+	})
+
+	t.Run("maximum spend still applies when minimum commitment is ignored", func(t *testing.T) {
+		testutil.RunCalculationTestCase(t, testutil.CalculationTestCase{
+			Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromFloat(10),
+				Commitments: productcatalog.Commitments{
+					MinimumAmount: lo.ToPtr(alpacadecimal.NewFromFloat(100)),
+					MaximumAmount: lo.ToPtr(alpacadecimal.NewFromFloat(100)),
+				},
+			}),
+			LineMode: testutil.MidPeriodSplitLineMode,
+			Usage: testutil.FeatureUsageResponse{
+				LinePeriodQty:    alpacadecimal.NewFromFloat(5),
+				PreLinePeriodQty: alpacadecimal.NewFromFloat(7),
+			},
+			PreviousBilledAmount: alpacadecimal.NewFromFloat(70),
+			Options: []rating.GenerateDetailedLinesOption{
+				rating.WithMinimumCommitmentIgnored(),
+			},
+			Expect: rating.DetailedLines{
+				{
+					Name:                   "feature: usage in period",
+					PerUnitAmount:          alpacadecimal.NewFromFloat(10),
+					Quantity:               alpacadecimal.NewFromFloat(5),
+					ChildUniqueReferenceID: rating.UnitPriceUsageChildUniqueReferenceID,
+					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+					AmountDiscounts: []billing.AmountLineDiscountManaged{
+						{
+							AmountLineDiscount: billing.AmountLineDiscount{
+								Amount: alpacadecimal.NewFromFloat(20),
+								LineDiscountBase: billing.LineDiscountBase{
+									Description:            lo.ToPtr("Maximum spend discount for charges over 100"),
+									ChildUniqueReferenceID: lo.ToPtr(billing.LineMaximumSpendReferenceID),
+									Reason:                 billing.NewDiscountReasonFrom(billing.MaximumSpendDiscount{}),
+								},
+							},
+						},
+					},
+					Totals: totals.Totals{
+						Amount:         alpacadecimal.NewFromFloat(50),
+						DiscountsTotal: alpacadecimal.NewFromFloat(20),
+						Total:          alpacadecimal.NewFromFloat(30),
+					},
+				},
+			},
+		})
+	})
+}
+
+func TestGenerateDetailedLinesCreditsMutatorOptions(t *testing.T) {
+	t.Run("credits mutator applied by default", func(t *testing.T) {
+		testutil.RunCalculationTestCase(t, testutil.CalculationTestCase{
+			Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromFloat(10),
+			}),
+			LineMode: testutil.SinglePerPeriodLineMode,
+			Usage: testutil.FeatureUsageResponse{
+				LinePeriodQty: alpacadecimal.NewFromFloat(5),
+			},
+			CreditsApplied: billing.CreditsApplied{
+				{
+					Amount: alpacadecimal.NewFromFloat(20),
+				},
+			},
+			Expect: rating.DetailedLines{
+				{
+					Name:                   "feature: usage in period",
+					PerUnitAmount:          alpacadecimal.NewFromFloat(10),
+					Quantity:               alpacadecimal.NewFromFloat(5),
+					ChildUniqueReferenceID: rating.UnitPriceUsageChildUniqueReferenceID,
+					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+					CreditsApplied: billing.CreditsApplied{
+						{
+							Amount: alpacadecimal.NewFromFloat(20),
+						},
+					},
+					Totals: totals.Totals{
+						Amount:       alpacadecimal.NewFromFloat(50),
+						CreditsTotal: alpacadecimal.NewFromFloat(20),
+						Total:        alpacadecimal.NewFromFloat(30),
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("credits mutator disabled when requested", func(t *testing.T) {
+		testutil.RunCalculationTestCase(t, testutil.CalculationTestCase{
+			Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromFloat(10),
+			}),
+			LineMode: testutil.SinglePerPeriodLineMode,
+			Usage: testutil.FeatureUsageResponse{
+				LinePeriodQty: alpacadecimal.NewFromFloat(5),
+			},
+			CreditsApplied: billing.CreditsApplied{
+				{
+					Amount: alpacadecimal.NewFromFloat(20),
+				},
+			},
+			Options: []rating.GenerateDetailedLinesOption{
+				rating.WithCreditsMutatorDisabled(),
+			},
+			Expect: rating.DetailedLines{
+				{
+					Name:                   "feature: usage in period",
+					PerUnitAmount:          alpacadecimal.NewFromFloat(10),
+					Quantity:               alpacadecimal.NewFromFloat(5),
+					ChildUniqueReferenceID: rating.UnitPriceUsageChildUniqueReferenceID,
+					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+					Totals: totals.Totals{
+						Amount: alpacadecimal.NewFromFloat(50),
+						Total:  alpacadecimal.NewFromFloat(50),
+					},
+				},
+			},
+		})
+	})
+}

--- a/openmeter/billing/rating/service/pricer.go
+++ b/openmeter/billing/rating/service/pricer.go
@@ -26,12 +26,17 @@ func getPricerFor(line rating.PriceAccessor, opts rating.GenerateDetailedLinesOp
 	}
 
 	if linePrice.Type() == productcatalog.FlatPriceType {
+		postCalculationMutators := []mutator.PostCalculationMutator{
+			&mutator.DiscountPercentage{},
+		}
+
+		if !opts.DisableCreditsMutator {
+			postCalculationMutators = append(postCalculationMutators, &mutator.Credits{})
+		}
+
 		return &priceMutator{
-			Pricer: rate.Flat{},
-			PostCalculation: []mutator.PostCalculationMutator{
-				&mutator.DiscountPercentage{},
-				&mutator.Credits{},
-			},
+			Pricer:          rate.Flat{},
+			PostCalculation: postCalculationMutators,
 		}, nil
 	}
 
@@ -61,7 +66,9 @@ func getPricerFor(line rating.PriceAccessor, opts rating.GenerateDetailedLinesOp
 		postCalculationMutators = append(postCalculationMutators, &mutator.MinAmountCommitment{})
 	}
 
-	postCalculationMutators = append(postCalculationMutators, &mutator.Credits{})
+	if !opts.DisableCreditsMutator {
+		postCalculationMutators = append(postCalculationMutators, &mutator.Credits{})
+	}
 
 	// This priceMutator captures the calculation flow for discounts and commitments:
 	return &priceMutator{

--- a/openmeter/billing/rating/service/testutil/ubptest.go
+++ b/openmeter/billing/rating/service/testutil/ubptest.go
@@ -45,10 +45,11 @@ type CalculationTestCase struct {
 	ExpectErrorIs        error
 	PreviousBilledAmount alpacadecimal.Decimal
 	CreditsApplied       billing.CreditsApplied
+	Options              []rating.GenerateDetailedLinesOption
 }
 
 type Service interface {
-	GenerateDetailedLines(in rating.StandardLineAccessor) (rating.GenerateDetailedLinesResult, error)
+	GenerateDetailedLines(in rating.StandardLineAccessor, opts ...rating.GenerateDetailedLinesOption) (rating.GenerateDetailedLinesResult, error)
 }
 
 func RunCalculationTestCase(t *testing.T, tc CalculationTestCase) {
@@ -124,7 +125,7 @@ func RunCalculationTestCase(t *testing.T, tc CalculationTestCase) {
 
 	service := service.New()
 
-	res, err := service.GenerateDetailedLines(line)
+	res, err := service.GenerateDetailedLines(line, tc.Options...)
 	if err != nil {
 		if tc.ExpectErrorIs != nil {
 			require.ErrorIs(t, err, tc.ExpectErrorIs)

--- a/openmeter/billing/service/invoicecalc/details.go
+++ b/openmeter/billing/service/invoicecalc/details.go
@@ -42,6 +42,13 @@ func RecalculateDetailedLinesAndTotals(invoice *billing.StandardInvoice, deps St
 			return fmt.Errorf("getting line engine[%s]: %w", lineEngineType, err)
 		}
 
+		// If the line engine doesn't implement the LineCalculator interface, we skip recalculation, and expect that the
+		// OnStandardInvoiceCreated/OnCollectionCompleted lifecycle event will return the fully calculated state.
+		lineCalculator, ok := lineEngine.(billing.LineCalculator)
+		if !ok {
+			continue
+		}
+
 		input := billing.CalculateLinesInput{
 			Invoice: *invoice,
 			Lines:   stdLines,
@@ -50,7 +57,7 @@ func RecalculateDetailedLinesAndTotals(invoice *billing.StandardInvoice, deps St
 			return fmt.Errorf("validating calculate lines input for engine[%s]: %w", lineEngineType, err)
 		}
 
-		updatedLines, err := lineEngine.CalculateLines(input)
+		updatedLines, err := lineCalculator.CalculateLines(input)
 		if err != nil {
 			return fmt.Errorf("calculating lines for engine[%s]: %w", lineEngineType, err)
 		}

--- a/openmeter/billing/service/invoicecalc/details_test.go
+++ b/openmeter/billing/service/invoicecalc/details_test.go
@@ -1,0 +1,57 @@
+package invoicecalc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	billingtestutils "github.com/openmeterio/openmeter/openmeter/billing/testutils"
+)
+
+func TestRecalculateDetailedLinesAndTotalsSkipsEnginesWithoutCalculator(t *testing.T) {
+	invoice := billing.StandardInvoice{
+		Lines: billing.NewStandardInvoiceLines([]*billing.StandardLine{
+			{
+				StandardLineBase: billing.StandardLineBase{
+					Engine: billing.LineEngineTypeChargeUsageBased,
+					Totals: totals.Totals{
+						Amount: alpacadecimal.NewFromInt(12),
+						Total:  alpacadecimal.NewFromInt(12),
+					},
+				},
+			},
+		}),
+	}
+
+	err := RecalculateDetailedLinesAndTotals(&invoice, StandardInvoiceCalculatorDependencies{
+		LineEngines: staticLineEngineResolver{
+			billing.LineEngineTypeChargeUsageBased: nonCalculatingLineEngine{
+				NoopLineEngine: billingtestutils.NoopLineEngine{
+					EngineType: billing.LineEngineTypeChargeUsageBased,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, alpacadecimal.NewFromInt(12).Equal(invoice.Totals.Amount))
+	require.True(t, alpacadecimal.NewFromInt(12).Equal(invoice.Totals.Total))
+}
+
+type staticLineEngineResolver map[billing.LineEngineType]billing.LineEngine
+
+func (r staticLineEngineResolver) Get(engineType billing.LineEngineType) (billing.LineEngine, error) {
+	engine, ok := r[engineType]
+	if !ok {
+		return nil, fmt.Errorf("engine %s is not registered", engineType)
+	}
+
+	return engine, nil
+}
+
+type nonCalculatingLineEngine struct {
+	billingtestutils.NoopLineEngine
+}

--- a/openmeter/billing/testutils/lineengine.go
+++ b/openmeter/billing/testutils/lineengine.go
@@ -1,0 +1,69 @@
+package testutils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+)
+
+var _ billing.LineEngine = NoopLineEngine{}
+
+// NoopLineEngine is a test helper intended for embedding in line-engine fakes.
+// It intentionally does not implement billing.LineCalculator.
+type NoopLineEngine struct {
+	EngineType billing.LineEngineType
+}
+
+func (e NoopLineEngine) GetLineEngineType() billing.LineEngineType {
+	if e.EngineType == "" {
+		panic("engine type is required")
+	}
+
+	return e.EngineType
+}
+
+func (NoopLineEngine) IsLineBillableAsOf(context.Context, billing.IsLineBillableAsOfInput) (bool, error) {
+	return true, nil
+}
+
+func (NoopLineEngine) SplitGatheringLine(_ context.Context, input billing.SplitGatheringLineInput) (billing.SplitGatheringLineResult, error) {
+	return billing.SplitGatheringLineResult{
+		PreSplitAtLine: input.Line,
+	}, nil
+}
+
+func (NoopLineEngine) BuildStandardInvoiceLines(_ context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
+	lines := make(billing.StandardLines, 0, len(input.GatheringLines))
+
+	for _, gatheringLine := range input.GatheringLines {
+		stdLine, err := gatheringLine.AsNewStandardLine(input.Invoice.ID)
+		if err != nil {
+			return nil, fmt.Errorf("converting gathering line to standard line: %w", err)
+		}
+
+		lines = append(lines, stdLine)
+	}
+
+	return lines, nil
+}
+
+func (NoopLineEngine) OnStandardInvoiceCreated(_ context.Context, input billing.OnStandardInvoiceCreatedInput) (billing.StandardLines, error) {
+	return input.Lines, nil
+}
+
+func (NoopLineEngine) OnCollectionCompleted(_ context.Context, input billing.OnCollectionCompletedInput) (billing.StandardLines, error) {
+	return input.Lines, nil
+}
+
+func (NoopLineEngine) OnInvoiceIssued(context.Context, billing.OnInvoiceIssuedInput) error {
+	return nil
+}
+
+func (NoopLineEngine) OnPaymentAuthorized(context.Context, billing.OnPaymentAuthorizedInput) error {
+	return nil
+}
+
+func (NoopLineEngine) OnPaymentSettled(context.Context, billing.OnPaymentSettledInput) error {
+	return nil
+}

--- a/openmeter/ent/db/chargeflatfeedetailedline.go
+++ b/openmeter/ent/db/chargeflatfeedetailedline.go
@@ -88,6 +88,8 @@ type ChargeFlatFeeDetailedLine struct {
 	Total alpacadecimal.Decimal `json:"total,omitempty"`
 	// ChargeID holds the value of the "charge_id" field.
 	ChargeID string `json:"charge_id,omitempty"`
+	// PricerReferenceID holds the value of the "pricer_reference_id" field.
+	PricerReferenceID string `json:"pricer_reference_id,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ChargeFlatFeeDetailedLineQuery when eager-loading is set.
 	Edges        ChargeFlatFeeDetailedLineEdges `json:"edges"`
@@ -138,7 +140,7 @@ func (*ChargeFlatFeeDetailedLine) scanValues(columns []string) ([]any, error) {
 			values[i] = new(alpacadecimal.Decimal)
 		case chargeflatfeedetailedline.FieldIndex:
 			values[i] = new(sql.NullInt64)
-		case chargeflatfeedetailedline.FieldID, chargeflatfeedetailedline.FieldCurrency, chargeflatfeedetailedline.FieldTaxCodeID, chargeflatfeedetailedline.FieldTaxBehavior, chargeflatfeedetailedline.FieldInvoicingAppExternalID, chargeflatfeedetailedline.FieldChildUniqueReferenceID, chargeflatfeedetailedline.FieldCategory, chargeflatfeedetailedline.FieldPaymentTerm, chargeflatfeedetailedline.FieldNamespace, chargeflatfeedetailedline.FieldName, chargeflatfeedetailedline.FieldDescription, chargeflatfeedetailedline.FieldChargeID:
+		case chargeflatfeedetailedline.FieldID, chargeflatfeedetailedline.FieldCurrency, chargeflatfeedetailedline.FieldTaxCodeID, chargeflatfeedetailedline.FieldTaxBehavior, chargeflatfeedetailedline.FieldInvoicingAppExternalID, chargeflatfeedetailedline.FieldChildUniqueReferenceID, chargeflatfeedetailedline.FieldCategory, chargeflatfeedetailedline.FieldPaymentTerm, chargeflatfeedetailedline.FieldNamespace, chargeflatfeedetailedline.FieldName, chargeflatfeedetailedline.FieldDescription, chargeflatfeedetailedline.FieldChargeID, chargeflatfeedetailedline.FieldPricerReferenceID:
 			values[i] = new(sql.NullString)
 		case chargeflatfeedetailedline.FieldServicePeriodStart, chargeflatfeedetailedline.FieldServicePeriodEnd, chargeflatfeedetailedline.FieldCreatedAt, chargeflatfeedetailedline.FieldUpdatedAt, chargeflatfeedetailedline.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -363,6 +365,12 @@ func (_m *ChargeFlatFeeDetailedLine) assignValues(columns []string, values []any
 			} else if value.Valid {
 				_m.ChargeID = value.String
 			}
+		case chargeflatfeedetailedline.FieldPricerReferenceID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field pricer_reference_id", values[i])
+			} else if value.Valid {
+				_m.PricerReferenceID = value.String
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -513,6 +521,9 @@ func (_m *ChargeFlatFeeDetailedLine) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("charge_id=")
 	builder.WriteString(_m.ChargeID)
+	builder.WriteString(", ")
+	builder.WriteString("pricer_reference_id=")
+	builder.WriteString(_m.PricerReferenceID)
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/openmeter/ent/db/chargeflatfeedetailedline/chargeflatfeedetailedline.go
+++ b/openmeter/ent/db/chargeflatfeedetailedline/chargeflatfeedetailedline.go
@@ -79,6 +79,8 @@ const (
 	FieldTotal = "total"
 	// FieldChargeID holds the string denoting the charge_id field in the database.
 	FieldChargeID = "charge_id"
+	// FieldPricerReferenceID holds the string denoting the pricer_reference_id field in the database.
+	FieldPricerReferenceID = "pricer_reference_id"
 	// EdgeCharge holds the string denoting the charge edge name in mutations.
 	EdgeCharge = "charge"
 	// EdgeTaxCode holds the string denoting the tax_code edge name in mutations.
@@ -135,6 +137,7 @@ var Columns = []string{
 	FieldCreditsTotal,
 	FieldTotal,
 	FieldChargeID,
+	FieldPricerReferenceID,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -160,6 +163,8 @@ var (
 	DefaultUpdatedAt func() time.Time
 	// UpdateDefaultUpdatedAt holds the default value on update for the "updated_at" field.
 	UpdateDefaultUpdatedAt func() time.Time
+	// PricerReferenceIDValidator is a validator for the "pricer_reference_id" field. It is called by the builders before save.
+	PricerReferenceIDValidator func(string) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -339,6 +344,11 @@ func ByTotal(opts ...sql.OrderTermOption) OrderOption {
 // ByChargeID orders the results by the charge_id field.
 func ByChargeID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldChargeID, opts...).ToFunc()
+}
+
+// ByPricerReferenceID orders the results by the pricer_reference_id field.
+func ByPricerReferenceID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldPricerReferenceID, opts...).ToFunc()
 }
 
 // ByChargeField orders the results by charge field.

--- a/openmeter/ent/db/chargeflatfeedetailedline/where.go
+++ b/openmeter/ent/db/chargeflatfeedetailedline/where.go
@@ -190,6 +190,11 @@ func ChargeID(v string) predicate.ChargeFlatFeeDetailedLine {
 	return predicate.ChargeFlatFeeDetailedLine(sql.FieldEQ(FieldChargeID, v))
 }
 
+// PricerReferenceID applies equality check predicate on the "pricer_reference_id" field. It's identical to PricerReferenceIDEQ.
+func PricerReferenceID(v string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldEQ(FieldPricerReferenceID, v))
+}
+
 // CurrencyEQ applies the EQ predicate on the "currency" field.
 func CurrencyEQ(v currencyx.Code) predicate.ChargeFlatFeeDetailedLine {
 	vc := string(v)
@@ -1557,6 +1562,71 @@ func ChargeIDEqualFold(v string) predicate.ChargeFlatFeeDetailedLine {
 // ChargeIDContainsFold applies the ContainsFold predicate on the "charge_id" field.
 func ChargeIDContainsFold(v string) predicate.ChargeFlatFeeDetailedLine {
 	return predicate.ChargeFlatFeeDetailedLine(sql.FieldContainsFold(FieldChargeID, v))
+}
+
+// PricerReferenceIDEQ applies the EQ predicate on the "pricer_reference_id" field.
+func PricerReferenceIDEQ(v string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldEQ(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDNEQ applies the NEQ predicate on the "pricer_reference_id" field.
+func PricerReferenceIDNEQ(v string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldNEQ(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDIn applies the In predicate on the "pricer_reference_id" field.
+func PricerReferenceIDIn(vs ...string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldIn(FieldPricerReferenceID, vs...))
+}
+
+// PricerReferenceIDNotIn applies the NotIn predicate on the "pricer_reference_id" field.
+func PricerReferenceIDNotIn(vs ...string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldNotIn(FieldPricerReferenceID, vs...))
+}
+
+// PricerReferenceIDGT applies the GT predicate on the "pricer_reference_id" field.
+func PricerReferenceIDGT(v string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldGT(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDGTE applies the GTE predicate on the "pricer_reference_id" field.
+func PricerReferenceIDGTE(v string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldGTE(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDLT applies the LT predicate on the "pricer_reference_id" field.
+func PricerReferenceIDLT(v string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldLT(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDLTE applies the LTE predicate on the "pricer_reference_id" field.
+func PricerReferenceIDLTE(v string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldLTE(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDContains applies the Contains predicate on the "pricer_reference_id" field.
+func PricerReferenceIDContains(v string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldContains(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDHasPrefix applies the HasPrefix predicate on the "pricer_reference_id" field.
+func PricerReferenceIDHasPrefix(v string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldHasPrefix(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDHasSuffix applies the HasSuffix predicate on the "pricer_reference_id" field.
+func PricerReferenceIDHasSuffix(v string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldHasSuffix(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDEqualFold applies the EqualFold predicate on the "pricer_reference_id" field.
+func PricerReferenceIDEqualFold(v string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldEqualFold(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDContainsFold applies the ContainsFold predicate on the "pricer_reference_id" field.
+func PricerReferenceIDContainsFold(v string) predicate.ChargeFlatFeeDetailedLine {
+	return predicate.ChargeFlatFeeDetailedLine(sql.FieldContainsFold(FieldPricerReferenceID, v))
 }
 
 // HasCharge applies the HasEdge predicate on the "charge" edge.

--- a/openmeter/ent/db/chargeflatfeedetailedline_create.go
+++ b/openmeter/ent/db/chargeflatfeedetailedline_create.go
@@ -305,6 +305,12 @@ func (_c *ChargeFlatFeeDetailedLineCreate) SetChargeID(v string) *ChargeFlatFeeD
 	return _c
 }
 
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (_c *ChargeFlatFeeDetailedLineCreate) SetPricerReferenceID(v string) *ChargeFlatFeeDetailedLineCreate {
+	_c.mutation.SetPricerReferenceID(v)
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *ChargeFlatFeeDetailedLineCreate) SetID(v string) *ChargeFlatFeeDetailedLineCreate {
 	_c.mutation.SetID(v)
@@ -491,6 +497,14 @@ func (_c *ChargeFlatFeeDetailedLineCreate) check() error {
 	if _, ok := _c.mutation.ChargeID(); !ok {
 		return &ValidationError{Name: "charge_id", err: errors.New(`db: missing required field "ChargeFlatFeeDetailedLine.charge_id"`)}
 	}
+	if _, ok := _c.mutation.PricerReferenceID(); !ok {
+		return &ValidationError{Name: "pricer_reference_id", err: errors.New(`db: missing required field "ChargeFlatFeeDetailedLine.pricer_reference_id"`)}
+	}
+	if v, ok := _c.mutation.PricerReferenceID(); ok {
+		if err := chargeflatfeedetailedline.PricerReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "pricer_reference_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeDetailedLine.pricer_reference_id": %w`, err)}
+		}
+	}
 	if len(_c.mutation.ChargeIDs()) == 0 {
 		return &ValidationError{Name: "charge", err: errors.New(`db: missing required edge "ChargeFlatFeeDetailedLine.charge"`)}
 	}
@@ -645,6 +659,10 @@ func (_c *ChargeFlatFeeDetailedLineCreate) createSpec() (*ChargeFlatFeeDetailedL
 	if value, ok := _c.mutation.Total(); ok {
 		_spec.SetField(chargeflatfeedetailedline.FieldTotal, field.TypeOther, value)
 		_node.Total = value
+	}
+	if value, ok := _c.mutation.PricerReferenceID(); ok {
+		_spec.SetField(chargeflatfeedetailedline.FieldPricerReferenceID, field.TypeString, value)
+		_node.PricerReferenceID = value
 	}
 	if nodes := _c.mutation.ChargeIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1131,6 +1149,18 @@ func (u *ChargeFlatFeeDetailedLineUpsert) SetChargeID(v string) *ChargeFlatFeeDe
 // UpdateChargeID sets the "charge_id" field to the value that was provided on create.
 func (u *ChargeFlatFeeDetailedLineUpsert) UpdateChargeID() *ChargeFlatFeeDetailedLineUpsert {
 	u.SetExcluded(chargeflatfeedetailedline.FieldChargeID)
+	return u
+}
+
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (u *ChargeFlatFeeDetailedLineUpsert) SetPricerReferenceID(v string) *ChargeFlatFeeDetailedLineUpsert {
+	u.Set(chargeflatfeedetailedline.FieldPricerReferenceID, v)
+	return u
+}
+
+// UpdatePricerReferenceID sets the "pricer_reference_id" field to the value that was provided on create.
+func (u *ChargeFlatFeeDetailedLineUpsert) UpdatePricerReferenceID() *ChargeFlatFeeDetailedLineUpsert {
+	u.SetExcluded(chargeflatfeedetailedline.FieldPricerReferenceID)
 	return u
 }
 
@@ -1657,6 +1687,20 @@ func (u *ChargeFlatFeeDetailedLineUpsertOne) SetChargeID(v string) *ChargeFlatFe
 func (u *ChargeFlatFeeDetailedLineUpsertOne) UpdateChargeID() *ChargeFlatFeeDetailedLineUpsertOne {
 	return u.Update(func(s *ChargeFlatFeeDetailedLineUpsert) {
 		s.UpdateChargeID()
+	})
+}
+
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (u *ChargeFlatFeeDetailedLineUpsertOne) SetPricerReferenceID(v string) *ChargeFlatFeeDetailedLineUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeDetailedLineUpsert) {
+		s.SetPricerReferenceID(v)
+	})
+}
+
+// UpdatePricerReferenceID sets the "pricer_reference_id" field to the value that was provided on create.
+func (u *ChargeFlatFeeDetailedLineUpsertOne) UpdatePricerReferenceID() *ChargeFlatFeeDetailedLineUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeDetailedLineUpsert) {
+		s.UpdatePricerReferenceID()
 	})
 }
 
@@ -2350,6 +2394,20 @@ func (u *ChargeFlatFeeDetailedLineUpsertBulk) SetChargeID(v string) *ChargeFlatF
 func (u *ChargeFlatFeeDetailedLineUpsertBulk) UpdateChargeID() *ChargeFlatFeeDetailedLineUpsertBulk {
 	return u.Update(func(s *ChargeFlatFeeDetailedLineUpsert) {
 		s.UpdateChargeID()
+	})
+}
+
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (u *ChargeFlatFeeDetailedLineUpsertBulk) SetPricerReferenceID(v string) *ChargeFlatFeeDetailedLineUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeDetailedLineUpsert) {
+		s.SetPricerReferenceID(v)
+	})
+}
+
+// UpdatePricerReferenceID sets the "pricer_reference_id" field to the value that was provided on create.
+func (u *ChargeFlatFeeDetailedLineUpsertBulk) UpdatePricerReferenceID() *ChargeFlatFeeDetailedLineUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeDetailedLineUpsert) {
+		s.UpdatePricerReferenceID()
 	})
 }
 

--- a/openmeter/ent/db/chargeflatfeedetailedline_update.go
+++ b/openmeter/ent/db/chargeflatfeedetailedline_update.go
@@ -462,6 +462,20 @@ func (_u *ChargeFlatFeeDetailedLineUpdate) SetNillableChargeID(v *string) *Charg
 	return _u
 }
 
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (_u *ChargeFlatFeeDetailedLineUpdate) SetPricerReferenceID(v string) *ChargeFlatFeeDetailedLineUpdate {
+	_u.mutation.SetPricerReferenceID(v)
+	return _u
+}
+
+// SetNillablePricerReferenceID sets the "pricer_reference_id" field if the given value is not nil.
+func (_u *ChargeFlatFeeDetailedLineUpdate) SetNillablePricerReferenceID(v *string) *ChargeFlatFeeDetailedLineUpdate {
+	if v != nil {
+		_u.SetPricerReferenceID(*v)
+	}
+	return _u
+}
+
 // SetCharge sets the "charge" edge to the ChargeFlatFee entity.
 func (_u *ChargeFlatFeeDetailedLineUpdate) SetCharge(v *ChargeFlatFee) *ChargeFlatFeeDetailedLineUpdate {
 	return _u.SetChargeID(v.ID)
@@ -555,6 +569,11 @@ func (_u *ChargeFlatFeeDetailedLineUpdate) check() error {
 	if v, ok := _u.mutation.CreditsApplied(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "credits_applied", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeDetailedLine.credits_applied": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.PricerReferenceID(); ok {
+		if err := chargeflatfeedetailedline.PricerReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "pricer_reference_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeDetailedLine.pricer_reference_id": %w`, err)}
 		}
 	}
 	if _u.mutation.ChargeCleared() && len(_u.mutation.ChargeIDs()) > 0 {
@@ -682,6 +701,9 @@ func (_u *ChargeFlatFeeDetailedLineUpdate) sqlSave(ctx context.Context) (_node i
 	}
 	if value, ok := _u.mutation.Total(); ok {
 		_spec.SetField(chargeflatfeedetailedline.FieldTotal, field.TypeOther, value)
+	}
+	if value, ok := _u.mutation.PricerReferenceID(); ok {
+		_spec.SetField(chargeflatfeedetailedline.FieldPricerReferenceID, field.TypeString, value)
 	}
 	if _u.mutation.ChargeCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1188,6 +1210,20 @@ func (_u *ChargeFlatFeeDetailedLineUpdateOne) SetNillableChargeID(v *string) *Ch
 	return _u
 }
 
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (_u *ChargeFlatFeeDetailedLineUpdateOne) SetPricerReferenceID(v string) *ChargeFlatFeeDetailedLineUpdateOne {
+	_u.mutation.SetPricerReferenceID(v)
+	return _u
+}
+
+// SetNillablePricerReferenceID sets the "pricer_reference_id" field if the given value is not nil.
+func (_u *ChargeFlatFeeDetailedLineUpdateOne) SetNillablePricerReferenceID(v *string) *ChargeFlatFeeDetailedLineUpdateOne {
+	if v != nil {
+		_u.SetPricerReferenceID(*v)
+	}
+	return _u
+}
+
 // SetCharge sets the "charge" edge to the ChargeFlatFee entity.
 func (_u *ChargeFlatFeeDetailedLineUpdateOne) SetCharge(v *ChargeFlatFee) *ChargeFlatFeeDetailedLineUpdateOne {
 	return _u.SetChargeID(v.ID)
@@ -1294,6 +1330,11 @@ func (_u *ChargeFlatFeeDetailedLineUpdateOne) check() error {
 	if v, ok := _u.mutation.CreditsApplied(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "credits_applied", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeDetailedLine.credits_applied": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.PricerReferenceID(); ok {
+		if err := chargeflatfeedetailedline.PricerReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "pricer_reference_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeDetailedLine.pricer_reference_id": %w`, err)}
 		}
 	}
 	if _u.mutation.ChargeCleared() && len(_u.mutation.ChargeIDs()) > 0 {
@@ -1438,6 +1479,9 @@ func (_u *ChargeFlatFeeDetailedLineUpdateOne) sqlSave(ctx context.Context) (_nod
 	}
 	if value, ok := _u.mutation.Total(); ok {
 		_spec.SetField(chargeflatfeedetailedline.FieldTotal, field.TypeOther, value)
+	}
+	if value, ok := _u.mutation.PricerReferenceID(); ok {
+		_spec.SetField(chargeflatfeedetailedline.FieldPricerReferenceID, field.TypeString, value)
 	}
 	if _u.mutation.ChargeCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/openmeter/ent/db/chargeusagebased.go
+++ b/openmeter/ent/db/chargeusagebased.go
@@ -92,6 +92,8 @@ type ChargeUsageBased struct {
 	FeatureKey string `json:"feature_key,omitempty"`
 	// FeatureID holds the value of the "feature_id" field.
 	FeatureID string `json:"feature_id,omitempty"`
+	// RatingEngine holds the value of the "rating_engine" field.
+	RatingEngine usagebased.RatingEngine `json:"rating_engine,omitempty"`
 	// Price holds the value of the "price" field.
 	Price *productcatalog.Price `json:"price,omitempty"`
 	// CurrentRealizationRunID holds the value of the "current_realization_run_id" field.
@@ -244,7 +246,7 @@ func (*ChargeUsageBased) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargeusagebased.FieldAnnotations, chargeusagebased.FieldMetadata:
 			values[i] = new([]byte)
-		case chargeusagebased.FieldID, chargeusagebased.FieldCustomerID, chargeusagebased.FieldStatus, chargeusagebased.FieldUniqueReferenceID, chargeusagebased.FieldCurrency, chargeusagebased.FieldManagedBy, chargeusagebased.FieldSubscriptionID, chargeusagebased.FieldSubscriptionPhaseID, chargeusagebased.FieldSubscriptionItemID, chargeusagebased.FieldTaxCodeID, chargeusagebased.FieldTaxBehavior, chargeusagebased.FieldNamespace, chargeusagebased.FieldName, chargeusagebased.FieldDescription, chargeusagebased.FieldSettlementMode, chargeusagebased.FieldFeatureKey, chargeusagebased.FieldFeatureID, chargeusagebased.FieldCurrentRealizationRunID, chargeusagebased.FieldStatusDetailed:
+		case chargeusagebased.FieldID, chargeusagebased.FieldCustomerID, chargeusagebased.FieldStatus, chargeusagebased.FieldUniqueReferenceID, chargeusagebased.FieldCurrency, chargeusagebased.FieldManagedBy, chargeusagebased.FieldSubscriptionID, chargeusagebased.FieldSubscriptionPhaseID, chargeusagebased.FieldSubscriptionItemID, chargeusagebased.FieldTaxCodeID, chargeusagebased.FieldTaxBehavior, chargeusagebased.FieldNamespace, chargeusagebased.FieldName, chargeusagebased.FieldDescription, chargeusagebased.FieldSettlementMode, chargeusagebased.FieldFeatureKey, chargeusagebased.FieldFeatureID, chargeusagebased.FieldRatingEngine, chargeusagebased.FieldCurrentRealizationRunID, chargeusagebased.FieldStatusDetailed:
 			values[i] = new(sql.NullString)
 		case chargeusagebased.FieldServicePeriodFrom, chargeusagebased.FieldServicePeriodTo, chargeusagebased.FieldBillingPeriodFrom, chargeusagebased.FieldBillingPeriodTo, chargeusagebased.FieldFullServicePeriodFrom, chargeusagebased.FieldFullServicePeriodTo, chargeusagebased.FieldAdvanceAfter, chargeusagebased.FieldCreatedAt, chargeusagebased.FieldUpdatedAt, chargeusagebased.FieldDeletedAt, chargeusagebased.FieldInvoiceAt:
 			values[i] = new(sql.NullTime)
@@ -466,6 +468,12 @@ func (_m *ChargeUsageBased) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.FeatureID = value.String
 			}
+		case chargeusagebased.FieldRatingEngine:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field rating_engine", values[i])
+			} else if value.Valid {
+				_m.RatingEngine = usagebased.RatingEngine(value.String)
+			}
 		case chargeusagebased.FieldPrice:
 			if value, err := chargeusagebased.ValueScanner.Price.FromValue(values[i]); err != nil {
 				return err
@@ -680,6 +688,9 @@ func (_m *ChargeUsageBased) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("feature_id=")
 	builder.WriteString(_m.FeatureID)
+	builder.WriteString(", ")
+	builder.WriteString("rating_engine=")
+	builder.WriteString(fmt.Sprintf("%v", _m.RatingEngine))
 	builder.WriteString(", ")
 	builder.WriteString("price=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Price))

--- a/openmeter/ent/db/chargeusagebased/chargeusagebased.go
+++ b/openmeter/ent/db/chargeusagebased/chargeusagebased.go
@@ -80,6 +80,8 @@ const (
 	FieldFeatureKey = "feature_key"
 	// FieldFeatureID holds the string denoting the feature_id field in the database.
 	FieldFeatureID = "feature_id"
+	// FieldRatingEngine holds the string denoting the rating_engine field in the database.
+	FieldRatingEngine = "rating_engine"
 	// FieldPrice holds the string denoting the price field in the database.
 	FieldPrice = "price"
 	// FieldCurrentRealizationRunID holds the string denoting the current_realization_run_id field in the database.
@@ -213,6 +215,7 @@ var Columns = []string{
 	FieldDiscounts,
 	FieldFeatureKey,
 	FieldFeatureID,
+	FieldRatingEngine,
 	FieldPrice,
 	FieldCurrentRealizationRunID,
 	FieldStatusDetailed,
@@ -291,6 +294,16 @@ func SettlementModeValidator(sm productcatalog.SettlementMode) error {
 		return nil
 	default:
 		return fmt.Errorf("chargeusagebased: invalid enum value for settlement_mode field: %q", sm)
+	}
+}
+
+// RatingEngineValidator is a validator for the "rating_engine" field enum values. It is called by the builders before save.
+func RatingEngineValidator(re usagebased.RatingEngine) error {
+	switch re {
+	case "delta", "period_preserving":
+		return nil
+	default:
+		return fmt.Errorf("chargeusagebased: invalid enum value for rating_engine field: %q", re)
 	}
 }
 
@@ -450,6 +463,11 @@ func ByFeatureKey(opts ...sql.OrderTermOption) OrderOption {
 // ByFeatureID orders the results by the feature_id field.
 func ByFeatureID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldFeatureID, opts...).ToFunc()
+}
+
+// ByRatingEngine orders the results by the rating_engine field.
+func ByRatingEngine(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRatingEngine, opts...).ToFunc()
 }
 
 // ByPrice orders the results by the price field.

--- a/openmeter/ent/db/chargeusagebased/where.go
+++ b/openmeter/ent/db/chargeusagebased/where.go
@@ -1670,6 +1670,36 @@ func FeatureIDContainsFold(v string) predicate.ChargeUsageBased {
 	return predicate.ChargeUsageBased(sql.FieldContainsFold(FieldFeatureID, v))
 }
 
+// RatingEngineEQ applies the EQ predicate on the "rating_engine" field.
+func RatingEngineEQ(v usagebased.RatingEngine) predicate.ChargeUsageBased {
+	vc := v
+	return predicate.ChargeUsageBased(sql.FieldEQ(FieldRatingEngine, vc))
+}
+
+// RatingEngineNEQ applies the NEQ predicate on the "rating_engine" field.
+func RatingEngineNEQ(v usagebased.RatingEngine) predicate.ChargeUsageBased {
+	vc := v
+	return predicate.ChargeUsageBased(sql.FieldNEQ(FieldRatingEngine, vc))
+}
+
+// RatingEngineIn applies the In predicate on the "rating_engine" field.
+func RatingEngineIn(vs ...usagebased.RatingEngine) predicate.ChargeUsageBased {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.ChargeUsageBased(sql.FieldIn(FieldRatingEngine, v...))
+}
+
+// RatingEngineNotIn applies the NotIn predicate on the "rating_engine" field.
+func RatingEngineNotIn(vs ...usagebased.RatingEngine) predicate.ChargeUsageBased {
+	v := make([]any, len(vs))
+	for i := range v {
+		v[i] = vs[i]
+	}
+	return predicate.ChargeUsageBased(sql.FieldNotIn(FieldRatingEngine, v...))
+}
+
 // CurrentRealizationRunIDEQ applies the EQ predicate on the "current_realization_run_id" field.
 func CurrentRealizationRunIDEQ(v string) predicate.ChargeUsageBased {
 	return predicate.ChargeUsageBased(sql.FieldEQ(FieldCurrentRealizationRunID, v))

--- a/openmeter/ent/db/chargeusagebased_create.go
+++ b/openmeter/ent/db/chargeusagebased_create.go
@@ -306,6 +306,12 @@ func (_c *ChargeUsageBasedCreate) SetFeatureID(v string) *ChargeUsageBasedCreate
 	return _c
 }
 
+// SetRatingEngine sets the "rating_engine" field.
+func (_c *ChargeUsageBasedCreate) SetRatingEngine(v usagebased.RatingEngine) *ChargeUsageBasedCreate {
+	_c.mutation.SetRatingEngine(v)
+	return _c
+}
+
 // SetPrice sets the "price" field.
 func (_c *ChargeUsageBasedCreate) SetPrice(v *productcatalog.Price) *ChargeUsageBasedCreate {
 	_c.mutation.SetPrice(v)
@@ -599,6 +605,14 @@ func (_c *ChargeUsageBasedCreate) check() error {
 			return &ValidationError{Name: "feature_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.feature_id": %w`, err)}
 		}
 	}
+	if _, ok := _c.mutation.RatingEngine(); !ok {
+		return &ValidationError{Name: "rating_engine", err: errors.New(`db: missing required field "ChargeUsageBased.rating_engine"`)}
+	}
+	if v, ok := _c.mutation.RatingEngine(); ok {
+		if err := chargeusagebased.RatingEngineValidator(v); err != nil {
+			return &ValidationError{Name: "rating_engine", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.rating_engine": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.Price(); !ok {
 		return &ValidationError{Name: "price", err: errors.New(`db: missing required field "ChargeUsageBased.price"`)}
 	}
@@ -759,6 +773,10 @@ func (_c *ChargeUsageBasedCreate) createSpec() (*ChargeUsageBased, *sqlgraph.Cre
 	if value, ok := _c.mutation.FeatureKey(); ok {
 		_spec.SetField(chargeusagebased.FieldFeatureKey, field.TypeString, value)
 		_node.FeatureKey = value
+	}
+	if value, ok := _c.mutation.RatingEngine(); ok {
+		_spec.SetField(chargeusagebased.FieldRatingEngine, field.TypeEnum, value)
+		_node.RatingEngine = value
 	}
 	if value, ok := _c.mutation.Price(); ok {
 		vv, err := chargeusagebased.ValueScanner.Price.Value(value)
@@ -1267,6 +1285,18 @@ func (u *ChargeUsageBasedUpsert) UpdateFeatureID() *ChargeUsageBasedUpsert {
 	return u
 }
 
+// SetRatingEngine sets the "rating_engine" field.
+func (u *ChargeUsageBasedUpsert) SetRatingEngine(v usagebased.RatingEngine) *ChargeUsageBasedUpsert {
+	u.Set(chargeusagebased.FieldRatingEngine, v)
+	return u
+}
+
+// UpdateRatingEngine sets the "rating_engine" field to the value that was provided on create.
+func (u *ChargeUsageBasedUpsert) UpdateRatingEngine() *ChargeUsageBasedUpsert {
+	u.SetExcluded(chargeusagebased.FieldRatingEngine)
+	return u
+}
+
 // SetCurrentRealizationRunID sets the "current_realization_run_id" field.
 func (u *ChargeUsageBasedUpsert) SetCurrentRealizationRunID(v string) *ChargeUsageBasedUpsert {
 	u.Set(chargeusagebased.FieldCurrentRealizationRunID, v)
@@ -1700,6 +1730,20 @@ func (u *ChargeUsageBasedUpsertOne) SetFeatureID(v string) *ChargeUsageBasedUpse
 func (u *ChargeUsageBasedUpsertOne) UpdateFeatureID() *ChargeUsageBasedUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedUpsert) {
 		s.UpdateFeatureID()
+	})
+}
+
+// SetRatingEngine sets the "rating_engine" field.
+func (u *ChargeUsageBasedUpsertOne) SetRatingEngine(v usagebased.RatingEngine) *ChargeUsageBasedUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.SetRatingEngine(v)
+	})
+}
+
+// UpdateRatingEngine sets the "rating_engine" field to the value that was provided on create.
+func (u *ChargeUsageBasedUpsertOne) UpdateRatingEngine() *ChargeUsageBasedUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.UpdateRatingEngine()
 	})
 }
 
@@ -2311,6 +2355,20 @@ func (u *ChargeUsageBasedUpsertBulk) SetFeatureID(v string) *ChargeUsageBasedUps
 func (u *ChargeUsageBasedUpsertBulk) UpdateFeatureID() *ChargeUsageBasedUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedUpsert) {
 		s.UpdateFeatureID()
+	})
+}
+
+// SetRatingEngine sets the "rating_engine" field.
+func (u *ChargeUsageBasedUpsertBulk) SetRatingEngine(v usagebased.RatingEngine) *ChargeUsageBasedUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.SetRatingEngine(v)
+	})
+}
+
+// UpdateRatingEngine sets the "rating_engine" field to the value that was provided on create.
+func (u *ChargeUsageBasedUpsertBulk) UpdateRatingEngine() *ChargeUsageBasedUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.UpdateRatingEngine()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebased_update.go
+++ b/openmeter/ent/db/chargeusagebased_update.go
@@ -319,6 +319,20 @@ func (_u *ChargeUsageBasedUpdate) SetNillableFeatureID(v *string) *ChargeUsageBa
 	return _u
 }
 
+// SetRatingEngine sets the "rating_engine" field.
+func (_u *ChargeUsageBasedUpdate) SetRatingEngine(v usagebased.RatingEngine) *ChargeUsageBasedUpdate {
+	_u.mutation.SetRatingEngine(v)
+	return _u
+}
+
+// SetNillableRatingEngine sets the "rating_engine" field if the given value is not nil.
+func (_u *ChargeUsageBasedUpdate) SetNillableRatingEngine(v *usagebased.RatingEngine) *ChargeUsageBasedUpdate {
+	if v != nil {
+		_u.SetRatingEngine(*v)
+	}
+	return _u
+}
+
 // SetCurrentRealizationRunID sets the "current_realization_run_id" field.
 func (_u *ChargeUsageBasedUpdate) SetCurrentRealizationRunID(v string) *ChargeUsageBasedUpdate {
 	_u.mutation.SetCurrentRealizationRunID(v)
@@ -540,6 +554,11 @@ func (_u *ChargeUsageBasedUpdate) check() error {
 			return &ValidationError{Name: "feature_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.feature_id": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.RatingEngine(); ok {
+		if err := chargeusagebased.RatingEngineValidator(v); err != nil {
+			return &ValidationError{Name: "rating_engine", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.rating_engine": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.StatusDetailed(); ok {
 		if err := chargeusagebased.StatusDetailedValidator(v); err != nil {
 			return &ValidationError{Name: "status_detailed", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.status_detailed": %w`, err)}
@@ -644,6 +663,9 @@ func (_u *ChargeUsageBasedUpdate) sqlSave(ctx context.Context) (_node int, err e
 	}
 	if _u.mutation.DiscountsCleared() {
 		_spec.ClearField(chargeusagebased.FieldDiscounts, field.TypeString)
+	}
+	if value, ok := _u.mutation.RatingEngine(); ok {
+		_spec.SetField(chargeusagebased.FieldRatingEngine, field.TypeEnum, value)
 	}
 	if value, ok := _u.mutation.StatusDetailed(); ok {
 		_spec.SetField(chargeusagebased.FieldStatusDetailed, field.TypeEnum, value)
@@ -1127,6 +1149,20 @@ func (_u *ChargeUsageBasedUpdateOne) SetNillableFeatureID(v *string) *ChargeUsag
 	return _u
 }
 
+// SetRatingEngine sets the "rating_engine" field.
+func (_u *ChargeUsageBasedUpdateOne) SetRatingEngine(v usagebased.RatingEngine) *ChargeUsageBasedUpdateOne {
+	_u.mutation.SetRatingEngine(v)
+	return _u
+}
+
+// SetNillableRatingEngine sets the "rating_engine" field if the given value is not nil.
+func (_u *ChargeUsageBasedUpdateOne) SetNillableRatingEngine(v *usagebased.RatingEngine) *ChargeUsageBasedUpdateOne {
+	if v != nil {
+		_u.SetRatingEngine(*v)
+	}
+	return _u
+}
+
 // SetCurrentRealizationRunID sets the "current_realization_run_id" field.
 func (_u *ChargeUsageBasedUpdateOne) SetCurrentRealizationRunID(v string) *ChargeUsageBasedUpdateOne {
 	_u.mutation.SetCurrentRealizationRunID(v)
@@ -1361,6 +1397,11 @@ func (_u *ChargeUsageBasedUpdateOne) check() error {
 			return &ValidationError{Name: "feature_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.feature_id": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.RatingEngine(); ok {
+		if err := chargeusagebased.RatingEngineValidator(v); err != nil {
+			return &ValidationError{Name: "rating_engine", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.rating_engine": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.StatusDetailed(); ok {
 		if err := chargeusagebased.StatusDetailedValidator(v); err != nil {
 			return &ValidationError{Name: "status_detailed", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.status_detailed": %w`, err)}
@@ -1482,6 +1523,9 @@ func (_u *ChargeUsageBasedUpdateOne) sqlSave(ctx context.Context) (_node *Charge
 	}
 	if _u.mutation.DiscountsCleared() {
 		_spec.ClearField(chargeusagebased.FieldDiscounts, field.TypeString)
+	}
+	if value, ok := _u.mutation.RatingEngine(); ok {
+		_spec.SetField(chargeusagebased.FieldRatingEngine, field.TypeEnum, value)
 	}
 	if value, ok := _u.mutation.StatusDetailed(); ok {
 		_spec.SetField(chargeusagebased.FieldStatusDetailed, field.TypeEnum, value)

--- a/openmeter/ent/db/chargeusagebasedrundetailedline.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline.go
@@ -91,6 +91,10 @@ type ChargeUsageBasedRunDetailedLine struct {
 	ChargeID string `json:"charge_id,omitempty"`
 	// RunID holds the value of the "run_id" field.
 	RunID string `json:"run_id,omitempty"`
+	// PricerReferenceID holds the value of the "pricer_reference_id" field.
+	PricerReferenceID string `json:"pricer_reference_id,omitempty"`
+	// CorrectsRunID holds the value of the "corrects_run_id" field.
+	CorrectsRunID *string `json:"corrects_run_id,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ChargeUsageBasedRunDetailedLineQuery when eager-loading is set.
 	Edges        ChargeUsageBasedRunDetailedLineEdges `json:"edges"`
@@ -103,11 +107,13 @@ type ChargeUsageBasedRunDetailedLineEdges struct {
 	Charge *ChargeUsageBased `json:"charge,omitempty"`
 	// Run holds the value of the run edge.
 	Run *ChargeUsageBasedRuns `json:"run,omitempty"`
+	// CorrectsRun holds the value of the corrects_run edge.
+	CorrectsRun *ChargeUsageBasedRuns `json:"corrects_run,omitempty"`
 	// TaxCode holds the value of the tax_code edge.
 	TaxCode *TaxCode `json:"tax_code,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [3]bool
+	loadedTypes [4]bool
 }
 
 // ChargeOrErr returns the Charge value or an error if the edge
@@ -132,12 +138,23 @@ func (e ChargeUsageBasedRunDetailedLineEdges) RunOrErr() (*ChargeUsageBasedRuns,
 	return nil, &NotLoadedError{edge: "run"}
 }
 
+// CorrectsRunOrErr returns the CorrectsRun value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e ChargeUsageBasedRunDetailedLineEdges) CorrectsRunOrErr() (*ChargeUsageBasedRuns, error) {
+	if e.CorrectsRun != nil {
+		return e.CorrectsRun, nil
+	} else if e.loadedTypes[2] {
+		return nil, &NotFoundError{label: chargeusagebasedruns.Label}
+	}
+	return nil, &NotLoadedError{edge: "corrects_run"}
+}
+
 // TaxCodeOrErr returns the TaxCode value or an error if the edge
 // was not loaded in eager-loading, or loaded but was not found.
 func (e ChargeUsageBasedRunDetailedLineEdges) TaxCodeOrErr() (*TaxCode, error) {
 	if e.TaxCode != nil {
 		return e.TaxCode, nil
-	} else if e.loadedTypes[2] {
+	} else if e.loadedTypes[3] {
 		return nil, &NotFoundError{label: dbtaxcode.Label}
 	}
 	return nil, &NotLoadedError{edge: "tax_code"}
@@ -154,7 +171,7 @@ func (*ChargeUsageBasedRunDetailedLine) scanValues(columns []string) ([]any, err
 			values[i] = new(alpacadecimal.Decimal)
 		case chargeusagebasedrundetailedline.FieldIndex:
 			values[i] = new(sql.NullInt64)
-		case chargeusagebasedrundetailedline.FieldID, chargeusagebasedrundetailedline.FieldCurrency, chargeusagebasedrundetailedline.FieldTaxCodeID, chargeusagebasedrundetailedline.FieldTaxBehavior, chargeusagebasedrundetailedline.FieldInvoicingAppExternalID, chargeusagebasedrundetailedline.FieldChildUniqueReferenceID, chargeusagebasedrundetailedline.FieldCategory, chargeusagebasedrundetailedline.FieldPaymentTerm, chargeusagebasedrundetailedline.FieldNamespace, chargeusagebasedrundetailedline.FieldName, chargeusagebasedrundetailedline.FieldDescription, chargeusagebasedrundetailedline.FieldChargeID, chargeusagebasedrundetailedline.FieldRunID:
+		case chargeusagebasedrundetailedline.FieldID, chargeusagebasedrundetailedline.FieldCurrency, chargeusagebasedrundetailedline.FieldTaxCodeID, chargeusagebasedrundetailedline.FieldTaxBehavior, chargeusagebasedrundetailedline.FieldInvoicingAppExternalID, chargeusagebasedrundetailedline.FieldChildUniqueReferenceID, chargeusagebasedrundetailedline.FieldCategory, chargeusagebasedrundetailedline.FieldPaymentTerm, chargeusagebasedrundetailedline.FieldNamespace, chargeusagebasedrundetailedline.FieldName, chargeusagebasedrundetailedline.FieldDescription, chargeusagebasedrundetailedline.FieldChargeID, chargeusagebasedrundetailedline.FieldRunID, chargeusagebasedrundetailedline.FieldPricerReferenceID, chargeusagebasedrundetailedline.FieldCorrectsRunID:
 			values[i] = new(sql.NullString)
 		case chargeusagebasedrundetailedline.FieldServicePeriodStart, chargeusagebasedrundetailedline.FieldServicePeriodEnd, chargeusagebasedrundetailedline.FieldCreatedAt, chargeusagebasedrundetailedline.FieldUpdatedAt, chargeusagebasedrundetailedline.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -385,6 +402,19 @@ func (_m *ChargeUsageBasedRunDetailedLine) assignValues(columns []string, values
 			} else if value.Valid {
 				_m.RunID = value.String
 			}
+		case chargeusagebasedrundetailedline.FieldPricerReferenceID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field pricer_reference_id", values[i])
+			} else if value.Valid {
+				_m.PricerReferenceID = value.String
+			}
+		case chargeusagebasedrundetailedline.FieldCorrectsRunID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field corrects_run_id", values[i])
+			} else if value.Valid {
+				_m.CorrectsRunID = new(string)
+				*_m.CorrectsRunID = value.String
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -406,6 +436,11 @@ func (_m *ChargeUsageBasedRunDetailedLine) QueryCharge() *ChargeUsageBasedQuery 
 // QueryRun queries the "run" edge of the ChargeUsageBasedRunDetailedLine entity.
 func (_m *ChargeUsageBasedRunDetailedLine) QueryRun() *ChargeUsageBasedRunsQuery {
 	return NewChargeUsageBasedRunDetailedLineClient(_m.config).QueryRun(_m)
+}
+
+// QueryCorrectsRun queries the "corrects_run" edge of the ChargeUsageBasedRunDetailedLine entity.
+func (_m *ChargeUsageBasedRunDetailedLine) QueryCorrectsRun() *ChargeUsageBasedRunsQuery {
+	return NewChargeUsageBasedRunDetailedLineClient(_m.config).QueryCorrectsRun(_m)
 }
 
 // QueryTaxCode queries the "tax_code" edge of the ChargeUsageBasedRunDetailedLine entity.
@@ -543,6 +578,14 @@ func (_m *ChargeUsageBasedRunDetailedLine) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("run_id=")
 	builder.WriteString(_m.RunID)
+	builder.WriteString(", ")
+	builder.WriteString("pricer_reference_id=")
+	builder.WriteString(_m.PricerReferenceID)
+	builder.WriteString(", ")
+	if v := _m.CorrectsRunID; v != nil {
+		builder.WriteString("corrects_run_id=")
+		builder.WriteString(*v)
+	}
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/openmeter/ent/db/chargeusagebasedrundetailedline/chargeusagebasedrundetailedline.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline/chargeusagebasedrundetailedline.go
@@ -81,10 +81,16 @@ const (
 	FieldChargeID = "charge_id"
 	// FieldRunID holds the string denoting the run_id field in the database.
 	FieldRunID = "run_id"
+	// FieldPricerReferenceID holds the string denoting the pricer_reference_id field in the database.
+	FieldPricerReferenceID = "pricer_reference_id"
+	// FieldCorrectsRunID holds the string denoting the corrects_run_id field in the database.
+	FieldCorrectsRunID = "corrects_run_id"
 	// EdgeCharge holds the string denoting the charge edge name in mutations.
 	EdgeCharge = "charge"
 	// EdgeRun holds the string denoting the run edge name in mutations.
 	EdgeRun = "run"
+	// EdgeCorrectsRun holds the string denoting the corrects_run edge name in mutations.
+	EdgeCorrectsRun = "corrects_run"
 	// EdgeTaxCode holds the string denoting the tax_code edge name in mutations.
 	EdgeTaxCode = "tax_code"
 	// Table holds the table name of the chargeusagebasedrundetailedline in the database.
@@ -103,6 +109,13 @@ const (
 	RunInverseTable = "charge_usage_based_runs"
 	// RunColumn is the table column denoting the run relation/edge.
 	RunColumn = "run_id"
+	// CorrectsRunTable is the table that holds the corrects_run relation/edge.
+	CorrectsRunTable = "charge_usage_based_run_detailed_line"
+	// CorrectsRunInverseTable is the table name for the ChargeUsageBasedRuns entity.
+	// It exists in this package in order to avoid circular dependency with the "chargeusagebasedruns" package.
+	CorrectsRunInverseTable = "charge_usage_based_runs"
+	// CorrectsRunColumn is the table column denoting the corrects_run relation/edge.
+	CorrectsRunColumn = "corrects_run_id"
 	// TaxCodeTable is the table that holds the tax_code relation/edge.
 	TaxCodeTable = "charge_usage_based_run_detailed_line"
 	// TaxCodeInverseTable is the table name for the TaxCode entity.
@@ -147,6 +160,8 @@ var Columns = []string{
 	FieldTotal,
 	FieldChargeID,
 	FieldRunID,
+	FieldPricerReferenceID,
+	FieldCorrectsRunID,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -172,6 +187,10 @@ var (
 	DefaultUpdatedAt func() time.Time
 	// UpdateDefaultUpdatedAt holds the default value on update for the "updated_at" field.
 	UpdateDefaultUpdatedAt func() time.Time
+	// PricerReferenceIDValidator is a validator for the "pricer_reference_id" field. It is called by the builders before save.
+	PricerReferenceIDValidator func(string) error
+	// CorrectsRunIDValidator is a validator for the "corrects_run_id" field. It is called by the builders before save.
+	CorrectsRunIDValidator func(string) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -358,6 +377,16 @@ func ByRunID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldRunID, opts...).ToFunc()
 }
 
+// ByPricerReferenceID orders the results by the pricer_reference_id field.
+func ByPricerReferenceID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldPricerReferenceID, opts...).ToFunc()
+}
+
+// ByCorrectsRunID orders the results by the corrects_run_id field.
+func ByCorrectsRunID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCorrectsRunID, opts...).ToFunc()
+}
+
 // ByChargeField orders the results by charge field.
 func ByChargeField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -369,6 +398,13 @@ func ByChargeField(field string, opts ...sql.OrderTermOption) OrderOption {
 func ByRunField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newRunStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByCorrectsRunField orders the results by corrects_run field.
+func ByCorrectsRunField(field string, opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCorrectsRunStep(), sql.OrderByField(field, opts...))
 	}
 }
 
@@ -390,6 +426,13 @@ func newRunStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(RunInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2O, true, RunTable, RunColumn),
+	)
+}
+func newCorrectsRunStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CorrectsRunInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, CorrectsRunTable, CorrectsRunColumn),
 	)
 }
 func newTaxCodeStep() *sqlgraph.Step {

--- a/openmeter/ent/db/chargeusagebasedrundetailedline/where.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline/where.go
@@ -195,6 +195,16 @@ func RunID(v string) predicate.ChargeUsageBasedRunDetailedLine {
 	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldEQ(FieldRunID, v))
 }
 
+// PricerReferenceID applies equality check predicate on the "pricer_reference_id" field. It's identical to PricerReferenceIDEQ.
+func PricerReferenceID(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldEQ(FieldPricerReferenceID, v))
+}
+
+// CorrectsRunID applies equality check predicate on the "corrects_run_id" field. It's identical to CorrectsRunIDEQ.
+func CorrectsRunID(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldEQ(FieldCorrectsRunID, v))
+}
+
 // CurrencyEQ applies the EQ predicate on the "currency" field.
 func CurrencyEQ(v currencyx.Code) predicate.ChargeUsageBasedRunDetailedLine {
 	vc := string(v)
@@ -1629,6 +1639,146 @@ func RunIDContainsFold(v string) predicate.ChargeUsageBasedRunDetailedLine {
 	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldContainsFold(FieldRunID, v))
 }
 
+// PricerReferenceIDEQ applies the EQ predicate on the "pricer_reference_id" field.
+func PricerReferenceIDEQ(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldEQ(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDNEQ applies the NEQ predicate on the "pricer_reference_id" field.
+func PricerReferenceIDNEQ(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldNEQ(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDIn applies the In predicate on the "pricer_reference_id" field.
+func PricerReferenceIDIn(vs ...string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldIn(FieldPricerReferenceID, vs...))
+}
+
+// PricerReferenceIDNotIn applies the NotIn predicate on the "pricer_reference_id" field.
+func PricerReferenceIDNotIn(vs ...string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldNotIn(FieldPricerReferenceID, vs...))
+}
+
+// PricerReferenceIDGT applies the GT predicate on the "pricer_reference_id" field.
+func PricerReferenceIDGT(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldGT(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDGTE applies the GTE predicate on the "pricer_reference_id" field.
+func PricerReferenceIDGTE(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldGTE(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDLT applies the LT predicate on the "pricer_reference_id" field.
+func PricerReferenceIDLT(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldLT(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDLTE applies the LTE predicate on the "pricer_reference_id" field.
+func PricerReferenceIDLTE(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldLTE(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDContains applies the Contains predicate on the "pricer_reference_id" field.
+func PricerReferenceIDContains(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldContains(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDHasPrefix applies the HasPrefix predicate on the "pricer_reference_id" field.
+func PricerReferenceIDHasPrefix(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldHasPrefix(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDHasSuffix applies the HasSuffix predicate on the "pricer_reference_id" field.
+func PricerReferenceIDHasSuffix(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldHasSuffix(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDEqualFold applies the EqualFold predicate on the "pricer_reference_id" field.
+func PricerReferenceIDEqualFold(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldEqualFold(FieldPricerReferenceID, v))
+}
+
+// PricerReferenceIDContainsFold applies the ContainsFold predicate on the "pricer_reference_id" field.
+func PricerReferenceIDContainsFold(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldContainsFold(FieldPricerReferenceID, v))
+}
+
+// CorrectsRunIDEQ applies the EQ predicate on the "corrects_run_id" field.
+func CorrectsRunIDEQ(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldEQ(FieldCorrectsRunID, v))
+}
+
+// CorrectsRunIDNEQ applies the NEQ predicate on the "corrects_run_id" field.
+func CorrectsRunIDNEQ(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldNEQ(FieldCorrectsRunID, v))
+}
+
+// CorrectsRunIDIn applies the In predicate on the "corrects_run_id" field.
+func CorrectsRunIDIn(vs ...string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldIn(FieldCorrectsRunID, vs...))
+}
+
+// CorrectsRunIDNotIn applies the NotIn predicate on the "corrects_run_id" field.
+func CorrectsRunIDNotIn(vs ...string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldNotIn(FieldCorrectsRunID, vs...))
+}
+
+// CorrectsRunIDGT applies the GT predicate on the "corrects_run_id" field.
+func CorrectsRunIDGT(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldGT(FieldCorrectsRunID, v))
+}
+
+// CorrectsRunIDGTE applies the GTE predicate on the "corrects_run_id" field.
+func CorrectsRunIDGTE(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldGTE(FieldCorrectsRunID, v))
+}
+
+// CorrectsRunIDLT applies the LT predicate on the "corrects_run_id" field.
+func CorrectsRunIDLT(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldLT(FieldCorrectsRunID, v))
+}
+
+// CorrectsRunIDLTE applies the LTE predicate on the "corrects_run_id" field.
+func CorrectsRunIDLTE(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldLTE(FieldCorrectsRunID, v))
+}
+
+// CorrectsRunIDContains applies the Contains predicate on the "corrects_run_id" field.
+func CorrectsRunIDContains(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldContains(FieldCorrectsRunID, v))
+}
+
+// CorrectsRunIDHasPrefix applies the HasPrefix predicate on the "corrects_run_id" field.
+func CorrectsRunIDHasPrefix(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldHasPrefix(FieldCorrectsRunID, v))
+}
+
+// CorrectsRunIDHasSuffix applies the HasSuffix predicate on the "corrects_run_id" field.
+func CorrectsRunIDHasSuffix(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldHasSuffix(FieldCorrectsRunID, v))
+}
+
+// CorrectsRunIDIsNil applies the IsNil predicate on the "corrects_run_id" field.
+func CorrectsRunIDIsNil() predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldIsNull(FieldCorrectsRunID))
+}
+
+// CorrectsRunIDNotNil applies the NotNil predicate on the "corrects_run_id" field.
+func CorrectsRunIDNotNil() predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldNotNull(FieldCorrectsRunID))
+}
+
+// CorrectsRunIDEqualFold applies the EqualFold predicate on the "corrects_run_id" field.
+func CorrectsRunIDEqualFold(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldEqualFold(FieldCorrectsRunID, v))
+}
+
+// CorrectsRunIDContainsFold applies the ContainsFold predicate on the "corrects_run_id" field.
+func CorrectsRunIDContainsFold(v string) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(sql.FieldContainsFold(FieldCorrectsRunID, v))
+}
+
 // HasCharge applies the HasEdge predicate on the "charge" edge.
 func HasCharge() predicate.ChargeUsageBasedRunDetailedLine {
 	return predicate.ChargeUsageBasedRunDetailedLine(func(s *sql.Selector) {
@@ -1667,6 +1817,29 @@ func HasRun() predicate.ChargeUsageBasedRunDetailedLine {
 func HasRunWith(preds ...predicate.ChargeUsageBasedRuns) predicate.ChargeUsageBasedRunDetailedLine {
 	return predicate.ChargeUsageBasedRunDetailedLine(func(s *sql.Selector) {
 		step := newRunStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasCorrectsRun applies the HasEdge predicate on the "corrects_run" edge.
+func HasCorrectsRun() predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, CorrectsRunTable, CorrectsRunColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasCorrectsRunWith applies the HasEdge predicate on the "corrects_run" edge with a given conditions (other predicates).
+func HasCorrectsRunWith(preds ...predicate.ChargeUsageBasedRuns) predicate.ChargeUsageBasedRunDetailedLine {
+	return predicate.ChargeUsageBasedRunDetailedLine(func(s *sql.Selector) {
+		step := newCorrectsRunStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/openmeter/ent/db/chargeusagebasedrundetailedline_create.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline_create.go
@@ -312,6 +312,26 @@ func (_c *ChargeUsageBasedRunDetailedLineCreate) SetRunID(v string) *ChargeUsage
 	return _c
 }
 
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (_c *ChargeUsageBasedRunDetailedLineCreate) SetPricerReferenceID(v string) *ChargeUsageBasedRunDetailedLineCreate {
+	_c.mutation.SetPricerReferenceID(v)
+	return _c
+}
+
+// SetCorrectsRunID sets the "corrects_run_id" field.
+func (_c *ChargeUsageBasedRunDetailedLineCreate) SetCorrectsRunID(v string) *ChargeUsageBasedRunDetailedLineCreate {
+	_c.mutation.SetCorrectsRunID(v)
+	return _c
+}
+
+// SetNillableCorrectsRunID sets the "corrects_run_id" field if the given value is not nil.
+func (_c *ChargeUsageBasedRunDetailedLineCreate) SetNillableCorrectsRunID(v *string) *ChargeUsageBasedRunDetailedLineCreate {
+	if v != nil {
+		_c.SetCorrectsRunID(*v)
+	}
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *ChargeUsageBasedRunDetailedLineCreate) SetID(v string) *ChargeUsageBasedRunDetailedLineCreate {
 	_c.mutation.SetID(v)
@@ -334,6 +354,11 @@ func (_c *ChargeUsageBasedRunDetailedLineCreate) SetCharge(v *ChargeUsageBased) 
 // SetRun sets the "run" edge to the ChargeUsageBasedRuns entity.
 func (_c *ChargeUsageBasedRunDetailedLineCreate) SetRun(v *ChargeUsageBasedRuns) *ChargeUsageBasedRunDetailedLineCreate {
 	return _c.SetRunID(v.ID)
+}
+
+// SetCorrectsRun sets the "corrects_run" edge to the ChargeUsageBasedRuns entity.
+func (_c *ChargeUsageBasedRunDetailedLineCreate) SetCorrectsRun(v *ChargeUsageBasedRuns) *ChargeUsageBasedRunDetailedLineCreate {
+	return _c.SetCorrectsRunID(v.ID)
 }
 
 // SetTaxCode sets the "tax_code" edge to the TaxCode entity.
@@ -506,6 +531,19 @@ func (_c *ChargeUsageBasedRunDetailedLineCreate) check() error {
 	if _, ok := _c.mutation.RunID(); !ok {
 		return &ValidationError{Name: "run_id", err: errors.New(`db: missing required field "ChargeUsageBasedRunDetailedLine.run_id"`)}
 	}
+	if _, ok := _c.mutation.PricerReferenceID(); !ok {
+		return &ValidationError{Name: "pricer_reference_id", err: errors.New(`db: missing required field "ChargeUsageBasedRunDetailedLine.pricer_reference_id"`)}
+	}
+	if v, ok := _c.mutation.PricerReferenceID(); ok {
+		if err := chargeusagebasedrundetailedline.PricerReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "pricer_reference_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.pricer_reference_id": %w`, err)}
+		}
+	}
+	if v, ok := _c.mutation.CorrectsRunID(); ok {
+		if err := chargeusagebasedrundetailedline.CorrectsRunIDValidator(v); err != nil {
+			return &ValidationError{Name: "corrects_run_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.corrects_run_id": %w`, err)}
+		}
+	}
 	if len(_c.mutation.ChargeIDs()) == 0 {
 		return &ValidationError{Name: "charge", err: errors.New(`db: missing required edge "ChargeUsageBasedRunDetailedLine.charge"`)}
 	}
@@ -664,6 +702,10 @@ func (_c *ChargeUsageBasedRunDetailedLineCreate) createSpec() (*ChargeUsageBased
 		_spec.SetField(chargeusagebasedrundetailedline.FieldTotal, field.TypeOther, value)
 		_node.Total = value
 	}
+	if value, ok := _c.mutation.PricerReferenceID(); ok {
+		_spec.SetField(chargeusagebasedrundetailedline.FieldPricerReferenceID, field.TypeString, value)
+		_node.PricerReferenceID = value
+	}
 	if nodes := _c.mutation.ChargeIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -696,6 +738,23 @@ func (_c *ChargeUsageBasedRunDetailedLineCreate) createSpec() (*ChargeUsageBased
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.RunID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.CorrectsRunIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeusagebasedrundetailedline.CorrectsRunTable,
+			Columns: []string{chargeusagebasedrundetailedline.CorrectsRunColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.CorrectsRunID = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := _c.mutation.TaxCodeIDs(); len(nodes) > 0 {
@@ -1178,6 +1237,36 @@ func (u *ChargeUsageBasedRunDetailedLineUpsert) SetRunID(v string) *ChargeUsageB
 // UpdateRunID sets the "run_id" field to the value that was provided on create.
 func (u *ChargeUsageBasedRunDetailedLineUpsert) UpdateRunID() *ChargeUsageBasedRunDetailedLineUpsert {
 	u.SetExcluded(chargeusagebasedrundetailedline.FieldRunID)
+	return u
+}
+
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (u *ChargeUsageBasedRunDetailedLineUpsert) SetPricerReferenceID(v string) *ChargeUsageBasedRunDetailedLineUpsert {
+	u.Set(chargeusagebasedrundetailedline.FieldPricerReferenceID, v)
+	return u
+}
+
+// UpdatePricerReferenceID sets the "pricer_reference_id" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunDetailedLineUpsert) UpdatePricerReferenceID() *ChargeUsageBasedRunDetailedLineUpsert {
+	u.SetExcluded(chargeusagebasedrundetailedline.FieldPricerReferenceID)
+	return u
+}
+
+// SetCorrectsRunID sets the "corrects_run_id" field.
+func (u *ChargeUsageBasedRunDetailedLineUpsert) SetCorrectsRunID(v string) *ChargeUsageBasedRunDetailedLineUpsert {
+	u.Set(chargeusagebasedrundetailedline.FieldCorrectsRunID, v)
+	return u
+}
+
+// UpdateCorrectsRunID sets the "corrects_run_id" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunDetailedLineUpsert) UpdateCorrectsRunID() *ChargeUsageBasedRunDetailedLineUpsert {
+	u.SetExcluded(chargeusagebasedrundetailedline.FieldCorrectsRunID)
+	return u
+}
+
+// ClearCorrectsRunID clears the value of the "corrects_run_id" field.
+func (u *ChargeUsageBasedRunDetailedLineUpsert) ClearCorrectsRunID() *ChargeUsageBasedRunDetailedLineUpsert {
+	u.SetNull(chargeusagebasedrundetailedline.FieldCorrectsRunID)
 	return u
 }
 
@@ -1718,6 +1807,41 @@ func (u *ChargeUsageBasedRunDetailedLineUpsertOne) SetRunID(v string) *ChargeUsa
 func (u *ChargeUsageBasedRunDetailedLineUpsertOne) UpdateRunID() *ChargeUsageBasedRunDetailedLineUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
 		s.UpdateRunID()
+	})
+}
+
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (u *ChargeUsageBasedRunDetailedLineUpsertOne) SetPricerReferenceID(v string) *ChargeUsageBasedRunDetailedLineUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
+		s.SetPricerReferenceID(v)
+	})
+}
+
+// UpdatePricerReferenceID sets the "pricer_reference_id" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunDetailedLineUpsertOne) UpdatePricerReferenceID() *ChargeUsageBasedRunDetailedLineUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
+		s.UpdatePricerReferenceID()
+	})
+}
+
+// SetCorrectsRunID sets the "corrects_run_id" field.
+func (u *ChargeUsageBasedRunDetailedLineUpsertOne) SetCorrectsRunID(v string) *ChargeUsageBasedRunDetailedLineUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
+		s.SetCorrectsRunID(v)
+	})
+}
+
+// UpdateCorrectsRunID sets the "corrects_run_id" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunDetailedLineUpsertOne) UpdateCorrectsRunID() *ChargeUsageBasedRunDetailedLineUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
+		s.UpdateCorrectsRunID()
+	})
+}
+
+// ClearCorrectsRunID clears the value of the "corrects_run_id" field.
+func (u *ChargeUsageBasedRunDetailedLineUpsertOne) ClearCorrectsRunID() *ChargeUsageBasedRunDetailedLineUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
+		s.ClearCorrectsRunID()
 	})
 }
 
@@ -2425,6 +2549,41 @@ func (u *ChargeUsageBasedRunDetailedLineUpsertBulk) SetRunID(v string) *ChargeUs
 func (u *ChargeUsageBasedRunDetailedLineUpsertBulk) UpdateRunID() *ChargeUsageBasedRunDetailedLineUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
 		s.UpdateRunID()
+	})
+}
+
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (u *ChargeUsageBasedRunDetailedLineUpsertBulk) SetPricerReferenceID(v string) *ChargeUsageBasedRunDetailedLineUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
+		s.SetPricerReferenceID(v)
+	})
+}
+
+// UpdatePricerReferenceID sets the "pricer_reference_id" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunDetailedLineUpsertBulk) UpdatePricerReferenceID() *ChargeUsageBasedRunDetailedLineUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
+		s.UpdatePricerReferenceID()
+	})
+}
+
+// SetCorrectsRunID sets the "corrects_run_id" field.
+func (u *ChargeUsageBasedRunDetailedLineUpsertBulk) SetCorrectsRunID(v string) *ChargeUsageBasedRunDetailedLineUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
+		s.SetCorrectsRunID(v)
+	})
+}
+
+// UpdateCorrectsRunID sets the "corrects_run_id" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunDetailedLineUpsertBulk) UpdateCorrectsRunID() *ChargeUsageBasedRunDetailedLineUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
+		s.UpdateCorrectsRunID()
+	})
+}
+
+// ClearCorrectsRunID clears the value of the "corrects_run_id" field.
+func (u *ChargeUsageBasedRunDetailedLineUpsertBulk) ClearCorrectsRunID() *ChargeUsageBasedRunDetailedLineUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunDetailedLineUpsert) {
+		s.ClearCorrectsRunID()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebasedrundetailedline_query.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline_query.go
@@ -22,14 +22,15 @@ import (
 // ChargeUsageBasedRunDetailedLineQuery is the builder for querying ChargeUsageBasedRunDetailedLine entities.
 type ChargeUsageBasedRunDetailedLineQuery struct {
 	config
-	ctx         *QueryContext
-	order       []chargeusagebasedrundetailedline.OrderOption
-	inters      []Interceptor
-	predicates  []predicate.ChargeUsageBasedRunDetailedLine
-	withCharge  *ChargeUsageBasedQuery
-	withRun     *ChargeUsageBasedRunsQuery
-	withTaxCode *TaxCodeQuery
-	modifiers   []func(*sql.Selector)
+	ctx             *QueryContext
+	order           []chargeusagebasedrundetailedline.OrderOption
+	inters          []Interceptor
+	predicates      []predicate.ChargeUsageBasedRunDetailedLine
+	withCharge      *ChargeUsageBasedQuery
+	withRun         *ChargeUsageBasedRunsQuery
+	withCorrectsRun *ChargeUsageBasedRunsQuery
+	withTaxCode     *TaxCodeQuery
+	modifiers       []func(*sql.Selector)
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -103,6 +104,28 @@ func (_q *ChargeUsageBasedRunDetailedLineQuery) QueryRun() *ChargeUsageBasedRuns
 			sqlgraph.From(chargeusagebasedrundetailedline.Table, chargeusagebasedrundetailedline.FieldID, selector),
 			sqlgraph.To(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, true, chargeusagebasedrundetailedline.RunTable, chargeusagebasedrundetailedline.RunColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryCorrectsRun chains the current query on the "corrects_run" edge.
+func (_q *ChargeUsageBasedRunDetailedLineQuery) QueryCorrectsRun() *ChargeUsageBasedRunsQuery {
+	query := (&ChargeUsageBasedRunsClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeusagebasedrundetailedline.Table, chargeusagebasedrundetailedline.FieldID, selector),
+			sqlgraph.To(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, chargeusagebasedrundetailedline.CorrectsRunTable, chargeusagebasedrundetailedline.CorrectsRunColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -319,14 +342,15 @@ func (_q *ChargeUsageBasedRunDetailedLineQuery) Clone() *ChargeUsageBasedRunDeta
 		return nil
 	}
 	return &ChargeUsageBasedRunDetailedLineQuery{
-		config:      _q.config,
-		ctx:         _q.ctx.Clone(),
-		order:       append([]chargeusagebasedrundetailedline.OrderOption{}, _q.order...),
-		inters:      append([]Interceptor{}, _q.inters...),
-		predicates:  append([]predicate.ChargeUsageBasedRunDetailedLine{}, _q.predicates...),
-		withCharge:  _q.withCharge.Clone(),
-		withRun:     _q.withRun.Clone(),
-		withTaxCode: _q.withTaxCode.Clone(),
+		config:          _q.config,
+		ctx:             _q.ctx.Clone(),
+		order:           append([]chargeusagebasedrundetailedline.OrderOption{}, _q.order...),
+		inters:          append([]Interceptor{}, _q.inters...),
+		predicates:      append([]predicate.ChargeUsageBasedRunDetailedLine{}, _q.predicates...),
+		withCharge:      _q.withCharge.Clone(),
+		withRun:         _q.withRun.Clone(),
+		withCorrectsRun: _q.withCorrectsRun.Clone(),
+		withTaxCode:     _q.withTaxCode.Clone(),
 		// clone intermediate query.
 		sql:  _q.sql.Clone(),
 		path: _q.path,
@@ -352,6 +376,17 @@ func (_q *ChargeUsageBasedRunDetailedLineQuery) WithRun(opts ...func(*ChargeUsag
 		opt(query)
 	}
 	_q.withRun = query
+	return _q
+}
+
+// WithCorrectsRun tells the query-builder to eager-load the nodes that are connected to
+// the "corrects_run" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *ChargeUsageBasedRunDetailedLineQuery) WithCorrectsRun(opts ...func(*ChargeUsageBasedRunsQuery)) *ChargeUsageBasedRunDetailedLineQuery {
+	query := (&ChargeUsageBasedRunsClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withCorrectsRun = query
 	return _q
 }
 
@@ -444,9 +479,10 @@ func (_q *ChargeUsageBasedRunDetailedLineQuery) sqlAll(ctx context.Context, hook
 	var (
 		nodes       = []*ChargeUsageBasedRunDetailedLine{}
 		_spec       = _q.querySpec()
-		loadedTypes = [3]bool{
+		loadedTypes = [4]bool{
 			_q.withCharge != nil,
 			_q.withRun != nil,
+			_q.withCorrectsRun != nil,
 			_q.withTaxCode != nil,
 		}
 	)
@@ -480,6 +516,12 @@ func (_q *ChargeUsageBasedRunDetailedLineQuery) sqlAll(ctx context.Context, hook
 	if query := _q.withRun; query != nil {
 		if err := _q.loadRun(ctx, query, nodes, nil,
 			func(n *ChargeUsageBasedRunDetailedLine, e *ChargeUsageBasedRuns) { n.Edges.Run = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withCorrectsRun; query != nil {
+		if err := _q.loadCorrectsRun(ctx, query, nodes, nil,
+			func(n *ChargeUsageBasedRunDetailedLine, e *ChargeUsageBasedRuns) { n.Edges.CorrectsRun = e }); err != nil {
 			return nil, err
 		}
 	}
@@ -543,6 +585,38 @@ func (_q *ChargeUsageBasedRunDetailedLineQuery) loadRun(ctx context.Context, que
 		nodes, ok := nodeids[n.ID]
 		if !ok {
 			return fmt.Errorf(`unexpected foreign-key "run_id" returned %v`, n.ID)
+		}
+		for i := range nodes {
+			assign(nodes[i], n)
+		}
+	}
+	return nil
+}
+func (_q *ChargeUsageBasedRunDetailedLineQuery) loadCorrectsRun(ctx context.Context, query *ChargeUsageBasedRunsQuery, nodes []*ChargeUsageBasedRunDetailedLine, init func(*ChargeUsageBasedRunDetailedLine), assign func(*ChargeUsageBasedRunDetailedLine, *ChargeUsageBasedRuns)) error {
+	ids := make([]string, 0, len(nodes))
+	nodeids := make(map[string][]*ChargeUsageBasedRunDetailedLine)
+	for i := range nodes {
+		if nodes[i].CorrectsRunID == nil {
+			continue
+		}
+		fk := *nodes[i].CorrectsRunID
+		if _, ok := nodeids[fk]; !ok {
+			ids = append(ids, fk)
+		}
+		nodeids[fk] = append(nodeids[fk], nodes[i])
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	query.Where(chargeusagebasedruns.IDIn(ids...))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nodeids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected foreign-key "corrects_run_id" returned %v`, n.ID)
 		}
 		for i := range nodes {
 			assign(nodes[i], n)
@@ -616,6 +690,9 @@ func (_q *ChargeUsageBasedRunDetailedLineQuery) querySpec() *sqlgraph.QuerySpec 
 		}
 		if _q.withRun != nil {
 			_spec.Node.AddColumnOnce(chargeusagebasedrundetailedline.FieldRunID)
+		}
+		if _q.withCorrectsRun != nil {
+			_spec.Node.AddColumnOnce(chargeusagebasedrundetailedline.FieldCorrectsRunID)
 		}
 		if _q.withTaxCode != nil {
 			_spec.Node.AddColumnOnce(chargeusagebasedrundetailedline.FieldTaxCodeID)

--- a/openmeter/ent/db/chargeusagebasedrundetailedline_update.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline_update.go
@@ -477,6 +477,40 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdate) SetNillableRunID(v *string) *Ch
 	return _u
 }
 
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (_u *ChargeUsageBasedRunDetailedLineUpdate) SetPricerReferenceID(v string) *ChargeUsageBasedRunDetailedLineUpdate {
+	_u.mutation.SetPricerReferenceID(v)
+	return _u
+}
+
+// SetNillablePricerReferenceID sets the "pricer_reference_id" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunDetailedLineUpdate) SetNillablePricerReferenceID(v *string) *ChargeUsageBasedRunDetailedLineUpdate {
+	if v != nil {
+		_u.SetPricerReferenceID(*v)
+	}
+	return _u
+}
+
+// SetCorrectsRunID sets the "corrects_run_id" field.
+func (_u *ChargeUsageBasedRunDetailedLineUpdate) SetCorrectsRunID(v string) *ChargeUsageBasedRunDetailedLineUpdate {
+	_u.mutation.SetCorrectsRunID(v)
+	return _u
+}
+
+// SetNillableCorrectsRunID sets the "corrects_run_id" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunDetailedLineUpdate) SetNillableCorrectsRunID(v *string) *ChargeUsageBasedRunDetailedLineUpdate {
+	if v != nil {
+		_u.SetCorrectsRunID(*v)
+	}
+	return _u
+}
+
+// ClearCorrectsRunID clears the value of the "corrects_run_id" field.
+func (_u *ChargeUsageBasedRunDetailedLineUpdate) ClearCorrectsRunID() *ChargeUsageBasedRunDetailedLineUpdate {
+	_u.mutation.ClearCorrectsRunID()
+	return _u
+}
+
 // SetCharge sets the "charge" edge to the ChargeUsageBased entity.
 func (_u *ChargeUsageBasedRunDetailedLineUpdate) SetCharge(v *ChargeUsageBased) *ChargeUsageBasedRunDetailedLineUpdate {
 	return _u.SetChargeID(v.ID)
@@ -485,6 +519,11 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdate) SetCharge(v *ChargeUsageBased) 
 // SetRun sets the "run" edge to the ChargeUsageBasedRuns entity.
 func (_u *ChargeUsageBasedRunDetailedLineUpdate) SetRun(v *ChargeUsageBasedRuns) *ChargeUsageBasedRunDetailedLineUpdate {
 	return _u.SetRunID(v.ID)
+}
+
+// SetCorrectsRun sets the "corrects_run" edge to the ChargeUsageBasedRuns entity.
+func (_u *ChargeUsageBasedRunDetailedLineUpdate) SetCorrectsRun(v *ChargeUsageBasedRuns) *ChargeUsageBasedRunDetailedLineUpdate {
+	return _u.SetCorrectsRunID(v.ID)
 }
 
 // SetTaxCode sets the "tax_code" edge to the TaxCode entity.
@@ -506,6 +545,12 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdate) ClearCharge() *ChargeUsageBased
 // ClearRun clears the "run" edge to the ChargeUsageBasedRuns entity.
 func (_u *ChargeUsageBasedRunDetailedLineUpdate) ClearRun() *ChargeUsageBasedRunDetailedLineUpdate {
 	_u.mutation.ClearRun()
+	return _u
+}
+
+// ClearCorrectsRun clears the "corrects_run" edge to the ChargeUsageBasedRuns entity.
+func (_u *ChargeUsageBasedRunDetailedLineUpdate) ClearCorrectsRun() *ChargeUsageBasedRunDetailedLineUpdate {
+	_u.mutation.ClearCorrectsRun()
 	return _u
 }
 
@@ -581,6 +626,16 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdate) check() error {
 	if v, ok := _u.mutation.CreditsApplied(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "credits_applied", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.credits_applied": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.PricerReferenceID(); ok {
+		if err := chargeusagebasedrundetailedline.PricerReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "pricer_reference_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.pricer_reference_id": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.CorrectsRunID(); ok {
+		if err := chargeusagebasedrundetailedline.CorrectsRunIDValidator(v); err != nil {
+			return &ValidationError{Name: "corrects_run_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.corrects_run_id": %w`, err)}
 		}
 	}
 	if _u.mutation.ChargeCleared() && len(_u.mutation.ChargeIDs()) > 0 {
@@ -712,6 +767,9 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdate) sqlSave(ctx context.Context) (_
 	if value, ok := _u.mutation.Total(); ok {
 		_spec.SetField(chargeusagebasedrundetailedline.FieldTotal, field.TypeOther, value)
 	}
+	if value, ok := _u.mutation.PricerReferenceID(); ok {
+		_spec.SetField(chargeusagebasedrundetailedline.FieldPricerReferenceID, field.TypeString, value)
+	}
 	if _u.mutation.ChargeCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -760,6 +818,35 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdate) sqlSave(ctx context.Context) (_
 			Inverse: true,
 			Table:   chargeusagebasedrundetailedline.RunTable,
 			Columns: []string{chargeusagebasedrundetailedline.RunColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.CorrectsRunCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeusagebasedrundetailedline.CorrectsRunTable,
+			Columns: []string{chargeusagebasedrundetailedline.CorrectsRunColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.CorrectsRunIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeusagebasedrundetailedline.CorrectsRunTable,
+			Columns: []string{chargeusagebasedrundetailedline.CorrectsRunColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
@@ -1260,6 +1347,40 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) SetNillableRunID(v *string) 
 	return _u
 }
 
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) SetPricerReferenceID(v string) *ChargeUsageBasedRunDetailedLineUpdateOne {
+	_u.mutation.SetPricerReferenceID(v)
+	return _u
+}
+
+// SetNillablePricerReferenceID sets the "pricer_reference_id" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) SetNillablePricerReferenceID(v *string) *ChargeUsageBasedRunDetailedLineUpdateOne {
+	if v != nil {
+		_u.SetPricerReferenceID(*v)
+	}
+	return _u
+}
+
+// SetCorrectsRunID sets the "corrects_run_id" field.
+func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) SetCorrectsRunID(v string) *ChargeUsageBasedRunDetailedLineUpdateOne {
+	_u.mutation.SetCorrectsRunID(v)
+	return _u
+}
+
+// SetNillableCorrectsRunID sets the "corrects_run_id" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) SetNillableCorrectsRunID(v *string) *ChargeUsageBasedRunDetailedLineUpdateOne {
+	if v != nil {
+		_u.SetCorrectsRunID(*v)
+	}
+	return _u
+}
+
+// ClearCorrectsRunID clears the value of the "corrects_run_id" field.
+func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) ClearCorrectsRunID() *ChargeUsageBasedRunDetailedLineUpdateOne {
+	_u.mutation.ClearCorrectsRunID()
+	return _u
+}
+
 // SetCharge sets the "charge" edge to the ChargeUsageBased entity.
 func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) SetCharge(v *ChargeUsageBased) *ChargeUsageBasedRunDetailedLineUpdateOne {
 	return _u.SetChargeID(v.ID)
@@ -1268,6 +1389,11 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) SetCharge(v *ChargeUsageBase
 // SetRun sets the "run" edge to the ChargeUsageBasedRuns entity.
 func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) SetRun(v *ChargeUsageBasedRuns) *ChargeUsageBasedRunDetailedLineUpdateOne {
 	return _u.SetRunID(v.ID)
+}
+
+// SetCorrectsRun sets the "corrects_run" edge to the ChargeUsageBasedRuns entity.
+func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) SetCorrectsRun(v *ChargeUsageBasedRuns) *ChargeUsageBasedRunDetailedLineUpdateOne {
+	return _u.SetCorrectsRunID(v.ID)
 }
 
 // SetTaxCode sets the "tax_code" edge to the TaxCode entity.
@@ -1289,6 +1415,12 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) ClearCharge() *ChargeUsageBa
 // ClearRun clears the "run" edge to the ChargeUsageBasedRuns entity.
 func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) ClearRun() *ChargeUsageBasedRunDetailedLineUpdateOne {
 	_u.mutation.ClearRun()
+	return _u
+}
+
+// ClearCorrectsRun clears the "corrects_run" edge to the ChargeUsageBasedRuns entity.
+func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) ClearCorrectsRun() *ChargeUsageBasedRunDetailedLineUpdateOne {
+	_u.mutation.ClearCorrectsRun()
 	return _u
 }
 
@@ -1377,6 +1509,16 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) check() error {
 	if v, ok := _u.mutation.CreditsApplied(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "credits_applied", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.credits_applied": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.PricerReferenceID(); ok {
+		if err := chargeusagebasedrundetailedline.PricerReferenceIDValidator(v); err != nil {
+			return &ValidationError{Name: "pricer_reference_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.pricer_reference_id": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.CorrectsRunID(); ok {
+		if err := chargeusagebasedrundetailedline.CorrectsRunIDValidator(v); err != nil {
+			return &ValidationError{Name: "corrects_run_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunDetailedLine.corrects_run_id": %w`, err)}
 		}
 	}
 	if _u.mutation.ChargeCleared() && len(_u.mutation.ChargeIDs()) > 0 {
@@ -1525,6 +1667,9 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) sqlSave(ctx context.Context)
 	if value, ok := _u.mutation.Total(); ok {
 		_spec.SetField(chargeusagebasedrundetailedline.FieldTotal, field.TypeOther, value)
 	}
+	if value, ok := _u.mutation.PricerReferenceID(); ok {
+		_spec.SetField(chargeusagebasedrundetailedline.FieldPricerReferenceID, field.TypeString, value)
+	}
 	if _u.mutation.ChargeCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -1573,6 +1718,35 @@ func (_u *ChargeUsageBasedRunDetailedLineUpdateOne) sqlSave(ctx context.Context)
 			Inverse: true,
 			Table:   chargeusagebasedrundetailedline.RunTable,
 			Columns: []string{chargeusagebasedrundetailedline.RunColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.CorrectsRunCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeusagebasedrundetailedline.CorrectsRunTable,
+			Columns: []string{chargeusagebasedrundetailedline.CorrectsRunColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.CorrectsRunIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeusagebasedrundetailedline.CorrectsRunTable,
+			Columns: []string{chargeusagebasedrundetailedline.CorrectsRunColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),

--- a/openmeter/ent/db/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns.go
@@ -64,6 +64,8 @@ type ChargeUsageBasedRuns struct {
 	LineID *string `json:"line_id,omitempty"`
 	// MeteredQuantity holds the value of the "metered_quantity" field.
 	MeteredQuantity alpacadecimal.Decimal `json:"metered_quantity,omitempty"`
+	// NoFiatTransactionRequired holds the value of the "no_fiat_transaction_required" field.
+	NoFiatTransactionRequired bool `json:"no_fiat_transaction_required,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ChargeUsageBasedRunsQuery when eager-loading is set.
 	Edges        ChargeUsageBasedRunsEdges `json:"edges"`
@@ -82,13 +84,15 @@ type ChargeUsageBasedRunsEdges struct {
 	CreditAllocations []*ChargeUsageBasedRunCreditAllocations `json:"credit_allocations,omitempty"`
 	// DetailedLines holds the value of the detailed_lines edge.
 	DetailedLines []*ChargeUsageBasedRunDetailedLine `json:"detailed_lines,omitempty"`
+	// CorrectedDetailedLines holds the value of the corrected_detailed_lines edge.
+	CorrectedDetailedLines []*ChargeUsageBasedRunDetailedLine `json:"corrected_detailed_lines,omitempty"`
 	// InvoicedUsage holds the value of the invoiced_usage edge.
 	InvoicedUsage *ChargeUsageBasedRunInvoicedUsage `json:"invoiced_usage,omitempty"`
 	// Payment holds the value of the payment edge.
 	Payment *ChargeUsageBasedRunPayment `json:"payment,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [7]bool
+	loadedTypes [8]bool
 }
 
 // UsageBasedOrErr returns the UsageBased value or an error if the edge
@@ -142,12 +146,21 @@ func (e ChargeUsageBasedRunsEdges) DetailedLinesOrErr() ([]*ChargeUsageBasedRunD
 	return nil, &NotLoadedError{edge: "detailed_lines"}
 }
 
+// CorrectedDetailedLinesOrErr returns the CorrectedDetailedLines value or an error if the edge
+// was not loaded in eager-loading.
+func (e ChargeUsageBasedRunsEdges) CorrectedDetailedLinesOrErr() ([]*ChargeUsageBasedRunDetailedLine, error) {
+	if e.loadedTypes[5] {
+		return e.CorrectedDetailedLines, nil
+	}
+	return nil, &NotLoadedError{edge: "corrected_detailed_lines"}
+}
+
 // InvoicedUsageOrErr returns the InvoicedUsage value or an error if the edge
 // was not loaded in eager-loading, or loaded but was not found.
 func (e ChargeUsageBasedRunsEdges) InvoicedUsageOrErr() (*ChargeUsageBasedRunInvoicedUsage, error) {
 	if e.InvoicedUsage != nil {
 		return e.InvoicedUsage, nil
-	} else if e.loadedTypes[5] {
+	} else if e.loadedTypes[6] {
 		return nil, &NotFoundError{label: chargeusagebasedruninvoicedusage.Label}
 	}
 	return nil, &NotLoadedError{edge: "invoiced_usage"}
@@ -158,7 +171,7 @@ func (e ChargeUsageBasedRunsEdges) InvoicedUsageOrErr() (*ChargeUsageBasedRunInv
 func (e ChargeUsageBasedRunsEdges) PaymentOrErr() (*ChargeUsageBasedRunPayment, error) {
 	if e.Payment != nil {
 		return e.Payment, nil
-	} else if e.loadedTypes[6] {
+	} else if e.loadedTypes[7] {
 		return nil, &NotFoundError{label: chargeusagebasedrunpayment.Label}
 	}
 	return nil, &NotLoadedError{edge: "payment"}
@@ -171,7 +184,7 @@ func (*ChargeUsageBasedRuns) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargeusagebasedruns.FieldAmount, chargeusagebasedruns.FieldTaxesTotal, chargeusagebasedruns.FieldTaxesInclusiveTotal, chargeusagebasedruns.FieldTaxesExclusiveTotal, chargeusagebasedruns.FieldChargesTotal, chargeusagebasedruns.FieldDiscountsTotal, chargeusagebasedruns.FieldCreditsTotal, chargeusagebasedruns.FieldTotal, chargeusagebasedruns.FieldMeteredQuantity:
 			values[i] = new(alpacadecimal.Decimal)
-		case chargeusagebasedruns.FieldDetailedLinesPresent:
+		case chargeusagebasedruns.FieldDetailedLinesPresent, chargeusagebasedruns.FieldNoFiatTransactionRequired:
 			values[i] = new(sql.NullBool)
 		case chargeusagebasedruns.FieldID, chargeusagebasedruns.FieldNamespace, chargeusagebasedruns.FieldChargeID, chargeusagebasedruns.FieldFeatureID, chargeusagebasedruns.FieldType, chargeusagebasedruns.FieldLineID:
 			values[i] = new(sql.NullString)
@@ -320,6 +333,12 @@ func (_m *ChargeUsageBasedRuns) assignValues(columns []string, values []any) err
 			} else if value != nil {
 				_m.MeteredQuantity = *value
 			}
+		case chargeusagebasedruns.FieldNoFiatTransactionRequired:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field no_fiat_transaction_required", values[i])
+			} else if value.Valid {
+				_m.NoFiatTransactionRequired = value.Bool
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -356,6 +375,11 @@ func (_m *ChargeUsageBasedRuns) QueryCreditAllocations() *ChargeUsageBasedRunCre
 // QueryDetailedLines queries the "detailed_lines" edge of the ChargeUsageBasedRuns entity.
 func (_m *ChargeUsageBasedRuns) QueryDetailedLines() *ChargeUsageBasedRunDetailedLineQuery {
 	return NewChargeUsageBasedRunsClient(_m.config).QueryDetailedLines(_m)
+}
+
+// QueryCorrectedDetailedLines queries the "corrected_detailed_lines" edge of the ChargeUsageBasedRuns entity.
+func (_m *ChargeUsageBasedRuns) QueryCorrectedDetailedLines() *ChargeUsageBasedRunDetailedLineQuery {
+	return NewChargeUsageBasedRunsClient(_m.config).QueryCorrectedDetailedLines(_m)
 }
 
 // QueryInvoicedUsage queries the "invoiced_usage" edge of the ChargeUsageBasedRuns entity.
@@ -454,6 +478,9 @@ func (_m *ChargeUsageBasedRuns) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("metered_quantity=")
 	builder.WriteString(fmt.Sprintf("%v", _m.MeteredQuantity))
+	builder.WriteString(", ")
+	builder.WriteString("no_fiat_transaction_required=")
+	builder.WriteString(fmt.Sprintf("%v", _m.NoFiatTransactionRequired))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
@@ -56,6 +56,8 @@ const (
 	FieldLineID = "line_id"
 	// FieldMeteredQuantity holds the string denoting the metered_quantity field in the database.
 	FieldMeteredQuantity = "metered_quantity"
+	// FieldNoFiatTransactionRequired holds the string denoting the no_fiat_transaction_required field in the database.
+	FieldNoFiatTransactionRequired = "no_fiat_transaction_required"
 	// EdgeUsageBased holds the string denoting the usage_based edge name in mutations.
 	EdgeUsageBased = "usage_based"
 	// EdgeFeature holds the string denoting the feature edge name in mutations.
@@ -66,6 +68,8 @@ const (
 	EdgeCreditAllocations = "credit_allocations"
 	// EdgeDetailedLines holds the string denoting the detailed_lines edge name in mutations.
 	EdgeDetailedLines = "detailed_lines"
+	// EdgeCorrectedDetailedLines holds the string denoting the corrected_detailed_lines edge name in mutations.
+	EdgeCorrectedDetailedLines = "corrected_detailed_lines"
 	// EdgeInvoicedUsage holds the string denoting the invoiced_usage edge name in mutations.
 	EdgeInvoicedUsage = "invoiced_usage"
 	// EdgePayment holds the string denoting the payment edge name in mutations.
@@ -107,6 +111,13 @@ const (
 	DetailedLinesInverseTable = "charge_usage_based_run_detailed_line"
 	// DetailedLinesColumn is the table column denoting the detailed_lines relation/edge.
 	DetailedLinesColumn = "run_id"
+	// CorrectedDetailedLinesTable is the table that holds the corrected_detailed_lines relation/edge.
+	CorrectedDetailedLinesTable = "charge_usage_based_run_detailed_line"
+	// CorrectedDetailedLinesInverseTable is the table name for the ChargeUsageBasedRunDetailedLine entity.
+	// It exists in this package in order to avoid circular dependency with the "chargeusagebasedrundetailedline" package.
+	CorrectedDetailedLinesInverseTable = "charge_usage_based_run_detailed_line"
+	// CorrectedDetailedLinesColumn is the table column denoting the corrected_detailed_lines relation/edge.
+	CorrectedDetailedLinesColumn = "corrects_run_id"
 	// InvoicedUsageTable is the table that holds the invoiced_usage relation/edge.
 	InvoicedUsageTable = "charge_usage_based_run_invoiced_usages"
 	// InvoicedUsageInverseTable is the table name for the ChargeUsageBasedRunInvoicedUsage entity.
@@ -146,6 +157,7 @@ var Columns = []string{
 	FieldDetailedLinesPresent,
 	FieldLineID,
 	FieldMeteredQuantity,
+	FieldNoFiatTransactionRequired,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -293,6 +305,11 @@ func ByMeteredQuantity(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMeteredQuantity, opts...).ToFunc()
 }
 
+// ByNoFiatTransactionRequired orders the results by the no_fiat_transaction_required field.
+func ByNoFiatTransactionRequired(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldNoFiatTransactionRequired, opts...).ToFunc()
+}
+
 // ByUsageBasedField orders the results by usage_based field.
 func ByUsageBasedField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -342,6 +359,20 @@ func ByDetailedLines(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
 	}
 }
 
+// ByCorrectedDetailedLinesCount orders the results by corrected_detailed_lines count.
+func ByCorrectedDetailedLinesCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newCorrectedDetailedLinesStep(), opts...)
+	}
+}
+
+// ByCorrectedDetailedLines orders the results by corrected_detailed_lines terms.
+func ByCorrectedDetailedLines(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newCorrectedDetailedLinesStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
 // ByInvoicedUsageField orders the results by invoiced_usage field.
 func ByInvoicedUsageField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -388,6 +419,13 @@ func newDetailedLinesStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(DetailedLinesInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.O2M, false, DetailedLinesTable, DetailedLinesColumn),
+	)
+}
+func newCorrectedDetailedLinesStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(CorrectedDetailedLinesInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, CorrectedDetailedLinesTable, CorrectedDetailedLinesColumn),
 	)
 }
 func newInvoicedUsageStep() *sqlgraph.Step {

--- a/openmeter/ent/db/chargeusagebasedruns/where.go
+++ b/openmeter/ent/db/chargeusagebasedruns/where.go
@@ -162,6 +162,11 @@ func MeteredQuantity(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldMeteredQuantity, v))
 }
 
+// NoFiatTransactionRequired applies equality check predicate on the "no_fiat_transaction_required" field. It's identical to NoFiatTransactionRequiredEQ.
+func NoFiatTransactionRequired(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldNoFiatTransactionRequired, v))
+}
+
 // NamespaceEQ applies the EQ predicate on the "namespace" field.
 func NamespaceEQ(v string) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldNamespace, v))
@@ -1042,6 +1047,16 @@ func MeteredQuantityLTE(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRuns 
 	return predicate.ChargeUsageBasedRuns(sql.FieldLTE(FieldMeteredQuantity, v))
 }
 
+// NoFiatTransactionRequiredEQ applies the EQ predicate on the "no_fiat_transaction_required" field.
+func NoFiatTransactionRequiredEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldNoFiatTransactionRequired, v))
+}
+
+// NoFiatTransactionRequiredNEQ applies the NEQ predicate on the "no_fiat_transaction_required" field.
+func NoFiatTransactionRequiredNEQ(v bool) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldNoFiatTransactionRequired, v))
+}
+
 // HasUsageBased applies the HasEdge predicate on the "usage_based" edge.
 func HasUsageBased() predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
@@ -1149,6 +1164,29 @@ func HasDetailedLines() predicate.ChargeUsageBasedRuns {
 func HasDetailedLinesWith(preds ...predicate.ChargeUsageBasedRunDetailedLine) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
 		step := newDetailedLinesStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasCorrectedDetailedLines applies the HasEdge predicate on the "corrected_detailed_lines" edge.
+func HasCorrectedDetailedLines() predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, CorrectedDetailedLinesTable, CorrectedDetailedLinesColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasCorrectedDetailedLinesWith applies the HasEdge predicate on the "corrected_detailed_lines" edge with a given conditions (other predicates).
+func HasCorrectedDetailedLinesWith(preds ...predicate.ChargeUsageBasedRunDetailedLine) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
+		step := newCorrectedDetailedLinesStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/openmeter/ent/db/chargeusagebasedruns_create.go
+++ b/openmeter/ent/db/chargeusagebasedruns_create.go
@@ -184,6 +184,12 @@ func (_c *ChargeUsageBasedRunsCreate) SetMeteredQuantity(v alpacadecimal.Decimal
 	return _c
 }
 
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (_c *ChargeUsageBasedRunsCreate) SetNoFiatTransactionRequired(v bool) *ChargeUsageBasedRunsCreate {
+	_c.mutation.SetNoFiatTransactionRequired(v)
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *ChargeUsageBasedRunsCreate) SetID(v string) *ChargeUsageBasedRunsCreate {
 	_c.mutation.SetID(v)
@@ -261,6 +267,21 @@ func (_c *ChargeUsageBasedRunsCreate) AddDetailedLines(v ...*ChargeUsageBasedRun
 		ids[i] = v[i].ID
 	}
 	return _c.AddDetailedLineIDs(ids...)
+}
+
+// AddCorrectedDetailedLineIDs adds the "corrected_detailed_lines" edge to the ChargeUsageBasedRunDetailedLine entity by IDs.
+func (_c *ChargeUsageBasedRunsCreate) AddCorrectedDetailedLineIDs(ids ...string) *ChargeUsageBasedRunsCreate {
+	_c.mutation.AddCorrectedDetailedLineIDs(ids...)
+	return _c
+}
+
+// AddCorrectedDetailedLines adds the "corrected_detailed_lines" edges to the ChargeUsageBasedRunDetailedLine entity.
+func (_c *ChargeUsageBasedRunsCreate) AddCorrectedDetailedLines(v ...*ChargeUsageBasedRunDetailedLine) *ChargeUsageBasedRunsCreate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _c.AddCorrectedDetailedLineIDs(ids...)
 }
 
 // SetInvoicedUsageID sets the "invoiced_usage" edge to the ChargeUsageBasedRunInvoicedUsage entity by ID.
@@ -426,6 +447,9 @@ func (_c *ChargeUsageBasedRunsCreate) check() error {
 	if _, ok := _c.mutation.MeteredQuantity(); !ok {
 		return &ValidationError{Name: "metered_quantity", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.metered_quantity"`)}
 	}
+	if _, ok := _c.mutation.NoFiatTransactionRequired(); !ok {
+		return &ValidationError{Name: "no_fiat_transaction_required", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.no_fiat_transaction_required"`)}
+	}
 	if len(_c.mutation.UsageBasedIDs()) == 0 {
 		return &ValidationError{Name: "usage_based", err: errors.New(`db: missing required edge "ChargeUsageBasedRuns.usage_based"`)}
 	}
@@ -536,6 +560,10 @@ func (_c *ChargeUsageBasedRunsCreate) createSpec() (*ChargeUsageBasedRuns, *sqlg
 		_spec.SetField(chargeusagebasedruns.FieldMeteredQuantity, field.TypeOther, value)
 		_node.MeteredQuantity = value
 	}
+	if value, ok := _c.mutation.NoFiatTransactionRequired(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldNoFiatTransactionRequired, field.TypeBool, value)
+		_node.NoFiatTransactionRequired = value
+	}
 	if nodes := _c.mutation.UsageBasedIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -609,6 +637,22 @@ func (_c *ChargeUsageBasedRunsCreate) createSpec() (*ChargeUsageBasedRuns, *sqlg
 			Inverse: false,
 			Table:   chargeusagebasedruns.DetailedLinesTable,
 			Columns: []string{chargeusagebasedruns.DetailedLinesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedrundetailedline.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.CorrectedDetailedLinesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.CorrectedDetailedLinesTable,
+			Columns: []string{chargeusagebasedruns.CorrectedDetailedLinesColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedrundetailedline.FieldID, field.TypeString),
@@ -880,6 +924,18 @@ func (u *ChargeUsageBasedRunsUpsert) SetMeteredQuantity(v alpacadecimal.Decimal)
 // UpdateMeteredQuantity sets the "metered_quantity" field to the value that was provided on create.
 func (u *ChargeUsageBasedRunsUpsert) UpdateMeteredQuantity() *ChargeUsageBasedRunsUpsert {
 	u.SetExcluded(chargeusagebasedruns.FieldMeteredQuantity)
+	return u
+}
+
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (u *ChargeUsageBasedRunsUpsert) SetNoFiatTransactionRequired(v bool) *ChargeUsageBasedRunsUpsert {
+	u.Set(chargeusagebasedruns.FieldNoFiatTransactionRequired, v)
+	return u
+}
+
+// UpdateNoFiatTransactionRequired sets the "no_fiat_transaction_required" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsert) UpdateNoFiatTransactionRequired() *ChargeUsageBasedRunsUpsert {
+	u.SetExcluded(chargeusagebasedruns.FieldNoFiatTransactionRequired)
 	return u
 }
 
@@ -1156,6 +1212,20 @@ func (u *ChargeUsageBasedRunsUpsertOne) SetMeteredQuantity(v alpacadecimal.Decim
 func (u *ChargeUsageBasedRunsUpsertOne) UpdateMeteredQuantity() *ChargeUsageBasedRunsUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateMeteredQuantity()
+	})
+}
+
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (u *ChargeUsageBasedRunsUpsertOne) SetNoFiatTransactionRequired(v bool) *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetNoFiatTransactionRequired(v)
+	})
+}
+
+// UpdateNoFiatTransactionRequired sets the "no_fiat_transaction_required" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertOne) UpdateNoFiatTransactionRequired() *ChargeUsageBasedRunsUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateNoFiatTransactionRequired()
 	})
 }
 
@@ -1599,6 +1669,20 @@ func (u *ChargeUsageBasedRunsUpsertBulk) SetMeteredQuantity(v alpacadecimal.Deci
 func (u *ChargeUsageBasedRunsUpsertBulk) UpdateMeteredQuantity() *ChargeUsageBasedRunsUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
 		s.UpdateMeteredQuantity()
+	})
+}
+
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (u *ChargeUsageBasedRunsUpsertBulk) SetNoFiatTransactionRequired(v bool) *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.SetNoFiatTransactionRequired(v)
+	})
+}
+
+// UpdateNoFiatTransactionRequired sets the "no_fiat_transaction_required" field to the value that was provided on create.
+func (u *ChargeUsageBasedRunsUpsertBulk) UpdateNoFiatTransactionRequired() *ChargeUsageBasedRunsUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedRunsUpsert) {
+		s.UpdateNoFiatTransactionRequired()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebasedruns_query.go
+++ b/openmeter/ent/db/chargeusagebasedruns_query.go
@@ -27,18 +27,19 @@ import (
 // ChargeUsageBasedRunsQuery is the builder for querying ChargeUsageBasedRuns entities.
 type ChargeUsageBasedRunsQuery struct {
 	config
-	ctx                    *QueryContext
-	order                  []chargeusagebasedruns.OrderOption
-	inters                 []Interceptor
-	predicates             []predicate.ChargeUsageBasedRuns
-	withUsageBased         *ChargeUsageBasedQuery
-	withFeature            *FeatureQuery
-	withBillingInvoiceLine *BillingInvoiceLineQuery
-	withCreditAllocations  *ChargeUsageBasedRunCreditAllocationsQuery
-	withDetailedLines      *ChargeUsageBasedRunDetailedLineQuery
-	withInvoicedUsage      *ChargeUsageBasedRunInvoicedUsageQuery
-	withPayment            *ChargeUsageBasedRunPaymentQuery
-	modifiers              []func(*sql.Selector)
+	ctx                        *QueryContext
+	order                      []chargeusagebasedruns.OrderOption
+	inters                     []Interceptor
+	predicates                 []predicate.ChargeUsageBasedRuns
+	withUsageBased             *ChargeUsageBasedQuery
+	withFeature                *FeatureQuery
+	withBillingInvoiceLine     *BillingInvoiceLineQuery
+	withCreditAllocations      *ChargeUsageBasedRunCreditAllocationsQuery
+	withDetailedLines          *ChargeUsageBasedRunDetailedLineQuery
+	withCorrectedDetailedLines *ChargeUsageBasedRunDetailedLineQuery
+	withInvoicedUsage          *ChargeUsageBasedRunInvoicedUsageQuery
+	withPayment                *ChargeUsageBasedRunPaymentQuery
+	modifiers                  []func(*sql.Selector)
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -178,6 +179,28 @@ func (_q *ChargeUsageBasedRunsQuery) QueryDetailedLines() *ChargeUsageBasedRunDe
 			sqlgraph.From(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID, selector),
 			sqlgraph.To(chargeusagebasedrundetailedline.Table, chargeusagebasedrundetailedline.FieldID),
 			sqlgraph.Edge(sqlgraph.O2M, false, chargeusagebasedruns.DetailedLinesTable, chargeusagebasedruns.DetailedLinesColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryCorrectedDetailedLines chains the current query on the "corrected_detailed_lines" edge.
+func (_q *ChargeUsageBasedRunsQuery) QueryCorrectedDetailedLines() *ChargeUsageBasedRunDetailedLineQuery {
+	query := (&ChargeUsageBasedRunDetailedLineClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID, selector),
+			sqlgraph.To(chargeusagebasedrundetailedline.Table, chargeusagebasedrundetailedline.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, chargeusagebasedruns.CorrectedDetailedLinesTable, chargeusagebasedruns.CorrectedDetailedLinesColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -416,18 +439,19 @@ func (_q *ChargeUsageBasedRunsQuery) Clone() *ChargeUsageBasedRunsQuery {
 		return nil
 	}
 	return &ChargeUsageBasedRunsQuery{
-		config:                 _q.config,
-		ctx:                    _q.ctx.Clone(),
-		order:                  append([]chargeusagebasedruns.OrderOption{}, _q.order...),
-		inters:                 append([]Interceptor{}, _q.inters...),
-		predicates:             append([]predicate.ChargeUsageBasedRuns{}, _q.predicates...),
-		withUsageBased:         _q.withUsageBased.Clone(),
-		withFeature:            _q.withFeature.Clone(),
-		withBillingInvoiceLine: _q.withBillingInvoiceLine.Clone(),
-		withCreditAllocations:  _q.withCreditAllocations.Clone(),
-		withDetailedLines:      _q.withDetailedLines.Clone(),
-		withInvoicedUsage:      _q.withInvoicedUsage.Clone(),
-		withPayment:            _q.withPayment.Clone(),
+		config:                     _q.config,
+		ctx:                        _q.ctx.Clone(),
+		order:                      append([]chargeusagebasedruns.OrderOption{}, _q.order...),
+		inters:                     append([]Interceptor{}, _q.inters...),
+		predicates:                 append([]predicate.ChargeUsageBasedRuns{}, _q.predicates...),
+		withUsageBased:             _q.withUsageBased.Clone(),
+		withFeature:                _q.withFeature.Clone(),
+		withBillingInvoiceLine:     _q.withBillingInvoiceLine.Clone(),
+		withCreditAllocations:      _q.withCreditAllocations.Clone(),
+		withDetailedLines:          _q.withDetailedLines.Clone(),
+		withCorrectedDetailedLines: _q.withCorrectedDetailedLines.Clone(),
+		withInvoicedUsage:          _q.withInvoicedUsage.Clone(),
+		withPayment:                _q.withPayment.Clone(),
 		// clone intermediate query.
 		sql:  _q.sql.Clone(),
 		path: _q.path,
@@ -486,6 +510,17 @@ func (_q *ChargeUsageBasedRunsQuery) WithDetailedLines(opts ...func(*ChargeUsage
 		opt(query)
 	}
 	_q.withDetailedLines = query
+	return _q
+}
+
+// WithCorrectedDetailedLines tells the query-builder to eager-load the nodes that are connected to
+// the "corrected_detailed_lines" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *ChargeUsageBasedRunsQuery) WithCorrectedDetailedLines(opts ...func(*ChargeUsageBasedRunDetailedLineQuery)) *ChargeUsageBasedRunsQuery {
+	query := (&ChargeUsageBasedRunDetailedLineClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withCorrectedDetailedLines = query
 	return _q
 }
 
@@ -589,12 +624,13 @@ func (_q *ChargeUsageBasedRunsQuery) sqlAll(ctx context.Context, hooks ...queryH
 	var (
 		nodes       = []*ChargeUsageBasedRuns{}
 		_spec       = _q.querySpec()
-		loadedTypes = [7]bool{
+		loadedTypes = [8]bool{
 			_q.withUsageBased != nil,
 			_q.withFeature != nil,
 			_q.withBillingInvoiceLine != nil,
 			_q.withCreditAllocations != nil,
 			_q.withDetailedLines != nil,
+			_q.withCorrectedDetailedLines != nil,
 			_q.withInvoicedUsage != nil,
 			_q.withPayment != nil,
 		}
@@ -652,6 +688,15 @@ func (_q *ChargeUsageBasedRunsQuery) sqlAll(ctx context.Context, hooks ...queryH
 			func(n *ChargeUsageBasedRuns) { n.Edges.DetailedLines = []*ChargeUsageBasedRunDetailedLine{} },
 			func(n *ChargeUsageBasedRuns, e *ChargeUsageBasedRunDetailedLine) {
 				n.Edges.DetailedLines = append(n.Edges.DetailedLines, e)
+			}); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withCorrectedDetailedLines; query != nil {
+		if err := _q.loadCorrectedDetailedLines(ctx, query, nodes,
+			func(n *ChargeUsageBasedRuns) { n.Edges.CorrectedDetailedLines = []*ChargeUsageBasedRunDetailedLine{} },
+			func(n *ChargeUsageBasedRuns, e *ChargeUsageBasedRunDetailedLine) {
+				n.Edges.CorrectedDetailedLines = append(n.Edges.CorrectedDetailedLines, e)
 			}); err != nil {
 			return nil, err
 		}
@@ -816,6 +861,39 @@ func (_q *ChargeUsageBasedRunsQuery) loadDetailedLines(ctx context.Context, quer
 		node, ok := nodeids[fk]
 		if !ok {
 			return fmt.Errorf(`unexpected referenced foreign-key "run_id" returned %v for node %v`, fk, n.ID)
+		}
+		assign(node, n)
+	}
+	return nil
+}
+func (_q *ChargeUsageBasedRunsQuery) loadCorrectedDetailedLines(ctx context.Context, query *ChargeUsageBasedRunDetailedLineQuery, nodes []*ChargeUsageBasedRuns, init func(*ChargeUsageBasedRuns), assign func(*ChargeUsageBasedRuns, *ChargeUsageBasedRunDetailedLine)) error {
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[string]*ChargeUsageBasedRuns)
+	for i := range nodes {
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
+		if init != nil {
+			init(nodes[i])
+		}
+	}
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(chargeusagebasedrundetailedline.FieldCorrectsRunID)
+	}
+	query.Where(predicate.ChargeUsageBasedRunDetailedLine(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(chargeusagebasedruns.CorrectedDetailedLinesColumn), fks...))
+	}))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		fk := n.CorrectsRunID
+		if fk == nil {
+			return fmt.Errorf(`foreign-key "corrects_run_id" is nil for node %v`, n.ID)
+		}
+		node, ok := nodeids[*fk]
+		if !ok {
+			return fmt.Errorf(`unexpected referenced foreign-key "corrects_run_id" returned %v for node %v`, *fk, n.ID)
 		}
 		assign(node, n)
 	}

--- a/openmeter/ent/db/chargeusagebasedruns_update.go
+++ b/openmeter/ent/db/chargeusagebasedruns_update.go
@@ -234,6 +234,20 @@ func (_u *ChargeUsageBasedRunsUpdate) SetNillableMeteredQuantity(v *alpacadecima
 	return _u
 }
 
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (_u *ChargeUsageBasedRunsUpdate) SetNoFiatTransactionRequired(v bool) *ChargeUsageBasedRunsUpdate {
+	_u.mutation.SetNoFiatTransactionRequired(v)
+	return _u
+}
+
+// SetNillableNoFiatTransactionRequired sets the "no_fiat_transaction_required" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdate) SetNillableNoFiatTransactionRequired(v *bool) *ChargeUsageBasedRunsUpdate {
+	if v != nil {
+		_u.SetNoFiatTransactionRequired(*v)
+	}
+	return _u
+}
+
 // SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
 func (_u *ChargeUsageBasedRunsUpdate) SetBillingInvoiceLineID(id string) *ChargeUsageBasedRunsUpdate {
 	_u.mutation.SetBillingInvoiceLineID(id)
@@ -281,6 +295,21 @@ func (_u *ChargeUsageBasedRunsUpdate) AddDetailedLines(v ...*ChargeUsageBasedRun
 		ids[i] = v[i].ID
 	}
 	return _u.AddDetailedLineIDs(ids...)
+}
+
+// AddCorrectedDetailedLineIDs adds the "corrected_detailed_lines" edge to the ChargeUsageBasedRunDetailedLine entity by IDs.
+func (_u *ChargeUsageBasedRunsUpdate) AddCorrectedDetailedLineIDs(ids ...string) *ChargeUsageBasedRunsUpdate {
+	_u.mutation.AddCorrectedDetailedLineIDs(ids...)
+	return _u
+}
+
+// AddCorrectedDetailedLines adds the "corrected_detailed_lines" edges to the ChargeUsageBasedRunDetailedLine entity.
+func (_u *ChargeUsageBasedRunsUpdate) AddCorrectedDetailedLines(v ...*ChargeUsageBasedRunDetailedLine) *ChargeUsageBasedRunsUpdate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddCorrectedDetailedLineIDs(ids...)
 }
 
 // SetInvoicedUsageID sets the "invoiced_usage" edge to the ChargeUsageBasedRunInvoicedUsage entity by ID.
@@ -372,6 +401,27 @@ func (_u *ChargeUsageBasedRunsUpdate) RemoveDetailedLines(v ...*ChargeUsageBased
 		ids[i] = v[i].ID
 	}
 	return _u.RemoveDetailedLineIDs(ids...)
+}
+
+// ClearCorrectedDetailedLines clears all "corrected_detailed_lines" edges to the ChargeUsageBasedRunDetailedLine entity.
+func (_u *ChargeUsageBasedRunsUpdate) ClearCorrectedDetailedLines() *ChargeUsageBasedRunsUpdate {
+	_u.mutation.ClearCorrectedDetailedLines()
+	return _u
+}
+
+// RemoveCorrectedDetailedLineIDs removes the "corrected_detailed_lines" edge to ChargeUsageBasedRunDetailedLine entities by IDs.
+func (_u *ChargeUsageBasedRunsUpdate) RemoveCorrectedDetailedLineIDs(ids ...string) *ChargeUsageBasedRunsUpdate {
+	_u.mutation.RemoveCorrectedDetailedLineIDs(ids...)
+	return _u
+}
+
+// RemoveCorrectedDetailedLines removes "corrected_detailed_lines" edges to ChargeUsageBasedRunDetailedLine entities.
+func (_u *ChargeUsageBasedRunsUpdate) RemoveCorrectedDetailedLines(v ...*ChargeUsageBasedRunDetailedLine) *ChargeUsageBasedRunsUpdate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveCorrectedDetailedLineIDs(ids...)
 }
 
 // ClearInvoicedUsage clears the "invoiced_usage" edge to the ChargeUsageBasedRunInvoicedUsage entity.
@@ -492,6 +542,9 @@ func (_u *ChargeUsageBasedRunsUpdate) sqlSave(ctx context.Context) (_node int, e
 	if value, ok := _u.mutation.MeteredQuantity(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldMeteredQuantity, field.TypeOther, value)
 	}
+	if value, ok := _u.mutation.NoFiatTransactionRequired(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldNoFiatTransactionRequired, field.TypeBool, value)
+	}
 	if _u.mutation.BillingInvoiceLineCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2O,
@@ -601,6 +654,51 @@ func (_u *ChargeUsageBasedRunsUpdate) sqlSave(ctx context.Context) (_node int, e
 			Inverse: false,
 			Table:   chargeusagebasedruns.DetailedLinesTable,
 			Columns: []string{chargeusagebasedruns.DetailedLinesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedrundetailedline.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.CorrectedDetailedLinesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.CorrectedDetailedLinesTable,
+			Columns: []string{chargeusagebasedruns.CorrectedDetailedLinesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedrundetailedline.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedCorrectedDetailedLinesIDs(); len(nodes) > 0 && !_u.mutation.CorrectedDetailedLinesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.CorrectedDetailedLinesTable,
+			Columns: []string{chargeusagebasedruns.CorrectedDetailedLinesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedrundetailedline.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.CorrectedDetailedLinesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.CorrectedDetailedLinesTable,
+			Columns: []string{chargeusagebasedruns.CorrectedDetailedLinesColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedrundetailedline.FieldID, field.TypeString),
@@ -889,6 +987,20 @@ func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableMeteredQuantity(v *alpacadec
 	return _u
 }
 
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetNoFiatTransactionRequired(v bool) *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.SetNoFiatTransactionRequired(v)
+	return _u
+}
+
+// SetNillableNoFiatTransactionRequired sets the "no_fiat_transaction_required" field if the given value is not nil.
+func (_u *ChargeUsageBasedRunsUpdateOne) SetNillableNoFiatTransactionRequired(v *bool) *ChargeUsageBasedRunsUpdateOne {
+	if v != nil {
+		_u.SetNoFiatTransactionRequired(*v)
+	}
+	return _u
+}
+
 // SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
 func (_u *ChargeUsageBasedRunsUpdateOne) SetBillingInvoiceLineID(id string) *ChargeUsageBasedRunsUpdateOne {
 	_u.mutation.SetBillingInvoiceLineID(id)
@@ -936,6 +1048,21 @@ func (_u *ChargeUsageBasedRunsUpdateOne) AddDetailedLines(v ...*ChargeUsageBased
 		ids[i] = v[i].ID
 	}
 	return _u.AddDetailedLineIDs(ids...)
+}
+
+// AddCorrectedDetailedLineIDs adds the "corrected_detailed_lines" edge to the ChargeUsageBasedRunDetailedLine entity by IDs.
+func (_u *ChargeUsageBasedRunsUpdateOne) AddCorrectedDetailedLineIDs(ids ...string) *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.AddCorrectedDetailedLineIDs(ids...)
+	return _u
+}
+
+// AddCorrectedDetailedLines adds the "corrected_detailed_lines" edges to the ChargeUsageBasedRunDetailedLine entity.
+func (_u *ChargeUsageBasedRunsUpdateOne) AddCorrectedDetailedLines(v ...*ChargeUsageBasedRunDetailedLine) *ChargeUsageBasedRunsUpdateOne {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddCorrectedDetailedLineIDs(ids...)
 }
 
 // SetInvoicedUsageID sets the "invoiced_usage" edge to the ChargeUsageBasedRunInvoicedUsage entity by ID.
@@ -1027,6 +1154,27 @@ func (_u *ChargeUsageBasedRunsUpdateOne) RemoveDetailedLines(v ...*ChargeUsageBa
 		ids[i] = v[i].ID
 	}
 	return _u.RemoveDetailedLineIDs(ids...)
+}
+
+// ClearCorrectedDetailedLines clears all "corrected_detailed_lines" edges to the ChargeUsageBasedRunDetailedLine entity.
+func (_u *ChargeUsageBasedRunsUpdateOne) ClearCorrectedDetailedLines() *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.ClearCorrectedDetailedLines()
+	return _u
+}
+
+// RemoveCorrectedDetailedLineIDs removes the "corrected_detailed_lines" edge to ChargeUsageBasedRunDetailedLine entities by IDs.
+func (_u *ChargeUsageBasedRunsUpdateOne) RemoveCorrectedDetailedLineIDs(ids ...string) *ChargeUsageBasedRunsUpdateOne {
+	_u.mutation.RemoveCorrectedDetailedLineIDs(ids...)
+	return _u
+}
+
+// RemoveCorrectedDetailedLines removes "corrected_detailed_lines" edges to ChargeUsageBasedRunDetailedLine entities.
+func (_u *ChargeUsageBasedRunsUpdateOne) RemoveCorrectedDetailedLines(v ...*ChargeUsageBasedRunDetailedLine) *ChargeUsageBasedRunsUpdateOne {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveCorrectedDetailedLineIDs(ids...)
 }
 
 // ClearInvoicedUsage clears the "invoiced_usage" edge to the ChargeUsageBasedRunInvoicedUsage entity.
@@ -1177,6 +1325,9 @@ func (_u *ChargeUsageBasedRunsUpdateOne) sqlSave(ctx context.Context) (_node *Ch
 	if value, ok := _u.mutation.MeteredQuantity(); ok {
 		_spec.SetField(chargeusagebasedruns.FieldMeteredQuantity, field.TypeOther, value)
 	}
+	if value, ok := _u.mutation.NoFiatTransactionRequired(); ok {
+		_spec.SetField(chargeusagebasedruns.FieldNoFiatTransactionRequired, field.TypeBool, value)
+	}
 	if _u.mutation.BillingInvoiceLineCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2O,
@@ -1286,6 +1437,51 @@ func (_u *ChargeUsageBasedRunsUpdateOne) sqlSave(ctx context.Context) (_node *Ch
 			Inverse: false,
 			Table:   chargeusagebasedruns.DetailedLinesTable,
 			Columns: []string{chargeusagebasedruns.DetailedLinesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedrundetailedline.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.CorrectedDetailedLinesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.CorrectedDetailedLinesTable,
+			Columns: []string{chargeusagebasedruns.CorrectedDetailedLinesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedrundetailedline.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedCorrectedDetailedLinesIDs(); len(nodes) > 0 && !_u.mutation.CorrectedDetailedLinesCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.CorrectedDetailedLinesTable,
+			Columns: []string{chargeusagebasedruns.CorrectedDetailedLinesColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedrundetailedline.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.CorrectedDetailedLinesIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   chargeusagebasedruns.CorrectedDetailedLinesTable,
+			Columns: []string{chargeusagebasedruns.CorrectedDetailedLinesColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedrundetailedline.FieldID, field.TypeString),

--- a/openmeter/ent/db/client.go
+++ b/openmeter/ent/db/client.go
@@ -8029,6 +8029,22 @@ func (c *ChargeUsageBasedRunDetailedLineClient) QueryRun(_m *ChargeUsageBasedRun
 	return query
 }
 
+// QueryCorrectsRun queries the corrects_run edge of a ChargeUsageBasedRunDetailedLine.
+func (c *ChargeUsageBasedRunDetailedLineClient) QueryCorrectsRun(_m *ChargeUsageBasedRunDetailedLine) *ChargeUsageBasedRunsQuery {
+	query := (&ChargeUsageBasedRunsClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeusagebasedrundetailedline.Table, chargeusagebasedrundetailedline.FieldID, id),
+			sqlgraph.To(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, chargeusagebasedrundetailedline.CorrectsRunTable, chargeusagebasedrundetailedline.CorrectsRunColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryTaxCode queries the tax_code edge of a ChargeUsageBasedRunDetailedLine.
 func (c *ChargeUsageBasedRunDetailedLineClient) QueryTaxCode(_m *ChargeUsageBasedRunDetailedLine) *TaxCodeQuery {
 	query := (&TaxCodeClient{config: c.config}).Query()
@@ -8549,6 +8565,22 @@ func (c *ChargeUsageBasedRunsClient) QueryDetailedLines(_m *ChargeUsageBasedRuns
 			sqlgraph.From(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID, id),
 			sqlgraph.To(chargeusagebasedrundetailedline.Table, chargeusagebasedrundetailedline.FieldID),
 			sqlgraph.Edge(sqlgraph.O2M, false, chargeusagebasedruns.DetailedLinesTable, chargeusagebasedruns.DetailedLinesColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryCorrectedDetailedLines queries the corrected_detailed_lines edge of a ChargeUsageBasedRuns.
+func (c *ChargeUsageBasedRunsClient) QueryCorrectedDetailedLines(_m *ChargeUsageBasedRuns) *ChargeUsageBasedRunDetailedLineQuery {
+	query := (&ChargeUsageBasedRunDetailedLineClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID, id),
+			sqlgraph.To(chargeusagebasedrundetailedline.Table, chargeusagebasedrundetailedline.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, chargeusagebasedruns.CorrectedDetailedLinesTable, chargeusagebasedruns.CorrectedDetailedLinesColumn),
 		)
 		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
 		return fromV, nil

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -2131,6 +2131,7 @@ var (
 		{Name: "discounts_total", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "credits_total", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "total", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
+		{Name: "pricer_reference_id", Type: field.TypeString},
 		{Name: "charge_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "tax_code_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 	}
@@ -2142,13 +2143,13 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_flat_fee_detailed_line_charge_flat_fees_detailed_lines",
-				Columns:    []*schema.Column{ChargeFlatFeeDetailedLineColumns[30]},
+				Columns:    []*schema.Column{ChargeFlatFeeDetailedLineColumns[31]},
 				RefColumns: []*schema.Column{ChargeFlatFeesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "charge_flat_fee_detailed_line_tax_codes_charge_flat_fee_detailed_lines",
-				Columns:    []*schema.Column{ChargeFlatFeeDetailedLineColumns[31]},
+				Columns:    []*schema.Column{ChargeFlatFeeDetailedLineColumns[32]},
 				RefColumns: []*schema.Column{TaxCodesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -2157,7 +2158,7 @@ var (
 			{
 				Name:    "chargeflatfeedetailedline_tax_code_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeFlatFeeDetailedLineColumns[31]},
+				Columns: []*schema.Column{ChargeFlatFeeDetailedLineColumns[32]},
 			},
 			{
 				Name:    "chargeflatfeedetailedline_annotations",
@@ -2187,12 +2188,12 @@ var (
 			{
 				Name:    "chargeflatfeedetailedline_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeFlatFeeDetailedLineColumns[15], ChargeFlatFeeDetailedLineColumns[30]},
+				Columns: []*schema.Column{ChargeFlatFeeDetailedLineColumns[15], ChargeFlatFeeDetailedLineColumns[31]},
 			},
 			{
 				Name:    "chargeffdetailedline_ns_charge_child_id",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeFlatFeeDetailedLineColumns[15], ChargeFlatFeeDetailedLineColumns[30], ChargeFlatFeeDetailedLineColumns[8]},
+				Columns: []*schema.Column{ChargeFlatFeeDetailedLineColumns[15], ChargeFlatFeeDetailedLineColumns[31], ChargeFlatFeeDetailedLineColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "deleted_at IS NULL",
 				},
@@ -2358,6 +2359,7 @@ var (
 		{Name: "settlement_mode", Type: field.TypeEnum, Enums: []string{"invoice_only", "credit_then_invoice", "credit_only"}},
 		{Name: "discounts", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "feature_key", Type: field.TypeString},
+		{Name: "rating_engine", Type: field.TypeEnum, Enums: []string{"delta", "period_preserving"}},
 		{Name: "price", Type: field.TypeString, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "status_detailed", Type: field.TypeEnum, Enums: []string{"created", "active", "active.partial_invoice.started", "active.partial_invoice.waiting_for_collection", "active.partial_invoice.processing", "active.partial_invoice.issuing", "active.partial_invoice.completed", "active.final_realization.started", "active.final_realization.waiting_for_collection", "active.final_realization.processing", "active.final_realization.issuing", "active.final_realization.completed", "active.awaiting_payment_settlement", "final", "deleted"}},
 		{Name: "current_realization_run_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -2376,43 +2378,43 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_charge_usage_based_runs_current_run",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[27]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[28]},
 				RefColumns: []*schema.Column{ChargeUsageBasedRunsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_customers_charges_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[28]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[29]},
 				RefColumns: []*schema.Column{CustomersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "charge_usage_based_features_usage_based_charges",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[29]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[30]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "charge_usage_based_subscriptions_charges_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[30]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[31]},
 				RefColumns: []*schema.Column{SubscriptionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_subscription_items_charges_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[31]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[32]},
 				RefColumns: []*schema.Column{SubscriptionItemsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_subscription_phases_charges_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[32]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[33]},
 				RefColumns: []*schema.Column{SubscriptionPhasesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_tax_codes_charge_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[33]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[34]},
 				RefColumns: []*schema.Column{TaxCodesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -2421,7 +2423,7 @@ var (
 			{
 				Name:    "chargeusagebased_namespace_customer_id_unique_reference_id",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeUsageBasedColumns[14], ChargeUsageBasedColumns[28], ChargeUsageBasedColumns[8]},
+				Columns: []*schema.Column{ChargeUsageBasedColumns[14], ChargeUsageBasedColumns[29], ChargeUsageBasedColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "unique_reference_id IS NOT NULL AND deleted_at IS NULL",
 				},
@@ -2454,7 +2456,7 @@ var (
 			{
 				Name:    "chargeusagebased_tax_code_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedColumns[33]},
+				Columns: []*schema.Column{ChargeUsageBasedColumns[34]},
 			},
 		},
 	}
@@ -2550,8 +2552,10 @@ var (
 		{Name: "discounts_total", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "credits_total", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "total", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
+		{Name: "pricer_reference_id", Type: field.TypeString},
 		{Name: "charge_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "run_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
+		{Name: "corrects_run_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "tax_code_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 	}
 	// ChargeUsageBasedRunDetailedLineTable holds the schema information for the "charge_usage_based_run_detailed_line" table.
@@ -2562,19 +2566,25 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_run_detailed_line_charge_usage_based_detailed_lines",
-				Columns:    []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[30]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[31]},
 				RefColumns: []*schema.Column{ChargeUsageBasedColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "charge_usage_based_run_detailed_line_charge_usage_based_runs_detailed_lines",
-				Columns:    []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[31]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[32]},
 				RefColumns: []*schema.Column{ChargeUsageBasedRunsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
+				Symbol:     "cub_run_corrected_detailed_lines",
+				Columns:    []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[33]},
+				RefColumns: []*schema.Column{ChargeUsageBasedRunsColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+			{
 				Symbol:     "charge_usage_based_run_detailed_line_tax_codes_charge_usage_based_run_detailed_lines",
-				Columns:    []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[32]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[34]},
 				RefColumns: []*schema.Column{TaxCodesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -2583,7 +2593,7 @@ var (
 			{
 				Name:    "chargeusagebasedrundetailedline_tax_code_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[32]},
+				Columns: []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[34]},
 			},
 			{
 				Name:    "chargeusagebasedrundetailedline_annotations",
@@ -2613,17 +2623,17 @@ var (
 			{
 				Name:    "chargeusagebasedrundetailedline_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[15], ChargeUsageBasedRunDetailedLineColumns[30]},
+				Columns: []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[15], ChargeUsageBasedRunDetailedLineColumns[31]},
 			},
 			{
 				Name:    "chargeusagebasedrundetailedline_namespace_run_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[15], ChargeUsageBasedRunDetailedLineColumns[31]},
+				Columns: []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[15], ChargeUsageBasedRunDetailedLineColumns[32]},
 			},
 			{
 				Name:    "chargeubdetailedline_ns_charge_run_child_id",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[15], ChargeUsageBasedRunDetailedLineColumns[30], ChargeUsageBasedRunDetailedLineColumns[31], ChargeUsageBasedRunDetailedLineColumns[8]},
+				Columns: []*schema.Column{ChargeUsageBasedRunDetailedLineColumns[15], ChargeUsageBasedRunDetailedLineColumns[31], ChargeUsageBasedRunDetailedLineColumns[32], ChargeUsageBasedRunDetailedLineColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "deleted_at IS NULL",
 				},
@@ -2765,6 +2775,7 @@ var (
 		{Name: "service_period_to", Type: field.TypeTime},
 		{Name: "detailed_lines_present", Type: field.TypeBool},
 		{Name: "metered_quantity", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
+		{Name: "no_fiat_transaction_required", Type: field.TypeBool},
 		{Name: "line_id", Type: field.TypeString, Unique: true, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "charge_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "feature_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -2777,19 +2788,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_runs_billing_invoice_lines_charge_usage_based_run",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[18]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[19]},
 				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[19]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[20]},
 				RefColumns: []*schema.Column{ChargeUsageBasedColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_features_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[20]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[21]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -2808,7 +2819,7 @@ var (
 			{
 				Name:    "chargeusagebasedruns_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[19]},
+				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[20]},
 			},
 		},
 	}
@@ -5177,7 +5188,8 @@ func init() {
 	ChargeUsageBasedRunCreditAllocationsTable.ForeignKeys[1].RefTable = ChargeUsageBasedRunsTable
 	ChargeUsageBasedRunDetailedLineTable.ForeignKeys[0].RefTable = ChargeUsageBasedTable
 	ChargeUsageBasedRunDetailedLineTable.ForeignKeys[1].RefTable = ChargeUsageBasedRunsTable
-	ChargeUsageBasedRunDetailedLineTable.ForeignKeys[2].RefTable = TaxCodesTable
+	ChargeUsageBasedRunDetailedLineTable.ForeignKeys[2].RefTable = ChargeUsageBasedRunsTable
+	ChargeUsageBasedRunDetailedLineTable.ForeignKeys[3].RefTable = TaxCodesTable
 	ChargeUsageBasedRunDetailedLineTable.Annotation = &entsql.Annotation{
 		Table: "charge_usage_based_run_detailed_line",
 	}

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -47272,6 +47272,7 @@ type ChargeFlatFeeDetailedLineMutation struct {
 	discounts_total           *alpacadecimal.Decimal
 	credits_total             *alpacadecimal.Decimal
 	total                     *alpacadecimal.Decimal
+	pricer_reference_id       *string
 	clearedFields             map[string]struct{}
 	charge                    *string
 	clearedcharge             bool
@@ -48653,6 +48654,42 @@ func (m *ChargeFlatFeeDetailedLineMutation) ResetChargeID() {
 	m.charge = nil
 }
 
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (m *ChargeFlatFeeDetailedLineMutation) SetPricerReferenceID(s string) {
+	m.pricer_reference_id = &s
+}
+
+// PricerReferenceID returns the value of the "pricer_reference_id" field in the mutation.
+func (m *ChargeFlatFeeDetailedLineMutation) PricerReferenceID() (r string, exists bool) {
+	v := m.pricer_reference_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPricerReferenceID returns the old "pricer_reference_id" field's value of the ChargeFlatFeeDetailedLine entity.
+// If the ChargeFlatFeeDetailedLine object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeFlatFeeDetailedLineMutation) OldPricerReferenceID(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPricerReferenceID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPricerReferenceID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPricerReferenceID: %w", err)
+	}
+	return oldValue.PricerReferenceID, nil
+}
+
+// ResetPricerReferenceID resets all changes to the "pricer_reference_id" field.
+func (m *ChargeFlatFeeDetailedLineMutation) ResetPricerReferenceID() {
+	m.pricer_reference_id = nil
+}
+
 // ClearCharge clears the "charge" edge to the ChargeFlatFee entity.
 func (m *ChargeFlatFeeDetailedLineMutation) ClearCharge() {
 	m.clearedcharge = true
@@ -48741,7 +48778,7 @@ func (m *ChargeFlatFeeDetailedLineMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeFlatFeeDetailedLineMutation) Fields() []string {
-	fields := make([]string, 0, 31)
+	fields := make([]string, 0, 32)
 	if m.currency != nil {
 		fields = append(fields, chargeflatfeedetailedline.FieldCurrency)
 	}
@@ -48835,6 +48872,9 @@ func (m *ChargeFlatFeeDetailedLineMutation) Fields() []string {
 	if m.charge != nil {
 		fields = append(fields, chargeflatfeedetailedline.FieldChargeID)
 	}
+	if m.pricer_reference_id != nil {
+		fields = append(fields, chargeflatfeedetailedline.FieldPricerReferenceID)
+	}
 	return fields
 }
 
@@ -48905,6 +48945,8 @@ func (m *ChargeFlatFeeDetailedLineMutation) Field(name string) (ent.Value, bool)
 		return m.Total()
 	case chargeflatfeedetailedline.FieldChargeID:
 		return m.ChargeID()
+	case chargeflatfeedetailedline.FieldPricerReferenceID:
+		return m.PricerReferenceID()
 	}
 	return nil, false
 }
@@ -48976,6 +49018,8 @@ func (m *ChargeFlatFeeDetailedLineMutation) OldField(ctx context.Context, name s
 		return m.OldTotal(ctx)
 	case chargeflatfeedetailedline.FieldChargeID:
 		return m.OldChargeID(ctx)
+	case chargeflatfeedetailedline.FieldPricerReferenceID:
+		return m.OldPricerReferenceID(ctx)
 	}
 	return nil, fmt.Errorf("unknown ChargeFlatFeeDetailedLine field %s", name)
 }
@@ -49202,6 +49246,13 @@ func (m *ChargeFlatFeeDetailedLineMutation) SetField(name string, value ent.Valu
 		}
 		m.SetChargeID(v)
 		return nil
+	case chargeflatfeedetailedline.FieldPricerReferenceID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPricerReferenceID(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ChargeFlatFeeDetailedLine field %s", name)
 }
@@ -49421,6 +49472,9 @@ func (m *ChargeFlatFeeDetailedLineMutation) ResetField(name string) error {
 		return nil
 	case chargeflatfeedetailedline.FieldChargeID:
 		m.ResetChargeID()
+		return nil
+	case chargeflatfeedetailedline.FieldPricerReferenceID:
+		m.ResetPricerReferenceID()
 		return nil
 	}
 	return fmt.Errorf("unknown ChargeFlatFeeDetailedLine field %s", name)
@@ -52442,6 +52496,7 @@ type ChargeUsageBasedMutation struct {
 	settlement_mode           *productcatalog.SettlementMode
 	discounts                 **productcatalog.Discounts
 	feature_key               *string
+	rating_engine             *usagebased.RatingEngine
 	price                     **productcatalog.Price
 	status_detailed           *usagebased.Status
 	clearedFields             map[string]struct{}
@@ -53812,6 +53867,42 @@ func (m *ChargeUsageBasedMutation) ResetFeatureID() {
 	m.feature = nil
 }
 
+// SetRatingEngine sets the "rating_engine" field.
+func (m *ChargeUsageBasedMutation) SetRatingEngine(ue usagebased.RatingEngine) {
+	m.rating_engine = &ue
+}
+
+// RatingEngine returns the value of the "rating_engine" field in the mutation.
+func (m *ChargeUsageBasedMutation) RatingEngine() (r usagebased.RatingEngine, exists bool) {
+	v := m.rating_engine
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldRatingEngine returns the old "rating_engine" field's value of the ChargeUsageBased entity.
+// If the ChargeUsageBased object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedMutation) OldRatingEngine(ctx context.Context) (v usagebased.RatingEngine, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldRatingEngine is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldRatingEngine requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldRatingEngine: %w", err)
+	}
+	return oldValue.RatingEngine, nil
+}
+
+// ResetRatingEngine resets all changes to the "rating_engine" field.
+func (m *ChargeUsageBasedMutation) ResetRatingEngine() {
+	m.rating_engine = nil
+}
+
 // SetPrice sets the "price" field.
 func (m *ChargeUsageBasedMutation) SetPrice(pr *productcatalog.Price) {
 	m.price = &pr
@@ -54316,7 +54407,7 @@ func (m *ChargeUsageBasedMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedMutation) Fields() []string {
-	fields := make([]string, 0, 33)
+	fields := make([]string, 0, 34)
 	if m.customer != nil {
 		fields = append(fields, chargeusagebased.FieldCustomerID)
 	}
@@ -54407,6 +54498,9 @@ func (m *ChargeUsageBasedMutation) Fields() []string {
 	if m.feature != nil {
 		fields = append(fields, chargeusagebased.FieldFeatureID)
 	}
+	if m.rating_engine != nil {
+		fields = append(fields, chargeusagebased.FieldRatingEngine)
+	}
 	if m.price != nil {
 		fields = append(fields, chargeusagebased.FieldPrice)
 	}
@@ -54484,6 +54578,8 @@ func (m *ChargeUsageBasedMutation) Field(name string) (ent.Value, bool) {
 		return m.FeatureKey()
 	case chargeusagebased.FieldFeatureID:
 		return m.FeatureID()
+	case chargeusagebased.FieldRatingEngine:
+		return m.RatingEngine()
 	case chargeusagebased.FieldPrice:
 		return m.Price()
 	case chargeusagebased.FieldCurrentRealizationRunID:
@@ -54559,6 +54655,8 @@ func (m *ChargeUsageBasedMutation) OldField(ctx context.Context, name string) (e
 		return m.OldFeatureKey(ctx)
 	case chargeusagebased.FieldFeatureID:
 		return m.OldFeatureID(ctx)
+	case chargeusagebased.FieldRatingEngine:
+		return m.OldRatingEngine(ctx)
 	case chargeusagebased.FieldPrice:
 		return m.OldPrice(ctx)
 	case chargeusagebased.FieldCurrentRealizationRunID:
@@ -54783,6 +54881,13 @@ func (m *ChargeUsageBasedMutation) SetField(name string, value ent.Value) error 
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetFeatureID(v)
+		return nil
+	case chargeusagebased.FieldRatingEngine:
+		v, ok := value.(usagebased.RatingEngine)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRatingEngine(v)
 		return nil
 	case chargeusagebased.FieldPrice:
 		v, ok := value.(*productcatalog.Price)
@@ -55024,6 +55129,9 @@ func (m *ChargeUsageBasedMutation) ResetField(name string) error {
 		return nil
 	case chargeusagebased.FieldFeatureID:
 		m.ResetFeatureID()
+		return nil
+	case chargeusagebased.FieldRatingEngine:
+		m.ResetRatingEngine()
 		return nil
 	case chargeusagebased.FieldPrice:
 		m.ResetPrice()
@@ -56675,11 +56783,14 @@ type ChargeUsageBasedRunDetailedLineMutation struct {
 	discounts_total           *alpacadecimal.Decimal
 	credits_total             *alpacadecimal.Decimal
 	total                     *alpacadecimal.Decimal
+	pricer_reference_id       *string
 	clearedFields             map[string]struct{}
 	charge                    *string
 	clearedcharge             bool
 	run                       *string
 	clearedrun                bool
+	corrects_run              *string
+	clearedcorrects_run       bool
 	tax_code                  *string
 	clearedtax_code           bool
 	done                      bool
@@ -58094,6 +58205,91 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) ResetRunID() {
 	m.run = nil
 }
 
+// SetPricerReferenceID sets the "pricer_reference_id" field.
+func (m *ChargeUsageBasedRunDetailedLineMutation) SetPricerReferenceID(s string) {
+	m.pricer_reference_id = &s
+}
+
+// PricerReferenceID returns the value of the "pricer_reference_id" field in the mutation.
+func (m *ChargeUsageBasedRunDetailedLineMutation) PricerReferenceID() (r string, exists bool) {
+	v := m.pricer_reference_id
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPricerReferenceID returns the old "pricer_reference_id" field's value of the ChargeUsageBasedRunDetailedLine entity.
+// If the ChargeUsageBasedRunDetailedLine object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedRunDetailedLineMutation) OldPricerReferenceID(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPricerReferenceID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPricerReferenceID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPricerReferenceID: %w", err)
+	}
+	return oldValue.PricerReferenceID, nil
+}
+
+// ResetPricerReferenceID resets all changes to the "pricer_reference_id" field.
+func (m *ChargeUsageBasedRunDetailedLineMutation) ResetPricerReferenceID() {
+	m.pricer_reference_id = nil
+}
+
+// SetCorrectsRunID sets the "corrects_run_id" field.
+func (m *ChargeUsageBasedRunDetailedLineMutation) SetCorrectsRunID(s string) {
+	m.corrects_run = &s
+}
+
+// CorrectsRunID returns the value of the "corrects_run_id" field in the mutation.
+func (m *ChargeUsageBasedRunDetailedLineMutation) CorrectsRunID() (r string, exists bool) {
+	v := m.corrects_run
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCorrectsRunID returns the old "corrects_run_id" field's value of the ChargeUsageBasedRunDetailedLine entity.
+// If the ChargeUsageBasedRunDetailedLine object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedRunDetailedLineMutation) OldCorrectsRunID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCorrectsRunID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCorrectsRunID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCorrectsRunID: %w", err)
+	}
+	return oldValue.CorrectsRunID, nil
+}
+
+// ClearCorrectsRunID clears the value of the "corrects_run_id" field.
+func (m *ChargeUsageBasedRunDetailedLineMutation) ClearCorrectsRunID() {
+	m.corrects_run = nil
+	m.clearedFields[chargeusagebasedrundetailedline.FieldCorrectsRunID] = struct{}{}
+}
+
+// CorrectsRunIDCleared returns if the "corrects_run_id" field was cleared in this mutation.
+func (m *ChargeUsageBasedRunDetailedLineMutation) CorrectsRunIDCleared() bool {
+	_, ok := m.clearedFields[chargeusagebasedrundetailedline.FieldCorrectsRunID]
+	return ok
+}
+
+// ResetCorrectsRunID resets all changes to the "corrects_run_id" field.
+func (m *ChargeUsageBasedRunDetailedLineMutation) ResetCorrectsRunID() {
+	m.corrects_run = nil
+	delete(m.clearedFields, chargeusagebasedrundetailedline.FieldCorrectsRunID)
+}
+
 // ClearCharge clears the "charge" edge to the ChargeUsageBased entity.
 func (m *ChargeUsageBasedRunDetailedLineMutation) ClearCharge() {
 	m.clearedcharge = true
@@ -58146,6 +58342,33 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) RunIDs() (ids []string) {
 func (m *ChargeUsageBasedRunDetailedLineMutation) ResetRun() {
 	m.run = nil
 	m.clearedrun = false
+}
+
+// ClearCorrectsRun clears the "corrects_run" edge to the ChargeUsageBasedRuns entity.
+func (m *ChargeUsageBasedRunDetailedLineMutation) ClearCorrectsRun() {
+	m.clearedcorrects_run = true
+	m.clearedFields[chargeusagebasedrundetailedline.FieldCorrectsRunID] = struct{}{}
+}
+
+// CorrectsRunCleared reports if the "corrects_run" edge to the ChargeUsageBasedRuns entity was cleared.
+func (m *ChargeUsageBasedRunDetailedLineMutation) CorrectsRunCleared() bool {
+	return m.CorrectsRunIDCleared() || m.clearedcorrects_run
+}
+
+// CorrectsRunIDs returns the "corrects_run" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// CorrectsRunID instead. It exists only for internal usage by the builders.
+func (m *ChargeUsageBasedRunDetailedLineMutation) CorrectsRunIDs() (ids []string) {
+	if id := m.corrects_run; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetCorrectsRun resets all changes to the "corrects_run" edge.
+func (m *ChargeUsageBasedRunDetailedLineMutation) ResetCorrectsRun() {
+	m.corrects_run = nil
+	m.clearedcorrects_run = false
 }
 
 // ClearTaxCode clears the "tax_code" edge to the TaxCode entity.
@@ -58209,7 +58432,7 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedRunDetailedLineMutation) Fields() []string {
-	fields := make([]string, 0, 32)
+	fields := make([]string, 0, 34)
 	if m.currency != nil {
 		fields = append(fields, chargeusagebasedrundetailedline.FieldCurrency)
 	}
@@ -58306,6 +58529,12 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) Fields() []string {
 	if m.run != nil {
 		fields = append(fields, chargeusagebasedrundetailedline.FieldRunID)
 	}
+	if m.pricer_reference_id != nil {
+		fields = append(fields, chargeusagebasedrundetailedline.FieldPricerReferenceID)
+	}
+	if m.corrects_run != nil {
+		fields = append(fields, chargeusagebasedrundetailedline.FieldCorrectsRunID)
+	}
 	return fields
 }
 
@@ -58378,6 +58607,10 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) Field(name string) (ent.Value,
 		return m.ChargeID()
 	case chargeusagebasedrundetailedline.FieldRunID:
 		return m.RunID()
+	case chargeusagebasedrundetailedline.FieldPricerReferenceID:
+		return m.PricerReferenceID()
+	case chargeusagebasedrundetailedline.FieldCorrectsRunID:
+		return m.CorrectsRunID()
 	}
 	return nil, false
 }
@@ -58451,6 +58684,10 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) OldField(ctx context.Context, 
 		return m.OldChargeID(ctx)
 	case chargeusagebasedrundetailedline.FieldRunID:
 		return m.OldRunID(ctx)
+	case chargeusagebasedrundetailedline.FieldPricerReferenceID:
+		return m.OldPricerReferenceID(ctx)
+	case chargeusagebasedrundetailedline.FieldCorrectsRunID:
+		return m.OldCorrectsRunID(ctx)
 	}
 	return nil, fmt.Errorf("unknown ChargeUsageBasedRunDetailedLine field %s", name)
 }
@@ -58684,6 +58921,20 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) SetField(name string, value en
 		}
 		m.SetRunID(v)
 		return nil
+	case chargeusagebasedrundetailedline.FieldPricerReferenceID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPricerReferenceID(v)
+		return nil
+	case chargeusagebasedrundetailedline.FieldCorrectsRunID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCorrectsRunID(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRunDetailedLine field %s", name)
 }
@@ -58759,6 +59010,9 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) ClearedFields() []string {
 	if m.FieldCleared(chargeusagebasedrundetailedline.FieldDescription) {
 		fields = append(fields, chargeusagebasedrundetailedline.FieldDescription)
 	}
+	if m.FieldCleared(chargeusagebasedrundetailedline.FieldCorrectsRunID) {
+		fields = append(fields, chargeusagebasedrundetailedline.FieldCorrectsRunID)
+	}
 	return fields
 }
 
@@ -58802,6 +59056,9 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) ClearField(name string) error 
 		return nil
 	case chargeusagebasedrundetailedline.FieldDescription:
 		m.ClearDescription()
+		return nil
+	case chargeusagebasedrundetailedline.FieldCorrectsRunID:
+		m.ClearCorrectsRunID()
 		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRunDetailedLine nullable field %s", name)
@@ -58907,18 +59164,27 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) ResetField(name string) error 
 	case chargeusagebasedrundetailedline.FieldRunID:
 		m.ResetRunID()
 		return nil
+	case chargeusagebasedrundetailedline.FieldPricerReferenceID:
+		m.ResetPricerReferenceID()
+		return nil
+	case chargeusagebasedrundetailedline.FieldCorrectsRunID:
+		m.ResetCorrectsRunID()
+		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRunDetailedLine field %s", name)
 }
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *ChargeUsageBasedRunDetailedLineMutation) AddedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 4)
 	if m.charge != nil {
 		edges = append(edges, chargeusagebasedrundetailedline.EdgeCharge)
 	}
 	if m.run != nil {
 		edges = append(edges, chargeusagebasedrundetailedline.EdgeRun)
+	}
+	if m.corrects_run != nil {
+		edges = append(edges, chargeusagebasedrundetailedline.EdgeCorrectsRun)
 	}
 	if m.tax_code != nil {
 		edges = append(edges, chargeusagebasedrundetailedline.EdgeTaxCode)
@@ -58938,6 +59204,10 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) AddedIDs(name string) []ent.Va
 		if id := m.run; id != nil {
 			return []ent.Value{*id}
 		}
+	case chargeusagebasedrundetailedline.EdgeCorrectsRun:
+		if id := m.corrects_run; id != nil {
+			return []ent.Value{*id}
+		}
 	case chargeusagebasedrundetailedline.EdgeTaxCode:
 		if id := m.tax_code; id != nil {
 			return []ent.Value{*id}
@@ -58948,7 +59218,7 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) AddedIDs(name string) []ent.Va
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *ChargeUsageBasedRunDetailedLineMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 4)
 	return edges
 }
 
@@ -58960,12 +59230,15 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) RemovedIDs(name string) []ent.
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *ChargeUsageBasedRunDetailedLineMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 3)
+	edges := make([]string, 0, 4)
 	if m.clearedcharge {
 		edges = append(edges, chargeusagebasedrundetailedline.EdgeCharge)
 	}
 	if m.clearedrun {
 		edges = append(edges, chargeusagebasedrundetailedline.EdgeRun)
+	}
+	if m.clearedcorrects_run {
+		edges = append(edges, chargeusagebasedrundetailedline.EdgeCorrectsRun)
 	}
 	if m.clearedtax_code {
 		edges = append(edges, chargeusagebasedrundetailedline.EdgeTaxCode)
@@ -58981,6 +59254,8 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) EdgeCleared(name string) bool 
 		return m.clearedcharge
 	case chargeusagebasedrundetailedline.EdgeRun:
 		return m.clearedrun
+	case chargeusagebasedrundetailedline.EdgeCorrectsRun:
+		return m.clearedcorrects_run
 	case chargeusagebasedrundetailedline.EdgeTaxCode:
 		return m.clearedtax_code
 	}
@@ -58996,6 +59271,9 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) ClearEdge(name string) error {
 		return nil
 	case chargeusagebasedrundetailedline.EdgeRun:
 		m.ClearRun()
+		return nil
+	case chargeusagebasedrundetailedline.EdgeCorrectsRun:
+		m.ClearCorrectsRun()
 		return nil
 	case chargeusagebasedrundetailedline.EdgeTaxCode:
 		m.ClearTaxCode()
@@ -59013,6 +59291,9 @@ func (m *ChargeUsageBasedRunDetailedLineMutation) ResetEdge(name string) error {
 		return nil
 	case chargeusagebasedrundetailedline.EdgeRun:
 		m.ResetRun()
+		return nil
+	case chargeusagebasedrundetailedline.EdgeCorrectsRun:
+		m.ResetCorrectsRun()
 		return nil
 	case chargeusagebasedrundetailedline.EdgeTaxCode:
 		m.ResetTaxCode()
@@ -61774,46 +62055,50 @@ func (m *ChargeUsageBasedRunPaymentMutation) ResetEdge(name string) error {
 // ChargeUsageBasedRunsMutation represents an operation that mutates the ChargeUsageBasedRuns nodes in the graph.
 type ChargeUsageBasedRunsMutation struct {
 	config
-	op                          Op
-	typ                         string
-	id                          *string
-	namespace                   *string
-	created_at                  *time.Time
-	updated_at                  *time.Time
-	deleted_at                  *time.Time
-	amount                      *alpacadecimal.Decimal
-	taxes_total                 *alpacadecimal.Decimal
-	taxes_inclusive_total       *alpacadecimal.Decimal
-	taxes_exclusive_total       *alpacadecimal.Decimal
-	charges_total               *alpacadecimal.Decimal
-	discounts_total             *alpacadecimal.Decimal
-	credits_total               *alpacadecimal.Decimal
-	total                       *alpacadecimal.Decimal
-	_type                       *usagebased.RealizationRunType
-	stored_at_lt                *time.Time
-	service_period_to           *time.Time
-	detailed_lines_present      *bool
-	metered_quantity            *alpacadecimal.Decimal
-	clearedFields               map[string]struct{}
-	usage_based                 *string
-	clearedusage_based          bool
-	feature                     *string
-	clearedfeature              bool
-	billing_invoice_line        *string
-	clearedbilling_invoice_line bool
-	credit_allocations          map[string]struct{}
-	removedcredit_allocations   map[string]struct{}
-	clearedcredit_allocations   bool
-	detailed_lines              map[string]struct{}
-	removeddetailed_lines       map[string]struct{}
-	cleareddetailed_lines       bool
-	invoiced_usage              *string
-	clearedinvoiced_usage       bool
-	payment                     *string
-	clearedpayment              bool
-	done                        bool
-	oldValue                    func(context.Context) (*ChargeUsageBasedRuns, error)
-	predicates                  []predicate.ChargeUsageBasedRuns
+	op                              Op
+	typ                             string
+	id                              *string
+	namespace                       *string
+	created_at                      *time.Time
+	updated_at                      *time.Time
+	deleted_at                      *time.Time
+	amount                          *alpacadecimal.Decimal
+	taxes_total                     *alpacadecimal.Decimal
+	taxes_inclusive_total           *alpacadecimal.Decimal
+	taxes_exclusive_total           *alpacadecimal.Decimal
+	charges_total                   *alpacadecimal.Decimal
+	discounts_total                 *alpacadecimal.Decimal
+	credits_total                   *alpacadecimal.Decimal
+	total                           *alpacadecimal.Decimal
+	_type                           *usagebased.RealizationRunType
+	stored_at_lt                    *time.Time
+	service_period_to               *time.Time
+	detailed_lines_present          *bool
+	metered_quantity                *alpacadecimal.Decimal
+	no_fiat_transaction_required    *bool
+	clearedFields                   map[string]struct{}
+	usage_based                     *string
+	clearedusage_based              bool
+	feature                         *string
+	clearedfeature                  bool
+	billing_invoice_line            *string
+	clearedbilling_invoice_line     bool
+	credit_allocations              map[string]struct{}
+	removedcredit_allocations       map[string]struct{}
+	clearedcredit_allocations       bool
+	detailed_lines                  map[string]struct{}
+	removeddetailed_lines           map[string]struct{}
+	cleareddetailed_lines           bool
+	corrected_detailed_lines        map[string]struct{}
+	removedcorrected_detailed_lines map[string]struct{}
+	clearedcorrected_detailed_lines bool
+	invoiced_usage                  *string
+	clearedinvoiced_usage           bool
+	payment                         *string
+	clearedpayment                  bool
+	done                            bool
+	oldValue                        func(context.Context) (*ChargeUsageBasedRuns, error)
+	predicates                      []predicate.ChargeUsageBasedRuns
 }
 
 var _ ent.Mutation = (*ChargeUsageBasedRunsMutation)(nil)
@@ -62666,6 +62951,42 @@ func (m *ChargeUsageBasedRunsMutation) ResetMeteredQuantity() {
 	m.metered_quantity = nil
 }
 
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (m *ChargeUsageBasedRunsMutation) SetNoFiatTransactionRequired(b bool) {
+	m.no_fiat_transaction_required = &b
+}
+
+// NoFiatTransactionRequired returns the value of the "no_fiat_transaction_required" field in the mutation.
+func (m *ChargeUsageBasedRunsMutation) NoFiatTransactionRequired() (r bool, exists bool) {
+	v := m.no_fiat_transaction_required
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldNoFiatTransactionRequired returns the old "no_fiat_transaction_required" field's value of the ChargeUsageBasedRuns entity.
+// If the ChargeUsageBasedRuns object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedRunsMutation) OldNoFiatTransactionRequired(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldNoFiatTransactionRequired is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldNoFiatTransactionRequired requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldNoFiatTransactionRequired: %w", err)
+	}
+	return oldValue.NoFiatTransactionRequired, nil
+}
+
+// ResetNoFiatTransactionRequired resets all changes to the "no_fiat_transaction_required" field.
+func (m *ChargeUsageBasedRunsMutation) ResetNoFiatTransactionRequired() {
+	m.no_fiat_transaction_required = nil
+}
+
 // SetUsageBasedID sets the "usage_based" edge to the ChargeUsageBased entity by id.
 func (m *ChargeUsageBasedRunsMutation) SetUsageBasedID(id string) {
 	m.usage_based = &id
@@ -62881,6 +63202,60 @@ func (m *ChargeUsageBasedRunsMutation) ResetDetailedLines() {
 	m.removeddetailed_lines = nil
 }
 
+// AddCorrectedDetailedLineIDs adds the "corrected_detailed_lines" edge to the ChargeUsageBasedRunDetailedLine entity by ids.
+func (m *ChargeUsageBasedRunsMutation) AddCorrectedDetailedLineIDs(ids ...string) {
+	if m.corrected_detailed_lines == nil {
+		m.corrected_detailed_lines = make(map[string]struct{})
+	}
+	for i := range ids {
+		m.corrected_detailed_lines[ids[i]] = struct{}{}
+	}
+}
+
+// ClearCorrectedDetailedLines clears the "corrected_detailed_lines" edge to the ChargeUsageBasedRunDetailedLine entity.
+func (m *ChargeUsageBasedRunsMutation) ClearCorrectedDetailedLines() {
+	m.clearedcorrected_detailed_lines = true
+}
+
+// CorrectedDetailedLinesCleared reports if the "corrected_detailed_lines" edge to the ChargeUsageBasedRunDetailedLine entity was cleared.
+func (m *ChargeUsageBasedRunsMutation) CorrectedDetailedLinesCleared() bool {
+	return m.clearedcorrected_detailed_lines
+}
+
+// RemoveCorrectedDetailedLineIDs removes the "corrected_detailed_lines" edge to the ChargeUsageBasedRunDetailedLine entity by IDs.
+func (m *ChargeUsageBasedRunsMutation) RemoveCorrectedDetailedLineIDs(ids ...string) {
+	if m.removedcorrected_detailed_lines == nil {
+		m.removedcorrected_detailed_lines = make(map[string]struct{})
+	}
+	for i := range ids {
+		delete(m.corrected_detailed_lines, ids[i])
+		m.removedcorrected_detailed_lines[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedCorrectedDetailedLines returns the removed IDs of the "corrected_detailed_lines" edge to the ChargeUsageBasedRunDetailedLine entity.
+func (m *ChargeUsageBasedRunsMutation) RemovedCorrectedDetailedLinesIDs() (ids []string) {
+	for id := range m.removedcorrected_detailed_lines {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// CorrectedDetailedLinesIDs returns the "corrected_detailed_lines" edge IDs in the mutation.
+func (m *ChargeUsageBasedRunsMutation) CorrectedDetailedLinesIDs() (ids []string) {
+	for id := range m.corrected_detailed_lines {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetCorrectedDetailedLines resets all changes to the "corrected_detailed_lines" edge.
+func (m *ChargeUsageBasedRunsMutation) ResetCorrectedDetailedLines() {
+	m.corrected_detailed_lines = nil
+	m.clearedcorrected_detailed_lines = false
+	m.removedcorrected_detailed_lines = nil
+}
+
 // SetInvoicedUsageID sets the "invoiced_usage" edge to the ChargeUsageBasedRunInvoicedUsage entity by id.
 func (m *ChargeUsageBasedRunsMutation) SetInvoicedUsageID(id string) {
 	m.invoiced_usage = &id
@@ -62993,7 +63368,7 @@ func (m *ChargeUsageBasedRunsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedRunsMutation) Fields() []string {
-	fields := make([]string, 0, 20)
+	fields := make([]string, 0, 21)
 	if m.namespace != nil {
 		fields = append(fields, chargeusagebasedruns.FieldNamespace)
 	}
@@ -63054,6 +63429,9 @@ func (m *ChargeUsageBasedRunsMutation) Fields() []string {
 	if m.metered_quantity != nil {
 		fields = append(fields, chargeusagebasedruns.FieldMeteredQuantity)
 	}
+	if m.no_fiat_transaction_required != nil {
+		fields = append(fields, chargeusagebasedruns.FieldNoFiatTransactionRequired)
+	}
 	return fields
 }
 
@@ -63102,6 +63480,8 @@ func (m *ChargeUsageBasedRunsMutation) Field(name string) (ent.Value, bool) {
 		return m.LineID()
 	case chargeusagebasedruns.FieldMeteredQuantity:
 		return m.MeteredQuantity()
+	case chargeusagebasedruns.FieldNoFiatTransactionRequired:
+		return m.NoFiatTransactionRequired()
 	}
 	return nil, false
 }
@@ -63151,6 +63531,8 @@ func (m *ChargeUsageBasedRunsMutation) OldField(ctx context.Context, name string
 		return m.OldLineID(ctx)
 	case chargeusagebasedruns.FieldMeteredQuantity:
 		return m.OldMeteredQuantity(ctx)
+	case chargeusagebasedruns.FieldNoFiatTransactionRequired:
+		return m.OldNoFiatTransactionRequired(ctx)
 	}
 	return nil, fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)
 }
@@ -63300,6 +63682,13 @@ func (m *ChargeUsageBasedRunsMutation) SetField(name string, value ent.Value) er
 		}
 		m.SetMeteredQuantity(v)
 		return nil
+	case chargeusagebasedruns.FieldNoFiatTransactionRequired:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetNoFiatTransactionRequired(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)
 }
@@ -63424,13 +63813,16 @@ func (m *ChargeUsageBasedRunsMutation) ResetField(name string) error {
 	case chargeusagebasedruns.FieldMeteredQuantity:
 		m.ResetMeteredQuantity()
 		return nil
+	case chargeusagebasedruns.FieldNoFiatTransactionRequired:
+		m.ResetNoFiatTransactionRequired()
+		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRuns field %s", name)
 }
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *ChargeUsageBasedRunsMutation) AddedEdges() []string {
-	edges := make([]string, 0, 7)
+	edges := make([]string, 0, 8)
 	if m.usage_based != nil {
 		edges = append(edges, chargeusagebasedruns.EdgeUsageBased)
 	}
@@ -63445,6 +63837,9 @@ func (m *ChargeUsageBasedRunsMutation) AddedEdges() []string {
 	}
 	if m.detailed_lines != nil {
 		edges = append(edges, chargeusagebasedruns.EdgeDetailedLines)
+	}
+	if m.corrected_detailed_lines != nil {
+		edges = append(edges, chargeusagebasedruns.EdgeCorrectedDetailedLines)
 	}
 	if m.invoiced_usage != nil {
 		edges = append(edges, chargeusagebasedruns.EdgeInvoicedUsage)
@@ -63483,6 +63878,12 @@ func (m *ChargeUsageBasedRunsMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case chargeusagebasedruns.EdgeCorrectedDetailedLines:
+		ids := make([]ent.Value, 0, len(m.corrected_detailed_lines))
+		for id := range m.corrected_detailed_lines {
+			ids = append(ids, id)
+		}
+		return ids
 	case chargeusagebasedruns.EdgeInvoicedUsage:
 		if id := m.invoiced_usage; id != nil {
 			return []ent.Value{*id}
@@ -63497,12 +63898,15 @@ func (m *ChargeUsageBasedRunsMutation) AddedIDs(name string) []ent.Value {
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *ChargeUsageBasedRunsMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 7)
+	edges := make([]string, 0, 8)
 	if m.removedcredit_allocations != nil {
 		edges = append(edges, chargeusagebasedruns.EdgeCreditAllocations)
 	}
 	if m.removeddetailed_lines != nil {
 		edges = append(edges, chargeusagebasedruns.EdgeDetailedLines)
+	}
+	if m.removedcorrected_detailed_lines != nil {
+		edges = append(edges, chargeusagebasedruns.EdgeCorrectedDetailedLines)
 	}
 	return edges
 }
@@ -63523,13 +63927,19 @@ func (m *ChargeUsageBasedRunsMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case chargeusagebasedruns.EdgeCorrectedDetailedLines:
+		ids := make([]ent.Value, 0, len(m.removedcorrected_detailed_lines))
+		for id := range m.removedcorrected_detailed_lines {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *ChargeUsageBasedRunsMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 7)
+	edges := make([]string, 0, 8)
 	if m.clearedusage_based {
 		edges = append(edges, chargeusagebasedruns.EdgeUsageBased)
 	}
@@ -63544,6 +63954,9 @@ func (m *ChargeUsageBasedRunsMutation) ClearedEdges() []string {
 	}
 	if m.cleareddetailed_lines {
 		edges = append(edges, chargeusagebasedruns.EdgeDetailedLines)
+	}
+	if m.clearedcorrected_detailed_lines {
+		edges = append(edges, chargeusagebasedruns.EdgeCorrectedDetailedLines)
 	}
 	if m.clearedinvoiced_usage {
 		edges = append(edges, chargeusagebasedruns.EdgeInvoicedUsage)
@@ -63568,6 +63981,8 @@ func (m *ChargeUsageBasedRunsMutation) EdgeCleared(name string) bool {
 		return m.clearedcredit_allocations
 	case chargeusagebasedruns.EdgeDetailedLines:
 		return m.cleareddetailed_lines
+	case chargeusagebasedruns.EdgeCorrectedDetailedLines:
+		return m.clearedcorrected_detailed_lines
 	case chargeusagebasedruns.EdgeInvoicedUsage:
 		return m.clearedinvoiced_usage
 	case chargeusagebasedruns.EdgePayment:
@@ -63617,6 +64032,9 @@ func (m *ChargeUsageBasedRunsMutation) ResetEdge(name string) error {
 		return nil
 	case chargeusagebasedruns.EdgeDetailedLines:
 		m.ResetDetailedLines()
+		return nil
+	case chargeusagebasedruns.EdgeCorrectedDetailedLines:
+		m.ResetCorrectedDetailedLines()
 		return nil
 	case chargeusagebasedruns.EdgeInvoicedUsage:
 		m.ResetInvoicedUsage()

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -1166,6 +1166,10 @@ func init() {
 	chargeflatfeedetailedline.DefaultUpdatedAt = chargeflatfeedetailedlineDescUpdatedAt.Default.(func() time.Time)
 	// chargeflatfeedetailedline.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	chargeflatfeedetailedline.UpdateDefaultUpdatedAt = chargeflatfeedetailedlineDescUpdatedAt.UpdateDefault.(func() time.Time)
+	// chargeflatfeedetailedlineDescPricerReferenceID is the schema descriptor for pricer_reference_id field.
+	chargeflatfeedetailedlineDescPricerReferenceID := chargeflatfeedetailedlineFields[1].Descriptor()
+	// chargeflatfeedetailedline.PricerReferenceIDValidator is a validator for the "pricer_reference_id" field. It is called by the builders before save.
+	chargeflatfeedetailedline.PricerReferenceIDValidator = chargeflatfeedetailedlineDescPricerReferenceID.Validators[0].(func(string) error)
 	// chargeflatfeedetailedlineDescID is the schema descriptor for id field.
 	chargeflatfeedetailedlineDescID := chargeflatfeedetailedlineMixinFields0[15].Descriptor()
 	// chargeflatfeedetailedline.DefaultID holds the default value on creation for the id field.
@@ -1271,7 +1275,7 @@ func init() {
 	// chargeusagebased.FeatureIDValidator is a validator for the "feature_id" field. It is called by the builders before save.
 	chargeusagebased.FeatureIDValidator = chargeusagebasedDescFeatureID.Validators[0].(func(string) error)
 	// chargeusagebasedDescPrice is the schema descriptor for price field.
-	chargeusagebasedDescPrice := chargeusagebasedFields[5].Descriptor()
+	chargeusagebasedDescPrice := chargeusagebasedFields[6].Descriptor()
 	chargeusagebased.ValueScanner.Price = chargeusagebasedDescPrice.ValueScanner.(field.TypeValueScanner[*productcatalog.Price])
 	// chargeusagebasedDescID is the schema descriptor for id field.
 	chargeusagebasedDescID := chargeusagebasedMixinFields0[18].Descriptor()
@@ -1339,6 +1343,14 @@ func init() {
 	chargeusagebasedrundetailedline.DefaultUpdatedAt = chargeusagebasedrundetailedlineDescUpdatedAt.Default.(func() time.Time)
 	// chargeusagebasedrundetailedline.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	chargeusagebasedrundetailedline.UpdateDefaultUpdatedAt = chargeusagebasedrundetailedlineDescUpdatedAt.UpdateDefault.(func() time.Time)
+	// chargeusagebasedrundetailedlineDescPricerReferenceID is the schema descriptor for pricer_reference_id field.
+	chargeusagebasedrundetailedlineDescPricerReferenceID := chargeusagebasedrundetailedlineFields[2].Descriptor()
+	// chargeusagebasedrundetailedline.PricerReferenceIDValidator is a validator for the "pricer_reference_id" field. It is called by the builders before save.
+	chargeusagebasedrundetailedline.PricerReferenceIDValidator = chargeusagebasedrundetailedlineDescPricerReferenceID.Validators[0].(func(string) error)
+	// chargeusagebasedrundetailedlineDescCorrectsRunID is the schema descriptor for corrects_run_id field.
+	chargeusagebasedrundetailedlineDescCorrectsRunID := chargeusagebasedrundetailedlineFields[3].Descriptor()
+	// chargeusagebasedrundetailedline.CorrectsRunIDValidator is a validator for the "corrects_run_id" field. It is called by the builders before save.
+	chargeusagebasedrundetailedline.CorrectsRunIDValidator = chargeusagebasedrundetailedlineDescCorrectsRunID.Validators[0].(func(string) error)
 	// chargeusagebasedrundetailedlineDescID is the schema descriptor for id field.
 	chargeusagebasedrundetailedlineDescID := chargeusagebasedrundetailedlineMixinFields0[15].Descriptor()
 	// chargeusagebasedrundetailedline.DefaultID holds the default value on creation for the id field.

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -3379,6 +3379,20 @@ func (u *ChargeUsageBasedRunDetailedLineUpdateOne) SetOrClearDescription(value *
 	return u.SetDescription(*value)
 }
 
+func (u *ChargeUsageBasedRunDetailedLineUpdate) SetOrClearCorrectsRunID(value *string) *ChargeUsageBasedRunDetailedLineUpdate {
+	if value == nil {
+		return u.ClearCorrectsRunID()
+	}
+	return u.SetCorrectsRunID(*value)
+}
+
+func (u *ChargeUsageBasedRunDetailedLineUpdateOne) SetOrClearCorrectsRunID(value *string) *ChargeUsageBasedRunDetailedLineUpdateOne {
+	if value == nil {
+		return u.ClearCorrectsRunID()
+	}
+	return u.SetCorrectsRunID(*value)
+}
+
 func (u *ChargeUsageBasedRunInvoicedUsageUpdate) SetOrClearLineID(value *string) *ChargeUsageBasedRunInvoicedUsageUpdate {
 	if value == nil {
 		return u.ClearLineID()

--- a/openmeter/ent/schema/chargesflatfee.go
+++ b/openmeter/ent/schema/chargesflatfee.go
@@ -153,6 +153,9 @@ func (ChargeFlatFeeDetailedLine) Fields() []ent.Field {
 			SchemaType(map[string]string{
 				dialect.Postgres: "char(26)",
 			}),
+
+		field.String("pricer_reference_id").
+			NotEmpty(),
 	}
 }
 

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -59,6 +59,9 @@ func (ChargeUsageBased) Fields() []ent.Field {
 				dialect.Postgres: "char(26)",
 			}),
 
+		field.Enum("rating_engine").
+			GoType(usagebased.RatingEngine("")),
+
 		field.String("price").
 			GoType(&productcatalog.Price{}).
 			ValueScanner(PriceValueScanner).
@@ -191,6 +194,8 @@ func (ChargeUsageBasedRuns) Fields() []ent.Field {
 			SchemaType(map[string]string{
 				dialect.Postgres: "numeric",
 			}),
+
+		field.Bool("no_fiat_transaction_required"),
 	}
 }
 
@@ -218,6 +223,9 @@ func (ChargeUsageBasedRuns) Edges() []ent.Edge {
 			Annotations(entsql.OnDelete(entsql.Cascade)),
 		edge.To("detailed_lines", ChargeUsageBasedRunDetailedLine.Type).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
+		edge.To("corrected_detailed_lines", ChargeUsageBasedRunDetailedLine.Type).
+			StorageKey(edge.Symbol("cub_run_corrected_detailed_lines")).
+			Annotations(entsql.OnDelete(entsql.SetNull)),
 		edge.To("invoiced_usage", ChargeUsageBasedRunInvoicedUsage.Type).
 			Unique().
 			Annotations(entsql.OnDelete(entsql.Cascade)),
@@ -254,6 +262,17 @@ func (ChargeUsageBasedRunDetailedLine) Fields() []ent.Field {
 			SchemaType(map[string]string{
 				dialect.Postgres: "char(26)",
 			}),
+
+		field.String("pricer_reference_id").
+			NotEmpty(),
+
+		field.String("corrects_run_id").
+			SchemaType(map[string]string{
+				dialect.Postgres: "char(26)",
+			}).
+			Optional().
+			NotEmpty().
+			Nillable(),
 	}
 }
 
@@ -269,6 +288,11 @@ func (ChargeUsageBasedRunDetailedLine) Edges() []ent.Edge {
 			Field("run_id").
 			Unique().
 			Required(),
+		edge.From("corrects_run", ChargeUsageBasedRuns.Type).
+			Ref("corrected_detailed_lines").
+			Field("corrects_run_id").
+			Unique().
+			Annotations(entsql.OnDelete(entsql.SetNull)),
 		edge.From("tax_code", TaxCode.Type).
 			Ref("charge_usage_based_run_detailed_lines").
 			Field("tax_code_id").

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -522,7 +522,8 @@ func (e *usageBasedHandlerTestEnv) newCharge(settlementMode productcatalog.Settl
 			},
 			Status: chargeusagebased.StatusActiveFinalRealizationProcessing,
 			State: chargeusagebased.State{
-				FeatureID: featureID,
+				FeatureID:    featureID,
+				RatingEngine: chargeusagebased.RatingEngineDelta,
 			},
 		},
 	}

--- a/tools/migrate/migrations/20260506102300_add_usage_based_detailed_line_corrects_run_id.down.sql
+++ b/tools/migrate/migrations/20260506102300_add_usage_based_detailed_line_corrects_run_id.down.sql
@@ -1,0 +1,8 @@
+-- reverse: modify "charge_usage_based_run_detailed_line" table
+ALTER TABLE "charge_usage_based_run_detailed_line" DROP CONSTRAINT "cub_run_corrected_detailed_lines", DROP COLUMN "corrects_run_id", DROP COLUMN "pricer_reference_id";
+-- reverse: modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" DROP COLUMN "no_fiat_transaction_required";
+-- reverse: modify "charge_usage_based" table
+ALTER TABLE "charge_usage_based" DROP COLUMN "rating_engine";
+-- reverse: modify "charge_flat_fee_detailed_line" table
+ALTER TABLE "charge_flat_fee_detailed_line" DROP COLUMN "pricer_reference_id";

--- a/tools/migrate/migrations/20260506102300_add_usage_based_detailed_line_corrects_run_id.up.sql
+++ b/tools/migrate/migrations/20260506102300_add_usage_based_detailed_line_corrects_run_id.up.sql
@@ -1,0 +1,16 @@
+-- modify "charge_flat_fee_detailed_line" table
+ALTER TABLE "charge_flat_fee_detailed_line" ADD COLUMN "pricer_reference_id" character varying;
+UPDATE "charge_flat_fee_detailed_line" SET "pricer_reference_id" = "child_unique_reference_id" WHERE "pricer_reference_id" IS NULL;
+ALTER TABLE "charge_flat_fee_detailed_line" ALTER COLUMN "pricer_reference_id" SET NOT NULL;
+-- modify "charge_usage_based" table
+ALTER TABLE "charge_usage_based" ADD COLUMN "rating_engine" character varying;
+UPDATE "charge_usage_based" SET "rating_engine" = 'delta' WHERE "rating_engine" IS NULL;
+ALTER TABLE "charge_usage_based" ALTER COLUMN "rating_engine" SET NOT NULL;
+-- modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" ADD COLUMN "no_fiat_transaction_required" boolean NOT NULL DEFAULT false;
+UPDATE "charge_usage_based_runs" AS r SET "no_fiat_transaction_required" = true FROM "charge_usage_based" AS c WHERE r."charge_id" = c."id" AND c."settlement_mode" = 'credit_only';
+ALTER TABLE "charge_usage_based_runs" ALTER COLUMN "no_fiat_transaction_required" DROP DEFAULT;
+-- modify "charge_usage_based_run_detailed_line" table
+ALTER TABLE "charge_usage_based_run_detailed_line" ADD COLUMN "pricer_reference_id" character varying, ADD COLUMN "corrects_run_id" character(26) NULL, ADD CONSTRAINT "cub_run_corrected_detailed_lines" FOREIGN KEY ("corrects_run_id") REFERENCES "charge_usage_based_runs" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;
+UPDATE "charge_usage_based_run_detailed_line" SET "pricer_reference_id" = "child_unique_reference_id" WHERE "pricer_reference_id" IS NULL;
+ALTER TABLE "charge_usage_based_run_detailed_line" ALTER COLUMN "pricer_reference_id" SET NOT NULL;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:F7HXXWG69yIAHauA7NOTJCzjqlTFbmj3N5eUtVuF+B8=
+h1:RmMiS2/dQS73aqJ6v0+kxlKOZOEuHtNrLfwTEHz6ZMM=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -191,3 +191,4 @@ h1:F7HXXWG69yIAHauA7NOTJCzjqlTFbmj3N5eUtVuF+B8=
 20260430095237_add_credit_realization_lineage_segment_source.up.sql h1:hp/S1jNs0MYQL+GSdLaDea2DmBct2CU8Rk2P7hK4qEE=
 20260502093117_distributed_locks.up.sql h1:fCZntakx52oo1fal4ymjjoCUpRK57gmKN18BLJd0Eow=
 20260506082128_add_organization_default_tax_codes.up.sql h1:DA4FrNmvWRnFbH5z/4TthG8K1Zfxw9kF5YRJV1MUv8s=
+20260506102300_add_usage_based_detailed_line_corrects_run_id.up.sql h1:7Y4GUjTD7V5w5dEEdJsN5XoiUZswvg42Srjo7VHPabc=


### PR DESCRIPTION
## Overview

This PR adds the usage-based charge scaffolding needed to make charge-owned realization runs map cleanly into billing standard invoice lines, while keeping rating behavior on the existing billing rating path.

Note: this PR uses the stock billingrating, the final delta engine is available here: https://github.com/openmeterio/openmeter/pull/4298

  ## Changed Behavior

  - Usage-based charge runs now persist enough metadata to reconstruct billing-facing invoice lines from charge realization state:
    - run detailed-line pricer reference IDs (will be required for late events`)
    - correction metadata (`corrects_run_id`) (will be needed for pro-rating)
    - run-level `no_fiat_transaction_required` (so that we don't start payment/invoice accrued ledger flow when not needed)
    - selected rating engine metadata, defaulted to `delta`

  - Usage-based standard invoice lines are now populated from realization runs instead of being recalculated through the generic billing line calculator (but the current implementation uses billing's rating in passthru).
    - Raw cumulative run quantities are mapped into billing line-period and pre-line-period quantities.
    - Usage discounts are communicated through the same standard billing usage-discount structure.
    - Run credits are projected onto the resulting billing line and detailed lines.

  - Charge line engines no longer have to implement billing recalculation.
    - `billing.LineCalculator` is split out from `billing.LineEngine`.
    - Invoice calculation skips engines that do not implement `LineCalculator`, expecting lifecycle hooks to return fully calculated lines.

  - Zero-fiat usage-based runs are handled explicitly.
    - `credit_only` runs always mark `NoFiatTransactionRequired`.
    - `credit_then_invoice` runs derive it from zero totals.
    - Invoice usage booking and payment authorization/settlement skip fiat ledger booking when the run is explicitly marked no-fiat.

  - Billing rating now supports disabling the credits mutator for charge-owned rating passes.
    - Charge rating totals remain gross before charge credit allocation.
    - Credits are applied later by the charge lifecycle.

  ## Migration

  Adds a new coalesced migration for:
  - `charge_usage_based.rating_engine`
  - `charge_usage_based_runs.no_fiat_transaction_required`
  - `charge_flat_fee_detailed_line.pricer_reference_id`
  - `charge_usage_based_run_detailed_line.pricer_reference_id`
  - `charge_usage_based_run_detailed_line.corrects_run_id`

  The migration backfills:
  - existing usage-based charges to `rating_engine = 'delta'`
  - detailed-line `pricer_reference_id` from `child_unique_reference_id`
  - existing `credit_only` usage-based runs to `no_fiat_transaction_required = true`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multiple rating engines for usage-based billing
  * Refined usage-based quantity semantics and progressive billing mapping
  * Detailed-line enhancements: pricer reference IDs, correction linkage, and a no‑fiat/zero‑total invoice path

* **Documentation**
  * Expanded lifecycle, invoice-line mapping, discounts, and detailed-line expansion guidance
  * Cross-documentation guideline for rating algorithm changes

* **Bug Fixes**
  * Typo fixed in billing README ("substracting" → "subtracting")
<!-- end of auto-generated comment: release notes by coderabbit.ai -->