### PR TITLE
chore: log API binding errors as warnings

### DIFF
--- a/pkg/errorsx/handler.go
+++ b/pkg/errorsx/handler.go
@@ -39,6 +39,11 @@ func (h SlogHandler) Handle(err error) {
 		return
 	}
 
+	if isAPIError(err) {
+		h.Logger.Warn(err.Error())
+		return
+	}
+
 	// Warn errors are logged as warnings.
 	if wErr, ok := lo.ErrorsAs[*warnError](err); ok {
 		h.Logger.Warn(wErr.Error())
@@ -52,6 +57,11 @@ func (h SlogHandler) Handle(err error) {
 func (h SlogHandler) HandleContext(ctx context.Context, err error) {
 	// Context canceled errors are logged as warnings.
 	if errors.Is(err, context.Canceled) {
+		h.Logger.WarnContext(ctx, err.Error())
+		return
+	}
+
+	if isAPIError(err) {
 		h.Logger.WarnContext(ctx, err.Error())
 		return
 	}

--- a/pkg/errorsx/helpers.go
+++ b/pkg/errorsx/helpers.go
@@ -1,0 +1,55 @@
+package errorsx
+
+import (
+	"errors"
+	"reflect"
+	"slices"
+
+	api "github.com/openmeterio/openmeter/api"
+	apiv3 "github.com/openmeterio/openmeter/api/v3"
+)
+
+var apiErrorPackages = []string{
+	reflect.TypeOf(api.InvalidParamFormatError{}).PkgPath(),
+	reflect.TypeOf(apiv3.InvalidParamFormatError{}).PkgPath(),
+}
+
+func isAPIError(err error) bool {
+	// Package matching is the most maintainable way to identify generated API errors.
+	// The codegen output does not provide a common base error or helper for them.
+	return isErrorFromPackages(err, apiErrorPackages)
+}
+
+func isErrorFromPackages(err error, packagePaths []string) bool {
+	if err == nil {
+		return false
+	}
+
+	t := reflect.TypeOf(err)
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	if slices.Contains(packagePaths, t.PkgPath()) {
+		return true
+	}
+
+	return isUnwrappedErrorFromPackages(err, packagePaths)
+}
+
+func isUnwrappedErrorFromPackages(err error, packagePaths []string) bool {
+	unwrapped := errors.Unwrap(err)
+	if unwrapped != nil {
+		return isErrorFromPackages(unwrapped, packagePaths)
+	}
+
+	if unwrapper, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, err := range unwrapper.Unwrap() {
+			if isErrorFromPackages(err, packagePaths) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/errorsx/helpers_test.go
+++ b/pkg/errorsx/helpers_test.go
@@ -1,0 +1,70 @@
+package errorsx
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	api "github.com/openmeterio/openmeter/api"
+	apiv3 "github.com/openmeterio/openmeter/api/v3"
+)
+
+func TestIsAPIError(t *testing.T) {
+	apiErr := &api.InvalidParamFormatError{
+		ParamName: "page",
+		Err:       errors.New("invalid syntax"),
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "legacy api error",
+			err:  apiErr,
+			want: true,
+		},
+		{
+			name: "v3 api error",
+			err:  &apiv3.InvalidParamFormatError{ParamName: "page", Err: errors.New("invalid syntax")},
+			want: true,
+		},
+		{
+			name: "different generated api error type",
+			err:  &api.RequiredParamError{ParamName: "page"},
+			want: true,
+		},
+		{
+			name: "wrapped api error",
+			err:  fmt.Errorf("wrapped: %w", apiErr),
+			want: true,
+		},
+		{
+			name: "joined api error",
+			err: errors.Join(
+				errors.New("other error"),
+				apiErr,
+			),
+			want: true,
+		},
+		{
+			name: "ordinary error",
+			err:  errors.New("other error"),
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, isAPIError(test.err))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- classify generated legacy and v3 API binding errors in errorsx
- log those API binding errors at warning level from the shared slog error handler
- add coverage for direct, wrapped, and joined API errors

## Why

These errors are request/API binding failures caused by invalid client input. They are expected warning-level events rather than server failures, so the handler should log them as warnings instead of errors.

## Affected errors

 - UnescapedCookieParamError
  - UnmarshalingParamError
  - RequiredParamError
  - RequiredHeaderError
  - InvalidParamFormatError
  - TooManyValuesForParamError


## Validation

- go test ./pkg/errorsx
- go vet ./pkg/errorsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API errors are now detected more reliably (including wrapped and combined cases) and are logged as warnings earlier to reduce noise and prevent duplicate/error cascades.

* **Tests**
  * Added unit tests validating API error detection across legacy and current API types, wrapped errors, combined errors, and nil/non-API cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->