### PR TITLE
feat: add charge intent override layering

### DIFF
--- a/.agents/skills/billing/SKILL.md
+++ b/.agents/skills/billing/SKILL.md
@@ -427,6 +427,8 @@ See `references/subscription-sync.md` for full details. Key concepts:
 2. **Target state** — compute what lines *should* exist (phase iterator + billing cadence)
 3. **Reconciler** — diff (new / delete / upsert) + apply patches
 
+For charge-backed subscription sync state, subscription sync owns the base/source intent, not the customer-facing effective override layer. When comparing, sorting, repairing, or asserting charge-backed persisted state, use `GetBaseIntent()` or cached base intents from persisted-state wrappers. Reserve effective intent getters for API/ledger/customer-facing behavior where user overrides should be visible.
+
 **Line identification**: every line has a `ChildUniqueReferenceID`:
 ```
 {subscriptionID}/{phaseKey}/{itemKey}/v[{version}]/period[{periodIndex}]

--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -70,7 +70,8 @@ Important types:
 - `charges.AdvanceChargesInput` identifies the customer whose charges should advance
 - `meta.Charge` and `meta.ChargeID` define the shared charge identity and type
 - `charges.Charge` wraps concrete charge variants
-- `flatfee.Intent` carries `AmountBeforeProration`, `ProRating`, `SettlementMode`, `PaymentTerm`, `InvoiceAt` — immutable inputs provided by the caller
+- `flatfee.OverridableIntent` carries the immutable flat-fee intent plus base and optional override mutable layers. Use accessors instead of reading layer fields directly unless the caller explicitly owns the base layer.
+- `flatfee.Intent` is the concrete base/effective intent shape used when creating or cloning a flat-fee intent. `Intent.AsOverridableIntent()` maps it into the base layer.
 - `flatfee.ChargeBase` stores the persisted flat-fee charge row: current `Status` plus durable `State`
 - `flatfee.State` currently tracks:
   - `AmountAfterProration`
@@ -83,7 +84,8 @@ Important types:
   - `DetailedLines`
 - `flatfee.Intent.CalculateAmountAfterProration()` computes the prorated amount from `AmountBeforeProration`, `ServicePeriod/FullServicePeriod` ratio, and `ProRating` config, with currency-precision rounding
 - Charge-backed targets do not use invoice-style semantic proration or empty-period filtering; the charge stack materializes and prorates state itself, and the flat fee charge is responsible for omitting empty lines
-- `usagebased.Intent` carries `FeatureKey`, `Price`, `SettlementMode`, `InvoiceAt`, and `ServicePeriod`
+- `usagebased.OverridableIntent` carries the immutable usage-based intent plus base and optional override mutable layers. Use accessors instead of reading layer fields directly unless the caller explicitly owns the base layer.
+- `usagebased.Intent` is the concrete base/effective intent shape used when creating or cloning a usage-based intent. `Intent.AsOverridableIntent()` maps it into the base layer.
 - `usagebased.ChargeBase` stores the current `Status` and `State`
 - `usagebased.State` currently tracks:
   - `CurrentRealizationRunID`
@@ -106,6 +108,13 @@ Intent deletion rules:
 - Flat-fee and usage-based intent overrides are type-owned domain objects stored in dedicated one-to-one override tables. Override presence is represented by the override row existing. The older embedded `override_*` charge columns are compatibility/deprecated fields and should not be used for active override behavior.
 - Delete flows should first update the right intent deletion field, then resolve `charge.DeletedAt` from the aggregate (`GetIntentDeletedAt()`), and then persist the type-specific row plus charge meta.
 - Credit-purchase charges do not participate in intent override deletion semantics; do not add `IntentDeletedAt` fields or persistence to credit-purchase paths.
+
+Intent layer access rules:
+
+- Customer-facing charge behavior should read the effective layer through dedicated `OverridableIntent` accessors such as `GetEffectiveServicePeriod()`, `GetEffectiveInvoiceAt()`, `GetEffectiveTaxConfig()`, `GetEffectiveFeatureKey()`, `GetEffectivePrice()`, or `GetEffectiveMetaIntentMutableFields()`.
+- Prefer field-specific effective getters over `GetEffectiveIntent()` when only a few fields are needed. `GetEffectiveIntent()` clones and assembles a full intent, so it is useful at mapping boundaries but too broad for hot lifecycle checks.
+- Subscription sync and repair code targets subscription-owned source state. It should use `GetBaseIntent()` or base-specific helpers, not effective getters, so user/API overrides do not feed back into the subscription target state.
+- Adapter writes should persist the base intent with `GetBaseIntent()` and persist override fields only through the override-specific adapter paths. Do not derive base persistence values from effective intent accessors.
 
 ## Usage-Based Invoice Line Mapping
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -28,6 +28,17 @@ reviews:
 
         Performance should be a priority in critical code paths. Anything related to event ingestion, message processing, database operations (regardless of database) should be vetted for potential performance bottlenecks.
 
+        Do not report findings based only on learned facts or prior review memory. Re-verify the claim against the current code and domain model. If the evidence is not present in the diff or reachable current code, omit the finding.
+
+        Do not post actionable comments for known gaps that are already captured by nearby TODO comments in the changed code. Treat those as intentionally documented follow-up work unless the current diff makes the TODO incorrect, stale, or materially worse.
+
+        Avoid outside-diff comments unless they identify a concrete correctness issue introduced by this PR and not already documented in the nearby code. Do not turn existing TODOs or future roadmap items into review findings.
+    - path: "openmeter/billing/charges/flatfee/**"
+      instructions: |
+        Do not flag `AdvanceAfter` usage in flat-fee charge metadata updates as unsupported. Flat-fee charges participate in lifecycle scheduling through shared charge metadata.
+
+        Only flag `AdvanceAfter` if the specific code path demonstrably persists an invalid value or violates an explicit flat-fee domain invariant in the current diff.
+
     - path: "**/*.tsp"
       instructions: |
         Review the TypeSpec code for conformity with TypeSpec best practices. When recommending changes also consider the fact that multiple codegeneration toolchains depend on the TypeSpec code, each of which have their idiosyncrasies and bugs.
@@ -37,6 +48,8 @@ reviews:
       instructions: |
         Make sure the tests are comprehensive and cover the changes. Keep a strong focus on unit tests and in-code integration tests.
         When appropriate, recommend e2e tests for critical changes.
+
+        Do not request additional tests only because a helper or fixture could also cover an override/base-layer variant. Suggest missing tests only when the PR introduces behavior without meaningful coverage, or when the current tests would pass despite a concrete regression in the changed code.
     - path: "**/*.md"
       instructions: |
         "Assess the documentation for misspellings, grammatical errors, missing documentation and correctness"

--- a/api/v3/handlers/customers/charges/convert.go
+++ b/api/v3/handlers/customers/charges/convert.go
@@ -28,9 +28,14 @@ var ConvertMetadataToLabels = labels.FromMetadata[models.Metadata]
 
 // convertFlatFeeChargeToAPI maps a flatfee.Charge to the API representation.
 func convertFlatFeeChargeToAPI(source flatfee.Charge) (api.BillingFlatFeeCharge, error) {
+	// TODO: when the base intent is not manually managed, expose the system/base
+	// state too so API clients can see what the charge would look like without
+	// the customer-facing override.
+	intent := source.ChargeBase.Intent.GetEffectiveIntent()
+
 	var price api.BillingPrice
 	if err := price.FromBillingPriceFlat(api.BillingPriceFlat{
-		Amount: source.ChargeBase.Intent.BaseLayer.AmountBeforeProration.String(),
+		Amount: intent.AmountBeforeProration.String(),
 		Type:   api.BillingPriceFlatTypeFlat,
 	}); err != nil {
 		return api.BillingFlatFeeCharge{}, fmt.Errorf("setting flat fee price union: %w", err)
@@ -39,30 +44,30 @@ func convertFlatFeeChargeToAPI(source flatfee.Charge) (api.BillingFlatFeeCharge,
 	return api.BillingFlatFeeCharge{
 		AdvanceAfter:           source.State.AdvanceAfter,
 		AmountAfterProration:   ConvertDecimalToCurrencyAmount(source.ChargeBase.State.AmountAfterProration),
-		BillingPeriod:          ConvertClosedPeriodToAPI(source.ChargeBase.Intent.BaseLayer.BillingPeriod),
+		BillingPeriod:          ConvertClosedPeriodToAPI(intent.BillingPeriod),
 		CreatedAt:              source.ChargeBase.ManagedResource.ManagedModel.CreatedAt,
-		Currency:               ConvertCurrencyCodeToAPI(source.ChargeBase.Intent.Intent.Currency),
-		Customer:               ConvertCustomerIDToReference(source.ChargeBase.Intent.Intent.CustomerID),
+		Currency:               ConvertCurrencyCodeToAPI(source.ChargeBase.Intent.GetCurrency()),
+		Customer:               ConvertCustomerIDToReference(source.ChargeBase.Intent.GetCustomerID()),
 		DeletedAt:              source.ChargeBase.ManagedResource.ManagedModel.DeletedAt,
-		Description:            source.ChargeBase.Intent.BaseLayer.Description,
-		Discounts:              convertFlatFeeDiscounts(source.Intent.BaseLayer.PercentageDiscounts),
-		FeatureKey:             lo.ToPtr(source.ChargeBase.Intent.BaseLayer.FeatureKey),
-		FullServicePeriod:      ConvertClosedPeriodToAPI(source.ChargeBase.Intent.BaseLayer.FullServicePeriod),
+		Description:            intent.Description,
+		Discounts:              convertFlatFeeDiscounts(intent.PercentageDiscounts),
+		FeatureKey:             lo.ToPtr(intent.FeatureKey),
+		FullServicePeriod:      ConvertClosedPeriodToAPI(intent.FullServicePeriod),
 		Id:                     source.ChargeBase.ManagedResource.ID,
-		InvoiceAt:              source.ChargeBase.Intent.BaseLayer.InvoiceAt,
-		Labels:                 ConvertMetadataToLabels(source.ChargeBase.Intent.BaseLayer.Metadata),
-		ManagedBy:              ConvertManagedByToAPI(source.ChargeBase.Intent.Intent.ManagedBy),
-		Name:                   source.ChargeBase.Intent.BaseLayer.Name,
-		PaymentTerm:            ConvertPaymentTermToAPI(source.ChargeBase.Intent.BaseLayer.PaymentTerm),
+		InvoiceAt:              intent.InvoiceAt,
+		Labels:                 ConvertMetadataToLabels(intent.Metadata),
+		ManagedBy:              ConvertManagedByToAPI(intent.ManagedBy),
+		Name:                   intent.Name,
+		PaymentTerm:            ConvertPaymentTermToAPI(intent.PaymentTerm),
 		Price:                  price,
-		ProrationConfiguration: ConvertProRatingConfigToAPI(source.ChargeBase.Intent.BaseLayer.ProRating),
-		ServicePeriod:          ConvertClosedPeriodToAPI(source.ChargeBase.Intent.BaseLayer.ServicePeriod),
-		SettlementMode:         ConvertSettlementModeToAPI(source.ChargeBase.Intent.SettlementMode),
+		ProrationConfiguration: ConvertProRatingConfigToAPI(intent.ProRating),
+		ServicePeriod:          ConvertClosedPeriodToAPI(intent.ServicePeriod),
+		SettlementMode:         ConvertSettlementModeToAPI(source.ChargeBase.Intent.GetSettlementMode()),
 		Status:                 ConvertChargeStatusToAPI(meta.ChargeStatus(source.Status)),
-		Subscription:           subscriptionRefPtrToAPI(source.ChargeBase.Intent.Intent.Subscription),
-		TaxConfig:              convertTaxCodeConfigToAPI(source.ChargeBase.Intent.BaseLayer.TaxConfig),
+		Subscription:           subscriptionRefPtrToAPI(source.ChargeBase.Intent.GetSubscription()),
+		TaxConfig:              convertTaxCodeConfigToAPI(intent.TaxConfig),
 		Type:                   api.BillingFlatFeeChargeTypeFlatFee,
-		UniqueReferenceId:      source.ChargeBase.Intent.Intent.UniqueReferenceID,
+		UniqueReferenceId:      source.ChargeBase.Intent.GetUniqueReferenceID(),
 		UpdatedAt:              source.ChargeBase.ManagedResource.ManagedModel.UpdatedAt,
 	}, nil
 }
@@ -74,36 +79,41 @@ func convertUsageBasedChargeToAPI(source usagebased.Charge) (api.BillingUsageBas
 		return api.BillingUsageBasedCharge{}, fmt.Errorf("converting usage based charge status: %w", err)
 	}
 
-	price, err := toAPIBillingPrice(source.Intent.BaseLayer.Price)
+	// TODO: when the base intent is not manually managed, expose the system/base
+	// state too so API clients can see what the charge would look like without
+	// the customer-facing override.
+	intent := source.ChargeBase.Intent.GetEffectiveIntent()
+
+	price, err := toAPIBillingPrice(intent.Price)
 	if err != nil {
 		return api.BillingUsageBasedCharge{}, fmt.Errorf("converting price: %w", err)
 	}
 
 	return api.BillingUsageBasedCharge{
 		AdvanceAfter:      source.State.AdvanceAfter,
-		BillingPeriod:     ConvertClosedPeriodToAPI(source.ChargeBase.Intent.BaseLayer.BillingPeriod),
+		BillingPeriod:     ConvertClosedPeriodToAPI(intent.BillingPeriod),
 		CreatedAt:         source.ChargeBase.ManagedResource.ManagedModel.CreatedAt,
-		Currency:          ConvertCurrencyCodeToAPI(source.ChargeBase.Intent.Intent.Currency),
-		Customer:          ConvertCustomerIDToReference(source.ChargeBase.Intent.Intent.CustomerID),
+		Currency:          ConvertCurrencyCodeToAPI(source.ChargeBase.Intent.GetCurrency()),
+		Customer:          ConvertCustomerIDToReference(source.ChargeBase.Intent.GetCustomerID()),
 		DeletedAt:         source.ChargeBase.ManagedResource.ManagedModel.DeletedAt,
-		Description:       source.ChargeBase.Intent.BaseLayer.Description,
-		Discounts:         convertUsageBasedDiscounts(source.Intent.BaseLayer.Discounts),
-		FeatureKey:        source.ChargeBase.Intent.BaseLayer.FeatureKey,
-		FullServicePeriod: ConvertClosedPeriodToAPI(source.ChargeBase.Intent.BaseLayer.FullServicePeriod),
+		Description:       intent.Description,
+		Discounts:         convertUsageBasedDiscounts(intent.Discounts),
+		FeatureKey:        intent.FeatureKey,
+		FullServicePeriod: ConvertClosedPeriodToAPI(intent.FullServicePeriod),
 		Id:                source.ChargeBase.ManagedResource.ID,
-		InvoiceAt:         source.ChargeBase.Intent.BaseLayer.InvoiceAt,
-		Labels:            ConvertMetadataToLabels(source.ChargeBase.Intent.BaseLayer.Metadata),
-		ManagedBy:         ConvertManagedByToAPI(source.ChargeBase.Intent.Intent.ManagedBy),
-		Name:              source.ChargeBase.Intent.BaseLayer.Name,
+		InvoiceAt:         intent.InvoiceAt,
+		Labels:            ConvertMetadataToLabels(intent.Metadata),
+		ManagedBy:         ConvertManagedByToAPI(intent.ManagedBy),
+		Name:              intent.Name,
 		Price:             price,
-		ServicePeriod:     ConvertClosedPeriodToAPI(source.ChargeBase.Intent.BaseLayer.ServicePeriod),
-		SettlementMode:    ConvertSettlementModeToAPI(source.ChargeBase.Intent.SettlementMode),
+		ServicePeriod:     ConvertClosedPeriodToAPI(intent.ServicePeriod),
+		SettlementMode:    ConvertSettlementModeToAPI(source.ChargeBase.Intent.GetSettlementMode()),
 		Status:            lo.FromPtr(status),
-		Subscription:      subscriptionRefPtrToAPI(source.ChargeBase.Intent.Intent.Subscription),
-		TaxConfig:         convertTaxCodeConfigToAPI(source.ChargeBase.Intent.BaseLayer.TaxConfig),
+		Subscription:      subscriptionRefPtrToAPI(source.ChargeBase.Intent.GetSubscription()),
+		TaxConfig:         convertTaxCodeConfigToAPI(intent.TaxConfig),
 		Totals:            convertUsageBasedChargeTotals(source),
 		Type:              api.BillingUsageBasedChargeTypeUsageBased,
-		UniqueReferenceId: source.ChargeBase.Intent.Intent.UniqueReferenceID,
+		UniqueReferenceId: source.ChargeBase.Intent.GetUniqueReferenceID(),
 		UpdatedAt:         source.ChargeBase.ManagedResource.ManagedModel.UpdatedAt,
 	}, nil
 }

--- a/openmeter/billing/charges/charge.go
+++ b/openmeter/billing/charges/charge.go
@@ -144,7 +144,7 @@ func (c Charge) GetUniqueReferenceID() (*string, error) {
 			return nil, fmt.Errorf("flat fee charge is nil")
 		}
 
-		return c.flatFee.Intent.UniqueReferenceID, nil
+		return c.flatFee.Intent.GetUniqueReferenceID(), nil
 	case meta.ChargeTypeCreditPurchase:
 		if c.creditPurchase == nil {
 			return nil, fmt.Errorf("credit purchase charge is nil")
@@ -219,7 +219,7 @@ func (c Charge) SettlementMode() (productcatalog.SettlementMode, error) {
 			return "", fmt.Errorf("flat fee charge is nil")
 		}
 
-		return c.flatFee.Intent.SettlementMode, nil
+		return c.flatFee.Intent.GetSettlementMode(), nil
 	case meta.ChargeTypeUsageBased:
 		if c.usageBased == nil {
 			return "", fmt.Errorf("usage based charge is nil")

--- a/openmeter/billing/charges/charge.go
+++ b/openmeter/billing/charges/charge.go
@@ -156,7 +156,7 @@ func (c Charge) GetUniqueReferenceID() (*string, error) {
 			return nil, fmt.Errorf("usage based charge is nil")
 		}
 
-		return c.usageBased.Intent.UniqueReferenceID, nil
+		return c.usageBased.Intent.GetUniqueReferenceID(), nil
 	}
 
 	return nil, fmt.Errorf("invalid charge type: %s", c.t)
@@ -225,7 +225,7 @@ func (c Charge) SettlementMode() (productcatalog.SettlementMode, error) {
 			return "", fmt.Errorf("usage based charge is nil")
 		}
 
-		return c.usageBased.Intent.SettlementMode, nil
+		return c.usageBased.Intent.GetSettlementMode(), nil
 	default:
 		return "", fmt.Errorf("settlement mode is not supported for charge type %s", c.t)
 	}

--- a/openmeter/billing/charges/flatfee/adapter.go
+++ b/openmeter/billing/charges/flatfee/adapter.go
@@ -32,7 +32,7 @@ type ChargeAdapter interface {
 	CreateCharges(ctx context.Context, charges CreateChargesInput) ([]Charge, error)
 
 	UpdateCharge(ctx context.Context, charge ChargeBase) (ChargeBase, error)
-	CreateChargeOverride(ctx context.Context, charge ChargeBase) (ChargeBase, error)
+	CreateChargeOverride(ctx context.Context, charge ChargeBase, override IntentMutableFields) (ChargeBase, error)
 	DeleteChargeOverride(ctx context.Context, charge ChargeBase) (ChargeBase, error)
 	UpdateSubscriptionItemID(ctx context.Context, charge Charge, newSubscriptionItemID string) (Charge, error)
 	DeleteCharge(ctx context.Context, charge Charge) error
@@ -134,8 +134,7 @@ func (i CreateInvoicedUsageInput) Validate() error {
 }
 
 type IntentWithInitialStatus struct {
-	Intent      OverridableIntent
-	Annotations models.Annotations `json:"annotations"`
+	Intent Intent
 
 	FeatureID                 *string
 	InitialStatus             Status

--- a/openmeter/billing/charges/flatfee/adapter/charge.go
+++ b/openmeter/billing/charges/flatfee/adapter/charge.go
@@ -121,7 +121,7 @@ func (a *adapter) UpdateSubscriptionItemID(ctx context.Context, charge flatfee.C
 		override, err := tx.db.ChargeFlatFeeOverride.Query().
 			Where(dbchargeflatfeeoverride.NamespaceEQ(charge.Namespace)).
 			Where(dbchargeflatfeeoverride.ChargeIDEQ(charge.ID)).
-			First(ctx)
+			Only(ctx)
 		if err != nil && !db.IsNotFound(err) {
 			return flatfee.Charge{}, err
 		}

--- a/openmeter/billing/charges/flatfee/adapter/charge.go
+++ b/openmeter/billing/charges/flatfee/adapter/charge.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/chargemeta"
 	"github.com/openmeterio/openmeter/openmeter/ent/db"
 	dbchargeflatfee "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfee"
+	dbchargeflatfeeoverride "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeeoverride"
 	dbchargeflatfeerun "github.com/openmeterio/openmeter/openmeter/ent/db/chargeflatfeerun"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -38,35 +39,34 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge flatfee.ChargeBase) (
 			return flatfee.ChargeBase{}, err
 		}
 
-		intent := charge.Intent
-		intentFields := intent.BaseLayer
+		intent := charge.Intent.GetBaseIntent()
 
 		var discounts *productcatalog.Discounts
-		if intentFields.PercentageDiscounts != nil {
-			discounts = &productcatalog.Discounts{Percentage: intentFields.PercentageDiscounts}
+		if intent.PercentageDiscounts != nil {
+			discounts = &productcatalog.Discounts{Percentage: intent.PercentageDiscounts}
 		}
 
-		proRating, err := proRatingConfigToDB(intentFields.ProRating)
+		proRating, err := proRatingConfigToDB(intent.ProRating)
 		if err != nil {
 			return flatfee.ChargeBase{}, err
 		}
 
 		update := tx.db.ChargeFlatFee.UpdateOneID(charge.ID).
 			Where(dbchargeflatfee.NamespaceEQ(charge.Namespace)).
-			SetPaymentTerm(intentFields.PaymentTerm).
-			SetOrClearIntentDeletedAt(convert.TimePtrIn(intentFields.IntentDeletedAt, time.UTC)).
-			SetInvoiceAt(meta.NormalizeTimestamp(intentFields.InvoiceAt).In(time.UTC)).
+			SetPaymentTerm(intent.PaymentTerm).
+			SetOrClearIntentDeletedAt(convert.TimePtrIn(intent.IntentDeletedAt, time.UTC)).
+			SetInvoiceAt(meta.NormalizeTimestamp(intent.InvoiceAt).In(time.UTC)).
 			SetDiscounts(discounts).
 			SetOrClearFeatureID(charge.State.FeatureID).
 			SetProRating(proRating).
 			SetStatusDetailed(charge.Status).
-			SetAmountBeforeProration(intentFields.AmountBeforeProration).
+			SetAmountBeforeProration(intent.AmountBeforeProration).
 			SetAmountAfterProration(charge.State.AmountAfterProration)
 
 		update, err = chargemeta.Update(update, chargemeta.UpdateInput{
 			ManagedResource:     charge.ManagedResource,
-			IntentMutableFields: intentFields.IntentMutableFields,
-			Annotations:         charge.Intent.Annotations,
+			IntentMutableFields: intent.IntentMutableFields.IntentMutableFields,
+			Annotations:         intent.Annotations,
 			Status:              metaStatus,
 			AdvanceAfter:        meta.NormalizeOptionalTimestamp(charge.State.AdvanceAfter),
 		})
@@ -74,15 +74,15 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge flatfee.ChargeBase) (
 			return flatfee.ChargeBase{}, err
 		}
 
-		update = update.SetOrClearDeletedAt(convert.TimePtrIn(charge.GetIntentDeletedAt(), time.UTC))
+		update = update.SetOrClearDeletedAt(convert.TimePtrIn(charge.Intent.GetDeletedAt(), time.UTC))
 
 		dbUpdatedChargeBase, err := update.Save(ctx)
 		if err != nil {
 			return flatfee.ChargeBase{}, err
 		}
 
-		if charge.Intent.OverrideLayer != nil {
-			intentOverride, err := tx.updateIntentOverride(ctx, charge.GetChargeID(), charge.Intent.OverrideLayer)
+		if overrideLayer := charge.Intent.GetOverrideLayerMutableFields(); overrideLayer != nil {
+			intentOverride, err := tx.updateIntentOverride(ctx, charge.GetChargeID(), overrideLayer)
 			if err != nil {
 				return flatfee.ChargeBase{}, fmt.Errorf("updating flat fee charge override: %w", err)
 			}
@@ -118,9 +118,16 @@ func (a *adapter) UpdateSubscriptionItemID(ctx context.Context, charge flatfee.C
 			return flatfee.Charge{}, err
 		}
 
-		intentOverride := charge.Intent.OverrideLayer
+		override, err := tx.db.ChargeFlatFeeOverride.Query().
+			Where(dbchargeflatfeeoverride.NamespaceEQ(charge.Namespace)).
+			Where(dbchargeflatfeeoverride.ChargeIDEQ(charge.ID)).
+			First(ctx)
+		if err != nil && !db.IsNotFound(err) {
+			return flatfee.Charge{}, err
+		}
+
+		updatedChargeBase.Edges.IntentOverride = override
 		charge.ChargeBase = MapChargeBaseFromDB(updatedChargeBase)
-		charge.Intent.OverrideLayer = intentOverride
 
 		return charge, nil
 	})
@@ -139,13 +146,15 @@ func (a *adapter) DeleteCharge(ctx context.Context, charge flatfee.Charge) error
 		update := tx.db.ChargeFlatFee.UpdateOneID(charge.ID).
 			Where(dbchargeflatfee.NamespaceEQ(charge.Namespace))
 
-		if charge.Intent.OverrideLayer == nil {
-			charge.Intent.BaseLayer.IntentDeletedAt = lo.ToPtr(clock.Now())
-		} else {
-			charge.Intent.OverrideLayer.IntentDeletedAt = lo.ToPtr(clock.Now())
+		err := charge.Intent.MutateEffective(func(intentMutableFields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+			intentMutableFields.IntentDeletedAt = lo.ToPtr(clock.Now())
+			return intentMutableFields, nil
+		})
+		if err != nil {
+			return err
 		}
 
-		charge.DeletedAt = charge.GetIntentDeletedAt()
+		charge.DeletedAt = charge.Intent.GetDeletedAt()
 		charge.Status = flatfee.StatusDeleted
 
 		metaStatus, err := charge.Status.ToMetaChargeStatus()
@@ -155,10 +164,12 @@ func (a *adapter) DeleteCharge(ctx context.Context, charge flatfee.Charge) error
 
 		update = update.SetStatusDetailed(charge.Status)
 
+		baseIntent := charge.Intent.GetBaseIntent()
+
 		update, err = chargemeta.Update(update, chargemeta.UpdateInput{
 			ManagedResource:     charge.ManagedResource,
-			IntentMutableFields: charge.Intent.BaseLayer.IntentMutableFields,
-			Annotations:         charge.Intent.Annotations,
+			IntentMutableFields: baseIntent.IntentMutableFields.IntentMutableFields,
+			Annotations:         baseIntent.Annotations,
 			Status:              metaStatus,
 		})
 		if err != nil {
@@ -166,15 +177,15 @@ func (a *adapter) DeleteCharge(ctx context.Context, charge flatfee.Charge) error
 		}
 
 		update = update.
-			SetOrClearIntentDeletedAt(convert.TimePtrIn(charge.Intent.BaseLayer.IntentDeletedAt, time.UTC)).
-			SetOrClearDeletedAt(convert.TimePtrIn(charge.GetIntentDeletedAt(), time.UTC))
+			SetOrClearIntentDeletedAt(convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)).
+			SetOrClearDeletedAt(convert.TimePtrIn(charge.Intent.GetDeletedAt(), time.UTC))
 
 		if _, err := update.Save(ctx); err != nil {
 			return err
 		}
 
-		if charge.Intent.OverrideLayer != nil {
-			if _, err := tx.updateIntentOverride(ctx, charge.GetChargeID(), charge.Intent.OverrideLayer); err != nil {
+		if overrideLayer := charge.Intent.GetOverrideLayerMutableFields(); overrideLayer != nil {
+			if _, err := tx.updateIntentOverride(ctx, charge.GetChargeID(), overrideLayer); err != nil {
 				return fmt.Errorf("updating flat fee intent override: %w", err)
 			}
 		}
@@ -321,37 +332,37 @@ func expandRealizations(query *db.ChargeFlatFeeQuery) *db.ChargeFlatFeeQuery {
 	})
 }
 
-func (a *adapter) buildCreateFlatFeeCharge(ns string, intent flatfee.IntentWithInitialStatus) (*db.ChargeFlatFeeCreate, error) {
-	metaStatus, err := intent.InitialStatus.ToMetaChargeStatus()
+func (a *adapter) buildCreateFlatFeeCharge(ns string, intentWithStatus flatfee.IntentWithInitialStatus) (*db.ChargeFlatFeeCreate, error) {
+	metaStatus, err := intentWithStatus.InitialStatus.ToMetaChargeStatus()
 	if err != nil {
 		return nil, err
 	}
 
-	intentFields := intent.Intent.BaseLayer
+	intent := intentWithStatus.Intent
 
 	var discounts *productcatalog.Discounts
-	if intentFields.PercentageDiscounts != nil {
-		discounts = &productcatalog.Discounts{Percentage: intentFields.PercentageDiscounts}
+	if intent.PercentageDiscounts != nil {
+		discounts = &productcatalog.Discounts{Percentage: intent.PercentageDiscounts}
 	}
 
-	proRating, err := proRatingConfigToDB(intentFields.ProRating)
+	proRating, err := proRatingConfigToDB(intent.ProRating)
 	if err != nil {
 		return nil, err
 	}
 
 	create := a.db.ChargeFlatFee.Create().
 		SetNamespace(ns).
-		SetNillableDeletedAt(convert.TimePtrIn(intentFields.IntentDeletedAt, time.UTC)).
-		SetNillableIntentDeletedAt(convert.TimePtrIn(intentFields.IntentDeletedAt, time.UTC)).
-		SetPaymentTerm(intentFields.PaymentTerm).
-		SetInvoiceAt(meta.NormalizeTimestamp(intentFields.InvoiceAt).In(time.UTC)).
-		SetSettlementMode(intent.Intent.SettlementMode).
-		SetNillableFeatureID(intent.FeatureID).
-		SetNillableFeatureKey(lo.EmptyableToPtr(intentFields.FeatureKey)).
-		SetStatusDetailed(intent.InitialStatus).
+		SetNillableDeletedAt(convert.TimePtrIn(intent.IntentDeletedAt, time.UTC)).
+		SetNillableIntentDeletedAt(convert.TimePtrIn(intent.IntentDeletedAt, time.UTC)).
+		SetPaymentTerm(intent.PaymentTerm).
+		SetInvoiceAt(meta.NormalizeTimestamp(intent.InvoiceAt).In(time.UTC)).
+		SetSettlementMode(intent.SettlementMode).
+		SetNillableFeatureID(intentWithStatus.FeatureID).
+		SetNillableFeatureKey(lo.EmptyableToPtr(intent.FeatureKey)).
+		SetStatusDetailed(intentWithStatus.InitialStatus).
 		SetProRating(proRating).
-		SetAmountBeforeProration(intentFields.AmountBeforeProration).
-		SetAmountAfterProration(intent.AmountAfterProration)
+		SetAmountBeforeProration(intent.AmountBeforeProration).
+		SetAmountAfterProration(intentWithStatus.AmountAfterProration)
 
 	if discounts != nil {
 		create = create.SetDiscounts(discounts)
@@ -359,10 +370,10 @@ func (a *adapter) buildCreateFlatFeeCharge(ns string, intent flatfee.IntentWithI
 
 	create, err = chargemeta.Create[*db.ChargeFlatFeeCreate](create, chargemeta.CreateInput{
 		Namespace:           ns,
-		Intent:              intent.Intent.Intent,
-		IntentMutableFields: intentFields.IntentMutableFields,
+		Intent:              intent.Intent,
+		IntentMutableFields: intent.IntentMutableFields.IntentMutableFields,
 		Status:              metaStatus,
-		AdvanceAfter:        meta.NormalizeOptionalTimestamp(intent.InitialAdvanceAfter),
+		AdvanceAfter:        meta.NormalizeOptionalTimestamp(intentWithStatus.InitialAdvanceAfter),
 	})
 	if err != nil {
 		return nil, err

--- a/openmeter/billing/charges/flatfee/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/flatfee/adapter/detailedline_test.go
@@ -103,13 +103,13 @@ func (s *FlatFeeDetailedLineAdapterSuite) TestUpsertDetailedLinesReplacesAndSoft
 		Namespace: namespace,
 		Intents: []flatfee.IntentWithInitialStatus{
 			{
-				Intent: flatfee.OverridableIntent{
+				Intent: flatfee.Intent{
 					Intent: chargesmeta.Intent{
 						ManagedBy:  billing.SubscriptionManagedLine,
 						CustomerID: customerID,
 						Currency:   currencyx.Code("USD"),
 					},
-					BaseLayer: flatfee.IntentMutableFields{
+					IntentMutableFields: flatfee.IntentMutableFields{
 						IntentMutableFields: chargesmeta.IntentMutableFields{
 							Name:              "flat-fee-charge",
 							ServicePeriod:     servicePeriod,
@@ -272,6 +272,7 @@ func (s *FlatFeeDetailedLineAdapterSuite) newDetailedLine(input newDetailedLineI
 	s.T().Helper()
 
 	totalAmount := alpacadecimal.NewFromFloat(0.1).Mul(alpacadecimal.NewFromInt(input.Quantity))
+	baseIntent := input.Charge.Intent.GetBaseIntent()
 
 	return flatfee.DetailedLine{
 		ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
@@ -280,9 +281,9 @@ func (s *FlatFeeDetailedLineAdapterSuite) newDetailedLine(input newDetailedLineI
 			Description: input.Description,
 		}),
 		ServicePeriod:          input.ServicePeriod,
-		Currency:               input.Charge.Intent.Currency,
+		Currency:               input.Charge.Intent.GetCurrency(),
 		ChildUniqueReferenceID: input.ChildUniqueReferenceID,
-		PaymentTerm:            input.Charge.Intent.BaseLayer.PaymentTerm,
+		PaymentTerm:            baseIntent.PaymentTerm,
 		PerUnitAmount:          alpacadecimal.NewFromFloat(0.1),
 		Quantity:               alpacadecimal.NewFromInt(input.Quantity),
 		Category:               stddetailedline.CategoryRegular,

--- a/openmeter/billing/charges/flatfee/adapter/intentoverride.go
+++ b/openmeter/billing/charges/flatfee/adapter/intentoverride.go
@@ -90,6 +90,10 @@ func (a *adapter) DeleteChargeOverride(ctx context.Context, charge flatfee.Charg
 		return flatfee.ChargeBase{}, err
 	}
 
+	if err := charge.Validate(); err != nil {
+		return flatfee.ChargeBase{}, err
+	}
+
 	if !charge.Intent.HasOverrideLayer() {
 		return flatfee.ChargeBase{}, errors.New("intent override is required")
 	}

--- a/openmeter/billing/charges/flatfee/adapter/intentoverride.go
+++ b/openmeter/billing/charges/flatfee/adapter/intentoverride.go
@@ -47,7 +47,7 @@ func mapIntentOverrideFromDB(dbOverride *entdb.ChargeFlatFeeOverride) *flatfee.I
 	}
 }
 
-func (a *adapter) CreateChargeOverride(ctx context.Context, charge flatfee.ChargeBase) (flatfee.ChargeBase, error) {
+func (a *adapter) CreateChargeOverride(ctx context.Context, charge flatfee.ChargeBase, override flatfee.IntentMutableFields) (flatfee.ChargeBase, error) {
 	if err := charge.ManagedModel.Validate(); err != nil {
 		return flatfee.ChargeBase{}, err
 	}
@@ -56,18 +56,22 @@ func (a *adapter) CreateChargeOverride(ctx context.Context, charge flatfee.Charg
 		return flatfee.ChargeBase{}, err
 	}
 
-	if charge.Intent.OverrideLayer == nil {
-		return flatfee.ChargeBase{}, errors.New("intent override is required")
+	if err := override.Validate(); err != nil {
+		return flatfee.ChargeBase{}, fmt.Errorf("validating intent override: %w", err)
+	}
+
+	if charge.Intent.HasOverrideLayer() {
+		return flatfee.ChargeBase{}, errors.New("intent override already exists")
 	}
 
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (flatfee.ChargeBase, error) {
-		intentOverride, err := tx.createIntentOverride(ctx, charge.GetChargeID(), charge.Intent.OverrideLayer)
+		dbIntentOverride, err := tx.createIntentOverride(ctx, charge.GetChargeID(), override)
 		if err != nil {
 			return flatfee.ChargeBase{}, err
 		}
 
-		deletedAt := convert.TimePtrIn(intentOverride.IntentDeletedAt, time.UTC)
-		_, err = tx.db.ChargeFlatFee.UpdateOneID(charge.ID).
+		deletedAt := convert.TimePtrIn(dbIntentOverride.IntentDeletedAt, time.UTC)
+		dbCharge, err := tx.db.ChargeFlatFee.UpdateOneID(charge.ID).
 			Where(dbchargeflatfee.NamespaceEQ(charge.Namespace)).
 			SetOrClearDeletedAt(deletedAt).
 			Save(ctx)
@@ -75,10 +79,9 @@ func (a *adapter) CreateChargeOverride(ctx context.Context, charge flatfee.Charg
 			return flatfee.ChargeBase{}, fmt.Errorf("updating flat fee effective deleted at: %w", err)
 		}
 
-		charge.Intent.OverrideLayer = intentOverride
-		charge.DeletedAt = deletedAt
+		dbCharge.Edges.IntentOverride = dbIntentOverride
 
-		return charge, nil
+		return MapChargeBaseFromDB(dbCharge), nil
 	})
 }
 
@@ -87,9 +90,8 @@ func (a *adapter) DeleteChargeOverride(ctx context.Context, charge flatfee.Charg
 		return flatfee.ChargeBase{}, err
 	}
 
-	charge.Intent.OverrideLayer = nil
-	if err := charge.Validate(); err != nil {
-		return flatfee.ChargeBase{}, err
+	if !charge.Intent.HasOverrideLayer() {
+		return flatfee.ChargeBase{}, errors.New("intent override is required")
 	}
 
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (flatfee.ChargeBase, error) {
@@ -105,7 +107,8 @@ func (a *adapter) DeleteChargeOverride(ctx context.Context, charge flatfee.Charg
 			return flatfee.ChargeBase{}, fmt.Errorf("intent override does not exist")
 		}
 
-		deletedAt := convert.TimePtrIn(charge.Intent.BaseLayer.IntentDeletedAt, time.UTC)
+		baseIntent := charge.Intent.GetBaseIntent()
+		deletedAt := convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)
 		_, err = tx.db.ChargeFlatFee.UpdateOneID(charge.ID).
 			Where(dbchargeflatfee.NamespaceEQ(charge.Namespace)).
 			SetOrClearDeletedAt(deletedAt).
@@ -114,13 +117,14 @@ func (a *adapter) DeleteChargeOverride(ctx context.Context, charge flatfee.Charg
 			return flatfee.ChargeBase{}, fmt.Errorf("updating flat fee effective deleted at: %w", err)
 		}
 
+		charge.Intent = baseIntent.AsOverridableIntent()
 		charge.DeletedAt = deletedAt
 
 		return charge, nil
 	})
 }
 
-func (a *adapter) createIntentOverride(ctx context.Context, chargeID meta.ChargeID, override *flatfee.IntentMutableFields) (*flatfee.IntentMutableFields, error) {
+func (a *adapter) createIntentOverride(ctx context.Context, chargeID meta.ChargeID, override flatfee.IntentMutableFields) (*entdb.ChargeFlatFeeOverride, error) {
 	if err := chargeID.Validate(); err != nil {
 		return nil, fmt.Errorf("charge id: %w", err)
 	}
@@ -157,12 +161,7 @@ func (a *adapter) createIntentOverride(ctx context.Context, chargeID meta.Charge
 		create = create.SetPercentageDiscounts(normalized.PercentageDiscounts)
 	}
 
-	dbOverride, err := create.Save(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return mapIntentOverrideFromDB(dbOverride), nil
+	return create.Save(ctx)
 }
 
 func (a *adapter) updateIntentOverride(ctx context.Context, chargeID meta.ChargeID, override *flatfee.IntentMutableFields) (*entdb.ChargeFlatFeeOverride, error) {

--- a/openmeter/billing/charges/flatfee/adapter/intentoverride_test.go
+++ b/openmeter/billing/charges/flatfee/adapter/intentoverride_test.go
@@ -103,8 +103,11 @@ func (s *FlatFeeIntentOverrideAdapterSuite) TestUpdateAndReadIntentOverride() {
 		Mode:    productcatalog.ProRatingModeProratePrices,
 	}
 
-	charge.Intent.BaseLayer.IntentDeletedAt = lo.ToPtr(time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC))
-	charge.Intent.OverrideLayer = &flatfee.IntentMutableFields{
+	s.Require().NoError(charge.Intent.Mutate(chargesmeta.ChangeTargetBase, func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+		fields.IntentDeletedAt = lo.ToPtr(time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC))
+		return fields, nil
+	}))
+	override := flatfee.IntentMutableFields{
 		IntentMutableFields: chargesmeta.IntentMutableFields{
 			Name:        "manual flat fee",
 			Description: lo.ToPtr("manual description"),
@@ -129,63 +132,70 @@ func (s *FlatFeeIntentOverrideAdapterSuite) TestUpdateAndReadIntentOverride() {
 		}),
 	}
 
-	_, err := s.adapter.UpdateCharge(ctx, charge.ChargeBase)
+	chargeWithMissingOverride := charge.ChargeBase
+	chargeWithMissingOverride.Intent = flatfee.NewOverridableIntent(charge.Intent.GetBaseIntent(), &override)
+	_, err := s.adapter.UpdateCharge(ctx, chargeWithMissingOverride)
 	s.Require().ErrorContains(err, "override does not exist")
 
-	chargeWithoutOverride := charge.ChargeBase
-	chargeWithoutOverride.Intent.OverrideLayer = nil
-	updated, err := s.adapter.UpdateCharge(ctx, chargeWithoutOverride)
+	updated, err := s.adapter.UpdateCharge(ctx, charge.ChargeBase)
 	s.Require().NoError(err)
-	s.NotNil(updated.Intent.BaseLayer.IntentDeletedAt)
+	s.NotNil(updated.Intent.GetBaseIntent().IntentDeletedAt)
 	fetchedBeforeOverrideCreate, err := s.adapter.GetByID(ctx, flatfee.GetByIDInput{
 		ChargeID: charge.GetChargeID(),
 	})
 	s.Require().NoError(err)
-	s.Nil(fetchedBeforeOverrideCreate.Intent.OverrideLayer)
+	s.Nil(fetchedBeforeOverrideCreate.Intent.GetOverrideLayerMutableFields())
 	s.NotNil(fetchedBeforeOverrideCreate.DeletedAt)
 
-	updated.Intent.OverrideLayer = charge.Intent.OverrideLayer
-	updated, err = s.adapter.CreateChargeOverride(ctx, updated)
+	updated, err = s.adapter.CreateChargeOverride(ctx, updated, override)
 	s.Require().NoError(err)
 	s.Nil(updated.DeletedAt)
-	s.requireOverrideMatches(updated.Intent.OverrideLayer, overrideServicePeriod, overrideFullServicePeriod, overrideBillingPeriod, overrideInvoiceAt, overrideTaxCodeID)
+	s.requireOverrideMatches(updated.Intent.GetOverrideLayerMutableFields(), overrideServicePeriod, overrideFullServicePeriod, overrideBillingPeriod, overrideInvoiceAt, overrideTaxCodeID)
 
-	_, err = s.adapter.CreateChargeOverride(ctx, updated)
+	_, err = s.adapter.CreateChargeOverride(ctx, updated, override)
 	s.Require().Error(err)
 
 	overrideInvoiceAt = time.Date(2026, 1, 22, 0, 0, 0, 0, time.UTC)
-	updated.Intent.OverrideLayer.InvoiceAt = overrideInvoiceAt
+	s.Require().NoError(updated.Intent.Mutate(chargesmeta.ChangeTargetOverride, func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+		fields.InvoiceAt = overrideInvoiceAt
+		return fields, nil
+	}))
 	updated, err = s.adapter.UpdateCharge(ctx, updated)
 	s.Require().NoError(err)
-	s.requireOverrideMatches(updated.Intent.OverrideLayer, overrideServicePeriod, overrideFullServicePeriod, overrideBillingPeriod, overrideInvoiceAt, overrideTaxCodeID)
+	s.requireOverrideMatches(updated.Intent.GetOverrideLayerMutableFields(), overrideServicePeriod, overrideFullServicePeriod, overrideBillingPeriod, overrideInvoiceAt, overrideTaxCodeID)
 
-	updated.Intent.OverrideLayer.Description = nil
-	updated.Intent.OverrideLayer.Metadata = nil
-	updated.Intent.OverrideLayer.TaxConfig.Behavior = nil
-	updated.Intent.OverrideLayer.TaxConfig.TaxCodeID = overrideTaxCodeID
-	updated.Intent.OverrideLayer.FeatureKey = ""
-	updated.Intent.OverrideLayer.PercentageDiscounts = nil
+	s.Require().NoError(updated.Intent.Mutate(chargesmeta.ChangeTargetOverride, func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+		fields.Description = nil
+		fields.Metadata = nil
+		fields.TaxConfig.Behavior = nil
+		fields.TaxConfig.TaxCodeID = overrideTaxCodeID
+		fields.FeatureKey = ""
+		fields.PercentageDiscounts = nil
+		return fields, nil
+	}))
 	updated, err = s.adapter.UpdateCharge(ctx, updated)
 	s.Require().NoError(err)
-	s.Require().NotNil(updated.Intent.OverrideLayer)
-	s.Nil(updated.Intent.OverrideLayer.Description)
-	s.Nil(updated.Intent.OverrideLayer.Metadata)
-	s.Nil(updated.Intent.OverrideLayer.TaxConfig.Behavior)
-	s.Equal(overrideTaxCodeID, updated.Intent.OverrideLayer.TaxConfig.TaxCodeID)
-	s.Empty(updated.Intent.OverrideLayer.FeatureKey)
-	s.Nil(updated.Intent.OverrideLayer.PercentageDiscounts)
+	updatedOverride := updated.Intent.GetOverrideLayerMutableFields()
+	s.Require().NotNil(updatedOverride)
+	s.Nil(updatedOverride.Description)
+	s.Nil(updatedOverride.Metadata)
+	s.Nil(updatedOverride.TaxConfig.Behavior)
+	s.Equal(overrideTaxCodeID, updatedOverride.TaxConfig.TaxCodeID)
+	s.Empty(updatedOverride.FeatureKey)
+	s.Nil(updatedOverride.PercentageDiscounts)
 
 	fetched, err := s.adapter.GetByID(ctx, flatfee.GetByIDInput{
 		ChargeID: charge.GetChargeID(),
 	})
 	s.Require().NoError(err)
-	s.Require().NotNil(fetched.Intent.OverrideLayer)
-	s.Nil(fetched.Intent.OverrideLayer.Description)
-	s.Nil(fetched.Intent.OverrideLayer.Metadata)
-	s.Nil(fetched.Intent.OverrideLayer.TaxConfig.Behavior)
-	s.Equal(overrideTaxCodeID, fetched.Intent.OverrideLayer.TaxConfig.TaxCodeID)
-	s.Empty(fetched.Intent.OverrideLayer.FeatureKey)
-	s.Nil(fetched.Intent.OverrideLayer.PercentageDiscounts)
+	fetchedOverride := fetched.Intent.GetOverrideLayerMutableFields()
+	s.Require().NotNil(fetchedOverride)
+	s.Nil(fetchedOverride.Description)
+	s.Nil(fetchedOverride.Metadata)
+	s.Nil(fetchedOverride.TaxConfig.Behavior)
+	s.Equal(overrideTaxCodeID, fetchedOverride.TaxConfig.TaxCodeID)
+	s.Empty(fetchedOverride.FeatureKey)
+	s.Nil(fetchedOverride.PercentageDiscounts)
 
 	fetchedByIDs, err := s.adapter.GetByIDs(ctx, flatfee.GetByIDsInput{
 		Namespace: namespace,
@@ -193,24 +203,25 @@ func (s *FlatFeeIntentOverrideAdapterSuite) TestUpdateAndReadIntentOverride() {
 	})
 	s.Require().NoError(err)
 	s.Require().Len(fetchedByIDs, 1)
-	s.Require().NotNil(fetchedByIDs[0].Intent.OverrideLayer)
-	s.Nil(fetchedByIDs[0].Intent.OverrideLayer.Description)
-	s.Nil(fetchedByIDs[0].Intent.OverrideLayer.Metadata)
-	s.Nil(fetchedByIDs[0].Intent.OverrideLayer.TaxConfig.Behavior)
-	s.Equal(overrideTaxCodeID, fetchedByIDs[0].Intent.OverrideLayer.TaxConfig.TaxCodeID)
-	s.Empty(fetchedByIDs[0].Intent.OverrideLayer.FeatureKey)
-	s.Nil(fetchedByIDs[0].Intent.OverrideLayer.PercentageDiscounts)
+	fetchedByIDOverride := fetchedByIDs[0].Intent.GetOverrideLayerMutableFields()
+	s.Require().NotNil(fetchedByIDOverride)
+	s.Nil(fetchedByIDOverride.Description)
+	s.Nil(fetchedByIDOverride.Metadata)
+	s.Nil(fetchedByIDOverride.TaxConfig.Behavior)
+	s.Equal(overrideTaxCodeID, fetchedByIDOverride.TaxConfig.TaxCodeID)
+	s.Empty(fetchedByIDOverride.FeatureKey)
+	s.Nil(fetchedByIDOverride.PercentageDiscounts)
 
 	cleared, err := s.adapter.DeleteChargeOverride(ctx, fetched.ChargeBase)
 	s.Require().NoError(err)
-	s.Nil(cleared.Intent.OverrideLayer)
+	s.Nil(cleared.Intent.GetOverrideLayerMutableFields())
 	s.NotNil(cleared.DeletedAt)
 
 	fetchedAfterClear, err := s.adapter.GetByID(ctx, flatfee.GetByIDInput{
 		ChargeID: charge.GetChargeID(),
 	})
 	s.Require().NoError(err)
-	s.Nil(fetchedAfterClear.Intent.OverrideLayer)
+	s.Nil(fetchedAfterClear.Intent.GetOverrideLayerMutableFields())
 	s.NotNil(fetchedAfterClear.DeletedAt)
 }
 
@@ -222,33 +233,34 @@ func (s *FlatFeeIntentOverrideAdapterSuite) TestDeleteChargeWithIntentOverrideDe
 	clock.FreezeTime(deletedAt)
 	defer clock.UnFreeze()
 
-	charge.Intent.OverrideLayer = &flatfee.IntentMutableFields{
+	baseIntent := charge.Intent.GetBaseIntent()
+	override := flatfee.IntentMutableFields{
 		IntentMutableFields: chargesmeta.IntentMutableFields{
 			Name:              "manual flat fee",
-			TaxConfig:         charge.Intent.BaseLayer.TaxConfig,
-			ServicePeriod:     charge.Intent.BaseLayer.ServicePeriod,
-			FullServicePeriod: charge.Intent.BaseLayer.FullServicePeriod,
-			BillingPeriod:     charge.Intent.BaseLayer.BillingPeriod,
+			TaxConfig:         baseIntent.TaxConfig,
+			ServicePeriod:     baseIntent.ServicePeriod,
+			FullServicePeriod: baseIntent.FullServicePeriod,
+			BillingPeriod:     baseIntent.BillingPeriod,
 		},
-		InvoiceAt:             charge.Intent.BaseLayer.InvoiceAt,
-		PaymentTerm:           charge.Intent.BaseLayer.PaymentTerm,
-		ProRating:             charge.Intent.BaseLayer.ProRating,
-		AmountBeforeProration: charge.Intent.BaseLayer.AmountBeforeProration,
+		InvoiceAt:             baseIntent.InvoiceAt,
+		PaymentTerm:           baseIntent.PaymentTerm,
+		ProRating:             baseIntent.ProRating,
+		AmountBeforeProration: baseIntent.AmountBeforeProration,
 	}
 
-	_, err := s.adapter.UpdateCharge(ctx, charge.ChargeBase)
+	chargeWithMissingOverride := charge.ChargeBase
+	chargeWithMissingOverride.Intent = flatfee.NewOverridableIntent(baseIntent, &override)
+	_, err := s.adapter.UpdateCharge(ctx, chargeWithMissingOverride)
 	s.Require().ErrorContains(err, "override does not exist")
 
-	updated := charge.ChargeBase
-	updated.Intent.OverrideLayer = nil
-	updated, err = s.adapter.UpdateCharge(ctx, updated)
+	updated, err := s.adapter.UpdateCharge(ctx, charge.ChargeBase)
 	s.Require().NoError(err)
-	updated.Intent.OverrideLayer = charge.Intent.OverrideLayer
-	updated, err = s.adapter.CreateChargeOverride(ctx, updated)
+	updated, err = s.adapter.CreateChargeOverride(ctx, updated, override)
 	s.Require().NoError(err)
-	s.Require().NotNil(updated.Intent.OverrideLayer)
-	s.Nil(updated.Intent.BaseLayer.IntentDeletedAt)
-	s.Nil(updated.Intent.OverrideLayer.IntentDeletedAt)
+	updatedOverride := updated.Intent.GetOverrideLayerMutableFields()
+	s.Require().NotNil(updatedOverride)
+	s.Nil(updated.Intent.GetBaseIntent().IntentDeletedAt)
+	s.Nil(updatedOverride.IntentDeletedAt)
 	s.Nil(updated.DeletedAt)
 
 	s.Require().NoError(s.adapter.DeleteCharge(ctx, flatfee.Charge{ChargeBase: updated}))
@@ -258,11 +270,12 @@ func (s *FlatFeeIntentOverrideAdapterSuite) TestDeleteChargeWithIntentOverrideDe
 	})
 	s.Require().NoError(err)
 	s.Equal(flatfee.StatusDeleted, fetched.Status)
-	s.Nil(fetched.Intent.BaseLayer.IntentDeletedAt)
-	s.Require().NotNil(fetched.Intent.OverrideLayer)
-	s.Require().NotNil(fetched.Intent.OverrideLayer.IntentDeletedAt)
+	fetchedOverride := fetched.Intent.GetOverrideLayerMutableFields()
+	s.Nil(fetched.Intent.GetBaseIntent().IntentDeletedAt)
+	s.Require().NotNil(fetchedOverride)
+	s.Require().NotNil(fetchedOverride.IntentDeletedAt)
 	s.Require().NotNil(fetched.DeletedAt)
-	s.Equal(deletedAt, *fetched.Intent.OverrideLayer.IntentDeletedAt)
+	s.Equal(deletedAt, *fetchedOverride.IntentDeletedAt)
 	s.Equal(deletedAt, *fetched.DeletedAt)
 }
 
@@ -310,13 +323,13 @@ func (s *FlatFeeIntentOverrideAdapterSuite) createCharge(namespace string) flatf
 		Namespace: namespace,
 		Intents: []flatfee.IntentWithInitialStatus{
 			{
-				Intent: flatfee.OverridableIntent{
+				Intent: flatfee.Intent{
 					Intent: chargesmeta.Intent{
 						ManagedBy:  billing.SubscriptionManagedLine,
 						CustomerID: customerID,
 						Currency:   currencyx.Code("USD"),
 					},
-					BaseLayer: flatfee.IntentMutableFields{
+					IntentMutableFields: flatfee.IntentMutableFields{
 						IntentMutableFields: chargesmeta.IntentMutableFields{
 							Name: "flat-fee-charge",
 							TaxConfig: productcatalog.TaxCodeConfig{
@@ -343,7 +356,7 @@ func (s *FlatFeeIntentOverrideAdapterSuite) createCharge(namespace string) flatf
 	})
 	s.Require().NoError(err)
 	s.Require().Len(createdCharges, 1)
-	s.Nil(createdCharges[0].Intent.OverrideLayer)
+	s.Nil(createdCharges[0].Intent.GetOverrideLayerMutableFields())
 
 	return createdCharges[0]
 }

--- a/openmeter/billing/charges/flatfee/adapter/mapper.go
+++ b/openmeter/billing/charges/flatfee/adapter/mapper.go
@@ -144,10 +144,10 @@ func MapChargeBaseFromDB(entity *entdb.ChargeFlatFee) flatfee.ChargeBase {
 			FeatureID:            entity.FeatureID,
 			AmountAfterProration: entity.AmountAfterProration,
 		},
-		Intent: flatfee.OverridableIntent{
+		Intent: flatfee.NewOverridableIntent(flatfee.Intent{
 			Intent:         mappedMeta.Intent,
 			SettlementMode: entity.SettlementMode,
-			BaseLayer: flatfee.IntentMutableFields{
+			IntentMutableFields: flatfee.IntentMutableFields{
 				IntentMutableFields:   mappedMeta.IntentMutableFields,
 				InvoiceAt:             entity.InvoiceAt.UTC(),
 				IntentDeletedAt:       convert.TimePtrIn(entity.IntentDeletedAt, time.UTC),
@@ -157,8 +157,7 @@ func MapChargeBaseFromDB(entity *entdb.ChargeFlatFee) flatfee.ChargeBase {
 				ProRating:             proRatingConfigFromDB(entity.ProRating),
 				AmountBeforeProration: entity.AmountBeforeProration,
 			},
-			OverrideLayer: mapIntentOverrideFromDB(entity.Edges.IntentOverride),
-		},
+		}, mapIntentOverrideFromDB(entity.Edges.IntentOverride)),
 	}
 }
 

--- a/openmeter/billing/charges/flatfee/adapter/realizationrun_test.go
+++ b/openmeter/billing/charges/flatfee/adapter/realizationrun_test.go
@@ -89,13 +89,13 @@ func (s *FlatFeeRealizationRunAdapterSuite) TestCreateCurrentRunFailsWhenCurrent
 		Namespace: namespace,
 		Intents: []flatfee.IntentWithInitialStatus{
 			{
-				Intent: flatfee.OverridableIntent{
+				Intent: flatfee.Intent{
 					Intent: chargesmeta.Intent{
 						ManagedBy:  billing.SubscriptionManagedLine,
 						CustomerID: customerID,
 						Currency:   currencyx.Code("USD"),
 					},
-					BaseLayer: flatfee.IntentMutableFields{
+					IntentMutableFields: flatfee.IntentMutableFields{
 						IntentMutableFields: chargesmeta.IntentMutableFields{
 							Name:              "flat-fee-charge",
 							ServicePeriod:     servicePeriod,

--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -233,6 +233,16 @@ func (i OverridableIntent) GetUniqueReferenceID() *string {
 	return i.intent.UniqueReferenceID
 }
 
+func (i OverridableIntent) GetSubscription() *meta.SubscriptionReference {
+	if i.intent.Subscription == nil {
+		return nil
+	}
+
+	subscription := *i.intent.Subscription
+
+	return &subscription
+}
+
 func (i OverridableIntent) Validate() error {
 	var errs []error
 
@@ -316,6 +326,16 @@ func (i OverridableIntent) GetEffectiveFeatureKey() string {
 	return i.baseLayer.FeatureKey
 }
 
+// GetEffectiveTaxConfig returns the tax config from the active mutable layer,
+// preferring the override layer when it is present.
+func (i OverridableIntent) GetEffectiveTaxConfig() productcatalog.TaxCodeConfig {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.TaxConfig
+	}
+
+	return i.baseLayer.TaxConfig
+}
+
 // GetEffectiveMetaIntentMutableFields returns the shared meta mutable fields
 // from the active mutable layer, preferring the override layer when it is
 // present.
@@ -325,6 +345,12 @@ func (i OverridableIntent) GetEffectiveMetaIntentMutableFields() meta.IntentMuta
 	}
 
 	return i.baseLayer.IntentMutableFields
+}
+
+// GetBaseTaxConfig returns the tax config from the base mutable layer,
+// ignoring any override layer.
+func (i OverridableIntent) GetBaseTaxConfig() productcatalog.TaxCodeConfig {
+	return i.baseLayer.TaxConfig
 }
 
 func (i OverridableIntent) GetBaseIntent() Intent {

--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -185,6 +185,10 @@ func (i Intent) CalculateAmountAfterProration() (alpacadecimal.Decimal, error) {
 	return calc.RoundToPrecision(amount), nil
 }
 
+// OverridableIntent stores the immutable intent plus the base and optional
+// override mutable layers. Direct layer access is error-prone because callers
+// must manually decide which layer is active; this API centralizes that choice
+// so reads and mutations use the correct override layer when present.
 type OverridableIntent struct {
 	intent meta.Intent
 

--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 type ChargeBase struct {
@@ -57,22 +58,12 @@ func (c ChargeBase) GetChargeID() meta.ChargeID {
 func (c ChargeBase) GetCustomerID() customer.CustomerID {
 	return customer.CustomerID{
 		Namespace: c.Namespace,
-		ID:        c.Intent.CustomerID,
+		ID:        c.Intent.GetCustomerID(),
 	}
 }
 
 func (c ChargeBase) GetCurrency() currencyx.Code {
-	return c.Intent.Currency
-}
-
-// GetIntentDeletedAt returns the effective intent deletion timestamp.
-// If an override is present, the override intent owns deletion; otherwise the base intent does.
-func (c ChargeBase) GetIntentDeletedAt() *time.Time {
-	if c.Intent.OverrideLayer != nil {
-		return c.Intent.OverrideLayer.IntentDeletedAt
-	}
-
-	return c.Intent.BaseLayer.IntentDeletedAt
+	return c.Intent.GetCurrency()
 }
 
 func (c ChargeBase) ErrorAttributes() models.Attributes {
@@ -138,9 +129,9 @@ func (i Intent) Normalized() Intent {
 // AsOverridableIntent maps the intent's mutable fields as the base layer.
 func (i Intent) AsOverridableIntent() OverridableIntent {
 	return OverridableIntent{
-		Intent:         i.Intent,
-		BaseLayer:      i.IntentMutableFields,
-		SettlementMode: i.SettlementMode,
+		intent:         i.Intent,
+		baseLayer:      i.IntentMutableFields,
+		settlementMode: i.SettlementMode,
 	}
 }
 
@@ -195,60 +186,191 @@ func (i Intent) CalculateAmountAfterProration() (alpacadecimal.Decimal, error) {
 }
 
 type OverridableIntent struct {
-	meta.Intent
+	intent meta.Intent
 
-	BaseLayer     IntentMutableFields  `json:"baseLayer"`
-	OverrideLayer *IntentMutableFields `json:"overrideLayer,omitempty"`
+	baseLayer     IntentMutableFields
+	overrideLayer *IntentMutableFields
 
-	SettlementMode productcatalog.SettlementMode `json:"settlementMode"`
+	settlementMode productcatalog.SettlementMode
+}
+
+func NewOverridableIntent(baseIntent Intent, overrideLayer *IntentMutableFields) OverridableIntent {
+	return OverridableIntent{
+		intent:         baseIntent.Intent,
+		baseLayer:      baseIntent.IntentMutableFields,
+		overrideLayer:  overrideLayer,
+		settlementMode: baseIntent.SettlementMode,
+	}
 }
 
 func (i OverridableIntent) Normalized() OverridableIntent {
-	i.BaseLayer = i.BaseLayer.Normalized(i.Currency)
-	if i.OverrideLayer != nil {
-		overrideLayer := i.OverrideLayer.Normalized(i.Currency)
-		i.OverrideLayer = &overrideLayer
+	i.baseLayer = i.baseLayer.Normalized(i.intent.Currency)
+	if i.overrideLayer != nil {
+		overrideLayer := i.overrideLayer.Normalized(i.intent.Currency)
+		i.overrideLayer = &overrideLayer
 	}
 
 	return i
 }
 
+func (i OverridableIntent) GetCustomerID() string {
+	return i.intent.CustomerID
+}
+
+func (i OverridableIntent) GetCurrency() currencyx.Code {
+	return i.intent.Currency
+}
+
+func (i OverridableIntent) GetSettlementMode() productcatalog.SettlementMode {
+	return i.settlementMode
+}
+
+func (i OverridableIntent) GetUniqueReferenceID() *string {
+	return i.intent.UniqueReferenceID
+}
+
 func (i OverridableIntent) Validate() error {
 	var errs []error
 
-	if err := i.Intent.Validate(); err != nil {
+	if err := i.intent.Validate(); err != nil {
 		errs = append(errs, err)
 	}
 
-	if err := i.BaseLayer.Validate(); err != nil {
+	if err := i.baseLayer.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("base layer: %w", err))
 	}
 
-	if i.OverrideLayer != nil {
-		if err := i.OverrideLayer.Validate(); err != nil {
+	if i.overrideLayer != nil {
+		if err := i.overrideLayer.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("override layer: %w", err))
 		}
 	}
 
-	if err := i.SettlementMode.Validate(); err != nil {
+	if err := i.settlementMode.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("settlement mode: %w", err))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
+// GetEffectiveIntent returns the customer-facing intent by combining the
+// immutable intent with the active mutable layer.
+//
+// WARNING: this clones and normalizes the intent and mutable fields. Prefer the
+// narrower effective getters when only a few fields are required.
 func (i OverridableIntent) GetEffectiveIntent() Intent {
 	intent := Intent{
-		Intent:              i.Intent.Clone(),
-		IntentMutableFields: i.BaseLayer.Clone(),
-		SettlementMode:      i.SettlementMode,
+		Intent:              i.intent.Clone(),
+		IntentMutableFields: i.baseLayer.Clone(),
+		SettlementMode:      i.settlementMode,
 	}
 
-	if i.OverrideLayer != nil {
-		intent.IntentMutableFields = i.OverrideLayer.Clone()
+	if i.overrideLayer != nil {
+		intent.IntentMutableFields = i.overrideLayer.Clone()
 	}
 
 	return intent.Normalized()
+}
+
+// GetEffectiveServicePeriod returns the service period from the active mutable
+// layer, preferring the override layer when it is present.
+func (i OverridableIntent) GetEffectiveServicePeriod() timeutil.ClosedPeriod {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.ServicePeriod
+	}
+
+	return i.baseLayer.ServicePeriod
+}
+
+// GetEffectiveInvoiceAt returns the invoice-at timestamp from the active
+// mutable layer, preferring the override layer when it is present.
+func (i OverridableIntent) GetEffectiveInvoiceAt() time.Time {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.InvoiceAt
+	}
+
+	return i.baseLayer.InvoiceAt
+}
+
+// GetEffectivePaymentTerm returns the payment term from the active mutable
+// layer, preferring the override layer when it is present.
+func (i OverridableIntent) GetEffectivePaymentTerm() productcatalog.PaymentTermType {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.PaymentTerm
+	}
+
+	return i.baseLayer.PaymentTerm
+}
+
+// GetEffectiveFeatureKey returns the feature key from the active mutable layer,
+// preferring the override layer when it is present.
+func (i OverridableIntent) GetEffectiveFeatureKey() string {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.FeatureKey
+	}
+
+	return i.baseLayer.FeatureKey
+}
+
+// GetEffectiveMetaIntentMutableFields returns the shared meta mutable fields
+// from the active mutable layer, preferring the override layer when it is
+// present.
+func (i OverridableIntent) GetEffectiveMetaIntentMutableFields() meta.IntentMutableFields {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.IntentMutableFields
+	}
+
+	return i.baseLayer.IntentMutableFields
+}
+
+func (i OverridableIntent) GetBaseIntent() Intent {
+	return Intent{
+		Intent:              i.intent.Clone(),
+		IntentMutableFields: i.baseLayer.Clone(),
+		SettlementMode:      i.settlementMode,
+	}
+}
+
+func (i OverridableIntent) GetIntentForTarget(target meta.ChangeTarget) (Intent, error) {
+	out := Intent{
+		Intent:         i.intent.Clone(),
+		SettlementMode: i.settlementMode,
+	}
+
+	switch target {
+	case meta.ChangeTargetBase:
+		out.IntentMutableFields = i.baseLayer.Clone()
+	case meta.ChangeTargetOverride:
+		if i.overrideLayer == nil {
+			return Intent{}, fmt.Errorf("override layer not present for charge")
+		}
+
+		out.IntentMutableFields = i.overrideLayer.Clone()
+	default:
+		return Intent{}, fmt.Errorf("invalid change target: %s", target)
+	}
+
+	return out, nil
+}
+
+func (i OverridableIntent) GetOverrideLayerMutableFields() *IntentMutableFields {
+	if i.overrideLayer == nil {
+		return nil
+	}
+
+	return lo.ToPtr(i.overrideLayer.Clone())
+}
+
+func (i OverridableIntent) HasOverrideLayer() bool {
+	return i.overrideLayer != nil
+}
+
+func (i OverridableIntent) GetDeletedAt() *time.Time {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.IntentDeletedAt
+	}
+
+	return i.baseLayer.IntentDeletedAt
 }
 
 func (i OverridableIntent) CalculateAmountAfterProration() (alpacadecimal.Decimal, error) {
@@ -256,68 +378,50 @@ func (i OverridableIntent) CalculateAmountAfterProration() (alpacadecimal.Decima
 	return i.GetEffectiveIntent().CalculateAmountAfterProration()
 }
 
-func (i *OverridableIntent) Mutate(target meta.ChangeTarget) (MutableIntent, error) {
-	return newMutableIntent(i, target)
+func (i *OverridableIntent) MutateEffective(editFn func(IntentMutableFields) (IntentMutableFields, error)) error {
+	target := meta.ChangeTargetBase
+	if i.overrideLayer != nil {
+		target = meta.ChangeTargetOverride
+	}
+
+	return i.Mutate(target, editFn)
 }
 
-type MutableIntent interface {
-	SetServicePeriodTo(time.Time) MutableIntent
-	Save() error
-}
-
-var _ MutableIntent = (*mutableIntent)(nil)
-
-type mutableIntent struct {
-	intent        *OverridableIntent
-	mutableFields IntentMutableFields
-	target        meta.ChangeTarget
-}
-
-func newMutableIntent(intent *OverridableIntent, target meta.ChangeTarget) (*mutableIntent, error) {
+func (i *OverridableIntent) Mutate(target meta.ChangeTarget, editFn func(IntentMutableFields) (IntentMutableFields, error)) error {
+	var targetFields IntentMutableFields
 	switch target {
 	case meta.ChangeTargetBase:
-		return &mutableIntent{
-			intent:        intent,
-			mutableFields: intent.BaseLayer.Clone(),
-			target:        target,
-		}, nil
+		targetFields = i.baseLayer.Clone()
 	case meta.ChangeTargetOverride:
-		if intent.OverrideLayer == nil {
-			return nil, fmt.Errorf("override layer not present for charge")
+		if i.overrideLayer == nil {
+			return fmt.Errorf("override layer not present for charge")
 		}
 
-		return &mutableIntent{
-			intent:        intent,
-			mutableFields: intent.OverrideLayer.Clone(),
-			target:        target,
-		}, nil
-	default:
-		return nil, fmt.Errorf("invalid change target: %s", target)
+		targetFields = i.overrideLayer.Clone()
 	}
-}
 
-func (m *mutableIntent) SetServicePeriodTo(to time.Time) MutableIntent {
-	m.mutableFields.ServicePeriod.To = to
-	return m
-}
+	targetFields, err := editFn(targetFields)
+	if err != nil {
+		return fmt.Errorf("editing intent mutable fields: %w", err)
+	}
 
-func (m *mutableIntent) Save() error {
-	normalizedFields := m.mutableFields.Normalized(m.intent.Currency)
-
+	normalizedFields := targetFields.Normalized(i.intent.Currency)
 	if err := normalizedFields.Validate(); err != nil {
 		return fmt.Errorf("validating intent: %w", err)
 	}
 
-	switch m.target {
+	switch target {
 	case meta.ChangeTargetBase:
-		m.intent.BaseLayer = normalizedFields
+		i.baseLayer = normalizedFields
 	case meta.ChangeTargetOverride:
-		m.intent.OverrideLayer = &normalizedFields
-	default:
-		return fmt.Errorf("invalid change target: %s", m.target)
-	}
+		if i.overrideLayer == nil {
+			return fmt.Errorf("override layer not present for charge")
+		}
 
-	m.mutableFields = normalizedFields
+		i.overrideLayer = &normalizedFields
+	default:
+		return fmt.Errorf("invalid change target: %s", target)
+	}
 
 	return nil
 }

--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -247,7 +247,7 @@ func (i OverridableIntent) Validate() error {
 	var errs []error
 
 	if err := i.intent.Validate(); err != nil {
-		errs = append(errs, err)
+		errs = append(errs, fmt.Errorf("intent: %w", err))
 	}
 
 	if err := i.baseLayer.Validate(); err != nil {

--- a/openmeter/billing/charges/flatfee/service/create.go
+++ b/openmeter/billing/charges/flatfee/service/create.go
@@ -46,8 +46,7 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 			}
 
 			return flatfee.IntentWithInitialStatus{
-				Intent:                    chargeIntent.AsOverridableIntent(),
-				Annotations:               chargeIntent.Annotations,
+				Intent:                    chargeIntent,
 				FeatureID:                 featureID,
 				InitialStatus:             flatfee.StatusCreated,
 				InitialAdvanceAfter:       lo.ToPtr(meta.NormalizeTimestamp(chargeIntent.ServicePeriod.From)),
@@ -69,7 +68,7 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 
 		return slicesx.MapWithErr(charges, func(charge flatfee.Charge) (flatfee.ChargeWithGatheringLine, error) {
 			// For credit only flat fees we are not relying on the invoicing stack at all, so we can return early.
-			if charge.Intent.SettlementMode == productcatalog.CreditOnlySettlementMode {
+			if charge.Intent.GetSettlementMode() == productcatalog.CreditOnlySettlementMode {
 				return flatfee.ChargeWithGatheringLine{
 					Charge: charge,
 				}, nil
@@ -85,8 +84,8 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 
 			gatheringLine, err := buildFlatFeeGatheringLine(buildFlatFeeGatheringLineInput{
 				Charge:        charge,
-				ServicePeriod: charge.Intent.BaseLayer.ServicePeriod,
-				InvoiceAt:     charge.Intent.BaseLayer.InvoiceAt,
+				ServicePeriod: charge.Intent.GetEffectiveServicePeriod(),
+				InvoiceAt:     charge.Intent.GetEffectiveInvoiceAt(),
 			})
 			if err != nil {
 				return flatfee.ChargeWithGatheringLine{}, err
@@ -119,7 +118,7 @@ func (i buildFlatFeeGatheringLineInput) Validate() error {
 		return fmt.Errorf("invoice at is required")
 	}
 
-	if i.Charge.Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+	if i.Charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
 		return fmt.Errorf("charge %s is not credit_then_invoice", i.Charge.ID)
 	}
 
@@ -132,11 +131,10 @@ func buildFlatFeeGatheringLine(input buildFlatFeeGatheringLineInput) (billing.Ga
 	}
 
 	flatFee := input.Charge
-	lineIntent := flatFee.Intent
-	lineIntent.BaseLayer.ServicePeriod = input.ServicePeriod
-	lineIntent.BaseLayer.InvoiceAt = input.InvoiceAt
+	lineIntent := flatFee.Intent.GetEffectiveIntent()
+	lineIntent.ServicePeriod = input.ServicePeriod
+	lineIntent.InvoiceAt = input.InvoiceAt
 	lineIntent = lineIntent.Normalized()
-	lineIntentFields := lineIntent.BaseLayer
 
 	if err := lineIntent.Validate(); err != nil {
 		return billing.GatheringLine{}, fmt.Errorf("validating line intent: %w", err)
@@ -154,13 +152,13 @@ func buildFlatFeeGatheringLine(input buildFlatFeeGatheringLineInput) (billing.Ga
 			PhaseID:        lineIntent.Subscription.PhaseID,
 			ItemID:         lineIntent.Subscription.ItemID,
 			BillingPeriod: timeutil.ClosedPeriod{
-				From: lineIntentFields.BillingPeriod.From,
-				To:   lineIntentFields.BillingPeriod.To,
+				From: lineIntent.BillingPeriod.From,
+				To:   lineIntent.BillingPeriod.To,
 			},
 		}
 	}
 
-	clonedAnnotations, err := flatFee.Intent.Annotations.Clone()
+	clonedAnnotations, err := lineIntent.Annotations.Clone()
 	if err != nil {
 		return billing.GatheringLine{}, fmt.Errorf("cloning annotations: %w", err)
 	}
@@ -169,11 +167,11 @@ func buildFlatFeeGatheringLine(input buildFlatFeeGatheringLineInput) (billing.Ga
 		GatheringLineBase: billing.GatheringLineBase{
 			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
 				Namespace:   flatFee.Namespace,
-				Name:        lineIntentFields.Name,
-				Description: lineIntentFields.Description,
+				Name:        lineIntent.Name,
+				Description: lineIntent.Description,
 			}),
 
-			Metadata:    lineIntentFields.Metadata.Clone(),
+			Metadata:    lineIntent.Metadata.Clone(),
 			Annotations: clonedAnnotations,
 			ManagedBy:   lineIntent.ManagedBy,
 
@@ -181,17 +179,17 @@ func buildFlatFeeGatheringLine(input buildFlatFeeGatheringLineInput) (billing.Ga
 				productcatalog.NewPriceFrom(
 					productcatalog.FlatPrice{
 						Amount:      amountAfterProration,
-						PaymentTerm: lineIntentFields.PaymentTerm,
+						PaymentTerm: lineIntent.PaymentTerm,
 					},
 				),
 			),
-			FeatureKey: lineIntentFields.FeatureKey,
+			FeatureKey: lineIntent.FeatureKey,
 
 			Currency:      lineIntent.Currency,
-			ServicePeriod: lineIntentFields.ServicePeriod,
-			InvoiceAt:     lineIntentFields.InvoiceAt,
+			ServicePeriod: lineIntent.ServicePeriod,
+			InvoiceAt:     lineIntent.InvoiceAt,
 
-			TaxConfig: lo.ToPtr(lineIntentFields.TaxConfig.ToTaxConfig()),
+			TaxConfig: lo.ToPtr(lineIntent.TaxConfig.ToTaxConfig()),
 
 			Engine:       billing.LineEngineTypeChargeFlatFee,
 			ChargeID:     lo.ToPtr(flatFee.ID),
@@ -199,10 +197,10 @@ func buildFlatFeeGatheringLine(input buildFlatFeeGatheringLineInput) (billing.Ga
 		},
 	}
 
-	if lineIntentFields.PercentageDiscounts != nil {
+	if lineIntent.PercentageDiscounts != nil {
 		gatheringLine.RateCardDiscounts = billing.Discounts{
 			Percentage: &billing.PercentageDiscount{
-				PercentageDiscount: *lineIntentFields.PercentageDiscounts,
+				PercentageDiscount: *lineIntent.PercentageDiscounts,
 			},
 		}
 	}

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -42,7 +42,7 @@ func NewCreditThenInvoiceStateMachine(config StateMachineConfig) (*CreditThenInv
 		return nil, fmt.Errorf("validate: %w", err)
 	}
 
-	if config.Charge.Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+	if config.Charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
 		return nil, fmt.Errorf("charge %s is not credit_then_invoice", config.Charge.ID)
 	}
 
@@ -180,7 +180,7 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, _ meta
 }
 
 func (s *CreditThenInvoiceStateMachine) ExtendCharge(ctx context.Context, patch meta.PatchExtend) error {
-	if err := patch.ValidateWith(s.Charge.Intent.BaseLayer.IntentMutableFields); err != nil {
+	if err := patch.ValidateWith(s.Charge.Intent.GetEffectiveMetaIntentMutableFields()); err != nil {
 		return fmt.Errorf("validate extend patch: %w", err)
 	}
 
@@ -193,7 +193,7 @@ func (s *CreditThenInvoiceStateMachine) ExtendCharge(ctx context.Context, patch 
 }
 
 func (s *CreditThenInvoiceStateMachine) ShrinkCharge(ctx context.Context, patch meta.PatchShrink) error {
-	if err := patch.ValidateWith(s.Charge.Intent.BaseLayer.IntentMutableFields); err != nil {
+	if err := patch.ValidateWith(s.Charge.Intent.GetEffectiveMetaIntentMutableFields()); err != nil {
 		return fmt.Errorf("validate shrink patch: %w", err)
 	}
 
@@ -209,11 +209,15 @@ func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(patch periodPatch) (rec
 	oldAmountAfterProration := s.Charge.State.AmountAfterProration
 
 	intent := s.Charge.Intent
-	intent.BaseLayer.ServicePeriod.To = patch.GetNewServicePeriodTo()
-	intent.BaseLayer.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
-	intent.BaseLayer.BillingPeriod.To = patch.GetNewBillingPeriodTo()
-	intent.BaseLayer.InvoiceAt = patch.GetNewInvoiceAt()
-	intent = intent.Normalized()
+	if err := intent.MutateEffective(func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+		fields.ServicePeriod.To = patch.GetNewServicePeriodTo()
+		fields.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
+		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
+		fields.InvoiceAt = patch.GetNewInvoiceAt()
+		return fields, nil
+	}); err != nil {
+		return reconcileInvoicingStateInput{}, fmt.Errorf("mutating effective intent: %w", err)
+	}
 
 	amountAfterProration, err := intent.CalculateAmountAfterProration()
 	if err != nil {
@@ -222,7 +226,7 @@ func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(patch periodPatch) (rec
 
 	return reconcileInvoicingStateInput{
 		Op:                      patch.Op(),
-		Period:                  intent.BaseLayer.ServicePeriod,
+		Period:                  intent.GetEffectiveServicePeriod(),
 		Intent:                  intent,
 		OldAmountAfterProration: oldAmountAfterProration,
 		NewAmountAfterProration: amountAfterProration,
@@ -358,7 +362,7 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 	updatedGatheringLine, err := buildFlatFeeGatheringLine(buildFlatFeeGatheringLineInput{
 		Charge:        s.Charge,
 		ServicePeriod: input.Period,
-		InvoiceAt:     s.Charge.Intent.BaseLayer.InvoiceAt,
+		InvoiceAt:     s.Charge.Intent.GetEffectiveInvoiceAt(),
 	})
 	if err != nil {
 		return fmt.Errorf("creating gathering line for %s period: %w", input.Op, err)
@@ -442,7 +446,7 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 			Charge:     s.Charge,
 			Run:        *currentRun,
 			Line:       *line,
-			AllocateAt: flatfee.UsageBookedAt(s.Charge.Intent.BaseLayer.PaymentTerm, currentRun.ServicePeriod),
+			AllocateAt: flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), currentRun.ServicePeriod),
 		})
 		if err != nil {
 			return fmt.Errorf("reconcile standard line to intent for %s flat-fee charge[%s]: %w", input.Op, s.Charge.ID, err)

--- a/openmeter/billing/charges/flatfee/service/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/creditsonly.go
@@ -23,7 +23,7 @@ func NewCreditsOnlyStateMachine(config StateMachineConfig) (*CreditsOnlyStateMac
 		return nil, fmt.Errorf("validate: %w", err)
 	}
 
-	if config.Charge.Intent.SettlementMode != productcatalog.CreditOnlySettlementMode {
+	if config.Charge.Intent.GetSettlementMode() != productcatalog.CreditOnlySettlementMode {
 		return nil, fmt.Errorf("charge %s is not credit_only", config.Charge.ID)
 	}
 
@@ -69,16 +69,16 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 }
 
 func (s *CreditsOnlyStateMachine) IsAfterInvoiceAt() bool {
-	return !clock.Now().Before(s.Charge.Intent.BaseLayer.InvoiceAt)
+	return !clock.Now().Before(s.Charge.Intent.GetEffectiveInvoiceAt())
 }
 
 func (s *CreditsOnlyStateMachine) AdvanceAfterInvoiceAt(ctx context.Context) error {
-	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.BaseLayer.InvoiceAt))
+	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveInvoiceAt()))
 	return nil
 }
 
 func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {
-	currencyCalculator, err := s.Charge.Intent.Currency.Calculator()
+	currencyCalculator, err := s.Charge.Intent.GetCurrency().Calculator()
 	if err != nil {
 		return fmt.Errorf("get currency calculator: %w", err)
 	}
@@ -92,7 +92,7 @@ func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {
 	if s.Charge.Realizations.CurrentRun == nil {
 		runBase, err := s.Adapter.CreateCurrentRun(ctx, flatfee.CreateCurrentRunInput{
 			Charge:                    s.Charge.ChargeBase,
-			ServicePeriod:             s.Charge.Intent.BaseLayer.ServicePeriod,
+			ServicePeriod:             s.Charge.Intent.GetEffectiveServicePeriod(),
 			AmountAfterProration:      amount,
 			NoFiatTransactionRequired: true, // We are in credits-only mode
 		})
@@ -120,7 +120,7 @@ func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {
 
 func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, policy meta.PatchDeletePolicy) error {
 	if policy.CreditRefundPolicy == meta.CreditRefundPolicyCorrect && s.Charge.Realizations.CurrentRun != nil {
-		currencyCalculator, err := s.Charge.Intent.Currency.Calculator()
+		currencyCalculator, err := s.Charge.Intent.GetCurrency().Calculator()
 		if err != nil {
 			return fmt.Errorf("get currency calculator: %w", err)
 		}
@@ -128,7 +128,7 @@ func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, policy meta.
 		if _, err := s.Realizations.CorrectAllCredits(ctx, flatfeerealizations.CorrectAllCreditRealizationsInput{
 			Charge:             s.Charge,
 			Run:                *s.Charge.Realizations.CurrentRun,
-			AllocateAt:         flatfee.UsageBookedAt(s.Charge.Intent.BaseLayer.PaymentTerm, s.Charge.Realizations.CurrentRun.ServicePeriod),
+			AllocateAt:         flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), s.Charge.Realizations.CurrentRun.ServicePeriod),
 			CurrencyCalculator: currencyCalculator,
 		}); err != nil {
 			return fmt.Errorf("correct credits: %w", err)

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -230,7 +230,7 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 			return fmt.Errorf("flat fee standard line[%s] cannot be deleted because realization run[%s] is still current for charge[%s]", stdLine.ID, run.ID.ID, charge.ID)
 		}
 
-		currencyCalculator, err := charge.Intent.Currency.Calculator()
+		currencyCalculator, err := charge.Intent.GetCurrency().Calculator()
 		if err != nil {
 			return fmt.Errorf("getting currency calculator for charge[%s]: %w", charge.ID, err)
 		}
@@ -238,7 +238,7 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 		if _, err := e.service.realizations.CorrectAllCredits(ctx, flatfeerealizations.CorrectAllCreditRealizationsInput{
 			Charge:             charge,
 			Run:                run,
-			AllocateAt:         flatfee.UsageBookedAt(charge.Intent.BaseLayer.PaymentTerm, run.ServicePeriod),
+			AllocateAt:         flatfee.UsageBookedAt(charge.Intent.GetEffectivePaymentTerm(), run.ServicePeriod),
 			CurrencyCalculator: currencyCalculator,
 		}); err != nil {
 			return fmt.Errorf("correcting credits for deleted flat fee standard line[%s] run[%s]: %w", stdLine.ID, run.ID.ID, err)
@@ -327,11 +327,11 @@ func (e *LineEngine) newStateMachineForStandardLine(ctx context.Context, stdLine
 		return nil, fmt.Errorf("getting flat fee charge for line[%s]: %w", stdLine.ID, err)
 	}
 
-	if charge.Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+	if charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
 		return nil, fmt.Errorf(
 			"flat fee standard line[%s]: unsupported settlement mode for standard invoice lifecycle: %s",
 			stdLine.ID,
-			charge.Intent.SettlementMode,
+			charge.Intent.GetSettlementMode(),
 		)
 	}
 

--- a/openmeter/billing/charges/flatfee/service/realizations/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/creditsonly.go
@@ -53,11 +53,11 @@ func (s *Service) AllocateCreditsOnly(ctx context.Context, in AllocateCreditsOnl
 		return AllocateCreditsOnlyResult{}, nil
 	}
 
-	intentFields := in.Charge.Intent.BaseLayer
+	servicePeriod := in.Charge.Intent.GetEffectiveServicePeriod()
 	input := flatfee.OnAllocateCreditsInput{
 		Charge:                 in.Charge,
-		ServicePeriod:          intentFields.ServicePeriod,
-		BookedAt:               flatfee.UsageBookedAt(intentFields.PaymentTerm, intentFields.ServicePeriod),
+		ServicePeriod:          servicePeriod,
+		BookedAt:               flatfee.UsageBookedAt(in.Charge.Intent.GetEffectivePaymentTerm(), servicePeriod),
 		PreTaxAmountToAllocate: in.Amount,
 	}
 	if err := input.Validate(); err != nil {

--- a/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/credittheninvoice.go
@@ -67,7 +67,7 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 	}
 
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (StartCreditThenInvoiceRunResult, error) {
-		currencyCalculator, err := in.Charge.Intent.Currency.Calculator()
+		currencyCalculator, err := in.Charge.Intent.GetCurrency().Calculator()
 		if err != nil {
 			return StartCreditThenInvoiceRunResult{}, fmt.Errorf("get currency calculator: %w", err)
 		}
@@ -114,7 +114,7 @@ func (s *Service) StartCreditThenInvoiceRun(ctx context.Context, in StartCreditT
 			handlerInput := flatfee.OnAllocateCreditsInput{
 				Charge:                 charge,
 				ServicePeriod:          in.Line.Period,
-				BookedAt:               flatfee.UsageBookedAt(charge.Intent.BaseLayer.PaymentTerm, in.Line.Period),
+				BookedAt:               flatfee.UsageBookedAt(charge.Intent.GetEffectivePaymentTerm(), in.Line.Period),
 				PreTaxAmountToAllocate: creditAllocationTarget,
 			}
 			if err := handlerInput.Validate(); err != nil {
@@ -253,7 +253,7 @@ func (s *Service) ReconcileStandardLineToIntent(ctx context.Context, in Reconcil
 	}
 
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (ReconcileStandardLineToIntentResult, error) {
-		currencyCalculator, err := in.Charge.Intent.Currency.Calculator()
+		currencyCalculator, err := in.Charge.Intent.GetCurrency().Calculator()
 		if err != nil {
 			return ReconcileStandardLineToIntentResult{}, fmt.Errorf("get currency calculator: %w", err)
 		}

--- a/openmeter/billing/charges/flatfee/service/realizations/invoiceaccrued.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/invoiceaccrued.go
@@ -81,7 +81,7 @@ func (s *Service) AccrueInvoiceUsage(ctx context.Context, in AccrueInvoiceUsageI
 			ledgerTransactionRef, err := s.handler.OnInvoiceUsageAccrued(ctx, flatfee.OnInvoiceUsageAccruedInput{
 				Charge:        in.Charge,
 				ServicePeriod: line.Period,
-				BookedAt:      flatfee.UsageBookedAt(in.Charge.Intent.BaseLayer.PaymentTerm, line.Period),
+				BookedAt:      flatfee.UsageBookedAt(in.Charge.Intent.GetEffectivePaymentTerm(), line.Period),
 				Totals:        line.Totals,
 			})
 			if err != nil {

--- a/openmeter/billing/charges/flatfee/service/realizations/preview.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/preview.go
@@ -35,8 +35,8 @@ func (i BuildCreditThenInvoiceGatheringPreviewRunInput) Validate() error {
 		errs = append(errs, fmt.Errorf("line charge id mismatch: got %s, want %s", lineChargeID, i.Charge.ID))
 	}
 
-	if i.Charge.Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
-		errs = append(errs, fmt.Errorf("unsupported settlement mode for gathering preview: %s", i.Charge.Intent.SettlementMode))
+	if i.Charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+		errs = append(errs, fmt.Errorf("unsupported settlement mode for gathering preview: %s", i.Charge.Intent.GetSettlementMode()))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
@@ -56,7 +56,7 @@ func (s *Service) BuildCreditThenInvoiceGatheringPreviewRun(in BuildCreditThenIn
 		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, err
 	}
 
-	currencyCalculator, err := in.Charge.Intent.Currency.Calculator()
+	currencyCalculator, err := in.Charge.Intent.GetCurrency().Calculator()
 	if err != nil {
 		return BuildCreditThenInvoiceGatheringPreviewRunResult{}, fmt.Errorf("get currency calculator: %w", err)
 	}

--- a/openmeter/billing/charges/flatfee/service/realizations/service.go
+++ b/openmeter/billing/charges/flatfee/service/realizations/service.go
@@ -69,13 +69,13 @@ func (s *Service) createCreditAllocations(ctx context.Context, charge flatfee.Ch
 	if err != nil {
 		return creditrealization.Realizations{}, err
 	}
-
+	featureKey := charge.Intent.GetEffectiveFeatureKey()
 	if err := s.lineage.CreateInitialLineages(ctx, lineage.CreateInitialLineagesInput{
 		Namespace:    charge.Namespace,
 		ChargeID:     charge.ID,
-		CustomerID:   charge.Intent.CustomerID,
-		Currency:     charge.Intent.Currency,
-		Features:     lo.Ternary(charge.Intent.BaseLayer.FeatureKey == "", nil, []string{charge.Intent.BaseLayer.FeatureKey}),
+		CustomerID:   charge.Intent.GetCustomerID(),
+		Currency:     charge.Intent.GetCurrency(),
+		Features:     lo.Ternary(featureKey == "", nil, []string{featureKey}),
 		Realizations: realizations,
 	}); err != nil {
 		return creditrealization.Realizations{}, fmt.Errorf("create initial credit realization lineages: %w", err)

--- a/openmeter/billing/charges/flatfee/service/statemachine.go
+++ b/openmeter/billing/charges/flatfee/service/statemachine.go
@@ -94,7 +94,7 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 }
 
 func (s *stateMachine) IsInsideServicePeriod() bool {
-	return !clock.Now().Before(s.Charge.Intent.BaseLayer.ServicePeriod.From)
+	return !clock.Now().Before(s.Charge.Intent.GetEffectiveServicePeriod().From)
 }
 
 func (s *stateMachine) IsInsideServicePeriodAndZeroAmount() bool {
@@ -110,12 +110,12 @@ func (s *stateMachine) IsZeroAmount() bool {
 }
 
 func (s *stateMachine) AdvanceAfterServicePeriodFrom(ctx context.Context) error {
-	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.BaseLayer.ServicePeriod.From))
+	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().From))
 	return nil
 }
 
 func (s *stateMachine) AdvanceAfterServicePeriodTo(ctx context.Context) error {
-	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.BaseLayer.ServicePeriod.To))
+	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().To))
 	return nil
 }
 

--- a/openmeter/billing/charges/flatfee/service/triggers.go
+++ b/openmeter/billing/charges/flatfee/service/triggers.go
@@ -76,7 +76,7 @@ func (s *service) TriggerPatch(ctx context.Context, chargeID meta.ChargeID, patc
 }
 
 func (s *service) newStateMachine(config StateMachineConfig) (StateMachine, error) {
-	switch config.Charge.Intent.SettlementMode {
+	switch config.Charge.Intent.GetSettlementMode() {
 	case productcatalog.CreditOnlySettlementMode:
 		stateMachine, err := NewCreditsOnlyStateMachine(config)
 		if err != nil {
@@ -93,7 +93,7 @@ func (s *service) newStateMachine(config StateMachineConfig) (StateMachine, erro
 		return stateMachine, nil
 	default:
 		return nil, models.NewGenericNotImplementedError(
-			fmt.Errorf("unsupported settlement mode %s for flat fee charge %s", config.Charge.Intent.SettlementMode, config.Charge.ID),
+			fmt.Errorf("unsupported settlement mode %s for flat fee charge %s", config.Charge.Intent.GetSettlementMode(), config.Charge.ID),
 		)
 	}
 }

--- a/openmeter/billing/charges/service/create.go
+++ b/openmeter/billing/charges/service/create.go
@@ -174,10 +174,7 @@ func (s *service) create(ctx context.Context, input charges.CreateInput) (*charg
 			if fee.GatheringLineToCreate != nil {
 				gatheringLinesToCreate = append(gatheringLinesToCreate, gatheringLineWithCustomerID{
 					gatheringLine: *fee.GatheringLineToCreate,
-					customerID: customer.CustomerID{
-						Namespace: input.Namespace,
-						ID:        fee.Charge.Intent.CustomerID,
-					},
+					customerID:    fee.Charge.GetCustomerID(),
 				})
 			}
 		}
@@ -208,10 +205,7 @@ func (s *service) create(ctx context.Context, input charges.CreateInput) (*charg
 			if charge.GatheringLineToCreate != nil {
 				gatheringLinesToCreate = append(gatheringLinesToCreate, gatheringLineWithCustomerID{
 					gatheringLine: *charge.GatheringLineToCreate,
-					customerID: customer.CustomerID{
-						Namespace: input.Namespace,
-						ID:        charge.Charge.Intent.CustomerID,
-					},
+					customerID:    charge.Charge.GetCustomerID(),
 				})
 			}
 		}
@@ -238,11 +232,8 @@ func (s *service) create(ctx context.Context, input charges.CreateInput) (*charg
 				}
 
 				gatheringLinesToCreate = append(gatheringLinesToCreate, gatheringLineWithCustomerID{
-					gatheringLine: *result.GatheringLineToCreate,
-					customerID: customer.CustomerID{
-						Namespace: input.Namespace,
-						ID:        result.Charge.Intent.CustomerID,
-					},
+					gatheringLine:             *result.GatheringLineToCreate,
+					customerID:                result.Charge.GetCustomerID(),
 					BypassCollectionAlignment: bypassCollectionAlignment,
 				})
 			}
@@ -288,7 +279,7 @@ func (s *service) create(ctx context.Context, input charges.CreateInput) (*charg
 // a worker will try to advance the charges again).
 func (s *service) autoAdvanceCreatedCharges(ctx context.Context, created charges.Charges) (charges.Charges, error) {
 	// Collect unique customer IDs that have newly created credit-only charges.
-	customerIDs := make(map[customer.CustomerID]struct{})
+	customerIDs := make([]customer.CustomerID, 0)
 	for _, c := range created {
 		switch c.Type() {
 		case meta.ChargeTypeUsageBased:
@@ -297,7 +288,7 @@ func (s *service) autoAdvanceCreatedCharges(ctx context.Context, created charges
 				return nil, err
 			}
 
-			if ub.Intent.SettlementMode != productcatalog.CreditOnlySettlementMode {
+			if ub.Intent.GetSettlementMode() != productcatalog.CreditOnlySettlementMode {
 				continue
 			}
 
@@ -305,7 +296,7 @@ func (s *service) autoAdvanceCreatedCharges(ctx context.Context, created charges
 				continue
 			}
 
-			customerIDs[customer.CustomerID{Namespace: ub.Namespace, ID: ub.Intent.CustomerID}] = struct{}{}
+			customerIDs = append(customerIDs, ub.GetCustomerID())
 
 		case meta.ChargeTypeFlatFee:
 			ff, err := c.AsFlatFeeCharge()
@@ -313,7 +304,7 @@ func (s *service) autoAdvanceCreatedCharges(ctx context.Context, created charges
 				return nil, err
 			}
 
-			if ff.Intent.SettlementMode != productcatalog.CreditOnlySettlementMode {
+			if ff.Intent.GetSettlementMode() != productcatalog.CreditOnlySettlementMode {
 				continue
 			}
 
@@ -321,16 +312,17 @@ func (s *service) autoAdvanceCreatedCharges(ctx context.Context, created charges
 				continue
 			}
 
-			customerIDs[customer.CustomerID{Namespace: ff.Namespace, ID: ff.Intent.CustomerID}] = struct{}{}
+			customerIDs = append(customerIDs, ff.GetCustomerID())
 		}
 	}
+	customerIDs = lo.Uniq(customerIDs)
 
 	if len(customerIDs) == 0 {
 		return created, nil
 	}
 
 	advancedByID := make(map[string]charges.Charge)
-	for custID := range customerIDs {
+	for _, custID := range customerIDs {
 		advancedCharges, err := s.AdvanceCharges(ctx, charges.AdvanceChargesInput{
 			Customer: custID,
 		})

--- a/openmeter/billing/charges/service/featureid_test.go
+++ b/openmeter/billing/charges/service/featureid_test.go
@@ -205,7 +205,7 @@ func (s *ChargeFeatureIDTestSuite) TestUsageBasedActivationRecalculatesFeatureID
 		return creditrealization.CreateAllocationInputs{
 			{
 				Amount:        input.AmountToAllocate,
-				ServicePeriod: input.Charge.Intent.BaseLayer.ServicePeriod,
+				ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
 				LedgerTransaction: ledgertransaction.GroupReference{
 					TransactionGroupID: ulid.Make().String(),
 				},

--- a/openmeter/billing/charges/service/handlers_test.go
+++ b/openmeter/billing/charges/service/handlers_test.go
@@ -234,7 +234,7 @@ func newCappedCreditAllocator(availableCredits float64) (func(ctx context.Contex
 
 		return creditrealization.CreateAllocationInputs{
 			{
-				ServicePeriod: input.Charge.Intent.BaseLayer.ServicePeriod,
+				ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
 				Amount:        amount,
 				LedgerTransaction: ledgertransaction.GroupReference{
 					TransactionGroupID: ulid.Make().String(),

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -1269,7 +1269,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycle() {
 
 			return creditrealization.CreateAllocationInputs{
 				{
-					ServicePeriod: input.Charge.Intent.BaseLayer.ServicePeriod,
+					ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
 					Amount:        input.AmountToAllocate,
 					LedgerTransaction: ledgertransaction.GroupReference{
 						TransactionGroupID: ulid.Make().String(),
@@ -1372,7 +1372,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycle() {
 
 			return creditrealization.CreateAllocationInputs{
 				{
-					ServicePeriod: input.Charge.Intent.BaseLayer.ServicePeriod,
+					ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
 					Amount:        input.AmountToAllocate,
 					LedgerTransaction: ledgertransaction.GroupReference{
 						TransactionGroupID: ulid.Make().String(),
@@ -1555,7 +1555,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTier
 			startedCallbacks = append(startedCallbacks, startedInvocation{Input: input})
 
 			s.Equal(usageBasedChargeID.ID, input.Charge.ID)
-			s.Equal(productcatalog.CreditOnlySettlementMode, input.Charge.Intent.SettlementMode)
+			s.Equal(productcatalog.CreditOnlySettlementMode, input.Charge.Intent.GetSettlementMode())
 			s.Equal(usagebased.RealizationRunTypeFinalRealization, input.Run.Type)
 			s.True(servicePeriod.To.Equal(input.BookedAt))
 			s.Equal(float64(20), input.AmountToAllocate.InexactFloat64())
@@ -1568,7 +1568,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTier
 
 			return creditrealization.CreateAllocationInputs{
 				{
-					ServicePeriod: input.Charge.Intent.BaseLayer.ServicePeriod,
+					ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
 					Amount:        input.AmountToAllocate,
 					LedgerTransaction: ledgertransaction.GroupReference{
 						TransactionGroupID: ulid.Make().String(),
@@ -1624,7 +1624,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreditOnlyLifecycleVolumeTier
 			correctedCallbacks = append(correctedCallbacks, correctedInvocation{Input: input})
 
 			s.Equal(usageBasedChargeID.ID, input.Charge.ID)
-			s.Equal(productcatalog.CreditOnlySettlementMode, input.Charge.Intent.SettlementMode)
+			s.Equal(productcatalog.CreditOnlySettlementMode, input.Charge.Intent.GetSettlementMode())
 			s.Equal(usagebased.RealizationRunTypeFinalRealization, input.Run.Type)
 			s.True(servicePeriod.To.Equal(input.BookedAt))
 			s.Equal(float64(10), input.Run.MeteredQuantity.InexactFloat64())
@@ -2463,7 +2463,7 @@ func (s *InvoicableChargesTestSuite) TestUsageBasedCreateImmediatelyFinal() {
 	s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued = func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
 		return creditrealization.CreateAllocationInputs{
 			{
-				ServicePeriod: input.Charge.Intent.BaseLayer.ServicePeriod,
+				ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
 				Amount:        input.AmountToAllocate,
 				LedgerTransaction: ledgertransaction.GroupReference{
 					TransactionGroupID: ulid.Make().String(),
@@ -2637,7 +2637,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyLifecycle() {
 
 			return creditrealization.CreateAllocationInputs{
 				{
-					ServicePeriod: input.Charge.Intent.BaseLayer.ServicePeriod,
+					ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
 					Amount:        input.PreTaxAmountToAllocate,
 					LedgerTransaction: ledgertransaction.GroupReference{
 						TransactionGroupID: ulid.Make().String(),
@@ -2716,7 +2716,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyCreateImmediatelyFinal
 	s.FlatFeeTestHandler.onAllocateCredits = func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 		return creditrealization.CreateAllocationInputs{
 			{
-				ServicePeriod: input.Charge.Intent.BaseLayer.ServicePeriod,
+				ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
 				Amount:        input.PreTaxAmountToAllocate,
 				LedgerTransaction: ledgertransaction.GroupReference{
 					TransactionGroupID: ulid.Make().String(),
@@ -2800,7 +2800,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyInArrearsActivatesAtSe
 	s.FlatFeeTestHandler.onAllocateCredits = allocateCreditsCallback.Handler(s.T(), func(input flatfee.OnAllocateCreditsInput, ledgerTransaction ledgertransaction.GroupReference) creditrealization.CreateAllocationInputs {
 		return creditrealization.CreateAllocationInputs{
 			{
-				ServicePeriod:     input.Charge.Intent.BaseLayer.ServicePeriod,
+				ServicePeriod:     input.Charge.Intent.GetEffectiveServicePeriod(),
 				Amount:            input.PreTaxAmountToAllocate,
 				LedgerTransaction: ledgerTransaction,
 			},

--- a/openmeter/billing/charges/service/lineage_test.go
+++ b/openmeter/billing/charges/service/lineage_test.go
@@ -78,7 +78,7 @@ func (s *CreditRealizationLineageTestSuite) TestFlatFeeCreditOnlyAllocationCreat
 	s.FlatFeeTestHandler.onAllocateCredits = func(ctx context.Context, input flatfee.OnAllocateCreditsInput) (creditrealization.CreateAllocationInputs, error) {
 		return creditrealization.CreateAllocationInputs{
 			{
-				ServicePeriod: input.Charge.Intent.BaseLayer.ServicePeriod,
+				ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
 				Amount:        alpacadecimal.NewFromInt(20),
 				Annotations:   creditrealization.LineageAnnotations(creditrealization.LineageOriginKindRealCredit),
 				LedgerTransaction: ledgertransaction.GroupReference{
@@ -86,7 +86,7 @@ func (s *CreditRealizationLineageTestSuite) TestFlatFeeCreditOnlyAllocationCreat
 				},
 			},
 			{
-				ServicePeriod: input.Charge.Intent.BaseLayer.ServicePeriod,
+				ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
 				Amount:        alpacadecimal.NewFromInt(30),
 				Annotations:   creditrealization.LineageAnnotations(creditrealization.LineageOriginKindAdvance),
 				LedgerTransaction: ledgertransaction.GroupReference{
@@ -163,7 +163,7 @@ func (s *CreditRealizationLineageTestSuite) TestUsageBasedCreditOnlyAllocationCr
 	s.UsageBasedTestHandler.onCreditsOnlyUsageAccrued = func(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
 		return creditrealization.CreateAllocationInputs{
 			{
-				ServicePeriod: input.Charge.Intent.BaseLayer.ServicePeriod,
+				ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
 				Amount:        input.AmountToAllocate,
 				Annotations:   creditrealization.LineageAnnotations(creditrealization.LineageOriginKindAdvance),
 				LedgerTransaction: ledgertransaction.GroupReference{

--- a/openmeter/billing/charges/service/pendinglines_test.go
+++ b/openmeter/billing/charges/service/pendinglines_test.go
@@ -111,12 +111,13 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 	})
 	usageBasedCharge, err := usageCharge.AsUsageBasedCharge()
 	s.NoError(err)
-	s.Equal(productcatalog.CreditThenInvoiceSettlementMode, usageBasedCharge.Intent.SettlementMode)
-	s.Equal(billing.ManuallyManagedLine, usageBasedCharge.Intent.ManagedBy)
-	s.Equal("manual-usage", lo.FromPtr(usageBasedCharge.Intent.UniqueReferenceID))
-	s.Equal(featureKey, usageBasedCharge.Intent.BaseLayer.FeatureKey)
-	s.Require().NotNil(usageBasedCharge.Intent.BaseLayer.Discounts.Usage)
-	s.Equal(float64(3), usageBasedCharge.Intent.BaseLayer.Discounts.Usage.Quantity.InexactFloat64())
+	usageBasedIntent := usageBasedCharge.Intent.GetBaseIntent()
+	s.Equal(productcatalog.CreditThenInvoiceSettlementMode, usageBasedCharge.Intent.GetSettlementMode())
+	s.Equal(billing.ManuallyManagedLine, usageBasedIntent.ManagedBy)
+	s.Equal("manual-usage", lo.FromPtr(usageBasedCharge.Intent.GetUniqueReferenceID()))
+	s.Equal(featureKey, usageBasedIntent.FeatureKey)
+	s.Require().NotNil(usageBasedIntent.Discounts.Usage)
+	s.Equal(float64(3), usageBasedIntent.Discounts.Usage.Quantity.InexactFloat64())
 
 	flatCharge := s.mustGetChargeByID(meta.ChargeID{
 		Namespace: ns,
@@ -124,13 +125,14 @@ func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesCreatesChargeB
 	})
 	flatFeeCharge, err := flatCharge.AsFlatFeeCharge()
 	s.NoError(err)
-	s.Equal(productcatalog.CreditThenInvoiceSettlementMode, flatFeeCharge.Intent.SettlementMode)
-	s.Equal(billing.ManuallyManagedLine, flatFeeCharge.Intent.ManagedBy)
-	s.Equal("manual-flat", lo.FromPtr(flatFeeCharge.Intent.UniqueReferenceID))
-	s.Equal(productcatalog.InAdvancePaymentTerm, flatFeeCharge.Intent.BaseLayer.PaymentTerm)
-	s.Equal(float64(10), flatFeeCharge.Intent.BaseLayer.AmountBeforeProration.InexactFloat64())
-	s.Require().NotNil(flatFeeCharge.Intent.BaseLayer.PercentageDiscounts)
-	s.Equal(float64(10), flatFeeCharge.Intent.BaseLayer.PercentageDiscounts.Percentage.InexactFloat64())
+	flatFeeIntent := flatFeeCharge.Intent.GetBaseIntent()
+	s.Equal(productcatalog.CreditThenInvoiceSettlementMode, flatFeeCharge.Intent.GetSettlementMode())
+	s.Equal(billing.ManuallyManagedLine, flatFeeIntent.ManagedBy)
+	s.Equal("manual-flat", lo.FromPtr(flatFeeCharge.Intent.GetUniqueReferenceID()))
+	s.Equal(productcatalog.InAdvancePaymentTerm, flatFeeIntent.PaymentTerm)
+	s.Equal(float64(10), flatFeeIntent.AmountBeforeProration.InexactFloat64())
+	s.Require().NotNil(flatFeeIntent.PercentageDiscounts)
+	s.Equal(float64(10), flatFeeIntent.PercentageDiscounts.Percentage.InexactFloat64())
 }
 
 func (s *InvoicableChargesTestSuite) TestCreatePendingInvoiceLinesRollsBackCreatedChargesOnFailure() {

--- a/openmeter/billing/charges/service/taxcode_test.go
+++ b/openmeter/billing/charges/service/taxcode_test.go
@@ -98,10 +98,10 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeChargePersistsTaxConfig() {
 		flatFee, err := readBack.AsFlatFeeCharge()
 		s.NoError(err)
 
-		s.Require().NotNil(flatFee.Intent.BaseLayer.TaxConfig.Behavior, "TaxBehavior must be persisted")
-		s.Equal(productcatalog.InclusiveTaxBehavior, *flatFee.Intent.BaseLayer.TaxConfig.Behavior)
-		s.Require().NotEmpty(flatFee.Intent.BaseLayer.TaxConfig.TaxCodeID, "TaxCodeID must be persisted as FK")
-		s.Equal(tc.ID, flatFee.Intent.BaseLayer.TaxConfig.TaxCodeID)
+		s.Require().NotNil(flatFee.Intent.GetEffectiveTaxConfig().Behavior, "TaxBehavior must be persisted")
+		s.Equal(productcatalog.InclusiveTaxBehavior, *flatFee.Intent.GetEffectiveTaxConfig().Behavior)
+		s.Require().NotEmpty(flatFee.Intent.GetEffectiveTaxConfig().TaxCodeID, "TaxCodeID must be persisted as FK")
+		s.Equal(tc.ID, flatFee.Intent.GetEffectiveTaxConfig().TaxCodeID)
 	})
 
 	s.Run("nil tax config gets default invoicing tax code stamped", func() {
@@ -134,9 +134,9 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeChargePersistsTaxConfig() {
 		s.NoError(err)
 
 		// nil TaxConfig intents get the namespace default invoicing TaxCodeID stamped.
-		s.Require().NotEmpty(flatFee.Intent.BaseLayer.TaxConfig.TaxCodeID, "default invoicing TaxCodeID must be stamped")
-		s.Equal(defaults.InvoicingTaxCodeID, flatFee.Intent.BaseLayer.TaxConfig.TaxCodeID)
-		s.Nil(flatFee.Intent.BaseLayer.TaxConfig.Behavior, "Behavior must remain nil when only default TaxCodeID is stamped")
+		s.Require().NotEmpty(flatFee.Intent.GetEffectiveTaxConfig().TaxCodeID, "default invoicing TaxCodeID must be stamped")
+		s.Equal(defaults.InvoicingTaxCodeID, flatFee.Intent.GetEffectiveTaxConfig().TaxCodeID)
+		s.Nil(flatFee.Intent.GetEffectiveTaxConfig().Behavior, "Behavior must remain nil when only default TaxCodeID is stamped")
 	})
 }
 
@@ -194,10 +194,10 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedChargePersistsTaxConfig() {
 		usageBased, err := readBack.AsUsageBasedCharge()
 		s.NoError(err)
 
-		s.Require().NotNil(usageBased.Intent.BaseLayer.TaxConfig.Behavior, "TaxBehavior must be persisted")
-		s.Equal(productcatalog.ExclusiveTaxBehavior, *usageBased.Intent.BaseLayer.TaxConfig.Behavior)
-		s.Require().NotEmpty(usageBased.Intent.BaseLayer.TaxConfig.TaxCodeID, "TaxCodeID must be persisted as FK")
-		s.Equal(tc.ID, usageBased.Intent.BaseLayer.TaxConfig.TaxCodeID)
+		s.Require().NotNil(usageBased.Intent.GetEffectiveTaxConfig().Behavior, "TaxBehavior must be persisted")
+		s.Equal(productcatalog.ExclusiveTaxBehavior, *usageBased.Intent.GetEffectiveTaxConfig().Behavior)
+		s.Require().NotEmpty(usageBased.Intent.GetEffectiveTaxConfig().TaxCodeID, "TaxCodeID must be persisted as FK")
+		s.Equal(tc.ID, usageBased.Intent.GetEffectiveTaxConfig().TaxCodeID)
 	})
 
 	s.Run("nil tax config gets default invoicing tax code stamped", func() {
@@ -230,9 +230,9 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedChargePersistsTaxConfig() {
 		s.NoError(err)
 
 		// nil TaxConfig intents get the namespace default invoicing TaxCodeID stamped.
-		s.Require().NotEmpty(usageBased.Intent.BaseLayer.TaxConfig.TaxCodeID, "default invoicing TaxCodeID must be stamped")
-		s.Equal(defaults.InvoicingTaxCodeID, usageBased.Intent.BaseLayer.TaxConfig.TaxCodeID)
-		s.Nil(usageBased.Intent.BaseLayer.TaxConfig.Behavior, "Behavior must remain nil when only default TaxCodeID is stamped")
+		s.Require().NotEmpty(usageBased.Intent.GetEffectiveTaxConfig().TaxCodeID, "default invoicing TaxCodeID must be stamped")
+		s.Equal(defaults.InvoicingTaxCodeID, usageBased.Intent.GetEffectiveTaxConfig().TaxCodeID)
+		s.Nil(usageBased.Intent.GetEffectiveTaxConfig().Behavior, "Behavior must remain nil when only default TaxCodeID is stamped")
 	})
 }
 
@@ -594,7 +594,7 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeCreditOnlyHandlerReceivesTaxCon
 		capturedInput = input
 		return creditrealization.CreateAllocationInputs{
 			{
-				ServicePeriod: input.Charge.Intent.BaseLayer.ServicePeriod,
+				ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
 				Amount:        input.PreTaxAmountToAllocate,
 				LedgerTransaction: ledgertransaction.GroupReference{
 					TransactionGroupID: ulid.Make().String(),
@@ -609,10 +609,10 @@ func (s *TaxCodePersistenceTestSuite) TestFlatFeeCreditOnlyHandlerReceivesTaxCon
 	s.NoError(err)
 	s.Require().Len(advancedCharges, 1)
 
-	s.Require().NotNil(capturedInput.Charge.Intent.BaseLayer.TaxConfig.Behavior)
-	s.Equal(productcatalog.InclusiveTaxBehavior, *capturedInput.Charge.Intent.BaseLayer.TaxConfig.Behavior)
-	s.Require().NotEmpty(capturedInput.Charge.Intent.BaseLayer.TaxConfig.TaxCodeID)
-	s.Equal(tc.ID, capturedInput.Charge.Intent.BaseLayer.TaxConfig.TaxCodeID)
+	s.Require().NotNil(capturedInput.Charge.Intent.GetEffectiveTaxConfig().Behavior)
+	s.Equal(productcatalog.InclusiveTaxBehavior, *capturedInput.Charge.Intent.GetEffectiveTaxConfig().Behavior)
+	s.Require().NotEmpty(capturedInput.Charge.Intent.GetEffectiveTaxConfig().TaxCodeID)
+	s.Equal(tc.ID, capturedInput.Charge.Intent.GetEffectiveTaxConfig().TaxCodeID)
 }
 
 // TestUsageBasedCreditOnlyHandlerReceivesTaxConfig verifies that when a credit-only usage-based
@@ -677,7 +677,7 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedCreditOnlyHandlerReceivesTax
 		capturedInput = input
 		return creditrealization.CreateAllocationInputs{
 			{
-				ServicePeriod: input.Charge.Intent.BaseLayer.ServicePeriod,
+				ServicePeriod: input.Charge.Intent.GetEffectiveServicePeriod(),
 				Amount:        input.AmountToAllocate,
 				LedgerTransaction: ledgertransaction.GroupReference{
 					TransactionGroupID: ulid.Make().String(),
@@ -691,10 +691,10 @@ func (s *TaxCodePersistenceTestSuite) TestUsageBasedCreditOnlyHandlerReceivesTax
 	_, err = s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{Customer: cust.GetID()})
 	s.NoError(err)
 
-	s.Require().NotNil(capturedInput.Charge.Intent.BaseLayer.TaxConfig.Behavior)
-	s.Equal(productcatalog.ExclusiveTaxBehavior, *capturedInput.Charge.Intent.BaseLayer.TaxConfig.Behavior)
-	s.Require().NotEmpty(capturedInput.Charge.Intent.BaseLayer.TaxConfig.TaxCodeID)
-	s.Equal(tc.ID, capturedInput.Charge.Intent.BaseLayer.TaxConfig.TaxCodeID)
+	s.Require().NotNil(capturedInput.Charge.Intent.GetEffectiveTaxConfig().Behavior)
+	s.Equal(productcatalog.ExclusiveTaxBehavior, *capturedInput.Charge.Intent.GetEffectiveTaxConfig().Behavior)
+	s.Require().NotEmpty(capturedInput.Charge.Intent.GetEffectiveTaxConfig().TaxCodeID)
+	s.Equal(tc.ID, capturedInput.Charge.Intent.GetEffectiveTaxConfig().TaxCodeID)
 }
 
 // TestFlatFeeInvoiceSettlementPopulatesStripeCodeOnStandardInvoice verifies the dual-write
@@ -899,25 +899,25 @@ func (s *TaxCodePersistenceTestSuite) TestTaxConfigInListCharges() {
 			ff, err := charge.AsFlatFeeCharge()
 			s.Require().NoError(err)
 
-			if ff.Intent.Intent.UniqueReferenceID != nil && *ff.Intent.Intent.UniqueReferenceID == "flat-fee-list-no-taxcode" {
+			if ff.Intent.GetUniqueReferenceID() != nil && *ff.Intent.GetUniqueReferenceID() == "flat-fee-list-no-taxcode" {
 				// nil TaxConfig intents get the default invoicing TaxCodeID stamped.
-				s.Require().NotEmpty(ff.Intent.BaseLayer.TaxConfig.TaxCodeID)
-				s.Equal(defaults.InvoicingTaxCodeID, ff.Intent.BaseLayer.TaxConfig.TaxCodeID)
-				s.Nil(ff.Intent.BaseLayer.TaxConfig.Behavior)
+				s.Require().NotEmpty(ff.Intent.GetEffectiveTaxConfig().TaxCodeID)
+				s.Equal(defaults.InvoicingTaxCodeID, ff.Intent.GetEffectiveTaxConfig().TaxCodeID)
+				s.Nil(ff.Intent.GetEffectiveTaxConfig().Behavior)
 			} else {
-				s.Require().NotNil(ff.Intent.BaseLayer.TaxConfig.Behavior)
-				s.Equal(productcatalog.InclusiveTaxBehavior, *ff.Intent.BaseLayer.TaxConfig.Behavior)
-				s.Require().NotEmpty(ff.Intent.BaseLayer.TaxConfig.TaxCodeID)
-				s.Equal(tc.ID, ff.Intent.BaseLayer.TaxConfig.TaxCodeID)
+				s.Require().NotNil(ff.Intent.GetEffectiveTaxConfig().Behavior)
+				s.Equal(productcatalog.InclusiveTaxBehavior, *ff.Intent.GetEffectiveTaxConfig().Behavior)
+				s.Require().NotEmpty(ff.Intent.GetEffectiveTaxConfig().TaxCodeID)
+				s.Equal(tc.ID, ff.Intent.GetEffectiveTaxConfig().TaxCodeID)
 			}
 
 		case meta.ChargeTypeUsageBased:
 			ub, err := charge.AsUsageBasedCharge()
 			s.Require().NoError(err)
-			s.Require().NotNil(ub.Intent.BaseLayer.TaxConfig.Behavior)
-			s.Equal(productcatalog.InclusiveTaxBehavior, *ub.Intent.BaseLayer.TaxConfig.Behavior)
-			s.Require().NotEmpty(ub.Intent.BaseLayer.TaxConfig.TaxCodeID)
-			s.Equal(tc.ID, ub.Intent.BaseLayer.TaxConfig.TaxCodeID)
+			s.Require().NotNil(ub.Intent.GetEffectiveTaxConfig().Behavior)
+			s.Equal(productcatalog.InclusiveTaxBehavior, *ub.Intent.GetEffectiveTaxConfig().Behavior)
+			s.Require().NotEmpty(ub.Intent.GetEffectiveTaxConfig().TaxCodeID)
+			s.Equal(tc.ID, ub.Intent.GetEffectiveTaxConfig().TaxCodeID)
 
 		default:
 			s.Failf("unexpected charge type", "type=%s", string(charge.Type()))

--- a/openmeter/billing/charges/service/truncation_test.go
+++ b/openmeter/billing/charges/service/truncation_test.go
@@ -92,10 +92,10 @@ func (s *ChargeTimestampTruncationTestSuite) TestCreateTruncatesFlatFeeIntentAnd
 	}
 	expectedInvoiceAt := datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:01Z", time.UTC).AsTime()
 
-	s.Equal(expectedServicePeriod, createdFlatFee.Intent.BaseLayer.ServicePeriod)
-	s.Equal(expectedFullServicePeriod, createdFlatFee.Intent.BaseLayer.FullServicePeriod)
-	s.Equal(expectedServicePeriod, createdFlatFee.Intent.BaseLayer.BillingPeriod)
-	s.True(expectedInvoiceAt.Equal(createdFlatFee.Intent.BaseLayer.InvoiceAt))
+	s.Equal(expectedServicePeriod, createdFlatFee.Intent.GetEffectiveServicePeriod())
+	s.Equal(expectedFullServicePeriod, createdFlatFee.Intent.GetEffectiveIntent().FullServicePeriod)
+	s.Equal(expectedServicePeriod, createdFlatFee.Intent.GetEffectiveIntent().BillingPeriod)
+	s.True(expectedInvoiceAt.Equal(createdFlatFee.Intent.GetEffectiveInvoiceAt()))
 	s.True(alpacadecimal.NewFromInt(60).Equal(createdFlatFee.State.AmountAfterProration))
 }
 
@@ -156,9 +156,9 @@ func (s *ChargeTimestampTruncationTestSuite) TestUsageBasedAdvanceTruncatesPersi
 			From: datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
 			To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:01:00Z", time.UTC).AsTime(),
 		},
-		createdUsageBased.Intent.BaseLayer.ServicePeriod,
+		createdUsageBased.Intent.GetEffectiveServicePeriod(),
 	)
-	s.True(datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:01:00Z", time.UTC).AsTime().Equal(createdUsageBased.Intent.BaseLayer.InvoiceAt))
+	s.True(datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:01:00Z", time.UTC).AsTime().Equal(createdUsageBased.Intent.GetEffectiveInvoiceAt()))
 
 	clock.FreezeTime(datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:02:00.900Z", time.UTC).AsTime())
 

--- a/openmeter/billing/charges/testutils/handlers.go
+++ b/openmeter/billing/charges/testutils/handlers.go
@@ -110,7 +110,7 @@ func (mockUsageBasedHandler) OnPaymentSettled(context.Context, usagebased.OnPaym
 func (mockUsageBasedHandler) OnCreditsOnlyUsageAccrued(_ context.Context, input usagebased.CreditsOnlyUsageAccruedInput) (creditrealization.CreateAllocationInputs, error) {
 	return creditrealization.CreateAllocationInputs{
 		{
-			ServicePeriod:     input.Charge.Intent.BaseLayer.ServicePeriod,
+			ServicePeriod:     input.Charge.Intent.GetEffectiveServicePeriod(),
 			LedgerTransaction: newMockLedgerTransactionGroupReference(),
 			Amount:            input.AmountToAllocate,
 		},

--- a/openmeter/billing/charges/usagebased/adapter.go
+++ b/openmeter/billing/charges/usagebased/adapter.go
@@ -23,7 +23,7 @@ type Adapter interface {
 type ChargeAdapter interface {
 	CreateCharges(ctx context.Context, charges CreateChargesInput) ([]Charge, error)
 	UpdateCharge(ctx context.Context, charge ChargeBase) (ChargeBase, error)
-	CreateChargeOverride(ctx context.Context, charge ChargeBase) (ChargeBase, error)
+	CreateChargeOverride(ctx context.Context, charge ChargeBase, override IntentMutableFields) (ChargeBase, error)
 	DeleteChargeOverride(ctx context.Context, charge ChargeBase) (ChargeBase, error)
 	UpdateSubscriptionItemID(ctx context.Context, charge Charge, newSubscriptionItemID string) (Charge, error)
 	DeleteCharge(ctx context.Context, charge Charge) error

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -33,14 +33,16 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge usagebased.ChargeBase
 			return usagebased.ChargeBase{}, err
 		}
 
+		baseIntent := charge.Intent.GetBaseIntent()
+
 		update := tx.db.ChargeUsageBased.UpdateOneID(charge.ID).
 			Where(dbchargeusagebased.NamespaceEQ(charge.Namespace)).
-			SetDiscounts(&charge.Intent.BaseLayer.Discounts).
-			SetFeatureKey(charge.Intent.BaseLayer.FeatureKey).
+			SetDiscounts(&baseIntent.Discounts).
+			SetFeatureKey(baseIntent.FeatureKey).
 			SetFeatureID(charge.State.FeatureID).
-			SetOrClearIntentDeletedAt(convert.TimePtrIn(charge.Intent.BaseLayer.IntentDeletedAt, time.UTC)).
-			SetInvoiceAt(meta.NormalizeTimestamp(charge.Intent.BaseLayer.InvoiceAt).In(time.UTC)).
-			SetPrice(&charge.Intent.BaseLayer.Price).
+			SetOrClearIntentDeletedAt(convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)).
+			SetInvoiceAt(meta.NormalizeTimestamp(baseIntent.InvoiceAt).In(time.UTC)).
+			SetPrice(&baseIntent.Price).
 			SetRatingEngine(charge.State.RatingEngine).
 			SetStatus(metaStatus).
 			SetStatusDetailed(charge.Status).
@@ -48,8 +50,8 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge usagebased.ChargeBase
 
 		update, err = chargemeta.Update(update, chargemeta.UpdateInput{
 			ManagedResource:     charge.ManagedResource,
-			IntentMutableFields: charge.Intent.BaseLayer.IntentMutableFields,
-			Annotations:         charge.Intent.Annotations,
+			IntentMutableFields: baseIntent.IntentMutableFields.IntentMutableFields,
+			Annotations:         baseIntent.Annotations,
 			Status:              metaStatus,
 			AdvanceAfter:        meta.NormalizeOptionalTimestamp(charge.State.AdvanceAfter),
 		})
@@ -64,8 +66,8 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge usagebased.ChargeBase
 			return usagebased.ChargeBase{}, err
 		}
 
-		if charge.Intent.OverrideLayer != nil {
-			intentOverride, err := tx.updateIntentOverride(ctx, charge.GetChargeID(), charge.Intent.OverrideLayer)
+		if overrideLayer := charge.Intent.GetOverrideLayerMutableFields(); overrideLayer != nil {
+			intentOverride, err := tx.updateIntentOverride(ctx, charge.GetChargeID(), overrideLayer)
 			if err != nil {
 				return usagebased.ChargeBase{}, fmt.Errorf("updating usage based charge override: %w", err)
 			}
@@ -101,9 +103,9 @@ func (a *adapter) UpdateSubscriptionItemID(ctx context.Context, charge usagebase
 			return usagebased.Charge{}, err
 		}
 
-		intentOverride := charge.Intent.OverrideLayer
+		overrideLayer := charge.Intent.GetOverrideLayerMutableFields()
 		charge.ChargeBase = MapChargeBaseFromDB(updatedChargeBase)
-		charge.Intent.OverrideLayer = intentOverride
+		charge.Intent = usagebased.NewOverridableIntent(charge.Intent.GetBaseIntent(), overrideLayer)
 
 		return charge, nil
 	})
@@ -119,10 +121,11 @@ func (a *adapter) DeleteCharge(ctx context.Context, charge usagebased.Charge) er
 	}
 
 	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, tx *adapter) error {
-		if charge.Intent.OverrideLayer == nil {
-			charge.Intent.BaseLayer.IntentDeletedAt = lo.ToPtr(clock.Now())
-		} else {
-			charge.Intent.OverrideLayer.IntentDeletedAt = lo.ToPtr(clock.Now())
+		if err := charge.Intent.MutateEffective(func(intentMutableFields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+			intentMutableFields.IntentDeletedAt = lo.ToPtr(clock.Now())
+			return intentMutableFields, nil
+		}); err != nil {
+			return err
 		}
 
 		charge.DeletedAt = charge.GetIntentDeletedAt()
@@ -133,6 +136,8 @@ func (a *adapter) DeleteCharge(ctx context.Context, charge usagebased.Charge) er
 			return err
 		}
 
+		baseIntent := charge.Intent.GetBaseIntent()
+
 		update := tx.db.ChargeUsageBased.UpdateOneID(charge.ID).
 			Where(dbchargeusagebased.NamespaceEQ(charge.Namespace)).
 			SetStatus(metaStatus).
@@ -140,8 +145,8 @@ func (a *adapter) DeleteCharge(ctx context.Context, charge usagebased.Charge) er
 
 		update, err = chargemeta.Update(update, chargemeta.UpdateInput{
 			ManagedResource:     charge.ManagedResource,
-			IntentMutableFields: charge.Intent.BaseLayer.IntentMutableFields,
-			Annotations:         charge.Intent.Annotations,
+			IntentMutableFields: baseIntent.IntentMutableFields.IntentMutableFields,
+			Annotations:         baseIntent.Annotations,
 			Status:              metaStatus,
 			AdvanceAfter:        charge.State.AdvanceAfter,
 		})
@@ -150,15 +155,15 @@ func (a *adapter) DeleteCharge(ctx context.Context, charge usagebased.Charge) er
 		}
 
 		update = update.
-			SetOrClearIntentDeletedAt(convert.TimePtrIn(charge.Intent.BaseLayer.IntentDeletedAt, time.UTC)).
+			SetOrClearIntentDeletedAt(convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)).
 			SetOrClearDeletedAt(convert.TimePtrIn(charge.GetIntentDeletedAt(), time.UTC))
 
 		if _, err := update.Save(ctx); err != nil {
 			return err
 		}
 
-		if charge.Intent.OverrideLayer != nil {
-			if _, err := tx.updateIntentOverride(ctx, charge.GetChargeID(), charge.Intent.OverrideLayer); err != nil {
+		if overrideLayer := charge.Intent.GetOverrideLayerMutableFields(); overrideLayer != nil {
+			if _, err := tx.updateIntentOverride(ctx, charge.GetChargeID(), overrideLayer); err != nil {
 				return fmt.Errorf("updating usage based intent override: %w", err)
 			}
 		}
@@ -292,22 +297,24 @@ func expandRealizations(query *db.ChargeUsageBasedQuery, expands meta.Expands) *
 }
 
 func (a *adapter) buildCreateUsageBasedCharge(ctx context.Context, ns string, intent usagebased.CreateIntent) (*db.ChargeUsageBasedCreate, error) {
+	baseIntent := intent.Intent.GetBaseIntent()
+
 	create := a.db.ChargeUsageBased.Create().
-		SetNillableDeletedAt(convert.TimePtrIn(intent.Intent.BaseLayer.IntentDeletedAt, time.UTC)).
-		SetNillableIntentDeletedAt(convert.TimePtrIn(intent.Intent.BaseLayer.IntentDeletedAt, time.UTC)).
-		SetDiscounts(&intent.Intent.BaseLayer.Discounts).
+		SetNillableDeletedAt(convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)).
+		SetNillableIntentDeletedAt(convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)).
+		SetDiscounts(&baseIntent.Discounts).
 		SetFeatureID(intent.FeatureID).
 		SetRatingEngine(intent.RatingEngine).
-		SetPrice(&intent.Intent.BaseLayer.Price).
+		SetPrice(&baseIntent.Price).
 		SetStatusDetailed(usagebased.Status(meta.ChargeStatusCreated)).
-		SetFeatureKey(intent.Intent.BaseLayer.FeatureKey).
-		SetInvoiceAt(meta.NormalizeTimestamp(intent.Intent.BaseLayer.InvoiceAt).In(time.UTC)).
-		SetSettlementMode(intent.Intent.SettlementMode)
+		SetFeatureKey(baseIntent.FeatureKey).
+		SetInvoiceAt(meta.NormalizeTimestamp(baseIntent.InvoiceAt).In(time.UTC)).
+		SetSettlementMode(baseIntent.SettlementMode)
 
 	create, err := chargemeta.Create[*db.ChargeUsageBasedCreate](create, chargemeta.CreateInput{
 		Namespace:           ns,
-		Intent:              intent.Intent.Intent,
-		IntentMutableFields: intent.Intent.BaseLayer.IntentMutableFields,
+		Intent:              baseIntent.Intent,
+		IntentMutableFields: baseIntent.IntentMutableFields.IntentMutableFields,
 		Status:              meta.ChargeStatusCreated,
 	})
 	if err != nil {

--- a/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/detailedline_test.go
@@ -109,14 +109,14 @@ func (s *DetailedLineAdapterSuite) TestUpsertRunDetailedLinesReplacesAndSoftDele
 		Namespace: namespace,
 		Intents: []usagebased.CreateIntent{
 			{
-				Intent: usagebased.OverridableIntent{
+				Intent: usagebased.Intent{
 					Intent: chargesmeta.Intent{
 						ManagedBy:         billing.SubscriptionManagedLine,
 						UniqueReferenceID: nil,
 						CustomerID:        customerID,
 						Currency:          currencyx.Code("USD"),
 					},
-					BaseLayer: usagebased.IntentMutableFields{
+					IntentMutableFields: usagebased.IntentMutableFields{
 						IntentMutableFields: chargesmeta.IntentMutableFields{
 							Name:              "usage-charge",
 							ServicePeriod:     servicePeriod,
@@ -133,7 +133,7 @@ func (s *DetailedLineAdapterSuite) TestUpsertRunDetailedLinesReplacesAndSoftDele
 						}),
 					},
 					SettlementMode: productcatalog.CreditOnlySettlementMode,
-				},
+				}.AsOverridableIntent(),
 				FeatureID:    "feature-1",
 				RatingEngine: usagebased.RatingEngineDelta,
 			},
@@ -470,14 +470,14 @@ func (s *DetailedLineAdapterSuite) createChargeWithRun(namespace string) (usageb
 		Namespace: namespace,
 		Intents: []usagebased.CreateIntent{
 			{
-				Intent: usagebased.OverridableIntent{
+				Intent: usagebased.Intent{
 					Intent: chargesmeta.Intent{
 						ManagedBy:         billing.SubscriptionManagedLine,
 						UniqueReferenceID: nil,
 						CustomerID:        customerID,
 						Currency:          currencyx.Code("USD"),
 					},
-					BaseLayer: usagebased.IntentMutableFields{
+					IntentMutableFields: usagebased.IntentMutableFields{
 						IntentMutableFields: chargesmeta.IntentMutableFields{
 							Name:              "usage-charge",
 							ServicePeriod:     servicePeriod,
@@ -494,7 +494,7 @@ func (s *DetailedLineAdapterSuite) createChargeWithRun(namespace string) (usageb
 						}),
 					},
 					SettlementMode: productcatalog.CreditOnlySettlementMode,
-				},
+				}.AsOverridableIntent(),
 				FeatureID:    featureID,
 				RatingEngine: usagebased.RatingEngineDelta,
 			},
@@ -558,7 +558,7 @@ func (s *DetailedLineAdapterSuite) newDetailedLine(input newDetailedLineInput) u
 				Description: input.Description,
 			}),
 			ServicePeriod:          input.ServicePeriod,
-			Currency:               input.Charge.Intent.Currency,
+			Currency:               input.Charge.Intent.GetCurrency(),
 			ChildUniqueReferenceID: input.ChildUniqueReferenceID,
 			PaymentTerm:            productcatalog.InArrearsPaymentTerm,
 			PerUnitAmount:          alpacadecimal.NewFromFloat(0.1),

--- a/openmeter/billing/charges/usagebased/adapter/intentoverride.go
+++ b/openmeter/billing/charges/usagebased/adapter/intentoverride.go
@@ -45,7 +45,7 @@ func mapIntentOverrideFromDB(dbOverride *entdb.ChargeUsageBasedOverride) *usageb
 	}
 }
 
-func (a *adapter) CreateChargeOverride(ctx context.Context, charge usagebased.ChargeBase) (usagebased.ChargeBase, error) {
+func (a *adapter) CreateChargeOverride(ctx context.Context, charge usagebased.ChargeBase, override usagebased.IntentMutableFields) (usagebased.ChargeBase, error) {
 	if err := charge.ManagedModel.Validate(); err != nil {
 		return usagebased.ChargeBase{}, err
 	}
@@ -54,18 +54,22 @@ func (a *adapter) CreateChargeOverride(ctx context.Context, charge usagebased.Ch
 		return usagebased.ChargeBase{}, err
 	}
 
-	if charge.Intent.OverrideLayer == nil {
-		return usagebased.ChargeBase{}, errors.New("intent override is required")
+	if err := override.Validate(); err != nil {
+		return usagebased.ChargeBase{}, fmt.Errorf("validating intent override: %w", err)
+	}
+
+	if charge.Intent.HasOverrideLayer() {
+		return usagebased.ChargeBase{}, errors.New("intent override already exists")
 	}
 
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (usagebased.ChargeBase, error) {
-		intentOverride, err := tx.createIntentOverride(ctx, charge.GetChargeID(), charge.Intent.OverrideLayer)
+		dbIntentOverride, err := tx.createIntentOverride(ctx, charge.GetChargeID(), override)
 		if err != nil {
 			return usagebased.ChargeBase{}, err
 		}
 
-		deletedAt := convert.TimePtrIn(intentOverride.IntentDeletedAt, time.UTC)
-		_, err = tx.db.ChargeUsageBased.UpdateOneID(charge.ID).
+		deletedAt := convert.TimePtrIn(dbIntentOverride.IntentDeletedAt, time.UTC)
+		dbCharge, err := tx.db.ChargeUsageBased.UpdateOneID(charge.ID).
 			Where(dbchargeusagebased.NamespaceEQ(charge.Namespace)).
 			SetOrClearDeletedAt(deletedAt).
 			Save(ctx)
@@ -73,10 +77,9 @@ func (a *adapter) CreateChargeOverride(ctx context.Context, charge usagebased.Ch
 			return usagebased.ChargeBase{}, fmt.Errorf("updating usage based effective deleted at: %w", err)
 		}
 
-		charge.Intent.OverrideLayer = intentOverride
-		charge.DeletedAt = deletedAt
+		dbCharge.Edges.IntentOverride = dbIntentOverride
 
-		return charge, nil
+		return MapChargeBaseFromDB(dbCharge), nil
 	})
 }
 
@@ -85,9 +88,12 @@ func (a *adapter) DeleteChargeOverride(ctx context.Context, charge usagebased.Ch
 		return usagebased.ChargeBase{}, err
 	}
 
-	charge.Intent.OverrideLayer = nil
 	if err := charge.Validate(); err != nil {
 		return usagebased.ChargeBase{}, err
+	}
+
+	if !charge.Intent.HasOverrideLayer() {
+		return usagebased.ChargeBase{}, errors.New("intent override is required")
 	}
 
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (usagebased.ChargeBase, error) {
@@ -103,7 +109,8 @@ func (a *adapter) DeleteChargeOverride(ctx context.Context, charge usagebased.Ch
 			return usagebased.ChargeBase{}, fmt.Errorf("intent override does not exist")
 		}
 
-		deletedAt := convert.TimePtrIn(charge.Intent.BaseLayer.IntentDeletedAt, time.UTC)
+		baseIntent := charge.Intent.GetBaseIntent()
+		deletedAt := convert.TimePtrIn(baseIntent.IntentDeletedAt, time.UTC)
 		_, err = tx.db.ChargeUsageBased.UpdateOneID(charge.ID).
 			Where(dbchargeusagebased.NamespaceEQ(charge.Namespace)).
 			SetOrClearDeletedAt(deletedAt).
@@ -112,13 +119,14 @@ func (a *adapter) DeleteChargeOverride(ctx context.Context, charge usagebased.Ch
 			return usagebased.ChargeBase{}, fmt.Errorf("updating usage based effective deleted at: %w", err)
 		}
 
+		charge.Intent = baseIntent.AsOverridableIntent()
 		charge.DeletedAt = deletedAt
 
 		return charge, nil
 	})
 }
 
-func (a *adapter) createIntentOverride(ctx context.Context, chargeID meta.ChargeID, override *usagebased.IntentMutableFields) (*usagebased.IntentMutableFields, error) {
+func (a *adapter) createIntentOverride(ctx context.Context, chargeID meta.ChargeID, override usagebased.IntentMutableFields) (*entdb.ChargeUsageBasedOverride, error) {
 	if err := chargeID.Validate(); err != nil {
 		return nil, fmt.Errorf("charge id: %w", err)
 	}
@@ -151,12 +159,7 @@ func (a *adapter) createIntentOverride(ctx context.Context, chargeID meta.Charge
 		create = create.SetMetadata(&normalized.Metadata)
 	}
 
-	dbOverride, err := create.Save(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return mapIntentOverrideFromDB(dbOverride), nil
+	return create.Save(ctx)
 }
 
 func (a *adapter) updateIntentOverride(ctx context.Context, chargeID meta.ChargeID, override *usagebased.IntentMutableFields) (*entdb.ChargeUsageBasedOverride, error) {

--- a/openmeter/billing/charges/usagebased/adapter/intentoverride_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/intentoverride_test.go
@@ -108,8 +108,11 @@ func (s *UsageBasedIntentOverrideAdapterSuite) TestUpdateAndReadIntentOverride()
 		}),
 	}
 
-	charge.Intent.BaseLayer.IntentDeletedAt = lo.ToPtr(time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC))
-	charge.Intent.OverrideLayer = &usagebased.IntentMutableFields{
+	s.Require().NoError(charge.Intent.Mutate(chargesmeta.ChangeTargetBase, func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+		fields.IntentDeletedAt = lo.ToPtr(time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC))
+		return fields, nil
+	}))
+	override := usagebased.IntentMutableFields{
 		IntentMutableFields: chargesmeta.IntentMutableFields{
 			Name:        "manual usage based",
 			Description: lo.ToPtr("manual description"),
@@ -130,57 +133,60 @@ func (s *UsageBasedIntentOverrideAdapterSuite) TestUpdateAndReadIntentOverride()
 		Discounts:  overrideDiscounts,
 	}
 
-	_, err := s.adapter.UpdateCharge(ctx, charge.ChargeBase)
+	chargeWithUnsavedOverride := charge.ChargeBase
+	chargeWithUnsavedOverride.Intent = usagebased.NewOverridableIntent(chargeWithUnsavedOverride.Intent.GetBaseIntent(), &override)
+	_, err := s.adapter.UpdateCharge(ctx, chargeWithUnsavedOverride)
 	s.Require().ErrorContains(err, "override does not exist")
 
-	chargeWithoutOverride := charge.ChargeBase
-	chargeWithoutOverride.Intent.OverrideLayer = nil
-	updated, err := s.adapter.UpdateCharge(ctx, chargeWithoutOverride)
+	updated, err := s.adapter.UpdateCharge(ctx, charge.ChargeBase)
 	s.Require().NoError(err)
-	s.NotNil(updated.Intent.BaseLayer.IntentDeletedAt)
+	s.NotNil(updated.Intent.GetBaseIntent().IntentDeletedAt)
 	fetchedBeforeOverrideCreate, err := s.adapter.GetByID(ctx, usagebased.GetByIDInput{
 		ChargeID: charge.GetChargeID(),
 	})
 	s.Require().NoError(err)
-	s.Nil(fetchedBeforeOverrideCreate.Intent.OverrideLayer)
+	s.Nil(fetchedBeforeOverrideCreate.Intent.GetOverrideLayerMutableFields())
 	s.NotNil(fetchedBeforeOverrideCreate.DeletedAt)
 
-	updated.Intent.OverrideLayer = charge.Intent.OverrideLayer
-	updated, err = s.adapter.CreateChargeOverride(ctx, updated)
+	updated, err = s.adapter.CreateChargeOverride(ctx, updated, override)
 	s.Require().NoError(err)
 	s.Nil(updated.DeletedAt)
-	s.requireOverrideMatches(updated.Intent.OverrideLayer, overrideServicePeriod, overrideFullServicePeriod, overrideBillingPeriod, overrideInvoiceAt, overrideTaxCodeID, overridePrice, overrideDiscounts)
+	s.requireOverrideMatches(updated.Intent.GetOverrideLayerMutableFields(), overrideServicePeriod, overrideFullServicePeriod, overrideBillingPeriod, overrideInvoiceAt, overrideTaxCodeID, overridePrice, overrideDiscounts)
 
-	_, err = s.adapter.CreateChargeOverride(ctx, updated)
+	_, err = s.adapter.CreateChargeOverride(ctx, updated, override)
 	s.Require().Error(err)
 
 	overrideInvoiceAt = time.Date(2026, 1, 22, 0, 0, 0, 0, time.UTC)
-	updated.Intent.OverrideLayer.InvoiceAt = overrideInvoiceAt
+	override = *updated.Intent.GetOverrideLayerMutableFields()
+	override.InvoiceAt = overrideInvoiceAt
+	updated.Intent = usagebased.NewOverridableIntent(updated.Intent.GetBaseIntent(), &override)
 	updated, err = s.adapter.UpdateCharge(ctx, updated)
 	s.Require().NoError(err)
-	s.requireOverrideMatches(updated.Intent.OverrideLayer, overrideServicePeriod, overrideFullServicePeriod, overrideBillingPeriod, overrideInvoiceAt, overrideTaxCodeID, overridePrice, overrideDiscounts)
+	s.requireOverrideMatches(updated.Intent.GetOverrideLayerMutableFields(), overrideServicePeriod, overrideFullServicePeriod, overrideBillingPeriod, overrideInvoiceAt, overrideTaxCodeID, overridePrice, overrideDiscounts)
 
-	updated.Intent.OverrideLayer.Description = nil
-	updated.Intent.OverrideLayer.Metadata = nil
-	updated.Intent.OverrideLayer.TaxConfig.Behavior = nil
-	updated.Intent.OverrideLayer.TaxConfig.TaxCodeID = overrideTaxCodeID
+	override = *updated.Intent.GetOverrideLayerMutableFields()
+	override.Description = nil
+	override.Metadata = nil
+	override.TaxConfig.Behavior = nil
+	override.TaxConfig.TaxCodeID = overrideTaxCodeID
+	updated.Intent = usagebased.NewOverridableIntent(updated.Intent.GetBaseIntent(), &override)
 	updated, err = s.adapter.UpdateCharge(ctx, updated)
 	s.Require().NoError(err)
-	s.Require().NotNil(updated.Intent.OverrideLayer)
-	s.Nil(updated.Intent.OverrideLayer.Description)
-	s.Nil(updated.Intent.OverrideLayer.Metadata)
-	s.Nil(updated.Intent.OverrideLayer.TaxConfig.Behavior)
-	s.Equal(overrideTaxCodeID, updated.Intent.OverrideLayer.TaxConfig.TaxCodeID)
+	s.Require().NotNil(updated.Intent.GetOverrideLayerMutableFields())
+	s.Nil(updated.Intent.GetOverrideLayerMutableFields().Description)
+	s.Nil(updated.Intent.GetOverrideLayerMutableFields().Metadata)
+	s.Nil(updated.Intent.GetOverrideLayerMutableFields().TaxConfig.Behavior)
+	s.Equal(overrideTaxCodeID, updated.Intent.GetOverrideLayerMutableFields().TaxConfig.TaxCodeID)
 
 	fetched, err := s.adapter.GetByID(ctx, usagebased.GetByIDInput{
 		ChargeID: charge.GetChargeID(),
 	})
 	s.Require().NoError(err)
-	s.Require().NotNil(fetched.Intent.OverrideLayer)
-	s.Nil(fetched.Intent.OverrideLayer.Description)
-	s.Nil(fetched.Intent.OverrideLayer.Metadata)
-	s.Nil(fetched.Intent.OverrideLayer.TaxConfig.Behavior)
-	s.Equal(overrideTaxCodeID, fetched.Intent.OverrideLayer.TaxConfig.TaxCodeID)
+	s.Require().NotNil(fetched.Intent.GetOverrideLayerMutableFields())
+	s.Nil(fetched.Intent.GetOverrideLayerMutableFields().Description)
+	s.Nil(fetched.Intent.GetOverrideLayerMutableFields().Metadata)
+	s.Nil(fetched.Intent.GetOverrideLayerMutableFields().TaxConfig.Behavior)
+	s.Equal(overrideTaxCodeID, fetched.Intent.GetOverrideLayerMutableFields().TaxConfig.TaxCodeID)
 
 	fetchedByIDs, err := s.adapter.GetByIDs(ctx, usagebased.GetByIDsInput{
 		Namespace: namespace,
@@ -188,22 +194,22 @@ func (s *UsageBasedIntentOverrideAdapterSuite) TestUpdateAndReadIntentOverride()
 	})
 	s.Require().NoError(err)
 	s.Require().Len(fetchedByIDs, 1)
-	s.Require().NotNil(fetchedByIDs[0].Intent.OverrideLayer)
-	s.Nil(fetchedByIDs[0].Intent.OverrideLayer.Description)
-	s.Nil(fetchedByIDs[0].Intent.OverrideLayer.Metadata)
-	s.Nil(fetchedByIDs[0].Intent.OverrideLayer.TaxConfig.Behavior)
-	s.Equal(overrideTaxCodeID, fetchedByIDs[0].Intent.OverrideLayer.TaxConfig.TaxCodeID)
+	s.Require().NotNil(fetchedByIDs[0].Intent.GetOverrideLayerMutableFields())
+	s.Nil(fetchedByIDs[0].Intent.GetOverrideLayerMutableFields().Description)
+	s.Nil(fetchedByIDs[0].Intent.GetOverrideLayerMutableFields().Metadata)
+	s.Nil(fetchedByIDs[0].Intent.GetOverrideLayerMutableFields().TaxConfig.Behavior)
+	s.Equal(overrideTaxCodeID, fetchedByIDs[0].Intent.GetOverrideLayerMutableFields().TaxConfig.TaxCodeID)
 
 	cleared, err := s.adapter.DeleteChargeOverride(ctx, fetched.ChargeBase)
 	s.Require().NoError(err)
-	s.Nil(cleared.Intent.OverrideLayer)
+	s.Nil(cleared.Intent.GetOverrideLayerMutableFields())
 	s.NotNil(cleared.DeletedAt)
 
 	fetchedAfterClear, err := s.adapter.GetByID(ctx, usagebased.GetByIDInput{
 		ChargeID: charge.GetChargeID(),
 	})
 	s.Require().NoError(err)
-	s.Nil(fetchedAfterClear.Intent.OverrideLayer)
+	s.Nil(fetchedAfterClear.Intent.GetOverrideLayerMutableFields())
 	s.NotNil(fetchedAfterClear.DeletedAt)
 }
 
@@ -215,33 +221,34 @@ func (s *UsageBasedIntentOverrideAdapterSuite) TestDeleteChargeWithIntentOverrid
 	clock.FreezeTime(deletedAt)
 	defer clock.UnFreeze()
 
-	charge.Intent.OverrideLayer = &usagebased.IntentMutableFields{
+	baseIntent := charge.Intent.GetBaseIntent()
+	override := usagebased.IntentMutableFields{
 		IntentMutableFields: chargesmeta.IntentMutableFields{
 			Name:              "manual usage based",
-			TaxConfig:         charge.Intent.BaseLayer.TaxConfig,
-			ServicePeriod:     charge.Intent.BaseLayer.ServicePeriod,
-			FullServicePeriod: charge.Intent.BaseLayer.FullServicePeriod,
-			BillingPeriod:     charge.Intent.BaseLayer.BillingPeriod,
+			TaxConfig:         baseIntent.TaxConfig,
+			ServicePeriod:     baseIntent.ServicePeriod,
+			FullServicePeriod: baseIntent.FullServicePeriod,
+			BillingPeriod:     baseIntent.BillingPeriod,
 		},
-		InvoiceAt:  charge.Intent.BaseLayer.InvoiceAt,
-		FeatureKey: charge.Intent.BaseLayer.FeatureKey,
-		Price:      charge.Intent.BaseLayer.Price,
-		Discounts:  charge.Intent.BaseLayer.Discounts,
+		InvoiceAt:  baseIntent.InvoiceAt,
+		FeatureKey: baseIntent.FeatureKey,
+		Price:      baseIntent.Price,
+		Discounts:  baseIntent.Discounts,
 	}
 
-	_, err := s.adapter.UpdateCharge(ctx, charge.ChargeBase)
+	chargeWithUnsavedOverride := charge.ChargeBase
+	chargeWithUnsavedOverride.Intent = usagebased.NewOverridableIntent(baseIntent, &override)
+	_, err := s.adapter.UpdateCharge(ctx, chargeWithUnsavedOverride)
 	s.Require().ErrorContains(err, "override does not exist")
 
 	updated := charge.ChargeBase
-	updated.Intent.OverrideLayer = nil
 	updated, err = s.adapter.UpdateCharge(ctx, updated)
 	s.Require().NoError(err)
-	updated.Intent.OverrideLayer = charge.Intent.OverrideLayer
-	updated, err = s.adapter.CreateChargeOverride(ctx, updated)
+	updated, err = s.adapter.CreateChargeOverride(ctx, updated, override)
 	s.Require().NoError(err)
-	s.Require().NotNil(updated.Intent.OverrideLayer)
-	s.Nil(updated.Intent.BaseLayer.IntentDeletedAt)
-	s.Nil(updated.Intent.OverrideLayer.IntentDeletedAt)
+	s.Require().NotNil(updated.Intent.GetOverrideLayerMutableFields())
+	s.Nil(updated.Intent.GetBaseIntent().IntentDeletedAt)
+	s.Nil(updated.Intent.GetOverrideLayerMutableFields().IntentDeletedAt)
 	s.Nil(updated.DeletedAt)
 
 	s.Require().NoError(s.adapter.DeleteCharge(ctx, usagebased.Charge{ChargeBase: updated}))
@@ -251,11 +258,11 @@ func (s *UsageBasedIntentOverrideAdapterSuite) TestDeleteChargeWithIntentOverrid
 	})
 	s.Require().NoError(err)
 	s.Equal(usagebased.StatusDeleted, fetched.Status)
-	s.Nil(fetched.Intent.BaseLayer.IntentDeletedAt)
-	s.Require().NotNil(fetched.Intent.OverrideLayer)
-	s.Require().NotNil(fetched.Intent.OverrideLayer.IntentDeletedAt)
+	s.Nil(fetched.Intent.GetBaseIntent().IntentDeletedAt)
+	s.Require().NotNil(fetched.Intent.GetOverrideLayerMutableFields())
+	s.Require().NotNil(fetched.Intent.GetOverrideLayerMutableFields().IntentDeletedAt)
 	s.Require().NotNil(fetched.DeletedAt)
-	s.Equal(deletedAt, *fetched.Intent.OverrideLayer.IntentDeletedAt)
+	s.Equal(deletedAt, *fetched.Intent.GetOverrideLayerMutableFields().IntentDeletedAt)
 	s.Equal(deletedAt, *fetched.DeletedAt)
 }
 
@@ -304,13 +311,13 @@ func (s *UsageBasedIntentOverrideAdapterSuite) createCharge(namespace string) us
 		Namespace: namespace,
 		Intents: []usagebased.CreateIntent{
 			{
-				Intent: usagebased.OverridableIntent{
+				Intent: usagebased.Intent{
 					Intent: chargesmeta.Intent{
 						ManagedBy:  billing.SubscriptionManagedLine,
 						CustomerID: customerID,
 						Currency:   currencyx.Code("USD"),
 					},
-					BaseLayer: usagebased.IntentMutableFields{
+					IntentMutableFields: usagebased.IntentMutableFields{
 						IntentMutableFields: chargesmeta.IntentMutableFields{
 							Name: "usage-based-charge",
 							TaxConfig: productcatalog.TaxCodeConfig{
@@ -327,7 +334,7 @@ func (s *UsageBasedIntentOverrideAdapterSuite) createCharge(namespace string) us
 						}),
 					},
 					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
-				},
+				}.AsOverridableIntent(),
 				FeatureID:    featureID,
 				RatingEngine: usagebased.RatingEngineDelta,
 			},
@@ -341,11 +348,11 @@ func (s *UsageBasedIntentOverrideAdapterSuite) createCharge(namespace string) us
 		Charges: []chargesmeta.IDWithUniqueReferenceID{
 			{
 				ID:                createdCharges[0].ID,
-				UniqueReferenceID: createdCharges[0].Intent.UniqueReferenceID,
+				UniqueReferenceID: createdCharges[0].Intent.GetUniqueReferenceID(),
 			},
 		},
 	}))
-	s.Nil(createdCharges[0].Intent.OverrideLayer)
+	s.Nil(createdCharges[0].Intent.GetOverrideLayerMutableFields())
 
 	return createdCharges[0]
 }

--- a/openmeter/billing/charges/usagebased/adapter/mapper.go
+++ b/openmeter/billing/charges/usagebased/adapter/mapper.go
@@ -42,23 +42,23 @@ func MapChargeFromDB(entity *entdb.ChargeUsageBased, expands meta.Expands) (usag
 
 func MapChargeBaseFromDB(entity *entdb.ChargeUsageBased) usagebased.ChargeBase {
 	chargeMeta := chargemeta.MapFromDB(entity)
+	intent := usagebased.Intent{
+		Intent: chargeMeta.Intent,
+		IntentMutableFields: usagebased.IntentMutableFields{
+			IntentMutableFields: chargeMeta.IntentMutableFields,
+			InvoiceAt:           entity.InvoiceAt.UTC(),
+			IntentDeletedAt:     convert.TimePtrIn(entity.IntentDeletedAt, time.UTC),
+			FeatureKey:          entity.FeatureKey,
+			Discounts:           lo.FromPtr(entity.Discounts),
+			Price:               lo.FromPtr(entity.Price),
+		},
+		SettlementMode: entity.SettlementMode,
+	}
 
 	return usagebased.ChargeBase{
 		ManagedResource: chargeMeta.ManagedResource,
 		Status:          entity.StatusDetailed,
-		Intent: usagebased.OverridableIntent{
-			Intent: chargeMeta.Intent,
-			BaseLayer: usagebased.IntentMutableFields{
-				IntentMutableFields: chargeMeta.IntentMutableFields,
-				InvoiceAt:           entity.InvoiceAt.UTC(),
-				IntentDeletedAt:     convert.TimePtrIn(entity.IntentDeletedAt, time.UTC),
-				FeatureKey:          entity.FeatureKey,
-				Discounts:           lo.FromPtr(entity.Discounts),
-				Price:               lo.FromPtr(entity.Price),
-			},
-			OverrideLayer:  mapIntentOverrideFromDB(entity.Edges.IntentOverride),
-			SettlementMode: entity.SettlementMode,
-		},
+		Intent:          usagebased.NewOverridableIntent(intent, mapIntentOverrideFromDB(entity.Edges.IntentOverride)),
 		State: usagebased.State{
 			CurrentRealizationRunID: entity.CurrentRealizationRunID,
 			AdvanceAfter:            entity.AdvanceAfter,

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/ref"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 var _ meta.ChargeAccessor = (*ChargeBase)(nil)
@@ -60,22 +61,18 @@ func (c ChargeBase) GetChargeID() meta.ChargeID {
 func (c ChargeBase) GetCustomerID() customer.CustomerID {
 	return customer.CustomerID{
 		Namespace: c.Namespace,
-		ID:        c.Intent.CustomerID,
+		ID:        c.Intent.GetCustomerID(),
 	}
 }
 
 func (c ChargeBase) GetCurrency() currencyx.Code {
-	return c.Intent.Currency
+	return c.Intent.GetCurrency()
 }
 
 // GetIntentDeletedAt returns the effective intent deletion timestamp.
 // If an override is present, the override intent owns deletion; otherwise the base intent does.
 func (c ChargeBase) GetIntentDeletedAt() *time.Time {
-	if c.Intent.OverrideLayer != nil {
-		return c.Intent.OverrideLayer.IntentDeletedAt
-	}
-
-	return c.Intent.BaseLayer.IntentDeletedAt
+	return c.Intent.GetDeletedAt()
 }
 
 func (c ChargeBase) ErrorAttributes() models.Attributes {
@@ -140,15 +137,18 @@ func (c Charge) GetCurrentRealizationRun() (RealizationRun, error) {
 func (c Charge) GetCustomerID() customer.CustomerID {
 	return customer.CustomerID{
 		Namespace: c.Namespace,
-		ID:        c.Intent.CustomerID,
+		ID:        c.Intent.GetCustomerID(),
 	}
 }
 
 func (c Charge) GetFeatureKeyOrID() ref.IDOrKey {
+	// TODO: if API edits can override FeatureKey, keep State.FeatureID in sync
+	// with the effective key. State.FeatureID is the persisted resolved feature
+	// snapshot used by active charges; created/deleted fallbacks resolve by key.
 	switch c.Status {
 	case StatusCreated:
 		return ref.IDOrKey{
-			Key: c.Intent.BaseLayer.FeatureKey,
+			Key: c.Intent.GetBaseIntent().FeatureKey,
 		}
 	case StatusDeleted:
 		if c.State.FeatureID != "" {
@@ -158,7 +158,7 @@ func (c Charge) GetFeatureKeyOrID() ref.IDOrKey {
 		}
 
 		return ref.IDOrKey{
-			Key: c.Intent.BaseLayer.FeatureKey,
+			Key: c.Intent.GetBaseIntent().FeatureKey,
 		}
 	default:
 		return ref.IDOrKey{
@@ -201,9 +201,9 @@ type Intent struct {
 // AsOverridableIntent maps the intent's mutable fields as the base layer.
 func (i Intent) AsOverridableIntent() OverridableIntent {
 	return OverridableIntent{
-		Intent:         i.Intent,
-		BaseLayer:      i.IntentMutableFields,
-		SettlementMode: i.SettlementMode,
+		intent:         i.Intent,
+		baseLayer:      i.IntentMutableFields,
+		settlementMode: i.SettlementMode,
 	}
 }
 
@@ -231,125 +231,253 @@ func (i Intent) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
+// OverridableIntent stores the immutable intent plus the base and optional
+// override mutable layers. Direct layer access is error-prone because callers
+// must manually decide which layer is active; this API centralizes that choice
+// so reads and mutations use the correct override layer when present.
 type OverridableIntent struct {
-	meta.Intent
+	intent meta.Intent
 
-	BaseLayer     IntentMutableFields  `json:"baseLayer"`
-	OverrideLayer *IntentMutableFields `json:"overrideLayer,omitempty"`
+	baseLayer     IntentMutableFields
+	overrideLayer *IntentMutableFields
 
-	SettlementMode productcatalog.SettlementMode `json:"settlementMode"`
+	settlementMode productcatalog.SettlementMode
+}
+
+func NewOverridableIntent(baseIntent Intent, overrideLayer *IntentMutableFields) OverridableIntent {
+	return OverridableIntent{
+		intent:         baseIntent.Intent,
+		baseLayer:      baseIntent.IntentMutableFields,
+		overrideLayer:  overrideLayer,
+		settlementMode: baseIntent.SettlementMode,
+	}
 }
 
 func (i OverridableIntent) Normalized() OverridableIntent {
-	i.BaseLayer = i.BaseLayer.Normalized()
-	if i.OverrideLayer != nil {
-		overrideLayer := i.OverrideLayer.Normalized()
-		i.OverrideLayer = &overrideLayer
+	i.baseLayer = i.baseLayer.Normalized()
+	if i.overrideLayer != nil {
+		overrideLayer := i.overrideLayer.Normalized()
+		i.overrideLayer = &overrideLayer
 	}
 
 	return i
 }
 
+func (i OverridableIntent) GetCustomerID() string {
+	return i.intent.CustomerID
+}
+
+func (i OverridableIntent) GetCurrency() currencyx.Code {
+	return i.intent.Currency
+}
+
+func (i OverridableIntent) GetSettlementMode() productcatalog.SettlementMode {
+	return i.settlementMode
+}
+
+func (i OverridableIntent) GetUniqueReferenceID() *string {
+	return i.intent.UniqueReferenceID
+}
+
 func (i OverridableIntent) Validate() error {
 	var errs []error
 
-	if err := i.Intent.Validate(); err != nil {
+	if err := i.intent.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("intent: %w", err))
 	}
 
-	if err := i.BaseLayer.Validate(); err != nil {
+	if err := i.baseLayer.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("base layer: %w", err))
 	}
 
-	if i.OverrideLayer != nil {
-		if err := i.OverrideLayer.Validate(); err != nil {
+	if i.overrideLayer != nil {
+		if err := i.overrideLayer.Validate(); err != nil {
 			errs = append(errs, fmt.Errorf("override layer: %w", err))
 		}
 	}
 
-	if err := i.SettlementMode.Validate(); err != nil {
+	if err := i.settlementMode.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("settlement mode: %w", err))
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
+// GetEffectiveIntent returns the customer-facing intent by combining the
+// immutable intent with the active mutable layer.
+//
+// WARNING: this clones and normalizes the intent and mutable fields. Prefer the
+// narrower effective getters when only a few fields are required.
 func (i OverridableIntent) GetEffectiveIntent() Intent {
 	intent := Intent{
-		Intent:              i.Intent.Clone(),
-		IntentMutableFields: i.BaseLayer.Clone(),
-		SettlementMode:      i.SettlementMode,
+		Intent:              i.intent.Clone(),
+		IntentMutableFields: i.baseLayer.Clone(),
+		SettlementMode:      i.settlementMode,
 	}
 
-	if i.OverrideLayer != nil {
-		intent.IntentMutableFields = i.OverrideLayer.Clone()
+	if i.overrideLayer != nil {
+		intent.IntentMutableFields = i.overrideLayer.Clone()
 	}
 
 	return intent.Normalized()
 }
 
-func (i *OverridableIntent) Mutate(target meta.ChangeTarget) (MutableIntent, error) {
-	return newMutableIntent(i, target)
+// GetEffectiveServicePeriod returns the service period from the active mutable
+// layer, preferring the override layer when it is present.
+func (i OverridableIntent) GetEffectiveServicePeriod() timeutil.ClosedPeriod {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.ServicePeriod
+	}
+
+	return i.baseLayer.ServicePeriod
 }
 
-type MutableIntent interface {
-	SetServicePeriodTo(time.Time) MutableIntent
-	Save() error
+// GetEffectiveInvoiceAt returns the invoice-at timestamp from the active
+// mutable layer, preferring the override layer when it is present.
+func (i OverridableIntent) GetEffectiveInvoiceAt() time.Time {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.InvoiceAt
+	}
+
+	return i.baseLayer.InvoiceAt
 }
 
-var _ MutableIntent = (*mutableIntent)(nil)
+// GetEffectiveFeatureKey returns the feature key from the active mutable layer,
+// preferring the override layer when it is present.
+func (i OverridableIntent) GetEffectiveFeatureKey() string {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.FeatureKey
+	}
 
-type mutableIntent struct {
-	intent        *OverridableIntent
-	mutableFields IntentMutableFields
-	target        meta.ChangeTarget
+	return i.baseLayer.FeatureKey
 }
 
-func newMutableIntent(intent *OverridableIntent, target meta.ChangeTarget) (*mutableIntent, error) {
-	switch target {
-	case meta.ChangeTargetBase:
-		return &mutableIntent{
-			intent:        intent,
-			mutableFields: intent.BaseLayer.Clone(),
-			target:        target,
-		}, nil
-	case meta.ChangeTargetOverride:
-		if intent.OverrideLayer == nil {
-			return nil, fmt.Errorf("override layer not present for charge")
-		}
+// GetEffectivePrice returns a cloned price from the active mutable layer,
+// preferring the override layer when it is present.
+func (i OverridableIntent) GetEffectivePrice() productcatalog.Price {
+	if i.overrideLayer != nil {
+		return *i.overrideLayer.Price.Clone()
+	}
 
-		return &mutableIntent{
-			intent:        intent,
-			mutableFields: intent.OverrideLayer.Clone(),
-			target:        target,
-		}, nil
-	default:
-		return nil, fmt.Errorf("invalid change target: %s", target)
+	return *i.baseLayer.Price.Clone()
+}
+
+// GetEffectiveDiscounts returns cloned discounts from the active mutable layer,
+// preferring the override layer when it is present.
+func (i OverridableIntent) GetEffectiveDiscounts() productcatalog.Discounts {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.Discounts.Clone()
+	}
+
+	return i.baseLayer.Discounts.Clone()
+}
+
+// GetEffectiveMetaIntentMutableFields returns the shared meta mutable fields
+// from the active mutable layer, preferring the override layer when it is
+// present.
+func (i OverridableIntent) GetEffectiveMetaIntentMutableFields() meta.IntentMutableFields {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.IntentMutableFields
+	}
+
+	return i.baseLayer.IntentMutableFields
+}
+
+func (i OverridableIntent) GetBaseIntent() Intent {
+	return Intent{
+		Intent:              i.intent.Clone(),
+		IntentMutableFields: i.baseLayer.Clone(),
+		SettlementMode:      i.settlementMode,
 	}
 }
 
-func (m *mutableIntent) SetServicePeriodTo(to time.Time) MutableIntent {
-	m.mutableFields.ServicePeriod.To = to
-	return m
+func (i OverridableIntent) GetIntentForTarget(target meta.ChangeTarget) (Intent, error) {
+	out := Intent{
+		Intent:         i.intent.Clone(),
+		SettlementMode: i.settlementMode,
+	}
+
+	switch target {
+	case meta.ChangeTargetBase:
+		out.IntentMutableFields = i.baseLayer.Clone()
+	case meta.ChangeTargetOverride:
+		if i.overrideLayer == nil {
+			return Intent{}, fmt.Errorf("override layer not present for charge")
+		}
+
+		out.IntentMutableFields = i.overrideLayer.Clone()
+	default:
+		return Intent{}, fmt.Errorf("invalid change target: %s", target)
+	}
+
+	return out, nil
 }
 
-func (m *mutableIntent) Save() error {
-	normalizedFields := m.mutableFields.Normalized()
+func (i OverridableIntent) GetOverrideLayerMutableFields() *IntentMutableFields {
+	if i.overrideLayer == nil {
+		return nil
+	}
+
+	return lo.ToPtr(i.overrideLayer.Clone())
+}
+
+func (i OverridableIntent) HasOverrideLayer() bool {
+	return i.overrideLayer != nil
+}
+
+func (i OverridableIntent) GetDeletedAt() *time.Time {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.IntentDeletedAt
+	}
+
+	return i.baseLayer.IntentDeletedAt
+}
+
+func (i *OverridableIntent) MutateEffective(editFn func(IntentMutableFields) (IntentMutableFields, error)) error {
+	target := meta.ChangeTargetBase
+	if i.overrideLayer != nil {
+		target = meta.ChangeTargetOverride
+	}
+
+	return i.Mutate(target, editFn)
+}
+
+func (i *OverridableIntent) Mutate(target meta.ChangeTarget, editFn func(IntentMutableFields) (IntentMutableFields, error)) error {
+	var targetFields IntentMutableFields
+	switch target {
+	case meta.ChangeTargetBase:
+		targetFields = i.baseLayer.Clone()
+	case meta.ChangeTargetOverride:
+		if i.overrideLayer == nil {
+			return fmt.Errorf("override layer not present for charge")
+		}
+
+		targetFields = i.overrideLayer.Clone()
+	}
+
+	targetFields, err := editFn(targetFields)
+	if err != nil {
+		return fmt.Errorf("editing intent mutable fields: %w", err)
+	}
+
+	normalizedFields := targetFields.Normalized()
 
 	if err := normalizedFields.Validate(); err != nil {
 		return fmt.Errorf("validating intent: %w", err)
 	}
 
-	switch m.target {
+	switch target {
 	case meta.ChangeTargetBase:
-		m.intent.BaseLayer = normalizedFields
+		i.baseLayer = normalizedFields
 	case meta.ChangeTargetOverride:
-		m.intent.OverrideLayer = &normalizedFields
-	default:
-		return fmt.Errorf("invalid change target: %s", m.target)
-	}
+		if i.overrideLayer == nil {
+			return fmt.Errorf("override layer not present for charge")
+		}
 
-	m.mutableFields = normalizedFields
+		i.overrideLayer = &normalizedFields
+	default:
+		return fmt.Errorf("invalid change target: %s", target)
+	}
 
 	return nil
 }

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -279,6 +279,16 @@ func (i OverridableIntent) GetUniqueReferenceID() *string {
 	return i.intent.UniqueReferenceID
 }
 
+func (i OverridableIntent) GetSubscription() *meta.SubscriptionReference {
+	if i.intent.Subscription == nil {
+		return nil
+	}
+
+	subscription := *i.intent.Subscription
+
+	return &subscription
+}
+
 func (i OverridableIntent) Validate() error {
 	var errs []error
 
@@ -372,6 +382,16 @@ func (i OverridableIntent) GetEffectiveDiscounts() productcatalog.Discounts {
 	return i.baseLayer.Discounts.Clone()
 }
 
+// GetEffectiveTaxConfig returns the tax config from the active mutable layer,
+// preferring the override layer when it is present.
+func (i OverridableIntent) GetEffectiveTaxConfig() productcatalog.TaxCodeConfig {
+	if i.overrideLayer != nil {
+		return i.overrideLayer.TaxConfig
+	}
+
+	return i.baseLayer.TaxConfig
+}
+
 // GetEffectiveMetaIntentMutableFields returns the shared meta mutable fields
 // from the active mutable layer, preferring the override layer when it is
 // present.
@@ -381,6 +401,12 @@ func (i OverridableIntent) GetEffectiveMetaIntentMutableFields() meta.IntentMuta
 	}
 
 	return i.baseLayer.IntentMutableFields
+}
+
+// GetBaseTaxConfig returns the tax config from the base mutable layer,
+// ignoring any override layer.
+func (i OverridableIntent) GetBaseTaxConfig() productcatalog.TaxCodeConfig {
+	return i.baseLayer.TaxConfig
 }
 
 func (i OverridableIntent) GetBaseIntent() Intent {

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -142,9 +142,11 @@ func (c Charge) GetCustomerID() customer.CustomerID {
 }
 
 func (c Charge) GetFeatureKeyOrID() ref.IDOrKey {
-	// TODO: if API edits can override FeatureKey, keep State.FeatureID in sync
-	// with the effective key. State.FeatureID is the persisted resolved feature
-	// snapshot used by active charges; created/deleted fallbacks resolve by key.
+	// TODO: if API edits can override FeatureKey, re-resolve State.FeatureID
+	// whenever the effective key changes. Call chain: API line edit -> usage-based
+	// line engine -> charge override -> feature resolution/current totals/triggers.
+	// State.FeatureID is the persisted resolved feature snapshot used by active
+	// charges; created/deleted fallbacks resolve by key.
 	switch c.Status {
 	case StatusCreated:
 		return ref.IDOrKey{

--- a/openmeter/billing/charges/usagebased/service/create.go
+++ b/openmeter/billing/charges/usagebased/service/create.go
@@ -61,7 +61,7 @@ func (s *service) Create(ctx context.Context, input usagebased.CreateInput) ([]u
 			Charges: lo.Map(charges, func(charge usagebased.Charge, idx int) meta.IDWithUniqueReferenceID {
 				return meta.IDWithUniqueReferenceID{
 					ID:                charge.ID,
-					UniqueReferenceID: charge.Intent.UniqueReferenceID,
+					UniqueReferenceID: charge.Intent.GetUniqueReferenceID(),
 				}
 			}),
 		})
@@ -71,7 +71,7 @@ func (s *service) Create(ctx context.Context, input usagebased.CreateInput) ([]u
 
 		return slicesx.MapWithErr(charges, func(charge usagebased.Charge) (usagebased.ChargeWithGatheringLine, error) {
 			// For credit only flat fees we are not relying on the invoicing stack at all, so we can return early.
-			if charge.Intent.SettlementMode == productcatalog.CreditOnlySettlementMode {
+			if charge.Intent.GetSettlementMode() == productcatalog.CreditOnlySettlementMode {
 				return usagebased.ChargeWithGatheringLine{
 					Charge: charge,
 				}, nil
@@ -83,11 +83,11 @@ func (s *service) Create(ctx context.Context, input usagebased.CreateInput) ([]u
 }
 
 func gatheringLineFromUsageBasedCharge(charge usagebased.Charge) (usagebased.ChargeWithGatheringLine, error) {
-	return gatheringLineFromUsageBasedChargeForPeriod(charge, charge.Intent.BaseLayer.ServicePeriod, charge.Intent.BaseLayer.InvoiceAt)
+	return gatheringLineFromUsageBasedChargeForPeriod(charge, charge.Intent.GetEffectiveServicePeriod(), charge.Intent.GetEffectiveInvoiceAt())
 }
 
 func gatheringLineFromUsageBasedChargeForPeriod(charge usagebased.Charge, servicePeriod timeutil.ClosedPeriod, invoiceAt time.Time) (usagebased.ChargeWithGatheringLine, error) {
-	intent := charge.Intent
+	intent := charge.Intent.GetEffectiveIntent()
 
 	var subscription *billing.SubscriptionReference
 	if intent.Subscription != nil {
@@ -96,13 +96,13 @@ func gatheringLineFromUsageBasedChargeForPeriod(charge usagebased.Charge, servic
 			PhaseID:        intent.Subscription.PhaseID,
 			ItemID:         intent.Subscription.ItemID,
 			BillingPeriod: timeutil.ClosedPeriod{
-				From: intent.BaseLayer.BillingPeriod.From,
-				To:   intent.BaseLayer.BillingPeriod.To,
+				From: intent.BillingPeriod.From,
+				To:   intent.BillingPeriod.To,
 			},
 		}
 	}
 
-	clonedAnnotations, err := charge.Intent.Annotations.Clone()
+	clonedAnnotations, err := intent.Annotations.Clone()
 	if err != nil {
 		return usagebased.ChargeWithGatheringLine{}, fmt.Errorf("cloning annotations: %w", err)
 	}
@@ -111,22 +111,22 @@ func gatheringLineFromUsageBasedChargeForPeriod(charge usagebased.Charge, servic
 		GatheringLineBase: billing.GatheringLineBase{
 			ManagedResource: models.NewManagedResource(models.ManagedResourceInput{
 				Namespace:   charge.Namespace,
-				Name:        intent.BaseLayer.Name,
-				Description: intent.BaseLayer.Description,
+				Name:        intent.Name,
+				Description: intent.Description,
 			}),
 
-			Metadata:    intent.BaseLayer.Metadata.Clone(),
+			Metadata:    intent.Metadata.Clone(),
 			Annotations: clonedAnnotations,
 			ManagedBy:   intent.ManagedBy,
 
-			Price:      intent.BaseLayer.Price,
-			FeatureKey: intent.BaseLayer.FeatureKey,
+			Price:      intent.Price,
+			FeatureKey: intent.FeatureKey,
 
 			Currency:      intent.Currency,
 			ServicePeriod: servicePeriod,
 			InvoiceAt:     invoiceAt,
 
-			TaxConfig: lo.ToPtr(intent.BaseLayer.TaxConfig.ToTaxConfig()),
+			TaxConfig: lo.ToPtr(intent.TaxConfig.ToTaxConfig()),
 
 			ChargeID:     lo.ToPtr(charge.ID),
 			Engine:       billing.LineEngineTypeChargeUsageBased,
@@ -134,15 +134,15 @@ func gatheringLineFromUsageBasedChargeForPeriod(charge usagebased.Charge, servic
 		},
 	}
 
-	if intent.BaseLayer.Discounts.Usage != nil {
+	if intent.Discounts.Usage != nil {
 		gatheringLine.RateCardDiscounts.Usage = &billing.UsageDiscount{
-			UsageDiscount: *intent.BaseLayer.Discounts.Usage,
+			UsageDiscount: *intent.Discounts.Usage,
 		}
 	}
 
-	if intent.BaseLayer.Discounts.Percentage != nil {
+	if intent.Discounts.Percentage != nil {
 		gatheringLine.RateCardDiscounts.Percentage = &billing.PercentageDiscount{
-			PercentageDiscount: *intent.BaseLayer.Discounts.Percentage,
+			PercentageDiscount: *intent.Discounts.Percentage,
 		}
 	}
 

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -30,7 +30,7 @@ func NewCreditThenInvoiceStateMachine(config StateMachineConfig) (*CreditThenInv
 		return nil, fmt.Errorf("validate: %w", err)
 	}
 
-	if config.Charge.Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+	if config.Charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
 		return nil, fmt.Errorf("charge %s is not credit_then_invoice", config.Charge.ID)
 	}
 
@@ -273,18 +273,21 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, _ meta
 }
 
 func (s *CreditThenInvoiceStateMachine) ExtendCharge(ctx context.Context, patch meta.PatchExtend) error {
-	oldIntent := s.Charge.Intent.BaseLayer
-	if err := patch.ValidateWith(oldIntent.IntentMutableFields); err != nil {
+	if err := patch.ValidateWith(s.Charge.Intent.GetEffectiveMetaIntentMutableFields()); err != nil {
 		return fmt.Errorf("validate extend patch: %w", err)
 	}
 
-	oldServicePeriod := meta.NormalizeClosedPeriod(s.Charge.Intent.BaseLayer.ServicePeriod)
+	oldServicePeriod := meta.NormalizeClosedPeriod(s.Charge.Intent.GetEffectiveServicePeriod())
 
-	s.Charge.Intent.BaseLayer.ServicePeriod.To = patch.GetNewServicePeriodTo()
-	s.Charge.Intent.BaseLayer.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
-	s.Charge.Intent.BaseLayer.BillingPeriod.To = patch.GetNewBillingPeriodTo()
-	s.Charge.Intent.BaseLayer.InvoiceAt = patch.GetNewInvoiceAt()
-	s.Charge.Intent = s.Charge.Intent.Normalized()
+	if err := s.Charge.Intent.MutateEffective(func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+		fields.ServicePeriod.To = patch.GetNewServicePeriodTo()
+		fields.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
+		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
+		fields.InvoiceAt = patch.GetNewInvoiceAt()
+		return fields, nil
+	}); err != nil {
+		return fmt.Errorf("mutating effective intent: %w", err)
+	}
 
 	newGatheringLinePeriod, err := s.handleFinalRunOnExtend(ctx, oldServicePeriod)
 	if err != nil {
@@ -292,7 +295,7 @@ func (s *CreditThenInvoiceStateMachine) ExtendCharge(ctx context.Context, patch 
 	}
 
 	if period, ok := newGatheringLinePeriod.Get(); ok {
-		withLine, err := gatheringLineFromUsageBasedChargeForPeriod(s.Charge, period, s.Charge.Intent.BaseLayer.InvoiceAt)
+		withLine, err := gatheringLineFromUsageBasedChargeForPeriod(s.Charge, period, s.Charge.Intent.GetEffectiveInvoiceAt())
 		if err != nil {
 			return fmt.Errorf("creating gathering line for extended period: %w", err)
 		}
@@ -305,8 +308,8 @@ func (s *CreditThenInvoiceStateMachine) ExtendCharge(ctx context.Context, patch 
 	} else {
 		s.AddInvoicePatch(invoiceupdater.NewUpdateGatheringLineByChargeIDPatch(
 			s.Charge.ID,
-			s.Charge.Intent.BaseLayer.ServicePeriod.To,
-			s.Charge.Intent.BaseLayer.InvoiceAt,
+			s.Charge.Intent.GetEffectiveServicePeriod().To,
+			s.Charge.Intent.GetEffectiveInvoiceAt(),
 		))
 	}
 
@@ -314,16 +317,19 @@ func (s *CreditThenInvoiceStateMachine) ExtendCharge(ctx context.Context, patch 
 }
 
 func (s *CreditThenInvoiceStateMachine) ShrinkCharge(_ context.Context, patch meta.PatchShrink) error {
-	oldIntent := s.Charge.Intent.BaseLayer
-	if err := patch.ValidateWith(oldIntent.IntentMutableFields); err != nil {
+	if err := patch.ValidateWith(s.Charge.Intent.GetEffectiveMetaIntentMutableFields()); err != nil {
 		return fmt.Errorf("validate shrink patch: %w", err)
 	}
 
-	s.Charge.Intent.BaseLayer.ServicePeriod.To = patch.GetNewServicePeriodTo()
-	s.Charge.Intent.BaseLayer.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
-	s.Charge.Intent.BaseLayer.BillingPeriod.To = patch.GetNewBillingPeriodTo()
-	s.Charge.Intent.BaseLayer.InvoiceAt = patch.GetNewInvoiceAt()
-	s.Charge.Intent = s.Charge.Intent.Normalized()
+	if err := s.Charge.Intent.MutateEffective(func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+		fields.ServicePeriod.To = patch.GetNewServicePeriodTo()
+		fields.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
+		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
+		fields.InvoiceAt = patch.GetNewInvoiceAt()
+		return fields, nil
+	}); err != nil {
+		return fmt.Errorf("mutating effective intent: %w", err)
+	}
 
 	if err := s.handleRunsOnShrink(); err != nil {
 		return fmt.Errorf("handling realization runs on shrink: %w", err)
@@ -345,9 +351,10 @@ func (s *CreditThenInvoiceStateMachine) UnsupportedShrinkOperation(_ context.Con
 }
 
 func (s *CreditThenInvoiceStateMachine) handleRunsOnShrink() error {
-	newServicePeriodTo := meta.NormalizeTimestamp(s.Charge.Intent.BaseLayer.ServicePeriod.To)
+	servicePeriod := s.Charge.Intent.GetEffectiveServicePeriod()
+	newServicePeriodTo := meta.NormalizeTimestamp(servicePeriod.To)
 	runsToKeep, runsToBeDeleted := s.Charge.Realizations.BisectByTimestamp(
-		s.Charge.Intent.BaseLayer.ServicePeriod,
+		servicePeriod,
 		newServicePeriodTo,
 	)
 
@@ -371,7 +378,7 @@ func (s *CreditThenInvoiceStateMachine) handleRunsOnShrink() error {
 	}
 
 	gatheringLinePeriod := timeutil.ClosedPeriod{
-		From: meta.NormalizeTimestamp(s.Charge.Intent.BaseLayer.ServicePeriod.From),
+		From: meta.NormalizeTimestamp(servicePeriod.From),
 		To:   newServicePeriodTo,
 	}
 
@@ -391,7 +398,7 @@ func (s *CreditThenInvoiceStateMachine) handleRunsOnShrink() error {
 		s.AddInvoicePatch(invoiceupdater.NewUpdateGatheringLineByChargeIDPatch(
 			s.Charge.ID,
 			gatheringLinePeriod.To,
-			s.Charge.Intent.BaseLayer.InvoiceAt,
+			s.Charge.Intent.GetEffectiveInvoiceAt(),
 		))
 	} else {
 		s.AddInvoicePatch(invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID))
@@ -400,7 +407,7 @@ func (s *CreditThenInvoiceStateMachine) handleRunsOnShrink() error {
 			withLine, err := gatheringLineFromUsageBasedChargeForPeriod(
 				s.Charge,
 				gatheringLinePeriod,
-				s.Charge.Intent.BaseLayer.InvoiceAt,
+				s.Charge.Intent.GetEffectiveInvoiceAt(),
 			)
 			if err != nil {
 				return fmt.Errorf("creating gathering line for shrunk period: %w", err)
@@ -499,7 +506,7 @@ func (s *CreditThenInvoiceStateMachine) handleFinalRunOnExtend(ctx context.Conte
 			*currentRun.InvoiceID,
 		))
 
-		return mo.Some(s.Charge.Intent.BaseLayer.ServicePeriod), nil
+		return mo.Some(s.Charge.Intent.GetEffectiveServicePeriod()), nil
 	}
 
 	finalRuns := lo.Filter(s.Charge.Realizations, func(run usagebased.RealizationRun, _ int) bool {
@@ -538,11 +545,11 @@ func (s *CreditThenInvoiceStateMachine) handleFinalRunOnExtend(ctx context.Conte
 
 	s.Charge.Status = usagebased.StatusActive
 	s.Charge.State.CurrentRealizationRunID = nil
-	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.BaseLayer.ServicePeriod.To))
+	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().To))
 
 	return mo.Some(timeutil.ClosedPeriod{
 		From: oldServicePeriod.To,
-		To:   s.Charge.Intent.BaseLayer.ServicePeriod.To,
+		To:   s.Charge.Intent.GetEffectiveServicePeriod().To,
 	}), nil
 }
 
@@ -585,7 +592,7 @@ func (s *CreditThenInvoiceStateMachine) startInvoiceCreatedRun(
 		if err != nil {
 			return fmt.Errorf("get stored at lt: %w", err)
 		}
-		servicePeriodTo = meta.NormalizeTimestamp(s.Charge.Intent.BaseLayer.ServicePeriod.To)
+		servicePeriodTo = meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().To)
 	}
 
 	result, err := s.Runs.CreateRatedRun(ctx, usagebasedrun.CreateRatedRunInput{
@@ -617,7 +624,7 @@ func (s *CreditThenInvoiceStateMachine) StartFinalInvoiceRun(ctx context.Context
 }
 
 func resolveInvoiceCreatedTrigger(charge usagebased.Charge, billedPeriod timeutil.ClosedPeriod) meta.Trigger {
-	if meta.NormalizeTimestamp(billedPeriod.To).Equal(meta.NormalizeTimestamp(charge.Intent.BaseLayer.ServicePeriod.To)) {
+	if meta.NormalizeTimestamp(billedPeriod.To).Equal(meta.NormalizeTimestamp(charge.Intent.GetEffectiveServicePeriod().To)) {
 		return meta.TriggerFinalInvoiceCreated
 	}
 

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -5,13 +5,17 @@ import (
 	"testing"
 	"time"
 
+	decimal "github.com/alpacahq/alpacadecimal"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/invoicedusage"
 	chargestatemachine "github.com/openmeterio/openmeter/openmeter/billing/charges/statemachine"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
@@ -150,16 +154,7 @@ func TestShrinkChargeKeepsCurrentRunStateWhenCurrentRunSurvivesShrink(t *testing
 				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
 				ID:              "charge-id",
 			},
-			Intent: usagebased.OverridableIntent{
-				BaseLayer: usagebased.IntentMutableFields{
-					IntentMutableFields: meta.IntentMutableFields{
-						ServicePeriod:     servicePeriod,
-						FullServicePeriod: servicePeriod,
-						BillingPeriod:     servicePeriod,
-					},
-					InvoiceAt: servicePeriod.To,
-				},
-			},
+			Intent: newUsageBasedIntentForCreditThenInvoiceTest(servicePeriod),
 			Status: usagebased.StatusActivePartialInvoiceProcessing,
 			State: usagebased.State{
 				CurrentRealizationRunID: &currentRunID,
@@ -205,16 +200,7 @@ func TestShrinkChargeMovesToAwaitingPaymentWhenKeptRunCoversNewEnd(t *testing.T)
 				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
 				ID:              "charge-id",
 			},
-			Intent: usagebased.OverridableIntent{
-				BaseLayer: usagebased.IntentMutableFields{
-					IntentMutableFields: meta.IntentMutableFields{
-						ServicePeriod:     servicePeriod,
-						FullServicePeriod: servicePeriod,
-						BillingPeriod:     servicePeriod,
-					},
-					InvoiceAt: servicePeriod.To,
-				},
-			},
+			Intent: newUsageBasedIntentForCreditThenInvoiceTest(servicePeriod),
 			Status: usagebased.StatusActive,
 			State: usagebased.State{
 				AdvanceAfter: &currentAdvanceAfter,
@@ -261,16 +247,7 @@ func TestShrinkChargeMovesToFinalWhenKeptRunCoversNewEndAndSettlementIsComplete(
 				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
 				ID:              "charge-id",
 			},
-			Intent: usagebased.OverridableIntent{
-				BaseLayer: usagebased.IntentMutableFields{
-					IntentMutableFields: meta.IntentMutableFields{
-						ServicePeriod:     servicePeriod,
-						FullServicePeriod: servicePeriod,
-						BillingPeriod:     servicePeriod,
-					},
-					InvoiceAt: servicePeriod.To,
-				},
-			},
+			Intent: newUsageBasedIntentForCreditThenInvoiceTest(servicePeriod),
 			Status: usagebased.StatusActiveAwaitingPaymentSettlement,
 			State: usagebased.State{
 				AdvanceAfter: &currentAdvanceAfter,
@@ -328,6 +305,33 @@ func newCreditThenInvoiceStateMachineForTest(t *testing.T, status usagebased.Sta
 	out.configureStates()
 
 	return out
+}
+
+func newUsageBasedIntentForCreditThenInvoiceTest(servicePeriod timeutil.ClosedPeriod) usagebased.OverridableIntent {
+	return usagebased.Intent{
+		Intent: meta.Intent{
+			ManagedBy:  billing.SubscriptionManagedLine,
+			CustomerID: "customer-id",
+			Currency:   currencyx.Code("USD"),
+		},
+		IntentMutableFields: usagebased.IntentMutableFields{
+			IntentMutableFields: meta.IntentMutableFields{
+				Name:              "usage",
+				ServicePeriod:     servicePeriod,
+				FullServicePeriod: servicePeriod,
+				BillingPeriod:     servicePeriod,
+				TaxConfig: productcatalog.TaxCodeConfig{
+					TaxCodeID: "tax-code-id",
+				},
+			},
+			InvoiceAt:  servicePeriod.To,
+			FeatureKey: "feature-key",
+			Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: decimal.NewFromInt(1),
+			}),
+		},
+		SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+	}.AsOverridableIntent()
 }
 
 func newCreditThenInvoiceStateMachineWithChargeForTest(t *testing.T, charge usagebased.Charge) *CreditThenInvoiceStateMachine {
@@ -415,13 +419,7 @@ func TestResolveInvoiceCreatedTrigger(t *testing.T) {
 
 	charge := usagebased.Charge{
 		ChargeBase: usagebased.ChargeBase{
-			Intent: usagebased.OverridableIntent{
-				BaseLayer: usagebased.IntentMutableFields{
-					IntentMutableFields: meta.IntentMutableFields{
-						ServicePeriod: servicePeriod,
-					},
-				},
-			},
+			Intent: newUsageBasedIntentForCreditThenInvoiceTest(servicePeriod),
 		},
 	}
 

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -24,7 +24,7 @@ func NewCreditsOnlyStateMachine(config StateMachineConfig) (*CreditsOnlyStateMac
 		return nil, fmt.Errorf("validate: %w", err)
 	}
 
-	if config.Charge.Intent.SettlementMode != productcatalog.CreditOnlySettlementMode {
+	if config.Charge.Intent.GetSettlementMode() != productcatalog.CreditOnlySettlementMode {
 		return nil, fmt.Errorf("charge %s is not credit_only", config.Charge.ID)
 	}
 
@@ -155,7 +155,7 @@ func (s *CreditsOnlyStateMachine) StartFinalRealizationRun(ctx context.Context) 
 		FeatureMeter:              s.FeatureMeter,
 		Type:                      usagebased.RealizationRunTypeFinalRealization,
 		StoredAtLT:                storedAtLT,
-		ServicePeriodTo:           meta.NormalizeTimestamp(s.Charge.Intent.BaseLayer.ServicePeriod.To),
+		ServicePeriodTo:           meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().To),
 		CreditAllocation:          usagebasedrun.CreditAllocationExact,
 		CurrencyCalculator:        s.CurrencyCalculator,
 		NoFiatTransactionRequired: true,

--- a/openmeter/billing/charges/usagebased/service/currenttotals.go
+++ b/openmeter/billing/charges/usagebased/service/currenttotals.go
@@ -28,7 +28,7 @@ func (s *service) GetCurrentTotals(ctx context.Context, input usagebased.GetCurr
 	customerOverride, err := s.customerOverrideService.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
 		Customer: customer.CustomerID{
 			Namespace: charge.Namespace,
-			ID:        charge.Intent.CustomerID,
+			ID:        charge.Intent.GetCustomerID(),
 		},
 		Expand: billing.CustomerOverrideExpand{
 			Customer: true,
@@ -55,7 +55,7 @@ func (s *service) GetCurrentTotals(ctx context.Context, input usagebased.GetCurr
 		Customer:                customerOverride,
 		FeatureMeter:            featureMeter,
 		StoredAtLT:              now,
-		IgnoreMinimumCommitment: now.Before(charge.Intent.BaseLayer.ServicePeriod.To),
+		IgnoreMinimumCommitment: now.Before(charge.Intent.GetEffectiveServicePeriod().To),
 	})
 	if err != nil {
 		return usagebased.GetCurrentTotalsResult{}, fmt.Errorf("get totals for usage: %w", err)

--- a/openmeter/billing/charges/usagebased/service/get.go
+++ b/openmeter/billing/charges/usagebased/service/get.go
@@ -148,7 +148,7 @@ func (s *service) expandChargesUsage(ctx context.Context, namespace string, char
 				Customer:                customerOverridesById[charge.GetCustomerID()],
 				FeatureMeter:            featureMeter,
 				StoredAtLT:              storedAt,
-				IgnoreMinimumCommitment: storedAt.Before(charge.Intent.BaseLayer.ServicePeriod.To),
+				IgnoreMinimumCommitment: storedAt.Before(charge.Intent.GetEffectiveServicePeriod().To),
 			})
 			if err != nil {
 				err = fmt.Errorf("get totals for charge %s: %w", charge.ID, err)

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -162,11 +162,11 @@ func (e *LineEngine) BuildStandardLinesForGatheringPreview(ctx context.Context, 
 }
 
 func (e *LineEngine) buildGatheringPreviewRun(ctx context.Context, charge usagebased.Charge, stdLine *billing.StandardLine) (usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunResult, error) {
-	if charge.Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+	if charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
 		return usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunResult{}, fmt.Errorf(
 			"usage based standard line[%s]: unsupported settlement mode for gathering preview: %s",
 			stdLine.ID,
-			charge.Intent.SettlementMode,
+			charge.Intent.GetSettlementMode(),
 		)
 	}
 
@@ -180,9 +180,9 @@ func (e *LineEngine) buildGatheringPreviewRun(ctx context.Context, charge usageb
 	servicePeriodTo := storedAtLT
 	if resolveInvoiceCreatedTrigger(charge, stdLine.Period) == meta.TriggerFinalInvoiceCreated {
 		runType = usagebased.RealizationRunTypeFinalRealization
-		storedAtLT, _ = stateMachineConfig.CustomerOverride.MergedProfile.WorkflowConfig.Collection.Interval.AddTo(charge.Intent.BaseLayer.ServicePeriod.To)
+		storedAtLT, _ = stateMachineConfig.CustomerOverride.MergedProfile.WorkflowConfig.Collection.Interval.AddTo(charge.Intent.GetEffectiveServicePeriod().To)
 		storedAtLT = meta.NormalizeTimestamp(storedAtLT)
-		servicePeriodTo = meta.NormalizeTimestamp(charge.Intent.BaseLayer.ServicePeriod.To)
+		servicePeriodTo = meta.NormalizeTimestamp(charge.Intent.GetEffectiveServicePeriod().To)
 	}
 
 	return e.service.runs.BuildCreditThenInvoiceGatheringPreviewRun(ctx, usagebasedrun.BuildCreditThenInvoiceGatheringPreviewRunInput{
@@ -209,11 +209,11 @@ func (e *LineEngine) OnStandardInvoiceCreated(ctx context.Context, input billing
 			return nil, err
 		}
 
-		if stateMachine.GetCharge().Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+		if stateMachine.GetCharge().Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
 			return nil, fmt.Errorf(
 				"usage based standard line[%s]: unsupported settlement mode for standard invoice creation: %s",
 				stdLine.ID,
-				stateMachine.GetCharge().Intent.SettlementMode,
+				stateMachine.GetCharge().Intent.GetSettlementMode(),
 			)
 		}
 
@@ -316,6 +316,10 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(_ context.Context, _ bill
 	// TODO: implement charge-backed manual creates by creating
 	// a manually managed charge and attaching its realization to the
 	// preallocated invoice line ID provided by billing.
+	// TODO: if API edits can override FeatureKey, re-resolve State.FeatureID
+	// based on charge state. The current resolution chain is:
+	// getStateMachineConfigForPatch -> ResolveFeatureMeters(GetFeatureKeyOrID)
+	// -> ResolveFeatureMeter -> SyncFeatureIDFromFeatureMeter.
 	return billing.OnMutableInvoiceUpdateResult{}, billing.ErrCannotUpdateChargeManagedLine
 }
 
@@ -360,7 +364,7 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 			return fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] has invoice accrued allocation", stdLine.ID, run.ID.ID)
 		}
 
-		currencyCalculator, err := charge.Intent.Currency.Calculator()
+		currencyCalculator, err := charge.Intent.GetCurrency().Calculator()
 		if err != nil {
 			return fmt.Errorf("getting currency calculator for charge[%s]: %w", charge.ID, err)
 		}
@@ -453,7 +457,7 @@ func (e *LineEngine) markMutableStandardLineRunDeleted(
 		charge.State.CurrentRealizationRunID = nil
 		if charge.Status != usagebased.StatusDeleted {
 			charge.Status = usagebased.StatusActive
-			charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(charge.Intent.BaseLayer.ServicePeriod.To))
+			charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(charge.Intent.GetEffectiveServicePeriod().To))
 		}
 
 		updatedChargeBase, err := e.service.adapter.UpdateCharge(ctx, charge.ChargeBase)

--- a/openmeter/billing/charges/usagebased/service/rating/details.go
+++ b/openmeter/billing/charges/usagebased/service/rating/details.go
@@ -221,6 +221,9 @@ func (s *service) ratePeriodPreservingDetails(ctx context.Context, in ratePeriod
 	priorPeriods := make([]periodpreserving.PriorPeriod, 0, len(in.EligibleRealizations))
 
 	for _, realization := range in.EligibleRealizations {
+		// TODO: when override-layer edits can move the effective service period
+		// forward, filter or remap prior realizations that predate the effective
+		// window so period-preserving rating cannot build invalid prior ranges.
 		servicePeriod := timeutil.ClosedPeriod{
 			From: servicePeriodFrom,
 			To:   realization.ServicePeriodTo,

--- a/openmeter/billing/charges/usagebased/service/rating/details.go
+++ b/openmeter/billing/charges/usagebased/service/rating/details.go
@@ -51,7 +51,7 @@ func (i GetDetailedRatingForUsageInput) Validate() error {
 		return fmt.Errorf("feature meter is required")
 	}
 
-	period := i.Charge.Intent.BaseLayer.ServicePeriod
+	period := i.Charge.Intent.GetEffectiveServicePeriod()
 	if i.ServicePeriodTo.IsZero() {
 		return fmt.Errorf("service period to is required")
 	}
@@ -74,7 +74,7 @@ func (i GetDetailedRatingForUsageInput) Validate() error {
 type GetDetailedRatingForUsageResult struct {
 	Totals        totals.Totals
 	DetailedLines usagebased.DetailedLines
-	// Quantity is the current run's meter value between [Charge.Intent.BaseLayer.ServicePeriod.From, ServicePeriodTo)
+	// Quantity is the current run's meter value between [Charge.Intent.GetEffectiveServicePeriod().From, ServicePeriodTo)
 	// capped at StoredAtLT.
 	Quantity alpacadecimal.Decimal
 }
@@ -90,7 +90,7 @@ func (s *service) GetDetailedRatingForUsage(ctx context.Context, in GetDetailedR
 	}
 
 	currentRunServicePeriod := timeutil.ClosedPeriod{
-		From: charge.Intent.BaseLayer.ServicePeriod.From,
+		From: charge.Intent.GetEffectiveServicePeriod().From,
 		To:   in.ServicePeriodTo,
 	}
 
@@ -217,7 +217,7 @@ func (s *service) ratePeriodPreservingDetails(ctx context.Context, in ratePeriod
 		return cmp.Compare(a.ServicePeriodTo.UnixNano(), b.ServicePeriodTo.UnixNano())
 	})
 
-	servicePeriodFrom := in.Charge.Intent.BaseLayer.ServicePeriod.From
+	servicePeriodFrom := in.Charge.Intent.GetEffectiveServicePeriod().From
 	priorPeriods := make([]periodpreserving.PriorPeriod, 0, len(in.EligibleRealizations))
 
 	for _, realization := range in.EligibleRealizations {
@@ -252,7 +252,7 @@ func (s *service) ratePeriodPreservingDetails(ctx context.Context, in ratePeriod
 			// The service period captured inside the PriorPeriod only contains the prior period's service period from billing perspective, but rating engines need the
 			// cumulative quantity for proper operation.
 			ServicePeriod: timeutil.ClosedPeriod{
-				From: in.Charge.Intent.BaseLayer.ServicePeriod.From,
+				From: in.Charge.Intent.GetEffectiveServicePeriod().From,
 				To:   realization.ServicePeriodTo,
 			},
 			StoredAtLT: in.Input.StoredAtLT,

--- a/openmeter/billing/charges/usagebased/service/rating/quantitysnapshot.go
+++ b/openmeter/billing/charges/usagebased/service/rating/quantitysnapshot.go
@@ -41,7 +41,7 @@ func (i getQuantityForUsageInput) Validate() error {
 		return fmt.Errorf("service period to is required")
 	}
 
-	period := i.Charge.Intent.BaseLayer.ServicePeriod
+	period := i.Charge.Intent.GetEffectiveServicePeriod()
 	if !i.ServicePeriodTo.After(period.From) {
 		return fmt.Errorf("service period to must be after charge service period from")
 	}
@@ -62,7 +62,7 @@ func (s *service) getQuantityForUsage(ctx context.Context, in getQuantityForUsag
 		return alpacadecimal.Zero, err
 	}
 
-	servicePeriod := in.Charge.Intent.BaseLayer.ServicePeriod
+	servicePeriod := in.Charge.Intent.GetEffectiveServicePeriod()
 	servicePeriod.To = in.ServicePeriodTo
 
 	return s.snapshotQuantity(ctx, snapshotQuantityInput{

--- a/openmeter/billing/charges/usagebased/service/rating/service_test.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service_test.go
@@ -425,6 +425,9 @@ func TestGetTotalsForUsageMinimumCommitment(t *testing.T) {
 func newGetDetailedRatingForUsageFixture(t *testing.T, result billingrating.GenerateDetailedLinesResult) getDetailedRatingForUsageFixture {
 	t.Helper()
 
+	// TODO: add a fixture where the override layer changes ServicePeriod.From
+	// and a prior realization exists before that effective start, so rating tests
+	// cover override-window behavior instead of only base/effective-identical intents.
 	servicePeriod := timeutil.ClosedPeriod{
 		From: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 		To:   time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),

--- a/openmeter/billing/charges/usagebased/service/rating/service_test.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service_test.go
@@ -241,7 +241,7 @@ func TestGetDetailedRatingForUsageLoadsPriorDetailedLines(t *testing.T) {
 	t.Parallel()
 
 	fixture := newGetDetailedRatingForUsageFixture(t, billingrating.GenerateDetailedLinesResult{})
-	priorRun := newDetailedRatingTestRun("prior", fixture.input.Charge.Intent.BaseLayer.ServicePeriod.From.Add(24*time.Hour), 0)
+	priorRun := newDetailedRatingTestRun("prior", fixture.input.Charge.Intent.GetEffectiveServicePeriod().From.Add(24*time.Hour), 0)
 	fixture.input.Charge.Realizations = usagebased.RealizationRuns{priorRun}
 
 	var called int
@@ -264,7 +264,7 @@ func TestGetDetailedRatingForUsageIgnoresInvalidUnsupportedCreditNotePriorRuns(t
 	t.Parallel()
 
 	fixture := newGetDetailedRatingForUsageFixture(t, billingrating.GenerateDetailedLinesResult{})
-	priorRun := newDetailedRatingTestRun("prior", fixture.input.Charge.Intent.BaseLayer.ServicePeriod.From.Add(24*time.Hour), 0)
+	priorRun := newDetailedRatingTestRun("prior", fixture.input.Charge.Intent.GetEffectiveServicePeriod().From.Add(24*time.Hour), 0)
 	priorRun.Type = usagebased.RealizationRunTypeInvalidDueToUnsupportedCreditNote
 	fixture.input.Charge.Realizations = usagebased.RealizationRuns{priorRun}
 
@@ -308,7 +308,7 @@ func TestGetDetailedRatingForUsageWrapsDetailedLinesLoadError(t *testing.T) {
 	t.Parallel()
 
 	fixture := newGetDetailedRatingForUsageFixture(t, billingrating.GenerateDetailedLinesResult{})
-	priorRun := newDetailedRatingTestRun("prior", fixture.input.Charge.Intent.BaseLayer.ServicePeriod.From.Add(24*time.Hour), 0)
+	priorRun := newDetailedRatingTestRun("prior", fixture.input.Charge.Intent.GetEffectiveServicePeriod().From.Add(24*time.Hour), 0)
 	fixture.input.Charge.Realizations = usagebased.RealizationRuns{priorRun}
 	fixture.config.DetailedLinesFetcher = detailedLinesFetcherFunc(func(_ context.Context, charge usagebased.Charge) (usagebased.Charge, error) {
 		return charge, errors.New("boom")
@@ -397,12 +397,16 @@ func TestGetTotalsForUsageMinimumCommitment(t *testing.T) {
 			require.NoError(t, err)
 
 			charge := newDetailedRatingTestCharge(servicePeriod, usagebased.RealizationRuns{})
-			charge.Intent.BaseLayer.Price = *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
-				Amount: alpacadecimal.NewFromInt(3),
-				Commitments: productcatalog.Commitments{
-					MinimumAmount: lo.ToPtr(alpacadecimal.NewFromInt(100)),
-				},
+			err = charge.Intent.MutateEffective(func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+				fields.Price = *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+					Amount: alpacadecimal.NewFromInt(3),
+					Commitments: productcatalog.Commitments{
+						MinimumAmount: lo.ToPtr(alpacadecimal.NewFromInt(100)),
+					},
+				})
+				return fields, nil
 			})
+			require.NoError(t, err)
 
 			out, err := svc.GetTotalsForUsage(t.Context(), GetTotalsForUsageInput{
 				Charge:                  charge,
@@ -483,13 +487,13 @@ func newDetailedRatingTestCharge(period timeutil.ClosedPeriod, runs usagebased.R
 				},
 				ID: "charge-1",
 			},
-			Intent: usagebased.OverridableIntent{
+			Intent: usagebased.Intent{
 				Intent: chargesmeta.Intent{
 					ManagedBy:  billing.SubscriptionManagedLine,
 					CustomerID: "customer-1",
 					Currency:   currencyx.Code("USD"),
 				},
-				BaseLayer: usagebased.IntentMutableFields{
+				IntentMutableFields: usagebased.IntentMutableFields{
 					IntentMutableFields: chargesmeta.IntentMutableFields{
 						Name:              "usage-charge",
 						ServicePeriod:     period,
@@ -506,7 +510,7 @@ func newDetailedRatingTestCharge(period timeutil.ClosedPeriod, runs usagebased.R
 					}),
 				},
 				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
-			},
+			}.AsOverridableIntent(),
 			Status: usagebased.StatusCreated,
 			State: usagebased.State{
 				FeatureID:    "feature-1",

--- a/openmeter/billing/charges/usagebased/service/rating/totals.go
+++ b/openmeter/billing/charges/usagebased/service/rating/totals.go
@@ -50,7 +50,7 @@ func (s *service) GetTotalsForUsage(ctx context.Context, in GetTotalsForUsageInp
 	snapshotQuantity, err := s.snapshotQuantity(ctx, snapshotQuantityInput{
 		Customer:      in.Customer.Customer,
 		FeatureMeter:  in.FeatureMeter,
-		ServicePeriod: in.Charge.Intent.BaseLayer.ServicePeriod,
+		ServicePeriod: in.Charge.Intent.GetEffectiveServicePeriod(),
 		StoredAtLT:    in.StoredAtLT,
 	})
 	if err != nil {
@@ -68,7 +68,7 @@ func (s *service) GetTotalsForUsage(ctx context.Context, in GetTotalsForUsageInp
 	ratingResult, err := s.ratingService.GenerateDetailedLines(usagebased.RateableIntent{
 		Intent:        in.Charge.Intent.GetEffectiveIntent(),
 		MeterValue:    snapshotQuantity,
-		ServicePeriod: in.Charge.Intent.BaseLayer.ServicePeriod,
+		ServicePeriod: in.Charge.Intent.GetEffectiveServicePeriod(),
 	}, opts...)
 	if err != nil {
 		return totals.Totals{}, fmt.Errorf("rating totals: %w", err)

--- a/openmeter/billing/charges/usagebased/service/run/create.go
+++ b/openmeter/billing/charges/usagebased/service/run/create.go
@@ -61,7 +61,7 @@ func (i CreateRatedRunInput) Validate() error {
 		return fmt.Errorf("service period to is required")
 	}
 
-	period := i.Charge.Intent.BaseLayer.ServicePeriod
+	period := i.Charge.Intent.GetEffectiveServicePeriod()
 	if !i.ServicePeriodTo.After(period.From) {
 		return fmt.Errorf("service period to must be after charge service period from")
 	}

--- a/openmeter/billing/charges/usagebased/service/run/credits.go
+++ b/openmeter/billing/charges/usagebased/service/run/credits.go
@@ -23,9 +23,9 @@ func (s *Service) createRunCreditRealizations(ctx context.Context, charge usageb
 	if err := s.lineage.CreateInitialLineages(ctx, lineage.CreateInitialLineagesInput{
 		Namespace:    charge.Namespace,
 		ChargeID:     charge.ID,
-		CustomerID:   charge.Intent.CustomerID,
-		Currency:     charge.Intent.Currency,
-		Features:     featuresForLineage(charge.Intent.BaseLayer.FeatureKey),
+		CustomerID:   charge.Intent.GetCustomerID(),
+		Currency:     charge.Intent.GetCurrency(),
+		Features:     featuresForLineage(charge.Intent.GetEffectiveFeatureKey()),
 		Realizations: realizations,
 	}); err != nil {
 		return nil, fmt.Errorf("create initial credit realization lineages: %w", err)

--- a/openmeter/billing/charges/usagebased/service/run/payment_test.go
+++ b/openmeter/billing/charges/usagebased/service/run/payment_test.go
@@ -176,13 +176,13 @@ func newUsageBasedCharge() usagebased.Charge {
 				ManagedModel:    models.ManagedModel{CreatedAt: now, UpdatedAt: now},
 				ID:              "charge-1",
 			},
-			Intent: usagebased.OverridableIntent{
+			Intent: usagebased.Intent{
 				Intent: meta.Intent{
 					ManagedBy:  billing.SystemManagedLine,
 					CustomerID: "cust-1",
 					Currency:   currencyx.Code("USD"),
 				},
-				BaseLayer: usagebased.IntentMutableFields{
+				IntentMutableFields: usagebased.IntentMutableFields{
 					IntentMutableFields: meta.IntentMutableFields{
 						Name:          "usage based",
 						ServicePeriod: period,
@@ -196,7 +196,7 @@ func newUsageBasedCharge() usagebased.Charge {
 					Price:      *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
 				},
 				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
-			},
+			}.AsOverridableIntent(),
 			Status: usagebased.StatusActiveAwaitingPaymentSettlement,
 			State: usagebased.State{
 				FeatureID:    "feature-1",

--- a/openmeter/billing/charges/usagebased/service/run/preview.go
+++ b/openmeter/billing/charges/usagebased/service/run/preview.go
@@ -38,8 +38,8 @@ func (i BuildCreditThenInvoiceGatheringPreviewRunInput) Validate() error {
 		errs = append(errs, fmt.Errorf("charge: %w", err))
 	}
 
-	if i.Charge.Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
-		errs = append(errs, fmt.Errorf("unsupported settlement mode for gathering preview: %s", i.Charge.Intent.SettlementMode))
+	if i.Charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+		errs = append(errs, fmt.Errorf("unsupported settlement mode for gathering preview: %s", i.Charge.Intent.GetSettlementMode()))
 	}
 
 	if i.CustomerOverride.Customer == nil {

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -124,15 +124,15 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 }
 
 func (s *stateMachine) IsInsideServicePeriod() bool {
-	return !clock.Now().Before(s.Charge.Intent.BaseLayer.ServicePeriod.From)
+	return !clock.Now().Before(s.Charge.Intent.GetEffectiveServicePeriod().From)
 }
 
 func (s *stateMachine) IsAfterServicePeriod() bool {
-	return !clock.Now().Before(s.Charge.Intent.BaseLayer.ServicePeriod.To)
+	return !clock.Now().Before(s.Charge.Intent.GetEffectiveServicePeriod().To)
 }
 
 func (s *stateMachine) AdvanceAfterServicePeriodTo(ctx context.Context) error {
-	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.BaseLayer.ServicePeriod.To))
+	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().To))
 	return nil
 }
 
@@ -142,7 +142,7 @@ func (s *stateMachine) SyncFeatureIDFromFeatureMeter(ctx context.Context) error 
 }
 
 func (s *stateMachine) AdvanceAfterServicePeriodFrom(ctx context.Context) error {
-	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.BaseLayer.ServicePeriod.From))
+	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().From))
 	return nil
 }
 
@@ -160,7 +160,7 @@ func (s *stateMachine) AdvanceAfterCollectionPeriodEnd(ctx context.Context) erro
 func (s *stateMachine) IsAfterCollectionPeriod(ctx context.Context, _ ...any) bool {
 	snapshotAfter, err := s.getCurrentRunSnapshotAfter()
 	if err != nil {
-		s.Logger.ErrorContext(ctx, "failed to get snapshot after", "error", err, "customerID", s.Charge.Intent.CustomerID)
+		s.Logger.ErrorContext(ctx, "failed to get snapshot after", "error", err, "customerID", s.Charge.Intent.GetCustomerID())
 		return false
 	}
 
@@ -169,7 +169,7 @@ func (s *stateMachine) IsAfterCollectionPeriod(ctx context.Context, _ ...any) bo
 
 func (s *stateMachine) getFinalRunStoredAtLT() (time.Time, error) {
 	collectionPeriod := s.CustomerOverride.MergedProfile.WorkflowConfig.Collection.Interval
-	storedAtLT, _ := collectionPeriod.AddTo(s.Charge.Intent.BaseLayer.ServicePeriod.To)
+	storedAtLT, _ := collectionPeriod.AddTo(s.Charge.Intent.GetEffectiveServicePeriod().To)
 	return meta.NormalizeTimestamp(storedAtLT), nil
 }
 

--- a/openmeter/billing/charges/usagebased/service/triggers.go
+++ b/openmeter/billing/charges/usagebased/service/triggers.go
@@ -25,7 +25,7 @@ func (s *service) AdvanceCharge(ctx context.Context, input usagebased.AdvanceCha
 			return nil, fmt.Errorf("get feature meter: %w", err)
 		}
 
-		currencyCalculator, err := charge.Intent.Currency.Calculator()
+		currencyCalculator, err := charge.Intent.GetCurrency().Calculator()
 		if err != nil {
 			return nil, fmt.Errorf("get currency calculator: %w", err)
 		}
@@ -88,7 +88,7 @@ func (s *service) TriggerPatch(ctx context.Context, chargeID meta.ChargeID, patc
 }
 
 func (s *service) newStateMachine(config StateMachineConfig) (StateMachine, error) {
-	switch config.Charge.Intent.SettlementMode {
+	switch config.Charge.Intent.GetSettlementMode() {
 	case productcatalog.CreditOnlySettlementMode:
 		stateMachine, err := NewCreditsOnlyStateMachine(config)
 		if err != nil {
@@ -105,7 +105,7 @@ func (s *service) newStateMachine(config StateMachineConfig) (StateMachine, erro
 		return stateMachine, nil
 	default:
 		return nil, models.NewGenericNotImplementedError(
-			fmt.Errorf("unsupported settlement mode %s for usage based charge %s", config.Charge.Intent.SettlementMode, config.Charge.ID),
+			fmt.Errorf("unsupported settlement mode %s for usage based charge %s", config.Charge.Intent.GetSettlementMode(), config.Charge.ID),
 		)
 	}
 }
@@ -117,7 +117,7 @@ func (s *service) getStateMachineConfigForPatch(ctx context.Context, charge usag
 	customerOverride, err := s.customerOverrideService.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
 		Customer: customer.CustomerID{
 			Namespace: charge.Namespace,
-			ID:        charge.Intent.CustomerID,
+			ID:        charge.Intent.GetCustomerID(),
 		},
 		Expand: billing.CustomerOverrideExpand{
 			Customer: true,
@@ -138,7 +138,7 @@ func (s *service) getStateMachineConfigForPatch(ctx context.Context, charge usag
 		return StateMachineConfig{}, err
 	}
 
-	currencyCalculator, err := charge.Intent.Currency.Calculator()
+	currencyCalculator, err := charge.Intent.GetCurrency().Calculator()
 	if err != nil {
 		return StateMachineConfig{}, fmt.Errorf("get currency calculator: %w", err)
 	}

--- a/openmeter/billing/worker/subscriptionsync/service/base_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/base_test.go
@@ -495,65 +495,69 @@ func (s *SuiteBase) assertCharge(ctx context.Context, charge charges.Charge, sub
 	case chargesmeta.ChargeTypeUsageBased:
 		usageBasedCharge, err := charge.AsUsageBasedCharge()
 		s.NoError(err)
+		baseIntent := usageBasedCharge.Intent.GetBaseIntent()
+		subscription := usageBasedCharge.Intent.GetSubscription()
 
 		s.Equal(expectedCharge.Status, string(usageBasedCharge.Status), "%s: status", childID)
-		s.Equal(subsView.Subscription.SettlementMode, usageBasedCharge.Intent.SettlementMode, "%s: settlement mode", childID)
-		s.Equal(s.Customer.ID, usageBasedCharge.Intent.CustomerID, "%s: customer id", childID)
-		s.Equal(subsView.Subscription.Currency, usageBasedCharge.Intent.Currency, "%s: currency", childID)
-		s.Equal(expectedCharge.Periods[idx], usageBasedCharge.Intent.BaseLayer.ServicePeriod, "%s: service period", childID)
+		s.Equal(subsView.Subscription.SettlementMode, usageBasedCharge.Intent.GetSettlementMode(), "%s: settlement mode", childID)
+		s.Equal(s.Customer.ID, usageBasedCharge.Intent.GetCustomerID(), "%s: customer id", childID)
+		s.Equal(subsView.Subscription.Currency, usageBasedCharge.Intent.GetCurrency(), "%s: currency", childID)
+		s.Equal(expectedCharge.Periods[idx], baseIntent.ServicePeriod, "%s: service period", childID)
 		if len(expectedCharge.FullServicePeriods) > 0 {
-			s.Equal(expectedCharge.FullServicePeriods[idx], usageBasedCharge.Intent.BaseLayer.FullServicePeriod, "%s: full service period", childID)
+			s.Equal(expectedCharge.FullServicePeriods[idx], baseIntent.FullServicePeriod, "%s: full service period", childID)
 		}
 		if len(expectedCharge.BillingPeriods) > 0 {
-			s.Equal(expectedCharge.BillingPeriods[idx], usageBasedCharge.Intent.BaseLayer.BillingPeriod, "%s: billing period", childID)
+			s.Equal(expectedCharge.BillingPeriods[idx], baseIntent.BillingPeriod, "%s: billing period", childID)
 		}
 		if expectedCharge.Price != nil {
-			s.Truef(expectedCharge.Price.Equal(&usageBasedCharge.Intent.BaseLayer.Price), "%s: price expected %v, got %v", childID, expectedCharge.Price, usageBasedCharge.Intent.BaseLayer.Price)
+			s.Truef(expectedCharge.Price.Equal(&baseIntent.Price), "%s: price expected %v, got %v", childID, expectedCharge.Price, baseIntent.Price)
 		}
 		if len(expectedCharge.InvoiceAt) > idx && expectedCharge.InvoiceAt[idx] != nil {
-			s.Equal(*expectedCharge.InvoiceAt[idx], usageBasedCharge.Intent.BaseLayer.InvoiceAt, "%s: invoice at", childID)
+			s.Equal(*expectedCharge.InvoiceAt[idx], baseIntent.InvoiceAt, "%s: invoice at", childID)
 		}
-		s.Require().NotNil(usageBasedCharge.Intent.Subscription, "%s: subscription", childID)
-		s.Equal(subsView.Subscription.ID, usageBasedCharge.Intent.Subscription.SubscriptionID, "%s: subscription id", childID)
-		s.Equal(phase.SubscriptionPhase.ID, usageBasedCharge.Intent.Subscription.PhaseID, "%s: phase id", childID)
+		s.Require().NotNil(subscription, "%s: subscription", childID)
+		s.Equal(subsView.Subscription.ID, subscription.SubscriptionID, "%s: subscription id", childID)
+		s.Equal(phase.SubscriptionPhase.ID, subscription.PhaseID, "%s: phase id", childID)
 		// Deleted charges can reference soft-deleted subscription items, and subscription views never
 		// contain soft-deleted items.
-		item, itemFound := s.subscriptionItemByID(phase, itemKey, usageBasedCharge.Intent.Subscription.ItemID, childID, usageBasedCharge.DeletedAt != nil)
+		item, itemFound := s.subscriptionItemByID(phase, itemKey, subscription.ItemID, childID, usageBasedCharge.DeletedAt != nil)
 		expectedFeatureKey := itemKey
 		if itemFound {
 			expectedFeatureKey = lo.FromPtrOr(item.Spec.RateCard.AsMeta().FeatureKey, itemKey)
 		}
-		s.Equal(expectedFeatureKey, usageBasedCharge.Intent.BaseLayer.FeatureKey, "%s: feature key", childID)
+		s.Equal(expectedFeatureKey, baseIntent.FeatureKey, "%s: feature key", childID)
 	case chargesmeta.ChargeTypeFlatFee:
 		flatFeeCharge, err := charge.AsFlatFeeCharge()
 		s.NoError(err)
+		baseIntent := flatFeeCharge.Intent.GetBaseIntent()
+		subscription := flatFeeCharge.Intent.GetSubscription()
 
 		s.Equal(expectedCharge.Status, string(flatFeeCharge.Status), "%s: status", childID)
-		s.Equal(subsView.Subscription.SettlementMode, flatFeeCharge.Intent.SettlementMode, "%s: settlement mode", childID)
-		s.Equal(s.Customer.ID, flatFeeCharge.Intent.CustomerID, "%s: customer id", childID)
-		s.Equal(subsView.Subscription.Currency, flatFeeCharge.Intent.Currency, "%s: currency", childID)
-		s.Equal(expectedCharge.Periods[idx], flatFeeCharge.Intent.BaseLayer.ServicePeriod, "%s: service period", childID)
+		s.Equal(subsView.Subscription.SettlementMode, flatFeeCharge.Intent.GetSettlementMode(), "%s: settlement mode", childID)
+		s.Equal(s.Customer.ID, flatFeeCharge.Intent.GetCustomerID(), "%s: customer id", childID)
+		s.Equal(subsView.Subscription.Currency, flatFeeCharge.Intent.GetCurrency(), "%s: currency", childID)
+		s.Equal(expectedCharge.Periods[idx], baseIntent.ServicePeriod, "%s: service period", childID)
 		if len(expectedCharge.FullServicePeriods) > 0 {
-			s.Equal(expectedCharge.FullServicePeriods[idx], flatFeeCharge.Intent.BaseLayer.FullServicePeriod, "%s: full service period", childID)
+			s.Equal(expectedCharge.FullServicePeriods[idx], baseIntent.FullServicePeriod, "%s: full service period", childID)
 		}
 		if len(expectedCharge.BillingPeriods) > 0 {
-			s.Equal(expectedCharge.BillingPeriods[idx], flatFeeCharge.Intent.BaseLayer.BillingPeriod, "%s: billing period", childID)
+			s.Equal(expectedCharge.BillingPeriods[idx], baseIntent.BillingPeriod, "%s: billing period", childID)
 		}
 		if expectedCharge.Price != nil {
 			expectedFlatPrice, err := expectedCharge.Price.AsFlat()
 			s.NoError(err)
-			require.Equal(s.T(), expectedFlatPrice.Amount.InexactFloat64(), flatFeeCharge.Intent.BaseLayer.AmountBeforeProration.InexactFloat64(), fmt.Sprintf("%s: amount before proration", childID))
+			require.Equal(s.T(), expectedFlatPrice.Amount.InexactFloat64(), baseIntent.AmountBeforeProration.InexactFloat64(), fmt.Sprintf("%s: amount before proration", childID))
 		}
 		if len(expectedCharge.InvoiceAt) > idx && expectedCharge.InvoiceAt[idx] != nil {
-			s.Equal(*expectedCharge.InvoiceAt[idx], flatFeeCharge.Intent.BaseLayer.InvoiceAt, "%s: invoice at", childID)
+			s.Equal(*expectedCharge.InvoiceAt[idx], baseIntent.InvoiceAt, "%s: invoice at", childID)
 		}
-		s.Require().NotNil(flatFeeCharge.Intent.Subscription, "%s: subscription", childID)
-		s.Equal(subsView.Subscription.ID, flatFeeCharge.Intent.Subscription.SubscriptionID, "%s: subscription id", childID)
-		s.Equal(phase.SubscriptionPhase.ID, flatFeeCharge.Intent.Subscription.PhaseID, "%s: phase id", childID)
+		s.Require().NotNil(subscription, "%s: subscription", childID)
+		s.Equal(subsView.Subscription.ID, subscription.SubscriptionID, "%s: subscription id", childID)
+		s.Equal(phase.SubscriptionPhase.ID, subscription.PhaseID, "%s: phase id", childID)
 		// Deleted charges can reference soft-deleted subscription items, and subscription views never
 		// contain soft-deleted items.
-		if item, itemFound := s.subscriptionItemByID(phase, itemKey, flatFeeCharge.Intent.Subscription.ItemID, childID, flatFeeCharge.DeletedAt != nil); itemFound {
-			s.Equal(item.SubscriptionItem.ID, flatFeeCharge.Intent.Subscription.ItemID, "%s: item id", childID)
+		if item, itemFound := s.subscriptionItemByID(phase, itemKey, subscription.ItemID, childID, flatFeeCharge.DeletedAt != nil); itemFound {
+			s.Equal(item.SubscriptionItem.ID, subscription.ItemID, "%s: item id", childID)
 		}
 	default:
 		s.Failf("unsupported charge type", "charge %s has unsupported type %s", chargeID.ID, charge.Type())

--- a/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
@@ -330,7 +330,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeCancella
 		s.Len(provisionedCharges, 2)
 
 		originalSecondPeriodCharge = provisionedCharges[1]
-		s.Equal(expectedCharges[0].ChildUniqueReferenceIDs[1], lo.FromPtr(originalSecondPeriodCharge.Intent.UniqueReferenceID))
+		s.Equal(expectedCharges[0].ChildUniqueReferenceIDs[1], lo.FromPtr(originalSecondPeriodCharge.Intent.GetUniqueReferenceID()))
 	})
 
 	s.Run("canceling at the first period boundary deletes the second flat fee", func() {
@@ -364,7 +364,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeCancella
 		s.NoError(err)
 		s.Equal(flatfee.StatusDeleted, deletedCharge.Status)
 		s.NotNil(deletedCharge.DeletedAt)
-		s.Equal(expectedCharges[0].ChildUniqueReferenceIDs[1], lo.FromPtr(deletedCharge.Intent.UniqueReferenceID))
+		s.Equal(expectedCharges[0].ChildUniqueReferenceIDs[1], lo.FromPtr(deletedCharge.Intent.GetUniqueReferenceID()))
 	})
 }
 
@@ -519,7 +519,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeMidPerio
 		s.NoError(err)
 		s.Equal(flatfee.StatusDeleted, deletedCharge.Status)
 		s.NotNil(deletedCharge.DeletedAt)
-		s.Equal(expectedCharges[0].ChildUniqueReferenceIDs[1], lo.FromPtr(deletedCharge.Intent.UniqueReferenceID))
+		s.Equal(expectedCharges[0].ChildUniqueReferenceIDs[1], lo.FromPtr(deletedCharge.Intent.GetUniqueReferenceID()))
 	})
 }
 
@@ -768,7 +768,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedCance
 		s.NoError(err)
 		s.Equal(usagebased.StatusDeleted, deletedCharge.Status)
 		s.NotNil(deletedCharge.DeletedAt)
-		s.Equal(expectedCharges[0].ChildUniqueReferenceIDs[0], lo.FromPtr(deletedCharge.Intent.UniqueReferenceID))
+		s.Equal(expectedCharges[0].ChildUniqueReferenceIDs[0], lo.FromPtr(deletedCharge.Intent.GetUniqueReferenceID()))
 	})
 }
 
@@ -977,7 +977,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedMidPe
 		s.NoError(err)
 		s.Equal(usagebased.StatusDeleted, deletedCharge.Status)
 		s.NotNil(deletedCharge.DeletedAt)
-		s.Equal(expectedCharges[0].ChildUniqueReferenceIDs[1], lo.FromPtr(deletedCharge.Intent.UniqueReferenceID))
+		s.Equal(expectedCharges[0].ChildUniqueReferenceIDs[1], lo.FromPtr(deletedCharge.Intent.GetUniqueReferenceID()))
 	})
 }
 
@@ -1138,10 +1138,10 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) expectCreditsOnlyMixedCharges(
 	})
 
 	slices.SortFunc(flatFeeCharges, func(left, right flatfee.Charge) int {
-		return left.Intent.BaseLayer.ServicePeriod.From.Compare(right.Intent.BaseLayer.ServicePeriod.From)
+		return left.Intent.GetBaseIntent().ServicePeriod.From.Compare(right.Intent.GetBaseIntent().ServicePeriod.From)
 	})
 	slices.SortFunc(usageBasedCharges, func(left, right usagebased.Charge) int {
-		return left.Intent.BaseLayer.ServicePeriod.From.Compare(right.Intent.BaseLayer.ServicePeriod.From)
+		return left.Intent.GetBaseIntent().ServicePeriod.From.Compare(right.Intent.GetBaseIntent().ServicePeriod.From)
 	})
 
 	s.Equal(expectedChargeCount, len(flatFeeCharges)+len(usageBasedCharges))
@@ -1168,7 +1168,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) expectCreditsOnlyFlatFeeCharge
 	}
 
 	slices.SortFunc(out, func(left, right flatfee.Charge) int {
-		return left.Intent.BaseLayer.ServicePeriod.From.Compare(right.Intent.BaseLayer.ServicePeriod.From)
+		return left.Intent.GetBaseIntent().ServicePeriod.From.Compare(right.Intent.GetBaseIntent().ServicePeriod.From)
 	})
 
 	s.assertExpectedFlatFeeCharges(ctx, subscriptionID, out, expected)
@@ -1187,27 +1187,27 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) assertExpectedFlatFeeCharges(c
 	for expectedIdx, expectedCharge := range expected {
 		for periodIdx, childID := range expectedCharge.ChildUniqueReferenceIDs {
 			charge, found := lo.Find(out, func(charge flatfee.Charge) bool {
-				return charge.Intent.UniqueReferenceID != nil && *charge.Intent.UniqueReferenceID == childID
+				return charge.Intent.GetUniqueReferenceID() != nil && *charge.Intent.GetUniqueReferenceID() == childID
 			})
 			if !found {
 				s.T().Fatalf("expected[%d] charge[%d] not found with child unique reference id %s", expectedIdx, periodIdx, childID)
 			}
 			expectedPhaseID := s.getExpectedPhaseIDForChildReference(ctx, subscriptionID, childID)
 
-			s.NotNilf(charge.Intent.UniqueReferenceID, "expected[%d] charge[%d] should have child unique reference id", expectedIdx, periodIdx)
-			s.Equalf(childID, lo.FromPtr(charge.Intent.UniqueReferenceID), "expected[%d] charge[%d] child unique reference id", expectedIdx, periodIdx)
-			s.Equalf(expectedCharge.ServicePeriods[periodIdx], charge.Intent.BaseLayer.ServicePeriod, "expected[%d] charge[%d] service period", expectedIdx, periodIdx)
-			s.Equalf(expectedCharge.FullServicePeriods[periodIdx], charge.Intent.BaseLayer.FullServicePeriod, "expected[%d] charge[%d] full service period", expectedIdx, periodIdx)
-			s.Equalf(expectedCharge.BillingPeriods[periodIdx], charge.Intent.BaseLayer.BillingPeriod, "expected[%d] charge[%d] billing period", expectedIdx, periodIdx)
-			s.Equalf(expectedCharge.InvoiceAt[periodIdx], charge.Intent.BaseLayer.InvoiceAt, "expected[%d] charge[%d] invoice at", expectedIdx, periodIdx)
-			s.Equalf(productcatalog.CreditOnlySettlementMode, charge.Intent.SettlementMode, "expected[%d] charge[%d] settlement mode", expectedIdx, periodIdx)
-			s.Equalf(productcatalog.InAdvancePaymentTerm, charge.Intent.BaseLayer.PaymentTerm, "expected[%d] charge[%d] payment term", expectedIdx, periodIdx)
-			s.Equalf(string(currency.USD), string(charge.Intent.Currency), "expected[%d] charge[%d] currency", expectedIdx, periodIdx)
-			s.Equalf(expectedCharge.amountBeforeProration(periodIdx), charge.Intent.BaseLayer.AmountBeforeProration, "expected[%d] charge[%d] amount before proration", expectedIdx, periodIdx)
+			s.NotNilf(charge.Intent.GetUniqueReferenceID(), "expected[%d] charge[%d] should have child unique reference id", expectedIdx, periodIdx)
+			s.Equalf(childID, lo.FromPtr(charge.Intent.GetUniqueReferenceID()), "expected[%d] charge[%d] child unique reference id", expectedIdx, periodIdx)
+			s.Equalf(expectedCharge.ServicePeriods[periodIdx], charge.Intent.GetBaseIntent().ServicePeriod, "expected[%d] charge[%d] service period", expectedIdx, periodIdx)
+			s.Equalf(expectedCharge.FullServicePeriods[periodIdx], charge.Intent.GetBaseIntent().FullServicePeriod, "expected[%d] charge[%d] full service period", expectedIdx, periodIdx)
+			s.Equalf(expectedCharge.BillingPeriods[periodIdx], charge.Intent.GetBaseIntent().BillingPeriod, "expected[%d] charge[%d] billing period", expectedIdx, periodIdx)
+			s.Equalf(expectedCharge.InvoiceAt[periodIdx], charge.Intent.GetBaseIntent().InvoiceAt, "expected[%d] charge[%d] invoice at", expectedIdx, periodIdx)
+			s.Equalf(productcatalog.CreditOnlySettlementMode, charge.Intent.GetSettlementMode(), "expected[%d] charge[%d] settlement mode", expectedIdx, periodIdx)
+			s.Equalf(productcatalog.InAdvancePaymentTerm, charge.Intent.GetBaseIntent().PaymentTerm, "expected[%d] charge[%d] payment term", expectedIdx, periodIdx)
+			s.Equalf(string(currency.USD), string(charge.Intent.GetCurrency()), "expected[%d] charge[%d] currency", expectedIdx, periodIdx)
+			s.Equalf(expectedCharge.amountBeforeProration(periodIdx), charge.Intent.GetBaseIntent().AmountBeforeProration, "expected[%d] charge[%d] amount before proration", expectedIdx, periodIdx)
 			s.Equalf(expectedCharge.amountAfterProration(periodIdx), charge.State.AmountAfterProration, "expected[%d] charge[%d] amount after proration", expectedIdx, periodIdx)
-			s.Equalf(subscriptionID, charge.Intent.Subscription.SubscriptionID, "expected[%d] charge[%d] subscription id", expectedIdx, periodIdx)
-			s.Equalf(expectedPhaseID, charge.Intent.Subscription.PhaseID, "expected[%d] charge[%d] subscription phase id", expectedIdx, periodIdx)
-			s.Equalf("flat-fee", charge.Intent.BaseLayer.Name, "expected[%d] charge[%d] charge name", expectedIdx, periodIdx)
+			s.Equalf(subscriptionID, charge.Intent.GetSubscription().SubscriptionID, "expected[%d] charge[%d] subscription id", expectedIdx, periodIdx)
+			s.Equalf(expectedPhaseID, charge.Intent.GetSubscription().PhaseID, "expected[%d] charge[%d] subscription phase id", expectedIdx, periodIdx)
+			s.Equalf("flat-fee", charge.Intent.GetBaseIntent().Name, "expected[%d] charge[%d] charge name", expectedIdx, periodIdx)
 		}
 	}
 }
@@ -1230,7 +1230,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) expectCreditsOnlyUsageBasedCha
 	}
 
 	slices.SortFunc(out, func(left, right usagebased.Charge) int {
-		return left.Intent.BaseLayer.ServicePeriod.From.Compare(right.Intent.BaseLayer.ServicePeriod.From)
+		return left.Intent.GetBaseIntent().ServicePeriod.From.Compare(right.Intent.GetBaseIntent().ServicePeriod.From)
 	})
 
 	s.assertExpectedUsageBasedCharges(ctx, subscriptionID, out, expected)
@@ -1249,26 +1249,26 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) assertExpectedUsageBasedCharge
 	for expectedIdx, expectedCharge := range expected {
 		for periodIdx, childID := range expectedCharge.ChildUniqueReferenceIDs {
 			charge, found := lo.Find(out, func(charge usagebased.Charge) bool {
-				return charge.Intent.UniqueReferenceID != nil && *charge.Intent.UniqueReferenceID == childID
+				return charge.Intent.GetUniqueReferenceID() != nil && *charge.Intent.GetUniqueReferenceID() == childID
 			})
 			if !found {
 				s.T().Fatalf("expected[%d] charge[%d] not found with child unique reference id %s", expectedIdx, periodIdx, childID)
 			}
 			expectedPhaseID := s.getExpectedPhaseIDForChildReference(ctx, subscriptionID, childID)
 
-			s.NotNilf(charge.Intent.UniqueReferenceID, "expected[%d] charge[%d] should have child unique reference id", expectedIdx, periodIdx)
-			s.Equalf(childID, lo.FromPtr(charge.Intent.UniqueReferenceID), "expected[%d] charge[%d] child unique reference id", expectedIdx, periodIdx)
-			s.Equalf(expectedCharge.ServicePeriods[periodIdx], charge.Intent.BaseLayer.ServicePeriod, "expected[%d] charge[%d] service period", expectedIdx, periodIdx)
-			s.Equalf(expectedCharge.FullServicePeriods[periodIdx], charge.Intent.BaseLayer.FullServicePeriod, "expected[%d] charge[%d] full service period", expectedIdx, periodIdx)
-			s.Equalf(expectedCharge.BillingPeriods[periodIdx], charge.Intent.BaseLayer.BillingPeriod, "expected[%d] charge[%d] billing period", expectedIdx, periodIdx)
-			s.Equalf(expectedCharge.InvoiceAt[periodIdx], charge.Intent.BaseLayer.InvoiceAt, "expected[%d] charge[%d] invoice at", expectedIdx, periodIdx)
-			s.Equalf(productcatalog.CreditOnlySettlementMode, charge.Intent.SettlementMode, "expected[%d] charge[%d] settlement mode", expectedIdx, periodIdx)
-			s.Equalf(string(currency.USD), string(charge.Intent.Currency), "expected[%d] charge[%d] currency", expectedIdx, periodIdx)
-			s.Equalf(expectedCharge.FeatureKey, charge.Intent.BaseLayer.FeatureKey, "expected[%d] charge[%d] feature key", expectedIdx, periodIdx)
-			s.Equalf(expectedCharge.Price, charge.Intent.BaseLayer.Price, "expected[%d] charge[%d] price", expectedIdx, periodIdx)
-			s.Equalf(subscriptionID, charge.Intent.Subscription.SubscriptionID, "expected[%d] charge[%d] subscription id", expectedIdx, periodIdx)
-			s.Equalf(expectedPhaseID, charge.Intent.Subscription.PhaseID, "expected[%d] charge[%d] subscription phase id", expectedIdx, periodIdx)
-			s.Equalf(s.APIRequestsTotalFeature.Key, charge.Intent.BaseLayer.Name, "expected[%d] charge[%d] charge name", expectedIdx, periodIdx)
+			s.NotNilf(charge.Intent.GetUniqueReferenceID(), "expected[%d] charge[%d] should have child unique reference id", expectedIdx, periodIdx)
+			s.Equalf(childID, lo.FromPtr(charge.Intent.GetUniqueReferenceID()), "expected[%d] charge[%d] child unique reference id", expectedIdx, periodIdx)
+			s.Equalf(expectedCharge.ServicePeriods[periodIdx], charge.Intent.GetBaseIntent().ServicePeriod, "expected[%d] charge[%d] service period", expectedIdx, periodIdx)
+			s.Equalf(expectedCharge.FullServicePeriods[periodIdx], charge.Intent.GetBaseIntent().FullServicePeriod, "expected[%d] charge[%d] full service period", expectedIdx, periodIdx)
+			s.Equalf(expectedCharge.BillingPeriods[periodIdx], charge.Intent.GetBaseIntent().BillingPeriod, "expected[%d] charge[%d] billing period", expectedIdx, periodIdx)
+			s.Equalf(expectedCharge.InvoiceAt[periodIdx], charge.Intent.GetBaseIntent().InvoiceAt, "expected[%d] charge[%d] invoice at", expectedIdx, periodIdx)
+			s.Equalf(productcatalog.CreditOnlySettlementMode, charge.Intent.GetSettlementMode(), "expected[%d] charge[%d] settlement mode", expectedIdx, periodIdx)
+			s.Equalf(string(currency.USD), string(charge.Intent.GetCurrency()), "expected[%d] charge[%d] currency", expectedIdx, periodIdx)
+			s.Equalf(expectedCharge.FeatureKey, charge.Intent.GetBaseIntent().FeatureKey, "expected[%d] charge[%d] feature key", expectedIdx, periodIdx)
+			s.Equalf(expectedCharge.Price, charge.Intent.GetBaseIntent().Price, "expected[%d] charge[%d] price", expectedIdx, periodIdx)
+			s.Equalf(subscriptionID, charge.Intent.GetSubscription().SubscriptionID, "expected[%d] charge[%d] subscription id", expectedIdx, periodIdx)
+			s.Equalf(expectedPhaseID, charge.Intent.GetSubscription().PhaseID, "expected[%d] charge[%d] subscription phase id", expectedIdx, periodIdx)
+			s.Equalf(s.APIRequestsTotalFeature.Key, charge.Intent.GetBaseIntent().Name, "expected[%d] charge[%d] charge name", expectedIdx, periodIdx)
 		}
 	}
 }
@@ -1291,7 +1291,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) getExpectedPhaseIDForChildRefe
 
 // TestCreditsOnlyFlatFeeTaxCodePropagation verifies that a flat-fee rate card with a TaxConfig set
 // in the subscription plan propagates TaxCodeID and TaxBehavior to the resulting charge intent
-// after the sync. Guards the patchcharge.go → meta.Intent.BaseLayer.TaxConfig path.
+// after the sync. Guards the patchcharge.go → meta.Intent.GetBaseTaxConfig() path.
 func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeTaxCodePropagation() {
 	ctx := s.testContext()
 	setupAt := s.mustParseTime("2024-01-01T00:00:00Z")
@@ -1363,15 +1363,15 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeTaxCodeP
 	ffCharge, err := res.Items[0].AsFlatFeeCharge()
 	s.NoError(err)
 
-	s.Require().NotNil(ffCharge.Intent.BaseLayer.TaxConfig.Behavior)
-	s.Equal(productcatalog.InclusiveTaxBehavior, *ffCharge.Intent.BaseLayer.TaxConfig.Behavior)
-	s.Require().NotEmpty(ffCharge.Intent.BaseLayer.TaxConfig.TaxCodeID)
-	s.Equal(tc.ID, ffCharge.Intent.BaseLayer.TaxConfig.TaxCodeID)
+	s.Require().NotNil(ffCharge.Intent.GetBaseTaxConfig().Behavior)
+	s.Equal(productcatalog.InclusiveTaxBehavior, *ffCharge.Intent.GetBaseTaxConfig().Behavior)
+	s.Require().NotEmpty(ffCharge.Intent.GetBaseTaxConfig().TaxCodeID)
+	s.Equal(tc.ID, ffCharge.Intent.GetBaseTaxConfig().TaxCodeID)
 }
 
 // TestCreditsOnlyUsageBasedTaxCodePropagation verifies that a usage-based rate card with a TaxConfig
 // set in the subscription plan propagates TaxCodeID and TaxBehavior to the resulting charge intent
-// after the sync. Guards the patchcharge.go → meta.Intent.BaseLayer.TaxConfig path.
+// after the sync. Guards the patchcharge.go → meta.Intent.GetBaseTaxConfig() path.
 func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedTaxCodePropagation() {
 	ctx := s.testContext()
 	setupAt := s.mustParseTime("2024-01-01T00:00:00Z")
@@ -1446,8 +1446,8 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedTaxCo
 	ubCharge, err := res.Items[0].AsUsageBasedCharge()
 	s.NoError(err)
 
-	s.Require().NotNil(ubCharge.Intent.BaseLayer.TaxConfig.Behavior)
-	s.Equal(productcatalog.ExclusiveTaxBehavior, *ubCharge.Intent.BaseLayer.TaxConfig.Behavior)
-	s.Require().NotEmpty(ubCharge.Intent.BaseLayer.TaxConfig.TaxCodeID)
-	s.Equal(tc.ID, ubCharge.Intent.BaseLayer.TaxConfig.TaxCodeID)
+	s.Require().NotNil(ubCharge.Intent.GetBaseTaxConfig().Behavior)
+	s.Equal(productcatalog.ExclusiveTaxBehavior, *ubCharge.Intent.GetBaseTaxConfig().Behavior)
+	s.Require().NotEmpty(ubCharge.Intent.GetBaseTaxConfig().TaxCodeID)
+	s.Equal(tc.ID, ubCharge.Intent.GetBaseTaxConfig().TaxCodeID)
 }

--- a/openmeter/billing/worker/subscriptionsync/service/persistedstate/item.go
+++ b/openmeter/billing/worker/subscriptionsync/service/persistedstate/item.go
@@ -220,7 +220,8 @@ func NewItemFromLineOrHierarchy(lineOrHierarchy billing.LineOrHierarchy) (Item, 
 }
 
 type persistedUsageBasedCharge struct {
-	charge usagebased.Charge
+	charge     usagebased.Charge
+	baseIntent usagebased.Intent
 }
 
 var (
@@ -236,7 +237,10 @@ func newPersistedUsageBasedCharge(charge usagebased.Charge) (persistedUsageBased
 		return persistedUsageBasedCharge{}, fmt.Errorf("usage based charge is invalid: %w", err)
 	}
 
-	return persistedUsageBasedCharge{charge: charge}, nil
+	return persistedUsageBasedCharge{
+		charge:     charge,
+		baseIntent: charge.Intent.GetBaseIntent(),
+	}, nil
 }
 
 func (i persistedUsageBasedCharge) ID() models.NamespacedID {
@@ -253,21 +257,21 @@ func (i persistedUsageBasedCharge) Type() ItemType {
 }
 
 func (i persistedUsageBasedCharge) ChildUniqueReferenceID() *string {
-	return i.charge.Intent.UniqueReferenceID
+	return i.charge.Intent.GetUniqueReferenceID()
 }
 
 func (i persistedUsageBasedCharge) ServicePeriod() timeutil.ClosedPeriod {
-	return i.charge.Intent.BaseLayer.ServicePeriod
+	return i.baseIntent.ServicePeriod
 }
 
 func (i persistedUsageBasedCharge) IsSubscriptionManaged() bool {
-	return i.charge.Intent.ManagedBy == billing.SubscriptionManagedLine
+	return i.baseIntent.ManagedBy == billing.SubscriptionManagedLine
 }
 
 // Charges carry subscription-sync annotations on their intent, so the effective
 // "last line" annotation is always the charge intent annotation itself.
 func (i persistedUsageBasedCharge) HasLastLineAnnotation(annotation string) bool {
-	return i.charge.Intent.Annotations.GetBool(annotation)
+	return i.baseIntent.Annotations.GetBool(annotation)
 }
 
 func (i persistedUsageBasedCharge) GetUsageBasedCharge() usagebased.Charge {
@@ -285,7 +289,8 @@ func ItemAsUsageBasedCharge(in Item) (usagebased.Charge, error) {
 }
 
 type persistedFlatFeeCharge struct {
-	charge flatfee.Charge
+	charge     flatfee.Charge
+	baseIntent flatfee.Intent
 }
 
 var (
@@ -301,7 +306,10 @@ func newPersistedFlatFeeCharge(charge flatfee.Charge) (persistedFlatFeeCharge, e
 		return persistedFlatFeeCharge{}, fmt.Errorf("flat fee charge is invalid: %w", err)
 	}
 
-	return persistedFlatFeeCharge{charge: charge}, nil
+	return persistedFlatFeeCharge{
+		charge:     charge,
+		baseIntent: charge.Intent.GetBaseIntent(),
+	}, nil
 }
 
 func (i persistedFlatFeeCharge) ID() models.NamespacedID {
@@ -318,21 +326,21 @@ func (i persistedFlatFeeCharge) Type() ItemType {
 }
 
 func (i persistedFlatFeeCharge) ChildUniqueReferenceID() *string {
-	return i.charge.Intent.UniqueReferenceID
+	return i.charge.Intent.GetUniqueReferenceID()
 }
 
 func (i persistedFlatFeeCharge) ServicePeriod() timeutil.ClosedPeriod {
-	return i.charge.Intent.BaseLayer.ServicePeriod
+	return i.baseIntent.ServicePeriod
 }
 
 func (i persistedFlatFeeCharge) IsSubscriptionManaged() bool {
-	return i.charge.Intent.ManagedBy == billing.SubscriptionManagedLine
+	return i.baseIntent.ManagedBy == billing.SubscriptionManagedLine
 }
 
 // Charges carry subscription-sync annotations on their intent, so the effective
 // "last line" annotation is always the charge intent annotation itself.
 func (i persistedFlatFeeCharge) HasLastLineAnnotation(annotation string) bool {
-	return i.charge.Intent.Annotations.GetBool(annotation)
+	return i.baseIntent.Annotations.GetBool(annotation)
 }
 
 func (i persistedFlatFeeCharge) GetFlatFeeCharge() flatfee.Charge {

--- a/openmeter/billing/worker/subscriptionsync/service/persistedstate/loader.go
+++ b/openmeter/billing/worker/subscriptionsync/service/persistedstate/loader.go
@@ -103,6 +103,9 @@ func (l Loader) loadChargesForSubscription(ctx context.Context, subs subscriptio
 		return map[string]Item{}, nil
 	}
 
+	// TODO: charge listing for subscription sync should filter by the base intent's
+	// deleted-at state. Effective DeletedAt can come from API overrides and would
+	// hide charges whose subscription-owned base intent still needs reconciliation.
 	listedCharges, err := l.chargeService.ListCharges(ctx, charges.ListChargesInput{
 		Namespace:       subs.Namespace,
 		SubscriptionIDs: []string{subs.ID},
@@ -122,40 +125,42 @@ func (l Loader) loadChargesForSubscription(ctx context.Context, subs subscriptio
 				return nil, fmt.Errorf("getting usage based charge: %w", err)
 			}
 
-			if usageBasedCharge.Intent.UniqueReferenceID == nil {
+			uniqueReferenceID := usageBasedCharge.Intent.GetUniqueReferenceID()
+			if uniqueReferenceID == nil {
 				continue
 			}
 
 			item, err := NewChargeItemFromChargeType(meta.ChargeTypeUsageBased, &usageBasedCharge, nil)
 			if err != nil {
-				return nil, fmt.Errorf("creating persisted usage based charge item[%s]: %w", *usageBasedCharge.Intent.UniqueReferenceID, err)
+				return nil, fmt.Errorf("creating persisted usage based charge item[%s]: %w", *uniqueReferenceID, err)
 			}
 
-			if _, ok := byUniqueID[*usageBasedCharge.Intent.UniqueReferenceID]; ok {
+			if _, ok := byUniqueID[*uniqueReferenceID]; ok {
 				return nil, fmt.Errorf("duplicate unique ids in the existing charges")
 			}
 
-			byUniqueID[*usageBasedCharge.Intent.UniqueReferenceID] = item
+			byUniqueID[*uniqueReferenceID] = item
 		case meta.ChargeTypeFlatFee:
 			flatFeeCharge, err := charge.AsFlatFeeCharge()
 			if err != nil {
 				return nil, fmt.Errorf("getting flat fee charge: %w", err)
 			}
 
-			if flatFeeCharge.Intent.UniqueReferenceID == nil {
+			uniqueReferenceID := flatFeeCharge.Intent.GetUniqueReferenceID()
+			if uniqueReferenceID == nil {
 				continue
 			}
 
 			item, err := NewChargeItemFromChargeType(meta.ChargeTypeFlatFee, nil, &flatFeeCharge)
 			if err != nil {
-				return nil, fmt.Errorf("creating persisted flat fee charge item[%s]: %w", *flatFeeCharge.Intent.UniqueReferenceID, err)
+				return nil, fmt.Errorf("creating persisted flat fee charge item[%s]: %w", *uniqueReferenceID, err)
 			}
 
-			if _, ok := byUniqueID[*flatFeeCharge.Intent.UniqueReferenceID]; ok {
+			if _, ok := byUniqueID[*uniqueReferenceID]; ok {
 				return nil, fmt.Errorf("duplicate unique ids in the existing charges")
 			}
 
-			byUniqueID[*flatFeeCharge.Intent.UniqueReferenceID] = item
+			byUniqueID[*uniqueReferenceID] = item
 		case meta.ChargeTypeCreditPurchase:
 			creditPurchaseCharge, err := charge.AsCreditPurchaseCharge()
 			if err != nil {

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge.go
@@ -91,6 +91,8 @@ func (c *chargePatchCollection) addPatch(chargeID string, patch charges.Patch) e
 }
 
 func (c *chargePatchCollection) AddDelete(_ string, existing persistedstate.Item) error {
+	// TODO: include the charge intent target on delete patches so subscription sync
+	// deletes the base intent layer without accidentally deleting an API override.
 	return c.addPatch(existing.ID().ID, chargesmeta.NewPatchDelete(chargesmeta.RefundAsCreditsDeletePolicy))
 }
 
@@ -102,6 +104,8 @@ func (c *chargePatchCollection) AddProrate(existing persistedstate.Item, target 
 }
 
 func (c *chargePatchCollection) addEmulatedReplacement(existing persistedstate.Item, replacement charges.ChargeIntent) error {
+	// TODO: include the charge intent target on delete patches so emulated
+	// replacements remove the base intent layer while preserving API overrides.
 	if err := c.addPatch(existing.ID().ID, chargesmeta.NewPatchDelete(chargesmeta.RefundAsCreditsDeletePolicy)); err != nil {
 		return fmt.Errorf("adding replacement delete patch: %w", err)
 	}

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge_test.go
@@ -169,9 +169,9 @@ func newChargePatchTestFlatFeeItem(t *testing.T, target targetstate.StateItem, i
 	charge := chargesflatfee.Charge{
 		ChargeBase: chargesflatfee.ChargeBase{
 			ManagedResource: newChargePatchTestManagedResource(target.Subscription.Namespace, id),
-			Intent: chargesflatfee.OverridableIntent{
+			Intent: chargesflatfee.Intent{
 				Intent: existingIntent.Intent,
-				BaseLayer: chargesflatfee.IntentMutableFields{
+				IntentMutableFields: chargesflatfee.IntentMutableFields{
 					IntentMutableFields:   existingIntent.IntentMutableFields.IntentMutableFields,
 					InvoiceAt:             target.GetInvoiceAt(),
 					PaymentTerm:           productcatalog.InAdvancePaymentTerm,
@@ -179,7 +179,7 @@ func newChargePatchTestFlatFeeItem(t *testing.T, target targetstate.StateItem, i
 					AmountBeforeProration: alpacadecimal.NewFromInt(10),
 				},
 				SettlementMode: target.Subscription.SettlementMode,
-			},
+			}.AsOverridableIntent(),
 			Status: chargesflatfee.StatusActive,
 			State: chargesflatfee.State{
 				AmountAfterProration: alpacadecimal.NewFromInt(10),
@@ -223,9 +223,9 @@ func newChargePatchTestUsageBasedItemWithIntent(t *testing.T, target targetstate
 	charge := chargesusagebased.Charge{
 		ChargeBase: chargesusagebased.ChargeBase{
 			ManagedResource: newChargePatchTestManagedResource(target.Subscription.Namespace, id),
-			Intent: chargesusagebased.OverridableIntent{
+			Intent: chargesusagebased.Intent{
 				Intent: intent.Intent,
-				BaseLayer: chargesusagebased.IntentMutableFields{
+				IntentMutableFields: chargesusagebased.IntentMutableFields{
 					IntentMutableFields: intent.IntentMutableFields.IntentMutableFields,
 					InvoiceAt:           target.GetInvoiceAt(),
 					FeatureKey:          "feature-key",
@@ -234,7 +234,7 @@ func newChargePatchTestUsageBasedItemWithIntent(t *testing.T, target targetstate
 					}),
 				},
 				SettlementMode: settlementMode,
-			},
+			}.AsOverridableIntent(),
 			Status: chargesusagebased.StatusActive,
 			State: chargesusagebased.State{
 				FeatureID:    "feature-id",

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeflatfee.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeflatfee.go
@@ -40,7 +40,7 @@ func (c *flatFeeChargeCollection) AddShrink(_ string, existing persistedstate.It
 		return fmt.Errorf("existing item is not a flat fee charge [item_type=%s,id=%s]", existing.Type(), existing.ID())
 	}
 
-	if existingCharge.GetFlatFeeCharge().Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+	if existingCharge.GetFlatFeeCharge().Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
 		intent, err := newFlatFeeChargeIntent(target)
 		if err != nil {
 			return err
@@ -51,6 +51,8 @@ func (c *flatFeeChargeCollection) AddShrink(_ string, existing persistedstate.It
 
 	targetServicePeriod := target.GetServicePeriod()
 
+	// TODO: include the charge intent target on shrink patches so subscription
+	// sync mutates the base intent layer without touching API overrides.
 	patch, err := chargesmeta.NewPatchShrink(chargesmeta.NewPatchShrinkInput{
 		NewServicePeriodTo:     targetServicePeriod.To,
 		NewFullServicePeriodTo: target.FullServicePeriod.To,
@@ -70,7 +72,7 @@ func (c *flatFeeChargeCollection) AddExtend(existing persistedstate.Item, target
 		return fmt.Errorf("existing item is not a flat fee charge [item_type=%s,id=%s]", existing.Type(), existing.ID())
 	}
 
-	if existingCharge.GetFlatFeeCharge().Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+	if existingCharge.GetFlatFeeCharge().Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
 		intent, err := newFlatFeeChargeIntent(target)
 		if err != nil {
 			return err
@@ -81,6 +83,8 @@ func (c *flatFeeChargeCollection) AddExtend(existing persistedstate.Item, target
 
 	targetServicePeriod := target.GetServicePeriod()
 
+	// TODO: include the charge intent target on extend patches so subscription
+	// sync mutates the base intent layer without touching API overrides.
 	patch, err := chargesmeta.NewPatchExtend(chargesmeta.NewPatchExtendInput{
 		NewServicePeriodTo:     targetServicePeriod.To,
 		NewFullServicePeriodTo: target.FullServicePeriod.To,

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeusagebased.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeusagebased.go
@@ -40,7 +40,7 @@ func (c *usageBasedChargeCollection) AddShrink(_ string, existing persistedstate
 		return fmt.Errorf("existing item is not a usage based charge [item_type=%s,id=%s]", existing.Type(), existing.ID())
 	}
 
-	if existingCharge.GetUsageBasedCharge().Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+	if existingCharge.GetUsageBasedCharge().Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
 		intent, err := newUsageBasedChargeIntent(target)
 		if err != nil {
 			return err
@@ -51,6 +51,8 @@ func (c *usageBasedChargeCollection) AddShrink(_ string, existing persistedstate
 
 	targetServicePeriod := target.GetServicePeriod()
 
+	// TODO: include the charge intent target on shrink patches so subscription
+	// sync mutates the base intent layer without touching API overrides.
 	patch, err := chargesmeta.NewPatchShrink(chargesmeta.NewPatchShrinkInput{
 		NewServicePeriodTo:     targetServicePeriod.To,
 		NewFullServicePeriodTo: target.FullServicePeriod.To,
@@ -70,7 +72,7 @@ func (c *usageBasedChargeCollection) AddExtend(existing persistedstate.Item, tar
 		return fmt.Errorf("existing item is not a usage based charge [item_type=%s,id=%s]", existing.Type(), existing.ID())
 	}
 
-	if existingCharge.GetUsageBasedCharge().Intent.SettlementMode != productcatalog.CreditThenInvoiceSettlementMode {
+	if existingCharge.GetUsageBasedCharge().Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
 		intent, err := newUsageBasedChargeIntent(target)
 		if err != nil {
 			return err
@@ -81,6 +83,8 @@ func (c *usageBasedChargeCollection) AddExtend(existing persistedstate.Item, tar
 
 	targetServicePeriod := target.GetServicePeriod()
 
+	// TODO: include the charge intent target on extend patches so subscription
+	// sync mutates the base intent layer without touching API overrides.
 	patch, err := chargesmeta.NewPatchExtend(chargesmeta.NewPatchExtendInput{
 		NewServicePeriodTo:     targetServicePeriod.To,
 		NewFullServicePeriodTo: target.FullServicePeriod.To,

--- a/openmeter/billing/worker/subscriptionsync/service/repair.go
+++ b/openmeter/billing/worker/subscriptionsync/service/repair.go
@@ -7,7 +7,9 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/persistedstate"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync/service/targetstate"
 )
@@ -138,12 +140,14 @@ func (r persistedChargeSubscriptionReference) WithSubscriptionItemID(newSubscrip
 			return charges.Charge{}, err
 		}
 
-		subscription, err := subscriptionReferenceWithItemID(charge.Intent.Subscription, newSubscriptionItemID)
+		baseIntent := charge.Intent.GetBaseIntent()
+		subscription, err := subscriptionReferenceWithItemID(baseIntent.Subscription, newSubscriptionItemID)
 		if err != nil {
 			return charges.Charge{}, err
 		}
 
-		charge.Intent.Subscription = subscription
+		baseIntent.Subscription = subscription
+		charge.Intent = flatfee.NewOverridableIntent(baseIntent, charge.Intent.GetOverrideLayerMutableFields())
 
 		return charges.NewCharge(charge), nil
 	case meta.ChargeTypeUsageBased:
@@ -152,12 +156,14 @@ func (r persistedChargeSubscriptionReference) WithSubscriptionItemID(newSubscrip
 			return charges.Charge{}, err
 		}
 
-		subscription, err := subscriptionReferenceWithItemID(charge.Intent.Subscription, newSubscriptionItemID)
+		baseIntent := charge.Intent.GetBaseIntent()
+		subscription, err := subscriptionReferenceWithItemID(baseIntent.Subscription, newSubscriptionItemID)
 		if err != nil {
 			return charges.Charge{}, err
 		}
 
-		charge.Intent.Subscription = subscription
+		baseIntent.Subscription = subscription
+		charge.Intent = usagebased.NewOverridableIntent(baseIntent, charge.Intent.GetOverrideLayerMutableFields())
 
 		return charges.NewCharge(charge), nil
 	default:
@@ -187,7 +193,7 @@ func persistedChargeSubscriptionReferenceFromItem(item persistedstate.Item) (per
 		return persistedChargeSubscriptionReference{
 			Charge:       charges.NewCharge(charge),
 			ChargeID:     charge.GetChargeID(),
-			Subscription: charge.Intent.Subscription,
+			Subscription: charge.Intent.GetSubscription(),
 			IsCharge:     true,
 		}, nil
 	case persistedstate.ItemTypeChargeUsageBased:
@@ -199,7 +205,7 @@ func persistedChargeSubscriptionReferenceFromItem(item persistedstate.Item) (per
 		return persistedChargeSubscriptionReference{
 			Charge:       charges.NewCharge(charge),
 			ChargeID:     charge.GetChargeID(),
-			Subscription: charge.Intent.Subscription,
+			Subscription: charge.Intent.GetSubscription(),
 			IsCharge:     true,
 		}, nil
 	default:

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -3634,8 +3634,8 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
 
 	s.Run("dry run does not repair the persisted charge item reference", func() {
 		chargeBeforeDryRun := s.mustGetOnlyUsageBasedCharge(ctx, subsView.Subscription.ID)
-		s.Require().NotNil(chargeBeforeDryRun.Intent.Subscription)
-		itemIDBeforeDryRun := chargeBeforeDryRun.Intent.Subscription.ItemID
+		s.Require().NotNil(chargeBeforeDryRun.Intent.GetSubscription())
+		itemIDBeforeDryRun := chargeBeforeDryRun.Intent.GetSubscription().ItemID
 
 		phase := s.getPhaseByKey(s.T(), updatedSubsView, "first-phase")
 		targetItemID := phase.ItemsByKey[s.APIRequestsTotalFeature.Key][0].SubscriptionItem.ID
@@ -3644,8 +3644,8 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdate() {
 		s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z"), subscriptionsync.EnableDryRun()))
 
 		chargeAfterDryRun := s.mustGetOnlyUsageBasedCharge(ctx, subsView.Subscription.ID)
-		s.Require().NotNil(chargeAfterDryRun.Intent.Subscription)
-		s.Equal(itemIDBeforeDryRun, chargeAfterDryRun.Intent.Subscription.ItemID)
+		s.Require().NotNil(chargeAfterDryRun.Intent.GetSubscription())
+		s.Equal(itemIDBeforeDryRun, chargeAfterDryRun.Intent.GetSubscription().ItemID)
 	})
 
 	s.NoError(s.Service.SyncByView(ctx, updatedSubsView, s.mustParseTime("2024-02-01T00:00:00Z")))
@@ -7382,11 +7382,11 @@ func (s *CreditThenInvoiceTestSuite) assertCreditThenInvoiceChargeTaxConfigs(ctx
 		case chargesmeta.ChargeTypeFlatFee:
 			flatFeeCharge, err := charge.AsFlatFeeCharge()
 			s.NoError(err)
-			s.assertTaxCodeConfigEqual(expectedChargeTaxConfig, flatFeeCharge.Intent.BaseLayer.TaxConfig, flatFeeCharge.ID)
+			s.assertTaxCodeConfigEqual(expectedChargeTaxConfig, flatFeeCharge.Intent.GetBaseTaxConfig(), flatFeeCharge.ID)
 		case chargesmeta.ChargeTypeUsageBased:
 			usageBasedCharge, err := charge.AsUsageBasedCharge()
 			s.NoError(err)
-			s.assertTaxCodeConfigEqual(expectedChargeTaxConfig, usageBasedCharge.Intent.BaseLayer.TaxConfig, usageBasedCharge.ID)
+			s.assertTaxCodeConfigEqual(expectedChargeTaxConfig, usageBasedCharge.Intent.GetBaseTaxConfig(), usageBasedCharge.ID)
 		default:
 			s.Failf("unsupported charge type", "unsupported charge type %s", chargeType)
 		}
@@ -7432,18 +7432,19 @@ func (s *CreditThenInvoiceTestSuite) assertCreditThenInvoiceUsageBasedCharge(cha
 	s.T().Helper()
 
 	s.Equal(input.Status, charge.Status)
-	s.Equal(productcatalog.CreditThenInvoiceSettlementMode, charge.Intent.SettlementMode)
-	s.Equal(input.ServicePeriod, charge.Intent.BaseLayer.ServicePeriod)
-	s.Equal(input.ServicePeriod, charge.Intent.BaseLayer.FullServicePeriod)
-	s.Equal(input.ServicePeriod, charge.Intent.BaseLayer.BillingPeriod)
-	s.Equal(input.InvoiceAt, charge.Intent.BaseLayer.InvoiceAt)
-	s.Equal(input.CustomerID, charge.Intent.CustomerID)
-	s.Equal(input.FeatureKey, charge.Intent.BaseLayer.FeatureKey)
-	s.Truef(input.Price.Equal(&charge.Intent.BaseLayer.Price), "price expected %v, got %v", input.Price, charge.Intent.BaseLayer.Price)
-	s.Require().NotNil(charge.Intent.Subscription)
-	s.Equal(input.SubscriptionID, charge.Intent.Subscription.SubscriptionID)
-	s.Equal(input.PhaseID, charge.Intent.Subscription.PhaseID)
-	s.Equal(input.ItemID, charge.Intent.Subscription.ItemID)
+	s.Equal(productcatalog.CreditThenInvoiceSettlementMode, charge.Intent.GetSettlementMode())
+	s.Equal(input.ServicePeriod, charge.Intent.GetBaseIntent().ServicePeriod)
+	s.Equal(input.ServicePeriod, charge.Intent.GetBaseIntent().FullServicePeriod)
+	s.Equal(input.ServicePeriod, charge.Intent.GetBaseIntent().BillingPeriod)
+	s.Equal(input.InvoiceAt, charge.Intent.GetBaseIntent().InvoiceAt)
+	s.Equal(input.CustomerID, charge.Intent.GetCustomerID())
+	s.Equal(input.FeatureKey, charge.Intent.GetBaseIntent().FeatureKey)
+	price := charge.Intent.GetBaseIntent().Price
+	s.Truef(input.Price.Equal(&price), "price expected %v, got %v", input.Price, price)
+	s.Require().NotNil(charge.Intent.GetSubscription())
+	s.Equal(input.SubscriptionID, charge.Intent.GetSubscription().SubscriptionID)
+	s.Equal(input.PhaseID, charge.Intent.GetSubscription().PhaseID)
+	s.Equal(input.ItemID, charge.Intent.GetSubscription().ItemID)
 }
 
 type expectedTotalsInput struct {

--- a/openmeter/ledger/chargeadapter/annotations.go
+++ b/openmeter/ledger/chargeadapter/annotations.go
@@ -28,7 +28,7 @@ func chargeAnnotationsForFlatFeeCharge(charge chargeflatfee.Charge) models.Annot
 			Namespace: charge.Namespace,
 			ID:        charge.ID,
 		},
-		charge.Intent.Subscription,
+		charge.Intent.GetSubscription(),
 		charge.State.FeatureID,
 	)
 }
@@ -39,7 +39,7 @@ func chargeAnnotationsForUsageBasedCharge(charge chargeusagebased.Charge) models
 			Namespace: charge.Namespace,
 			ID:        charge.ID,
 		},
-		charge.Intent.Subscription,
+		charge.Intent.GetSubscription(),
 		lo.EmptyableToPtr(charge.State.FeatureID),
 	)
 }

--- a/openmeter/ledger/chargeadapter/flatfee.go
+++ b/openmeter/ledger/chargeadapter/flatfee.go
@@ -49,8 +49,11 @@ func (h *flatFeeHandler) OnAllocateCredits(ctx context.Context, input flatfee.On
 		return nil, nil
 	}
 
+	intent := input.Charge.Intent
+	taxConfig := intent.GetEffectiveTaxConfig()
+
 	if err := validateSettlementMode(
-		input.Charge.Intent.SettlementMode,
+		intent.GetSettlementMode(),
 		productcatalog.CreditThenInvoiceSettlementMode,
 		productcatalog.CreditOnlySettlementMode,
 	); err != nil {
@@ -60,16 +63,16 @@ func (h *flatFeeHandler) OnAllocateCredits(ctx context.Context, input flatfee.On
 	realizations, err := h.collector.CollectToAccrued(ctx, collector.CollectToAccruedInput{
 		Namespace:         input.Charge.Namespace,
 		ChargeID:          input.Charge.ID,
-		CustomerID:        input.Charge.Intent.CustomerID,
+		CustomerID:        intent.GetCustomerID(),
 		Annotations:       chargeAnnotationsForFlatFeeCharge(input.Charge),
 		BookedAt:          input.BookedAt,
-		SourceBalanceAsOf: input.Charge.Intent.BaseLayer.InvoiceAt,
-		Currency:          input.Charge.Intent.Currency,
-		TaxCode:           lo.ToPtr(input.Charge.Intent.BaseLayer.TaxConfig.TaxCodeID),
-		TaxBehavior:       (*ledger.TaxBehavior)(input.Charge.Intent.BaseLayer.TaxConfig.Behavior),
-		SettlementMode:    input.Charge.Intent.SettlementMode,
+		SourceBalanceAsOf: intent.GetEffectiveInvoiceAt(),
+		Currency:          intent.GetCurrency(),
+		TaxCode:           lo.ToPtr(taxConfig.TaxCodeID),
+		TaxBehavior:       (*ledger.TaxBehavior)(taxConfig.Behavior),
+		SettlementMode:    intent.GetSettlementMode(),
 		ServicePeriod:     input.ServicePeriod,
-		FeatureKey:        input.Charge.Intent.BaseLayer.FeatureKey,
+		FeatureKey:        intent.GetEffectiveFeatureKey(),
 		Amount:            input.PreTaxAmountToAllocate,
 	})
 	if err != nil {
@@ -95,8 +98,11 @@ func (h *flatFeeHandler) OnInvoiceUsageAccrued(ctx context.Context, input flatfe
 		return ledgertransaction.GroupReference{}, nil
 	}
 
+	intent := input.Charge.Intent
+	taxConfig := intent.GetEffectiveTaxConfig()
+
 	if err := validateSettlementMode(
-		input.Charge.Intent.SettlementMode,
+		intent.GetSettlementMode(),
 		productcatalog.CreditThenInvoiceSettlementMode,
 	); err != nil {
 		return ledgertransaction.GroupReference{}, fmt.Errorf("invoice usage accrued: %w", err)
@@ -104,7 +110,7 @@ func (h *flatFeeHandler) OnInvoiceUsageAccrued(ctx context.Context, input flatfe
 
 	customerID := customer.CustomerID{
 		Namespace: input.Charge.Namespace,
-		ID:        input.Charge.Intent.CustomerID,
+		ID:        intent.GetCustomerID(),
 	}
 	annotations := chargeAnnotationsForFlatFeeCharge(input.Charge)
 
@@ -118,9 +124,9 @@ func (h *flatFeeHandler) OnInvoiceUsageAccrued(ctx context.Context, input flatfe
 		transactions.TransferCustomerReceivableToAccruedTemplate{
 			At:          input.BookedAt,
 			Amount:      amount,
-			Currency:    input.Charge.Intent.Currency,
-			TaxCode:     lo.ToPtr(input.Charge.Intent.BaseLayer.TaxConfig.TaxCodeID),
-			TaxBehavior: (*ledger.TaxBehavior)(input.Charge.Intent.BaseLayer.TaxConfig.Behavior),
+			Currency:    intent.GetCurrency(),
+			TaxCode:     lo.ToPtr(taxConfig.TaxCodeID),
+			TaxBehavior: (*ledger.TaxBehavior)(taxConfig.Behavior),
 			CostBasis:   invoiceCostBasis,
 		},
 	)
@@ -149,7 +155,9 @@ func (h *flatFeeHandler) OnInvoiceUsageAccrued(ctx context.Context, input flatfe
 }
 
 func (h *flatFeeHandler) OnCorrectCreditAllocations(ctx context.Context, input flatfee.CorrectCreditAllocationsInput) (creditrealization.CreateCorrectionInputs, error) {
-	currencyCalculator, err := input.Charge.Intent.Currency.Calculator()
+	intent := input.Charge.Intent
+
+	currencyCalculator, err := intent.GetCurrency().Calculator()
 	if err != nil {
 		return nil, fmt.Errorf("get currency calculator: %w", err)
 	}
@@ -161,7 +169,7 @@ func (h *flatFeeHandler) OnCorrectCreditAllocations(ctx context.Context, input f
 	return h.collector.CorrectCollectedAccrued(ctx, collector.CorrectCollectedAccruedInput{
 		Namespace:                    input.Charge.Namespace,
 		ChargeID:                     input.Charge.ID,
-		CustomerID:                   input.Charge.Intent.CustomerID,
+		CustomerID:                   intent.GetCustomerID(),
 		Annotations:                  chargeAnnotationsForFlatFeeCharge(input.Charge),
 		AllocateAt:                   input.BookedAt,
 		Corrections:                  input.Corrections,
@@ -180,9 +188,11 @@ func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, input flatfee.
 		return ledgertransaction.GroupReference{}, nil
 	}
 
+	intent := input.Charge.Intent
+
 	customerID := customer.CustomerID{
 		Namespace: input.Charge.Namespace,
-		ID:        input.Charge.Intent.CustomerID,
+		ID:        intent.GetCustomerID(),
 	}
 	annotations := chargeAnnotationsForFlatFeeCharge(input.Charge)
 
@@ -196,7 +206,7 @@ func (h *flatFeeHandler) OnPaymentAuthorized(ctx context.Context, input flatfee.
 		transactions.AuthorizeCustomerReceivablePaymentTemplate{
 			At:        input.EventAt,
 			Amount:    input.Amount,
-			Currency:  input.Charge.Intent.Currency,
+			Currency:  intent.GetCurrency(),
 			CostBasis: invoiceCostBasis,
 		},
 	)
@@ -233,9 +243,11 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, input flatfee.OnP
 		return ledgertransaction.GroupReference{}, nil
 	}
 
+	intent := input.Charge.Intent
+
 	customerID := customer.CustomerID{
 		Namespace: input.Charge.Namespace,
-		ID:        input.Charge.Intent.CustomerID,
+		ID:        intent.GetCustomerID(),
 	}
 	annotations := chargeAnnotationsForFlatFeeCharge(input.Charge)
 
@@ -249,7 +261,7 @@ func (h *flatFeeHandler) OnPaymentSettled(ctx context.Context, input flatfee.OnP
 		transactions.SettleCustomerReceivableFromPaymentTemplate{
 			At:        input.EventAt,
 			Amount:    input.Amount,
-			Currency:  input.Charge.Intent.Currency,
+			Currency:  intent.GetCurrency(),
 			CostBasis: invoiceCostBasis,
 		},
 	)

--- a/openmeter/ledger/chargeadapter/flatfee_test.go
+++ b/openmeter/ledger/chargeadapter/flatfee_test.go
@@ -54,7 +54,7 @@ func TestOnAllocateCredits(t *testing.T) {
 		)
 		for _, bookedAt := range env.transactionBookedAtTimes(t, realizations[0].LedgerTransaction.TransactionGroupID) {
 			requireLedgerBookedAtEqual(t, input.ServicePeriod.From, bookedAt)
-			requireLedgerBookedAtNotEqual(t, input.Charge.Intent.BaseLayer.InvoiceAt, bookedAt)
+			requireLedgerBookedAtNotEqual(t, input.Charge.Intent.GetEffectiveInvoiceAt(), bookedAt)
 		}
 
 		require.True(t, env.sumBalance(t, priorityOne).Equal(alpacadecimal.NewFromInt(40)))
@@ -137,9 +137,11 @@ func TestOnAllocateCredits(t *testing.T) {
 
 		env.fundPriority(t, 1, 30)
 		input := env.newAssignmentInput(alpacadecimal.NewFromInt(30))
-		input.Charge.Intent.BaseLayer.PaymentTerm = productcatalog.InArrearsPaymentTerm
-		input.Charge.Intent.BaseLayer.InvoiceAt = input.ServicePeriod.From
-		input.BookedAt = chargeflatfee.UsageBookedAt(input.Charge.Intent.BaseLayer.PaymentTerm, input.ServicePeriod)
+		editFlatFeeBaseLayerForTest(t, &input.Charge, func(intent *chargeflatfee.IntentMutableFields) {
+			intent.PaymentTerm = productcatalog.InArrearsPaymentTerm
+			intent.InvoiceAt = input.ServicePeriod.From
+		})
+		input.BookedAt = chargeflatfee.UsageBookedAt(input.Charge.Intent.GetEffectivePaymentTerm(), input.ServicePeriod)
 
 		realizations, err := env.handler.OnAllocateCredits(t.Context(), input)
 		require.NoError(t, err)
@@ -147,7 +149,7 @@ func TestOnAllocateCredits(t *testing.T) {
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, realizations[0].LedgerTransaction.TransactionGroupID) {
 			requireLedgerBookedAtEqual(t, input.ServicePeriod.To, bookedAt)
-			requireLedgerBookedAtNotEqual(t, input.Charge.Intent.BaseLayer.InvoiceAt, bookedAt)
+			requireLedgerBookedAtNotEqual(t, input.Charge.Intent.GetEffectiveInvoiceAt(), bookedAt)
 		}
 	})
 }
@@ -187,7 +189,9 @@ func TestOnAllocateCreditsCreditOnly(t *testing.T) {
 		restricted := env.fundPriorityWithFeatures(t, 1, 4, []string{featureKey})
 		general := env.fundPriorityWithFeatures(t, 2, 6, nil)
 		charge := env.newCreditsOnlyCharge(alpacadecimal.NewFromInt(7))
-		charge.Intent.BaseLayer.FeatureKey = featureKey
+		editFlatFeeBaseLayerForTest(t, &charge, func(intent *chargeflatfee.IntentMutableFields) {
+			intent.FeatureKey = featureKey
+		})
 
 		realizations, err := env.handler.OnAllocateCredits(t.Context(), env.newAllocateCreditsInputForCharge(
 			charge,
@@ -212,9 +216,11 @@ func TestOnCorrectCreditAllocations(t *testing.T) {
 		require.Len(t, allocations, 1)
 
 		chargeWithRealizations := env.newChargeWithCreditRealizationsAndAccruedUsage(allocations, alpacadecimal.Zero)
-		chargeWithRealizations.Intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		editFlatFeeBaseIntentForTest(t, &chargeWithRealizations, func(intent *chargeflatfee.Intent) {
+			intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		})
 
-		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
+		currencyCalculator, err := chargeWithRealizations.Intent.GetCurrency().Calculator()
 		require.NoError(t, err)
 
 		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
@@ -246,9 +252,11 @@ func TestOnCorrectCreditAllocations(t *testing.T) {
 		require.Len(t, allocations, 2)
 
 		chargeWithRealizations := env.newChargeWithCreditRealizationsAndAccruedUsage(allocations, alpacadecimal.Zero)
-		chargeWithRealizations.Intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		editFlatFeeBaseIntentForTest(t, &chargeWithRealizations, func(intent *chargeflatfee.Intent) {
+			intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		})
 
-		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
+		currencyCalculator, err := chargeWithRealizations.Intent.GetCurrency().Calculator()
 		require.NoError(t, err)
 
 		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-35), currencyCalculator)
@@ -278,9 +286,11 @@ func TestOnCorrectCreditAllocations(t *testing.T) {
 		require.Len(t, allocations, 2)
 
 		chargeWithRealizations := env.newChargeWithCreditRealizationsAndAccruedUsage(allocations, alpacadecimal.Zero)
-		chargeWithRealizations.Intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		editFlatFeeBaseIntentForTest(t, &chargeWithRealizations, func(intent *chargeflatfee.Intent) {
+			intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		})
 
-		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
+		currencyCalculator, err := chargeWithRealizations.Intent.GetCurrency().Calculator()
 		require.NoError(t, err)
 
 		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
@@ -311,7 +321,7 @@ func TestOnCorrectCreditAllocations(t *testing.T) {
 
 		chargeWithRealizations := env.newChargeWithCreditRealizationsAndAccruedUsage(allocations, alpacadecimal.Zero)
 
-		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
+		currencyCalculator, err := chargeWithRealizations.Intent.GetCurrency().Calculator()
 		require.NoError(t, err)
 
 		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
@@ -345,7 +355,7 @@ func TestOnCorrectCreditAllocations(t *testing.T) {
 		require.True(t, env.sumBalance(t, env.creditAccruedSubAccount(t)).Equal(alpacadecimal.Zero))
 		require.True(t, env.sumBalance(t, env.creditEarningsSubAccount(t)).Equal(alpacadecimal.NewFromInt(30)))
 
-		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
+		currencyCalculator, err := chargeWithRealizations.Intent.GetCurrency().Calculator()
 		require.NoError(t, err)
 
 		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
@@ -376,14 +386,16 @@ func TestOnCorrectCreditAllocations(t *testing.T) {
 		require.Len(t, allocations, 1)
 
 		chargeWithRealizations := env.newChargeWithCreditRealizationsAndAccruedUsage(allocations, alpacadecimal.Zero)
-		chargeWithRealizations.Intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		editFlatFeeBaseIntentForTest(t, &chargeWithRealizations, func(intent *chargeflatfee.Intent) {
+			intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		})
 		env.createInitialLineages(t, chargeWithRealizations.ID, chargeWithRealizations.Realizations.CurrentRun.CreditRealizations)
 		recognitionGroupID := env.recognizeCreditAccrued(t, alpacadecimal.NewFromInt(30))
 
 		require.True(t, env.sumBalance(t, env.creditAccruedSubAccount(t)).Equal(alpacadecimal.Zero))
 		require.True(t, env.sumBalance(t, env.creditEarningsSubAccount(t)).Equal(alpacadecimal.NewFromInt(30)))
 
-		currencyCalculator, err := chargeWithRealizations.Intent.Currency.Calculator()
+		currencyCalculator, err := chargeWithRealizations.Intent.GetCurrency().Calculator()
 		require.NoError(t, err)
 
 		correctionsRequest, err := chargeWithRealizations.Realizations.CurrentRun.CreditRealizations.CreateCorrectionRequest(alpacadecimal.NewFromInt(-30), currencyCalculator)
@@ -428,7 +440,7 @@ func TestOnFlatFeeStandardInvoiceUsageAccrued(t *testing.T) {
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
 			requireLedgerBookedAtEqual(t, input.ServicePeriod.From, bookedAt)
-			requireLedgerBookedAtNotEqual(t, input.Charge.Intent.BaseLayer.InvoiceAt, bookedAt)
+			requireLedgerBookedAtNotEqual(t, input.Charge.Intent.GetEffectiveInvoiceAt(), bookedAt)
 		}
 	})
 
@@ -436,16 +448,18 @@ func TestOnFlatFeeStandardInvoiceUsageAccrued(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 
 		input := env.newAccrualInput(alpacadecimal.NewFromInt(50))
-		input.Charge.Intent.BaseLayer.PaymentTerm = productcatalog.InArrearsPaymentTerm
-		input.Charge.Intent.BaseLayer.InvoiceAt = input.ServicePeriod.From
-		input.BookedAt = chargeflatfee.UsageBookedAt(input.Charge.Intent.BaseLayer.PaymentTerm, input.ServicePeriod)
+		editFlatFeeBaseLayerForTest(t, &input.Charge, func(intent *chargeflatfee.IntentMutableFields) {
+			intent.PaymentTerm = productcatalog.InArrearsPaymentTerm
+			intent.InvoiceAt = input.ServicePeriod.From
+		})
+		input.BookedAt = chargeflatfee.UsageBookedAt(input.Charge.Intent.GetEffectivePaymentTerm(), input.ServicePeriod)
 		ref, err := env.handler.OnInvoiceUsageAccrued(t.Context(), input)
 		require.NoError(t, err)
 		require.NotEmpty(t, ref.TransactionGroupID)
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
 			requireLedgerBookedAtEqual(t, input.ServicePeriod.To, bookedAt)
-			requireLedgerBookedAtNotEqual(t, input.Charge.Intent.BaseLayer.InvoiceAt, bookedAt)
+			requireLedgerBookedAtNotEqual(t, input.Charge.Intent.GetEffectiveInvoiceAt(), bookedAt)
 		}
 	})
 
@@ -472,7 +486,9 @@ func TestOnFlatFeeStandardInvoiceUsageAccrued(t *testing.T) {
 		env := newFlatFeeHandlerTestEnv(t)
 
 		input := env.newAccrualInput(alpacadecimal.NewFromInt(10))
-		input.Charge.Intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		editFlatFeeBaseIntentForTest(t, &input.Charge, func(intent *chargeflatfee.Intent) {
+			intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		})
 
 		ref, err := env.handler.OnInvoiceUsageAccrued(t.Context(), input)
 		require.Error(t, err)
@@ -490,7 +506,9 @@ func TestOnFlatFeePaymentAuthorized(t *testing.T) {
 		require.NoError(t, err)
 
 		charge := env.newChargeWithAccruedUsage(total)
-		charge.Intent.BaseLayer.InvoiceAt = env.Now().Add(-24 * time.Hour)
+		editFlatFeeBaseLayerForTest(t, &charge, func(intent *chargeflatfee.IntentMutableFields) {
+			intent.InvoiceAt = env.Now().Add(-24 * time.Hour)
+		})
 		eventTime := env.Now().Add(15 * time.Minute)
 		clock.FreezeTime(eventTime)
 		defer clock.UnFreeze()
@@ -510,7 +528,7 @@ func TestOnFlatFeePaymentAuthorized(t *testing.T) {
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
 			require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
-			require.False(t, bookedAt.UTC().Equal(charge.Intent.BaseLayer.InvoiceAt.UTC()))
+			require.False(t, bookedAt.UTC().Equal(charge.Intent.GetEffectiveInvoiceAt().UTC()))
 		}
 	})
 
@@ -582,7 +600,9 @@ func TestOnFlatFeePaymentAuthorized(t *testing.T) {
 		require.Len(t, realizations, 1)
 
 		charge := env.newChargeWithCreditRealizationsAndAccruedUsage(realizations, alpacadecimal.Zero)
-		charge.Intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		editFlatFeeBaseIntentForTest(t, &charge, func(intent *chargeflatfee.Intent) {
+			intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		})
 
 		ref, err := env.handler.OnPaymentAuthorized(t.Context(), env.newPaymentEventInput(charge))
 		require.NoError(t, err)
@@ -620,7 +640,9 @@ func TestOnFlatFeePaymentSettled(t *testing.T) {
 		_, err = env.handler.OnPaymentAuthorized(t.Context(), env.newPaymentEventInput(charge))
 		require.NoError(t, err)
 
-		charge.Intent.BaseLayer.InvoiceAt = env.Now().Add(-48 * time.Hour)
+		editFlatFeeBaseLayerForTest(t, &charge, func(intent *chargeflatfee.IntentMutableFields) {
+			intent.InvoiceAt = env.Now().Add(-48 * time.Hour)
+		})
 		eventTime := env.Now().Add(30 * time.Minute)
 		clock.FreezeTime(eventTime)
 		defer clock.UnFreeze()
@@ -636,7 +658,7 @@ func TestOnFlatFeePaymentSettled(t *testing.T) {
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
 			require.True(t, bookedAt.UTC().Equal(eventTime.UTC()))
-			require.False(t, bookedAt.UTC().Equal(charge.Intent.BaseLayer.InvoiceAt.UTC()))
+			require.False(t, bookedAt.UTC().Equal(charge.Intent.GetEffectiveInvoiceAt().UTC()))
 		}
 	})
 
@@ -660,7 +682,9 @@ func TestOnFlatFeePaymentSettled(t *testing.T) {
 		require.NoError(t, err)
 
 		charge := env.newChargeWithCreditRealizationsAndAccruedUsage(realizations, alpacadecimal.Zero)
-		charge.Intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		editFlatFeeBaseIntentForTest(t, &charge, func(intent *chargeflatfee.Intent) {
+			intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+		})
 
 		_, err = env.handler.OnPaymentAuthorized(t.Context(), env.newPaymentEventInput(charge))
 		require.NoError(t, err)
@@ -744,8 +768,8 @@ func (e *flatFeeHandlerTestEnv) newAssignmentInput(amount alpacadecimal.Decimal)
 func (e *flatFeeHandlerTestEnv) newAllocateCreditsInputForCharge(charge chargeflatfee.Charge, amount alpacadecimal.Decimal) chargeflatfee.OnAllocateCreditsInput {
 	return chargeflatfee.OnAllocateCreditsInput{
 		Charge:                 charge,
-		ServicePeriod:          charge.Intent.BaseLayer.ServicePeriod,
-		BookedAt:               chargeflatfee.UsageBookedAt(charge.Intent.BaseLayer.PaymentTerm, charge.Intent.BaseLayer.ServicePeriod),
+		ServicePeriod:          charge.Intent.GetEffectiveServicePeriod(),
+		BookedAt:               chargeflatfee.UsageBookedAt(charge.Intent.GetEffectivePaymentTerm(), charge.Intent.GetEffectiveServicePeriod()),
 		PreTaxAmountToAllocate: amount,
 	}
 }
@@ -770,13 +794,13 @@ func (e *flatFeeHandlerTestEnv) newAssignmentInputWithMode(amount alpacadecimal.
 					},
 					ID: "flat-fee-charge",
 				},
-				Intent: chargeflatfee.OverridableIntent{
+				Intent: chargeflatfee.Intent{
 					Intent: meta.Intent{
 						ManagedBy:  billing.SystemManagedLine,
 						CustomerID: e.CustomerID.ID,
 						Currency:   currencyx.Code("USD"),
 					},
-					BaseLayer: chargeflatfee.IntentMutableFields{
+					IntentMutableFields: chargeflatfee.IntentMutableFields{
 						IntentMutableFields: meta.IntentMutableFields{
 							Name:              "Flat fee",
 							ServicePeriod:     servicePeriod,
@@ -792,7 +816,7 @@ func (e *flatFeeHandlerTestEnv) newAssignmentInputWithMode(amount alpacadecimal.
 						AmountBeforeProration: amount,
 					},
 					SettlementMode: mode,
-				},
+				}.AsOverridableIntent(),
 				State: chargeflatfee.State{
 					AmountAfterProration: amount,
 				},
@@ -895,7 +919,9 @@ func (e *flatFeeHandlerTestEnv) newCreditsOnlyCharge(amount alpacadecimal.Decima
 	}
 
 	charge := e.newBaseCharge(servicePeriod, amount)
-	charge.Intent.SettlementMode = productcatalog.CreditOnlySettlementMode
+	baseIntent := charge.Intent.GetBaseIntent()
+	baseIntent.SettlementMode = productcatalog.CreditOnlySettlementMode
+	charge.Intent = baseIntent.AsOverridableIntent()
 
 	return charge
 }
@@ -913,13 +939,13 @@ func (e *flatFeeHandlerTestEnv) newBaseCharge(servicePeriod timeutil.ClosedPerio
 				},
 				ID: "flat-fee-charge",
 			},
-			Intent: chargeflatfee.OverridableIntent{
+			Intent: chargeflatfee.Intent{
 				Intent: meta.Intent{
 					ManagedBy:  billing.SystemManagedLine,
 					CustomerID: e.CustomerID.ID,
 					Currency:   currencyx.Code("USD"),
 				},
-				BaseLayer: chargeflatfee.IntentMutableFields{
+				IntentMutableFields: chargeflatfee.IntentMutableFields{
 					IntentMutableFields: meta.IntentMutableFields{
 						Name:              "Flat fee",
 						ServicePeriod:     servicePeriod,
@@ -935,7 +961,7 @@ func (e *flatFeeHandlerTestEnv) newBaseCharge(servicePeriod timeutil.ClosedPerio
 					AmountBeforeProration: amount,
 				},
 				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
-			},
+			}.AsOverridableIntent(),
 			State: chargeflatfee.State{
 				AmountAfterProration: amount,
 			},

--- a/openmeter/ledger/chargeadapter/intent_test_helpers_test.go
+++ b/openmeter/ledger/chargeadapter/intent_test_helpers_test.go
@@ -1,0 +1,49 @@
+package chargeadapter_test
+
+import (
+	"testing"
+
+	chargeflatfee "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	chargeusagebased "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+)
+
+func editFlatFeeBaseIntentForTest(t testing.TB, charge *chargeflatfee.Charge, edit func(*chargeflatfee.Intent)) {
+	t.Helper()
+
+	intent := charge.Intent.GetBaseIntent()
+	edit(&intent)
+	charge.Intent = chargeflatfee.NewOverridableIntent(intent, charge.Intent.GetOverrideLayerMutableFields())
+}
+
+func editFlatFeeBaseLayerForTest(t testing.TB, charge *chargeflatfee.Charge, edit func(*chargeflatfee.IntentMutableFields)) {
+	t.Helper()
+
+	editFlatFeeBaseIntentForTest(t, charge, func(intent *chargeflatfee.Intent) {
+		edit(&intent.IntentMutableFields)
+	})
+}
+
+func editUsageBasedBaseIntentForTest(t testing.TB, charge *chargeusagebased.Charge, edit func(*chargeusagebased.Intent)) {
+	t.Helper()
+
+	intent := charge.Intent.GetBaseIntent()
+	edit(&intent)
+	charge.Intent = chargeusagebased.NewOverridableIntent(intent, charge.Intent.GetOverrideLayerMutableFields())
+}
+
+func editUsageBasedBaseLayerForTest(t testing.TB, charge *chargeusagebased.Charge, edit func(*chargeusagebased.IntentMutableFields)) {
+	t.Helper()
+
+	editUsageBasedBaseIntentForTest(t, charge, func(intent *chargeusagebased.Intent) {
+		edit(&intent.IntentMutableFields)
+	})
+}
+
+func setUsageBasedSubscriptionForTest(t testing.TB, charge *chargeusagebased.Charge, subscription meta.SubscriptionReference) {
+	t.Helper()
+
+	editUsageBasedBaseIntentForTest(t, charge, func(intent *chargeusagebased.Intent) {
+		intent.Subscription = &subscription
+	})
+}

--- a/openmeter/ledger/chargeadapter/usagebased.go
+++ b/openmeter/ledger/chargeadapter/usagebased.go
@@ -49,8 +49,11 @@ func (h *usageBasedHandler) OnInvoiceUsageAccrued(ctx context.Context, input usa
 		return ledgertransaction.GroupReference{}, nil
 	}
 
+	intent := input.Charge.Intent
+	taxConfig := intent.GetEffectiveTaxConfig()
+
 	if err := validateSettlementMode(
-		input.Charge.Intent.SettlementMode,
+		intent.GetSettlementMode(),
 		productcatalog.CreditThenInvoiceSettlementMode,
 	); err != nil {
 		return ledgertransaction.GroupReference{}, fmt.Errorf("invoice usage accrued: %w", err)
@@ -58,7 +61,7 @@ func (h *usageBasedHandler) OnInvoiceUsageAccrued(ctx context.Context, input usa
 
 	customerID := customer.CustomerID{
 		Namespace: input.Charge.Namespace,
-		ID:        input.Charge.Intent.CustomerID,
+		ID:        intent.GetCustomerID(),
 	}
 
 	inputs, err := transactions.ResolveTransactions(
@@ -71,9 +74,9 @@ func (h *usageBasedHandler) OnInvoiceUsageAccrued(ctx context.Context, input usa
 		transactions.TransferCustomerReceivableToAccruedTemplate{
 			At:          input.BookedAt,
 			Amount:      amount,
-			Currency:    input.Charge.Intent.Currency,
-			TaxCode:     lo.ToPtr(input.Charge.Intent.BaseLayer.TaxConfig.TaxCodeID),
-			TaxBehavior: (*ledger.TaxBehavior)(input.Charge.Intent.BaseLayer.TaxConfig.Behavior),
+			Currency:    intent.GetCurrency(),
+			TaxCode:     lo.ToPtr(taxConfig.TaxCodeID),
+			TaxBehavior: (*ledger.TaxBehavior)(taxConfig.Behavior),
 			CostBasis:   invoiceCostBasis,
 		},
 	)
@@ -100,8 +103,10 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 		return ledgertransaction.GroupReference{}, err
 	}
 
+	intent := input.Charge.Intent
+
 	if err := validateSettlementMode(
-		input.Charge.Intent.SettlementMode,
+		intent.GetSettlementMode(),
 		productcatalog.CreditThenInvoiceSettlementMode,
 	); err != nil {
 		return ledgertransaction.GroupReference{}, fmt.Errorf("payment authorized: %w", err)
@@ -118,7 +123,7 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 
 	customerID := customer.CustomerID{
 		Namespace: input.Charge.Namespace,
-		ID:        input.Charge.Intent.CustomerID,
+		ID:        intent.GetCustomerID(),
 	}
 	annotations := chargeAnnotationsForUsageBasedCharge(input.Charge)
 
@@ -132,7 +137,7 @@ func (h *usageBasedHandler) OnPaymentAuthorized(ctx context.Context, input usage
 		transactions.AuthorizeCustomerReceivablePaymentTemplate{
 			At:        input.EventAt,
 			Amount:    receivableReplenishment,
-			Currency:  input.Charge.Intent.Currency,
+			Currency:  intent.GetCurrency(),
 			CostBasis: invoiceCostBasis,
 		},
 	)
@@ -165,8 +170,10 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 		return ledgertransaction.GroupReference{}, err
 	}
 
+	intent := input.Charge.Intent
+
 	if err := validateSettlementMode(
-		input.Charge.Intent.SettlementMode,
+		intent.GetSettlementMode(),
 		productcatalog.CreditThenInvoiceSettlementMode,
 	); err != nil {
 		return ledgertransaction.GroupReference{}, fmt.Errorf("payment settled: %w", err)
@@ -178,7 +185,7 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 
 	customerID := customer.CustomerID{
 		Namespace: input.Charge.Namespace,
-		ID:        input.Charge.Intent.CustomerID,
+		ID:        intent.GetCustomerID(),
 	}
 	annotations := chargeAnnotationsForUsageBasedCharge(input.Charge)
 
@@ -192,7 +199,7 @@ func (h *usageBasedHandler) OnPaymentSettled(ctx context.Context, input usagebas
 		transactions.SettleCustomerReceivableFromPaymentTemplate{
 			At:        input.EventAt,
 			Amount:    input.Run.InvoiceUsage.Totals.Total,
-			Currency:  input.Charge.Intent.Currency,
+			Currency:  intent.GetCurrency(),
 			CostBasis: invoiceCostBasis,
 		},
 	)
@@ -229,8 +236,11 @@ func (h *usageBasedHandler) OnCreditsOnlyUsageAccrued(ctx context.Context, input
 		return nil, nil
 	}
 
+	intent := input.Charge.Intent
+	taxConfig := intent.GetEffectiveTaxConfig()
+
 	if err := validateSettlementMode(
-		input.Charge.Intent.SettlementMode,
+		intent.GetSettlementMode(),
 		productcatalog.CreditOnlySettlementMode,
 		productcatalog.CreditThenInvoiceSettlementMode,
 	); err != nil {
@@ -240,16 +250,16 @@ func (h *usageBasedHandler) OnCreditsOnlyUsageAccrued(ctx context.Context, input
 	realizations, err := h.collector.CollectToAccrued(ctx, collector.CollectToAccruedInput{
 		Namespace:         input.Charge.Namespace,
 		ChargeID:          input.Charge.ID,
-		CustomerID:        input.Charge.Intent.CustomerID,
+		CustomerID:        intent.GetCustomerID(),
 		Annotations:       chargeAnnotationsForUsageBasedCharge(input.Charge),
 		BookedAt:          input.BookedAt,
 		SourceBalanceAsOf: clock.Now(),
-		Currency:          input.Charge.Intent.Currency,
-		FeatureKey:        input.Charge.Intent.BaseLayer.FeatureKey,
-		TaxCode:           lo.ToPtr(input.Charge.Intent.BaseLayer.TaxConfig.TaxCodeID),
-		TaxBehavior:       (*ledger.TaxBehavior)(input.Charge.Intent.BaseLayer.TaxConfig.Behavior),
-		SettlementMode:    input.Charge.Intent.SettlementMode,
-		ServicePeriod:     input.Charge.Intent.BaseLayer.ServicePeriod,
+		Currency:          intent.GetCurrency(),
+		FeatureKey:        intent.GetEffectiveFeatureKey(),
+		TaxCode:           lo.ToPtr(taxConfig.TaxCodeID),
+		TaxBehavior:       (*ledger.TaxBehavior)(taxConfig.Behavior),
+		SettlementMode:    intent.GetSettlementMode(),
+		ServicePeriod:     intent.GetEffectiveServicePeriod(),
 		Amount:            input.AmountToAllocate,
 	})
 	if err != nil {
@@ -263,15 +273,17 @@ func (h *usageBasedHandler) OnCreditsOnlyUsageAccrued(ctx context.Context, input
 }
 
 func (h *usageBasedHandler) OnCreditsOnlyUsageAccruedCorrection(ctx context.Context, input usagebased.CreditsOnlyUsageAccruedCorrectionInput) (creditrealization.CreateCorrectionInputs, error) {
+	intent := input.Charge.Intent
+
 	if err := validateSettlementMode(
-		input.Charge.Intent.SettlementMode,
+		intent.GetSettlementMode(),
 		productcatalog.CreditOnlySettlementMode,
 		productcatalog.CreditThenInvoiceSettlementMode,
 	); err != nil {
 		return nil, fmt.Errorf("credits only usage accrued correction: %w", err)
 	}
 
-	currencyCalculator, err := input.Charge.Intent.Currency.Calculator()
+	currencyCalculator, err := intent.GetCurrency().Calculator()
 	if err != nil {
 		return nil, fmt.Errorf("get currency calculator: %w", err)
 	}
@@ -283,7 +295,7 @@ func (h *usageBasedHandler) OnCreditsOnlyUsageAccruedCorrection(ctx context.Cont
 	return h.collector.CorrectCollectedAccrued(ctx, collector.CorrectCollectedAccruedInput{
 		Namespace:                    input.Charge.Namespace,
 		ChargeID:                     input.Charge.ID,
-		CustomerID:                   input.Charge.Intent.CustomerID,
+		CustomerID:                   intent.GetCustomerID(),
 		Annotations:                  chargeAnnotationsForUsageBasedCharge(input.Charge),
 		AllocateAt:                   input.BookedAt,
 		Corrections:                  input.Corrections,

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -80,7 +80,9 @@ func TestOnUsageBasedCreditsOnlyUsageAccrued(t *testing.T) {
 
 		priorityOne := env.fundPriority(t, 1, 20)
 		charge := env.newCharge(productcatalog.CreditThenInvoiceSettlementMode)
-		charge.Intent.BaseLayer.InvoiceAt = env.Now().Add(24 * time.Hour)
+		editUsageBasedBaseLayerForTest(t, &charge, func(intent *chargeusagebased.IntentMutableFields) {
+			intent.InvoiceAt = env.Now().Add(24 * time.Hour)
+		})
 		run := env.newRun()
 
 		realizations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedInput{
@@ -100,7 +102,7 @@ func TestOnUsageBasedCreditsOnlyUsageAccrued(t *testing.T) {
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, realizations[0].LedgerTransaction.TransactionGroupID) {
 			requireLedgerBookedAtEqual(t, run.ServicePeriodTo, bookedAt)
-			requireLedgerBookedAtNotEqual(t, charge.Intent.BaseLayer.InvoiceAt, bookedAt)
+			requireLedgerBookedAtNotEqual(t, charge.Intent.GetEffectiveInvoiceAt(), bookedAt)
 		}
 	})
 
@@ -108,11 +110,12 @@ func TestOnUsageBasedCreditsOnlyUsageAccrued(t *testing.T) {
 		env := newUsageBasedHandlerTestEnv(t)
 
 		charge := env.newCreditsOnlyCharge()
-		charge.Intent.Subscription = &meta.SubscriptionReference{
+		subscription := meta.SubscriptionReference{
 			SubscriptionID: "subscription-01JABCDEF0123456789ABCDEF",
 			PhaseID:        "phase-01JABCDEF0123456789ABCDEF",
 			ItemID:         "item-01JABCDEF0123456789ABCDEF",
 		}
+		setUsageBasedSubscriptionForTest(t, &charge, subscription)
 
 		realizations, err := env.handler.OnCreditsOnlyUsageAccrued(t.Context(), chargeusagebased.CreditsOnlyUsageAccruedInput{
 			Charge:           charge,
@@ -128,9 +131,9 @@ func TestOnUsageBasedCreditsOnlyUsageAccrued(t *testing.T) {
 		for _, annotations := range transactionAnnotations {
 			require.Equal(t, charge.ID, annotations[ledger.AnnotationChargeID])
 			require.Equal(t, env.Namespace, annotations[ledger.AnnotationChargeNamespace])
-			require.Equal(t, charge.Intent.Subscription.SubscriptionID, annotations[ledger.AnnotationSubscriptionID])
-			require.Equal(t, charge.Intent.Subscription.PhaseID, annotations[ledger.AnnotationSubscriptionPhaseID])
-			require.Equal(t, charge.Intent.Subscription.ItemID, annotations[ledger.AnnotationSubscriptionItemID])
+			require.Equal(t, subscription.SubscriptionID, annotations[ledger.AnnotationSubscriptionID])
+			require.Equal(t, subscription.PhaseID, annotations[ledger.AnnotationSubscriptionPhaseID])
+			require.Equal(t, subscription.ItemID, annotations[ledger.AnnotationSubscriptionItemID])
 			require.Equal(t, charge.State.FeatureID, annotations[ledger.AnnotationFeatureID])
 		}
 	})
@@ -361,7 +364,9 @@ func TestOnUsageBasedInvoiceUsageAccrued(t *testing.T) {
 			To:   env.Now().Add(-time.Hour),
 		}
 		charge := env.newCharge(productcatalog.CreditThenInvoiceSettlementMode)
-		charge.Intent.BaseLayer.InvoiceAt = servicePeriod.To.Add(24 * time.Hour)
+		editUsageBasedBaseLayerForTest(t, &charge, func(intent *chargeusagebased.IntentMutableFields) {
+			intent.InvoiceAt = servicePeriod.To.Add(24 * time.Hour)
+		})
 
 		ref, err := env.handler.OnInvoiceUsageAccrued(t.Context(), chargeusagebased.OnInvoiceUsageAccruedInput{
 			Charge:        charge,
@@ -375,7 +380,7 @@ func TestOnUsageBasedInvoiceUsageAccrued(t *testing.T) {
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
 			requireLedgerBookedAtEqual(t, servicePeriod.To, bookedAt)
-			requireLedgerBookedAtNotEqual(t, charge.Intent.BaseLayer.InvoiceAt, bookedAt)
+			requireLedgerBookedAtNotEqual(t, charge.Intent.GetEffectiveInvoiceAt(), bookedAt)
 		}
 	})
 
@@ -409,7 +414,9 @@ func TestOnUsageBasedPaymentAuthorized(t *testing.T) {
 		require.NoError(t, err)
 
 		charge := env.newCharge(productcatalog.CreditThenInvoiceSettlementMode)
-		charge.Intent.BaseLayer.InvoiceAt = env.Now().Add(-24 * time.Hour)
+		editUsageBasedBaseLayerForTest(t, &charge, func(intent *chargeusagebased.IntentMutableFields) {
+			intent.InvoiceAt = env.Now().Add(-24 * time.Hour)
+		})
 		eventTime := env.Now().Add(15 * time.Minute)
 		clock.FreezeTime(eventTime)
 		defer clock.UnFreeze()
@@ -432,7 +439,7 @@ func TestOnUsageBasedPaymentAuthorized(t *testing.T) {
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
 			requireLedgerBookedAtEqual(t, eventTime, bookedAt)
-			requireLedgerBookedAtNotEqual(t, charge.Intent.BaseLayer.InvoiceAt, bookedAt)
+			requireLedgerBookedAtNotEqual(t, charge.Intent.GetEffectiveInvoiceAt(), bookedAt)
 		}
 	})
 
@@ -476,7 +483,9 @@ func TestOnUsageBasedPaymentSettled(t *testing.T) {
 		require.NoError(t, err)
 
 		authorizedCharge := env.newCharge(productcatalog.CreditThenInvoiceSettlementMode)
-		authorizedCharge.Intent.BaseLayer.InvoiceAt = env.Now().Add(-24 * time.Hour)
+		editUsageBasedBaseLayerForTest(t, &authorizedCharge, func(intent *chargeusagebased.IntentMutableFields) {
+			intent.InvoiceAt = env.Now().Add(-24 * time.Hour)
+		})
 		_, err = env.handler.OnPaymentAuthorized(t.Context(), chargeusagebased.OnPaymentAuthorizedInput{
 			Charge:  authorizedCharge,
 			Run:     env.newRunWithInvoiceUsage("line-1", total),
@@ -485,7 +494,9 @@ func TestOnUsageBasedPaymentSettled(t *testing.T) {
 		require.NoError(t, err)
 
 		settledCharge := env.newCharge(productcatalog.CreditThenInvoiceSettlementMode)
-		settledCharge.Intent.BaseLayer.InvoiceAt = env.Now().Add(-48 * time.Hour)
+		editUsageBasedBaseLayerForTest(t, &settledCharge, func(intent *chargeusagebased.IntentMutableFields) {
+			intent.InvoiceAt = env.Now().Add(-48 * time.Hour)
+		})
 		eventTime := env.Now().Add(30 * time.Minute)
 		clock.FreezeTime(eventTime)
 		defer clock.UnFreeze()
@@ -504,7 +515,7 @@ func TestOnUsageBasedPaymentSettled(t *testing.T) {
 
 		for _, bookedAt := range env.transactionBookedAtTimes(t, ref.TransactionGroupID) {
 			requireLedgerBookedAtEqual(t, eventTime, bookedAt)
-			requireLedgerBookedAtNotEqual(t, settledCharge.Intent.BaseLayer.InvoiceAt, bookedAt)
+			requireLedgerBookedAtNotEqual(t, settledCharge.Intent.GetEffectiveInvoiceAt(), bookedAt)
 		}
 	})
 
@@ -612,13 +623,13 @@ func (e *usageBasedHandlerTestEnv) newCharge(settlementMode productcatalog.Settl
 				},
 				ID: "usage-based-charge",
 			},
-			Intent: chargeusagebased.OverridableIntent{
+			Intent: chargeusagebased.Intent{
 				Intent: meta.Intent{
 					ManagedBy:  billing.SystemManagedLine,
 					CustomerID: e.CustomerID.ID,
 					Currency:   currencyx.Code("USD"),
 				},
-				BaseLayer: chargeusagebased.IntentMutableFields{
+				IntentMutableFields: chargeusagebased.IntentMutableFields{
 					IntentMutableFields: meta.IntentMutableFields{
 						Name:          "Usage based",
 						ServicePeriod: servicePeriod,
@@ -632,7 +643,7 @@ func (e *usageBasedHandlerTestEnv) newCharge(settlementMode productcatalog.Settl
 					Price:      *productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: alpacadecimal.NewFromInt(1)}),
 				},
 				SettlementMode: settlementMode,
-			},
+			}.AsOverridableIntent(),
 			Status: chargeusagebased.StatusActiveFinalRealizationProcessing,
 			State: chargeusagebased.State{
 				FeatureID:    featureID,
@@ -680,7 +691,7 @@ func (e *usageBasedHandlerTestEnv) newRunWithLine(lineID string) chargeusagebase
 func (e *usageBasedHandlerTestEnv) newRunWithInvoiceUsage(lineID string, total alpacadecimal.Decimal) chargeusagebased.RealizationRun {
 	run := e.newRunWithLine(lineID)
 	run.InvoiceUsage = &invoicedusage.AccruedUsage{
-		ServicePeriod: e.newCharge(productcatalog.CreditThenInvoiceSettlementMode).Intent.BaseLayer.ServicePeriod,
+		ServicePeriod: e.newCharge(productcatalog.CreditThenInvoiceSettlementMode).Intent.GetEffectiveServicePeriod(),
 		Totals: totals.Totals{
 			Amount: total,
 			Total:  total,

--- a/openmeter/ledger/customerbalance/service.go
+++ b/openmeter/ledger/customerbalance/service.go
@@ -335,11 +335,11 @@ func getFlatFeeChargePendingBalanceImpact(charge charges.Charge, currency curren
 		return nil, fmt.Errorf("map flat fee charge: %w", err)
 	}
 
-	if flatFeeCharge.Intent.Currency != currency {
+	if flatFeeCharge.Intent.GetCurrency() != currency {
 		return nil, nil
 	}
 
-	if !featureFilterMatchesChargeFeatureKey(featureFilter, flatFeeCharge.Intent.BaseLayer.FeatureKey) {
+	if !featureFilterMatchesChargeFeatureKey(featureFilter, flatFeeCharge.Intent.GetEffectiveFeatureKey()) {
 		return nil, nil
 	}
 
@@ -352,11 +352,11 @@ func (s *service) getUsageBasedChargePendingBalanceImpact(ctx context.Context, c
 		return nil, fmt.Errorf("map usage based charge: %w", err)
 	}
 
-	if usageBasedCharge.Intent.Currency != currency {
+	if usageBasedCharge.Intent.GetCurrency() != currency {
 		return nil, nil
 	}
 
-	if !featureFilterMatchesChargeFeatureKey(featureFilter, usageBasedCharge.Intent.BaseLayer.FeatureKey) {
+	if !featureFilterMatchesChargeFeatureKey(featureFilter, usageBasedCharge.Intent.GetEffectiveFeatureKey()) {
 		return nil, nil
 	}
 
@@ -397,14 +397,14 @@ func chargeHasStarted(charge charges.Charge) bool {
 			return false
 		}
 
-		return !now.Before(flatFeeCharge.Intent.BaseLayer.ServicePeriod.From)
+		return !now.Before(flatFeeCharge.Intent.GetEffectiveServicePeriod().From)
 	case meta.ChargeTypeUsageBased:
 		usageBasedCharge, err := charge.AsUsageBasedCharge()
 		if err != nil {
 			return false
 		}
 
-		return !now.Before(usageBasedCharge.Intent.BaseLayer.ServicePeriod.From)
+		return !now.Before(usageBasedCharge.Intent.GetEffectiveServicePeriod().From)
 	default:
 		return false
 	}

--- a/openmeter/ledger/customerbalance/service_test.go
+++ b/openmeter/ledger/customerbalance/service_test.go
@@ -283,9 +283,9 @@ func TestImpactRealizedCreditsSkipsVoidedUsageBasedBillingHistory(t *testing.T) 
 
 	impact, err := NewImpact(charges.NewCharge(usagebased.Charge{
 		ChargeBase: usagebased.ChargeBase{
-			Intent: usagebased.OverridableIntent{
+			Intent: usagebased.Intent{
 				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
-			},
+			}.AsOverridableIntent(),
 		},
 		Realizations: usagebased.RealizationRuns{
 			{
@@ -337,9 +337,9 @@ func TestImpactRealizedCreditsSkipsVoidedUsageBasedBillingHistory(t *testing.T) 
 func TestImpactRealizedCreditsSkipsVoidedFlatFeeBillingHistory(t *testing.T) {
 	impact, err := NewImpact(charges.NewCharge(flatfee.Charge{
 		ChargeBase: flatfee.ChargeBase{
-			Intent: flatfee.OverridableIntent{
+			Intent: flatfee.Intent{
 				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
-			},
+			}.AsOverridableIntent(),
 		},
 		Realizations: flatfee.Realizations{
 			CurrentRun: &flatfee.RealizationRun{

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -514,7 +514,7 @@ func (e *testEnv) advanceFlatFeeCharge(t *testing.T, charge flatfee.Charge) flat
 
 	chargeCustomerID := customer.CustomerID{
 		Namespace: charge.Namespace,
-		ID:        charge.Intent.CustomerID,
+		ID:        charge.Intent.GetCustomerID(),
 	}
 	require.Equal(t, e.CustomerID, chargeCustomerID, "charge scope differs from test env scope")
 
@@ -528,7 +528,7 @@ func (e *testEnv) advanceFlatFeeCharge(t *testing.T, charge flatfee.Charge) flat
 	})
 	require.NoError(t, err)
 	require.Len(t, latestCharges, 1)
-	require.Equal(t, e.CustomerID.ID, latestCharges[0].Intent.CustomerID, "persisted charge customer differs from test env customer")
+	require.Equal(t, e.CustomerID.ID, latestCharges[0].Intent.GetCustomerID(), "persisted charge customer differs from test env customer")
 	require.Equal(t, e.Namespace, latestCharges[0].Namespace, "persisted charge namespace differs from test env namespace")
 
 	advancedCharge, err := e.flatFeeService.AdvanceCharge(t.Context(), flatfee.AdvanceChargeInput{

--- a/openmeter/ledger/customerbalance/transactions.go
+++ b/openmeter/ledger/customerbalance/transactions.go
@@ -400,9 +400,11 @@ func chargeDisplayMetadataFromCharge(charge charges.Charge) (chargeDisplayMetada
 			return chargeDisplayMetadata{}, fmt.Errorf("map flat fee charge: %w", err)
 		}
 
+		intent := flatFeeCharge.Intent.GetEffectiveMetaIntentMutableFields()
+
 		return chargeDisplayMetadata{
-			Name:        flatFeeCharge.Intent.BaseLayer.Name,
-			Description: flatFeeCharge.Intent.BaseLayer.Description,
+			Name:        intent.Name,
+			Description: intent.Description,
 		}, nil
 	case meta.ChargeTypeUsageBased:
 		usageBasedCharge, err := charge.AsUsageBasedCharge()
@@ -410,9 +412,11 @@ func chargeDisplayMetadataFromCharge(charge charges.Charge) (chargeDisplayMetada
 			return chargeDisplayMetadata{}, fmt.Errorf("map usage based charge: %w", err)
 		}
 
+		intent := usageBasedCharge.Intent.GetEffectiveMetaIntentMutableFields()
+
 		return chargeDisplayMetadata{
-			Name:        usageBasedCharge.Intent.BaseLayer.Name,
-			Description: usageBasedCharge.Intent.BaseLayer.Description,
+			Name:        intent.Name,
+			Description: intent.Description,
 		}, nil
 	case meta.ChargeTypeCreditPurchase:
 		creditPurchaseCharge, err := charge.AsCreditPurchaseCharge()

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -598,7 +598,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceCreatePatchCrea
 		flatFeeCharge, err := result.Items[0].AsFlatFeeCharge()
 		s.NoError(err)
 		s.Equal(flatfee.StatusCreated, flatFeeCharge.Status)
-		s.Equal(productcatalog.CreditThenInvoiceSettlementMode, flatFeeCharge.Intent.SettlementMode)
+		s.Equal(productcatalog.CreditThenInvoiceSettlementMode, flatFeeCharge.Intent.GetSettlementMode())
 
 		activeLines := s.mustGatheringLinesForCharge(ns, cust.ID, flatFeeCharge.ID, false)
 		s.Len(activeLines, 1)
@@ -2838,7 +2838,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkExtendPat
 		}))
 
 		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusCreated)
-		s.Equal(shrunkServicePeriodTo, charge.Intent.BaseLayer.ServicePeriod.To)
+		s.Equal(shrunkServicePeriodTo, charge.Intent.GetEffectiveServicePeriod().To)
 		shrunkAmount, err := alpacadecimal.NewFromString("63.05")
 		s.NoError(err)
 		s.AssertDecimalEqual(shrunkAmount, charge.State.AmountAfterProration, "charge state amount should be prorated for the shrunk period")
@@ -2864,7 +2864,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkExtendPat
 		s.mustExtendChargeWithInvoiceAt(ctx, cust.GetID(), flatFeeChargeID, extendedServicePeriodTo, extendedInvoiceAt)
 
 		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusCreated)
-		s.Equal(extendedServicePeriodTo, charge.Intent.BaseLayer.ServicePeriod.To)
+		s.Equal(extendedServicePeriodTo, charge.Intent.GetEffectiveServicePeriod().To)
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(120), charge.State.AmountAfterProration, "extension past full period should not exceed the full flat fee amount")
 
 		activeLine := s.mustSingleActiveGatheringLineForCharge(ns, cust.ID, flatFeeChargeID.ID)
@@ -3344,7 +3344,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceImmutableShrink
 		s.Equal(runID, charge.Realizations.CurrentRun.ID)
 		s.Equal(lineID.ID, lo.FromPtr(charge.Realizations.CurrentRun.LineID))
 		s.Equal(flatfee.RealizationRunTypeInvalidDueToUnsupportedCreditNote, charge.Realizations.CurrentRun.Type)
-		s.Equal(firstShrinkTo, charge.Intent.BaseLayer.ServicePeriod.To)
+		s.Equal(firstShrinkTo, charge.Intent.GetEffectiveServicePeriod().To)
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(15), charge.State.AmountAfterProration, "amount after proration")
 		run, err := charge.Realizations.GetByLineID(lineID.ID)
 		s.NoError(err)
@@ -3378,7 +3378,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceImmutableShrink
 		extendedCharge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusFinal)
 		s.Require().NotNil(extendedCharge.Realizations.CurrentRun)
 		s.Equal(runID, extendedCharge.Realizations.CurrentRun.ID)
-		s.Equal(servicePeriod, extendedCharge.Intent.BaseLayer.ServicePeriod)
+		s.Equal(servicePeriod, extendedCharge.Intent.GetEffectiveServicePeriod())
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(31), extendedCharge.State.AmountAfterProration, "extended amount after proration")
 		s.Empty(s.mustGatheringLinesForCharge(ns, cust.ID, flatFeeChargeID.ID, false))
 
@@ -3399,7 +3399,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceImmutableShrink
 		shrunkCharge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusFinal)
 		s.Require().NotNil(shrunkCharge.Realizations.CurrentRun)
 		s.Equal(runID, shrunkCharge.Realizations.CurrentRun.ID)
-		s.Equal(secondShrinkTo, shrunkCharge.Intent.BaseLayer.ServicePeriod.To)
+		s.Equal(secondShrinkTo, shrunkCharge.Intent.GetEffectiveServicePeriod().To)
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(19), shrunkCharge.State.AmountAfterProration, "shrunk amount after proration")
 		run, err := shrunkCharge.Realizations.GetByLineID(lineID.ID)
 		s.NoError(err)
@@ -3501,10 +3501,10 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchU
 
 		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusCreated)
 		s.Equal(usageBasedChargeID.ID, charge.ID)
-		s.Equal(extendedServicePeriodTo, charge.Intent.BaseLayer.ServicePeriod.To)
-		s.Equal(extendedServicePeriodTo, charge.Intent.BaseLayer.FullServicePeriod.To)
-		s.Equal(extendedServicePeriodTo, charge.Intent.BaseLayer.BillingPeriod.To)
-		s.Equal(extendedInvoiceAt, charge.Intent.BaseLayer.InvoiceAt)
+		s.Equal(extendedServicePeriodTo, charge.Intent.GetEffectiveServicePeriod().To)
+		s.Equal(extendedServicePeriodTo, charge.Intent.GetEffectiveIntent().FullServicePeriod.To)
+		s.Equal(extendedServicePeriodTo, charge.Intent.GetEffectiveIntent().BillingPeriod.To)
+		s.Equal(extendedInvoiceAt, charge.Intent.GetEffectiveIntent().InvoiceAt)
 
 		activeLine := s.mustSingleActiveGatheringLineForCharge(ns, cust.ID, usageBasedChargeID.ID)
 		s.Equal(gatheringLineID, activeLine.ID)
@@ -3616,9 +3616,9 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkPatchU
 
 		charge := s.RequireUsageBasedChargeStatus(usageBasedChargeID, usagebased.StatusCreated)
 		s.Equal(usageBasedChargeID.ID, charge.ID)
-		s.Equal(shrunkServicePeriodTo, charge.Intent.BaseLayer.ServicePeriod.To)
-		s.Equal(shrunkServicePeriodTo, charge.Intent.BaseLayer.FullServicePeriod.To)
-		s.Equal(shrunkServicePeriodTo, charge.Intent.BaseLayer.BillingPeriod.To)
+		s.Equal(shrunkServicePeriodTo, charge.Intent.GetEffectiveServicePeriod().To)
+		s.Equal(shrunkServicePeriodTo, charge.Intent.GetEffectiveIntent().FullServicePeriod.To)
+		s.Equal(shrunkServicePeriodTo, charge.Intent.GetEffectiveIntent().BillingPeriod.To)
 
 		activeLine := s.mustSingleActiveGatheringLineForCharge(ns, cust.ID, usageBasedChargeID.ID)
 		s.Equal(gatheringLineID, activeLine.ID)
@@ -3817,7 +3817,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchD
 		s.Nil(charge.State.CurrentRealizationRunID)
 		s.Require().NotNil(charge.State.AdvanceAfter)
 		s.True(charge.State.AdvanceAfter.Equal(extendedServicePeriodTo), "advance after should match the extended service-period end")
-		s.True(charge.Intent.BaseLayer.ServicePeriod.To.Equal(extendedServicePeriodTo), "service-period end should match the extension")
+		s.True(charge.Intent.GetEffectiveServicePeriod().To.Equal(extendedServicePeriodTo), "service-period end should match the extension")
 
 		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
 		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "aggregate open receivable should stay empty")
@@ -4004,7 +4004,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkPatchD
 		s.Nil(charge.State.CurrentRealizationRunID)
 		s.Require().NotNil(charge.State.AdvanceAfter)
 		s.True(charge.State.AdvanceAfter.Equal(shrunkServicePeriodTo), "advance after should match the shrunk service-period end")
-		s.True(charge.Intent.BaseLayer.ServicePeriod.To.Equal(shrunkServicePeriodTo), "service-period end should match the shrink")
+		s.True(charge.Intent.GetEffectiveServicePeriod().To.Equal(shrunkServicePeriodTo), "service-period end should match the shrink")
 
 		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
 		s.AssertDecimalEqual(alpacadecimal.Zero, s.MustCustomerReceivableBalance(cust.GetID(), USD, mo.None[*alpacadecimal.Decimal](), ledger.TransactionAuthorizationStatusOpen), "aggregate open receivable should stay empty")
@@ -4679,7 +4679,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceExtendPatchD
 		s.Nil(charge.State.CurrentRealizationRunID)
 		s.Require().NotNil(charge.State.AdvanceAfter)
 		s.True(charge.State.AdvanceAfter.Equal(extendedServicePeriodTo), "advance after should match the extended service-period end")
-		s.True(charge.Intent.BaseLayer.ServicePeriod.To.Equal(extendedServicePeriodTo), "service-period end should match the extension")
+		s.True(charge.Intent.GetEffectiveServicePeriod().To.Equal(extendedServicePeriodTo), "service-period end should match the extension")
 		s.Len(charge.Realizations, 1)
 		s.Equal(usagebased.RealizationRunTypePartialInvoice, charge.Realizations[0].Type)
 
@@ -4967,7 +4967,7 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedCreditThenInvoiceShrinkExtend
 			meta.ExpandDeletedRealizations,
 		})
 		s.Equal(usagebased.StatusActive, charge.Status)
-		s.Equal(secondShrinkTo, charge.Intent.BaseLayer.ServicePeriod.To)
+		s.Equal(secondShrinkTo, charge.Intent.GetEffectiveServicePeriod().To)
 		s.Len(charge.Realizations, 2)
 
 		firstRun, err := charge.Realizations.GetByID(firstRunID.ID)

--- a/test/credits/rating_test.go
+++ b/test/credits/rating_test.go
@@ -110,9 +110,9 @@ func (s *RatingTestSuite) TestListChargesExpandsRealtimeUsageForMultipleUsageBas
 		s.NoError(err)
 
 		s.NotNil(charge.Expands.RealtimeUsage)
-		s.NotNil(charge.Intent.UniqueReferenceID)
-		realtimeByReference[*charge.Intent.UniqueReferenceID] = charge.Expands.RealtimeUsage.Total
-		bookedByReference[*charge.Intent.UniqueReferenceID] = charge.Realizations.Sum().Total
+		s.NotNil(charge.Intent.GetUniqueReferenceID())
+		realtimeByReference[*charge.Intent.GetUniqueReferenceID()] = charge.Expands.RealtimeUsage.Total
+		bookedByReference[*charge.Intent.GetUniqueReferenceID()] = charge.Realizations.Sum().Total
 	}
 
 	s.True(alpacadecimal.NewFromInt(7).Equal(realtimeByReference[standardRateReference]))

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -3132,7 +3132,7 @@ func (s *SanitySuite) TestFlatFeeCreditOnlyTaxConfigFlowsToEarnings() {
 	advancedCharge, err := advancedCharges[0].AsFlatFeeCharge()
 	s.NoError(err)
 	s.Equal(flatfee.StatusFinal, advancedCharge.Status)
-	s.requireChargeTaxConfig(advancedCharge.Intent.BaseLayer.TaxConfig, tc.ID, productcatalog.InclusiveTaxBehavior)
+	s.requireChargeTaxConfig(advancedCharge.Intent.GetEffectiveTaxConfig(), tc.ID, productcatalog.InclusiveTaxBehavior)
 	s.Require().NotNil(advancedCharge.Realizations.CurrentRun)
 	s.Len(advancedCharge.Realizations.CurrentRun.CreditRealizations, 1)
 
@@ -3235,7 +3235,7 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceTaxConfigFlowsToEarnings() {
 	finalCharge, err := s.MustGetChargeByID(chargeID).AsFlatFeeCharge()
 	s.NoError(err)
 	s.Equal(flatfee.StatusFinal, finalCharge.Status)
-	s.requireChargeTaxConfig(finalCharge.Intent.BaseLayer.TaxConfig, tc.ID, productcatalog.InclusiveTaxBehavior)
+	s.requireChargeTaxConfig(finalCharge.Intent.GetEffectiveTaxConfig(), tc.ID, productcatalog.InclusiveTaxBehavior)
 
 	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
 	s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
@@ -3342,7 +3342,7 @@ func (s *SanitySuite) TestUsageBasedCreditOnlyTaxConfigFlowsToEarnings() {
 	advancedCharge, err = advancedCharges[0].AsUsageBasedCharge()
 	s.NoError(err)
 	s.Equal(usagebased.StatusFinal, advancedCharge.Status)
-	s.requireChargeTaxConfig(advancedCharge.Intent.BaseLayer.TaxConfig, tc.ID, productcatalog.InclusiveTaxBehavior)
+	s.requireChargeTaxConfig(advancedCharge.Intent.GetEffectiveTaxConfig(), tc.ID, productcatalog.InclusiveTaxBehavior)
 	s.Len(advancedCharge.Realizations, 1)
 	s.Len(advancedCharge.Realizations[0].CreditsAllocated, 1)
 
@@ -3453,7 +3453,7 @@ func (s *SanitySuite) TestUsageBasedCreditThenInvoiceTaxConfigFlowsToEarnings() 
 	finalCharge, err := s.MustGetChargeByID(chargeID).AsUsageBasedCharge()
 	s.NoError(err)
 	s.Equal(usagebased.StatusFinal, finalCharge.Status)
-	s.requireChargeTaxConfig(finalCharge.Intent.BaseLayer.TaxConfig, tc.ID, productcatalog.InclusiveTaxBehavior)
+	s.requireChargeTaxConfig(finalCharge.Intent.GetEffectiveTaxConfig(), tc.ID, productcatalog.InclusiveTaxBehavior)
 
 	ledgerTaxBehavior := ledger.TaxBehaviorInclusive
 	s.Equal(float64(amount), s.MustCustomerAccruedBalanceForTaxConfig(cust.GetID(), USD, mo.Some(&invoiceCostBasis), mo.Some(&tc.ID), mo.Some(&ledgerTaxBehavior)).InexactFloat64())
@@ -3851,8 +3851,8 @@ func (s *SanitySuite) TestChargeIntentTaxBehaviorFlowsToAdvanceAccrualCreditOnly
 	advancedCharge, err := advancedCharges[0].AsFlatFeeCharge()
 	s.NoError(err)
 	s.Equal(flatfee.StatusFinal, advancedCharge.Status)
-	s.Require().NotNil(advancedCharge.Intent.BaseLayer.TaxConfig.Behavior)
-	s.Equal(productcatalog.InclusiveTaxBehavior, *advancedCharge.Intent.BaseLayer.TaxConfig.Behavior)
+	s.Require().NotNil(advancedCharge.Intent.GetEffectiveTaxConfig().Behavior)
+	s.Equal(productcatalog.InclusiveTaxBehavior, *advancedCharge.Intent.GetEffectiveTaxConfig().Behavior)
 	s.Require().NotNil(advancedCharge.Realizations.CurrentRun)
 	s.Len(advancedCharge.Realizations.CurrentRun.CreditRealizations, 1)
 
@@ -3965,8 +3965,8 @@ func (s *SanitySuite) TestChargeIntentTaxConfigOverridesFundingTaxCodeCreditOnly
 		s.Equal(flatfee.StatusFinal, advancedCharge.Status)
 
 		// Charge entity preserves Intent.TaxConfig=B (metadata survives)
-		s.Require().NotEmpty(advancedCharge.Intent.BaseLayer.TaxConfig.TaxCodeID)
-		s.Equal(taxB.ID, advancedCharge.Intent.BaseLayer.TaxConfig.TaxCodeID)
+		s.Require().NotEmpty(advancedCharge.Intent.GetEffectiveTaxConfig().TaxCodeID)
+		s.Equal(taxB.ID, advancedCharge.Intent.GetEffectiveTaxConfig().TaxCodeID)
 
 		nilCostBasis := alpacadecimal.Zero
 		s.Equal(float64(0), s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&nilCostBasis), ledger.DefaultCustomerFBOPriority).InexactFloat64(),
@@ -3991,7 +3991,7 @@ func (s *SanitySuite) TestChargeIntentTaxConfigOverridesFundingTaxCodeCreditOnly
 	})
 }
 
-// TestTaxCodeFlowsFromInvoicedChargeToAccrued verifies that charge.Intent.BaseLayer.TaxConfig
+// TestTaxCodeFlowsFromInvoicedChargeToAccrued verifies that charge.Intent.GetEffectiveTaxConfig()
 // flows through the credit-then-invoice path: accrual → payment authorization →
 // settlement. Receivable and accrued buckets must reconcile cleanly within the
 // TaxCode-keyed routes.


### PR DESCRIPTION
## Summary

Introduces explicit intent layering for flat-fee and usage-based charges so the persisted subscription/base intent can coexist with a customer-facing override layer.

## Domain Rules

- Flat-fee and usage-based charges now expose overridable intents with a base layer and optional override layer.
- Customer-facing and ledger-facing paths should read effective intent values through field-specific getters.
- Subscription sync and adapter persistence should keep targeting the base intent so API overrides do not feed back into subscription-owned state.
- `GetEffectiveIntent()` remains available for mapping boundaries, but field-specific getters are preferred when only a few values are needed.

## Notes

- Updates charge service, adapter, API mapping, ledger adapter, and subscription-sync call sites to use the intended base/effective access pattern.
- Updates the billing and charges skills with the new intent-layering guidance.

## Validation

- `make lint`
- `make test-nocache`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Billing charges now consistently derive customer, currency, settlement mode, service periods, invoice timing, tax, discounts, and feature metadata from effective intent values across invoices, credits, previews, rating, allocation, and ledger postings.
  * Improved charge override and charge deletion behavior, including subscription item ID updates and more reliable reconciliation/repair for subscription sync persisted state.
  * Updated API charge conversion to use effective intent details for flat-fee and usage-based charges.
* **Documentation**
  * Refreshed guidance on “base intent” vs “effective intent” usage for charge-backed subscription sync state and intent layer access rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->