### PR TITLE
Add unitconfig to ratecard in domain layer - OM-393

### DIFF
--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -247,20 +247,24 @@ func (r RateCardMeta) Validate() error {
 
 	if r.TaxConfig != nil {
 		if err := r.TaxConfig.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("invalid tax config: %w",
+			errs = append(errs, fmt.Errorf(
+				"invalid tax config: %w",
 				models.ErrorWithFieldPrefix(
 					models.NewFieldSelectorGroup(models.NewFieldSelector("taxConfig")),
-					err),
+					err,
+				),
 			))
 		}
 	}
 
 	if r.Price != nil {
 		if err := r.Price.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("invalid price: %w",
+			errs = append(errs, fmt.Errorf(
+				"invalid price: %w",
 				models.ErrorWithFieldPrefix(
 					models.NewFieldSelectorGroup(models.NewFieldSelector("price")),
-					err),
+					err,
+				),
 			))
 		}
 
@@ -284,10 +288,12 @@ func (r RateCardMeta) Validate() error {
 
 	if r.UnitConfig != nil {
 		if err := r.UnitConfig.Validate(); err != nil {
-			errs = append(errs, fmt.Errorf("invalid unit config: %w",
+			errs = append(errs, fmt.Errorf(
+				"invalid unit config: %w",
 				models.ErrorWithFieldPrefix(
-					models.NewFieldSelectorGroup(models.NewFieldSelector("unitConfig")),
-					err),
+					models.NewFieldSelectorGroup(models.NewFieldSelector("unit_config")),
+					err,
+				),
 			))
 		}
 	}
@@ -680,7 +686,8 @@ func ValidateRateCards() models.ValidatorFunc[RateCards] {
 		for _, rateCard := range ratecards {
 			fieldSelector := models.NewFieldSelectorGroup(
 				models.NewFieldSelector("ratecards").WithExpression(
-					models.NewFieldAttrValue("key", rateCard.Key())),
+					models.NewFieldAttrValue("key", rateCard.Key()),
+				),
 			)
 
 			if _, ok := rateCardKeys[rateCard.Key()]; ok {

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -97,6 +97,11 @@ type RateCardMeta struct {
 
 	// Discounts defines a list of discounts for the RateCard
 	Discounts Discounts `json:"discounts,omitempty"`
+
+	// UnitConfig defines an optional per-rate-card conversion applied to the raw
+	// metered quantity before pricing and entitlement evaluation. Shared by plan
+	// and addon rate cards.
+	UnitConfig *UnitConfig `json:"unitConfig,omitempty"`
 }
 
 func (r RateCardMeta) HasFeature() bool {
@@ -162,6 +167,10 @@ func (r RateCardMeta) Clone() RateCardMeta {
 
 	clone.Discounts = r.Discounts.Clone()
 
+	if r.UnitConfig != nil {
+		clone.UnitConfig = lo.ToPtr(r.UnitConfig.Clone())
+	}
+
 	// TaxCode is an eagerly loaded reference, shallow copy is sufficient
 	clone.TaxCode = r.TaxCode
 
@@ -203,6 +212,10 @@ func (r RateCardMeta) Equal(v RateCardMeta) bool {
 	}
 
 	if !r.Discounts.Equal(v.Discounts) {
+		return false
+	}
+
+	if !r.UnitConfig.Equal(v.UnitConfig) {
 		return false
 	}
 
@@ -267,6 +280,16 @@ func (r RateCardMeta) Validate() error {
 
 	if err := r.Discounts.ValidateForPrice(r.Price); err != nil {
 		errs = append(errs, err)
+	}
+
+	if r.UnitConfig != nil {
+		if err := r.UnitConfig.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("invalid unit config: %w",
+				models.ErrorWithFieldPrefix(
+					models.NewFieldSelectorGroup(models.NewFieldSelector("unitConfig")),
+					err),
+			))
+		}
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/productcatalog/ratecard_test.go
+++ b/openmeter/productcatalog/ratecard_test.go
@@ -38,7 +38,8 @@ func TestFlatFeeRateCard(t *testing.T) {
 									"name": "static-1",
 								},
 								Config: []byte(`"test"`),
-							}),
+							},
+						),
 						TaxConfig: &TaxConfig{
 							Stripe: &StripeTaxConfig{
 								Code: "txcd_99999999",
@@ -83,7 +84,8 @@ func TestFlatFeeRateCard(t *testing.T) {
 									"name": "static-1",
 								},
 								Config: []byte("invalid JSON"),
-							}),
+							},
+						),
 						TaxConfig: &TaxConfig{
 							Stripe: &StripeTaxConfig{
 								Code: "invalid_code",
@@ -93,7 +95,8 @@ func TestFlatFeeRateCard(t *testing.T) {
 							FlatPrice{
 								Amount:      decimal.NewFromInt(-1000),
 								PaymentTerm: PaymentTermType("invalid"),
-							}),
+							},
+						),
 					},
 					BillingCadence: lo.ToPtr(datetime.MustParseDuration(t, "P0M")),
 				},
@@ -201,7 +204,8 @@ func TestUsageBasedRateCard(t *testing.T) {
 								IssueAfterResetPriority: lo.ToPtr[uint8](1),
 								PreserveOverageAtReset:  nil,
 								UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-							}),
+							},
+						),
 						TaxConfig: &TaxConfig{
 							Stripe: &StripeTaxConfig{
 								Code: "txcd_99999999",
@@ -214,7 +218,8 @@ func TestUsageBasedRateCard(t *testing.T) {
 									MinimumAmount: lo.ToPtr(decimal.NewFromInt(500)),
 									MaximumAmount: lo.ToPtr(decimal.NewFromInt(1500)),
 								},
-							}),
+							},
+						),
 					},
 					BillingCadence: datetime.MustParseDuration(t, "P1M"),
 				},
@@ -242,7 +247,8 @@ func TestUsageBasedRateCard(t *testing.T) {
 								IssueAfterResetPriority: lo.ToPtr[uint8](1),
 								PreserveOverageAtReset:  nil,
 								UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-							}),
+							},
+						),
 						TaxConfig: &TaxConfig{
 							Stripe: &StripeTaxConfig{
 								Code: "invalid_code",
@@ -255,7 +261,8 @@ func TestUsageBasedRateCard(t *testing.T) {
 									MinimumAmount: lo.ToPtr(decimal.NewFromInt(1500)),
 									MaximumAmount: lo.ToPtr(decimal.NewFromInt(500)),
 								},
-							}),
+							},
+						),
 					},
 					BillingCadence: datetime.MustParseDuration(t, "P0M"),
 				},
@@ -276,7 +283,8 @@ func TestUsageBasedRateCard(t *testing.T) {
 									MinimumAmount: lo.ToPtr(decimal.NewFromInt(500)),
 									MaximumAmount: lo.ToPtr(decimal.NewFromInt(1500)),
 								},
-							}),
+							},
+						),
 						Discounts: Discounts{
 							Percentage: &PercentageDiscount{
 								Percentage: models.NewPercentage(10),
@@ -301,7 +309,8 @@ func TestUsageBasedRateCard(t *testing.T) {
 						Price: NewPriceFrom(
 							FlatPrice{
 								Amount: decimal.NewFromInt(1000),
-							}),
+							},
+						),
 						Discounts: Discounts{
 							Percentage: &PercentageDiscount{
 								Percentage: models.NewPercentage(10),
@@ -398,7 +407,8 @@ func TestRateCardsEqual(t *testing.T) {
 									IssueAfterResetPriority: lo.ToPtr[uint8](1),
 									PreserveOverageAtReset:  nil,
 									UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-								}),
+								},
+							),
 							TaxConfig: &TaxConfig{
 								Stripe: &StripeTaxConfig{
 									Code: "txcd_99999999",
@@ -411,7 +421,8 @@ func TestRateCardsEqual(t *testing.T) {
 										MinimumAmount: lo.ToPtr(decimal.NewFromInt(500)),
 										MaximumAmount: lo.ToPtr(decimal.NewFromInt(1500)),
 									},
-								}),
+								},
+							),
 							Discounts: Discounts{
 								Percentage: &PercentageDiscount{
 									Percentage: models.NewPercentage(10),
@@ -445,7 +456,8 @@ func TestRateCardsEqual(t *testing.T) {
 									IssueAfterResetPriority: lo.ToPtr[uint8](1),
 									PreserveOverageAtReset:  nil,
 									UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-								}),
+								},
+							),
 							TaxConfig: &TaxConfig{
 								Stripe: &StripeTaxConfig{
 									Code: "txcd_99999999",
@@ -458,7 +470,8 @@ func TestRateCardsEqual(t *testing.T) {
 										MinimumAmount: lo.ToPtr(decimal.NewFromInt(500)),
 										MaximumAmount: lo.ToPtr(decimal.NewFromInt(1500)),
 									},
-								}),
+								},
+							),
 							Discounts: Discounts{
 								Percentage: &PercentageDiscount{
 									Percentage: models.NewPercentage(10),
@@ -496,7 +509,8 @@ func TestRateCardsEqual(t *testing.T) {
 									IssueAfterResetPriority: lo.ToPtr[uint8](1),
 									PreserveOverageAtReset:  nil,
 									UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-								}),
+								},
+							),
 							TaxConfig: &TaxConfig{
 								Stripe: &StripeTaxConfig{
 									Code: "txcd_99999999",
@@ -509,7 +523,8 @@ func TestRateCardsEqual(t *testing.T) {
 										MinimumAmount: lo.ToPtr(decimal.NewFromInt(500)),
 										MaximumAmount: lo.ToPtr(decimal.NewFromInt(1500)),
 									},
-								}),
+								},
+							),
 						},
 						BillingCadence: datetime.MustParseDuration(t, "P1M"),
 					},
@@ -531,7 +546,8 @@ func TestRateCardsEqual(t *testing.T) {
 										"name": "static-1",
 									},
 									Config: []byte(`"test"`),
-								}),
+								},
+							),
 							TaxConfig: &TaxConfig{
 								Stripe: &StripeTaxConfig{
 									Code: "txcd_99999999",
@@ -569,7 +585,8 @@ func TestRateCardsEqual(t *testing.T) {
 										MinimumAmount: lo.ToPtr(decimal.NewFromInt(500)),
 										MaximumAmount: lo.ToPtr(decimal.NewFromInt(1500)),
 									},
-								}),
+								},
+							),
 							Discounts: Discounts{
 								Percentage: &PercentageDiscount{
 									Percentage: models.NewPercentage(10),
@@ -600,7 +617,8 @@ func TestRateCardsEqual(t *testing.T) {
 										MinimumAmount: lo.ToPtr(decimal.NewFromInt(500)),
 										MaximumAmount: lo.ToPtr(decimal.NewFromInt(1500)),
 									},
-								}),
+								},
+							),
 							Discounts: Discounts{
 								Usage: &UsageDiscount{
 									Quantity: decimal.NewFromInt(100),
@@ -851,7 +869,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							IssueAfterResetPriority: lo.ToPtr[uint8](1),
 							PreserveOverageAtReset:  lo.ToPtr(false),
 							UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-						}),
+						},
+					),
 				},
 				BillingCadence: datetime.MustParseDuration(t, "P1M"),
 			},
@@ -873,7 +892,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							IssueAfterResetPriority: lo.ToPtr[uint8](3),
 							PreserveOverageAtReset:  lo.ToPtr(true),
 							UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-						}),
+						},
+					),
 				},
 				BillingCadence: datetime.MustParseDuration(t, "P1M"),
 			},
@@ -899,7 +919,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							IssueAfterResetPriority: lo.ToPtr[uint8](1),
 							PreserveOverageAtReset:  lo.ToPtr(false),
 							UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-						}),
+						},
+					),
 				},
 				BillingCadence: datetime.MustParseDuration(t, "P1M"),
 			},
@@ -924,7 +945,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							IssueAfterResetPriority: lo.ToPtr[uint8](3),
 							PreserveOverageAtReset:  lo.ToPtr(true),
 							UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-						}),
+						},
+					),
 				},
 				BillingCadence: datetime.MustParseDuration(t, "P1M"),
 			},
@@ -950,7 +972,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							IssueAfterResetPriority: lo.ToPtr[uint8](3),
 							PreserveOverageAtReset:  lo.ToPtr(true),
 							UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-						}),
+						},
+					),
 				},
 				BillingCadence: lo.ToPtr(datetime.MustParseDuration(t, "P1M")),
 			},
@@ -972,7 +995,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							IssueAfterResetPriority: lo.ToPtr[uint8](3),
 							PreserveOverageAtReset:  lo.ToPtr(true),
 							UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-						}),
+						},
+					),
 				},
 				BillingCadence: datetime.MustParseDuration(t, "P1M"),
 			},
@@ -998,7 +1022,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							IssueAfterResetPriority: lo.ToPtr[uint8](3),
 							PreserveOverageAtReset:  lo.ToPtr(true),
 							UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-						}),
+						},
+					),
 				},
 				BillingCadence: lo.ToPtr(datetime.MustParseDuration(t, "P1M")),
 			},
@@ -1020,7 +1045,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							IssueAfterResetPriority: lo.ToPtr[uint8](3),
 							PreserveOverageAtReset:  lo.ToPtr(true),
 							UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-						}),
+						},
+					),
 				},
 				BillingCadence: datetime.MustParseDuration(t, "P1M"),
 			},
@@ -1046,7 +1072,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							IssueAfterResetPriority: lo.ToPtr[uint8](3),
 							PreserveOverageAtReset:  lo.ToPtr(true),
 							UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-						}),
+						},
+					),
 				},
 				BillingCadence: lo.ToPtr(datetime.MustParseDuration(t, "P3M")),
 			},
@@ -1068,7 +1095,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							IssueAfterResetPriority: lo.ToPtr[uint8](3),
 							PreserveOverageAtReset:  lo.ToPtr(true),
 							UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-						}),
+						},
+					),
 				},
 				BillingCadence: datetime.MustParseDuration(t, "P1M"),
 			},
@@ -1094,7 +1122,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							IssueAfterResetPriority: lo.ToPtr[uint8](3),
 							PreserveOverageAtReset:  lo.ToPtr(true),
 							UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-						}),
+						},
+					),
 				},
 				BillingCadence: lo.ToPtr(datetime.MustParseDuration(t, "P1M")),
 			},
@@ -1111,7 +1140,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							Metadata: map[string]string{
 								"name": "metered-1",
 							},
-						}),
+						},
+					),
 				},
 				BillingCadence: datetime.MustParseDuration(t, "P1M"),
 			},
@@ -1137,7 +1167,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							IssueAfterResetPriority: lo.ToPtr[uint8](3),
 							PreserveOverageAtReset:  lo.ToPtr(true),
 							UsagePeriod:             datetime.MustParseDuration(t, "P1M"),
-						}),
+						},
+					),
 				},
 				BillingCadence: lo.ToPtr(datetime.MustParseDuration(t, "P1M")),
 			},
@@ -1159,7 +1190,8 @@ func TestRateCardsCompatible(t *testing.T) {
 							IssueAfterResetPriority: lo.ToPtr[uint8](3),
 							PreserveOverageAtReset:  lo.ToPtr(true),
 							UsagePeriod:             datetime.MustParseDuration(t, "P3M"),
-						}),
+						},
+					),
 				},
 				BillingCadence: datetime.MustParseDuration(t, "P1M"),
 			},
@@ -1181,4 +1213,68 @@ func TestRateCardsCompatible(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRateCardMetaUnitConfig(t *testing.T) {
+	withUnitConfig := func(uc *UnitConfig) RateCardMeta {
+		return RateCardMeta{
+			Key:        "feat-1",
+			Name:       "Usage 1",
+			UnitConfig: uc,
+		}
+	}
+
+	t.Run("Clone deep-copies UnitConfig", func(t *testing.T) {
+		original := withUnitConfig(&UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			DisplayUnit:      lo.ToPtr("GB"),
+		})
+
+		clone := original.Clone()
+		assert.True(t, original.Equal(clone))
+
+		// Mutating the clone must not affect the original.
+		*clone.UnitConfig.DisplayUnit = "MB"
+		assert.Equal(t, "GB", *original.UnitConfig.DisplayUnit)
+	})
+
+	t.Run("Equal", func(t *testing.T) {
+		uc := func() *UnitConfig {
+			return &UnitConfig{Operation: UnitConfigOperationDivide, ConversionFactor: decimal.NewFromInt(1000)}
+		}
+
+		// both nil → equal
+		assert.True(t, withUnitConfig(nil).Equal(withUnitConfig(nil)))
+
+		// equal configs → equal
+		assert.True(t, withUnitConfig(uc()).Equal(withUnitConfig(uc())))
+
+		// differs only by UnitConfig presence → not equal
+		assert.False(t, withUnitConfig(uc()).Equal(withUnitConfig(nil)))
+
+		// differs only by UnitConfig value → not equal
+		other := uc()
+		other.ConversionFactor = decimal.NewFromInt(2000)
+		assert.False(t, withUnitConfig(uc()).Equal(withUnitConfig(other)))
+	})
+
+	t.Run("Validate reports nested failures under the unit_config path", func(t *testing.T) {
+		invalid := withUnitConfig(&UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(0), // must be > 0
+		})
+
+		err := invalid.Validate()
+		assert.Error(t, err)
+		// The field prefix is the "unit_config" selector (the v3 wire name),
+		// distinct from the "invalid unit config" message text.
+		assert.Contains(t, err.Error(), "unit_config")
+
+		valid := withUnitConfig(&UnitConfig{
+			Operation:        UnitConfigOperationMultiply,
+			ConversionFactor: decimal.NewFromFloat(1.5),
+		})
+		assert.NoError(t, valid.Validate())
+	})
 }

--- a/openmeter/productcatalog/unitconfig.go
+++ b/openmeter/productcatalog/unitconfig.go
@@ -149,12 +149,16 @@ func (c *UnitConfig) Equal(v *UnitConfig) bool {
 		return false
 	}
 
-	if !c.Rounding.IsNone() && c.Rounding != v.Rounding {
-		return false
-	}
+	// When rounding is none, both the mode value and Precision are inert
+	// (Apply and Validate ignore them), so they are not part of equality.
+	if !c.Rounding.IsNone() {
+		if c.Rounding != v.Rounding {
+			return false
+		}
 
-	if c.Precision != v.Precision {
-		return false
+		if c.Precision != v.Precision {
+			return false
+		}
 	}
 
 	if lo.FromPtr(c.DisplayUnit) != lo.FromPtr(v.DisplayUnit) {

--- a/openmeter/productcatalog/unitconfig.go
+++ b/openmeter/productcatalog/unitconfig.go
@@ -1,0 +1,228 @@
+package productcatalog
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	decimal "github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+const (
+	UnitConfigOperationMultiply UnitConfigOperation = "multiply"
+	UnitConfigOperationDivide   UnitConfigOperation = "divide"
+)
+
+type UnitConfigOperation string
+
+func (o UnitConfigOperation) Values() []string {
+	return []string{
+		string(UnitConfigOperationMultiply),
+		string(UnitConfigOperationDivide),
+	}
+}
+
+func (o UnitConfigOperation) Validate() error {
+	if !slices.Contains(o.Values(), string(o)) {
+		return fmt.Errorf("invalid unit config operation: %s", o)
+	}
+
+	return nil
+}
+
+const (
+	UnitConfigRoundingModeNone    UnitConfigRoundingMode = "none"
+	UnitConfigRoundingModeCeiling UnitConfigRoundingMode = "ceiling"
+	UnitConfigRoundingModeFloor   UnitConfigRoundingMode = "floor"
+	UnitConfigRoundingModeHalfUp  UnitConfigRoundingMode = "half_up"
+)
+
+type UnitConfigRoundingMode string
+
+func (r UnitConfigRoundingMode) Values() []string {
+	return []string{
+		string(UnitConfigRoundingModeNone),
+		string(UnitConfigRoundingModeCeiling),
+		string(UnitConfigRoundingModeFloor),
+		string(UnitConfigRoundingModeHalfUp),
+	}
+}
+
+// IsNone reports whether the mode applies no rounding. The empty string is the
+// zero value of the field and is treated as the default, "none".
+func (r UnitConfigRoundingMode) IsNone() bool {
+	return r == "" || r == UnitConfigRoundingModeNone
+}
+
+func (r UnitConfigRoundingMode) Validate() error {
+	// The empty string is the field's zero value and means the default ("none").
+	if r == "" {
+		return nil
+	}
+
+	if !slices.Contains(r.Values(), string(r)) {
+		return fmt.Errorf("invalid unit config rounding mode: %s", r)
+	}
+
+	return nil
+}
+
+// UnitConfig transforms a raw metered quantity into a billing quantity before
+// pricing and entitlement evaluation. It is a self-contained domain DTO with no
+// dependency on the persistence layer — persistence maps to/from it.
+//
+// Rounding and Precision are value types with sensible defaults (no rounding,
+// zero decimal places); only DisplayUnit is optional and pointer-typed.
+type UnitConfig struct {
+	// Operation is the arithmetic conversion to apply: multiply or divide.
+	Operation UnitConfigOperation `json:"operation"`
+
+	// ConversionFactor is the positive non-zero factor used by Operation. Full
+	// precision is retained; the factor is never capped.
+	ConversionFactor decimal.Decimal `json:"conversionFactor"`
+
+	// Rounding controls how the converted quantity is rounded for invoicing.
+	// Defaults to "none". Entitlement balance checks always use the unrounded
+	// (converted) value, never the rounded one.
+	Rounding UnitConfigRoundingMode `json:"rounding,omitempty"`
+
+	// Precision is the number of decimal places retained when rounding. It is
+	// only meaningful when Rounding is set to a value other than "none"; it is
+	// ignored otherwise. Defaults to 0 (whole units).
+	Precision int `json:"precision,omitempty"`
+
+	// DisplayUnit is a human-readable label for the converted unit shown on
+	// invoices and the customer portal (e.g. "GB", "hours").
+	DisplayUnit *string `json:"displayUnit,omitempty"`
+}
+
+func (c *UnitConfig) Validate() error {
+	if c == nil {
+		return nil
+	}
+
+	var errs []error
+
+	if err := c.Operation.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	if c.ConversionFactor.Sign() <= 0 {
+		errs = append(errs, errors.New("conversion_factor must be greater than zero"))
+	}
+
+	if err := c.Rounding.Validate(); err != nil {
+		errs = append(errs, err)
+	}
+
+	// Precision is ignored when no rounding is applied, so only enforce it when
+	// rounding is active.
+	if !c.Rounding.IsNone() && c.Precision < 0 {
+		errs = append(errs, errors.New("precision must not be negative"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func (c *UnitConfig) Equal(v *UnitConfig) bool {
+	if c == nil && v == nil {
+		return true
+	}
+
+	if c == nil || v == nil {
+		return false
+	}
+
+	if c.Operation != v.Operation {
+		return false
+	}
+
+	if !c.ConversionFactor.Equal(v.ConversionFactor) {
+		return false
+	}
+
+	// Treat the empty zero value and the explicit "none" as the same mode.
+	if c.Rounding.IsNone() != v.Rounding.IsNone() {
+		return false
+	}
+
+	if !c.Rounding.IsNone() && c.Rounding != v.Rounding {
+		return false
+	}
+
+	if c.Precision != v.Precision {
+		return false
+	}
+
+	if lo.FromPtr(c.DisplayUnit) != lo.FromPtr(v.DisplayUnit) {
+		return false
+	}
+
+	return true
+}
+
+// Apply transforms a raw metered quantity into the converted (precise) and
+// invoiced (rounded) billing quantities.
+//
+//   - converted: raw with the operation × conversion_factor applied. Used for
+//     entitlement balance checks, which always see the precise value.
+//   - invoiced: converted with the configured rounding/precision applied. Used
+//     as the line quantity at billing time. Equal to converted when no rounding
+//     is set.
+//
+// When c is nil, both return values equal raw. Callers must have already run
+// Validate so the operation and rounding enums are known values; an
+// unrecognized operation or rounding mode falls back to identity rather than
+// panicking mid-billing.
+func (c *UnitConfig) Apply(raw decimal.Decimal) (converted, invoiced decimal.Decimal) {
+	if c == nil {
+		return raw, raw
+	}
+
+	switch c.Operation {
+	case UnitConfigOperationMultiply:
+		converted = raw.Mul(c.ConversionFactor)
+	case UnitConfigOperationDivide:
+		converted = raw.Div(c.ConversionFactor)
+	default:
+		return raw, raw
+	}
+
+	invoiced = converted
+
+	places := int32(c.Precision)
+
+	switch c.Rounding {
+	case UnitConfigRoundingModeCeiling:
+		invoiced = converted.RoundCeil(places)
+	case UnitConfigRoundingModeFloor:
+		invoiced = converted.RoundFloor(places)
+	case UnitConfigRoundingModeHalfUp:
+		// Round rounds half away from zero (2.5 → 3, −2.5 → −3).
+		invoiced = converted.Round(places)
+	case UnitConfigRoundingModeNone, "":
+		// No rounding: invoiced stays equal to converted.
+	default:
+		// Unknown mode: identity. Validate rejects it before billing.
+	}
+
+	return converted, invoiced
+}
+
+func (c UnitConfig) Clone() UnitConfig {
+	out := UnitConfig{
+		Operation:        c.Operation,
+		ConversionFactor: c.ConversionFactor.Copy(),
+		Rounding:         c.Rounding,
+		Precision:        c.Precision,
+	}
+
+	if c.DisplayUnit != nil {
+		out.DisplayUnit = lo.ToPtr(*c.DisplayUnit)
+	}
+
+	return out
+}

--- a/openmeter/productcatalog/unitconfig_test.go
+++ b/openmeter/productcatalog/unitconfig_test.go
@@ -1,0 +1,311 @@
+package productcatalog
+
+import (
+	"testing"
+
+	decimal "github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnitConfigApply(t *testing.T) {
+	t.Run("nil receiver is identity", func(t *testing.T) {
+		var c *UnitConfig
+		raw := decimal.NewFromInt(1247)
+
+		converted, invoiced := c.Apply(raw)
+		assert.Equal(t, raw.InexactFloat64(), converted.InexactFloat64())
+		assert.Equal(t, raw.InexactFloat64(), invoiced.InexactFloat64())
+	})
+
+	t.Run("unknown operation is identity (never panics mid-billing)", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        "bogus",
+			ConversionFactor: decimal.NewFromInt(1000),
+		}
+		raw := decimal.NewFromInt(1247)
+
+		converted, invoiced := c.Apply(raw)
+		assert.Equal(t, float64(1247), converted.InexactFloat64())
+		assert.Equal(t, float64(1247), invoiced.InexactFloat64())
+	})
+
+	t.Run("multiply without rounding produces precise converted", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationMultiply,
+			ConversionFactor: decimal.NewFromFloat(1.5),
+		}
+
+		converted, invoiced := c.Apply(decimal.NewFromFloat(4.2))
+		assert.Equal(t, 6.3, converted.InexactFloat64())
+		assert.Equal(t, converted.InexactFloat64(), invoiced.InexactFloat64(), "no rounding → invoiced equals converted")
+	})
+
+	t.Run("divide without rounding produces precise converted", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+		}
+
+		converted, invoiced := c.Apply(decimal.NewFromInt(1247))
+		assert.Equal(t, 1.247, converted.InexactFloat64())
+		assert.Equal(t, converted.InexactFloat64(), invoiced.InexactFloat64())
+	})
+
+	t.Run("ceiling rounds up, converted stays precise (package-style)", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			Rounding:         UnitConfigRoundingModeCeiling,
+		}
+
+		converted, invoiced := c.Apply(decimal.NewFromInt(1247))
+		assert.Equal(t, 1.247, converted.InexactFloat64(), "converted stays precise")
+		assert.Equal(t, float64(2), invoiced.InexactFloat64(), "invoiced rounds up")
+
+		// exact boundary and zero
+		_, exact := c.Apply(decimal.NewFromInt(1000))
+		assert.Equal(t, float64(1), exact.InexactFloat64())
+
+		_, zero := c.Apply(decimal.NewFromInt(0))
+		assert.Equal(t, float64(0), zero.InexactFloat64())
+	})
+
+	t.Run("floor rounds down (incomplete unit)", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			Rounding:         UnitConfigRoundingModeFloor,
+		}
+
+		_, invoiced := c.Apply(decimal.NewFromInt(1999))
+		assert.Equal(t, float64(1), invoiced.InexactFloat64())
+	})
+
+	t.Run("half_up rounds to nearest, ties away from zero", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			Rounding:         UnitConfigRoundingModeHalfUp,
+		}
+
+		// 2.4 → 2, 2.5 → 3 (tie up), 2.6 → 3, 3.5 → 4 (tie up)
+		_, down := c.Apply(decimal.NewFromInt(2400))
+		assert.Equal(t, float64(2), down.InexactFloat64())
+
+		_, tie := c.Apply(decimal.NewFromInt(2500))
+		assert.Equal(t, float64(3), tie.InexactFloat64(), "exact tie rounds away from zero")
+
+		_, up := c.Apply(decimal.NewFromInt(2600))
+		assert.Equal(t, float64(3), up.InexactFloat64())
+
+		_, tie2 := c.Apply(decimal.NewFromInt(3500))
+		assert.Equal(t, float64(4), tie2.InexactFloat64())
+	})
+
+	// Only negatives prove "away from zero" rather than "toward +∞"; spec matches
+	// Java RoundingMode.HALF_UP / Python ROUND_HALF_UP.
+	t.Run("half_up tie is away from zero for negatives", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			Rounding:         UnitConfigRoundingModeHalfUp,
+		}
+
+		_, invoiced := c.Apply(decimal.NewFromInt(-2500))
+		assert.Equal(t, float64(-3), invoiced.InexactFloat64(), "−2.5 → −3, not −2")
+	})
+
+	t.Run("precision moves where the tie is evaluated", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(100),
+			Rounding:         UnitConfigRoundingModeHalfUp,
+			Precision:        1,
+		}
+
+		// 245/100 = 2.45 → 2.5 (tie at 2nd dp → up)
+		_, tie := c.Apply(decimal.NewFromInt(245))
+		assert.Equal(t, 2.5, tie.InexactFloat64())
+
+		// 244/100 = 2.44 → 2.4
+		_, near := c.Apply(decimal.NewFromInt(244))
+		assert.Equal(t, 2.4, near.InexactFloat64())
+	})
+
+	t.Run("ceiling with precision retains decimal places", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			Rounding:         UnitConfigRoundingModeCeiling,
+			Precision:        2,
+		}
+
+		_, invoiced := c.Apply(decimal.NewFromInt(1247))
+		assert.Equal(t, 1.25, invoiced.InexactFloat64(), "1.247 ceil to 2dp")
+	})
+
+	t.Run("rounding none and empty leave converted intact", func(t *testing.T) {
+		for _, mode := range []UnitConfigRoundingMode{UnitConfigRoundingModeNone, ""} {
+			c := &UnitConfig{
+				Operation:        UnitConfigOperationDivide,
+				ConversionFactor: decimal.NewFromInt(1000),
+				Rounding:         mode,
+			}
+
+			converted, invoiced := c.Apply(decimal.NewFromInt(1247))
+			assert.Equal(t, converted.InexactFloat64(), invoiced.InexactFloat64(), "mode %q", mode)
+		}
+	})
+}
+
+func TestUnitConfigValidate(t *testing.T) {
+	t.Run("nil is valid", func(t *testing.T) {
+		var c *UnitConfig
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("valid config", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			Rounding:         UnitConfigRoundingModeCeiling,
+			Precision:        2,
+		}
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("valid with defaults (empty rounding, zero precision)", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationMultiply,
+			ConversionFactor: decimal.NewFromFloat(1.5),
+		}
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("invalid operation", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        "bogus",
+			ConversionFactor: decimal.NewFromInt(1000),
+		}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("conversion_factor must be greater than zero", func(t *testing.T) {
+		zero := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(0),
+		}
+		require.Error(t, zero.Validate())
+
+		negative := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(-5),
+		}
+		require.Error(t, negative.Validate())
+	})
+
+	t.Run("invalid rounding mode", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			Rounding:         "bogus",
+		}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("negative precision is rejected when rounding is active", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			Rounding:         UnitConfigRoundingModeCeiling,
+			Precision:        -1,
+		}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("negative precision is ignored when rounding is none", func(t *testing.T) {
+		c := &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			Rounding:         UnitConfigRoundingModeNone,
+			Precision:        -1,
+		}
+		require.NoError(t, c.Validate())
+	})
+}
+
+func TestUnitConfigEqual(t *testing.T) {
+	base := func() *UnitConfig {
+		return &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			Rounding:         UnitConfigRoundingModeCeiling,
+			Precision:        2,
+			DisplayUnit:      lo.ToPtr("GB"),
+		}
+	}
+
+	t.Run("both nil", func(t *testing.T) {
+		var a, b *UnitConfig
+		assert.True(t, a.Equal(b))
+	})
+
+	t.Run("one nil", func(t *testing.T) {
+		assert.False(t, base().Equal(nil))
+		assert.False(t, (*UnitConfig)(nil).Equal(base()))
+	})
+
+	t.Run("equal", func(t *testing.T) {
+		assert.True(t, base().Equal(base()))
+	})
+
+	t.Run("empty rounding equals explicit none", func(t *testing.T) {
+		a := &UnitConfig{Operation: UnitConfigOperationDivide, ConversionFactor: decimal.NewFromInt(1000)}
+		b := &UnitConfig{Operation: UnitConfigOperationDivide, ConversionFactor: decimal.NewFromInt(1000), Rounding: UnitConfigRoundingModeNone}
+		assert.True(t, a.Equal(b))
+	})
+
+	t.Run("differs by each field", func(t *testing.T) {
+		differ := base()
+		differ.Operation = UnitConfigOperationMultiply
+		assert.False(t, base().Equal(differ))
+
+		differ = base()
+		differ.ConversionFactor = decimal.NewFromInt(2000)
+		assert.False(t, base().Equal(differ))
+
+		differ = base()
+		differ.Rounding = UnitConfigRoundingModeFloor
+		assert.False(t, base().Equal(differ))
+
+		differ = base()
+		differ.Precision = 3
+		assert.False(t, base().Equal(differ))
+
+		differ = base()
+		differ.DisplayUnit = lo.ToPtr("MB")
+		assert.False(t, base().Equal(differ))
+	})
+}
+
+func TestUnitConfigClone(t *testing.T) {
+	original := &UnitConfig{
+		Operation:        UnitConfigOperationDivide,
+		ConversionFactor: decimal.NewFromInt(1000),
+		Rounding:         UnitConfigRoundingModeCeiling,
+		Precision:        2,
+		DisplayUnit:      lo.ToPtr("GB"),
+	}
+
+	clone := original.Clone()
+	assert.True(t, original.Equal(&clone))
+
+	// Mutating the clone's DisplayUnit must not affect the original (deep copy).
+	*clone.DisplayUnit = "MB"
+	assert.Equal(t, "GB", *original.DisplayUnit)
+
+	clone.DisplayUnit = nil
+	assert.NotNil(t, original.DisplayUnit)
+}

--- a/openmeter/productcatalog/unitconfig_test.go
+++ b/openmeter/productcatalog/unitconfig_test.go
@@ -267,6 +267,14 @@ func TestUnitConfigEqual(t *testing.T) {
 		assert.True(t, a.Equal(b))
 	})
 
+	t.Run("precision is inert when rounding is none", func(t *testing.T) {
+		// Apply and Validate ignore Precision when rounding is none, so differing
+		// precision must not make two behaviorally identical configs unequal.
+		a := &UnitConfig{Operation: UnitConfigOperationDivide, ConversionFactor: decimal.NewFromInt(1000), Rounding: UnitConfigRoundingModeNone, Precision: 0}
+		b := &UnitConfig{Operation: UnitConfigOperationDivide, ConversionFactor: decimal.NewFromInt(1000), Rounding: UnitConfigRoundingModeNone, Precision: 5}
+		assert.True(t, a.Equal(b))
+	})
+
 	t.Run("differs by each field", func(t *testing.T) {
 		differ := base()
 		differ.Operation = UnitConfigOperationMultiply


### PR DESCRIPTION
## Overview

Added `UnitConfig` to `RateCardMeta` in preparation for the next phase, persisting it. This change should be pretty low risk as:

- it is additive only even with the change being on the `RateCardMeta`
- no surface moved as persisting it will be the next ticket and there is no api wiring or typespec change
- no behavior change if the unit config field is nil




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-rate-card unit conversion configuration (multiply/divide) with configurable rounding mode, precision, and display unit.
  * Rate card calculations can now produce both converted and invoiced quantities, applying rounding/precision when configured.

* **Bug Fixes**
  * Improved unit conversion handling for cloning, equality comparisons, and validation error reporting (including unit-config field paths).

* **Tests**
  * Added coverage for unit conversion apply/validate/equality/clone, plus rate card metadata behavior and deep-copy semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->