### PR TITLE
Chore/hurl complex productcatalog flow

### DIFF
--- a/.agents/skills/create-hurl-test/SKILL.md
+++ b/.agents/skills/create-hurl-test/SKILL.md
@@ -1,0 +1,474 @@
+---
+name: create-hurl-test
+description: Generate a Hurl (.hurl) end-to-end test for an OpenMeter API endpoint. Covers both v3 (AIP-style filtering, api/v3/openapi.yaml) and v1 (api/openapi.yaml, api/spec/packages/legacy/) APIs. Output files go in e2e/hurl/ named openmeter-<api-version>-<domain>.hurl. Use this when someone wants to create an HTTP-level e2e test using the Hurl tool.
+user-invocable: true
+argument-hint: "<test name> <description>"
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, Agent
+---
+
+# Create Hurl E2E Test
+
+Generate a [Hurl](https://hurl.dev/) end-to-end test for an OpenMeter API endpoint.
+
+**Args:**
+- `$1` — test name (e.g. `"Meter Lifecycle"`)
+- `$2` — description of what to test (e.g. `"create, get, list, update, delete a meter"`)
+
+Parse both from `args`. If unclear, ask once.
+
+## Hurl Format Primer
+
+A `.hurl` file is a sequence of HTTP entries separated by blank lines. Each entry has:
+
+```hurl
+# Optional comment
+METHOD url
+[Headers]
+Header-Name: value
+
+[Request body — for POST/PUT]
+```json
+{ "key": "value" }
+```
+
+HTTP status_code
+[Asserts]
+jsonpath "$.field" == "value"
+
+[Captures]
+var_name: jsonpath "$.id"
+```
+
+Key syntax rules:
+- Variables: `{{variable_name}}` — injected via CLI `--variable key=value` or captured from previous responses
+- `[QueryStringParams]` section handles `deepObject` style filters (`filter[key]=value`) — always prefer this over URL encoding
+- `[Captures]` binds response values to variables for later requests
+- `[Asserts]` holds multiple assertions; jsonpath queries use `$.field` syntax
+- Requests within one file run sequentially; blank lines between entries
+- Comments: `#` prefix
+
+## File Location and Naming
+
+```
+e2e/hurl/openmeter-v3-<domain>.hurl        # v3 API, fast (no extra workers needed)
+e2e/hurl/openmeter-v1-<domain>.hurl        # v1 API, fast
+e2e/hurl/async/<test>-v3-smoke.hurl        # depends on async pipeline (sink-worker, billing-worker, etc.)
+```
+
+Create `e2e/hurl/` if it doesn't exist. The default `make etoe-hurl` target uses a
+non-recursive glob (`e2e/hurl/*.hurl`), so anything in `async/` is automatically
+excluded — keep it that way and use `make etoe-hurl-async` for tests that need
+extra workers running. See the **Async / Eventual Consistency** section below.
+
+## Unique Keys / Run Isolation
+
+Hurl has no built-in random generation. Pass a unique suffix at CLI time:
+
+```bash
+hurl --test \
+  --variable base_url=http://localhost:8888 \
+  --variable api_key="" \
+  --variable run_id=$(date +%s%N | head -c 13) \
+  e2e/hurl/openmeter-v3-meters.hurl
+```
+
+In the `.hurl` file, append `{{run_id}}` to any field that must be unique per run:
+
+```
+"key": "test_meter_{{run_id}}"
+"name": "Test Meter {{run_id}}"
+```
+
+## Standard Variables
+
+Every test file uses these variables (passed via CLI `--variable`):
+
+| Variable | Default at CLI | Purpose |
+|---|---|---|
+| `base_url` | `http://localhost:8888` | Server base URL (no trailing slash) |
+| `api_key` | `""` (empty = no auth) | Bearer token; empty value omits auth effectively |
+| `run_id` | `$(date +%s%N \| head -c 13)` | Unique suffix to avoid key collisions |
+
+Auth header in every request (empty value is a valid no-op for local dev):
+
+```hurl
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```
+
+## Step 1 — Research the Endpoint
+
+Read sources in this order before writing any Hurl code:
+
+### 1a. OpenAPI spec
+
+**v3:** `api/v3/openapi.yaml`
+**v1:** `api/openapi.yaml`
+
+Extract:
+- Path (e.g. `/openmeter/meters`) → append to `{{base_url}}/api/v3`
+- Methods + status codes (POST→201, GET→200, PUT→200, DELETE→204, etc.)
+- Required fields and their types
+- Filter params and their `style` (deepObject for v3 AIP filters)
+- Pagination shape: always `{ data: [...], meta: { page: { ... } } }` for v3 list responses
+
+```bash
+# Find paths for a domain
+grep -n '/openmeter/meters' api/v3/openapi.yaml
+
+# Find schema
+grep -n -A 30 'CreateMeterRequest:' api/v3/openapi.yaml
+```
+
+### 1b. TypeSpec source
+
+**v3:** `api/spec/packages/aip/src/<domain>/`
+**v1:** `api/spec/packages/legacy/src/<domain>/`
+
+Read when OpenAPI field semantics are unclear.
+
+### 1c. Handler
+
+**v3:** `api/v3/handlers/<domain>/`
+
+Key files: `create.go`, `list.go`, `get.go`, `update.go`, `delete.go`, `convert.go`, `errors.go`
+
+Tells you:
+- Which validators fire (look for `validateDimensions*`, `request.ParseBody`, etc.)
+- Error shape used: `apierrors.GenericErrorEncoder()` → domain code via `extensions.validationErrors[].code`; `BaseAPIError` → detail substring via `problem.detail`; schema binder → `invalid_parameters[].rule`
+- Which fields are accepted vs. ignored
+
+### 1d. Domain module
+
+`openmeter/<domain>/`
+
+Look for `Validate()`, validation error codes, enum values, constraint logic.
+
+## Step 2 — Choose or Create the Hurl File
+
+| Scenario | Action |
+|---|---|
+| Domain has no `.hurl` file yet | Create `e2e/hurl/openmeter-v3-<domain>.hurl` |
+| File exists, adding a new test | Append below the last entry (blank line separator) |
+
+## Step 3 — Write the Hurl Test
+
+### Base URL Path
+
+v3 path = `{{base_url}}/api/v3` + OpenAPI path suffix without `/openmeter` prefix:
+
+> `/openmeter/meters` → `{{base_url}}/api/v3/openmeter/meters`
+
+### Lifecycle Template (v3)
+
+```hurl
+# ── 1. Create ─────────────────────────────────────────────────────────────────
+POST {{base_url}}/api/v3/openmeter/meters
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "key": "test_meter_{{run_id}}",
+  "name": "Test Meter {{run_id}}",
+  "aggregation": "sum",
+  "event_type": "api_request",
+  "value_property": "$.duration_ms"
+}
+```
+HTTP 201
+[Captures]
+meter_id: jsonpath "$.id"
+meter_key: jsonpath "$.key"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.key" == "test_meter_{{run_id}}"
+jsonpath "$.status" == "active"
+jsonpath "$.deleted_at" not exists
+
+# ── 2. Get by ID ──────────────────────────────────────────────────────────────
+GET {{base_url}}/api/v3/openmeter/meters/{{meter_id}}
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{meter_id}}"
+jsonpath "$.key" == "test_meter_{{run_id}}"
+
+# ── 3. List — verify appears ──────────────────────────────────────────────────
+# Use JSONPath filter expression, NOT $.data[*].id contains "{{id}}"
+# $.data[*].id returns a bare string (not array) when exactly 1 item exists,
+# making the contains predicate do a substring check instead of membership check.
+GET {{base_url}}/api/v3/openmeter/meters
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+page[size]: 1000
+HTTP 200
+[Asserts]
+jsonpath "$.data" isCollection
+jsonpath "$.data[?(@.id=='{{meter_id}}')].id" contains "{{meter_id}}"
+
+# ── 4. List — filter by key ───────────────────────────────────────────────────
+GET {{base_url}}/api/v3/openmeter/meters
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+filter[key]: test_meter_{{run_id}}
+page[size]: 10
+HTTP 200
+[Asserts]
+jsonpath "$.data" count == 1
+jsonpath "$.data[0].id" == "{{meter_id}}"
+
+# ── 5. Update ─────────────────────────────────────────────────────────────────
+PUT {{base_url}}/api/v3/openmeter/meters/{{meter_id}}
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "name": "Updated Meter {{run_id}}"
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.name" == "Updated Meter {{run_id}}"
+jsonpath "$.key" == "test_meter_{{run_id}}"
+
+# ── 6. Delete ─────────────────────────────────────────────────────────────────
+DELETE {{base_url}}/api/v3/openmeter/meters/{{meter_id}}
+Authorization: Bearer {{api_key}}
+HTTP 204
+
+# ── 7. Get after delete — soft delete returns 200 + deleted_at ───────────────
+GET {{base_url}}/api/v3/openmeter/meters/{{meter_id}}
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.deleted_at" isString
+```
+
+### Validation Test Template (single-request)
+
+```hurl
+# ── Validation: count aggregation must not have value_property ───────────────
+POST {{base_url}}/api/v3/openmeter/meters
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "key": "test_count_bad_{{run_id}}",
+  "name": "Count Bad {{run_id}}",
+  "aggregation": "count",
+  "event_type": "api_request",
+  "value_property": "$.duration_ms"
+}
+```
+HTTP 400
+```
+
+### Asserting Error Shapes
+
+v3 uses three error shapes — pick the right one per handler:
+
+| Shape | How server returns it | Hurl assertion |
+|---|---|---|
+| Domain code | `extensions.validationErrors[].code` | `jsonpath "$.extensions.validationErrors[0].code" == "reserved_dimension"` |
+| Detail substring | `problem.detail` (free text) | `jsonpath "$.detail" contains "reserved"` |
+| Schema rule | `invalid_parameters[].rule` | `jsonpath "$.extensions.invalidParameters[0].rule" == "pattern"` |
+
+Check the handler's `errors.go` for defined error codes (e.g. `ErrCodeReservedDimension = "reserved_dimension"`).
+
+**Detail substring gotcha:** `apierrors.NewConflictError(ctx, err, "message")` — the second string argument is NOT the `problem.detail` value. The actual `detail` comes from the underlying error's `Error()` string (e.g. `"conflict error: currency with code X already exists"`). Always use a short substring that appears in the real error, not the handler's label string. When in doubt, run the request once and read the actual `detail` before asserting.
+
+### Asserting List Membership
+
+**Never use `$.data[*].id contains "{{id}}"`.** When the array has exactly 1 element,
+jsonpath returns a bare string (not a collection), making `contains` do a substring check
+instead of a membership check — it silently passes or fails for the wrong reason.
+
+Use a JSONPath filter expression with `contains`:
+
+```hurl
+# ✅ Correct — `contains` works whether the filter returns a 1-element list or
+# a multi-element list. Hurl wraps filter results in a list, so `==` against a
+# bare string fails with `actual: list <[X]>` even when the filter matched once.
+jsonpath "$.data[?(@.id=='{{resource_id}}')].id" contains "{{resource_id}}"
+
+# ✅ Also correct when you know position (e.g. filter already narrowed to 1 result)
+jsonpath "$.data[0].id" == "{{resource_id}}"
+
+# ❌ `==` on filter-result path — actual is a list, not a string
+jsonpath "$.data[?(@.id=='{{resource_id}}')].id" == "{{resource_id}}"
+
+# ❌ count predicate on filter result — fails when filter returns single object (not list)
+jsonpath "$.data[?(@.id=='{{resource_id}}')]" count == 1
+
+# ❌ Broken for single-item arrays — DO NOT USE
+jsonpath "$.data[*].id" contains "{{resource_id}}"
+```
+
+For **absence** assertions (the field is gone OR the filter matched zero items),
+prefer `not exists` over `count == 0`. A filter that matches nothing returns
+no value, which `count` cannot apply to and errors out:
+
+```hurl
+# ✅ Correct — passes for "field missing" AND "filter matched zero items"
+jsonpath "$.validation_errors[?(@.code=='rate_card_billing_cadence_unaligned')]" not exists
+
+# ❌ Errors with "missing value to apply filter" when the filter matches nothing
+jsonpath "$.validation_errors[?(@.code=='rate_card_billing_cadence_unaligned')]" count == 0
+```
+
+Also note: `includes` predicate is deprecated in favour of `contains` — always use `contains`.
+
+### Async / Eventual Consistency
+
+When a request depends on an async pipeline (Kafka → sink-worker → ClickHouse,
+billing-worker reconciliation, notification delivery, etc.), the response will
+not be ready immediately after the trigger. Use Hurl's `[Options] retry` block
+to retry the **whole entry** — status code AND every assert — until it passes
+or the retry budget is exhausted.
+
+```hurl
+# Wait for the async ingest pipeline to surface events in the meter query.
+POST {{base_url}}/api/v3/openmeter/meters/{{meter_id}}/query
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+[Options]
+retry: 60
+retry-interval: 1000
+```json
+{ "granularity": "PT1H" }
+```
+HTTP 200
+[Asserts]
+jsonpath "$.data" count == 2
+jsonpath "$.data[0].value" == "2"
+```
+
+Notes:
+- `retry: N` is the max attempt count (not "retries on top of the first try"); `retry: -1` retries indefinitely.
+- `retry-interval` is in milliseconds.
+- Retry kicks in on **any** failed status code OR failed assert — perfect for "wait until the data shows up", much cleaner than the Go test's `EventuallyWithT` loops.
+- Apply retry to the trigger too (e.g., ingest) when the upstream service can return transient 5xx during sink-worker warmup. Idempotent operations (CloudEvents dedupe by event id) make this safe.
+- Tests that need an async worker beyond `make server` should live in `e2e/hurl/async/` and run via `make etoe-hurl-async`. The default `make etoe-hurl` glob is non-recursive and skips that subdir; document the prereq (`make sink-worker`, etc.) in the file's header comment.
+
+## Step 4 — Run Command
+
+Add a run command comment at the top of each new file:
+
+```hurl
+# Run: hurl --test \
+#   --variable base_url=http://localhost:8888 \
+#   --variable api_key="" \
+#   --variable run_id=$(date +%s%N | head -c 13) \
+#   e2e/hurl/openmeter-v3-meters.hurl
+```
+
+Run the test:
+
+```bash
+hurl --test \
+  --variable base_url=http://localhost:8888 \
+  --variable api_key="" \
+  --variable run_id=$(date +%s%N | head -c 13) \
+  e2e/hurl/openmeter-v3-<domain>.hurl
+```
+
+Run all hurl files:
+
+```bash
+hurl --test \
+  --variable base_url=http://localhost:8888 \
+  --variable api_key="" \
+  --variable run_id=$(date +%s%N | head -c 13) \
+  e2e/hurl/*.hurl
+```
+
+## Domain-Specific Knowledge
+
+### Meters (v3) — `POST /openmeter/meters`
+
+Required fields: `key`, `name`, `aggregation`, `event_type`
+
+| Aggregation | `value_property` |
+|---|---|
+| `count` | Must be absent/omitted — error if present |
+| `sum`, `avg`, `min`, `max`, `unique_count`, `latest` | Required — error if absent |
+
+Reserved dimensions (rejected at create and update — domain code `reserved_dimension`):
+- `subject`
+- `customer_id`
+
+Updatable fields: `name`, `description`, `dimensions`, `labels` (key/aggregation/event_type/value_property are immutable).
+
+**Soft-delete:** `DELETE` returns 204, subsequent `GET` returns 200 with `deleted_at` non-null. Does NOT return 404.
+
+### Plans (v3) — `POST /openmeter/plans`
+
+Soft-delete: same as meters — GET after DELETE returns 200 + `deleted_at`.
+
+Draft/publish lifecycle: plans have `status: draft/active/archived`. Publish via `POST /openmeter/plans/{id}/publish`.
+
+Validation errors surface via `validation_errors[]` on GET (draft-with-errors shape).
+
+### Features (v3) — `POST /openmeter/features`
+
+**Hard-delete:** GET after DELETE returns 404. Contrast with meters/plans.
+
+### Filter Params (v3 AIP style)
+
+Use `[QueryStringParams]` section — not inline URL query string — for deepObject style params:
+
+```hurl
+GET {{base_url}}/api/v3/openmeter/meters
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+filter[key]: my-meter-key
+filter[name]: My Meter
+page[size]: 20
+page[number]: 1
+```
+
+Named string type fields (`*BillingCurrencyType`, etc.) use `parseStringPtrTyped` in the filter parser — they work the same as `*string` from the wire perspective.
+
+### Pagination (v3)
+
+All v3 list responses:
+```json
+{
+  "data": [...],
+  "meta": {
+    "page": { "size": 20, "number": 1, "total": 42 }
+  }
+}
+```
+
+Default page size is 20. Use `page[size]=1000` when checking if a specific item appears in a potentially large shared dataset.
+
+### Error Response Shape (v3)
+
+```json
+{
+  "type": "about:blank",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "human readable message",
+  "extensions": {
+    "validationErrors": [
+      { "code": "reserved_dimension", "field": "dimensions.subject" }
+    ]
+  }
+}
+```
+
+## Checklist
+
+1. Read `api/v3/openapi.yaml` (or `api/openapi.yaml` for v1) — paths, methods, fields, status codes
+2. Read `api/v3/handlers/<domain>/` — error shapes, which validators fire, convert.go
+3. Read `openmeter/<domain>/` — Validate() constraints not always visible in OpenAPI
+4. Check for existing `.hurl` file in `e2e/hurl/`; append or create
+5. Use `{{run_id}}` suffix on all unique fields
+6. Use `[QueryStringParams]` for all filter/pagination params (deepObject style)
+7. Assert correct soft-delete vs hard-delete behavior per resource type
+8. For list-membership asserts use `contains` against a JSONPath filter, not `==` (Hurl wraps filter results in a list); for absence use `not exists`, not `count == 0`
+9. If the test depends on an async worker (sink-worker, billing-worker, etc.), put it in `e2e/hurl/async/` and add the prereq to the file's header comment + use `[Options] retry` on the entries that wait for the pipeline
+10. Validate JSON syntax: `hurl --check <file>`
+11. Add run command comment at top of file

--- a/.agents/skills/create-hurl-test/SKILL.md
+++ b/.agents/skills/create-hurl-test/SKILL.md
@@ -67,7 +67,6 @@ Hurl has no built-in random generation. Pass a unique suffix at CLI time:
 ```bash
 hurl --test \
   --variable base_url=http://localhost:8888 \
-  --variable api_key="" \
   --variable run_id=$(date +%s%N | head -c 13) \
   e2e/hurl/openmeter-v3-meters.hurl
 ```
@@ -86,15 +85,13 @@ Every test file uses these variables (passed via CLI `--variable`):
 | Variable | Default at CLI | Purpose |
 |---|---|---|
 | `base_url` | `http://localhost:8888` | Server base URL (no trailing slash) |
-| `api_key` | `""` (empty = no auth) | Bearer token; empty value omits auth effectively |
 | `run_id` | `$(date +%s%N \| head -c 13)` | Unique suffix to avoid key collisions |
 
-Auth header in every request (empty value is a valid no-op for local dev):
-
-```hurl
-Authorization: Bearer {{api_key}}
-Content-Type: application/json
-```
+The local OpenMeter dev server doesn't enforce auth, so requests don't carry an
+`Authorization` header. If you're targeting an auth-enabled deployment (e.g.
+OpenMeter Cloud, or a self-hosted instance with auth wired up), pass
+`--variable api_key=<token>` at the CLI and add `Authorization: Bearer {{api_key}}`
+as a header on each request.
 
 ## Step 1 — Research the Endpoint
 
@@ -164,7 +161,6 @@ v3 path = `{{base_url}}/api/v3` + OpenAPI path suffix without `/openmeter` prefi
 ```hurl
 # ── 1. Create ─────────────────────────────────────────────────────────────────
 POST {{base_url}}/api/v3/openmeter/meters
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
@@ -187,7 +183,6 @@ jsonpath "$.deleted_at" not exists
 
 # ── 2. Get by ID ──────────────────────────────────────────────────────────────
 GET {{base_url}}/api/v3/openmeter/meters/{{meter_id}}
-Authorization: Bearer {{api_key}}
 HTTP 200
 [Asserts]
 jsonpath "$.id" == "{{meter_id}}"
@@ -198,7 +193,6 @@ jsonpath "$.key" == "test_meter_{{run_id}}"
 # $.data[*].id returns a bare string (not array) when exactly 1 item exists,
 # making the contains predicate do a substring check instead of membership check.
 GET {{base_url}}/api/v3/openmeter/meters
-Authorization: Bearer {{api_key}}
 [QueryStringParams]
 page[size]: 1000
 HTTP 200
@@ -208,7 +202,6 @@ jsonpath "$.data[?(@.id=='{{meter_id}}')].id" contains "{{meter_id}}"
 
 # ── 4. List — filter by key ───────────────────────────────────────────────────
 GET {{base_url}}/api/v3/openmeter/meters
-Authorization: Bearer {{api_key}}
 [QueryStringParams]
 filter[key]: test_meter_{{run_id}}
 page[size]: 10
@@ -219,7 +212,6 @@ jsonpath "$.data[0].id" == "{{meter_id}}"
 
 # ── 5. Update ─────────────────────────────────────────────────────────────────
 PUT {{base_url}}/api/v3/openmeter/meters/{{meter_id}}
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
@@ -233,12 +225,10 @@ jsonpath "$.key" == "test_meter_{{run_id}}"
 
 # ── 6. Delete ─────────────────────────────────────────────────────────────────
 DELETE {{base_url}}/api/v3/openmeter/meters/{{meter_id}}
-Authorization: Bearer {{api_key}}
 HTTP 204
 
 # ── 7. Get after delete — soft delete returns 200 + deleted_at ───────────────
 GET {{base_url}}/api/v3/openmeter/meters/{{meter_id}}
-Authorization: Bearer {{api_key}}
 HTTP 200
 [Asserts]
 jsonpath "$.deleted_at" isString
@@ -249,7 +239,6 @@ jsonpath "$.deleted_at" isString
 ```hurl
 # ── Validation: count aggregation must not have value_property ───────────────
 POST {{base_url}}/api/v3/openmeter/meters
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
@@ -329,7 +318,6 @@ or the retry budget is exhausted.
 ```hurl
 # Wait for the async ingest pipeline to surface events in the meter query.
 POST {{base_url}}/api/v3/openmeter/meters/{{meter_id}}/query
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 [Options]
 retry: 60
@@ -357,7 +345,6 @@ Add a run command comment at the top of each new file:
 ```hurl
 # Run: hurl --test \
 #   --variable base_url=http://localhost:8888 \
-#   --variable api_key="" \
 #   --variable run_id=$(date +%s%N | head -c 13) \
 #   e2e/hurl/openmeter-v3-meters.hurl
 ```
@@ -367,7 +354,6 @@ Run the test:
 ```bash
 hurl --test \
   --variable base_url=http://localhost:8888 \
-  --variable api_key="" \
   --variable run_id=$(date +%s%N | head -c 13) \
   e2e/hurl/openmeter-v3-<domain>.hurl
 ```
@@ -377,7 +363,6 @@ Run all hurl files:
 ```bash
 hurl --test \
   --variable base_url=http://localhost:8888 \
-  --variable api_key="" \
   --variable run_id=$(date +%s%N | head -c 13) \
   e2e/hurl/*.hurl
 ```
@@ -419,7 +404,6 @@ Use `[QueryStringParams]` section — not inline URL query string — for deepOb
 
 ```hurl
 GET {{base_url}}/api/v3/openmeter/meters
-Authorization: Bearer {{api_key}}
 [QueryStringParams]
 filter[key]: my-meter-key
 filter[name]: My Meter

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -819,3 +819,119 @@ jobs:
             e2e/logs/openmeter/openmeter.log
             e2e/logs/sink-worker/openmeter.log
           retention-days: 14
+
+  e2e-hurl:
+    name: E2E Hurl
+    runs-on: depot-ubuntu-latest-8
+    # Note: This check is running against the image that is going to be pushed.
+    needs:
+      - trusted-artifacts
+      - untrusted-artifacts
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && contains(needs.*.result, 'success') }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Create override files for e2e
+        env:
+          DEPOT_IMAGE_URL: ${{ needs.trusted-artifacts.outputs.container-image-url-depot }}
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        run: |
+          cat > e2e/docker-compose.override.yaml <<EOF
+          services:
+            openmeter:
+              image: $DEPOT_IMAGE_URL
+            sink-worker:
+              image: $DEPOT_IMAGE_URL
+          EOF
+
+          cat e2e/docker-compose.override.yaml
+
+      - name: Build as part of e2e
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        run: |
+          cat > e2e/docker-compose.override.yaml <<EOF
+          services:
+            openmeter:
+              build: ..
+            sink-worker:
+              build: ..
+          EOF
+
+          cat e2e/docker-compose.override.yaml
+
+      - name: Launch Docker Compose infra
+        run: docker compose -f docker-compose.infra.yaml -f docker-compose.openmeter.yaml -f docker-compose.override.yaml up -d
+        working-directory: e2e
+
+      - name: Set up Nix
+        uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          nix_conf: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: Restore Nix store
+        uses: nix-community/cache-nix-action/restore@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
+        with:
+          primary-key: ${{ runner.os }}-openmeter-nix-build-${{ github.ref_name }}-${{ hashFiles('flake.*') }}
+          restore-prefixes-first-match: |
+            ${{ runner.os }}-openmeter-nix-build-${{ github.ref_name }}-
+            ${{ runner.os }}-openmeter-nix-build-main-${{ hashFiles('flake.*') }}
+            ${{ runner.os }}-openmeter-nix-build-main-
+            ${{ runner.os }}-openmeter-nix-build-
+
+      - name: Check container health
+        run: docker inspect --format "{{json .State.Health }}" $(docker container list --all --filter 'name=^*-openmeter-*' --format '{{.Names}}')
+        if: always()
+        continue-on-error: true
+
+      - name: Wait for worker to become ready
+        run: |
+          curl --retry 10 --retry-max-time 120 --retry-all-errors http://localhost:30000/healthz
+          docker ps
+
+      # Single hurl invocation across the fast suite (e2e/hurl/*.hurl) AND the
+      # async suite (e2e/hurl/async/*.hurl) so the HTML/JUnit reports cover the
+      # whole run. The async suite needs sink-worker, which the e2e compose
+      # stack already brings up.
+      - name: Run Hurl tests
+        env:
+          HURL_BASE_URL: http://localhost:38888
+          TZ: UTC
+        run: |
+          mkdir -p e2e/hurl-reports
+          nix develop --impure .#ci -c hurl --test \
+            --variable "base_url=$HURL_BASE_URL" \
+            --variable "run_id=$(date +%s%N | head -c 13)" \
+            --report-html e2e/hurl-reports/html \
+            --report-junit e2e/hurl-reports/junit.xml \
+            e2e/hurl/*.hurl e2e/hurl/async/*.hurl
+
+      - name: Cleanup Docker Compose
+        run: docker compose -f docker-compose.infra.yaml -f docker-compose.openmeter.yaml -f docker-compose.override.yaml down -v
+        working-directory: e2e
+        if: always()
+
+      - name: Upload Hurl reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: "[${{ github.job }}] Hurl reports"
+          path: e2e/hurl-reports/
+          retention-days: 14
+
+      - name: Upload Openmeter logs as artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: "[${{ github.job }}] Openmeter logs"
+          path: |
+            e2e/logs/openmeter/openmeter.log
+            e2e/logs/sink-worker/openmeter.log
+          retention-days: 14

--- a/Makefile
+++ b/Makefile
@@ -216,14 +216,12 @@ etoe-slow: ## Run e2e tests with slow tests enabled
 	$(MAKE) -C e2e test-local
 
 HURL_BASE_URL ?= http://localhost:8888
-HURL_API_KEY ?=
 
 .PHONY: etoe-hurl
-etoe-hurl: ## Run Hurl e2e tests (requires server running; set HURL_BASE_URL and HURL_API_KEY as needed)
+etoe-hurl: ## Run Hurl e2e tests (requires server running; override HURL_BASE_URL if not on localhost:8888)
 	$(call print-target)
 	hurl --test \
 		--variable base_url=$(HURL_BASE_URL) \
-		--variable api_key=$(HURL_API_KEY) \
 		--variable run_id=$$(date +%s%N | head -c 13) \
 		e2e/hurl/*.hurl
 
@@ -236,7 +234,6 @@ etoe-hurl-async: ## Run async Hurl e2e tests (requires sink-worker running; see 
 	$(call print-target)
 	hurl --test \
 		--variable base_url=$(HURL_BASE_URL) \
-		--variable api_key=$(HURL_API_KEY) \
 		--variable run_id=$$(date +%s%N | head -c 13) \
 		e2e/hurl/async/*.hurl
 

--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,31 @@ etoe-slow: ## Run e2e tests with slow tests enabled
 	export RUN_SLOW_TESTS=1
 	$(MAKE) -C e2e test-local
 
+HURL_BASE_URL ?= http://localhost:8888
+HURL_API_KEY ?=
+
+.PHONY: etoe-hurl
+etoe-hurl: ## Run Hurl e2e tests (requires server running; set HURL_BASE_URL and HURL_API_KEY as needed)
+	$(call print-target)
+	hurl --test \
+		--variable base_url=$(HURL_BASE_URL) \
+		--variable api_key=$(HURL_API_KEY) \
+		--variable run_id=$$(date +%s%N | head -c 13) \
+		e2e/hurl/*.hurl
+
+# Tests in e2e/hurl/async/ depend on the async ingest pipeline
+# (Kafka → sink-worker → ClickHouse). They are NOT run by `etoe-hurl` because
+# they require `make sink-worker` to be running in addition to `make server`,
+# and they wait/retry for sink processing — so they're noticeably slower.
+.PHONY: etoe-hurl-async
+etoe-hurl-async: ## Run async Hurl e2e tests (requires sink-worker running; see e2e/hurl/async/)
+	$(call print-target)
+	hurl --test \
+		--variable base_url=$(HURL_BASE_URL) \
+		--variable api_key=$(HURL_API_KEY) \
+		--variable run_id=$$(date +%s%N | head -c 13) \
+		e2e/hurl/async/*.hurl
+
 
 .PHONY: test
 test: ## Run tests

--- a/e2e/hurl/async/quickstart-v3-smoke.hurl
+++ b/e2e/hurl/async/quickstart-v3-smoke.hurl
@@ -1,0 +1,144 @@
+# Quickstart Smoke (v3) — ingest CloudEvents, wait for sink, query the meter
+#
+# Mirrors quickstart/quickstart_test.go (v3 portion only).
+# Touches: meters, events, meter query.
+#   POST /openmeter/meters          (v3, create)
+#   POST /api/v1/events             (v1 ingest — only public ingest path)
+#   POST /openmeter/meters/{id}/query (v3, query)
+#
+# This test exercises the full async ingest pipeline:
+#   client → /api/v1/events → Kafka → sink-worker → ClickHouse → meter query.
+#
+# Local prereqs (in addition to `make up` + `make server`):
+#   make sink-worker    # run in a separate terminal
+# Without sink-worker the events never land in ClickHouse and the query
+# retries will exhaust waiting for two data points to appear.
+#
+# Run:
+#   hurl --test \
+#     --variable base_url=http://localhost:8888 \
+#     --variable api_key="" \
+#     --variable run_id=$(date +%s%N | head -c 13) \
+#     e2e/hurl/async/quickstart-v3-smoke.hurl
+
+# ── 1. Create a v3 count meter with method+route dimensions ───────────────────
+POST {{base_url}}/api/v3/openmeter/meters
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "key": "quickstart_v3_{{run_id}}",
+  "name": "Quickstart V3 Meter {{run_id}}",
+  "aggregation": "count",
+  "event_type": "request",
+  "dimensions": {
+    "method": "$.method",
+    "route":  "$.route"
+  }
+}
+```
+HTTP 201
+[Captures]
+meter_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.aggregation" == "count"
+
+# ── 2. Ingest event 1 — day 1 ─────────────────────────────────────────────────
+# Retry on transient 5xx during sink-worker warmup; idempotent (event id is the
+# dedup key, so re-POSTing the same id is a no-op).
+POST {{base_url}}/api/v1/events
+Authorization: Bearer {{api_key}}
+Content-Type: application/cloudevents+json
+[Options]
+retry: 30
+retry-interval: 1000
+```json
+{
+  "specversion": "1.0",
+  "id": "qs_{{run_id}}_00001",
+  "source": "service-0",
+  "type": "request",
+  "subject": "customer-1",
+  "time": "2023-01-01T00:00:00Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "method": "GET",
+    "route": "/hello",
+    "duration_ms": "40"
+  }
+}
+```
+HTTP 204
+
+# ── 3. Ingest event 2 — day 1 (same hour as event 1) ─────────────────────────
+POST {{base_url}}/api/v1/events
+Authorization: Bearer {{api_key}}
+Content-Type: application/cloudevents+json
+[Options]
+retry: 30
+retry-interval: 1000
+```json
+{
+  "specversion": "1.0",
+  "id": "qs_{{run_id}}_00002",
+  "source": "service-0",
+  "type": "request",
+  "subject": "customer-1",
+  "time": "2023-01-01T00:00:00Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "method": "GET",
+    "route": "/hello",
+    "duration_ms": "40"
+  }
+}
+```
+HTTP 204
+
+# ── 4. Ingest event 3 — day 2 ─────────────────────────────────────────────────
+POST {{base_url}}/api/v1/events
+Authorization: Bearer {{api_key}}
+Content-Type: application/cloudevents+json
+[Options]
+retry: 30
+retry-interval: 1000
+```json
+{
+  "specversion": "1.0",
+  "id": "qs_{{run_id}}_00003",
+  "source": "service-0",
+  "type": "request",
+  "subject": "customer-1",
+  "time": "2023-01-02T00:00:00Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "method": "GET",
+    "route": "/hello",
+    "duration_ms": "40"
+  }
+}
+```
+HTTP 204
+
+# ── 5. Query meter at PT1H granularity — wait for sink to process the events ─
+# Retries the entire request (status + asserts) until two windows appear with
+# values 2 and 1 respectively. Up to 60s ceiling — matches the Go test's
+# EventuallyWithT(30s, 1s) but doubled to give the sink-worker more headroom
+# under load.
+POST {{base_url}}/api/v3/openmeter/meters/{{meter_id}}/query
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+[Options]
+retry: 60
+retry-interval: 1000
+```json
+{
+  "granularity": "PT1H"
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.data" count == 2
+jsonpath "$.data[0].value" == "2"
+jsonpath "$.data[1].value" == "1"

--- a/e2e/hurl/async/quickstart-v3-smoke.hurl
+++ b/e2e/hurl/async/quickstart-v3-smoke.hurl
@@ -17,20 +17,18 @@
 # Run:
 #   hurl --test \
 #     --variable base_url=http://localhost:8888 \
-#     --variable api_key="" \
 #     --variable run_id=$(date +%s%N | head -c 13) \
 #     e2e/hurl/async/quickstart-v3-smoke.hurl
 
 # ── 1. Create a v3 count meter with method+route dimensions ───────────────────
 POST {{base_url}}/api/v3/openmeter/meters
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
   "key": "quickstart_v3_{{run_id}}",
   "name": "Quickstart V3 Meter {{run_id}}",
   "aggregation": "count",
-  "event_type": "request",
+  "event_type": "quickstart_request_{{run_id}}",
   "dimensions": {
     "method": "$.method",
     "route":  "$.route"
@@ -48,7 +46,6 @@ jsonpath "$.aggregation" == "count"
 # Retry on transient 5xx during sink-worker warmup; idempotent (event id is the
 # dedup key, so re-POSTing the same id is a no-op).
 POST {{base_url}}/api/v1/events
-Authorization: Bearer {{api_key}}
 Content-Type: application/cloudevents+json
 [Options]
 retry: 30
@@ -58,7 +55,7 @@ retry-interval: 1000
   "specversion": "1.0",
   "id": "qs_{{run_id}}_00001",
   "source": "service-0",
-  "type": "request",
+  "type": "quickstart_request_{{run_id}}",
   "subject": "customer-1",
   "time": "2023-01-01T00:00:00Z",
   "datacontenttype": "application/json",
@@ -73,7 +70,6 @@ HTTP 204
 
 # ── 3. Ingest event 2 — day 1 (same hour as event 1) ─────────────────────────
 POST {{base_url}}/api/v1/events
-Authorization: Bearer {{api_key}}
 Content-Type: application/cloudevents+json
 [Options]
 retry: 30
@@ -83,7 +79,7 @@ retry-interval: 1000
   "specversion": "1.0",
   "id": "qs_{{run_id}}_00002",
   "source": "service-0",
-  "type": "request",
+  "type": "quickstart_request_{{run_id}}",
   "subject": "customer-1",
   "time": "2023-01-01T00:00:00Z",
   "datacontenttype": "application/json",
@@ -98,7 +94,6 @@ HTTP 204
 
 # ── 4. Ingest event 3 — day 2 ─────────────────────────────────────────────────
 POST {{base_url}}/api/v1/events
-Authorization: Bearer {{api_key}}
 Content-Type: application/cloudevents+json
 [Options]
 retry: 30
@@ -108,7 +103,7 @@ retry-interval: 1000
   "specversion": "1.0",
   "id": "qs_{{run_id}}_00003",
   "source": "service-0",
-  "type": "request",
+  "type": "quickstart_request_{{run_id}}",
   "subject": "customer-1",
   "time": "2023-01-02T00:00:00Z",
   "datacontenttype": "application/json",
@@ -127,7 +122,6 @@ HTTP 204
 # EventuallyWithT(30s, 1s) but doubled to give the sink-worker more headroom
 # under load.
 POST {{base_url}}/api/v3/openmeter/meters/{{meter_id}}/query
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 [Options]
 retry: 60

--- a/e2e/hurl/openmeter-v3-currencies.hurl
+++ b/e2e/hurl/openmeter-v3-currencies.hurl
@@ -1,0 +1,114 @@
+# Currencies E2E — custom currency lifecycle + cost bases
+#
+# Covers: currency_custom_lifecycle (p0)
+#   POST /openmeter/currencies/custom
+#   GET  /openmeter/currencies
+#   POST /openmeter/currencies/custom/{id}/cost-bases
+#   GET  /openmeter/currencies/custom/{id}/cost-bases
+#
+# Run:
+#   hurl --test \
+#     --variable base_url=http://localhost:8888 \
+#     --variable api_key="" \
+#     --variable run_id=$(date +%s%N | head -c 13) \
+#     e2e/hurl/openmeter-v3-currencies.hurl
+
+# ── 1. Create custom currency ─────────────────────────────────────────────────
+POST {{base_url}}/api/v3/openmeter/currencies/custom
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "code": "TC{{run_id}}",
+  "name": "Test Currency {{run_id}}",
+  "symbol": "T$"
+}
+```
+HTTP 201
+[Captures]
+currency_id: jsonpath "$.id"
+currency_code: jsonpath "$.code"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.type" == "custom"
+jsonpath "$.code" == "TC{{run_id}}"
+jsonpath "$.name" == "Test Currency {{run_id}}"
+jsonpath "$.symbol" == "T$"
+
+# ── 2. List all currencies — custom currency present ─────────────────────────
+# Use JSONPath filter expression — avoids $.data[*].id type inconsistency
+# (returns string for 1-item arrays, breaking contains predicate)
+GET {{base_url}}/api/v3/openmeter/currencies
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+page[size]: 1000
+HTTP 200
+[Asserts]
+jsonpath "$.data" isCollection
+jsonpath "$.data[?(@.id=='{{currency_id}}')].id" contains "{{currency_id}}"
+
+# ── 3. List filtered by type=custom — currency present, all entries custom ───
+GET {{base_url}}/api/v3/openmeter/currencies
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+filter[type]: custom
+page[size]: 1000
+HTTP 200
+[Asserts]
+jsonpath "$.data[?(@.id=='{{currency_id}}')].id" contains "{{currency_id}}"
+jsonpath "$.data[0].type" == "custom"
+
+# ── 4. List filtered by type=fiat — only fiat currencies returned ─────────────
+# Fiat currencies have no id field; assert type of first result is fiat
+GET {{base_url}}/api/v3/openmeter/currencies
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+filter[type]: fiat
+page[size]: 10
+HTTP 200
+[Asserts]
+jsonpath "$.data" isCollection
+jsonpath "$.data[0].type" == "fiat"
+
+# ── 5. Create cost basis ──────────────────────────────────────────────────────
+POST {{base_url}}/api/v3/openmeter/currencies/custom/{{currency_id}}/cost-bases
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "fiat_code": "USD",
+  "rate": "1.5"
+}
+```
+HTTP 201
+[Captures]
+cost_basis_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.fiat_code" == "USD"
+jsonpath "$.rate" == "1.5"
+
+# ── 6. List cost bases — cost basis present ───────────────────────────────────
+GET {{base_url}}/api/v3/openmeter/currencies/custom/{{currency_id}}/cost-bases
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.data" isCollection
+jsonpath "$.data[?(@.id=='{{cost_basis_id}}')].id" contains "{{cost_basis_id}}"
+jsonpath "$.data[0].fiat_code" == "USD"
+jsonpath "$.data[0].rate" == "1.5"
+
+# ── 7. Duplicate code rejected with 409 ──────────────────────────────────────
+POST {{base_url}}/api/v3/openmeter/currencies/custom
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "code": "TC{{run_id}}",
+  "name": "Duplicate Currency",
+  "symbol": "D$"
+}
+```
+HTTP 409
+[Asserts]
+jsonpath "$.detail" contains "already exists"

--- a/e2e/hurl/openmeter-v3-currencies.hurl
+++ b/e2e/hurl/openmeter-v3-currencies.hurl
@@ -9,13 +9,11 @@
 # Run:
 #   hurl --test \
 #     --variable base_url=http://localhost:8888 \
-#     --variable api_key="" \
 #     --variable run_id=$(date +%s%N | head -c 13) \
 #     e2e/hurl/openmeter-v3-currencies.hurl
 
 # ── 1. Create custom currency ─────────────────────────────────────────────────
 POST {{base_url}}/api/v3/openmeter/currencies/custom
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
@@ -39,7 +37,6 @@ jsonpath "$.symbol" == "T$"
 # Use JSONPath filter expression — avoids $.data[*].id type inconsistency
 # (returns string for 1-item arrays, breaking contains predicate)
 GET {{base_url}}/api/v3/openmeter/currencies
-Authorization: Bearer {{api_key}}
 [QueryStringParams]
 page[size]: 1000
 HTTP 200
@@ -49,7 +46,6 @@ jsonpath "$.data[?(@.id=='{{currency_id}}')].id" contains "{{currency_id}}"
 
 # ── 3. List filtered by type=custom — currency present, all entries custom ───
 GET {{base_url}}/api/v3/openmeter/currencies
-Authorization: Bearer {{api_key}}
 [QueryStringParams]
 filter[type]: custom
 page[size]: 1000
@@ -61,7 +57,6 @@ jsonpath "$.data[0].type" == "custom"
 # ── 4. List filtered by type=fiat — only fiat currencies returned ─────────────
 # Fiat currencies have no id field; assert type of first result is fiat
 GET {{base_url}}/api/v3/openmeter/currencies
-Authorization: Bearer {{api_key}}
 [QueryStringParams]
 filter[type]: fiat
 page[size]: 10
@@ -72,7 +67,6 @@ jsonpath "$.data[0].type" == "fiat"
 
 # ── 5. Create cost basis ──────────────────────────────────────────────────────
 POST {{base_url}}/api/v3/openmeter/currencies/custom/{{currency_id}}/cost-bases
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
@@ -90,7 +84,6 @@ jsonpath "$.rate" == "1.5"
 
 # ── 6. List cost bases — cost basis present ───────────────────────────────────
 GET {{base_url}}/api/v3/openmeter/currencies/custom/{{currency_id}}/cost-bases
-Authorization: Bearer {{api_key}}
 HTTP 200
 [Asserts]
 jsonpath "$.data" isCollection
@@ -100,7 +93,6 @@ jsonpath "$.data[0].rate" == "1.5"
 
 # ── 7. Duplicate code rejected with 409 ──────────────────────────────────────
 POST {{base_url}}/api/v3/openmeter/currencies/custom
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {

--- a/e2e/hurl/productcatalog-v3-smoke.hurl
+++ b/e2e/hurl/productcatalog-v3-smoke.hurl
@@ -20,13 +20,11 @@
 # Run:
 #   hurl --test \
 #     --variable base_url=http://localhost:8888 \
-#     --variable api_key="" \
 #     --variable run_id=$(date +%s%N | head -c 13) \
 #     e2e/hurl/productcatalog-v3-smoke.hurl
 
 # ── 1. Create a meter ─────────────────────────────────────────────────────────
 POST {{base_url}}/api/v3/openmeter/meters
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
@@ -46,7 +44,6 @@ jsonpath "$.key" == "pc_smoke_meter_{{run_id}}"
 
 # ── 2. Create a feature bound to the meter ────────────────────────────────────
 POST {{base_url}}/api/v3/openmeter/features
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
@@ -67,7 +64,6 @@ jsonpath "$.meter.id" == "{{meter_id}}"
 
 # ── 3. Create a draft plan with a single flat rate card ───────────────────────
 POST {{base_url}}/api/v3/openmeter/plans
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
@@ -104,7 +100,6 @@ jsonpath "$.phases[0].key" == "pc_smoke_phase_{{run_id}}"
 
 # ── 4. Update the plan: flat + unit-with-feature + graduated rate cards ───────
 PUT {{base_url}}/api/v3/openmeter/plans/{{plan_id}}
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
@@ -157,7 +152,6 @@ jsonpath "$.phases[0].rate_cards[?(@.key=='usage_{{run_id}}')].feature.id" conta
 # Plan cadence is P1M, so a P2W rate card surfaces rate_card_billing_cadence_unaligned.
 # The PUT itself is accepted (200) — the defect appears as a draft validation_error.
 PUT {{base_url}}/api/v3/openmeter/plans/{{plan_id}}
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
@@ -213,7 +207,6 @@ jsonpath "$.phases[0].rate_cards" count == 4
 
 # ── 6. GET plan — validation_errors surfaces the cadence-unaligned code ──────
 GET {{base_url}}/api/v3/openmeter/plans/{{plan_id}}
-Authorization: Bearer {{api_key}}
 HTTP 200
 [Asserts]
 jsonpath "$.status" == "draft"
@@ -221,14 +214,12 @@ jsonpath "$.validation_errors[?(@.code=='rate_card_billing_cadence_unaligned')].
 
 # ── 7. Publish — rejected with the same domain code ──────────────────────────
 POST {{base_url}}/api/v3/openmeter/plans/{{plan_id}}/publish
-Authorization: Bearer {{api_key}}
 HTTP 400
 [Asserts]
 jsonpath "$.extensions.validationErrors[?(@.code=='rate_card_billing_cadence_unaligned')].code" contains "rate_card_billing_cadence_unaligned"
 
 # ── 8. Update the plan: remove the defective rate card ───────────────────────
 PUT {{base_url}}/api/v3/openmeter/plans/{{plan_id}}
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
@@ -279,14 +270,12 @@ jsonpath "$.phases[0].rate_cards" count == 3
 # Robust against the field being absent OR an empty array OR populated by
 # unrelated codes — only the one we just fixed is asserted absent.
 GET {{base_url}}/api/v3/openmeter/plans/{{plan_id}}
-Authorization: Bearer {{api_key}}
 HTTP 200
 [Asserts]
 jsonpath "$.validation_errors[?(@.code=='rate_card_billing_cadence_unaligned')]" not exists
 
 # ── 10. Create a draft addon ─────────────────────────────────────────────────
 POST {{base_url}}/api/v3/openmeter/addons
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
@@ -314,7 +303,6 @@ jsonpath "$.status" == "draft"
 
 # ── 11. Publish the addon ────────────────────────────────────────────────────
 POST {{base_url}}/api/v3/openmeter/addons/{{addon_id}}/publish
-Authorization: Bearer {{api_key}}
 HTTP 200
 [Asserts]
 jsonpath "$.id" == "{{addon_id}}"
@@ -322,7 +310,6 @@ jsonpath "$.status" == "active"
 
 # ── 12. Attach the published addon to the still-draft plan ───────────────────
 POST {{base_url}}/api/v3/openmeter/plans/{{plan_id}}/addons
-Authorization: Bearer {{api_key}}
 Content-Type: application/json
 ```json
 {
@@ -341,7 +328,6 @@ jsonpath "$.from_plan_phase" == "pc_smoke_phase_{{run_id}}"
 
 # ── 13. Publish the plan — addon attached, plan goes active ──────────────────
 POST {{base_url}}/api/v3/openmeter/plans/{{plan_id}}/publish
-Authorization: Bearer {{api_key}}
 HTTP 200
 [Asserts]
 jsonpath "$.id" == "{{plan_id}}"
@@ -350,7 +336,6 @@ jsonpath "$.effective_from" isString
 
 # ── 14. List plan-addons — attached addon survives publish ───────────────────
 GET {{base_url}}/api/v3/openmeter/plans/{{plan_id}}/addons
-Authorization: Bearer {{api_key}}
 [QueryStringParams]
 page[size]: 1000
 HTTP 200

--- a/e2e/hurl/productcatalog-v3-smoke.hurl
+++ b/e2e/hurl/productcatalog-v3-smoke.hurl
@@ -1,0 +1,359 @@
+# Product Catalog Smoke (v3) — cross-cutting plan + addon authoring flow
+#
+# Mirrors e2e/productcatalog_smoke_v3_test.go (TestV3ProductCatalogSmoke).
+# Touches: meters, features, plans, plan-addons, addons.
+#   POST /openmeter/meters
+#   POST /openmeter/features
+#   POST /openmeter/plans
+#   PUT  /openmeter/plans/{id}
+#   GET  /openmeter/plans/{id}
+#   POST /openmeter/plans/{id}/publish
+#   POST /openmeter/addons
+#   POST /openmeter/addons/{id}/publish
+#   POST /openmeter/plans/{id}/addons
+#   GET  /openmeter/plans/{id}/addons
+#
+# Decimal note: prices are pre-normalized ("0.1", not "0.10") so re-sending the
+# same body across PUTs stays stable — the server canonicalizes decimals on
+# round-trip and the Go test pulls rate cards back from GET to avoid drift.
+#
+# Run:
+#   hurl --test \
+#     --variable base_url=http://localhost:8888 \
+#     --variable api_key="" \
+#     --variable run_id=$(date +%s%N | head -c 13) \
+#     e2e/hurl/productcatalog-v3-smoke.hurl
+
+# ── 1. Create a meter ─────────────────────────────────────────────────────────
+POST {{base_url}}/api/v3/openmeter/meters
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "key": "pc_smoke_meter_{{run_id}}",
+  "name": "PC Smoke Meter {{run_id}}",
+  "aggregation": "sum",
+  "event_type": "pc_smoke_event_{{run_id}}",
+  "value_property": "$.value"
+}
+```
+HTTP 201
+[Captures]
+meter_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.key" == "pc_smoke_meter_{{run_id}}"
+
+# ── 2. Create a feature bound to the meter ────────────────────────────────────
+POST {{base_url}}/api/v3/openmeter/features
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "key": "pc_smoke_feature_{{run_id}}",
+  "name": "PC Smoke Feature {{run_id}}",
+  "meter": {
+    "id": "{{meter_id}}"
+  }
+}
+```
+HTTP 201
+[Captures]
+feature_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.key" == "pc_smoke_feature_{{run_id}}"
+jsonpath "$.meter.id" == "{{meter_id}}"
+
+# ── 3. Create a draft plan with a single flat rate card ───────────────────────
+POST {{base_url}}/api/v3/openmeter/plans
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "key": "pc_smoke_plan_{{run_id}}",
+  "name": "PC Smoke Plan {{run_id}}",
+  "currency": "USD",
+  "billing_cadence": "P1M",
+  "phases": [
+    {
+      "key": "pc_smoke_phase_{{run_id}}",
+      "name": "PC Smoke Phase",
+      "rate_cards": [
+        {
+          "key": "flat_{{run_id}}",
+          "name": "Flat Fee",
+          "price": { "type": "flat", "amount": "10" },
+          "billing_cadence": "P1M",
+          "payment_term": "in_advance"
+        }
+      ]
+    }
+  ]
+}
+```
+HTTP 201
+[Captures]
+plan_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.status" == "draft"
+jsonpath "$.phases" count == 1
+jsonpath "$.phases[0].rate_cards" count == 1
+jsonpath "$.phases[0].key" == "pc_smoke_phase_{{run_id}}"
+
+# ── 4. Update the plan: flat + unit-with-feature + graduated rate cards ───────
+PUT {{base_url}}/api/v3/openmeter/plans/{{plan_id}}
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "name": "PC Smoke Plan {{run_id}}",
+  "phases": [
+    {
+      "key": "pc_smoke_phase_{{run_id}}",
+      "name": "PC Smoke Phase",
+      "rate_cards": [
+        {
+          "key": "flat_{{run_id}}",
+          "name": "Flat Fee",
+          "price": { "type": "flat", "amount": "10" },
+          "billing_cadence": "P1M",
+          "payment_term": "in_advance"
+        },
+        {
+          "key": "usage_{{run_id}}",
+          "name": "Usage Unit Fee",
+          "feature": { "id": "{{feature_id}}" },
+          "price": { "type": "unit", "amount": "0.1" },
+          "billing_cadence": "P1M",
+          "payment_term": "in_arrears"
+        },
+        {
+          "key": "graduated_{{run_id}}",
+          "name": "Graduated Fee",
+          "price": {
+            "type": "graduated",
+            "tiers": [
+              { "up_to_amount": "100", "unit_price": { "type": "unit", "amount": "0.1" } },
+              { "unit_price": { "type": "unit", "amount": "0.05" } }
+            ]
+          },
+          "billing_cadence": "P1M",
+          "payment_term": "in_arrears"
+        }
+      ]
+    }
+  ]
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.phases" count == 1
+jsonpath "$.phases[0].rate_cards" count == 3
+jsonpath "$.phases[0].rate_cards[?(@.key=='usage_{{run_id}}')].feature.id" contains "{{feature_id}}"
+
+# ── 5. Update the plan: append a defective P2W rate card (cadence misaligned)
+# Plan cadence is P1M, so a P2W rate card surfaces rate_card_billing_cadence_unaligned.
+# The PUT itself is accepted (200) — the defect appears as a draft validation_error.
+PUT {{base_url}}/api/v3/openmeter/plans/{{plan_id}}
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "name": "PC Smoke Plan {{run_id}}",
+  "phases": [
+    {
+      "key": "pc_smoke_phase_{{run_id}}",
+      "name": "PC Smoke Phase",
+      "rate_cards": [
+        {
+          "key": "flat_{{run_id}}",
+          "name": "Flat Fee",
+          "price": { "type": "flat", "amount": "10" },
+          "billing_cadence": "P1M",
+          "payment_term": "in_advance"
+        },
+        {
+          "key": "usage_{{run_id}}",
+          "name": "Usage Unit Fee",
+          "feature": { "id": "{{feature_id}}" },
+          "price": { "type": "unit", "amount": "0.1" },
+          "billing_cadence": "P1M",
+          "payment_term": "in_arrears"
+        },
+        {
+          "key": "graduated_{{run_id}}",
+          "name": "Graduated Fee",
+          "price": {
+            "type": "graduated",
+            "tiers": [
+              { "up_to_amount": "100", "unit_price": { "type": "unit", "amount": "0.1" } },
+              { "unit_price": { "type": "unit", "amount": "0.05" } }
+            ]
+          },
+          "billing_cadence": "P1M",
+          "payment_term": "in_arrears"
+        },
+        {
+          "key": "defective_{{run_id}}",
+          "name": "Defective Cadence Fee",
+          "price": { "type": "flat", "amount": "5" },
+          "billing_cadence": "P2W",
+          "payment_term": "in_advance"
+        }
+      ]
+    }
+  ]
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.phases[0].rate_cards" count == 4
+
+# ── 6. GET plan — validation_errors surfaces the cadence-unaligned code ──────
+GET {{base_url}}/api/v3/openmeter/plans/{{plan_id}}
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.status" == "draft"
+jsonpath "$.validation_errors[?(@.code=='rate_card_billing_cadence_unaligned')].code" contains "rate_card_billing_cadence_unaligned"
+
+# ── 7. Publish — rejected with the same domain code ──────────────────────────
+POST {{base_url}}/api/v3/openmeter/plans/{{plan_id}}/publish
+Authorization: Bearer {{api_key}}
+HTTP 400
+[Asserts]
+jsonpath "$.extensions.validationErrors[?(@.code=='rate_card_billing_cadence_unaligned')].code" contains "rate_card_billing_cadence_unaligned"
+
+# ── 8. Update the plan: remove the defective rate card ───────────────────────
+PUT {{base_url}}/api/v3/openmeter/plans/{{plan_id}}
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "name": "PC Smoke Plan {{run_id}}",
+  "phases": [
+    {
+      "key": "pc_smoke_phase_{{run_id}}",
+      "name": "PC Smoke Phase",
+      "rate_cards": [
+        {
+          "key": "flat_{{run_id}}",
+          "name": "Flat Fee",
+          "price": { "type": "flat", "amount": "10" },
+          "billing_cadence": "P1M",
+          "payment_term": "in_advance"
+        },
+        {
+          "key": "usage_{{run_id}}",
+          "name": "Usage Unit Fee",
+          "feature": { "id": "{{feature_id}}" },
+          "price": { "type": "unit", "amount": "0.1" },
+          "billing_cadence": "P1M",
+          "payment_term": "in_arrears"
+        },
+        {
+          "key": "graduated_{{run_id}}",
+          "name": "Graduated Fee",
+          "price": {
+            "type": "graduated",
+            "tiers": [
+              { "up_to_amount": "100", "unit_price": { "type": "unit", "amount": "0.1" } },
+              { "unit_price": { "type": "unit", "amount": "0.05" } }
+            ]
+          },
+          "billing_cadence": "P1M",
+          "payment_term": "in_arrears"
+        }
+      ]
+    }
+  ]
+}
+```
+HTTP 200
+[Asserts]
+jsonpath "$.phases[0].rate_cards" count == 3
+
+# ── 9. GET plan — validation_errors no longer carries the cadence code ───────
+# Robust against the field being absent OR an empty array OR populated by
+# unrelated codes — only the one we just fixed is asserted absent.
+GET {{base_url}}/api/v3/openmeter/plans/{{plan_id}}
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.validation_errors[?(@.code=='rate_card_billing_cadence_unaligned')]" not exists
+
+# ── 10. Create a draft addon ─────────────────────────────────────────────────
+POST {{base_url}}/api/v3/openmeter/addons
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "key": "pc_smoke_addon_{{run_id}}",
+  "name": "PC Smoke Addon {{run_id}}",
+  "currency": "USD",
+  "instance_type": "single",
+  "rate_cards": [
+    {
+      "key": "addon_fee_{{run_id}}",
+      "name": "Addon Flat Fee",
+      "price": { "type": "flat", "amount": "10" },
+      "billing_cadence": "P1M",
+      "payment_term": "in_advance"
+    }
+  ]
+}
+```
+HTTP 201
+[Captures]
+addon_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.status" == "draft"
+
+# ── 11. Publish the addon ────────────────────────────────────────────────────
+POST {{base_url}}/api/v3/openmeter/addons/{{addon_id}}/publish
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{addon_id}}"
+jsonpath "$.status" == "active"
+
+# ── 12. Attach the published addon to the still-draft plan ───────────────────
+POST {{base_url}}/api/v3/openmeter/plans/{{plan_id}}/addons
+Authorization: Bearer {{api_key}}
+Content-Type: application/json
+```json
+{
+  "name": "PC Smoke Plan Addon",
+  "addon": { "id": "{{addon_id}}" },
+  "from_plan_phase": "pc_smoke_phase_{{run_id}}"
+}
+```
+HTTP 201
+[Captures]
+plan_addon_id: jsonpath "$.id"
+[Asserts]
+jsonpath "$.id" isString
+jsonpath "$.addon.id" == "{{addon_id}}"
+jsonpath "$.from_plan_phase" == "pc_smoke_phase_{{run_id}}"
+
+# ── 13. Publish the plan — addon attached, plan goes active ──────────────────
+POST {{base_url}}/api/v3/openmeter/plans/{{plan_id}}/publish
+Authorization: Bearer {{api_key}}
+HTTP 200
+[Asserts]
+jsonpath "$.id" == "{{plan_id}}"
+jsonpath "$.status" == "active"
+jsonpath "$.effective_from" isString
+
+# ── 14. List plan-addons — attached addon survives publish ───────────────────
+GET {{base_url}}/api/v3/openmeter/plans/{{plan_id}}/addons
+Authorization: Bearer {{api_key}}
+[QueryStringParams]
+page[size]: 1000
+HTTP 200
+[Asserts]
+jsonpath "$.data" isCollection
+jsonpath "$.data[?(@.id=='{{plan_addon_id}}')].id" contains "{{plan_addon_id}}"

--- a/e2e/specs/currencies.md
+++ b/e2e/specs/currencies.md
@@ -1,0 +1,141 @@
+# E2E Scenario Specifications — Currencies
+
+Natural-language, runner-agnostic description of e2e scenarios for the
+`currencies` endpoint family. Each `## Scenario` describes wire-level
+behavior (HTTP verb, path, status code, response shape,
+`problem+json` error shape) that any downstream runner can translate
+to an executable test.
+
+See the `e2e-nl` skill (`.agents/skills/e2e-nl/`) for format rules
+(`references/format.md`) and worked examples (`references/examples.md`).
+
+**Endpoints covered:**
+- `GET /openmeter/currencies` — list all currencies (fiat + custom)
+- `POST /openmeter/currencies/custom` — create a custom currency
+- `POST /openmeter/currencies/custom/{currencyId}/cost-bases` — create a cost basis for a custom currency
+- `GET /openmeter/currencies/custom/{currencyId}/cost-bases` — list cost bases for a custom currency
+
+**Custom vs fiat currencies:** Custom currencies have an `id` and `type: "custom"` in responses.
+Fiat currencies (ISO-4217) are built-in — no `id` field. The list endpoint returns both unless filtered by `filter[type]`.
+
+**Error-shape convention:** The `create-custom-currency` handler wraps ALL service errors as
+`ConflictError`, but validation errors still resolve to `400` because `BaseAPIError.Unwrap()`
+exposes the underlying `GenericValidationError` through the error encoder. Only genuine
+duplicate-code conflicts return `409`. All other 4xx use `apierrors.GenericErrorEncoder()` → standard
+`problem+json` shape.
+
+**No lifecycle (no draft/publish/archive):** Custom currencies have no status transitions.
+There is no delete endpoint — custom currencies persist indefinitely.
+
+---
+
+## Scenario list
+
+**p0 — happy path**
+
+- `currency_custom_lifecycle` — Create a custom currency, verify it appears in the list, filter by type, create a cost basis, list cost bases. — shape: lifecycle — priority: p0
+
+**p1 — core validation**
+
+- `currency_create_duplicate_code_rejected` — Creating a second custom currency with the same `code` returns 409 with detail containing `"Currency already exists"`. — shape: single-request — priority: p1
+- `currency_create_missing_required_fields` — Creating a custom currency without `name` or `code` returns 400 (schema rule shape from OpenAPI binder). — shape: single-request — priority: p1
+- `currency_create_symbol_required_by_domain` — Creating a custom currency without `symbol` returns 400 (domain validation; symbol is required by `CreateCurrencyInput.Validate()` even though the OpenAPI schema marks it optional). — shape: single-request — priority: p1 — NEEDS-VERIFY: confirm 400 vs pass-through when symbol absent
+- `currency_cost_basis_rate_must_be_positive` — Creating a cost basis with `rate: "0"` or negative rate returns 400. — shape: single-request — priority: p1
+- `currency_cost_basis_invalid_fiat_code` — Creating a cost basis with an unknown fiat code returns 400. — shape: single-request — priority: p1 — NEEDS-VERIFY: confirm error detail/code from server
+- `currency_list_filter_by_type_custom` — `filter[type]=custom` returns only custom currencies (no fiat entries in `data[]`). — shape: single-request — priority: p1
+- `currency_list_filter_by_type_fiat` — `filter[type]=fiat` returns only fiat currencies (no custom entry in `data[]`). — shape: single-request — priority: p1
+- `currency_cost_bases_list_filter_by_fiat_code` — `filter[fiat_code]=USD` on the cost-bases list returns only cost bases with `fiat_code == "USD"`. — shape: single-request — priority: p1
+
+**p2 — edge cases**
+
+- `currency_list_pagination` — `page[number]` + `page[size]` return the expected slice and `meta.page.total`. — shape: single-request — priority: p2
+- `currency_cost_basis_effective_from` — Cost basis created with an explicit `effective_from` timestamp returns that timestamp in the response. — shape: single-request — priority: p2
+- `currency_cost_basis_nonexistent_currency` — Creating a cost basis for a non-existent `currencyId` returns 404 or 400. — shape: single-request — priority: p2 — NEEDS-VERIFY: confirm status code from server
+
+---
+
+## Baselines
+
+### Baseline custom currency — `CreateCurrencyCustomRequest`
+
+- `code`: unique per run (3–24 chars, must not conflict with ISO-4217 codes)
+- `name`: `"Test Currency"`
+- `symbol`: `"TC"` (symbol is required by domain `Validate()` even though OpenAPI schema marks it optional)
+
+### Baseline cost basis — `CreateCostBasisRequest`
+
+- `fiat_code`: `"USD"` (valid ISO-4217 code)
+- `rate`: `"1.5"` (positive decimal string)
+- `effective_from`: omitted (server sets to now)
+
+---
+
+## Scenario: currency_custom_lifecycle
+
+```yaml
+id: currency_custom_lifecycle
+endpoints:
+  - POST /openmeter/currencies/custom
+  - GET /openmeter/currencies
+  - POST /openmeter/currencies/custom/{currencyId}/cost-bases
+  - GET /openmeter/currencies/custom/{currencyId}/cost-bases
+entities: [currency, cost-basis]
+tags: [lifecycle, crud, p0]
+```
+
+**Intent:** A custom currency is created, appears in the list (filterable by type), and can have a cost basis attached and listed.
+
+**Fixtures:**
+- A `CreateCurrencyCustomRequest` per **Baseline custom currency**.
+- A `CreateCostBasisRequest` per **Baseline cost basis**.
+
+**Steps:**
+
+1. **Create custom currency.** `POST /openmeter/currencies/custom` with the fixture.
+   - Expect `201 Created`.
+   - Expect `id` is non-null.
+   - Expect `type` is `"custom"`.
+   - Expect `code` equals the fixture code.
+   - Expect `name` equals the fixture name.
+   - Expect `symbol` equals the fixture symbol.
+
+   Captures:
+   - `currency` ← `response.body`
+
+2. **List all currencies — verify custom currency appears.**
+   `GET /openmeter/currencies?page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect `data[]` contains an entry with `id == {currency.id}`.
+
+3. **List filtered by type `custom` — only custom currencies returned.**
+   `GET /openmeter/currencies` with `filter[type]=custom` and `page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect `data[]` contains an entry with `id == {currency.id}`.
+   - Expect every item in `data[]` has `type == "custom"`.
+
+4. **List filtered by type `fiat` — custom currency not in results.**
+   `GET /openmeter/currencies` with `filter[type]=fiat` and `page[size]=1000`.
+   - Expect `200 OK`.
+   - Expect `data[]` does NOT contain an entry with `id == {currency.id}`.
+   - Expect every item in `data[]` has `type == "fiat"`.
+
+5. **Create cost basis.** `POST /openmeter/currencies/custom/{currency.id}/cost-bases`
+   with the cost basis fixture.
+   - Expect `201 Created`.
+   - Expect `id` is non-null.
+   - Expect `fiat_code` equals `"USD"`.
+   - Expect `rate` equals `"1.5"`.
+
+   Captures:
+   - `cost_basis` ← `response.body`
+
+6. **List cost bases.** `GET /openmeter/currencies/custom/{currency.id}/cost-bases`.
+   - Expect `200 OK`.
+   - Expect `data[]` contains an entry with `id == {cost_basis.id}`.
+
+**Notes:**
+
+- There is no DELETE endpoint for custom currencies — they persist indefinitely. No cleanup step.
+- `symbol` is required by the domain `Validate()` even though the OpenAPI schema marks it optional in `CreateCurrencyCustomRequest`. Always include `symbol` in create requests.
+- The create handler wraps ALL errors as `ConflictError`. Validation errors (missing fields, etc.) still resolve to `400` because the error encoder unwraps through `BaseAPIError.Unwrap()`. Only genuine duplicate-code conflicts return `409`.
+- Fiat currencies returned from `GET /openmeter/currencies` have no `id` field in the response body (`id` is absent, not null).

--- a/flake.nix
+++ b/flake.nix
@@ -99,6 +99,7 @@
 
               curl
               jq
+              hurl
               minikube
               kind
               kubectl


### PR DESCRIPTION
## Overview

Adds Hurl as an e2e testing style with a skill and ci wired in. 

- Three reference tests under `e2e/hurl/`: currencies lifecycle, productcatalog
smoke (mirrors `productcatalog_smoke_v3_test.go`), and quickstart smoke under
`async/` (mirrors quickstart's v3 portion).
- Tests depending on sink-worker / billing-worker live in `e2e/hurl/async/`.
Default `make etoe-hurl` skips it via non-recursive glob; `make etoe-hurl-async`
runs it.
- New `e2e-hurl` CI job mirrors the existing `e2e` job, reuses its compose stack,
runs both suites in one invocation, uploads HTML + JUnit reports and openmeter /
sink-worker logs.
- `/create-hurl-test` skill documents conventions, JSONPath gotchas, and the
`[Options] retry` pattern for async waits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test suites covering async ingest pipeline, custom currencies, and product catalog workflows.
  * Introduced automated E2E testing job in CI/CD pipeline.

* **Documentation**
  * Added specification documents for currency endpoints and test generation guidelines.

* **Chores**
  * Enhanced development environment with Hurl testing tools.
  * Integrated E2E testing into continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->