### PR TITLE
feat: delete usage-based pending invoice lines by charge

### DIFF
--- a/openmeter/billing/charges/invoiceupdater/feehelper.go
+++ b/openmeter/billing/charges/invoiceupdater/feehelper.go
@@ -1,0 +1,62 @@
+package invoiceupdater
+
+import (
+	"fmt"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+)
+
+func IsFlatFee(line billing.GenericInvoiceLineReader) bool {
+	if line == nil {
+		return false
+	}
+
+	price := line.GetPrice()
+	if price == nil {
+		return false
+	}
+
+	return price.Type() == productcatalog.FlatPriceType
+}
+
+func GetFlatFeePerUnitAmount(line billing.GenericInvoiceLineReader) (alpacadecimal.Decimal, error) {
+	if line == nil {
+		return alpacadecimal.Zero, fmt.Errorf("line is nil")
+	}
+
+	price := line.GetPrice()
+	if price == nil {
+		return alpacadecimal.Zero, fmt.Errorf("line misses usage based metadata")
+	}
+
+	flatPrice, err := price.AsFlat()
+	if err != nil {
+		return alpacadecimal.Zero, err
+	}
+
+	return flatPrice.Amount, nil
+}
+
+func SetFlatFeePerUnitAmount(line billing.GenericInvoiceLine, perUnitAmount alpacadecimal.Decimal) error {
+	if line == nil {
+		return fmt.Errorf("line is nil")
+	}
+
+	price := line.GetPrice()
+	if price == nil {
+		return fmt.Errorf("line misses usage based metadata")
+	}
+
+	flatPrice, err := price.AsFlat()
+	if err != nil {
+		return err
+	}
+
+	flatPrice.Amount = perUnitAmount
+	line.SetPrice(lo.FromPtr(productcatalog.NewPriceFrom(flatPrice)))
+	return nil
+}

--- a/openmeter/billing/charges/invoiceupdater/feehelper.go
+++ b/openmeter/billing/charges/invoiceupdater/feehelper.go
@@ -30,7 +30,7 @@ func GetFlatFeePerUnitAmount(line billing.GenericInvoiceLineReader) (alpacadecim
 
 	price := line.GetPrice()
 	if price == nil {
-		return alpacadecimal.Zero, fmt.Errorf("line misses usage based metadata")
+		return alpacadecimal.Zero, fmt.Errorf("line missing flat-fee metadata")
 	}
 
 	flatPrice, err := price.AsFlat()
@@ -48,7 +48,7 @@ func SetFlatFeePerUnitAmount(line billing.GenericInvoiceLine, perUnitAmount alpa
 
 	price := line.GetPrice()
 	if price == nil {
-		return fmt.Errorf("line misses usage based metadata")
+		return fmt.Errorf("line missing flat-fee metadata")
 	}
 
 	flatPrice, err := price.AsFlat()

--- a/openmeter/billing/charges/invoiceupdater/invoiceupdate.go
+++ b/openmeter/billing/charges/invoiceupdater/invoiceupdate.go
@@ -1,0 +1,505 @@
+package invoiceupdater
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+const invoiceUpdaterComponentName billing.ComponentName = "charges.invoiceupdater"
+
+type Updater struct {
+	billingService billing.Service
+	logger         *slog.Logger
+}
+
+func New(billingService billing.Service, logger *slog.Logger) *Updater {
+	return &Updater{
+		billingService: billingService,
+		logger:         logger,
+	}
+}
+
+func (u *Updater) ApplyPatches(ctx context.Context, customerID customer.CustomerID, patches []Patch) error {
+	patchesParsed, err := u.parsePatches(patches)
+	if err != nil {
+		return fmt.Errorf("parsing patches: %w", err)
+	}
+
+	err = u.provisionUpcomingLines(ctx, customerID, patchesParsed.newLines)
+	if err != nil {
+		return fmt.Errorf("provisioning upcoming lines: %w", err)
+	}
+
+	for invoiceID, linePatches := range patchesParsed.updatedLinesByInvoiceID {
+		namespacedInvoiceID := billing.InvoiceID{
+			Namespace: customerID.Namespace,
+			ID:        invoiceID,
+		}
+
+		invoice, err := u.billingService.GetInvoiceById(ctx, billing.GetInvoiceByIdInput{
+			Invoice: namespacedInvoiceID,
+		})
+		if err != nil {
+			return fmt.Errorf("getting invoice: %w", err)
+		}
+
+		if invoice.Type() == billing.InvoiceTypeGathering {
+			if err := u.updateGatheringInvoice(ctx, namespacedInvoiceID, linePatches); err != nil {
+				return fmt.Errorf("updating gathering invoice: %w", err)
+			}
+
+			continue
+		}
+
+		standardInvoice, err := invoice.AsStandardInvoice()
+		if err != nil {
+			return fmt.Errorf("converting invoice to standard invoice: %w", err)
+		}
+
+		if !standardInvoice.StatusDetails.Immutable {
+			if err := u.updateMutableStandardInvoice(ctx, standardInvoice, linePatches); err != nil {
+				return fmt.Errorf("updating mutable invoice: %w", err)
+			}
+
+			continue
+		}
+
+		if err := u.updateImmutableInvoice(ctx, standardInvoice, linePatches); err != nil {
+			return fmt.Errorf("updating immutable invoice: %w", err)
+		}
+	}
+
+	err = u.upsertSplitLineGroups(ctx, customerID, patchesParsed.splitLineGroups)
+	if err != nil {
+		return fmt.Errorf("upserting split line groups: %w", err)
+	}
+
+	return nil
+}
+
+func (u *Updater) LogPatches(patches []Patch, invoicesByID map[string]billing.Invoice) {
+	suppressedDryRunPatches := 0
+
+	for _, patch := range patches {
+		if !isDryRunLoggablePatch(patch, invoicesByID) {
+			suppressedDryRunPatches++
+			continue
+		}
+
+		patch.Log(u.logger)
+	}
+
+	if suppressedDryRunPatches > 0 {
+		u.logger.Info("suppressed dry run patches", "count", suppressedDryRunPatches)
+	}
+}
+
+func isDryRunLoggablePatch(patch Patch, invoicesByID map[string]billing.Invoice) bool {
+	switch patch.Op() {
+	case PatchOpLineCreate:
+		createPatch, err := patch.AsCreateLinePatch()
+		if err != nil {
+			return true
+		}
+
+		// Missing current-period pending lines are expected catch-up work for subscription
+		// sync. Dry-run output should focus on actionable drift on already materialized
+		// resources, so we suppress create-line logs only when they belong to the current
+		// billing period.
+		return !isCurrentBillingPeriod(createPatch.Line)
+	case PatchOpLineDelete:
+		deletePatch, err := patch.AsDeleteLinePatch()
+		if err != nil {
+			return true
+		}
+
+		return isMutableInvoice(deletePatch.InvoiceID, invoicesByID)
+	case PatchOpLineUpdate:
+		updatePatch, err := patch.AsUpdateLinePatch()
+		if err != nil {
+			return true
+		}
+
+		return isMutableInvoice(updatePatch.TargetState.GetInvoiceID(), invoicesByID)
+	default:
+		return true
+	}
+}
+
+func isCurrentBillingPeriod(line billing.GatheringLine) bool {
+	subscriptionRef := line.GetSubscriptionReference()
+	if subscriptionRef == nil {
+		return false
+	}
+
+	now := clock.Now().UTC()
+	billingPeriod := subscriptionRef.BillingPeriod
+
+	return !now.Before(billingPeriod.From) && now.Before(billingPeriod.To)
+}
+
+func isMutableInvoice(invoiceID string, invoicesByID map[string]billing.Invoice) bool {
+	invoice, ok := invoicesByID[invoiceID]
+	if !ok {
+		return true
+	}
+
+	if invoice.Type() == billing.InvoiceTypeGathering {
+		return true
+	}
+
+	standardInvoice, err := invoice.AsStandardInvoice()
+	if err != nil {
+		return true
+	}
+
+	return !standardInvoice.StatusDetails.Immutable
+}
+
+type patchesParsed struct {
+	newLines []billing.GatheringLine
+
+	updatedLinesByInvoiceID map[string]invoicePatches
+
+	splitLineGroups splitLineGroupPatches
+}
+
+type invoicePatches struct {
+	updatedLines []billing.GenericInvoiceLine
+	deletedLines []billing.LineID
+}
+
+type splitLineGroupPatches struct {
+	deleted []models.NamespacedID
+	updated []billing.SplitLineGroupUpdate
+}
+
+func (u *Updater) parsePatches(patches []Patch) (patchesParsed, error) {
+	parsed := patchesParsed{
+		updatedLinesByInvoiceID: make(map[string]invoicePatches),
+	}
+
+	for _, patch := range patches {
+		switch patch.Op() {
+		case PatchOpLineCreate:
+			create, err := patch.AsCreateLinePatch()
+			if err != nil {
+				return patchesParsed{}, fmt.Errorf("getting line: %w", err)
+			}
+
+			parsed.newLines = append(parsed.newLines, create.Line)
+		case PatchOpLineDelete:
+			deletePatch, err := patch.AsDeleteLinePatch()
+			if err != nil {
+				return patchesParsed{}, fmt.Errorf("getting line: %w", err)
+			}
+
+			lineUpdates := parsed.updatedLinesByInvoiceID[deletePatch.InvoiceID]
+			lineUpdates.deletedLines = append(lineUpdates.deletedLines, deletePatch.Line)
+			parsed.updatedLinesByInvoiceID[deletePatch.InvoiceID] = lineUpdates
+		case PatchOpLineUpdate:
+			update, err := patch.AsUpdateLinePatch()
+			if err != nil {
+				return patchesParsed{}, fmt.Errorf("getting line: %w", err)
+			}
+
+			lineUpdates := parsed.updatedLinesByInvoiceID[update.TargetState.GetInvoiceID()]
+			lineUpdates.updatedLines = append(lineUpdates.updatedLines, update.TargetState)
+			parsed.updatedLinesByInvoiceID[update.TargetState.GetInvoiceID()] = lineUpdates
+		default:
+			return patchesParsed{}, fmt.Errorf("unexpected patch operation: %s", patch.Op())
+		}
+	}
+
+	return parsed, nil
+}
+
+func (u *Updater) provisionUpcomingLines(ctx context.Context, customerID customer.CustomerID, lines []billing.GatheringLine) error {
+	if len(lines) == 0 {
+		return nil
+	}
+
+	linesByCurrency := lo.GroupBy(lines, func(l billing.GatheringLine) currencyx.Code {
+		return l.Currency
+	})
+
+	for currency, lines := range linesByCurrency {
+		_, err := u.billingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+			Customer: customerID,
+			Currency: currency,
+			Lines:    lines,
+		})
+		if err != nil {
+			return fmt.Errorf("creating pending invoice lines: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (u *Updater) updateMutableStandardInvoice(ctx context.Context, invoice billing.StandardInvoice, linePatches invoicePatches) error {
+	updatedInvoice, err := u.billingService.UpdateStandardInvoice(ctx, billing.UpdateStandardInvoiceInput{
+		Invoice:             invoice.GetInvoiceID(),
+		IncludeDeletedLines: true,
+		EditFn: func(invoice *billing.StandardInvoice) error {
+			for _, lineID := range linePatches.deletedLines {
+				line := invoice.Lines.GetByID(lineID.ID)
+				if line == nil {
+					return fmt.Errorf("line[%s] not found in the invoice, cannot delete", lineID)
+				}
+
+				line.DeletedAt = lo.ToPtr(clock.Now())
+			}
+
+			for _, targetState := range linePatches.updatedLines {
+				targetStandardLine, err := targetState.AsInvoiceLine().AsStandardLine()
+				if err != nil {
+					return fmt.Errorf("line[%s] is not a standard line, cannot update: %w", targetState.GetID(), err)
+				}
+
+				line := invoice.Lines.GetByID(targetStandardLine.ID)
+				if line == nil {
+					return fmt.Errorf("line[%s] not found in the invoice, cannot update", targetStandardLine.ID)
+				}
+
+				updatedQtyLine, err := u.billingService.SnapshotLineQuantity(ctx, billing.SnapshotLineQuantityInput{
+					Invoice: invoice,
+					Line:    &targetStandardLine,
+				})
+				if err != nil {
+					return fmt.Errorf("recalculating line[%s]: %w", targetStandardLine.ID, err)
+				}
+
+				targetStandardLine = *updatedQtyLine
+
+				if ok := invoice.Lines.ReplaceByID(targetStandardLine.ID, &targetStandardLine); !ok {
+					return fmt.Errorf("line[%s/%s] not found in the invoice, cannot update", targetStandardLine.ID, lo.FromPtrOr(targetStandardLine.ChildUniqueReferenceID, "nil"))
+				}
+			}
+
+			return nil
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("updating invoice[%s]: %w", invoice.ID, err)
+	}
+
+	if updatedInvoice.Lines.NonDeletedLineCount() == 0 {
+		if updatedInvoice.Status == billing.StandardInvoiceStatusGathering {
+			return nil
+		}
+
+		invoice, err := u.billingService.DeleteInvoice(ctx, updatedInvoice.GetInvoiceID())
+		if err != nil {
+			return fmt.Errorf("deleting empty invoice: %w", err)
+		}
+
+		if invoice.Status == billing.StandardInvoiceStatusDeleteFailed {
+			u.logger.WarnContext(ctx, "empty invoice deletion failed",
+				"invoice.id", invoice.ID,
+				"invoice.namespace", invoice.Namespace,
+				"validation_issues", strings.Join(
+					lo.Map(invoice.ValidationIssues, func(i billing.ValidationIssue, _ int) string {
+						return fmt.Sprintf("[id=%s] %s: %s", i.ID, i.Code, i.Message)
+					}),
+					", "))
+		}
+	}
+
+	return err
+}
+
+func (u *Updater) updateGatheringInvoice(ctx context.Context, invoiceID billing.InvoiceID, linePatches invoicePatches) error {
+	return u.billingService.UpdateGatheringInvoice(ctx, billing.UpdateGatheringInvoiceInput{
+		Invoice:             invoiceID,
+		IncludeDeletedLines: true,
+		EditFn: func(invoice *billing.GatheringInvoice) error {
+			for _, lineID := range linePatches.deletedLines {
+				line, ok := invoice.Lines.GetByID(lineID.ID)
+				if !ok {
+					return fmt.Errorf("line[%s] not found in the invoice, cannot delete", lineID)
+				}
+
+				line.DeletedAt = lo.ToPtr(clock.Now())
+
+				if err := invoice.Lines.ReplaceByID(line); err != nil {
+					return fmt.Errorf("setting line[%s]: %w", lineID, err)
+				}
+			}
+
+			for _, targetStateGeneric := range linePatches.updatedLines {
+				targetGatheringLine, err := targetStateGeneric.AsInvoiceLine().AsGatheringLine()
+				if err != nil {
+					return fmt.Errorf("line[%s] is not a gathering line, cannot update: %w", targetStateGeneric.GetID(), err)
+				}
+
+				if err := invoice.Lines.ReplaceByID(targetGatheringLine); err != nil {
+					return fmt.Errorf("setting line[%s]: %w", targetGatheringLine.ID, err)
+				}
+			}
+
+			return nil
+		},
+	})
+}
+
+func (u *Updater) updateImmutableInvoice(ctx context.Context, invoice billing.StandardInvoice, linePatches invoicePatches) error {
+	invoice, err := u.billingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+		Invoice: invoice.GetInvoiceID(),
+		Expand:  billing.StandardInvoiceExpandAll,
+	})
+	if err != nil {
+		return fmt.Errorf("getting invoice: %w", err)
+	}
+
+	validationIssues := []billing.ValidationIssue{}
+
+	for _, line := range linePatches.deletedLines {
+		validationIssues = append(validationIssues,
+			newValidationIssueOnLine(invoice.Lines.GetByID(line.ID), "line should be deleted, but the invoice is immutable"),
+		)
+	}
+
+	for _, targetState := range linePatches.updatedLines {
+		existingLine := invoice.Lines.GetByID(targetState.GetID())
+		if existingLine == nil {
+			return fmt.Errorf("line[%s] not found in the invoice, cannot update", targetState.GetID())
+		}
+
+		if IsFlatFee(targetState) {
+			existingPerUnitAmount, err := GetFlatFeePerUnitAmount(existingLine)
+			if err != nil {
+				return fmt.Errorf("getting flat fee per unit amount: %w", err)
+			}
+
+			targetPerUnitAmount, err := GetFlatFeePerUnitAmount(targetState)
+			if err != nil {
+				return fmt.Errorf("getting flat fee per unit amount: %w", err)
+			}
+
+			if !existingPerUnitAmount.Equal(targetPerUnitAmount) {
+				validationIssues = append(validationIssues,
+					newValidationIssueOnLine(existingLine, "flat fee line's per unit amount cannot be changed on immutable invoice (new per unit amount: %s)",
+						targetPerUnitAmount.String()),
+				)
+
+				continue
+			}
+
+			if !targetState.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration).Equal(existingLine.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration)) {
+				validationIssues = append(validationIssues,
+					newValidationIssueOnLine(existingLine, "flat fee line's service period cannot be changed on immutable invoice"),
+				)
+			}
+
+			continue
+		}
+
+		if !targetState.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration).Equal(existingLine.GetServicePeriod().Truncate(streaming.MinimumWindowSizeDuration)) {
+			targetStandardLine, err := targetState.AsInvoiceLine().AsStandardLine()
+			if err != nil {
+				return fmt.Errorf("line[%s] is not a standard line, cannot update: %w", targetState.GetID(), err)
+			}
+
+			targetStateWithUpdatedQty, err := u.billingService.SnapshotLineQuantity(ctx, billing.SnapshotLineQuantityInput{
+				Invoice: &invoice,
+				Line:    &targetStandardLine,
+			})
+			if err != nil {
+				return fmt.Errorf("snapshotting quantity for line[%s]: %w", targetState.GetID(), err)
+			}
+
+			if !targetStateWithUpdatedQty.UsageBased.Quantity.Equal(lo.FromPtr(existingLine.UsageBased.Quantity)) {
+				validationIssues = append(validationIssues,
+					newValidationIssueOnLine(existingLine, "usage based line's quantity cannot be changed on immutable invoice (new qty: %s)",
+						targetStateWithUpdatedQty.UsageBased.Quantity.String()),
+				)
+			}
+		}
+	}
+
+	if len(validationIssues) > 0 {
+		mergedValidationIssues, wasChange := u.mergeValidationIssues(invoice, validationIssues)
+		if !wasChange {
+			return nil
+		}
+
+		return u.billingService.UpsertValidationIssues(ctx, billing.UpsertValidationIssuesInput{
+			Invoice: invoice.GetInvoiceID(),
+			Issues:  mergedValidationIssues,
+		})
+	}
+
+	return nil
+}
+
+func newValidationIssueOnLine(line *billing.StandardLine, message string, a ...any) billing.ValidationIssue {
+	if line == nil {
+		return billing.ValidationIssue{
+			Severity:  billing.ValidationIssueSeverityCritical,
+			Message:   "line not found in the invoice, cannot update",
+			Code:      billing.ImmutableInvoiceHandlingNotSupportedErrorCode,
+			Component: invoiceUpdaterComponentName,
+			Path:      "lines/nil",
+		}
+	}
+
+	return billing.ValidationIssue{
+		Severity:  billing.ValidationIssueSeverityWarning,
+		Message:   fmt.Sprintf(message, a...),
+		Code:      billing.ImmutableInvoiceHandlingNotSupportedErrorCode,
+		Component: invoiceUpdaterComponentName,
+		Path:      fmt.Sprintf("lines/%s", line.ID),
+	}
+}
+
+func (u *Updater) mergeValidationIssues(invoice billing.StandardInvoice, issues []billing.ValidationIssue) (billing.ValidationIssues, bool) {
+	changed := false
+
+	for _, issue := range issues {
+		_, found := lo.Find(invoice.ValidationIssues, func(i billing.ValidationIssue) bool {
+			return i.Path == issue.Path && i.Component == invoiceUpdaterComponentName && i.Code == billing.ImmutableInvoiceHandlingNotSupportedErrorCode &&
+				i.Message == issue.Message
+		})
+
+		if found {
+			continue
+		}
+
+		changed = true
+		invoice.ValidationIssues = append(invoice.ValidationIssues, issue)
+	}
+
+	return invoice.ValidationIssues, changed
+}
+
+func (u *Updater) upsertSplitLineGroups(ctx context.Context, customerID customer.CustomerID, changes splitLineGroupPatches) error {
+	if len(changes.deleted) == 0 && len(changes.updated) == 0 {
+		return nil
+	}
+
+	for _, groupID := range changes.deleted {
+		if err := u.billingService.DeleteSplitLineGroup(ctx, groupID); err != nil {
+			return fmt.Errorf("deleting split line group: %w", err)
+		}
+	}
+
+	for _, group := range changes.updated {
+		if _, err := u.billingService.UpdateSplitLineGroup(ctx, group); err != nil {
+			return fmt.Errorf("upserting split line group: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/openmeter/billing/charges/invoiceupdater/invoiceupdate.go
+++ b/openmeter/billing/charges/invoiceupdater/invoiceupdate.go
@@ -13,7 +13,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
-	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 const invoiceUpdaterComponentName billing.ComponentName = "charges.invoiceupdater"
@@ -41,17 +40,20 @@ func (u *Updater) ApplyPatches(ctx context.Context, customerID customer.Customer
 		return fmt.Errorf("provisioning upcoming lines: %w", err)
 	}
 
+	invoicesByID, err := u.listInvoicesByID(ctx, customerID.Namespace, lo.Keys(patchesParsed.updatedLinesByInvoiceID))
+	if err != nil {
+		return fmt.Errorf("listing invoices: %w", err)
+	}
+
 	for invoiceID, linePatches := range patchesParsed.updatedLinesByInvoiceID {
 		namespacedInvoiceID := billing.InvoiceID{
 			Namespace: customerID.Namespace,
 			ID:        invoiceID,
 		}
 
-		invoice, err := u.billingService.GetInvoiceById(ctx, billing.GetInvoiceByIdInput{
-			Invoice: namespacedInvoiceID,
-		})
-		if err != nil {
-			return fmt.Errorf("getting invoice: %w", err)
+		invoice, ok := invoicesByID[invoiceID]
+		if !ok {
+			return fmt.Errorf("getting invoice: invoice[%s/%s] not found", customerID.Namespace, invoiceID)
 		}
 
 		if invoice.Type() == billing.InvoiceTypeGathering {
@@ -80,12 +82,34 @@ func (u *Updater) ApplyPatches(ctx context.Context, customerID customer.Customer
 		}
 	}
 
-	err = u.upsertSplitLineGroups(ctx, customerID, patchesParsed.splitLineGroups)
-	if err != nil {
-		return fmt.Errorf("upserting split line groups: %w", err)
+	return nil
+}
+
+func (u *Updater) listInvoicesByID(ctx context.Context, namespace string, invoiceIDs []string) (map[string]billing.Invoice, error) {
+	if len(invoiceIDs) == 0 {
+		return map[string]billing.Invoice{}, nil
 	}
 
-	return nil
+	resp, err := u.billingService.ListInvoices(ctx, billing.ListInvoicesInput{
+		Namespaces:     []string{namespace},
+		IDs:            invoiceIDs,
+		IncludeDeleted: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	invoicesByID := make(map[string]billing.Invoice, len(resp.Items))
+	for _, invoice := range resp.Items {
+		genericInvoice, err := invoice.AsGenericInvoice()
+		if err != nil {
+			return nil, fmt.Errorf("converting invoice to generic invoice: %w", err)
+		}
+
+		invoicesByID[genericInvoice.GetID()] = invoice
+	}
+
+	return invoicesByID, nil
 }
 
 func (u *Updater) LogPatches(patches []Patch, invoicesByID map[string]billing.Invoice) {
@@ -171,18 +195,11 @@ type patchesParsed struct {
 	newLines []billing.GatheringLine
 
 	updatedLinesByInvoiceID map[string]invoicePatches
-
-	splitLineGroups splitLineGroupPatches
 }
 
 type invoicePatches struct {
 	updatedLines []billing.GenericInvoiceLine
 	deletedLines []billing.LineID
-}
-
-type splitLineGroupPatches struct {
-	deleted []models.NamespacedID
-	updated []billing.SplitLineGroupUpdate
 }
 
 func (u *Updater) parsePatches(patches []Patch) (patchesParsed, error) {
@@ -317,7 +334,7 @@ func (u *Updater) updateMutableStandardInvoice(ctx context.Context, invoice bill
 		}
 	}
 
-	return err
+	return nil
 }
 
 func (u *Updater) updateGatheringInvoice(ctx context.Context, invoiceID billing.InvoiceID, linePatches invoicePatches) error {
@@ -420,7 +437,8 @@ func (u *Updater) updateImmutableInvoice(ctx context.Context, invoice billing.St
 				return fmt.Errorf("snapshotting quantity for line[%s]: %w", targetState.GetID(), err)
 			}
 
-			if !targetStateWithUpdatedQty.UsageBased.Quantity.Equal(lo.FromPtr(existingLine.UsageBased.Quantity)) {
+			existingQty := existingLine.UsageBased.Quantity
+			if existingQty == nil || !targetStateWithUpdatedQty.UsageBased.Quantity.Equal(*existingQty) {
 				validationIssues = append(validationIssues,
 					newValidationIssueOnLine(existingLine, "usage based line's quantity cannot be changed on immutable invoice (new qty: %s)",
 						targetStateWithUpdatedQty.UsageBased.Quantity.String()),
@@ -482,24 +500,4 @@ func (u *Updater) mergeValidationIssues(invoice billing.StandardInvoice, issues 
 	}
 
 	return invoice.ValidationIssues, changed
-}
-
-func (u *Updater) upsertSplitLineGroups(ctx context.Context, customerID customer.CustomerID, changes splitLineGroupPatches) error {
-	if len(changes.deleted) == 0 && len(changes.updated) == 0 {
-		return nil
-	}
-
-	for _, groupID := range changes.deleted {
-		if err := u.billingService.DeleteSplitLineGroup(ctx, groupID); err != nil {
-			return fmt.Errorf("deleting split line group: %w", err)
-		}
-	}
-
-	for _, group := range changes.updated {
-		if _, err := u.billingService.UpdateSplitLineGroup(ctx, group); err != nil {
-			return fmt.Errorf("upserting split line group: %w", err)
-		}
-	}
-
-	return nil
 }

--- a/openmeter/billing/charges/invoiceupdater/invoiceupdate.go
+++ b/openmeter/billing/charges/invoiceupdater/invoiceupdate.go
@@ -23,6 +23,10 @@ type Updater struct {
 }
 
 func New(billingService billing.Service, logger *slog.Logger) *Updater {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	return &Updater{
 		billingService: billingService,
 		logger:         logger,
@@ -38,6 +42,10 @@ func (u *Updater) ApplyPatches(ctx context.Context, customerID customer.Customer
 	err = u.provisionUpcomingLines(ctx, customerID, patchesParsed.newLines)
 	if err != nil {
 		return fmt.Errorf("provisioning upcoming lines: %w", err)
+	}
+
+	if err := u.resolveGatheringLineDeletesByChargeID(ctx, customerID, &patchesParsed); err != nil {
+		return fmt.Errorf("resolving gathering line deletes by charge id: %w", err)
 	}
 
 	invoicesByID, err := u.listInvoicesByID(ctx, customerID.Namespace, lo.Keys(patchesParsed.updatedLinesByInvoiceID))
@@ -194,7 +202,8 @@ func isMutableInvoice(invoiceID string, invoicesByID map[string]billing.Invoice)
 type patchesParsed struct {
 	newLines []billing.GatheringLine
 
-	updatedLinesByInvoiceID map[string]invoicePatches
+	updatedLinesByInvoiceID        map[string]invoicePatches
+	gatheringLineDeletesByChargeID []string
 }
 
 type invoicePatches struct {
@@ -234,12 +243,63 @@ func (u *Updater) parsePatches(patches []Patch) (patchesParsed, error) {
 			lineUpdates := parsed.updatedLinesByInvoiceID[update.TargetState.GetInvoiceID()]
 			lineUpdates.updatedLines = append(lineUpdates.updatedLines, update.TargetState)
 			parsed.updatedLinesByInvoiceID[update.TargetState.GetInvoiceID()] = lineUpdates
+		case PatchOpDeleteGatheringLineByChargeID:
+			deletePatch, err := patch.AsDeleteGatheringLineByChargeIDPatch()
+			if err != nil {
+				return patchesParsed{}, fmt.Errorf("getting charge id: %w", err)
+			}
+
+			if deletePatch.ChargeID == "" {
+				return patchesParsed{}, fmt.Errorf("charge id is required")
+			}
+
+			parsed.gatheringLineDeletesByChargeID = append(parsed.gatheringLineDeletesByChargeID, deletePatch.ChargeID)
 		default:
 			return patchesParsed{}, fmt.Errorf("unexpected patch operation: %s", patch.Op())
 		}
 	}
 
 	return parsed, nil
+}
+
+func (u *Updater) resolveGatheringLineDeletesByChargeID(ctx context.Context, customerID customer.CustomerID, parsed *patchesParsed) error {
+	if len(parsed.gatheringLineDeletesByChargeID) == 0 {
+		return nil
+	}
+
+	chargeIDs := make(map[string]struct{}, len(parsed.gatheringLineDeletesByChargeID))
+	for _, chargeID := range parsed.gatheringLineDeletesByChargeID {
+		chargeIDs[chargeID] = struct{}{}
+	}
+
+	invoices, err := u.billingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+		Namespaces: []string{customerID.Namespace},
+		Customers:  []string{customerID.ID},
+		Expand: billing.GatheringInvoiceExpands{
+			billing.GatheringInvoiceExpandLines,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("listing gathering invoices: %w", err)
+	}
+
+	for _, invoice := range invoices.Items {
+		for _, line := range invoice.Lines.OrEmpty() {
+			if line.DeletedAt != nil || line.ChargeID == nil {
+				continue
+			}
+
+			if _, ok := chargeIDs[*line.ChargeID]; !ok {
+				continue
+			}
+
+			lineUpdates := parsed.updatedLinesByInvoiceID[invoice.ID]
+			lineUpdates.deletedLines = append(lineUpdates.deletedLines, line.GetLineID())
+			parsed.updatedLinesByInvoiceID[invoice.ID] = lineUpdates
+		}
+	}
+
+	return nil
 }
 
 func (u *Updater) provisionUpcomingLines(ctx context.Context, customerID customer.CustomerID, lines []billing.GatheringLine) error {

--- a/openmeter/billing/charges/invoiceupdater/patch.go
+++ b/openmeter/billing/charges/invoiceupdater/patch.go
@@ -1,0 +1,106 @@
+package invoiceupdater
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+)
+
+type PatchOperation string
+
+const (
+	PatchOpLineCreate PatchOperation = "line_create"
+	PatchOpLineDelete PatchOperation = "line_delete"
+	PatchOpLineUpdate PatchOperation = "line_update"
+)
+
+type PatchLineCreate struct {
+	Line billing.GatheringLine
+}
+
+type PatchLineDelete struct {
+	Line      billing.LineID
+	InvoiceID string
+}
+
+type PatchLineUpdate struct {
+	TargetState billing.GenericInvoiceLine
+}
+
+type Patch struct {
+	op PatchOperation
+
+	createLinePatch PatchLineCreate
+	deleteLinePatch PatchLineDelete
+	updateLinePatch PatchLineUpdate
+}
+
+func (p Patch) Op() PatchOperation {
+	return p.op
+}
+
+func (p Patch) AsCreateLinePatch() (PatchLineCreate, error) {
+	if p.op != PatchOpLineCreate {
+		return PatchLineCreate{}, fmt.Errorf("expected create line patch, got %s", p.op)
+	}
+
+	return p.createLinePatch, nil
+}
+
+func (p Patch) AsDeleteLinePatch() (PatchLineDelete, error) {
+	if p.op != PatchOpLineDelete {
+		return PatchLineDelete{}, fmt.Errorf("expected delete line patch, got %s", p.op)
+	}
+
+	return p.deleteLinePatch, nil
+}
+
+func (p Patch) AsUpdateLinePatch() (PatchLineUpdate, error) {
+	if p.op != PatchOpLineUpdate {
+		return PatchLineUpdate{}, fmt.Errorf("expected update line patch, got %s", p.op)
+	}
+
+	return p.updateLinePatch, nil
+}
+
+func NewDeleteLinePatch(lineID billing.LineID, invoiceID string) Patch {
+	return Patch{
+		op: PatchOpLineDelete,
+		deleteLinePatch: PatchLineDelete{
+			Line:      lineID,
+			InvoiceID: invoiceID,
+		},
+	}
+}
+
+func NewUpdateLinePatch(line billing.GenericInvoiceLine) Patch {
+	return Patch{
+		op: PatchOpLineUpdate,
+		updateLinePatch: PatchLineUpdate{
+			TargetState: line,
+		},
+	}
+}
+
+func NewCreateLinePatch(line billing.GatheringLine) Patch {
+	return Patch{
+		op: PatchOpLineCreate,
+		createLinePatch: PatchLineCreate{
+			Line: line,
+		},
+	}
+}
+
+func (p Patch) Log(logger *slog.Logger) {
+	switch p.op {
+	case PatchOpLineCreate:
+		logger.Info("create line patch", "line_id", p.createLinePatch.Line.GetLineID().ID, "new_service_period_from", p.createLinePatch.Line.GetServicePeriod().From, "new_service_period_to", p.createLinePatch.Line.GetServicePeriod().To, "unique_reference_id", p.createLinePatch.Line.GetChildUniqueReferenceID())
+	case PatchOpLineDelete:
+		logger.Info("delete line patch", "line_id", p.deleteLinePatch.Line, "invoice_id", p.deleteLinePatch.InvoiceID)
+	case PatchOpLineUpdate:
+		logger.Info("update line patch", "line_id", p.updateLinePatch.TargetState.GetLineID().ID, "invoice_id", p.updateLinePatch.TargetState.GetInvoiceID(), "new_service_period_from", p.updateLinePatch.TargetState.GetServicePeriod().From, "new_service_period_to", p.updateLinePatch.TargetState.GetServicePeriod().To, "unique_reference_id", p.updateLinePatch.TargetState.GetChildUniqueReferenceID())
+	default:
+		logger.Info("unknown patch operation", "operation", p.op)
+	}
+}

--- a/openmeter/billing/charges/invoiceupdater/patch.go
+++ b/openmeter/billing/charges/invoiceupdater/patch.go
@@ -10,9 +10,10 @@ import (
 type PatchOperation string
 
 const (
-	PatchOpLineCreate PatchOperation = "line_create"
-	PatchOpLineDelete PatchOperation = "line_delete"
-	PatchOpLineUpdate PatchOperation = "line_update"
+	PatchOpLineCreate                    PatchOperation = "line_create"
+	PatchOpLineDelete                    PatchOperation = "line_delete"
+	PatchOpLineUpdate                    PatchOperation = "line_update"
+	PatchOpDeleteGatheringLineByChargeID PatchOperation = "delete_gathering_line_by_charge_id"
 )
 
 type PatchLineCreate struct {
@@ -28,12 +29,17 @@ type PatchLineUpdate struct {
 	TargetState billing.GenericInvoiceLine
 }
 
+type PatchDeleteGatheringLineByChargeID struct {
+	ChargeID string
+}
+
 type Patch struct {
 	op PatchOperation
 
-	createLinePatch PatchLineCreate
-	deleteLinePatch PatchLineDelete
-	updateLinePatch PatchLineUpdate
+	createLinePatch                    PatchLineCreate
+	deleteLinePatch                    PatchLineDelete
+	updateLinePatch                    PatchLineUpdate
+	deleteGatheringLineByChargeIDPatch PatchDeleteGatheringLineByChargeID
 }
 
 func (p Patch) Op() PatchOperation {
@@ -64,12 +70,29 @@ func (p Patch) AsUpdateLinePatch() (PatchLineUpdate, error) {
 	return p.updateLinePatch, nil
 }
 
+func (p Patch) AsDeleteGatheringLineByChargeIDPatch() (PatchDeleteGatheringLineByChargeID, error) {
+	if p.op != PatchOpDeleteGatheringLineByChargeID {
+		return PatchDeleteGatheringLineByChargeID{}, fmt.Errorf("expected delete gathering line by charge id patch, got %s", p.op)
+	}
+
+	return p.deleteGatheringLineByChargeIDPatch, nil
+}
+
 func NewDeleteLinePatch(lineID billing.LineID, invoiceID string) Patch {
 	return Patch{
 		op: PatchOpLineDelete,
 		deleteLinePatch: PatchLineDelete{
 			Line:      lineID,
 			InvoiceID: invoiceID,
+		},
+	}
+}
+
+func NewDeleteGatheringLineByChargeIDPatch(chargeID string) Patch {
+	return Patch{
+		op: PatchOpDeleteGatheringLineByChargeID,
+		deleteGatheringLineByChargeIDPatch: PatchDeleteGatheringLineByChargeID{
+			ChargeID: chargeID,
 		},
 	}
 }
@@ -100,6 +123,8 @@ func (p Patch) Log(logger *slog.Logger) {
 		logger.Info("delete line patch", "line_id", p.deleteLinePatch.Line, "invoice_id", p.deleteLinePatch.InvoiceID)
 	case PatchOpLineUpdate:
 		logger.Info("update line patch", "line_id", p.updateLinePatch.TargetState.GetLineID().ID, "invoice_id", p.updateLinePatch.TargetState.GetInvoiceID(), "new_service_period_from", p.updateLinePatch.TargetState.GetServicePeriod().From, "new_service_period_to", p.updateLinePatch.TargetState.GetServicePeriod().To, "unique_reference_id", p.updateLinePatch.TargetState.GetChildUniqueReferenceID())
+	case PatchOpDeleteGatheringLineByChargeID:
+		logger.Info("delete gathering line by charge id patch", "charge_id", p.deleteGatheringLineByChargeIDPatch.ChargeID)
 	default:
 		logger.Info("unknown patch operation", "operation", p.op)
 	}

--- a/openmeter/billing/charges/service/helpers.go
+++ b/openmeter/billing/charges/service/helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 )
@@ -60,6 +61,7 @@ func chargesByType(in charges.Charges) (chargesByTypeResult, error) {
 type InvocableCharge interface {
 	GetChargeID() meta.ChargeID
 	TriggerPatch(ctx context.Context, patch meta.Patch) (*charges.Charge, error)
+	GetInvoicePatchesForPatch(patch meta.Patch) ([]invoiceupdater.Patch, error)
 }
 
 func (s *service) newInvocableCharges(si charges.ChargeSearchItems) (map[string]InvocableCharge, error) {
@@ -111,6 +113,10 @@ func (c *flatFeeInvocableCharge) GetChargeID() meta.ChargeID {
 	return c.chargeID
 }
 
+func (c *flatFeeInvocableCharge) GetInvoicePatchesForPatch(_ meta.Patch) ([]invoiceupdater.Patch, error) {
+	return nil, nil
+}
+
 var _ InvocableCharge = (*usageBasedInvocableCharge)(nil)
 
 type usageBasedInvocableCharge struct {
@@ -133,4 +139,15 @@ func (c *usageBasedInvocableCharge) TriggerPatch(ctx context.Context, patch meta
 
 func (c *usageBasedInvocableCharge) GetChargeID() meta.ChargeID {
 	return c.chargeID
+}
+
+func (c *usageBasedInvocableCharge) GetInvoicePatchesForPatch(patch meta.Patch) ([]invoiceupdater.Patch, error) {
+	switch patch.(type) {
+	case meta.PatchDelete, *meta.PatchDelete:
+		return []invoiceupdater.Patch{
+			invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(c.chargeID.ID),
+		}, nil
+	default:
+		return nil, nil
+	}
 }

--- a/openmeter/billing/charges/service/patch.go
+++ b/openmeter/billing/charges/service/patch.go
@@ -7,6 +7,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
@@ -65,6 +66,27 @@ func (s *service) applyPatches(ctx context.Context, customerID customer.Customer
 	invocableChargesByID, err := s.newInvocableCharges(chargesItems)
 	if err != nil {
 		return err
+	}
+
+	invoicePatches := make([]invoiceupdater.Patch, 0, len(patchesByChargeID))
+	for chargeID, patch := range patchesByChargeID {
+		invocableCharge, ok := invocableChargesByID[chargeID]
+		if !ok {
+			return fmt.Errorf("charge %s not found", chargeID)
+		}
+
+		newInvoicePatches, err := invocableCharge.GetInvoicePatchesForPatch(patch)
+		if err != nil {
+			return fmt.Errorf("getting invoice patches for charge %s: %w", chargeID, err)
+		}
+
+		invoicePatches = append(invoicePatches, newInvoicePatches...)
+	}
+
+	if len(invoicePatches) > 0 {
+		if err := s.invoiceUpdater.ApplyPatches(ctx, customerID, invoicePatches); err != nil {
+			return fmt.Errorf("updating invoices: %w", err)
+		}
 	}
 
 	for chargeID, patch := range patchesByChargeID {

--- a/openmeter/billing/charges/service/service.go
+++ b/openmeter/billing/charges/service/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/ledger/recognizer"
@@ -20,6 +21,7 @@ type service struct {
 	// Note: if meta has a service layer, we should use it here instead of the adapter
 	metaAdapter    meta.Adapter
 	billingService billing.Service
+	invoiceUpdater *invoiceupdater.Updater
 	featureService feature.FeatureConnector
 
 	flatFeeService        flatfee.Service
@@ -91,6 +93,7 @@ func New(config Config) (*service, error) {
 	svc := &service{
 		adapter:               config.Adapter,
 		billingService:        config.BillingService,
+		invoiceUpdater:        invoiceupdater.New(config.BillingService, nil),
 		featureService:        config.FeatureService,
 		metaAdapter:           config.MetaAdapter,
 		flatFeeService:        config.FlatFeeService,

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -208,6 +208,8 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePartialInvoi
 		s.Equal(usagebased.RealizationRunTypePartialInvoice, currentRun.Type)
 		s.Require().NotNil(currentRun.LineID)
 		s.Equal(stdLine.ID, *currentRun.LineID)
+		s.Require().NotNil(currentRun.InvoiceID)
+		s.Equal(partialInvoice.ID, *currentRun.InvoiceID)
 		s.True(midPeriodInvoiceAt.Equal(currentRun.ServicePeriodTo))
 		s.True(midPeriodInvoiceAt.Equal(currentRun.StoredAtLT))
 		s.Require().NotNil(partialInvoice.CollectionAt)
@@ -335,6 +337,8 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePartialInvoi
 		currentRun, runErr := charge.GetCurrentRealizationRun()
 		s.NoError(runErr)
 		s.Equal(usagebased.RealizationRunTypeFinalRealization, currentRun.Type)
+		s.Require().NotNil(currentRun.InvoiceID)
+		s.Equal(finalInvoice.ID, *currentRun.InvoiceID)
 
 		// given
 		clock.FreezeTime(finalInvoice.DefaultCollectionAtForStandardInvoice())
@@ -447,6 +451,94 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePartialInvoi
 		s.Len(charge.Realizations, 2)
 		s.Nil(charge.State.CurrentRealizationRunID)
 	})
+}
+
+func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoiceDeletePatchDeletesPendingGatheringLine() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-service-usage-based-delete-pending-gathering-line")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	s.NotEmpty(cust.ID)
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID())
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	meterSlug := apiRequestsTotal.Feature.Key
+
+	res, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: []charges.ChargeIntent{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromFloat(1),
+				}),
+				name:              "usage-based-delete-pending-gathering-line",
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: "usage-based-delete-pending-gathering-line",
+				featureKey:        meterSlug,
+			}),
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(res, 1)
+
+	usageBasedCharge, err := res[0].AsUsageBasedCharge()
+	s.Require().NoError(err)
+	chargeID := usageBasedCharge.GetChargeID()
+
+	gatheringInvoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+		Namespaces: []string{ns},
+		Customers:  []string{cust.ID},
+		Expand: billing.GatheringInvoiceExpands{
+			billing.GatheringInvoiceExpandLines,
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(gatheringInvoices.Items, 1)
+	s.Require().Len(gatheringInvoices.Items[0].Lines.OrEmpty(), 1)
+	s.Require().NotNil(gatheringInvoices.Items[0].Lines.OrEmpty()[0].ChargeID)
+	s.Equal(chargeID.ID, *gatheringInvoices.Items[0].Lines.OrEmpty()[0].ChargeID)
+
+	err = s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
+		CustomerID: cust.GetID(),
+		PatchesByChargeID: map[string]charges.Patch{
+			chargeID.ID: meta.NewPatchDelete(meta.RefundAsCreditsDeletePolicy),
+		},
+	})
+	s.Require().NoError(err)
+
+	activeGatheringInvoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+		Namespaces: []string{ns},
+		Customers:  []string{cust.ID},
+	})
+	s.Require().NoError(err)
+	s.Empty(activeGatheringInvoices.Items)
+
+	deletedGatheringInvoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+		Namespaces:     []string{ns},
+		Customers:      []string{cust.ID},
+		IncludeDeleted: true,
+		Expand: billing.GatheringInvoiceExpands{
+			billing.GatheringInvoiceExpandLines,
+			billing.GatheringInvoiceExpandDeletedLines,
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(deletedGatheringInvoices.Items, 1)
+	s.NotNil(deletedGatheringInvoices.Items[0].DeletedAt)
+	s.Require().Len(deletedGatheringInvoices.Items[0].Lines.OrEmpty(), 1)
+	s.NotNil(deletedGatheringInvoices.Items[0].Lines.OrEmpty()[0].DeletedAt)
 }
 
 func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePendingPartialInvoiceBlocksFinalRealizationUntilApproval() {

--- a/openmeter/billing/charges/usagebased/adapter/mapper.go
+++ b/openmeter/billing/charges/usagebased/adapter/mapper.go
@@ -97,6 +97,7 @@ func MapRealizationRunBaseFromDB(dbRun *entdb.ChargeUsageBasedRuns) usagebased.R
 
 		FeatureID:       dbRun.FeatureID,
 		LineID:          dbRun.LineID,
+		InvoiceID:       dbRun.InvoiceID,
 		Type:            dbRun.Type,
 		StoredAtLT:      dbRun.StoredAtLt.UTC(),
 		ServicePeriodTo: dbRun.ServicePeriodTo.UTC(),

--- a/openmeter/billing/charges/usagebased/adapter/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/adapter/realizationrun.go
@@ -31,6 +31,7 @@ func (a *adapter) CreateRealizationRun(ctx context.Context, chargeID meta.Charge
 			SetServicePeriodTo(meta.NormalizeTimestamp(input.ServicePeriodTo)).
 			SetDetailedLinesPresent(false).
 			SetNillableBillingInvoiceLineID(input.LineID).
+			SetNillableBillingInvoiceID(input.InvoiceID).
 			SetMeteredQuantity(input.MeteredQuantity)
 
 		create = totals.Set(create, input.Totals)

--- a/openmeter/billing/charges/usagebased/realizationrun.go
+++ b/openmeter/billing/charges/usagebased/realizationrun.go
@@ -51,6 +51,7 @@ type CreateRealizationRunInput struct {
 	StoredAtLT      time.Time             `json:"storedAtLT"`
 	ServicePeriodTo time.Time             `json:"servicePeriodTo"`
 	LineID          *string               `json:"lineId,omitempty"`
+	InvoiceID       *string               `json:"invoiceId,omitempty"`
 	MeteredQuantity alpacadecimal.Decimal `json:"meteredQuantity"`
 	Totals          totals.Totals         `json:"totals"`
 }
@@ -91,6 +92,10 @@ func (r CreateRealizationRunInput) Validate() error {
 
 	if r.LineID != nil && *r.LineID == "" {
 		errs = append(errs, fmt.Errorf("line id must be non-empty"))
+	}
+
+	if r.InvoiceID != nil && *r.InvoiceID == "" {
+		errs = append(errs, fmt.Errorf("invoice id must be non-empty"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
@@ -151,6 +156,7 @@ type RealizationRunBase struct {
 
 	FeatureID string  `json:"featureId"`
 	LineID    *string `json:"lineId,omitempty"`
+	InvoiceID *string `json:"invoiceId,omitempty"`
 
 	Type       RealizationRunType `json:"type"`
 	StoredAtLT time.Time          `json:"storedAtLT"`
@@ -185,6 +191,10 @@ func (r RealizationRunBase) Validate() error {
 
 	if r.LineID != nil && *r.LineID == "" {
 		errs = append(errs, fmt.Errorf("line id must be non-empty"))
+	}
+
+	if r.InvoiceID != nil && *r.InvoiceID == "" {
+		errs = append(errs, fmt.Errorf("invoice id must be non-empty"))
 	}
 
 	if err := r.Type.Validate(); err != nil {

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -212,12 +212,17 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, _ meta
 
 type invoiceCreatedInput struct {
 	LineID          string
+	InvoiceID       string
 	ServicePeriodTo time.Time
 }
 
 func (i invoiceCreatedInput) Validate() error {
 	if i.LineID == "" {
 		return fmt.Errorf("line id is required")
+	}
+
+	if i.InvoiceID == "" {
+		return fmt.Errorf("invoice id is required")
 	}
 
 	if i.ServicePeriodTo.IsZero() {
@@ -255,6 +260,7 @@ func (s *CreditThenInvoiceStateMachine) startInvoiceCreatedRun(
 		StoredAtLT:         storedAtLT,
 		ServicePeriodTo:    servicePeriodTo,
 		LineID:             lo.ToPtr(input.LineID),
+		InvoiceID:          lo.ToPtr(input.InvoiceID),
 		CreditAllocation:   usagebasedrun.CreditAllocationAvailable,
 		CurrencyCalculator: s.CurrencyCalculator,
 	})

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -17,7 +17,8 @@ func TestStartInvoiceCreatedRunValidatesInput(t *testing.T) {
 	err := machine.startInvoiceCreatedRun(
 		t.Context(),
 		invoiceCreatedInput{
-			LineID: "line-1",
+			LineID:    "line-1",
+			InvoiceID: "invoice-1",
 		},
 		usagebased.RealizationRunTypePartialInvoice,
 	)

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -151,6 +151,7 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 
 		if err := stateMachine.FireAndActivate(ctx, trigger, invoiceCreatedInput{
 			LineID:          stdLine.ID,
+			InvoiceID:       input.Invoice.ID,
 			ServicePeriodTo: stdLine.Period.To,
 		}); err != nil {
 			return nil, fmt.Errorf("triggering %s for charge[%s]: %w", trigger, stateMachine.GetCharge().ID, err)

--- a/openmeter/billing/charges/usagebased/service/run/create.go
+++ b/openmeter/billing/charges/usagebased/service/run/create.go
@@ -24,6 +24,7 @@ type CreateRatedRunInput struct {
 	StoredAtLT         time.Time
 	ServicePeriodTo    time.Time
 	LineID             *string
+	InvoiceID          *string
 	CreditAllocation   CreditAllocationMode
 	CurrencyCalculator currencyx.Calculator
 }
@@ -68,6 +69,10 @@ func (i CreateRatedRunInput) Validate() error {
 
 	if i.LineID != nil && *i.LineID == "" {
 		return fmt.Errorf("line id if set, must be non-empty")
+	}
+
+	if i.InvoiceID != nil && *i.InvoiceID == "" {
+		return fmt.Errorf("invoice id if set, must be non-empty")
 	}
 
 	if err := i.CreditAllocation.Validate(); err != nil {
@@ -148,6 +153,7 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 		StoredAtLT:      in.StoredAtLT,
 		ServicePeriodTo: in.ServicePeriodTo,
 		LineID:          in.LineID,
+		InvoiceID:       in.InvoiceID,
 		MeteredQuantity: ratingResult.Quantity,
 		Totals:          runTotals,
 	})

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/invoiceupdate.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/invoiceupdater/invoiceupdate.go
@@ -41,17 +41,20 @@ func (u *Updater) ApplyPatches(ctx context.Context, customerID customer.Customer
 		return fmt.Errorf("provisioning upcoming lines: %w", err)
 	}
 
+	invoicesByID, err := u.listInvoicesByID(ctx, customerID.Namespace, lo.Keys(patchesParsed.updatedLinesByInvoiceID))
+	if err != nil {
+		return fmt.Errorf("listing invoices: %w", err)
+	}
+
 	for invoiceID, linePatches := range patchesParsed.updatedLinesByInvoiceID {
 		namespacedInvoiceID := billing.InvoiceID{
 			Namespace: customerID.Namespace,
 			ID:        invoiceID,
 		}
 
-		invoice, err := u.billingService.GetInvoiceById(ctx, billing.GetInvoiceByIdInput{
-			Invoice: namespacedInvoiceID,
-		})
-		if err != nil {
-			return fmt.Errorf("getting invoice: %w", err)
+		invoice, ok := invoicesByID[invoiceID]
+		if !ok {
+			return fmt.Errorf("getting invoice: invoice[%s/%s] not found", customerID.Namespace, invoiceID)
 		}
 
 		if invoice.Type() == billing.InvoiceTypeGathering {
@@ -86,6 +89,33 @@ func (u *Updater) ApplyPatches(ctx context.Context, customerID customer.Customer
 	}
 
 	return nil
+}
+
+func (u *Updater) listInvoicesByID(ctx context.Context, namespace string, invoiceIDs []string) (map[string]billing.Invoice, error) {
+	if len(invoiceIDs) == 0 {
+		return map[string]billing.Invoice{}, nil
+	}
+
+	resp, err := u.billingService.ListInvoices(ctx, billing.ListInvoicesInput{
+		Namespaces:     []string{namespace},
+		IDs:            invoiceIDs,
+		IncludeDeleted: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	invoicesByID := make(map[string]billing.Invoice, len(resp.Items))
+	for _, invoice := range resp.Items {
+		genericInvoice, err := invoice.AsGenericInvoice()
+		if err != nil {
+			return nil, fmt.Errorf("converting invoice to generic invoice: %w", err)
+		}
+
+		invoicesByID[genericInvoice.GetID()] = invoice
+	}
+
+	return invoicesByID, nil
 }
 
 func (u *Updater) LogPatches(patches []Patch, invoicesByID map[string]billing.Invoice) {

--- a/openmeter/ent/db/billinginvoice.go
+++ b/openmeter/ent/db/billinginvoice.go
@@ -160,6 +160,8 @@ type BillingInvoiceEdges struct {
 	BillingInvoiceDetailedLines []*BillingStandardInvoiceDetailedLine `json:"billing_invoice_detailed_lines,omitempty"`
 	// BillingInvoiceValidationIssues holds the value of the billing_invoice_validation_issues edge.
 	BillingInvoiceValidationIssues []*BillingInvoiceValidationIssue `json:"billing_invoice_validation_issues,omitempty"`
+	// ChargeUsageBasedRuns holds the value of the charge_usage_based_runs edge.
+	ChargeUsageBasedRuns []*ChargeUsageBasedRuns `json:"charge_usage_based_runs,omitempty"`
 	// BillingInvoiceCustomer holds the value of the billing_invoice_customer edge.
 	BillingInvoiceCustomer *Customer `json:"billing_invoice_customer,omitempty"`
 	// TaxApp holds the value of the tax_app edge.
@@ -170,7 +172,7 @@ type BillingInvoiceEdges struct {
 	PaymentApp *App `json:"payment_app,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [9]bool
+	loadedTypes [10]bool
 }
 
 // SourceBillingProfileOrErr returns the SourceBillingProfile value or an error if the edge
@@ -222,12 +224,21 @@ func (e BillingInvoiceEdges) BillingInvoiceValidationIssuesOrErr() ([]*BillingIn
 	return nil, &NotLoadedError{edge: "billing_invoice_validation_issues"}
 }
 
+// ChargeUsageBasedRunsOrErr returns the ChargeUsageBasedRuns value or an error if the edge
+// was not loaded in eager-loading.
+func (e BillingInvoiceEdges) ChargeUsageBasedRunsOrErr() ([]*ChargeUsageBasedRuns, error) {
+	if e.loadedTypes[5] {
+		return e.ChargeUsageBasedRuns, nil
+	}
+	return nil, &NotLoadedError{edge: "charge_usage_based_runs"}
+}
+
 // BillingInvoiceCustomerOrErr returns the BillingInvoiceCustomer value or an error if the edge
 // was not loaded in eager-loading, or loaded but was not found.
 func (e BillingInvoiceEdges) BillingInvoiceCustomerOrErr() (*Customer, error) {
 	if e.BillingInvoiceCustomer != nil {
 		return e.BillingInvoiceCustomer, nil
-	} else if e.loadedTypes[5] {
+	} else if e.loadedTypes[6] {
 		return nil, &NotFoundError{label: customer.Label}
 	}
 	return nil, &NotLoadedError{edge: "billing_invoice_customer"}
@@ -238,7 +249,7 @@ func (e BillingInvoiceEdges) BillingInvoiceCustomerOrErr() (*Customer, error) {
 func (e BillingInvoiceEdges) TaxAppOrErr() (*App, error) {
 	if e.TaxApp != nil {
 		return e.TaxApp, nil
-	} else if e.loadedTypes[6] {
+	} else if e.loadedTypes[7] {
 		return nil, &NotFoundError{label: dbapp.Label}
 	}
 	return nil, &NotLoadedError{edge: "tax_app"}
@@ -249,7 +260,7 @@ func (e BillingInvoiceEdges) TaxAppOrErr() (*App, error) {
 func (e BillingInvoiceEdges) InvoicingAppOrErr() (*App, error) {
 	if e.InvoicingApp != nil {
 		return e.InvoicingApp, nil
-	} else if e.loadedTypes[7] {
+	} else if e.loadedTypes[8] {
 		return nil, &NotFoundError{label: dbapp.Label}
 	}
 	return nil, &NotLoadedError{edge: "invoicing_app"}
@@ -260,7 +271,7 @@ func (e BillingInvoiceEdges) InvoicingAppOrErr() (*App, error) {
 func (e BillingInvoiceEdges) PaymentAppOrErr() (*App, error) {
 	if e.PaymentApp != nil {
 		return e.PaymentApp, nil
-	} else if e.loadedTypes[8] {
+	} else if e.loadedTypes[9] {
 		return nil, &NotFoundError{label: dbapp.Label}
 	}
 	return nil, &NotLoadedError{edge: "payment_app"}
@@ -723,6 +734,11 @@ func (_m *BillingInvoice) QueryBillingInvoiceDetailedLines() *BillingStandardInv
 // QueryBillingInvoiceValidationIssues queries the "billing_invoice_validation_issues" edge of the BillingInvoice entity.
 func (_m *BillingInvoice) QueryBillingInvoiceValidationIssues() *BillingInvoiceValidationIssueQuery {
 	return NewBillingInvoiceClient(_m.config).QueryBillingInvoiceValidationIssues(_m)
+}
+
+// QueryChargeUsageBasedRuns queries the "charge_usage_based_runs" edge of the BillingInvoice entity.
+func (_m *BillingInvoice) QueryChargeUsageBasedRuns() *ChargeUsageBasedRunsQuery {
+	return NewBillingInvoiceClient(_m.config).QueryChargeUsageBasedRuns(_m)
 }
 
 // QueryBillingInvoiceCustomer queries the "billing_invoice_customer" edge of the BillingInvoice entity.

--- a/openmeter/ent/db/billinginvoice/billinginvoice.go
+++ b/openmeter/ent/db/billinginvoice/billinginvoice.go
@@ -142,6 +142,8 @@ const (
 	EdgeBillingInvoiceDetailedLines = "billing_invoice_detailed_lines"
 	// EdgeBillingInvoiceValidationIssues holds the string denoting the billing_invoice_validation_issues edge name in mutations.
 	EdgeBillingInvoiceValidationIssues = "billing_invoice_validation_issues"
+	// EdgeChargeUsageBasedRuns holds the string denoting the charge_usage_based_runs edge name in mutations.
+	EdgeChargeUsageBasedRuns = "charge_usage_based_runs"
 	// EdgeBillingInvoiceCustomer holds the string denoting the billing_invoice_customer edge name in mutations.
 	EdgeBillingInvoiceCustomer = "billing_invoice_customer"
 	// EdgeTaxApp holds the string denoting the tax_app edge name in mutations.
@@ -187,6 +189,13 @@ const (
 	BillingInvoiceValidationIssuesInverseTable = "billing_invoice_validation_issues"
 	// BillingInvoiceValidationIssuesColumn is the table column denoting the billing_invoice_validation_issues relation/edge.
 	BillingInvoiceValidationIssuesColumn = "invoice_id"
+	// ChargeUsageBasedRunsTable is the table that holds the charge_usage_based_runs relation/edge.
+	ChargeUsageBasedRunsTable = "charge_usage_based_runs"
+	// ChargeUsageBasedRunsInverseTable is the table name for the ChargeUsageBasedRuns entity.
+	// It exists in this package in order to avoid circular dependency with the "chargeusagebasedruns" package.
+	ChargeUsageBasedRunsInverseTable = "charge_usage_based_runs"
+	// ChargeUsageBasedRunsColumn is the table column denoting the charge_usage_based_runs relation/edge.
+	ChargeUsageBasedRunsColumn = "invoice_id"
 	// BillingInvoiceCustomerTable is the table that holds the billing_invoice_customer relation/edge.
 	BillingInvoiceCustomerTable = "billing_invoices"
 	// BillingInvoiceCustomerInverseTable is the table name for the Customer entity.
@@ -678,6 +687,20 @@ func ByBillingInvoiceValidationIssues(term sql.OrderTerm, terms ...sql.OrderTerm
 	}
 }
 
+// ByChargeUsageBasedRunsCount orders the results by charge_usage_based_runs count.
+func ByChargeUsageBasedRunsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newChargeUsageBasedRunsStep(), opts...)
+	}
+}
+
+// ByChargeUsageBasedRuns orders the results by charge_usage_based_runs terms.
+func ByChargeUsageBasedRuns(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newChargeUsageBasedRunsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
 // ByBillingInvoiceCustomerField orders the results by billing_invoice_customer field.
 func ByBillingInvoiceCustomerField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -738,6 +761,13 @@ func newBillingInvoiceValidationIssuesStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(BillingInvoiceValidationIssuesInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.O2M, false, BillingInvoiceValidationIssuesTable, BillingInvoiceValidationIssuesColumn),
+	)
+}
+func newChargeUsageBasedRunsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ChargeUsageBasedRunsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, ChargeUsageBasedRunsTable, ChargeUsageBasedRunsColumn),
 	)
 }
 func newBillingInvoiceCustomerStep() *sqlgraph.Step {

--- a/openmeter/ent/db/billinginvoice/where.go
+++ b/openmeter/ent/db/billinginvoice/where.go
@@ -3804,6 +3804,29 @@ func HasBillingInvoiceValidationIssuesWith(preds ...predicate.BillingInvoiceVali
 	})
 }
 
+// HasChargeUsageBasedRuns applies the HasEdge predicate on the "charge_usage_based_runs" edge.
+func HasChargeUsageBasedRuns() predicate.BillingInvoice {
+	return predicate.BillingInvoice(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, ChargeUsageBasedRunsTable, ChargeUsageBasedRunsColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasChargeUsageBasedRunsWith applies the HasEdge predicate on the "charge_usage_based_runs" edge with a given conditions (other predicates).
+func HasChargeUsageBasedRunsWith(preds ...predicate.ChargeUsageBasedRuns) predicate.BillingInvoice {
+	return predicate.BillingInvoice(func(s *sql.Selector) {
+		step := newChargeUsageBasedRunsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasBillingInvoiceCustomer applies the HasEdge predicate on the "billing_invoice_customer" edge.
 func HasBillingInvoiceCustomer() predicate.BillingInvoice {
 	return predicate.BillingInvoice(func(s *sql.Selector) {

--- a/openmeter/ent/db/billinginvoice_create.go
+++ b/openmeter/ent/db/billinginvoice_create.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingprofile"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingstandardinvoicedetailedline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingworkflowconfig"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/customer"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -737,6 +738,21 @@ func (_c *BillingInvoiceCreate) AddBillingInvoiceValidationIssues(v ...*BillingI
 	return _c.AddBillingInvoiceValidationIssueIDs(ids...)
 }
 
+// AddChargeUsageBasedRunIDs adds the "charge_usage_based_runs" edge to the ChargeUsageBasedRuns entity by IDs.
+func (_c *BillingInvoiceCreate) AddChargeUsageBasedRunIDs(ids ...string) *BillingInvoiceCreate {
+	_c.mutation.AddChargeUsageBasedRunIDs(ids...)
+	return _c
+}
+
+// AddChargeUsageBasedRuns adds the "charge_usage_based_runs" edges to the ChargeUsageBasedRuns entity.
+func (_c *BillingInvoiceCreate) AddChargeUsageBasedRuns(v ...*ChargeUsageBasedRuns) *BillingInvoiceCreate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _c.AddChargeUsageBasedRunIDs(ids...)
+}
+
 // SetBillingInvoiceCustomerID sets the "billing_invoice_customer" edge to the Customer entity by ID.
 func (_c *BillingInvoiceCreate) SetBillingInvoiceCustomerID(id string) *BillingInvoiceCreate {
 	_c.mutation.SetBillingInvoiceCustomerID(id)
@@ -1282,6 +1298,22 @@ func (_c *BillingInvoiceCreate) createSpec() (*BillingInvoice, *sqlgraph.CreateS
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(billinginvoicevalidationissue.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.ChargeUsageBasedRunsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeUsageBasedRunsTable,
+			Columns: []string{billinginvoice.ChargeUsageBasedRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/openmeter/ent/db/billinginvoice_query.go
+++ b/openmeter/ent/db/billinginvoice_query.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingprofile"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingstandardinvoicedetailedline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingworkflowconfig"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/customer"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 )
@@ -36,6 +37,7 @@ type BillingInvoiceQuery struct {
 	withBillingInvoiceLines            *BillingInvoiceLineQuery
 	withBillingInvoiceDetailedLines    *BillingStandardInvoiceDetailedLineQuery
 	withBillingInvoiceValidationIssues *BillingInvoiceValidationIssueQuery
+	withChargeUsageBasedRuns           *ChargeUsageBasedRunsQuery
 	withBillingInvoiceCustomer         *CustomerQuery
 	withTaxApp                         *AppQuery
 	withInvoicingApp                   *AppQuery
@@ -180,6 +182,28 @@ func (_q *BillingInvoiceQuery) QueryBillingInvoiceValidationIssues() *BillingInv
 			sqlgraph.From(billinginvoice.Table, billinginvoice.FieldID, selector),
 			sqlgraph.To(billinginvoicevalidationissue.Table, billinginvoicevalidationissue.FieldID),
 			sqlgraph.Edge(sqlgraph.O2M, false, billinginvoice.BillingInvoiceValidationIssuesTable, billinginvoice.BillingInvoiceValidationIssuesColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryChargeUsageBasedRuns chains the current query on the "charge_usage_based_runs" edge.
+func (_q *BillingInvoiceQuery) QueryChargeUsageBasedRuns() *ChargeUsageBasedRunsQuery {
+	query := (&ChargeUsageBasedRunsClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(billinginvoice.Table, billinginvoice.FieldID, selector),
+			sqlgraph.To(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, billinginvoice.ChargeUsageBasedRunsTable, billinginvoice.ChargeUsageBasedRunsColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -472,6 +496,7 @@ func (_q *BillingInvoiceQuery) Clone() *BillingInvoiceQuery {
 		withBillingInvoiceLines:            _q.withBillingInvoiceLines.Clone(),
 		withBillingInvoiceDetailedLines:    _q.withBillingInvoiceDetailedLines.Clone(),
 		withBillingInvoiceValidationIssues: _q.withBillingInvoiceValidationIssues.Clone(),
+		withChargeUsageBasedRuns:           _q.withChargeUsageBasedRuns.Clone(),
 		withBillingInvoiceCustomer:         _q.withBillingInvoiceCustomer.Clone(),
 		withTaxApp:                         _q.withTaxApp.Clone(),
 		withInvoicingApp:                   _q.withInvoicingApp.Clone(),
@@ -534,6 +559,17 @@ func (_q *BillingInvoiceQuery) WithBillingInvoiceValidationIssues(opts ...func(*
 		opt(query)
 	}
 	_q.withBillingInvoiceValidationIssues = query
+	return _q
+}
+
+// WithChargeUsageBasedRuns tells the query-builder to eager-load the nodes that are connected to
+// the "charge_usage_based_runs" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *BillingInvoiceQuery) WithChargeUsageBasedRuns(opts ...func(*ChargeUsageBasedRunsQuery)) *BillingInvoiceQuery {
+	query := (&ChargeUsageBasedRunsClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withChargeUsageBasedRuns = query
 	return _q
 }
 
@@ -659,12 +695,13 @@ func (_q *BillingInvoiceQuery) sqlAll(ctx context.Context, hooks ...queryHook) (
 	var (
 		nodes       = []*BillingInvoice{}
 		_spec       = _q.querySpec()
-		loadedTypes = [9]bool{
+		loadedTypes = [10]bool{
 			_q.withSourceBillingProfile != nil,
 			_q.withBillingWorkflowConfig != nil,
 			_q.withBillingInvoiceLines != nil,
 			_q.withBillingInvoiceDetailedLines != nil,
 			_q.withBillingInvoiceValidationIssues != nil,
+			_q.withChargeUsageBasedRuns != nil,
 			_q.withBillingInvoiceCustomer != nil,
 			_q.withTaxApp != nil,
 			_q.withInvoicingApp != nil,
@@ -727,6 +764,15 @@ func (_q *BillingInvoiceQuery) sqlAll(ctx context.Context, hooks ...queryHook) (
 			func(n *BillingInvoice) { n.Edges.BillingInvoiceValidationIssues = []*BillingInvoiceValidationIssue{} },
 			func(n *BillingInvoice, e *BillingInvoiceValidationIssue) {
 				n.Edges.BillingInvoiceValidationIssues = append(n.Edges.BillingInvoiceValidationIssues, e)
+			}); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withChargeUsageBasedRuns; query != nil {
+		if err := _q.loadChargeUsageBasedRuns(ctx, query, nodes,
+			func(n *BillingInvoice) { n.Edges.ChargeUsageBasedRuns = []*ChargeUsageBasedRuns{} },
+			func(n *BillingInvoice, e *ChargeUsageBasedRuns) {
+				n.Edges.ChargeUsageBasedRuns = append(n.Edges.ChargeUsageBasedRuns, e)
 			}); err != nil {
 			return nil, err
 		}
@@ -902,6 +948,39 @@ func (_q *BillingInvoiceQuery) loadBillingInvoiceValidationIssues(ctx context.Co
 		node, ok := nodeids[fk]
 		if !ok {
 			return fmt.Errorf(`unexpected referenced foreign-key "invoice_id" returned %v for node %v`, fk, n.ID)
+		}
+		assign(node, n)
+	}
+	return nil
+}
+func (_q *BillingInvoiceQuery) loadChargeUsageBasedRuns(ctx context.Context, query *ChargeUsageBasedRunsQuery, nodes []*BillingInvoice, init func(*BillingInvoice), assign func(*BillingInvoice, *ChargeUsageBasedRuns)) error {
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[string]*BillingInvoice)
+	for i := range nodes {
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
+		if init != nil {
+			init(nodes[i])
+		}
+	}
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(chargeusagebasedruns.FieldInvoiceID)
+	}
+	query.Where(predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(billinginvoice.ChargeUsageBasedRunsColumn), fks...))
+	}))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		fk := n.InvoiceID
+		if fk == nil {
+			return fmt.Errorf(`foreign-key "invoice_id" is nil for node %v`, n.ID)
+		}
+		node, ok := nodeids[*fk]
+		if !ok {
+			return fmt.Errorf(`unexpected referenced foreign-key "invoice_id" returned %v for node %v`, *fk, n.ID)
 		}
 		assign(node, n)
 	}

--- a/openmeter/ent/db/billinginvoice_update.go
+++ b/openmeter/ent/db/billinginvoice_update.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicevalidationissue"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingstandardinvoicedetailedline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingworkflowconfig"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -978,6 +979,21 @@ func (_u *BillingInvoiceUpdate) AddBillingInvoiceValidationIssues(v ...*BillingI
 	return _u.AddBillingInvoiceValidationIssueIDs(ids...)
 }
 
+// AddChargeUsageBasedRunIDs adds the "charge_usage_based_runs" edge to the ChargeUsageBasedRuns entity by IDs.
+func (_u *BillingInvoiceUpdate) AddChargeUsageBasedRunIDs(ids ...string) *BillingInvoiceUpdate {
+	_u.mutation.AddChargeUsageBasedRunIDs(ids...)
+	return _u
+}
+
+// AddChargeUsageBasedRuns adds the "charge_usage_based_runs" edges to the ChargeUsageBasedRuns entity.
+func (_u *BillingInvoiceUpdate) AddChargeUsageBasedRuns(v ...*ChargeUsageBasedRuns) *BillingInvoiceUpdate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddChargeUsageBasedRunIDs(ids...)
+}
+
 // Mutation returns the BillingInvoiceMutation object of the builder.
 func (_u *BillingInvoiceUpdate) Mutation() *BillingInvoiceMutation {
 	return _u.mutation
@@ -1050,6 +1066,27 @@ func (_u *BillingInvoiceUpdate) RemoveBillingInvoiceValidationIssues(v ...*Billi
 		ids[i] = v[i].ID
 	}
 	return _u.RemoveBillingInvoiceValidationIssueIDs(ids...)
+}
+
+// ClearChargeUsageBasedRuns clears all "charge_usage_based_runs" edges to the ChargeUsageBasedRuns entity.
+func (_u *BillingInvoiceUpdate) ClearChargeUsageBasedRuns() *BillingInvoiceUpdate {
+	_u.mutation.ClearChargeUsageBasedRuns()
+	return _u
+}
+
+// RemoveChargeUsageBasedRunIDs removes the "charge_usage_based_runs" edge to ChargeUsageBasedRuns entities by IDs.
+func (_u *BillingInvoiceUpdate) RemoveChargeUsageBasedRunIDs(ids ...string) *BillingInvoiceUpdate {
+	_u.mutation.RemoveChargeUsageBasedRunIDs(ids...)
+	return _u
+}
+
+// RemoveChargeUsageBasedRuns removes "charge_usage_based_runs" edges to ChargeUsageBasedRuns entities.
+func (_u *BillingInvoiceUpdate) RemoveChargeUsageBasedRuns(v ...*ChargeUsageBasedRuns) *BillingInvoiceUpdate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveChargeUsageBasedRunIDs(ids...)
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -1567,6 +1604,51 @@ func (_u *BillingInvoiceUpdate) sqlSave(ctx context.Context) (_node int, err err
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(billinginvoicevalidationissue.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.ChargeUsageBasedRunsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeUsageBasedRunsTable,
+			Columns: []string{billinginvoice.ChargeUsageBasedRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedChargeUsageBasedRunsIDs(); len(nodes) > 0 && !_u.mutation.ChargeUsageBasedRunsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeUsageBasedRunsTable,
+			Columns: []string{billinginvoice.ChargeUsageBasedRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.ChargeUsageBasedRunsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeUsageBasedRunsTable,
+			Columns: []string{billinginvoice.ChargeUsageBasedRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {
@@ -2537,6 +2619,21 @@ func (_u *BillingInvoiceUpdateOne) AddBillingInvoiceValidationIssues(v ...*Billi
 	return _u.AddBillingInvoiceValidationIssueIDs(ids...)
 }
 
+// AddChargeUsageBasedRunIDs adds the "charge_usage_based_runs" edge to the ChargeUsageBasedRuns entity by IDs.
+func (_u *BillingInvoiceUpdateOne) AddChargeUsageBasedRunIDs(ids ...string) *BillingInvoiceUpdateOne {
+	_u.mutation.AddChargeUsageBasedRunIDs(ids...)
+	return _u
+}
+
+// AddChargeUsageBasedRuns adds the "charge_usage_based_runs" edges to the ChargeUsageBasedRuns entity.
+func (_u *BillingInvoiceUpdateOne) AddChargeUsageBasedRuns(v ...*ChargeUsageBasedRuns) *BillingInvoiceUpdateOne {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddChargeUsageBasedRunIDs(ids...)
+}
+
 // Mutation returns the BillingInvoiceMutation object of the builder.
 func (_u *BillingInvoiceUpdateOne) Mutation() *BillingInvoiceMutation {
 	return _u.mutation
@@ -2609,6 +2706,27 @@ func (_u *BillingInvoiceUpdateOne) RemoveBillingInvoiceValidationIssues(v ...*Bi
 		ids[i] = v[i].ID
 	}
 	return _u.RemoveBillingInvoiceValidationIssueIDs(ids...)
+}
+
+// ClearChargeUsageBasedRuns clears all "charge_usage_based_runs" edges to the ChargeUsageBasedRuns entity.
+func (_u *BillingInvoiceUpdateOne) ClearChargeUsageBasedRuns() *BillingInvoiceUpdateOne {
+	_u.mutation.ClearChargeUsageBasedRuns()
+	return _u
+}
+
+// RemoveChargeUsageBasedRunIDs removes the "charge_usage_based_runs" edge to ChargeUsageBasedRuns entities by IDs.
+func (_u *BillingInvoiceUpdateOne) RemoveChargeUsageBasedRunIDs(ids ...string) *BillingInvoiceUpdateOne {
+	_u.mutation.RemoveChargeUsageBasedRunIDs(ids...)
+	return _u
+}
+
+// RemoveChargeUsageBasedRuns removes "charge_usage_based_runs" edges to ChargeUsageBasedRuns entities.
+func (_u *BillingInvoiceUpdateOne) RemoveChargeUsageBasedRuns(v ...*ChargeUsageBasedRuns) *BillingInvoiceUpdateOne {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveChargeUsageBasedRunIDs(ids...)
 }
 
 // Where appends a list predicates to the BillingInvoiceUpdate builder.
@@ -3156,6 +3274,51 @@ func (_u *BillingInvoiceUpdateOne) sqlSave(ctx context.Context) (_node *BillingI
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(billinginvoicevalidationissue.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.ChargeUsageBasedRunsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeUsageBasedRunsTable,
+			Columns: []string{billinginvoice.ChargeUsageBasedRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedChargeUsageBasedRunsIDs(); len(nodes) > 0 && !_u.mutation.ChargeUsageBasedRunsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeUsageBasedRunsTable,
+			Columns: []string{billinginvoice.ChargeUsageBasedRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.ChargeUsageBasedRunsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeUsageBasedRunsTable,
+			Columns: []string{billinginvoice.ChargeUsageBasedRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/openmeter/ent/db/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns.go
@@ -11,6 +11,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoice"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebased"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruninvoicedusage"
@@ -62,6 +63,8 @@ type ChargeUsageBasedRuns struct {
 	DetailedLinesPresent bool `json:"detailed_lines_present,omitempty"`
 	// LineID holds the value of the "line_id" field.
 	LineID *string `json:"line_id,omitempty"`
+	// InvoiceID holds the value of the "invoice_id" field.
+	InvoiceID *string `json:"invoice_id,omitempty"`
 	// MeteredQuantity holds the value of the "metered_quantity" field.
 	MeteredQuantity alpacadecimal.Decimal `json:"metered_quantity,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
@@ -78,6 +81,8 @@ type ChargeUsageBasedRunsEdges struct {
 	Feature *Feature `json:"feature,omitempty"`
 	// BillingInvoiceLine holds the value of the billing_invoice_line edge.
 	BillingInvoiceLine *BillingInvoiceLine `json:"billing_invoice_line,omitempty"`
+	// BillingInvoice holds the value of the billing_invoice edge.
+	BillingInvoice *BillingInvoice `json:"billing_invoice,omitempty"`
 	// CreditAllocations holds the value of the credit_allocations edge.
 	CreditAllocations []*ChargeUsageBasedRunCreditAllocations `json:"credit_allocations,omitempty"`
 	// DetailedLines holds the value of the detailed_lines edge.
@@ -88,7 +93,7 @@ type ChargeUsageBasedRunsEdges struct {
 	Payment *ChargeUsageBasedRunPayment `json:"payment,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [7]bool
+	loadedTypes [8]bool
 }
 
 // UsageBasedOrErr returns the UsageBased value or an error if the edge
@@ -124,10 +129,21 @@ func (e ChargeUsageBasedRunsEdges) BillingInvoiceLineOrErr() (*BillingInvoiceLin
 	return nil, &NotLoadedError{edge: "billing_invoice_line"}
 }
 
+// BillingInvoiceOrErr returns the BillingInvoice value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e ChargeUsageBasedRunsEdges) BillingInvoiceOrErr() (*BillingInvoice, error) {
+	if e.BillingInvoice != nil {
+		return e.BillingInvoice, nil
+	} else if e.loadedTypes[3] {
+		return nil, &NotFoundError{label: billinginvoice.Label}
+	}
+	return nil, &NotLoadedError{edge: "billing_invoice"}
+}
+
 // CreditAllocationsOrErr returns the CreditAllocations value or an error if the edge
 // was not loaded in eager-loading.
 func (e ChargeUsageBasedRunsEdges) CreditAllocationsOrErr() ([]*ChargeUsageBasedRunCreditAllocations, error) {
-	if e.loadedTypes[3] {
+	if e.loadedTypes[4] {
 		return e.CreditAllocations, nil
 	}
 	return nil, &NotLoadedError{edge: "credit_allocations"}
@@ -136,7 +152,7 @@ func (e ChargeUsageBasedRunsEdges) CreditAllocationsOrErr() ([]*ChargeUsageBased
 // DetailedLinesOrErr returns the DetailedLines value or an error if the edge
 // was not loaded in eager-loading.
 func (e ChargeUsageBasedRunsEdges) DetailedLinesOrErr() ([]*ChargeUsageBasedRunDetailedLine, error) {
-	if e.loadedTypes[4] {
+	if e.loadedTypes[5] {
 		return e.DetailedLines, nil
 	}
 	return nil, &NotLoadedError{edge: "detailed_lines"}
@@ -147,7 +163,7 @@ func (e ChargeUsageBasedRunsEdges) DetailedLinesOrErr() ([]*ChargeUsageBasedRunD
 func (e ChargeUsageBasedRunsEdges) InvoicedUsageOrErr() (*ChargeUsageBasedRunInvoicedUsage, error) {
 	if e.InvoicedUsage != nil {
 		return e.InvoicedUsage, nil
-	} else if e.loadedTypes[5] {
+	} else if e.loadedTypes[6] {
 		return nil, &NotFoundError{label: chargeusagebasedruninvoicedusage.Label}
 	}
 	return nil, &NotLoadedError{edge: "invoiced_usage"}
@@ -158,7 +174,7 @@ func (e ChargeUsageBasedRunsEdges) InvoicedUsageOrErr() (*ChargeUsageBasedRunInv
 func (e ChargeUsageBasedRunsEdges) PaymentOrErr() (*ChargeUsageBasedRunPayment, error) {
 	if e.Payment != nil {
 		return e.Payment, nil
-	} else if e.loadedTypes[6] {
+	} else if e.loadedTypes[7] {
 		return nil, &NotFoundError{label: chargeusagebasedrunpayment.Label}
 	}
 	return nil, &NotLoadedError{edge: "payment"}
@@ -173,7 +189,7 @@ func (*ChargeUsageBasedRuns) scanValues(columns []string) ([]any, error) {
 			values[i] = new(alpacadecimal.Decimal)
 		case chargeusagebasedruns.FieldDetailedLinesPresent:
 			values[i] = new(sql.NullBool)
-		case chargeusagebasedruns.FieldID, chargeusagebasedruns.FieldNamespace, chargeusagebasedruns.FieldChargeID, chargeusagebasedruns.FieldFeatureID, chargeusagebasedruns.FieldType, chargeusagebasedruns.FieldLineID:
+		case chargeusagebasedruns.FieldID, chargeusagebasedruns.FieldNamespace, chargeusagebasedruns.FieldChargeID, chargeusagebasedruns.FieldFeatureID, chargeusagebasedruns.FieldType, chargeusagebasedruns.FieldLineID, chargeusagebasedruns.FieldInvoiceID:
 			values[i] = new(sql.NullString)
 		case chargeusagebasedruns.FieldCreatedAt, chargeusagebasedruns.FieldUpdatedAt, chargeusagebasedruns.FieldDeletedAt, chargeusagebasedruns.FieldStoredAtLt, chargeusagebasedruns.FieldServicePeriodTo:
 			values[i] = new(sql.NullTime)
@@ -314,6 +330,13 @@ func (_m *ChargeUsageBasedRuns) assignValues(columns []string, values []any) err
 				_m.LineID = new(string)
 				*_m.LineID = value.String
 			}
+		case chargeusagebasedruns.FieldInvoiceID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field invoice_id", values[i])
+			} else if value.Valid {
+				_m.InvoiceID = new(string)
+				*_m.InvoiceID = value.String
+			}
 		case chargeusagebasedruns.FieldMeteredQuantity:
 			if value, ok := values[i].(*alpacadecimal.Decimal); !ok {
 				return fmt.Errorf("unexpected type %T for field metered_quantity", values[i])
@@ -346,6 +369,11 @@ func (_m *ChargeUsageBasedRuns) QueryFeature() *FeatureQuery {
 // QueryBillingInvoiceLine queries the "billing_invoice_line" edge of the ChargeUsageBasedRuns entity.
 func (_m *ChargeUsageBasedRuns) QueryBillingInvoiceLine() *BillingInvoiceLineQuery {
 	return NewChargeUsageBasedRunsClient(_m.config).QueryBillingInvoiceLine(_m)
+}
+
+// QueryBillingInvoice queries the "billing_invoice" edge of the ChargeUsageBasedRuns entity.
+func (_m *ChargeUsageBasedRuns) QueryBillingInvoice() *BillingInvoiceQuery {
+	return NewChargeUsageBasedRunsClient(_m.config).QueryBillingInvoice(_m)
 }
 
 // QueryCreditAllocations queries the "credit_allocations" edge of the ChargeUsageBasedRuns entity.
@@ -449,6 +477,11 @@ func (_m *ChargeUsageBasedRuns) String() string {
 	builder.WriteString(", ")
 	if v := _m.LineID; v != nil {
 		builder.WriteString("line_id=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	if v := _m.InvoiceID; v != nil {
+		builder.WriteString("invoice_id=")
 		builder.WriteString(*v)
 	}
 	builder.WriteString(", ")

--- a/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
+++ b/openmeter/ent/db/chargeusagebasedruns/chargeusagebasedruns.go
@@ -54,6 +54,8 @@ const (
 	FieldDetailedLinesPresent = "detailed_lines_present"
 	// FieldLineID holds the string denoting the line_id field in the database.
 	FieldLineID = "line_id"
+	// FieldInvoiceID holds the string denoting the invoice_id field in the database.
+	FieldInvoiceID = "invoice_id"
 	// FieldMeteredQuantity holds the string denoting the metered_quantity field in the database.
 	FieldMeteredQuantity = "metered_quantity"
 	// EdgeUsageBased holds the string denoting the usage_based edge name in mutations.
@@ -62,6 +64,8 @@ const (
 	EdgeFeature = "feature"
 	// EdgeBillingInvoiceLine holds the string denoting the billing_invoice_line edge name in mutations.
 	EdgeBillingInvoiceLine = "billing_invoice_line"
+	// EdgeBillingInvoice holds the string denoting the billing_invoice edge name in mutations.
+	EdgeBillingInvoice = "billing_invoice"
 	// EdgeCreditAllocations holds the string denoting the credit_allocations edge name in mutations.
 	EdgeCreditAllocations = "credit_allocations"
 	// EdgeDetailedLines holds the string denoting the detailed_lines edge name in mutations.
@@ -93,6 +97,13 @@ const (
 	BillingInvoiceLineInverseTable = "billing_invoice_lines"
 	// BillingInvoiceLineColumn is the table column denoting the billing_invoice_line relation/edge.
 	BillingInvoiceLineColumn = "line_id"
+	// BillingInvoiceTable is the table that holds the billing_invoice relation/edge.
+	BillingInvoiceTable = "charge_usage_based_runs"
+	// BillingInvoiceInverseTable is the table name for the BillingInvoice entity.
+	// It exists in this package in order to avoid circular dependency with the "billinginvoice" package.
+	BillingInvoiceInverseTable = "billing_invoices"
+	// BillingInvoiceColumn is the table column denoting the billing_invoice relation/edge.
+	BillingInvoiceColumn = "invoice_id"
 	// CreditAllocationsTable is the table that holds the credit_allocations relation/edge.
 	CreditAllocationsTable = "charge_usage_based_run_credit_allocations"
 	// CreditAllocationsInverseTable is the table name for the ChargeUsageBasedRunCreditAllocations entity.
@@ -145,6 +156,7 @@ var Columns = []string{
 	FieldServicePeriodTo,
 	FieldDetailedLinesPresent,
 	FieldLineID,
+	FieldInvoiceID,
 	FieldMeteredQuantity,
 }
 
@@ -171,6 +183,8 @@ var (
 	FeatureIDValidator func(string) error
 	// LineIDValidator is a validator for the "line_id" field. It is called by the builders before save.
 	LineIDValidator func(string) error
+	// InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
+	InvoiceIDValidator func(string) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -288,6 +302,11 @@ func ByLineID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldLineID, opts...).ToFunc()
 }
 
+// ByInvoiceID orders the results by the invoice_id field.
+func ByInvoiceID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldInvoiceID, opts...).ToFunc()
+}
+
 // ByMeteredQuantity orders the results by the metered_quantity field.
 func ByMeteredQuantity(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldMeteredQuantity, opts...).ToFunc()
@@ -311,6 +330,13 @@ func ByFeatureField(field string, opts ...sql.OrderTermOption) OrderOption {
 func ByBillingInvoiceLineField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newBillingInvoiceLineStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByBillingInvoiceField orders the results by billing_invoice field.
+func ByBillingInvoiceField(field string, opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newBillingInvoiceStep(), sql.OrderByField(field, opts...))
 	}
 }
 
@@ -374,6 +400,13 @@ func newBillingInvoiceLineStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(BillingInvoiceLineInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.O2O, true, BillingInvoiceLineTable, BillingInvoiceLineColumn),
+	)
+}
+func newBillingInvoiceStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(BillingInvoiceInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, BillingInvoiceTable, BillingInvoiceColumn),
 	)
 }
 func newCreditAllocationsStep() *sqlgraph.Step {

--- a/openmeter/ent/db/chargeusagebasedruns/where.go
+++ b/openmeter/ent/db/chargeusagebasedruns/where.go
@@ -157,6 +157,11 @@ func LineID(v string) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldLineID, v))
 }
 
+// InvoiceID applies equality check predicate on the "invoice_id" field. It's identical to InvoiceIDEQ.
+func InvoiceID(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldInvoiceID, v))
+}
+
 // MeteredQuantity applies equality check predicate on the "metered_quantity" field. It's identical to MeteredQuantityEQ.
 func MeteredQuantity(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldMeteredQuantity, v))
@@ -1002,6 +1007,81 @@ func LineIDContainsFold(v string) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldContainsFold(FieldLineID, v))
 }
 
+// InvoiceIDEQ applies the EQ predicate on the "invoice_id" field.
+func InvoiceIDEQ(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldInvoiceID, v))
+}
+
+// InvoiceIDNEQ applies the NEQ predicate on the "invoice_id" field.
+func InvoiceIDNEQ(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNEQ(FieldInvoiceID, v))
+}
+
+// InvoiceIDIn applies the In predicate on the "invoice_id" field.
+func InvoiceIDIn(vs ...string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldIn(FieldInvoiceID, vs...))
+}
+
+// InvoiceIDNotIn applies the NotIn predicate on the "invoice_id" field.
+func InvoiceIDNotIn(vs ...string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNotIn(FieldInvoiceID, vs...))
+}
+
+// InvoiceIDGT applies the GT predicate on the "invoice_id" field.
+func InvoiceIDGT(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldGT(FieldInvoiceID, v))
+}
+
+// InvoiceIDGTE applies the GTE predicate on the "invoice_id" field.
+func InvoiceIDGTE(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldGTE(FieldInvoiceID, v))
+}
+
+// InvoiceIDLT applies the LT predicate on the "invoice_id" field.
+func InvoiceIDLT(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldLT(FieldInvoiceID, v))
+}
+
+// InvoiceIDLTE applies the LTE predicate on the "invoice_id" field.
+func InvoiceIDLTE(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldLTE(FieldInvoiceID, v))
+}
+
+// InvoiceIDContains applies the Contains predicate on the "invoice_id" field.
+func InvoiceIDContains(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldContains(FieldInvoiceID, v))
+}
+
+// InvoiceIDHasPrefix applies the HasPrefix predicate on the "invoice_id" field.
+func InvoiceIDHasPrefix(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldHasPrefix(FieldInvoiceID, v))
+}
+
+// InvoiceIDHasSuffix applies the HasSuffix predicate on the "invoice_id" field.
+func InvoiceIDHasSuffix(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldHasSuffix(FieldInvoiceID, v))
+}
+
+// InvoiceIDIsNil applies the IsNil predicate on the "invoice_id" field.
+func InvoiceIDIsNil() predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldIsNull(FieldInvoiceID))
+}
+
+// InvoiceIDNotNil applies the NotNil predicate on the "invoice_id" field.
+func InvoiceIDNotNil() predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldNotNull(FieldInvoiceID))
+}
+
+// InvoiceIDEqualFold applies the EqualFold predicate on the "invoice_id" field.
+func InvoiceIDEqualFold(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldEqualFold(FieldInvoiceID, v))
+}
+
+// InvoiceIDContainsFold applies the ContainsFold predicate on the "invoice_id" field.
+func InvoiceIDContainsFold(v string) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(sql.FieldContainsFold(FieldInvoiceID, v))
+}
+
 // MeteredQuantityEQ applies the EQ predicate on the "metered_quantity" field.
 func MeteredQuantityEQ(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(sql.FieldEQ(FieldMeteredQuantity, v))
@@ -1103,6 +1183,29 @@ func HasBillingInvoiceLine() predicate.ChargeUsageBasedRuns {
 func HasBillingInvoiceLineWith(preds ...predicate.BillingInvoiceLine) predicate.ChargeUsageBasedRuns {
 	return predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
 		step := newBillingInvoiceLineStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasBillingInvoice applies the HasEdge predicate on the "billing_invoice" edge.
+func HasBillingInvoice() predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, BillingInvoiceTable, BillingInvoiceColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasBillingInvoiceWith applies the HasEdge predicate on the "billing_invoice" edge with a given conditions (other predicates).
+func HasBillingInvoiceWith(preds ...predicate.BillingInvoice) predicate.ChargeUsageBasedRuns {
+	return predicate.ChargeUsageBasedRuns(func(s *sql.Selector) {
+		step := newBillingInvoiceStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/openmeter/ent/db/chargeusagebasedruns_create.go
+++ b/openmeter/ent/db/chargeusagebasedruns_create.go
@@ -14,6 +14,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoice"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebased"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruncreditallocations"
@@ -178,6 +179,20 @@ func (_c *ChargeUsageBasedRunsCreate) SetNillableLineID(v *string) *ChargeUsageB
 	return _c
 }
 
+// SetInvoiceID sets the "invoice_id" field.
+func (_c *ChargeUsageBasedRunsCreate) SetInvoiceID(v string) *ChargeUsageBasedRunsCreate {
+	_c.mutation.SetInvoiceID(v)
+	return _c
+}
+
+// SetNillableInvoiceID sets the "invoice_id" field if the given value is not nil.
+func (_c *ChargeUsageBasedRunsCreate) SetNillableInvoiceID(v *string) *ChargeUsageBasedRunsCreate {
+	if v != nil {
+		_c.SetInvoiceID(*v)
+	}
+	return _c
+}
+
 // SetMeteredQuantity sets the "metered_quantity" field.
 func (_c *ChargeUsageBasedRunsCreate) SetMeteredQuantity(v alpacadecimal.Decimal) *ChargeUsageBasedRunsCreate {
 	_c.mutation.SetMeteredQuantity(v)
@@ -231,6 +246,25 @@ func (_c *ChargeUsageBasedRunsCreate) SetNillableBillingInvoiceLineID(id *string
 // SetBillingInvoiceLine sets the "billing_invoice_line" edge to the BillingInvoiceLine entity.
 func (_c *ChargeUsageBasedRunsCreate) SetBillingInvoiceLine(v *BillingInvoiceLine) *ChargeUsageBasedRunsCreate {
 	return _c.SetBillingInvoiceLineID(v.ID)
+}
+
+// SetBillingInvoiceID sets the "billing_invoice" edge to the BillingInvoice entity by ID.
+func (_c *ChargeUsageBasedRunsCreate) SetBillingInvoiceID(id string) *ChargeUsageBasedRunsCreate {
+	_c.mutation.SetBillingInvoiceID(id)
+	return _c
+}
+
+// SetNillableBillingInvoiceID sets the "billing_invoice" edge to the BillingInvoice entity by ID if the given value is not nil.
+func (_c *ChargeUsageBasedRunsCreate) SetNillableBillingInvoiceID(id *string) *ChargeUsageBasedRunsCreate {
+	if id != nil {
+		_c = _c.SetBillingInvoiceID(*id)
+	}
+	return _c
+}
+
+// SetBillingInvoice sets the "billing_invoice" edge to the BillingInvoice entity.
+func (_c *ChargeUsageBasedRunsCreate) SetBillingInvoice(v *BillingInvoice) *ChargeUsageBasedRunsCreate {
+	return _c.SetBillingInvoiceID(v.ID)
 }
 
 // AddCreditAllocationIDs adds the "credit_allocations" edge to the ChargeUsageBasedRunCreditAllocations entity by IDs.
@@ -423,6 +457,11 @@ func (_c *ChargeUsageBasedRunsCreate) check() error {
 			return &ValidationError{Name: "line_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRuns.line_id": %w`, err)}
 		}
 	}
+	if v, ok := _c.mutation.InvoiceID(); ok {
+		if err := chargeusagebasedruns.InvoiceIDValidator(v); err != nil {
+			return &ValidationError{Name: "invoice_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRuns.invoice_id": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.MeteredQuantity(); !ok {
 		return &ValidationError{Name: "metered_quantity", err: errors.New(`db: missing required field "ChargeUsageBasedRuns.metered_quantity"`)}
 	}
@@ -585,6 +624,23 @@ func (_c *ChargeUsageBasedRunsCreate) createSpec() (*ChargeUsageBasedRuns, *sqlg
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.LineID = &nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.BillingInvoiceIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeusagebasedruns.BillingInvoiceTable,
+			Columns: []string{chargeusagebasedruns.BillingInvoiceColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billinginvoice.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.InvoiceID = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := _c.mutation.CreditAllocationsIDs(); len(nodes) > 0 {
@@ -917,6 +973,9 @@ func (u *ChargeUsageBasedRunsUpsertOne) UpdateNewValues() *ChargeUsageBasedRunsU
 		}
 		if _, exists := u.create.mutation.ServicePeriodTo(); exists {
 			s.SetIgnore(chargeusagebasedruns.FieldServicePeriodTo)
+		}
+		if _, exists := u.create.mutation.InvoiceID(); exists {
+			s.SetIgnore(chargeusagebasedruns.FieldInvoiceID)
 		}
 	}))
 	return u
@@ -1359,6 +1418,9 @@ func (u *ChargeUsageBasedRunsUpsertBulk) UpdateNewValues() *ChargeUsageBasedRuns
 			}
 			if _, exists := b.mutation.ServicePeriodTo(); exists {
 				s.SetIgnore(chargeusagebasedruns.FieldServicePeriodTo)
+			}
+			if _, exists := b.mutation.InvoiceID(); exists {
+				s.SetIgnore(chargeusagebasedruns.FieldInvoiceID)
 			}
 		}
 	}))

--- a/openmeter/ent/db/chargeusagebasedruns_query.go
+++ b/openmeter/ent/db/chargeusagebasedruns_query.go
@@ -13,6 +13,7 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoice"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebased"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruncreditallocations"
@@ -34,6 +35,7 @@ type ChargeUsageBasedRunsQuery struct {
 	withUsageBased         *ChargeUsageBasedQuery
 	withFeature            *FeatureQuery
 	withBillingInvoiceLine *BillingInvoiceLineQuery
+	withBillingInvoice     *BillingInvoiceQuery
 	withCreditAllocations  *ChargeUsageBasedRunCreditAllocationsQuery
 	withDetailedLines      *ChargeUsageBasedRunDetailedLineQuery
 	withInvoicedUsage      *ChargeUsageBasedRunInvoicedUsageQuery
@@ -134,6 +136,28 @@ func (_q *ChargeUsageBasedRunsQuery) QueryBillingInvoiceLine() *BillingInvoiceLi
 			sqlgraph.From(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID, selector),
 			sqlgraph.To(billinginvoiceline.Table, billinginvoiceline.FieldID),
 			sqlgraph.Edge(sqlgraph.O2O, true, chargeusagebasedruns.BillingInvoiceLineTable, chargeusagebasedruns.BillingInvoiceLineColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryBillingInvoice chains the current query on the "billing_invoice" edge.
+func (_q *ChargeUsageBasedRunsQuery) QueryBillingInvoice() *BillingInvoiceQuery {
+	query := (&BillingInvoiceClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID, selector),
+			sqlgraph.To(billinginvoice.Table, billinginvoice.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, chargeusagebasedruns.BillingInvoiceTable, chargeusagebasedruns.BillingInvoiceColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -424,6 +448,7 @@ func (_q *ChargeUsageBasedRunsQuery) Clone() *ChargeUsageBasedRunsQuery {
 		withUsageBased:         _q.withUsageBased.Clone(),
 		withFeature:            _q.withFeature.Clone(),
 		withBillingInvoiceLine: _q.withBillingInvoiceLine.Clone(),
+		withBillingInvoice:     _q.withBillingInvoice.Clone(),
 		withCreditAllocations:  _q.withCreditAllocations.Clone(),
 		withDetailedLines:      _q.withDetailedLines.Clone(),
 		withInvoicedUsage:      _q.withInvoicedUsage.Clone(),
@@ -464,6 +489,17 @@ func (_q *ChargeUsageBasedRunsQuery) WithBillingInvoiceLine(opts ...func(*Billin
 		opt(query)
 	}
 	_q.withBillingInvoiceLine = query
+	return _q
+}
+
+// WithBillingInvoice tells the query-builder to eager-load the nodes that are connected to
+// the "billing_invoice" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *ChargeUsageBasedRunsQuery) WithBillingInvoice(opts ...func(*BillingInvoiceQuery)) *ChargeUsageBasedRunsQuery {
+	query := (&BillingInvoiceClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withBillingInvoice = query
 	return _q
 }
 
@@ -589,10 +625,11 @@ func (_q *ChargeUsageBasedRunsQuery) sqlAll(ctx context.Context, hooks ...queryH
 	var (
 		nodes       = []*ChargeUsageBasedRuns{}
 		_spec       = _q.querySpec()
-		loadedTypes = [7]bool{
+		loadedTypes = [8]bool{
 			_q.withUsageBased != nil,
 			_q.withFeature != nil,
 			_q.withBillingInvoiceLine != nil,
+			_q.withBillingInvoice != nil,
 			_q.withCreditAllocations != nil,
 			_q.withDetailedLines != nil,
 			_q.withInvoicedUsage != nil,
@@ -635,6 +672,12 @@ func (_q *ChargeUsageBasedRunsQuery) sqlAll(ctx context.Context, hooks ...queryH
 	if query := _q.withBillingInvoiceLine; query != nil {
 		if err := _q.loadBillingInvoiceLine(ctx, query, nodes, nil,
 			func(n *ChargeUsageBasedRuns, e *BillingInvoiceLine) { n.Edges.BillingInvoiceLine = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withBillingInvoice; query != nil {
+		if err := _q.loadBillingInvoice(ctx, query, nodes, nil,
+			func(n *ChargeUsageBasedRuns, e *BillingInvoice) { n.Edges.BillingInvoice = e }); err != nil {
 			return nil, err
 		}
 	}
@@ -754,6 +797,38 @@ func (_q *ChargeUsageBasedRunsQuery) loadBillingInvoiceLine(ctx context.Context,
 		nodes, ok := nodeids[n.ID]
 		if !ok {
 			return fmt.Errorf(`unexpected foreign-key "line_id" returned %v`, n.ID)
+		}
+		for i := range nodes {
+			assign(nodes[i], n)
+		}
+	}
+	return nil
+}
+func (_q *ChargeUsageBasedRunsQuery) loadBillingInvoice(ctx context.Context, query *BillingInvoiceQuery, nodes []*ChargeUsageBasedRuns, init func(*ChargeUsageBasedRuns), assign func(*ChargeUsageBasedRuns, *BillingInvoice)) error {
+	ids := make([]string, 0, len(nodes))
+	nodeids := make(map[string][]*ChargeUsageBasedRuns)
+	for i := range nodes {
+		if nodes[i].InvoiceID == nil {
+			continue
+		}
+		fk := *nodes[i].InvoiceID
+		if _, ok := nodeids[fk]; !ok {
+			ids = append(ids, fk)
+		}
+		nodeids[fk] = append(nodeids[fk], nodes[i])
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	query.Where(billinginvoice.IDIn(ids...))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nodeids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected foreign-key "invoice_id" returned %v`, n.ID)
 		}
 		for i := range nodes {
 			assign(nodes[i], n)
@@ -912,6 +987,9 @@ func (_q *ChargeUsageBasedRunsQuery) querySpec() *sqlgraph.QuerySpec {
 		}
 		if _q.withBillingInvoiceLine != nil {
 			_spec.Node.AddColumnOnce(chargeusagebasedruns.FieldLineID)
+		}
+		if _q.withBillingInvoice != nil {
+			_spec.Node.AddColumnOnce(chargeusagebasedruns.FieldInvoiceID)
 		}
 	}
 	if ps := _q.predicates; len(ps) > 0 {

--- a/openmeter/ent/db/client.go
+++ b/openmeter/ent/db/client.go
@@ -2955,6 +2955,22 @@ func (c *BillingInvoiceClient) QueryBillingInvoiceValidationIssues(_m *BillingIn
 	return query
 }
 
+// QueryChargeUsageBasedRuns queries the charge_usage_based_runs edge of a BillingInvoice.
+func (c *BillingInvoiceClient) QueryChargeUsageBasedRuns(_m *BillingInvoice) *ChargeUsageBasedRunsQuery {
+	query := (&ChargeUsageBasedRunsClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(billinginvoice.Table, billinginvoice.FieldID, id),
+			sqlgraph.To(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, billinginvoice.ChargeUsageBasedRunsTable, billinginvoice.ChargeUsageBasedRunsColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryBillingInvoiceCustomer queries the billing_invoice_customer edge of a BillingInvoice.
 func (c *BillingInvoiceClient) QueryBillingInvoiceCustomer(_m *BillingInvoice) *CustomerQuery {
 	query := (&CustomerClient{config: c.config}).Query()
@@ -8517,6 +8533,22 @@ func (c *ChargeUsageBasedRunsClient) QueryBillingInvoiceLine(_m *ChargeUsageBase
 			sqlgraph.From(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID, id),
 			sqlgraph.To(billinginvoiceline.Table, billinginvoiceline.FieldID),
 			sqlgraph.Edge(sqlgraph.O2O, true, chargeusagebasedruns.BillingInvoiceLineTable, chargeusagebasedruns.BillingInvoiceLineColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryBillingInvoice queries the billing_invoice edge of a ChargeUsageBasedRuns.
+func (c *ChargeUsageBasedRunsClient) QueryBillingInvoice(_m *ChargeUsageBasedRuns) *BillingInvoiceQuery {
+	query := (&BillingInvoiceClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeusagebasedruns.Table, chargeusagebasedruns.FieldID, id),
+			sqlgraph.To(billinginvoice.Table, billinginvoice.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, chargeusagebasedruns.BillingInvoiceTable, chargeusagebasedruns.BillingInvoiceColumn),
 		)
 		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
 		return fromV, nil

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -2765,6 +2765,7 @@ var (
 		{Name: "service_period_to", Type: field.TypeTime},
 		{Name: "detailed_lines_present", Type: field.TypeBool},
 		{Name: "metered_quantity", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
+		{Name: "invoice_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "line_id", Type: field.TypeString, Unique: true, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "charge_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "feature_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -2776,20 +2777,26 @@ var (
 		PrimaryKey: []*schema.Column{ChargeUsageBasedRunsColumns[0]},
 		ForeignKeys: []*schema.ForeignKey{
 			{
-				Symbol:     "charge_usage_based_runs_billing_invoice_lines_charge_usage_based_run",
+				Symbol:     "charge_usage_based_runs_billing_invoices_charge_usage_based_runs",
 				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[18]},
+				RefColumns: []*schema.Column{BillingInvoicesColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+			{
+				Symbol:     "charge_usage_based_runs_billing_invoice_lines_charge_usage_based_run",
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[19]},
 				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_charge_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[19]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[20]},
 				RefColumns: []*schema.Column{ChargeUsageBasedColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "charge_usage_based_runs_features_usage_based_runs",
-				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[20]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunsColumns[21]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -2808,7 +2815,7 @@ var (
 			{
 				Name:    "chargeusagebasedruns_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[19]},
+				Columns: []*schema.Column{ChargeUsageBasedRunsColumns[1], ChargeUsageBasedRunsColumns[20]},
 			},
 		},
 	}
@@ -5186,9 +5193,10 @@ func init() {
 	}
 	ChargeUsageBasedRunInvoicedUsagesTable.ForeignKeys[0].RefTable = ChargeUsageBasedRunsTable
 	ChargeUsageBasedRunPaymentsTable.ForeignKeys[0].RefTable = ChargeUsageBasedRunsTable
-	ChargeUsageBasedRunsTable.ForeignKeys[0].RefTable = BillingInvoiceLinesTable
-	ChargeUsageBasedRunsTable.ForeignKeys[1].RefTable = ChargeUsageBasedTable
-	ChargeUsageBasedRunsTable.ForeignKeys[2].RefTable = FeaturesTable
+	ChargeUsageBasedRunsTable.ForeignKeys[0].RefTable = BillingInvoicesTable
+	ChargeUsageBasedRunsTable.ForeignKeys[1].RefTable = BillingInvoiceLinesTable
+	ChargeUsageBasedRunsTable.ForeignKeys[2].RefTable = ChargeUsageBasedTable
+	ChargeUsageBasedRunsTable.ForeignKeys[3].RefTable = FeaturesTable
 	CreditRealizationLineagesTable.ForeignKeys[0].RefTable = ChargesTable
 	CreditRealizationLineageSegmentsTable.ForeignKeys[0].RefTable = CreditRealizationLineagesTable
 	CurrencyCostBasesTable.ForeignKeys[0].RefTable = CustomCurrenciesTable

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -11946,6 +11946,9 @@ type BillingInvoiceMutation struct {
 	billing_invoice_validation_issues        map[string]struct{}
 	removedbilling_invoice_validation_issues map[string]struct{}
 	clearedbilling_invoice_validation_issues bool
+	charge_usage_based_runs                  map[string]struct{}
+	removedcharge_usage_based_runs           map[string]struct{}
+	clearedcharge_usage_based_runs           bool
 	billing_invoice_customer                 *string
 	clearedbilling_invoice_customer          bool
 	tax_app                                  *string
@@ -14842,6 +14845,60 @@ func (m *BillingInvoiceMutation) ResetBillingInvoiceValidationIssues() {
 	m.removedbilling_invoice_validation_issues = nil
 }
 
+// AddChargeUsageBasedRunIDs adds the "charge_usage_based_runs" edge to the ChargeUsageBasedRuns entity by ids.
+func (m *BillingInvoiceMutation) AddChargeUsageBasedRunIDs(ids ...string) {
+	if m.charge_usage_based_runs == nil {
+		m.charge_usage_based_runs = make(map[string]struct{})
+	}
+	for i := range ids {
+		m.charge_usage_based_runs[ids[i]] = struct{}{}
+	}
+}
+
+// ClearChargeUsageBasedRuns clears the "charge_usage_based_runs" edge to the ChargeUsageBasedRuns entity.
+func (m *BillingInvoiceMutation) ClearChargeUsageBasedRuns() {
+	m.clearedcharge_usage_based_runs = true
+}
+
+// ChargeUsageBasedRunsCleared reports if the "charge_usage_based_runs" edge to the ChargeUsageBasedRuns entity was cleared.
+func (m *BillingInvoiceMutation) ChargeUsageBasedRunsCleared() bool {
+	return m.clearedcharge_usage_based_runs
+}
+
+// RemoveChargeUsageBasedRunIDs removes the "charge_usage_based_runs" edge to the ChargeUsageBasedRuns entity by IDs.
+func (m *BillingInvoiceMutation) RemoveChargeUsageBasedRunIDs(ids ...string) {
+	if m.removedcharge_usage_based_runs == nil {
+		m.removedcharge_usage_based_runs = make(map[string]struct{})
+	}
+	for i := range ids {
+		delete(m.charge_usage_based_runs, ids[i])
+		m.removedcharge_usage_based_runs[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedChargeUsageBasedRuns returns the removed IDs of the "charge_usage_based_runs" edge to the ChargeUsageBasedRuns entity.
+func (m *BillingInvoiceMutation) RemovedChargeUsageBasedRunsIDs() (ids []string) {
+	for id := range m.removedcharge_usage_based_runs {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ChargeUsageBasedRunsIDs returns the "charge_usage_based_runs" edge IDs in the mutation.
+func (m *BillingInvoiceMutation) ChargeUsageBasedRunsIDs() (ids []string) {
+	for id := range m.charge_usage_based_runs {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetChargeUsageBasedRuns resets all changes to the "charge_usage_based_runs" edge.
+func (m *BillingInvoiceMutation) ResetChargeUsageBasedRuns() {
+	m.charge_usage_based_runs = nil
+	m.clearedcharge_usage_based_runs = false
+	m.removedcharge_usage_based_runs = nil
+}
+
 // SetBillingInvoiceCustomerID sets the "billing_invoice_customer" edge to the Customer entity by id.
 func (m *BillingInvoiceMutation) SetBillingInvoiceCustomerID(id string) {
 	m.billing_invoice_customer = &id
@@ -16287,7 +16344,7 @@ func (m *BillingInvoiceMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *BillingInvoiceMutation) AddedEdges() []string {
-	edges := make([]string, 0, 9)
+	edges := make([]string, 0, 10)
 	if m.source_billing_profile != nil {
 		edges = append(edges, billinginvoice.EdgeSourceBillingProfile)
 	}
@@ -16302,6 +16359,9 @@ func (m *BillingInvoiceMutation) AddedEdges() []string {
 	}
 	if m.billing_invoice_validation_issues != nil {
 		edges = append(edges, billinginvoice.EdgeBillingInvoiceValidationIssues)
+	}
+	if m.charge_usage_based_runs != nil {
+		edges = append(edges, billinginvoice.EdgeChargeUsageBasedRuns)
 	}
 	if m.billing_invoice_customer != nil {
 		edges = append(edges, billinginvoice.EdgeBillingInvoiceCustomer)
@@ -16348,6 +16408,12 @@ func (m *BillingInvoiceMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case billinginvoice.EdgeChargeUsageBasedRuns:
+		ids := make([]ent.Value, 0, len(m.charge_usage_based_runs))
+		for id := range m.charge_usage_based_runs {
+			ids = append(ids, id)
+		}
+		return ids
 	case billinginvoice.EdgeBillingInvoiceCustomer:
 		if id := m.billing_invoice_customer; id != nil {
 			return []ent.Value{*id}
@@ -16370,7 +16436,7 @@ func (m *BillingInvoiceMutation) AddedIDs(name string) []ent.Value {
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *BillingInvoiceMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 9)
+	edges := make([]string, 0, 10)
 	if m.removedbilling_invoice_lines != nil {
 		edges = append(edges, billinginvoice.EdgeBillingInvoiceLines)
 	}
@@ -16379,6 +16445,9 @@ func (m *BillingInvoiceMutation) RemovedEdges() []string {
 	}
 	if m.removedbilling_invoice_validation_issues != nil {
 		edges = append(edges, billinginvoice.EdgeBillingInvoiceValidationIssues)
+	}
+	if m.removedcharge_usage_based_runs != nil {
+		edges = append(edges, billinginvoice.EdgeChargeUsageBasedRuns)
 	}
 	return edges
 }
@@ -16405,13 +16474,19 @@ func (m *BillingInvoiceMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case billinginvoice.EdgeChargeUsageBasedRuns:
+		ids := make([]ent.Value, 0, len(m.removedcharge_usage_based_runs))
+		for id := range m.removedcharge_usage_based_runs {
+			ids = append(ids, id)
+		}
+		return ids
 	}
 	return nil
 }
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *BillingInvoiceMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 9)
+	edges := make([]string, 0, 10)
 	if m.clearedsource_billing_profile {
 		edges = append(edges, billinginvoice.EdgeSourceBillingProfile)
 	}
@@ -16426,6 +16501,9 @@ func (m *BillingInvoiceMutation) ClearedEdges() []string {
 	}
 	if m.clearedbilling_invoice_validation_issues {
 		edges = append(edges, billinginvoice.EdgeBillingInvoiceValidationIssues)
+	}
+	if m.clearedcharge_usage_based_runs {
+		edges = append(edges, billinginvoice.EdgeChargeUsageBasedRuns)
 	}
 	if m.clearedbilling_invoice_customer {
 		edges = append(edges, billinginvoice.EdgeBillingInvoiceCustomer)
@@ -16456,6 +16534,8 @@ func (m *BillingInvoiceMutation) EdgeCleared(name string) bool {
 		return m.clearedbilling_invoice_detailed_lines
 	case billinginvoice.EdgeBillingInvoiceValidationIssues:
 		return m.clearedbilling_invoice_validation_issues
+	case billinginvoice.EdgeChargeUsageBasedRuns:
+		return m.clearedcharge_usage_based_runs
 	case billinginvoice.EdgeBillingInvoiceCustomer:
 		return m.clearedbilling_invoice_customer
 	case billinginvoice.EdgeTaxApp:
@@ -16512,6 +16592,9 @@ func (m *BillingInvoiceMutation) ResetEdge(name string) error {
 		return nil
 	case billinginvoice.EdgeBillingInvoiceValidationIssues:
 		m.ResetBillingInvoiceValidationIssues()
+		return nil
+	case billinginvoice.EdgeChargeUsageBasedRuns:
+		m.ResetChargeUsageBasedRuns()
 		return nil
 	case billinginvoice.EdgeBillingInvoiceCustomer:
 		m.ResetBillingInvoiceCustomer()
@@ -61801,6 +61884,8 @@ type ChargeUsageBasedRunsMutation struct {
 	clearedfeature              bool
 	billing_invoice_line        *string
 	clearedbilling_invoice_line bool
+	billing_invoice             *string
+	clearedbilling_invoice      bool
 	credit_allocations          map[string]struct{}
 	removedcredit_allocations   map[string]struct{}
 	clearedcredit_allocations   bool
@@ -62630,6 +62715,55 @@ func (m *ChargeUsageBasedRunsMutation) ResetLineID() {
 	delete(m.clearedFields, chargeusagebasedruns.FieldLineID)
 }
 
+// SetInvoiceID sets the "invoice_id" field.
+func (m *ChargeUsageBasedRunsMutation) SetInvoiceID(s string) {
+	m.billing_invoice = &s
+}
+
+// InvoiceID returns the value of the "invoice_id" field in the mutation.
+func (m *ChargeUsageBasedRunsMutation) InvoiceID() (r string, exists bool) {
+	v := m.billing_invoice
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldInvoiceID returns the old "invoice_id" field's value of the ChargeUsageBasedRuns entity.
+// If the ChargeUsageBasedRuns object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedRunsMutation) OldInvoiceID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldInvoiceID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldInvoiceID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldInvoiceID: %w", err)
+	}
+	return oldValue.InvoiceID, nil
+}
+
+// ClearInvoiceID clears the value of the "invoice_id" field.
+func (m *ChargeUsageBasedRunsMutation) ClearInvoiceID() {
+	m.billing_invoice = nil
+	m.clearedFields[chargeusagebasedruns.FieldInvoiceID] = struct{}{}
+}
+
+// InvoiceIDCleared returns if the "invoice_id" field was cleared in this mutation.
+func (m *ChargeUsageBasedRunsMutation) InvoiceIDCleared() bool {
+	_, ok := m.clearedFields[chargeusagebasedruns.FieldInvoiceID]
+	return ok
+}
+
+// ResetInvoiceID resets all changes to the "invoice_id" field.
+func (m *ChargeUsageBasedRunsMutation) ResetInvoiceID() {
+	m.billing_invoice = nil
+	delete(m.clearedFields, chargeusagebasedruns.FieldInvoiceID)
+}
+
 // SetMeteredQuantity sets the "metered_quantity" field.
 func (m *ChargeUsageBasedRunsMutation) SetMeteredQuantity(a alpacadecimal.Decimal) {
 	m.metered_quantity = &a
@@ -62771,6 +62905,46 @@ func (m *ChargeUsageBasedRunsMutation) BillingInvoiceLineIDs() (ids []string) {
 func (m *ChargeUsageBasedRunsMutation) ResetBillingInvoiceLine() {
 	m.billing_invoice_line = nil
 	m.clearedbilling_invoice_line = false
+}
+
+// SetBillingInvoiceID sets the "billing_invoice" edge to the BillingInvoice entity by id.
+func (m *ChargeUsageBasedRunsMutation) SetBillingInvoiceID(id string) {
+	m.billing_invoice = &id
+}
+
+// ClearBillingInvoice clears the "billing_invoice" edge to the BillingInvoice entity.
+func (m *ChargeUsageBasedRunsMutation) ClearBillingInvoice() {
+	m.clearedbilling_invoice = true
+	m.clearedFields[chargeusagebasedruns.FieldInvoiceID] = struct{}{}
+}
+
+// BillingInvoiceCleared reports if the "billing_invoice" edge to the BillingInvoice entity was cleared.
+func (m *ChargeUsageBasedRunsMutation) BillingInvoiceCleared() bool {
+	return m.InvoiceIDCleared() || m.clearedbilling_invoice
+}
+
+// BillingInvoiceID returns the "billing_invoice" edge ID in the mutation.
+func (m *ChargeUsageBasedRunsMutation) BillingInvoiceID() (id string, exists bool) {
+	if m.billing_invoice != nil {
+		return *m.billing_invoice, true
+	}
+	return
+}
+
+// BillingInvoiceIDs returns the "billing_invoice" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// BillingInvoiceID instead. It exists only for internal usage by the builders.
+func (m *ChargeUsageBasedRunsMutation) BillingInvoiceIDs() (ids []string) {
+	if id := m.billing_invoice; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetBillingInvoice resets all changes to the "billing_invoice" edge.
+func (m *ChargeUsageBasedRunsMutation) ResetBillingInvoice() {
+	m.billing_invoice = nil
+	m.clearedbilling_invoice = false
 }
 
 // AddCreditAllocationIDs adds the "credit_allocations" edge to the ChargeUsageBasedRunCreditAllocations entity by ids.
@@ -62993,7 +63167,7 @@ func (m *ChargeUsageBasedRunsMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedRunsMutation) Fields() []string {
-	fields := make([]string, 0, 20)
+	fields := make([]string, 0, 21)
 	if m.namespace != nil {
 		fields = append(fields, chargeusagebasedruns.FieldNamespace)
 	}
@@ -63051,6 +63225,9 @@ func (m *ChargeUsageBasedRunsMutation) Fields() []string {
 	if m.billing_invoice_line != nil {
 		fields = append(fields, chargeusagebasedruns.FieldLineID)
 	}
+	if m.billing_invoice != nil {
+		fields = append(fields, chargeusagebasedruns.FieldInvoiceID)
+	}
 	if m.metered_quantity != nil {
 		fields = append(fields, chargeusagebasedruns.FieldMeteredQuantity)
 	}
@@ -63100,6 +63277,8 @@ func (m *ChargeUsageBasedRunsMutation) Field(name string) (ent.Value, bool) {
 		return m.DetailedLinesPresent()
 	case chargeusagebasedruns.FieldLineID:
 		return m.LineID()
+	case chargeusagebasedruns.FieldInvoiceID:
+		return m.InvoiceID()
 	case chargeusagebasedruns.FieldMeteredQuantity:
 		return m.MeteredQuantity()
 	}
@@ -63149,6 +63328,8 @@ func (m *ChargeUsageBasedRunsMutation) OldField(ctx context.Context, name string
 		return m.OldDetailedLinesPresent(ctx)
 	case chargeusagebasedruns.FieldLineID:
 		return m.OldLineID(ctx)
+	case chargeusagebasedruns.FieldInvoiceID:
+		return m.OldInvoiceID(ctx)
 	case chargeusagebasedruns.FieldMeteredQuantity:
 		return m.OldMeteredQuantity(ctx)
 	}
@@ -63293,6 +63474,13 @@ func (m *ChargeUsageBasedRunsMutation) SetField(name string, value ent.Value) er
 		}
 		m.SetLineID(v)
 		return nil
+	case chargeusagebasedruns.FieldInvoiceID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetInvoiceID(v)
+		return nil
 	case chargeusagebasedruns.FieldMeteredQuantity:
 		v, ok := value.(alpacadecimal.Decimal)
 		if !ok {
@@ -63336,6 +63524,9 @@ func (m *ChargeUsageBasedRunsMutation) ClearedFields() []string {
 	if m.FieldCleared(chargeusagebasedruns.FieldLineID) {
 		fields = append(fields, chargeusagebasedruns.FieldLineID)
 	}
+	if m.FieldCleared(chargeusagebasedruns.FieldInvoiceID) {
+		fields = append(fields, chargeusagebasedruns.FieldInvoiceID)
+	}
 	return fields
 }
 
@@ -63355,6 +63546,9 @@ func (m *ChargeUsageBasedRunsMutation) ClearField(name string) error {
 		return nil
 	case chargeusagebasedruns.FieldLineID:
 		m.ClearLineID()
+		return nil
+	case chargeusagebasedruns.FieldInvoiceID:
+		m.ClearInvoiceID()
 		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedRuns nullable field %s", name)
@@ -63421,6 +63615,9 @@ func (m *ChargeUsageBasedRunsMutation) ResetField(name string) error {
 	case chargeusagebasedruns.FieldLineID:
 		m.ResetLineID()
 		return nil
+	case chargeusagebasedruns.FieldInvoiceID:
+		m.ResetInvoiceID()
+		return nil
 	case chargeusagebasedruns.FieldMeteredQuantity:
 		m.ResetMeteredQuantity()
 		return nil
@@ -63430,7 +63627,7 @@ func (m *ChargeUsageBasedRunsMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *ChargeUsageBasedRunsMutation) AddedEdges() []string {
-	edges := make([]string, 0, 7)
+	edges := make([]string, 0, 8)
 	if m.usage_based != nil {
 		edges = append(edges, chargeusagebasedruns.EdgeUsageBased)
 	}
@@ -63439,6 +63636,9 @@ func (m *ChargeUsageBasedRunsMutation) AddedEdges() []string {
 	}
 	if m.billing_invoice_line != nil {
 		edges = append(edges, chargeusagebasedruns.EdgeBillingInvoiceLine)
+	}
+	if m.billing_invoice != nil {
+		edges = append(edges, chargeusagebasedruns.EdgeBillingInvoice)
 	}
 	if m.credit_allocations != nil {
 		edges = append(edges, chargeusagebasedruns.EdgeCreditAllocations)
@@ -63471,6 +63671,10 @@ func (m *ChargeUsageBasedRunsMutation) AddedIDs(name string) []ent.Value {
 		if id := m.billing_invoice_line; id != nil {
 			return []ent.Value{*id}
 		}
+	case chargeusagebasedruns.EdgeBillingInvoice:
+		if id := m.billing_invoice; id != nil {
+			return []ent.Value{*id}
+		}
 	case chargeusagebasedruns.EdgeCreditAllocations:
 		ids := make([]ent.Value, 0, len(m.credit_allocations))
 		for id := range m.credit_allocations {
@@ -63497,7 +63701,7 @@ func (m *ChargeUsageBasedRunsMutation) AddedIDs(name string) []ent.Value {
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *ChargeUsageBasedRunsMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 7)
+	edges := make([]string, 0, 8)
 	if m.removedcredit_allocations != nil {
 		edges = append(edges, chargeusagebasedruns.EdgeCreditAllocations)
 	}
@@ -63529,7 +63733,7 @@ func (m *ChargeUsageBasedRunsMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *ChargeUsageBasedRunsMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 7)
+	edges := make([]string, 0, 8)
 	if m.clearedusage_based {
 		edges = append(edges, chargeusagebasedruns.EdgeUsageBased)
 	}
@@ -63538,6 +63742,9 @@ func (m *ChargeUsageBasedRunsMutation) ClearedEdges() []string {
 	}
 	if m.clearedbilling_invoice_line {
 		edges = append(edges, chargeusagebasedruns.EdgeBillingInvoiceLine)
+	}
+	if m.clearedbilling_invoice {
+		edges = append(edges, chargeusagebasedruns.EdgeBillingInvoice)
 	}
 	if m.clearedcredit_allocations {
 		edges = append(edges, chargeusagebasedruns.EdgeCreditAllocations)
@@ -63564,6 +63771,8 @@ func (m *ChargeUsageBasedRunsMutation) EdgeCleared(name string) bool {
 		return m.clearedfeature
 	case chargeusagebasedruns.EdgeBillingInvoiceLine:
 		return m.clearedbilling_invoice_line
+	case chargeusagebasedruns.EdgeBillingInvoice:
+		return m.clearedbilling_invoice
 	case chargeusagebasedruns.EdgeCreditAllocations:
 		return m.clearedcredit_allocations
 	case chargeusagebasedruns.EdgeDetailedLines:
@@ -63589,6 +63798,9 @@ func (m *ChargeUsageBasedRunsMutation) ClearEdge(name string) error {
 	case chargeusagebasedruns.EdgeBillingInvoiceLine:
 		m.ClearBillingInvoiceLine()
 		return nil
+	case chargeusagebasedruns.EdgeBillingInvoice:
+		m.ClearBillingInvoice()
+		return nil
 	case chargeusagebasedruns.EdgeInvoicedUsage:
 		m.ClearInvoicedUsage()
 		return nil
@@ -63611,6 +63823,9 @@ func (m *ChargeUsageBasedRunsMutation) ResetEdge(name string) error {
 		return nil
 	case chargeusagebasedruns.EdgeBillingInvoiceLine:
 		m.ResetBillingInvoiceLine()
+		return nil
+	case chargeusagebasedruns.EdgeBillingInvoice:
+		m.ResetBillingInvoice()
 		return nil
 	case chargeusagebasedruns.EdgeCreditAllocations:
 		m.ResetCreditAllocations()

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -1436,6 +1436,10 @@ func init() {
 	chargeusagebasedrunsDescLineID := chargeusagebasedrunsFields[6].Descriptor()
 	// chargeusagebasedruns.LineIDValidator is a validator for the "line_id" field. It is called by the builders before save.
 	chargeusagebasedruns.LineIDValidator = chargeusagebasedrunsDescLineID.Validators[0].(func(string) error)
+	// chargeusagebasedrunsDescInvoiceID is the schema descriptor for invoice_id field.
+	chargeusagebasedrunsDescInvoiceID := chargeusagebasedrunsFields[7].Descriptor()
+	// chargeusagebasedruns.InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
+	chargeusagebasedruns.InvoiceIDValidator = chargeusagebasedrunsDescInvoiceID.Validators[0].(func(string) error)
 	// chargeusagebasedrunsDescID is the schema descriptor for id field.
 	chargeusagebasedrunsDescID := chargeusagebasedrunsMixinFields1[0].Descriptor()
 	// chargeusagebasedruns.DefaultID holds the default value on creation for the id field.

--- a/openmeter/ent/schema/billing.go
+++ b/openmeter/ent/schema/billing.go
@@ -1186,6 +1186,7 @@ func (BillingInvoice) Edges() []ent.Edge {
 			Annotations(entsql.OnDelete(entsql.Cascade)),
 		edge.To("billing_invoice_validation_issues", BillingInvoiceValidationIssue.Type).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
+		edge.To("charge_usage_based_runs", ChargeUsageBasedRuns.Type),
 		edge.From("billing_invoice_customer", Customer.Type).
 			Ref("billing_invoice").
 			Field("customer_id").

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -187,6 +187,15 @@ func (ChargeUsageBasedRuns) Fields() []ent.Field {
 			NotEmpty().
 			Nillable(),
 
+		field.String("invoice_id").
+			SchemaType(map[string]string{
+				dialect.Postgres: "char(26)",
+			}).
+			Optional().
+			NotEmpty().
+			Nillable().
+			Immutable(),
+
 		field.Other("metered_quantity", alpacadecimal.Decimal{}).
 			SchemaType(map[string]string{
 				dialect.Postgres: "numeric",
@@ -212,6 +221,12 @@ func (ChargeUsageBasedRuns) Edges() []ent.Edge {
 			Ref("charge_usage_based_run").
 			Field("line_id").
 			Unique().
+			Annotations(entsql.OnDelete(entsql.SetNull)),
+		edge.From("billing_invoice", BillingInvoice.Type).
+			Ref("charge_usage_based_runs").
+			Field("invoice_id").
+			Unique().
+			Immutable().
 			Annotations(entsql.OnDelete(entsql.SetNull)),
 		edge.To("credit_allocations", ChargeUsageBasedRunCreditAllocations.Type).
 			StorageKey(edge.Symbol("charge_ub_run_credit_alloc_run")).

--- a/tools/migrate/migrations/20260506134501_add_usage_based_run_invoice_id.down.sql
+++ b/tools/migrate/migrations/20260506134501_add_usage_based_run_invoice_id.down.sql
@@ -1,0 +1,2 @@
+-- reverse: modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" DROP CONSTRAINT "charge_usage_based_runs_billing_invoices_charge_usage_based_run", DROP COLUMN "invoice_id";

--- a/tools/migrate/migrations/20260506134501_add_usage_based_run_invoice_id.up.sql
+++ b/tools/migrate/migrations/20260506134501_add_usage_based_run_invoice_id.up.sql
@@ -1,0 +1,2 @@
+-- modify "charge_usage_based_runs" table
+ALTER TABLE "charge_usage_based_runs" ADD COLUMN "invoice_id" character(26) NULL, ADD CONSTRAINT "charge_usage_based_runs_billing_invoices_charge_usage_based_run" FOREIGN KEY ("invoice_id") REFERENCES "billing_invoices" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:F7HXXWG69yIAHauA7NOTJCzjqlTFbmj3N5eUtVuF+B8=
+h1:6EvcLc9zTSxo75x65XGH9W3d5U7OddC9LgKqGMHgVRI=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -191,3 +191,4 @@ h1:F7HXXWG69yIAHauA7NOTJCzjqlTFbmj3N5eUtVuF+B8=
 20260430095237_add_credit_realization_lineage_segment_source.up.sql h1:hp/S1jNs0MYQL+GSdLaDea2DmBct2CU8Rk2P7hK4qEE=
 20260502093117_distributed_locks.up.sql h1:fCZntakx52oo1fal4ymjjoCUpRK57gmKN18BLJd0Eow=
 20260506082128_add_organization_default_tax_codes.up.sql h1:DA4FrNmvWRnFbH5z/4TthG8K1Zfxw9kF5YRJV1MUv8s=
+20260506134501_add_usage_based_run_invoice_id.up.sql h1:hbWNYrEelRKDq62yXuyJhCmkXAT5Sqz3cUhsXN5bshQ=


### PR DESCRIPTION
## Overview

Adds the first usage-based credit_then_invoice delete support slice on top of the charges invoiceupdater branch.

- persists the standard invoice ID on usage-based realization runs alongside line ID
- adds a charges invoiceupdater patch type for deleting pending gathering lines by charge ID
- wires usage-based delete patches through the root charges patch flow so pending gathering lines are removed before the charge patch is applied
- covers partial/final run invoice ID persistence and pending gathering-line deletion in service tests

Base branch: chore/add-lineupdater

## Validation

- make generate
- env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/charges/usagebased/...
- env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/charges/service
- make migrate-check

Note: make lint-go-fast failed locally with golangci-lint context loading error: `no go files to analyze: running go mod tidy may solve the problem`. It did not report code diagnostics.