### PR TITLE
chore: flat-fee run support

### DIFF
--- a/openmeter/billing/charges/flatfee/adapter.go
+++ b/openmeter/billing/charges/flatfee/adapter.go
@@ -27,6 +27,7 @@ type Adapter interface {
 
 type ChargeAdapter interface {
 	CreateCharges(ctx context.Context, charges CreateChargesInput) ([]Charge, error)
+	ProvisionCurrentRun(ctx context.Context, input ProvisionCurrentRunInput) (RealizationRunBase, error)
 	UpdateCharge(ctx context.Context, charge ChargeBase) (ChargeBase, error)
 	DeleteCharge(ctx context.Context, charge Charge) error
 	GetByIDs(ctx context.Context, ids GetByIDsInput) ([]Charge, error)
@@ -35,11 +36,11 @@ type ChargeAdapter interface {
 
 type ChargeDetailedLineAdapter interface {
 	UpsertDetailedLines(ctx context.Context, chargeID meta.ChargeID, lines DetailedLines) error
-	FetchDetailedLines(ctx context.Context, charge Charge) (Charge, error)
+	FetchCurrentRunDetailedLines(ctx context.Context, charge Charge) (Charge, error)
 }
 
 type ChargeInvoicedUsageAdapter interface {
-	CreateInvoicedUsage(ctx context.Context, chargeID meta.ChargeID, invoicedUsage invoicedusage.AccruedUsage) (invoicedusage.AccruedUsage, error)
+	CreateInvoicedUsage(ctx context.Context, input CreateInvoicedUsageInput) (invoicedusage.AccruedUsage, error)
 }
 
 type ChargeCreditAllocationAdapter interface {
@@ -51,11 +52,56 @@ type ChargePaymentAdapter interface {
 	UpdatePayment(ctx context.Context, paymentSettlement payment.Invoiced) (payment.Invoiced, error)
 }
 
+type ProvisionCurrentRunInput struct {
+	Charge                    ChargeBase
+	NoFiatTransactionRequired bool
+}
+
+func (i ProvisionCurrentRunInput) Validate() error {
+	var errs []error
+
+	if err := i.Charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type CreateInvoicedUsageInput struct {
+	ChargeID      meta.ChargeID
+	LineID        string
+	InvoiceID     string
+	InvoicedUsage invoicedusage.AccruedUsage
+}
+
+func (i CreateInvoicedUsageInput) Validate() error {
+	var errs []error
+
+	if err := i.ChargeID.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge ID: %w", err))
+	}
+
+	if i.InvoiceID == "" {
+		errs = append(errs, fmt.Errorf("invoice ID is required"))
+	}
+
+	if i.LineID == "" {
+		errs = append(errs, fmt.Errorf("line ID is required"))
+	}
+
+	if err := i.InvoicedUsage.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("invoiced usage: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
 type IntentWithInitialStatus struct {
 	Intent
-	FeatureID            *string
-	InitialStatus        Status
-	AmountAfterProration alpacadecimal.Decimal
+	FeatureID                 *string
+	InitialStatus             Status
+	AmountAfterProration      alpacadecimal.Decimal
+	NoFiatTransactionRequired bool
 }
 
 func (i IntentWithInitialStatus) Validate() error {

--- a/openmeter/billing/charges/flatfee/adapter/charge.go
+++ b/openmeter/billing/charges/flatfee/adapter/charge.go
@@ -10,9 +10,9 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/chargemeta"
-	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	dbchargeflatfee "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfee"
+	dbchargeflatfeerun "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
@@ -137,8 +137,16 @@ func (a *adapter) CreateCharges(ctx context.Context, in flatfee.CreateChargesInp
 			return nil, err
 		}
 
-		for _, entity := range entities {
-			if _, err := tx.createCurrentRun(ctx, entity, totals.Totals{}); err != nil {
+		for idx, entity := range entities {
+			if entity.StatusDetailed != flatfee.StatusActive {
+				continue
+			}
+
+			chargeBase := MapChargeBaseFromDB(entity)
+			if _, err := tx.ProvisionCurrentRun(ctx, flatfee.ProvisionCurrentRunInput{
+				Charge:                    chargeBase,
+				NoFiatTransactionRequired: in.Intents[idx].NoFiatTransactionRequired,
+			}); err != nil {
 				return nil, err
 			}
 		}
@@ -204,7 +212,7 @@ func (a *adapter) GetByIDs(ctx context.Context, input flatfee.GetByIDsInput) ([]
 
 		if input.Expands.Has(meta.ExpandDetailedLines) {
 			return slicesx.MapWithErr(out, func(charge flatfee.Charge) (flatfee.Charge, error) {
-				return tx.FetchDetailedLines(ctx, charge)
+				return tx.FetchCurrentRunDetailedLines(ctx, charge)
 			})
 		}
 
@@ -241,7 +249,7 @@ func (a *adapter) GetByID(ctx context.Context, input flatfee.GetByIDInput) (flat
 		}
 
 		if input.Expands.Has(meta.ExpandDetailedLines) {
-			return tx.FetchDetailedLines(ctx, charge)
+			return tx.FetchCurrentRunDetailedLines(ctx, charge)
 		}
 
 		return charge, nil
@@ -249,8 +257,12 @@ func (a *adapter) GetByID(ctx context.Context, input flatfee.GetByIDInput) (flat
 }
 
 func expandRealizations(query *db.ChargeFlatFeeQuery) *db.ChargeFlatFeeQuery {
-	return query.WithCurrentRun(func(query *db.ChargeFlatFeeRunQuery) {
+	return query.WithRuns(func(query *db.ChargeFlatFeeRunQuery) {
 		query.
+			Order(
+				dbchargeflatfeerun.ByServicePeriodTo(),
+				dbchargeflatfeerun.ByCreatedAt(),
+			).
 			WithCreditAllocations().
 			WithInvoicedUsage().
 			WithPayment()

--- a/openmeter/billing/charges/flatfee/adapter/detailedline.go
+++ b/openmeter/billing/charges/flatfee/adapter/detailedline.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"entgo.io/ent/dialect/sql"
@@ -20,17 +21,21 @@ import (
 
 var _ flatfee.ChargeDetailedLineAdapter = (*adapter)(nil)
 
-func (a *adapter) FetchDetailedLines(ctx context.Context, charge flatfee.Charge) (flatfee.Charge, error) {
-	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (flatfee.Charge, error) {
-		run, err := queryCurrentRunByChargeID(tx.db, charge.GetChargeID()).Only(ctx)
-		if err != nil {
-			return flatfee.Charge{}, err
-		}
+func (a *adapter) FetchCurrentRunDetailedLines(ctx context.Context, charge flatfee.Charge) (flatfee.Charge, error) {
+	if charge.Realizations.CurrentRun == nil {
+		return flatfee.Charge{}, fmt.Errorf("current run is required to fetch flat fee detailed lines for charge %s", charge.GetChargeID())
+	}
 
+	currentRunID := charge.Realizations.CurrentRun.ID
+	if err := currentRunID.Validate(); err != nil {
+		return flatfee.Charge{}, fmt.Errorf("current run ID: %w", err)
+	}
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (flatfee.Charge, error) {
 		dbLines, err := tx.db.ChargeFlatFeeRunDetailedLine.Query().
 			Where(
 				dbchargeflatfeerundetailedline.NamespaceEQ(charge.Namespace),
-				dbchargeflatfeerundetailedline.RunIDEQ(run.ID),
+				dbchargeflatfeerundetailedline.RunIDEQ(currentRunID.ID),
 				dbchargeflatfeerundetailedline.DeletedAtIsNil(),
 			).
 			WithTaxCode().
@@ -50,7 +55,7 @@ func (a *adapter) FetchDetailedLines(ctx context.Context, charge flatfee.Charge)
 		}
 
 		sortDetailedLines(lines)
-		charge.Realizations.DetailedLines = mo.Some(lines)
+		charge.Realizations.CurrentRun.DetailedLines = mo.Some(lines)
 
 		return charge, nil
 	})

--- a/openmeter/billing/charges/flatfee/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/flatfee/adapter/detailedline_test.go
@@ -170,12 +170,13 @@ func (s *FlatFeeDetailedLineAdapterSuite) TestUpsertDetailedLinesReplacesAndSoft
 		},
 	})
 	s.Require().NoError(err)
-	s.True(fetchedCharge.Realizations.DetailedLines.IsPresent())
-	s.Len(fetchedCharge.Realizations.DetailedLines.OrEmpty(), 2)
-	s.Equal("keep", fetchedCharge.Realizations.DetailedLines.OrEmpty()[0].ChildUniqueReferenceID)
-	s.Equal("new", fetchedCharge.Realizations.DetailedLines.OrEmpty()[1].ChildUniqueReferenceID)
-	s.Equal(float64(3), fetchedCharge.Realizations.DetailedLines.OrEmpty()[0].Quantity.InexactFloat64())
-	s.Nil(fetchedCharge.Realizations.DetailedLines.OrEmpty()[0].Description)
+	s.Require().NotNil(fetchedCharge.Realizations.CurrentRun)
+	s.True(fetchedCharge.Realizations.CurrentRun.DetailedLines.IsPresent())
+	s.Len(fetchedCharge.Realizations.CurrentRun.DetailedLines.OrEmpty(), 2)
+	s.Equal("keep", fetchedCharge.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].ChildUniqueReferenceID)
+	s.Equal("new", fetchedCharge.Realizations.CurrentRun.DetailedLines.OrEmpty()[1].ChildUniqueReferenceID)
+	s.Equal(float64(3), fetchedCharge.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].Quantity.InexactFloat64())
+	s.Nil(fetchedCharge.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].Description)
 
 	dbCharge, err := s.dbClient.ChargeFlatFee.Query().
 		Where(
@@ -218,6 +219,22 @@ func (s *FlatFeeDetailedLineAdapterSuite) TestUpsertDetailedLinesReplacesAndSoft
 		Only(ctx)
 	s.Require().NoError(err)
 	s.NotNil(deletedRow.DeletedAt)
+}
+
+func (s *FlatFeeDetailedLineAdapterSuite) TestFetchCurrentRunDetailedLinesRequiresCurrentRun() {
+	ctx := s.T().Context()
+
+	_, err := s.adapter.FetchCurrentRunDetailedLines(ctx, flatfee.Charge{
+		ChargeBase: flatfee.ChargeBase{
+			ManagedResource: chargesmeta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{
+					Namespace: "flatfee-detailedline-adapter",
+				},
+				ID: "charge-id",
+			},
+		},
+	})
+	s.Require().ErrorContains(err, "current run is required")
 }
 
 func (s *FlatFeeDetailedLineAdapterSuite) createCustomer(namespace string) string {

--- a/openmeter/billing/charges/flatfee/adapter/mapper.go
+++ b/openmeter/billing/charges/flatfee/adapter/mapper.go
@@ -73,6 +73,10 @@ func mapRealizationsFromDB(entity *entdb.ChargeFlatFee) (flatfee.Realizations, e
 		realizations.PriorRuns = append(realizations.PriorRuns, run)
 	}
 
+	if entity.CurrentRealizationRunID != nil && realizations.CurrentRun == nil {
+		return flatfee.Realizations{}, fmt.Errorf("current realization run [id=%s] not loaded for flat fee charge [id=%s]", *entity.CurrentRealizationRunID, entity.ID)
+	}
+
 	return realizations, nil
 }
 

--- a/openmeter/billing/charges/flatfee/adapter/mapper.go
+++ b/openmeter/billing/charges/flatfee/adapter/mapper.go
@@ -5,7 +5,6 @@ import (
 	"slices"
 
 	"github.com/samber/lo"
-	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
@@ -14,8 +13,11 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 // MapFlatFeeChargeFromDB converts a DB Charge entity (with loaded FlatFee edge) to a FlatFeeCharge.
@@ -27,18 +29,11 @@ func MapChargeFlatFeeFromDB(entity *entdb.ChargeFlatFee, expands meta.Expands) (
 	}
 
 	if expands.Has(meta.ExpandRealizations) {
-		dbRun, err := entity.Edges.CurrentRunOrErr()
+		realizations, err := mapRealizationsFromDB(entity)
 		if err != nil {
-			if _, ok := lo.ErrorsAs[*entdb.NotFoundError](err); !ok {
-				return flatfee.Charge{}, fmt.Errorf("mapping flat fee charge [id=%s]: %w", entity.ID, err)
-			}
+			return flatfee.Charge{}, fmt.Errorf("mapping flat fee charge [id=%s]: %w", entity.ID, err)
 		}
-
-		if dbRun != nil {
-			if err := mapRealizationsFromCurrentRun(dbRun, &charge); err != nil {
-				return flatfee.Charge{}, fmt.Errorf("mapping flat fee realization run [charge_id=%s]: %w", entity.ID, err)
-			}
-		}
+		charge.Realizations = realizations
 	}
 
 	return charge, nil
@@ -57,53 +52,84 @@ func mapRunDetailedLineFromDB(dbLine *entdb.ChargeFlatFeeRunDetailedLine) (flatf
 	return line, line.Validate()
 }
 
-func mapRealizationsFromCurrentRun(dbRun *entdb.ChargeFlatFeeRun, charge *flatfee.Charge) error {
+func mapRealizationsFromDB(entity *entdb.ChargeFlatFee) (flatfee.Realizations, error) {
+	dbRuns, err := entity.Edges.RunsOrErr()
+	if err != nil {
+		return flatfee.Realizations{}, fmt.Errorf("runs not loaded for flat fee charge [id=%s]: %w", entity.ID, err)
+	}
+
+	var realizations flatfee.Realizations
+	for _, dbRun := range dbRuns {
+		run, err := mapRealizationRunFromDB(dbRun)
+		if err != nil {
+			return flatfee.Realizations{}, fmt.Errorf("mapping flat fee realization run [id=%s]: %w", dbRun.ID, err)
+		}
+
+		if entity.CurrentRealizationRunID != nil && dbRun.ID == *entity.CurrentRealizationRunID {
+			realizations.CurrentRun = &run
+			continue
+		}
+
+		realizations.PriorRuns = append(realizations.PriorRuns, run)
+	}
+
+	return realizations, nil
+}
+
+func mapRealizationRunBaseFromDB(dbRun *entdb.ChargeFlatFeeRun) flatfee.RealizationRunBase {
+	return flatfee.RealizationRunBase{
+		ID: flatfee.RealizationRunID{
+			Namespace: dbRun.Namespace,
+			ID:        dbRun.ID,
+		},
+		ManagedModel: entutils.MapTimeMixinFromDB(dbRun),
+
+		LineID:                    dbRun.LineID,
+		InvoiceID:                 dbRun.InvoiceID,
+		Type:                      dbRun.Type,
+		InitialType:               dbRun.InitialType,
+		ServicePeriod:             timeutil.ClosedPeriod{From: dbRun.ServicePeriodFrom.UTC(), To: dbRun.ServicePeriodTo.UTC()},
+		AmountAfterProration:      dbRun.AmountAfterProration,
+		Totals:                    totals.FromDB(dbRun),
+		NoFiatTransactionRequired: dbRun.NoFiatTransactionRequired,
+	}
+}
+
+func mapRealizationRunFromDB(dbRun *entdb.ChargeFlatFeeRun) (flatfee.RealizationRun, error) {
+	run := flatfee.RealizationRun{
+		RealizationRunBase: mapRealizationRunBaseFromDB(dbRun),
+	}
+
 	dbCreditsAllocated, err := dbRun.Edges.CreditAllocationsOrErr()
 	if _, ok := lo.ErrorsAs[*entdb.NotLoadedError](err); ok {
-		return fmt.Errorf("credits allocated not loaded for flat fee charge run [id=%s]", dbRun.ID)
+		return flatfee.RealizationRun{}, fmt.Errorf("credits allocated not loaded for flat fee charge run [id=%s]", dbRun.ID)
 	}
 
 	for _, credit := range dbCreditsAllocated {
-		charge.Realizations.CreditRealizations = append(charge.Realizations.CreditRealizations, creditrealization.MapFromDB(credit))
+		run.CreditRealizations = append(run.CreditRealizations, creditrealization.MapFromDB(credit))
 	}
 
 	dbInvoiceUsage, err := dbRun.Edges.InvoicedUsageOrErr()
 	if _, ok := lo.ErrorsAs[*entdb.NotLoadedError](err); ok {
-		return fmt.Errorf("invoice usage not loaded for flat fee charge run [id=%s]", dbRun.ID)
+		return flatfee.RealizationRun{}, fmt.Errorf("invoice usage not loaded for flat fee charge run [id=%s]", dbRun.ID)
 	}
 
 	if dbInvoiceUsage != nil {
 		usage := invoicedusage.MapAccruedUsageFromDB(dbInvoiceUsage)
-		charge.Realizations.AccruedUsage = &usage
+		run.AccruedUsage = &usage
 	}
 
 	dbPayment, err := dbRun.Edges.PaymentOrErr()
 	if _, ok := lo.ErrorsAs[*entdb.NotLoadedError](err); ok {
-		return fmt.Errorf("payment not loaded for flat fee charge run [id=%s]", dbRun.ID)
+		return flatfee.RealizationRun{}, fmt.Errorf("payment not loaded for flat fee charge run [id=%s]", dbRun.ID)
 	}
 
 	if dbPayment != nil {
 		paymentState := payment.MapInvoicedFromDB(dbPayment)
-		charge.Realizations.Payment = &paymentState
+		run.Payment = &paymentState
 	}
 
-	dbDetailedLines, err := dbRun.Edges.DetailedLinesOrErr()
-	if err == nil {
-		lines := make(flatfee.DetailedLines, 0, len(dbDetailedLines))
-		for _, dbLine := range dbDetailedLines {
-			line, err := mapRunDetailedLineFromDB(dbLine)
-			if err != nil {
-				return err
-			}
-
-			lines = append(lines, line)
-		}
-
-		sortDetailedLines(lines)
-		charge.Realizations.DetailedLines = mo.Some(lines)
-	}
-
-	return nil
+	return run, nil
 }
 
 func taxCodeIDFromEnt(resolvedTaxCode *entdb.TaxCode) *string {

--- a/openmeter/billing/charges/flatfee/adapter/realizationrun.go
+++ b/openmeter/billing/charges/flatfee/adapter/realizationrun.go
@@ -10,9 +10,10 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	dbchargeflatfee "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfee"
 	dbchargeflatfeerun "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
+	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 )
 
-func (a *adapter) createCurrentRun(ctx context.Context, dbCharge *db.ChargeFlatFee, runTotals totals.Totals) (*db.ChargeFlatFeeRun, error) {
+func (a *adapter) createCurrentRun(ctx context.Context, dbCharge *db.ChargeFlatFee, runTotals totals.Totals, noFiatTransactionRequired bool) (*db.ChargeFlatFeeRun, error) {
 	runCreate := a.db.ChargeFlatFeeRun.Create().
 		SetNamespace(dbCharge.Namespace).
 		SetChargeID(dbCharge.ID).
@@ -20,7 +21,8 @@ func (a *adapter) createCurrentRun(ctx context.Context, dbCharge *db.ChargeFlatF
 		SetInitialType(flatfee.RealizationRunTypeFinalRealization).
 		SetServicePeriodFrom(dbCharge.ServicePeriodFrom).
 		SetServicePeriodTo(dbCharge.ServicePeriodTo).
-		SetAmountAfterProration(dbCharge.AmountAfterProration)
+		SetAmountAfterProration(dbCharge.AmountAfterProration).
+		SetNoFiatTransactionRequired(noFiatTransactionRequired)
 
 	runCreate = totals.Set(runCreate, runTotals)
 
@@ -37,6 +39,41 @@ func (a *adapter) createCurrentRun(ctx context.Context, dbCharge *db.ChargeFlatF
 	}
 
 	return dbRun, nil
+}
+
+func (a *adapter) ProvisionCurrentRun(ctx context.Context, input flatfee.ProvisionCurrentRunInput) (flatfee.RealizationRunBase, error) {
+	if err := input.Validate(); err != nil {
+		return flatfee.RealizationRunBase{}, err
+	}
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (flatfee.RealizationRunBase, error) {
+		dbCharge, err := tx.db.ChargeFlatFee.Query().
+			Where(
+				dbchargeflatfee.NamespaceEQ(input.Charge.Namespace),
+				dbchargeflatfee.IDEQ(input.Charge.ID),
+			).
+			WithCurrentRun().
+			Only(ctx)
+		if err != nil {
+			return flatfee.RealizationRunBase{}, fmt.Errorf("querying flat fee charge [id=%s]: %w", input.Charge.ID, err)
+		}
+
+		if dbCharge.CurrentRealizationRunID != nil {
+			dbRun, err := dbCharge.Edges.CurrentRunOrErr()
+			if err != nil {
+				return flatfee.RealizationRunBase{}, fmt.Errorf("querying flat fee current run [charge_id=%s]: %w", input.Charge.ID, err)
+			}
+
+			return mapRealizationRunBaseFromDB(dbRun), nil
+		}
+
+		dbRun, err := tx.createCurrentRun(ctx, dbCharge, totals.Totals{}, input.NoFiatTransactionRequired)
+		if err != nil {
+			return flatfee.RealizationRunBase{}, err
+		}
+
+		return mapRealizationRunBaseFromDB(dbRun), nil
+	})
 }
 
 func (a *adapter) currentRunByChargeID(ctx context.Context, chargeID meta.ChargeID) (*db.ChargeFlatFeeRun, error) {

--- a/openmeter/billing/charges/flatfee/adapter/usage.go
+++ b/openmeter/billing/charges/flatfee/adapter/usage.go
@@ -3,30 +3,39 @@ package adapter
 import (
 	"context"
 
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 )
 
-func (a *adapter) CreateInvoicedUsage(ctx context.Context, chargeID meta.ChargeID, invoicedUsage invoicedusage.AccruedUsage) (invoicedusage.AccruedUsage, error) {
-	if err := invoicedUsage.Validate(); err != nil {
+func (a *adapter) CreateInvoicedUsage(ctx context.Context, input flatfee.CreateInvoicedUsageInput) (invoicedusage.AccruedUsage, error) {
+	if err := input.Validate(); err != nil {
 		return invoicedusage.AccruedUsage{}, err
 	}
 
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (invoicedusage.AccruedUsage, error) {
-		run, err := tx.currentRunByChargeID(ctx, chargeID)
+		run, err := tx.currentRunByChargeID(ctx, input.ChargeID)
 		if err != nil {
 			return invoicedusage.AccruedUsage{}, err
 		}
 
-		if _, err := tx.updateCurrentRunTotals(ctx, run, invoicedUsage.Totals); err != nil {
+		if _, err := tx.updateCurrentRunTotals(ctx, run, input.InvoicedUsage.Totals); err != nil {
+			return invoicedusage.AccruedUsage{}, err
+		}
+
+		if _, err := tx.db.ChargeFlatFeeRun.UpdateOneID(run.ID).
+			Where(chargeflatfeerun.Namespace(input.ChargeID.Namespace)).
+			SetLineID(input.LineID).
+			SetInvoiceID(input.InvoiceID).
+			Save(ctx); err != nil {
 			return invoicedusage.AccruedUsage{}, err
 		}
 
 		create := tx.db.ChargeFlatFeeRunInvoicedUsage.Create().
 			SetRunID(run.ID)
 
-		create = invoicedusage.Create(create, chargeID.Namespace, invoicedUsage)
+		create = invoicedusage.Create(create, input.ChargeID.Namespace, input.InvoicedUsage)
 
 		entity, err := create.Save(ctx)
 		if err != nil {

--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -7,12 +7,8 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -239,37 +235,21 @@ func (s State) Validate() error {
 }
 
 type Realizations struct {
-	CreditRealizations creditrealization.Realizations `json:"creditRealizations"`
-	AccruedUsage       *invoicedusage.AccruedUsage    `json:"accruedUsage"`
-	Payment            *payment.Invoiced              `json:"payment"`
-	DetailedLines      mo.Option[DetailedLines]       `json:"detailedLines,omitzero"`
+	CurrentRun *RealizationRun `json:"currentRun,omitempty"`
+	PriorRuns  RealizationRuns `json:"priorRuns,omitempty"`
 }
 
 func (r Realizations) Validate() error {
 	var errs []error
 
-	for _, realization := range r.CreditRealizations {
-		if err := realization.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("credit realization[id=%s]: %w", realization.ID, err))
+	if r.CurrentRun != nil {
+		if err := r.CurrentRun.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("current run: %w", err))
 		}
 	}
 
-	if r.Payment != nil {
-		if err := r.Payment.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("payment[id=%s]: %w", r.Payment.ID, err))
-		}
-	}
-
-	if r.AccruedUsage != nil {
-		if err := r.AccruedUsage.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("accrued usage[id=%s]: %w", r.AccruedUsage.ID, err))
-		}
-	}
-
-	if r.DetailedLines.IsPresent() {
-		if err := r.DetailedLines.OrEmpty().Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("detailed lines: %w", err))
-		}
+	if err := r.PriorRuns.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("prior runs: %w", err))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/billing/charges/flatfee/realizationrun.go
+++ b/openmeter/billing/charges/flatfee/realizationrun.go
@@ -1,10 +1,20 @@
 package flatfee
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/mo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type RealizationRunType string
@@ -31,4 +41,140 @@ func (t RealizationRunType) Validate() error {
 
 func (t RealizationRunType) IsVoidedBillingHistory() bool {
 	return t == RealizationRunTypeInvalidDueToUnsupportedCreditNote
+}
+
+type RealizationRunID models.NamespacedID
+
+func (i RealizationRunID) Validate() error {
+	return models.NamespacedID(i).Validate()
+}
+
+type RealizationRunBase struct {
+	ID RealizationRunID `json:"id"`
+	models.ManagedModel
+
+	LineID    *string `json:"lineId,omitempty"`
+	InvoiceID *string `json:"invoiceId,omitempty"`
+
+	Type        RealizationRunType `json:"type"`
+	InitialType RealizationRunType `json:"initialType"`
+
+	ServicePeriod             timeutil.ClosedPeriod `json:"servicePeriod"`
+	AmountAfterProration      alpacadecimal.Decimal `json:"amountAfterProration"`
+	Totals                    totals.Totals         `json:"totals"`
+	NoFiatTransactionRequired bool                  `json:"noFiatTransactionRequired"`
+}
+
+func (r RealizationRunBase) Normalized() RealizationRunBase {
+	r.ServicePeriod = meta.NormalizeClosedPeriod(r.ServicePeriod)
+
+	return r
+}
+
+func (r RealizationRunBase) Validate() error {
+	var errs []error
+
+	if err := r.ID.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("namespaced id: %w", err))
+	}
+
+	if err := r.ManagedModel.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("managed model: %w", err))
+	}
+
+	if r.LineID != nil && *r.LineID == "" {
+		errs = append(errs, fmt.Errorf("line id must be non-empty"))
+	}
+
+	if r.InvoiceID != nil && *r.InvoiceID == "" {
+		errs = append(errs, fmt.Errorf("invoice id must be non-empty"))
+	}
+
+	if err := r.Type.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("type: %w", err))
+	}
+
+	if err := r.InitialType.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("initial type: %w", err))
+	}
+
+	if r.InitialType == RealizationRunTypeInvalidDueToUnsupportedCreditNote {
+		errs = append(errs, fmt.Errorf("initial type cannot be %s", RealizationRunTypeInvalidDueToUnsupportedCreditNote))
+	}
+
+	if r.ServicePeriod.From.IsZero() {
+		errs = append(errs, fmt.Errorf("service period from must be set"))
+	}
+
+	if r.ServicePeriod.To.IsZero() {
+		errs = append(errs, fmt.Errorf("service period to must be set"))
+	}
+
+	if r.ServicePeriod.To.Before(r.ServicePeriod.From) {
+		errs = append(errs, fmt.Errorf("service period to must be after service period from"))
+	}
+
+	if r.AmountAfterProration.IsNegative() {
+		errs = append(errs, fmt.Errorf("amount after proration must be zero or positive"))
+	}
+
+	if err := r.Totals.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("totals: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type RealizationRun struct {
+	RealizationRunBase
+
+	CreditRealizations creditrealization.Realizations `json:"creditRealizations"`
+	AccruedUsage       *invoicedusage.AccruedUsage    `json:"accruedUsage"`
+	Payment            *payment.Invoiced              `json:"payment"`
+	DetailedLines      mo.Option[DetailedLines]       `json:"detailedLines,omitzero"`
+}
+
+func (r RealizationRun) Validate() error {
+	var errs []error
+
+	if err := r.RealizationRunBase.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("realization run: %w", err))
+	}
+
+	if err := r.CreditRealizations.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("credit realizations: %w", err))
+	}
+
+	if r.AccruedUsage != nil {
+		if err := r.AccruedUsage.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("accrued usage: %w", err))
+		}
+	}
+
+	if r.Payment != nil {
+		if err := r.Payment.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("payment: %w", err))
+		}
+	}
+
+	if r.DetailedLines.IsPresent() {
+		if err := r.DetailedLines.OrEmpty().Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("detailed lines: %w", err))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type RealizationRuns []RealizationRun
+
+func (r RealizationRuns) Validate() error {
+	var errs []error
+	for idx, run := range r {
+		if err := run.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("realization run[%d]: %w", idx, err))
+		}
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }

--- a/openmeter/billing/charges/flatfee/realizationrun.go
+++ b/openmeter/billing/charges/flatfee/realizationrun.go
@@ -166,6 +166,18 @@ func (r RealizationRun) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
+// IsVoidedBillingHistory reports whether this run must be ignored as billing
+// history. Deleted runs were already cleaned up through billing; unsupported
+// credit-note runs are retained for audit even though the invoice line should
+// have been removed once prorating/credit-note support exists.
+func (r RealizationRun) IsVoidedBillingHistory() bool {
+	if r.Type.IsVoidedBillingHistory() {
+		return true
+	}
+
+	return r.DeletedAt != nil
+}
+
 type RealizationRuns []RealizationRun
 
 func (r RealizationRuns) Validate() error {

--- a/openmeter/billing/charges/flatfee/service/create.go
+++ b/openmeter/billing/charges/flatfee/service/create.go
@@ -49,10 +49,11 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 			}
 
 			return flatfee.IntentWithInitialStatus{
-				Intent:               intent,
-				FeatureID:            featureID,
-				InitialStatus:        initialStatus,
-				AmountAfterProration: amountAfterProration,
+				Intent:                    intent,
+				FeatureID:                 featureID,
+				InitialStatus:             initialStatus,
+				AmountAfterProration:      amountAfterProration,
+				NoFiatTransactionRequired: intent.SettlementMode == productcatalog.CreditOnlySettlementMode || amountAfterProration.IsZero(),
 			}, nil
 		})
 		if err != nil {

--- a/openmeter/billing/charges/flatfee/service/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/creditsonly.go
@@ -51,9 +51,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 	s.Configure(flatfee.StatusActive).
 		Permit(meta.TriggerNext, flatfee.StatusFinal).
 		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
-		OnActive(
-			s.AllocateCredits,
-		)
+		OnActive(s.AllocateCredits)
 
 	s.Configure(flatfee.StatusFinal).
 		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
@@ -89,6 +87,20 @@ func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {
 		return fmt.Errorf("charge total is negative [charge_id=%s, amount=%s]", s.Charge.ID, amount.String())
 	}
 
+	if s.Charge.Realizations.CurrentRun == nil {
+		runBase, err := s.Adapter.ProvisionCurrentRun(ctx, flatfee.ProvisionCurrentRunInput{
+			Charge:                    s.Charge.ChargeBase,
+			NoFiatTransactionRequired: true, // We are in credits-only mode
+		})
+		if err != nil {
+			return fmt.Errorf("provision current run: %w", err)
+		}
+
+		s.Charge.Realizations.CurrentRun = &flatfee.RealizationRun{
+			RealizationRunBase: runBase,
+		}
+	}
+
 	result, err := s.Realizations.AllocateCreditsOnly(ctx, flatfeerealizations.AllocateCreditsOnlyInput{
 		Charge:             s.Charge,
 		Amount:             amount,
@@ -98,12 +110,12 @@ func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {
 		return fmt.Errorf("allocate credits: %w", err)
 	}
 
-	s.Charge.Realizations.CreditRealizations = append(s.Charge.Realizations.CreditRealizations, result.Realizations...)
+	s.Charge.Realizations.CurrentRun.CreditRealizations = append(s.Charge.Realizations.CurrentRun.CreditRealizations, result.Realizations...)
 	return nil
 }
 
 func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, policy meta.PatchDeletePolicy) error {
-	if policy.CreditRefundPolicy == meta.CreditRefundPolicyCorrect {
+	if policy.CreditRefundPolicy == meta.CreditRefundPolicyCorrect && s.Charge.Realizations.CurrentRun != nil {
 		currencyCalculator, err := s.Charge.Intent.Currency.Calculator()
 		if err != nil {
 			return fmt.Errorf("get currency calculator: %w", err)

--- a/openmeter/billing/charges/flatfee/service/invoice.go
+++ b/openmeter/billing/charges/flatfee/service/invoice.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/samber/lo"
-
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
@@ -54,7 +52,11 @@ func (s *service) PostLineAssignedToInvoice(ctx context.Context, charge flatfee.
 
 func (s *service) PostInvoiceIssued(ctx context.Context, charge flatfee.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
-		if charge.Realizations.AccruedUsage != nil {
+		if charge.Realizations.CurrentRun == nil {
+			return fmt.Errorf("current run is required")
+		}
+
+		if charge.Realizations.CurrentRun.AccruedUsage != nil {
 			// Lifecycle violation: this should not happen as we should not be able to issue an invoice if the charge already has an accrued usage.
 			return fmt.Errorf("accrued invoice usage already exists for charge %s", charge.GetChargeID())
 		}
@@ -81,14 +83,17 @@ func (s *service) PostInvoiceIssued(ctx context.Context, charge flatfee.Charge, 
 		}
 
 		accruedUsage := invoicedusage.AccruedUsage{
-			LineID:            lo.ToPtr(lineWithHeader.Line.ID),
 			ServicePeriod:     lineWithHeader.Line.Period,
-			Mutable:           false,
 			Totals:            lineWithHeader.Line.Totals,
 			LedgerTransaction: &ledgerTransactionRef,
 		}
 
-		_, err = s.adapter.CreateInvoicedUsage(ctx, charge.GetChargeID(), accruedUsage)
+		_, err = s.adapter.CreateInvoicedUsage(ctx, flatfee.CreateInvoicedUsageInput{
+			ChargeID:      charge.GetChargeID(),
+			LineID:        lineWithHeader.Line.ID,
+			InvoiceID:     lineWithHeader.Invoice.ID,
+			InvoicedUsage: accruedUsage,
+		})
 		if err != nil {
 			return fmt.Errorf("creating standard invoice accrued usage: %w", err)
 		}

--- a/openmeter/billing/charges/flatfee/service/payment.go
+++ b/openmeter/billing/charges/flatfee/service/payment.go
@@ -14,10 +14,14 @@ import (
 
 func (s *service) PostInvoicePaymentAuthorized(ctx context.Context, charge flatfee.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
-		if charge.Realizations.Payment != nil {
+		if charge.Realizations.CurrentRun == nil {
+			return fmt.Errorf("current run is required")
+		}
+
+		if charge.Realizations.CurrentRun.Payment != nil {
 			return payment.ErrPaymentAlreadyAuthorized.
 				WithAttrs(charge.ErrorAttributes()).
-				WithAttrs(charge.Realizations.Payment.ErrorAttributes())
+				WithAttrs(charge.Realizations.CurrentRun.Payment.ErrorAttributes())
 		}
 
 		ledgerTransactionGroupReference, err := s.handler.OnPaymentAuthorized(ctx, charge)
@@ -47,7 +51,7 @@ func (s *service) PostInvoicePaymentAuthorized(ctx context.Context, charge flatf
 			return err
 		}
 
-		charge.Realizations.Payment = &paymentSettlement
+		charge.Realizations.CurrentRun.Payment = &paymentSettlement
 
 		return nil
 	})
@@ -55,11 +59,15 @@ func (s *service) PostInvoicePaymentAuthorized(ctx context.Context, charge flatf
 
 func (s *service) PostInvoicePaymentSettled(ctx context.Context, charge flatfee.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
-		if charge.Realizations.Payment == nil {
+		if charge.Realizations.CurrentRun == nil {
+			return fmt.Errorf("current run is required")
+		}
+
+		if charge.Realizations.CurrentRun.Payment == nil {
 			return payment.ErrCannotSettleNotAuthorizedPayment.WithAttrs(charge.ErrorAttributes())
 		}
 
-		paymentSettlement := *charge.Realizations.Payment
+		paymentSettlement := *charge.Realizations.CurrentRun.Payment
 
 		if paymentSettlement.LineID != lineWithHeader.Line.ID {
 			return fmt.Errorf("payment settlement line ID does not match the line ID: %s != %s", paymentSettlement.LineID, lineWithHeader.Line.ID)
@@ -88,7 +96,7 @@ func (s *service) PostInvoicePaymentSettled(ctx context.Context, charge flatfee.
 			return err
 		}
 
-		charge.Realizations.Payment = &paymentSettlement
+		charge.Realizations.CurrentRun.Payment = &paymentSettlement
 		charge.Status = flatfee.StatusFinal
 
 		_, err = s.adapter.UpdateCharge(ctx, charge.ChargeBase)

--- a/openmeter/billing/charges/flatfee/service/realizations/service.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/service.go
@@ -192,7 +192,11 @@ func (s *Service) CorrectAllCredits(ctx context.Context, in CorrectAllCreditReal
 		return CorrectAllCreditRealizationsResult{}, err
 	}
 
-	realizationIDs := lo.Map(in.Charge.Realizations.CreditRealizations, func(realization creditrealization.Realization, _ int) string {
+	if in.Charge.Realizations.CurrentRun == nil {
+		return CorrectAllCreditRealizationsResult{}, fmt.Errorf("current run is required")
+	}
+
+	realizationIDs := lo.Map(in.Charge.Realizations.CurrentRun.CreditRealizations, func(realization creditrealization.Realization, _ int) string {
 		return realization.ID
 	})
 	lineageSegmentsByRealization, err := s.lineage.LoadActiveSegmentsByRealizationID(ctx, in.Charge.Namespace, realizationIDs)
@@ -200,7 +204,7 @@ func (s *Service) CorrectAllCredits(ctx context.Context, in CorrectAllCreditReal
 		return CorrectAllCreditRealizationsResult{}, fmt.Errorf("load active lineage segments: %w", err)
 	}
 
-	corrections, err := in.Charge.Realizations.CreditRealizations.CorrectAll(in.CurrencyCalculator, func(req creditrealization.CorrectionRequest) (creditrealization.CreateCorrectionInputs, error) {
+	corrections, err := in.Charge.Realizations.CurrentRun.CreditRealizations.CorrectAll(in.CurrencyCalculator, func(req creditrealization.CorrectionRequest) (creditrealization.CreateCorrectionInputs, error) {
 		return s.handler.OnCreditsOnlyUsageAccruedCorrection(ctx, flatfee.CreditsOnlyUsageAccruedCorrectionInput{
 			Charge:                       in.Charge,
 			AllocateAt:                   in.AllocateAt,

--- a/openmeter/billing/charges/models/invoicedusage/mixin.go
+++ b/openmeter/billing/charges/models/invoicedusage/mixin.go
@@ -32,21 +32,8 @@ func (mixin) Mixin() []ent.Mixin {
 
 func (mixin) Fields() []ent.Field {
 	return []ent.Field{
-		field.String("line_id").
-			SchemaType(map[string]string{
-				dialect.Postgres: "char(26)",
-			}).
-			Optional().
-			NotEmpty().
-			Nillable(),
-
 		field.Time("service_period_from"),
 		field.Time("service_period_to"),
-
-		// Mutable flag indicates if the accrued usage can be reallocated as credits or if this needs to happen via
-		// the invoicing flow.
-		field.Bool("mutable"),
-
 		field.String("ledger_transaction_group_id").
 			SchemaType(map[string]string{
 				dialect.Postgres: "char(26)",
@@ -65,8 +52,6 @@ type Creator[T any] interface {
 	totals.Setter[T]
 	SetServicePeriodFrom(servicePeriodFrom time.Time) T
 	SetServicePeriodTo(servicePeriodTo time.Time) T
-	SetMutable(mutable bool) T
-	SetNillableLineID(lineID *string) T
 	SetNillableLedgerTransactionGroupID(ledgerTransactionGroupID *string) T
 }
 
@@ -78,10 +63,8 @@ func Create[T Creator[T]](creator T, ns string, invoicedUsage AccruedUsage) T {
 
 	creator = creator.SetAnnotations(invoicedUsage.Annotations).
 		SetNamespace(ns).
-		SetNillableLineID(invoicedUsage.LineID).
 		SetServicePeriodFrom(invoicedUsage.ServicePeriod.From.In(time.UTC)).
 		SetServicePeriodTo(invoicedUsage.ServicePeriod.To.In(time.UTC)).
-		SetMutable(invoicedUsage.Mutable).
 		SetNillableLedgerTransactionGroupID(trnsGroupID)
 
 	creator = totals.Set(creator, invoicedUsage.Totals)
@@ -95,10 +78,8 @@ type Getter interface {
 	entutils.IDMixinGetter
 	entutils.AnnotationsMixinGetter
 	totals.TotalsGetter
-	GetLineID() *string
 	GetServicePeriodFrom() time.Time
 	GetServicePeriodTo() time.Time
-	GetMutable() bool
 	GetLedgerTransactionGroupID() *string
 }
 
@@ -117,12 +98,10 @@ func MapAccruedUsageFromDB(dbEntity Getter) AccruedUsage {
 		},
 		ManagedModel: entutils.MapTimeMixinFromDB(dbEntity),
 		Annotations:  dbEntity.GetAnnotations(),
-		LineID:       dbEntity.GetLineID(),
 		ServicePeriod: timeutil.ClosedPeriod{
 			From: dbEntity.GetServicePeriodFrom().In(time.UTC),
 			To:   dbEntity.GetServicePeriodTo().In(time.UTC),
 		},
-		Mutable:           dbEntity.GetMutable(),
 		LedgerTransaction: ledgerTransaction,
 		Totals:            totals.FromDB(dbEntity),
 	}

--- a/openmeter/billing/charges/models/invoicedusage/stdinvoice.go
+++ b/openmeter/billing/charges/models/invoicedusage/stdinvoice.go
@@ -14,11 +14,8 @@ type AccruedUsage struct {
 	models.NamespacedID
 	models.ManagedModel
 
-	Annotations models.Annotations `json:"annotations"`
-	// TODO: Remove LineID from accrued usage once flat-fee stores line assignment on its own realization state too.
-	LineID            *string                           `json:"lineID"`
+	Annotations       models.Annotations                `json:"annotations"`
 	ServicePeriod     timeutil.ClosedPeriod             `json:"servicePeriod"`
-	Mutable           bool                              `json:"mutable"`
 	LedgerTransaction *ledgertransaction.GroupReference `json:"ledgerTransaction"`
 
 	Totals totals.Totals `json:"totals"`
@@ -27,24 +24,12 @@ type AccruedUsage struct {
 func (r AccruedUsage) Validate() error {
 	var errs []error
 
-	if !r.Mutable {
-		if r.LineID == nil {
-			errs = append(errs, fmt.Errorf("line ID is required when mutable is false"))
-		}
-	}
-
 	if err := r.ServicePeriod.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("service period: %w", err))
 	}
 
 	if err := r.Totals.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("totals: %w", err))
-	}
-
-	if r.LineID != nil {
-		if *r.LineID == "" {
-			errs = append(errs, fmt.Errorf("line ID is required"))
-		}
 	}
 
 	if r.LedgerTransaction != nil {

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -168,8 +168,9 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 
 		// Validate the credit realizations
 		// The charge should have $30 realized as credits
-		s.Len(updatedFlatFeeCharge.Realizations.CreditRealizations, 1)
-		creditRealization := updatedFlatFeeCharge.Realizations.CreditRealizations[0]
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.Len(updatedFlatFeeCharge.Realizations.CurrentRun.CreditRealizations, 1)
+		creditRealization := updatedFlatFeeCharge.Realizations.CurrentRun.CreditRealizations[0]
 		s.Equal(testTrnsGroupID, creditRealization.LedgerTransaction.TransactionGroupID)
 		s.Equal(servicePeriod.From, creditRealization.ServicePeriod.From)
 		s.Equal(servicePeriod.To, creditRealization.ServicePeriod.To)
@@ -213,12 +214,13 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 		s.Equal(creditRealization.ID, creditRealizationDetail.CreditRealizationID)
 
 		flatFeeWithDetailedLines := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
-		s.True(flatFeeWithDetailedLines.Realizations.DetailedLines.IsPresent())
-		s.Len(flatFeeWithDetailedLines.Realizations.DetailedLines.OrEmpty(), 1)
-		s.Equal(detailedLine.ChildUniqueReferenceID, flatFeeWithDetailedLines.Realizations.DetailedLines.OrEmpty()[0].ChildUniqueReferenceID)
-		s.Equal(detailedLine.Totals.Total.String(), flatFeeWithDetailedLines.Realizations.DetailedLines.OrEmpty()[0].Totals.Total.String())
-		s.Equal(detailedLine.Quantity.String(), flatFeeWithDetailedLines.Realizations.DetailedLines.OrEmpty()[0].Quantity.String())
-		s.Len(flatFeeWithDetailedLines.Realizations.DetailedLines.OrEmpty()[0].CreditsApplied, 1)
+		s.Require().NotNil(flatFeeWithDetailedLines.Realizations.CurrentRun)
+		s.True(flatFeeWithDetailedLines.Realizations.CurrentRun.DetailedLines.IsPresent())
+		s.Len(flatFeeWithDetailedLines.Realizations.CurrentRun.DetailedLines.OrEmpty(), 1)
+		s.Equal(detailedLine.ChildUniqueReferenceID, flatFeeWithDetailedLines.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].ChildUniqueReferenceID)
+		s.Equal(detailedLine.Totals.Total.String(), flatFeeWithDetailedLines.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].Totals.Total.String())
+		s.Equal(detailedLine.Quantity.String(), flatFeeWithDetailedLines.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].Quantity.String())
+		s.Len(flatFeeWithDetailedLines.Realizations.CurrentRun.DetailedLines.OrEmpty()[0].CreditsApplied, 1)
 
 		stdInvoiceID = invoice.GetInvoiceID()
 		s.NotEmpty(stdInvoiceID)
@@ -231,8 +233,9 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 		// Use non-fatal assertions inside handler callbacks so failures are reported
 		// on the callback's testing context without aborting the parent test flow.
 		s.FlatFeeTestHandler.onPaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, charge flatfee.Charge) {
-			assert.NotNil(t, charge.Realizations.AccruedUsage)
-			assert.Nil(t, charge.Realizations.Payment)
+			assert.NotNil(t, charge.Realizations.CurrentRun)
+			assert.NotNil(t, charge.Realizations.CurrentRun.AccruedUsage)
+			assert.Nil(t, charge.Realizations.CurrentRun.Payment)
 			assert.Equal(t, flatfee.StatusActive, charge.Status)
 		})
 
@@ -251,13 +254,13 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 		s.NoError(err)
 
 		// Invoice usage accrued callback should have been invoked
-		accruedUsage := updatedFlatFeeCharge.Realizations.AccruedUsage
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		accruedUsage := updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage
 		s.NotNil(accruedUsage)
 		s.Equal(invoiceUsageAccruedCallback.id, accruedUsage.LedgerTransaction.TransactionGroupID, "ledger transaction gets recorded")
 		s.Equal(servicePeriod, accruedUsage.ServicePeriod, "service period should be the same as the input")
-		s.False(accruedUsage.Mutable, "accrued usage should not be mutable")
-		s.NotNil(accruedUsage.LineID, "line ID should be set")
-		s.Equal(stdLineID.ID, *accruedUsage.LineID, "line ID should be the same as the standard line")
+		s.NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.LineID, "run line ID should be set")
+		s.Equal(stdLineID.ID, *updatedFlatFeeCharge.Realizations.CurrentRun.LineID, "run line ID should be the same as the standard line")
 		s.RequireTotals(billingtest.ExpectedTotals{
 			Amount:       100,
 			Total:        70,
@@ -265,7 +268,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 		}, accruedUsage.Totals)
 
 		// Payment authorization should not be persisted until the payment flow advances past pending.
-		s.Nil(updatedFlatFeeCharge.Realizations.Payment)
+		s.Nil(updatedFlatFeeCharge.Realizations.CurrentRun.Payment)
 		s.Equal(flatfee.StatusActive, updatedFlatFeeCharge.Status)
 	})
 
@@ -276,8 +279,9 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 		// Use non-fatal assertions inside handler callbacks so failures are reported
 		// on the callback's testing context without aborting the parent test flow.
 		s.FlatFeeTestHandler.onPaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, charge flatfee.Charge) {
-			assert.Nil(t, charge.Realizations.Payment)
-			assert.NotNil(t, charge.Realizations.AccruedUsage)
+			assert.NotNil(t, charge.Realizations.CurrentRun)
+			assert.Nil(t, charge.Realizations.CurrentRun.Payment)
+			assert.NotNil(t, charge.Realizations.CurrentRun.AccruedUsage)
 			assert.Equal(t, flatfee.StatusActive, charge.Status)
 		})
 
@@ -285,11 +289,12 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 		// Use non-fatal assertions inside handler callbacks so failures are reported
 		// on the callback's testing context without aborting the parent test flow.
 		s.FlatFeeTestHandler.onPaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, charge flatfee.Charge) {
-			assert.NotNil(t, charge.Realizations.Payment)
-			assert.NotNil(t, charge.Realizations.Payment.Authorized)
-			assert.Nil(t, charge.Realizations.Payment.Settled)
-			assert.Equal(t, authorizedCallback.id, charge.Realizations.Payment.Authorized.TransactionGroupID)
-			assert.Equal(t, payment.StatusAuthorized, charge.Realizations.Payment.Status)
+			assert.NotNil(t, charge.Realizations.CurrentRun)
+			assert.NotNil(t, charge.Realizations.CurrentRun.Payment)
+			assert.NotNil(t, charge.Realizations.CurrentRun.Payment.Authorized)
+			assert.Nil(t, charge.Realizations.CurrentRun.Payment.Settled)
+			assert.Equal(t, authorizedCallback.id, charge.Realizations.CurrentRun.Payment.Authorized.TransactionGroupID)
+			assert.Equal(t, payment.StatusAuthorized, charge.Realizations.CurrentRun.Payment.Status)
 			assert.Equal(t, flatfee.StatusActive, charge.Status)
 		})
 
@@ -306,8 +311,9 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 		charge := s.mustGetChargeByID(flatFeeChargeID)
 		updatedFlatFeeCharge, err := charge.AsFlatFeeCharge()
 		s.NoError(err)
-		s.Equal(authorizedCallback.id, updatedFlatFeeCharge.Realizations.Payment.Authorized.TransactionGroupID)
-		s.Equal(settledCallback.id, updatedFlatFeeCharge.Realizations.Payment.Settled.TransactionGroupID)
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.Equal(authorizedCallback.id, updatedFlatFeeCharge.Realizations.CurrentRun.Payment.Authorized.TransactionGroupID)
+		s.Equal(settledCallback.id, updatedFlatFeeCharge.Realizations.CurrentRun.Payment.Settled.TransactionGroupID)
 		s.Equal(flatfee.StatusFinal, updatedFlatFeeCharge.Status)
 	})
 }
@@ -397,12 +403,14 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 		charge := s.mustGetChargeByID(flatFeeChargeID)
 		updatedFlatFeeCharge, err := charge.AsFlatFeeCharge()
 		s.NoError(err)
-		s.Len(updatedFlatFeeCharge.Realizations.CreditRealizations, 1)
-		s.Nil(updatedFlatFeeCharge.Realizations.AccruedUsage)
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.Len(updatedFlatFeeCharge.Realizations.CurrentRun.CreditRealizations, 1)
+		s.Nil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage)
 
 		flatFeeWithDetailedLines := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
-		s.True(flatFeeWithDetailedLines.Realizations.DetailedLines.IsPresent())
-		s.Len(flatFeeWithDetailedLines.Realizations.DetailedLines.OrEmpty(), len(invoice.Lines.OrEmpty()[0].DetailedLines))
+		s.Require().NotNil(flatFeeWithDetailedLines.Realizations.CurrentRun)
+		s.True(flatFeeWithDetailedLines.Realizations.CurrentRun.DetailedLines.IsPresent())
+		s.Len(flatFeeWithDetailedLines.Realizations.CurrentRun.DetailedLines.OrEmpty(), len(invoice.Lines.OrEmpty()[0].DetailedLines))
 	})
 
 	s.Run("post invoice issued without invoice usage accrual", func() {
@@ -423,9 +431,10 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
 
 		updatedFlatFeeCharge := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
-		s.Nil(updatedFlatFeeCharge.Realizations.AccruedUsage)
-		s.True(updatedFlatFeeCharge.Realizations.DetailedLines.IsPresent())
-		s.Len(updatedFlatFeeCharge.Realizations.DetailedLines.OrEmpty(), len(invoice.Lines.OrEmpty()[0].DetailedLines))
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.Nil(updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage)
+		s.True(updatedFlatFeeCharge.Realizations.CurrentRun.DetailedLines.IsPresent())
+		s.Len(updatedFlatFeeCharge.Realizations.CurrentRun.DetailedLines.OrEmpty(), len(invoice.Lines.OrEmpty()[0].DetailedLines))
 	})
 }
 
@@ -1246,8 +1255,6 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() 
 		s.NotNil(finalRun.LineID)
 		s.Equal(stdLineID.ID, *finalRun.LineID)
 		s.NotNil(finalRun.InvoiceUsage)
-		s.NotNil(finalRun.InvoiceUsage.LineID)
-		s.Equal(stdLineID.ID, *finalRun.InvoiceUsage.LineID)
 		s.Equal(invoice.Lines.OrEmpty()[0].Period, finalRun.InvoiceUsage.ServicePeriod)
 		s.RequireTotals(billingtest.ExpectedTotals{
 			Amount:       12.5,
@@ -1502,8 +1509,6 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCredite
 		s.Equal(stdLineID.ID, *finalRun.LineID)
 		s.True(finalRun.NoFiatTransactionRequired)
 		s.NotNil(finalRun.InvoiceUsage)
-		s.NotNil(finalRun.InvoiceUsage.LineID)
-		s.Equal(stdLineID.ID, *finalRun.InvoiceUsage.LineID)
 		s.Nil(finalRun.InvoiceUsage.LedgerTransaction)
 		s.RequireTotals(billingtest.ExpectedTotals{
 			Amount:       10,
@@ -1917,7 +1922,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 		flatFeeChargeID = flatFeeCharge.GetChargeID()
 
 		s.Equal(flatfee.StatusCreated, fetchedFF.Status)
-		s.Empty(fetchedFF.Realizations.CreditRealizations)
+		s.Nil(fetchedFF.Realizations.CurrentRun)
 		s.Nil(fetchedFF.State.AdvanceAfter)
 
 		// Advancing is a noop (clock is before InvoiceAt).
@@ -1980,8 +1985,9 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 		s.Equal(float64(100), callbacks[0].Input.AmountToAllocate.InexactFloat64())
 
 		// Credit realizations were persisted.
-		s.Len(fetchedFF.Realizations.CreditRealizations, 1)
-		s.Equal(float64(100), fetchedFF.Realizations.CreditRealizations[0].Amount.InexactFloat64())
+		s.Require().NotNil(fetchedFF.Realizations.CurrentRun)
+		s.Len(fetchedFF.Realizations.CurrentRun.CreditRealizations, 1)
+		s.Equal(float64(100), fetchedFF.Realizations.CurrentRun.CreditRealizations[0].Amount.InexactFloat64())
 	})
 
 	s.Run("#3 final charge advance is noop", func() {
@@ -2065,8 +2071,9 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyCreateImmediatelyFinal
 	s.NoError(err)
 	s.Equal(flatfee.StatusFinal, returnedCharge.Status)
 	s.Nil(returnedCharge.State.AdvanceAfter)
-	s.Len(returnedCharge.Realizations.CreditRealizations, 1)
-	s.Equal(float64(50), returnedCharge.Realizations.CreditRealizations[0].Amount.InexactFloat64())
+	s.Require().NotNil(returnedCharge.Realizations.CurrentRun)
+	s.Len(returnedCharge.Realizations.CurrentRun.CreditRealizations, 1)
+	s.Equal(float64(50), returnedCharge.Realizations.CurrentRun.CreditRealizations[0].Amount.InexactFloat64())
 
 	// And the DB state matches.
 	dbCharge := s.mustGetChargeByID(returnedCharge.GetChargeID())
@@ -2074,8 +2081,9 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyCreateImmediatelyFinal
 	s.NoError(err)
 	s.Equal(flatfee.StatusFinal, dbFF.Status)
 	s.Nil(dbFF.State.AdvanceAfter)
-	s.Len(dbFF.Realizations.CreditRealizations, 1)
-	s.Equal(float64(50), dbFF.Realizations.CreditRealizations[0].Amount.InexactFloat64())
+	s.Require().NotNil(dbFF.Realizations.CurrentRun)
+	s.Len(dbFF.Realizations.CurrentRun.CreditRealizations, 1)
+	s.Equal(float64(50), dbFF.Realizations.CurrentRun.CreditRealizations[0].Amount.InexactFloat64())
 }
 
 func (s *InvoicableChargesTestSuite) mustAdvanceFlatFeeCharges(ctx context.Context, customerID customer.CustomerID) charges.Charges {

--- a/openmeter/billing/charges/service/lineage_test.go
+++ b/openmeter/billing/charges/service/lineage_test.go
@@ -122,13 +122,14 @@ func (s *CreditRealizationLineageTestSuite) TestFlatFeeCreditOnlyAllocationCreat
 
 	charge, err := s.mustGetChargeByID(chargeID).AsFlatFeeCharge()
 	s.NoError(err)
-	s.Len(charge.Realizations.CreditRealizations, 2)
+	s.Require().NotNil(charge.Realizations.CurrentRun)
+	s.Len(charge.Realizations.CurrentRun.CreditRealizations, 2)
 
-	lineages := s.mustListLineages(ns, realizationIDs(charge.Realizations.CreditRealizations))
+	lineages := s.mustListLineages(ns, realizationIDs(charge.Realizations.CurrentRun.CreditRealizations))
 	s.Require().Len(lineages, 2)
 
-	s.assertInitialLineage(lineages[charge.Realizations.CreditRealizations[0].ID], chargeID.ID, charge.Realizations.CreditRealizations[0].Amount, creditrealization.LineageOriginKindRealCredit, creditrealization.LineageSegmentStateRealCredit)
-	s.assertInitialLineage(lineages[charge.Realizations.CreditRealizations[1].ID], chargeID.ID, charge.Realizations.CreditRealizations[1].Amount, creditrealization.LineageOriginKindAdvance, creditrealization.LineageSegmentStateAdvanceUncovered)
+	s.assertInitialLineage(lineages[charge.Realizations.CurrentRun.CreditRealizations[0].ID], chargeID.ID, charge.Realizations.CurrentRun.CreditRealizations[0].Amount, creditrealization.LineageOriginKindRealCredit, creditrealization.LineageSegmentStateRealCredit)
+	s.assertInitialLineage(lineages[charge.Realizations.CurrentRun.CreditRealizations[1].ID], chargeID.ID, charge.Realizations.CurrentRun.CreditRealizations[1].Amount, creditrealization.LineageOriginKindAdvance, creditrealization.LineageSegmentStateAdvanceUncovered)
 }
 
 func (s *CreditRealizationLineageTestSuite) TestUsageBasedCreditOnlyAllocationCreatesInitialLineage() {

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -249,7 +249,6 @@ func TestShrinkChargeMovesToFinalWhenKeptRunCoversNewEndAndSettlementIsComplete(
 			From: servicePeriod.From,
 			To:   newServicePeriodTo,
 		},
-		Mutable: true,
 	}
 
 	machine := newCreditThenInvoiceStateMachineWithChargeForTest(t, usagebased.Charge{

--- a/openmeter/billing/charges/usagebased/service/run/invoice.go
+++ b/openmeter/billing/charges/usagebased/service/run/invoice.go
@@ -63,9 +63,7 @@ func (s *Service) BookAccruedInvoiceUsage(ctx context.Context, in BookAccruedInv
 
 	if in.Run.NoFiatTransactionRequired {
 		accruedUsage, err := s.adapter.CreateRunInvoicedUsage(ctx, in.Run.ID, invoicedusage.AccruedUsage{
-			LineID:        in.Run.LineID,
 			ServicePeriod: in.Line.Period,
-			Mutable:       false,
 			Totals:        in.Line.Totals,
 		})
 		if err != nil {
@@ -101,9 +99,7 @@ func (s *Service) BookAccruedInvoiceUsage(ctx context.Context, in BookAccruedInv
 	}
 
 	accruedUsage, err := s.adapter.CreateRunInvoicedUsage(ctx, in.Run.ID, invoicedusage.AccruedUsage{
-		LineID:            in.Run.LineID,
 		ServicePeriod:     in.Line.Period,
-		Mutable:           false,
 		Totals:            in.Line.Totals,
 		LedgerTransaction: &ledgerTransactionRef,
 	})

--- a/openmeter/billing/charges/usagebased/service/run/payment_test.go
+++ b/openmeter/billing/charges/usagebased/service/run/payment_test.go
@@ -139,9 +139,7 @@ func newBookPaymentAuthorizedInput() BookInvoicedPaymentAuthorizedInput {
 func newSettlePaymentInput() SettleInvoicedPaymentInput {
 	authInput := newBookPaymentAuthorizedInput()
 	authInput.Run.InvoiceUsage = &invoicedusage.AccruedUsage{
-		LineID:        &authInput.Line.ID,
 		ServicePeriod: authInput.Line.Period,
-		Mutable:       false,
 		Totals:        authInput.Line.Totals,
 	}
 	authInput.Run.Payment = &payment.Invoiced{

--- a/openmeter/ent/db/billinginvoice.go
+++ b/openmeter/ent/db/billinginvoice.go
@@ -160,6 +160,8 @@ type BillingInvoiceEdges struct {
 	BillingInvoiceDetailedLines []*BillingStandardInvoiceDetailedLine `json:"billing_invoice_detailed_lines,omitempty"`
 	// BillingInvoiceValidationIssues holds the value of the billing_invoice_validation_issues edge.
 	BillingInvoiceValidationIssues []*BillingInvoiceValidationIssue `json:"billing_invoice_validation_issues,omitempty"`
+	// ChargeFlatFeeRuns holds the value of the charge_flat_fee_runs edge.
+	ChargeFlatFeeRuns []*ChargeFlatFeeRun `json:"charge_flat_fee_runs,omitempty"`
 	// ChargeUsageBasedRuns holds the value of the charge_usage_based_runs edge.
 	ChargeUsageBasedRuns []*ChargeUsageBasedRuns `json:"charge_usage_based_runs,omitempty"`
 	// BillingInvoiceCustomer holds the value of the billing_invoice_customer edge.
@@ -172,7 +174,7 @@ type BillingInvoiceEdges struct {
 	PaymentApp *App `json:"payment_app,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [10]bool
+	loadedTypes [11]bool
 }
 
 // SourceBillingProfileOrErr returns the SourceBillingProfile value or an error if the edge
@@ -224,10 +226,19 @@ func (e BillingInvoiceEdges) BillingInvoiceValidationIssuesOrErr() ([]*BillingIn
 	return nil, &NotLoadedError{edge: "billing_invoice_validation_issues"}
 }
 
+// ChargeFlatFeeRunsOrErr returns the ChargeFlatFeeRuns value or an error if the edge
+// was not loaded in eager-loading.
+func (e BillingInvoiceEdges) ChargeFlatFeeRunsOrErr() ([]*ChargeFlatFeeRun, error) {
+	if e.loadedTypes[5] {
+		return e.ChargeFlatFeeRuns, nil
+	}
+	return nil, &NotLoadedError{edge: "charge_flat_fee_runs"}
+}
+
 // ChargeUsageBasedRunsOrErr returns the ChargeUsageBasedRuns value or an error if the edge
 // was not loaded in eager-loading.
 func (e BillingInvoiceEdges) ChargeUsageBasedRunsOrErr() ([]*ChargeUsageBasedRuns, error) {
-	if e.loadedTypes[5] {
+	if e.loadedTypes[6] {
 		return e.ChargeUsageBasedRuns, nil
 	}
 	return nil, &NotLoadedError{edge: "charge_usage_based_runs"}
@@ -238,7 +249,7 @@ func (e BillingInvoiceEdges) ChargeUsageBasedRunsOrErr() ([]*ChargeUsageBasedRun
 func (e BillingInvoiceEdges) BillingInvoiceCustomerOrErr() (*Customer, error) {
 	if e.BillingInvoiceCustomer != nil {
 		return e.BillingInvoiceCustomer, nil
-	} else if e.loadedTypes[6] {
+	} else if e.loadedTypes[7] {
 		return nil, &NotFoundError{label: customer.Label}
 	}
 	return nil, &NotLoadedError{edge: "billing_invoice_customer"}
@@ -249,7 +260,7 @@ func (e BillingInvoiceEdges) BillingInvoiceCustomerOrErr() (*Customer, error) {
 func (e BillingInvoiceEdges) TaxAppOrErr() (*App, error) {
 	if e.TaxApp != nil {
 		return e.TaxApp, nil
-	} else if e.loadedTypes[7] {
+	} else if e.loadedTypes[8] {
 		return nil, &NotFoundError{label: dbapp.Label}
 	}
 	return nil, &NotLoadedError{edge: "tax_app"}
@@ -260,7 +271,7 @@ func (e BillingInvoiceEdges) TaxAppOrErr() (*App, error) {
 func (e BillingInvoiceEdges) InvoicingAppOrErr() (*App, error) {
 	if e.InvoicingApp != nil {
 		return e.InvoicingApp, nil
-	} else if e.loadedTypes[8] {
+	} else if e.loadedTypes[9] {
 		return nil, &NotFoundError{label: dbapp.Label}
 	}
 	return nil, &NotLoadedError{edge: "invoicing_app"}
@@ -271,7 +282,7 @@ func (e BillingInvoiceEdges) InvoicingAppOrErr() (*App, error) {
 func (e BillingInvoiceEdges) PaymentAppOrErr() (*App, error) {
 	if e.PaymentApp != nil {
 		return e.PaymentApp, nil
-	} else if e.loadedTypes[9] {
+	} else if e.loadedTypes[10] {
 		return nil, &NotFoundError{label: dbapp.Label}
 	}
 	return nil, &NotLoadedError{edge: "payment_app"}
@@ -734,6 +745,11 @@ func (_m *BillingInvoice) QueryBillingInvoiceDetailedLines() *BillingStandardInv
 // QueryBillingInvoiceValidationIssues queries the "billing_invoice_validation_issues" edge of the BillingInvoice entity.
 func (_m *BillingInvoice) QueryBillingInvoiceValidationIssues() *BillingInvoiceValidationIssueQuery {
 	return NewBillingInvoiceClient(_m.config).QueryBillingInvoiceValidationIssues(_m)
+}
+
+// QueryChargeFlatFeeRuns queries the "charge_flat_fee_runs" edge of the BillingInvoice entity.
+func (_m *BillingInvoice) QueryChargeFlatFeeRuns() *ChargeFlatFeeRunQuery {
+	return NewBillingInvoiceClient(_m.config).QueryChargeFlatFeeRuns(_m)
 }
 
 // QueryChargeUsageBasedRuns queries the "charge_usage_based_runs" edge of the BillingInvoice entity.

--- a/openmeter/ent/db/billinginvoice/billinginvoice.go
+++ b/openmeter/ent/db/billinginvoice/billinginvoice.go
@@ -142,6 +142,8 @@ const (
 	EdgeBillingInvoiceDetailedLines = "billing_invoice_detailed_lines"
 	// EdgeBillingInvoiceValidationIssues holds the string denoting the billing_invoice_validation_issues edge name in mutations.
 	EdgeBillingInvoiceValidationIssues = "billing_invoice_validation_issues"
+	// EdgeChargeFlatFeeRuns holds the string denoting the charge_flat_fee_runs edge name in mutations.
+	EdgeChargeFlatFeeRuns = "charge_flat_fee_runs"
 	// EdgeChargeUsageBasedRuns holds the string denoting the charge_usage_based_runs edge name in mutations.
 	EdgeChargeUsageBasedRuns = "charge_usage_based_runs"
 	// EdgeBillingInvoiceCustomer holds the string denoting the billing_invoice_customer edge name in mutations.
@@ -189,6 +191,13 @@ const (
 	BillingInvoiceValidationIssuesInverseTable = "billing_invoice_validation_issues"
 	// BillingInvoiceValidationIssuesColumn is the table column denoting the billing_invoice_validation_issues relation/edge.
 	BillingInvoiceValidationIssuesColumn = "invoice_id"
+	// ChargeFlatFeeRunsTable is the table that holds the charge_flat_fee_runs relation/edge.
+	ChargeFlatFeeRunsTable = "charge_flat_fee_runs"
+	// ChargeFlatFeeRunsInverseTable is the table name for the ChargeFlatFeeRun entity.
+	// It exists in this package in order to avoid circular dependency with the "chargeflatfeerun" package.
+	ChargeFlatFeeRunsInverseTable = "charge_flat_fee_runs"
+	// ChargeFlatFeeRunsColumn is the table column denoting the charge_flat_fee_runs relation/edge.
+	ChargeFlatFeeRunsColumn = "invoice_id"
 	// ChargeUsageBasedRunsTable is the table that holds the charge_usage_based_runs relation/edge.
 	ChargeUsageBasedRunsTable = "charge_usage_based_runs"
 	// ChargeUsageBasedRunsInverseTable is the table name for the ChargeUsageBasedRuns entity.
@@ -687,6 +696,20 @@ func ByBillingInvoiceValidationIssues(term sql.OrderTerm, terms ...sql.OrderTerm
 	}
 }
 
+// ByChargeFlatFeeRunsCount orders the results by charge_flat_fee_runs count.
+func ByChargeFlatFeeRunsCount(opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborsCount(s, newChargeFlatFeeRunsStep(), opts...)
+	}
+}
+
+// ByChargeFlatFeeRuns orders the results by charge_flat_fee_runs terms.
+func ByChargeFlatFeeRuns(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newChargeFlatFeeRunsStep(), append([]sql.OrderTerm{term}, terms...)...)
+	}
+}
+
 // ByChargeUsageBasedRunsCount orders the results by charge_usage_based_runs count.
 func ByChargeUsageBasedRunsCount(opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
@@ -761,6 +784,13 @@ func newBillingInvoiceValidationIssuesStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(BillingInvoiceValidationIssuesInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.O2M, false, BillingInvoiceValidationIssuesTable, BillingInvoiceValidationIssuesColumn),
+	)
+}
+func newChargeFlatFeeRunsStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(ChargeFlatFeeRunsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2M, false, ChargeFlatFeeRunsTable, ChargeFlatFeeRunsColumn),
 	)
 }
 func newChargeUsageBasedRunsStep() *sqlgraph.Step {

--- a/openmeter/ent/db/billinginvoice/where.go
+++ b/openmeter/ent/db/billinginvoice/where.go
@@ -3804,6 +3804,29 @@ func HasBillingInvoiceValidationIssuesWith(preds ...predicate.BillingInvoiceVali
 	})
 }
 
+// HasChargeFlatFeeRuns applies the HasEdge predicate on the "charge_flat_fee_runs" edge.
+func HasChargeFlatFeeRuns() predicate.BillingInvoice {
+	return predicate.BillingInvoice(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, ChargeFlatFeeRunsTable, ChargeFlatFeeRunsColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasChargeFlatFeeRunsWith applies the HasEdge predicate on the "charge_flat_fee_runs" edge with a given conditions (other predicates).
+func HasChargeFlatFeeRunsWith(preds ...predicate.ChargeFlatFeeRun) predicate.BillingInvoice {
+	return predicate.BillingInvoice(func(s *sql.Selector) {
+		step := newChargeFlatFeeRunsStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
 // HasChargeUsageBasedRuns applies the HasEdge predicate on the "charge_usage_based_runs" edge.
 func HasChargeUsageBasedRuns() predicate.BillingInvoice {
 	return predicate.BillingInvoice(func(s *sql.Selector) {

--- a/openmeter/ent/db/billinginvoice_create.go
+++ b/openmeter/ent/db/billinginvoice_create.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingprofile"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingstandardinvoicedetailedline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingworkflowconfig"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/customer"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -738,6 +739,21 @@ func (_c *BillingInvoiceCreate) AddBillingInvoiceValidationIssues(v ...*BillingI
 	return _c.AddBillingInvoiceValidationIssueIDs(ids...)
 }
 
+// AddChargeFlatFeeRunIDs adds the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity by IDs.
+func (_c *BillingInvoiceCreate) AddChargeFlatFeeRunIDs(ids ...string) *BillingInvoiceCreate {
+	_c.mutation.AddChargeFlatFeeRunIDs(ids...)
+	return _c
+}
+
+// AddChargeFlatFeeRuns adds the "charge_flat_fee_runs" edges to the ChargeFlatFeeRun entity.
+func (_c *BillingInvoiceCreate) AddChargeFlatFeeRuns(v ...*ChargeFlatFeeRun) *BillingInvoiceCreate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _c.AddChargeFlatFeeRunIDs(ids...)
+}
+
 // AddChargeUsageBasedRunIDs adds the "charge_usage_based_runs" edge to the ChargeUsageBasedRuns entity by IDs.
 func (_c *BillingInvoiceCreate) AddChargeUsageBasedRunIDs(ids ...string) *BillingInvoiceCreate {
 	_c.mutation.AddChargeUsageBasedRunIDs(ids...)
@@ -1298,6 +1314,22 @@ func (_c *BillingInvoiceCreate) createSpec() (*BillingInvoice, *sqlgraph.CreateS
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(billinginvoicevalidationissue.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.ChargeFlatFeeRunsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeFlatFeeRunsTable,
+			Columns: []string{billinginvoice.ChargeFlatFeeRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeerun.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/openmeter/ent/db/billinginvoice_query.go
+++ b/openmeter/ent/db/billinginvoice_query.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingprofile"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingstandardinvoicedetailedline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingworkflowconfig"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/customer"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
@@ -37,6 +38,7 @@ type BillingInvoiceQuery struct {
 	withBillingInvoiceLines            *BillingInvoiceLineQuery
 	withBillingInvoiceDetailedLines    *BillingStandardInvoiceDetailedLineQuery
 	withBillingInvoiceValidationIssues *BillingInvoiceValidationIssueQuery
+	withChargeFlatFeeRuns              *ChargeFlatFeeRunQuery
 	withChargeUsageBasedRuns           *ChargeUsageBasedRunsQuery
 	withBillingInvoiceCustomer         *CustomerQuery
 	withTaxApp                         *AppQuery
@@ -182,6 +184,28 @@ func (_q *BillingInvoiceQuery) QueryBillingInvoiceValidationIssues() *BillingInv
 			sqlgraph.From(billinginvoice.Table, billinginvoice.FieldID, selector),
 			sqlgraph.To(billinginvoicevalidationissue.Table, billinginvoicevalidationissue.FieldID),
 			sqlgraph.Edge(sqlgraph.O2M, false, billinginvoice.BillingInvoiceValidationIssuesTable, billinginvoice.BillingInvoiceValidationIssuesColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryChargeFlatFeeRuns chains the current query on the "charge_flat_fee_runs" edge.
+func (_q *BillingInvoiceQuery) QueryChargeFlatFeeRuns() *ChargeFlatFeeRunQuery {
+	query := (&ChargeFlatFeeRunClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(billinginvoice.Table, billinginvoice.FieldID, selector),
+			sqlgraph.To(chargeflatfeerun.Table, chargeflatfeerun.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, billinginvoice.ChargeFlatFeeRunsTable, billinginvoice.ChargeFlatFeeRunsColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -496,6 +520,7 @@ func (_q *BillingInvoiceQuery) Clone() *BillingInvoiceQuery {
 		withBillingInvoiceLines:            _q.withBillingInvoiceLines.Clone(),
 		withBillingInvoiceDetailedLines:    _q.withBillingInvoiceDetailedLines.Clone(),
 		withBillingInvoiceValidationIssues: _q.withBillingInvoiceValidationIssues.Clone(),
+		withChargeFlatFeeRuns:              _q.withChargeFlatFeeRuns.Clone(),
 		withChargeUsageBasedRuns:           _q.withChargeUsageBasedRuns.Clone(),
 		withBillingInvoiceCustomer:         _q.withBillingInvoiceCustomer.Clone(),
 		withTaxApp:                         _q.withTaxApp.Clone(),
@@ -559,6 +584,17 @@ func (_q *BillingInvoiceQuery) WithBillingInvoiceValidationIssues(opts ...func(*
 		opt(query)
 	}
 	_q.withBillingInvoiceValidationIssues = query
+	return _q
+}
+
+// WithChargeFlatFeeRuns tells the query-builder to eager-load the nodes that are connected to
+// the "charge_flat_fee_runs" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *BillingInvoiceQuery) WithChargeFlatFeeRuns(opts ...func(*ChargeFlatFeeRunQuery)) *BillingInvoiceQuery {
+	query := (&ChargeFlatFeeRunClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withChargeFlatFeeRuns = query
 	return _q
 }
 
@@ -695,12 +731,13 @@ func (_q *BillingInvoiceQuery) sqlAll(ctx context.Context, hooks ...queryHook) (
 	var (
 		nodes       = []*BillingInvoice{}
 		_spec       = _q.querySpec()
-		loadedTypes = [10]bool{
+		loadedTypes = [11]bool{
 			_q.withSourceBillingProfile != nil,
 			_q.withBillingWorkflowConfig != nil,
 			_q.withBillingInvoiceLines != nil,
 			_q.withBillingInvoiceDetailedLines != nil,
 			_q.withBillingInvoiceValidationIssues != nil,
+			_q.withChargeFlatFeeRuns != nil,
 			_q.withChargeUsageBasedRuns != nil,
 			_q.withBillingInvoiceCustomer != nil,
 			_q.withTaxApp != nil,
@@ -764,6 +801,15 @@ func (_q *BillingInvoiceQuery) sqlAll(ctx context.Context, hooks ...queryHook) (
 			func(n *BillingInvoice) { n.Edges.BillingInvoiceValidationIssues = []*BillingInvoiceValidationIssue{} },
 			func(n *BillingInvoice, e *BillingInvoiceValidationIssue) {
 				n.Edges.BillingInvoiceValidationIssues = append(n.Edges.BillingInvoiceValidationIssues, e)
+			}); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withChargeFlatFeeRuns; query != nil {
+		if err := _q.loadChargeFlatFeeRuns(ctx, query, nodes,
+			func(n *BillingInvoice) { n.Edges.ChargeFlatFeeRuns = []*ChargeFlatFeeRun{} },
+			func(n *BillingInvoice, e *ChargeFlatFeeRun) {
+				n.Edges.ChargeFlatFeeRuns = append(n.Edges.ChargeFlatFeeRuns, e)
 			}); err != nil {
 			return nil, err
 		}
@@ -948,6 +994,39 @@ func (_q *BillingInvoiceQuery) loadBillingInvoiceValidationIssues(ctx context.Co
 		node, ok := nodeids[fk]
 		if !ok {
 			return fmt.Errorf(`unexpected referenced foreign-key "invoice_id" returned %v for node %v`, fk, n.ID)
+		}
+		assign(node, n)
+	}
+	return nil
+}
+func (_q *BillingInvoiceQuery) loadChargeFlatFeeRuns(ctx context.Context, query *ChargeFlatFeeRunQuery, nodes []*BillingInvoice, init func(*BillingInvoice), assign func(*BillingInvoice, *ChargeFlatFeeRun)) error {
+	fks := make([]driver.Value, 0, len(nodes))
+	nodeids := make(map[string]*BillingInvoice)
+	for i := range nodes {
+		fks = append(fks, nodes[i].ID)
+		nodeids[nodes[i].ID] = nodes[i]
+		if init != nil {
+			init(nodes[i])
+		}
+	}
+	if len(query.ctx.Fields) > 0 {
+		query.ctx.AppendFieldOnce(chargeflatfeerun.FieldInvoiceID)
+	}
+	query.Where(predicate.ChargeFlatFeeRun(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(billinginvoice.ChargeFlatFeeRunsColumn), fks...))
+	}))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		fk := n.InvoiceID
+		if fk == nil {
+			return fmt.Errorf(`foreign-key "invoice_id" is nil for node %v`, n.ID)
+		}
+		node, ok := nodeids[*fk]
+		if !ok {
+			return fmt.Errorf(`unexpected referenced foreign-key "invoice_id" returned %v for node %v`, *fk, n.ID)
 		}
 		assign(node, n)
 	}

--- a/openmeter/ent/db/billinginvoice_update.go
+++ b/openmeter/ent/db/billinginvoice_update.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicevalidationissue"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingstandardinvoicedetailedline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingworkflowconfig"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -979,6 +980,21 @@ func (_u *BillingInvoiceUpdate) AddBillingInvoiceValidationIssues(v ...*BillingI
 	return _u.AddBillingInvoiceValidationIssueIDs(ids...)
 }
 
+// AddChargeFlatFeeRunIDs adds the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity by IDs.
+func (_u *BillingInvoiceUpdate) AddChargeFlatFeeRunIDs(ids ...string) *BillingInvoiceUpdate {
+	_u.mutation.AddChargeFlatFeeRunIDs(ids...)
+	return _u
+}
+
+// AddChargeFlatFeeRuns adds the "charge_flat_fee_runs" edges to the ChargeFlatFeeRun entity.
+func (_u *BillingInvoiceUpdate) AddChargeFlatFeeRuns(v ...*ChargeFlatFeeRun) *BillingInvoiceUpdate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddChargeFlatFeeRunIDs(ids...)
+}
+
 // AddChargeUsageBasedRunIDs adds the "charge_usage_based_runs" edge to the ChargeUsageBasedRuns entity by IDs.
 func (_u *BillingInvoiceUpdate) AddChargeUsageBasedRunIDs(ids ...string) *BillingInvoiceUpdate {
 	_u.mutation.AddChargeUsageBasedRunIDs(ids...)
@@ -1066,6 +1082,27 @@ func (_u *BillingInvoiceUpdate) RemoveBillingInvoiceValidationIssues(v ...*Billi
 		ids[i] = v[i].ID
 	}
 	return _u.RemoveBillingInvoiceValidationIssueIDs(ids...)
+}
+
+// ClearChargeFlatFeeRuns clears all "charge_flat_fee_runs" edges to the ChargeFlatFeeRun entity.
+func (_u *BillingInvoiceUpdate) ClearChargeFlatFeeRuns() *BillingInvoiceUpdate {
+	_u.mutation.ClearChargeFlatFeeRuns()
+	return _u
+}
+
+// RemoveChargeFlatFeeRunIDs removes the "charge_flat_fee_runs" edge to ChargeFlatFeeRun entities by IDs.
+func (_u *BillingInvoiceUpdate) RemoveChargeFlatFeeRunIDs(ids ...string) *BillingInvoiceUpdate {
+	_u.mutation.RemoveChargeFlatFeeRunIDs(ids...)
+	return _u
+}
+
+// RemoveChargeFlatFeeRuns removes "charge_flat_fee_runs" edges to ChargeFlatFeeRun entities.
+func (_u *BillingInvoiceUpdate) RemoveChargeFlatFeeRuns(v ...*ChargeFlatFeeRun) *BillingInvoiceUpdate {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveChargeFlatFeeRunIDs(ids...)
 }
 
 // ClearChargeUsageBasedRuns clears all "charge_usage_based_runs" edges to the ChargeUsageBasedRuns entity.
@@ -1604,6 +1641,51 @@ func (_u *BillingInvoiceUpdate) sqlSave(ctx context.Context) (_node int, err err
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(billinginvoicevalidationissue.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.ChargeFlatFeeRunsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeFlatFeeRunsTable,
+			Columns: []string{billinginvoice.ChargeFlatFeeRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeerun.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedChargeFlatFeeRunsIDs(); len(nodes) > 0 && !_u.mutation.ChargeFlatFeeRunsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeFlatFeeRunsTable,
+			Columns: []string{billinginvoice.ChargeFlatFeeRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeerun.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.ChargeFlatFeeRunsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeFlatFeeRunsTable,
+			Columns: []string{billinginvoice.ChargeFlatFeeRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeerun.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {
@@ -2619,6 +2701,21 @@ func (_u *BillingInvoiceUpdateOne) AddBillingInvoiceValidationIssues(v ...*Billi
 	return _u.AddBillingInvoiceValidationIssueIDs(ids...)
 }
 
+// AddChargeFlatFeeRunIDs adds the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity by IDs.
+func (_u *BillingInvoiceUpdateOne) AddChargeFlatFeeRunIDs(ids ...string) *BillingInvoiceUpdateOne {
+	_u.mutation.AddChargeFlatFeeRunIDs(ids...)
+	return _u
+}
+
+// AddChargeFlatFeeRuns adds the "charge_flat_fee_runs" edges to the ChargeFlatFeeRun entity.
+func (_u *BillingInvoiceUpdateOne) AddChargeFlatFeeRuns(v ...*ChargeFlatFeeRun) *BillingInvoiceUpdateOne {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.AddChargeFlatFeeRunIDs(ids...)
+}
+
 // AddChargeUsageBasedRunIDs adds the "charge_usage_based_runs" edge to the ChargeUsageBasedRuns entity by IDs.
 func (_u *BillingInvoiceUpdateOne) AddChargeUsageBasedRunIDs(ids ...string) *BillingInvoiceUpdateOne {
 	_u.mutation.AddChargeUsageBasedRunIDs(ids...)
@@ -2706,6 +2803,27 @@ func (_u *BillingInvoiceUpdateOne) RemoveBillingInvoiceValidationIssues(v ...*Bi
 		ids[i] = v[i].ID
 	}
 	return _u.RemoveBillingInvoiceValidationIssueIDs(ids...)
+}
+
+// ClearChargeFlatFeeRuns clears all "charge_flat_fee_runs" edges to the ChargeFlatFeeRun entity.
+func (_u *BillingInvoiceUpdateOne) ClearChargeFlatFeeRuns() *BillingInvoiceUpdateOne {
+	_u.mutation.ClearChargeFlatFeeRuns()
+	return _u
+}
+
+// RemoveChargeFlatFeeRunIDs removes the "charge_flat_fee_runs" edge to ChargeFlatFeeRun entities by IDs.
+func (_u *BillingInvoiceUpdateOne) RemoveChargeFlatFeeRunIDs(ids ...string) *BillingInvoiceUpdateOne {
+	_u.mutation.RemoveChargeFlatFeeRunIDs(ids...)
+	return _u
+}
+
+// RemoveChargeFlatFeeRuns removes "charge_flat_fee_runs" edges to ChargeFlatFeeRun entities.
+func (_u *BillingInvoiceUpdateOne) RemoveChargeFlatFeeRuns(v ...*ChargeFlatFeeRun) *BillingInvoiceUpdateOne {
+	ids := make([]string, len(v))
+	for i := range v {
+		ids[i] = v[i].ID
+	}
+	return _u.RemoveChargeFlatFeeRunIDs(ids...)
 }
 
 // ClearChargeUsageBasedRuns clears all "charge_usage_based_runs" edges to the ChargeUsageBasedRuns entity.
@@ -3274,6 +3392,51 @@ func (_u *BillingInvoiceUpdateOne) sqlSave(ctx context.Context) (_node *BillingI
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(billinginvoicevalidationissue.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.ChargeFlatFeeRunsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeFlatFeeRunsTable,
+			Columns: []string{billinginvoice.ChargeFlatFeeRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeerun.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.RemovedChargeFlatFeeRunsIDs(); len(nodes) > 0 && !_u.mutation.ChargeFlatFeeRunsCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeFlatFeeRunsTable,
+			Columns: []string{billinginvoice.ChargeFlatFeeRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeerun.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.ChargeFlatFeeRunsIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2M,
+			Inverse: false,
+			Table:   billinginvoice.ChargeFlatFeeRunsTable,
+			Columns: []string{billinginvoice.ChargeFlatFeeRunsColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeerun.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/openmeter/ent/db/billinginvoiceline.go
+++ b/openmeter/ent/db/billinginvoiceline.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceusagebasedlineconfig"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/charge"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargecreditpurchaseinvoicedpayment"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerunpayment"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscription"
@@ -164,8 +165,8 @@ type BillingInvoiceLineEdges struct {
 	ChargeFlatFeeRunPayment *ChargeFlatFeeRunPayment `json:"charge_flat_fee_run_payment,omitempty"`
 	// ChargeFlatFeeRunCreditAllocations holds the value of the charge_flat_fee_run_credit_allocations edge.
 	ChargeFlatFeeRunCreditAllocations []*ChargeFlatFeeRunCreditAllocations `json:"charge_flat_fee_run_credit_allocations,omitempty"`
-	// ChargeFlatFeeRunInvoicedUsage holds the value of the charge_flat_fee_run_invoiced_usage edge.
-	ChargeFlatFeeRunInvoicedUsage []*ChargeFlatFeeRunInvoicedUsage `json:"charge_flat_fee_run_invoiced_usage,omitempty"`
+	// ChargeFlatFeeRuns holds the value of the charge_flat_fee_runs edge.
+	ChargeFlatFeeRuns *ChargeFlatFeeRun `json:"charge_flat_fee_runs,omitempty"`
 	// ChargeUsageBasedRun holds the value of the charge_usage_based_run edge.
 	ChargeUsageBasedRun *ChargeUsageBasedRuns `json:"charge_usage_based_run,omitempty"`
 	// ChargeCreditPurchaseInvoicedPayment holds the value of the charge_credit_purchase_invoiced_payment edge.
@@ -332,13 +333,15 @@ func (e BillingInvoiceLineEdges) ChargeFlatFeeRunCreditAllocationsOrErr() ([]*Ch
 	return nil, &NotLoadedError{edge: "charge_flat_fee_run_credit_allocations"}
 }
 
-// ChargeFlatFeeRunInvoicedUsageOrErr returns the ChargeFlatFeeRunInvoicedUsage value or an error if the edge
-// was not loaded in eager-loading.
-func (e BillingInvoiceLineEdges) ChargeFlatFeeRunInvoicedUsageOrErr() ([]*ChargeFlatFeeRunInvoicedUsage, error) {
-	if e.loadedTypes[15] {
-		return e.ChargeFlatFeeRunInvoicedUsage, nil
+// ChargeFlatFeeRunsOrErr returns the ChargeFlatFeeRuns value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e BillingInvoiceLineEdges) ChargeFlatFeeRunsOrErr() (*ChargeFlatFeeRun, error) {
+	if e.ChargeFlatFeeRuns != nil {
+		return e.ChargeFlatFeeRuns, nil
+	} else if e.loadedTypes[15] {
+		return nil, &NotFoundError{label: chargeflatfeerun.Label}
 	}
-	return nil, &NotLoadedError{edge: "charge_flat_fee_run_invoiced_usage"}
+	return nil, &NotLoadedError{edge: "charge_flat_fee_runs"}
 }
 
 // ChargeUsageBasedRunOrErr returns the ChargeUsageBasedRun value or an error if the edge
@@ -801,9 +804,9 @@ func (_m *BillingInvoiceLine) QueryChargeFlatFeeRunCreditAllocations() *ChargeFl
 	return NewBillingInvoiceLineClient(_m.config).QueryChargeFlatFeeRunCreditAllocations(_m)
 }
 
-// QueryChargeFlatFeeRunInvoicedUsage queries the "charge_flat_fee_run_invoiced_usage" edge of the BillingInvoiceLine entity.
-func (_m *BillingInvoiceLine) QueryChargeFlatFeeRunInvoicedUsage() *ChargeFlatFeeRunInvoicedUsageQuery {
-	return NewBillingInvoiceLineClient(_m.config).QueryChargeFlatFeeRunInvoicedUsage(_m)
+// QueryChargeFlatFeeRuns queries the "charge_flat_fee_runs" edge of the BillingInvoiceLine entity.
+func (_m *BillingInvoiceLine) QueryChargeFlatFeeRuns() *ChargeFlatFeeRunQuery {
+	return NewBillingInvoiceLineClient(_m.config).QueryChargeFlatFeeRuns(_m)
 }
 
 // QueryChargeUsageBasedRun queries the "charge_usage_based_run" edge of the BillingInvoiceLine entity.

--- a/openmeter/ent/db/billinginvoiceline/billinginvoiceline.go
+++ b/openmeter/ent/db/billinginvoiceline/billinginvoiceline.go
@@ -135,8 +135,8 @@ const (
 	EdgeChargeFlatFeeRunPayment = "charge_flat_fee_run_payment"
 	// EdgeChargeFlatFeeRunCreditAllocations holds the string denoting the charge_flat_fee_run_credit_allocations edge name in mutations.
 	EdgeChargeFlatFeeRunCreditAllocations = "charge_flat_fee_run_credit_allocations"
-	// EdgeChargeFlatFeeRunInvoicedUsage holds the string denoting the charge_flat_fee_run_invoiced_usage edge name in mutations.
-	EdgeChargeFlatFeeRunInvoicedUsage = "charge_flat_fee_run_invoiced_usage"
+	// EdgeChargeFlatFeeRuns holds the string denoting the charge_flat_fee_runs edge name in mutations.
+	EdgeChargeFlatFeeRuns = "charge_flat_fee_runs"
 	// EdgeChargeUsageBasedRun holds the string denoting the charge_usage_based_run edge name in mutations.
 	EdgeChargeUsageBasedRun = "charge_usage_based_run"
 	// EdgeChargeCreditPurchaseInvoicedPayment holds the string denoting the charge_credit_purchase_invoiced_payment edge name in mutations.
@@ -244,13 +244,13 @@ const (
 	ChargeFlatFeeRunCreditAllocationsInverseTable = "charge_flat_fee_run_credit_allocations"
 	// ChargeFlatFeeRunCreditAllocationsColumn is the table column denoting the charge_flat_fee_run_credit_allocations relation/edge.
 	ChargeFlatFeeRunCreditAllocationsColumn = "line_id"
-	// ChargeFlatFeeRunInvoicedUsageTable is the table that holds the charge_flat_fee_run_invoiced_usage relation/edge.
-	ChargeFlatFeeRunInvoicedUsageTable = "charge_flat_fee_run_invoiced_usages"
-	// ChargeFlatFeeRunInvoicedUsageInverseTable is the table name for the ChargeFlatFeeRunInvoicedUsage entity.
-	// It exists in this package in order to avoid circular dependency with the "chargeflatfeeruninvoicedusage" package.
-	ChargeFlatFeeRunInvoicedUsageInverseTable = "charge_flat_fee_run_invoiced_usages"
-	// ChargeFlatFeeRunInvoicedUsageColumn is the table column denoting the charge_flat_fee_run_invoiced_usage relation/edge.
-	ChargeFlatFeeRunInvoicedUsageColumn = "line_id"
+	// ChargeFlatFeeRunsTable is the table that holds the charge_flat_fee_runs relation/edge.
+	ChargeFlatFeeRunsTable = "charge_flat_fee_runs"
+	// ChargeFlatFeeRunsInverseTable is the table name for the ChargeFlatFeeRun entity.
+	// It exists in this package in order to avoid circular dependency with the "chargeflatfeerun" package.
+	ChargeFlatFeeRunsInverseTable = "charge_flat_fee_runs"
+	// ChargeFlatFeeRunsColumn is the table column denoting the charge_flat_fee_runs relation/edge.
+	ChargeFlatFeeRunsColumn = "line_id"
 	// ChargeUsageBasedRunTable is the table that holds the charge_usage_based_run relation/edge.
 	ChargeUsageBasedRunTable = "charge_usage_based_runs"
 	// ChargeUsageBasedRunInverseTable is the table name for the ChargeUsageBasedRuns entity.
@@ -768,17 +768,10 @@ func ByChargeFlatFeeRunCreditAllocations(term sql.OrderTerm, terms ...sql.OrderT
 	}
 }
 
-// ByChargeFlatFeeRunInvoicedUsageCount orders the results by charge_flat_fee_run_invoiced_usage count.
-func ByChargeFlatFeeRunInvoicedUsageCount(opts ...sql.OrderTermOption) OrderOption {
+// ByChargeFlatFeeRunsField orders the results by charge_flat_fee_runs field.
+func ByChargeFlatFeeRunsField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborsCount(s, newChargeFlatFeeRunInvoicedUsageStep(), opts...)
-	}
-}
-
-// ByChargeFlatFeeRunInvoicedUsage orders the results by charge_flat_fee_run_invoiced_usage terms.
-func ByChargeFlatFeeRunInvoicedUsage(term sql.OrderTerm, terms ...sql.OrderTerm) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newChargeFlatFeeRunInvoicedUsageStep(), append([]sql.OrderTerm{term}, terms...)...)
+		sqlgraph.OrderByNeighborTerms(s, newChargeFlatFeeRunsStep(), sql.OrderByField(field, opts...))
 	}
 }
 
@@ -907,11 +900,11 @@ func newChargeFlatFeeRunCreditAllocationsStep() *sqlgraph.Step {
 		sqlgraph.Edge(sqlgraph.O2M, false, ChargeFlatFeeRunCreditAllocationsTable, ChargeFlatFeeRunCreditAllocationsColumn),
 	)
 }
-func newChargeFlatFeeRunInvoicedUsageStep() *sqlgraph.Step {
+func newChargeFlatFeeRunsStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(
 		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(ChargeFlatFeeRunInvoicedUsageInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.O2M, false, ChargeFlatFeeRunInvoicedUsageTable, ChargeFlatFeeRunInvoicedUsageColumn),
+		sqlgraph.To(ChargeFlatFeeRunsInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, false, ChargeFlatFeeRunsTable, ChargeFlatFeeRunsColumn),
 	)
 }
 func newChargeUsageBasedRunStep() *sqlgraph.Step {

--- a/openmeter/ent/db/billinginvoiceline/where.go
+++ b/openmeter/ent/db/billinginvoiceline/where.go
@@ -2664,21 +2664,21 @@ func HasChargeFlatFeeRunCreditAllocationsWith(preds ...predicate.ChargeFlatFeeRu
 	})
 }
 
-// HasChargeFlatFeeRunInvoicedUsage applies the HasEdge predicate on the "charge_flat_fee_run_invoiced_usage" edge.
-func HasChargeFlatFeeRunInvoicedUsage() predicate.BillingInvoiceLine {
+// HasChargeFlatFeeRuns applies the HasEdge predicate on the "charge_flat_fee_runs" edge.
+func HasChargeFlatFeeRuns() predicate.BillingInvoiceLine {
 	return predicate.BillingInvoiceLine(func(s *sql.Selector) {
 		step := sqlgraph.NewStep(
 			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, ChargeFlatFeeRunInvoicedUsageTable, ChargeFlatFeeRunInvoicedUsageColumn),
+			sqlgraph.Edge(sqlgraph.O2O, false, ChargeFlatFeeRunsTable, ChargeFlatFeeRunsColumn),
 		)
 		sqlgraph.HasNeighbors(s, step)
 	})
 }
 
-// HasChargeFlatFeeRunInvoicedUsageWith applies the HasEdge predicate on the "charge_flat_fee_run_invoiced_usage" edge with a given conditions (other predicates).
-func HasChargeFlatFeeRunInvoicedUsageWith(preds ...predicate.ChargeFlatFeeRunInvoicedUsage) predicate.BillingInvoiceLine {
+// HasChargeFlatFeeRunsWith applies the HasEdge predicate on the "charge_flat_fee_runs" edge with a given conditions (other predicates).
+func HasChargeFlatFeeRunsWith(preds ...predicate.ChargeFlatFeeRun) predicate.BillingInvoiceLine {
 	return predicate.BillingInvoiceLine(func(s *sql.Selector) {
-		step := newChargeFlatFeeRunInvoicedUsageStep()
+		step := newChargeFlatFeeRunsStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/openmeter/ent/db/billinginvoiceline_create.go
+++ b/openmeter/ent/db/billinginvoiceline_create.go
@@ -25,8 +25,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingstandardinvoicedetailedline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/charge"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargecreditpurchaseinvoicedpayment"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruncreditallocations"
-	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruninvoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerunpayment"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/subscription"
@@ -659,19 +659,23 @@ func (_c *BillingInvoiceLineCreate) AddChargeFlatFeeRunCreditAllocations(v ...*C
 	return _c.AddChargeFlatFeeRunCreditAllocationIDs(ids...)
 }
 
-// AddChargeFlatFeeRunInvoicedUsageIDs adds the "charge_flat_fee_run_invoiced_usage" edge to the ChargeFlatFeeRunInvoicedUsage entity by IDs.
-func (_c *BillingInvoiceLineCreate) AddChargeFlatFeeRunInvoicedUsageIDs(ids ...string) *BillingInvoiceLineCreate {
-	_c.mutation.AddChargeFlatFeeRunInvoicedUsageIDs(ids...)
+// SetChargeFlatFeeRunsID sets the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity by ID.
+func (_c *BillingInvoiceLineCreate) SetChargeFlatFeeRunsID(id string) *BillingInvoiceLineCreate {
+	_c.mutation.SetChargeFlatFeeRunsID(id)
 	return _c
 }
 
-// AddChargeFlatFeeRunInvoicedUsage adds the "charge_flat_fee_run_invoiced_usage" edges to the ChargeFlatFeeRunInvoicedUsage entity.
-func (_c *BillingInvoiceLineCreate) AddChargeFlatFeeRunInvoicedUsage(v ...*ChargeFlatFeeRunInvoicedUsage) *BillingInvoiceLineCreate {
-	ids := make([]string, len(v))
-	for i := range v {
-		ids[i] = v[i].ID
+// SetNillableChargeFlatFeeRunsID sets the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity by ID if the given value is not nil.
+func (_c *BillingInvoiceLineCreate) SetNillableChargeFlatFeeRunsID(id *string) *BillingInvoiceLineCreate {
+	if id != nil {
+		_c = _c.SetChargeFlatFeeRunsID(*id)
 	}
-	return _c.AddChargeFlatFeeRunInvoicedUsageIDs(ids...)
+	return _c
+}
+
+// SetChargeFlatFeeRuns sets the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity.
+func (_c *BillingInvoiceLineCreate) SetChargeFlatFeeRuns(v *ChargeFlatFeeRun) *BillingInvoiceLineCreate {
+	return _c.SetChargeFlatFeeRunsID(v.ID)
 }
 
 // SetChargeUsageBasedRunID sets the "charge_usage_based_run" edge to the ChargeUsageBasedRuns entity by ID.
@@ -1319,15 +1323,15 @@ func (_c *BillingInvoiceLineCreate) createSpec() (*BillingInvoiceLine, *sqlgraph
 		}
 		_spec.Edges = append(_spec.Edges, edge)
 	}
-	if nodes := _c.mutation.ChargeFlatFeeRunInvoicedUsageIDs(); len(nodes) > 0 {
+	if nodes := _c.mutation.ChargeFlatFeeRunsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.O2O,
 			Inverse: false,
-			Table:   billinginvoiceline.ChargeFlatFeeRunInvoicedUsageTable,
-			Columns: []string{billinginvoiceline.ChargeFlatFeeRunInvoicedUsageColumn},
+			Table:   billinginvoiceline.ChargeFlatFeeRunsTable,
+			Columns: []string{billinginvoiceline.ChargeFlatFeeRunsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeeruninvoicedusage.FieldID, field.TypeString),
+				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeerun.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/openmeter/ent/db/billinginvoiceline_query.go
+++ b/openmeter/ent/db/billinginvoiceline_query.go
@@ -23,8 +23,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingstandardinvoicedetailedline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/charge"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargecreditpurchaseinvoicedpayment"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruncreditallocations"
-	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruninvoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerunpayment"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
@@ -56,7 +56,7 @@ type BillingInvoiceLineQuery struct {
 	withCharge                              *ChargeQuery
 	withChargeFlatFeeRunPayment             *ChargeFlatFeeRunPaymentQuery
 	withChargeFlatFeeRunCreditAllocations   *ChargeFlatFeeRunCreditAllocationsQuery
-	withChargeFlatFeeRunInvoicedUsage       *ChargeFlatFeeRunInvoicedUsageQuery
+	withChargeFlatFeeRuns                   *ChargeFlatFeeRunQuery
 	withChargeUsageBasedRun                 *ChargeUsageBasedRunsQuery
 	withChargeCreditPurchaseInvoicedPayment *ChargeCreditPurchaseInvoicedPaymentQuery
 	withTaxCode                             *TaxCodeQuery
@@ -428,9 +428,9 @@ func (_q *BillingInvoiceLineQuery) QueryChargeFlatFeeRunCreditAllocations() *Cha
 	return query
 }
 
-// QueryChargeFlatFeeRunInvoicedUsage chains the current query on the "charge_flat_fee_run_invoiced_usage" edge.
-func (_q *BillingInvoiceLineQuery) QueryChargeFlatFeeRunInvoicedUsage() *ChargeFlatFeeRunInvoicedUsageQuery {
-	query := (&ChargeFlatFeeRunInvoicedUsageClient{config: _q.config}).Query()
+// QueryChargeFlatFeeRuns chains the current query on the "charge_flat_fee_runs" edge.
+func (_q *BillingInvoiceLineQuery) QueryChargeFlatFeeRuns() *ChargeFlatFeeRunQuery {
+	query := (&ChargeFlatFeeRunClient{config: _q.config}).Query()
 	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
 		if err := _q.prepareQuery(ctx); err != nil {
 			return nil, err
@@ -441,8 +441,8 @@ func (_q *BillingInvoiceLineQuery) QueryChargeFlatFeeRunInvoicedUsage() *ChargeF
 		}
 		step := sqlgraph.NewStep(
 			sqlgraph.From(billinginvoiceline.Table, billinginvoiceline.FieldID, selector),
-			sqlgraph.To(chargeflatfeeruninvoicedusage.Table, chargeflatfeeruninvoicedusage.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, billinginvoiceline.ChargeFlatFeeRunInvoicedUsageTable, billinginvoiceline.ChargeFlatFeeRunInvoicedUsageColumn),
+			sqlgraph.To(chargeflatfeerun.Table, chargeflatfeerun.FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, false, billinginvoiceline.ChargeFlatFeeRunsTable, billinginvoiceline.ChargeFlatFeeRunsColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -723,7 +723,7 @@ func (_q *BillingInvoiceLineQuery) Clone() *BillingInvoiceLineQuery {
 		withCharge:                              _q.withCharge.Clone(),
 		withChargeFlatFeeRunPayment:             _q.withChargeFlatFeeRunPayment.Clone(),
 		withChargeFlatFeeRunCreditAllocations:   _q.withChargeFlatFeeRunCreditAllocations.Clone(),
-		withChargeFlatFeeRunInvoicedUsage:       _q.withChargeFlatFeeRunInvoicedUsage.Clone(),
+		withChargeFlatFeeRuns:                   _q.withChargeFlatFeeRuns.Clone(),
 		withChargeUsageBasedRun:                 _q.withChargeUsageBasedRun.Clone(),
 		withChargeCreditPurchaseInvoicedPayment: _q.withChargeCreditPurchaseInvoicedPayment.Clone(),
 		withTaxCode:                             _q.withTaxCode.Clone(),
@@ -898,14 +898,14 @@ func (_q *BillingInvoiceLineQuery) WithChargeFlatFeeRunCreditAllocations(opts ..
 	return _q
 }
 
-// WithChargeFlatFeeRunInvoicedUsage tells the query-builder to eager-load the nodes that are connected to
-// the "charge_flat_fee_run_invoiced_usage" edge. The optional arguments are used to configure the query builder of the edge.
-func (_q *BillingInvoiceLineQuery) WithChargeFlatFeeRunInvoicedUsage(opts ...func(*ChargeFlatFeeRunInvoicedUsageQuery)) *BillingInvoiceLineQuery {
-	query := (&ChargeFlatFeeRunInvoicedUsageClient{config: _q.config}).Query()
+// WithChargeFlatFeeRuns tells the query-builder to eager-load the nodes that are connected to
+// the "charge_flat_fee_runs" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *BillingInvoiceLineQuery) WithChargeFlatFeeRuns(opts ...func(*ChargeFlatFeeRunQuery)) *BillingInvoiceLineQuery {
+	query := (&ChargeFlatFeeRunClient{config: _q.config}).Query()
 	for _, opt := range opts {
 		opt(query)
 	}
-	_q.withChargeFlatFeeRunInvoicedUsage = query
+	_q.withChargeFlatFeeRuns = query
 	return _q
 }
 
@@ -1037,7 +1037,7 @@ func (_q *BillingInvoiceLineQuery) sqlAll(ctx context.Context, hooks ...queryHoo
 			_q.withCharge != nil,
 			_q.withChargeFlatFeeRunPayment != nil,
 			_q.withChargeFlatFeeRunCreditAllocations != nil,
-			_q.withChargeFlatFeeRunInvoicedUsage != nil,
+			_q.withChargeFlatFeeRuns != nil,
 			_q.withChargeUsageBasedRun != nil,
 			_q.withChargeCreditPurchaseInvoicedPayment != nil,
 			_q.withTaxCode != nil,
@@ -1177,14 +1177,9 @@ func (_q *BillingInvoiceLineQuery) sqlAll(ctx context.Context, hooks ...queryHoo
 			return nil, err
 		}
 	}
-	if query := _q.withChargeFlatFeeRunInvoicedUsage; query != nil {
-		if err := _q.loadChargeFlatFeeRunInvoicedUsage(ctx, query, nodes,
-			func(n *BillingInvoiceLine) {
-				n.Edges.ChargeFlatFeeRunInvoicedUsage = []*ChargeFlatFeeRunInvoicedUsage{}
-			},
-			func(n *BillingInvoiceLine, e *ChargeFlatFeeRunInvoicedUsage) {
-				n.Edges.ChargeFlatFeeRunInvoicedUsage = append(n.Edges.ChargeFlatFeeRunInvoicedUsage, e)
-			}); err != nil {
+	if query := _q.withChargeFlatFeeRuns; query != nil {
+		if err := _q.loadChargeFlatFeeRuns(ctx, query, nodes, nil,
+			func(n *BillingInvoiceLine, e *ChargeFlatFeeRun) { n.Edges.ChargeFlatFeeRuns = e }); err != nil {
 			return nil, err
 		}
 	}
@@ -1680,21 +1675,18 @@ func (_q *BillingInvoiceLineQuery) loadChargeFlatFeeRunCreditAllocations(ctx con
 	}
 	return nil
 }
-func (_q *BillingInvoiceLineQuery) loadChargeFlatFeeRunInvoicedUsage(ctx context.Context, query *ChargeFlatFeeRunInvoicedUsageQuery, nodes []*BillingInvoiceLine, init func(*BillingInvoiceLine), assign func(*BillingInvoiceLine, *ChargeFlatFeeRunInvoicedUsage)) error {
+func (_q *BillingInvoiceLineQuery) loadChargeFlatFeeRuns(ctx context.Context, query *ChargeFlatFeeRunQuery, nodes []*BillingInvoiceLine, init func(*BillingInvoiceLine), assign func(*BillingInvoiceLine, *ChargeFlatFeeRun)) error {
 	fks := make([]driver.Value, 0, len(nodes))
 	nodeids := make(map[string]*BillingInvoiceLine)
 	for i := range nodes {
 		fks = append(fks, nodes[i].ID)
 		nodeids[nodes[i].ID] = nodes[i]
-		if init != nil {
-			init(nodes[i])
-		}
 	}
 	if len(query.ctx.Fields) > 0 {
-		query.ctx.AppendFieldOnce(chargeflatfeeruninvoicedusage.FieldLineID)
+		query.ctx.AppendFieldOnce(chargeflatfeerun.FieldLineID)
 	}
-	query.Where(predicate.ChargeFlatFeeRunInvoicedUsage(func(s *sql.Selector) {
-		s.Where(sql.InValues(s.C(billinginvoiceline.ChargeFlatFeeRunInvoicedUsageColumn), fks...))
+	query.Where(predicate.ChargeFlatFeeRun(func(s *sql.Selector) {
+		s.Where(sql.InValues(s.C(billinginvoiceline.ChargeFlatFeeRunsColumn), fks...))
 	}))
 	neighbors, err := query.All(ctx)
 	if err != nil {

--- a/openmeter/ent/db/billinginvoiceline_update.go
+++ b/openmeter/ent/db/billinginvoiceline_update.go
@@ -24,8 +24,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billingstandardinvoicedetailedline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/charge"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargecreditpurchaseinvoicedpayment"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruncreditallocations"
-	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruninvoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerunpayment"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
@@ -861,19 +861,23 @@ func (_u *BillingInvoiceLineUpdate) AddChargeFlatFeeRunCreditAllocations(v ...*C
 	return _u.AddChargeFlatFeeRunCreditAllocationIDs(ids...)
 }
 
-// AddChargeFlatFeeRunInvoicedUsageIDs adds the "charge_flat_fee_run_invoiced_usage" edge to the ChargeFlatFeeRunInvoicedUsage entity by IDs.
-func (_u *BillingInvoiceLineUpdate) AddChargeFlatFeeRunInvoicedUsageIDs(ids ...string) *BillingInvoiceLineUpdate {
-	_u.mutation.AddChargeFlatFeeRunInvoicedUsageIDs(ids...)
+// SetChargeFlatFeeRunsID sets the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity by ID.
+func (_u *BillingInvoiceLineUpdate) SetChargeFlatFeeRunsID(id string) *BillingInvoiceLineUpdate {
+	_u.mutation.SetChargeFlatFeeRunsID(id)
 	return _u
 }
 
-// AddChargeFlatFeeRunInvoicedUsage adds the "charge_flat_fee_run_invoiced_usage" edges to the ChargeFlatFeeRunInvoicedUsage entity.
-func (_u *BillingInvoiceLineUpdate) AddChargeFlatFeeRunInvoicedUsage(v ...*ChargeFlatFeeRunInvoicedUsage) *BillingInvoiceLineUpdate {
-	ids := make([]string, len(v))
-	for i := range v {
-		ids[i] = v[i].ID
+// SetNillableChargeFlatFeeRunsID sets the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity by ID if the given value is not nil.
+func (_u *BillingInvoiceLineUpdate) SetNillableChargeFlatFeeRunsID(id *string) *BillingInvoiceLineUpdate {
+	if id != nil {
+		_u = _u.SetChargeFlatFeeRunsID(*id)
 	}
-	return _u.AddChargeFlatFeeRunInvoicedUsageIDs(ids...)
+	return _u
+}
+
+// SetChargeFlatFeeRuns sets the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity.
+func (_u *BillingInvoiceLineUpdate) SetChargeFlatFeeRuns(v *ChargeFlatFeeRun) *BillingInvoiceLineUpdate {
+	return _u.SetChargeFlatFeeRunsID(v.ID)
 }
 
 // SetChargeUsageBasedRunID sets the "charge_usage_based_run" edge to the ChargeUsageBasedRuns entity by ID.
@@ -1089,25 +1093,10 @@ func (_u *BillingInvoiceLineUpdate) RemoveChargeFlatFeeRunCreditAllocations(v ..
 	return _u.RemoveChargeFlatFeeRunCreditAllocationIDs(ids...)
 }
 
-// ClearChargeFlatFeeRunInvoicedUsage clears all "charge_flat_fee_run_invoiced_usage" edges to the ChargeFlatFeeRunInvoicedUsage entity.
-func (_u *BillingInvoiceLineUpdate) ClearChargeFlatFeeRunInvoicedUsage() *BillingInvoiceLineUpdate {
-	_u.mutation.ClearChargeFlatFeeRunInvoicedUsage()
+// ClearChargeFlatFeeRuns clears the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity.
+func (_u *BillingInvoiceLineUpdate) ClearChargeFlatFeeRuns() *BillingInvoiceLineUpdate {
+	_u.mutation.ClearChargeFlatFeeRuns()
 	return _u
-}
-
-// RemoveChargeFlatFeeRunInvoicedUsageIDs removes the "charge_flat_fee_run_invoiced_usage" edge to ChargeFlatFeeRunInvoicedUsage entities by IDs.
-func (_u *BillingInvoiceLineUpdate) RemoveChargeFlatFeeRunInvoicedUsageIDs(ids ...string) *BillingInvoiceLineUpdate {
-	_u.mutation.RemoveChargeFlatFeeRunInvoicedUsageIDs(ids...)
-	return _u
-}
-
-// RemoveChargeFlatFeeRunInvoicedUsage removes "charge_flat_fee_run_invoiced_usage" edges to ChargeFlatFeeRunInvoicedUsage entities.
-func (_u *BillingInvoiceLineUpdate) RemoveChargeFlatFeeRunInvoicedUsage(v ...*ChargeFlatFeeRunInvoicedUsage) *BillingInvoiceLineUpdate {
-	ids := make([]string, len(v))
-	for i := range v {
-		ids[i] = v[i].ID
-	}
-	return _u.RemoveChargeFlatFeeRunInvoicedUsageIDs(ids...)
 }
 
 // ClearChargeUsageBasedRun clears the "charge_usage_based_run" edge to the ChargeUsageBasedRuns entity.
@@ -1875,44 +1864,28 @@ func (_u *BillingInvoiceLineUpdate) sqlSave(ctx context.Context) (_node int, err
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if _u.mutation.ChargeFlatFeeRunInvoicedUsageCleared() {
+	if _u.mutation.ChargeFlatFeeRunsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.O2O,
 			Inverse: false,
-			Table:   billinginvoiceline.ChargeFlatFeeRunInvoicedUsageTable,
-			Columns: []string{billinginvoiceline.ChargeFlatFeeRunInvoicedUsageColumn},
+			Table:   billinginvoiceline.ChargeFlatFeeRunsTable,
+			Columns: []string{billinginvoiceline.ChargeFlatFeeRunsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeeruninvoicedusage.FieldID, field.TypeString),
+				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeerun.FieldID, field.TypeString),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := _u.mutation.RemovedChargeFlatFeeRunInvoicedUsageIDs(); len(nodes) > 0 && !_u.mutation.ChargeFlatFeeRunInvoicedUsageCleared() {
+	if nodes := _u.mutation.ChargeFlatFeeRunsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.O2O,
 			Inverse: false,
-			Table:   billinginvoiceline.ChargeFlatFeeRunInvoicedUsageTable,
-			Columns: []string{billinginvoiceline.ChargeFlatFeeRunInvoicedUsageColumn},
+			Table:   billinginvoiceline.ChargeFlatFeeRunsTable,
+			Columns: []string{billinginvoiceline.ChargeFlatFeeRunsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeeruninvoicedusage.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := _u.mutation.ChargeFlatFeeRunInvoicedUsageIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: false,
-			Table:   billinginvoiceline.ChargeFlatFeeRunInvoicedUsageTable,
-			Columns: []string{billinginvoiceline.ChargeFlatFeeRunInvoicedUsageColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeeruninvoicedusage.FieldID, field.TypeString),
+				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeerun.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {
@@ -2838,19 +2811,23 @@ func (_u *BillingInvoiceLineUpdateOne) AddChargeFlatFeeRunCreditAllocations(v ..
 	return _u.AddChargeFlatFeeRunCreditAllocationIDs(ids...)
 }
 
-// AddChargeFlatFeeRunInvoicedUsageIDs adds the "charge_flat_fee_run_invoiced_usage" edge to the ChargeFlatFeeRunInvoicedUsage entity by IDs.
-func (_u *BillingInvoiceLineUpdateOne) AddChargeFlatFeeRunInvoicedUsageIDs(ids ...string) *BillingInvoiceLineUpdateOne {
-	_u.mutation.AddChargeFlatFeeRunInvoicedUsageIDs(ids...)
+// SetChargeFlatFeeRunsID sets the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity by ID.
+func (_u *BillingInvoiceLineUpdateOne) SetChargeFlatFeeRunsID(id string) *BillingInvoiceLineUpdateOne {
+	_u.mutation.SetChargeFlatFeeRunsID(id)
 	return _u
 }
 
-// AddChargeFlatFeeRunInvoicedUsage adds the "charge_flat_fee_run_invoiced_usage" edges to the ChargeFlatFeeRunInvoicedUsage entity.
-func (_u *BillingInvoiceLineUpdateOne) AddChargeFlatFeeRunInvoicedUsage(v ...*ChargeFlatFeeRunInvoicedUsage) *BillingInvoiceLineUpdateOne {
-	ids := make([]string, len(v))
-	for i := range v {
-		ids[i] = v[i].ID
+// SetNillableChargeFlatFeeRunsID sets the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity by ID if the given value is not nil.
+func (_u *BillingInvoiceLineUpdateOne) SetNillableChargeFlatFeeRunsID(id *string) *BillingInvoiceLineUpdateOne {
+	if id != nil {
+		_u = _u.SetChargeFlatFeeRunsID(*id)
 	}
-	return _u.AddChargeFlatFeeRunInvoicedUsageIDs(ids...)
+	return _u
+}
+
+// SetChargeFlatFeeRuns sets the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity.
+func (_u *BillingInvoiceLineUpdateOne) SetChargeFlatFeeRuns(v *ChargeFlatFeeRun) *BillingInvoiceLineUpdateOne {
+	return _u.SetChargeFlatFeeRunsID(v.ID)
 }
 
 // SetChargeUsageBasedRunID sets the "charge_usage_based_run" edge to the ChargeUsageBasedRuns entity by ID.
@@ -3066,25 +3043,10 @@ func (_u *BillingInvoiceLineUpdateOne) RemoveChargeFlatFeeRunCreditAllocations(v
 	return _u.RemoveChargeFlatFeeRunCreditAllocationIDs(ids...)
 }
 
-// ClearChargeFlatFeeRunInvoicedUsage clears all "charge_flat_fee_run_invoiced_usage" edges to the ChargeFlatFeeRunInvoicedUsage entity.
-func (_u *BillingInvoiceLineUpdateOne) ClearChargeFlatFeeRunInvoicedUsage() *BillingInvoiceLineUpdateOne {
-	_u.mutation.ClearChargeFlatFeeRunInvoicedUsage()
+// ClearChargeFlatFeeRuns clears the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity.
+func (_u *BillingInvoiceLineUpdateOne) ClearChargeFlatFeeRuns() *BillingInvoiceLineUpdateOne {
+	_u.mutation.ClearChargeFlatFeeRuns()
 	return _u
-}
-
-// RemoveChargeFlatFeeRunInvoicedUsageIDs removes the "charge_flat_fee_run_invoiced_usage" edge to ChargeFlatFeeRunInvoicedUsage entities by IDs.
-func (_u *BillingInvoiceLineUpdateOne) RemoveChargeFlatFeeRunInvoicedUsageIDs(ids ...string) *BillingInvoiceLineUpdateOne {
-	_u.mutation.RemoveChargeFlatFeeRunInvoicedUsageIDs(ids...)
-	return _u
-}
-
-// RemoveChargeFlatFeeRunInvoicedUsage removes "charge_flat_fee_run_invoiced_usage" edges to ChargeFlatFeeRunInvoicedUsage entities.
-func (_u *BillingInvoiceLineUpdateOne) RemoveChargeFlatFeeRunInvoicedUsage(v ...*ChargeFlatFeeRunInvoicedUsage) *BillingInvoiceLineUpdateOne {
-	ids := make([]string, len(v))
-	for i := range v {
-		ids[i] = v[i].ID
-	}
-	return _u.RemoveChargeFlatFeeRunInvoicedUsageIDs(ids...)
 }
 
 // ClearChargeUsageBasedRun clears the "charge_usage_based_run" edge to the ChargeUsageBasedRuns entity.
@@ -3882,44 +3844,28 @@ func (_u *BillingInvoiceLineUpdateOne) sqlSave(ctx context.Context) (_node *Bill
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
-	if _u.mutation.ChargeFlatFeeRunInvoicedUsageCleared() {
+	if _u.mutation.ChargeFlatFeeRunsCleared() {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.O2O,
 			Inverse: false,
-			Table:   billinginvoiceline.ChargeFlatFeeRunInvoicedUsageTable,
-			Columns: []string{billinginvoiceline.ChargeFlatFeeRunInvoicedUsageColumn},
+			Table:   billinginvoiceline.ChargeFlatFeeRunsTable,
+			Columns: []string{billinginvoiceline.ChargeFlatFeeRunsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeeruninvoicedusage.FieldID, field.TypeString),
+				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeerun.FieldID, field.TypeString),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
 	}
-	if nodes := _u.mutation.RemovedChargeFlatFeeRunInvoicedUsageIDs(); len(nodes) > 0 && !_u.mutation.ChargeFlatFeeRunInvoicedUsageCleared() {
+	if nodes := _u.mutation.ChargeFlatFeeRunsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
+			Rel:     sqlgraph.O2O,
 			Inverse: false,
-			Table:   billinginvoiceline.ChargeFlatFeeRunInvoicedUsageTable,
-			Columns: []string{billinginvoiceline.ChargeFlatFeeRunInvoicedUsageColumn},
+			Table:   billinginvoiceline.ChargeFlatFeeRunsTable,
+			Columns: []string{billinginvoiceline.ChargeFlatFeeRunsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeeruninvoicedusage.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := _u.mutation.ChargeFlatFeeRunInvoicedUsageIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.O2M,
-			Inverse: false,
-			Table:   billinginvoiceline.ChargeFlatFeeRunInvoicedUsageTable,
-			Columns: []string{billinginvoiceline.ChargeFlatFeeRunInvoicedUsageColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeeruninvoicedusage.FieldID, field.TypeString),
+				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeerun.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/openmeter/ent/db/chargeflatfeerun.go
+++ b/openmeter/ent/db/chargeflatfeerun.go
@@ -11,6 +11,8 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoice"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfee"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruninvoicedusage"
@@ -56,8 +58,14 @@ type ChargeFlatFeeRun struct {
 	ServicePeriodFrom time.Time `json:"service_period_from,omitempty"`
 	// ServicePeriodTo holds the value of the "service_period_to" field.
 	ServicePeriodTo time.Time `json:"service_period_to,omitempty"`
+	// LineID holds the value of the "line_id" field.
+	LineID *string `json:"line_id,omitempty"`
+	// InvoiceID holds the value of the "invoice_id" field.
+	InvoiceID *string `json:"invoice_id,omitempty"`
 	// AmountAfterProration holds the value of the "amount_after_proration" field.
 	AmountAfterProration alpacadecimal.Decimal `json:"amount_after_proration,omitempty"`
+	// NoFiatTransactionRequired holds the value of the "no_fiat_transaction_required" field.
+	NoFiatTransactionRequired bool `json:"no_fiat_transaction_required,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ChargeFlatFeeRunQuery when eager-loading is set.
 	Edges        ChargeFlatFeeRunEdges `json:"edges"`
@@ -68,6 +76,10 @@ type ChargeFlatFeeRun struct {
 type ChargeFlatFeeRunEdges struct {
 	// FlatFee holds the value of the flat_fee edge.
 	FlatFee *ChargeFlatFee `json:"flat_fee,omitempty"`
+	// BillingInvoiceLine holds the value of the billing_invoice_line edge.
+	BillingInvoiceLine *BillingInvoiceLine `json:"billing_invoice_line,omitempty"`
+	// BillingInvoice holds the value of the billing_invoice edge.
+	BillingInvoice *BillingInvoice `json:"billing_invoice,omitempty"`
 	// CreditAllocations holds the value of the credit_allocations edge.
 	CreditAllocations []*ChargeFlatFeeRunCreditAllocations `json:"credit_allocations,omitempty"`
 	// DetailedLines holds the value of the detailed_lines edge.
@@ -78,7 +90,7 @@ type ChargeFlatFeeRunEdges struct {
 	Payment *ChargeFlatFeeRunPayment `json:"payment,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [5]bool
+	loadedTypes [7]bool
 }
 
 // FlatFeeOrErr returns the FlatFee value or an error if the edge
@@ -92,10 +104,32 @@ func (e ChargeFlatFeeRunEdges) FlatFeeOrErr() (*ChargeFlatFee, error) {
 	return nil, &NotLoadedError{edge: "flat_fee"}
 }
 
+// BillingInvoiceLineOrErr returns the BillingInvoiceLine value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e ChargeFlatFeeRunEdges) BillingInvoiceLineOrErr() (*BillingInvoiceLine, error) {
+	if e.BillingInvoiceLine != nil {
+		return e.BillingInvoiceLine, nil
+	} else if e.loadedTypes[1] {
+		return nil, &NotFoundError{label: billinginvoiceline.Label}
+	}
+	return nil, &NotLoadedError{edge: "billing_invoice_line"}
+}
+
+// BillingInvoiceOrErr returns the BillingInvoice value or an error if the edge
+// was not loaded in eager-loading, or loaded but was not found.
+func (e ChargeFlatFeeRunEdges) BillingInvoiceOrErr() (*BillingInvoice, error) {
+	if e.BillingInvoice != nil {
+		return e.BillingInvoice, nil
+	} else if e.loadedTypes[2] {
+		return nil, &NotFoundError{label: billinginvoice.Label}
+	}
+	return nil, &NotLoadedError{edge: "billing_invoice"}
+}
+
 // CreditAllocationsOrErr returns the CreditAllocations value or an error if the edge
 // was not loaded in eager-loading.
 func (e ChargeFlatFeeRunEdges) CreditAllocationsOrErr() ([]*ChargeFlatFeeRunCreditAllocations, error) {
-	if e.loadedTypes[1] {
+	if e.loadedTypes[3] {
 		return e.CreditAllocations, nil
 	}
 	return nil, &NotLoadedError{edge: "credit_allocations"}
@@ -104,7 +138,7 @@ func (e ChargeFlatFeeRunEdges) CreditAllocationsOrErr() ([]*ChargeFlatFeeRunCred
 // DetailedLinesOrErr returns the DetailedLines value or an error if the edge
 // was not loaded in eager-loading.
 func (e ChargeFlatFeeRunEdges) DetailedLinesOrErr() ([]*ChargeFlatFeeRunDetailedLine, error) {
-	if e.loadedTypes[2] {
+	if e.loadedTypes[4] {
 		return e.DetailedLines, nil
 	}
 	return nil, &NotLoadedError{edge: "detailed_lines"}
@@ -115,7 +149,7 @@ func (e ChargeFlatFeeRunEdges) DetailedLinesOrErr() ([]*ChargeFlatFeeRunDetailed
 func (e ChargeFlatFeeRunEdges) InvoicedUsageOrErr() (*ChargeFlatFeeRunInvoicedUsage, error) {
 	if e.InvoicedUsage != nil {
 		return e.InvoicedUsage, nil
-	} else if e.loadedTypes[3] {
+	} else if e.loadedTypes[5] {
 		return nil, &NotFoundError{label: chargeflatfeeruninvoicedusage.Label}
 	}
 	return nil, &NotLoadedError{edge: "invoiced_usage"}
@@ -126,7 +160,7 @@ func (e ChargeFlatFeeRunEdges) InvoicedUsageOrErr() (*ChargeFlatFeeRunInvoicedUs
 func (e ChargeFlatFeeRunEdges) PaymentOrErr() (*ChargeFlatFeeRunPayment, error) {
 	if e.Payment != nil {
 		return e.Payment, nil
-	} else if e.loadedTypes[4] {
+	} else if e.loadedTypes[6] {
 		return nil, &NotFoundError{label: chargeflatfeerunpayment.Label}
 	}
 	return nil, &NotLoadedError{edge: "payment"}
@@ -139,7 +173,9 @@ func (*ChargeFlatFeeRun) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case chargeflatfeerun.FieldAmount, chargeflatfeerun.FieldTaxesTotal, chargeflatfeerun.FieldTaxesInclusiveTotal, chargeflatfeerun.FieldTaxesExclusiveTotal, chargeflatfeerun.FieldChargesTotal, chargeflatfeerun.FieldDiscountsTotal, chargeflatfeerun.FieldCreditsTotal, chargeflatfeerun.FieldTotal, chargeflatfeerun.FieldAmountAfterProration:
 			values[i] = new(alpacadecimal.Decimal)
-		case chargeflatfeerun.FieldID, chargeflatfeerun.FieldNamespace, chargeflatfeerun.FieldChargeID, chargeflatfeerun.FieldType, chargeflatfeerun.FieldInitialType:
+		case chargeflatfeerun.FieldNoFiatTransactionRequired:
+			values[i] = new(sql.NullBool)
+		case chargeflatfeerun.FieldID, chargeflatfeerun.FieldNamespace, chargeflatfeerun.FieldChargeID, chargeflatfeerun.FieldType, chargeflatfeerun.FieldInitialType, chargeflatfeerun.FieldLineID, chargeflatfeerun.FieldInvoiceID:
 			values[i] = new(sql.NullString)
 		case chargeflatfeerun.FieldCreatedAt, chargeflatfeerun.FieldUpdatedAt, chargeflatfeerun.FieldDeletedAt, chargeflatfeerun.FieldServicePeriodFrom, chargeflatfeerun.FieldServicePeriodTo:
 			values[i] = new(sql.NullTime)
@@ -267,11 +303,31 @@ func (_m *ChargeFlatFeeRun) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				_m.ServicePeriodTo = value.Time
 			}
+		case chargeflatfeerun.FieldLineID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field line_id", values[i])
+			} else if value.Valid {
+				_m.LineID = new(string)
+				*_m.LineID = value.String
+			}
+		case chargeflatfeerun.FieldInvoiceID:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field invoice_id", values[i])
+			} else if value.Valid {
+				_m.InvoiceID = new(string)
+				*_m.InvoiceID = value.String
+			}
 		case chargeflatfeerun.FieldAmountAfterProration:
 			if value, ok := values[i].(*alpacadecimal.Decimal); !ok {
 				return fmt.Errorf("unexpected type %T for field amount_after_proration", values[i])
 			} else if value != nil {
 				_m.AmountAfterProration = *value
+			}
+		case chargeflatfeerun.FieldNoFiatTransactionRequired:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field no_fiat_transaction_required", values[i])
+			} else if value.Valid {
+				_m.NoFiatTransactionRequired = value.Bool
 			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
@@ -289,6 +345,16 @@ func (_m *ChargeFlatFeeRun) Value(name string) (ent.Value, error) {
 // QueryFlatFee queries the "flat_fee" edge of the ChargeFlatFeeRun entity.
 func (_m *ChargeFlatFeeRun) QueryFlatFee() *ChargeFlatFeeQuery {
 	return NewChargeFlatFeeRunClient(_m.config).QueryFlatFee(_m)
+}
+
+// QueryBillingInvoiceLine queries the "billing_invoice_line" edge of the ChargeFlatFeeRun entity.
+func (_m *ChargeFlatFeeRun) QueryBillingInvoiceLine() *BillingInvoiceLineQuery {
+	return NewChargeFlatFeeRunClient(_m.config).QueryBillingInvoiceLine(_m)
+}
+
+// QueryBillingInvoice queries the "billing_invoice" edge of the ChargeFlatFeeRun entity.
+func (_m *ChargeFlatFeeRun) QueryBillingInvoice() *BillingInvoiceQuery {
+	return NewChargeFlatFeeRunClient(_m.config).QueryBillingInvoice(_m)
 }
 
 // QueryCreditAllocations queries the "credit_allocations" edge of the ChargeFlatFeeRun entity.
@@ -387,8 +453,21 @@ func (_m *ChargeFlatFeeRun) String() string {
 	builder.WriteString("service_period_to=")
 	builder.WriteString(_m.ServicePeriodTo.Format(time.ANSIC))
 	builder.WriteString(", ")
+	if v := _m.LineID; v != nil {
+		builder.WriteString("line_id=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	if v := _m.InvoiceID; v != nil {
+		builder.WriteString("invoice_id=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
 	builder.WriteString("amount_after_proration=")
 	builder.WriteString(fmt.Sprintf("%v", _m.AmountAfterProration))
+	builder.WriteString(", ")
+	builder.WriteString("no_fiat_transaction_required=")
+	builder.WriteString(fmt.Sprintf("%v", _m.NoFiatTransactionRequired))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/openmeter/ent/db/chargeflatfeerun/chargeflatfeerun.go
+++ b/openmeter/ent/db/chargeflatfeerun/chargeflatfeerun.go
@@ -50,10 +50,20 @@ const (
 	FieldServicePeriodFrom = "service_period_from"
 	// FieldServicePeriodTo holds the string denoting the service_period_to field in the database.
 	FieldServicePeriodTo = "service_period_to"
+	// FieldLineID holds the string denoting the line_id field in the database.
+	FieldLineID = "line_id"
+	// FieldInvoiceID holds the string denoting the invoice_id field in the database.
+	FieldInvoiceID = "invoice_id"
 	// FieldAmountAfterProration holds the string denoting the amount_after_proration field in the database.
 	FieldAmountAfterProration = "amount_after_proration"
+	// FieldNoFiatTransactionRequired holds the string denoting the no_fiat_transaction_required field in the database.
+	FieldNoFiatTransactionRequired = "no_fiat_transaction_required"
 	// EdgeFlatFee holds the string denoting the flat_fee edge name in mutations.
 	EdgeFlatFee = "flat_fee"
+	// EdgeBillingInvoiceLine holds the string denoting the billing_invoice_line edge name in mutations.
+	EdgeBillingInvoiceLine = "billing_invoice_line"
+	// EdgeBillingInvoice holds the string denoting the billing_invoice edge name in mutations.
+	EdgeBillingInvoice = "billing_invoice"
 	// EdgeCreditAllocations holds the string denoting the credit_allocations edge name in mutations.
 	EdgeCreditAllocations = "credit_allocations"
 	// EdgeDetailedLines holds the string denoting the detailed_lines edge name in mutations.
@@ -71,6 +81,20 @@ const (
 	FlatFeeInverseTable = "charge_flat_fees"
 	// FlatFeeColumn is the table column denoting the flat_fee relation/edge.
 	FlatFeeColumn = "charge_id"
+	// BillingInvoiceLineTable is the table that holds the billing_invoice_line relation/edge.
+	BillingInvoiceLineTable = "charge_flat_fee_runs"
+	// BillingInvoiceLineInverseTable is the table name for the BillingInvoiceLine entity.
+	// It exists in this package in order to avoid circular dependency with the "billinginvoiceline" package.
+	BillingInvoiceLineInverseTable = "billing_invoice_lines"
+	// BillingInvoiceLineColumn is the table column denoting the billing_invoice_line relation/edge.
+	BillingInvoiceLineColumn = "line_id"
+	// BillingInvoiceTable is the table that holds the billing_invoice relation/edge.
+	BillingInvoiceTable = "charge_flat_fee_runs"
+	// BillingInvoiceInverseTable is the table name for the BillingInvoice entity.
+	// It exists in this package in order to avoid circular dependency with the "billinginvoice" package.
+	BillingInvoiceInverseTable = "billing_invoices"
+	// BillingInvoiceColumn is the table column denoting the billing_invoice relation/edge.
+	BillingInvoiceColumn = "invoice_id"
 	// CreditAllocationsTable is the table that holds the credit_allocations relation/edge.
 	CreditAllocationsTable = "charge_flat_fee_run_credit_allocations"
 	// CreditAllocationsInverseTable is the table name for the ChargeFlatFeeRunCreditAllocations entity.
@@ -121,7 +145,10 @@ var Columns = []string{
 	FieldInitialType,
 	FieldServicePeriodFrom,
 	FieldServicePeriodTo,
+	FieldLineID,
+	FieldInvoiceID,
 	FieldAmountAfterProration,
+	FieldNoFiatTransactionRequired,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -143,6 +170,10 @@ var (
 	DefaultUpdatedAt func() time.Time
 	// UpdateDefaultUpdatedAt holds the default value on update for the "updated_at" field.
 	UpdateDefaultUpdatedAt func() time.Time
+	// LineIDValidator is a validator for the "line_id" field. It is called by the builders before save.
+	LineIDValidator func(string) error
+	// InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
+	InvoiceIDValidator func(string) error
 	// DefaultID holds the default value on creation for the "id" field.
 	DefaultID func() string
 )
@@ -260,15 +291,44 @@ func ByServicePeriodTo(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldServicePeriodTo, opts...).ToFunc()
 }
 
+// ByLineID orders the results by the line_id field.
+func ByLineID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldLineID, opts...).ToFunc()
+}
+
+// ByInvoiceID orders the results by the invoice_id field.
+func ByInvoiceID(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldInvoiceID, opts...).ToFunc()
+}
+
 // ByAmountAfterProration orders the results by the amount_after_proration field.
 func ByAmountAfterProration(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldAmountAfterProration, opts...).ToFunc()
+}
+
+// ByNoFiatTransactionRequired orders the results by the no_fiat_transaction_required field.
+func ByNoFiatTransactionRequired(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldNoFiatTransactionRequired, opts...).ToFunc()
 }
 
 // ByFlatFeeField orders the results by flat_fee field.
 func ByFlatFeeField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newFlatFeeStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByBillingInvoiceLineField orders the results by billing_invoice_line field.
+func ByBillingInvoiceLineField(field string, opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newBillingInvoiceLineStep(), sql.OrderByField(field, opts...))
+	}
+}
+
+// ByBillingInvoiceField orders the results by billing_invoice field.
+func ByBillingInvoiceField(field string, opts ...sql.OrderTermOption) OrderOption {
+	return func(s *sql.Selector) {
+		sqlgraph.OrderByNeighborTerms(s, newBillingInvoiceStep(), sql.OrderByField(field, opts...))
 	}
 }
 
@@ -318,6 +378,20 @@ func newFlatFeeStep() *sqlgraph.Step {
 		sqlgraph.From(Table, FieldID),
 		sqlgraph.To(FlatFeeInverseTable, FieldID),
 		sqlgraph.Edge(sqlgraph.M2O, true, FlatFeeTable, FlatFeeColumn),
+	)
+}
+func newBillingInvoiceLineStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(BillingInvoiceLineInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.O2O, true, BillingInvoiceLineTable, BillingInvoiceLineColumn),
+	)
+}
+func newBillingInvoiceStep() *sqlgraph.Step {
+	return sqlgraph.NewStep(
+		sqlgraph.From(Table, FieldID),
+		sqlgraph.To(BillingInvoiceInverseTable, FieldID),
+		sqlgraph.Edge(sqlgraph.M2O, true, BillingInvoiceTable, BillingInvoiceColumn),
 	)
 }
 func newCreditAllocationsStep() *sqlgraph.Step {

--- a/openmeter/ent/db/chargeflatfeerun/where.go
+++ b/openmeter/ent/db/chargeflatfeerun/where.go
@@ -142,9 +142,24 @@ func ServicePeriodTo(v time.Time) predicate.ChargeFlatFeeRun {
 	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldServicePeriodTo, v))
 }
 
+// LineID applies equality check predicate on the "line_id" field. It's identical to LineIDEQ.
+func LineID(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldLineID, v))
+}
+
+// InvoiceID applies equality check predicate on the "invoice_id" field. It's identical to InvoiceIDEQ.
+func InvoiceID(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldInvoiceID, v))
+}
+
 // AmountAfterProration applies equality check predicate on the "amount_after_proration" field. It's identical to AmountAfterProrationEQ.
 func AmountAfterProration(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRun {
 	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldAmountAfterProration, v))
+}
+
+// NoFiatTransactionRequired applies equality check predicate on the "no_fiat_transaction_required" field. It's identical to NoFiatTransactionRequiredEQ.
+func NoFiatTransactionRequired(v bool) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldNoFiatTransactionRequired, v))
 }
 
 // NamespaceEQ applies the EQ predicate on the "namespace" field.
@@ -867,6 +882,156 @@ func ServicePeriodToLTE(v time.Time) predicate.ChargeFlatFeeRun {
 	return predicate.ChargeFlatFeeRun(sql.FieldLTE(FieldServicePeriodTo, v))
 }
 
+// LineIDEQ applies the EQ predicate on the "line_id" field.
+func LineIDEQ(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldLineID, v))
+}
+
+// LineIDNEQ applies the NEQ predicate on the "line_id" field.
+func LineIDNEQ(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldNEQ(FieldLineID, v))
+}
+
+// LineIDIn applies the In predicate on the "line_id" field.
+func LineIDIn(vs ...string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldIn(FieldLineID, vs...))
+}
+
+// LineIDNotIn applies the NotIn predicate on the "line_id" field.
+func LineIDNotIn(vs ...string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldNotIn(FieldLineID, vs...))
+}
+
+// LineIDGT applies the GT predicate on the "line_id" field.
+func LineIDGT(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldGT(FieldLineID, v))
+}
+
+// LineIDGTE applies the GTE predicate on the "line_id" field.
+func LineIDGTE(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldGTE(FieldLineID, v))
+}
+
+// LineIDLT applies the LT predicate on the "line_id" field.
+func LineIDLT(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldLT(FieldLineID, v))
+}
+
+// LineIDLTE applies the LTE predicate on the "line_id" field.
+func LineIDLTE(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldLTE(FieldLineID, v))
+}
+
+// LineIDContains applies the Contains predicate on the "line_id" field.
+func LineIDContains(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldContains(FieldLineID, v))
+}
+
+// LineIDHasPrefix applies the HasPrefix predicate on the "line_id" field.
+func LineIDHasPrefix(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldHasPrefix(FieldLineID, v))
+}
+
+// LineIDHasSuffix applies the HasSuffix predicate on the "line_id" field.
+func LineIDHasSuffix(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldHasSuffix(FieldLineID, v))
+}
+
+// LineIDIsNil applies the IsNil predicate on the "line_id" field.
+func LineIDIsNil() predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldIsNull(FieldLineID))
+}
+
+// LineIDNotNil applies the NotNil predicate on the "line_id" field.
+func LineIDNotNil() predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldNotNull(FieldLineID))
+}
+
+// LineIDEqualFold applies the EqualFold predicate on the "line_id" field.
+func LineIDEqualFold(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldEqualFold(FieldLineID, v))
+}
+
+// LineIDContainsFold applies the ContainsFold predicate on the "line_id" field.
+func LineIDContainsFold(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldContainsFold(FieldLineID, v))
+}
+
+// InvoiceIDEQ applies the EQ predicate on the "invoice_id" field.
+func InvoiceIDEQ(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldInvoiceID, v))
+}
+
+// InvoiceIDNEQ applies the NEQ predicate on the "invoice_id" field.
+func InvoiceIDNEQ(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldNEQ(FieldInvoiceID, v))
+}
+
+// InvoiceIDIn applies the In predicate on the "invoice_id" field.
+func InvoiceIDIn(vs ...string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldIn(FieldInvoiceID, vs...))
+}
+
+// InvoiceIDNotIn applies the NotIn predicate on the "invoice_id" field.
+func InvoiceIDNotIn(vs ...string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldNotIn(FieldInvoiceID, vs...))
+}
+
+// InvoiceIDGT applies the GT predicate on the "invoice_id" field.
+func InvoiceIDGT(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldGT(FieldInvoiceID, v))
+}
+
+// InvoiceIDGTE applies the GTE predicate on the "invoice_id" field.
+func InvoiceIDGTE(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldGTE(FieldInvoiceID, v))
+}
+
+// InvoiceIDLT applies the LT predicate on the "invoice_id" field.
+func InvoiceIDLT(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldLT(FieldInvoiceID, v))
+}
+
+// InvoiceIDLTE applies the LTE predicate on the "invoice_id" field.
+func InvoiceIDLTE(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldLTE(FieldInvoiceID, v))
+}
+
+// InvoiceIDContains applies the Contains predicate on the "invoice_id" field.
+func InvoiceIDContains(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldContains(FieldInvoiceID, v))
+}
+
+// InvoiceIDHasPrefix applies the HasPrefix predicate on the "invoice_id" field.
+func InvoiceIDHasPrefix(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldHasPrefix(FieldInvoiceID, v))
+}
+
+// InvoiceIDHasSuffix applies the HasSuffix predicate on the "invoice_id" field.
+func InvoiceIDHasSuffix(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldHasSuffix(FieldInvoiceID, v))
+}
+
+// InvoiceIDIsNil applies the IsNil predicate on the "invoice_id" field.
+func InvoiceIDIsNil() predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldIsNull(FieldInvoiceID))
+}
+
+// InvoiceIDNotNil applies the NotNil predicate on the "invoice_id" field.
+func InvoiceIDNotNil() predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldNotNull(FieldInvoiceID))
+}
+
+// InvoiceIDEqualFold applies the EqualFold predicate on the "invoice_id" field.
+func InvoiceIDEqualFold(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldEqualFold(FieldInvoiceID, v))
+}
+
+// InvoiceIDContainsFold applies the ContainsFold predicate on the "invoice_id" field.
+func InvoiceIDContainsFold(v string) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldContainsFold(FieldInvoiceID, v))
+}
+
 // AmountAfterProrationEQ applies the EQ predicate on the "amount_after_proration" field.
 func AmountAfterProrationEQ(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRun {
 	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldAmountAfterProration, v))
@@ -907,6 +1072,16 @@ func AmountAfterProrationLTE(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRun
 	return predicate.ChargeFlatFeeRun(sql.FieldLTE(FieldAmountAfterProration, v))
 }
 
+// NoFiatTransactionRequiredEQ applies the EQ predicate on the "no_fiat_transaction_required" field.
+func NoFiatTransactionRequiredEQ(v bool) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldEQ(FieldNoFiatTransactionRequired, v))
+}
+
+// NoFiatTransactionRequiredNEQ applies the NEQ predicate on the "no_fiat_transaction_required" field.
+func NoFiatTransactionRequiredNEQ(v bool) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(sql.FieldNEQ(FieldNoFiatTransactionRequired, v))
+}
+
 // HasFlatFee applies the HasEdge predicate on the "flat_fee" edge.
 func HasFlatFee() predicate.ChargeFlatFeeRun {
 	return predicate.ChargeFlatFeeRun(func(s *sql.Selector) {
@@ -922,6 +1097,52 @@ func HasFlatFee() predicate.ChargeFlatFeeRun {
 func HasFlatFeeWith(preds ...predicate.ChargeFlatFee) predicate.ChargeFlatFeeRun {
 	return predicate.ChargeFlatFeeRun(func(s *sql.Selector) {
 		step := newFlatFeeStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasBillingInvoiceLine applies the HasEdge predicate on the "billing_invoice_line" edge.
+func HasBillingInvoiceLine() predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, true, BillingInvoiceLineTable, BillingInvoiceLineColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasBillingInvoiceLineWith applies the HasEdge predicate on the "billing_invoice_line" edge with a given conditions (other predicates).
+func HasBillingInvoiceLineWith(preds ...predicate.BillingInvoiceLine) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(func(s *sql.Selector) {
+		step := newBillingInvoiceLineStep()
+		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
+			for _, p := range preds {
+				p(s)
+			}
+		})
+	})
+}
+
+// HasBillingInvoice applies the HasEdge predicate on the "billing_invoice" edge.
+func HasBillingInvoice() predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(func(s *sql.Selector) {
+		step := sqlgraph.NewStep(
+			sqlgraph.From(Table, FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, BillingInvoiceTable, BillingInvoiceColumn),
+		)
+		sqlgraph.HasNeighbors(s, step)
+	})
+}
+
+// HasBillingInvoiceWith applies the HasEdge predicate on the "billing_invoice" edge with a given conditions (other predicates).
+func HasBillingInvoiceWith(preds ...predicate.BillingInvoice) predicate.ChargeFlatFeeRun {
+	return predicate.ChargeFlatFeeRun(func(s *sql.Selector) {
+		step := newBillingInvoiceStep()
 		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
 			for _, p := range preds {
 				p(s)

--- a/openmeter/ent/db/chargeflatfeerun_create.go
+++ b/openmeter/ent/db/chargeflatfeerun_create.go
@@ -14,6 +14,8 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoice"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfee"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruncreditallocations"
@@ -156,9 +158,43 @@ func (_c *ChargeFlatFeeRunCreate) SetServicePeriodTo(v time.Time) *ChargeFlatFee
 	return _c
 }
 
+// SetLineID sets the "line_id" field.
+func (_c *ChargeFlatFeeRunCreate) SetLineID(v string) *ChargeFlatFeeRunCreate {
+	_c.mutation.SetLineID(v)
+	return _c
+}
+
+// SetNillableLineID sets the "line_id" field if the given value is not nil.
+func (_c *ChargeFlatFeeRunCreate) SetNillableLineID(v *string) *ChargeFlatFeeRunCreate {
+	if v != nil {
+		_c.SetLineID(*v)
+	}
+	return _c
+}
+
+// SetInvoiceID sets the "invoice_id" field.
+func (_c *ChargeFlatFeeRunCreate) SetInvoiceID(v string) *ChargeFlatFeeRunCreate {
+	_c.mutation.SetInvoiceID(v)
+	return _c
+}
+
+// SetNillableInvoiceID sets the "invoice_id" field if the given value is not nil.
+func (_c *ChargeFlatFeeRunCreate) SetNillableInvoiceID(v *string) *ChargeFlatFeeRunCreate {
+	if v != nil {
+		_c.SetInvoiceID(*v)
+	}
+	return _c
+}
+
 // SetAmountAfterProration sets the "amount_after_proration" field.
 func (_c *ChargeFlatFeeRunCreate) SetAmountAfterProration(v alpacadecimal.Decimal) *ChargeFlatFeeRunCreate {
 	_c.mutation.SetAmountAfterProration(v)
+	return _c
+}
+
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (_c *ChargeFlatFeeRunCreate) SetNoFiatTransactionRequired(v bool) *ChargeFlatFeeRunCreate {
+	_c.mutation.SetNoFiatTransactionRequired(v)
 	return _c
 }
 
@@ -185,6 +221,44 @@ func (_c *ChargeFlatFeeRunCreate) SetFlatFeeID(id string) *ChargeFlatFeeRunCreat
 // SetFlatFee sets the "flat_fee" edge to the ChargeFlatFee entity.
 func (_c *ChargeFlatFeeRunCreate) SetFlatFee(v *ChargeFlatFee) *ChargeFlatFeeRunCreate {
 	return _c.SetFlatFeeID(v.ID)
+}
+
+// SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
+func (_c *ChargeFlatFeeRunCreate) SetBillingInvoiceLineID(id string) *ChargeFlatFeeRunCreate {
+	_c.mutation.SetBillingInvoiceLineID(id)
+	return _c
+}
+
+// SetNillableBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID if the given value is not nil.
+func (_c *ChargeFlatFeeRunCreate) SetNillableBillingInvoiceLineID(id *string) *ChargeFlatFeeRunCreate {
+	if id != nil {
+		_c = _c.SetBillingInvoiceLineID(*id)
+	}
+	return _c
+}
+
+// SetBillingInvoiceLine sets the "billing_invoice_line" edge to the BillingInvoiceLine entity.
+func (_c *ChargeFlatFeeRunCreate) SetBillingInvoiceLine(v *BillingInvoiceLine) *ChargeFlatFeeRunCreate {
+	return _c.SetBillingInvoiceLineID(v.ID)
+}
+
+// SetBillingInvoiceID sets the "billing_invoice" edge to the BillingInvoice entity by ID.
+func (_c *ChargeFlatFeeRunCreate) SetBillingInvoiceID(id string) *ChargeFlatFeeRunCreate {
+	_c.mutation.SetBillingInvoiceID(id)
+	return _c
+}
+
+// SetNillableBillingInvoiceID sets the "billing_invoice" edge to the BillingInvoice entity by ID if the given value is not nil.
+func (_c *ChargeFlatFeeRunCreate) SetNillableBillingInvoiceID(id *string) *ChargeFlatFeeRunCreate {
+	if id != nil {
+		_c = _c.SetBillingInvoiceID(*id)
+	}
+	return _c
+}
+
+// SetBillingInvoice sets the "billing_invoice" edge to the BillingInvoice entity.
+func (_c *ChargeFlatFeeRunCreate) SetBillingInvoice(v *BillingInvoice) *ChargeFlatFeeRunCreate {
+	return _c.SetBillingInvoiceID(v.ID)
 }
 
 // AddCreditAllocationIDs adds the "credit_allocations" edge to the ChargeFlatFeeRunCreditAllocations entity by IDs.
@@ -369,8 +443,21 @@ func (_c *ChargeFlatFeeRunCreate) check() error {
 	if _, ok := _c.mutation.ServicePeriodTo(); !ok {
 		return &ValidationError{Name: "service_period_to", err: errors.New(`db: missing required field "ChargeFlatFeeRun.service_period_to"`)}
 	}
+	if v, ok := _c.mutation.LineID(); ok {
+		if err := chargeflatfeerun.LineIDValidator(v); err != nil {
+			return &ValidationError{Name: "line_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRun.line_id": %w`, err)}
+		}
+	}
+	if v, ok := _c.mutation.InvoiceID(); ok {
+		if err := chargeflatfeerun.InvoiceIDValidator(v); err != nil {
+			return &ValidationError{Name: "invoice_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRun.invoice_id": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.AmountAfterProration(); !ok {
 		return &ValidationError{Name: "amount_after_proration", err: errors.New(`db: missing required field "ChargeFlatFeeRun.amount_after_proration"`)}
+	}
+	if _, ok := _c.mutation.NoFiatTransactionRequired(); !ok {
+		return &ValidationError{Name: "no_fiat_transaction_required", err: errors.New(`db: missing required field "ChargeFlatFeeRun.no_fiat_transaction_required"`)}
 	}
 	if len(_c.mutation.FlatFeeIDs()) == 0 {
 		return &ValidationError{Name: "flat_fee", err: errors.New(`db: missing required edge "ChargeFlatFeeRun.flat_fee"`)}
@@ -479,6 +566,10 @@ func (_c *ChargeFlatFeeRunCreate) createSpec() (*ChargeFlatFeeRun, *sqlgraph.Cre
 		_spec.SetField(chargeflatfeerun.FieldAmountAfterProration, field.TypeOther, value)
 		_node.AmountAfterProration = value
 	}
+	if value, ok := _c.mutation.NoFiatTransactionRequired(); ok {
+		_spec.SetField(chargeflatfeerun.FieldNoFiatTransactionRequired, field.TypeBool, value)
+		_node.NoFiatTransactionRequired = value
+	}
 	if nodes := _c.mutation.FlatFeeIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -494,6 +585,40 @@ func (_c *ChargeFlatFeeRunCreate) createSpec() (*ChargeFlatFeeRun, *sqlgraph.Cre
 			edge.Target.Nodes = append(edge.Target.Nodes, k)
 		}
 		_node.ChargeID = nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.BillingInvoiceLineIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: true,
+			Table:   chargeflatfeerun.BillingInvoiceLineTable,
+			Columns: []string{chargeflatfeerun.BillingInvoiceLineColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billinginvoiceline.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.LineID = &nodes[0]
+		_spec.Edges = append(_spec.Edges, edge)
+	}
+	if nodes := _c.mutation.BillingInvoiceIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeflatfeerun.BillingInvoiceTable,
+			Columns: []string{chargeflatfeerun.BillingInvoiceColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billinginvoice.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_node.InvoiceID = &nodes[0]
 		_spec.Edges = append(_spec.Edges, edge)
 	}
 	if nodes := _c.mutation.CreditAllocationsIDs(); len(nodes) > 0 {
@@ -774,6 +899,42 @@ func (u *ChargeFlatFeeRunUpsert) UpdateServicePeriodTo() *ChargeFlatFeeRunUpsert
 	return u
 }
 
+// SetLineID sets the "line_id" field.
+func (u *ChargeFlatFeeRunUpsert) SetLineID(v string) *ChargeFlatFeeRunUpsert {
+	u.Set(chargeflatfeerun.FieldLineID, v)
+	return u
+}
+
+// UpdateLineID sets the "line_id" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsert) UpdateLineID() *ChargeFlatFeeRunUpsert {
+	u.SetExcluded(chargeflatfeerun.FieldLineID)
+	return u
+}
+
+// ClearLineID clears the value of the "line_id" field.
+func (u *ChargeFlatFeeRunUpsert) ClearLineID() *ChargeFlatFeeRunUpsert {
+	u.SetNull(chargeflatfeerun.FieldLineID)
+	return u
+}
+
+// SetInvoiceID sets the "invoice_id" field.
+func (u *ChargeFlatFeeRunUpsert) SetInvoiceID(v string) *ChargeFlatFeeRunUpsert {
+	u.Set(chargeflatfeerun.FieldInvoiceID, v)
+	return u
+}
+
+// UpdateInvoiceID sets the "invoice_id" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsert) UpdateInvoiceID() *ChargeFlatFeeRunUpsert {
+	u.SetExcluded(chargeflatfeerun.FieldInvoiceID)
+	return u
+}
+
+// ClearInvoiceID clears the value of the "invoice_id" field.
+func (u *ChargeFlatFeeRunUpsert) ClearInvoiceID() *ChargeFlatFeeRunUpsert {
+	u.SetNull(chargeflatfeerun.FieldInvoiceID)
+	return u
+}
+
 // SetAmountAfterProration sets the "amount_after_proration" field.
 func (u *ChargeFlatFeeRunUpsert) SetAmountAfterProration(v alpacadecimal.Decimal) *ChargeFlatFeeRunUpsert {
 	u.Set(chargeflatfeerun.FieldAmountAfterProration, v)
@@ -783,6 +944,18 @@ func (u *ChargeFlatFeeRunUpsert) SetAmountAfterProration(v alpacadecimal.Decimal
 // UpdateAmountAfterProration sets the "amount_after_proration" field to the value that was provided on create.
 func (u *ChargeFlatFeeRunUpsert) UpdateAmountAfterProration() *ChargeFlatFeeRunUpsert {
 	u.SetExcluded(chargeflatfeerun.FieldAmountAfterProration)
+	return u
+}
+
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (u *ChargeFlatFeeRunUpsert) SetNoFiatTransactionRequired(v bool) *ChargeFlatFeeRunUpsert {
+	u.Set(chargeflatfeerun.FieldNoFiatTransactionRequired, v)
+	return u
+}
+
+// UpdateNoFiatTransactionRequired sets the "no_fiat_transaction_required" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsert) UpdateNoFiatTransactionRequired() *ChargeFlatFeeRunUpsert {
+	u.SetExcluded(chargeflatfeerun.FieldNoFiatTransactionRequired)
 	return u
 }
 
@@ -1035,6 +1208,48 @@ func (u *ChargeFlatFeeRunUpsertOne) UpdateServicePeriodTo() *ChargeFlatFeeRunUps
 	})
 }
 
+// SetLineID sets the "line_id" field.
+func (u *ChargeFlatFeeRunUpsertOne) SetLineID(v string) *ChargeFlatFeeRunUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.SetLineID(v)
+	})
+}
+
+// UpdateLineID sets the "line_id" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsertOne) UpdateLineID() *ChargeFlatFeeRunUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.UpdateLineID()
+	})
+}
+
+// ClearLineID clears the value of the "line_id" field.
+func (u *ChargeFlatFeeRunUpsertOne) ClearLineID() *ChargeFlatFeeRunUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.ClearLineID()
+	})
+}
+
+// SetInvoiceID sets the "invoice_id" field.
+func (u *ChargeFlatFeeRunUpsertOne) SetInvoiceID(v string) *ChargeFlatFeeRunUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.SetInvoiceID(v)
+	})
+}
+
+// UpdateInvoiceID sets the "invoice_id" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsertOne) UpdateInvoiceID() *ChargeFlatFeeRunUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.UpdateInvoiceID()
+	})
+}
+
+// ClearInvoiceID clears the value of the "invoice_id" field.
+func (u *ChargeFlatFeeRunUpsertOne) ClearInvoiceID() *ChargeFlatFeeRunUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.ClearInvoiceID()
+	})
+}
+
 // SetAmountAfterProration sets the "amount_after_proration" field.
 func (u *ChargeFlatFeeRunUpsertOne) SetAmountAfterProration(v alpacadecimal.Decimal) *ChargeFlatFeeRunUpsertOne {
 	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
@@ -1046,6 +1261,20 @@ func (u *ChargeFlatFeeRunUpsertOne) SetAmountAfterProration(v alpacadecimal.Deci
 func (u *ChargeFlatFeeRunUpsertOne) UpdateAmountAfterProration() *ChargeFlatFeeRunUpsertOne {
 	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
 		s.UpdateAmountAfterProration()
+	})
+}
+
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (u *ChargeFlatFeeRunUpsertOne) SetNoFiatTransactionRequired(v bool) *ChargeFlatFeeRunUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.SetNoFiatTransactionRequired(v)
+	})
+}
+
+// UpdateNoFiatTransactionRequired sets the "no_fiat_transaction_required" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsertOne) UpdateNoFiatTransactionRequired() *ChargeFlatFeeRunUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.UpdateNoFiatTransactionRequired()
 	})
 }
 
@@ -1465,6 +1694,48 @@ func (u *ChargeFlatFeeRunUpsertBulk) UpdateServicePeriodTo() *ChargeFlatFeeRunUp
 	})
 }
 
+// SetLineID sets the "line_id" field.
+func (u *ChargeFlatFeeRunUpsertBulk) SetLineID(v string) *ChargeFlatFeeRunUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.SetLineID(v)
+	})
+}
+
+// UpdateLineID sets the "line_id" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsertBulk) UpdateLineID() *ChargeFlatFeeRunUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.UpdateLineID()
+	})
+}
+
+// ClearLineID clears the value of the "line_id" field.
+func (u *ChargeFlatFeeRunUpsertBulk) ClearLineID() *ChargeFlatFeeRunUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.ClearLineID()
+	})
+}
+
+// SetInvoiceID sets the "invoice_id" field.
+func (u *ChargeFlatFeeRunUpsertBulk) SetInvoiceID(v string) *ChargeFlatFeeRunUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.SetInvoiceID(v)
+	})
+}
+
+// UpdateInvoiceID sets the "invoice_id" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsertBulk) UpdateInvoiceID() *ChargeFlatFeeRunUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.UpdateInvoiceID()
+	})
+}
+
+// ClearInvoiceID clears the value of the "invoice_id" field.
+func (u *ChargeFlatFeeRunUpsertBulk) ClearInvoiceID() *ChargeFlatFeeRunUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.ClearInvoiceID()
+	})
+}
+
 // SetAmountAfterProration sets the "amount_after_proration" field.
 func (u *ChargeFlatFeeRunUpsertBulk) SetAmountAfterProration(v alpacadecimal.Decimal) *ChargeFlatFeeRunUpsertBulk {
 	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
@@ -1476,6 +1747,20 @@ func (u *ChargeFlatFeeRunUpsertBulk) SetAmountAfterProration(v alpacadecimal.Dec
 func (u *ChargeFlatFeeRunUpsertBulk) UpdateAmountAfterProration() *ChargeFlatFeeRunUpsertBulk {
 	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
 		s.UpdateAmountAfterProration()
+	})
+}
+
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (u *ChargeFlatFeeRunUpsertBulk) SetNoFiatTransactionRequired(v bool) *ChargeFlatFeeRunUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.SetNoFiatTransactionRequired(v)
+	})
+}
+
+// UpdateNoFiatTransactionRequired sets the "no_fiat_transaction_required" field to the value that was provided on create.
+func (u *ChargeFlatFeeRunUpsertBulk) UpdateNoFiatTransactionRequired() *ChargeFlatFeeRunUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeRunUpsert) {
+		s.UpdateNoFiatTransactionRequired()
 	})
 }
 

--- a/openmeter/ent/db/chargeflatfeerun_query.go
+++ b/openmeter/ent/db/chargeflatfeerun_query.go
@@ -13,6 +13,8 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoice"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfee"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruncreditallocations"
@@ -25,16 +27,18 @@ import (
 // ChargeFlatFeeRunQuery is the builder for querying ChargeFlatFeeRun entities.
 type ChargeFlatFeeRunQuery struct {
 	config
-	ctx                   *QueryContext
-	order                 []chargeflatfeerun.OrderOption
-	inters                []Interceptor
-	predicates            []predicate.ChargeFlatFeeRun
-	withFlatFee           *ChargeFlatFeeQuery
-	withCreditAllocations *ChargeFlatFeeRunCreditAllocationsQuery
-	withDetailedLines     *ChargeFlatFeeRunDetailedLineQuery
-	withInvoicedUsage     *ChargeFlatFeeRunInvoicedUsageQuery
-	withPayment           *ChargeFlatFeeRunPaymentQuery
-	modifiers             []func(*sql.Selector)
+	ctx                    *QueryContext
+	order                  []chargeflatfeerun.OrderOption
+	inters                 []Interceptor
+	predicates             []predicate.ChargeFlatFeeRun
+	withFlatFee            *ChargeFlatFeeQuery
+	withBillingInvoiceLine *BillingInvoiceLineQuery
+	withBillingInvoice     *BillingInvoiceQuery
+	withCreditAllocations  *ChargeFlatFeeRunCreditAllocationsQuery
+	withDetailedLines      *ChargeFlatFeeRunDetailedLineQuery
+	withInvoicedUsage      *ChargeFlatFeeRunInvoicedUsageQuery
+	withPayment            *ChargeFlatFeeRunPaymentQuery
+	modifiers              []func(*sql.Selector)
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -86,6 +90,50 @@ func (_q *ChargeFlatFeeRunQuery) QueryFlatFee() *ChargeFlatFeeQuery {
 			sqlgraph.From(chargeflatfeerun.Table, chargeflatfeerun.FieldID, selector),
 			sqlgraph.To(chargeflatfee.Table, chargeflatfee.FieldID),
 			sqlgraph.Edge(sqlgraph.M2O, true, chargeflatfeerun.FlatFeeTable, chargeflatfeerun.FlatFeeColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryBillingInvoiceLine chains the current query on the "billing_invoice_line" edge.
+func (_q *ChargeFlatFeeRunQuery) QueryBillingInvoiceLine() *BillingInvoiceLineQuery {
+	query := (&BillingInvoiceLineClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeflatfeerun.Table, chargeflatfeerun.FieldID, selector),
+			sqlgraph.To(billinginvoiceline.Table, billinginvoiceline.FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, true, chargeflatfeerun.BillingInvoiceLineTable, chargeflatfeerun.BillingInvoiceLineColumn),
+		)
+		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
+		return fromU, nil
+	}
+	return query
+}
+
+// QueryBillingInvoice chains the current query on the "billing_invoice" edge.
+func (_q *ChargeFlatFeeRunQuery) QueryBillingInvoice() *BillingInvoiceQuery {
+	query := (&BillingInvoiceClient{config: _q.config}).Query()
+	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
+		if err := _q.prepareQuery(ctx); err != nil {
+			return nil, err
+		}
+		selector := _q.sqlQuery(ctx)
+		if err := selector.Err(); err != nil {
+			return nil, err
+		}
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeflatfeerun.Table, chargeflatfeerun.FieldID, selector),
+			sqlgraph.To(billinginvoice.Table, billinginvoice.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, chargeflatfeerun.BillingInvoiceTable, chargeflatfeerun.BillingInvoiceColumn),
 		)
 		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
 		return fromU, nil
@@ -368,16 +416,18 @@ func (_q *ChargeFlatFeeRunQuery) Clone() *ChargeFlatFeeRunQuery {
 		return nil
 	}
 	return &ChargeFlatFeeRunQuery{
-		config:                _q.config,
-		ctx:                   _q.ctx.Clone(),
-		order:                 append([]chargeflatfeerun.OrderOption{}, _q.order...),
-		inters:                append([]Interceptor{}, _q.inters...),
-		predicates:            append([]predicate.ChargeFlatFeeRun{}, _q.predicates...),
-		withFlatFee:           _q.withFlatFee.Clone(),
-		withCreditAllocations: _q.withCreditAllocations.Clone(),
-		withDetailedLines:     _q.withDetailedLines.Clone(),
-		withInvoicedUsage:     _q.withInvoicedUsage.Clone(),
-		withPayment:           _q.withPayment.Clone(),
+		config:                 _q.config,
+		ctx:                    _q.ctx.Clone(),
+		order:                  append([]chargeflatfeerun.OrderOption{}, _q.order...),
+		inters:                 append([]Interceptor{}, _q.inters...),
+		predicates:             append([]predicate.ChargeFlatFeeRun{}, _q.predicates...),
+		withFlatFee:            _q.withFlatFee.Clone(),
+		withBillingInvoiceLine: _q.withBillingInvoiceLine.Clone(),
+		withBillingInvoice:     _q.withBillingInvoice.Clone(),
+		withCreditAllocations:  _q.withCreditAllocations.Clone(),
+		withDetailedLines:      _q.withDetailedLines.Clone(),
+		withInvoicedUsage:      _q.withInvoicedUsage.Clone(),
+		withPayment:            _q.withPayment.Clone(),
 		// clone intermediate query.
 		sql:  _q.sql.Clone(),
 		path: _q.path,
@@ -392,6 +442,28 @@ func (_q *ChargeFlatFeeRunQuery) WithFlatFee(opts ...func(*ChargeFlatFeeQuery)) 
 		opt(query)
 	}
 	_q.withFlatFee = query
+	return _q
+}
+
+// WithBillingInvoiceLine tells the query-builder to eager-load the nodes that are connected to
+// the "billing_invoice_line" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *ChargeFlatFeeRunQuery) WithBillingInvoiceLine(opts ...func(*BillingInvoiceLineQuery)) *ChargeFlatFeeRunQuery {
+	query := (&BillingInvoiceLineClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withBillingInvoiceLine = query
+	return _q
+}
+
+// WithBillingInvoice tells the query-builder to eager-load the nodes that are connected to
+// the "billing_invoice" edge. The optional arguments are used to configure the query builder of the edge.
+func (_q *ChargeFlatFeeRunQuery) WithBillingInvoice(opts ...func(*BillingInvoiceQuery)) *ChargeFlatFeeRunQuery {
+	query := (&BillingInvoiceClient{config: _q.config}).Query()
+	for _, opt := range opts {
+		opt(query)
+	}
+	_q.withBillingInvoice = query
 	return _q
 }
 
@@ -517,8 +589,10 @@ func (_q *ChargeFlatFeeRunQuery) sqlAll(ctx context.Context, hooks ...queryHook)
 	var (
 		nodes       = []*ChargeFlatFeeRun{}
 		_spec       = _q.querySpec()
-		loadedTypes = [5]bool{
+		loadedTypes = [7]bool{
 			_q.withFlatFee != nil,
+			_q.withBillingInvoiceLine != nil,
+			_q.withBillingInvoice != nil,
 			_q.withCreditAllocations != nil,
 			_q.withDetailedLines != nil,
 			_q.withInvoicedUsage != nil,
@@ -549,6 +623,18 @@ func (_q *ChargeFlatFeeRunQuery) sqlAll(ctx context.Context, hooks ...queryHook)
 	if query := _q.withFlatFee; query != nil {
 		if err := _q.loadFlatFee(ctx, query, nodes, nil,
 			func(n *ChargeFlatFeeRun, e *ChargeFlatFee) { n.Edges.FlatFee = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withBillingInvoiceLine; query != nil {
+		if err := _q.loadBillingInvoiceLine(ctx, query, nodes, nil,
+			func(n *ChargeFlatFeeRun, e *BillingInvoiceLine) { n.Edges.BillingInvoiceLine = e }); err != nil {
+			return nil, err
+		}
+	}
+	if query := _q.withBillingInvoice; query != nil {
+		if err := _q.loadBillingInvoice(ctx, query, nodes, nil,
+			func(n *ChargeFlatFeeRun, e *BillingInvoice) { n.Edges.BillingInvoice = e }); err != nil {
 			return nil, err
 		}
 	}
@@ -607,6 +693,70 @@ func (_q *ChargeFlatFeeRunQuery) loadFlatFee(ctx context.Context, query *ChargeF
 		nodes, ok := nodeids[n.ID]
 		if !ok {
 			return fmt.Errorf(`unexpected foreign-key "charge_id" returned %v`, n.ID)
+		}
+		for i := range nodes {
+			assign(nodes[i], n)
+		}
+	}
+	return nil
+}
+func (_q *ChargeFlatFeeRunQuery) loadBillingInvoiceLine(ctx context.Context, query *BillingInvoiceLineQuery, nodes []*ChargeFlatFeeRun, init func(*ChargeFlatFeeRun), assign func(*ChargeFlatFeeRun, *BillingInvoiceLine)) error {
+	ids := make([]string, 0, len(nodes))
+	nodeids := make(map[string][]*ChargeFlatFeeRun)
+	for i := range nodes {
+		if nodes[i].LineID == nil {
+			continue
+		}
+		fk := *nodes[i].LineID
+		if _, ok := nodeids[fk]; !ok {
+			ids = append(ids, fk)
+		}
+		nodeids[fk] = append(nodeids[fk], nodes[i])
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	query.Where(billinginvoiceline.IDIn(ids...))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nodeids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected foreign-key "line_id" returned %v`, n.ID)
+		}
+		for i := range nodes {
+			assign(nodes[i], n)
+		}
+	}
+	return nil
+}
+func (_q *ChargeFlatFeeRunQuery) loadBillingInvoice(ctx context.Context, query *BillingInvoiceQuery, nodes []*ChargeFlatFeeRun, init func(*ChargeFlatFeeRun), assign func(*ChargeFlatFeeRun, *BillingInvoice)) error {
+	ids := make([]string, 0, len(nodes))
+	nodeids := make(map[string][]*ChargeFlatFeeRun)
+	for i := range nodes {
+		if nodes[i].InvoiceID == nil {
+			continue
+		}
+		fk := *nodes[i].InvoiceID
+		if _, ok := nodeids[fk]; !ok {
+			ids = append(ids, fk)
+		}
+		nodeids[fk] = append(nodeids[fk], nodes[i])
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	query.Where(billinginvoice.IDIn(ids...))
+	neighbors, err := query.All(ctx)
+	if err != nil {
+		return err
+	}
+	for _, n := range neighbors {
+		nodes, ok := nodeids[n.ID]
+		if !ok {
+			return fmt.Errorf(`unexpected foreign-key "invoice_id" returned %v`, n.ID)
 		}
 		for i := range nodes {
 			assign(nodes[i], n)
@@ -759,6 +909,12 @@ func (_q *ChargeFlatFeeRunQuery) querySpec() *sqlgraph.QuerySpec {
 		}
 		if _q.withFlatFee != nil {
 			_spec.Node.AddColumnOnce(chargeflatfeerun.FieldChargeID)
+		}
+		if _q.withBillingInvoiceLine != nil {
+			_spec.Node.AddColumnOnce(chargeflatfeerun.FieldLineID)
+		}
+		if _q.withBillingInvoice != nil {
+			_spec.Node.AddColumnOnce(chargeflatfeerun.FieldInvoiceID)
 		}
 	}
 	if ps := _q.predicates; len(ps) > 0 {

--- a/openmeter/ent/db/chargeflatfeerun_update.go
+++ b/openmeter/ent/db/chargeflatfeerun_update.go
@@ -13,6 +13,8 @@ import (
 	"entgo.io/ent/schema/field"
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoice"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruncreditallocations"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerundetailedline"
@@ -214,6 +216,46 @@ func (_u *ChargeFlatFeeRunUpdate) SetNillableServicePeriodTo(v *time.Time) *Char
 	return _u
 }
 
+// SetLineID sets the "line_id" field.
+func (_u *ChargeFlatFeeRunUpdate) SetLineID(v string) *ChargeFlatFeeRunUpdate {
+	_u.mutation.SetLineID(v)
+	return _u
+}
+
+// SetNillableLineID sets the "line_id" field if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdate) SetNillableLineID(v *string) *ChargeFlatFeeRunUpdate {
+	if v != nil {
+		_u.SetLineID(*v)
+	}
+	return _u
+}
+
+// ClearLineID clears the value of the "line_id" field.
+func (_u *ChargeFlatFeeRunUpdate) ClearLineID() *ChargeFlatFeeRunUpdate {
+	_u.mutation.ClearLineID()
+	return _u
+}
+
+// SetInvoiceID sets the "invoice_id" field.
+func (_u *ChargeFlatFeeRunUpdate) SetInvoiceID(v string) *ChargeFlatFeeRunUpdate {
+	_u.mutation.SetInvoiceID(v)
+	return _u
+}
+
+// SetNillableInvoiceID sets the "invoice_id" field if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdate) SetNillableInvoiceID(v *string) *ChargeFlatFeeRunUpdate {
+	if v != nil {
+		_u.SetInvoiceID(*v)
+	}
+	return _u
+}
+
+// ClearInvoiceID clears the value of the "invoice_id" field.
+func (_u *ChargeFlatFeeRunUpdate) ClearInvoiceID() *ChargeFlatFeeRunUpdate {
+	_u.mutation.ClearInvoiceID()
+	return _u
+}
+
 // SetAmountAfterProration sets the "amount_after_proration" field.
 func (_u *ChargeFlatFeeRunUpdate) SetAmountAfterProration(v alpacadecimal.Decimal) *ChargeFlatFeeRunUpdate {
 	_u.mutation.SetAmountAfterProration(v)
@@ -226,6 +268,58 @@ func (_u *ChargeFlatFeeRunUpdate) SetNillableAmountAfterProration(v *alpacadecim
 		_u.SetAmountAfterProration(*v)
 	}
 	return _u
+}
+
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (_u *ChargeFlatFeeRunUpdate) SetNoFiatTransactionRequired(v bool) *ChargeFlatFeeRunUpdate {
+	_u.mutation.SetNoFiatTransactionRequired(v)
+	return _u
+}
+
+// SetNillableNoFiatTransactionRequired sets the "no_fiat_transaction_required" field if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdate) SetNillableNoFiatTransactionRequired(v *bool) *ChargeFlatFeeRunUpdate {
+	if v != nil {
+		_u.SetNoFiatTransactionRequired(*v)
+	}
+	return _u
+}
+
+// SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
+func (_u *ChargeFlatFeeRunUpdate) SetBillingInvoiceLineID(id string) *ChargeFlatFeeRunUpdate {
+	_u.mutation.SetBillingInvoiceLineID(id)
+	return _u
+}
+
+// SetNillableBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdate) SetNillableBillingInvoiceLineID(id *string) *ChargeFlatFeeRunUpdate {
+	if id != nil {
+		_u = _u.SetBillingInvoiceLineID(*id)
+	}
+	return _u
+}
+
+// SetBillingInvoiceLine sets the "billing_invoice_line" edge to the BillingInvoiceLine entity.
+func (_u *ChargeFlatFeeRunUpdate) SetBillingInvoiceLine(v *BillingInvoiceLine) *ChargeFlatFeeRunUpdate {
+	return _u.SetBillingInvoiceLineID(v.ID)
+}
+
+// SetBillingInvoiceID sets the "billing_invoice" edge to the BillingInvoice entity by ID.
+func (_u *ChargeFlatFeeRunUpdate) SetBillingInvoiceID(id string) *ChargeFlatFeeRunUpdate {
+	_u.mutation.SetBillingInvoiceID(id)
+	return _u
+}
+
+// SetNillableBillingInvoiceID sets the "billing_invoice" edge to the BillingInvoice entity by ID if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdate) SetNillableBillingInvoiceID(id *string) *ChargeFlatFeeRunUpdate {
+	if id != nil {
+		_u = _u.SetBillingInvoiceID(*id)
+	}
+	return _u
+}
+
+// SetBillingInvoice sets the "billing_invoice" edge to the BillingInvoice entity.
+func (_u *ChargeFlatFeeRunUpdate) SetBillingInvoice(v *BillingInvoice) *ChargeFlatFeeRunUpdate {
+	return _u.SetBillingInvoiceID(v.ID)
 }
 
 // AddCreditAllocationIDs adds the "credit_allocations" edge to the ChargeFlatFeeRunCreditAllocations entity by IDs.
@@ -299,6 +393,18 @@ func (_u *ChargeFlatFeeRunUpdate) SetPayment(v *ChargeFlatFeeRunPayment) *Charge
 // Mutation returns the ChargeFlatFeeRunMutation object of the builder.
 func (_u *ChargeFlatFeeRunUpdate) Mutation() *ChargeFlatFeeRunMutation {
 	return _u.mutation
+}
+
+// ClearBillingInvoiceLine clears the "billing_invoice_line" edge to the BillingInvoiceLine entity.
+func (_u *ChargeFlatFeeRunUpdate) ClearBillingInvoiceLine() *ChargeFlatFeeRunUpdate {
+	_u.mutation.ClearBillingInvoiceLine()
+	return _u
+}
+
+// ClearBillingInvoice clears the "billing_invoice" edge to the BillingInvoice entity.
+func (_u *ChargeFlatFeeRunUpdate) ClearBillingInvoice() *ChargeFlatFeeRunUpdate {
+	_u.mutation.ClearBillingInvoice()
+	return _u
 }
 
 // ClearCreditAllocations clears all "credit_allocations" edges to the ChargeFlatFeeRunCreditAllocations entity.
@@ -398,6 +504,16 @@ func (_u *ChargeFlatFeeRunUpdate) check() error {
 			return &ValidationError{Name: "type", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRun.type": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.LineID(); ok {
+		if err := chargeflatfeerun.LineIDValidator(v); err != nil {
+			return &ValidationError{Name: "line_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRun.line_id": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.InvoiceID(); ok {
+		if err := chargeflatfeerun.InvoiceIDValidator(v); err != nil {
+			return &ValidationError{Name: "invoice_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRun.invoice_id": %w`, err)}
+		}
+	}
 	if _u.mutation.FlatFeeCleared() && len(_u.mutation.FlatFeeIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "ChargeFlatFeeRun.flat_fee"`)
 	}
@@ -460,6 +576,67 @@ func (_u *ChargeFlatFeeRunUpdate) sqlSave(ctx context.Context) (_node int, err e
 	}
 	if value, ok := _u.mutation.AmountAfterProration(); ok {
 		_spec.SetField(chargeflatfeerun.FieldAmountAfterProration, field.TypeOther, value)
+	}
+	if value, ok := _u.mutation.NoFiatTransactionRequired(); ok {
+		_spec.SetField(chargeflatfeerun.FieldNoFiatTransactionRequired, field.TypeBool, value)
+	}
+	if _u.mutation.BillingInvoiceLineCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: true,
+			Table:   chargeflatfeerun.BillingInvoiceLineTable,
+			Columns: []string{chargeflatfeerun.BillingInvoiceLineColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billinginvoiceline.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.BillingInvoiceLineIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: true,
+			Table:   chargeflatfeerun.BillingInvoiceLineTable,
+			Columns: []string{chargeflatfeerun.BillingInvoiceLineColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billinginvoiceline.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.BillingInvoiceCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeflatfeerun.BillingInvoiceTable,
+			Columns: []string{chargeflatfeerun.BillingInvoiceColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billinginvoice.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.BillingInvoiceIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeflatfeerun.BillingInvoiceTable,
+			Columns: []string{chargeflatfeerun.BillingInvoiceColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billinginvoice.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if _u.mutation.CreditAllocationsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -809,6 +986,46 @@ func (_u *ChargeFlatFeeRunUpdateOne) SetNillableServicePeriodTo(v *time.Time) *C
 	return _u
 }
 
+// SetLineID sets the "line_id" field.
+func (_u *ChargeFlatFeeRunUpdateOne) SetLineID(v string) *ChargeFlatFeeRunUpdateOne {
+	_u.mutation.SetLineID(v)
+	return _u
+}
+
+// SetNillableLineID sets the "line_id" field if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdateOne) SetNillableLineID(v *string) *ChargeFlatFeeRunUpdateOne {
+	if v != nil {
+		_u.SetLineID(*v)
+	}
+	return _u
+}
+
+// ClearLineID clears the value of the "line_id" field.
+func (_u *ChargeFlatFeeRunUpdateOne) ClearLineID() *ChargeFlatFeeRunUpdateOne {
+	_u.mutation.ClearLineID()
+	return _u
+}
+
+// SetInvoiceID sets the "invoice_id" field.
+func (_u *ChargeFlatFeeRunUpdateOne) SetInvoiceID(v string) *ChargeFlatFeeRunUpdateOne {
+	_u.mutation.SetInvoiceID(v)
+	return _u
+}
+
+// SetNillableInvoiceID sets the "invoice_id" field if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdateOne) SetNillableInvoiceID(v *string) *ChargeFlatFeeRunUpdateOne {
+	if v != nil {
+		_u.SetInvoiceID(*v)
+	}
+	return _u
+}
+
+// ClearInvoiceID clears the value of the "invoice_id" field.
+func (_u *ChargeFlatFeeRunUpdateOne) ClearInvoiceID() *ChargeFlatFeeRunUpdateOne {
+	_u.mutation.ClearInvoiceID()
+	return _u
+}
+
 // SetAmountAfterProration sets the "amount_after_proration" field.
 func (_u *ChargeFlatFeeRunUpdateOne) SetAmountAfterProration(v alpacadecimal.Decimal) *ChargeFlatFeeRunUpdateOne {
 	_u.mutation.SetAmountAfterProration(v)
@@ -821,6 +1038,58 @@ func (_u *ChargeFlatFeeRunUpdateOne) SetNillableAmountAfterProration(v *alpacade
 		_u.SetAmountAfterProration(*v)
 	}
 	return _u
+}
+
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (_u *ChargeFlatFeeRunUpdateOne) SetNoFiatTransactionRequired(v bool) *ChargeFlatFeeRunUpdateOne {
+	_u.mutation.SetNoFiatTransactionRequired(v)
+	return _u
+}
+
+// SetNillableNoFiatTransactionRequired sets the "no_fiat_transaction_required" field if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdateOne) SetNillableNoFiatTransactionRequired(v *bool) *ChargeFlatFeeRunUpdateOne {
+	if v != nil {
+		_u.SetNoFiatTransactionRequired(*v)
+	}
+	return _u
+}
+
+// SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
+func (_u *ChargeFlatFeeRunUpdateOne) SetBillingInvoiceLineID(id string) *ChargeFlatFeeRunUpdateOne {
+	_u.mutation.SetBillingInvoiceLineID(id)
+	return _u
+}
+
+// SetNillableBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdateOne) SetNillableBillingInvoiceLineID(id *string) *ChargeFlatFeeRunUpdateOne {
+	if id != nil {
+		_u = _u.SetBillingInvoiceLineID(*id)
+	}
+	return _u
+}
+
+// SetBillingInvoiceLine sets the "billing_invoice_line" edge to the BillingInvoiceLine entity.
+func (_u *ChargeFlatFeeRunUpdateOne) SetBillingInvoiceLine(v *BillingInvoiceLine) *ChargeFlatFeeRunUpdateOne {
+	return _u.SetBillingInvoiceLineID(v.ID)
+}
+
+// SetBillingInvoiceID sets the "billing_invoice" edge to the BillingInvoice entity by ID.
+func (_u *ChargeFlatFeeRunUpdateOne) SetBillingInvoiceID(id string) *ChargeFlatFeeRunUpdateOne {
+	_u.mutation.SetBillingInvoiceID(id)
+	return _u
+}
+
+// SetNillableBillingInvoiceID sets the "billing_invoice" edge to the BillingInvoice entity by ID if the given value is not nil.
+func (_u *ChargeFlatFeeRunUpdateOne) SetNillableBillingInvoiceID(id *string) *ChargeFlatFeeRunUpdateOne {
+	if id != nil {
+		_u = _u.SetBillingInvoiceID(*id)
+	}
+	return _u
+}
+
+// SetBillingInvoice sets the "billing_invoice" edge to the BillingInvoice entity.
+func (_u *ChargeFlatFeeRunUpdateOne) SetBillingInvoice(v *BillingInvoice) *ChargeFlatFeeRunUpdateOne {
+	return _u.SetBillingInvoiceID(v.ID)
 }
 
 // AddCreditAllocationIDs adds the "credit_allocations" edge to the ChargeFlatFeeRunCreditAllocations entity by IDs.
@@ -894,6 +1163,18 @@ func (_u *ChargeFlatFeeRunUpdateOne) SetPayment(v *ChargeFlatFeeRunPayment) *Cha
 // Mutation returns the ChargeFlatFeeRunMutation object of the builder.
 func (_u *ChargeFlatFeeRunUpdateOne) Mutation() *ChargeFlatFeeRunMutation {
 	return _u.mutation
+}
+
+// ClearBillingInvoiceLine clears the "billing_invoice_line" edge to the BillingInvoiceLine entity.
+func (_u *ChargeFlatFeeRunUpdateOne) ClearBillingInvoiceLine() *ChargeFlatFeeRunUpdateOne {
+	_u.mutation.ClearBillingInvoiceLine()
+	return _u
+}
+
+// ClearBillingInvoice clears the "billing_invoice" edge to the BillingInvoice entity.
+func (_u *ChargeFlatFeeRunUpdateOne) ClearBillingInvoice() *ChargeFlatFeeRunUpdateOne {
+	_u.mutation.ClearBillingInvoice()
+	return _u
 }
 
 // ClearCreditAllocations clears all "credit_allocations" edges to the ChargeFlatFeeRunCreditAllocations entity.
@@ -1006,6 +1287,16 @@ func (_u *ChargeFlatFeeRunUpdateOne) check() error {
 			return &ValidationError{Name: "type", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRun.type": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.LineID(); ok {
+		if err := chargeflatfeerun.LineIDValidator(v); err != nil {
+			return &ValidationError{Name: "line_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRun.line_id": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.InvoiceID(); ok {
+		if err := chargeflatfeerun.InvoiceIDValidator(v); err != nil {
+			return &ValidationError{Name: "invoice_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRun.invoice_id": %w`, err)}
+		}
+	}
 	if _u.mutation.FlatFeeCleared() && len(_u.mutation.FlatFeeIDs()) > 0 {
 		return errors.New(`db: clearing a required unique edge "ChargeFlatFeeRun.flat_fee"`)
 	}
@@ -1085,6 +1376,67 @@ func (_u *ChargeFlatFeeRunUpdateOne) sqlSave(ctx context.Context) (_node *Charge
 	}
 	if value, ok := _u.mutation.AmountAfterProration(); ok {
 		_spec.SetField(chargeflatfeerun.FieldAmountAfterProration, field.TypeOther, value)
+	}
+	if value, ok := _u.mutation.NoFiatTransactionRequired(); ok {
+		_spec.SetField(chargeflatfeerun.FieldNoFiatTransactionRequired, field.TypeBool, value)
+	}
+	if _u.mutation.BillingInvoiceLineCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: true,
+			Table:   chargeflatfeerun.BillingInvoiceLineTable,
+			Columns: []string{chargeflatfeerun.BillingInvoiceLineColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billinginvoiceline.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.BillingInvoiceLineIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.O2O,
+			Inverse: true,
+			Table:   chargeflatfeerun.BillingInvoiceLineTable,
+			Columns: []string{chargeflatfeerun.BillingInvoiceLineColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billinginvoiceline.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.BillingInvoiceCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeflatfeerun.BillingInvoiceTable,
+			Columns: []string{chargeflatfeerun.BillingInvoiceColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billinginvoice.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.BillingInvoiceIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeflatfeerun.BillingInvoiceTable,
+			Columns: []string{chargeflatfeerun.BillingInvoiceColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(billinginvoice.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	if _u.mutation.CreditAllocationsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/openmeter/ent/db/chargeflatfeeruninvoicedusage.go
+++ b/openmeter/ent/db/chargeflatfeeruninvoicedusage.go
@@ -11,7 +11,6 @@ import (
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruninvoicedusage"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -22,14 +21,10 @@ type ChargeFlatFeeRunInvoicedUsage struct {
 	config `json:"-"`
 	// ID of the ent.
 	ID string `json:"id,omitempty"`
-	// LineID holds the value of the "line_id" field.
-	LineID *string `json:"line_id,omitempty"`
 	// ServicePeriodFrom holds the value of the "service_period_from" field.
 	ServicePeriodFrom time.Time `json:"service_period_from,omitempty"`
 	// ServicePeriodTo holds the value of the "service_period_to" field.
 	ServicePeriodTo time.Time `json:"service_period_to,omitempty"`
-	// Mutable holds the value of the "mutable" field.
-	Mutable bool `json:"mutable,omitempty"`
 	// LedgerTransactionGroupID holds the value of the "ledger_transaction_group_id" field.
 	LedgerTransactionGroupID *string `json:"ledger_transaction_group_id,omitempty"`
 	// Namespace holds the value of the "namespace" field.
@@ -68,24 +63,11 @@ type ChargeFlatFeeRunInvoicedUsage struct {
 
 // ChargeFlatFeeRunInvoicedUsageEdges holds the relations/edges for other nodes in the graph.
 type ChargeFlatFeeRunInvoicedUsageEdges struct {
-	// BillingInvoiceLine holds the value of the billing_invoice_line edge.
-	BillingInvoiceLine *BillingInvoiceLine `json:"billing_invoice_line,omitempty"`
 	// Run holds the value of the run edge.
 	Run *ChargeFlatFeeRun `json:"run,omitempty"`
 	// loadedTypes holds the information for reporting if a
 	// type was loaded (or requested) in eager-loading or not.
-	loadedTypes [2]bool
-}
-
-// BillingInvoiceLineOrErr returns the BillingInvoiceLine value or an error if the edge
-// was not loaded in eager-loading, or loaded but was not found.
-func (e ChargeFlatFeeRunInvoicedUsageEdges) BillingInvoiceLineOrErr() (*BillingInvoiceLine, error) {
-	if e.BillingInvoiceLine != nil {
-		return e.BillingInvoiceLine, nil
-	} else if e.loadedTypes[0] {
-		return nil, &NotFoundError{label: billinginvoiceline.Label}
-	}
-	return nil, &NotLoadedError{edge: "billing_invoice_line"}
+	loadedTypes [1]bool
 }
 
 // RunOrErr returns the Run value or an error if the edge
@@ -93,7 +75,7 @@ func (e ChargeFlatFeeRunInvoicedUsageEdges) BillingInvoiceLineOrErr() (*BillingI
 func (e ChargeFlatFeeRunInvoicedUsageEdges) RunOrErr() (*ChargeFlatFeeRun, error) {
 	if e.Run != nil {
 		return e.Run, nil
-	} else if e.loadedTypes[1] {
+	} else if e.loadedTypes[0] {
 		return nil, &NotFoundError{label: chargeflatfeerun.Label}
 	}
 	return nil, &NotLoadedError{edge: "run"}
@@ -108,9 +90,7 @@ func (*ChargeFlatFeeRunInvoicedUsage) scanValues(columns []string) ([]any, error
 			values[i] = new([]byte)
 		case chargeflatfeeruninvoicedusage.FieldAmount, chargeflatfeeruninvoicedusage.FieldTaxesTotal, chargeflatfeeruninvoicedusage.FieldTaxesInclusiveTotal, chargeflatfeeruninvoicedusage.FieldTaxesExclusiveTotal, chargeflatfeeruninvoicedusage.FieldChargesTotal, chargeflatfeeruninvoicedusage.FieldDiscountsTotal, chargeflatfeeruninvoicedusage.FieldCreditsTotal, chargeflatfeeruninvoicedusage.FieldTotal:
 			values[i] = new(alpacadecimal.Decimal)
-		case chargeflatfeeruninvoicedusage.FieldMutable:
-			values[i] = new(sql.NullBool)
-		case chargeflatfeeruninvoicedusage.FieldID, chargeflatfeeruninvoicedusage.FieldLineID, chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID, chargeflatfeeruninvoicedusage.FieldNamespace, chargeflatfeeruninvoicedusage.FieldRunID:
+		case chargeflatfeeruninvoicedusage.FieldID, chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID, chargeflatfeeruninvoicedusage.FieldNamespace, chargeflatfeeruninvoicedusage.FieldRunID:
 			values[i] = new(sql.NullString)
 		case chargeflatfeeruninvoicedusage.FieldServicePeriodFrom, chargeflatfeeruninvoicedusage.FieldServicePeriodTo, chargeflatfeeruninvoicedusage.FieldCreatedAt, chargeflatfeeruninvoicedusage.FieldUpdatedAt, chargeflatfeeruninvoicedusage.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -135,13 +115,6 @@ func (_m *ChargeFlatFeeRunInvoicedUsage) assignValues(columns []string, values [
 			} else if value.Valid {
 				_m.ID = value.String
 			}
-		case chargeflatfeeruninvoicedusage.FieldLineID:
-			if value, ok := values[i].(*sql.NullString); !ok {
-				return fmt.Errorf("unexpected type %T for field line_id", values[i])
-			} else if value.Valid {
-				_m.LineID = new(string)
-				*_m.LineID = value.String
-			}
 		case chargeflatfeeruninvoicedusage.FieldServicePeriodFrom:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field service_period_from", values[i])
@@ -153,12 +126,6 @@ func (_m *ChargeFlatFeeRunInvoicedUsage) assignValues(columns []string, values [
 				return fmt.Errorf("unexpected type %T for field service_period_to", values[i])
 			} else if value.Valid {
 				_m.ServicePeriodTo = value.Time
-			}
-		case chargeflatfeeruninvoicedusage.FieldMutable:
-			if value, ok := values[i].(*sql.NullBool); !ok {
-				return fmt.Errorf("unexpected type %T for field mutable", values[i])
-			} else if value.Valid {
-				_m.Mutable = value.Bool
 			}
 		case chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -267,11 +234,6 @@ func (_m *ChargeFlatFeeRunInvoicedUsage) Value(name string) (ent.Value, error) {
 	return _m.selectValues.Get(name)
 }
 
-// QueryBillingInvoiceLine queries the "billing_invoice_line" edge of the ChargeFlatFeeRunInvoicedUsage entity.
-func (_m *ChargeFlatFeeRunInvoicedUsage) QueryBillingInvoiceLine() *BillingInvoiceLineQuery {
-	return NewChargeFlatFeeRunInvoicedUsageClient(_m.config).QueryBillingInvoiceLine(_m)
-}
-
 // QueryRun queries the "run" edge of the ChargeFlatFeeRunInvoicedUsage entity.
 func (_m *ChargeFlatFeeRunInvoicedUsage) QueryRun() *ChargeFlatFeeRunQuery {
 	return NewChargeFlatFeeRunInvoicedUsageClient(_m.config).QueryRun(_m)
@@ -300,19 +262,11 @@ func (_m *ChargeFlatFeeRunInvoicedUsage) String() string {
 	var builder strings.Builder
 	builder.WriteString("ChargeFlatFeeRunInvoicedUsage(")
 	builder.WriteString(fmt.Sprintf("id=%v, ", _m.ID))
-	if v := _m.LineID; v != nil {
-		builder.WriteString("line_id=")
-		builder.WriteString(*v)
-	}
-	builder.WriteString(", ")
 	builder.WriteString("service_period_from=")
 	builder.WriteString(_m.ServicePeriodFrom.Format(time.ANSIC))
 	builder.WriteString(", ")
 	builder.WriteString("service_period_to=")
 	builder.WriteString(_m.ServicePeriodTo.Format(time.ANSIC))
-	builder.WriteString(", ")
-	builder.WriteString("mutable=")
-	builder.WriteString(fmt.Sprintf("%v", _m.Mutable))
 	builder.WriteString(", ")
 	if v := _m.LedgerTransactionGroupID; v != nil {
 		builder.WriteString("ledger_transaction_group_id=")

--- a/openmeter/ent/db/chargeflatfeeruninvoicedusage/chargeflatfeeruninvoicedusage.go
+++ b/openmeter/ent/db/chargeflatfeeruninvoicedusage/chargeflatfeeruninvoicedusage.go
@@ -14,14 +14,10 @@ const (
 	Label = "charge_flat_fee_run_invoiced_usage"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
-	// FieldLineID holds the string denoting the line_id field in the database.
-	FieldLineID = "line_id"
 	// FieldServicePeriodFrom holds the string denoting the service_period_from field in the database.
 	FieldServicePeriodFrom = "service_period_from"
 	// FieldServicePeriodTo holds the string denoting the service_period_to field in the database.
 	FieldServicePeriodTo = "service_period_to"
-	// FieldMutable holds the string denoting the mutable field in the database.
-	FieldMutable = "mutable"
 	// FieldLedgerTransactionGroupID holds the string denoting the ledger_transaction_group_id field in the database.
 	FieldLedgerTransactionGroupID = "ledger_transaction_group_id"
 	// FieldNamespace holds the string denoting the namespace field in the database.
@@ -52,19 +48,10 @@ const (
 	FieldTotal = "total"
 	// FieldRunID holds the string denoting the run_id field in the database.
 	FieldRunID = "run_id"
-	// EdgeBillingInvoiceLine holds the string denoting the billing_invoice_line edge name in mutations.
-	EdgeBillingInvoiceLine = "billing_invoice_line"
 	// EdgeRun holds the string denoting the run edge name in mutations.
 	EdgeRun = "run"
 	// Table holds the table name of the chargeflatfeeruninvoicedusage in the database.
 	Table = "charge_flat_fee_run_invoiced_usages"
-	// BillingInvoiceLineTable is the table that holds the billing_invoice_line relation/edge.
-	BillingInvoiceLineTable = "charge_flat_fee_run_invoiced_usages"
-	// BillingInvoiceLineInverseTable is the table name for the BillingInvoiceLine entity.
-	// It exists in this package in order to avoid circular dependency with the "billinginvoiceline" package.
-	BillingInvoiceLineInverseTable = "billing_invoice_lines"
-	// BillingInvoiceLineColumn is the table column denoting the billing_invoice_line relation/edge.
-	BillingInvoiceLineColumn = "line_id"
 	// RunTable is the table that holds the run relation/edge.
 	RunTable = "charge_flat_fee_run_invoiced_usages"
 	// RunInverseTable is the table name for the ChargeFlatFeeRun entity.
@@ -77,10 +64,8 @@ const (
 // Columns holds all SQL columns for chargeflatfeeruninvoicedusage fields.
 var Columns = []string{
 	FieldID,
-	FieldLineID,
 	FieldServicePeriodFrom,
 	FieldServicePeriodTo,
-	FieldMutable,
 	FieldLedgerTransactionGroupID,
 	FieldNamespace,
 	FieldCreatedAt,
@@ -109,8 +94,6 @@ func ValidColumn(column string) bool {
 }
 
 var (
-	// LineIDValidator is a validator for the "line_id" field. It is called by the builders before save.
-	LineIDValidator func(string) error
 	// LedgerTransactionGroupIDValidator is a validator for the "ledger_transaction_group_id" field. It is called by the builders before save.
 	LedgerTransactionGroupIDValidator func(string) error
 	// NamespaceValidator is a validator for the "namespace" field. It is called by the builders before save.
@@ -133,11 +116,6 @@ func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
-// ByLineID orders the results by the line_id field.
-func ByLineID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldLineID, opts...).ToFunc()
-}
-
 // ByServicePeriodFrom orders the results by the service_period_from field.
 func ByServicePeriodFrom(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldServicePeriodFrom, opts...).ToFunc()
@@ -146,11 +124,6 @@ func ByServicePeriodFrom(opts ...sql.OrderTermOption) OrderOption {
 // ByServicePeriodTo orders the results by the service_period_to field.
 func ByServicePeriodTo(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldServicePeriodTo, opts...).ToFunc()
-}
-
-// ByMutable orders the results by the mutable field.
-func ByMutable(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldMutable, opts...).ToFunc()
 }
 
 // ByLedgerTransactionGroupID orders the results by the ledger_transaction_group_id field.
@@ -223,25 +196,11 @@ func ByRunID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldRunID, opts...).ToFunc()
 }
 
-// ByBillingInvoiceLineField orders the results by billing_invoice_line field.
-func ByBillingInvoiceLineField(field string, opts ...sql.OrderTermOption) OrderOption {
-	return func(s *sql.Selector) {
-		sqlgraph.OrderByNeighborTerms(s, newBillingInvoiceLineStep(), sql.OrderByField(field, opts...))
-	}
-}
-
 // ByRunField orders the results by run field.
 func ByRunField(field string, opts ...sql.OrderTermOption) OrderOption {
 	return func(s *sql.Selector) {
 		sqlgraph.OrderByNeighborTerms(s, newRunStep(), sql.OrderByField(field, opts...))
 	}
-}
-func newBillingInvoiceLineStep() *sqlgraph.Step {
-	return sqlgraph.NewStep(
-		sqlgraph.From(Table, FieldID),
-		sqlgraph.To(BillingInvoiceLineInverseTable, FieldID),
-		sqlgraph.Edge(sqlgraph.M2O, true, BillingInvoiceLineTable, BillingInvoiceLineColumn),
-	)
 }
 func newRunStep() *sqlgraph.Step {
 	return sqlgraph.NewStep(

--- a/openmeter/ent/db/chargeflatfeeruninvoicedusage/where.go
+++ b/openmeter/ent/db/chargeflatfeeruninvoicedusage/where.go
@@ -66,11 +66,6 @@ func IDContainsFold(id string) predicate.ChargeFlatFeeRunInvoicedUsage {
 	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldContainsFold(FieldID, id))
 }
 
-// LineID applies equality check predicate on the "line_id" field. It's identical to LineIDEQ.
-func LineID(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldEQ(FieldLineID, v))
-}
-
 // ServicePeriodFrom applies equality check predicate on the "service_period_from" field. It's identical to ServicePeriodFromEQ.
 func ServicePeriodFrom(v time.Time) predicate.ChargeFlatFeeRunInvoicedUsage {
 	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldEQ(FieldServicePeriodFrom, v))
@@ -79,11 +74,6 @@ func ServicePeriodFrom(v time.Time) predicate.ChargeFlatFeeRunInvoicedUsage {
 // ServicePeriodTo applies equality check predicate on the "service_period_to" field. It's identical to ServicePeriodToEQ.
 func ServicePeriodTo(v time.Time) predicate.ChargeFlatFeeRunInvoicedUsage {
 	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldEQ(FieldServicePeriodTo, v))
-}
-
-// Mutable applies equality check predicate on the "mutable" field. It's identical to MutableEQ.
-func Mutable(v bool) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldEQ(FieldMutable, v))
 }
 
 // LedgerTransactionGroupID applies equality check predicate on the "ledger_transaction_group_id" field. It's identical to LedgerTransactionGroupIDEQ.
@@ -154,81 +144,6 @@ func Total(v alpacadecimal.Decimal) predicate.ChargeFlatFeeRunInvoicedUsage {
 // RunID applies equality check predicate on the "run_id" field. It's identical to RunIDEQ.
 func RunID(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
 	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldEQ(FieldRunID, v))
-}
-
-// LineIDEQ applies the EQ predicate on the "line_id" field.
-func LineIDEQ(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldEQ(FieldLineID, v))
-}
-
-// LineIDNEQ applies the NEQ predicate on the "line_id" field.
-func LineIDNEQ(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldNEQ(FieldLineID, v))
-}
-
-// LineIDIn applies the In predicate on the "line_id" field.
-func LineIDIn(vs ...string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldIn(FieldLineID, vs...))
-}
-
-// LineIDNotIn applies the NotIn predicate on the "line_id" field.
-func LineIDNotIn(vs ...string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldNotIn(FieldLineID, vs...))
-}
-
-// LineIDGT applies the GT predicate on the "line_id" field.
-func LineIDGT(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldGT(FieldLineID, v))
-}
-
-// LineIDGTE applies the GTE predicate on the "line_id" field.
-func LineIDGTE(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldGTE(FieldLineID, v))
-}
-
-// LineIDLT applies the LT predicate on the "line_id" field.
-func LineIDLT(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldLT(FieldLineID, v))
-}
-
-// LineIDLTE applies the LTE predicate on the "line_id" field.
-func LineIDLTE(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldLTE(FieldLineID, v))
-}
-
-// LineIDContains applies the Contains predicate on the "line_id" field.
-func LineIDContains(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldContains(FieldLineID, v))
-}
-
-// LineIDHasPrefix applies the HasPrefix predicate on the "line_id" field.
-func LineIDHasPrefix(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldHasPrefix(FieldLineID, v))
-}
-
-// LineIDHasSuffix applies the HasSuffix predicate on the "line_id" field.
-func LineIDHasSuffix(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldHasSuffix(FieldLineID, v))
-}
-
-// LineIDIsNil applies the IsNil predicate on the "line_id" field.
-func LineIDIsNil() predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldIsNull(FieldLineID))
-}
-
-// LineIDNotNil applies the NotNil predicate on the "line_id" field.
-func LineIDNotNil() predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldNotNull(FieldLineID))
-}
-
-// LineIDEqualFold applies the EqualFold predicate on the "line_id" field.
-func LineIDEqualFold(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldEqualFold(FieldLineID, v))
-}
-
-// LineIDContainsFold applies the ContainsFold predicate on the "line_id" field.
-func LineIDContainsFold(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldContainsFold(FieldLineID, v))
 }
 
 // ServicePeriodFromEQ applies the EQ predicate on the "service_period_from" field.
@@ -309,16 +224,6 @@ func ServicePeriodToLT(v time.Time) predicate.ChargeFlatFeeRunInvoicedUsage {
 // ServicePeriodToLTE applies the LTE predicate on the "service_period_to" field.
 func ServicePeriodToLTE(v time.Time) predicate.ChargeFlatFeeRunInvoicedUsage {
 	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldLTE(FieldServicePeriodTo, v))
-}
-
-// MutableEQ applies the EQ predicate on the "mutable" field.
-func MutableEQ(v bool) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldEQ(FieldMutable, v))
-}
-
-// MutableNEQ applies the NEQ predicate on the "mutable" field.
-func MutableNEQ(v bool) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldNEQ(FieldMutable, v))
 }
 
 // LedgerTransactionGroupIDEQ applies the EQ predicate on the "ledger_transaction_group_id" field.
@@ -984,29 +889,6 @@ func RunIDEqualFold(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
 // RunIDContainsFold applies the ContainsFold predicate on the "run_id" field.
 func RunIDContainsFold(v string) predicate.ChargeFlatFeeRunInvoicedUsage {
 	return predicate.ChargeFlatFeeRunInvoicedUsage(sql.FieldContainsFold(FieldRunID, v))
-}
-
-// HasBillingInvoiceLine applies the HasEdge predicate on the "billing_invoice_line" edge.
-func HasBillingInvoiceLine() predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(func(s *sql.Selector) {
-		step := sqlgraph.NewStep(
-			sqlgraph.From(Table, FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, BillingInvoiceLineTable, BillingInvoiceLineColumn),
-		)
-		sqlgraph.HasNeighbors(s, step)
-	})
-}
-
-// HasBillingInvoiceLineWith applies the HasEdge predicate on the "billing_invoice_line" edge with a given conditions (other predicates).
-func HasBillingInvoiceLineWith(preds ...predicate.BillingInvoiceLine) predicate.ChargeFlatFeeRunInvoicedUsage {
-	return predicate.ChargeFlatFeeRunInvoicedUsage(func(s *sql.Selector) {
-		step := newBillingInvoiceLineStep()
-		sqlgraph.HasNeighborsWith(s, step, func(s *sql.Selector) {
-			for _, p := range preds {
-				p(s)
-			}
-		})
-	})
 }
 
 // HasRun applies the HasEdge predicate on the "run" edge.

--- a/openmeter/ent/db/chargeflatfeeruninvoicedusage_create.go
+++ b/openmeter/ent/db/chargeflatfeeruninvoicedusage_create.go
@@ -13,7 +13,6 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruninvoicedusage"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -27,20 +26,6 @@ type ChargeFlatFeeRunInvoicedUsageCreate struct {
 	conflict []sql.ConflictOption
 }
 
-// SetLineID sets the "line_id" field.
-func (_c *ChargeFlatFeeRunInvoicedUsageCreate) SetLineID(v string) *ChargeFlatFeeRunInvoicedUsageCreate {
-	_c.mutation.SetLineID(v)
-	return _c
-}
-
-// SetNillableLineID sets the "line_id" field if the given value is not nil.
-func (_c *ChargeFlatFeeRunInvoicedUsageCreate) SetNillableLineID(v *string) *ChargeFlatFeeRunInvoicedUsageCreate {
-	if v != nil {
-		_c.SetLineID(*v)
-	}
-	return _c
-}
-
 // SetServicePeriodFrom sets the "service_period_from" field.
 func (_c *ChargeFlatFeeRunInvoicedUsageCreate) SetServicePeriodFrom(v time.Time) *ChargeFlatFeeRunInvoicedUsageCreate {
 	_c.mutation.SetServicePeriodFrom(v)
@@ -50,12 +35,6 @@ func (_c *ChargeFlatFeeRunInvoicedUsageCreate) SetServicePeriodFrom(v time.Time)
 // SetServicePeriodTo sets the "service_period_to" field.
 func (_c *ChargeFlatFeeRunInvoicedUsageCreate) SetServicePeriodTo(v time.Time) *ChargeFlatFeeRunInvoicedUsageCreate {
 	_c.mutation.SetServicePeriodTo(v)
-	return _c
-}
-
-// SetMutable sets the "mutable" field.
-func (_c *ChargeFlatFeeRunInvoicedUsageCreate) SetMutable(v bool) *ChargeFlatFeeRunInvoicedUsageCreate {
-	_c.mutation.SetMutable(v)
 	return _c
 }
 
@@ -195,25 +174,6 @@ func (_c *ChargeFlatFeeRunInvoicedUsageCreate) SetNillableID(v *string) *ChargeF
 	return _c
 }
 
-// SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
-func (_c *ChargeFlatFeeRunInvoicedUsageCreate) SetBillingInvoiceLineID(id string) *ChargeFlatFeeRunInvoicedUsageCreate {
-	_c.mutation.SetBillingInvoiceLineID(id)
-	return _c
-}
-
-// SetNillableBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID if the given value is not nil.
-func (_c *ChargeFlatFeeRunInvoicedUsageCreate) SetNillableBillingInvoiceLineID(id *string) *ChargeFlatFeeRunInvoicedUsageCreate {
-	if id != nil {
-		_c = _c.SetBillingInvoiceLineID(*id)
-	}
-	return _c
-}
-
-// SetBillingInvoiceLine sets the "billing_invoice_line" edge to the BillingInvoiceLine entity.
-func (_c *ChargeFlatFeeRunInvoicedUsageCreate) SetBillingInvoiceLine(v *BillingInvoiceLine) *ChargeFlatFeeRunInvoicedUsageCreate {
-	return _c.SetBillingInvoiceLineID(v.ID)
-}
-
 // SetRun sets the "run" edge to the ChargeFlatFeeRun entity.
 func (_c *ChargeFlatFeeRunInvoicedUsageCreate) SetRun(v *ChargeFlatFeeRun) *ChargeFlatFeeRunInvoicedUsageCreate {
 	return _c.SetRunID(v.ID)
@@ -270,19 +230,11 @@ func (_c *ChargeFlatFeeRunInvoicedUsageCreate) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (_c *ChargeFlatFeeRunInvoicedUsageCreate) check() error {
-	if v, ok := _c.mutation.LineID(); ok {
-		if err := chargeflatfeeruninvoicedusage.LineIDValidator(v); err != nil {
-			return &ValidationError{Name: "line_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRunInvoicedUsage.line_id": %w`, err)}
-		}
-	}
 	if _, ok := _c.mutation.ServicePeriodFrom(); !ok {
 		return &ValidationError{Name: "service_period_from", err: errors.New(`db: missing required field "ChargeFlatFeeRunInvoicedUsage.service_period_from"`)}
 	}
 	if _, ok := _c.mutation.ServicePeriodTo(); !ok {
 		return &ValidationError{Name: "service_period_to", err: errors.New(`db: missing required field "ChargeFlatFeeRunInvoicedUsage.service_period_to"`)}
-	}
-	if _, ok := _c.mutation.Mutable(); !ok {
-		return &ValidationError{Name: "mutable", err: errors.New(`db: missing required field "ChargeFlatFeeRunInvoicedUsage.mutable"`)}
 	}
 	if v, ok := _c.mutation.LedgerTransactionGroupID(); ok {
 		if err := chargeflatfeeruninvoicedusage.LedgerTransactionGroupIDValidator(v); err != nil {
@@ -377,10 +329,6 @@ func (_c *ChargeFlatFeeRunInvoicedUsageCreate) createSpec() (*ChargeFlatFeeRunIn
 		_spec.SetField(chargeflatfeeruninvoicedusage.FieldServicePeriodTo, field.TypeTime, value)
 		_node.ServicePeriodTo = value
 	}
-	if value, ok := _c.mutation.Mutable(); ok {
-		_spec.SetField(chargeflatfeeruninvoicedusage.FieldMutable, field.TypeBool, value)
-		_node.Mutable = value
-	}
 	if value, ok := _c.mutation.LedgerTransactionGroupID(); ok {
 		_spec.SetField(chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID, field.TypeString, value)
 		_node.LedgerTransactionGroupID = &value
@@ -437,23 +385,6 @@ func (_c *ChargeFlatFeeRunInvoicedUsageCreate) createSpec() (*ChargeFlatFeeRunIn
 		_spec.SetField(chargeflatfeeruninvoicedusage.FieldTotal, field.TypeOther, value)
 		_node.Total = value
 	}
-	if nodes := _c.mutation.BillingInvoiceLineIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   chargeflatfeeruninvoicedusage.BillingInvoiceLineTable,
-			Columns: []string{chargeflatfeeruninvoicedusage.BillingInvoiceLineColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(billinginvoiceline.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_node.LineID = &nodes[0]
-		_spec.Edges = append(_spec.Edges, edge)
-	}
 	if nodes := _c.mutation.RunIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.O2O,
@@ -478,7 +409,7 @@ func (_c *ChargeFlatFeeRunInvoicedUsageCreate) createSpec() (*ChargeFlatFeeRunIn
 // of the `INSERT` statement. For example:
 //
 //	client.ChargeFlatFeeRunInvoicedUsage.Create().
-//		SetLineID(v).
+//		SetServicePeriodFrom(v).
 //		OnConflict(
 //			// Update the row with the new values
 //			// the was proposed for insertion.
@@ -487,7 +418,7 @@ func (_c *ChargeFlatFeeRunInvoicedUsageCreate) createSpec() (*ChargeFlatFeeRunIn
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.ChargeFlatFeeRunInvoicedUsageUpsert) {
-//			SetLineID(v+v).
+//			SetServicePeriodFrom(v+v).
 //		}).
 //		Exec(ctx)
 func (_c *ChargeFlatFeeRunInvoicedUsageCreate) OnConflict(opts ...sql.ConflictOption) *ChargeFlatFeeRunInvoicedUsageUpsertOne {
@@ -523,24 +454,6 @@ type (
 	}
 )
 
-// SetLineID sets the "line_id" field.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsert) SetLineID(v string) *ChargeFlatFeeRunInvoicedUsageUpsert {
-	u.Set(chargeflatfeeruninvoicedusage.FieldLineID, v)
-	return u
-}
-
-// UpdateLineID sets the "line_id" field to the value that was provided on create.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsert) UpdateLineID() *ChargeFlatFeeRunInvoicedUsageUpsert {
-	u.SetExcluded(chargeflatfeeruninvoicedusage.FieldLineID)
-	return u
-}
-
-// ClearLineID clears the value of the "line_id" field.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsert) ClearLineID() *ChargeFlatFeeRunInvoicedUsageUpsert {
-	u.SetNull(chargeflatfeeruninvoicedusage.FieldLineID)
-	return u
-}
-
 // SetServicePeriodFrom sets the "service_period_from" field.
 func (u *ChargeFlatFeeRunInvoicedUsageUpsert) SetServicePeriodFrom(v time.Time) *ChargeFlatFeeRunInvoicedUsageUpsert {
 	u.Set(chargeflatfeeruninvoicedusage.FieldServicePeriodFrom, v)
@@ -562,18 +475,6 @@ func (u *ChargeFlatFeeRunInvoicedUsageUpsert) SetServicePeriodTo(v time.Time) *C
 // UpdateServicePeriodTo sets the "service_period_to" field to the value that was provided on create.
 func (u *ChargeFlatFeeRunInvoicedUsageUpsert) UpdateServicePeriodTo() *ChargeFlatFeeRunInvoicedUsageUpsert {
 	u.SetExcluded(chargeflatfeeruninvoicedusage.FieldServicePeriodTo)
-	return u
-}
-
-// SetMutable sets the "mutable" field.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsert) SetMutable(v bool) *ChargeFlatFeeRunInvoicedUsageUpsert {
-	u.Set(chargeflatfeeruninvoicedusage.FieldMutable, v)
-	return u
-}
-
-// UpdateMutable sets the "mutable" field to the value that was provided on create.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsert) UpdateMutable() *ChargeFlatFeeRunInvoicedUsageUpsert {
-	u.SetExcluded(chargeflatfeeruninvoicedusage.FieldMutable)
 	return u
 }
 
@@ -796,27 +697,6 @@ func (u *ChargeFlatFeeRunInvoicedUsageUpsertOne) Update(set func(*ChargeFlatFeeR
 	return u
 }
 
-// SetLineID sets the "line_id" field.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsertOne) SetLineID(v string) *ChargeFlatFeeRunInvoicedUsageUpsertOne {
-	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
-		s.SetLineID(v)
-	})
-}
-
-// UpdateLineID sets the "line_id" field to the value that was provided on create.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsertOne) UpdateLineID() *ChargeFlatFeeRunInvoicedUsageUpsertOne {
-	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
-		s.UpdateLineID()
-	})
-}
-
-// ClearLineID clears the value of the "line_id" field.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsertOne) ClearLineID() *ChargeFlatFeeRunInvoicedUsageUpsertOne {
-	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
-		s.ClearLineID()
-	})
-}
-
 // SetServicePeriodFrom sets the "service_period_from" field.
 func (u *ChargeFlatFeeRunInvoicedUsageUpsertOne) SetServicePeriodFrom(v time.Time) *ChargeFlatFeeRunInvoicedUsageUpsertOne {
 	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
@@ -842,20 +722,6 @@ func (u *ChargeFlatFeeRunInvoicedUsageUpsertOne) SetServicePeriodTo(v time.Time)
 func (u *ChargeFlatFeeRunInvoicedUsageUpsertOne) UpdateServicePeriodTo() *ChargeFlatFeeRunInvoicedUsageUpsertOne {
 	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
 		s.UpdateServicePeriodTo()
-	})
-}
-
-// SetMutable sets the "mutable" field.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsertOne) SetMutable(v bool) *ChargeFlatFeeRunInvoicedUsageUpsertOne {
-	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
-		s.SetMutable(v)
-	})
-}
-
-// UpdateMutable sets the "mutable" field to the value that was provided on create.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsertOne) UpdateMutable() *ChargeFlatFeeRunInvoicedUsageUpsertOne {
-	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
-		s.UpdateMutable()
 	})
 }
 
@@ -1184,7 +1050,7 @@ func (_c *ChargeFlatFeeRunInvoicedUsageCreateBulk) ExecX(ctx context.Context) {
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.ChargeFlatFeeRunInvoicedUsageUpsert) {
-//			SetLineID(v+v).
+//			SetServicePeriodFrom(v+v).
 //		}).
 //		Exec(ctx)
 func (_c *ChargeFlatFeeRunInvoicedUsageCreateBulk) OnConflict(opts ...sql.ConflictOption) *ChargeFlatFeeRunInvoicedUsageUpsertBulk {
@@ -1272,27 +1138,6 @@ func (u *ChargeFlatFeeRunInvoicedUsageUpsertBulk) Update(set func(*ChargeFlatFee
 	return u
 }
 
-// SetLineID sets the "line_id" field.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsertBulk) SetLineID(v string) *ChargeFlatFeeRunInvoicedUsageUpsertBulk {
-	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
-		s.SetLineID(v)
-	})
-}
-
-// UpdateLineID sets the "line_id" field to the value that was provided on create.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsertBulk) UpdateLineID() *ChargeFlatFeeRunInvoicedUsageUpsertBulk {
-	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
-		s.UpdateLineID()
-	})
-}
-
-// ClearLineID clears the value of the "line_id" field.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsertBulk) ClearLineID() *ChargeFlatFeeRunInvoicedUsageUpsertBulk {
-	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
-		s.ClearLineID()
-	})
-}
-
 // SetServicePeriodFrom sets the "service_period_from" field.
 func (u *ChargeFlatFeeRunInvoicedUsageUpsertBulk) SetServicePeriodFrom(v time.Time) *ChargeFlatFeeRunInvoicedUsageUpsertBulk {
 	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
@@ -1318,20 +1163,6 @@ func (u *ChargeFlatFeeRunInvoicedUsageUpsertBulk) SetServicePeriodTo(v time.Time
 func (u *ChargeFlatFeeRunInvoicedUsageUpsertBulk) UpdateServicePeriodTo() *ChargeFlatFeeRunInvoicedUsageUpsertBulk {
 	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
 		s.UpdateServicePeriodTo()
-	})
-}
-
-// SetMutable sets the "mutable" field.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsertBulk) SetMutable(v bool) *ChargeFlatFeeRunInvoicedUsageUpsertBulk {
-	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
-		s.SetMutable(v)
-	})
-}
-
-// UpdateMutable sets the "mutable" field to the value that was provided on create.
-func (u *ChargeFlatFeeRunInvoicedUsageUpsertBulk) UpdateMutable() *ChargeFlatFeeRunInvoicedUsageUpsertBulk {
-	return u.Update(func(s *ChargeFlatFeeRunInvoicedUsageUpsert) {
-		s.UpdateMutable()
 	})
 }
 

--- a/openmeter/ent/db/chargeflatfeeruninvoicedusage_query.go
+++ b/openmeter/ent/db/chargeflatfeeruninvoicedusage_query.go
@@ -12,7 +12,6 @@ import (
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
-	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruninvoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
@@ -21,13 +20,12 @@ import (
 // ChargeFlatFeeRunInvoicedUsageQuery is the builder for querying ChargeFlatFeeRunInvoicedUsage entities.
 type ChargeFlatFeeRunInvoicedUsageQuery struct {
 	config
-	ctx                    *QueryContext
-	order                  []chargeflatfeeruninvoicedusage.OrderOption
-	inters                 []Interceptor
-	predicates             []predicate.ChargeFlatFeeRunInvoicedUsage
-	withBillingInvoiceLine *BillingInvoiceLineQuery
-	withRun                *ChargeFlatFeeRunQuery
-	modifiers              []func(*sql.Selector)
+	ctx        *QueryContext
+	order      []chargeflatfeeruninvoicedusage.OrderOption
+	inters     []Interceptor
+	predicates []predicate.ChargeFlatFeeRunInvoicedUsage
+	withRun    *ChargeFlatFeeRunQuery
+	modifiers  []func(*sql.Selector)
 	// intermediate query (i.e. traversal path).
 	sql  *sql.Selector
 	path func(context.Context) (*sql.Selector, error)
@@ -62,28 +60,6 @@ func (_q *ChargeFlatFeeRunInvoicedUsageQuery) Unique(unique bool) *ChargeFlatFee
 func (_q *ChargeFlatFeeRunInvoicedUsageQuery) Order(o ...chargeflatfeeruninvoicedusage.OrderOption) *ChargeFlatFeeRunInvoicedUsageQuery {
 	_q.order = append(_q.order, o...)
 	return _q
-}
-
-// QueryBillingInvoiceLine chains the current query on the "billing_invoice_line" edge.
-func (_q *ChargeFlatFeeRunInvoicedUsageQuery) QueryBillingInvoiceLine() *BillingInvoiceLineQuery {
-	query := (&BillingInvoiceLineClient{config: _q.config}).Query()
-	query.path = func(ctx context.Context) (fromU *sql.Selector, err error) {
-		if err := _q.prepareQuery(ctx); err != nil {
-			return nil, err
-		}
-		selector := _q.sqlQuery(ctx)
-		if err := selector.Err(); err != nil {
-			return nil, err
-		}
-		step := sqlgraph.NewStep(
-			sqlgraph.From(chargeflatfeeruninvoicedusage.Table, chargeflatfeeruninvoicedusage.FieldID, selector),
-			sqlgraph.To(billinginvoiceline.Table, billinginvoiceline.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, chargeflatfeeruninvoicedusage.BillingInvoiceLineTable, chargeflatfeeruninvoicedusage.BillingInvoiceLineColumn),
-		)
-		fromU = sqlgraph.SetNeighbors(_q.driver.Dialect(), step)
-		return fromU, nil
-	}
-	return query
 }
 
 // QueryRun chains the current query on the "run" edge.
@@ -295,28 +271,16 @@ func (_q *ChargeFlatFeeRunInvoicedUsageQuery) Clone() *ChargeFlatFeeRunInvoicedU
 		return nil
 	}
 	return &ChargeFlatFeeRunInvoicedUsageQuery{
-		config:                 _q.config,
-		ctx:                    _q.ctx.Clone(),
-		order:                  append([]chargeflatfeeruninvoicedusage.OrderOption{}, _q.order...),
-		inters:                 append([]Interceptor{}, _q.inters...),
-		predicates:             append([]predicate.ChargeFlatFeeRunInvoicedUsage{}, _q.predicates...),
-		withBillingInvoiceLine: _q.withBillingInvoiceLine.Clone(),
-		withRun:                _q.withRun.Clone(),
+		config:     _q.config,
+		ctx:        _q.ctx.Clone(),
+		order:      append([]chargeflatfeeruninvoicedusage.OrderOption{}, _q.order...),
+		inters:     append([]Interceptor{}, _q.inters...),
+		predicates: append([]predicate.ChargeFlatFeeRunInvoicedUsage{}, _q.predicates...),
+		withRun:    _q.withRun.Clone(),
 		// clone intermediate query.
 		sql:  _q.sql.Clone(),
 		path: _q.path,
 	}
-}
-
-// WithBillingInvoiceLine tells the query-builder to eager-load the nodes that are connected to
-// the "billing_invoice_line" edge. The optional arguments are used to configure the query builder of the edge.
-func (_q *ChargeFlatFeeRunInvoicedUsageQuery) WithBillingInvoiceLine(opts ...func(*BillingInvoiceLineQuery)) *ChargeFlatFeeRunInvoicedUsageQuery {
-	query := (&BillingInvoiceLineClient{config: _q.config}).Query()
-	for _, opt := range opts {
-		opt(query)
-	}
-	_q.withBillingInvoiceLine = query
-	return _q
 }
 
 // WithRun tells the query-builder to eager-load the nodes that are connected to
@@ -336,12 +300,12 @@ func (_q *ChargeFlatFeeRunInvoicedUsageQuery) WithRun(opts ...func(*ChargeFlatFe
 // Example:
 //
 //	var v []struct {
-//		LineID string `json:"line_id,omitempty"`
+//		ServicePeriodFrom time.Time `json:"service_period_from,omitempty"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
 //	client.ChargeFlatFeeRunInvoicedUsage.Query().
-//		GroupBy(chargeflatfeeruninvoicedusage.FieldLineID).
+//		GroupBy(chargeflatfeeruninvoicedusage.FieldServicePeriodFrom).
 //		Aggregate(db.Count()).
 //		Scan(ctx, &v)
 func (_q *ChargeFlatFeeRunInvoicedUsageQuery) GroupBy(field string, fields ...string) *ChargeFlatFeeRunInvoicedUsageGroupBy {
@@ -359,11 +323,11 @@ func (_q *ChargeFlatFeeRunInvoicedUsageQuery) GroupBy(field string, fields ...st
 // Example:
 //
 //	var v []struct {
-//		LineID string `json:"line_id,omitempty"`
+//		ServicePeriodFrom time.Time `json:"service_period_from,omitempty"`
 //	}
 //
 //	client.ChargeFlatFeeRunInvoicedUsage.Query().
-//		Select(chargeflatfeeruninvoicedusage.FieldLineID).
+//		Select(chargeflatfeeruninvoicedusage.FieldServicePeriodFrom).
 //		Scan(ctx, &v)
 func (_q *ChargeFlatFeeRunInvoicedUsageQuery) Select(fields ...string) *ChargeFlatFeeRunInvoicedUsageSelect {
 	_q.ctx.Fields = append(_q.ctx.Fields, fields...)
@@ -408,8 +372,7 @@ func (_q *ChargeFlatFeeRunInvoicedUsageQuery) sqlAll(ctx context.Context, hooks 
 	var (
 		nodes       = []*ChargeFlatFeeRunInvoicedUsage{}
 		_spec       = _q.querySpec()
-		loadedTypes = [2]bool{
-			_q.withBillingInvoiceLine != nil,
+		loadedTypes = [1]bool{
 			_q.withRun != nil,
 		}
 	)
@@ -434,12 +397,6 @@ func (_q *ChargeFlatFeeRunInvoicedUsageQuery) sqlAll(ctx context.Context, hooks 
 	if len(nodes) == 0 {
 		return nodes, nil
 	}
-	if query := _q.withBillingInvoiceLine; query != nil {
-		if err := _q.loadBillingInvoiceLine(ctx, query, nodes, nil,
-			func(n *ChargeFlatFeeRunInvoicedUsage, e *BillingInvoiceLine) { n.Edges.BillingInvoiceLine = e }); err != nil {
-			return nil, err
-		}
-	}
 	if query := _q.withRun; query != nil {
 		if err := _q.loadRun(ctx, query, nodes, nil,
 			func(n *ChargeFlatFeeRunInvoicedUsage, e *ChargeFlatFeeRun) { n.Edges.Run = e }); err != nil {
@@ -449,38 +406,6 @@ func (_q *ChargeFlatFeeRunInvoicedUsageQuery) sqlAll(ctx context.Context, hooks 
 	return nodes, nil
 }
 
-func (_q *ChargeFlatFeeRunInvoicedUsageQuery) loadBillingInvoiceLine(ctx context.Context, query *BillingInvoiceLineQuery, nodes []*ChargeFlatFeeRunInvoicedUsage, init func(*ChargeFlatFeeRunInvoicedUsage), assign func(*ChargeFlatFeeRunInvoicedUsage, *BillingInvoiceLine)) error {
-	ids := make([]string, 0, len(nodes))
-	nodeids := make(map[string][]*ChargeFlatFeeRunInvoicedUsage)
-	for i := range nodes {
-		if nodes[i].LineID == nil {
-			continue
-		}
-		fk := *nodes[i].LineID
-		if _, ok := nodeids[fk]; !ok {
-			ids = append(ids, fk)
-		}
-		nodeids[fk] = append(nodeids[fk], nodes[i])
-	}
-	if len(ids) == 0 {
-		return nil
-	}
-	query.Where(billinginvoiceline.IDIn(ids...))
-	neighbors, err := query.All(ctx)
-	if err != nil {
-		return err
-	}
-	for _, n := range neighbors {
-		nodes, ok := nodeids[n.ID]
-		if !ok {
-			return fmt.Errorf(`unexpected foreign-key "line_id" returned %v`, n.ID)
-		}
-		for i := range nodes {
-			assign(nodes[i], n)
-		}
-	}
-	return nil
-}
 func (_q *ChargeFlatFeeRunInvoicedUsageQuery) loadRun(ctx context.Context, query *ChargeFlatFeeRunQuery, nodes []*ChargeFlatFeeRunInvoicedUsage, init func(*ChargeFlatFeeRunInvoicedUsage), assign func(*ChargeFlatFeeRunInvoicedUsage, *ChargeFlatFeeRun)) error {
 	ids := make([]string, 0, len(nodes))
 	nodeids := make(map[string][]*ChargeFlatFeeRunInvoicedUsage)
@@ -538,9 +463,6 @@ func (_q *ChargeFlatFeeRunInvoicedUsageQuery) querySpec() *sqlgraph.QuerySpec {
 			if fields[i] != chargeflatfeeruninvoicedusage.FieldID {
 				_spec.Node.Columns = append(_spec.Node.Columns, fields[i])
 			}
-		}
-		if _q.withBillingInvoiceLine != nil {
-			_spec.Node.AddColumnOnce(chargeflatfeeruninvoicedusage.FieldLineID)
 		}
 		if _q.withRun != nil {
 			_spec.Node.AddColumnOnce(chargeflatfeeruninvoicedusage.FieldRunID)

--- a/openmeter/ent/db/chargeflatfeeruninvoicedusage_update.go
+++ b/openmeter/ent/db/chargeflatfeeruninvoicedusage_update.go
@@ -12,7 +12,6 @@ import (
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeruninvoicedusage"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -28,26 +27,6 @@ type ChargeFlatFeeRunInvoicedUsageUpdate struct {
 // Where appends a list predicates to the ChargeFlatFeeRunInvoicedUsageUpdate builder.
 func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) Where(ps ...predicate.ChargeFlatFeeRunInvoicedUsage) *ChargeFlatFeeRunInvoicedUsageUpdate {
 	_u.mutation.Where(ps...)
-	return _u
-}
-
-// SetLineID sets the "line_id" field.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) SetLineID(v string) *ChargeFlatFeeRunInvoicedUsageUpdate {
-	_u.mutation.SetLineID(v)
-	return _u
-}
-
-// SetNillableLineID sets the "line_id" field if the given value is not nil.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) SetNillableLineID(v *string) *ChargeFlatFeeRunInvoicedUsageUpdate {
-	if v != nil {
-		_u.SetLineID(*v)
-	}
-	return _u
-}
-
-// ClearLineID clears the value of the "line_id" field.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) ClearLineID() *ChargeFlatFeeRunInvoicedUsageUpdate {
-	_u.mutation.ClearLineID()
 	return _u
 }
 
@@ -75,20 +54,6 @@ func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) SetServicePeriodTo(v time.Time) *
 func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) SetNillableServicePeriodTo(v *time.Time) *ChargeFlatFeeRunInvoicedUsageUpdate {
 	if v != nil {
 		_u.SetServicePeriodTo(*v)
-	}
-	return _u
-}
-
-// SetMutable sets the "mutable" field.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) SetMutable(v bool) *ChargeFlatFeeRunInvoicedUsageUpdate {
-	_u.mutation.SetMutable(v)
-	return _u
-}
-
-// SetNillableMutable sets the "mutable" field if the given value is not nil.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) SetNillableMutable(v *bool) *ChargeFlatFeeRunInvoicedUsageUpdate {
-	if v != nil {
-		_u.SetMutable(*v)
 	}
 	return _u
 }
@@ -263,34 +228,9 @@ func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) SetNillableTotal(v *alpacadecimal
 	return _u
 }
 
-// SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) SetBillingInvoiceLineID(id string) *ChargeFlatFeeRunInvoicedUsageUpdate {
-	_u.mutation.SetBillingInvoiceLineID(id)
-	return _u
-}
-
-// SetNillableBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID if the given value is not nil.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) SetNillableBillingInvoiceLineID(id *string) *ChargeFlatFeeRunInvoicedUsageUpdate {
-	if id != nil {
-		_u = _u.SetBillingInvoiceLineID(*id)
-	}
-	return _u
-}
-
-// SetBillingInvoiceLine sets the "billing_invoice_line" edge to the BillingInvoiceLine entity.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) SetBillingInvoiceLine(v *BillingInvoiceLine) *ChargeFlatFeeRunInvoicedUsageUpdate {
-	return _u.SetBillingInvoiceLineID(v.ID)
-}
-
 // Mutation returns the ChargeFlatFeeRunInvoicedUsageMutation object of the builder.
 func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) Mutation() *ChargeFlatFeeRunInvoicedUsageMutation {
 	return _u.mutation
-}
-
-// ClearBillingInvoiceLine clears the "billing_invoice_line" edge to the BillingInvoiceLine entity.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) ClearBillingInvoiceLine() *ChargeFlatFeeRunInvoicedUsageUpdate {
-	_u.mutation.ClearBillingInvoiceLine()
-	return _u
 }
 
 // Save executes the query and returns the number of nodes affected by the update operation.
@@ -331,11 +271,6 @@ func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) check() error {
-	if v, ok := _u.mutation.LineID(); ok {
-		if err := chargeflatfeeruninvoicedusage.LineIDValidator(v); err != nil {
-			return &ValidationError{Name: "line_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRunInvoicedUsage.line_id": %w`, err)}
-		}
-	}
 	if v, ok := _u.mutation.LedgerTransactionGroupID(); ok {
 		if err := chargeflatfeeruninvoicedusage.LedgerTransactionGroupIDValidator(v); err != nil {
 			return &ValidationError{Name: "ledger_transaction_group_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRunInvoicedUsage.ledger_transaction_group_id": %w`, err)}
@@ -364,9 +299,6 @@ func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) sqlSave(ctx context.Context) (_no
 	}
 	if value, ok := _u.mutation.ServicePeriodTo(); ok {
 		_spec.SetField(chargeflatfeeruninvoicedusage.FieldServicePeriodTo, field.TypeTime, value)
-	}
-	if value, ok := _u.mutation.Mutable(); ok {
-		_spec.SetField(chargeflatfeeruninvoicedusage.FieldMutable, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.LedgerTransactionGroupID(); ok {
 		_spec.SetField(chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID, field.TypeString, value)
@@ -413,35 +345,6 @@ func (_u *ChargeFlatFeeRunInvoicedUsageUpdate) sqlSave(ctx context.Context) (_no
 	if value, ok := _u.mutation.Total(); ok {
 		_spec.SetField(chargeflatfeeruninvoicedusage.FieldTotal, field.TypeOther, value)
 	}
-	if _u.mutation.BillingInvoiceLineCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   chargeflatfeeruninvoicedusage.BillingInvoiceLineTable,
-			Columns: []string{chargeflatfeeruninvoicedusage.BillingInvoiceLineColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(billinginvoiceline.FieldID, field.TypeString),
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := _u.mutation.BillingInvoiceLineIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   chargeflatfeeruninvoicedusage.BillingInvoiceLineTable,
-			Columns: []string{chargeflatfeeruninvoicedusage.BillingInvoiceLineColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(billinginvoiceline.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
-	}
 	if _node, err = sqlgraph.UpdateNodes(ctx, _u.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{chargeflatfeeruninvoicedusage.Label}
@@ -460,26 +363,6 @@ type ChargeFlatFeeRunInvoicedUsageUpdateOne struct {
 	fields   []string
 	hooks    []Hook
 	mutation *ChargeFlatFeeRunInvoicedUsageMutation
-}
-
-// SetLineID sets the "line_id" field.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) SetLineID(v string) *ChargeFlatFeeRunInvoicedUsageUpdateOne {
-	_u.mutation.SetLineID(v)
-	return _u
-}
-
-// SetNillableLineID sets the "line_id" field if the given value is not nil.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) SetNillableLineID(v *string) *ChargeFlatFeeRunInvoicedUsageUpdateOne {
-	if v != nil {
-		_u.SetLineID(*v)
-	}
-	return _u
-}
-
-// ClearLineID clears the value of the "line_id" field.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) ClearLineID() *ChargeFlatFeeRunInvoicedUsageUpdateOne {
-	_u.mutation.ClearLineID()
-	return _u
 }
 
 // SetServicePeriodFrom sets the "service_period_from" field.
@@ -506,20 +389,6 @@ func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) SetServicePeriodTo(v time.Time
 func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) SetNillableServicePeriodTo(v *time.Time) *ChargeFlatFeeRunInvoicedUsageUpdateOne {
 	if v != nil {
 		_u.SetServicePeriodTo(*v)
-	}
-	return _u
-}
-
-// SetMutable sets the "mutable" field.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) SetMutable(v bool) *ChargeFlatFeeRunInvoicedUsageUpdateOne {
-	_u.mutation.SetMutable(v)
-	return _u
-}
-
-// SetNillableMutable sets the "mutable" field if the given value is not nil.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) SetNillableMutable(v *bool) *ChargeFlatFeeRunInvoicedUsageUpdateOne {
-	if v != nil {
-		_u.SetMutable(*v)
 	}
 	return _u
 }
@@ -694,34 +563,9 @@ func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) SetNillableTotal(v *alpacadeci
 	return _u
 }
 
-// SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) SetBillingInvoiceLineID(id string) *ChargeFlatFeeRunInvoicedUsageUpdateOne {
-	_u.mutation.SetBillingInvoiceLineID(id)
-	return _u
-}
-
-// SetNillableBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by ID if the given value is not nil.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) SetNillableBillingInvoiceLineID(id *string) *ChargeFlatFeeRunInvoicedUsageUpdateOne {
-	if id != nil {
-		_u = _u.SetBillingInvoiceLineID(*id)
-	}
-	return _u
-}
-
-// SetBillingInvoiceLine sets the "billing_invoice_line" edge to the BillingInvoiceLine entity.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) SetBillingInvoiceLine(v *BillingInvoiceLine) *ChargeFlatFeeRunInvoicedUsageUpdateOne {
-	return _u.SetBillingInvoiceLineID(v.ID)
-}
-
 // Mutation returns the ChargeFlatFeeRunInvoicedUsageMutation object of the builder.
 func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) Mutation() *ChargeFlatFeeRunInvoicedUsageMutation {
 	return _u.mutation
-}
-
-// ClearBillingInvoiceLine clears the "billing_invoice_line" edge to the BillingInvoiceLine entity.
-func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) ClearBillingInvoiceLine() *ChargeFlatFeeRunInvoicedUsageUpdateOne {
-	_u.mutation.ClearBillingInvoiceLine()
-	return _u
 }
 
 // Where appends a list predicates to the ChargeFlatFeeRunInvoicedUsageUpdate builder.
@@ -775,11 +619,6 @@ func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) check() error {
-	if v, ok := _u.mutation.LineID(); ok {
-		if err := chargeflatfeeruninvoicedusage.LineIDValidator(v); err != nil {
-			return &ValidationError{Name: "line_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRunInvoicedUsage.line_id": %w`, err)}
-		}
-	}
 	if v, ok := _u.mutation.LedgerTransactionGroupID(); ok {
 		if err := chargeflatfeeruninvoicedusage.LedgerTransactionGroupIDValidator(v); err != nil {
 			return &ValidationError{Name: "ledger_transaction_group_id", err: fmt.Errorf(`db: validator failed for field "ChargeFlatFeeRunInvoicedUsage.ledger_transaction_group_id": %w`, err)}
@@ -826,9 +665,6 @@ func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) sqlSave(ctx context.Context) (
 	if value, ok := _u.mutation.ServicePeriodTo(); ok {
 		_spec.SetField(chargeflatfeeruninvoicedusage.FieldServicePeriodTo, field.TypeTime, value)
 	}
-	if value, ok := _u.mutation.Mutable(); ok {
-		_spec.SetField(chargeflatfeeruninvoicedusage.FieldMutable, field.TypeBool, value)
-	}
 	if value, ok := _u.mutation.LedgerTransactionGroupID(); ok {
 		_spec.SetField(chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID, field.TypeString, value)
 	}
@@ -873,35 +709,6 @@ func (_u *ChargeFlatFeeRunInvoicedUsageUpdateOne) sqlSave(ctx context.Context) (
 	}
 	if value, ok := _u.mutation.Total(); ok {
 		_spec.SetField(chargeflatfeeruninvoicedusage.FieldTotal, field.TypeOther, value)
-	}
-	if _u.mutation.BillingInvoiceLineCleared() {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   chargeflatfeeruninvoicedusage.BillingInvoiceLineTable,
-			Columns: []string{chargeflatfeeruninvoicedusage.BillingInvoiceLineColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(billinginvoiceline.FieldID, field.TypeString),
-			},
-		}
-		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
-	}
-	if nodes := _u.mutation.BillingInvoiceLineIDs(); len(nodes) > 0 {
-		edge := &sqlgraph.EdgeSpec{
-			Rel:     sqlgraph.M2O,
-			Inverse: true,
-			Table:   chargeflatfeeruninvoicedusage.BillingInvoiceLineTable,
-			Columns: []string{chargeflatfeeruninvoicedusage.BillingInvoiceLineColumn},
-			Bidi:    false,
-			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(billinginvoiceline.FieldID, field.TypeString),
-			},
-		}
-		for _, k := range nodes {
-			edge.Target.Nodes = append(edge.Target.Nodes, k)
-		}
-		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
 	_node = &ChargeFlatFeeRunInvoicedUsage{config: _u.config}
 	_spec.Assign = _node.assignValues

--- a/openmeter/ent/db/chargeusagebasedruninvoicedusage.go
+++ b/openmeter/ent/db/chargeusagebasedruninvoicedusage.go
@@ -21,14 +21,10 @@ type ChargeUsageBasedRunInvoicedUsage struct {
 	config `json:"-"`
 	// ID of the ent.
 	ID string `json:"id,omitempty"`
-	// LineID holds the value of the "line_id" field.
-	LineID *string `json:"line_id,omitempty"`
 	// ServicePeriodFrom holds the value of the "service_period_from" field.
 	ServicePeriodFrom time.Time `json:"service_period_from,omitempty"`
 	// ServicePeriodTo holds the value of the "service_period_to" field.
 	ServicePeriodTo time.Time `json:"service_period_to,omitempty"`
-	// Mutable holds the value of the "mutable" field.
-	Mutable bool `json:"mutable,omitempty"`
 	// LedgerTransactionGroupID holds the value of the "ledger_transaction_group_id" field.
 	LedgerTransactionGroupID *string `json:"ledger_transaction_group_id,omitempty"`
 	// Namespace holds the value of the "namespace" field.
@@ -94,9 +90,7 @@ func (*ChargeUsageBasedRunInvoicedUsage) scanValues(columns []string) ([]any, er
 			values[i] = new([]byte)
 		case chargeusagebasedruninvoicedusage.FieldAmount, chargeusagebasedruninvoicedusage.FieldTaxesTotal, chargeusagebasedruninvoicedusage.FieldTaxesInclusiveTotal, chargeusagebasedruninvoicedusage.FieldTaxesExclusiveTotal, chargeusagebasedruninvoicedusage.FieldChargesTotal, chargeusagebasedruninvoicedusage.FieldDiscountsTotal, chargeusagebasedruninvoicedusage.FieldCreditsTotal, chargeusagebasedruninvoicedusage.FieldTotal:
 			values[i] = new(alpacadecimal.Decimal)
-		case chargeusagebasedruninvoicedusage.FieldMutable:
-			values[i] = new(sql.NullBool)
-		case chargeusagebasedruninvoicedusage.FieldID, chargeusagebasedruninvoicedusage.FieldLineID, chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID, chargeusagebasedruninvoicedusage.FieldNamespace, chargeusagebasedruninvoicedusage.FieldRunID:
+		case chargeusagebasedruninvoicedusage.FieldID, chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID, chargeusagebasedruninvoicedusage.FieldNamespace, chargeusagebasedruninvoicedusage.FieldRunID:
 			values[i] = new(sql.NullString)
 		case chargeusagebasedruninvoicedusage.FieldServicePeriodFrom, chargeusagebasedruninvoicedusage.FieldServicePeriodTo, chargeusagebasedruninvoicedusage.FieldCreatedAt, chargeusagebasedruninvoicedusage.FieldUpdatedAt, chargeusagebasedruninvoicedusage.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -121,13 +115,6 @@ func (_m *ChargeUsageBasedRunInvoicedUsage) assignValues(columns []string, value
 			} else if value.Valid {
 				_m.ID = value.String
 			}
-		case chargeusagebasedruninvoicedusage.FieldLineID:
-			if value, ok := values[i].(*sql.NullString); !ok {
-				return fmt.Errorf("unexpected type %T for field line_id", values[i])
-			} else if value.Valid {
-				_m.LineID = new(string)
-				*_m.LineID = value.String
-			}
 		case chargeusagebasedruninvoicedusage.FieldServicePeriodFrom:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field service_period_from", values[i])
@@ -139,12 +126,6 @@ func (_m *ChargeUsageBasedRunInvoicedUsage) assignValues(columns []string, value
 				return fmt.Errorf("unexpected type %T for field service_period_to", values[i])
 			} else if value.Valid {
 				_m.ServicePeriodTo = value.Time
-			}
-		case chargeusagebasedruninvoicedusage.FieldMutable:
-			if value, ok := values[i].(*sql.NullBool); !ok {
-				return fmt.Errorf("unexpected type %T for field mutable", values[i])
-			} else if value.Valid {
-				_m.Mutable = value.Bool
 			}
 		case chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -281,19 +262,11 @@ func (_m *ChargeUsageBasedRunInvoicedUsage) String() string {
 	var builder strings.Builder
 	builder.WriteString("ChargeUsageBasedRunInvoicedUsage(")
 	builder.WriteString(fmt.Sprintf("id=%v, ", _m.ID))
-	if v := _m.LineID; v != nil {
-		builder.WriteString("line_id=")
-		builder.WriteString(*v)
-	}
-	builder.WriteString(", ")
 	builder.WriteString("service_period_from=")
 	builder.WriteString(_m.ServicePeriodFrom.Format(time.ANSIC))
 	builder.WriteString(", ")
 	builder.WriteString("service_period_to=")
 	builder.WriteString(_m.ServicePeriodTo.Format(time.ANSIC))
-	builder.WriteString(", ")
-	builder.WriteString("mutable=")
-	builder.WriteString(fmt.Sprintf("%v", _m.Mutable))
 	builder.WriteString(", ")
 	if v := _m.LedgerTransactionGroupID; v != nil {
 		builder.WriteString("ledger_transaction_group_id=")

--- a/openmeter/ent/db/chargeusagebasedruninvoicedusage/chargeusagebasedruninvoicedusage.go
+++ b/openmeter/ent/db/chargeusagebasedruninvoicedusage/chargeusagebasedruninvoicedusage.go
@@ -14,14 +14,10 @@ const (
 	Label = "charge_usage_based_run_invoiced_usage"
 	// FieldID holds the string denoting the id field in the database.
 	FieldID = "id"
-	// FieldLineID holds the string denoting the line_id field in the database.
-	FieldLineID = "line_id"
 	// FieldServicePeriodFrom holds the string denoting the service_period_from field in the database.
 	FieldServicePeriodFrom = "service_period_from"
 	// FieldServicePeriodTo holds the string denoting the service_period_to field in the database.
 	FieldServicePeriodTo = "service_period_to"
-	// FieldMutable holds the string denoting the mutable field in the database.
-	FieldMutable = "mutable"
 	// FieldLedgerTransactionGroupID holds the string denoting the ledger_transaction_group_id field in the database.
 	FieldLedgerTransactionGroupID = "ledger_transaction_group_id"
 	// FieldNamespace holds the string denoting the namespace field in the database.
@@ -68,10 +64,8 @@ const (
 // Columns holds all SQL columns for chargeusagebasedruninvoicedusage fields.
 var Columns = []string{
 	FieldID,
-	FieldLineID,
 	FieldServicePeriodFrom,
 	FieldServicePeriodTo,
-	FieldMutable,
 	FieldLedgerTransactionGroupID,
 	FieldNamespace,
 	FieldCreatedAt,
@@ -100,8 +94,6 @@ func ValidColumn(column string) bool {
 }
 
 var (
-	// LineIDValidator is a validator for the "line_id" field. It is called by the builders before save.
-	LineIDValidator func(string) error
 	// LedgerTransactionGroupIDValidator is a validator for the "ledger_transaction_group_id" field. It is called by the builders before save.
 	LedgerTransactionGroupIDValidator func(string) error
 	// NamespaceValidator is a validator for the "namespace" field. It is called by the builders before save.
@@ -124,11 +116,6 @@ func ByID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldID, opts...).ToFunc()
 }
 
-// ByLineID orders the results by the line_id field.
-func ByLineID(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldLineID, opts...).ToFunc()
-}
-
 // ByServicePeriodFrom orders the results by the service_period_from field.
 func ByServicePeriodFrom(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldServicePeriodFrom, opts...).ToFunc()
@@ -137,11 +124,6 @@ func ByServicePeriodFrom(opts ...sql.OrderTermOption) OrderOption {
 // ByServicePeriodTo orders the results by the service_period_to field.
 func ByServicePeriodTo(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldServicePeriodTo, opts...).ToFunc()
-}
-
-// ByMutable orders the results by the mutable field.
-func ByMutable(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldMutable, opts...).ToFunc()
 }
 
 // ByLedgerTransactionGroupID orders the results by the ledger_transaction_group_id field.

--- a/openmeter/ent/db/chargeusagebasedruninvoicedusage/where.go
+++ b/openmeter/ent/db/chargeusagebasedruninvoicedusage/where.go
@@ -66,11 +66,6 @@ func IDContainsFold(id string) predicate.ChargeUsageBasedRunInvoicedUsage {
 	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldContainsFold(FieldID, id))
 }
 
-// LineID applies equality check predicate on the "line_id" field. It's identical to LineIDEQ.
-func LineID(v string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldEQ(FieldLineID, v))
-}
-
 // ServicePeriodFrom applies equality check predicate on the "service_period_from" field. It's identical to ServicePeriodFromEQ.
 func ServicePeriodFrom(v time.Time) predicate.ChargeUsageBasedRunInvoicedUsage {
 	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldEQ(FieldServicePeriodFrom, v))
@@ -79,11 +74,6 @@ func ServicePeriodFrom(v time.Time) predicate.ChargeUsageBasedRunInvoicedUsage {
 // ServicePeriodTo applies equality check predicate on the "service_period_to" field. It's identical to ServicePeriodToEQ.
 func ServicePeriodTo(v time.Time) predicate.ChargeUsageBasedRunInvoicedUsage {
 	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldEQ(FieldServicePeriodTo, v))
-}
-
-// Mutable applies equality check predicate on the "mutable" field. It's identical to MutableEQ.
-func Mutable(v bool) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldEQ(FieldMutable, v))
 }
 
 // LedgerTransactionGroupID applies equality check predicate on the "ledger_transaction_group_id" field. It's identical to LedgerTransactionGroupIDEQ.
@@ -154,81 +144,6 @@ func Total(v alpacadecimal.Decimal) predicate.ChargeUsageBasedRunInvoicedUsage {
 // RunID applies equality check predicate on the "run_id" field. It's identical to RunIDEQ.
 func RunID(v string) predicate.ChargeUsageBasedRunInvoicedUsage {
 	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldEQ(FieldRunID, v))
-}
-
-// LineIDEQ applies the EQ predicate on the "line_id" field.
-func LineIDEQ(v string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldEQ(FieldLineID, v))
-}
-
-// LineIDNEQ applies the NEQ predicate on the "line_id" field.
-func LineIDNEQ(v string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldNEQ(FieldLineID, v))
-}
-
-// LineIDIn applies the In predicate on the "line_id" field.
-func LineIDIn(vs ...string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldIn(FieldLineID, vs...))
-}
-
-// LineIDNotIn applies the NotIn predicate on the "line_id" field.
-func LineIDNotIn(vs ...string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldNotIn(FieldLineID, vs...))
-}
-
-// LineIDGT applies the GT predicate on the "line_id" field.
-func LineIDGT(v string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldGT(FieldLineID, v))
-}
-
-// LineIDGTE applies the GTE predicate on the "line_id" field.
-func LineIDGTE(v string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldGTE(FieldLineID, v))
-}
-
-// LineIDLT applies the LT predicate on the "line_id" field.
-func LineIDLT(v string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldLT(FieldLineID, v))
-}
-
-// LineIDLTE applies the LTE predicate on the "line_id" field.
-func LineIDLTE(v string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldLTE(FieldLineID, v))
-}
-
-// LineIDContains applies the Contains predicate on the "line_id" field.
-func LineIDContains(v string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldContains(FieldLineID, v))
-}
-
-// LineIDHasPrefix applies the HasPrefix predicate on the "line_id" field.
-func LineIDHasPrefix(v string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldHasPrefix(FieldLineID, v))
-}
-
-// LineIDHasSuffix applies the HasSuffix predicate on the "line_id" field.
-func LineIDHasSuffix(v string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldHasSuffix(FieldLineID, v))
-}
-
-// LineIDIsNil applies the IsNil predicate on the "line_id" field.
-func LineIDIsNil() predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldIsNull(FieldLineID))
-}
-
-// LineIDNotNil applies the NotNil predicate on the "line_id" field.
-func LineIDNotNil() predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldNotNull(FieldLineID))
-}
-
-// LineIDEqualFold applies the EqualFold predicate on the "line_id" field.
-func LineIDEqualFold(v string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldEqualFold(FieldLineID, v))
-}
-
-// LineIDContainsFold applies the ContainsFold predicate on the "line_id" field.
-func LineIDContainsFold(v string) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldContainsFold(FieldLineID, v))
 }
 
 // ServicePeriodFromEQ applies the EQ predicate on the "service_period_from" field.
@@ -309,16 +224,6 @@ func ServicePeriodToLT(v time.Time) predicate.ChargeUsageBasedRunInvoicedUsage {
 // ServicePeriodToLTE applies the LTE predicate on the "service_period_to" field.
 func ServicePeriodToLTE(v time.Time) predicate.ChargeUsageBasedRunInvoicedUsage {
 	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldLTE(FieldServicePeriodTo, v))
-}
-
-// MutableEQ applies the EQ predicate on the "mutable" field.
-func MutableEQ(v bool) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldEQ(FieldMutable, v))
-}
-
-// MutableNEQ applies the NEQ predicate on the "mutable" field.
-func MutableNEQ(v bool) predicate.ChargeUsageBasedRunInvoicedUsage {
-	return predicate.ChargeUsageBasedRunInvoicedUsage(sql.FieldNEQ(FieldMutable, v))
 }
 
 // LedgerTransactionGroupIDEQ applies the EQ predicate on the "ledger_transaction_group_id" field.

--- a/openmeter/ent/db/chargeusagebasedruninvoicedusage_create.go
+++ b/openmeter/ent/db/chargeusagebasedruninvoicedusage_create.go
@@ -26,20 +26,6 @@ type ChargeUsageBasedRunInvoicedUsageCreate struct {
 	conflict []sql.ConflictOption
 }
 
-// SetLineID sets the "line_id" field.
-func (_c *ChargeUsageBasedRunInvoicedUsageCreate) SetLineID(v string) *ChargeUsageBasedRunInvoicedUsageCreate {
-	_c.mutation.SetLineID(v)
-	return _c
-}
-
-// SetNillableLineID sets the "line_id" field if the given value is not nil.
-func (_c *ChargeUsageBasedRunInvoicedUsageCreate) SetNillableLineID(v *string) *ChargeUsageBasedRunInvoicedUsageCreate {
-	if v != nil {
-		_c.SetLineID(*v)
-	}
-	return _c
-}
-
 // SetServicePeriodFrom sets the "service_period_from" field.
 func (_c *ChargeUsageBasedRunInvoicedUsageCreate) SetServicePeriodFrom(v time.Time) *ChargeUsageBasedRunInvoicedUsageCreate {
 	_c.mutation.SetServicePeriodFrom(v)
@@ -49,12 +35,6 @@ func (_c *ChargeUsageBasedRunInvoicedUsageCreate) SetServicePeriodFrom(v time.Ti
 // SetServicePeriodTo sets the "service_period_to" field.
 func (_c *ChargeUsageBasedRunInvoicedUsageCreate) SetServicePeriodTo(v time.Time) *ChargeUsageBasedRunInvoicedUsageCreate {
 	_c.mutation.SetServicePeriodTo(v)
-	return _c
-}
-
-// SetMutable sets the "mutable" field.
-func (_c *ChargeUsageBasedRunInvoicedUsageCreate) SetMutable(v bool) *ChargeUsageBasedRunInvoicedUsageCreate {
-	_c.mutation.SetMutable(v)
 	return _c
 }
 
@@ -250,19 +230,11 @@ func (_c *ChargeUsageBasedRunInvoicedUsageCreate) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (_c *ChargeUsageBasedRunInvoicedUsageCreate) check() error {
-	if v, ok := _c.mutation.LineID(); ok {
-		if err := chargeusagebasedruninvoicedusage.LineIDValidator(v); err != nil {
-			return &ValidationError{Name: "line_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunInvoicedUsage.line_id": %w`, err)}
-		}
-	}
 	if _, ok := _c.mutation.ServicePeriodFrom(); !ok {
 		return &ValidationError{Name: "service_period_from", err: errors.New(`db: missing required field "ChargeUsageBasedRunInvoicedUsage.service_period_from"`)}
 	}
 	if _, ok := _c.mutation.ServicePeriodTo(); !ok {
 		return &ValidationError{Name: "service_period_to", err: errors.New(`db: missing required field "ChargeUsageBasedRunInvoicedUsage.service_period_to"`)}
-	}
-	if _, ok := _c.mutation.Mutable(); !ok {
-		return &ValidationError{Name: "mutable", err: errors.New(`db: missing required field "ChargeUsageBasedRunInvoicedUsage.mutable"`)}
 	}
 	if v, ok := _c.mutation.LedgerTransactionGroupID(); ok {
 		if err := chargeusagebasedruninvoicedusage.LedgerTransactionGroupIDValidator(v); err != nil {
@@ -349,10 +321,6 @@ func (_c *ChargeUsageBasedRunInvoicedUsageCreate) createSpec() (*ChargeUsageBase
 		_node.ID = id
 		_spec.ID.Value = id
 	}
-	if value, ok := _c.mutation.LineID(); ok {
-		_spec.SetField(chargeusagebasedruninvoicedusage.FieldLineID, field.TypeString, value)
-		_node.LineID = &value
-	}
 	if value, ok := _c.mutation.ServicePeriodFrom(); ok {
 		_spec.SetField(chargeusagebasedruninvoicedusage.FieldServicePeriodFrom, field.TypeTime, value)
 		_node.ServicePeriodFrom = value
@@ -360,10 +328,6 @@ func (_c *ChargeUsageBasedRunInvoicedUsageCreate) createSpec() (*ChargeUsageBase
 	if value, ok := _c.mutation.ServicePeriodTo(); ok {
 		_spec.SetField(chargeusagebasedruninvoicedusage.FieldServicePeriodTo, field.TypeTime, value)
 		_node.ServicePeriodTo = value
-	}
-	if value, ok := _c.mutation.Mutable(); ok {
-		_spec.SetField(chargeusagebasedruninvoicedusage.FieldMutable, field.TypeBool, value)
-		_node.Mutable = value
 	}
 	if value, ok := _c.mutation.LedgerTransactionGroupID(); ok {
 		_spec.SetField(chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID, field.TypeString, value)
@@ -445,7 +409,7 @@ func (_c *ChargeUsageBasedRunInvoicedUsageCreate) createSpec() (*ChargeUsageBase
 // of the `INSERT` statement. For example:
 //
 //	client.ChargeUsageBasedRunInvoicedUsage.Create().
-//		SetLineID(v).
+//		SetServicePeriodFrom(v).
 //		OnConflict(
 //			// Update the row with the new values
 //			// the was proposed for insertion.
@@ -454,7 +418,7 @@ func (_c *ChargeUsageBasedRunInvoicedUsageCreate) createSpec() (*ChargeUsageBase
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.ChargeUsageBasedRunInvoicedUsageUpsert) {
-//			SetLineID(v+v).
+//			SetServicePeriodFrom(v+v).
 //		}).
 //		Exec(ctx)
 func (_c *ChargeUsageBasedRunInvoicedUsageCreate) OnConflict(opts ...sql.ConflictOption) *ChargeUsageBasedRunInvoicedUsageUpsertOne {
@@ -490,24 +454,6 @@ type (
 	}
 )
 
-// SetLineID sets the "line_id" field.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsert) SetLineID(v string) *ChargeUsageBasedRunInvoicedUsageUpsert {
-	u.Set(chargeusagebasedruninvoicedusage.FieldLineID, v)
-	return u
-}
-
-// UpdateLineID sets the "line_id" field to the value that was provided on create.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsert) UpdateLineID() *ChargeUsageBasedRunInvoicedUsageUpsert {
-	u.SetExcluded(chargeusagebasedruninvoicedusage.FieldLineID)
-	return u
-}
-
-// ClearLineID clears the value of the "line_id" field.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsert) ClearLineID() *ChargeUsageBasedRunInvoicedUsageUpsert {
-	u.SetNull(chargeusagebasedruninvoicedusage.FieldLineID)
-	return u
-}
-
 // SetServicePeriodFrom sets the "service_period_from" field.
 func (u *ChargeUsageBasedRunInvoicedUsageUpsert) SetServicePeriodFrom(v time.Time) *ChargeUsageBasedRunInvoicedUsageUpsert {
 	u.Set(chargeusagebasedruninvoicedusage.FieldServicePeriodFrom, v)
@@ -529,18 +475,6 @@ func (u *ChargeUsageBasedRunInvoicedUsageUpsert) SetServicePeriodTo(v time.Time)
 // UpdateServicePeriodTo sets the "service_period_to" field to the value that was provided on create.
 func (u *ChargeUsageBasedRunInvoicedUsageUpsert) UpdateServicePeriodTo() *ChargeUsageBasedRunInvoicedUsageUpsert {
 	u.SetExcluded(chargeusagebasedruninvoicedusage.FieldServicePeriodTo)
-	return u
-}
-
-// SetMutable sets the "mutable" field.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsert) SetMutable(v bool) *ChargeUsageBasedRunInvoicedUsageUpsert {
-	u.Set(chargeusagebasedruninvoicedusage.FieldMutable, v)
-	return u
-}
-
-// UpdateMutable sets the "mutable" field to the value that was provided on create.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsert) UpdateMutable() *ChargeUsageBasedRunInvoicedUsageUpsert {
-	u.SetExcluded(chargeusagebasedruninvoicedusage.FieldMutable)
 	return u
 }
 
@@ -763,27 +697,6 @@ func (u *ChargeUsageBasedRunInvoicedUsageUpsertOne) Update(set func(*ChargeUsage
 	return u
 }
 
-// SetLineID sets the "line_id" field.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsertOne) SetLineID(v string) *ChargeUsageBasedRunInvoicedUsageUpsertOne {
-	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
-		s.SetLineID(v)
-	})
-}
-
-// UpdateLineID sets the "line_id" field to the value that was provided on create.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsertOne) UpdateLineID() *ChargeUsageBasedRunInvoicedUsageUpsertOne {
-	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
-		s.UpdateLineID()
-	})
-}
-
-// ClearLineID clears the value of the "line_id" field.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsertOne) ClearLineID() *ChargeUsageBasedRunInvoicedUsageUpsertOne {
-	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
-		s.ClearLineID()
-	})
-}
-
 // SetServicePeriodFrom sets the "service_period_from" field.
 func (u *ChargeUsageBasedRunInvoicedUsageUpsertOne) SetServicePeriodFrom(v time.Time) *ChargeUsageBasedRunInvoicedUsageUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
@@ -809,20 +722,6 @@ func (u *ChargeUsageBasedRunInvoicedUsageUpsertOne) SetServicePeriodTo(v time.Ti
 func (u *ChargeUsageBasedRunInvoicedUsageUpsertOne) UpdateServicePeriodTo() *ChargeUsageBasedRunInvoicedUsageUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
 		s.UpdateServicePeriodTo()
-	})
-}
-
-// SetMutable sets the "mutable" field.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsertOne) SetMutable(v bool) *ChargeUsageBasedRunInvoicedUsageUpsertOne {
-	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
-		s.SetMutable(v)
-	})
-}
-
-// UpdateMutable sets the "mutable" field to the value that was provided on create.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsertOne) UpdateMutable() *ChargeUsageBasedRunInvoicedUsageUpsertOne {
-	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
-		s.UpdateMutable()
 	})
 }
 
@@ -1151,7 +1050,7 @@ func (_c *ChargeUsageBasedRunInvoicedUsageCreateBulk) ExecX(ctx context.Context)
 //		// Override some of the fields with custom
 //		// update values.
 //		Update(func(u *ent.ChargeUsageBasedRunInvoicedUsageUpsert) {
-//			SetLineID(v+v).
+//			SetServicePeriodFrom(v+v).
 //		}).
 //		Exec(ctx)
 func (_c *ChargeUsageBasedRunInvoicedUsageCreateBulk) OnConflict(opts ...sql.ConflictOption) *ChargeUsageBasedRunInvoicedUsageUpsertBulk {
@@ -1239,27 +1138,6 @@ func (u *ChargeUsageBasedRunInvoicedUsageUpsertBulk) Update(set func(*ChargeUsag
 	return u
 }
 
-// SetLineID sets the "line_id" field.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsertBulk) SetLineID(v string) *ChargeUsageBasedRunInvoicedUsageUpsertBulk {
-	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
-		s.SetLineID(v)
-	})
-}
-
-// UpdateLineID sets the "line_id" field to the value that was provided on create.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsertBulk) UpdateLineID() *ChargeUsageBasedRunInvoicedUsageUpsertBulk {
-	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
-		s.UpdateLineID()
-	})
-}
-
-// ClearLineID clears the value of the "line_id" field.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsertBulk) ClearLineID() *ChargeUsageBasedRunInvoicedUsageUpsertBulk {
-	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
-		s.ClearLineID()
-	})
-}
-
 // SetServicePeriodFrom sets the "service_period_from" field.
 func (u *ChargeUsageBasedRunInvoicedUsageUpsertBulk) SetServicePeriodFrom(v time.Time) *ChargeUsageBasedRunInvoicedUsageUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
@@ -1285,20 +1163,6 @@ func (u *ChargeUsageBasedRunInvoicedUsageUpsertBulk) SetServicePeriodTo(v time.T
 func (u *ChargeUsageBasedRunInvoicedUsageUpsertBulk) UpdateServicePeriodTo() *ChargeUsageBasedRunInvoicedUsageUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
 		s.UpdateServicePeriodTo()
-	})
-}
-
-// SetMutable sets the "mutable" field.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsertBulk) SetMutable(v bool) *ChargeUsageBasedRunInvoicedUsageUpsertBulk {
-	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
-		s.SetMutable(v)
-	})
-}
-
-// UpdateMutable sets the "mutable" field to the value that was provided on create.
-func (u *ChargeUsageBasedRunInvoicedUsageUpsertBulk) UpdateMutable() *ChargeUsageBasedRunInvoicedUsageUpsertBulk {
-	return u.Update(func(s *ChargeUsageBasedRunInvoicedUsageUpsert) {
-		s.UpdateMutable()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebasedruninvoicedusage_query.go
+++ b/openmeter/ent/db/chargeusagebasedruninvoicedusage_query.go
@@ -300,12 +300,12 @@ func (_q *ChargeUsageBasedRunInvoicedUsageQuery) WithRun(opts ...func(*ChargeUsa
 // Example:
 //
 //	var v []struct {
-//		LineID string `json:"line_id,omitempty"`
+//		ServicePeriodFrom time.Time `json:"service_period_from,omitempty"`
 //		Count int `json:"count,omitempty"`
 //	}
 //
 //	client.ChargeUsageBasedRunInvoicedUsage.Query().
-//		GroupBy(chargeusagebasedruninvoicedusage.FieldLineID).
+//		GroupBy(chargeusagebasedruninvoicedusage.FieldServicePeriodFrom).
 //		Aggregate(db.Count()).
 //		Scan(ctx, &v)
 func (_q *ChargeUsageBasedRunInvoicedUsageQuery) GroupBy(field string, fields ...string) *ChargeUsageBasedRunInvoicedUsageGroupBy {
@@ -323,11 +323,11 @@ func (_q *ChargeUsageBasedRunInvoicedUsageQuery) GroupBy(field string, fields ..
 // Example:
 //
 //	var v []struct {
-//		LineID string `json:"line_id,omitempty"`
+//		ServicePeriodFrom time.Time `json:"service_period_from,omitempty"`
 //	}
 //
 //	client.ChargeUsageBasedRunInvoicedUsage.Query().
-//		Select(chargeusagebasedruninvoicedusage.FieldLineID).
+//		Select(chargeusagebasedruninvoicedusage.FieldServicePeriodFrom).
 //		Scan(ctx, &v)
 func (_q *ChargeUsageBasedRunInvoicedUsageQuery) Select(fields ...string) *ChargeUsageBasedRunInvoicedUsageSelect {
 	_q.ctx.Fields = append(_q.ctx.Fields, fields...)

--- a/openmeter/ent/db/chargeusagebasedruninvoicedusage_update.go
+++ b/openmeter/ent/db/chargeusagebasedruninvoicedusage_update.go
@@ -30,26 +30,6 @@ func (_u *ChargeUsageBasedRunInvoicedUsageUpdate) Where(ps ...predicate.ChargeUs
 	return _u
 }
 
-// SetLineID sets the "line_id" field.
-func (_u *ChargeUsageBasedRunInvoicedUsageUpdate) SetLineID(v string) *ChargeUsageBasedRunInvoicedUsageUpdate {
-	_u.mutation.SetLineID(v)
-	return _u
-}
-
-// SetNillableLineID sets the "line_id" field if the given value is not nil.
-func (_u *ChargeUsageBasedRunInvoicedUsageUpdate) SetNillableLineID(v *string) *ChargeUsageBasedRunInvoicedUsageUpdate {
-	if v != nil {
-		_u.SetLineID(*v)
-	}
-	return _u
-}
-
-// ClearLineID clears the value of the "line_id" field.
-func (_u *ChargeUsageBasedRunInvoicedUsageUpdate) ClearLineID() *ChargeUsageBasedRunInvoicedUsageUpdate {
-	_u.mutation.ClearLineID()
-	return _u
-}
-
 // SetServicePeriodFrom sets the "service_period_from" field.
 func (_u *ChargeUsageBasedRunInvoicedUsageUpdate) SetServicePeriodFrom(v time.Time) *ChargeUsageBasedRunInvoicedUsageUpdate {
 	_u.mutation.SetServicePeriodFrom(v)
@@ -74,20 +54,6 @@ func (_u *ChargeUsageBasedRunInvoicedUsageUpdate) SetServicePeriodTo(v time.Time
 func (_u *ChargeUsageBasedRunInvoicedUsageUpdate) SetNillableServicePeriodTo(v *time.Time) *ChargeUsageBasedRunInvoicedUsageUpdate {
 	if v != nil {
 		_u.SetServicePeriodTo(*v)
-	}
-	return _u
-}
-
-// SetMutable sets the "mutable" field.
-func (_u *ChargeUsageBasedRunInvoicedUsageUpdate) SetMutable(v bool) *ChargeUsageBasedRunInvoicedUsageUpdate {
-	_u.mutation.SetMutable(v)
-	return _u
-}
-
-// SetNillableMutable sets the "mutable" field if the given value is not nil.
-func (_u *ChargeUsageBasedRunInvoicedUsageUpdate) SetNillableMutable(v *bool) *ChargeUsageBasedRunInvoicedUsageUpdate {
-	if v != nil {
-		_u.SetMutable(*v)
 	}
 	return _u
 }
@@ -305,11 +271,6 @@ func (_u *ChargeUsageBasedRunInvoicedUsageUpdate) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (_u *ChargeUsageBasedRunInvoicedUsageUpdate) check() error {
-	if v, ok := _u.mutation.LineID(); ok {
-		if err := chargeusagebasedruninvoicedusage.LineIDValidator(v); err != nil {
-			return &ValidationError{Name: "line_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunInvoicedUsage.line_id": %w`, err)}
-		}
-	}
 	if v, ok := _u.mutation.LedgerTransactionGroupID(); ok {
 		if err := chargeusagebasedruninvoicedusage.LedgerTransactionGroupIDValidator(v); err != nil {
 			return &ValidationError{Name: "ledger_transaction_group_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunInvoicedUsage.ledger_transaction_group_id": %w`, err)}
@@ -333,20 +294,11 @@ func (_u *ChargeUsageBasedRunInvoicedUsageUpdate) sqlSave(ctx context.Context) (
 			}
 		}
 	}
-	if value, ok := _u.mutation.LineID(); ok {
-		_spec.SetField(chargeusagebasedruninvoicedusage.FieldLineID, field.TypeString, value)
-	}
-	if _u.mutation.LineIDCleared() {
-		_spec.ClearField(chargeusagebasedruninvoicedusage.FieldLineID, field.TypeString)
-	}
 	if value, ok := _u.mutation.ServicePeriodFrom(); ok {
 		_spec.SetField(chargeusagebasedruninvoicedusage.FieldServicePeriodFrom, field.TypeTime, value)
 	}
 	if value, ok := _u.mutation.ServicePeriodTo(); ok {
 		_spec.SetField(chargeusagebasedruninvoicedusage.FieldServicePeriodTo, field.TypeTime, value)
-	}
-	if value, ok := _u.mutation.Mutable(); ok {
-		_spec.SetField(chargeusagebasedruninvoicedusage.FieldMutable, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.LedgerTransactionGroupID(); ok {
 		_spec.SetField(chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID, field.TypeString, value)
@@ -413,26 +365,6 @@ type ChargeUsageBasedRunInvoicedUsageUpdateOne struct {
 	mutation *ChargeUsageBasedRunInvoicedUsageMutation
 }
 
-// SetLineID sets the "line_id" field.
-func (_u *ChargeUsageBasedRunInvoicedUsageUpdateOne) SetLineID(v string) *ChargeUsageBasedRunInvoicedUsageUpdateOne {
-	_u.mutation.SetLineID(v)
-	return _u
-}
-
-// SetNillableLineID sets the "line_id" field if the given value is not nil.
-func (_u *ChargeUsageBasedRunInvoicedUsageUpdateOne) SetNillableLineID(v *string) *ChargeUsageBasedRunInvoicedUsageUpdateOne {
-	if v != nil {
-		_u.SetLineID(*v)
-	}
-	return _u
-}
-
-// ClearLineID clears the value of the "line_id" field.
-func (_u *ChargeUsageBasedRunInvoicedUsageUpdateOne) ClearLineID() *ChargeUsageBasedRunInvoicedUsageUpdateOne {
-	_u.mutation.ClearLineID()
-	return _u
-}
-
 // SetServicePeriodFrom sets the "service_period_from" field.
 func (_u *ChargeUsageBasedRunInvoicedUsageUpdateOne) SetServicePeriodFrom(v time.Time) *ChargeUsageBasedRunInvoicedUsageUpdateOne {
 	_u.mutation.SetServicePeriodFrom(v)
@@ -457,20 +389,6 @@ func (_u *ChargeUsageBasedRunInvoicedUsageUpdateOne) SetServicePeriodTo(v time.T
 func (_u *ChargeUsageBasedRunInvoicedUsageUpdateOne) SetNillableServicePeriodTo(v *time.Time) *ChargeUsageBasedRunInvoicedUsageUpdateOne {
 	if v != nil {
 		_u.SetServicePeriodTo(*v)
-	}
-	return _u
-}
-
-// SetMutable sets the "mutable" field.
-func (_u *ChargeUsageBasedRunInvoicedUsageUpdateOne) SetMutable(v bool) *ChargeUsageBasedRunInvoicedUsageUpdateOne {
-	_u.mutation.SetMutable(v)
-	return _u
-}
-
-// SetNillableMutable sets the "mutable" field if the given value is not nil.
-func (_u *ChargeUsageBasedRunInvoicedUsageUpdateOne) SetNillableMutable(v *bool) *ChargeUsageBasedRunInvoicedUsageUpdateOne {
-	if v != nil {
-		_u.SetMutable(*v)
 	}
 	return _u
 }
@@ -701,11 +619,6 @@ func (_u *ChargeUsageBasedRunInvoicedUsageUpdateOne) defaults() {
 
 // check runs all checks and user-defined validators on the builder.
 func (_u *ChargeUsageBasedRunInvoicedUsageUpdateOne) check() error {
-	if v, ok := _u.mutation.LineID(); ok {
-		if err := chargeusagebasedruninvoicedusage.LineIDValidator(v); err != nil {
-			return &ValidationError{Name: "line_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunInvoicedUsage.line_id": %w`, err)}
-		}
-	}
 	if v, ok := _u.mutation.LedgerTransactionGroupID(); ok {
 		if err := chargeusagebasedruninvoicedusage.LedgerTransactionGroupIDValidator(v); err != nil {
 			return &ValidationError{Name: "ledger_transaction_group_id", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedRunInvoicedUsage.ledger_transaction_group_id": %w`, err)}
@@ -746,20 +659,11 @@ func (_u *ChargeUsageBasedRunInvoicedUsageUpdateOne) sqlSave(ctx context.Context
 			}
 		}
 	}
-	if value, ok := _u.mutation.LineID(); ok {
-		_spec.SetField(chargeusagebasedruninvoicedusage.FieldLineID, field.TypeString, value)
-	}
-	if _u.mutation.LineIDCleared() {
-		_spec.ClearField(chargeusagebasedruninvoicedusage.FieldLineID, field.TypeString)
-	}
 	if value, ok := _u.mutation.ServicePeriodFrom(); ok {
 		_spec.SetField(chargeusagebasedruninvoicedusage.FieldServicePeriodFrom, field.TypeTime, value)
 	}
 	if value, ok := _u.mutation.ServicePeriodTo(); ok {
 		_spec.SetField(chargeusagebasedruninvoicedusage.FieldServicePeriodTo, field.TypeTime, value)
-	}
-	if value, ok := _u.mutation.Mutable(); ok {
-		_spec.SetField(chargeusagebasedruninvoicedusage.FieldMutable, field.TypeBool, value)
 	}
 	if value, ok := _u.mutation.LedgerTransactionGroupID(); ok {
 		_spec.SetField(chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID, field.TypeString, value)

--- a/openmeter/ent/db/client.go
+++ b/openmeter/ent/db/client.go
@@ -2965,6 +2965,22 @@ func (c *BillingInvoiceClient) QueryBillingInvoiceValidationIssues(_m *BillingIn
 	return query
 }
 
+// QueryChargeFlatFeeRuns queries the charge_flat_fee_runs edge of a BillingInvoice.
+func (c *BillingInvoiceClient) QueryChargeFlatFeeRuns(_m *BillingInvoice) *ChargeFlatFeeRunQuery {
+	query := (&ChargeFlatFeeRunClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(billinginvoice.Table, billinginvoice.FieldID, id),
+			sqlgraph.To(chargeflatfeerun.Table, chargeflatfeerun.FieldID),
+			sqlgraph.Edge(sqlgraph.O2M, false, billinginvoice.ChargeFlatFeeRunsTable, billinginvoice.ChargeFlatFeeRunsColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryChargeUsageBasedRuns queries the charge_usage_based_runs edge of a BillingInvoice.
 func (c *BillingInvoiceClient) QueryChargeUsageBasedRuns(_m *BillingInvoice) *ChargeUsageBasedRunsQuery {
 	query := (&ChargeUsageBasedRunsClient{config: c.config}).Query()
@@ -3551,15 +3567,15 @@ func (c *BillingInvoiceLineClient) QueryChargeFlatFeeRunCreditAllocations(_m *Bi
 	return query
 }
 
-// QueryChargeFlatFeeRunInvoicedUsage queries the charge_flat_fee_run_invoiced_usage edge of a BillingInvoiceLine.
-func (c *BillingInvoiceLineClient) QueryChargeFlatFeeRunInvoicedUsage(_m *BillingInvoiceLine) *ChargeFlatFeeRunInvoicedUsageQuery {
-	query := (&ChargeFlatFeeRunInvoicedUsageClient{config: c.config}).Query()
+// QueryChargeFlatFeeRuns queries the charge_flat_fee_runs edge of a BillingInvoiceLine.
+func (c *BillingInvoiceLineClient) QueryChargeFlatFeeRuns(_m *BillingInvoiceLine) *ChargeFlatFeeRunQuery {
+	query := (&ChargeFlatFeeRunClient{config: c.config}).Query()
 	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
 		id := _m.ID
 		step := sqlgraph.NewStep(
 			sqlgraph.From(billinginvoiceline.Table, billinginvoiceline.FieldID, id),
-			sqlgraph.To(chargeflatfeeruninvoicedusage.Table, chargeflatfeeruninvoicedusage.FieldID),
-			sqlgraph.Edge(sqlgraph.O2M, false, billinginvoiceline.ChargeFlatFeeRunInvoicedUsageTable, billinginvoiceline.ChargeFlatFeeRunInvoicedUsageColumn),
+			sqlgraph.To(chargeflatfeerun.Table, chargeflatfeerun.FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, false, billinginvoiceline.ChargeFlatFeeRunsTable, billinginvoiceline.ChargeFlatFeeRunsColumn),
 		)
 		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
 		return fromV, nil
@@ -6841,6 +6857,38 @@ func (c *ChargeFlatFeeRunClient) QueryFlatFee(_m *ChargeFlatFeeRun) *ChargeFlatF
 	return query
 }
 
+// QueryBillingInvoiceLine queries the billing_invoice_line edge of a ChargeFlatFeeRun.
+func (c *ChargeFlatFeeRunClient) QueryBillingInvoiceLine(_m *ChargeFlatFeeRun) *BillingInvoiceLineQuery {
+	query := (&BillingInvoiceLineClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeflatfeerun.Table, chargeflatfeerun.FieldID, id),
+			sqlgraph.To(billinginvoiceline.Table, billinginvoiceline.FieldID),
+			sqlgraph.Edge(sqlgraph.O2O, true, chargeflatfeerun.BillingInvoiceLineTable, chargeflatfeerun.BillingInvoiceLineColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
+// QueryBillingInvoice queries the billing_invoice edge of a ChargeFlatFeeRun.
+func (c *ChargeFlatFeeRunClient) QueryBillingInvoice(_m *ChargeFlatFeeRun) *BillingInvoiceQuery {
+	query := (&BillingInvoiceClient{config: c.config}).Query()
+	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
+		id := _m.ID
+		step := sqlgraph.NewStep(
+			sqlgraph.From(chargeflatfeerun.Table, chargeflatfeerun.FieldID, id),
+			sqlgraph.To(billinginvoice.Table, billinginvoice.FieldID),
+			sqlgraph.Edge(sqlgraph.M2O, true, chargeflatfeerun.BillingInvoiceTable, chargeflatfeerun.BillingInvoiceColumn),
+		)
+		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
+		return fromV, nil
+	}
+	return query
+}
+
 // QueryCreditAllocations queries the credit_allocations edge of a ChargeFlatFeeRun.
 func (c *ChargeFlatFeeRunClient) QueryCreditAllocations(_m *ChargeFlatFeeRun) *ChargeFlatFeeRunCreditAllocationsQuery {
 	query := (&ChargeFlatFeeRunCreditAllocationsClient{config: c.config}).Query()
@@ -7398,22 +7446,6 @@ func (c *ChargeFlatFeeRunInvoicedUsageClient) GetX(ctx context.Context, id strin
 		panic(err)
 	}
 	return obj
-}
-
-// QueryBillingInvoiceLine queries the billing_invoice_line edge of a ChargeFlatFeeRunInvoicedUsage.
-func (c *ChargeFlatFeeRunInvoicedUsageClient) QueryBillingInvoiceLine(_m *ChargeFlatFeeRunInvoicedUsage) *BillingInvoiceLineQuery {
-	query := (&BillingInvoiceLineClient{config: c.config}).Query()
-	query.path = func(context.Context) (fromV *sql.Selector, _ error) {
-		id := _m.ID
-		step := sqlgraph.NewStep(
-			sqlgraph.From(chargeflatfeeruninvoicedusage.Table, chargeflatfeeruninvoicedusage.FieldID, id),
-			sqlgraph.To(billinginvoiceline.Table, billinginvoiceline.FieldID),
-			sqlgraph.Edge(sqlgraph.M2O, true, chargeflatfeeruninvoicedusage.BillingInvoiceLineTable, chargeflatfeeruninvoicedusage.BillingInvoiceLineColumn),
-		)
-		fromV = sqlgraph.Neighbors(_m.driver.Dialect(), step)
-		return fromV, nil
-	}
-	return query
 }
 
 // QueryRun queries the run edge of a ChargeFlatFeeRunInvoicedUsage.

--- a/openmeter/ent/db/entmixinaccessor.go
+++ b/openmeter/ent/db/entmixinaccessor.go
@@ -1497,20 +1497,12 @@ func (e *ChargeFlatFeeRunInvoicedUsage) GetID() string {
 	return e.ID
 }
 
-func (e *ChargeFlatFeeRunInvoicedUsage) GetLineID() *string {
-	return e.LineID
-}
-
 func (e *ChargeFlatFeeRunInvoicedUsage) GetServicePeriodFrom() time.Time {
 	return e.ServicePeriodFrom
 }
 
 func (e *ChargeFlatFeeRunInvoicedUsage) GetServicePeriodTo() time.Time {
 	return e.ServicePeriodTo
-}
-
-func (e *ChargeFlatFeeRunInvoicedUsage) GetMutable() bool {
-	return e.Mutable
 }
 
 func (e *ChargeFlatFeeRunInvoicedUsage) GetLedgerTransactionGroupID() *string {
@@ -1921,20 +1913,12 @@ func (e *ChargeUsageBasedRunInvoicedUsage) GetID() string {
 	return e.ID
 }
 
-func (e *ChargeUsageBasedRunInvoicedUsage) GetLineID() *string {
-	return e.LineID
-}
-
 func (e *ChargeUsageBasedRunInvoicedUsage) GetServicePeriodFrom() time.Time {
 	return e.ServicePeriodFrom
 }
 
 func (e *ChargeUsageBasedRunInvoicedUsage) GetServicePeriodTo() time.Time {
 	return e.ServicePeriodTo
-}
-
-func (e *ChargeUsageBasedRunInvoicedUsage) GetMutable() bool {
-	return e.Mutable
 }
 
 func (e *ChargeUsageBasedRunInvoicedUsage) GetLedgerTransactionGroupID() *string {

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -2069,6 +2069,9 @@ var (
 		{Name: "service_period_from", Type: field.TypeTime},
 		{Name: "service_period_to", Type: field.TypeTime},
 		{Name: "amount_after_proration", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
+		{Name: "no_fiat_transaction_required", Type: field.TypeBool},
+		{Name: "invoice_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
+		{Name: "line_id", Type: field.TypeString, Unique: true, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "charge_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 	}
 	// ChargeFlatFeeRunsTable holds the schema information for the "charge_flat_fee_runs" table.
@@ -2078,8 +2081,20 @@ var (
 		PrimaryKey: []*schema.Column{ChargeFlatFeeRunsColumns[0]},
 		ForeignKeys: []*schema.ForeignKey{
 			{
+				Symbol:     "charge_flat_fee_runs_billing_invoices_charge_flat_fee_runs",
+				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[19]},
+				RefColumns: []*schema.Column{BillingInvoicesColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+			{
+				Symbol:     "charge_flat_fee_runs_billing_invoice_lines_charge_flat_fee_runs",
+				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[20]},
+				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
+				OnDelete:   schema.SetNull,
+			},
+			{
 				Symbol:     "charge_flat_fee_runs_charge_flat_fees_runs",
-				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[18]},
+				Columns:    []*schema.Column{ChargeFlatFeeRunsColumns[21]},
 				RefColumns: []*schema.Column{ChargeFlatFeesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -2098,7 +2113,7 @@ var (
 			{
 				Name:    "chargeflatfeerun_namespace_charge_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeFlatFeeRunsColumns[1], ChargeFlatFeeRunsColumns[18]},
+				Columns: []*schema.Column{ChargeFlatFeeRunsColumns[1], ChargeFlatFeeRunsColumns[21]},
 			},
 		},
 	}
@@ -2274,7 +2289,6 @@ var (
 		{Name: "id", Type: field.TypeString, Unique: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "service_period_from", Type: field.TypeTime},
 		{Name: "service_period_to", Type: field.TypeTime},
-		{Name: "mutable", Type: field.TypeBool},
 		{Name: "ledger_transaction_group_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "namespace", Type: field.TypeString},
 		{Name: "created_at", Type: field.TypeTime},
@@ -2289,7 +2303,6 @@ var (
 		{Name: "discounts_total", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "credits_total", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "total", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
-		{Name: "line_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "run_id", Type: field.TypeString, Unique: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 	}
 	// ChargeFlatFeeRunInvoicedUsagesTable holds the schema information for the "charge_flat_fee_run_invoiced_usages" table.
@@ -2299,14 +2312,8 @@ var (
 		PrimaryKey: []*schema.Column{ChargeFlatFeeRunInvoicedUsagesColumns[0]},
 		ForeignKeys: []*schema.ForeignKey{
 			{
-				Symbol:     "charge_flat_fee_run_invoiced_usages_billing_invoice_lines_charge_flat_fee_run_invoiced_usage",
-				Columns:    []*schema.Column{ChargeFlatFeeRunInvoicedUsagesColumns[18]},
-				RefColumns: []*schema.Column{BillingInvoiceLinesColumns[0]},
-				OnDelete:   schema.SetNull,
-			},
-			{
 				Symbol:     "charge_flat_fee_run_invoiced_usages_charge_flat_fee_runs_invoiced_usage",
-				Columns:    []*schema.Column{ChargeFlatFeeRunInvoicedUsagesColumns[19]},
+				Columns:    []*schema.Column{ChargeFlatFeeRunInvoicedUsagesColumns[17]},
 				RefColumns: []*schema.Column{ChargeFlatFeeRunsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -2315,7 +2322,7 @@ var (
 			{
 				Name:    "chargeflatfeeruninvoicedusage_namespace",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeFlatFeeRunInvoicedUsagesColumns[5]},
+				Columns: []*schema.Column{ChargeFlatFeeRunInvoicedUsagesColumns[4]},
 			},
 			{
 				Name:    "chargeflatfeeruninvoicedusage_id",
@@ -2325,7 +2332,7 @@ var (
 			{
 				Name:    "chargeflatfeeruninvoicedusage_annotations",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeFlatFeeRunInvoicedUsagesColumns[9]},
+				Columns: []*schema.Column{ChargeFlatFeeRunInvoicedUsagesColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Types: map[string]string{
 						"postgres": "GIN",
@@ -2335,7 +2342,7 @@ var (
 			{
 				Name:    "chargeflatfeeruninvoicedusage_namespace_run_id",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeFlatFeeRunInvoicedUsagesColumns[5], ChargeFlatFeeRunInvoicedUsagesColumns[19]},
+				Columns: []*schema.Column{ChargeFlatFeeRunInvoicedUsagesColumns[4], ChargeFlatFeeRunInvoicedUsagesColumns[17]},
 			},
 		},
 	}
@@ -2712,10 +2719,8 @@ var (
 	// ChargeUsageBasedRunInvoicedUsagesColumns holds the columns for the "charge_usage_based_run_invoiced_usages" table.
 	ChargeUsageBasedRunInvoicedUsagesColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeString, Unique: true, SchemaType: map[string]string{"postgres": "char(26)"}},
-		{Name: "line_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "service_period_from", Type: field.TypeTime},
 		{Name: "service_period_to", Type: field.TypeTime},
-		{Name: "mutable", Type: field.TypeBool},
 		{Name: "ledger_transaction_group_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "namespace", Type: field.TypeString},
 		{Name: "created_at", Type: field.TypeTime},
@@ -2740,7 +2745,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_run_invoiced_usages_charge_usage_based_runs_invoiced_usage",
-				Columns:    []*schema.Column{ChargeUsageBasedRunInvoicedUsagesColumns[19]},
+				Columns:    []*schema.Column{ChargeUsageBasedRunInvoicedUsagesColumns[17]},
 				RefColumns: []*schema.Column{ChargeUsageBasedRunsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
@@ -2749,7 +2754,7 @@ var (
 			{
 				Name:    "chargeusagebasedruninvoicedusage_namespace",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunInvoicedUsagesColumns[6]},
+				Columns: []*schema.Column{ChargeUsageBasedRunInvoicedUsagesColumns[4]},
 			},
 			{
 				Name:    "chargeusagebasedruninvoicedusage_id",
@@ -2759,7 +2764,7 @@ var (
 			{
 				Name:    "chargeusagebasedruninvoicedusage_annotations",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedRunInvoicedUsagesColumns[10]},
+				Columns: []*schema.Column{ChargeUsageBasedRunInvoicedUsagesColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Types: map[string]string{
 						"postgres": "GIN",
@@ -5238,7 +5243,9 @@ func init() {
 	ChargeFlatFeesTable.ForeignKeys[4].RefTable = SubscriptionItemsTable
 	ChargeFlatFeesTable.ForeignKeys[5].RefTable = SubscriptionPhasesTable
 	ChargeFlatFeesTable.ForeignKeys[6].RefTable = TaxCodesTable
-	ChargeFlatFeeRunsTable.ForeignKeys[0].RefTable = ChargeFlatFeesTable
+	ChargeFlatFeeRunsTable.ForeignKeys[0].RefTable = BillingInvoicesTable
+	ChargeFlatFeeRunsTable.ForeignKeys[1].RefTable = BillingInvoiceLinesTable
+	ChargeFlatFeeRunsTable.ForeignKeys[2].RefTable = ChargeFlatFeesTable
 	ChargeFlatFeeRunCreditAllocationsTable.ForeignKeys[0].RefTable = BillingInvoiceLinesTable
 	ChargeFlatFeeRunCreditAllocationsTable.ForeignKeys[1].RefTable = ChargeFlatFeeRunsTable
 	ChargeFlatFeeRunCreditAllocationsTable.ForeignKeys[2].RefTable = ChargeFlatFeeRunCreditAllocationsTable
@@ -5248,8 +5255,7 @@ func init() {
 	ChargeFlatFeeRunDetailedLinesTable.Annotation.Checks = map[string]string{
 		"child_unique_reference_id_not_empty": "child_unique_reference_id <> ''",
 	}
-	ChargeFlatFeeRunInvoicedUsagesTable.ForeignKeys[0].RefTable = BillingInvoiceLinesTable
-	ChargeFlatFeeRunInvoicedUsagesTable.ForeignKeys[1].RefTable = ChargeFlatFeeRunsTable
+	ChargeFlatFeeRunInvoicedUsagesTable.ForeignKeys[0].RefTable = ChargeFlatFeeRunsTable
 	ChargeFlatFeeRunPaymentsTable.ForeignKeys[0].RefTable = BillingInvoiceLinesTable
 	ChargeFlatFeeRunPaymentsTable.ForeignKeys[1].RefTable = ChargeFlatFeeRunsTable
 	ChargeUsageBasedTable.ForeignKeys[0].RefTable = ChargeUsageBasedRunsTable

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -11948,6 +11948,9 @@ type BillingInvoiceMutation struct {
 	billing_invoice_validation_issues        map[string]struct{}
 	removedbilling_invoice_validation_issues map[string]struct{}
 	clearedbilling_invoice_validation_issues bool
+	charge_flat_fee_runs                     map[string]struct{}
+	removedcharge_flat_fee_runs              map[string]struct{}
+	clearedcharge_flat_fee_runs              bool
 	charge_usage_based_runs                  map[string]struct{}
 	removedcharge_usage_based_runs           map[string]struct{}
 	clearedcharge_usage_based_runs           bool
@@ -14847,6 +14850,60 @@ func (m *BillingInvoiceMutation) ResetBillingInvoiceValidationIssues() {
 	m.removedbilling_invoice_validation_issues = nil
 }
 
+// AddChargeFlatFeeRunIDs adds the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity by ids.
+func (m *BillingInvoiceMutation) AddChargeFlatFeeRunIDs(ids ...string) {
+	if m.charge_flat_fee_runs == nil {
+		m.charge_flat_fee_runs = make(map[string]struct{})
+	}
+	for i := range ids {
+		m.charge_flat_fee_runs[ids[i]] = struct{}{}
+	}
+}
+
+// ClearChargeFlatFeeRuns clears the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity.
+func (m *BillingInvoiceMutation) ClearChargeFlatFeeRuns() {
+	m.clearedcharge_flat_fee_runs = true
+}
+
+// ChargeFlatFeeRunsCleared reports if the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity was cleared.
+func (m *BillingInvoiceMutation) ChargeFlatFeeRunsCleared() bool {
+	return m.clearedcharge_flat_fee_runs
+}
+
+// RemoveChargeFlatFeeRunIDs removes the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity by IDs.
+func (m *BillingInvoiceMutation) RemoveChargeFlatFeeRunIDs(ids ...string) {
+	if m.removedcharge_flat_fee_runs == nil {
+		m.removedcharge_flat_fee_runs = make(map[string]struct{})
+	}
+	for i := range ids {
+		delete(m.charge_flat_fee_runs, ids[i])
+		m.removedcharge_flat_fee_runs[ids[i]] = struct{}{}
+	}
+}
+
+// RemovedChargeFlatFeeRuns returns the removed IDs of the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity.
+func (m *BillingInvoiceMutation) RemovedChargeFlatFeeRunsIDs() (ids []string) {
+	for id := range m.removedcharge_flat_fee_runs {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ChargeFlatFeeRunsIDs returns the "charge_flat_fee_runs" edge IDs in the mutation.
+func (m *BillingInvoiceMutation) ChargeFlatFeeRunsIDs() (ids []string) {
+	for id := range m.charge_flat_fee_runs {
+		ids = append(ids, id)
+	}
+	return
+}
+
+// ResetChargeFlatFeeRuns resets all changes to the "charge_flat_fee_runs" edge.
+func (m *BillingInvoiceMutation) ResetChargeFlatFeeRuns() {
+	m.charge_flat_fee_runs = nil
+	m.clearedcharge_flat_fee_runs = false
+	m.removedcharge_flat_fee_runs = nil
+}
+
 // AddChargeUsageBasedRunIDs adds the "charge_usage_based_runs" edge to the ChargeUsageBasedRuns entity by ids.
 func (m *BillingInvoiceMutation) AddChargeUsageBasedRunIDs(ids ...string) {
 	if m.charge_usage_based_runs == nil {
@@ -16346,7 +16403,7 @@ func (m *BillingInvoiceMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *BillingInvoiceMutation) AddedEdges() []string {
-	edges := make([]string, 0, 10)
+	edges := make([]string, 0, 11)
 	if m.source_billing_profile != nil {
 		edges = append(edges, billinginvoice.EdgeSourceBillingProfile)
 	}
@@ -16361,6 +16418,9 @@ func (m *BillingInvoiceMutation) AddedEdges() []string {
 	}
 	if m.billing_invoice_validation_issues != nil {
 		edges = append(edges, billinginvoice.EdgeBillingInvoiceValidationIssues)
+	}
+	if m.charge_flat_fee_runs != nil {
+		edges = append(edges, billinginvoice.EdgeChargeFlatFeeRuns)
 	}
 	if m.charge_usage_based_runs != nil {
 		edges = append(edges, billinginvoice.EdgeChargeUsageBasedRuns)
@@ -16410,6 +16470,12 @@ func (m *BillingInvoiceMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case billinginvoice.EdgeChargeFlatFeeRuns:
+		ids := make([]ent.Value, 0, len(m.charge_flat_fee_runs))
+		for id := range m.charge_flat_fee_runs {
+			ids = append(ids, id)
+		}
+		return ids
 	case billinginvoice.EdgeChargeUsageBasedRuns:
 		ids := make([]ent.Value, 0, len(m.charge_usage_based_runs))
 		for id := range m.charge_usage_based_runs {
@@ -16438,7 +16504,7 @@ func (m *BillingInvoiceMutation) AddedIDs(name string) []ent.Value {
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *BillingInvoiceMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 10)
+	edges := make([]string, 0, 11)
 	if m.removedbilling_invoice_lines != nil {
 		edges = append(edges, billinginvoice.EdgeBillingInvoiceLines)
 	}
@@ -16447,6 +16513,9 @@ func (m *BillingInvoiceMutation) RemovedEdges() []string {
 	}
 	if m.removedbilling_invoice_validation_issues != nil {
 		edges = append(edges, billinginvoice.EdgeBillingInvoiceValidationIssues)
+	}
+	if m.removedcharge_flat_fee_runs != nil {
+		edges = append(edges, billinginvoice.EdgeChargeFlatFeeRuns)
 	}
 	if m.removedcharge_usage_based_runs != nil {
 		edges = append(edges, billinginvoice.EdgeChargeUsageBasedRuns)
@@ -16476,6 +16545,12 @@ func (m *BillingInvoiceMutation) RemovedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
+	case billinginvoice.EdgeChargeFlatFeeRuns:
+		ids := make([]ent.Value, 0, len(m.removedcharge_flat_fee_runs))
+		for id := range m.removedcharge_flat_fee_runs {
+			ids = append(ids, id)
+		}
+		return ids
 	case billinginvoice.EdgeChargeUsageBasedRuns:
 		ids := make([]ent.Value, 0, len(m.removedcharge_usage_based_runs))
 		for id := range m.removedcharge_usage_based_runs {
@@ -16488,7 +16563,7 @@ func (m *BillingInvoiceMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *BillingInvoiceMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 10)
+	edges := make([]string, 0, 11)
 	if m.clearedsource_billing_profile {
 		edges = append(edges, billinginvoice.EdgeSourceBillingProfile)
 	}
@@ -16503,6 +16578,9 @@ func (m *BillingInvoiceMutation) ClearedEdges() []string {
 	}
 	if m.clearedbilling_invoice_validation_issues {
 		edges = append(edges, billinginvoice.EdgeBillingInvoiceValidationIssues)
+	}
+	if m.clearedcharge_flat_fee_runs {
+		edges = append(edges, billinginvoice.EdgeChargeFlatFeeRuns)
 	}
 	if m.clearedcharge_usage_based_runs {
 		edges = append(edges, billinginvoice.EdgeChargeUsageBasedRuns)
@@ -16536,6 +16614,8 @@ func (m *BillingInvoiceMutation) EdgeCleared(name string) bool {
 		return m.clearedbilling_invoice_detailed_lines
 	case billinginvoice.EdgeBillingInvoiceValidationIssues:
 		return m.clearedbilling_invoice_validation_issues
+	case billinginvoice.EdgeChargeFlatFeeRuns:
+		return m.clearedcharge_flat_fee_runs
 	case billinginvoice.EdgeChargeUsageBasedRuns:
 		return m.clearedcharge_usage_based_runs
 	case billinginvoice.EdgeBillingInvoiceCustomer:
@@ -16594,6 +16674,9 @@ func (m *BillingInvoiceMutation) ResetEdge(name string) error {
 		return nil
 	case billinginvoice.EdgeBillingInvoiceValidationIssues:
 		m.ResetBillingInvoiceValidationIssues()
+		return nil
+	case billinginvoice.EdgeChargeFlatFeeRuns:
+		m.ResetChargeFlatFeeRuns()
 		return nil
 	case billinginvoice.EdgeChargeUsageBasedRuns:
 		m.ResetChargeUsageBasedRuns()
@@ -17298,9 +17381,8 @@ type BillingInvoiceLineMutation struct {
 	charge_flat_fee_run_credit_allocations         map[string]struct{}
 	removedcharge_flat_fee_run_credit_allocations  map[string]struct{}
 	clearedcharge_flat_fee_run_credit_allocations  bool
-	charge_flat_fee_run_invoiced_usage             map[string]struct{}
-	removedcharge_flat_fee_run_invoiced_usage      map[string]struct{}
-	clearedcharge_flat_fee_run_invoiced_usage      bool
+	charge_flat_fee_runs                           *string
+	clearedcharge_flat_fee_runs                    bool
 	charge_usage_based_run                         *string
 	clearedcharge_usage_based_run                  bool
 	charge_credit_purchase_invoiced_payment        *string
@@ -19839,58 +19921,43 @@ func (m *BillingInvoiceLineMutation) ResetChargeFlatFeeRunCreditAllocations() {
 	m.removedcharge_flat_fee_run_credit_allocations = nil
 }
 
-// AddChargeFlatFeeRunInvoicedUsageIDs adds the "charge_flat_fee_run_invoiced_usage" edge to the ChargeFlatFeeRunInvoicedUsage entity by ids.
-func (m *BillingInvoiceLineMutation) AddChargeFlatFeeRunInvoicedUsageIDs(ids ...string) {
-	if m.charge_flat_fee_run_invoiced_usage == nil {
-		m.charge_flat_fee_run_invoiced_usage = make(map[string]struct{})
-	}
-	for i := range ids {
-		m.charge_flat_fee_run_invoiced_usage[ids[i]] = struct{}{}
-	}
+// SetChargeFlatFeeRunsID sets the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity by id.
+func (m *BillingInvoiceLineMutation) SetChargeFlatFeeRunsID(id string) {
+	m.charge_flat_fee_runs = &id
 }
 
-// ClearChargeFlatFeeRunInvoicedUsage clears the "charge_flat_fee_run_invoiced_usage" edge to the ChargeFlatFeeRunInvoicedUsage entity.
-func (m *BillingInvoiceLineMutation) ClearChargeFlatFeeRunInvoicedUsage() {
-	m.clearedcharge_flat_fee_run_invoiced_usage = true
+// ClearChargeFlatFeeRuns clears the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity.
+func (m *BillingInvoiceLineMutation) ClearChargeFlatFeeRuns() {
+	m.clearedcharge_flat_fee_runs = true
 }
 
-// ChargeFlatFeeRunInvoicedUsageCleared reports if the "charge_flat_fee_run_invoiced_usage" edge to the ChargeFlatFeeRunInvoicedUsage entity was cleared.
-func (m *BillingInvoiceLineMutation) ChargeFlatFeeRunInvoicedUsageCleared() bool {
-	return m.clearedcharge_flat_fee_run_invoiced_usage
+// ChargeFlatFeeRunsCleared reports if the "charge_flat_fee_runs" edge to the ChargeFlatFeeRun entity was cleared.
+func (m *BillingInvoiceLineMutation) ChargeFlatFeeRunsCleared() bool {
+	return m.clearedcharge_flat_fee_runs
 }
 
-// RemoveChargeFlatFeeRunInvoicedUsageIDs removes the "charge_flat_fee_run_invoiced_usage" edge to the ChargeFlatFeeRunInvoicedUsage entity by IDs.
-func (m *BillingInvoiceLineMutation) RemoveChargeFlatFeeRunInvoicedUsageIDs(ids ...string) {
-	if m.removedcharge_flat_fee_run_invoiced_usage == nil {
-		m.removedcharge_flat_fee_run_invoiced_usage = make(map[string]struct{})
-	}
-	for i := range ids {
-		delete(m.charge_flat_fee_run_invoiced_usage, ids[i])
-		m.removedcharge_flat_fee_run_invoiced_usage[ids[i]] = struct{}{}
-	}
-}
-
-// RemovedChargeFlatFeeRunInvoicedUsage returns the removed IDs of the "charge_flat_fee_run_invoiced_usage" edge to the ChargeFlatFeeRunInvoicedUsage entity.
-func (m *BillingInvoiceLineMutation) RemovedChargeFlatFeeRunInvoicedUsageIDs() (ids []string) {
-	for id := range m.removedcharge_flat_fee_run_invoiced_usage {
-		ids = append(ids, id)
+// ChargeFlatFeeRunsID returns the "charge_flat_fee_runs" edge ID in the mutation.
+func (m *BillingInvoiceLineMutation) ChargeFlatFeeRunsID() (id string, exists bool) {
+	if m.charge_flat_fee_runs != nil {
+		return *m.charge_flat_fee_runs, true
 	}
 	return
 }
 
-// ChargeFlatFeeRunInvoicedUsageIDs returns the "charge_flat_fee_run_invoiced_usage" edge IDs in the mutation.
-func (m *BillingInvoiceLineMutation) ChargeFlatFeeRunInvoicedUsageIDs() (ids []string) {
-	for id := range m.charge_flat_fee_run_invoiced_usage {
-		ids = append(ids, id)
+// ChargeFlatFeeRunsIDs returns the "charge_flat_fee_runs" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// ChargeFlatFeeRunsID instead. It exists only for internal usage by the builders.
+func (m *BillingInvoiceLineMutation) ChargeFlatFeeRunsIDs() (ids []string) {
+	if id := m.charge_flat_fee_runs; id != nil {
+		ids = append(ids, *id)
 	}
 	return
 }
 
-// ResetChargeFlatFeeRunInvoicedUsage resets all changes to the "charge_flat_fee_run_invoiced_usage" edge.
-func (m *BillingInvoiceLineMutation) ResetChargeFlatFeeRunInvoicedUsage() {
-	m.charge_flat_fee_run_invoiced_usage = nil
-	m.clearedcharge_flat_fee_run_invoiced_usage = false
-	m.removedcharge_flat_fee_run_invoiced_usage = nil
+// ResetChargeFlatFeeRuns resets all changes to the "charge_flat_fee_runs" edge.
+func (m *BillingInvoiceLineMutation) ResetChargeFlatFeeRuns() {
+	m.charge_flat_fee_runs = nil
+	m.clearedcharge_flat_fee_runs = false
 }
 
 // SetChargeUsageBasedRunID sets the "charge_usage_based_run" edge to the ChargeUsageBasedRuns entity by id.
@@ -21026,8 +21093,8 @@ func (m *BillingInvoiceLineMutation) AddedEdges() []string {
 	if m.charge_flat_fee_run_credit_allocations != nil {
 		edges = append(edges, billinginvoiceline.EdgeChargeFlatFeeRunCreditAllocations)
 	}
-	if m.charge_flat_fee_run_invoiced_usage != nil {
-		edges = append(edges, billinginvoiceline.EdgeChargeFlatFeeRunInvoicedUsage)
+	if m.charge_flat_fee_runs != nil {
+		edges = append(edges, billinginvoiceline.EdgeChargeFlatFeeRuns)
 	}
 	if m.charge_usage_based_run != nil {
 		edges = append(edges, billinginvoiceline.EdgeChargeUsageBasedRun)
@@ -21115,12 +21182,10 @@ func (m *BillingInvoiceLineMutation) AddedIDs(name string) []ent.Value {
 			ids = append(ids, id)
 		}
 		return ids
-	case billinginvoiceline.EdgeChargeFlatFeeRunInvoicedUsage:
-		ids := make([]ent.Value, 0, len(m.charge_flat_fee_run_invoiced_usage))
-		for id := range m.charge_flat_fee_run_invoiced_usage {
-			ids = append(ids, id)
+	case billinginvoiceline.EdgeChargeFlatFeeRuns:
+		if id := m.charge_flat_fee_runs; id != nil {
+			return []ent.Value{*id}
 		}
-		return ids
 	case billinginvoiceline.EdgeChargeUsageBasedRun:
 		if id := m.charge_usage_based_run; id != nil {
 			return []ent.Value{*id}
@@ -21154,9 +21219,6 @@ func (m *BillingInvoiceLineMutation) RemovedEdges() []string {
 	}
 	if m.removedcharge_flat_fee_run_credit_allocations != nil {
 		edges = append(edges, billinginvoiceline.EdgeChargeFlatFeeRunCreditAllocations)
-	}
-	if m.removedcharge_flat_fee_run_invoiced_usage != nil {
-		edges = append(edges, billinginvoiceline.EdgeChargeFlatFeeRunInvoicedUsage)
 	}
 	return edges
 }
@@ -21192,12 +21254,6 @@ func (m *BillingInvoiceLineMutation) RemovedIDs(name string) []ent.Value {
 	case billinginvoiceline.EdgeChargeFlatFeeRunCreditAllocations:
 		ids := make([]ent.Value, 0, len(m.removedcharge_flat_fee_run_credit_allocations))
 		for id := range m.removedcharge_flat_fee_run_credit_allocations {
-			ids = append(ids, id)
-		}
-		return ids
-	case billinginvoiceline.EdgeChargeFlatFeeRunInvoicedUsage:
-		ids := make([]ent.Value, 0, len(m.removedcharge_flat_fee_run_invoiced_usage))
-		for id := range m.removedcharge_flat_fee_run_invoiced_usage {
 			ids = append(ids, id)
 		}
 		return ids
@@ -21253,8 +21309,8 @@ func (m *BillingInvoiceLineMutation) ClearedEdges() []string {
 	if m.clearedcharge_flat_fee_run_credit_allocations {
 		edges = append(edges, billinginvoiceline.EdgeChargeFlatFeeRunCreditAllocations)
 	}
-	if m.clearedcharge_flat_fee_run_invoiced_usage {
-		edges = append(edges, billinginvoiceline.EdgeChargeFlatFeeRunInvoicedUsage)
+	if m.clearedcharge_flat_fee_runs {
+		edges = append(edges, billinginvoiceline.EdgeChargeFlatFeeRuns)
 	}
 	if m.clearedcharge_usage_based_run {
 		edges = append(edges, billinginvoiceline.EdgeChargeUsageBasedRun)
@@ -21302,8 +21358,8 @@ func (m *BillingInvoiceLineMutation) EdgeCleared(name string) bool {
 		return m.clearedcharge_flat_fee_run_payment
 	case billinginvoiceline.EdgeChargeFlatFeeRunCreditAllocations:
 		return m.clearedcharge_flat_fee_run_credit_allocations
-	case billinginvoiceline.EdgeChargeFlatFeeRunInvoicedUsage:
-		return m.clearedcharge_flat_fee_run_invoiced_usage
+	case billinginvoiceline.EdgeChargeFlatFeeRuns:
+		return m.clearedcharge_flat_fee_runs
 	case billinginvoiceline.EdgeChargeUsageBasedRun:
 		return m.clearedcharge_usage_based_run
 	case billinginvoiceline.EdgeChargeCreditPurchaseInvoicedPayment:
@@ -21347,6 +21403,9 @@ func (m *BillingInvoiceLineMutation) ClearEdge(name string) error {
 		return nil
 	case billinginvoiceline.EdgeChargeFlatFeeRunPayment:
 		m.ClearChargeFlatFeeRunPayment()
+		return nil
+	case billinginvoiceline.EdgeChargeFlatFeeRuns:
+		m.ClearChargeFlatFeeRuns()
 		return nil
 	case billinginvoiceline.EdgeChargeUsageBasedRun:
 		m.ClearChargeUsageBasedRun()
@@ -21410,8 +21469,8 @@ func (m *BillingInvoiceLineMutation) ResetEdge(name string) error {
 	case billinginvoiceline.EdgeChargeFlatFeeRunCreditAllocations:
 		m.ResetChargeFlatFeeRunCreditAllocations()
 		return nil
-	case billinginvoiceline.EdgeChargeFlatFeeRunInvoicedUsage:
-		m.ResetChargeFlatFeeRunInvoicedUsage()
+	case billinginvoiceline.EdgeChargeFlatFeeRuns:
+		m.ResetChargeFlatFeeRuns()
 		return nil
 	case billinginvoiceline.EdgeChargeUsageBasedRun:
 		m.ResetChargeUsageBasedRun()
@@ -45836,42 +45895,47 @@ func (m *ChargeFlatFeeMutation) ResetEdge(name string) error {
 // ChargeFlatFeeRunMutation represents an operation that mutates the ChargeFlatFeeRun nodes in the graph.
 type ChargeFlatFeeRunMutation struct {
 	config
-	op                        Op
-	typ                       string
-	id                        *string
-	namespace                 *string
-	created_at                *time.Time
-	updated_at                *time.Time
-	deleted_at                *time.Time
-	amount                    *alpacadecimal.Decimal
-	taxes_total               *alpacadecimal.Decimal
-	taxes_inclusive_total     *alpacadecimal.Decimal
-	taxes_exclusive_total     *alpacadecimal.Decimal
-	charges_total             *alpacadecimal.Decimal
-	discounts_total           *alpacadecimal.Decimal
-	credits_total             *alpacadecimal.Decimal
-	total                     *alpacadecimal.Decimal
-	_type                     *flatfee.RealizationRunType
-	initial_type              *flatfee.RealizationRunType
-	service_period_from       *time.Time
-	service_period_to         *time.Time
-	amount_after_proration    *alpacadecimal.Decimal
-	clearedFields             map[string]struct{}
-	flat_fee                  *string
-	clearedflat_fee           bool
-	credit_allocations        map[string]struct{}
-	removedcredit_allocations map[string]struct{}
-	clearedcredit_allocations bool
-	detailed_lines            map[string]struct{}
-	removeddetailed_lines     map[string]struct{}
-	cleareddetailed_lines     bool
-	invoiced_usage            *string
-	clearedinvoiced_usage     bool
-	payment                   *string
-	clearedpayment            bool
-	done                      bool
-	oldValue                  func(context.Context) (*ChargeFlatFeeRun, error)
-	predicates                []predicate.ChargeFlatFeeRun
+	op                           Op
+	typ                          string
+	id                           *string
+	namespace                    *string
+	created_at                   *time.Time
+	updated_at                   *time.Time
+	deleted_at                   *time.Time
+	amount                       *alpacadecimal.Decimal
+	taxes_total                  *alpacadecimal.Decimal
+	taxes_inclusive_total        *alpacadecimal.Decimal
+	taxes_exclusive_total        *alpacadecimal.Decimal
+	charges_total                *alpacadecimal.Decimal
+	discounts_total              *alpacadecimal.Decimal
+	credits_total                *alpacadecimal.Decimal
+	total                        *alpacadecimal.Decimal
+	_type                        *flatfee.RealizationRunType
+	initial_type                 *flatfee.RealizationRunType
+	service_period_from          *time.Time
+	service_period_to            *time.Time
+	amount_after_proration       *alpacadecimal.Decimal
+	no_fiat_transaction_required *bool
+	clearedFields                map[string]struct{}
+	flat_fee                     *string
+	clearedflat_fee              bool
+	billing_invoice_line         *string
+	clearedbilling_invoice_line  bool
+	billing_invoice              *string
+	clearedbilling_invoice       bool
+	credit_allocations           map[string]struct{}
+	removedcredit_allocations    map[string]struct{}
+	clearedcredit_allocations    bool
+	detailed_lines               map[string]struct{}
+	removeddetailed_lines        map[string]struct{}
+	cleareddetailed_lines        bool
+	invoiced_usage               *string
+	clearedinvoiced_usage        bool
+	payment                      *string
+	clearedpayment               bool
+	done                         bool
+	oldValue                     func(context.Context) (*ChargeFlatFeeRun, error)
+	predicates                   []predicate.ChargeFlatFeeRun
 }
 
 var _ ent.Mutation = (*ChargeFlatFeeRunMutation)(nil)
@@ -46603,6 +46667,104 @@ func (m *ChargeFlatFeeRunMutation) ResetServicePeriodTo() {
 	m.service_period_to = nil
 }
 
+// SetLineID sets the "line_id" field.
+func (m *ChargeFlatFeeRunMutation) SetLineID(s string) {
+	m.billing_invoice_line = &s
+}
+
+// LineID returns the value of the "line_id" field in the mutation.
+func (m *ChargeFlatFeeRunMutation) LineID() (r string, exists bool) {
+	v := m.billing_invoice_line
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldLineID returns the old "line_id" field's value of the ChargeFlatFeeRun entity.
+// If the ChargeFlatFeeRun object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeFlatFeeRunMutation) OldLineID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldLineID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldLineID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldLineID: %w", err)
+	}
+	return oldValue.LineID, nil
+}
+
+// ClearLineID clears the value of the "line_id" field.
+func (m *ChargeFlatFeeRunMutation) ClearLineID() {
+	m.billing_invoice_line = nil
+	m.clearedFields[chargeflatfeerun.FieldLineID] = struct{}{}
+}
+
+// LineIDCleared returns if the "line_id" field was cleared in this mutation.
+func (m *ChargeFlatFeeRunMutation) LineIDCleared() bool {
+	_, ok := m.clearedFields[chargeflatfeerun.FieldLineID]
+	return ok
+}
+
+// ResetLineID resets all changes to the "line_id" field.
+func (m *ChargeFlatFeeRunMutation) ResetLineID() {
+	m.billing_invoice_line = nil
+	delete(m.clearedFields, chargeflatfeerun.FieldLineID)
+}
+
+// SetInvoiceID sets the "invoice_id" field.
+func (m *ChargeFlatFeeRunMutation) SetInvoiceID(s string) {
+	m.billing_invoice = &s
+}
+
+// InvoiceID returns the value of the "invoice_id" field in the mutation.
+func (m *ChargeFlatFeeRunMutation) InvoiceID() (r string, exists bool) {
+	v := m.billing_invoice
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldInvoiceID returns the old "invoice_id" field's value of the ChargeFlatFeeRun entity.
+// If the ChargeFlatFeeRun object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeFlatFeeRunMutation) OldInvoiceID(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldInvoiceID is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldInvoiceID requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldInvoiceID: %w", err)
+	}
+	return oldValue.InvoiceID, nil
+}
+
+// ClearInvoiceID clears the value of the "invoice_id" field.
+func (m *ChargeFlatFeeRunMutation) ClearInvoiceID() {
+	m.billing_invoice = nil
+	m.clearedFields[chargeflatfeerun.FieldInvoiceID] = struct{}{}
+}
+
+// InvoiceIDCleared returns if the "invoice_id" field was cleared in this mutation.
+func (m *ChargeFlatFeeRunMutation) InvoiceIDCleared() bool {
+	_, ok := m.clearedFields[chargeflatfeerun.FieldInvoiceID]
+	return ok
+}
+
+// ResetInvoiceID resets all changes to the "invoice_id" field.
+func (m *ChargeFlatFeeRunMutation) ResetInvoiceID() {
+	m.billing_invoice = nil
+	delete(m.clearedFields, chargeflatfeerun.FieldInvoiceID)
+}
+
 // SetAmountAfterProration sets the "amount_after_proration" field.
 func (m *ChargeFlatFeeRunMutation) SetAmountAfterProration(a alpacadecimal.Decimal) {
 	m.amount_after_proration = &a
@@ -46637,6 +46799,42 @@ func (m *ChargeFlatFeeRunMutation) OldAmountAfterProration(ctx context.Context) 
 // ResetAmountAfterProration resets all changes to the "amount_after_proration" field.
 func (m *ChargeFlatFeeRunMutation) ResetAmountAfterProration() {
 	m.amount_after_proration = nil
+}
+
+// SetNoFiatTransactionRequired sets the "no_fiat_transaction_required" field.
+func (m *ChargeFlatFeeRunMutation) SetNoFiatTransactionRequired(b bool) {
+	m.no_fiat_transaction_required = &b
+}
+
+// NoFiatTransactionRequired returns the value of the "no_fiat_transaction_required" field in the mutation.
+func (m *ChargeFlatFeeRunMutation) NoFiatTransactionRequired() (r bool, exists bool) {
+	v := m.no_fiat_transaction_required
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldNoFiatTransactionRequired returns the old "no_fiat_transaction_required" field's value of the ChargeFlatFeeRun entity.
+// If the ChargeFlatFeeRun object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeFlatFeeRunMutation) OldNoFiatTransactionRequired(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldNoFiatTransactionRequired is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldNoFiatTransactionRequired requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldNoFiatTransactionRequired: %w", err)
+	}
+	return oldValue.NoFiatTransactionRequired, nil
+}
+
+// ResetNoFiatTransactionRequired resets all changes to the "no_fiat_transaction_required" field.
+func (m *ChargeFlatFeeRunMutation) ResetNoFiatTransactionRequired() {
+	m.no_fiat_transaction_required = nil
 }
 
 // SetFlatFeeID sets the "flat_fee" edge to the ChargeFlatFee entity by id.
@@ -46677,6 +46875,86 @@ func (m *ChargeFlatFeeRunMutation) FlatFeeIDs() (ids []string) {
 func (m *ChargeFlatFeeRunMutation) ResetFlatFee() {
 	m.flat_fee = nil
 	m.clearedflat_fee = false
+}
+
+// SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by id.
+func (m *ChargeFlatFeeRunMutation) SetBillingInvoiceLineID(id string) {
+	m.billing_invoice_line = &id
+}
+
+// ClearBillingInvoiceLine clears the "billing_invoice_line" edge to the BillingInvoiceLine entity.
+func (m *ChargeFlatFeeRunMutation) ClearBillingInvoiceLine() {
+	m.clearedbilling_invoice_line = true
+	m.clearedFields[chargeflatfeerun.FieldLineID] = struct{}{}
+}
+
+// BillingInvoiceLineCleared reports if the "billing_invoice_line" edge to the BillingInvoiceLine entity was cleared.
+func (m *ChargeFlatFeeRunMutation) BillingInvoiceLineCleared() bool {
+	return m.LineIDCleared() || m.clearedbilling_invoice_line
+}
+
+// BillingInvoiceLineID returns the "billing_invoice_line" edge ID in the mutation.
+func (m *ChargeFlatFeeRunMutation) BillingInvoiceLineID() (id string, exists bool) {
+	if m.billing_invoice_line != nil {
+		return *m.billing_invoice_line, true
+	}
+	return
+}
+
+// BillingInvoiceLineIDs returns the "billing_invoice_line" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// BillingInvoiceLineID instead. It exists only for internal usage by the builders.
+func (m *ChargeFlatFeeRunMutation) BillingInvoiceLineIDs() (ids []string) {
+	if id := m.billing_invoice_line; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetBillingInvoiceLine resets all changes to the "billing_invoice_line" edge.
+func (m *ChargeFlatFeeRunMutation) ResetBillingInvoiceLine() {
+	m.billing_invoice_line = nil
+	m.clearedbilling_invoice_line = false
+}
+
+// SetBillingInvoiceID sets the "billing_invoice" edge to the BillingInvoice entity by id.
+func (m *ChargeFlatFeeRunMutation) SetBillingInvoiceID(id string) {
+	m.billing_invoice = &id
+}
+
+// ClearBillingInvoice clears the "billing_invoice" edge to the BillingInvoice entity.
+func (m *ChargeFlatFeeRunMutation) ClearBillingInvoice() {
+	m.clearedbilling_invoice = true
+	m.clearedFields[chargeflatfeerun.FieldInvoiceID] = struct{}{}
+}
+
+// BillingInvoiceCleared reports if the "billing_invoice" edge to the BillingInvoice entity was cleared.
+func (m *ChargeFlatFeeRunMutation) BillingInvoiceCleared() bool {
+	return m.InvoiceIDCleared() || m.clearedbilling_invoice
+}
+
+// BillingInvoiceID returns the "billing_invoice" edge ID in the mutation.
+func (m *ChargeFlatFeeRunMutation) BillingInvoiceID() (id string, exists bool) {
+	if m.billing_invoice != nil {
+		return *m.billing_invoice, true
+	}
+	return
+}
+
+// BillingInvoiceIDs returns the "billing_invoice" edge IDs in the mutation.
+// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
+// BillingInvoiceID instead. It exists only for internal usage by the builders.
+func (m *ChargeFlatFeeRunMutation) BillingInvoiceIDs() (ids []string) {
+	if id := m.billing_invoice; id != nil {
+		ids = append(ids, *id)
+	}
+	return
+}
+
+// ResetBillingInvoice resets all changes to the "billing_invoice" edge.
+func (m *ChargeFlatFeeRunMutation) ResetBillingInvoice() {
+	m.billing_invoice = nil
+	m.clearedbilling_invoice = false
 }
 
 // AddCreditAllocationIDs adds the "credit_allocations" edge to the ChargeFlatFeeRunCreditAllocations entity by ids.
@@ -46899,7 +47177,7 @@ func (m *ChargeFlatFeeRunMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeFlatFeeRunMutation) Fields() []string {
-	fields := make([]string, 0, 18)
+	fields := make([]string, 0, 21)
 	if m.namespace != nil {
 		fields = append(fields, chargeflatfeerun.FieldNamespace)
 	}
@@ -46951,8 +47229,17 @@ func (m *ChargeFlatFeeRunMutation) Fields() []string {
 	if m.service_period_to != nil {
 		fields = append(fields, chargeflatfeerun.FieldServicePeriodTo)
 	}
+	if m.billing_invoice_line != nil {
+		fields = append(fields, chargeflatfeerun.FieldLineID)
+	}
+	if m.billing_invoice != nil {
+		fields = append(fields, chargeflatfeerun.FieldInvoiceID)
+	}
 	if m.amount_after_proration != nil {
 		fields = append(fields, chargeflatfeerun.FieldAmountAfterProration)
+	}
+	if m.no_fiat_transaction_required != nil {
+		fields = append(fields, chargeflatfeerun.FieldNoFiatTransactionRequired)
 	}
 	return fields
 }
@@ -46996,8 +47283,14 @@ func (m *ChargeFlatFeeRunMutation) Field(name string) (ent.Value, bool) {
 		return m.ServicePeriodFrom()
 	case chargeflatfeerun.FieldServicePeriodTo:
 		return m.ServicePeriodTo()
+	case chargeflatfeerun.FieldLineID:
+		return m.LineID()
+	case chargeflatfeerun.FieldInvoiceID:
+		return m.InvoiceID()
 	case chargeflatfeerun.FieldAmountAfterProration:
 		return m.AmountAfterProration()
+	case chargeflatfeerun.FieldNoFiatTransactionRequired:
+		return m.NoFiatTransactionRequired()
 	}
 	return nil, false
 }
@@ -47041,8 +47334,14 @@ func (m *ChargeFlatFeeRunMutation) OldField(ctx context.Context, name string) (e
 		return m.OldServicePeriodFrom(ctx)
 	case chargeflatfeerun.FieldServicePeriodTo:
 		return m.OldServicePeriodTo(ctx)
+	case chargeflatfeerun.FieldLineID:
+		return m.OldLineID(ctx)
+	case chargeflatfeerun.FieldInvoiceID:
+		return m.OldInvoiceID(ctx)
 	case chargeflatfeerun.FieldAmountAfterProration:
 		return m.OldAmountAfterProration(ctx)
+	case chargeflatfeerun.FieldNoFiatTransactionRequired:
+		return m.OldNoFiatTransactionRequired(ctx)
 	}
 	return nil, fmt.Errorf("unknown ChargeFlatFeeRun field %s", name)
 }
@@ -47171,12 +47470,33 @@ func (m *ChargeFlatFeeRunMutation) SetField(name string, value ent.Value) error 
 		}
 		m.SetServicePeriodTo(v)
 		return nil
+	case chargeflatfeerun.FieldLineID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetLineID(v)
+		return nil
+	case chargeflatfeerun.FieldInvoiceID:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetInvoiceID(v)
+		return nil
 	case chargeflatfeerun.FieldAmountAfterProration:
 		v, ok := value.(alpacadecimal.Decimal)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetAmountAfterProration(v)
+		return nil
+	case chargeflatfeerun.FieldNoFiatTransactionRequired:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetNoFiatTransactionRequired(v)
 		return nil
 	}
 	return fmt.Errorf("unknown ChargeFlatFeeRun field %s", name)
@@ -47211,6 +47531,12 @@ func (m *ChargeFlatFeeRunMutation) ClearedFields() []string {
 	if m.FieldCleared(chargeflatfeerun.FieldDeletedAt) {
 		fields = append(fields, chargeflatfeerun.FieldDeletedAt)
 	}
+	if m.FieldCleared(chargeflatfeerun.FieldLineID) {
+		fields = append(fields, chargeflatfeerun.FieldLineID)
+	}
+	if m.FieldCleared(chargeflatfeerun.FieldInvoiceID) {
+		fields = append(fields, chargeflatfeerun.FieldInvoiceID)
+	}
 	return fields
 }
 
@@ -47227,6 +47553,12 @@ func (m *ChargeFlatFeeRunMutation) ClearField(name string) error {
 	switch name {
 	case chargeflatfeerun.FieldDeletedAt:
 		m.ClearDeletedAt()
+		return nil
+	case chargeflatfeerun.FieldLineID:
+		m.ClearLineID()
+		return nil
+	case chargeflatfeerun.FieldInvoiceID:
+		m.ClearInvoiceID()
 		return nil
 	}
 	return fmt.Errorf("unknown ChargeFlatFeeRun nullable field %s", name)
@@ -47287,8 +47619,17 @@ func (m *ChargeFlatFeeRunMutation) ResetField(name string) error {
 	case chargeflatfeerun.FieldServicePeriodTo:
 		m.ResetServicePeriodTo()
 		return nil
+	case chargeflatfeerun.FieldLineID:
+		m.ResetLineID()
+		return nil
+	case chargeflatfeerun.FieldInvoiceID:
+		m.ResetInvoiceID()
+		return nil
 	case chargeflatfeerun.FieldAmountAfterProration:
 		m.ResetAmountAfterProration()
+		return nil
+	case chargeflatfeerun.FieldNoFiatTransactionRequired:
+		m.ResetNoFiatTransactionRequired()
 		return nil
 	}
 	return fmt.Errorf("unknown ChargeFlatFeeRun field %s", name)
@@ -47296,9 +47637,15 @@ func (m *ChargeFlatFeeRunMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *ChargeFlatFeeRunMutation) AddedEdges() []string {
-	edges := make([]string, 0, 5)
+	edges := make([]string, 0, 7)
 	if m.flat_fee != nil {
 		edges = append(edges, chargeflatfeerun.EdgeFlatFee)
+	}
+	if m.billing_invoice_line != nil {
+		edges = append(edges, chargeflatfeerun.EdgeBillingInvoiceLine)
+	}
+	if m.billing_invoice != nil {
+		edges = append(edges, chargeflatfeerun.EdgeBillingInvoice)
 	}
 	if m.credit_allocations != nil {
 		edges = append(edges, chargeflatfeerun.EdgeCreditAllocations)
@@ -47321,6 +47668,14 @@ func (m *ChargeFlatFeeRunMutation) AddedIDs(name string) []ent.Value {
 	switch name {
 	case chargeflatfeerun.EdgeFlatFee:
 		if id := m.flat_fee; id != nil {
+			return []ent.Value{*id}
+		}
+	case chargeflatfeerun.EdgeBillingInvoiceLine:
+		if id := m.billing_invoice_line; id != nil {
+			return []ent.Value{*id}
+		}
+	case chargeflatfeerun.EdgeBillingInvoice:
+		if id := m.billing_invoice; id != nil {
 			return []ent.Value{*id}
 		}
 	case chargeflatfeerun.EdgeCreditAllocations:
@@ -47349,7 +47704,7 @@ func (m *ChargeFlatFeeRunMutation) AddedIDs(name string) []ent.Value {
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *ChargeFlatFeeRunMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 5)
+	edges := make([]string, 0, 7)
 	if m.removedcredit_allocations != nil {
 		edges = append(edges, chargeflatfeerun.EdgeCreditAllocations)
 	}
@@ -47381,9 +47736,15 @@ func (m *ChargeFlatFeeRunMutation) RemovedIDs(name string) []ent.Value {
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *ChargeFlatFeeRunMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 5)
+	edges := make([]string, 0, 7)
 	if m.clearedflat_fee {
 		edges = append(edges, chargeflatfeerun.EdgeFlatFee)
+	}
+	if m.clearedbilling_invoice_line {
+		edges = append(edges, chargeflatfeerun.EdgeBillingInvoiceLine)
+	}
+	if m.clearedbilling_invoice {
+		edges = append(edges, chargeflatfeerun.EdgeBillingInvoice)
 	}
 	if m.clearedcredit_allocations {
 		edges = append(edges, chargeflatfeerun.EdgeCreditAllocations)
@@ -47406,6 +47767,10 @@ func (m *ChargeFlatFeeRunMutation) EdgeCleared(name string) bool {
 	switch name {
 	case chargeflatfeerun.EdgeFlatFee:
 		return m.clearedflat_fee
+	case chargeflatfeerun.EdgeBillingInvoiceLine:
+		return m.clearedbilling_invoice_line
+	case chargeflatfeerun.EdgeBillingInvoice:
+		return m.clearedbilling_invoice
 	case chargeflatfeerun.EdgeCreditAllocations:
 		return m.clearedcredit_allocations
 	case chargeflatfeerun.EdgeDetailedLines:
@@ -47425,6 +47790,12 @@ func (m *ChargeFlatFeeRunMutation) ClearEdge(name string) error {
 	case chargeflatfeerun.EdgeFlatFee:
 		m.ClearFlatFee()
 		return nil
+	case chargeflatfeerun.EdgeBillingInvoiceLine:
+		m.ClearBillingInvoiceLine()
+		return nil
+	case chargeflatfeerun.EdgeBillingInvoice:
+		m.ClearBillingInvoice()
+		return nil
 	case chargeflatfeerun.EdgeInvoicedUsage:
 		m.ClearInvoicedUsage()
 		return nil
@@ -47441,6 +47812,12 @@ func (m *ChargeFlatFeeRunMutation) ResetEdge(name string) error {
 	switch name {
 	case chargeflatfeerun.EdgeFlatFee:
 		m.ResetFlatFee()
+		return nil
+	case chargeflatfeerun.EdgeBillingInvoiceLine:
+		m.ResetBillingInvoiceLine()
+		return nil
+	case chargeflatfeerun.EdgeBillingInvoice:
+		m.ResetBillingInvoice()
 		return nil
 	case chargeflatfeerun.EdgeCreditAllocations:
 		m.ResetCreditAllocations()
@@ -51208,7 +51585,6 @@ type ChargeFlatFeeRunInvoicedUsageMutation struct {
 	id                          *string
 	service_period_from         *time.Time
 	service_period_to           *time.Time
-	mutable                     *bool
 	ledger_transaction_group_id *string
 	namespace                   *string
 	created_at                  *time.Time
@@ -51224,8 +51600,6 @@ type ChargeFlatFeeRunInvoicedUsageMutation struct {
 	credits_total               *alpacadecimal.Decimal
 	total                       *alpacadecimal.Decimal
 	clearedFields               map[string]struct{}
-	billing_invoice_line        *string
-	clearedbilling_invoice_line bool
 	run                         *string
 	clearedrun                  bool
 	done                        bool
@@ -51337,55 +51711,6 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) IDs(ctx context.Context) ([]stri
 	}
 }
 
-// SetLineID sets the "line_id" field.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) SetLineID(s string) {
-	m.billing_invoice_line = &s
-}
-
-// LineID returns the value of the "line_id" field in the mutation.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) LineID() (r string, exists bool) {
-	v := m.billing_invoice_line
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldLineID returns the old "line_id" field's value of the ChargeFlatFeeRunInvoicedUsage entity.
-// If the ChargeFlatFeeRunInvoicedUsage object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) OldLineID(ctx context.Context) (v *string, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldLineID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldLineID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldLineID: %w", err)
-	}
-	return oldValue.LineID, nil
-}
-
-// ClearLineID clears the value of the "line_id" field.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) ClearLineID() {
-	m.billing_invoice_line = nil
-	m.clearedFields[chargeflatfeeruninvoicedusage.FieldLineID] = struct{}{}
-}
-
-// LineIDCleared returns if the "line_id" field was cleared in this mutation.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) LineIDCleared() bool {
-	_, ok := m.clearedFields[chargeflatfeeruninvoicedusage.FieldLineID]
-	return ok
-}
-
-// ResetLineID resets all changes to the "line_id" field.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) ResetLineID() {
-	m.billing_invoice_line = nil
-	delete(m.clearedFields, chargeflatfeeruninvoicedusage.FieldLineID)
-}
-
 // SetServicePeriodFrom sets the "service_period_from" field.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) SetServicePeriodFrom(t time.Time) {
 	m.service_period_from = &t
@@ -51456,42 +51781,6 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) OldServicePeriodTo(ctx context.C
 // ResetServicePeriodTo resets all changes to the "service_period_to" field.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) ResetServicePeriodTo() {
 	m.service_period_to = nil
-}
-
-// SetMutable sets the "mutable" field.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) SetMutable(b bool) {
-	m.mutable = &b
-}
-
-// Mutable returns the value of the "mutable" field in the mutation.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) Mutable() (r bool, exists bool) {
-	v := m.mutable
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldMutable returns the old "mutable" field's value of the ChargeFlatFeeRunInvoicedUsage entity.
-// If the ChargeFlatFeeRunInvoicedUsage object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) OldMutable(ctx context.Context) (v bool, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldMutable is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldMutable requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldMutable: %w", err)
-	}
-	return oldValue.Mutable, nil
-}
-
-// ResetMutable resets all changes to the "mutable" field.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) ResetMutable() {
-	m.mutable = nil
 }
 
 // SetLedgerTransactionGroupID sets the "ledger_transaction_group_id" field.
@@ -52073,46 +52362,6 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) ResetRunID() {
 	m.run = nil
 }
 
-// SetBillingInvoiceLineID sets the "billing_invoice_line" edge to the BillingInvoiceLine entity by id.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) SetBillingInvoiceLineID(id string) {
-	m.billing_invoice_line = &id
-}
-
-// ClearBillingInvoiceLine clears the "billing_invoice_line" edge to the BillingInvoiceLine entity.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) ClearBillingInvoiceLine() {
-	m.clearedbilling_invoice_line = true
-	m.clearedFields[chargeflatfeeruninvoicedusage.FieldLineID] = struct{}{}
-}
-
-// BillingInvoiceLineCleared reports if the "billing_invoice_line" edge to the BillingInvoiceLine entity was cleared.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) BillingInvoiceLineCleared() bool {
-	return m.LineIDCleared() || m.clearedbilling_invoice_line
-}
-
-// BillingInvoiceLineID returns the "billing_invoice_line" edge ID in the mutation.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) BillingInvoiceLineID() (id string, exists bool) {
-	if m.billing_invoice_line != nil {
-		return *m.billing_invoice_line, true
-	}
-	return
-}
-
-// BillingInvoiceLineIDs returns the "billing_invoice_line" edge IDs in the mutation.
-// Note that IDs always returns len(IDs) <= 1 for unique edges, and you should use
-// BillingInvoiceLineID instead. It exists only for internal usage by the builders.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) BillingInvoiceLineIDs() (ids []string) {
-	if id := m.billing_invoice_line; id != nil {
-		ids = append(ids, *id)
-	}
-	return
-}
-
-// ResetBillingInvoiceLine resets all changes to the "billing_invoice_line" edge.
-func (m *ChargeFlatFeeRunInvoicedUsageMutation) ResetBillingInvoiceLine() {
-	m.billing_invoice_line = nil
-	m.clearedbilling_invoice_line = false
-}
-
 // ClearRun clears the "run" edge to the ChargeFlatFeeRun entity.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) ClearRun() {
 	m.clearedrun = true
@@ -52174,18 +52423,12 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) Fields() []string {
-	fields := make([]string, 0, 19)
-	if m.billing_invoice_line != nil {
-		fields = append(fields, chargeflatfeeruninvoicedusage.FieldLineID)
-	}
+	fields := make([]string, 0, 17)
 	if m.service_period_from != nil {
 		fields = append(fields, chargeflatfeeruninvoicedusage.FieldServicePeriodFrom)
 	}
 	if m.service_period_to != nil {
 		fields = append(fields, chargeflatfeeruninvoicedusage.FieldServicePeriodTo)
-	}
-	if m.mutable != nil {
-		fields = append(fields, chargeflatfeeruninvoicedusage.FieldMutable)
 	}
 	if m.ledger_transaction_group_id != nil {
 		fields = append(fields, chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID)
@@ -52240,14 +52483,10 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) Fields() []string {
 // schema.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case chargeflatfeeruninvoicedusage.FieldLineID:
-		return m.LineID()
 	case chargeflatfeeruninvoicedusage.FieldServicePeriodFrom:
 		return m.ServicePeriodFrom()
 	case chargeflatfeeruninvoicedusage.FieldServicePeriodTo:
 		return m.ServicePeriodTo()
-	case chargeflatfeeruninvoicedusage.FieldMutable:
-		return m.Mutable()
 	case chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID:
 		return m.LedgerTransactionGroupID()
 	case chargeflatfeeruninvoicedusage.FieldNamespace:
@@ -52287,14 +52526,10 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) Field(name string) (ent.Value, b
 // database failed.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case chargeflatfeeruninvoicedusage.FieldLineID:
-		return m.OldLineID(ctx)
 	case chargeflatfeeruninvoicedusage.FieldServicePeriodFrom:
 		return m.OldServicePeriodFrom(ctx)
 	case chargeflatfeeruninvoicedusage.FieldServicePeriodTo:
 		return m.OldServicePeriodTo(ctx)
-	case chargeflatfeeruninvoicedusage.FieldMutable:
-		return m.OldMutable(ctx)
 	case chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID:
 		return m.OldLedgerTransactionGroupID(ctx)
 	case chargeflatfeeruninvoicedusage.FieldNamespace:
@@ -52334,13 +52569,6 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) OldField(ctx context.Context, na
 // type.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case chargeflatfeeruninvoicedusage.FieldLineID:
-		v, ok := value.(string)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetLineID(v)
-		return nil
 	case chargeflatfeeruninvoicedusage.FieldServicePeriodFrom:
 		v, ok := value.(time.Time)
 		if !ok {
@@ -52354,13 +52582,6 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) SetField(name string, value ent.
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetServicePeriodTo(v)
-		return nil
-	case chargeflatfeeruninvoicedusage.FieldMutable:
-		v, ok := value.(bool)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetMutable(v)
 		return nil
 	case chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID:
 		v, ok := value.(string)
@@ -52497,9 +52718,6 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) AddField(name string, value ent.
 // mutation.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) ClearedFields() []string {
 	var fields []string
-	if m.FieldCleared(chargeflatfeeruninvoicedusage.FieldLineID) {
-		fields = append(fields, chargeflatfeeruninvoicedusage.FieldLineID)
-	}
 	if m.FieldCleared(chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID) {
 		fields = append(fields, chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID)
 	}
@@ -52523,9 +52741,6 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) ClearField(name string) error {
 	switch name {
-	case chargeflatfeeruninvoicedusage.FieldLineID:
-		m.ClearLineID()
-		return nil
 	case chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID:
 		m.ClearLedgerTransactionGroupID()
 		return nil
@@ -52543,17 +52758,11 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) ClearField(name string) error {
 // It returns an error if the field is not defined in the schema.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) ResetField(name string) error {
 	switch name {
-	case chargeflatfeeruninvoicedusage.FieldLineID:
-		m.ResetLineID()
-		return nil
 	case chargeflatfeeruninvoicedusage.FieldServicePeriodFrom:
 		m.ResetServicePeriodFrom()
 		return nil
 	case chargeflatfeeruninvoicedusage.FieldServicePeriodTo:
 		m.ResetServicePeriodTo()
-		return nil
-	case chargeflatfeeruninvoicedusage.FieldMutable:
-		m.ResetMutable()
 		return nil
 	case chargeflatfeeruninvoicedusage.FieldLedgerTransactionGroupID:
 		m.ResetLedgerTransactionGroupID()
@@ -52606,10 +52815,7 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) ResetField(name string) error {
 
 // AddedEdges returns all edge names that were set/added in this mutation.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) AddedEdges() []string {
-	edges := make([]string, 0, 2)
-	if m.billing_invoice_line != nil {
-		edges = append(edges, chargeflatfeeruninvoicedusage.EdgeBillingInvoiceLine)
-	}
+	edges := make([]string, 0, 1)
 	if m.run != nil {
 		edges = append(edges, chargeflatfeeruninvoicedusage.EdgeRun)
 	}
@@ -52620,10 +52826,6 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) AddedEdges() []string {
 // name in this mutation.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) AddedIDs(name string) []ent.Value {
 	switch name {
-	case chargeflatfeeruninvoicedusage.EdgeBillingInvoiceLine:
-		if id := m.billing_invoice_line; id != nil {
-			return []ent.Value{*id}
-		}
 	case chargeflatfeeruninvoicedusage.EdgeRun:
 		if id := m.run; id != nil {
 			return []ent.Value{*id}
@@ -52634,7 +52836,7 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) AddedIDs(name string) []ent.Valu
 
 // RemovedEdges returns all edge names that were removed in this mutation.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) RemovedEdges() []string {
-	edges := make([]string, 0, 2)
+	edges := make([]string, 0, 1)
 	return edges
 }
 
@@ -52646,10 +52848,7 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) RemovedIDs(name string) []ent.Va
 
 // ClearedEdges returns all edge names that were cleared in this mutation.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) ClearedEdges() []string {
-	edges := make([]string, 0, 2)
-	if m.clearedbilling_invoice_line {
-		edges = append(edges, chargeflatfeeruninvoicedusage.EdgeBillingInvoiceLine)
-	}
+	edges := make([]string, 0, 1)
 	if m.clearedrun {
 		edges = append(edges, chargeflatfeeruninvoicedusage.EdgeRun)
 	}
@@ -52660,8 +52859,6 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) ClearedEdges() []string {
 // was cleared in this mutation.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) EdgeCleared(name string) bool {
 	switch name {
-	case chargeflatfeeruninvoicedusage.EdgeBillingInvoiceLine:
-		return m.clearedbilling_invoice_line
 	case chargeflatfeeruninvoicedusage.EdgeRun:
 		return m.clearedrun
 	}
@@ -52672,9 +52869,6 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) EdgeCleared(name string) bool {
 // if that edge is not defined in the schema.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) ClearEdge(name string) error {
 	switch name {
-	case chargeflatfeeruninvoicedusage.EdgeBillingInvoiceLine:
-		m.ClearBillingInvoiceLine()
-		return nil
 	case chargeflatfeeruninvoicedusage.EdgeRun:
 		m.ClearRun()
 		return nil
@@ -52686,9 +52880,6 @@ func (m *ChargeFlatFeeRunInvoicedUsageMutation) ClearEdge(name string) error {
 // It returns an error if the edge is not defined in the schema.
 func (m *ChargeFlatFeeRunInvoicedUsageMutation) ResetEdge(name string) error {
 	switch name {
-	case chargeflatfeeruninvoicedusage.EdgeBillingInvoiceLine:
-		m.ResetBillingInvoiceLine()
-		return nil
 	case chargeflatfeeruninvoicedusage.EdgeRun:
 		m.ResetRun()
 		return nil
@@ -60910,10 +61101,8 @@ type ChargeUsageBasedRunInvoicedUsageMutation struct {
 	op                          Op
 	typ                         string
 	id                          *string
-	line_id                     *string
 	service_period_from         *time.Time
 	service_period_to           *time.Time
-	mutable                     *bool
 	ledger_transaction_group_id *string
 	namespace                   *string
 	created_at                  *time.Time
@@ -61040,55 +61229,6 @@ func (m *ChargeUsageBasedRunInvoicedUsageMutation) IDs(ctx context.Context) ([]s
 	}
 }
 
-// SetLineID sets the "line_id" field.
-func (m *ChargeUsageBasedRunInvoicedUsageMutation) SetLineID(s string) {
-	m.line_id = &s
-}
-
-// LineID returns the value of the "line_id" field in the mutation.
-func (m *ChargeUsageBasedRunInvoicedUsageMutation) LineID() (r string, exists bool) {
-	v := m.line_id
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldLineID returns the old "line_id" field's value of the ChargeUsageBasedRunInvoicedUsage entity.
-// If the ChargeUsageBasedRunInvoicedUsage object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ChargeUsageBasedRunInvoicedUsageMutation) OldLineID(ctx context.Context) (v *string, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldLineID is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldLineID requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldLineID: %w", err)
-	}
-	return oldValue.LineID, nil
-}
-
-// ClearLineID clears the value of the "line_id" field.
-func (m *ChargeUsageBasedRunInvoicedUsageMutation) ClearLineID() {
-	m.line_id = nil
-	m.clearedFields[chargeusagebasedruninvoicedusage.FieldLineID] = struct{}{}
-}
-
-// LineIDCleared returns if the "line_id" field was cleared in this mutation.
-func (m *ChargeUsageBasedRunInvoicedUsageMutation) LineIDCleared() bool {
-	_, ok := m.clearedFields[chargeusagebasedruninvoicedusage.FieldLineID]
-	return ok
-}
-
-// ResetLineID resets all changes to the "line_id" field.
-func (m *ChargeUsageBasedRunInvoicedUsageMutation) ResetLineID() {
-	m.line_id = nil
-	delete(m.clearedFields, chargeusagebasedruninvoicedusage.FieldLineID)
-}
-
 // SetServicePeriodFrom sets the "service_period_from" field.
 func (m *ChargeUsageBasedRunInvoicedUsageMutation) SetServicePeriodFrom(t time.Time) {
 	m.service_period_from = &t
@@ -61159,42 +61299,6 @@ func (m *ChargeUsageBasedRunInvoicedUsageMutation) OldServicePeriodTo(ctx contex
 // ResetServicePeriodTo resets all changes to the "service_period_to" field.
 func (m *ChargeUsageBasedRunInvoicedUsageMutation) ResetServicePeriodTo() {
 	m.service_period_to = nil
-}
-
-// SetMutable sets the "mutable" field.
-func (m *ChargeUsageBasedRunInvoicedUsageMutation) SetMutable(b bool) {
-	m.mutable = &b
-}
-
-// Mutable returns the value of the "mutable" field in the mutation.
-func (m *ChargeUsageBasedRunInvoicedUsageMutation) Mutable() (r bool, exists bool) {
-	v := m.mutable
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldMutable returns the old "mutable" field's value of the ChargeUsageBasedRunInvoicedUsage entity.
-// If the ChargeUsageBasedRunInvoicedUsage object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *ChargeUsageBasedRunInvoicedUsageMutation) OldMutable(ctx context.Context) (v bool, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldMutable is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldMutable requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldMutable: %w", err)
-	}
-	return oldValue.Mutable, nil
-}
-
-// ResetMutable resets all changes to the "mutable" field.
-func (m *ChargeUsageBasedRunInvoicedUsageMutation) ResetMutable() {
-	m.mutable = nil
 }
 
 // SetLedgerTransactionGroupID sets the "ledger_transaction_group_id" field.
@@ -61837,18 +61941,12 @@ func (m *ChargeUsageBasedRunInvoicedUsageMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedRunInvoicedUsageMutation) Fields() []string {
-	fields := make([]string, 0, 19)
-	if m.line_id != nil {
-		fields = append(fields, chargeusagebasedruninvoicedusage.FieldLineID)
-	}
+	fields := make([]string, 0, 17)
 	if m.service_period_from != nil {
 		fields = append(fields, chargeusagebasedruninvoicedusage.FieldServicePeriodFrom)
 	}
 	if m.service_period_to != nil {
 		fields = append(fields, chargeusagebasedruninvoicedusage.FieldServicePeriodTo)
-	}
-	if m.mutable != nil {
-		fields = append(fields, chargeusagebasedruninvoicedusage.FieldMutable)
 	}
 	if m.ledger_transaction_group_id != nil {
 		fields = append(fields, chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID)
@@ -61903,14 +62001,10 @@ func (m *ChargeUsageBasedRunInvoicedUsageMutation) Fields() []string {
 // schema.
 func (m *ChargeUsageBasedRunInvoicedUsageMutation) Field(name string) (ent.Value, bool) {
 	switch name {
-	case chargeusagebasedruninvoicedusage.FieldLineID:
-		return m.LineID()
 	case chargeusagebasedruninvoicedusage.FieldServicePeriodFrom:
 		return m.ServicePeriodFrom()
 	case chargeusagebasedruninvoicedusage.FieldServicePeriodTo:
 		return m.ServicePeriodTo()
-	case chargeusagebasedruninvoicedusage.FieldMutable:
-		return m.Mutable()
 	case chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID:
 		return m.LedgerTransactionGroupID()
 	case chargeusagebasedruninvoicedusage.FieldNamespace:
@@ -61950,14 +62044,10 @@ func (m *ChargeUsageBasedRunInvoicedUsageMutation) Field(name string) (ent.Value
 // database failed.
 func (m *ChargeUsageBasedRunInvoicedUsageMutation) OldField(ctx context.Context, name string) (ent.Value, error) {
 	switch name {
-	case chargeusagebasedruninvoicedusage.FieldLineID:
-		return m.OldLineID(ctx)
 	case chargeusagebasedruninvoicedusage.FieldServicePeriodFrom:
 		return m.OldServicePeriodFrom(ctx)
 	case chargeusagebasedruninvoicedusage.FieldServicePeriodTo:
 		return m.OldServicePeriodTo(ctx)
-	case chargeusagebasedruninvoicedusage.FieldMutable:
-		return m.OldMutable(ctx)
 	case chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID:
 		return m.OldLedgerTransactionGroupID(ctx)
 	case chargeusagebasedruninvoicedusage.FieldNamespace:
@@ -61997,13 +62087,6 @@ func (m *ChargeUsageBasedRunInvoicedUsageMutation) OldField(ctx context.Context,
 // type.
 func (m *ChargeUsageBasedRunInvoicedUsageMutation) SetField(name string, value ent.Value) error {
 	switch name {
-	case chargeusagebasedruninvoicedusage.FieldLineID:
-		v, ok := value.(string)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetLineID(v)
-		return nil
 	case chargeusagebasedruninvoicedusage.FieldServicePeriodFrom:
 		v, ok := value.(time.Time)
 		if !ok {
@@ -62017,13 +62100,6 @@ func (m *ChargeUsageBasedRunInvoicedUsageMutation) SetField(name string, value e
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetServicePeriodTo(v)
-		return nil
-	case chargeusagebasedruninvoicedusage.FieldMutable:
-		v, ok := value.(bool)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetMutable(v)
 		return nil
 	case chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID:
 		v, ok := value.(string)
@@ -62160,9 +62236,6 @@ func (m *ChargeUsageBasedRunInvoicedUsageMutation) AddField(name string, value e
 // mutation.
 func (m *ChargeUsageBasedRunInvoicedUsageMutation) ClearedFields() []string {
 	var fields []string
-	if m.FieldCleared(chargeusagebasedruninvoicedusage.FieldLineID) {
-		fields = append(fields, chargeusagebasedruninvoicedusage.FieldLineID)
-	}
 	if m.FieldCleared(chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID) {
 		fields = append(fields, chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID)
 	}
@@ -62186,9 +62259,6 @@ func (m *ChargeUsageBasedRunInvoicedUsageMutation) FieldCleared(name string) boo
 // error if the field is not defined in the schema.
 func (m *ChargeUsageBasedRunInvoicedUsageMutation) ClearField(name string) error {
 	switch name {
-	case chargeusagebasedruninvoicedusage.FieldLineID:
-		m.ClearLineID()
-		return nil
 	case chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID:
 		m.ClearLedgerTransactionGroupID()
 		return nil
@@ -62206,17 +62276,11 @@ func (m *ChargeUsageBasedRunInvoicedUsageMutation) ClearField(name string) error
 // It returns an error if the field is not defined in the schema.
 func (m *ChargeUsageBasedRunInvoicedUsageMutation) ResetField(name string) error {
 	switch name {
-	case chargeusagebasedruninvoicedusage.FieldLineID:
-		m.ResetLineID()
-		return nil
 	case chargeusagebasedruninvoicedusage.FieldServicePeriodFrom:
 		m.ResetServicePeriodFrom()
 		return nil
 	case chargeusagebasedruninvoicedusage.FieldServicePeriodTo:
 		m.ResetServicePeriodTo()
-		return nil
-	case chargeusagebasedruninvoicedusage.FieldMutable:
-		m.ResetMutable()
 		return nil
 	case chargeusagebasedruninvoicedusage.FieldLedgerTransactionGroupID:
 		m.ResetLedgerTransactionGroupID()

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -1128,6 +1128,14 @@ func init() {
 	chargeflatfeerun.DefaultUpdatedAt = chargeflatfeerunDescUpdatedAt.Default.(func() time.Time)
 	// chargeflatfeerun.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	chargeflatfeerun.UpdateDefaultUpdatedAt = chargeflatfeerunDescUpdatedAt.UpdateDefault.(func() time.Time)
+	// chargeflatfeerunDescLineID is the schema descriptor for line_id field.
+	chargeflatfeerunDescLineID := chargeflatfeerunFields[5].Descriptor()
+	// chargeflatfeerun.LineIDValidator is a validator for the "line_id" field. It is called by the builders before save.
+	chargeflatfeerun.LineIDValidator = chargeflatfeerunDescLineID.Validators[0].(func(string) error)
+	// chargeflatfeerunDescInvoiceID is the schema descriptor for invoice_id field.
+	chargeflatfeerunDescInvoiceID := chargeflatfeerunFields[6].Descriptor()
+	// chargeflatfeerun.InvoiceIDValidator is a validator for the "invoice_id" field. It is called by the builders before save.
+	chargeflatfeerun.InvoiceIDValidator = chargeflatfeerunDescInvoiceID.Validators[0].(func(string) error)
 	// chargeflatfeerunDescID is the schema descriptor for id field.
 	chargeflatfeerunDescID := chargeflatfeerunMixinFields1[0].Descriptor()
 	// chargeflatfeerun.DefaultID holds the default value on creation for the id field.
@@ -1207,30 +1215,26 @@ func init() {
 	_ = chargeflatfeeruninvoicedusageMixinFields0
 	chargeflatfeeruninvoicedusageFields := schema.ChargeFlatFeeRunInvoicedUsage{}.Fields()
 	_ = chargeflatfeeruninvoicedusageFields
-	// chargeflatfeeruninvoicedusageDescLineID is the schema descriptor for line_id field.
-	chargeflatfeeruninvoicedusageDescLineID := chargeflatfeeruninvoicedusageMixinFields0[0].Descriptor()
-	// chargeflatfeeruninvoicedusage.LineIDValidator is a validator for the "line_id" field. It is called by the builders before save.
-	chargeflatfeeruninvoicedusage.LineIDValidator = chargeflatfeeruninvoicedusageDescLineID.Validators[0].(func(string) error)
 	// chargeflatfeeruninvoicedusageDescLedgerTransactionGroupID is the schema descriptor for ledger_transaction_group_id field.
-	chargeflatfeeruninvoicedusageDescLedgerTransactionGroupID := chargeflatfeeruninvoicedusageMixinFields0[4].Descriptor()
+	chargeflatfeeruninvoicedusageDescLedgerTransactionGroupID := chargeflatfeeruninvoicedusageMixinFields0[2].Descriptor()
 	// chargeflatfeeruninvoicedusage.LedgerTransactionGroupIDValidator is a validator for the "ledger_transaction_group_id" field. It is called by the builders before save.
 	chargeflatfeeruninvoicedusage.LedgerTransactionGroupIDValidator = chargeflatfeeruninvoicedusageDescLedgerTransactionGroupID.Validators[0].(func(string) error)
 	// chargeflatfeeruninvoicedusageDescNamespace is the schema descriptor for namespace field.
-	chargeflatfeeruninvoicedusageDescNamespace := chargeflatfeeruninvoicedusageMixinFields0[5].Descriptor()
+	chargeflatfeeruninvoicedusageDescNamespace := chargeflatfeeruninvoicedusageMixinFields0[3].Descriptor()
 	// chargeflatfeeruninvoicedusage.NamespaceValidator is a validator for the "namespace" field. It is called by the builders before save.
 	chargeflatfeeruninvoicedusage.NamespaceValidator = chargeflatfeeruninvoicedusageDescNamespace.Validators[0].(func(string) error)
 	// chargeflatfeeruninvoicedusageDescCreatedAt is the schema descriptor for created_at field.
-	chargeflatfeeruninvoicedusageDescCreatedAt := chargeflatfeeruninvoicedusageMixinFields0[7].Descriptor()
+	chargeflatfeeruninvoicedusageDescCreatedAt := chargeflatfeeruninvoicedusageMixinFields0[5].Descriptor()
 	// chargeflatfeeruninvoicedusage.DefaultCreatedAt holds the default value on creation for the created_at field.
 	chargeflatfeeruninvoicedusage.DefaultCreatedAt = chargeflatfeeruninvoicedusageDescCreatedAt.Default.(func() time.Time)
 	// chargeflatfeeruninvoicedusageDescUpdatedAt is the schema descriptor for updated_at field.
-	chargeflatfeeruninvoicedusageDescUpdatedAt := chargeflatfeeruninvoicedusageMixinFields0[8].Descriptor()
+	chargeflatfeeruninvoicedusageDescUpdatedAt := chargeflatfeeruninvoicedusageMixinFields0[6].Descriptor()
 	// chargeflatfeeruninvoicedusage.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	chargeflatfeeruninvoicedusage.DefaultUpdatedAt = chargeflatfeeruninvoicedusageDescUpdatedAt.Default.(func() time.Time)
 	// chargeflatfeeruninvoicedusage.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	chargeflatfeeruninvoicedusage.UpdateDefaultUpdatedAt = chargeflatfeeruninvoicedusageDescUpdatedAt.UpdateDefault.(func() time.Time)
 	// chargeflatfeeruninvoicedusageDescID is the schema descriptor for id field.
-	chargeflatfeeruninvoicedusageDescID := chargeflatfeeruninvoicedusageMixinFields0[6].Descriptor()
+	chargeflatfeeruninvoicedusageDescID := chargeflatfeeruninvoicedusageMixinFields0[4].Descriptor()
 	// chargeflatfeeruninvoicedusage.DefaultID holds the default value on creation for the id field.
 	chargeflatfeeruninvoicedusage.DefaultID = chargeflatfeeruninvoicedusageDescID.Default.(func() string)
 	chargeflatfeerunpaymentMixin := schema.ChargeFlatFeeRunPayment{}.Mixin()
@@ -1388,30 +1392,26 @@ func init() {
 	_ = chargeusagebasedruninvoicedusageMixinFields0
 	chargeusagebasedruninvoicedusageFields := schema.ChargeUsageBasedRunInvoicedUsage{}.Fields()
 	_ = chargeusagebasedruninvoicedusageFields
-	// chargeusagebasedruninvoicedusageDescLineID is the schema descriptor for line_id field.
-	chargeusagebasedruninvoicedusageDescLineID := chargeusagebasedruninvoicedusageMixinFields0[0].Descriptor()
-	// chargeusagebasedruninvoicedusage.LineIDValidator is a validator for the "line_id" field. It is called by the builders before save.
-	chargeusagebasedruninvoicedusage.LineIDValidator = chargeusagebasedruninvoicedusageDescLineID.Validators[0].(func(string) error)
 	// chargeusagebasedruninvoicedusageDescLedgerTransactionGroupID is the schema descriptor for ledger_transaction_group_id field.
-	chargeusagebasedruninvoicedusageDescLedgerTransactionGroupID := chargeusagebasedruninvoicedusageMixinFields0[4].Descriptor()
+	chargeusagebasedruninvoicedusageDescLedgerTransactionGroupID := chargeusagebasedruninvoicedusageMixinFields0[2].Descriptor()
 	// chargeusagebasedruninvoicedusage.LedgerTransactionGroupIDValidator is a validator for the "ledger_transaction_group_id" field. It is called by the builders before save.
 	chargeusagebasedruninvoicedusage.LedgerTransactionGroupIDValidator = chargeusagebasedruninvoicedusageDescLedgerTransactionGroupID.Validators[0].(func(string) error)
 	// chargeusagebasedruninvoicedusageDescNamespace is the schema descriptor for namespace field.
-	chargeusagebasedruninvoicedusageDescNamespace := chargeusagebasedruninvoicedusageMixinFields0[5].Descriptor()
+	chargeusagebasedruninvoicedusageDescNamespace := chargeusagebasedruninvoicedusageMixinFields0[3].Descriptor()
 	// chargeusagebasedruninvoicedusage.NamespaceValidator is a validator for the "namespace" field. It is called by the builders before save.
 	chargeusagebasedruninvoicedusage.NamespaceValidator = chargeusagebasedruninvoicedusageDescNamespace.Validators[0].(func(string) error)
 	// chargeusagebasedruninvoicedusageDescCreatedAt is the schema descriptor for created_at field.
-	chargeusagebasedruninvoicedusageDescCreatedAt := chargeusagebasedruninvoicedusageMixinFields0[7].Descriptor()
+	chargeusagebasedruninvoicedusageDescCreatedAt := chargeusagebasedruninvoicedusageMixinFields0[5].Descriptor()
 	// chargeusagebasedruninvoicedusage.DefaultCreatedAt holds the default value on creation for the created_at field.
 	chargeusagebasedruninvoicedusage.DefaultCreatedAt = chargeusagebasedruninvoicedusageDescCreatedAt.Default.(func() time.Time)
 	// chargeusagebasedruninvoicedusageDescUpdatedAt is the schema descriptor for updated_at field.
-	chargeusagebasedruninvoicedusageDescUpdatedAt := chargeusagebasedruninvoicedusageMixinFields0[8].Descriptor()
+	chargeusagebasedruninvoicedusageDescUpdatedAt := chargeusagebasedruninvoicedusageMixinFields0[6].Descriptor()
 	// chargeusagebasedruninvoicedusage.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	chargeusagebasedruninvoicedusage.DefaultUpdatedAt = chargeusagebasedruninvoicedusageDescUpdatedAt.Default.(func() time.Time)
 	// chargeusagebasedruninvoicedusage.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	chargeusagebasedruninvoicedusage.UpdateDefaultUpdatedAt = chargeusagebasedruninvoicedusageDescUpdatedAt.UpdateDefault.(func() time.Time)
 	// chargeusagebasedruninvoicedusageDescID is the schema descriptor for id field.
-	chargeusagebasedruninvoicedusageDescID := chargeusagebasedruninvoicedusageMixinFields0[6].Descriptor()
+	chargeusagebasedruninvoicedusageDescID := chargeusagebasedruninvoicedusageMixinFields0[4].Descriptor()
 	// chargeusagebasedruninvoicedusage.DefaultID holds the default value on creation for the id field.
 	chargeusagebasedruninvoicedusage.DefaultID = chargeusagebasedruninvoicedusageDescID.Default.(func() string)
 	chargeusagebasedrunpaymentMixin := schema.ChargeUsageBasedRunPayment{}.Mixin()

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -2749,6 +2749,34 @@ func (u *ChargeFlatFeeRunUpdateOne) SetOrClearDeletedAt(value *time.Time) *Charg
 	return u.SetDeletedAt(*value)
 }
 
+func (u *ChargeFlatFeeRunUpdate) SetOrClearLineID(value *string) *ChargeFlatFeeRunUpdate {
+	if value == nil {
+		return u.ClearLineID()
+	}
+	return u.SetLineID(*value)
+}
+
+func (u *ChargeFlatFeeRunUpdateOne) SetOrClearLineID(value *string) *ChargeFlatFeeRunUpdateOne {
+	if value == nil {
+		return u.ClearLineID()
+	}
+	return u.SetLineID(*value)
+}
+
+func (u *ChargeFlatFeeRunUpdate) SetOrClearInvoiceID(value *string) *ChargeFlatFeeRunUpdate {
+	if value == nil {
+		return u.ClearInvoiceID()
+	}
+	return u.SetInvoiceID(*value)
+}
+
+func (u *ChargeFlatFeeRunUpdateOne) SetOrClearInvoiceID(value *string) *ChargeFlatFeeRunUpdateOne {
+	if value == nil {
+		return u.ClearInvoiceID()
+	}
+	return u.SetInvoiceID(*value)
+}
+
 func (u *ChargeFlatFeeRunCreditAllocationsUpdate) SetOrClearLineID(value *string) *ChargeFlatFeeRunCreditAllocationsUpdate {
 	if value == nil {
 		return u.ClearLineID()
@@ -2943,20 +2971,6 @@ func (u *ChargeFlatFeeRunDetailedLineUpdateOne) SetOrClearDescription(value *str
 		return u.ClearDescription()
 	}
 	return u.SetDescription(*value)
-}
-
-func (u *ChargeFlatFeeRunInvoicedUsageUpdate) SetOrClearLineID(value *string) *ChargeFlatFeeRunInvoicedUsageUpdate {
-	if value == nil {
-		return u.ClearLineID()
-	}
-	return u.SetLineID(*value)
-}
-
-func (u *ChargeFlatFeeRunInvoicedUsageUpdateOne) SetOrClearLineID(value *string) *ChargeFlatFeeRunInvoicedUsageUpdateOne {
-	if value == nil {
-		return u.ClearLineID()
-	}
-	return u.SetLineID(*value)
 }
 
 func (u *ChargeFlatFeeRunInvoicedUsageUpdate) SetOrClearLedgerTransactionGroupID(value *string) *ChargeFlatFeeRunInvoicedUsageUpdate {
@@ -3419,20 +3433,6 @@ func (u *ChargeUsageBasedRunDetailedLineUpdateOne) SetOrClearCorrectsRunID(value
 		return u.ClearCorrectsRunID()
 	}
 	return u.SetCorrectsRunID(*value)
-}
-
-func (u *ChargeUsageBasedRunInvoicedUsageUpdate) SetOrClearLineID(value *string) *ChargeUsageBasedRunInvoicedUsageUpdate {
-	if value == nil {
-		return u.ClearLineID()
-	}
-	return u.SetLineID(*value)
-}
-
-func (u *ChargeUsageBasedRunInvoicedUsageUpdateOne) SetOrClearLineID(value *string) *ChargeUsageBasedRunInvoicedUsageUpdateOne {
-	if value == nil {
-		return u.ClearLineID()
-	}
-	return u.SetLineID(*value)
 }
 
 func (u *ChargeUsageBasedRunInvoicedUsageUpdate) SetOrClearLedgerTransactionGroupID(value *string) *ChargeUsageBasedRunInvoicedUsageUpdate {

--- a/openmeter/ent/schema/billing.go
+++ b/openmeter/ent/schema/billing.go
@@ -494,7 +494,8 @@ func (BillingInvoiceLine) Edges() []ent.Edge {
 		edge.To("charge_flat_fee_run_payment", ChargeFlatFeeRunPayment.Type).
 			Unique(),
 		edge.To("charge_flat_fee_run_credit_allocations", ChargeFlatFeeRunCreditAllocations.Type),
-		edge.To("charge_flat_fee_run_invoiced_usage", ChargeFlatFeeRunInvoicedUsage.Type),
+		edge.To("charge_flat_fee_runs", ChargeFlatFeeRun.Type).
+			Unique(),
 		edge.To("charge_usage_based_run", ChargeUsageBasedRuns.Type).
 			Unique(),
 		edge.To("charge_credit_purchase_invoiced_payment", ChargeCreditPurchaseInvoicedPayment.Type).
@@ -1186,6 +1187,7 @@ func (BillingInvoice) Edges() []ent.Edge {
 			Annotations(entsql.OnDelete(entsql.Cascade)),
 		edge.To("billing_invoice_validation_issues", BillingInvoiceValidationIssue.Type).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
+		edge.To("charge_flat_fee_runs", ChargeFlatFeeRun.Type),
 		edge.To("charge_usage_based_runs", ChargeUsageBasedRuns.Type),
 		edge.From("billing_invoice_customer", Customer.Type).
 			Ref("billing_invoice").

--- a/openmeter/ent/schema/chargesflatfee.go
+++ b/openmeter/ent/schema/chargesflatfee.go
@@ -170,10 +170,28 @@ func (ChargeFlatFeeRun) Fields() []ent.Field {
 		field.Time("service_period_from"),
 		field.Time("service_period_to"),
 
+		field.String("line_id").
+			SchemaType(map[string]string{
+				dialect.Postgres: "char(26)",
+			}).
+			Optional().
+			NotEmpty().
+			Nillable(),
+
+		field.String("invoice_id").
+			SchemaType(map[string]string{
+				dialect.Postgres: "char(26)",
+			}).
+			Optional().
+			NotEmpty().
+			Nillable(),
+
 		field.Other("amount_after_proration", alpacadecimal.Decimal{}).
 			SchemaType(map[string]string{
 				dialect.Postgres: "numeric",
 			}),
+
+		field.Bool("no_fiat_transaction_required"),
 	}
 }
 
@@ -185,6 +203,16 @@ func (ChargeFlatFeeRun) Edges() []ent.Edge {
 			Unique().
 			Required().
 			Immutable(),
+		edge.From("billing_invoice_line", BillingInvoiceLine.Type).
+			Ref("charge_flat_fee_runs").
+			Field("line_id").
+			Unique().
+			Annotations(entsql.OnDelete(entsql.SetNull)),
+		edge.From("billing_invoice", BillingInvoice.Type).
+			Ref("charge_flat_fee_runs").
+			Field("invoice_id").
+			Unique().
+			Annotations(entsql.OnDelete(entsql.SetNull)),
 		edge.To("credit_allocations", ChargeFlatFeeRunCreditAllocations.Type).
 			StorageKey(edge.Symbol("charge_ff_credit_alloc_run")).
 			Annotations(entsql.OnDelete(entsql.Cascade)),
@@ -319,10 +347,6 @@ func (ChargeFlatFeeRunInvoicedUsage) Fields() []ent.Field {
 
 func (ChargeFlatFeeRunInvoicedUsage) Edges() []ent.Edge {
 	return []ent.Edge{
-		edge.From("billing_invoice_line", BillingInvoiceLine.Type).
-			Ref("charge_flat_fee_run_invoiced_usage").
-			Field("line_id").
-			Unique(),
 		edge.From("run", ChargeFlatFeeRun.Type).
 			Ref("invoiced_usage").
 			Field("run_id").

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -212,9 +212,13 @@ func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, charge flatfee
 		return ledgertransaction.GroupReference{}, err
 	}
 
+	if charge.Realizations.CurrentRun == nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("current run is required for payment authorization")
+	}
+
 	receivableReplenishment := alpacadecimal.NewFromInt(0)
-	if charge.Realizations.AccruedUsage != nil {
-		receivableReplenishment = charge.Realizations.AccruedUsage.Totals.Total
+	if charge.Realizations.CurrentRun.AccruedUsage != nil {
+		receivableReplenishment = charge.Realizations.CurrentRun.AccruedUsage.Totals.Total
 	}
 
 	if receivableReplenishment.IsZero() {
@@ -270,7 +274,11 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, charge flatfee.Ch
 		return ledgertransaction.GroupReference{}, err
 	}
 
-	if charge.Realizations.AccruedUsage == nil || !charge.Realizations.AccruedUsage.Totals.Total.IsPositive() {
+	if charge.Realizations.CurrentRun == nil {
+		return ledgertransaction.GroupReference{}, fmt.Errorf("current run is required for payment settled")
+	}
+
+	if charge.Realizations.CurrentRun.AccruedUsage == nil || !charge.Realizations.CurrentRun.AccruedUsage.Totals.Total.IsPositive() {
 		return ledgertransaction.GroupReference{}, nil
 	}
 
@@ -289,7 +297,7 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, charge flatfee.Ch
 		},
 		transactions.SettleCustomerReceivableFromPaymentTemplate{
 			At:        charge.Intent.InvoiceAt,
-			Amount:    charge.Realizations.AccruedUsage.Totals.Total,
+			Amount:    charge.Realizations.CurrentRun.AccruedUsage.Totals.Total,
 			Currency:  charge.Intent.Currency,
 			CostBasis: invoiceCostBasis,
 		},

--- a/openmeter/ledger/chargeadapter/flatfee_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_test.go
@@ -184,7 +184,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
 		require.NoError(t, err)
 
-		correctionsRequest, err := chargeWithRealizations.Realizations.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
+		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
 		require.NoError(t, err)
 
 		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
@@ -221,7 +221,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
 		require.NoError(t, err)
 
-		correctionsRequest, err := chargeWithRealizations.Realizations.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-35), currencyCalculator)
+		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-35), currencyCalculator)
 		require.NoError(t, err)
 
 		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
@@ -256,7 +256,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
 		require.NoError(t, err)
 
-		correctionsRequest, err := chargeWithRealizations.Realizations.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
+		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
 		require.NoError(t, err)
 
 		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
@@ -287,7 +287,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
 		require.NoError(t, err)
 
-		correctionsRequest, err := chargeWithRealizations.Realizations.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
+		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
 		require.NoError(t, err)
 
 		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
@@ -312,7 +312,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		require.Len(t, allocations, 1)
 
 		chargeWithRealizations := env.newChargeWithCreditRealizationsAndAccruedUsage(allocations, alpacadecimal.Zero)
-		env.createInitialLineages(t, chargeWithRealizations.ID, chargeWithRealizations.Realizations.CreditRealizations)
+		env.createInitialLineages(t, chargeWithRealizations.ID, chargeWithRealizations.Realizations.CurrentRun.CreditRealizations)
 		recognitionGroupID := env.recognizeCreditAccrued(t, alpacadecimal.NewFromInt(30))
 
 		require.True(t, env.sumBalance(t, env.creditAccruedSubAccount(t)).Equal(alpacadecimal.Zero))
@@ -321,14 +321,14 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
 		require.NoError(t, err)
 
-		correctionsRequest, err := chargeWithRealizations.Realizations.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
+		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
 		require.NoError(t, err)
 
 		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
 			Charge:                       chargeWithRealizations,
 			AllocateAt:                   env.Now(),
 			Corrections:                  correctionsRequest,
-			LineageSegmentsByRealization: env.assertRecognizedSegments(t, chargeWithRealizations.Realizations.CreditRealizations, recognitionGroupID),
+			LineageSegmentsByRealization: env.assertRecognizedSegments(t, chargeWithRealizations.Realizations.CurrentRun.CreditRealizations, recognitionGroupID),
 		})
 		require.NoError(t, err)
 		require.Len(t, corrections, 1)
@@ -353,7 +353,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 
 		chargeWithRealizations := env.newChargeWithCreditRealizationsAndAccruedUsage(allocations, alpacadecimal.Zero)
 		chargeWithRealizations.Intent.SettlementMode = productcatalog.CreditOnlySettlementMode
-		env.createInitialLineages(t, chargeWithRealizations.ID, chargeWithRealizations.Realizations.CreditRealizations)
+		env.createInitialLineages(t, chargeWithRealizations.ID, chargeWithRealizations.Realizations.CurrentRun.CreditRealizations)
 		recognitionGroupID := env.recognizeCreditAccrued(t, alpacadecimal.NewFromInt(30))
 
 		require.True(t, env.sumBalance(t, env.creditAccruedSubAccount(t)).Equal(alpacadecimal.Zero))
@@ -362,14 +362,14 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
 		require.NoError(t, err)
 
-		correctionsRequest, err := chargeWithRealizations.Realizations.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
+		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
 		require.NoError(t, err)
 
 		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
 			Charge:                       chargeWithRealizations,
 			AllocateAt:                   env.Now(),
 			Corrections:                  correctionsRequest,
-			LineageSegmentsByRealization: env.assertRecognizedSegments(t, chargeWithRealizations.Realizations.CreditRealizations, recognitionGroupID),
+			LineageSegmentsByRealization: env.assertRecognizedSegments(t, chargeWithRealizations.Realizations.CurrentRun.CreditRealizations, recognitionGroupID),
 		})
 		require.NoError(t, err)
 		require.Len(t, corrections, 1)
@@ -807,6 +807,23 @@ func (e *flatFeeHandlerTestEnv) newBaseCharge(servicePeriod timeutil.ClosedPerio
 	}
 }
 
+func (e *flatFeeHandlerTestEnv) newRunBase(servicePeriod timeutil.ClosedPeriod, amount alpacadecimal.Decimal) chargeflatfee.RealizationRunBase {
+	return chargeflatfee.RealizationRunBase{
+		ID: chargeflatfee.RealizationRunID{
+			Namespace: e.Namespace,
+			ID:        ulid.Make().String(),
+		},
+		ManagedModel: models.ManagedModel{
+			CreatedAt: servicePeriod.To,
+			UpdatedAt: servicePeriod.To,
+		},
+		Type:                 chargeflatfee.RealizationRunTypeFinalRealization,
+		InitialType:          chargeflatfee.RealizationRunTypeFinalRealization,
+		ServicePeriod:        servicePeriod,
+		AmountAfterProration: amount,
+	}
+}
+
 func (e *flatFeeHandlerTestEnv) newChargeWithAccruedUsage(total alpacadecimal.Decimal) chargeflatfee.Charge {
 	now := time.Now().UTC()
 	servicePeriod := timeutil.ClosedPeriod{
@@ -815,9 +832,11 @@ func (e *flatFeeHandlerTestEnv) newChargeWithAccruedUsage(total alpacadecimal.De
 	}
 
 	charge := e.newBaseCharge(servicePeriod, total)
-	charge.Realizations.AccruedUsage = &invoicedusage.AccruedUsage{
+	charge.Realizations.CurrentRun = &chargeflatfee.RealizationRun{
+		RealizationRunBase: e.newRunBase(servicePeriod, total),
+	}
+	charge.Realizations.CurrentRun.AccruedUsage = &invoicedusage.AccruedUsage{
 		ServicePeriod: servicePeriod,
-		Mutable:       true,
 		Totals: totals.Totals{
 			Amount: total,
 			Total:  total,
@@ -854,10 +873,12 @@ func (e *flatFeeHandlerTestEnv) newChargeWithCreditRealizationsAndAccruedUsage(r
 	}
 
 	charge := e.newBaseCharge(servicePeriod, totalAmount)
-	charge.Realizations.CreditRealizations = creditRealizations
-	charge.Realizations.AccruedUsage = &invoicedusage.AccruedUsage{
+	charge.Realizations.CurrentRun = &chargeflatfee.RealizationRun{
+		RealizationRunBase: e.newRunBase(servicePeriod, totalAmount),
+		CreditRealizations: creditRealizations,
+	}
+	charge.Realizations.CurrentRun.AccruedUsage = &invoicedusage.AccruedUsage{
 		ServicePeriod: servicePeriod,
-		Mutable:       true,
 		Totals: totals.Totals{
 			Amount: accruedTotal,
 			Total:  accruedTotal,

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -567,9 +567,7 @@ func (e *usageBasedHandlerTestEnv) newRunWithLine(lineID string) chargeusagebase
 func (e *usageBasedHandlerTestEnv) newRunWithInvoiceUsage(lineID string, total alpacadecimal.Decimal) chargeusagebased.RealizationRun {
 	run := e.newRunWithLine(lineID)
 	run.InvoiceUsage = &invoicedusage.AccruedUsage{
-		LineID:        &lineID,
 		ServicePeriod: e.newCharge(productcatalog.CreditThenInvoiceSettlementMode).Intent.ServicePeriod,
-		Mutable:       false,
 		Totals: totals.Totals{
 			Amount: total,
 			Total:  total,

--- a/openmeter/ledger/customerbalance/calculation.go
+++ b/openmeter/ledger/customerbalance/calculation.go
@@ -38,7 +38,11 @@ func (i Impact) RealizedCredits() alpacadecimal.Decimal {
 	switch i.Type() {
 	case meta.ChargeTypeFlatFee:
 		charge, _ := i.AsFlatFeeCharge()
-		return charge.Realizations.CreditRealizations.Sum()
+		if charge.Realizations.CurrentRun == nil {
+			return alpacadecimal.Zero
+		}
+
+		return charge.Realizations.CurrentRun.CreditRealizations.Sum()
 	case meta.ChargeTypeUsageBased:
 		charge, _ := i.AsUsageBasedCharge()
 		total := alpacadecimal.Zero

--- a/openmeter/ledger/customerbalance/calculation.go
+++ b/openmeter/ledger/customerbalance/calculation.go
@@ -41,6 +41,9 @@ func (i Impact) RealizedCredits() alpacadecimal.Decimal {
 		if charge.Realizations.CurrentRun == nil {
 			return alpacadecimal.Zero
 		}
+		if charge.Realizations.CurrentRun.IsVoidedBillingHistory() {
+			return alpacadecimal.Zero
+		}
 
 		return charge.Realizations.CurrentRun.CreditRealizations.Sum()
 	case meta.ChargeTypeUsageBased:

--- a/openmeter/ledger/customerbalance/service_test.go
+++ b/openmeter/ledger/customerbalance/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
@@ -200,6 +201,33 @@ func TestImpactRealizedCreditsSkipsVoidedUsageBasedBillingHistory(t *testing.T) 
 	require.NoError(t, err)
 
 	require.Equal(t, float64(7), impact.RealizedCredits().InexactFloat64())
+}
+
+func TestImpactRealizedCreditsSkipsVoidedFlatFeeBillingHistory(t *testing.T) {
+	impact, err := NewImpact(charges.NewCharge(flatfee.Charge{
+		ChargeBase: flatfee.ChargeBase{
+			Intent: flatfee.Intent{
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			},
+		},
+		Realizations: flatfee.Realizations{
+			CurrentRun: &flatfee.RealizationRun{
+				RealizationRunBase: flatfee.RealizationRunBase{
+					Type: flatfee.RealizationRunTypeInvalidDueToUnsupportedCreditNote,
+				},
+				CreditRealizations: creditrealization.Realizations{
+					{
+						CreateInput: creditrealization.CreateInput{
+							Amount: alpacadecimal.NewFromInt(10),
+						},
+					},
+				},
+			},
+		},
+	}), alpacadecimal.NewFromInt(50))
+	require.NoError(t, err)
+
+	require.True(t, impact.RealizedCredits().Equal(alpacadecimal.Zero))
 }
 
 func TestGetBalanceWithDifferentCurrency(t *testing.T) {

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -245,7 +245,8 @@ func (s *SanitySuite) createAndAdvanceFlatFeeCreditOnlyCharge(setup creditOnlyDe
 	advancedCharge, err := advancedCharges[0].AsFlatFeeCharge()
 	s.NoError(err)
 	s.Equal(flatfee.StatusFinal, advancedCharge.Status)
-	s.Len(advancedCharge.Realizations.CreditRealizations, 1)
+	s.Require().NotNil(advancedCharge.Realizations.CurrentRun)
+	s.Len(advancedCharge.Realizations.CurrentRun.CreditRealizations, 1)
 
 	return flatFeeChargeID.ID
 }
@@ -696,6 +697,7 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 		s.NoError(err)
 
 		s.Equal(flatFeeChargeID.ID, updatedFlatFeeCharge.ID)
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
 
 		// LEDGER:
 		// - OnFlatFeeAssignedToInvoice is called with the pre tax total amount of USD 100
@@ -703,11 +705,11 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 
 		// Validate the credit realizations
 		// The charge should have $80 realized as credits
-		s.Len(updatedFlatFeeCharge.Realizations.CreditRealizations, 2)
-		promotionalCreditRealization := updatedFlatFeeCharge.Realizations.CreditRealizations[0]
+		s.Len(updatedFlatFeeCharge.Realizations.CurrentRun.CreditRealizations, 2)
+		promotionalCreditRealization := updatedFlatFeeCharge.Realizations.CurrentRun.CreditRealizations[0]
 		s.Equal(float64(30), promotionalCreditRealization.Amount.InexactFloat64())
 
-		customerCreditRealization := updatedFlatFeeCharge.Realizations.CreditRealizations[1]
+		customerCreditRealization := updatedFlatFeeCharge.Realizations.CurrentRun.CreditRealizations[1]
 		s.Equal(float64(50), customerCreditRealization.Amount.InexactFloat64())
 
 		assertDelta("promo FBO after invoice assignment", flatFeeStart.promoFBO, alpacadecimal.NewFromInt(-30), s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&promoCostBasis)))
@@ -740,12 +742,12 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 		// - Payment authorization is deferred until the payment app advances the invoice beyond pending
 
 		// Invoice usage accrued callback should have been invoked
-		accruedUsage := updatedFlatFeeCharge.Realizations.AccruedUsage
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		accruedUsage := updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage
 		s.NotNil(accruedUsage)
 		s.Equal(servicePeriod, accruedUsage.ServicePeriod, "service period should be the same as the input")
-		s.False(accruedUsage.Mutable, "accrued usage should not be mutable")
-		s.NotNil(accruedUsage.LineID, "line ID should be set")
-		s.Equal(stdLineID.ID, *accruedUsage.LineID, "line ID should be the same as the standard line")
+		s.NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.LineID, "run line ID should be set")
+		s.Equal(stdLineID.ID, *updatedFlatFeeCharge.Realizations.CurrentRun.LineID, "run line ID should be the same as the standard line")
 		s.Equal(float64(20), accruedUsage.Totals.Total.InexactFloat64(), "totals should be the same as the input")
 		s.Equal(float64(80), accruedUsage.Totals.CreditsTotal.InexactFloat64(), "totals should be the same as the input")
 
@@ -773,10 +775,11 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 		updatedFlatFeeCharge, err := charge.AsFlatFeeCharge()
 		s.NoError(err)
 		s.Equal(flatfee.StatusActive, updatedFlatFeeCharge.Status)
-		s.NotNil(updatedFlatFeeCharge.Realizations.Payment)
-		s.Equal(payment.StatusAuthorized, updatedFlatFeeCharge.Realizations.Payment.Status)
-		s.NotNil(updatedFlatFeeCharge.Realizations.Payment.Authorized)
-		s.Nil(updatedFlatFeeCharge.Realizations.Payment.Settled)
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.Payment)
+		s.Equal(payment.StatusAuthorized, updatedFlatFeeCharge.Realizations.CurrentRun.Payment.Status)
+		s.NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.Payment.Authorized)
+		s.Nil(updatedFlatFeeCharge.Realizations.CurrentRun.Payment.Settled)
 
 		assertDelta("promo receivable after payment authorization", flatFeeStart.promoReceivable, alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen))
 		assertDelta("external receivable after payment authorization", flatFeeStart.externalReceivable, alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&externalCostBasis), ledger.TransactionAuthorizationStatusOpen))
@@ -803,10 +806,11 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 		updatedFlatFeeCharge, err := charge.AsFlatFeeCharge()
 		s.NoError(err)
 		s.Equal(flatfee.StatusFinal, updatedFlatFeeCharge.Status)
-		s.NotNil(updatedFlatFeeCharge.Realizations.Payment)
-		s.Equal(payment.StatusSettled, updatedFlatFeeCharge.Realizations.Payment.Status)
-		s.NotNil(updatedFlatFeeCharge.Realizations.Payment.Authorized)
-		s.NotNil(updatedFlatFeeCharge.Realizations.Payment.Settled)
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.Payment)
+		s.Equal(payment.StatusSettled, updatedFlatFeeCharge.Realizations.CurrentRun.Payment.Status)
+		s.NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.Payment.Authorized)
+		s.NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.Payment.Settled)
 
 		assertDelta("promo receivable after payment settlement", flatFeeStart.promoReceivable, alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&promoCostBasis), ledger.TransactionAuthorizationStatusOpen))
 		assertDelta("external receivable after payment settlement", flatFeeStart.externalReceivable, alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&externalCostBasis), ledger.TransactionAuthorizationStatusOpen))
@@ -1231,14 +1235,16 @@ func (s *SanitySuite) TestFlatFeeCreditOnlySanity() {
 		s.NoError(err)
 		s.Equal(flatFeeChargeID.ID, advancedFlatFee.ID)
 		s.Equal(flatfee.StatusFinal, advancedFlatFee.Status)
+		s.Require().NotNil(advancedFlatFee.Realizations.CurrentRun)
 		// We expect three realizations here: promotional credit, purchased credit, and the synthetic shortfall coverage.
-		s.Len(advancedFlatFee.Realizations.CreditRealizations, 3)
+		s.Len(advancedFlatFee.Realizations.CurrentRun.CreditRealizations, 3)
 
 		fetchedCharge := s.MustGetChargeByID(flatFeeChargeID)
 		updatedFlatFeeCharge, err := fetchedCharge.AsFlatFeeCharge()
 		s.NoError(err)
 		s.Equal(flatfee.StatusFinal, updatedFlatFeeCharge.Status)
-		s.Len(updatedFlatFeeCharge.Realizations.CreditRealizations, 3)
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.Len(updatedFlatFeeCharge.Realizations.CurrentRun.CreditRealizations, 3)
 
 		gatheringInvoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
 			Namespaces: []string{ns},

--- a/tools/migrate/migrations/20260512114051_flatfee_run_domain_fields.down.sql
+++ b/tools/migrate/migrations/20260512114051_flatfee_run_domain_fields.down.sql
@@ -1,0 +1,13 @@
+-- reverse: create index "charge_flat_fee_runs_line_id_key" to table: "charge_flat_fee_runs"
+DROP INDEX "charge_flat_fee_runs_line_id_key";
+-- reverse: modify "charge_flat_fee_runs" table
+ALTER TABLE "charge_flat_fee_runs" DROP CONSTRAINT "charge_flat_fee_runs_billing_invoices_charge_flat_fee_runs", DROP CONSTRAINT "charge_flat_fee_runs_billing_invoice_lines_charge_flat_fee_runs";
+-- reverse: modify "charge_usage_based_run_invoiced_usages" table
+ALTER TABLE "charge_usage_based_run_invoiced_usages" ADD COLUMN "line_id" character(26) NULL, ADD COLUMN "mutable" boolean NOT NULL DEFAULT false;
+ALTER TABLE "charge_usage_based_run_invoiced_usages" ALTER COLUMN "mutable" DROP DEFAULT;
+-- reverse: modify "charge_flat_fee_run_invoiced_usages" table
+ALTER TABLE "charge_flat_fee_run_invoiced_usages" ADD COLUMN "line_id" character(26) NULL, ADD COLUMN "mutable" boolean NOT NULL DEFAULT false;
+ALTER TABLE "charge_flat_fee_run_invoiced_usages" ALTER COLUMN "mutable" DROP DEFAULT;
+ALTER TABLE "charge_flat_fee_run_invoiced_usages" ADD CONSTRAINT "charge_flat_fee_run_invoiced_usages_billing_invoice_lines_charg" FOREIGN KEY ("line_id") REFERENCES "billing_invoice_lines" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;
+-- reverse: modify "charge_flat_fee_runs" table
+ALTER TABLE "charge_flat_fee_runs" DROP COLUMN "no_fiat_transaction_required", DROP COLUMN "invoice_id", DROP COLUMN "line_id";

--- a/tools/migrate/migrations/20260512114051_flatfee_run_domain_fields.up.sql
+++ b/tools/migrate/migrations/20260512114051_flatfee_run_domain_fields.up.sql
@@ -1,0 +1,16 @@
+-- modify "charge_flat_fee_runs" table
+ALTER TABLE "charge_flat_fee_runs" ADD COLUMN "line_id" character(26) NULL, ADD COLUMN "invoice_id" character(26) NULL, ADD COLUMN "no_fiat_transaction_required" boolean NULL;
+
+UPDATE "charge_flat_fee_runs" AS "r"
+SET "no_fiat_transaction_required" = true;
+
+ALTER TABLE "charge_flat_fee_runs" ALTER COLUMN "no_fiat_transaction_required" SET NOT NULL;
+
+-- modify "charge_flat_fee_run_invoiced_usages" table
+ALTER TABLE "charge_flat_fee_run_invoiced_usages" DROP CONSTRAINT "charge_flat_fee_run_invoiced_usages_billing_invoice_lines_charg", DROP COLUMN "line_id", DROP COLUMN "mutable";
+-- modify "charge_usage_based_run_invoiced_usages" table
+ALTER TABLE "charge_usage_based_run_invoiced_usages" DROP COLUMN "line_id", DROP COLUMN "mutable";
+
+ALTER TABLE "charge_flat_fee_runs" ADD CONSTRAINT "charge_flat_fee_runs_billing_invoice_lines_charge_flat_fee_runs" FOREIGN KEY ("line_id") REFERENCES "billing_invoice_lines" ("id") ON UPDATE NO ACTION ON DELETE SET NULL, ADD CONSTRAINT "charge_flat_fee_runs_billing_invoices_charge_flat_fee_runs" FOREIGN KEY ("invoice_id") REFERENCES "billing_invoices" ("id") ON UPDATE NO ACTION ON DELETE SET NULL;
+-- create index "charge_flat_fee_runs_line_id_key" to table: "charge_flat_fee_runs"
+CREATE UNIQUE INDEX "charge_flat_fee_runs_line_id_key" ON "charge_flat_fee_runs" ("line_id");

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:ykfKXtq6VIQ/7Vkk+k3XVSU9VZkMxTLUuMVtMv++FKo=
+h1:UopySVZkdQLSY1XYDxwpw0v92Qh3DyIrgjrLTMlfT4k=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -196,3 +196,4 @@ h1:ykfKXtq6VIQ/7Vkk+k3XVSU9VZkMxTLUuMVtMv++FKo=
 20260508124235_add_app_customer_partial_unique_indexes.up.sql h1:lDSECg/89RhVuaA2l6wuctd0+QGywbFBWLbTLMDLHo8=
 20260511120000_usagebased_run_initial_type.up.sql h1:S3KxvJL6OEf4DjnYqxNorvoc9kqg63kb/TZIIq9BPlY=
 20260511201803_flatfee_runs.up.sql h1:mNKOZNFhdZEZ1Y4p/dZpGNg51BeOu42qaeQ4bBaxxsQ=
+20260512114051_flatfee_run_domain_fields.up.sql h1:U1HP3IRA9klnhKXDKymFQhwCErWNPqValuwCZjqyTmc=


### PR DESCRIPTION
## Summary

Adds domain-level run support for flat-fee charge realizations.

Flat-fee realizations are now grouped under a current run, with prior runs available for future prorating workflows. Credit allocations, invoice usage, detailed lines, and payment state are represented through the current run instead of directly on the flat-fee charge realization state.

## Behavior Changes

- Flat-fee credit-only charges are created without a run and provision the current run when they become active.
- Deleting a future credit-only flat-fee charge no longer requires credit correction, because no credits have been allocated yet.
- Flat-fee credit-then-invoice charges persist invoice line and invoice references on the current run.
- Accrued usage no longer carries lineID or mutable; line assignment belongs to the realization run.
- Detailed lines are fetched from the current run.

## Migration

Existing flat-fee run data is migrated into the new run shape without backfilling invoice line references, since flat-fee credit-then-invoice was not active for existing production data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Separate current run data from prior runs for clearer billing history
  * Move invoice line tracking and invoice association into charge runs
  * Payment and credit processing now operate on the run-scoped current run
  * Add explicit provisioning for charge current runs

* **Data model / Migrations**
  * Add run-level invoice/line fields and a no-fiat-transaction flag; remove line/mutable from invoiced usage

* **Tests**
  * Update tests to validate run-scoped behavior and voided-run handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4350)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->