### PR TITLE
fix(telemetry): instrument v3 API routes with tracing

### DIFF
--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	health "github.com/AppsFlyer/go-sundheit"
@@ -14,6 +15,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-slog/otelslog"
 	"github.com/google/wire"
+	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -278,21 +280,53 @@ func NewTelemetryRouterHook(meterProvider metric.MeterProvider, tracerProvider t
 
 					routePattern := chi.RouteContext(r.Context()).RoutePattern()
 
+					// Record the route template as http.route on the span and request
+					// metrics — the canonical low-cardinality routing dimension. The span
+					// *name* is set separately by WithSpanNameFormatter below: otelhttp
+					// fixes the name at tracer.Start and a post-start SetName here is a
+					// no-op in this setup, so we cannot rename the span from this point.
 					span := trace.SpanFromContext(r.Context())
-					span.SetName(routePattern)
 					span.SetAttributes(semconv.URLPath(r.URL.String()), semconv.HTTPRoute(routePattern))
 
-					labeler, ok := otelhttp.LabelerFromContext(r.Context())
-					if ok {
+					if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
 						labeler.Add(semconv.HTTPRoute(routePattern))
 					}
 				}),
 				"",
 				otelhttp.WithMeterProvider(meterProvider),
 				otelhttp.WithTracerProvider(tracerProvider),
+				otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
+					// Name the server span "METHOD /route/{template}". chi's route pattern
+					// is the exact, low-cardinality template (path params appear as
+					// "{param}", so both ids and arbitrary keys collapse). It is already
+					// resolved by the time otelhttp calls this formatter. Fall back to the
+					// ULID-collapsed raw path when no route matched (e.g. 404s).
+					name := lowCardinalityPath(r.URL.Path)
+					if rctx := chi.RouteContext(r.Context()); rctx != nil {
+						if pat := rctx.RoutePattern(); pat != "" {
+							name = pat
+						}
+					}
+					return r.Method + " " + name
+				}),
 			)
 		})
 	}
+}
+
+// lowCardinalityPath collapses ULID path segments to ":id" so span names stay
+// bounded. OpenMeter resource IDs are ULIDs, so this keeps parameterized routes
+// (e.g. "/api/v3/openmeter/customers/01KFTS.../billing") from exploding span-name
+// cardinality, yielding "/api/v3/openmeter/customers/:id/billing". The exact route
+// template is carried separately in the http.route attribute.
+func lowCardinalityPath(path string) string {
+	segments := strings.Split(path, "/")
+	for i, seg := range segments {
+		if _, err := ulid.ParseStrict(seg); err == nil {
+			segments[i] = ":id"
+		}
+	}
+	return strings.Join(segments, "/")
 }
 
 type RuntimeMetricsCollector struct{}

--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -286,7 +286,7 @@ func NewTelemetryRouterHook(meterProvider metric.MeterProvider, tracerProvider t
 					// fixes the name at tracer.Start and a post-start SetName here is a
 					// no-op in this setup, so we cannot rename the span from this point.
 					span := trace.SpanFromContext(r.Context())
-					span.SetAttributes(semconv.URLPath(r.URL.String()), semconv.HTTPRoute(routePattern))
+					span.SetAttributes(semconv.URLPath(r.URL.Path), semconv.HTTPRoute(routePattern))
 
 					if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
 						labeler.Add(semconv.HTTPRoute(routePattern))

--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-slog/otelslog"
+	"github.com/google/uuid"
 	"github.com/google/wire"
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus"
@@ -332,19 +333,73 @@ func NewTelemetryRouterHook(meterProvider metric.MeterProvider, tracerProvider t
 	}
 }
 
-// lowCardinalityPath collapses ULID path segments to ":id" so span names stay
-// bounded. OpenMeter resource IDs are ULIDs, so this keeps parameterized routes
-// (e.g. "/api/v3/openmeter/customers/01KFTS.../billing") from exploding span-name
-// cardinality, yielding "/api/v3/openmeter/customers/:id/billing". The exact route
-// template is carried separately in the http.route attribute.
+const (
+	// maxRouteSegmentLen: segments longer than this are treated as opaque identifiers
+	// (tokens, keys, random slugs — typical of unmatched/scanner traffic). Legitimate
+	// route segments are well under this (longest is ~"entitlement-access").
+	maxRouteSegmentLen = 32
+	// maxRouteSegments: paths deeper than this are truncated. Real routes are shallow;
+	// deeper paths are almost always scanner traversal.
+	maxRouteSegments = 12
+)
+
+// lowCardinalityPath turns a raw request path into a bounded span-name fragment.
+// It masks high-cardinality segments (ULIDs, UUIDs, numeric ids, over-long opaque
+// tokens) to ":id" and truncates pathologically deep paths, so unmatched/scanner
+// traffic cannot blow up span-name cardinality. It is the name source both for v3
+// routes (whose chi pattern is the skipped "/api/v3/*" mount wildcard) and for
+// unmatched requests. The exact route template, when one matched, is carried
+// separately on the http.route attribute.
 func lowCardinalityPath(path string) string {
 	segments := strings.Split(path, "/")
+
+	truncated := false
+	if len(segments) > maxRouteSegments {
+		segments = segments[:maxRouteSegments]
+		truncated = true
+	}
+
 	for i, seg := range segments {
-		if _, err := ulid.ParseStrict(seg); err == nil {
+		if isHighCardinalitySegment(seg) {
 			segments[i] = ":id"
 		}
 	}
-	return strings.Join(segments, "/")
+
+	out := strings.Join(segments, "/")
+	if truncated {
+		out += "/..."
+	}
+	return out
+}
+
+// isHighCardinalitySegment reports whether a path segment looks like an identifier or
+// opaque token rather than a fixed route word.
+func isHighCardinalitySegment(seg string) bool {
+	if len(seg) > maxRouteSegmentLen {
+		return true
+	}
+	if isAllDigits(seg) {
+		return true
+	}
+	if _, err := ulid.ParseStrict(seg); err == nil {
+		return true
+	}
+	if _, err := uuid.Parse(seg); err == nil {
+		return true
+	}
+	return false
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 type RuntimeMetricsCollector struct{}

--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/server"
 	"github.com/openmeterio/openmeter/pkg/contextx"
+	"github.com/openmeterio/openmeter/pkg/framework/transport/httptransport"
 	"github.com/openmeterio/openmeter/pkg/gosundheit"
 )
 
@@ -199,6 +200,9 @@ func NewTracerProvider(ctx context.Context, conf config.TraceTelemetryConfig, re
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to initialize OpenTelemetry Trace provider: %w", err)
 	}
+
+	// Apply the global per-operation child-span toggle once, at trace init.
+	httptransport.EnableOperationSpans(conf.OperationSpans)
 
 	return tracerProvider, func() {
 		// Use dedicated context with timeout for shutdown as parent context might be canceled

--- a/app/common/telemetry.go
+++ b/app/common/telemetry.go
@@ -296,18 +296,36 @@ func NewTelemetryRouterHook(meterProvider metric.MeterProvider, tracerProvider t
 				otelhttp.WithMeterProvider(meterProvider),
 				otelhttp.WithTracerProvider(tracerProvider),
 				otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
-					// Name the server span "METHOD /route/{template}". chi's route pattern
-					// is the exact, low-cardinality template (path params appear as
-					// "{param}", so both ids and arbitrary keys collapse). It is already
-					// resolved by the time otelhttp calls this formatter. Fall back to the
-					// ULID-collapsed raw path when no route matched (e.g. 404s).
-					name := lowCardinalityPath(r.URL.Path)
-					if rctx := chi.RouteContext(r.Context()); rctx != nil {
-						if pat := rctx.RoutePattern(); pat != "" {
-							name = pat
+					// Name the server span "METHOD /route/{template}" using the lowest-
+					// cardinality route identifier available.
+					//
+					// Two-pass note: otelhttp calls this formatter once when the span
+					// starts (before chi has finished routing) and, in v0.68, again after
+					// the handler only when r.Pattern is set. r.Pattern is the net/http
+					// ServeMux pattern; chi does not populate it, so under chi the name is
+					// set on the first (pre-routing) call only. We therefore resolve the
+					// route from the available signals, most specific first:
+					//   1. r.Pattern           — net/http ServeMux pattern; chi sets it to the
+					//                            mount prefix ("/api/v3/*") for sub-routers
+					//   2. chi RoutePattern    — matched chi template ("{param}" placeholders)
+					//   3. ULID-collapsed path — fallback when no resolved template is available
+					// The exact template is also recorded on the http.route attribute.
+					//
+					// A value containing "*" is an unresolved mount prefix (e.g. "/api/v3/*"
+					// when otelhttp runs inside a sub-router, before the leaf is matched —
+					// this surfaces via r.Pattern on otelhttp's post-handler pass). It is not
+					// a usable route name, so skip it (from any source) and fall back to the
+					// ULID-collapsed path.
+					route := r.Pattern
+					if route == "" {
+						if rctx := chi.RouteContext(r.Context()); rctx != nil {
+							route = rctx.RoutePattern()
 						}
 					}
-					return r.Method + " " + name
+					if route == "" || strings.Contains(route, "*") {
+						route = lowCardinalityPath(r.URL.Path)
+					}
+					return r.Method + " " + route
 				}),
 			)
 		})

--- a/app/common/telemetry_test.go
+++ b/app/common/telemetry_test.go
@@ -3,10 +3,66 @@ package common
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
+
+func TestLowCardinalityPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "fixed route is unchanged",
+			path: "/api/v3/openmeter/customers",
+			want: "/api/v3/openmeter/customers",
+		},
+		{
+			name: "ULID segment masked",
+			path: "/api/v3/openmeter/customers/01ARZ3NDEKTSV4RRFFQ69G5FAV/billing",
+			want: "/api/v3/openmeter/customers/:id/billing",
+		},
+		{
+			name: "UUID segment masked",
+			path: "/api/v3/openmeter/customers/550e8400-e29b-41d4-a716-446655440000",
+			want: "/api/v3/openmeter/customers/:id",
+		},
+		{
+			name: "numeric segment masked",
+			path: "/api/v1/things/12345",
+			want: "/api/v1/things/:id",
+		},
+		{
+			name: "over-long opaque token masked",
+			path: "/api/v1/things/" + strings.Repeat("x", 40),
+			want: "/api/v1/things/:id",
+		},
+		{
+			name: "short legit segments preserved",
+			path: "/api/v3/openmeter/customers/01ARZ3NDEKTSV4RRFFQ69G5FAV/entitlement-access",
+			want: "/api/v3/openmeter/customers/:id/entitlement-access",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, lowCardinalityPath(tc.path))
+		})
+	}
+}
+
+func TestLowCardinalityPath_TruncatesDeepPaths(t *testing.T) {
+	// A pathologically deep path (scanner traversal) is truncated and suffixed.
+	deep := "/" + strings.Repeat("a/", 30)
+	got := lowCardinalityPath(deep)
+
+	assert.True(t, strings.HasSuffix(got, "/..."), "deep path should be truncated, got %q", got)
+	assert.LessOrEqual(t, strings.Count(got, "/"), maxRouteSegments+1)
+}
 
 func TestLevelHandler(t *testing.T) {
 	mockHandler := &MockHandler{}

--- a/app/config/telemetry.go
+++ b/app/config/telemetry.go
@@ -100,6 +100,12 @@ func (c TelemetryConfig) Validate() error {
 type TraceTelemetryConfig struct {
 	Sampler   string
 	Exporters ExportersTraceTelemetryConfig
+
+	// OperationSpans enables an application-level child span per HTTP operation
+	// (named after the operation, e.g. "list-customers"), nested under the otelhttp
+	// server span. Off by default: it adds a span to every operation request across
+	// the API, so it is a deliberate, env-level opt-in given the extra span volume.
+	OperationSpans bool
 }
 
 // Validate validates the configuration.
@@ -659,6 +665,7 @@ func ConfigureTelemetry(v *viper.Viper, flags *pflag.FlagSet) {
 	v.SetDefault("telemetry.address", ":10000")
 
 	v.SetDefault("telemetry.trace.sampler", "never")
+	v.SetDefault("telemetry.trace.operationSpans", false)
 	v.SetDefault("telemetry.trace.exporters.otlp.enabled", false)
 	v.SetDefault("telemetry.trace.exporters.otlp.address", "")
 

--- a/openmeter/server/server.go
+++ b/openmeter/server/server.go
@@ -92,9 +92,16 @@ func NewServer(config *Config) (*Server, error) {
 	r := chi.NewRouter()
 	r.Use(server.NewPoweredByMiddleware())
 
-	// Collect router-hook middlewares (e.g. otelhttp tracing/metrics) so v3
-	// has the same OTEL HTTP instrumentation as the v1 router group.
-	v3Middlewares := append(collectMiddlewareHooks(config.RouterHooks.Middlewares), []server.MiddlewareFunc{
+	// Materialize the router-hook middlewares once (running each hook body a single
+	// time) and apply the same slice to both the v3 and v1 groups below. Invoking the
+	// hooks per-group instead would run their bodies twice — harmless for the stateless
+	// telemetry hook, but unsafe for any future hook with construction side effects.
+	hookMiddlewares := collectMiddlewareHooks(config.RouterHooks.Middlewares)
+
+	// v3 gets the hook middlewares (e.g. otelhttp tracing/metrics) plus the standard
+	// stack, so it has the same OTEL HTTP instrumentation as the v1 router group.
+	v3Middlewares := append([]server.MiddlewareFunc{}, hookMiddlewares...)
+	v3Middlewares = append(v3Middlewares, []server.MiddlewareFunc{
 		middleware.RealIP,
 		middleware.RequestID,
 		func(h http.Handler) http.Handler {
@@ -159,9 +166,9 @@ func NewServer(config *Config) (*Server, error) {
 	}
 
 	r.Group(func(r chi.Router) {
-		// Apply middlewares
-		for _, middlewareHook := range config.RouterHooks.Middlewares {
-			middlewareHook(r)
+		// Apply the same materialized hook middlewares as the v3 group above.
+		for _, mw := range hookMiddlewares {
+			r.Use(mw)
 		}
 
 		r.Use(middleware.RealIP)

--- a/openmeter/server/server.go
+++ b/openmeter/server/server.go
@@ -92,7 +92,9 @@ func NewServer(config *Config) (*Server, error) {
 	r := chi.NewRouter()
 	r.Use(server.NewPoweredByMiddleware())
 
-	v3Middlewares := []server.MiddlewareFunc{
+	// Collect router-hook middlewares (e.g. otelhttp tracing/metrics) so v3
+	// has the same OTEL HTTP instrumentation as the v1 router group.
+	v3Middlewares := append(collectMiddlewareHooks(config.RouterHooks.Middlewares), []server.MiddlewareFunc{
 		middleware.RealIP,
 		middleware.RequestID,
 		func(h http.Handler) http.Handler {
@@ -105,7 +107,7 @@ func NewServer(config *Config) (*Server, error) {
 		},
 		server.NewRequestLoggerMiddleware(slog.Default().Handler()),
 		middleware.Recoverer,
-	}
+	}...)
 
 	v3API, err := v3server.NewServer(&v3server.Config{
 		BaseURL:                  "/api/v3",
@@ -245,6 +247,26 @@ func NewServer(config *Config) (*Server, error) {
 	return &Server{
 		Router: r,
 	}, nil
+}
+
+// middlewareCollector implements MiddlewareManager to collect middlewares from hooks.
+type middlewareCollector struct {
+	middlewares []server.MiddlewareFunc
+}
+
+func (c *middlewareCollector) Use(middlewares ...func(http.Handler) http.Handler) {
+	for _, mw := range middlewares {
+		c.middlewares = append(c.middlewares, server.MiddlewareFunc(mw))
+	}
+}
+
+// collectMiddlewareHooks materialises MiddlewareHooks into a flat slice of middleware funcs.
+func collectMiddlewareHooks(hooks []MiddlewareHook) []server.MiddlewareFunc {
+	c := &middlewareCollector{}
+	for _, hook := range hooks {
+		hook(c)
+	}
+	return c.middlewares
 }
 
 // errorHandlerReply handles errors returned by the OpenAPI layer.

--- a/openmeter/server/server.go
+++ b/openmeter/server/server.go
@@ -260,7 +260,7 @@ func (c *middlewareCollector) Use(middlewares ...func(http.Handler) http.Handler
 	}
 }
 
-// collectMiddlewareHooks materialises MiddlewareHooks into a flat slice of middleware funcs.
+// collectMiddlewareHooks materializes MiddlewareHooks into a flat slice of middleware funcs.
 func collectMiddlewareHooks(hooks []MiddlewareHook) []server.MiddlewareFunc {
 	c := &middlewareCollector{}
 	for _, hook := range hooks {

--- a/pkg/framework/transport/httptransport/handler.go
+++ b/pkg/framework/transport/httptransport/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync/atomic"
 
 	"go.opentelemetry.io/otel"
 	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
@@ -24,6 +25,18 @@ var defaultHandlerOptions = []HandlerOption{
 // Used to start an application-level span named after the handler operation, as a
 // child of the otelhttp server span.
 var tracer = otel.Tracer("github.com/openmeterio/openmeter/pkg/framework/transport/httptransport")
+
+// operationSpansEnabled is a global toggle for the per-operation child span. It is off
+// by default — the span is added to every operation request, so enabling it across the
+// whole API surface meaningfully increases trace-span volume. Set once at startup via
+// EnableOperationSpans.
+var operationSpansEnabled atomic.Bool
+
+// EnableOperationSpans globally enables or disables the application-level per-operation
+// child span. Intended to be called once during startup from telemetry configuration.
+func EnableOperationSpans(enabled bool) {
+	operationSpansEnabled.Store(enabled)
+}
 
 type Handler[Request any, Response any] interface {
 	ServeHTTP(w http.ResponseWriter, r *http.Request)
@@ -89,12 +102,17 @@ func (h handler[Request, Response]) ServeHTTP(w http.ResponseWriter, r *http.Req
 		name := h.operationNameFunc(ctx)
 		ctx = contextx.WithAttr(ctx, string(semconv.HTTPRouteKey), name)
 
-		// Start an application-level span named after the operation, as a child of
-		// the otelhttp server span. The server span stays route-named; this one
-		// carries the operation identity (e.g. "query-governance-access").
-		var span trace.Span
-		ctx, span = tracer.Start(ctx, name)
-		defer span.End()
+		// When enabled globally (EnableOperationSpans), start an application-level span
+		// named after the operation, as a child of the otelhttp server span. The server
+		// span stays route-named; this one carries the operation identity (e.g.
+		// "query-governance-access") and exposes the handler-vs-middleware timing split.
+		// Off by default: it adds a span to every operation request API-wide, so it is
+		// gated by a single startup toggle rather than enabled unconditionally.
+		if operationSpansEnabled.Load() {
+			var span trace.Span
+			ctx, span = tracer.Start(ctx, name)
+			defer span.End()
+		}
 	}
 
 	request, err := h.decodeRequest(ctx, r)

--- a/pkg/framework/transport/httptransport/handler.go
+++ b/pkg/framework/transport/httptransport/handler.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"net/http"
 
+	"go.opentelemetry.io/otel"
 	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/pkg/contextx"
 	"github.com/openmeterio/openmeter/pkg/framework/commonhttp"
@@ -17,6 +19,11 @@ import (
 var defaultHandlerOptions = []HandlerOption{
 	WithErrorEncoder(commonhttp.GenericErrorEncoder()),
 }
+
+// tracer reads the globally configured TracerProvider (set during telemetry init).
+// Used to start an application-level span named after the handler operation, as a
+// child of the otelhttp server span.
+var tracer = otel.Tracer("github.com/openmeterio/openmeter/pkg/framework/transport/httptransport")
 
 type Handler[Request any, Response any] interface {
 	ServeHTTP(w http.ResponseWriter, r *http.Request)
@@ -79,7 +86,15 @@ func (h handler[Request, Response]) ServeHTTP(w http.ResponseWriter, r *http.Req
 
 	// TODO: rewrite this as a generic hook
 	if h.operationNameFunc != nil {
-		ctx = contextx.WithAttr(ctx, string(semconv.HTTPRouteKey), h.operationNameFunc(ctx))
+		name := h.operationNameFunc(ctx)
+		ctx = contextx.WithAttr(ctx, string(semconv.HTTPRouteKey), name)
+
+		// Start an application-level span named after the operation, as a child of
+		// the otelhttp server span. The server span stays route-named; this one
+		// carries the operation identity (e.g. "query-governance-access").
+		var span trace.Span
+		ctx, span = tracer.Start(ctx, name)
+		defer span.End()
 	}
 
 	request, err := h.decodeRequest(ctx, r)


### PR DESCRIPTION
## What

Instruments the v3 API with OpenTelemetry HTTP tracing/metrics (on par with v1), gives server spans meaningful low-cardinality names, and adds an optional per-operation child span behind a global toggle.

## Why

v3 routes had **no** otelhttp instrumentation (the v3 group was registered before the telemetry middleware), and server spans had empty/unhelpful names — making v3 traces hard to find and group. We also wanted handler-vs-middleware timing visibility without inflating span volume across the whole API.

## How

- **v3 instrumentation:** materialize the router-hook middlewares once and apply the same slice to both the v3 and v1 groups (hooks run once; no double side effects).
- **Span name:** `METHOD /route/{template}` from the chi route pattern (`r.Pattern` → chi `RouteContext` → fallback). Unresolved mount wildcards (`/api/v3/*`) are skipped.
- **`http.route` attribute + metric label:** the exact route template — the canonical low-cardinality routing dimension. `url.path` is path-only (no query string).
- **Cardinality bounding:** the fallback path masks ULIDs, UUIDs, numeric ids, and over-long opaque segments to `:id`, and truncates pathologically deep paths — so unmatched/scanner traffic can't blow up span-name cardinality.
- **Per-operation child span:** application-level span named after the operation (e.g. `list-customers`), nested under the server span, exposing the middleware-vs-handler split. **Off by default**, enabled via `telemetry.trace.operationSpans`, since it adds a span to every request.

> Note on otelhttp v0.68: the span name is set at span start (and re-set on a post-handler pass when `r.Pattern` is set), so naming is done in `WithSpanNameFormatter` rather than via a post-start `SetName` (a no-op in this chi setup).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced OpenTelemetry instrumentation for richer request tracing and reduced span cardinality by masking dynamic path segments.
  * Normalized server span naming and improved URL-path attribution for clearer traces.
* **New Features**
  * Optional per-operation child spans (disabled by default) for more granular application-level tracing.
* **Improvements**
  * Consolidated middleware collection so routing groups share consistent middleware.
* **Tests**
  * Added tests validating path masking and truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->