### PR TITLE
feat: deprecate splitline group tax fields

### DIFF
--- a/openmeter/billing/adapter/invoicelinesplitgroup.go
+++ b/openmeter/billing/adapter/invoicelinesplitgroup.go
@@ -10,9 +10,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicesplitlinegroup"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/openmeter/taxcode"
-	taxcodeadapter "github.com/openmeterio/openmeter/openmeter/taxcode/adapter"
 	"github.com/openmeterio/openmeter/pkg/framework/entutils"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/slicesx"
@@ -40,13 +37,7 @@ func (a *adapter) CreateSplitLineGroup(ctx context.Context, input billing.Create
 			SetCurrency(input.Currency).
 			SetRatecardDiscounts(&input.RatecardDiscounts).
 			SetPrice(input.Price).
-			SetNillableTaxConfig(input.TaxConfig).
 			SetNillableFeatureKey(input.FeatureKey)
-
-		if input.TaxConfig != nil {
-			create = create.SetNillableTaxCodeID(input.TaxConfig.TaxCodeID).
-				SetNillableTaxBehavior(input.TaxConfig.Behavior)
-		}
 
 		if input.Subscription != nil {
 			create = create.SetSubscriptionID(input.Subscription.SubscriptionID).
@@ -81,18 +72,9 @@ func (a *adapter) UpdateSplitLineGroup(ctx context.Context, input billing.Update
 			SetServicePeriodStart(input.ServicePeriod.From.UTC()).
 			SetServicePeriodEnd(input.ServicePeriod.To.UTC()).
 			SetRatecardDiscounts(&input.RatecardDiscounts).
-			SetOrClearTaxConfig(input.TaxConfig).
 			Where(
 				billinginvoicesplitlinegroup.Namespace(input.Namespace),
 			)
-
-		if input.TaxConfig != nil {
-			updateQuery = updateQuery.
-				SetOrClearTaxCodeID(input.TaxConfig.TaxCodeID).
-				SetOrClearTaxBehavior(input.TaxConfig.Behavior)
-		} else {
-			updateQuery = updateQuery.ClearTaxCodeID().ClearTaxBehavior()
-		}
 
 		dbSplitLineGroup, err := updateQuery.Save(ctx)
 		if err != nil {
@@ -143,7 +125,6 @@ func (a *adapter) GetSplitLineGroup(ctx context.Context, input billing.GetSplitL
 				billinginvoicesplitlinegroup.Namespace(input.Namespace),
 				billinginvoicesplitlinegroup.ID(input.ID),
 			).
-			WithTaxCode().
 			WithBillingInvoiceLines(func(q *db.BillingInvoiceLineQuery) {
 				a.expandLineItems(q)
 				q.WithBillingInvoice(func(q *db.BillingInvoiceQuery) {
@@ -163,18 +144,6 @@ func (a *adapter) GetSplitLineGroup(ctx context.Context, input billing.GetSplitL
 
 		return a.mapSplitLineHierarchyFromDB(ctx, dbSplitLineGroup)
 	})
-}
-
-func taxCodeFromSplitLineGroupEdge(dbGroup *db.BillingInvoiceSplitLineGroup) *taxcode.TaxCode {
-	tc, err := dbGroup.Edges.TaxCodeOrErr()
-	if err != nil {
-		return nil
-	}
-	mapped, err := taxcodeadapter.MapTaxCodeFromEntity(tc)
-	if err != nil {
-		return nil
-	}
-	return &mapped
 }
 
 func (a *adapter) mapSplitLineGroupFromDB(dbSplitLineGroup *db.BillingInvoiceSplitLineGroup) (billing.SplitLineGroup, error) {
@@ -220,12 +189,6 @@ func (a *adapter) mapSplitLineGroupFromDB(dbSplitLineGroup *db.BillingInvoiceSpl
 			},
 
 			RatecardDiscounts: lo.FromPtr(dbSplitLineGroup.RatecardDiscounts),
-
-			TaxConfig: productcatalog.BackfillTaxConfig(
-				lo.EmptyableToPtr(dbSplitLineGroup.TaxConfig),
-				dbSplitLineGroup.TaxBehavior,
-				taxCodeFromSplitLineGroupEdge(dbSplitLineGroup),
-			),
 		},
 		UniqueReferenceID: dbSplitLineGroup.UniqueReferenceID,
 
@@ -369,7 +332,6 @@ func (a *adapter) fetchAllSplitLineGroups(ctx context.Context, namespace string,
 			billinginvoicesplitlinegroup.Namespace(namespace),
 			billinginvoicesplitlinegroup.IDIn(splitLineGroupIDs...),
 		).
-		WithTaxCode().
 		WithBillingInvoiceLines(func(q *db.BillingInvoiceLineQuery) {
 			a.expandLineItems(q)
 			q.WithBillingInvoice(func(q *db.BillingInvoiceQuery) {

--- a/openmeter/billing/invoicelinesplitgroup.go
+++ b/openmeter/billing/invoicelinesplitgroup.go
@@ -23,8 +23,7 @@ type SplitLineGroupMutableFields struct {
 
 	ServicePeriod timeutil.ClosedPeriod `json:"period"`
 
-	RatecardDiscounts Discounts                 `json:"ratecardDiscounts"`
-	TaxConfig         *productcatalog.TaxConfig `json:"taxConfig,omitempty"`
+	RatecardDiscounts Discounts `json:"ratecardDiscounts"`
 }
 
 func (i SplitLineGroupMutableFields) ValidateForPrice(price *productcatalog.Price) error {
@@ -42,22 +41,12 @@ func (i SplitLineGroupMutableFields) ValidateForPrice(price *productcatalog.Pric
 		errs = append(errs, err)
 	}
 
-	if i.TaxConfig != nil {
-		if err := i.TaxConfig.Validate(); err != nil {
-			errs = append(errs, err)
-		}
-	}
-
 	return errors.Join(errs...)
 }
 
 func (i SplitLineGroupMutableFields) Clone() SplitLineGroupMutableFields {
 	clone := i
 	clone.RatecardDiscounts = i.RatecardDiscounts.Clone()
-
-	if i.TaxConfig != nil {
-		clone.TaxConfig = lo.ToPtr(i.TaxConfig.Clone())
-	}
 
 	return clone
 }

--- a/openmeter/billing/lineengine/splitlinegroup.go
+++ b/openmeter/billing/lineengine/splitlinegroup.go
@@ -43,7 +43,6 @@ func (e *Engine) SplitGatheringLine(ctx context.Context, in billing.SplitGatheri
 					To:   line.ServicePeriod.To,
 				},
 				RatecardDiscounts: line.RateCardDiscounts,
-				TaxConfig:         line.TaxConfig,
 			},
 			UniqueReferenceID: line.ChildUniqueReferenceID,
 			Currency:          line.Currency,

--- a/openmeter/ent/db/billinginvoicesplitlinegroup.go
+++ b/openmeter/ent/db/billinginvoicesplitlinegroup.go
@@ -43,10 +43,16 @@ type BillingInvoiceSplitLineGroup struct {
 	// Currency holds the value of the "currency" field.
 	Currency currencyx.Code `json:"currency,omitempty"`
 	// TaxConfig holds the value of the "tax_config" field.
+	//
+	// Deprecated: Field "tax_config" was marked as deprecated in the schema.
 	TaxConfig productcatalog.TaxConfig `json:"tax_config,omitempty"`
 	// TaxCodeID holds the value of the "tax_code_id" field.
+	//
+	// Deprecated: split line groups no longer carry tax configuration; use invoice line tax fields instead
 	TaxCodeID *string `json:"tax_code_id,omitempty"`
 	// TaxBehavior holds the value of the "tax_behavior" field.
+	//
+	// Deprecated: split line groups no longer carry tax configuration; use invoice line tax fields instead
 	TaxBehavior *productcatalog.TaxBehavior `json:"tax_behavior,omitempty"`
 	// ServicePeriodStart holds the value of the "service_period_start" field.
 	ServicePeriodStart time.Time `json:"service_period_start,omitempty"`

--- a/openmeter/ent/db/billinginvoicesplitlinegroup/billinginvoicesplitlinegroup.go
+++ b/openmeter/ent/db/billinginvoicesplitlinegroup/billinginvoicesplitlinegroup.go
@@ -133,9 +133,6 @@ var Columns = []string{
 	FieldName,
 	FieldDescription,
 	FieldCurrency,
-	FieldTaxConfig,
-	FieldTaxCodeID,
-	FieldTaxBehavior,
 	FieldServicePeriodStart,
 	FieldServicePeriodEnd,
 	FieldUniqueReferenceID,
@@ -154,6 +151,11 @@ var Columns = []string{
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
+			return true
+		}
+	}
+	for _, f := range [...]string{FieldTaxConfig, FieldTaxCodeID, FieldTaxBehavior} {
+		if column == f {
 			return true
 		}
 	}

--- a/openmeter/ent/db/entmixinaccessor.go
+++ b/openmeter/ent/db/entmixinaccessor.go
@@ -605,22 +605,6 @@ func (e *BillingInvoiceSplitLineGroup) GetDescription() *string {
 	return e.Description
 }
 
-func (e *BillingInvoiceSplitLineGroup) GetCurrency() currencyx.Code {
-	return e.Currency
-}
-
-func (e *BillingInvoiceSplitLineGroup) GetTaxConfig() productcatalog.TaxConfig {
-	return e.TaxConfig
-}
-
-func (e *BillingInvoiceSplitLineGroup) GetTaxCodeID() *string {
-	return e.TaxCodeID
-}
-
-func (e *BillingInvoiceSplitLineGroup) GetTaxBehavior() *productcatalog.TaxBehavior {
-	return e.TaxBehavior
-}
-
 func (e *BillingInvoiceUsageBasedLineConfig) GetID() string {
 	return e.ID
 }

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1151,17 +1151,17 @@ var (
 				Columns: []*schema.Column{BillingInvoiceSplitLineGroupsColumns[1], BillingInvoiceSplitLineGroupsColumns[0]},
 			},
 			{
-				Name:    "billinginvoicesplitlinegroup_tax_code_id",
-				Unique:  false,
-				Columns: []*schema.Column{BillingInvoiceSplitLineGroupsColumns[23]},
-			},
-			{
 				Name:    "billinginvoicesplitlinegroup_namespace_unique_reference_id",
 				Unique:  true,
 				Columns: []*schema.Column{BillingInvoiceSplitLineGroupsColumns[1], BillingInvoiceSplitLineGroupsColumns[13]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "unique_reference_id IS NOT NULL AND deleted_at IS NULL",
 				},
+			},
+			{
+				Name:    "billinginvoicesplitlinegroup_tax_code_id",
+				Unique:  false,
+				Columns: []*schema.Column{BillingInvoiceSplitLineGroupsColumns[23]},
 			},
 		},
 	}

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -645,8 +645,6 @@ func init() {
 	billinginvoicesplitlinegroupMixin := schema.BillingInvoiceSplitLineGroup{}.Mixin()
 	billinginvoicesplitlinegroupMixinFields0 := billinginvoicesplitlinegroupMixin[0].Fields()
 	_ = billinginvoicesplitlinegroupMixinFields0
-	billinginvoicesplitlinegroupMixinFields1 := billinginvoicesplitlinegroupMixin[1].Fields()
-	_ = billinginvoicesplitlinegroupMixinFields1
 	billinginvoicesplitlinegroupFields := schema.BillingInvoiceSplitLineGroup{}.Fields()
 	_ = billinginvoicesplitlinegroupFields
 	// billinginvoicesplitlinegroupDescNamespace is the schema descriptor for namespace field.
@@ -664,14 +662,14 @@ func init() {
 	// billinginvoicesplitlinegroup.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
 	billinginvoicesplitlinegroup.UpdateDefaultUpdatedAt = billinginvoicesplitlinegroupDescUpdatedAt.UpdateDefault.(func() time.Time)
 	// billinginvoicesplitlinegroupDescCurrency is the schema descriptor for currency field.
-	billinginvoicesplitlinegroupDescCurrency := billinginvoicesplitlinegroupMixinFields1[0].Descriptor()
+	billinginvoicesplitlinegroupDescCurrency := billinginvoicesplitlinegroupFields[0].Descriptor()
 	// billinginvoicesplitlinegroup.CurrencyValidator is a validator for the "currency" field. It is called by the builders before save.
 	billinginvoicesplitlinegroup.CurrencyValidator = billinginvoicesplitlinegroupDescCurrency.Validators[0].(func(string) error)
 	// billinginvoicesplitlinegroupDescRatecardDiscounts is the schema descriptor for ratecard_discounts field.
-	billinginvoicesplitlinegroupDescRatecardDiscounts := billinginvoicesplitlinegroupFields[3].Descriptor()
+	billinginvoicesplitlinegroupDescRatecardDiscounts := billinginvoicesplitlinegroupFields[7].Descriptor()
 	billinginvoicesplitlinegroup.ValueScanner.RatecardDiscounts = billinginvoicesplitlinegroupDescRatecardDiscounts.ValueScanner.(field.TypeValueScanner[*billing.Discounts])
 	// billinginvoicesplitlinegroupDescPrice is the schema descriptor for price field.
-	billinginvoicesplitlinegroupDescPrice := billinginvoicesplitlinegroupFields[5].Descriptor()
+	billinginvoicesplitlinegroupDescPrice := billinginvoicesplitlinegroupFields[9].Descriptor()
 	billinginvoicesplitlinegroup.ValueScanner.Price = billinginvoicesplitlinegroupDescPrice.ValueScanner.(field.TypeValueScanner[*productcatalog.Price])
 	// billinginvoicesplitlinegroupDescID is the schema descriptor for id field.
 	billinginvoicesplitlinegroupDescID := billinginvoicesplitlinegroupMixinFields0[0].Descriptor()

--- a/openmeter/ent/schema/billing.go
+++ b/openmeter/ent/schema/billing.go
@@ -615,13 +615,42 @@ type BillingInvoiceSplitLineGroup struct {
 func (BillingInvoiceSplitLineGroup) Mixin() []ent.Mixin {
 	return []ent.Mixin{
 		entutils.ResourceMixin{},
-		InvoiceLineBaseMixin{},
-		TaxMixin{},
 	}
 }
 
 func (BillingInvoiceSplitLineGroup) Fields() []ent.Field {
 	return []ent.Field{
+		field.String("currency").
+			GoType(currencyx.Code("")).
+			NotEmpty().
+			Immutable().
+			SchemaType(map[string]string{
+				dialect.Postgres: "varchar(3)",
+			}),
+
+		// Deprecated fields: split line groups no longer carry tax configuration.
+		// Tax configuration is stored on invoice lines and detailed lines.
+		field.JSON("tax_config", productcatalog.TaxConfig{}).
+			SchemaType(map[string]string{
+				dialect.Postgres: "jsonb",
+			}).
+			Optional().
+			Deprecated("split line groups no longer carry tax configuration; use invoice line tax fields instead"),
+
+		field.String("tax_code_id").
+			Optional().
+			Nillable().
+			SchemaType(map[string]string{
+				dialect.Postgres: "char(26)",
+			}).
+			Deprecated("split line groups no longer carry tax configuration; use invoice line tax fields instead"),
+
+		field.Enum("tax_behavior").
+			GoType(productcatalog.TaxBehavior("")).
+			Optional().
+			Nillable().
+			Deprecated("split line groups no longer carry tax configuration; use invoice line tax fields instead"),
+
 		field.Time("service_period_start"),
 		field.Time("service_period_end"),
 
@@ -689,6 +718,7 @@ func (BillingInvoiceSplitLineGroup) Indexes() []ent.Index {
 			Annotations(
 				entsql.IndexWhere("unique_reference_id IS NOT NULL AND deleted_at IS NULL"),
 			).Unique(),
+		index.Fields("tax_code_id"),
 	}
 }
 

--- a/test/billing/tax_test.go
+++ b/test/billing/tax_test.go
@@ -302,7 +302,6 @@ func (s *InvoicingTaxTestSuite) TestLineSplittingRetainsTaxConfig() {
 	s.Equal(createdTC.ID, *dbDetailedLine.TaxCodeID, "detailed line tax_code_id must match")
 	s.Require().NotNil(dbDetailedLine.TaxBehavior, "tax_behavior column must be populated on the detailed line row")
 	s.Equal(productcatalog.ExclusiveTaxBehavior, *dbDetailedLine.TaxBehavior, "detailed line tax_behavior must match")
-
 }
 
 func (s *InvoicingTaxTestSuite) generateDraftInvoice(ctx context.Context, customer *customer.Customer) billing.StandardInvoice {

--- a/test/billing/tax_test.go
+++ b/test/billing/tax_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	billinginvoicelinedb "github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoiceline"
-	billinginvoicesplitlinegroupdb "github.com/openmeterio/openmeter/openmeter/ent/db/billinginvoicesplitlinegroup"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
@@ -304,17 +303,6 @@ func (s *InvoicingTaxTestSuite) TestLineSplittingRetainsTaxConfig() {
 	s.Require().NotNil(dbDetailedLine.TaxBehavior, "tax_behavior column must be populated on the detailed line row")
 	s.Equal(productcatalog.ExclusiveTaxBehavior, *dbDetailedLine.TaxBehavior, "detailed line tax_behavior must match")
 
-	// Verify the normalized columns on the split line group row.
-	// Note: tax_code_id is NULL on split line groups because TaxCodeID resolution happens
-	// at the invoice line level (SnapshotTaxConfigIntoLines), not at the split group level.
-	// Only tax_behavior is populated because it's set directly from TaxConfig.Behavior.
-	dbSplitGroup, err := s.DBClient.BillingInvoiceSplitLineGroup.Query().
-		Where(billinginvoicesplitlinegroupdb.ID(*ubpSplitLine.SplitLineGroupID)).
-		Only(ctx)
-	s.Require().NoError(err)
-	s.Nil(dbSplitGroup.TaxCodeID, "tax_code_id is not resolved at split line group level")
-	s.Require().NotNil(dbSplitGroup.TaxBehavior, "tax_behavior column must be populated on the split line group row")
-	s.Equal(productcatalog.ExclusiveTaxBehavior, *dbSplitGroup.TaxBehavior, "split line group tax_behavior must match")
 }
 
 func (s *InvoicingTaxTestSuite) generateDraftInvoice(ctx context.Context, customer *customer.Customer) billing.StandardInvoice {


### PR DESCRIPTION
## Summary

This removes tax configuration from the billing split line group domain model and stops persisting or reading split-line-group-level tax fields during split group create, update, and fetch flows.

Included changes:
- Remove `TaxConfig` from `SplitLineGroupMutableFields`.
- Stop split line group create, update, and mapping code from writing or backfilling `tax_config`, `tax_code_id`, and `tax_behavior` on split line groups.
- Keep the underlying Ent fields for DB compatibility, but mark split-line-group tax fields as deprecated in schema metadata.
- Regenerate Ent code for the split line group schema change.
- Update the billing tax test to assert line and detailed-line tax persistence without expecting tax columns on the split line group row.

## Impact

Tax configuration remains owned by invoice lines and detailed lines. Split line group tax columns remain in the generated schema for compatibility, but new billing split group flows no longer populate or depend on them.

## Validation

- `go test -tags=dynamic ./openmeter/billing ./openmeter/billing/adapter ./openmeter/billing/lineengine ./openmeter/ent/schema`
- `go vet -tags=dynamic ./openmeter/billing ./openmeter/billing/adapter ./openmeter/billing/lineengine ./openmeter/ent/schema`
- `go vet -tags=dynamic ./test/billing`

Attempted the focused DB-backed billing tax test, but local Postgres was not listening on `127.0.0.1:5432`:

- `env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./test/billing -run 'TestInvoicingTax/TestLineSplittingRetainsTaxConfig'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified tax handling for split line groups: tax code/behavior are no longer applied or backfilled on split line groups; related split-group fields are now deprecated and split-group creation/update flows no longer set tax config.
* **Tests**
  * Updated tests to remove assertions that normalized tax columns exist on split line groups; tax validation remains at invoice and line levels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->