### PR TITLE
Fix CTI ledger booking timestamps

### DIFF
--- a/openmeter/billing/charges/creditpurchase/handler.go
+++ b/openmeter/billing/charges/creditpurchase/handler.go
@@ -2,8 +2,12 @@ package creditpurchase
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 // CreditPurchaseHandler is the interface for handling credit purchase charges.
@@ -37,9 +41,28 @@ type Handler interface {
 
 	// OnCreditPurchasePaymentAuthorized is called when a credit purchase payment is authorized for a credit
 	// purchase.
-	OnCreditPurchasePaymentAuthorized(ctx context.Context, charge Charge) (ledgertransaction.GroupReference, error)
+	OnCreditPurchasePaymentAuthorized(ctx context.Context, input PaymentEventInput) (ledgertransaction.GroupReference, error)
 
 	// OnCreditPurchasePaymentSettled is called when a credit purchase payment is settled for a credit
 	// purchase.
-	OnCreditPurchasePaymentSettled(ctx context.Context, charge Charge) (ledgertransaction.GroupReference, error)
+	OnCreditPurchasePaymentSettled(ctx context.Context, input PaymentEventInput) (ledgertransaction.GroupReference, error)
+}
+
+type PaymentEventInput struct {
+	Charge  Charge    `json:"charge"`
+	EventAt time.Time `json:"eventAt"`
+}
+
+func (i PaymentEventInput) Validate() error {
+	var errs []error
+
+	if err := i.Charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if i.EventAt.IsZero() {
+		errs = append(errs, fmt.Errorf("event at is required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }

--- a/openmeter/billing/charges/creditpurchase/service/external.go
+++ b/openmeter/billing/charges/creditpurchase/service/external.go
@@ -92,7 +92,11 @@ func (s *service) HandleExternalPaymentAuthorized(ctx context.Context, charge cr
 				WithAttrs(charge.Realizations.ExternalPaymentSettlement.ErrorAttributes())
 		}
 
-		ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentAuthorized(ctx, charge)
+		eventAt := clock.Now()
+		ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentAuthorized(ctx, creditpurchase.PaymentEventInput{
+			Charge:  charge,
+			EventAt: eventAt,
+		})
 		if err != nil {
 			return creditpurchase.Charge{}, err
 		}
@@ -104,7 +108,7 @@ func (s *service) HandleExternalPaymentAuthorized(ctx context.Context, charge cr
 				Amount:        charge.Intent.CreditAmount,
 				Authorized: &ledgertransaction.TimedGroupReference{
 					GroupReference: ledgerTransactionGroupReference,
-					Time:           clock.Now(),
+					Time:           eventAt,
 				},
 				Status: payment.StatusAuthorized,
 			},
@@ -136,14 +140,18 @@ func (s *service) HandleExternalPaymentSettled(ctx context.Context, charge credi
 				WithAttrs(paymentSettlement.ErrorAttributes())
 		}
 
-		ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentSettled(ctx, charge)
+		eventAt := clock.Now()
+		ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentSettled(ctx, creditpurchase.PaymentEventInput{
+			Charge:  charge,
+			EventAt: eventAt,
+		})
 		if err != nil {
 			return creditpurchase.Charge{}, err
 		}
 
 		paymentSettlement.Settled = &ledgertransaction.TimedGroupReference{
 			GroupReference: ledgerTransactionGroupReference,
-			Time:           clock.Now(),
+			Time:           eventAt,
 		}
 
 		paymentSettlement.Status = payment.StatusSettled

--- a/openmeter/billing/charges/creditpurchase/service/invoice.go
+++ b/openmeter/billing/charges/creditpurchase/service/invoice.go
@@ -53,7 +53,11 @@ func (s *service) PostInvoicePaymentAuthorized(ctx context.Context, charge credi
 		return fmt.Errorf("invoice settlement already authorized - settlement already exists: %s", charge.Realizations.InvoiceSettlement.InvoiceID)
 	}
 
-	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentAuthorized(ctx, charge)
+	eventAt := clock.Now()
+	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentAuthorized(ctx, creditpurchase.PaymentEventInput{
+		Charge:  charge,
+		EventAt: eventAt,
+	})
 	if err != nil {
 		return err
 	}
@@ -65,7 +69,7 @@ func (s *service) PostInvoicePaymentAuthorized(ctx context.Context, charge credi
 			Amount:        charge.Intent.CreditAmount,
 			Authorized: &ledgertransaction.TimedGroupReference{
 				GroupReference: ledgerTransactionGroupReference,
-				Time:           clock.Now(),
+				Time:           eventAt,
 			},
 			Status: payment.StatusAuthorized,
 		},
@@ -95,14 +99,18 @@ func (s *service) PostInvoicePaymentSettled(ctx context.Context, charge creditpu
 
 	paymentSettlement := *charge.Realizations.InvoiceSettlement
 
-	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentSettled(ctx, charge)
+	eventAt := clock.Now()
+	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentSettled(ctx, creditpurchase.PaymentEventInput{
+		Charge:  charge,
+		EventAt: eventAt,
+	})
 	if err != nil {
 		return err
 	}
 
 	paymentSettlement.Settled = &ledgertransaction.TimedGroupReference{
 		GroupReference: ledgerTransactionGroupReference,
-		Time:           clock.Now(),
+		Time:           eventAt,
 	}
 
 	paymentSettlement.Status = payment.StatusSettled

--- a/openmeter/billing/charges/flatfee/bookedat.go
+++ b/openmeter/billing/charges/flatfee/bookedat.go
@@ -1,0 +1,17 @@
+package flatfee
+
+import (
+	"time"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+// UsageBookedAt returns the ledger booking time for a flat-fee service period.
+func UsageBookedAt(paymentTerm productcatalog.PaymentTermType, servicePeriod timeutil.ClosedPeriod) time.Time {
+	if paymentTerm == productcatalog.InArrearsPaymentTerm {
+		return servicePeriod.To
+	}
+
+	return servicePeriod.From
+}

--- a/openmeter/billing/charges/flatfee/handler.go
+++ b/openmeter/billing/charges/flatfee/handler.go
@@ -20,6 +20,7 @@ import (
 type OnAllocateCreditsInput struct {
 	Charge        Charge                `json:"charge"`
 	ServicePeriod timeutil.ClosedPeriod `json:"servicePeriod"`
+	BookedAt      time.Time             `json:"bookedAt"`
 	// PreTaxAmountToAllocate is the pre-tax amount to allocate from credits.
 	// The input charge's settlement mode governs whether this may create a negative balance.
 	PreTaxAmountToAllocate alpacadecimal.Decimal `json:"preTaxAmountToAllocate"`
@@ -36,6 +37,10 @@ func (i OnAllocateCreditsInput) Validate() error {
 		errs = append(errs, fmt.Errorf("service period: %w", err))
 	}
 
+	if i.BookedAt.IsZero() {
+		errs = append(errs, fmt.Errorf("booked at is required"))
+	}
+
 	if i.PreTaxAmountToAllocate.IsNegative() {
 		errs = append(errs, fmt.Errorf("pre tax amount to allocate cannot be negative"))
 	}
@@ -46,6 +51,7 @@ func (i OnAllocateCreditsInput) Validate() error {
 type OnInvoiceUsageAccruedInput struct {
 	Charge        Charge                `json:"charge"`
 	ServicePeriod timeutil.ClosedPeriod `json:"servicePeriod"`
+	BookedAt      time.Time             `json:"bookedAt"`
 	Totals        totals.Totals         `json:"totals"`
 }
 
@@ -60,6 +66,10 @@ func (i OnInvoiceUsageAccruedInput) Validate() error {
 		errs = append(errs, fmt.Errorf("service period: %w", err))
 	}
 
+	if i.BookedAt.IsZero() {
+		errs = append(errs, fmt.Errorf("booked at is required"))
+	}
+
 	if err := i.Totals.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("totals: %w", err))
 	}
@@ -68,8 +78,8 @@ func (i OnInvoiceUsageAccruedInput) Validate() error {
 }
 
 type CorrectCreditAllocationsInput struct {
-	Charge     Charge    `json:"charge"`
-	AllocateAt time.Time `json:"allocateAt"`
+	Charge   Charge    `json:"charge"`
+	BookedAt time.Time `json:"bookedAt"`
 
 	Corrections                  creditrealization.CorrectionRequest   `json:"corrections"`
 	LineageSegmentsByRealization lineage.ActiveSegmentsByRealizationID `json:"-"`
@@ -82,8 +92,8 @@ func (i CorrectCreditAllocationsInput) Validate() error {
 		errs = append(errs, fmt.Errorf("charge: %w", err))
 	}
 
-	if i.AllocateAt.IsZero() {
-		errs = append(errs, fmt.Errorf("allocate at is required"))
+	if i.BookedAt.IsZero() {
+		errs = append(errs, fmt.Errorf("booked at is required"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
@@ -104,8 +114,9 @@ func (i CorrectCreditAllocationsInput) ValidateWith(currencyCalculator currencyx
 }
 
 type PaymentEventInput struct {
-	Charge Charge                `json:"charge"`
-	Amount alpacadecimal.Decimal `json:"amount"`
+	Charge  Charge                `json:"charge"`
+	EventAt time.Time             `json:"eventAt"`
+	Amount  alpacadecimal.Decimal `json:"amount"`
 }
 
 func (i PaymentEventInput) Validate() error {
@@ -113,6 +124,10 @@ func (i PaymentEventInput) Validate() error {
 
 	if err := i.Charge.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if i.EventAt.IsZero() {
+		errs = append(errs, fmt.Errorf("event at is required"))
 	}
 
 	if i.Amount.IsNegative() {

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/statelessx"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -443,7 +442,7 @@ func (s *CreditThenInvoiceStateMachine) generateInvoicePatches(ctx context.Conte
 			Charge:     s.Charge,
 			Run:        *currentRun,
 			Line:       *line,
-			AllocateAt: clock.Now(),
+			AllocateAt: flatfee.UsageBookedAt(s.Charge.Intent.PaymentTerm, currentRun.ServicePeriod),
 		})
 		if err != nil {
 			return fmt.Errorf("reconcile standard line to intent for %s flat-fee charge[%s]: %w", input.Op, s.Charge.ID, err)

--- a/openmeter/billing/charges/flatfee/service/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/creditsonly.go
@@ -128,7 +128,7 @@ func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, policy meta.
 		if _, err := s.Realizations.CorrectAllCredits(ctx, flatfeerealizations.CorrectAllCreditRealizationsInput{
 			Charge:             s.Charge,
 			Run:                *s.Charge.Realizations.CurrentRun,
-			AllocateAt:         clock.Now(),
+			AllocateAt:         flatfee.UsageBookedAt(s.Charge.Intent.PaymentTerm, s.Charge.Realizations.CurrentRun.ServicePeriod),
 			CurrencyCalculator: currencyCalculator,
 		}); err != nil {
 			return fmt.Errorf("correct credits: %w", err)

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -185,7 +185,7 @@ func (e *LineEngine) OnMutableStandardLinesDeleted(ctx context.Context, input bi
 		if _, err := e.service.realizations.CorrectAllCredits(ctx, flatfeerealizations.CorrectAllCreditRealizationsInput{
 			Charge:             charge,
 			Run:                run,
-			AllocateAt:         clock.Now(),
+			AllocateAt:         flatfee.UsageBookedAt(charge.Intent.PaymentTerm, run.ServicePeriod),
 			CurrencyCalculator: currencyCalculator,
 		}); err != nil {
 			return fmt.Errorf("correcting credits for deleted flat fee standard line[%s] run[%s]: %w", stdLine.ID, run.ID.ID, err)

--- a/openmeter/billing/charges/flatfee/service/payment.go
+++ b/openmeter/billing/charges/flatfee/service/payment.go
@@ -44,9 +44,11 @@ func (s *service) postInvoicePaymentAuthorized(ctx context.Context, charge flatf
 			return err
 		}
 
+		eventAt := clock.Now()
 		ledgerTransactionGroupReference, err := s.handler.OnPaymentAuthorized(ctx, flatfee.OnPaymentAuthorizedInput{
-			Charge: charge,
-			Amount: paymentTotal,
+			Charge:  charge,
+			EventAt: eventAt,
+			Amount:  paymentTotal,
 		})
 		if err != nil {
 			return err
@@ -63,7 +65,7 @@ func (s *service) postInvoicePaymentAuthorized(ctx context.Context, charge flatf
 					GroupReference: ledgertransaction.GroupReference{
 						TransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
 					},
-					Time: clock.Now(),
+					Time: eventAt,
 				},
 				Status: payment.StatusAuthorized,
 			},
@@ -115,9 +117,11 @@ func (s *service) postInvoicePaymentSettled(ctx context.Context, charge flatfee.
 			return err
 		}
 
+		eventAt := clock.Now()
 		ledgerTransactionGroupReference, err := s.handler.OnPaymentSettled(ctx, flatfee.OnPaymentSettledInput{
-			Charge: charge,
-			Amount: paymentTotal,
+			Charge:  charge,
+			EventAt: eventAt,
+			Amount:  paymentTotal,
 		})
 		if err != nil {
 			return err
@@ -127,7 +131,7 @@ func (s *service) postInvoicePaymentSettled(ctx context.Context, charge flatfee.
 			GroupReference: ledgertransaction.GroupReference{
 				TransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
 			},
-			Time: clock.Now(),
+			Time: eventAt,
 		}
 
 		paymentSettlement.Status = payment.StatusSettled

--- a/openmeter/billing/charges/flatfee/service/realizations/correct.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/correct.go
@@ -84,6 +84,7 @@ func (s *Service) ReconcileCredits(ctx context.Context, in ReconcileCreditRealiz
 		handlerInput := flatfee.OnAllocateCreditsInput{
 			Charge:                 in.Charge,
 			ServicePeriod:          in.Run.ServicePeriod,
+			BookedAt:               in.AllocateAt,
 			PreTaxAmountToAllocate: delta,
 		}
 		if err := handlerInput.Validate(); err != nil {
@@ -125,7 +126,7 @@ func (s *Service) ReconcileCredits(ctx context.Context, in ReconcileCreditRealiz
 			func(req creditrealization.CorrectionRequest) (creditrealization.CreateCorrectionInputs, error) {
 				return s.handler.OnCorrectCreditAllocations(ctx, flatfee.CorrectCreditAllocationsInput{
 					Charge:                       in.Charge,
-					AllocateAt:                   in.AllocateAt,
+					BookedAt:                     in.AllocateAt,
 					Corrections:                  req,
 					LineageSegmentsByRealization: lineageSegmentsByRealization,
 				})
@@ -196,7 +197,7 @@ func (s *Service) CorrectAllCredits(ctx context.Context, in CorrectAllCreditReal
 	corrections, err := in.Run.CreditRealizations.CorrectAll(in.CurrencyCalculator, func(req creditrealization.CorrectionRequest) (creditrealization.CreateCorrectionInputs, error) {
 		return s.handler.OnCorrectCreditAllocations(ctx, flatfee.CorrectCreditAllocationsInput{
 			Charge:                       in.Charge,
-			AllocateAt:                   in.AllocateAt,
+			BookedAt:                     in.AllocateAt,
 			Corrections:                  req,
 			LineageSegmentsByRealization: lineageSegmentsByRealization,
 		})

--- a/openmeter/billing/charges/flatfee/service/realizations/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/creditsonly.go
@@ -56,6 +56,7 @@ func (s *Service) AllocateCreditsOnly(ctx context.Context, in AllocateCreditsOnl
 	input := flatfee.OnAllocateCreditsInput{
 		Charge:                 in.Charge,
 		ServicePeriod:          in.Charge.Intent.ServicePeriod,
+		BookedAt:               flatfee.UsageBookedAt(in.Charge.Intent.PaymentTerm, in.Charge.Intent.ServicePeriod),
 		PreTaxAmountToAllocate: in.Amount,
 	}
 	if err := input.Validate(); err != nil {

--- a/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
@@ -114,6 +114,7 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 			handlerInput := flatfee.OnAllocateCreditsInput{
 				Charge:                 charge,
 				ServicePeriod:          in.Line.Period,
+				BookedAt:               flatfee.UsageBookedAt(charge.Intent.PaymentTerm, in.Line.Period),
 				PreTaxAmountToAllocate: creditAllocationTarget,
 			}
 			if err := handlerInput.Validate(); err != nil {

--- a/openmeter/billing/charges/flatfee/service/realizations/invoiceaccrued.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/invoiceaccrued.go
@@ -81,6 +81,7 @@ func (s *Service) AccrueInvoiceUsage(ctx context.Context, in AccrueInvoiceUsageI
 			ledgerTransactionRef, err := s.handler.OnInvoiceUsageAccrued(ctx, flatfee.OnInvoiceUsageAccruedInput{
 				Charge:        in.Charge,
 				ServicePeriod: line.Period,
+				BookedAt:      flatfee.UsageBookedAt(in.Charge.Intent.PaymentTerm, line.Period),
 				Totals:        line.Totals,
 			})
 			if err != nil {

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -240,8 +240,9 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 	})
 
 	// Then the authorized callback should be called, with a grant realization and no payment settlement
-	authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
-	s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, charge creditpurchase.Charge) {
+	authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
+	s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
+		charge := input.Charge
 		assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeExternal)
 		assert.NotNil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should be set")
 		assert.Equal(t, initiatedCallback.id, charge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
@@ -250,8 +251,9 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 	})
 
 	// Then the settled callback should be called, with a grant realization and a payment settlement
-	settledCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
-	s.CreditPurchaseTestHandler.onCreditPurchasePaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, charge creditpurchase.Charge) {
+	settledCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
+	s.CreditPurchaseTestHandler.onCreditPurchasePaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
+		charge := input.Charge
 		assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeExternal)
 		assert.NotNil(t, charge.Realizations.ExternalPaymentSettlement, "external payment settlement should be set")
 
@@ -370,8 +372,9 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySe
 		defer s.CreditPurchaseTestHandler.Reset()
 
 		// Then the authorized callback should be called, with a grant realization and no payment settlement
-		authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
-		s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, charge creditpurchase.Charge) {
+		authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
+		s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
+			charge := input.Charge
 			assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeExternal)
 			assert.NotNil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should be set")
 			assert.Equal(t, initatedTrnsID, charge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
@@ -397,8 +400,9 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySe
 		defer s.CreditPurchaseTestHandler.Reset()
 
 		// Then the settled callback should be called, with a grant realization and a payment settlement
-		settledCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
-		s.CreditPurchaseTestHandler.onCreditPurchasePaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, charge creditpurchase.Charge) {
+		settledCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
+		s.CreditPurchaseTestHandler.onCreditPurchasePaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
+			charge := input.Charge
 			assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeExternal)
 			assert.NotNil(t, charge.Realizations.ExternalPaymentSettlement, "external payment settlement should be set")
 
@@ -539,8 +543,9 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchase() {
 		defer s.CreditPurchaseTestHandler.Reset()
 
 		// Then the authorized callback should be called, with a grant realization and no payment settlement
-		authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
-		s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, charge creditpurchase.Charge) {
+		authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
+		s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
+			charge := input.Charge
 			assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeInvoice)
 			assert.NotNil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should be set")
 			assert.Equal(t, initatedTrnsID, charge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
@@ -609,12 +614,13 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchase() {
 
 	s.Run("settled", func() {
 		defer s.CreditPurchaseTestHandler.Reset()
-		authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
+		authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
 		s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T())
 
 		// Then the settled callback should be called, with a grant realization and a payment settlement
-		settledCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
-		s.CreditPurchaseTestHandler.onCreditPurchasePaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, charge creditpurchase.Charge) {
+		settledCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
+		s.CreditPurchaseTestHandler.onCreditPurchasePaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
+			charge := input.Charge
 			assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeInvoice)
 			assert.NotNil(t, charge.Realizations.InvoiceSettlement, "invoice settlement should be set")
 

--- a/openmeter/billing/charges/service/handlers_test.go
+++ b/openmeter/billing/charges/service/handlers_test.go
@@ -87,8 +87,8 @@ var _ creditpurchase.Handler = (*creditPurchaseTestHandler)(nil)
 type creditPurchaseTestHandler struct {
 	onPromotionalCreditPurchase       func(ctx context.Context, charge creditpurchase.Charge) (ledgertransaction.GroupReference, error)
 	onCreditPurchaseInitiated         func(ctx context.Context, charge creditpurchase.Charge) (ledgertransaction.GroupReference, error)
-	onCreditPurchasePaymentAuthorized func(ctx context.Context, charge creditpurchase.Charge) (ledgertransaction.GroupReference, error)
-	onCreditPurchasePaymentSettled    func(ctx context.Context, charge creditpurchase.Charge) (ledgertransaction.GroupReference, error)
+	onCreditPurchasePaymentAuthorized func(ctx context.Context, input creditpurchase.PaymentEventInput) (ledgertransaction.GroupReference, error)
+	onCreditPurchasePaymentSettled    func(ctx context.Context, input creditpurchase.PaymentEventInput) (ledgertransaction.GroupReference, error)
 }
 
 func newCreditPurchaseTestHandler() *creditPurchaseTestHandler {
@@ -111,20 +111,20 @@ func (h *creditPurchaseTestHandler) OnCreditPurchaseInitiated(ctx context.Contex
 	return h.onCreditPurchaseInitiated(ctx, charge)
 }
 
-func (h *creditPurchaseTestHandler) OnCreditPurchasePaymentAuthorized(ctx context.Context, charge creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+func (h *creditPurchaseTestHandler) OnCreditPurchasePaymentAuthorized(ctx context.Context, input creditpurchase.PaymentEventInput) (ledgertransaction.GroupReference, error) {
 	if h.onCreditPurchasePaymentAuthorized == nil {
 		return ledgertransaction.GroupReference{}, errors.New("onCreditPurchasePaymentAuthorized is not set")
 	}
 
-	return h.onCreditPurchasePaymentAuthorized(ctx, charge)
+	return h.onCreditPurchasePaymentAuthorized(ctx, input)
 }
 
-func (h *creditPurchaseTestHandler) OnCreditPurchasePaymentSettled(ctx context.Context, charge creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+func (h *creditPurchaseTestHandler) OnCreditPurchasePaymentSettled(ctx context.Context, input creditpurchase.PaymentEventInput) (ledgertransaction.GroupReference, error) {
 	if h.onCreditPurchasePaymentSettled == nil {
 		return ledgertransaction.GroupReference{}, errors.New("onCreditPurchasePaymentSettled is not set")
 	}
 
-	return h.onCreditPurchasePaymentSettled(ctx, charge)
+	return h.onCreditPurchasePaymentSettled(ctx, input)
 }
 
 func (h *creditPurchaseTestHandler) Reset() {

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -1157,7 +1157,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycle() {
 		s.Len(startedCallbacks, 1)
 		s.Equal(float64(3), startedCallbacks[0].Input.AmountToAllocate.InexactFloat64())
 		s.Equal(usagebased.RealizationRunTypeFinalRealization, startedCallbacks[0].Input.Run.Type)
-		s.True(finalStoredAtLT.Equal(startedCallbacks[0].Input.AllocateAt))
+		s.True(servicePeriod.To.Equal(startedCallbacks[0].Input.BookedAt))
 	})
 
 	s.Run("#3.2 second realization advance is noop", func() {
@@ -1254,7 +1254,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycle() {
 		s.Len(finalizedCallbacks, 1)
 		s.Equal(float64(5), finalizedCallbacks[0].Input.AmountToAllocate.InexactFloat64())
 		s.Equal(usagebased.RealizationRunTypeFinalRealization, finalizedCallbacks[0].Input.Run.Type)
-		s.True(finalStoredAtLT.Equal(finalizedCallbacks[0].Input.AllocateAt))
+		s.True(servicePeriod.To.Equal(finalizedCallbacks[0].Input.BookedAt))
 	})
 
 	s.Run("#5 final charge advance is noop", func() {
@@ -1384,7 +1384,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTier
 			s.Equal(usageBasedChargeID.ID, input.Charge.ID)
 			s.Equal(productcatalog.CreditOnlySettlementMode, input.Charge.Intent.SettlementMode)
 			s.Equal(usagebased.RealizationRunTypeFinalRealization, input.Run.Type)
-			s.True(finalStoredAtLT.Equal(input.AllocateAt))
+			s.True(servicePeriod.To.Equal(input.BookedAt))
 			s.Equal(float64(20), input.AmountToAllocate.InexactFloat64())
 			s.Equal(float64(10), input.Run.MeteredQuantity.InexactFloat64())
 			s.RequireTotals(billingtest.ExpectedTotals{
@@ -1453,7 +1453,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTier
 			s.Equal(usageBasedChargeID.ID, input.Charge.ID)
 			s.Equal(productcatalog.CreditOnlySettlementMode, input.Charge.Intent.SettlementMode)
 			s.Equal(usagebased.RealizationRunTypeFinalRealization, input.Run.Type)
-			s.True(finalStoredAtLT.Equal(input.AllocateAt))
+			s.True(servicePeriod.To.Equal(input.BookedAt))
 			s.Equal(float64(10), input.Run.MeteredQuantity.InexactFloat64())
 			s.RequireTotals(billingtest.ExpectedTotals{
 				Amount:       20,
@@ -1502,7 +1502,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTier
 		s.Require().NotNil(advancedCharge)
 		s.Equal(meta.ChargeStatusFinal, meta.ChargeStatus(usageBasedFromDB.Status))
 		s.Len(correctedCallbacks, 1)
-		s.True(finalStoredAtLT.Equal(correctedCallbacks[0].Input.AllocateAt))
+		s.True(servicePeriod.To.Equal(correctedCallbacks[0].Input.BookedAt))
 		s.Len(correctedCallbacks[0].Input.Corrections, 1)
 		s.Equal(float64(-9), correctedCallbacks[0].Input.Corrections[0].Amount.InexactFloat64())
 

--- a/openmeter/billing/charges/service/taxcode_test.go
+++ b/openmeter/billing/charges/service/taxcode_test.go
@@ -424,9 +424,9 @@ func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementPropaga
 	_, err = s.BillingService.ApproveInvoice(ctx, invoiceID)
 	s.NoError(err)
 
-	authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
+	authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
 	s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T())
-	settledCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
+	settledCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
 	s.CreditPurchaseTestHandler.onCreditPurchasePaymentSettled = settledCallback.Handler(s.T())
 
 	_, err = s.CustomInvoicingService.HandlePaymentTrigger(ctx, appcustominvoicing.HandlePaymentTriggerInput{

--- a/openmeter/billing/charges/testutils/handlers.go
+++ b/openmeter/billing/charges/testutils/handlers.go
@@ -83,11 +83,11 @@ func (mockCreditPurchaseHandler) OnCreditPurchaseInitiated(context.Context, cred
 	return newMockLedgerTransactionGroupReference(), nil
 }
 
-func (mockCreditPurchaseHandler) OnCreditPurchasePaymentAuthorized(context.Context, creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+func (mockCreditPurchaseHandler) OnCreditPurchasePaymentAuthorized(context.Context, creditpurchase.PaymentEventInput) (ledgertransaction.GroupReference, error) {
 	return newMockLedgerTransactionGroupReference(), nil
 }
 
-func (mockCreditPurchaseHandler) OnCreditPurchasePaymentSettled(context.Context, creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+func (mockCreditPurchaseHandler) OnCreditPurchasePaymentSettled(context.Context, creditpurchase.PaymentEventInput) (ledgertransaction.GroupReference, error) {
 	return newMockLedgerTransactionGroupReference(), nil
 }
 

--- a/openmeter/billing/charges/usagebased/handler.go
+++ b/openmeter/billing/charges/usagebased/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/creditrealization"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -18,7 +19,7 @@ import (
 type CreditsOnlyUsageAccruedInput struct {
 	Charge           Charge                `json:"charge"`
 	Run              RealizationRun        `json:"run"`
-	AllocateAt       time.Time             `json:"allocateAt"`
+	BookedAt         time.Time             `json:"bookedAt"`
 	AmountToAllocate alpacadecimal.Decimal `json:"amountToAllocate"`
 }
 
@@ -33,8 +34,8 @@ func (i CreditsOnlyUsageAccruedInput) Validate() error {
 		errs = append(errs, fmt.Errorf("run: %w", err))
 	}
 
-	if i.AllocateAt.IsZero() {
-		errs = append(errs, fmt.Errorf("as of is required"))
+	if i.BookedAt.IsZero() {
+		errs = append(errs, fmt.Errorf("booked at is required"))
 	}
 
 	if !i.AmountToAllocate.IsPositive() {
@@ -45,18 +46,51 @@ func (i CreditsOnlyUsageAccruedInput) Validate() error {
 }
 
 type CreditsOnlyUsageAccruedCorrectionInput struct {
-	Charge     Charge         `json:"charge"`
-	Run        RealizationRun `json:"run"`
-	AllocateAt time.Time      `json:"allocateAt"`
+	Charge   Charge         `json:"charge"`
+	Run      RealizationRun `json:"run"`
+	BookedAt time.Time      `json:"bookedAt"`
 
 	Corrections                  creditrealization.CorrectionRequest   `json:"corrections"`
 	LineageSegmentsByRealization lineage.ActiveSegmentsByRealizationID `json:"-"`
+}
+
+func (i CreditsOnlyUsageAccruedCorrectionInput) Validate() error {
+	var errs []error
+
+	if err := i.Charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if err := i.Run.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("run: %w", err))
+	}
+
+	if i.BookedAt.IsZero() {
+		errs = append(errs, fmt.Errorf("booked at is required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func (i CreditsOnlyUsageAccruedCorrectionInput) ValidateWith(currencyCalculator currencyx.Calculator) error {
+	var errs []error
+
+	if err := i.Validate(); err != nil {
+		return err
+	}
+
+	if err := i.Corrections.ValidateWith(currencyCalculator); err != nil {
+		errs = append(errs, fmt.Errorf("corrections: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type OnInvoiceUsageAccruedInput struct {
 	Charge        Charge                `json:"charge"`
 	Run           RealizationRun        `json:"run"`
 	ServicePeriod timeutil.ClosedPeriod `json:"servicePeriod"`
+	BookedAt      time.Time             `json:"bookedAt"`
 	Amount        alpacadecimal.Decimal `json:"amount"`
 }
 
@@ -75,6 +109,10 @@ func (i OnInvoiceUsageAccruedInput) Validate() error {
 		errs = append(errs, fmt.Errorf("service period: %w", err))
 	}
 
+	if i.BookedAt.IsZero() {
+		errs = append(errs, fmt.Errorf("booked at is required"))
+	}
+
 	if i.Amount.IsNegative() {
 		errs = append(errs, fmt.Errorf("amount cannot be negative"))
 	}
@@ -83,8 +121,9 @@ func (i OnInvoiceUsageAccruedInput) Validate() error {
 }
 
 type RunEventInput struct {
-	Charge Charge         `json:"charge"`
-	Run    RealizationRun `json:"run"`
+	Charge  Charge         `json:"charge"`
+	Run     RealizationRun `json:"run"`
+	EventAt time.Time      `json:"eventAt"`
 }
 
 func (i RunEventInput) Validate() error {
@@ -96,6 +135,10 @@ func (i RunEventInput) Validate() error {
 
 	if err := i.Run.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("run: %w", err))
+	}
+
+	if i.EventAt.IsZero() {
+		errs = append(errs, fmt.Errorf("event at is required"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -656,7 +656,7 @@ func (s *CreditThenInvoiceStateMachine) SnapshotInvoiceUsage(ctx context.Context
 	reconcileResult, err := s.Runs.ReconcileCredits(ctx, usagebasedrun.ReconcileCreditRealizationsInput{
 		Charge:             s.Charge,
 		Run:                currentRun,
-		AllocateAt:         storedAtLT,
+		AllocateAt:         currentRun.ServicePeriodTo,
 		TargetAmount:       currentTotals.Total,
 		CurrencyCalculator: s.CurrencyCalculator,
 		ExactAllocation:    false,

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -12,7 +12,6 @@ import (
 	usagebasedrating "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/rating"
 	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/statelessx"
 )
 
@@ -125,7 +124,7 @@ func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, policy meta.
 			if _, err := s.Runs.CorrectAllCredits(ctx, usagebasedrun.CorrectAllCreditRealizationsInput{
 				Charge:             s.Charge,
 				Run:                run,
-				AllocateAt:         clock.Now(),
+				AllocateAt:         run.ServicePeriodTo,
 				CurrencyCalculator: s.CurrencyCalculator,
 			}); err != nil {
 				return fmt.Errorf("correct credits for run %s: %w", run.ID.ID, err)
@@ -198,7 +197,7 @@ func (s *CreditsOnlyStateMachine) FinalizeRealizationRun(ctx context.Context) er
 	if _, err := s.Runs.ReconcileCredits(ctx, usagebasedrun.ReconcileCreditRealizationsInput{
 		Charge:             s.Charge,
 		Run:                currentRun,
-		AllocateAt:         storedAtLT,
+		AllocateAt:         currentRun.ServicePeriodTo,
 		TargetAmount:       targetCreditsTotal,
 		CurrencyCalculator: s.CurrencyCalculator,
 		ExactAllocation:    true,

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -281,7 +281,7 @@ func (e *LineEngine) OnMutableStandardLinesDeleted(ctx context.Context, input bi
 		if _, err := e.service.runs.CorrectAllCredits(ctx, usagebasedrun.CorrectAllCreditRealizationsInput{
 			Charge:             charge,
 			Run:                run,
-			AllocateAt:         stdLine.GetServicePeriod().To,
+			AllocateAt:         run.ServicePeriodTo,
 			CurrencyCalculator: currencyCalculator,
 		}); err != nil {
 			return fmt.Errorf("correcting credits for deleted usage based standard line[%s] run[%s]: %w", stdLine.ID, run.ID.ID, err)

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -281,7 +281,7 @@ func (e *LineEngine) OnMutableStandardLinesDeleted(ctx context.Context, input bi
 		if _, err := e.service.runs.CorrectAllCredits(ctx, usagebasedrun.CorrectAllCreditRealizationsInput{
 			Charge:             charge,
 			Run:                run,
-			AllocateAt:         now,
+			AllocateAt:         stdLine.GetServicePeriod().To,
 			CurrencyCalculator: currencyCalculator,
 		}); err != nil {
 			return fmt.Errorf("correcting credits for deleted usage based standard line[%s] run[%s]: %w", stdLine.ID, run.ID.ID, err)

--- a/openmeter/billing/charges/usagebased/service/run/correct.go
+++ b/openmeter/billing/charges/usagebased/service/run/correct.go
@@ -108,7 +108,7 @@ func (s *Service) ReconcileCredits(ctx context.Context, in ReconcileCreditRealiz
 				return s.handler.OnCreditsOnlyUsageAccruedCorrection(ctx, usagebased.CreditsOnlyUsageAccruedCorrectionInput{
 					Charge:                       in.Charge,
 					Run:                          in.Run,
-					AllocateAt:                   in.AllocateAt,
+					BookedAt:                     in.AllocateAt,
 					Corrections:                  req,
 					LineageSegmentsByRealization: lineageSegmentsByRealization,
 				})
@@ -180,7 +180,7 @@ func (s *Service) CorrectAllCredits(ctx context.Context, in CorrectAllCreditReal
 		return s.handler.OnCreditsOnlyUsageAccruedCorrection(ctx, usagebased.CreditsOnlyUsageAccruedCorrectionInput{
 			Charge:                       in.Charge,
 			Run:                          in.Run,
-			AllocateAt:                   in.AllocateAt,
+			BookedAt:                     in.AllocateAt,
 			Corrections:                  req,
 			LineageSegmentsByRealization: lineageSegmentsByRealization,
 		})

--- a/openmeter/billing/charges/usagebased/service/run/create.go
+++ b/openmeter/billing/charges/usagebased/service/run/create.go
@@ -180,7 +180,7 @@ func (s *Service) CreateRatedRun(ctx context.Context, in CreateRatedRunInput) (C
 		allocationResult, err := s.allocate(ctx, allocateCreditRealizationsInput{
 			Charge:             updatedCharge,
 			Run:                currentRun,
-			AllocateAt:         in.StoredAtLT,
+			AllocateAt:         in.ServicePeriodTo,
 			AmountToAllocate:   runTotals.Total,
 			CurrencyCalculator: in.CurrencyCalculator,
 			Exact:              in.CreditAllocation == CreditAllocationExact,

--- a/openmeter/billing/charges/usagebased/service/run/credits.go
+++ b/openmeter/billing/charges/usagebased/service/run/credits.go
@@ -92,7 +92,7 @@ func (s *Service) allocate(ctx context.Context, in allocateCreditRealizationsInp
 	creditAllocations, err := s.handler.OnCreditsOnlyUsageAccrued(ctx, usagebased.CreditsOnlyUsageAccruedInput{
 		Charge:           in.Charge,
 		Run:              in.Run,
-		AllocateAt:       in.AllocateAt,
+		BookedAt:         in.AllocateAt,
 		AmountToAllocate: in.AmountToAllocate,
 	})
 	if err != nil {

--- a/openmeter/billing/charges/usagebased/service/run/invoice.go
+++ b/openmeter/billing/charges/usagebased/service/run/invoice.go
@@ -82,6 +82,7 @@ func (s *Service) BookAccruedInvoiceUsage(ctx context.Context, in BookAccruedInv
 		Charge:        in.Charge,
 		Run:           in.Run,
 		ServicePeriod: in.Line.Period,
+		BookedAt:      in.Line.Period.To,
 		Amount:        in.Line.Totals.Total,
 	}
 

--- a/openmeter/billing/charges/usagebased/service/run/payment.go
+++ b/openmeter/billing/charges/usagebased/service/run/payment.go
@@ -66,9 +66,11 @@ func (s *Service) BookInvoicedPaymentAuthorized(ctx context.Context, in BookInvo
 		}, nil
 	}
 
+	eventAt := clock.Now()
 	input := usagebased.OnPaymentAuthorizedInput{
-		Charge: in.Charge,
-		Run:    in.Run,
+		Charge:  in.Charge,
+		Run:     in.Run,
+		EventAt: eventAt,
 	}
 	if err := input.Validate(); err != nil {
 		return BookInvoicedPaymentAuthorizedResult{}, fmt.Errorf("validate on payment authorized input: %w", err)
@@ -90,7 +92,7 @@ func (s *Service) BookInvoicedPaymentAuthorized(ctx context.Context, in BookInvo
 				GroupReference: ledgertransaction.GroupReference{
 					TransactionGroupID: ledgerTransactionRef.TransactionGroupID,
 				},
-				Time: clock.Now(),
+				Time: eventAt,
 			},
 			Status: payment.StatusAuthorized,
 		},
@@ -174,9 +176,11 @@ func (s *Service) SettleInvoicedPayment(ctx context.Context, in SettleInvoicedPa
 		}, nil
 	}
 
+	eventAt := clock.Now()
 	input := usagebased.OnPaymentSettledInput{
-		Charge: in.Charge,
-		Run:    in.Run,
+		Charge:  in.Charge,
+		Run:     in.Run,
+		EventAt: eventAt,
 	}
 	if err := input.Validate(); err != nil {
 		return SettleInvoicedPaymentResult{}, fmt.Errorf("validate on payment settled input: %w", err)
@@ -192,7 +196,7 @@ func (s *Service) SettleInvoicedPayment(ctx context.Context, in SettleInvoicedPa
 		GroupReference: ledgertransaction.GroupReference{
 			TransactionGroupID: ledgerTransactionRef.TransactionGroupID,
 		},
-		Time: clock.Now(),
+		Time: eventAt,
 	}
 	paymentRealization.Status = payment.StatusSettled
 

--- a/openmeter/billing/worker/subscriptionsync/service/base_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/base_test.go
@@ -606,9 +606,26 @@ func (s *SuiteBase) assertChargeRealizationLedgerTransactions(ctx context.Contex
 	s.T().Helper()
 
 	s.Require().False(expectedRealization.BookedAt.IsZero(), "%s: realization booked_at", childID)
+	if len(actualRealization.LedgerTransactionGroups) == 0 {
+		s.Require().False(expectedChargeRealizationRequiresLedgerTransactionGroups(expectedRealization), "%s: realization ledger transaction groups", childID)
+		return
+	}
 
 	for _, transactionGroup := range actualRealization.LedgerTransactionGroups {
 		s.assertLedgerTransactionGroupBookedAt(ctx, namespace, transactionGroup.ID, expectedRealization.BookedAt, fmt.Sprintf("%s: %s", childID, transactionGroup.Label))
+	}
+}
+
+func expectedChargeRealizationRequiresLedgerTransactionGroups(expectedRealization expectedChargeRealization) bool {
+	if expectedRealization.Totals.IsZero() {
+		return false
+	}
+
+	switch expectedRealization.Status.ShortStatus() {
+	case "draft", "gathering", "delete":
+		return false
+	default:
+		return true
 	}
 }
 

--- a/openmeter/billing/worker/subscriptionsync/service/base_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/base_test.go
@@ -17,12 +17,16 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	chargepayment "github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	chargestestutils "github.com/openmeterio/openmeter/openmeter/billing/charges/testutils"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/adapter"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
@@ -46,6 +50,7 @@ type SuiteBase struct {
 	Service *Service
 	Adapter subscriptionsync.Adapter
 	Charges charges.Service
+	Ledger  ledger.Ledger
 
 	Namespace               string
 	Customer                *customer.Customer
@@ -382,6 +387,7 @@ type expectedChargeRealization struct {
 	Period      timeutil.ClosedPeriod
 	Status      billing.StandardInvoiceStatus
 	IsVoided    bool
+	BookedAt    time.Time
 	Price       *productcatalog.Price
 	Totals      totals.Totals
 }
@@ -396,6 +402,11 @@ type chargeRealizationKey struct {
 	Period   timeutil.ClosedPeriod
 	Status   billing.StandardInvoiceStatus
 	IsVoided bool
+}
+
+type actualChargeLedgerTransactionGroup struct {
+	ID    string
+	Label string
 }
 
 func (s *SuiteBase) assertCharges(ctx context.Context, subsView subscription.SubscriptionView, expectedCharges []expectedCharge) {
@@ -540,6 +551,7 @@ func (s *SuiteBase) assertCharge(ctx context.Context, charge charges.Charge, sub
 		s.Failf("unsupported charge type", "charge %s has unsupported type %s", chargeID.ID, charge.Type())
 	}
 
+	s.assertChargePaymentLedgerTransactions(ctx, charge, childID)
 	s.assertChargeGatheringLines(ctx, charge, subsView.Subscription.ID, childID, expectedChargeIDs, expectedCharge.Periods[idx], expectedCharge.Price, expectedCharge.GatheringLines)
 
 	expectedRealizations := s.expectedRealizationsForCharge(subsView.Subscription.ID, childID, expectedChargeIDs, expectedCharge.Periods[idx], expectedCharge.Realizations)
@@ -585,6 +597,91 @@ func (s *SuiteBase) assertCharge(ctx context.Context, charge charges.Charge, sub
 		if !expectedRealization.Totals.IsZero() {
 			s.Truef(expectedRealization.Totals.Equal(actualRealization.Totals), "%s: realization totals expected %v, got %v", childID, expectedRealization.Totals, actualRealization.Totals)
 		}
+
+		s.assertChargeRealizationLedgerTransactions(ctx, chargeID.Namespace, childID, expectedRealization, actualRealization)
+	}
+}
+
+func (s *SuiteBase) assertChargeRealizationLedgerTransactions(ctx context.Context, namespace string, childID string, expectedRealization expectedChargeRealization, actualRealization actualChargeRealization) {
+	s.T().Helper()
+
+	s.Require().False(expectedRealization.BookedAt.IsZero(), "%s: realization booked_at", childID)
+
+	for _, transactionGroup := range actualRealization.LedgerTransactionGroups {
+		s.assertLedgerTransactionGroupBookedAt(ctx, namespace, transactionGroup.ID, expectedRealization.BookedAt, fmt.Sprintf("%s: %s", childID, transactionGroup.Label))
+	}
+}
+
+func (s *SuiteBase) assertChargePaymentLedgerTransactions(ctx context.Context, charge charges.Charge, childID string) {
+	s.T().Helper()
+
+	chargeID, err := charge.GetChargeID()
+	s.NoError(err)
+
+	switch charge.Type() {
+	case chargesmeta.ChargeTypeFlatFee:
+		flatFeeCharge, err := charge.AsFlatFeeCharge()
+		s.NoError(err)
+
+		runs := slices.Clone(flatFeeCharge.Realizations.PriorRuns)
+		if flatFeeCharge.Realizations.CurrentRun != nil {
+			runs = append(runs, *flatFeeCharge.Realizations.CurrentRun)
+		}
+
+		for _, run := range runs {
+			s.assertPaymentLedgerTransactions(ctx, chargeID.Namespace, childID, run.Payment)
+		}
+	case chargesmeta.ChargeTypeUsageBased:
+		usageBasedCharge, err := charge.AsUsageBasedCharge()
+		s.NoError(err)
+
+		for _, run := range usageBasedCharge.Realizations {
+			s.assertPaymentLedgerTransactions(ctx, chargeID.Namespace, childID, run.Payment)
+		}
+	}
+}
+
+func (s *SuiteBase) assertPaymentLedgerTransactions(ctx context.Context, namespace string, childID string, payment *chargepayment.Invoiced) {
+	s.T().Helper()
+
+	if payment == nil {
+		return
+	}
+
+	if payment.Authorized != nil && payment.Authorized.TransactionGroupID != "" {
+		s.assertLedgerTransactionGroupBookedAt(ctx, namespace, payment.Authorized.TransactionGroupID, payment.Authorized.Time, fmt.Sprintf("%s: payment authorization", childID))
+	}
+	if payment.Settled != nil && payment.Settled.TransactionGroupID != "" {
+		s.assertLedgerTransactionGroupBookedAt(ctx, namespace, payment.Settled.TransactionGroupID, payment.Settled.Time, fmt.Sprintf("%s: payment settlement", childID))
+	}
+}
+
+func (s *SuiteBase) assertLedgerTransactionGroupBookedAt(ctx context.Context, namespace string, groupID string, expectedBookedAt time.Time, label string) {
+	s.T().Helper()
+
+	s.Require().NotEmpty(groupID, "%s: ledger transaction group id", label)
+	s.Require().False(expectedBookedAt.IsZero(), "%s: expected booked_at", label)
+	s.Require().NotNil(s.Ledger, "%s: ledger service", label)
+
+	group, err := s.Ledger.GetTransactionGroup(ctx, models.NamespacedID{
+		Namespace: namespace,
+		ID:        groupID,
+	})
+	s.NoError(err, "%s: get ledger transaction group %s", label, groupID)
+
+	transactions := group.Transactions()
+	s.Require().NotEmpty(transactions, "%s: ledger transaction group %s transactions", label, groupID)
+
+	for _, transaction := range transactions {
+		s.Truef(
+			transaction.BookedAt().UTC().Equal(expectedBookedAt.UTC()),
+			"%s: transaction %s in group %s booked_at expected %s, got %s",
+			label,
+			transaction.ID().ID,
+			groupID,
+			expectedBookedAt.UTC(),
+			transaction.BookedAt().UTC(),
+		)
 	}
 }
 
@@ -724,6 +821,7 @@ func (s *SuiteBase) chargeRealizations(ctx context.Context, charge charges.Charg
 				ID:        *run.InvoiceID,
 			}, *run.LineID)
 			realization.IsVoided = run.IsVoidedBillingHistory()
+			realization.LedgerTransactionGroups = s.usageBasedRunLedgerTransactionGroups(run)
 
 			out = append(out, realization)
 		}
@@ -749,6 +847,7 @@ func (s *SuiteBase) chargeRealizations(ctx context.Context, charge charges.Charg
 				ID:        *run.InvoiceID,
 			}, *run.LineID)
 			realization.IsVoided = run.IsVoidedBillingHistory()
+			realization.LedgerTransactionGroups = s.flatFeeRunLedgerTransactionGroups(run)
 
 			out = append(out, realization)
 		}
@@ -757,12 +856,61 @@ func (s *SuiteBase) chargeRealizations(ctx context.Context, charge charges.Charg
 	return out
 }
 
+func (s *SuiteBase) usageBasedRunLedgerTransactionGroups(run usagebased.RealizationRun) []actualChargeLedgerTransactionGroup {
+	s.T().Helper()
+
+	out := make([]actualChargeLedgerTransactionGroup, 0, len(run.CreditsAllocated)+1)
+	for _, realization := range run.CreditsAllocated {
+		if realization.LedgerTransaction.TransactionGroupID == "" {
+			continue
+		}
+
+		out = append(out, actualChargeLedgerTransactionGroup{
+			ID:    realization.LedgerTransaction.TransactionGroupID,
+			Label: fmt.Sprintf("usage-based credit realization %s", realization.ID),
+		})
+	}
+	if run.InvoiceUsage != nil && run.InvoiceUsage.LedgerTransaction != nil && run.InvoiceUsage.LedgerTransaction.TransactionGroupID != "" {
+		out = append(out, actualChargeLedgerTransactionGroup{
+			ID:    run.InvoiceUsage.LedgerTransaction.TransactionGroupID,
+			Label: fmt.Sprintf("usage-based invoice usage %s", run.InvoiceUsage.ID),
+		})
+	}
+
+	return out
+}
+
+func (s *SuiteBase) flatFeeRunLedgerTransactionGroups(run flatfee.RealizationRun) []actualChargeLedgerTransactionGroup {
+	s.T().Helper()
+
+	out := make([]actualChargeLedgerTransactionGroup, 0, len(run.CreditRealizations)+1)
+	for _, realization := range run.CreditRealizations {
+		if realization.LedgerTransaction.TransactionGroupID == "" {
+			continue
+		}
+
+		out = append(out, actualChargeLedgerTransactionGroup{
+			ID:    realization.LedgerTransaction.TransactionGroupID,
+			Label: fmt.Sprintf("flat fee credit realization %s", realization.ID),
+		})
+	}
+	if run.AccruedUsage != nil && run.AccruedUsage.LedgerTransaction != nil && run.AccruedUsage.LedgerTransaction.TransactionGroupID != "" {
+		out = append(out, actualChargeLedgerTransactionGroup{
+			ID:    run.AccruedUsage.LedgerTransaction.TransactionGroupID,
+			Label: fmt.Sprintf("flat fee accrued usage %s", run.AccruedUsage.ID),
+		})
+	}
+
+	return out
+}
+
 type actualChargeRealization struct {
-	Period   timeutil.ClosedPeriod
-	Status   billing.StandardInvoiceStatus
-	IsVoided bool
-	Price    *productcatalog.Price
-	Totals   totals.Totals
+	Period                  timeutil.ClosedPeriod
+	Status                  billing.StandardInvoiceStatus
+	IsVoided                bool
+	Price                   *productcatalog.Price
+	Totals                  totals.Totals
+	LedgerTransactionGroups []actualChargeLedgerTransactionGroup
 }
 
 func (s *SuiteBase) standardLineChargeRealization(ctx context.Context, invoiceID billing.InvoiceID, lineID string) actualChargeRealization {

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -68,6 +68,7 @@ func (s *CreditThenInvoiceTestSuite) SetupSuite() {
 
 	s.BalanceQuerier = ledgerDeps.HistoricalLedger
 	s.LedgerResolver = ledgerDeps.ResolversService
+	s.Ledger = ledgerDeps.HistoricalLedger
 
 	transactionManager := enttx.NewCreator(s.DBClient)
 
@@ -266,6 +267,9 @@ func (s *CreditThenInvoiceTestSuite) TestSubscriptionHappyPath() {
 
 	s.NoError(err)
 	s.NotNil(subsView)
+
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.SetTime(start.Add(time.Minute))
 
 	freeTierPhase := s.getPhaseByKey(s.T(), subsView, "free-trial")
 	s.Equal(lo.ToPtr(datetime.MustParseDuration(s.T(), "P1M")), freeTierPhase.ItemsByKey[s.APIRequestsTotalFeature.Key][0].Spec.RateCard.GetBillingCadence())
@@ -739,6 +743,9 @@ func (s *CreditThenInvoiceTestSuite) TestInArrearsProratingGathering() {
 	s.NoError(err)
 	s.NotNil(subsView)
 
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.SetTime(start.Add(time.Minute))
+
 	// let's provision the first set of items
 	s.Run("provision first set of items", func() {
 		s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
@@ -893,6 +900,9 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncNonBillableAmount
 			},
 		},
 	})
+
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(start.Add(time.Minute))
 
 	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
@@ -1092,6 +1102,9 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncNonBillableAmount
 	}
 
 	subsView := s.createSubscriptionFromPlan(planInput)
+
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(start.Add(time.Minute))
 
 	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
@@ -1295,6 +1308,9 @@ func (s *CreditThenInvoiceTestSuite) TestInArrearsGatheringSyncNonBillableAmount
 
 	subsView := s.createSubscriptionFromPlan(planInput)
 
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(start.Add(time.Minute))
+
 	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
 	s.assertCreditThenInvoiceBalances(startBalances)
@@ -1450,6 +1466,9 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncBillableAmountPro
 			},
 		},
 	})
+
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(start.Add(time.Minute))
 
 	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.DebugDumpInvoice("gathering invoice", s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID))
@@ -1670,6 +1689,9 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncDraftInvoiceProra
 				},
 			},
 		})
+
+		// Simulate async subscription sync running shortly after subscription creation.
+		clock.FreezeTime(start.Add(time.Minute))
 	})
 
 	s.Run("create gathering invoice", func() {
@@ -1723,7 +1745,8 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncDraftInvoiceProra
 				InvoiceAt: []*time.Time{lo.ToPtr(s.mustParseTime("2024-01-01T00:00:00Z"))},
 				Realizations: []expectedChargeRealization{
 					{
-						Status: draftInvoice.Status,
+						Status:   draftInvoice.Status,
+						BookedAt: s.mustParseTime("2024-01-01T00:00:00Z"),
 						Totals: totals.Totals{
 							Amount:       alpacadecimal.NewFromFloat(6),
 							CreditsTotal: alpacadecimal.NewFromFloat(2),
@@ -1813,7 +1836,8 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncDraftInvoiceProra
 				InvoiceAt: []*time.Time{lo.ToPtr(s.mustParseTime("2024-01-01T00:00:00Z"))},
 				Realizations: []expectedChargeRealization{
 					{
-						Status: draftInvoice.Status,
+						Status:   draftInvoice.Status,
+						BookedAt: s.mustParseTime("2024-01-01T00:00:00Z"),
 						Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
 							Amount:      alpacadecimal.NewFromFloat(0.19), // 6 * 1 / 31
 							PaymentTerm: productcatalog.InAdvancePaymentTerm,
@@ -1942,7 +1966,8 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncDraftInvoiceProra
 				InvoiceAt: []*time.Time{lo.ToPtr(s.mustParseTime("2024-01-01T00:00:00Z"))},
 				Realizations: []expectedChargeRealization{
 					{
-						Status: draftInvoice.Status,
+						Status:   draftInvoice.Status,
+						BookedAt: s.mustParseTime("2024-01-01T00:00:00Z"),
 						Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
 							Amount:      alpacadecimal.NewFromFloat(0.19), // 6 * 1 / 31
 							PaymentTerm: productcatalog.InAdvancePaymentTerm,
@@ -2113,6 +2138,9 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePror
 				},
 			},
 		})
+
+		// Simulate async subscription sync running shortly after subscription creation.
+		clock.FreezeTime(start.Add(time.Minute))
 	})
 
 	s.Run("create gathering invoice", func() {
@@ -2202,7 +2230,8 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePror
 				InvoiceAt: []*time.Time{lo.ToPtr(s.mustParseTime("2024-01-01T00:00:00Z"))},
 				Realizations: []expectedChargeRealization{
 					{
-						Status: approvedInvoice.Status,
+						Status:   approvedInvoice.Status,
+						BookedAt: s.mustParseTime("2024-01-01T00:00:00Z"),
 						Totals: totals.Totals{
 							Amount:       alpacadecimal.NewFromFloat(6),
 							CreditsTotal: alpacadecimal.NewFromFloat(2),
@@ -2302,6 +2331,7 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceGatheringSyncIssuedInvoicePror
 						},
 						Status:   billing.StandardInvoiceStatusPaid,
 						IsVoided: true,
+						BookedAt: s.mustParseTime("2024-01-01T00:00:00Z"),
 						Totals: totals.Totals{
 							Amount:       alpacadecimal.NewFromFloat(6),
 							CreditsTotal: alpacadecimal.NewFromFloat(2),
@@ -2483,6 +2513,9 @@ func (s *CreditThenInvoiceTestSuite) TestDefactoZeroPrices() {
 		// then:
 		// - creating the subscription does not affect ledger balances
 		s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
+
+		// Simulate async subscription sync running shortly after subscription creation.
+		clock.FreezeTime(clock.Now().Add(time.Minute))
 	})
 
 	// Now let's synchronize the subscription
@@ -2591,6 +2624,9 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionInvoicing() {
 			},
 		},
 	})
+
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(start.Add(time.Minute))
 
 	// Let's advance a day and make some edits
 	clock.FreezeTime(s.mustParseTime("2024-01-02T00:00:00Z"))
@@ -2938,7 +2974,7 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionCancellation() {
 		},
 	})
 
-	// Let's advane the clock a minute
+	// Simulate async subscription sync running shortly after subscription creation.
 	clock.FreezeTime(clock.Now().Add(time.Minute))
 
 	// Let's synchronize the subscription until well into the second phase
@@ -3115,8 +3151,11 @@ func (s *CreditThenInvoiceTestSuite) TestAlignedSubscriptionProgressiveBillingCa
 		},
 	})
 
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(startTime.Add(time.Minute))
+
 	// Let's synchronize the subscription
-	s.NoError(s.Service.SyncByView(ctx, subView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing)
+	s.NoError(s.Service.SyncByView(ctx, subView, clock.Now()))
 
 	// Let's check the invoice
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -3284,6 +3323,9 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceOneTimeFeeSyncing() {
 	})
 	s.assertCreditThenInvoiceBalances(startBalances)
 
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(start.Add(time.Minute))
+
 	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
@@ -3415,6 +3457,9 @@ func (s *CreditThenInvoiceTestSuite) TestInArrearsOneTimeFeeSyncing() {
 	s.NotNil(subsView)
 	s.assertCreditThenInvoiceBalances(startBalances)
 
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(start.Add(time.Minute))
+
 	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.assertCreditThenInvoiceBalances(startBalances)
@@ -3517,6 +3562,9 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
 			},
 		},
 	})
+
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(clock.Now().Add(time.Minute))
 
 	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
@@ -3723,6 +3771,9 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 		},
 	})
 
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(clock.Now().Add(time.Minute))
+
 	// we sync two months so we have lines on gathering
 	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
@@ -3815,7 +3866,8 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 			InvoiceAt: []*time.Time{lo.ToPtr(s.mustParseTime("2024-02-01T00:00:00Z"))},
 			Realizations: []expectedChargeRealization{
 				{
-					Status: draftInvoice.Status,
+					Status:   draftInvoice.Status,
+					BookedAt: s.mustParseTime("2024-02-01T00:00:00Z"),
 					Totals: totals.Totals{
 						Amount: alpacadecimal.NewFromFloat(110),
 						Total:  alpacadecimal.NewFromFloat(110),
@@ -4110,6 +4162,9 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateIssuedInvoice(
 		},
 	})
 
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(clock.Now().Add(time.Minute))
+
 	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 	s.assertCreditThenInvoiceBalances(startBalances)
 
@@ -4178,7 +4233,9 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateIssuedInvoice(
 	draftInvoice := draftInvoices[0]
 	s.Equal(billing.StandardInvoiceStatusDraftWaitingForCollection, draftInvoice.Status)
 
-	draftInvoice, err = s.BillingService.ForceCollectInvoice(ctx, draftInvoice.GetInvoiceID())
+	s.Require().NotNil(draftInvoice.CollectionAt)
+	clock.FreezeTime(draftInvoice.CollectionAt.Add(time.Minute))
+	draftInvoice, err = s.BillingService.AdvanceInvoice(ctx, draftInvoice.GetInvoiceID())
 	s.NoError(err)
 	s.Equal(billing.StandardInvoiceStatusDraftWaitingAutoApproval, draftInvoice.Status)
 	s.assertCreditThenInvoiceBalances(afterDraftInvoiceBalances)
@@ -4274,6 +4331,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateIssuedInvoice(
 					},
 					Status:   billing.StandardInvoiceStatusPaid,
 					IsVoided: true,
+					BookedAt: s.mustParseTime("2024-02-01T00:00:00Z"),
 				},
 			},
 		},
@@ -4448,6 +4506,9 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedUpdateWithLineSplits() {
 		},
 	})
 
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(clock.Now().Add(time.Minute))
+
 	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
 	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 
@@ -4520,7 +4581,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedUpdateWithLineSplits() {
 	s.Len(draftInvoices1, 1)
 
 	s.Require().NotNil(draftInvoices1[0].CollectionAt)
-	clock.FreezeTime(*draftInvoices1[0].CollectionAt)
+	clock.FreezeTime(draftInvoices1[0].CollectionAt.Add(time.Minute))
 	invoice1, err := s.BillingService.AdvanceInvoice(ctx, draftInvoices1[0].GetInvoiceID())
 	s.NoError(err)
 	s.Equal(billing.StandardInvoiceStatusDraftWaitingAutoApproval, invoice1.Status)
@@ -4567,7 +4628,8 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedUpdateWithLineSplits() {
 						From: s.mustParseTime("2024-01-01T00:00:00Z"),
 						To:   s.mustParseTime("2024-01-15T00:00:00Z"),
 					},
-					Status: billing.StandardInvoiceStatusPaid,
+					Status:   billing.StandardInvoiceStatusPaid,
+					BookedAt: s.mustParseTime("2024-01-15T00:00:00Z"),
 					Totals: totals.Totals{
 						Amount: alpacadecimal.NewFromFloat(20),
 						Total:  alpacadecimal.NewFromFloat(20),
@@ -4652,7 +4714,8 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedUpdateWithLineSplits() {
 						From: s.mustParseTime("2024-01-01T00:00:00Z"),
 						To:   s.mustParseTime("2024-01-15T00:00:00Z"),
 					},
-					Status: billing.StandardInvoiceStatusPaid,
+					Status:   billing.StandardInvoiceStatusPaid,
+					BookedAt: s.mustParseTime("2024-01-15T00:00:00Z"),
 					Totals: totals.Totals{
 						Amount: alpacadecimal.NewFromFloat(20),
 						Total:  alpacadecimal.NewFromFloat(20),
@@ -4663,7 +4726,8 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedUpdateWithLineSplits() {
 						From: s.mustParseTime("2024-01-15T00:00:00Z"),
 						To:   s.mustParseTime("2024-01-18T00:00:00Z"),
 					},
-					Status: billing.StandardInvoiceStatusDraftWaitingForCollection,
+					Status:   billing.StandardInvoiceStatusDraftWaitingForCollection,
+					BookedAt: s.mustParseTime("2024-01-18T00:00:00Z"),
 					Totals: totals.Totals{
 						Amount: alpacadecimal.NewFromFloat(30),
 						Total:  alpacadecimal.NewFromFloat(30),
@@ -4774,6 +4838,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedUpdateWithLineSplits() {
 					},
 					Status:   billing.StandardInvoiceStatusPaid,
 					IsVoided: true,
+					BookedAt: s.mustParseTime("2024-01-15T00:00:00Z"),
 					Totals: totals.Totals{
 						Amount: alpacadecimal.NewFromFloat(20),
 						Total:  alpacadecimal.NewFromFloat(20),
@@ -4941,6 +5006,9 @@ func (s *CreditThenInvoiceTestSuite) TestRateCardTaxSyncFlatFee() {
 				},
 			},
 		})
+
+		// Simulate async subscription sync running shortly after subscription creation.
+		clock.FreezeTime(clock.Now().Add(time.Minute))
 	})
 
 	s.Run("gathering invoice", func() {
@@ -5102,6 +5170,9 @@ func (s *CreditThenInvoiceTestSuite) TestRateCardTaxSyncUsageBased() {
 				},
 			},
 		})
+
+		// Simulate async subscription sync running shortly after subscription creation.
+		clock.FreezeTime(clock.Now().Add(time.Minute))
 	})
 
 	s.Run("gathering invoice", func() {
@@ -5174,7 +5245,8 @@ func (s *CreditThenInvoiceTestSuite) TestRateCardTaxSyncUsageBased() {
 		s.Require().NotEmpty(draftInvoices)
 
 		for idx, draftInvoice := range draftInvoices {
-			clock.FreezeTime(draftInvoice.DefaultCollectionAtForStandardInvoice())
+			s.Require().NotNil(draftInvoice.CollectionAt)
+			clock.FreezeTime(draftInvoice.CollectionAt.Add(time.Minute))
 			readyInvoice, err := s.BillingService.AdvanceInvoice(ctx, draftInvoice.GetInvoiceID())
 			s.NoError(err)
 			s.assertStandardLineTaxConfigs(readyInvoice.Lines.OrEmpty(), taxConfig)
@@ -5272,7 +5344,10 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceInstantBillingOnSubscriptionCr
 		},
 	})
 
-	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, s.mustParseTime("2024-01-01T00:00:00Z")))
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(start.Add(time.Minute))
+
+	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, start))
 	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{
 		FBOAll:             0,
 		FBOPromotional:     0,
@@ -5317,7 +5392,8 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceInstantBillingOnSubscriptionCr
 			},
 			Realizations: []expectedChargeRealization{
 				{
-					Status: instantInvoice.Status,
+					Status:   instantInvoice.Status,
+					BookedAt: s.mustParseTime("2024-01-01T00:00:00Z"),
 				},
 			},
 		},
@@ -5405,7 +5481,8 @@ func (s *CreditThenInvoiceTestSuite) TestInAdvanceInstantBillingOnSubscriptionCr
 		},
 	})
 
-	clock.FreezeTime(present) // This will be the present
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(present.Add(time.Minute)) // This will be the present
 
 	s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now()))
 	s.assertCreditThenInvoiceBalances(startBalances)
@@ -5547,6 +5624,9 @@ func (s *CreditThenInvoiceTestSuite) TestDiscountSynchronization() {
 			},
 		})
 		s.assertCreditThenInvoiceBalances(startBalances)
+
+		// Simulate async subscription sync running shortly after subscription creation.
+		clock.FreezeTime(start.Add(time.Minute))
 	})
 
 	s.Run("when syncing at subscription start", func() {
@@ -5556,7 +5636,7 @@ func (s *CreditThenInvoiceTestSuite) TestDiscountSynchronization() {
 		// - subscription sync runs just after the start timestamp
 		// then:
 		// - the in-advance fee is instant-invoiced and future charge lines are gathered
-		s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing, and we want both the instant invoice for in advance as well as the gathering for UBP)
+		s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now()))
 		s.assertCreditThenInvoiceBalances(startBalances)
 
 		invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
@@ -5668,7 +5748,8 @@ func (s *CreditThenInvoiceTestSuite) TestDiscountSynchronization() {
 				},
 				Realizations: []expectedChargeRealization{
 					{
-						Status: instantInvoice.Status,
+						Status:   instantInvoice.Status,
+						BookedAt: s.mustParseTime("2024-01-01T00:00:00Z"),
 					},
 				},
 			},
@@ -5785,6 +5866,9 @@ func (s *CreditThenInvoiceTestSuite) TestDiscountSynchronizationWithPartialDisco
 			},
 		})
 		s.assertCreditThenInvoiceBalances(startBalances)
+
+		// Simulate async subscription sync running shortly after subscription creation.
+		clock.FreezeTime(start.Add(time.Minute))
 	})
 
 	s.Run("when syncing at subscription start", func() {
@@ -5795,7 +5879,7 @@ func (s *CreditThenInvoiceTestSuite) TestDiscountSynchronizationWithPartialDisco
 		// then:
 		// - the payable part of the in-advance fee consumes promotional credits
 		// - future charge lines are gathered
-		s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now().Add(time.Minute))) // time is frozen to start time (syncing in arrears upto which would sync nothing, and we want both the instant invoice for in advance as well as the gathering for UBP)
+		s.NoError(s.Service.SyncByViewAndInvoiceCustomer(ctx, subsView, clock.Now()))
 		s.assertCreditThenInvoiceBalances(afterInstantInvoiceBalances)
 
 		invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
@@ -5907,7 +5991,8 @@ func (s *CreditThenInvoiceTestSuite) TestDiscountSynchronizationWithPartialDisco
 				},
 				Realizations: []expectedChargeRealization{
 					{
-						Status: instantInvoice.Status,
+						Status:   instantInvoice.Status,
+						BookedAt: s.mustParseTime("2024-01-01T00:00:00Z"),
 					},
 				},
 			},
@@ -6333,7 +6418,10 @@ func (s *CreditThenInvoiceTestSuite) TestSynchronizeSubscriptionPeriodAlgorithmC
 		},
 	})
 
-	s.NoError(s.Service.SyncByView(ctx, subsView, clock.Now()))
+	// Simulate async subscription sync running shortly after subscription creation.
+	clock.FreezeTime(clock.Now().Add(time.Minute))
+
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2025-01-31T00:00:00Z")))
 
 	invoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.DebugDumpInvoice("gathering invoice", invoice)
@@ -6598,7 +6686,8 @@ func (s *CreditThenInvoiceTestSuite) TestDeletedCustomerHandling() {
 			InvoiceAt: []*time.Time{lo.ToPtr(s.mustParseTime("2025-01-01T01:00:00Z"))},
 			Realizations: []expectedChargeRealization{
 				{
-					Status: invoice.Status,
+					Status:   invoice.Status,
+					BookedAt: s.mustParseTime("2025-01-01T01:00:00Z"),
 					Totals: totals.Totals{
 						Amount: alpacadecimal.NewFromFloat(60),
 						Total:  alpacadecimal.NewFromFloat(60),
@@ -7002,7 +7091,8 @@ func (s *CreditThenInvoiceTestSuite) TestSyncStateUpdateWithFreePhaseActiveInThe
 			},
 			Realizations: []expectedChargeRealization{
 				{
-					Status: billing.StandardInvoiceStatusDraftWaitingAutoApproval,
+					Status:   billing.StandardInvoiceStatusDraftWaitingAutoApproval,
+					BookedAt: s.mustParseTime("2025-12-15T00:00:00Z"),
 					Totals: totals.Totals{
 						Amount: alpacadecimal.NewFromFloat(5),
 						Total:  alpacadecimal.NewFromFloat(5),

--- a/openmeter/ledger/chargeadapter/bookedat_test.go
+++ b/openmeter/ledger/chargeadapter/bookedat_test.go
@@ -1,0 +1,20 @@
+package chargeadapter_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func requireLedgerBookedAtEqual(t *testing.T, expected, actual time.Time) {
+	t.Helper()
+
+	require.True(t, actual.UTC().Equal(expected.UTC().Truncate(time.Microsecond)))
+}
+
+func requireLedgerBookedAtNotEqual(t *testing.T, expected, actual time.Time) {
+	t.Helper()
+
+	require.False(t, actual.UTC().Equal(expected.UTC().Truncate(time.Microsecond)))
+}

--- a/openmeter/ledger/chargeadapter/bookedat_test.go
+++ b/openmeter/ledger/chargeadapter/bookedat_test.go
@@ -10,11 +10,15 @@ import (
 func requireLedgerBookedAtEqual(t *testing.T, expected, actual time.Time) {
 	t.Helper()
 
-	require.True(t, actual.UTC().Equal(expected.UTC().Truncate(time.Microsecond)))
+	expectedAt := expected.UTC().Truncate(time.Microsecond)
+	actualAt := actual.UTC().Truncate(time.Microsecond)
+	require.True(t, actualAt.Equal(expectedAt))
 }
 
 func requireLedgerBookedAtNotEqual(t *testing.T, expected, actual time.Time) {
 	t.Helper()
 
-	require.False(t, actual.UTC().Equal(expected.UTC().Truncate(time.Microsecond)))
+	expectedAt := expected.UTC().Truncate(time.Microsecond)
+	actualAt := actual.UTC().Truncate(time.Microsecond)
+	require.False(t, actualAt.Equal(expectedAt))
 }

--- a/openmeter/ledger/chargeadapter/creditpurchase.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase.go
@@ -62,10 +62,11 @@ func (h *creditPurchaseHandler) OnCreditPurchaseInitiated(ctx context.Context, c
 	return h.issueCreditPurchase(ctx, charge)
 }
 
-func (h *creditPurchaseHandler) OnCreditPurchasePaymentAuthorized(ctx context.Context, charge chargecreditpurchase.Charge) (ledgertransaction.GroupReference, error) {
-	if err := charge.Validate(); err != nil {
+func (h *creditPurchaseHandler) OnCreditPurchasePaymentAuthorized(ctx context.Context, input chargecreditpurchase.PaymentEventInput) (ledgertransaction.GroupReference, error) {
+	if err := input.Validate(); err != nil {
 		return ledgertransaction.GroupReference{}, err
 	}
+	charge := input.Charge
 
 	costBasis, err := charge.Intent.Settlement.GetCostBasis()
 	if err != nil {
@@ -86,7 +87,7 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentAuthorized(ctx context.Co
 			Namespace:  charge.Namespace,
 		},
 		transactions.AuthorizeCustomerReceivablePaymentTemplate{
-			At:        charge.CreatedAt,
+			At:        input.EventAt,
 			Amount:    charge.Intent.CreditAmount,
 			Currency:  charge.Intent.Currency,
 			CostBasis: &costBasis,
@@ -116,10 +117,11 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentAuthorized(ctx context.Co
 	}, nil
 }
 
-func (h *creditPurchaseHandler) OnCreditPurchasePaymentSettled(ctx context.Context, charge chargecreditpurchase.Charge) (ledgertransaction.GroupReference, error) {
-	if err := charge.Validate(); err != nil {
+func (h *creditPurchaseHandler) OnCreditPurchasePaymentSettled(ctx context.Context, input chargecreditpurchase.PaymentEventInput) (ledgertransaction.GroupReference, error) {
+	if err := input.Validate(); err != nil {
 		return ledgertransaction.GroupReference{}, err
 	}
+	charge := input.Charge
 
 	costBasis, err := charge.Intent.Settlement.GetCostBasis()
 	if err != nil {
@@ -140,7 +142,7 @@ func (h *creditPurchaseHandler) OnCreditPurchasePaymentSettled(ctx context.Conte
 			Namespace:  charge.Namespace,
 		},
 		transactions.SettleCustomerReceivableFromPaymentTemplate{
-			At:        charge.CreatedAt,
+			At:        input.EventAt,
 			Amount:    charge.Intent.CreditAmount,
 			Currency:  charge.Intent.Currency,
 			CostBasis: &costBasis,

--- a/openmeter/ledger/chargeadapter/creditpurchase_test.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase_test.go
@@ -238,8 +238,8 @@ func TestOnCreditPurchasePaymentAuthorized(t *testing.T) {
 	require.True(t, env.sumBalance(t, env.fboSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(100)))
 
 	for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
-		require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
-		require.False(t, bookedAt.UTC().Equal(charge.CreatedAt.UTC()))
+		requireLedgerBookedAtEqual(t, eventTime, bookedAt)
+		requireLedgerBookedAtNotEqual(t, charge.CreatedAt, bookedAt)
 	}
 
 	ref, err = env.handler.OnCreditPurchasePaymentAuthorized(t.Context(), chargecreditpurchase.PaymentEventInput{
@@ -284,8 +284,8 @@ func TestOnCreditPurchasePaymentSettled(t *testing.T) {
 	require.True(t, env.sumBalance(t, env.fboSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(100)))
 
 	for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
-		require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
-		require.False(t, bookedAt.UTC().Equal(charge.CreatedAt.UTC()))
+		requireLedgerBookedAtEqual(t, eventTime, bookedAt)
+		requireLedgerBookedAtNotEqual(t, charge.CreatedAt, bookedAt)
 	}
 }
 
@@ -326,8 +326,8 @@ func TestOnCreditPurchasePaymentSettled_BacksAdvanceBeforeTopUp(t *testing.T) {
 	require.True(t, env.sumBalance(t, env.fboSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(60)))
 
 	for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
-		require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
-		require.False(t, bookedAt.UTC().Equal(charge.CreatedAt.UTC()))
+		requireLedgerBookedAtEqual(t, eventTime, bookedAt)
+		requireLedgerBookedAtNotEqual(t, charge.CreatedAt, bookedAt)
 	}
 }
 

--- a/openmeter/ledger/chargeadapter/creditpurchase_test.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase_test.go
@@ -324,6 +324,11 @@ func TestOnCreditPurchasePaymentSettled_BacksAdvanceBeforeTopUp(t *testing.T) {
 	require.True(t, env.sumBalance(t, env.unknownAccruedSubAccount(t)).Equal(alpacadecimal.Zero))
 	require.True(t, env.sumBalance(t, env.accruedSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(40)))
 	require.True(t, env.sumBalance(t, env.fboSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(60)))
+
+	for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
+		require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
+		require.False(t, bookedAt.UTC().Equal(charge.CreatedAt.UTC()))
+	}
 }
 
 type creditPurchaseHandlerTestEnv struct {

--- a/openmeter/ledger/chargeadapter/creditpurchase_test.go
+++ b/openmeter/ledger/chargeadapter/creditpurchase_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ledger/chargeadapter"
 	ledgertestutils "github.com/openmeterio/openmeter/openmeter/ledger/testutils"
 	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -220,7 +221,14 @@ func TestOnCreditPurchasePaymentAuthorized(t *testing.T) {
 	_, err := env.handler.OnCreditPurchaseInitiated(t.Context(), charge)
 	require.NoError(t, err)
 
-	ref, err := env.handler.OnCreditPurchasePaymentAuthorized(t.Context(), charge)
+	eventTime := charge.CreatedAt.Add(15 * time.Minute)
+	clock.FreezeTime(eventTime)
+	defer clock.UnFreeze()
+
+	ref, err := env.handler.OnCreditPurchasePaymentAuthorized(t.Context(), chargecreditpurchase.PaymentEventInput{
+		Charge:  charge,
+		EventAt: eventTime,
+	})
 	require.NoError(t, err)
 	require.NotEmpty(t, ref.TransactionGroupID)
 
@@ -228,6 +236,18 @@ func TestOnCreditPurchasePaymentAuthorized(t *testing.T) {
 	require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(-100)))
 	require.True(t, env.sumBalance(t, env.washSubAccount(t, costBasis)).Equal(alpacadecimal.Zero))
 	require.True(t, env.sumBalance(t, env.fboSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(100)))
+
+	for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
+		require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
+		require.False(t, bookedAt.UTC().Equal(charge.CreatedAt.UTC()))
+	}
+
+	ref, err = env.handler.OnCreditPurchasePaymentAuthorized(t.Context(), chargecreditpurchase.PaymentEventInput{
+		Charge:  charge,
+		EventAt: time.Time{},
+	})
+	require.ErrorContains(t, err, "event at is required")
+	require.Empty(t, ref.TransactionGroupID)
 }
 
 func TestOnCreditPurchasePaymentSettled(t *testing.T) {
@@ -241,10 +261,20 @@ func TestOnCreditPurchasePaymentSettled(t *testing.T) {
 		transactions.TemplateCode(transactions.IssueCustomerReceivableTemplate{}),
 	}, env.transactionTemplateCodes(t, initRef.TransactionGroupID))
 
-	_, err = env.handler.OnCreditPurchasePaymentAuthorized(t.Context(), charge)
+	_, err = env.handler.OnCreditPurchasePaymentAuthorized(t.Context(), chargecreditpurchase.PaymentEventInput{
+		Charge:  charge,
+		EventAt: charge.CreatedAt.Add(15 * time.Minute),
+	})
 	require.NoError(t, err)
 
-	ref, err := env.handler.OnCreditPurchasePaymentSettled(t.Context(), charge)
+	eventTime := charge.CreatedAt.Add(30 * time.Minute)
+	clock.FreezeTime(eventTime)
+	defer clock.UnFreeze()
+
+	ref, err := env.handler.OnCreditPurchasePaymentSettled(t.Context(), chargecreditpurchase.PaymentEventInput{
+		Charge:  charge,
+		EventAt: eventTime,
+	})
 	require.NoError(t, err)
 	require.NotEmpty(t, ref.TransactionGroupID)
 
@@ -252,6 +282,11 @@ func TestOnCreditPurchasePaymentSettled(t *testing.T) {
 	require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t, costBasis)).Equal(alpacadecimal.Zero))
 	require.True(t, env.sumBalance(t, env.washSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(-100)))
 	require.True(t, env.sumBalance(t, env.fboSubAccount(t, costBasis)).Equal(alpacadecimal.NewFromInt(100)))
+
+	for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
+		require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
+		require.False(t, bookedAt.UTC().Equal(charge.CreatedAt.UTC()))
+	}
 }
 
 func TestOnCreditPurchasePaymentSettled_BacksAdvanceBeforeTopUp(t *testing.T) {
@@ -269,10 +304,17 @@ func TestOnCreditPurchasePaymentSettled_BacksAdvanceBeforeTopUp(t *testing.T) {
 		transactions.TemplateCode(transactions.IssueCustomerReceivableTemplate{}),
 	}, env.transactionTemplateCodes(t, initRef.TransactionGroupID))
 
-	_, err = env.handler.OnCreditPurchasePaymentAuthorized(t.Context(), charge)
+	_, err = env.handler.OnCreditPurchasePaymentAuthorized(t.Context(), chargecreditpurchase.PaymentEventInput{
+		Charge:  charge,
+		EventAt: charge.CreatedAt.Add(15 * time.Minute),
+	})
 	require.NoError(t, err)
 
-	ref, err := env.handler.OnCreditPurchasePaymentSettled(t.Context(), charge)
+	eventTime := charge.CreatedAt.Add(30 * time.Minute)
+	ref, err := env.handler.OnCreditPurchasePaymentSettled(t.Context(), chargecreditpurchase.PaymentEventInput{
+		Charge:  charge,
+		EventAt: eventTime,
+	})
 	require.NoError(t, err)
 	require.NotEmpty(t, ref.TransactionGroupID)
 
@@ -586,6 +628,30 @@ func (e *creditPurchaseHandlerTestEnv) transactionAnnotations(t *testing.T, grou
 	out := make([]models.Annotations, 0, len(transactions))
 	for _, tx := range transactions {
 		out = append(out, tx.Annotations)
+	}
+
+	return out
+}
+
+func (e *creditPurchaseHandlerTestEnv) transactionBookedAtTimes(t *testing.T, groupID string) []time.Time {
+	t.Helper()
+
+	transactions, err := e.DB.LedgerTransaction.Query().
+		Where(
+			ledgertransactiondb.Namespace(e.Namespace),
+			ledgertransactiondb.GroupID(groupID),
+		).
+		Order(
+			ledgertransactiondb.ByCreatedAt(),
+			ledgertransactiondb.ByID(),
+		).
+		All(t.Context())
+	require.NoError(t, err)
+	require.NotEmpty(t, transactions, "expected at least one ledger transaction for group")
+
+	out := make([]time.Time, 0, len(transactions))
+	for _, tx := range transactions {
+		out = append(out, tx.BookedAt)
 	}
 
 	return out

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/ledger/collector"
 	"github.com/openmeterio/openmeter/openmeter/ledger/transactions"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/pkg/clock"
 )
 
 // flatFeeHandler maps charge lifecycle events to ledger transaction templates
@@ -63,7 +62,7 @@ func (h *flatFeeHandler) OnAllocateCredits(ctx context.Context, input flatfee.On
 		ChargeID:          input.Charge.ID,
 		CustomerID:        input.Charge.Intent.CustomerID,
 		Annotations:       chargeAnnotationsForFlatFeeCharge(input.Charge),
-		BookedAt:          input.Charge.Intent.InvoiceAt,
+		BookedAt:          input.BookedAt,
 		SourceBalanceAsOf: input.Charge.Intent.InvoiceAt,
 		Currency:          input.Charge.Intent.Currency,
 		SettlementMode:    input.Charge.Intent.SettlementMode,
@@ -114,7 +113,7 @@ func (h *flatFeeHandler) OnInvoiceUsageAccrued(ctx context.Context, input flatfe
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.TransferCustomerReceivableToAccruedTemplate{
-			At:        input.Charge.Intent.InvoiceAt,
+			At:        input.BookedAt,
 			Amount:    amount,
 			Currency:  input.Charge.Intent.Currency,
 			CostBasis: invoiceCostBasis,
@@ -159,7 +158,7 @@ func (h *flatFeeHandler) OnCorrectCreditAllocations(ctx context.Context, input f
 		ChargeID:                     input.Charge.ID,
 		CustomerID:                   input.Charge.Intent.CustomerID,
 		Annotations:                  chargeAnnotationsForFlatFeeCharge(input.Charge),
-		AllocateAt:                   input.AllocateAt,
+		AllocateAt:                   input.BookedAt,
 		Corrections:                  input.Corrections,
 		LineageSegmentsByRealization: input.LineageSegmentsByRealization,
 	})
@@ -190,7 +189,7 @@ func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, input flatfee.
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.AuthorizeCustomerReceivablePaymentTemplate{
-			At:        clock.Now(),
+			At:        input.EventAt,
 			Amount:    input.Amount,
 			Currency:  input.Charge.Intent.Currency,
 			CostBasis: invoiceCostBasis,
@@ -243,7 +242,7 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, input flatfee.OnP
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.SettleCustomerReceivableFromPaymentTemplate{
-			At:        clock.Now(),
+			At:        input.EventAt,
 			Amount:    input.Amount,
 			Currency:  input.Charge.Intent.Currency,
 			CostBasis: invoiceCostBasis,

--- a/openmeter/ledger/chargeadapter/flatfee_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_test.go
@@ -50,6 +50,10 @@ func TestOnAllocateCredits(t *testing.T) {
 			ledger.ChargeAnnotations(models.NamespacedID{Namespace: env.Namespace, ID: input.Charge.ID}),
 			env.transactionGroupAnnotations(t, realizations[0].LedgerTransaction.TransactionGroupID),
 		)
+		for _, bookedAt := range env.transactionBookedAtTimes(t, realizations[0].LedgerTransaction.TransactionGroupID) {
+			require.True(t, bookedAt.UTC().Equal(input.ServicePeriod.From.UTC()))
+			require.False(t, bookedAt.UTC().Equal(input.Charge.Intent.InvoiceAt.UTC()))
+		}
 
 		require.True(t, env.sumBalance(t, priorityOne).Equal(alpacadecimal.NewFromInt(40)))
 		require.True(t, env.sumBalance(t, env.creditAccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(60)))
@@ -114,6 +118,36 @@ func TestOnAllocateCredits(t *testing.T) {
 		require.Len(t, realizations, 1)
 		require.True(t, realizations[0].Amount.Equal(alpacadecimal.NewFromInt(30)))
 	})
+
+	t.Run("booked at is required", func(t *testing.T) {
+		env := newFlatFeeHandlerTestEnv(t)
+
+		input := env.newAssignmentInput(alpacadecimal.NewFromInt(30))
+		input.BookedAt = time.Time{}
+
+		realizations, err := env.handler.OnAllocateCredits(t.Context(), input)
+		require.ErrorContains(t, err, "booked at is required")
+		require.Nil(t, realizations)
+	})
+
+	t.Run("in arrears books credit allocation at service period end", func(t *testing.T) {
+		env := newFlatFeeHandlerTestEnv(t)
+
+		env.fundPriority(t, 1, 30)
+		input := env.newAssignmentInput(alpacadecimal.NewFromInt(30))
+		input.Charge.Intent.PaymentTerm = productcatalog.InArrearsPaymentTerm
+		input.Charge.Intent.InvoiceAt = input.ServicePeriod.From
+		input.BookedAt = chargeflatfee.UsageBookedAt(input.Charge.Intent.PaymentTerm, input.ServicePeriod)
+
+		realizations, err := env.handler.OnAllocateCredits(t.Context(), input)
+		require.NoError(t, err)
+		require.Len(t, realizations, 1)
+
+		for _, bookedAt := range env.transactionBookedAtTimes(t, realizations[0].LedgerTransaction.TransactionGroupID) {
+			require.True(t, bookedAt.UTC().Equal(input.ServicePeriod.To.UTC()))
+			require.False(t, bookedAt.UTC().Equal(input.Charge.Intent.InvoiceAt.UTC()))
+		}
+	})
 }
 
 func TestOnAllocateCreditsCreditOnly(t *testing.T) {
@@ -165,7 +199,7 @@ func TestOnCorrectCreditAllocations(t *testing.T) {
 
 		corrections, err := env.handler.OnCorrectCreditAllocations(t.Context(), chargeflatfee.CorrectCreditAllocationsInput{
 			Charge:      chargeWithRealizations,
-			AllocateAt:  env.Now(),
+			BookedAt:    env.Now(),
 			Corrections: correctionsRequest,
 		})
 		require.NoError(t, err)
@@ -199,7 +233,7 @@ func TestOnCorrectCreditAllocations(t *testing.T) {
 
 		corrections, err := env.handler.OnCorrectCreditAllocations(t.Context(), chargeflatfee.CorrectCreditAllocationsInput{
 			Charge:      chargeWithRealizations,
-			AllocateAt:  env.Now(),
+			BookedAt:    env.Now(),
 			Corrections: correctionsRequest,
 		})
 		require.NoError(t, err)
@@ -231,7 +265,7 @@ func TestOnCorrectCreditAllocations(t *testing.T) {
 
 		corrections, err := env.handler.OnCorrectCreditAllocations(t.Context(), chargeflatfee.CorrectCreditAllocationsInput{
 			Charge:      chargeWithRealizations,
-			AllocateAt:  env.Now(),
+			BookedAt:    env.Now(),
 			Corrections: correctionsRequest,
 		})
 		require.NoError(t, err)
@@ -262,7 +296,7 @@ func TestOnCorrectCreditAllocations(t *testing.T) {
 
 		corrections, err := env.handler.OnCorrectCreditAllocations(t.Context(), chargeflatfee.CorrectCreditAllocationsInput{
 			Charge:      chargeWithRealizations,
-			AllocateAt:  env.Now(),
+			BookedAt:    env.Now(),
 			Corrections: correctionsRequest,
 		})
 		require.NoError(t, err)
@@ -296,7 +330,7 @@ func TestOnCorrectCreditAllocations(t *testing.T) {
 
 		corrections, err := env.handler.OnCorrectCreditAllocations(t.Context(), chargeflatfee.CorrectCreditAllocationsInput{
 			Charge:                       chargeWithRealizations,
-			AllocateAt:                   env.Now(),
+			BookedAt:                     env.Now(),
 			Corrections:                  correctionsRequest,
 			LineageSegmentsByRealization: env.assertRecognizedSegments(t, chargeWithRealizations.Realizations.CurrentRun.CreditRealizations, recognitionGroupID),
 		})
@@ -334,7 +368,7 @@ func TestOnCorrectCreditAllocations(t *testing.T) {
 
 		corrections, err := env.handler.OnCorrectCreditAllocations(t.Context(), chargeflatfee.CorrectCreditAllocationsInput{
 			Charge:                       chargeWithRealizations,
-			AllocateAt:                   env.Now(),
+			BookedAt:                     env.Now(),
 			Corrections:                  correctionsRequest,
 			LineageSegmentsByRealization: env.assertRecognizedSegments(t, chargeWithRealizations.Realizations.CurrentRun.CreditRealizations, recognitionGroupID),
 		})
@@ -361,11 +395,53 @@ func TestOnFlatFeeStandardInvoiceUsageAccrued(t *testing.T) {
 		require.True(t, env.sumBalance(t, env.invoiceAccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(50)))
 	})
 
+	t.Run("in advance books receivable-backed usage at service period start", func(t *testing.T) {
+		env := newFlatFeeHandlerTestEnv(t)
+
+		input := env.newAccrualInput(alpacadecimal.NewFromInt(50))
+		ref, err := env.handler.OnInvoiceUsageAccrued(t.Context(), input)
+		require.NoError(t, err)
+		require.NotEmpty(t, ref.TransactionGroupID)
+
+		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
+			require.True(t, bookedAt.UTC().Equal(input.ServicePeriod.From.UTC()))
+			require.False(t, bookedAt.UTC().Equal(input.Charge.Intent.InvoiceAt.UTC()))
+		}
+	})
+
+	t.Run("in arrears books receivable-backed usage at service period end", func(t *testing.T) {
+		env := newFlatFeeHandlerTestEnv(t)
+
+		input := env.newAccrualInput(alpacadecimal.NewFromInt(50))
+		input.Charge.Intent.PaymentTerm = productcatalog.InArrearsPaymentTerm
+		input.Charge.Intent.InvoiceAt = input.ServicePeriod.From
+		input.BookedAt = chargeflatfee.UsageBookedAt(input.Charge.Intent.PaymentTerm, input.ServicePeriod)
+		ref, err := env.handler.OnInvoiceUsageAccrued(t.Context(), input)
+		require.NoError(t, err)
+		require.NotEmpty(t, ref.TransactionGroupID)
+
+		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
+			require.True(t, bookedAt.UTC().Equal(input.ServicePeriod.To.UTC()))
+			require.False(t, bookedAt.UTC().Equal(input.Charge.Intent.InvoiceAt.UTC()))
+		}
+	})
+
 	t.Run("credit_then_invoice zero total returns empty reference", func(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 
 		ref, err := env.handler.OnInvoiceUsageAccrued(t.Context(), env.newAccrualInput(alpacadecimal.NewFromInt(0)))
 		require.NoError(t, err)
+		require.Empty(t, ref.TransactionGroupID)
+	})
+
+	t.Run("booked at is required", func(t *testing.T) {
+		env := newFlatFeeHandlerTestEnv(t)
+
+		input := env.newAccrualInput(alpacadecimal.NewFromInt(10))
+		input.BookedAt = time.Time{}
+
+		ref, err := env.handler.OnInvoiceUsageAccrued(t.Context(), input)
+		require.ErrorContains(t, err, "booked at is required")
 		require.Empty(t, ref.TransactionGroupID)
 	})
 
@@ -495,6 +571,17 @@ func TestOnFlatFeePaymentAuthorized(t *testing.T) {
 		require.True(t, env.sumBalance(t, env.receivableSubAccount(t)).Equal(alpacadecimal.Zero))
 		require.True(t, env.sumBalance(t, env.authorizedReceivableSubAccount(t)).Equal(alpacadecimal.Zero))
 		require.True(t, env.sumBalance(t, env.invoiceEarningsSubAccount(t)).Equal(alpacadecimal.Zero))
+	})
+
+	t.Run("event at is required", func(t *testing.T) {
+		env := newFlatFeeHandlerTestEnv(t)
+
+		input := env.newPaymentEventInput(env.newChargeWithAccruedUsage(alpacadecimal.NewFromInt(10)))
+		input.EventAt = time.Time{}
+
+		ref, err := env.handler.OnPaymentAuthorized(t.Context(), input)
+		require.ErrorContains(t, err, "event at is required")
+		require.Empty(t, ref.TransactionGroupID)
 	})
 }
 
@@ -635,6 +722,7 @@ func (e *flatFeeHandlerTestEnv) newAllocateCreditsInputForCharge(charge chargefl
 	return chargeflatfee.OnAllocateCreditsInput{
 		Charge:                 charge,
 		ServicePeriod:          charge.Intent.ServicePeriod,
+		BookedAt:               chargeflatfee.UsageBookedAt(charge.Intent.PaymentTerm, charge.Intent.ServicePeriod),
 		PreTaxAmountToAllocate: amount,
 	}
 }
@@ -682,6 +770,7 @@ func (e *flatFeeHandlerTestEnv) newAssignmentInputWithMode(amount alpacadecimal.
 			},
 		},
 		ServicePeriod:          servicePeriod,
+		BookedAt:               chargeflatfee.UsageBookedAt(productcatalog.InAdvancePaymentTerm, servicePeriod),
 		PreTaxAmountToAllocate: amount,
 	}
 }
@@ -750,6 +839,7 @@ func (e *flatFeeHandlerTestEnv) newAccrualInput(total alpacadecimal.Decimal) cha
 	return chargeflatfee.OnInvoiceUsageAccruedInput{
 		Charge:        e.newBaseCharge(servicePeriod, total),
 		ServicePeriod: servicePeriod,
+		BookedAt:      chargeflatfee.UsageBookedAt(productcatalog.InAdvancePaymentTerm, servicePeriod),
 		Totals: totals.Totals{
 			Amount: total,
 			Total:  total,
@@ -836,8 +926,9 @@ func (e *flatFeeHandlerTestEnv) newPaymentEventInput(charge chargeflatfee.Charge
 	}
 
 	return chargeflatfee.PaymentEventInput{
-		Charge: charge,
-		Amount: amount,
+		Charge:  charge,
+		EventAt: e.Now(),
+		Amount:  amount,
 	}
 }
 

--- a/openmeter/ledger/chargeadapter/flatfee_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_test.go
@@ -51,8 +51,8 @@ func TestOnAllocateCredits(t *testing.T) {
 			env.transactionGroupAnnotations(t, realizations[0].LedgerTransaction.TransactionGroupID),
 		)
 		for _, bookedAt := range env.transactionBookedAtTimes(t, realizations[0].LedgerTransaction.TransactionGroupID) {
-			require.True(t, bookedAt.UTC().Equal(input.ServicePeriod.From.UTC()))
-			require.False(t, bookedAt.UTC().Equal(input.Charge.Intent.InvoiceAt.UTC()))
+			requireLedgerBookedAtEqual(t, input.ServicePeriod.From, bookedAt)
+			requireLedgerBookedAtNotEqual(t, input.Charge.Intent.InvoiceAt, bookedAt)
 		}
 
 		require.True(t, env.sumBalance(t, priorityOne).Equal(alpacadecimal.NewFromInt(40)))
@@ -144,8 +144,8 @@ func TestOnAllocateCredits(t *testing.T) {
 		require.Len(t, realizations, 1)
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, realizations[0].LedgerTransaction.TransactionGroupID) {
-			require.True(t, bookedAt.UTC().Equal(input.ServicePeriod.To.UTC()))
-			require.False(t, bookedAt.UTC().Equal(input.Charge.Intent.InvoiceAt.UTC()))
+			requireLedgerBookedAtEqual(t, input.ServicePeriod.To, bookedAt)
+			requireLedgerBookedAtNotEqual(t, input.Charge.Intent.InvoiceAt, bookedAt)
 		}
 	})
 }
@@ -404,8 +404,8 @@ func TestOnFlatFeeStandardInvoiceUsageAccrued(t *testing.T) {
 		require.NotEmpty(t, ref.TransactionGroupID)
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
-			require.True(t, bookedAt.UTC().Equal(input.ServicePeriod.From.UTC()))
-			require.False(t, bookedAt.UTC().Equal(input.Charge.Intent.InvoiceAt.UTC()))
+			requireLedgerBookedAtEqual(t, input.ServicePeriod.From, bookedAt)
+			requireLedgerBookedAtNotEqual(t, input.Charge.Intent.InvoiceAt, bookedAt)
 		}
 	})
 
@@ -421,8 +421,8 @@ func TestOnFlatFeeStandardInvoiceUsageAccrued(t *testing.T) {
 		require.NotEmpty(t, ref.TransactionGroupID)
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
-			require.True(t, bookedAt.UTC().Equal(input.ServicePeriod.To.UTC()))
-			require.False(t, bookedAt.UTC().Equal(input.Charge.Intent.InvoiceAt.UTC()))
+			requireLedgerBookedAtEqual(t, input.ServicePeriod.To, bookedAt)
+			requireLedgerBookedAtNotEqual(t, input.Charge.Intent.InvoiceAt, bookedAt)
 		}
 	})
 

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -68,7 +68,7 @@ func (h *usageBasedHandler) OnInvoiceUsageAccrued(ctx context.Context, input usa
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.TransferCustomerReceivableToAccruedTemplate{
-			At:        input.Charge.Intent.InvoiceAt,
+			At:        input.BookedAt,
 			Amount:    amount,
 			Currency:  input.Charge.Intent.Currency,
 			CostBasis: invoiceCostBasis,
@@ -96,7 +96,6 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 	if err := input.Validate(); err != nil {
 		return ledgertransaction.GroupReference{}, err
 	}
-	eventTime := clock.Now()
 
 	if err := validateSettlementMode(
 		input.Charge.Intent.SettlementMode,
@@ -128,7 +127,7 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.AuthorizeCustomerReceivablePaymentTemplate{
-			At:        eventTime,
+			At:        input.EventAt,
 			Amount:    receivableReplenishment,
 			Currency:  input.Charge.Intent.Currency,
 			CostBasis: invoiceCostBasis,
@@ -162,7 +161,6 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 	if err := input.Validate(); err != nil {
 		return ledgertransaction.GroupReference{}, err
 	}
-	eventTime := clock.Now()
 
 	if err := validateSettlementMode(
 		input.Charge.Intent.SettlementMode,
@@ -189,7 +187,7 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 			Namespace:  input.Charge.Namespace,
 		},
 		transactions.SettleCustomerReceivableFromPaymentTemplate{
-			At:        eventTime,
+			At:        input.EventAt,
 			Amount:    input.Run.InvoiceUsage.Totals.Total,
 			Currency:  input.Charge.Intent.Currency,
 			CostBasis: invoiceCostBasis,
@@ -241,7 +239,7 @@ func (h *usageBasedHandler) OnCreditsOnlyUsageAccrued(ctx context.Context, input
 		ChargeID:          input.Charge.ID,
 		CustomerID:        input.Charge.Intent.CustomerID,
 		Annotations:       chargeAnnotationsForUsageBasedCharge(input.Charge),
-		BookedAt:          input.AllocateAt,
+		BookedAt:          input.BookedAt,
 		SourceBalanceAsOf: clock.Now(),
 		Currency:          input.Charge.Intent.Currency,
 		SettlementMode:    input.Charge.Intent.SettlementMode,
@@ -259,18 +257,6 @@ func (h *usageBasedHandler) OnCreditsOnlyUsageAccrued(ctx context.Context, input
 }
 
 func (h *usageBasedHandler) OnCreditsOnlyUsageAccruedCorrection(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error) {
-	if err := input.Charge.Validate(); err != nil {
-		return nil, fmt.Errorf("charge: %w", err)
-	}
-
-	if err := input.Run.Validate(); err != nil {
-		return nil, fmt.Errorf("run: %w", err)
-	}
-
-	if input.AllocateAt.IsZero() {
-		return nil, fmt.Errorf("allocate at is required")
-	}
-
 	if err := validateSettlementMode(
 		input.Charge.Intent.SettlementMode,
 		productcatalog.CreditOnlySettlementMode,
@@ -284,8 +270,8 @@ func (h *usageBasedHandler) OnCreditsOnlyUsageAccruedCorrection(ctx context.Cont
 		return nil, fmt.Errorf("get currency calculator: %w", err)
 	}
 
-	if err := input.Corrections.ValidateWith(currencyCalculator); err != nil {
-		return nil, fmt.Errorf("corrections: %w", err)
+	if err := input.ValidateWith(currencyCalculator); err != nil {
+		return nil, err
 	}
 
 	return h.collector.CorrectCollectedAccrued(ctx, collector.CorrectCollectedAccruedInput{
@@ -293,7 +279,7 @@ func (h *usageBasedHandler) OnCreditsOnlyUsageAccruedCorrection(ctx context.Cont
 		ChargeID:                     input.Charge.ID,
 		CustomerID:                   input.Charge.Intent.CustomerID,
 		Annotations:                  chargeAnnotationsForUsageBasedCharge(input.Charge),
-		AllocateAt:                   input.AllocateAt,
+		AllocateAt:                   input.BookedAt,
 		Corrections:                  input.Corrections,
 		LineageSegmentsByRealization: input.LineageSegmentsByRealization,
 	})

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -41,7 +41,7 @@ func TestOnUsageBasedCreditsOnlyUsageAccrued(t *testing.T) {
 		realizations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedInput{
 			Charge:           env.newCreditsOnlyCharge(),
 			Run:              env.newRun(),
-			AllocateAt:       env.Now(),
+			BookedAt:         env.Now(),
 			AmountToAllocate: alpacadecimal.NewFromInt(30),
 		})
 		require.NoError(t, err)
@@ -61,7 +61,7 @@ func TestOnUsageBasedCreditsOnlyUsageAccrued(t *testing.T) {
 		realizations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedInput{
 			Charge:           env.newCreditsOnlyCharge(),
 			Run:              env.newRun(),
-			AllocateAt:       env.Now(),
+			BookedAt:         env.Now(),
 			AmountToAllocate: alpacadecimal.NewFromInt(30),
 		})
 		require.NoError(t, err)
@@ -79,11 +79,14 @@ func TestOnUsageBasedCreditsOnlyUsageAccrued(t *testing.T) {
 		env := newUsageBasedHandlerTestEnv(t)
 
 		priorityOne := env.fundPriority(t, 1, 20)
+		charge := env.newCharge(productcatalog.CreditThenInvoiceSettlementMode)
+		charge.Intent.InvoiceAt = env.Now().Add(24 * time.Hour)
+		run := env.newRun()
 
 		realizations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedInput{
-			Charge:           env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
-			Run:              env.newRun(),
-			AllocateAt:       env.Now(),
+			Charge:           charge,
+			Run:              run,
+			BookedAt:         run.ServicePeriodTo,
 			AmountToAllocate: alpacadecimal.NewFromInt(30),
 		})
 		require.NoError(t, err)
@@ -94,6 +97,11 @@ func TestOnUsageBasedCreditsOnlyUsageAccrued(t *testing.T) {
 		require.True(t, env.sumBalance(t, env.unknownReceivableSubAccount(t)).Equal(alpacadecimal.Zero))
 		require.True(t, env.sumBalance(t, env.creditAccruedSubAccount(t)).Equal(alpacadecimal.NewFromInt(20)))
 		require.True(t, env.sumBalance(t, env.unknownAccruedSubAccount(t)).Equal(alpacadecimal.Zero))
+
+		for _, bookedAt := range env.transactionBookedAtTimes(t, realizations[0].LedgerTransaction.TransactionGroupID) {
+			require.True(t, bookedAt.UTC().Equal(run.ServicePeriodTo.UTC()))
+			require.False(t, bookedAt.UTC().Equal(charge.Intent.InvoiceAt.UTC()))
+		}
 	})
 
 	t.Run("tracks charge references on transactions", func(t *testing.T) {
@@ -109,7 +117,7 @@ func TestOnUsageBasedCreditsOnlyUsageAccrued(t *testing.T) {
 		realizations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedInput{
 			Charge:           charge,
 			Run:              env.newRun(),
-			AllocateAt:       env.Now(),
+			BookedAt:         env.Now(),
 			AmountToAllocate: alpacadecimal.NewFromInt(30),
 		})
 		require.NoError(t, err)
@@ -133,12 +141,25 @@ func TestOnUsageBasedCreditsOnlyUsageAccrued(t *testing.T) {
 		realizations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedInput{
 			Charge:           env.newCreditsOnlyCharge(),
 			Run:              env.newRun(),
-			AllocateAt:       env.Now(),
+			BookedAt:         env.Now(),
 			AmountToAllocate: alpacadecimal.Zero,
 		})
 		require.Error(t, err)
 		require.Nil(t, realizations)
 		require.Contains(t, err.Error(), "amount to allocate must be positive")
+	})
+
+	t.Run("booked at is required", func(t *testing.T) {
+		env := newUsageBasedHandlerTestEnv(t)
+
+		realizations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedInput{
+			Charge:           env.newCreditsOnlyCharge(),
+			Run:              env.newRun(),
+			BookedAt:         time.Time{},
+			AmountToAllocate: alpacadecimal.NewFromInt(30),
+		})
+		require.ErrorContains(t, err, "booked at is required")
+		require.Nil(t, realizations)
 	})
 }
 
@@ -150,7 +171,7 @@ func TestOnUsageBasedCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		allocations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedInput{
 			Charge:           env.newCreditsOnlyCharge(),
 			Run:              run,
-			AllocateAt:       env.Now(),
+			BookedAt:         env.Now(),
 			AmountToAllocate: alpacadecimal.NewFromInt(30),
 		})
 		require.NoError(t, err)
@@ -167,7 +188,7 @@ func TestOnUsageBasedCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedCorrectionInput{
 			Charge:      env.newCreditsOnlyCharge(),
 			Run:         run,
-			AllocateAt:  env.Now(),
+			BookedAt:    env.Now(),
 			Corrections: correctionsRequest,
 		})
 		require.NoError(t, err)
@@ -187,7 +208,7 @@ func TestOnUsageBasedCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		allocations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedInput{
 			Charge:           env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
 			Run:              run,
-			AllocateAt:       env.Now(),
+			BookedAt:         env.Now(),
 			AmountToAllocate: alpacadecimal.NewFromInt(20),
 		})
 		require.NoError(t, err)
@@ -204,7 +225,7 @@ func TestOnUsageBasedCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedCorrectionInput{
 			Charge:      env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
 			Run:         run,
-			AllocateAt:  env.Now(),
+			BookedAt:    env.Now(),
 			Corrections: correctionsRequest,
 		})
 		require.NoError(t, err)
@@ -225,7 +246,7 @@ func TestOnUsageBasedCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		allocations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedInput{
 			Charge:           charge,
 			Run:              run,
-			AllocateAt:       env.Now(),
+			BookedAt:         env.Now(),
 			AmountToAllocate: alpacadecimal.NewFromInt(20),
 		})
 		require.NoError(t, err)
@@ -248,7 +269,7 @@ func TestOnUsageBasedCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedCorrectionInput{
 			Charge:                       charge,
 			Run:                          run,
-			AllocateAt:                   env.Now(),
+			BookedAt:                     env.Now(),
 			Corrections:                  correctionsRequest,
 			LineageSegmentsByRealization: env.assertRecognizedSegments(t, run.CreditsAllocated, recognitionGroupID),
 		})
@@ -270,7 +291,7 @@ func TestOnUsageBasedCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		allocations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedInput{
 			Charge:           charge,
 			Run:              run,
-			AllocateAt:       env.Now(),
+			BookedAt:         env.Now(),
 			AmountToAllocate: alpacadecimal.NewFromInt(20),
 		})
 		require.NoError(t, err)
@@ -293,7 +314,7 @@ func TestOnUsageBasedCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedCorrectionInput{
 			Charge:                       charge,
 			Run:                          run,
-			AllocateAt:                   env.Now(),
+			BookedAt:                     env.Now(),
 			Corrections:                  correctionsRequest,
 			LineageSegmentsByRealization: env.assertRecognizedSegments(t, run.CreditsAllocated, recognitionGroupID),
 		})
@@ -305,6 +326,18 @@ func TestOnUsageBasedCreditsOnlyUsageAccruedCorrection(t *testing.T) {
 		require.True(t, env.sumBalance(t, env.creditAccruedSubAccount(t)).Equal(alpacadecimal.Zero))
 		require.True(t, env.sumBalance(t, env.EarningsSubAccountWithCostBasis(t, &zeroCostBasis)).Equal(alpacadecimal.Zero))
 	})
+
+	t.Run("booked at is required", func(t *testing.T) {
+		env := newUsageBasedHandlerTestEnv(t)
+
+		corrections, err := env.handler.OnCreditsOnlyUsageAccruedCorrection(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedCorrectionInput{
+			Charge:   env.newCreditsOnlyCharge(),
+			Run:      env.newRun(),
+			BookedAt: time.Time{},
+		})
+		require.ErrorContains(t, err, "booked at is required")
+		require.Nil(t, corrections)
+	})
 }
 
 func TestOnUsageBasedInvoiceUsageAccrued(t *testing.T) {
@@ -315,9 +348,50 @@ func TestOnUsageBasedInvoiceUsageAccrued(t *testing.T) {
 			Charge:        env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
 			Run:           env.newRun(),
 			ServicePeriod: timeutil.ClosedPeriod{From: env.Now().Add(-time.Hour), To: env.Now()},
+			BookedAt:      env.Now(),
 			Amount:        alpacadecimal.Zero,
 		})
 		require.NoError(t, err)
+		require.Empty(t, ref.TransactionGroupID)
+	})
+
+	t.Run("credit_then_invoice books invoice usage at service period end", func(t *testing.T) {
+		env := newUsageBasedHandlerTestEnv(t)
+
+		servicePeriod := timeutil.ClosedPeriod{
+			From: env.Now().Add(-2 * time.Hour),
+			To:   env.Now().Add(-time.Hour),
+		}
+		charge := env.newCharge(productcatalog.CreditThenInvoiceSettlementMode)
+		charge.Intent.InvoiceAt = servicePeriod.To.Add(24 * time.Hour)
+
+		ref, err := env.handler.OnInvoiceUsageAccrued(t.Context(), chargeusagebased.OnInvoiceUsageAccruedInput{
+			Charge:        charge,
+			Run:           env.newRunWithLine("line-1"),
+			ServicePeriod: servicePeriod,
+			BookedAt:      servicePeriod.To,
+			Amount:        alpacadecimal.NewFromInt(30),
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, ref.TransactionGroupID)
+
+		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
+			require.True(t, bookedAt.UTC().Equal(servicePeriod.To.UTC()))
+			require.False(t, bookedAt.UTC().Equal(charge.Intent.InvoiceAt.UTC()))
+		}
+	})
+
+	t.Run("booked at is required", func(t *testing.T) {
+		env := newUsageBasedHandlerTestEnv(t)
+
+		ref, err := env.handler.OnInvoiceUsageAccrued(t.Context(), chargeusagebased.OnInvoiceUsageAccruedInput{
+			Charge:        env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Run:           env.newRun(),
+			ServicePeriod: timeutil.ClosedPeriod{From: env.Now().Add(-time.Hour), To: env.Now()},
+			BookedAt:      time.Time{},
+			Amount:        alpacadecimal.NewFromInt(30),
+		})
+		require.ErrorContains(t, err, "booked at is required")
 		require.Empty(t, ref.TransactionGroupID)
 	})
 }
@@ -331,6 +405,7 @@ func TestOnUsageBasedPaymentAuthorized(t *testing.T) {
 			Charge:        env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
 			Run:           env.newRunWithLine("line-1"),
 			ServicePeriod: timeutil.ClosedPeriod{From: env.Now().Add(-time.Hour), To: env.Now()},
+			BookedAt:      env.Now(),
 			Amount:        total,
 		})
 		require.NoError(t, err)
@@ -342,8 +417,9 @@ func TestOnUsageBasedPaymentAuthorized(t *testing.T) {
 		defer clock.UnFreeze()
 
 		ref, err := env.handler.OnPaymentAuthorized(t.Context(), chargeusagebased.OnPaymentAuthorizedInput{
-			Charge: charge,
-			Run:    env.newRunWithInvoiceUsage("line-1", total),
+			Charge:  charge,
+			Run:     env.newRunWithInvoiceUsage("line-1", total),
+			EventAt: env.Now(),
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, ref.TransactionGroupID)
@@ -366,10 +442,23 @@ func TestOnUsageBasedPaymentAuthorized(t *testing.T) {
 		env := newUsageBasedHandlerTestEnv(t)
 
 		ref, err := env.handler.OnPaymentAuthorized(t.Context(), chargeusagebased.OnPaymentAuthorizedInput{
-			Charge: env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
-			Run:    env.newRunWithInvoiceUsage("line-1", alpacadecimal.Zero),
+			Charge:  env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Run:     env.newRunWithInvoiceUsage("line-1", alpacadecimal.Zero),
+			EventAt: env.Now(),
 		})
 		require.NoError(t, err)
+		require.Empty(t, ref.TransactionGroupID)
+	})
+
+	t.Run("event at is required", func(t *testing.T) {
+		env := newUsageBasedHandlerTestEnv(t)
+
+		ref, err := env.handler.OnPaymentAuthorized(t.Context(), chargeusagebased.OnPaymentAuthorizedInput{
+			Charge:  env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Run:     env.newRunWithInvoiceUsage("line-1", alpacadecimal.NewFromInt(10)),
+			EventAt: time.Time{},
+		})
+		require.ErrorContains(t, err, "event at is required")
 		require.Empty(t, ref.TransactionGroupID)
 	})
 }
@@ -383,6 +472,7 @@ func TestOnUsageBasedPaymentSettled(t *testing.T) {
 			Charge:        env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
 			Run:           env.newRunWithLine("line-1"),
 			ServicePeriod: timeutil.ClosedPeriod{From: env.Now().Add(-time.Hour), To: env.Now()},
+			BookedAt:      env.Now(),
 			Amount:        total,
 		})
 		require.NoError(t, err)
@@ -390,8 +480,9 @@ func TestOnUsageBasedPaymentSettled(t *testing.T) {
 		authorizedCharge := env.newCharge(productcatalog.CreditThenInvoiceSettlementMode)
 		authorizedCharge.Intent.InvoiceAt = env.Now().Add(-24 * time.Hour)
 		_, err = env.handler.OnPaymentAuthorized(t.Context(), chargeusagebased.OnPaymentAuthorizedInput{
-			Charge: authorizedCharge,
-			Run:    env.newRunWithInvoiceUsage("line-1", total),
+			Charge:  authorizedCharge,
+			Run:     env.newRunWithInvoiceUsage("line-1", total),
+			EventAt: env.Now(),
 		})
 		require.NoError(t, err)
 
@@ -402,8 +493,9 @@ func TestOnUsageBasedPaymentSettled(t *testing.T) {
 		defer clock.UnFreeze()
 
 		ref, err := env.handler.OnPaymentSettled(t.Context(), chargeusagebased.OnPaymentSettledInput{
-			Charge: settledCharge,
-			Run:    env.newRunWithAuthorizedPayment("line-1", total),
+			Charge:  settledCharge,
+			Run:     env.newRunWithAuthorizedPayment("line-1", total),
+			EventAt: eventTime,
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, ref.TransactionGroupID)
@@ -422,8 +514,9 @@ func TestOnUsageBasedPaymentSettled(t *testing.T) {
 		env := newUsageBasedHandlerTestEnv(t)
 
 		ref, err := env.handler.OnPaymentSettled(t.Context(), chargeusagebased.OnPaymentSettledInput{
-			Charge: env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
-			Run:    env.newRunWithAuthorizedPaymentAndInvoiceUsage("line-1", alpacadecimal.NewFromInt(1), alpacadecimal.Zero),
+			Charge:  env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Run:     env.newRunWithAuthorizedPaymentAndInvoiceUsage("line-1", alpacadecimal.NewFromInt(1), alpacadecimal.Zero),
+			EventAt: env.Now(),
 		})
 		require.NoError(t, err)
 		require.Empty(t, ref.TransactionGroupID)

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -99,8 +99,8 @@ func TestOnUsageBasedCreditsOnlyUsageAccrued(t *testing.T) {
 		require.True(t, env.sumBalance(t, env.unknownAccruedSubAccount(t)).Equal(alpacadecimal.Zero))
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, realizations[0].LedgerTransaction.TransactionGroupID) {
-			require.True(t, bookedAt.UTC().Equal(run.ServicePeriodTo.UTC()))
-			require.False(t, bookedAt.UTC().Equal(charge.Intent.InvoiceAt.UTC()))
+			requireLedgerBookedAtEqual(t, run.ServicePeriodTo, bookedAt)
+			requireLedgerBookedAtNotEqual(t, charge.Intent.InvoiceAt, bookedAt)
 		}
 	})
 
@@ -376,8 +376,8 @@ func TestOnUsageBasedInvoiceUsageAccrued(t *testing.T) {
 		require.NotEmpty(t, ref.TransactionGroupID)
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
-			require.True(t, bookedAt.UTC().Equal(servicePeriod.To.UTC()))
-			require.False(t, bookedAt.UTC().Equal(charge.Intent.InvoiceAt.UTC()))
+			requireLedgerBookedAtEqual(t, servicePeriod.To, bookedAt)
+			requireLedgerBookedAtNotEqual(t, charge.Intent.InvoiceAt, bookedAt)
 		}
 	})
 
@@ -433,8 +433,8 @@ func TestOnUsageBasedPaymentAuthorized(t *testing.T) {
 		require.True(t, env.sumBalance(t, env.invoiceEarningsSubAccount(t)).Equal(alpacadecimal.Zero))
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
-			require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
-			require.False(t, bookedAt.UTC().Equal(charge.Intent.InvoiceAt.UTC()))
+			requireLedgerBookedAtEqual(t, eventTime, bookedAt)
+			requireLedgerBookedAtNotEqual(t, charge.Intent.InvoiceAt, bookedAt)
 		}
 	})
 
@@ -505,8 +505,8 @@ func TestOnUsageBasedPaymentSettled(t *testing.T) {
 		require.True(t, env.sumBalance(t, env.washSubAccount(t)).Equal(alpacadecimal.NewFromInt(-25)))
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
-			require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
-			require.False(t, bookedAt.UTC().Equal(settledCharge.Intent.InvoiceAt.UTC()))
+			requireLedgerBookedAtEqual(t, eventTime, bookedAt)
+			requireLedgerBookedAtNotEqual(t, settledCharge.Intent.InvoiceAt, bookedAt)
 		}
 	})
 

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -521,6 +521,18 @@ func TestOnUsageBasedPaymentSettled(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, ref.TransactionGroupID)
 	})
+
+	t.Run("event at is required", func(t *testing.T) {
+		env := newUsageBasedHandlerTestEnv(t)
+
+		ref, err := env.handler.OnPaymentSettled(t.Context(), chargeusagebased.OnPaymentSettledInput{
+			Charge:  env.newCharge(productcatalog.CreditThenInvoiceSettlementMode),
+			Run:     env.newRunWithAuthorizedPayment("line-1", alpacadecimal.NewFromInt(10)),
+			EventAt: time.Time{},
+		})
+		require.ErrorContains(t, err, "event at is required")
+		require.Empty(t, ref.TransactionGroupID)
+	})
 }
 
 type usageBasedHandlerTestEnv struct {

--- a/openmeter/ledger/customerbalance/expired_loader_test.go
+++ b/openmeter/ledger/customerbalance/expired_loader_test.go
@@ -128,7 +128,7 @@ func TestListCreditTransactionsCombinesFundedConsumedAndExpired(t *testing.T) {
 			consumed: 5,
 			asOf:     2 * time.Hour,
 			expected: []expectedCreditTransaction{
-				{txType: CreditTransactionTypeConsumed, bookedAfter: 59 * time.Minute, amount: -5, balanceBefore: 20, balanceAfter: 15},
+				{txType: CreditTransactionTypeConsumed, bookedAfter: 0, amount: -5, balanceBefore: 20, balanceAfter: 15},
 				{txType: CreditTransactionTypeFunded, bookedAfter: 0, amount: 20, balanceBefore: 0, balanceAfter: 20},
 			},
 		},
@@ -148,7 +148,7 @@ func TestListCreditTransactionsCombinesFundedConsumedAndExpired(t *testing.T) {
 			asOf:     10 * time.Hour,
 			expected: []expectedCreditTransaction{
 				{txType: CreditTransactionTypeExpired, bookedAfter: 10 * time.Hour, amount: -15, balanceBefore: 15, balanceAfter: 0},
-				{txType: CreditTransactionTypeConsumed, bookedAfter: 59 * time.Minute, amount: -5, balanceBefore: 20, balanceAfter: 15},
+				{txType: CreditTransactionTypeConsumed, bookedAfter: 0, amount: -5, balanceBefore: 20, balanceAfter: 15},
 				{txType: CreditTransactionTypeFunded, bookedAfter: 0, amount: 20, balanceBefore: 0, balanceAfter: 20},
 			},
 		},
@@ -158,7 +158,7 @@ func TestListCreditTransactionsCombinesFundedConsumedAndExpired(t *testing.T) {
 			consumed: 20,
 			asOf:     10 * time.Hour,
 			expected: []expectedCreditTransaction{
-				{txType: CreditTransactionTypeConsumed, bookedAfter: 59 * time.Minute, amount: -20, balanceBefore: 20, balanceAfter: 0},
+				{txType: CreditTransactionTypeConsumed, bookedAfter: 0, amount: -20, balanceBefore: 20, balanceAfter: 0},
 				{txType: CreditTransactionTypeFunded, bookedAfter: 0, amount: 20, balanceBefore: 0, balanceAfter: 20},
 			},
 		},

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -1209,7 +1209,7 @@ func (s *SanitySuite) createPromotionalCreditGrant(ctx context.Context, input Cr
 	return charge
 }
 
-func (s *SanitySuite) correctCreditUsageAllocation(ctx context.Context, charge flatfee.Charge, allocation creditrealization.Realization, amount alpacadecimal.Decimal, allocateAt time.Time) {
+func (s *SanitySuite) correctCreditUsageAllocation(ctx context.Context, charge flatfee.Charge, allocation creditrealization.Realization, amount alpacadecimal.Decimal, bookedAt time.Time) {
 	s.T().Helper()
 
 	lineageSegmentsByRealization, err := s.LineageService.LoadActiveSegmentsByRealizationID(ctx, charge.Namespace, []string{allocation.ID})
@@ -1217,7 +1217,7 @@ func (s *SanitySuite) correctCreditUsageAllocation(ctx context.Context, charge f
 
 	corrections, err := s.FlatFeeHandler.OnCorrectCreditAllocations(ctx, flatfee.CorrectCreditAllocationsInput{
 		Charge:                       charge,
-		AllocateAt:                   allocateAt,
+		BookedAt:                     bookedAt,
 		LineageSegmentsByRealization: lineageSegmentsByRealization,
 		Corrections: creditrealization.CorrectionRequest{
 			{


### PR DESCRIPTION
## Business impact

Credit-then-invoice and credit-only charge flows now book ledger transactions at the domain event time they represent instead of deriving timestamps inside the ledger adapter. This makes customer balances and revenue staging auditable by service period:

- flat fee in-advance usage books at the service period start
- flat fee in-arrears usage books at the service period end
- usage-based run allocations, accruals, and corrections book at the run service period end
- payment authorization and settlement book at the payment event time

This prevents balance history from drifting to invoice dates, stored-at cutoffs, or wall-clock correction times, which is especially important for credit allocation, rollback, and subscription sync validation.

## Technical notes

- Moves booking timestamps into charge handler inputs (BookedAt / EventAt) and validates they are explicitly supplied.
- Centralizes flat-fee usage booking with flatfee.UsageBookedAt.
- Aligns usage-based credit-only and CTI reconciliation to use run service period end.
- Extends chargeadapter and subscription-sync assertions to validate ledger transaction booking dates.

## Validation

- make lint-go-fast
- env POSTGRES_HOST=127.0.0.1 make test-nocache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Handlers and services now accept validated event inputs carrying explicit EventAt/BookedAt timestamps; ledger entries use these input-driven booking times.
* **Bug Fixes**
  * Payment flows capture a single event timestamp per operation to avoid timing inconsistencies between authorization and settlement.
* **New Features**
  * Booking time logic now respects payment terms when determining ledger booking timestamps.
* **Tests**
  * Tests updated to pass/validate timestamps and assert ledger BookedAt behavior; missing-timestamp validations added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->