### PR TITLE
fix: validating metered feature for ubp ratecard

### DIFF
--- a/openmeter/productcatalog/addon/adapter/addon.go
+++ b/openmeter/productcatalog/addon/adapter/addon.go
@@ -543,8 +543,19 @@ func (a *adapter) UpdateAddon(ctx context.Context, params addon.UpdateAddonInput
 }
 
 var AddonEagerLoadRateCardsFn = func(q *entdb.AddonRateCardQuery) {
-	q.Where(addonratecarddb.Or(
-		addonratecarddb.DeletedAtIsNil(),
-		addonratecarddb.DeletedAtGT(clock.Now().UTC()),
-	)).WithFeatures().WithTaxCode()
+	q.Where(
+		addonratecarddb.Or(
+			addonratecarddb.DeletedAtIsNil(),
+			addonratecarddb.DeletedAtGT(clock.Now().UTC()),
+		))
+	rateCardEagerLoadFeaturesFn(q)
+	rateCardEagerLoadTaxCodesFn(q)
+}
+
+var rateCardEagerLoadFeaturesFn = func(q *entdb.AddonRateCardQuery) {
+	q.WithFeatures()
+}
+
+var rateCardEagerLoadTaxCodesFn = func(q *entdb.AddonRateCardQuery) {
+	q.WithTaxCode()
 }

--- a/openmeter/productcatalog/addon/adapter/mapping.go
+++ b/openmeter/productcatalog/addon/adapter/mapping.go
@@ -98,14 +98,13 @@ func FromAddonRateCardRow(r entdb.AddonRateCard) (*addon.RateCard, error) {
 		Discounts:           lo.FromPtr(r.Discounts),
 	}
 
-	// This is a workaround to make sure that the feature key is set if the feature id is set.
-	if r.FeatureID != nil && r.FeatureKey == nil {
+	if r.FeatureID != nil || r.FeatureKey != nil {
 		ratecardFeature, err := r.Edges.FeaturesOrErr()
 		if err != nil {
 			return nil, errors.New("feature is not loaded for ratecard")
 		}
 
-		meta.FeatureKey = &ratecardFeature.Key
+		meta.SetFeature(&ratecardFeature.ID, &ratecardFeature.Key)
 	}
 
 	// Map TaxCode if eagerly loaded.

--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -376,6 +376,16 @@ var ErrRateCardUsageBasedPriceWithNoFeature = models.NewValidationIssue(
 	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
 )
 
+const ErrCodeRateCardUsageBasedPriceWithFeatureAndNoMeter models.ErrorCode = "usage_based_price_with_feature_and_no_meter"
+
+var ErrRateCardUsageBasedPriceWithFeatureAndNoMeter = models.NewValidationIssue(
+	ErrCodeRateCardUsageBasedPriceWithFeatureAndNoMeter,
+	"usage-based price requires feature with meter to be associated with",
+	models.WithFieldString("featureKey"),
+	models.WithWarningSeverity(),
+	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
+)
+
 // Addon errors
 
 const ErrCodeAddonKeyEmpty models.ErrorCode = "addon_key_empty"

--- a/openmeter/productcatalog/featureresolver/ratecard.go
+++ b/openmeter/productcatalog/featureresolver/ratecard.go
@@ -109,7 +109,13 @@ func ResolveFeaturesForRateCards(
 			}
 		}
 
-		rc.SetFeature(&(f).ID, &(f).Key)
+		if f == nil {
+			errs = append(errs, models.ErrorWithFieldPrefix(fieldSelector,
+				fmt.Errorf("feature not found [ratecard.key=%s]: %w", rc.Key(), productcatalog.ErrRateCardFeatureNotFound),
+			))
+		} else {
+			rc.SetFeature(&(f).ID, &(f).Key)
+		}
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/productcatalog/featureresolver/resolver_test.go
+++ b/openmeter/productcatalog/featureresolver/resolver_test.go
@@ -66,9 +66,10 @@ func Test_NamespacedFeatureResolver(t *testing.T) {
 
 	t.Run("Resolve", func(t *testing.T) {
 		tests := []struct {
-			name          string
-			featureID     *string
-			featureKey    *string
+			name       string
+			featureID  *string
+			featureKey *string
+
 			expectedError error
 		}{
 			{
@@ -156,17 +157,17 @@ func Test_NamespacedFeatureResolver(t *testing.T) {
 	})
 
 	t.Run("BatchResolve", func(t *testing.T) {
-		testBatch := map[string]bool{
-			features[0].ID:  true,
-			features[0].Key: true,
-			features[1].ID:  true,
-			features[1].Key: true,
-			features[2].ID:  true,
-			features[2].Key: true,
-			"abracadabra":   false,
+		testBatch := map[string]*feature.Feature{
+			features[0].ID:  &features[0],
+			features[0].Key: &features[0],
+			features[1].ID:  &features[1],
+			features[1].Key: &features[1],
+			features[2].ID:  &features[2],
+			features[2].Key: &features[2],
+			"abracadabra":   nil,
 		}
 
-		idOrKeys := lo.MapToSlice(testBatch, func(key string, _ bool) string {
+		idOrKeys := lo.MapToSlice(testBatch, func(key string, _ *feature.Feature) string {
 			return key
 		})
 
@@ -175,10 +176,11 @@ func Test_NamespacedFeatureResolver(t *testing.T) {
 		resolved, err = namespacedResolver.BatchResolve(t.Context(), idOrKeys...)
 		require.NoErrorf(t, err, "expected no error: %v", err)
 
-		for k, ok := range testBatch {
-			if ok {
+		for k, f := range testBatch {
+			if f != nil {
 				assert.NotNilf(t, resolved[k], "resolved feature must not be nil")
-				assert.True(t, resolved[k].ID == k || resolved[k].Key == k, "resolved feature id or key must be equal to the one we set")
+				assert.Equalf(t, f.ID, resolved[k].ID, "resolved feature id must be equal to the one we set")
+				assert.Equalf(t, f.Key, resolved[k].Key, "resolved feature key must be equal to the one we set")
 			} else {
 				assert.Nilf(t, resolved[k], "resolved feature must be nil")
 			}

--- a/openmeter/productcatalog/plan/adapter/mapping.go
+++ b/openmeter/productcatalog/plan/adapter/mapping.go
@@ -299,14 +299,13 @@ func fromPlanRateCardRow(r entdb.PlanRateCard) (productcatalog.RateCard, error) 
 		Discounts:           lo.FromPtr(r.Discounts),
 	}
 
-	// This is a workaround to make sure that the feature key is set if the feature id is set.
-	if r.FeatureID != nil && r.FeatureKey == nil {
+	if r.FeatureID != nil || r.FeatureKey != nil {
 		ratecardFeature, err := r.Edges.FeaturesOrErr()
 		if err != nil {
 			return nil, errors.New("feature is not loaded for ratecard")
 		}
 
-		meta.FeatureKey = &ratecardFeature.Key
+		meta.SetFeature(&ratecardFeature.ID, &ratecardFeature.Key)
 	}
 
 	// Map TaxCode if eagerly loaded.

--- a/openmeter/productcatalog/plan/adapter/plan.go
+++ b/openmeter/productcatalog/plan/adapter/plan.go
@@ -524,7 +524,12 @@ var planEagerLoadActiveAddons = func(paq *entdb.PlanAddonQuery) {
 
 var planPhaseEagerLoadRateCardsFn = func(q *entdb.PlanPhaseQuery) {
 	q.WithRatecards(func(prcq *entdb.PlanRateCardQuery) {
-		prcq.Where(ratecarddb.Or(ratecarddb.DeletedAtIsNil(), ratecarddb.DeletedAtGT(clock.Now().UTC())))
+		prcq.Where(
+			ratecarddb.Or(
+				ratecarddb.DeletedAtIsNil(),
+				ratecarddb.DeletedAtGT(clock.Now().UTC()),
+			),
+		)
 		rateCardEagerLoadFeaturesFn(prcq)
 		rateCardEagerLoadTaxCodesFn(prcq)
 	})

--- a/openmeter/productcatalog/plan/repository.go
+++ b/openmeter/productcatalog/plan/repository.go
@@ -7,8 +7,6 @@ import (
 	"github.com/openmeterio/openmeter/pkg/pagination"
 )
 
-// TODO: add bulk api
-
 type Repository interface {
 	entutils.TxCreator
 	// Plans

--- a/openmeter/productcatalog/plan/service/plan.go
+++ b/openmeter/productcatalog/plan/service/plan.go
@@ -335,7 +335,7 @@ func (s service) UpdatePlan(ctx context.Context, params plan.UpdatePlanInput) (*
 
 		p, err = s.adapter.UpdatePlan(ctx, params)
 		if err != nil {
-			return nil, fmt.Errorf("failed to udpate Plan: %w", err)
+			return nil, fmt.Errorf("failed to update Plan: %w", err)
 		}
 
 		logger.Debug("Plan updated")

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -29,9 +29,18 @@ func (s RateCardType) Values() []string {
 	}
 }
 
+type RateCardFeature interface {
+	HasFeature() bool
+	GetFeatureID() *string
+	GetFeatureKey() *string
+	SetFeature(id, key *string)
+}
+
 type RateCard interface {
 	models.Validator
 	models.Equaler[RateCard]
+
+	RateCardFeature
 
 	Type() RateCardType
 	AsMeta() RateCardMeta
@@ -42,11 +51,6 @@ type RateCard interface {
 	Compatible(RateCard) error
 	GetBillingCadence() *datetime.ISODuration
 	IsBillable() bool
-
-	HasFeature() bool
-	GetFeatureID() *string
-	GetFeatureKey() *string
-	SetFeature(id, key *string)
 }
 
 type RateCardSerde struct {
@@ -920,6 +924,13 @@ func ValidateRateCardsWithFeatures(ctx context.Context, resolver NamespacedFeatu
 
 			if feat.ArchivedAt != nil && clock.Now().UTC().After(feat.ArchivedAt.UTC()) {
 				errs = append(errs, models.ErrorWithFieldPrefix(rateCardFieldSelector, ErrRateCardFeatureArchived))
+			}
+
+			// Make sure that ratecard with UBP has metered feature
+			if rc.Price != nil && rc.Price.Type() != FlatPriceType {
+				if feat.MeterID == nil {
+					errs = append(errs, models.ErrorWithFieldPrefix(rateCardFieldSelector, ErrRateCardUsageBasedPriceWithFeatureAndNoMeter))
+				}
 			}
 		}
 

--- a/openmeter/subscription/addon/diff/apply_test.go
+++ b/openmeter/subscription/addon/diff/apply_test.go
@@ -140,6 +140,9 @@ func TestApply(t *testing.T) {
 
 	t.Run("Should add multiple instances of new item to the subscription", func(t *testing.T) {
 		runWithDeps(t, func(t *testing.T, deps *tcDeps) {
+			exampleAddonRateCard3, ok := (subscriptiontestutils.ExampleAddonRateCard3.Clone()).(*productcatalog.FlatFeeRateCard)
+			require.True(t, ok, "expected FlatFeeRateCard, got %T", exampleAddonRateCard3)
+
 			p, a := subscriptiontestutils.CreatePlanWithAddon(
 				t,
 				deps.deps,
@@ -150,7 +153,7 @@ func TestApply(t *testing.T) {
 						EffectiveTo:   nil,
 					},
 					productcatalog.AddonInstanceTypeSingle,
-					subscriptiontestutils.ExampleAddonRateCard3.Clone(),
+					exampleAddonRateCard3,
 				),
 			)
 
@@ -182,7 +185,7 @@ func TestApply(t *testing.T) {
 			for _, p := range spec.GetSortedPhases() {
 				b, _ := json.MarshalIndent(p, "", "  ")
 
-				itemHistory, ok := p.ItemsByKey[subscriptiontestutils.ExampleAddonRateCard3.Key()]
+				itemHistory, ok := p.ItemsByKey[exampleAddonRateCard3.Key()]
 				require.True(t, ok, "item history missing in phase %s, got %+v, \nfull: %s", p.PhaseKey, lo.Keys(p.ItemsByKey), string(b))
 
 				// It should have a single entry in all phases
@@ -205,7 +208,7 @@ func TestApply(t *testing.T) {
 				require.Equal(t, int64(300), pr.Amount.IntPart())
 
 				// It should have the proper RateCard info, which is price * quantity + bool access
-				compareRateCardsWithAmountChange(t, &subscriptiontestutils.ExampleAddonRateCard3, 100*3, item.RateCard, "phase %s", p.PhaseKey)
+				compareRateCardsWithAmountChange(t, exampleAddonRateCard3, 100*3, item.RateCard, "phase %s", p.PhaseKey)
 			}
 		})
 	})
@@ -957,16 +960,10 @@ func compareRateCardsWithAmountChange(t *testing.T, baseTarget *productcatalog.F
 	msgX := fmt.Sprintf("item %s not equal to target %s", b1, b2)
 
 	left := target.Clone()
-	require.NoError(t, left.ChangeMeta(func(m productcatalog.RateCardMeta) (productcatalog.RateCardMeta, error) {
-		m.FeatureID = nil
-		return m, nil
-	}))
+	left.SetFeature(nil, left.GetFeatureKey())
 
 	right := value.Clone()
-	require.NoError(t, right.ChangeMeta(func(m productcatalog.RateCardMeta) (productcatalog.RateCardMeta, error) {
-		m.FeatureID = nil
-		return m, nil
-	}))
+	right.SetFeature(nil, right.GetFeatureKey())
 
 	if len(msgAndArgs) > 0 {
 		customMsg := fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...)

--- a/openmeter/subscription/addon/extend_test.go
+++ b/openmeter/subscription/addon/extend_test.go
@@ -872,6 +872,8 @@ func TestExtendRestore(t *testing.T) {
 	})
 }
 
+var _ productcatalog.RateCard = nonPointerRateCard{}
+
 type nonPointerRateCard struct{}
 
 func (n nonPointerRateCard) HasFeature() bool {
@@ -888,8 +890,6 @@ func (n nonPointerRateCard) GetFeatureKey() *string {
 
 func (n nonPointerRateCard) SetFeature(_, _ *string) {
 }
-
-var _ productcatalog.RateCard = nonPointerRateCard{}
 
 func (n nonPointerRateCard) IsBillable() bool {
 	return true

--- a/openmeter/subscription/workflow/service/addon_test.go
+++ b/openmeter/subscription/workflow/service/addon_test.go
@@ -650,10 +650,7 @@ func stripFeatureIDs(spec *subscription.SubscriptionSpec) {
 	for _, phase := range spec.Phases {
 		for _, items := range phase.ItemsByKey {
 			for _, item := range items {
-				_ = item.RateCard.ChangeMeta(func(m productcatalog.RateCardMeta) (productcatalog.RateCardMeta, error) {
-					m.FeatureID = nil
-					return m, nil
-				})
+				item.RateCard.SetFeature(nil, item.RateCard.GetFeatureKey())
 			}
 		}
 	}


### PR DESCRIPTION
## Overview

Ensure that ratecards with usage-based pricing have metered feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforcement: usage-based rate cards that reference a feature now require an associated meter (returns a validation error).
  * Improved feature resolution with nil-safety and clearer validation errors when features are missing.
  * Fixed plan update error message text.

* **Refactor**
  * Internal restructuring of rate card and feature handling for more consistent behavior and safer eager-loading/backfilling of feature metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->