### PR TITLE
ci: add security section to release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,9 @@ changelog:
     labels:
       - release-note/ignore
   categories:
+    - title: Security Fixes 🚨
+      labels:
+        - release-note/security-fix
     - title: Exciting New Features 🎉
       labels:
         - kind/feature


### PR DESCRIPTION
## Overview

Add **Security Fixes** section to release notes by assigning `release-note/security-fix` label to PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release notes configuration to add a dedicated "Security Fixes" changelog category, improving the organization and visibility of security-related entries in future releases so users can more easily spot important security updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4384?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->