### PR TITLE
fix: credit then invoice config name

### DIFF
--- a/app/config/credits.go
+++ b/app/config/credits.go
@@ -8,7 +8,7 @@ import (
 
 type CreditsConfiguration struct {
 	Enabled                 bool `yaml:"enabled"`
-	EnableCreditThenInvoice bool `yaml:"enable_credit_then_invoice"`
+	EnableCreditThenInvoice bool `yaml:"enableCreditThenInvoice"`
 }
 
 func (c CreditsConfiguration) Validate() error {
@@ -21,5 +21,5 @@ func (c CreditsConfiguration) Validate() error {
 
 func ConfigureCredits(v *viper.Viper) {
 	v.SetDefault("credits.enabled", false)
-	v.SetDefault("credits.enable_credit_then_invoice", false)
+	v.SetDefault("credits.enableCreditThenInvoice", false)
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -84,7 +84,7 @@ billing:
 
 credits:
   enabled: true
-  enable_credit_then_invoice: false
+  enableCreditThenInvoice: false
 
 apps:
   baseURL: https://example.com

--- a/e2e/config.yaml
+++ b/e2e/config.yaml
@@ -46,7 +46,7 @@ postgres:
 # to verify that credit_only settlement mode is rejected when credits are disabled.
 credits:
   enabled: false
-  enable_credit_then_invoice: false
+  enableCreditThenInvoice: false
 
 notification:
   lock:


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

We use camelCase for these variables.


## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated billing configuration naming convention: the credits setting has been renamed from `enable_credit_then_invoice` to `enableCreditThenInvoice`. Users must update existing configuration files to use the new key name.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->