### PR TITLE
feat(billing): add mutable line deletion hook

### DIFF
--- a/openmeter/billing/charges/creditpurchase/lineengine/engine.go
+++ b/openmeter/billing/charges/creditpurchase/lineengine/engine.go
@@ -86,6 +86,10 @@ func (e *Engine) OnStandardInvoiceCreated(_ context.Context, input billing.OnSta
 	return input.Lines, nil
 }
 
+func (e *Engine) OnMutableStandardLinesDeleted(_ context.Context, _ billing.OnMutableStandardLinesDeletedInput) error {
+	return nil
+}
+
 func (e *Engine) OnInvoiceIssued(_ context.Context, _ billing.OnInvoiceIssuedInput) error {
 	return nil
 }

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -118,6 +118,10 @@ func (e *LineEngine) OnCollectionCompleted(_ context.Context, input billing.OnCo
 	return input.Lines, nil
 }
 
+func (e *LineEngine) OnMutableStandardLinesDeleted(_ context.Context, _ billing.OnMutableStandardLinesDeletedInput) error {
+	return nil
+}
+
 func (e *LineEngine) OnInvoiceIssued(_ context.Context, _ billing.OnInvoiceIssuedInput) error {
 	return nil
 }

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -228,6 +228,10 @@ func (e *LineEngine) OnCollectionCompleted(ctx context.Context, input billing.On
 	return input.Lines, nil
 }
 
+func (e *LineEngine) OnMutableStandardLinesDeleted(_ context.Context, _ billing.OnMutableStandardLinesDeletedInput) error {
+	return nil
+}
+
 func (e *LineEngine) OnInvoiceIssued(ctx context.Context, input billing.OnInvoiceIssuedInput) error {
 	if err := input.Validate(); err != nil {
 		return fmt.Errorf("validating input: %w", err)

--- a/openmeter/billing/lineengine.go
+++ b/openmeter/billing/lineengine.go
@@ -129,11 +129,12 @@ func (i StandardLineEventInput) Validate() error {
 }
 
 type (
-	OnStandardInvoiceCreatedInput = StandardLineEventInput
-	OnCollectionCompletedInput    = StandardLineEventInput
-	OnInvoiceIssuedInput          = StandardLineEventInput
-	OnPaymentAuthorizedInput      = StandardLineEventInput
-	OnPaymentSettledInput         = StandardLineEventInput
+	OnStandardInvoiceCreatedInput      = StandardLineEventInput
+	OnCollectionCompletedInput         = StandardLineEventInput
+	OnMutableStandardLinesDeletedInput = StandardLineEventInput
+	OnInvoiceIssuedInput               = StandardLineEventInput
+	OnPaymentAuthorizedInput           = StandardLineEventInput
+	OnPaymentSettledInput              = StandardLineEventInput
 )
 
 type IsLineBillableAsOfInput struct {
@@ -217,6 +218,8 @@ type LineEngine interface {
 	OnStandardInvoiceCreated(ctx context.Context, input OnStandardInvoiceCreatedInput) (StandardLines, error)
 	// OnCollectionCompleted is invoked when a standard invoice collection window closes.
 	OnCollectionCompleted(ctx context.Context, input OnCollectionCompletedInput) (StandardLines, error)
+	// OnMutableStandardLinesDeleted is invoked after mutable standard invoice lines are marked deleted.
+	OnMutableStandardLinesDeleted(ctx context.Context, input OnMutableStandardLinesDeletedInput) error
 	// OnInvoiceIssued is invoked when a standard invoice reaches the issued state.
 	OnInvoiceIssued(ctx context.Context, input OnInvoiceIssuedInput) error
 	// OnPaymentAuthorized is invoked when a standard invoice reaches the payment authorized state.

--- a/openmeter/billing/lineengine/engine.go
+++ b/openmeter/billing/lineengine/engine.go
@@ -92,6 +92,10 @@ func (e *Engine) OnCollectionCompleted(ctx context.Context, input billing.OnColl
 	return input.Lines, nil
 }
 
+func (e *Engine) OnMutableStandardLinesDeleted(_ context.Context, _ billing.OnMutableStandardLinesDeletedInput) error {
+	return nil
+}
+
 func (e *Engine) OnStandardInvoiceCreated(_ context.Context, input billing.OnStandardInvoiceCreatedInput) (billing.StandardLines, error) {
 	return input.Lines, nil
 }

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -64,6 +64,7 @@ type LineEngineService interface {
 	RegisterLineEngine(engine LineEngine) error
 	DeregisterLineEngine(engineType LineEngineType) error
 	GetRegisteredLineEngines() []LineEngineType
+	OnMutableStandardLinesDeleted(ctx context.Context, input OnMutableStandardLinesDeletedInput) error
 }
 
 type SplitLineGroupService interface {

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -576,6 +576,46 @@ func ExecuteTriggerWithIncludeDeletedLines(includeDeletedLines bool) executeTrig
 	}
 }
 
+func collectNewlyDeletedStandardLines(before, after billing.StandardInvoiceLines) (billing.StandardLines, error) {
+	if before.IsAbsent() || after.IsAbsent() {
+		return nil, nil
+	}
+
+	beforeByID := make(map[string]*billing.StandardLine, len(before.OrEmpty()))
+	for _, line := range before.OrEmpty() {
+		if line == nil {
+			return nil, fmt.Errorf("before line is nil")
+		}
+
+		beforeByID[line.ID] = line
+	}
+
+	deletedLines := make(billing.StandardLines, 0)
+	for _, line := range after.OrEmpty() {
+		if line == nil {
+			return nil, fmt.Errorf("after line is nil")
+		}
+
+		beforeLine, ok := beforeByID[line.ID]
+		if !ok {
+			continue
+		}
+
+		if beforeLine.DeletedAt != nil || line.DeletedAt == nil {
+			continue
+		}
+
+		clonedLine, err := line.Clone()
+		if err != nil {
+			return nil, fmt.Errorf("cloning deleted line[%s]: %w", line.ID, err)
+		}
+
+		deletedLines = append(deletedLines, clonedLine)
+	}
+
+	return deletedLines, nil
+}
+
 func (s *Service) executeTriggerOnInvoice(ctx context.Context, invoiceID billing.InvoiceID, trigger billing.InvoiceTrigger, opts ...executeTriggerApplyOptionFunc) (billing.StandardInvoice, error) {
 	if err := invoiceID.Validate(); err != nil {
 		return billing.StandardInvoice{}, billing.ValidationError{
@@ -605,6 +645,11 @@ func (s *Service) executeTriggerOnInvoice(ctx context.Context, invoiceID billing
 				}
 
 				if options.editCallback != nil {
+					linesBeforeEdit, err := sm.Invoice.Lines.Clone()
+					if err != nil {
+						return fmt.Errorf("cloning invoice lines before edit: %w", err)
+					}
+
 					if err := options.editCallback(sm); err != nil {
 						return err
 					}
@@ -628,6 +673,20 @@ func (s *Service) executeTriggerOnInvoice(ctx context.Context, invoiceID billing
 					sm.Invoice, err = s.updateInvoice(ctx, sm.Invoice)
 					if err != nil {
 						return fmt.Errorf("updating invoice[%s]: %w", invoiceID, err)
+					}
+
+					deletedLines, err := collectNewlyDeletedStandardLines(linesBeforeEdit, sm.Invoice.Lines)
+					if err != nil {
+						return fmt.Errorf("collecting newly deleted standard lines for invoice[%s]: %w", invoiceID, err)
+					}
+
+					if len(deletedLines) > 0 {
+						if err := s.OnMutableStandardLinesDeleted(ctx, billing.OnMutableStandardLinesDeletedInput{
+							Invoice: sm.Invoice,
+							Lines:   deletedLines,
+						}); err != nil {
+							return fmt.Errorf("handling mutable standard lines deleted for invoice[%s]: %w", invoiceID, err)
+						}
 					}
 				}
 

--- a/openmeter/billing/service/invoice_test.go
+++ b/openmeter/billing/service/invoice_test.go
@@ -1,0 +1,72 @@
+package billingservice
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestCollectNewlyDeletedStandardLines(t *testing.T) {
+	before := billing.NewStandardInvoiceLines([]*billing.StandardLine{
+		newStandardLineForLineEngineTest("newly-deleted", billing.LineEngineTypeInvoice, false),
+		newStandardLineForLineEngineTest("already-deleted", billing.LineEngineTypeInvoice, true),
+		newStandardLineForLineEngineTest("unchanged", billing.LineEngineTypeInvoice, false),
+	})
+
+	after := billing.NewStandardInvoiceLines([]*billing.StandardLine{
+		newStandardLineForLineEngineTest("newly-deleted", billing.LineEngineTypeInvoice, true),
+		newStandardLineForLineEngineTest("already-deleted", billing.LineEngineTypeInvoice, true),
+		newStandardLineForLineEngineTest("unchanged", billing.LineEngineTypeInvoice, false),
+		newStandardLineForLineEngineTest("new-deleted-line", billing.LineEngineTypeInvoice, true),
+	})
+
+	deletedLines, err := collectNewlyDeletedStandardLines(before, after)
+	require.NoError(t, err)
+	require.Len(t, deletedLines, 1)
+	require.Equal(t, "newly-deleted", deletedLines[0].ID)
+	require.NotNil(t, deletedLines[0].DeletedAt)
+}
+
+func newStandardLineForLineEngineTest(id string, engine billing.LineEngineType, deleted bool) *billing.StandardLine {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var deletedAt *time.Time
+	if deleted {
+		deletedAt = lo.ToPtr(now.Add(time.Hour))
+	}
+
+	return &billing.StandardLine{
+		StandardLineBase: billing.StandardLineBase{
+			ManagedResource: models.ManagedResource{
+				NamespacedModel: models.NamespacedModel{Namespace: "ns"},
+				ManagedModel: models.ManagedModel{
+					DeletedAt: deletedAt,
+				},
+				ID:   id,
+				Name: id,
+			},
+			Engine:    engine,
+			InvoiceID: "invoice-1",
+			Currency:  currencyx.Code("USD"),
+			ManagedBy: billing.ManuallyManagedLine,
+			Period: timeutil.ClosedPeriod{
+				From: now,
+				To:   now.Add(time.Hour),
+			},
+			InvoiceAt: now.Add(time.Hour),
+		},
+		UsageBased: &billing.UsageBasedLine{
+			Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+				Amount: alpacadecimal.NewFromInt(100),
+			}),
+		},
+	}
+}

--- a/openmeter/billing/service/lineengine.go
+++ b/openmeter/billing/service/lineengine.go
@@ -1,6 +1,7 @@
 package billingservice
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -165,4 +166,32 @@ func (s *Service) DeregisterLineEngine(engineType billing.LineEngineType) error 
 
 func (s *Service) GetRegisteredLineEngines() []billing.LineEngineType {
 	return s.lineEngines.List()
+}
+
+func (s *Service) OnMutableStandardLinesDeleted(ctx context.Context, input billing.OnMutableStandardLinesDeletedInput) error {
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("validating mutable standard lines deleted input: %w", err)
+	}
+
+	groupedLines, err := s.lineEngines.groupStandardLinesByEngine(input.Lines)
+	if err != nil {
+		return fmt.Errorf("grouping standard lines by engine: %w", err)
+	}
+
+	for _, grouped := range groupedLines {
+		groupedInput := billing.OnMutableStandardLinesDeletedInput{
+			Invoice: input.Invoice,
+			Lines:   grouped.Lines,
+		}
+
+		if err := groupedInput.Validate(); err != nil {
+			return fmt.Errorf("validating mutable standard lines deleted input for engine %s: %w", grouped.Engine.GetLineEngineType(), err)
+		}
+
+		if err := grouped.Engine.OnMutableStandardLinesDeleted(ctx, groupedInput); err != nil {
+			return billing.NewLineEngineValidationError(grouped.Engine, err)
+		}
+	}
+
+	return nil
 }

--- a/openmeter/billing/service/lineengine_test.go
+++ b/openmeter/billing/service/lineengine_test.go
@@ -2,6 +2,7 @@ package billingservice
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -56,14 +57,45 @@ func TestOnMutableStandardLinesDeletedGroupsLinesByEngine(t *testing.T) {
 	require.Equal(t, []string{"line-2"}, lineIDs(chargeEngine.inputs[0].Lines))
 }
 
+func TestOnMutableStandardLinesDeletedReturnsEngineError(t *testing.T) {
+	errEngineFailed := errors.New("engine failed")
+	invoiceEngine := &recordingLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{
+			EngineType: billing.LineEngineTypeInvoice,
+		},
+		err: errEngineFailed,
+	}
+
+	svc := &Service{
+		lineEngines: newEngineRegistry(),
+	}
+
+	require.NoError(t, svc.RegisterLineEngine(invoiceEngine))
+
+	err := svc.OnMutableStandardLinesDeleted(t.Context(), billing.OnMutableStandardLinesDeletedInput{
+		Invoice: billing.StandardInvoice{
+			StandardInvoiceBase: billing.StandardInvoiceBase{
+				Namespace: "ns",
+				ID:        "invoice-1",
+			},
+		},
+		Lines: billing.StandardLines{
+			newStandardLineForLineEngineTest("line-1", billing.LineEngineTypeInvoice, true),
+		},
+	})
+
+	require.ErrorIs(t, err, errEngineFailed)
+}
+
 type recordingLineEngine struct {
 	billingtestutils.NoopLineEngine
 	inputs []billing.OnMutableStandardLinesDeletedInput
+	err    error
 }
 
 func (e *recordingLineEngine) OnMutableStandardLinesDeleted(_ context.Context, input billing.OnMutableStandardLinesDeletedInput) error {
 	e.inputs = append(e.inputs, input)
-	return nil
+	return e.err
 }
 
 func lineIDs(lines billing.StandardLines) []string {

--- a/openmeter/billing/service/lineengine_test.go
+++ b/openmeter/billing/service/lineengine_test.go
@@ -1,0 +1,76 @@
+package billingservice
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	billingtestutils "github.com/openmeterio/openmeter/openmeter/billing/testutils"
+)
+
+func TestOnMutableStandardLinesDeletedGroupsLinesByEngine(t *testing.T) {
+	invoiceEngine := &recordingLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{
+			EngineType: billing.LineEngineTypeInvoice,
+		},
+	}
+	chargeEngine := &recordingLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{
+			EngineType: billing.LineEngineTypeChargeUsageBased,
+		},
+	}
+
+	svc := &Service{
+		lineEngines: newEngineRegistry(),
+	}
+
+	require.NoError(t, svc.RegisterLineEngine(invoiceEngine))
+	require.NoError(t, svc.RegisterLineEngine(chargeEngine))
+
+	invoice := billing.StandardInvoice{
+		StandardInvoiceBase: billing.StandardInvoiceBase{
+			Namespace: "ns",
+			ID:        "invoice-1",
+		},
+	}
+
+	invoiceLine := newStandardLineForLineEngineTest("line-1", billing.LineEngineTypeInvoice, true)
+	chargeLine := newStandardLineForLineEngineTest("line-2", billing.LineEngineTypeChargeUsageBased, true)
+
+	require.NoError(t, svc.OnMutableStandardLinesDeleted(t.Context(), billing.OnMutableStandardLinesDeletedInput{
+		Invoice: invoice,
+		Lines: billing.StandardLines{
+			invoiceLine,
+			chargeLine,
+		},
+	}))
+
+	require.Len(t, invoiceEngine.inputs, 1)
+	require.Equal(t, "invoice-1", invoiceEngine.inputs[0].Invoice.ID)
+	require.Equal(t, []string{"line-1"}, lineIDs(invoiceEngine.inputs[0].Lines))
+
+	require.Len(t, chargeEngine.inputs, 1)
+	require.Equal(t, "invoice-1", chargeEngine.inputs[0].Invoice.ID)
+	require.Equal(t, []string{"line-2"}, lineIDs(chargeEngine.inputs[0].Lines))
+}
+
+type recordingLineEngine struct {
+	billingtestutils.NoopLineEngine
+	inputs []billing.OnMutableStandardLinesDeletedInput
+}
+
+func (e *recordingLineEngine) OnMutableStandardLinesDeleted(_ context.Context, input billing.OnMutableStandardLinesDeletedInput) error {
+	e.inputs = append(e.inputs, input)
+	return nil
+}
+
+func lineIDs(lines billing.StandardLines) []string {
+	ids := make([]string, 0, len(lines))
+	for _, line := range lines {
+		ids = append(ids, line.ID)
+	}
+
+	return ids
+}

--- a/openmeter/billing/testutils/lineengine.go
+++ b/openmeter/billing/testutils/lineengine.go
@@ -56,6 +56,10 @@ func (NoopLineEngine) OnCollectionCompleted(_ context.Context, input billing.OnC
 	return input.Lines, nil
 }
 
+func (NoopLineEngine) OnMutableStandardLinesDeleted(context.Context, billing.OnMutableStandardLinesDeletedInput) error {
+	return nil
+}
+
 func (NoopLineEngine) OnInvoiceIssued(context.Context, billing.OnInvoiceIssuedInput) error {
 	return nil
 }

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1829,6 +1829,10 @@ func (n NoopBillingService) GetRegisteredLineEngines() []billing.LineEngineType 
 	return nil
 }
 
+func (n NoopBillingService) OnMutableStandardLinesDeleted(ctx context.Context, input billing.OnMutableStandardLinesDeletedInput) error {
+	return nil
+}
+
 func (n NoopBillingService) GetLinesForSubscription(ctx context.Context, input billing.GetLinesForSubscriptionInput) ([]billing.LineOrHierarchy, error) {
 	return []billing.LineOrHierarchy{}, nil
 }

--- a/test/billing/lineengine_test.go
+++ b/test/billing/lineengine_test.go
@@ -40,6 +40,7 @@ type mockCollectionCompletedLineEngine struct {
 	buildStandardInvoiceLines func(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error)
 	onStandardInvoiceCreated  func(ctx context.Context, input ombilling.OnStandardInvoiceCreatedInput) (ombilling.StandardLines, error)
 	onCollectionCompleted     func(ctx context.Context, input ombilling.OnCollectionCompletedInput) (ombilling.StandardLines, error)
+	onMutableLinesDeleted     func(ctx context.Context, input ombilling.OnMutableStandardLinesDeletedInput) error
 	onInvoiceIssued           func(ctx context.Context, input ombilling.OnInvoiceIssuedInput) error
 	onPaymentAuthorized       func(ctx context.Context, input ombilling.OnPaymentAuthorizedInput) error
 	onPaymentSettled          func(ctx context.Context, input ombilling.OnPaymentSettledInput) error
@@ -97,6 +98,14 @@ func (m *mockCollectionCompletedLineEngine) OnStandardInvoiceCreated(ctx context
 	}
 
 	return m.onStandardInvoiceCreated(ctx, input)
+}
+
+func (m *mockCollectionCompletedLineEngine) OnMutableStandardLinesDeleted(ctx context.Context, input ombilling.OnMutableStandardLinesDeletedInput) error {
+	if m.onMutableLinesDeleted == nil {
+		return nil
+	}
+
+	return m.onMutableLinesDeleted(ctx, input)
 }
 
 func (m *mockCollectionCompletedLineEngine) OnInvoiceIssued(ctx context.Context, input ombilling.OnInvoiceIssuedInput) error {


### PR DESCRIPTION
## Summary
- add a billing line-engine hook for mutable standard invoice line deletion
- detect newly deleted mutable standard lines inside the billing invoice update transaction
- add no-op hook implementations for existing line engines and focused billing service tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Billing now detects invoice standard lines newly marked deleted during edits and invokes per-engine deletion handlers so each line engine processes only its lines.
* **Chores**
  * Added default no-op handling for engines that don’t require special deletion logic.
  * Service interface extended to surface deletion events to registered engines.
* **Tests**
  * Added tests for deletion detection, per-engine grouping, and error propagation from engine handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->