### PR TITLE
feat(charges): apply namespace default tax codes on charge create

### DIFF
--- a/app/common/billing.go
+++ b/app/common/billing.go
@@ -187,6 +187,7 @@ func NewBillingRegistry(
 			accountResolver,
 			accountService,
 			breakageService,
+			taxCodeService,
 			fsConfig.NamespaceLockdown,
 		)
 		if err != nil {

--- a/app/common/charges.go
+++ b/app/common/charges.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
@@ -330,6 +331,7 @@ func NewChargesService(
 	usageBasedSvc usagebased.Service,
 	billingService billing.Service,
 	recognizerService recognizer.Service,
+	taxCodeService taxcode.Service,
 	fsNamespaceLockdown []string,
 ) (charges.Service, error) {
 	chargesSvc, err := chargesservice.New(chargesservice.Config{
@@ -342,6 +344,7 @@ func NewChargesService(
 		UsageBasedService:     usageBasedSvc,
 		BillingService:        billingService,
 		RecognizerService:     recognizerService,
+		TaxCodeService:        taxCodeService,
 		FSNamespaceLockdown:   fsNamespaceLockdown,
 	})
 	if err != nil {
@@ -386,6 +389,7 @@ func newChargesRegistry(
 	accountResolver ledger.AccountResolver,
 	accountService ledgeraccount.Service,
 	breakageService ledgerbreakage.Service,
+	taxCodeService taxcode.Service,
 	fsNamespaceLockdown []string,
 ) (*ChargesRegistry, error) {
 	metaAdapter, err := NewChargesMetaAdapter(db, logger)
@@ -512,6 +516,7 @@ func newChargesRegistry(
 		usageBasedSvc,
 		billingService,
 		recognizerService,
+		taxCodeService,
 		fsNamespaceLockdown,
 	)
 	if err != nil {

--- a/openmeter/billing/charges/charge.go
+++ b/openmeter/billing/charges/charge.go
@@ -385,6 +385,86 @@ func (c ChargeIntent) GetUniqueReferenceID() (*string, error) {
 	return nil, fmt.Errorf("invalid charge type: %s", c.t)
 }
 
+// Meta returns the shared meta.Intent embedded in every charge type.
+func (i ChargeIntent) Meta() (meta.Intent, error) {
+	switch i.t {
+	case meta.ChargeTypeFlatFee:
+		if i.flatFee == nil {
+			return meta.Intent{}, fmt.Errorf("flat fee is nil")
+		}
+
+		return i.flatFee.Intent, nil
+	case meta.ChargeTypeCreditPurchase:
+		if i.creditPurchase == nil {
+			return meta.Intent{}, fmt.Errorf("credit purchase is nil")
+		}
+
+		return i.creditPurchase.Intent, nil
+	case meta.ChargeTypeUsageBased:
+		if i.usageBased == nil {
+			return meta.Intent{}, fmt.Errorf("usage based is nil")
+		}
+
+		return i.usageBased.Intent, nil
+	}
+
+	return meta.Intent{}, fmt.Errorf("invalid charge type: %s", i.t)
+}
+
+// WithTaxCodeID returns a copy of the intent with TaxCodeID set to id.
+// If TaxConfig is nil a new one is created; all other fields are preserved.
+func (i ChargeIntent) WithTaxCodeID(id string) (ChargeIntent, error) {
+	switch i.t {
+	case meta.ChargeTypeFlatFee:
+		ff, err := i.AsFlatFeeIntent()
+		if err != nil {
+			return ChargeIntent{}, err
+		}
+
+		if ff.Intent.TaxConfig == nil {
+			ff.Intent.TaxConfig = &productcatalog.TaxCodeConfig{TaxCodeID: &id}
+		} else {
+			cfg := *ff.Intent.TaxConfig
+			cfg.TaxCodeID = &id
+			ff.Intent.TaxConfig = &cfg
+		}
+
+		return NewChargeIntent(ff), nil
+	case meta.ChargeTypeUsageBased:
+		ub, err := i.AsUsageBasedIntent()
+		if err != nil {
+			return ChargeIntent{}, err
+		}
+
+		if ub.Intent.TaxConfig == nil {
+			ub.Intent.TaxConfig = &productcatalog.TaxCodeConfig{TaxCodeID: &id}
+		} else {
+			cfg := *ub.Intent.TaxConfig
+			cfg.TaxCodeID = &id
+			ub.Intent.TaxConfig = &cfg
+		}
+
+		return NewChargeIntent(ub), nil
+	case meta.ChargeTypeCreditPurchase:
+		cp, err := i.AsCreditPurchaseIntent()
+		if err != nil {
+			return ChargeIntent{}, err
+		}
+
+		if cp.Intent.TaxConfig == nil {
+			cp.Intent.TaxConfig = &productcatalog.TaxCodeConfig{TaxCodeID: &id}
+		} else {
+			cfg := *cp.Intent.TaxConfig
+			cfg.TaxCodeID = &id
+			cp.Intent.TaxConfig = &cfg
+		}
+
+		return NewChargeIntent(cp), nil
+	}
+
+	return ChargeIntent{}, fmt.Errorf("unsupported charge type: %s", i.t)
+}
+
 type ChargeIntents []ChargeIntent
 
 func (i ChargeIntents) Validate() error {

--- a/openmeter/billing/charges/service/advance_test.go
+++ b/openmeter/billing/charges/service/advance_test.go
@@ -36,6 +36,7 @@ func (s *AdvanceChargesTestSuite) TearDownTest() {
 func (s *AdvanceChargesTestSuite) TestAdvanceChargesReturnsEmptyForAlreadyActiveCreditCharges() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-advance-usage-only")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -123,6 +124,7 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesReturnsEmptyForAlreadyActive
 func (s *AdvanceChargesTestSuite) TestAdvanceChargesActivatesCreditThenInvoiceFlatFeeAtServicePeriodStart() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-advance-empty")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -173,6 +175,7 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesActivatesCreditThenInvoiceFl
 func (s *AdvanceChargesTestSuite) TestAdvanceChargesActivatesCreditThenInvoiceUsageBasedChargesAtServicePeriodStart() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-advance-credit-then-invoice")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)

--- a/openmeter/billing/charges/service/base_test.go
+++ b/openmeter/billing/charges/service/base_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/ledger/recognizer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
@@ -162,9 +163,41 @@ func (s *BaseSuite) SetupSuite() {
 		RecognizerService:     recognizer.NoopService{},
 
 		BillingService: s.BillingService,
+		TaxCodeService: s.TaxCodeService,
 	})
 	s.NoError(err)
 	s.Charges = chargesService
+}
+
+// ProvisionDefaultTaxCodes creates two tax codes in the namespace (one for invoicing,
+// one for credit grants) and stores them as the namespace's OrganizationDefaultTaxCodes.
+// Every test that creates charges via s.Charges.Create must call this after
+// GetUniqueNamespace because charge creation now requires the namespace to have
+// default tax codes provisioned. Returns the upsert result for tests that need the IDs.
+func (s *BaseSuite) ProvisionDefaultTaxCodes(ctx context.Context, ns string) taxcode.OrganizationDefaultTaxCodes {
+	s.T().Helper()
+
+	invoicing, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "default-invoicing",
+		Name:      "Default Invoicing",
+	})
+	s.Require().NoError(err, "creating default invoicing tax code")
+
+	creditGrant, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "default-credit-grant",
+		Name:      "Default Credit Grant",
+	})
+	s.Require().NoError(err, "creating default credit grant tax code")
+
+	defaults, err := s.TaxCodeService.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
+		Namespace:            ns,
+		InvoicingTaxCodeID:   invoicing.ID,
+		CreditGrantTaxCodeID: creditGrant.ID,
+	})
+	s.Require().NoError(err, "upserting organization default tax codes")
+	return defaults
 }
 
 func (s *BaseSuite) TearDownTest() {

--- a/openmeter/billing/charges/service/base_test.go
+++ b/openmeter/billing/charges/service/base_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/ledger/recognizer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
@@ -167,37 +166,6 @@ func (s *BaseSuite) SetupSuite() {
 	})
 	s.NoError(err)
 	s.Charges = chargesService
-}
-
-// ProvisionDefaultTaxCodes creates two tax codes in the namespace (one for invoicing,
-// one for credit grants) and stores them as the namespace's OrganizationDefaultTaxCodes.
-// Every test that creates charges via s.Charges.Create must call this after
-// GetUniqueNamespace because charge creation now requires the namespace to have
-// default tax codes provisioned. Returns the upsert result for tests that need the IDs.
-func (s *BaseSuite) ProvisionDefaultTaxCodes(ctx context.Context, ns string) taxcode.OrganizationDefaultTaxCodes {
-	s.T().Helper()
-
-	invoicing, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: ns,
-		Key:       "default-invoicing",
-		Name:      "Default Invoicing",
-	})
-	s.Require().NoError(err, "creating default invoicing tax code")
-
-	creditGrant, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: ns,
-		Key:       "default-credit-grant",
-		Name:      "Default Credit Grant",
-	})
-	s.Require().NoError(err, "creating default credit grant tax code")
-
-	defaults, err := s.TaxCodeService.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
-		Namespace:            ns,
-		InvoicingTaxCodeID:   invoicing.ID,
-		CreditGrantTaxCodeID: creditGrant.ID,
-	})
-	s.Require().NoError(err, "upserting organization default tax codes")
-	return defaults
 }
 
 func (s *BaseSuite) TearDownTest() {

--- a/openmeter/billing/charges/service/create.go
+++ b/openmeter/billing/charges/service/create.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/samber/lo"
@@ -28,103 +29,24 @@ type chargesWithInvoiceNowActions struct {
 	collectionAlignmentBypassedLines []invoicePendingLinesInput
 }
 
-func chargeIntentMeta(intent charges.ChargeIntent) (meta.Intent, error) {
-	switch intent.Type() {
-	case meta.ChargeTypeFlatFee:
-		ff, err := intent.AsFlatFeeIntent()
-
-		return ff.Intent, err
-	case meta.ChargeTypeUsageBased:
-		ub, err := intent.AsUsageBasedIntent()
-
-		return ub.Intent, err
-	case meta.ChargeTypeCreditPurchase:
-		cp, err := intent.AsCreditPurchaseIntent()
-
-		return cp.Intent, err
-	}
-
-	return meta.Intent{}, fmt.Errorf("unsupported charge type: %s", intent.Type())
-}
-
-func needsDefaultTaxCode(i meta.Intent) bool {
-	return i.TaxConfig == nil || i.TaxConfig.TaxCodeID == nil
-}
-
-func stampTaxCodeID(cfg *productcatalog.TaxCodeConfig, id string) *productcatalog.TaxCodeConfig {
-	if cfg == nil {
-		return &productcatalog.TaxCodeConfig{TaxCodeID: &id}
-	}
-
-	cfg.TaxCodeID = &id
-
-	return cfg
-}
-
-// defaultTaxCodeIDFor picks which namespace default applies to the given charge type.
-// Credit purchases use the credit-grant default; invoicing charges (flat-fee, usage-based) use the invoicing default.
-func defaultTaxCodeIDFor(t meta.ChargeType, defaults taxcode.OrganizationDefaultTaxCodes) string {
-	if t == meta.ChargeTypeCreditPurchase {
-		return defaults.CreditGrantTaxCodeID
-	}
-
-	return defaults.InvoicingTaxCodeID
-}
-
-func rebuildChargeIntentWithTaxCodeID(intent charges.ChargeIntent, defaultID string) (charges.ChargeIntent, error) {
-	switch intent.Type() {
-	case meta.ChargeTypeFlatFee:
-		ff, err := intent.AsFlatFeeIntent()
-		if err != nil {
-			return charges.ChargeIntent{}, err
-		}
-
-		ff.Intent.TaxConfig = stampTaxCodeID(ff.Intent.TaxConfig, defaultID)
-
-		return charges.NewChargeIntent(ff), nil
-	case meta.ChargeTypeUsageBased:
-		ub, err := intent.AsUsageBasedIntent()
-		if err != nil {
-			return charges.ChargeIntent{}, err
-		}
-
-		ub.Intent.TaxConfig = stampTaxCodeID(ub.Intent.TaxConfig, defaultID)
-
-		return charges.NewChargeIntent(ub), nil
-
-	case meta.ChargeTypeCreditPurchase:
-		cp, err := intent.AsCreditPurchaseIntent()
-		if err != nil {
-			return charges.ChargeIntent{}, err
-		}
-
-		cp.Intent.TaxConfig = stampTaxCodeID(cp.Intent.TaxConfig, defaultID)
-
-		return charges.NewChargeIntent(cp), nil
-	}
-
-	return charges.ChargeIntent{}, fmt.Errorf("unsupported charge type: %s", intent.Type())
-}
-
 // applyDefaultTaxCodes fills in nil TaxCodeID on each intent's TaxConfig using the namespace's
 // organization default tax codes. Invoicing default applies to flat-fee and usage-based charges;
 // credit-grant default applies to credit purchase charges. Fails if any intent needs the fallback
 // but the namespace has no defaults provisioned.
 func (s *service) applyDefaultTaxCodes(ctx context.Context, namespace string, intents charges.ChargeIntents) (charges.ChargeIntents, error) {
-	needsDefault := false
-	for _, intent := range intents {
-		m, err := chargeIntentMeta(intent)
+	var needsDefaultIdx []int
+	for i, intent := range intents {
+		m, err := intent.Meta()
 		if err != nil {
 			return nil, err
 		}
 
-		if needsDefaultTaxCode(m) {
-			needsDefault = true
-			break
+		if m.TaxConfig == nil || m.TaxConfig.TaxCodeID == nil {
+			needsDefaultIdx = append(needsDefaultIdx, i)
 		}
 	}
 
-	if !needsDefault {
+	if len(needsDefaultIdx) == 0 {
 		return intents, nil
 	}
 
@@ -135,24 +57,22 @@ func (s *service) applyDefaultTaxCodes(ctx context.Context, namespace string, in
 		return nil, fmt.Errorf("resolving default tax codes for namespace %s: %w", namespace, err)
 	}
 
-	out := make(charges.ChargeIntents, len(intents))
-	for i, intent := range intents {
-		m, err := chargeIntentMeta(intent)
+	out := slices.Clone(intents)
+	for _, idx := range needsDefaultIdx {
+		// credit purchases use the credit-grant default; flat-fee and usage-based use the invoicing default
+		defaultID := defaults.InvoicingTaxCodeID
+		if intents[idx].Type() == meta.ChargeTypeCreditPurchase {
+			defaultID = defaults.CreditGrantTaxCodeID
+		}
+
+		rebuilt, err := intents[idx].WithTaxCodeID(defaultID)
 		if err != nil {
 			return nil, err
 		}
 
-		if !needsDefaultTaxCode(m) {
-			out[i] = intent
-			continue
-		}
-
-		rebuilt, err := rebuildChargeIntentWithTaxCodeID(intent, defaultTaxCodeIDFor(intent.Type(), defaults))
-		if err != nil {
-			return nil, err
-		}
-		out[i] = rebuilt
+		out[idx] = rebuilt
 	}
+
 	return out, nil
 }
 

--- a/openmeter/billing/charges/service/create.go
+++ b/openmeter/billing/charges/service/create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
@@ -27,6 +28,134 @@ type chargesWithInvoiceNowActions struct {
 	collectionAlignmentBypassedLines []invoicePendingLinesInput
 }
 
+func chargeIntentMeta(intent charges.ChargeIntent) (meta.Intent, error) {
+	switch intent.Type() {
+	case meta.ChargeTypeFlatFee:
+		ff, err := intent.AsFlatFeeIntent()
+
+		return ff.Intent, err
+	case meta.ChargeTypeUsageBased:
+		ub, err := intent.AsUsageBasedIntent()
+
+		return ub.Intent, err
+	case meta.ChargeTypeCreditPurchase:
+		cp, err := intent.AsCreditPurchaseIntent()
+
+		return cp.Intent, err
+	}
+
+	return meta.Intent{}, fmt.Errorf("unsupported charge type: %s", intent.Type())
+}
+
+func needsDefaultTaxCode(i meta.Intent) bool {
+	return i.TaxConfig == nil || i.TaxConfig.TaxCodeID == nil
+}
+
+func stampTaxCodeID(cfg *productcatalog.TaxCodeConfig, id string) *productcatalog.TaxCodeConfig {
+	if cfg == nil {
+		return &productcatalog.TaxCodeConfig{TaxCodeID: &id}
+	}
+
+	cfg.TaxCodeID = &id
+
+	return cfg
+}
+
+// defaultTaxCodeIDFor picks which namespace default applies to the given charge type.
+// Credit purchases use the credit-grant default; invoicing charges (flat-fee, usage-based) use the invoicing default.
+func defaultTaxCodeIDFor(t meta.ChargeType, defaults taxcode.OrganizationDefaultTaxCodes) string {
+	if t == meta.ChargeTypeCreditPurchase {
+		return defaults.CreditGrantTaxCodeID
+	}
+
+	return defaults.InvoicingTaxCodeID
+}
+
+func rebuildChargeIntentWithTaxCodeID(intent charges.ChargeIntent, defaultID string) (charges.ChargeIntent, error) {
+	switch intent.Type() {
+	case meta.ChargeTypeFlatFee:
+		ff, err := intent.AsFlatFeeIntent()
+		if err != nil {
+			return charges.ChargeIntent{}, err
+		}
+
+		ff.Intent.TaxConfig = stampTaxCodeID(ff.Intent.TaxConfig, defaultID)
+
+		return charges.NewChargeIntent(ff), nil
+	case meta.ChargeTypeUsageBased:
+		ub, err := intent.AsUsageBasedIntent()
+		if err != nil {
+			return charges.ChargeIntent{}, err
+		}
+
+		ub.Intent.TaxConfig = stampTaxCodeID(ub.Intent.TaxConfig, defaultID)
+
+		return charges.NewChargeIntent(ub), nil
+
+	case meta.ChargeTypeCreditPurchase:
+		cp, err := intent.AsCreditPurchaseIntent()
+		if err != nil {
+			return charges.ChargeIntent{}, err
+		}
+
+		cp.Intent.TaxConfig = stampTaxCodeID(cp.Intent.TaxConfig, defaultID)
+
+		return charges.NewChargeIntent(cp), nil
+	}
+
+	return charges.ChargeIntent{}, fmt.Errorf("unsupported charge type: %s", intent.Type())
+}
+
+// applyDefaultTaxCodes fills in nil TaxCodeID on each intent's TaxConfig using the namespace's
+// organization default tax codes. Invoicing default applies to flat-fee and usage-based charges;
+// credit-grant default applies to credit purchase charges. Fails if any intent needs the fallback
+// but the namespace has no defaults provisioned.
+func (s *service) applyDefaultTaxCodes(ctx context.Context, namespace string, intents charges.ChargeIntents) (charges.ChargeIntents, error) {
+	needsDefault := false
+	for _, intent := range intents {
+		m, err := chargeIntentMeta(intent)
+		if err != nil {
+			return nil, err
+		}
+
+		if needsDefaultTaxCode(m) {
+			needsDefault = true
+			break
+		}
+	}
+
+	if !needsDefault {
+		return intents, nil
+	}
+
+	defaults, err := s.taxCodeService.GetOrganizationDefaultTaxCodes(ctx, taxcode.GetOrganizationDefaultTaxCodesInput{
+		Namespace: namespace,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("resolving default tax codes for namespace %s: %w", namespace, err)
+	}
+
+	out := make(charges.ChargeIntents, len(intents))
+	for i, intent := range intents {
+		m, err := chargeIntentMeta(intent)
+		if err != nil {
+			return nil, err
+		}
+
+		if !needsDefaultTaxCode(m) {
+			out[i] = intent
+			continue
+		}
+
+		rebuilt, err := rebuildChargeIntentWithTaxCodeID(intent, defaultTaxCodeIDFor(intent.Type(), defaults))
+		if err != nil {
+			return nil, err
+		}
+		out[i] = rebuilt
+	}
+	return out, nil
+}
+
 func (s *service) Create(ctx context.Context, input charges.CreateInput) (charges.Charges, error) {
 	if err := input.Validate(); err != nil {
 		return nil, err
@@ -35,6 +164,12 @@ func (s *service) Create(ctx context.Context, input charges.CreateInput) (charge
 	if err := s.validateNamespaceLockdown(input.Namespace); err != nil {
 		return nil, err
 	}
+
+	intentsWithDefaults, err := s.applyDefaultTaxCodes(ctx, input.Namespace, input.Intents)
+	if err != nil {
+		return nil, err
+	}
+	input.Intents = intentsWithDefaults
 
 	result, err := transaction.Run(ctx, s.adapter, func(ctx context.Context) (*chargesWithInvoiceNowActions, error) {
 		intentsByType, err := input.Intents.ByType()

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -47,6 +47,7 @@ func (s *CreditPurchaseTestSuite) TearDownTest() {
 func (s *CreditPurchaseTestSuite) TestPromotionalCreditPurchase() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-promotional-credit-purchase")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -98,6 +99,7 @@ func (s *CreditPurchaseTestSuite) TestPromotionalCreditPurchase() {
 func (s *CreditPurchaseTestSuite) TestCreditPurchaseRejectsMismatchedSettlementCurrency() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-credit-purchase-mismatched-settlement-currency")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -207,6 +209,7 @@ func CreateCreditPurchaseIntent(t *testing.T, input createCreditPurchaseIntentIn
 func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettled() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-external-authorized-credit-purchase-auto-settled")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -309,6 +312,7 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySettled() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-external-authorized-credit-purchase-manually-settled")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -428,6 +432,7 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchase() {
 	defer clock.UnFreeze()
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-standard-invoice-credit-purchase")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -665,6 +670,7 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchaseDeferred() {
 	// The gathering line is created but not immediately invoiced.
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-standard-invoice-credit-purchase-deferred")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	clock.FreezeTime(datetime.MustParseTimeInLocation(s.T(), "2025-12-01T00:00:00Z", time.UTC).AsTime())
 	defer clock.ResetTime()

--- a/openmeter/billing/charges/service/featureid_test.go
+++ b/openmeter/billing/charges/service/featureid_test.go
@@ -46,6 +46,7 @@ func (s *ChargeFeatureIDTestSuite) TearDownTest() {
 func (s *ChargeFeatureIDTestSuite) TestCreateResolvesFeatureIDsForUsageBasedAndFlatFeeCharges() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-feature-id-create")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "feature-id-create")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -122,6 +123,7 @@ func (s *ChargeFeatureIDTestSuite) TestCreateResolvesFeatureIDsForUsageBasedAndF
 func (s *ChargeFeatureIDTestSuite) TestUsageBasedActivationRecalculatesFeatureIDAndRunsKeepUsingIt() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-feature-id-usage")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "feature-id-usage")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -70,6 +70,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceImmutableProrat
 func runFlatFeeCreditThenInvoiceImmutableProrationScenario(s *BaseSuite, expectReplacementGatheringLine bool) {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-immutable-proration")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateTestCustomer(ns, "test-subject")
@@ -219,6 +220,7 @@ func runFlatFeeCreditThenInvoiceImmutableProrationScenario(s *BaseSuite, expectR
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountCreatesNoGatheringLine() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-zero-amount")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateTestCustomer(ns, "test-subject")
@@ -269,6 +271,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountCreat
 func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-partial-credit-realizations")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -542,6 +545,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceInAdvanceWithPromotionalCredits() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-in-advance-promotional")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -692,6 +696,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceInAdvanceWithPr
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDoesNotAccrueInvoiceUsage() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-fully-credited")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -816,6 +821,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountNonZeroChargesAccruesInvoiceUsage() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-zero-amount-charges")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -946,6 +952,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountNonZe
 func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycle() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-only-lifecycle")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -1274,6 +1281,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTier
 
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-only-lifecycle-volume-tiered-correction")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -1539,6 +1547,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTier
 func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-then-invoice")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -1836,6 +1845,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() 
 func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCreditedDoesNotAccrueInvoiceUsage() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-then-invoice-fully-credited")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2025,6 +2035,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCredite
 func (s *InvoicableChargesTestSuite) TestUsageBasedCreateImmediatelyActive() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-create-immediately-active")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2102,6 +2113,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceDirectPaidFl
 
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-then-invoice-direct-paid")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2241,6 +2253,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreateImmediatelyFinal() {
 
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-create-immediately-final")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2352,6 +2365,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreateImmediatelyFinal() {
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-only-lifecycle")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2516,6 +2530,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyCreateImmediatelyFinal
 
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-only-create-immediately-final")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2597,6 +2612,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyInArrearsActivatesAtSe
 
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-only-in-arrears")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 

--- a/openmeter/billing/charges/service/lineage_test.go
+++ b/openmeter/billing/charges/service/lineage_test.go
@@ -58,6 +58,7 @@ func (s *CreditRealizationLineageTestSuite) TestFlatFeeCreditOnlyAllocationCreat
 
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-realization-lineage")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -137,6 +138,7 @@ func (s *CreditRealizationLineageTestSuite) TestUsageBasedCreditOnlyAllocationCr
 
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-usagebased-credit-realization-lineage")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)

--- a/openmeter/billing/charges/service/service.go
+++ b/openmeter/billing/charges/service/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/ledger/recognizer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 )
 
 type service struct {
@@ -29,6 +30,7 @@ type service struct {
 	creditPurchaseService creditpurchase.Service
 	usageBasedService     usagebased.Service
 	recognizerService     recognizer.Service
+	taxCodeService        taxcode.Service
 
 	fsNamespaceLockdown []string
 }
@@ -46,6 +48,8 @@ type Config struct {
 	RecognizerService     recognizer.Service
 
 	BillingService billing.Service
+
+	TaxCodeService taxcode.Service
 
 	FSNamespaceLockdown []string
 }
@@ -89,6 +93,10 @@ func (c Config) Validate() error {
 		errs = append(errs, errors.New("recognizer service cannot be null"))
 	}
 
+	if c.TaxCodeService == nil {
+		errs = append(errs, errors.New("tax code service cannot be null"))
+	}
+
 	return errors.Join(errs...)
 }
 
@@ -107,6 +115,7 @@ func New(config Config) (*service, error) {
 		creditPurchaseService: config.CreditPurchaseService,
 		usageBasedService:     config.UsageBasedService,
 		recognizerService:     config.RecognizerService,
+		taxCodeService:        config.TaxCodeService,
 		fsNamespaceLockdown:   config.FSNamespaceLockdown,
 	}
 

--- a/openmeter/billing/charges/service/taxcode_test.go
+++ b/openmeter/billing/charges/service/taxcode_test.go
@@ -51,6 +51,7 @@ func (s *TaxCodePersistenceTestSuite) TearDownTest() {
 func (s *TaxCodePersistenceTestSuite) TestFlatFeeChargePersistsTaxConfig() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-flatfee")
+	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
@@ -104,7 +105,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeChargePersistsTaxConfig() {
 		s.Equal(tc.ID, *flatFee.Intent.TaxConfig.TaxCodeID)
 	})
 
-	s.Run("nil tax config reads back as nil", func() {
+	s.Run("nil tax config gets default invoicing tax code stamped", func() {
 		res, err := s.Charges.Create(ctx, charges.CreateInput{
 			Namespace: ns,
 			Intents: charges.ChargeIntents{
@@ -133,7 +134,11 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeChargePersistsTaxConfig() {
 		flatFee, err := readBack.AsFlatFeeCharge()
 		s.NoError(err)
 
-		s.Nil(flatFee.Intent.TaxConfig, "TaxConfig must be nil when not set on intent")
+		// nil TaxConfig intents get the namespace default invoicing TaxCodeID stamped.
+		s.Require().NotNil(flatFee.Intent.TaxConfig, "TaxConfig must be stamped with the default invoicing tax code")
+		s.Require().NotNil(flatFee.Intent.TaxConfig.TaxCodeID, "default invoicing TaxCodeID must be stamped")
+		s.Equal(defaults.InvoicingTaxCodeID, *flatFee.Intent.TaxConfig.TaxCodeID)
+		s.Nil(flatFee.Intent.TaxConfig.Behavior, "Behavior must remain nil when only default TaxCodeID is stamped")
 	})
 }
 
@@ -142,6 +147,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeChargePersistsTaxConfig() {
 func (s *TaxCodePersistenceTestSuite) TestUsageBasedChargePersistsTaxConfig() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-usagebased")
+	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
@@ -197,7 +203,7 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedChargePersistsTaxConfig() {
 		s.Equal(tc.ID, *usageBased.Intent.TaxConfig.TaxCodeID)
 	})
 
-	s.Run("nil tax config reads back as nil", func() {
+	s.Run("nil tax config gets default invoicing tax code stamped", func() {
 		res, err := s.Charges.Create(ctx, charges.CreateInput{
 			Namespace: ns,
 			Intents: charges.ChargeIntents{
@@ -226,7 +232,11 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedChargePersistsTaxConfig() {
 		usageBased, err := readBack.AsUsageBasedCharge()
 		s.NoError(err)
 
-		s.Nil(usageBased.Intent.TaxConfig, "TaxConfig must be nil when not set on intent")
+		// nil TaxConfig intents get the namespace default invoicing TaxCodeID stamped.
+		s.Require().NotNil(usageBased.Intent.TaxConfig, "TaxConfig must be stamped with the default invoicing tax code")
+		s.Require().NotNil(usageBased.Intent.TaxConfig.TaxCodeID, "default invoicing TaxCodeID must be stamped")
+		s.Equal(defaults.InvoicingTaxCodeID, *usageBased.Intent.TaxConfig.TaxCodeID)
+		s.Nil(usageBased.Intent.TaxConfig.Behavior, "Behavior must remain nil when only default TaxCodeID is stamped")
 	})
 }
 
@@ -235,6 +245,7 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedChargePersistsTaxConfig() {
 func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseChargePersistsTaxConfig() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-creditpurchase")
+	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 
@@ -289,7 +300,7 @@ func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseChargePersistsTaxConfig(
 		s.Equal(tc.ID, *cp.Intent.TaxConfig.TaxCodeID)
 	})
 
-	s.Run("nil tax config reads back as nil", func() {
+	s.Run("nil tax config gets default credit grant tax code stamped", func() {
 		callback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
 		s.CreditPurchaseTestHandler.onPromotionalCreditPurchase = callback.Handler(s.T())
 
@@ -321,7 +332,11 @@ func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseChargePersistsTaxConfig(
 		cp, err := readBack.AsCreditPurchaseCharge()
 		s.NoError(err)
 
-		s.Nil(cp.Intent.TaxConfig, "TaxConfig must be nil when not set on intent")
+		// nil TaxConfig intents get the namespace default credit-grant TaxCodeID stamped.
+		s.Require().NotNil(cp.Intent.TaxConfig, "TaxConfig must be stamped with the default credit grant tax code")
+		s.Require().NotNil(cp.Intent.TaxConfig.TaxCodeID, "default credit grant TaxCodeID must be stamped")
+		s.Equal(defaults.CreditGrantTaxCodeID, *cp.Intent.TaxConfig.TaxCodeID)
+		s.Nil(cp.Intent.TaxConfig.Behavior, "Behavior must remain nil when only default TaxCodeID is stamped")
 	})
 }
 
@@ -332,6 +347,7 @@ func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseChargePersistsTaxConfig(
 func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementPropagatesTaxConfigToGatheringLine() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-creditpurchase-invoice")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -454,11 +470,13 @@ func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementPropaga
 	s.Equal(stripeCode, line.TaxConfig.Stripe.Code)
 }
 
-// TestCreditPurchaseInvoiceSettlementNilTaxConfigDoesNotPropagateToGatheringLine verifies that
-// when Intent.TaxConfig is nil the gathering line's TaxConfig is also nil.
-func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementNilTaxConfigDoesNotPropagateToGatheringLine() {
+// TestCreditPurchaseInvoiceSettlementNilTaxConfigGetsDefaultCreditGrantTaxCodeStamped verifies that
+// when Intent.TaxConfig is nil the gathering line's TaxConfig is populated with the namespace
+// default credit-grant tax code ID stamped by applyDefaultTaxCodes.
+func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementNilTaxConfigGetsDefaultCreditGrantTaxCodeStamped() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-creditpurchase-invoice-nil")
+	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
@@ -508,7 +526,12 @@ func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementNilTaxC
 	lines := gatheringInvoices.Items[0].Lines.OrEmpty()
 	s.Require().Len(lines, 1)
 
-	s.Nil(lines[0].TaxConfig, "gathering line TaxConfig must be nil when Intent.TaxConfig is nil")
+	// nil TaxConfig credit-purchase intents get the default credit-grant TaxCodeID stamped,
+	// which propagates to the gathering line.
+	s.Require().NotNil(lines[0].TaxConfig, "gathering line TaxConfig must be set from the default credit-grant tax code")
+	s.Require().NotNil(lines[0].TaxConfig.TaxCodeID, "default credit-grant TaxCodeID must be on gathering line")
+	s.Equal(defaults.CreditGrantTaxCodeID, *lines[0].TaxConfig.TaxCodeID)
+	s.Nil(lines[0].TaxConfig.Behavior, "Behavior must remain nil when only default TaxCodeID is stamped")
 }
 
 // TestFlatFeeCreditOnlyHandlerReceivesTaxConfig verifies that when a credit-only flat-fee charge
@@ -517,6 +540,7 @@ func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementNilTaxC
 func (s *TaxCodePersistenceTestSuite) TestFlatFeeCreditOnlyHandlerReceivesTaxConfig() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-creditonly")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 
@@ -588,6 +612,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeCreditOnlyHandlerReceivesTaxCon
 func (s *TaxCodePersistenceTestSuite) TestUsageBasedCreditOnlyHandlerReceivesTaxConfig() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-usagebased-creditonly")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
@@ -670,6 +695,7 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedCreditOnlyHandlerReceivesTax
 func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementPopulatesStripeCodeOnStandardInvoice() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-invoice-settled")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -767,6 +793,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementPopulatesStrip
 func (s *TaxCodePersistenceTestSuite) TestTaxConfigInListCharges() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-list")
+	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
@@ -865,7 +892,11 @@ func (s *TaxCodePersistenceTestSuite) TestTaxConfigInListCharges() {
 			s.Require().NoError(err)
 
 			if ff.Intent.Intent.UniqueReferenceID != nil && *ff.Intent.Intent.UniqueReferenceID == "flat-fee-list-no-taxcode" {
-				s.Nil(ff.Intent.TaxConfig, "flat fee charge without tax config must list with nil TaxConfig")
+				// nil TaxConfig intents get the default invoicing TaxCodeID stamped.
+				s.Require().NotNil(ff.Intent.TaxConfig, "flat fee charge without explicit tax config must have default invoicing TaxCodeID stamped")
+				s.Require().NotNil(ff.Intent.TaxConfig.TaxCodeID)
+				s.Equal(defaults.InvoicingTaxCodeID, *ff.Intent.TaxConfig.TaxCodeID)
+				s.Nil(ff.Intent.TaxConfig.Behavior)
 			} else {
 				s.Require().NotNil(ff.Intent.TaxConfig, "flat fee charge must carry TaxConfig in list response")
 				s.Require().NotNil(ff.Intent.TaxConfig.Behavior)
@@ -896,6 +927,7 @@ func (s *TaxCodePersistenceTestSuite) TestTaxConfigInListCharges() {
 func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementPropagatesTaxConfigToGatheringLine() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-gathering")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -960,11 +992,13 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementPropagatesTaxC
 	s.Equal(stripeCode, gatheringLine.TaxConfig.Stripe.Code)
 }
 
-// TestFlatFeeInvoiceSettlementNilTaxConfigDoesNotPropagateToGatheringLine verifies that when
-// Intent.TaxConfig is nil the flat-fee CreditThenInvoice gathering line's TaxConfig is also nil.
-func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementNilTaxConfigDoesNotPropagateToGatheringLine() {
+// TestFlatFeeInvoiceSettlementNilTaxConfigGetsDefaultInvoicingTaxCodeStampedOnGatheringLine verifies
+// that when Intent.TaxConfig is nil, the flat-fee CreditThenInvoice gathering line's TaxConfig is
+// populated with the namespace default invoicing tax code ID stamped by applyDefaultTaxCodes.
+func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementNilTaxConfigGetsDefaultInvoicingTaxCodeStampedOnGatheringLine() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-gathering-nil")
+	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
@@ -1007,7 +1041,13 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementNilTaxConfigDo
 
 	lines := gatheringInvoices.Items[0].Lines.OrEmpty()
 	s.Require().Len(lines, 1)
-	s.Nil(lines[0].TaxConfig, "gathering line TaxConfig must be nil when Intent.TaxConfig is nil")
+
+	// nil TaxConfig flat-fee intents get the default invoicing TaxCodeID stamped,
+	// which propagates to the gathering line.
+	s.Require().NotNil(lines[0].TaxConfig, "gathering line TaxConfig must be set from the default invoicing tax code")
+	s.Require().NotNil(lines[0].TaxConfig.TaxCodeID, "default invoicing TaxCodeID must be on gathering line")
+	s.Equal(defaults.InvoicingTaxCodeID, *lines[0].TaxConfig.TaxCodeID)
+	s.Nil(lines[0].TaxConfig.Behavior, "Behavior must remain nil when only default TaxCodeID is stamped")
 }
 
 // TestUsageBasedCreditThenInvoicePropagatesTaxConfigToGatheringLine verifies that TaxConfig set on
@@ -1017,6 +1057,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementNilTaxConfigDo
 func (s *TaxCodePersistenceTestSuite) TestUsageBasedCreditThenInvoicePropagatesTaxConfigToGatheringLine() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-usagebased-gathering")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -1089,6 +1130,7 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedCreditThenInvoicePropagatesT
 func (s *TaxCodePersistenceTestSuite) TestUsageBasedInvoiceSettlementPopulatesStripeCodeOnStandardInvoice() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-usagebased-invoice-settled")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -1190,12 +1232,25 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedInvoiceSettlementPopulatesSt
 	s.Equal(stripeCode, line.TaxConfig.Stripe.Code)
 }
 
-// TestFlatFeeBehaviorOnlyTaxConfigPropagatesToGatheringLine verifies that a TaxCodeConfig with only
-// Behavior set (no TaxCodeID) propagates correctly to the flat-fee gathering line. Guards against
-// regressions that drop Behavior when TaxCodeID is nil.
-func (s *TaxCodePersistenceTestSuite) TestFlatFeeBehaviorOnlyTaxConfigPropagatesToGatheringLine() {
+// TestFlatFeeBehaviorOnlyTaxConfigGetsDefaultTaxCodeStamped verifies that a TaxCodeConfig with only
+// Behavior set (no TaxCodeID) has the namespace default invoicing TaxCodeID stamped by
+// applyDefaultTaxCodes before persistence. The gathering line therefore carries both Behavior and
+// the default TaxCodeID, and Stripe.Code is backfilled from the TaxCode entity's app mapping.
+func (s *TaxCodePersistenceTestSuite) TestFlatFeeBehaviorOnlyTaxConfigGetsDefaultTaxCodeStamped() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-gathering-behavior-only")
+
+	// Provision defaults with a Stripe mapping on the invoicing default so that a behavior-only
+	// TaxConfig still resolves to a Stripe code via the default invoicing tax code.
+	const invoicingStripeCode = "txcd_30000003"
+	invoicingTaxCode := s.createTestTaxCodeWithStripeMapping(ctx, ns, "default-invoicing", invoicingStripeCode)
+	creditGrantTaxCode := s.createTestTaxCode(ctx, ns, "default-credit-grant")
+	_, err := s.TaxCodeService.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
+		Namespace:            ns,
+		InvoicingTaxCodeID:   invoicingTaxCode.ID,
+		CreditGrantTaxCodeID: creditGrantTaxCode.ID,
+	})
+	s.Require().NoError(err)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -1209,7 +1264,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeBehaviorOnlyTaxConfigPropagates
 	}
 	clock.SetTime(time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC))
 
-	_, err := s.Charges.Create(ctx, charges.CreateInput{
+	_, err = s.Charges.Create(ctx, charges.CreateInput{
 		Namespace: ns,
 		Intents: charges.ChargeIntents{
 			s.createMockChargeIntent(createMockChargeIntentInput{
@@ -1243,19 +1298,35 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeBehaviorOnlyTaxConfigPropagates
 	s.Require().Len(lines, 1)
 	gatheringLine := lines[0]
 
+	// Behavior is preserved from the original intent; default invoicing TaxCodeID is stamped.
 	s.Require().NotNil(gatheringLine.TaxConfig, "gathering line TaxConfig must be set")
 	s.Require().NotNil(gatheringLine.TaxConfig.Behavior, "TaxBehavior must propagate to gathering line")
 	s.Equal(productcatalog.InclusiveTaxBehavior, *gatheringLine.TaxConfig.Behavior)
-	s.Nil(gatheringLine.TaxConfig.TaxCodeID, "TaxCodeID must be nil for behavior-only TaxConfig")
-	s.Nil(gatheringLine.TaxConfig.Stripe, "Stripe must be nil when no TaxCodeID to resolve")
+	s.Require().NotNil(gatheringLine.TaxConfig.TaxCodeID, "default invoicing TaxCodeID must be stamped on gathering line")
+	s.Equal(invoicingTaxCode.ID, *gatheringLine.TaxConfig.TaxCodeID)
+	s.Require().NotNil(gatheringLine.TaxConfig.Stripe, "Stripe.Code must be backfilled from the default invoicing TaxCode entity")
+	s.Equal(invoicingStripeCode, gatheringLine.TaxConfig.Stripe.Code)
 }
 
-// TestUsageBasedBehaviorOnlyTaxConfigPropagatesToGatheringLine verifies that a TaxCodeConfig with
-// only Behavior set (no TaxCodeID) propagates correctly to the usage-based gathering line. Guards
-// against regressions that drop Behavior when TaxCodeID is nil.
-func (s *TaxCodePersistenceTestSuite) TestUsageBasedBehaviorOnlyTaxConfigPropagatesToGatheringLine() {
+// TestUsageBasedBehaviorOnlyTaxConfigGetsDefaultTaxCodeStamped verifies that a TaxCodeConfig with
+// only Behavior set (no TaxCodeID) has the namespace default invoicing TaxCodeID stamped by
+// applyDefaultTaxCodes before persistence. The gathering line therefore carries both Behavior and
+// the default TaxCodeID, and Stripe.Code is backfilled from the TaxCode entity's app mapping.
+func (s *TaxCodePersistenceTestSuite) TestUsageBasedBehaviorOnlyTaxConfigGetsDefaultTaxCodeStamped() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-usagebased-gathering-behavior-only")
+
+	// Provision defaults with a Stripe mapping on the invoicing default so that a behavior-only
+	// TaxConfig still resolves to a Stripe code via the default invoicing tax code.
+	const invoicingStripeCode = "txcd_30000004"
+	invoicingTaxCode := s.createTestTaxCodeWithStripeMapping(ctx, ns, "default-invoicing", invoicingStripeCode)
+	creditGrantTaxCode := s.createTestTaxCode(ctx, ns, "default-credit-grant")
+	_, err := s.TaxCodeService.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
+		Namespace:            ns,
+		InvoicingTaxCodeID:   invoicingTaxCode.ID,
+		CreditGrantTaxCodeID: creditGrantTaxCode.ID,
+	})
+	s.Require().NoError(err)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -1271,7 +1342,7 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedBehaviorOnlyTaxConfigPropaga
 	}
 	clock.SetTime(time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC))
 
-	_, err := s.Charges.Create(ctx, charges.CreateInput{
+	_, err = s.Charges.Create(ctx, charges.CreateInput{
 		Namespace: ns,
 		Intents: charges.ChargeIntents{
 			s.createMockChargeIntent(createMockChargeIntentInput{
@@ -1303,11 +1374,14 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedBehaviorOnlyTaxConfigPropaga
 	s.Require().Len(lines, 1)
 	gatheringLine := lines[0]
 
+	// Behavior is preserved from the original intent; default invoicing TaxCodeID is stamped.
 	s.Require().NotNil(gatheringLine.TaxConfig, "gathering line TaxConfig must be set")
 	s.Require().NotNil(gatheringLine.TaxConfig.Behavior, "TaxBehavior must propagate to gathering line")
 	s.Equal(productcatalog.ExclusiveTaxBehavior, *gatheringLine.TaxConfig.Behavior)
-	s.Nil(gatheringLine.TaxConfig.TaxCodeID, "TaxCodeID must be nil for behavior-only TaxConfig")
-	s.Nil(gatheringLine.TaxConfig.Stripe, "Stripe must be nil when no TaxCodeID to resolve")
+	s.Require().NotNil(gatheringLine.TaxConfig.TaxCodeID, "default invoicing TaxCodeID must be stamped on gathering line")
+	s.Equal(invoicingTaxCode.ID, *gatheringLine.TaxConfig.TaxCodeID)
+	s.Require().NotNil(gatheringLine.TaxConfig.Stripe, "Stripe.Code must be backfilled from the default invoicing TaxCode entity")
+	s.Equal(invoicingStripeCode, gatheringLine.TaxConfig.Stripe.Code)
 }
 
 func (s *TaxCodePersistenceTestSuite) createTestTaxCode(ctx context.Context, ns, key string) taxcode.TaxCode {

--- a/openmeter/billing/charges/service/truncation_test.go
+++ b/openmeter/billing/charges/service/truncation_test.go
@@ -40,6 +40,7 @@ func (s *ChargeTimestampTruncationTestSuite) TearDownTest() {
 func (s *ChargeTimestampTruncationTestSuite) TestCreateTruncatesFlatFeeIntentAndProrationInputs() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-truncation-flatfee")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 
@@ -97,6 +98,7 @@ func (s *ChargeTimestampTruncationTestSuite) TestCreateTruncatesFlatFeeIntentAnd
 func (s *ChargeTimestampTruncationTestSuite) TestUsageBasedAdvanceTruncatesPersistedCalculationTimestamps() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-truncation-usagebased")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -39,6 +39,7 @@ func (s *UsageBasedChargesTestSuite) TearDownTest() {
 func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePartialInvoiceLifecycle() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-partial-invoice-lifecycle")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -456,6 +457,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePartialInvoi
 func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePendingPartialInvoiceBlocksFinalRealizationUntilApproval() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-pending-partial-invoice-blocks-final")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 

--- a/openmeter/billing/charges/testutils/service.go
+++ b/openmeter/billing/charges/testutils/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ledger/recognizer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/pkg/framework/lockr"
 )
 
@@ -39,6 +40,7 @@ type Config struct {
 	FeatureService     feature.FeatureConnector
 	StreamingConnector streaming.Connector
 	RecognizerService  recognizer.Service
+	TaxCodeService     taxcode.Service
 
 	FlatFeeHandler        flatfee.Handler
 	CreditPurchaseHandler creditpurchase.Handler
@@ -74,6 +76,10 @@ func (c Config) Validate() error {
 
 	if c.UsageBasedHandler == nil {
 		errs = append(errs, fmt.Errorf("usage based handler is required"))
+	}
+
+	if c.TaxCodeService == nil {
+		errs = append(errs, fmt.Errorf("tax code service is required"))
 	}
 
 	return errors.Join(errs...)
@@ -233,6 +239,7 @@ func NewServices(t testing.TB, config Config) (*Services, error) {
 		UsageBasedService:     usageBasedService,
 		RecognizerService:     config.RecognizerService,
 		BillingService:        config.BillingService,
+		TaxCodeService:        config.TaxCodeService,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating charges service: %w", err)

--- a/openmeter/billing/worker/subscriptionsync/service/base_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/base_test.go
@@ -110,6 +110,7 @@ func (s *SuiteBase) beforeTest(ctx context.Context, suiteName, testName string) 
 	appSandbox := s.InstallSandboxApp(s.T(), s.Namespace)
 
 	s.ProvisionBillingProfile(ctx, s.Namespace, appSandbox.GetID())
+	s.ProvisionDefaultTaxCodes(ctx, s.Namespace)
 
 	apiRequestsTotalMeterSlug := "api-requests-total"
 	apiRequestsTotalMeterID := ulid.Make().String()

--- a/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
@@ -106,6 +106,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) SetupSuite() {
 		BillingService:        s.BillingService,
 		FeatureService:        s.FeatureService,
 		StreamingConnector:    s.MockStreamingConnector,
+		TaxCodeService:        s.TaxCodeService,
 		FlatFeeHandler:        handlers.FlatFee,
 		CreditPurchaseHandler: handlers.CreditPurchase,
 		UsageBasedHandler:     handlers.UsageBased,

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/openmeter/subscription/patch"
 	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -100,6 +101,7 @@ func (s *CreditThenInvoiceTestSuite) SetupSuite() {
 		BillingService:     s.BillingService,
 		FeatureService:     s.FeatureService,
 		StreamingConnector: s.MockStreamingConnector,
+		TaxCodeService:     s.TaxCodeService,
 		FlatFeeHandler: ledgerchargeadapter.NewFlatFeeHandler(
 			ledgerDeps.HistoricalLedger,
 			transactions.ResolverDependencies{
@@ -4957,8 +4959,15 @@ func (s *CreditThenInvoiceTestSuite) TestRateCardTaxSyncFlatFee() {
 	// Then
 	//  the gathering invoice will contain the tax details
 
+	// The namespace's default invoicing tax code is auto-stamped on charges and
+	// propagated lines when the rate card leaves TaxCodeID nil. Set it explicitly
+	// here so the rate card carries the tax code we then assert is propagated.
+	defaults, err := s.TaxCodeService.GetOrganizationDefaultTaxCodes(ctx, taxcode.GetOrganizationDefaultTaxCodesInput{Namespace: s.Namespace})
+	s.Require().NoError(err)
+
 	taxConfig := &productcatalog.TaxConfig{
-		Behavior: lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
+		Behavior:  lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
+		TaxCodeID: lo.ToPtr(defaults.InvoicingTaxCodeID),
 	}
 
 	var subsView subscription.SubscriptionView
@@ -5119,8 +5128,15 @@ func (s *CreditThenInvoiceTestSuite) TestRateCardTaxSyncUsageBased() {
 	// Then
 	//  the gathering invoice will contain the tax details
 
+	// The namespace's default invoicing tax code is auto-stamped on charges and
+	// propagated lines when the rate card leaves TaxCodeID nil. Set it explicitly
+	// here so the rate card carries the tax code we then assert is propagated.
+	defaults, err := s.TaxCodeService.GetOrganizationDefaultTaxCodes(ctx, taxcode.GetOrganizationDefaultTaxCodesInput{Namespace: s.Namespace})
+	s.Require().NoError(err)
+
 	taxConfig := &productcatalog.TaxConfig{
-		Behavior: lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
+		Behavior:  lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
+		TaxCodeID: lo.ToPtr(defaults.InvoicingTaxCodeID),
 	}
 
 	var subsView subscription.SubscriptionView

--- a/test/app/stripe/invoice_credits_test.go
+++ b/test/app/stripe/invoice_credits_test.go
@@ -32,6 +32,7 @@ func (s *StripeInvoiceTestSuite) TestUsageBasedCreditThenInvoiceProgressiveBilli
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("stripe-credits-usagebased-progressive-credit-then-invoice")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
 	servicePeriod := timeutil.ClosedPeriod{

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -142,6 +142,7 @@ func (s *StripeInvoiceTestSuite) SetupSuite() {
 		BillingService:        s.BillingService,
 		FeatureService:        s.FeatureService,
 		StreamingConnector:    s.MockStreamingConnector,
+		TaxCodeService:        s.TaxCodeService,
 		FlatFeeHandler:        ledgerchargeadapter.NewFlatFeeHandler(ledgerDeps.HistoricalLedger, transactions.ResolverDependencies{AccountService: ledgerDeps.ResolversService, AccountCatalog: ledgerDeps.AccountService, BalanceQuerier: ledgerDeps.HistoricalLedger}, collectorService),
 		CreditPurchaseHandler: creditPurchaseHandler,
 		UsageBasedHandler:     ledgerchargeadapter.NewUsageBasedHandler(ledgerDeps.HistoricalLedger, transactions.ResolverDependencies{AccountService: ledgerDeps.ResolversService, AccountCatalog: ledgerDeps.AccountService, BalanceQuerier: ledgerDeps.HistoricalLedger}, collectorService),

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -636,6 +636,37 @@ func (s *BaseSuite) ProvisionBillingProfile(ctx context.Context, ns string, appI
 	return profile
 }
 
+// ProvisionDefaultTaxCodes creates the invoicing and credit-grant tax codes for the
+// namespace and stores them as the organization defaults. Tests that create charges
+// via the real charges service must call this for the namespace, because charge
+// creation auto-stamps the namespace's default tax code when the caller's TaxConfig
+// has no TaxCodeID.
+func (s *BaseSuite) ProvisionDefaultTaxCodes(ctx context.Context, ns string) taxcode.OrganizationDefaultTaxCodes {
+	s.T().Helper()
+
+	invoicing, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "default-invoicing",
+		Name:      "Default Invoicing",
+	})
+	s.Require().NoError(err, "creating default invoicing tax code")
+
+	creditGrant, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "default-credit-grant",
+		Name:      "Default Credit Grant",
+	})
+	s.Require().NoError(err, "creating default credit grant tax code")
+
+	defaults, err := s.TaxCodeService.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
+		Namespace:            ns,
+		InvoicingTaxCodeID:   invoicing.ID,
+		CreditGrantTaxCodeID: creditGrant.ID,
+	})
+	s.Require().NoError(err, "upserting organization default tax codes")
+	return defaults
+}
+
 type SetupCustomInvoicingResponse struct {
 	App app.App
 }

--- a/test/credits/base.go
+++ b/test/credits/base.go
@@ -144,6 +144,7 @@ func (s *BaseSuite) SetupSuite() {
 		BillingService:        s.BillingService,
 		FeatureService:        s.FeatureService,
 		StreamingConnector:    s.MockStreamingConnector,
+		TaxCodeService:        s.TaxCodeService,
 		FlatFeeHandler:        flatFeeHandler,
 		CreditPurchaseHandler: creditPurchaseHandler,
 		UsageBasedHandler:     ledgerchargeadapter.NewUsageBasedHandler(deps.HistoricalLedger, transactions.ResolverDependencies{AccountService: deps.ResolversService, AccountCatalog: deps.AccountService, BalanceQuerier: deps.HistoricalLedger}, collectorService),

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -42,6 +42,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceDeletePatchD
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-delete-gathering")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -147,6 +148,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceDeletePatchD
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-delete-standard")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -337,6 +339,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceDeletePatchK
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-delete-immutable")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -528,6 +531,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceCreatePatchCrea
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-create")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -646,6 +650,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchDele
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-gathering")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -749,6 +754,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchDele
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-standard")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -928,6 +934,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchDele
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-standard-partial")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1096,6 +1103,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchKeep
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-immutable")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1274,6 +1282,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoicePartialCreditPa
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-partial-payment")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1514,6 +1523,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDirectPaidTrigg
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-direct-paid")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1629,6 +1639,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedPa
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-no-fiat-payment-callback")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1757,6 +1768,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountFinal
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-zero")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1877,6 +1889,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkToZeroThe
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-shrink-zero-extend")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -2136,6 +2149,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteImmutable
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-immutable-payment")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -2285,6 +2299,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceAsyncPaymentBoo
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-async-prior-payment")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -2480,6 +2495,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceInArrearsActiva
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-in-arrears")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -2624,6 +2640,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteActiveCha
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-active")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -2718,6 +2735,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkExtendPat
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-shrink-extend-gathering")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -2864,6 +2882,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkPatchUpda
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-shrink-mutable-standard")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3012,6 +3031,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkPatchCorr
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-cti-shrink-mutable-with-credits")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3180,6 +3200,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceImmutableShrink
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-immutable-shrink-extend-shrink")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3392,6 +3413,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchU
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-extend-gathering")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3507,6 +3529,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkPatchU
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-shrink-gathering")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3620,6 +3643,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchD
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-extend-mutable-standard")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3805,6 +3829,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkPatchD
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-shrink-mutable-standard")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3991,6 +4016,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkPatchD
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-shrink-immutable")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -4250,6 +4276,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchD
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-extend-final-collection")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -4471,6 +4498,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchD
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-extend-immutable")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -4665,6 +4693,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkExtend
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-shrink-extend-shrink")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -5052,6 +5081,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchF
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-extend-tail")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")

--- a/test/credits/creditgrant_test.go
+++ b/test/credits/creditgrant_test.go
@@ -94,6 +94,7 @@ func (s *CreditGrantTestSuite) SetupSuite() {
 func (s *CreditGrantTestSuite) TestCreateInvoiceFundedCreatesInvoiceArtifacts() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("creditgrant-service-invoice-funded")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -150,6 +151,7 @@ func (s *CreditGrantTestSuite) TestCreateInvoiceFundedCreatesInvoiceArtifacts() 
 func (s *CreditGrantTestSuite) TestCreatePromotionalGrant() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("creditgrant-service-promotional")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -188,6 +190,7 @@ func (s *CreditGrantTestSuite) TestCreatePromotionalGrant() {
 func (s *CreditGrantTestSuite) TestCreateExternalGrantAndSettle() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("creditgrant-service-external")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -245,6 +248,7 @@ func (s *CreditGrantTestSuite) TestCreateExternalGrantAndSettle() {
 func (s *CreditGrantTestSuite) TestListCreditGrants() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("creditgrant-service-list")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -277,6 +281,7 @@ func (s *CreditGrantTestSuite) TestListCreditGrants() {
 func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantPropagatesTaxConfigToInvoiceLine() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("creditgrant-taxconfig-propagation")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -340,11 +345,13 @@ func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantPropagatesTaxConfigTo
 	s.Equal("txcd_40000001", line.TaxConfig.Stripe.Code)
 }
 
-// TestCreateInvoiceFundedGrantNilTaxConfigInvoiceLineNil verifies that when TaxConfig is omitted
-// from creditgrant.CreateInput the resulting standard invoice line has nil TaxConfig.
-func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantNilTaxConfigInvoiceLineNil() {
+// TestCreateInvoiceFundedGrantNilTaxConfigAppliesCreditGrantDefault verifies that when
+// TaxConfig is omitted from creditgrant.CreateInput, the resulting standard invoice line
+// inherits the namespace's default credit-grant tax code stamped during charge creation.
+func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantNilTaxConfigAppliesCreditGrantDefault() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("creditgrant-taxconfig-nil")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -355,10 +362,13 @@ func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantNilTaxConfigInvoiceLi
 		billingtest.WithManualApproval(),
 	)
 
+	defaults, err := s.TaxCodeService.GetOrganizationDefaultTaxCodes(ctx, taxcode.GetOrganizationDefaultTaxCodesInput{Namespace: ns})
+	s.Require().NoError(err)
+
 	now := datetime.MustParseTimeInLocation(s.T(), "2026-04-17T11:23:53Z", time.UTC).AsTime()
 	clock.SetTime(now)
 
-	_, err := s.CreditGrantService.Create(ctx, creditgrant.CreateInput{
+	_, err = s.CreditGrantService.Create(ctx, creditgrant.CreateInput{
 		Namespace:     ns,
 		CustomerID:    cust.ID,
 		Name:          "$10.00 grant without tax config",
@@ -382,7 +392,9 @@ func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantNilTaxConfigInvoiceLi
 
 	lines := standardInvoices.Items[0].Lines.OrEmpty()
 	s.Require().Len(lines, 1)
-	s.Nil(lines[0].TaxConfig, "standard invoice line TaxConfig must be nil when grant has no TaxConfig")
+	s.Require().NotNil(lines[0].TaxConfig, "standard invoice line TaxConfig must be populated with namespace default credit-grant tax code")
+	s.Require().NotNil(lines[0].TaxConfig.TaxCodeID)
+	s.Equal(defaults.CreditGrantTaxCodeID, *lines[0].TaxConfig.TaxCodeID, "standard invoice line must reference the namespace default credit-grant tax code")
 }
 
 // TestCreateExternalGrantPropagatesTaxConfigToCharge verifies that TaxConfig set on
@@ -392,6 +404,7 @@ func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantNilTaxConfigInvoiceLi
 func (s *CreditGrantTestSuite) TestCreateExternalGrantPropagatesTaxConfigToCharge() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("creditgrant-external-taxconfig")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -442,6 +455,7 @@ func (s *CreditGrantTestSuite) TestCreateExternalGrantPropagatesTaxConfigToCharg
 func (s *CreditGrantTestSuite) TestCreatePromotionalGrantPropagatesTaxConfigToCharge() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("creditgrant-promotional-taxconfig")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)

--- a/test/credits/rating_test.go
+++ b/test/credits/rating_test.go
@@ -28,6 +28,7 @@ type RatingTestSuite struct {
 func (s *RatingTestSuite) TestListChargesExpandsRealtimeUsageForMultipleUsageBasedCharges() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("credits-rating-list-charges")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	const (
 		standardRateReference = "usage-based-standard-rate"

--- a/test/credits/sanity_lifecycle_test.go
+++ b/test/credits/sanity_lifecycle_test.go
@@ -113,6 +113,7 @@ func (s *SanityLifecycleSuite) TestUsageBasedCreditOnlyLifecyclePartialBackfillC
 func (s *SanityLifecycleSuite) TestUsageBasedCreditOnlyLifecycleTwoChargesTwoPurchasesSanity() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-usagebased-credit-only-lifecycle-two-charges-two-purchases")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -372,6 +373,7 @@ func (s *SanityLifecycleSuite) TestUsageBasedCreditOnlyLifecycleTwoChargesTwoPur
 // the later correction has already been applied.
 func (s *SanityLifecycleSuite) setupUsageBasedCreditOnlyLifecyclePartialBackfillCorrection(ctx context.Context, namespacePrefix string) usageBasedPartialBackfillLifecycleState {
 	ns := s.GetUniqueNamespace(namespacePrefix)
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -1302,6 +1302,7 @@ func (s *SanitySuite) assertBreakageBalancesAt(input breakageBalanceAssertionInp
 func (s *SanitySuite) setupFlatFeeCreditOnlyDeleteCorrection(namespaceSuffix string) creditOnlyDeleteCorrectionSetup {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace(namespaceSuffix)
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1327,6 +1328,7 @@ func (s *SanitySuite) setupFlatFeeCreditOnlyDeleteCorrection(namespaceSuffix str
 func (s *SanitySuite) setupUsageBasedCreditOnlyDeleteCorrection(namespaceSuffix string) creditOnlyDeleteCorrectionSetup {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace(namespaceSuffix)
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -1488,6 +1490,7 @@ func (s *SanitySuite) assertFundedRecognizedCreditOnlyDeleted(namespace string, 
 func (s *SanitySuite) TestUsageBasedCreditOnlyDeleteCorrectionWithPartialBackfillSanity() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-usagebased-credit-only-delete-partial-backfill")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -1611,6 +1614,7 @@ func (s *SanitySuite) TestUsageBasedCreditOnlyDeleteCorrectionWithPartialBackfil
 func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-test")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -1956,6 +1960,7 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 func (s *SanitySuite) TestCreditPurchasePersistsPriority() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-creditpurchase-persists-priority")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -1987,6 +1992,7 @@ func (s *SanitySuite) TestCreditPurchasePersistsPriority() {
 func (s *SanitySuite) TestUsageBasedCreditThenInvoicePaymentLifecycle() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-payment-lifecycle")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -2165,6 +2171,7 @@ func (s *SanitySuite) TestUsageBasedCreditThenInvoicePaymentLifecycle() {
 func (s *SanitySuite) TestFlatFeeCreditOnlySanity() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-test-credit-only")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -1102,6 +1102,7 @@ func (s *SanitySuite) assertBreakageRowsByExpiry(ctx context.Context, namespace 
 func (s *SanitySuite) setupExpiringCreditBreakage(namespaceSuffix string, opts ...expiringCreditBreakageSetupOption) expiringCreditBreakageSetup {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace(namespaceSuffix)
+	s.ProvisionDefaultTaxCodes(ctx, ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Charges now automatically receive default tax codes when none are provided.
  * Distinct defaults apply for credit purchases vs invoicing flows.
  * Defaults are applied at charge creation and carried through invoices and gathering lines.

* **Tests**
  * Extensive test updates to provision, validate, and assert default tax-code provisioning and propagation across charge lifecycles and settlements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->