### PR TITLE
chore: improve Nix dev shell robustness

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -388,11 +388,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1779694939,
-        "narHash": "sha256-Ly4j75O8ICaSQx3uxPnwk2x7PMF0XQvn5r0c3yBA7FI=",
+        "lastModified": 1779877693,
+        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9d8b65950353691ab56561e7c73d2e1063d810b",
+        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -71,6 +71,7 @@
             git-hooks.package = pkgs.prek;
 
             packages = with pkgs; [
+              git
               gnumake
               mage
 
@@ -116,10 +117,10 @@
               # We can consider adding a pkgs.buildNpmPackage for spectral-cli if build takes a lot of time, but for now
               # this is a quick fix to get it working.
               (writeShellScriptBin "spectral" ''
-                exec ${pkgs.nodejs_24}/bin/npx -y @stoplight/spectral-cli@6.16.0 "$@"
+                exec ${pkgs.corepack_24}/bin/pnpx @stoplight/spectral-cli@6.16.0 "$@"
               '')
               (writeShellScriptBin "codegraph" ''
-                exec ${pkgs.nodejs_24}/bin/npx -y @colbymchenry/codegraph@0.9.5 "$@"
+                exec ${pkgs.corepack_24}/bin/pnpx @colbymchenry/codegraph@0.9.6 "$@"
               '')
 
               # python


### PR DESCRIPTION
## Overview

### What
- Add `git` to the Nix shell packages (was missing; caused issues in environments where system `git` isn't available)
- Switch `spectral` and `codegraph` wrappers from `npx` → `pnpx` (via `corepack_24`) and bump `codegraph` to `0.9.6`
- Bump `nixpkgs` input to latest `nixpkgs-unstable` (2026-05-27)

### Why
- `npx -y` silently downloads packages on every invocation and is not aligned with the corepack-managed pnpm setup already in the shell; `pnpx` uses the same toolchain and caches properly
- `git` is assumed present in most environments but should be declared explicitly for hermetic shells (e.g. CI, containers)
- Keeping the nixpkgs pin current reduces drift and picks up upstream security/bug fixes

### How
- `flake.nix`: add `git` to `packages`, replace `npx` with `corepack_24`-backed `pnpx`, pin codegraph `0.9.5` → `0.9.6`
- `flake.lock`: updated nixpkgs rev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Git is now included in the development shell environment

* **Chores**
  * Updated development helper scripts to use an improved package runner
  * Bumped code analysis tool version to 0.9.6 for enhanced functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->