### PR TITLE
chore: allow negative detailed lines

### DIFF
--- a/openmeter/billing/invoicedetailedline.go
+++ b/openmeter/billing/invoicedetailedline.go
@@ -31,7 +31,7 @@ func (l DetailedLineBase) Validate() error {
 		errs = append(errs, errors.New("invoiceID is required"))
 	}
 
-	if err := l.Base.Validate(); err != nil {
+	if err := l.Base.Validate(stddetailedline.IgnoreQuantityChecks()); err != nil {
 		errs = append(errs, fmt.Errorf("base: %w", err))
 	}
 

--- a/openmeter/billing/invoicedetailedline_test.go
+++ b/openmeter/billing/invoicedetailedline_test.go
@@ -1,0 +1,50 @@
+package billing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestDetailedLineValidateAllowsNegativeQuantity(t *testing.T) {
+	line := validDetailedLineForValidation()
+	line.Quantity = alpacadecimal.NewFromInt(-1)
+
+	require.NoError(t, line.Validate())
+}
+
+func TestDetailedLineValidateRejectsNegativePerUnitAmount(t *testing.T) {
+	line := validDetailedLineForValidation()
+	line.PerUnitAmount = alpacadecimal.NewFromInt(-1)
+
+	require.ErrorContains(t, line.Validate(), "price should be positive or zero")
+}
+
+func validDetailedLineForValidation() DetailedLine {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	return DetailedLine{
+		DetailedLineBase: DetailedLineBase{
+			InvoiceID: "inv_123",
+			Base: stddetailedline.Base{
+				Category:               stddetailedline.CategoryRegular,
+				ChildUniqueReferenceID: "child_123",
+				PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+				ServicePeriod: timeutil.ClosedPeriod{
+					From: start,
+					To:   start.Add(time.Hour),
+				},
+				Currency:      currencyx.Code("USD"),
+				PerUnitAmount: alpacadecimal.NewFromInt(10),
+				Quantity:      alpacadecimal.NewFromInt(1),
+			},
+		},
+	}
+}

--- a/openmeter/billing/models/totals/model.go
+++ b/openmeter/billing/models/totals/model.go
@@ -66,6 +66,14 @@ func (t Totals) Validate() error {
 	return nil
 }
 
+func (t Totals) ValidateTotalNonNegative() error {
+	if t.Total.IsNegative() {
+		return errors.New("total is negative")
+	}
+
+	return nil
+}
+
 func (t Totals) Add(others ...Totals) Totals {
 	res := t
 

--- a/openmeter/billing/models/totals/model_test.go
+++ b/openmeter/billing/models/totals/model_test.go
@@ -68,3 +68,11 @@ func TestTotalsEqual(t *testing.T) {
 	other.Total = alpacadecimal.NewFromInt(9)
 	require.False(t, in.Equal(other))
 }
+
+func TestValidateTotalNonNegative(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, Totals{Total: alpacadecimal.Zero}.ValidateTotalNonNegative())
+	require.NoError(t, Totals{Total: alpacadecimal.NewFromInt(1)}.ValidateTotalNonNegative())
+	require.ErrorContains(t, Totals{Total: alpacadecimal.NewFromInt(-1)}.ValidateTotalNonNegative(), "total is negative")
+}

--- a/openmeter/billing/rating/detailedline.go
+++ b/openmeter/billing/rating/detailedline.go
@@ -31,10 +31,6 @@ type DetailedLine struct {
 }
 
 func (i DetailedLine) Validate() error {
-	if i.Quantity.IsNegative() {
-		return fmt.Errorf("quantity must be zero or positive")
-	}
-
 	if i.PerUnitAmount.IsNegative() {
 		return fmt.Errorf("amount must be zero or positive")
 	}

--- a/openmeter/billing/rating/detailedline_test.go
+++ b/openmeter/billing/rating/detailedline_test.go
@@ -12,6 +12,28 @@ import (
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 )
 
+func TestDetailedLineValidateAllowsNegativeQuantity(t *testing.T) {
+	line := DetailedLine{
+		Name:                   "usage correction",
+		Quantity:               alpacadecimal.NewFromInt(-1),
+		PerUnitAmount:          alpacadecimal.NewFromInt(10),
+		ChildUniqueReferenceID: "usage-correction",
+	}
+
+	require.NoError(t, line.Validate())
+}
+
+func TestDetailedLineValidateRejectsNegativePerUnitAmount(t *testing.T) {
+	line := DetailedLine{
+		Name:                   "usage correction",
+		Quantity:               alpacadecimal.NewFromInt(1),
+		PerUnitAmount:          alpacadecimal.NewFromInt(-10),
+		ChildUniqueReferenceID: "usage-correction",
+	}
+
+	require.ErrorContains(t, line.Validate(), "amount must be zero or positive")
+}
+
 func TestAddDiscountForOverage(t *testing.T) {
 	currency, err := currencyx.Code(currency.USD).Calculator()
 	require.NoError(t, err)

--- a/openmeter/billing/stdinvoiceline.go
+++ b/openmeter/billing/stdinvoiceline.go
@@ -607,6 +607,10 @@ func (i StandardLine) Validate() error {
 		errs = append(errs, err)
 	}
 
+	if err := i.Totals.ValidateTotalNonNegative(); err != nil {
+		errs = append(errs, fmt.Errorf("totals: %w", err))
+	}
+
 	if err := i.Discounts.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("discounts: %w", err))
 	}

--- a/openmeter/billing/stdinvoiceline_test.go
+++ b/openmeter/billing/stdinvoiceline_test.go
@@ -1,0 +1,96 @@
+package billing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestStandardLineValidateAllowsNonNegativeTotals(t *testing.T) {
+	line := validStandardLineForValidation()
+	line.Totals.Total = alpacadecimal.Zero
+
+	require.NoError(t, line.Validate())
+
+	line.Totals.Total = alpacadecimal.NewFromInt(1)
+
+	require.NoError(t, line.Validate())
+}
+
+func TestStandardLineValidateRejectsNegativeTotals(t *testing.T) {
+	line := validStandardLineForValidation()
+	line.Totals.Total = alpacadecimal.NewFromInt(-1)
+
+	require.ErrorContains(t, line.Validate(), "totals: total is negative")
+}
+
+func TestStandardLineValidateAllowsNegativeDetailedLineQuantityWithPositiveTotal(t *testing.T) {
+	line := validStandardLineForValidation()
+	line.Totals.Total = alpacadecimal.NewFromInt(1)
+	line.DetailedLines = DetailedLines{
+		{
+			DetailedLineBase: DetailedLineBase{
+				InvoiceID: line.InvoiceID,
+				Base: stddetailedline.Base{
+					ManagedResource: models.ManagedResource{
+						NamespacedModel: models.NamespacedModel{
+							Namespace: line.Namespace,
+						},
+						ID:   "detail_123",
+						Name: "usage correction",
+					},
+					Category:               stddetailedline.CategoryRegular,
+					ChildUniqueReferenceID: "detail_123",
+					PaymentTerm:            productcatalog.InArrearsPaymentTerm,
+					ServicePeriod:          line.Period,
+					Currency:               line.Currency,
+					PerUnitAmount:          alpacadecimal.NewFromInt(10),
+					Quantity:               alpacadecimal.NewFromInt(-1),
+				},
+			},
+		},
+	}
+
+	require.NoError(t, line.Validate())
+}
+
+func validStandardLineForValidation() StandardLine {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	return StandardLine{
+		StandardLineBase: StandardLineBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{
+					Namespace: "test-namespace",
+				},
+				ID:   "line_123",
+				Name: "usage",
+			},
+			ManagedBy: SystemManagedLine,
+			InvoiceID: "inv_123",
+			Currency:  currencyx.Code("USD"),
+			Period: timeutil.ClosedPeriod{
+				From: start,
+				To:   start.Add(time.Hour),
+			},
+			InvoiceAt: start.Add(time.Hour),
+			Totals: totals.Totals{
+				Total: alpacadecimal.NewFromInt(1),
+			},
+		},
+		UsageBased: &UsageBasedLine{
+			Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+				Amount: alpacadecimal.NewFromInt(1),
+			}),
+		},
+	}
+}


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

Allow detailed lines to contain negative values as corrections for prior periods.

Standard lines still mandate positive totals, as otherwise we would fall back to stripe credits or violate invariants in other billing systems.

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Allow negative quantities on detailed invoice lines while still enforcing non-negative per‑unit amounts.
  * Enforce non-negative invoice totals so totals cannot be negative during validation.

* **Tests**
  * Added unit tests covering negative quantities, negative per‑unit amounts, and total non‑negativity to ensure validation rules behave as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->