### PR TITLE
feat(ledger): validate currency rounding

### DIFF
--- a/openmeter/ledger/validations.go
+++ b/openmeter/ledger/validations.go
@@ -46,6 +46,10 @@ func ValidateEntryInput(ctx context.Context, entry EntryInput) error {
 		})
 	}
 
+	if err := validateEntryAmountPrecision(entry); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -57,6 +61,29 @@ func ValidateAddress(ctx context.Context, address PostingAddress) error {
 	}
 
 	return nil
+}
+
+func validateEntryAmountPrecision(entry EntryInput) error {
+	currency := entry.PostingAddress().Route().Route().Currency
+	calculator, err := currency.Calculator()
+	if err != nil {
+		return ErrCurrencyInvalid.WithAttrs(models.Attributes{
+			"currency": currency,
+			"error":    err,
+		})
+	}
+
+	amount := entry.Amount()
+	if calculator.IsRoundedToPrecision(amount) {
+		return nil
+	}
+
+	return ErrTransactionAmountInvalid.WithAttrs(models.Attributes{
+		"reason":         "amount_not_rounded_to_currency_precision",
+		"currency":       currency,
+		"amount":         amount.String(),
+		"rounded_amount": calculator.RoundToPrecision(amount).String(),
+	})
 }
 
 func ValidateTransactionInput(ctx context.Context, transaction TransactionInput) error {

--- a/openmeter/ledger/validations_test.go
+++ b/openmeter/ledger/validations_test.go
@@ -1,0 +1,120 @@
+package ledger_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/ledger"
+	ledgeraccount "github.com/openmeterio/openmeter/openmeter/ledger/account"
+	"github.com/openmeterio/openmeter/openmeter/ledger/transactions/testutils"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestValidateTransactionInputEntryAmountPrecision(t *testing.T) {
+	tests := []struct {
+		name     string
+		currency currencyx.Code
+		amount   string
+		wantErr  bool
+	}{
+		{
+			name:     "USD accepts cents",
+			currency: currencyx.Code("USD"),
+			amount:   "10.01",
+		},
+		{
+			name:     "USD rejects sub-cent amount",
+			currency: currencyx.Code("USD"),
+			amount:   "10.001",
+			wantErr:  true,
+		},
+		{
+			name:     "USD accepts negative cents",
+			currency: currencyx.Code("USD"),
+			amount:   "-10.01",
+		},
+		{
+			name:     "JPY accepts whole amount",
+			currency: currencyx.Code("JPY"),
+			amount:   "10",
+		},
+		{
+			name:     "JPY rejects fractional amount",
+			currency: currencyx.Code("JPY"),
+			amount:   "10.1",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			amount := mustDecimal(t, tt.amount)
+			address := mustPostingAddress(t, tt.currency)
+			txInput := &testutils.AnyTransactionInput{
+				BookedAtValue: time.Now(),
+				EntryInputsValues: []*testutils.AnyEntryInput{
+					{
+						Address:     address,
+						AmountValue: amount,
+					},
+					{
+						Address:     address,
+						AmountValue: amount.Neg(),
+					},
+				},
+			}
+
+			err := ledger.ValidateTransactionInput(t.Context(), txInput)
+			if !tt.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			require.ErrorIs(t, err, ledger.ErrTransactionAmountInvalid)
+
+			issues, issueErr := models.AsValidationIssues(err)
+			require.NoError(t, issueErr)
+			require.Len(t, issues, 1)
+			require.Equal(t, ledger.ErrCodeTransactionAmountInvalid, issues[0].Code())
+
+			attrs := issues[0].Attributes()
+			require.Equal(t, "amount_not_rounded_to_currency_precision", attrs["reason"])
+			require.Equal(t, tt.currency, attrs["currency"])
+			require.Equal(t, amount.String(), attrs["amount"])
+			require.NotEmpty(t, attrs["rounded_amount"])
+		})
+	}
+}
+
+func mustPostingAddress(t *testing.T, currency currencyx.Code) ledger.PostingAddress {
+	t.Helper()
+
+	route := ledger.Route{Currency: currency}
+	key, err := ledger.BuildRoutingKey(ledger.RoutingKeyVersionV1, route)
+	require.NoError(t, err)
+
+	address, err := ledgeraccount.NewAddressFromData(ledgeraccount.AddressData{
+		SubAccountID: "sub_" + string(currency),
+		AccountType:  ledger.AccountTypeCustomerFBO,
+		Route:        route,
+		RouteID:      "route_" + string(currency),
+		RoutingKey:   key,
+	})
+	require.NoError(t, err)
+
+	return address
+}
+
+func mustDecimal(t *testing.T, raw string) alpacadecimal.Decimal {
+	t.Helper()
+
+	value, err := alpacadecimal.NewFromString(raw)
+	require.NoError(t, err)
+
+	return value
+}


### PR DESCRIPTION
## summary

Adds ledger validation to reject transaction entry amounts that are not rounded to the posting currency precision.

## details

- validates each ledger entry amount using `currencyx.Calculator.IsRoundedToPrecision`
- derives currency from the entry posting address route
- rejects invalid precision with `ledger_transaction_amount_invalid`
- does not normalize/round inside ledger, since ledger is the audit boundary

## tests

- added USD/JPP precision coverage for ledger transaction validation
- ran:

```bash
nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/ledger/...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Entry amounts are now validated to match their posting currency's decimal precision. Invalid amounts will be rejected with detailed error messages.

* **Tests**
  * Added test coverage for amount precision validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4342)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->