### PR TITLE
fix(ledger): hydrate tax behavior

### DIFF
--- a/openmeter/ledger/historical/adapter/ledger.go
+++ b/openmeter/ledger/historical/adapter/ledger.go
@@ -54,6 +54,7 @@ func hydrateHistoricalTransaction(tx *db.LedgerTransaction) (*ledgerhistorical.T
 			Route: ledger.Route{
 				Currency:                       currencyx.Code(route.Currency),
 				TaxCode:                        route.TaxCode,
+				TaxBehavior:                    route.TaxBehavior,
 				Features:                       route.Features,
 				CostBasis:                      route.CostBasis,
 				CreditPriority:                 route.CreditPriority,

--- a/openmeter/ledger/historical/adapter/ledger_test.go
+++ b/openmeter/ledger/historical/adapter/ledger_test.go
@@ -141,6 +141,61 @@ func TestRepo_BookTransaction_CreatesTransactionAndEntries(t *testing.T) {
 	require.Equal(t, "", entriesBySubAccountFromTx[subAccountB.ID].IdentityKey())
 }
 
+func TestRepo_GetTransactionGroup_PreservesTaxBehavior(t *testing.T) {
+	env := NewTestEnv(t)
+	t.Cleanup(func() {
+		env.Close(t)
+	})
+	env.DBSchemaMigrate(t)
+
+	ctx := t.Context()
+	namespace := testNamespace()
+	taxCode := "tax-code"
+	taxBehavior := ledger.TaxBehaviorInclusive
+	route := ledger.Route{
+		Currency:    currencyx.Code("USD"),
+		TaxCode:     &taxCode,
+		TaxBehavior: &taxBehavior,
+	}
+	accruedSubAccount := env.createSubAccountOfType(t, namespace, ledger.AccountTypeCustomerAccrued, route)
+	earningsSubAccount := env.createSubAccountOfType(t, namespace, ledger.AccountTypeEarnings, route)
+
+	group, err := env.repo.CreateTransactionGroup(ctx, ledgerhistorical.CreateTransactionGroupInput{
+		Namespace: namespace,
+	})
+	require.NoError(t, err)
+
+	txInput := mustSetUpHistoricalTransactionInput(t, time.Now().UTC(), []*transactionstestutils.AnyEntryInput{
+		{
+			Address:     testAddress(t, accruedSubAccount),
+			AmountValue: alpacadecimal.NewFromInt(-10),
+		},
+		{
+			Address:     testAddress(t, earningsSubAccount),
+			AmountValue: alpacadecimal.NewFromInt(10),
+		},
+	})
+	_, err = env.repo.BookTransaction(ctx, models.NamespacedID{
+		Namespace: namespace,
+		ID:        group.ID,
+	}, txInput)
+	require.NoError(t, err)
+
+	hydratedGroup, err := env.repo.GetTransactionGroup(ctx, models.NamespacedID{
+		Namespace: namespace,
+		ID:        group.ID,
+	})
+	require.NoError(t, err)
+	require.Len(t, hydratedGroup.Transactions(), 1)
+
+	for _, entry := range hydratedGroup.Transactions()[0].Entries() {
+		hydratedRoute := entry.PostingAddress().Route().Route()
+		require.NotNil(t, hydratedRoute.TaxBehavior)
+		require.Equal(t, taxBehavior, *hydratedRoute.TaxBehavior)
+		require.Equal(t, ledger.RoutingKeyVersionV2, entry.PostingAddress().Route().RoutingKey().Version())
+	}
+}
+
 func TestRepo_BookTransaction_NilInput(t *testing.T) {
 	env := NewTestEnv(t)
 	t.Cleanup(func() {
@@ -982,11 +1037,17 @@ func (e *TestEnv) Close(t *testing.T) {
 func (e *TestEnv) createSubAccount(t *testing.T, namespace string, route ledger.Route) *ledgeraccount.SubAccountData {
 	t.Helper()
 
+	return e.createSubAccountOfType(t, namespace, ledger.AccountTypeCustomerFBO, route)
+}
+
+func (e *TestEnv) createSubAccountOfType(t *testing.T, namespace string, accountType ledger.AccountType, route ledger.Route) *ledgeraccount.SubAccountData {
+	t.Helper()
+
 	ctx := t.Context()
 
 	acc, err := e.accountRepo.CreateAccount(ctx, ledgeraccount.CreateAccountInput{
 		Namespace: namespace,
-		Type:      ledger.AccountTypeCustomerFBO,
+		Type:      accountType,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- hydrate TaxBehavior when rebuilding historical ledger transaction entries
- add a focused GetTransactionGroup regression test for v2 tax-behavior routes

## Tests
- nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go vet -tags=dynamic ./openmeter/ledger/historical/adapter
- nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/ledger/historical/adapter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a data integrity issue where tax behavior configuration was not properly preserved when retrieving historical transaction records, ensuring consistent and accurate tax handling.

* **Tests**
  * Added test coverage to validate that tax behavior settings are correctly maintained in historical transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->