### PR TITLE
fix(api): entitlements static config

### DIFF
--- a/api/v3/handlers/addons/convert.go
+++ b/api/v3/handlers/addons/convert.go
@@ -522,10 +522,17 @@ func ToAPIBillingRateCardEntitlement(t *productcatalog.EntitlementTemplate) (*ap
 			return nil, fmt.Errorf("failed to read static entitlement template: %w", err)
 		}
 
-		var config interface{}
+		// The domain stores the config as a JSON string token wrapping the JSON
+		// text (v1 convention, relied on by subscription materialization). Unwrap
+		// it so the v3 API returns the raw JSON value. Legacy values that are not
+		// string-wrapped are returned as stored so reads never hard-fail.
+		var config json.RawMessage
 		if len(static.Config) > 0 {
-			if err := json.Unmarshal(static.Config, &config); err != nil {
-				return nil, fmt.Errorf("failed to decode static entitlement config: %w", err)
+			var text string
+			if err := json.Unmarshal(static.Config, &text); err == nil && json.Valid([]byte(text)) {
+				config = json.RawMessage(text)
+			} else {
+				config = json.RawMessage(static.Config)
 			}
 		}
 
@@ -568,7 +575,7 @@ func FromAPIBillingRateCardEntitlement(e apiv3.BillingRateCardEntitlement, billi
 		if metered.UsagePeriod != nil {
 			usagePeriod, err = datetime.ISODurationString(*metered.UsagePeriod).Parse()
 			if err != nil {
-				return nil, fmt.Errorf("invalid usage period: %w", err)
+				return nil, models.NewGenericValidationError(fmt.Errorf("invalid usage period: %w", err))
 			}
 		}
 
@@ -591,18 +598,34 @@ func FromAPIBillingRateCardEntitlement(e apiv3.BillingRateCardEntitlement, billi
 		return productcatalog.NewEntitlementTemplateFrom(tmpl), nil
 
 	case "static":
-		static, err := e.AsBillingRateCardStaticEntitlement()
+		// Extract the config's raw JSON bytes from the union so client values
+		// survive untouched (no float64 round-trip), then wrap them in a JSON
+		// string token: the domain-wide convention (shared with v1) stores the
+		// config as JSON-encoded text, which subscription materialization
+		// unwraps when instantiating the entitlement.
+		rawEnt, err := e.MarshalJSON()
 		if err != nil {
 			return nil, fmt.Errorf("failed to read static entitlement template: %w", err)
 		}
 
-		raw, err := json.Marshal(static.Config)
+		var static struct {
+			Config json.RawMessage `json:"config"`
+		}
+		if err := json.Unmarshal(rawEnt, &static); err != nil {
+			return nil, fmt.Errorf("failed to read static entitlement template: %w", err)
+		}
+
+		if len(static.Config) == 0 {
+			static.Config = json.RawMessage("null")
+		}
+
+		token, err := json.Marshal(string(static.Config))
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode static entitlement config: %w", err)
 		}
 
 		return productcatalog.NewEntitlementTemplateFrom(productcatalog.StaticEntitlementTemplate{
-			Config: raw,
+			Config: token,
 		}), nil
 
 	case "boolean":
@@ -661,20 +684,20 @@ func FromAPIBillingRateCard(rc apiv3.BillingRateCard) (productcatalog.RateCard, 
 		meta.Discounts = discounts
 	}
 
-	if rc.Entitlement != nil {
-		// The metered usage period defaults to the rate card billing cadence, so
-		// parse it up front to pass into the entitlement converter (v1 parity).
-		var cadence *datetime.ISODuration
-		if rc.BillingCadence != nil {
-			bc, err := datetime.ISODurationString(*rc.BillingCadence).Parse()
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse billing_cadence: %w", err)
-			}
-
-			cadence = &bc
+	// The billing cadence doubles as the default usage period for metered
+	// entitlement templates, so parse it once up front.
+	var parsedBillingCadence *datetime.ISODuration
+	if rc.BillingCadence != nil {
+		bc, err := datetime.ISODurationString(*rc.BillingCadence).Parse()
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse billing_cadence: %w", err)
 		}
 
-		tmpl, err := FromAPIBillingRateCardEntitlement(*rc.Entitlement, cadence)
+		parsedBillingCadence = &bc
+	}
+
+	if rc.Entitlement != nil {
+		tmpl, err := FromAPIBillingRateCardEntitlement(*rc.Entitlement, parsedBillingCadence)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert entitlement template: %w", err)
 		}
@@ -715,15 +738,9 @@ func FromAPIBillingRateCard(rc apiv3.BillingRateCard) (productcatalog.RateCard, 
 	}
 
 	// UsageBasedRateCard
-	isoStr := datetime.ISODurationString(*rc.BillingCadence)
-	billingCadence, err := isoStr.Parse()
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse billing_cadence: %w", err)
-	}
-
 	usageRC := &productcatalog.UsageBasedRateCard{
 		RateCardMeta:   meta,
-		BillingCadence: billingCadence,
+		BillingCadence: *parsedBillingCadence,
 	}
 
 	switch priceDiscriminator {

--- a/api/v3/handlers/addons/convert.go
+++ b/api/v3/handlers/addons/convert.go
@@ -532,7 +532,7 @@ func ToAPIBillingRateCardEntitlement(t *productcatalog.EntitlementTemplate) (*ap
 			if err := json.Unmarshal(static.Config, &text); err == nil && json.Valid([]byte(text)) {
 				config = json.RawMessage(text)
 			} else {
-				config = json.RawMessage(static.Config)
+				config = static.Config
 			}
 		}
 

--- a/api/v3/handlers/addons/convert_test.go
+++ b/api/v3/handlers/addons/convert_test.go
@@ -1,0 +1,202 @@
+package addons
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apiv3 "github.com/openmeterio/openmeter/api/v3"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func roundTripStaticConfig(t *testing.T, config interface{}) interface{} {
+	t.Helper()
+
+	var apiEnt apiv3.BillingRateCardEntitlement
+	require.NoError(t, apiEnt.FromBillingRateCardStaticEntitlement(apiv3.BillingRateCardStaticEntitlement{
+		Type:   "static",
+		Config: config,
+	}))
+
+	domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
+	require.NoError(t, err)
+
+	out, err := ToAPIBillingRateCardEntitlement(domain)
+	require.NoError(t, err)
+
+	static, err := out.AsBillingRateCardStaticEntitlement()
+	require.NoError(t, err)
+
+	return static.Config
+}
+
+func TestFromToAPIBillingRateCardEntitlement(t *testing.T) {
+	t.Run("static — object config round-trips as a JSON object, not a string", func(t *testing.T) {
+		config := map[string]interface{}{
+			"integrations": []interface{}{"github", "slack"},
+			"limit":        float64(10),
+		}
+
+		out := roundTripStaticConfig(t, config)
+
+		assert.Equal(t, config, out)
+
+		_, isObject := out.(map[string]interface{})
+		assert.True(t, isObject, "config must round-trip as a JSON object")
+	})
+
+	t.Run("static — array config round-trips", func(t *testing.T) {
+		config := []interface{}{float64(1), float64(2), float64(3)}
+		assert.Equal(t, config, roundTripStaticConfig(t, config))
+	})
+
+	t.Run("static — scalar string config round-trips", func(t *testing.T) {
+		config := "just-a-string"
+		assert.Equal(t, config, roundTripStaticConfig(t, config))
+	})
+
+	t.Run("static — nil config round-trips as nil", func(t *testing.T) {
+		assert.Nil(t, roundTripStaticConfig(t, nil))
+	})
+
+	t.Run("static — domain stores the v1 string-token convention", func(t *testing.T) {
+		// Subscription materialization (subscriptionspec.go) unwraps the stored
+		// config as a JSON string token containing JSON text. Pin that convention
+		// so v3-created static entitlements stay materializable.
+		var apiEnt apiv3.BillingRateCardEntitlement
+		require.NoError(t, apiEnt.FromBillingRateCardStaticEntitlement(apiv3.BillingRateCardStaticEntitlement{
+			Type:   "static",
+			Config: map[string]interface{}{"integrations": []interface{}{"github"}},
+		}))
+
+		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
+		require.NoError(t, err)
+
+		static, err := domain.AsStatic()
+		require.NoError(t, err)
+
+		var text string
+		require.NoError(t, json.Unmarshal(static.Config, &text),
+			"stored config must be a JSON string token wrapping the JSON text")
+		assert.JSONEq(t, `{"integrations":["github"]}`, text)
+	})
+
+	t.Run("static — legacy non-token stored config is returned as stored, not an error", func(t *testing.T) {
+		// Reads must never hard-fail on data that was valid to persist.
+		domain := productcatalog.NewEntitlementTemplateFrom(productcatalog.StaticEntitlementTemplate{
+			Config: json.RawMessage(`{"a":1}`),
+		})
+
+		out, err := ToAPIBillingRateCardEntitlement(domain)
+		require.NoError(t, err)
+
+		static, err := out.AsBillingRateCardStaticEntitlement()
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{"a": float64(1)}, static.Config)
+	})
+
+	t.Run("metered — limit, soft limit, usage period round-trip", func(t *testing.T) {
+		usagePeriod := apiv3.ISO8601Duration("P1M")
+
+		var apiEnt apiv3.BillingRateCardEntitlement
+		require.NoError(t, apiEnt.FromBillingRateCardMeteredEntitlement(apiv3.BillingRateCardMeteredEntitlement{
+			Type:        "metered",
+			IsSoftLimit: lo.ToPtr(true),
+			UsagePeriod: &usagePeriod,
+			Limit:       lo.ToPtr(float64(1000)),
+		}))
+
+		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
+		require.NoError(t, err)
+
+		out, err := ToAPIBillingRateCardEntitlement(domain)
+		require.NoError(t, err)
+
+		metered, err := out.AsBillingRateCardMeteredEntitlement()
+		require.NoError(t, err)
+
+		assert.Equal(t, "metered", string(metered.Type))
+		require.NotNil(t, metered.Limit)
+		assert.Equal(t, float64(1000), *metered.Limit)
+		require.NotNil(t, metered.IsSoftLimit)
+		assert.True(t, *metered.IsSoftLimit)
+		require.NotNil(t, metered.UsagePeriod)
+		assert.Equal(t, "P1M", string(*metered.UsagePeriod))
+	})
+
+	t.Run("metered — usage period defaults to billing cadence when omitted", func(t *testing.T) {
+		var apiEnt apiv3.BillingRateCardEntitlement
+		require.NoError(t, apiEnt.FromBillingRateCardMeteredEntitlement(apiv3.BillingRateCardMeteredEntitlement{
+			Type:  "metered",
+			Limit: lo.ToPtr(float64(5)),
+		}))
+
+		cadence, err := datetime.ISODurationString("P3M").Parse()
+		require.NoError(t, err)
+
+		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, &cadence)
+		require.NoError(t, err)
+
+		metered, err := domain.AsMetered()
+		require.NoError(t, err)
+		assert.Equal(t, "P3M", metered.UsagePeriod.ISOString().String())
+	})
+
+	t.Run("metered — missing usage period with no billing cadence is a validation error", func(t *testing.T) {
+		var apiEnt apiv3.BillingRateCardEntitlement
+		require.NoError(t, apiEnt.FromBillingRateCardMeteredEntitlement(apiv3.BillingRateCardMeteredEntitlement{
+			Type: "metered",
+		}))
+
+		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
+		require.Error(t, err)
+		assert.Nil(t, domain)
+	})
+
+	t.Run("metered — malformed usage period is a validation error", func(t *testing.T) {
+		bad := apiv3.ISO8601Duration("not-a-duration")
+		var apiEnt apiv3.BillingRateCardEntitlement
+		require.NoError(t, apiEnt.FromBillingRateCardMeteredEntitlement(apiv3.BillingRateCardMeteredEntitlement{
+			Type:        "metered",
+			UsagePeriod: &bad,
+		}))
+
+		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "invalid usage period")
+		assert.True(t, models.IsGenericValidationError(err), "malformed durations must surface as validation errors")
+		assert.Nil(t, domain)
+	})
+
+	t.Run("unknown entitlement type is rejected", func(t *testing.T) {
+		var apiEnt apiv3.BillingRateCardEntitlement
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"unknown"}`), &apiEnt))
+
+		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "unsupported entitlement type")
+		assert.Nil(t, domain)
+	})
+
+	t.Run("boolean — round-trips", func(t *testing.T) {
+		var apiEnt apiv3.BillingRateCardEntitlement
+		require.NoError(t, apiEnt.FromBillingRateCardBooleanEntitlement(apiv3.BillingRateCardBooleanEntitlement{
+			Type: "boolean",
+		}))
+
+		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
+		require.NoError(t, err)
+
+		out, err := ToAPIBillingRateCardEntitlement(domain)
+		require.NoError(t, err)
+
+		boolean, err := out.AsBillingRateCardBooleanEntitlement()
+		require.NoError(t, err)
+		assert.Equal(t, "boolean", string(boolean.Type))
+	})
+}

--- a/api/v3/handlers/addons/convert_test.go
+++ b/api/v3/handlers/addons/convert_test.go
@@ -126,7 +126,7 @@ func TestFromToAPIBillingRateCardEntitlement(t *testing.T) {
 		require.NotNil(t, metered.IsSoftLimit)
 		assert.True(t, *metered.IsSoftLimit)
 		require.NotNil(t, metered.UsagePeriod)
-		assert.Equal(t, "P1M", string(*metered.UsagePeriod))
+		assert.Equal(t, "P1M", *metered.UsagePeriod)
 	})
 
 	t.Run("metered — usage period defaults to billing cadence when omitted", func(t *testing.T) {

--- a/api/v3/handlers/plans/convert.go
+++ b/api/v3/handlers/plans/convert.go
@@ -205,10 +205,17 @@ func ToAPIBillingRateCardEntitlement(t *productcatalog.EntitlementTemplate) (*ap
 			return nil, fmt.Errorf("failed to read static entitlement template: %w", err)
 		}
 
-		var config interface{}
+		// The domain stores the config as a JSON string token wrapping the JSON
+		// text (v1 convention, relied on by subscription materialization). Unwrap
+		// it so the v3 API returns the raw JSON value. Legacy values that are not
+		// string-wrapped are returned as stored so reads never hard-fail.
+		var config json.RawMessage
 		if len(static.Config) > 0 {
-			if err := json.Unmarshal(static.Config, &config); err != nil {
-				return nil, fmt.Errorf("failed to decode static entitlement config: %w", err)
+			var text string
+			if err := json.Unmarshal(static.Config, &text); err == nil && json.Valid([]byte(text)) {
+				config = json.RawMessage(text)
+			} else {
+				config = json.RawMessage(static.Config)
 			}
 		}
 
@@ -586,20 +593,20 @@ func FromAPIBillingRateCard(rc api.BillingRateCard) (productcatalog.RateCard, er
 		meta.Discounts = discounts
 	}
 
-	if rc.Entitlement != nil {
-		// The metered usage period defaults to the rate card billing cadence, so
-		// parse it up front to pass into the entitlement converter (v1 parity).
-		var cadence *datetime.ISODuration
-		if rc.BillingCadence != nil {
-			bc, err := datetime.ISODurationString(*rc.BillingCadence).Parse()
-			if err != nil {
-				return nil, fmt.Errorf("invalid billing cadence: %w", err)
-			}
-
-			cadence = &bc
+	// The billing cadence doubles as the default usage period for metered
+	// entitlement templates, so parse it once up front.
+	var billingCadence *datetime.ISODuration
+	if rc.BillingCadence != nil {
+		bc, err := datetime.ISODurationString(*rc.BillingCadence).Parse()
+		if err != nil {
+			return nil, fmt.Errorf("invalid billing cadence: %w", err)
 		}
 
-		tmpl, err := FromAPIBillingRateCardEntitlement(*rc.Entitlement, cadence)
+		billingCadence = &bc
+	}
+
+	if rc.Entitlement != nil {
+		tmpl, err := FromAPIBillingRateCardEntitlement(*rc.Entitlement, billingCadence)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert entitlement template: %w", err)
 		}
@@ -617,29 +624,18 @@ func FromAPIBillingRateCard(rc api.BillingRateCard) (productcatalog.RateCard, er
 		meta.Price = price
 
 		flatRC := &productcatalog.FlatFeeRateCard{
-			RateCardMeta: meta,
-		}
-
-		if rc.BillingCadence != nil {
-			bc, err := datetime.ISODurationString(*rc.BillingCadence).Parse()
-			if err != nil {
-				return nil, fmt.Errorf("invalid billing cadence: %w", err)
-			}
-
-			flatRC.BillingCadence = &bc
+			RateCardMeta:   meta,
+			BillingCadence: billingCadence,
 		}
 
 		return flatRC, nil
 
 	case "unit", "graduated", "volume":
-		if rc.BillingCadence == nil {
+		if billingCadence == nil {
 			return nil, fmt.Errorf("billing cadence is required for usage-based rate card %q", rc.Key)
 		}
 
-		bc, err := datetime.ISODurationString(*rc.BillingCadence).Parse()
-		if err != nil {
-			return nil, fmt.Errorf("invalid billing cadence: %w", err)
-		}
+		bc := *billingCadence
 
 		price, err := FromAPIBillingPriceWithCommitments(rc.Price, rc.Commitments)
 		if err != nil {
@@ -676,7 +672,7 @@ func FromAPIBillingRateCardEntitlement(e api.BillingRateCardEntitlement, billing
 		if metered.UsagePeriod != nil {
 			usagePeriod, err = datetime.ISODurationString(*metered.UsagePeriod).Parse()
 			if err != nil {
-				return nil, fmt.Errorf("invalid usage period: %w", err)
+				return nil, models.NewGenericValidationError(fmt.Errorf("invalid usage period: %w", err))
 			}
 		}
 
@@ -699,18 +695,34 @@ func FromAPIBillingRateCardEntitlement(e api.BillingRateCardEntitlement, billing
 		return productcatalog.NewEntitlementTemplateFrom(tmpl), nil
 
 	case "static":
-		static, err := e.AsBillingRateCardStaticEntitlement()
+		// Extract the config's raw JSON bytes from the union so client values
+		// survive untouched (no float64 round-trip), then wrap them in a JSON
+		// string token: the domain-wide convention (shared with v1) stores the
+		// config as JSON-encoded text, which subscription materialization
+		// unwraps when instantiating the entitlement.
+		rawEnt, err := e.MarshalJSON()
 		if err != nil {
 			return nil, fmt.Errorf("failed to read static entitlement template: %w", err)
 		}
 
-		raw, err := json.Marshal(static.Config)
+		var static struct {
+			Config json.RawMessage `json:"config"`
+		}
+		if err := json.Unmarshal(rawEnt, &static); err != nil {
+			return nil, fmt.Errorf("failed to read static entitlement template: %w", err)
+		}
+
+		if len(static.Config) == 0 {
+			static.Config = json.RawMessage("null")
+		}
+
+		token, err := json.Marshal(string(static.Config))
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode static entitlement config: %w", err)
 		}
 
 		return productcatalog.NewEntitlementTemplateFrom(productcatalog.StaticEntitlementTemplate{
-			Config: raw,
+			Config: token,
 		}), nil
 
 	case "boolean":

--- a/api/v3/handlers/plans/convert.go
+++ b/api/v3/handlers/plans/convert.go
@@ -215,7 +215,7 @@ func ToAPIBillingRateCardEntitlement(t *productcatalog.EntitlementTemplate) (*ap
 			if err := json.Unmarshal(static.Config, &text); err == nil && json.Valid([]byte(text)) {
 				config = json.RawMessage(text)
 			} else {
-				config = json.RawMessage(static.Config)
+				config = static.Config
 			}
 		}
 

--- a/api/v3/handlers/plans/convert_test.go
+++ b/api/v3/handlers/plans/convert_test.go
@@ -1,6 +1,7 @@
 package plans
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -1328,6 +1329,57 @@ func TestFromToAPIBillingRateCardEntitlement(t *testing.T) {
 		assert.Nil(t, roundTripStaticConfig(t, nil))
 	})
 
+	t.Run("static — domain stores the v1 string-token convention", func(t *testing.T) {
+		// Subscription materialization (subscriptionspec.go) unwraps the stored
+		// config as a JSON string token containing JSON text. Pin that convention
+		// so v3-created static entitlements stay materializable.
+		var apiEnt api.BillingRateCardEntitlement
+		require.NoError(t, apiEnt.FromBillingRateCardStaticEntitlement(api.BillingRateCardStaticEntitlement{
+			Type:   "static",
+			Config: map[string]interface{}{"integrations": []interface{}{"github"}},
+		}))
+
+		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
+		require.NoError(t, err)
+
+		static, err := domain.AsStatic()
+		require.NoError(t, err)
+
+		var text string
+		require.NoError(t, json.Unmarshal(static.Config, &text),
+			"stored config must be a JSON string token wrapping the JSON text")
+		assert.JSONEq(t, `{"integrations":["github"]}`, text)
+	})
+
+	t.Run("static — large integers survive without float64 precision loss", func(t *testing.T) {
+		var apiEnt api.BillingRateCardEntitlement
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"static","config":{"id":9007199254740993}}`), &apiEnt))
+
+		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
+		require.NoError(t, err)
+
+		out, err := ToAPIBillingRateCardEntitlement(domain)
+		require.NoError(t, err)
+
+		raw, err := out.MarshalJSON()
+		require.NoError(t, err)
+		assert.Contains(t, string(raw), "9007199254740993")
+	})
+
+	t.Run("static — legacy non-token stored config is returned as stored, not an error", func(t *testing.T) {
+		// Reads must never hard-fail on data that was valid to persist.
+		domain := productcatalog.NewEntitlementTemplateFrom(productcatalog.StaticEntitlementTemplate{
+			Config: json.RawMessage(`{"a":1}`),
+		})
+
+		out, err := ToAPIBillingRateCardEntitlement(domain)
+		require.NoError(t, err)
+
+		static, err := out.AsBillingRateCardStaticEntitlement()
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{"a": float64(1)}, static.Config)
+	})
+
 	t.Run("metered — limit, soft limit, usage period round-trip", func(t *testing.T) {
 		usagePeriod := api.ISO8601Duration("P1M")
 
@@ -1384,6 +1436,52 @@ func TestFromToAPIBillingRateCardEntitlement(t *testing.T) {
 		// No usage_period on the entitlement and no billing cadence to default from.
 		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
 		require.Error(t, err)
+		assert.Nil(t, domain)
+	})
+
+	t.Run("metered — malformed usage period is a validation error", func(t *testing.T) {
+		bad := api.ISO8601Duration("not-a-duration")
+		var apiEnt api.BillingRateCardEntitlement
+		require.NoError(t, apiEnt.FromBillingRateCardMeteredEntitlement(api.BillingRateCardMeteredEntitlement{
+			Type:        "metered",
+			UsagePeriod: &bad,
+		}))
+
+		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "invalid usage period")
+		assert.True(t, models.IsGenericValidationError(err), "malformed durations must surface as validation errors")
+		assert.Nil(t, domain)
+	})
+
+	t.Run("metered — omitted is_soft_limit round-trips as explicit false", func(t *testing.T) {
+		usagePeriod := api.ISO8601Duration("P1M")
+		var apiEnt api.BillingRateCardEntitlement
+		require.NoError(t, apiEnt.FromBillingRateCardMeteredEntitlement(api.BillingRateCardMeteredEntitlement{
+			Type:        "metered",
+			UsagePeriod: &usagePeriod,
+			Limit:       lo.ToPtr(float64(5)),
+		}))
+
+		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
+		require.NoError(t, err)
+
+		out, err := ToAPIBillingRateCardEntitlement(domain)
+		require.NoError(t, err)
+
+		metered, err := out.AsBillingRateCardMeteredEntitlement()
+		require.NoError(t, err)
+		require.NotNil(t, metered.IsSoftLimit)
+		assert.False(t, *metered.IsSoftLimit)
+	})
+
+	t.Run("unknown entitlement type is rejected", func(t *testing.T) {
+		var apiEnt api.BillingRateCardEntitlement
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"unknown"}`), &apiEnt))
+
+		domain, err := FromAPIBillingRateCardEntitlement(apiEnt, nil)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "unsupported entitlement type")
 		assert.Nil(t, domain)
 	})
 

--- a/e2e/plan_entitlement_template_v3_test.go
+++ b/e2e/plan_entitlement_template_v3_test.go
@@ -22,8 +22,9 @@ import (
 // all (local servers rejected it with 400 "property \"entitlement\" is
 // unsupported"; Kong Konnect's gateway stripped it and returned a silent 201).
 //
-// The fix adds the `entitlement` field (V2-aligned: structured `issue`) to the
-// v3 schema and wires it through the converter. This test asserts the corrected
+// The fix adds the `entitlement` field (simplified metered shape: `limit`,
+// `is_soft_limit`, `usage_period`) to the v3 schema and wires it through the
+// converter. This test asserts the corrected
 // end-to-end behavior: create is accepted (201), the entitlement round-trips on
 // GET, and the metered entitlement materializes on subscription, surfacing via
 // GET .../entitlement-access.

--- a/e2e/plan_entitlement_template_v3_test.go
+++ b/e2e/plan_entitlement_template_v3_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	api "github.com/openmeterio/openmeter/api/client/go"
 	apiv3 "github.com/openmeterio/openmeter/api/v3"
 )
 
@@ -169,4 +171,181 @@ func meteredEntitlementRateCard(f apiv3.Feature, limit float64) apiv3.BillingRat
 		Feature:        &apiv3.FeatureReferenceItem{Id: f.Id},
 		Entitlement:    &entitlement,
 	}
+}
+
+// TestV3V1StaticEntitlementConfigCrossVersion proves the v1 and v3 plan
+// converters agree on the *stored domain representation* of a static
+// entitlement config, by writing through one API version and reading through
+// the other.
+func TestV3V1StaticEntitlementConfigCrossVersion(t *testing.T) {
+	v3 := newV3Client(t)
+	v1 := initClient(t)
+
+	// The canonical config object the client cares about. Compared with
+	// assert.JSONEq throughout, so key ordering is irrelevant.
+	const configJSON = `{"integrations":["github","slack"],"limit":10}`
+
+	t.Run("write via v3 (JSON object) -> read via v1 (JSON string token)", func(t *testing.T) {
+		featureKey := uniqueKey("xver_v3w_feat")
+		status, feature, problem := v3.CreateFeature(apiv3.CreateFeatureRequest{
+			Key:  featureKey,
+			Name: "Cross-version static (v3 write)",
+		})
+		require.Equal(t, http.StatusCreated, status, "create feature: %+v", problem)
+		require.NotNil(t, feature)
+
+		// v3 sends the config as a raw JSON object.
+		var configObj map[string]any
+		require.NoError(t, json.Unmarshal([]byte(configJSON), &configObj))
+
+		ent := apiv3.BillingRateCardEntitlement{}
+		require.NoError(t, ent.FromBillingRateCardStaticEntitlement(apiv3.BillingRateCardStaticEntitlement{
+			Type:   "static",
+			Config: configObj,
+		}))
+
+		status, created, problem := v3.CreatePlan(apiv3.CreatePlanRequest{
+			Key:            uniqueKey("xver_v3w_plan"),
+			Name:           "Cross-version static (v3 write)",
+			Currency:       "USD",
+			BillingCadence: apiv3.ISO8601Duration("P1M"),
+			Phases: []apiv3.BillingPlanPhase{{
+				Key:       "subscription",
+				Name:      "Subscription",
+				RateCards: []apiv3.BillingRateCard{staticRateCardV3(t, *feature, ent)},
+			}},
+		})
+		require.Equal(t, http.StatusCreated, status, "create plan (v3): %+v", problem)
+		require.NotNil(t, created)
+
+		// Read the same plan back through the v1 SDK.
+		getResp, err := v1.GetPlanWithResponse(t.Context(), created.Id, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, getResp.StatusCode(), "get plan (v1): %s", string(getResp.Body))
+		require.NotNil(t, getResp.JSON200)
+
+		v1Config := v1StaticConfig(t, *getResp.JSON200)
+
+		// The v1 contract is a JSON string token: the bytes must decode into a
+		// Go string whose content is the original JSON object. (Under the old v3
+		// write this would be a raw object and the unmarshal-into-string fails.)
+		var inner string
+		require.NoError(t, json.Unmarshal(v1Config, &inner),
+			"v1 must return the static config as a JSON string token, got raw bytes %q", string(v1Config))
+		assert.JSONEq(t, configJSON, inner, "decoded v1 string token must equal the config the v3 client sent")
+	})
+
+	t.Run("write via v1 (JSON string token) -> read via v3 (JSON object)", func(t *testing.T) {
+		featureKey := uniqueKey("xver_v1w_feat")
+		status, feature, problem := v3.CreateFeature(apiv3.CreateFeatureRequest{
+			Key:  featureKey,
+			Name: "Cross-version static (v1 write)",
+		})
+		require.Equal(t, http.StatusCreated, status, "create feature: %+v", problem)
+		require.NotNil(t, feature)
+
+		// v1 sends the config as a JSON string token: a JSON string whose
+		// content is the config object. json.Marshal of a Go string produces
+		// exactly that quoted, escaped form.
+		token := lo.Must(json.Marshal(configJSON))
+
+		et := api.RateCardEntitlement{}
+		require.NoError(t, et.FromRateCardStaticEntitlement(api.RateCardStaticEntitlement{
+			Type:   api.RateCardStaticEntitlementTypeStatic,
+			Config: json.RawMessage(token),
+		}))
+
+		rc := api.RateCard{}
+		require.NoError(t, rc.FromRateCardFlatFee(api.RateCardFlatFee{
+			Type:                api.RateCardFlatFeeTypeFlatFee,
+			Key:                 feature.Key,
+			Name:                "Cross-version static (v1 write)",
+			FeatureKey:          lo.ToPtr(feature.Key),
+			EntitlementTemplate: &et,
+			BillingCadence:      lo.ToPtr("P1M"),
+			Price: &api.FlatPriceWithPaymentTerm{
+				Type:        api.FlatPriceWithPaymentTermTypeFlat,
+				Amount:      "3000",
+				PaymentTerm: lo.ToPtr(api.PricePaymentTermInAdvance),
+			},
+		}))
+
+		createResp, err := v1.CreatePlanWithResponse(t.Context(), api.PlanCreate{
+			Key:            uniqueKey("xver_v1w_plan"),
+			Name:           "Cross-version static (v1 write)",
+			Currency:       api.CurrencyCode("USD"),
+			BillingCadence: "P1M",
+			Phases: []api.PlanPhase{{
+				Key:       "subscription",
+				Name:      "Subscription",
+				RateCards: []api.RateCard{rc},
+			}},
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, createResp.StatusCode(), "create plan (v1): %s", string(createResp.Body))
+		require.NotNil(t, createResp.JSON201)
+
+		// Read the same plan back through the v3 API.
+		status, got, problem := v3.GetPlan(createResp.JSON201.Id)
+		require.Equal(t, http.StatusOK, status, "get plan (v3): %+v", problem)
+		require.NotNil(t, got)
+		require.Len(t, got.Phases, 1)
+		require.Len(t, got.Phases[0].RateCards, 1)
+		require.NotNil(t, got.Phases[0].RateCards[0].Entitlement, "entitlement should round-trip on v3 GET")
+
+		static, err := got.Phases[0].RateCards[0].Entitlement.AsBillingRateCardStaticEntitlement()
+		require.NoError(t, err, "rate card entitlement should be the static variant")
+
+		// The v3 contract is a JSON object: the token must have been unwrapped.
+		// (Under the old v3 read this would surface as a Go string instead.)
+		_, isString := static.Config.(string)
+		assert.False(t, isString, "v3 must return the static config as a JSON object, not a string token")
+
+		raw, err := json.Marshal(static.Config)
+		require.NoError(t, err)
+		assert.JSONEq(t, configJSON, string(raw), "v3 object must equal the config the v1 client sent")
+	})
+}
+
+// staticRateCardV3 builds a flat, in-advance, feature-linked v3 rate card
+// carrying the given static entitlement template.
+func staticRateCardV3(t *testing.T, f apiv3.Feature, ent apiv3.BillingRateCardEntitlement) apiv3.BillingRateCard {
+	t.Helper()
+
+	cadence := apiv3.ISO8601Duration("P1M")
+	term := apiv3.BillingPricePaymentTermInAdvance
+
+	price := apiv3.BillingPrice{}
+	require.NoError(t, price.FromBillingPriceFlat(apiv3.BillingPriceFlat{
+		Type:   apiv3.BillingPriceFlatTypeFlat,
+		Amount: "3000",
+	}))
+
+	return apiv3.BillingRateCard{
+		Key:            f.Key,
+		Name:           "Cross-version static",
+		Price:          price,
+		BillingCadence: &cadence,
+		PaymentTerm:    &term,
+		Feature:        &apiv3.FeatureReferenceItem{Id: f.Id},
+		Entitlement:    &ent,
+	}
+}
+
+// v1StaticConfig pulls the static entitlement config bytes out of the single
+// rate card of a v1 plan response.
+func v1StaticConfig(t *testing.T, plan api.Plan) json.RawMessage {
+	t.Helper()
+
+	require.Len(t, plan.Phases, 1)
+	require.Len(t, plan.Phases[0].RateCards, 1)
+
+	flat, err := plan.Phases[0].RateCards[0].AsRateCardFlatFee()
+	require.NoError(t, err, "rate card should be the flat-fee variant")
+	require.NotNil(t, flat.EntitlementTemplate, "entitlement should round-trip on v1 GET")
+
+	static, err := flat.EntitlementTemplate.AsRateCardStaticEntitlement()
+	require.NoError(t, err, "entitlement should be the static variant")
+
+	return static.Config
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve client-provided JSON for static entitlements (unwrap legacy string-wrapped JSON, keep non-wrapped payloads) and avoid hard-failing reads.
  * Malformed or missing usage periods now yield proper validation errors; billing cadence is parsed once and applied consistently during conversions.
  * Boolean and other entitlement types now round-trip reliably.

* **Tests**
  * Added unit and end-to-end tests for static-config round-trips, legacy token handling, metered-entitlement validation, and cross-version serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->