### PR TITLE
refactor(billing): remove detailed line tax config domain

### DIFF
--- a/openmeter/app/stripe/appinvoice.go
+++ b/openmeter/app/stripe/appinvoice.go
@@ -218,7 +218,7 @@ func (a App) createInvoice(ctx context.Context, invoice billing.StandardInvoice)
 	// Add lines to the Stripe invoice
 	var stripeLineAdd []*stripe.InvoiceItemParams
 
-	leafLines := invoice.GetLeafLinesWithConsolidatedTaxBehavior()
+	leafLines := invoice.GetLeafLinesWithResolvedTaxConfig()
 
 	// Iterate over the leaf lines
 	for _, line := range leafLines {
@@ -349,7 +349,7 @@ func (a App) updateInvoice(ctx context.Context, invoice billing.StandardInvoice)
 	}
 
 	// Iterate over the leaf lines
-	for _, line := range invoice.GetLeafLinesWithConsolidatedTaxBehavior() {
+	for _, line := range invoice.GetLeafLinesWithResolvedTaxConfig() {
 		amountDiscountsById, err := line.AmountDiscounts.GetByID()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get amount discounts by ID: %w", err)
@@ -498,7 +498,7 @@ func sortInvoiceLines[K StripeInvoiceLineOperationParams](stripeLineAdd []*K) {
 // getDiscountStripeUpdateInvoiceItemParams returns the Stripe line item for a discount
 func getDiscountStripeUpdateInvoiceItemParams(
 	calculator StripeCalculator,
-	line billing.DetailedLine,
+	line billing.DetailedLineWithResolvedTaxConfig,
 	discount billing.AmountLineDiscountManaged,
 	stripeLine *stripe.InvoiceLineItem,
 ) *stripeclient.StripeInvoiceItemWithID {
@@ -509,9 +509,9 @@ func getDiscountStripeUpdateInvoiceItemParams(
 }
 
 // getDiscountStripeInvoiceItemParams returns the Stripe line item for a discount
-func getDiscountStripeInvoiceItemParams(calculator StripeCalculator, line billing.DetailedLine, discount billing.AmountLineDiscountManaged) *stripe.InvoiceItemParams {
-	name := getDiscountLineName(line, discount)
-	period := getPeriod(line)
+func getDiscountStripeInvoiceItemParams(calculator StripeCalculator, line billing.DetailedLineWithResolvedTaxConfig, discount billing.AmountLineDiscountManaged) *stripe.InvoiceItemParams {
+	name := getDiscountLineName(line.DetailedLine, discount)
+	period := getPeriod(line.DetailedLine)
 
 	addParams := &stripe.InvoiceItemParams{
 		Description: lo.ToPtr(name),
@@ -523,10 +523,10 @@ func getDiscountStripeInvoiceItemParams(calculator StripeCalculator, line billin
 		},
 	}
 
-	return applyTaxSettingsToInvoiceItem(addParams, line)
+	return applyTaxSettingsToInvoiceItem(addParams, line.TaxConfig)
 }
 
-func getDiscountStripeAddInvoiceItemParams(calculator StripeCalculator, line billing.DetailedLine, discount billing.AmountLineDiscountManaged, stripeCustomerID string) *stripe.InvoiceItemParams {
+func getDiscountStripeAddInvoiceItemParams(calculator StripeCalculator, line billing.DetailedLineWithResolvedTaxConfig, discount billing.AmountLineDiscountManaged, stripeCustomerID string) *stripe.InvoiceItemParams {
 	params := getDiscountStripeInvoiceItemParams(calculator, line, discount)
 	// Customer is required for adds
 	params.Customer = stripe.String(stripeCustomerID)
@@ -536,7 +536,7 @@ func getDiscountStripeAddInvoiceItemParams(calculator StripeCalculator, line bil
 // getCreditStripeUpdateInvoiceItemParams returns the Stripe line item for an applied credit.
 func getCreditStripeUpdateInvoiceItemParams(
 	calculator StripeCalculator,
-	line billing.DetailedLine,
+	line billing.DetailedLineWithResolvedTaxConfig,
 	credit billing.CreditApplied,
 	stripeLine *stripe.InvoiceLineItem,
 ) *stripeclient.StripeInvoiceItemWithID {
@@ -547,9 +547,9 @@ func getCreditStripeUpdateInvoiceItemParams(
 }
 
 // getCreditStripeInvoiceItemParams returns the Stripe line item for an applied credit.
-func getCreditStripeInvoiceItemParams(calculator StripeCalculator, line billing.DetailedLine, credit billing.CreditApplied) *stripe.InvoiceItemParams {
-	name := getCreditLineName(line, credit)
-	period := getPeriod(line)
+func getCreditStripeInvoiceItemParams(calculator StripeCalculator, line billing.DetailedLineWithResolvedTaxConfig, credit billing.CreditApplied) *stripe.InvoiceItemParams {
+	name := getCreditLineName(line.DetailedLine, credit)
+	period := getPeriod(line.DetailedLine)
 
 	addParams := &stripe.InvoiceItemParams{
 		Description: lo.ToPtr(name),
@@ -561,24 +561,24 @@ func getCreditStripeInvoiceItemParams(calculator StripeCalculator, line billing.
 		},
 	}
 
-	return applyTaxSettingsToInvoiceItem(addParams, line)
+	return applyTaxSettingsToInvoiceItem(addParams, line.TaxConfig)
 }
 
-func getCreditStripeAddInvoiceItemParams(calculator StripeCalculator, line billing.DetailedLine, credit billing.CreditApplied, stripeCustomerID string) *stripe.InvoiceItemParams {
+func getCreditStripeAddInvoiceItemParams(calculator StripeCalculator, line billing.DetailedLineWithResolvedTaxConfig, credit billing.CreditApplied, stripeCustomerID string) *stripe.InvoiceItemParams {
 	params := getCreditStripeInvoiceItemParams(calculator, line, credit)
 	// Customer is required for adds
 	params.Customer = stripe.String(stripeCustomerID)
 	return params
 }
 
-func applyTaxSettingsToInvoiceItem(add *stripe.InvoiceItemParams, line billing.DetailedLine) *stripe.InvoiceItemParams {
-	if line.TaxConfig != nil && !lo.IsEmpty(line.TaxConfig) {
-		if line.TaxConfig.Behavior != nil {
-			add.TaxBehavior = getStripeTaxBehavior(line.TaxConfig.Behavior)
+func applyTaxSettingsToInvoiceItem(add *stripe.InvoiceItemParams, taxConfig *productcatalog.TaxConfig) *stripe.InvoiceItemParams {
+	if taxConfig != nil && !lo.IsEmpty(taxConfig) {
+		if taxConfig.Behavior != nil {
+			add.TaxBehavior = getStripeTaxBehavior(taxConfig.Behavior)
 		}
 
-		if line.TaxConfig.Stripe != nil {
-			add.TaxCode = stripe.String(line.TaxConfig.Stripe.Code)
+		if taxConfig.Stripe != nil {
+			add.TaxCode = stripe.String(taxConfig.Stripe.Code)
 		}
 	}
 
@@ -588,7 +588,7 @@ func applyTaxSettingsToInvoiceItem(add *stripe.InvoiceItemParams, line billing.D
 // getStripeUpdateInvoiceItemParams returns the Stripe update line params
 func getStripeUpdateInvoiceItemParams(
 	calculator StripeCalculator,
-	line billing.DetailedLine,
+	line billing.DetailedLineWithResolvedTaxConfig,
 	stripeLine *stripe.InvoiceLineItem,
 ) *stripeclient.StripeInvoiceItemWithID {
 	return &stripeclient.StripeInvoiceItemWithID{
@@ -598,9 +598,9 @@ func getStripeUpdateInvoiceItemParams(
 }
 
 // getStripeAddLinesLineParams returns the Stripe line item
-func getStripeInvoiceItemParams(line billing.DetailedLine, calculator StripeCalculator) *stripe.InvoiceItemParams {
-	description := getLineName(line)
-	period := getPeriod(line)
+func getStripeInvoiceItemParams(line billing.DetailedLineWithResolvedTaxConfig, calculator StripeCalculator) *stripe.InvoiceItemParams {
+	description := getLineName(line.DetailedLine)
+	period := getPeriod(line.DetailedLine)
 	amount := line.Totals.Amount
 
 	// Handle usage based commitments like minimum spend
@@ -631,11 +631,11 @@ func getStripeInvoiceItemParams(line billing.DetailedLine, calculator StripeCalc
 		},
 	}
 
-	return applyTaxSettingsToInvoiceItem(addParams, line)
+	return applyTaxSettingsToInvoiceItem(addParams, line.TaxConfig)
 }
 
 // getStripeAddInvoiceItemParams returns the Stripe line item
-func getStripeAddInvoiceItemParams(line billing.DetailedLine, calculator StripeCalculator, stripeCustomerID string) *stripe.InvoiceItemParams {
+func getStripeAddInvoiceItemParams(line billing.DetailedLineWithResolvedTaxConfig, calculator StripeCalculator, stripeCustomerID string) *stripe.InvoiceItemParams {
 	params := getStripeInvoiceItemParams(line, calculator)
 	params.Customer = stripe.String(stripeCustomerID)
 	return params

--- a/openmeter/billing/adapter/stdinvoicelinemapper.go
+++ b/openmeter/billing/adapter/stdinvoicelinemapper.go
@@ -188,13 +188,8 @@ func (a *adapter) mapStandardInvoiceDetailedLineFromDB(dbLine *db.BillingInvoice
 			Index:          dbLine.Edges.FlatFeeLine.Index,
 			Currency:       dbLine.Currency,
 			CreditsApplied: creditsApplied,
-			TaxConfig: backfillTaxConfigReferences(
-				lo.EmptyableToPtr(dbLine.TaxConfig),
-				dbLine.TaxBehavior,
-				taxCodeFromInvoiceLineEdge(dbLine),
-			),
-			Totals:      totals.FromDB(dbLine),
-			ExternalIDs: externalid.MapLineExternalIDFromDB(dbLine),
+			Totals:         totals.FromDB(dbLine),
+			ExternalIDs:    externalid.MapLineExternalIDFromDB(dbLine),
 		},
 	}
 
@@ -212,14 +207,7 @@ func (a *adapter) mapStandardInvoiceDetailedLineFromDB(dbLine *db.BillingInvoice
 func (a *adapter) mapStandardInvoiceDetailedLineV2FromDB(dbLine *db.BillingStandardInvoiceDetailedLine) (billing.DetailedLine, error) {
 	detailedLineBase := billing.DetailedLineBase{
 		InvoiceID: dbLine.InvoiceID,
-		Base: stddetailedline.FromDB(
-			dbLine,
-			backfillTaxConfigReferences(
-				lo.EmptyableToPtr(dbLine.TaxConfig),
-				dbLine.TaxBehavior,
-				taxCodeFromDetailedLineV2Edge(dbLine),
-			),
-		),
+		Base:      stddetailedline.FromDB(dbLine),
 	}
 
 	discounts, err := slicesx.MapWithErr(dbLine.Edges.AmountDiscounts, a.mapStandardInvoiceDetailedLineAmountDiscountFromDB)
@@ -306,18 +294,6 @@ func (a *adapter) mapStandardInvoiceLineAmountDiscountFromDB(dbDiscount *db.Bill
 }
 
 func taxCodeFromInvoiceLineEdge(dbLine *db.BillingInvoiceLine) *taxcode.TaxCode {
-	tc, err := dbLine.Edges.TaxCodeOrErr()
-	if err != nil {
-		return nil
-	}
-	mapped, err := taxcodeadapter.MapTaxCodeFromEntity(tc)
-	if err != nil {
-		return nil
-	}
-	return &mapped
-}
-
-func taxCodeFromDetailedLineV2Edge(dbLine *db.BillingStandardInvoiceDetailedLine) *taxcode.TaxCode {
 	tc, err := dbLine.Edges.TaxCodeOrErr()
 	if err != nil {
 		return nil

--- a/openmeter/billing/adapter/stdinvoicelines.go
+++ b/openmeter/billing/adapter/stdinvoicelines.go
@@ -326,12 +326,6 @@ func (a *adapter) upsertDetailedLines(ctx context.Context, in detailedLineDiff) 
 			create = externalid.CreateLineExternalID(create, line.ExternalIDs)
 			create = totals.Set(create, line.Totals)
 
-			if line.TaxConfig != nil {
-				create = create.SetTaxConfig(*line.TaxConfig).
-					SetNillableTaxCodeID(line.TaxConfig.TaxCodeID).
-					SetNillableTaxBehavior(line.TaxConfig.Behavior)
-			}
-
 			if len(line.CreditsApplied) > 0 {
 				create = create.SetCreditsApplied(&line.CreditsApplied)
 			}
@@ -353,9 +347,6 @@ func (a *adapter) upsertDetailedLines(ctx context.Context, in detailedLineDiff) 
 				UpdateQuantity().
 				UpdateChildUniqueReferenceID().
 				UpdateCreditsApplied().
-				UpdateTaxConfig().
-				UpdateTaxCodeID().
-				UpdateTaxBehavior().
 				Exec(ctx)
 		},
 		MarkDeleted: func(ctx context.Context, line detailedLineWithParent) (detailedLineWithParent, error) {
@@ -432,12 +423,6 @@ func (a *adapter) upsertDetailedLinesV2(ctx context.Context, in detailedLineDiff
 				create = create.SetCreditsApplied(&line.CreditsApplied)
 			}
 
-			if line.TaxConfig != nil {
-				create = create.SetTaxConfig(*line.TaxConfig).
-					SetNillableTaxCodeID(line.TaxConfig.TaxCodeID).
-					SetNillableTaxBehavior(line.TaxConfig.Behavior)
-			}
-
 			return create, nil
 		},
 		UpsertItems: func(ctx context.Context, tx *db.Client, items []*db.BillingStandardInvoiceDetailedLineCreate) error {
@@ -452,9 +437,6 @@ func (a *adapter) upsertDetailedLinesV2(ctx context.Context, in detailedLineDiff
 				).
 				UpdateChildUniqueReferenceID().
 				UpdateDescription().
-				UpdateTaxConfig().
-				UpdateTaxCodeID().
-				UpdateTaxBehavior().
 				UpdateIndex().
 				UpdateDeletedAt().
 				Exec(ctx)

--- a/openmeter/billing/charges/flatfee/adapter/detailedline.go
+++ b/openmeter/billing/charges/flatfee/adapter/detailedline.go
@@ -45,12 +45,7 @@ func (a *adapter) FetchCurrentRunDetailedLines(ctx context.Context, charge flatf
 
 		lines := make(flatfee.DetailedLines, 0, len(dbLines))
 		for _, dbLine := range dbLines {
-			line, err := mapRunDetailedLineFromDB(dbLine)
-			if err != nil {
-				return flatfee.Charge{}, err
-			}
-
-			lines = append(lines, line)
+			lines = append(lines, stddetailedline.FromDB(dbLine))
 		}
 
 		sortDetailedLines(lines)
@@ -126,9 +121,6 @@ func (a *adapter) UpsertDetailedLines(ctx context.Context, runID flatfee.Realiza
 				}),
 			).
 			UpdateDescription().
-			UpdateTaxConfig().
-			UpdateTaxCodeID().
-			UpdateTaxBehavior().
 			UpdateIndex().
 			UpdatePricerReferenceID().
 			UpdateDeletedAt().
@@ -156,12 +148,6 @@ func buildDetailedLineCreate(db *entdb.Client, runID flatfee.RealizationRunID, l
 
 	if len(line.CreditsApplied) > 0 {
 		create = create.SetCreditsApplied(&line.CreditsApplied)
-	}
-
-	if line.TaxConfig != nil {
-		create = create.SetTaxConfig(*line.TaxConfig).
-			SetNillableTaxCodeID(line.TaxConfig.TaxCodeID).
-			SetNillableTaxBehavior(line.TaxConfig.Behavior)
 	}
 
 	return create, nil

--- a/openmeter/billing/charges/flatfee/adapter/detailedline.go
+++ b/openmeter/billing/charges/flatfee/adapter/detailedline.go
@@ -37,7 +37,6 @@ func (a *adapter) FetchCurrentRunDetailedLines(ctx context.Context, charge flatf
 				dbchargeflatfeerundetailedline.RunIDEQ(currentRunID.ID),
 				dbchargeflatfeerundetailedline.DeletedAtIsNil(),
 			).
-			WithTaxCode().
 			All(ctx)
 		if err != nil {
 			return flatfee.Charge{}, err

--- a/openmeter/billing/charges/flatfee/adapter/mapper.go
+++ b/openmeter/billing/charges/flatfee/adapter/mapper.go
@@ -39,19 +39,6 @@ func MapChargeFlatFeeFromDB(entity *entdb.ChargeFlatFee, expands meta.Expands) (
 	return charge, nil
 }
 
-func mapRunDetailedLineFromDB(dbLine *entdb.ChargeFlatFeeRunDetailedLine) (flatfee.DetailedLine, error) {
-	line := stddetailedline.FromDB(
-		dbLine,
-		stddetailedline.BackfillTaxConfig(
-			lo.EmptyableToPtr(dbLine.TaxConfig),
-			dbLine.TaxBehavior,
-			taxCodeIDFromEnt(dbLine.Edges.TaxCode),
-		),
-	)
-
-	return line, line.Validate()
-}
-
 func mapRealizationsFromDB(entity *entdb.ChargeFlatFee) (flatfee.Realizations, error) {
 	dbRuns, err := entity.Edges.RunsOrErr()
 	if err != nil {
@@ -135,14 +122,6 @@ func mapRealizationRunFromDB(dbRun *entdb.ChargeFlatFeeRun) (flatfee.Realization
 	}
 
 	return run, nil
-}
-
-func taxCodeIDFromEnt(resolvedTaxCode *entdb.TaxCode) *string {
-	if resolvedTaxCode == nil {
-		return nil
-	}
-
-	return lo.ToPtr(resolvedTaxCode.ID)
 }
 
 func sortDetailedLines(lines flatfee.DetailedLines) {

--- a/openmeter/billing/charges/usagebased/adapter/detailedline.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline.go
@@ -37,7 +37,6 @@ func (a *adapter) FetchDetailedLines(ctx context.Context, charge usagebased.Char
 				dbchargeusagebasedrundetailedline.RunIDIn(runIDs...),
 				dbchargeusagebasedrundetailedline.DeletedAtIsNil(),
 			).
-			WithTaxCode().
 			All(ctx)
 		if err != nil {
 			return usagebased.Charge{}, err

--- a/openmeter/billing/charges/usagebased/adapter/detailedline.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline.go
@@ -181,9 +181,6 @@ func (a *adapter) UpsertRunDetailedLines(ctx context.Context, chargeID chargesme
 				}),
 			).
 			UpdateDescription().
-			UpdateTaxConfig().
-			UpdateTaxCodeID().
-			UpdateTaxBehavior().
 			UpdateIndex().
 			UpdatePricerReferenceID().
 			UpdateCorrectsRunID().
@@ -216,36 +213,15 @@ func buildDetailedLineCreate(db *entdb.Client, chargeID chargesmeta.ChargeID, ru
 		create = create.SetCreditsApplied(&line.CreditsApplied)
 	}
 
-	if line.TaxConfig != nil {
-		create = create.SetTaxConfig(*line.TaxConfig).
-			SetNillableTaxCodeID(line.TaxConfig.TaxCodeID).
-			SetNillableTaxBehavior(line.TaxConfig.Behavior)
-	}
-
 	return create, nil
 }
 
 func mapDetailedLineFromDB(dbLine *entdb.ChargeUsageBasedRunDetailedLine) (usagebased.DetailedLine, error) {
 	line := usagebased.DetailedLine{
-		Base: stddetailedline.FromDB(
-			dbLine,
-			stddetailedline.BackfillTaxConfig(
-				lo.EmptyableToPtr(dbLine.TaxConfig),
-				dbLine.TaxBehavior,
-				taxCodeIDFromEnt(dbLine.Edges.TaxCode),
-			),
-		),
+		Base:              stddetailedline.FromDB(dbLine),
 		PricerReferenceID: dbLine.PricerReferenceID,
 		CorrectsRunID:     dbLine.CorrectsRunID,
 	}
 
 	return line, line.Validate()
-}
-
-func taxCodeIDFromEnt(resolvedTaxCode *entdb.TaxCode) *string {
-	if resolvedTaxCode == nil {
-		return nil
-	}
-
-	return lo.ToPtr(resolvedTaxCode.ID)
 }

--- a/openmeter/billing/charges/usagebased/detailedline.go
+++ b/openmeter/billing/charges/usagebased/detailedline.go
@@ -85,7 +85,6 @@ func NewDetailedLinesFromBilling(
 				Category:               category,
 				CreditsApplied:         line.CreditsApplied,
 				Totals:                 line.Totals,
-				TaxConfig:              intent.TaxConfig.ToTaxConfig(),
 			},
 		}
 	})

--- a/openmeter/billing/charges/usagebased/service/rating/service_test.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service_test.go
@@ -87,10 +87,6 @@ func TestNewDetailedLinesFromBilling(t *testing.T) {
 		To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
 	}
 	intent := newDetailedRatingTestCharge(defaultServicePeriod, nil).Intent
-	intent.TaxConfig = &productcatalog.TaxCodeConfig{
-		Behavior: lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
-	}
-
 	out := usagebased.NewDetailedLinesFromBilling(
 		intent,
 		defaultServicePeriod,
@@ -127,8 +123,6 @@ func TestNewDetailedLinesFromBilling(t *testing.T) {
 	require.Equal(t, float64(12), out[0].Quantity.InexactFloat64())
 	require.Equal(t, float64(3), out[0].PerUnitAmount.InexactFloat64())
 	require.Equal(t, float64(36), out[0].Totals.Total.InexactFloat64())
-	require.NotNil(t, out[0].TaxConfig)
-	require.NotSame(t, intent.TaxConfig, out[0].TaxConfig)
 
 	require.Equal(t, explicitServicePeriod, out[1].ServicePeriod)
 	require.Equal(t, productcatalog.InAdvancePaymentTerm, out[1].PaymentTerm)

--- a/openmeter/billing/httpdriver/invoiceline.go
+++ b/openmeter/billing/httpdriver/invoiceline.go
@@ -227,9 +227,9 @@ func mapTaxConfigToAPI(to *productcatalog.TaxConfig) *api.TaxConfig {
 	return lo.ToPtr(productcataloghttp.FromTaxConfig(*to))
 }
 
-func mapDetailedLinesToAPI(lines billing.DetailedLines, invoiceAt time.Time) (*[]api.InvoiceDetailedLine, error) {
+func mapDetailedLinesToAPI(lines billing.DetailedLines, invoiceAt time.Time, taxConfig *productcatalog.TaxConfig) (*[]api.InvoiceDetailedLine, error) {
 	mappedLines, err := slicesx.MapWithErr(lines, func(line billing.DetailedLine) (api.InvoiceDetailedLine, error) {
-		return mapDetailedLineToAPI(line, invoiceAt)
+		return mapDetailedLineToAPI(line, invoiceAt, taxConfig)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to map detailed lines: %w", err)
@@ -238,7 +238,7 @@ func mapDetailedLinesToAPI(lines billing.DetailedLines, invoiceAt time.Time) (*[
 	return lo.ToPtr(mappedLines), nil
 }
 
-func mapDetailedLineToAPI(line billing.DetailedLine, invoiceAt time.Time) (api.InvoiceDetailedLine, error) {
+func mapDetailedLineToAPI(line billing.DetailedLine, invoiceAt time.Time, taxConfig *productcatalog.TaxConfig) (api.InvoiceDetailedLine, error) {
 	amountDiscountsAPI, err := mapInvoiceLineAmountDiscountsToAPI(line.AmountDiscounts)
 	if err != nil {
 		return api.InvoiceDetailedLine{}, fmt.Errorf("failed to map amount discounts: %w", err)
@@ -279,11 +279,11 @@ func mapDetailedLineToAPI(line billing.DetailedLine, invoiceAt time.Time) (api.I
 		PerUnitAmount: lo.ToPtr(line.PerUnitAmount.String()),
 		Quantity:      lo.ToPtr(line.Quantity.String()),
 		Category:      lo.ToPtr(api.InvoiceDetailedLineCostCategory(line.Category)),
-		TaxConfig:     mapTaxConfigToAPI(line.TaxConfig),
+		TaxConfig:     mapTaxConfigToAPI(taxConfig),
 		PaymentTerm:   lo.ToPtr(api.PricePaymentTerm(line.PaymentTerm)),
 
 		RateCard: &api.InvoiceDetailedLineRateCard{
-			TaxConfig: mapTaxConfigToAPI(line.TaxConfig),
+			TaxConfig: mapTaxConfigToAPI(taxConfig),
 			Price: &api.FlatPriceWithPaymentTerm{
 				Type:        api.FlatPriceWithPaymentTermTypeFlat,
 				PaymentTerm: lo.ToPtr(api.PricePaymentTerm(line.PaymentTerm)),
@@ -324,7 +324,7 @@ func mapInvoiceLineToAPI(line *billing.StandardLine) (api.InvoiceLine, error) {
 		return api.InvoiceLine{}, fmt.Errorf("failed to map price: %w", err)
 	}
 
-	children, err := mapDetailedLinesToAPI(line.DetailedLines, line.InvoiceAt)
+	children, err := mapDetailedLinesToAPI(line.DetailedLines, line.InvoiceAt, line.TaxConfig)
 	if err != nil {
 		return api.InvoiceLine{}, fmt.Errorf("failed to map children: %w", err)
 	}

--- a/openmeter/billing/models/stddetailedline/derived.gen.go
+++ b/openmeter/billing/models/stddetailedline/derived.gen.go
@@ -21,7 +21,6 @@ func deriveEqualBase(this, that *Base) bool {
 			this.PerUnitAmount.Equal(that.PerUnitAmount) &&
 			this.Quantity.Equal(that.Quantity) &&
 			this.Totals.Equal(that.Totals) &&
-			this.TaxConfig.Equal(that.TaxConfig) &&
 			this.ExternalIDs.Equal(that.ExternalIDs) &&
 			deriveEqual_(this.CreditsApplied, that.CreditsApplied)
 }

--- a/openmeter/billing/models/stddetailedline/mapping.go
+++ b/openmeter/billing/models/stddetailedline/mapping.go
@@ -39,7 +39,7 @@ type DBGetter interface {
 	totals.TotalsGetter
 }
 
-func FromDB[T DBGetter](dbEntity T, taxConfig *productcatalog.TaxConfig) Base {
+func FromDB[T DBGetter](dbEntity T) Base {
 	return Base{
 		ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
 			Namespace:   dbEntity.GetNamespace(),
@@ -62,7 +62,6 @@ func FromDB[T DBGetter](dbEntity T, taxConfig *productcatalog.TaxConfig) Base {
 		PerUnitAmount:  dbEntity.GetPerUnitAmount(),
 		Quantity:       dbEntity.GetQuantity(),
 		Totals:         totals.FromDB(dbEntity),
-		TaxConfig:      taxConfig,
 		ExternalIDs:    externalid.MapLineExternalIDFromDB(dbEntity),
 		CreditsApplied: lo.FromPtr(dbEntity.GetCreditsApplied()),
 	}

--- a/openmeter/billing/models/stddetailedline/mixin.go
+++ b/openmeter/billing/models/stddetailedline/mixin.go
@@ -43,22 +43,27 @@ func (mixinBase) Fields() []ent.Field {
 				dialect.Postgres: "varchar(3)",
 			}),
 
+		// TODO: remove these deprecated detailed-line tax fields after the parent-line
+		// inherited tax config rollout has been deployed to production.
 		field.JSON("tax_config", productcatalog.TaxConfig{}).
 			SchemaType(map[string]string{
 				dialect.Postgres: "jsonb",
 			}).
-			Optional(),
+			Optional().
+			Deprecated("detailed lines inherit tax configuration from their parent standard line"),
 
 		field.String("tax_code_id").
 			Optional().
 			Nillable().
 			SchemaType(map[string]string{
 				dialect.Postgres: "char(26)",
-			}),
+			}).
+			Deprecated("detailed lines inherit tax configuration from their parent standard line"),
 		field.Enum("tax_behavior").
 			GoType(productcatalog.TaxBehavior("")).
 			Optional().
-			Nillable(),
+			Nillable().
+			Deprecated("detailed lines inherit tax configuration from their parent standard line"),
 
 		field.Time("service_period_start"),
 		field.Time("service_period_end"),

--- a/openmeter/billing/models/stddetailedline/model.go
+++ b/openmeter/billing/models/stddetailedline/model.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
-	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/models/creditsapplied"
 	"github.com/openmeterio/openmeter/openmeter/billing/models/externalid"
@@ -59,7 +58,6 @@ type Base struct {
 	Quantity      alpacadecimal.Decimal `json:"quantity"`
 	Totals        totals.Totals         `json:"totals"`
 
-	TaxConfig      *productcatalog.TaxConfig     `json:"taxConfig,omitempty"`
 	ExternalIDs    externalid.LineExternalIDs    `json:"externalIDs,omitempty"`
 	CreditsApplied creditsapplied.CreditsApplied `json:"creditsApplied,omitempty"`
 }
@@ -120,11 +118,6 @@ func (l Base) Validate(opts ...ValidateOption) error {
 }
 
 func (l Base) Clone() Base {
-	if l.TaxConfig != nil {
-		taxConfig := *l.TaxConfig
-		l.TaxConfig = &taxConfig
-	}
-
 	if len(l.CreditsApplied) > 0 {
 		l.CreditsApplied = l.CreditsApplied.Clone()
 	}
@@ -170,25 +163,4 @@ func Compare[T Comparable](a, b T) int {
 		return c
 	}
 	return cmp.Compare(a.GetID(), b.GetID())
-}
-
-func BackfillTaxConfig(snapshotted *productcatalog.TaxConfig, behavior *productcatalog.TaxBehavior, resolvedTaxCodeID *string) *productcatalog.TaxConfig {
-	if snapshotted == nil && behavior == nil && resolvedTaxCodeID == nil {
-		return nil
-	}
-
-	var out productcatalog.TaxConfig
-	if snapshotted != nil {
-		out = *snapshotted
-	}
-
-	if behavior != nil {
-		out.Behavior = behavior
-	}
-
-	if resolvedTaxCodeID != nil {
-		out.TaxCodeID = lo.ToPtr(*resolvedTaxCodeID)
-	}
-
-	return &out
 }

--- a/openmeter/billing/service/invoicecalc/details.go
+++ b/openmeter/billing/service/invoicecalc/details.go
@@ -118,7 +118,6 @@ func newDetailedLines(line *billing.StandardLine, inputs ...rating.DetailedLine)
 					ServicePeriod:          period,
 					Currency:               line.Currency,
 					ChildUniqueReferenceID: in.ChildUniqueReferenceID,
-					TaxConfig:              line.TaxConfig,
 					PaymentTerm:            lo.CoalesceOrEmpty(in.PaymentTerm, productcatalog.InArrearsPaymentTerm),
 					PerUnitAmount:          in.PerUnitAmount,
 					Quantity:               in.Quantity,

--- a/openmeter/billing/stdinvoice.go
+++ b/openmeter/billing/stdinvoice.go
@@ -448,18 +448,27 @@ func (i *StandardInvoice) getLeafLines() DetailedLines {
 	return out
 }
 
-// GetLeafLinesWithConsolidatedTaxBehavior returns the leaf lines with the tax behavior set to the invoice's tax behavior
-// unless the line already has a tax behavior set.
-func (i *StandardInvoice) GetLeafLinesWithConsolidatedTaxBehavior() DetailedLines {
-	leafLines := i.getLeafLines()
-	if i.Workflow.Config.Invoicing.DefaultTaxConfig == nil {
-		return leafLines
+type DetailedLineWithResolvedTaxConfig struct {
+	DetailedLine
+	TaxConfig *productcatalog.TaxConfig
+}
+
+// GetLeafLinesWithResolvedTaxConfig returns invoice leaf lines together with the effective tax
+// config inherited from the parent standard line.
+func (i *StandardInvoice) GetLeafLinesWithResolvedTaxConfig() []DetailedLineWithResolvedTaxConfig {
+	out := make([]DetailedLineWithResolvedTaxConfig, 0)
+
+	for _, parentLine := range i.Lines.OrEmpty() {
+		taxConfig := productcatalog.MergeTaxConfigs(i.Workflow.Config.Invoicing.DefaultTaxConfig, parentLine.TaxConfig)
+		for _, line := range parentLine.DetailedLines {
+			out = append(out, DetailedLineWithResolvedTaxConfig{
+				DetailedLine: line,
+				TaxConfig:    taxConfig,
+			})
+		}
 	}
 
-	return lo.Map(leafLines, func(line DetailedLine, _ int) DetailedLine {
-		line.TaxConfig = productcatalog.MergeTaxConfigs(i.Workflow.Config.Invoicing.DefaultTaxConfig, line.TaxConfig)
-		return line
-	})
+	return out
 }
 
 func (i StandardInvoice) Clone() (StandardInvoice, error) {

--- a/openmeter/ent/db/billingstandardinvoicedetailedline.go
+++ b/openmeter/ent/db/billingstandardinvoicedetailedline.go
@@ -30,10 +30,16 @@ type BillingStandardInvoiceDetailedLine struct {
 	// Currency holds the value of the "currency" field.
 	Currency currencyx.Code `json:"currency,omitempty"`
 	// TaxConfig holds the value of the "tax_config" field.
+	//
+	// Deprecated: Field "tax_config" was marked as deprecated in the schema.
 	TaxConfig productcatalog.TaxConfig `json:"tax_config,omitempty"`
 	// TaxCodeID holds the value of the "tax_code_id" field.
+	//
+	// Deprecated: detailed lines inherit tax configuration from their parent standard line
 	TaxCodeID *string `json:"tax_code_id,omitempty"`
 	// TaxBehavior holds the value of the "tax_behavior" field.
+	//
+	// Deprecated: detailed lines inherit tax configuration from their parent standard line
 	TaxBehavior *productcatalog.TaxBehavior `json:"tax_behavior,omitempty"`
 	// ServicePeriodStart holds the value of the "service_period_start" field.
 	ServicePeriodStart time.Time `json:"service_period_start,omitempty"`

--- a/openmeter/ent/db/billingstandardinvoicedetailedline/billingstandardinvoicedetailedline.go
+++ b/openmeter/ent/db/billingstandardinvoicedetailedline/billingstandardinvoicedetailedline.go
@@ -125,9 +125,6 @@ const (
 var Columns = []string{
 	FieldID,
 	FieldCurrency,
-	FieldTaxConfig,
-	FieldTaxCodeID,
-	FieldTaxBehavior,
 	FieldServicePeriodStart,
 	FieldServicePeriodEnd,
 	FieldQuantity,
@@ -162,6 +159,11 @@ var Columns = []string{
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
+			return true
+		}
+	}
+	for _, f := range [...]string{FieldTaxConfig, FieldTaxCodeID, FieldTaxBehavior} {
+		if column == f {
 			return true
 		}
 	}

--- a/openmeter/ent/db/chargeflatfeerundetailedline.go
+++ b/openmeter/ent/db/chargeflatfeerundetailedline.go
@@ -29,10 +29,16 @@ type ChargeFlatFeeRunDetailedLine struct {
 	// Currency holds the value of the "currency" field.
 	Currency currencyx.Code `json:"currency,omitempty"`
 	// TaxConfig holds the value of the "tax_config" field.
+	//
+	// Deprecated: Field "tax_config" was marked as deprecated in the schema.
 	TaxConfig productcatalog.TaxConfig `json:"tax_config,omitempty"`
 	// TaxCodeID holds the value of the "tax_code_id" field.
+	//
+	// Deprecated: detailed lines inherit tax configuration from their parent standard line
 	TaxCodeID *string `json:"tax_code_id,omitempty"`
 	// TaxBehavior holds the value of the "tax_behavior" field.
+	//
+	// Deprecated: detailed lines inherit tax configuration from their parent standard line
 	TaxBehavior *productcatalog.TaxBehavior `json:"tax_behavior,omitempty"`
 	// ServicePeriodStart holds the value of the "service_period_start" field.
 	ServicePeriodStart time.Time `json:"service_period_start,omitempty"`

--- a/openmeter/ent/db/chargeflatfeerundetailedline/chargeflatfeerundetailedline.go
+++ b/openmeter/ent/db/chargeflatfeerundetailedline/chargeflatfeerundetailedline.go
@@ -107,9 +107,6 @@ const (
 var Columns = []string{
 	FieldID,
 	FieldCurrency,
-	FieldTaxConfig,
-	FieldTaxCodeID,
-	FieldTaxBehavior,
 	FieldServicePeriodStart,
 	FieldServicePeriodEnd,
 	FieldQuantity,
@@ -144,6 +141,11 @@ var Columns = []string{
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
+			return true
+		}
+	}
+	for _, f := range [...]string{FieldTaxConfig, FieldTaxCodeID, FieldTaxBehavior} {
+		if column == f {
 			return true
 		}
 	}

--- a/openmeter/ent/db/chargeusagebasedrundetailedline.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline.go
@@ -30,10 +30,16 @@ type ChargeUsageBasedRunDetailedLine struct {
 	// Currency holds the value of the "currency" field.
 	Currency currencyx.Code `json:"currency,omitempty"`
 	// TaxConfig holds the value of the "tax_config" field.
+	//
+	// Deprecated: Field "tax_config" was marked as deprecated in the schema.
 	TaxConfig productcatalog.TaxConfig `json:"tax_config,omitempty"`
 	// TaxCodeID holds the value of the "tax_code_id" field.
+	//
+	// Deprecated: detailed lines inherit tax configuration from their parent standard line
 	TaxCodeID *string `json:"tax_code_id,omitempty"`
 	// TaxBehavior holds the value of the "tax_behavior" field.
+	//
+	// Deprecated: detailed lines inherit tax configuration from their parent standard line
 	TaxBehavior *productcatalog.TaxBehavior `json:"tax_behavior,omitempty"`
 	// ServicePeriodStart holds the value of the "service_period_start" field.
 	ServicePeriodStart time.Time `json:"service_period_start,omitempty"`

--- a/openmeter/ent/db/chargeusagebasedrundetailedline/chargeusagebasedrundetailedline.go
+++ b/openmeter/ent/db/chargeusagebasedrundetailedline/chargeusagebasedrundetailedline.go
@@ -129,9 +129,6 @@ const (
 var Columns = []string{
 	FieldID,
 	FieldCurrency,
-	FieldTaxConfig,
-	FieldTaxCodeID,
-	FieldTaxBehavior,
 	FieldServicePeriodStart,
 	FieldServicePeriodEnd,
 	FieldQuantity,
@@ -168,6 +165,11 @@ var Columns = []string{
 func ValidColumn(column string) bool {
 	for i := range Columns {
 		if column == Columns[i] {
+			return true
+		}
+	}
+	for _, f := range [...]string{FieldTaxConfig, FieldTaxCodeID, FieldTaxBehavior} {
+		if column == f {
 			return true
 		}
 	}

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -562,7 +562,8 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 		}
 
 		getLine := func(description string) *billing.DetailedLine {
-			for _, line := range invoice.GetLeafLinesWithConsolidatedTaxBehavior() {
+			for _, lineWithTax := range invoice.GetLeafLinesWithResolvedTaxConfig() {
+				line := lineWithTax.DetailedLine
 				name := line.Name
 				if line.Description != nil {
 					name = fmt.Sprintf("%s (%s)", name, *line.Description)

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -778,14 +778,14 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 		lineWithDefaultTax, found := lo.Find(expectedInvoiceAddLines, func(line *stripe.InvoiceItemParams) bool {
 			return lo.FromPtr(line.Description) == "UBP - AI Usecase: usage in period (103,000,025 x $0.000001)"
 		})
-		s.True(found)
+		s.Require().True(found)
 		s.Equal(string(stripe.PriceCurrencyOptionsTaxBehaviorInclusive), lo.FromPtr(lineWithDefaultTax.TaxBehavior))
 		s.Equal(defaultStripeTaxCode, lo.FromPtr(lineWithDefaultTax.TaxCode))
 
 		lineWithOverrideTax, found := lo.Find(expectedInvoiceAddLines, func(line *stripe.InvoiceItemParams) bool {
 			return lo.FromPtr(line.Description) == "UBP - FLAT per any usage"
 		})
-		s.True(found)
+		s.Require().True(found)
 		s.Equal(string(stripe.PriceCurrencyOptionsTaxBehaviorExclusive), lo.FromPtr(lineWithOverrideTax.TaxBehavior))
 		s.Equal(overrideStripeTaxCode, lo.FromPtr(lineWithOverrideTax.TaxCode))
 

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -39,6 +39,7 @@ import (
 	secretadapter "github.com/openmeterio/openmeter/openmeter/secret/adapter"
 	secretservice "github.com/openmeterio/openmeter/openmeter/secret/service"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -175,7 +176,34 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 	clock.FreezeTime(periodStart)
 	defer clock.UnFreeze()
 
+	defaultStripeTaxCode := "txcd_10000000"
+	overrideStripeTaxCode := "txcd_20000000"
+
 	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+
+	defaultInvoicingTaxCode, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "default-invoicing",
+		Name:      "Default Invoicing",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: defaultStripeTaxCode},
+		},
+	})
+	s.NoError(err)
+
+	defaultCreditGrantTaxCode, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "default-credit-grant",
+		Name:      "Default Credit Grant",
+	})
+	s.NoError(err)
+
+	defaultTaxCodes, err := s.TaxCodeService.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
+		Namespace:            namespace,
+		InvoicingTaxCodeID:   defaultInvoicingTaxCode.ID,
+		CreditGrantTaxCodeID: defaultCreditGrantTaxCode.ID,
+	})
+	s.NoError(err)
 
 	flatPerUnitMeterID := ulid.Make().String()
 	flatPerUsageMeterID := ulid.Make().String()
@@ -183,7 +211,7 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 	tieredVolumeMeterID := ulid.Make().String()
 	aiFlatPerUnitMeterID := ulid.Make().String()
 
-	err := s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{
+	err = s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{
 		{
 			ManagedResource: models.ManagedResource{
 				ID: flatPerUnitMeterID,
@@ -384,6 +412,10 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 							Price: lo.FromPtr(productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 								Amount: alpacadecimal.NewFromFloat(0.00000075),
 							})),
+							TaxConfig: &productcatalog.TaxConfig{
+								Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+								TaxCodeID: lo.ToPtr(defaultTaxCodes.InvoicingTaxCodeID),
+							},
 						},
 					},
 					{
@@ -400,6 +432,12 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 								Amount:      alpacadecimal.NewFromFloat(100),
 								PaymentTerm: productcatalog.InArrearsPaymentTerm,
 							})),
+							TaxConfig: &productcatalog.TaxConfig{
+								Behavior: lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
+								Stripe: &productcatalog.StripeTaxConfig{
+									Code: overrideStripeTaxCode,
+								},
+							},
 						},
 					},
 					{
@@ -725,6 +763,31 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 				},
 			},
 		}
+
+		for _, line := range expectedInvoiceAddLines {
+			switch lo.FromPtr(line.Description) {
+			case "UBP - AI Usecase: usage in period (103,000,025 x $0.000001)":
+				line.TaxBehavior = lo.ToPtr(string(stripe.PriceCurrencyOptionsTaxBehaviorInclusive))
+				line.TaxCode = lo.ToPtr(defaultStripeTaxCode)
+			case "UBP - FLAT per any usage":
+				line.TaxBehavior = lo.ToPtr(string(stripe.PriceCurrencyOptionsTaxBehaviorExclusive))
+				line.TaxCode = lo.ToPtr(overrideStripeTaxCode)
+			}
+		}
+
+		lineWithDefaultTax, found := lo.Find(expectedInvoiceAddLines, func(line *stripe.InvoiceItemParams) bool {
+			return lo.FromPtr(line.Description) == "UBP - AI Usecase: usage in period (103,000,025 x $0.000001)"
+		})
+		s.True(found)
+		s.Equal(string(stripe.PriceCurrencyOptionsTaxBehaviorInclusive), lo.FromPtr(lineWithDefaultTax.TaxBehavior))
+		s.Equal(defaultStripeTaxCode, lo.FromPtr(lineWithDefaultTax.TaxCode))
+
+		lineWithOverrideTax, found := lo.Find(expectedInvoiceAddLines, func(line *stripe.InvoiceItemParams) bool {
+			return lo.FromPtr(line.Description) == "UBP - FLAT per any usage"
+		})
+		s.True(found)
+		s.Equal(string(stripe.PriceCurrencyOptionsTaxBehaviorExclusive), lo.FromPtr(lineWithOverrideTax.TaxBehavior))
+		s.Equal(overrideStripeTaxCode, lo.FromPtr(lineWithOverrideTax.TaxCode))
 
 		s.StripeAppClient.StableSortInvoiceItemParams(expectedInvoiceAddLines)
 

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -922,18 +922,29 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 		// From existing lines, one is removed and the rest are updated.
 
 		filteredUpdatedLines := lo.FilterMap(stripeInvoice.Lines.Data, func(line *stripe.InvoiceLineItem, idx int) (*stripeclient.StripeInvoiceItemWithID, bool) {
+			params := &stripe.InvoiceItemParams{
+				Amount:      &line.Amount,
+				Description: &line.Description,
+				Period: &stripe.InvoiceItemPeriodParams{
+					Start: &line.Period.Start,
+					End:   &line.Period.End,
+				},
+				Metadata: line.Metadata,
+			}
+
+			switch line.Description {
+			case "UBP - AI Usecase: usage in period (103,000,025 x $0.000001)":
+				params.TaxBehavior = lo.ToPtr(string(stripe.PriceCurrencyOptionsTaxBehaviorInclusive))
+				params.TaxCode = lo.ToPtr(defaultStripeTaxCode)
+			case "UBP - FLAT per any usage":
+				params.TaxBehavior = lo.ToPtr(string(stripe.PriceCurrencyOptionsTaxBehaviorExclusive))
+				params.TaxCode = lo.ToPtr(overrideStripeTaxCode)
+			}
+
 			// No changes to the line items.
 			return &stripeclient.StripeInvoiceItemWithID{
-				ID: line.ID,
-				InvoiceItemParams: &stripe.InvoiceItemParams{
-					Amount:      &line.Amount,
-					Description: &line.Description,
-					Period: &stripe.InvoiceItemPeriodParams{
-						Start: &line.Period.Start,
-						End:   &line.Period.End,
-					},
-					Metadata: line.Metadata,
-				},
+				ID:                line.ID,
+				InvoiceItemParams: params,
 			}, line.ID != stripeLineIDToRemove
 		})
 

--- a/test/billing/tax_test.go
+++ b/test/billing/tax_test.go
@@ -277,11 +277,6 @@ func (s *InvoicingTaxTestSuite) TestLineSplittingRetainsTaxConfig() {
 	ubpSplitLineDetailedLines := ubpSplitLine.DetailedLines
 	s.Len(ubpSplitLineDetailedLines, 1)
 
-	ubpDetailedLine := ubpSplitLineDetailedLines[0]
-	s.Require().NotNil(ubpDetailedLine.TaxConfig, "tax config is retained in detailed line")
-	s.Equal(taxConfig.Behavior, ubpDetailedLine.TaxConfig.Behavior, "detailed line tax config behavior is retained")
-	s.Equal(taxConfig.Stripe, ubpDetailedLine.TaxConfig.Stripe, "detailed line tax config stripe is retained")
-
 	// Verify the normalized tax_code_id column is written in the DB (not just the JSONB).
 	dbLine, err := s.DBClient.BillingInvoiceLine.Query().
 		Where(billinginvoicelinedb.ID(ubpSplitLine.GetID())).
@@ -291,17 +286,6 @@ func (s *InvoicingTaxTestSuite) TestLineSplittingRetainsTaxConfig() {
 	s.Equal(createdTC.ID, *dbLine.TaxCodeID, "tax_code_id column must match the resolved TaxCode entity")
 	s.Require().NotNil(dbLine.TaxBehavior, "tax_behavior column must be populated on the invoice line row")
 	s.Equal(productcatalog.ExclusiveTaxBehavior, *dbLine.TaxBehavior, "tax_behavior column must match")
-
-	// Verify the normalized tax_code_id and tax_behavior columns on the detailed line row.
-	// Detailed lines at schema level 1 are stored in the billing_invoice_lines table.
-	dbDetailedLine, err := s.DBClient.BillingInvoiceLine.Query().
-		Where(billinginvoicelinedb.ID(ubpDetailedLine.GetID())).
-		Only(ctx)
-	s.Require().NoError(err)
-	s.Require().NotNil(dbDetailedLine.TaxCodeID, "tax_code_id column must be populated on the detailed line row")
-	s.Equal(createdTC.ID, *dbDetailedLine.TaxCodeID, "detailed line tax_code_id must match")
-	s.Require().NotNil(dbDetailedLine.TaxBehavior, "tax_behavior column must be populated on the detailed line row")
-	s.Equal(productcatalog.ExclusiveTaxBehavior, *dbDetailedLine.TaxBehavior, "detailed line tax_behavior must match")
 }
 
 func (s *InvoicingTaxTestSuite) generateDraftInvoice(ctx context.Context, customer *customer.Customer) billing.StandardInvoice {


### PR DESCRIPTION
## Summary

- Remove tax configuration from detailed-line domain objects and stop writing/reading detailed-line tax fields in billing and charge adapters.
- Resolve effective detailed-line tax config from the parent standard line where app/API boundaries still need it.
- Mark the remaining detailed-line Ent tax fields as deprecated so the DB shape stays non-breaking until a later cleanup.

## Validation

- go generate ./openmeter/billing/models/stddetailedline
- make generate
- go test ./openmeter/billing/models/stddetailedline ./openmeter/ent/db/...
- go test ./openmeter/app/stripe/...
- go vet -tags=dynamic ./openmeter/app/stripe/...
- go test -tags=dynamic ./openmeter/billing/charges/flatfee/adapter
- go vet -tags=dynamic ./openmeter/billing/charges/flatfee/adapter
- make lint-go-fast running
- make test-nocache pending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Tax resolution moved to the invoice/workflow level; detailed invoice rows no longer carry per-line tax config and legacy tax fields were deprecated/removed.
  * Leaf invoice lines now include an explicit resolved tax config and external billing integrations use that resolved config.

* **New Features**
  * Invoices now compute and attach an inherited/resolved tax configuration to leaf lines for downstream billing and tax calculations.

* **Tests**
  * Tests updated to validate tax settings at the invoice/DB level and reflect the new resolved-tax behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->