### PR TITLE
fix: ent reset list logic

### DIFF
--- a/openmeter/entitlement/adapter/entitlement.go
+++ b/openmeter/entitlement/adapter/entitlement.go
@@ -771,11 +771,13 @@ func (a *entitlementDBAdapter) ListActiveEntitlementsWithExpiredUsagePeriod(ctx 
 			now := clock.Now()
 
 			query := withAllUsageResets(repo.db.Entitlement.Query(), params.Namespaces).
-				Where(EntitlementActiveAt(params.Highwatermark)...).
+				Where(EntitlementActiveAt(now)...).
 				Where(
+					db_entitlement.EntitlementTypeEQ(db_entitlement.EntitlementType(entitlement.EntitlementTypeMetered)),
 					db_entitlement.CurrentUsagePeriodEndNotNil(),
 					db_entitlement.CurrentUsagePeriodEndLTE(params.Highwatermark),
 					db_entitlement.Or(db_entitlement.DeletedAtIsNil(), db_entitlement.DeletedAtGT(now)),
+					entitlementHasResetAnchor(),
 				)
 
 			if len(params.Namespaces) > 0 {
@@ -985,6 +987,13 @@ func EntitlementActiveAt(at time.Time) []predicate.Entitlement {
 			db_entitlement.ActiveToGT(at),
 		),
 	}
+}
+
+func entitlementHasResetAnchor() predicate.Entitlement {
+	return db_entitlement.Or(
+		db_entitlement.MeasureUsageFromNotNil(),
+		db_entitlement.HasUsageReset(),
+	)
 }
 
 func withAllUsageResets(q *db.EntitlementQuery, namespaces []string) *db.EntitlementQuery {

--- a/openmeter/entitlement/adapter/entitlement.go
+++ b/openmeter/entitlement/adapter/entitlement.go
@@ -777,7 +777,10 @@ func (a *entitlementDBAdapter) ListActiveEntitlementsWithExpiredUsagePeriod(ctx 
 					db_entitlement.CurrentUsagePeriodEndNotNil(),
 					db_entitlement.CurrentUsagePeriodEndLTE(params.Highwatermark),
 					db_entitlement.Or(db_entitlement.DeletedAtIsNil(), db_entitlement.DeletedAtGT(now)),
-					entitlementHasResetAnchor(),
+					db_entitlement.Or(
+						db_entitlement.MeasureUsageFromNotNil(),
+						db_entitlement.HasUsageReset(),
+					),
 				)
 
 			if len(params.Namespaces) > 0 {
@@ -987,13 +990,6 @@ func EntitlementActiveAt(at time.Time) []predicate.Entitlement {
 			db_entitlement.ActiveToGT(at),
 		),
 	}
-}
-
-func entitlementHasResetAnchor() predicate.Entitlement {
-	return db_entitlement.Or(
-		db_entitlement.MeasureUsageFromNotNil(),
-		db_entitlement.HasUsageReset(),
-	)
 }
 
 func withAllUsageResets(q *db.EntitlementQuery, namespaces []string) *db.EntitlementQuery {

--- a/openmeter/entitlement/adapter/entitlement_test.go
+++ b/openmeter/entitlement/adapter/entitlement_test.go
@@ -37,11 +37,12 @@ import (
 var m sync.Mutex
 
 type deps struct {
-	entRepo      entitlement.EntitlementRepo
-	featureRepo  feature.FeatureRepo
-	subjectRepo  subject.Service
-	customerRepo customer.Adapter
-	meterRepo    *meteradapter.Adapter
+	entRepo        entitlement.EntitlementRepo
+	featureRepo    feature.FeatureRepo
+	subjectRepo    subject.Service
+	customerRepo   customer.Adapter
+	meterRepo      *meteradapter.Adapter
+	usageResetRepo meteredentitlement.UsageResetRepo
 }
 
 func setup(t *testing.T) (deps deps, cleanup func()) {
@@ -74,6 +75,7 @@ func setup(t *testing.T) (deps deps, cleanup func()) {
 	require.NotNilf(t, deps.meterRepo, "meter adapter must not be nil")
 
 	deps.entRepo = adapter.NewPostgresEntitlementRepo(dbClient)
+	deps.usageResetRepo = adapter.NewPostgresUsageResetRepo(dbClient)
 	deps.featureRepo = featureadapter.NewPostgresFeatureRepo(dbClient, logger)
 
 	// customer adapter for creating customers in tests
@@ -329,12 +331,11 @@ func TestListActiveEntitlementsWithExpiredUsagePeriod(t *testing.T) {
 	ns := "ns1"
 	featureKey := "feature1"
 
-	t.Run("Should return entitlements with expired usage period", func(t *testing.T) {
-		ctx := context.Background()
+	t.Run("Should return only resettable metered entitlements with expired usage period", func(t *testing.T) {
+		ctx := t.Context()
 		repo, cleanup := setup(t)
 		defer cleanup()
 
-		// Let's create an example feature
 		feature, err := repo.featureRepo.CreateFeature(ctx, feature.CreateFeatureInputs{
 			Namespace: ns,
 			Key:       featureKey,
@@ -342,66 +343,127 @@ func TestListActiveEntitlementsWithExpiredUsagePeriod(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Let's set the current time
 		now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 		clock.SetTime(now)
 		defer clock.ResetTime()
 
-		// First, create the subjects
+		expiredPeriod := &timeutil.ClosedPeriod{
+			From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+		}
+		activePeriod := &timeutil.ClosedPeriod{
+			From: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			To:   time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
+		}
+		usagePeriod := lo.ToPtr(entitlement.NewUsagePeriodInputFromRecurrence(timeutil.Recurrence{
+			Interval: timeutil.RecurrencePeriodMonth,
+			Anchor:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		}))
+
 		cust1 := createCustomerWithSubject(t, repo.subjectRepo, repo.customerRepo, ns, "subject1")
 		cust2 := createCustomerWithSubject(t, repo.subjectRepo, repo.customerRepo, ns, "subject2")
+		custStatic := createCustomerWithSubject(t, repo.subjectRepo, repo.customerRepo, ns, "subject-static")
+		custBoolean := createCustomerWithSubject(t, repo.subjectRepo, repo.customerRepo, ns, "subject-boolean")
+		custMalformed := createCustomerWithSubject(t, repo.subjectRepo, repo.customerRepo, ns, "subject-malformed")
+		custResetAnchor := createCustomerWithSubject(t, repo.subjectRepo, repo.customerRepo, ns, "subject-reset-anchor")
 
-		// Then create two entitlements, one with expired usage period and one with no expired usage period
 		ent1, err := repo.entRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
-			Namespace:        ns,
-			FeatureID:        feature.ID,
-			FeatureKey:       featureKey,
-			UsageAttribution: cust1.GetUsageAttribution(),
-			EntitlementType:  entitlement.EntitlementTypeMetered,
-			MeasureUsageFrom: lo.ToPtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
-			UsagePeriod: lo.ToPtr(entitlement.NewUsagePeriodInputFromRecurrence(timeutil.Recurrence{
-				Interval: timeutil.RecurrencePeriodMonth,
-				Anchor:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-			})),
-			CurrentUsagePeriod: &timeutil.ClosedPeriod{
-				From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-				To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
-			},
+			Namespace:          ns,
+			FeatureID:          feature.ID,
+			FeatureKey:         featureKey,
+			UsageAttribution:   cust1.GetUsageAttribution(),
+			EntitlementType:    entitlement.EntitlementTypeMetered,
+			MeasureUsageFrom:   lo.ToPtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+			UsagePeriod:        usagePeriod,
+			CurrentUsagePeriod: expiredPeriod,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, ent1)
 
 		ent2, err := repo.entRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
-			Namespace:        ns,
-			FeatureID:        feature.ID,
-			FeatureKey:       featureKey,
-			UsageAttribution: cust2.GetUsageAttribution(),
-			EntitlementType:  entitlement.EntitlementTypeMetered,
-			MeasureUsageFrom: lo.ToPtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
-			UsagePeriod: lo.ToPtr(entitlement.NewUsagePeriodInputFromRecurrence(timeutil.Recurrence{
-				Interval: timeutil.RecurrencePeriodMonth,
-				Anchor:   time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-			})),
-			CurrentUsagePeriod: &timeutil.ClosedPeriod{
-				From: time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
-				To:   time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC),
-			},
+			Namespace:          ns,
+			FeatureID:          feature.ID,
+			FeatureKey:         featureKey,
+			UsageAttribution:   cust2.GetUsageAttribution(),
+			EntitlementType:    entitlement.EntitlementTypeMetered,
+			MeasureUsageFrom:   lo.ToPtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+			UsagePeriod:        usagePeriod,
+			CurrentUsagePeriod: activePeriod,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, ent2)
 
+		staticEnt, err := repo.entRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
+			Namespace:          ns,
+			FeatureID:          feature.ID,
+			FeatureKey:         featureKey,
+			UsageAttribution:   custStatic.GetUsageAttribution(),
+			EntitlementType:    entitlement.EntitlementTypeStatic,
+			Config:             lo.ToPtr(`{"on":true}`),
+			UsagePeriod:        usagePeriod,
+			CurrentUsagePeriod: expiredPeriod,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, staticEnt)
+
+		booleanEnt, err := repo.entRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
+			Namespace:          ns,
+			FeatureID:          feature.ID,
+			FeatureKey:         featureKey,
+			UsageAttribution:   custBoolean.GetUsageAttribution(),
+			EntitlementType:    entitlement.EntitlementTypeBoolean,
+			UsagePeriod:        usagePeriod,
+			CurrentUsagePeriod: expiredPeriod,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, booleanEnt)
+
+		malformedEnt, err := repo.entRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
+			Namespace:          ns,
+			FeatureID:          feature.ID,
+			FeatureKey:         featureKey,
+			UsageAttribution:   custMalformed.GetUsageAttribution(),
+			EntitlementType:    entitlement.EntitlementTypeMetered,
+			UsagePeriod:        usagePeriod,
+			CurrentUsagePeriod: expiredPeriod,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, malformedEnt)
+
+		resetAnchorEnt, err := repo.entRepo.CreateEntitlement(ctx, entitlement.CreateEntitlementRepoInputs{
+			Namespace:          ns,
+			FeatureID:          feature.ID,
+			FeatureKey:         featureKey,
+			UsageAttribution:   custResetAnchor.GetUsageAttribution(),
+			EntitlementType:    entitlement.EntitlementTypeMetered,
+			UsagePeriod:        usagePeriod,
+			CurrentUsagePeriod: expiredPeriod,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resetAnchorEnt)
+
+		err = repo.usageResetRepo.Save(ctx, meteredentitlement.UsageResetUpdate{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: ns,
+			},
+			EntitlementID:       resetAnchorEnt.ID,
+			ResetTime:           time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC),
+			Anchor:              time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			UsagePeriodInterval: timeutil.RecurrencePeriodMonth.ISOString(),
+		})
+		require.NoError(t, err)
+
 		now = time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
 		clock.SetTime(now)
-		defer clock.ResetTime()
 
-		// Let's check that the entitlement with expired usage period is returned
 		ents, err := repo.entRepo.ListActiveEntitlementsWithExpiredUsagePeriod(ctx, entitlement.ListExpiredEntitlementsParams{
 			Namespaces:    []string{ns},
 			Highwatermark: now,
 		})
 		require.NoError(t, err)
-		require.Equal(t, 1, len(ents))
+		require.Len(t, ents, 2)
 		require.Equal(t, ent1.ID, ents[0].ID)
+		require.Equal(t, resetAnchorEnt.ID, ents[1].ID)
 	})
 
 	t.Run("Should return entitlements with cursor and limit", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

TLDR we were returning more than we should have hence the log storm (the relevant change is only the extra filter, the TS comparison changes are just for semantic correctness)

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #(issue)

## Notes for reviewer

<!-- Anything the reviewer should know? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened entitlement filtering so expired usage periods are identified more accurately: activity is evaluated at the current time, results are limited to metered entitlements, current usage period end must be set and ≤ highwatermark, deletion is considered relative to now, and eligibility requires a measure anchor or a usage-reset.
* **Tests**
  * Updated tests to cover resettable metered entitlements, set the clock explicitly, and validate inclusion of reset-anchored items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->