### PR TITLE
feat(creditpurchase): Add statemachine to externally-settled creaditp…

### DIFF
--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -562,6 +562,13 @@ When status changes:
 
 Implement `ToMetaChargeStatus()` by validating the charge-type-specific status and then deriving the root status with `meta.DetailedStatusToMetaStatus(string(status))`. Do not enumerate detailed states in this conversion; detailed status lists belong in `Values()` and lifecycle transition matrices, and duplicated switch statements drift as states are added.
 
+### `status_detailed` is a Go-validated enum, not a DB constraint
+
+All three charge types declare the column as `field.Enum("status_detailed").GoType(<type>.Status(""))`, which in this repo's Atlas setup maps to a plain Postgres `character varying` column — there is **no** DB-level CHECK enumerating the values. Validation happens only in Go: the generated `StatusDetailedValidator` and `Status.Validate()`, both driven by `Status.Values()`. Consequences:
+
+- Adding or removing a detailed status requires `make generate` so the generated Go validator and the `Enums` list in `ent/db/migrate/schema.go` match `Values()`, but it does **not** require an Atlas migration — `atlas migrate --env local diff ...` reports "no changes to be made" because the column type is unchanged. Do not hand-write a migration for a `status_detailed` value change.
+- The shared state-machine base (`charges/statemachine.Machine`) uses external storage whose state setter calls `Status.Validate()` on **every** transition. A `Configure(...)`/`Permit(...)` into a status that is absent from `Status.Values()` passes `CanFire(...)` but fails the moment the transition actually fires. Keep `configureStates()` and `Values()` in sync: every status reachable in the transition matrix must be listed in `Values()`, and a status that is configured but never fired (because orchestration bypasses it) is a latent bug — either wire it into `Values()` and fire it, or remove it from `configureStates()`.
+
 ## Testing Guidance
 
 Key tests:
@@ -676,6 +683,16 @@ When changing credit purchase charges:
 - Service methods that only change edge data (e.g., `HandleExternalPaymentAuthorized`) update `charge.Realizations` in memory and return the full `Charge` without calling `UpdateCharge`
 - Service methods that change status (e.g., `HandleExternalPaymentSettled`, `onPromotionalCreditPurchase`) call `UpdateCharge(ctx, charge.ChargeBase)` and merge the result back: `charge.ChargeBase = updatedBase`
 - Credit grant creation must go through `adapter.CreateCreditGrant(...)` — do not write credit grant data through `UpdateCharge`
+
+External-settled credit purchase (its own lifecycle, separate from promotional/invoice):
+
+- the external settlement lifecycle has its own state machine `ExternalCreditPurchaseStateMachine` (`creditpurchase/service/external.go`), built by `onExternalCreditPurchase(...)`; promotional and invoice settlement each have their own state machine too
+- `creditpurchase.ExternalSettlement` carries `InitialStatus` (`InitialPaymentSettlementStatus`: `created` / `authorized` / `settled`). `externalInitialPaymentTrigger(...)` maps it to the lifecycle entry: `created` → no trigger (empty string), `authorized` → `billing.TriggerAuthorized`, `settled` → `billing.TriggerPaid`
+- reuse the billing invoice triggers `billing.TriggerAuthorized` / `billing.TriggerPaid` for the payment lifecycle; do not introduce external-specific trigger names even though external and invoice settlement run on separate state machines
+- external realization mechanics live in `creditpurchase/service/realizations` (`realizations.Service`): `InitiateExternalCreditPurchase`, `AuthorizeExternalPayment`, `SettleExternalPayment`, `AuthorizeAndSettleExternalPayment`. Same separation rule as the flat-fee/usage-based realization helpers — the helper executes mechanics and must not decide which trigger fires or which status is entered (its doc comment states this). Its `Config.Validate()` returns `models.NewNillableGenericValidationError(errors.Join(errs...))`
+- the realization layer owns the payment guards: authorize rejects a charge that already has `Realizations.ExternalPaymentSettlement` (`payment.ErrPaymentAlreadyAuthorized`); settle rejects a nil settlement (`payment.ErrCannotSettleNotAuthorizedPayment`) or one not in `payment.StatusAuthorized` (`payment.ErrPaymentAlreadySettled`)
+- every credit-purchase grant path must call `lineage.BackfillAdvanceLineageSegments(...)` with `FeatureFilters: charge.Intent.FeatureFilters.Normalize()` — promotional (`promotional.go`), invoice (`invoice.go`), and external (`realizations/service.go` `InitiateExternalCreditPurchase`). Omitting `FeatureFilters` silently produces over-broad lineage segments for feature-scoped grants; guard each call on a non-empty `TransactionGroupID`
+- external/invoice settlement cost basis must be positive; `GenericSettlement.Validate()` enforces it and `InitiateExternalCreditPurchase` re-checks before creating the grant realization
 
 ## Credit Realization Model
 

--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -560,6 +560,8 @@ When status changes:
 
 `usagebased.Status.ToMetaChargeStatus()`, `flatfee.Status.ToMetaChargeStatus()`, and `creditpurchase.Status.ToMetaChargeStatus()` are the bridges between the full state-machine status and the root charge meta status.
 
+Implement `ToMetaChargeStatus()` by validating the charge-type-specific status and then deriving the root status with `meta.DetailedStatusToMetaStatus(string(status))`. Do not enumerate detailed states in this conversion; detailed status lists belong in `Values()` and lifecycle transition matrices, and duplicated switch statements drift as states are added.
+
 ## Testing Guidance
 
 Key tests:
@@ -583,6 +585,7 @@ Use these conventions for lifecycle tests:
 - for credit-only charges (usage-based or flat fee), `Create(...)` itself may return an already-advanced charge — assert the returned charge's status, do not assume it will be `created`
 - for flat fee credit-only tests, use `mustAdvanceFlatFeeCharges(...)` helper — it filters the advance result to flat fee charges only
 - flat fee credit-only handler callbacks (`onCreditsOnlyUsageAccrued`) must return credit allocations that sum to the input `AmountToAllocate`
+- for credit-purchase state-machine unit tests, use testify `mock.Mock` with `On(...).Run(...).Return(...).Once()` for expected handler callbacks so missing or unexpected calls fail; in service-suite tests, leave callbacks unset when validating that a flow fails before callbacks, because the shared `CreditPurchaseTestHandler` already errors if an unset callback is invoked
 - when testing timestamp truncation, use sub-second fixtures and assert the persisted charge/run fields are second-aligned after create/advance
 - `time.Time` fields on domain models are value typed; use `s.False(ts.IsZero())` instead of `s.NotNil(ts)` when asserting they are populated
 - cover the temporary shrink/extend remap path as well; it synthesizes new intents and must normalize the replacement period ends before re-create
@@ -650,8 +653,8 @@ Usage-based handler interface (`usagebased.Handler`):
 Credit purchase handler interface (`creditpurchase.Handler`):
 - `OnPromotionalCreditPurchase(ctx, Charge)` → `ledgertransaction.GroupReference`
 - `OnCreditPurchaseInitiated(ctx, Charge)` → `ledgertransaction.GroupReference`
-- `OnCreditPurchasePaymentAuthorized(ctx, Charge)` → `ledgertransaction.GroupReference`
-- `OnCreditPurchasePaymentSettled(ctx, Charge)` → `ledgertransaction.GroupReference`
+- `OnCreditPurchasePaymentAuthorized(ctx, PaymentEventInput)` → `ledgertransaction.GroupReference`
+- `OnCreditPurchasePaymentSettled(ctx, PaymentEventInput)` → `ledgertransaction.GroupReference`
 
 `flatfee/service/service.go` Config requires a `*lockr.Locker` — when constructing in tests, create the locker before the flat fee service
 
@@ -663,6 +666,9 @@ When changing credit purchase charges:
 - `CreditGrantRealization` is stored in its own `charge_credit_purchase_credit_grants` table, not on the base row
 - `creditpurchase.Status` mirrors the flatfee pattern: `StatusCreated`, `StatusActive`, `StatusFinal`, `StatusDeleted` with `ToMetaChargeStatus()` bridge
 - `charge_credit_purchases.status_detailed` column mirrors `status` and is set via `SetStatusDetailed(...)` on create/update
+- external credit-purchase direct provider `paid` events must authorize first so `OnCreditPurchasePaymentAuthorized(...)` observes `active.payment.authorized` without an external payment realization; run settlement before the transition to `final` is persisted, so `OnCreditPurchasePaymentSettled(...)` observes the authorized payment realization while the charge is still `active.payment.authorized`
+- prefer `OnActive(...)` for credit-purchase state-owned realization side effects such as grant initiation and payment authorization; use `OnExitWith(...)` for settlement when the callback must run before moving to `final` without adding a durable intermediate status
+- do not add credit-purchase detailed statuses only to model callback ordering; add persisted `status_detailed` values only when callers need to observe or retry a durable lifecycle state
 - `UpdateCharge(ctx, ChargeBase) (ChargeBase, error)` only updates base-row fields — do not call it just because realization edges changed
 - Realization edges are created/updated through dedicated adapter methods: `CreateCreditGrant`, `CreateExternalPayment`, `UpdateExternalPayment`, `CreateInvoicedPayment`, `UpdateInvoicedPayment`
 - Adapter interface is composite: `ChargeAdapter` + `CreditGrantAdapter` + `ExternalPaymentAdapter` + `InvoicedPaymentAdapter`

--- a/openmeter/billing/charges/creditpurchase/adapter/charge.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/charge.go
@@ -59,6 +59,16 @@ func (a *adapter) CreateCharge(ctx context.Context, in creditpurchase.CreateChar
 	}
 
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (creditpurchase.Charge, error) {
+		initialStatus := creditpurchase.StatusCreated
+		if in.Intent.Settlement.Type() == creditpurchase.SettlementTypeExternal {
+			initialStatus = creditpurchase.StatusActiveInitialCreditGrant
+		}
+
+		metaStatus, err := initialStatus.ToMetaChargeStatus()
+		if err != nil {
+			return creditpurchase.Charge{}, err
+		}
+
 		create := tx.db.ChargeCreditPurchase.Create().
 			SetNamespace(in.Namespace).
 			SetCreditAmount(in.Intent.CreditAmount).
@@ -67,12 +77,12 @@ func (a *adapter) CreateCharge(ctx context.Context, in creditpurchase.CreateChar
 			SetNillablePriority(in.Intent.Priority).
 			SetFeatureFilters(pq.StringArray(in.Intent.FeatureFilters.Normalize())).
 			SetSettlement(in.Intent.Settlement).
-			SetStatusDetailed(creditpurchase.StatusCreated)
+			SetStatusDetailed(initialStatus)
 
-		create, err := chargemeta.Create(create, chargemeta.CreateInput{
+		create, err = chargemeta.Create(create, chargemeta.CreateInput{
 			Namespace: in.Namespace,
 			Intent:    in.Intent.Intent,
-			Status:    meta.ChargeStatusCreated,
+			Status:    metaStatus,
 		})
 		if err != nil {
 			return creditpurchase.Charge{}, err

--- a/openmeter/billing/charges/creditpurchase/adapter/charge.go
+++ b/openmeter/billing/charges/creditpurchase/adapter/charge.go
@@ -60,9 +60,6 @@ func (a *adapter) CreateCharge(ctx context.Context, in creditpurchase.CreateChar
 
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (creditpurchase.Charge, error) {
 		initialStatus := creditpurchase.StatusCreated
-		if in.Intent.Settlement.Type() == creditpurchase.SettlementTypeExternal {
-			initialStatus = creditpurchase.StatusActiveInitialCreditGrant
-		}
 
 		metaStatus, err := initialStatus.ToMetaChargeStatus()
 		if err != nil {

--- a/openmeter/billing/charges/creditpurchase/service/external.go
+++ b/openmeter/billing/charges/creditpurchase/service/external.go
@@ -9,7 +9,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
-	chargestatemachine "github.com/openmeterio/openmeter/openmeter/billing/charges/statemachine"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
 
@@ -111,71 +110,57 @@ func (s *ExternalCreditPurchaseStateMachine) configureStates() {
 		Permit(billing.TriggerPaid, creditpurchase.StatusActivePaymentSettled)
 
 	s.Configure(creditpurchase.StatusActivePaymentPaidAndAuthorized).
-		Permit(billing.TriggerNext, creditpurchase.StatusActivePaymentSettled).
+		Permit(meta.TriggerNext, creditpurchase.StatusActivePaymentSettled).
 		OnActive(s.AuthorizeExternalPayment)
 
 	s.Configure(creditpurchase.StatusActivePaymentSettled).
-		Permit(billing.TriggerNext, creditpurchase.StatusFinal).
+		Permit(meta.TriggerNext, creditpurchase.StatusFinal).
 		OnActive(s.SettleExternalPayment)
 
 	s.Configure(creditpurchase.StatusFinal)
 }
 
 func (s *ExternalCreditPurchaseStateMachine) AdvanceUntilStateStable(ctx context.Context) (*creditpurchase.Charge, error) {
-	hadGrant := hasExternalCreditGrant(s.Charge)
-
-	advancedCharge, err := s.stateMachine.Machine.AdvanceUntilStateStable(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	switch s.Charge.Status {
-	case creditpurchase.StatusActivePaymentPending, creditpurchase.StatusActivePaymentAuthorized:
+	if s.Charge.Status == creditpurchase.StatusActiveInitialCreditGrant {
 		if err := s.EnsureExternalCreditPurchaseInitiated(ctx); err != nil {
 			return nil, err
 		}
 	}
 
-	if advancedCharge != nil || (!hadGrant && hasExternalCreditGrant(s.Charge)) {
-		charge := s.GetCharge()
-		return &charge, nil
-	}
-
-	return nil, nil
+	return s.stateMachine.Machine.AdvanceUntilStateStable(ctx)
 }
 
 func (s *ExternalCreditPurchaseStateMachine) InitiateExternalCreditPurchaseFromCreated(ctx context.Context) error {
-	return s.applyRealizationUpdate(ctx, s.Realizations.InitiateExternalCreditPurchase)
-}
-
-func (s *ExternalCreditPurchaseStateMachine) EnsureExternalCreditPurchaseInitiated(ctx context.Context) error {
-	if hasExternalCreditGrant(s.Charge) {
-		return nil
-	}
-
-	return s.InitiateExternalCreditPurchaseFromCreated(ctx)
-}
-
-func (s *ExternalCreditPurchaseStateMachine) AuthorizeExternalPayment(ctx context.Context) error {
-	return s.applyRealizationUpdate(ctx, s.Realizations.AuthorizeExternalPayment)
-}
-
-func (s *ExternalCreditPurchaseStateMachine) SettleExternalPayment(ctx context.Context) error {
-	return s.applyRealizationUpdate(ctx, s.Realizations.SettleExternalPayment)
-}
-
-// applyRealizationUpdate records realization-side effects while preserving the
-// state-machine-owned base from the current transition.
-func (s *ExternalCreditPurchaseStateMachine) applyRealizationUpdate(
-	ctx context.Context,
-	update func(context.Context, creditpurchase.Charge) (creditpurchase.Charge, error),
-) error {
-	updatedCharge, err := update(ctx, s.Charge)
+	updatedCharge, err := s.Realizations.InitiateExternalCreditPurchase(ctx, s.Charge)
 	if err != nil {
 		return err
 	}
 
-	s.Charge = updatedCharge.WithBase(s.Charge.ChargeBase)
+	s.Charge = updatedCharge
+	return nil
+}
+
+func (s *ExternalCreditPurchaseStateMachine) EnsureExternalCreditPurchaseInitiated(ctx context.Context) error {
+	return s.InitiateExternalCreditPurchaseFromCreated(ctx)
+}
+
+func (s *ExternalCreditPurchaseStateMachine) AuthorizeExternalPayment(ctx context.Context) error {
+	updatedCharge, err := s.Realizations.AuthorizeExternalPayment(ctx, s.Charge)
+	if err != nil {
+		return err
+	}
+
+	s.Charge = updatedCharge
+	return nil
+}
+
+func (s *ExternalCreditPurchaseStateMachine) SettleExternalPayment(ctx context.Context) error {
+	updatedCharge, err := s.Realizations.SettleExternalPayment(ctx, s.Charge)
+	if err != nil {
+		return err
+	}
+
+	s.Charge = updatedCharge
 	return nil
 }
 
@@ -192,50 +177,7 @@ func (s *ExternalCreditPurchaseStateMachine) handleExternalPaymentLifecycleTrigg
 		return creditpurchase.Charge{}, fmt.Errorf("advance external state machine: %w", err)
 	}
 
-	if trigger == billing.TriggerPaid {
-		return s.handleSettledExternalPayment(ctx)
-	}
-
 	return s.FireAndAdvanceUntilStateStable(ctx, trigger)
-}
-
-func hasExternalCreditGrant(charge creditpurchase.Charge) bool {
-	return charge.Realizations.CreditGrantRealization != nil &&
-		charge.Realizations.CreditGrantRealization.TransactionGroupID != ""
-}
-
-// handleSettledExternalPayment handles provider flows that may report paid
-// without a separate authorization event, preserving authorization before settlement.
-func (s *ExternalCreditPurchaseStateMachine) handleSettledExternalPayment(ctx context.Context) (creditpurchase.Charge, error) {
-	if s.Charge.Status == creditpurchase.StatusActivePaymentPending {
-		if _, err := s.FireAndAdvanceUntilStateStable(ctx, billing.TriggerAuthorized); err != nil {
-			return creditpurchase.Charge{}, err
-		}
-	}
-
-	if s.Charge.Status != creditpurchase.StatusActivePaymentAuthorized {
-		return creditpurchase.Charge{}, fmt.Errorf(
-			"%w: %s [status=%s,id=%s]",
-			chargestatemachine.ErrUnsupportedOperation,
-			billing.TriggerPaid,
-			s.Charge.Status,
-			s.Charge.GetChargeID().ID,
-		)
-	}
-
-	if err := s.SettleExternalPayment(ctx); err != nil {
-		return creditpurchase.Charge{}, err
-	}
-
-	s.Charge = s.Charge.WithStatus(creditpurchase.StatusFinal)
-	updatedBase, err := s.Adapter.UpdateCharge(ctx, s.Charge.GetBase())
-	if err != nil {
-		return creditpurchase.Charge{}, fmt.Errorf("persist charge: %w", err)
-	}
-
-	s.Charge = s.Charge.WithBase(updatedBase)
-
-	return s.GetCharge(), nil
 }
 
 func (s *service) HandleExternalPaymentAuthorized(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {

--- a/openmeter/billing/charges/creditpurchase/service/external.go
+++ b/openmeter/billing/charges/creditpurchase/service/external.go
@@ -2,12 +2,14 @@ package service
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
-	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	chargestatemachine "github.com/openmeterio/openmeter/openmeter/billing/charges/statemachine"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 )
 
@@ -17,163 +19,240 @@ func (s *service) onExternalCreditPurchase(ctx context.Context, charge creditpur
 		return creditpurchase.Charge{}, err
 	}
 
-	targetStatus := externalCreditPurchaseSettlement.InitialStatus
-
-	charge, err = transaction.Run(ctx, s.adapter, func(ctx context.Context) (creditpurchase.Charge, error) {
-		ledgerTransactionGroupReference, err := s.handler.OnCreditPurchaseInitiated(ctx, charge)
-		if err != nil {
-			return creditpurchase.Charge{}, err
-		}
-
-		grantRealization, err := s.adapter.CreateCreditGrant(ctx, charge.GetChargeID(), creditpurchase.CreateCreditGrantInput{
-			TransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
-			GrantedAt:          clock.Now(),
-		})
-		if err != nil {
-			return creditpurchase.Charge{}, err
-		}
-
-		charge.Realizations.CreditGrantRealization = &grantRealization
-
-		if ledgerTransactionGroupReference.TransactionGroupID != "" {
-			if err := s.lineage.BackfillAdvanceLineageSegments(ctx, lineage.BackfillAdvanceLineageSegmentsInput{
-				Namespace:                 charge.Namespace,
-				CustomerID:                charge.Intent.CustomerID,
-				Currency:                  charge.Intent.Currency,
-				Amount:                    charge.Intent.CreditAmount,
-				BackingTransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
-				FeatureFilters:            charge.Intent.FeatureFilters.Normalize(),
-			}); err != nil {
-				return creditpurchase.Charge{}, err
-			}
-		}
-
-		charge.Status = creditpurchase.StatusActive
-
-		updatedBase, err := s.adapter.UpdateCharge(ctx, charge.ChargeBase)
-		if err != nil {
-			return creditpurchase.Charge{}, err
-		}
-
-		charge.ChargeBase = updatedBase
-
-		return charge, nil
-	})
+	trigger, err := externalInitialPaymentTrigger(externalCreditPurchaseSettlement.InitialStatus)
 	if err != nil {
 		return creditpurchase.Charge{}, err
 	}
 
-	// Let's handle the payment authorized state transition if requested
-	if targetStatus.In(
-		creditpurchase.AuthorizedInitialPaymentSettlementStatus,
-		creditpurchase.SettledInitialPaymentSettlementStatus,
-	) {
-		charge, err = s.HandleExternalPaymentAuthorized(ctx, charge)
-		if err != nil {
-			return creditpurchase.Charge{}, err
-		}
+	stateMachine, err := s.newExternalCreditPurchaseStateMachine(charge)
+	if err != nil {
+		return creditpurchase.Charge{}, fmt.Errorf("new external state machine: %w", err)
 	}
 
-	// Let's handle the payment settled state transition if requested
-	if targetStatus == creditpurchase.SettledInitialPaymentSettlementStatus {
-		charge, err = s.HandleExternalPaymentSettled(ctx, charge)
-		if err != nil {
-			return creditpurchase.Charge{}, err
-		}
+	advancedCharge, err := stateMachine.AdvanceUntilStateStable(ctx)
+	if err != nil {
+		return creditpurchase.Charge{}, fmt.Errorf("advance external state machine: %w", err)
+	}
+
+	charge = lo.FromPtrOr(advancedCharge, charge)
+
+	if trigger == "" {
+		return charge, nil
+	}
+
+	charge, err = stateMachine.handleExternalPaymentLifecycleTrigger(ctx, trigger)
+	if err != nil {
+		return creditpurchase.Charge{}, fmt.Errorf("fire external payment trigger %s: %w", trigger, err)
 	}
 
 	return charge, nil
 }
 
-func (s *service) HandleExternalPaymentAuthorized(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
-	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (creditpurchase.Charge, error) {
-		if charge.Realizations.ExternalPaymentSettlement != nil {
-			return creditpurchase.Charge{}, payment.ErrPaymentAlreadyAuthorized.
-				WithAttrs(charge.ErrorAttributes()).
-				WithAttrs(charge.Realizations.ExternalPaymentSettlement.ErrorAttributes())
+func externalInitialPaymentTrigger(status creditpurchase.InitialPaymentSettlementStatus) (meta.Trigger, error) {
+	switch status {
+	case creditpurchase.CreatedInitialPaymentSettlementStatus:
+		return "", nil
+	case creditpurchase.AuthorizedInitialPaymentSettlementStatus:
+		return billing.TriggerAuthorized, nil
+	case creditpurchase.SettledInitialPaymentSettlementStatus:
+		return billing.TriggerPaid, nil
+	default:
+		return "", fmt.Errorf("invalid initial payment settlement status: %s", status)
+	}
+}
+
+type ExternalCreditPurchaseStateMachine struct {
+	*stateMachine
+}
+
+func NewExternalCreditPurchaseStateMachine(config StateMachineConfig) (*ExternalCreditPurchaseStateMachine, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("validate: %w", err)
+	}
+
+	if config.Realizations == nil {
+		return nil, fmt.Errorf("realizations service is required")
+	}
+
+	if config.Charge.Intent.Settlement.Type() != creditpurchase.SettlementTypeExternal {
+		return nil, fmt.Errorf("charge %s is not external", config.Charge.ID)
+	}
+
+	stateMachine, err := newStateMachineBase(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create external credit purchase state machine: %w", err)
+	}
+
+	out := &ExternalCreditPurchaseStateMachine{
+		stateMachine: stateMachine,
+	}
+	out.configureStates()
+
+	return out, nil
+}
+
+func (s *ExternalCreditPurchaseStateMachine) configureStates() {
+	s.Configure(creditpurchase.StatusCreated).
+		Permit(meta.TriggerNext, creditpurchase.StatusActivePaymentPending)
+
+	s.Configure(creditpurchase.StatusActive).
+		Permit(meta.TriggerNext, creditpurchase.StatusActivePaymentPending)
+
+	s.Configure(creditpurchase.StatusActiveInitialCreditGrant).
+		Permit(meta.TriggerNext, creditpurchase.StatusActivePaymentPending).
+		OnActive(s.InitiateExternalCreditPurchaseFromCreated)
+
+	s.Configure(creditpurchase.StatusActivePaymentPending).
+		Permit(billing.TriggerAuthorized, creditpurchase.StatusActivePaymentAuthorized).
+		Permit(billing.TriggerPaid, creditpurchase.StatusActivePaymentPaidAndAuthorized)
+
+	s.Configure(creditpurchase.StatusActivePaymentAuthorized).
+		OnActive(s.AuthorizeExternalPayment).
+		Permit(billing.TriggerPaid, creditpurchase.StatusActivePaymentSettled)
+
+	s.Configure(creditpurchase.StatusActivePaymentPaidAndAuthorized).
+		Permit(billing.TriggerNext, creditpurchase.StatusActivePaymentSettled).
+		OnActive(s.AuthorizeExternalPayment)
+
+	s.Configure(creditpurchase.StatusActivePaymentSettled).
+		Permit(billing.TriggerNext, creditpurchase.StatusFinal).
+		OnActive(s.SettleExternalPayment)
+
+	s.Configure(creditpurchase.StatusFinal)
+}
+
+func (s *ExternalCreditPurchaseStateMachine) AdvanceUntilStateStable(ctx context.Context) (*creditpurchase.Charge, error) {
+	hadGrant := hasExternalCreditGrant(s.Charge)
+
+	advancedCharge, err := s.stateMachine.Machine.AdvanceUntilStateStable(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	switch s.Charge.Status {
+	case creditpurchase.StatusActivePaymentPending, creditpurchase.StatusActivePaymentAuthorized:
+		if err := s.EnsureExternalCreditPurchaseInitiated(ctx); err != nil {
+			return nil, err
 		}
+	}
 
-		eventAt := clock.Now()
-		ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentAuthorized(ctx, creditpurchase.PaymentEventInput{
-			Charge:  charge,
-			EventAt: eventAt,
-		})
-		if err != nil {
-			return creditpurchase.Charge{}, err
-		}
+	if advancedCharge != nil || (!hadGrant && hasExternalCreditGrant(s.Charge)) {
+		charge := s.GetCharge()
+		return &charge, nil
+	}
 
-		newPaymentSettlement := payment.ExternalCreateInput{
-			Namespace: charge.Namespace,
-			Base: payment.Base{
-				ServicePeriod: charge.Intent.ServicePeriod,
-				Amount:        charge.Intent.CreditAmount,
-				Authorized: &ledgertransaction.TimedGroupReference{
-					GroupReference: ledgerTransactionGroupReference,
-					Time:           eventAt,
-				},
-				Status: payment.StatusAuthorized,
-			},
-		}
+	return nil, nil
+}
 
-		paymentSettlement, err := s.adapter.CreateExternalPayment(ctx, charge.GetChargeID(), newPaymentSettlement)
-		if err != nil {
-			return creditpurchase.Charge{}, err
-		}
+func (s *ExternalCreditPurchaseStateMachine) InitiateExternalCreditPurchaseFromCreated(ctx context.Context) error {
+	return s.applyRealizationUpdate(ctx, s.Realizations.InitiateExternalCreditPurchase)
+}
 
-		charge.Realizations.ExternalPaymentSettlement = &paymentSettlement
+func (s *ExternalCreditPurchaseStateMachine) EnsureExternalCreditPurchaseInitiated(ctx context.Context) error {
+	if hasExternalCreditGrant(s.Charge) {
+		return nil
+	}
 
-		return charge, nil
+	return s.InitiateExternalCreditPurchaseFromCreated(ctx)
+}
+
+func (s *ExternalCreditPurchaseStateMachine) AuthorizeExternalPayment(ctx context.Context) error {
+	return s.applyRealizationUpdate(ctx, s.Realizations.AuthorizeExternalPayment)
+}
+
+func (s *ExternalCreditPurchaseStateMachine) SettleExternalPayment(ctx context.Context) error {
+	return s.applyRealizationUpdate(ctx, s.Realizations.SettleExternalPayment)
+}
+
+// applyRealizationUpdate records realization-side effects while preserving the
+// state-machine-owned base from the current transition.
+func (s *ExternalCreditPurchaseStateMachine) applyRealizationUpdate(
+	ctx context.Context,
+	update func(context.Context, creditpurchase.Charge) (creditpurchase.Charge, error),
+) error {
+	updatedCharge, err := update(ctx, s.Charge)
+	if err != nil {
+		return err
+	}
+
+	s.Charge = updatedCharge.WithBase(s.Charge.ChargeBase)
+	return nil
+}
+
+func (s *service) newExternalCreditPurchaseStateMachine(charge creditpurchase.Charge) (*ExternalCreditPurchaseStateMachine, error) {
+	return NewExternalCreditPurchaseStateMachine(StateMachineConfig{
+		Charge:       charge,
+		Adapter:      s.adapter,
+		Realizations: s.realizations,
 	})
 }
 
+func (s *ExternalCreditPurchaseStateMachine) handleExternalPaymentLifecycleTrigger(ctx context.Context, trigger meta.Trigger) (creditpurchase.Charge, error) {
+	if _, err := s.AdvanceUntilStateStable(ctx); err != nil {
+		return creditpurchase.Charge{}, fmt.Errorf("advance external state machine: %w", err)
+	}
+
+	if trigger == billing.TriggerPaid {
+		return s.handleSettledExternalPayment(ctx)
+	}
+
+	return s.FireAndAdvanceUntilStateStable(ctx, trigger)
+}
+
+func hasExternalCreditGrant(charge creditpurchase.Charge) bool {
+	return charge.Realizations.CreditGrantRealization != nil &&
+		charge.Realizations.CreditGrantRealization.TransactionGroupID != ""
+}
+
+// handleSettledExternalPayment handles provider flows that may report paid
+// without a separate authorization event, preserving authorization before settlement.
+func (s *ExternalCreditPurchaseStateMachine) handleSettledExternalPayment(ctx context.Context) (creditpurchase.Charge, error) {
+	if s.Charge.Status == creditpurchase.StatusActivePaymentPending {
+		if _, err := s.FireAndAdvanceUntilStateStable(ctx, billing.TriggerAuthorized); err != nil {
+			return creditpurchase.Charge{}, err
+		}
+	}
+
+	if s.Charge.Status != creditpurchase.StatusActivePaymentAuthorized {
+		return creditpurchase.Charge{}, fmt.Errorf(
+			"%w: %s [status=%s,id=%s]",
+			chargestatemachine.ErrUnsupportedOperation,
+			billing.TriggerPaid,
+			s.Charge.Status,
+			s.Charge.GetChargeID().ID,
+		)
+	}
+
+	if err := s.SettleExternalPayment(ctx); err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	s.Charge = s.Charge.WithStatus(creditpurchase.StatusFinal)
+	updatedBase, err := s.Adapter.UpdateCharge(ctx, s.Charge.GetBase())
+	if err != nil {
+		return creditpurchase.Charge{}, fmt.Errorf("persist charge: %w", err)
+	}
+
+	s.Charge = s.Charge.WithBase(updatedBase)
+
+	return s.GetCharge(), nil
+}
+
+func (s *service) HandleExternalPaymentAuthorized(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
+	return s.handleExternalPaymentTrigger(ctx, charge, billing.TriggerAuthorized)
+}
+
 func (s *service) HandleExternalPaymentSettled(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
+	return s.handleExternalPaymentTrigger(ctx, charge, billing.TriggerPaid)
+}
+
+func (s *service) handleExternalPaymentTrigger(ctx context.Context, charge creditpurchase.Charge, trigger meta.Trigger) (creditpurchase.Charge, error) {
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (creditpurchase.Charge, error) {
-		if charge.Realizations.ExternalPaymentSettlement == nil {
-			return creditpurchase.Charge{}, payment.ErrCannotSettleNotAuthorizedPayment.
-				WithAttrs(charge.ErrorAttributes())
-		}
-
-		paymentSettlement := *charge.Realizations.ExternalPaymentSettlement
-
-		if paymentSettlement.Status != payment.StatusAuthorized {
-			return creditpurchase.Charge{}, payment.ErrPaymentAlreadySettled.
-				WithAttrs(charge.ErrorAttributes()).
-				WithAttrs(paymentSettlement.ErrorAttributes())
-		}
-
-		eventAt := clock.Now()
-		ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentSettled(ctx, creditpurchase.PaymentEventInput{
-			Charge:  charge,
-			EventAt: eventAt,
-		})
+		stateMachine, err := s.newExternalCreditPurchaseStateMachine(charge)
 		if err != nil {
 			return creditpurchase.Charge{}, err
 		}
 
-		paymentSettlement.Settled = &ledgertransaction.TimedGroupReference{
-			GroupReference: ledgerTransactionGroupReference,
-			Time:           eventAt,
-		}
-
-		paymentSettlement.Status = payment.StatusSettled
-
-		paymentSettlement, err = s.adapter.UpdateExternalPayment(ctx, paymentSettlement)
-		if err != nil {
-			return creditpurchase.Charge{}, err
-		}
-
-		charge.Realizations.ExternalPaymentSettlement = &paymentSettlement
-
-		// Let's update the charge status to final
-		charge.Status = creditpurchase.StatusFinal
-
-		updatedBase, err := s.adapter.UpdateCharge(ctx, charge.ChargeBase)
-		if err != nil {
-			return creditpurchase.Charge{}, err
-		}
-
-		charge.ChargeBase = updatedBase
-
-		return charge, nil
+		return stateMachine.handleExternalPaymentLifecycleTrigger(ctx, trigger)
 	})
 }

--- a/openmeter/billing/charges/creditpurchase/service/external.go
+++ b/openmeter/billing/charges/creditpurchase/service/external.go
@@ -95,7 +95,7 @@ func (s *ExternalCreditPurchaseStateMachine) configureStates() {
 		Permit(meta.TriggerNext, creditpurchase.StatusActiveInitialCreditGrant)
 
 	s.Configure(creditpurchase.StatusActive).
-		Permit(meta.TriggerNext, creditpurchase.StatusActivePaymentPending)
+		Permit(meta.TriggerNext, creditpurchase.StatusActiveInitialCreditGrant)
 
 	s.Configure(creditpurchase.StatusActiveInitialCreditGrant).
 		Permit(meta.TriggerNext, creditpurchase.StatusActivePaymentPending).

--- a/openmeter/billing/charges/creditpurchase/service/external.go
+++ b/openmeter/billing/charges/creditpurchase/service/external.go
@@ -92,14 +92,14 @@ func NewExternalCreditPurchaseStateMachine(config StateMachineConfig) (*External
 
 func (s *ExternalCreditPurchaseStateMachine) configureStates() {
 	s.Configure(creditpurchase.StatusCreated).
-		Permit(meta.TriggerNext, creditpurchase.StatusActivePaymentPending)
+		Permit(meta.TriggerNext, creditpurchase.StatusActiveInitialCreditGrant)
 
 	s.Configure(creditpurchase.StatusActive).
 		Permit(meta.TriggerNext, creditpurchase.StatusActivePaymentPending)
 
 	s.Configure(creditpurchase.StatusActiveInitialCreditGrant).
 		Permit(meta.TriggerNext, creditpurchase.StatusActivePaymentPending).
-		OnActive(s.InitiateExternalCreditPurchaseFromCreated)
+		OnActive(s.GrantCredits)
 
 	s.Configure(creditpurchase.StatusActivePaymentPending).
 		Permit(billing.TriggerAuthorized, creditpurchase.StatusActivePaymentAuthorized).
@@ -120,28 +120,14 @@ func (s *ExternalCreditPurchaseStateMachine) configureStates() {
 	s.Configure(creditpurchase.StatusFinal)
 }
 
-func (s *ExternalCreditPurchaseStateMachine) AdvanceUntilStateStable(ctx context.Context) (*creditpurchase.Charge, error) {
-	if s.Charge.Status == creditpurchase.StatusActiveInitialCreditGrant {
-		if err := s.EnsureExternalCreditPurchaseInitiated(ctx); err != nil {
-			return nil, err
-		}
-	}
-
-	return s.stateMachine.Machine.AdvanceUntilStateStable(ctx)
-}
-
-func (s *ExternalCreditPurchaseStateMachine) InitiateExternalCreditPurchaseFromCreated(ctx context.Context) error {
-	updatedCharge, err := s.Realizations.InitiateExternalCreditPurchase(ctx, s.Charge)
+func (s *ExternalCreditPurchaseStateMachine) GrantCredits(ctx context.Context) error {
+	updatedCharge, err := s.Realizations.GrantCredits(ctx, s.Charge)
 	if err != nil {
 		return err
 	}
 
 	s.Charge = updatedCharge
 	return nil
-}
-
-func (s *ExternalCreditPurchaseStateMachine) EnsureExternalCreditPurchaseInitiated(ctx context.Context) error {
-	return s.InitiateExternalCreditPurchaseFromCreated(ctx)
 }
 
 func (s *ExternalCreditPurchaseStateMachine) AuthorizeExternalPayment(ctx context.Context) error {

--- a/openmeter/billing/charges/creditpurchase/service/external_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/external_test.go
@@ -22,35 +22,107 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func TestExternalCreditPurchaseStateMachineAdvancesCreatedChargeToPaymentPending(t *testing.T) {
+func TestExternalCreditPurchaseStateMachineAdvancesToPaymentPending(t *testing.T) {
+	for _, status := range []creditpurchase.Status{
+		creditpurchase.StatusCreated,
+		creditpurchase.StatusActive,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			// given:
+			// - an external credit-purchase charge in an initial lifecycle status
+			// when:
+			// - the external state machine advances until stable
+			// then:
+			// - it advances to and persists the payment-pending status; the credit grant is not
+			//   initiated by the lifecycle advance
+			fixture := newExternalStateMachineTestMachine(
+				t,
+				status,
+				alpacadecimal.NewFromFloat(0.5),
+			)
+
+			advancedCharge, err := fixture.stateMachine.AdvanceUntilStateStable(t.Context())
+
+			require.NoError(t, err)
+			require.NotNil(t, advancedCharge)
+			require.Equal(t, creditpurchase.StatusActivePaymentPending, advancedCharge.Status)
+			require.Equal(t, []creditpurchase.Status{
+				creditpurchase.StatusActivePaymentPending,
+			}, fixture.adapter.updatedBaseStatuses)
+			require.Nil(t, advancedCharge.Realizations.CreditGrantRealization)
+			require.Nil(t, advancedCharge.Realizations.ExternalPaymentSettlement)
+			require.Equal(t, 0, fixture.adapter.createCreditGrantCalls)
+			require.Equal(t, 1, fixture.adapter.updateChargeCalls)
+			fixture.handler.AssertExpectations(t)
+			fixture.lineageService.AssertExpectations(t)
+		})
+	}
+}
+
+func TestExternalCreditPurchaseStateMachineInitialCreditGrantAdvancesToPaymentPending(t *testing.T) {
 	// given:
-	// - a created external credit-purchase charge
+	// - an external credit-purchase charge already parked in the initial credit grant state
 	// when:
 	// - the external state machine advances until stable
 	// then:
-	// - it grants credits, backfills lineage, and persists the payment-pending status
-	fixture := newExternalStateMachineTestMachine(
-		t,
-		creditpurchase.StatusCreated,
-		alpacadecimal.NewFromFloat(0.5),
-	)
+	// - it initiates the grant exactly once, then persists payment-pending
+	charge := newExternalStateMachineTestChargeWithInput(externalStateMachineTestChargeInput{
+		status:         creditpurchase.StatusActiveInitialCreditGrant,
+		costBasis:      alpacadecimal.NewFromFloat(0.5),
+		creditAmount:   alpacadecimal.NewFromFloat(100),
+		initialStatus:  creditpurchase.CreatedInitialPaymentSettlementStatus,
+		featureFilters: creditpurchase.FeatureFilters{"storage", "api-calls", "storage"},
+	})
+	adapter := &externalStateMachineAdapter{}
+	lineageService := &externalStateMachineLineage{}
+	handler := &externalStateMachineHandler{}
+	handler.On("OnCreditPurchaseInitiated", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			charge := args.Get(1).(creditpurchase.Charge)
+			require.Equal(t, creditpurchase.StatusActiveInitialCreditGrant, charge.Status)
+			require.Nil(t, charge.Realizations.CreditGrantRealization)
+			require.Nil(t, charge.Realizations.ExternalPaymentSettlement)
+		}).
+		Return(ledgertransaction.GroupReference{TransactionGroupID: "initiated-ledger-tx"}, nil).
+		Once()
+	lineageService.On("BackfillAdvanceLineageSegments",
+		mock.Anything,
+		mock.MatchedBy(func(input lineage.BackfillAdvanceLineageSegmentsInput) bool {
+			return input.Namespace == charge.Namespace &&
+				input.CustomerID == charge.Intent.CustomerID &&
+				input.Currency == charge.Intent.Currency &&
+				input.Amount.Equal(charge.Intent.CreditAmount) &&
+				input.BackingTransactionGroupID == "initiated-ledger-tx" &&
+				len(input.FeatureFilters) == 2 &&
+				input.FeatureFilters[0] == "api-calls" &&
+				input.FeatureFilters[1] == "storage"
+		})).
+		Return(nil).
+		Once()
+	realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
 
-	advancedCharge, err := fixture.stateMachine.AdvanceUntilStateStable(t.Context())
+	stateMachine, err := NewExternalCreditPurchaseStateMachine(StateMachineConfig{
+		Charge:       charge,
+		Adapter:      adapter,
+		Realizations: realizationsService,
+	})
+	require.NoError(t, err)
+
+	advancedCharge, err := stateMachine.AdvanceUntilStateStable(t.Context())
 
 	require.NoError(t, err)
 	require.NotNil(t, advancedCharge)
 	require.Equal(t, creditpurchase.StatusActivePaymentPending, advancedCharge.Status)
-	require.Equal(t, creditpurchase.StatusActivePaymentPending, fixture.adapter.updatedBase.Status)
 	require.NotNil(t, advancedCharge.Realizations.CreditGrantRealization)
 	require.Equal(t, "initiated-ledger-tx", advancedCharge.Realizations.CreditGrantRealization.TransactionGroupID)
 	require.Nil(t, advancedCharge.Realizations.ExternalPaymentSettlement)
-	require.Equal(t, 1, fixture.adapter.createCreditGrantCalls)
-	require.Equal(t, fixture.charge.GetChargeID(), fixture.adapter.createdGrantChargeID)
-	require.Equal(t, "initiated-ledger-tx", fixture.adapter.createdGrantInput.TransactionGroupID)
-	require.False(t, fixture.adapter.createdGrantInput.GrantedAt.IsZero())
-	require.Equal(t, 1, fixture.adapter.updateChargeCalls)
-	fixture.handler.AssertExpectations(t)
-	fixture.lineageService.AssertExpectations(t)
+	require.Equal(t, 1, adapter.createCreditGrantCalls)
+	require.Equal(t, 1, adapter.updateChargeCalls)
+	require.Equal(t, []creditpurchase.Status{
+		creditpurchase.StatusActivePaymentPending,
+	}, adapter.updatedBaseStatuses)
+	handler.AssertExpectations(t)
+	lineageService.AssertExpectations(t)
 }
 
 func TestExternalCreditPurchaseStateMachineUsesRoundedCreditAmount(t *testing.T) {
@@ -120,61 +192,67 @@ func TestExternalCreditPurchaseStateMachineUsesRoundedCreditAmount(t *testing.T)
 
 func TestExternalCreditPurchaseServiceRoutesInitialStatuses(t *testing.T) {
 	for _, tc := range []struct {
-		name                    string
-		initialStatus           creditpurchase.InitialPaymentSettlementStatus
-		wantStatus              creditpurchase.Status
-		wantPaymentStatus       *payment.Status
-		wantAuthorizedCalls     int
-		wantAuthorizedStatus    creditpurchase.Status
-		wantSettledCalls        int
-		wantSettledStatus       creditpurchase.Status
-		wantCreatePaymentCalls  int
-		wantUpdatePaymentCalls  int
-		wantUpdateChargeCalls   int
-		wantUpdatedChargeStatus creditpurchase.Status
+		name                     string
+		initialStatus            creditpurchase.InitialPaymentSettlementStatus
+		wantStatus               creditpurchase.Status
+		wantPaymentStatus        *payment.Status
+		wantAuthorizedCalls      int
+		wantAuthorizedStatus     creditpurchase.Status
+		wantSettledCalls         int
+		wantSettledStatus        creditpurchase.Status
+		wantCreatePaymentCalls   int
+		wantUpdatePaymentCalls   int
+		wantUpdateChargeStatuses []creditpurchase.Status
 	}{
 		{
-			name:                    "created",
-			initialStatus:           creditpurchase.CreatedInitialPaymentSettlementStatus,
-			wantStatus:              creditpurchase.StatusActivePaymentPending,
-			wantUpdateChargeCalls:   1,
-			wantUpdatedChargeStatus: creditpurchase.StatusActivePaymentPending,
+			name:          "created",
+			initialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
+			wantStatus:    creditpurchase.StatusActivePaymentPending,
+			wantUpdateChargeStatuses: []creditpurchase.Status{
+				creditpurchase.StatusActivePaymentPending,
+			},
 		},
 		{
-			name:                    "authorized",
-			initialStatus:           creditpurchase.AuthorizedInitialPaymentSettlementStatus,
-			wantStatus:              creditpurchase.StatusActivePaymentAuthorized,
-			wantPaymentStatus:       lo.ToPtr(payment.StatusAuthorized),
-			wantAuthorizedCalls:     1,
-			wantAuthorizedStatus:    creditpurchase.StatusActivePaymentAuthorized,
-			wantCreatePaymentCalls:  1,
-			wantUpdateChargeCalls:   2,
-			wantUpdatedChargeStatus: creditpurchase.StatusActivePaymentAuthorized,
+			name:                   "authorized",
+			initialStatus:          creditpurchase.AuthorizedInitialPaymentSettlementStatus,
+			wantStatus:             creditpurchase.StatusActivePaymentAuthorized,
+			wantPaymentStatus:      lo.ToPtr(payment.StatusAuthorized),
+			wantAuthorizedCalls:    1,
+			wantAuthorizedStatus:   creditpurchase.StatusActivePaymentAuthorized,
+			wantCreatePaymentCalls: 1,
+			wantUpdateChargeStatuses: []creditpurchase.Status{
+				creditpurchase.StatusActivePaymentPending,
+				creditpurchase.StatusActivePaymentAuthorized,
+			},
 		},
 		{
-			name:                    "settled",
-			initialStatus:           creditpurchase.SettledInitialPaymentSettlementStatus,
-			wantStatus:              creditpurchase.StatusFinal,
-			wantPaymentStatus:       lo.ToPtr(payment.StatusSettled),
-			wantAuthorizedCalls:     1,
-			wantAuthorizedStatus:    creditpurchase.StatusActivePaymentAuthorized,
-			wantSettledCalls:        1,
-			wantSettledStatus:       creditpurchase.StatusActivePaymentAuthorized,
-			wantCreatePaymentCalls:  1,
-			wantUpdatePaymentCalls:  1,
-			wantUpdateChargeCalls:   3,
-			wantUpdatedChargeStatus: creditpurchase.StatusFinal,
+			name:                   "settled",
+			initialStatus:          creditpurchase.SettledInitialPaymentSettlementStatus,
+			wantStatus:             creditpurchase.StatusFinal,
+			wantPaymentStatus:      lo.ToPtr(payment.StatusSettled),
+			wantAuthorizedCalls:    1,
+			wantAuthorizedStatus:   creditpurchase.StatusActivePaymentPaidAndAuthorized,
+			wantSettledCalls:       1,
+			wantSettledStatus:      creditpurchase.StatusActivePaymentSettled,
+			wantCreatePaymentCalls: 1,
+			wantUpdatePaymentCalls: 1,
+			wantUpdateChargeStatuses: []creditpurchase.Status{
+				creditpurchase.StatusActivePaymentPending,
+				creditpurchase.StatusActivePaymentPaidAndAuthorized,
+				creditpurchase.StatusActivePaymentSettled,
+				creditpurchase.StatusFinal,
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// given:
-			// - a created external credit-purchase charge with a provider initial status
+			// - an external credit-purchase charge parked in the initial credit grant state
 			// when:
 			// - the credit-purchase service starts the external lifecycle
 			// then:
-			// - it routes the initial status through the expected state-machine transitions
+			// - it grants credits first, then routes the initial payment status through the expected transitions
 			charge := newExternalStateMachineTestChargeWithInput(externalStateMachineTestChargeInput{
-				status:        creditpurchase.StatusCreated,
+				status:        creditpurchase.StatusActiveInitialCreditGrant,
 				costBasis:     alpacadecimal.NewFromFloat(0.5),
 				creditAmount:  alpacadecimal.NewFromFloat(100),
 				initialStatus: tc.initialStatus,
@@ -187,11 +265,23 @@ func TestExternalCreditPurchaseServiceRoutesInitialStatuses(t *testing.T) {
 			handler.On("OnCreditPurchaseInitiated", mock.Anything, mock.Anything).
 				Run(func(args mock.Arguments) {
 					charge := args.Get(1).(creditpurchase.Charge)
-					require.Equal(t, creditpurchase.StatusActivePaymentPending, charge.Status)
+					require.Equal(t, creditpurchase.StatusActiveInitialCreditGrant, charge.Status)
 					require.Nil(t, charge.Realizations.CreditGrantRealization)
 					require.Nil(t, charge.Realizations.ExternalPaymentSettlement)
 				}).
 				Return(ledgertransaction.GroupReference{TransactionGroupID: "initiated-ledger-tx"}, nil).
+				Once()
+			lineageService.On("BackfillAdvanceLineageSegments",
+				mock.Anything,
+				mock.MatchedBy(func(input lineage.BackfillAdvanceLineageSegmentsInput) bool {
+					return input.Namespace == charge.Namespace &&
+						input.CustomerID == charge.Intent.CustomerID &&
+						input.Currency == charge.Intent.Currency &&
+						input.Amount.Equal(charge.Intent.CreditAmount) &&
+						input.BackingTransactionGroupID == "initiated-ledger-tx" &&
+						len(input.FeatureFilters) == 0
+				})).
+				Return(nil).
 				Once()
 			if tc.wantAuthorizedCalls > 0 {
 				handler.On("OnCreditPurchasePaymentAuthorized", mock.Anything, mock.Anything).
@@ -222,18 +312,6 @@ func TestExternalCreditPurchaseServiceRoutesInitialStatuses(t *testing.T) {
 				realizations: realizationsService,
 			}
 
-			lineageService.On("BackfillAdvanceLineageSegments",
-				mock.Anything,
-				mock.MatchedBy(func(input lineage.BackfillAdvanceLineageSegmentsInput) bool {
-					return input.Namespace == charge.Namespace &&
-						input.CustomerID == charge.Intent.CustomerID &&
-						input.Currency == charge.Intent.Currency &&
-						input.Amount.Equal(charge.Intent.CreditAmount) &&
-						input.BackingTransactionGroupID == "initiated-ledger-tx"
-				})).
-				Return(nil).
-				Once()
-
 			got, err := svc.onExternalCreditPurchase(t.Context(), charge)
 
 			require.NoError(t, err)
@@ -246,10 +324,12 @@ func TestExternalCreditPurchaseServiceRoutesInitialStatuses(t *testing.T) {
 				require.NotNil(t, got.Realizations.ExternalPaymentSettlement)
 				require.Equal(t, *tc.wantPaymentStatus, got.Realizations.ExternalPaymentSettlement.Status)
 			}
+			require.Equal(t, 1, adapter.createCreditGrantCalls)
 			require.Equal(t, tc.wantCreatePaymentCalls, adapter.createExternalPaymentCalls)
 			require.Equal(t, tc.wantUpdatePaymentCalls, adapter.updateExternalPaymentCalls)
-			require.Equal(t, tc.wantUpdateChargeCalls, adapter.updateChargeCalls)
-			require.Equal(t, tc.wantUpdatedChargeStatus, adapter.updatedBase.Status)
+			require.Equal(t, len(tc.wantUpdateChargeStatuses), adapter.updateChargeCalls)
+			require.Equal(t, tc.wantUpdateChargeStatuses, adapter.updatedBaseStatuses)
+			require.Equal(t, tc.wantStatus, adapter.updatedBase.Status)
 			handler.AssertExpectations(t)
 			lineageService.AssertExpectations(t)
 		})
@@ -325,7 +405,7 @@ func TestExternalCreditPurchaseStateMachineAuthorizesAndSettlesPayment(t *testin
 	handler.On("OnCreditPurchasePaymentSettled", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			input := args.Get(1).(creditpurchase.PaymentEventInput)
-			require.Equal(t, creditpurchase.StatusActivePaymentAuthorized, input.Charge.Status)
+			require.Equal(t, creditpurchase.StatusActivePaymentSettled, input.Charge.Status)
 			require.NotNil(t, input.Charge.Realizations.ExternalPaymentSettlement)
 			require.Equal(t, payment.StatusAuthorized, input.Charge.Realizations.ExternalPaymentSettlement.Status)
 			require.Equal(t, "authorized-ledger-tx", input.Charge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
@@ -362,7 +442,12 @@ func TestExternalCreditPurchaseStateMachineAuthorizesAndSettlesPayment(t *testin
 	require.Equal(t, "authorized-ledger-tx", settledCharge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
 	require.Equal(t, "settled-ledger-tx", settledCharge.Realizations.ExternalPaymentSettlement.Settled.TransactionGroupID)
 	require.Equal(t, 1, adapter.updateExternalPaymentCalls)
-	require.Equal(t, 2, adapter.updateChargeCalls)
+	require.Equal(t, 3, adapter.updateChargeCalls)
+	require.Equal(t, []creditpurchase.Status{
+		creditpurchase.StatusActivePaymentAuthorized,
+		creditpurchase.StatusActivePaymentSettled,
+		creditpurchase.StatusFinal,
+	}, adapter.updatedBaseStatuses)
 	handler.AssertExpectations(t)
 }
 
@@ -429,7 +514,7 @@ func TestExternalCreditPurchaseStateMachineAuthorizesAndSettlesInSingleTransitio
 	handler.On("OnCreditPurchasePaymentAuthorized", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			input := args.Get(1).(creditpurchase.PaymentEventInput)
-			require.Equal(t, creditpurchase.StatusActivePaymentAuthorized, input.Charge.Status)
+			require.Equal(t, creditpurchase.StatusActivePaymentPaidAndAuthorized, input.Charge.Status)
 			require.Nil(t, input.Charge.Realizations.ExternalPaymentSettlement)
 		}).
 		Return(ledgertransaction.GroupReference{TransactionGroupID: "authorized-ledger-tx"}, nil).
@@ -437,7 +522,7 @@ func TestExternalCreditPurchaseStateMachineAuthorizesAndSettlesInSingleTransitio
 	handler.On("OnCreditPurchasePaymentSettled", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			input := args.Get(1).(creditpurchase.PaymentEventInput)
-			require.Equal(t, creditpurchase.StatusActivePaymentAuthorized, input.Charge.Status)
+			require.Equal(t, creditpurchase.StatusActivePaymentSettled, input.Charge.Status)
 			require.NotNil(t, input.Charge.Realizations.ExternalPaymentSettlement)
 			require.Equal(t, payment.StatusAuthorized, input.Charge.Realizations.ExternalPaymentSettlement.Status)
 			require.Equal(t, "authorized-ledger-tx", input.Charge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
@@ -465,7 +550,12 @@ func TestExternalCreditPurchaseStateMachineAuthorizesAndSettlesInSingleTransitio
 	require.Equal(t, "settled-ledger-tx", settledCharge.Realizations.ExternalPaymentSettlement.Settled.TransactionGroupID)
 	require.Equal(t, 1, adapter.createExternalPaymentCalls)
 	require.Equal(t, 1, adapter.updateExternalPaymentCalls)
-	require.Equal(t, 2, adapter.updateChargeCalls)
+	require.Equal(t, 3, adapter.updateChargeCalls)
+	require.Equal(t, []creditpurchase.Status{
+		creditpurchase.StatusActivePaymentPaidAndAuthorized,
+		creditpurchase.StatusActivePaymentSettled,
+		creditpurchase.StatusFinal,
+	}, adapter.updatedBaseStatuses)
 	handler.AssertExpectations(t)
 }
 
@@ -498,29 +588,9 @@ func newExternalStateMachineTestMachine(
 	adapter := &externalStateMachineAdapter{}
 	lineageService := &externalStateMachineLineage{}
 	handler := &externalStateMachineHandler{}
-	handler.On("OnCreditPurchaseInitiated", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			charge := args.Get(1).(creditpurchase.Charge)
-			require.Equal(t, creditpurchase.StatusActivePaymentPending, charge.Status)
-			require.Nil(t, charge.Realizations.CreditGrantRealization)
-		}).
-		Return(ledgertransaction.GroupReference{
-			TransactionGroupID: "initiated-ledger-tx",
-		}, nil).
-		Once()
+	// The lifecycle advance does not initiate the credit grant, so no grant or
+	// lineage handler calls are expected here.
 	realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
-
-	lineageService.On("BackfillAdvanceLineageSegments",
-		mock.Anything,
-		mock.MatchedBy(func(input lineage.BackfillAdvanceLineageSegmentsInput) bool {
-			return input.Namespace == charge.Namespace &&
-				input.CustomerID == charge.Intent.CustomerID &&
-				input.Currency == charge.Intent.Currency &&
-				input.Amount.Equal(charge.Intent.CreditAmount) &&
-				input.BackingTransactionGroupID != ""
-		})).
-		Return(nil).
-		Once()
 
 	stateMachine, err := NewExternalCreditPurchaseStateMachine(StateMachineConfig{
 		Charge:       charge,
@@ -561,6 +631,8 @@ type externalStateMachineTestChargeInput struct {
 	costBasis     alpacadecimal.Decimal
 	creditAmount  alpacadecimal.Decimal
 	initialStatus creditpurchase.InitialPaymentSettlementStatus
+
+	featureFilters creditpurchase.FeatureFilters
 }
 
 func newExternalStateMachineTestCharge(status creditpurchase.Status, costBasis alpacadecimal.Decimal) creditpurchase.Charge {
@@ -587,7 +659,8 @@ func newExternalStateMachineTestChargeWithInput(input externalStateMachineTestCh
 			FullServicePeriod: period,
 			BillingPeriod:     period,
 		},
-		CreditAmount: input.creditAmount,
+		CreditAmount:   input.creditAmount,
+		FeatureFilters: input.featureFilters,
 		Settlement: creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{
 			GenericSettlement: creditpurchase.GenericSettlement{
 				Currency:  currencyx.Code("USD"),
@@ -618,8 +691,9 @@ func newExternalStateMachineTestChargeWithInput(input externalStateMachineTestCh
 type externalStateMachineAdapter struct {
 	creditpurchase.Adapter
 
-	updateChargeCalls int
-	updatedBase       creditpurchase.ChargeBase
+	updateChargeCalls   int
+	updatedBase         creditpurchase.ChargeBase
+	updatedBaseStatuses []creditpurchase.Status
 
 	createCreditGrantCalls int
 	createdGrantChargeID   meta.ChargeID
@@ -636,6 +710,7 @@ type externalStateMachineAdapter struct {
 func (a *externalStateMachineAdapter) UpdateCharge(ctx context.Context, charge creditpurchase.ChargeBase) (creditpurchase.ChargeBase, error) {
 	a.updateChargeCalls++
 	a.updatedBase = charge
+	a.updatedBaseStatuses = append(a.updatedBaseStatuses, charge.Status)
 	return charge, nil
 }
 

--- a/openmeter/billing/charges/creditpurchase/service/external_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/external_test.go
@@ -22,52 +22,44 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func TestExternalCreditPurchaseStateMachineAdvancesToPaymentPending(t *testing.T) {
-	for _, status := range []creditpurchase.Status{
-		creditpurchase.StatusCreated,
-		creditpurchase.StatusActive,
-	} {
-		t.Run(string(status), func(t *testing.T) {
-			// given:
-			// - an external credit-purchase charge in an initial lifecycle status
-			// when:
-			// - the external state machine advances until stable
-			// then:
-			// - it advances to and persists the payment-pending status; the credit grant is not
-			//   initiated by the lifecycle advance
-			fixture := newExternalStateMachineTestMachine(
-				t,
-				status,
-				alpacadecimal.NewFromFloat(0.5),
-			)
-
-			advancedCharge, err := fixture.stateMachine.AdvanceUntilStateStable(t.Context())
-
-			require.NoError(t, err)
-			require.NotNil(t, advancedCharge)
-			require.Equal(t, creditpurchase.StatusActivePaymentPending, advancedCharge.Status)
-			require.Equal(t, []creditpurchase.Status{
-				creditpurchase.StatusActivePaymentPending,
-			}, fixture.adapter.updatedBaseStatuses)
-			require.Nil(t, advancedCharge.Realizations.CreditGrantRealization)
-			require.Nil(t, advancedCharge.Realizations.ExternalPaymentSettlement)
-			require.Equal(t, 0, fixture.adapter.createCreditGrantCalls)
-			require.Equal(t, 1, fixture.adapter.updateChargeCalls)
-			fixture.handler.AssertExpectations(t)
-			fixture.lineageService.AssertExpectations(t)
-		})
-	}
-}
-
-func TestExternalCreditPurchaseStateMachineInitialCreditGrantAdvancesToPaymentPending(t *testing.T) {
+func TestExternalCreditPurchaseStateMachineActiveAdvancesToPaymentPending(t *testing.T) {
 	// given:
-	// - an external credit-purchase charge already parked in the initial credit grant state
+	// - an external credit-purchase charge in the legacy active lifecycle status
 	// when:
 	// - the external state machine advances until stable
 	// then:
-	// - it initiates the grant exactly once, then persists payment-pending
+	// - it advances to and persists the payment-pending status without granting credits
+	fixture := newExternalStateMachineTestMachine(
+		t,
+		creditpurchase.StatusActive,
+		alpacadecimal.NewFromFloat(0.5),
+	)
+
+	advancedCharge, err := fixture.stateMachine.AdvanceUntilStateStable(t.Context())
+
+	require.NoError(t, err)
+	require.NotNil(t, advancedCharge)
+	require.Equal(t, creditpurchase.StatusActivePaymentPending, advancedCharge.Status)
+	require.Equal(t, []creditpurchase.Status{
+		creditpurchase.StatusActivePaymentPending,
+	}, fixture.adapter.updatedBaseStatuses)
+	require.Nil(t, advancedCharge.Realizations.CreditGrantRealization)
+	require.Nil(t, advancedCharge.Realizations.ExternalPaymentSettlement)
+	require.Equal(t, 0, fixture.adapter.createCreditGrantCalls)
+	require.Equal(t, 1, fixture.adapter.updateChargeCalls)
+	fixture.handler.AssertExpectations(t)
+	fixture.lineageService.AssertExpectations(t)
+}
+
+func TestExternalCreditPurchaseStateMachineCreatedAdvancesThroughGrantToPaymentPending(t *testing.T) {
+	// given:
+	// - an external credit-purchase charge in the created status
+	// when:
+	// - the external state machine advances until stable
+	// then:
+	// - it enters the initial credit grant state, grants credits, then persists payment-pending
 	charge := newExternalStateMachineTestChargeWithInput(externalStateMachineTestChargeInput{
-		status:         creditpurchase.StatusActiveInitialCreditGrant,
+		status:         creditpurchase.StatusCreated,
 		costBasis:      alpacadecimal.NewFromFloat(0.5),
 		creditAmount:   alpacadecimal.NewFromFloat(100),
 		initialStatus:  creditpurchase.CreatedInitialPaymentSettlementStatus,
@@ -117,8 +109,9 @@ func TestExternalCreditPurchaseStateMachineInitialCreditGrantAdvancesToPaymentPe
 	require.Equal(t, "initiated-ledger-tx", advancedCharge.Realizations.CreditGrantRealization.TransactionGroupID)
 	require.Nil(t, advancedCharge.Realizations.ExternalPaymentSettlement)
 	require.Equal(t, 1, adapter.createCreditGrantCalls)
-	require.Equal(t, 1, adapter.updateChargeCalls)
+	require.Equal(t, 2, adapter.updateChargeCalls)
 	require.Equal(t, []creditpurchase.Status{
+		creditpurchase.StatusActiveInitialCreditGrant,
 		creditpurchase.StatusActivePaymentPending,
 	}, adapter.updatedBaseStatuses)
 	handler.AssertExpectations(t)
@@ -179,7 +172,7 @@ func TestExternalCreditPurchaseStateMachineUsesRoundedCreditAmount(t *testing.T)
 	})
 	require.NoError(t, err)
 
-	err = stateMachine.InitiateExternalCreditPurchaseFromCreated(t.Context())
+	err = stateMachine.GrantCredits(t.Context())
 	require.NoError(t, err)
 
 	err = stateMachine.FireAndActivate(t.Context(), billing.TriggerAuthorized)
@@ -209,6 +202,7 @@ func TestExternalCreditPurchaseServiceRoutesInitialStatuses(t *testing.T) {
 			initialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
 			wantStatus:    creditpurchase.StatusActivePaymentPending,
 			wantUpdateChargeStatuses: []creditpurchase.Status{
+				creditpurchase.StatusActiveInitialCreditGrant,
 				creditpurchase.StatusActivePaymentPending,
 			},
 		},
@@ -221,6 +215,7 @@ func TestExternalCreditPurchaseServiceRoutesInitialStatuses(t *testing.T) {
 			wantAuthorizedStatus:   creditpurchase.StatusActivePaymentAuthorized,
 			wantCreatePaymentCalls: 1,
 			wantUpdateChargeStatuses: []creditpurchase.Status{
+				creditpurchase.StatusActiveInitialCreditGrant,
 				creditpurchase.StatusActivePaymentPending,
 				creditpurchase.StatusActivePaymentAuthorized,
 			},
@@ -237,6 +232,7 @@ func TestExternalCreditPurchaseServiceRoutesInitialStatuses(t *testing.T) {
 			wantCreatePaymentCalls: 1,
 			wantUpdatePaymentCalls: 1,
 			wantUpdateChargeStatuses: []creditpurchase.Status{
+				creditpurchase.StatusActiveInitialCreditGrant,
 				creditpurchase.StatusActivePaymentPending,
 				creditpurchase.StatusActivePaymentPaidAndAuthorized,
 				creditpurchase.StatusActivePaymentSettled,
@@ -246,13 +242,13 @@ func TestExternalCreditPurchaseServiceRoutesInitialStatuses(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// given:
-			// - an external credit-purchase charge parked in the initial credit grant state
+			// - an external credit-purchase charge in the created state
 			// when:
 			// - the credit-purchase service starts the external lifecycle
 			// then:
 			// - it grants credits first, then routes the initial payment status through the expected transitions
 			charge := newExternalStateMachineTestChargeWithInput(externalStateMachineTestChargeInput{
-				status:        creditpurchase.StatusActiveInitialCreditGrant,
+				status:        creditpurchase.StatusCreated,
 				costBasis:     alpacadecimal.NewFromFloat(0.5),
 				creditAmount:  alpacadecimal.NewFromFloat(100),
 				initialStatus: tc.initialStatus,
@@ -336,28 +332,45 @@ func TestExternalCreditPurchaseServiceRoutesInitialStatuses(t *testing.T) {
 	}
 }
 
-func TestExternalCreditPurchaseStateMachineInitiationRejectsNonPositiveCostBasis(t *testing.T) {
+func TestExternalCreditPurchaseStateMachineGrantCreditsRejectsInvalidExternalSettlement(t *testing.T) {
 	for _, tc := range []struct {
-		name      string
-		costBasis alpacadecimal.Decimal
+		name          string
+		costBasis     alpacadecimal.Decimal
+		initialStatus creditpurchase.InitialPaymentSettlementStatus
+		wantErr       string
 	}{
 		{
-			name:      "zero",
-			costBasis: alpacadecimal.Zero,
+			name:          "zero cost basis",
+			costBasis:     alpacadecimal.Zero,
+			initialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
+			wantErr:       "cost basis must be positive",
 		},
 		{
-			name:      "negative",
-			costBasis: alpacadecimal.NewFromFloat(-0.5),
+			name:          "negative cost basis",
+			costBasis:     alpacadecimal.NewFromFloat(-0.5),
+			initialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
+			wantErr:       "cost basis must be positive",
+		},
+		{
+			name:          "invalid initial status",
+			costBasis:     alpacadecimal.NewFromFloat(0.5),
+			initialStatus: creditpurchase.InitialPaymentSettlementStatus("invalid"),
+			wantErr:       "initial status",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// given:
-			// - an external credit-purchase charge with non-positive cost basis
+			// - an external credit-purchase charge with invalid settlement input
 			// when:
-			// - the current initiation helper tries to create the credit grant realization
+			// - the grant-credit action tries to create the credit grant realization
 			// then:
 			// - it fails with a validation error before creating realizations
-			charge := newExternalStateMachineTestCharge(creditpurchase.StatusActivePaymentPending, tc.costBasis)
+			charge := newExternalStateMachineTestChargeWithInput(externalStateMachineTestChargeInput{
+				status:        creditpurchase.StatusActivePaymentPending,
+				costBasis:     tc.costBasis,
+				creditAmount:  alpacadecimal.NewFromFloat(100),
+				initialStatus: tc.initialStatus,
+			})
 			adapter := &externalStateMachineAdapter{}
 			handler := &externalStateMachineHandler{}
 			lineageService := &externalStateMachineLineage{}
@@ -370,10 +383,10 @@ func TestExternalCreditPurchaseStateMachineInitiationRejectsNonPositiveCostBasis
 			})
 			require.NoError(t, err)
 
-			err = stateMachine.InitiateExternalCreditPurchaseFromCreated(t.Context())
+			err = stateMachine.GrantCredits(t.Context())
 
 			require.Error(t, err)
-			require.ErrorContains(t, err, "cost basis must be positive")
+			require.ErrorContains(t, err, tc.wantErr)
 			require.True(t, models.IsGenericValidationError(err))
 			require.Zero(t, adapter.createCreditGrantCalls)
 			require.Zero(t, adapter.createExternalPaymentCalls)

--- a/openmeter/billing/charges/creditpurchase/service/external_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/external_test.go
@@ -1,0 +1,712 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	creditpurchaserealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service/realizations"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestExternalCreditPurchaseStateMachineAdvancesCreatedChargeToPaymentPending(t *testing.T) {
+	// given:
+	// - a created external credit-purchase charge
+	// when:
+	// - the external state machine advances until stable
+	// then:
+	// - it grants credits, backfills lineage, and persists the payment-pending status
+	fixture := newExternalStateMachineTestMachine(
+		t,
+		creditpurchase.StatusCreated,
+		alpacadecimal.NewFromFloat(0.5),
+	)
+
+	advancedCharge, err := fixture.stateMachine.AdvanceUntilStateStable(t.Context())
+
+	require.NoError(t, err)
+	require.NotNil(t, advancedCharge)
+	require.Equal(t, creditpurchase.StatusActivePaymentPending, advancedCharge.Status)
+	require.Equal(t, creditpurchase.StatusActivePaymentPending, fixture.adapter.updatedBase.Status)
+	require.NotNil(t, advancedCharge.Realizations.CreditGrantRealization)
+	require.Equal(t, "initiated-ledger-tx", advancedCharge.Realizations.CreditGrantRealization.TransactionGroupID)
+	require.Nil(t, advancedCharge.Realizations.ExternalPaymentSettlement)
+	require.Equal(t, 1, fixture.adapter.createCreditGrantCalls)
+	require.Equal(t, fixture.charge.GetChargeID(), fixture.adapter.createdGrantChargeID)
+	require.Equal(t, "initiated-ledger-tx", fixture.adapter.createdGrantInput.TransactionGroupID)
+	require.False(t, fixture.adapter.createdGrantInput.GrantedAt.IsZero())
+	require.Equal(t, 1, fixture.adapter.updateChargeCalls)
+	fixture.handler.AssertExpectations(t)
+	fixture.lineageService.AssertExpectations(t)
+}
+
+func TestExternalCreditPurchaseStateMachineUsesRoundedCreditAmount(t *testing.T) {
+	// given:
+	// - a payment-pending external credit-purchase charge with a sub-cent credit amount
+	// when:
+	// - the current external helpers grant credits and authorize payment
+	// then:
+	// - lineage and payment realization both use the currency-rounded credit amount
+	expectedAmount := alpacadecimal.NewFromFloat(100.12)
+	charge := newExternalStateMachineTestChargeWithInput(externalStateMachineTestChargeInput{
+		status:        creditpurchase.StatusActivePaymentPending,
+		costBasis:     alpacadecimal.NewFromFloat(0.5),
+		creditAmount:  alpacadecimal.NewFromFloat(100.123),
+		initialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
+	})
+
+	calc, err := charge.Intent.Currency.Calculator()
+	require.NoError(t, err)
+	require.True(t, calc.IsRoundedToPrecision(charge.Intent.CreditAmount))
+	require.Equal(t, 100.12, charge.Intent.CreditAmount.InexactFloat64())
+
+	adapter := &externalStateMachineAdapter{}
+	lineageService := &externalStateMachineLineage{}
+	handler := &externalStateMachineHandler{}
+	handler.On("OnCreditPurchaseInitiated", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			charge := args.Get(1).(creditpurchase.Charge)
+			require.Equal(t, expectedAmount.InexactFloat64(), charge.Intent.CreditAmount.InexactFloat64())
+		}).
+		Return(ledgertransaction.GroupReference{TransactionGroupID: "initiated-ledger-tx"}, nil).
+		Once()
+	handler.On("OnCreditPurchasePaymentAuthorized", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			input := args.Get(1).(creditpurchase.PaymentEventInput)
+			require.Equal(t, expectedAmount.InexactFloat64(), input.Charge.Intent.CreditAmount.InexactFloat64())
+		}).
+		Return(ledgertransaction.GroupReference{TransactionGroupID: "authorized-ledger-tx"}, nil).
+		Once()
+	realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
+
+	lineageService.On("BackfillAdvanceLineageSegments",
+		mock.Anything,
+		mock.MatchedBy(func(input lineage.BackfillAdvanceLineageSegmentsInput) bool {
+			return input.Amount.Equal(expectedAmount)
+		})).
+		Return(nil).
+		Once()
+
+	stateMachine, err := NewExternalCreditPurchaseStateMachine(StateMachineConfig{
+		Charge:       charge,
+		Adapter:      adapter,
+		Realizations: realizationsService,
+	})
+	require.NoError(t, err)
+
+	err = stateMachine.InitiateExternalCreditPurchaseFromCreated(t.Context())
+	require.NoError(t, err)
+
+	err = stateMachine.FireAndActivate(t.Context(), billing.TriggerAuthorized)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedAmount.InexactFloat64(), adapter.createdExternalPayment.Amount.InexactFloat64())
+	handler.AssertExpectations(t)
+	lineageService.AssertExpectations(t)
+}
+
+func TestExternalCreditPurchaseServiceRoutesInitialStatuses(t *testing.T) {
+	for _, tc := range []struct {
+		name                    string
+		initialStatus           creditpurchase.InitialPaymentSettlementStatus
+		wantStatus              creditpurchase.Status
+		wantPaymentStatus       *payment.Status
+		wantAuthorizedCalls     int
+		wantAuthorizedStatus    creditpurchase.Status
+		wantSettledCalls        int
+		wantSettledStatus       creditpurchase.Status
+		wantCreatePaymentCalls  int
+		wantUpdatePaymentCalls  int
+		wantUpdateChargeCalls   int
+		wantUpdatedChargeStatus creditpurchase.Status
+	}{
+		{
+			name:                    "created",
+			initialStatus:           creditpurchase.CreatedInitialPaymentSettlementStatus,
+			wantStatus:              creditpurchase.StatusActivePaymentPending,
+			wantUpdateChargeCalls:   1,
+			wantUpdatedChargeStatus: creditpurchase.StatusActivePaymentPending,
+		},
+		{
+			name:                    "authorized",
+			initialStatus:           creditpurchase.AuthorizedInitialPaymentSettlementStatus,
+			wantStatus:              creditpurchase.StatusActivePaymentAuthorized,
+			wantPaymentStatus:       lo.ToPtr(payment.StatusAuthorized),
+			wantAuthorizedCalls:     1,
+			wantAuthorizedStatus:    creditpurchase.StatusActivePaymentAuthorized,
+			wantCreatePaymentCalls:  1,
+			wantUpdateChargeCalls:   2,
+			wantUpdatedChargeStatus: creditpurchase.StatusActivePaymentAuthorized,
+		},
+		{
+			name:                    "settled",
+			initialStatus:           creditpurchase.SettledInitialPaymentSettlementStatus,
+			wantStatus:              creditpurchase.StatusFinal,
+			wantPaymentStatus:       lo.ToPtr(payment.StatusSettled),
+			wantAuthorizedCalls:     1,
+			wantAuthorizedStatus:    creditpurchase.StatusActivePaymentAuthorized,
+			wantSettledCalls:        1,
+			wantSettledStatus:       creditpurchase.StatusActivePaymentAuthorized,
+			wantCreatePaymentCalls:  1,
+			wantUpdatePaymentCalls:  1,
+			wantUpdateChargeCalls:   3,
+			wantUpdatedChargeStatus: creditpurchase.StatusFinal,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// given:
+			// - a created external credit-purchase charge with a provider initial status
+			// when:
+			// - the credit-purchase service starts the external lifecycle
+			// then:
+			// - it routes the initial status through the expected state-machine transitions
+			charge := newExternalStateMachineTestChargeWithInput(externalStateMachineTestChargeInput{
+				status:        creditpurchase.StatusCreated,
+				costBasis:     alpacadecimal.NewFromFloat(0.5),
+				creditAmount:  alpacadecimal.NewFromFloat(100),
+				initialStatus: tc.initialStatus,
+			})
+
+			adapter := &externalStateMachineAdapter{}
+			lineageService := &externalStateMachineLineage{}
+
+			handler := &externalStateMachineHandler{}
+			handler.On("OnCreditPurchaseInitiated", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					charge := args.Get(1).(creditpurchase.Charge)
+					require.Equal(t, creditpurchase.StatusActivePaymentPending, charge.Status)
+					require.Nil(t, charge.Realizations.CreditGrantRealization)
+					require.Nil(t, charge.Realizations.ExternalPaymentSettlement)
+				}).
+				Return(ledgertransaction.GroupReference{TransactionGroupID: "initiated-ledger-tx"}, nil).
+				Once()
+			if tc.wantAuthorizedCalls > 0 {
+				handler.On("OnCreditPurchasePaymentAuthorized", mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						input := args.Get(1).(creditpurchase.PaymentEventInput)
+						require.Equal(t, tc.wantAuthorizedStatus, input.Charge.Status)
+						require.NotNil(t, input.Charge.Realizations.CreditGrantRealization)
+						require.Nil(t, input.Charge.Realizations.ExternalPaymentSettlement)
+					}).
+					Return(ledgertransaction.GroupReference{TransactionGroupID: "authorized-ledger-tx"}, nil).
+					Once()
+			}
+			if tc.wantSettledCalls > 0 {
+				handler.On("OnCreditPurchasePaymentSettled", mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						input := args.Get(1).(creditpurchase.PaymentEventInput)
+						require.Equal(t, tc.wantSettledStatus, input.Charge.Status)
+						require.NotNil(t, input.Charge.Realizations.CreditGrantRealization)
+						require.NotNil(t, input.Charge.Realizations.ExternalPaymentSettlement)
+						require.Equal(t, payment.StatusAuthorized, input.Charge.Realizations.ExternalPaymentSettlement.Status)
+					}).
+					Return(ledgertransaction.GroupReference{TransactionGroupID: "settled-ledger-tx"}, nil).
+					Once()
+			}
+			realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
+			svc := &service{
+				adapter:      adapter,
+				realizations: realizationsService,
+			}
+
+			lineageService.On("BackfillAdvanceLineageSegments",
+				mock.Anything,
+				mock.MatchedBy(func(input lineage.BackfillAdvanceLineageSegmentsInput) bool {
+					return input.Namespace == charge.Namespace &&
+						input.CustomerID == charge.Intent.CustomerID &&
+						input.Currency == charge.Intent.Currency &&
+						input.Amount.Equal(charge.Intent.CreditAmount) &&
+						input.BackingTransactionGroupID == "initiated-ledger-tx"
+				})).
+				Return(nil).
+				Once()
+
+			got, err := svc.onExternalCreditPurchase(t.Context(), charge)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.wantStatus, got.Status)
+			require.NotNil(t, got.Realizations.CreditGrantRealization)
+			require.Equal(t, "initiated-ledger-tx", got.Realizations.CreditGrantRealization.TransactionGroupID)
+			if tc.wantPaymentStatus == nil {
+				require.Nil(t, got.Realizations.ExternalPaymentSettlement)
+			} else {
+				require.NotNil(t, got.Realizations.ExternalPaymentSettlement)
+				require.Equal(t, *tc.wantPaymentStatus, got.Realizations.ExternalPaymentSettlement.Status)
+			}
+			require.Equal(t, tc.wantCreatePaymentCalls, adapter.createExternalPaymentCalls)
+			require.Equal(t, tc.wantUpdatePaymentCalls, adapter.updateExternalPaymentCalls)
+			require.Equal(t, tc.wantUpdateChargeCalls, adapter.updateChargeCalls)
+			require.Equal(t, tc.wantUpdatedChargeStatus, adapter.updatedBase.Status)
+			handler.AssertExpectations(t)
+			lineageService.AssertExpectations(t)
+		})
+	}
+}
+
+func TestExternalCreditPurchaseStateMachineInitiationRejectsNonPositiveCostBasis(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		costBasis alpacadecimal.Decimal
+	}{
+		{
+			name:      "zero",
+			costBasis: alpacadecimal.Zero,
+		},
+		{
+			name:      "negative",
+			costBasis: alpacadecimal.NewFromFloat(-0.5),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// given:
+			// - an external credit-purchase charge with non-positive cost basis
+			// when:
+			// - the current initiation helper tries to create the credit grant realization
+			// then:
+			// - it fails with a validation error before creating realizations
+			charge := newExternalStateMachineTestCharge(creditpurchase.StatusActivePaymentPending, tc.costBasis)
+			adapter := &externalStateMachineAdapter{}
+			handler := &externalStateMachineHandler{}
+			lineageService := &externalStateMachineLineage{}
+			realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
+
+			stateMachine, err := NewExternalCreditPurchaseStateMachine(StateMachineConfig{
+				Charge:       charge,
+				Adapter:      adapter,
+				Realizations: realizationsService,
+			})
+			require.NoError(t, err)
+
+			err = stateMachine.InitiateExternalCreditPurchaseFromCreated(t.Context())
+
+			require.Error(t, err)
+			require.ErrorContains(t, err, "cost basis must be positive")
+			require.True(t, models.IsGenericValidationError(err))
+			require.Zero(t, adapter.createCreditGrantCalls)
+			require.Zero(t, adapter.createExternalPaymentCalls)
+			require.Zero(t, adapter.updateChargeCalls)
+			handler.AssertNotCalled(t, "OnCreditPurchaseInitiated", mock.Anything, mock.Anything)
+			lineageService.AssertNotCalled(t, "BackfillAdvanceLineageSegments", mock.Anything, mock.Anything)
+		})
+	}
+}
+
+func TestExternalCreditPurchaseStateMachineAuthorizesAndSettlesPayment(t *testing.T) {
+	// given:
+	// - an active external credit-purchase charge with granted credits
+	// when:
+	// - the payment is authorized and then settled
+	// then:
+	// - payment realization moves to settled and the charge becomes final
+	charge := newGrantedExternalCreditPurchaseCharge(creditpurchase.StatusActivePaymentPending)
+	handler := &externalStateMachineHandler{}
+	handler.On("OnCreditPurchasePaymentAuthorized", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			input := args.Get(1).(creditpurchase.PaymentEventInput)
+			require.Equal(t, creditpurchase.StatusActivePaymentAuthorized, input.Charge.Status)
+			require.NotNil(t, input.Charge.Realizations.CreditGrantRealization)
+			require.Nil(t, input.Charge.Realizations.ExternalPaymentSettlement)
+		}).
+		Return(ledgertransaction.GroupReference{TransactionGroupID: "authorized-ledger-tx"}, nil).
+		Once()
+	handler.On("OnCreditPurchasePaymentSettled", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			input := args.Get(1).(creditpurchase.PaymentEventInput)
+			require.Equal(t, creditpurchase.StatusActivePaymentAuthorized, input.Charge.Status)
+			require.NotNil(t, input.Charge.Realizations.ExternalPaymentSettlement)
+			require.Equal(t, payment.StatusAuthorized, input.Charge.Realizations.ExternalPaymentSettlement.Status)
+			require.Equal(t, "authorized-ledger-tx", input.Charge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
+		}).
+		Return(ledgertransaction.GroupReference{TransactionGroupID: "settled-ledger-tx"}, nil).
+		Once()
+	adapter := &externalStateMachineAdapter{}
+	lineageService := &externalStateMachineLineage{}
+	realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
+
+	stateMachine, err := NewExternalCreditPurchaseStateMachine(StateMachineConfig{
+		Charge:       charge,
+		Adapter:      adapter,
+		Realizations: realizationsService,
+	})
+	require.NoError(t, err)
+
+	err = stateMachine.FireAndActivate(t.Context(), billing.TriggerAuthorized)
+	require.NoError(t, err)
+	require.Equal(t, creditpurchase.StatusActivePaymentAuthorized, stateMachine.GetCharge().Status)
+	require.NotNil(t, stateMachine.GetCharge().Realizations.ExternalPaymentSettlement)
+	require.Equal(t, payment.StatusAuthorized, stateMachine.GetCharge().Realizations.ExternalPaymentSettlement.Status)
+	require.Equal(t, "authorized-ledger-tx", stateMachine.GetCharge().Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
+	require.Equal(t, 1, adapter.createExternalPaymentCalls)
+	require.Equal(t, 1, adapter.updateChargeCalls)
+	require.Equal(t, creditpurchase.StatusActivePaymentAuthorized, adapter.updatedBase.Status)
+
+	settledCharge, err := stateMachine.handleExternalPaymentLifecycleTrigger(t.Context(), billing.TriggerPaid)
+
+	require.NoError(t, err)
+	require.Equal(t, creditpurchase.StatusFinal, settledCharge.Status)
+	require.NotNil(t, settledCharge.Realizations.ExternalPaymentSettlement)
+	require.Equal(t, payment.StatusSettled, settledCharge.Realizations.ExternalPaymentSettlement.Status)
+	require.Equal(t, "authorized-ledger-tx", settledCharge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
+	require.Equal(t, "settled-ledger-tx", settledCharge.Realizations.ExternalPaymentSettlement.Settled.TransactionGroupID)
+	require.Equal(t, 1, adapter.updateExternalPaymentCalls)
+	require.Equal(t, 2, adapter.updateChargeCalls)
+	handler.AssertExpectations(t)
+}
+
+func TestExternalCreditPurchaseStateMachineAuthorizationUsesRealizationDuplicateGuard(t *testing.T) {
+	// given:
+	// - a payment-pending external credit-purchase charge that already has an authorized payment realization
+	// when:
+	// - the state machine receives another authorized trigger
+	// then:
+	// - the realization service reports the duplicate payment and the charge status is not persisted
+	charge := newExternalStateMachineTestCharge(creditpurchase.StatusActivePaymentPending, alpacadecimal.NewFromFloat(0.5))
+	charge.Realizations.CreditGrantRealization = &ledgertransaction.TimedGroupReference{
+		GroupReference: ledgertransaction.GroupReference{TransactionGroupID: "initiated-ledger-tx"},
+		Time:           time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	charge.Realizations.ExternalPaymentSettlement = &payment.External{
+		Payment: payment.Payment{
+			NamespacedID: models.NamespacedID{
+				Namespace: charge.Namespace,
+				ID:        "external-payment-1",
+			},
+			Base: payment.Base{
+				ServicePeriod: charge.Intent.ServicePeriod,
+				Amount:        charge.Intent.CreditAmount,
+				Status:        payment.StatusAuthorized,
+				Authorized: &ledgertransaction.TimedGroupReference{
+					GroupReference: ledgertransaction.GroupReference{TransactionGroupID: "authorized-ledger-tx"},
+					Time:           time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+	}
+
+	adapter := &externalStateMachineAdapter{}
+	lineageService := &externalStateMachineLineage{}
+	handler := &externalStateMachineHandler{}
+	realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
+
+	stateMachine, err := NewExternalCreditPurchaseStateMachine(StateMachineConfig{
+		Charge:       charge,
+		Adapter:      adapter,
+		Realizations: realizationsService,
+	})
+	require.NoError(t, err)
+
+	err = stateMachine.FireAndActivate(t.Context(), billing.TriggerAuthorized)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, payment.ErrPaymentAlreadyAuthorized)
+	require.Zero(t, adapter.createExternalPaymentCalls)
+	require.Zero(t, adapter.updateChargeCalls)
+	handler.AssertNotCalled(t, "OnCreditPurchasePaymentAuthorized", mock.Anything, mock.Anything)
+}
+
+func TestExternalCreditPurchaseStateMachineAuthorizesAndSettlesInSingleTransition(t *testing.T) {
+	// given:
+	// - a payment-pending external credit-purchase charge with no payment realization
+	// when:
+	// - the state machine receives the paid trigger
+	// then:
+	// - it books authorization before settlement and persists the final charge status
+	charge := newGrantedExternalCreditPurchaseCharge(creditpurchase.StatusActivePaymentPending)
+	handler := &externalStateMachineHandler{}
+	handler.On("OnCreditPurchasePaymentAuthorized", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			input := args.Get(1).(creditpurchase.PaymentEventInput)
+			require.Equal(t, creditpurchase.StatusActivePaymentAuthorized, input.Charge.Status)
+			require.Nil(t, input.Charge.Realizations.ExternalPaymentSettlement)
+		}).
+		Return(ledgertransaction.GroupReference{TransactionGroupID: "authorized-ledger-tx"}, nil).
+		Once()
+	handler.On("OnCreditPurchasePaymentSettled", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			input := args.Get(1).(creditpurchase.PaymentEventInput)
+			require.Equal(t, creditpurchase.StatusActivePaymentAuthorized, input.Charge.Status)
+			require.NotNil(t, input.Charge.Realizations.ExternalPaymentSettlement)
+			require.Equal(t, payment.StatusAuthorized, input.Charge.Realizations.ExternalPaymentSettlement.Status)
+			require.Equal(t, "authorized-ledger-tx", input.Charge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
+		}).
+		Return(ledgertransaction.GroupReference{TransactionGroupID: "settled-ledger-tx"}, nil).
+		Once()
+	adapter := &externalStateMachineAdapter{}
+	lineageService := &externalStateMachineLineage{}
+	realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
+
+	stateMachine, err := NewExternalCreditPurchaseStateMachine(StateMachineConfig{
+		Charge:       charge,
+		Adapter:      adapter,
+		Realizations: realizationsService,
+	})
+	require.NoError(t, err)
+
+	settledCharge, err := stateMachine.handleExternalPaymentLifecycleTrigger(t.Context(), billing.TriggerPaid)
+
+	require.NoError(t, err)
+	require.Equal(t, creditpurchase.StatusFinal, settledCharge.Status)
+	require.NotNil(t, settledCharge.Realizations.ExternalPaymentSettlement)
+	require.Equal(t, payment.StatusSettled, settledCharge.Realizations.ExternalPaymentSettlement.Status)
+	require.Equal(t, "authorized-ledger-tx", settledCharge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
+	require.Equal(t, "settled-ledger-tx", settledCharge.Realizations.ExternalPaymentSettlement.Settled.TransactionGroupID)
+	require.Equal(t, 1, adapter.createExternalPaymentCalls)
+	require.Equal(t, 1, adapter.updateExternalPaymentCalls)
+	require.Equal(t, 2, adapter.updateChargeCalls)
+	handler.AssertExpectations(t)
+}
+
+func newGrantedExternalCreditPurchaseCharge(status creditpurchase.Status) creditpurchase.Charge {
+	charge := newExternalStateMachineTestCharge(status, alpacadecimal.NewFromFloat(0.5))
+	charge.Realizations.CreditGrantRealization = &ledgertransaction.TimedGroupReference{
+		GroupReference: ledgertransaction.GroupReference{TransactionGroupID: "initiated-ledger-tx"},
+		Time:           time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	return charge
+}
+
+type externalStateMachineFixture struct {
+	stateMachine   *ExternalCreditPurchaseStateMachine
+	charge         creditpurchase.Charge
+	adapter        *externalStateMachineAdapter
+	handler        *externalStateMachineHandler
+	lineageService *externalStateMachineLineage
+}
+
+func newExternalStateMachineTestMachine(
+	t *testing.T,
+	status creditpurchase.Status,
+	costBasis alpacadecimal.Decimal,
+) externalStateMachineFixture {
+	t.Helper()
+
+	charge := newExternalStateMachineTestCharge(status, costBasis)
+	adapter := &externalStateMachineAdapter{}
+	lineageService := &externalStateMachineLineage{}
+	handler := &externalStateMachineHandler{}
+	handler.On("OnCreditPurchaseInitiated", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			charge := args.Get(1).(creditpurchase.Charge)
+			require.Equal(t, creditpurchase.StatusActivePaymentPending, charge.Status)
+			require.Nil(t, charge.Realizations.CreditGrantRealization)
+		}).
+		Return(ledgertransaction.GroupReference{
+			TransactionGroupID: "initiated-ledger-tx",
+		}, nil).
+		Once()
+	realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
+
+	lineageService.On("BackfillAdvanceLineageSegments",
+		mock.Anything,
+		mock.MatchedBy(func(input lineage.BackfillAdvanceLineageSegmentsInput) bool {
+			return input.Namespace == charge.Namespace &&
+				input.CustomerID == charge.Intent.CustomerID &&
+				input.Currency == charge.Intent.Currency &&
+				input.Amount.Equal(charge.Intent.CreditAmount) &&
+				input.BackingTransactionGroupID != ""
+		})).
+		Return(nil).
+		Once()
+
+	stateMachine, err := NewExternalCreditPurchaseStateMachine(StateMachineConfig{
+		Charge:       charge,
+		Adapter:      adapter,
+		Realizations: realizationsService,
+	})
+	require.NoError(t, err)
+
+	return externalStateMachineFixture{
+		stateMachine:   stateMachine,
+		charge:         charge,
+		adapter:        adapter,
+		handler:        handler,
+		lineageService: lineageService,
+	}
+}
+
+func newExternalStateMachineRealizations(
+	t *testing.T,
+	adapter creditpurchase.Adapter,
+	handler creditpurchase.Handler,
+	lineageService lineage.Service,
+) *creditpurchaserealizations.Service {
+	t.Helper()
+
+	realizationsService, err := creditpurchaserealizations.New(creditpurchaserealizations.Config{
+		Adapter: adapter,
+		Handler: handler,
+		Lineage: lineageService,
+	})
+	require.NoError(t, err)
+
+	return realizationsService
+}
+
+type externalStateMachineTestChargeInput struct {
+	status        creditpurchase.Status
+	costBasis     alpacadecimal.Decimal
+	creditAmount  alpacadecimal.Decimal
+	initialStatus creditpurchase.InitialPaymentSettlementStatus
+}
+
+func newExternalStateMachineTestCharge(status creditpurchase.Status, costBasis alpacadecimal.Decimal) creditpurchase.Charge {
+	return newExternalStateMachineTestChargeWithInput(externalStateMachineTestChargeInput{
+		status:        status,
+		costBasis:     costBasis,
+		creditAmount:  alpacadecimal.NewFromFloat(100),
+		initialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
+	})
+}
+
+func newExternalStateMachineTestChargeWithInput(input externalStateMachineTestChargeInput) creditpurchase.Charge {
+	period := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	intent := creditpurchase.Intent{
+		Intent: meta.Intent{
+			Name:              "test external credits",
+			CustomerID:        "customer-1",
+			Currency:          currencyx.Code("USD"),
+			ServicePeriod:     period,
+			FullServicePeriod: period,
+			BillingPeriod:     period,
+		},
+		CreditAmount: input.creditAmount,
+		Settlement: creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{
+			GenericSettlement: creditpurchase.GenericSettlement{
+				Currency:  currencyx.Code("USD"),
+				CostBasis: input.costBasis,
+			},
+			InitialStatus: input.initialStatus,
+		}),
+	}.Normalized()
+
+	return creditpurchase.Charge{
+		ChargeBase: creditpurchase.ChargeBase{
+			ManagedResource: meta.ManagedResource{
+				NamespacedModel: models.NamespacedModel{
+					Namespace: "test-namespace",
+				},
+				ManagedModel: models.ManagedModel{
+					CreatedAt: period.From,
+					UpdatedAt: period.From,
+				},
+				ID: "charge-1",
+			},
+			Intent: intent,
+			Status: input.status,
+		},
+	}
+}
+
+type externalStateMachineAdapter struct {
+	creditpurchase.Adapter
+
+	updateChargeCalls int
+	updatedBase       creditpurchase.ChargeBase
+
+	createCreditGrantCalls int
+	createdGrantChargeID   meta.ChargeID
+	createdGrantInput      creditpurchase.CreateCreditGrantInput
+
+	createExternalPaymentCalls int
+	createdExternalPaymentID   meta.ChargeID
+	createdExternalPayment     payment.ExternalCreateInput
+
+	updateExternalPaymentCalls int
+	updatedExternalPayment     payment.External
+}
+
+func (a *externalStateMachineAdapter) UpdateCharge(ctx context.Context, charge creditpurchase.ChargeBase) (creditpurchase.ChargeBase, error) {
+	a.updateChargeCalls++
+	a.updatedBase = charge
+	return charge, nil
+}
+
+func (a *externalStateMachineAdapter) CreateCreditGrant(ctx context.Context, chargeID meta.ChargeID, input creditpurchase.CreateCreditGrantInput) (ledgertransaction.TimedGroupReference, error) {
+	a.createCreditGrantCalls++
+	a.createdGrantChargeID = chargeID
+	a.createdGrantInput = input
+	return ledgertransaction.TimedGroupReference{
+		GroupReference: ledgertransaction.GroupReference{
+			TransactionGroupID: input.TransactionGroupID,
+		},
+		Time: input.GrantedAt,
+	}, nil
+}
+
+func (a *externalStateMachineAdapter) CreateExternalPayment(ctx context.Context, chargeID meta.ChargeID, input payment.ExternalCreateInput) (payment.External, error) {
+	a.createExternalPaymentCalls++
+	a.createdExternalPaymentID = chargeID
+	a.createdExternalPayment = input
+	return payment.External{
+		Payment: payment.Payment{
+			NamespacedID: models.NamespacedID{
+				Namespace: input.Namespace,
+				ID:        "external-payment-1",
+			},
+			ManagedModel: models.ManagedModel{
+				CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+				UpdatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			Base: input.Base,
+		},
+	}, nil
+}
+
+func (a *externalStateMachineAdapter) UpdateExternalPayment(ctx context.Context, paymentSettlement payment.External) (payment.External, error) {
+	a.updateExternalPaymentCalls++
+	a.updatedExternalPayment = paymentSettlement
+	return paymentSettlement, nil
+}
+
+type externalStateMachineHandler struct {
+	creditpurchase.Handler
+	mock.Mock
+}
+
+func (h *externalStateMachineHandler) OnCreditPurchaseInitiated(ctx context.Context, charge creditpurchase.Charge) (ledgertransaction.GroupReference, error) {
+	args := h.Called(ctx, charge)
+	return args.Get(0).(ledgertransaction.GroupReference), args.Error(1)
+}
+
+func (h *externalStateMachineHandler) OnCreditPurchasePaymentAuthorized(ctx context.Context, input creditpurchase.PaymentEventInput) (ledgertransaction.GroupReference, error) {
+	args := h.Called(ctx, input)
+	return args.Get(0).(ledgertransaction.GroupReference), args.Error(1)
+}
+
+func (h *externalStateMachineHandler) OnCreditPurchasePaymentSettled(ctx context.Context, input creditpurchase.PaymentEventInput) (ledgertransaction.GroupReference, error) {
+	args := h.Called(ctx, input)
+	return args.Get(0).(ledgertransaction.GroupReference), args.Error(1)
+}
+
+type externalStateMachineLineage struct {
+	lineage.Service
+	mock.Mock
+}
+
+func (l *externalStateMachineLineage) BackfillAdvanceLineageSegments(ctx context.Context, input lineage.BackfillAdvanceLineageSegmentsInput) error {
+	args := l.Called(ctx, input)
+	return args.Error(0)
+}
+
+var (
+	_ creditpurchase.Handler = (*externalStateMachineHandler)(nil)
+	_ lineage.Service        = (*externalStateMachineLineage)(nil)
+)

--- a/openmeter/billing/charges/creditpurchase/service/external_test.go
+++ b/openmeter/billing/charges/creditpurchase/service/external_test.go
@@ -22,100 +22,78 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func TestExternalCreditPurchaseStateMachineActiveAdvancesToPaymentPending(t *testing.T) {
-	// given:
-	// - an external credit-purchase charge in the legacy active lifecycle status
-	// when:
-	// - the external state machine advances until stable
-	// then:
-	// - it advances to and persists the payment-pending status without granting credits
-	fixture := newExternalStateMachineTestMachine(
-		t,
+func TestExternalCreditPurchaseStateMachineAdvancesThroughGrantToPaymentPending(t *testing.T) {
+	for _, status := range []creditpurchase.Status{
+		creditpurchase.StatusCreated,
 		creditpurchase.StatusActive,
-		alpacadecimal.NewFromFloat(0.5),
-	)
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			// given:
+			// - an external credit-purchase charge in a pre-payment lifecycle status
+			// when:
+			// - the external state machine advances until stable
+			// then:
+			// - it enters the initial credit grant state, grants credits, then persists payment-pending
+			charge := newExternalStateMachineTestChargeWithInput(externalStateMachineTestChargeInput{
+				status:         status,
+				costBasis:      alpacadecimal.NewFromFloat(0.5),
+				creditAmount:   alpacadecimal.NewFromFloat(100),
+				initialStatus:  creditpurchase.CreatedInitialPaymentSettlementStatus,
+				featureFilters: creditpurchase.FeatureFilters{"storage", "api-calls", "storage"},
+			})
+			adapter := &externalStateMachineAdapter{}
+			lineageService := &externalStateMachineLineage{}
+			handler := &externalStateMachineHandler{}
+			handler.On("OnCreditPurchaseInitiated", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					charge := args.Get(1).(creditpurchase.Charge)
+					require.Equal(t, creditpurchase.StatusActiveInitialCreditGrant, charge.Status)
+					require.Nil(t, charge.Realizations.CreditGrantRealization)
+					require.Nil(t, charge.Realizations.ExternalPaymentSettlement)
+				}).
+				Return(ledgertransaction.GroupReference{TransactionGroupID: "initiated-ledger-tx"}, nil).
+				Once()
+			lineageService.On("BackfillAdvanceLineageSegments",
+				mock.Anything,
+				mock.MatchedBy(func(input lineage.BackfillAdvanceLineageSegmentsInput) bool {
+					return input.Namespace == charge.Namespace &&
+						input.CustomerID == charge.Intent.CustomerID &&
+						input.Currency == charge.Intent.Currency &&
+						input.Amount.Equal(charge.Intent.CreditAmount) &&
+						input.BackingTransactionGroupID == "initiated-ledger-tx" &&
+						len(input.FeatureFilters) == 2 &&
+						input.FeatureFilters[0] == "api-calls" &&
+						input.FeatureFilters[1] == "storage"
+				})).
+				Return(nil).
+				Once()
+			realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
 
-	advancedCharge, err := fixture.stateMachine.AdvanceUntilStateStable(t.Context())
+			stateMachine, err := NewExternalCreditPurchaseStateMachine(StateMachineConfig{
+				Charge:       charge,
+				Adapter:      adapter,
+				Realizations: realizationsService,
+			})
+			require.NoError(t, err)
 
-	require.NoError(t, err)
-	require.NotNil(t, advancedCharge)
-	require.Equal(t, creditpurchase.StatusActivePaymentPending, advancedCharge.Status)
-	require.Equal(t, []creditpurchase.Status{
-		creditpurchase.StatusActivePaymentPending,
-	}, fixture.adapter.updatedBaseStatuses)
-	require.Nil(t, advancedCharge.Realizations.CreditGrantRealization)
-	require.Nil(t, advancedCharge.Realizations.ExternalPaymentSettlement)
-	require.Equal(t, 0, fixture.adapter.createCreditGrantCalls)
-	require.Equal(t, 1, fixture.adapter.updateChargeCalls)
-	fixture.handler.AssertExpectations(t)
-	fixture.lineageService.AssertExpectations(t)
-}
+			advancedCharge, err := stateMachine.AdvanceUntilStateStable(t.Context())
 
-func TestExternalCreditPurchaseStateMachineCreatedAdvancesThroughGrantToPaymentPending(t *testing.T) {
-	// given:
-	// - an external credit-purchase charge in the created status
-	// when:
-	// - the external state machine advances until stable
-	// then:
-	// - it enters the initial credit grant state, grants credits, then persists payment-pending
-	charge := newExternalStateMachineTestChargeWithInput(externalStateMachineTestChargeInput{
-		status:         creditpurchase.StatusCreated,
-		costBasis:      alpacadecimal.NewFromFloat(0.5),
-		creditAmount:   alpacadecimal.NewFromFloat(100),
-		initialStatus:  creditpurchase.CreatedInitialPaymentSettlementStatus,
-		featureFilters: creditpurchase.FeatureFilters{"storage", "api-calls", "storage"},
-	})
-	adapter := &externalStateMachineAdapter{}
-	lineageService := &externalStateMachineLineage{}
-	handler := &externalStateMachineHandler{}
-	handler.On("OnCreditPurchaseInitiated", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			charge := args.Get(1).(creditpurchase.Charge)
-			require.Equal(t, creditpurchase.StatusActiveInitialCreditGrant, charge.Status)
-			require.Nil(t, charge.Realizations.CreditGrantRealization)
-			require.Nil(t, charge.Realizations.ExternalPaymentSettlement)
-		}).
-		Return(ledgertransaction.GroupReference{TransactionGroupID: "initiated-ledger-tx"}, nil).
-		Once()
-	lineageService.On("BackfillAdvanceLineageSegments",
-		mock.Anything,
-		mock.MatchedBy(func(input lineage.BackfillAdvanceLineageSegmentsInput) bool {
-			return input.Namespace == charge.Namespace &&
-				input.CustomerID == charge.Intent.CustomerID &&
-				input.Currency == charge.Intent.Currency &&
-				input.Amount.Equal(charge.Intent.CreditAmount) &&
-				input.BackingTransactionGroupID == "initiated-ledger-tx" &&
-				len(input.FeatureFilters) == 2 &&
-				input.FeatureFilters[0] == "api-calls" &&
-				input.FeatureFilters[1] == "storage"
-		})).
-		Return(nil).
-		Once()
-	realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
-
-	stateMachine, err := NewExternalCreditPurchaseStateMachine(StateMachineConfig{
-		Charge:       charge,
-		Adapter:      adapter,
-		Realizations: realizationsService,
-	})
-	require.NoError(t, err)
-
-	advancedCharge, err := stateMachine.AdvanceUntilStateStable(t.Context())
-
-	require.NoError(t, err)
-	require.NotNil(t, advancedCharge)
-	require.Equal(t, creditpurchase.StatusActivePaymentPending, advancedCharge.Status)
-	require.NotNil(t, advancedCharge.Realizations.CreditGrantRealization)
-	require.Equal(t, "initiated-ledger-tx", advancedCharge.Realizations.CreditGrantRealization.TransactionGroupID)
-	require.Nil(t, advancedCharge.Realizations.ExternalPaymentSettlement)
-	require.Equal(t, 1, adapter.createCreditGrantCalls)
-	require.Equal(t, 2, adapter.updateChargeCalls)
-	require.Equal(t, []creditpurchase.Status{
-		creditpurchase.StatusActiveInitialCreditGrant,
-		creditpurchase.StatusActivePaymentPending,
-	}, adapter.updatedBaseStatuses)
-	handler.AssertExpectations(t)
-	lineageService.AssertExpectations(t)
+			require.NoError(t, err)
+			require.NotNil(t, advancedCharge)
+			require.Equal(t, creditpurchase.StatusActivePaymentPending, advancedCharge.Status)
+			require.NotNil(t, advancedCharge.Realizations.CreditGrantRealization)
+			require.Equal(t, "initiated-ledger-tx", advancedCharge.Realizations.CreditGrantRealization.TransactionGroupID)
+			require.Nil(t, advancedCharge.Realizations.ExternalPaymentSettlement)
+			require.Equal(t, 1, adapter.createCreditGrantCalls)
+			require.Equal(t, 2, adapter.updateChargeCalls)
+			require.Equal(t, []creditpurchase.Status{
+				creditpurchase.StatusActiveInitialCreditGrant,
+				creditpurchase.StatusActivePaymentPending,
+			}, adapter.updatedBaseStatuses)
+			handler.AssertExpectations(t)
+			lineageService.AssertExpectations(t)
+		})
+	}
 }
 
 func TestExternalCreditPurchaseStateMachineUsesRoundedCreditAmount(t *testing.T) {
@@ -580,45 +558,6 @@ func newGrantedExternalCreditPurchaseCharge(status creditpurchase.Status) credit
 	}
 
 	return charge
-}
-
-type externalStateMachineFixture struct {
-	stateMachine   *ExternalCreditPurchaseStateMachine
-	charge         creditpurchase.Charge
-	adapter        *externalStateMachineAdapter
-	handler        *externalStateMachineHandler
-	lineageService *externalStateMachineLineage
-}
-
-func newExternalStateMachineTestMachine(
-	t *testing.T,
-	status creditpurchase.Status,
-	costBasis alpacadecimal.Decimal,
-) externalStateMachineFixture {
-	t.Helper()
-
-	charge := newExternalStateMachineTestCharge(status, costBasis)
-	adapter := &externalStateMachineAdapter{}
-	lineageService := &externalStateMachineLineage{}
-	handler := &externalStateMachineHandler{}
-	// The lifecycle advance does not initiate the credit grant, so no grant or
-	// lineage handler calls are expected here.
-	realizationsService := newExternalStateMachineRealizations(t, adapter, handler, lineageService)
-
-	stateMachine, err := NewExternalCreditPurchaseStateMachine(StateMachineConfig{
-		Charge:       charge,
-		Adapter:      adapter,
-		Realizations: realizationsService,
-	})
-	require.NoError(t, err)
-
-	return externalStateMachineFixture{
-		stateMachine:   stateMachine,
-		charge:         charge,
-		adapter:        adapter,
-		handler:        handler,
-		lineageService: lineageService,
-	}
 }
 
 func newExternalStateMachineRealizations(

--- a/openmeter/billing/charges/creditpurchase/service/realizations/service.go
+++ b/openmeter/billing/charges/creditpurchase/service/realizations/service.go
@@ -93,6 +93,7 @@ func (s *Service) InitiateExternalCreditPurchase(ctx context.Context, charge cre
 			Currency:                  charge.Intent.Currency,
 			Amount:                    charge.Intent.CreditAmount,
 			BackingTransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
+			FeatureFilters:            charge.Intent.FeatureFilters.Normalize(),
 		}); err != nil {
 			return creditpurchase.Charge{}, err
 		}

--- a/openmeter/billing/charges/creditpurchase/service/realizations/service.go
+++ b/openmeter/billing/charges/creditpurchase/service/realizations/service.go
@@ -57,14 +57,14 @@ func New(config Config) (*Service, error) {
 	}, nil
 }
 
-func (s *Service) InitiateExternalCreditPurchase(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
+func (s *Service) GrantCredits(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
 	externalSettlement, err := charge.Intent.Settlement.AsExternalSettlement()
 	if err != nil {
 		return creditpurchase.Charge{}, err
 	}
 
-	if !externalSettlement.CostBasis.IsPositive() {
-		return creditpurchase.Charge{}, models.NewGenericValidationError(errors.New("cost basis must be positive"))
+	if err := externalSettlement.Validate(); err != nil {
+		return creditpurchase.Charge{}, err
 	}
 
 	if charge.Realizations.CreditGrantRealization != nil && charge.Realizations.CreditGrantRealization.TransactionGroupID != "" {

--- a/openmeter/billing/charges/creditpurchase/service/realizations/service.go
+++ b/openmeter/billing/charges/creditpurchase/service/realizations/service.go
@@ -1,0 +1,195 @@
+package realizations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/ledgertransaction"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
+	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// Service owns credit-purchase realization mechanics. It must not decide which
+// lifecycle trigger should fire or which charge status should be entered.
+type Service struct {
+	adapter creditpurchase.Adapter
+	handler creditpurchase.Handler
+	lineage lineage.Service
+}
+
+type Config struct {
+	Adapter creditpurchase.Adapter
+	Handler creditpurchase.Handler
+	Lineage lineage.Service
+}
+
+func (c Config) Validate() error {
+	var errs []error
+
+	if c.Adapter == nil {
+		errs = append(errs, errors.New("adapter is required"))
+	}
+
+	if c.Handler == nil {
+		errs = append(errs, errors.New("handler is required"))
+	}
+
+	if c.Lineage == nil {
+		errs = append(errs, errors.New("lineage service is required"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func New(config Config) (*Service, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &Service{
+		adapter: config.Adapter,
+		handler: config.Handler,
+		lineage: config.Lineage,
+	}, nil
+}
+
+func (s *Service) InitiateExternalCreditPurchase(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
+	externalSettlement, err := charge.Intent.Settlement.AsExternalSettlement()
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	if !externalSettlement.CostBasis.IsPositive() {
+		return creditpurchase.Charge{}, models.NewGenericValidationError(errors.New("cost basis must be positive"))
+	}
+
+	if charge.Realizations.CreditGrantRealization != nil && charge.Realizations.CreditGrantRealization.TransactionGroupID != "" {
+		return creditpurchase.Charge{}, fmt.Errorf("external credit grant already realized [charge_id=%s, transaction_group_id=%s]", charge.ID, charge.Realizations.CreditGrantRealization.TransactionGroupID)
+	}
+
+	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchaseInitiated(ctx, charge)
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	grantRealization, err := s.adapter.CreateCreditGrant(ctx, charge.GetChargeID(), creditpurchase.CreateCreditGrantInput{
+		TransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
+		GrantedAt:          clock.Now(),
+	})
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	charge.Realizations.CreditGrantRealization = &grantRealization
+
+	if ledgerTransactionGroupReference.TransactionGroupID != "" {
+		if err := s.lineage.BackfillAdvanceLineageSegments(ctx, lineage.BackfillAdvanceLineageSegmentsInput{
+			Namespace:                 charge.Namespace,
+			CustomerID:                charge.Intent.CustomerID,
+			Currency:                  charge.Intent.Currency,
+			Amount:                    charge.Intent.CreditAmount,
+			BackingTransactionGroupID: ledgerTransactionGroupReference.TransactionGroupID,
+		}); err != nil {
+			return creditpurchase.Charge{}, err
+		}
+	}
+
+	return charge, nil
+}
+
+func (s *Service) AuthorizeExternalPayment(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
+	if charge.Realizations.ExternalPaymentSettlement != nil {
+		return creditpurchase.Charge{}, payment.ErrPaymentAlreadyAuthorized.
+			WithAttrs(charge.ErrorAttributes()).
+			WithAttrs(charge.Realizations.ExternalPaymentSettlement.ErrorAttributes())
+	}
+
+	eventAt := clock.Now()
+	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentAuthorized(ctx, creditpurchase.PaymentEventInput{
+		Charge:  charge,
+		EventAt: eventAt,
+	})
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	newPaymentSettlement := payment.ExternalCreateInput{
+		Namespace: charge.Namespace,
+		Base: payment.Base{
+			ServicePeriod: charge.Intent.ServicePeriod,
+			Amount:        charge.Intent.CreditAmount,
+			Authorized: &ledgertransaction.TimedGroupReference{
+				GroupReference: ledgerTransactionGroupReference,
+				Time:           eventAt,
+			},
+			Status: payment.StatusAuthorized,
+		},
+	}
+
+	paymentSettlement, err := s.adapter.CreateExternalPayment(ctx, charge.GetChargeID(), newPaymentSettlement)
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	charge.Realizations.ExternalPaymentSettlement = &paymentSettlement
+
+	return charge, nil
+}
+
+func (s *Service) SettleExternalPayment(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
+	if charge.Realizations.ExternalPaymentSettlement == nil {
+		return creditpurchase.Charge{}, payment.ErrCannotSettleNotAuthorizedPayment.
+			WithAttrs(charge.ErrorAttributes())
+	}
+
+	paymentSettlement := *charge.Realizations.ExternalPaymentSettlement
+
+	if paymentSettlement.Status != payment.StatusAuthorized {
+		return creditpurchase.Charge{}, payment.ErrPaymentAlreadySettled.
+			WithAttrs(charge.ErrorAttributes()).
+			WithAttrs(paymentSettlement.ErrorAttributes())
+	}
+
+	eventAt := clock.Now()
+	ledgerTransactionGroupReference, err := s.handler.OnCreditPurchasePaymentSettled(ctx, creditpurchase.PaymentEventInput{
+		Charge:  charge,
+		EventAt: eventAt,
+	})
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	paymentSettlement.Settled = &ledgertransaction.TimedGroupReference{
+		GroupReference: ledgerTransactionGroupReference,
+		Time:           eventAt,
+	}
+
+	paymentSettlement.Status = payment.StatusSettled
+
+	paymentSettlement, err = s.adapter.UpdateExternalPayment(ctx, paymentSettlement)
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	charge.Realizations.ExternalPaymentSettlement = &paymentSettlement
+
+	return charge, nil
+}
+
+func (s *Service) AuthorizeAndSettleExternalPayment(ctx context.Context, charge creditpurchase.Charge) (creditpurchase.Charge, error) {
+	charge, err := s.AuthorizeExternalPayment(ctx, charge)
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	charge, err = s.SettleExternalPayment(ctx, charge)
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	return charge, nil
+}

--- a/openmeter/billing/charges/creditpurchase/service/service.go
+++ b/openmeter/billing/charges/creditpurchase/service/service.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	creditpurchaserealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 )
@@ -42,17 +44,28 @@ func New(config Config) (creditpurchase.Service, error) {
 		return nil, err
 	}
 
+	realizations, err := creditpurchaserealizations.New(creditpurchaserealizations.Config{
+		Adapter: config.Adapter,
+		Handler: config.Handler,
+		Lineage: config.Lineage,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("realizations: %w", err)
+	}
+
 	return &service{
-		adapter:     config.Adapter,
-		handler:     config.Handler,
-		lineage:     config.Lineage,
-		metaAdapter: config.MetaAdapter,
+		adapter:      config.Adapter,
+		handler:      config.Handler,
+		lineage:      config.Lineage,
+		metaAdapter:  config.MetaAdapter,
+		realizations: realizations,
 	}, nil
 }
 
 type service struct {
-	adapter     creditpurchase.Adapter
-	metaAdapter meta.Adapter
-	handler     creditpurchase.Handler
-	lineage     lineage.Service
+	adapter      creditpurchase.Adapter
+	metaAdapter  meta.Adapter
+	handler      creditpurchase.Handler
+	lineage      lineage.Service
+	realizations *creditpurchaserealizations.Service
 }

--- a/openmeter/billing/charges/creditpurchase/service/statemachine.go
+++ b/openmeter/billing/charges/creditpurchase/service/statemachine.go
@@ -2,19 +2,22 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
+	creditpurchaserealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	chargestatemachine "github.com/openmeterio/openmeter/openmeter/billing/charges/statemachine"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type stateMachine struct {
 	*chargestatemachine.Machine[creditpurchase.Charge, creditpurchase.ChargeBase, creditpurchase.Status]
 
-	Adapter creditpurchase.Adapter
-	// Realizations *realizations.Service
-	Service *service
+	Adapter      creditpurchase.Adapter
+	Realizations *creditpurchaserealizations.Service
+	Service      *service
 
 	CreditNotesSupported bool
 }
@@ -24,21 +27,25 @@ type StateMachine = chargestatemachine.StateMachine[creditpurchase.Charge]
 type StateMachineConfig struct {
 	Charge creditpurchase.Charge
 
-	Adapter creditpurchase.Adapter
-	// Realizations *realizations.Service
-	Service *service
+	Adapter      creditpurchase.Adapter
+	Realizations *creditpurchaserealizations.Service
+	Service      *service
 
 	CreditNotesSupported bool
 }
 
 func (c StateMachineConfig) Validate() error {
+	var errs []error
+
 	if c.Charge.ID == "" {
-		return fmt.Errorf("charge ID is required")
+		errs = append(errs, errors.New("charge ID is required"))
 	}
+
 	if c.Adapter == nil {
-		return fmt.Errorf("adapter is required")
+		errs = append(errs, errors.New("adapter is required"))
 	}
-	return nil
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
@@ -48,6 +55,7 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 
 	out := &stateMachine{
 		Adapter:              config.Adapter,
+		Realizations:         config.Realizations,
 		Service:              config.Service,
 		CreditNotesSupported: config.CreditNotesSupported,
 	}
@@ -73,4 +81,21 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 	out.Machine = machine
 
 	return out, nil
+}
+
+func (s *stateMachine) FireAndAdvanceUntilStateStable(ctx context.Context, trigger meta.Trigger) (creditpurchase.Charge, error) {
+	if err := s.FireAndActivate(ctx, trigger); err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	advancedCharge, err := s.AdvanceUntilStateStable(ctx)
+	if err != nil {
+		return creditpurchase.Charge{}, err
+	}
+
+	if advancedCharge != nil {
+		return *advancedCharge, nil
+	}
+
+	return s.GetCharge(), nil
 }

--- a/openmeter/billing/charges/creditpurchase/settlement.go
+++ b/openmeter/billing/charges/creditpurchase/settlement.go
@@ -47,8 +47,8 @@ func (s GenericSettlement) Validate() error {
 		errs = append(errs, fmt.Errorf("settlement currency: %w", err))
 	}
 
-	if s.CostBasis.IsNegative() {
-		errs = append(errs, fmt.Errorf("cost basis must be zero or positive"))
+	if !s.CostBasis.IsPositive() {
+		errs = append(errs, fmt.Errorf("cost basis must be positive"))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/billing/charges/creditpurchase/settlement_test.go
+++ b/openmeter/billing/charges/creditpurchase/settlement_test.go
@@ -1,0 +1,52 @@
+package creditpurchase
+
+import (
+	"testing"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestGenericSettlementValidateRequiresPositiveCostBasis(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		costBasis alpacadecimal.Decimal
+		wantErr   bool
+	}{
+		{
+			name:      "positive",
+			costBasis: alpacadecimal.NewFromFloat(0.5),
+		},
+		{
+			name:      "zero",
+			costBasis: alpacadecimal.Zero,
+			wantErr:   true,
+		},
+		{
+			name:      "negative",
+			costBasis: alpacadecimal.NewFromFloat(-0.5),
+			wantErr:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			settlement := GenericSettlement{
+				Currency:  currencyx.Code("USD"),
+				CostBasis: tc.costBasis,
+			}
+
+			err := settlement.Validate()
+
+			if tc.wantErr {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "cost basis must be positive")
+				require.True(t, models.IsGenericValidationError(err))
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}

--- a/openmeter/billing/charges/creditpurchase/statemachine.go
+++ b/openmeter/billing/charges/creditpurchase/statemachine.go
@@ -26,8 +26,11 @@ func (Status) Values() []string {
 	return []string{
 		string(StatusCreated),
 		string(StatusActive),
+		string(StatusActiveInitialCreditGrant),
 		string(StatusActivePaymentPending),
 		string(StatusActivePaymentAuthorized),
+		string(StatusActivePaymentPaidAndAuthorized),
+		string(StatusActivePaymentSettled),
 		string(StatusFinal),
 		string(StatusDeleted),
 	}

--- a/openmeter/billing/charges/creditpurchase/statemachine.go
+++ b/openmeter/billing/charges/creditpurchase/statemachine.go
@@ -11,16 +11,23 @@ import (
 type Status string
 
 const (
-	StatusCreated Status = Status(meta.ChargeStatusCreated)
-	StatusActive  Status = Status(meta.ChargeStatusActive)
-	StatusFinal   Status = Status(meta.ChargeStatusFinal)
-	StatusDeleted Status = Status(meta.ChargeStatusDeleted)
+	StatusCreated                        Status = Status(meta.ChargeStatusCreated)
+	StatusActive                         Status = Status(meta.ChargeStatusActive)
+	StatusActivePaymentPending           Status = "active.payment.pending"
+	StatusActiveInitialCreditGrant       Status = "active.initial_credit_grant"
+	StatusActivePaymentAuthorized        Status = "active.payment.authorized"
+	StatusActivePaymentSettled           Status = "active.payment.settled"
+	StatusActivePaymentPaidAndAuthorized Status = "active.payment.paid_and_authorized"
+	StatusFinal                          Status = Status(meta.ChargeStatusFinal)
+	StatusDeleted                        Status = Status(meta.ChargeStatusDeleted)
 )
 
 func (Status) Values() []string {
 	return []string{
 		string(StatusCreated),
 		string(StatusActive),
+		string(StatusActivePaymentPending),
+		string(StatusActivePaymentAuthorized),
 		string(StatusFinal),
 		string(StatusDeleted),
 	}
@@ -38,5 +45,5 @@ func (s Status) ToMetaChargeStatus() (meta.ChargeStatus, error) {
 		return meta.ChargeStatusCreated, err
 	}
 
-	return meta.ChargeStatus(s), nil
+	return meta.DetailedStatusToMetaStatus(string(s))
 }

--- a/openmeter/billing/charges/flatfee/statemachine.go
+++ b/openmeter/billing/charges/flatfee/statemachine.go
@@ -3,7 +3,6 @@ package flatfee
 import (
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -53,15 +52,5 @@ func (s Status) ToMetaChargeStatus() (meta.ChargeStatus, error) {
 		return meta.ChargeStatusCreated, err
 	}
 
-	split := strings.SplitN(string(s), ".", 2)
-	if len(split) == 0 {
-		return meta.ChargeStatusCreated, fmt.Errorf("invalid status: %s", s)
-	}
-
-	metaStatus := meta.ChargeStatus(split[0])
-	if err := metaStatus.Validate(); err != nil {
-		return meta.ChargeStatusCreated, fmt.Errorf("invalid status: %s", s)
-	}
-
-	return metaStatus, nil
+	return meta.DetailedStatusToMetaStatus(string(s))
 }

--- a/openmeter/billing/charges/meta/charge.go
+++ b/openmeter/billing/charges/meta/charge.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -124,6 +125,15 @@ func (s ChargeStatus) Validate() error {
 	}
 
 	return nil
+}
+
+func DetailedStatusToMetaStatus(status string) (ChargeStatus, error) {
+	metaStatus := ChargeStatus(strings.SplitN(status, ".", 2)[0])
+	if err := metaStatus.Validate(); err != nil {
+		return ChargeStatusCreated, fmt.Errorf("invalid status: %s", status)
+	}
+
+	return metaStatus, nil
 }
 
 type Charge struct {

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -335,38 +335,42 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 		},
 	)
 
-	// First the initiated callback should be called, without any grant realizations or payment settlements
+	// The initiated callback is invoked before the payment lifecycle starts, so the
+	// purchased credits are available while the external payment is still pending.
 	initiatedCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
 	s.CreditPurchaseTestHandler.onCreditPurchaseInitiated = initiatedCallback.Handler(s.T(), func(t *testing.T, charge creditpurchase.Charge) {
 		assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeExternal)
 		assert.Nil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should not be set")
 		assert.Nil(t, charge.Realizations.ExternalPaymentSettlement, "external payment settlement should not be set")
+		assert.Equal(t, creditpurchase.StatusActiveInitialCreditGrant, charge.Status, "charge status should be initial credit grant")
 	})
 
-	// Then the authorized callback should be called, with a grant realization and no payment settlement.
-	// Direct paid transitions authorize first, before settlement advances the charge to final.
+	// Then the authorized callback should be called in the direct-paid authorization state,
+	// with the credit grant realization and no payment settlement.
 	authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
 	s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
 		charge := input.Charge
 		assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeExternal)
 		assert.NotNil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should be set")
-		assert.Equal(t, initiatedCallback.id, charge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
+		assert.Equal(t, initiatedCallback.id, charge.Realizations.CreditGrantRealization.TransactionGroupID)
 		assert.Nil(t, charge.Realizations.ExternalPaymentSettlement)
-		assert.Equal(t, creditpurchase.StatusActivePaymentAuthorized, charge.Status, "charge status should be payment authorized")
+		assert.Equal(t, creditpurchase.StatusActivePaymentPaidAndAuthorized, charge.Status, "charge status should be paid and authorized")
 	})
 
-	// Then the settled callback should be called, with a grant realization and a payment settlement.
-	// The settlement handler receives the authorized charge before the transition is finalized.
+	// Then the settled callback should be called in the settlement state with a grant
+	// realization and a payment settlement.
 	settledCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
 	s.CreditPurchaseTestHandler.onCreditPurchasePaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
 		charge := input.Charge
 		assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeExternal)
+		assert.NotNil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should be set")
+		assert.Equal(t, initiatedCallback.id, charge.Realizations.CreditGrantRealization.TransactionGroupID)
 		assert.NotNil(t, charge.Realizations.ExternalPaymentSettlement, "external payment settlement should be set")
 
 		// Authorized transaction group ID should be set
 		assert.Equal(t, authorizedCallback.id, charge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
 		assert.Equal(t, payment.StatusAuthorized, charge.Realizations.ExternalPaymentSettlement.Status)
-		assert.Equal(t, creditpurchase.StatusActivePaymentAuthorized, charge.Status, "charge status should be payment authorized")
+		assert.Equal(t, creditpurchase.StatusActivePaymentSettled, charge.Status, "charge status should be payment settled")
 	})
 	res, err := s.Charges.Create(ctx, charges.CreateInput{
 		Namespace: ns,
@@ -378,7 +382,6 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 	s.Len(res, 1)
 	s.Equal(meta.ChargeTypeCreditPurchase, res[0].Type())
 
-	// All callback should have been invoked only once
 	s.Equal(1, initiatedCallback.nrInvocations)
 	s.Equal(1, authorizedCallback.nrInvocations)
 	s.Equal(1, settledCallback.nrInvocations)
@@ -394,12 +397,11 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 		{name: "db", charge: dbCharge},
 	} {
 		s.Run(tc.name, func() {
-			// The charge should have a grant realization and a payment settlement
+			// The charge should have both a grant and a payment settlement.
 			creditPurchaseCharge, err := tc.charge.AsCreditPurchaseCharge()
 			s.NoError(err)
-			// Credit grant realization should be set
-			s.NotNil(creditPurchaseCharge.Realizations.CreditGrantRealization)
-			s.Equal(initiatedCallback.id, creditPurchaseCharge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
+			s.NotNil(creditPurchaseCharge.Realizations.CreditGrantRealization, "credit grant realization should be set")
+			s.Equal(initiatedCallback.id, creditPurchaseCharge.Realizations.CreditGrantRealization.TransactionGroupID)
 
 			// Payment settlement should be set
 			s.NotNil(creditPurchaseCharge.Realizations.ExternalPaymentSettlement, "external payment settlement should be set")
@@ -447,12 +449,13 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySe
 	s.Run("initiated", func() {
 		defer s.CreditPurchaseTestHandler.Reset()
 
-		// First the initiated callback should be called, without any grant realizations or payment settlements
+		// The initiated callback creates the credit grant before payment is authorized.
 		initatedCallback := newCountedLedgerTransactionCallback[creditpurchase.Charge]()
 		s.CreditPurchaseTestHandler.onCreditPurchaseInitiated = initatedCallback.Handler(s.T(), func(t *testing.T, charge creditpurchase.Charge) {
 			assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeExternal)
 			assert.Nil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should not be set")
 			assert.Nil(t, charge.Realizations.ExternalPaymentSettlement, "external payment settlement should not be set")
+			assert.Equal(t, creditpurchase.StatusActiveInitialCreditGrant, charge.Status, "charge status should be initial credit grant")
 		})
 
 		res, err := s.Charges.Create(ctx, charges.CreateInput{
@@ -468,7 +471,8 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySe
 		creditPurchaseCharge, err := res[0].AsCreditPurchaseCharge()
 		s.NoError(err)
 		s.Equal(1, initatedCallback.nrInvocations)
-		s.Equal(initatedCallback.id, creditPurchaseCharge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
+		s.NotNil(creditPurchaseCharge.Realizations.CreditGrantRealization)
+		s.Equal(initatedCallback.id, creditPurchaseCharge.Realizations.CreditGrantRealization.TransactionGroupID)
 		s.Equal(creditpurchase.StatusActivePaymentPending, creditPurchaseCharge.Status)
 
 		chargeID = creditPurchaseCharge.GetChargeID()
@@ -485,7 +489,7 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySe
 			charge := input.Charge
 			assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeExternal)
 			assert.NotNil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should be set")
-			assert.Equal(t, initatedTrnsID, charge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
+			assert.Equal(t, initatedTrnsID, charge.Realizations.CreditGrantRealization.TransactionGroupID)
 			assert.Nil(t, charge.Realizations.ExternalPaymentSettlement)
 			assert.Equal(t, creditpurchase.StatusActivePaymentAuthorized, charge.Status, "charge status should be payment authorized")
 		})
@@ -507,18 +511,19 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySe
 	s.Run("settled", func() {
 		defer s.CreditPurchaseTestHandler.Reset()
 
-		// Then the settled callback should be called, with a grant realization and a payment settlement.
-		// The handler receives the authorized charge before the transition is finalized.
+		// Then the settled callback should be called in the settlement state with a payment settlement.
 		settledCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
 		s.CreditPurchaseTestHandler.onCreditPurchasePaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
 			charge := input.Charge
 			assert.Equal(t, charge.Intent.Settlement.Type(), creditpurchase.SettlementTypeExternal)
+			assert.NotNil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should be set")
+			assert.Equal(t, initatedTrnsID, charge.Realizations.CreditGrantRealization.TransactionGroupID)
 			assert.NotNil(t, charge.Realizations.ExternalPaymentSettlement, "external payment settlement should be set")
 
 			// Authorized transaction group ID should be set
 			assert.Equal(t, authorizedTrnsID, charge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
 			assert.Equal(t, payment.StatusAuthorized, charge.Realizations.ExternalPaymentSettlement.Status)
-			assert.Equal(t, creditpurchase.StatusActivePaymentAuthorized, charge.Status, "charge status should be payment authorized")
+			assert.Equal(t, creditpurchase.StatusActivePaymentSettled, charge.Status, "charge status should be payment settled")
 		})
 		res, err := s.Charges.HandleCreditPurchaseExternalPaymentStateTransition(ctx, charges.HandleCreditPurchaseExternalPaymentStateTransitionInput{
 			ChargeID:           chargeID,

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 	billingtest "github.com/openmeterio/openmeter/test/billing"
 )
@@ -155,6 +156,106 @@ func (s *CreditPurchaseTestSuite) TestCreditPurchaseRejectsMismatchedSettlementC
 	}
 }
 
+func (s *CreditPurchaseTestSuite) TestCreditPurchaseRejectsNonPositiveSettlementCostBasisBeforeCallbacks() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-service-credit-purchase-non-positive-cost-basis")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	s.NotEmpty(cust.ID)
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+
+	for _, tc := range []struct {
+		name       string
+		settlement creditpurchase.Settlement
+	}{
+		{
+			name: "external zero",
+			settlement: creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{
+				InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
+				GenericSettlement: creditpurchase.GenericSettlement{
+					Currency:  USD,
+					CostBasis: alpacadecimal.Zero,
+				},
+			}),
+		},
+		{
+			name: "external negative",
+			settlement: creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{
+				InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
+				GenericSettlement: creditpurchase.GenericSettlement{
+					Currency:  USD,
+					CostBasis: alpacadecimal.NewFromFloat(-0.5),
+				},
+			}),
+		},
+		{
+			name: "invoice zero",
+			settlement: creditpurchase.NewSettlement(creditpurchase.InvoiceSettlement{
+				GenericSettlement: creditpurchase.GenericSettlement{
+					Currency:  USD,
+					CostBasis: alpacadecimal.Zero,
+				},
+			}),
+		},
+		{
+			name: "invoice negative",
+			settlement: creditpurchase.NewSettlement(creditpurchase.InvoiceSettlement{
+				GenericSettlement: creditpurchase.GenericSettlement{
+					Currency:  USD,
+					CostBasis: alpacadecimal.NewFromFloat(-0.5),
+				},
+			}),
+		},
+	} {
+		s.Run(tc.name, func() {
+			// given:
+			// - a credit-purchase intent with a non-positive external or invoice cost basis
+			// when:
+			// - charge creation validates the intent
+			// then:
+			// - it fails before lifecycle callbacks or charge persistence can run
+			intent := charges.NewChargeIntent(creditpurchase.Intent{
+				Intent: meta.Intent{
+					Name:              "Credit Purchase",
+					ManagedBy:         billing.ManuallyManagedLine,
+					CustomerID:        cust.ID,
+					Currency:          USD,
+					ServicePeriod:     servicePeriod,
+					BillingPeriod:     servicePeriod,
+					FullServicePeriod: servicePeriod,
+				},
+				CreditAmount: alpacadecimal.NewFromFloat(100),
+				Settlement:   tc.settlement,
+			})
+
+			res, err := s.Charges.Create(ctx, charges.CreateInput{
+				Namespace: ns,
+				Intents: charges.ChargeIntents{
+					intent,
+				},
+			})
+
+			s.Error(err)
+			s.True(models.IsGenericValidationError(err))
+			s.ErrorContains(err, "cost basis must be positive")
+			s.Empty(res)
+
+			chargesResult, err := s.Charges.ListCharges(ctx, charges.ListChargesInput{
+				Namespace:   ns,
+				CustomerIDs: []string{cust.ID},
+				ChargeTypes: []meta.ChargeType{meta.ChargeTypeCreditPurchase},
+			})
+			s.NoError(err)
+			s.Empty(chargesResult.Items)
+		})
+	}
+}
+
 type createCreditPurchaseIntentInput struct {
 	customer      customer.CustomerID
 	currency      currencyx.Code
@@ -242,7 +343,8 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 		assert.Nil(t, charge.Realizations.ExternalPaymentSettlement, "external payment settlement should not be set")
 	})
 
-	// Then the authorized callback should be called, with a grant realization and no payment settlement
+	// Then the authorized callback should be called, with a grant realization and no payment settlement.
+	// Direct paid transitions authorize first, before settlement advances the charge to final.
 	authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
 	s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
 		charge := input.Charge
@@ -250,10 +352,11 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 		assert.NotNil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should be set")
 		assert.Equal(t, initiatedCallback.id, charge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
 		assert.Nil(t, charge.Realizations.ExternalPaymentSettlement)
-		assert.Equal(t, creditpurchase.StatusActive, charge.Status, "charge status should be active")
+		assert.Equal(t, creditpurchase.StatusActivePaymentAuthorized, charge.Status, "charge status should be payment authorized")
 	})
 
-	// Then the settled callback should be called, with a grant realization and a payment settlement
+	// Then the settled callback should be called, with a grant realization and a payment settlement.
+	// The settlement handler receives the authorized charge before the transition is finalized.
 	settledCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
 	s.CreditPurchaseTestHandler.onCreditPurchasePaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
 		charge := input.Charge
@@ -263,7 +366,7 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 		// Authorized transaction group ID should be set
 		assert.Equal(t, authorizedCallback.id, charge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
 		assert.Equal(t, payment.StatusAuthorized, charge.Realizations.ExternalPaymentSettlement.Status)
-		assert.Equal(t, creditpurchase.StatusActive, charge.Status, "charge status should be active")
+		assert.Equal(t, creditpurchase.StatusActivePaymentAuthorized, charge.Status, "charge status should be payment authorized")
 	})
 	res, err := s.Charges.Create(ctx, charges.CreateInput{
 		Namespace: ns,
@@ -366,7 +469,7 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySe
 		s.NoError(err)
 		s.Equal(1, initatedCallback.nrInvocations)
 		s.Equal(initatedCallback.id, creditPurchaseCharge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
-		s.Equal(creditpurchase.StatusActive, creditPurchaseCharge.Status)
+		s.Equal(creditpurchase.StatusActivePaymentPending, creditPurchaseCharge.Status)
 
 		chargeID = creditPurchaseCharge.GetChargeID()
 		initatedTrnsID = initatedCallback.id
@@ -375,7 +478,8 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySe
 	s.Run("authorized", func() {
 		defer s.CreditPurchaseTestHandler.Reset()
 
-		// Then the authorized callback should be called, with a grant realization and no payment settlement
+		// Then the authorized callback should be called, with a grant realization and no payment settlement.
+		// The handler receives the charge after the authorized transition has entered its destination state.
 		authorizedCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
 		s.CreditPurchaseTestHandler.onCreditPurchasePaymentAuthorized = authorizedCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
 			charge := input.Charge
@@ -383,7 +487,7 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySe
 			assert.NotNil(t, charge.Realizations.CreditGrantRealization, "credit grant realization should be set")
 			assert.Equal(t, initatedTrnsID, charge.Realizations.CreditGrantRealization.GroupReference.TransactionGroupID)
 			assert.Nil(t, charge.Realizations.ExternalPaymentSettlement)
-			assert.Equal(t, creditpurchase.StatusActive, charge.Status, "charge status should be active")
+			assert.Equal(t, creditpurchase.StatusActivePaymentAuthorized, charge.Status, "charge status should be payment authorized")
 		})
 
 		res, err := s.Charges.HandleCreditPurchaseExternalPaymentStateTransition(ctx, charges.HandleCreditPurchaseExternalPaymentStateTransitionInput{
@@ -395,7 +499,7 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySe
 		s.Equal(1, authorizedCallback.nrInvocations)
 		s.Equal(authorizedCallback.id, res.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
 		s.Equal(payment.StatusAuthorized, res.Realizations.ExternalPaymentSettlement.Status)
-		s.Equal(creditpurchase.StatusActive, res.Status)
+		s.Equal(creditpurchase.StatusActivePaymentAuthorized, res.Status)
 
 		authorizedTrnsID = authorizedCallback.id
 	})
@@ -403,7 +507,8 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySe
 	s.Run("settled", func() {
 		defer s.CreditPurchaseTestHandler.Reset()
 
-		// Then the settled callback should be called, with a grant realization and a payment settlement
+		// Then the settled callback should be called, with a grant realization and a payment settlement.
+		// The handler receives the authorized charge before the transition is finalized.
 		settledCallback := newCountedLedgerTransactionCallback[creditpurchase.PaymentEventInput]()
 		s.CreditPurchaseTestHandler.onCreditPurchasePaymentSettled = settledCallback.Handler(s.T(), func(t *testing.T, input creditpurchase.PaymentEventInput) {
 			charge := input.Charge
@@ -413,7 +518,7 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySe
 			// Authorized transaction group ID should be set
 			assert.Equal(t, authorizedTrnsID, charge.Realizations.ExternalPaymentSettlement.Authorized.TransactionGroupID)
 			assert.Equal(t, payment.StatusAuthorized, charge.Realizations.ExternalPaymentSettlement.Status)
-			assert.Equal(t, creditpurchase.StatusActive, charge.Status, "charge status should be active")
+			assert.Equal(t, creditpurchase.StatusActivePaymentAuthorized, charge.Status, "charge status should be payment authorized")
 		})
 		res, err := s.Charges.HandleCreditPurchaseExternalPaymentStateTransition(ctx, charges.HandleCreditPurchaseExternalPaymentStateTransitionInput{
 			ChargeID:           chargeID,

--- a/openmeter/billing/charges/usagebased/statemachine.go
+++ b/openmeter/billing/charges/usagebased/statemachine.go
@@ -3,7 +3,6 @@ package usagebased
 import (
 	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/pkg/models"
@@ -93,15 +92,5 @@ func (s Status) ToMetaChargeStatus() (meta.ChargeStatus, error) {
 		return meta.ChargeStatusCreated, err
 	}
 
-	split := strings.SplitN(string(s), ".", 2)
-	if len(split) == 0 {
-		return meta.ChargeStatusCreated, fmt.Errorf("invalid status: %s", s)
-	}
-
-	metaStatus := meta.ChargeStatus(split[0])
-	if err := metaStatus.Validate(); err != nil {
-		return meta.ChargeStatusCreated, fmt.Errorf("invalid status: %s", s)
-	}
-
-	return metaStatus, nil
+	return meta.DetailedStatusToMetaStatus(string(s))
 }

--- a/openmeter/ent/db/chargecreditpurchase/chargecreditpurchase.go
+++ b/openmeter/ent/db/chargecreditpurchase/chargecreditpurchase.go
@@ -272,7 +272,7 @@ func TaxBehaviorValidator(tb productcatalog.TaxBehavior) error {
 // StatusDetailedValidator is a validator for the "status_detailed" field enum values. It is called by the builders before save.
 func StatusDetailedValidator(sd creditpurchase.Status) error {
 	switch sd {
-	case "created", "active", "final", "deleted":
+	case "created", "active", "active.payment.pending", "active.payment.authorized", "final", "deleted":
 		return nil
 	default:
 		return fmt.Errorf("chargecreditpurchase: invalid enum value for status_detailed field: %q", sd)

--- a/openmeter/ent/db/chargecreditpurchase/chargecreditpurchase.go
+++ b/openmeter/ent/db/chargecreditpurchase/chargecreditpurchase.go
@@ -272,7 +272,7 @@ func TaxBehaviorValidator(tb productcatalog.TaxBehavior) error {
 // StatusDetailedValidator is a validator for the "status_detailed" field enum values. It is called by the builders before save.
 func StatusDetailedValidator(sd creditpurchase.Status) error {
 	switch sd {
-	case "created", "active", "active.payment.pending", "active.payment.authorized", "final", "deleted":
+	case "created", "active", "active.initial_credit_grant", "active.payment.pending", "active.payment.authorized", "active.payment.paid_and_authorized", "active.payment.settled", "final", "deleted":
 		return nil
 	default:
 		return fmt.Errorf("chargecreditpurchase: invalid enum value for status_detailed field: %q", sd)

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1676,7 +1676,7 @@ var (
 		{Name: "priority", Type: field.TypeInt, Nullable: true},
 		{Name: "feature_filters", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "text[]"}},
 		{Name: "settlement", Type: field.TypeString, SchemaType: map[string]string{"postgres": "jsonb"}},
-		{Name: "status_detailed", Type: field.TypeEnum, Enums: []string{"created", "active", "final", "deleted"}},
+		{Name: "status_detailed", Type: field.TypeEnum, Enums: []string{"created", "active", "active.payment.pending", "active.payment.authorized", "final", "deleted"}},
 		{Name: "customer_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "subscription_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "subscription_item_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -1676,7 +1676,7 @@ var (
 		{Name: "priority", Type: field.TypeInt, Nullable: true},
 		{Name: "feature_filters", Type: field.TypeOther, Nullable: true, SchemaType: map[string]string{"postgres": "text[]"}},
 		{Name: "settlement", Type: field.TypeString, SchemaType: map[string]string{"postgres": "jsonb"}},
-		{Name: "status_detailed", Type: field.TypeEnum, Enums: []string{"created", "active", "active.payment.pending", "active.payment.authorized", "final", "deleted"}},
+		{Name: "status_detailed", Type: field.TypeEnum, Enums: []string{"created", "active", "active.initial_credit_grant", "active.payment.pending", "active.payment.authorized", "active.payment.paid_and_authorized", "active.payment.settled", "final", "deleted"}},
 		{Name: "customer_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "subscription_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "subscription_item_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},

--- a/test/credits/creditgrant_test.go
+++ b/test/credits/creditgrant_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/openmeterio/openmeter/openmeter/app"
@@ -22,6 +23,7 @@ import (
 	creditgrantservice "github.com/openmeterio/openmeter/openmeter/billing/creditgrant/service"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
 	ledgerbreakage "github.com/openmeterio/openmeter/openmeter/ledger/breakage"
 	ledgerchargeadapter "github.com/openmeterio/openmeter/openmeter/ledger/chargeadapter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
@@ -243,7 +245,7 @@ func (s *CreditGrantTestSuite) TestCreateExternalGrantAndSettle() {
 	s.Require().NoError(err)
 
 	s.Equal(creditpurchase.SettlementTypeExternal, grant.Intent.Settlement.Type())
-	s.Equal(creditpurchase.StatusActive, grant.Status)
+	s.Equal(creditpurchase.StatusActivePaymentPending, grant.Status)
 	s.NotNil(grant.Realizations.CreditGrantRealization)
 	s.Nil(grant.Realizations.ExternalPaymentSettlement)
 
@@ -254,7 +256,7 @@ func (s *CreditGrantTestSuite) TestCreateExternalGrantAndSettle() {
 		TargetStatus: payment.StatusAuthorized,
 	})
 	s.Require().NoError(err)
-	s.Equal(creditpurchase.StatusActive, grant.Status)
+	s.Equal(creditpurchase.StatusActivePaymentAuthorized, grant.Status)
 	s.NotNil(grant.Realizations.ExternalPaymentSettlement)
 	s.Equal(payment.StatusAuthorized, grant.Realizations.ExternalPaymentSettlement.Status)
 
@@ -269,6 +271,95 @@ func (s *CreditGrantTestSuite) TestCreateExternalGrantAndSettle() {
 	s.Equal(creditpurchase.StatusFinal, grant.Status)
 	s.NotNil(grant.Realizations.ExternalPaymentSettlement)
 	s.Equal(payment.StatusSettled, grant.Realizations.ExternalPaymentSettlement.Status)
+}
+
+func (s *CreditGrantTestSuite) TestCreateExternalGrantWithSubCentCostBasisAndSettle() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("creditgrant-service-external-sub-cent-cost-basis")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+	sandboxApp := s.InstallSandboxApp(s.T(), ns)
+	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
+
+	now := datetime.MustParseTimeInLocation(s.T(), "2026-04-17T11:23:53Z", time.UTC).AsTime()
+	clock.SetTime(now)
+
+	creditAmount := alpacadecimal.NewFromInt(1)
+	costBasis, err := alpacadecimal.NewFromString("0.005")
+	s.Require().NoError(err)
+	priority := int16(20)
+
+	// given:
+	// - an externally funded $1 credit grant with sub-cent per-unit cost basis
+	// when:
+	// - the grant is created before the external payment is authorized
+	// then:
+	// - the credit allocation is visible and backed by an open receivable
+	grant, err := s.CreditGrantService.Create(ctx, creditgrant.CreateInput{
+		Namespace:     ns,
+		CustomerID:    cust.ID,
+		Name:          "$1.00 external grant with sub-cent cost basis",
+		Description:   lo.ToPtr("External credit grant with sub-cent cost basis"),
+		Currency:      USD,
+		Amount:        creditAmount,
+		Priority:      lo.ToPtr(priority),
+		FundingMethod: creditgrant.FundingMethodExternal,
+		Purchase: &creditgrant.PurchaseTerms{
+			Currency:           USD,
+			PerUnitCostBasis:   lo.ToPtr(costBasis),
+			AvailabilityPolicy: lo.ToPtr(creditpurchase.CreatedInitialPaymentSettlementStatus),
+		},
+	})
+	s.Require().NoError(err)
+
+	s.Equal(creditpurchase.SettlementTypeExternal, grant.Intent.Settlement.Type())
+	s.Equal(creditpurchase.StatusActivePaymentPending, grant.Status)
+	s.NotNil(grant.Realizations.CreditGrantRealization)
+	s.Nil(grant.Realizations.ExternalPaymentSettlement)
+	s.AssertDecimalEqual(creditAmount, s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&costBasis), int(priority)), "created grant should allocate credits")
+	s.AssertDecimalEqual(creditAmount.Neg(), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusOpen), "created grant should book an open receivable")
+	s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusAuthorized), "created grant should not book authorized receivable")
+	s.AssertDecimalEqual(alpacadecimal.Zero, s.MustWashBalance(ns, USD, mo.Some(&costBasis)), "created grant should not book wash")
+
+	// when:
+	// - the external payment is authorized
+	// then:
+	// - the receivable moves from open to authorized while credits stay allocated
+	grant, err = s.CreditGrantService.UpdateExternalSettlement(ctx, creditgrant.UpdateExternalSettlementInput{
+		Namespace:    ns,
+		CustomerID:   cust.ID,
+		ChargeID:     grant.ID,
+		TargetStatus: payment.StatusAuthorized,
+	})
+	s.Require().NoError(err)
+	s.Equal(creditpurchase.StatusActivePaymentAuthorized, grant.Status)
+	s.NotNil(grant.Realizations.ExternalPaymentSettlement)
+	s.Equal(payment.StatusAuthorized, grant.Realizations.ExternalPaymentSettlement.Status)
+	s.AssertDecimalEqual(creditAmount, s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&costBasis), int(priority)), "authorized grant should keep credits allocated")
+	s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusOpen), "authorized grant should clear open receivable")
+	s.AssertDecimalEqual(creditAmount.Neg(), s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusAuthorized), "authorized grant should book authorized receivable")
+	s.AssertDecimalEqual(alpacadecimal.Zero, s.MustWashBalance(ns, USD, mo.Some(&costBasis)), "authorized grant should not book wash")
+
+	// when:
+	// - the external payment is settled
+	// then:
+	// - the charge finalizes and the receivable is funded from wash
+	grant, err = s.CreditGrantService.UpdateExternalSettlement(ctx, creditgrant.UpdateExternalSettlementInput{
+		Namespace:    ns,
+		CustomerID:   cust.ID,
+		ChargeID:     grant.ID,
+		TargetStatus: payment.StatusSettled,
+	})
+	s.Require().NoError(err)
+
+	s.Equal(creditpurchase.StatusFinal, grant.Status)
+	s.NotNil(grant.Realizations.ExternalPaymentSettlement)
+	s.Equal(payment.StatusSettled, grant.Realizations.ExternalPaymentSettlement.Status)
+	s.AssertDecimalEqual(creditAmount, s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&costBasis), int(priority)), "settled grant should keep credits allocated")
+	s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusOpen), "settled grant should keep open receivable cleared")
+	s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.Some(&costBasis), ledger.TransactionAuthorizationStatusAuthorized), "settled grant should clear authorized receivable")
+	s.AssertDecimalEqual(creditAmount.Neg(), s.MustWashBalance(ns, USD, mo.Some(&costBasis)), "settled grant should book wash")
 }
 
 func (s *CreditGrantTestSuite) TestListCreditGrants() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved external credit-purchase flow with explicit created → payment-pending → payment-authorized → final transitions and single-step authorize+settle support.
  * Preserves charge state across external purchase realizations and surfaces more detailed payment-phase statuses.

* **Bug Fixes**
  * Reject non-positive settlement cost basis with clearer validation errors.
  * More robust error handling and consistent rounding for external purchase and payment flows.

* **Tests**
  * Expanded unit tests covering lifecycle paths, rounding, validation, duplicate-authorization guards, and adapter/realization side effects.

* **Documentation**
  * Guidance updated for mapping detailed statuses to root meta statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->