### PR TITLE
feat: improve redis dedupe failover handling [poc]

### DIFF
--- a/app/common/openmeter_sinkworker.go
+++ b/app/common/openmeter_sinkworker.go
@@ -192,11 +192,16 @@ func NewSink(
 		NamespaceTopicRegexp:    conf.NamespaceTopicRegexp,
 		FlushEventHandler:       flushHandler,
 		FlushSuccessTimeout:     conf.FlushSuccessTimeout,
-		DrainTimeout:            conf.DrainTimeout,
-		TopicResolver:           topicResolver,
-		MeterRefetchInterval:    conf.MeterRefetchInterval,
-		MeterService:            meterService,
-		LogDroppedEvents:        conf.LogDroppedEvents,
+		DedupeWriteTimeout:      conf.DedupeWriteTimeout,
+		DedupeWriteRetry: sink.DedupeWriteRetryConfig{
+			InitialInterval: conf.DedupeWriteRetry.InitialInterval,
+			MaxInterval:     conf.DedupeWriteRetry.MaxInterval,
+		},
+		DrainTimeout:         conf.DrainTimeout,
+		TopicResolver:        topicResolver,
+		MeterRefetchInterval: conf.MeterRefetchInterval,
+		MeterService:         meterService,
+		LogDroppedEvents:     conf.LogDroppedEvents,
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to initialize sink: %w", err)

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -194,12 +194,17 @@ func TestComplete(t *testing.T) {
 			FeatureFlag:             "",
 		},
 		Sink: SinkConfiguration{
-			GroupId:                 "openmeter-sink-worker",
-			MinCommitCount:          500,
-			MaxCommitWait:           30 * time.Second,
-			MaxPollTimeout:          100 * time.Millisecond,
-			NamespaceRefetch:        15 * time.Second,
-			FlushSuccessTimeout:     5 * time.Second,
+			GroupId:             "openmeter-sink-worker",
+			MinCommitCount:      500,
+			MaxCommitWait:       30 * time.Second,
+			MaxPollTimeout:      100 * time.Millisecond,
+			NamespaceRefetch:    15 * time.Second,
+			FlushSuccessTimeout: 5 * time.Second,
+			DedupeWriteTimeout:  90 * time.Second,
+			DedupeWriteRetry: DedupeWriteRetryConfiguration{
+				InitialInterval: 100 * time.Millisecond,
+				MaxInterval:     30 * time.Second,
+			},
 			DrainTimeout:            10 * time.Second,
 			NamespaceRefetchTimeout: 9 * time.Second,
 			NamespaceTopicRegexp:    "^om_test_([A-Za-z0-9]+(?:_[A-Za-z0-9]+)*)_events$",
@@ -208,10 +213,18 @@ func TestComplete(t *testing.T) {
 				Enabled: true,
 				DedupeDriverConfiguration: DedupeDriverRedisConfiguration{
 					Config: redis.Config{
-						Address:  "127.0.0.1:6379",
-						Database: 0,
-						Username: "default",
-						Password: "pass",
+						Address:    "127.0.0.1:6379",
+						Database:   0,
+						Username:   "default",
+						Password:   "pass",
+						PoolSize:   3,
+						MaxRetries: 3,
+
+						DialTimeout:     5 * time.Second,
+						ReadTimeout:     3 * time.Second,
+						WriteTimeout:    3 * time.Second,
+						PoolTimeout:     4 * time.Second,
+						ConnMaxIdleTime: 30 * time.Minute,
 
 						TLS: struct {
 							Enabled            bool
@@ -268,10 +281,18 @@ func TestComplete(t *testing.T) {
 			Enabled: true,
 			DedupeDriverConfiguration: DedupeDriverRedisConfiguration{
 				Config: redis.Config{
-					Address:  "127.0.0.1:6379",
-					Database: 0,
-					Username: "default",
-					Password: "pass",
+					Address:    "127.0.0.1:6379",
+					Database:   0,
+					Username:   "default",
+					Password:   "pass",
+					PoolSize:   3,
+					MaxRetries: 3,
+
+					DialTimeout:     5 * time.Second,
+					ReadTimeout:     3 * time.Second,
+					WriteTimeout:    3 * time.Second,
+					PoolTimeout:     4 * time.Second,
+					ConnMaxIdleTime: 30 * time.Minute,
 
 					TLS: struct {
 						Enabled            bool
@@ -427,10 +448,19 @@ func TestComplete(t *testing.T) {
 			Enabled:    false,
 			Expiration: 5 * time.Minute,
 			Redis: redis.Config{
-				Address:  "127.0.0.1:6379",
-				Database: 0,
-				Username: "",
-				Password: "",
+				Address:    "127.0.0.1:6379",
+				Database:   0,
+				Username:   "",
+				Password:   "",
+				PoolSize:   3,
+				MaxRetries: 3,
+
+				DialTimeout:     5 * time.Second,
+				ReadTimeout:     3 * time.Second,
+				WriteTimeout:    3 * time.Second,
+				PoolTimeout:     4 * time.Second,
+				ConnMaxIdleTime: 30 * time.Minute,
+
 				TLS: struct {
 					Enabled            bool
 					InsecureSkipVerify bool

--- a/app/config/dedupe.go
+++ b/app/config/dedupe.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/mapstructure"
+	goredis "github.com/redis/go-redis/v9"
 	"github.com/spf13/viper"
 
 	"github.com/openmeterio/openmeter/openmeter/dedupe"
@@ -178,11 +179,9 @@ func (c DedupeDriverRedisConfiguration) NewDeduplicator() (dedupe.Deduplicator, 
 	}
 
 	// TODO: register health check for redis
-	return redisdedupe.Deduplicator{
-		Redis:      redisClient,
-		Expiration: c.Expiration,
-		Mode:       c.Mode,
-	}, nil
+	return redisdedupe.NewDeduplicator(redisClient, c.Expiration, c.Mode, func() (*goredis.Client, error) {
+		return c.NewClient()
+	}), nil
 }
 
 func (c DedupeDriverRedisConfiguration) Validate() error {

--- a/app/config/sink.go
+++ b/app/config/sink.go
@@ -18,6 +18,8 @@ type SinkConfiguration struct {
 	MaxPollTimeout      time.Duration
 	NamespaceRefetch    time.Duration
 	FlushSuccessTimeout time.Duration
+	DedupeWriteTimeout  time.Duration
+	DedupeWriteRetry    DedupeWriteRetryConfiguration
 	DrainTimeout        time.Duration
 	IngestNotifications IngestNotificationsConfiguration
 	// Kafka client/Consumer configuration
@@ -63,6 +65,14 @@ func (c SinkConfiguration) Validate() error {
 		errs = append(errs, errors.New("FlushSuccessTimeout must be greater than 0"))
 	}
 
+	if c.DedupeWriteTimeout == 0 {
+		errs = append(errs, errors.New("DedupeWriteTimeout must be greater than 0"))
+	}
+
+	if err := c.DedupeWriteRetry.Validate(); err != nil {
+		errs = append(errs, errorsx.WithPrefix(err, "dedupe write retry"))
+	}
+
 	if c.DrainTimeout == 0 {
 		errs = append(errs, errors.New("DrainTimeout must be greater than 0"))
 	}
@@ -85,6 +95,25 @@ func (c SinkConfiguration) Validate() error {
 
 	if c.MeterRefetchInterval <= 0 {
 		errs = append(errs, errors.New("MeterRefetchInterval must be greater than 0"))
+	}
+
+	return errors.Join(errs...)
+}
+
+type DedupeWriteRetryConfiguration struct {
+	InitialInterval time.Duration
+	MaxInterval     time.Duration
+}
+
+func (c DedupeWriteRetryConfiguration) Validate() error {
+	var errs []error
+
+	if c.InitialInterval <= 0 {
+		errs = append(errs, errors.New("initial interval must be greater than 0"))
+	}
+
+	if c.MaxInterval <= 0 {
+		errs = append(errs, errors.New("max interval must be greater than 0"))
 	}
 
 	return errors.Join(errs...)
@@ -151,6 +180,15 @@ func ConfigureSink(v *viper.Viper) {
 	v.SetDefault("sink.dedupe.config.sentinel.masterName", "")
 	v.SetDefault("sink.dedupe.config.tls.enabled", false)
 	v.SetDefault("sink.dedupe.config.tls.insecureSkipVerify", false)
+	v.SetDefault("sink.dedupe.config.poolSize", 3)
+	v.SetDefault("sink.dedupe.config.maxRetries", 3)
+	v.SetDefault("sink.dedupe.config.dialTimeout", "5s")
+	v.SetDefault("sink.dedupe.config.readTimeout", "3s")
+	v.SetDefault("sink.dedupe.config.writeTimeout", "3s")
+	v.SetDefault("sink.dedupe.config.poolTimeout", "4s")
+	v.SetDefault("sink.dedupe.config.connMaxIdleTime", "30m")
+	v.SetDefault("sink.dedupe.config.connMaxLifetime", "0s")
+	v.SetDefault("sink.dedupe.config.connMaxLifetimeJitter", "0s")
 
 	// Sink
 	// FIXME(chrisgacsal): remove as it is deprecated by moving Kafka specific configuration to dedicated config params.
@@ -160,6 +198,9 @@ func ConfigureSink(v *viper.Viper) {
 	v.SetDefault("sink.maxPollTimeout", "100ms")
 	v.SetDefault("sink.namespaceRefetch", "15s")
 	v.SetDefault("sink.flushSuccessTimeout", "5s")
+	v.SetDefault("sink.dedupeWriteTimeout", "90s")
+	v.SetDefault("sink.dedupeWriteRetry.initialInterval", "100ms")
+	v.SetDefault("sink.dedupeWriteRetry.maxInterval", "30s")
 	v.SetDefault("sink.drainTimeout", "10s")
 	v.SetDefault("sink.ingestNotifications.maxEventsInBatch", 50)
 	v.SetDefault("sink.namespaceRefetchTimeout", "10s")

--- a/openmeter/dedupe/redisdedupe/redisdedupe.go
+++ b/openmeter/dedupe/redisdedupe/redisdedupe.go
@@ -5,6 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net"
+	"sync"
+	"syscall"
 	"time"
 
 	"github.com/cloudevents/sdk-go/v2/event"
@@ -29,17 +33,43 @@ func (m DedupeMode) Validate() error {
 	return fmt.Errorf("invalid dedupe mode: %s", m)
 }
 
+type ClientFactory func() (*redis.Client, error)
+
 // Deduplicator implements event deduplication using Redis.
 type Deduplicator struct {
 	Redis      *redis.Client
 	Expiration time.Duration
 	Mode       DedupeMode
+
+	mu        sync.RWMutex
+	newClient ClientFactory
+}
+
+func NewDeduplicator(redisClient *redis.Client, expiration time.Duration, mode DedupeMode, newClient ClientFactory) *Deduplicator {
+	return &Deduplicator{
+		Redis:      redisClient,
+		Expiration: expiration,
+		Mode:       mode,
+		newClient:  newClient,
+	}
+}
+
+func (d *Deduplicator) client() (*redis.Client, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if d.Redis == nil {
+		return nil, errors.New("redis client not initialized")
+	}
+
+	return d.Redis, nil
 }
 
 // IsUnique checks if an event is unique AND adds it to the deduplication index.
-func (d Deduplicator) IsUnique(ctx context.Context, namespace string, ev event.Event) (bool, error) {
-	if d.Redis == nil {
-		return false, errors.New("redis client not initialized")
+func (d *Deduplicator) IsUnique(ctx context.Context, namespace string, ev event.Event) (bool, error) {
+	client, err := d.client()
+	if err != nil {
+		return false, err
 	}
 
 	item := dedupe.Item{
@@ -65,7 +95,7 @@ func (d Deduplicator) IsUnique(ctx context.Context, namespace string, ev event.E
 		if isUnique {
 			// We might have succeeded setting the key only because the key just exist in the old format
 			// Let's check if the old key exists
-			isSet, err := d.Redis.Exists(ctx, item.Key()).Result()
+			isSet, err := client.Exists(ctx, item.Key()).Result()
 			if err != nil {
 				return false, err
 			}
@@ -79,8 +109,13 @@ func (d Deduplicator) IsUnique(ctx context.Context, namespace string, ev event.E
 	return false, fmt.Errorf("unknown status")
 }
 
-func (d Deduplicator) setKey(ctx context.Context, key string) (bool, error) {
-	status, err := d.Redis.SetArgs(ctx, key, "", redis.SetArgs{
+func (d *Deduplicator) setKey(ctx context.Context, key string) (bool, error) {
+	client, err := d.client()
+	if err != nil {
+		return false, err
+	}
+
+	status, err := client.SetArgs(ctx, key, "", redis.SetArgs{
 		TTL:  d.Expiration,
 		Mode: "nx",
 	}).Result()
@@ -104,7 +139,12 @@ func (d Deduplicator) setKey(ctx context.Context, key string) (bool, error) {
 }
 
 // CheckUnique checks if the event is unique based on the key
-func (d Deduplicator) CheckUnique(ctx context.Context, item dedupe.Item) (bool, error) {
+func (d *Deduplicator) CheckUnique(ctx context.Context, item dedupe.Item) (bool, error) {
+	client, err := d.client()
+	if err != nil {
+		return false, err
+	}
+
 	keysToCheck := make([]string, 0, 2)
 	switch d.Mode {
 	case DedupeModeRawKey:
@@ -115,7 +155,7 @@ func (d Deduplicator) CheckUnique(ctx context.Context, item dedupe.Item) (bool, 
 		keysToCheck = append(keysToCheck, item.Key(), GetKeyHash(item.Key()))
 	}
 
-	isSet, err := d.Redis.Exists(ctx, keysToCheck...).Result()
+	isSet, err := client.Exists(ctx, keysToCheck...).Result()
 	if err != nil {
 		return false, err
 	}
@@ -124,7 +164,12 @@ func (d Deduplicator) CheckUnique(ctx context.Context, item dedupe.Item) (bool, 
 }
 
 // Set sets events into redis
-func (d Deduplicator) Set(ctx context.Context, items ...dedupe.Item) ([]dedupe.Item, error) {
+func (d *Deduplicator) Set(ctx context.Context, items ...dedupe.Item) ([]dedupe.Item, error) {
+	client, err := d.client()
+	if err != nil {
+		return nil, err
+	}
+
 	keys := make([]string, 0, len(items))
 	for _, item := range items {
 		switch d.Mode {
@@ -135,7 +180,7 @@ func (d Deduplicator) Set(ctx context.Context, items ...dedupe.Item) ([]dedupe.I
 		}
 	}
 
-	cmds, err := d.Redis.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+	cmds, err := client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 		for _, key := range keys {
 			_, err := pipe.SetArgs(ctx, key, "", redis.SetArgs{
 				TTL:  d.Expiration,
@@ -148,7 +193,17 @@ func (d Deduplicator) Set(ctx context.Context, items ...dedupe.Item) ([]dedupe.I
 		return nil
 	})
 	if err != nil && !errors.Is(err, redis.Nil) {
-		return nil, fmt.Errorf("failed to set multiple keys in redis: %w", err)
+		writeErr := fmt.Errorf("failed to set multiple keys in redis: %w", err)
+		if shouldReconnectAfterWrite(ctx, writeErr) && d.newClient != nil {
+			// Primary failover can leave stale sockets in the go-redis pool.
+			// Replacing the whole client forces the next sink retry to create fresh
+			// connections and re-resolve the configured endpoint.
+			if reconnectErr := d.reconnect(); reconnectErr != nil {
+				return nil, errors.Join(writeErr, fmt.Errorf("failed to reconnect redis client: %w", reconnectErr))
+			}
+		}
+
+		return nil, writeErr
 	}
 
 	// Let's check if all the keys were created or if some of them already existed
@@ -157,7 +212,17 @@ func (d Deduplicator) Set(ctx context.Context, items ...dedupe.Item) ([]dedupe.I
 		item := items[i]
 		if cmd.Err() != nil {
 			if !errors.Is(cmd.Err(), redis.Nil) {
-				return nil, fmt.Errorf("failed to set key %s in redis: %w", item.Key(), cmd.Err())
+				writeErr := fmt.Errorf("failed to set key %s in redis: %w", item.Key(), cmd.Err())
+				if shouldReconnectAfterWrite(ctx, writeErr) && d.newClient != nil {
+					// Primary failover can leave stale sockets in the go-redis pool.
+					// Replacing the whole client forces the next sink retry to create fresh
+					// connections and re-resolve the configured endpoint.
+					if reconnectErr := d.reconnect(); reconnectErr != nil {
+						return nil, errors.Join(writeErr, fmt.Errorf("failed to reconnect redis client: %w", reconnectErr))
+					}
+				}
+
+				return nil, writeErr
 			}
 
 			existingItems = append(existingItems, item)
@@ -167,8 +232,81 @@ func (d Deduplicator) Set(ctx context.Context, items ...dedupe.Item) ([]dedupe.I
 	return existingItems, nil
 }
 
+func shouldReconnectAfterWrite(ctx context.Context, err error) bool {
+	// nil and redis.Nil are normal outcomes for SET NX: redis.Nil means the key
+	// already existed, not that the connection or primary endpoint is unhealthy.
+	if err == nil || errors.Is(err, redis.Nil) {
+		return false
+	}
+
+	// Once the caller context is done, the retry loop is already bounded by
+	// cancellation. Reconnecting would create a fresh pool for an operation that
+	// is no longer allowed to continue.
+	if ctx.Err() != nil {
+		return false
+	}
+
+	// Caller cancellation is not a Redis failover signal. It should stop the
+	// current operation without forcing unrelated future operations onto a new pool.
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	// A bare context deadline is not enough to prove the Redis pool is stale. If
+	// the failure is a socket timeout, the net.Error checks below catch it.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Transport failures mean the checked-out socket is gone or unusable. During
+	// primary failover this is the common stale-pool failure mode.
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, net.ErrClosed) {
+		return true
+	}
+
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+
+	// READONLY means the endpoint we reached is not writable. That is the Redis
+	// role signal we expect when a stale connection survives primary failover.
+	return redis.IsReadOnlyError(err) || redis.HasErrorPrefix(err, "READONLY")
+}
+
+func (d *Deduplicator) reconnect() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	newClient, err := d.newClient()
+	if err != nil {
+		return err
+	}
+
+	oldClient := d.Redis
+	d.Redis = newClient
+
+	if oldClient != nil && oldClient != newClient {
+		return oldClient.Close()
+	}
+
+	return nil
+}
+
 // Close closes underlying redis client
-func (d Deduplicator) Close() error {
+func (d *Deduplicator) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	if d.Redis != nil {
 		return d.Redis.Close()
 	}
@@ -178,7 +316,12 @@ func (d Deduplicator) Close() error {
 
 var ErrNoDedupItems = errors.New("no dedup items provided")
 
-func (d Deduplicator) CheckUniqueBatch(ctx context.Context, items []dedupe.Item) (dedupe.CheckUniqueBatchResult, error) {
+func (d *Deduplicator) CheckUniqueBatch(ctx context.Context, items []dedupe.Item) (dedupe.CheckUniqueBatchResult, error) {
+	client, err := d.client()
+	if err != nil {
+		return dedupe.CheckUniqueBatchResult{}, err
+	}
+
 	if len(items) == 0 {
 		return dedupe.CheckUniqueBatchResult{}, ErrNoDedupItems
 	}
@@ -193,7 +336,7 @@ func (d Deduplicator) CheckUniqueBatch(ctx context.Context, items []dedupe.Item)
 		}
 	}
 
-	cmdResults, err := d.Redis.MGet(ctx, keys...).Result()
+	cmdResults, err := client.MGet(ctx, keys...).Result()
 	if err != nil && !errors.Is(err, redis.Nil) {
 		return dedupe.CheckUniqueBatchResult{}, fmt.Errorf("failed to get multiple keys in redis: %w", err)
 	}

--- a/openmeter/dedupe/redisdedupe/redisdedupe_test.go
+++ b/openmeter/dedupe/redisdedupe/redisdedupe_test.go
@@ -1,0 +1,117 @@
+package redisdedupe
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/dedupe"
+)
+
+type redisError string
+
+func (e redisError) Error() string {
+	return string(e)
+}
+
+func (redisError) RedisError() {}
+
+type pipelineErrorHook struct {
+	err error
+}
+
+func (h pipelineErrorHook) DialHook(next redis.DialHook) redis.DialHook {
+	return next
+}
+
+func (h pipelineErrorHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return next
+}
+
+func (h pipelineErrorHook) ProcessPipelineHook(redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(context.Context, []redis.Cmder) error {
+		return h.err
+	}
+}
+
+func TestSetReconnectsOnFailoverShapedWriteError(t *testing.T) {
+	firstClient := newHookedClient(redisError("READONLY You can't write against a read only replica"))
+	secondClient := newHookedClient(nil)
+
+	var reconnects int
+	deduplicator := NewDeduplicator(firstClient, time.Hour, DedupeModeRawKey, func() (*redis.Client, error) {
+		reconnects++
+		return secondClient, nil
+	})
+
+	_, err := deduplicator.Set(context.Background(), dedupe.Item{
+		Namespace: "namespace",
+		Source:    "source",
+		ID:        "id",
+	})
+
+	require.Error(t, err)
+	require.Equal(t, 1, reconnects)
+	require.Same(t, secondClient, deduplicator.Redis)
+}
+
+func TestSetDoesNotReconnectOnApplicationWriteError(t *testing.T) {
+	firstClient := newHookedClient(redisError("WRONGTYPE Operation against a key holding the wrong kind of value"))
+	secondClient := newHookedClient(nil)
+
+	var reconnects int
+	deduplicator := NewDeduplicator(firstClient, time.Hour, DedupeModeRawKey, func() (*redis.Client, error) {
+		reconnects++
+		return secondClient, nil
+	})
+
+	_, err := deduplicator.Set(context.Background(), dedupe.Item{
+		Namespace: "namespace",
+		Source:    "source",
+		ID:        "id",
+	})
+
+	require.Error(t, err)
+	require.Zero(t, reconnects)
+	require.Same(t, firstClient, deduplicator.Redis)
+}
+
+func TestSetDoesNotReconnectAfterContextCancellation(t *testing.T) {
+	firstClient := newHookedClient(redisError("READONLY You can't write against a read only replica"))
+	secondClient := newHookedClient(nil)
+
+	var reconnects int
+	deduplicator := NewDeduplicator(firstClient, time.Hour, DedupeModeRawKey, func() (*redis.Client, error) {
+		reconnects++
+		return secondClient, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := deduplicator.Set(ctx, dedupe.Item{
+		Namespace: "namespace",
+		Source:    "source",
+		ID:        "id",
+	})
+
+	require.Error(t, err)
+	require.Zero(t, reconnects)
+	require.Same(t, firstClient, deduplicator.Redis)
+}
+
+func newHookedClient(err error) *redis.Client {
+	client := redis.NewClient(&redis.Options{
+		Addr:       "127.0.0.1:0",
+		MaxRetries: -1,
+	})
+
+	if err != nil {
+		client.AddHook(pipelineErrorHook{err: err})
+	}
+
+	return client
+}

--- a/openmeter/sink/sink.go
+++ b/openmeter/sink/sink.go
@@ -87,6 +87,11 @@ type SinkConfig struct {
 	// after this period the context of the callback will be canceled.
 	FlushSuccessTimeout time.Duration
 
+	// DedupeWriteTimeout bounds the post-persist Redis dedupe write. It is separate
+	// from FlushSuccessTimeout, which only applies to the success callback.
+	DedupeWriteTimeout time.Duration
+	DedupeWriteRetry   DedupeWriteRetryConfig
+
 	// DrainTimeout is the maximum time to wait before draining the buffer and closing the sink.
 	DrainTimeout time.Duration
 
@@ -100,6 +105,11 @@ type SinkConfig struct {
 
 	// LogDroppedEvents controls whether dropped events are logged
 	LogDroppedEvents bool
+}
+
+type DedupeWriteRetryConfig struct {
+	InitialInterval time.Duration
+	MaxInterval     time.Duration
 }
 
 func (s *SinkConfig) Validate() error {
@@ -149,6 +159,18 @@ func (s *SinkConfig) Validate() error {
 
 	if s.FlushSuccessTimeout == 0 {
 		return errors.New("FlushSuccessTimeout must be greater than 0")
+	}
+
+	if s.DedupeWriteTimeout == 0 {
+		return errors.New("DedupeWriteTimeout must be greater than 0")
+	}
+
+	if s.DedupeWriteRetry.InitialInterval <= 0 {
+		return errors.New("DedupeWriteRetry.InitialInterval must be greater than 0")
+	}
+
+	if s.DedupeWriteRetry.MaxInterval <= 0 {
+		return errors.New("DedupeWriteRetry.MaxInterval must be greater than 0")
 	}
 
 	if s.DrainTimeout == 0 {
@@ -477,9 +499,13 @@ func (s *Sink) persistToStorage(ctx context.Context, messages []sinkmodels.SinkM
 // dedupeSet sets the dedupe keys in Deduplicator with retry
 func (s *Sink) dedupeSet(ctx context.Context, messages []sinkmodels.SinkMessage) error {
 	logger := s.config.Logger.With("operation", "dedupeSet")
-	dedupeCtx, dedupeSet := s.config.Tracer.Start(ctx, "dedupe-set")
+	dedupeCtx, cancel := context.WithTimeout(ctx, s.config.DedupeWriteTimeout)
+	defer cancel()
+
+	dedupeCtx, dedupeSet := s.config.Tracer.Start(dedupeCtx, "dedupe-set")
 	dedupeSet.SetAttributes(
 		attribute.Int("size", len(messages)),
+		attribute.Int64("timeout_ms", s.config.DedupeWriteTimeout.Milliseconds()),
 	)
 
 	dedupeItems := []dedupe.Item{}
@@ -536,6 +562,13 @@ func (s *Sink) dedupeSet(ctx context.Context, messages []sinkmodels.SinkMessage)
 			return nil
 		},
 		retry.Context(dedupeCtx),
+		// The timeout context is the only hard bound. During primary failover we
+		// prefer to keep retrying the post-persist dedupe write until Redis recovers
+		// rather than fail early because a stale connection pool consumed attempts.
+		retry.UntilSucceeded(),
+		retry.Delay(s.config.DedupeWriteRetry.InitialInterval),
+		retry.MaxDelay(s.config.DedupeWriteRetry.MaxInterval),
+		retry.DelayType(retry.CombineDelay(retry.BackOffDelay, retry.RandomDelay)),
 		retry.OnRetry(func(n uint, err error) {
 			dedupeSet.AddEvent("retry", trace.WithAttributes(attribute.Int("count", int(n))))
 			logger.WarnContext(ctx, "failed to sink to redis, will retry", "err", err, "retry", n)

--- a/pkg/redis/client.go
+++ b/pkg/redis/client.go
@@ -58,20 +58,38 @@ func NewClient(o Options, opts ...Option) (*redis.Client, error) {
 	var client *redis.Client
 	if o.Sentinel.Enabled {
 		client = redis.NewFailoverClient(&redis.FailoverOptions{
-			MasterName:    o.Sentinel.MasterName,
-			SentinelAddrs: []string{o.Address},
-			DB:            o.Database,
-			Username:      o.Username,
-			Password:      o.Password,
-			TLSConfig:     tlsConfig,
+			MasterName:            o.Sentinel.MasterName,
+			SentinelAddrs:         []string{o.Address},
+			DB:                    o.Database,
+			Username:              o.Username,
+			Password:              o.Password,
+			MaxRetries:            o.MaxRetries,
+			DialTimeout:           o.DialTimeout,
+			ReadTimeout:           o.ReadTimeout,
+			WriteTimeout:          o.WriteTimeout,
+			PoolSize:              o.PoolSize,
+			PoolTimeout:           o.PoolTimeout,
+			ConnMaxIdleTime:       o.ConnMaxIdleTime,
+			ConnMaxLifetime:       o.ConnMaxLifetime,
+			ConnMaxLifetimeJitter: o.ConnMaxLifetimeJitter,
+			TLSConfig:             tlsConfig,
 		})
 	} else {
 		client = redis.NewClient(&redis.Options{
-			Addr:      o.Address,
-			DB:        o.Database,
-			Username:  o.Username,
-			Password:  o.Password,
-			TLSConfig: tlsConfig,
+			Addr:                  o.Address,
+			DB:                    o.Database,
+			Username:              o.Username,
+			Password:              o.Password,
+			MaxRetries:            o.MaxRetries,
+			DialTimeout:           o.DialTimeout,
+			ReadTimeout:           o.ReadTimeout,
+			WriteTimeout:          o.WriteTimeout,
+			PoolSize:              o.PoolSize,
+			PoolTimeout:           o.PoolTimeout,
+			ConnMaxIdleTime:       o.ConnMaxIdleTime,
+			ConnMaxLifetime:       o.ConnMaxLifetime,
+			ConnMaxLifetimeJitter: o.ConnMaxLifetimeJitter,
+			TLSConfig:             tlsConfig,
 		})
 	}
 

--- a/pkg/redis/config.go
+++ b/pkg/redis/config.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/spf13/viper"
@@ -22,6 +23,15 @@ type Config struct {
 		Enabled            bool
 		InsecureSkipVerify bool
 	}
+	PoolSize              int
+	MaxRetries            int
+	DialTimeout           time.Duration
+	ReadTimeout           time.Duration
+	WriteTimeout          time.Duration
+	PoolTimeout           time.Duration
+	ConnMaxIdleTime       time.Duration
+	ConnMaxLifetime       time.Duration
+	ConnMaxLifetimeJitter time.Duration
 }
 
 // Validate checks if the configuration is valid
@@ -36,6 +46,42 @@ func (c Config) Validate() error {
 		if c.Sentinel.MasterName == "" {
 			errs = append(errs, errors.New("sentinel: master name is required"))
 		}
+	}
+
+	if c.PoolSize < 0 {
+		errs = append(errs, errors.New("pool size must be positive or 0"))
+	}
+
+	if c.MaxRetries < 0 {
+		errs = append(errs, errors.New("max retries must be positive or 0"))
+	}
+
+	if c.DialTimeout < 0 {
+		errs = append(errs, errors.New("dial timeout must be positive or 0"))
+	}
+
+	if c.ReadTimeout < 0 {
+		errs = append(errs, errors.New("read timeout must be positive or 0"))
+	}
+
+	if c.WriteTimeout < 0 {
+		errs = append(errs, errors.New("write timeout must be positive or 0"))
+	}
+
+	if c.PoolTimeout < 0 {
+		errs = append(errs, errors.New("pool timeout must be positive or 0"))
+	}
+
+	if c.ConnMaxIdleTime < 0 {
+		errs = append(errs, errors.New("connection max idle time must be positive or 0"))
+	}
+
+	if c.ConnMaxLifetime < 0 {
+		errs = append(errs, errors.New("connection max lifetime must be positive or 0"))
+	}
+
+	if c.ConnMaxLifetimeJitter < 0 {
+		errs = append(errs, errors.New("connection max lifetime jitter must be positive or 0"))
 	}
 
 	return errors.Join(errs...)
@@ -58,4 +104,13 @@ func Configure(v *viper.Viper, prefix string) {
 	v.SetDefault(fmt.Sprintf("%s.sentinel.masterName", prefix), "")
 	v.SetDefault(fmt.Sprintf("%s.tls.enabled", prefix), false)
 	v.SetDefault(fmt.Sprintf("%s.tls.insecureSkipVerify", prefix), false)
+	v.SetDefault(fmt.Sprintf("%s.poolSize", prefix), 3)
+	v.SetDefault(fmt.Sprintf("%s.maxRetries", prefix), 3)
+	v.SetDefault(fmt.Sprintf("%s.dialTimeout", prefix), "5s")
+	v.SetDefault(fmt.Sprintf("%s.readTimeout", prefix), "3s")
+	v.SetDefault(fmt.Sprintf("%s.writeTimeout", prefix), "3s")
+	v.SetDefault(fmt.Sprintf("%s.poolTimeout", prefix), "4s")
+	v.SetDefault(fmt.Sprintf("%s.connMaxIdleTime", prefix), "30m")
+	v.SetDefault(fmt.Sprintf("%s.connMaxLifetime", prefix), "0s")
+	v.SetDefault(fmt.Sprintf("%s.connMaxLifetimeJitter", prefix), "0s")
 }


### PR DESCRIPTION
## Summary

- Add an explicit `sink.dedupeWriteTimeout` around the post-persist Redis dedupe write path.
- Keep dedupe writes retrying until that timeout expires instead of stopping after a fixed attempt count.
- Recreate the Redis dedupe client/pool after write-path errors that indicate a stale connection or a read-only primary connection.
- Expose Redis client pool and timeout settings, with a small default pool size of `3`.
- Add focused Redis dedupe tests for reconnect and non-reconnect paths.

## Flow-level rationale

The sink flow persists a batch to storage, stores Kafka offsets, and then writes dedupe keys to Redis. At that point the worker is in the consistency-sensitive part of the flow: if Redis dedupe writes fail, future replays can accept duplicate events even though the batch was already persisted.

Before this change, the dedupe write retried with implicit retry defaults. During Redis primary failover, go-redis can remove only the checked-out bad connection while other stale connections remain in the pool. A fixed retry count can therefore be consumed by stale pooled connections before a fresh connection dials and resolves the writable endpoint again.

This change keeps the read-side uniqueness checks fail-fast, but makes the post-persist dedupe write path more resilient. The retry loop is bounded by `dedupeWriteTimeout`, and reconnect-worthy write errors now swap the Redis client so the next retry starts with a fresh pool and fresh endpoint resolution.

## Validation

- `go test ./openmeter/dedupe/redisdedupe ./app/config ./pkg/redis ./openmeter/sink ./app/common`
