### PR TITLE
fix(ledger): lock accrued account postings

### DIFF
--- a/openmeter/ledger/account/service/service.go
+++ b/openmeter/ledger/account/service/service.go
@@ -125,7 +125,7 @@ func (s *service) LockAccountsForPosting(ctx context.Context, accounts []ledger.
 		}
 
 		switch acc.Type() {
-		case ledger.AccountTypeCustomerFBO, ledger.AccountTypeCustomerReceivable:
+		case ledger.AccountTypeCustomerFBO, ledger.AccountTypeCustomerReceivable, ledger.AccountTypeCustomerAccrued:
 			byID[acc.ID()] = acc
 		}
 	}


### PR DESCRIPTION
## Summary
- include customer accrued accounts in ledger posting advisory locks
- keeps accrued-to-earnings recognition serialized through the existing posting lock path

## Verification
- nix develop --impure .#ci -c go vet ./openmeter/ledger/account/service
- nix develop --impure .#ci -c go test -tags=dynamic ./openmeter/ledger/account/service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account locking behavior during posting operations to handle additional account types consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->