### PR TITLE
refactor: rename flat fee credit allocation handler

### DIFF
--- a/openmeter/billing/charges/flatfee/handler.go
+++ b/openmeter/billing/charges/flatfee/handler.go
@@ -17,13 +17,15 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-type OnAssignedToInvoiceInput struct {
-	Charge            Charge                `json:"charge"`
-	ServicePeriod     timeutil.ClosedPeriod `json:"servicePeriod"`
-	PreTaxTotalAmount alpacadecimal.Decimal `json:"totalAmount"`
+type OnAllocateCreditsInput struct {
+	Charge        Charge                `json:"charge"`
+	ServicePeriod timeutil.ClosedPeriod `json:"servicePeriod"`
+	// PreTaxAmountToAllocate is the pre-tax amount to allocate from credits.
+	// The input charge's settlement mode governs whether this may create a negative balance.
+	PreTaxAmountToAllocate alpacadecimal.Decimal `json:"preTaxAmountToAllocate"`
 }
 
-func (i OnAssignedToInvoiceInput) Validate() error {
+func (i OnAllocateCreditsInput) Validate() error {
 	var errs []error
 
 	if err := i.Charge.Validate(); err != nil {
@@ -34,8 +36,8 @@ func (i OnAssignedToInvoiceInput) Validate() error {
 		errs = append(errs, fmt.Errorf("service period: %w", err))
 	}
 
-	if i.PreTaxTotalAmount.IsNegative() {
-		errs = append(errs, fmt.Errorf("pre tax total amount cannot be negative"))
+	if i.PreTaxAmountToAllocate.IsNegative() {
+		errs = append(errs, fmt.Errorf("pre tax amount to allocate cannot be negative"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
@@ -65,26 +67,7 @@ func (i OnInvoiceUsageAccruedInput) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
-type OnCreditsOnlyUsageAccruedInput struct {
-	Charge           Charge                `json:"charge"`
-	AmountToAllocate alpacadecimal.Decimal `json:"amountToAllocate"`
-}
-
-func (i OnCreditsOnlyUsageAccruedInput) Validate() error {
-	var errs []error
-
-	if err := i.Charge.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("charge: %w", err))
-	}
-
-	if i.AmountToAllocate.IsNegative() {
-		errs = append(errs, fmt.Errorf("amount to allocate cannot be negative"))
-	}
-
-	return models.NewNillableGenericValidationError(errors.Join(errs...))
-}
-
-type CreditsOnlyUsageAccruedCorrectionInput struct {
+type CorrectCreditAllocationsInput struct {
 	Charge     Charge    `json:"charge"`
 	AllocateAt time.Time `json:"allocateAt"`
 
@@ -92,7 +75,7 @@ type CreditsOnlyUsageAccruedCorrectionInput struct {
 	LineageSegmentsByRealization lineage.ActiveSegmentsByRealizationID `json:"-"`
 }
 
-func (i CreditsOnlyUsageAccruedCorrectionInput) Validate() error {
+func (i CorrectCreditAllocationsInput) Validate() error {
 	var errs []error
 
 	if err := i.Charge.Validate(); err != nil {
@@ -106,7 +89,7 @@ func (i CreditsOnlyUsageAccruedCorrectionInput) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
-func (i CreditsOnlyUsageAccruedCorrectionInput) ValidateWith(currencyCalculator currencyx.Calculator) error {
+func (i CorrectCreditAllocationsInput) ValidateWith(currencyCalculator currencyx.Calculator) error {
 	var errs []error
 
 	if err := i.Validate(); err != nil {
@@ -145,18 +128,14 @@ type (
 )
 
 type Handler interface {
-	// OnFlatFeeAssignedToInvoice is called when a flat fee is being assigned to an invoice
-	OnAssignedToInvoice(ctx context.Context, input OnAssignedToInvoiceInput) (creditrealization.CreateAllocationInputs, error)
+	// OnAllocateCredits is called when a flat fee allocates credits.
+	OnAllocateCredits(ctx context.Context, input OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error)
 
 	// OnFlatFeeStandardInvoiceUsageAccrued is called when the remaining usage is sent to the customer on a standard invoice.
 	OnInvoiceUsageAccrued(ctx context.Context, input OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
 
-	// OnCreditsOnlyUsageAccrued is called when a credit-only flat fee reaches invoice_at
-	// and the full amount needs to be allocated as credits.
-	OnCreditsOnlyUsageAccrued(ctx context.Context, input OnCreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
-
-	// OnCreditsOnlyUsageAccruedCorrection is called when a credit allocation needs to be corrected.
-	OnCreditsOnlyUsageAccruedCorrection(ctx context.Context, input CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error)
+	// OnCorrectCreditAllocations is called when a credit allocation needs to be corrected.
+	OnCorrectCreditAllocations(ctx context.Context, input CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
 
 	// OnFlatFeePaymentAuthorized is called when a flat fee payment is authorized.
 	OnPaymentAuthorized(ctx context.Context, input OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)

--- a/openmeter/billing/charges/flatfee/service/realizations/correct.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/correct.go
@@ -57,7 +57,7 @@ func (s *Service) CorrectAllCredits(ctx context.Context, in CorrectAllCreditReal
 	}
 
 	corrections, err := in.Run.CreditRealizations.CorrectAll(in.CurrencyCalculator, func(req creditrealization.CorrectionRequest) (creditrealization.CreateCorrectionInputs, error) {
-		return s.handler.OnCreditsOnlyUsageAccruedCorrection(ctx, flatfee.CreditsOnlyUsageAccruedCorrectionInput{
+		return s.handler.OnCorrectCreditAllocations(ctx, flatfee.CorrectCreditAllocationsInput{
 			Charge:                       in.Charge,
 			AllocateAt:                   in.AllocateAt,
 			Corrections:                  req,

--- a/openmeter/billing/charges/flatfee/service/realizations/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/creditsonly.go
@@ -53,17 +53,18 @@ func (s *Service) AllocateCreditsOnly(ctx context.Context, in AllocateCreditsOnl
 		return AllocateCreditsOnlyResult{}, nil
 	}
 
-	input := flatfee.OnCreditsOnlyUsageAccruedInput{
-		Charge:           in.Charge,
-		AmountToAllocate: in.Amount,
+	input := flatfee.OnAllocateCreditsInput{
+		Charge:                 in.Charge,
+		ServicePeriod:          in.Charge.Intent.ServicePeriod,
+		PreTaxAmountToAllocate: in.Amount,
 	}
 	if err := input.Validate(); err != nil {
 		return AllocateCreditsOnlyResult{}, fmt.Errorf("validate input: %w", err)
 	}
 
-	creditAllocations, err := s.handler.OnCreditsOnlyUsageAccrued(ctx, input)
+	creditAllocations, err := s.handler.OnAllocateCredits(ctx, input)
 	if err != nil {
-		return AllocateCreditsOnlyResult{}, fmt.Errorf("on credits only usage accrued: %w", err)
+		return AllocateCreditsOnlyResult{}, fmt.Errorf("allocate credits: %w", err)
 	}
 
 	allocated := in.CurrencyCalculator.RoundToPrecision(creditAllocations.Sum())

--- a/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
@@ -101,18 +101,18 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 		}
 
 		if !amountAfterProration.IsZero() {
-			handlerInput := flatfee.OnAssignedToInvoiceInput{
-				Charge:            charge,
-				ServicePeriod:     in.Line.Period,
-				PreTaxTotalAmount: amountAfterProration,
+			handlerInput := flatfee.OnAllocateCreditsInput{
+				Charge:                 charge,
+				ServicePeriod:          in.Line.Period,
+				PreTaxAmountToAllocate: amountAfterProration,
 			}
 			if err := handlerInput.Validate(); err != nil {
-				return StartCreditThenInvoiceRunResult{}, fmt.Errorf("validating on assigned to invoice input: %w", err)
+				return StartCreditThenInvoiceRunResult{}, fmt.Errorf("validating allocate credits input: %w", err)
 			}
 
-			creditAllocations, err := s.handler.OnAssignedToInvoice(ctx, handlerInput)
+			creditAllocations, err := s.handler.OnAllocateCredits(ctx, handlerInput)
 			if err != nil {
-				return StartCreditThenInvoiceRunResult{}, fmt.Errorf("on flat fee assigned to invoice: %w", err)
+				return StartCreditThenInvoiceRunResult{}, fmt.Errorf("allocate credits for flat fee: %w", err)
 			}
 
 			creditAllocationsWithLineID := append(creditrealization.CreateAllocationInputs(nil), creditAllocations...)

--- a/openmeter/billing/charges/service/handlers_test.go
+++ b/openmeter/billing/charges/service/handlers_test.go
@@ -18,25 +18,24 @@ import (
 var _ flatfee.Handler = (*flatFeeTestHandler)(nil)
 
 type flatFeeTestHandler struct {
-	onAssignedToInvoice                 func(ctx context.Context, input flatfee.OnAssignedToInvoiceInput) (creditrealization.CreateAllocationInputs, error)
-	onInvoiceUsageAccrued               func(ctx context.Context, input flatfee.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
-	onCreditsOnlyUsageAccrued           func(ctx context.Context, input flatfee.OnCreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error)
-	onCreditsOnlyUsageAccruedCorrection func(ctx context.Context, input flatfee.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error)
-	onPaymentAuthorized                 func(ctx context.Context, input flatfee.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
-	onPaymentSettled                    func(ctx context.Context, input flatfee.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
-	onPaymentUncollectible              func(ctx context.Context, charge flatfee.Charge) (ledgertransaction.GroupReference, error)
+	onAllocateCredits          func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error)
+	onInvoiceUsageAccrued      func(ctx context.Context, input flatfee.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error)
+	onCorrectCreditAllocations func(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error)
+	onPaymentAuthorized        func(ctx context.Context, input flatfee.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error)
+	onPaymentSettled           func(ctx context.Context, input flatfee.OnPaymentSettledInput) (ledgertransaction.GroupReference, error)
+	onPaymentUncollectible     func(ctx context.Context, charge flatfee.Charge) (ledgertransaction.GroupReference, error)
 }
 
 func newFlatFeeTestHandler() *flatFeeTestHandler {
 	return &flatFeeTestHandler{}
 }
 
-func (h *flatFeeTestHandler) OnAssignedToInvoice(ctx context.Context, input flatfee.OnAssignedToInvoiceInput) (creditrealization.CreateAllocationInputs, error) {
-	if h.onAssignedToInvoice == nil {
-		return nil, errors.New("onAssignedToInvoice is not set")
+func (h *flatFeeTestHandler) OnAllocateCredits(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
+	if h.onAllocateCredits == nil {
+		return nil, errors.New("onAllocateCredits is not set")
 	}
 
-	return h.onAssignedToInvoice(ctx, input)
+	return h.onAllocateCredits(ctx, input)
 }
 
 func (h *flatFeeTestHandler) OnInvoiceUsageAccrued(ctx context.Context, input flatfee.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error) {
@@ -47,20 +46,12 @@ func (h *flatFeeTestHandler) OnInvoiceUsageAccrued(ctx context.Context, input fl
 	return h.onInvoiceUsageAccrued(ctx, input)
 }
 
-func (h *flatFeeTestHandler) OnCreditsOnlyUsageAccrued(ctx context.Context, input flatfee.OnCreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
-	if h.onCreditsOnlyUsageAccrued == nil {
-		return nil, errors.New("onCreditsOnlyUsageAccrued is not set")
+func (h *flatFeeTestHandler) OnCorrectCreditAllocations(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
+	if h.onCorrectCreditAllocations == nil {
+		return nil, errors.New("onCorrectCreditAllocations is not set")
 	}
 
-	return h.onCreditsOnlyUsageAccrued(ctx, input)
-}
-
-func (h *flatFeeTestHandler) OnCreditsOnlyUsageAccruedCorrection(ctx context.Context, input flatfee.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error) {
-	if h.onCreditsOnlyUsageAccruedCorrection == nil {
-		return nil, errors.New("onCreditsOnlyUsageAccruedCorrection is not set")
-	}
-
-	return h.onCreditsOnlyUsageAccruedCorrection(ctx, input)
+	return h.onCorrectCreditAllocations(ctx, input)
 }
 
 func (h *flatFeeTestHandler) OnPaymentAuthorized(ctx context.Context, input flatfee.OnPaymentAuthorizedInput) (ledgertransaction.GroupReference, error) {

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -130,13 +130,13 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 
 		testTrnsGroupID := ulid.Make().String()
 		creditRealizationCallbackInvocations := 0
-		s.FlatFeeTestHandler.onAssignedToInvoice = func(ctx context.Context, input flatfee.OnAssignedToInvoiceInput) (creditrealization.CreateAllocationInputs, error) {
+		s.FlatFeeTestHandler.onAllocateCredits = func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 			creditRealizationCallbackInvocations++
 
 			return creditrealization.CreateAllocationInputs{
 				{
 					ServicePeriod: input.ServicePeriod,
-					Amount:        input.PreTaxTotalAmount.Mul(alpacadecimal.NewFromFloat(0.3)), // 30% as credits
+					Amount:        input.PreTaxAmountToAllocate.Mul(alpacadecimal.NewFromFloat(0.3)), // 30% as credits
 					LedgerTransaction: ledgertransaction.GroupReference{
 						TransactionGroupID: testTrnsGroupID,
 					},
@@ -397,10 +397,10 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceInAdvanceWithPr
 	s.Run("when the charge becomes active and draft invoice is created", func() {
 		defer s.FlatFeeTestHandler.Reset()
 
-		creditAllocationCallback := newCountedCreditAllocationCallback[flatfee.OnAssignedToInvoiceInput]()
-		s.FlatFeeTestHandler.onAssignedToInvoice = creditAllocationCallback.Handler(
+		creditAllocationCallback := newCountedCreditAllocationCallback[flatfee.OnAllocateCreditsInput]()
+		s.FlatFeeTestHandler.onAllocateCredits = creditAllocationCallback.Handler(
 			s.T(),
-			func(input flatfee.OnAssignedToInvoiceInput, ledgerTransaction ledgertransaction.GroupReference) creditrealization.CreateAllocationInputs {
+			func(input flatfee.OnAllocateCreditsInput, ledgerTransaction ledgertransaction.GroupReference) creditrealization.CreateAllocationInputs {
 				return creditrealization.CreateAllocationInputs{
 					{
 						ServicePeriod:     input.ServicePeriod,
@@ -409,10 +409,10 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceInAdvanceWithPr
 					},
 				}
 			},
-			func(t *testing.T, input flatfee.OnAssignedToInvoiceInput) {
+			func(t *testing.T, input flatfee.OnAllocateCreditsInput) {
 				assert.Equal(t, flatFeeChargeID.ID, input.Charge.ID)
 				assert.Equal(t, servicePeriod, input.ServicePeriod)
-				assert.Equal(t, float64(7), input.PreTaxTotalAmount.InexactFloat64())
+				assert.Equal(t, float64(7), input.PreTaxAmountToAllocate.InexactFloat64())
 			},
 		)
 
@@ -528,11 +528,11 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 	s.Run("invoice pending lines fully settled by credits", func() {
 		defer s.FlatFeeTestHandler.Reset()
 
-		s.FlatFeeTestHandler.onAssignedToInvoice = func(ctx context.Context, input flatfee.OnAssignedToInvoiceInput) (creditrealization.CreateAllocationInputs, error) {
+		s.FlatFeeTestHandler.onAllocateCredits = func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 			return creditrealization.CreateAllocationInputs{
 				{
 					ServicePeriod: input.ServicePeriod,
-					Amount:        input.PreTaxTotalAmount,
+					Amount:        input.PreTaxAmountToAllocate,
 					LedgerTransaction: ledgertransaction.GroupReference{
 						TransactionGroupID: ulid.Make().String(),
 					},
@@ -628,7 +628,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountNonZe
 		// - billing invoices pending lines at the service period start
 		// then:
 		// - the draft invoice has one standard line and the charge has a mutable run
-		s.FlatFeeTestHandler.onAssignedToInvoice = func(context.Context, flatfee.OnAssignedToInvoiceInput) (creditrealization.CreateAllocationInputs, error) {
+		s.FlatFeeTestHandler.onAllocateCredits = func(context.Context, flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 			return nil, nil
 		}
 
@@ -2231,18 +2231,18 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 		defer s.FlatFeeTestHandler.Reset()
 
 		type callbackInvocation struct {
-			Input flatfee.OnCreditsOnlyUsageAccruedInput
+			Input flatfee.OnAllocateCreditsInput
 		}
 
 		var callbacks []callbackInvocation
 
-		s.FlatFeeTestHandler.onCreditsOnlyUsageAccrued = func(ctx context.Context, input flatfee.OnCreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
+		s.FlatFeeTestHandler.onAllocateCredits = func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 			callbacks = append(callbacks, callbackInvocation{Input: input})
 
 			return creditrealization.CreateAllocationInputs{
 				{
 					ServicePeriod: input.Charge.Intent.ServicePeriod,
-					Amount:        input.AmountToAllocate,
+					Amount:        input.PreTaxAmountToAllocate,
 					LedgerTransaction: ledgertransaction.GroupReference{
 						TransactionGroupID: ulid.Make().String(),
 					},
@@ -2271,7 +2271,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 
 		// The handler was called exactly once with the correct amount.
 		s.Len(callbacks, 1)
-		s.Equal(float64(100), callbacks[0].Input.AmountToAllocate.InexactFloat64())
+		s.Equal(float64(100), callbacks[0].Input.PreTaxAmountToAllocate.InexactFloat64())
 
 		// Credit realizations were persisted.
 		s.Require().NotNil(fetchedFF.Realizations.CurrentRun)
@@ -2316,11 +2316,11 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyCreateImmediatelyFinal
 		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
 	}
 
-	s.FlatFeeTestHandler.onCreditsOnlyUsageAccrued = func(ctx context.Context, input flatfee.OnCreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
+	s.FlatFeeTestHandler.onAllocateCredits = func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 		return creditrealization.CreateAllocationInputs{
 			{
 				ServicePeriod: input.Charge.Intent.ServicePeriod,
-				Amount:        input.AmountToAllocate,
+				Amount:        input.PreTaxAmountToAllocate,
 				LedgerTransaction: ledgertransaction.GroupReference{
 					TransactionGroupID: ulid.Make().String(),
 				},
@@ -2398,12 +2398,12 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyInArrearsActivatesAtSe
 	}
 	createAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-01T00:00:00Z", time.UTC).AsTime()
 
-	creditsOnlyUsageAccruedCallback := newCountedCreditAllocationCallback[flatfee.OnCreditsOnlyUsageAccruedInput]()
-	s.FlatFeeTestHandler.onCreditsOnlyUsageAccrued = creditsOnlyUsageAccruedCallback.Handler(s.T(), func(input flatfee.OnCreditsOnlyUsageAccruedInput, ledgerTransaction ledgertransaction.GroupReference) creditrealization.CreateAllocationInputs {
+	allocateCreditsCallback := newCountedCreditAllocationCallback[flatfee.OnAllocateCreditsInput]()
+	s.FlatFeeTestHandler.onAllocateCredits = allocateCreditsCallback.Handler(s.T(), func(input flatfee.OnAllocateCreditsInput, ledgerTransaction ledgertransaction.GroupReference) creditrealization.CreateAllocationInputs {
 		return creditrealization.CreateAllocationInputs{
 			{
 				ServicePeriod:     input.Charge.Intent.ServicePeriod,
-				Amount:            input.AmountToAllocate,
+				Amount:            input.PreTaxAmountToAllocate,
 				LedgerTransaction: ledgerTransaction,
 			},
 		}
@@ -2439,7 +2439,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyInArrearsActivatesAtSe
 	s.NotNil(createdCharge.State.AdvanceAfter)
 	s.True(servicePeriod.From.Equal(*createdCharge.State.AdvanceAfter))
 	s.Nil(createdCharge.Realizations.CurrentRun)
-	s.Zero(creditsOnlyUsageAccruedCallback.nrInvocations)
+	s.Zero(allocateCreditsCallback.nrInvocations)
 
 	clock.FreezeTime(servicePeriod.From)
 	advancedCharges := s.mustAdvanceFlatFeeCharges(ctx, cust.GetID())
@@ -2450,7 +2450,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyInArrearsActivatesAtSe
 	s.NotNil(activeCharge.State.AdvanceAfter)
 	s.True(servicePeriod.To.Equal(*activeCharge.State.AdvanceAfter))
 	s.Nil(activeCharge.Realizations.CurrentRun)
-	s.Zero(creditsOnlyUsageAccruedCallback.nrInvocations)
+	s.Zero(allocateCreditsCallback.nrInvocations)
 
 	clock.FreezeTime(servicePeriod.To)
 	advancedCharges = s.mustAdvanceFlatFeeCharges(ctx, cust.GetID())
@@ -2462,7 +2462,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyInArrearsActivatesAtSe
 	s.Require().NotNil(finalCharge.Realizations.CurrentRun)
 	s.Len(finalCharge.Realizations.CurrentRun.CreditRealizations, 1)
 	s.Equal(float64(75), finalCharge.Realizations.CurrentRun.CreditRealizations[0].Amount.InexactFloat64())
-	s.Equal(1, creditsOnlyUsageAccruedCallback.nrInvocations)
+	s.Equal(1, allocateCreditsCallback.nrInvocations)
 }
 
 func (s *InvoicableChargesTestSuite) mustAdvanceFlatFeeCharges(ctx context.Context, customerID customer.CustomerID) charges.Charges {

--- a/openmeter/billing/charges/service/lineage_test.go
+++ b/openmeter/billing/charges/service/lineage_test.go
@@ -73,7 +73,7 @@ func (s *CreditRealizationLineageTestSuite) TestFlatFeeCreditOnlyAllocationCreat
 		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
 	}
 
-	s.FlatFeeTestHandler.onCreditsOnlyUsageAccrued = func(ctx context.Context, input flatfee.OnCreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
+	s.FlatFeeTestHandler.onAllocateCredits = func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 		return creditrealization.CreateAllocationInputs{
 			{
 				ServicePeriod: input.Charge.Intent.ServicePeriod,

--- a/openmeter/billing/charges/service/taxcode_test.go
+++ b/openmeter/billing/charges/service/taxcode_test.go
@@ -555,13 +555,13 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeCreditOnlyHandlerReceivesTaxCon
 	s.NoError(err)
 	s.Require().Len(res, 1)
 
-	var capturedInput flatfee.OnCreditsOnlyUsageAccruedInput
-	s.FlatFeeTestHandler.onCreditsOnlyUsageAccrued = func(_ context.Context, input flatfee.OnCreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
+	var capturedInput flatfee.OnAllocateCreditsInput
+	s.FlatFeeTestHandler.onAllocateCredits = func(_ context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 		capturedInput = input
 		return creditrealization.CreateAllocationInputs{
 			{
 				ServicePeriod: input.Charge.Intent.ServicePeriod,
-				Amount:        input.AmountToAllocate,
+				Amount:        input.PreTaxAmountToAllocate,
 				LedgerTransaction: ledgertransaction.GroupReference{
 					TransactionGroupID: ulid.Make().String(),
 				},
@@ -710,7 +710,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementPopulatesStrip
 	})
 	s.NoError(err)
 
-	s.FlatFeeTestHandler.onAssignedToInvoice = func(_ context.Context, input flatfee.OnAssignedToInvoiceInput) (creditrealization.CreateAllocationInputs, error) {
+	s.FlatFeeTestHandler.onAllocateCredits = func(_ context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 		return creditrealization.CreateAllocationInputs{}, nil
 	}
 

--- a/openmeter/billing/charges/testutils/handlers.go
+++ b/openmeter/billing/charges/testutils/handlers.go
@@ -31,25 +31,21 @@ type mockFlatFeeHandler struct{}
 
 var _ flatfee.Handler = (*mockFlatFeeHandler)(nil)
 
-func (mockFlatFeeHandler) OnAssignedToInvoice(context.Context, flatfee.OnAssignedToInvoiceInput) (creditrealization.CreateAllocationInputs, error) {
-	return nil, nil
+func (mockFlatFeeHandler) OnAllocateCredits(_ context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
+	return creditrealization.CreateAllocationInputs{
+		{
+			ServicePeriod:     input.ServicePeriod,
+			LedgerTransaction: newMockLedgerTransactionGroupReference(),
+			Amount:            input.PreTaxAmountToAllocate,
+		},
+	}, nil
 }
 
 func (mockFlatFeeHandler) OnInvoiceUsageAccrued(context.Context, flatfee.OnInvoiceUsageAccruedInput) (ledgertransaction.GroupReference, error) {
 	return newMockLedgerTransactionGroupReference(), nil
 }
 
-func (mockFlatFeeHandler) OnCreditsOnlyUsageAccrued(_ context.Context, input flatfee.OnCreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
-	return creditrealization.CreateAllocationInputs{
-		{
-			ServicePeriod:     input.Charge.Intent.ServicePeriod,
-			LedgerTransaction: newMockLedgerTransactionGroupReference(),
-			Amount:            input.AmountToAllocate,
-		},
-	}, nil
-}
-
-func (mockFlatFeeHandler) OnCreditsOnlyUsageAccruedCorrection(_ context.Context, input flatfee.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error) {
+func (mockFlatFeeHandler) OnCorrectCreditAllocations(_ context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
 	return lo.Map(input.Corrections, func(correction creditrealization.CorrectionRequestItem, _ int) creditrealization.CreateCorrectionInput {
 		return creditrealization.CreateCorrectionInput{
 			LedgerTransaction:     newMockLedgerTransactionGroupReference(),

--- a/openmeter/billing/charges/testutils/handlers.go
+++ b/openmeter/billing/charges/testutils/handlers.go
@@ -32,6 +32,10 @@ type mockFlatFeeHandler struct{}
 var _ flatfee.Handler = (*mockFlatFeeHandler)(nil)
 
 func (mockFlatFeeHandler) OnAllocateCredits(_ context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
+	if input.PreTaxAmountToAllocate.IsZero() {
+		return nil, nil
+	}
+
 	return creditrealization.CreateAllocationInputs{
 		{
 			ServicePeriod:     input.ServicePeriod,

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -39,23 +39,23 @@ func NewFlatFeeHandler(
 	}
 }
 
-// OnFlatFeeAssignedToInvoice is called when a flat fee is being assigned to an invoice.
 // This acknowledges FBO-backed usage on the ledger by consuming value from prioritized
 // customer FBO subaccounts and moving it into customer_accrued. This is NOT revenue recognition.
-func (h *flatFeeHandler) OnAssignedToInvoice(ctx context.Context, input flatfee.OnAssignedToInvoiceInput) (creditrealization.CreateAllocationInputs, error) {
+func (h *flatFeeHandler) OnAllocateCredits(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 	if err := input.Validate(); err != nil {
 		return nil, err
 	}
 
-	if input.PreTaxTotalAmount.IsZero() {
+	if input.PreTaxAmountToAllocate.IsZero() {
 		return nil, nil
 	}
 
 	if err := validateSettlementMode(
 		input.Charge.Intent.SettlementMode,
 		productcatalog.CreditThenInvoiceSettlementMode,
+		productcatalog.CreditOnlySettlementMode,
 	); err != nil {
-		return nil, fmt.Errorf("assigned to invoice: %w", err)
+		return nil, fmt.Errorf("allocate credits: %w", err)
 	}
 
 	realizations, err := h.collector.CollectToAccrued(ctx, collector.CollectToAccruedInput{
@@ -67,7 +67,7 @@ func (h *flatFeeHandler) OnAssignedToInvoice(ctx context.Context, input flatfee.
 		Currency:       input.Charge.Intent.Currency,
 		SettlementMode: input.Charge.Intent.SettlementMode,
 		ServicePeriod:  input.ServicePeriod,
-		Amount:         input.PreTaxTotalAmount,
+		Amount:         input.PreTaxAmountToAllocate,
 	})
 	if err != nil {
 		return nil, err
@@ -143,43 +143,7 @@ func (h *flatFeeHandler) OnInvoiceUsageAccrued(ctx context.Context, input flatfe
 	}, nil
 }
 
-// OnCreditsOnlyUsageAccrued is called when a credit-only flat fee becomes active.
-// It consumes value from prioritized customer FBO subaccounts and moves it into customer_accrued.
-func (h *flatFeeHandler) OnCreditsOnlyUsageAccrued(ctx context.Context, input flatfee.OnCreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
-	if err := input.Validate(); err != nil {
-		return nil, err
-	}
-
-	if input.AmountToAllocate.IsZero() {
-		return nil, nil
-	}
-
-	if err := validateSettlementMode(input.Charge.Intent.SettlementMode, productcatalog.CreditOnlySettlementMode); err != nil {
-		return nil, fmt.Errorf("credits only usage accrued: %w", err)
-	}
-
-	realizations, err := h.collector.CollectToAccrued(ctx, collector.CollectToAccruedInput{
-		Namespace:      input.Charge.Namespace,
-		ChargeID:       input.Charge.ID,
-		CustomerID:     input.Charge.Intent.CustomerID,
-		Annotations:    chargeAnnotationsForFlatFeeCharge(input.Charge),
-		At:             input.Charge.Intent.InvoiceAt,
-		Currency:       input.Charge.Intent.Currency,
-		SettlementMode: input.Charge.Intent.SettlementMode,
-		ServicePeriod:  input.Charge.Intent.ServicePeriod,
-		Amount:         input.AmountToAllocate,
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(realizations) == 0 {
-		return nil, nil
-	}
-
-	return realizations, nil
-}
-
-func (h *flatFeeHandler) OnCreditsOnlyUsageAccruedCorrection(ctx context.Context, input flatfee.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error) {
+func (h *flatFeeHandler) OnCorrectCreditAllocations(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
 	currencyCalculator, err := input.Charge.Intent.Currency.Calculator()
 	if err != nil {
 		return nil, fmt.Errorf("get currency calculator: %w", err)

--- a/openmeter/ledger/chargeadapter/flatfee_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_test.go
@@ -33,14 +33,14 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func TestOnFlatFeeAssignedToInvoice(t *testing.T) {
+func TestOnAllocateCredits(t *testing.T) {
 	t.Run("credit_then_invoice single bucket full coverage lands in accrued", func(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 
 		priorityOne := env.fundPriority(t, 1, 100)
 		input := env.newAssignmentInput(alpacadecimal.NewFromInt(60))
 
-		realizations, err := env.handler.OnAssignedToInvoice(t.Context(), input)
+		realizations, err := env.handler.OnAllocateCredits(t.Context(), input)
 		require.NoError(t, err)
 		require.Len(t, realizations, 1)
 		require.True(t, realizations[0].Amount.Equal(alpacadecimal.NewFromInt(60)))
@@ -62,7 +62,7 @@ func TestOnFlatFeeAssignedToInvoice(t *testing.T) {
 		priorityTwo := env.fundPriority(t, 2, 50)
 		priorityOne := env.fundPriority(t, 1, 30)
 
-		realizations, err := env.handler.OnAssignedToInvoice(t.Context(), env.newAssignmentInput(alpacadecimal.NewFromInt(60)))
+		realizations, err := env.handler.OnAllocateCredits(t.Context(), env.newAssignmentInput(alpacadecimal.NewFromInt(60)))
 		require.NoError(t, err)
 		require.Len(t, realizations, 2)
 		require.True(t, realizations[0].Amount.Equal(alpacadecimal.NewFromInt(30)))
@@ -81,7 +81,7 @@ func TestOnFlatFeeAssignedToInvoice(t *testing.T) {
 		priorityOne := env.fundPriority(t, 1, 10)
 		priorityTwo := env.fundPriority(t, 2, 5)
 
-		realizations, err := env.handler.OnAssignedToInvoice(t.Context(), env.newAssignmentInput(alpacadecimal.NewFromInt(30)))
+		realizations, err := env.handler.OnAllocateCredits(t.Context(), env.newAssignmentInput(alpacadecimal.NewFromInt(30)))
 		require.NoError(t, err)
 		require.Len(t, realizations, 2)
 		require.True(t, realizations[0].Amount.Equal(alpacadecimal.NewFromInt(10)))
@@ -99,30 +99,31 @@ func TestOnFlatFeeAssignedToInvoice(t *testing.T) {
 
 		priorityOne := env.fundPriority(t, 1, 100)
 
-		realizations, err := env.handler.OnAssignedToInvoice(t.Context(), env.newAssignmentInput(alpacadecimal.NewFromInt(0)))
+		realizations, err := env.handler.OnAllocateCredits(t.Context(), env.newAssignmentInput(alpacadecimal.NewFromInt(0)))
 		require.NoError(t, err)
 		require.Nil(t, realizations)
 		require.True(t, env.sumBalance(t, priorityOne).Equal(alpacadecimal.NewFromInt(100)))
 		require.True(t, env.sumBalance(t, env.creditAccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(0)))
 	})
 
-	t.Run("credit_only returns an error from invoice assignment handler", func(t *testing.T) {
+	t.Run("credit_only settlement mode is accepted", func(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 
-		realizations, err := env.handler.OnAssignedToInvoice(t.Context(), env.newAssignmentInputWithMode(alpacadecimal.NewFromInt(30), productcatalog.CreditOnlySettlementMode))
-		require.Error(t, err)
-		require.Nil(t, realizations)
+		realizations, err := env.handler.OnAllocateCredits(t.Context(), env.newAssignmentInputWithMode(alpacadecimal.NewFromInt(30), productcatalog.CreditOnlySettlementMode))
+		require.NoError(t, err)
+		require.Len(t, realizations, 1)
+		require.True(t, realizations[0].Amount.Equal(alpacadecimal.NewFromInt(30)))
 	})
 }
 
-func TestOnFlatFeeCreditsOnlyUsageAccrued(t *testing.T) {
+func TestOnAllocateCreditsCreditOnly(t *testing.T) {
 	t.Run("credit_only advances uncovered amount", func(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 
-		realizations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeflatfee.OnCreditsOnlyUsageAccruedInput{
-			Charge:           env.newCreditsOnlyCharge(alpacadecimal.NewFromInt(30)),
-			AmountToAllocate: alpacadecimal.NewFromInt(30),
-		})
+		realizations, err := env.handler.OnAllocateCredits(t.Context(), env.newAllocateCreditsInputForCharge(
+			env.newCreditsOnlyCharge(alpacadecimal.NewFromInt(30)),
+			alpacadecimal.NewFromInt(30),
+		))
 		require.NoError(t, err)
 		require.Len(t, realizations, 1)
 		require.True(t, realizations[0].Amount.Equal(alpacadecimal.NewFromInt(30)))
@@ -135,35 +136,21 @@ func TestOnFlatFeeCreditsOnlyUsageAccrued(t *testing.T) {
 	t.Run("credit_only zero amount returns no realization", func(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 
-		realizations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeflatfee.OnCreditsOnlyUsageAccruedInput{
-			Charge:           env.newCreditsOnlyCharge(alpacadecimal.NewFromInt(30)),
-			AmountToAllocate: alpacadecimal.Zero,
-		})
+		realizations, err := env.handler.OnAllocateCredits(t.Context(), env.newAllocateCreditsInputForCharge(
+			env.newCreditsOnlyCharge(alpacadecimal.NewFromInt(30)),
+			alpacadecimal.Zero,
+		))
 		require.NoError(t, err)
-		require.Nil(t, realizations)
-	})
-
-	t.Run("credit_then_invoice returns an error from credits-only accrual handler", func(t *testing.T) {
-		env := newFlatFeeHandlerTestEnv(t)
-
-		realizations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeflatfee.OnCreditsOnlyUsageAccruedInput{
-			Charge:           env.newBaseCharge(timeutil.ClosedPeriod{From: env.Now().Add(-time.Hour), To: env.Now()}, alpacadecimal.NewFromInt(30)),
-			AmountToAllocate: alpacadecimal.NewFromInt(30),
-		})
-		require.Error(t, err)
 		require.Nil(t, realizations)
 	})
 }
 
-func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
+func TestOnCorrectCreditAllocations(t *testing.T) {
 	t.Run("credit_only reverses advance-backed accrual", func(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 
 		charge := env.newCreditsOnlyCharge(alpacadecimal.NewFromInt(30))
-		allocations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeflatfee.OnCreditsOnlyUsageAccruedInput{
-			Charge:           charge,
-			AmountToAllocate: alpacadecimal.NewFromInt(30),
-		})
+		allocations, err := env.handler.OnAllocateCredits(t.Context(), env.newAllocateCreditsInputForCharge(charge, alpacadecimal.NewFromInt(30)))
 		require.NoError(t, err)
 		require.Len(t, allocations, 1)
 
@@ -176,7 +163,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
 		require.NoError(t, err)
 
-		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
+		corrections, err := env.handler.OnCorrectCreditAllocations(t.Context(), chargeflatfee.CorrectCreditAllocationsInput{
 			Charge:      chargeWithRealizations,
 			AllocateAt:  env.Now(),
 			Corrections: correctionsRequest,
@@ -197,10 +184,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		priorityOne := env.fundPriority(t, 1, 30)
 
 		charge := env.newCreditsOnlyCharge(alpacadecimal.NewFromInt(50))
-		allocations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeflatfee.OnCreditsOnlyUsageAccruedInput{
-			Charge:           charge,
-			AmountToAllocate: alpacadecimal.NewFromInt(50),
-		})
+		allocations, err := env.handler.OnAllocateCredits(t.Context(), env.newAllocateCreditsInputForCharge(charge, alpacadecimal.NewFromInt(50)))
 		require.NoError(t, err)
 		require.Len(t, allocations, 2)
 
@@ -213,7 +197,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-35), currencyCalculator)
 		require.NoError(t, err)
 
-		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
+		corrections, err := env.handler.OnCorrectCreditAllocations(t.Context(), chargeflatfee.CorrectCreditAllocationsInput{
 			Charge:      chargeWithRealizations,
 			AllocateAt:  env.Now(),
 			Corrections: correctionsRequest,
@@ -232,10 +216,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		priorityOne := env.fundPriority(t, 1, 20)
 
 		charge := env.newCreditsOnlyCharge(alpacadecimal.NewFromInt(30))
-		allocations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeflatfee.OnCreditsOnlyUsageAccruedInput{
-			Charge:           charge,
-			AmountToAllocate: alpacadecimal.NewFromInt(30),
-		})
+		allocations, err := env.handler.OnAllocateCredits(t.Context(), env.newAllocateCreditsInputForCharge(charge, alpacadecimal.NewFromInt(30)))
 		require.NoError(t, err)
 		require.Len(t, allocations, 2)
 
@@ -248,7 +229,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
 		require.NoError(t, err)
 
-		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
+		corrections, err := env.handler.OnCorrectCreditAllocations(t.Context(), chargeflatfee.CorrectCreditAllocationsInput{
 			Charge:      chargeWithRealizations,
 			AllocateAt:  env.Now(),
 			Corrections: correctionsRequest,
@@ -267,7 +248,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 		priorityOne := env.fundPriority(t, 1, 30)
 
-		allocations, err := env.handler.OnAssignedToInvoice(t.Context(), env.newAssignmentInput(alpacadecimal.NewFromInt(30)))
+		allocations, err := env.handler.OnAllocateCredits(t.Context(), env.newAssignmentInput(alpacadecimal.NewFromInt(30)))
 		require.NoError(t, err)
 		require.Len(t, allocations, 1)
 
@@ -279,7 +260,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
 		require.NoError(t, err)
 
-		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
+		corrections, err := env.handler.OnCorrectCreditAllocations(t.Context(), chargeflatfee.CorrectCreditAllocationsInput{
 			Charge:      chargeWithRealizations,
 			AllocateAt:  env.Now(),
 			Corrections: correctionsRequest,
@@ -296,7 +277,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 		priorityOne := env.fundPriority(t, 1, 30)
 
-		allocations, err := env.handler.OnAssignedToInvoice(t.Context(), env.newAssignmentInput(alpacadecimal.NewFromInt(30)))
+		allocations, err := env.handler.OnAllocateCredits(t.Context(), env.newAssignmentInput(alpacadecimal.NewFromInt(30)))
 		require.NoError(t, err)
 		require.Len(t, allocations, 1)
 
@@ -313,7 +294,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
 		require.NoError(t, err)
 
-		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
+		corrections, err := env.handler.OnCorrectCreditAllocations(t.Context(), chargeflatfee.CorrectCreditAllocationsInput{
 			Charge:                       chargeWithRealizations,
 			AllocateAt:                   env.Now(),
 			Corrections:                  correctionsRequest,
@@ -333,10 +314,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		priorityOne := env.fundPriority(t, 1, 30)
 
 		charge := env.newCreditsOnlyCharge(alpacadecimal.NewFromInt(30))
-		allocations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeflatfee.OnCreditsOnlyUsageAccruedInput{
-			Charge:           charge,
-			AmountToAllocate: alpacadecimal.NewFromInt(30),
-		})
+		allocations, err := env.handler.OnAllocateCredits(t.Context(), env.newAllocateCreditsInputForCharge(charge, alpacadecimal.NewFromInt(30)))
 		require.NoError(t, err)
 		require.Len(t, allocations, 1)
 
@@ -354,7 +332,7 @@ func TestOnFlatFeeCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
 		require.NoError(t, err)
 
-		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeflatfee.CreditsOnlyUsageAccruedCorrectionInput{
+		corrections, err := env.handler.OnCorrectCreditAllocations(t.Context(), chargeflatfee.CorrectCreditAllocationsInput{
 			Charge:                       chargeWithRealizations,
 			AllocateAt:                   env.Now(),
 			Corrections:                  correctionsRequest,
@@ -444,7 +422,7 @@ func TestOnFlatFeePaymentAuthorized(t *testing.T) {
 		env.fundPriority(t, 1, 40)
 
 		// FBO → accrued for 40
-		realizations, err := env.handler.OnAssignedToInvoice(t.Context(), env.newAssignmentInput(alpacadecimal.NewFromInt(60)))
+		realizations, err := env.handler.OnAllocateCredits(t.Context(), env.newAssignmentInput(alpacadecimal.NewFromInt(60)))
 		require.NoError(t, err)
 		require.Len(t, realizations, 1)
 		require.True(t, realizations[0].Amount.Equal(alpacadecimal.NewFromInt(40)))
@@ -497,10 +475,10 @@ func TestOnFlatFeePaymentAuthorized(t *testing.T) {
 
 		priorityOne := env.fundPriority(t, 1, 40)
 
-		realizations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeflatfee.OnCreditsOnlyUsageAccruedInput{
-			Charge:           env.newCreditsOnlyCharge(alpacadecimal.NewFromInt(30)),
-			AmountToAllocate: alpacadecimal.NewFromInt(30),
-		})
+		realizations, err := env.handler.OnAllocateCredits(t.Context(), env.newAllocateCreditsInputForCharge(
+			env.newCreditsOnlyCharge(alpacadecimal.NewFromInt(30)),
+			alpacadecimal.NewFromInt(30),
+		))
 		require.NoError(t, err)
 		require.Len(t, realizations, 1)
 
@@ -565,10 +543,10 @@ func TestOnFlatFeePaymentSettled(t *testing.T) {
 
 		env.fundPriority(t, 1, 30)
 
-		realizations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeflatfee.OnCreditsOnlyUsageAccruedInput{
-			Charge:           env.newCreditsOnlyCharge(alpacadecimal.NewFromInt(30)),
-			AmountToAllocate: alpacadecimal.NewFromInt(30),
-		})
+		realizations, err := env.handler.OnAllocateCredits(t.Context(), env.newAllocateCreditsInputForCharge(
+			env.newCreditsOnlyCharge(alpacadecimal.NewFromInt(30)),
+			alpacadecimal.NewFromInt(30),
+		))
 		require.NoError(t, err)
 
 		charge := env.newChargeWithCreditRealizationsAndAccruedUsage(realizations, alpacadecimal.Zero)
@@ -646,18 +624,26 @@ func newFlatFeeHandlerTestEnv(t *testing.T) *flatFeeHandlerTestEnv {
 	}
 }
 
-func (e *flatFeeHandlerTestEnv) newAssignmentInput(amount alpacadecimal.Decimal) chargeflatfee.OnAssignedToInvoiceInput {
+func (e *flatFeeHandlerTestEnv) newAssignmentInput(amount alpacadecimal.Decimal) chargeflatfee.OnAllocateCreditsInput {
 	return e.newAssignmentInputWithMode(amount, productcatalog.CreditThenInvoiceSettlementMode)
 }
 
-func (e *flatFeeHandlerTestEnv) newAssignmentInputWithMode(amount alpacadecimal.Decimal, mode productcatalog.SettlementMode) chargeflatfee.OnAssignedToInvoiceInput {
+func (e *flatFeeHandlerTestEnv) newAllocateCreditsInputForCharge(charge chargeflatfee.Charge, amount alpacadecimal.Decimal) chargeflatfee.OnAllocateCreditsInput {
+	return chargeflatfee.OnAllocateCreditsInput{
+		Charge:                 charge,
+		ServicePeriod:          charge.Intent.ServicePeriod,
+		PreTaxAmountToAllocate: amount,
+	}
+}
+
+func (e *flatFeeHandlerTestEnv) newAssignmentInputWithMode(amount alpacadecimal.Decimal, mode productcatalog.SettlementMode) chargeflatfee.OnAllocateCreditsInput {
 	now := time.Now().UTC()
 	servicePeriod := timeutil.ClosedPeriod{
 		From: now.Add(-time.Hour),
 		To:   now,
 	}
 
-	return chargeflatfee.OnAssignedToInvoiceInput{
+	return chargeflatfee.OnAllocateCreditsInput{
 		Charge: chargeflatfee.Charge{
 			ChargeBase: chargeflatfee.ChargeBase{
 				ManagedResource: meta.ManagedResource{
@@ -692,8 +678,8 @@ func (e *flatFeeHandlerTestEnv) newAssignmentInputWithMode(amount alpacadecimal.
 				Status: chargeflatfee.StatusActive,
 			},
 		},
-		ServicePeriod:     servicePeriod,
-		PreTaxTotalAmount: amount,
+		ServicePeriod:          servicePeriod,
+		PreTaxAmountToAllocate: amount,
 	}
 }
 

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -700,7 +700,7 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
 
 		// LEDGER:
-		// - OnFlatFeeAssignedToInvoice is called with the pre tax total amount of USD 100
+		// - OnAllocateCredits is called with the pre tax amount to allocate of USD 100
 		// - Two credit realizations should happen for the two different credit types
 
 		// Validate the credit realizations


### PR DESCRIPTION
## Summary
- rename the flat-fee credit allocation handler to OnAllocateCredits
- route credit-only flat-fee allocation through the same handler
- rename flat-fee credit allocation correction handler to OnCorrectCreditAllocations

## Verification
- direnv exec . env POSTGRES_HOST=127.0.0.1 GOCACHE=/tmp/go-build-openmeter-handler-renames go test -count=1 -tags=dynamic ./openmeter/billing/charges/flatfee/... ./openmeter/billing/charges/service ./openmeter/ledger/chargeadapter ./test/credits
- direnv exec . env GOCACHE=/tmp/go-build-openmeter-handler-renames make lint-go-fast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated credit allocation and correction flows into unified allocation events, simplifying billing behavior during invoice and payment processing.
  * Standardized allocation input handling and validation to prevent negative pre-tax allocations.

* **Tests**
  * Updated and reorganized test coverage to exercise the new allocation and correction flows end-to-end.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4362)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->