### PR TITLE
fix: credit-then-invoice discount sync

### DIFF
--- a/openmeter/billing/charges/flatfee/adapter.go
+++ b/openmeter/billing/charges/flatfee/adapter.go
@@ -32,6 +32,7 @@ type ChargeAdapter interface {
 	CreateCharges(ctx context.Context, charges CreateChargesInput) ([]Charge, error)
 
 	UpdateCharge(ctx context.Context, charge ChargeBase) (ChargeBase, error)
+	UpdateSubscriptionItemID(ctx context.Context, charge Charge, newSubscriptionItemID string) (Charge, error)
 	DeleteCharge(ctx context.Context, charge Charge) error
 	GetByIDs(ctx context.Context, ids GetByIDsInput) ([]Charge, error)
 	GetByID(ctx context.Context, id GetByIDInput) (Charge, error)

--- a/openmeter/billing/charges/flatfee/adapter/charge.go
+++ b/openmeter/billing/charges/flatfee/adapter/charge.go
@@ -79,6 +79,32 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge flatfee.ChargeBase) (
 	})
 }
 
+func (a *adapter) UpdateSubscriptionItemID(ctx context.Context, charge flatfee.Charge, newSubscriptionItemID string) (flatfee.Charge, error) {
+	if err := charge.Validate(); err != nil {
+		return flatfee.Charge{}, err
+	}
+
+	if newSubscriptionItemID == "" {
+		return flatfee.Charge{}, fmt.Errorf("subscription item ID is required")
+	}
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (flatfee.Charge, error) {
+		// TODO: make subscription_item_id immutable again once subscription edits
+		// no longer recreate the item ID for logical item updates.
+		updatedChargeBase, err := tx.db.ChargeFlatFee.UpdateOneID(charge.ID).
+			Where(dbchargeflatfee.NamespaceEQ(charge.Namespace)).
+			SetSubscriptionItemID(newSubscriptionItemID).
+			Save(ctx)
+		if err != nil {
+			return flatfee.Charge{}, err
+		}
+
+		charge.ChargeBase = MapChargeBaseFromDB(updatedChargeBase)
+
+		return charge, nil
+	})
+}
+
 func (a *adapter) DeleteCharge(ctx context.Context, charge flatfee.Charge) error {
 	if err := charge.ManagedModel.Validate(); err != nil {
 		return err

--- a/openmeter/billing/charges/flatfee/adapter/charge.go
+++ b/openmeter/billing/charges/flatfee/adapter/charge.go
@@ -80,6 +80,10 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge flatfee.ChargeBase) (
 }
 
 func (a *adapter) UpdateSubscriptionItemID(ctx context.Context, charge flatfee.Charge, newSubscriptionItemID string) (flatfee.Charge, error) {
+	if err := charge.ManagedModel.Validate(); err != nil {
+		return flatfee.Charge{}, err
+	}
+
 	if err := charge.Validate(); err != nil {
 		return flatfee.Charge{}, err
 	}

--- a/openmeter/billing/charges/flatfee/adapter/realizationrun_test.go
+++ b/openmeter/billing/charges/flatfee/adapter/realizationrun_test.go
@@ -14,7 +14,6 @@ import (
 	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	metaadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/meta/adapter"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
-	dbchargeflatfeerun "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -112,28 +111,14 @@ func (s *FlatFeeRealizationRunAdapterSuite) TestCreateCurrentRunFailsWhenCurrent
 	s.Require().NoError(err)
 	s.Require().Len(createdCharges, 1)
 
-	lineID := "line-id"
-	invoiceID := "invoice-id"
 	run, err := s.adapter.CreateCurrentRun(ctx, flatfee.CreateCurrentRunInput{
 		Charge:               createdCharges[0].ChargeBase,
 		ServicePeriod:        servicePeriod,
 		AmountAfterProration: alpacadecimal.NewFromInt(10),
-		LineID:               &lineID,
-		InvoiceID:            &invoiceID,
 	})
 	s.Require().NoError(err)
-	s.Equal(lineID, *run.LineID)
-	s.Equal(invoiceID, *run.InvoiceID)
-
-	dbRun, err := s.dbClient.ChargeFlatFeeRun.Query().
-		Where(
-			dbchargeflatfeerun.NamespaceEQ(namespace),
-			dbchargeflatfeerun.IDEQ(run.ID.ID),
-		).
-		Only(ctx)
-	s.Require().NoError(err)
-	s.Equal(lineID, *dbRun.LineID)
-	s.Equal(invoiceID, *dbRun.InvoiceID)
+	s.Nil(run.LineID)
+	s.Nil(run.InvoiceID)
 
 	_, err = s.adapter.CreateCurrentRun(ctx, flatfee.CreateCurrentRunInput{
 		Charge:               createdCharges[0].ChargeBase,

--- a/openmeter/billing/charges/flatfee/adapter/realizationrun_test.go
+++ b/openmeter/billing/charges/flatfee/adapter/realizationrun_test.go
@@ -14,6 +14,7 @@ import (
 	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	metaadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/meta/adapter"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	dbchargeflatfeerun "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -111,14 +112,28 @@ func (s *FlatFeeRealizationRunAdapterSuite) TestCreateCurrentRunFailsWhenCurrent
 	s.Require().NoError(err)
 	s.Require().Len(createdCharges, 1)
 
+	lineID := "line-id"
+	invoiceID := "invoice-id"
 	run, err := s.adapter.CreateCurrentRun(ctx, flatfee.CreateCurrentRunInput{
 		Charge:               createdCharges[0].ChargeBase,
 		ServicePeriod:        servicePeriod,
 		AmountAfterProration: alpacadecimal.NewFromInt(10),
+		LineID:               &lineID,
+		InvoiceID:            &invoiceID,
 	})
 	s.Require().NoError(err)
-	s.Nil(run.LineID)
-	s.Nil(run.InvoiceID)
+	s.Equal(lineID, *run.LineID)
+	s.Equal(invoiceID, *run.InvoiceID)
+
+	dbRun, err := s.dbClient.ChargeFlatFeeRun.Query().
+		Where(
+			dbchargeflatfeerun.NamespaceEQ(namespace),
+			dbchargeflatfeerun.IDEQ(run.ID.ID),
+		).
+		Only(ctx)
+	s.Require().NoError(err)
+	s.Equal(lineID, *dbRun.LineID)
+	s.Equal(invoiceID, *dbRun.InvoiceID)
 
 	_, err = s.adapter.CreateCurrentRun(ctx, flatfee.CreateCurrentRunInput{
 		Charge:               createdCharges[0].ChargeBase,

--- a/openmeter/billing/charges/flatfee/service.go
+++ b/openmeter/billing/charges/flatfee/service.go
@@ -20,6 +20,7 @@ type FlatFeeService interface {
 	Create(ctx context.Context, input CreateInput) ([]ChargeWithGatheringLine, error)
 	GetByIDs(ctx context.Context, input GetByIDsInput) ([]Charge, error)
 	GetByID(ctx context.Context, input GetByIDInput) (Charge, error)
+	UpdateSubscriptionItemID(ctx context.Context, charge Charge, newSubscriptionItemID string) (Charge, error)
 	AdvanceCharge(ctx context.Context, input AdvanceChargeInput) (*Charge, error)
 	TriggerPatch(ctx context.Context, charge meta.ChargeID, patch meta.Patch) (meta.TriggerPatchResult[Charge], error)
 }

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -141,6 +141,7 @@ func (e *LineEngine) OnMutableStandardLinesDeleted(ctx context.Context, input bi
 
 	chargesByID, err := e.getChargesForStandardLineEvent(ctx, input, meta.Expands{
 		meta.ExpandRealizations,
+		meta.ExpandDetailedLines,
 	})
 	if err != nil {
 		return fmt.Errorf("getting flat fee charges for deleted standard lines: %w", err)

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -141,7 +141,6 @@ func (e *LineEngine) OnMutableStandardLinesDeleted(ctx context.Context, input bi
 
 	chargesByID, err := e.getChargesForStandardLineEvent(ctx, input, meta.Expands{
 		meta.ExpandRealizations,
-		meta.ExpandDetailedLines,
 	})
 	if err != nil {
 		return fmt.Errorf("getting flat fee charges for deleted standard lines: %w", err)

--- a/openmeter/billing/charges/flatfee/service/linemapper.go
+++ b/openmeter/billing/charges/flatfee/service/linemapper.go
@@ -11,6 +11,11 @@ import (
 )
 
 func populateFlatFeeStandardLineFromRun(stdLine *billing.StandardLine, run flatfee.RealizationRun) error {
+	currencyCalculator, err := stdLine.Currency.Calculator()
+	if err != nil {
+		return fmt.Errorf("creating currency calculator: %w", err)
+	}
+
 	creditsApplied, err := run.CreditRealizations.AsCreditsApplied()
 	if err != nil {
 		return err
@@ -23,12 +28,18 @@ func populateFlatFeeStandardLineFromRun(stdLine *billing.StandardLine, run flatf
 		return fmt.Errorf("mapping run detailed lines: %w", err)
 	}
 
-	stdLine.DetailedLines = stdLine.DetailedLinesWithIDReuse(mappedDetailedLines)
-	stdLine.Totals = stdLine.DetailedLines.SumTotals()
+	mappedDetailedLines, err = mappedDetailedLines.WithCreditsApplied(stdLine.CreditsApplied, currencyCalculator)
+	if err != nil {
+		return fmt.Errorf("applying run credits to detailed lines: %w", err)
+	}
 
-	if !stdLine.Totals.Equal(run.Totals) {
+	stdLine.DetailedLines = stdLine.DetailedLinesWithIDReuse(mappedDetailedLines)
+	stdLine.Totals = stdLine.DetailedLines.SumTotals().RoundToPrecision(currencyCalculator)
+
+	expectedTotals := run.Totals.RoundToPrecision(currencyCalculator)
+	if !stdLine.Totals.Equal(expectedTotals) {
 		return fmt.Errorf("mapped line totals do not match run totals [line_id=%s run_id=%s line_total=%s run_total=%s]",
-			stdLine.ID, run.ID.ID, stdLine.Totals.Total.String(), run.Totals.Total.String())
+			stdLine.ID, run.ID.ID, stdLine.Totals.Total.String(), expectedTotals.Total.String())
 	}
 
 	return nil

--- a/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
@@ -13,7 +13,9 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
+	billingrating "github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -101,11 +103,18 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 			RealizationRunBase: runBase,
 		}
 
-		if !amountAfterProration.IsZero() {
+		line, err := rateFlatFeeLine(in.Line, s.ratingService)
+		if err != nil {
+			return StartCreditThenInvoiceRunResult{}, err
+		}
+
+		creditAllocationTarget := currencyCalculator.RoundToPrecision(line.Totals.Total)
+
+		if !creditAllocationTarget.IsZero() {
 			handlerInput := flatfee.OnAllocateCreditsInput{
 				Charge:                 charge,
 				ServicePeriod:          in.Line.Period,
-				PreTaxAmountToAllocate: amountAfterProration,
+				PreTaxAmountToAllocate: creditAllocationTarget,
 			}
 			if err := handlerInput.Validate(); err != nil {
 				return StartCreditThenInvoiceRunResult{}, fmt.Errorf("validating allocate credits input: %w", err)
@@ -136,24 +145,9 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("mapping credit realizations to credits applied: %w", err)
 		}
 
-		line, err := in.Line.Clone()
+		mappedLine, err := applyCreditsToFlatFeeLine(*line, creditsApplied, currencyCalculator)
 		if err != nil {
-			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("cloning line: %w", err)
-		}
-
-		line.CreditsApplied = creditsApplied
-
-		generatedDetailedLines, err := s.ratingService.GenerateDetailedLines(line)
-		if err != nil {
-			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("generating detailed lines for line[%s]: %w", line.ID, err)
-		}
-
-		if err := invoicecalc.MergeGeneratedDetailedLines(line, generatedDetailedLines); err != nil {
-			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("merging generated detailed lines for line[%s]: %w", line.ID, err)
-		}
-
-		if err := line.Validate(); err != nil {
-			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("validating standard line[%s]: %w", line.ID, err)
+			return StartCreditThenInvoiceRunResult{}, err
 		}
 
 		detailedLines := flatfee.DetailedLines(lo.Map(line.DetailedLines, func(detailedLine billing.DetailedLine, _ int) flatfee.DetailedLine {
@@ -166,8 +160,8 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 
 		runBase, err = s.adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
 			ID:                        runBase.ID,
-			Totals:                    mo.Some(line.Totals),
-			NoFiatTransactionRequired: mo.Some(line.Totals.Total.IsZero()),
+			Totals:                    mo.Some(mappedLine.Totals),
+			NoFiatTransactionRequired: mo.Some(mappedLine.Totals.Total.IsZero()),
 		})
 		if err != nil {
 			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("updating run totals for line[%s]: %w", line.ID, err)
@@ -276,11 +270,19 @@ func (s *Service) ReconcileStandardLineToIntent(ctx context.Context, in Reconcil
 		// run update so ledger and invoice state describe the same service
 		// window.
 		run.ServicePeriod = in.Line.Period
+
+		line, err := rateFlatFeeLine(in.Line, s.ratingService)
+		if err != nil {
+			return ReconcileStandardLineToIntentResult{}, err
+		}
+
+		creditAllocationTarget := currencyCalculator.RoundToPrecision(line.Totals.Total)
+
 		reconcileResult, err := s.ReconcileCredits(ctx, ReconcileCreditRealizationsInput{
 			Charge:             in.Charge,
 			Run:                run,
 			AllocateAt:         in.AllocateAt,
-			TargetAmount:       amountAfterProration,
+			TargetAmount:       creditAllocationTarget,
 			CurrencyCalculator: currencyCalculator,
 		})
 		if err != nil {
@@ -294,26 +296,9 @@ func (s *Service) ReconcileStandardLineToIntent(ctx context.Context, in Reconcil
 			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("mapping credit realizations to credits applied: %w", err)
 		}
 
-		line, err := in.Line.Clone()
+		mappedLine, err := applyCreditsToFlatFeeLine(*line, creditsApplied, currencyCalculator)
 		if err != nil {
-			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("cloning line: %w", err)
-		}
-
-		// CreditsApplied is invoice-facing derived data. The durable credit
-		// source of truth remains the run's credit realization rows.
-		line.CreditsApplied = creditsApplied
-
-		generatedDetailedLines, err := s.ratingService.GenerateDetailedLines(line)
-		if err != nil {
-			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("generating detailed lines for line[%s]: %w", line.ID, err)
-		}
-
-		if err := invoicecalc.MergeGeneratedDetailedLines(line, generatedDetailedLines); err != nil {
-			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("merging generated detailed lines for line[%s]: %w", line.ID, err)
-		}
-
-		if err := line.Validate(); err != nil {
-			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("validating standard line[%s]: %w", line.ID, err)
+			return ReconcileStandardLineToIntentResult{}, err
 		}
 
 		detailedLines := flatfee.DetailedLines(lo.Map(line.DetailedLines, func(detailedLine billing.DetailedLine, _ int) flatfee.DetailedLine {
@@ -328,8 +313,8 @@ func (s *Service) ReconcileStandardLineToIntent(ctx context.Context, in Reconcil
 			ID:                        run.ID,
 			ServicePeriod:             mo.Some(line.Period),
 			AmountAfterProration:      mo.Some(amountAfterProration),
-			Totals:                    mo.Some(line.Totals),
-			NoFiatTransactionRequired: mo.Some(line.Totals.Total.IsZero()),
+			Totals:                    mo.Some(mappedLine.Totals),
+			NoFiatTransactionRequired: mo.Some(mappedLine.Totals.Total.IsZero()),
 		})
 		if err != nil {
 			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("updating run totals for line[%s]: %w", line.ID, err)
@@ -340,7 +325,66 @@ func (s *Service) ReconcileStandardLineToIntent(ctx context.Context, in Reconcil
 
 		return ReconcileStandardLineToIntentResult{
 			Run:  run,
-			Line: *line,
+			Line: *mappedLine,
 		}, nil
 	})
+}
+
+func rateFlatFeeLine(line billing.StandardLine, ratingService billingrating.Service) (*billing.StandardLine, error) {
+	ratedLine, err := line.Clone()
+	if err != nil {
+		return nil, fmt.Errorf("cloning line: %w", err)
+	}
+
+	ratedLine.CreditsApplied = nil
+
+	ratingLine, err := line.Clone()
+	if err != nil {
+		return nil, fmt.Errorf("cloning rating line: %w", err)
+	}
+
+	ratingLine.CreditsApplied = nil
+	// Flat-fee charges materialize their own billable periods. Subscription
+	// split-line metadata must not make the flat pricer skip an otherwise
+	// billable in-advance or in-arrears charge run.
+	ratingLine.SplitLineGroupID = nil
+	ratingLine.SplitLineHierarchy = nil
+
+	generatedDetailedLines, err := ratingService.GenerateDetailedLines(ratingLine, billingrating.WithCreditsMutatorDisabled())
+	if err != nil {
+		return nil, fmt.Errorf("generating detailed lines for line[%s]: %w", ratedLine.ID, err)
+	}
+
+	if err := invoicecalc.MergeGeneratedDetailedLines(ratedLine, generatedDetailedLines); err != nil {
+		return nil, fmt.Errorf("merging generated detailed lines for line[%s]: %w", ratedLine.ID, err)
+	}
+
+	if err := ratedLine.Validate(); err != nil {
+		return nil, fmt.Errorf("validating standard line[%s]: %w", ratedLine.ID, err)
+	}
+
+	return ratedLine, nil
+}
+
+func applyCreditsToFlatFeeLine(line billing.StandardLine, creditsApplied billing.CreditsApplied, currencyCalculator currencyx.Calculator) (*billing.StandardLine, error) {
+	mappedLine, err := line.Clone()
+	if err != nil {
+		return nil, fmt.Errorf("cloning line: %w", err)
+	}
+
+	mappedLine.CreditsApplied = creditsApplied
+
+	detailedLines, err := mappedLine.DetailedLines.WithCreditsApplied(creditsApplied, currencyCalculator)
+	if err != nil {
+		return nil, fmt.Errorf("applying credits to detailed lines for line[%s]: %w", mappedLine.ID, err)
+	}
+
+	mappedLine.DetailedLines = detailedLines
+	mappedLine.Totals = mappedLine.DetailedLines.SumTotals().RoundToPrecision(currencyCalculator)
+
+	if err := mappedLine.Validate(); err != nil {
+		return nil, fmt.Errorf("validating standard line[%s]: %w", mappedLine.ID, err)
+	}
+
+	return mappedLine, nil
 }

--- a/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
@@ -331,6 +331,8 @@ func (s *Service) ReconcileStandardLineToIntent(ctx context.Context, in Reconcil
 }
 
 func rateFlatFeeLine(line billing.StandardLine, ratingService billingrating.Service) (*billing.StandardLine, error) {
+	// Keep the caller-facing line shape on ratedLine, and use ratingLine only
+	// to clear split metadata for pricing before merging generated details back.
 	ratedLine, err := line.Clone()
 	if err != nil {
 		return nil, fmt.Errorf("cloning line: %w", err)

--- a/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
@@ -150,7 +150,7 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 			return StartCreditThenInvoiceRunResult{}, err
 		}
 
-		detailedLines := flatfee.DetailedLines(lo.Map(line.DetailedLines, func(detailedLine billing.DetailedLine, _ int) flatfee.DetailedLine {
+		detailedLines := flatfee.DetailedLines(lo.Map(mappedLine.DetailedLines, func(detailedLine billing.DetailedLine, _ int) flatfee.DetailedLine {
 			return detailedLine.Base.Clone()
 		}))
 
@@ -301,7 +301,7 @@ func (s *Service) ReconcileStandardLineToIntent(ctx context.Context, in Reconcil
 			return ReconcileStandardLineToIntentResult{}, err
 		}
 
-		detailedLines := flatfee.DetailedLines(lo.Map(line.DetailedLines, func(detailedLine billing.DetailedLine, _ int) flatfee.DetailedLine {
+		detailedLines := flatfee.DetailedLines(lo.Map(mappedLine.DetailedLines, func(detailedLine billing.DetailedLine, _ int) flatfee.DetailedLine {
 			return detailedLine.Base.Clone()
 		}))
 

--- a/openmeter/billing/charges/flatfee/service/subscription.go
+++ b/openmeter/billing/charges/flatfee/service/subscription.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func (s *service) UpdateSubscriptionItemID(ctx context.Context, charge flatfee.Charge, newSubscriptionItemID string) (flatfee.Charge, error) {
+	var errs []error
+
+	if err := charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if newSubscriptionItemID == "" {
+		errs = append(errs, errors.New("subscription item ID is required"))
+	}
+
+	if err := models.NewNillableGenericValidationError(errors.Join(errs...)); err != nil {
+		return flatfee.Charge{}, err
+	}
+
+	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (flatfee.Charge, error) {
+		return s.adapter.UpdateSubscriptionItemID(ctx, charge, newSubscriptionItemID)
+	})
+}
+
+var _ flatfee.FlatFeeService = (*service)(nil)

--- a/openmeter/billing/charges/models/chargemeta/mixin.go
+++ b/openmeter/billing/charges/models/chargemeta/mixin.go
@@ -81,8 +81,7 @@ func (metaMixin) Fields() []ent.Field {
 
 		field.String("subscription_item_id").
 			Optional().
-			Nillable().
-			Immutable(),
+			Nillable(),
 
 		field.Time("advance_after").
 			Optional().

--- a/openmeter/billing/charges/service.go
+++ b/openmeter/billing/charges/service.go
@@ -26,6 +26,7 @@ type ChargeService interface {
 	GetByID(ctx context.Context, input GetByIDInput) (Charge, error)
 	GetByIDs(ctx context.Context, input GetByIDsInput) (Charges, error)
 	Create(ctx context.Context, input CreateInput) (Charges, error)
+	UpdateSubscriptionItemID(ctx context.Context, charge Charge, newSubscriptionItemID string) (Charge, error)
 
 	AdvanceCharges(ctx context.Context, input AdvanceChargesInput) (Charges, error)
 	ListCustomersToAdvance(ctx context.Context, input ListCustomersToAdvanceInput) (pagination.Result[customer.CustomerID], error)

--- a/openmeter/billing/charges/service/subscription.go
+++ b/openmeter/billing/charges/service/subscription.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func (s *service) UpdateSubscriptionItemID(ctx context.Context, charge charges.Charge, newSubscriptionItemID string) (charges.Charge, error) {
+	var errs []error
+
+	if err := charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if newSubscriptionItemID == "" {
+		errs = append(errs, errors.New("subscription item ID is required"))
+	}
+
+	if err := models.NewNillableGenericValidationError(errors.Join(errs...)); err != nil {
+		return charges.Charge{}, err
+	}
+
+	switch charge.Type() {
+	case meta.ChargeTypeFlatFee:
+		flatFeeCharge, err := charge.AsFlatFeeCharge()
+		if err != nil {
+			return charges.Charge{}, err
+		}
+
+		updatedCharge, err := s.flatFeeService.UpdateSubscriptionItemID(ctx, flatFeeCharge, newSubscriptionItemID)
+		if err != nil {
+			return charges.Charge{}, err
+		}
+
+		return charges.NewCharge(updatedCharge), nil
+	case meta.ChargeTypeUsageBased:
+		usageBasedCharge, err := charge.AsUsageBasedCharge()
+		if err != nil {
+			return charges.Charge{}, err
+		}
+
+		updatedCharge, err := s.usageBasedService.UpdateSubscriptionItemID(ctx, usageBasedCharge, newSubscriptionItemID)
+		if err != nil {
+			return charges.Charge{}, err
+		}
+
+		return charges.NewCharge(updatedCharge), nil
+	case meta.ChargeTypeCreditPurchase:
+		return charges.Charge{}, fmt.Errorf("updating subscription item ID is unsupported for charge type: %s", charge.Type())
+	default:
+		return charges.Charge{}, fmt.Errorf("unsupported charge type: %s", charge.Type())
+	}
+}

--- a/openmeter/billing/charges/usagebased/adapter.go
+++ b/openmeter/billing/charges/usagebased/adapter.go
@@ -23,6 +23,7 @@ type Adapter interface {
 type ChargeAdapter interface {
 	CreateCharges(ctx context.Context, charges CreateChargesInput) ([]Charge, error)
 	UpdateCharge(ctx context.Context, charge ChargeBase) (ChargeBase, error)
+	UpdateSubscriptionItemID(ctx context.Context, charge Charge, newSubscriptionItemID string) (Charge, error)
 	DeleteCharge(ctx context.Context, charge Charge) error
 	GetByIDs(ctx context.Context, input GetByIDsInput) ([]Charge, error)
 	GetByID(ctx context.Context, input GetByIDInput) (Charge, error)

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -61,6 +61,32 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge usagebased.ChargeBase
 	})
 }
 
+func (a *adapter) UpdateSubscriptionItemID(ctx context.Context, charge usagebased.Charge, newSubscriptionItemID string) (usagebased.Charge, error) {
+	if err := charge.Validate(); err != nil {
+		return usagebased.Charge{}, err
+	}
+
+	if newSubscriptionItemID == "" {
+		return usagebased.Charge{}, fmt.Errorf("subscription item ID is required")
+	}
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (usagebased.Charge, error) {
+		// TODO: make subscription_item_id immutable again once subscription edits
+		// no longer recreate the item ID for logical item updates.
+		updatedChargeBase, err := tx.db.ChargeUsageBased.UpdateOneID(charge.ID).
+			Where(dbchargeusagebased.NamespaceEQ(charge.Namespace)).
+			SetSubscriptionItemID(newSubscriptionItemID).
+			Save(ctx)
+		if err != nil {
+			return usagebased.Charge{}, err
+		}
+
+		charge.ChargeBase = MapChargeBaseFromDB(updatedChargeBase)
+
+		return charge, nil
+	})
+}
+
 func (a *adapter) DeleteCharge(ctx context.Context, charge usagebased.Charge) error {
 	if err := charge.ManagedModel.Validate(); err != nil {
 		return err

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -62,6 +62,10 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge usagebased.ChargeBase
 }
 
 func (a *adapter) UpdateSubscriptionItemID(ctx context.Context, charge usagebased.Charge, newSubscriptionItemID string) (usagebased.Charge, error) {
+	if err := charge.ManagedModel.Validate(); err != nil {
+		return usagebased.Charge{}, err
+	}
+
 	if err := charge.Validate(); err != nil {
 		return usagebased.Charge{}, err
 	}

--- a/openmeter/billing/charges/usagebased/service.go
+++ b/openmeter/billing/charges/usagebased/service.go
@@ -20,6 +20,7 @@ type Service interface {
 type UsageBasedService interface {
 	Create(ctx context.Context, input CreateInput) ([]ChargeWithGatheringLine, error)
 	GetByIDs(ctx context.Context, input GetByIDsInput) ([]Charge, error)
+	UpdateSubscriptionItemID(ctx context.Context, charge Charge, newSubscriptionItemID string) (Charge, error)
 	AdvanceCharge(ctx context.Context, input AdvanceChargeInput) (*Charge, error)
 	TriggerPatch(ctx context.Context, charge meta.ChargeID, patch meta.Patch) (meta.TriggerPatchResult[Charge], error)
 	GetCurrentTotals(ctx context.Context, input GetCurrentTotalsInput) (GetCurrentTotalsResult, error)

--- a/openmeter/billing/charges/usagebased/service/linemapper.go
+++ b/openmeter/billing/charges/usagebased/service/linemapper.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
@@ -59,24 +58,24 @@ func populateUsageBasedStandardLineFromRun(stdLine *billing.StandardLine, run us
 
 	stdLine.CreditsApplied = creditsApplied
 
-	projectedDetailedLines, err := projectUsageBasedDetailedLines(stdLine, run, currencyCalculator)
+	mappedDetailedLines, err := mapUsageBasedDetailedLines(stdLine, run, currencyCalculator)
 	if err != nil {
-		return fmt.Errorf("projecting run detailed lines: %w", err)
+		return fmt.Errorf("mapping run detailed lines: %w", err)
 	}
 
-	stdLine.DetailedLines = stdLine.DetailedLinesWithIDReuse(projectedDetailedLines)
+	stdLine.DetailedLines = stdLine.DetailedLinesWithIDReuse(mappedDetailedLines)
 	stdLine.Totals = stdLine.DetailedLines.SumTotals().RoundToPrecision(currencyCalculator)
 
 	expectedTotals := run.Totals.RoundToPrecision(currencyCalculator)
 	if !stdLine.Totals.Equal(expectedTotals) {
-		return fmt.Errorf("projected line totals do not match run totals [line_id=%s run_id=%s line_total=%s run_total=%s]",
+		return fmt.Errorf("mapped line totals do not match run totals [line_id=%s run_id=%s line_total=%s run_total=%s]",
 			stdLine.ID, run.ID.ID, stdLine.Totals.Total.String(), expectedTotals.Total.String())
 	}
 
 	return nil
 }
 
-func projectUsageBasedDetailedLines(
+func mapUsageBasedDetailedLines(
 	stdLine *billing.StandardLine,
 	run usagebased.RealizationRun,
 	currencyCalculator currencyx.Calculator,
@@ -85,17 +84,13 @@ func projectUsageBasedDetailedLines(
 		return nil, fmt.Errorf("run %s detailed lines must be expanded", run.ID.ID)
 	}
 
-	detailedLines := lo.Map(run.DetailedLines.OrEmpty(), func(line usagebased.DetailedLine, _ int) billing.DetailedLine {
+	detailedLines := billing.DetailedLines(lo.Map(run.DetailedLines.OrEmpty(), func(line usagebased.DetailedLine, _ int) billing.DetailedLine {
 		base := line.Base.Clone()
 		base.Namespace = stdLine.Namespace
 		base.ID = ""
 		base.CreatedAt = time.Time{}
 		base.UpdatedAt = time.Time{}
 		base.DeletedAt = nil
-		// Extra logic to reset credits applied before credits are applied. The rating output should not contain credits, but let's make sure.
-		base.CreditsApplied = nil
-		base.Totals.CreditsTotal = alpacadecimal.Zero
-		base.Totals.Total = base.Totals.CalculateTotal()
 
 		return billing.DetailedLine{
 			DetailedLineBase: billing.DetailedLineBase{
@@ -103,51 +98,11 @@ func projectUsageBasedDetailedLines(
 				InvoiceID: stdLine.InvoiceID,
 			},
 		}
-	})
+	}))
 
-	detailedLines, err := applyUsageBasedRunCreditsToDetailedLines(detailedLines, stdLine.CreditsApplied, currencyCalculator)
+	detailedLines, err := detailedLines.WithCreditsApplied(stdLine.CreditsApplied, currencyCalculator)
 	if err != nil {
 		return nil, err
-	}
-
-	return detailedLines, nil
-}
-
-func applyUsageBasedRunCreditsToDetailedLines(
-	detailedLines billing.DetailedLines,
-	creditsApplied billing.CreditsApplied,
-	currencyCalculator currencyx.Calculator,
-) (billing.DetailedLines, error) {
-	for _, creditToApply := range creditsApplied {
-		creditValueRemaining := currencyCalculator.RoundToPrecision(creditToApply.Amount)
-
-		for idx := range detailedLines {
-			if creditValueRemaining.IsZero() {
-				break
-			}
-
-			totalAmount := currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.Total)
-			if !totalAmount.IsPositive() {
-				continue
-			}
-
-			if totalAmount.LessThanOrEqual(creditValueRemaining) {
-				creditValueRemaining = currencyCalculator.RoundToPrecision(creditValueRemaining.Sub(totalAmount))
-				detailedLines[idx].CreditsApplied = append(detailedLines[idx].CreditsApplied, creditToApply.CloneWithAmount(totalAmount))
-				detailedLines[idx].Totals.CreditsTotal = currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.CreditsTotal.Add(totalAmount))
-				detailedLines[idx].Totals.Total = currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.Total.Sub(totalAmount))
-			} else {
-				detailedLines[idx].CreditsApplied = append(detailedLines[idx].CreditsApplied, creditToApply.CloneWithAmount(creditValueRemaining))
-				detailedLines[idx].Totals.CreditsTotal = currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.CreditsTotal.Add(creditValueRemaining))
-				detailedLines[idx].Totals.Total = currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.Total.Sub(creditValueRemaining))
-				creditValueRemaining = alpacadecimal.Zero
-				break
-			}
-		}
-
-		if creditValueRemaining.IsPositive() {
-			return nil, billing.ErrInvoiceLineCreditsNotConsumedFully
-		}
 	}
 
 	return detailedLines, nil

--- a/openmeter/billing/charges/usagebased/service/subscription.go
+++ b/openmeter/billing/charges/usagebased/service/subscription.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func (s *service) UpdateSubscriptionItemID(ctx context.Context, charge usagebased.Charge, newSubscriptionItemID string) (usagebased.Charge, error) {
+	var errs []error
+
+	if err := charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if newSubscriptionItemID == "" {
+		errs = append(errs, errors.New("subscription item ID is required"))
+	}
+
+	if err := models.NewNillableGenericValidationError(errors.Join(errs...)); err != nil {
+		return usagebased.Charge{}, err
+	}
+
+	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (usagebased.Charge, error) {
+		return s.adapter.UpdateSubscriptionItemID(ctx, charge, newSubscriptionItemID)
+	})
+}
+
+var _ usagebased.UsageBasedService = (*service)(nil)

--- a/openmeter/billing/invoicedetailedline.go
+++ b/openmeter/billing/invoicedetailedline.go
@@ -4,10 +4,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
@@ -114,6 +116,60 @@ func (l DetailedLines) SumTotals() totals.Totals {
 	return totals.Sum(lo.Map(l, func(line DetailedLine, _ int) totals.Totals {
 		return line.Totals
 	})...)
+}
+
+// WithReversedCredits returns cloned detailed lines with credit applications
+// removed and totals recalculated as if no credits had been applied.
+func (l DetailedLines) WithReversedCredits() DetailedLines {
+	return l.Map(func(line DetailedLine) DetailedLine {
+		line = line.Clone()
+		line.CreditsApplied = nil
+		line.Totals.CreditsTotal = alpacadecimal.Zero
+		line.Totals.Total = line.Totals.CalculateTotal()
+
+		return line
+	})
+}
+
+func (l DetailedLines) WithCreditsApplied(
+	creditsApplied CreditsApplied,
+	currencyCalculator currencyx.Calculator,
+) (DetailedLines, error) {
+	detailedLines := l.WithReversedCredits()
+
+	for _, creditToApply := range creditsApplied {
+		creditValueRemaining := currencyCalculator.RoundToPrecision(creditToApply.Amount)
+
+		for idx := range detailedLines {
+			if creditValueRemaining.IsZero() {
+				break
+			}
+
+			totalAmount := currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.Total)
+			if !totalAmount.IsPositive() {
+				continue
+			}
+
+			if totalAmount.LessThanOrEqual(creditValueRemaining) {
+				creditValueRemaining = currencyCalculator.RoundToPrecision(creditValueRemaining.Sub(totalAmount))
+				detailedLines[idx].CreditsApplied = append(detailedLines[idx].CreditsApplied, creditToApply.CloneWithAmount(totalAmount))
+				detailedLines[idx].Totals.CreditsTotal = currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.CreditsTotal.Add(totalAmount))
+				detailedLines[idx].Totals.Total = currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.Total.Sub(totalAmount))
+			} else {
+				detailedLines[idx].CreditsApplied = append(detailedLines[idx].CreditsApplied, creditToApply.CloneWithAmount(creditValueRemaining))
+				detailedLines[idx].Totals.CreditsTotal = currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.CreditsTotal.Add(creditValueRemaining))
+				detailedLines[idx].Totals.Total = currencyCalculator.RoundToPrecision(detailedLines[idx].Totals.Total.Sub(creditValueRemaining))
+				creditValueRemaining = alpacadecimal.Zero
+				break
+			}
+		}
+
+		if creditValueRemaining.IsPositive() {
+			return nil, ErrInvoiceLineCreditsNotConsumedFully
+		}
+	}
+
+	return detailedLines, nil
 }
 
 func (l DetailedLines) Validate() error {

--- a/openmeter/billing/invoicedetailedline_test.go
+++ b/openmeter/billing/invoicedetailedline_test.go
@@ -207,5 +207,5 @@ func detailedLineWithAppliedCredit(childUniqueReferenceID string, amount int64, 
 func requireDecimalEqual(t *testing.T, expected, actual alpacadecimal.Decimal) {
 	t.Helper()
 
-	require.True(t, expected.Equal(actual), "expected %s, got %s", expected.String(), actual.String())
+	require.Equal(t, expected.InexactFloat64(), actual.InexactFloat64())
 }

--- a/openmeter/billing/invoicedetailedline_test.go
+++ b/openmeter/billing/invoicedetailedline_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/models/stddetailedline"
+	billingtotals "github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -25,6 +26,134 @@ func TestDetailedLineValidateRejectsNegativePerUnitAmount(t *testing.T) {
 	line.PerUnitAmount = alpacadecimal.NewFromInt(-1)
 
 	require.ErrorContains(t, line.Validate(), "price should be positive or zero")
+}
+
+func TestDetailedLinesWithCreditsAppliedConsumesCreditsAcrossPositiveTotals(t *testing.T) {
+	currencyCalculator, err := currencyx.Code("USD").Calculator()
+	require.NoError(t, err)
+
+	lines := DetailedLines{
+		detailedLineWithTotal("line-1", 10),
+		detailedLineWithTotal("line-2", 5),
+		detailedLineWithTotal("zero-line", 0),
+	}
+
+	mappedLines, err := lines.WithCreditsApplied(CreditsApplied{
+		{
+			Amount:              alpacadecimal.NewFromInt(12),
+			Description:         "test credit",
+			CreditRealizationID: "credit-1",
+		},
+	}, currencyCalculator)
+	require.NoError(t, err)
+	require.Len(t, mappedLines, 3)
+
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(10), mappedLines[0].CreditsApplied[0].Amount)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(10), mappedLines[0].Totals.CreditsTotal)
+	requireDecimalEqual(t, alpacadecimal.Zero, mappedLines[0].Totals.Total)
+
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(2), mappedLines[1].CreditsApplied[0].Amount)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(2), mappedLines[1].Totals.CreditsTotal)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(3), mappedLines[1].Totals.Total)
+
+	require.Empty(t, mappedLines[2].CreditsApplied)
+	requireDecimalEqual(t, alpacadecimal.Zero, mappedLines[2].Totals.CreditsTotal)
+	requireDecimalEqual(t, alpacadecimal.Zero, mappedLines[2].Totals.Total)
+
+	require.Empty(t, lines[0].CreditsApplied)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(10), lines[0].Totals.Total)
+	require.Empty(t, lines[1].CreditsApplied)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(5), lines[1].Totals.Total)
+}
+
+func TestDetailedLinesWithCreditsAppliedReturnsErrorForUnusedCredits(t *testing.T) {
+	currencyCalculator, err := currencyx.Code("USD").Calculator()
+	require.NoError(t, err)
+
+	lines := DetailedLines{
+		detailedLineWithTotal("line-1", 5),
+	}
+
+	_, err = lines.WithCreditsApplied(CreditsApplied{
+		{
+			Amount:              alpacadecimal.NewFromInt(6),
+			Description:         "test credit",
+			CreditRealizationID: "credit-1",
+		},
+	}, currencyCalculator)
+	require.ErrorIs(t, err, ErrInvoiceLineCreditsNotConsumedFully)
+
+	require.Empty(t, lines[0].CreditsApplied)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(5), lines[0].Totals.Total)
+}
+
+func TestDetailedLinesWithCreditsAppliedReplacesExistingCredits(t *testing.T) {
+	currencyCalculator, err := currencyx.Code("USD").Calculator()
+	require.NoError(t, err)
+
+	lines := DetailedLines{
+		detailedLineWithAppliedCredit("line-1", 10, 2),
+	}
+
+	mappedLines, err := lines.WithCreditsApplied(CreditsApplied{
+		{
+			Amount:              alpacadecimal.NewFromInt(3),
+			Description:         "replacement credit",
+			CreditRealizationID: "replacement-credit",
+		},
+	}, currencyCalculator)
+	require.NoError(t, err)
+	require.Len(t, mappedLines, 1)
+	require.Len(t, mappedLines[0].CreditsApplied, 1)
+
+	require.Equal(t, "replacement-credit", mappedLines[0].CreditsApplied[0].CreditRealizationID)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(3), mappedLines[0].CreditsApplied[0].Amount)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(3), mappedLines[0].Totals.CreditsTotal)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(7), mappedLines[0].Totals.Total)
+
+	require.Len(t, lines[0].CreditsApplied, 1)
+	require.Equal(t, "existing-credit", lines[0].CreditsApplied[0].CreditRealizationID)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(2), lines[0].Totals.CreditsTotal)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(8), lines[0].Totals.Total)
+}
+
+func TestDetailedLinesWithCreditsAppliedNoCreditsReturnsClone(t *testing.T) {
+	currencyCalculator, err := currencyx.Code("USD").Calculator()
+	require.NoError(t, err)
+
+	lines := DetailedLines{
+		detailedLineWithAppliedCredit("line-1", 5, 2),
+	}
+
+	mappedLines, err := lines.WithCreditsApplied(nil, currencyCalculator)
+	require.NoError(t, err)
+
+	require.Empty(t, mappedLines[0].CreditsApplied)
+	requireDecimalEqual(t, alpacadecimal.Zero, mappedLines[0].Totals.CreditsTotal)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(5), mappedLines[0].Totals.Total)
+
+	mappedLines[0].Totals.Total = alpacadecimal.Zero
+
+	require.Len(t, lines[0].CreditsApplied, 1)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(3), lines[0].Totals.Total)
+	requireDecimalEqual(t, alpacadecimal.Zero, mappedLines[0].Totals.Total)
+}
+
+func TestDetailedLinesWithReversedCreditsClearsCreditValues(t *testing.T) {
+	lines := DetailedLines{
+		detailedLineWithAppliedCredit("line-1", 5, 2),
+	}
+
+	mappedLines := lines.WithReversedCredits()
+	require.Len(t, mappedLines, 1)
+
+	require.Empty(t, mappedLines[0].CreditsApplied)
+	requireDecimalEqual(t, alpacadecimal.Zero, mappedLines[0].Totals.CreditsTotal)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(5), mappedLines[0].Totals.Total)
+
+	require.Len(t, lines[0].CreditsApplied, 1)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(2), lines[0].Totals.CreditsTotal)
+	requireDecimalEqual(t, alpacadecimal.NewFromInt(3), lines[0].Totals.Total)
 }
 
 func validDetailedLineForValidation() DetailedLine {
@@ -47,4 +176,36 @@ func validDetailedLineForValidation() DetailedLine {
 			},
 		},
 	}
+}
+
+func detailedLineWithTotal(childUniqueReferenceID string, total int64) DetailedLine {
+	line := validDetailedLineForValidation()
+	line.ChildUniqueReferenceID = childUniqueReferenceID
+	line.Totals = billingtotals.Totals{
+		Amount: alpacadecimal.NewFromInt(total),
+		Total:  alpacadecimal.NewFromInt(total),
+	}
+
+	return line
+}
+
+func detailedLineWithAppliedCredit(childUniqueReferenceID string, amount int64, creditAmount int64) DetailedLine {
+	line := detailedLineWithTotal(childUniqueReferenceID, amount)
+	line.CreditsApplied = CreditsApplied{
+		{
+			Amount:              alpacadecimal.NewFromInt(creditAmount),
+			Description:         "existing credit",
+			CreditRealizationID: "existing-credit",
+		},
+	}
+	line.Totals.CreditsTotal = alpacadecimal.NewFromInt(creditAmount)
+	line.Totals.Total = line.Totals.CalculateTotal()
+
+	return line
+}
+
+func requireDecimalEqual(t *testing.T, expected, actual alpacadecimal.Decimal) {
+	t.Helper()
+
+	require.True(t, expected.Equal(actual), "expected %s, got %s", expected.String(), actual.String())
 }

--- a/openmeter/billing/worker/subscriptionsync/service/base_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/base_test.go
@@ -333,7 +333,9 @@ func (s *SuiteBase) expectLines(invoice billing.GenericInvoiceReader, subscripti
 			}
 
 			if expectedLine.Price.IsPresent() {
-				s.Equal(*expectedLine.Price.OrEmpty(), *line.GetPrice(), "%s: price", childID)
+				expectedPrice := expectedLine.Price.OrEmpty()
+				actualPrice := line.GetPrice()
+				s.Truef(expectedPrice.Equal(actualPrice), "%s: price expected %v, got %v", childID, expectedPrice, actualPrice)
 			}
 
 			s.Equal(expectedLine.Periods[idx].From, line.GetServicePeriod().From, "%s: period start", childID)
@@ -368,10 +370,8 @@ func (s *SuiteBase) assertChargesForLines(ctx context.Context, subsView subscrip
 		switch expectedLine.Price.OrEmpty().Type() {
 		case productcatalog.FlatPriceType:
 			flatFeeExpectedLines = append(flatFeeExpectedLines, expectedLine)
-		case productcatalog.UnitPriceType:
-			usageBasedExpectedLines = append(usageBasedExpectedLines, expectedLine)
 		default:
-			s.Failf("unsupported charge price", "unsupported charge price type %s", expectedLine.Price.OrEmpty().Type())
+			usageBasedExpectedLines = append(usageBasedExpectedLines, expectedLine)
 		}
 	}
 
@@ -511,8 +511,6 @@ func (s *SuiteBase) assertUsageBasedChargesForLines(ctx context.Context, subsVie
 		item := phase.ItemsByKey[itemKey][version]
 
 		s.Require().True(expectedLine.Price.IsPresent())
-		unitPrice, err := expectedLine.Price.OrEmpty().AsUnit()
-		s.NoError(err)
 		s.Require().True(expectedLine.Charge.IsPresent(), "charge expectations are required")
 		chargeExpects := expectedLine.Charge.OrEmpty()
 		s.Require().NotEmpty(chargeExpects.Status, "charge status expectation is required")
@@ -533,13 +531,13 @@ func (s *SuiteBase) assertUsageBasedChargesForLines(ctx context.Context, subsVie
 			s.Equal(s.Customer.ID, charge.Intent.CustomerID, "%s: customer id", childID)
 			expectedFeatureKey := lo.FromPtrOr(item.Spec.RateCard.AsMeta().FeatureKey, itemKey)
 			s.Equal(expectedFeatureKey, charge.Intent.FeatureKey, "%s: feature key", childID)
-			s.Equal(*productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: unitPrice.Amount}), charge.Intent.Price, "%s: price", childID)
+			expectedPrice := expectedLine.Price.OrEmpty()
+			s.Truef(expectedPrice.Equal(&charge.Intent.Price), "%s: price expected %v, got %v", childID, expectedPrice, charge.Intent.Price)
 			s.Require().NotNil(charge.Intent.Subscription, "%s: subscription", childID)
 			s.Equal(subsView.Subscription.ID, charge.Intent.Subscription.SubscriptionID, "%s: subscription id", childID)
 			s.Equal(phase.SubscriptionPhase.ID, charge.Intent.Subscription.PhaseID, "%s: phase id", childID)
 			s.Equal(item.SubscriptionItem.ID, charge.Intent.Subscription.ItemID, "%s: item id", childID)
 			s.Nil(charge.State.CurrentRealizationRunID, "%s: current realization run", childID)
-			s.Nil(charge.State.AdvanceAfter, "%s: advance after", childID)
 		}
 	}
 }

--- a/openmeter/billing/worker/subscriptionsync/service/reconcile.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconcile.go
@@ -33,6 +33,11 @@ func (s *Service) buildSyncPlan(ctx context.Context, subsView subscription.Subsc
 			return nil, err
 		}
 
+		persisted, err = s.repairChargeSubscriptionReferences(ctx, persisted, target)
+		if err != nil {
+			return nil, err
+		}
+
 		return s.reconciler.Plan(ctx, reconciler.PlanInput{
 			Subscription: subsView.Subscription,
 			Currency:     currency,

--- a/openmeter/billing/worker/subscriptionsync/service/reconcile.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconcile.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/framework/tracex"
 )
 
-func (s *Service) buildSyncPlan(ctx context.Context, subsView subscription.SubscriptionView, asOf time.Time, customerDeletedAt *time.Time, currency currencyx.Calculator) (*reconciler.Plan, error) {
+func (s *Service) buildSyncPlan(ctx context.Context, subsView subscription.SubscriptionView, asOf time.Time, customerDeletedAt *time.Time, currency currencyx.Calculator, dryRun bool) (*reconciler.Plan, error) {
 	span := tracex.Start[*reconciler.Plan](ctx, s.tracer, "billing.worker.subscription.sync.buildSyncPlan")
 
 	return span.Wrap(func(ctx context.Context) (*reconciler.Plan, error) {
@@ -33,7 +33,7 @@ func (s *Service) buildSyncPlan(ctx context.Context, subsView subscription.Subsc
 			return nil, err
 		}
 
-		persisted, err = s.repairChargeSubscriptionReferences(ctx, persisted, target)
+		persisted, err = s.repairChargeSubscriptionReferences(ctx, persisted, target, dryRun)
 		if err != nil {
 			return nil, err
 		}

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patch_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patch_test.go
@@ -40,13 +40,6 @@ func TestPatchCollectionRouterResolveDefaultCollection(t *testing.T) {
 		expectedCollection      any
 	}{
 		{
-			name:               "credit then invoice disabled stays on invoice lines",
-			settlementMode:     productcatalog.CreditThenInvoiceSettlementMode,
-			enableCredits:      true,
-			rateCard:           flatRateCard,
-			expectedCollection: &lineInvoicePatchCollection{},
-		},
-		{
 			name:               "credit only flat fee uses flat fee charges",
 			settlementMode:     productcatalog.CreditOnlySettlementMode,
 			rateCard:           flatRateCard,

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patch_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patch_test.go
@@ -40,6 +40,13 @@ func TestPatchCollectionRouterResolveDefaultCollection(t *testing.T) {
 		expectedCollection      any
 	}{
 		{
+			name:               "credit then invoice disabled stays on invoice lines",
+			settlementMode:     productcatalog.CreditThenInvoiceSettlementMode,
+			enableCredits:      true,
+			rateCard:           flatRateCard,
+			expectedCollection: &lineInvoicePatchCollection{},
+		},
+		{
 			name:               "credit only flat fee uses flat fee charges",
 			settlementMode:     productcatalog.CreditOnlySettlementMode,
 			rateCard:           flatRateCard,

--- a/openmeter/billing/worker/subscriptionsync/service/repair.go
+++ b/openmeter/billing/worker/subscriptionsync/service/repair.go
@@ -1,0 +1,166 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/persistedstate"
+	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/targetstate"
+)
+
+// repairChargeSubscriptionReferences repairs charge subscription item references before reconciliation.
+//
+// Subscription sync identifies billable items by logical path:
+// subscription / phase key / item key / item version / billing period. That identity intentionally does
+// not contain the concrete subscription_items.id, because most reconciliation decisions are about the
+// billable path and period shape, not the DB row backing the current view.
+//
+// Subscription edits can still recreate the subscription item row for the same logical item. One known
+// case is shrinking an item by inserting a later phase: the phase is preserved, but the item may be
+// soft-deleted and recreated with the same key, same version, and a new active_to. In that case the target
+// item and the persisted charge still share the same subscription-sync unique ID, so the reconciler should
+// update/shrink the existing charge rather than delete and recreate it. However, the charge must continue
+// to point at the concrete subscription item returned by the current subscription view.
+//
+// This repair is deliberately narrow: subscription_id and phase_id mismatches are treated as integrity
+// errors, and only subscription_item_id is updated. The charge adapter keeps a matching TODO on the
+// temporary mutability of subscription_item_id; it should become immutable again once subscription edits no
+// longer recreate item IDs for logical item updates.
+func (s *Service) repairChargeSubscriptionReferences(ctx context.Context, persisted persistedstate.State, target targetstate.State) (persistedstate.State, error) {
+	if s.chargesService == nil {
+		return persisted, nil
+	}
+
+	targetByUniqueID := lo.SliceToMap(
+		lo.Filter(target.Items, func(item targetstate.StateItem, _ int) bool {
+			return item.IsBillable()
+		}),
+		func(item targetstate.StateItem) (string, targetstate.StateItem) {
+			return item.UniqueID, item
+		},
+	)
+
+	for _, persistedEntry := range lo.Entries(persisted.ByUniqueID) {
+		targetItem, ok := targetByUniqueID[persistedEntry.Key]
+		if !ok {
+			continue
+		}
+
+		chargeSubscription, err := persistedChargeSubscriptionReferenceFromItem(persistedEntry.Value)
+		if err != nil {
+			return persistedstate.State{}, fmt.Errorf("getting persisted charge subscription reference: %w", err)
+		}
+		if !chargeSubscription.IsCharge {
+			continue
+		}
+
+		expectedSubscription := meta.SubscriptionReference{
+			SubscriptionID: targetItem.Subscription.ID,
+			PhaseID:        targetItem.PhaseID,
+			ItemID:         targetItem.SubscriptionItem.ID,
+		}
+
+		if chargeSubscription.Subscription == nil {
+			return persistedstate.State{}, fmt.Errorf("charge[%s] is missing subscription reference", chargeSubscription.ChargeID.ID)
+		}
+
+		if chargeSubscription.Subscription.SubscriptionID != expectedSubscription.SubscriptionID || chargeSubscription.Subscription.PhaseID != expectedSubscription.PhaseID {
+			return persistedstate.State{}, fmt.Errorf("charge[%s] subscription reference mismatch: expected subscription[%s]/phase[%s], got subscription[%s]/phase[%s]",
+				chargeSubscription.ChargeID.ID,
+				expectedSubscription.SubscriptionID,
+				expectedSubscription.PhaseID,
+				chargeSubscription.Subscription.SubscriptionID,
+				chargeSubscription.Subscription.PhaseID,
+			)
+		}
+
+		if chargeSubscription.Subscription.ItemID == expectedSubscription.ItemID {
+			continue
+		}
+
+		// TODO: subscription edits can recreate subscription items while the
+		// subscription-sync identity remains based on the logical path. Keep
+		// charge references aligned here until subscription item identity or
+		// target unique IDs can model this case directly.
+		updatedCharge, err := chargeSubscription.UpdateSubscriptionItemID(ctx, s.chargesService, expectedSubscription.ItemID)
+		if err != nil {
+			return persistedstate.State{}, fmt.Errorf("updating charge subscription reference: %w", err)
+		}
+
+		updatedPersistedItem, err := persistedItemFromCharge(updatedCharge)
+		if err != nil {
+			return persistedstate.State{}, fmt.Errorf("mapping updated charge to persisted item: %w", err)
+		}
+
+		persisted.ByUniqueID[persistedEntry.Key] = updatedPersistedItem
+	}
+
+	return persisted, nil
+}
+
+type persistedChargeSubscriptionReference struct {
+	Charge       charges.Charge
+	ChargeID     meta.ChargeID
+	Subscription *meta.SubscriptionReference
+	IsCharge     bool
+}
+
+func (r persistedChargeSubscriptionReference) UpdateSubscriptionItemID(ctx context.Context, chargesService charges.Service, newSubscriptionItemID string) (charges.Charge, error) {
+	return chargesService.UpdateSubscriptionItemID(ctx, r.Charge, newSubscriptionItemID)
+}
+
+func persistedChargeSubscriptionReferenceFromItem(item persistedstate.Item) (persistedChargeSubscriptionReference, error) {
+	switch item.Type() {
+	case persistedstate.ItemTypeChargeFlatFee:
+		charge, err := persistedstate.ItemAsFlatFeeCharge(item)
+		if err != nil {
+			return persistedChargeSubscriptionReference{}, err
+		}
+
+		return persistedChargeSubscriptionReference{
+			Charge:       charges.NewCharge(charge),
+			ChargeID:     charge.GetChargeID(),
+			Subscription: charge.Intent.Subscription,
+			IsCharge:     true,
+		}, nil
+	case persistedstate.ItemTypeChargeUsageBased:
+		charge, err := persistedstate.ItemAsUsageBasedCharge(item)
+		if err != nil {
+			return persistedChargeSubscriptionReference{}, err
+		}
+
+		return persistedChargeSubscriptionReference{
+			Charge:       charges.NewCharge(charge),
+			ChargeID:     charge.GetChargeID(),
+			Subscription: charge.Intent.Subscription,
+			IsCharge:     true,
+		}, nil
+	default:
+		return persistedChargeSubscriptionReference{}, nil
+	}
+}
+
+func persistedItemFromCharge(charge charges.Charge) (persistedstate.Item, error) {
+	switch charge.Type() {
+	case meta.ChargeTypeFlatFee:
+		flatFeeCharge, err := charge.AsFlatFeeCharge()
+		if err != nil {
+			return nil, err
+		}
+
+		return persistedstate.NewChargeItemFromChargeType(meta.ChargeTypeFlatFee, nil, &flatFeeCharge)
+	case meta.ChargeTypeUsageBased:
+		usageBasedCharge, err := charge.AsUsageBasedCharge()
+		if err != nil {
+			return nil, err
+		}
+
+		return persistedstate.NewChargeItemFromChargeType(meta.ChargeTypeUsageBased, &usageBasedCharge, nil)
+	default:
+		return nil, fmt.Errorf("unsupported charge type: %s", charge.Type())
+	}
+}

--- a/openmeter/billing/worker/subscriptionsync/service/repair.go
+++ b/openmeter/billing/worker/subscriptionsync/service/repair.go
@@ -30,7 +30,7 @@ import (
 // errors, and only subscription_item_id is updated. The charge adapter keeps a matching TODO on the
 // temporary mutability of subscription_item_id; it should become immutable again once subscription edits no
 // longer recreate item IDs for logical item updates.
-func (s *Service) repairChargeSubscriptionReferences(ctx context.Context, persisted persistedstate.State, target targetstate.State) (persistedstate.State, error) {
+func (s *Service) repairChargeSubscriptionReferences(ctx context.Context, persisted persistedstate.State, target targetstate.State, dryRun bool) (persistedstate.State, error) {
 	if s.chargesService == nil {
 		return persisted, nil
 	}
@@ -87,13 +87,21 @@ func (s *Service) repairChargeSubscriptionReferences(ctx context.Context, persis
 			continue
 		}
 
-		// TODO: subscription edits can recreate subscription items while the
-		// subscription-sync identity remains based on the logical path. Keep
-		// charge references aligned here until subscription item identity or
-		// target unique IDs can model this case directly.
-		updatedCharge, err := chargeSubscription.UpdateSubscriptionItemID(ctx, s.chargesService, expectedSubscription.ItemID)
-		if err != nil {
-			return persistedstate.State{}, fmt.Errorf("updating charge subscription reference: %w", err)
+		var updatedCharge charges.Charge
+		if dryRun {
+			updatedCharge, err = chargeSubscription.WithSubscriptionItemID(expectedSubscription.ItemID)
+			if err != nil {
+				return persistedstate.State{}, fmt.Errorf("updating charge subscription reference in memory: %w", err)
+			}
+		} else {
+			// TODO: subscription edits can recreate subscription items while the
+			// subscription-sync identity remains based on the logical path. Keep
+			// charge references aligned here until subscription item identity or
+			// target unique IDs can model this case directly.
+			updatedCharge, err = chargeSubscription.UpdateSubscriptionItemID(ctx, s.chargesService, expectedSubscription.ItemID)
+			if err != nil {
+				return persistedstate.State{}, fmt.Errorf("updating charge subscription reference: %w", err)
+			}
 		}
 
 		updatedPersistedItem, err := persistedItemFromCharge(updatedCharge)
@@ -116,6 +124,56 @@ type persistedChargeSubscriptionReference struct {
 
 func (r persistedChargeSubscriptionReference) UpdateSubscriptionItemID(ctx context.Context, chargesService charges.Service, newSubscriptionItemID string) (charges.Charge, error) {
 	return chargesService.UpdateSubscriptionItemID(ctx, r.Charge, newSubscriptionItemID)
+}
+
+func (r persistedChargeSubscriptionReference) WithSubscriptionItemID(newSubscriptionItemID string) (charges.Charge, error) {
+	if newSubscriptionItemID == "" {
+		return charges.Charge{}, fmt.Errorf("subscription item ID is required")
+	}
+
+	switch r.Charge.Type() {
+	case meta.ChargeTypeFlatFee:
+		charge, err := r.Charge.AsFlatFeeCharge()
+		if err != nil {
+			return charges.Charge{}, err
+		}
+
+		subscription, err := subscriptionReferenceWithItemID(charge.Intent.Subscription, newSubscriptionItemID)
+		if err != nil {
+			return charges.Charge{}, err
+		}
+
+		charge.Intent.Subscription = subscription
+
+		return charges.NewCharge(charge), nil
+	case meta.ChargeTypeUsageBased:
+		charge, err := r.Charge.AsUsageBasedCharge()
+		if err != nil {
+			return charges.Charge{}, err
+		}
+
+		subscription, err := subscriptionReferenceWithItemID(charge.Intent.Subscription, newSubscriptionItemID)
+		if err != nil {
+			return charges.Charge{}, err
+		}
+
+		charge.Intent.Subscription = subscription
+
+		return charges.NewCharge(charge), nil
+	default:
+		return charges.Charge{}, fmt.Errorf("unsupported charge type: %s", r.Charge.Type())
+	}
+}
+
+func subscriptionReferenceWithItemID(subscription *meta.SubscriptionReference, newSubscriptionItemID string) (*meta.SubscriptionReference, error) {
+	if subscription == nil {
+		return nil, fmt.Errorf("subscription reference is required")
+	}
+
+	subscriptionCopy := *subscription
+	subscriptionCopy.ItemID = newSubscriptionItemID
+
+	return &subscriptionCopy, nil
 }
 
 func persistedChargeSubscriptionReferenceFromItem(item persistedstate.Item) (persistedChargeSubscriptionReference, error) {

--- a/openmeter/billing/worker/subscriptionsync/service/repair.go
+++ b/openmeter/billing/worker/subscriptionsync/service/repair.go
@@ -35,14 +35,19 @@ func (s *Service) repairChargeSubscriptionReferences(ctx context.Context, persis
 		return persisted, nil
 	}
 
-	targetByUniqueID := lo.SliceToMap(
-		lo.Filter(target.Items, func(item targetstate.StateItem, _ int) bool {
-			return item.IsBillable()
-		}),
-		func(item targetstate.StateItem) (string, targetstate.StateItem) {
-			return item.UniqueID, item
-		},
-	)
+	billableTargetItems := lo.Filter(target.Items, func(item targetstate.StateItem, _ int) bool {
+		return item.IsBillable()
+	})
+	billableTargetUniqueIDs := lo.Map(billableTargetItems, func(item targetstate.StateItem, _ int) string {
+		return item.UniqueID
+	})
+	if len(lo.Uniq(billableTargetUniqueIDs)) != len(billableTargetUniqueIDs) {
+		return persistedstate.State{}, fmt.Errorf("duplicate billable target unique IDs while repairing charge subscription references")
+	}
+
+	targetByUniqueID := lo.SliceToMap(billableTargetItems, func(item targetstate.StateItem) (string, targetstate.StateItem) {
+		return item.UniqueID, item
+	})
 
 	for _, persistedEntry := range lo.Entries(persisted.ByUniqueID) {
 		targetItem, ok := targetByUniqueID[persistedEntry.Key]

--- a/openmeter/billing/worker/subscriptionsync/service/sync.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync.go
@@ -163,7 +163,7 @@ func (s *Service) SynchronizeSubscription(ctx context.Context, subs subscription
 			ID:        subs.Subscription.CustomerId,
 		}, func(ctx context.Context) error {
 			// Calculate per line patches
-			linesDiff, err := s.buildSyncPlan(ctx, subs, asOf, customerDeletedAt, currency)
+			linesDiff, err := s.buildSyncPlan(ctx, subs, asOf, customerDeletedAt, currency, options.DryRun)
 			if err != nil {
 				return err
 			}

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -174,7 +174,6 @@ func (s *CreditThenInvoiceTestSuite) TestSubscriptionHappyPath() {
 						Key:      "free-trial",
 						Duration: lo.ToPtr(datetime.MustParseDuration(s.T(), "P1M")),
 					},
-					// TODO[OM-1031]: let's add discount handling (as this could be a 100% discount for the first month)
 					RateCards: productcatalog.RateCards{
 						&productcatalog.UsageBasedRateCard{
 							RateCardMeta: productcatalog.RateCardMeta{
@@ -193,7 +192,6 @@ func (s *CreditThenInvoiceTestSuite) TestSubscriptionHappyPath() {
 						Key:      "discounted-phase",
 						Duration: lo.ToPtr(datetime.MustParseDuration(s.T(), "P2M")),
 					},
-					// TODO[OM-1031]: 50% discount
 					RateCards: productcatalog.RateCards{
 						&productcatalog.UsageBasedRateCard{
 							RateCardMeta: productcatalog.RateCardMeta{
@@ -513,8 +511,6 @@ func (s *CreditThenInvoiceTestSuite) TestSubscriptionHappyPath() {
 			To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 		})
 
-		// TODO[OM-1037]: let's add/change some items of the subscription then expect that the new item appears on the gathering
-		// invoice, but the draft invoice is untouched.
 	})
 
 	s.Run("subscription cancellation", func() {
@@ -2353,19 +2349,18 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionInvoicing() {
 }
 
 func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionCancellation() {
-	s.T().Skip("TODO: transform this copied suite into credit then invoice settlement mode validation")
-
 	ctx := s.T().Context()
 	startTime := s.mustParseTime("2024-01-01T00:00:00Z")
 	clock.FreezeTime(startTime)
 	defer clock.UnFreeze()
 
-	// Given
-	//	a subscription with two phases, first is a trial, second is a regular phase, that has been already sinced
-	// When
-	//  we cancel said subscription during the trial phase
-	// Then
-	//  items of future phases should be removed
+	// given:
+	// - a credit-then-invoice subscription with a trial phase and a future paid phase
+	// when:
+	// - the subscription is synchronized into the future and then canceled during the trial
+	// then:
+	// - future paid phase lines and charges are removed without ledger movement
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
 	// Let's create the initial subscription
 	subView := s.createSubscriptionFromPlan(plan.CreatePlanInput{
@@ -2378,6 +2373,7 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionCancellation() {
 				Key:            "test-plan",
 				Version:        1,
 				Currency:       currency.USD,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
 				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
 				ProRatingConfig: productcatalog.ProRatingConfig{
 					Enabled: true,
@@ -2391,7 +2387,6 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionCancellation() {
 						Key:      "trial",
 						Duration: lo.ToPtr(datetime.MustParseDuration(s.T(), "P1M")),
 					},
-					// TODO[OM-1031]: let's add discount handling (as this could be a 100% discount for the first month)
 					RateCards: productcatalog.RateCards{
 						&productcatalog.UsageBasedRateCard{
 							RateCardMeta: productcatalog.RateCardMeta{
@@ -2410,7 +2405,6 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionCancellation() {
 						Key:      "default",
 						Duration: nil,
 					},
-					// TODO[OM-1031]: 50% discount
 					RateCards: productcatalog.RateCards{
 						&productcatalog.UsageBasedRateCard{
 							RateCardMeta: productcatalog.RateCardMeta{
@@ -2440,10 +2434,11 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionCancellation() {
 	// Let's check the invoice
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
 	// Trial isn't synchronized as its a free trial...
 	// Let's check the default phase
-	s.expectLines(gatheringInvoice, subView.Subscription.ID, []expectedLine{
+	expectedLines := []expectedLine{
 		{
 			Matcher: recurringLineMatcher{
 				PhaseKey:  "default",
@@ -2467,8 +2462,14 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionCancellation() {
 				startTime.AddDate(0, 2, 0),
 				startTime.AddDate(0, 3, 0),
 			}),
+			Charge: mo.Some(chargeExpects{
+				Status:         string(usagebased.StatusCreated),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			}),
 		},
-	})
+	}
+	s.assertChargesForLines(ctx, subView, expectedLines)
+	s.expectLines(gatheringInvoice, subView.Subscription.ID, expectedLines)
 
 	// Let's cancel the subscription a day later
 	cancelAt := clock.Now().Add(time.Hour * 24)
@@ -2487,11 +2488,11 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionCancellation() {
 
 	// Let's validate that every line was canceled
 	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	s.assertChargesForLines(ctx, subView, nil)
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 }
 
 func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionProgressiveBillingCancellation() {
-	s.T().Skip("TODO: transform this copied suite into credit then invoice settlement mode validation")
-
 	ctx := s.T().Context()
 	startTime := s.mustParseTime("2024-01-01T00:00:00Z")
 	clock.FreezeTime(startTime)
@@ -2508,14 +2509,14 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionProgressiveBillingCa
 	})
 	s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 1, s.mustParseTime("2023-01-01T00:00:00Z"))
 
-	// Given
-	//	a subscription with one phase, with an usage-based rate card that has been already sinced
-	//  we have already progressively billed the line for a day
-	// When
-	//  we cancel said subscription during the first billing period
-	// Then
-	//  The remaining part of the billing period should be invoiced
-	//  The gathering invoice should be deleted
+	// given:
+	// - a credit-then-invoice subscription with a usage-based rate card
+	// - the usage-based line has already been progressively billed for a day
+	// when:
+	// - the subscription is canceled during the first billing period
+	// then:
+	// - the remaining gathering line is removed without additional ledger movement
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
 	testPrice := productcatalog.NewPriceFrom(productcatalog.TieredPrice{
 		Mode: productcatalog.GraduatedTieredPrice,
@@ -2546,6 +2547,7 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionProgressiveBillingCa
 				Key:            "test-plan",
 				Version:        1,
 				Currency:       currency.USD,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
 				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
 				ProRatingConfig: productcatalog.ProRatingConfig{
 					Enabled: true,
@@ -2582,10 +2584,10 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionProgressiveBillingCa
 	// Let's check the invoice
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
-	// Trial isn't synchronized as its a free trial...
 	// Let's check the default phase
-	s.expectLines(gatheringInvoice, subView.Subscription.ID, []expectedLine{
+	initialExpectedLines := []expectedLine{
 		{
 			Matcher: recurringLineMatcher{
 				PhaseKey: "default",
@@ -2601,8 +2603,14 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionProgressiveBillingCa
 			InvoiceAt: mo.Some([]time.Time{
 				startTime.AddDate(0, 1, 0),
 			}),
+			Charge: mo.Some(chargeExpects{
+				Status:         string(usagebased.StatusCreated),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			}),
 		},
-	})
+	}
+	s.assertChargesForLines(ctx, subView, initialExpectedLines)
+	s.expectLines(gatheringInvoice, subView.Subscription.ID, initialExpectedLines)
 
 	// Given we already have a progressively billed line/invoice for a day
 	// Let's advane the clock a day
@@ -2623,46 +2631,32 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionProgressiveBillingCa
 	// Let's check the invoice
 	s.populateChildIDsFromParents(&createdInvoice)
 	s.DebugDumpInvoice("partial invoice", createdInvoice)
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
-	s.expectLines(createdInvoice, subView.Subscription.ID, []expectedLine{
-		{
-			Matcher: recurringLineMatcher{
-				PhaseKey: "default",
-				ItemKey:  s.APIRequestsTotalFeature.Key,
-			},
-			Price: mo.Some(testPrice),
-			Periods: []timeutil.ClosedPeriod{
-				{
-					From: startTime,
-					To:   startTime.AddDate(0, 0, 1),
-				},
-			},
-		},
-	})
+	partialInvoiceLines := createdInvoice.Lines.OrEmpty()
+	s.Require().Len(partialInvoiceLines, 1)
+	s.True(testPrice.Equal(partialInvoiceLines[0].GetPrice()), "partial invoice price")
+	s.Equal(timeutil.ClosedPeriod{
+		From: startTime,
+		To:   startTime.AddDate(0, 0, 1),
+	}, partialInvoiceLines[0].GetServicePeriod())
+	s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), partialInvoiceLines[0].Totals.Amount, "partial invoice amount")
+	s.AssertDecimalEqual(alpacadecimal.NewFromInt(5), partialInvoiceLines[0].Totals.Total, "partial invoice total")
 
 	// Let's fetch the gathering invoice again
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.populateChildIDsFromParents(&gatheringInvoice)
 	s.DebugDumpInvoice("gathering invoice - after progressive billing", gatheringInvoice)
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
-	s.expectLines(gatheringInvoice, subView.Subscription.ID, []expectedLine{
-		{
-			Matcher: recurringLineMatcher{
-				PhaseKey: "default",
-				ItemKey:  s.APIRequestsTotalFeature.Key,
-			},
-			Price: mo.Some(testPrice),
-			Periods: []timeutil.ClosedPeriod{
-				{
-					From: startTime.AddDate(0, 0, 1),
-					To:   startTime.AddDate(0, 1, 0),
-				},
-			},
-			InvoiceAt: mo.Some([]time.Time{
-				startTime.AddDate(0, 1, 0),
-			}),
-		},
-	})
+	gatheringLinesAfterProgressiveBilling := gatheringInvoice.Lines.OrEmpty()
+	s.Require().Len(gatheringLinesAfterProgressiveBilling, 1)
+	s.True(testPrice.Equal(gatheringLinesAfterProgressiveBilling[0].GetPrice()), "gathering invoice after progressive billing price")
+	s.Equal(timeutil.ClosedPeriod{
+		From: startTime.AddDate(0, 0, 1),
+		To:   startTime.AddDate(0, 1, 0),
+	}, gatheringLinesAfterProgressiveBilling[0].GetServicePeriod())
+	s.Equal(startTime.AddDate(0, 1, 0), gatheringLinesAfterProgressiveBilling[0].GetInvoiceAt())
 
 	// When canceling the subscription, only the remaining part of the billing period should be invoiced
 	// Let's cancel the subscription a few ms later, to make sure that the remaining gathering line is empty
@@ -2685,6 +2679,7 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionProgressiveBillingCa
 
 	// Let's validate that the gathering invoice is gone too
 	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 }
 
 func (s *CreditThenInvoiceTestSuite) TestInAdvanceOneTimeFeeSyncing() {
@@ -2933,33 +2928,50 @@ func (s *CreditThenInvoiceTestSuite) TestInArrearsOneTimeFeeSyncing() {
 }
 
 func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
-	s.T().Skip("TODO: transform this copied suite into credit then invoice settlement mode validation")
-
 	ctx := s.T().Context()
 	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:00Z"))
+	defer clock.UnFreeze()
 
-	// Given
-	//  we have a subscription with a single phase with an usage based price, and the gathering invoice contains the items
-	// When
-	//  when we add a new phase, that disrupts the period of previous items with a new usage based price for the same feature
-	// Then
-	//  then the gathering invoice is updated, the period of the previous items are updated accordingly
+	// given:
+	// - we have a credit-then-invoice subscription with a single phase with an usage based price
+	// - the gathering invoice contains the items
+	// when:
+	// - we add a new phase, that disrupts the period of previous items with a new usage based price for the same feature
+	// then:
+	// - the gathering invoice is updated, the period of the previous items are updated accordingly
+	// - charges are reconciled without ledger movement
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
-	subsView := s.createSubscriptionFromPlanPhases([]productcatalog.Phase{
-		{
-			PhaseMeta: s.phaseMeta("first-phase", ""),
-			RateCards: productcatalog.RateCards{
-				&productcatalog.UsageBasedRateCard{
-					RateCardMeta: productcatalog.RateCardMeta{
-						Key:        s.APIRequestsTotalFeature.Key,
-						Name:       s.APIRequestsTotalFeature.Key,
-						FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
-						FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
-						Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
-							Amount: alpacadecimal.NewFromFloat(10),
-						}),
+	subsView := s.createSubscriptionFromPlan(plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: s.Namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Test Plan",
+				Key:            "test-plan",
+				Version:        1,
+				Currency:       currency.USD,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: s.phaseMeta("first-phase", ""),
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:        s.APIRequestsTotalFeature.Key,
+								Name:       s.APIRequestsTotalFeature.Key,
+								FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+								FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
+								Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+									Amount: alpacadecimal.NewFromFloat(10),
+								}),
+							},
+							BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+						},
 					},
-					BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
 				},
 			},
 		},
@@ -2968,8 +2980,9 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
 	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
-	s.expectLines(gatheringInvoice, subsView.Subscription.ID, []expectedLine{
+	initialExpectedLines := []expectedLine{
 		{
 			Matcher: recurringLineMatcher{
 				PhaseKey:  "first-phase",
@@ -2988,8 +3001,14 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
+			Charge: mo.Some(chargeExpects{
+				Status:         string(usagebased.StatusCreated),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			}),
 		},
-	})
+	}
+	s.assertChargesForLines(ctx, subsView, initialExpectedLines)
+	s.expectLines(gatheringInvoice, subsView.Subscription.ID, initialExpectedLines)
 
 	updatedSubsView, err := s.SubscriptionWorkflowService.EditRunning(ctx, subsView.Subscription.NamespacedID, []subscription.Patch{
 		patch.PatchAddPhase{
@@ -3020,8 +3039,9 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
 	// gathering invoice
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - 2nd sync", gatheringInvoice)
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
-	s.expectLines(gatheringInvoice, subsView.Subscription.ID, []expectedLine{
+	updatedExpectedLines := []expectedLine{
 		// we'll have the single line in the first phase truncated to its 2 day length
 		{
 			Matcher: recurringLineMatcher{
@@ -3042,6 +3062,10 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-03T00:00:00Z")}),
+			Charge: mo.Some(chargeExpects{
+				Status:         string(usagebased.StatusCreated),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			}),
 		},
 		// We'll have one line for the second phase that gets aligned to the billing anchor
 		{
@@ -3063,8 +3087,14 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
+			Charge: mo.Some(chargeExpects{
+				Status:         string(usagebased.StatusCreated),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			}),
 		},
-	})
+	}
+	s.assertChargesForLines(ctx, updatedSubsView, updatedExpectedLines)
+	s.expectLines(gatheringInvoice, subsView.Subscription.ID, updatedExpectedLines)
 }
 
 func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice() {
@@ -4264,196 +4294,489 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceInstantBillingOnSubscriptionCr
 }
 
 func (s *CreditThenInvoiceTestSuite) TestDiscountSynchronization() {
-	s.T().Skip("TODO: fix credit-then-invoice flat-fee discount handling before enabling this scenario")
-
 	ctx := s.T().Context()
 	start := s.mustParseTime("2024-01-01T00:00:00Z")
 	clock.FreezeTime(start)
+	defer clock.UnFreeze()
 
-	s.createPromotionalCreditFunding(ctx, createPromotionalCreditFundingInput{
-		Namespace: s.Namespace,
-		Customer:  s.Customer.GetID(),
-		Currency:  currencyx.Code(currency.USD),
-		Amount:    alpacadecimal.NewFromInt(2),
-		At:        start,
-	})
 	startBalances := expectedCreditThenInvoiceBalances{
 		FBOAll:          2,
 		FBOPromotional:  2,
 		WashAll:         -2,
 		WashPromotional: -2,
 	}
-	s.assertCreditThenInvoiceBalances(startBalances)
 
-	subsView := s.createSubscriptionFromPlan(plan.CreatePlanInput{
-		NamespacedModel: models.NamespacedModel{
+	var gatheringInvoice *billing.GatheringInvoice
+	var instantInvoice *billing.StandardInvoice
+	var subsView subscription.SubscriptionView
+
+	s.Run("given promotional credits and a fully discounted subscription", func() {
+		// given:
+		// - the customer has promotional credits available
+		// - the plan uses credit-then-invoice settlement mode
+		// - the in-advance flat fee is fully discounted
+		// when:
+		// - the subscription is created
+		// then:
+		// - the promotional credits are funded and no credit allocation has happened yet
+		s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
+
+		s.createPromotionalCreditFunding(ctx, createPromotionalCreditFundingInput{
 			Namespace: s.Namespace,
-		},
-		Plan: productcatalog.Plan{
-			PlanMeta: productcatalog.PlanMeta{
-				Name:           "Test Plan",
-				Key:            "test-plan",
-				Version:        1,
-				Currency:       currency.USD,
-				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
-				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
-				ProRatingConfig: productcatalog.ProRatingConfig{
-					Enabled: true,
-					Mode:    productcatalog.ProRatingModeProratePrices,
-				},
+			Customer:  s.Customer.GetID(),
+			Currency:  currencyx.Code(currency.USD),
+			Amount:    alpacadecimal.NewFromInt(2),
+			At:        start,
+		})
+		s.assertCreditThenInvoiceBalances(startBalances)
+
+		subsView = s.createSubscriptionFromPlan(plan.CreatePlanInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: s.Namespace,
 			},
-			Phases: []productcatalog.Phase{
-				{
-					PhaseMeta: s.phaseMeta("first-phase", ""),
-					RateCards: productcatalog.RateCards{
-						&productcatalog.UsageBasedRateCard{
-							RateCardMeta: productcatalog.RateCardMeta{
-								Key:  "in-advance",
-								Name: "in-advance",
-								Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
-									Amount:      alpacadecimal.NewFromFloat(6),
-									PaymentTerm: productcatalog.InAdvancePaymentTerm,
-								}),
-								Discounts: productcatalog.Discounts{
-									Percentage: &productcatalog.PercentageDiscount{
-										Percentage: models.NewPercentage(100),
+			Plan: productcatalog.Plan{
+				PlanMeta: productcatalog.PlanMeta{
+					Name:           "Test Plan",
+					Key:            "test-plan",
+					Version:        1,
+					Currency:       currency.USD,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+					ProRatingConfig: productcatalog.ProRatingConfig{
+						Enabled: true,
+						Mode:    productcatalog.ProRatingModeProratePrices,
+					},
+				},
+				Phases: []productcatalog.Phase{
+					{
+						PhaseMeta: s.phaseMeta("first-phase", ""),
+						RateCards: productcatalog.RateCards{
+							&productcatalog.UsageBasedRateCard{
+								RateCardMeta: productcatalog.RateCardMeta{
+									Key:  "in-advance",
+									Name: "in-advance",
+									Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+										Amount:      alpacadecimal.NewFromFloat(6),
+										PaymentTerm: productcatalog.InAdvancePaymentTerm,
+									}),
+									Discounts: productcatalog.Discounts{
+										Percentage: &productcatalog.PercentageDiscount{
+											Percentage: models.NewPercentage(100),
+										},
 									},
 								},
+								BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
 							},
-							BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
-						},
-						&productcatalog.UsageBasedRateCard{
-							RateCardMeta: productcatalog.RateCardMeta{
-								Key:        s.APIRequestsTotalFeature.Key,
-								Name:       s.APIRequestsTotalFeature.Key,
-								FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
-								FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
-								Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
-									Amount: alpacadecimal.NewFromFloat(10),
-								}),
+							&productcatalog.UsageBasedRateCard{
+								RateCardMeta: productcatalog.RateCardMeta{
+									Key:        s.APIRequestsTotalFeature.Key,
+									Name:       s.APIRequestsTotalFeature.Key,
+									FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+									FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
+									Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+										Amount: alpacadecimal.NewFromFloat(10),
+									}),
+								},
+								BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
 							},
-							BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
 						},
 					},
 				},
 			},
-		},
+		})
+		s.assertCreditThenInvoiceBalances(startBalances)
 	})
 
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing, and we want both the instant invoice for in advance as well as the gathering for UBP)
-	s.assertCreditThenInvoiceBalances(startBalances)
+	s.Run("when syncing at subscription start", func() {
+		// given:
+		// - the subscription exists at the start of its first billing period
+		// when:
+		// - subscription sync runs just after the start timestamp
+		// then:
+		// - the in-advance fee is instant-invoiced and future charge lines are gathered
+		s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing, and we want both the instant invoice for in advance as well as the gathering for UBP)
+		s.assertCreditThenInvoiceBalances(startBalances)
 
-	invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
-		Customers: []string{s.Customer.ID},
-		Expand:    billing.InvoiceExpandAll,
+		invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
+			Customers: []string{s.Customer.ID},
+			Expand:    billing.InvoiceExpandAll,
+		})
+		s.NoError(err)
+		s.Len(invoices.Items, 2)
+
+		for _, invoice := range invoices.Items {
+			if invoice.Type() == billing.InvoiceTypeGathering {
+				invoiceAsGathering, err := invoice.AsGatheringInvoice()
+				s.NoError(err)
+				gatheringInvoice = &invoiceAsGathering
+				continue
+			}
+
+			invoiceAsStandard, err := invoice.AsStandardInvoice()
+			s.NoError(err)
+			instantInvoice = &invoiceAsStandard
+		}
+
+		s.Require().NotNil(gatheringInvoice, "gathering invoice should be present")
+		s.Require().NotNil(instantInvoice, "instant invoice should be present")
+
+		s.DebugDumpInvoice("gathering invoice", *gatheringInvoice)
+		s.DebugDumpInvoice("instant invoice", *instantInvoice)
+		s.assertCreditThenInvoiceBalances(startBalances)
 	})
-	s.NoError(err)
-	s.Len(invoices.Items, 2)
+
+	s.Run("then charges invoices and ledger balances reflect the full discount", func() {
+		// given:
+		// - subscription sync created the gathering and instant invoices
+		// when:
+		// - invoice lines and charges are inspected
+		// then:
+		// - the instant line has a full discount and no credit allocation
+		// - promotional credits remain available on the ledger
+		gatheringExpectedLines := []expectedLine{
+			// Gathering invoice should have the UBP line
+			{
+				Matcher: recurringLineMatcher{
+					PhaseKey: "first-phase",
+					ItemKey:  s.APIRequestsTotalFeature.Key,
+				},
+				Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromFloat(10),
+				})),
+				Periods: []timeutil.ClosedPeriod{
+					{
+						From: s.mustParseTime("2024-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					},
+				},
+				InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
+				Charge: mo.Some(chargeExpects{
+					Status:         string(usagebased.StatusCreated),
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				}),
+			},
+			// And next Billing Period's in advance line
+			{
+				Matcher: recurringLineMatcher{
+					PhaseKey:  "first-phase",
+					ItemKey:   "in-advance",
+					PeriodMin: 1,
+					PeriodMax: 1,
+					Version:   0,
+				},
+				Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromFloat(6),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				})),
+				Periods: []timeutil.ClosedPeriod{
+					{
+						From: s.mustParseTime("2024-02-01T00:00:00Z"),
+						To:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					},
+				},
+				InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
+				Charge: mo.Some(chargeExpects{
+					Status:         string(flatfee.StatusCreated),
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				}),
+			},
+		}
+		s.expectLines(*gatheringInvoice, subsView.Subscription.ID, gatheringExpectedLines)
+
+		// Instant invoice should have the in advance fee
+		instantExpectedLines := []expectedLine{
+			{
+				Matcher: recurringLineMatcher{
+					PhaseKey: "first-phase",
+					ItemKey:  "in-advance",
+				},
+				Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromFloat(6),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				})),
+				Periods: []timeutil.ClosedPeriod{
+					{
+						From: s.mustParseTime("2024-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					},
+				},
+				Charge: mo.Some(chargeExpects{
+					Status:         string(flatfee.StatusActiveRealizationProcessing),
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				}),
+			},
+		}
+		s.expectLines(*instantInvoice, subsView.Subscription.ID, instantExpectedLines)
+		s.assertChargesForLines(ctx, subsView, append(gatheringExpectedLines, instantExpectedLines...))
+		s.assertCreditThenInvoiceBalances(startBalances)
+
+		// The advance fee should have 100% discount
+		line := instantInvoice.Lines.OrEmpty()[0]
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(6), line.Totals.DiscountsTotal, "discount total")
+		s.AssertDecimalEqual(alpacadecimal.Zero, line.Totals.Total, "total")
+		s.AssertDecimalEqual(alpacadecimal.Zero, line.Totals.CreditsTotal, "credits total")
+		s.assertCreditThenInvoiceBalances(startBalances)
+	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestDiscountSynchronizationWithPartialDiscount() {
+	ctx := s.T().Context()
+	start := s.mustParseTime("2024-01-01T00:00:00Z")
+	clock.FreezeTime(start)
+	defer clock.UnFreeze()
+
+	startBalances := expectedCreditThenInvoiceBalances{
+		FBOAll:          2,
+		FBOPromotional:  2,
+		WashAll:         -2,
+		WashPromotional: -2,
+	}
+	afterInstantInvoiceBalances := expectedCreditThenInvoiceBalances{
+		FBOAll:             0,
+		FBOPromotional:     0,
+		AccruedAll:         2,
+		AccruedPromotional: 2,
+		WashAll:            -2,
+		WashPromotional:    -2,
+	}
 
 	var gatheringInvoice *billing.GatheringInvoice
 	var instantInvoice *billing.StandardInvoice
+	var subsView subscription.SubscriptionView
 
-	for _, invoice := range invoices.Items {
-		if invoice.Type() == billing.InvoiceTypeGathering {
-			invoiceAsGathering, err := invoice.AsGatheringInvoice()
+	s.Run("given promotional credits and a partially discounted subscription", func() {
+		// given:
+		// - the customer has promotional credits available
+		// - the plan uses credit-then-invoice settlement mode
+		// - the in-advance flat fee has a 50% discount
+		// when:
+		// - the subscription is created
+		// then:
+		// - the promotional credits are funded and no credit allocation has happened yet
+		s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
+
+		s.createPromotionalCreditFunding(ctx, createPromotionalCreditFundingInput{
+			Namespace: s.Namespace,
+			Customer:  s.Customer.GetID(),
+			Currency:  currencyx.Code(currency.USD),
+			Amount:    alpacadecimal.NewFromInt(2),
+			At:        start,
+		})
+		s.assertCreditThenInvoiceBalances(startBalances)
+
+		subsView = s.createSubscriptionFromPlan(plan.CreatePlanInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: s.Namespace,
+			},
+			Plan: productcatalog.Plan{
+				PlanMeta: productcatalog.PlanMeta{
+					Name:           "Test Plan",
+					Key:            "test-plan",
+					Version:        1,
+					Currency:       currency.USD,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+					ProRatingConfig: productcatalog.ProRatingConfig{
+						Enabled: true,
+						Mode:    productcatalog.ProRatingModeProratePrices,
+					},
+				},
+				Phases: []productcatalog.Phase{
+					{
+						PhaseMeta: s.phaseMeta("first-phase", ""),
+						RateCards: productcatalog.RateCards{
+							&productcatalog.UsageBasedRateCard{
+								RateCardMeta: productcatalog.RateCardMeta{
+									Key:  "in-advance",
+									Name: "in-advance",
+									Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+										Amount:      alpacadecimal.NewFromFloat(6),
+										PaymentTerm: productcatalog.InAdvancePaymentTerm,
+									}),
+									Discounts: productcatalog.Discounts{
+										Percentage: &productcatalog.PercentageDiscount{
+											Percentage: models.NewPercentage(50),
+										},
+									},
+								},
+								BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+							},
+							&productcatalog.UsageBasedRateCard{
+								RateCardMeta: productcatalog.RateCardMeta{
+									Key:        s.APIRequestsTotalFeature.Key,
+									Name:       s.APIRequestsTotalFeature.Key,
+									FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+									FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
+									Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+										Amount: alpacadecimal.NewFromFloat(10),
+									}),
+								},
+								BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+							},
+						},
+					},
+				},
+			},
+		})
+		s.assertCreditThenInvoiceBalances(startBalances)
+	})
+
+	s.Run("when syncing at subscription start", func() {
+		// given:
+		// - the subscription exists at the start of its first billing period
+		// when:
+		// - subscription sync runs just after the start timestamp
+		// then:
+		// - the payable part of the in-advance fee consumes promotional credits
+		// - future charge lines are gathered
+		s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing, and we want both the instant invoice for in advance as well as the gathering for UBP)
+		s.assertCreditThenInvoiceBalances(afterInstantInvoiceBalances)
+
+		invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
+			Customers: []string{s.Customer.ID},
+			Expand:    billing.InvoiceExpandAll,
+		})
+		s.NoError(err)
+		s.Len(invoices.Items, 2)
+		s.assertCreditThenInvoiceBalances(afterInstantInvoiceBalances)
+
+		for _, invoice := range invoices.Items {
+			if invoice.Type() == billing.InvoiceTypeGathering {
+				invoiceAsGathering, err := invoice.AsGatheringInvoice()
+				s.NoError(err)
+				gatheringInvoice = &invoiceAsGathering
+				continue
+			}
+
+			invoiceAsStandard, err := invoice.AsStandardInvoice()
 			s.NoError(err)
-			gatheringInvoice = &invoiceAsGathering
-			continue
+			instantInvoice = &invoiceAsStandard
 		}
 
-		invoiceAsStandard, err := invoice.AsStandardInvoice()
+		s.Require().NotNil(gatheringInvoice, "gathering invoice should be present")
+		s.Require().NotNil(instantInvoice, "instant invoice should be present")
+
+		s.DebugDumpInvoice("gathering invoice", *gatheringInvoice)
+		s.DebugDumpInvoice("instant invoice", *instantInvoice)
+	})
+
+	s.Run("then charges invoices and ledger balances reflect the partial discount", func() {
+		// given:
+		// - subscription sync created the gathering and instant invoices
+		// when:
+		// - invoice lines, charges, and ledger balances are inspected
+		// then:
+		// - the instant line has a 50% discount and consumes available promotional credits
+		// - the remaining invoice total is not covered by credits
+		gatheringExpectedLines := []expectedLine{
+			// Gathering invoice should have the UBP line
+			{
+				Matcher: recurringLineMatcher{
+					PhaseKey: "first-phase",
+					ItemKey:  s.APIRequestsTotalFeature.Key,
+				},
+				Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromFloat(10),
+				})),
+				Periods: []timeutil.ClosedPeriod{
+					{
+						From: s.mustParseTime("2024-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					},
+				},
+				InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
+				Charge: mo.Some(chargeExpects{
+					Status:         string(usagebased.StatusCreated),
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				}),
+			},
+			// And next Billing Period's in advance line
+			{
+				Matcher: recurringLineMatcher{
+					PhaseKey:  "first-phase",
+					ItemKey:   "in-advance",
+					PeriodMin: 1,
+					PeriodMax: 1,
+					Version:   0,
+				},
+				Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromFloat(6),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				})),
+				Periods: []timeutil.ClosedPeriod{
+					{
+						From: s.mustParseTime("2024-02-01T00:00:00Z"),
+						To:   s.mustParseTime("2024-03-01T00:00:00Z"),
+					},
+				},
+				InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
+				Charge: mo.Some(chargeExpects{
+					Status:         string(flatfee.StatusCreated),
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				}),
+			},
+		}
+		s.expectLines(*gatheringInvoice, subsView.Subscription.ID, gatheringExpectedLines)
+
+		// Instant invoice should have the in advance fee
+		instantExpectedLines := []expectedLine{
+			{
+				Matcher: recurringLineMatcher{
+					PhaseKey: "first-phase",
+					ItemKey:  "in-advance",
+				},
+				Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromFloat(6),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				})),
+				Periods: []timeutil.ClosedPeriod{
+					{
+						From: s.mustParseTime("2024-01-01T00:00:00Z"),
+						To:   s.mustParseTime("2024-02-01T00:00:00Z"),
+					},
+				},
+				Charge: mo.Some(chargeExpects{
+					Status:         string(flatfee.StatusActiveRealizationProcessing),
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				}),
+			},
+		}
+		s.expectLines(*instantInvoice, subsView.Subscription.ID, instantExpectedLines)
+		s.assertChargesForLines(ctx, subsView, append(gatheringExpectedLines, instantExpectedLines...))
+		s.assertCreditThenInvoiceBalances(afterInstantInvoiceBalances)
+
+		// The advance fee should have 50% discount and consume the available credits
+		line := instantInvoice.Lines.OrEmpty()[0]
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(6), line.Totals.Amount, "amount")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(3), line.Totals.DiscountsTotal, "discount total")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(2), line.Totals.CreditsTotal, "credits total")
+		s.AssertDecimalEqual(alpacadecimal.NewFromInt(1), line.Totals.Total, "total")
+		s.assertCreditThenInvoiceBalances(afterInstantInvoiceBalances)
+	})
+
+	s.Run("then issued invoice books the fiat remainder", func() {
+		// given:
+		// - the instant invoice has consumed all available promotional credits
+		// when:
+		// - the invoice is approved and paid by the sandbox app
+		// then:
+		// - the remaining invoice amount is booked with invoice cost basis
+		issuedInvoice, err := s.BillingService.ApproveInvoice(ctx, instantInvoice.GetInvoiceID())
 		s.NoError(err)
-		instantInvoice = &invoiceAsStandard
-	}
+		s.Equal(billing.StandardInvoiceStatusPaid, issuedInvoice.Status)
+		s.DebugDumpInvoice("issued invoice", issuedInvoice)
 
-	s.NotNil(gatheringInvoice, "gathering invoice should be present")
-	s.NotNil(instantInvoice, "instant invoice should be present")
-
-	s.DebugDumpInvoice("gathering invoice", *gatheringInvoice)
-	s.DebugDumpInvoice("instant invoice", *instantInvoice)
-
-	gatheringExpectedLines := []expectedLine{
-		// Gathering invoice should have the UBP line
-		{
-			Matcher: recurringLineMatcher{
-				PhaseKey: "first-phase",
-				ItemKey:  s.APIRequestsTotalFeature.Key,
-			},
-			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
-				Amount: alpacadecimal.NewFromFloat(10),
-			})),
-			Periods: []timeutil.ClosedPeriod{
-				{
-					From: s.mustParseTime("2024-01-01T00:00:00Z"),
-					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
-				},
-			},
-			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
-			Charge: mo.Some(chargeExpects{
-				Status:         string(usagebased.StatusCreated),
-				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
-			}),
-		},
-		// And next Billing Period's in advance line
-		{
-			Matcher: recurringLineMatcher{
-				PhaseKey:  "first-phase",
-				ItemKey:   "in-advance",
-				PeriodMin: 1,
-				PeriodMax: 1,
-				Version:   0,
-			},
-			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.FlatPrice{
-				Amount:      alpacadecimal.NewFromFloat(6),
-				PaymentTerm: productcatalog.InAdvancePaymentTerm,
-			})),
-			Periods: []timeutil.ClosedPeriod{
-				{
-					From: s.mustParseTime("2024-02-01T00:00:00Z"),
-					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
-				},
-			},
-			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
-			Charge: mo.Some(chargeExpects{
-				Status:         string(flatfee.StatusCreated),
-				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
-			}),
-		},
-	}
-	s.expectLines(*gatheringInvoice, subsView.Subscription.ID, gatheringExpectedLines)
-
-	// Instant invoice should have the in advance fee
-	instantExpectedLines := []expectedLine{
-		{
-			Matcher: recurringLineMatcher{
-				PhaseKey: "first-phase",
-				ItemKey:  "in-advance",
-			},
-			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.FlatPrice{
-				Amount:      alpacadecimal.NewFromFloat(6),
-				PaymentTerm: productcatalog.InAdvancePaymentTerm,
-			})),
-			Periods: []timeutil.ClosedPeriod{
-				{
-					From: s.mustParseTime("2024-01-01T00:00:00Z"),
-					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
-				},
-			},
-			Charge: mo.Some(chargeExpects{
-				Status:         string(flatfee.StatusActiveRealizationProcessing),
-				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
-			}),
-		},
-	}
-	s.expectLines(*instantInvoice, subsView.Subscription.ID, instantExpectedLines)
-	s.assertChargesForLines(ctx, subsView, append(gatheringExpectedLines, instantExpectedLines...))
-
-	// The advance fee should have 100% discount
-	line := instantInvoice.Lines.OrEmpty()[0]
-	s.Len(line.DetailedLines, 1)
-	child := line.DetailedLines[0]
-
-	s.Equal(float64(6), child.AmountDiscounts[0].Amount.InexactFloat64())
+		s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{
+			FBOAll:             0,
+			FBOPromotional:     0,
+			AccruedAll:         3,
+			AccruedPromotional: 2,
+			AccruedInvoice:     1,
+			WashAll:            -3,
+			WashPromotional:    -2,
+			WashInvoice:        -1,
+		})
+	})
 }
 
 func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionProratingBehavior() {
@@ -5615,7 +5938,7 @@ func (s *CreditThenInvoiceTestSuite) assertCreditThenInvoiceUsageBasedCharge(cha
 	s.Equal(input.InvoiceAt, charge.Intent.InvoiceAt)
 	s.Equal(input.CustomerID, charge.Intent.CustomerID)
 	s.Equal(input.FeatureKey, charge.Intent.FeatureKey)
-	s.Equal(input.Price, charge.Intent.Price)
+	s.Truef(input.Price.Equal(&charge.Intent.Price), "price expected %v, got %v", input.Price, charge.Intent.Price)
 	s.Require().NotNil(charge.Intent.Subscription)
 	s.Equal(input.SubscriptionID, charge.Intent.Subscription.SubscriptionID)
 	s.Equal(input.PhaseID, charge.Intent.Subscription.PhaseID)

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -3033,6 +3033,22 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
+	s.Run("dry run does not repair the persisted charge item reference", func() {
+		chargeBeforeDryRun := s.mustGetOnlyUsageBasedCharge(ctx, subsView.Subscription.ID)
+		s.Require().NotNil(chargeBeforeDryRun.Intent.Subscription)
+		itemIDBeforeDryRun := chargeBeforeDryRun.Intent.Subscription.ItemID
+
+		phase := s.getPhaseByKey(s.T(), updatedSubsView, "first-phase")
+		targetItemID := phase.ItemsByKey[s.APIRequestsTotalFeature.Key][0].SubscriptionItem.ID
+		s.NotEqual(itemIDBeforeDryRun, targetItemID)
+
+		s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z"), subscriptionsync.EnableDryRun()))
+
+		chargeAfterDryRun := s.mustGetOnlyUsageBasedCharge(ctx, subsView.Subscription.ID)
+		s.Require().NotNil(chargeAfterDryRun.Intent.Subscription)
+		s.Equal(itemIDBeforeDryRun, chargeAfterDryRun.Intent.Subscription.ItemID)
+	})
+
 	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	// gathering invoice

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -510,7 +510,6 @@ func (s *CreditThenInvoiceTestSuite) TestSubscriptionHappyPath() {
 			From: s.mustParseTime("2024-02-15T00:00:00Z"),
 			To:   s.mustParseTime("2024-03-01T00:00:00Z"),
 		})
-
 	})
 
 	s.Run("subscription cancellation", func() {
@@ -3098,21 +3097,23 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
 }
 
 func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice() {
-	s.T().Skip("TODO: transform this copied suite into credit then invoice settlement mode validation")
-
 	ctx := s.T().Context()
 	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:00Z"))
+	defer clock.UnFreeze()
 
-	// Given
-	//  we have a subscription with a single phase with an usage based price, and the gathering invoice contains the items
-	//  a draft invoice has been created.
-	// When
-	//  we add a new phase, that disrupts the period of previous items with a new usage based qty due to the period changes for the same feature
-	// Then
-	//  the gathering invoice is updated, the period of the previous items are updated accordingly in the draft invoice
+	// given:
+	// - we have a credit-then-invoice subscription with a single phase with an usage based price
+	// - a draft invoice has been created
+	// when:
+	// - we add a new phase, that disrupts the period of previous items with a new usage based qty due to the period changes for the same feature
+	// then:
+	// - the gathering invoice is updated, the period of the previous items are updated accordingly in the draft invoice
+	// - charges are reconciled without ledger movement before invoice issuance
 	//
 	// NOTE: this simulates late event processing when we are severely behind the real time in billing worker (~1 day), this should not
 	// happen, but we support this scenario
+
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
 	// Initialize events
 	s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 0, s.mustParseTime("2023-01-01T00:00:00Z"))
@@ -3120,21 +3121,40 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 	s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 3, s.mustParseTime("2024-01-01T12:00:00Z"))
 	s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 6, s.mustParseTime("2024-01-02T00:00:00Z"))
 
-	subsView := s.createSubscriptionFromPlanPhases([]productcatalog.Phase{
-		{
-			PhaseMeta: s.phaseMeta("first-phase", ""),
-			RateCards: productcatalog.RateCards{
-				&productcatalog.UsageBasedRateCard{
-					RateCardMeta: productcatalog.RateCardMeta{
-						Key:        s.APIRequestsTotalFeature.Key,
-						Name:       s.APIRequestsTotalFeature.Key,
-						FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
-						FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
-						Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
-							Amount: alpacadecimal.NewFromFloat(10),
-						}),
+	subsView := s.createSubscriptionFromPlan(plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: s.Namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Test Plan",
+				Key:            "test-plan",
+				Version:        1,
+				Currency:       currency.USD,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+				ProRatingConfig: productcatalog.ProRatingConfig{
+					Enabled: true,
+					Mode:    productcatalog.ProRatingModeProratePrices,
+				},
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: s.phaseMeta("first-phase", ""),
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:        s.APIRequestsTotalFeature.Key,
+								Name:       s.APIRequestsTotalFeature.Key,
+								FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+								FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
+								Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+									Amount: alpacadecimal.NewFromFloat(10),
+								}),
+							},
+							BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+						},
 					},
-					BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
 				},
 			},
 		},
@@ -3142,6 +3162,41 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 
 	// we sync two months so we have lines on gathering
 	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
+
+	initialExpectedLines := []expectedLine{
+		{
+			Matcher: recurringLineMatcher{
+				PhaseKey:  "first-phase",
+				ItemKey:   s.APIRequestsTotalFeature.Key,
+				Version:   0,
+				PeriodMin: 0,
+				PeriodMax: 1,
+			},
+			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromFloat(10),
+			})),
+			Periods: []timeutil.ClosedPeriod{
+				{
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
+				},
+				{
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
+				},
+			},
+			InvoiceAt: mo.Some([]time.Time{
+				s.mustParseTime("2024-02-01T00:00:00Z"),
+				s.mustParseTime("2024-03-01T00:00:00Z"),
+			}),
+			Charge: mo.Some(chargeExpects{
+				Status:         string(usagebased.StatusCreated),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			}),
+		},
+	}
+	s.assertChargesForLines(ctx, subsView, initialExpectedLines)
 
 	// Some time has passed, we're syncing the draft invoice
 	clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
@@ -3153,6 +3208,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 
 	draftInvoice := draftInvoices[0]
 	s.DebugDumpInvoice("draft invoice", draftInvoice)
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 	s.expectLines(draftInvoice, subsView.Subscription.ID, []expectedLine{
 		{
 			Matcher: recurringLineMatcher{
@@ -3174,6 +3230,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
 	s.expectLines(gatheringInvoice, subsView.Subscription.ID, []expectedLine{
 		{
@@ -3230,12 +3287,37 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 	// Now the time-travel is over, let's reset back to the "present"
 	clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
 	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
 	// gathering invoice
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - 2nd sync", gatheringInvoice)
 
-	s.expectLines(gatheringInvoice, subsView.Subscription.ID, []expectedLine{
+	updatedGatheringExpectedLines := []expectedLine{
+		// The mutable draft line is deleted and recreated as a gathering line for the shortened first phase.
+		{
+			Matcher: recurringLineMatcher{
+				PhaseKey:  "first-phase",
+				ItemKey:   s.APIRequestsTotalFeature.Key,
+				Version:   0,
+				PeriodMin: 0,
+				PeriodMax: 0,
+			},
+			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromFloat(10),
+			})),
+			Periods: []timeutil.ClosedPeriod{
+				{
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-31T00:00:00Z"),
+				},
+			},
+			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-31T00:00:00Z")}),
+			Charge: mo.Some(chargeExpects{
+				Status:         string(usagebased.StatusActive),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			}),
+		},
 		{
 			Matcher: recurringLineMatcher{
 				PhaseKey:  "second-phase",
@@ -3254,6 +3336,10 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
+			Charge: mo.Some(chargeExpects{
+				Status:         string(usagebased.StatusCreated),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			}),
 		},
 		{
 			Matcher: recurringLineMatcher{
@@ -3273,8 +3359,14 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 				},
 			},
 			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-03-01T00:00:00Z")}),
+			Charge: mo.Some(chargeExpects{
+				Status:         string(usagebased.StatusCreated),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			}),
 		},
-	})
+	}
+	s.assertChargesForLines(ctx, updatedSubsView, updatedGatheringExpectedLines)
+	s.expectLines(gatheringInvoice, subsView.Subscription.ID, updatedGatheringExpectedLines)
 
 	updatedDraftInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
 		Invoice: draftInvoice.GetInvoiceID(),
@@ -3282,47 +3374,64 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 	})
 	s.NoError(err)
 	s.DebugDumpInvoice("draft invoice - 2nd sync", updatedDraftInvoice)
-
-	s.expectLines(updatedDraftInvoice, subsView.Subscription.ID, []expectedLine{
-		{
-			Matcher: recurringLineMatcher{
-				PhaseKey: "first-phase",
-				ItemKey:  s.APIRequestsTotalFeature.Key,
-			},
-
-			Qty: mo.Some[float64](11),
-			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
-				Amount: alpacadecimal.NewFromFloat(10),
-			})),
-			Periods: []timeutil.ClosedPeriod{
-				{
-					From: s.mustParseTime("2024-01-01T00:00:00Z"),
-					To:   s.mustParseTime("2024-01-31T00:00:00Z"),
-				},
-			},
-		},
-	})
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
+	s.expectLines(updatedDraftInvoice, subsView.Subscription.ID, nil)
 }
 
 func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateIssuedInvoice() {
-	s.T().Skip("TODO: transform this copied suite into credit then invoice settlement mode validation")
-
 	ctx := s.T().Context()
 	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:00Z"))
+	defer clock.UnFreeze()
 
-	// Given
-	//  we have a subscription with a single phase with an usage based price, and the gathering invoice contains the items
-	//  an issued invoice has been created.
-	// When
-	//  when we add a new phase, that disrupts the period of previous items with a new usage based qty due to the period changes for
-	//  the same feature
-	// Then
-	//  then the gathering invoice is updated, the finalized invoice doesn't get updated with the periods, but a validation issue is added
+	// given:
+	// - we have a credit-then-invoice subscription with a single phase with an usage based price
+	// - an issued invoice has been created
+	// when:
+	// - we add a new phase, that disrupts the period of previous items with a new usage based qty due to the period changes for the same feature
+	// then:
+	// - the gathering invoice is updated
+	// - the paid invoice and its ledger bookings are not updated
+	// - a validation issue is added for the immutable invoice change
 	//
 	// NOTE: this simulates late event processing when we are severely behind the real time in billing worker (~1 day), this should not
 	// happen, but we support this scenario
 	//
 	// NOTE: This is variant of the TestUsageBasedGatheringUpdateDraftInvoice so we are keeping the checks at a minimum here
+
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
+	s.createPromotionalCreditFunding(ctx, createPromotionalCreditFundingInput{
+		Namespace: s.Namespace,
+		Customer:  s.Customer.GetID(),
+		Currency:  currencyx.Code(currency.USD),
+		Amount:    alpacadecimal.NewFromInt(2),
+		At:        clock.Now(),
+	})
+
+	startBalances := expectedCreditThenInvoiceBalances{
+		FBOAll:          2,
+		FBOPromotional:  2,
+		WashAll:         -2,
+		WashPromotional: -2,
+	}
+	afterDraftInvoiceBalances := expectedCreditThenInvoiceBalances{
+		FBOAll:             0,
+		FBOPromotional:     0,
+		AccruedAll:         2,
+		AccruedPromotional: 2,
+		WashAll:            -2,
+		WashPromotional:    -2,
+	}
+	afterIssuedInvoiceBalances := expectedCreditThenInvoiceBalances{
+		FBOAll:             0,
+		FBOPromotional:     0,
+		AccruedAll:         120,
+		AccruedPromotional: 2,
+		AccruedInvoice:     118,
+		WashAll:            -120,
+		WashPromotional:    -2,
+		WashInvoice:        -118,
+	}
+	s.assertCreditThenInvoiceBalances(startBalances)
 
 	// Initialize events
 	s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 0, s.mustParseTime("2023-01-01T00:00:00Z"))
@@ -3332,27 +3441,81 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateIssuedInvoice(
 	// We need usage at the period change to trigger the validation issue
 	s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 1, s.mustParseTime("2024-01-31T12:00:00Z"))
 
-	subsView := s.createSubscriptionFromPlanPhases([]productcatalog.Phase{
-		{
-			PhaseMeta: s.phaseMeta("first-phase", ""),
-			RateCards: productcatalog.RateCards{
-				&productcatalog.UsageBasedRateCard{
-					RateCardMeta: productcatalog.RateCardMeta{
-						Key:        s.APIRequestsTotalFeature.Key,
-						Name:       s.APIRequestsTotalFeature.Key,
-						FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
-						FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
-						Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
-							Amount: alpacadecimal.NewFromFloat(10),
-						}),
+	subsView := s.createSubscriptionFromPlan(plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: s.Namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Test Plan",
+				Key:            "test-plan",
+				Version:        1,
+				Currency:       currency.USD,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+				ProRatingConfig: productcatalog.ProRatingConfig{
+					Enabled: true,
+					Mode:    productcatalog.ProRatingModeProratePrices,
+				},
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: s.phaseMeta("first-phase", ""),
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:        s.APIRequestsTotalFeature.Key,
+								Name:       s.APIRequestsTotalFeature.Key,
+								FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+								FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
+								Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+									Amount: alpacadecimal.NewFromFloat(10),
+								}),
+							},
+							BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+						},
 					},
-					BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
 				},
 			},
 		},
 	})
 
 	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.assertCreditThenInvoiceBalances(startBalances)
+
+	initialExpectedLines := []expectedLine{
+		{
+			Matcher: recurringLineMatcher{
+				PhaseKey:  "first-phase",
+				ItemKey:   s.APIRequestsTotalFeature.Key,
+				Version:   0,
+				PeriodMin: 0,
+				PeriodMax: 1,
+			},
+			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromFloat(10),
+			})),
+			Periods: []timeutil.ClosedPeriod{
+				{
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
+				},
+				{
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
+				},
+			},
+			InvoiceAt: mo.Some([]time.Time{
+				s.mustParseTime("2024-02-01T00:00:00Z"),
+				s.mustParseTime("2024-03-01T00:00:00Z"),
+			}),
+			Charge: mo.Some(chargeExpects{
+				Status:         string(usagebased.StatusCreated),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			}),
+		},
+	}
+	s.assertChargesForLines(ctx, subsView, initialExpectedLines)
 
 	clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
 	draftInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
@@ -3360,15 +3523,22 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateIssuedInvoice(
 	})
 	s.NoError(err)
 	s.Len(draftInvoices, 1)
+	s.assertCreditThenInvoiceBalances(afterDraftInvoiceBalances)
 
 	draftInvoice := draftInvoices[0]
+	s.Equal(billing.StandardInvoiceStatusDraftWaitingForCollection, draftInvoice.Status)
+
+	draftInvoice, err = s.BillingService.SnapshotQuantities(ctx, draftInvoice.GetInvoiceID())
+	s.NoError(err)
 	s.Equal(billing.StandardInvoiceStatusDraftWaitingAutoApproval, draftInvoice.Status)
+	s.assertCreditThenInvoiceBalances(afterDraftInvoiceBalances)
 
 	issuedInvoice, err := s.BillingService.ApproveInvoice(ctx, draftInvoice.GetInvoiceID())
 	s.NoError(err)
 	s.Equal(billing.StandardInvoiceStatusPaid, issuedInvoice.Status)
 	s.Len(issuedInvoice.ValidationIssues, 0)
 	s.DebugDumpInvoice("issued invoice", issuedInvoice)
+	s.assertCreditThenInvoiceBalances(afterIssuedInvoiceBalances)
 	s.expectLines(issuedInvoice, subsView.Subscription.ID, []expectedLine{
 		{
 			Matcher: recurringLineMatcher{
@@ -3390,6 +3560,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateIssuedInvoice(
 	})
 
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
+	s.assertCreditThenInvoiceBalances(afterIssuedInvoiceBalances)
 
 	// Now lets travel back in time
 	clock.FreezeTime(s.mustParseTime("2024-01-30T00:00:00Z"))
@@ -3421,9 +3592,85 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateIssuedInvoice(
 	// Let's reset back the clock to the last sync's time
 	clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
 	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.assertCreditThenInvoiceBalances(afterIssuedInvoiceBalances)
 
 	// gathering invoice
-	s.DebugDumpInvoice("gathering invoice - 2nd sync", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
+	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	s.DebugDumpInvoice("gathering invoice - 2nd sync", gatheringInvoice)
+
+	updatedGatheringExpectedLines := []expectedLine{
+		{
+			Matcher: recurringLineMatcher{
+				PhaseKey:  "first-phase",
+				ItemKey:   s.APIRequestsTotalFeature.Key,
+				Version:   0,
+				PeriodMin: 0,
+				PeriodMax: 0,
+			},
+			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromFloat(10),
+			})),
+			Periods: []timeutil.ClosedPeriod{
+				{
+					From: s.mustParseTime("2024-01-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-01-31T00:00:00Z"),
+				},
+			},
+			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-01-31T00:00:00Z")}),
+			Charge: mo.Some(chargeExpects{
+				Status:         string(usagebased.StatusActive),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			}),
+		},
+		{
+			Matcher: recurringLineMatcher{
+				PhaseKey:  "second-phase",
+				ItemKey:   s.APIRequestsTotalFeature.Key,
+				Version:   0,
+				PeriodMin: 0,
+				PeriodMax: 0,
+			},
+			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromFloat(5),
+			})),
+			Periods: []timeutil.ClosedPeriod{
+				{
+					From: s.mustParseTime("2024-01-31T00:00:00Z"),
+					To:   s.mustParseTime("2024-02-01T00:00:00Z"),
+				},
+			},
+			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-02-01T00:00:00Z")}),
+			Charge: mo.Some(chargeExpects{
+				Status:         string(usagebased.StatusCreated),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			}),
+		},
+		{
+			Matcher: recurringLineMatcher{
+				PhaseKey:  "second-phase",
+				ItemKey:   s.APIRequestsTotalFeature.Key,
+				Version:   0,
+				PeriodMin: 1,
+				PeriodMax: 1,
+			},
+			Price: mo.Some(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: alpacadecimal.NewFromFloat(5),
+			})),
+			Periods: []timeutil.ClosedPeriod{
+				{
+					From: s.mustParseTime("2024-02-01T00:00:00Z"),
+					To:   s.mustParseTime("2024-03-01T00:00:00Z"),
+				},
+			},
+			InvoiceAt: mo.Some([]time.Time{s.mustParseTime("2024-03-01T00:00:00Z")}),
+			Charge: mo.Some(chargeExpects{
+				Status:         string(usagebased.StatusCreated),
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+			}),
+		},
+	}
+	s.assertChargesForLines(ctx, updatedSubsView, updatedGatheringExpectedLines)
+	s.expectLines(gatheringInvoice, subsView.Subscription.ID, updatedGatheringExpectedLines)
 
 	updatedIssuedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
 		Invoice: issuedInvoice.GetInvoiceID(),
@@ -3431,6 +3678,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateIssuedInvoice(
 	})
 	s.NoError(err)
 	s.DebugDumpInvoice("issued invoice - 2nd sync", updatedIssuedInvoice)
+	s.assertCreditThenInvoiceBalances(afterIssuedInvoiceBalances)
 
 	s.expectLines(updatedIssuedInvoice, subsView.Subscription.ID, []expectedLine{
 		{
@@ -3452,6 +3700,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateIssuedInvoice(
 		},
 	})
 
+	s.Len(updatedIssuedInvoice.ValidationIssues, 1)
 	s.expectValidationIssueForLine(updatedIssuedInvoice.Lines.OrEmpty()[0], updatedIssuedInvoice.ValidationIssues[0])
 }
 
@@ -5673,7 +5922,7 @@ func (s *CreditThenInvoiceTestSuite) TestSyncStateUpdateWithFreePhaseActiveInThe
 func (s *CreditThenInvoiceTestSuite) expectValidationIssueForLine(line *billing.StandardLine, issue billing.ValidationIssue) {
 	s.Equal(billing.ValidationIssueSeverityWarning, issue.Severity)
 	s.Equal(billing.ImmutableInvoiceHandlingNotSupportedErrorCode, issue.Code)
-	s.Equal(SubscriptionSyncComponentName, issue.Component)
+	s.Equal(billing.ComponentName("charges.invoiceupdater"), issue.Component)
 	s.Equal(fmt.Sprintf("lines/%s", line.ID), issue.Path)
 }
 

--- a/openmeter/ent/db/chargecreditpurchase_create.go
+++ b/openmeter/ent/db/chargecreditpurchase_create.go
@@ -1023,6 +1023,24 @@ func (u *ChargeCreditPurchaseUpsert) UpdateManagedBy() *ChargeCreditPurchaseUpse
 	return u
 }
 
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (u *ChargeCreditPurchaseUpsert) SetSubscriptionItemID(v string) *ChargeCreditPurchaseUpsert {
+	u.Set(chargecreditpurchase.FieldSubscriptionItemID, v)
+	return u
+}
+
+// UpdateSubscriptionItemID sets the "subscription_item_id" field to the value that was provided on create.
+func (u *ChargeCreditPurchaseUpsert) UpdateSubscriptionItemID() *ChargeCreditPurchaseUpsert {
+	u.SetExcluded(chargecreditpurchase.FieldSubscriptionItemID)
+	return u
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (u *ChargeCreditPurchaseUpsert) ClearSubscriptionItemID() *ChargeCreditPurchaseUpsert {
+	u.SetNull(chargecreditpurchase.FieldSubscriptionItemID)
+	return u
+}
+
 // SetAdvanceAfter sets the "advance_after" field.
 func (u *ChargeCreditPurchaseUpsert) SetAdvanceAfter(v time.Time) *ChargeCreditPurchaseUpsert {
 	u.Set(chargecreditpurchase.FieldAdvanceAfter, v)
@@ -1241,9 +1259,6 @@ func (u *ChargeCreditPurchaseUpsertOne) UpdateNewValues() *ChargeCreditPurchaseU
 		if _, exists := u.create.mutation.SubscriptionPhaseID(); exists {
 			s.SetIgnore(chargecreditpurchase.FieldSubscriptionPhaseID)
 		}
-		if _, exists := u.create.mutation.SubscriptionItemID(); exists {
-			s.SetIgnore(chargecreditpurchase.FieldSubscriptionItemID)
-		}
 		if _, exists := u.create.mutation.Namespace(); exists {
 			s.SetIgnore(chargecreditpurchase.FieldNamespace)
 		}
@@ -1396,6 +1411,27 @@ func (u *ChargeCreditPurchaseUpsertOne) SetManagedBy(v billing.InvoiceLineManage
 func (u *ChargeCreditPurchaseUpsertOne) UpdateManagedBy() *ChargeCreditPurchaseUpsertOne {
 	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
 		s.UpdateManagedBy()
+	})
+}
+
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (u *ChargeCreditPurchaseUpsertOne) SetSubscriptionItemID(v string) *ChargeCreditPurchaseUpsertOne {
+	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
+		s.SetSubscriptionItemID(v)
+	})
+}
+
+// UpdateSubscriptionItemID sets the "subscription_item_id" field to the value that was provided on create.
+func (u *ChargeCreditPurchaseUpsertOne) UpdateSubscriptionItemID() *ChargeCreditPurchaseUpsertOne {
+	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
+		s.UpdateSubscriptionItemID()
+	})
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (u *ChargeCreditPurchaseUpsertOne) ClearSubscriptionItemID() *ChargeCreditPurchaseUpsertOne {
+	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
+		s.ClearSubscriptionItemID()
 	})
 }
 
@@ -1817,9 +1853,6 @@ func (u *ChargeCreditPurchaseUpsertBulk) UpdateNewValues() *ChargeCreditPurchase
 			if _, exists := b.mutation.SubscriptionPhaseID(); exists {
 				s.SetIgnore(chargecreditpurchase.FieldSubscriptionPhaseID)
 			}
-			if _, exists := b.mutation.SubscriptionItemID(); exists {
-				s.SetIgnore(chargecreditpurchase.FieldSubscriptionItemID)
-			}
 			if _, exists := b.mutation.Namespace(); exists {
 				s.SetIgnore(chargecreditpurchase.FieldNamespace)
 			}
@@ -1973,6 +2006,27 @@ func (u *ChargeCreditPurchaseUpsertBulk) SetManagedBy(v billing.InvoiceLineManag
 func (u *ChargeCreditPurchaseUpsertBulk) UpdateManagedBy() *ChargeCreditPurchaseUpsertBulk {
 	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
 		s.UpdateManagedBy()
+	})
+}
+
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (u *ChargeCreditPurchaseUpsertBulk) SetSubscriptionItemID(v string) *ChargeCreditPurchaseUpsertBulk {
+	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
+		s.SetSubscriptionItemID(v)
+	})
+}
+
+// UpdateSubscriptionItemID sets the "subscription_item_id" field to the value that was provided on create.
+func (u *ChargeCreditPurchaseUpsertBulk) UpdateSubscriptionItemID() *ChargeCreditPurchaseUpsertBulk {
+	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
+		s.UpdateSubscriptionItemID()
+	})
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (u *ChargeCreditPurchaseUpsertBulk) ClearSubscriptionItemID() *ChargeCreditPurchaseUpsertBulk {
+	return u.Update(func(s *ChargeCreditPurchaseUpsert) {
+		s.ClearSubscriptionItemID()
 	})
 }
 

--- a/openmeter/ent/db/chargecreditpurchase_update.go
+++ b/openmeter/ent/db/chargecreditpurchase_update.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargecreditpurchaseexternalpayment"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargecreditpurchaseinvoicedpayment"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionitem"
 	dbtaxcode "github.com/openmeterio/openmeter/openmeter/ent/db/taxcode"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -147,6 +148,26 @@ func (_u *ChargeCreditPurchaseUpdate) SetNillableManagedBy(v *billing.InvoiceLin
 	if v != nil {
 		_u.SetManagedBy(*v)
 	}
+	return _u
+}
+
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (_u *ChargeCreditPurchaseUpdate) SetSubscriptionItemID(v string) *ChargeCreditPurchaseUpdate {
+	_u.mutation.SetSubscriptionItemID(v)
+	return _u
+}
+
+// SetNillableSubscriptionItemID sets the "subscription_item_id" field if the given value is not nil.
+func (_u *ChargeCreditPurchaseUpdate) SetNillableSubscriptionItemID(v *string) *ChargeCreditPurchaseUpdate {
+	if v != nil {
+		_u.SetSubscriptionItemID(*v)
+	}
+	return _u
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (_u *ChargeCreditPurchaseUpdate) ClearSubscriptionItemID() *ChargeCreditPurchaseUpdate {
+	_u.mutation.ClearSubscriptionItemID()
 	return _u
 }
 
@@ -393,6 +414,11 @@ func (_u *ChargeCreditPurchaseUpdate) SetCreditGrant(v *ChargeCreditPurchaseCred
 	return _u.SetCreditGrantID(v.ID)
 }
 
+// SetSubscriptionItem sets the "subscription_item" edge to the SubscriptionItem entity.
+func (_u *ChargeCreditPurchaseUpdate) SetSubscriptionItem(v *SubscriptionItem) *ChargeCreditPurchaseUpdate {
+	return _u.SetSubscriptionItemID(v.ID)
+}
+
 // SetTaxCode sets the "tax_code" edge to the TaxCode entity.
 func (_u *ChargeCreditPurchaseUpdate) SetTaxCode(v *TaxCode) *ChargeCreditPurchaseUpdate {
 	return _u.SetTaxCodeID(v.ID)
@@ -418,6 +444,12 @@ func (_u *ChargeCreditPurchaseUpdate) ClearInvoicedPayment() *ChargeCreditPurcha
 // ClearCreditGrant clears the "credit_grant" edge to the ChargeCreditPurchaseCreditGrant entity.
 func (_u *ChargeCreditPurchaseUpdate) ClearCreditGrant() *ChargeCreditPurchaseUpdate {
 	_u.mutation.ClearCreditGrant()
+	return _u
+}
+
+// ClearSubscriptionItem clears the "subscription_item" edge to the SubscriptionItem entity.
+func (_u *ChargeCreditPurchaseUpdate) ClearSubscriptionItem() *ChargeCreditPurchaseUpdate {
+	_u.mutation.ClearSubscriptionItem()
 	return _u
 }
 
@@ -683,6 +715,35 @@ func (_u *ChargeCreditPurchaseUpdate) sqlSave(ctx context.Context) (_node int, e
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if _u.mutation.SubscriptionItemCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargecreditpurchase.SubscriptionItemTable,
+			Columns: []string{chargecreditpurchase.SubscriptionItemColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(subscriptionitem.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.SubscriptionItemIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargecreditpurchase.SubscriptionItemTable,
+			Columns: []string{chargecreditpurchase.SubscriptionItemColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(subscriptionitem.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if _u.mutation.TaxCodeCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -841,6 +902,26 @@ func (_u *ChargeCreditPurchaseUpdateOne) SetNillableManagedBy(v *billing.Invoice
 	if v != nil {
 		_u.SetManagedBy(*v)
 	}
+	return _u
+}
+
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (_u *ChargeCreditPurchaseUpdateOne) SetSubscriptionItemID(v string) *ChargeCreditPurchaseUpdateOne {
+	_u.mutation.SetSubscriptionItemID(v)
+	return _u
+}
+
+// SetNillableSubscriptionItemID sets the "subscription_item_id" field if the given value is not nil.
+func (_u *ChargeCreditPurchaseUpdateOne) SetNillableSubscriptionItemID(v *string) *ChargeCreditPurchaseUpdateOne {
+	if v != nil {
+		_u.SetSubscriptionItemID(*v)
+	}
+	return _u
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (_u *ChargeCreditPurchaseUpdateOne) ClearSubscriptionItemID() *ChargeCreditPurchaseUpdateOne {
+	_u.mutation.ClearSubscriptionItemID()
 	return _u
 }
 
@@ -1087,6 +1168,11 @@ func (_u *ChargeCreditPurchaseUpdateOne) SetCreditGrant(v *ChargeCreditPurchaseC
 	return _u.SetCreditGrantID(v.ID)
 }
 
+// SetSubscriptionItem sets the "subscription_item" edge to the SubscriptionItem entity.
+func (_u *ChargeCreditPurchaseUpdateOne) SetSubscriptionItem(v *SubscriptionItem) *ChargeCreditPurchaseUpdateOne {
+	return _u.SetSubscriptionItemID(v.ID)
+}
+
 // SetTaxCode sets the "tax_code" edge to the TaxCode entity.
 func (_u *ChargeCreditPurchaseUpdateOne) SetTaxCode(v *TaxCode) *ChargeCreditPurchaseUpdateOne {
 	return _u.SetTaxCodeID(v.ID)
@@ -1112,6 +1198,12 @@ func (_u *ChargeCreditPurchaseUpdateOne) ClearInvoicedPayment() *ChargeCreditPur
 // ClearCreditGrant clears the "credit_grant" edge to the ChargeCreditPurchaseCreditGrant entity.
 func (_u *ChargeCreditPurchaseUpdateOne) ClearCreditGrant() *ChargeCreditPurchaseUpdateOne {
 	_u.mutation.ClearCreditGrant()
+	return _u
+}
+
+// ClearSubscriptionItem clears the "subscription_item" edge to the SubscriptionItem entity.
+func (_u *ChargeCreditPurchaseUpdateOne) ClearSubscriptionItem() *ChargeCreditPurchaseUpdateOne {
+	_u.mutation.ClearSubscriptionItem()
 	return _u
 }
 
@@ -1400,6 +1492,35 @@ func (_u *ChargeCreditPurchaseUpdateOne) sqlSave(ctx context.Context) (_node *Ch
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(chargecreditpurchasecreditgrant.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.SubscriptionItemCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargecreditpurchase.SubscriptionItemTable,
+			Columns: []string{chargecreditpurchase.SubscriptionItemColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(subscriptionitem.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.SubscriptionItemIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargecreditpurchase.SubscriptionItemTable,
+			Columns: []string{chargecreditpurchase.SubscriptionItemColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(subscriptionitem.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/openmeter/ent/db/chargeflatfee_create.go
+++ b/openmeter/ent/db/chargeflatfee_create.go
@@ -1098,6 +1098,24 @@ func (u *ChargeFlatFeeUpsert) UpdateManagedBy() *ChargeFlatFeeUpsert {
 	return u
 }
 
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (u *ChargeFlatFeeUpsert) SetSubscriptionItemID(v string) *ChargeFlatFeeUpsert {
+	u.Set(chargeflatfee.FieldSubscriptionItemID, v)
+	return u
+}
+
+// UpdateSubscriptionItemID sets the "subscription_item_id" field to the value that was provided on create.
+func (u *ChargeFlatFeeUpsert) UpdateSubscriptionItemID() *ChargeFlatFeeUpsert {
+	u.SetExcluded(chargeflatfee.FieldSubscriptionItemID)
+	return u
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (u *ChargeFlatFeeUpsert) ClearSubscriptionItemID() *ChargeFlatFeeUpsert {
+	u.SetNull(chargeflatfee.FieldSubscriptionItemID)
+	return u
+}
+
 // SetAdvanceAfter sets the "advance_after" field.
 func (u *ChargeFlatFeeUpsert) SetAdvanceAfter(v time.Time) *ChargeFlatFeeUpsert {
 	u.Set(chargeflatfee.FieldAdvanceAfter, v)
@@ -1424,9 +1442,6 @@ func (u *ChargeFlatFeeUpsertOne) UpdateNewValues() *ChargeFlatFeeUpsertOne {
 		if _, exists := u.create.mutation.SubscriptionPhaseID(); exists {
 			s.SetIgnore(chargeflatfee.FieldSubscriptionPhaseID)
 		}
-		if _, exists := u.create.mutation.SubscriptionItemID(); exists {
-			s.SetIgnore(chargeflatfee.FieldSubscriptionItemID)
-		}
 		if _, exists := u.create.mutation.Namespace(); exists {
 			s.SetIgnore(chargeflatfee.FieldNamespace)
 		}
@@ -1576,6 +1591,27 @@ func (u *ChargeFlatFeeUpsertOne) SetManagedBy(v billing.InvoiceLineManagedBy) *C
 func (u *ChargeFlatFeeUpsertOne) UpdateManagedBy() *ChargeFlatFeeUpsertOne {
 	return u.Update(func(s *ChargeFlatFeeUpsert) {
 		s.UpdateManagedBy()
+	})
+}
+
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (u *ChargeFlatFeeUpsertOne) SetSubscriptionItemID(v string) *ChargeFlatFeeUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.SetSubscriptionItemID(v)
+	})
+}
+
+// UpdateSubscriptionItemID sets the "subscription_item_id" field to the value that was provided on create.
+func (u *ChargeFlatFeeUpsertOne) UpdateSubscriptionItemID() *ChargeFlatFeeUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.UpdateSubscriptionItemID()
+	})
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (u *ChargeFlatFeeUpsertOne) ClearSubscriptionItemID() *ChargeFlatFeeUpsertOne {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.ClearSubscriptionItemID()
 	})
 }
 
@@ -2123,9 +2159,6 @@ func (u *ChargeFlatFeeUpsertBulk) UpdateNewValues() *ChargeFlatFeeUpsertBulk {
 			if _, exists := b.mutation.SubscriptionPhaseID(); exists {
 				s.SetIgnore(chargeflatfee.FieldSubscriptionPhaseID)
 			}
-			if _, exists := b.mutation.SubscriptionItemID(); exists {
-				s.SetIgnore(chargeflatfee.FieldSubscriptionItemID)
-			}
 			if _, exists := b.mutation.Namespace(); exists {
 				s.SetIgnore(chargeflatfee.FieldNamespace)
 			}
@@ -2276,6 +2309,27 @@ func (u *ChargeFlatFeeUpsertBulk) SetManagedBy(v billing.InvoiceLineManagedBy) *
 func (u *ChargeFlatFeeUpsertBulk) UpdateManagedBy() *ChargeFlatFeeUpsertBulk {
 	return u.Update(func(s *ChargeFlatFeeUpsert) {
 		s.UpdateManagedBy()
+	})
+}
+
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (u *ChargeFlatFeeUpsertBulk) SetSubscriptionItemID(v string) *ChargeFlatFeeUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.SetSubscriptionItemID(v)
+	})
+}
+
+// UpdateSubscriptionItemID sets the "subscription_item_id" field to the value that was provided on create.
+func (u *ChargeFlatFeeUpsertBulk) UpdateSubscriptionItemID() *ChargeFlatFeeUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.UpdateSubscriptionItemID()
+	})
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (u *ChargeFlatFeeUpsertBulk) ClearSubscriptionItemID() *ChargeFlatFeeUpsertBulk {
+	return u.Update(func(s *ChargeFlatFeeUpsert) {
+		s.ClearSubscriptionItemID()
 	})
 }
 

--- a/openmeter/ent/db/chargeflatfee_update.go
+++ b/openmeter/ent/db/chargeflatfee_update.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	dbfeature "github.com/openmeterio/openmeter/openmeter/ent/db/feature"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionitem"
 	dbtaxcode "github.com/openmeterio/openmeter/openmeter/ent/db/taxcode"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -146,6 +147,26 @@ func (_u *ChargeFlatFeeUpdate) SetNillableManagedBy(v *billing.InvoiceLineManage
 	if v != nil {
 		_u.SetManagedBy(*v)
 	}
+	return _u
+}
+
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (_u *ChargeFlatFeeUpdate) SetSubscriptionItemID(v string) *ChargeFlatFeeUpdate {
+	_u.mutation.SetSubscriptionItemID(v)
+	return _u
+}
+
+// SetNillableSubscriptionItemID sets the "subscription_item_id" field if the given value is not nil.
+func (_u *ChargeFlatFeeUpdate) SetNillableSubscriptionItemID(v *string) *ChargeFlatFeeUpdate {
+	if v != nil {
+		_u.SetSubscriptionItemID(*v)
+	}
+	return _u
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (_u *ChargeFlatFeeUpdate) ClearSubscriptionItemID() *ChargeFlatFeeUpdate {
+	_u.mutation.ClearSubscriptionItemID()
 	return _u
 }
 
@@ -483,6 +504,11 @@ func (_u *ChargeFlatFeeUpdate) SetCurrentRun(v *ChargeFlatFeeRun) *ChargeFlatFee
 	return _u.SetCurrentRunID(v.ID)
 }
 
+// SetSubscriptionItem sets the "subscription_item" edge to the SubscriptionItem entity.
+func (_u *ChargeFlatFeeUpdate) SetSubscriptionItem(v *SubscriptionItem) *ChargeFlatFeeUpdate {
+	return _u.SetSubscriptionItemID(v.ID)
+}
+
 // SetFeature sets the "feature" edge to the Feature entity.
 func (_u *ChargeFlatFeeUpdate) SetFeature(v *Feature) *ChargeFlatFeeUpdate {
 	return _u.SetFeatureID(v.ID)
@@ -522,6 +548,12 @@ func (_u *ChargeFlatFeeUpdate) RemoveRuns(v ...*ChargeFlatFeeRun) *ChargeFlatFee
 // ClearCurrentRun clears the "current_run" edge to the ChargeFlatFeeRun entity.
 func (_u *ChargeFlatFeeUpdate) ClearCurrentRun() *ChargeFlatFeeUpdate {
 	_u.mutation.ClearCurrentRun()
+	return _u
+}
+
+// ClearSubscriptionItem clears the "subscription_item" edge to the SubscriptionItem entity.
+func (_u *ChargeFlatFeeUpdate) ClearSubscriptionItem() *ChargeFlatFeeUpdate {
+	_u.mutation.ClearSubscriptionItem()
 	return _u
 }
 
@@ -810,6 +842,35 @@ func (_u *ChargeFlatFeeUpdate) sqlSave(ctx context.Context) (_node int, err erro
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if _u.mutation.SubscriptionItemCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeflatfee.SubscriptionItemTable,
+			Columns: []string{chargeflatfee.SubscriptionItemColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(subscriptionitem.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.SubscriptionItemIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeflatfee.SubscriptionItemTable,
+			Columns: []string{chargeflatfee.SubscriptionItemColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(subscriptionitem.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if _u.mutation.FeatureCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -997,6 +1058,26 @@ func (_u *ChargeFlatFeeUpdateOne) SetNillableManagedBy(v *billing.InvoiceLineMan
 	if v != nil {
 		_u.SetManagedBy(*v)
 	}
+	return _u
+}
+
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (_u *ChargeFlatFeeUpdateOne) SetSubscriptionItemID(v string) *ChargeFlatFeeUpdateOne {
+	_u.mutation.SetSubscriptionItemID(v)
+	return _u
+}
+
+// SetNillableSubscriptionItemID sets the "subscription_item_id" field if the given value is not nil.
+func (_u *ChargeFlatFeeUpdateOne) SetNillableSubscriptionItemID(v *string) *ChargeFlatFeeUpdateOne {
+	if v != nil {
+		_u.SetSubscriptionItemID(*v)
+	}
+	return _u
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (_u *ChargeFlatFeeUpdateOne) ClearSubscriptionItemID() *ChargeFlatFeeUpdateOne {
+	_u.mutation.ClearSubscriptionItemID()
 	return _u
 }
 
@@ -1334,6 +1415,11 @@ func (_u *ChargeFlatFeeUpdateOne) SetCurrentRun(v *ChargeFlatFeeRun) *ChargeFlat
 	return _u.SetCurrentRunID(v.ID)
 }
 
+// SetSubscriptionItem sets the "subscription_item" edge to the SubscriptionItem entity.
+func (_u *ChargeFlatFeeUpdateOne) SetSubscriptionItem(v *SubscriptionItem) *ChargeFlatFeeUpdateOne {
+	return _u.SetSubscriptionItemID(v.ID)
+}
+
 // SetFeature sets the "feature" edge to the Feature entity.
 func (_u *ChargeFlatFeeUpdateOne) SetFeature(v *Feature) *ChargeFlatFeeUpdateOne {
 	return _u.SetFeatureID(v.ID)
@@ -1373,6 +1459,12 @@ func (_u *ChargeFlatFeeUpdateOne) RemoveRuns(v ...*ChargeFlatFeeRun) *ChargeFlat
 // ClearCurrentRun clears the "current_run" edge to the ChargeFlatFeeRun entity.
 func (_u *ChargeFlatFeeUpdateOne) ClearCurrentRun() *ChargeFlatFeeUpdateOne {
 	_u.mutation.ClearCurrentRun()
+	return _u
+}
+
+// ClearSubscriptionItem clears the "subscription_item" edge to the SubscriptionItem entity.
+func (_u *ChargeFlatFeeUpdateOne) ClearSubscriptionItem() *ChargeFlatFeeUpdateOne {
+	_u.mutation.ClearSubscriptionItem()
 	return _u
 }
 
@@ -1684,6 +1776,35 @@ func (_u *ChargeFlatFeeUpdateOne) sqlSave(ctx context.Context) (_node *ChargeFla
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(chargeflatfeerun.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.SubscriptionItemCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeflatfee.SubscriptionItemTable,
+			Columns: []string{chargeflatfee.SubscriptionItemColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(subscriptionitem.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.SubscriptionItemIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeflatfee.SubscriptionItemTable,
+			Columns: []string{chargeflatfee.SubscriptionItemColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(subscriptionitem.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/openmeter/ent/db/chargeusagebased_create.go
+++ b/openmeter/ent/db/chargeusagebased_create.go
@@ -1105,6 +1105,24 @@ func (u *ChargeUsageBasedUpsert) UpdateManagedBy() *ChargeUsageBasedUpsert {
 	return u
 }
 
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (u *ChargeUsageBasedUpsert) SetSubscriptionItemID(v string) *ChargeUsageBasedUpsert {
+	u.Set(chargeusagebased.FieldSubscriptionItemID, v)
+	return u
+}
+
+// UpdateSubscriptionItemID sets the "subscription_item_id" field to the value that was provided on create.
+func (u *ChargeUsageBasedUpsert) UpdateSubscriptionItemID() *ChargeUsageBasedUpsert {
+	u.SetExcluded(chargeusagebased.FieldSubscriptionItemID)
+	return u
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (u *ChargeUsageBasedUpsert) ClearSubscriptionItemID() *ChargeUsageBasedUpsert {
+	u.SetNull(chargeusagebased.FieldSubscriptionItemID)
+	return u
+}
+
 // SetAdvanceAfter sets the "advance_after" field.
 func (u *ChargeUsageBasedUpsert) SetAdvanceAfter(v time.Time) *ChargeUsageBasedUpsert {
 	u.Set(chargeusagebased.FieldAdvanceAfter, v)
@@ -1371,9 +1389,6 @@ func (u *ChargeUsageBasedUpsertOne) UpdateNewValues() *ChargeUsageBasedUpsertOne
 		if _, exists := u.create.mutation.SubscriptionPhaseID(); exists {
 			s.SetIgnore(chargeusagebased.FieldSubscriptionPhaseID)
 		}
-		if _, exists := u.create.mutation.SubscriptionItemID(); exists {
-			s.SetIgnore(chargeusagebased.FieldSubscriptionItemID)
-		}
 		if _, exists := u.create.mutation.Namespace(); exists {
 			s.SetIgnore(chargeusagebased.FieldNamespace)
 		}
@@ -1529,6 +1544,27 @@ func (u *ChargeUsageBasedUpsertOne) SetManagedBy(v billing.InvoiceLineManagedBy)
 func (u *ChargeUsageBasedUpsertOne) UpdateManagedBy() *ChargeUsageBasedUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedUpsert) {
 		s.UpdateManagedBy()
+	})
+}
+
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (u *ChargeUsageBasedUpsertOne) SetSubscriptionItemID(v string) *ChargeUsageBasedUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.SetSubscriptionItemID(v)
+	})
+}
+
+// UpdateSubscriptionItemID sets the "subscription_item_id" field to the value that was provided on create.
+func (u *ChargeUsageBasedUpsertOne) UpdateSubscriptionItemID() *ChargeUsageBasedUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.UpdateSubscriptionItemID()
+	})
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (u *ChargeUsageBasedUpsertOne) ClearSubscriptionItemID() *ChargeUsageBasedUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.ClearSubscriptionItemID()
 	})
 }
 
@@ -2006,9 +2042,6 @@ func (u *ChargeUsageBasedUpsertBulk) UpdateNewValues() *ChargeUsageBasedUpsertBu
 			if _, exists := b.mutation.SubscriptionPhaseID(); exists {
 				s.SetIgnore(chargeusagebased.FieldSubscriptionPhaseID)
 			}
-			if _, exists := b.mutation.SubscriptionItemID(); exists {
-				s.SetIgnore(chargeusagebased.FieldSubscriptionItemID)
-			}
 			if _, exists := b.mutation.Namespace(); exists {
 				s.SetIgnore(chargeusagebased.FieldNamespace)
 			}
@@ -2165,6 +2198,27 @@ func (u *ChargeUsageBasedUpsertBulk) SetManagedBy(v billing.InvoiceLineManagedBy
 func (u *ChargeUsageBasedUpsertBulk) UpdateManagedBy() *ChargeUsageBasedUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedUpsert) {
 		s.UpdateManagedBy()
+	})
+}
+
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (u *ChargeUsageBasedUpsertBulk) SetSubscriptionItemID(v string) *ChargeUsageBasedUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.SetSubscriptionItemID(v)
+	})
+}
+
+// UpdateSubscriptionItemID sets the "subscription_item_id" field to the value that was provided on create.
+func (u *ChargeUsageBasedUpsertBulk) UpdateSubscriptionItemID() *ChargeUsageBasedUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.UpdateSubscriptionItemID()
+	})
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (u *ChargeUsageBasedUpsertBulk) ClearSubscriptionItemID() *ChargeUsageBasedUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.ClearSubscriptionItemID()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebased_update.go
+++ b/openmeter/ent/db/chargeusagebased_update.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ent/db/chargeusagebasedruns"
 	dbfeature "github.com/openmeterio/openmeter/openmeter/ent/db/feature"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/predicate"
+	"github.com/openmeterio/openmeter/openmeter/ent/db/subscriptionitem"
 	dbtaxcode "github.com/openmeterio/openmeter/openmeter/ent/db/taxcode"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -146,6 +147,26 @@ func (_u *ChargeUsageBasedUpdate) SetNillableManagedBy(v *billing.InvoiceLineMan
 	if v != nil {
 		_u.SetManagedBy(*v)
 	}
+	return _u
+}
+
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (_u *ChargeUsageBasedUpdate) SetSubscriptionItemID(v string) *ChargeUsageBasedUpdate {
+	_u.mutation.SetSubscriptionItemID(v)
+	return _u
+}
+
+// SetNillableSubscriptionItemID sets the "subscription_item_id" field if the given value is not nil.
+func (_u *ChargeUsageBasedUpdate) SetNillableSubscriptionItemID(v *string) *ChargeUsageBasedUpdate {
+	if v != nil {
+		_u.SetSubscriptionItemID(*v)
+	}
+	return _u
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (_u *ChargeUsageBasedUpdate) ClearSubscriptionItemID() *ChargeUsageBasedUpdate {
+	_u.mutation.ClearSubscriptionItemID()
 	return _u
 }
 
@@ -430,6 +451,11 @@ func (_u *ChargeUsageBasedUpdate) SetCurrentRun(v *ChargeUsageBasedRuns) *Charge
 	return _u.SetCurrentRunID(v.ID)
 }
 
+// SetSubscriptionItem sets the "subscription_item" edge to the SubscriptionItem entity.
+func (_u *ChargeUsageBasedUpdate) SetSubscriptionItem(v *SubscriptionItem) *ChargeUsageBasedUpdate {
+	return _u.SetSubscriptionItemID(v.ID)
+}
+
 // SetFeature sets the "feature" edge to the Feature entity.
 func (_u *ChargeUsageBasedUpdate) SetFeature(v *Feature) *ChargeUsageBasedUpdate {
 	return _u.SetFeatureID(v.ID)
@@ -490,6 +516,12 @@ func (_u *ChargeUsageBasedUpdate) RemoveDetailedLines(v ...*ChargeUsageBasedRunD
 // ClearCurrentRun clears the "current_run" edge to the ChargeUsageBasedRuns entity.
 func (_u *ChargeUsageBasedUpdate) ClearCurrentRun() *ChargeUsageBasedUpdate {
 	_u.mutation.ClearCurrentRun()
+	return _u
+}
+
+// ClearSubscriptionItem clears the "subscription_item" edge to the SubscriptionItem entity.
+func (_u *ChargeUsageBasedUpdate) ClearSubscriptionItem() *ChargeUsageBasedUpdate {
+	_u.mutation.ClearSubscriptionItem()
 	return _u
 }
 
@@ -806,6 +838,35 @@ func (_u *ChargeUsageBasedUpdate) sqlSave(ctx context.Context) (_node int, err e
 		}
 		_spec.Edges.Add = append(_spec.Edges.Add, edge)
 	}
+	if _u.mutation.SubscriptionItemCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeusagebased.SubscriptionItemTable,
+			Columns: []string{chargeusagebased.SubscriptionItemColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(subscriptionitem.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.SubscriptionItemIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeusagebased.SubscriptionItemTable,
+			Columns: []string{chargeusagebased.SubscriptionItemColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(subscriptionitem.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
 	if _u.mutation.FeatureCleared() {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -993,6 +1054,26 @@ func (_u *ChargeUsageBasedUpdateOne) SetNillableManagedBy(v *billing.InvoiceLine
 	if v != nil {
 		_u.SetManagedBy(*v)
 	}
+	return _u
+}
+
+// SetSubscriptionItemID sets the "subscription_item_id" field.
+func (_u *ChargeUsageBasedUpdateOne) SetSubscriptionItemID(v string) *ChargeUsageBasedUpdateOne {
+	_u.mutation.SetSubscriptionItemID(v)
+	return _u
+}
+
+// SetNillableSubscriptionItemID sets the "subscription_item_id" field if the given value is not nil.
+func (_u *ChargeUsageBasedUpdateOne) SetNillableSubscriptionItemID(v *string) *ChargeUsageBasedUpdateOne {
+	if v != nil {
+		_u.SetSubscriptionItemID(*v)
+	}
+	return _u
+}
+
+// ClearSubscriptionItemID clears the value of the "subscription_item_id" field.
+func (_u *ChargeUsageBasedUpdateOne) ClearSubscriptionItemID() *ChargeUsageBasedUpdateOne {
+	_u.mutation.ClearSubscriptionItemID()
 	return _u
 }
 
@@ -1277,6 +1358,11 @@ func (_u *ChargeUsageBasedUpdateOne) SetCurrentRun(v *ChargeUsageBasedRuns) *Cha
 	return _u.SetCurrentRunID(v.ID)
 }
 
+// SetSubscriptionItem sets the "subscription_item" edge to the SubscriptionItem entity.
+func (_u *ChargeUsageBasedUpdateOne) SetSubscriptionItem(v *SubscriptionItem) *ChargeUsageBasedUpdateOne {
+	return _u.SetSubscriptionItemID(v.ID)
+}
+
 // SetFeature sets the "feature" edge to the Feature entity.
 func (_u *ChargeUsageBasedUpdateOne) SetFeature(v *Feature) *ChargeUsageBasedUpdateOne {
 	return _u.SetFeatureID(v.ID)
@@ -1337,6 +1423,12 @@ func (_u *ChargeUsageBasedUpdateOne) RemoveDetailedLines(v ...*ChargeUsageBasedR
 // ClearCurrentRun clears the "current_run" edge to the ChargeUsageBasedRuns entity.
 func (_u *ChargeUsageBasedUpdateOne) ClearCurrentRun() *ChargeUsageBasedUpdateOne {
 	_u.mutation.ClearCurrentRun()
+	return _u
+}
+
+// ClearSubscriptionItem clears the "subscription_item" edge to the SubscriptionItem entity.
+func (_u *ChargeUsageBasedUpdateOne) ClearSubscriptionItem() *ChargeUsageBasedUpdateOne {
+	_u.mutation.ClearSubscriptionItem()
 	return _u
 }
 
@@ -1676,6 +1768,35 @@ func (_u *ChargeUsageBasedUpdateOne) sqlSave(ctx context.Context) (_node *Charge
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
 				IDSpec: sqlgraph.NewFieldSpec(chargeusagebasedruns.FieldID, field.TypeString),
+			},
+		}
+		for _, k := range nodes {
+			edge.Target.Nodes = append(edge.Target.Nodes, k)
+		}
+		_spec.Edges.Add = append(_spec.Edges.Add, edge)
+	}
+	if _u.mutation.SubscriptionItemCleared() {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeusagebased.SubscriptionItemTable,
+			Columns: []string{chargeusagebased.SubscriptionItemColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(subscriptionitem.FieldID, field.TypeString),
+			},
+		}
+		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
+	}
+	if nodes := _u.mutation.SubscriptionItemIDs(); len(nodes) > 0 {
+		edge := &sqlgraph.EdgeSpec{
+			Rel:     sqlgraph.M2O,
+			Inverse: true,
+			Table:   chargeusagebased.SubscriptionItemTable,
+			Columns: []string{chargeusagebased.SubscriptionItemColumn},
+			Bidi:    false,
+			Target: &sqlgraph.EdgeTarget{
+				IDSpec: sqlgraph.NewFieldSpec(subscriptionitem.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -2301,6 +2301,20 @@ func (u *ChargeUpdateOne) SetOrClearDeletedAt(value *time.Time) *ChargeUpdateOne
 	return u.SetDeletedAt(*value)
 }
 
+func (u *ChargeCreditPurchaseUpdate) SetOrClearSubscriptionItemID(value *string) *ChargeCreditPurchaseUpdate {
+	if value == nil {
+		return u.ClearSubscriptionItemID()
+	}
+	return u.SetSubscriptionItemID(*value)
+}
+
+func (u *ChargeCreditPurchaseUpdateOne) SetOrClearSubscriptionItemID(value *string) *ChargeCreditPurchaseUpdateOne {
+	if value == nil {
+		return u.ClearSubscriptionItemID()
+	}
+	return u.SetSubscriptionItemID(*value)
+}
+
 func (u *ChargeCreditPurchaseUpdate) SetOrClearAdvanceAfter(value *time.Time) *ChargeCreditPurchaseUpdate {
 	if value == nil {
 		return u.ClearAdvanceAfter()
@@ -2579,6 +2593,20 @@ func (u *ChargeCreditPurchaseInvoicedPaymentUpdateOne) SetOrClearAnnotations(val
 		return u.ClearAnnotations()
 	}
 	return u.SetAnnotations(*value)
+}
+
+func (u *ChargeFlatFeeUpdate) SetOrClearSubscriptionItemID(value *string) *ChargeFlatFeeUpdate {
+	if value == nil {
+		return u.ClearSubscriptionItemID()
+	}
+	return u.SetSubscriptionItemID(*value)
+}
+
+func (u *ChargeFlatFeeUpdateOne) SetOrClearSubscriptionItemID(value *string) *ChargeFlatFeeUpdateOne {
+	if value == nil {
+		return u.ClearSubscriptionItemID()
+	}
+	return u.SetSubscriptionItemID(*value)
 }
 
 func (u *ChargeFlatFeeUpdate) SetOrClearAdvanceAfter(value *time.Time) *ChargeFlatFeeUpdate {
@@ -3097,6 +3125,20 @@ func (u *ChargeFlatFeeRunPaymentUpdateOne) SetOrClearAnnotations(value *models.A
 		return u.ClearAnnotations()
 	}
 	return u.SetAnnotations(*value)
+}
+
+func (u *ChargeUsageBasedUpdate) SetOrClearSubscriptionItemID(value *string) *ChargeUsageBasedUpdate {
+	if value == nil {
+		return u.ClearSubscriptionItemID()
+	}
+	return u.SetSubscriptionItemID(*value)
+}
+
+func (u *ChargeUsageBasedUpdateOne) SetOrClearSubscriptionItemID(value *string) *ChargeUsageBasedUpdateOne {
+	if value == nil {
+		return u.ClearSubscriptionItemID()
+	}
+	return u.SetSubscriptionItemID(*value)
 }
 
 func (u *ChargeUsageBasedUpdate) SetOrClearAdvanceAfter(value *time.Time) *ChargeUsageBasedUpdate {

--- a/openmeter/ent/schema/chargescreditpurchase.go
+++ b/openmeter/ent/schema/chargescreditpurchase.go
@@ -83,7 +83,6 @@ func (ChargeCreditPurchase) Edges() []ent.Edge {
 		edge.From("subscription_item", SubscriptionItem.Type).
 			Ref("charges_credit_purchase").
 			Field("subscription_item_id").
-			Immutable().
 			Unique(),
 		edge.From("customer", Customer.Type).
 			Field("customer_id").

--- a/openmeter/ent/schema/chargesflatfee.go
+++ b/openmeter/ent/schema/chargesflatfee.go
@@ -112,7 +112,6 @@ func (ChargeFlatFee) Edges() []ent.Edge {
 		edge.From("subscription_item", SubscriptionItem.Type).
 			Ref("charges_flat_fee").
 			Field("subscription_item_id").
-			Immutable().
 			Unique(),
 		edge.From("customer", Customer.Type).
 			Ref("charges_flat_fee").

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -107,8 +107,7 @@ func (ChargeUsageBased) Edges() []ent.Edge {
 		edge.From("subscription_item", SubscriptionItem.Type).
 			Ref("charges_usage_based").
 			Field("subscription_item_id").
-			Unique().
-			Immutable(),
+			Unique(),
 		edge.From("customer", Customer.Type).
 			Field("customer_id").
 			Ref("charges_usage_based").

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -834,6 +834,10 @@ func (n NoopChargeService) Create(_ context.Context, _ billingcharges.CreateInpu
 	return nil, nil
 }
 
+func (n NoopChargeService) UpdateSubscriptionItemID(_ context.Context, charge billingcharges.Charge, _ string) (billingcharges.Charge, error) {
+	return charge, nil
+}
+
 func (n NoopChargeService) AdvanceCharges(_ context.Context, _ billingcharges.AdvanceChargesInput) (billingcharges.Charges, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

This PR tightens credit-then-invoice reconciliation for subscription-backed charges. From the billing domain perspective it covers three related consistency issues:

- Keeps charge-backed flat-fee invoice details aligned with the credited standard invoice line, so promotional credit allocations are reflected in persisted realization-run detailed lines and run totals.
- Repairs subscription item references on existing charges when subscription edits recreate the concrete item row for the same logical item, preserving charge identity while pointing future sync operations at the current subscription item.
- Moves credit application mapping into shared detailed-line behavior so discount and credit calculations can be reapplied deterministically without carrying stale credit allocations across recalculation.

The PR also extends credit-then-invoice subscription sync coverage for usage-based draft and issued invoice edit flows, including ledger balance expectations, charge state expectations, immutable invoice warning behavior, and promotional credit settlement.

## Validation

- make lint-go-fast
- targeted billing/charges/subscription-sync go test package set with dynamic tags and POSTGRES_HOST=127.0.0.1
- focused CreditThenInvoice usage-based gathering update draft and issued invoice tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Charges can now have their subscription item references updated in-place.

* **Improvements**
  * Consistent currency rounding and recomputed detailed-line totals.
  * Refined credit allocation and application for more accurate billing.

* **Reliability**
  * Subscription-sync can repair mismatched charge subscription references and supports dry-run verification.

* **Tests**
  * Expanded unit and integration tests covering credit application, detailed-line behavior, and sync scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->