### PR TITLE
chore: update CodeGraph startup guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,13 +301,11 @@ Rule of thumb: **if the target is a Go identifier, start with CodeGraph. If it's
 
 ### Keeping the index fresh
 
-Run `codegraph sync` after significant code changes (new files, renames, major refactors). Run `codegraph index` for a full rebuild if the index seems stale or after branch switches.
+At the start of work, refresh CodeGraph before exploring Go code. If `.codegraph/` exists, run `codegraph sync`; if it does not exist, run `codegraph init -i` without asking first. Run `codegraph index` for a full rebuild if the index seems stale or after branch switches.
 
 ### If `.codegraph/` does NOT exist
 
-At the start of a session, ask the user if they'd like to initialize CodeGraph:
-
-> I notice this project doesn't have CodeGraph initialized. Would you like me to run `codegraph init -i` to build a code knowledge graph? It indexes ~1,800 Go files and takes about 5 seconds.
+Initialize it with `codegraph init -i` before doing code exploration. It indexes the Go codebase quickly and keeps symbol-aware lookup available.
 
 ## Skills
 


### PR DESCRIPTION
## What changed

- Updated `AGENTS.md` so agents refresh CodeGraph at the start of work.
- Replaced the old "ask before init" path with automatic `codegraph init -i` when `.codegraph/` is missing.

## Why

This keeps symbol-aware lookup available before code exploration and matches the workflow expected for this repo.

## Validation

- Reviewed the staged markdown diff.
- Ran `nix develop --impure .#ci -c codegraph sync`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced CodeGraph setup documentation with clearer initialization and usage procedures
  * Added explicit step-by-step instructions for refreshing the index at the beginning of work sessions
  * Documented the index rebuild process for when the index becomes stale or after branch switches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->