### PR TITLE
ci: enforce append-only migration sums

### DIFF
--- a/.github/tools/migrate/.gitignore
+++ b/.github/tools/migrate/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+

--- a/.github/tools/migrate/README.md
+++ b/.github/tools/migrate/README.md
@@ -1,0 +1,31 @@
+# Migration CI Checks
+
+This directory contains GitHub Actions helper code for migration-specific PR
+checks.
+
+`check_atlas_sum_append_only.py` protects `tools/migrate/migrations/atlas.sum`.
+Atlas updates the first `h1:` line when the migration directory hash changes, but
+existing migration record lines should remain immutable once they are on the base
+branch. The check compares the PR copy of `atlas.sum` against the pull request
+base revision and enforces that:
+
+- existing migration records are unchanged and stay in the same order
+- new migration records are appended after the previous end of the file
+- appended migration timestamps are strictly newer than the previous last
+  migration timestamp
+- the Atlas header checksum changes only when records are appended
+
+Run the unit tests locally with:
+
+```bash
+python3 -m unittest discover -s .github/tools/migrate -p 'test_*.py'
+```
+
+Run the same append-only check that CI runs with:
+
+```bash
+python3 .github/tools/migrate/check_atlas_sum_append_only.py main
+```
+
+Pass a different base revision when testing a branch against something other
+than `main`.

--- a/.github/tools/migrate/check_atlas_sum_append_only.py
+++ b/.github/tools/migrate/check_atlas_sum_append_only.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+DEFAULT_ATLAS_SUM_PATH = "tools/migrate/migrations/atlas.sum"
+MIGRATION_RECORD_PATTERN = re.compile(r"^([0-9]{14})_.+\.up\.sql h1:\S+$")
+
+
+def fail(message: str) -> None:
+    print(
+        "tools/migrate/migrations/atlas.sum must only append new migration records.",
+        file=sys.stderr,
+    )
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_base_atlas_sum(base_revision: str, path: str) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{base_revision}:{path}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip()
+        if stderr:
+            print(stderr, file=sys.stderr)
+
+        fail(f"Could not read {path} from base revision {base_revision}.")
+
+    return result.stdout.splitlines()
+
+
+def read_current_atlas_sum(path: str) -> list[str]:
+    atlas_sum_path = Path(path)
+    if not atlas_sum_path.is_file():
+        fail(f"Current atlas.sum file does not exist at {path}.")
+
+    return atlas_sum_path.read_text().splitlines()
+
+
+def last_migration_timestamp(records: list[str]) -> str | None:
+    timestamp = None
+
+    for record in records:
+        match = MIGRATION_RECORD_PATTERN.match(record)
+        if match is not None:
+            timestamp = match.group(1)
+
+    return timestamp
+
+
+def validate_appended_records(appended_records: list[str], previous_timestamp: str | None) -> None:
+    for record in appended_records:
+        match = MIGRATION_RECORD_PATTERN.match(record)
+        if match is None:
+            fail(f"Malformed appended atlas.sum migration record: {record}")
+
+        timestamp = match.group(1)
+        if previous_timestamp is not None and timestamp <= previous_timestamp:
+            fail(
+                f"Appended migration {record.split()[0]} must have a timestamp "
+                f"newer than {previous_timestamp}."
+            )
+
+        previous_timestamp = timestamp
+
+
+def check_atlas_sum_append_only(base_revision: str, path: str) -> None:
+    base_lines = read_base_atlas_sum(base_revision, path)
+    current_lines = read_current_atlas_sum(path)
+
+    base_header = base_lines[:1]
+    current_header = current_lines[:1]
+    base_records = base_lines[1:]
+    current_records = current_lines[1:]
+
+    if current_records[: len(base_records)] != base_records:
+        fail(
+            "Existing migration records were modified, removed, reordered, "
+            "or a new record was inserted before the previous end."
+        )
+
+    appended_records = current_records[len(base_records) :]
+    if not appended_records:
+        if current_header != base_header:
+            fail("Atlas checksum header changed without any appended migration records.")
+
+        return
+
+    validate_appended_records(
+        appended_records,
+        previous_timestamp=last_migration_timestamp(base_records),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check that atlas.sum only appends new migration records.",
+    )
+    parser.add_argument("base_revision")
+    parser.add_argument("atlas_sum_path", nargs="?", default=DEFAULT_ATLAS_SUM_PATH)
+    args = parser.parse_args()
+
+    check_atlas_sum_append_only(args.base_revision, args.atlas_sum_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/tools/migrate/test_check_atlas_sum_append_only.py
+++ b/.github/tools/migrate/test_check_atlas_sum_append_only.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("check_atlas_sum_append_only.py")
+MODULE_SPEC = importlib.util.spec_from_file_location(
+    "check_atlas_sum_append_only",
+    MODULE_PATH,
+)
+assert MODULE_SPEC is not None
+assert MODULE_SPEC.loader is not None
+check_atlas_sum_append_only = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(check_atlas_sum_append_only)
+
+
+class CheckAtlasSumAppendOnlyTest(unittest.TestCase):
+    def run_check(self, base_atlas_sum: str, current_atlas_sum: str) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            atlas_sum_path = Path(tmp_dir) / "atlas.sum"
+            atlas_sum_path.write_text(current_atlas_sum)
+
+            with mock.patch.object(
+                check_atlas_sum_append_only.subprocess,
+                "run",
+                return_value=subprocess.CompletedProcess(
+                    args=["git", "show", f"base:{atlas_sum_path}"],
+                    returncode=0,
+                    stdout=base_atlas_sum,
+                    stderr="",
+                ),
+            ) as git_show:
+                check_atlas_sum_append_only.check_atlas_sum_append_only(
+                    "base",
+                    str(atlas_sum_path),
+                )
+
+            git_show.assert_called_once_with(
+                ["git", "show", f"base:{atlas_sum_path}"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+    def assert_check_fails(self, base_atlas_sum: str, current_atlas_sum: str) -> None:
+        with mock.patch("sys.stderr", new_callable=io.StringIO):
+            with self.assertRaises(SystemExit) as error:
+                self.run_check(base_atlas_sum, current_atlas_sum)
+
+        self.assertEqual(error.exception.code, 1)
+
+    def test_allows_unchanged_atlas_sum(self) -> None:
+        atlas_sum = "\n".join(
+            [
+                "h1:base",
+                "20260519132345_reset-sync-state.up.sql h1:old=",
+                "",
+            ]
+        )
+
+        self.run_check(atlas_sum, atlas_sum)
+
+    def test_allows_newer_records_appended_after_existing_records(self) -> None:
+        base_atlas_sum = "\n".join(
+            [
+                "h1:base",
+                "20260519132345_reset-sync-state.up.sql h1:old=",
+                "",
+            ]
+        )
+        current_atlas_sum = "\n".join(
+            [
+                "h1:changed",
+                "20260519132345_reset-sync-state.up.sql h1:old=",
+                "20260520120000_newer.up.sql h1:new=",
+                "",
+            ]
+        )
+
+        self.run_check(base_atlas_sum, current_atlas_sum)
+
+    def test_rejects_changed_existing_record(self) -> None:
+        base_atlas_sum = "\n".join(
+            [
+                "h1:base",
+                "20260519132345_reset-sync-state.up.sql h1:old=",
+                "",
+            ]
+        )
+        current_atlas_sum = "\n".join(
+            [
+                "h1:changed",
+                "20260519132345_reset-sync-state.up.sql h1:changed=",
+                "20260520120000_newer.up.sql h1:new=",
+                "",
+            ]
+        )
+
+        self.assert_check_fails(base_atlas_sum, current_atlas_sum)
+
+    def test_rejects_header_change_without_appended_record(self) -> None:
+        base_atlas_sum = "\n".join(
+            [
+                "h1:base",
+                "20260519132345_reset-sync-state.up.sql h1:old=",
+                "",
+            ]
+        )
+        current_atlas_sum = "\n".join(
+            [
+                "h1:changed",
+                "20260519132345_reset-sync-state.up.sql h1:old=",
+                "",
+            ]
+        )
+
+        self.assert_check_fails(base_atlas_sum, current_atlas_sum)
+
+    def test_rejects_appended_record_with_older_timestamp(self) -> None:
+        base_atlas_sum = "\n".join(
+            [
+                "h1:base",
+                "20260519132345_reset-sync-state.up.sql h1:old=",
+                "",
+            ]
+        )
+        current_atlas_sum = "\n".join(
+            [
+                "h1:changed",
+                "20260519132345_reset-sync-state.up.sql h1:old=",
+                "20260518120000_older.up.sql h1:new=",
+                "",
+            ]
+        )
+
+        self.assert_check_fails(base_atlas_sum, current_atlas_sum)
+
+    def test_rejects_malformed_appended_record(self) -> None:
+        base_atlas_sum = "\n".join(
+            [
+                "h1:base",
+                "20260519132345_reset-sync-state.up.sql h1:old=",
+                "",
+            ]
+        )
+        current_atlas_sum = "\n".join(
+            [
+                "h1:changed",
+                "20260519132345_reset-sync-state.up.sql h1:old=",
+                "not-a-migration h1:new=",
+                "",
+            ]
+        )
+
+        self.assert_check_fails(base_atlas_sum, current_atlas_sum)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -13,6 +13,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  migration-atlas-sum:
+    name: Migration atlas.sum append-only
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Run atlas.sum check unit tests
+        run: python3 -m unittest discover -s .github/tools/migrate -p 'test_*.py'
+
+      - name: Check atlas.sum is append-only
+        run: python3 .github/tools/migrate/check_atlas_sum_append_only.py "${{ github.event.pull_request.base.sha }}"
+
   release-label:
     name: Release note label
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add a PR check for tools/migrate/migrations/atlas.sum append-only behavior
- fail when existing migration sum records are modified, removed, reordered, or backfilled
- require appended migration records to use timestamps newer than the existing migration stream
- keep the CI helper under .github/tools/migrate with README documentation, Python ignore rules, and stdlib unittest coverage with git show mocked

## Verification
- python3 -m unittest discover -s .github/tools/migrate -p 'test_*.py'
- python3 .github/tools/migrate/check_atlas_sum_append_only.py HEAD
- actionlint .github/workflows/pr-checks.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI validation to ensure migration records remain append-only and correctly formatted; updated ignore rules to omit Python bytecode artifacts.

* **Tests**
  * Added unit tests covering acceptance and rejection cases for migration record changes.

* **Documentation**
  * Added guidance documenting the migration checks and how to run them locally.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->