### PR TITLE
feat(taxcode): prevent deletion of plan-referenced tax codes and validate tax codes on plan publish

### DIFF
--- a/app/common/productcatalog.go
+++ b/app/common/productcatalog.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
 	planaddonadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/adapter"
 	planaddonservice "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/service"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/taxcoderesolver"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
@@ -49,6 +50,7 @@ var Cost = wire.NewSet(
 
 var Plan = wire.NewSet(
 	NewPlanService,
+	NewTaxCodeResolver,
 )
 
 var Addon = wire.NewSet(
@@ -71,6 +73,8 @@ func NewFeatureConnector(
 
 var NewFeatureResolver = featureresolver.New
 
+var NewTaxCodeResolver = taxcoderesolver.New
+
 func NewCostService(
 	featureConnector feature.FeatureConnector,
 	meterService meter.Service,
@@ -88,6 +92,7 @@ func NewPlanService(
 	logger *slog.Logger,
 	db *entdb.Client,
 	featureResolver productcatalog.FeatureResolver,
+	taxCodeResolver productcatalog.TaxCodeResolver,
 	taxCodeService taxcode.Service,
 	publisher eventbus.Publisher,
 ) (plan.Service, error) {
@@ -102,6 +107,7 @@ func NewPlanService(
 	return planservice.New(planservice.Config{
 		Adapter:         adapter,
 		FeatureResolver: featureResolver,
+		TaxCodeResolver: taxCodeResolver,
 		TaxCode:         taxCodeService,
 		Logger:          logger.With("subsystem", "productcatalog.plan"),
 		Publisher:       publisher,

--- a/cmd/billing-worker/wire_gen.go
+++ b/cmd/billing-worker/wire_gen.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/namespace"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/taxcoderesolver"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/watermill/driver/kafka"
 	"github.com/openmeterio/openmeter/openmeter/watermill/router"
@@ -280,7 +281,18 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	planService, err := common.NewPlanService(logger, client, featureResolver, taxcodeService, eventbusPublisher)
+	taxCodeResolver, err := taxcoderesolver.New(taxcodeService)
+	if err != nil {
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
+	planService, err := common.NewPlanService(logger, client, featureResolver, taxCodeResolver, taxcodeService, eventbusPublisher)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/cmd/jobs/internal/wire_gen.go
+++ b/cmd/jobs/internal/wire_gen.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/taxcoderesolver"
 	"github.com/openmeterio/openmeter/openmeter/registry"
 	"github.com/openmeterio/openmeter/openmeter/secret"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
@@ -289,7 +290,18 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	planService, err := common.NewPlanService(logger, client, featureResolver, taxcodeService, eventbusPublisher)
+	taxCodeResolver, err := taxcoderesolver.New(taxcodeService)
+	if err != nil {
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
+	planService, err := common.NewPlanService(logger, client, featureResolver, taxCodeResolver, taxcodeService, eventbusPublisher)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/featureresolver"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/taxcoderesolver"
 	"github.com/openmeterio/openmeter/openmeter/progressmanager"
 	"github.com/openmeterio/openmeter/openmeter/registry"
 	"github.com/openmeterio/openmeter/openmeter/secret"
@@ -295,7 +296,18 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	planService, err := common.NewPlanService(logger, client, featureResolver, taxcodeService, eventbusPublisher)
+	taxCodeResolver, err := taxcoderesolver.New(taxcodeService)
+	if err != nil {
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
+	planService, err := common.NewPlanService(logger, client, featureResolver, taxCodeResolver, taxcodeService, eventbusPublisher)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -121,6 +121,16 @@ var ErrRateCardFeatureArchived = models.NewValidationIssue(
 	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
 )
 
+const ErrCodeRateCardTaxCodeNotFound models.ErrorCode = "rate_card_tax_code_not_found"
+
+var ErrRateCardTaxCodeNotFound = models.NewValidationIssue(
+	ErrCodeRateCardTaxCodeNotFound,
+	"tax code not found",
+	models.WithFieldString("taxConfig"),
+	models.WithCriticalSeverity(),
+	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
+)
+
 const ErrCodeRateCardFeatureMismatch models.ErrorCode = "rate_card_feature_mismatch"
 
 var ErrRateCardFeatureMismatch = models.NewValidationIssue(

--- a/openmeter/productcatalog/plan.go
+++ b/openmeter/productcatalog/plan.go
@@ -365,3 +365,24 @@ func ValidatePlanWithFeatures(ctx context.Context, resolver NamespacedFeatureRes
 		return errors.Join(errs...)
 	}
 }
+
+func ValidatePlanWithTaxCodes(ctx context.Context, resolver NamespacedTaxCodeResolver) models.ValidatorFunc[Plan] {
+	return func(p Plan) error {
+		var errs []error
+
+		for _, phase := range p.Phases {
+			phaseFieldSelector := models.NewFieldSelectorGroup(
+				models.NewFieldSelector("phases").
+					WithExpression(
+						models.NewFieldAttrValue("key", phase.Key),
+					),
+			)
+
+			if err := ValidateRateCardsWithTaxCodes(ctx, resolver)(phase.RateCards); err != nil {
+				errs = append(errs, models.ErrorWithFieldPrefix(phaseFieldSelector, err))
+			}
+		}
+
+		return errors.Join(errs...)
+	}
+}

--- a/openmeter/productcatalog/plan/service/plan.go
+++ b/openmeter/productcatalog/plan/service/plan.go
@@ -437,6 +437,16 @@ func (s service) PublishPlan(ctx context.Context, params plan.PublishPlanInput) 
 			)
 		}
 
+		// Validate plan with tax codes
+		err = pp.ValidateWith(
+			productcatalog.ValidatePlanWithTaxCodes(ctx, s.taxCodeResolver.WithNamespace(params.Namespace)),
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid plan [id=%s key=%s version=%d]: %w",
+				p.ID, p.Key, p.Version, err),
+			)
+		}
+
 		// Check for incompatible add-ons assigned to this plan
 
 		if p.Addons == nil {

--- a/openmeter/productcatalog/plan/service/service.go
+++ b/openmeter/productcatalog/plan/service/service.go
@@ -17,6 +17,7 @@ type Config struct {
 	Publisher eventbus.Publisher
 
 	FeatureResolver productcatalog.FeatureResolver
+	TaxCodeResolver productcatalog.TaxCodeResolver
 }
 
 func New(config Config) (plan.Service, error) {
@@ -26,6 +27,10 @@ func New(config Config) (plan.Service, error) {
 
 	if config.FeatureResolver == nil {
 		return nil, errors.New("feature resolver is required")
+	}
+
+	if config.TaxCodeResolver == nil {
+		return nil, errors.New("tax code resolver is required")
 	}
 
 	if config.Logger == nil {
@@ -47,6 +52,7 @@ func New(config Config) (plan.Service, error) {
 		publisher: config.Publisher,
 
 		featureResolver: config.FeatureResolver,
+		taxCodeResolver: config.TaxCodeResolver,
 	}, nil
 }
 
@@ -59,4 +65,5 @@ type service struct {
 	publisher eventbus.Publisher
 
 	featureResolver productcatalog.FeatureResolver
+	taxCodeResolver productcatalog.TaxCodeResolver
 }

--- a/openmeter/productcatalog/plan/service/taxcode_test.go
+++ b/openmeter/productcatalog/plan/service/taxcode_test.go
@@ -923,7 +923,7 @@ func TestPlanPublishRejectsDeletedTaxCode(t *testing.T) {
 		features = append(features, feat)
 	}
 
-	// Provision organisation-default tax codes so DeleteTaxCode can proceed past the org-defaults check.
+	// Provision organization-default tax codes so DeleteTaxCode can proceed past the org-defaults check.
 	invoicingTC, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
 		Namespace: namespace,
 		Key:       "org-default-invoicing",

--- a/openmeter/productcatalog/plan/service/taxcode_test.go
+++ b/openmeter/productcatalog/plan/service/taxcode_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -883,6 +884,119 @@ func TestPlanTaxCodeBackfill(t *testing.T) {
 		assert.Equal(t, productcatalog.InclusiveTaxBehavior, *tc.Behavior)
 		assert.Nil(t, tc.Stripe, "Stripe must be nil when no TaxCode entity is linked")
 	})
+}
+
+func TestPlanPublishRejectsDeletedTaxCode(t *testing.T) {
+	MonthPeriod := datetime.MustParseDuration(t, "P1M")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := pctestutils.NewTestEnv(t)
+	t.Cleanup(func() { env.Close(t) })
+	env.DBSchemaMigrate(t)
+
+	namespace := pctestutils.NewTestNamespace(t)
+
+	// given:
+	// - meters and a feature are provisioned
+	// - a tax code is created and then deleted, leaving a dangling reference
+	// - a draft plan has a rate card referencing that (now-deleted) tax code
+
+	err := env.Meter.ReplaceMeters(ctx, pctestutils.NewTestMeters(t, namespace))
+	require.NoError(t, err)
+
+	result, err := env.Meter.ListMeters(ctx, meter.ListMetersParams{
+		Page: pagination.Page{
+			PageSize:   1000,
+			PageNumber: 1,
+		},
+		Namespace: namespace,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Items)
+
+	features := make([]feature.Feature, 0, len(result.Items))
+	for _, m := range result.Items {
+		feat, err := env.Feature.CreateFeature(ctx, pctestutils.NewTestFeatureFromMeter(t, &m))
+		require.NoError(t, err)
+		features = append(features, feat)
+	}
+
+	// Provision organisation-default tax codes so DeleteTaxCode can proceed past the org-defaults check.
+	invoicingTC, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "org-default-invoicing",
+		Name:      "Org Default Invoicing",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_00000001"},
+		},
+	})
+	require.NoError(t, err)
+
+	creditGrantTC, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "org-default-credit-grant",
+		Name:      "Org Default Credit Grant",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_00000002"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = env.TaxCode.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
+		Namespace:            namespace,
+		InvoicingTaxCodeID:   invoicingTC.ID,
+		CreditGrantTaxCodeID: creditGrantTC.ID,
+	})
+	require.NoError(t, err)
+
+	// Create a tax code with a Stripe app mapping so it resolves at create time.
+	tcEntity, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "stripe_txcd_40000001",
+		Name:      "txcd_40000001",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000001"},
+		},
+	})
+	require.NoError(t, err)
+
+	taxCodeID := tcEntity.ID
+
+	// Create a DRAFT plan with a rate card referencing the tax code.
+	input := newTestPlanInput(t, namespace, newTestFlatRateCard(features[0], &productcatalog.TaxConfig{
+		TaxCodeID: lo.ToPtr(taxCodeID),
+	}, &MonthPeriod))
+	input.Key = "publish-deleted-taxcode"
+	input.Name = "Publish Deleted TaxCode"
+
+	p, err := env.Plan.CreatePlan(ctx, input)
+	require.NoError(t, err)
+
+	// Delete the tax code — the plan-reference delete hook is NOT registered in pctestutils,
+	// so this succeeds and leaves a dangling reference (intended for this test).
+	err = env.TaxCode.DeleteTaxCode(ctx, taxcode.DeleteTaxCodeInput{
+		NamespacedID: models.NamespacedID{Namespace: namespace, ID: taxCodeID},
+	})
+	require.NoError(t, err)
+
+	// when: publishing the plan
+	publishAt := time.Now().Truncate(time.Microsecond)
+	_, err = env.Plan.PublishPlan(ctx, plan.PublishPlanInput{
+		NamespacedID: p.NamespacedID,
+		EffectivePeriod: productcatalog.EffectivePeriod{
+			EffectiveFrom: &publishAt,
+			EffectiveTo:   nil,
+		},
+	})
+
+	// then: publish fails with a rate-card tax-code-not-found validation issue
+	require.Error(t, err)
+
+	var vi models.ValidationIssue
+	require.True(t, errors.As(err, &vi), "expected ValidationIssue wrapping ErrCodeRateCardTaxCodeNotFound, got %T: %v", err, err)
+	require.Equal(t, productcatalog.ErrCodeRateCardTaxCodeNotFound, vi.Code())
 }
 
 func TestPlanWithAddonTaxCode(t *testing.T) {

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -973,3 +973,41 @@ func ValidateRateCardsWithFeatures(ctx context.Context, resolver NamespacedFeatu
 		return errors.Join(errs...)
 	}
 }
+
+func ValidateRateCardsWithTaxCodes(ctx context.Context, resolver NamespacedTaxCodeResolver) func(cards RateCards) error {
+	return func(rateCards RateCards) error {
+		var errs []error
+
+		for _, rateCard := range rateCards {
+			rc := rateCard.AsMeta()
+
+			rateCardFieldSelector := models.NewFieldSelectorGroup(
+				models.NewFieldSelector("rateCards").
+					WithExpression(
+						models.NewFieldAttrValue("key", rateCard.Key()),
+					),
+			)
+
+			if rc.TaxConfig == nil || rc.TaxConfig.TaxCodeID == nil {
+				continue
+			}
+
+			tc, err := resolver.ResolveTaxCode(ctx, *rc.TaxConfig.TaxCodeID)
+			if err != nil {
+				if models.IsGenericNotFoundError(err) || taxcode.IsTaxCodeNotFoundError(err) {
+					errs = append(errs, models.ErrorWithFieldPrefix(rateCardFieldSelector, ErrRateCardTaxCodeNotFound))
+				} else {
+					errs = append(errs, fmt.Errorf("failed to resolve tax code for ratecard: %w", err))
+				}
+
+				continue
+			}
+
+			if tc == nil || tc.DeletedAt != nil {
+				errs = append(errs, models.ErrorWithFieldPrefix(rateCardFieldSelector, ErrRateCardTaxCodeNotFound))
+			}
+		}
+
+		return errors.Join(errs...)
+	}
+}

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -121,6 +121,18 @@ func (r *RateCardMeta) SetFeature(id, key *string) {
 	r.FeatureKey = key
 }
 
+// TaxCodeReference returns the ID of the tax code this rate card references, or nil
+// when no tax code is set. It is the single read point for the referenced tax code ID:
+// today the ID lives on TaxConfig, but it is migrating onto RateCardMeta directly, so
+// routing all reads through this accessor keeps callers stable across that move.
+func (r RateCardMeta) TaxCodeReference() *string {
+	if r.TaxConfig == nil {
+		return nil
+	}
+
+	return r.TaxConfig.TaxCodeID
+}
+
 func (r RateCardMeta) Clone() RateCardMeta {
 	clone := RateCardMeta{
 		Key:  r.Key,
@@ -974,7 +986,7 @@ func ValidateRateCardsWithFeatures(ctx context.Context, resolver NamespacedFeatu
 	}
 }
 
-func ValidateRateCardsWithTaxCodes(ctx context.Context, resolver NamespacedTaxCodeResolver) func(cards RateCards) error {
+func ValidateRateCardsWithTaxCodes(ctx context.Context, taxCodeResolver NamespacedTaxCodeResolver) func(cards RateCards) error {
 	return func(rateCards RateCards) error {
 		var errs []error
 
@@ -988,11 +1000,21 @@ func ValidateRateCardsWithTaxCodes(ctx context.Context, resolver NamespacedTaxCo
 					),
 			)
 
-			if rc.TaxConfig == nil || rc.TaxConfig.TaxCodeID == nil {
+			taxCodeID := rc.TaxCodeReference()
+			if taxCodeID == nil {
 				continue
 			}
 
-			tc, err := resolver.ResolveTaxCode(ctx, *rc.TaxConfig.TaxCodeID)
+			// An explicitly empty tax code reference is a malformed user reference, not an
+			// internal failure: resolving it would surface a generic system error, so classify
+			// it as a not-found validation issue here instead.
+			if *taxCodeID == "" {
+				errs = append(errs, models.ErrorWithFieldPrefix(rateCardFieldSelector, ErrRateCardTaxCodeNotFound))
+
+				continue
+			}
+
+			tc, err := taxCodeResolver.Resolve(ctx, *taxCodeID)
 			if err != nil {
 				if models.IsGenericNotFoundError(err) || taxcode.IsTaxCodeNotFoundError(err) {
 					errs = append(errs, models.ErrorWithFieldPrefix(rateCardFieldSelector, ErrRateCardTaxCodeNotFound))
@@ -1003,6 +1025,9 @@ func ValidateRateCardsWithTaxCodes(ctx context.Context, resolver NamespacedTaxCo
 				continue
 			}
 
+			// Defensive: the NamespacedTaxCodeResolver interface permits a (nil, nil) return.
+			// The concrete resolver never returns it, but guard against a nil code to avoid a
+			// nil-pointer panic and treat it as not-found.
 			if tc == nil || tc.DeletedAt != nil {
 				errs = append(errs, models.ErrorWithFieldPrefix(rateCardFieldSelector, ErrRateCardTaxCodeNotFound))
 			}

--- a/openmeter/productcatalog/taxcoderesolver.go
+++ b/openmeter/productcatalog/taxcoderesolver.go
@@ -1,0 +1,19 @@
+package productcatalog
+
+import (
+	"context"
+
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
+)
+
+// TaxCodeResolver resolves tax codes across namespaces and can create a namespace-scoped resolver.
+type TaxCodeResolver interface {
+	ResolveTaxCode(ctx context.Context, namespace string, id string) (*taxcode.TaxCode, error)
+	WithNamespace(namespace string) NamespacedTaxCodeResolver
+}
+
+// NamespacedTaxCodeResolver resolves tax codes within a fixed namespace.
+type NamespacedTaxCodeResolver interface {
+	ResolveTaxCode(ctx context.Context, id string) (*taxcode.TaxCode, error)
+	Namespace() string
+}

--- a/openmeter/productcatalog/taxcoderesolver.go
+++ b/openmeter/productcatalog/taxcoderesolver.go
@@ -8,12 +8,12 @@ import (
 
 // TaxCodeResolver resolves tax codes across namespaces and can create a namespace-scoped resolver.
 type TaxCodeResolver interface {
-	ResolveTaxCode(ctx context.Context, namespace string, id string) (*taxcode.TaxCode, error)
+	Resolve(ctx context.Context, namespace string, id string) (*taxcode.TaxCode, error)
 	WithNamespace(namespace string) NamespacedTaxCodeResolver
 }
 
 // NamespacedTaxCodeResolver resolves tax codes within a fixed namespace.
 type NamespacedTaxCodeResolver interface {
-	ResolveTaxCode(ctx context.Context, id string) (*taxcode.TaxCode, error)
+	Resolve(ctx context.Context, id string) (*taxcode.TaxCode, error)
 	Namespace() string
 }

--- a/openmeter/productcatalog/taxcoderesolver/resolver.go
+++ b/openmeter/productcatalog/taxcoderesolver/resolver.go
@@ -26,8 +26,8 @@ type namespacedResolver struct {
 
 func (n *namespacedResolver) Namespace() string { return n.namespace }
 
-func (n *namespacedResolver) ResolveTaxCode(ctx context.Context, id string) (*taxcode.TaxCode, error) {
-	return n.resolver.ResolveTaxCode(ctx, n.namespace, id)
+func (n *namespacedResolver) Resolve(ctx context.Context, id string) (*taxcode.TaxCode, error) {
+	return n.resolver.Resolve(ctx, n.namespace, id)
 }
 
 var _ productcatalog.TaxCodeResolver = (*resolver)(nil)
@@ -40,7 +40,7 @@ func (r *resolver) WithNamespace(namespace string) productcatalog.NamespacedTaxC
 	return &namespacedResolver{resolver: r, namespace: namespace}
 }
 
-func (r *resolver) ResolveTaxCode(ctx context.Context, namespace string, id string) (*taxcode.TaxCode, error) {
+func (r *resolver) Resolve(ctx context.Context, namespace string, id string) (*taxcode.TaxCode, error) {
 	if namespace == "" {
 		return nil, errors.New("namespace is not set")
 	}

--- a/openmeter/productcatalog/taxcoderesolver/resolver.go
+++ b/openmeter/productcatalog/taxcoderesolver/resolver.go
@@ -1,0 +1,56 @@
+package taxcoderesolver
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func New(service taxcode.Service) (productcatalog.TaxCodeResolver, error) {
+	if service == nil {
+		return nil, errors.New("tax code service is not set")
+	}
+
+	return &resolver{service: service}, nil
+}
+
+var _ productcatalog.NamespacedTaxCodeResolver = (*namespacedResolver)(nil)
+
+type namespacedResolver struct {
+	resolver  *resolver
+	namespace string
+}
+
+func (n *namespacedResolver) Namespace() string { return n.namespace }
+
+func (n *namespacedResolver) ResolveTaxCode(ctx context.Context, id string) (*taxcode.TaxCode, error) {
+	return n.resolver.ResolveTaxCode(ctx, n.namespace, id)
+}
+
+var _ productcatalog.TaxCodeResolver = (*resolver)(nil)
+
+type resolver struct {
+	service taxcode.Service
+}
+
+func (r *resolver) WithNamespace(namespace string) productcatalog.NamespacedTaxCodeResolver {
+	return &namespacedResolver{resolver: r, namespace: namespace}
+}
+
+func (r *resolver) ResolveTaxCode(ctx context.Context, namespace string, id string) (*taxcode.TaxCode, error) {
+	if namespace == "" {
+		return nil, errors.New("namespace is not set")
+	}
+
+	tc, err := r.service.GetTaxCode(ctx, taxcode.GetTaxCodeInput{
+		NamespacedID: models.NamespacedID{Namespace: namespace, ID: id},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &tc, nil
+}

--- a/openmeter/productcatalog/taxcoderesolver_test.go
+++ b/openmeter/productcatalog/taxcoderesolver_test.go
@@ -1,0 +1,139 @@
+package productcatalog
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// stubTaxCodeResolver is a minimal NamespacedTaxCodeResolver for unit tests.
+type stubTaxCodeResolver struct {
+	namespace string
+	result    *taxcode.TaxCode
+	err       error
+}
+
+func (s stubTaxCodeResolver) Namespace() string { return s.namespace }
+
+func (s stubTaxCodeResolver) ResolveTaxCode(_ context.Context, _ string) (*taxcode.TaxCode, error) {
+	return s.result, s.err
+}
+
+// makeFlatFeeRateCardWithTaxCodeID builds a minimal FlatFeeRateCard with a TaxConfig pointing at id.
+func makeFlatFeeRateCardWithTaxCodeID(key, taxCodeID string) RateCard {
+	return &FlatFeeRateCard{
+		RateCardMeta: RateCardMeta{
+			Key:  key,
+			Name: key,
+			TaxConfig: &TaxConfig{
+				TaxCodeID: lo.ToPtr(taxCodeID),
+			},
+		},
+	}
+}
+
+// makeFlatFeeRateCardNoTaxConfig builds a minimal FlatFeeRateCard without any TaxConfig.
+func makeFlatFeeRateCardNoTaxConfig(key string) RateCard {
+	return &FlatFeeRateCard{
+		RateCardMeta: RateCardMeta{
+			Key:  key,
+			Name: key,
+		},
+	}
+}
+
+// validTaxCode returns a non-deleted TaxCode stub.
+func validTaxCode(id string) *taxcode.TaxCode {
+	now := time.Now()
+	return &taxcode.TaxCode{
+		NamespacedID: models.NamespacedID{Namespace: "test", ID: id},
+		ManagedModel: models.ManagedModel{
+			CreatedAt: now,
+			UpdatedAt: now,
+			DeletedAt: nil,
+		},
+		Key:  "tc-key",
+		Name: "Tax Code",
+	}
+}
+
+// deletedTaxCode returns a TaxCode stub whose DeletedAt is set.
+func deletedTaxCode(id string) *taxcode.TaxCode {
+	now := time.Now()
+	deleted := now.Add(-time.Hour)
+	return &taxcode.TaxCode{
+		NamespacedID: models.NamespacedID{Namespace: "test", ID: id},
+		ManagedModel: models.ManagedModel{
+			CreatedAt: now.Add(-2 * time.Hour),
+			UpdatedAt: now.Add(-2 * time.Hour),
+			DeletedAt: &deleted,
+		},
+		Key:  "tc-key",
+		Name: "Tax Code",
+	}
+}
+
+func TestValidateRateCardsWithTaxCodes(t *testing.T) {
+	ctx := context.Background()
+	const taxCodeID = "01JBP3SGZ20Y7VRVC351TDFXYZ"
+
+	t.Run("valid tax code returns no error", func(t *testing.T) {
+		resolver := stubTaxCodeResolver{
+			namespace: "test",
+			result:    validTaxCode(taxCodeID),
+		}
+
+		cards := RateCards{makeFlatFeeRateCardWithTaxCodeID("rc-1", taxCodeID)}
+		err := ValidateRateCardsWithTaxCodes(ctx, resolver)(cards)
+		require.NoError(t, err)
+	})
+
+	t.Run("deleted tax code returns ErrCodeRateCardTaxCodeNotFound", func(t *testing.T) {
+		resolver := stubTaxCodeResolver{
+			namespace: "test",
+			result:    deletedTaxCode(taxCodeID),
+		}
+
+		cards := RateCards{makeFlatFeeRateCardWithTaxCodeID("rc-1", taxCodeID)}
+		err := ValidateRateCardsWithTaxCodes(ctx, resolver)(cards)
+		require.Error(t, err)
+
+		var vi models.ValidationIssue
+		require.True(t, errors.As(err, &vi), "expected ValidationIssue, got %T: %v", err, err)
+		require.Equal(t, ErrCodeRateCardTaxCodeNotFound, vi.Code())
+	})
+
+	t.Run("not-found error from resolver returns ErrCodeRateCardTaxCodeNotFound", func(t *testing.T) {
+		resolver := stubTaxCodeResolver{
+			namespace: "test",
+			err:       taxcode.NewTaxCodeNotFoundError(taxCodeID),
+		}
+
+		cards := RateCards{makeFlatFeeRateCardWithTaxCodeID("rc-1", taxCodeID)}
+		err := ValidateRateCardsWithTaxCodes(ctx, resolver)(cards)
+		require.Error(t, err)
+
+		var vi models.ValidationIssue
+		require.True(t, errors.As(err, &vi), "expected ValidationIssue, got %T: %v", err, err)
+		require.Equal(t, ErrCodeRateCardTaxCodeNotFound, vi.Code())
+	})
+
+	t.Run("rate card without TaxConfig is skipped", func(t *testing.T) {
+		resolver := stubTaxCodeResolver{
+			namespace: "test",
+			// err set to ensure resolver is never called
+			err: errors.New("resolver should not be called"),
+		}
+
+		cards := RateCards{makeFlatFeeRateCardNoTaxConfig("rc-no-tax")}
+		err := ValidateRateCardsWithTaxCodes(ctx, resolver)(cards)
+		require.NoError(t, err)
+	})
+}

--- a/openmeter/productcatalog/taxcoderesolver_test.go
+++ b/openmeter/productcatalog/taxcoderesolver_test.go
@@ -22,7 +22,7 @@ type stubTaxCodeResolver struct {
 
 func (s stubTaxCodeResolver) Namespace() string { return s.namespace }
 
-func (s stubTaxCodeResolver) ResolveTaxCode(_ context.Context, _ string) (*taxcode.TaxCode, error) {
+func (s stubTaxCodeResolver) Resolve(_ context.Context, _ string) (*taxcode.TaxCode, error) {
 	return s.result, s.err
 }
 
@@ -85,24 +85,24 @@ func TestValidateRateCardsWithTaxCodes(t *testing.T) {
 	const taxCodeID = "01JBP3SGZ20Y7VRVC351TDFXYZ"
 
 	t.Run("valid tax code returns no error", func(t *testing.T) {
-		resolver := stubTaxCodeResolver{
+		taxCodeResolver := stubTaxCodeResolver{
 			namespace: "test",
 			result:    validTaxCode(taxCodeID),
 		}
 
 		cards := RateCards{makeFlatFeeRateCardWithTaxCodeID("rc-1", taxCodeID)}
-		err := ValidateRateCardsWithTaxCodes(ctx, resolver)(cards)
+		err := ValidateRateCardsWithTaxCodes(ctx, taxCodeResolver)(cards)
 		require.NoError(t, err)
 	})
 
 	t.Run("deleted tax code returns ErrCodeRateCardTaxCodeNotFound", func(t *testing.T) {
-		resolver := stubTaxCodeResolver{
+		taxCodeResolver := stubTaxCodeResolver{
 			namespace: "test",
 			result:    deletedTaxCode(taxCodeID),
 		}
 
 		cards := RateCards{makeFlatFeeRateCardWithTaxCodeID("rc-1", taxCodeID)}
-		err := ValidateRateCardsWithTaxCodes(ctx, resolver)(cards)
+		err := ValidateRateCardsWithTaxCodes(ctx, taxCodeResolver)(cards)
 		require.Error(t, err)
 
 		var vi models.ValidationIssue
@@ -110,14 +110,14 @@ func TestValidateRateCardsWithTaxCodes(t *testing.T) {
 		require.Equal(t, ErrCodeRateCardTaxCodeNotFound, vi.Code())
 	})
 
-	t.Run("not-found error from resolver returns ErrCodeRateCardTaxCodeNotFound", func(t *testing.T) {
-		resolver := stubTaxCodeResolver{
+	t.Run("not-found error from taxCodeResolver returns ErrCodeRateCardTaxCodeNotFound", func(t *testing.T) {
+		taxCodeResolver := stubTaxCodeResolver{
 			namespace: "test",
 			err:       taxcode.NewTaxCodeNotFoundError(taxCodeID),
 		}
 
 		cards := RateCards{makeFlatFeeRateCardWithTaxCodeID("rc-1", taxCodeID)}
-		err := ValidateRateCardsWithTaxCodes(ctx, resolver)(cards)
+		err := ValidateRateCardsWithTaxCodes(ctx, taxCodeResolver)(cards)
 		require.Error(t, err)
 
 		var vi models.ValidationIssue
@@ -126,14 +126,44 @@ func TestValidateRateCardsWithTaxCodes(t *testing.T) {
 	})
 
 	t.Run("rate card without TaxConfig is skipped", func(t *testing.T) {
-		resolver := stubTaxCodeResolver{
+		taxCodeResolver := stubTaxCodeResolver{
 			namespace: "test",
-			// err set to ensure resolver is never called
-			err: errors.New("resolver should not be called"),
+			// err set to ensure taxCodeResolver is never called
+			err: errors.New("taxCodeResolver should not be called"),
 		}
 
 		cards := RateCards{makeFlatFeeRateCardNoTaxConfig("rc-no-tax")}
-		err := ValidateRateCardsWithTaxCodes(ctx, resolver)(cards)
+		err := ValidateRateCardsWithTaxCodes(ctx, taxCodeResolver)(cards)
 		require.NoError(t, err)
+	})
+
+	t.Run("empty tax code ID returns ErrCodeRateCardTaxCodeNotFound without calling resolver", func(t *testing.T) {
+		// given: a rate card with an explicitly empty TaxCodeID, and a resolver that errors if called
+		taxCodeResolver := stubTaxCodeResolver{
+			namespace: "test",
+			err:       errors.New("resolver should not be called"),
+		}
+
+		cards := RateCards{
+			&FlatFeeRateCard{
+				RateCardMeta: RateCardMeta{
+					Key:  "rc-empty-id",
+					Name: "rc-empty-id",
+					TaxConfig: &TaxConfig{
+						TaxCodeID: lo.ToPtr(""),
+					},
+				},
+			},
+		}
+
+		// when: running the validator
+		err := ValidateRateCardsWithTaxCodes(ctx, taxCodeResolver)(cards)
+
+		// then: error is a ValidationIssue with ErrCodeRateCardTaxCodeNotFound
+		require.Error(t, err)
+
+		var vi models.ValidationIssue
+		require.True(t, errors.As(err, &vi), "expected ValidationIssue, got %T: %v", err, err)
+		require.Equal(t, ErrCodeRateCardTaxCodeNotFound, vi.Code())
 	})
 }

--- a/openmeter/productcatalog/testutils/env.go
+++ b/openmeter/productcatalog/testutils/env.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
 	planaddonadapter "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/adapter"
 	planaddonservice "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/service"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/taxcoderesolver"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	taxcodeadapter "github.com/openmeterio/openmeter/openmeter/taxcode/adapter"
 	taxcodeservice "github.com/openmeterio/openmeter/openmeter/taxcode/service"
@@ -117,6 +118,9 @@ func NewTestEnv(t *testing.T) *TestEnv {
 	})
 	require.NoErrorf(t, err, "initializing tax code service must not fail")
 
+	taxCodeResolver, err := taxcoderesolver.New(taxCodeService)
+	require.NoErrorf(t, err, "failed to create tax code resolver: %v", err)
+
 	// Init plan service
 	planAdapter, err := planadapter.New(planadapter.Config{
 		Client: client,
@@ -128,6 +132,7 @@ func NewTestEnv(t *testing.T) *TestEnv {
 	planService, err := planservice.New(planservice.Config{
 		Adapter:         planAdapter,
 		FeatureResolver: featureResolver,
+		TaxCodeResolver: taxCodeResolver,
 		TaxCode:         taxCodeService,
 		Logger:          logger,
 		Publisher:       publisher,

--- a/openmeter/subscription/testutils/service.go
+++ b/openmeter/subscription/testutils/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
 	planaddonrepo "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/adapter"
 	planaddonservice "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/service"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/taxcoderesolver"
 	"github.com/openmeterio/openmeter/openmeter/registry"
 	registrybuilder "github.com/openmeterio/openmeter/openmeter/registry/builder"
 	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
@@ -188,8 +189,12 @@ func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
 	featureResolver, err := featureresolver.New(entitlementRegistry.Feature)
 	require.NoErrorf(t, err, "failed to create feature resolver: %v", err)
 
+	taxCodeResolver, err := taxcoderesolver.New(taxCodeService)
+	require.NoErrorf(t, err, "failed to create tax code resolver: %v", err)
+
 	planService, err := planservice.New(planservice.Config{
 		FeatureResolver: featureResolver,
+		TaxCodeResolver: taxCodeResolver,
 		Logger:          logger,
 		Adapter:         planRepo,
 		Publisher:       publisher,

--- a/test/billing/subscription_suite.go
+++ b/test/billing/subscription_suite.go
@@ -34,6 +34,7 @@ import (
 	planaddonrepo "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/adapter"
 	planaddonservice "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/service"
 	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/productcatalog/subscription/testutils"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/taxcoderesolver"
 	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	subscriptionaddon "github.com/openmeterio/openmeter/openmeter/subscription/addon"
@@ -129,8 +130,12 @@ func (s *SubscriptionMixin) SetupSuite(t *testing.T, deps SubscriptionMixInDepen
 	featureResolver, err := featureresolver.New(deps.FeatureService)
 	require.NoErrorf(t, err, "failed to create feature resolver: %v", err)
 
+	taxCodeResolver, err := taxcoderesolver.New(taxCodeService)
+	require.NoErrorf(t, err, "failed to create tax code resolver: %v", err)
+
 	planService, err := planservice.New(planservice.Config{
 		FeatureResolver: featureResolver,
+		TaxCodeResolver: taxCodeResolver,
 		Adapter:         planAdapter,
 		TaxCode:         taxCodeService,
 		Logger:          slog.Default(),

--- a/test/customer/testenv.go
+++ b/test/customer/testenv.go
@@ -36,6 +36,7 @@ import (
 	planservice "github.com/openmeterio/openmeter/openmeter/productcatalog/plan/service"
 	planaddonrepo "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/adapter"
 	planaddonservice "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/service"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/taxcoderesolver"
 	registrybuilder "github.com/openmeterio/openmeter/openmeter/registry/builder"
 	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
 	"github.com/openmeterio/openmeter/openmeter/subject"
@@ -275,9 +276,13 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 	featureResolver, err := featureresolver.New(entitlementRegistry.Feature)
 	require.NoErrorf(t, err, "failed to create feature resolver: %v", err)
 
+	taxCodeResolver, err := taxcoderesolver.New(taxCodeService)
+	require.NoErrorf(t, err, "failed to create tax code resolver: %v", err)
+
 	planService, err := planservice.New(planservice.Config{
 		Adapter:         planAdapter,
 		FeatureResolver: featureResolver,
+		TaxCodeResolver: taxCodeResolver,
 		TaxCode:         taxCodeService,
 		Logger:          logger.WithGroup("plan"),
 		Publisher:       publisher,


### PR DESCRIPTION
@coderabbitai


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plan publishing now validates referenced tax codes and surfaces missing or deleted tax-code issues clearly.
  * Rate cards can now report their linked tax-code reference for validation.

* **Bug Fixes**
  * Publishing a plan now fails when a referenced tax code no longer exists or has been deleted.
  * Validation errors now point to the specific phase or rate card involved.

* **Tests**
  * Added coverage for tax-code resolution, missing references, and publish-time validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->