### PR TITLE
fix(app/sandbox): fix marketplace install and billing profile provisioning

### DIFF
--- a/openmeter/app/httpdriver/marketplace.go
+++ b/openmeter/app/httpdriver/marketplace.go
@@ -249,8 +249,15 @@ func (h *handler) createBillingProfile(ctx context.Context, installedApp app.App
 	case app.AppTypeStripe:
 		return h.makeStripeDefaultBillingApp(ctx, installedApp)
 	case app.AppTypeSandbox:
-		// TODO: Implement sandbox billing profile creation
-		return nil, nil
+		namespace := installedApp.GetID().Namespace
+		if err := h.billingService.ProvisionDefaultBillingProfile(ctx, namespace); err != nil {
+			return nil, fmt.Errorf("provision default billing profile: %w", err)
+		}
+		return []api.AppCapabilityType{
+			api.AppCapabilityType(app.CapabilityTypeCalculateTax),
+			api.AppCapabilityType(app.CapabilityTypeInvoiceCustomers),
+			api.AppCapabilityType(app.CapabilityTypeCollectPayments),
+		}, nil
 	case app.AppTypeCustomInvoicing:
 		// TODO: Implement custom invoicing billing profile creation
 		return nil, nil

--- a/openmeter/app/sandbox/app.go
+++ b/openmeter/app/sandbox/app.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/samber/lo"
+
 	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	customerapp "github.com/openmeterio/openmeter/openmeter/customer/app"
 	"github.com/openmeterio/openmeter/pkg/clock"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 const (
@@ -217,6 +220,20 @@ func (a *Factory) NewApp(_ context.Context, appBase app.AppBase) (app.App, error
 func (a *Factory) InstallApp(ctx context.Context, input app.AppFactoryInstallAppInput) (app.App, error) {
 	if err := input.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid input: %w", err)
+	}
+
+	// Sandbox is a singleton per namespace — only one instance makes sense since all
+	// instances are functionally identical (no credentials, no external state).
+	existing, err := a.appService.ListApps(ctx, app.ListAppInput{
+		Namespace: input.Namespace,
+		Type:      lo.ToPtr(app.AppTypeSandbox),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list sandbox apps: %w", err)
+	}
+
+	if existing.TotalCount > 0 {
+		return nil, models.NewGenericConflictError(fmt.Errorf("sandbox app: %s already exists", existing.Items[0].GetName()))
 	}
 
 	appBase, err := a.appService.CreateApp(ctx, app.CreateAppInput{

--- a/openmeter/app/sandbox/app.go
+++ b/openmeter/app/sandbox/app.go
@@ -214,8 +214,7 @@ func (a *Factory) NewApp(_ context.Context, appBase app.AppBase) (app.App, error
 	}, nil
 }
 
-func (a *Factory) InstallAppWithAPIKey(ctx context.Context, input app.AppFactoryInstallAppWithAPIKeyInput) (app.App, error) {
-	// Validate input
+func (a *Factory) InstallApp(ctx context.Context, input app.AppFactoryInstallAppInput) (app.App, error) {
 	if err := input.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid input: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Fix `POST /api/v1/marketplace/listings/sandbox/install` returning 400 "does not support this installation method": the sandbox `Factory` advertised `no_credentials_required` in its marketplace listing but only implemented `AppFactoryInstallWithAPIKey`. Added the missing `InstallApp` method and inlined the logic directly, removing the now-redundant `InstallAppWithAPIKey`.

- Fix `createBillingProfile` being a no-op for sandbox: the marketplace install handler had a `// TODO: Implement sandbox billing profile creation` stub that always returned nil. Replaced it with a call to `ProvisionDefaultBillingProfile`, matching what server startup does for the default namespace.

Together these two fixes make `POST /api/v1/marketplace/listings/sandbox/install` with `{"createBillingProfile": true}` fully self-contained — one call installs the app and provisions the default billing profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox apps now provision a default billing profile during install, including capabilities for tax calculation, invoicing customers, and collecting payments.
* **Refactor**
  * Sandbox app installation now validates input, checks for an existing sandbox app in the target namespace, returns a conflict if one is present, and otherwise returns the newly created app instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->