### PR TITLE
chore: fix taxcode conflicts

### DIFF
--- a/openmeter/taxcode/adapter/taxcode.go
+++ b/openmeter/taxcode/adapter/taxcode.go
@@ -1,9 +1,11 @@
 package adapter
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"entgo.io/ent/dialect/sql"
 
@@ -141,7 +143,7 @@ func (a *adapter) GetTaxCodeByAppMapping(ctx context.Context, input taxcode.GetT
 			return taxcode.TaxCode{}, fmt.Errorf("failed to marshal app mapping pattern: %w", err)
 		}
 
-		entity, err := a.db.TaxCode.Query().
+		entities, err := a.db.TaxCode.Query().
 			Where(taxcodedb.Namespace(input.Namespace)).
 			Where(taxcodedb.DeletedAtIsNil()).
 			Where(func(s *sql.Selector) {
@@ -149,18 +151,40 @@ func (a *adapter) GetTaxCodeByAppMapping(ctx context.Context, input taxcode.GetT
 					b.Ident(taxcodedb.FieldAppMappings).WriteString(" @> ").Arg(string(pattern))
 				}))
 			}).
-			Only(ctx)
+			All(ctx)
 		if err != nil {
-			if db.IsNotFound(err) {
-				return taxcode.TaxCode{}, taxcode.NewTaxCodeByAppMappingNotFoundError(
-					string(input.AppType), input.TaxCode,
-				)
-			}
-
 			return taxcode.TaxCode{}, fmt.Errorf("failed to get tax code by app mapping: %w", err)
 		}
 
-		return MapTaxCodeFromEntity(entity)
+		if len(entities) == 0 {
+			return taxcode.TaxCode{}, taxcode.NewTaxCodeByAppMappingNotFoundError(
+				string(input.AppType), input.TaxCode,
+			)
+		}
+
+		slices.SortStableFunc(entities, func(a, b *db.TaxCode) int {
+			aManagedBy, _ := a.Annotations.GetString(taxcode.AnnotationKeyManagedBy)
+			bManagedBy, _ := b.Annotations.GetString(taxcode.AnnotationKeyManagedBy)
+
+			aSystemManaged := aManagedBy == taxcode.AnnotationValueManagedBySystem
+			bSystemManaged := bManagedBy == taxcode.AnnotationValueManagedBySystem
+
+			if aSystemManaged && !bSystemManaged {
+				return -1
+			}
+
+			if !aSystemManaged && bSystemManaged {
+				return 1
+			}
+
+			if byCreatedAt := a.CreatedAt.Compare(b.CreatedAt); byCreatedAt != 0 {
+				return byCreatedAt
+			}
+
+			return cmp.Compare(a.ID, b.ID)
+		})
+
+		return MapTaxCodeFromEntity(entities[0])
 	})
 }
 

--- a/openmeter/taxcode/service/taxcode_test.go
+++ b/openmeter/taxcode/service/taxcode_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	taxcodetestutils "github.com/openmeterio/openmeter/openmeter/taxcode/testutils"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
@@ -180,5 +181,49 @@ func TestTaxCodeService(t *testing.T) {
 			})
 			require.NoError(t, err)
 		})
+	})
+
+	t.Run("GetByAppMappingPrefersSystemManagedDuplicate", func(t *testing.T) {
+		// given:
+		// - a user-created tax code and a system-managed seed tax code share the same Stripe mapping
+		// when:
+		// - resolving by app mapping
+		// then:
+		// - the system-managed code is preferred over the user-created duplicate
+		duplicateNs := testutils.NameGenerator.Generate().Key
+		stripeCode := "txcd_10103001"
+
+		_, err := env.Service.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+			Namespace: duplicateNs,
+			Key:       "stripe_txcd_10103001",
+			Name:      stripeCode,
+			AppMappings: taxcode.TaxCodeAppMappings{
+				{AppType: app.AppTypeStripe, TaxCode: stripeCode},
+			},
+		})
+		require.NoError(t, err)
+
+		systemManaged, err := env.Service.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+			Namespace: duplicateNs,
+			Key:       "saas_business",
+			Name:      "Software as a Service (SaaS) - Business Use",
+			AppMappings: taxcode.TaxCodeAppMappings{
+				{AppType: app.AppTypeStripe, TaxCode: stripeCode},
+			},
+			Annotations: models.Annotations{
+				taxcode.AnnotationKeyManagedBy: taxcode.AnnotationValueManagedBySystem,
+				"schema_version":               1,
+			},
+		})
+		require.NoError(t, err)
+
+		got, err := env.Service.GetTaxCodeByAppMapping(t.Context(), taxcode.GetTaxCodeByAppMappingInput{
+			Namespace: duplicateNs,
+			AppType:   app.AppTypeStripe,
+			TaxCode:   stripeCode,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, systemManaged.ID, got.ID)
+		assert.True(t, got.IsManagedBySystem())
 	})
 }


### PR DESCRIPTION
## Overview

This fixes tax code resolution when a namespace contains both a user-created tax code and a system-provisioned catalog tax code for the same provider tax code.

In that state, invoice views that calculate gathering invoices with live data could fail before returning invoice details, because the provider tax-code mapping was assumed to identify exactly one tax code. For customers, this meant an otherwise valid invoice list could become unavailable after tax-code catalog seeding introduced a managed tax code that overlapped with an existing custom entry.

The fix resolves that ambiguity from the business ownership model: when multiple active tax codes match the same provider mapping, OpenMeter now prefers the system-managed tax code. If there is still more than one candidate in the same ownership class, resolution falls back to deterministic ordering so invoice calculation remains stable.

## Notes for reviewer

- No tax codes are deleted or migrated; duplicate user-created tax codes remain available by ID/key.
- The not-found behavior is preserved when no tax code matches the provider mapping.
- Regression coverage verifies that system-managed tax codes are preferred over user-created duplicates for the same Stripe tax code.