### PR TITLE
perf(governance): resolve customer keys in one bulk query [OM-387]

### DIFF
--- a/openmeter/customer/adapter.go
+++ b/openmeter/customer/adapter.go
@@ -21,5 +21,6 @@ type CustomerAdapter interface {
 	DeleteCustomer(ctx context.Context, customer DeleteCustomerInput) error
 	GetCustomer(ctx context.Context, customer GetCustomerInput) (*Customer, error)
 	GetCustomerByUsageAttribution(ctx context.Context, input GetCustomerByUsageAttributionInput) (*Customer, error)
+	GetCustomersByUsageAttribution(ctx context.Context, input GetCustomersByUsageAttributionInput) ([]Customer, error)
 	UpdateCustomer(ctx context.Context, params UpdateCustomerInput) (*Customer, error)
 }

--- a/openmeter/customer/adapter/customer.go
+++ b/openmeter/customer/adapter/customer.go
@@ -552,6 +552,69 @@ func (a *adapter) GetCustomerByUsageAttribution(ctx context.Context, input custo
 	})
 }
 
+// GetCustomersByUsageAttribution resolves multiple customers by usage attribution keys in a single query.
+// A key matches a customer either by the customer's own key or by one of its subject keys, mirroring
+// the single-key GetCustomerByUsageAttribution. Keys that match no customer are simply absent from the
+// result; the caller derives which keys were not found.
+func (a *adapter) GetCustomersByUsageAttribution(ctx context.Context, input customer.GetCustomersByUsageAttributionInput) ([]customer.Customer, error) {
+	if err := input.Validate(); err != nil {
+		return nil, models.NewGenericValidationError(
+			fmt.Errorf("error getting customers by usage attribution: %w", err),
+		)
+	}
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, repo *adapter) ([]customer.Customer, error) {
+		now := clock.Now().UTC()
+
+		query := repo.db.Customer.Query().
+			Where(customerdb.Namespace(input.Namespace)).
+			Where(
+				customerdb.Or(
+					// We lookup customers by subject key in the subjects table
+					customerdb.HasSubjectsWith(
+						customersubjectsdb.SubjectKeyIn(input.Keys...),
+						customersubjectsdb.Or(
+							customersubjectsdb.DeletedAtIsNil(),
+							customersubjectsdb.DeletedAtGT(now),
+						),
+					),
+					// Or else we lookup customers by key in the customers table
+					customerdb.KeyIn(input.Keys...),
+				),
+			).
+			Where(customerdb.DeletedAtIsNil())
+		query = WithSubjects(query, now)
+		if slices.Contains(input.Expands, customer.ExpandSubscriptions) {
+			query = WithActiveSubscriptions(query, now)
+		}
+
+		entities, err := query.All(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch customers: %w", err)
+		}
+
+		result := make([]customer.Customer, 0, len(entities))
+		for _, entity := range entities {
+			if entity == nil {
+				a.logger.WarnContext(ctx, "invalid query result: nil customer received")
+				continue
+			}
+
+			cust, err := CustomerFromDBEntity(*entity, input.Expands)
+			if err != nil {
+				return nil, fmt.Errorf("failed to convert customer: %w", err)
+			}
+			if cust == nil {
+				return nil, fmt.Errorf("invalid query result: nil customer received")
+			}
+
+			result = append(result, *cust)
+		}
+
+		return result, nil
+	})
+}
+
 // UpdateCustomer updates a customer
 func (a *adapter) UpdateCustomer(ctx context.Context, input customer.UpdateCustomerInput) (*customer.Customer, error) {
 	if err := input.Validate(); err != nil {

--- a/openmeter/customer/adapter/customer.go
+++ b/openmeter/customer/adapter/customer.go
@@ -557,15 +557,11 @@ func (a *adapter) GetCustomerByUsageAttribution(ctx context.Context, input custo
 // the single-key GetCustomerByUsageAttribution. Keys that match no customer are simply absent from the
 // result; the caller derives which keys were not found.
 func (a *adapter) GetCustomersByUsageAttribution(ctx context.Context, input customer.GetCustomersByUsageAttributionInput) ([]customer.Customer, error) {
-	if err := input.Validate(); err != nil {
-		return nil, models.NewGenericValidationError(
-			fmt.Errorf("error getting customers by usage attribution: %w", err),
-		)
-	}
-
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, repo *adapter) ([]customer.Customer, error) {
 		now := clock.Now().UTC()
 
+		// TODO: consider adding a CreatedAtLTE(now) guard to the customer/subject query,
+		//       to defend against the edge case of having customers/subjects becoming active in the future
 		query := repo.db.Customer.Query().
 			Where(customerdb.Namespace(input.Namespace)).
 			Where(
@@ -573,6 +569,7 @@ func (a *adapter) GetCustomersByUsageAttribution(ctx context.Context, input cust
 					// We lookup customers by subject key in the subjects table
 					customerdb.HasSubjectsWith(
 						customersubjectsdb.SubjectKeyIn(input.Keys...),
+						customersubjectsdb.CreatedAtLTE(now),
 						customersubjectsdb.Or(
 							customersubjectsdb.DeletedAtIsNil(),
 							customersubjectsdb.DeletedAtGT(now),
@@ -583,7 +580,11 @@ func (a *adapter) GetCustomersByUsageAttribution(ctx context.Context, input cust
 				),
 			).
 			Where(customerdb.DeletedAtIsNil())
+
+		// TODO: consider adding a CreatedAtLTE(now) guard to the WithSubjects query,
+		//       to defend against the edge case of having customers/subjects becoming active in the future
 		query = WithSubjects(query, now)
+
 		if slices.Contains(input.Expands, customer.ExpandSubscriptions) {
 			query = WithActiveSubscriptions(query, now)
 		}
@@ -594,9 +595,11 @@ func (a *adapter) GetCustomersByUsageAttribution(ctx context.Context, input cust
 		}
 
 		result := make([]customer.Customer, 0, len(entities))
+
 		for _, entity := range entities {
 			if entity == nil {
 				a.logger.WarnContext(ctx, "invalid query result: nil customer received")
+
 				continue
 			}
 
@@ -604,6 +607,7 @@ func (a *adapter) GetCustomersByUsageAttribution(ctx context.Context, input cust
 			if err != nil {
 				return nil, fmt.Errorf("failed to convert customer: %w", err)
 			}
+
 			if cust == nil {
 				return nil, fmt.Errorf("invalid query result: nil customer received")
 			}

--- a/openmeter/customer/adapter/customer_test.go
+++ b/openmeter/customer/adapter/customer_test.go
@@ -526,17 +526,6 @@ func TestGetCustomersByUsageAttribution(t *testing.T) {
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{idA}, customerIDs(got), "must only return the customer in the queried namespace")
 	})
-
-	t.Run("ValidationError", func(t *testing.T) {
-		env := newTestEnv(t)
-		ns := ulid.Make().String()
-
-		_, err := env.adapter.GetCustomersByUsageAttribution(t.Context(), customer.GetCustomersByUsageAttributionInput{
-			Namespace: ns,
-			Keys:      nil,
-		})
-		require.Error(t, err, "empty key set must fail validation")
-	})
 }
 
 // --- assertion helpers ---

--- a/openmeter/customer/adapter/customer_test.go
+++ b/openmeter/customer/adapter/customer_test.go
@@ -358,6 +358,188 @@ func TestDeleteCustomer(t *testing.T) {
 	})
 }
 
+// seedCustomerWithKey creates an active customer with the given key and subject keys.
+func (e *testEnv) seedCustomerWithKey(namespace, key string, subjectKeys ...string) string {
+	e.t.Helper()
+	ctx := e.t.Context()
+
+	create := e.db.Customer.Create().
+		SetNamespace(namespace).
+		SetName("customer-" + key)
+	if key != "" {
+		create = create.SetKey(key)
+	}
+	cust, err := create.Save(ctx)
+	require.NoError(e.t, err, "seeding customer must not fail")
+
+	for _, sk := range subjectKeys {
+		_, err = e.db.CustomerSubjects.Create().
+			SetNamespace(namespace).
+			SetCustomerID(cust.ID).
+			SetSubjectKey(sk).
+			Save(ctx)
+		require.NoError(e.t, err, "seeding customer subject must not fail")
+	}
+
+	return cust.ID
+}
+
+func customerIDs(customers []customer.Customer) []string {
+	ids := make([]string, 0, len(customers))
+	for _, c := range customers {
+		ids = append(ids, c.ID)
+	}
+	return ids
+}
+
+func TestGetCustomersByUsageAttribution(t *testing.T) {
+	t.Run("MatchByCustomerKey", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		id := env.seedCustomerWithKey(ns, "cust-key", "subj-1")
+
+		got, err := env.adapter.GetCustomersByUsageAttribution(t.Context(), customer.GetCustomersByUsageAttributionInput{
+			Namespace: ns,
+			Keys:      []string{"cust-key"},
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{id}, customerIDs(got))
+	})
+
+	t.Run("MatchBySubjectKey", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		id := env.seedCustomerWithKey(ns, "cust-key", "subj-1", "subj-2")
+
+		got, err := env.adapter.GetCustomersByUsageAttribution(t.Context(), customer.GetCustomersByUsageAttributionInput{
+			Namespace: ns,
+			Keys:      []string{"subj-2"},
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{id}, customerIDs(got))
+	})
+
+	t.Run("MixedSetResolvesDistinctCustomers", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		idA := env.seedCustomerWithKey(ns, "key-a", "subj-a")
+		idB := env.seedCustomerWithKey(ns, "key-b", "subj-b")
+
+		got, err := env.adapter.GetCustomersByUsageAttribution(t.Context(), customer.GetCustomersByUsageAttributionInput{
+			Namespace: ns,
+			// key-a hits A by customer key, subj-b hits B by subject key.
+			Keys: []string{"key-a", "subj-b"},
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{idA, idB}, customerIDs(got))
+	})
+
+	t.Run("UnmatchedKeyIsAbsent", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		id := env.seedCustomerWithKey(ns, "key-a", "subj-a")
+
+		got, err := env.adapter.GetCustomersByUsageAttribution(t.Context(), customer.GetCustomersByUsageAttributionInput{
+			Namespace: ns,
+			Keys:      []string{"key-a", "does-not-exist"},
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{id}, customerIDs(got))
+	})
+
+	t.Run("CustomerMatchedByOwnKeyAndSubjectKeyReturnedOnce", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		id := env.seedCustomerWithKey(ns, "key-a", "subj-a")
+
+		got, err := env.adapter.GetCustomersByUsageAttribution(t.Context(), customer.GetCustomersByUsageAttributionInput{
+			Namespace: ns,
+			Keys:      []string{"key-a", "subj-a"},
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{id}, customerIDs(got), "a customer matched by multiple keys must appear once")
+	})
+
+	t.Run("SoftDeletedCustomerExcluded", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		id := env.seedCustomerWithKey(ns, "key-a", "subj-a")
+
+		_ = freezeTime(t, time.Now())
+		require.NoError(t, env.adapter.DeleteCustomer(t.Context(), customer.DeleteCustomerInput{
+			Namespace: ns,
+			ID:        id,
+		}))
+
+		got, err := env.adapter.GetCustomersByUsageAttribution(t.Context(), customer.GetCustomersByUsageAttributionInput{
+			Namespace: ns,
+			Keys:      []string{"key-a", "subj-a"},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, customerIDs(got), "soft-deleted customer must not be returned")
+	})
+
+	t.Run("SoftDeletedSubjectExcludedButCustomerKeyStillMatches", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+		id := env.seedCustomerWithKey(ns, "key-a", "subj-a")
+
+		// Soft-delete the subject only; the customer itself stays active.
+		t0 := time.Now().Add(-time.Hour).UTC().Truncate(time.Microsecond)
+		_, err := env.db.CustomerSubjects.Update().
+			Where(
+				customersubjectsdb.Namespace(ns),
+				customersubjectsdb.CustomerID(id),
+				customersubjectsdb.SubjectKey("subj-a"),
+			).
+			SetDeletedAt(t0).
+			Save(t.Context())
+		require.NoError(t, err)
+
+		// The deleted subject key no longer matches.
+		bySubject, err := env.adapter.GetCustomersByUsageAttribution(t.Context(), customer.GetCustomersByUsageAttributionInput{
+			Namespace: ns,
+			Keys:      []string{"subj-a"},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, customerIDs(bySubject), "soft-deleted subject key must not match")
+
+		// But the customer's own key still matches.
+		byKey, err := env.adapter.GetCustomersByUsageAttribution(t.Context(), customer.GetCustomersByUsageAttributionInput{
+			Namespace: ns,
+			Keys:      []string{"key-a"},
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{id}, customerIDs(byKey))
+	})
+
+	t.Run("NamespaceIsolation", func(t *testing.T) {
+		env := newTestEnv(t)
+		nsA := ulid.Make().String()
+		nsB := ulid.Make().String()
+		idA := env.seedCustomerWithKey(nsA, "shared-key", "shared-subj")
+		_ = env.seedCustomerWithKey(nsB, "shared-key", "shared-subj")
+
+		got, err := env.adapter.GetCustomersByUsageAttribution(t.Context(), customer.GetCustomersByUsageAttributionInput{
+			Namespace: nsA,
+			Keys:      []string{"shared-key", "shared-subj"},
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{idA}, customerIDs(got), "must only return the customer in the queried namespace")
+	})
+
+	t.Run("ValidationError", func(t *testing.T) {
+		env := newTestEnv(t)
+		ns := ulid.Make().String()
+
+		_, err := env.adapter.GetCustomersByUsageAttribution(t.Context(), customer.GetCustomersByUsageAttributionInput{
+			Namespace: ns,
+			Keys:      nil,
+		})
+		require.Error(t, err, "empty key set must fail validation")
+	})
+}
+
 // --- assertion helpers ---
 
 func assertCustomerDeletedAt(t *testing.T, db *entdb.Client, ns, id string, want time.Time) {

--- a/openmeter/customer/adapter/customer_test.go
+++ b/openmeter/customer/adapter/customer_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -385,11 +386,9 @@ func (e *testEnv) seedCustomerWithKey(namespace, key string, subjectKeys ...stri
 }
 
 func customerIDs(customers []customer.Customer) []string {
-	ids := make([]string, 0, len(customers))
-	for _, c := range customers {
-		ids = append(ids, c.ID)
-	}
-	return ids
+	return lo.Map(customers, func(c customer.Customer, _ int) string {
+		return c.ID
+	})
 }
 
 func TestGetCustomersByUsageAttribution(t *testing.T) {

--- a/openmeter/customer/customer.go
+++ b/openmeter/customer/customer.go
@@ -292,6 +292,39 @@ func (i GetCustomerByUsageAttributionInput) Validate() error {
 	return nil
 }
 
+// GetCustomersByUsageAttributionInput represents the input for the GetCustomersByUsageAttribution method
+type GetCustomersByUsageAttributionInput struct {
+	Namespace string
+
+	// The keys of either the customers or one of their subjects
+	Keys []string
+
+	// Expand
+	Expands Expands
+}
+
+func (i GetCustomersByUsageAttributionInput) Validate() error {
+	var errs []error
+
+	if i.Namespace == "" {
+		errs = append(errs, errors.New("namespace is required"))
+	}
+
+	if len(i.Keys) == 0 {
+		errs = append(errs, errors.New("at least one key is required"))
+	}
+
+	if slices.Contains(i.Keys, "") {
+		errs = append(errs, errors.New("key cannot be empty"))
+	}
+
+	if err := i.Expands.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
 // ListCustomersInput represents the input for the ListCustomers method
 type ListCustomersInput struct {
 	Namespace string

--- a/openmeter/customer/service.go
+++ b/openmeter/customer/service.go
@@ -26,5 +26,6 @@ type CustomerService interface {
 	DeleteCustomer(ctx context.Context, customer DeleteCustomerInput) error
 	GetCustomer(ctx context.Context, customer GetCustomerInput) (*Customer, error)
 	GetCustomerByUsageAttribution(ctx context.Context, input GetCustomerByUsageAttributionInput) (*Customer, error)
+	GetCustomersByUsageAttribution(ctx context.Context, input GetCustomersByUsageAttributionInput) ([]Customer, error)
 	UpdateCustomer(ctx context.Context, params UpdateCustomerInput) (*Customer, error)
 }

--- a/openmeter/customer/service/customer.go
+++ b/openmeter/customer/service/customer.go
@@ -138,6 +138,12 @@ func (s *Service) GetCustomerByUsageAttribution(ctx context.Context, input custo
 
 // GetCustomersByUsageAttribution resolves multiple customers by usage attribution keys in a single query
 func (s *Service) GetCustomersByUsageAttribution(ctx context.Context, input customer.GetCustomersByUsageAttributionInput) ([]customer.Customer, error) {
+	if err := input.Validate(); err != nil {
+		return nil, models.NewGenericValidationError(
+			fmt.Errorf("error getting customers by usage attribution: %w", err),
+		)
+	}
+
 	return s.adapter.GetCustomersByUsageAttribution(ctx, input)
 }
 

--- a/openmeter/customer/service/customer.go
+++ b/openmeter/customer/service/customer.go
@@ -136,6 +136,11 @@ func (s *Service) GetCustomerByUsageAttribution(ctx context.Context, input custo
 	return s.adapter.GetCustomerByUsageAttribution(ctx, input)
 }
 
+// GetCustomersByUsageAttribution resolves multiple customers by usage attribution keys in a single query
+func (s *Service) GetCustomersByUsageAttribution(ctx context.Context, input customer.GetCustomersByUsageAttributionInput) ([]customer.Customer, error) {
+	return s.adapter.GetCustomersByUsageAttribution(ctx, input)
+}
+
 // UpdateCustomer updates a customer
 func (s *Service) UpdateCustomer(ctx context.Context, input customer.UpdateCustomerInput) (*customer.Customer, error) {
 	// Validate the input

--- a/openmeter/customer/service/service_test.go
+++ b/openmeter/customer/service/service_test.go
@@ -220,3 +220,26 @@ func Test_CustomerService(t *testing.T) {
 		})
 	})
 }
+
+func Test_GetCustomersByUsageAttribution_Validation(t *testing.T) {
+	env := customertestutils.NewTestEnv(t)
+	t.Cleanup(func() {
+		env.Close(t)
+	})
+	env.DBSchemaMigrate(t)
+
+	namespace := customertestutils.NewTestNamespace(t)
+
+	// given:
+	// - an empty key set
+	// when:
+	// - resolving customers by usage attribution
+	// then:
+	// - the service rejects it with a validation error before any DB query is built
+	_, err := env.CustomerService.GetCustomersByUsageAttribution(t.Context(), customer.GetCustomersByUsageAttributionInput{
+		Namespace: namespace,
+		Keys:      nil,
+	})
+	require.Error(t, err, "empty key set must fail validation")
+	assert.True(t, models.IsGenericValidationError(err), "error must be a validation error")
+}

--- a/openmeter/governance/service/service.go
+++ b/openmeter/governance/service/service.go
@@ -278,9 +278,9 @@ type resolveCustomersResult struct {
 	queryErrors       []governance.QueryError
 }
 
-// resolveCustomers resolves each input key to a customer, deduplicating by customer ID.
-// Keys that resolve to no customer are collected as customer-not-found query errors rather
-// than failing the whole request.
+// resolveCustomers resolves the input keys to customers in a single bulk lookup, deduplicating
+// by customer ID. Keys that resolve to no customer are collected as customer-not-found query
+// errors rather than failing the whole request.
 func (s *service) resolveCustomers(ctx context.Context, input governance.QueryAccessInput) (resolveCustomersResult, error) {
 	fn := func(ctx context.Context) (resolveCustomersResult, error) {
 		span := trace.SpanFromContext(ctx)
@@ -289,24 +289,47 @@ func (s *service) resolveCustomers(ctx context.Context, input governance.QueryAc
 			attribute.Int("requested", len(input.CustomerKeys)),
 		)
 
+		customers, err := s.customerService.GetCustomersByUsageAttribution(ctx, customer.GetCustomersByUsageAttributionInput{
+			Namespace: input.Namespace,
+			Keys:      input.CustomerKeys,
+		})
+		if err != nil {
+			return resolveCustomersResult{}, fmt.Errorf("failed to resolve customer keys: %w", err)
+		}
+
+		// Map each lookup key to the customer it resolved to. A key matches a customer either by
+		// the customer's own key or by one of its subject keys. First match wins on the rare
+		// collision, mirroring the single-key First() lookup.
+		keyToCustomer := make(map[string]*customer.Customer, len(customers))
+		for i := range customers {
+			cus := &customers[i]
+			if cus.Key != nil {
+				if _, ok := keyToCustomer[*cus.Key]; !ok {
+					keyToCustomer[*cus.Key] = cus
+				}
+			}
+			if cus.UsageAttribution != nil {
+				for _, sk := range cus.UsageAttribution.SubjectKeys {
+					if _, ok := keyToCustomer[sk]; !ok {
+						keyToCustomer[sk] = cus
+					}
+				}
+			}
+		}
+
 		customerMap := make(map[string]*resolvedCustomer)
 		var queryErrors []governance.QueryError
 
+		// Iterate the input keys in order so matched keys and not-found errors keep input ordering.
 		for _, key := range input.CustomerKeys {
-			cus, err := s.customerService.GetCustomerByUsageAttribution(ctx, customer.GetCustomerByUsageAttributionInput{
-				Namespace: input.Namespace,
-				Key:       key,
-			})
-			if err != nil {
-				if models.IsGenericNotFoundError(err) {
-					queryErrors = append(queryErrors, governance.QueryError{
-						CustomerKey: key,
-						Code:        governance.QueryErrorCustomerNotFound,
-						Message:     "customer not found",
-					})
-					continue
-				}
-				return resolveCustomersResult{}, fmt.Errorf("failed to resolve customer key %q: %w", key, err)
+			cus, ok := keyToCustomer[key]
+			if !ok {
+				queryErrors = append(queryErrors, governance.QueryError{
+					CustomerKey: key,
+					Code:        governance.QueryErrorCustomerNotFound,
+					Message:     "customer not found",
+				})
+				continue
 			}
 
 			if rc, ok := customerMap[cus.ID]; ok {

--- a/openmeter/governance/service/service.go
+++ b/openmeter/governance/service/service.go
@@ -299,13 +299,16 @@ func (s *service) resolveCustomers(ctx context.Context, input governance.QueryAc
 		// the customer's own key or by one of its subject keys. First match wins on the rare
 		// collision, mirroring the single-key First() lookup.
 		keyToCustomer := make(map[string]*customer.Customer, len(customers))
+
 		for i := range customers {
 			cus := &customers[i]
+
 			if cus.Key != nil {
 				if _, ok := keyToCustomer[*cus.Key]; !ok {
 					keyToCustomer[*cus.Key] = cus
 				}
 			}
+
 			if cus.UsageAttribution != nil {
 				for _, sk := range cus.UsageAttribution.SubjectKeys {
 					if _, ok := keyToCustomer[sk]; !ok {
@@ -321,6 +324,7 @@ func (s *service) resolveCustomers(ctx context.Context, input governance.QueryAc
 		// Iterate the input keys in order so matched keys and not-found errors keep input ordering.
 		for _, key := range input.CustomerKeys {
 			cus, ok := keyToCustomer[key]
+
 			if !ok {
 				queryErrors = append(queryErrors, governance.QueryError{
 					CustomerKey: key,

--- a/openmeter/governance/service/service.go
+++ b/openmeter/governance/service/service.go
@@ -158,25 +158,23 @@ var _ governance.Service = (*service)(nil)
 // Pagination is in-memory, by design. The reason is the BOUND: the input is OAS-capped at
 // 100 keys (@maxItems), so the resolvable set is ≤100 — sorting and slicing it in memory is
 // trivially cheap, and pushing a keyset cursor into the DB would buy nothing. (It is NOT
-// because there's no collection to paginate: customer.ListCustomers is a DB-side, orderable,
-// paginated query and could resolve+order+limit the key set via a `Key $in [...] $or
-// usageAttributionSubjectKey $in [...]` filter. That path only becomes worthwhile if the
-// 100-key cap is ever lifted — see below.)
+// because there's no collection to paginate: resolution already runs as a single bulk
+// customer.GetCustomersByUsageAttribution query, and customer.ListCustomers is a DB-side,
+// orderable, paginated query that could additionally order+limit the key set via a
+// `Key $in [...] $or usageAttributionSubjectKey $in [...]` filter. That DB-paginated path
+// only becomes worthwhile if the 100-key cap is ever lifted — see below.)
 //
 // Phase order and what each page actually costs (e.g. page size 10 over 100 resolved):
-//  1. resolveCustomers resolves ALL keys (today: a point lookup per key) — runs in full
-//     regardless of page size, because the sort key is (CreatedAt, ID), customer fields:
-//     page order can't be established without first resolving every key to a customer.
+//  1. resolveCustomers resolves ALL keys (one bulk customer.GetCustomersByUsageAttribution
+//     query) — runs in full regardless of page size, because the sort key is (CreatedAt, ID),
+//     customer fields: page order can't be established without first resolving every key to a
+//     customer. Dedup, the per-input `matched` mapping, and per-key not-found reporting are
+//     done in memory, since the input mixes customer keys and subject keys.
 //  2. sort the full set in memory.
 //  3. paginate slices to PageSize (10).
 //  4. resolveAccess runs only over the page (10): the expensive per-customer GetAccess
 //     fan-out + one listOrgFeatures. So the dominant cost IS page-limited; only the cheaper
 //     full-set resolution is paid in full (and repeated per page across a paging client).
-//
-// Possible optimization (orthogonal to pagination): replace the per-key point lookups in
-// resolveCustomers with a single customer.ListCustomers call using an `$in` key filter
-// (N lookups → 1 query). Dedup, the per-input `matched` mapping, and per-key not-found
-// reporting stay in memory either way, since the input mixes customer keys and subject keys.
 //
 // Pagination would only need to move into the adapter (as a keyset query) if the contract
 // gained an unbounded mode — "all customers in a namespace", or dropping the 100-key cap.

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1462,6 +1462,10 @@ func (n NoopCustomerService) GetCustomerByUsageAttribution(ctx context.Context, 
 	return &customer.Customer{}, nil
 }
 
+func (n NoopCustomerService) GetCustomersByUsageAttribution(ctx context.Context, input customer.GetCustomersByUsageAttributionInput) ([]customer.Customer, error) {
+	return nil, nil
+}
+
 func (n NoopCustomerService) UpdateCustomer(ctx context.Context, params customer.UpdateCustomerInput) (*customer.Customer, error) {
 	return &customer.Customer{}, nil
 }


### PR DESCRIPTION
## What

Optimize the governance access query (`POST /api/v3/openmeter/governance/query`) by resolving customer keys in a single bulk query instead of one DB round trip per key.

## Why

`resolveCustomers` looped `GetCustomerByUsageAttribution` once per customer key — N serial DB round trips over the **full** key set (before pagination, so page size didn't help). The e2e benchmark showed this made the customers axis linear; it was the dominant cost at high customer counts.

## How

- Add `customer.GetCustomersByUsageAttribution(ctx, {Namespace, Keys})` on the customer `Service` + `Adapter`: **one** query matching `customer.key IN keys OR subject_key IN keys` (mirrors the single-key `GetCustomerByUsageAttribution` semantics), subjects eager-loaded, soft-deleted rows filtered. Returns `[]Customer` — multi-get-by-set convention, not paginated.
- Rewrite governance `resolveCustomers` to call it once and reconstruct `matched[]` / customer-not-found errors in memory from each customer's key + subject keys. Result shape unchanged → sort → paginate → `resolveAccess` untouched; behavior preserved.

Collapses N customer-resolution queries to 1.

**Benchmark (p50, baseline → new):** `100×10` −21%, whole `C=10` row −17…−29%. High-feature cells flat (`100×100` ≈0) — bounded by the still-serial `resolveAccess` `GetAccess` loop, a deliberate follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk customer resolution by usage-attribution keys, returning deduplicated matches and supporting lookups via both customer keys and active subject keys.
* **Refactor**
  * Updated governance access customer resolution to resolve the full key set in one bulk call, then map and report per-key results in-memory.
* **Tests**
  * Added adapter/service coverage for mixed-key resolution, deduplication, namespace isolation, soft-deleted exclusions, and input validation.
* **Documentation**
  * Refreshed pagination/phase notes for the new single-bulk-lookup resolution flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->