### PR TITLE
fix: usage based ratecard validation

### DIFF
--- a/e2e/addons_v3_test.go
+++ b/e2e/addons_v3_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -132,11 +133,62 @@ func TestV3Addon(t *testing.T) {
 func TestV3AddonMixedRateCardRoundTrip(t *testing.T) {
 	c := newV3Client(t)
 
+	eventTypes := []string{
+		uniqueKey("sanity_event"),
+		uniqueKey("sanity_event"),
+	}
+
+	meterKeys := []string{
+		uniqueKey("sanity_meter"),
+		uniqueKey("sanity_meter"),
+	}
+
+	meters := make([]apiv3.Meter, 0, len(meterKeys))
+
+	for i := range meterKeys {
+		valueProperty := "$.value"
+
+		status, m, problem := c.CreateMeter(apiv3.CreateMeterRequest{
+			Key:           meterKeys[i],
+			Name:          "Test Meter " + meterKeys[i],
+			Aggregation:   apiv3.MeterAggregationSum,
+			EventType:     eventTypes[i],
+			ValueProperty: &valueProperty,
+		})
+		require.Equalf(t, http.StatusCreated, status, "problem: %+v", problem)
+		require.NotNil(t, m)
+		require.NotEmpty(t, m.Id)
+
+		meters = append(meters, *m)
+	}
+
+	featureKeys := []string{
+		uniqueKey("mix_unit"),
+		uniqueKey("mix_graduated"),
+	}
+
+	features := make([]apiv3.Feature, 0, len(featureKeys))
+
+	for i := range featureKeys {
+		status, f, problem := c.CreateFeature(apiv3.CreateFeatureRequest{
+			Key:  featureKeys[i],
+			Name: "Test Feature " + featureKeys[i],
+			Meter: &apiv3.FeatureMeterReference{
+				Id: meters[i].Id,
+			},
+		})
+		require.Equal(t, http.StatusCreated, status, "problem: %+v", problem)
+		require.NotNil(t, f)
+		require.NotEmpty(t, f.Id)
+
+		features = append(features, *f)
+	}
+
 	flat := validFlatRateCard("mix_flat")
-	unit := validUnitRateCard("mix_unit")
+	unit := validUnitRateCard(features[0])
 	percent := float32(10)
 	unit.Discounts = &apiv3.BillingRateCardDiscounts{Percentage: &percent}
-	graduated := validGraduatedRateCard("mix_graduated")
+	graduated := validGraduatedRateCard(features[1])
 
 	body := validAddonRequest("mixed_rc")
 	body.RateCards = []apiv3.BillingRateCard{flat, unit, graduated}
@@ -283,6 +335,34 @@ func TestV3AddonPaymentTermPriceCompatibility(t *testing.T) {
 // Only the "happy" rows are exercised — they confirm flat and unit prices are
 // accepted in their respective valid combinations.
 func TestV3AddonInstanceTypePriceCompatibility(t *testing.T) {
+	c := newV3Client(t)
+
+	meterKey := uniqueKey("single_unit")
+
+	status, m, problem := c.CreateMeter(apiv3.CreateMeterRequest{
+		Key:           meterKey,
+		Name:          "Test Meter " + meterKey,
+		Aggregation:   apiv3.MeterAggregationSum,
+		EventType:     uniqueKey("sanity_event"),
+		ValueProperty: lo.ToPtr("$.value"),
+	})
+	require.Equal(t, http.StatusCreated, status, "problem: %+v", problem)
+	require.NotNil(t, m)
+	require.NotEmpty(t, m.Id)
+
+	featureKey := uniqueKey("single_unit")
+
+	status, f, problem := c.CreateFeature(apiv3.CreateFeatureRequest{
+		Key:  featureKey,
+		Name: "Test Feature " + featureKey,
+		Meter: &apiv3.FeatureMeterReference{
+			Id: m.Id,
+		},
+	})
+	require.Equal(t, http.StatusCreated, status, "problem: %+v", problem)
+	require.NotNil(t, f)
+	require.NotEmpty(t, f.Id)
+
 	cases := []struct {
 		name           string
 		instanceType   apiv3.AddonInstanceType
@@ -298,15 +378,13 @@ func TestV3AddonInstanceTypePriceCompatibility(t *testing.T) {
 		{
 			name:           "single + unit rate card → 201",
 			instanceType:   apiv3.AddonInstanceTypeSingle,
-			rateCard:       validUnitRateCard("single_unit"),
+			rateCard:       validUnitRateCard(*f),
 			expectedStatus: http.StatusCreated,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			c := newV3Client(t)
-
 			body := validAddonRequest("instance_type_price")
 			body.InstanceType = tc.instanceType
 			body.RateCards = []apiv3.BillingRateCard{tc.rateCard}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1560,7 +1560,9 @@ func TestCredit(t *testing.T) {
 		require.Len(t, *grantListResp.JSON200, 1)
 
 		// Get feature
-		featureListResp, err := client.ListFeaturesWithResponse(context.Background(), nil)
+		featureListResp, err := client.ListFeaturesWithResponse(t.Context(), &api.ListFeaturesParams{
+			MeterSlug: &[]string{meterSlug},
+		})
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, featureListResp.StatusCode())
 		require.NotNil(t, featureListResp.JSON200)

--- a/e2e/productcatalog_smoke_v3_test.go
+++ b/e2e/productcatalog_smoke_v3_test.go
@@ -30,49 +30,63 @@ import (
 func TestV3ProductCatalogSmoke(t *testing.T) {
 	c := newV3Client(t)
 
-	meterKey := uniqueKey("sanity_meter")
-	eventType := uniqueKey("sanity_event")
-	featureKey := uniqueKey("sanity_feature")
+	eventTypes := []string{
+		uniqueKey("sanity_event"),
+		uniqueKey("sanity_event"),
+	}
 
-	var (
-		meterID     string
-		featureID   string
-		planID      string
-		addonID     string
-		planAddonID string
-		phaseKey    string
-	)
+	meterKeys := []string{
+		uniqueKey("sanity_meter"),
+		uniqueKey("sanity_meter"),
+	}
 
-	t.Run("Should create a meter", func(t *testing.T) {
+	meters := make([]apiv3.Meter, 0, len(meterKeys))
+
+	for i := range meterKeys {
 		valueProperty := "$.value"
+
 		status, m, problem := c.CreateMeter(apiv3.CreateMeterRequest{
-			Key:           meterKey,
-			Name:          "Test Meter " + meterKey,
+			Key:           meterKeys[i],
+			Name:          "Test Meter " + meterKeys[i],
 			Aggregation:   apiv3.MeterAggregationSum,
-			EventType:     eventType,
+			EventType:     eventTypes[i],
 			ValueProperty: &valueProperty,
 		})
 		require.Equal(t, http.StatusCreated, status, "problem: %+v", problem)
 		require.NotNil(t, m)
 		require.NotEmpty(t, m.Id)
-		meterID = m.Id
-	})
 
-	t.Run("Should create a feature bound to the meter", func(t *testing.T) {
-		require.NotEmpty(t, meterID)
+		meters = append(meters, *m)
+	}
 
+	featureKeys := []string{
+		uniqueKey("sanity_feature"),
+		uniqueKey("sanity_feature"),
+	}
+
+	features := make([]apiv3.Feature, 0, len(featureKeys))
+
+	for i := range featureKeys {
 		status, f, problem := c.CreateFeature(apiv3.CreateFeatureRequest{
-			Key:  featureKey,
-			Name: "Test Feature " + featureKey,
+			Key:  featureKeys[i],
+			Name: "Test Feature " + featureKeys[i],
 			Meter: &apiv3.FeatureMeterReference{
-				Id: meterID,
+				Id: meters[i].Id,
 			},
 		})
 		require.Equal(t, http.StatusCreated, status, "problem: %+v", problem)
 		require.NotNil(t, f)
 		require.NotEmpty(t, f.Id)
-		featureID = f.Id
-	})
+
+		features = append(features, *f)
+	}
+
+	var (
+		planID      string
+		addonID     string
+		planAddonID string
+		phaseKey    string
+	)
 
 	t.Run("Should create a draft plan with a single flat rate card", func(t *testing.T) {
 		body := validPlanRequest("sanity_plan")
@@ -89,12 +103,6 @@ func TestV3ProductCatalogSmoke(t *testing.T) {
 	})
 
 	t.Run("Should update the plan to carry flat + usage + graduated rate cards", func(t *testing.T) {
-		t.Skip("Skip this test as it does not use rate cards with features properly")
-
-		require.NotEmpty(t, planID)
-		require.NotEmpty(t, phaseKey)
-		require.NotEmpty(t, featureID)
-
 		// Three different rate card shapes on one phase. The flat fee is
 		// in_advance, both usage-based ones are in_arrears (unit/graduated
 		// prices cannot be in_advance). Only the unit one carries a feature
@@ -102,8 +110,8 @@ func TestV3ProductCatalogSmoke(t *testing.T) {
 		// round-trip pattern (no feature) to keep this iteration close to
 		// known-good shapes.
 		flat := validFlatRateCard("sanity_flat")
-		usage := validUsageRateCard("sanity_usage", featureID)
-		graduated := validGraduatedRateCard("sanity_graduated")
+		usage := validUnitRateCard(features[0])
+		graduated := validGraduatedRateCard(features[1])
 
 		update := apiv3.UpsertPlanRequest{
 			Name: "Sanity Plan",
@@ -129,7 +137,7 @@ func TestV3ProductCatalogSmoke(t *testing.T) {
 		}
 		require.NotNil(t, usageRC, "usage rate card missing after update")
 		require.NotNil(t, usageRC.Feature, "usage rate card lost its feature binding after update")
-		assert.Equal(t, featureID, usageRC.Feature.Id)
+		assert.Equal(t, usage.Feature.Id, usageRC.Feature.Id)
 	})
 
 	// Track the three valid rate cards across the invalid-loop subtests so
@@ -137,8 +145,6 @@ func TestV3ProductCatalogSmoke(t *testing.T) {
 	var validRateCards []apiv3.BillingRateCard
 
 	t.Run("Should add a defective rate card and surface validation_errors", func(t *testing.T) {
-		t.Skip("Skip this test as it does not use rate cards with features properly")
-
 		require.NotEmpty(t, planID)
 		require.NotEmpty(t, phaseKey)
 
@@ -190,8 +196,6 @@ func TestV3ProductCatalogSmoke(t *testing.T) {
 	})
 
 	t.Run("Should remove the defective rate card and clear validation_errors", func(t *testing.T) {
-		t.Skip("Skip this test as it does not use rate cards with features properly")
-
 		require.NotEmpty(t, planID)
 		require.NotEmpty(t, phaseKey)
 		require.NotEmpty(t, validRateCards)

--- a/e2e/v3helpers_test.go
+++ b/e2e/v3helpers_test.go
@@ -376,7 +376,7 @@ func validFlatRateCard(keyPrefix string) apiv3.BillingRateCard {
 // validUnitRateCard returns a usage-based unit-priced rate card. Unit prices
 // cannot use payment_term=in_advance (that's flat-only), so this uses
 // in_arrears.
-func validUnitRateCard(keyPrefix string) apiv3.BillingRateCard {
+func validUnitRateCard(f apiv3.Feature) apiv3.BillingRateCard {
 	cadence := apiv3.ISO8601Duration("P1M")
 	term := apiv3.BillingPricePaymentTermInArrears
 
@@ -389,27 +389,18 @@ func validUnitRateCard(keyPrefix string) apiv3.BillingRateCard {
 	}
 
 	return apiv3.BillingRateCard{
-		Key:            uniqueKey(keyPrefix),
-		Name:           "Test Unit Rate Card " + keyPrefix,
+		Key:            f.Key,
+		Name:           "Test Unit Rate Card " + f.Key,
 		Price:          price,
 		BillingCadence: &cadence,
 		PaymentTerm:    &term,
+		Feature:        &apiv3.FeatureReferenceItem{Id: f.Id},
 	}
-}
-
-// validUsageRateCard returns a unit-priced rate card bound to the given
-// feature ID — the shape needed when a plan/addon meters usage against a
-// metered feature. Reuses validUnitRateCard's price + cadence + payment_term
-// (unit prices must use in_arrears).
-func validUsageRateCard(keyPrefix, featureID string) apiv3.BillingRateCard {
-	rc := validUnitRateCard(keyPrefix)
-	rc.Feature = &apiv3.FeatureReferenceItem{Id: featureID}
-	return rc
 }
 
 // validGraduatedRateCard returns a graduated tiered rate card with two tiers:
 // 0–100 units at $0.10/unit and 100+ units at $0.05/unit.
-func validGraduatedRateCard(keyPrefix string) apiv3.BillingRateCard {
+func validGraduatedRateCard(f apiv3.Feature) apiv3.BillingRateCard {
 	cadence := apiv3.ISO8601Duration("P1M")
 	term := apiv3.BillingPricePaymentTermInArrears
 
@@ -437,11 +428,12 @@ func validGraduatedRateCard(keyPrefix string) apiv3.BillingRateCard {
 	}
 
 	return apiv3.BillingRateCard{
-		Key:            uniqueKey(keyPrefix),
-		Name:           "Test Graduated Rate Card " + keyPrefix,
+		Key:            f.Key,
+		Name:           "Test Graduated Rate Card " + f.Key,
 		Price:          price,
 		BillingCadence: &cadence,
 		PaymentTerm:    &term,
+		Feature:        &apiv3.FeatureReferenceItem{Id: f.Id},
 	}
 }
 

--- a/openmeter/productcatalog/addon/service/taxcode_test.go
+++ b/openmeter/productcatalog/addon/service/taxcode_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
 	pctestutils "github.com/openmeterio/openmeter/openmeter/productcatalog/testutils"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
-	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 )
@@ -807,27 +806,32 @@ func TestAddonWithPlanTaxCode(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create a plan. Rate card billing cadence must match the plan's P1M cadence.
-		planMonthPeriod := datetime.MustParseDuration(t, "P1M")
-		planInput := pctestutils.NewTestPlan(t, namespace, productcatalog.Phase{
-			PhaseMeta: productcatalog.PhaseMeta{Key: "default", Name: "Default"},
-			RateCards: productcatalog.RateCards{
-				&productcatalog.FlatFeeRateCard{
-					RateCardMeta: productcatalog.RateCardMeta{
-						Key:        features[0].Key,
-						Name:       features[0].Name,
-						FeatureKey: lo.ToPtr(features[0].Key),
-						FeatureID:  lo.ToPtr(features[0].ID),
-						Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
-							Amount:      decimal.NewFromInt(100),
-							PaymentTerm: productcatalog.InArrearsPaymentTerm,
-						}),
+		planInput := pctestutils.NewTestPlan(t, namespace,
+			pctestutils.WithPlanPhases(productcatalog.Phase{
+				PhaseMeta: productcatalog.PhaseMeta{Key: "default", Name: "Default"},
+				RateCards: productcatalog.RateCards{
+					&productcatalog.FlatFeeRateCard{
+						RateCardMeta: productcatalog.RateCardMeta{
+							Key:        features[0].Key,
+							Name:       features[0].Name,
+							FeatureKey: lo.ToPtr(features[0].Key),
+							FeatureID:  lo.ToPtr(features[0].ID),
+							Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+								Amount:      decimal.NewFromInt(100),
+								PaymentTerm: productcatalog.InArrearsPaymentTerm,
+							}),
+						},
+						BillingCadence: &pctestutils.MonthPeriod,
 					},
-					BillingCadence: &planMonthPeriod,
 				},
+			}),
+			func(t *testing.T, p *productcatalog.Plan) {
+				t.Helper()
+
+				p.Key = "plan-for-addon-backfill"
+				p.Name = "Plan For Addon Backfill"
 			},
-		})
-		planInput.Key = "plan-for-addon-backfill"
-		planInput.Name = "Plan For Addon Backfill"
+		)
 
 		p, err := env.Plan.CreatePlan(ctx, planInput)
 		require.NoError(t, err)

--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -366,6 +366,16 @@ var ErrRateCardBillingCadenceUnaligned = models.NewValidationIssue(
 	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
 )
 
+const ErrCodeRateCardUsageBasedPriceWithNoFeature models.ErrorCode = "usage_based_price_with_no_feature"
+
+var ErrRateCardUsageBasedPriceWithNoFeature = models.NewValidationIssue(
+	ErrCodeRateCardUsageBasedPriceWithNoFeature,
+	"usage-based price requires feature to be associated with",
+	models.WithFieldString("featureKey"),
+	models.WithWarningSeverity(),
+	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
+)
+
 // Addon errors
 
 const ErrCodeAddonKeyEmpty models.ErrorCode = "addon_key_empty"

--- a/openmeter/productcatalog/plan/adapter/adapter_test.go
+++ b/openmeter/productcatalog/plan/adapter/adapter_test.go
@@ -10,111 +10,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	pctestutils "github.com/openmeterio/openmeter/openmeter/productcatalog/testutils"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/clock"
-	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
 )
 
-var MonthPeriod = datetime.NewISODuration(0, 1, 0, 0, 0, 0, 0)
-
-var planPhases = []productcatalog.Phase{
-	{
-		PhaseMeta: productcatalog.PhaseMeta{
-			Key:         "trial",
-			Name:        "Trial",
-			Description: lo.ToPtr("Trial phase"),
-			Metadata:    models.Metadata{"name": "trial"},
-			Duration:    &MonthPeriod,
-		},
-		RateCards: []productcatalog.RateCard{
-			&productcatalog.FlatFeeRateCard{
-				RateCardMeta: productcatalog.RateCardMeta{
-					Key:                 "trial-ratecard-1",
-					Name:                "Trial RateCard 1",
-					Description:         lo.ToPtr("Trial RateCard 1"),
-					Metadata:            models.Metadata{"name": "trial-ratecard-1"},
-					FeatureKey:          nil,
-					FeatureID:           nil,
-					EntitlementTemplate: nil,
-					TaxConfig: &productcatalog.TaxConfig{
-						Stripe: &productcatalog.StripeTaxConfig{
-							Code: "txcd_10000000",
-						},
-					},
-					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
-						Amount:      decimal.NewFromInt(0),
-						PaymentTerm: productcatalog.InArrearsPaymentTerm,
-					}),
-				},
-				BillingCadence: &MonthPeriod,
-			},
-		},
-	},
-	{
-		PhaseMeta: productcatalog.PhaseMeta{
-			Key:         "pro",
-			Name:        "Pro",
-			Description: lo.ToPtr("Pro phase"),
-			Metadata:    models.Metadata{"name": "pro"},
-			Duration:    nil,
-		},
-		RateCards: []productcatalog.RateCard{
-			&productcatalog.UsageBasedRateCard{
-				RateCardMeta: productcatalog.RateCardMeta{
-					Key:                 "pro-ratecard-1",
-					Name:                "Pro RateCard 1",
-					Description:         lo.ToPtr("Pro RateCard 1"),
-					Metadata:            models.Metadata{"name": "pro-ratecard-1"},
-					FeatureKey:          nil,
-					FeatureID:           nil,
-					EntitlementTemplate: nil,
-					TaxConfig: &productcatalog.TaxConfig{
-						Stripe: &productcatalog.StripeTaxConfig{
-							Code: "txcd_10000000",
-						},
-					},
-					Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
-						Mode: productcatalog.VolumeTieredPrice,
-						Tiers: []productcatalog.PriceTier{
-							{
-								UpToAmount: lo.ToPtr(decimal.NewFromInt(1000)),
-								FlatPrice: &productcatalog.PriceTierFlatPrice{
-									Amount: decimal.NewFromInt(100),
-								},
-								UnitPrice: &productcatalog.PriceTierUnitPrice{
-									Amount: decimal.NewFromInt(50),
-								},
-							},
-							{
-								UpToAmount: nil,
-								FlatPrice: &productcatalog.PriceTierFlatPrice{
-									Amount: decimal.NewFromInt(5),
-								},
-								UnitPrice: &productcatalog.PriceTierUnitPrice{
-									Amount: decimal.NewFromInt(25),
-								},
-							},
-						},
-						Commitments: productcatalog.Commitments{
-							MinimumAmount: lo.ToPtr(decimal.NewFromInt(1000)),
-							MaximumAmount: nil,
-						},
-					}),
-				},
-				BillingCadence: MonthPeriod,
-			},
-		},
-	},
-}
-
 func TestPostgresAdapter(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	env := pctestutils.NewTestEnv(t)
 	t.Cleanup(func() {
 		env.Close(t)
@@ -125,7 +32,125 @@ func TestPostgresAdapter(t *testing.T) {
 	// Get new namespace ID
 	namespace := pctestutils.NewTestNamespace(t)
 
-	planV1Input := pctestutils.NewTestPlan(t, namespace, planPhases...)
+	// Setup meter repository
+	err := env.Meter.ReplaceMeters(t.Context(), pctestutils.NewTestMeters(t, namespace))
+	require.NoError(t, err, "replacing meters must not fail")
+
+	result, err := env.Meter.ListMeters(t.Context(), meter.ListMetersParams{
+		Page: pagination.Page{
+			PageSize:   1000,
+			PageNumber: 1,
+		},
+		Namespace: namespace,
+	})
+	require.NoErrorf(t, err, "listing meters must not fail")
+
+	meters := result.Items
+	require.NotEmptyf(t, meters, "list of Meters must not be empty")
+
+	// Set a feature for each meter
+	features := make([]feature.Feature, 0, len(meters))
+	for _, m := range meters {
+		input := pctestutils.NewTestFeatureFromMeter(t, &m)
+
+		feat, err := env.Feature.CreateFeature(t.Context(), input)
+		require.NoErrorf(t, err, "creating feature must not fail")
+		require.NotNil(t, feat, "feature must not be empty")
+
+		features = append(features, feat)
+	}
+
+	planPhases := []productcatalog.Phase{
+		{
+			PhaseMeta: productcatalog.PhaseMeta{
+				Key:         "trial",
+				Name:        "Trial",
+				Description: lo.ToPtr("Trial phase"),
+				Metadata:    models.Metadata{"name": "trial"},
+				Duration:    &pctestutils.MonthPeriod,
+			},
+			RateCards: []productcatalog.RateCard{
+				&productcatalog.FlatFeeRateCard{
+					RateCardMeta: productcatalog.RateCardMeta{
+						Key:                 "trial-ratecard-1",
+						Name:                "Trial RateCard 1",
+						Description:         lo.ToPtr("Trial RateCard 1"),
+						Metadata:            models.Metadata{"name": "trial-ratecard-1"},
+						FeatureKey:          nil,
+						FeatureID:           nil,
+						EntitlementTemplate: nil,
+						TaxConfig: &productcatalog.TaxConfig{
+							Stripe: &productcatalog.StripeTaxConfig{
+								Code: "txcd_10000000",
+							},
+						},
+						Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+							Amount:      decimal.NewFromInt(0),
+							PaymentTerm: productcatalog.InArrearsPaymentTerm,
+						}),
+					},
+					BillingCadence: &pctestutils.MonthPeriod,
+				},
+			},
+		},
+		{
+			PhaseMeta: productcatalog.PhaseMeta{
+				Key:         "pro",
+				Name:        "Pro",
+				Description: lo.ToPtr("Pro phase"),
+				Metadata:    models.Metadata{"name": "pro"},
+				Duration:    nil,
+			},
+			RateCards: []productcatalog.RateCard{
+				&productcatalog.UsageBasedRateCard{
+					RateCardMeta: productcatalog.RateCardMeta{
+						Key:                 features[0].Key,
+						Name:                "Pro RateCard 1",
+						Description:         lo.ToPtr("Pro RateCard 1"),
+						Metadata:            models.Metadata{"name": features[0].Key},
+						FeatureKey:          &features[0].Key,
+						FeatureID:           nil,
+						EntitlementTemplate: nil,
+						TaxConfig: &productcatalog.TaxConfig{
+							Stripe: &productcatalog.StripeTaxConfig{
+								Code: "txcd_10000000",
+							},
+						},
+						Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
+							Mode: productcatalog.VolumeTieredPrice,
+							Tiers: []productcatalog.PriceTier{
+								{
+									UpToAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+									FlatPrice: &productcatalog.PriceTierFlatPrice{
+										Amount: decimal.NewFromInt(100),
+									},
+									UnitPrice: &productcatalog.PriceTierUnitPrice{
+										Amount: decimal.NewFromInt(50),
+									},
+								},
+								{
+									UpToAmount: nil,
+									FlatPrice: &productcatalog.PriceTierFlatPrice{
+										Amount: decimal.NewFromInt(5),
+									},
+									UnitPrice: &productcatalog.PriceTierUnitPrice{
+										Amount: decimal.NewFromInt(25),
+									},
+								},
+							},
+							Commitments: productcatalog.Commitments{
+								MinimumAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+								MaximumAmount: nil,
+							},
+						}),
+					},
+					BillingCadence: pctestutils.MonthPeriod,
+				},
+			},
+		},
+	}
+
+	planV1Input := pctestutils.NewTestPlan(t, namespace, pctestutils.WithPlanPhases(planPhases...))
 
 	t.Run("Plan", func(t *testing.T) {
 		var (
@@ -134,7 +159,7 @@ func TestPostgresAdapter(t *testing.T) {
 		)
 
 		t.Run("Create", func(t *testing.T) {
-			planV1, err = env.Plan.CreatePlan(ctx, planV1Input)
+			planV1, err = env.Plan.CreatePlan(t.Context(), planV1Input)
 			require.NoErrorf(t, err, "creating new plan must not fail")
 
 			require.NotNilf(t, planV1, "plan must not be nil")
@@ -143,11 +168,17 @@ func TestPostgresAdapter(t *testing.T) {
 		})
 
 		t.Run("CreateWithCreditOnlySettlement", func(t *testing.T) {
-			input := pctestutils.NewTestPlan(t, namespace, planPhases...)
-			input.Key = "test-credit-only"
-			input.SettlementMode = productcatalog.CreditOnlySettlementMode
+			input := pctestutils.NewTestPlan(t, namespace,
+				pctestutils.WithPlanPhases(planPhases...),
+				func(t *testing.T, p *productcatalog.Plan) {
+					t.Helper()
 
-			p, err := env.PlanRepository.CreatePlan(ctx, input)
+					p.Key = "test-credit-only"
+					p.SettlementMode = productcatalog.CreditOnlySettlementMode
+				},
+			)
+
+			p, err := env.PlanRepository.CreatePlan(t.Context(), input)
 			require.NoErrorf(t, err, "creating plan with credit_only settlement must not fail")
 			require.NotNilf(t, p, "plan must not be nil")
 
@@ -155,7 +186,7 @@ func TestPostgresAdapter(t *testing.T) {
 				"settlement mode mismatch: expected=%s, actual=%s", productcatalog.CreditOnlySettlementMode, p.SettlementMode)
 
 			// Verify persistence via GetPlan
-			fetched, err := env.PlanRepository.GetPlan(ctx, plan.GetPlanInput{
+			fetched, err := env.PlanRepository.GetPlan(t.Context(), plan.GetPlanInput{
 				NamespacedID: models.NamespacedID{
 					Namespace: namespace,
 					ID:        p.ID,
@@ -169,7 +200,7 @@ func TestPostgresAdapter(t *testing.T) {
 
 		t.Run("Get", func(t *testing.T) {
 			t.Run("ById", func(t *testing.T) {
-				getPlanV1, err := env.Plan.GetPlan(ctx, plan.GetPlanInput{
+				getPlanV1, err := env.Plan.GetPlan(t.Context(), plan.GetPlanInput{
 					NamespacedID: models.NamespacedID{
 						Namespace: namespace,
 						ID:        planV1.ID,
@@ -183,7 +214,7 @@ func TestPostgresAdapter(t *testing.T) {
 			})
 
 			t.Run("ByKey", func(t *testing.T) {
-				getPlanV1, err := env.Plan.GetPlan(ctx, plan.GetPlanInput{
+				getPlanV1, err := env.Plan.GetPlan(t.Context(), plan.GetPlanInput{
 					NamespacedID: models.NamespacedID{
 						Namespace: namespace,
 					},
@@ -198,7 +229,7 @@ func TestPostgresAdapter(t *testing.T) {
 			})
 
 			t.Run("ByKeyVersion", func(t *testing.T) {
-				getPlanV1, err := env.Plan.GetPlan(ctx, plan.GetPlanInput{
+				getPlanV1, err := env.Plan.GetPlan(t.Context(), plan.GetPlanInput{
 					NamespacedID: models.NamespacedID{
 						Namespace: namespace,
 					},
@@ -213,7 +244,7 @@ func TestPostgresAdapter(t *testing.T) {
 			})
 
 			t.Run("ByIdExpandAddon", func(t *testing.T) {
-				getPlanV1, err := env.PlanRepository.GetPlan(ctx, plan.GetPlanInput{
+				getPlanV1, err := env.PlanRepository.GetPlan(t.Context(), plan.GetPlanInput{
 					NamespacedID: models.NamespacedID{
 						Namespace: namespace,
 						ID:        planV1.ID,
@@ -232,7 +263,7 @@ func TestPostgresAdapter(t *testing.T) {
 
 		t.Run("List", func(t *testing.T) {
 			t.Run("ById", func(t *testing.T) {
-				listPlanV1, err := env.PlanRepository.ListPlans(ctx, plan.ListPlansInput{
+				listPlanV1, err := env.PlanRepository.ListPlans(t.Context(), plan.ListPlansInput{
 					Namespaces: []string{namespace},
 					IDs:        []string{planV1.ID},
 				})
@@ -244,7 +275,7 @@ func TestPostgresAdapter(t *testing.T) {
 			})
 
 			t.Run("ByKey", func(t *testing.T) {
-				listPlanV1, err := env.PlanRepository.ListPlans(ctx, plan.ListPlansInput{
+				listPlanV1, err := env.PlanRepository.ListPlans(t.Context(), plan.ListPlansInput{
 					Namespaces: []string{namespace},
 					Keys:       []string{planV1Input.Key},
 				})
@@ -256,7 +287,7 @@ func TestPostgresAdapter(t *testing.T) {
 			})
 
 			t.Run("ByKeyVersion", func(t *testing.T) {
-				listPlanV1, err := env.PlanRepository.ListPlans(ctx, plan.ListPlansInput{
+				listPlanV1, err := env.PlanRepository.ListPlans(t.Context(), plan.ListPlansInput{
 					Namespaces:  []string{namespace},
 					KeyVersions: map[string][]int{planV1Input.Key: {1}},
 				})
@@ -289,7 +320,7 @@ func TestPostgresAdapter(t *testing.T) {
 				Phases: nil,
 			}
 
-			planV1, err = env.PlanRepository.UpdatePlan(ctx, planV1Update)
+			planV1, err = env.PlanRepository.UpdatePlan(t.Context(), planV1Update)
 			require.NoErrorf(t, err, "updating plan must not fail")
 
 			require.NotNilf(t, planV1, "plan must not be nil")
@@ -300,7 +331,7 @@ func TestPostgresAdapter(t *testing.T) {
 		t.Run("UpdateSettlementMode", func(t *testing.T) {
 			newMode := productcatalog.CreditOnlySettlementMode
 
-			planV1, err = env.PlanRepository.UpdatePlan(ctx, plan.UpdatePlanInput{
+			planV1, err = env.PlanRepository.UpdatePlan(t.Context(), plan.UpdatePlanInput{
 				NamespacedID: models.NamespacedID{
 					Namespace: namespace,
 					ID:        planV1.ID,
@@ -314,7 +345,7 @@ func TestPostgresAdapter(t *testing.T) {
 				"settlement mode mismatch: expected=%s, actual=%s", productcatalog.CreditOnlySettlementMode, planV1.SettlementMode)
 
 			// Verify persistence
-			fetched, err := env.PlanRepository.GetPlan(ctx, plan.GetPlanInput{
+			fetched, err := env.PlanRepository.GetPlan(t.Context(), plan.GetPlanInput{
 				NamespacedID: models.NamespacedID{
 					Namespace: namespace,
 					ID:        planV1.ID,
@@ -327,7 +358,7 @@ func TestPostgresAdapter(t *testing.T) {
 		})
 
 		t.Run("Delete", func(t *testing.T) {
-			err = env.PlanRepository.DeletePlan(ctx, plan.DeletePlanInput{
+			err = env.PlanRepository.DeletePlan(t.Context(), plan.DeletePlanInput{
 				NamespacedID: models.NamespacedID{
 					Namespace: planV1.Namespace,
 					ID:        planV1.ID,
@@ -335,7 +366,7 @@ func TestPostgresAdapter(t *testing.T) {
 			})
 			require.NoErrorf(t, err, "deleting plan must not fail")
 
-			getPlanV1, err := env.PlanRepository.GetPlan(ctx, plan.GetPlanInput{
+			getPlanV1, err := env.PlanRepository.GetPlan(t.Context(), plan.GetPlanInput{
 				NamespacedID: models.NamespacedID{
 					Namespace: namespace,
 					ID:        planV1.ID,
@@ -349,7 +380,7 @@ func TestPostgresAdapter(t *testing.T) {
 		})
 
 		t.Run("ListStatusFilter", func(t *testing.T) {
-			testListPlanStatusFilter(ctx, t, env.PlanRepository)
+			testListPlanStatusFilter(t.Context(), t, env.PlanRepository)
 		})
 	})
 }
@@ -387,7 +418,7 @@ func testListPlanStatusFilter(ctx context.Context, t *testing.T, repo plan.Repos
 
 	ns := "list-plan-status-filter"
 
-	planV1Input := pctestutils.NewTestPlan(t, ns, planPhases...)
+	planV1Input := pctestutils.NewTestPlan(t, ns)
 
 	err := createPlanVersion(ctx, repo, createPlanVersionInput{
 		Namespace: ns,

--- a/openmeter/productcatalog/plan/service/service_test.go
+++ b/openmeter/productcatalog/plan/service/service_test.go
@@ -113,7 +113,7 @@ func TestPlanService(t *testing.T) {
 
 	t.Run("Plan", func(t *testing.T) {
 		t.Run("Create", func(t *testing.T) {
-			planInput := pctestutils.NewTestPlan(t, namespace, []productcatalog.Phase{
+			planPhases := []productcatalog.Phase{
 				{
 					PhaseMeta: productcatalog.PhaseMeta{
 						Key:         "trial",
@@ -200,7 +200,9 @@ func TestPlanService(t *testing.T) {
 						},
 					},
 				},
-			}...)
+			}
+
+			planInput := pctestutils.NewTestPlan(t, namespace, pctestutils.WithPlanPhases(planPhases...))
 
 			var draftPlanV1 *plan.Plan
 
@@ -214,9 +216,15 @@ func TestPlanService(t *testing.T) {
 				"Plan Status mismatch: expected=%s, actual=%s", productcatalog.PlanStatusDraft, draftPlanV1.Status())
 
 			t.Run("WithCreditOnlySettlement", func(t *testing.T) {
-				creditOnlyInput := pctestutils.NewTestPlan(t, namespace, planInput.Phases...)
-				creditOnlyInput.Key = "test-credit-only"
-				creditOnlyInput.SettlementMode = productcatalog.CreditOnlySettlementMode
+				creditOnlyInput := pctestutils.NewTestPlan(t, namespace,
+					pctestutils.WithPlanPhases(planInput.Phases...),
+					func(t *testing.T, p *productcatalog.Plan) {
+						t.Helper()
+
+						p.Key = "test-credit-only"
+						p.SettlementMode = productcatalog.CreditOnlySettlementMode
+					},
+				)
 
 				p, err := env.Plan.CreatePlan(ctx, creditOnlyInput)
 				require.NoErrorf(t, err, "creating plan with credit_only settlement must not fail")
@@ -227,9 +235,15 @@ func TestPlanService(t *testing.T) {
 			})
 
 			t.Run("DefaultsSettlementModeWhenEmpty", func(t *testing.T) {
-				defaultInput := pctestutils.NewTestPlan(t, namespace, planInput.Phases...)
-				defaultInput.Key = "test-default-settlement"
-				defaultInput.SettlementMode = "" // explicitly empty, simulating API caller that doesn't set it
+				defaultInput := pctestutils.NewTestPlan(t, namespace,
+					pctestutils.WithPlanPhases(planInput.Phases...),
+					func(t *testing.T, p *productcatalog.Plan) {
+						t.Helper()
+
+						p.Key = "test-default-settlement"
+						p.SettlementMode = ""
+					},
+				)
 
 				p, err := env.Plan.CreatePlan(ctx, defaultInput)
 				require.NoErrorf(t, err, "creating plan without settlement mode must not fail")
@@ -840,31 +854,37 @@ func TestListPlansFilters(t *testing.T) {
 
 	// createPlan builds a draft plan with a minimal FlatFeeRateCard phase (no feature reference).
 	createPlan := func(key, name string, cur currency.Code) {
-		input := pctestutils.NewTestPlan(t, ns, productcatalog.Phase{
-			PhaseMeta: productcatalog.PhaseMeta{
-				Key:  "default",
-				Name: "Default",
-			},
-			RateCards: []productcatalog.RateCard{
-				&productcatalog.FlatFeeRateCard{
-					RateCardMeta: productcatalog.RateCardMeta{
-						Key:  "flat-fee",
-						Name: "Flat Fee",
-						TaxConfig: &productcatalog.TaxConfig{
-							Stripe: &productcatalog.StripeTaxConfig{Code: "txcd_10000000"},
-						},
-						Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
-							Amount:      decimal.NewFromInt(0),
-							PaymentTerm: productcatalog.InArrearsPaymentTerm,
-						}),
-					},
-					BillingCadence: &monthPeriod,
+		input := pctestutils.NewTestPlan(t, ns,
+			pctestutils.WithPlanPhases(productcatalog.Phase{
+				PhaseMeta: productcatalog.PhaseMeta{
+					Key:  "default",
+					Name: "Default",
 				},
+				RateCards: []productcatalog.RateCard{
+					&productcatalog.FlatFeeRateCard{
+						RateCardMeta: productcatalog.RateCardMeta{
+							Key:  "flat-fee",
+							Name: "Flat Fee",
+							TaxConfig: &productcatalog.TaxConfig{
+								Stripe: &productcatalog.StripeTaxConfig{Code: "txcd_10000000"},
+							},
+							Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+								Amount:      decimal.NewFromInt(0),
+								PaymentTerm: productcatalog.InArrearsPaymentTerm,
+							}),
+						},
+						BillingCadence: &monthPeriod,
+					},
+				},
+			}),
+			func(t *testing.T, p *productcatalog.Plan) {
+				t.Helper()
+
+				p.Key = key
+				p.Name = name
+				p.Currency = cur
 			},
-		})
-		input.Key = key
-		input.Name = name
-		input.Currency = cur
+		)
 
 		_, err := env.Plan.CreatePlan(ctx, input)
 		require.NoError(t, err, "creating plan %q must not fail", key)

--- a/openmeter/productcatalog/plan/service/taxcode_test.go
+++ b/openmeter/productcatalog/plan/service/taxcode_test.go
@@ -44,13 +44,13 @@ func newTestFlatRateCard(feat feature.Feature, tc *productcatalog.TaxConfig, bil
 
 func newTestPlanInput(t *testing.T, namespace string, rc productcatalog.RateCard) plan.CreatePlanInput {
 	t.Helper()
-	return pctestutils.NewTestPlan(t, namespace, productcatalog.Phase{
+	return pctestutils.NewTestPlan(t, namespace, pctestutils.WithPlanPhases(productcatalog.Phase{
 		PhaseMeta: productcatalog.PhaseMeta{
 			Key:  "default",
 			Name: "Default",
 		},
 		RateCards: productcatalog.RateCards{rc},
-	})
+	}))
 }
 
 func getFirstRCTaxConfig(t *testing.T, p *plan.Plan) *productcatalog.TaxConfig {
@@ -291,15 +291,21 @@ func TestPlanTaxCodeDualWrite(t *testing.T) {
 				BillingCadence: &MonthPeriod,
 			}
 
-			input := pctestutils.NewTestPlan(t, namespace, productcatalog.Phase{
-				PhaseMeta: productcatalog.PhaseMeta{
-					Key:  "default",
-					Name: "Default",
+			input := pctestutils.NewTestPlan(t, namespace,
+				pctestutils.WithPlanPhases(productcatalog.Phase{
+					PhaseMeta: productcatalog.PhaseMeta{
+						Key:  "default",
+						Name: "Default",
+					},
+					RateCards: productcatalog.RateCards{rc1, rc2},
+				}),
+				func(t *testing.T, p *productcatalog.Plan) {
+					t.Helper()
+
+					p.Key = "multi-stripe"
+					p.Name = "Multi Stripe"
 				},
-				RateCards: productcatalog.RateCards{rc1, rc2},
-			})
-			input.Key = "multi-stripe"
-			input.Name = "Multi Stripe"
+			)
 
 			p, err := env.Plan.CreatePlan(ctx, input)
 			require.NoError(t, err)
@@ -377,32 +383,38 @@ func TestPlanTaxCodeDualWrite(t *testing.T) {
 			TwoMonthPeriod := datetime.MustParseDuration(t, "P2M")
 
 			input := pctestutils.NewTestPlan(t, namespace,
-				productcatalog.Phase{
-					PhaseMeta: productcatalog.PhaseMeta{
-						Key:      "phase-a",
-						Name:     "Phase A",
-						Duration: &TwoMonthPeriod,
+				pctestutils.WithPlanPhases(
+					productcatalog.Phase{
+						PhaseMeta: productcatalog.PhaseMeta{
+							Key:      "phase-a",
+							Name:     "Phase A",
+							Duration: &TwoMonthPeriod,
+						},
+						RateCards: productcatalog.RateCards{
+							newTestFlatRateCard(features[0], &productcatalog.TaxConfig{
+								Stripe: &productcatalog.StripeTaxConfig{Code: "txcd_60000000"},
+							}, &MonthPeriod),
+						},
 					},
-					RateCards: productcatalog.RateCards{
-						newTestFlatRateCard(features[0], &productcatalog.TaxConfig{
-							Stripe: &productcatalog.StripeTaxConfig{Code: "txcd_60000000"},
-						}, &MonthPeriod),
+					productcatalog.Phase{
+						PhaseMeta: productcatalog.PhaseMeta{
+							Key:  "phase-b",
+							Name: "Phase B",
+						},
+						RateCards: productcatalog.RateCards{
+							newTestFlatRateCard(features[0], &productcatalog.TaxConfig{
+								Stripe: &productcatalog.StripeTaxConfig{Code: "txcd_60000000"},
+							}, &MonthPeriod),
+						},
 					},
-				},
-				productcatalog.Phase{
-					PhaseMeta: productcatalog.PhaseMeta{
-						Key:  "phase-b",
-						Name: "Phase B",
-					},
-					RateCards: productcatalog.RateCards{
-						newTestFlatRateCard(features[0], &productcatalog.TaxConfig{
-							Stripe: &productcatalog.StripeTaxConfig{Code: "txcd_60000000"},
-						}, &MonthPeriod),
-					},
+				),
+				func(t *testing.T, p *productcatalog.Plan) {
+					t.Helper()
+
+					p.Key = "multi-phase-same-code"
+					p.Name = "Multi Phase Same Code"
 				},
 			)
-			input.Key = "multi-phase-same-code"
-			input.Name = "Multi Phase Same Code"
 
 			p, err := env.Plan.CreatePlan(ctx, input)
 			require.NoError(t, err)

--- a/openmeter/productcatalog/planaddon/adapter/adapter_test.go
+++ b/openmeter/productcatalog/planaddon/adapter/adapter_test.go
@@ -68,7 +68,7 @@ func TestPostgresAdapter(t *testing.T) {
 				features = append(features, feat)
 			}
 
-			planV1Input := pctestutils.NewTestPlan(t, namespace, []productcatalog.Phase{
+			planV1Input := pctestutils.NewTestPlan(t, namespace, pctestutils.WithPlanPhases([]productcatalog.Phase{
 				{
 					PhaseMeta: productcatalog.PhaseMeta{
 						Key:         "invalid",
@@ -211,7 +211,7 @@ func TestPostgresAdapter(t *testing.T) {
 						},
 					},
 				},
-			}...)
+			}...))
 
 			var planV1 *plan.Plan
 

--- a/openmeter/productcatalog/planaddon/service/service_test.go
+++ b/openmeter/productcatalog/planaddon/service/service_test.go
@@ -68,7 +68,7 @@ func TestPlanAddonService(t *testing.T) {
 				features = append(features, feat)
 			}
 
-			planV1Input := pctestutils.NewTestPlan(t, namespace, []productcatalog.Phase{
+			planV1Input := pctestutils.NewTestPlan(t, namespace, pctestutils.WithPlanPhases([]productcatalog.Phase{
 				{
 					PhaseMeta: productcatalog.PhaseMeta{
 						Key:         "invalid",
@@ -211,7 +211,7 @@ func TestPlanAddonService(t *testing.T) {
 						},
 					},
 				},
-			}...)
+			}...))
 
 			var planV1 *plan.Plan
 

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -224,6 +224,13 @@ func (r RateCardMeta) Validate() error {
 					err),
 			))
 		}
+
+		// Ratecard with usage-based price type must have feature key.
+		if r.Price.Type() != FlatPriceType {
+			if r.FeatureKey == nil {
+				errs = append(errs, ErrRateCardUsageBasedPriceWithNoFeature)
+			}
+		}
 	}
 
 	if r.FeatureKey != nil {

--- a/openmeter/productcatalog/testutils/plan.go
+++ b/openmeter/productcatalog/testutils/plan.go
@@ -3,6 +3,7 @@ package testutils
 import (
 	"testing"
 
+	decimal "github.com/alpacahq/alpacadecimal"
 	"github.com/invopop/gobl/currency"
 	"github.com/samber/lo"
 
@@ -12,10 +13,30 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-func NewTestPlan(t *testing.T, namespace string, phases ...productcatalog.Phase) plan.CreatePlanInput {
+var MonthPeriod = datetime.NewISODuration(0, 1, 0, 0, 0, 0, 0)
+
+type TransformerFunc[T any] func(*testing.T, *T)
+
+func WithPlanPhases(phases ...productcatalog.Phase) TransformerFunc[productcatalog.Plan] {
+	return func(t *testing.T, plan *productcatalog.Plan) {
+		t.Helper()
+
+		plan.Phases = phases
+	}
+}
+
+func WithPlanKey(key string) TransformerFunc[productcatalog.Plan] {
+	return func(t *testing.T, plan *productcatalog.Plan) {
+		t.Helper()
+
+		plan.PlanMeta.Key = key
+	}
+}
+
+func NewTestPlan(t *testing.T, namespace string, transformers ...TransformerFunc[productcatalog.Plan]) plan.CreatePlanInput {
 	t.Helper()
 
-	return plan.CreatePlanInput{
+	input := plan.CreatePlanInput{
 		NamespacedModel: models.NamespacedModel{
 			Namespace: namespace,
 		},
@@ -26,14 +47,53 @@ func NewTestPlan(t *testing.T, namespace string, phases ...productcatalog.Phase)
 				Description:    lo.ToPtr("Test plan"),
 				Metadata:       models.Metadata{"name": "test"},
 				Currency:       currency.USD,
-				BillingCadence: datetime.MustParseDuration(t, "P1M"),
+				BillingCadence: MonthPeriod,
 				ProRatingConfig: productcatalog.ProRatingConfig{
 					Enabled: true,
 					Mode:    productcatalog.ProRatingModeProratePrices,
 				},
 				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
 			},
-			Phases: phases,
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: productcatalog.PhaseMeta{
+						Key:         "free",
+						Name:        "Free",
+						Description: lo.ToPtr("Trial phase"),
+						Metadata:    models.Metadata{"name": "free"},
+						Duration:    nil,
+					},
+					RateCards: []productcatalog.RateCard{
+						&productcatalog.FlatFeeRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:                 "api_requests",
+								Name:                "API Requests",
+								Description:         lo.ToPtr("API Requests"),
+								Metadata:            models.Metadata{"name": "api_requests"},
+								FeatureKey:          nil,
+								FeatureID:           nil,
+								EntitlementTemplate: nil,
+								TaxConfig: &productcatalog.TaxConfig{
+									Stripe: &productcatalog.StripeTaxConfig{
+										Code: "txcd_10000000",
+									},
+								},
+								Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+									Amount:      decimal.NewFromInt(0),
+									PaymentTerm: productcatalog.InArrearsPaymentTerm,
+								}),
+							},
+							BillingCadence: &MonthPeriod,
+						},
+					},
+				},
+			},
 		},
 	}
+
+	for _, transformer := range transformers {
+		transformer(t, &input.Plan)
+	}
+
+	return input
 }

--- a/openmeter/subscription/addon/diff/restore_test.go
+++ b/openmeter/subscription/addon/diff/restore_test.go
@@ -573,8 +573,9 @@ func TestRestore(t *testing.T) {
 					subscriptiontestutils.ExampleRateCard1.Clone(), // Flat price
 					&productcatalog.UsageBasedRateCard{ // Dynamic price
 						RateCardMeta: productcatalog.RateCardMeta{
-							Key:  "dynamic_rc_1",
-							Name: "Dynamic Rate Card 1",
+							Key:        subscriptiontestutils.ExampleFeatureKey2,
+							Name:       "Dynamic Rate Card 1",
+							FeatureKey: &subscriptiontestutils.ExampleFeatureKey2,
 							Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
 								Mode: productcatalog.VolumeTieredPrice,
 								Tiers: []productcatalog.PriceTier{
@@ -605,8 +606,9 @@ func TestRestore(t *testing.T) {
 				productcatalog.AddonInstanceTypeSingle,
 				&productcatalog.UsageBasedRateCard{ // Dynamic price for addon
 					RateCardMeta: productcatalog.RateCardMeta{
-						Key:  "addon_dynamic_rc",
-						Name: "Addon Dynamic Rate Card",
+						Key:        subscriptiontestutils.ExampleFeatureKey3,
+						Name:       "Addon Dynamic Rate Card",
+						FeatureKey: &subscriptiontestutils.ExampleFeatureKey3,
 						Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
 							Mode: productcatalog.VolumeTieredPrice,
 							Tiers: []productcatalog.PriceTier{

--- a/openmeter/subscription/workflow/service/addon_test.go
+++ b/openmeter/subscription/workflow/service/addon_test.go
@@ -688,8 +688,9 @@ func TestAddonCombinations(t *testing.T) {
 				subscriptiontestutils.ExampleRateCard1.Clone(), // Flat price
 				&productcatalog.UsageBasedRateCard{ // Dynamic price
 					RateCardMeta: productcatalog.RateCardMeta{
-						Key:  "dynamic_rc_1",
-						Name: "Dynamic Rate Card 1",
+						Key:        subscriptiontestutils.ExampleFeatureKey2,
+						Name:       "Dynamic Rate Card 1",
+						FeatureKey: &subscriptiontestutils.ExampleFeatureKey2,
 						Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
 							Mode: productcatalog.VolumeTieredPrice,
 							Tiers: []productcatalog.PriceTier{
@@ -724,8 +725,9 @@ func TestAddonCombinations(t *testing.T) {
 				productcatalog.AddonInstanceTypeSingle,
 				&productcatalog.UsageBasedRateCard{ // Dynamic price for addon
 					RateCardMeta: productcatalog.RateCardMeta{
-						Key:  "addon_dynamic_rc",
-						Name: "Addon Dynamic Rate Card",
+						Key:        subscriptiontestutils.ExampleFeatureKey3,
+						Name:       "Addon Dynamic Rate Card",
+						FeatureKey: &subscriptiontestutils.ExampleFeatureKey3,
 						Price: productcatalog.NewPriceFrom(productcatalog.TieredPrice{
 							Mode: productcatalog.VolumeTieredPrice,
 							Tiers: []productcatalog.PriceTier{


### PR DESCRIPTION
## Overview

Ensure that usage based ratecards with  usage-based pricing always have valid feature assigned to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Usage-based rate cards now require an associated feature key; missing feature keys produce a validation error.

* **Tests**
  * Extensive test refactors to standardize plan/phase construction and to exercise feature-backed rate cards across unit, graduated, addon, and e2e flows.
  * Updated fixtures and helpers to create and reference features dynamically for more robust round-trip and compatibility checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4331)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->