### PR TITLE
feat: introduce feature gate into the subscription sync reconciler

### DIFF
--- a/app/common/billing.go
+++ b/app/common/billing.go
@@ -295,6 +295,7 @@ func NewBillingSubscriptionSyncService(logger *slog.Logger, subsServices Subscri
 		SubscriptionSyncAdapter: subscriptionSyncAdapter,
 		FeatureFlags: subscriptionsyncservice.FeatureFlags{
 			EnableCreditThenInvoice: creditsConfig.EnableCreditThenInvoice,
+			CreditsFlag:             creditsConfig.CreditsFlag,
 		},
 		Logger:      logger,
 		Tracer:      tracer,

--- a/app/common/billing.go
+++ b/app/common/billing.go
@@ -295,7 +295,7 @@ func NewBillingSubscriptionSyncService(logger *slog.Logger, subsServices Subscri
 		SubscriptionSyncAdapter: subscriptionSyncAdapter,
 		FeatureFlags: subscriptionsyncservice.FeatureFlags{
 			EnableCreditThenInvoice: creditsConfig.EnableCreditThenInvoice,
-			CreditsFlag:             creditsConfig.CreditsFlag,
+			CreditsFlag:             creditsConfig.FeatureFlag,
 		},
 		Logger:      logger,
 		Tracer:      tracer,

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -218,7 +218,7 @@ func SetViperDefaults(v *viper.Viper, flags *pflag.FlagSet) {
 	ConfigureEvents(v)
 	ConfigureBalanceWorker(v)
 	ConfigureNotification(v)
-	ConfigureCredits(v)
+	ConfigureCredits(v, "credits")
 	ConfigureBilling(v, flags)
 	ConfigureProductCatalog(v)
 	ConfigureApps(v, flags)
@@ -227,6 +227,6 @@ func SetViperDefaults(v *viper.Viper, flags *pflag.FlagSet) {
 	ConfigureServer(v, "server")
 	ConfigureProgressManager(v)
 	ConfigureCustomer(v, "customer")
-	ConfigureCredits(v)
+	ConfigureCredits(v, "credits")
 	ConfigureTaxCode(v)
 }

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -191,7 +191,7 @@ func TestComplete(t *testing.T) {
 		Credits: CreditsConfiguration{
 			Enabled:                 false,
 			EnableCreditThenInvoice: false,
-			CreditsFlag:             "billing_credits",
+			FeatureFlag:             "billing_credits",
 		},
 		Sink: SinkConfiguration{
 			GroupId:                 "openmeter-sink-worker",

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -191,7 +191,7 @@ func TestComplete(t *testing.T) {
 		Credits: CreditsConfiguration{
 			Enabled:                 false,
 			EnableCreditThenInvoice: false,
-			FeatureFlag:             "billing_credits",
+			FeatureFlag:             "",
 		},
 		Sink: SinkConfiguration{
 			GroupId:                 "openmeter-sink-worker",

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -191,6 +191,7 @@ func TestComplete(t *testing.T) {
 		Credits: CreditsConfiguration{
 			Enabled:                 false,
 			EnableCreditThenInvoice: false,
+			CreditsFlag:             "billing_credits",
 		},
 		Sink: SinkConfiguration{
 			GroupId:                 "openmeter-sink-worker",

--- a/app/config/credits.go
+++ b/app/config/credits.go
@@ -7,8 +7,9 @@ import (
 )
 
 type CreditsConfiguration struct {
-	Enabled                 bool `yaml:"enabled"`
-	EnableCreditThenInvoice bool `yaml:"enableCreditThenInvoice"`
+	Enabled                 bool   `yaml:"enabled"`
+	EnableCreditThenInvoice bool   `yaml:"enableCreditThenInvoice"`
+	CreditsFlag             string `yaml:"creditsFlag"`
 }
 
 func (c CreditsConfiguration) Validate() error {
@@ -19,7 +20,10 @@ func (c CreditsConfiguration) Validate() error {
 	return errors.Join(errs...)
 }
 
-func ConfigureCredits(v *viper.Viper) {
-	v.SetDefault("credits.enabled", false)
-	v.SetDefault("credits.enableCreditThenInvoice", false)
+func ConfigureCredits(v *viper.Viper, prefixes ...string) {
+	prefixer := NewViperKeyPrefixer(prefixes...)
+
+	v.SetDefault(prefixer("enabled"), false)
+	v.SetDefault(prefixer("enableCreditThenInvoice"), false)
+	v.SetDefault(prefixer("creditsFlag"), "billing_credits")
 }

--- a/app/config/credits.go
+++ b/app/config/credits.go
@@ -9,7 +9,7 @@ import (
 type CreditsConfiguration struct {
 	Enabled                 bool   `yaml:"enabled"`
 	EnableCreditThenInvoice bool   `yaml:"enableCreditThenInvoice"`
-	CreditsFlag             string `yaml:"creditsFlag"`
+	FeatureFlag             string `yaml:"featureFlag"`
 }
 
 func (c CreditsConfiguration) Validate() error {
@@ -25,5 +25,5 @@ func ConfigureCredits(v *viper.Viper, prefixes ...string) {
 
 	v.SetDefault(prefixer("enabled"), false)
 	v.SetDefault(prefixer("enableCreditThenInvoice"), false)
-	v.SetDefault(prefixer("creditsFlag"), "billing_credits")
+	v.SetDefault(prefixer("featureFlag"), "")
 }

--- a/openmeter/billing/worker/subscriptionsync/service/base_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/base_test.go
@@ -97,6 +97,7 @@ func (s *SuiteBase) setupChargesService(config chargestestutils.Config) {
 		SubscriptionSyncAdapter: s.Adapter,
 		SubscriptionService:     s.SubscriptionService,
 		FeatureGate:             featuregate.NewNoop(),
+		FeatureFlags:            FeatureFlags{CreditsFlag: "test-credit"},
 	})
 	s.NoError(err)
 

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patch.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patch.go
@@ -1,6 +1,7 @@
 package reconciler
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 
@@ -64,6 +65,7 @@ type patchCollectionRouter struct {
 	creditThenInvoiceEnabled   bool
 	creditsEnabled             bool
 	featureGate                featuregate.Gate
+	creditsFlag                string
 }
 
 type patchCollectionRouterConfig struct {
@@ -72,6 +74,7 @@ type patchCollectionRouterConfig struct {
 	creditThenInvoiceEnabled bool
 	creditsEnabled           bool
 	featureGate              featuregate.Gate
+	creditsFlag              string
 }
 
 func (c patchCollectionRouterConfig) Validate() error {
@@ -102,6 +105,7 @@ func newPatchCollectionRouter(cfg patchCollectionRouterConfig) (*patchCollection
 		creditThenInvoiceEnabled:   cfg.creditThenInvoiceEnabled,
 		creditsEnabled:             cfg.creditsEnabled,
 		featureGate:                cfg.featureGate,
+		creditsFlag:                cfg.creditsFlag,
 	}, nil
 }
 
@@ -127,11 +131,14 @@ func (c patchCollectionRouter) isCreditsEnabled(ns string) (bool, error) {
 	if c.featureGate == nil {
 		return true, nil
 	}
+	if c.creditsFlag == "" {
+		return false, errors.New("feature flag for credit is not set")
+	}
 	gate, err := c.featureGate.WithOrg(featuregate.NamespaceOrg(ns))
 	if err != nil {
 		return false, err
 	}
-	return gate.EvaluateBool(featuregate.FlagMeteringPrepaidCredits, false)
+	return gate.EvaluateBool(c.creditsFlag, false)
 }
 
 func (c patchCollectionRouter) ResolveDefaultCollection(target targetstate.StateItem) (PatchCollection, error) {

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patch.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patch.go
@@ -81,9 +81,6 @@ func (c patchCollectionRouterConfig) Validate() error {
 	if c.invoices == nil {
 		return fmt.Errorf("invoices is required")
 	}
-	if c.featureGate == nil {
-		return fmt.Errorf("feature gate is required")
-	}
 	return nil
 }
 
@@ -123,8 +120,24 @@ func (c patchCollectionRouter) GetCollectionFor(item persistedstate.Item) (Patch
 	}
 }
 
-func (c patchCollectionRouter) ResolveDefaultCollection(target targetstate.StateItem) (PatchCollection, error) {
+func (c patchCollectionRouter) isCreditsEnabled(ns string) (bool, error) {
 	if !c.creditsEnabled {
+		return false, nil
+	}
+	if c.featureGate == nil {
+		return true, nil
+	}
+	gate, err := c.featureGate.WithOrg(featuregate.NamespaceOrg(ns))
+	if err != nil {
+		return false, err
+	}
+	return gate.EvaluateBool(featuregate.FlagMeteringPrepaidCredits, false)
+}
+
+func (c patchCollectionRouter) ResolveDefaultCollection(target targetstate.StateItem) (PatchCollection, error) {
+	if enabled, err := c.isCreditsEnabled(target.SubscriptionItem.NamespacedID.Namespace); err != nil {
+		return c.lineCollection, err
+	} else if !enabled {
 		return c.lineCollection, nil
 	}
 

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patch.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patch.go
@@ -135,9 +135,12 @@ func (c patchCollectionRouter) isCreditsEnabled(ns string) (bool, error) {
 }
 
 func (c patchCollectionRouter) ResolveDefaultCollection(target targetstate.StateItem) (PatchCollection, error) {
-	if enabled, err := c.isCreditsEnabled(target.SubscriptionItem.NamespacedID.Namespace); err != nil {
-		return c.lineCollection, err
-	} else if !enabled {
+	enabled, err := c.isCreditsEnabled(target.SubscriptionItem.NamespacedID.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	if !enabled {
 		return c.lineCollection, nil
 	}
 

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patch.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patch.go
@@ -1,7 +1,6 @@
 package reconciler
 
 import (
-	"errors"
 	"fmt"
 	"slices"
 
@@ -132,7 +131,7 @@ func (c patchCollectionRouter) isCreditsEnabled(ns string) (bool, error) {
 		return true, nil
 	}
 	if c.creditsFlag == "" {
-		return false, errors.New("feature flag for credit is not set")
+		return true, nil
 	}
 	gate, err := c.featureGate.WithOrg(featuregate.NamespaceOrg(ns))
 	if err != nil {

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patch_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patch_test.go
@@ -90,6 +90,7 @@ func TestPatchCollectionRouterResolveDefaultCollection(t *testing.T) {
 				creditThenInvoiceEnabled: tt.enableCreditThenInvoice,
 				creditsEnabled:           tt.enableCredits,
 				featureGate:              featuregate.NewNoop(),
+				creditsFlag:              "test-credit",
 			})
 			require.NoError(t, err)
 
@@ -132,6 +133,7 @@ func TestIsCreditEnabled(t *testing.T) {
 			creditThenInvoiceEnabled: false,
 			creditsEnabled:           true,
 			featureGate:              featuregate.NewNoop(),
+			creditsFlag:              "test-credit",
 		})
 		require.NoError(t, err)
 

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patch_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patch_test.go
@@ -121,3 +121,52 @@ func testTargetStateItem(settlementMode productcatalog.SettlementMode, rateCard 
 		},
 	}
 }
+
+func TestIsCreditEnabled(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy_path", func(t *testing.T) {
+		router, err := newPatchCollectionRouter(patchCollectionRouterConfig{
+			capacity:                 1,
+			invoices:                 persistedstate.Invoices{},
+			creditThenInvoiceEnabled: false,
+			creditsEnabled:           true,
+			featureGate:              featuregate.NewNoop(),
+		})
+		require.NoError(t, err)
+
+		enabled, err := router.isCreditsEnabled("test")
+		require.NoError(t, err)
+		require.True(t, enabled)
+	})
+
+	t.Run("no_feature_gate_client", func(t *testing.T) {
+		router, err := newPatchCollectionRouter(patchCollectionRouterConfig{
+			capacity:                 1,
+			invoices:                 persistedstate.Invoices{},
+			creditThenInvoiceEnabled: false,
+			creditsEnabled:           true,
+			featureGate:              nil, // If feature gate is nil, it should default to enabled.
+		})
+		require.NoError(t, err)
+
+		enabled, err := router.isCreditsEnabled("test")
+		require.NoError(t, err)
+		require.True(t, enabled)
+	})
+
+	t.Run("credit_flag_disabled", func(t *testing.T) {
+		router, err := newPatchCollectionRouter(patchCollectionRouterConfig{
+			capacity:                 1,
+			invoices:                 persistedstate.Invoices{},
+			creditThenInvoiceEnabled: false,
+			creditsEnabled:           false,
+			featureGate:              featuregate.NewNoop(),
+		})
+		require.NoError(t, err)
+
+		enabled, err := router.isCreditsEnabled("test")
+		require.NoError(t, err)
+		require.False(t, enabled)
+	})
+}

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/reconciler.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/reconciler.go
@@ -33,6 +33,7 @@ type Config struct {
 	EnableCreditThenInvoice bool
 	Logger                  *slog.Logger
 	FeatureGate             featuregate.Gate
+	CreditsFlag             string
 }
 
 func (c Config) Validate() error {
@@ -47,9 +48,6 @@ func (c Config) Validate() error {
 	if c.EnableCreditThenInvoice && c.ChargesService == nil {
 		return fmt.Errorf("charges service is required when credit then invoice is enabled")
 	}
-	if c.FeatureGate == nil {
-		return fmt.Errorf("feature gate is required")
-	}
 
 	return nil
 }
@@ -62,6 +60,7 @@ type Service struct {
 
 	invoiceUpdater *invoiceupdater.Updater
 	featureGate    featuregate.Gate
+	creditsFlag    string
 }
 
 func New(config Config) (*Service, error) {
@@ -76,6 +75,7 @@ func New(config Config) (*Service, error) {
 		chargesService:          config.ChargesService,
 		enableCreditThenInvoice: config.EnableCreditThenInvoice && config.ChargesService != nil,
 		featureGate:             config.FeatureGate,
+		creditsFlag:             config.CreditsFlag,
 	}, nil
 }
 
@@ -228,6 +228,7 @@ func (s *Service) Plan(ctx context.Context, input PlanInput) (*Plan, error) {
 			creditThenInvoiceEnabled: s.enableCreditThenInvoice,
 			creditsEnabled:           s.chargesService != nil,
 			featureGate:              s.featureGate,
+			creditsFlag:              s.creditsFlag,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("creating collection by type: %w", err)

--- a/openmeter/billing/worker/subscriptionsync/service/service.go
+++ b/openmeter/billing/worker/subscriptionsync/service/service.go
@@ -22,6 +22,8 @@ type FeatureFlags struct {
 	EnableFlatFeeInAdvanceProrating bool
 	EnableFlatFeeInArrearsProrating bool
 	EnableCreditThenInvoice         bool
+
+	CreditsFlag string
 }
 
 type Config struct {
@@ -56,9 +58,6 @@ func (c Config) Validate() error {
 	if c.Tracer == nil {
 		return fmt.Errorf("tracer is required")
 	}
-	if c.FeatureGate == nil {
-		return fmt.Errorf("feature gate is required")
-	}
 
 	return nil
 }
@@ -86,6 +85,7 @@ func New(config Config) (*Service, error) {
 		EnableCreditThenInvoice: config.FeatureFlags.EnableCreditThenInvoice,
 		Logger:                  config.Logger,
 		FeatureGate:             config.FeatureGate,
+		CreditsFlag:             config.FeatureFlags.CreditsFlag,
 	})
 	if err != nil {
 		return nil, err

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -136,6 +136,7 @@ func (s *CreditThenInvoiceTestSuite) SetupSuite() {
 		SubscriptionService:     s.SubscriptionService,
 		FeatureFlags: FeatureFlags{
 			EnableCreditThenInvoice: true,
+			CreditsFlag:             "billing_credits",
 		},
 		FeatureGate: featuregate.NewNoop(),
 	})

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -7,10 +7,6 @@ import (
 	"github.com/samber/lo"
 )
 
-const (
-	FlagMeteringPrepaidCredits = "metering-prepaid-credits"
-)
-
 type Org interface {
 	Context
 

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -4,6 +4,11 @@ import (
 	"encoding/json"
 
 	"github.com/google/uuid"
+	"github.com/samber/lo"
+)
+
+const (
+	FlagMeteringPrepaidCredits = "metering-prepaid-credits"
 )
 
 type Org interface {
@@ -67,4 +72,46 @@ func (n Noop) WithFFContext(custom ...Context) (Gate, error) {
 
 func (n Noop) WithOrg(org Org) (Gate, error) {
 	return n.WithFFContext(org)
+}
+
+type NamespaceOrg string
+
+var _ Org = NamespaceOrg("")
+
+func (n NamespaceOrg) AddCustomAttribute(name string, value any) {}
+
+func (n NamespaceOrg) Anonymous() bool {
+	return false
+}
+
+func (n NamespaceOrg) FeatureSet() *string {
+	return nil
+}
+
+func (n NamespaceOrg) GetCustomAttributes() map[string]any {
+	return nil
+}
+
+func (n NamespaceOrg) ID() *uuid.UUID {
+	return lo.ToPtr(uuid.NewSHA1(uuid.NameSpaceURL, []byte(n)))
+}
+
+func (n NamespaceOrg) Key() string {
+	return string(n)
+}
+
+func (n NamespaceOrg) Kind() string {
+	return "namespace"
+}
+
+func (n NamespaceOrg) OrgName() *string {
+	return lo.ToPtr(string(n))
+}
+
+func (n NamespaceOrg) PortalID() *uuid.UUID {
+	return n.ID()
+}
+
+func (n NamespaceOrg) Tier() *string {
+	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Namespace-level control for enabling/disabling prepaid credits; added a configurable credits flag option.

* **Behavior**
  * Default collection routing now checks per-namespace prepaid credits and skips line-item collection when prepaid credits are not enabled.
  * Prepaid credits default to enabled when no feature-gate is present; feature-gate can explicitly disable them.

* **Configuration**
  * New creditsFlag configuration key and updated credits defaults handling.

* **Tests**
  * Added unit tests covering enabled, disabled, and missing feature-gate scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4445?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->