### PR TITLE
feat(taxcode): create tax codes on namespace create & set defaults

### DIFF
--- a/app/common/taxcode.go
+++ b/app/common/taxcode.go
@@ -4,7 +4,10 @@ import (
 	"log/slog"
 
 	"github.com/google/wire"
+	"github.com/samber/lo"
 
+	"github.com/openmeterio/openmeter/app/config"
+	"github.com/openmeterio/openmeter/openmeter/app"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	taxcodeadapter "github.com/openmeterio/openmeter/openmeter/taxcode/adapter"
@@ -14,6 +17,11 @@ import (
 var TaxCode = wire.NewSet(
 	NewTaxCodeAdapter,
 	NewTaxCodeService,
+)
+
+var TaxCodeNamespaceHandler = wire.NewSet(
+	wire.FieldsOf(new(config.Configuration), "TaxCode"),
+	NewTaxCodeNamespaceHandler,
 )
 
 func NewTaxCodeAdapter(logger *slog.Logger, db *entdb.Client) (taxcode.Repository, error) {
@@ -30,5 +38,35 @@ func NewTaxCodeService(
 	return taxcodeservice.New(taxcodeservice.Config{
 		Adapter: adapter,
 		Logger:  logger.With("subsystem", "taxcode"),
+	})
+}
+
+func NewTaxCodeNamespaceHandler(
+	logger *slog.Logger,
+	service taxcode.Service,
+	repository taxcode.Repository,
+	cfg config.TaxCodeConfiguration,
+) (*taxcode.NamespaceHandler, error) {
+	seeds := lo.Map(cfg.Seeds, func(s config.TaxCodeSeed, _ int) taxcode.SeedEntry {
+		return taxcode.SeedEntry{
+			Key:         s.Key,
+			Name:        s.Name,
+			Description: s.Description,
+			AppMappings: lo.Map(s.AppMappings, func(m config.TaxCodeAppMapping, _ int) taxcode.TaxCodeAppMapping {
+				return taxcode.TaxCodeAppMapping{
+					AppType: app.AppType(m.AppType),
+					TaxCode: m.TaxCode,
+				}
+			}),
+			DefaultInvoicing:   s.DefaultInvoicing,
+			DefaultCreditGrant: s.DefaultCreditGrant,
+		}
+	})
+
+	return taxcode.NewNamespaceHandler(taxcode.NamespaceHandlerConfig{
+		Logger:             logger.With("subsystem", "taxcode", "component", "namespace-handler"),
+		Service:            service,
+		Seeds:              seeds,
+		TransactionManager: repository,
 	})
 }

--- a/app/common/taxcode.go
+++ b/app/common/taxcode.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"log/slog"
+	"strings"
 
 	"github.com/google/wire"
 	"github.com/samber/lo"
@@ -49,13 +50,13 @@ func NewTaxCodeNamespaceHandler(
 ) (*taxcode.NamespaceHandler, error) {
 	seeds := lo.Map(cfg.Seeds, func(s config.TaxCodeSeed, _ int) taxcode.SeedEntry {
 		return taxcode.SeedEntry{
-			Key:         s.Key,
-			Name:        s.Name,
+			Key:         strings.TrimSpace(s.Key),
+			Name:        strings.TrimSpace(s.Name),
 			Description: s.Description,
 			AppMappings: lo.Map(s.AppMappings, func(m config.TaxCodeAppMapping, _ int) taxcode.TaxCodeAppMapping {
 				return taxcode.TaxCodeAppMapping{
-					AppType: app.AppType(m.AppType),
-					TaxCode: m.TaxCode,
+					AppType: app.AppType(strings.TrimSpace(m.AppType)),
+					TaxCode: strings.TrimSpace(m.TaxCode),
 				}
 			}),
 			DefaultInvoicing:   s.DefaultInvoicing,

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -51,6 +51,7 @@ type Configuration struct {
 	Billing            BillingConfiguration
 	Apps               AppsConfiguration
 	Svix               SvixConfig
+	TaxCode            TaxCodeConfiguration
 }
 
 // Validate validates the configuration.
@@ -172,6 +173,10 @@ func (c Configuration) Validate() error {
 		errs = append(errs, errorsx.WithPrefix(err, "credit"))
 	}
 
+	if err := c.TaxCode.Validate(); err != nil {
+		errs = append(errs, errorsx.WithPrefix(err, "taxcode"))
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -223,4 +228,5 @@ func SetViperDefaults(v *viper.Viper, flags *pflag.FlagSet) {
 	ConfigureProgressManager(v)
 	ConfigureCustomer(v, "customer")
 	ConfigureCredits(v)
+	ConfigureTaxCode(v)
 }

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -447,6 +447,26 @@ func TestComplete(t *testing.T) {
 			`^_\..*$`,
 			`^openmeter\..*$`,
 		},
+		TaxCode: TaxCodeConfiguration{
+			Seeds: []TaxCodeSeed{
+				{
+					Key:              "default",
+					Name:             "Provider default",
+					DefaultInvoicing: true,
+				},
+				{
+					Key:                "nontaxable",
+					Name:               "Nontaxable",
+					DefaultCreditGrant: true,
+					AppMappings: []TaxCodeAppMapping{
+						{
+							AppType: "stripe",
+							TaxCode: "txcd_00000000",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	assert.Equal(t, expected, actual)

--- a/app/config/taxcode.go
+++ b/app/config/taxcode.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/viper"
 
@@ -43,19 +44,20 @@ func (c TaxCodeConfiguration) Validate() error {
 	defaultCreditGrantCount := 0
 
 	for i, seed := range c.Seeds {
-		if seed.Key == "" {
+		trimmedKey := strings.TrimSpace(seed.Key)
+		if trimmedKey == "" {
 			errs = append(errs, fmt.Errorf("seed[%d]: key must not be empty", i))
 		}
 
-		if seed.Name == "" {
+		if strings.TrimSpace(seed.Name) == "" {
 			errs = append(errs, fmt.Errorf("seed[%d]: name must not be empty", i))
 		}
 
-		if seed.Key != "" {
-			if _, exists := keys[seed.Key]; exists {
+		if trimmedKey != "" {
+			if _, exists := keys[trimmedKey]; exists {
 				errs = append(errs, fmt.Errorf("seed[%d]: duplicate key %q", i, seed.Key))
 			}
-			keys[seed.Key] = struct{}{}
+			keys[trimmedKey] = struct{}{}
 		}
 
 		if seed.DefaultInvoicing {
@@ -67,11 +69,11 @@ func (c TaxCodeConfiguration) Validate() error {
 		}
 
 		for j, mapping := range seed.AppMappings {
-			if mapping.AppType == "" {
+			if strings.TrimSpace(mapping.AppType) == "" {
 				errs = append(errs, fmt.Errorf("seed[%d].appMappings[%d]: appType must not be empty", i, j))
 			}
 
-			if mapping.TaxCode == "" {
+			if strings.TrimSpace(mapping.TaxCode) == "" {
 				errs = append(errs, fmt.Errorf("seed[%d].appMappings[%d]: taxCode must not be empty", i, j))
 			} else if mapping.AppType == "stripe" && !taxcode.TaxCodeStripeRegexp.MatchString(mapping.TaxCode) {
 				errs = append(errs, fmt.Errorf("seed[%d].appMappings[%d]: taxCode %q is not a valid Stripe tax code (must match %s)", i, j, mapping.TaxCode, taxcode.TaxCodeStripeRegexp.String()))

--- a/app/config/taxcode.go
+++ b/app/config/taxcode.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/spf13/viper"
+
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 )
 
 type TaxCodeConfiguration struct {
@@ -71,6 +73,8 @@ func (c TaxCodeConfiguration) Validate() error {
 
 			if mapping.TaxCode == "" {
 				errs = append(errs, fmt.Errorf("seed[%d].appMappings[%d]: taxCode must not be empty", i, j))
+			} else if mapping.AppType == "stripe" && !taxcode.TaxCodeStripeRegexp.MatchString(mapping.TaxCode) {
+				errs = append(errs, fmt.Errorf("seed[%d].appMappings[%d]: taxCode %q is not a valid Stripe tax code (must match %s)", i, j, mapping.TaxCode, taxcode.TaxCodeStripeRegexp.String()))
 			}
 		}
 	}

--- a/app/config/taxcode.go
+++ b/app/config/taxcode.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/viper"
+)
+
+type TaxCodeConfiguration struct {
+	Seeds []TaxCodeSeed `mapstructure:"seeds"`
+}
+
+// TaxCodeSeed defines a single tax code entry to provision for every namespace.
+// A single seed may carry both DefaultInvoicing and DefaultCreditGrant; the two flags are
+// independent and the exactly-one rule is enforced per flag.
+type TaxCodeSeed struct {
+	Key                string              `mapstructure:"key"`
+	Name               string              `mapstructure:"name"`
+	Description        *string             `mapstructure:"description"`
+	AppMappings        []TaxCodeAppMapping `mapstructure:"appMappings"`
+	DefaultInvoicing   bool                `mapstructure:"defaultInvoicing"`
+	DefaultCreditGrant bool                `mapstructure:"defaultCreditGrant"`
+}
+
+type TaxCodeAppMapping struct {
+	AppType string `mapstructure:"appType"`
+	TaxCode string `mapstructure:"taxCode"`
+}
+
+func (c TaxCodeConfiguration) Validate() error {
+	var errs []error
+
+	if len(c.Seeds) == 0 {
+		errs = append(errs, errors.New("seeds must not be empty"))
+		return errors.Join(errs...)
+	}
+
+	keys := make(map[string]struct{}, len(c.Seeds))
+	defaultInvoicingCount := 0
+	defaultCreditGrantCount := 0
+
+	for i, seed := range c.Seeds {
+		if seed.Key == "" {
+			errs = append(errs, fmt.Errorf("seed[%d]: key must not be empty", i))
+		}
+
+		if seed.Name == "" {
+			errs = append(errs, fmt.Errorf("seed[%d]: name must not be empty", i))
+		}
+
+		if seed.Key != "" {
+			if _, exists := keys[seed.Key]; exists {
+				errs = append(errs, fmt.Errorf("seed[%d]: duplicate key %q", i, seed.Key))
+			}
+			keys[seed.Key] = struct{}{}
+		}
+
+		if seed.DefaultInvoicing {
+			defaultInvoicingCount++
+		}
+
+		if seed.DefaultCreditGrant {
+			defaultCreditGrantCount++
+		}
+
+		for j, mapping := range seed.AppMappings {
+			if mapping.AppType == "" {
+				errs = append(errs, fmt.Errorf("seed[%d].appMappings[%d]: appType must not be empty", i, j))
+			}
+
+			if mapping.TaxCode == "" {
+				errs = append(errs, fmt.Errorf("seed[%d].appMappings[%d]: taxCode must not be empty", i, j))
+			}
+		}
+	}
+
+	if defaultInvoicingCount != 1 {
+		errs = append(errs, fmt.Errorf("exactly one seed must have defaultInvoicing=true, got %d", defaultInvoicingCount))
+	}
+
+	if defaultCreditGrantCount != 1 {
+		errs = append(errs, fmt.Errorf("exactly one seed must have defaultCreditGrant=true, got %d", defaultCreditGrantCount))
+	}
+
+	return errors.Join(errs...)
+}
+
+func ConfigureTaxCode(v *viper.Viper) {
+	v.SetDefault("taxcode.seeds", []map[string]any{
+		{
+			"key":              "default",
+			"name":             "Provider default",
+			"defaultInvoicing": true,
+		},
+		{
+			"key":                "nontaxable",
+			"name":               "Nontaxable",
+			"defaultCreditGrant": true,
+			"appMappings": []map[string]any{
+				{
+					"appType": "stripe",
+					"taxCode": "txcd_00000000",
+				},
+			},
+		},
+	})
+}

--- a/app/config/taxcode.go
+++ b/app/config/taxcode.go
@@ -69,14 +69,17 @@ func (c TaxCodeConfiguration) Validate() error {
 		}
 
 		for j, mapping := range seed.AppMappings {
-			if strings.TrimSpace(mapping.AppType) == "" {
+			trimmedAppType := strings.TrimSpace(mapping.AppType)
+			trimmedTaxCode := strings.TrimSpace(mapping.TaxCode)
+
+			if trimmedAppType == "" {
 				errs = append(errs, fmt.Errorf("seed[%d].appMappings[%d]: appType must not be empty", i, j))
 			}
 
-			if strings.TrimSpace(mapping.TaxCode) == "" {
+			if trimmedTaxCode == "" {
 				errs = append(errs, fmt.Errorf("seed[%d].appMappings[%d]: taxCode must not be empty", i, j))
-			} else if mapping.AppType == "stripe" && !taxcode.TaxCodeStripeRegexp.MatchString(mapping.TaxCode) {
-				errs = append(errs, fmt.Errorf("seed[%d].appMappings[%d]: taxCode %q is not a valid Stripe tax code (must match %s)", i, j, mapping.TaxCode, taxcode.TaxCodeStripeRegexp.String()))
+			} else if trimmedAppType == "stripe" && !taxcode.TaxCodeStripeRegexp.MatchString(trimmedTaxCode) {
+				errs = append(errs, fmt.Errorf("seed[%d].appMappings[%d]: taxCode %q is not a valid Stripe tax code (must match %s)", i, j, trimmedTaxCode, taxcode.TaxCodeStripeRegexp.String()))
 			}
 		}
 	}

--- a/app/config/taxcode_test.go
+++ b/app/config/taxcode_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTaxCodeConfigurationValidate(t *testing.T) {
+	validBase := func() TaxCodeConfiguration {
+		return TaxCodeConfiguration{
+			Seeds: []TaxCodeSeed{
+				{Key: "default", Name: "Provider default", DefaultInvoicing: true},
+				{Key: "nontaxable", Name: "Nontaxable", DefaultCreditGrant: true, AppMappings: []TaxCodeAppMapping{
+					{AppType: "stripe", TaxCode: "txcd_00000000"},
+				}},
+			},
+		}
+	}
+
+	t.Run("Valid", func(t *testing.T) {
+		require.NoError(t, validBase().Validate())
+	})
+
+	t.Run("EmptySeeds", func(t *testing.T) {
+		err := TaxCodeConfiguration{}.Validate()
+		assert.ErrorContains(t, err, "seeds must not be empty")
+	})
+
+	t.Run("EmptyKey", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Seeds[0].Key = ""
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "key must not be empty")
+	})
+
+	t.Run("EmptyName", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Seeds[0].Name = ""
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "name must not be empty")
+	})
+
+	t.Run("DuplicateKeys", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Seeds[1].Key = cfg.Seeds[0].Key
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "duplicate key")
+	})
+
+	t.Run("NoDefaultInvoicing", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Seeds[0].DefaultInvoicing = false
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "defaultInvoicing=true")
+	})
+
+	t.Run("MultipleDefaultInvoicing", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Seeds[1].DefaultInvoicing = true
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "defaultInvoicing=true")
+	})
+
+	t.Run("NoDefaultCreditGrant", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Seeds[1].DefaultCreditGrant = false
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "defaultCreditGrant=true")
+	})
+
+	t.Run("MultipleDefaultCreditGrant", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Seeds[0].DefaultCreditGrant = true
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "defaultCreditGrant=true")
+	})
+
+	t.Run("SingleSeedCarriesBothFlags", func(t *testing.T) {
+		// A single seed may carry both flags; this is legal.
+		cfg := TaxCodeConfiguration{
+			Seeds: []TaxCodeSeed{
+				{Key: "all", Name: "All", DefaultInvoicing: true, DefaultCreditGrant: true},
+			},
+		}
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("AppMappingEmptyAppType", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Seeds[1].AppMappings[0].AppType = ""
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "appType must not be empty")
+	})
+
+	t.Run("AppMappingEmptyTaxCode", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Seeds[1].AppMappings[0].TaxCode = ""
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "taxCode must not be empty")
+	})
+}

--- a/app/config/testdata/complete.yaml
+++ b/app/config/testdata/complete.yaml
@@ -167,3 +167,15 @@ productCatalog:
   subscription:
     multiSubscriptionNamespaces:
       - "multi-subscription"
+
+taxcode:
+  seeds:
+    - key: default
+      name: Provider default
+      defaultInvoicing: true
+    - key: nontaxable
+      name: Nontaxable
+      defaultCreditGrant: true
+      appMappings:
+        - appType: stripe
+          taxCode: txcd_00000000

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -119,6 +119,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	err = app.NamespaceManager.RegisterHandler(app.TaxCodeNamespaceHandler)
+	if err != nil {
+		logger.Error("failed to register tax code namespace handler", "error", err)
+		os.Exit(1)
+	}
+
 	// Initialize Namespace
 	err = initNamespace(app.NamespaceManager, logger)
 	if err != nil {

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -94,6 +94,7 @@ type Application struct {
 	SubjectCustomerHook              subjecthooks.CustomerSubjectHook
 	Subscription                     common.SubscriptionServiceWithWorkflow
 	StreamingConnector               streaming.Connector
+	TaxCodeNamespaceHandler          *taxcode.NamespaceHandler
 	TaxCodeService                   taxcode.Service
 	TelemetryServer                  common.TelemetryServer
 	TerminationChecker               *common.TerminationChecker
@@ -140,6 +141,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		common.ProgressManager,
 		common.Server,
 		common.TaxCode,
+		common.TaxCodeNamespaceHandler,
 		common.Subscription,
 		common.Lockr,
 		common.Secret,

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -724,6 +724,19 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
+	taxCodeConfiguration := conf.TaxCode
+	taxcodeNamespaceHandler, err := common.NewTaxCodeNamespaceHandler(logger, taxcodeService, repository, taxCodeConfiguration)
+	if err != nil {
+		cleanup8()
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
 	health := common.NewHealthChecker(logger)
 	telemetryHandler := common.NewTelemetryHandler(metricsTelemetryConfig, health, logger)
 	v10, cleanup9 := common.NewTelemetryServer(telemetryConfig, telemetryHandler)
@@ -801,6 +814,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		SubjectCustomerHook:              v9,
 		Subscription:                     subscriptionServiceWithWorkflow,
 		StreamingConnector:               connector,
+		TaxCodeNamespaceHandler:          taxcodeNamespaceHandler,
 		TaxCodeService:                   taxcodeService,
 		TelemetryServer:                  v10,
 		TerminationChecker:               terminationChecker,
@@ -870,6 +884,7 @@ type Application struct {
 	SubjectCustomerHook              hooks.CustomerSubjectHook
 	Subscription                     common.SubscriptionServiceWithWorkflow
 	StreamingConnector               streaming.Connector
+	TaxCodeNamespaceHandler          *taxcode.NamespaceHandler
 	TaxCodeService                   taxcode.Service
 	TelemetryServer                  common.TelemetryServer
 	TerminationChecker               *common.TerminationChecker

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -222,3 +222,16 @@ notification:
 #     address: 127.0.0.1:6379
 #     database: 0
 #     # Other redis options as needed
+
+# taxcode configures the list of tax codes to be auto-provisioned on namespace creation.
+# taxcode:
+#   seeds:
+#     - key: default
+#       name: "Provider default"
+#       defaultInvoicing: true
+#     - key: nontaxable
+#       name: "Nontaxable"
+#       defaultCreditGrant: true
+#       appMappings:
+#         - appType: stripe
+#           taxCode: "txcd_00000000"

--- a/openmeter/taxcode/adapter/taxcode.go
+++ b/openmeter/taxcode/adapter/taxcode.go
@@ -110,6 +110,7 @@ func (a *adapter) GetTaxCode(ctx context.Context, input taxcode.GetTaxCodeInput)
 		entity, err := a.db.TaxCode.Query().
 			Where(taxcodedb.Namespace(input.Namespace)).
 			Where(taxcodedb.ID(input.ID)).
+			Where(taxcodedb.DeletedAtIsNil()).
 			Only(ctx)
 		if err != nil {
 			if db.IsNotFound(err) {

--- a/openmeter/taxcode/adapter/taxcode.go
+++ b/openmeter/taxcode/adapter/taxcode.go
@@ -107,11 +107,14 @@ func (a *adapter) GetTaxCode(ctx context.Context, input taxcode.GetTaxCodeInput)
 	}
 
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, a *adapter) (taxcode.TaxCode, error) {
-		entity, err := a.db.TaxCode.Query().
+		query := a.db.TaxCode.Query().
 			Where(taxcodedb.Namespace(input.Namespace)).
-			Where(taxcodedb.ID(input.ID)).
-			Where(taxcodedb.DeletedAtIsNil()).
-			Only(ctx)
+			Where(taxcodedb.ID(input.ID))
+		if !input.IncludeDeleted {
+			query = query.Where(taxcodedb.DeletedAtIsNil())
+		}
+
+		entity, err := query.Only(ctx)
 		if err != nil {
 			if db.IsNotFound(err) {
 				return taxcode.TaxCode{}, taxcode.NewTaxCodeNotFoundError(input.ID)

--- a/openmeter/taxcode/namespacehandler.go
+++ b/openmeter/taxcode/namespacehandler.go
@@ -48,6 +48,15 @@ func (c NamespaceHandlerConfig) validate() error {
 
 	if len(c.Seeds) == 0 {
 		errs = append(errs, errors.New("at least one seed entry is required"))
+	} else {
+		invoicingCount := lo.CountBy(c.Seeds, func(s SeedEntry) bool { return s.DefaultInvoicing })
+		creditGrantCount := lo.CountBy(c.Seeds, func(s SeedEntry) bool { return s.DefaultCreditGrant })
+		if invoicingCount != 1 {
+			errs = append(errs, fmt.Errorf("exactly one seed must have DefaultInvoicing=true, got %d", invoicingCount))
+		}
+		if creditGrantCount != 1 {
+			errs = append(errs, fmt.Errorf("exactly one seed must have DefaultCreditGrant=true, got %d", creditGrantCount))
+		}
 	}
 
 	return errors.Join(errs...)
@@ -80,7 +89,8 @@ func NewNamespaceHandler(cfg NamespaceHandlerConfig) (*NamespaceHandler, error) 
 
 // CreateNamespace provisions the configured seed tax codes and sets the per-namespace
 // OrganizationDefaultTaxCodes. The operation is idempotent: pre-existing tax codes are
-// left unchanged and a complete org-defaults row causes an early return.
+// left unchanged and a pre-existing org-defaults row skips the org-defaults upsert (seed
+// creation always runs regardless).
 // All seed creates and the org-defaults upsert run inside a single transaction.
 func (h *NamespaceHandler) CreateNamespace(ctx context.Context, ns string) error {
 	return transaction.RunWithNoValue(ctx, h.transactionManager, func(ctx context.Context) error {
@@ -101,15 +111,15 @@ func (h *NamespaceHandler) CreateNamespace(ctx context.Context, ns string) error
 			}
 		}
 
-		// Idempotency check: if org defaults already exist and are complete, skip upsert.
-		existing, err := h.service.GetOrganizationDefaultTaxCodes(ctx, GetOrganizationDefaultTaxCodesInput{
+		// Idempotency check: if org defaults already exist, skip upsert.
+		_, err := h.service.GetOrganizationDefaultTaxCodes(ctx, GetOrganizationDefaultTaxCodesInput{
 			Namespace: ns,
 		})
 		if err != nil && !IsOrganizationDefaultTaxCodesNotFoundError(err) {
 			return fmt.Errorf("get organization default tax codes: %w", err)
 		}
 
-		if err == nil && existing.InvoicingTaxCodeID != "" && existing.CreditGrantTaxCodeID != "" {
+		if err == nil {
 			// Already provisioned — nothing to do.
 			return nil
 		}

--- a/openmeter/taxcode/namespacehandler.go
+++ b/openmeter/taxcode/namespacehandler.go
@@ -94,10 +94,20 @@ func NewNamespaceHandler(cfg NamespaceHandlerConfig) (*NamespaceHandler, error) 
 // All seed creates and the org-defaults upsert run inside a single transaction.
 func (h *NamespaceHandler) CreateNamespace(ctx context.Context, ns string) error {
 	return transaction.RunWithNoValue(ctx, h.transactionManager, func(ctx context.Context) error {
+		// List existing tax codes once; ensureTaxCode does map lookups against this set
+		// and only re-lists on a concurrent-create conflict.
+		listed, err := h.service.ListTaxCodes(ctx, ListTaxCodesInput{Namespace: ns})
+		if err != nil {
+			return fmt.Errorf("list tax codes: %w", err)
+		}
+		existingByKey := lo.SliceToMap(listed.Items, func(tc TaxCode) (string, TaxCode) {
+			return tc.Key, tc
+		})
+
 		var invoicingID, creditGrantID string
 
 		for _, seed := range h.seeds {
-			id, err := h.ensureTaxCode(ctx, ns, seed)
+			id, err := h.ensureTaxCode(ctx, ns, seed, existingByKey)
 			if err != nil {
 				return fmt.Errorf("seed tax code %q: %w", seed.Key, err)
 			}
@@ -112,7 +122,7 @@ func (h *NamespaceHandler) CreateNamespace(ctx context.Context, ns string) error
 		}
 
 		// Idempotency check: if org defaults already exist, skip upsert.
-		_, err := h.service.GetOrganizationDefaultTaxCodes(ctx, GetOrganizationDefaultTaxCodesInput{
+		_, err = h.service.GetOrganizationDefaultTaxCodes(ctx, GetOrganizationDefaultTaxCodesInput{
 			Namespace: ns,
 		})
 		if err != nil && !IsOrganizationDefaultTaxCodesNotFoundError(err) {
@@ -144,19 +154,10 @@ func (h *NamespaceHandler) DeleteNamespace(_ context.Context, _ string) error {
 
 // ensureTaxCode returns the ID of the tax code identified by seed.Key in namespace ns.
 // If it does not exist yet, it is created. Pre-existing codes are never mutated.
-func (h *NamespaceHandler) ensureTaxCode(ctx context.Context, ns string, seed SeedEntry) (string, error) {
-	// There is no GetTaxCodeByKey API, so we list all codes and filter in memory.
-	result, err := h.service.ListTaxCodes(ctx, ListTaxCodesInput{
-		Namespace: ns,
-	})
-	if err != nil {
-		return "", fmt.Errorf("list tax codes: %w", err)
-	}
-
-	existing, found := lo.Find(result.Items, func(tc TaxCode) bool {
-		return tc.Key == seed.Key
-	})
-	if found {
+// existingByKey is the pre-fetched index built by CreateNamespace; the conflict path
+// re-lists from the service to reconcile concurrent inserts that the index missed.
+func (h *NamespaceHandler) ensureTaxCode(ctx context.Context, ns string, seed SeedEntry, existingByKey map[string]TaxCode) (string, error) {
+	if existing, found := existingByKey[seed.Key]; found {
 		return existing.ID, nil
 	}
 

--- a/openmeter/taxcode/namespacehandler.go
+++ b/openmeter/taxcode/namespacehandler.go
@@ -1,0 +1,188 @@
+package taxcode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/namespace"
+	"github.com/openmeterio/openmeter/pkg/framework/transaction"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// SeedEntry defines a tax code that should be provisioned for every namespace.
+type SeedEntry struct {
+	Key                string
+	Name               string
+	Description        *string
+	AppMappings        TaxCodeAppMappings
+	DefaultInvoicing   bool
+	DefaultCreditGrant bool
+}
+
+// NamespaceHandlerConfig holds the dependencies for the taxcode namespace handler.
+type NamespaceHandlerConfig struct {
+	Logger             *slog.Logger
+	Service            Service
+	Seeds              []SeedEntry
+	TransactionManager transaction.Creator
+}
+
+func (c NamespaceHandlerConfig) validate() error {
+	var errs []error
+
+	if c.Logger == nil {
+		errs = append(errs, errors.New("logger is required"))
+	}
+
+	if c.Service == nil {
+		errs = append(errs, errors.New("service is required"))
+	}
+
+	if c.TransactionManager == nil {
+		errs = append(errs, errors.New("transaction manager is required"))
+	}
+
+	if len(c.Seeds) == 0 {
+		errs = append(errs, errors.New("at least one seed entry is required"))
+	}
+
+	return errors.Join(errs...)
+}
+
+// NamespaceHandler implements namespace.Handler for the taxcode domain.
+type NamespaceHandler struct {
+	logger             *slog.Logger
+	service            Service
+	seeds              []SeedEntry
+	transactionManager transaction.Creator
+}
+
+var _ namespace.Handler = (*NamespaceHandler)(nil)
+
+// NewNamespaceHandler creates a *NamespaceHandler that seeds tax codes and org
+// defaults when a new namespace is provisioned.
+func NewNamespaceHandler(cfg NamespaceHandlerConfig) (*NamespaceHandler, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, fmt.Errorf("invalid namespace handler config: %w", err)
+	}
+
+	return &NamespaceHandler{
+		logger:             cfg.Logger,
+		service:            cfg.Service,
+		seeds:              cfg.Seeds,
+		transactionManager: cfg.TransactionManager,
+	}, nil
+}
+
+// CreateNamespace provisions the configured seed tax codes and sets the per-namespace
+// OrganizationDefaultTaxCodes. The operation is idempotent: pre-existing tax codes are
+// left unchanged and a complete org-defaults row causes an early return.
+// All seed creates and the org-defaults upsert run inside a single transaction.
+func (h *NamespaceHandler) CreateNamespace(ctx context.Context, ns string) error {
+	return transaction.RunWithNoValue(ctx, h.transactionManager, func(ctx context.Context) error {
+		var invoicingID, creditGrantID string
+
+		for _, seed := range h.seeds {
+			id, err := h.ensureTaxCode(ctx, ns, seed)
+			if err != nil {
+				return fmt.Errorf("seed tax code %q: %w", seed.Key, err)
+			}
+
+			if seed.DefaultInvoicing {
+				invoicingID = id
+			}
+
+			if seed.DefaultCreditGrant {
+				creditGrantID = id
+			}
+		}
+
+		// Idempotency check: if org defaults already exist and are complete, skip upsert.
+		existing, err := h.service.GetOrganizationDefaultTaxCodes(ctx, GetOrganizationDefaultTaxCodesInput{
+			Namespace: ns,
+		})
+		if err != nil && !IsOrganizationDefaultTaxCodesNotFoundError(err) {
+			return fmt.Errorf("get organization default tax codes: %w", err)
+		}
+
+		if err == nil && existing.InvoicingTaxCodeID != "" && existing.CreditGrantTaxCodeID != "" {
+			// Already provisioned — nothing to do.
+			return nil
+		}
+
+		if _, err := h.service.UpsertOrganizationDefaultTaxCodes(ctx, UpsertOrganizationDefaultTaxCodesInput{
+			Namespace:            ns,
+			InvoicingTaxCodeID:   invoicingID,
+			CreditGrantTaxCodeID: creditGrantID,
+		}); err != nil {
+			return fmt.Errorf("upsert organization default tax codes: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// DeleteNamespace is a no-op; tax codes belong to the namespace and are cleaned up
+// by the database cascade or a dedicated purge job.
+func (h *NamespaceHandler) DeleteNamespace(_ context.Context, _ string) error {
+	return nil
+}
+
+// ensureTaxCode returns the ID of the tax code identified by seed.Key in namespace ns.
+// If it does not exist yet, it is created. Pre-existing codes are never mutated.
+func (h *NamespaceHandler) ensureTaxCode(ctx context.Context, ns string, seed SeedEntry) (string, error) {
+	// There is no GetTaxCodeByKey API, so we list all codes and filter in memory.
+	result, err := h.service.ListTaxCodes(ctx, ListTaxCodesInput{
+		Namespace: ns,
+	})
+	if err != nil {
+		return "", fmt.Errorf("list tax codes: %w", err)
+	}
+
+	existing, found := lo.Find(result.Items, func(tc TaxCode) bool {
+		return tc.Key == seed.Key
+	})
+	if found {
+		return existing.ID, nil
+	}
+
+	// Not found — create it.
+	created, createErr := h.service.CreateTaxCode(ctx, CreateTaxCodeInput{
+		Namespace:   ns,
+		Key:         seed.Key,
+		Name:        seed.Name,
+		Description: seed.Description,
+		AppMappings: seed.AppMappings,
+		Annotations: models.Annotations{
+			AnnotationKeyManagedBy: AnnotationValueManagedBySystem,
+		},
+	})
+	if createErr != nil {
+		// Another goroutine may have created it concurrently; re-fetch by listing.
+		if models.IsGenericConflictError(createErr) {
+			result2, listErr := h.service.ListTaxCodes(ctx, ListTaxCodesInput{
+				Namespace: ns,
+			})
+			if listErr != nil {
+				return "", fmt.Errorf("list tax codes after conflict: %w", listErr)
+			}
+
+			concurrent, ok := lo.Find(result2.Items, func(tc TaxCode) bool {
+				return tc.Key == seed.Key
+			})
+			if ok {
+				return concurrent.ID, nil
+			}
+
+			return "", fmt.Errorf("tax code with key %q: conflict reported by create but key not found after re-list: %w", seed.Key, createErr)
+		}
+
+		return "", fmt.Errorf("create tax code: %w", createErr)
+	}
+
+	return created.ID, nil
+}

--- a/openmeter/taxcode/namespacehandler_test.go
+++ b/openmeter/taxcode/namespacehandler_test.go
@@ -1,0 +1,269 @@
+package taxcode_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
+	taxcodetestutils "github.com/openmeterio/openmeter/openmeter/taxcode/testutils"
+	"github.com/openmeterio/openmeter/openmeter/testutils"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+)
+
+// makeTestSeeds returns two seed entries: "default" (invoicing) and "nontaxable"
+// (credit grant). Each test that needs different seeds can build its own, but
+// most tests share this helper.
+func makeTestSeeds() []taxcode.SeedEntry {
+	return []taxcode.SeedEntry{
+		{
+			Key:              "default",
+			Name:             "Default Tax",
+			DefaultInvoicing: true,
+		},
+		{
+			Key:                "nontaxable",
+			Name:               "Non-Taxable",
+			DefaultCreditGrant: true,
+		},
+	}
+}
+
+func TestNamespaceHandler(t *testing.T) {
+	env := taxcodetestutils.NewTestEnv(t)
+	t.Cleanup(func() { env.Close(t) })
+	env.DBSchemaMigrate(t)
+
+	makeHandler := func(t *testing.T, seeds []taxcode.SeedEntry) *taxcode.NamespaceHandler {
+		t.Helper()
+		h, err := taxcode.NewNamespaceHandler(taxcode.NamespaceHandlerConfig{
+			Logger:             env.Logger,
+			Service:            env.Service,
+			Seeds:              seeds,
+			TransactionManager: env.Adapter,
+		})
+		require.NoError(t, err)
+		return h
+	}
+
+	t.Run("FreshNamespace", func(t *testing.T) {
+		ns := testutils.NameGenerator.Generate().Key
+		h := makeHandler(t, makeTestSeeds())
+
+		err := h.CreateNamespace(t.Context(), ns)
+		require.NoError(t, err)
+
+		// Both tax codes must exist.
+		result, err := env.Service.ListTaxCodes(t.Context(), taxcode.ListTaxCodesInput{
+			Namespace: ns,
+			Page:      pagination.Page{PageSize: 100, PageNumber: 1},
+		})
+		require.NoError(t, err)
+		require.Len(t, result.Items, 2)
+
+		keyToTC := make(map[string]taxcode.TaxCode, 2)
+		for _, tc := range result.Items {
+			keyToTC[tc.Key] = tc
+		}
+
+		defaultTC, ok := keyToTC["default"]
+		require.True(t, ok, "default tax code must exist")
+		assert.True(t, defaultTC.IsManagedBySystem(), "default tax code must be managed by system")
+
+		nontaxableTC, ok := keyToTC["nontaxable"]
+		require.True(t, ok, "nontaxable tax code must exist")
+		assert.True(t, nontaxableTC.IsManagedBySystem(), "nontaxable tax code must be managed by system")
+
+		// Org defaults must reference both.
+		defaults, err := env.Service.GetOrganizationDefaultTaxCodes(t.Context(), taxcode.GetOrganizationDefaultTaxCodesInput{
+			Namespace: ns,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, defaultTC.ID, defaults.InvoicingTaxCodeID)
+		assert.Equal(t, nontaxableTC.ID, defaults.CreditGrantTaxCodeID)
+	})
+
+	t.Run("PreExistingTaxCode", func(t *testing.T) {
+		ns := testutils.NameGenerator.Generate().Key
+
+		// Pre-seed a "default" tax code with a different name and no annotations.
+		preExisting, err := env.Service.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+			Namespace: ns,
+			Key:       "default",
+			Name:      "Pre-Existing Default",
+		})
+		require.NoError(t, err)
+		assert.False(t, preExisting.IsManagedBySystem())
+
+		h := makeHandler(t, makeTestSeeds())
+		err = h.CreateNamespace(t.Context(), ns)
+		require.NoError(t, err)
+
+		// The pre-existing "default" must be untouched (same ID, same name).
+		result, err := env.Service.ListTaxCodes(t.Context(), taxcode.ListTaxCodesInput{
+			Namespace: ns,
+			Page:      pagination.Page{PageSize: 100, PageNumber: 1},
+		})
+		require.NoError(t, err)
+		require.Len(t, result.Items, 2)
+
+		keyToTC := make(map[string]taxcode.TaxCode, 2)
+		for _, tc := range result.Items {
+			keyToTC[tc.Key] = tc
+		}
+
+		gotDefault, ok := keyToTC["default"]
+		require.True(t, ok)
+		assert.Equal(t, preExisting.ID, gotDefault.ID, "pre-existing ID must not change")
+		assert.Equal(t, "Pre-Existing Default", gotDefault.Name, "pre-existing name must not change")
+		// Note: not managed by system because we didn't add annotation when pre-creating.
+		assert.False(t, gotDefault.IsManagedBySystem())
+
+		gotNontaxable, ok := keyToTC["nontaxable"]
+		require.True(t, ok, "nontaxable must be freshly created")
+		assert.True(t, gotNontaxable.IsManagedBySystem())
+
+		// Org defaults must point at the pre-existing default and the new nontaxable.
+		defaults, err := env.Service.GetOrganizationDefaultTaxCodes(t.Context(), taxcode.GetOrganizationDefaultTaxCodesInput{
+			Namespace: ns,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, preExisting.ID, defaults.InvoicingTaxCodeID)
+		assert.Equal(t, gotNontaxable.ID, defaults.CreditGrantTaxCodeID)
+	})
+
+	t.Run("PreExistingOrgDefaults", func(t *testing.T) {
+		ns := testutils.NameGenerator.Generate().Key
+
+		// Pre-seed both tax codes and a complete org defaults row.
+		defaultTC, err := env.Service.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+			Namespace: ns,
+			Key:       "default",
+			Name:      "Default Tax",
+			Annotations: models.Annotations{
+				taxcode.AnnotationKeyManagedBy: taxcode.AnnotationValueManagedBySystem,
+			},
+		})
+		require.NoError(t, err)
+
+		nontaxableTC, err := env.Service.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+			Namespace: ns,
+			Key:       "nontaxable",
+			Name:      "Non-Taxable",
+			Annotations: models.Annotations{
+				taxcode.AnnotationKeyManagedBy: taxcode.AnnotationValueManagedBySystem,
+			},
+		})
+		require.NoError(t, err)
+
+		preDefaults, err := env.Service.UpsertOrganizationDefaultTaxCodes(t.Context(), taxcode.UpsertOrganizationDefaultTaxCodesInput{
+			Namespace:            ns,
+			InvoicingTaxCodeID:   defaultTC.ID,
+			CreditGrantTaxCodeID: nontaxableTC.ID,
+		})
+		require.NoError(t, err)
+
+		h := makeHandler(t, makeTestSeeds())
+		err = h.CreateNamespace(t.Context(), ns)
+		require.NoError(t, err)
+
+		// Org defaults must be unchanged.
+		afterDefaults, err := env.Service.GetOrganizationDefaultTaxCodes(t.Context(), taxcode.GetOrganizationDefaultTaxCodesInput{
+			Namespace: ns,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, preDefaults.ID, afterDefaults.ID, "org defaults row ID must not change")
+		assert.Equal(t, preDefaults.InvoicingTaxCodeID, afterDefaults.InvoicingTaxCodeID)
+		assert.Equal(t, preDefaults.CreditGrantTaxCodeID, afterDefaults.CreditGrantTaxCodeID)
+	})
+
+	t.Run("Idempotency", func(t *testing.T) {
+		ns := testutils.NameGenerator.Generate().Key
+		h := makeHandler(t, makeTestSeeds())
+
+		// First call.
+		err := h.CreateNamespace(t.Context(), ns)
+		require.NoError(t, err)
+
+		firstDefaults, err := env.Service.GetOrganizationDefaultTaxCodes(t.Context(), taxcode.GetOrganizationDefaultTaxCodesInput{
+			Namespace: ns,
+		})
+		require.NoError(t, err)
+
+		// Second call must be a no-op.
+		err = h.CreateNamespace(t.Context(), ns)
+		require.NoError(t, err)
+
+		secondDefaults, err := env.Service.GetOrganizationDefaultTaxCodes(t.Context(), taxcode.GetOrganizationDefaultTaxCodesInput{
+			Namespace: ns,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, firstDefaults.ID, secondDefaults.ID)
+		assert.Equal(t, firstDefaults.InvoicingTaxCodeID, secondDefaults.InvoicingTaxCodeID)
+		assert.Equal(t, firstDefaults.CreditGrantTaxCodeID, secondDefaults.CreditGrantTaxCodeID)
+		assert.Equal(t, firstDefaults.CreatedAt, secondDefaults.CreatedAt, "created_at must not move on second call")
+
+		// Only 2 tax codes must exist.
+		result, err := env.Service.ListTaxCodes(t.Context(), taxcode.ListTaxCodesInput{
+			Namespace: ns,
+			Page:      pagination.Page{PageSize: 100, PageNumber: 1},
+		})
+		require.NoError(t, err)
+		assert.Len(t, result.Items, 2)
+	})
+}
+
+func TestNewNamespaceHandler_Validation(t *testing.T) {
+	env := taxcodetestutils.NewTestEnv(t)
+	t.Cleanup(func() { env.Close(t) })
+
+	validSeeds := makeTestSeeds()
+
+	t.Run("MissingLogger", func(t *testing.T) {
+		_, err := taxcode.NewNamespaceHandler(taxcode.NamespaceHandlerConfig{
+			Service: env.Service,
+			Seeds:   validSeeds,
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("MissingService", func(t *testing.T) {
+		_, err := taxcode.NewNamespaceHandler(taxcode.NamespaceHandlerConfig{
+			Logger: env.Logger,
+			Seeds:  validSeeds,
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("EmptySeeds", func(t *testing.T) {
+		_, err := taxcode.NewNamespaceHandler(taxcode.NamespaceHandlerConfig{
+			Logger:  env.Logger,
+			Service: env.Service,
+			Seeds:   nil,
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("MissingTransactionManager", func(t *testing.T) {
+		_, err := taxcode.NewNamespaceHandler(taxcode.NamespaceHandlerConfig{
+			Logger:  env.Logger,
+			Service: env.Service,
+			Seeds:   validSeeds,
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("ValidConfig", func(t *testing.T) {
+		h, err := taxcode.NewNamespaceHandler(taxcode.NamespaceHandlerConfig{
+			Logger:             env.Logger,
+			Service:            env.Service,
+			Seeds:              validSeeds,
+			TransactionManager: env.Adapter,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, h)
+	})
+}

--- a/openmeter/taxcode/service.go
+++ b/openmeter/taxcode/service.go
@@ -131,6 +131,10 @@ func (i ListTaxCodesInput) Validate() error {
 
 type GetTaxCodeInput struct {
 	models.NamespacedID
+
+	// IncludeDeleted controls whether soft-deleted records are returned.
+	// Only for internal service-to-service use; never set from API handlers.
+	IncludeDeleted bool
 }
 
 func (i GetTaxCodeInput) Validate() error {

--- a/openmeter/taxcode/testutils/env.go
+++ b/openmeter/taxcode/testutils/env.go
@@ -17,6 +17,7 @@ import (
 type TestEnv struct {
 	Logger  *slog.Logger
 	Service taxcode.Service
+	Adapter taxcode.Repository
 	Client  *entdb.Client
 	db      *testutils.TestDB
 	close   sync.Once
@@ -80,6 +81,7 @@ func NewTestEnv(t *testing.T) *TestEnv {
 	})
 	require.NoErrorf(t, err, "initializing taxcode service must not fail")
 
+	env.Adapter = adapter
 	env.Service = svc
 
 	return env


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic, idempotent tax-code provisioning for new namespaces and org-defaults
  * Configurable organization default tax codes for invoicing and credit grants
  * Per-application tax code mappings (e.g., Stripe)
* **Configuration**
  * New taxcode config section with seeds, defaults, app mappings, examples and validation
* **Bug Fixes**
  * Exclude soft-deleted tax codes from normal lookups
* **Tests**
  * Unit tests for tax-code seeding, namespace handling, and config validation
* **Chores**
  * Server wiring and registration of the TaxCode namespace handler

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->