### PR TITLE
chore(ci): support POSTGRES_PORT env var

### DIFF
--- a/openmeter/testutils/pg_driver.go
+++ b/openmeter/testutils/pg_driver.go
@@ -104,13 +104,18 @@ func WithDriverOptions(opts []pgdriver.Option) Option {
 func InitPostgresDB(t *testing.T, opts ...Option) *TestDB {
 	t.Helper()
 
+	port := os.Getenv("POSTGRES_PORT")
+	if port == "" {
+		port = "5432"
+	}
+
 	o := options{
 		config: pgtestdb.Config{
 			DriverName: "pgx",
 			User:       "postgres",
 			Password:   "postgres",
 			Host:       os.Getenv("POSTGRES_HOST"),
-			Port:       "5432",
+			Port:       port,
 			Options:    "sslmode=disable",
 		},
 		migrator: &NoopMigrator{}, // TODO: fix migrations


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL database initialization to support environment-based port configuration, with a default fallback to the standard port when not specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->