### PR TITLE
fix(sec): sql injection in validate jsonpath query (CVE-2026-8462)

### DIFF
--- a/openmeter/streaming/clickhouse/utils_query.go
+++ b/openmeter/streaming/clickhouse/utils_query.go
@@ -1,20 +1,13 @@
 package clickhouse
 
-import (
-	"fmt"
-
-	"github.com/huandu/go-sqlbuilder"
-)
+import "github.com/huandu/go-sqlbuilder"
 
 type validateJsonPathQuery struct {
 	jsonPath string
 }
 
+// See: https://github.com/huandu/go-sqlbuilder#freestyle-builder
 func (d validateJsonPathQuery) toSQL() (string, []interface{}) {
-	sb := sqlbuilder.ClickHouse.NewSelectBuilder()
-	sb.Select(fmt.Sprintf("JSON_VALUE('{}', '%s')", sqlbuilder.Escape(d.jsonPath)))
-
-	sql, args := sb.Build()
-
-	return sql, args
+	return sqlbuilder.Buildf("SELECT JSON_VALUE('{}', %v)", d.jsonPath).
+		BuildWithFlavor(sqlbuilder.ClickHouse)
 }

--- a/openmeter/streaming/clickhouse/utils_query_test.go
+++ b/openmeter/streaming/clickhouse/utils_query_test.go
@@ -1,0 +1,18 @@
+package clickhouse
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ValidateJsonPathQuery(t *testing.T) {
+	query, args := validateJsonPathQuery{
+		jsonPath: "$.foo.bar",
+	}.toSQL()
+
+	assert.Equal(t, `SELECT JSON_VALUE('{}', ?)`, query)
+	assert.Equal(t, []interface{}{
+		"$.foo.bar",
+	}, args)
+}


### PR DESCRIPTION
## SQL Injection in ClickHouse-backed Meter Definitions (CVE-2026-8462)

An attacker may be able to perform SQL injection through meter configuration fields in `POST /api/v1/meters` when OpenMeter is configured to use ClickHouse as the event database.

The issue affects user-controlled JSONPath values which may be incorporated into ClickHouse queries without sufficient parameterization. Under vulnerable configurations, an attacker with access to the meter creation endpoint could craft a meter definition that alters the intended SQL query.

In multi-tenant ClickHouse deployments where tenant event data is stored in shared tables without database-enforced row-level isolation, successful exploitation could allow an attacker to access metering event data belonging to other tenants. Depending on the ClickHouse user's database permissions, additional impact such as data modification or denial of service through expensive queries may also be possible.

## Am I affected?

You are affected if all of the following hold:

1. You expose `POST /api/v1/meters` to untrusted users or without authentication.
2. The meter creation endpoint can be reached without authentication or effective authorization.
3. Meter definitions accept user-controlled values.

## Resolution

Please upgrade to version v1.0.0-beta.228 or newer.

## CVSS

**CVSS v4.0:** CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/E:P
**Severity:** High
**Score:** 8.9

## Details

Please see the following security advisory: https://github.com/openmeterio/openmeter/security/advisories/GHSA-wc3v-3457-c8cm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit test coverage for ClickHouse JSON-path query handling to ensure consistent SQL output and parameters.

* **Refactor**
  * Updated ClickHouse SQL generation to use parameterized building for safer, more consistent query construction and improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->