### PR TITLE
fix: properly soft delete app custom invoicing customer associations upon customer delete [OM-357]

### DIFF
--- a/openmeter/app/custominvoicing/adapter/customerdata.go
+++ b/openmeter/app/custominvoicing/adapter/customerdata.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"entgo.io/ent/dialect/sql"
+
 	appcustominvoicing "github.com/openmeterio/openmeter/openmeter/app/custominvoicing"
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/appcustominvoicingcustomer"
@@ -47,7 +49,15 @@ func (a *adapter) UpsertCustomerData(ctx context.Context, input appcustominvoici
 			SetCustomerID(input.CustomerDataID.CustomerID).
 			SetNamespace(input.CustomerDataID.Namespace).
 			SetAppID(input.CustomerDataID.AppID).
-			OnConflictColumns(appcustominvoicingcustomer.FieldCustomerID, appcustominvoicingcustomer.FieldNamespace, appcustominvoicingcustomer.FieldAppID).
+			// Upsert
+			OnConflict(
+				sql.ConflictColumns(
+					appcustominvoicingcustomer.FieldCustomerID,
+					appcustominvoicingcustomer.FieldNamespace,
+					appcustominvoicingcustomer.FieldAppID,
+				),
+				sql.ConflictWhere(sql.IsNull(appcustominvoicingcustomer.FieldDeletedAt)),
+			).
 			UpdateMetadata().
 			UpdateDeletedAt().
 			Exec(ctx)
@@ -66,6 +76,7 @@ func (a *adapter) DeleteCustomerData(ctx context.Context, input appcustominvoici
 				appcustominvoicingcustomer.CustomerID(input.CustomerID),
 				appcustominvoicingcustomer.Namespace(input.Namespace),
 				appcustominvoicingcustomer.AppID(input.AppID),
+				appcustominvoicingcustomer.DeletedAtIsNil(),
 			).
 			Exec(ctx)
 	})

--- a/openmeter/customer/adapter/customer.go
+++ b/openmeter/customer/adapter/customer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	appcustomerdb "github.com/openmeterio/openmeter/openmeter/ent/db/appcustomer"
+	appcustominvoicingcustomerdb "github.com/openmeterio/openmeter/openmeter/ent/db/appcustominvoicingcustomer"
 	appstripecustomerdb "github.com/openmeterio/openmeter/openmeter/ent/db/appstripecustomer"
 	billingcustomeroverridedb "github.com/openmeterio/openmeter/openmeter/ent/db/billingcustomeroverride"
 	customerdb "github.com/openmeterio/openmeter/openmeter/ent/db/customer"
@@ -407,6 +408,17 @@ func (a *adapter) DeleteCustomer(ctx context.Context, input customer.DeleteCusto
 			Exec(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to delete app stripe customer: %w", err)
+		}
+
+		// Soft delete the app custom invoicing customer associations
+		err = repo.db.AppCustomInvoicingCustomer.Update().
+			Where(appcustominvoicingcustomerdb.CustomerID(input.ID)).
+			Where(appcustominvoicingcustomerdb.Namespace(input.Namespace)).
+			Where(appcustominvoicingcustomerdb.DeletedAtIsNil()).
+			SetDeletedAt(deletedAt).
+			Exec(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to delete app custom invoicing customer: %w", err)
 		}
 
 		return nil

--- a/openmeter/customer/adapter/customer_test.go
+++ b/openmeter/customer/adapter/customer_test.go
@@ -13,6 +13,7 @@ import (
 	customeradapter "github.com/openmeterio/openmeter/openmeter/customer/adapter"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	appcustomerdb "github.com/openmeterio/openmeter/openmeter/ent/db/appcustomer"
+	appcustominvoicingcustomerdb "github.com/openmeterio/openmeter/openmeter/ent/db/appcustominvoicingcustomer"
 	appstripecustomerdb "github.com/openmeterio/openmeter/openmeter/ent/db/appstripecustomer"
 	customerdb "github.com/openmeterio/openmeter/openmeter/ent/db/customer"
 	customersubjectsdb "github.com/openmeterio/openmeter/openmeter/ent/db/customersubjects"
@@ -22,11 +23,13 @@ import (
 )
 
 type fixture struct {
-	customerID          string
-	subjectKeys         []string
-	appID               string
-	appCustomerRowID    int
-	appStripeCustomerID int
+	customerID                      string
+	subjectKeys                     []string
+	appID                           string
+	appCustomerRowID                int
+	appStripeCustomerID             int
+	customInvoicingAppID            string
+	appCustomInvoicingCustomerRowID int
 }
 
 type testEnv struct {
@@ -62,8 +65,9 @@ func newTestEnv(t *testing.T) *testEnv {
 }
 
 // seed creates a Customer in the given namespace plus a full cascade chain:
-// 2 CustomerSubjects, an App, an AppStripe (sharing the same id as App),
-// 1 AppCustomer, and 1 AppStripeCustomer — all with deleted_at = NULL.
+// 2 CustomerSubjects, an App (Stripe), an AppStripe, 1 AppCustomer,
+// 1 AppStripeCustomer, an App (CustomInvoicing), an AppCustomInvoicing, and
+// 1 AppCustomInvoicingCustomer — all with deleted_at = NULL.
 func (e *testEnv) seed(namespace string) fixture {
 	e.t.Helper()
 	ctx := e.t.Context()
@@ -122,12 +126,35 @@ func (e *testEnv) seed(namespace string) fixture {
 		Save(ctx)
 	require.NoError(e.t, err, "seeding app stripe customer must not fail")
 
+	ciAppRow, err := e.db.App.Create().
+		SetNamespace(namespace).
+		SetName("custom-invoicing").
+		SetType(app.AppTypeCustomInvoicing).
+		SetStatus(app.AppStatusReady).
+		Save(ctx)
+	require.NoError(e.t, err, "seeding custom invoicing app must not fail")
+
+	_, err = e.db.AppCustomInvoicing.Create().
+		SetID(ciAppRow.ID).
+		SetNamespace(namespace).
+		Save(ctx)
+	require.NoError(e.t, err, "seeding app custom invoicing must not fail")
+
+	ciCust, err := e.db.AppCustomInvoicingCustomer.Create().
+		SetNamespace(namespace).
+		SetAppID(ciAppRow.ID).
+		SetCustomerID(cust.ID).
+		Save(ctx)
+	require.NoError(e.t, err, "seeding app custom invoicing customer must not fail")
+
 	return fixture{
-		customerID:          cust.ID,
-		subjectKeys:         subjectKeys,
-		appID:               appRow.ID,
-		appCustomerRowID:    appCust.ID,
-		appStripeCustomerID: appStripeCust.ID,
+		customerID:                      cust.ID,
+		subjectKeys:                     subjectKeys,
+		appID:                           appRow.ID,
+		appCustomerRowID:                appCust.ID,
+		appStripeCustomerID:             appStripeCust.ID,
+		customInvoicingAppID:            ciAppRow.ID,
+		appCustomInvoicingCustomerRowID: ciCust.ID,
 	}
 }
 
@@ -160,6 +187,7 @@ func TestDeleteCustomer(t *testing.T) {
 		assertSubjectsDeletedAt(t, env.db, ns, fix.customerID, fix.subjectKeys, now)
 		assertAppCustomerDeletedAt(t, env.db, ns, fix.customerID, now)
 		assertAppStripeCustomerDeletedAt(t, env.db, ns, fix.customerID, now)
+		assertAppCustomInvoicingCustomerDeletedAt(t, env.db, ns, fix.customerID, now)
 	})
 
 	t.Run("NoChildren", func(t *testing.T) {
@@ -260,6 +288,9 @@ func TestDeleteCustomer(t *testing.T) {
 
 		// app_stripe_customer: was active, must be deleted at t1.
 		assertAppStripeCustomerDeletedAt(t, env.db, ns, fix.customerID, t1)
+
+		// app_custom_invoicing_customer: was active, must be deleted at t1.
+		assertAppCustomInvoicingCustomerDeletedAt(t, env.db, ns, fix.customerID, t1)
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
@@ -316,12 +347,14 @@ func TestDeleteCustomer(t *testing.T) {
 		assertSubjectsDeletedAt(t, env.db, nsA, fixA.customerID, fixA.subjectKeys, now)
 		assertAppCustomerDeletedAt(t, env.db, nsA, fixA.customerID, now)
 		assertAppStripeCustomerDeletedAt(t, env.db, nsA, fixA.customerID, now)
+		assertAppCustomInvoicingCustomerDeletedAt(t, env.db, nsA, fixA.customerID, now)
 
 		// nsB: completely untouched.
 		assertCustomerActive(t, env.db, nsB, fixB.customerID)
 		assertSubjectsActive(t, env.db, nsB, fixB.customerID, fixB.subjectKeys)
 		assertAppCustomerActive(t, env.db, nsB, fixB.customerID)
 		assertAppStripeCustomerActive(t, env.db, nsB, fixB.customerID)
+		assertAppCustomInvoicingCustomerActive(t, env.db, nsB, fixB.customerID)
 	})
 }
 
@@ -440,5 +473,37 @@ func assertAppStripeCustomerActive(t *testing.T, db *entdb.Client, ns, customerI
 	require.NotEmpty(t, rows, "expected at least one app_stripe_customer row")
 	for _, r := range rows {
 		assert.Nilf(t, r.DeletedAt, "app_stripe_customer %d must remain active", r.ID)
+	}
+}
+
+func assertAppCustomInvoicingCustomerDeletedAt(t *testing.T, db *entdb.Client, ns, customerID string, want time.Time) {
+	t.Helper()
+	rows, err := db.AppCustomInvoicingCustomer.Query().
+		Where(
+			appcustominvoicingcustomerdb.Namespace(ns),
+			appcustominvoicingcustomerdb.CustomerID(customerID),
+		).
+		All(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, rows, "expected at least one app_custom_invoicing_customer row")
+	for _, r := range rows {
+		require.NotNilf(t, r.DeletedAt, "app_custom_invoicing_customer %d deleted_at must be set", r.ID)
+		assert.Truef(t, r.DeletedAt.Equal(want),
+			"app_custom_invoicing_customer %d deleted_at: want %s, got %s", r.ID, want, r.DeletedAt)
+	}
+}
+
+func assertAppCustomInvoicingCustomerActive(t *testing.T, db *entdb.Client, ns, customerID string) {
+	t.Helper()
+	rows, err := db.AppCustomInvoicingCustomer.Query().
+		Where(
+			appcustominvoicingcustomerdb.Namespace(ns),
+			appcustominvoicingcustomerdb.CustomerID(customerID),
+		).
+		All(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, rows, "expected at least one app_custom_invoicing_customer row")
+	for _, r := range rows {
+		assert.Nilf(t, r.DeletedAt, "app_custom_invoicing_customer %d must remain active", r.ID)
 	}
 }

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -287,6 +287,9 @@ var (
 				Name:    "appcustominvoicingcustomer_namespace_app_id_customer_id",
 				Unique:  true,
 				Columns: []*schema.Column{AppCustomInvoicingCustomersColumns[1], AppCustomInvoicingCustomersColumns[6], AppCustomInvoicingCustomersColumns[7]},
+				Annotation: &entsql.IndexAnnotation{
+					Where: "deleted_at IS NULL",
+				},
 			},
 		},
 	}

--- a/openmeter/ent/schema/appcustominvoicing.go
+++ b/openmeter/ent/schema/appcustominvoicing.go
@@ -77,6 +77,9 @@ func (AppCustomInvoicingCustomer) Fields() []ent.Field {
 func (AppCustomInvoicingCustomer) Indexes() []ent.Index {
 	return []ent.Index{
 		index.Fields("namespace", "app_id", "customer_id").
+			Annotations(
+				entsql.IndexWhere("deleted_at IS NULL"),
+			).
 			Unique(),
 	}
 }

--- a/tools/migrate/migrations/20260513120726_add_app_custom_invoicing_customers_partial_unique_indexes.down.sql
+++ b/tools/migrate/migrations/20260513120726_add_app_custom_invoicing_customers_partial_unique_indexes.down.sql
@@ -1,0 +1,4 @@
+-- reverse: create index "appcustominvoicingcustomer_namespace_app_id_customer_id" to table: "app_custom_invoicing_customers"
+DROP INDEX "appcustominvoicingcustomer_namespace_app_id_customer_id";
+-- reverse: drop index "appcustominvoicingcustomer_namespace_app_id_customer_id" from table: "app_custom_invoicing_customers"
+CREATE UNIQUE INDEX "appcustominvoicingcustomer_namespace_app_id_customer_id" ON "app_custom_invoicing_customers" ("namespace", "app_id", "customer_id");

--- a/tools/migrate/migrations/20260513120726_add_app_custom_invoicing_customers_partial_unique_indexes.up.sql
+++ b/tools/migrate/migrations/20260513120726_add_app_custom_invoicing_customers_partial_unique_indexes.up.sql
@@ -1,0 +1,4 @@
+-- drop index "appcustominvoicingcustomer_namespace_app_id_customer_id" from table: "app_custom_invoicing_customers"
+DROP INDEX "appcustominvoicingcustomer_namespace_app_id_customer_id";
+-- create index "appcustominvoicingcustomer_namespace_app_id_customer_id" to table: "app_custom_invoicing_customers"
+CREATE UNIQUE INDEX "appcustominvoicingcustomer_namespace_app_id_customer_id" ON "app_custom_invoicing_customers" ("namespace", "app_id", "customer_id") WHERE (deleted_at IS NULL);

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:9vBaeX5kYyDD2PLFByAmoDdx/eO9MczUU5tHdj1qiiI=
+h1:Dg22hfXFpV550xRLyZhvL6WsKyc5zsE9f5CKym+xRGw=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -198,3 +198,4 @@ h1:9vBaeX5kYyDD2PLFByAmoDdx/eO9MczUU5tHdj1qiiI=
 20260511201803_flatfee_runs.up.sql h1:mNKOZNFhdZEZ1Y4p/dZpGNg51BeOu42qaeQ4bBaxxsQ=
 20260512114051_flatfee_run_domain_fields.up.sql h1:U1HP3IRA9klnhKXDKymFQhwCErWNPqValuwCZjqyTmc=
 20260513072457_ledger_transaction_template_codes.up.sql h1:qbiFeJwp78WmAiUZjBne6RZwsij5lMRdkJn24yVkPTE=
+20260513120726_add_app_custom_invoicing_customers_partial_unique_indexes.up.sql h1:XiyiSN7JC3YQTKmA1dKBF3kgprlBKnK116tdU0pXfd0=


### PR DESCRIPTION
## Overview

Fix soft-delete unique constraint for app custom invoicing customers

### What

- Converts the unique index on `app_custom_invoicing_customers` to a **partial unique index** scoped to non-deleted rows (`WHERE deleted_at IS NULL`).
- Updates `UpsertCustomerData` to use `ON CONFLICT ... WHERE (deleted_at IS NULL)` to match the partial index.
- Adds `DeletedAtIsNil()` filter to `DeleteCustomerData` for consistency.
- Extends `customer.DeleteCustomer` to soft-delete `app_custom_invoicing_customers` rows when a customer is deleted.
- Extends the customer adapter test suite to cover the new cascade.

### Why

Mirrors the fix applied to `app_customers` and `app_stripe_customers` in the previous PR (#4325). Soft-deleted `app_custom_invoicing_customers` records were blocking re-creation of the same customer–app association after deletion, because the unique index covered all rows including soft-deleted ones.

### How

- Migration drops the existing full-table unique index on `(namespace, app_id, customer_id)` and recreates it as a partial index filtered to `deleted_at IS NULL`.
- Ent schema updated with `entsql.IndexWhere("deleted_at IS NULL")` + `make generate` run.
- Upsert switches from `OnConflictColumns(...)` to `OnConflict(sql.ConflictColumns(...), sql.ConflictWhere(sql.IsNull(...)))`.
- `customer.DeleteCustomer` now soft-deletes associated `app_custom_invoicing_customers` rows in the same transaction.
- Tests: `seed()` extended with `AppCustomInvoicing` + `AppCustomInvoicingCustomer` rows; assertions added to `Cascade_AllChildren`, `PreservesAlreadyDeletedChildren`, and `DifferentNamespaceIsolation`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced customer deletion logic to properly cascade soft-delete operations across all related custom invoicing records and ensure data consistency.
  * Refined database constraints to enforce uniqueness only on active records, preventing conflicts when handling soft-deleted data while maintaining referential integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4344)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->