### PR TITLE
fix: validating ratecard with feature

### DIFF
--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -42,6 +42,8 @@ type RateCard interface {
 	Compatible(RateCard) error
 	GetBillingCadence() *datetime.ISODuration
 	IsBillable() bool
+
+	HasFeature() bool
 }
 
 type RateCardSerde struct {
@@ -88,6 +90,10 @@ type RateCardMeta struct {
 
 	// Discounts defines a list of discounts for the RateCard
 	Discounts Discounts `json:"discounts,omitempty"`
+}
+
+func (r RateCardMeta) HasFeature() bool {
+	return lo.FromPtr(r.FeatureID) != "" || lo.FromPtr(r.FeatureKey) != ""
 }
 
 func (r RateCardMeta) Clone() RateCardMeta {
@@ -191,7 +197,7 @@ func (r RateCardMeta) Validate() error {
 	var errs []error
 
 	if r.EntitlementTemplate != nil {
-		if r.FeatureKey == nil {
+		if !r.HasFeature() {
 			errs = append(errs, ErrRateCardEntitlementTemplateWithNoFeature)
 		}
 
@@ -227,7 +233,7 @@ func (r RateCardMeta) Validate() error {
 
 		// Ratecard with usage-based price type must have feature key.
 		if r.Price.Type() != FlatPriceType {
-			if r.FeatureKey == nil {
+			if !r.HasFeature() {
 				errs = append(errs, ErrRateCardUsageBasedPriceWithNoFeature)
 			}
 		}

--- a/openmeter/subscription/addon/extend_test.go
+++ b/openmeter/subscription/addon/extend_test.go
@@ -874,6 +874,10 @@ func TestExtendRestore(t *testing.T) {
 
 type nonPointerRateCard struct{}
 
+func (n nonPointerRateCard) HasFeature() bool {
+	return false
+}
+
 var _ productcatalog.RateCard = nonPointerRateCard{}
 
 func (n nonPointerRateCard) IsBillable() bool {


### PR DESCRIPTION
## Overview

Fix evaluating both _FeatureID_ and _FeatureKey_ for _Ratecard_ in order to determine whether it has _Feature_ assigned or not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Strengthened validation for rate cards to ensure entitlement templates and usage-based pricing require a linked feature, improving consistency and preventing invalid configurations.

* **Tests**
  * Updated test doubles and validation tests to align with the enhanced rate card validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4352)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->