### PR TITLE
fix: env var decoding for bool config fields and redis sentinel multi-node support and change fs.FS path construction

### DIFF
--- a/app/config/sink.go
+++ b/app/config/sink.go
@@ -176,5 +176,5 @@ func ConfigureSink(v *viper.Viper) {
 	ConfigureKafkaConfiguration(v, "sink")
 
 	// Override Kafka configuration defaults
-	v.SetDefault("sink.kafka.consumerGroupId", "openmeter-sink-worker")
+	v.SetDefault("sink.kafka.consumerGroupID", "openmeter-sink-worker")
 }

--- a/app/config/viper.go
+++ b/app/config/viper.go
@@ -11,6 +11,7 @@ func DecodeHook() mapstructure.DecodeHookFunc {
 		mapstructure.TextUnmarshallerHookFunc(),
 		mapstructure.StringToTimeDurationHookFunc(),
 		mapstructure.StringToSliceHookFunc(","),
+		mapstructure.StringToBasicTypeHookFunc(),
 	)
 }
 

--- a/pkg/redis/client.go
+++ b/pkg/redis/client.go
@@ -57,9 +57,14 @@ func NewClient(o Options, opts ...Option) (*redis.Client, error) {
 	// Initialize Redis Client
 	var client *redis.Client
 	if o.Sentinel.Enabled {
+		// Address may be a comma-separated list of sentinel nodes.
+		sentinelAddrs := strings.Split(o.Address, ",")
+		for i, a := range sentinelAddrs {
+			sentinelAddrs[i] = strings.TrimSpace(a)
+		}
 		client = redis.NewFailoverClient(&redis.FailoverOptions{
 			MasterName:    o.Sentinel.MasterName,
-			SentinelAddrs: []string{o.Address},
+			SentinelAddrs: sentinelAddrs,
 			DB:            o.Database,
 			Username:      o.Username,
 			Password:      o.Password,

--- a/pkg/redis/client.go
+++ b/pkg/redis/client.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"crypto/tls"
 	"fmt"
+	"strings"
 
 	"github.com/redis/go-redis/extra/redisotel/v9"
 	"github.com/redis/go-redis/v9"

--- a/tools/migrate/fs.go
+++ b/tools/migrate/fs.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"strings"
 )
 
@@ -29,15 +29,15 @@ func (s *SourceWrapper) Open(name string) (fs.File, error) {
 	return s.fsys.Open(name)
 }
 
-func (s *SourceWrapper) ReadDir(path string) ([]fs.DirEntry, error) {
-	entries, err := fs.ReadDir(s.fsys, path)
+func (s *SourceWrapper) ReadDir(dir string) ([]fs.DirEntry, error) {
+	entries, err := fs.ReadDir(s.fsys, dir)
 	if err != nil {
 		return nil, err
 	}
 
 	results := make([]fs.DirEntry, 0, len(entries))
 	for _, entry := range entries {
-		filePath := filepath.Join(path, entry.Name())
+		filePath := path.Join(dir, entry.Name())
 
 		if entry.IsDir() {
 			r, err := s.ReadDir(filePath)


### PR DESCRIPTION
## Overview
Four small fixes for running OpenMeter in Kubernetes where config values arrive as environment variable strings rather than typed YAML values.

1. ```app/config/viper.go``` — __bool env var decoding__

Added ```StringToBasicTypeHookFunc()``` to the global ```DecodeHook```. When config values are set via env vars or ConfigMaps, they are always strings — ```"true"```, ```"false"```, ```"1"```. Without this hook, any ```bool``` config field panics on startup with:
```
expected type 'bool', got unconvertible type 'string', value: 'false'
```
This affects fields like ```DEDUPE_ENABLED```, ```NOTIFICATION_ENABLED```, and any other boolean config sourced from the environment.

2. ```app/config/sink.go``` — __consumer group ID key name typo__

```sink.kafka.consumerGroupId``` → ```sink.kafka.consumerGroupID``` (capital ```ID``` to match the struct field's mapstructure tag). The previous key never matched the actual config field, so the default value ```"openmeter-sink-worker"``` was never applied. The sink-worker joined Kafka with an empty consumer group ID, which caused Kafka to reject partition assignment and left events unsynced to ClickHouse.

3. ```pkg/redis/client.go``` — __Redis Sentinel multi-node support__

The ```Address``` field now supports a comma-separated list of sentinel nodes (e.g. ```"sentinel1:26379,sentinel2:26379,sentinel3:26379"```). Previously it was hardcoded to ```[]string{o.Address}```, which only ever used a single sentinel endpoint regardless of what was configured.

4. ```tools/migrate/fs.go``` — __use ```path.Join``` instead of ```filepath.Join``` for ```fs.FS``` path construction__

```filepath.Join``` uses the OS path separator (```\``` on Windows), which breaks ```fs.FS``` implementations that require forward-slash paths per the ```io/fs``` spec. Replace with ```path.Join``` which always uses ```/```

## Notes for reviewer
- ```StringToBasicTypeHookFunc``` only activates when the target struct field is a basic type (```bool```, ```int```, ```float64```) — it has no effect on string fields or ```interface{}``` maps. Existing YAML-based configs are unaffected since YAML already deserialises native types correctly.
- The sentinel change is backward compatible — ```strings.Split``` on a non-comma string returns a single-element slice, identical to the previous ```[]string{o.Address}``` behaviour.
- The consumer group typo fix has no migration concern — the field was silently broken before, so no existing deployment relied on the wrong default being applied.
- The ```path``` package (always forward-slash) is used instead of ```filepath``` (OS-dependent separator) because ```fs.FS``` requires forward-slash paths on all platforms per the ```io/fs``` spec; the function parameter was renamed from ```path``` to ```dir``` to avoid shadowing the import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Normalized Kafka consumer group configuration key naming for consistency.
  * Redis Sentinel failover now accepts comma-separated sentinel node addresses.
  * Configuration decoding enhanced to support more string-to-type conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->