### PR TITLE
fix: sync deleted subscriptions at least once

### DIFF
--- a/.agents/skills/subscriptionsync/SKILL.md
+++ b/.agents/skills/subscriptionsync/SKILL.md
@@ -11,7 +11,7 @@ Guidance for working with `openmeter/billing/worker/subscriptionsync/`.
 
 `subscriptionsync` is the bridge between the subscription domain and billing.
 
-- Input: `subscription.SubscriptionView`
+- Input: either a subscription ID (`models.NamespacedID`) or an already-expanded `subscription.SubscriptionView`
 - Output: reconciled billing state
   - invoice lines / split-line groups
   - charges
@@ -25,7 +25,8 @@ It does not own subscription editing rules and it does not own billing primitive
 openmeter/billing/worker/subscriptionsync/
 ├── service/                         # orchestration entrypoint used by the worker
 │   ├── service.go                   # Service struct, Config, FeatureFlags, constructor
-│   ├── sync.go                      # SynchronizeSubscription + SynchronizeSubscriptionAndInvoiceCustomer
+│   ├── sync.go                      # internal sync orchestration for SyncByID/SyncByView entrypoints
+│   ├── ref.go                       # normalizes subscription ID vs view references
 │   ├── reconcile.go                 # build persisted snapshot + target state + plan
 │   ├── handlers.go                  # event handlers (HandleCancelledEvent, HandleInvoiceCreation)
 │   ├── base_test.go                 # shared SuiteBase + SyncSuiteBase test harness
@@ -54,19 +55,28 @@ openmeter/billing/worker/subscriptionsync/
 
 ## Core Flow
 
-`Service.SynchronizeSubscription(...)` in `service/sync.go` is the main entrypoint.
+The public sync entrypoints are defined by `subscriptionsync.SyncService`:
+
+- `SyncByID(...)` and `SyncByIDAndInvoiceCustomer(...)` fetch subscription state internally.
+- `SyncByView(...)` and `SyncByViewAndInvoiceCustomer(...)` use an already-expanded subscription view.
+- The `AndInvoiceCustomer` variants run the regular sync and then invoice pending lines for the subscription customer.
+
+The internal orchestration lives in `service/sync.go` (`synchronizeSubscription`, `synchronizeSubscriptionAndInvoiceCustomer`) and normalizes the public input through `subscriptionReferenceOrView` from `service/ref.go`.
 
 High-level flow:
-1. Load persisted sync state and persisted billing artifacts.
-2. Build target state from the subscription view.
-3. Reconcile target vs persisted.
-4. Apply billing patches.
-5. Persist sync state.
+1. Load the subscription entity, including deleted subscriptions when the ID path is used.
+2. Load persisted sync state and persisted billing artifacts.
+3. Build target state from the subscription view, or an empty target state when the subscription is deleted.
+4. Reconcile target vs persisted.
+5. Apply billing patches.
+6. Persist sync state.
 
 The important bridge boundaries are:
 - `persistedstate`: current billing-side reality relevant to this subscription
 - `targetstate`: expected billing-side reality derived from the subscription view
 - `reconciler`: diff between the two, expressed as backend-specific patches
+
+Deleted-subscription cleanup uses the ID path. `subscription.Service.GetView` follows the normal non-deleted read path, so code that needs to reconcile deleted subscriptions must use `List(... IncludeDeleted: true)` or the sync service's ID entrypoints rather than calling `GetView` first.
 
 ## Persisted State
 
@@ -100,6 +110,7 @@ Invoice loading notes:
 `service/targetstate` converts a subscription view into expected billing/charge items.
 
 Useful points:
+- `BuildInput.SubscriptionView` is a pointer. A nil view represents a deleted subscription and builds an empty target state so persisted billing artifacts are removed.
 - `StateItem.IsBillable()` is the first gate
 - `StateItem.GetServicePeriod()` is the diff-level period source
 - `StateItem.GetExpectedLine()` is invoice-specific rendering; keep direct billing assumptions isolated to places that really need invoice lines
@@ -191,6 +202,8 @@ Test suite hierarchy:
 
 Use `setupChargesService(config)` on `SuiteBase` to rebuild the sync service with a charge-capable stack (replaces the default no-charges service).
 
+When a billing sync test needs to exercise deleted-subscription cleanup, prefer the public ID entrypoint (`SyncByID` / `SyncByIDAndInvoiceCustomer`) so the service owns the `IncludeDeleted` lookup. Subscription-domain coverage for deleted scheduled replacements belongs under `openmeter/subscription/service/sync_test.go`; keep billing-package tests focused on billing artifacts.
+
 For charge-backed sync tests:
 - prefer `openmeter/billing/charges/testutils.NewMockHandlers()`
 - these mocks are intentionally minimal but valid enough for charge creation/advancement
@@ -216,7 +229,7 @@ Pattern for credit-only tests:
 
 Key methods:
 - `ListSubscriptions(...)` — pages through active subscriptions with their sync states
-- `ReconcileSubscription(...)` — fetches subscription view and calls `SynchronizeSubscription`
+- `ReconcileSubscription(...)` — calls `SyncByID` for the subscription under reconciliation
 - `All(...)` — reconciles all eligible subscriptions, skipping those with no billables or whose `NextSyncAfter` is in the future (unless `Force` is set)
 
 ## Common Refactor Rules

--- a/migrations/atlas.sum
+++ b/migrations/atlas.sum
@@ -1,2 +1,0 @@
-h1:G6UtEVbUpj9eU1Lo7cT3/bcngvQRwEkMnyrmE+QCb+M=
-20260513072457_ledger_transaction_template_codes.sql h1:CtBOPiB3DfKjONdF/89UkjWOrx1LTcGlguxZaH6VK7Q=

--- a/openmeter/billing/validators/customer/customer.go
+++ b/openmeter/billing/validators/customer/customer.go
@@ -47,8 +47,9 @@ func (v *Validator) ValidateDeleteCustomer(ctx context.Context, input customer.D
 
 	// Let's sync any subscriptions pending for this customer
 	subs, err := v.subscriptionService.List(ctx, subscription.ListSubscriptionsInput{
-		Namespaces: []string{input.Namespace},
-		CustomerID: &filter.FilterULID{FilterString: filter.FilterString{Eq: &input.ID}},
+		Namespaces:     []string{input.Namespace},
+		CustomerID:     &filter.FilterULID{FilterString: filter.FilterString{Eq: &input.ID}},
+		IncludeDeleted: true,
 	})
 	if err != nil {
 		return err
@@ -57,13 +58,8 @@ func (v *Validator) ValidateDeleteCustomer(ctx context.Context, input customer.D
 	watermark := time.Now().Add(-24 * time.Hour)
 
 	for _, sub := range subs.Items {
-		if sub.ActiveTo == nil || watermark.Before(*sub.ActiveTo) {
-			view, err := v.subscriptionService.GetView(ctx, sub.NamespacedID)
-			if err != nil {
-				return err
-			}
-
-			if err := v.syncService.SynchronizeSubscription(ctx, view, time.Now()); err != nil {
+		if sub.ActiveTo == nil || sub.DeletedAt != nil || watermark.Before(*sub.ActiveTo) {
+			if err := v.syncService.SyncByID(ctx, sub.NamespacedID, time.Now()); err != nil {
 				return err
 			}
 		}

--- a/openmeter/billing/worker/subscriptionsync/reconciler/reconciler.go
+++ b/openmeter/billing/worker/subscriptionsync/reconciler/reconciler.go
@@ -137,6 +137,8 @@ func (r *Reconciler) ListSubscriptions(ctx context.Context, in ReconcilerListSub
 		pageIndex++
 	}
 
+	pageIndex = 1
+
 	for {
 		subscriptions, err := r.subscriptionService.List(ctx, subscription.ListSubscriptionsInput{
 			Namespaces: in.Namespaces,

--- a/openmeter/billing/worker/subscriptionsync/reconciler/reconciler.go
+++ b/openmeter/billing/worker/subscriptionsync/reconciler/reconciler.go
@@ -127,36 +127,45 @@ func (r *Reconciler) ListSubscriptions(ctx context.Context, in ReconcilerListSub
 			break
 		}
 
-		syncStates, err := r.subscriptionSync.GetSyncStates(ctx, lo.Map(subscriptions.Items, func(item subscription.Subscription, _ int) models.NamespacedID {
-			return models.NamespacedID{
-				ID:        item.ID,
-				Namespace: item.Namespace,
-			}
-		}))
+		mapped, err := r.mapToSubscriptionWithSyncState(ctx, subscriptions.Items)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get sync states: %w", err)
+			return nil, fmt.Errorf("failed to map subscriptions to subscription with sync state: %w", err)
 		}
 
-		syncStatesBySubscriptionID := lo.SliceToMap(syncStates, func(syncState subscriptionsync.SyncState) (models.NamespacedID, subscriptionsync.SyncState) {
-			return models.NamespacedID{
-				ID:        syncState.SubscriptionID.ID,
-				Namespace: syncState.SubscriptionID.Namespace,
-			}, syncState
+		out = append(out, mapped...)
+
+		pageIndex++
+	}
+
+	for {
+		subscriptions, err := r.subscriptionService.List(ctx, subscription.ListSubscriptionsInput{
+			Namespaces: in.Namespaces,
+			CustomerID: customerID,
+			// TODO: Later we might want to have a lookback for deleted subscriptions as well, but as of 2026-05-19
+			// we had a delete bug, so we need to reconcile all deleted subscriptions.
+			DeletedAt: &filter.FilterTime{
+				Lte: lo.ToPtr(clock.Now()),
+			},
+			IncludeDeleted: true,
+			Page: pagination.Page{
+				PageNumber: pageIndex,
+				PageSize:   defaultWindowSize,
+			},
 		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list subscriptions: %w", err)
+		}
 
-		out = append(out, lo.Map(subscriptions.Items, func(item subscription.Subscription, _ int) SubscriptionWithSyncState {
-			existingSyncState, ok := syncStatesBySubscriptionID[item.NamespacedID]
+		if len(subscriptions.Items) == 0 {
+			break
+		}
 
-			var syncState *subscriptionsync.SyncState
-			if ok {
-				syncState = lo.ToPtr(existingSyncState)
-			}
+		mapped, err := r.mapToSubscriptionWithSyncState(ctx, subscriptions.Items)
+		if err != nil {
+			return nil, fmt.Errorf("failed to map subscriptions to subscription with sync state: %w", err)
+		}
 
-			return SubscriptionWithSyncState{
-				Subscription: item,
-				SyncState:    syncState,
-			}
-		})...)
+		out = append(out, mapped...)
 
 		pageIndex++
 	}
@@ -164,30 +173,41 @@ func (r *Reconciler) ListSubscriptions(ctx context.Context, in ReconcilerListSub
 	return out, nil
 }
 
-func (r *Reconciler) ReconcileSubscription(ctx context.Context, subsID models.NamespacedID) error {
-	subsView, err := r.subscriptionService.GetView(ctx, subsID)
+func (r *Reconciler) mapToSubscriptionWithSyncState(ctx context.Context, subs []subscription.Subscription) ([]SubscriptionWithSyncState, error) {
+	syncStates, err := r.subscriptionSync.GetSyncStates(ctx, lo.Map(subs, func(item subscription.Subscription, _ int) models.NamespacedID {
+		return models.NamespacedID{
+			ID:        item.ID,
+			Namespace: item.Namespace,
+		}
+	}))
 	if err != nil {
-		return fmt.Errorf("failed to get subscription: %w", err)
+		return nil, fmt.Errorf("failed to get sync states: %w", err)
 	}
 
-	cus, err := r.customerService.GetCustomer(ctx, customer.GetCustomerInput{
-		CustomerID: &customer.CustomerID{
-			ID:        subsView.Customer.ID,
-			Namespace: subsID.Namespace,
-		},
+	syncStatesBySubscriptionID := lo.SliceToMap(syncStates, func(syncState subscriptionsync.SyncState) (models.NamespacedID, subscriptionsync.SyncState) {
+		return models.NamespacedID{
+			ID:        syncState.SubscriptionID.ID,
+			Namespace: syncState.SubscriptionID.Namespace,
+		}, syncState
 	})
-	if err != nil {
-		return fmt.Errorf("failed to get customer: %w", err)
-	}
 
-	// TODO: remove this check to make sure that deleted customers are fully invoiced
-	if cus != nil && cus.IsDeleted() {
-		r.logger.WarnContext(ctx, "customer is deleted, skipping reconciliation", "customer_id", subsView.Customer.ID)
+	return lo.Map(subs, func(item subscription.Subscription, _ int) SubscriptionWithSyncState {
+		existingSyncState, ok := syncStatesBySubscriptionID[item.NamespacedID]
 
-		return nil
-	}
+		var syncState *subscriptionsync.SyncState
+		if ok {
+			syncState = lo.ToPtr(existingSyncState)
+		}
 
-	return r.subscriptionSync.SynchronizeSubscription(ctx, subsView, time.Now())
+		return SubscriptionWithSyncState{
+			Subscription: item,
+			SyncState:    syncState,
+		}
+	}), nil
+}
+
+func (r *Reconciler) ReconcileSubscription(ctx context.Context, subsID models.NamespacedID) error {
+	return r.subscriptionSync.SyncByID(ctx, subsID, time.Now())
 }
 
 type ReconcilerAllInput struct {

--- a/openmeter/billing/worker/subscriptionsync/service.go
+++ b/openmeter/billing/worker/subscriptionsync/service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type Service interface {
@@ -15,12 +16,15 @@ type Service interface {
 }
 
 type SyncService interface {
-	SynchronizeSubscriptionAndInvoiceCustomer(ctx context.Context, subs subscription.SubscriptionView, asOf time.Time) error
-	SynchronizeSubscription(ctx context.Context, subs subscription.SubscriptionView, asOf time.Time, opts ...SynchronizeSubscriptionOption) error
+	SyncByViewAndInvoiceCustomer(ctx context.Context, view subscription.SubscriptionView, asOf time.Time) error
+	SyncByIDAndInvoiceCustomer(ctx context.Context, subscriptionID models.NamespacedID, asOf time.Time) error
+	SyncByView(ctx context.Context, view subscription.SubscriptionView, asOf time.Time, opts ...SynchronizeSubscriptionOption) error
+	SyncByID(ctx context.Context, subscriptionID models.NamespacedID, asOf time.Time, opts ...SynchronizeSubscriptionOption) error
 }
 
 type EventHandler interface {
 	HandleCancelledEvent(ctx context.Context, event *subscription.CancelledEvent) error
+	HandleDeletedEvent(ctx context.Context, event *subscription.DeletedEvent) error
 	HandleSubscriptionSyncEvent(ctx context.Context, event *subscription.SubscriptionSyncEvent) error
 	HandleInvoiceCreation(ctx context.Context, event *billing.StandardInvoiceCreatedEvent) error
 }

--- a/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
@@ -205,7 +205,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeProvisio
 
 	s.Run("provisions the next two billing cycles", func() {
 		// When we provision the next two billing cycles.
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, syncUntil))
+		s.NoError(s.Service.SyncByView(ctx, subscriptionView, syncUntil))
 
 		// Then two matching flat fee charges are created.
 		initialCharges = s.expectCreditsOnlyFlatFeeCharges(ctx, subscriptionView.Subscription.ID, expectedCharges)
@@ -219,7 +219,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeProvisio
 
 		// When the clock advances and we re-provision the same next two billing cycles.
 		clock.SetTime(s.mustParseTime("2024-01-15T00:00:00Z"))
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, syncUntil))
+		s.NoError(s.Service.SyncByView(ctx, subscriptionView, syncUntil))
 
 		// Then the existing charges are unchanged.
 		reconciledCharges := s.expectCreditsOnlyFlatFeeCharges(ctx, subscriptionView.Subscription.ID, expectedCharges)
@@ -324,7 +324,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeCancella
 	var originalSecondPeriodCharge flatfee.Charge
 
 	s.Run("provisions the next two billing cycles", func() {
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, syncUntil))
+		s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subscriptionView, syncUntil))
 		provisionedCharges := s.expectCreditsOnlyFlatFeeCharges(ctx, subscriptionView.Subscription.ID, expectedCharges)
 		s.Len(provisionedCharges, 2)
 
@@ -344,7 +344,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeCancella
 		subscriptionView, err = s.SubscriptionService.GetView(ctx, subscriptionModel.NamespacedID)
 		s.NoError(err)
 
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, syncUntil))
+		s.NoError(s.Service.SyncByView(ctx, subscriptionView, syncUntil))
 
 		remainingCharges := s.expectCreditsOnlyFlatFeeCharges(ctx, subscriptionView.Subscription.ID, []expectedFlatFeeCharge{
 			expectedCharges[0].Indexes(0),
@@ -461,7 +461,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeMidPerio
 	var originalSecondPeriodCharge flatfee.Charge
 
 	s.Run("provisions the current and next billing cycle", func() {
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, initialSyncUntil))
+		s.NoError(s.Service.SyncByView(ctx, subscriptionView, initialSyncUntil))
 
 		provisionedCharges := s.expectCreditsOnlyFlatFeeCharges(ctx, subscriptionView.Subscription.ID, expectedCharges)
 		s.Len(provisionedCharges, 2)
@@ -481,7 +481,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeMidPerio
 		subscriptionView, err = s.SubscriptionService.GetView(ctx, subscriptionModel.NamespacedID)
 		s.NoError(err)
 
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, resyncUntil))
+		s.NoError(s.Service.SyncByView(ctx, subscriptionView, resyncUntil))
 
 		remainingCharges := s.expectCreditsOnlyFlatFeeCharges(ctx, subscriptionView.Subscription.ID, []expectedFlatFeeCharge{
 			{
@@ -619,7 +619,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedProvi
 	var initialCharges []usagebased.Charge
 
 	s.Run("provisions the next two billing cycles", func() {
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, syncUntil))
+		s.NoError(s.Service.SyncByView(ctx, subscriptionView, syncUntil))
 		initialCharges = s.expectCreditsOnlyUsageBasedCharges(ctx, subscriptionView.Subscription.ID, expectedCharges)
 	})
 
@@ -629,7 +629,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedProvi
 		})
 
 		clock.SetTime(s.mustParseTime("2024-01-15T00:00:00Z"))
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, syncUntil))
+		s.NoError(s.Service.SyncByView(ctx, subscriptionView, syncUntil))
 
 		reconciledCharges := s.expectCreditsOnlyUsageBasedCharges(ctx, subscriptionView.Subscription.ID, expectedCharges)
 		s.Len(reconciledCharges, len(initialCharges))
@@ -733,7 +733,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedCance
 	var originalCharge usagebased.Charge
 
 	s.Run("provisions the charge in created state", func() {
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, syncUntil))
+		s.NoError(s.Service.SyncByView(ctx, subscriptionView, syncUntil))
 		provisionedCharges := s.expectCreditsOnlyUsageBasedCharges(ctx, subscriptionView.Subscription.ID, expectedCharges)
 		s.Len(provisionedCharges, 1)
 		originalCharge = provisionedCharges[0]
@@ -752,7 +752,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedCance
 		subscriptionView, err = s.SubscriptionService.GetView(ctx, subscriptionModel.NamespacedID)
 		s.NoError(err)
 
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, syncUntil))
+		s.NoError(s.Service.SyncByView(ctx, subscriptionView, syncUntil))
 		s.expectCreditsOnlyUsageBasedCharges(ctx, subscriptionView.Subscription.ID, nil)
 
 		deletedChargeRes, err := s.Charges.GetByID(ctx, charges.GetByIDInput{
@@ -866,7 +866,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedMidPe
 	var originalFirstPeriodCharge usagebased.Charge
 
 	s.Run("provisions the current and next billing cycle", func() {
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, initialSyncUntil))
+		s.NoError(s.Service.SyncByView(ctx, subscriptionView, initialSyncUntil))
 
 		provisionedCharges := s.expectCreditsOnlyUsageBasedCharges(ctx, subscriptionView.Subscription.ID, expectedCharges)
 		s.Len(provisionedCharges, 2)
@@ -917,7 +917,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedMidPe
 		subscriptionView, err = s.SubscriptionService.GetView(ctx, subscriptionModel.NamespacedID)
 		s.NoError(err)
 
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, initialSyncUntil))
+		s.NoError(s.Service.SyncByView(ctx, subscriptionView, initialSyncUntil))
 
 		remainingCharges := s.expectCreditsOnlyUsageBasedCharges(ctx, subscriptionView.Subscription.ID, []expectedUsageBasedCharge{
 			{
@@ -1095,7 +1095,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyMixedProvisioni
 		}).Indexes(0),
 	}
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, syncUntil))
+	s.NoError(s.Service.SyncByView(ctx, subscriptionView, syncUntil))
 	s.expectCreditsOnlyMixedCharges(ctx, subscriptionView.Subscription.ID, expectedFlatFeeCharges, expectedUsageBasedCharges)
 }
 
@@ -1349,7 +1349,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeTaxCodeP
 		},
 	}, startAt)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, syncUntil))
+	s.NoError(s.Service.SyncByView(ctx, subscriptionView, syncUntil))
 
 	res, err := s.Charges.ListCharges(ctx, charges.ListChargesInput{
 		Namespace:       s.Namespace,
@@ -1433,7 +1433,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedTaxCo
 		},
 	}, startAt)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subscriptionView, syncUntil))
+	s.NoError(s.Service.SyncByView(ctx, subscriptionView, syncUntil))
 
 	res, err := s.Charges.ListCharges(ctx, charges.ListChargesInput{
 		Namespace:       s.Namespace,

--- a/openmeter/billing/worker/subscriptionsync/service/handlers.go
+++ b/openmeter/billing/worker/subscriptionsync/service/handlers.go
@@ -23,7 +23,7 @@ func (s *Service) HandleCancelledEvent(ctx context.Context, event *subscription.
 
 	if event.Spec.ActiveTo == nil {
 		// Let's do one sync, just to make sure we have at least the new items lined up
-		err := s.SynchronizeSubscriptionAndInvoiceCustomer(ctx, event.SubscriptionView, now)
+		err := s.synchronizeSubscriptionAndInvoiceCustomer(ctx, newSubscriptionReferenceOrView(event.SubscriptionView), now)
 		if err != nil {
 			return err
 		}
@@ -32,7 +32,7 @@ func (s *Service) HandleCancelledEvent(ctx context.Context, event *subscription.
 	}
 
 	// Let's sync up to the end of the subscription
-	err := s.SynchronizeSubscriptionAndInvoiceCustomer(ctx, event.SubscriptionView, *event.Spec.ActiveTo)
+	err := s.synchronizeSubscriptionAndInvoiceCustomer(ctx, newSubscriptionReferenceOrView(event.SubscriptionView), *event.Spec.ActiveTo)
 	if err != nil {
 		return err
 	}
@@ -62,20 +62,22 @@ func (s *Service) HandleInvoiceCreation(ctx context.Context, event *billing.Stan
 	)
 
 	for _, subscriptionID := range affectedSubscriptions {
-		subsView, err := s.subscriptionService.GetView(ctx, models.NamespacedID{
-			Namespace: event.Invoice.Namespace,
-			ID:        subscriptionID,
-		})
-		if err != nil {
-			return fmt.Errorf("getting subscription view[%s]: %w", subscriptionID, err)
-		}
-
 		// We use the current time as reference point instead of the invoice, as if we are delayed
 		// we might want to provision more lines
-		if err := s.SynchronizeSubscription(ctx, subsView, clock.Now()); err != nil {
+		if err := s.synchronizeSubscriptionAndInvoiceCustomer(ctx, newSubscriptionReferenceOrView(models.NamespacedID{
+			Namespace: event.Invoice.Namespace,
+			ID:        subscriptionID,
+		}), clock.Now()); err != nil {
 			return fmt.Errorf("syncing subscription[%s]: %w", subscriptionID, err)
 		}
 	}
 
 	return nil
+}
+
+// HandleDeletedEvent is a handler for the subscription deleted event, it will make sure that
+// we synchronize the subscription and invoice customer.
+func (s *Service) HandleDeletedEvent(ctx context.Context, event *subscription.DeletedEvent) error {
+	_, err := s.synchronizeSubscription(ctx, newSubscriptionReferenceOrView(event.Subscription.NamespacedID), clock.Now())
+	return err
 }

--- a/openmeter/billing/worker/subscriptionsync/service/reconcile.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconcile.go
@@ -7,12 +7,14 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/persistedstate"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/reconciler"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/targetstate"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/tracex"
 )
 
-func (s *Service) buildSyncPlan(ctx context.Context, subsView subscription.SubscriptionView, asOf time.Time, customerDeletedAt *time.Time, currency currencyx.Calculator, dryRun bool) (*reconciler.Plan, error) {
+// buildSyncPlan builds a sync plan for a subscription. If the subscription is deleted subsView should be nil.
+func (s *Service) buildSyncPlan(ctx context.Context, subscriptionSettlementMode productcatalog.SettlementMode, subsView *subscription.SubscriptionView, asOf time.Time, customerDeletedAt *time.Time, currency currencyx.Calculator, dryRun bool) (*reconciler.Plan, error) {
 	span := tracex.Start[*reconciler.Plan](ctx, s.tracer, "billing.worker.subscription.sync.buildSyncPlan")
 
 	return span.Wrap(func(ctx context.Context) (*reconciler.Plan, error) {
@@ -39,10 +41,10 @@ func (s *Service) buildSyncPlan(ctx context.Context, subsView subscription.Subsc
 		}
 
 		return s.reconciler.Plan(ctx, reconciler.PlanInput{
-			Subscription: subsView.Subscription,
-			Currency:     currency,
-			Target:       target,
-			Persisted:    persisted,
+			SubscriptionSettlementMode: subscriptionSettlementMode,
+			Currency:                   currency,
+			Target:                     target,
+			Persisted:                  persisted,
 		})
 	})
 }

--- a/openmeter/billing/worker/subscriptionsync/service/reconcile.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconcile.go
@@ -7,19 +7,18 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/persistedstate"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/reconciler"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/targetstate"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/tracex"
 )
 
 // buildSyncPlan builds a sync plan for a subscription. If the subscription is deleted subsView should be nil.
-func (s *Service) buildSyncPlan(ctx context.Context, subscriptionSettlementMode productcatalog.SettlementMode, subsView *subscription.SubscriptionView, asOf time.Time, customerDeletedAt *time.Time, currency currencyx.Calculator, dryRun bool) (*reconciler.Plan, error) {
+func (s *Service) buildSyncPlan(ctx context.Context, subs subscription.Subscription, subsView *subscription.SubscriptionView, asOf time.Time, customerDeletedAt *time.Time, currency currencyx.Calculator, dryRun bool) (*reconciler.Plan, error) {
 	span := tracex.Start[*reconciler.Plan](ctx, s.tracer, "billing.worker.subscription.sync.buildSyncPlan")
 
 	return span.Wrap(func(ctx context.Context) (*reconciler.Plan, error) {
 		persistedLoader := persistedstate.NewLoader(s.billingService, s.chargesService)
-		persisted, err := persistedLoader.LoadForSubscription(ctx, subsView.Subscription)
+		persisted, err := persistedLoader.LoadForSubscription(ctx, subs)
 		if err != nil {
 			return nil, err
 		}
@@ -41,7 +40,7 @@ func (s *Service) buildSyncPlan(ctx context.Context, subscriptionSettlementMode 
 		}
 
 		return s.reconciler.Plan(ctx, reconciler.PlanInput{
-			SubscriptionSettlementMode: subscriptionSettlementMode,
+			SubscriptionSettlementMode: subs.SettlementMode,
 			Currency:                   currency,
 			Target:                     target,
 			Persisted:                  persisted,

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/reconciler.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/reconciler.go
@@ -17,7 +17,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/targetstate"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
@@ -74,18 +73,17 @@ func New(config Config) (*Service, error) {
 }
 
 type PlanInput struct {
-	Subscription subscription.Subscription
-	Currency     currencyx.Calculator
-	Target       targetstate.State
-	Persisted    persistedstate.State
+	SubscriptionSettlementMode productcatalog.SettlementMode
+	Currency                   currencyx.Calculator
+	Target                     targetstate.State
+	Persisted                  persistedstate.State
 }
 
 type ApplyInput struct {
-	DryRun       bool
-	Customer     customer.CustomerID
-	Subscription subscription.Subscription
-	Currency     currencyx.Calculator
-	Plan         *Plan
+	DryRun   bool
+	Customer customer.CustomerID
+	Currency currencyx.Calculator
+	Plan     *Plan
 }
 
 func (i ApplyInput) Validate() error {
@@ -95,10 +93,6 @@ func (i ApplyInput) Validate() error {
 	}
 	if err := i.Customer.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("customer: %w", err))
-	}
-
-	if err := i.Subscription.NamespacedID.Validate(); err != nil {
-		errs = append(errs, fmt.Errorf("subscription namespaced id: %w", err))
 	}
 
 	if err := i.Currency.Validate(); err != nil {
@@ -210,8 +204,14 @@ func filterInScopeLines(inScopeLines []targetstate.StateItem, patchCollections *
 }
 
 func (s *Service) Plan(ctx context.Context, input PlanInput) (*Plan, error) {
-	if input.Subscription.SettlementMode == productcatalog.CreditOnlySettlementMode && s.chargesService == nil {
+	if input.SubscriptionSettlementMode == productcatalog.CreditOnlySettlementMode && s.chargesService == nil {
 		return nil, fmt.Errorf("credit only settlement mode is not supported without charges service enabled")
+	}
+
+	if len(input.Target.Items) == 0 && len(input.Persisted.ByUniqueID) == 0 {
+		return &Plan{
+			SubscriptionMaxGenerationTimeLimit: input.Target.MaxGenerationTimeLimit,
+		}, nil
 	}
 
 	patchCollections, err := newPatchCollectionRouter(

--- a/openmeter/billing/worker/subscriptionsync/service/ref.go
+++ b/openmeter/billing/worker/subscriptionsync/service/ref.go
@@ -1,0 +1,123 @@
+package service
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/openmeterio/openmeter/openmeter/subscription"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type SubscriptionReferenceType string
+
+const (
+	SubscriptionReferenceTypeID   SubscriptionReferenceType = "id"
+	SubscriptionReferenceTypeView SubscriptionReferenceType = "view"
+)
+
+var SubscriptionReferenceTypes = []SubscriptionReferenceType{
+	SubscriptionReferenceTypeID,
+	SubscriptionReferenceTypeView,
+}
+
+func (t SubscriptionReferenceType) Validate() error {
+	if slices.Contains(SubscriptionReferenceTypes, t) {
+		return nil
+	}
+
+	return fmt.Errorf("invalid subscription reference type: %s", t)
+}
+
+type subscriptionReferenceOrView struct {
+	t    SubscriptionReferenceType
+	id   *models.NamespacedID
+	view *subscription.SubscriptionView
+}
+
+func newSubscriptionReferenceOrView[T models.NamespacedID | subscription.SubscriptionView | subscription.Subscription](refOrView T) subscriptionReferenceOrView {
+	switch v := any(refOrView).(type) {
+	case models.NamespacedID:
+		return subscriptionReferenceOrView{
+			t:  SubscriptionReferenceTypeID,
+			id: &v,
+		}
+	case subscription.SubscriptionView:
+		return subscriptionReferenceOrView{
+			t:    SubscriptionReferenceTypeView,
+			view: &v,
+		}
+	case subscription.Subscription:
+		return subscriptionReferenceOrView{
+			t:  SubscriptionReferenceTypeID,
+			id: &v.NamespacedID,
+		}
+	default:
+		return subscriptionReferenceOrView{}
+	}
+}
+
+func (r subscriptionReferenceOrView) Validate() error {
+	switch r.t {
+	case SubscriptionReferenceTypeID:
+		if r.id == nil {
+			return fmt.Errorf("subscription ID is required")
+		}
+
+		return nil
+	case SubscriptionReferenceTypeView:
+		if r.view == nil {
+			return fmt.Errorf("subscription view is required")
+		}
+
+		return r.view.Validate(true)
+	default:
+		return fmt.Errorf("invalid subscription reference type: %s", r.t)
+	}
+}
+
+func (r subscriptionReferenceOrView) Type() SubscriptionReferenceType {
+	return r.t
+}
+
+func (r subscriptionReferenceOrView) AsNamespacedID() (models.NamespacedID, error) {
+	if r.t != SubscriptionReferenceTypeID {
+		return models.NamespacedID{}, fmt.Errorf("subscription reference type is not ID: %s", r.t)
+	}
+
+	if r.id == nil {
+		return models.NamespacedID{}, fmt.Errorf("subscription ID is required")
+	}
+
+	return *r.id, nil
+}
+
+func (r subscriptionReferenceOrView) AsSubscriptionView() (subscription.SubscriptionView, error) {
+	if r.t != SubscriptionReferenceTypeView {
+		return subscription.SubscriptionView{}, fmt.Errorf("subscription reference type is not view: %s", r.t)
+	}
+
+	if r.view == nil {
+		return subscription.SubscriptionView{}, fmt.Errorf("subscription view is required")
+	}
+
+	return *r.view, nil
+}
+
+func (r subscriptionReferenceOrView) GetID() models.NamespacedID {
+	switch r.t {
+	case SubscriptionReferenceTypeID:
+		if r.id == nil {
+			return models.NamespacedID{}
+		}
+
+		return *r.id
+	case SubscriptionReferenceTypeView:
+		if r.view == nil {
+			return models.NamespacedID{}
+		}
+
+		return r.view.Subscription.NamespacedID
+	default:
+		return models.NamespacedID{}
+	}
+}

--- a/openmeter/billing/worker/subscriptionsync/service/service.go
+++ b/openmeter/billing/worker/subscriptionsync/service/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"go.opentelemetry.io/otel/trace"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/reconciler"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type FeatureFlags struct {
@@ -98,4 +100,22 @@ func (s *Service) GetSyncStates(ctx context.Context, input subscriptionsync.GetS
 	return transaction.Run(ctx, s.subscriptionSyncAdapter, func(ctx context.Context) ([]subscriptionsync.SyncState, error) {
 		return s.subscriptionSyncAdapter.GetSyncStates(ctx, input)
 	})
+}
+
+func (s *Service) SyncByViewAndInvoiceCustomer(ctx context.Context, view subscription.SubscriptionView, asOf time.Time) error {
+	return s.synchronizeSubscriptionAndInvoiceCustomer(ctx, newSubscriptionReferenceOrView(view), asOf)
+}
+
+func (s *Service) SyncByIDAndInvoiceCustomer(ctx context.Context, subscriptionID models.NamespacedID, asOf time.Time) error {
+	return s.synchronizeSubscriptionAndInvoiceCustomer(ctx, newSubscriptionReferenceOrView(subscriptionID), asOf)
+}
+
+func (s *Service) SyncByView(ctx context.Context, view subscription.SubscriptionView, asOf time.Time, opts ...subscriptionsync.SynchronizeSubscriptionOption) error {
+	_, err := s.synchronizeSubscription(ctx, newSubscriptionReferenceOrView(view), asOf, opts...)
+	return err
+}
+
+func (s *Service) SyncByID(ctx context.Context, subscriptionID models.NamespacedID, asOf time.Time, opts ...subscriptionsync.SynchronizeSubscriptionOption) error {
+	_, err := s.synchronizeSubscription(ctx, newSubscriptionReferenceOrView(subscriptionID), asOf, opts...)
+	return err
 }

--- a/openmeter/billing/worker/subscriptionsync/service/sync.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync.go
@@ -177,7 +177,7 @@ func (s *Service) synchronizeSubscription(ctx context.Context, refOrView subscri
 			ID:        subs.CustomerId,
 		}, func(ctx context.Context) (*synchronizeSubscriptionResult, error) {
 			// Calculate per line patches
-			linesDiff, err := s.buildSyncPlan(ctx, subs.SettlementMode, subsView, asOf, customerDeletedAt, currency, options.DryRun)
+			linesDiff, err := s.buildSyncPlan(ctx, subs, subsView, asOf, customerDeletedAt, currency, options.DryRun)
 			if err != nil {
 				return nil, err
 			}

--- a/openmeter/billing/worker/subscriptionsync/service/sync.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync.go
@@ -17,8 +17,10 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/convert"
+	"github.com/openmeterio/openmeter/pkg/filter"
 	"github.com/openmeterio/openmeter/pkg/framework/tracex"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
 )
 
 const (
@@ -55,41 +57,39 @@ func (s *Service) HandleSubscriptionSyncEvent(ctx context.Context, event *subscr
 		return nil
 	}
 
-	subsView, err := s.subscriptionService.GetView(ctx, event.Subscription.NamespacedID)
-	if err != nil {
-		return fmt.Errorf("getting subscription view: %w", err)
-	}
-
-	return s.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, time.Now())
+	return s.synchronizeSubscriptionAndInvoiceCustomer(ctx, newSubscriptionReferenceOrView(event.Subscription), time.Now())
 }
 
-func (s *Service) SynchronizeSubscriptionAndInvoiceCustomer(ctx context.Context, subs subscription.SubscriptionView, asOf time.Time) error {
-	span := tracex.StartWithNoValue(ctx, s.tracer, "billing.worker.subscription.sync.SynchronizeSubscriptionAndInvoiceCustomer", trace.WithAttributes(
-		attribute.String("subscription_id", subs.Subscription.ID),
-		attribute.String("as_of", asOf.Format(time.RFC3339)),
-	))
+func (s *Service) synchronizeSubscriptionAndInvoiceCustomer(ctx context.Context, refOrView subscriptionReferenceOrView, asOf time.Time) error {
+	res, err := s.synchronizeSubscription(ctx, refOrView, asOf)
+	if err != nil {
+		return fmt.Errorf("synchronize subscription: %w", err)
+	}
 
-	return span.Wrap(func(ctx context.Context) error {
-		if err := s.SynchronizeSubscription(ctx, subs, asOf); err != nil {
-			return fmt.Errorf("synchronize subscription: %w", err)
-		}
-
+	if res != nil && res.View != nil {
 		customerID := customer.CustomerID{
-			Namespace: subs.Subscription.Namespace,
-			ID:        subs.Subscription.CustomerId,
+			Namespace: res.View.Subscription.Namespace,
+			ID:        res.View.Subscription.CustomerId,
 		}
 		// Invoice any pending lines invoicable now, so that any in advance fees are invoiced immediately.
 		if err := s.invoicePendingLines(ctx, customerID); err != nil {
 			return fmt.Errorf("invoice pending lines (post): %w [customer_id=%s]", err, customerID.ID)
 		}
+	}
 
-		return nil
-	})
+	return nil
 }
 
-func (s *Service) SynchronizeSubscription(ctx context.Context, subs subscription.SubscriptionView, asOf time.Time, opts ...subscriptionsync.SynchronizeSubscriptionOption) error {
-	span := tracex.StartWithNoValue(ctx, s.tracer, "billing.worker.subscription.sync.SynchronizeSubscription", trace.WithAttributes(
-		attribute.String("subscription_id", subs.Subscription.ID),
+type synchronizeSubscriptionResult struct {
+	View    *subscription.SubscriptionView
+	Deleted bool
+}
+
+func (s *Service) synchronizeSubscription(ctx context.Context, refOrView subscriptionReferenceOrView, asOf time.Time, opts ...subscriptionsync.SynchronizeSubscriptionOption) (*synchronizeSubscriptionResult, error) {
+	subscriptionID := refOrView.GetID()
+
+	span := tracex.Start[*synchronizeSubscriptionResult](ctx, s.tracer, "billing.worker.subscription.sync.SynchronizeSubscription", trace.WithAttributes(
+		attribute.String("subscription_id", subscriptionID.ID),
 		attribute.String("as_of", asOf.Format(time.RFC3339)),
 	))
 
@@ -98,79 +98,100 @@ func (s *Service) SynchronizeSubscription(ctx context.Context, subs subscription
 		opt(&options)
 	}
 
-	return span.Wrap(func(ctx context.Context) error {
-		if !subs.Spec.HasBillables() {
-			if options.DryRun {
-				return nil
+	return span.Wrap(func(ctx context.Context) (*synchronizeSubscriptionResult, error) {
+		subs, err := s.getSubscription(ctx, subscriptionID)
+		if err != nil {
+			return nil, err
+		}
+
+		var subsView *subscription.SubscriptionView
+		if refOrView.Type() == SubscriptionReferenceTypeView {
+			view, err := refOrView.AsSubscriptionView()
+			if err != nil {
+				return nil, err
 			}
 
-			if err := s.updateSyncState(ctx, updateSyncStateInput{
-				SubscriptionView: subs,
-			}); err != nil {
-				return fmt.Errorf("updating sync state: %w", err)
+			subsView = &view
+		} else if !subs.IsDeleted() {
+			view, err := s.subscriptionService.GetView(ctx, subscriptionID)
+			if err != nil {
+				return nil, err
 			}
 
-			s.logger.DebugContext(ctx, "subscription has no billables, skipping sync", "subscription_id", subs.Subscription.ID)
-			return nil
+			subsView = &view
+		}
+
+		res := &synchronizeSubscriptionResult{
+			View:    subsView,
+			Deleted: subs.IsDeleted(),
 		}
 
 		customerID := customer.CustomerID{
-			Namespace: subs.Subscription.Namespace,
-			ID:        subs.Subscription.CustomerId,
-		}
-
-		// TODO[later]: Right now we are getting the billing profile as a validation step, but later if we allow more collection
-		// alignment settings, we should use the collection settings from here to determine the generation end (overriding asof).
-		customerOverride, err := s.billingService.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
-			Customer: customerID,
-			Expand: billing.CustomerOverrideExpand{
-				Customer: true,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("getting billing profile: %w", err)
+			Namespace: subs.Namespace,
+			ID:        subs.CustomerId,
 		}
 
 		var customerDeletedAt *time.Time
-		if customerOverride.Customer != nil {
-			customerDeletedAt = convert.SafeToUTC(customerOverride.Customer.GetDeletedAt())
-		}
-
-		if customerOverride.Customer != nil && customerOverride.Customer.DeletedAt != nil && !customerOverride.Customer.DeletedAt.After(subs.Spec.ActiveFrom) {
-			if options.DryRun {
-				return nil
-			}
-
-			if err := s.updateSyncState(ctx, updateSyncStateInput{
-				SubscriptionView: subs,
-				// Prevent deleted customers from continuing to be scheduled for sync.
-				PreventFurtherSyncs: true,
-			}); err != nil {
-				return fmt.Errorf("updating sync state: %w", err)
-			}
-
-			s.logger.WarnContext(ctx, "customer deleted before subscription start, skipping sync", "subscription_id", subs.Subscription.ID, "customer_id", customerID.ID)
-			return nil
-		}
-
-		currency, err := subs.Spec.Currency.Calculator()
-		if err != nil {
-			return fmt.Errorf("getting currency calculator: %w", err)
-		}
-
-		return s.billingService.WithLock(ctx, customer.CustomerID{
-			Namespace: subs.Subscription.Namespace,
-			ID:        subs.Subscription.CustomerId,
-		}, func(ctx context.Context) error {
-			// Calculate per line patches
-			linesDiff, err := s.buildSyncPlan(ctx, subs, asOf, customerDeletedAt, currency, options.DryRun)
+		if subsView != nil && subsView.Spec.HasBillables() {
+			// TODO[later]: Right now we are getting the billing profile as a validation step, but later if we allow more collection
+			// alignment settings, we should use the collection settings from here to determine the generation end (overriding asof).
+			customerOverride, err := s.billingService.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
+				Customer: customerID,
+				Expand: billing.CustomerOverrideExpand{
+					Customer: true,
+				},
+			})
 			if err != nil {
-				return err
+				return nil, fmt.Errorf("getting billing profile: %w", err)
+			}
+
+			if customerOverride.Customer != nil {
+				customerDeletedAt = convert.SafeToUTC(customerOverride.Customer.GetDeletedAt())
+			}
+
+			if customerOverride.Customer != nil && customerOverride.Customer.DeletedAt != nil && !customerOverride.Customer.DeletedAt.After(subsView.Spec.ActiveFrom) {
+				if options.DryRun {
+					return res, nil
+				}
+
+				if err := s.updateSyncState(ctx, updateSyncStateInput{
+					SubscriptionID: subscriptionID,
+					// Prevent deleted customers from continuing to be scheduled for sync.
+					PreventFurtherSyncs: true,
+				}); err != nil {
+					return nil, fmt.Errorf("updating sync state: %w", err)
+				}
+
+				s.logger.WarnContext(ctx, "customer deleted before subscription start, skipping sync", "subscription_id", subscriptionID.ID, "customer_id", customerID.ID)
+				return res, nil
+			}
+		}
+
+		currency, err := subs.Currency.Calculator()
+		if err != nil {
+			return nil, fmt.Errorf("getting currency calculator: %w", err)
+		}
+
+		return withBillingLock(ctx, s, customer.CustomerID{
+			Namespace: subs.Namespace,
+			ID:        subs.CustomerId,
+		}, func(ctx context.Context) (*synchronizeSubscriptionResult, error) {
+			// Calculate per line patches
+			linesDiff, err := s.buildSyncPlan(ctx, subs.SettlementMode, subsView, asOf, customerDeletedAt, currency, options.DryRun)
+			if err != nil {
+				return nil, err
+			}
+
+			// If we have a view, we can use it to determine if the subscription has billables, if the
+			// subscription is deleted (no view), let's set hasBillables to false, so that we prevent further syncs.
+			hasBillables := false
+			if subsView != nil {
+				hasBillables = subsView.Spec.HasBillables()
 			}
 
 			if linesDiff == nil || linesDiff.IsEmpty() {
 				if options.DryRun {
-					return nil
+					return res, nil
 				}
 
 				generationLimit := time.Time{}
@@ -179,55 +200,92 @@ func (s *Service) SynchronizeSubscription(ctx context.Context, subs subscription
 				}
 
 				if err := s.updateSyncState(ctx, updateSyncStateInput{
-					SubscriptionView:       subs,
+					SubscriptionID:         subscriptionID,
 					MaxGenerationTimeLimit: generationLimit,
+					HasBillables:           hasBillables,
 				}); err != nil {
-					return fmt.Errorf("updating sync state: %w", err)
+					return nil, fmt.Errorf("updating sync state: %w", err)
 				}
 
-				return nil
+				return res, nil
 			}
 
 			if err := s.reconciler.Apply(ctx, reconciler.ApplyInput{
-				DryRun:       options.DryRun,
-				Customer:     customerID,
-				Subscription: subs.Subscription,
-				Currency:     currency,
-				Plan:         linesDiff,
+				DryRun:   options.DryRun,
+				Customer: customerID,
+				Currency: currency,
+				Plan:     linesDiff,
 			}); err != nil {
-				return err
+				return nil, err
 			}
 
 			if options.DryRun {
-				return nil
+				return res, nil
 			}
 
 			if err := s.updateSyncState(ctx, updateSyncStateInput{
-				SubscriptionView:       subs,
+				SubscriptionID:         subscriptionID,
 				MaxGenerationTimeLimit: linesDiff.SubscriptionMaxGenerationTimeLimit,
+				HasBillables:           hasBillables,
 			}); err != nil {
-				return fmt.Errorf("updating sync state: %w", err)
+				return nil, fmt.Errorf("updating sync state: %w", err)
 			}
 
-			return nil
+			return res, nil
 		})
 	})
 }
 
+func withBillingLock[T any](ctx context.Context, s *Service, customerID customer.CustomerID, fn func(ctx context.Context) (T, error)) (T, error) {
+	var out T
+	err := s.billingService.WithLock(ctx, customerID, func(ctx context.Context) error {
+		var err error
+		out, err = fn(ctx)
+		return err
+	})
+	if err != nil {
+		return lo.Empty[T](), err
+	}
+
+	return out, nil
+}
+
+func (s *Service) getSubscription(ctx context.Context, subscriptionID models.NamespacedID) (subscription.Subscription, error) {
+	subs, err := s.subscriptionService.List(ctx, subscription.ListSubscriptionsInput{
+		Namespaces:     []string{subscriptionID.Namespace},
+		ID:             &filter.FilterULID{FilterString: filter.FilterString{In: &[]string{subscriptionID.ID}}},
+		IncludeDeleted: true,
+		Page: pagination.Page{
+			PageNumber: 1,
+			PageSize:   1,
+		},
+	})
+	if err != nil {
+		return subscription.Subscription{}, fmt.Errorf("getting subscription: %w", err)
+	}
+
+	if len(subs.Items) == 0 {
+		return subscription.Subscription{}, subscription.NewSubscriptionNotFoundError(subscriptionID.ID)
+	}
+
+	return subs.Items[0], nil
+}
+
 type updateSyncStateInput struct {
-	SubscriptionView       subscription.SubscriptionView
+	SubscriptionID         models.NamespacedID
 	MaxGenerationTimeLimit time.Time
 	PreventFurtherSyncs    bool
+	HasBillables           bool
 }
 
 func (s *Service) updateSyncState(ctx context.Context, in updateSyncStateInput) error {
 	span := tracex.StartWithNoValue(ctx, s.tracer, "billing.worker.subscription.sync.updateSyncState", trace.WithAttributes(
-		attribute.String("subscription_id", in.SubscriptionView.Subscription.ID),
+		attribute.String("subscription_id", in.SubscriptionID.ID),
 		attribute.String("max_generation_time_limit", in.MaxGenerationTimeLimit.Format(time.RFC3339)),
 	))
 
 	return span.Wrap(func(ctx context.Context) error {
-		hasBillables := in.SubscriptionView.Spec.HasBillables()
+		hasBillables := in.HasBillables
 		if in.PreventFurtherSyncs {
 			// We are using the hasBillables flag to prevent further syncs, this is used when the customer is
 			// deleted etc.
@@ -236,12 +294,9 @@ func (s *Service) updateSyncState(ctx context.Context, in updateSyncStateInput) 
 
 		if !hasBillables {
 			return s.subscriptionSyncAdapter.UpsertSyncState(ctx, subscriptionsync.UpsertSyncStateInput{
-				SubscriptionID: models.NamespacedID{
-					ID:        in.SubscriptionView.Subscription.ID,
-					Namespace: in.SubscriptionView.Subscription.Namespace,
-				},
-				HasBillables: false,
-				SyncedAt:     clock.Now().UTC(),
+				SubscriptionID: in.SubscriptionID,
+				HasBillables:   false,
+				SyncedAt:       clock.Now().UTC(),
 			})
 		}
 
@@ -250,19 +305,16 @@ func (s *Service) updateSyncState(ctx context.Context, in updateSyncStateInput) 
 		if in.MaxGenerationTimeLimit.IsZero() {
 			// Fallback: we cannot determine the next sync after, so we'll just mandate the sync
 			if nextSyncAfter.IsZero() {
-				s.logger.WarnContext(ctx, "cannot determine the next sync after, syncing immediately", "subscription_id", in.SubscriptionView.Subscription.ID)
+				s.logger.WarnContext(ctx, "cannot determine the next sync after, syncing immediately", "subscription_id", in.SubscriptionID.ID)
 				nextSyncAfter = clock.Now().UTC()
 			}
 		}
 
 		return s.subscriptionSyncAdapter.UpsertSyncState(ctx, subscriptionsync.UpsertSyncStateInput{
-			SubscriptionID: models.NamespacedID{
-				ID:        in.SubscriptionView.Subscription.ID,
-				Namespace: in.SubscriptionView.Subscription.Namespace,
-			},
-			HasBillables:  true,
-			NextSyncAfter: lo.ToPtr(nextSyncAfter),
-			SyncedAt:      clock.Now().UTC(),
+			SubscriptionID: in.SubscriptionID,
+			HasBillables:   true,
+			NextSyncAfter:  lo.ToPtr(nextSyncAfter),
+			SyncedAt:       clock.Now().UTC(),
 		})
 	})
 }

--- a/openmeter/billing/worker/subscriptionsync/service/sync.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync.go
@@ -105,14 +105,16 @@ func (s *Service) synchronizeSubscription(ctx context.Context, refOrView subscri
 		}
 
 		var subsView *subscription.SubscriptionView
-		if refOrView.Type() == SubscriptionReferenceTypeView {
+		if subs.IsDeleted() {
+			subsView = nil
+		} else if refOrView.Type() == SubscriptionReferenceTypeView {
 			view, err := refOrView.AsSubscriptionView()
 			if err != nil {
 				return nil, err
 			}
 
 			subsView = &view
-		} else if !subs.IsDeleted() {
+		} else {
 			view, err := s.subscriptionService.GetView(ctx, subscriptionID)
 			if err != nil {
 				return nil, err

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -301,7 +301,7 @@ func (s *CreditThenInvoiceTestSuite) TestSubscriptionHappyPath() {
 
 		// when:
 		// - the first set of billable items is provisioned
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now().AddDate(0, 1, 0)))
+		s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now().AddDate(0, 1, 0)))
 
 		// then:
 		// - billing has a gathering invoice for the charge-backed line
@@ -366,7 +366,7 @@ func (s *CreditThenInvoiceTestSuite) TestSubscriptionHappyPath() {
 
 		// When we advance the clock the invoice doesn't get changed
 		clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now().AddDate(0, 1, 0)))
+		s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now().AddDate(0, 1, 0)))
 
 		reconciledCharge := s.mustGetOnlyUsageBasedCharge(ctx, subsView.Subscription.ID)
 
@@ -538,7 +538,7 @@ func (s *CreditThenInvoiceTestSuite) TestSubscriptionHappyPath() {
 		// If we are now resyncing the subscription, the gathering invoice should be updated to reflect the new cadence.
 
 		// when:
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+		s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 		// then:
 		// - the remaining gathering line stays charge-managed
@@ -590,7 +590,7 @@ func (s *CreditThenInvoiceTestSuite) TestSubscriptionHappyPath() {
 		// If we are now resyncing the subscription, the gathering invoice should be updated to reflect the original cadence
 
 		// when:
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+		s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 		// then:
 		// - the gathering line keeps the charge-backed line engine
@@ -729,7 +729,7 @@ func (s *CreditThenInvoiceTestSuite) TestInArrearsProratingGathering() {
 
 	// let's provision the first set of items
 	s.Run("provision first set of items", func() {
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+		s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 		// then there should be a gathering invoice
 		invoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
@@ -783,7 +783,7 @@ func (s *CreditThenInvoiceTestSuite) TestInArrearsProratingGathering() {
 		})
 		s.NoError(err)
 
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+		s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 		// then there should be a gathering invoice
 		invoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
@@ -882,7 +882,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncNonBillableAmount
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 	s.assertCreditThenInvoiceBalances(startBalances)
 
@@ -906,7 +906,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncNonBillableAmount
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - 2nd sync", gatheringInvoice)
@@ -1013,7 +1013,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncNonBillableAmount
 
 	subsView := s.createSubscriptionFromPlan(planInput)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 	s.assertCreditThenInvoiceBalances(startBalances)
 
@@ -1037,7 +1037,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncNonBillableAmount
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - 2nd sync", gatheringInvoice)
@@ -1166,7 +1166,7 @@ func (s *CreditThenInvoiceTestSuite) TestInArrearsGatheringSyncNonBillableAmount
 
 	subsView := s.createSubscriptionFromPlan(planInput)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 	s.assertCreditThenInvoiceBalances(startBalances)
 
@@ -1190,7 +1190,7 @@ func (s *CreditThenInvoiceTestSuite) TestInArrearsGatheringSyncNonBillableAmount
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - 2nd sync", gatheringInvoice)
@@ -1310,7 +1310,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncBillableAmountPro
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 	s.assertCreditThenInvoiceBalances(startBalances)
 
@@ -1334,7 +1334,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncBillableAmountPro
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - 2nd sync", gatheringInvoice)
@@ -1490,7 +1490,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncDraftInvoiceProra
 	})
 
 	s.Run("create gathering invoice", func() {
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+		s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 		s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 		s.assertCreditThenInvoiceBalances(startBalances)
 	})
@@ -1559,7 +1559,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncDraftInvoiceProra
 		s.NoError(err)
 		s.NotNil(updatedSubsView)
 
-		s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+		s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	})
 
 	s.Run("invoices after edit", func() {
@@ -1731,7 +1731,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePror
 	s.Run("create gathering invoice", func() {
 		// when:
 		// - the subscription is synchronized into billing
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+		s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 		s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 
 		// then:
@@ -1836,7 +1836,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePror
 		s.NoError(err)
 		s.NotNil(updatedSubsView)
 
-		s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+		s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	})
 
 	s.Run("invoices after edit", func() {
@@ -2010,7 +2010,7 @@ func (s *CreditThenInvoiceTestSuite) TestDefactoZeroPrices() {
 		// when:
 		// - subscription sync reaches the zero-priced service periods
 		asOf := s.mustParseTime("2024-01-03T12:00:00Z")
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subView, asOf))
+		s.NoError(s.Service.SyncByView(ctx, subView, asOf))
 
 		// then:
 		// - no gathering invoices are materialized
@@ -2178,7 +2178,7 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionInvoicing() {
 	// Now let's synchronize the subscription
 
 	asOf := s.mustParseTime("2024-01-03T12:00:00Z")
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subView, asOf))
+	s.NoError(s.Service.SyncByView(ctx, subView, asOf))
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
 	s.assertCreditThenInvoiceBalances(startBalances)
@@ -2428,7 +2428,7 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionCancellation() {
 
 	// Let's synchronize the subscription until well into the second phase
 	syncUntil := startTime.AddDate(0, 3, 0) // 3 months should suffice
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subView, syncUntil))
+	s.NoError(s.Service.SyncByView(ctx, subView, syncUntil))
 
 	// Let's check the invoice
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -2483,7 +2483,7 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionCancellation() {
 	s.NoError(err)
 
 	// Let's synchronize the subscription
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subView, syncUntil))
+	s.NoError(s.Service.SyncByView(ctx, subView, syncUntil))
 
 	// Let's validate that every line was canceled
 	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -2578,7 +2578,7 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionProgressiveBillingCa
 	})
 
 	// Let's synchronize the subscription
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing)
+	s.NoError(s.Service.SyncByView(ctx, subView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing)
 
 	// Let's check the invoice
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -2674,7 +2674,7 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionProgressiveBillingCa
 	// Event delivery is async, so we need to advance the clock a bit
 	clock.FreezeTime(clock.Now().Add(time.Second))
 	// Let's synchronize the subscription
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subView, clock.Now()))
+	s.NoError(s.Service.SyncByView(ctx, subView, clock.Now()))
 
 	// Let's validate that the gathering invoice is gone too
 	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -2746,7 +2746,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceOneTimeFeeSyncing() {
 	})
 	s.assertCreditThenInvoiceBalances(startBalances)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
 	s.assertCreditThenInvoiceBalances(startBalances)
@@ -2875,7 +2875,7 @@ func (s *CreditThenInvoiceTestSuite) TestInArrearsOneTimeFeeSyncing() {
 	s.NotNil(subsView)
 	s.assertCreditThenInvoiceBalances(startBalances)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.assertCreditThenInvoiceBalances(startBalances)
 
@@ -2890,7 +2890,7 @@ func (s *CreditThenInvoiceTestSuite) TestInArrearsOneTimeFeeSyncing() {
 	subsView, err = s.SubscriptionService.GetView(ctx, subs.NamespacedID)
 	s.NoError(err)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
@@ -2976,7 +2976,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
 	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
@@ -3042,14 +3042,14 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
 		targetItemID := phase.ItemsByKey[s.APIRequestsTotalFeature.Key][0].SubscriptionItem.ID
 		s.NotEqual(itemIDBeforeDryRun, targetItemID)
 
-		s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z"), subscriptionsync.EnableDryRun()))
+		s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z"), subscriptionsync.EnableDryRun()))
 
 		chargeAfterDryRun := s.mustGetOnlyUsageBasedCharge(ctx, subsView.Subscription.ID)
 		s.Require().NotNil(chargeAfterDryRun.Intent.Subscription)
 		s.Equal(itemIDBeforeDryRun, chargeAfterDryRun.Intent.Subscription.ItemID)
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	// gathering invoice
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -3177,7 +3177,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 	})
 
 	// we sync two months so we have lines on gathering
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
 	initialExpectedLines := []expectedLine{
@@ -3302,7 +3302,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 
 	// Now the time-travel is over, let's reset back to the "present"
 	clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
 	// gathering invoice
@@ -3496,7 +3496,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateIssuedInvoice(
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 	s.assertCreditThenInvoiceBalances(startBalances)
 
 	initialExpectedLines := []expectedLine{
@@ -3607,7 +3607,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateIssuedInvoice(
 
 	// Let's reset back the clock to the last sync's time
 	clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 	s.assertCreditThenInvoiceBalances(afterIssuedInvoiceBalances)
 
 	// gathering invoice
@@ -3772,7 +3772,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedUpdateWithLineSplits() {
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 
 	// invoice 1: issued invoice creation
 	clock.FreezeTime(s.mustParseTime("2024-01-15T00:00:00Z"))
@@ -3906,7 +3906,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedUpdateWithLineSplits() {
 	// THEN
 	// Let's reset back the clock to the last sync's time
 	clock.FreezeTime(s.mustParseTime("2024-01-18T00:00:00Z"))
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 
 	// gathering invoice
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -4051,7 +4051,7 @@ func (s *CreditThenInvoiceTestSuite) TestRateCardTaxSyncFlatFee() {
 	})
 
 	s.Run("gathering invoice", func() {
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+		s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 		_, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
 			Customer: s.Customer.GetID(),
 		})
@@ -4089,7 +4089,7 @@ func (s *CreditThenInvoiceTestSuite) TestRateCardTaxSyncFlatFee() {
 		s.NoError(err)
 		s.NotNil(updatedSubsView)
 
-		s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+		s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 		_, err = s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
 			Customer: s.Customer.GetID(),
 		})
@@ -4212,7 +4212,7 @@ func (s *CreditThenInvoiceTestSuite) TestRateCardTaxSyncUsageBased() {
 	})
 
 	s.Run("gathering invoice", func() {
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+		s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 		s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 		s.assertCreditThenInvoiceChargeTaxConfigs(ctx, subsView.Subscription.ID, chargesmeta.ChargeTypeUsageBased, taxConfig)
 
@@ -4246,7 +4246,7 @@ func (s *CreditThenInvoiceTestSuite) TestRateCardTaxSyncUsageBased() {
 		s.NoError(err)
 		s.NotNil(updatedSubsView)
 
-		s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+		s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 		s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 		s.assertCreditThenInvoiceChargeTaxConfigs(ctx, updatedSubsView.Subscription.ID, chargesmeta.ChargeTypeUsageBased, taxConfig)
 
@@ -4379,7 +4379,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceInstantBillingOnSubscriptionCr
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, s.mustParseTime("2024-01-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, s.mustParseTime("2024-01-01T00:00:00Z")))
 	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{
 		FBOAll:             0,
 		FBOPromotional:     0,
@@ -4512,7 +4512,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceInstantBillingOnSubscriptionCr
 
 	clock.FreezeTime(present) // This will be the present
 
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now()))
 	s.assertCreditThenInvoiceBalances(startBalances)
 
 	invoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
@@ -4659,7 +4659,7 @@ func (s *CreditThenInvoiceTestSuite) TestDiscountSynchronization() {
 		// - subscription sync runs just after the start timestamp
 		// then:
 		// - the in-advance fee is instant-invoiced and future charge lines are gathered
-		s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing, and we want both the instant invoice for in advance as well as the gathering for UBP)
+		s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing, and we want both the instant invoice for in advance as well as the gathering for UBP)
 		s.assertCreditThenInvoiceBalances(startBalances)
 
 		invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
@@ -4894,7 +4894,7 @@ func (s *CreditThenInvoiceTestSuite) TestDiscountSynchronizationWithPartialDisco
 		// then:
 		// - the payable part of the in-advance fee consumes promotional credits
 		// - future charge lines are gathered
-		s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing, and we want both the instant invoice for in advance as well as the gathering for UBP)
+		s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing, and we want both the instant invoice for in advance as well as the gathering for UBP)
 		s.assertCreditThenInvoiceBalances(afterInstantInvoiceBalances)
 
 		invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
@@ -5145,7 +5145,7 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionProratingBehavior() 
 	s.NoError(err)
 
 	// Let's syncrhonize subscription data for 1 month
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subView, s.mustParseTime("2024-03-01T00:00:00Z")))
 	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -5373,7 +5373,7 @@ func (s *CreditThenInvoiceTestSuite) TestSynchronizeSubscriptionPeriodAlgorithmC
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 	invoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", invoice)
@@ -5430,7 +5430,7 @@ func (s *CreditThenInvoiceTestSuite) TestSynchronizeSubscriptionPeriodAlgorithmC
 	// Let's generate the next set of items
 	clock.FreezeTime(s.mustParseTime("2025-02-28T00:00:00Z"))
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 	invoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - updated", invoice)
@@ -5525,7 +5525,7 @@ func (s *CreditThenInvoiceTestSuite) TestDeletedCustomerHandling() {
 	subsView, err = s.SubscriptionService.GetView(ctx, subs.NamespacedID)
 	s.NoError(err)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 	// Then the gathering invoice should be available
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -5665,7 +5665,7 @@ func (s *CreditThenInvoiceTestSuite) TestFirstDayOfMonthBillingForSubPeriodLengt
 
 	clock.FreezeTime(s.mustParseTime("2024-01-20T00:00:00Z")) // This will be the present
 
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now()))
 
 	invoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
 		Customers: []string{s.Customer.ID},
@@ -5698,7 +5698,7 @@ func (s *CreditThenInvoiceTestSuite) TestFirstDayOfMonthBillingForSubPeriodLengt
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 	invoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", invoice)
@@ -5776,7 +5776,7 @@ func (s *CreditThenInvoiceTestSuite) TestSyncStateUpdateNoBillables() {
 
 	clock.FreezeTime(s.mustParseTime("2024-01-20T00:00:00Z")) // This will be the present
 
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now()))
 
 	syncStates, err := s.Adapter.GetSyncStates(ctx, subscriptionsync.GetSyncStatesInput{
 		{
@@ -5888,7 +5888,7 @@ func (s *CreditThenInvoiceTestSuite) TestSyncStateUpdateWithFreePhaseActiveInThe
 
 	clock.FreezeTime(s.mustParseTime("2024-01-20T00:00:00Z")) // This will be the present
 
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now()))
 
 	syncStates, err := s.Adapter.GetSyncStates(ctx, subscriptionsync.GetSyncStatesInput{
 		{
@@ -5912,7 +5912,7 @@ func (s *CreditThenInvoiceTestSuite) TestSyncStateUpdateWithFreePhaseActiveInThe
 
 	// Let's advance the clock to simulate the next sync happening
 	clock.FreezeTime(s.mustParseTime("2025-12-15T01:00:00Z"))
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now()))
 
 	syncStates, err = s.Adapter.GetSyncStates(ctx, subscriptionsync.GetSyncStatesInput{
 		{

--- a/openmeter/billing/worker/subscriptionsync/service/sync_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_test.go
@@ -3730,7 +3730,7 @@ func (s *SubscriptionHandlerTestSuite) TestRateCardTaxSync() {
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
-	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - after edit", gatheringInvoice)

--- a/openmeter/billing/worker/subscriptionsync/service/sync_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_test.go
@@ -165,7 +165,7 @@ func (s *SubscriptionHandlerTestSuite) TestSubscriptionHappyPath() {
 
 	// let's provision the first set of items
 	s.Run("provision first set of items", func() {
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now().AddDate(0, 1, 0)))
+		s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now().AddDate(0, 1, 0)))
 
 		invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
 			Namespaces: []string{namespace},
@@ -199,7 +199,7 @@ func (s *SubscriptionHandlerTestSuite) TestSubscriptionHappyPath() {
 
 		// When we advance the clock the invoice doesn't get changed
 		clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now().AddDate(0, 1, 0)))
+		s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now().AddDate(0, 1, 0)))
 
 		gatheringInvoice := s.gatheringInvoice(ctx, namespace, s.Customer.ID)
 		s.NoError(err)
@@ -297,7 +297,7 @@ func (s *SubscriptionHandlerTestSuite) TestSubscriptionHappyPath() {
 
 		// If we are now resyncing the subscription, the gathering invoice should be updated to reflect the new cadence.
 
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+		s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 		gatheringInvoice, err := s.BillingService.GetGatheringInvoiceById(ctx, billing.GetGatheringInvoiceByIdInput{
 			Invoice: gatheringInvoiceID,
@@ -346,7 +346,7 @@ func (s *SubscriptionHandlerTestSuite) TestSubscriptionHappyPath() {
 
 		// If we are now resyncing the subscription, the gathering invoice should be updated to reflect the original cadence
 
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+		s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 		gatheringInvoice, err := s.BillingService.GetGatheringInvoiceById(ctx, billing.GetGatheringInvoiceByIdInput{
 			Invoice: gatheringInvoiceID,
@@ -473,7 +473,7 @@ func (s *SubscriptionHandlerTestSuite) TestInArrearsProratingGathering() {
 
 	// let's provision the first set of items
 	s.Run("provision first set of items", func() {
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+		s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 		// then there should be a gathering invoice
 		invoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
@@ -525,7 +525,7 @@ func (s *SubscriptionHandlerTestSuite) TestInArrearsProratingGathering() {
 		})
 		s.NoError(err)
 
-		s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+		s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 		// then there should be a gathering invoice
 		invoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
@@ -588,7 +588,7 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncNonBillableAmou
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 
 	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:40Z"))
@@ -611,7 +611,7 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncNonBillableAmou
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - 2nd sync", gatheringInvoice)
@@ -700,7 +700,7 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncNonBillableAmou
 
 	subsView := s.createSubscriptionFromPlan(planInput)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 
 	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:40Z"))
@@ -723,7 +723,7 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncNonBillableAmou
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - 2nd sync", gatheringInvoice)
@@ -834,7 +834,7 @@ func (s *SubscriptionHandlerTestSuite) TestInArrearsGatheringSyncNonBillableAmou
 
 	subsView := s.createSubscriptionFromPlan(planInput)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 
 	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:40Z"))
@@ -857,7 +857,7 @@ func (s *SubscriptionHandlerTestSuite) TestInArrearsGatheringSyncNonBillableAmou
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - 2nd sync", gatheringInvoice)
@@ -941,7 +941,7 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncBillableAmountP
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 
 	clock.FreezeTime(s.mustParseTime("2024-01-02T00:00:00Z"))
@@ -964,7 +964,7 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncBillableAmountP
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - 2nd sync", gatheringInvoice)
@@ -1076,7 +1076,7 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncDraftInvoicePro
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 
 	clock.FreezeTime(s.mustParseTime("2024-01-02T00:00:00Z"))
@@ -1131,7 +1131,7 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncDraftInvoicePro
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	// gathering invoice
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -1245,7 +1245,7 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePr
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 
 	clock.FreezeTime(s.mustParseTime("2024-01-02T00:00:00Z"))
@@ -1304,7 +1304,7 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePr
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	// gathering invoice
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -1441,7 +1441,7 @@ func (s *SubscriptionHandlerTestSuite) TestDefactoZeroPrices() {
 	// Now let's synchronize the subscription
 
 	asOf := s.mustParseTime("2024-01-03T12:00:00Z")
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subView, asOf))
+	s.NoError(s.Service.SyncByView(ctx, subView, asOf))
 
 	invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
 		Namespaces: []string{s.Namespace},
@@ -1588,7 +1588,7 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionInvoicing() {
 	// Now let's synchronize the subscription
 
 	asOf := s.mustParseTime("2024-01-03T12:00:00Z")
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subView, asOf))
+	s.NoError(s.Service.SyncByView(ctx, subView, asOf))
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
 
@@ -1818,7 +1818,7 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionCancellation() {
 
 	// Let's synchronize the subscription until well into the second phase
 	syncUntil := startTime.AddDate(0, 3, 0) // 3 months should suffice
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subView, syncUntil))
+	s.NoError(s.Service.SyncByView(ctx, subView, syncUntil))
 
 	// Let's check the invoice
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -1866,7 +1866,7 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionCancellation() {
 	s.NoError(err)
 
 	// Let's synchronize the subscription
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subView, syncUntil))
+	s.NoError(s.Service.SyncByView(ctx, subView, syncUntil))
 
 	// Let's validate that every line was canceled
 	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -1958,7 +1958,7 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProgressiveBilling
 	})
 
 	// Let's synchronize the subscription
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing)
+	s.NoError(s.Service.SyncByView(ctx, subView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing)
 
 	// Let's check the invoice
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -2062,7 +2062,7 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProgressiveBilling
 	// Event delivery is async, so we need to advance the clock a bit
 	clock.FreezeTime(clock.Now().Add(time.Second))
 	// Let's synchronize the subscription
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subView, clock.Now()))
+	s.NoError(s.Service.SyncByView(ctx, subView, clock.Now()))
 
 	// Let's validate that the gathering invoice is gone too
 	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -2097,7 +2097,7 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceOneTimeFeeSyncing() {
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
 
@@ -2200,7 +2200,7 @@ func (s *SubscriptionHandlerTestSuite) TestInArrearsOneTimeFeeSyncing() {
 	s.NoError(err)
 	s.NotNil(subsView)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 
 	// let's cancel the subscription
@@ -2214,7 +2214,7 @@ func (s *SubscriptionHandlerTestSuite) TestInArrearsOneTimeFeeSyncing() {
 	subsView, err = s.SubscriptionService.GetView(ctx, subs.NamespacedID)
 	s.NoError(err)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
@@ -2273,7 +2273,7 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdate() {
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
 
@@ -2323,7 +2323,7 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdate() {
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 
 	// gathering invoice
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -2417,7 +2417,7 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdateDraftInvoice
 	})
 
 	// we sync two months so we have lines on gathering
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 
 	// Some time has passed, we're syncing the draft invoice
 	clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
@@ -2505,7 +2505,7 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdateDraftInvoice
 
 	// Now the time-travel is over, let's reset back to the "present"
 	clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 
 	// gathering invoice
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -2626,7 +2626,7 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdateIssuedInvoic
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 
 	clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
 	draftInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
@@ -2694,7 +2694,7 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedGatheringUpdateIssuedInvoic
 
 	// Let's reset back the clock to the last sync's time
 	clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 
 	// gathering invoice
 	s.DebugDumpInvoice("gathering invoice - 2nd sync", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
@@ -2779,7 +2779,7 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedUpdateWithLineSplits() {
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 
 	// invoice 1: issued invoice creation
 	clock.FreezeTime(s.mustParseTime("2024-01-15T00:00:00Z"))
@@ -2913,7 +2913,7 @@ func (s *SubscriptionHandlerTestSuite) TestUsageBasedUpdateWithLineSplits() {
 	// THEN
 	// Let's reset back the clock to the last sync's time
 	clock.FreezeTime(s.mustParseTime("2024-01-18T00:00:00Z"))
-	s.NoError(s.Service.SynchronizeSubscription(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 
 	// gathering invoice
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -3025,7 +3025,7 @@ func (s *SubscriptionHandlerTestSuite) TestGatheringManualEditSync() {
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
 
@@ -3067,7 +3067,7 @@ func (s *SubscriptionHandlerTestSuite) TestGatheringManualEditSync() {
 	s.DebugDumpInvoice("edited invoice", editedInvoice)
 
 	// When resyncing the subscription
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - after sync", gatheringInvoice)
 
@@ -3113,7 +3113,7 @@ func (s *SubscriptionHandlerTestSuite) TestSplitLineManualEditSync() {
 	})
 
 	// lets sync for 2 months so we have lines on gathering
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice - pre invoicing", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 
 	clock.FreezeTime(s.mustParseTime("2024-01-15T00:00:00Z"))
@@ -3159,7 +3159,7 @@ func (s *SubscriptionHandlerTestSuite) TestSplitLineManualEditSync() {
 	s.NoError(err)
 
 	// When resyncing the subscription
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 	s.T().Log("-> Subscription canceled")
 
 	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -3213,7 +3213,7 @@ func (s *SubscriptionHandlerTestSuite) TestGatheringManualDeleteSync() {
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
 
@@ -3252,7 +3252,7 @@ func (s *SubscriptionHandlerTestSuite) TestGatheringManualDeleteSync() {
 	s.DebugDumpInvoice("edited invoice", editedInvoice)
 
 	// When resyncing the subscription
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - after sync", gatheringInvoice)
 
@@ -3294,7 +3294,7 @@ func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLines() {
 	})
 
 	// Let's sync for 2 months so we have lines on gathering and draft
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 
 	// Let's assert we have one line on the draft invoice
 	draftInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
@@ -3377,7 +3377,7 @@ func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLines() {
 	s.NoError(err)
 
 	// Now let's resync the subscription
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 
 	// Then the lines should not be updated
 	draftInvoiceAfterSync, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
@@ -3488,7 +3488,7 @@ func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLinesWhenPeriod
 	})
 
 	// Let's just sync for the current month
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-04-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-04-01T00:00:00Z")))
 
 	// Let's assert we have two lines on the gathering invoice
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -3526,7 +3526,7 @@ func (s *SubscriptionHandlerTestSuite) TestManualIgnoringOfSyncedLinesWhenPeriod
 	s.NoError(err)
 
 	// Now let's resync the subscription
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-04-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-04-01T00:00:00Z")))
 
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - after sync", gatheringInvoice)
@@ -3583,7 +3583,7 @@ func (s *SubscriptionHandlerTestSuite) TestSplitLineManualDeleteSync() {
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice - pre invoicing", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 
 	clock.FreezeTime(s.mustParseTime("2024-01-15T00:00:00Z"))
@@ -3628,7 +3628,7 @@ func (s *SubscriptionHandlerTestSuite) TestSplitLineManualDeleteSync() {
 	s.NoError(err)
 
 	// When resyncing the subscription
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.T().Log("-> Subscription canceled")
 
 	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -3699,7 +3699,7 @@ func (s *SubscriptionHandlerTestSuite) TestRateCardTaxSync() {
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
@@ -3730,7 +3730,7 @@ func (s *SubscriptionHandlerTestSuite) TestRateCardTaxSync() {
 	s.NoError(err)
 	s.NotNil(updatedSubsView)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - after edit", gatheringInvoice)
@@ -3785,7 +3785,7 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceInstantBillingOnSubscription
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, s.mustParseTime("2024-01-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, s.mustParseTime("2024-01-01T00:00:00Z")))
 
 	// in-arrears lines wont get synced with this deadline so we'll only have the in advance line on the draft invoice
 	invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
@@ -3867,7 +3867,7 @@ func (s *SubscriptionHandlerTestSuite) TestInAdvanceInstantBillingOnSubscription
 
 	clock.FreezeTime(s.mustParseTime("2024-01-20T00:00:00Z")) // This will be the present
 
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now()))
 
 	invoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
 		Namespaces: []string{s.Namespace},
@@ -3953,7 +3953,7 @@ func (s *SubscriptionHandlerTestSuite) TestDiscountSynchronization() {
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing, and we want both the instant invoice for in advance as well as the gathering for UBP)
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing, and we want both the instant invoice for in advance as well as the gathering for UBP)
 
 	invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
 		Customers: []string{s.Customer.ID},
@@ -4152,7 +4152,7 @@ func (s *SubscriptionHandlerTestSuite) TestAlignedSubscriptionProratingBehavior(
 	s.NoError(err)
 
 	// Let's syncrhonize subscription data for 1 month
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subView, s.mustParseTime("2024-03-01T00:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subView, s.mustParseTime("2024-03-01T00:00:00Z")))
 
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
@@ -4343,7 +4343,7 @@ func (s *SubscriptionHandlerTestSuite) TestSynchronizeSubscriptionPeriodAlgorith
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 	invoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", invoice)
@@ -4400,7 +4400,7 @@ func (s *SubscriptionHandlerTestSuite) TestSynchronizeSubscriptionPeriodAlgorith
 	// Let's generate the next set of items
 	clock.FreezeTime(s.mustParseTime("2025-02-28T00:00:00Z"))
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 	invoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice - updated", invoice)
@@ -4493,7 +4493,7 @@ func (s *SubscriptionHandlerTestSuite) TestDeletedCustomerHandling() {
 	subsView, err = s.SubscriptionService.GetView(ctx, subs.NamespacedID)
 	s.NoError(err)
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 	// Then the gathering invoice should be available
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -4633,7 +4633,7 @@ func (s *SubscriptionHandlerTestSuite) TestFirstDayOfMonthBillingForSubPeriodLen
 
 	clock.FreezeTime(s.mustParseTime("2024-01-20T00:00:00Z")) // This will be the present
 
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now()))
 
 	invoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
 		Customers: []string{s.Customer.ID},
@@ -4666,7 +4666,7 @@ func (s *SubscriptionHandlerTestSuite) TestFirstDayOfMonthBillingForSubPeriodLen
 		},
 	})
 
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
 
 	invoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", invoice)
@@ -4742,7 +4742,7 @@ func (s *SubscriptionHandlerTestSuite) TestSyncStateUpdateNoBillables() {
 
 	clock.FreezeTime(s.mustParseTime("2024-01-20T00:00:00Z")) // This will be the present
 
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now()))
 
 	syncStates, err := s.Adapter.GetSyncStates(ctx, subscriptionsync.GetSyncStatesInput{
 		{
@@ -4852,7 +4852,7 @@ func (s *SubscriptionHandlerTestSuite) TestSyncStateUpdateWithFreePhaseActiveInT
 
 	clock.FreezeTime(s.mustParseTime("2024-01-20T00:00:00Z")) // This will be the present
 
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now()))
 
 	syncStates, err := s.Adapter.GetSyncStates(ctx, subscriptionsync.GetSyncStatesInput{
 		{
@@ -4876,7 +4876,7 @@ func (s *SubscriptionHandlerTestSuite) TestSyncStateUpdateWithFreePhaseActiveInT
 
 	// Let's advance the clock to simulate the next sync happening
 	clock.FreezeTime(s.mustParseTime("2025-12-15T01:00:00Z"))
-	s.NoError(s.Service.SynchronizeSubscriptionAndInvoiceCustomer(ctx, subsView, clock.Now()))
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now()))
 
 	syncStates, err = s.Adapter.GetSyncStates(ctx, subscriptionsync.GetSyncStatesInput{
 		{

--- a/openmeter/billing/worker/subscriptionsync/service/syncbillinganchor_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/syncbillinganchor_test.go
@@ -126,7 +126,7 @@ func (s *BillingAnchorTestSuite) TestBillingAnchorSinglePhase() {
 	s.Equal(billingAnchor, subsView.Subscription.BillingAnchor)
 
 	// When synchronizing the subscription up to 2025-09-30T15:00:00Z
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, testutils.GetRFC3339Time(s.T(), "2025-09-29T15:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, testutils.GetRFC3339Time(s.T(), "2025-09-29T15:00:00Z")))
 
 	// Then:
 	//  - the entitlement should be set up to be active from 2025-07-10T15:00:00Z,
@@ -323,7 +323,7 @@ func (s *BillingAnchorTestSuite) TestBillingAnchorMultiPhase() {
 	s.Equal(billingAnchor, subsView.Subscription.BillingAnchor)
 
 	// When synchronizing the subscription up to 2025-09-30T15:00:00Z
-	s.NoError(s.Service.SynchronizeSubscription(ctx, subsView, testutils.GetRFC3339Time(s.T(), "2025-09-29T15:00:00Z")))
+	s.NoError(s.Service.SyncByView(ctx, subsView, testutils.GetRFC3339Time(s.T(), "2025-09-29T15:00:00Z")))
 
 	// Then:
 	//  - the entitlement should be set up to be active from 2025-07-10T15:00:00Z,

--- a/openmeter/billing/worker/subscriptionsync/service/targetstate/targetstate.go
+++ b/openmeter/billing/worker/subscriptionsync/service/targetstate/targetstate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/framework/tracex"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
@@ -49,7 +50,7 @@ func (i BuildInput) Validate() error {
 		errs = append(errs, err)
 	}
 
-	return errors.Join(errs...)
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type Builder struct {

--- a/openmeter/billing/worker/subscriptionsync/service/targetstate/targetstate.go
+++ b/openmeter/billing/worker/subscriptionsync/service/targetstate/targetstate.go
@@ -28,7 +28,7 @@ type State struct {
 type BuildInput struct {
 	AsOf              time.Time
 	CustomerDeletedAt *time.Time
-	SubscriptionView  subscription.SubscriptionView
+	SubscriptionView  *subscription.SubscriptionView
 	Persisted         persistedstate.State
 }
 
@@ -39,8 +39,10 @@ func (i BuildInput) Validate() error {
 		errs = append(errs, errors.New("asOf is required"))
 	}
 
-	if err := i.SubscriptionView.Validate(true); err != nil {
-		errs = append(errs, err)
+	if i.SubscriptionView != nil {
+		if err := i.SubscriptionView.Validate(true); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	if err := i.Persisted.Validate(); err != nil {
@@ -67,7 +69,14 @@ func (b Builder) Build(ctx context.Context, input BuildInput) (State, error) {
 			return State{}, fmt.Errorf("validating input: %w", err)
 		}
 
-		subs := input.SubscriptionView
+		if input.SubscriptionView == nil {
+			// If the subscription is deleted, we return an empty state to force reconciliation to delete any depending objects.
+			return State{
+				MaxGenerationTimeLimit: input.AsOf,
+			}, nil
+		}
+
+		subs := *input.SubscriptionView
 		// If the customer is deleted, we need to cap the subscription view at the customer deleted at
 		// or invoicing will not allow creating the lines.
 		// Note: this only happens if there is a db inconsistency between the subscription and the customer lifecycle.

--- a/openmeter/billing/worker/worker.go
+++ b/openmeter/billing/worker/worker.go
@@ -192,7 +192,6 @@ func (w *Worker) eventHandler(opts WorkerOptions) (*grouphandler.NoPublishingHan
 
 			return w.subscriptionSync.HandleSubscriptionSyncEvent(ctx, event)
 		}),
-		// TODO: let's add deleted event handling!!!~!
 		grouphandler.NewGroupEventHandler(func(ctx context.Context, event *billing.AdvanceStandardInvoiceEvent) error {
 			if event != nil && slices.Contains(w.lockdownNamespaces, event.Invoice.Namespace) {
 				return nil

--- a/openmeter/billing/worker/worker.go
+++ b/openmeter/billing/worker/worker.go
@@ -155,7 +155,7 @@ func (w *Worker) eventHandler(opts WorkerOptions) (*grouphandler.NoPublishingHan
 				return nil
 			}
 
-			return w.subscriptionSync.SynchronizeSubscriptionAndInvoiceCustomer(ctx, event.SubscriptionView, time.Now())
+			return w.subscriptionSync.SyncByViewAndInvoiceCustomer(ctx, event.SubscriptionView, time.Now())
 		}),
 		grouphandler.NewGroupEventHandler(func(ctx context.Context, event *subscription.CancelledEvent) error {
 			if event != nil && slices.Contains(w.lockdownNamespaces, event.Subscription.Namespace) {
@@ -164,19 +164,26 @@ func (w *Worker) eventHandler(opts WorkerOptions) (*grouphandler.NoPublishingHan
 
 			return w.subscriptionSync.HandleCancelledEvent(ctx, event)
 		}),
+		grouphandler.NewGroupEventHandler(func(ctx context.Context, event *subscription.DeletedEvent) error {
+			if event != nil && slices.Contains(w.lockdownNamespaces, event.Subscription.Namespace) {
+				return nil
+			}
+
+			return w.subscriptionSync.HandleDeletedEvent(ctx, event)
+		}),
 		grouphandler.NewGroupEventHandler(func(ctx context.Context, event *subscription.ContinuedEvent) error {
 			if event != nil && slices.Contains(w.lockdownNamespaces, event.Subscription.Namespace) {
 				return nil
 			}
 
-			return w.subscriptionSync.SynchronizeSubscriptionAndInvoiceCustomer(ctx, event.SubscriptionView, time.Now())
+			return w.subscriptionSync.SyncByViewAndInvoiceCustomer(ctx, event.SubscriptionView, time.Now())
 		}),
 		grouphandler.NewGroupEventHandler(func(ctx context.Context, event *subscription.UpdatedEvent) error {
 			if event != nil && slices.Contains(w.lockdownNamespaces, event.UpdatedView.Subscription.Namespace) {
 				return nil
 			}
 
-			return w.subscriptionSync.SynchronizeSubscriptionAndInvoiceCustomer(ctx, event.UpdatedView, time.Now())
+			return w.subscriptionSync.SyncByViewAndInvoiceCustomer(ctx, event.UpdatedView, time.Now())
 		}),
 		grouphandler.NewGroupEventHandler(func(ctx context.Context, event *subscription.SubscriptionSyncEvent) error {
 			if event != nil && slices.Contains(w.lockdownNamespaces, event.Subscription.Namespace) {
@@ -185,6 +192,7 @@ func (w *Worker) eventHandler(opts WorkerOptions) (*grouphandler.NoPublishingHan
 
 			return w.subscriptionSync.HandleSubscriptionSyncEvent(ctx, event)
 		}),
+		// TODO: let's add deleted event handling!!!~!
 		grouphandler.NewGroupEventHandler(func(ctx context.Context, event *billing.AdvanceStandardInvoiceEvent) error {
 			if event != nil && slices.Contains(w.lockdownNamespaces, event.Invoice.Namespace) {
 				return nil

--- a/openmeter/subscription/events.go
+++ b/openmeter/subscription/events.go
@@ -72,7 +72,7 @@ func NewDeletedEvent(ctx context.Context, view SubscriptionView) DeletedEvent {
 type DeletedEvent viewEvent
 
 var (
-	_ marshaler.Event = CreatedEvent{}
+	_ marshaler.Event = DeletedEvent{}
 
 	subscriptionDeletedEventName = metadata.GetEventName(metadata.EventType{
 		Subsystem: EventSubsystem,

--- a/openmeter/subscription/list.go
+++ b/openmeter/subscription/list.go
@@ -38,10 +38,12 @@ type ListSubscriptionsInput struct {
 	ActiveAt       *time.Time
 	ActiveInPeriod *timeutil.StartBoundedPeriod
 	Status         []SubscriptionStatus
+	IncludeDeleted bool
 
-	ID      *filter.FilterULID
-	PlanID  *filter.FilterULID
-	PlanKey *filter.FilterString
+	ID        *filter.FilterULID
+	PlanID    *filter.FilterULID
+	PlanKey   *filter.FilterString
+	DeletedAt *filter.FilterTime
 }
 
 func (i ListSubscriptionsInput) Validate() error {
@@ -86,6 +88,12 @@ func (i ListSubscriptionsInput) Validate() error {
 	if i.PlanKey != nil {
 		if err := i.PlanKey.Validate(); err != nil {
 			errs = append(errs, models.NewGenericValidationError(fmt.Errorf("invalid plan_key filter: %w", err)))
+		}
+	}
+
+	if i.DeletedAt != nil {
+		if err := i.DeletedAt.Validate(); err != nil {
+			errs = append(errs, models.NewGenericValidationError(fmt.Errorf("invalid deleted_at filter: %w", err)))
 		}
 	}
 

--- a/openmeter/subscription/repo/subscriptionrepo.go
+++ b/openmeter/subscription/repo/subscriptionrepo.go
@@ -156,8 +156,12 @@ func (r *subscriptionRepo) List(ctx context.Context, in subscription.ListSubscri
 		now := clock.Now()
 
 		query := repo.db.Subscription.Query().
-			WithPlan().
-			Where(SubscriptionNotDeletedAt(now)...)
+			WithPlan()
+
+		notDeletedAtNow := SubscriptionNotDeletedAt(now)
+		if !in.IncludeDeleted {
+			query = query.Where(notDeletedAtNow...)
+		}
 
 		if len(in.Namespaces) > 0 {
 			query = query.Where(dbsubscription.NamespaceIn(in.Namespaces...))
@@ -171,6 +175,7 @@ func (r *subscriptionRepo) List(ctx context.Context, in subscription.ListSubscri
 		query = filter.ApplyToQuery(query, in.ID, dbsubscription.FieldID)
 		query = filter.ApplyToQuery(query, in.CustomerID, dbsubscription.FieldCustomerID)
 		query = filter.ApplyToQuery(query, in.PlanID, dbsubscription.FieldPlanID)
+		query = filter.ApplyToQuery(query, in.DeletedAt, dbsubscription.FieldDeletedAt)
 
 		if planKeyPred := filter.SelectPredicate[predicate.Plan](lo.FromPtrOr(in.PlanKey, filter.FilterString{}), dbplan.FieldKey); planKeyPred != nil {
 			query = query.Where(dbsubscription.HasPlanWith(*planKeyPred))

--- a/openmeter/subscription/service/service_test.go
+++ b/openmeter/subscription/service/service_test.go
@@ -674,6 +674,25 @@ func TestList(t *testing.T) {
 			require.Equal(t, sub4.ID, list.Items[0].ID)
 			require.Equal(t, subscription.SubscriptionStatusScheduled, list.Items[0].GetStatusAt(clock.Now()))
 		})
+
+		t.Run("Should list deleted subscriptions when requested", func(t *testing.T) {
+			require.NoError(t, service.Delete(ctx, sub4.NamespacedID))
+
+			defaultList, err := service.List(ctx, subscription.ListSubscriptionsInput{
+				Status: []subscription.SubscriptionStatus{subscription.SubscriptionStatusScheduled},
+			})
+			require.NoError(t, err)
+			require.Empty(t, defaultList.Items)
+
+			includeDeletedScheduledList, err := service.List(ctx, subscription.ListSubscriptionsInput{
+				IncludeDeleted: true,
+				Status:         []subscription.SubscriptionStatus{subscription.SubscriptionStatusScheduled},
+			})
+			require.NoError(t, err)
+			require.Len(t, includeDeletedScheduledList.Items, 1)
+			require.Equal(t, sub4.ID, includeDeletedScheduledList.Items[0].ID)
+			require.NotNil(t, includeDeletedScheduledList.Items[0].DeletedAt)
+		})
 	})
 
 	t.Run("Should filter and sort by new fields", func(t *testing.T) {

--- a/openmeter/subscription/service/service_test.go
+++ b/openmeter/subscription/service/service_test.go
@@ -692,6 +692,28 @@ func TestList(t *testing.T) {
 			require.Len(t, includeDeletedScheduledList.Items, 1)
 			require.Equal(t, sub4.ID, includeDeletedScheduledList.Items[0].ID)
 			require.NotNil(t, includeDeletedScheduledList.Items[0].DeletedAt)
+
+			deletedAt := includeDeletedScheduledList.Items[0].DeletedAt
+			includeDeletedAfterList, err := service.List(ctx, subscription.ListSubscriptionsInput{
+				IncludeDeleted: true,
+				Status:         []subscription.SubscriptionStatus{subscription.SubscriptionStatusScheduled},
+				DeletedAt: &filter.FilterTime{
+					Gt: lo.ToPtr(deletedAt.Add(-time.Second)),
+				},
+			})
+			require.NoError(t, err)
+			require.Len(t, includeDeletedAfterList.Items, 1)
+			require.Equal(t, sub4.ID, includeDeletedAfterList.Items[0].ID)
+
+			includeDeletedBeforeList, err := service.List(ctx, subscription.ListSubscriptionsInput{
+				IncludeDeleted: true,
+				Status:         []subscription.SubscriptionStatus{subscription.SubscriptionStatusScheduled},
+				DeletedAt: &filter.FilterTime{
+					Lt: lo.ToPtr(deletedAt.Add(-time.Second)),
+				},
+			})
+			require.NoError(t, err)
+			require.Empty(t, includeDeletedBeforeList.Items)
 		})
 	})
 

--- a/openmeter/subscription/service/sync_test.go
+++ b/openmeter/subscription/service/sync_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -12,10 +13,13 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/subscription/testutils"
+	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/filter"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 func TestEdit(t *testing.T) {
@@ -374,4 +378,112 @@ func TestEdit(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestDeleteScheduledDowngradeCanExpandDeletedSubscriptionForSync(t *testing.T) {
+	ctx := t.Context()
+	currentTime := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	clock.FreezeTime(currentTime)
+	defer clock.UnFreeze()
+
+	dbDeps := subscriptiontestutils.SetupDBDeps(t)
+	defer dbDeps.Cleanup(t)
+
+	deps := subscriptiontestutils.NewService(t, dbDeps)
+	customerEntity := deps.CustomerAdapter.CreateExampleCustomer(t)
+	_ = deps.FeatureConnector.CreateExampleFeatures(t, deps.ExampleMeterID)
+
+	billingAnchor := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	premiumPlanInput := subscriptiontestutils.GetExamplePlanInput(t)
+	premiumPlanInput.Key = "premium-plan"
+	premiumPlanInput.Name = "Premium"
+	premiumPlan := deps.PlanHelper.CreatePlan(t, premiumPlanInput)
+
+	basicPlanInput := subscriptiontestutils.GetExamplePlanInput(t)
+	basicPlanInput.Key = "basic-plan"
+	basicPlanInput.Name = "Basic"
+	basicPlan := deps.PlanHelper.CreatePlan(t, basicPlanInput)
+
+	var premiumSubscription subscription.SubscriptionView
+	var scheduledSubscription subscription.SubscriptionView
+
+	t.Run("given a customer with a premium subscription", func(t *testing.T) {
+		// given:
+		// - a customer with a premium subscription anchored to the first day of the month
+		// - a lower-priced basic plan available for the next billing cycle
+		// when:
+		// - the premium subscription is created from its plan
+		// then:
+		// - the active subscription exists
+		var err error
+		premiumSubscription, err = deps.WorkflowService.CreateFromPlan(ctx, subscriptionworkflow.CreateSubscriptionWorkflowInput{
+			ChangeSubscriptionWorkflowInput: subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+				Timing: subscription.Timing{
+					Custom: &currentTime,
+				},
+			},
+			Namespace:     subscriptiontestutils.ExampleNamespace,
+			CustomerID:    customerEntity.ID,
+			BillingAnchor: &billingAnchor,
+		}, premiumPlan)
+		require.NoError(t, err)
+		require.NotNil(t, premiumSubscription)
+	})
+
+	t.Run("when a downgrade is scheduled for the next billing cycle", func(t *testing.T) {
+		// given:
+		// - an active premium subscription
+		// when:
+		// - the customer schedules a downgrade to the basic plan
+		// then:
+		// - the current subscription is capped
+		// - a scheduled basic subscription is created
+		currentSubscription, nextSubscription, err := deps.WorkflowService.ChangeToPlan(ctx, premiumSubscription.Subscription.NamespacedID, subscriptionworkflow.ChangeSubscriptionWorkflowInput{
+			Timing: subscription.Timing{
+				Enum: lo.ToPtr(subscription.TimingNextBillingCycle),
+			},
+		}, basicPlan)
+		require.NoError(t, err)
+		require.NotNil(t, currentSubscription.ActiveTo)
+		require.NotNil(t, nextSubscription)
+
+		scheduledSubscription = nextSubscription
+		require.Equal(t, subscription.SubscriptionStatusScheduled, scheduledSubscription.Subscription.GetStatusAt(clock.Now()))
+	})
+
+	t.Run("when the scheduled downgrade is deleted", func(t *testing.T) {
+		// given:
+		// - a scheduled downgrade subscription
+		// when:
+		// - the customer cancels the scheduled downgrade
+		// then:
+		// - the default read path no longer returns the deleted subscription
+		// - the deleted subscription can still be listed and expanded for billing-side cleanup
+		require.NoError(t, deps.SubscriptionService.Delete(ctx, scheduledSubscription.Subscription.NamespacedID))
+
+		_, err := deps.SubscriptionService.GetView(ctx, scheduledSubscription.Subscription.NamespacedID)
+		require.Error(t, err)
+
+		deletedSubscription := getSubscriptionViewIncludingDeleted(t, ctx, deps.SubscriptionService, scheduledSubscription.Subscription.NamespacedID)
+		require.Equal(t, scheduledSubscription.Subscription.ID, deletedSubscription.Subscription.ID)
+		require.NotNil(t, deletedSubscription.Subscription.DeletedAt)
+	})
+}
+
+func getSubscriptionViewIncludingDeleted(t *testing.T, ctx context.Context, service subscription.Service, subscriptionID models.NamespacedID) subscription.SubscriptionView {
+	t.Helper()
+
+	subscriptions, err := service.List(ctx, subscription.ListSubscriptionsInput{
+		Namespaces:     []string{subscriptionID.Namespace},
+		ID:             &filter.FilterULID{FilterString: filter.FilterString{Eq: &subscriptionID.ID}},
+		IncludeDeleted: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, subscriptions.Items, 1)
+
+	views, err := service.ExpandViews(ctx, subscriptions.Items)
+	require.NoError(t, err)
+	require.Len(t, views, 1)
+
+	return views[0]
 }

--- a/test/billing/subscription_test.go
+++ b/test/billing/subscription_test.go
@@ -328,7 +328,29 @@ func (s *SubscriptionTestSuite) createCustomerWithSubscription(ctx context.Conte
 	s.NoError(err)
 	s.NotNil(subsView)
 
-	s.NoError(s.SubscriptionSyncService.SynchronizeSubscription(ctx, subsView, clock.Now()))
+	s.NoError(s.SubscriptionSyncService.SyncByView(ctx, subsView, clock.Now()))
 
 	return cust
+}
+
+func (s *SubscriptionTestSuite) listGatheringLines(ctx context.Context, namespace string, customerID string) []billing.GatheringLine {
+	invoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+		Namespaces: []string{namespace},
+		Customers:  []string{customerID},
+		Expand:     billing.NewGatheringInvoiceExpands(billing.GatheringInvoiceExpandLines),
+	})
+	s.NoError(err)
+
+	var lines []billing.GatheringLine
+	for _, invoice := range invoices.Items {
+		lines = append(lines, invoice.Lines.OrEmpty()...)
+	}
+
+	return lines
+}
+
+func nonDeletedGatheringLinesForSubscription(lines []billing.GatheringLine, subscriptionID string) []billing.GatheringLine {
+	return lo.Filter(lines, func(line billing.GatheringLine, _ int) bool {
+		return line.DeletedAt == nil && line.Subscription != nil && line.Subscription.SubscriptionID == subscriptionID
+	})
 }

--- a/test/subscription/scenario_firstofmonth_test.go
+++ b/test/subscription/scenario_firstofmonth_test.go
@@ -410,6 +410,9 @@ func TestAnchoredAlignment_MidMonthStart_EarlyCancel_IssueNextAnchor(t *testing.
 	_, err = tDeps.subscriptionService.Cancel(ctx, s.NamespacedID, subscription.Timing{Custom: &cancelAt})
 	require.NoError(t, err)
 
+	view, err = tDeps.SubscriptionService.GetView(ctx, s.NamespacedID)
+	require.NoError(t, err)
+
 	// Let's advance time until after
 	clock.SetTime(cancelAt.Add(time.Hour * 1))
 

--- a/test/subscription/scenario_firstofmonth_test.go
+++ b/test/subscription/scenario_firstofmonth_test.go
@@ -212,7 +212,7 @@ func TestBillingOnFirstOfMonth(t *testing.T) {
 	clock.SetTime(currentTime.Add(time.Minute))
 
 	// 5th, let's synchronize the invoice
-	require.NoError(t, tDeps.subscriptionSyncService.SynchronizeSubscription(ctx, view, firstOfMonth.AddDate(0, 1, 0)))
+	require.NoError(t, tDeps.subscriptionSyncService.SyncByView(ctx, view, firstOfMonth.AddDate(0, 1, 0)))
 
 	// 6th, let's check the invoice
 	invoices, err := tDeps.billingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
@@ -414,7 +414,7 @@ func TestAnchoredAlignment_MidMonthStart_EarlyCancel_IssueNextAnchor(t *testing.
 	clock.SetTime(cancelAt.Add(time.Hour * 1))
 
 	// Sync up to the next anchor (July 1st). Lines should remain on gathering invoice until then.
-	require.NoError(t, tDeps.subscriptionSyncService.SynchronizeSubscriptionAndInvoiceCustomer(ctx, view, firstOfNextMonth))
+	require.NoError(t, tDeps.subscriptionSyncService.SyncByViewAndInvoiceCustomer(ctx, view, firstOfNextMonth))
 
 	invoices, err := tDeps.billingService.ListInvoices(ctx, billing.ListInvoicesInput{
 		Namespaces: []string{namespace},

--- a/test/subscription/scenario_firstofmonth_test.go
+++ b/test/subscription/scenario_firstofmonth_test.go
@@ -402,15 +402,12 @@ func TestAnchoredAlignment_MidMonthStart_EarlyCancel_IssueNextAnchor(t *testing.
 	})
 	require.NoError(t, err)
 
-	view, err := tDeps.SubscriptionService.GetView(ctx, s.NamespacedID)
-	require.NoError(t, err)
-
 	// Cancel effective before end of month (e.g., on 20th)
 	cancelAt := beforeFirstOfMonth
 	_, err = tDeps.subscriptionService.Cancel(ctx, s.NamespacedID, subscription.Timing{Custom: &cancelAt})
 	require.NoError(t, err)
 
-	view, err = tDeps.SubscriptionService.GetView(ctx, s.NamespacedID)
+	view, err := tDeps.SubscriptionService.GetView(ctx, s.NamespacedID)
 	require.NoError(t, err)
 
 	// Let's advance time until after

--- a/tools/migrate/migrations/20260519132345_reset-sync-state.up.sql
+++ b/tools/migrate/migrations/20260519132345_reset-sync-state.up.sql
@@ -1,0 +1,2 @@
+-- force sync all subscriptions
+DELETE FROM "subscription_billing_sync_states";

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:WTxy/UBLguSNWcnzymmD8y2u5y7y4Nqng2u2P5ud9ro=
+h1:tUCSfRSZemEuRYoL4HSuueC369LTc4CN+ZrP+A8Hw2U=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -200,3 +200,4 @@ h1:WTxy/UBLguSNWcnzymmD8y2u5y7y4Nqng2u2P5ud9ro=
 20260513072457_ledger_transaction_template_codes.up.sql h1:qbiFeJwp78WmAiUZjBne6RZwsij5lMRdkJn24yVkPTE=
 20260513083018_add_flat_fee_run_immutable.up.sql h1:Wbl6jpSXveNQ8s1IJQ72AKsULD1pFffVTyPOypXYsY0=
 20260513120726_add_app_custom_invoicing_customers_partial_unique_indexes.up.sql h1:8CAyzs63mv7p2EXSZ7IxvLvPvemN+9kTMn8iiY/jXm4=
+20260519132345_reset-sync-state.up.sql h1:pZz+HK6hMwpHYCCdSd+CEkYE+s2nB6LwIfL1XmS56WQ=


### PR DESCRIPTION


<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

As if a subscription was changed, then the subscription change gets canceled the subscription already yields the upcoming line and entitlements that should be deleted after the cancel.

This patch makes sure that:
- Deleted subscriptions are synced at least once with empty target state.
- Reconcile gets and syncs all deleted subscriptions.
- Subscription deleted events are used to instantly sync subscriptions in question.

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deleted-subscription handling and cleanup: reconciliation now processes active and deleted subscriptions in separate phases and uses ID-based reconciliation for deleted records.

* **New Features**
  * Added explicit sync entrypoints and a handler for subscription-deleted events to ensure reliable cleanup and invoicing behavior.

* **Documentation**
  * Clarified sync orchestration, target-state semantics (nil view = deleted), and deleted-subscription guidance.

* **Tests**
  * Updated and added tests to exercise deleted-subscription cleanup and new reconciliation paths.

* **Chores**
  * Migration to reset stored subscription sync state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->