### PR TITLE
feat(taxcode): add default guard to DeleteTaxCode

### DIFF
--- a/openmeter/taxcode/errors.go
+++ b/openmeter/taxcode/errors.go
@@ -132,3 +132,17 @@ func IsOrganizationDefaultTaxCodesNotFoundError(err error) bool {
 	var vi models.ValidationIssue
 	return errors.As(err, &vi) && vi.Code() == ErrCodeOrganizationDefaultTaxCodesNotFound
 }
+
+const ErrCodeTaxCodeIsOrganizationDefault models.ErrorCode = "tax_code_is_organization_default"
+
+var ErrTaxCodeIsOrganizationDefault = models.NewValidationIssue(
+	ErrCodeTaxCodeIsOrganizationDefault,
+	"tax code is set as an organization default and cannot be deleted",
+	models.WithCriticalSeverity(),
+	commonhttp.WithHTTPStatusCodeAttribute(http.StatusConflict),
+)
+
+func IsTaxCodeIsOrganizationDefaultError(err error) bool {
+	var vi models.ValidationIssue
+	return errors.As(err, &vi) && vi.Code() == ErrCodeTaxCodeIsOrganizationDefault
+}

--- a/openmeter/taxcode/service/taxcode.go
+++ b/openmeter/taxcode/service/taxcode.go
@@ -126,6 +126,15 @@ func (s *Service) DeleteTaxCode(ctx context.Context, input taxcode.DeleteTaxCode
 			return models.NewGenericConflictError(taxcode.ErrTaxCodeManagedBySystem)
 		}
 
+		defaults, err := s.adapter.GetOrganizationDefaultTaxCodes(ctx, taxcode.GetOrganizationDefaultTaxCodesInput{Namespace: input.NamespacedID.Namespace})
+		if err != nil {
+			return err
+		}
+
+		if defaults.CreditGrantTaxCodeID == existing.ID || defaults.InvoicingTaxCodeID == existing.ID {
+			return models.NewGenericConflictError(taxcode.ErrTaxCodeIsOrganizationDefault)
+		}
+
 		return s.adapter.DeleteTaxCode(ctx, input)
 	})
 }

--- a/openmeter/taxcode/service/taxcode_test.go
+++ b/openmeter/taxcode/service/taxcode_test.go
@@ -80,6 +80,57 @@ func TestTaxCodeService(t *testing.T) {
 		})
 	})
 
+	t.Run("OrganizationDefault", func(t *testing.T) {
+		// given:
+		// - two tax codes set as org defaults (invoicing + credit grant)
+		// - one extra tax code that is not a default
+		// when:
+		// - caller tries to delete an org default tax code
+		// then:
+		// - deletion is blocked with ErrCodeTaxCodeIsOrganizationDefault (409)
+		// - deletion of a non-default tax code succeeds
+		defaultNs := testutils.NameGenerator.Generate().Key
+		invoicing := env.CreateTaxCode(t.Context(), t, defaultNs)
+		creditGrant := env.CreateTaxCode(t.Context(), t, defaultNs)
+		other := env.CreateTaxCode(t.Context(), t, defaultNs)
+
+		_, err := env.Service.UpsertOrganizationDefaultTaxCodes(t.Context(), taxcode.UpsertOrganizationDefaultTaxCodesInput{
+			Namespace:            defaultNs,
+			InvoicingTaxCodeID:   invoicing.ID,
+			CreditGrantTaxCodeID: creditGrant.ID,
+		})
+		require.NoError(t, err)
+
+		t.Run("DeleteInvoicingDefaultIsBlocked", func(t *testing.T) {
+			err := env.Service.DeleteTaxCode(t.Context(), taxcode.DeleteTaxCodeInput{
+				NamespacedID: models.NamespacedID{Namespace: defaultNs, ID: invoicing.ID},
+			})
+			require.Error(t, err)
+
+			var vi models.ValidationIssue
+			require.ErrorAs(t, err, &vi)
+			assert.Equal(t, taxcode.ErrCodeTaxCodeIsOrganizationDefault, vi.Code())
+		})
+
+		t.Run("DeleteCreditGrantDefaultIsBlocked", func(t *testing.T) {
+			err := env.Service.DeleteTaxCode(t.Context(), taxcode.DeleteTaxCodeInput{
+				NamespacedID: models.NamespacedID{Namespace: defaultNs, ID: creditGrant.ID},
+			})
+			require.Error(t, err)
+
+			var vi models.ValidationIssue
+			require.ErrorAs(t, err, &vi)
+			assert.Equal(t, taxcode.ErrCodeTaxCodeIsOrganizationDefault, vi.Code())
+		})
+
+		t.Run("DeleteNonDefaultSucceeds", func(t *testing.T) {
+			err := env.Service.DeleteTaxCode(t.Context(), taxcode.DeleteTaxCodeInput{
+				NamespacedID: models.NamespacedID{Namespace: defaultNs, ID: other.ID},
+			})
+			require.NoError(t, err)
+		})
+	})
+
 	t.Run("UserManaged", func(t *testing.T) {
 		name := testutils.NameGenerator.Generate()
 		tc, err := env.Service.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{

--- a/openmeter/taxcode/service/taxcode_test.go
+++ b/openmeter/taxcode/service/taxcode_test.go
@@ -18,6 +18,7 @@ func TestTaxCodeService(t *testing.T) {
 	env.DBSchemaMigrate(t)
 
 	ns := testutils.NameGenerator.Generate().Key
+	env.SetupNamespaceDefaults(t.Context(), t, ns)
 
 	t.Run("SystemManaged", func(t *testing.T) {
 		// Create a system-managed tax code by explicitly setting the annotation.

--- a/openmeter/taxcode/testutils/env.go
+++ b/openmeter/taxcode/testutils/env.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/app"
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	taxcodeadapter "github.com/openmeterio/openmeter/openmeter/taxcode/adapter"
 	taxcodeservice "github.com/openmeterio/openmeter/openmeter/taxcode/service"

--- a/openmeter/taxcode/testutils/env.go
+++ b/openmeter/taxcode/testutils/env.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"context"
 	"log/slog"
 	"sync"
 	"testing"
@@ -52,6 +53,18 @@ func (e *TestEnv) Close(t *testing.T) {
 			}
 		}
 	})
+}
+
+func (e *TestEnv) CreateTaxCode(ctx context.Context, t *testing.T, namespace string) taxcode.TaxCode {
+	t.Helper()
+	name := testutils.NameGenerator.Generate()
+	tc, err := e.Service.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       name.Key,
+		Name:      name.Name,
+	})
+	require.NoError(t, err)
+	return tc
 }
 
 func NewTestEnv(t *testing.T) *TestEnv {

--- a/openmeter/taxcode/testutils/env.go
+++ b/openmeter/taxcode/testutils/env.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	taxcodeadapter "github.com/openmeterio/openmeter/openmeter/taxcode/adapter"
 	taxcodeservice "github.com/openmeterio/openmeter/openmeter/taxcode/service"
@@ -55,16 +56,45 @@ func (e *TestEnv) Close(t *testing.T) {
 	})
 }
 
-func (e *TestEnv) CreateTaxCode(ctx context.Context, t *testing.T, namespace string) taxcode.TaxCode {
+// CreateTaxCode creates a tax code; if opts is provided its first element overrides the
+// input — Namespace, Key, and Name are generated when empty.
+func (e *TestEnv) CreateTaxCode(ctx context.Context, t *testing.T, namespace string, opts ...taxcode.CreateTaxCodeInput) taxcode.TaxCode {
 	t.Helper()
-	name := testutils.NameGenerator.Generate()
-	tc, err := e.Service.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: namespace,
-		Key:       name.Key,
-		Name:      name.Name,
-	})
+	var input taxcode.CreateTaxCodeInput
+	if len(opts) > 0 {
+		input = opts[0]
+	}
+	generated := testutils.NameGenerator.Generate()
+	input.Namespace = namespace
+	if input.Key == "" {
+		input.Key = generated.Key
+	}
+	if input.Name == "" {
+		input.Name = generated.Name
+	}
+	tc, err := e.Service.CreateTaxCode(ctx, input)
 	require.NoError(t, err)
 	return tc
+}
+
+// SetupNamespaceDefaults provisions two seed tax codes and upserts the org-default tax codes for namespace.
+func (e *TestEnv) SetupNamespaceDefaults(ctx context.Context, t *testing.T, namespace string) {
+	t.Helper()
+	invoicing := e.CreateTaxCode(ctx, t, namespace, taxcode.CreateTaxCodeInput{
+		Name: "Provider Default",
+	})
+	creditGrant := e.CreateTaxCode(ctx, t, namespace, taxcode.CreateTaxCodeInput{
+		Name: "Non-Taxable",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_00000000"},
+		},
+	})
+	_, err := e.Service.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
+		Namespace:            namespace,
+		InvoicingTaxCodeID:   invoicing.ID,
+		CreditGrantTaxCodeID: creditGrant.ID,
+	})
+	require.NoError(t, err)
 }
 
 func NewTestEnv(t *testing.T) *TestEnv {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent deletion of tax codes that are configured as organization defaults for invoicing or credit grants; attempts now return a conflict validation error and the tax code remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->