### PR TITLE
feat(taxcode): prevent deletion of add-on-referenced tax codes

### DIFF
--- a/app/common/productcatalog.go
+++ b/app/common/productcatalog.go
@@ -118,6 +118,7 @@ func NewAddonService(
 	logger *slog.Logger,
 	db *entdb.Client,
 	featureResolver productcatalog.FeatureResolver,
+	taxCodeResolver productcatalog.TaxCodeResolver,
 	taxCodeService taxcode.Service,
 	publisher eventbus.Publisher,
 ) (addon.Service, error) {
@@ -132,6 +133,7 @@ func NewAddonService(
 	return addonservice.New(addonservice.Config{
 		Adapter:         adapter,
 		FeatureResolver: featureResolver,
+		TaxCodeResolver: taxCodeResolver,
 		TaxCode:         taxCodeService,
 		Logger:          logger.With("subsystem", "productcatalog.addon"),
 		Publisher:       publisher,

--- a/app/common/taxcode.go
+++ b/app/common/taxcode.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/app"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	taxcodeadapter "github.com/openmeterio/openmeter/openmeter/taxcode/adapter"
@@ -60,6 +61,28 @@ func NewTaxCodePlanServiceHook(
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create tax code plan hook: %w", err)
+	}
+
+	taxCodeService.RegisterHooks(h)
+
+	return h, nil
+}
+
+// TaxCodeAddonHook prevents deleting tax codes that are still referenced by add-ons.
+type TaxCodeAddonHook taxcodehooks.AddonHook
+
+// NewTaxCodeAddonServiceHook builds the add-on-reference hook and registers it
+// on the tax code service. It depends on both the add-on and tax code services so wire constructs
+// it only after both exist, avoiding a construction cycle (add-on already depends on tax code).
+func NewTaxCodeAddonServiceHook(
+	addonService addon.Service,
+	taxCodeService taxcode.Service,
+) (TaxCodeAddonHook, error) {
+	h, err := taxcodehooks.NewAddonHook(taxcodehooks.AddonHookConfig{
+		AddonService: addonService,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tax code add-on hook: %w", err)
 	}
 
 	taxCodeService.RegisterHooks(h)

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	notificationwebhook "github.com/openmeterio/openmeter/openmeter/notification/webhook"
 	"github.com/openmeterio/openmeter/openmeter/notification/webhook/svix"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/featuregate"
 	pkgkafka "github.com/openmeterio/openmeter/pkg/kafka"
@@ -467,12 +468,12 @@ func TestComplete(t *testing.T) {
 		TaxCode: TaxCodeConfiguration{
 			Seeds: []TaxCodeSeed{
 				{
-					Key:              "default",
+					Key:              taxcode.ProviderDefaultTaxCodeKey,
 					Name:             "Provider default",
 					DefaultInvoicing: true,
 				},
 				{
-					Key:                "nontaxable",
+					Key:                taxcode.CreditGrantTaxCodeKey,
 					Name:               "Nontaxable",
 					DefaultCreditGrant: true,
 					AppMappings: []TaxCodeAppMapping{

--- a/app/config/taxcode.go
+++ b/app/config/taxcode.go
@@ -103,7 +103,7 @@ func ConfigureTaxCode(v *viper.Viper) {
 			"defaultInvoicing": true,
 		},
 		{
-			"key":                "nontaxable",
+			"key":                taxcode.CreditGrantTaxCodeKey,
 			"name":               "Nontaxable",
 			"defaultCreditGrant": true,
 			"appMappings": []map[string]any{

--- a/app/config/taxcode_test.go
+++ b/app/config/taxcode_test.go
@@ -5,14 +5,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 )
 
 func TestTaxCodeConfigurationValidate(t *testing.T) {
 	validBase := func() TaxCodeConfiguration {
 		return TaxCodeConfiguration{
 			Seeds: []TaxCodeSeed{
-				{Key: "default", Name: "Provider default", DefaultInvoicing: true},
-				{Key: "nontaxable", Name: "Nontaxable", DefaultCreditGrant: true, AppMappings: []TaxCodeAppMapping{
+				{Key: taxcode.ProviderDefaultTaxCodeKey, Name: "Provider default", DefaultInvoicing: true},
+				{Key: taxcode.CreditGrantTaxCodeKey, Name: "Nontaxable", DefaultCreditGrant: true, AppMappings: []TaxCodeAppMapping{
 					{AppType: "stripe", TaxCode: "txcd_00000000"},
 				}},
 			},

--- a/cmd/billing-worker/wire_gen.go
+++ b/cmd/billing-worker/wire_gen.go
@@ -303,7 +303,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	addonService, err := common.NewAddonService(logger, client, featureResolver, taxcodeService, eventbusPublisher)
+	addonService, err := common.NewAddonService(logger, client, featureResolver, taxCodeResolver, taxcodeService, eventbusPublisher)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/cmd/jobs/internal/wire_gen.go
+++ b/cmd/jobs/internal/wire_gen.go
@@ -312,7 +312,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	addonService, err := common.NewAddonService(logger, client, featureResolver, taxcodeService, eventbusPublisher)
+	addonService, err := common.NewAddonService(logger, client, featureResolver, taxCodeResolver, taxcodeService, eventbusPublisher)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -100,6 +100,7 @@ type Application struct {
 	TaxCodeNamespaceHandler          *taxcode.NamespaceHandler
 	TaxCodeService                   taxcode.Service
 	TaxCodePlanHook                  common.TaxCodePlanHook
+	TaxCodeAddonHook                 common.TaxCodeAddonHook
 	TelemetryServer                  common.TelemetryServer
 	TerminationChecker               *common.TerminationChecker
 	RuntimeMetricsCollector          common.RuntimeMetricsCollector
@@ -150,6 +151,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		common.TaxCode,
 		common.TaxCodeNamespaceHandler,
 		common.NewTaxCodePlanServiceHook,
+		common.NewTaxCodeAddonServiceHook,
 		common.Subscription,
 		common.Lockr,
 		common.Secret,

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -811,6 +811,18 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
+	taxCodeAddonHook, err := common.NewTaxCodeAddonServiceHook(addonService, taxcodeService)
+	if err != nil {
+		cleanup8()
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
 	health := common.NewHealthChecker(logger)
 	telemetryHandler := common.NewTelemetryHandler(metricsTelemetryConfig, health, logger)
 	v10, cleanup9 := common.NewTelemetryServer(telemetryConfig, telemetryHandler)
@@ -907,6 +919,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		TaxCodeNamespaceHandler:          taxcodeNamespaceHandler,
 		TaxCodeService:                   taxcodeService,
 		TaxCodePlanHook:                  taxCodePlanHook,
+		TaxCodeAddonHook:                 taxCodeAddonHook,
 		TelemetryServer:                  v10,
 		TerminationChecker:               terminationChecker,
 		RuntimeMetricsCollector:          runtimeMetricsCollector,
@@ -981,6 +994,7 @@ type Application struct {
 	TaxCodeNamespaceHandler          *taxcode.NamespaceHandler
 	TaxCodeService                   taxcode.Service
 	TaxCodePlanHook                  common.TaxCodePlanHook
+	TaxCodeAddonHook                 common.TaxCodeAddonHook
 	TelemetryServer                  common.TelemetryServer
 	TerminationChecker               *common.TerminationChecker
 	RuntimeMetricsCollector          common.RuntimeMetricsCollector

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -182,7 +182,17 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	addonService, err := common.NewAddonService(logger, client, featureResolver, taxcodeService, eventbusPublisher)
+	taxCodeResolver, err := taxcoderesolver.New(taxcodeService)
+	if err != nil {
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
+	addonService, err := common.NewAddonService(logger, client, featureResolver, taxCodeResolver, taxcodeService, eventbusPublisher)
 	if err != nil {
 		cleanup6()
 		cleanup5()
@@ -286,17 +296,6 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	entitlement, err := common.NewEntitlementRegistry(logger, client, tracer, entitlementsConfiguration, connector, service, eventbusPublisher, locker, customerService)
-	if err != nil {
-		cleanup7()
-		cleanup6()
-		cleanup5()
-		cleanup4()
-		cleanup3()
-		cleanup2()
-		cleanup()
-		return Application{}, nil, err
-	}
-	taxCodeResolver, err := taxcoderesolver.New(taxcodeService)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/openmeter/billing/charges/service/advance_test.go
+++ b/openmeter/billing/charges/service/advance_test.go
@@ -36,7 +36,7 @@ func (s *AdvanceChargesTestSuite) TearDownTest() {
 func (s *AdvanceChargesTestSuite) TestAdvanceChargesReturnsEmptyForAlreadyActiveCreditCharges() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-advance-usage-only")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -124,7 +124,7 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesReturnsEmptyForAlreadyActive
 func (s *AdvanceChargesTestSuite) TestAdvanceChargesActivatesCreditThenInvoiceFlatFeeAtServicePeriodStart() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-advance-empty")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -175,7 +175,7 @@ func (s *AdvanceChargesTestSuite) TestAdvanceChargesActivatesCreditThenInvoiceFl
 func (s *AdvanceChargesTestSuite) TestAdvanceChargesActivatesCreditThenInvoiceUsageBasedChargesAtServicePeriodStart() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-advance-credit-then-invoice")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)

--- a/openmeter/billing/charges/service/create.go
+++ b/openmeter/billing/charges/service/create.go
@@ -69,7 +69,9 @@ func (s *service) applyDefaultTaxCodes(ctx context.Context, namespace string, in
 }
 
 // validateTaxCodesExist verifies every distinct non-empty tax code referenced by the intents
-// exists.
+// exists and is not soft-deleted. GetTaxCode returns soft-deleted rows by ID (so billing can
+// still resolve frozen Stripe mappings for existing charges), so a deleted code must be rejected
+// explicitly here to prevent it from being used on a newly created charge.
 func (s *service) validateTaxCodesExist(ctx context.Context, namespace string, intents charges.ChargeIntents) error {
 	seen := make(map[string]struct{}, len(intents))
 
@@ -88,7 +90,7 @@ func (s *service) validateTaxCodesExist(ctx context.Context, namespace string, i
 		}
 		seen[taxCodeID] = struct{}{}
 
-		_, err = s.taxCodeService.GetTaxCode(ctx, taxcode.GetTaxCodeInput{
+		tc, err := s.taxCodeService.GetTaxCode(ctx, taxcode.GetTaxCodeInput{
 			NamespacedID: models.NamespacedID{Namespace: namespace, ID: taxCodeID},
 		})
 		if err != nil {
@@ -100,6 +102,13 @@ func (s *service) validateTaxCodesExist(ctx context.Context, namespace string, i
 			}
 
 			return err
+		}
+
+		if tc.IsDeleted() {
+			return models.NewGenericValidationError(
+				models.NewValidationError("tax_code_not_found", fmt.Sprintf("referenced tax code %q does not exist", taxCodeID)).
+					WithPathString("tax_config", "tax_code"),
+			)
 		}
 	}
 

--- a/openmeter/billing/charges/service/creditpurchase_test.go
+++ b/openmeter/billing/charges/service/creditpurchase_test.go
@@ -48,7 +48,7 @@ func (s *CreditPurchaseTestSuite) TearDownTest() {
 func (s *CreditPurchaseTestSuite) TestPromotionalCreditPurchase() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-promotional-credit-purchase")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -100,7 +100,7 @@ func (s *CreditPurchaseTestSuite) TestPromotionalCreditPurchase() {
 func (s *CreditPurchaseTestSuite) TestCreditPurchaseRejectsMismatchedSettlementCurrency() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-credit-purchase-mismatched-settlement-currency")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -159,7 +159,7 @@ func (s *CreditPurchaseTestSuite) TestCreditPurchaseRejectsMismatchedSettlementC
 func (s *CreditPurchaseTestSuite) TestCreditPurchaseRejectsNonPositiveSettlementCostBasisBeforeCallbacks() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-credit-purchase-non-positive-cost-basis")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -318,7 +318,7 @@ func CreateCreditPurchaseIntent(t *testing.T, input createCreditPurchaseIntentIn
 func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettled() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-external-authorized-credit-purchase-auto-settled")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -425,7 +425,7 @@ func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseAutoSettle
 func (s *CreditPurchaseTestSuite) TestExternalAuthorizedCreditPurchaseManuallySettled() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-external-authorized-credit-purchase-manually-settled")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -550,7 +550,7 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchase() {
 	defer clock.UnFreeze()
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-standard-invoice-credit-purchase")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -788,7 +788,7 @@ func (s *CreditPurchaseTestSuite) TestStandardInvoiceCreditPurchaseDeferred() {
 	// The gathering line is created but not immediately invoiced.
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-standard-invoice-credit-purchase-deferred")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	clock.FreezeTime(datetime.MustParseTimeInLocation(s.T(), "2025-12-01T00:00:00Z", time.UTC).AsTime())
 	defer clock.ResetTime()

--- a/openmeter/billing/charges/service/featureid_test.go
+++ b/openmeter/billing/charges/service/featureid_test.go
@@ -46,7 +46,7 @@ func (s *ChargeFeatureIDTestSuite) TearDownTest() {
 func (s *ChargeFeatureIDTestSuite) TestCreateResolvesFeatureIDsForUsageBasedAndFlatFeeCharges() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-feature-id-create")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "feature-id-create")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -123,7 +123,7 @@ func (s *ChargeFeatureIDTestSuite) TestCreateResolvesFeatureIDsForUsageBasedAndF
 func (s *ChargeFeatureIDTestSuite) TestUsageBasedActivationRecalculatesFeatureIDAndRunsKeepUsingIt() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-feature-id-usage")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "feature-id-usage")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -52,7 +52,7 @@ func (s *InvoicableChargesTestSuite) TearDownTest() {
 func (s *InvoicableChargesTestSuite) TestFlatFeeGatheringPreviewPopulatesTotalsWithoutRealizationRun() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-gathering-preview")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateTestCustomer(ns, "test-subject")
@@ -130,7 +130,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeGatheringPreviewPopulatesTotalsW
 func (s *InvoicableChargesTestSuite) TestUsageBasedGatheringPreviewPopulatesTotalsWithoutRealizationRun() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-gathering-preview")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -235,7 +235,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceImmutableProrat
 func runFlatFeeCreditThenInvoiceImmutableProrationScenario(s *BaseSuite, expectReplacementGatheringLine bool) {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-immutable-proration")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateTestCustomer(ns, "test-subject")
@@ -386,7 +386,7 @@ func runFlatFeeCreditThenInvoiceImmutableProrationScenario(s *BaseSuite, expectR
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountCreatesNoGatheringLine() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-zero-amount")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateTestCustomer(ns, "test-subject")
@@ -437,7 +437,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountCreat
 func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-partial-credit-realizations")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -711,7 +711,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeePartialCreditRealizations() {
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceInAdvanceWithPromotionalCredits() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-in-advance-promotional")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -862,7 +862,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceInAdvanceWithPr
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceInvoiceAtBeforeServicePeriodStart() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-before-service-period")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateTestCustomer(ns, "test-subject")
@@ -1022,7 +1022,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceInvoiceAtBefore
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDoesNotAccrueInvoiceUsage() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-fully-credited")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -1147,7 +1147,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDo
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountNonZeroChargesAccruesInvoiceUsage() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-zero-amount-charges")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -1278,7 +1278,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountNonZe
 func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycle() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-only-lifecycle")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -1607,7 +1607,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTier
 
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-only-lifecycle-volume-tiered-correction")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -1873,7 +1873,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTier
 func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-then-invoice")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2171,7 +2171,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceLifecycle() 
 func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCreditedDoesNotAccrueInvoiceUsage() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-then-invoice-fully-credited")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2361,7 +2361,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceFullyCredite
 func (s *InvoicableChargesTestSuite) TestUsageBasedCreateImmediatelyActive() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-create-immediately-active")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2439,7 +2439,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditThenInvoiceDirectPaidFl
 
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-credit-then-invoice-direct-paid")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2579,7 +2579,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreateImmediatelyFinal() {
 
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-create-immediately-final")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2691,7 +2691,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreateImmediatelyFinal() {
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-only-lifecycle")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2856,7 +2856,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyCreateImmediatelyFinal
 
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-only-create-immediately-final")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2938,7 +2938,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyInArrearsAllocatesAtIn
 
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-only-in-arrears")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 

--- a/openmeter/billing/charges/service/lineage_test.go
+++ b/openmeter/billing/charges/service/lineage_test.go
@@ -59,7 +59,7 @@ func (s *CreditRealizationLineageTestSuite) TestFlatFeeCreditOnlyAllocationCreat
 
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-realization-lineage")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -139,7 +139,7 @@ func (s *CreditRealizationLineageTestSuite) TestUsageBasedCreditOnlyAllocationCr
 
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-usagebased-credit-realization-lineage")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)

--- a/openmeter/billing/charges/service/pendinglines_test.go
+++ b/openmeter/billing/charges/service/pendinglines_test.go
@@ -19,7 +19,7 @@ import (
 func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeBackedGatheringLines() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-create-pending-lines")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateTestCustomer(ns, "test-subject")
@@ -138,7 +138,7 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesRollsBackCreatedChargesOnFailure() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-create-pending-lines-rollback")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -244,7 +244,7 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesRejectsNonManu
 func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesRollsBackPartialChargeLineResults() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-create-pending-lines-partial-rollback")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateTestCustomer(ns, "test-subject")

--- a/openmeter/billing/charges/service/taxcode_test.go
+++ b/openmeter/billing/charges/service/taxcode_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
+	taxcodetestutils "github.com/openmeterio/openmeter/openmeter/taxcode/testutils"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -52,13 +53,13 @@ func (s *TaxCodePersistenceTestSuite) TearDownTest() {
 func (s *TaxCodePersistenceTestSuite) TestFlatFeeChargePersistsTaxConfig() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-flatfee")
-	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
+	defaults := s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
 	cust := s.CreateTestCustomer(ns, "test-subject")
 
-	tc := s.createTestTaxCode(ctx, ns, "txcd-10000000")
+	tc := s.TaxCodeEnv.CreateTaxCode(s.T(), ns, taxcode.CreateTaxCodeInput{Key: "txcd-10000000"})
 
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -146,7 +147,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeChargePersistsTaxConfig() {
 func (s *TaxCodePersistenceTestSuite) TestUsageBasedChargePersistsTaxConfig() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-usagebased")
-	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
+	defaults := s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
@@ -154,7 +155,7 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedChargePersistsTaxConfig() {
 	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
 	defer apiRequestsTotal.Cleanup()
 
-	tc := s.createTestTaxCode(ctx, ns, "txcd-10000001")
+	tc := s.TaxCodeEnv.CreateTaxCode(s.T(), ns, taxcode.CreateTaxCodeInput{Key: "txcd-10000001"})
 
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -242,11 +243,11 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedChargePersistsTaxConfig() {
 func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseChargePersistsTaxConfig() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-creditpurchase")
-	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
+	defaults := s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 
-	tc := s.createTestTaxCode(ctx, ns, "txcd-10000002")
+	tc := s.TaxCodeEnv.CreateTaxCode(s.T(), ns, taxcode.CreateTaxCodeInput{Key: "txcd-10000002"})
 
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -350,7 +351,7 @@ func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseChargePersistsTaxConfig(
 func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementPropagatesTaxConfigToGatheringLine() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-creditpurchase-invoice")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -359,7 +360,12 @@ func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementPropaga
 	cust := s.CreateTestCustomer(ns, "test-subject")
 
 	const stripeCode = "txcd_10000003"
-	tc := s.createTestTaxCodeWithStripeMapping(ctx, ns, "txcd-10000003", stripeCode)
+	tc := s.TaxCodeEnv.CreateTaxCode(s.T(), ns, taxcode.CreateTaxCodeInput{
+		Key: "txcd-10000003",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: stripeCode},
+		},
+	})
 
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -483,7 +489,7 @@ func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementPropaga
 func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementNilTaxConfigGetsDefaultCreditGrantTaxCodeStamped() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-creditpurchase-invoice-nil")
-	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
+	defaults := s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
@@ -551,11 +557,11 @@ func (s *TaxCodePersistenceTestSuite) TestCreditPurchaseInvoiceSettlementNilTaxC
 func (s *TaxCodePersistenceTestSuite) TestFlatFeeCreditOnlyHandlerReceivesTaxConfig() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-creditonly")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 
-	tc := s.createTestTaxCode(ctx, ns, "txcd-20000000")
+	tc := s.TaxCodeEnv.CreateTaxCode(s.T(), ns, taxcode.CreateTaxCodeInput{Key: "txcd-20000000"})
 
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -622,7 +628,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeCreditOnlyHandlerReceivesTaxCon
 func (s *TaxCodePersistenceTestSuite) TestUsageBasedCreditOnlyHandlerReceivesTaxConfig() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-usagebased-creditonly")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
@@ -631,7 +637,7 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedCreditOnlyHandlerReceivesTax
 	defer apiRequestsTotal.Cleanup()
 	meterSlug := apiRequestsTotal.Feature.Key
 
-	tc := s.createTestTaxCode(ctx, ns, "txcd-20000001")
+	tc := s.TaxCodeEnv.CreateTaxCode(s.T(), ns, taxcode.CreateTaxCodeInput{Key: "txcd-20000001"})
 
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -704,7 +710,7 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedCreditOnlyHandlerReceivesTax
 func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementPopulatesStripeCodeOnStandardInvoice() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-invoice-settled")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -713,7 +719,12 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementPopulatesStrip
 	cust := s.CreateTestCustomer(ns, "test-subject")
 
 	const stripeCode = "txcd_20000005"
-	tc := s.createTestTaxCodeWithStripeMapping(ctx, ns, "txcd-20000005", stripeCode)
+	tc := s.TaxCodeEnv.CreateTaxCode(s.T(), ns, taxcode.CreateTaxCodeInput{
+		Key: "txcd-20000005",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: stripeCode},
+		},
+	})
 
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -802,7 +813,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementPopulatesStrip
 func (s *TaxCodePersistenceTestSuite) TestTaxConfigInListCharges() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-list")
-	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
+	defaults := s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
@@ -810,7 +821,7 @@ func (s *TaxCodePersistenceTestSuite) TestTaxConfigInListCharges() {
 	apiRequestsTotal := s.SetupApiRequestsTotalFeature(ctx, ns)
 	defer apiRequestsTotal.Cleanup()
 
-	tc := s.createTestTaxCode(ctx, ns, "txcd-10000010")
+	tc := s.TaxCodeEnv.CreateTaxCode(s.T(), ns, taxcode.CreateTaxCodeInput{Key: "txcd-10000010"})
 
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -933,7 +944,7 @@ func (s *TaxCodePersistenceTestSuite) TestTaxConfigInListCharges() {
 func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementPropagatesTaxConfigToGatheringLine() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-gathering")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -942,7 +953,12 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementPropagatesTaxC
 	cust := s.CreateTestCustomer(ns, "test-subject")
 
 	const stripeCode = "txcd_30000001"
-	tc := s.createTestTaxCodeWithStripeMapping(ctx, ns, "txcd-30000001", stripeCode)
+	tc := s.TaxCodeEnv.CreateTaxCode(s.T(), ns, taxcode.CreateTaxCodeInput{
+		Key: "txcd-30000001",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: stripeCode},
+		},
+	})
 
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -1004,7 +1020,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementPropagatesTaxC
 func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementNilTaxConfigGetsDefaultInvoicingTaxCodeStampedOnGatheringLine() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-gathering-nil")
-	defaults := s.ProvisionDefaultTaxCodes(ctx, ns)
+	defaults := s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
@@ -1063,7 +1079,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeInvoiceSettlementNilTaxConfigGe
 func (s *TaxCodePersistenceTestSuite) TestUsageBasedCreditThenInvoicePropagatesTaxConfigToGatheringLine() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-usagebased-gathering")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -1074,7 +1090,12 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedCreditThenInvoicePropagatesT
 	defer apiRequestsTotal.Cleanup()
 
 	const stripeCode = "txcd_30000002"
-	tc := s.createTestTaxCodeWithStripeMapping(ctx, ns, "txcd-30000002", stripeCode)
+	tc := s.TaxCodeEnv.CreateTaxCode(s.T(), ns, taxcode.CreateTaxCodeInput{
+		Key: "txcd-30000002",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: stripeCode},
+		},
+	})
 
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -1136,7 +1157,7 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedCreditThenInvoicePropagatesT
 func (s *TaxCodePersistenceTestSuite) TestUsageBasedInvoiceSettlementPopulatesStripeCodeOnStandardInvoice() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-usagebased-invoice-settled")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -1149,7 +1170,12 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedInvoiceSettlementPopulatesSt
 	meterSlug := apiRequestsTotal.Feature.Key
 
 	const stripeCode = "txcd_30000010"
-	tc := s.createTestTaxCodeWithStripeMapping(ctx, ns, "txcd-30000010", stripeCode)
+	tc := s.TaxCodeEnv.CreateTaxCode(s.T(), ns, taxcode.CreateTaxCodeInput{
+		Key: "txcd-30000010",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: stripeCode},
+		},
+	})
 
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -1249,14 +1275,11 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeBehaviorOnlyTaxConfigGetsDefaul
 	// Provision defaults with a Stripe mapping on the invoicing default so that a behavior-only
 	// TaxConfig still resolves to a Stripe code via the default invoicing tax code.
 	const invoicingStripeCode = "txcd_30000003"
-	invoicingTaxCode := s.createTestTaxCodeWithStripeMapping(ctx, ns, "default-invoicing", invoicingStripeCode)
-	creditGrantTaxCode := s.createTestTaxCode(ctx, ns, "default-credit-grant")
-	_, err := s.TaxCodeService.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
-		Namespace:            ns,
-		InvoicingTaxCodeID:   invoicingTaxCode.ID,
-		CreditGrantTaxCodeID: creditGrantTaxCode.ID,
+	defaultTaxCodes := s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns, taxcodetestutils.ProvisionDefaultTaxCodesInput{
+		InvoicingAppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: invoicingStripeCode},
+		},
 	})
-	s.Require().NoError(err)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -1270,7 +1293,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeBehaviorOnlyTaxConfigGetsDefaul
 	}
 	clock.SetTime(time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC))
 
-	_, err = s.Charges.Create(ctx, charges.CreateInput{
+	_, err := s.Charges.Create(ctx, charges.CreateInput{
 		Namespace: ns,
 		Intents: charges.ChargeIntents{
 			s.createMockChargeIntent(createMockChargeIntentInput{
@@ -1309,7 +1332,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeBehaviorOnlyTaxConfigGetsDefaul
 	s.Require().NotNil(gatheringLine.TaxConfig.Behavior, "TaxBehavior must propagate to gathering line")
 	s.Equal(productcatalog.InclusiveTaxBehavior, *gatheringLine.TaxConfig.Behavior)
 	s.Require().NotNil(gatheringLine.TaxConfig.TaxCodeID, "default invoicing TaxCodeID must be stamped on gathering line")
-	s.Equal(invoicingTaxCode.ID, *gatheringLine.TaxConfig.TaxCodeID)
+	s.Equal(defaultTaxCodes.InvoicingTaxCodeID, *gatheringLine.TaxConfig.TaxCodeID)
 	s.Require().NotNil(gatheringLine.TaxConfig.Stripe, "Stripe.Code must be backfilled from the default invoicing TaxCode entity")
 	s.Equal(invoicingStripeCode, gatheringLine.TaxConfig.Stripe.Code)
 }
@@ -1325,14 +1348,11 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedBehaviorOnlyTaxConfigGetsDef
 	// Provision defaults with a Stripe mapping on the invoicing default so that a behavior-only
 	// TaxConfig still resolves to a Stripe code via the default invoicing tax code.
 	const invoicingStripeCode = "txcd_30000004"
-	invoicingTaxCode := s.createTestTaxCodeWithStripeMapping(ctx, ns, "default-invoicing", invoicingStripeCode)
-	creditGrantTaxCode := s.createTestTaxCode(ctx, ns, "default-credit-grant")
-	_, err := s.TaxCodeService.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
-		Namespace:            ns,
-		InvoicingTaxCodeID:   invoicingTaxCode.ID,
-		CreditGrantTaxCodeID: creditGrantTaxCode.ID,
+	defaultTaxCodes := s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns, taxcodetestutils.ProvisionDefaultTaxCodesInput{
+		InvoicingAppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: invoicingStripeCode},
+		},
 	})
-	s.Require().NoError(err)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
@@ -1348,7 +1368,7 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedBehaviorOnlyTaxConfigGetsDef
 	}
 	clock.SetTime(time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC))
 
-	_, err = s.Charges.Create(ctx, charges.CreateInput{
+	_, err := s.Charges.Create(ctx, charges.CreateInput{
 		Namespace: ns,
 		Intents: charges.ChargeIntents{
 			s.createMockChargeIntent(createMockChargeIntentInput{
@@ -1385,7 +1405,7 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedBehaviorOnlyTaxConfigGetsDef
 	s.Require().NotNil(gatheringLine.TaxConfig.Behavior, "TaxBehavior must propagate to gathering line")
 	s.Equal(productcatalog.ExclusiveTaxBehavior, *gatheringLine.TaxConfig.Behavior)
 	s.Require().NotNil(gatheringLine.TaxConfig.TaxCodeID, "default invoicing TaxCodeID must be stamped on gathering line")
-	s.Equal(invoicingTaxCode.ID, *gatheringLine.TaxConfig.TaxCodeID)
+	s.Equal(defaultTaxCodes.InvoicingTaxCodeID, *gatheringLine.TaxConfig.TaxCodeID)
 	s.Require().NotNil(gatheringLine.TaxConfig.Stripe, "Stripe.Code must be backfilled from the default invoicing TaxCode entity")
 	s.Equal(invoicingStripeCode, gatheringLine.TaxConfig.Stripe.Code)
 }
@@ -1397,7 +1417,7 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedBehaviorOnlyTaxConfigGetsDef
 func (s *TaxCodePersistenceTestSuite) TestCreateFlatFeeChargeWithMissingTaxCodeFailsValidation() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-missing")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 
@@ -1433,6 +1453,56 @@ func (s *TaxCodePersistenceTestSuite) TestCreateFlatFeeChargeWithMissingTaxCodeF
 	s.True(models.IsGenericValidationError(err), "a reference to a non-existent tax code must be a validation error, got: %v", err)
 }
 
+// TestCreateFlatFeeChargeWithDeletedTaxCodeFailsValidation verifies that a charge referencing a
+// soft-deleted tax code is rejected. GetTaxCode returns soft-deleted rows by ID, so
+// validateTaxCodesExist must reject the deleted code explicitly rather than treating it as found.
+func (s *TaxCodePersistenceTestSuite) TestCreateFlatFeeChargeWithDeletedTaxCodeFailsValidation() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-taxcode-flatfee-deleted")
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
+
+	cust := s.CreateTestCustomer(ns, "test-subject")
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	// Freeze the clock before creating and deleting the tax code: TaxCode.IsDeleted() compares
+	// DeletedAt against clock.Now(), so DeletedAt must be stamped at or before the frozen time the
+	// rest of the test (and the create-charge call below) runs at.
+	clock.SetTime(servicePeriod.From)
+	defer clock.UnFreeze()
+
+	tc := s.TaxCodeEnv.CreateTaxCode(s.T(), ns, taxcode.CreateTaxCodeInput{Key: "txcd-90000000"})
+	s.Require().NoError(s.TaxCodeService.DeleteTaxCode(ctx, taxcode.DeleteTaxCodeInput{
+		NamespacedID: models.NamespacedID{Namespace: ns, ID: tc.ID},
+	}))
+
+	_, err := s.Charges.Create(ctx, charges.CreateInput{
+		Namespace: ns,
+		Intents: charges.ChargeIntents{
+			s.createMockChargeIntent(createMockChargeIntentInput{
+				customer:       cust.GetID(),
+				currency:       USD,
+				servicePeriod:  servicePeriod,
+				settlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromFloat(100),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+				name:              "flat-fee-deleted-taxcode",
+				managedBy:         billing.ManuallyManagedLine,
+				uniqueReferenceID: "flat-fee-deleted-taxcode",
+				taxConfig: productcatalog.TaxCodeConfig{
+					TaxCodeID: tc.ID,
+				},
+			}),
+		},
+	})
+	s.Require().Error(err)
+	s.True(models.IsGenericValidationError(err), "a reference to a soft-deleted tax code must be a validation error, got: %v", err)
+}
+
 // TestCreateChargeWithDuplicateReferenceIsConflict verifies that a unique_reference_id collision
 // raised by the bulk insert is mapped by MapChargeConstraintError to a conflict error (409), not a
 // precondition-failed (412) or a raw DB error (500). This exercises the runtime constraint-error
@@ -1441,7 +1511,7 @@ func (s *TaxCodePersistenceTestSuite) TestCreateFlatFeeChargeWithMissingTaxCodeF
 func (s *TaxCodePersistenceTestSuite) TestCreateChargeWithDuplicateReferenceIsConflict() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-taxcode-duplicate-reference")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID())
@@ -1486,29 +1556,4 @@ func (s *TaxCodePersistenceTestSuite) TestCreateChargeWithDuplicateReferenceIsCo
 	// then: the uniqueness collision surfaces as a conflict, not a precondition or raw DB error.
 	s.Require().Error(err)
 	s.True(models.IsGenericConflictError(err), "a duplicate charge reference must be a conflict error, got: %v", err)
-}
-
-func (s *TaxCodePersistenceTestSuite) createTestTaxCode(ctx context.Context, ns, key string) taxcode.TaxCode {
-	s.T().Helper()
-	tc, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: ns,
-		Key:       key,
-		Name:      "Test Tax Code " + key,
-	})
-	s.Require().NoError(err, "creating test tax code must succeed")
-	return tc
-}
-
-func (s *TaxCodePersistenceTestSuite) createTestTaxCodeWithStripeMapping(ctx context.Context, ns, key, stripeCode string) taxcode.TaxCode {
-	s.T().Helper()
-	tc, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: ns,
-		Key:       key,
-		Name:      "Test Tax Code " + key,
-		AppMappings: taxcode.TaxCodeAppMappings{
-			{AppType: app.AppTypeStripe, TaxCode: stripeCode},
-		},
-	})
-	s.Require().NoError(err, "creating test tax code with stripe mapping must succeed")
-	return tc
 }

--- a/openmeter/billing/charges/service/truncation_test.go
+++ b/openmeter/billing/charges/service/truncation_test.go
@@ -40,7 +40,7 @@ func (s *ChargeTimestampTruncationTestSuite) TearDownTest() {
 func (s *ChargeTimestampTruncationTestSuite) TestCreateTruncatesFlatFeeIntentAndProrationInputs() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-truncation-flatfee")
-	defaultTaxCodes := s.ProvisionDefaultTaxCodes(ctx, ns)
+	defaultTaxCodes := s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 
@@ -105,7 +105,7 @@ func (s *ChargeTimestampTruncationTestSuite) TestCreateTruncatesFlatFeeIntentAnd
 func (s *ChargeTimestampTruncationTestSuite) TestUsageBasedAdvanceTruncatesPersistedCalculationTimestamps() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("charges-service-truncation-usagebased")
-	defaultTaxCodes := s.ProvisionDefaultTaxCodes(ctx, ns)
+	defaultTaxCodes := s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateTestCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)

--- a/openmeter/billing/charges/service/unitconfig_rating_test.go
+++ b/openmeter/billing/charges/service/unitconfig_rating_test.go
@@ -115,7 +115,7 @@ func (s *BaseSuite) invoiceUnitConfigChargesScenario() ([]billing.StandardInvoic
 
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-unit-config-rating")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 

--- a/openmeter/billing/charges/service/usagebased_test.go
+++ b/openmeter/billing/charges/service/usagebased_test.go
@@ -39,7 +39,7 @@ func (s *UsageBasedChargesTestSuite) TearDownTest() {
 func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePartialInvoiceLifecycle() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-partial-invoice-lifecycle")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -497,7 +497,7 @@ func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePartialInvoi
 func (s *UsageBasedChargesTestSuite) TestUsageBasedCreditThenInvoicePendingPartialInvoiceBlocksFinalRealizationUntilApproval() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-usage-based-pending-partial-invoice-blocks-final")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 

--- a/openmeter/billing/service/customeroverride.go
+++ b/openmeter/billing/service/customeroverride.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
@@ -26,9 +27,17 @@ func (s *Service) UpsertCustomerOverride(ctx context.Context, input billing.Upse
 	}
 
 	adapterOverride, err := transaction.Run(ctx, s.adapter, func(ctx context.Context) (billing.CustomerOverrideWithDetails, error) {
-		if err := s.resolveDefaultTaxCode(ctx, input.Namespace, input.Invoicing.DefaultTaxConfig); err != nil {
+		// IncludeDeleted is left false: this is fresh client input setting the customer-override
+		// default, so a reference to a soft-deleted tax code must be rejected. Accepting one would
+		// let an override adopt a default that can never resolve to a live Stripe mapping again.
+		resolved, err := productcatalog.ResolveTaxConfig(ctx, s.taxCodeService, productcatalog.ResolveTaxConfigInput{
+			Namespace: input.Namespace,
+			Cfg:       input.Invoicing.DefaultTaxConfig,
+		})
+		if err != nil {
 			return def, err
 		}
+		input.Invoicing.DefaultTaxConfig = resolved
 
 		existingOverride, err := s.adapter.GetCustomerOverride(ctx, billing.GetCustomerOverrideAdapterInput{
 			Customer: customer.CustomerID{

--- a/openmeter/billing/service/gatheringinvoicependinglines.go
+++ b/openmeter/billing/service/gatheringinvoicependinglines.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/sequence"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -690,9 +691,19 @@ func (s *Service) CreateStandardInvoiceFromGatheringLines(ctx context.Context, i
 		return nil, fmt.Errorf("generating invoice number: %w", err)
 	}
 
-	if err := s.resolveDefaultTaxCode(ctx, in.Customer.Namespace, profile.MergedProfile.WorkflowConfig.Invoicing.DefaultTaxConfig); err != nil {
+	// Continuity read: IncludeDeleted is true because we snapshot the customer's already-persisted
+	// merged-profile default, which may have been soft-deleted after it was set. Rejecting it would
+	// block invoice creation for customers whose stored default was later deleted; the frozen Stripe
+	// mapping must still resolve so the invoice carries the tax code it was configured with.
+	resolvedDefaultTaxConfig, err := productcatalog.ResolveTaxConfig(ctx, s.taxCodeService, productcatalog.ResolveTaxConfigInput{
+		Namespace:      in.Customer.Namespace,
+		Cfg:            profile.MergedProfile.WorkflowConfig.Invoicing.DefaultTaxConfig,
+		IncludeDeleted: true,
+	})
+	if err != nil {
 		return nil, fmt.Errorf("resolving default tax code: %w", err)
 	}
+	profile.MergedProfile.WorkflowConfig.Invoicing.DefaultTaxConfig = resolvedDefaultTaxConfig
 
 	// let's create the invoice
 	invoice, err := s.adapter.CreateInvoice(ctx, billing.CreateInvoiceAdapterInput{

--- a/openmeter/billing/service/invoiceupdate.go
+++ b/openmeter/billing/service/invoiceupdate.go
@@ -326,12 +326,15 @@ func (s *Service) sanitizeTaxConfigForDiff(
 		return &sanitized, nil
 	}
 
-	productCatalogTaxConfig := sanitized.ToProductCatalog()
-	if err := productcatalog.ResolveTaxConfig(ctx, s.taxCodeService, namespace, productCatalogTaxConfig); err != nil {
+	resolved, err := productcatalog.ResolveTaxConfig(ctx, s.taxCodeService, productcatalog.ResolveTaxConfigInput{
+		Namespace: namespace,
+		Cfg:       sanitized.ToProductCatalog(),
+	})
+	if err != nil {
 		return nil, err
 	}
 
-	sanitized.TaxConfig = productCatalogTaxConfig.Clone()
+	sanitized.TaxConfig = *resolved
 	if err := validateTaxConfigTaxCodeIDResolvedForDiff(&sanitized); err != nil {
 		return nil, err
 	}
@@ -736,8 +739,16 @@ func (s *Service) taxCodeIDWithBackfill(ctx context.Context, namespace string, t
 		return "", nil
 	}
 
-	resolved := taxConfig.Clone()
-	if err := s.resolveDefaultTaxCode(ctx, namespace, &resolved); err != nil {
+	// Continuity read: IncludeDeleted is true because this backfills the TaxCodeID for an
+	// already-persisted tax config that may reference a since-soft-deleted code. Rejecting it would
+	// break the backfill for existing lines; the frozen Stripe mapping must still resolve so the
+	// persisted record keeps the tax code it already carried.
+	resolved, err := productcatalog.ResolveTaxConfig(ctx, s.taxCodeService, productcatalog.ResolveTaxConfigInput{
+		Namespace:      namespace,
+		Cfg:            taxConfig,
+		IncludeDeleted: true,
+	})
+	if err != nil {
 		return "", err
 	}
 

--- a/openmeter/billing/service/profile.go
+++ b/openmeter/billing/service/profile.go
@@ -305,9 +305,18 @@ func (s *Service) UpdateProfile(ctx context.Context, input billing.UpdateProfile
 		// Resolution must run after the deprecation gate and cannot be removed: legacy clients
 		// that predate taxCodeId echo only stripe.code on no-op updates, and resolution is what
 		// re-stamps TaxCodeID from that echoed code.
-		if err := s.resolveDefaultTaxCode(ctx, input.Namespace, targetState.WorkflowConfig.Invoicing.DefaultTaxConfig); err != nil {
+		//
+		// IncludeDeleted is left false: this is fresh client input setting the profile default, so a
+		// reference to a soft-deleted tax code must be rejected. Accepting one would let a profile
+		// adopt a default that can never resolve to a live Stripe mapping again.
+		resolved, err := productcatalog.ResolveTaxConfig(ctx, s.taxCodeService, productcatalog.ResolveTaxConfigInput{
+			Namespace: input.Namespace,
+			Cfg:       targetState.WorkflowConfig.Invoicing.DefaultTaxConfig,
+		})
+		if err != nil {
 			return nil, err
 		}
+		targetState.WorkflowConfig.Invoicing.DefaultTaxConfig = resolved
 
 		updatedProfile, err := s.adapter.UpdateProfile(ctx, billing.UpdateProfileAdapterInput{
 			TargetState:      targetState,
@@ -649,10 +658,4 @@ func (s *Service) ResolveStripeAppIDFromBillingProfile(ctx context.Context, name
 	}
 
 	return appID, nil
-}
-
-// resolveDefaultTaxCode resolves the billing profile's default tax config in place.
-// See productcatalog.ResolveTaxConfig for precedence rules.
-func (s *Service) resolveDefaultTaxCode(ctx context.Context, namespace string, taxConfig *productcatalog.TaxConfig) error {
-	return productcatalog.ResolveTaxConfig(ctx, s.taxCodeService, namespace, taxConfig)
 }

--- a/openmeter/billing/worker/subscriptionsync/service/base_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/base_test.go
@@ -117,7 +117,7 @@ func (s *SuiteBase) beforeTest(ctx context.Context, suiteName, testName string) 
 	appSandbox := s.InstallSandboxApp(s.T(), s.Namespace)
 
 	s.ProvisionBillingProfile(ctx, s.Namespace, appSandbox.GetID())
-	s.ProvisionDefaultTaxCodes(ctx, s.Namespace)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), s.Namespace)
 
 	apiRequestsTotalMeterSlug := "api-requests-total"
 	apiRequestsTotalMeterID := ulid.Make().String()

--- a/openmeter/billing/worker/subscriptionsync/service/sync_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_test.go
@@ -3917,7 +3917,10 @@ func (s *SubscriptionHandlerTestSuite) TestRateCardTaxSync() {
 
 	lines := gatheringInvoice.Lines.OrEmpty()
 	for _, line := range lines {
-		s.Equal(taxConfig, line.TaxConfig)
+		s.Require().NotNil(line.TaxConfig)
+		s.Equal(taxConfig.Behavior, line.TaxConfig.Behavior)
+		s.Equal(taxConfig.Stripe, line.TaxConfig.Stripe)
+		s.NotNil(line.TaxConfig.TaxCodeID)
 	}
 
 	// Given we edit the subscription the tax config is carried over to the lines
@@ -3948,7 +3951,10 @@ func (s *SubscriptionHandlerTestSuite) TestRateCardTaxSync() {
 
 	lines = gatheringInvoice.Lines.OrEmpty()
 	for _, line := range lines {
-		s.Equal(taxConfig, line.TaxConfig)
+		s.Require().NotNil(line.TaxConfig)
+		s.Equal(taxConfig.Behavior, line.TaxConfig.Behavior)
+		s.Equal(taxConfig.Stripe, line.TaxConfig.Stripe)
+		s.NotNil(line.TaxConfig.TaxCodeID)
 	}
 }
 

--- a/openmeter/productcatalog/addon.go
+++ b/openmeter/productcatalog/addon.go
@@ -336,3 +336,9 @@ func ValidateAddonWithFeatures(ctx context.Context, resolver NamespacedFeatureRe
 		return ValidateRateCardsWithFeatures(ctx, resolver)(a.RateCards)
 	}
 }
+
+func ValidateAddonWithTaxCodes(ctx context.Context, resolver NamespacedTaxCodeResolver) models.ValidatorFunc[Addon] {
+	return func(a Addon) error {
+		return ValidateRateCardsWithTaxCodes(ctx, resolver)(a.RateCards)
+	}
+}

--- a/openmeter/productcatalog/addon/adapter/adapter_test.go
+++ b/openmeter/productcatalog/addon/adapter/adapter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/app"
 	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
@@ -17,6 +18,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon/adapter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	pctestutils "github.com/openmeterio/openmeter/openmeter/productcatalog/testutils"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
+	tctestutils "github.com/openmeterio/openmeter/openmeter/taxcode/testutils"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -445,6 +448,10 @@ func TestPostgresAdapter(t *testing.T) {
 				})
 			}
 		})
+
+		t.Run("ListTaxCodeFilter", func(t *testing.T) {
+			testListAddonTaxCodeFilter(t, env)
+		})
 	})
 }
 
@@ -545,4 +552,103 @@ func TestFromPlanRateCardRowMapsUnitConfig(t *testing.T) {
 
 	require.Equal(t, unitConfig, rc.AsMeta().UnitConfig,
 		"UnitConfig must survive the add-on adapter's linked plan mapper")
+}
+
+func testListAddonTaxCodeFilter(t *testing.T, env *pctestutils.TestEnv) {
+	t.Helper()
+
+	ns := pctestutils.NewTestNamespace(t)
+
+	// Create two tax codes with distinct Stripe app mappings so the add-on service
+	// can resolve them and populate the rate-card tax_code_id FK.
+	tcEnv := tctestutils.NewTestEnvFromClient(t, env.Client, env.Logger)
+
+	taxA := tcEnv.CreateTaxCode(t, ns, taxcode.CreateTaxCodeInput{
+		Key:  "tax-a",
+		Name: "Tax A",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_20000001"},
+		},
+	})
+
+	taxB := tcEnv.CreateTaxCode(t, ns, taxcode.CreateTaxCodeInput{
+		Key:  "tax-b",
+		Name: "Tax B",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_20000002"},
+		},
+	})
+
+	// Helper: build a minimal add-on input with a FlatFeeRateCard referencing the given taxCodeID.
+	makeAddonInput := func(key string, taxCodeID string) addon.CreateAddonInput {
+		input := pctestutils.NewTestAddon(t, ns,
+			&productcatalog.FlatFeeRateCard{
+				RateCardMeta: productcatalog.RateCardMeta{
+					Key:  "rc-1",
+					Name: "RC 1",
+					TaxConfig: &productcatalog.TaxConfig{
+						TaxCodeID: lo.ToPtr(taxCodeID),
+					},
+				},
+			},
+		)
+		input.Addon.AddonMeta.Key = key
+		return input
+	}
+
+	// given: two add-ons each referencing a different tax code
+	addonA, err := env.Addon.CreateAddon(t.Context(), makeAddonInput("addon-a", taxA.ID))
+	require.NoError(t, err, "creating addonA must not fail")
+
+	addonB, err := env.Addon.CreateAddon(t.Context(), makeAddonInput("addon-b", taxB.ID))
+	require.NoError(t, err, "creating addonB must not fail")
+
+	t.Run("filter by taxA returns only addonA", func(t *testing.T) {
+		// when: listing add-ons filtered by taxA
+		result, err := env.AddonRepository.ListAddons(t.Context(), addon.ListAddonsInput{
+			Namespaces: []string{ns},
+			TaxCodes:   &filter.FilterString{In: lo.ToPtr([]string{taxA.ID})},
+			Page:       pagination.Page{PageSize: 100, PageNumber: 1},
+		})
+
+		// then: only addonA is returned
+		require.NoError(t, err)
+		ids := addonIDs(result)
+		require.ElementsMatch(t, []string{addonA.ID}, ids)
+	})
+
+	t.Run("filter by taxB returns only addonB", func(t *testing.T) {
+		// when: listing add-ons filtered by taxB
+		result, err := env.AddonRepository.ListAddons(t.Context(), addon.ListAddonsInput{
+			Namespaces: []string{ns},
+			TaxCodes:   &filter.FilterString{In: lo.ToPtr([]string{taxB.ID})},
+			Page:       pagination.Page{PageSize: 100, PageNumber: 1},
+		})
+
+		// then: only addonB is returned
+		require.NoError(t, err)
+		ids := addonIDs(result)
+		require.ElementsMatch(t, []string{addonB.ID}, ids)
+	})
+
+	t.Run("filter by nonexistent tax code returns empty", func(t *testing.T) {
+		// when: listing add-ons filtered by a tax code id that doesn't exist
+		result, err := env.AddonRepository.ListAddons(t.Context(), addon.ListAddonsInput{
+			Namespaces: []string{ns},
+			TaxCodes:   &filter.FilterString{In: lo.ToPtr([]string{"01000000000000000000000000"})},
+			Page:       pagination.Page{PageSize: 100, PageNumber: 1},
+		})
+
+		// then: no add-ons are returned
+		require.NoError(t, err)
+		require.Empty(t, result.Items)
+	})
+}
+
+func addonIDs(result pagination.Result[addon.Addon]) []string {
+	ids := make([]string, 0, len(result.Items))
+	for _, a := range result.Items {
+		ids = append(ids, a.ID)
+	}
+	return ids
 }

--- a/openmeter/productcatalog/addon/adapter/addon.go
+++ b/openmeter/productcatalog/addon/adapter/addon.go
@@ -57,6 +57,15 @@ func (a *adapter) ListAddons(ctx context.Context, params addon.ListAddonsInput) 
 			)))
 		}
 
+		if params.TaxCodes != nil {
+			if p := filter.SelectPredicate[predicate.AddonRateCard](filter.Filter(*params.TaxCodes), addonratecarddb.FieldTaxCodeID); p != nil {
+				query = query.Where(addondb.HasRatecardsWith(
+					*p,
+					addonratecarddb.DeletedAtIsNil(),
+				))
+			}
+		}
+
 		if !params.IncludeDeleted {
 			query = query.Where(addondb.DeletedAtIsNil())
 		}

--- a/openmeter/productcatalog/addon/service.go
+++ b/openmeter/productcatalog/addon/service.go
@@ -98,6 +98,9 @@ type ListAddonsInput struct {
 
 	// ExcludeUnitConfig omits add-ons carrying a unit_config conversion on any of their rate cards.
 	ExcludeUnitConfig bool
+
+	// TaxCodes filters add-ons by the tax code IDs referenced on their rate cards.
+	TaxCodes *filter.FilterString
 }
 
 func (i ListAddonsInput) Validate() error {
@@ -120,6 +123,11 @@ func (i ListAddonsInput) Validate() error {
 	}
 	if i.Currency != nil {
 		if err := i.Currency.Validate(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if i.TaxCodes != nil {
+		if err := i.TaxCodes.Validate(); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/openmeter/productcatalog/addon/service/addon.go
+++ b/openmeter/productcatalog/addon/service/addon.go
@@ -434,6 +434,16 @@ func (s service) PublishAddon(ctx context.Context, params addon.PublishAddonInpu
 			)
 		}
 
+		// Validate add-on with tax codes
+		err = pa.ValidateWith(
+			productcatalog.ValidateAddonWithTaxCodes(ctx, s.taxCodeResolver.WithNamespace(params.Namespace)),
+		)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid add-on [id=%s key=%s version=%d]: %w",
+				add.ID, add.Key, add.Version, err),
+			)
+		}
+
 		if err = errors.Join(errs...); err != nil {
 			return nil, models.NewGenericValidationError(err)
 		}

--- a/openmeter/productcatalog/addon/service/addon.go
+++ b/openmeter/productcatalog/addon/service/addon.go
@@ -44,9 +44,14 @@ func (s service) resolveTaxCodes(ctx context.Context, namespace string, rateCard
 			continue
 		}
 
-		if err := productcatalog.ResolveTaxConfig(ctx, s.taxCode, namespace, meta.TaxConfig); err != nil {
+		resolved, err := productcatalog.ResolveTaxConfig(ctx, s.taxCode, productcatalog.ResolveTaxConfigInput{
+			Namespace: namespace,
+			Cfg:       meta.TaxConfig,
+		})
+		if err != nil {
 			return err
 		}
+		meta.TaxConfig = resolved
 
 		var rcNew productcatalog.RateCard
 

--- a/openmeter/productcatalog/addon/service/service.go
+++ b/openmeter/productcatalog/addon/service/service.go
@@ -17,6 +17,7 @@ type Config struct {
 	Publisher eventbus.Publisher
 
 	FeatureResolver productcatalog.FeatureResolver
+	TaxCodeResolver productcatalog.TaxCodeResolver
 }
 
 func New(config Config) (addon.Service, error) {
@@ -26,6 +27,10 @@ func New(config Config) (addon.Service, error) {
 
 	if config.FeatureResolver == nil {
 		return nil, errors.New("feature resolver is required")
+	}
+
+	if config.TaxCodeResolver == nil {
+		return nil, errors.New("tax code resolver is required")
 	}
 
 	if config.TaxCode == nil {
@@ -47,6 +52,7 @@ func New(config Config) (addon.Service, error) {
 		publisher: config.Publisher,
 
 		featureResolver: config.FeatureResolver,
+		taxCodeResolver: config.TaxCodeResolver,
 	}, nil
 }
 
@@ -59,4 +65,5 @@ type service struct {
 	publisher eventbus.Publisher
 
 	featureResolver productcatalog.FeatureResolver
+	taxCodeResolver productcatalog.TaxCodeResolver
 }

--- a/openmeter/productcatalog/addon/service/taxcode_test.go
+++ b/openmeter/productcatalog/addon/service/taxcode_test.go
@@ -905,7 +905,6 @@ func TestAddonPublishRejectsDeletedTaxCode(t *testing.T) {
 
 	env := pctestutils.NewTestEnv(t)
 	t.Cleanup(func() { env.Close(t) })
-	env.DBSchemaMigrate(t)
 
 	namespace := pctestutils.NewTestNamespace(t)
 

--- a/openmeter/productcatalog/addon/service/taxcode_test.go
+++ b/openmeter/productcatalog/addon/service/taxcode_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -896,4 +897,111 @@ func TestAddonWithPlanTaxCode(t *testing.T) {
 		require.NotNil(t, tc.TaxCodeID, "TaxCodeID must be backfilled from TaxCode entity")
 		assert.Equal(t, tcEntity.ID, *tc.TaxCodeID)
 	})
+}
+
+func TestAddonPublishRejectsDeletedTaxCode(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := pctestutils.NewTestEnv(t)
+	t.Cleanup(func() { env.Close(t) })
+	env.DBSchemaMigrate(t)
+
+	namespace := pctestutils.NewTestNamespace(t)
+
+	// given:
+	// - a meter and a feature are provisioned
+	// - a tax code is created and then deleted, leaving a dangling reference
+	// - a draft add-on has a rate card referencing that (now-deleted) tax code
+
+	err := env.Meter.ReplaceMeters(ctx, pctestutils.NewTestMeters(t, namespace))
+	require.NoError(t, err)
+
+	result, err := env.Meter.ListMeters(ctx, meter.ListMetersParams{
+		Page: pagination.Page{
+			PageSize:   1000,
+			PageNumber: 1,
+		},
+		Namespace: namespace,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Items)
+
+	feat, err := env.Feature.CreateFeature(ctx, pctestutils.NewTestFeatureFromMeter(t, &result.Items[0]))
+	require.NoError(t, err)
+
+	// Provision organization-default tax codes so DeleteTaxCode can proceed past the org-defaults check.
+	invoicingTC, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "org-default-invoicing",
+		Name:      "Org Default Invoicing",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_00000001"},
+		},
+	})
+	require.NoError(t, err)
+
+	creditGrantTC, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "org-default-credit-grant",
+		Name:      "Org Default Credit Grant",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_00000002"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = env.TaxCode.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
+		Namespace:            namespace,
+		InvoicingTaxCodeID:   invoicingTC.ID,
+		CreditGrantTaxCodeID: creditGrantTC.ID,
+	})
+	require.NoError(t, err)
+
+	// Create a tax code with a Stripe app mapping so it resolves at create time.
+	tcEntity, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "stripe_txcd_40000001",
+		Name:      "txcd_40000001",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000001"},
+		},
+	})
+	require.NoError(t, err)
+
+	taxCodeID := tcEntity.ID
+
+	// Create a DRAFT add-on with a rate card referencing the tax code.
+	input := newTestAddonInput(t, namespace, newTestAddonFlatRateCard(feat, &productcatalog.TaxConfig{
+		TaxCodeID: lo.ToPtr(taxCodeID),
+	}))
+	input.Key = "publish-deleted-taxcode"
+	input.Name = "Publish Deleted TaxCode"
+
+	a, err := env.Addon.CreateAddon(ctx, input)
+	require.NoError(t, err)
+
+	// Delete the tax code — the add-on-reference delete hook is NOT registered in pctestutils,
+	// so this succeeds and leaves a dangling reference (intended for this test).
+	err = env.TaxCode.DeleteTaxCode(ctx, taxcode.DeleteTaxCodeInput{
+		NamespacedID: models.NamespacedID{Namespace: namespace, ID: taxCodeID},
+	})
+	require.NoError(t, err)
+
+	// when: publishing the add-on
+	publishAt := time.Now().Truncate(time.Microsecond)
+	_, err = env.Addon.PublishAddon(ctx, addon.PublishAddonInput{
+		NamespacedID: a.NamespacedID,
+		EffectivePeriod: productcatalog.EffectivePeriod{
+			EffectiveFrom: &publishAt,
+			EffectiveTo:   nil,
+		},
+	})
+
+	// then: publish fails with a rate-card tax-code-not-found validation issue
+	require.Error(t, err)
+
+	var vi models.ValidationIssue
+	require.True(t, errors.As(err, &vi), "expected ValidationIssue wrapping ErrCodeRateCardTaxCodeNotFound, got %T: %v", err, err)
+	require.Equal(t, productcatalog.ErrCodeRateCardTaxCodeNotFound, vi.Code())
 }

--- a/openmeter/productcatalog/addon/service/taxcode_test.go
+++ b/openmeter/productcatalog/addon/service/taxcode_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
 	pctestutils "github.com/openmeterio/openmeter/openmeter/productcatalog/testutils"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
-	taxcodetestutils "github.com/openmeterio/openmeter/openmeter/taxcode/testutils"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 )
@@ -581,7 +580,6 @@ func TestAddonTaxCodeBackfill(t *testing.T) {
 
 	env := pctestutils.NewTestEnv(t)
 	t.Cleanup(func() { env.Close(t) })
-	taxCodeEnv := taxcodetestutils.NewTestEnvFromClient(t, env.Client, nil)
 
 	namespace := pctestutils.NewTestNamespace(t)
 
@@ -612,7 +610,7 @@ func TestAddonTaxCodeBackfill(t *testing.T) {
 		a, err := env.Addon.CreateAddon(ctx, input)
 		require.NoError(t, err)
 
-		tcEntity := taxCodeEnv.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{
+		tcEntity := env.TaxCodeEnv.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{
 			Key:  "stripe_txcd_99000002",
 			Name: "txcd_99000002",
 			AppMappings: taxcode.TaxCodeAppMappings{
@@ -669,7 +667,7 @@ func TestAddonTaxCodeBackfill(t *testing.T) {
 		a, err := env.Addon.CreateAddon(ctx, input)
 		require.NoError(t, err)
 
-		tcEntity := taxCodeEnv.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{
+		tcEntity := env.TaxCodeEnv.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{
 			Key:  "stripe_txcd_99000010",
 			Name: "txcd_99000010",
 			AppMappings: taxcode.TaxCodeAppMappings{
@@ -761,7 +759,6 @@ func TestAddonWithPlanTaxCode(t *testing.T) {
 
 	env := pctestutils.NewTestEnv(t)
 	t.Cleanup(func() { env.Close(t) })
-	taxCodeEnv := taxcodetestutils.NewTestEnvFromClient(t, env.Client, nil)
 
 	namespace := pctestutils.NewTestNamespace(t)
 
@@ -841,7 +838,7 @@ func TestAddonWithPlanTaxCode(t *testing.T) {
 
 		phaseID := p.Phases[0].PhaseManagedFields.NamespacedID.ID
 
-		tcEntity := taxCodeEnv.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{
+		tcEntity := env.TaxCodeEnv.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{
 			Key:  "stripe_txcd_99000020",
 			Name: "txcd_99000020",
 			AppMappings: taxcode.TaxCodeAppMappings{
@@ -930,32 +927,7 @@ func TestAddonPublishRejectsDeletedTaxCode(t *testing.T) {
 	require.NoError(t, err)
 
 	// Provision organization-default tax codes so DeleteTaxCode can proceed past the org-defaults check.
-	invoicingTC, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: namespace,
-		Key:       "org-default-invoicing",
-		Name:      "Org Default Invoicing",
-		AppMappings: taxcode.TaxCodeAppMappings{
-			{AppType: app.AppTypeStripe, TaxCode: "txcd_00000001"},
-		},
-	})
-	require.NoError(t, err)
-
-	creditGrantTC, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: namespace,
-		Key:       "org-default-credit-grant",
-		Name:      "Org Default Credit Grant",
-		AppMappings: taxcode.TaxCodeAppMappings{
-			{AppType: app.AppTypeStripe, TaxCode: "txcd_00000002"},
-		},
-	})
-	require.NoError(t, err)
-
-	_, err = env.TaxCode.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
-		Namespace:            namespace,
-		InvoicingTaxCodeID:   invoicingTC.ID,
-		CreditGrantTaxCodeID: creditGrantTC.ID,
-	})
-	require.NoError(t, err)
+	env.TaxCodeEnv.ProvisionDefaultTaxCodes(t, namespace)
 
 	// Create a tax code with a Stripe app mapping so it resolves at create time.
 	tcEntity, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
@@ -1003,4 +975,145 @@ func TestAddonPublishRejectsDeletedTaxCode(t *testing.T) {
 	var vi models.ValidationIssue
 	require.True(t, errors.As(err, &vi), "expected ValidationIssue wrapping ErrCodeRateCardTaxCodeNotFound, got %T: %v", err, err)
 	require.Equal(t, productcatalog.ErrCodeRateCardTaxCodeNotFound, vi.Code())
+}
+
+// TestCreateAddonRejectsDeletedTaxCode verifies that CreateAddon rejects a rate card whose
+// TaxConfig.TaxCodeID references a tax code that is already soft-deleted at creation time.
+// taxcode.Service.GetTaxCode intentionally returns soft-deleted rows by ID (so existing
+// references keep resolving for reads), so resolveTaxCodes must independently reject a fresh
+// reference to a deleted tax code via TaxCode.IsDeleted() rather than relying on GetTaxCode
+// to fail lookup.
+func TestCreateAddonRejectsDeletedTaxCode(t *testing.T) {
+	ctx := t.Context()
+
+	env := pctestutils.NewTestEnv(t)
+	t.Cleanup(func() { env.Close(t) })
+
+	namespace := pctestutils.NewTestNamespace(t)
+
+	// given:
+	// - a meter and a feature are provisioned
+	// - a tax code is created and then soft-deleted before any add-on references it
+
+	err := env.Meter.ReplaceMeters(ctx, pctestutils.NewTestMeters(t, namespace))
+	require.NoError(t, err)
+
+	result, err := env.Meter.ListMeters(ctx, meter.ListMetersParams{
+		Page: pagination.Page{
+			PageSize:   1000,
+			PageNumber: 1,
+		},
+		Namespace: namespace,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Items)
+
+	feat, err := env.Feature.CreateFeature(ctx, pctestutils.NewTestFeatureFromMeter(t, &result.Items[0]))
+	require.NoError(t, err)
+
+	// Provision organization-default tax codes so DeleteTaxCode can proceed past the org-defaults check.
+	env.TaxCodeEnv.ProvisionDefaultTaxCodes(t, namespace)
+
+	tcEntity, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "stripe_txcd_40000002",
+		Name:      "txcd_40000002",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000002"},
+		},
+	})
+	require.NoError(t, err)
+
+	err = env.TaxCode.DeleteTaxCode(ctx, taxcode.DeleteTaxCodeInput{
+		NamespacedID: models.NamespacedID{Namespace: namespace, ID: tcEntity.ID},
+	})
+	require.NoError(t, err)
+
+	// when: creating an add-on whose rate card references the already-deleted tax code
+	input := newTestAddonInput(t, namespace, newTestAddonFlatRateCard(feat, &productcatalog.TaxConfig{
+		TaxCodeID: lo.ToPtr(tcEntity.ID),
+	}))
+	input.Key = "create-deleted-taxcode"
+	input.Name = "Create Deleted TaxCode"
+
+	_, err = env.Addon.CreateAddon(ctx, input)
+
+	// then: creation is rejected with a generic validation error
+	require.Error(t, err)
+	assert.True(t, models.IsGenericValidationError(err), "expected validation error for deleted taxCodeId, got: %v", err)
+}
+
+// TestUpdateAddonRejectsDeletedTaxCode verifies that UpdateAddon rejects a rate card whose
+// TaxConfig.TaxCodeID references a tax code that has since been soft-deleted. The add-on is
+// created without a tax reference, then updated to reference the deleted tax code; the same
+// resolveTaxCodes guard used by CreateAddon runs on every rate-card update.
+func TestUpdateAddonRejectsDeletedTaxCode(t *testing.T) {
+	ctx := t.Context()
+
+	env := pctestutils.NewTestEnv(t)
+	t.Cleanup(func() { env.Close(t) })
+
+	namespace := pctestutils.NewTestNamespace(t)
+
+	// given:
+	// - a meter and a feature are provisioned
+	// - a draft add-on exists with no tax reference on its rate card
+	// - a tax code is created and then soft-deleted
+
+	err := env.Meter.ReplaceMeters(ctx, pctestutils.NewTestMeters(t, namespace))
+	require.NoError(t, err)
+
+	result, err := env.Meter.ListMeters(ctx, meter.ListMetersParams{
+		Page: pagination.Page{
+			PageSize:   1000,
+			PageNumber: 1,
+		},
+		Namespace: namespace,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Items)
+
+	feat, err := env.Feature.CreateFeature(ctx, pctestutils.NewTestFeatureFromMeter(t, &result.Items[0]))
+	require.NoError(t, err)
+
+	// Provision organization-default tax codes so DeleteTaxCode can proceed past the org-defaults check.
+	env.TaxCodeEnv.ProvisionDefaultTaxCodes(t, namespace)
+
+	input := newTestAddonInput(t, namespace, newTestAddonFlatRateCard(feat, nil))
+	input.Key = "update-deleted-taxcode"
+	input.Name = "Update Deleted TaxCode"
+
+	a, err := env.Addon.CreateAddon(ctx, input)
+	require.NoError(t, err)
+
+	tcEntity, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "stripe_txcd_40000003",
+		Name:      "txcd_40000003",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000003"},
+		},
+	})
+	require.NoError(t, err)
+
+	err = env.TaxCode.DeleteTaxCode(ctx, taxcode.DeleteTaxCodeInput{
+		NamespacedID: models.NamespacedID{Namespace: namespace, ID: tcEntity.ID},
+	})
+	require.NoError(t, err)
+
+	// when: updating the add-on's rate card to reference the deleted tax code
+	updatedRateCards := productcatalog.RateCards{
+		newTestAddonFlatRateCard(feat, &productcatalog.TaxConfig{
+			TaxCodeID: lo.ToPtr(tcEntity.ID),
+		}),
+	}
+
+	_, err = env.Addon.UpdateAddon(ctx, addon.UpdateAddonInput{
+		NamespacedID: a.NamespacedID,
+		RateCards:    &updatedRateCards,
+	})
+
+	// then: update is rejected with a generic validation error
+	require.Error(t, err)
+	assert.True(t, models.IsGenericValidationError(err), "expected validation error for deleted taxCodeId, got: %v", err)
 }

--- a/openmeter/productcatalog/plan/service/plan.go
+++ b/openmeter/productcatalog/plan/service/plan.go
@@ -41,9 +41,14 @@ func (s service) resolveTaxCodes(ctx context.Context, namespace string, rateCard
 			continue
 		}
 
-		if err := productcatalog.ResolveTaxConfig(ctx, s.taxCode, namespace, meta.TaxConfig); err != nil {
+		resolved, err := productcatalog.ResolveTaxConfig(ctx, s.taxCode, productcatalog.ResolveTaxConfigInput{
+			Namespace: namespace,
+			Cfg:       meta.TaxConfig,
+		})
+		if err != nil {
 			return err
 		}
+		meta.TaxConfig = resolved
 
 		var rcNew productcatalog.RateCard
 

--- a/openmeter/productcatalog/plan/service/taxcode_test.go
+++ b/openmeter/productcatalog/plan/service/taxcode_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon"
 	pctestutils "github.com/openmeterio/openmeter/openmeter/productcatalog/testutils"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
-	taxcodetestutils "github.com/openmeterio/openmeter/openmeter/taxcode/testutils"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/pagination"
@@ -701,7 +700,6 @@ func TestPlanTaxCodeBackfill(t *testing.T) {
 
 	env := pctestutils.NewTestEnv(t)
 	t.Cleanup(func() { env.Close(t) })
-	taxCodeEnv := taxcodetestutils.NewTestEnvFromClient(t, env.Client, nil)
 
 	namespace := pctestutils.NewTestNamespace(t)
 	MonthPeriod := datetime.MustParseDuration(t, "P1M")
@@ -736,7 +734,7 @@ func TestPlanTaxCodeBackfill(t *testing.T) {
 
 		phaseID := p.Phases[0].PhaseManagedFields.NamespacedID.ID
 
-		tcEntity := taxCodeEnv.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{
+		tcEntity := env.TaxCodeEnv.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{
 			Key:  "stripe_txcd_99000001",
 			Name: "txcd_99000001",
 			AppMappings: taxcode.TaxCodeAppMappings{
@@ -795,7 +793,7 @@ func TestPlanTaxCodeBackfill(t *testing.T) {
 
 		phaseID := p.Phases[0].PhaseManagedFields.NamespacedID.ID
 
-		tcEntity := taxCodeEnv.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{
+		tcEntity := env.TaxCodeEnv.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{
 			Key:  "stripe_txcd_99000010",
 			Name: "txcd_99000010",
 			AppMappings: taxcode.TaxCodeAppMappings{
@@ -920,32 +918,7 @@ func TestPlanPublishRejectsDeletedTaxCode(t *testing.T) {
 	}
 
 	// Provision organization-default tax codes so DeleteTaxCode can proceed past the org-defaults check.
-	invoicingTC, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: namespace,
-		Key:       "org-default-invoicing",
-		Name:      "Org Default Invoicing",
-		AppMappings: taxcode.TaxCodeAppMappings{
-			{AppType: app.AppTypeStripe, TaxCode: "txcd_00000001"},
-		},
-	})
-	require.NoError(t, err)
-
-	creditGrantTC, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: namespace,
-		Key:       "org-default-credit-grant",
-		Name:      "Org Default Credit Grant",
-		AppMappings: taxcode.TaxCodeAppMappings{
-			{AppType: app.AppTypeStripe, TaxCode: "txcd_00000002"},
-		},
-	})
-	require.NoError(t, err)
-
-	_, err = env.TaxCode.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
-		Namespace:            namespace,
-		InvoicingTaxCodeID:   invoicingTC.ID,
-		CreditGrantTaxCodeID: creditGrantTC.ID,
-	})
-	require.NoError(t, err)
+	env.TaxCodeEnv.ProvisionDefaultTaxCodes(t, namespace)
 
 	// Create a tax code with a Stripe app mapping so it resolves at create time.
 	tcEntity, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
@@ -993,6 +966,159 @@ func TestPlanPublishRejectsDeletedTaxCode(t *testing.T) {
 	var vi models.ValidationIssue
 	require.True(t, errors.As(err, &vi), "expected ValidationIssue wrapping ErrCodeRateCardTaxCodeNotFound, got %T: %v", err, err)
 	require.Equal(t, productcatalog.ErrCodeRateCardTaxCodeNotFound, vi.Code())
+}
+
+// TestCreatePlanRejectsDeletedTaxCode verifies that CreatePlan rejects a rate card whose
+// TaxConfig.TaxCodeID references a tax code that is already soft-deleted at creation time.
+// taxcode.Service.GetTaxCode intentionally returns soft-deleted rows by ID (so existing
+// references keep resolving for reads), so resolveTaxCodes must independently reject a fresh
+// reference to a deleted tax code via TaxCode.IsDeleted() rather than relying on GetTaxCode
+// to fail lookup.
+func TestCreatePlanRejectsDeletedTaxCode(t *testing.T) {
+	MonthPeriod := datetime.MustParseDuration(t, "P1M")
+
+	ctx := t.Context()
+
+	env := pctestutils.NewTestEnv(t)
+	t.Cleanup(func() { env.Close(t) })
+
+	namespace := pctestutils.NewTestNamespace(t)
+
+	// given:
+	// - a meter and a feature are provisioned
+	// - a tax code is created and then soft-deleted before any plan references it
+
+	err := env.Meter.ReplaceMeters(ctx, pctestutils.NewTestMeters(t, namespace))
+	require.NoError(t, err)
+
+	result, err := env.Meter.ListMeters(ctx, meter.ListMetersParams{
+		Page: pagination.Page{
+			PageSize:   1000,
+			PageNumber: 1,
+		},
+		Namespace: namespace,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Items)
+
+	feat, err := env.Feature.CreateFeature(ctx, pctestutils.NewTestFeatureFromMeter(t, &result.Items[0]))
+	require.NoError(t, err)
+
+	// Provision organization-default tax codes so DeleteTaxCode can proceed past the org-defaults check.
+	env.TaxCodeEnv.ProvisionDefaultTaxCodes(t, namespace)
+
+	tcEntity, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "stripe_txcd_40000002",
+		Name:      "txcd_40000002",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000002"},
+		},
+	})
+	require.NoError(t, err)
+
+	err = env.TaxCode.DeleteTaxCode(ctx, taxcode.DeleteTaxCodeInput{
+		NamespacedID: models.NamespacedID{Namespace: namespace, ID: tcEntity.ID},
+	})
+	require.NoError(t, err)
+
+	// when: creating a plan whose rate card references the already-deleted tax code
+	input := newTestPlanInput(t, namespace, newTestFlatRateCard(feat, &productcatalog.TaxConfig{
+		TaxCodeID: lo.ToPtr(tcEntity.ID),
+	}, &MonthPeriod))
+	input.Key = "create-deleted-taxcode"
+	input.Name = "Create Deleted TaxCode"
+
+	_, err = env.Plan.CreatePlan(ctx, input)
+
+	// then: creation is rejected with a generic validation error
+	require.Error(t, err)
+	assert.True(t, models.IsGenericValidationError(err), "expected validation error for deleted taxCodeId, got: %v", err)
+}
+
+// TestUpdatePlanRejectsDeletedTaxCode verifies that UpdatePlan rejects a rate card whose
+// TaxConfig.TaxCodeID references a tax code that has since been soft-deleted. The plan is
+// created without a tax reference, then updated to reference the deleted tax code; the same
+// resolveTaxCodes guard used by CreatePlan runs on every phase update.
+func TestUpdatePlanRejectsDeletedTaxCode(t *testing.T) {
+	MonthPeriod := datetime.MustParseDuration(t, "P1M")
+
+	ctx := t.Context()
+
+	env := pctestutils.NewTestEnv(t)
+	t.Cleanup(func() { env.Close(t) })
+
+	namespace := pctestutils.NewTestNamespace(t)
+
+	// given:
+	// - a meter and a feature are provisioned
+	// - a draft plan exists with no tax reference on its rate card
+	// - a tax code is created and then soft-deleted
+
+	err := env.Meter.ReplaceMeters(ctx, pctestutils.NewTestMeters(t, namespace))
+	require.NoError(t, err)
+
+	result, err := env.Meter.ListMeters(ctx, meter.ListMetersParams{
+		Page: pagination.Page{
+			PageSize:   1000,
+			PageNumber: 1,
+		},
+		Namespace: namespace,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Items)
+
+	feat, err := env.Feature.CreateFeature(ctx, pctestutils.NewTestFeatureFromMeter(t, &result.Items[0]))
+	require.NoError(t, err)
+
+	// Provision organization-default tax codes so DeleteTaxCode can proceed past the org-defaults check.
+	env.TaxCodeEnv.ProvisionDefaultTaxCodes(t, namespace)
+
+	input := newTestPlanInput(t, namespace, newTestFlatRateCard(feat, nil, &MonthPeriod))
+	input.Key = "update-deleted-taxcode"
+	input.Name = "Update Deleted TaxCode"
+
+	p, err := env.Plan.CreatePlan(ctx, input)
+	require.NoError(t, err)
+
+	tcEntity, err := env.TaxCode.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "stripe_txcd_40000003",
+		Name:      "txcd_40000003",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: "txcd_40000003"},
+		},
+	})
+	require.NoError(t, err)
+
+	err = env.TaxCode.DeleteTaxCode(ctx, taxcode.DeleteTaxCodeInput{
+		NamespacedID: models.NamespacedID{Namespace: namespace, ID: tcEntity.ID},
+	})
+	require.NoError(t, err)
+
+	// when: updating the plan's rate card to reference the deleted tax code
+	updatedPhases := []productcatalog.Phase{
+		{
+			PhaseMeta: productcatalog.PhaseMeta{
+				Key:  "default",
+				Name: "Default",
+			},
+			RateCards: productcatalog.RateCards{
+				newTestFlatRateCard(feat, &productcatalog.TaxConfig{
+					TaxCodeID: lo.ToPtr(tcEntity.ID),
+				}, &MonthPeriod),
+			},
+		},
+	}
+
+	_, err = env.Plan.UpdatePlan(ctx, plan.UpdatePlanInput{
+		NamespacedID: p.NamespacedID,
+		Phases:       &updatedPhases,
+	})
+
+	// then: update is rejected with a generic validation error
+	require.Error(t, err)
+	assert.True(t, models.IsGenericValidationError(err), "expected validation error for deleted taxCodeId, got: %v", err)
 }
 
 func TestPlanWithAddonTaxCode(t *testing.T) {

--- a/openmeter/productcatalog/tax.go
+++ b/openmeter/productcatalog/tax.go
@@ -230,37 +230,59 @@ func TaxCodeConfigFrom(cfg *TaxConfig) TaxCodeConfig {
 	return out
 }
 
-// ResolveTaxConfig cross-populates TaxCodeID and provider-specific codes on the pointed-to
-// config so the persisted record is internally consistent. Four input cases:
-//   - Only TaxCodeID: looks up the entity, validates it exists (400 if not), and sets Stripe
-//     from the entity's Stripe app mapping (or clears Stripe if the entity has no mapping).
+// ResolveTaxConfigInput describes a TaxConfig resolution request.
+type ResolveTaxConfigInput struct {
+	Namespace string
+	Cfg       *TaxConfig
+	// IncludeDeleted allows resolving a soft-deleted TaxCode by ID instead of rejecting it.
+	// Defaults to false (reject): most callers are accepting a reference that must remain live
+	// going forward (plan/addon rate cards, subscription items, billing profile/customer-override
+	// defaults being newly set). Set true only for continuity reads that re-derive an
+	// already-persisted, possibly-since-deleted reference (billing invoice/gathering-line
+	// snapshotting).
+	IncludeDeleted bool
+}
+
+// ResolveTaxConfig returns a resolved clone of input.Cfg with TaxCodeID and provider-specific
+// codes cross-populated so the persisted record is internally consistent. Four input cases:
+//   - Only TaxCodeID, or both TaxCodeID and Stripe.Code (same branch below): looks up the
+//     entity by ID and validates it exists (400 if not). Rejects a soft-deleted entity (400)
+//     unless input.IncludeDeleted is true. Sets Stripe from the entity's Stripe app mapping (or
+//     clears Stripe if the entity has no mapping). When both are supplied, TaxCodeID wins; the
+//     caller-supplied Stripe.Code is discarded.
 //   - Only Stripe.Code: upserts the TaxCode entity via GetOrCreateByAppMapping and stamps
-//     TaxCodeID (idempotent; updating the code txcd_A → txcd_B updates the FK).
-//   - Both TaxCodeID and Stripe.Code: TaxCodeID wins. Stripe is overridden from the entity's
-//     Stripe app mapping (or cleared if the entity has no mapping); the caller-supplied
-//     Stripe.Code is discarded.
+//     TaxCodeID (idempotent; updating the code txcd_A → txcd_B updates the FK). IncludeDeleted is
+//     irrelevant here: GetTaxCodeByAppMapping already filters soft-deleted rows, and the
+//     (namespace, key) unique index only applies to non-deleted rows, so re-migrating a Stripe
+//     code whose prior TaxCode was soft-deleted always creates a fresh entity.
 //   - Neither: no-op.
 //
-// No-op when cfg is nil.
-func ResolveTaxConfig(ctx context.Context, svc taxcode.Service, namespace string, cfg *TaxConfig) error {
-	if cfg == nil {
-		return nil
+// Returns nil when input.Cfg is nil.
+func ResolveTaxConfig(ctx context.Context, svc taxcode.Service, input ResolveTaxConfigInput) (*TaxConfig, error) {
+	if input.Cfg == nil {
+		return nil, nil
 	}
 
 	if svc == nil {
-		return fmt.Errorf("taxcode service is required")
+		return nil, fmt.Errorf("taxcode service is required")
 	}
+
+	cfg := input.Cfg.Clone()
 
 	switch {
 	case cfg.TaxCodeID != nil:
 		tc, err := svc.GetTaxCode(ctx, taxcode.GetTaxCodeInput{
-			NamespacedID: models.NamespacedID{Namespace: namespace, ID: *cfg.TaxCodeID},
+			NamespacedID: models.NamespacedID{Namespace: input.Namespace, ID: *cfg.TaxCodeID},
 		})
 		if err != nil {
 			if taxcode.IsTaxCodeNotFoundError(err) {
-				return models.NewGenericValidationError(fmt.Errorf("tax code %s not found", *cfg.TaxCodeID))
+				return nil, models.NewGenericValidationError(fmt.Errorf("tax code %s not found", *cfg.TaxCodeID))
 			}
-			return fmt.Errorf("resolving tax code %s: %w", *cfg.TaxCodeID, err)
+			return nil, fmt.Errorf("resolving tax code %s: %w", *cfg.TaxCodeID, err)
+		}
+
+		if !input.IncludeDeleted && tc.IsDeleted() {
+			return nil, models.NewGenericValidationError(fmt.Errorf("tax code %s not found", *cfg.TaxCodeID))
 		}
 
 		if m, ok := tc.GetAppMapping(app.AppTypeStripe); ok {
@@ -271,18 +293,18 @@ func ResolveTaxConfig(ctx context.Context, svc taxcode.Service, namespace string
 
 	case cfg.Stripe != nil && cfg.Stripe.Code != "":
 		tc, err := svc.GetOrCreateByAppMapping(ctx, taxcode.GetOrCreateByAppMappingInput{
-			Namespace: namespace,
+			Namespace: input.Namespace,
 			AppType:   app.AppTypeStripe,
 			TaxCode:   cfg.Stripe.Code,
 		})
 		if err != nil {
-			return fmt.Errorf("resolving tax code for stripe code %s: %w", cfg.Stripe.Code, err)
+			return nil, fmt.Errorf("resolving tax code for stripe code %s: %w", cfg.Stripe.Code, err)
 		}
 
 		cfg.TaxCodeID = lo.ToPtr(tc.ID)
 	}
 
-	return nil
+	return &cfg, nil
 }
 
 // BackfillTaxConfig fills in missing legacy TaxConfig fields from the new tax_behavior column

--- a/openmeter/productcatalog/tax_test.go
+++ b/openmeter/productcatalog/tax_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -732,23 +733,30 @@ func TestResolveTaxConfig(t *testing.T) {
 		NamespacedID: models.NamespacedID{Namespace: ns, ID: "tc-no-stripe"},
 		AppMappings:  taxcode.TaxCodeAppMappings{},
 	}
+	// Fixed epoch timestamp (not the mocked clock) so IsDeleted() is true regardless of
+	// clock.Now() state in the test process.
+	tcDeletedWithStripe := taxcode.TaxCode{
+		NamespacedID: models.NamespacedID{Namespace: ns, ID: "tc-deleted"},
+		ManagedModel: models.ManagedModel{DeletedAt: lo.ToPtr(time.Unix(0, 0))},
+		AppMappings:  taxcode.TaxCodeAppMappings{{AppType: app.AppTypeStripe, TaxCode: "txcd_10000000"}},
+	}
 
 	tests := []struct {
 		name    string
 		svc     taxcode.Service
-		cfg     *TaxConfig
+		input   ResolveTaxConfigInput
 		wantCfg *TaxConfig
 		wantErr string
 	}{
 		{
 			name:    "nil cfg is no-op",
-			cfg:     nil,
+			input:   ResolveTaxConfigInput{Namespace: ns, Cfg: nil},
 			wantCfg: nil,
 		},
 		{
 			name:    "nil svc with non-nil cfg returns error",
 			svc:     nil,
-			cfg:     &TaxConfig{TaxCodeID: lo.ToPtr("tc-stripe")},
+			input:   ResolveTaxConfigInput{Namespace: ns, Cfg: &TaxConfig{TaxCodeID: lo.ToPtr("tc-stripe")}},
 			wantErr: "taxcode service is required",
 		},
 		{
@@ -758,7 +766,7 @@ func TestResolveTaxConfig(t *testing.T) {
 					return tcWithStripe, nil
 				},
 			},
-			cfg:     &TaxConfig{TaxCodeID: lo.ToPtr("tc-stripe")},
+			input:   ResolveTaxConfigInput{Namespace: ns, Cfg: &TaxConfig{TaxCodeID: lo.ToPtr("tc-stripe")}},
 			wantCfg: &TaxConfig{TaxCodeID: lo.ToPtr("tc-stripe"), Stripe: &StripeTaxConfig{Code: "txcd_10000000"}},
 		},
 		{
@@ -768,7 +776,7 @@ func TestResolveTaxConfig(t *testing.T) {
 					return tcWithoutStripe, nil
 				},
 			},
-			cfg:     &TaxConfig{TaxCodeID: lo.ToPtr("tc-no-stripe"), Stripe: &StripeTaxConfig{Code: "txcd_10000000"}},
+			input:   ResolveTaxConfigInput{Namespace: ns, Cfg: &TaxConfig{TaxCodeID: lo.ToPtr("tc-no-stripe"), Stripe: &StripeTaxConfig{Code: "txcd_10000000"}}},
 			wantCfg: &TaxConfig{TaxCodeID: lo.ToPtr("tc-no-stripe"), Stripe: nil},
 		},
 		{
@@ -778,7 +786,7 @@ func TestResolveTaxConfig(t *testing.T) {
 					return tcWithStripe, nil
 				},
 			},
-			cfg:     &TaxConfig{TaxCodeID: lo.ToPtr("tc-stripe"), Stripe: &StripeTaxConfig{Code: "txcd_99999999"}},
+			input:   ResolveTaxConfigInput{Namespace: ns, Cfg: &TaxConfig{TaxCodeID: lo.ToPtr("tc-stripe"), Stripe: &StripeTaxConfig{Code: "txcd_99999999"}}},
 			wantCfg: &TaxConfig{TaxCodeID: lo.ToPtr("tc-stripe"), Stripe: &StripeTaxConfig{Code: "txcd_10000000"}},
 		},
 		{
@@ -788,8 +796,28 @@ func TestResolveTaxConfig(t *testing.T) {
 					return taxcode.TaxCode{}, taxcode.NewTaxCodeNotFoundError(input.ID)
 				},
 			},
-			cfg:     &TaxConfig{TaxCodeID: lo.ToPtr("missing-id")},
+			input:   ResolveTaxConfigInput{Namespace: ns, Cfg: &TaxConfig{TaxCodeID: lo.ToPtr("missing-id")}},
 			wantErr: "validation error: tax code missing-id not found",
+		},
+		{
+			name: "TaxCodeID set, entity is soft-deleted, IncludeDeleted false — validation error",
+			svc: &stubTaxCodeService{
+				getTaxCode: func(_ context.Context, _ taxcode.GetTaxCodeInput) (taxcode.TaxCode, error) {
+					return tcDeletedWithStripe, nil
+				},
+			},
+			input:   ResolveTaxConfigInput{Namespace: ns, Cfg: &TaxConfig{TaxCodeID: lo.ToPtr("tc-deleted")}},
+			wantErr: "validation error: tax code tc-deleted not found",
+		},
+		{
+			name: "TaxCodeID set, entity is soft-deleted, IncludeDeleted true — Stripe backfilled",
+			svc: &stubTaxCodeService{
+				getTaxCode: func(_ context.Context, _ taxcode.GetTaxCodeInput) (taxcode.TaxCode, error) {
+					return tcDeletedWithStripe, nil
+				},
+			},
+			input:   ResolveTaxConfigInput{Namespace: ns, Cfg: &TaxConfig{TaxCodeID: lo.ToPtr("tc-deleted")}, IncludeDeleted: true},
+			wantCfg: &TaxConfig{TaxCodeID: lo.ToPtr("tc-deleted"), Stripe: &StripeTaxConfig{Code: "txcd_10000000"}},
 		},
 		{
 			name: "Stripe code set — TaxCodeID stamped",
@@ -798,19 +826,19 @@ func TestResolveTaxConfig(t *testing.T) {
 					return tcWithStripe, nil
 				},
 			},
-			cfg:     &TaxConfig{Stripe: &StripeTaxConfig{Code: "txcd_10000000"}},
+			input:   ResolveTaxConfigInput{Namespace: ns, Cfg: &TaxConfig{Stripe: &StripeTaxConfig{Code: "txcd_10000000"}}},
 			wantCfg: &TaxConfig{Stripe: &StripeTaxConfig{Code: "txcd_10000000"}, TaxCodeID: lo.ToPtr("tc-stripe")},
 		},
 		{
 			name:    "neither TaxCodeID nor Stripe code — no-op",
 			svc:     &stubTaxCodeService{},
-			cfg:     &TaxConfig{Behavior: lo.ToPtr(InclusiveTaxBehavior)},
+			input:   ResolveTaxConfigInput{Namespace: ns, Cfg: &TaxConfig{Behavior: lo.ToPtr(InclusiveTaxBehavior)}},
 			wantCfg: &TaxConfig{Behavior: lo.ToPtr(InclusiveTaxBehavior)},
 		},
 		{
 			name:    "empty Stripe code — no-op",
 			svc:     &stubTaxCodeService{},
-			cfg:     &TaxConfig{Stripe: &StripeTaxConfig{Code: ""}},
+			input:   ResolveTaxConfigInput{Namespace: ns, Cfg: &TaxConfig{Stripe: &StripeTaxConfig{Code: ""}}},
 			wantCfg: &TaxConfig{Stripe: &StripeTaxConfig{Code: ""}},
 		},
 	}
@@ -819,7 +847,12 @@ func TestResolveTaxConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := ResolveTaxConfig(t.Context(), tt.svc, ns, tt.cfg)
+			var originalCfg *TaxConfig
+			if tt.input.Cfg != nil {
+				originalCfg = lo.ToPtr(tt.input.Cfg.Clone())
+			}
+
+			got, err := ResolveTaxConfig(t.Context(), tt.svc, tt.input)
 
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)
@@ -827,7 +860,9 @@ func TestResolveTaxConfig(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantCfg, tt.cfg)
+			assert.Equal(t, tt.wantCfg, got)
+			// input.Cfg must not be mutated: ResolveTaxConfig returns a resolved clone.
+			assert.Equal(t, originalCfg, tt.input.Cfg)
 		})
 	}
 }

--- a/openmeter/productcatalog/testutils/env.go
+++ b/openmeter/productcatalog/testutils/env.go
@@ -141,6 +141,7 @@ func NewTestEnv(t *testing.T) *TestEnv {
 	addonService, err := addonservice.New(addonservice.Config{
 		Adapter:         addonAdapter,
 		FeatureResolver: featureResolver,
+		TaxCodeResolver: taxCodeResolver,
 		TaxCode:         taxCodeService,
 		Logger:          logger,
 		Publisher:       publisher,

--- a/openmeter/productcatalog/testutils/env.go
+++ b/openmeter/productcatalog/testutils/env.go
@@ -23,8 +23,7 @@ import (
 	planaddonservice "github.com/openmeterio/openmeter/openmeter/productcatalog/planaddon/service"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/taxcoderesolver"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
-	taxcodeadapter "github.com/openmeterio/openmeter/openmeter/taxcode/adapter"
-	taxcodeservice "github.com/openmeterio/openmeter/openmeter/taxcode/service"
+	taxcodetestutils "github.com/openmeterio/openmeter/openmeter/taxcode/testutils"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 )
@@ -35,6 +34,7 @@ type TestEnv struct {
 	Meter               *meteradapter.TestAdapter
 	Feature             feature.FeatureConnector
 	TaxCode             taxcode.Service
+	TaxCodeEnv          *taxcodetestutils.TestEnv
 	Plan                plan.Service
 	PlanRepository      plan.Repository
 	PlanAddon           planaddon.Service
@@ -95,20 +95,9 @@ func NewTestEnv(t *testing.T) *TestEnv {
 	require.NoErrorf(t, err, "failed to create feature resolver: %v", err)
 
 	// Init tax code service
-	taxCodeAdapter, err := taxcodeadapter.New(taxcodeadapter.Config{
-		Client: client,
-		Logger: logger,
-	})
-	require.NoErrorf(t, err, "initializing tax code adapter must not fail")
-	require.NotNilf(t, taxCodeAdapter, "tax code adapter must not be nil")
+	taxCodeEnv := taxcodetestutils.NewTestEnvFromClient(t, client, logger)
 
-	taxCodeService, err := taxcodeservice.New(taxcodeservice.Config{
-		Adapter: taxCodeAdapter,
-		Logger:  logger,
-	})
-	require.NoErrorf(t, err, "initializing tax code service must not fail")
-
-	taxCodeResolver, err := taxcoderesolver.New(taxCodeService)
+	taxCodeResolver, err := taxcoderesolver.New(taxCodeEnv.Service)
 	require.NoErrorf(t, err, "failed to create tax code resolver: %v", err)
 
 	// Init plan service
@@ -123,7 +112,7 @@ func NewTestEnv(t *testing.T) *TestEnv {
 		Adapter:         planAdapter,
 		FeatureResolver: featureResolver,
 		TaxCodeResolver: taxCodeResolver,
-		TaxCode:         taxCodeService,
+		TaxCode:         taxCodeEnv.Service,
 		Logger:          logger,
 		Publisher:       publisher,
 	})
@@ -142,7 +131,7 @@ func NewTestEnv(t *testing.T) *TestEnv {
 		Adapter:         addonAdapter,
 		FeatureResolver: featureResolver,
 		TaxCodeResolver: taxCodeResolver,
-		TaxCode:         taxCodeService,
+		TaxCode:         taxCodeEnv.Service,
 		Logger:          logger,
 		Publisher:       publisher,
 	})
@@ -172,7 +161,8 @@ func NewTestEnv(t *testing.T) *TestEnv {
 		Publisher:           publisher,
 		Meter:               meterAdapter,
 		Feature:             featureService,
-		TaxCode:             taxCodeService,
+		TaxCode:             taxCodeEnv.Service,
+		TaxCodeEnv:          taxCodeEnv,
 		Plan:                planService,
 		PlanRepository:      planAdapter,
 		PlanAddon:           planAddonService,

--- a/openmeter/subscription/service/service_test.go
+++ b/openmeter/subscription/service/service_test.go
@@ -1398,4 +1398,90 @@ func TestTaxCodeResolution(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, models.IsGenericValidationError(err), "expected validation error for unknown taxCodeId, got: %v", err)
 	})
+
+	// Fresh subscription creation must not be allowed to reference a tax code that has since
+	// been soft-deleted: resolveTaxCode calls ResolveTaxConfig with IncludeDeleted=false, so
+	// a rate card pointing at a soft-deleted TaxCode fails item creation with a validation
+	// error, even though GetTaxCode itself still returns the soft-deleted row by design.
+	t.Run("Should return validation error when subscription item references a soft-deleted tax code", func(t *testing.T) {
+		ctx := t.Context()
+
+		currentTime := testutils.GetRFC3339Time(t, "2021-01-01T00:00:11Z")
+		clock.SetTime(currentTime)
+
+		dbDeps := subscriptiontestutils.SetupDBDeps(t)
+		defer dbDeps.Cleanup(t)
+
+		deps := subscriptiontestutils.NewService(t, dbDeps)
+		service := deps.SubscriptionService
+
+		// given: a TaxCode that is created and then soft-deleted before the subscription exists.
+		tcEntity, err := deps.TaxCodeService.GetOrCreateByAppMapping(ctx, taxcode.GetOrCreateByAppMappingInput{
+			Namespace: subscriptiontestutils.ExampleNamespace,
+			AppType:   app.AppTypeStripe,
+			TaxCode:   "txcd_60000011",
+		})
+		require.NoError(t, err)
+
+		// Provision organization-default tax codes (distinct from tcEntity) so DeleteTaxCode
+		// can proceed past its org-defaults guard.
+		deps.TaxCodeEnv.ProvisionDefaultTaxCodes(t, subscriptiontestutils.ExampleNamespace)
+
+		err = deps.TaxCodeService.DeleteTaxCode(ctx, taxcode.DeleteTaxCodeInput{
+			NamespacedID: models.NamespacedID{Namespace: subscriptiontestutils.ExampleNamespace, ID: tcEntity.ID},
+		})
+		require.NoError(t, err)
+
+		// Create a plan with NO TaxConfig so plan-level tax code validation on publish passes.
+		rc := &productcatalog.FlatFeeRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Key:  "deleted-taxcodeid-rc",
+				Name: "Deleted TaxCodeId RC",
+				Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+					Amount:      alpacadecimal.NewFromInt(100),
+					PaymentTerm: productcatalog.InAdvancePaymentTerm,
+				}),
+			},
+		}
+
+		planInput := subscriptiontestutils.BuildTestPlanInput(t).AddPhase(nil, rc).Build()
+		planInput.Key = "deleted-taxcodeid-plan"
+		planInput.Name = "Deleted TaxCodeId Plan"
+
+		cust := deps.CustomerAdapter.CreateExampleCustomer(t)
+		plan := deps.PlanHelper.CreatePlan(t, planInput)
+
+		spec, err := subscription.NewSpecFromPlan(plan, subscription.CreateSubscriptionCustomerInput{
+			CustomerId:    cust.ID,
+			Currency:      "USD",
+			ActiveFrom:    currentTime,
+			BillingAnchor: currentTime,
+			Name:          "Test Subscription",
+			Annotations:   models.Annotations{},
+		})
+		require.NoError(t, err)
+
+		// when: the spec is mutated directly to reference the soft-deleted TaxCode, bypassing
+		// plan publish validation, so the only guard exercised is subscription sync's
+		// resolveTaxCode (via createItem) at subscription-creation time.
+		for _, phase := range spec.Phases {
+			for _, items := range phase.ItemsByKey {
+				for _, item := range items {
+					err := item.RateCard.ChangeMeta(func(m productcatalog.RateCardMeta) (productcatalog.RateCardMeta, error) {
+						m.TaxConfig = &productcatalog.TaxConfig{
+							TaxCodeID: lo.ToPtr(tcEntity.ID),
+						}
+						return m, nil
+					})
+					require.NoError(t, err)
+				}
+			}
+		}
+
+		// then: subscription creation must fail validation instead of silently persisting a
+		// reference to a tax code that no longer exists from the caller's point of view.
+		_, err = service.Create(ctx, subscriptiontestutils.ExampleNamespace, spec)
+		require.Error(t, err)
+		assert.True(t, models.IsGenericValidationError(err), "expected validation error for soft-deleted taxCodeId, got: %v", err)
+	})
 }

--- a/openmeter/subscription/service/synchelpers.go
+++ b/openmeter/subscription/service/synchelpers.go
@@ -192,9 +192,16 @@ func (s *service) resolveTaxCode(ctx context.Context, namespace string, rc produ
 	}
 
 	return rc.ChangeMeta(func(m productcatalog.RateCardMeta) (productcatalog.RateCardMeta, error) {
-		if err := productcatalog.ResolveTaxConfig(ctx, s.TaxCode, namespace, m.TaxConfig); err != nil {
+		resolved, err := productcatalog.ResolveTaxConfig(ctx, s.TaxCode, productcatalog.ResolveTaxConfigInput{
+			Namespace: namespace,
+			Cfg:       m.TaxConfig,
+		})
+		if err != nil {
 			return m, err
 		}
+
+		m.TaxConfig = resolved
+
 		return m, nil
 	})
 }

--- a/openmeter/subscription/testutils/service.go
+++ b/openmeter/subscription/testutils/service.go
@@ -40,8 +40,7 @@ import (
 	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
 	subscriptionworkflowservice "github.com/openmeterio/openmeter/openmeter/subscription/workflow/service"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
-	taxcodeadapter "github.com/openmeterio/openmeter/openmeter/taxcode/adapter"
-	taxcodeservice "github.com/openmeterio/openmeter/openmeter/taxcode/service"
+	taxcodetestutils "github.com/openmeterio/openmeter/openmeter/taxcode/testutils"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -70,6 +69,7 @@ type SubscriptionDependencies struct {
 	AddonService             *testAddonService
 	PlanAddonService         planaddon.Service
 	TaxCodeService           taxcode.Service
+	TaxCodeEnv               *taxcodetestutils.TestEnv
 }
 
 func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
@@ -174,22 +174,12 @@ func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
 	})
 	require.NoError(t, err)
 
-	taxCodeAdapter, err := taxcodeadapter.New(taxcodeadapter.Config{
-		Client: dbDeps.DBClient,
-		Logger: logger,
-	})
-	require.NoError(t, err)
-
-	taxCodeService, err := taxcodeservice.New(taxcodeservice.Config{
-		Adapter: taxCodeAdapter,
-		Logger:  logger,
-	})
-	require.NoError(t, err)
+	taxCodeEnv := taxcodetestutils.NewTestEnvFromClient(t, dbDeps.DBClient, logger)
 
 	featureResolver, err := featureresolver.New(entitlementRegistry.Feature)
 	require.NoErrorf(t, err, "failed to create feature resolver: %v", err)
 
-	taxCodeResolver, err := taxcoderesolver.New(taxCodeService)
+	taxCodeResolver, err := taxcoderesolver.New(taxCodeEnv.Service)
 	require.NoErrorf(t, err, "failed to create tax code resolver: %v", err)
 
 	planService, err := planservice.New(planservice.Config{
@@ -198,7 +188,7 @@ func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
 		Logger:          logger,
 		Adapter:         planRepo,
 		Publisher:       publisher,
-		TaxCode:         taxCodeService,
+		TaxCode:         taxCodeEnv.Service,
 	})
 	require.NoError(t, err)
 
@@ -219,7 +209,7 @@ func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
 		Publisher:             publisher,
 		Lockr:                 lockr,
 		FeatureFlags:          ffService,
-		TaxCode:               taxCodeService,
+		TaxCode:               taxCodeEnv.Service,
 	})
 	require.NoError(t, err)
 
@@ -235,7 +225,7 @@ func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
 		Publisher:       publisher,
 		FeatureResolver: featureResolver,
 		TaxCodeResolver: taxCodeResolver,
-		TaxCode:         taxCodeService,
+		TaxCode:         taxCodeEnv.Service,
 	})
 	require.NoError(t, err)
 
@@ -301,6 +291,7 @@ func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
 		PlanAddonService:         planAddonService,
 		MeterService:             meterAdapter,
 		MockStreamingConnector:   mockStreaming,
-		TaxCodeService:           taxCodeService,
+		TaxCodeService:           taxCodeEnv.Service,
+		TaxCodeEnv:               taxCodeEnv,
 	}
 }

--- a/openmeter/subscription/testutils/service.go
+++ b/openmeter/subscription/testutils/service.go
@@ -234,6 +234,7 @@ func NewService(t *testing.T, dbDeps *DBDeps) SubscriptionDependencies {
 		Logger:          logger,
 		Publisher:       publisher,
 		FeatureResolver: featureResolver,
+		TaxCodeResolver: taxCodeResolver,
 		TaxCode:         taxCodeService,
 	})
 	require.NoError(t, err)

--- a/openmeter/taxcode/errors.go
+++ b/openmeter/taxcode/errors.go
@@ -182,3 +182,23 @@ func IsTaxCodeReferencedByPlanError(err error) bool {
 	var vi models.ValidationIssue
 	return errors.As(err, &vi) && vi.Code() == ErrCodeTaxCodeReferencedByPlan
 }
+
+const ErrCodeTaxCodeReferencedByAddon models.ErrorCode = "tax_code_referenced_by_addon"
+
+var ErrTaxCodeReferencedByAddon = models.NewValidationIssue(
+	ErrCodeTaxCodeReferencedByAddon,
+	"tax code cannot be deleted as it is referenced by one or more add-ons",
+	models.WithCriticalSeverity(),
+	commonhttp.WithHTTPStatusCodeAttribute(http.StatusConflict),
+)
+
+func NewTaxCodeReferencedByAddonError(taxCodeID string, addonIDs []string) error {
+	return ErrTaxCodeReferencedByAddon.
+		WithAttr("id", taxCodeID).
+		WithAttr("addon_ids", addonIDs)
+}
+
+func IsTaxCodeReferencedByAddonError(err error) bool {
+	var vi models.ValidationIssue
+	return errors.As(err, &vi) && vi.Code() == ErrCodeTaxCodeReferencedByAddon
+}

--- a/openmeter/taxcode/errors.go
+++ b/openmeter/taxcode/errors.go
@@ -163,42 +163,22 @@ func IsTaxCodeOrphanedKeyError(err error) bool {
 	return errors.Is(err, ErrTaxCodeOrphanedKey)
 }
 
-const ErrCodeTaxCodeReferencedByPlan models.ErrorCode = "tax_code_referenced_by_plan"
+const ErrCodeTaxCodeReferencedByRateCard models.ErrorCode = "tax_code_referenced_by_rate_card"
 
-var ErrTaxCodeReferencedByPlan = models.NewValidationIssue(
-	ErrCodeTaxCodeReferencedByPlan,
-	"tax code cannot be deleted as it is referenced by one or more plans",
+var ErrTaxCodeReferencedByRateCard = models.NewValidationIssue(
+	ErrCodeTaxCodeReferencedByRateCard,
+	"tax code cannot be deleted as it is referenced by a rate card",
 	models.WithCriticalSeverity(),
 	commonhttp.WithHTTPStatusCodeAttribute(http.StatusConflict),
 )
 
-func NewTaxCodeReferencedByPlanError(taxCodeID string, planIDs []string) error {
-	return ErrTaxCodeReferencedByPlan.
+func NewTaxCodeReferencedByRateCardError(taxCodeID string, rateCardKey string) error {
+	return ErrTaxCodeReferencedByRateCard.
 		WithAttr("id", taxCodeID).
-		WithAttr("plan_ids", planIDs)
+		WithAttr("rate_card_key", rateCardKey)
 }
 
-func IsTaxCodeReferencedByPlanError(err error) bool {
+func IsTaxCodeReferencedByRateCardError(err error) bool {
 	var vi models.ValidationIssue
-	return errors.As(err, &vi) && vi.Code() == ErrCodeTaxCodeReferencedByPlan
-}
-
-const ErrCodeTaxCodeReferencedByAddon models.ErrorCode = "tax_code_referenced_by_addon"
-
-var ErrTaxCodeReferencedByAddon = models.NewValidationIssue(
-	ErrCodeTaxCodeReferencedByAddon,
-	"tax code cannot be deleted as it is referenced by one or more add-ons",
-	models.WithCriticalSeverity(),
-	commonhttp.WithHTTPStatusCodeAttribute(http.StatusConflict),
-)
-
-func NewTaxCodeReferencedByAddonError(taxCodeID string, addonIDs []string) error {
-	return ErrTaxCodeReferencedByAddon.
-		WithAttr("id", taxCodeID).
-		WithAttr("addon_ids", addonIDs)
-}
-
-func IsTaxCodeReferencedByAddonError(err error) bool {
-	var vi models.ValidationIssue
-	return errors.As(err, &vi) && vi.Code() == ErrCodeTaxCodeReferencedByAddon
+	return errors.As(err, &vi) && vi.Code() == ErrCodeTaxCodeReferencedByRateCard
 }

--- a/openmeter/taxcode/namespacehandler_test.go
+++ b/openmeter/taxcode/namespacehandler_test.go
@@ -24,7 +24,7 @@ func makeTestSeeds() []taxcode.SeedEntry {
 			DefaultInvoicing: true,
 		},
 		{
-			Key:                "nontaxable",
+			Key:                taxcode.CreditGrantTaxCodeKey,
 			Name:               "Non-Taxable",
 			DefaultCreditGrant: true,
 		},
@@ -67,11 +67,11 @@ func TestNamespaceHandler(t *testing.T) {
 			keyToTC[tc.Key] = tc
 		}
 
-		defaultTC, ok := keyToTC["default"]
+		defaultTC, ok := keyToTC[taxcode.ProviderDefaultTaxCodeKey]
 		require.True(t, ok, "default tax code must exist")
 		assert.True(t, defaultTC.IsManagedBySystem(), "default tax code must be managed by system")
 
-		nontaxableTC, ok := keyToTC["nontaxable"]
+		nontaxableTC, ok := keyToTC[taxcode.CreditGrantTaxCodeKey]
 		require.True(t, ok, "nontaxable tax code must exist")
 		assert.True(t, nontaxableTC.IsManagedBySystem(), "nontaxable tax code must be managed by system")
 
@@ -113,14 +113,14 @@ func TestNamespaceHandler(t *testing.T) {
 			keyToTC[tc.Key] = tc
 		}
 
-		gotDefault, ok := keyToTC["default"]
+		gotDefault, ok := keyToTC[taxcode.ProviderDefaultTaxCodeKey]
 		require.True(t, ok)
 		assert.Equal(t, preExisting.ID, gotDefault.ID, "pre-existing ID must not change")
 		assert.Equal(t, "Pre-Existing Default", gotDefault.Name, "pre-existing name must not change")
 		// Note: not managed by system because we didn't add annotation when pre-creating.
 		assert.False(t, gotDefault.IsManagedBySystem())
 
-		gotNontaxable, ok := keyToTC["nontaxable"]
+		gotNontaxable, ok := keyToTC[taxcode.CreditGrantTaxCodeKey]
 		require.True(t, ok, "nontaxable must be freshly created")
 		assert.True(t, gotNontaxable.IsManagedBySystem())
 
@@ -149,7 +149,7 @@ func TestNamespaceHandler(t *testing.T) {
 
 		nontaxableTC, err := env.Service.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
 			Namespace: ns,
-			Key:       "nontaxable",
+			Key:       taxcode.CreditGrantTaxCodeKey,
 			Name:      "Non-Taxable",
 			Annotations: models.Annotations{
 				taxcode.AnnotationKeyManagedBy: taxcode.AnnotationValueManagedBySystem,

--- a/openmeter/taxcode/service/hooks/addonhook.go
+++ b/openmeter/taxcode/service/hooks/addonhook.go
@@ -2,9 +2,8 @@ package hooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
-
-	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
@@ -72,12 +71,22 @@ func (e *addonHook) PreDelete(ctx context.Context, tc *taxcode.TaxCode) error {
 		return fmt.Errorf("failed to list add-ons: %w", err)
 	}
 
-	if len(affectedAddons.Items) > 0 {
-		addonIDs := lo.Map(affectedAddons.Items, func(item addon.Addon, _ int) string {
-			return item.ID
-		})
-		return taxcode.NewTaxCodeReferencedByAddonError(tc.ID, addonIDs)
+	var errs []error
+
+	for _, affectedAddon := range affectedAddons.Items {
+		for _, rateCard := range affectedAddon.RateCards {
+			taxCodeID := rateCard.AsMeta().TaxCodeReference()
+			if taxCodeID == nil || *taxCodeID != tc.ID {
+				continue
+			}
+
+			errs = append(errs, taxcode.NewTaxCodeReferencedByRateCardError(tc.ID, rateCard.Key()))
+		}
 	}
 
-	return nil
+	if len(affectedAddons.Items) > 0 && len(errs) == 0 {
+		return fmt.Errorf("add-on %s matched tax code filter but no rate card references tax code %s", affectedAddons.Items[0].ID, tc.ID)
+	}
+
+	return errors.Join(errs...)
 }

--- a/openmeter/taxcode/service/hooks/addonhook.go
+++ b/openmeter/taxcode/service/hooks/addonhook.go
@@ -1,0 +1,82 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
+	"github.com/openmeterio/openmeter/pkg/filter"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+)
+
+type (
+	AddonHook     = models.ServiceHook[taxcode.TaxCode]
+	NoopAddonHook = models.NoopServiceHook[taxcode.TaxCode]
+)
+
+type AddonHookConfig struct {
+	AddonService addon.Service
+}
+
+func (e AddonHookConfig) Validate() error {
+	if e.AddonService == nil {
+		return fmt.Errorf("addon service is required")
+	}
+
+	return nil
+}
+
+var _ models.ServiceHook[taxcode.TaxCode] = (*addonHook)(nil)
+
+type addonHook struct {
+	NoopAddonHook
+
+	addonService addon.Service
+}
+
+func NewAddonHook(config AddonHookConfig) (AddonHook, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid addon hook config: %w", err)
+	}
+
+	return &addonHook{
+		addonService: config.AddonService,
+	}, nil
+}
+
+func (e *addonHook) PreDelete(ctx context.Context, tc *taxcode.TaxCode) error {
+	affectedAddons, err := e.addonService.ListAddons(ctx, addon.ListAddonsInput{
+		Namespaces: []string{tc.Namespace},
+		Status: []productcatalog.AddonStatus{
+			productcatalog.AddonStatusActive,
+			productcatalog.AddonStatusDraft,
+			productcatalog.AddonStatusArchived,
+		},
+		TaxCodes: &filter.FilterString{
+			In: &[]string{
+				tc.ID,
+			},
+		},
+		Page: pagination.Page{
+			PageSize:   5,
+			PageNumber: 1,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list add-ons: %w", err)
+	}
+
+	if len(affectedAddons.Items) > 0 {
+		addonIDs := lo.Map(affectedAddons.Items, func(item addon.Addon, _ int) string {
+			return item.ID
+		})
+		return taxcode.NewTaxCodeReferencedByAddonError(tc.ID, addonIDs)
+	}
+
+	return nil
+}

--- a/openmeter/taxcode/service/hooks/addonhook.go
+++ b/openmeter/taxcode/service/hooks/addonhook.go
@@ -56,6 +56,7 @@ func (e *addonHook) PreDelete(ctx context.Context, tc *taxcode.TaxCode) error {
 			productcatalog.AddonStatusActive,
 			productcatalog.AddonStatusDraft,
 			productcatalog.AddonStatusArchived,
+			productcatalog.AddonStatusInvalid,
 		},
 		TaxCodes: &filter.FilterString{
 			In: &[]string{

--- a/openmeter/taxcode/service/hooks/addonhook_test.go
+++ b/openmeter/taxcode/service/hooks/addonhook_test.go
@@ -19,7 +19,6 @@ func TestAddonHookPreDelete(t *testing.T) {
 	// Setup real services backed by Postgres.
 	env := pctestutils.NewTestEnv(t)
 	t.Cleanup(func() { env.Close(t) })
-	env.DBSchemaMigrate(t)
 
 	// Register the addon hook on the real taxcode service.
 	addonHook, err := hooks.NewAddonHook(hooks.AddonHookConfig{AddonService: env.Addon})

--- a/openmeter/taxcode/service/hooks/addonhook_test.go
+++ b/openmeter/taxcode/service/hooks/addonhook_test.go
@@ -1,0 +1,115 @@
+package hooks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
+	"github.com/openmeterio/openmeter/openmeter/taxcode/service/hooks"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+)
+
+// stubAddonService implements addon.Service for testing the addon hook.
+// Only ListAddons has real behavior; all other methods panic.
+type stubAddonService struct {
+	listResult pagination.Result[addon.Addon]
+	listErr    error
+	lastInput  addon.ListAddonsInput
+}
+
+func (s *stubAddonService) ListAddons(ctx context.Context, params addon.ListAddonsInput) (pagination.Result[addon.Addon], error) {
+	s.lastInput = params
+	return s.listResult, s.listErr
+}
+
+func (s *stubAddonService) CreateAddon(_ context.Context, _ addon.CreateAddonInput) (*addon.Addon, error) {
+	panic("not implemented")
+}
+
+func (s *stubAddonService) DeleteAddon(_ context.Context, _ addon.DeleteAddonInput) error {
+	panic("not implemented")
+}
+
+func (s *stubAddonService) GetAddon(_ context.Context, _ addon.GetAddonInput) (*addon.Addon, error) {
+	panic("not implemented")
+}
+
+func (s *stubAddonService) UpdateAddon(_ context.Context, _ addon.UpdateAddonInput) (*addon.Addon, error) {
+	panic("not implemented")
+}
+
+func (s *stubAddonService) PublishAddon(_ context.Context, _ addon.PublishAddonInput) (*addon.Addon, error) {
+	panic("not implemented")
+}
+
+func (s *stubAddonService) ArchiveAddon(_ context.Context, _ addon.ArchiveAddonInput) (*addon.Addon, error) {
+	panic("not implemented")
+}
+
+func (s *stubAddonService) NextAddon(_ context.Context, _ addon.NextAddonInput) (*addon.Addon, error) {
+	panic("not implemented")
+}
+
+var _ addon.Service = (*stubAddonService)(nil)
+
+const addonTestTaxCodeID = "01234567890123456789012346"
+
+func TestAddonHook_PreDelete(t *testing.T) {
+	tc := &taxcode.TaxCode{
+		NamespacedID: models.NamespacedID{
+			Namespace: "test-ns",
+			ID:        addonTestTaxCodeID,
+		},
+	}
+
+	t.Run("blocks deletion when an add-on references the tax code", func(t *testing.T) {
+		// given: an addon service that returns one matching add-on
+		stub := &stubAddonService{
+			listResult: pagination.Result[addon.Addon]{
+				Items: []addon.Addon{
+					{ManagedModel: models.ManagedModel{}, NamespacedID: models.NamespacedID{ID: "addon-abc"}},
+				},
+				TotalCount: 1,
+			},
+		}
+
+		hook, err := hooks.NewAddonHook(hooks.AddonHookConfig{AddonService: stub})
+		require.NoError(t, err)
+
+		// when: PreDelete is called
+		err = hook.PreDelete(t.Context(), tc)
+
+		// then: an error is returned and it is a TaxCodeReferencedByAddon error
+		require.Error(t, err)
+		require.True(t, taxcode.IsTaxCodeReferencedByAddonError(err),
+			"expected TaxCodeReferencedByAddon error, got: %v", err)
+
+		// and: the stub received a ListAddonsInput whose TaxCodes.In contains the tax code id
+		require.NotNil(t, stub.lastInput.TaxCodes)
+		require.NotNil(t, stub.lastInput.TaxCodes.In)
+		require.Contains(t, *stub.lastInput.TaxCodes.In, addonTestTaxCodeID)
+	})
+
+	t.Run("allows deletion when no add-on references the tax code", func(t *testing.T) {
+		// given: an addon service that returns no matching add-ons
+		stub := &stubAddonService{
+			listResult: pagination.Result[addon.Addon]{
+				Items:      []addon.Addon{},
+				TotalCount: 0,
+			},
+		}
+
+		hook, err := hooks.NewAddonHook(hooks.AddonHookConfig{AddonService: stub})
+		require.NoError(t, err)
+
+		// when: PreDelete is called
+		err = hook.PreDelete(t.Context(), tc)
+
+		// then: no error is returned
+		require.NoError(t, err)
+	})
+}

--- a/openmeter/taxcode/service/hooks/addonhook_test.go
+++ b/openmeter/taxcode/service/hooks/addonhook_test.go
@@ -69,10 +69,10 @@ func TestAddonHookPreDelete(t *testing.T) {
 			NamespacedID: models.NamespacedID{Namespace: ns, ID: referenced.ID},
 		})
 
-		// then: an error is returned and it is a TaxCodeReferencedByAddon error
+		// then: an error is returned and it is a TaxCodeReferencedByRateCard error
 		require.Error(t, err)
-		require.True(t, taxcode.IsTaxCodeReferencedByAddonError(err),
-			"expected TaxCodeReferencedByAddon error, got: %v", err)
+		require.True(t, taxcode.IsTaxCodeReferencedByRateCardError(err),
+			"expected TaxCodeReferencedByRateCard error, got: %v", err)
 	})
 
 	t.Run("allows deletion when no add-on references the tax code", func(t *testing.T) {

--- a/openmeter/taxcode/service/hooks/addonhook_test.go
+++ b/openmeter/taxcode/service/hooks/addonhook_test.go
@@ -1,113 +1,96 @@
 package hooks_test
 
 import (
-	"context"
 	"testing"
 
+	decimal "github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	"github.com/openmeterio/openmeter/openmeter/app"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	pctestutils "github.com/openmeterio/openmeter/openmeter/productcatalog/testutils"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/openmeter/taxcode/service/hooks"
 	"github.com/openmeterio/openmeter/pkg/models"
-	"github.com/openmeterio/openmeter/pkg/pagination"
 )
 
-// stubAddonService implements addon.Service for testing the addon hook.
-// Only ListAddons has real behavior; all other methods panic.
-type stubAddonService struct {
-	listResult pagination.Result[addon.Addon]
-	listErr    error
-	lastInput  addon.ListAddonsInput
-}
+func TestAddonHookPreDelete(t *testing.T) {
+	// Setup real services backed by Postgres.
+	env := pctestutils.NewTestEnv(t)
+	t.Cleanup(func() { env.Close(t) })
+	env.DBSchemaMigrate(t)
 
-func (s *stubAddonService) ListAddons(ctx context.Context, params addon.ListAddonsInput) (pagination.Result[addon.Addon], error) {
-	s.lastInput = params
-	return s.listResult, s.listErr
-}
+	// Register the addon hook on the real taxcode service.
+	addonHook, err := hooks.NewAddonHook(hooks.AddonHookConfig{AddonService: env.Addon})
+	require.NoError(t, err)
+	env.TaxCode.RegisterHooks(addonHook)
 
-func (s *stubAddonService) CreateAddon(_ context.Context, _ addon.CreateAddonInput) (*addon.Addon, error) {
-	panic("not implemented")
-}
+	ns := pctestutils.NewTestNamespace(t)
 
-func (s *stubAddonService) DeleteAddon(_ context.Context, _ addon.DeleteAddonInput) error {
-	panic("not implemented")
-}
-
-func (s *stubAddonService) GetAddon(_ context.Context, _ addon.GetAddonInput) (*addon.Addon, error) {
-	panic("not implemented")
-}
-
-func (s *stubAddonService) UpdateAddon(_ context.Context, _ addon.UpdateAddonInput) (*addon.Addon, error) {
-	panic("not implemented")
-}
-
-func (s *stubAddonService) PublishAddon(_ context.Context, _ addon.PublishAddonInput) (*addon.Addon, error) {
-	panic("not implemented")
-}
-
-func (s *stubAddonService) ArchiveAddon(_ context.Context, _ addon.ArchiveAddonInput) (*addon.Addon, error) {
-	panic("not implemented")
-}
-
-func (s *stubAddonService) NextAddon(_ context.Context, _ addon.NextAddonInput) (*addon.Addon, error) {
-	panic("not implemented")
-}
-
-var _ addon.Service = (*stubAddonService)(nil)
-
-const addonTestTaxCodeID = "01234567890123456789012346"
-
-func TestAddonHook_PreDelete(t *testing.T) {
-	tc := &taxcode.TaxCode{
-		NamespacedID: models.NamespacedID{
-			Namespace: "test-ns",
-			ID:        addonTestTaxCodeID,
-		},
-	}
+	// Provision organization-default tax codes so DeleteTaxCode can proceed past
+	// the org-defaults check and reach the pre-delete hook.
+	setupNamespaceDefaults(t, env, ns)
 
 	t.Run("blocks deletion when an add-on references the tax code", func(t *testing.T) {
-		// given: an addon service that returns one matching add-on
-		stub := &stubAddonService{
-			listResult: pagination.Result[addon.Addon]{
-				Items: []addon.Addon{
-					{ManagedModel: models.ManagedModel{}, NamespacedID: models.NamespacedID{ID: "addon-abc"}},
-				},
-				TotalCount: 1,
+		// given: a tax code that an add-on will reference
+		referenced, err := env.TaxCode.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+			Namespace: ns,
+			Key:       "addon-referenced",
+			Name:      "Referenced Tax Code",
+			AppMappings: taxcode.TaxCodeAppMappings{
+				{AppType: app.AppTypeStripe, TaxCode: "txcd_20000003"},
 			},
-		}
-
-		hook, err := hooks.NewAddonHook(hooks.AddonHookConfig{AddonService: stub})
+		})
 		require.NoError(t, err)
 
-		// when: PreDelete is called
-		err = hook.PreDelete(t.Context(), tc)
+		// given: an add-on whose rate card references the tax code
+		addonInput := pctestutils.NewTestAddon(t, ns,
+			&productcatalog.FlatFeeRateCard{
+				RateCardMeta: productcatalog.RateCardMeta{
+					Key:  "rc-1",
+					Name: "RC 1",
+					TaxConfig: &productcatalog.TaxConfig{
+						TaxCodeID: lo.ToPtr(referenced.ID),
+					},
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      decimal.NewFromInt(0),
+						PaymentTerm: productcatalog.InArrearsPaymentTerm,
+					}),
+				},
+			},
+		)
+		addonInput.Key = "addon-with-taxcode"
+		_, err = env.Addon.CreateAddon(t.Context(), addonInput)
+		require.NoError(t, err)
+
+		// when: attempting to delete the referenced tax code
+		err = env.TaxCode.DeleteTaxCode(t.Context(), taxcode.DeleteTaxCodeInput{
+			NamespacedID: models.NamespacedID{Namespace: ns, ID: referenced.ID},
+		})
 
 		// then: an error is returned and it is a TaxCodeReferencedByAddon error
 		require.Error(t, err)
 		require.True(t, taxcode.IsTaxCodeReferencedByAddonError(err),
 			"expected TaxCodeReferencedByAddon error, got: %v", err)
-
-		// and: the stub received a ListAddonsInput whose TaxCodes.In contains the tax code id
-		require.NotNil(t, stub.lastInput.TaxCodes)
-		require.NotNil(t, stub.lastInput.TaxCodes.In)
-		require.Contains(t, *stub.lastInput.TaxCodes.In, addonTestTaxCodeID)
 	})
 
 	t.Run("allows deletion when no add-on references the tax code", func(t *testing.T) {
-		// given: an addon service that returns no matching add-ons
-		stub := &stubAddonService{
-			listResult: pagination.Result[addon.Addon]{
-				Items:      []addon.Addon{},
-				TotalCount: 0,
+		// given: a tax code that no add-on references
+		unreferenced, err := env.TaxCode.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
+			Namespace: ns,
+			Key:       "addon-unreferenced",
+			Name:      "Unreferenced Tax Code",
+			AppMappings: taxcode.TaxCodeAppMappings{
+				{AppType: app.AppTypeStripe, TaxCode: "txcd_20000004"},
 			},
-		}
-
-		hook, err := hooks.NewAddonHook(hooks.AddonHookConfig{AddonService: stub})
+		})
 		require.NoError(t, err)
 
-		// when: PreDelete is called
-		err = hook.PreDelete(t.Context(), tc)
+		// when: deleting the unreferenced tax code
+		err = env.TaxCode.DeleteTaxCode(t.Context(), taxcode.DeleteTaxCodeInput{
+			NamespacedID: models.NamespacedID{Namespace: ns, ID: unreferenced.ID},
+		})
 
 		// then: no error is returned
 		require.NoError(t, err)

--- a/openmeter/taxcode/service/hooks/addonhook_test.go
+++ b/openmeter/taxcode/service/hooks/addonhook_test.go
@@ -29,7 +29,7 @@ func TestAddonHookPreDelete(t *testing.T) {
 
 	// Provision organization-default tax codes so DeleteTaxCode can proceed past
 	// the org-defaults check and reach the pre-delete hook.
-	setupNamespaceDefaults(t, env, ns)
+	env.TaxCodeEnv.ProvisionDefaultTaxCodes(t, ns)
 
 	t.Run("blocks deletion when an add-on references the tax code", func(t *testing.T) {
 		// given: a tax code that an add-on will reference

--- a/openmeter/taxcode/service/hooks/planhook.go
+++ b/openmeter/taxcode/service/hooks/planhook.go
@@ -2,9 +2,8 @@ package hooks
 
 import (
 	"context"
+	"errors"
 	"fmt"
-
-	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
@@ -73,12 +72,24 @@ func (e *planHook) PreDelete(ctx context.Context, tc *taxcode.TaxCode) error {
 		return fmt.Errorf("failed to list plans: %w", err)
 	}
 
-	if len(affectedPlans.Items) > 0 {
-		planIDs := lo.Map(affectedPlans.Items, func(item plan.Plan, _ int) string {
-			return item.ID
-		})
-		return taxcode.NewTaxCodeReferencedByPlanError(tc.ID, planIDs)
+	var errs []error
+
+	for _, affectedPlan := range affectedPlans.Items {
+		for _, phase := range affectedPlan.Phases {
+			for _, rateCard := range phase.RateCards {
+				taxCodeID := rateCard.AsMeta().TaxCodeReference()
+				if taxCodeID == nil || *taxCodeID != tc.ID {
+					continue
+				}
+
+				errs = append(errs, taxcode.NewTaxCodeReferencedByRateCardError(tc.ID, rateCard.Key()))
+			}
+		}
 	}
 
-	return nil
+	if len(affectedPlans.Items) > 0 && len(errs) == 0 {
+		return fmt.Errorf("plan %s matched tax code filter but no rate card references tax code %s", affectedPlans.Items[0].ID, tc.ID)
+	}
+
+	return errors.Join(errs...)
 }

--- a/openmeter/taxcode/service/hooks/planhook_test.go
+++ b/openmeter/taxcode/service/hooks/planhook_test.go
@@ -107,10 +107,10 @@ func TestPlanHookPreDelete(t *testing.T) {
 			NamespacedID: models.NamespacedID{Namespace: ns, ID: referenced.ID},
 		})
 
-		// then: an error is returned and it is a TaxCodeReferencedByPlan error
+		// then: an error is returned and it is a TaxCodeReferencedByRateCard error
 		require.Error(t, err)
-		require.True(t, taxcode.IsTaxCodeReferencedByPlanError(err),
-			"expected TaxCodeReferencedByPlan error, got: %v", err)
+		require.True(t, taxcode.IsTaxCodeReferencedByRateCardError(err),
+			"expected TaxCodeReferencedByRateCard error, got: %v", err)
 	})
 
 	t.Run("allows deletion when no plan references the tax code", func(t *testing.T) {

--- a/openmeter/taxcode/service/hooks/planhook_test.go
+++ b/openmeter/taxcode/service/hooks/planhook_test.go
@@ -15,36 +15,6 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-// setupNamespaceDefaults provisions the organization-default tax codes that
-// DeleteTaxCode requires to exist before it calls the pre-delete hook.
-func setupNamespaceDefaults(t *testing.T, env *pctestutils.TestEnv, ns string) {
-	t.Helper()
-
-	invoicing, err := env.TaxCode.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
-		Namespace: ns,
-		Key:       "default-invoicing",
-		Name:      "Provider Default",
-	})
-	require.NoError(t, err)
-
-	creditGrant, err := env.TaxCode.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
-		Namespace: ns,
-		Key:       "default-credit-grant",
-		Name:      "Non-Taxable",
-		AppMappings: taxcode.TaxCodeAppMappings{
-			{AppType: app.AppTypeStripe, TaxCode: "txcd_00000000"},
-		},
-	})
-	require.NoError(t, err)
-
-	_, err = env.TaxCode.UpsertOrganizationDefaultTaxCodes(t.Context(), taxcode.UpsertOrganizationDefaultTaxCodesInput{
-		Namespace:            ns,
-		InvoicingTaxCodeID:   invoicing.ID,
-		CreditGrantTaxCodeID: creditGrant.ID,
-	})
-	require.NoError(t, err)
-}
-
 func TestPlanHookPreDelete(t *testing.T) {
 	// Setup real services backed by Postgres.
 	env := pctestutils.NewTestEnv(t)
@@ -59,7 +29,7 @@ func TestPlanHookPreDelete(t *testing.T) {
 
 	// Provision organization-default tax codes so DeleteTaxCode can proceed past
 	// the org-defaults check and reach the pre-delete hook.
-	setupNamespaceDefaults(t, env, ns)
+	env.TaxCodeEnv.ProvisionDefaultTaxCodes(t, ns)
 
 	t.Run("blocks deletion when a plan references the tax code", func(t *testing.T) {
 		// given: a tax code that a plan will reference

--- a/openmeter/taxcode/service/organizationdefaulttaxcodes_test.go
+++ b/openmeter/taxcode/service/organizationdefaulttaxcodes_test.go
@@ -118,7 +118,7 @@ func TestOrganizationDefaultTaxCodesService(t *testing.T) {
 
 		t.Run("SoftDeleted/InvoicingTaxCodeIsDeleted", func(t *testing.T) {
 			dns := testutils.NameGenerator.Generate().Key
-			env.SetupNamespaceDefaults(t, dns)
+			env.ProvisionDefaultTaxCodes(t, dns)
 			deleted := env.CreateTaxCode(t, dns)
 			active := env.CreateTaxCode(t, dns)
 
@@ -137,7 +137,7 @@ func TestOrganizationDefaultTaxCodesService(t *testing.T) {
 
 		t.Run("SoftDeleted/CreditGrantTaxCodeIsDeleted", func(t *testing.T) {
 			dns := testutils.NameGenerator.Generate().Key
-			env.SetupNamespaceDefaults(t, dns)
+			env.ProvisionDefaultTaxCodes(t, dns)
 			active := env.CreateTaxCode(t, dns)
 			deleted := env.CreateTaxCode(t, dns)
 

--- a/openmeter/taxcode/service/taxcode_test.go
+++ b/openmeter/taxcode/service/taxcode_test.go
@@ -18,7 +18,7 @@ func TestTaxCodeService(t *testing.T) {
 	t.Cleanup(func() { env.Close(t) })
 
 	ns := testutils.NameGenerator.Generate().Key
-	env.SetupNamespaceDefaults(t, ns)
+	env.ProvisionDefaultTaxCodes(t, ns)
 
 	t.Run("GetByKey", func(t *testing.T) {
 		// given:

--- a/openmeter/taxcode/taxcode.go
+++ b/openmeter/taxcode/taxcode.go
@@ -12,7 +12,10 @@ import (
 
 var TaxCodeStripeRegexp = regexp.MustCompile(`^txcd_\d{8}$`)
 
-const ProviderDefaultTaxCodeKey = "default"
+const (
+	ProviderDefaultTaxCodeKey = "default"
+	CreditGrantTaxCodeKey     = "nontaxable"
+)
 
 // TaxCodeAppMapping represents a mapping of an app type to a tax code.
 type TaxCodeAppMapping struct {

--- a/openmeter/taxcode/testutils/env.go
+++ b/openmeter/taxcode/testutils/env.go
@@ -52,42 +52,110 @@ func (e *TestEnv) Close(t *testing.T) {
 // input — Namespace, Key, and Name are generated when empty.
 func (e *TestEnv) CreateTaxCode(t *testing.T, namespace string, opts ...taxcode.CreateTaxCodeInput) taxcode.TaxCode {
 	t.Helper()
+
 	var input taxcode.CreateTaxCodeInput
+
 	if len(opts) > 0 {
 		input = opts[0]
 	}
+
 	generated := testutils.NameGenerator.Generate()
 	input.Namespace = namespace
+
 	if input.Key == "" {
 		input.Key = generated.Key
 	}
+
 	if input.Name == "" {
 		input.Name = generated.Name
 	}
+
 	tc, err := e.Service.CreateTaxCode(t.Context(), input)
 	require.NoError(t, err)
+
 	return tc
 }
 
-// SetupNamespaceDefaults provisions two seed tax codes and upserts the org-default tax codes for namespace.
-func (e *TestEnv) SetupNamespaceDefaults(t *testing.T, namespace string) {
+// ProvisionDefaultTaxCodesInput overrides the app mappings ProvisionDefaultTaxCodes puts on the
+// generated invoicing/credit-grant tax codes. Zero-value fields keep the built-in defaults.
+type ProvisionDefaultTaxCodesInput struct {
+	InvoicingAppMappings   taxcode.TaxCodeAppMappings
+	CreditGrantAppMappings taxcode.TaxCodeAppMappings
+}
+
+// ProvisionDefaultTaxCodes creates (if necessary) the invoicing and credit-grant tax codes for
+// namespace and stores them as the namespace's organization defaults. Tests that create charges
+// via the real charges service must call this for the namespace, because charge creation
+// auto-stamps the namespace's default tax code when the caller's TaxConfig has no TaxCodeID.
+// Idempotent — safe to call more than once for the same namespace, e.g. after
+// ProvisionProviderDefaultTaxCode was already called standalone for it.
+//
+// opts optionally overrides the app mappings placed on the invoicing/credit-grant tax codes, e.g.
+// for tests asserting that TaxConfig.Stripe is backfilled from the namespace's default tax codes.
+// App mappings apply only when this call creates the tax code; a pre-existing row is reused as-is.
+func (e *TestEnv) ProvisionDefaultTaxCodes(t *testing.T, namespace string, opts ...ProvisionDefaultTaxCodesInput) taxcode.OrganizationDefaultTaxCodes {
 	t.Helper()
-	invoicing := e.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{
-		Key:  taxcode.ProviderDefaultTaxCodeKey,
-		Name: "Provider Default",
-	})
-	creditGrant := e.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{
-		Name: "Non-Taxable",
-		AppMappings: taxcode.TaxCodeAppMappings{
+
+	var input ProvisionDefaultTaxCodesInput
+	if len(opts) > 0 {
+		input = opts[0]
+	}
+
+	creditGrantAppMappings := input.CreditGrantAppMappings
+	if creditGrantAppMappings == nil {
+		creditGrantAppMappings = taxcode.TaxCodeAppMappings{
 			{AppType: app.AppTypeStripe, TaxCode: "txcd_00000000"},
-		},
-	})
-	_, err := e.Service.UpsertOrganizationDefaultTaxCodes(t.Context(), taxcode.UpsertOrganizationDefaultTaxCodesInput{
+		}
+	}
+
+	invoicing := e.getOrCreateTaxCodeByKey(t, namespace, taxcode.ProviderDefaultTaxCodeKey, "Provider Default", input.InvoicingAppMappings)
+	creditGrant := e.getOrCreateTaxCodeByKey(t, namespace, taxcode.CreditGrantTaxCodeKey, "Non-Taxable", creditGrantAppMappings)
+
+	defaults, err := e.Service.UpsertOrganizationDefaultTaxCodes(t.Context(), taxcode.UpsertOrganizationDefaultTaxCodesInput{
 		Namespace:            namespace,
 		InvoicingTaxCodeID:   invoicing.ID,
 		CreditGrantTaxCodeID: creditGrant.ID,
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "upserting organization default tax codes")
+
+	return defaults
+}
+
+// ProvisionProviderDefaultTaxCode returns (creating if necessary) the tax code used when an
+// invoicing app omits an app-specific provider code for namespace. This is distinct from
+// organization default tax-code settings: API invoice edit diffing needs the provider-default tax
+// code row to resolve empty provider tax config, but it must not imply that the namespace has
+// configured org-level default tax codes. Idempotent.
+func (e *TestEnv) ProvisionProviderDefaultTaxCode(t *testing.T, namespace string) taxcode.TaxCode {
+	t.Helper()
+	return e.getOrCreateTaxCodeByKey(t, namespace, taxcode.ProviderDefaultTaxCodeKey, "Provider Default", nil)
+}
+
+// getOrCreateTaxCodeByKey returns the tax code identified by (namespace, key), creating it with
+// name and appMappings if it doesn't exist yet. Idempotent: the (namespace, key) unique index only
+// applies to non-deleted rows, so this is safe to call more than once for the same namespace/key.
+func (e *TestEnv) getOrCreateTaxCodeByKey(t *testing.T, namespace, key, name string, appMappings taxcode.TaxCodeAppMappings) taxcode.TaxCode {
+	t.Helper()
+	ctx := t.Context()
+
+	tc, err := e.Service.GetTaxCodeByKey(ctx, taxcode.GetTaxCodeByKeyInput{
+		Namespace: namespace,
+		Key:       key,
+	})
+	if err == nil {
+		return tc
+	}
+	require.True(t, taxcode.IsTaxCodeNotFoundError(err), "getting tax code by key should either succeed or return not found")
+
+	tc, err = e.Service.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace:   namespace,
+		Key:         key,
+		Name:        name,
+		AppMappings: appMappings,
+	})
+	require.NoError(t, err, "creating tax code")
+
+	return tc
 }
 
 func NewTestEnv(t *testing.T) *TestEnv {

--- a/test/app/stripe/invoice_credits_test.go
+++ b/test/app/stripe/invoice_credits_test.go
@@ -35,7 +35,7 @@ func (s *StripeInvoiceTestSuite) TestInvoiceFundedCreditGrantRequiresStripeCusto
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("stripe-credit-grant-missing-customer-data")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	stripeApp, err := s.Fixture.setupApp(ctx, ns)
 	s.NoError(err)
@@ -74,7 +74,7 @@ func (s *StripeInvoiceTestSuite) TestUsageBasedCreditThenInvoiceProgressiveBilli
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("stripe-credits-usagebased-progressive-credit-then-invoice")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	setupAt := datetime.MustParseTimeInLocation(t, "2025-12-01T00:00:00Z", time.UTC).AsTime()
 	servicePeriod := timeutil.ClosedPeriod{

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -43,6 +43,7 @@ import (
 	secretservice "github.com/openmeterio/openmeter/openmeter/secret/service"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
+	taxcodetestutils "github.com/openmeterio/openmeter/openmeter/taxcode/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -196,29 +197,11 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 
 	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
 
-	defaultInvoicingTaxCode, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: namespace,
-		Key:       "default-invoicing",
-		Name:      "Default Invoicing",
-		AppMappings: taxcode.TaxCodeAppMappings{
+	defaultTaxCodes := s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), namespace, taxcodetestutils.ProvisionDefaultTaxCodesInput{
+		InvoicingAppMappings: taxcode.TaxCodeAppMappings{
 			{AppType: app.AppTypeStripe, TaxCode: defaultStripeTaxCode},
 		},
 	})
-	s.NoError(err)
-
-	defaultCreditGrantTaxCode, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: namespace,
-		Key:       "default-credit-grant",
-		Name:      "Default Credit Grant",
-	})
-	s.NoError(err)
-
-	defaultTaxCodes, err := s.TaxCodeService.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
-		Namespace:            namespace,
-		InvoicingTaxCodeID:   defaultInvoicingTaxCode.ID,
-		CreditGrantTaxCodeID: defaultCreditGrantTaxCode.ID,
-	})
-	s.NoError(err)
 
 	flatPerUnitMeterID := ulid.Make().String()
 	flatPerUsageMeterID := ulid.Make().String()
@@ -226,7 +209,7 @@ func (s *StripeInvoiceTestSuite) TestComplexInvoice() {
 	tieredVolumeMeterID := ulid.Make().String()
 	aiFlatPerUnitMeterID := ulid.Make().String()
 
-	err = s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{
+	err := s.MeterAdapter.ReplaceMeters(ctx, []meter.Meter{
 		{
 			ManagedResource: models.ManagedResource{
 				ID: flatPerUnitMeterID,
@@ -1204,7 +1187,7 @@ func (s *StripeInvoiceTestSuite) TestEmptyInvoiceGenerationZeroUsage() {
 		// manual advancement for testing the update invoice flow
 		profile.WorkflowConfig.Invoicing.AutoAdvance = false
 	}))
-	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
+	s.TaxCodeEnv.ProvisionProviderDefaultTaxCode(s.T(), namespace)
 
 	// Setup the app with the customer
 

--- a/test/app/testenv.go
+++ b/test/app/testenv.go
@@ -31,8 +31,7 @@ import (
 	secretadapter "github.com/openmeterio/openmeter/openmeter/secret/adapter"
 	secretservice "github.com/openmeterio/openmeter/openmeter/secret/service"
 	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
-	taxcodeadapter "github.com/openmeterio/openmeter/openmeter/taxcode/adapter"
-	taxcodeservice "github.com/openmeterio/openmeter/openmeter/taxcode/service"
+	taxcodetestutils "github.com/openmeterio/openmeter/openmeter/taxcode/testutils"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -244,17 +243,7 @@ func InitBillingService(t *testing.T, ctx context.Context, in InitBillingService
 	featureService := entitlementRegistry.Feature
 
 	// TaxCode
-	taxCodeAdapter, err := taxcodeadapter.New(taxcodeadapter.Config{
-		Client: in.DBClient,
-		Logger: slog.Default(),
-	})
-	require.NoError(t, err)
-
-	taxCodeService, err := taxcodeservice.New(taxcodeservice.Config{
-		Adapter: taxCodeAdapter,
-		Logger:  slog.Default(),
-	})
-	require.NoError(t, err)
+	taxCodeEnv := taxcodetestutils.NewTestEnvFromClient(t, in.DBClient, slog.Default())
 
 	// Billing
 	billingAdapter, err := billingadapter.New(billingadapter.Config{
@@ -294,6 +283,6 @@ func InitBillingService(t *testing.T, ctx context.Context, in InitBillingService
 		Publisher:                    eventbus.NewMock(t),
 		AdvancementStrategy:          billing.ForegroundAdvancementStrategy,
 		MaxParallelQuantitySnapshots: 2,
-		TaxCodeService:               taxCodeService,
+		TaxCodeService:               taxCodeEnv.Service,
 	})
 }

--- a/test/billing/collection_test.go
+++ b/test/billing/collection_test.go
@@ -459,7 +459,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeEditing() {
 
 	res := s.setupNS(ctx, namespace)
 	defer res.Cleanup()
-	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
+	s.TaxCodeEnv.ProvisionProviderDefaultTaxCode(s.T(), namespace)
 
 	customer := res.customer
 	apiRequestsTotalFeature := res.TestFeature
@@ -816,7 +816,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithUBPEditingExtendingCollectio
 
 	res := s.setupNS(ctx, namespace)
 	defer res.Cleanup()
-	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
+	s.TaxCodeEnv.ProvisionProviderDefaultTaxCode(s.T(), namespace)
 
 	customer := res.customer
 	apiRequestsTotalFeature := res.TestFeature

--- a/test/billing/customeroverride_test.go
+++ b/test/billing/customeroverride_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -484,6 +486,62 @@ func (s *CustomerOverrideTestSuite) TestGetCustomerApp() {
 
 	// Then we get the customer app
 	require.Equal(s.T(), sandboxApp.GetID(), customerApp.GetID())
+}
+
+// TestUpsertCustomerOverrideRejectsSoftDeletedDefaultTaxConfig asserts that a customer override
+// cannot freshly point its defaultTaxConfig.taxCodeId at a soft-deleted tax code.
+// taxcode.Service.GetTaxCode intentionally still returns soft-deleted rows by ID (they remain
+// resolvable for continuity reads such as invoice snapshotting), so this relies on
+// productcatalog.ResolveTaxConfig's IncludeDeleted=false check to reject a *new* assignment. Unlike
+// billing profiles, customer overrides have no deprecated-tax-code echo gate in front of
+// resolution, so the soft-deleted tax code can be referenced directly without first seeding a
+// stored value.
+func (s *CustomerOverrideTestSuite) TestUpsertCustomerOverrideRejectsSoftDeletedDefaultTaxConfig() {
+	ns := "test-ns-soft-deleted-override-tax-code"
+	ctx := s.T().Context()
+
+	// given:
+	// - a customer
+	// - a tax code that has been soft-deleted
+	custKey := "johny-the-doe-soft-deleted-tax-code"
+	cust, err := s.CustomerService.CreateCustomer(ctx, customer.CreateCustomerInput{
+		Namespace: ns,
+		CustomerMutate: customer.CustomerMutate{
+			Name: "Johny the Doe",
+			Key:  &custKey,
+		},
+	})
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), cust)
+
+	taxCode, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       "soft-deleted-override-default",
+		Name:      "Soft Deleted Override Default",
+	})
+	require.NoError(s.T(), err)
+
+	// DeleteTaxCode checks the deleted code against the namespace's organization-default tax
+	// codes, so those must be provisioned first even though this tax code isn't one of them.
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
+	require.NoError(s.T(), s.TaxCodeService.DeleteTaxCode(ctx, taxcode.DeleteTaxCodeInput{
+		NamespacedID: models.NamespacedID{Namespace: ns, ID: taxCode.ID},
+	}))
+
+	// when: a customer override is upserted with a defaultTaxConfig freshly pointing at the
+	// soft-deleted tax code
+	_, err = s.BillingService.UpsertCustomerOverride(ctx, billing.UpsertCustomerOverrideInput{
+		Namespace:  ns,
+		CustomerID: cust.ID,
+		Invoicing: billing.InvoicingOverrideConfig{
+			DefaultTaxConfig: &productcatalog.TaxConfig{
+				TaxCodeID: lo.ToPtr(taxCode.ID),
+			},
+		},
+	})
+
+	// then: the upsert is rejected with a generic validation error
+	require.True(s.T(), models.IsGenericValidationError(err), "expected a generic validation error, got: %v", err)
 }
 
 func (s *CustomerOverrideTestSuite) TestListCustomerOverrides() {

--- a/test/billing/discount_test.go
+++ b/test/billing/discount_test.go
@@ -36,7 +36,7 @@ func (s *DiscountsTestSuite) TestCorrelationIDHandling() {
 	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
 
 	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), WithProgressiveBilling())
-	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
+	s.TaxCodeEnv.ProvisionProviderDefaultTaxCode(s.T(), namespace)
 
 	customerEntity := s.CreateTestCustomer(namespace, "test-customer")
 	s.NotNil(customerEntity)

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -924,7 +924,7 @@ func (s *InvoicingTestSuite) TestInvoicingFlow() {
 			s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), WithBillingProfileEditFn(func(profile *billing.CreateProfileInput) {
 				profile.WorkflowConfig = tc.workflowConfig
 			}))
-			s.ProvisionProviderDefaultTaxCode(ctx, namespace)
+			s.TaxCodeEnv.ProvisionProviderDefaultTaxCode(s.T(), namespace)
 
 			invoice := s.CreateDraftInvoice(s.T(), ctx, DraftInvoiceInput{
 				Namespace: namespace,
@@ -1580,7 +1580,7 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 
 	// Given we have a default profile for the namespace
 	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), WithProgressiveBilling())
-	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
+	s.TaxCodeEnv.ProvisionProviderDefaultTaxCode(s.T(), namespace)
 
 	lines := ubpPendingLines{}
 	s.Run("create pending invoice items", func() {
@@ -4153,7 +4153,7 @@ func (s *InvoicingTestSuite) TestDeleteGatheringInvoiceViaService() {
 
 	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
 	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
-	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
+	s.TaxCodeEnv.ProvisionProviderDefaultTaxCode(s.T(), namespace)
 
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	periodStart := now.Add(-24 * time.Hour)
@@ -4565,7 +4565,7 @@ func (s *InvoicingTestSuite) TestUpdateInvoice() {
 			},
 		}
 	}))
-	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
+	s.TaxCodeEnv.ProvisionProviderDefaultTaxCode(s.T(), namespace)
 
 	s.Run("gathering invoice", func() {
 		var gatheringInvoiceID billing.InvoiceID

--- a/test/billing/subscription_suite.go
+++ b/test/billing/subscription_suite.go
@@ -186,6 +186,7 @@ func (s *SubscriptionMixin) SetupSuite(t *testing.T, deps SubscriptionMixInDepen
 		Logger:          slog.Default(),
 		Publisher:       publisher,
 		FeatureResolver: featureResolver,
+		TaxCodeResolver: taxCodeResolver,
 		TaxCode:         taxCodeService,
 	})
 	require.NoError(t, err)

--- a/test/billing/subscription_suite.go
+++ b/test/billing/subscription_suite.go
@@ -45,8 +45,7 @@ import (
 	subscriptionservice "github.com/openmeterio/openmeter/openmeter/subscription/service"
 	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
 	subscriptionworkflowservice "github.com/openmeterio/openmeter/openmeter/subscription/workflow/service"
-	taxcodeadapter "github.com/openmeterio/openmeter/openmeter/taxcode/adapter"
-	taxcodeservice "github.com/openmeterio/openmeter/openmeter/taxcode/service"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/ffx"
@@ -68,6 +67,7 @@ type SubscriptionMixInDependencies struct {
 	FeatureRepo     feature.FeatureRepo
 	FeatureService  feature.FeatureConnector
 	CustomerService customer.Service
+	TaxCodeService  taxcode.Service
 
 	MeterAdapter           *meteradapter.TestAdapter
 	MockStreamingConnector *streamingtestutils.MockStreamingConnector
@@ -88,6 +88,10 @@ func (d SubscriptionMixInDependencies) Validate() error {
 
 	if d.CustomerService == nil {
 		return errors.New("CustomerService is required")
+	}
+
+	if d.TaxCodeService == nil {
+		return errors.New("TaxCodeService is required")
 	}
 
 	if d.MeterAdapter == nil {
@@ -115,29 +119,17 @@ func (s *SubscriptionMixin) SetupSuite(t *testing.T, deps SubscriptionMixInDepen
 	})
 	require.NoError(t, err)
 
-	taxCodeAdapter, err := taxcodeadapter.New(taxcodeadapter.Config{
-		Client: deps.DBClient,
-		Logger: slog.Default(),
-	})
-	require.NoError(t, err)
-
-	taxCodeService, err := taxcodeservice.New(taxcodeservice.Config{
-		Adapter: taxCodeAdapter,
-		Logger:  slog.Default(),
-	})
-	require.NoError(t, err)
-
 	featureResolver, err := featureresolver.New(deps.FeatureService)
 	require.NoErrorf(t, err, "failed to create feature resolver: %v", err)
 
-	taxCodeResolver, err := taxcoderesolver.New(taxCodeService)
+	taxCodeResolver, err := taxcoderesolver.New(deps.TaxCodeService)
 	require.NoErrorf(t, err, "failed to create tax code resolver: %v", err)
 
 	planService, err := planservice.New(planservice.Config{
 		FeatureResolver: featureResolver,
 		TaxCodeResolver: taxCodeResolver,
 		Adapter:         planAdapter,
-		TaxCode:         taxCodeService,
+		TaxCode:         deps.TaxCodeService,
 		Logger:          slog.Default(),
 		Publisher:       publisher,
 	})
@@ -170,6 +162,7 @@ func (s *SubscriptionMixin) SetupSuite(t *testing.T, deps SubscriptionMixInDepen
 		TransactionManager: subsRepo,
 		Lockr:              lockr,
 		FeatureFlags:       ffService,
+		TaxCode:            deps.TaxCodeService,
 		// events
 		Publisher: publisher,
 	})
@@ -187,7 +180,7 @@ func (s *SubscriptionMixin) SetupSuite(t *testing.T, deps SubscriptionMixInDepen
 		Publisher:       publisher,
 		FeatureResolver: featureResolver,
 		TaxCodeResolver: taxCodeResolver,
-		TaxCode:         taxCodeService,
+		TaxCode:         deps.TaxCodeService,
 	})
 	require.NoError(t, err)
 

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -53,8 +53,7 @@ import (
 	subjectservice "github.com/openmeterio/openmeter/openmeter/subject/service"
 	subjecthooks "github.com/openmeterio/openmeter/openmeter/subject/service/hooks"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
-	taxcodeadapter "github.com/openmeterio/openmeter/openmeter/taxcode/adapter"
-	taxcodeservice "github.com/openmeterio/openmeter/openmeter/taxcode/service"
+	taxcodetestutils "github.com/openmeterio/openmeter/openmeter/taxcode/testutils"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -90,6 +89,7 @@ type BaseSuite struct {
 	SandboxApp *appsandbox.MockableFactory
 
 	TaxCodeService taxcode.Service
+	TaxCodeEnv     *taxcodetestutils.TestEnv
 }
 
 func (s *BaseSuite) TearDownTest() {
@@ -108,6 +108,7 @@ func (b *BaseSuite) GetSubscriptionMixInDependencies() SubscriptionMixInDependen
 		FeatureRepo:            b.FeatureRepo,
 		FeatureService:         b.FeatureService,
 		CustomerService:        b.CustomerService,
+		TaxCodeService:         b.TaxCodeService,
 		MeterAdapter:           b.MeterAdapter,
 		MockStreamingConnector: b.MockStreamingConnector,
 	}
@@ -201,18 +202,8 @@ func (s *BaseSuite) setupSuite() {
 	s.AppService = appService
 
 	// TaxCode
-	taxCodeAdapter, err := taxcodeadapter.New(taxcodeadapter.Config{
-		Client: dbClient,
-		Logger: slog.Default(),
-	})
-	require.NoError(t, err)
-
-	taxCodeService, err := taxcodeservice.New(taxcodeservice.Config{
-		Adapter: taxCodeAdapter,
-		Logger:  slog.Default(),
-	})
-	require.NoError(t, err)
-	s.TaxCodeService = taxCodeService
+	s.TaxCodeEnv = taxcodetestutils.NewTestEnvFromClient(t, dbClient, slog.Default())
+	s.TaxCodeService = s.TaxCodeEnv.Service
 
 	// Billing
 	billingAdapter, err := billingadapter.New(billingadapter.Config{
@@ -249,7 +240,7 @@ func (s *BaseSuite) setupSuite() {
 		Publisher:                    publisher,
 		AdvancementStrategy:          billing.ForegroundAdvancementStrategy,
 		MaxParallelQuantitySnapshots: 2,
-		TaxCodeService:               taxCodeService,
+		TaxCodeService:               s.TaxCodeService,
 	})
 	require.NoError(t, err)
 
@@ -640,7 +631,7 @@ func (s *BaseSuite) ProvisionBillingProfile(ctx context.Context, ns string, appI
 // code deprecation gate (InvoicingConfig.EnforceTaxCodeDeprecation). This simulates legacy
 // rows that were created before tax codes on billing profiles were deprecated.
 //
-// The tax config is resolved in place exactly like the pre-deprecation service path
+// The tax config is resolved exactly like the pre-deprecation service path
 // (productcatalog.ResolveTaxConfig cross-populates TaxCodeID and Stripe.Code), then
 // persisted via the adapter so the JSON column, tax_code_id FK and tax_behavior columns
 // are written by the production adapter code path. Returns the re-read profile so tests
@@ -648,7 +639,11 @@ func (s *BaseSuite) ProvisionBillingProfile(ctx context.Context, ns string, appI
 func (s *BaseSuite) SeedProfileDefaultTaxConfigViaAdapter(ctx context.Context, profileID billing.ProfileID, taxConfig *productcatalog.TaxConfig) *billing.AdapterGetProfileResponse {
 	s.T().Helper()
 
-	s.Require().NoError(productcatalog.ResolveTaxConfig(ctx, s.TaxCodeService, profileID.Namespace, taxConfig))
+	resolvedTaxConfig, err := productcatalog.ResolveTaxConfig(ctx, s.TaxCodeService, productcatalog.ResolveTaxConfigInput{
+		Namespace: profileID.Namespace,
+		Cfg:       taxConfig,
+	})
+	s.Require().NoError(err)
 
 	adapterProfile, err := s.BillingAdapter.GetProfile(ctx, billing.GetProfileInput{Profile: profileID})
 	s.Require().NoError(err)
@@ -656,7 +651,7 @@ func (s *BaseSuite) SeedProfileDefaultTaxConfigViaAdapter(ctx context.Context, p
 	targetState := adapterProfile.BaseProfile
 	// Mirror the service update path: app references are never part of the update target state.
 	targetState.AppReferences = nil
-	targetState.WorkflowConfig.Invoicing.DefaultTaxConfig = taxConfig
+	targetState.WorkflowConfig.Invoicing.DefaultTaxConfig = resolvedTaxConfig
 
 	_, err = s.BillingAdapter.UpdateProfile(ctx, billing.UpdateProfileAdapterInput{
 		TargetState:      targetState,
@@ -668,60 +663,6 @@ func (s *BaseSuite) SeedProfileDefaultTaxConfigViaAdapter(ctx context.Context, p
 	s.Require().NoError(err)
 
 	return updatedProfile
-}
-
-// ProvisionDefaultTaxCodes creates the invoicing and credit-grant tax codes for the
-// namespace and stores them as the organization defaults. Tests that create charges
-// via the real charges service must call this for the namespace, because charge
-// creation auto-stamps the namespace's default tax code when the caller's TaxConfig
-// has no TaxCodeID.
-func (s *BaseSuite) ProvisionDefaultTaxCodes(ctx context.Context, ns string) taxcode.OrganizationDefaultTaxCodes {
-	s.T().Helper()
-
-	invoicing := s.ProvisionProviderDefaultTaxCode(ctx, ns)
-	creditGrant := s.getOrCreateTaxCodeByKey(ctx, ns, "default-credit-grant", "Default Credit Grant")
-
-	defaults, err := s.TaxCodeService.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
-		Namespace:            ns,
-		InvoicingTaxCodeID:   invoicing.ID,
-		CreditGrantTaxCodeID: creditGrant.ID,
-	})
-	s.Require().NoError(err, "upserting organization default tax codes")
-	return defaults
-}
-
-// ProvisionProviderDefaultTaxCode creates the tax code used when an invoicing app
-// omits an app-specific provider code. This is distinct from organization default
-// tax-code settings: API invoice edit diffing needs the provider-default tax code
-// row to resolve empty provider tax config, but it must not imply that the
-// namespace has configured org-level default tax codes.
-func (s *BaseSuite) ProvisionProviderDefaultTaxCode(ctx context.Context, ns string) taxcode.TaxCode {
-	s.T().Helper()
-
-	return s.getOrCreateTaxCodeByKey(ctx, ns, taxcode.ProviderDefaultTaxCodeKey, "Provider Default")
-}
-
-func (s *BaseSuite) getOrCreateTaxCodeByKey(ctx context.Context, ns string, key string, name string) taxcode.TaxCode {
-	s.T().Helper()
-
-	taxCode, err := s.TaxCodeService.GetTaxCodeByKey(ctx, taxcode.GetTaxCodeByKeyInput{
-		Namespace: ns,
-		Key:       key,
-	})
-	if err == nil {
-		return taxCode
-	}
-
-	s.Require().True(taxcode.IsTaxCodeNotFoundError(err), "getting tax code by key should either succeed or return not found")
-
-	taxCode, err = s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: ns,
-		Key:       key,
-		Name:      name,
-	})
-	s.Require().NoError(err, "creating tax code")
-
-	return taxCode
 }
 
 type SetupCustomInvoicingResponse struct {

--- a/test/billing/tax_test.go
+++ b/test/billing/tax_test.go
@@ -122,7 +122,7 @@ func (s *InvoicingTaxTestSuite) TestDefaultTaxConfigProfileSnapshotting() {
 
 		draftInvoice := s.generateDraftInvoice(ctx, cust)
 		s.Nil(draftInvoice.Workflow.Config.Invoicing.DefaultTaxConfig)
-		s.ProvisionProviderDefaultTaxCode(ctx, namespace)
+		s.TaxCodeEnv.ProvisionProviderDefaultTaxCode(s.T(), namespace)
 
 		// let's update the invoice
 		updatedInvoice, err := s.BillingService.UpdateStandardInvoice(ctx, billing.UpdateStandardInvoiceInput{
@@ -143,6 +143,148 @@ func (s *InvoicingTaxTestSuite) TestDefaultTaxConfigProfileSnapshotting() {
 		s.Equal(productcatalog.InclusiveTaxBehavior, *updatedInvoice.Workflow.Config.Invoicing.DefaultTaxConfig.Behavior)
 		s.Equal("txcd_30000000", updatedInvoice.Workflow.Config.Invoicing.DefaultTaxConfig.Stripe.Code)
 	})
+}
+
+// TestUpdateProfileRejectsSoftDeletedDefaultTaxConfig asserts that UpdateProfile rejects a
+// billing profile's defaultTaxConfig.taxCodeId once the referenced tax code has been soft
+// deleted. taxcode.Service.GetTaxCode intentionally still returns soft-deleted rows by ID (they
+// remain resolvable for continuity reads such as invoice snapshotting), so the guard against
+// assigning a dead reference as a billing default lives in productcatalog.ResolveTaxConfig's
+// IncludeDeleted=false check. The taxCodeId must be echoed back unchanged from the stored
+// profile for the update to reach that check at all: profile.InvoicingConfig.
+// WithDeprecatedTaxCodeEnforced runs first and rejects any *new* taxCodeId assignment outright,
+// so this test seeds the stored reference (mirroring a legacy pre-deprecation row) before
+// deleting the tax code and echoing it back unchanged.
+func (s *InvoicingTaxTestSuite) TestUpdateProfileRejectsSoftDeletedDefaultTaxConfig() {
+	namespace := "ns-tax-profile-soft-deleted"
+	ctx := s.T().Context()
+
+	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+
+	// given:
+	// - a billing profile whose stored defaultTaxConfig already references a tax code, seeded via
+	//   the adapter to simulate a legacy row created before taxCodeId echoing was deprecated
+	// - the referenced tax code is then soft-deleted
+	profile := s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
+
+	taxCode, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: namespace,
+		Key:       "soft-deleted-profile-default",
+		Name:      "Soft Deleted Profile Default",
+	})
+	s.NoError(err)
+
+	seededProfile := s.SeedProfileDefaultTaxConfigViaAdapter(ctx, profile.ProfileID(), &productcatalog.TaxConfig{
+		Behavior:  lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+		TaxCodeID: lo.ToPtr(taxCode.ID),
+	})
+
+	// DeleteTaxCode checks the deleted code against the namespace's organization-default tax
+	// codes, so those must be provisioned first even though this tax code isn't one of them.
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), namespace)
+	s.NoError(s.TaxCodeService.DeleteTaxCode(ctx, taxcode.DeleteTaxCodeInput{
+		NamespacedID: models.NamespacedID{Namespace: namespace, ID: taxCode.ID},
+	}))
+
+	// when: the profile is updated while echoing the same (now soft-deleted) taxCodeId
+	// unchanged, so the update passes the deprecated-tax-code gate and reaches tax-code
+	// resolution
+	updateInput := billing.UpdateProfileInput(seededProfile.BaseProfile)
+	updateInput.AppReferences = nil
+
+	_, err = s.BillingService.UpdateProfile(ctx, updateInput)
+
+	// then: resolution rejects the soft-deleted reference as a generic validation error
+	s.True(models.IsGenericValidationError(err), "expected a generic validation error, got: %v", err)
+}
+
+// TestCreateStandardInvoiceFromGatheringLinesResolvesSoftDeletedDefaultTaxConfig pins the
+// billing continuity contract in CreateStandardInvoiceFromGatheringLines: it re-derives the
+// customer's already persisted profile default tax config with IncludeDeleted=true, so a tax
+// code that is the profile default and has since been soft-deleted must not block invoicing.
+// Without IncludeDeleted=true here, the same soft-delete gate proven in
+// TestUpdateProfileRejectsSoftDeletedDefaultTaxConfig would also block routine invoicing for
+// every customer whose profile still points at that code as its default, turning a tax-code
+// cleanup into an invoicing outage.
+func (s *InvoicingTaxTestSuite) TestCreateStandardInvoiceFromGatheringLinesResolvesSoftDeletedDefaultTaxConfig() {
+	namespace := "ns-tax-profile-deleted-default"
+	ctx := s.T().Context()
+
+	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+	cust := s.CreateTestCustomer(namespace, "test")
+
+	// given:
+	// - organization default tax codes are provisioned so DeleteTaxCode's org-default lookup
+	//   below has a row to compare against for this namespace
+	// - a billing profile whose default tax config references a tax code that is NOT an
+	//   organization default (org-default tax codes reject deletion, see taxcode.Service.DeleteTaxCode)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), namespace)
+	profile := s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
+	taxConfig := &productcatalog.TaxConfig{
+		Behavior: lo.ToPtr(productcatalog.InclusiveTaxBehavior),
+		Stripe: &productcatalog.StripeTaxConfig{
+			Code: "txcd_10000001",
+		},
+	}
+
+	seeded := s.SeedProfileDefaultTaxConfigViaAdapter(ctx, profile.ProfileID(), taxConfig)
+	seededDefault := seeded.WorkflowConfig.Invoicing.DefaultTaxConfig
+	s.Require().NotNil(seededDefault, "seeding must persist the default tax config")
+	s.Require().NotNil(seededDefault.TaxCodeID, "seeding must resolve and stamp the tax code id")
+
+	deletedTaxCodeID := *seededDefault.TaxCodeID
+
+	// when:
+	// - pending lines are created while the default tax code is still live
+	// - the default tax code is then soft-deleted before the standard invoice is generated
+	//   from those gathering lines
+	now := time.Now().Truncate(time.Microsecond).In(time.UTC)
+
+	res, err := s.BillingService.CreatePendingInvoiceLines(ctx,
+		billing.CreatePendingInvoiceLinesInput{
+			Customer: cust.GetID(),
+			Currency: currencyx.Code(currency.USD),
+			Lines: []billing.GatheringLine{
+				billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
+					Period: timeutil.ClosedPeriod{From: now, To: now.Add(time.Hour * 24)},
+
+					InvoiceAt: now,
+					ManagedBy: billing.ManuallyManagedLine,
+
+					Name: "Test item - USD",
+
+					Metadata: map[string]string{
+						"key": "value",
+					},
+					PerUnitAmount: alpacadecimal.NewFromFloat(100),
+					PaymentTerm:   productcatalog.InAdvancePaymentTerm,
+				}),
+			},
+		},
+	)
+	s.NoError(err)
+	s.Len(res.Lines, 1)
+
+	s.Require().NoError(s.TaxCodeService.DeleteTaxCode(ctx, taxcode.DeleteTaxCodeInput{
+		NamespacedID: models.NamespacedID{Namespace: namespace, ID: deletedTaxCodeID},
+	}), "deleting a non-org-default tax code must succeed")
+
+	// then:
+	// - invoice creation from the gathering lines still succeeds
+	// - the snapshotted default tax config resolves the deleted code's id and Stripe mapping
+	invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: cust.GetID(),
+		AsOf:     &now,
+	})
+	s.Require().NoError(err, "invoice creation must succeed even though the profile default tax code was soft-deleted")
+	s.Require().Len(invoices, 1)
+
+	invoice := invoices[0]
+	s.Require().NotNil(invoice.Workflow.Config.Invoicing.DefaultTaxConfig)
+	s.Require().NotNil(invoice.Workflow.Config.Invoicing.DefaultTaxConfig.TaxCodeID)
+	s.Equal(deletedTaxCodeID, *invoice.Workflow.Config.Invoicing.DefaultTaxConfig.TaxCodeID)
+	s.Require().NotNil(invoice.Workflow.Config.Invoicing.DefaultTaxConfig.Stripe)
+	s.Equal("txcd_10000001", invoice.Workflow.Config.Invoicing.DefaultTaxConfig.Stripe.Code)
 }
 
 func (s *InvoicingTaxTestSuite) TestLineSplittingRetainsTaxConfig() {

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -42,7 +42,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceDeletePatchD
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-delete-gathering")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -148,7 +148,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceDeletePatchD
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-delete-standard")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -339,7 +339,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceDeletePatchK
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-delete-immutable")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -531,7 +531,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceCreatePatchCrea
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-create")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -650,7 +650,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchDele
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-gathering")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -754,7 +754,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchDele
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-standard")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -934,7 +934,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchDele
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-standard-partial")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1103,7 +1103,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeletePatchKeep
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-immutable")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1282,7 +1282,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoicePartialCreditPa
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-partial-payment")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1573,7 +1573,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDirectPaidTrigg
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-direct-paid")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1689,7 +1689,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedPa
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-no-fiat-payment-callback")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1818,7 +1818,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceZeroAmountFinal
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-zero")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1939,7 +1939,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkToZeroThe
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-shrink-zero-extend")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -2201,7 +2201,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteImmutable
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-immutable-payment")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -2351,7 +2351,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceAsyncPaymentBoo
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-async-prior-payment")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -2548,7 +2548,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceInArrearsActiva
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-in-arrears")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -2700,7 +2700,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteActiveCha
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-delete-active")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -2795,7 +2795,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkExtendPat
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-shrink-extend-gathering")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -2947,7 +2947,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkPatchUpda
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-shrink-mutable-standard")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3097,7 +3097,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkPatchCorr
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-cti-shrink-mutable-with-credits")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3267,7 +3267,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceImmutableShrink
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-immutable-shrink-extend-shrink")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3483,7 +3483,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchU
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-extend-gathering")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3599,7 +3599,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkPatchU
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-shrink-gathering")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3713,7 +3713,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchD
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-extend-mutable-standard")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3899,7 +3899,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkPatchD
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-shrink-mutable-standard")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -4086,7 +4086,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkPatchA
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-shrink-immutable")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -4346,7 +4346,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchD
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-extend-final-collection")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -4568,7 +4568,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchA
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-extend-immutable")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -4763,7 +4763,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkExtend
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-shrink-extend-shrink")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -5151,7 +5151,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchF
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-extend-tail")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")

--- a/test/credits/creditgrant_test.go
+++ b/test/credits/creditgrant_test.go
@@ -101,7 +101,7 @@ func (s *CreditGrantTestSuite) SetupSuite() {
 func (s *CreditGrantTestSuite) TestCreateInvoiceFundedCreatesInvoiceArtifacts() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("creditgrant-service-invoice-funded")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -158,7 +158,7 @@ func (s *CreditGrantTestSuite) TestCreateInvoiceFundedCreatesInvoiceArtifacts() 
 func (s *CreditGrantTestSuite) TestCreatePromotionalGrant() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("creditgrant-service-promotional")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -197,7 +197,7 @@ func (s *CreditGrantTestSuite) TestCreatePromotionalGrant() {
 func (s *CreditGrantTestSuite) TestCreatePromotionalGrantUsesEffectiveAtForServicePeriodAndLedgerBookedAt() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("creditgrant-service-promotional-effective-at")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -244,7 +244,7 @@ func (s *CreditGrantTestSuite) TestCreatePromotionalGrantUsesEffectiveAtForServi
 func (s *CreditGrantTestSuite) TestCreateFeatureFilteredGrant() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("creditgrant-service-feature-filters")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 
@@ -270,7 +270,7 @@ func (s *CreditGrantTestSuite) TestCreateFeatureFilteredGrant() {
 func (s *CreditGrantTestSuite) TestCreateExternalGrantAndSettle() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("creditgrant-service-external")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -328,7 +328,7 @@ func (s *CreditGrantTestSuite) TestCreateExternalGrantAndSettle() {
 func (s *CreditGrantTestSuite) TestCreateExternalGrantWithSubCentCostBasisAndSettle() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("creditgrant-service-external-sub-cent-cost-basis")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -417,7 +417,7 @@ func (s *CreditGrantTestSuite) TestCreateExternalGrantWithSubCentCostBasisAndSet
 func (s *CreditGrantTestSuite) TestListCreditGrants() {
 	ctx := context.Background()
 	ns := s.GetUniqueNamespace("creditgrant-service-list")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -450,7 +450,7 @@ func (s *CreditGrantTestSuite) TestListCreditGrants() {
 func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantPropagatesTaxConfigToInvoiceLine() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("creditgrant-taxconfig-propagation")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -520,7 +520,7 @@ func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantPropagatesTaxConfigTo
 func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantNilTaxConfigAppliesCreditGrantDefault() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("creditgrant-taxconfig-nil")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -573,7 +573,7 @@ func (s *CreditGrantTestSuite) TestCreateInvoiceFundedGrantNilTaxConfigAppliesCr
 func (s *CreditGrantTestSuite) TestCreateExternalGrantPropagatesTaxConfigToCharge() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("creditgrant-external-taxconfig")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -623,7 +623,7 @@ func (s *CreditGrantTestSuite) TestCreateExternalGrantPropagatesTaxConfigToCharg
 func (s *CreditGrantTestSuite) TestCreatePromotionalGrantPropagatesTaxConfigToCharge() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("creditgrant-promotional-taxconfig")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)

--- a/test/credits/rating_test.go
+++ b/test/credits/rating_test.go
@@ -28,7 +28,7 @@ type RatingTestSuite struct {
 func (s *RatingTestSuite) TestListChargesExpandsRealtimeUsageForMultipleUsageBasedCharges() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("credits-rating-list-charges")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	const (
 		standardRateReference = "usage-based-standard-rate"

--- a/test/credits/sanity_lifecycle_test.go
+++ b/test/credits/sanity_lifecycle_test.go
@@ -119,7 +119,7 @@ func (s *SanityLifecycleSuite) TestUsageBasedCreditOnlyLifecyclePartialBackfillC
 func (s *SanityLifecycleSuite) TestUsageBasedCreditOnlyLifecycleTwoChargesTwoPurchasesSanity() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-usagebased-credit-only-lifecycle-two-charges-two-purchases")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -379,7 +379,7 @@ func (s *SanityLifecycleSuite) TestUsageBasedCreditOnlyLifecycleTwoChargesTwoPur
 // the later correction has already been applied.
 func (s *SanityLifecycleSuite) setupUsageBasedCreditOnlyLifecyclePartialBackfillCorrection(ctx context.Context, namespacePrefix string) usageBasedPartialBackfillLifecycleState {
 	ns := s.GetUniqueNamespace(namespacePrefix)
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -979,7 +979,7 @@ func (s *SanitySuite) TestExpiringCreditBreakageIgnoresNonExpiringSourceOnUsageS
 func (s *SanitySuite) TestFeatureRestrictedCreditCollectionCorrectionThenCollectionSanity() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-feature-credit-correction-collection")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1484,7 +1484,7 @@ func (s *SanitySuite) assertBreakageRowsByExpiry(ctx context.Context, namespace 
 func (s *SanitySuite) setupExpiringCreditBreakage(namespaceSuffix string, opts ...expiringCreditBreakageSetupOption) expiringCreditBreakageSetup {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace(namespaceSuffix)
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1687,7 +1687,7 @@ func (s *SanitySuite) assertBreakageBalancesAt(input breakageBalanceAssertionInp
 func (s *SanitySuite) setupFlatFeeCreditOnlyDeleteCorrection(namespaceSuffix string) creditOnlyDeleteCorrectionSetup {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace(namespaceSuffix)
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -1713,7 +1713,7 @@ func (s *SanitySuite) setupFlatFeeCreditOnlyDeleteCorrection(namespaceSuffix str
 func (s *SanitySuite) setupClosedPeriodUsageBasedCreditOnlyCollection(namespaceSuffix string) creditOnlyDeleteCorrectionSetup {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace(namespaceSuffix)
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -1941,7 +1941,7 @@ func (s *SanitySuite) assertFundedRecognizedCreditOnlyDeleted(namespace string, 
 func (s *SanitySuite) TestUsageBasedCreditOnlyDeleteCorrectionWithPartialBackfillSanity() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-usagebased-credit-only-delete-partial-backfill")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -2115,7 +2115,7 @@ func (s *SanitySuite) TestUsageBasedCreditOnlyDeleteCorrectionWithPartialBackfil
 func (s *SanitySuite) TestUsageBasedCreditOnlyDeleteCorrectionWithMixedFeatureAdvanceBackfillSanity() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-usagebased-credit-only-delete-mixed-feature-backfill")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
@@ -2334,7 +2334,7 @@ func (s *SanitySuite) TestUsageBasedCreditOnlyDeleteCorrectionWithMixedFeatureAd
 func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-test")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -2787,7 +2787,7 @@ func (s *SanitySuite) setupMeteredFeatures(ctx context.Context, ns string, input
 func (s *SanitySuite) TestCreditPurchasePersistsPriority() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-creditpurchase-persists-priority")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	s.NotEmpty(cust.ID)
@@ -2827,7 +2827,7 @@ func (s *SanitySuite) TestCreditPurchasePersistsPriority() {
 func (s *SanitySuite) TestUsageBasedCreditThenInvoicePaymentLifecycle() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-credits-usagebased-credit-then-invoice-payment-lifecycle")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3122,7 +3122,7 @@ func (s *SanitySuite) TestUsageBasedCreditThenInvoicePaymentLifecycle() {
 func (s *SanitySuite) TestFlatFeeCreditOnlySanity() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-sanity-test-credit-only")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 
@@ -3548,7 +3548,7 @@ func (s *SanitySuite) TestFlatFeeCreditOnlySanity() {
 func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("credit-purchase-multi-taxcode-advance")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3748,7 +3748,7 @@ func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionAcrossTaxCodeBuckets()
 func (s *SanitySuite) TestCreditPurchaseAdvanceAttributionClearsLegacyNilSpendFeatureBuckets() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("credit-purchase-legacy-feature-advance")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -3902,7 +3902,7 @@ func (s *SanitySuite) markLedgerEntriesLegacyBySpendChargeID(ctx context.Context
 func (s *SanitySuite) TestFlatFeeCreditOnlyTaxConfigFlowsToEarnings() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("flatfee-credit-taxconfig-earnings")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -4022,7 +4022,7 @@ func (s *SanitySuite) TestFlatFeeCreditOnlyTaxConfigFlowsToEarnings() {
 func (s *SanitySuite) TestFlatFeeCreditThenInvoiceTaxConfigFlowsToEarnings() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("flatfee-invoice-taxconfig-earnings")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -4122,7 +4122,7 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceTaxConfigFlowsToEarnings() {
 func (s *SanitySuite) TestUsageBasedCreditOnlyTaxConfigFlowsToEarnings() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("usage-credit-taxconfig-earnings")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -4259,7 +4259,7 @@ func (s *SanitySuite) TestUsageBasedCreditOnlyTaxConfigFlowsToEarnings() {
 func (s *SanitySuite) TestUsageBasedCreditThenInvoiceTaxConfigFlowsToEarnings() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("usage-invoice-taxconfig-earnings")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
@@ -4439,7 +4439,7 @@ func (s *SanitySuite) mustEarningsBalanceForTaxConfig(namespace string, code cur
 func (s *SanitySuite) TestTaxCodeFlowsFromCreditPurchaseToEarnings() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("taxcode-earnings-flow")
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")

--- a/test/credits/voidgrant_test.go
+++ b/test/credits/voidgrant_test.go
@@ -700,7 +700,7 @@ func (s *VoidGrantTestSuite) TestConcurrentVoidsDoNotDoubleBook() {
 func (s *VoidGrantTestSuite) setupVoidTestCustomer(ctx context.Context, ns string) *customer.Customer {
 	s.T().Helper()
 
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	sandboxApp := s.InstallSandboxApp(s.T(), ns)
 	_ = s.ProvisionBillingProfile(ctx, ns, sandboxApp.GetID(),
@@ -715,7 +715,7 @@ func (s *VoidGrantTestSuite) setupVoidTestCustomer(ctx context.Context, ns strin
 func (s *VoidGrantTestSuite) setupInvoiceFundedVoidGrant(ctx context.Context, ns string, issuedAt time.Time, amount, costBasis alpacadecimal.Decimal) (*customer.Customer, creditpurchase.Charge, billing.StandardInvoice) {
 	s.T().Helper()
 
-	s.ProvisionDefaultTaxCodes(ctx, ns)
+	s.TaxCodeEnv.ProvisionDefaultTaxCodes(s.T(), ns)
 	customInvoicing := s.SetupCustomInvoicing(ns)
 	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
 	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),

--- a/test/customer/testenv.go
+++ b/test/customer/testenv.go
@@ -350,6 +350,7 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 		Logger:          logger,
 		Publisher:       publisher,
 		FeatureResolver: featureResolver,
+		TaxCodeResolver: taxCodeResolver,
 		TaxCode:         taxCodeService,
 	})
 	require.NoError(t, err)

--- a/test/customer/testenv.go
+++ b/test/customer/testenv.go
@@ -57,8 +57,7 @@ import (
 	subscriptioncustomer "github.com/openmeterio/openmeter/openmeter/subscription/validators/customer"
 	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
 	subscriptionworkflowservice "github.com/openmeterio/openmeter/openmeter/subscription/workflow/service"
-	taxcodeadapter "github.com/openmeterio/openmeter/openmeter/taxcode/adapter"
-	taxcodeservice "github.com/openmeterio/openmeter/openmeter/taxcode/service"
+	taxcodetestutils "github.com/openmeterio/openmeter/openmeter/taxcode/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/ffx"
@@ -260,33 +259,19 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 		return nil, fmt.Errorf("failed to create plan adapter: %w", err)
 	}
 
-	taxCodeAdapter, err := taxcodeadapter.New(taxcodeadapter.Config{
-		Client: dbDeps.DBClient,
-		Logger: logger.WithGroup("taxcode"),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create tax code adapter: %w", err)
-	}
-
-	taxCodeService, err := taxcodeservice.New(taxcodeservice.Config{
-		Adapter: taxCodeAdapter,
-		Logger:  logger.WithGroup("taxcode"),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create tax code service: %w", err)
-	}
+	taxCodeEnv := taxcodetestutils.NewTestEnvFromClient(t, dbDeps.DBClient, logger.WithGroup("taxcode"))
 
 	featureResolver, err := featureresolver.New(entitlementRegistry.Feature)
 	require.NoErrorf(t, err, "failed to create feature resolver: %v", err)
 
-	taxCodeResolver, err := taxcoderesolver.New(taxCodeService)
+	taxCodeResolver, err := taxcoderesolver.New(taxCodeEnv.Service)
 	require.NoErrorf(t, err, "failed to create tax code resolver: %v", err)
 
 	planService, err := planservice.New(planservice.Config{
 		Adapter:         planAdapter,
 		FeatureResolver: featureResolver,
 		TaxCodeResolver: taxCodeResolver,
-		TaxCode:         taxCodeService,
+		TaxCode:         taxCodeEnv.Service,
 		Logger:          logger.WithGroup("plan"),
 		Publisher:       publisher,
 	})
@@ -351,7 +336,7 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 		Publisher:       publisher,
 		FeatureResolver: featureResolver,
 		TaxCodeResolver: taxCodeResolver,
-		TaxCode:         taxCodeService,
+		TaxCode:         taxCodeEnv.Service,
 	})
 	require.NoError(t, err)
 
@@ -443,7 +428,7 @@ func NewTestEnv(t *testing.T, ctx context.Context) (TestEnv, error) {
 		Publisher:                    publisher,
 		AdvancementStrategy:          billing.ForegroundAdvancementStrategy,
 		MaxParallelQuantitySnapshots: 2,
-		TaxCodeService:               taxCodeService,
+		TaxCodeService:               taxCodeEnv.Service,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create billing service: %w", err)

--- a/test/subscription/framework_test.go
+++ b/test/subscription/framework_test.go
@@ -29,8 +29,6 @@ import (
 	subscription "github.com/openmeterio/openmeter/openmeter/subscription"
 	subscriptiontestutils "github.com/openmeterio/openmeter/openmeter/subscription/testutils"
 	subscriptionworkflow "github.com/openmeterio/openmeter/openmeter/subscription/workflow"
-	taxcodeadapter "github.com/openmeterio/openmeter/openmeter/taxcode/adapter"
-	taxcodeservice "github.com/openmeterio/openmeter/openmeter/taxcode/service"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
 	"github.com/openmeterio/openmeter/pkg/datetime"
@@ -100,18 +98,6 @@ func setup(t *testing.T, _ setupConfig) testDeps {
 	})
 	require.NoError(t, err)
 
-	taxCodeAdapter, err := taxcodeadapter.New(taxcodeadapter.Config{
-		Client: deps.DBDeps.DBClient,
-		Logger: slog.Default(),
-	})
-	require.NoError(t, err)
-
-	taxCodeService, err := taxcodeservice.New(taxcodeservice.Config{
-		Adapter: taxCodeAdapter,
-		Logger:  slog.Default(),
-	})
-	require.NoError(t, err)
-
 	billingService, err := billingservice.New(billingservice.Config{
 		Adapter:                      billingAdapter,
 		SequenceService:              billingSequenceService,
@@ -125,7 +111,7 @@ func setup(t *testing.T, _ setupConfig) testDeps {
 		Publisher:                    publisher,
 		AdvancementStrategy:          billing.ForegroundAdvancementStrategy,
 		MaxParallelQuantitySnapshots: 2,
-		TaxCodeService:               taxCodeService,
+		TaxCodeService:               deps.TaxCodeService,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
@coderabbitai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add-ons can now be filtered by tax code in listings.
  * Add-ons are validated against tax code references before publishing.
  * Tax codes now have deletion protection when they’re still used by add-ons (via rate cards).
* **Bug Fixes**
  * Deletion protection now reports clearer “referenced by rate cards” details (and can return multiple issues).
  * Prevents using soft-deleted tax codes during charge, plan, subscription, and profile/customer override flows.
* **Tests**
  * Expanded coverage for tax-code filtering and add-on–tax-code deletion protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends tax code deletion protection to add-ons (in addition to the existing plan hook), refactors `ResolveTaxConfig` to return a resolved clone instead of mutating its input, and adds `IncludeDeleted` control so continuity reads (invoice snapshotting, backfill) can still resolve soft-deleted codes while fresh references (plans, add-ons, billing profiles, subscriptions) are rejected.

- **New add-on pre-delete hook** (`addonhook.go`): before deleting a tax code, lists active/draft/archived/invalid add-ons that reference it via rate cards and returns `ErrTaxCodeReferencedByRateCard` for each match; mirrors the existing plan hook.
- **`ResolveTaxConfig` refactoring**: now returns `(*TaxConfig, error)` and all 7 call-sites have been updated to assign the returned value; soft-deleted IDs are rejected unless `IncludeDeleted: true` is passed.
- **Error code rename**: `\"tax_code_referenced_by_plan\"` → `\"tax_code_referenced_by_rate_card\"` (breaking change for consumers of the delete conflict response, but the error was introduced on the base branch `fix/tax-code-delete`, so production exposure is minimal).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the logic is correct, all ResolveTaxConfig callers assign the returned clone, nil-safety is guarded at every call-site, and the new addon hook follows the same proven pattern as the existing plan hook.

The ResolveTaxConfig refactoring (mutating → clone-and-return) is applied consistently across all seven call-sites. Continuity reads (invoice snapshotting, backfill) correctly set IncludeDeleted: true while fresh-input paths leave it false. The new addon pre-delete hook is well-structured, covers all four non-deleted addon statuses, and includes a defensive sanity check for DB/filter inconsistencies. Test coverage is thorough, with integration tests for the hook itself and for create/update/publish flows that reference deleted tax codes.

**Files Needing Attention:** No files require special attention. The wire_gen files for billing-worker and jobs intentionally omit the addon hook because those binaries do not expose a tax code deletion endpoint.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/taxcode/service/hooks/addonhook.go | New pre-delete hook: lists addons by tax code filter (page 5), iterates rate cards, and accumulates NewTaxCodeReferencedByRateCardError per matching rate card; sanity check detects DB/filter inconsistency; all four non-deleted statuses (including Invalid) are covered. |
| openmeter/productcatalog/tax.go | ResolveTaxConfig refactored to non-mutating: clones input, adds IncludeDeleted guard for soft-deleted tax codes, and returns *TaxConfig; nil-in/nil-out contract is preserved. |
| openmeter/taxcode/service/hooks/planhook.go | Updated to match the new per-rate-card error style; uses errors.Join for multiple plan phases, and adds the same DB/filter sanity check as the new addon hook. |
| openmeter/billing/service/invoiceupdate.go | Two call-sites updated: sanitizeTaxConfigForDiff (fresh client input, IncludeDeleted false, dereference is safe because Stripe.Code guard precedes it) and taxCodeIDWithBackfill (continuity read, IncludeDeleted true, nil guard at function top). |
| openmeter/billing/service/gatheringinvoicependinglines.go | Continuity read path (IncludeDeleted: true) correctly allows already-persisted but since-deleted default tax codes to resolve for invoice creation snapshots. |
| openmeter/productcatalog/addon/service/addon.go | resolveTaxCodes now assigns the returned clone to meta.TaxConfig before building rcNew; ValidateAddonWithTaxCodes validation added to PublishAddon to reject soft-deleted tax codes at publish time. |
| openmeter/taxcode/errors.go | Error code renamed from tax_code_referenced_by_plan to tax_code_referenced_by_rate_card; error message and attrs updated; IsTaxCodeReferencedByRateCardError predicate works correctly with errors.Join-wrapped errors via errors.As traversal. |
| app/common/taxcode.go | NewTaxCodeAddonServiceHook wires the addon hook and registers it on the taxcode service; same pattern as the plan hook; only the server binary gets the hook (billing-worker and jobs don't expose tax code deletion). |
| openmeter/taxcode/testutils/env.go | SetupNamespaceDefaults replaced by idempotent ProvisionDefaultTaxCodes (get-or-create by key); adds ProvisionProviderDefaultTaxCode for narrow cases; consolidates test helper logic previously duplicated across multiple test files. |

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant TaxCodeService
    participant PlanHook
    participant AddonHook
    participant PlanService
    participant AddonService

    Client->>TaxCodeService: DeleteTaxCode(id)
    TaxCodeService->>PlanHook: PreDelete(taxCode)
    PlanHook->>PlanService: "ListPlans(TaxCodes=[id], Status=[Active,Draft,Archived,Invalid], PageSize=5)"
    PlanService-->>PlanHook: affectedPlans
    loop each plan → phase → rateCard
        PlanHook->>PlanHook: "TaxCodeReference() == id?"
        PlanHook->>PlanHook: append NewTaxCodeReferencedByRateCardError
    end
    PlanHook-->>TaxCodeService: errors.Join(errs) or nil

    TaxCodeService->>AddonHook: PreDelete(taxCode)
    AddonHook->>AddonService: "ListAddons(TaxCodes=[id], Status=[Active,Draft,Archived,Invalid], PageSize=5)"
    AddonService-->>AddonHook: affectedAddons
    loop each addon → rateCard
        AddonHook->>AddonHook: "TaxCodeReference() == id?"
        AddonHook->>AddonHook: append NewTaxCodeReferencedByRateCardError
    end
    AddonHook-->>TaxCodeService: errors.Join(errs) or nil

    alt any hook returned error
        TaxCodeService-->>Client: 409 tax_code_referenced_by_rate_card
    else all hooks passed
        TaxCodeService->>TaxCodeService: soft-delete tax code
        TaxCodeService-->>Client: 200 OK
    end
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(taxcode): reject soft-deleted tax co..."](https://github.com/openmeterio/openmeter/commit/60e084bec8fd261425a137b4dc9201b70bbe0465) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39392592)</sub>

<!-- /greptile_comment -->