### PR TITLE
feat: add flat fee credit-then-invoice lifecycle

### DIFF
--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -152,6 +152,12 @@ Important rules:
 - usage-based invoice branches should read in this order: `started -> waiting_for_collection -> processing -> issuing -> completed`, then auto-advance out of the branch. Keep `invoice_issued` as the boundary between `processing` and `issuing`, run `FinalizeInvoiceRun(...)` from the `issuing` state, and let `completed` be the last branch-local status before `next` returns a partial invoice to `active` or moves a final invoice to `active.awaiting_payment_settlement`
 - when adding or renaming usage-based detailed statuses, remember that `status_detailed` is an Ent enum for `ChargeUsageBased`; run `make generate` so the generated enum validators and migrate schema include the new values before trusting state-machine changes
 
+Flat-fee credit-then-invoice lifecycle rules:
+
+- Flat-fee invoice lifecycle behavior must be driven by `billing.LineEngineTypeChargeFlatFee` through the flat-fee line engine. Do not reintroduce public flat-fee invoice lifecycle service methods or call the flat-fee state machine from `charges/service` standard-invoice hooks.
+- The charges standard-invoice hook may still run for cross-charge concerns such as revenue recognition and credit-purchase callbacks. For flat-fee invoice statuses, keep the hook processors as no-ops and let the line engine own `OnStandardInvoiceCreated`, `OnCollectionCompleted`, `OnInvoiceIssued`, `OnPaymentAuthorized`, `OnPaymentSettled`, and mutable-line cleanup.
+- Flat-fee `credit_only` is not a line-engine flow; the flat-fee line engine should treat non-`credit_then_invoice` standard invoice callbacks as lifecycle misuse.
+
 Usage-based credit-then-invoice extension rules:
 
 - `PatchExtend` must represent a real extension: the new service period end must be after the persisted intent end; full service period and billing period ends may stay unchanged but must not move backwards. Carry the new invoice-at on the patch separately from the service-period end.

--- a/openmeter/billing/charges/flatfee/adapter.go
+++ b/openmeter/billing/charges/flatfee/adapter.go
@@ -29,6 +29,7 @@ type Adapter interface {
 type ChargeAdapter interface {
 	CreateCharges(ctx context.Context, charges CreateChargesInput) ([]Charge, error)
 	ProvisionCurrentRun(ctx context.Context, input ProvisionCurrentRunInput) (RealizationRunBase, error)
+	AssignCurrentRunInvoiceLine(ctx context.Context, input AssignCurrentRunInvoiceLineInput) (RealizationRunBase, error)
 	UpdateCharge(ctx context.Context, charge ChargeBase) (ChargeBase, error)
 	DeleteCharge(ctx context.Context, charge Charge) error
 	GetByIDs(ctx context.Context, ids GetByIDsInput) ([]Charge, error)
@@ -92,6 +93,30 @@ func (i CreateInvoicedUsageInput) Validate() error {
 
 	if err := i.InvoicedUsage.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("invoiced usage: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type AssignCurrentRunInvoiceLineInput struct {
+	ChargeID  meta.ChargeID
+	LineID    string
+	InvoiceID string
+}
+
+func (i AssignCurrentRunInvoiceLineInput) Validate() error {
+	var errs []error
+
+	if err := i.ChargeID.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge ID: %w", err))
+	}
+
+	if i.InvoiceID == "" {
+		errs = append(errs, fmt.Errorf("invoice ID is required"))
+	}
+
+	if i.LineID == "" {
+		errs = append(errs, fmt.Errorf("line ID is required"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/billing/charges/flatfee/adapter.go
+++ b/openmeter/billing/charges/flatfee/adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/alpacahq/alpacadecimal"
 
@@ -100,6 +101,7 @@ type IntentWithInitialStatus struct {
 	Intent
 	FeatureID                 *string
 	InitialStatus             Status
+	InitialAdvanceAfter       *time.Time
 	AmountAfterProration      alpacadecimal.Decimal
 	NoFiatTransactionRequired bool
 }
@@ -116,6 +118,10 @@ func (i IntentWithInitialStatus) Validate() error {
 
 	if err := i.InitialStatus.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("initial status: %w", err))
+	}
+
+	if i.InitialAdvanceAfter != nil && i.InitialAdvanceAfter.IsZero() {
+		errs = append(errs, fmt.Errorf("initial advance after cannot be zero"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/billing/charges/flatfee/adapter/charge.go
+++ b/openmeter/billing/charges/flatfee/adapter/charge.go
@@ -302,9 +302,10 @@ func (a *adapter) buildCreateFlatFeeCharge(ns string, intent flatfee.IntentWithI
 	}
 
 	create, err = chargemeta.Create[*db.ChargeFlatFeeCreate](create, chargemeta.CreateInput{
-		Namespace: ns,
-		Intent:    intent.Intent.Intent,
-		Status:    metaStatus,
+		Namespace:    ns,
+		Intent:       intent.Intent.Intent,
+		Status:       metaStatus,
+		AdvanceAfter: meta.NormalizeOptionalTimestamp(intent.InitialAdvanceAfter),
 	})
 	if err != nil {
 		return nil, err

--- a/openmeter/billing/charges/flatfee/adapter/realizationrun.go
+++ b/openmeter/billing/charges/flatfee/adapter/realizationrun.go
@@ -76,6 +76,30 @@ func (a *adapter) ProvisionCurrentRun(ctx context.Context, input flatfee.Provisi
 	})
 }
 
+func (a *adapter) AssignCurrentRunInvoiceLine(ctx context.Context, input flatfee.AssignCurrentRunInvoiceLineInput) (flatfee.RealizationRunBase, error) {
+	if err := input.Validate(); err != nil {
+		return flatfee.RealizationRunBase{}, err
+	}
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (flatfee.RealizationRunBase, error) {
+		run, err := tx.currentRunByChargeID(ctx, input.ChargeID)
+		if err != nil {
+			return flatfee.RealizationRunBase{}, err
+		}
+
+		updated, err := tx.db.ChargeFlatFeeRun.UpdateOneID(run.ID).
+			Where(dbchargeflatfeerun.Namespace(input.ChargeID.Namespace)).
+			SetLineID(input.LineID).
+			SetInvoiceID(input.InvoiceID).
+			Save(ctx)
+		if err != nil {
+			return flatfee.RealizationRunBase{}, fmt.Errorf("assigning invoice line to flat fee current run [charge_id=%s, run_id=%s]: %w", input.ChargeID.ID, run.ID, err)
+		}
+
+		return mapRealizationRunBaseFromDB(updated), nil
+	})
+}
+
 func (a *adapter) currentRunByChargeID(ctx context.Context, chargeID meta.ChargeID) (*db.ChargeFlatFeeRun, error) {
 	if err := chargeID.Validate(); err != nil {
 		return nil, err

--- a/openmeter/billing/charges/flatfee/handler.go
+++ b/openmeter/billing/charges/flatfee/handler.go
@@ -127,7 +127,7 @@ type Handler interface {
 	// OnFlatFeeStandardInvoiceUsageAccrued is called when the remaining usage is sent to the customer on a standard invoice.
 	OnInvoiceUsageAccrued(ctx context.Context, input OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
 
-	// OnCreditsOnlyUsageAccrued is called when a credit-only flat fee becomes active (clock >= InvoiceAt)
+	// OnCreditsOnlyUsageAccrued is called when a credit-only flat fee reaches invoice_at
 	// and the full amount needs to be allocated as credits.
 	OnCreditsOnlyUsageAccrued(ctx context.Context, input OnCreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
 

--- a/openmeter/billing/charges/flatfee/service.go
+++ b/openmeter/billing/charges/flatfee/service.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -15,7 +14,6 @@ import (
 type Service interface {
 	FlatFeeService
 	GetLineEngine() billing.LineEngine
-	InvoiceLifecycleHooks
 }
 
 type FlatFeeService interface {
@@ -24,13 +22,6 @@ type FlatFeeService interface {
 	GetByID(ctx context.Context, input GetByIDInput) (Charge, error)
 	AdvanceCharge(ctx context.Context, input AdvanceChargeInput) (*Charge, error)
 	TriggerPatch(ctx context.Context, charge meta.ChargeID, patch meta.Patch) (meta.TriggerPatchResult[Charge], error)
-}
-
-type InvoiceLifecycleHooks interface {
-	PostLineAssignedToInvoice(ctx context.Context, charge Charge, line billing.StandardLine) (creditrealization.Realizations, error)
-	PostInvoiceIssued(ctx context.Context, charge Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error
-	PostInvoicePaymentAuthorized(ctx context.Context, charge Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error
-	PostInvoicePaymentSettled(ctx context.Context, charge Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error
 }
 
 type CreateInput struct {

--- a/openmeter/billing/charges/flatfee/service/create.go
+++ b/openmeter/billing/charges/flatfee/service/create.go
@@ -3,11 +3,13 @@ package service
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -29,14 +31,17 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 		intentsWithStatus, err := slicesx.MapWithErr(input.Intents, func(intent flatfee.Intent) (flatfee.IntentWithInitialStatus, error) {
 			intent = intent.Normalized()
 
-			initialStatus := flatfee.StatusActive
-			if intent.SettlementMode == productcatalog.CreditOnlySettlementMode {
-				initialStatus = flatfee.StatusCreated
-			}
-
 			amountAfterProration, err := intent.CalculateAmountAfterProration()
 			if err != nil {
 				return flatfee.IntentWithInitialStatus{}, fmt.Errorf("calculating amount after proration: %w", err)
+			}
+
+			initialStatus := flatfee.StatusActive
+			var initialAdvanceAfter *time.Time
+			switch intent.SettlementMode {
+			case productcatalog.CreditOnlySettlementMode, productcatalog.CreditThenInvoiceSettlementMode:
+				initialStatus = flatfee.StatusCreated
+				initialAdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(intent.ServicePeriod.From))
 			}
 
 			var featureID *string
@@ -52,6 +57,7 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 				Intent:                    intent,
 				FeatureID:                 featureID,
 				InitialStatus:             initialStatus,
+				InitialAdvanceAfter:       initialAdvanceAfter,
 				AmountAfterProration:      amountAfterProration,
 				NoFiatTransactionRequired: intent.SettlementMode == productcatalog.CreditOnlySettlementMode || amountAfterProration.IsZero(),
 			}, nil

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -25,10 +24,6 @@ func NewCreditThenInvoiceStateMachine(config StateMachineConfig) (*CreditThenInv
 
 	if config.Charge.Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
 		return nil, fmt.Errorf("charge %s is not credit_then_invoice", config.Charge.ID)
-	}
-
-	if config.Service == nil {
-		return nil, errors.New("service is required")
 	}
 
 	stateMachine, err := newStateMachineBase(config)

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -124,6 +124,8 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, _ meta
 	return nil
 }
 
+// StartRealization mutates input.Line.CreditsApplied after allocating credits.
+// The line engine relies on that in-place update when persisting detailed lines.
 func (s *CreditThenInvoiceStateMachine) StartRealization(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
 	if err := input.Validate(); err != nil {
 		return err
@@ -180,6 +182,7 @@ func (s *CreditThenInvoiceStateMachine) AccrueInvoiceUsage(ctx context.Context, 
 
 	s.Charge.Realizations.CurrentRun.AccruedUsage = accruedUsage
 
+	// The state machine persists this clear through StatusFinal's ClearAdvanceAfter hook.
 	s.Charge.State.AdvanceAfter = nil
 
 	return nil
@@ -187,7 +190,7 @@ func (s *CreditThenInvoiceStateMachine) AccrueInvoiceUsage(ctx context.Context, 
 
 func (s *CreditThenInvoiceStateMachine) AreAllPaymentsSettled() bool {
 	if s.Charge.Realizations.CurrentRun == nil {
-		return true
+		return false
 	}
 
 	if s.Charge.Realizations.CurrentRun.AccruedUsage == nil {

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -1,0 +1,202 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/statelessx"
+)
+
+type CreditThenInvoiceStateMachine struct {
+	*stateMachine
+}
+
+func NewCreditThenInvoiceStateMachine(config StateMachineConfig) (*CreditThenInvoiceStateMachine, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("validate: %w", err)
+	}
+
+	if config.Charge.Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+		return nil, fmt.Errorf("charge %s is not credit_then_invoice", config.Charge.ID)
+	}
+
+	if config.Service == nil {
+		return nil, errors.New("service is required")
+	}
+
+	stateMachine, err := newStateMachineBase(config)
+	if err != nil {
+		return nil, fmt.Errorf("new state machine: %w", err)
+	}
+
+	out := &CreditThenInvoiceStateMachine{
+		stateMachine: stateMachine,
+	}
+	out.configureStates()
+
+	return out, nil
+}
+
+func (s *CreditThenInvoiceStateMachine) configureStates() {
+	s.Configure(flatfee.StatusCreated).
+		Permit(
+			meta.TriggerNext,
+			flatfee.StatusActive,
+			statelessx.BoolFn(s.IsInsideServicePeriod),
+		).
+		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		OnActive(s.AdvanceAfterServicePeriodFrom)
+
+	s.Configure(flatfee.StatusActive).
+		Permit(meta.TriggerFinalInvoiceCreated, flatfee.StatusActiveRealizationStarted).
+		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		OnActive(s.AdvanceAfterServicePeriodTo)
+
+	s.Configure(flatfee.StatusActiveRealizationStarted).
+		Permit(meta.TriggerNext, flatfee.StatusActiveRealizationWaitingForCollection).
+		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		OnEntryFrom(meta.TriggerFinalInvoiceCreated, statelessx.WithParameters(s.StartRealization))
+
+	s.Configure(flatfee.StatusActiveRealizationWaitingForCollection).
+		Permit(meta.TriggerCollectionCompleted, flatfee.StatusActiveRealizationProcessing).
+		Permit(meta.TriggerDelete, flatfee.StatusDeleted)
+
+	s.Configure(flatfee.StatusActiveRealizationProcessing).
+		Permit(meta.TriggerInvoiceIssued, flatfee.StatusActiveRealizationIssuing).
+		Permit(meta.TriggerDelete, flatfee.StatusDeleted)
+
+	s.Configure(flatfee.StatusActiveRealizationIssuing).
+		Permit(meta.TriggerNext, flatfee.StatusActiveRealizationCompleted).
+		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.AccrueInvoiceUsage))
+
+	s.Configure(flatfee.StatusActiveRealizationCompleted).
+		Permit(meta.TriggerNext, flatfee.StatusActiveAwaitingPaymentSettlement).
+		Permit(meta.TriggerDelete, flatfee.StatusDeleted)
+
+	s.Configure(flatfee.StatusActiveAwaitingPaymentSettlement).
+		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.AreAllPaymentsSettled)).
+		Permit(meta.TriggerAllPaymentsSettled, flatfee.StatusFinal, statelessx.BoolFn(s.AreAllPaymentsSettled)).
+		Permit(meta.TriggerDelete, flatfee.StatusDeleted)
+
+	s.Configure(flatfee.StatusFinal).
+		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		OnActive(s.ClearAdvanceAfter)
+
+	s.Configure(flatfee.StatusDeleted).
+		OnEntry(statelessx.WithParameters(s.DeleteCharge))
+}
+
+func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, _ meta.PatchDeletePolicy) error {
+	patches := []invoiceupdater.Patch{
+		invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID),
+	}
+
+	if s.Charge.Realizations.CurrentRun != nil &&
+		s.Charge.Realizations.CurrentRun.LineID != nil &&
+		s.Charge.Realizations.CurrentRun.InvoiceID != nil {
+		patches = append(patches, invoiceupdater.NewDeleteLinePatch(
+			billing.LineID{
+				Namespace: s.Charge.Namespace,
+				ID:        *s.Charge.Realizations.CurrentRun.LineID,
+			},
+			*s.Charge.Realizations.CurrentRun.InvoiceID,
+		))
+	}
+
+	s.AddInvoicePatch(patches...)
+
+	if err := s.Adapter.DeleteCharge(ctx, s.Charge); err != nil {
+		return fmt.Errorf("delete charge: %w", err)
+	}
+
+	if err := s.RefetchCharge(ctx); err != nil {
+		return fmt.Errorf("get charge: %w", err)
+	}
+
+	return nil
+}
+
+func (s *CreditThenInvoiceStateMachine) StartRealization(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	if s.Charge.Realizations.CurrentRun == nil {
+		runBase, err := s.Adapter.ProvisionCurrentRun(ctx, flatfee.ProvisionCurrentRunInput{
+			Charge:                    s.Charge.ChargeBase,
+			NoFiatTransactionRequired: s.Charge.State.AmountAfterProration.IsZero(),
+		})
+		if err != nil {
+			return fmt.Errorf("provision current run: %w", err)
+		}
+
+		s.Charge.Realizations.CurrentRun = &flatfee.RealizationRun{
+			RealizationRunBase: runBase,
+		}
+	}
+
+	runBase, err := s.Adapter.AssignCurrentRunInvoiceLine(ctx, flatfee.AssignCurrentRunInvoiceLineInput{
+		ChargeID:  s.Charge.GetChargeID(),
+		LineID:    input.Line.ID,
+		InvoiceID: input.Invoice.ID,
+	})
+	if err != nil {
+		return fmt.Errorf("assign invoice line to current run: %w", err)
+	}
+
+	s.Charge.Realizations.CurrentRun.RealizationRunBase = runBase
+
+	realizations, err := s.Service.postLineAssignedToInvoice(ctx, s.Charge, *input.Line)
+	if err != nil {
+		return fmt.Errorf("assign line to invoice: %w", err)
+	}
+
+	if len(realizations) > 0 {
+		input.Line.CreditsApplied = convertCreditRealizations(realizations)
+	}
+
+	s.Charge.Realizations.CurrentRun.CreditRealizations = append(s.Charge.Realizations.CurrentRun.CreditRealizations, realizations...)
+
+	return nil
+}
+
+func (s *CreditThenInvoiceStateMachine) AccrueInvoiceUsage(ctx context.Context, input billing.StandardLineWithInvoiceHeader) error {
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	accruedUsage, err := s.Service.accrueInvoiceUsage(ctx, s.Charge, input)
+	if err != nil {
+		return fmt.Errorf("post invoice issued: %w", err)
+	}
+
+	s.Charge.Realizations.CurrentRun.AccruedUsage = accruedUsage
+
+	s.Charge.State.AdvanceAfter = nil
+
+	return nil
+}
+
+func (s *CreditThenInvoiceStateMachine) AreAllPaymentsSettled() bool {
+	if s.Charge.Realizations.CurrentRun == nil {
+		return true
+	}
+
+	if s.Charge.Realizations.CurrentRun.AccruedUsage == nil {
+		return true
+	}
+
+	if s.Charge.Realizations.CurrentRun.Payment == nil {
+		return false
+	}
+
+	return s.Charge.Realizations.CurrentRun.Payment.Status == payment.StatusSettled
+}

--- a/openmeter/billing/charges/flatfee/service/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/creditsonly.go
@@ -42,20 +42,27 @@ func NewCreditsOnlyStateMachine(config StateMachineConfig) (*CreditsOnlyStateMac
 
 func (s *CreditsOnlyStateMachine) configureStates() {
 	s.Configure(flatfee.StatusCreated).
-		Permit(meta.TriggerNext, flatfee.StatusActive, statelessx.BoolFn(s.IsAfterInvoiceAt)).
+		Permit(meta.TriggerNext, flatfee.StatusActive, statelessx.BoolFn(s.IsInsideServicePeriod)).
 		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
 		OnActive(
-			s.SetAdvanceAfterInvoiceAt,
+			s.AdvanceAfterServicePeriodFrom,
 		)
 
 	s.Configure(flatfee.StatusActive).
-		Permit(meta.TriggerNext, flatfee.StatusFinal).
+		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.IsAfterInvoiceAt)).
 		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
-		OnActive(s.AllocateCredits)
+		OnActive(
+			s.AdvanceAfterInvoiceAt,
+		)
 
 	s.Configure(flatfee.StatusFinal).
 		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
-		OnActive(s.ClearAdvanceAfter)
+		OnActive(
+			statelessx.AllOf(
+				s.AllocateCredits,
+				s.ClearAdvanceAfter,
+			),
+		)
 
 	s.Configure(flatfee.StatusDeleted).
 		OnEntry(statelessx.WithParameters(s.DeleteCharge))
@@ -65,13 +72,8 @@ func (s *CreditsOnlyStateMachine) IsAfterInvoiceAt() bool {
 	return !clock.Now().Before(s.Charge.Intent.InvoiceAt)
 }
 
-func (s *CreditsOnlyStateMachine) SetAdvanceAfterInvoiceAt(ctx context.Context) error {
+func (s *CreditsOnlyStateMachine) AdvanceAfterInvoiceAt(ctx context.Context) error {
 	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.InvoiceAt))
-	return nil
-}
-
-func (s *CreditsOnlyStateMachine) ClearAdvanceAfter(ctx context.Context) error {
-	s.Charge.State.AdvanceAfter = nil
 	return nil
 }
 

--- a/openmeter/billing/charges/flatfee/service/invoice.go
+++ b/openmeter/billing/charges/flatfee/service/invoice.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/samber/lo"
+
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
@@ -11,7 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
 
-func (s *service) PostLineAssignedToInvoice(ctx context.Context, charge flatfee.Charge, line billing.StandardLine) (creditrealization.Realizations, error) {
+func (s *service) postLineAssignedToInvoice(ctx context.Context, charge flatfee.Charge, line billing.StandardLine) (creditrealization.Realizations, error) {
 	if charge.State.AmountAfterProration.IsZero() {
 		return nil, nil
 	}
@@ -40,6 +42,10 @@ func (s *service) PostLineAssignedToInvoice(ctx context.Context, charge flatfee.
 			return nil, nil
 		}
 
+		for idx := range creditAllocations {
+			creditAllocations[idx].LineID = lo.ToPtr(line.ID)
+		}
+
 		// TODO: If we want we can bulk insert these into the database for better performance (for now it's fine)
 		realizations, err := s.realizations.CreateCreditAllocations(ctx, charge, creditAllocations.AsCreateInputs())
 		if err != nil {
@@ -50,54 +56,52 @@ func (s *service) PostLineAssignedToInvoice(ctx context.Context, charge flatfee.
 	})
 }
 
-func (s *service) PostInvoiceIssued(ctx context.Context, charge flatfee.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
-	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
-		if charge.Realizations.CurrentRun == nil {
-			return fmt.Errorf("current run is required")
-		}
+func (s *service) accrueInvoiceUsage(ctx context.Context, charge flatfee.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) (*invoicedusage.AccruedUsage, error) {
+	if charge.Realizations.CurrentRun == nil {
+		return nil, fmt.Errorf("current run is required")
+	}
 
-		if charge.Realizations.CurrentRun.AccruedUsage != nil {
-			// Lifecycle violation: this should not happen as we should not be able to issue an invoice if the charge already has an accrued usage.
-			return fmt.Errorf("accrued invoice usage already exists for charge %s", charge.GetChargeID())
-		}
+	if charge.Realizations.CurrentRun.AccruedUsage != nil {
+		// Lifecycle violation: this should not happen as we should not be able to issue an invoice if the charge already has an accrued usage.
+		return nil, fmt.Errorf("accrued invoice usage already exists for charge %s", charge.GetChargeID())
+	}
 
-		if lineWithHeader.Line == nil {
-			return fmt.Errorf("postInvoiceIssued: line is nil")
-		}
+	if lineWithHeader.Line == nil {
+		return nil, fmt.Errorf("postInvoiceIssued: line is nil")
+	}
 
-		if err := s.persistDetailedLines(ctx, charge, *lineWithHeader.Line); err != nil {
-			return fmt.Errorf("persisting detailed lines: %w", err)
-		}
+	if err := s.persistDetailedLines(ctx, charge, *lineWithHeader.Line); err != nil {
+		return nil, fmt.Errorf("persisting detailed lines: %w", err)
+	}
 
-		if lineWithHeader.Line.Totals.Total.IsZero() {
-			return nil
-		}
+	if lineWithHeader.Line.Totals.Total.IsZero() {
+		return nil, nil
+	}
 
-		ledgerTransactionRef, err := s.handler.OnInvoiceUsageAccrued(ctx, flatfee.OnInvoiceUsageAccruedInput{
-			Charge:        charge,
-			ServicePeriod: lineWithHeader.Line.Period,
-			Totals:        lineWithHeader.Line.Totals,
-		})
-		if err != nil {
-			return fmt.Errorf("on flat fee standard invoice usage accrued: %w", err)
-		}
-
-		accruedUsage := invoicedusage.AccruedUsage{
-			ServicePeriod:     lineWithHeader.Line.Period,
-			Totals:            lineWithHeader.Line.Totals,
-			LedgerTransaction: &ledgerTransactionRef,
-		}
-
-		_, err = s.adapter.CreateInvoicedUsage(ctx, flatfee.CreateInvoicedUsageInput{
-			ChargeID:      charge.GetChargeID(),
-			LineID:        lineWithHeader.Line.ID,
-			InvoiceID:     lineWithHeader.Invoice.ID,
-			InvoicedUsage: accruedUsage,
-		})
-		if err != nil {
-			return fmt.Errorf("creating standard invoice accrued usage: %w", err)
-		}
-
-		return nil
+	ledgerTransactionRef, err := s.handler.OnInvoiceUsageAccrued(ctx, flatfee.OnInvoiceUsageAccruedInput{
+		Charge:        charge,
+		ServicePeriod: lineWithHeader.Line.Period,
+		Totals:        lineWithHeader.Line.Totals,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("on flat fee standard invoice usage accrued: %w", err)
+	}
+
+	accruedUsage := invoicedusage.AccruedUsage{
+		ServicePeriod:     lineWithHeader.Line.Period,
+		Totals:            lineWithHeader.Line.Totals,
+		LedgerTransaction: &ledgerTransactionRef,
+	}
+
+	accruedUsage, err = s.adapter.CreateInvoicedUsage(ctx, flatfee.CreateInvoicedUsageInput{
+		ChargeID:      charge.GetChargeID(),
+		LineID:        lineWithHeader.Line.ID,
+		InvoiceID:     lineWithHeader.Invoice.ID,
+		InvoicedUsage: accruedUsage,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating standard invoice accrued usage: %w", err)
+	}
+
+	return &accruedUsage, nil
 }

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -167,32 +167,42 @@ func (e *LineEngine) OnMutableStandardLinesDeleted(ctx context.Context, input bi
 			continue
 		}
 
-		if charge.Realizations.CurrentRun != nil && charge.Realizations.CurrentRun.AccruedUsage != nil {
-			return fmt.Errorf("flat fee standard line[%s] cannot be deleted because charge[%s] has invoice accrued allocation", stdLine.ID, charge.ID)
-		}
-
-		if charge.Realizations.CurrentRun != nil && charge.Realizations.CurrentRun.Payment != nil {
-			return fmt.Errorf("flat fee standard line[%s] cannot be deleted because charge[%s] has payment allocation", stdLine.ID, charge.ID)
-		}
-
-		currencyCalculator, err := charge.Intent.Currency.Calculator()
-		if err != nil {
-			return fmt.Errorf("getting currency calculator for charge[%s]: %w", charge.ID, err)
-		}
-
-		if _, err := e.service.realizations.CorrectAllCredits(ctx, flatfeerealizations.CorrectAllCreditRealizationsInput{
-			Charge:             charge,
-			AllocateAt:         clock.Now(),
-			CurrencyCalculator: currencyCalculator,
-		}); err != nil {
-			return fmt.Errorf("correcting credits for deleted flat fee standard line[%s] charge[%s]: %w", stdLine.ID, charge.ID, err)
-		}
-
-		if err := e.service.adapter.UpsertDetailedLines(ctx, charge.GetChargeID(), nil); err != nil {
-			return fmt.Errorf("deleting detailed lines for deleted flat fee standard line[%s] charge[%s]: %w", stdLine.ID, charge.ID, err)
+		// Guards and cleanup are per charge, not per line; cleanedChargeIDs dedupes repeated lines.
+		if err := e.cleanChargeForDeletedMutableStandardLine(ctx, *stdLine, charge); err != nil {
+			return err
 		}
 
 		cleanedChargeIDs[charge.ID] = struct{}{}
+	}
+
+	return nil
+}
+
+func (e *LineEngine) cleanChargeForDeletedMutableStandardLine(ctx context.Context, stdLine billing.StandardLine, charge flatfee.Charge) error {
+	if charge.Realizations.CurrentRun != nil && charge.Realizations.CurrentRun.AccruedUsage != nil {
+		return fmt.Errorf("flat fee standard line[%s] cannot be deleted because charge[%s] has invoice accrued allocation", stdLine.ID, charge.ID)
+	}
+
+	if charge.Realizations.CurrentRun != nil && charge.Realizations.CurrentRun.Payment != nil {
+		return fmt.Errorf("flat fee standard line[%s] cannot be deleted because charge[%s] has payment allocation", stdLine.ID, charge.ID)
+	}
+
+	currencyCalculator, err := charge.Intent.Currency.Calculator()
+	if err != nil {
+		return fmt.Errorf("getting currency calculator for charge[%s]: %w", charge.ID, err)
+	}
+
+	if _, err := e.service.realizations.CorrectAllCredits(ctx, flatfeerealizations.CorrectAllCreditRealizationsInput{
+		Charge:             charge,
+		AllocateAt:         clock.Now(),
+		CurrencyCalculator: currencyCalculator,
+	}); err != nil {
+		return fmt.Errorf("correcting credits for deleted flat fee standard line[%s] charge[%s]: %w", stdLine.ID, charge.ID, err)
+	}
+
+	// Passing nil deletes all charge-owned detailed lines for the current run.
+	if err := e.service.adapter.UpsertDetailedLines(ctx, charge.GetChargeID(), nil); err != nil {
+		return fmt.Errorf("deleting detailed lines for deleted flat fee standard line[%s] charge[%s]: %w", stdLine.ID, charge.ID, err)
 	}
 
 	return nil
@@ -244,7 +254,7 @@ func (e *LineEngine) newStateMachineForStandardLine(ctx context.Context, stdLine
 
 	creditThenInvoiceStateMachine, ok := stateMachine.(*CreditThenInvoiceStateMachine)
 	if !ok {
-		return nil, fmt.Errorf("flat fee charge[%s]: expected credit_then_invoice state machine, got %T", charge.ID, stateMachine)
+		return nil, fmt.Errorf("BUG: flat fee charge[%s]: expected credit_then_invoice state machine, got %T", charge.ID, stateMachine)
 	}
 
 	return creditThenInvoiceStateMachine, nil

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/samber/lo"
+
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	flatfeerealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
@@ -62,33 +67,28 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 
 	chargesByID := make(map[string]flatfee.Charge, len(input.Lines))
 	for _, stdLine := range input.Lines {
-		chargeID := stdLine.ChargeID
-		if chargeID == nil {
-			return nil, fmt.Errorf("flat fee standard line[%s]: charge id is required", stdLine.ID)
+		stateMachine, err := e.newStateMachineForStandardLine(ctx, stdLine)
+		if err != nil {
+			return nil, err
 		}
 
-		charge, err := e.service.GetByID(ctx, flatfee.GetByIDInput{
-			ChargeID: meta.ChargeID{
-				Namespace: stdLine.Namespace,
-				ID:        *chargeID,
-			},
-			Expands: meta.Expands{
-				meta.ExpandRealizations,
-			},
-		})
-		if err != nil {
-			return nil, fmt.Errorf("getting flat fee charge for line[%s]: %w", stdLine.ID, err)
+		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
+			return nil, fmt.Errorf("advancing flat fee charge[%s]: %w", stateMachine.GetCharge().ID, err)
 		}
+
+		if err := stateMachine.FireAndActivate(ctx, meta.TriggerFinalInvoiceCreated, billing.StandardLineWithInvoiceHeader{
+			Line:    stdLine,
+			Invoice: input.Invoice,
+		}); err != nil {
+			return nil, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerFinalInvoiceCreated, stateMachine.GetCharge().ID, err)
+		}
+
+		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
+			return nil, fmt.Errorf("advancing flat fee charge[%s] after %s: %w", stateMachine.GetCharge().ID, meta.TriggerFinalInvoiceCreated, err)
+		}
+
+		charge := stateMachine.GetCharge()
 		chargesByID[charge.ID] = charge
-
-		realizations, err := e.service.PostLineAssignedToInvoice(ctx, charge, *stdLine)
-		if err != nil {
-			return nil, fmt.Errorf("allocating credits for line[%s]: %w", stdLine.ID, err)
-		}
-
-		if len(realizations) > 0 {
-			stdLine.CreditsApplied = convertCreditRealizations(realizations)
-		}
 	}
 
 	lines, err := e.CalculateLines(billing.CalculateLinesInput(input))
@@ -114,11 +114,87 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 	return lines, nil
 }
 
-func (e *LineEngine) OnCollectionCompleted(_ context.Context, input billing.OnCollectionCompletedInput) (billing.StandardLines, error) {
+func (e *LineEngine) OnCollectionCompleted(ctx context.Context, input billing.OnCollectionCompletedInput) (billing.StandardLines, error) {
+	if err := input.Validate(); err != nil {
+		return nil, fmt.Errorf("validating input: %w", err)
+	}
+
+	for _, stdLine := range input.Lines {
+		stateMachine, err := e.newStateMachineForStandardLine(ctx, stdLine)
+		if err != nil {
+			return nil, err
+		}
+
+		canFire, err := stateMachine.CanFire(ctx, meta.TriggerCollectionCompleted)
+		if err != nil {
+			return nil, fmt.Errorf("checking collection_completed for charge[%s]: %w", stateMachine.GetCharge().ID, err)
+		}
+
+		if !canFire {
+			continue
+		}
+
+		if err := stateMachine.FireAndActivate(ctx, meta.TriggerCollectionCompleted); err != nil {
+			return nil, fmt.Errorf("triggering collection_completed for charge[%s]: %w", stateMachine.GetCharge().ID, err)
+		}
+
+		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
+			return nil, fmt.Errorf("advancing flat fee charge[%s] after collection_completed: %w", stateMachine.GetCharge().ID, err)
+		}
+	}
+
 	return input.Lines, nil
 }
 
-func (e *LineEngine) OnMutableStandardLinesDeleted(_ context.Context, _ billing.OnMutableStandardLinesDeletedInput) error {
+func (e *LineEngine) OnMutableStandardLinesDeleted(ctx context.Context, input billing.OnMutableStandardLinesDeletedInput) error {
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("validating input: %w", err)
+	}
+
+	chargesByID, err := e.getChargesForMutableStandardLineDelete(ctx, input)
+	if err != nil {
+		return err
+	}
+
+	cleanedChargeIDs := make(map[string]struct{}, len(chargesByID))
+	for _, stdLine := range input.Lines {
+		charge, ok := chargesByID[*stdLine.ChargeID]
+		if !ok {
+			return fmt.Errorf("flat fee charge[%s] not found for deleted standard line[%s]", *stdLine.ChargeID, stdLine.ID)
+		}
+
+		if _, ok := cleanedChargeIDs[charge.ID]; ok {
+			continue
+		}
+
+		if charge.Realizations.CurrentRun != nil && charge.Realizations.CurrentRun.AccruedUsage != nil {
+			return fmt.Errorf("flat fee standard line[%s] cannot be deleted because charge[%s] has invoice accrued allocation", stdLine.ID, charge.ID)
+		}
+
+		if charge.Realizations.CurrentRun != nil && charge.Realizations.CurrentRun.Payment != nil {
+			return fmt.Errorf("flat fee standard line[%s] cannot be deleted because charge[%s] has payment allocation", stdLine.ID, charge.ID)
+		}
+
+		currencyCalculator, err := charge.Intent.Currency.Calculator()
+		if err != nil {
+			return fmt.Errorf("getting currency calculator for charge[%s]: %w", charge.ID, err)
+		}
+
+		if _, err := e.service.realizations.CorrectAllCredits(ctx, flatfeerealizations.CorrectAllCreditRealizationsInput{
+			Charge:             charge,
+			AllocateAt:         clock.Now(),
+			CurrencyCalculator: currencyCalculator,
+		}); err != nil {
+			return fmt.Errorf("correcting credits for deleted flat fee standard line[%s] charge[%s]: %w", stdLine.ID, charge.ID, err)
+		}
+
+		if err := e.service.adapter.UpsertDetailedLines(ctx, charge.GetChargeID(), nil); err != nil {
+			return fmt.Errorf("deleting detailed lines for deleted flat fee standard line[%s] charge[%s]: %w", stdLine.ID, charge.ID, err)
+		}
+
+		cleanedChargeIDs[charge.ID] = struct{}{}
+	}
+
 	return nil
 }
 
@@ -126,15 +202,176 @@ func (e *LineEngine) OnUnsupportedCreditNote(_ context.Context, _ billing.OnUnsu
 	return nil
 }
 
-func (e *LineEngine) OnInvoiceIssued(_ context.Context, _ billing.OnInvoiceIssuedInput) error {
+func (e *LineEngine) newStateMachineForStandardLine(ctx context.Context, stdLine *billing.StandardLine) (*CreditThenInvoiceStateMachine, error) {
+	if stdLine == nil {
+		return nil, fmt.Errorf("flat fee standard line is nil")
+	}
+
+	if stdLine.ChargeID == nil || *stdLine.ChargeID == "" {
+		return nil, fmt.Errorf("flat fee standard line[%s]: charge id is required", stdLine.ID)
+	}
+
+	charge, err := e.service.GetByID(ctx, flatfee.GetByIDInput{
+		ChargeID: meta.ChargeID{
+			Namespace: stdLine.Namespace,
+			ID:        *stdLine.ChargeID,
+		},
+		Expands: meta.Expands{
+			meta.ExpandRealizations,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getting flat fee charge for line[%s]: %w", stdLine.ID, err)
+	}
+
+	if charge.Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+		return nil, fmt.Errorf(
+			"flat fee standard line[%s]: unsupported settlement mode for standard invoice lifecycle: %s",
+			stdLine.ID,
+			charge.Intent.SettlementMode,
+		)
+	}
+
+	stateMachine, err := e.service.newStateMachine(StateMachineConfig{
+		Charge:       charge,
+		Adapter:      e.service.adapter,
+		Realizations: e.service.realizations,
+		Service:      e.service,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("new state machine for flat fee charge[%s]: %w", charge.ID, err)
+	}
+
+	creditThenInvoiceStateMachine, ok := stateMachine.(*CreditThenInvoiceStateMachine)
+	if !ok {
+		return nil, fmt.Errorf("flat fee charge[%s]: expected credit_then_invoice state machine, got %T", charge.ID, stateMachine)
+	}
+
+	return creditThenInvoiceStateMachine, nil
+}
+
+func (e *LineEngine) getChargesForMutableStandardLineDelete(ctx context.Context, input billing.OnMutableStandardLinesDeletedInput) (map[string]flatfee.Charge, error) {
+	chargeIDs := make([]string, 0, len(input.Lines))
+	seenChargeIDs := make(map[string]struct{}, len(input.Lines))
+
+	for _, stdLine := range input.Lines {
+		if stdLine.ChargeID == nil || *stdLine.ChargeID == "" {
+			return nil, fmt.Errorf("flat fee standard line[%s]: charge id is required", stdLine.ID)
+		}
+
+		if stdLine.Namespace != input.Invoice.Namespace {
+			return nil, fmt.Errorf("flat fee standard line[%s]: namespace %s does not match invoice namespace %s", stdLine.ID, stdLine.Namespace, input.Invoice.Namespace)
+		}
+
+		if _, ok := seenChargeIDs[*stdLine.ChargeID]; ok {
+			continue
+		}
+
+		seenChargeIDs[*stdLine.ChargeID] = struct{}{}
+		chargeIDs = append(chargeIDs, *stdLine.ChargeID)
+	}
+
+	charges, err := e.service.GetByIDs(ctx, flatfee.GetByIDsInput{
+		Namespace: input.Invoice.Namespace,
+		IDs:       chargeIDs,
+		Expands: meta.Expands{
+			meta.ExpandRealizations,
+			meta.ExpandDetailedLines,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getting flat fee charges for deleted standard lines: %w", err)
+	}
+
+	return lo.KeyBy(charges, func(charge flatfee.Charge) string {
+		return charge.ID
+	}), nil
+}
+
+func (e *LineEngine) OnInvoiceIssued(ctx context.Context, input billing.OnInvoiceIssuedInput) error {
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("validating input: %w", err)
+	}
+
+	for _, stdLine := range input.Lines {
+		stateMachine, err := e.newStateMachineForStandardLine(ctx, stdLine)
+		if err != nil {
+			return err
+		}
+
+		if err := stateMachine.FireAndActivate(ctx, meta.TriggerInvoiceIssued, billing.StandardLineWithInvoiceHeader{
+			Line:    stdLine,
+			Invoice: input.Invoice,
+		}); err != nil {
+			return fmt.Errorf("triggering invoice_issued for charge[%s]: %w", stateMachine.GetCharge().ID, err)
+		}
+
+		if _, err := stateMachine.AdvanceUntilStateStable(ctx); err != nil {
+			return fmt.Errorf("advancing flat fee charge[%s] after invoice_issued: %w", stateMachine.GetCharge().ID, err)
+		}
+	}
+
 	return nil
 }
 
-func (e *LineEngine) OnPaymentAuthorized(_ context.Context, _ billing.OnPaymentAuthorizedInput) error {
+func (e *LineEngine) OnPaymentAuthorized(ctx context.Context, input billing.OnPaymentAuthorizedInput) error {
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("validating input: %w", err)
+	}
+
+	for _, stdLine := range input.Lines {
+		stateMachine, err := e.newStateMachineForStandardLine(ctx, stdLine)
+		if err != nil {
+			return err
+		}
+
+		if err := e.service.postInvoicePaymentAuthorized(ctx, stateMachine.GetCharge(), billing.StandardLineWithInvoiceHeader{
+			Line:    stdLine,
+			Invoice: input.Invoice,
+		}); err != nil {
+			return fmt.Errorf("authorizing invoice payment for charge[%s]: %w", stateMachine.GetCharge().ID, err)
+		}
+	}
+
 	return nil
 }
 
-func (e *LineEngine) OnPaymentSettled(_ context.Context, _ billing.OnPaymentSettledInput) error {
+func (e *LineEngine) OnPaymentSettled(ctx context.Context, input billing.OnPaymentSettledInput) error {
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("validating input: %w", err)
+	}
+
+	for _, stdLine := range input.Lines {
+		stateMachine, err := e.newStateMachineForStandardLine(ctx, stdLine)
+		if err != nil {
+			return err
+		}
+
+		if err := e.service.postInvoicePaymentSettled(ctx, stateMachine.GetCharge(), billing.StandardLineWithInvoiceHeader{
+			Line:    stdLine,
+			Invoice: input.Invoice,
+		}); err != nil {
+			return fmt.Errorf("settling invoice payment for charge[%s]: %w", stateMachine.GetCharge().ID, err)
+		}
+
+		if err := stateMachine.RefetchCharge(ctx); err != nil {
+			return fmt.Errorf("refetching flat fee charge[%s]: %w", stateMachine.GetCharge().ID, err)
+		}
+
+		canFire, err := stateMachine.CanFire(ctx, meta.TriggerAllPaymentsSettled)
+		if err != nil {
+			return fmt.Errorf("checking all_payments_settled for charge[%s]: %w", stateMachine.GetCharge().ID, err)
+		}
+
+		if !canFire {
+			continue
+		}
+
+		if err := stateMachine.FireAndActivate(ctx, meta.TriggerAllPaymentsSettled); err != nil {
+			return fmt.Errorf("triggering all_payments_settled for charge[%s]: %w", stateMachine.GetCharge().ID, err)
+		}
+	}
+
 	return nil
 }
 

--- a/openmeter/billing/charges/flatfee/service/payment.go
+++ b/openmeter/billing/charges/flatfee/service/payment.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
 
-func (s *service) PostInvoicePaymentAuthorized(ctx context.Context, charge flatfee.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
+func (s *service) postInvoicePaymentAuthorized(ctx context.Context, charge flatfee.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
 		if charge.Realizations.CurrentRun == nil {
 			return fmt.Errorf("current run is required")
@@ -57,7 +57,7 @@ func (s *service) PostInvoicePaymentAuthorized(ctx context.Context, charge flatf
 	})
 }
 
-func (s *service) PostInvoicePaymentSettled(ctx context.Context, charge flatfee.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
+func (s *service) postInvoicePaymentSettled(ctx context.Context, charge flatfee.Charge, lineWithHeader billing.StandardLineWithInvoiceHeader) error {
 	return transaction.RunWithNoValue(ctx, s.adapter, func(ctx context.Context) error {
 		if charge.Realizations.CurrentRun == nil {
 			return fmt.Errorf("current run is required")
@@ -97,12 +97,6 @@ func (s *service) PostInvoicePaymentSettled(ctx context.Context, charge flatfee.
 		}
 
 		charge.Realizations.CurrentRun.Payment = &paymentSettlement
-		charge.Status = flatfee.StatusFinal
-
-		_, err = s.adapter.UpdateCharge(ctx, charge.ChargeBase)
-		if err != nil {
-			return err
-		}
 
 		return nil
 	})

--- a/openmeter/billing/charges/flatfee/service/statemachine.go
+++ b/openmeter/billing/charges/flatfee/service/statemachine.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/samber/lo"
+
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	flatfeerealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	chargestatemachine "github.com/openmeterio/openmeter/openmeter/billing/charges/statemachine"
+	"github.com/openmeterio/openmeter/pkg/clock"
 )
 
 type stateMachine struct {
@@ -16,6 +19,7 @@ type stateMachine struct {
 
 	Adapter      flatfee.Adapter
 	Realizations *flatfeerealizations.Service
+	Service      *service
 }
 
 type StateMachine = chargestatemachine.StateMachine[flatfee.Charge]
@@ -25,6 +29,7 @@ type StateMachineConfig struct {
 
 	Adapter      flatfee.Adapter
 	Realizations *flatfeerealizations.Service
+	Service      *service
 }
 
 func (c StateMachineConfig) Validate() error {
@@ -53,6 +58,7 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 	out := &stateMachine{
 		Adapter:      config.Adapter,
 		Realizations: config.Realizations,
+		Service:      config.Service,
 	}
 
 	machine, err := chargestatemachine.New(chargestatemachine.Config[flatfee.Charge, flatfee.ChargeBase, flatfee.Status]{
@@ -76,4 +82,23 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 	out.Machine = machine
 
 	return out, nil
+}
+
+func (s *stateMachine) IsInsideServicePeriod() bool {
+	return !clock.Now().Before(s.Charge.Intent.ServicePeriod.From)
+}
+
+func (s *stateMachine) AdvanceAfterServicePeriodFrom(ctx context.Context) error {
+	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.ServicePeriod.From))
+	return nil
+}
+
+func (s *stateMachine) AdvanceAfterServicePeriodTo(ctx context.Context) error {
+	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.ServicePeriod.To))
+	return nil
+}
+
+func (s *stateMachine) ClearAdvanceAfter(ctx context.Context) error {
+	s.Charge.State.AdvanceAfter = nil
+	return nil
 }

--- a/openmeter/billing/charges/flatfee/service/statemachine.go
+++ b/openmeter/billing/charges/flatfee/service/statemachine.go
@@ -47,6 +47,10 @@ func (c StateMachineConfig) Validate() error {
 		errs = append(errs, errors.New("realizations service is required"))
 	}
 
+	if c.Service == nil {
+		errs = append(errs, errors.New("service is required"))
+	}
+
 	return errors.Join(errs...)
 }
 

--- a/openmeter/billing/charges/flatfee/service/triggers.go
+++ b/openmeter/billing/charges/flatfee/service/triggers.go
@@ -22,6 +22,7 @@ func (s *service) AdvanceCharge(ctx context.Context, input flatfee.AdvanceCharge
 			Charge:       charge,
 			Adapter:      s.adapter,
 			Realizations: s.realizations,
+			Service:      s,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("new state machine: %w", err)
@@ -47,6 +48,7 @@ func (s *service) TriggerPatch(ctx context.Context, chargeID meta.ChargeID, patc
 			Charge:       charge,
 			Adapter:      s.adapter,
 			Realizations: s.realizations,
+			Service:      s,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("new state machine: %w", err)
@@ -75,6 +77,13 @@ func (s *service) newStateMachine(config StateMachineConfig) (StateMachine, erro
 	switch config.Charge.Intent.SettlementMode {
 	case productcatalog.CreditOnlySettlementMode:
 		stateMachine, err := NewCreditsOnlyStateMachine(config)
+		if err != nil {
+			return nil, err
+		}
+
+		return stateMachine, nil
+	case productcatalog.CreditThenInvoiceSettlementMode:
+		stateMachine, err := NewCreditThenInvoiceStateMachine(config)
 		if err != nil {
 			return nil, err
 		}
@@ -112,10 +121,6 @@ func (s *service) withLockedCharge(ctx context.Context, chargeID meta.ChargeID, 
 		}
 
 		charge := fetchedCharges[0]
-
-		if charge.Intent.SettlementMode != productcatalog.CreditOnlySettlementMode {
-			return nil, fmt.Errorf("charge %s is not credit_only (settlement_mode=%s)", charge.ID, charge.Intent.SettlementMode)
-		}
 
 		return fn(ctx, charge)
 	})

--- a/openmeter/billing/charges/flatfee/service/triggers.go
+++ b/openmeter/billing/charges/flatfee/service/triggers.go
@@ -18,6 +18,10 @@ func (s *service) AdvanceCharge(ctx context.Context, input flatfee.AdvanceCharge
 	}
 
 	return s.withLockedCharge(ctx, input.ChargeID, func(ctx context.Context, charge flatfee.Charge) (*flatfee.Charge, error) {
+		if charge.Intent.SettlementMode == productcatalog.InvoiceOnlySettlementMode {
+			return nil, nil
+		}
+
 		stateMachine, err := s.newStateMachine(StateMachineConfig{
 			Charge:       charge,
 			Adapter:      s.adapter,

--- a/openmeter/billing/charges/flatfee/statemachine.go
+++ b/openmeter/billing/charges/flatfee/statemachine.go
@@ -15,12 +15,12 @@ const (
 	StatusCreated Status = Status(meta.ChargeStatusCreated)
 	StatusActive  Status = Status(meta.ChargeStatusActive)
 
-	StatusRealizationStarted              Status = "active.realization.started"
-	StatusRealizationWaitingForCollection Status = "active.realization.waiting_for_collection"
-	StatusRealizationProcessing           Status = "active.realization.processing"
-	StatusRealizationIssuing              Status = "active.realization.issuing"
-	StatusRealizationCompleted            Status = "active.realization.completed"
-	StatusAwaitingPaymentSettlement       Status = "active.awaiting_payment_settlement"
+	StatusActiveRealizationStarted              Status = "active.realization.started"
+	StatusActiveRealizationWaitingForCollection Status = "active.realization.waiting_for_collection"
+	StatusActiveRealizationProcessing           Status = "active.realization.processing"
+	StatusActiveRealizationIssuing              Status = "active.realization.issuing"
+	StatusActiveRealizationCompleted            Status = "active.realization.completed"
+	StatusActiveAwaitingPaymentSettlement       Status = "active.awaiting_payment_settlement"
 
 	StatusFinal   Status = Status(meta.ChargeStatusFinal)
 	StatusDeleted Status = Status(meta.ChargeStatusDeleted)
@@ -30,12 +30,12 @@ func (Status) Values() []string {
 	return []string{
 		string(StatusCreated),
 		string(StatusActive),
-		string(StatusRealizationStarted),
-		string(StatusRealizationWaitingForCollection),
-		string(StatusRealizationProcessing),
-		string(StatusRealizationIssuing),
-		string(StatusRealizationCompleted),
-		string(StatusAwaitingPaymentSettlement),
+		string(StatusActiveRealizationStarted),
+		string(StatusActiveRealizationWaitingForCollection),
+		string(StatusActiveRealizationProcessing),
+		string(StatusActiveRealizationIssuing),
+		string(StatusActiveRealizationCompleted),
+		string(StatusActiveAwaitingPaymentSettlement),
 		string(StatusFinal),
 		string(StatusDeleted),
 	}

--- a/openmeter/billing/charges/flatfee/statemachine.go
+++ b/openmeter/billing/charges/flatfee/statemachine.go
@@ -3,6 +3,7 @@ package flatfee
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -13,6 +14,14 @@ type Status string
 const (
 	StatusCreated Status = Status(meta.ChargeStatusCreated)
 	StatusActive  Status = Status(meta.ChargeStatusActive)
+
+	StatusRealizationStarted              Status = "active.realization.started"
+	StatusRealizationWaitingForCollection Status = "active.realization.waiting_for_collection"
+	StatusRealizationProcessing           Status = "active.realization.processing"
+	StatusRealizationIssuing              Status = "active.realization.issuing"
+	StatusRealizationCompleted            Status = "active.realization.completed"
+	StatusAwaitingPaymentSettlement       Status = "active.awaiting_payment_settlement"
+
 	StatusFinal   Status = Status(meta.ChargeStatusFinal)
 	StatusDeleted Status = Status(meta.ChargeStatusDeleted)
 )
@@ -21,6 +30,12 @@ func (Status) Values() []string {
 	return []string{
 		string(StatusCreated),
 		string(StatusActive),
+		string(StatusRealizationStarted),
+		string(StatusRealizationWaitingForCollection),
+		string(StatusRealizationProcessing),
+		string(StatusRealizationIssuing),
+		string(StatusRealizationCompleted),
+		string(StatusAwaitingPaymentSettlement),
 		string(StatusFinal),
 		string(StatusDeleted),
 	}
@@ -38,5 +53,15 @@ func (s Status) ToMetaChargeStatus() (meta.ChargeStatus, error) {
 		return meta.ChargeStatusCreated, err
 	}
 
-	return meta.ChargeStatus(s), nil
+	split := strings.SplitN(string(s), ".", 2)
+	if len(split) == 0 {
+		return meta.ChargeStatusCreated, fmt.Errorf("invalid status: %s", s)
+	}
+
+	metaStatus := meta.ChargeStatus(split[0])
+	if err := metaStatus.Validate(); err != nil {
+		return meta.ChargeStatusCreated, fmt.Errorf("invalid status: %s", s)
+	}
+
+	return metaStatus, nil
 }

--- a/openmeter/billing/charges/service/advance.go
+++ b/openmeter/billing/charges/service/advance.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
@@ -47,11 +46,7 @@ func (s *service) AdvanceCharges(ctx context.Context, input charges.AdvanceCharg
 
 		advancedCharges := make(charges.Charges, 0, len(chargesByType.usageBased)+len(chargesByType.flatFees))
 
-		// Advance credit-only flat fee charges
 		for _, charge := range chargesByType.flatFees {
-			if charge.Intent.SettlementMode != productcatalog.CreditOnlySettlementMode {
-				continue
-			}
 
 			advancedCharge, err := s.flatFeeService.AdvanceCharge(ctx, flatfee.AdvanceChargeInput{
 				ChargeID: charge.GetChargeID(),

--- a/openmeter/billing/charges/service/advance.go
+++ b/openmeter/billing/charges/service/advance.go
@@ -47,7 +47,6 @@ func (s *service) AdvanceCharges(ctx context.Context, input charges.AdvanceCharg
 		advancedCharges := make(charges.Charges, 0, len(chargesByType.usageBased)+len(chargesByType.flatFees))
 
 		for _, charge := range chargesByType.flatFees {
-
 			advancedCharge, err := s.flatFeeService.AdvanceCharge(ctx, flatfee.AdvanceChargeInput{
 				ChargeID: charge.GetChargeID(),
 			})

--- a/openmeter/billing/charges/service/advance_test.go
+++ b/openmeter/billing/charges/service/advance_test.go
@@ -34,7 +34,7 @@ func (s *AdvanceChargesTestSuite) TearDownTest() {
 	s.BaseSuite.TearDownTest()
 }
 
-func (s *AdvanceChargesTestSuite) TestAdvanceChargesSkipsNonUsageBasedCharges() {
+func (s *AdvanceChargesTestSuite) TestAdvanceChargesReturnsEmptyForAlreadyActiveCreditCharges() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-advance-usage-only")
 
@@ -87,6 +87,11 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesSkipsNonUsageBasedCharges() 
 	s.NoError(err)
 	s.Len(createdCharges, 2)
 
+	// Create auto-advances credit-then-invoice flat fee charges that start now.
+	flatFeeCharge, err := createdCharges[0].AsFlatFeeCharge()
+	s.NoError(err)
+	s.Equal(meta.ChargeStatusActive, meta.ChargeStatus(flatFeeCharge.Status))
+
 	// Create auto-advances credit-only usage-based charges: the returned charge is already active.
 	usageBasedCharge, err := createdCharges[1].AsUsageBasedCharge()
 	s.NoError(err)
@@ -94,16 +99,18 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesSkipsNonUsageBasedCharges() 
 	s.NotNil(usageBasedCharge.State.AdvanceAfter)
 	s.True(servicePeriod.To.Equal(*usageBasedCharge.State.AdvanceAfter))
 
-	// AdvanceCharges is a noop: the usage-based charge is already active and not yet past the service period.
+	// AdvanceCharges is a noop: both charges are already active and not yet past the service period.
 	advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
 		Customer: cust.GetID(),
 	})
 	s.NoError(err)
 	s.Empty(advancedCharges)
 
-	// The flat fee was not touched by either create or advance.
 	fetchedFlatFee := s.mustGetChargeByID(lo.Must(createdCharges[0].GetChargeID()))
 	s.Equal(meta.ChargeTypeFlatFee, fetchedFlatFee.Type())
+	fetchedFlatFeeCharge, err := fetchedFlatFee.AsFlatFeeCharge()
+	s.NoError(err)
+	s.Equal(flatFeeCharge.Status, fetchedFlatFeeCharge.Status)
 
 	// DB state matches what Create returned.
 	fetchedUsageBased := s.mustGetChargeByID(usageBasedCharge.GetChargeID())
@@ -114,7 +121,7 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesSkipsNonUsageBasedCharges() 
 	s.True(servicePeriod.To.Equal(*usageBasedFromDB.State.AdvanceAfter))
 }
 
-func (s *AdvanceChargesTestSuite) TestAdvanceChargesReturnsEmptyWhenCustomerHasNoUsageBasedCharges() {
+func (s *AdvanceChargesTestSuite) TestAdvanceChargesSkipsInvoiceOnlyFlatFeeCharges() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-advance-empty")
 
@@ -136,7 +143,7 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesReturnsEmptyWhenCustomerHasN
 				customer:       cust.GetID(),
 				currency:       USD,
 				servicePeriod:  servicePeriod,
-				settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				settlementMode: productcatalog.InvoiceOnlySettlementMode,
 				price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
 					Amount:      alpacadecimal.NewFromFloat(100),
 					PaymentTerm: productcatalog.InAdvancePaymentTerm,

--- a/openmeter/billing/charges/service/advance_test.go
+++ b/openmeter/billing/charges/service/advance_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -35,7 +34,7 @@ func (s *AdvanceChargesTestSuite) TearDownTest() {
 }
 
 func (s *AdvanceChargesTestSuite) TestAdvanceChargesReturnsEmptyForAlreadyActiveCreditCharges() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-advance-usage-only")
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
@@ -122,7 +121,7 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesReturnsEmptyForAlreadyActive
 }
 
 func (s *AdvanceChargesTestSuite) TestAdvanceChargesSkipsInvoiceOnlyFlatFeeCharges() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-advance-empty")
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
@@ -164,7 +163,7 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesSkipsInvoiceOnlyFlatFeeCharg
 }
 
 func (s *AdvanceChargesTestSuite) TestAdvanceChargesActivatesCreditThenInvoiceUsageBasedChargesAtServicePeriodStart() {
-	ctx := context.Background()
+	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-advance-credit-then-invoice")
 
 	cust := s.CreateTestCustomer(ns, "test-subject")

--- a/openmeter/billing/charges/service/create.go
+++ b/openmeter/billing/charges/service/create.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/samber/mo"
@@ -198,7 +199,7 @@ func (s *service) Create(ctx context.Context, input charges.CreateInput) (charge
 }
 
 // autoAdvanceCreatedCharges post-processes newly created charges
-// it handles credit-only usage-based and flat fee charges
+// it handles credit-only usage-based and flat fee charges whose next advancement is already due.
 // a separate transaction is used to make sure that we persist the creation state even if the advancing fails (as
 // a worker will try to advance the charges again).
 func (s *service) autoAdvanceCreatedCharges(ctx context.Context, created charges.Charges) (charges.Charges, error) {
@@ -216,6 +217,10 @@ func (s *service) autoAdvanceCreatedCharges(ctx context.Context, created charges
 				continue
 			}
 
+			if !isAdvanceDue(ub.State.AdvanceAfter) {
+				continue
+			}
+
 			customerIDs[customer.CustomerID{Namespace: ub.Namespace, ID: ub.Intent.CustomerID}] = struct{}{}
 
 		case meta.ChargeTypeFlatFee:
@@ -225,6 +230,10 @@ func (s *service) autoAdvanceCreatedCharges(ctx context.Context, created charges
 			}
 
 			if ff.Intent.SettlementMode != productcatalog.CreditOnlySettlementMode {
+				continue
+			}
+
+			if !isAdvanceDue(ff.State.AdvanceAfter) {
 				continue
 			}
 
@@ -273,6 +282,10 @@ func (s *service) autoAdvanceCreatedCharges(ctx context.Context, created charges
 	}
 
 	return out, nil
+}
+
+func isAdvanceDue(advanceAfter *time.Time) bool {
+	return advanceAfter == nil || !clock.Now().Before(*advanceAfter)
 }
 
 type currencyAndCustomerID struct {

--- a/openmeter/billing/charges/service/handlers_test.go
+++ b/openmeter/billing/charges/service/handlers_test.go
@@ -214,6 +214,18 @@ func newCountedLedgerTransactionCallback[T any]() *countedLedgerTransactionCallb
 	}
 }
 
+type countedCreditAllocationCallback[T any] struct {
+	nrInvocations int
+	id            string
+}
+
+func newCountedCreditAllocationCallback[T any]() *countedCreditAllocationCallback[T] {
+	return &countedCreditAllocationCallback[T]{
+		nrInvocations: 0,
+		id:            ulid.Make().String(),
+	}
+}
+
 func newCappedCreditAllocator(availableCredits float64) (func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error), *alpacadecimal.Decimal) {
 	remainingCredits := alpacadecimal.NewFromFloat(availableCredits)
 
@@ -250,5 +262,18 @@ func (c *countedLedgerTransactionCallback[T]) Handler(t *testing.T, asserts ...a
 		return ledgertransaction.GroupReference{
 			TransactionGroupID: c.id,
 		}, nil
+	}
+}
+
+func (c *countedCreditAllocationCallback[T]) Handler(t *testing.T, allocations func(T, ledgertransaction.GroupReference) creditrealization.CreateAllocationInputs, asserts ...assertFunc[T]) func(ctx context.Context, t T) (creditrealization.CreateAllocationInputs, error) {
+	return func(ctx context.Context, arg T) (creditrealization.CreateAllocationInputs, error) {
+		c.nrInvocations++
+		for _, assert := range asserts {
+			assert(t, arg)
+		}
+
+		return allocations(arg, ledgertransaction.GroupReference{
+			TransactionGroupID: c.id,
+		}), nil
 	}
 }

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -236,7 +236,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 			assert.NotNil(t, charge.Realizations.CurrentRun)
 			assert.NotNil(t, charge.Realizations.CurrentRun.AccruedUsage)
 			assert.Nil(t, charge.Realizations.CurrentRun.Payment)
-			assert.Equal(t, flatfee.StatusActive, charge.Status)
+			assert.Equal(t, flatfee.StatusActiveAwaitingPaymentSettlement, charge.Status)
 		})
 
 		invoiceUsageAccruedCallback := newCountedLedgerTransactionCallback[flatfee.OnInvoiceUsageAccruedInput]()
@@ -269,7 +269,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 
 		// Payment authorization should not be persisted until the payment flow advances past pending.
 		s.Nil(updatedFlatFeeCharge.Realizations.CurrentRun.Payment)
-		s.Equal(flatfee.StatusActive, updatedFlatFeeCharge.Status)
+		s.Equal(flatfee.StatusActiveAwaitingPaymentSettlement, updatedFlatFeeCharge.Status)
 	})
 
 	s.Run("trigger paid authorizes then settles payment", func() {
@@ -282,7 +282,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 			assert.NotNil(t, charge.Realizations.CurrentRun)
 			assert.Nil(t, charge.Realizations.CurrentRun.Payment)
 			assert.NotNil(t, charge.Realizations.CurrentRun.AccruedUsage)
-			assert.Equal(t, flatfee.StatusActive, charge.Status)
+			assert.Equal(t, flatfee.StatusActiveAwaitingPaymentSettlement, charge.Status)
 		})
 
 		settledCallback := newCountedLedgerTransactionCallback[flatfee.Charge]()
@@ -295,7 +295,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 			assert.Nil(t, charge.Realizations.CurrentRun.Payment.Settled)
 			assert.Equal(t, authorizedCallback.id, charge.Realizations.CurrentRun.Payment.Authorized.TransactionGroupID)
 			assert.Equal(t, payment.StatusAuthorized, charge.Realizations.CurrentRun.Payment.Status)
-			assert.Equal(t, flatfee.StatusActive, charge.Status)
+			assert.Equal(t, flatfee.StatusActiveAwaitingPaymentSettlement, charge.Status)
 		})
 
 		invoice, err := s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -419,13 +419,17 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 		invoiceUsageAccruedCallback := newCountedLedgerTransactionCallback[flatfee.OnInvoiceUsageAccruedInput]()
 		s.FlatFeeTestHandler.onInvoiceUsageAccrued = invoiceUsageAccruedCallback.Handler(s.T())
 
-		charge := s.mustGetChargeByID(flatFeeChargeID)
-		flatFeeCharge, err := charge.AsFlatFeeCharge()
-		s.NoError(err)
-
-		err = s.Charges.flatFeeService.PostInvoiceIssued(ctx, flatFeeCharge, billing.StandardLineWithInvoiceHeader{
-			Line:    invoice.Lines.OrEmpty()[0],
+		lineEngine := s.Charges.flatFeeService.GetLineEngine()
+		lines, err := lineEngine.OnCollectionCompleted(ctx, billing.OnCollectionCompletedInput{
 			Invoice: invoice,
+			Lines:   invoice.Lines.OrEmpty(),
+		})
+		s.NoError(err)
+		invoice.Lines = billing.NewStandardInvoiceLines(lines)
+
+		err = lineEngine.OnInvoiceIssued(ctx, billing.OnInvoiceIssuedInput{
+			Invoice: invoice,
+			Lines:   invoice.Lines.OrEmpty(),
 		})
 		s.NoError(err)
 		s.Equal(0, invoiceUsageAccruedCallback.nrInvocations)
@@ -1923,7 +1927,8 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 
 		s.Equal(flatfee.StatusCreated, fetchedFF.Status)
 		s.Nil(fetchedFF.Realizations.CurrentRun)
-		s.Nil(fetchedFF.State.AdvanceAfter)
+		s.NotNil(fetchedFF.State.AdvanceAfter)
+		s.True(servicePeriod.From.Equal(*fetchedFF.State.AdvanceAfter))
 
 		// Advancing is a noop (clock is before InvoiceAt).
 		advancedCharges := s.mustAdvanceFlatFeeCharges(ctx, cust.GetID())
@@ -2084,6 +2089,96 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyCreateImmediatelyFinal
 	s.Require().NotNil(dbFF.Realizations.CurrentRun)
 	s.Len(dbFF.Realizations.CurrentRun.CreditRealizations, 1)
 	s.Equal(float64(50), dbFF.Realizations.CurrentRun.CreditRealizations[0].Amount.InexactFloat64())
+}
+
+func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyInArrearsActivatesAtServiceStartAndAllocatesAtInvoiceAt() {
+	defer s.FlatFeeTestHandler.Reset()
+
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-only-in-arrears")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	s.NotEmpty(cust.ID)
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithProgressiveBilling(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "PT1H")),
+		billingtest.WithManualApproval(),
+	)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-01T00:00:00Z", time.UTC).AsTime()
+
+	creditsOnlyUsageAccruedCallback := newCountedCreditAllocationCallback[flatfee.OnCreditsOnlyUsageAccruedInput]()
+	s.FlatFeeTestHandler.onCreditsOnlyUsageAccrued = creditsOnlyUsageAccruedCallback.Handler(s.T(), func(input flatfee.OnCreditsOnlyUsageAccruedInput, ledgerTransaction ledgertransaction.GroupReference) creditrealization.CreateAllocationInputs {
+		return creditrealization.CreateAllocationInputs{
+			{
+				ServicePeriod:     input.Charge.Intent.ServicePeriod,
+				Amount:            input.AmountToAllocate,
+				LedgerTransaction: ledgerTransaction,
+			},
+		}
+	})
+
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	res, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: []charges.ChargeIntent{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditOnlySettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromFloat(75),
+					PaymentTerm: productcatalog.InArrearsPaymentTerm,
+				}),
+				name:              "flat-fee-credit-only-in-arrears",
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: "flat-fee-credit-only-in-arrears",
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Len(res, 1)
+
+	createdCharge, err := res[0].AsFlatFeeCharge()
+	s.NoError(err)
+	s.Equal(flatfee.StatusCreated, createdCharge.Status)
+	s.NotNil(createdCharge.State.AdvanceAfter)
+	s.True(servicePeriod.From.Equal(*createdCharge.State.AdvanceAfter))
+	s.Nil(createdCharge.Realizations.CurrentRun)
+	s.Zero(creditsOnlyUsageAccruedCallback.nrInvocations)
+
+	clock.FreezeTime(servicePeriod.From)
+	advancedCharges := s.mustAdvanceFlatFeeCharges(ctx, cust.GetID())
+	s.Len(advancedCharges, 1)
+	activeCharge, err := advancedCharges[0].AsFlatFeeCharge()
+	s.NoError(err)
+	s.Equal(flatfee.StatusActive, activeCharge.Status)
+	s.NotNil(activeCharge.State.AdvanceAfter)
+	s.True(servicePeriod.To.Equal(*activeCharge.State.AdvanceAfter))
+	s.Nil(activeCharge.Realizations.CurrentRun)
+	s.Zero(creditsOnlyUsageAccruedCallback.nrInvocations)
+
+	clock.FreezeTime(servicePeriod.To)
+	advancedCharges = s.mustAdvanceFlatFeeCharges(ctx, cust.GetID())
+	s.Len(advancedCharges, 1)
+	finalCharge, err := advancedCharges[0].AsFlatFeeCharge()
+	s.NoError(err)
+	s.Equal(flatfee.StatusFinal, finalCharge.Status)
+	s.Nil(finalCharge.State.AdvanceAfter)
+	s.Require().NotNil(finalCharge.Realizations.CurrentRun)
+	s.Len(finalCharge.Realizations.CurrentRun.CreditRealizations, 1)
+	s.Equal(float64(75), finalCharge.Realizations.CurrentRun.CreditRealizations[0].Amount.InexactFloat64())
+	s.Equal(1, creditsOnlyUsageAccruedCallback.nrInvocations)
 }
 
 func (s *InvoicableChargesTestSuite) mustAdvanceFlatFeeCharges(ctx context.Context, customerID customer.CustomerID) charges.Charges {

--- a/openmeter/billing/charges/service/invoice.go
+++ b/openmeter/billing/charges/service/invoice.go
@@ -48,7 +48,7 @@ func (s *service) handleStandardInvoiceUpdate(ctx context.Context, invoice billi
 
 	case billing.StandardInvoiceStatusIssued:
 		processors = &processorByType{
-			flatFee:    s.flatFeeService.PostInvoiceIssued,
+			flatFee:    noop[flatfee.Charge],
 			usageBased: noop[usagebased.Charge],
 			// Invoice credit purchase settlements are not requiring any special handling at this point
 			creditPurchase: noop[creditpurchase.Charge],
@@ -56,7 +56,7 @@ func (s *service) handleStandardInvoiceUpdate(ctx context.Context, invoice billi
 
 	case billing.StandardInvoiceStatusPaymentProcessingAuthorized:
 		processors = &processorByType{
-			flatFee:        s.flatFeeService.PostInvoicePaymentAuthorized,
+			flatFee:        noop[flatfee.Charge],
 			usageBased:     noop[usagebased.Charge],
 			creditPurchase: s.creditPurchaseService.PostInvoicePaymentAuthorized,
 		}
@@ -66,14 +66,14 @@ func (s *service) handleStandardInvoiceUpdate(ctx context.Context, invoice billi
 	// charge types.
 	case billing.StandardInvoiceStatusPaymentProcessingBookingAuthorizedAndSettled:
 		processors = &processorByType{
-			flatFee:        s.flatFeeService.PostInvoicePaymentAuthorized,
+			flatFee:        noop[flatfee.Charge],
 			usageBased:     noop[usagebased.Charge],
 			creditPurchase: s.creditPurchaseService.PostInvoicePaymentAuthorized,
 		}
 
 	case billing.StandardInvoiceStatusPaid:
 		processors = &processorByType{
-			flatFee:        s.flatFeeService.PostInvoicePaymentSettled,
+			flatFee:        noop[flatfee.Charge],
 			usageBased:     noop[usagebased.Charge],
 			creditPurchase: s.creditPurchaseService.PostInvoicePaymentSettled,
 		}

--- a/openmeter/ent/db/chargeflatfee/chargeflatfee.go
+++ b/openmeter/ent/db/chargeflatfee/chargeflatfee.go
@@ -306,7 +306,7 @@ func ProRatingValidator(pr flatfee.ProRatingModeAdapterEnum) error {
 // StatusDetailedValidator is a validator for the "status_detailed" field enum values. It is called by the builders before save.
 func StatusDetailedValidator(sd flatfee.Status) error {
 	switch sd {
-	case "created", "active", "final", "deleted":
+	case "created", "active", "active.realization.started", "active.realization.waiting_for_collection", "active.realization.processing", "active.realization.issuing", "active.realization.completed", "active.awaiting_payment_settlement", "final", "deleted":
 		return nil
 	default:
 		return fmt.Errorf("chargeflatfee: invalid enum value for status_detailed field: %q", sd)

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1950,7 +1950,7 @@ var (
 		{Name: "feature_key", Type: field.TypeString, Nullable: true},
 		{Name: "amount_before_proration", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
 		{Name: "amount_after_proration", Type: field.TypeOther, SchemaType: map[string]string{"postgres": "numeric"}},
-		{Name: "status_detailed", Type: field.TypeEnum, Enums: []string{"created", "active", "final", "deleted"}},
+		{Name: "status_detailed", Type: field.TypeEnum, Enums: []string{"created", "active", "active.realization.started", "active.realization.waiting_for_collection", "active.realization.processing", "active.realization.issuing", "active.realization.completed", "active.awaiting_payment_settlement", "final", "deleted"}},
 		{Name: "current_realization_run_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "customer_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "feature_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -1394,6 +1394,8 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoicePartialCreditPa
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(2), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()), "draft line should not accrue the fiat remainder")
 		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "draft line should not create open receivable")
 		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "draft line should not create authorized receivable")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-2), s.MustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()), "draft line should book credited portion to wash")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-2), s.MustWashBalance(ns, USD, mo.Some(&zeroCostBasis)), "draft line should book credited portion to zero-cost-basis wash")
 	})
 
 	t.Run("when the invoice is approved", func(t *testing.T) {
@@ -1434,7 +1436,8 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoicePartialCreditPa
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()), "approved invoice should accrue full line amount")
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-3), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "approved invoice should create open receivable for fiat remainder")
 		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "payment should not be authorized yet")
-		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()), "payment should not be settled yet")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-2), s.MustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()), "approval should not settle the fiat remainder")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-2), s.MustWashBalance(ns, USD, mo.Some(&zeroCostBasis)), "approval should keep only credited portion in zero-cost-basis wash")
 	})
 
 	t.Run("when payment is authorized but not settled", func(t *testing.T) {
@@ -1460,7 +1463,8 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoicePartialCreditPa
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()), "authorized payment should keep accrued amount")
 		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "authorized payment should clear open receivable")
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-3), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "authorized payment should move fiat remainder to authorized receivable")
-		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()), "authorized payment should not settle to wash")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-2), s.MustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()), "authorized payment should not settle the fiat remainder")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-2), s.MustWashBalance(ns, USD, mo.Some(&zeroCostBasis)), "authorized payment should keep zero-cost-basis wash unchanged")
 	})
 
 	t.Run("when payment is settled", func(t *testing.T) {
@@ -1489,7 +1493,8 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoicePartialCreditPa
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()), "settled payment should keep accrued amount")
 		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "settled payment should keep open receivable cleared")
 		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "settled payment should clear authorized receivable")
-		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-3), s.MustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()), "settled payment should book fiat remainder to wash")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-5), s.MustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()), "settled payment should book fiat remainder to wash in addition to credits")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-2), s.MustWashBalance(ns, USD, mo.Some(&zeroCostBasis)), "settled payment should leave zero-cost-basis wash at credited portion only")
 		s.AssertDecimalEqual(startLedger.Earnings, s.MustEarningsBalance(ns, USD), "settled payment should not change earnings")
 	})
 }

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -958,7 +958,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchDele
 		CostBasis: mo.Some(&zeroCostBasis),
 	}
 
-	t.Run("given a partially credited flat fee charge", func(t *testing.T) {
+	s.Run("given a partially credited flat fee charge", func() {
 		// given:
 		// - a ledger-backed customer receives 2 USD promotional credits
 		// when:
@@ -1004,7 +1004,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchDele
 		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "aggregate authorized receivable should be empty before invoicing")
 	})
 
-	t.Run("when the pending line is collected into a mutable draft invoice", func(t *testing.T) {
+	s.Run("when the pending line is collected into a mutable draft invoice", func() {
 		// given:
 		// - the flat fee has 2 USD available credits and 3 USD remaining fiat amount
 		// when:
@@ -1040,7 +1040,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchDele
 		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "draft line should not create authorized receivable")
 	})
 
-	t.Run("when the charge delete patch removes the mutable standard line", func(t *testing.T) {
+	s.Run("when the charge delete patch removes the mutable standard line", func() {
 		// given:
 		// - the standard invoice is still mutable and has only draft credit allocations
 		// when:
@@ -1078,7 +1078,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchDele
 		s.Empty(deletedCharge.Realizations.CurrentRun.DetailedLines.OrEmpty())
 	})
 
-	t.Run("then deleting the mutable line restores the initial ledger state", func(t *testing.T) {
+	s.Run("then deleting the mutable line restores the initial ledger state", func() {
 		// given:
 		// - the mutable line has been deleted by billing's line engine
 		// when:
@@ -1297,7 +1297,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoicePartialCreditPa
 		CostBasis: mo.Some(&zeroCostBasis),
 	}
 
-	t.Run("given a partially credited flat fee charge", func(t *testing.T) {
+	s.Run("given a partially credited flat fee charge", func() {
 		// given:
 		// - a ledger-backed customer receives 2 USD promotional credits
 		// when:
@@ -1346,7 +1346,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoicePartialCreditPa
 		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "aggregate authorized receivable should be empty before invoicing")
 	})
 
-	t.Run("when the line is collected into a draft invoice", func(t *testing.T) {
+	s.Run("when the line is collected into a draft invoice", func() {
 		// given:
 		// - the charge has a pending gathering line at service period start
 		// when:
@@ -1398,7 +1398,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoicePartialCreditPa
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-2), s.MustWashBalance(ns, USD, mo.Some(&zeroCostBasis)), "draft line should book credited portion to zero-cost-basis wash")
 	})
 
-	t.Run("when the invoice is approved", func(t *testing.T) {
+	s.Run("when the invoice is approved", func() {
 		// given:
 		// - the draft standard invoice has a 3 USD fiat total after credits
 		// when:
@@ -1440,7 +1440,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoicePartialCreditPa
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-2), s.MustWashBalance(ns, USD, mo.Some(&zeroCostBasis)), "approval should keep only credited portion in zero-cost-basis wash")
 	})
 
-	t.Run("when payment is authorized but not settled", func(t *testing.T) {
+	s.Run("when payment is authorized but not settled", func() {
 		// given:
 		// - the invoice is payment-processing pending
 		// when:
@@ -1467,7 +1467,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoicePartialCreditPa
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-2), s.MustWashBalance(ns, USD, mo.Some(&zeroCostBasis)), "authorized payment should keep zero-cost-basis wash unchanged")
 	})
 
-	t.Run("when payment is settled", func(t *testing.T) {
+	s.Run("when payment is settled", func() {
 		// given:
 		// - the invoice payment is authorized
 		// when:
@@ -1533,7 +1533,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDirectPaidTrigg
 		invoice         billing.StandardInvoice
 	)
 
-	t.Run("given an unpaid credit-then-invoice flat fee invoice", func(t *testing.T) {
+	s.Run("given an unpaid credit-then-invoice flat fee invoice", func() {
 		// given:
 		// - a ledger-backed customer has no credits
 		// when:
@@ -1583,7 +1583,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDirectPaidTrigg
 		s.AssertDecimalEqual(startLedger.Wash, s.MustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()), "payment should not be settled yet")
 	})
 
-	t.Run("when the payment app reports paid directly", func(t *testing.T) {
+	s.Run("when the payment app reports paid directly", func() {
 		// given:
 		// - the invoice is payment-processing pending and payment has not been separately authorized
 		// when:
@@ -1649,7 +1649,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteImmutable
 		immutableLedger LedgerSnapshot
 	)
 
-	t.Run("given an immutable invoice with accrued usage and authorized payment", func(t *testing.T) {
+	s.Run("given an immutable invoice with accrued usage and authorized payment", func() {
 		// given:
 		// - a ledger-backed customer has no credits
 		// when:
@@ -1714,7 +1714,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteImmutable
 		s.Equal(payment.StatusAuthorized, charge.Realizations.CurrentRun.Payment.Status)
 	})
 
-	t.Run("when the charge delete patch targets the immutable standard line", func(t *testing.T) {
+	s.Run("when the charge delete patch targets the immutable standard line", func() {
 		// given:
 		// - the invoice line is immutable and payment authorization is booked
 		// when:
@@ -1747,7 +1747,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteImmutable
 		s.Equal(payment.StatusAuthorized, deletedCharge.Realizations.CurrentRun.Payment.Status)
 	})
 
-	t.Run("then immutable invoice delete keeps ledger bookings unchanged", func(t *testing.T) {
+	s.Run("then immutable invoice delete keeps ledger bookings unchanged", func() {
 		// given:
 		// - the delete request only produced an immutable invoice warning
 		// when:
@@ -1790,7 +1790,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceInArrearsActiva
 
 	var flatFeeChargeID meta.ChargeID
 
-	t.Run("given an in-arrears flat fee charge", func(t *testing.T) {
+	s.Run("given an in-arrears flat fee charge", func() {
 		// given:
 		// - a future service period flat fee uses in-arrears payment term
 		// when:
@@ -1828,7 +1828,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceInArrearsActiva
 		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
 	})
 
-	t.Run("when charges advance before the service period starts", func(t *testing.T) {
+	s.Run("when charges advance before the service period starts", func() {
 		// given:
 		// - the service period has not started
 		// when:
@@ -1845,7 +1845,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceInArrearsActiva
 		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
 	})
 
-	t.Run("when the service period starts", func(t *testing.T) {
+	s.Run("when the service period starts", func() {
 		// given:
 		// - the clock is at service period start
 		// when:
@@ -1862,7 +1862,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceInArrearsActiva
 		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
 	})
 
-	t.Run("when billing tries to invoice at service period start", func(t *testing.T) {
+	s.Run("when billing tries to invoice at service period start", func() {
 		// given:
 		// - the in-arrears line is not due until service period end
 		// when:
@@ -1878,7 +1878,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceInArrearsActiva
 		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
 	})
 
-	t.Run("when billing invoices at invoice_at", func(t *testing.T) {
+	s.Run("when billing invoices at invoice_at", func() {
 		// given:
 		// - the clock is at service period end
 		// when:
@@ -1934,7 +1934,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteActiveCha
 
 	var flatFeeChargeID meta.ChargeID
 
-	t.Run("given an active flat fee charge before standard invoice creation", func(t *testing.T) {
+	s.Run("given an active flat fee charge before standard invoice creation", func() {
 		// given:
 		// - an in-arrears flat fee has a pending gathering line
 		// when:
@@ -1975,7 +1975,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteActiveCha
 		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
 	})
 
-	t.Run("when the active charge is deleted before standard invoice creation", func(t *testing.T) {
+	s.Run("when the active charge is deleted before standard invoice creation", func() {
 		// given:
 		// - the only billing artifact is still the gathering line
 		// when:
@@ -1989,6 +1989,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteActiveCha
 
 		allLines := s.mustGatheringLinesForCharge(ns, cust.ID, flatFeeChargeID.ID, true)
 		s.Len(allLines, 1)
+		s.Equal(flatFeeChargeID.ID, lo.FromPtr(allLines[0].ChargeID))
 		s.NotNil(allLines[0].DeletedAt)
 		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusDeleted)
 		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -11,9 +11,12 @@ import (
 	"github.com/samber/mo"
 	"github.com/stretchr/testify/suite"
 
+	appcustominvoicing "github.com/openmeterio/openmeter/openmeter/app/custominvoicing"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/ledger"
@@ -21,6 +24,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 	billingtest "github.com/openmeterio/openmeter/test/billing"
 )
@@ -177,7 +181,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceDeletePatchD
 		CostBasis: mo.Some(&zeroCostBasis),
 	}
 
-	s.Run("given prepaid credits and a credit-then-invoice usage charge", func() {
+	s.Run("given promotional credits and a credit-then-invoice usage charge", func() {
 		// given:
 		// - a ledger-backed customer receives 5 USD promotional credits
 		// - 5 usage units are visible inside the service period
@@ -227,7 +231,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceDeletePatchD
 		s.RequireChargeStatus(usageBasedChargeID, usagebased.StatusCreated)
 
 		startLedger = s.CreateLedgerSnapshot(ledgerSnapshotInput)
-		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), startLedger.FBO, "prepaid credits should be available before invoicing")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), startLedger.FBO, "promotional credits should be available before invoicing")
 		s.AssertDecimalEqual(alpacadecimal.Zero, startLedger.Accrued, "no usage should be accrued before invoicing")
 	})
 
@@ -516,6 +520,1473 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceDeletePatchK
 		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, immutableLedger)
 		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "aggregate open receivable should stay empty")
 		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "aggregate authorized receivable should stay empty")
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceCreatePatchCreatesPendingGatheringLine() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-create")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	ledgerSnapshotInput := LedgerSnapshotInput{
+		Namespace: ns,
+		Customer:  cust.GetID(),
+		Currency:  USD,
+		CostBasis: mo.None[*alpacadecimal.Decimal](),
+	}
+	startLedger := s.CreateLedgerSnapshot(ledgerSnapshotInput)
+
+	s.Run("when a flat fee credit-then-invoice charge is created through patches", func() {
+		// given:
+		// - a ledger-backed customer has no active charges or credit bookings
+		// when:
+		// - the subscription patch flow creates a credit-then-invoice flat fee charge
+		// then:
+		// - one created flat fee charge and one pending gathering line are created
+		err := s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
+			CustomerID: cust.GetID(),
+			Creates: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(5),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					Name:              "flatfee-credit-then-invoice-create",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flatfee-credit-then-invoice-create",
+				}),
+			},
+		})
+		s.NoError(err)
+
+		result, err := s.Charges.ListCharges(ctx, charges.ListChargesInput{
+			Page:        pagination.NewPage(1, 20),
+			Namespace:   ns,
+			CustomerIDs: []string{cust.ID},
+			ChargeTypes: []meta.ChargeType{meta.ChargeTypeFlatFee},
+			Expands:     meta.Expands{meta.ExpandRealizations},
+		})
+		s.NoError(err)
+		s.Len(result.Items, 1)
+
+		flatFeeCharge, err := result.Items[0].AsFlatFeeCharge()
+		s.NoError(err)
+		s.Equal(flatfee.StatusCreated, flatFeeCharge.Status)
+		s.Equal(productcatalog.CreditThenInvoiceSettlementMode, flatFeeCharge.Intent.SettlementMode)
+
+		activeLines := s.mustGatheringLinesForCharge(ns, cust.ID, flatFeeCharge.ID, false)
+		s.Len(activeLines, 1)
+		s.Nil(activeLines[0].DeletedAt)
+		s.Equal(flatFeeCharge.ID, lo.FromPtr(activeLines[0].ChargeID))
+
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+	})
+
+	s.Run("then the charge becomes active at the service period start and can be invoiced", func() {
+		// given:
+		// - the charge has a due in-advance gathering line
+		// when:
+		// - charges advance at service period start and billing collects pending lines
+		// then:
+		// - the charge is active, the standard line is created, and the ledger remains unchanged
+		clock.FreezeTime(servicePeriod.From)
+
+		advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+			Customer: cust.GetID(),
+		})
+		s.NoError(err)
+		s.Len(advancedCharges, 1)
+
+		flatFeeCharge, err := advancedCharges[0].AsFlatFeeCharge()
+		s.NoError(err)
+		s.Equal(flatfee.StatusActive, flatFeeCharge.Status)
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.From),
+		})
+		s.NoError(err)
+		s.Len(invoices, 1)
+		s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, invoices[0].Status)
+		s.Require().Len(invoices[0].Lines.OrEmpty(), 1)
+		line := invoices[0].Lines.OrEmpty()[0]
+		s.Equal(flatFeeCharge.ID, lo.FromPtr(line.ChargeID))
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount: 5,
+			Total:  5,
+		}, line.Totals)
+		s.RequireFlatFeeChargeStatus(flatFeeCharge.GetChargeID(), flatfee.StatusActiveRealizationProcessing)
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchDeletesPendingGatheringLine() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-gathering")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	var flatFeeChargeID meta.ChargeID
+	ledgerSnapshotInput := LedgerSnapshotInput{
+		Namespace: ns,
+		Customer:  cust.GetID(),
+		Currency:  USD,
+		CostBasis: mo.None[*alpacadecimal.Decimal](),
+	}
+	startLedger := s.CreateLedgerSnapshot(ledgerSnapshotInput)
+
+	s.Run("given a credit-then-invoice flat fee charge with a pending gathering line", func() {
+		// given:
+		// - a ledger-backed customer has no credit allocations or invoice bookings
+		// when:
+		// - a credit-then-invoice flat fee charge is created for a future service period
+		// then:
+		// - billing has one active gathering line for the charge and the ledger remains unchanged
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(5),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					Name:              "flatfee-credit-then-invoice-delete-gathering",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flatfee-credit-then-invoice-delete-gathering",
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		flatFeeCharge, err := res[0].AsFlatFeeCharge()
+		s.NoError(err)
+		flatFeeChargeID = flatFeeCharge.GetChargeID()
+
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusCreated)
+
+		activeLines := s.mustGatheringLinesForCharge(ns, cust.ID, flatFeeChargeID.ID, false)
+		s.Len(activeLines, 1)
+		s.Nil(activeLines[0].DeletedAt)
+
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+	})
+
+	s.Run("when the charge delete patch is applied", func() {
+		// given:
+		// - the only billing artifact is a mutable gathering line
+		// when:
+		// - the charge is deleted through the patch flow
+		// then:
+		// - the gathering line is soft-deleted
+		s.MustRefundCharge(ctx, cust.GetID(), flatFeeChargeID)
+
+		activeLines := s.mustGatheringLinesForCharge(ns, cust.ID, flatFeeChargeID.ID, false)
+		s.Empty(activeLines)
+
+		allLines := s.mustGatheringLinesForCharge(ns, cust.ID, flatFeeChargeID.ID, true)
+		s.Len(allLines, 1)
+		s.NotNil(allLines[0].DeletedAt)
+
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusDeleted)
+	})
+
+	s.Run("then no ledger transaction was reversed or created for the gathering-line-only delete", func() {
+		// given:
+		// - gathering lines do not have credit allocations, invoice accrual, or payment bookings
+		// when:
+		// - the deleted gathering line is inspected after the patch
+		// then:
+		// - every ledger balance is still identical to the pre-delete snapshot
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusDeleted)
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchDeletesMutableStandardLineAndCorrectsCredits() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-standard")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	zeroCostBasis := alpacadecimal.Zero
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	var (
+		flatFeeChargeID meta.ChargeID
+		invoice         billing.StandardInvoice
+		lineID          billing.LineID
+		startLedger     LedgerSnapshot
+	)
+	ledgerSnapshotInput := LedgerSnapshotInput{
+		Namespace: ns,
+		Customer:  cust.GetID(),
+		Currency:  USD,
+		CostBasis: mo.Some(&zeroCostBasis),
+	}
+
+	s.Run("given promotional credits and a credit-then-invoice flat fee charge", func() {
+		// given:
+		// - a ledger-backed customer receives 5 USD promotional credits
+		// when:
+		// - a 7 USD credit-then-invoice flat fee charge is created
+		// then:
+		// - credits are available in FBO and the charge has no invoice-backed realizations yet
+		s.CreatePromotionalCreditFunding(ctx, CreatePromotionalCreditFundingInput{
+			Namespace: ns,
+			Customer:  cust.GetID(),
+			Amount:    alpacadecimal.NewFromInt(5),
+			At:        setupAt,
+			CostBasis: zeroCostBasis,
+		})
+
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(7),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					Name:              "flatfee-credit-then-invoice-delete-standard",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flatfee-credit-then-invoice-delete-standard",
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		flatFeeCharge, err := res[0].AsFlatFeeCharge()
+		s.NoError(err)
+		flatFeeChargeID = flatFeeCharge.GetChargeID()
+
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusCreated)
+
+		startLedger = s.CreateLedgerSnapshot(ledgerSnapshotInput)
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), startLedger.FBO, "promotional credits should be available before invoicing")
+		s.AssertDecimalEqual(alpacadecimal.Zero, startLedger.Accrued, "no usage should be accrued before invoicing")
+		s.AssertDecimalEqual(alpacadecimal.Zero, startLedger.OpenReceivable, "promotional credits should not create open receivable")
+		s.AssertDecimalEqual(alpacadecimal.Zero, startLedger.AuthorizedReceivable, "promotional credits should not create authorized receivable")
+	})
+
+	s.Run("when the pending line is collected into a mutable draft invoice", func() {
+		// given:
+		// - the flat fee has 5 USD available credits and 2 USD remaining fiat amount
+		// when:
+		// - billing creates the standard invoice but does not approve it
+		// then:
+		// - the mutable standard line has credit allocations, but no fiat accrued usage or payment booking
+		clock.FreezeTime(servicePeriod.From)
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.From),
+		})
+		s.NoError(err)
+		s.Len(invoices, 1)
+		invoice = invoices[0]
+		s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, invoice.Status)
+		s.Len(invoice.Lines.OrEmpty(), 1)
+
+		line := invoice.Lines.OrEmpty()[0]
+		lineID = line.GetLineID()
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount:       7,
+			CreditsTotal: 5,
+			Total:        2,
+		}, line.Totals)
+
+		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusActiveRealizationProcessing)
+		s.Require().NotNil(charge.Realizations.CurrentRun)
+		s.Len(charge.Realizations.CurrentRun.CreditRealizations, 1)
+		s.Equal(lineID.ID, lo.FromPtr(charge.Realizations.CurrentRun.CreditRealizations[0].LineID))
+		s.Equal(alpacadecimal.NewFromInt(5), charge.Realizations.CurrentRun.CreditRealizations.Sum())
+		s.Nil(charge.Realizations.CurrentRun.AccruedUsage)
+		s.Nil(charge.Realizations.CurrentRun.Payment)
+
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&zeroCostBasis)), "draft line credit allocation should consume FBO")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&zeroCostBasis)), "draft line credit allocation should accrue credits")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()), "draft line should not accrue the fiat remainder")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "draft line should not create open receivable")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "draft line should not create authorized receivable")
+	})
+
+	s.Run("when the charge delete patch removes the mutable standard line", func() {
+		// given:
+		// - the standard invoice is still mutable and has no payment or invoice accrued allocation
+		// when:
+		// - the charge is deleted through the patch flow
+		// then:
+		// - the standard line is soft-deleted and charge-owned draft realizations are cleaned up
+		s.MustRefundCharge(ctx, cust.GetID(), flatFeeChargeID)
+
+		fetchedInvoice, err := s.BillingService.GetInvoiceById(ctx, billing.GetInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand: billing.InvoiceExpands{
+				billing.InvoiceExpandLines,
+				billing.InvoiceExpandDeletedLines,
+			},
+		})
+		s.NoError(err)
+
+		standardInvoice, err := fetchedInvoice.AsStandardInvoice()
+		s.NoError(err)
+		deletedLine := standardInvoice.Lines.GetByID(lineID.ID)
+		s.Require().NotNil(deletedLine)
+		s.NotNil(deletedLine.DeletedAt)
+		s.Zero(standardInvoice.Lines.NonDeletedLineCount())
+
+		charge := s.mustGetFlatFeeChargeByIDWithExpands(flatFeeChargeID, meta.Expands{
+			meta.ExpandRealizations,
+			meta.ExpandDetailedLines,
+		})
+		s.Equal(flatfee.StatusDeleted, charge.Status)
+		s.Require().NotNil(charge.Realizations.CurrentRun)
+		s.Equal(alpacadecimal.Zero, charge.Realizations.CurrentRun.CreditRealizations.Sum())
+		s.Nil(charge.Realizations.CurrentRun.AccruedUsage)
+		s.Nil(charge.Realizations.CurrentRun.Payment)
+		s.True(charge.Realizations.CurrentRun.DetailedLines.IsPresent())
+		s.Empty(charge.Realizations.CurrentRun.DetailedLines.OrEmpty())
+	})
+
+	s.Run("then deleting the mutable line reverses only the credit allocation ledger transactions", func() {
+		// given:
+		// - the deleted draft line had only credit allocations
+		// when:
+		// - the line-engine cleanup has completed
+		// then:
+		// - credits are returned to FBO, accrued is cleared, and receivables stay unchanged
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusDeleted)
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "aggregate open receivable should stay empty")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "aggregate authorized receivable should stay empty")
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchDeletesMutableStandardLineAndCorrectsPartialCredits() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-standard-partial")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	zeroCostBasis := alpacadecimal.Zero
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	var (
+		flatFeeChargeID meta.ChargeID
+		invoice         billing.StandardInvoice
+		lineID          billing.LineID
+		startLedger     LedgerSnapshot
+	)
+	ledgerSnapshotInput := LedgerSnapshotInput{
+		Namespace: ns,
+		Customer:  cust.GetID(),
+		Currency:  USD,
+		CostBasis: mo.Some(&zeroCostBasis),
+	}
+
+	t.Run("given a partially credited flat fee charge", func(t *testing.T) {
+		// given:
+		// - a ledger-backed customer receives 2 USD promotional credits
+		// when:
+		// - a 5 USD credit-then-invoice flat fee charge is created
+		// then:
+		// - the charge is created and the initial ledger snapshot has only the promotional credits
+		s.CreatePromotionalCreditFunding(ctx, CreatePromotionalCreditFundingInput{
+			Namespace: ns,
+			Customer:  cust.GetID(),
+			Amount:    alpacadecimal.NewFromInt(2),
+			At:        setupAt,
+			CostBasis: zeroCostBasis,
+		})
+
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(5),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					Name:              "flatfee-credit-then-invoice-delete-standard-partial",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flatfee-credit-then-invoice-delete-standard-partial",
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		flatFeeCharge, err := res[0].AsFlatFeeCharge()
+		s.NoError(err)
+		flatFeeChargeID = flatFeeCharge.GetChargeID()
+		startLedger = s.CreateLedgerSnapshot(ledgerSnapshotInput)
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(2), startLedger.FBO, "promotional credits should be available before invoicing")
+		s.AssertDecimalEqual(alpacadecimal.Zero, startLedger.Accrued, "no credits should be accrued before invoicing")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "aggregate open receivable should be empty before invoicing")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "aggregate authorized receivable should be empty before invoicing")
+	})
+
+	t.Run("when the pending line is collected into a mutable draft invoice", func(t *testing.T) {
+		// given:
+		// - the flat fee has 2 USD available credits and 3 USD remaining fiat amount
+		// when:
+		// - billing creates the standard invoice but does not approve it
+		// then:
+		// - the current run has partial credit realizations and no invoice accrual or payment
+		clock.FreezeTime(servicePeriod.From)
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.From),
+		})
+		s.NoError(err)
+		s.Len(invoices, 1)
+		invoice = invoices[0]
+		s.Require().Len(invoice.Lines.OrEmpty(), 1)
+
+		line := invoice.Lines.OrEmpty()[0]
+		lineID = line.GetLineID()
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount:       5,
+			CreditsTotal: 2,
+			Total:        3,
+		}, line.Totals)
+
+		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusActiveRealizationProcessing)
+		s.Require().NotNil(charge.Realizations.CurrentRun)
+		s.Equal(alpacadecimal.NewFromInt(2), charge.Realizations.CurrentRun.CreditRealizations.Sum())
+		s.Nil(charge.Realizations.CurrentRun.AccruedUsage)
+		s.Nil(charge.Realizations.CurrentRun.Payment)
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&zeroCostBasis)), "draft line credit allocation should consume FBO")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(2), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&zeroCostBasis)), "draft line credit allocation should accrue credits")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "draft line should not create open receivable")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "draft line should not create authorized receivable")
+	})
+
+	t.Run("when the charge delete patch removes the mutable standard line", func(t *testing.T) {
+		// given:
+		// - the standard invoice is still mutable and has only draft credit allocations
+		// when:
+		// - the charge is deleted through the patch flow
+		// then:
+		// - the line is soft-deleted and charge-owned draft realizations are corrected
+		s.MustRefundCharge(ctx, cust.GetID(), flatFeeChargeID)
+
+		fetchedInvoice, err := s.BillingService.GetInvoiceById(ctx, billing.GetInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand: billing.InvoiceExpands{
+				billing.InvoiceExpandLines,
+				billing.InvoiceExpandDeletedLines,
+			},
+		})
+		s.NoError(err)
+
+		standardInvoice, err := fetchedInvoice.AsStandardInvoice()
+		s.NoError(err)
+		deletedLine := standardInvoice.Lines.GetByID(lineID.ID)
+		s.Require().NotNil(deletedLine)
+		s.NotNil(deletedLine.DeletedAt)
+		s.Zero(standardInvoice.Lines.NonDeletedLineCount())
+
+		deletedCharge := s.mustGetFlatFeeChargeByIDWithExpands(flatFeeChargeID, meta.Expands{
+			meta.ExpandRealizations,
+			meta.ExpandDetailedLines,
+		})
+		s.Equal(flatfee.StatusDeleted, deletedCharge.Status)
+		s.Require().NotNil(deletedCharge.Realizations.CurrentRun)
+		s.Equal(alpacadecimal.Zero, deletedCharge.Realizations.CurrentRun.CreditRealizations.Sum())
+		s.Nil(deletedCharge.Realizations.CurrentRun.AccruedUsage)
+		s.Nil(deletedCharge.Realizations.CurrentRun.Payment)
+		s.True(deletedCharge.Realizations.CurrentRun.DetailedLines.IsPresent())
+		s.Empty(deletedCharge.Realizations.CurrentRun.DetailedLines.OrEmpty())
+	})
+
+	t.Run("then deleting the mutable line restores the initial ledger state", func(t *testing.T) {
+		// given:
+		// - the mutable line has been deleted by billing's line engine
+		// when:
+		// - the ledger is inspected after cleanup
+		// then:
+		// - the partial credit allocation is reversed and fiat receivables remain absent
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "aggregate open receivable should stay empty")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "aggregate authorized receivable should stay empty")
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchKeepsImmutableStandardLineAndLedgerBookings() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-immutable")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	zeroCostBasis := alpacadecimal.Zero
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	var (
+		flatFeeChargeID meta.ChargeID
+		invoice         billing.StandardInvoice
+		lineID          billing.LineID
+		immutableLedger LedgerSnapshot
+	)
+	ledgerSnapshotInput := LedgerSnapshotInput{
+		Namespace: ns,
+		Customer:  cust.GetID(),
+		Currency:  USD,
+		CostBasis: mo.Some(&zeroCostBasis),
+	}
+
+	s.Run("given a credit-then-invoice flat fee charge with an immutable invoice", func() {
+		// given:
+		// - a ledger-backed customer has enough credits to cover the invoice line
+		// when:
+		// - the standard invoice is collected and approved
+		// then:
+		// - the invoice line is immutable and its credit ledger bookings exist
+		s.CreatePromotionalCreditFunding(ctx, CreatePromotionalCreditFundingInput{
+			Namespace: ns,
+			Customer:  cust.GetID(),
+			Amount:    alpacadecimal.NewFromInt(5),
+			At:        setupAt,
+			CostBasis: zeroCostBasis,
+		})
+
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(5),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					Name:              "flatfee-credit-then-invoice-delete-immutable",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flatfee-credit-then-invoice-delete-immutable",
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		flatFeeCharge, err := res[0].AsFlatFeeCharge()
+		s.NoError(err)
+		flatFeeChargeID = flatFeeCharge.GetChargeID()
+
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusCreated)
+
+		clock.FreezeTime(servicePeriod.From)
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.From),
+		})
+		s.NoError(err)
+		s.Len(invoices, 1)
+		invoice = invoices[0]
+		s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, invoice.Status)
+		s.Len(invoice.Lines.OrEmpty(), 1)
+
+		line := invoice.Lines.OrEmpty()[0]
+		lineID = line.GetLineID()
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount:       5,
+			CreditsTotal: 5,
+			Total:        0,
+		}, line.Totals)
+
+		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
+		s.True(invoice.StatusDetails.Immutable)
+
+		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusFinal)
+		s.Require().NotNil(charge.Realizations.CurrentRun)
+		s.Len(charge.Realizations.CurrentRun.CreditRealizations, 1)
+		s.Equal(lineID.ID, lo.FromPtr(charge.Realizations.CurrentRun.CreditRealizations[0].LineID))
+		s.Nil(charge.Realizations.CurrentRun.AccruedUsage)
+		s.Nil(charge.Realizations.CurrentRun.Payment)
+
+		immutableLedger = s.CreateLedgerSnapshot(ledgerSnapshotInput)
+		s.AssertDecimalEqual(alpacadecimal.Zero, immutableLedger.FBO, "immutable invoice credit allocation should keep FBO consumed")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), immutableLedger.Accrued, "immutable invoice should keep accrued credit booking")
+		s.AssertDecimalEqual(alpacadecimal.Zero, immutableLedger.OpenReceivable, "fully credited immutable invoice should not create open receivable")
+		s.AssertDecimalEqual(alpacadecimal.Zero, immutableLedger.AuthorizedReceivable, "fully credited immutable invoice should not create authorized receivable")
+	})
+
+	s.Run("when the charge delete patch targets the immutable standard line", func() {
+		// given:
+		// - the invoice line is immutable and cannot be deleted without prorating support
+		// when:
+		// - the charge is deleted through the patch flow
+		// then:
+		// - the invoice line remains active, and the invoice records a warning
+		s.MustRefundCharge(ctx, cust.GetID(), flatFeeChargeID)
+
+		fetchedInvoice, err := s.BillingService.GetInvoiceById(ctx, billing.GetInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand: billing.InvoiceExpands{
+				billing.InvoiceExpandLines,
+			},
+		})
+		s.NoError(err)
+
+		standardInvoice, err := fetchedInvoice.AsStandardInvoice()
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, standardInvoice.Status)
+
+		line := standardInvoice.Lines.GetByID(lineID.ID)
+		s.Require().NotNil(line)
+		s.Nil(line.DeletedAt)
+		s.Equal(1, standardInvoice.Lines.NonDeletedLineCount())
+
+		s.Require().Len(standardInvoice.ValidationIssues, 1)
+		issue := standardInvoice.ValidationIssues[0]
+		s.Equal(billing.ValidationIssueSeverityWarning, issue.Severity)
+		s.Equal(billing.ImmutableInvoiceHandlingNotSupportedErrorCode, issue.Code)
+		s.Equal(billing.ComponentName("charges.invoiceupdater"), issue.Component)
+		s.Equal("line should be deleted, but the invoice is immutable", issue.Message)
+		s.Equal("lines/"+lineID.ID, issue.Path)
+
+		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusDeleted)
+		s.Require().NotNil(charge.Realizations.CurrentRun)
+		s.Len(charge.Realizations.CurrentRun.CreditRealizations, 1)
+		s.Equal(alpacadecimal.NewFromInt(5), charge.Realizations.CurrentRun.CreditRealizations.Sum())
+	})
+
+	s.Run("then immutable invoice deletion does not reverse ledger bookings", func() {
+		// given:
+		// - the delete request only produced an immutable-invoice warning
+		// when:
+		// - the ledger is inspected after the patch
+		// then:
+		// - the already-issued invoice credit bookings remain unchanged
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusDeleted)
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, immutableLedger)
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "aggregate open receivable should stay empty")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "aggregate authorized receivable should stay empty")
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoicePartialCreditPaymentLifecyclePersistsRunState() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-partial-payment")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	zeroCostBasis := alpacadecimal.Zero
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	var (
+		flatFeeChargeID meta.ChargeID
+		invoice         billing.StandardInvoice
+		lineID          billing.LineID
+		startLedger     LedgerSnapshot
+	)
+	ledgerSnapshotInput := LedgerSnapshotInput{
+		Namespace: ns,
+		Customer:  cust.GetID(),
+		Currency:  USD,
+		CostBasis: mo.Some(&zeroCostBasis),
+	}
+
+	t.Run("given a partially credited flat fee charge", func(t *testing.T) {
+		// given:
+		// - a ledger-backed customer receives 2 USD promotional credits
+		// when:
+		// - a 5 USD credit-then-invoice flat fee charge is created
+		// then:
+		// - the charge starts as created with a pending gathering line
+		s.CreatePromotionalCreditFunding(ctx, CreatePromotionalCreditFundingInput{
+			Namespace: ns,
+			Customer:  cust.GetID(),
+			Amount:    alpacadecimal.NewFromInt(2),
+			At:        setupAt,
+			CostBasis: zeroCostBasis,
+		})
+
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(5),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					Name:              "flatfee-credit-then-invoice-partial-payment",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flatfee-credit-then-invoice-partial-payment",
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		flatFeeCharge, err := res[0].AsFlatFeeCharge()
+		s.NoError(err)
+		flatFeeChargeID = flatFeeCharge.GetChargeID()
+
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusCreated)
+
+		startLedger = s.CreateLedgerSnapshot(ledgerSnapshotInput)
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(2), startLedger.FBO, "promotional credits should be available before invoicing")
+		s.AssertDecimalEqual(alpacadecimal.Zero, startLedger.Accrued, "no credits should be accrued before invoicing")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "aggregate open receivable should be empty before invoicing")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "aggregate authorized receivable should be empty before invoicing")
+	})
+
+	t.Run("when the line is collected into a draft invoice", func(t *testing.T) {
+		// given:
+		// - the charge has a pending gathering line at service period start
+		// when:
+		// - billing invoices pending lines
+		// then:
+		// - one draft invoice is created, run line identity is persisted, and duplicate collection is rejected
+		clock.FreezeTime(servicePeriod.From)
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.From),
+		})
+		s.NoError(err)
+		s.Len(invoices, 1)
+		invoice = invoices[0]
+		s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, invoice.Status)
+
+		duplicateInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.From),
+		})
+		s.Error(err)
+		s.Empty(duplicateInvoices)
+
+		s.Require().Len(invoice.Lines.OrEmpty(), 1)
+		line := invoice.Lines.OrEmpty()[0]
+		lineID = line.GetLineID()
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount:       5,
+			CreditsTotal: 2,
+			Total:        3,
+		}, line.Totals)
+
+		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusActiveRealizationProcessing)
+		s.Require().NotNil(charge.Realizations.CurrentRun)
+		s.Equal(lineID.ID, lo.FromPtr(charge.Realizations.CurrentRun.LineID))
+		s.Equal(invoice.ID, lo.FromPtr(charge.Realizations.CurrentRun.InvoiceID))
+		s.Len(charge.Realizations.CurrentRun.CreditRealizations, 1)
+		s.Equal(alpacadecimal.NewFromInt(2), charge.Realizations.CurrentRun.CreditRealizations.Sum())
+		s.Nil(charge.Realizations.CurrentRun.AccruedUsage)
+		s.Nil(charge.Realizations.CurrentRun.Payment)
+
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&zeroCostBasis)), "draft line credit allocation should consume FBO")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(2), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&zeroCostBasis)), "draft line credit allocation should accrue credits")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(2), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()), "draft line should not accrue the fiat remainder")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "draft line should not create open receivable")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "draft line should not create authorized receivable")
+	})
+
+	t.Run("when the invoice is approved", func(t *testing.T) {
+		// given:
+		// - the draft standard invoice has a 3 USD fiat total after credits
+		// when:
+		// - the invoice is approved
+		// then:
+		// - invoice usage and detailed lines are persisted on the current run, but payment is not authorized yet
+		var err error
+		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
+
+		charge := s.mustGetFlatFeeChargeByIDWithExpands(flatFeeChargeID, meta.Expands{
+			meta.ExpandRealizations,
+			meta.ExpandDetailedLines,
+		})
+		s.Equal(flatfee.StatusActiveAwaitingPaymentSettlement, charge.Status)
+		s.Require().NotNil(charge.Realizations.CurrentRun)
+		s.Equal(lineID.ID, lo.FromPtr(charge.Realizations.CurrentRun.LineID))
+		s.Equal(invoice.ID, lo.FromPtr(charge.Realizations.CurrentRun.InvoiceID))
+
+		accruedUsage := charge.Realizations.CurrentRun.AccruedUsage
+		s.Require().NotNil(accruedUsage)
+		s.Equal(servicePeriod, accruedUsage.ServicePeriod)
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount:       5,
+			CreditsTotal: 2,
+			Total:        3,
+		}, accruedUsage.Totals)
+		s.Nil(charge.Realizations.CurrentRun.Payment)
+		s.True(charge.Realizations.CurrentRun.DetailedLines.IsPresent())
+		s.Len(charge.Realizations.CurrentRun.DetailedLines.OrEmpty(), 1)
+
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&zeroCostBasis)), "approved invoice should keep credits consumed")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(2), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.Some(&zeroCostBasis)), "approved invoice should keep credited portion accrued")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()), "approved invoice should accrue full line amount")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-3), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "approved invoice should create open receivable for fiat remainder")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "payment should not be authorized yet")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()), "payment should not be settled yet")
+	})
+
+	t.Run("when payment is authorized but not settled", func(t *testing.T) {
+		// given:
+		// - the invoice is payment-processing pending
+		// when:
+		// - the payment app reports authorization
+		// then:
+		// - the charge stays awaiting settlement with authorized payment state
+		var err error
+		invoice, err = s.BillingService.PaymentAuthorized(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingAuthorized, invoice.Status)
+
+		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusActiveAwaitingPaymentSettlement)
+		s.Require().NotNil(charge.Realizations.CurrentRun)
+		s.Require().NotNil(charge.Realizations.CurrentRun.Payment)
+		s.Equal(payment.StatusAuthorized, charge.Realizations.CurrentRun.Payment.Status)
+		s.NotNil(charge.Realizations.CurrentRun.Payment.Authorized)
+		s.Nil(charge.Realizations.CurrentRun.Payment.Settled)
+
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&zeroCostBasis)), "authorized payment should keep credits consumed")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()), "authorized payment should keep accrued amount")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "authorized payment should clear open receivable")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-3), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "authorized payment should move fiat remainder to authorized receivable")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()), "authorized payment should not settle to wash")
+	})
+
+	t.Run("when payment is settled", func(t *testing.T) {
+		// given:
+		// - the invoice payment is authorized
+		// when:
+		// - the payment app reports paid
+		// then:
+		// - payment settlement is persisted and the charge becomes final
+		var err error
+		invoice, err = s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{
+			InvoiceID: invoice.GetInvoiceID(),
+			Trigger:   billing.TriggerPaid,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
+
+		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusFinal)
+		s.Require().NotNil(charge.Realizations.CurrentRun)
+		s.Require().NotNil(charge.Realizations.CurrentRun.Payment)
+		s.Equal(payment.StatusSettled, charge.Realizations.CurrentRun.Payment.Status)
+		s.NotNil(charge.Realizations.CurrentRun.Payment.Authorized)
+		s.NotNil(charge.Realizations.CurrentRun.Payment.Settled)
+
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerFBOBalance(cust.GetID(), USD, mo.Some(&zeroCostBasis)), "settled payment should keep credits consumed")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()), "settled payment should keep accrued amount")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "settled payment should keep open receivable cleared")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "settled payment should clear authorized receivable")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-3), s.MustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()), "settled payment should book fiat remainder to wash")
+		s.AssertDecimalEqual(startLedger.Earnings, s.MustEarningsBalance(ns, USD), "settled payment should not change earnings")
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDirectPaidTriggerAuthorizesAndSettlesPayment() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-direct-paid")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime())
+	defer clock.UnFreeze()
+
+	ledgerSnapshotInput := LedgerSnapshotInput{
+		Namespace: ns,
+		Customer:  cust.GetID(),
+		Currency:  USD,
+		CostBasis: mo.None[*alpacadecimal.Decimal](),
+	}
+	startLedger := s.CreateLedgerSnapshot(ledgerSnapshotInput)
+
+	var (
+		flatFeeChargeID meta.ChargeID
+		invoice         billing.StandardInvoice
+	)
+
+	t.Run("given an unpaid credit-then-invoice flat fee invoice", func(t *testing.T) {
+		// given:
+		// - a ledger-backed customer has no credits
+		// when:
+		// - a 5 USD flat fee charge is invoiced and approved
+		// then:
+		// - the invoice waits for payment processing
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(5),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					Name:              "flatfee-credit-then-invoice-direct-paid",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flatfee-credit-then-invoice-direct-paid",
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		flatFeeCharge, err := res[0].AsFlatFeeCharge()
+		s.NoError(err)
+		flatFeeChargeID = flatFeeCharge.GetChargeID()
+
+		clock.FreezeTime(servicePeriod.From)
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.From),
+		})
+		s.NoError(err)
+		s.Len(invoices, 1)
+
+		invoice, err = s.BillingService.ApproveInvoice(ctx, invoices[0].GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
+
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()), "approved invoice should accrue full line amount")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-5), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "approved invoice should create open receivable")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "payment should not be authorized yet")
+		s.AssertDecimalEqual(startLedger.Wash, s.MustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()), "payment should not be settled yet")
+	})
+
+	t.Run("when the payment app reports paid directly", func(t *testing.T) {
+		// given:
+		// - the invoice is payment-processing pending and payment has not been separately authorized
+		// when:
+		// - the payment app reports paid
+		// then:
+		// - authorization and settlement are both recorded and the charge becomes final
+		var err error
+		invoice, err = s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{
+			InvoiceID: invoice.GetInvoiceID(),
+			Trigger:   billing.TriggerPaid,
+		})
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaid, invoice.Status)
+
+		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusFinal)
+		s.Require().NotNil(charge.Realizations.CurrentRun)
+		s.Require().NotNil(charge.Realizations.CurrentRun.AccruedUsage)
+		s.Require().NotNil(charge.Realizations.CurrentRun.Payment)
+		s.Equal(payment.StatusSettled, charge.Realizations.CurrentRun.Payment.Status)
+		s.NotNil(charge.Realizations.CurrentRun.Payment.Authorized)
+		s.NotNil(charge.Realizations.CurrentRun.Payment.Settled)
+
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), s.MustCustomerAccruedBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal]()), "settled invoice should keep accrued amount")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "direct paid trigger should clear open receivable")
+		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusAuthorized), "direct paid trigger should settle authorized receivable")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-5), s.MustWashBalance(ns, USD, mo.None[*alpacadecimal.Decimal]()), "direct paid trigger should book payment to wash")
+		s.AssertDecimalEqual(startLedger.Earnings, s.MustEarningsBalance(ns, USD), "direct paid trigger should not change earnings")
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteImmutableInvoiceWithPaymentKeepsBookings() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-immutable-payment")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime())
+	defer clock.UnFreeze()
+
+	ledgerSnapshotInput := LedgerSnapshotInput{
+		Namespace: ns,
+		Customer:  cust.GetID(),
+		Currency:  USD,
+		CostBasis: mo.None[*alpacadecimal.Decimal](),
+	}
+
+	var (
+		flatFeeChargeID meta.ChargeID
+		invoice         billing.StandardInvoice
+		lineID          billing.LineID
+		immutableLedger LedgerSnapshot
+	)
+
+	t.Run("given an immutable invoice with accrued usage and authorized payment", func(t *testing.T) {
+		// given:
+		// - a ledger-backed customer has no credits
+		// when:
+		// - a flat fee invoice is approved and payment is authorized
+		// then:
+		// - the line is immutable and the current run has invoice usage plus authorized payment
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(5),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					Name:              "flatfee-credit-then-invoice-delete-immutable-payment",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flatfee-credit-then-invoice-delete-immutable-payment",
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		flatFeeCharge, err := res[0].AsFlatFeeCharge()
+		s.NoError(err)
+		flatFeeChargeID = flatFeeCharge.GetChargeID()
+
+		clock.FreezeTime(servicePeriod.From)
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.From),
+		})
+		s.NoError(err)
+		s.Len(invoices, 1)
+		invoice = invoices[0]
+		s.Require().Len(invoice.Lines.OrEmpty(), 1)
+		lineID = invoice.Lines.OrEmpty()[0].GetLineID()
+
+		invoice, err = s.BillingService.ApproveInvoice(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingPending, invoice.Status)
+		invoice, err = s.BillingService.PaymentAuthorized(ctx, invoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaymentProcessingAuthorized, invoice.Status)
+
+		immutableLedger = s.CreateLedgerSnapshot(ledgerSnapshotInput)
+		s.AssertDecimalEqual(alpacadecimal.Zero, immutableLedger.FBO, "invoice without credits should not change FBO")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), immutableLedger.Accrued, "authorized immutable invoice should keep accrued booking")
+		s.AssertDecimalEqual(alpacadecimal.Zero, immutableLedger.OpenReceivable, "payment authorization should clear open receivable")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(-5), immutableLedger.AuthorizedReceivable, "payment authorization should move receivable to authorized")
+		s.AssertDecimalEqual(alpacadecimal.Zero, immutableLedger.Wash, "authorized payment should not be settled to wash")
+		s.AssertDecimalEqual(alpacadecimal.Zero, immutableLedger.Earnings, "authorized payment should not change earnings")
+
+		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusActiveAwaitingPaymentSettlement)
+		s.Require().NotNil(charge.Realizations.CurrentRun)
+		s.Require().NotNil(charge.Realizations.CurrentRun.AccruedUsage)
+		s.Require().NotNil(charge.Realizations.CurrentRun.Payment)
+		s.Equal(payment.StatusAuthorized, charge.Realizations.CurrentRun.Payment.Status)
+	})
+
+	t.Run("when the charge delete patch targets the immutable standard line", func(t *testing.T) {
+		// given:
+		// - the invoice line is immutable and payment authorization is booked
+		// when:
+		// - the charge is deleted through the patch flow
+		// then:
+		// - the line remains active, billing records an immutable-line warning, and run bookings remain
+		s.MustRefundCharge(ctx, cust.GetID(), flatFeeChargeID)
+
+		fetchedInvoice, err := s.BillingService.GetInvoiceById(ctx, billing.GetInvoiceByIdInput{
+			Invoice: invoice.GetInvoiceID(),
+			Expand: billing.InvoiceExpands{
+				billing.InvoiceExpandLines,
+			},
+		})
+		s.NoError(err)
+
+		standardInvoice, err := fetchedInvoice.AsStandardInvoice()
+		s.NoError(err)
+		line := standardInvoice.Lines.GetByID(lineID.ID)
+		s.Require().NotNil(line)
+		s.Nil(line.DeletedAt)
+		s.Equal(1, standardInvoice.Lines.NonDeletedLineCount())
+		s.Require().Len(standardInvoice.ValidationIssues, 1)
+		s.Equal(billing.ImmutableInvoiceHandlingNotSupportedErrorCode, standardInvoice.ValidationIssues[0].Code)
+
+		deletedCharge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusDeleted)
+		s.Require().NotNil(deletedCharge.Realizations.CurrentRun)
+		s.NotNil(deletedCharge.Realizations.CurrentRun.AccruedUsage)
+		s.Require().NotNil(deletedCharge.Realizations.CurrentRun.Payment)
+		s.Equal(payment.StatusAuthorized, deletedCharge.Realizations.CurrentRun.Payment.Status)
+	})
+
+	t.Run("then immutable invoice delete keeps ledger bookings unchanged", func(t *testing.T) {
+		// given:
+		// - the delete request only produced an immutable invoice warning
+		// when:
+		// - the ledger is inspected after delete
+		// then:
+		// - invoice accrual and payment authorization bookings are preserved
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, immutableLedger)
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceInArrearsActivatesAtServiceStartAndInvoicesAtInvoiceAt() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-in-arrears")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	ledgerSnapshotInput := LedgerSnapshotInput{
+		Namespace: ns,
+		Customer:  cust.GetID(),
+		Currency:  USD,
+		CostBasis: mo.None[*alpacadecimal.Decimal](),
+	}
+	startLedger := s.CreateLedgerSnapshot(ledgerSnapshotInput)
+
+	var flatFeeChargeID meta.ChargeID
+
+	t.Run("given an in-arrears flat fee charge", func(t *testing.T) {
+		// given:
+		// - a future service period flat fee uses in-arrears payment term
+		// when:
+		// - the charge is created
+		// then:
+		// - it starts as created and the pending gathering line invoices at service period end
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(5),
+						PaymentTerm: productcatalog.InArrearsPaymentTerm,
+					}),
+					Name:              "flatfee-credit-then-invoice-in-arrears",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flatfee-credit-then-invoice-in-arrears",
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		flatFeeCharge, err := res[0].AsFlatFeeCharge()
+		s.NoError(err)
+		flatFeeChargeID = flatFeeCharge.GetChargeID()
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusCreated)
+
+		gatheringLine := s.mustSingleActiveGatheringLineForCharge(ns, cust.ID, flatFeeChargeID.ID)
+		s.Equal(servicePeriod.To, gatheringLine.InvoiceAt)
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+	})
+
+	t.Run("when charges advance before the service period starts", func(t *testing.T) {
+		// given:
+		// - the service period has not started
+		// when:
+		// - charges are advanced
+		// then:
+		// - the flat fee remains created
+		clock.FreezeTime(servicePeriod.From.Add(-time.Second))
+		advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+			Customer: cust.GetID(),
+		})
+		s.NoError(err)
+		s.Empty(advancedCharges)
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusCreated)
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+	})
+
+	t.Run("when the service period starts", func(t *testing.T) {
+		// given:
+		// - the clock is at service period start
+		// when:
+		// - charges are advanced
+		// then:
+		// - the flat fee becomes active
+		clock.FreezeTime(servicePeriod.From)
+		advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+			Customer: cust.GetID(),
+		})
+		s.NoError(err)
+		s.Len(advancedCharges, 1)
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusActive)
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+	})
+
+	t.Run("when billing tries to invoice at service period start", func(t *testing.T) {
+		// given:
+		// - the in-arrears line is not due until service period end
+		// when:
+		// - billing invoices pending lines at service period start
+		// then:
+		// - no invoice is produced
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.From),
+		})
+		s.Error(err)
+		s.Empty(invoices)
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+	})
+
+	t.Run("when billing invoices at invoice_at", func(t *testing.T) {
+		// given:
+		// - the clock is at service period end
+		// when:
+		// - billing invoices pending lines
+		// then:
+		// - the in-arrears flat fee is collected into a standard invoice
+		clock.FreezeTime(servicePeriod.To)
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.To),
+		})
+		s.NoError(err)
+		s.Len(invoices, 1)
+		s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, invoices[0].Status)
+		s.Require().Len(invoices[0].Lines.OrEmpty(), 1)
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount: 5,
+			Total:  5,
+		}, invoices[0].Lines.OrEmpty()[0].Totals)
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteActiveChargeBeforeStandardInvoiceDeletesGatheringLine() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-active")
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(t, "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(t, "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(setupAt)
+	defer clock.UnFreeze()
+
+	ledgerSnapshotInput := LedgerSnapshotInput{
+		Namespace: ns,
+		Customer:  cust.GetID(),
+		Currency:  USD,
+		CostBasis: mo.None[*alpacadecimal.Decimal](),
+	}
+	startLedger := s.CreateLedgerSnapshot(ledgerSnapshotInput)
+
+	var flatFeeChargeID meta.ChargeID
+
+	t.Run("given an active flat fee charge before standard invoice creation", func(t *testing.T) {
+		// given:
+		// - an in-arrears flat fee has a pending gathering line
+		// when:
+		// - the service period starts and charges advance
+		// then:
+		// - the charge becomes active but no standard invoice exists yet
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(5),
+						PaymentTerm: productcatalog.InArrearsPaymentTerm,
+					}),
+					Name:              "flatfee-credit-then-invoice-delete-active",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flatfee-credit-then-invoice-delete-active",
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		flatFeeCharge, err := res[0].AsFlatFeeCharge()
+		s.NoError(err)
+		flatFeeChargeID = flatFeeCharge.GetChargeID()
+
+		clock.FreezeTime(servicePeriod.From)
+		_, err = s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+			Customer: cust.GetID(),
+		})
+		s.NoError(err)
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusActive)
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
+	})
+
+	t.Run("when the active charge is deleted before standard invoice creation", func(t *testing.T) {
+		// given:
+		// - the only billing artifact is still the gathering line
+		// when:
+		// - the charge is deleted through the patch flow
+		// then:
+		// - the gathering line is soft-deleted and no ledger bookings are created
+		s.MustRefundCharge(ctx, cust.GetID(), flatFeeChargeID)
+
+		activeLines := s.mustGatheringLinesForCharge(ns, cust.ID, flatFeeChargeID.ID, false)
+		s.Empty(activeLines)
+
+		allLines := s.mustGatheringLinesForCharge(ns, cust.ID, flatFeeChargeID.ID, true)
+		s.Len(allLines, 1)
+		s.NotNil(allLines[0].DeletedAt)
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusDeleted)
+		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
 	})
 }
 
@@ -835,7 +2306,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchD
 		usageBasedChargeID = usageBasedCharge.GetChargeID()
 
 		startLedger = s.CreateLedgerSnapshot(ledgerSnapshotInput)
-		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), startLedger.FBO, "prepaid credits should be available before invoicing")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), startLedger.FBO, "promotional credits should be available before invoicing")
 
 		clock.FreezeTime(servicePeriod.To.Add(time.Second))
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
@@ -1020,7 +2491,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkPatchD
 		usageBasedChargeID = usageBasedCharge.GetChargeID()
 
 		startLedger = s.CreateLedgerSnapshot(ledgerSnapshotInput)
-		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), startLedger.FBO, "prepaid credits should be available before invoicing")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), startLedger.FBO, "promotional credits should be available before invoicing")
 
 		clock.FreezeTime(servicePeriod.To.Add(time.Second))
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
@@ -2470,6 +3941,15 @@ func (s *CreditThenInvoiceTestSuite) RequireUsageBasedChargeStatus(chargeID meta
 	return charge
 }
 
+func (s *CreditThenInvoiceTestSuite) RequireFlatFeeChargeStatus(chargeID meta.ChargeID, status flatfee.Status) flatfee.Charge {
+	s.T().Helper()
+
+	charge, err := s.RequireChargeStatus(chargeID, status).AsFlatFeeCharge()
+	s.NoError(err)
+
+	return charge
+}
+
 func (s *CreditThenInvoiceTestSuite) mustGetUsageBasedChargeByIDWithExpands(chargeID meta.ChargeID, expands meta.Expands) usagebased.Charge {
 	s.T().Helper()
 
@@ -2483,4 +3963,19 @@ func (s *CreditThenInvoiceTestSuite) mustGetUsageBasedChargeByIDWithExpands(char
 	s.NoError(err)
 
 	return usageBasedCharge
+}
+
+func (s *CreditThenInvoiceTestSuite) mustGetFlatFeeChargeByIDWithExpands(chargeID meta.ChargeID, expands meta.Expands) flatfee.Charge {
+	s.T().Helper()
+
+	charge, err := s.Charges.GetByID(s.T().Context(), charges.GetByIDInput{
+		ChargeID: chargeID,
+		Expands:  expands,
+	})
+	s.NoError(err)
+
+	flatFeeCharge, err := charge.AsFlatFeeCharge()
+	s.NoError(err)
+
+	return flatFeeCharge
 }

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -745,6 +745,7 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
 		accruedUsage := updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage
 		s.NotNil(accruedUsage)
+		s.Equal(flatfee.StatusAwaitingPaymentSettlement, updatedFlatFeeCharge.Status)
 		s.Equal(servicePeriod, accruedUsage.ServicePeriod, "service period should be the same as the input")
 		s.NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.LineID, "run line ID should be set")
 		s.Equal(stdLineID.ID, *updatedFlatFeeCharge.Realizations.CurrentRun.LineID, "run line ID should be the same as the standard line")
@@ -774,7 +775,7 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 		charge := s.MustGetChargeByID(flatFeeChargeID)
 		updatedFlatFeeCharge, err := charge.AsFlatFeeCharge()
 		s.NoError(err)
-		s.Equal(flatfee.StatusActive, updatedFlatFeeCharge.Status)
+		s.Equal(flatfee.StatusAwaitingPaymentSettlement, updatedFlatFeeCharge.Status)
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
 		s.NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.Payment)
 		s.Equal(payment.StatusAuthorized, updatedFlatFeeCharge.Realizations.CurrentRun.Payment.Status)

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -745,7 +745,7 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
 		accruedUsage := updatedFlatFeeCharge.Realizations.CurrentRun.AccruedUsage
 		s.NotNil(accruedUsage)
-		s.Equal(flatfee.StatusAwaitingPaymentSettlement, updatedFlatFeeCharge.Status)
+		s.Equal(flatfee.StatusActiveAwaitingPaymentSettlement, updatedFlatFeeCharge.Status)
 		s.Equal(servicePeriod, accruedUsage.ServicePeriod, "service period should be the same as the input")
 		s.NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.LineID, "run line ID should be set")
 		s.Equal(stdLineID.ID, *updatedFlatFeeCharge.Realizations.CurrentRun.LineID, "run line ID should be the same as the standard line")
@@ -775,7 +775,7 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 		charge := s.MustGetChargeByID(flatFeeChargeID)
 		updatedFlatFeeCharge, err := charge.AsFlatFeeCharge()
 		s.NoError(err)
-		s.Equal(flatfee.StatusAwaitingPaymentSettlement, updatedFlatFeeCharge.Status)
+		s.Equal(flatfee.StatusActiveAwaitingPaymentSettlement, updatedFlatFeeCharge.Status)
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
 		s.NotNil(updatedFlatFeeCharge.Realizations.CurrentRun.Payment)
 		s.Equal(payment.StatusAuthorized, updatedFlatFeeCharge.Realizations.CurrentRun.Payment.Status)


### PR DESCRIPTION
## Overview

Adds flat-fee credit-then-invoice behavior so flat-fee charges begin in a created state, become active at the start of their service period, and produce invoiceable flat-fee lines at the configured invoice time.

Available customer credits are applied before any remaining fiat amount is invoiced. Fully credited charges can complete without payment settlement, while partially credited or non-credited charges remain active until invoice payment is settled.

Deleting flat-fee charges preserves billing history according to invoice mutability: pending gathering lines and mutable standard lines are removed with draft credit effects corrected, while immutable invoice lines remain in place and keep their booked ledger effects.

## Notes for reviewer

Shrink and extend behavior remains out of scope for this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full credit-then-invoice lifecycle for flat-fee charges with a dedicated state machine
  * Assign invoice lines to ongoing flat-fee realization runs

* **Improvements**
  * New active-realization and awaiting-payment statuses; service-period-aware scheduling (advance-after)
  * State-machine-driven handling for invoicing, collection, payment, deletion, mutable-line cleanup, and auto-advance timing
  * Line engine now orchestrates most flat-fee lifecycle events; clearer separation of lifecycle callbacks

* **Documentation**
  * Added rules for flat-fee credit-then-invoice lifecycle and line-engine behavior

* **Tests**
  * Extensive new and updated tests covering credit-then-invoice flows, transitions, deletions, and timing behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->