### PR TITLE
fix(entitlement): reject duplicate reset time

### DIFF
--- a/openmeter/entitlement/metered/reset.go
+++ b/openmeter/entitlement/metered/reset.go
@@ -38,6 +38,12 @@ func (e *connector) ResetEntitlementUsage(ctx context.Context, entitlementID mod
 			return nil, fmt.Errorf("failed to parse entitlement: %w", err)
 		}
 
+		resetTime := params.At.Truncate(time.Minute)
+		lastReset := mEnt.LastReset.Truncate(time.Minute)
+		if resetTime.Equal(lastReset) {
+			return nil, models.NewGenericValidationError(fmt.Errorf("reset at %s must be after last reset at %s", resetTime, lastReset))
+		}
+
 		if err := e.hooks.PreUpdate(ctx, mEnt); err != nil {
 			return nil, err
 		}

--- a/openmeter/entitlement/metered/reset_test.go
+++ b/openmeter/entitlement/metered/reset_test.go
@@ -205,6 +205,47 @@ func TestResetEntitlementUsage(t *testing.T) {
 			},
 		},
 		{
+			name: "Should error if requested reset time is the same minute as the last reset",
+			run: func(t *testing.T, connector meteredentitlement.Connector, deps *dependencies) {
+				ctx := t.Context()
+				startTime := getAnchor(t)
+				randName := testutils.NameGenerator.Generate()
+
+				// given:
+				// - a metered entitlement that has already been reset in a specific minute
+				// when:
+				// - reset is requested again inside the same minute
+				// then:
+				// - the second reset is rejected as a duplicate reset time
+
+				// create customer and subject
+				cust := createCustomerAndSubject(t, deps.subjectService, deps.customerService, namespace, randName.Key, randName.Name)
+
+				// create entitlement in db
+				inp := getEntitlement(t, feat, cust.GetUsageAttribution())
+				inp.MeasureUsageFrom = &startTime
+				ent, err := deps.entitlementRepo.CreateEntitlement(ctx, inp)
+				require.NoError(t, err)
+
+				deps.streamingConnector.AddSimpleEvent(meterSlug, 100, startTime.Add(time.Minute))
+
+				resetTime := startTime.Add(3*time.Hour + 10*time.Second)
+				_, err = connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime,
+					})
+				require.NoError(t, err)
+
+				_, err = connector.ResetEntitlementUsage(ctx,
+					models.NamespacedID{Namespace: namespace, ID: ent.ID},
+					meteredentitlement.ResetEntitlementUsageParams{
+						At: resetTime.Truncate(time.Minute).Add(30 * time.Second),
+					})
+				assert.ErrorContains(t, err, "must be after last reset")
+			},
+		},
+		{
 			name: "Should invalidate snapshots after the reset time",
 			run: func(t *testing.T, connector meteredentitlement.Connector, deps *dependencies) {
 				ctx := context.Background()


### PR DESCRIPTION
## What

- Reject metered entitlement reset requests whose effective reset time truncates to the same minute as the entitlement's persisted `LastReset`.
- Add a regression test for a second reset request in the same stored reset minute.

## Why

Manual reset requests can be submitted twice from the UI before client-side pending state fully protects the button. The backend previously rejected reset times before later resets, but allowed equality with the last reset time, so duplicate reset rows/events for the same stored minute were possible.

## Validation

- `nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go vet -tags=dynamic ./openmeter/entitlement/metered/...`
- `nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/entitlement/metered/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for entitlement reset operations to ensure requests must occur strictly after the previous reset time, preventing multiple resets within the same minute.

* **Tests**
  * Added test case to verify that consecutive reset attempts occurring within the same minute are properly rejected with appropriate error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->