### PR TITLE
fix: gathering preview totals for charge lines

### DIFF
--- a/openmeter/billing/charges/creditpurchase/lineengine/engine.go
+++ b/openmeter/billing/charges/creditpurchase/lineengine/engine.go
@@ -78,6 +78,10 @@ func (e *Engine) BuildStandardInvoiceLines(ctx context.Context, input billing.Bu
 	})
 }
 
+func (e *Engine) BuildStandardLinesForGatheringPreview(_ context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
+	return input.GatheringLines.ToStandardLines(input.Invoice.ID)
+}
+
 func (e *Engine) OnCollectionCompleted(_ context.Context, input billing.OnCollectionCompletedInput) (billing.StandardLines, error) {
 	return input.Lines, nil
 }

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -54,6 +54,52 @@ func (e *LineEngine) BuildStandardInvoiceLines(ctx context.Context, input billin
 	return stdLines, nil
 }
 
+func (e *LineEngine) BuildStandardLinesForGatheringPreview(ctx context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
+	if err := input.Validate(); err != nil {
+		return nil, fmt.Errorf("validating input: %w", err)
+	}
+
+	stdLines, err := input.GatheringLines.ToStandardLines(input.Invoice.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	chargesByID, err := e.getChargesForStandardLineEvent(ctx, billing.StandardLineEventInput{
+		Invoice: input.Invoice,
+		Lines:   stdLines,
+	}, meta.Expands{
+		meta.ExpandRealizations,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, stdLine := range stdLines {
+		charge, ok := chargesByID[*stdLine.ChargeID]
+		if !ok {
+			return nil, fmt.Errorf("flat fee charge[%s] not found for gathering preview line[%s]", *stdLine.ChargeID, stdLine.ID)
+		}
+
+		previewResult, err := e.service.realizations.BuildCreditThenInvoiceGatheringPreviewRun(flatfeerealizations.BuildCreditThenInvoiceGatheringPreviewRunInput{
+			Charge: charge,
+			Line:   *stdLine,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("building gathering preview run for line[%s]: %w", stdLine.ID, err)
+		}
+
+		if err := populateFlatFeeStandardLineFromRun(stdLine, previewResult.Run); err != nil {
+			return nil, fmt.Errorf("populating gathering preview line[%s] from run: %w", stdLine.ID, err)
+		}
+
+		if err := stdLine.Validate(); err != nil {
+			return nil, fmt.Errorf("validating gathering preview line[%s]: %w", stdLine.ID, err)
+		}
+	}
+
+	return stdLines, nil
+}
+
 func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing.OnStandardInvoiceCreatedInput) (billing.StandardLines, error) {
 	if err := input.Validate(); err != nil {
 		return nil, fmt.Errorf("validating input: %w", err)

--- a/openmeter/billing/charges/flatfee/service/realizations/preview.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/preview.go
@@ -1,0 +1,101 @@
+package realizations
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type BuildCreditThenInvoiceGatheringPreviewRunInput struct {
+	Charge flatfee.Charge
+	Line   billing.StandardLine
+}
+
+func (i BuildCreditThenInvoiceGatheringPreviewRunInput) Validate() error {
+	var errs []error
+
+	if err := i.Charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if err := i.Line.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("line: %w", err))
+	}
+
+	lineChargeID := lo.FromPtrOr(i.Line.ChargeID, "<nil>")
+	if lineChargeID != i.Charge.ID {
+		errs = append(errs, fmt.Errorf("line charge id mismatch: got %s, want %s", lineChargeID, i.Charge.ID))
+	}
+
+	if i.Charge.Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+		errs = append(errs, fmt.Errorf("unsupported settlement mode for gathering preview: %s", i.Charge.Intent.SettlementMode))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type BuildCreditThenInvoiceGatheringPreviewRunResult struct {
+	Run flatfee.RealizationRun
+}
+
+// BuildCreditThenInvoiceGatheringPreviewRun creates the charge run shape needed
+// to map a gathering invoice preview line without persisting realization state.
+// Preview intentionally does not allocate credits: get/list expansion must stay
+// side-effect-free, so returned standard lines show charge-rated totals before
+// charge credit allocation.
+func (s *Service) BuildCreditThenInvoiceGatheringPreviewRun(in BuildCreditThenInvoiceGatheringPreviewRunInput) (BuildCreditThenInvoiceGatheringPreviewRunResult, error) {
+	if err := in.Validate(); err != nil {
+		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, err
+	}
+
+	currencyCalculator, err := in.Charge.Intent.Currency.Calculator()
+	if err != nil {
+		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, fmt.Errorf("get currency calculator: %w", err)
+	}
+
+	amountAfterProration, err := invoiceupdater.GetFlatFeePerUnitAmount(&in.Line)
+	if err != nil {
+		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, fmt.Errorf("get flat fee line amount: %w", err)
+	}
+
+	amountAfterProration = currencyCalculator.RoundToPrecision(amountAfterProration)
+
+	line, err := rateFlatFeeLine(in.Line, s.ratingService)
+	if err != nil {
+		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, err
+	}
+
+	detailedLines := flatfee.DetailedLines(lo.Map(line.DetailedLines, func(detailedLine billing.DetailedLine, _ int) flatfee.DetailedLine {
+		return detailedLine.Base.Clone()
+	}))
+
+	runTotals := line.Totals.RoundToPrecision(currencyCalculator)
+	runType := flatfee.RealizationRunTypeFinalRealization
+	run := flatfee.RealizationRun{
+		RealizationRunBase: flatfee.RealizationRunBase{
+			ID: flatfee.RealizationRunID{
+				Namespace: in.Line.Namespace,
+				ID:        fmt.Sprintf("preview-%s", in.Line.ID),
+			},
+			LineID:                    lo.ToPtr(in.Line.ID),
+			InvoiceID:                 lo.ToPtr(in.Line.InvoiceID),
+			Type:                      runType,
+			InitialType:               runType,
+			ServicePeriod:             in.Line.Period,
+			AmountAfterProration:      amountAfterProration,
+			Totals:                    runTotals,
+			NoFiatTransactionRequired: runTotals.Total.IsZero(),
+		},
+		DetailedLines: mo.Some(detailedLines),
+	}
+
+	return BuildCreditThenInvoiceGatheringPreviewRunResult{Run: run}, nil
+}

--- a/openmeter/billing/charges/service/gathering_preview_test.go
+++ b/openmeter/billing/charges/service/gathering_preview_test.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	billingtest "github.com/openmeterio/openmeter/test/billing"
+)
+
+type assertGatheringPreviewInput struct {
+	Namespace  string
+	CustomerID string
+
+	ExpectedInvoiceTotals billingtest.ExpectedTotals
+	ExpectedLineTotals    billingtest.ExpectedTotals
+
+	AssertLine func(*billing.StandardLine)
+}
+
+func (s *BaseSuite) assertGatheringPreview(input assertGatheringPreviewInput) billing.StandardInvoice {
+	s.T().Helper()
+
+	invoices, err := s.BillingService.ListInvoices(s.T().Context(), billing.ListInvoicesInput{
+		Namespaces:       []string{input.Namespace},
+		Customers:        []string{input.CustomerID},
+		ExtendedStatuses: []billing.StandardInvoiceStatus{billing.StandardInvoiceStatusGathering},
+		Expand: billing.InvoiceExpands{}.
+			With(billing.InvoiceExpandLines).
+			With(billing.InvoiceExpandCalculateGatheringInvoiceWithLiveData),
+	})
+	s.NoError(err)
+	s.Require().Len(invoices.Items, 1)
+
+	previewInvoice, err := invoices.Items[0].AsStandardInvoice()
+	s.NoError(err)
+	s.RequireTotals(input.ExpectedInvoiceTotals, previewInvoice.Totals)
+
+	s.Require().True(previewInvoice.Lines.IsPresent())
+	s.Require().Len(previewInvoice.Lines.OrEmpty(), 1)
+	previewLine := previewInvoice.Lines.OrEmpty()[0]
+	s.NotEmpty(previewLine.DetailedLines)
+	s.RequireTotals(input.ExpectedLineTotals, previewLine.Totals)
+
+	if input.AssertLine != nil {
+		input.AssertLine(previewLine)
+	}
+
+	return previewInvoice
+}

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -49,6 +49,162 @@ func (s *InvoicableChargesTestSuite) TearDownTest() {
 	s.BaseSuite.TearDownTest()
 }
 
+func (s *InvoicableChargesTestSuite) TestFlatFeeGatheringPreviewPopulatesTotalsWithoutRealizationRun() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-service-flatfee-gathering-preview")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	s.NotEmpty(cust.ID)
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(servicePeriod.From)
+	defer clock.UnFreeze()
+
+	created, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: []charges.ChargeIntent{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(100),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				name:              "flat-fee-gathering-preview",
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: "flat-fee-gathering-preview",
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Require().Len(created, 1)
+
+	flatFeeCharge, err := created[0].AsFlatFeeCharge()
+	s.NoError(err)
+	flatFeeChargeID := flatFeeCharge.GetChargeID()
+
+	s.assertGatheringPreview(assertGatheringPreviewInput{
+		Namespace:  ns,
+		CustomerID: cust.ID,
+		ExpectedInvoiceTotals: billingtest.ExpectedTotals{
+			Amount: 100,
+			Total:  100,
+		},
+		ExpectedLineTotals: billingtest.ExpectedTotals{
+			Amount: 100,
+			Total:  100,
+		},
+		AssertLine: func(previewLine *billing.StandardLine) {
+			s.Equal(flatFeeChargeID.ID, lo.FromPtr(previewLine.ChargeID))
+			s.Empty(previewLine.CreditsApplied)
+		},
+	})
+
+	chargeAfterPreview := mustGetFlatFeeChargeWithExpands(&s.BaseSuite, flatFeeChargeID, meta.Expands{meta.ExpandRealizations})
+	s.Nil(chargeAfterPreview.Realizations.CurrentRun)
+	s.Empty(chargeAfterPreview.Realizations.PriorRuns)
+}
+
+func (s *InvoicableChargesTestSuite) TestUsageBasedGatheringPreviewPopulatesTotalsWithoutRealizationRun() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-service-usage-based-gathering-preview")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	s.NotEmpty(cust.ID)
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "P2D")),
+		billingtest.WithManualApproval(),
+	)
+
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-01T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
+	meterSlug := apiRequestsTotal.Feature.Key
+
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	created, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: []charges.ChargeIntent{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(2),
+				}),
+				name:              "usage-based-gathering-preview",
+				managedBy:         billing.SubscriptionManagedLine,
+				uniqueReferenceID: "usage-based-gathering-preview",
+				featureKey:        meterSlug,
+			}),
+		},
+	})
+	s.NoError(err)
+	s.Require().Len(created, 1)
+
+	usageBasedCharge, err := created[0].AsUsageBasedCharge()
+	s.NoError(err)
+	usageBasedChargeID := usageBasedCharge.GetChargeID()
+
+	s.MockStreamingConnector.AddSimpleEvent(
+		meterSlug,
+		15,
+		datetime.MustParseTimeInLocation(s.T(), "2026-01-15T00:00:00Z", time.UTC).AsTime(),
+	)
+
+	s.assertGatheringPreview(assertGatheringPreviewInput{
+		Namespace:  ns,
+		CustomerID: cust.ID,
+		ExpectedInvoiceTotals: billingtest.ExpectedTotals{
+			Amount: 30,
+			Total:  30,
+		},
+		ExpectedLineTotals: billingtest.ExpectedTotals{
+			Amount: 30,
+			Total:  30,
+		},
+		AssertLine: func(previewLine *billing.StandardLine) {
+			s.Require().NotNil(previewLine.UsageBased)
+			s.Require().NotNil(previewLine.UsageBased.MeteredQuantity)
+			s.Require().NotNil(previewLine.UsageBased.Quantity)
+			s.Require().NotNil(previewLine.UsageBased.MeteredPreLinePeriodQuantity)
+			s.Require().NotNil(previewLine.UsageBased.PreLinePeriodQuantity)
+			s.Equal(float64(15), lo.FromPtr(previewLine.UsageBased.MeteredQuantity).InexactFloat64())
+			s.Equal(float64(15), lo.FromPtr(previewLine.UsageBased.Quantity).InexactFloat64())
+			s.Equal(float64(0), lo.FromPtr(previewLine.UsageBased.MeteredPreLinePeriodQuantity).InexactFloat64())
+			s.Equal(float64(0), lo.FromPtr(previewLine.UsageBased.PreLinePeriodQuantity).InexactFloat64())
+		},
+	})
+
+	chargeAfterPreview := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
+	s.Nil(chargeAfterPreview.State.CurrentRealizationRunID)
+	s.Empty(chargeAfterPreview.Realizations)
+}
+
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceImmutableProration() {
 	for _, creditNotesAvailable := range []bool{true, false} {
 		name := "credit notes unavailable"

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -71,6 +71,14 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeGatheringPreviewPopulatesTotalsW
 	clock.FreezeTime(servicePeriod.From)
 	defer clock.UnFreeze()
 
+	creditAllocationCallback := newCountedCreditAllocationCallback[flatfee.OnAllocateCreditsInput]()
+	s.FlatFeeTestHandler.onAllocateCredits = creditAllocationCallback.Handler(
+		s.T(),
+		func(flatfee.OnAllocateCreditsInput, ledgertransaction.GroupReference) creditrealization.CreateAllocationInputs {
+			return nil
+		},
+	)
+
 	created, err := s.Charges.Create(ctx, charges.CreateInput{
 		Namespace: ns,
 		Intents: []charges.ChargeIntent{
@@ -116,6 +124,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeGatheringPreviewPopulatesTotalsW
 	chargeAfterPreview := mustGetFlatFeeChargeWithExpands(&s.BaseSuite, flatFeeChargeID, meta.Expands{meta.ExpandRealizations})
 	s.Nil(chargeAfterPreview.Realizations.CurrentRun)
 	s.Empty(chargeAfterPreview.Realizations.PriorRuns)
+	s.Zero(creditAllocationCallback.nrInvocations)
 }
 
 func (s *InvoicableChargesTestSuite) TestUsageBasedGatheringPreviewPopulatesTotalsWithoutRealizationRun() {

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -266,6 +266,54 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePartialInvoi
 		s.Equal(partialInvoice.ID, invoicesResult.Items[0].ID)
 	})
 
+	s.Run("when gathering invoice is previewed with an active partial run", func() {
+		// given:
+		// - the partial realization run is still active
+		// - a remaining gathering line exists for the rest of the service period
+		// when:
+		// - billing lists the gathering invoice with live preview expansion
+		// then:
+		// - preview uses the active run as prior billing history and does not create a new run
+		invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
+			Namespaces:       []string{ns},
+			Customers:        []string{cust.ID},
+			ExtendedStatuses: []billing.StandardInvoiceStatus{billing.StandardInvoiceStatusGathering},
+			Expand: billing.InvoiceExpands{}.
+				With(billing.InvoiceExpandLines).
+				With(billing.InvoiceExpandCalculateGatheringInvoiceWithLiveData),
+		})
+		s.NoError(err)
+		s.Require().Len(invoices.Items, 1)
+
+		previewInvoice, err := invoices.Items[0].AsStandardInvoice()
+		s.NoError(err)
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount: 2.5,
+			Total:  2.5,
+		}, previewInvoice.Totals)
+
+		s.Require().True(previewInvoice.Lines.IsPresent())
+		s.Require().Len(previewInvoice.Lines.OrEmpty(), 1)
+		previewLine := previewInvoice.Lines.OrEmpty()[0]
+		s.Require().NotNil(previewLine.UsageBased)
+		s.Require().NotNil(previewLine.UsageBased.MeteredQuantity)
+		s.Require().NotNil(previewLine.UsageBased.Quantity)
+		s.Require().NotNil(previewLine.UsageBased.MeteredPreLinePeriodQuantity)
+		s.Require().NotNil(previewLine.UsageBased.PreLinePeriodQuantity)
+		s.Equal(float64(5), lo.FromPtr(previewLine.UsageBased.MeteredQuantity).InexactFloat64())
+		s.Equal(float64(5), lo.FromPtr(previewLine.UsageBased.Quantity).InexactFloat64())
+		s.Equal(float64(15), lo.FromPtr(previewLine.UsageBased.MeteredPreLinePeriodQuantity).InexactFloat64())
+		s.Equal(float64(15), lo.FromPtr(previewLine.UsageBased.PreLinePeriodQuantity).InexactFloat64())
+		s.NotEmpty(previewLine.DetailedLines)
+
+		charge := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
+		s.Equal(usagebased.StatusActivePartialInvoiceWaitingForCollection, charge.Status)
+		s.Len(charge.Realizations, 1)
+		currentRun, runErr := charge.GetCurrentRealizationRun()
+		s.NoError(runErr)
+		s.Equal(partialRunID, currentRun.ID.ID)
+	})
+
 	s.Run("when the first partial invoice is advanced and approved", func() {
 		// given:
 		// - the first partial invoice is ready to be collected and manually approved

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -274,37 +274,29 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePartialInvoi
 		// - billing lists the gathering invoice with live preview expansion
 		// then:
 		// - preview uses the active run as prior billing history and does not create a new run
-		invoices, err := s.BillingService.ListInvoices(ctx, billing.ListInvoicesInput{
-			Namespaces:       []string{ns},
-			Customers:        []string{cust.ID},
-			ExtendedStatuses: []billing.StandardInvoiceStatus{billing.StandardInvoiceStatusGathering},
-			Expand: billing.InvoiceExpands{}.
-				With(billing.InvoiceExpandLines).
-				With(billing.InvoiceExpandCalculateGatheringInvoiceWithLiveData),
+		s.assertGatheringPreview(assertGatheringPreviewInput{
+			Namespace:  ns,
+			CustomerID: cust.ID,
+			ExpectedInvoiceTotals: billingtest.ExpectedTotals{
+				Amount: 2.5,
+				Total:  2.5,
+			},
+			ExpectedLineTotals: billingtest.ExpectedTotals{
+				Amount: 2.5,
+				Total:  2.5,
+			},
+			AssertLine: func(previewLine *billing.StandardLine) {
+				s.Require().NotNil(previewLine.UsageBased)
+				s.Require().NotNil(previewLine.UsageBased.MeteredQuantity)
+				s.Require().NotNil(previewLine.UsageBased.Quantity)
+				s.Require().NotNil(previewLine.UsageBased.MeteredPreLinePeriodQuantity)
+				s.Require().NotNil(previewLine.UsageBased.PreLinePeriodQuantity)
+				s.Equal(float64(5), lo.FromPtr(previewLine.UsageBased.MeteredQuantity).InexactFloat64())
+				s.Equal(float64(5), lo.FromPtr(previewLine.UsageBased.Quantity).InexactFloat64())
+				s.Equal(float64(15), lo.FromPtr(previewLine.UsageBased.MeteredPreLinePeriodQuantity).InexactFloat64())
+				s.Equal(float64(15), lo.FromPtr(previewLine.UsageBased.PreLinePeriodQuantity).InexactFloat64())
+			},
 		})
-		s.NoError(err)
-		s.Require().Len(invoices.Items, 1)
-
-		previewInvoice, err := invoices.Items[0].AsStandardInvoice()
-		s.NoError(err)
-		s.RequireTotals(billingtest.ExpectedTotals{
-			Amount: 2.5,
-			Total:  2.5,
-		}, previewInvoice.Totals)
-
-		s.Require().True(previewInvoice.Lines.IsPresent())
-		s.Require().Len(previewInvoice.Lines.OrEmpty(), 1)
-		previewLine := previewInvoice.Lines.OrEmpty()[0]
-		s.Require().NotNil(previewLine.UsageBased)
-		s.Require().NotNil(previewLine.UsageBased.MeteredQuantity)
-		s.Require().NotNil(previewLine.UsageBased.Quantity)
-		s.Require().NotNil(previewLine.UsageBased.MeteredPreLinePeriodQuantity)
-		s.Require().NotNil(previewLine.UsageBased.PreLinePeriodQuantity)
-		s.Equal(float64(5), lo.FromPtr(previewLine.UsageBased.MeteredQuantity).InexactFloat64())
-		s.Equal(float64(5), lo.FromPtr(previewLine.UsageBased.Quantity).InexactFloat64())
-		s.Equal(float64(15), lo.FromPtr(previewLine.UsageBased.MeteredPreLinePeriodQuantity).InexactFloat64())
-		s.Equal(float64(15), lo.FromPtr(previewLine.UsageBased.PreLinePeriodQuantity).InexactFloat64())
-		s.NotEmpty(previewLine.DetailedLines)
 
 		charge := s.mustGetUsageBasedChargeByID(usageBasedChargeID)
 		s.Equal(usagebased.StatusActivePartialInvoiceWaitingForCollection, charge.Status)

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -117,6 +117,87 @@ func (e *LineEngine) BuildStandardInvoiceLines(ctx context.Context, input billin
 	return stdLines, nil
 }
 
+func (e *LineEngine) BuildStandardLinesForGatheringPreview(ctx context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
+	if err := input.Validate(); err != nil {
+		return nil, fmt.Errorf("validating input: %w", err)
+	}
+
+	stdLines, err := input.GatheringLines.ToStandardLines(input.Invoice.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	chargesByID, err := e.getChargesForStandardLineEvent(ctx, billing.StandardLineEventInput{
+		Invoice: input.Invoice,
+		Lines:   stdLines,
+	}, meta.Expands{
+		meta.ExpandRealizations,
+		meta.ExpandDetailedLines,
+	}, "gathering preview")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, stdLine := range stdLines {
+		charge, ok := chargesByID[*stdLine.ChargeID]
+		if !ok {
+			return nil, fmt.Errorf("usage based charge[%s] not found for gathering preview line[%s]", *stdLine.ChargeID, stdLine.ID)
+		}
+
+		previewResult, err := e.buildGatheringPreviewRun(ctx, charge, stdLine)
+		if err != nil {
+			return nil, fmt.Errorf("building gathering preview run for line[%s]: %w", stdLine.ID, err)
+		}
+
+		if err := populateUsageBasedStandardLineFromRun(stdLine, previewResult.Run, previewResult.Runs); err != nil {
+			return nil, fmt.Errorf("populating gathering preview line[%s] from run: %w", stdLine.ID, err)
+		}
+
+		if err := stdLine.Validate(); err != nil {
+			return nil, fmt.Errorf("validating gathering preview line[%s]: %w", stdLine.ID, err)
+		}
+	}
+
+	return stdLines, nil
+}
+
+func (e *LineEngine) buildGatheringPreviewRun(ctx context.Context, charge usagebased.Charge, stdLine *billing.StandardLine) (usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunResult, error) {
+	if charge.Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+		return usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunResult{}, fmt.Errorf(
+			"usage based standard line[%s]: unsupported settlement mode for gathering preview: %s",
+			stdLine.ID,
+			charge.Intent.SettlementMode,
+		)
+	}
+
+	stateMachineConfig, err := e.service.getStateMachineConfigForPatch(ctx, charge)
+	if err != nil {
+		return usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunResult{}, fmt.Errorf("getting state machine config for line[%s]: %w", stdLine.ID, err)
+	}
+
+	runType := usagebased.RealizationRunTypePartialInvoice
+	storedAtLT := meta.NormalizeTimestamp(stdLine.Period.To)
+	servicePeriodTo := storedAtLT
+	if resolveInvoiceCreatedTrigger(charge, stdLine.Period) == meta.TriggerFinalInvoiceCreated {
+		runType = usagebased.RealizationRunTypeFinalRealization
+		storedAtLT, _ = stateMachineConfig.CustomerOverride.MergedProfile.WorkflowConfig.Collection.Interval.AddTo(charge.Intent.ServicePeriod.To)
+		storedAtLT = meta.NormalizeTimestamp(storedAtLT)
+		servicePeriodTo = meta.NormalizeTimestamp(charge.Intent.ServicePeriod.To)
+	}
+
+	return e.service.runs.BuildCreditThenInvoiceGatheringPreviewRun(ctx, usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunInput{
+		Charge:             charge,
+		CustomerOverride:   stateMachineConfig.CustomerOverride,
+		FeatureMeter:       stateMachineConfig.FeatureMeter,
+		Type:               runType,
+		StoredAtLT:         storedAtLT,
+		ServicePeriodTo:    servicePeriodTo,
+		LineID:             stdLine.ID,
+		InvoiceID:          stdLine.InvoiceID,
+		CurrencyCalculator: stateMachineConfig.CurrencyCalculator,
+	})
+}
+
 func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing.OnStandardInvoiceCreatedInput) (billing.StandardLines, error) {
 	if err := input.Validate(); err != nil {
 		return nil, fmt.Errorf("validating input: %w", err)

--- a/openmeter/billing/charges/usagebased/service/run/preview.go
+++ b/openmeter/billing/charges/usagebased/service/run/preview.go
@@ -1,0 +1,139 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/samber/mo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	usagebasedrating "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/rating"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+type BuildCreditThenInvoiceGatheringPreviewRunInput struct {
+	Charge             usagebased.Charge
+	CustomerOverride   billing.CustomerOverrideWithDetails
+	FeatureMeter       feature.FeatureMeter
+	Type               usagebased.RealizationRunType
+	StoredAtLT         time.Time
+	ServicePeriodTo    time.Time
+	LineID             string
+	InvoiceID          string
+	CurrencyCalculator currencyx.Calculator
+}
+
+func (i BuildCreditThenInvoiceGatheringPreviewRunInput) Validate() error {
+	var errs []error
+
+	if err := i.Charge.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("charge: %w", err))
+	}
+
+	if i.Charge.Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+		errs = append(errs, fmt.Errorf("unsupported settlement mode for gathering preview: %s", i.Charge.Intent.SettlementMode))
+	}
+
+	if i.CustomerOverride.Customer == nil {
+		errs = append(errs, errors.New("expanded customer is required"))
+	}
+
+	if i.FeatureMeter.Meter == nil {
+		errs = append(errs, errors.New("feature meter is required"))
+	}
+
+	if err := i.Type.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("type: %w", err))
+	}
+
+	if i.StoredAtLT.IsZero() {
+		errs = append(errs, errors.New("stored at lt is required"))
+	}
+
+	if i.ServicePeriodTo.IsZero() {
+		errs = append(errs, errors.New("service period to is required"))
+	}
+
+	if i.LineID == "" {
+		errs = append(errs, errors.New("line id is required"))
+	}
+
+	if i.InvoiceID == "" {
+		errs = append(errs, errors.New("invoice id is required"))
+	}
+
+	if err := i.CurrencyCalculator.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("currency calculator: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type BuildCreditThenInvoiceGatheringPreviewRunResult struct {
+	Run  usagebased.RealizationRun
+	Runs usagebased.RealizationRuns
+}
+
+// BuildCreditThenInvoiceGatheringPreviewRun creates the charge run shape needed
+// to map a gathering invoice preview line without persisting realization state.
+// Preview intentionally does not allocate credits: get/list expansion must stay
+// side-effect-free, so returned standard lines show charge-rated totals before
+// charge credit allocation.
+func (s *Service) BuildCreditThenInvoiceGatheringPreviewRun(ctx context.Context, in BuildCreditThenInvoiceGatheringPreviewRunInput) (BuildCreditThenInvoiceGatheringPreviewRunResult, error) {
+	if err := in.Validate(); err != nil {
+		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, err
+	}
+
+	ratingResult, err := s.rater.GetDetailedRatingForUsage(ctx, usagebasedrating.GetDetailedRatingForUsageInput{
+		Charge:          in.Charge,
+		StoredAtLT:      in.StoredAtLT,
+		ServicePeriodTo: in.ServicePeriodTo,
+		Customer:        in.CustomerOverride,
+		FeatureMeter:    in.FeatureMeter,
+	})
+	if err != nil {
+		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, fmt.Errorf("get detailed rating for usage: %w", err)
+	}
+
+	runTotals := ratingResult.Totals.RoundToPrecision(in.CurrencyCalculator)
+	if runTotals.Total.IsNegative() {
+		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, usagebased.ErrChargeTotalIsNegative.
+			WithAttrs(models.Attributes{
+				"total":     runTotals.Total.String(),
+				"charge_id": in.Charge.ID,
+			})
+	}
+
+	previewRun := usagebased.RealizationRun{
+		RealizationRunBase: usagebased.RealizationRunBase{
+			ID: usagebased.RealizationRunID{
+				Namespace: in.Charge.Namespace,
+				ID:        fmt.Sprintf("preview-%s", in.LineID),
+			},
+			FeatureID:                 in.FeatureMeter.Feature.ID,
+			Type:                      in.Type,
+			InitialType:               in.Type,
+			StoredAtLT:                in.StoredAtLT,
+			ServicePeriodTo:           in.ServicePeriodTo,
+			LineID:                    lo.ToPtr(in.LineID),
+			InvoiceID:                 lo.ToPtr(in.InvoiceID),
+			MeteredQuantity:           ratingResult.Quantity,
+			Totals:                    runTotals,
+			NoFiatTransactionRequired: runTotals.Total.IsZero(),
+		},
+		DetailedLines: mo.Some(ratingResult.DetailedLines),
+	}
+
+	return BuildCreditThenInvoiceGatheringPreviewRunResult{
+		Run:  previewRun,
+		Runs: slices.Concat(in.Charge.Realizations, usagebased.RealizationRuns{previewRun}),
+	}, nil
+}

--- a/openmeter/billing/charges/usagebased/service/run/preview.go
+++ b/openmeter/billing/charges/usagebased/service/run/preview.go
@@ -50,6 +50,10 @@ func (i BuildCreditThenInvoiceGatheringPreviewRunInput) Validate() error {
 		errs = append(errs, errors.New("feature meter is required"))
 	}
 
+	if i.FeatureMeter.Feature.ID == "" {
+		errs = append(errs, errors.New("feature id is required"))
+	}
+
 	if err := i.Type.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("type: %w", err))
 	}

--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -218,6 +218,32 @@ type GatheringInvoiceAvailableActions struct {
 
 type GatheringLines []GatheringLine
 
+func (l GatheringLines) ToStandardLines(invoiceID string) (StandardLines, error) {
+	return slicesx.MapWithErr(l, func(gatheringLine GatheringLine) (*StandardLine, error) {
+		stdLine, err := gatheringLine.AsNewStandardLine(invoiceID)
+		if err != nil {
+			return nil, fmt.Errorf("converting gathering line to standard line: %w", err)
+		}
+
+		return stdLine, nil
+	})
+}
+
+func ValidateStandardLineIDsMatchGatheringLinesExactly(expected GatheringLines, actual StandardLines) error {
+	expectedIDs := lo.Map(expected, func(line GatheringLine, _ int) string {
+		return line.ID
+	})
+	actualIDs := lo.Map(actual, func(line *StandardLine, _ int) string {
+		return line.ID
+	})
+
+	if !lo.ElementsMatch(expectedIDs, actualIDs) {
+		return fmt.Errorf("line ids mismatch: expected %v, got %v", expectedIDs, actualIDs)
+	}
+
+	return nil
+}
+
 func (l GatheringLines) Validate() error {
 	return errors.Join(
 		lo.Map(l, func(l GatheringLine, _ int) error {

--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -229,7 +229,9 @@ func (l GatheringLines) ToStandardLines(invoiceID string) (StandardLines, error)
 	})
 }
 
-func ValidateStandardLineIDsMatchGatheringLinesExactly(expected GatheringLines, actual StandardLines) error {
+// ValidateStandardLineIDsMatchGatheringLinesUnordered validates that a standard-line result
+// preserves the same gathering-line IDs, regardless of output order.
+func ValidateStandardLineIDsMatchGatheringLinesUnordered(expected GatheringLines, actual StandardLines) error {
 	expectedIDs := lo.Map(expected, func(line GatheringLine, _ int) string {
 		return line.ID
 	})

--- a/openmeter/billing/lineengine.go
+++ b/openmeter/billing/lineengine.go
@@ -215,6 +215,9 @@ type LineEngine interface {
 	// BuildStandardInvoiceLines materializes gathering lines into standard lines for a target invoice.
 	// Returned standard lines must reuse the exact same line IDs as the input gathering lines.
 	BuildStandardInvoiceLines(ctx context.Context, input BuildStandardInvoiceLinesInput) (StandardLines, error)
+	// BuildStandardLinesForGatheringPreview materializes gathering lines into a transient standard invoice preview.
+	// Returned standard lines must reuse the exact same line IDs as the input gathering lines.
+	BuildStandardLinesForGatheringPreview(ctx context.Context, input BuildStandardInvoiceLinesInput) (StandardLines, error)
 	// OnStandardInvoiceCreated is invoked after the standard invoice and its standard lines have been persisted.
 	OnStandardInvoiceCreated(ctx context.Context, input OnStandardInvoiceCreatedInput) (StandardLines, error)
 	// OnCollectionCompleted is invoked when a standard invoice collection window closes.

--- a/openmeter/billing/lineengine.go
+++ b/openmeter/billing/lineengine.go
@@ -215,8 +215,11 @@ type LineEngine interface {
 	// BuildStandardInvoiceLines materializes gathering lines into standard lines for a target invoice.
 	// Returned standard lines must reuse the exact same line IDs as the input gathering lines.
 	BuildStandardInvoiceLines(ctx context.Context, input BuildStandardInvoiceLinesInput) (StandardLines, error)
-	// BuildStandardLinesForGatheringPreview materializes gathering lines into a transient standard invoice preview.
-	// Returned standard lines must reuse the exact same line IDs as the input gathering lines.
+	// BuildStandardLinesForGatheringPreview materializes gathering lines from BuildStandardInvoiceLinesInput
+	// into transient StandardLines for a read-only standard invoice preview. Implementations must be
+	// side-effect free: they must not persist realization state, modify or allocate credits, mutate
+	// input IDs, emit events, or perform external billing side effects. Returned StandardLines must
+	// reuse the exact same line IDs as the input gathering lines.
 	BuildStandardLinesForGatheringPreview(ctx context.Context, input BuildStandardInvoiceLinesInput) (StandardLines, error)
 	// OnStandardInvoiceCreated is invoked after the standard invoice and its standard lines have been persisted.
 	OnStandardInvoiceCreated(ctx context.Context, input OnStandardInvoiceCreatedInput) (StandardLines, error)

--- a/openmeter/billing/lineengine/stdinvoice.go
+++ b/openmeter/billing/lineengine/stdinvoice.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
-	"github.com/openmeterio/openmeter/pkg/slicesx"
 )
 
 type QuantitySnapshotter interface {
@@ -16,6 +15,22 @@ type QuantitySnapshotter interface {
 }
 
 func (e *Engine) BuildStandardInvoiceLines(ctx context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
+	stdLines, err := e.buildStandardInvoiceLinesWithQuantitySnapshot(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return e.CalculateLines(billing.CalculateLinesInput{
+		Invoice: input.Invoice,
+		Lines:   stdLines,
+	})
+}
+
+func (e *Engine) BuildStandardLinesForGatheringPreview(ctx context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
+	return e.buildStandardInvoiceLinesWithQuantitySnapshot(ctx, input)
+}
+
+func (e *Engine) buildStandardInvoiceLinesWithQuantitySnapshot(ctx context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
 	if input.Invoice.ID == "" {
 		return nil, fmt.Errorf("invoice id is required")
 	}
@@ -24,14 +39,7 @@ func (e *Engine) BuildStandardInvoiceLines(ctx context.Context, input billing.Bu
 		return nil, fmt.Errorf("gathering lines are required")
 	}
 
-	stdLines, err := slicesx.MapWithErr(input.GatheringLines, func(gatheringLine billing.GatheringLine) (*billing.StandardLine, error) {
-		newStandardLine, err := gatheringLine.AsNewStandardLine(input.Invoice.ID)
-		if err != nil {
-			return nil, fmt.Errorf("converting gathering line to standard line: %w", err)
-		}
-
-		return newStandardLine, nil
-	})
+	stdLines, err := input.GatheringLines.ToStandardLines(input.Invoice.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -44,10 +52,7 @@ func (e *Engine) BuildStandardInvoiceLines(ctx context.Context, input billing.Bu
 		return nil, fmt.Errorf("snapshotting line quantities: %w", err)
 	}
 
-	return e.CalculateLines(billing.CalculateLinesInput{
-		Invoice: input.Invoice,
-		Lines:   stdLines,
-	})
+	return stdLines, nil
 }
 
 func (e *Engine) CalculateLines(input billing.CalculateLinesInput) (billing.StandardLines, error) {

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -210,22 +210,60 @@ func (s *Service) calculateGatheringInvoiceAsStandardInvoice(ctx context.Context
 		return nil, fmt.Errorf("resolving feature meters: %w", err)
 	}
 
-	inScopeLines := make([]*billing.StandardLine, 0, len(invoice.Lines.OrEmpty()))
+	inScopeGatheringLines := make(billing.GatheringLines, 0, len(invoice.Lines.OrEmpty()))
 	for _, line := range invoice.Lines.OrEmpty() {
 		if line.DeletedAt != nil {
 			continue
 		}
 
-		newStandardLine, err := line.AsNewStandardLine(out.ID)
-		if err != nil {
-			return nil, fmt.Errorf("converting gathering line to standard line: %w", err)
+		if err := s.lineEngines.populateGatheringLineEngine(&line); err != nil {
+			return nil, fmt.Errorf("populating gathering line engine: %w", err)
 		}
 
-		inScopeLines = append(inScopeLines, newStandardLine)
+		inScopeGatheringLines = append(inScopeGatheringLines, line)
 	}
 
-	if err := s.snapshotLineQuantitiesInParallel(ctx, out.Customer, inScopeLines, featureMeters); err != nil {
-		return nil, fmt.Errorf("snapshotting lines: %w", err)
+	linesWithEngines, err := s.lineEngines.groupGatheringLinesByEngine(inScopeGatheringLines)
+	if err != nil {
+		return nil, fmt.Errorf("grouping gathering lines by engine: %w", err)
+	}
+
+	standardLinesByID := make(map[string]*billing.StandardLine, len(inScopeGatheringLines))
+	for _, item := range linesWithEngines {
+		engineInput := billing.BuildStandardInvoiceLinesInput{
+			Invoice:        *out,
+			GatheringLines: item.Lines,
+		}
+		if err := engineInput.Validate(); err != nil {
+			return nil, fmt.Errorf("validating build standard invoice lines with live data input for engine %s: %w", item.Engine.GetLineEngineType(), err)
+		}
+
+		stdLines, err := item.Engine.BuildStandardLinesForGatheringPreview(ctx, engineInput)
+		if err != nil {
+			return nil, fmt.Errorf("building standard invoice lines with live data for engine %s: %w", item.Engine.GetLineEngineType(), err)
+		}
+
+		if err := stdLines.Validate(); err != nil {
+			return nil, fmt.Errorf("validating build standard invoice lines with live data output for engine %s: %w", item.Engine.GetLineEngineType(), err)
+		}
+
+		if err := billing.ValidateStandardLineIDsMatchGatheringLinesExactly(item.Lines, stdLines); err != nil {
+			return nil, fmt.Errorf("validating build standard invoice lines with live data ids for engine %s: %w", item.Engine.GetLineEngineType(), err)
+		}
+
+		for _, stdLine := range stdLines {
+			standardLinesByID[stdLine.ID] = stdLine
+		}
+	}
+
+	inScopeLines := make([]*billing.StandardLine, 0, len(inScopeGatheringLines))
+	for _, line := range inScopeGatheringLines {
+		stdLine, ok := standardLinesByID[line.ID]
+		if !ok {
+			return nil, fmt.Errorf("standard line for gathering line[%s] is missing", line.ID)
+		}
+
+		inScopeLines = append(inScopeLines, stdLine)
 	}
 
 	hasInvoicableLines, err := s.hasInvoicableLines(ctx, hasInvoicableLinesInput{

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -247,7 +247,7 @@ func (s *Service) calculateGatheringInvoiceAsStandardInvoice(ctx context.Context
 			return nil, fmt.Errorf("validating build standard invoice lines with live data output for engine %s: %w", item.Engine.GetLineEngineType(), err)
 		}
 
-		if err := billing.ValidateStandardLineIDsMatchGatheringLinesExactly(item.Lines, stdLines); err != nil {
+		if err := billing.ValidateStandardLineIDsMatchGatheringLinesUnordered(item.Lines, stdLines); err != nil {
 			return nil, fmt.Errorf("validating build standard invoice lines with live data ids for engine %s: %w", item.Engine.GetLineEngineType(), err)
 		}
 

--- a/openmeter/billing/testutils/lineengine.go
+++ b/openmeter/billing/testutils/lineengine.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 )
@@ -34,18 +33,11 @@ func (NoopLineEngine) SplitGatheringLine(_ context.Context, input billing.SplitG
 }
 
 func (NoopLineEngine) BuildStandardInvoiceLines(_ context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
-	lines := make(billing.StandardLines, 0, len(input.GatheringLines))
+	return input.GatheringLines.ToStandardLines(input.Invoice.ID)
+}
 
-	for _, gatheringLine := range input.GatheringLines {
-		stdLine, err := gatheringLine.AsNewStandardLine(input.Invoice.ID)
-		if err != nil {
-			return nil, fmt.Errorf("converting gathering line to standard line: %w", err)
-		}
-
-		lines = append(lines, stdLine)
-	}
-
-	return lines, nil
+func (NoopLineEngine) BuildStandardLinesForGatheringPreview(_ context.Context, input billing.BuildStandardInvoiceLinesInput) (billing.StandardLines, error) {
+	return input.GatheringLines.ToStandardLines(input.Invoice.ID)
 }
 
 func (NoopLineEngine) OnStandardInvoiceCreated(_ context.Context, input billing.OnStandardInvoiceCreatedInput) (billing.StandardLines, error) {

--- a/test/billing/lineengine_test.go
+++ b/test/billing/lineengine_test.go
@@ -38,7 +38,7 @@ type mockCollectionCompletedLineEngine struct {
 	engineType ombilling.LineEngineType
 
 	buildStandardInvoiceLines             func(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error)
-	buildStandardInvoiceLinesWithLiveData func(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error)
+	buildStandardLinesForGatheringPreview func(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error)
 	onStandardInvoiceCreated              func(ctx context.Context, input ombilling.OnStandardInvoiceCreatedInput) (ombilling.StandardLines, error)
 	onCollectionCompleted                 func(ctx context.Context, input ombilling.OnCollectionCompletedInput) (ombilling.StandardLines, error)
 	onMutableLinesDeleted                 func(ctx context.Context, input ombilling.OnMutableStandardLinesDeletedInput) error
@@ -87,8 +87,8 @@ func (m *mockCollectionCompletedLineEngine) BuildStandardInvoiceLines(ctx contex
 }
 
 func (m *mockCollectionCompletedLineEngine) BuildStandardLinesForGatheringPreview(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error) {
-	if m.buildStandardInvoiceLinesWithLiveData != nil {
-		return m.buildStandardInvoiceLinesWithLiveData(ctx, input)
+	if m.buildStandardLinesForGatheringPreview != nil {
+		return m.buildStandardLinesForGatheringPreview(ctx, input)
 	}
 
 	return mustAsNewStandardLines(input), nil
@@ -319,6 +319,109 @@ func (s *LineEngineTestSuite) mustGetInvoiceAppType(ctx context.Context, invoice
 	s.Require().NoError(err)
 
 	return invoicingApp.GetType()
+}
+
+func (s *LineEngineTestSuite) TestGatheringPreviewUsesPreviewLineEngineCallback() {
+	ctx := s.T().Context()
+	namespace := s.GetUniqueNamespace("ns-line-engine-gathering-preview-callback")
+	mockEngine := &mockCollectionCompletedLineEngine{engineType: ombilling.LineEngineTypeChargeCreditPurchase}
+	meterSlug := fmt.Sprintf("%s-meter", namespace)
+	meterID := ulid.Make().String()
+
+	periodStart := lo.Must(time.Parse(time.RFC3339, "2024-09-02T11:13:14Z"))
+	periodEnd := lo.Must(time.Parse(time.RFC3339, "2024-09-02T13:13:14Z"))
+	clock.SetTime(periodEnd)
+	defer clock.ResetTime()
+	defer func() { _ = s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{}) }()
+	defer s.MockStreamingConnector.Reset()
+	s.registerMockLineEngine(s.T(), mockEngine)
+	defer s.unregisterLineEngine(s.T(), mockEngine)
+
+	mockEngine.buildStandardInvoiceLines = func(context.Context, ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error) {
+		return nil, errors.New("standard invoice build path must not be used for gathering preview")
+	}
+
+	previewCallbackCalled := false
+	mockEngine.buildStandardLinesForGatheringPreview = func(_ context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error) {
+		previewCallbackCalled = true
+		lines := mustAsNewStandardLines(input)
+		lines[0].Name = "preview callback line"
+
+		return lines, nil
+	}
+
+	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), WithCollectionInterval(datetime.NewISODuration(0, 0, 0, 1, 0, 0, 0)))
+
+	err := s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{{
+		ManagedResource: models.ManagedResource{
+			ID: meterID,
+			NamespacedModel: models.NamespacedModel{
+				Namespace: namespace,
+			},
+			ManagedModel: models.ManagedModel{
+				CreatedAt: time.Now(),
+				UpdatedAt: time.Now(),
+			},
+			Name: "Line Engine Gathering Preview Test Meter",
+		},
+		Key:           meterSlug,
+		Aggregation:   meter.MeterAggregationSum,
+		EventType:     "test",
+		ValueProperty: lo.ToPtr("$.value"),
+	}})
+	s.Require().NoError(err)
+
+	testFeature := lo.Must(s.FeatureService.CreateFeature(ctx, feature.CreateFeatureInputs{
+		Namespace: namespace,
+		Name:      fmt.Sprintf("%s-feature", namespace),
+		Key:       fmt.Sprintf("%s-feature", namespace),
+		MeterID:   lo.ToPtr(meterID),
+	}))
+
+	customerEntity := s.CreateTestCustomer(namespace, "test-subject-1")
+	_, err = s.BillingService.CreatePendingInvoiceLines(ctx, ombilling.CreatePendingInvoiceLinesInput{
+		Customer: customer.CustomerID{
+			Namespace: customerEntity.Namespace,
+			ID:        customerEntity.ID,
+		},
+		Currency: currencyx.Code(currency.USD),
+		Lines: []ombilling.GatheringLine{{
+			GatheringLineBase: ombilling.GatheringLineBase{
+				ManagedResource: models.ManagedResource{
+					NamespacedModel: models.NamespacedModel{Namespace: namespace},
+					Name:            "gathering preview callback source line",
+				},
+				ServicePeriod: timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
+				InvoiceAt:     periodEnd,
+				ManagedBy:     ombilling.ManuallyManagedLine,
+				FeatureKey:    testFeature.Key,
+				Engine:        mockEngine.GetLineEngineType(),
+				Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromFloat(1),
+				})),
+			},
+		}},
+	})
+	s.Require().NoError(err)
+
+	invoices, err := s.BillingService.ListInvoices(ctx, ombilling.ListInvoicesInput{
+		Namespaces:       []string{namespace},
+		Customers:        []string{customerEntity.ID},
+		ExtendedStatuses: []ombilling.StandardInvoiceStatus{ombilling.StandardInvoiceStatusGathering},
+		Expand: ombilling.InvoiceExpands{}.
+			With(ombilling.InvoiceExpandLines).
+			With(ombilling.InvoiceExpandCalculateGatheringInvoiceWithLiveData),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(invoices.Items, 1)
+
+	previewInvoice, err := invoices.Items[0].AsStandardInvoice()
+	s.Require().NoError(err)
+	s.Require().True(previewInvoice.Lines.IsPresent())
+	s.Require().Len(previewInvoice.Lines.OrEmpty(), 1)
+	s.True(previewCallbackCalled)
+	s.Equal("preview callback line", previewInvoice.Lines.OrEmpty()[0].Name)
 }
 
 func (s *LineEngineTestSuite) TestCollectionCompletedErrorsBecomeValidationIssues() {

--- a/test/billing/lineengine_test.go
+++ b/test/billing/lineengine_test.go
@@ -37,14 +37,15 @@ func TestLineEngine(t *testing.T) {
 type mockCollectionCompletedLineEngine struct {
 	engineType ombilling.LineEngineType
 
-	buildStandardInvoiceLines func(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error)
-	onStandardInvoiceCreated  func(ctx context.Context, input ombilling.OnStandardInvoiceCreatedInput) (ombilling.StandardLines, error)
-	onCollectionCompleted     func(ctx context.Context, input ombilling.OnCollectionCompletedInput) (ombilling.StandardLines, error)
-	onMutableLinesDeleted     func(ctx context.Context, input ombilling.OnMutableStandardLinesDeletedInput) error
-	onUnsupportedCreditNote   func(ctx context.Context, input ombilling.OnUnsupportedCreditNoteInput) error
-	onInvoiceIssued           func(ctx context.Context, input ombilling.OnInvoiceIssuedInput) error
-	onPaymentAuthorized       func(ctx context.Context, input ombilling.OnPaymentAuthorizedInput) error
-	onPaymentSettled          func(ctx context.Context, input ombilling.OnPaymentSettledInput) error
+	buildStandardInvoiceLines             func(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error)
+	buildStandardInvoiceLinesWithLiveData func(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error)
+	onStandardInvoiceCreated              func(ctx context.Context, input ombilling.OnStandardInvoiceCreatedInput) (ombilling.StandardLines, error)
+	onCollectionCompleted                 func(ctx context.Context, input ombilling.OnCollectionCompletedInput) (ombilling.StandardLines, error)
+	onMutableLinesDeleted                 func(ctx context.Context, input ombilling.OnMutableStandardLinesDeletedInput) error
+	onUnsupportedCreditNote               func(ctx context.Context, input ombilling.OnUnsupportedCreditNoteInput) error
+	onInvoiceIssued                       func(ctx context.Context, input ombilling.OnInvoiceIssuedInput) error
+	onPaymentAuthorized                   func(ctx context.Context, input ombilling.OnPaymentAuthorizedInput) error
+	onPaymentSettled                      func(ctx context.Context, input ombilling.OnPaymentSettledInput) error
 }
 
 func mustAsNewStandardLines(input ombilling.BuildStandardInvoiceLinesInput) ombilling.StandardLines {
@@ -83,6 +84,14 @@ func (m *mockCollectionCompletedLineEngine) BuildStandardInvoiceLines(ctx contex
 	}
 
 	return m.buildStandardInvoiceLines(ctx, input)
+}
+
+func (m *mockCollectionCompletedLineEngine) BuildStandardLinesForGatheringPreview(ctx context.Context, input ombilling.BuildStandardInvoiceLinesInput) (ombilling.StandardLines, error) {
+	if m.buildStandardInvoiceLinesWithLiveData != nil {
+		return m.buildStandardInvoiceLinesWithLiveData(ctx, input)
+	}
+
+	return mustAsNewStandardLines(input), nil
 }
 
 func (m *mockCollectionCompletedLineEngine) OnCollectionCompleted(ctx context.Context, input ombilling.OnCollectionCompletedInput) (ombilling.StandardLines, error) {


### PR DESCRIPTION
## Summary

Fixes the gathering invoice live-data preview regression where charge-backed gathering lines produced zero totals when expanded through `InvoiceExpandCalculateGatheringInvoiceWithLiveData`.

- add a required `BuildStandardLinesForGatheringPreview` line-engine path for converting gathering lines into standard preview lines
- route gathering invoice live-data calculation through the owning line engines while preserving line order
- populate flat-fee and usage-based charge preview totals using side-effect-free in-memory realization runs
- document and test that preview runs do not allocate credits or persist realization state

## Issue

Fixes the regression where gathering invoice get/list with `InvoiceExpandCalculateGatheringInvoiceWithLiveData` returned zero totals for charge-based lines.

I could not find a matching GitHub issue by the regression terms, so this PR describes the fixed issue directly rather than linking an unrelated issue.

## Testing

- `make lint-go-fast`
- `make test-nocache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gathering invoice preview for flat-fee and usage-based charges: shows totals, per-line amounts, and usage quantities without persisting realizations.
  * Previews are side-effect free and preserve original line IDs; preview runs use deterministic preview IDs.

* **Tests**
  * Added comprehensive tests asserting preview behavior, totals, and that no realizations are persisted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmeterio/openmeter/pull/4458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->