### PR TITLE
feat: subscription sync patch targeting

### DIFF
--- a/.agents/skills/billing/SKILL.md
+++ b/.agents/skills/billing/SKILL.md
@@ -202,6 +202,8 @@ The same registry also owns the single `CreateLineRouter`. Billing's default rou
 - `ChangeSourceAPIRequest`: user/API-originated line edits. Billing diffs the original invoice against the edited invoice with `diffMutableInvoiceLines`, applies API edits through line engines with `applyAPIInvoiceLineEdits`, and rebuilds the invoice from unchanged lines plus line-engine outputs.
 - `ChangeSourceSystem`: system-originated edits from billing/charges/subscription sync. Billing still computes the line diff, but does not invoke API create/update callbacks. For standard invoices only, deleted lines are dispatched through `OnMutableStandardLinesDeletedBySystem` because charge line updaters currently rely on that cleanup notification. Gathering invoices do not emit system delete callbacks.
 
+Subscription-sync charge patches can update or delete invoice lines as a side effect of reconciling charges. Those invoice updates must use `ChangeSourceSystem`: API edit callbacks are for user-initiated invoice-line edits, while system deletes use `OnMutableStandardLinesDeletedBySystem` so charge line engines can clean up detached line-backed runs.
+
 The API edit path treats the diff as the owner of invoice lines while engines run:
 
 - `applyAPIInvoiceLineEdits` clones the edited invoice and calls `UnsetLines()` before line-engine dispatch so the edited invoice is only the header/context, not a competing source of line truth.

--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -116,6 +116,14 @@ Intent layer access rules:
 - Subscription sync and repair code targets subscription-owned source state. It should use `GetBaseIntent()` or base-specific helpers, not effective getters, so user/API overrides do not feed back into the subscription target state.
 - Adapter writes should persist the base intent with `GetBaseIntent()` and persist override fields only through the override-specific adapter paths. Do not derive base persistence values from effective intent accessors.
 
+Patch target rules:
+
+- Charge patch payloads (`PatchShrink`, `PatchExtend`, `PatchDelete`) must carry an explicit `meta.ChangeTarget`. Do not rely on a zero/default target.
+- Subscription sync emits patches against `meta.ChangeTargetBase` because it reconciles subscription-owned source state, not user/API overrides.
+- State machines should mutate the requested patch target, then reconcile customer-facing invoice artifacts from the effective intent. If a base-target patch hits a charge with an active override, updating the base layer should not rewrite effective invoice state.
+- Delete patches follow the same target rule: deleting the base layer while an override is active should mark the base intent deleted but leave the effective override-backed charge behavior intact.
+- Charge listing for subscription-sync persisted-state loading must filter on base-intent deletion state, not effective `DeletedAt`; otherwise an active override can hide a subscription-owned base charge that sync still needs to reconcile.
+
 ## Usage-Based Invoice Line Mapping
 
 Usage-based charge realization runs are not billing standard lines. When mapping a run back to `billing.StandardLine` in `openmeter/billing/charges/usagebased/service/linemapper.go`, preserve the billing-facing semantics:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -39,6 +39,16 @@ reviews:
 
         Only flag `AdvanceAfter` if the specific code path demonstrably persists an invalid value or violates an explicit flat-fee domain invariant in the current diff.
 
+    - path: "openmeter/billing/charges/**/service/*.go"
+      instructions: |
+        For charge state-machine handlers in this path, do not claim that an in-memory mutation is not persisted until you trace the full patch execution and persistence flow in the current code.
+
+        When a handler is invoked from `service.TriggerPatch`, follow this call chain before raising a persistence finding: `service.TriggerPatch -> stateMachine.FireAndActivate -> chargestatemachine.Machine.FireAndActivate`.
+
+        In this flow, mutations made by the handler are persisted after the handler returns via `Persistence.UpdateBase(ctx, m.Charge.GetBase())`.
+
+        Before reporting that a mutation is "only in memory" or "not saved", verify whether the handler mutates the base/intent state that `UpdateBase(...)` persists. If that persistence path exists in reachable current code, omit the finding. If you cannot verify a missing persistence path from the diff and reachable current code, omit the finding.
+
     - path: "**/*.tsp"
       instructions: |
         Review the TypeSpec code for conformity with TypeSpec best practices. When recommending changes also consider the fact that multiple codegeneration toolchains depend on the TypeSpec code, each of which have their idiosyncrasies and bugs.

--- a/openmeter/billing/charges/adapter/search.go
+++ b/openmeter/billing/charges/adapter/search.go
@@ -53,7 +53,11 @@ func (a *adapter) ListCharges(ctx context.Context, input charges.ListChargesInpu
 			Where(dbchargessearchv1.Namespace(input.Namespace))
 
 		if !input.IncludeDeleted {
-			query = query.Where(dbchargessearchv1.DeletedAtIsNil())
+			if input.DeletedAtFilter == charges.ListChargesDeletedAtFilterBaseIntent {
+				query = query.Where(dbchargessearchv1.BaseIntentDeletedAtIsNil())
+			} else {
+				query = query.Where(dbchargessearchv1.DeletedAtIsNil())
+			}
 		}
 
 		if len(input.CustomerIDs) > 0 {

--- a/openmeter/billing/charges/adapter/search_test.go
+++ b/openmeter/billing/charges/adapter/search_test.go
@@ -85,7 +85,7 @@ func (s *ListCustomersToAdvanceSuite) createCustomer(namespace string) string {
 }
 
 // insertFlatFeeCharge inserts a minimal flat fee charge row for testing the search view.
-func (s *ListCustomersToAdvanceSuite) insertFlatFeeCharge(namespace, customerID string, status meta.ChargeStatus, advanceAfter *time.Time) {
+func (s *ListCustomersToAdvanceSuite) insertFlatFeeCharge(namespace, customerID string, status meta.ChargeStatus, advanceAfter *time.Time) string {
 	s.T().Helper()
 
 	now := time.Now().UTC().Truncate(time.Microsecond)
@@ -121,8 +121,62 @@ func (s *ListCustomersToAdvanceSuite) insertFlatFeeCharge(namespace, customerID 
 		create = create.SetAdvanceAfter(*advanceAfter)
 	}
 
-	_, err := create.Save(context.Background())
+	charge, err := create.Save(context.Background())
 	s.Require().NoError(err)
+
+	return charge.ID
+}
+
+func (s *ListCustomersToAdvanceSuite) TestListChargesDeletedAtFilter() {
+	ctx := s.T().Context()
+	ns := "test-list-charges-deleted-at-filter"
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	deletedAt := now.Add(time.Minute)
+
+	customerID := s.createCustomer(ns)
+
+	liveChargeID := s.insertFlatFeeCharge(ns, customerID, meta.ChargeStatusActive, nil)
+	overrideDeletedChargeID := s.insertFlatFeeCharge(ns, customerID, meta.ChargeStatusActive, nil)
+	baseDeletedChargeID := s.insertFlatFeeCharge(ns, customerID, meta.ChargeStatusActive, nil)
+
+	_, err := s.dbClient.ChargeFlatFee.UpdateOneID(overrideDeletedChargeID).
+		SetDeletedAt(deletedAt).
+		Save(ctx)
+	s.Require().NoError(err)
+
+	_, err = s.dbClient.ChargeFlatFee.UpdateOneID(baseDeletedChargeID).
+		SetDeletedAt(deletedAt).
+		SetIntentDeletedAt(deletedAt).
+		Save(ctx)
+	s.Require().NoError(err)
+
+	listIDs := func(input charges.ListChargesInput) []string {
+		s.T().Helper()
+
+		input.Namespace = ns
+		input.ChargeTypes = []meta.ChargeType{meta.ChargeTypeFlatFee}
+
+		result, err := s.adapter.ListCharges(ctx, input)
+		s.Require().NoError(err)
+
+		out := make([]string, 0, len(result.Items))
+		for _, item := range result.Items {
+			out = append(out, item.ID.ID)
+		}
+
+		return out
+	}
+
+	s.ElementsMatch([]string{liveChargeID}, listIDs(charges.ListChargesInput{}))
+	s.ElementsMatch([]string{liveChargeID}, listIDs(charges.ListChargesInput{
+		DeletedAtFilter: charges.ListChargesDeletedAtFilterEffective,
+	}))
+	s.ElementsMatch([]string{liveChargeID, overrideDeletedChargeID}, listIDs(charges.ListChargesInput{
+		DeletedAtFilter: charges.ListChargesDeletedAtFilterBaseIntent,
+	}))
+	s.ElementsMatch([]string{liveChargeID, overrideDeletedChargeID, baseDeletedChargeID}, listIDs(charges.ListChargesInput{
+		IncludeDeleted: true,
+	}))
 }
 
 func (s *ListCustomersToAdvanceSuite) TestReturnsOnlyEligibleCustomers() {

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/statelessx"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -26,10 +27,12 @@ type CreditThenInvoiceStateMachine struct {
 
 type periodPatch interface {
 	Op() meta.PatchType
+	GetTarget() meta.ChangeTarget
 	GetNewServicePeriodTo() time.Time
 	GetNewFullServicePeriodTo() time.Time
 	GetNewBillingPeriodTo() time.Time
 	GetNewInvoiceAt() time.Time
+	ValidateWith(meta.IntentMutableFields) error
 }
 
 var (
@@ -77,7 +80,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			flatfee.StatusActive,
 			statelessx.BoolFn(s.IsInsideServicePeriodAndNonZeroAmount),
 		).
-		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(s.AdvanceAfterServicePeriodFrom)
@@ -88,63 +91,77 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		// operational state.
 		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.IsZeroAmount)).
 		Permit(meta.TriggerFinalInvoiceCreated, flatfee.StatusActiveRealizationStarted).
-		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(s.AdvanceAfterServicePeriodTo)
 
 	s.Configure(flatfee.StatusActiveRealizationStarted).
 		Permit(meta.TriggerNext, flatfee.StatusActiveRealizationWaitingForCollection).
-		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnEntryFrom(meta.TriggerFinalInvoiceCreated, statelessx.WithParameters(s.StartRealization))
 
 	s.Configure(flatfee.StatusActiveRealizationWaitingForCollection).
 		Permit(meta.TriggerCollectionCompleted, flatfee.StatusActiveRealizationProcessing).
-		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge))
 
 	s.Configure(flatfee.StatusActiveRealizationProcessing).
 		Permit(meta.TriggerInvoiceIssued, flatfee.StatusActiveRealizationIssuing).
-		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge))
 
 	s.Configure(flatfee.StatusActiveRealizationIssuing).
 		Permit(meta.TriggerNext, flatfee.StatusActiveRealizationCompleted).
-		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
 		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.AccrueInvoiceUsage))
 
 	s.Configure(flatfee.StatusActiveRealizationCompleted).
 		Permit(meta.TriggerNext, flatfee.StatusActiveAwaitingPaymentSettlement).
-		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation))
 
 	s.Configure(flatfee.StatusActiveAwaitingPaymentSettlement).
 		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.AreAllPaymentsSettled)).
 		Permit(meta.TriggerAllPaymentsSettled, flatfee.StatusFinal, statelessx.BoolFn(s.AreAllPaymentsSettled)).
-		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge))
 
 	s.Configure(flatfee.StatusFinal).
-		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(s.ClearAdvanceAfter)
 
 	s.Configure(flatfee.StatusDeleted).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
-		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
-		OnEntry(statelessx.WithParameters(s.DeleteCharge))
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation))
 }
 
-func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, _ meta.PatchDeletePolicy) error {
+func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
+	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+		fields.IntentDeletedAt = lo.ToPtr(clock.Now())
+		return fields, nil
+	}); err != nil {
+		return fmt.Errorf("mutating %s intent deleted at: %w", patch.GetTarget(), err)
+	}
+
+	if patch.GetTarget() == meta.ChangeTargetBase && s.Charge.Intent.HasOverrideLayer() {
+		// Subscription sync targets the base intent. When an override is active,
+		// the customer-facing charge and invoice history remain owned by the override.
+		return nil
+	}
+
+	s.Charge.Status = flatfee.StatusDeleted
+
 	patches := []invoiceupdater.Patch{
 		invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID),
 	}
@@ -180,43 +197,57 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, _ meta
 }
 
 func (s *CreditThenInvoiceStateMachine) ExtendCharge(ctx context.Context, patch meta.PatchExtend) error {
-	if err := patch.ValidateWith(s.Charge.Intent.GetEffectiveMetaIntentMutableFields()); err != nil {
-		return fmt.Errorf("validate extend patch: %w", err)
-	}
-
 	invoicingStateInput, err := s.applyPeriodPatch(patch)
 	if err != nil {
 		return err
+	}
+
+	if !invoicingStateInput.ShouldReconcile {
+		return nil
 	}
 
 	return s.reconcileInvoicingState(ctx, invoicingStateInput)
 }
 
 func (s *CreditThenInvoiceStateMachine) ShrinkCharge(ctx context.Context, patch meta.PatchShrink) error {
-	if err := patch.ValidateWith(s.Charge.Intent.GetEffectiveMetaIntentMutableFields()); err != nil {
-		return fmt.Errorf("validate shrink patch: %w", err)
-	}
-
 	invoicingStateInput, err := s.applyPeriodPatch(patch)
 	if err != nil {
 		return err
+	}
+
+	if !invoicingStateInput.ShouldReconcile {
+		return nil
 	}
 
 	return s.reconcileInvoicingState(ctx, invoicingStateInput)
 }
 
 func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(patch periodPatch) (reconcileInvoicingStateInput, error) {
-	oldAmountAfterProration := s.Charge.State.AmountAfterProration
+	targetIntent, err := s.Charge.Intent.GetIntentForTarget(patch.GetTarget())
+	if err != nil {
+		return reconcileInvoicingStateInput{}, fmt.Errorf("getting %s intent: %w", patch.GetTarget(), err)
+	}
 
+	if err := patch.ValidateWith(targetIntent.IntentMutableFields.IntentMutableFields); err != nil {
+		return reconcileInvoicingStateInput{}, fmt.Errorf("validate %s patch: %w", patch.Op(), err)
+	}
 	intent := s.Charge.Intent
-	if err := intent.MutateEffective(func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+	if err := intent.Mutate(patch.GetTarget(), func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
 		fields.ServicePeriod.To = patch.GetNewServicePeriodTo()
 		fields.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
 		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
 		fields.InvoiceAt = patch.GetNewInvoiceAt()
 		return fields, nil
 	}); err != nil {
-		return reconcileInvoicingStateInput{}, fmt.Errorf("mutating effective intent: %w", err)
+		return reconcileInvoicingStateInput{}, fmt.Errorf("mutating %s intent: %w", patch.GetTarget(), err)
+	}
+
+	s.Charge.Intent = intent
+
+	if patch.GetTarget() == meta.ChangeTargetBase && s.Charge.Intent.HasOverrideLayer() {
+		// Subscription sync targets the base intent. When an override is active,
+		// the customer-facing invoice remains owned by the override layer.
+		return reconcileInvoicingStateInput{}, nil
 	}
 
 	amountAfterProration, err := intent.CalculateAmountAfterProration()
@@ -225,10 +256,11 @@ func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(patch periodPatch) (rec
 	}
 
 	return reconcileInvoicingStateInput{
+		ShouldReconcile:         true,
 		Op:                      patch.Op(),
 		Period:                  intent.GetEffectiveServicePeriod(),
 		Intent:                  intent,
-		OldAmountAfterProration: oldAmountAfterProration,
+		OldAmountAfterProration: s.Charge.State.AmountAfterProration,
 		NewAmountAfterProration: amountAfterProration,
 	}, nil
 }
@@ -304,6 +336,7 @@ func (s *CreditThenInvoiceStateMachine) AreAllPaymentsSettled() bool {
 }
 
 type reconcileInvoicingStateInput struct {
+	ShouldReconcile         bool
 	Op                      meta.PatchType
 	Period                  timeutil.ClosedPeriod
 	Intent                  flatfee.OverridableIntent

--- a/openmeter/billing/charges/flatfee/service/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/creditsonly.go
@@ -43,29 +43,26 @@ func NewCreditsOnlyStateMachine(config StateMachineConfig) (*CreditsOnlyStateMac
 func (s *CreditsOnlyStateMachine) configureStates() {
 	s.Configure(flatfee.StatusCreated).
 		Permit(meta.TriggerNext, flatfee.StatusActive, statelessx.BoolFn(s.IsInsideServicePeriod)).
-		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		OnActive(
 			s.AdvanceAfterServicePeriodFrom,
 		)
 
 	s.Configure(flatfee.StatusActive).
 		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.IsAfterInvoiceAt)).
-		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		OnActive(
 			s.AdvanceAfterInvoiceAt,
 		)
 
 	s.Configure(flatfee.StatusFinal).
-		Permit(meta.TriggerDelete, flatfee.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		OnActive(
 			statelessx.AllOf(
 				s.AllocateCredits,
 				s.ClearAdvanceAfter,
 			),
 		)
-
-	s.Configure(flatfee.StatusDeleted).
-		OnEntry(statelessx.WithParameters(s.DeleteCharge))
 }
 
 func (s *CreditsOnlyStateMachine) IsAfterInvoiceAt() bool {
@@ -118,8 +115,23 @@ func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {
 	return nil
 }
 
-func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, policy meta.PatchDeletePolicy) error {
-	if policy.CreditRefundPolicy == meta.CreditRefundPolicyCorrect && s.Charge.Realizations.CurrentRun != nil {
+func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
+	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+		fields.IntentDeletedAt = lo.ToPtr(clock.Now())
+		return fields, nil
+	}); err != nil {
+		return fmt.Errorf("mutating %s intent deleted at: %w", patch.GetTarget(), err)
+	}
+
+	if patch.GetTarget() == meta.ChangeTargetBase && s.Charge.Intent.HasOverrideLayer() {
+		// Subscription sync targets the base intent. When an override is active,
+		// customer-facing credit allocations remain owned by the override.
+		return nil
+	}
+
+	s.Charge.Status = flatfee.StatusDeleted
+
+	if patch.GetPolicy().CreditRefundPolicy == meta.CreditRefundPolicyCorrect && s.Charge.Realizations.CurrentRun != nil {
 		currencyCalculator, err := s.Charge.Intent.GetCurrency().Calculator()
 		if err != nil {
 			return fmt.Errorf("get currency calculator: %w", err)

--- a/openmeter/billing/charges/meta/patch.go
+++ b/openmeter/billing/charges/meta/patch.go
@@ -44,6 +44,7 @@ type Patch interface {
 	models.Validator
 
 	Op() PatchType
+	GetTarget() ChangeTarget
 	Trigger() stateless.Trigger
 	// Note: trigger params is any as stateless only support this as an input argument
 	TriggerParams() any

--- a/openmeter/billing/charges/meta/patchdelete.go
+++ b/openmeter/billing/charges/meta/patchdelete.go
@@ -16,13 +16,46 @@ var (
 )
 
 type PatchDelete struct {
+	target ChangeTarget
 	policy PatchDeletePolicy
 }
 
-func NewPatchDelete(policy PatchDeletePolicy) PatchDelete {
+type NewPatchDeleteInput struct {
+	Target ChangeTarget
+	Policy PatchDeletePolicy
+}
+
+func (i NewPatchDeleteInput) Validate() error {
+	var errs []error
+
+	if err := i.Target.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("target: %w", err))
+	}
+
+	if err := i.Policy.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("policy: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func NewPatchDelete(input NewPatchDeleteInput) (PatchDelete, error) {
+	if err := input.Validate(); err != nil {
+		return PatchDelete{}, err
+	}
+
 	var patch PatchDelete
-	patch.SetPolicy(policy)
-	return patch
+	patch.SetTarget(input.Target)
+	patch.SetPolicy(input.Policy)
+	return patch, nil
+}
+
+func (p *PatchDelete) SetTarget(target ChangeTarget) {
+	p.target = target
+}
+
+func (p PatchDelete) GetTarget() ChangeTarget {
+	return p.target
 }
 
 func (p *PatchDelete) SetPolicy(policy PatchDeletePolicy) {
@@ -42,11 +75,21 @@ func (p PatchDelete) Trigger() stateless.Trigger {
 }
 
 func (p PatchDelete) TriggerParams() any {
-	return p.GetPolicy()
+	return p
 }
 
 func (p PatchDelete) Validate() error {
-	return p.GetPolicy().Validate()
+	var errs []error
+
+	if err := p.GetTarget().Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("target: %w", err))
+	}
+
+	if err := p.GetPolicy().Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("policy: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 type CreditRefundPolicy string

--- a/openmeter/billing/charges/meta/patchextend.go
+++ b/openmeter/billing/charges/meta/patchextend.go
@@ -32,27 +32,29 @@ type NewPatchExtendInput struct {
 }
 
 func (i NewPatchExtendInput) Validate() error {
+	var errs []error
+
 	if err := i.Target.Validate(); err != nil {
-		return fmt.Errorf("target: %w", err)
+		errs = append(errs, fmt.Errorf("target: %w", err))
 	}
 
 	if i.NewServicePeriodTo.IsZero() {
-		return models.NewGenericValidationError(fmt.Errorf("new service period to is required"))
+		errs = append(errs, errors.New("new service period to is required"))
 	}
 
 	if i.NewFullServicePeriodTo.IsZero() {
-		return models.NewGenericValidationError(fmt.Errorf("new full service period to is required"))
+		errs = append(errs, errors.New("new full service period to is required"))
 	}
 
 	if i.NewBillingPeriodTo.IsZero() {
-		return models.NewGenericValidationError(fmt.Errorf("new billing period to is required"))
+		errs = append(errs, errors.New("new billing period to is required"))
 	}
 
 	if i.NewInvoiceAt.IsZero() {
-		return models.NewGenericValidationError(fmt.Errorf("new invoice at is required"))
+		errs = append(errs, errors.New("new invoice at is required"))
 	}
 
-	return nil
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 func NewPatchExtend(input NewPatchExtendInput) (PatchExtend, error) {
@@ -122,27 +124,29 @@ func (p PatchExtend) TriggerParams() any {
 }
 
 func (p PatchExtend) Validate() error {
+	var errs []error
+
 	if err := p.GetTarget().Validate(); err != nil {
-		return fmt.Errorf("target: %w", err)
+		errs = append(errs, fmt.Errorf("target: %w", err))
 	}
 
 	if p.GetNewServicePeriodTo().IsZero() {
-		return models.NewGenericValidationError(fmt.Errorf("new service period to is required"))
+		errs = append(errs, errors.New("new service period to is required"))
 	}
 
 	if p.GetNewFullServicePeriodTo().IsZero() {
-		return models.NewGenericValidationError(fmt.Errorf("new full service period to is required"))
+		errs = append(errs, errors.New("new full service period to is required"))
 	}
 
 	if p.GetNewBillingPeriodTo().IsZero() {
-		return models.NewGenericValidationError(fmt.Errorf("new billing period to is required"))
+		errs = append(errs, errors.New("new billing period to is required"))
 	}
 
 	if p.GetNewInvoiceAt().IsZero() {
-		return models.NewGenericValidationError(fmt.Errorf("new invoice at is required"))
+		errs = append(errs, errors.New("new invoice at is required"))
 	}
 
-	return nil
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
 func (p PatchExtend) ValidateWith(intent IntentMutableFields) error {

--- a/openmeter/billing/charges/meta/patchextend.go
+++ b/openmeter/billing/charges/meta/patchextend.go
@@ -16,6 +16,7 @@ var (
 )
 
 type PatchExtend struct {
+	target                 ChangeTarget
 	newServicePeriodTo     time.Time
 	newFullServicePeriodTo time.Time
 	newBillingPeriodTo     time.Time
@@ -23,6 +24,7 @@ type PatchExtend struct {
 }
 
 type NewPatchExtendInput struct {
+	Target                 ChangeTarget
 	NewServicePeriodTo     time.Time
 	NewFullServicePeriodTo time.Time
 	NewBillingPeriodTo     time.Time
@@ -30,6 +32,10 @@ type NewPatchExtendInput struct {
 }
 
 func (i NewPatchExtendInput) Validate() error {
+	if err := i.Target.Validate(); err != nil {
+		return fmt.Errorf("target: %w", err)
+	}
+
 	if i.NewServicePeriodTo.IsZero() {
 		return models.NewGenericValidationError(fmt.Errorf("new service period to is required"))
 	}
@@ -55,11 +61,20 @@ func NewPatchExtend(input NewPatchExtendInput) (PatchExtend, error) {
 	}
 
 	var patch PatchExtend
+	patch.SetTarget(input.Target)
 	patch.SetNewServicePeriodTo(input.NewServicePeriodTo)
 	patch.SetNewFullServicePeriodTo(input.NewFullServicePeriodTo)
 	patch.SetNewBillingPeriodTo(input.NewBillingPeriodTo)
 	patch.SetNewInvoiceAt(input.NewInvoiceAt)
 	return patch, nil
+}
+
+func (p *PatchExtend) SetTarget(v ChangeTarget) {
+	p.target = v
+}
+
+func (p PatchExtend) GetTarget() ChangeTarget {
+	return p.target
 }
 
 func (p *PatchExtend) SetNewServicePeriodTo(v time.Time) {
@@ -107,6 +122,10 @@ func (p PatchExtend) TriggerParams() any {
 }
 
 func (p PatchExtend) Validate() error {
+	if err := p.GetTarget().Validate(); err != nil {
+		return fmt.Errorf("target: %w", err)
+	}
+
 	if p.GetNewServicePeriodTo().IsZero() {
 		return models.NewGenericValidationError(fmt.Errorf("new service period to is required"))
 	}

--- a/openmeter/billing/charges/meta/patchextend_test.go
+++ b/openmeter/billing/charges/meta/patchextend_test.go
@@ -33,6 +33,16 @@ func TestPatchExtendValidateWith(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "rejects missing target",
+			patch: PatchExtend{
+				newServicePeriodTo:     intent.ServicePeriod.To.Add(time.Hour),
+				newFullServicePeriodTo: intent.FullServicePeriod.To,
+				newBillingPeriodTo:     intent.BillingPeriod.To,
+				newInvoiceAt:           intent.ServicePeriod.To.Add(time.Hour),
+			},
+			wantErr: true,
+		},
+		{
 			name: "allows service period extension with unchanged full service and billing periods",
 			patch: mustNewPatchExtend(t, NewPatchExtendInput{
 				Target:                 ChangeTargetBase,
@@ -99,6 +109,18 @@ func TestPatchExtendValidateWith(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestNewPatchExtendInputValidateRequiresTarget(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	_, err := NewPatchExtend(NewPatchExtendInput{
+		NewServicePeriodTo:     base.AddDate(0, 1, 0),
+		NewFullServicePeriodTo: base.AddDate(0, 1, 0),
+		NewBillingPeriodTo:     base.AddDate(0, 1, 0),
+		NewInvoiceAt:           base.AddDate(0, 1, 0),
+	})
+	require.Error(t, err)
 }
 
 func mustNewPatchExtend(t *testing.T, input NewPatchExtendInput) PatchExtend {

--- a/openmeter/billing/charges/meta/patchextend_test.go
+++ b/openmeter/billing/charges/meta/patchextend_test.go
@@ -35,6 +35,7 @@ func TestPatchExtendValidateWith(t *testing.T) {
 		{
 			name: "allows service period extension with unchanged full service and billing periods",
 			patch: mustNewPatchExtend(t, NewPatchExtendInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.To.Add(time.Hour),
 				NewFullServicePeriodTo: intent.FullServicePeriod.To,
 				NewBillingPeriodTo:     intent.BillingPeriod.To,
@@ -44,6 +45,7 @@ func TestPatchExtendValidateWith(t *testing.T) {
 		{
 			name: "rejects unchanged service period end",
 			patch: mustNewPatchExtend(t, NewPatchExtendInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.To,
 				NewFullServicePeriodTo: intent.FullServicePeriod.To,
 				NewBillingPeriodTo:     intent.BillingPeriod.To,
@@ -54,6 +56,7 @@ func TestPatchExtendValidateWith(t *testing.T) {
 		{
 			name: "rejects earlier service period end",
 			patch: mustNewPatchExtend(t, NewPatchExtendInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.To.Add(-time.Hour),
 				NewFullServicePeriodTo: intent.FullServicePeriod.To,
 				NewBillingPeriodTo:     intent.BillingPeriod.To,
@@ -64,6 +67,7 @@ func TestPatchExtendValidateWith(t *testing.T) {
 		{
 			name: "rejects earlier full service period end",
 			patch: mustNewPatchExtend(t, NewPatchExtendInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.To.Add(time.Hour),
 				NewFullServicePeriodTo: intent.FullServicePeriod.To.Add(-time.Hour),
 				NewBillingPeriodTo:     intent.BillingPeriod.To,
@@ -74,6 +78,7 @@ func TestPatchExtendValidateWith(t *testing.T) {
 		{
 			name: "rejects earlier billing period end",
 			patch: mustNewPatchExtend(t, NewPatchExtendInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.To.Add(time.Hour),
 				NewFullServicePeriodTo: intent.FullServicePeriod.To,
 				NewBillingPeriodTo:     intent.BillingPeriod.To.Add(-time.Hour),

--- a/openmeter/billing/charges/meta/patchshrink.go
+++ b/openmeter/billing/charges/meta/patchshrink.go
@@ -16,6 +16,7 @@ var (
 )
 
 type PatchShrink struct {
+	target                 ChangeTarget
 	newServicePeriodTo     time.Time
 	newFullServicePeriodTo time.Time
 	newBillingPeriodTo     time.Time
@@ -23,6 +24,7 @@ type PatchShrink struct {
 }
 
 type NewPatchShrinkInput struct {
+	Target                 ChangeTarget
 	NewServicePeriodTo     time.Time
 	NewFullServicePeriodTo time.Time
 	NewBillingPeriodTo     time.Time
@@ -30,6 +32,10 @@ type NewPatchShrinkInput struct {
 }
 
 func (i NewPatchShrinkInput) Validate() error {
+	if err := i.Target.Validate(); err != nil {
+		return fmt.Errorf("target: %w", err)
+	}
+
 	if i.NewServicePeriodTo.IsZero() {
 		return models.NewGenericValidationError(fmt.Errorf("new service period to is required"))
 	}
@@ -55,11 +61,20 @@ func NewPatchShrink(input NewPatchShrinkInput) (PatchShrink, error) {
 	}
 
 	var patch PatchShrink
+	patch.SetTarget(input.Target)
 	patch.SetNewServicePeriodTo(input.NewServicePeriodTo)
 	patch.SetNewFullServicePeriodTo(input.NewFullServicePeriodTo)
 	patch.SetNewBillingPeriodTo(input.NewBillingPeriodTo)
 	patch.SetNewInvoiceAt(input.NewInvoiceAt)
 	return patch, nil
+}
+
+func (p *PatchShrink) SetTarget(v ChangeTarget) {
+	p.target = v
+}
+
+func (p PatchShrink) GetTarget() ChangeTarget {
+	return p.target
 }
 
 func (p *PatchShrink) SetNewServicePeriodTo(v time.Time) {
@@ -107,6 +122,10 @@ func (p PatchShrink) TriggerParams() any {
 }
 
 func (p PatchShrink) Validate() error {
+	if err := p.GetTarget().Validate(); err != nil {
+		return fmt.Errorf("target: %w", err)
+	}
+
 	if p.GetNewServicePeriodTo().IsZero() {
 		return models.NewGenericValidationError(fmt.Errorf("new service period to is required"))
 	}

--- a/openmeter/billing/charges/meta/patchshrink_test.go
+++ b/openmeter/billing/charges/meta/patchshrink_test.go
@@ -35,6 +35,7 @@ func TestPatchShrinkValidateWith(t *testing.T) {
 		{
 			name: "allows service period shrink with unchanged full service and billing periods",
 			patch: mustNewPatchShrink(t, NewPatchShrinkInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.To.Add(-time.Hour),
 				NewFullServicePeriodTo: intent.FullServicePeriod.To,
 				NewBillingPeriodTo:     intent.BillingPeriod.To,
@@ -44,6 +45,7 @@ func TestPatchShrinkValidateWith(t *testing.T) {
 		{
 			name: "allows full service and billing period shrink",
 			patch: mustNewPatchShrink(t, NewPatchShrinkInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.To.Add(-time.Hour),
 				NewFullServicePeriodTo: intent.FullServicePeriod.To.Add(-time.Hour),
 				NewBillingPeriodTo:     intent.BillingPeriod.To.Add(-time.Hour),
@@ -53,6 +55,7 @@ func TestPatchShrinkValidateWith(t *testing.T) {
 		{
 			name: "rejects unchanged service period end",
 			patch: mustNewPatchShrink(t, NewPatchShrinkInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.To,
 				NewFullServicePeriodTo: intent.FullServicePeriod.To,
 				NewBillingPeriodTo:     intent.BillingPeriod.To,
@@ -63,6 +66,7 @@ func TestPatchShrinkValidateWith(t *testing.T) {
 		{
 			name: "rejects later service period end",
 			patch: mustNewPatchShrink(t, NewPatchShrinkInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.To.Add(time.Hour),
 				NewFullServicePeriodTo: intent.FullServicePeriod.To,
 				NewBillingPeriodTo:     intent.BillingPeriod.To,
@@ -73,6 +77,7 @@ func TestPatchShrinkValidateWith(t *testing.T) {
 		{
 			name: "rejects service period end at service period start",
 			patch: mustNewPatchShrink(t, NewPatchShrinkInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.From,
 				NewFullServicePeriodTo: intent.FullServicePeriod.To,
 				NewBillingPeriodTo:     intent.BillingPeriod.To,
@@ -83,6 +88,7 @@ func TestPatchShrinkValidateWith(t *testing.T) {
 		{
 			name: "rejects service period end before service period start",
 			patch: mustNewPatchShrink(t, NewPatchShrinkInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.From.Add(-time.Hour),
 				NewFullServicePeriodTo: intent.FullServicePeriod.To,
 				NewBillingPeriodTo:     intent.BillingPeriod.To,
@@ -93,6 +99,7 @@ func TestPatchShrinkValidateWith(t *testing.T) {
 		{
 			name: "rejects later full service period end",
 			patch: mustNewPatchShrink(t, NewPatchShrinkInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.To.Add(-time.Hour),
 				NewFullServicePeriodTo: intent.FullServicePeriod.To.Add(time.Hour),
 				NewBillingPeriodTo:     intent.BillingPeriod.To,
@@ -103,6 +110,7 @@ func TestPatchShrinkValidateWith(t *testing.T) {
 		{
 			name: "rejects full service period end at full service period start",
 			patch: mustNewPatchShrink(t, NewPatchShrinkInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.To.Add(-time.Hour),
 				NewFullServicePeriodTo: intent.FullServicePeriod.From,
 				NewBillingPeriodTo:     intent.BillingPeriod.To,
@@ -113,6 +121,7 @@ func TestPatchShrinkValidateWith(t *testing.T) {
 		{
 			name: "rejects later billing period end",
 			patch: mustNewPatchShrink(t, NewPatchShrinkInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.To.Add(-time.Hour),
 				NewFullServicePeriodTo: intent.FullServicePeriod.To,
 				NewBillingPeriodTo:     intent.BillingPeriod.To.Add(time.Hour),
@@ -123,6 +132,7 @@ func TestPatchShrinkValidateWith(t *testing.T) {
 		{
 			name: "rejects billing period end at billing period start",
 			patch: mustNewPatchShrink(t, NewPatchShrinkInput{
+				Target:                 ChangeTargetBase,
 				NewServicePeriodTo:     intent.ServicePeriod.To.Add(-time.Hour),
 				NewFullServicePeriodTo: intent.FullServicePeriod.To,
 				NewBillingPeriodTo:     intent.BillingPeriod.From,

--- a/openmeter/billing/charges/service.go
+++ b/openmeter/billing/charges/service.go
@@ -145,6 +145,22 @@ func (i AdvanceChargesInput) Validate() error {
 	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }
 
+type ListChargesDeletedAtFilter string
+
+const (
+	ListChargesDeletedAtFilterEffective  ListChargesDeletedAtFilter = "effective"
+	ListChargesDeletedAtFilterBaseIntent ListChargesDeletedAtFilter = "base_intent"
+)
+
+func (f ListChargesDeletedAtFilter) Validate() error {
+	switch f {
+	case "", ListChargesDeletedAtFilterEffective, ListChargesDeletedAtFilterBaseIntent:
+		return nil
+	default:
+		return fmt.Errorf("invalid value: %s", f)
+	}
+}
+
 type ListChargesInput struct {
 	pagination.Page
 
@@ -155,6 +171,9 @@ type ListChargesInput struct {
 	StatusIn        []meta.ChargeStatus
 	StatusNotIn     []meta.ChargeStatus
 	IncludeDeleted  bool
+	// DeletedAtFilter selects which deleted-at field is used when IncludeDeleted is false.
+	// Empty defaults to effective charge deletion.
+	DeletedAtFilter ListChargesDeletedAtFilter
 
 	// OrderBy is the field to sort by. Supported values: id, created_at,
 	// service_period.from, billing_period.from.
@@ -204,6 +223,10 @@ func (i ListChargesInput) Validate() error {
 
 	if len(i.StatusIn) > 0 && len(i.StatusNotIn) > 0 {
 		errs = append(errs, errors.New("status_in and status_not_in cannot be set at the same time"))
+	}
+
+	if err := i.DeletedAtFilter.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("deleted at filter: %w", err))
 	}
 
 	if err := i.Expands.Validate(); err != nil {

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -330,6 +330,7 @@ func runFlatFeeCreditThenInvoiceImmutableProrationScenario(s *BaseSuite, expectR
 		// when:
 		// - the charge is shrunk to a prorated amount
 		patch, err := meta.NewPatchShrink(meta.NewPatchShrinkInput{
+			Target:                 meta.ChangeTargetBase,
 			NewServicePeriodTo:     shrunkServicePeriodTo,
 			NewFullServicePeriodTo: servicePeriod.To,
 			NewBillingPeriodTo:     shrunkServicePeriodTo,

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -16,6 +16,7 @@ import (
 	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/statelessx"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
@@ -24,6 +25,26 @@ import (
 type CreditThenInvoiceStateMachine struct {
 	*stateMachine
 }
+
+type periodPatch interface {
+	Op() meta.PatchType
+	GetTarget() meta.ChangeTarget
+	GetNewServicePeriodTo() time.Time
+	GetNewFullServicePeriodTo() time.Time
+	GetNewBillingPeriodTo() time.Time
+	GetNewInvoiceAt() time.Time
+	ValidateWith(meta.IntentMutableFields) error
+}
+
+type applyPeriodPatchResult struct {
+	ShouldReconcile  bool
+	OldServicePeriod timeutil.ClosedPeriod
+}
+
+var (
+	_ periodPatch = meta.PatchExtend{}
+	_ periodPatch = meta.PatchShrink{}
+)
 
 func NewCreditThenInvoiceStateMachine(config StateMachineConfig) (*CreditThenInvoiceStateMachine, error) {
 	if err := config.Validate(); err != nil {
@@ -55,7 +76,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			usagebased.StatusActive,
 			statelessx.BoolFn(s.IsInsideServicePeriod),
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
@@ -74,7 +95,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			usagebased.StatusActiveFinalRealizationStarted,
 			statelessx.BoolFn(s.IsAfterServicePeriod),
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
@@ -98,7 +119,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			meta.TriggerNext,
 			usagebased.StatusActivePartialInvoiceWaitingForCollection,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnEntry(statelessx.WithParameters(s.StartPartialInvoiceRun))
@@ -113,7 +134,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			meta.TriggerCollectionCompleted,
 			usagebased.StatusActivePartialInvoiceProcessing,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(s.AdvanceAfterCollectionPeriodEnd)
@@ -128,7 +149,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			meta.TriggerInvoiceIssued,
 			usagebased.StatusActivePartialInvoiceIssuing,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
@@ -145,7 +166,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			meta.TriggerNext,
 			usagebased.StatusActivePartialInvoiceCompleted,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
 		OnEntryFrom(meta.TriggerInvoiceIssued, statelessx.WithParameters(s.FinalizeInvoiceRun))
@@ -155,7 +176,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			meta.TriggerNext,
 			usagebased.StatusActive,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation))
 
@@ -166,7 +187,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			meta.TriggerNext,
 			usagebased.StatusActiveFinalRealizationWaitingForCollection,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnEntry(statelessx.WithParameters(s.StartFinalInvoiceRun))
@@ -176,7 +197,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			meta.TriggerCollectionCompleted,
 			usagebased.StatusActiveFinalRealizationProcessing,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(s.AdvanceAfterCollectionPeriodEnd)
@@ -186,7 +207,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			meta.TriggerInvoiceIssued,
 			usagebased.StatusActiveFinalRealizationIssuing,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
@@ -198,7 +219,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			meta.TriggerNext,
 			usagebased.StatusActiveFinalRealizationCompleted,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		// Extend is rejected while invoice-issued callbacks own this state.
 		// Subscription sync can retry after billing advances the charge.
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
@@ -210,7 +231,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 			meta.TriggerNext,
 			usagebased.StatusActiveAwaitingPaymentSettlement,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		// Extend is rejected because this branch still has its own next
 		// transition to payment settlement. Subscription sync can retry.
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.UnsupportedExtendOperation)).
@@ -220,21 +241,35 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 
 	s.Configure(usagebased.StatusActiveAwaitingPaymentSettlement).
 		Permit(meta.TriggerAllPaymentsSettled, usagebased.StatusFinal, statelessx.BoolFn(s.AreAllInvoicedRunsSettled)).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge))
 
 	s.Configure(usagebased.StatusFinal).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge))
 
 	s.Configure(usagebased.StatusDeleted).
-		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation)).
-		OnEntry(statelessx.WithParameters(s.DeleteCharge))
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.UnsupportedShrinkOperation))
 }
 
-func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, _ meta.PatchDeletePolicy) error {
+func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
+	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+		fields.IntentDeletedAt = lo.ToPtr(clock.Now())
+		return fields, nil
+	}); err != nil {
+		return fmt.Errorf("mutating %s intent deleted at: %w", patch.GetTarget(), err)
+	}
+
+	if patch.GetTarget() == meta.ChangeTargetBase && s.Charge.Intent.HasOverrideLayer() {
+		// Subscription sync targets the base intent. When an override is active,
+		// customer-facing invoice/run state remains owned by the override layer.
+		return nil
+	}
+
+	s.Charge.Status = usagebased.StatusDeleted
+
 	patches := []invoiceupdater.Patch{
 		invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID),
 	}
@@ -273,23 +308,16 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, _ meta
 }
 
 func (s *CreditThenInvoiceStateMachine) ExtendCharge(ctx context.Context, patch meta.PatchExtend) error {
-	if err := patch.ValidateWith(s.Charge.Intent.GetEffectiveMetaIntentMutableFields()); err != nil {
-		return fmt.Errorf("validate extend patch: %w", err)
+	patchResult, err := s.applyPeriodPatch(patch)
+	if err != nil {
+		return err
 	}
 
-	oldServicePeriod := meta.NormalizeClosedPeriod(s.Charge.Intent.GetEffectiveServicePeriod())
-
-	if err := s.Charge.Intent.MutateEffective(func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
-		fields.ServicePeriod.To = patch.GetNewServicePeriodTo()
-		fields.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
-		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
-		fields.InvoiceAt = patch.GetNewInvoiceAt()
-		return fields, nil
-	}); err != nil {
-		return fmt.Errorf("mutating effective intent: %w", err)
+	if !patchResult.ShouldReconcile {
+		return nil
 	}
 
-	newGatheringLinePeriod, err := s.handleFinalRunOnExtend(ctx, oldServicePeriod)
+	newGatheringLinePeriod, err := s.handleFinalRunOnExtend(ctx, patchResult.OldServicePeriod)
 	if err != nil {
 		return fmt.Errorf("handling final run on extend: %w", err)
 	}
@@ -317,18 +345,13 @@ func (s *CreditThenInvoiceStateMachine) ExtendCharge(ctx context.Context, patch 
 }
 
 func (s *CreditThenInvoiceStateMachine) ShrinkCharge(_ context.Context, patch meta.PatchShrink) error {
-	if err := patch.ValidateWith(s.Charge.Intent.GetEffectiveMetaIntentMutableFields()); err != nil {
-		return fmt.Errorf("validate shrink patch: %w", err)
+	patchResult, err := s.applyPeriodPatch(patch)
+	if err != nil {
+		return err
 	}
 
-	if err := s.Charge.Intent.MutateEffective(func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
-		fields.ServicePeriod.To = patch.GetNewServicePeriodTo()
-		fields.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
-		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
-		fields.InvoiceAt = patch.GetNewInvoiceAt()
-		return fields, nil
-	}); err != nil {
-		return fmt.Errorf("mutating effective intent: %w", err)
+	if !patchResult.ShouldReconcile {
+		return nil
 	}
 
 	if err := s.handleRunsOnShrink(); err != nil {
@@ -336,6 +359,40 @@ func (s *CreditThenInvoiceStateMachine) ShrinkCharge(_ context.Context, patch me
 	}
 
 	return nil
+}
+
+func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(patch periodPatch) (applyPeriodPatchResult, error) {
+	targetIntent, err := s.Charge.Intent.GetIntentForTarget(patch.GetTarget())
+	if err != nil {
+		return applyPeriodPatchResult{}, fmt.Errorf("getting %s intent: %w", patch.GetTarget(), err)
+	}
+
+	if err := patch.ValidateWith(targetIntent.IntentMutableFields.IntentMutableFields); err != nil {
+		return applyPeriodPatchResult{}, fmt.Errorf("validate %s patch: %w", patch.Op(), err)
+	}
+
+	oldServicePeriod := meta.NormalizeClosedPeriod(targetIntent.IntentMutableFields.ServicePeriod)
+
+	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+		fields.ServicePeriod.To = patch.GetNewServicePeriodTo()
+		fields.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
+		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
+		fields.InvoiceAt = patch.GetNewInvoiceAt()
+		return fields, nil
+	}); err != nil {
+		return applyPeriodPatchResult{}, fmt.Errorf("mutating %s intent: %w", patch.GetTarget(), err)
+	}
+
+	if patch.GetTarget() == meta.ChangeTargetBase && s.Charge.Intent.HasOverrideLayer() {
+		// Subscription sync targets the base intent. When an override is active,
+		// customer-facing invoice/run state remains owned by the override layer.
+		return applyPeriodPatchResult{}, nil
+	}
+
+	return applyPeriodPatchResult{
+		ShouldReconcile:  true,
+		OldServicePeriod: oldServicePeriod,
+	}, nil
 }
 
 func (s *CreditThenInvoiceStateMachine) UnsupportedExtendOperation(_ context.Context, _ meta.PatchExtend) error {

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -55,6 +55,7 @@ func TestUnsupportedExtendOperationIsConfiguredForFinalRealizationBoundary(t *te
 		t.Run(string(status), func(t *testing.T) {
 			machine := newCreditThenInvoiceStateMachineForTest(t, status)
 			patch, err := meta.NewPatchExtend(meta.NewPatchExtendInput{
+				Target:                 meta.ChangeTargetBase,
 				NewServicePeriodTo:     time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC),
 				NewFullServicePeriodTo: time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC),
 				NewBillingPeriodTo:     time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC),
@@ -117,6 +118,7 @@ func TestUnsupportedShrinkOperationIsConfiguredForImmutableBoundaries(t *testing
 		t.Run(string(status), func(t *testing.T) {
 			machine := newCreditThenInvoiceStateMachineForTest(t, status)
 			patch, err := meta.NewPatchShrink(meta.NewPatchShrinkInput{
+				Target:                 meta.ChangeTargetBase,
 				NewServicePeriodTo:     time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
 				NewFullServicePeriodTo: time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
 				NewBillingPeriodTo:     time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
@@ -384,6 +386,7 @@ func mustNewPatchShrink(t *testing.T, newServicePeriodTo time.Time) meta.PatchSh
 	t.Helper()
 
 	patch, err := meta.NewPatchShrink(meta.NewPatchShrinkInput{
+		Target:                 meta.ChangeTargetBase,
 		NewServicePeriodTo:     newServicePeriodTo,
 		NewFullServicePeriodTo: newServicePeriodTo,
 		NewBillingPeriodTo:     newServicePeriodTo,

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
@@ -12,6 +13,7 @@ import (
 	usagebasedrating "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/rating"
 	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/statelessx"
 )
 
@@ -49,7 +51,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			usagebased.StatusActive,
 			statelessx.BoolFn(s.IsInsideServicePeriod),
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		OnActive(
 			s.AdvanceAfterServicePeriodFrom,
 		)
@@ -60,7 +62,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			usagebased.StatusActiveFinalRealizationStarted,
 			statelessx.BoolFn(s.IsAfterServicePeriod),
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		OnActive(
 			statelessx.AllOf(
 				s.SyncFeatureIDFromFeatureMeter,
@@ -73,7 +75,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			meta.TriggerNext,
 			usagebased.StatusActiveFinalRealizationWaitingForCollection,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		OnActive(
 			s.StartFinalRealizationRun,
 		)
@@ -84,7 +86,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			usagebased.StatusActiveFinalRealizationProcessing,
 			s.IsAfterCollectionPeriod,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		// TODO: Transition to a failed state if the collection period end is not set
 		OnActive(s.AdvanceAfterCollectionPeriodEnd)
 
@@ -93,7 +95,7 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			meta.TriggerNext,
 			usagebased.StatusActiveFinalRealizationCompleted,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		OnActive(
 			s.FinalizeRealizationRun,
 		)
@@ -103,14 +105,11 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			meta.TriggerNext,
 			usagebased.StatusFinal,
 		).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted)
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge))
 
 	s.Configure(usagebased.StatusFinal).
-		Permit(meta.TriggerDelete, usagebased.StatusDeleted).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		OnActive(s.ClearAdvanceAfter)
-
-	s.Configure(usagebased.StatusDeleted).
-		OnEntry(statelessx.WithParameters(s.DeleteCharge))
 }
 
 func (s *CreditsOnlyStateMachine) ClearAdvanceAfter(ctx context.Context) error {
@@ -118,8 +117,23 @@ func (s *CreditsOnlyStateMachine) ClearAdvanceAfter(ctx context.Context) error {
 	return nil
 }
 
-func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, policy meta.PatchDeletePolicy) error {
-	if policy.CreditRefundPolicy == meta.CreditRefundPolicyCorrect {
+func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
+	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+		fields.IntentDeletedAt = lo.ToPtr(clock.Now())
+		return fields, nil
+	}); err != nil {
+		return fmt.Errorf("mutating %s intent deleted at: %w", patch.GetTarget(), err)
+	}
+
+	if patch.GetTarget() == meta.ChangeTargetBase && s.Charge.Intent.HasOverrideLayer() {
+		// Subscription sync targets the base intent. When an override is active,
+		// customer-facing credit allocations remain owned by the override.
+		return nil
+	}
+
+	s.Charge.Status = usagebased.StatusDeleted
+
+	if patch.GetPolicy().CreditRefundPolicy == meta.CreditRefundPolicyCorrect {
 		for _, run := range s.Charge.Realizations {
 			if _, err := s.Runs.CorrectAllCredits(ctx, usagebasedrun.CorrectAllCreditRealizationsInput{
 				Charge:             s.Charge,

--- a/openmeter/billing/worker/subscriptionsync/service/persistedstate/loader.go
+++ b/openmeter/billing/worker/subscriptionsync/service/persistedstate/loader.go
@@ -103,12 +103,12 @@ func (l Loader) loadChargesForSubscription(ctx context.Context, subs subscriptio
 		return map[string]Item{}, nil
 	}
 
-	// TODO: charge listing for subscription sync should filter by the base intent's
-	// deleted-at state. Effective DeletedAt can come from API overrides and would
-	// hide charges whose subscription-owned base intent still needs reconciliation.
 	listedCharges, err := l.chargeService.ListCharges(ctx, charges.ListChargesInput{
 		Namespace:       subs.Namespace,
 		SubscriptionIDs: []string{subs.ID},
+		// Subscription sync reconciles subscription-owned source state, so API
+		// override deletion must not hide a charge whose base intent is still live.
+		DeletedAtFilter: charges.ListChargesDeletedAtFilterBaseIntent,
 		Expands:         meta.ExpandNone,
 	})
 	if err != nil {

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge.go
@@ -110,6 +110,10 @@ func (c *chargePatchCollection) AddProrate(existing persistedstate.Item, target 
 }
 
 func (c *chargePatchCollection) addEmulatedReplacement(existing persistedstate.Item, replacement charges.ChargeIntent) error {
+	// TODO: Do not add charge override support for credit-only charges while
+	// period changes are modeled as delete+create replacements. A base-target
+	// delete intentionally leaves an active override customer-facing, which does
+	// not compose with creating a replacement charge for the same subscription item.
 	deletePatch, err := chargesmeta.NewPatchDelete(chargesmeta.NewPatchDeleteInput{
 		Target: chargesmeta.ChangeTargetBase,
 		Policy: chargesmeta.RefundAsCreditsDeletePolicy,

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge.go
@@ -91,9 +91,15 @@ func (c *chargePatchCollection) addPatch(chargeID string, patch charges.Patch) e
 }
 
 func (c *chargePatchCollection) AddDelete(_ string, existing persistedstate.Item) error {
-	// TODO: include the charge intent target on delete patches so subscription sync
-	// deletes the base intent layer without accidentally deleting an API override.
-	return c.addPatch(existing.ID().ID, chargesmeta.NewPatchDelete(chargesmeta.RefundAsCreditsDeletePolicy))
+	patch, err := chargesmeta.NewPatchDelete(chargesmeta.NewPatchDeleteInput{
+		Target: chargesmeta.ChangeTargetBase,
+		Policy: chargesmeta.RefundAsCreditsDeletePolicy,
+	})
+	if err != nil {
+		return err
+	}
+
+	return c.addPatch(existing.ID().ID, patch)
 }
 
 func (c *chargePatchCollection) AddProrate(existing persistedstate.Item, target targetstate.StateItem, originalPeriod, targetPeriod timeutil.ClosedPeriod, originalAmount, targetAmount alpacadecimal.Decimal) error {
@@ -104,9 +110,15 @@ func (c *chargePatchCollection) AddProrate(existing persistedstate.Item, target 
 }
 
 func (c *chargePatchCollection) addEmulatedReplacement(existing persistedstate.Item, replacement charges.ChargeIntent) error {
-	// TODO: include the charge intent target on delete patches so emulated
-	// replacements remove the base intent layer while preserving API overrides.
-	if err := c.addPatch(existing.ID().ID, chargesmeta.NewPatchDelete(chargesmeta.RefundAsCreditsDeletePolicy)); err != nil {
+	deletePatch, err := chargesmeta.NewPatchDelete(chargesmeta.NewPatchDeleteInput{
+		Target: chargesmeta.ChangeTargetBase,
+		Policy: chargesmeta.RefundAsCreditsDeletePolicy,
+	})
+	if err != nil {
+		return fmt.Errorf("creating replacement delete patch: %w", err)
+	}
+
+	if err := c.addPatch(existing.ID().ID, deletePatch); err != nil {
 		return fmt.Errorf("adding replacement delete patch: %w", err)
 	}
 

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeflatfee.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeflatfee.go
@@ -51,9 +51,8 @@ func (c *flatFeeChargeCollection) AddShrink(_ string, existing persistedstate.It
 
 	targetServicePeriod := target.GetServicePeriod()
 
-	// TODO: include the charge intent target on shrink patches so subscription
-	// sync mutates the base intent layer without touching API overrides.
 	patch, err := chargesmeta.NewPatchShrink(chargesmeta.NewPatchShrinkInput{
+		Target:                 chargesmeta.ChangeTargetBase,
 		NewServicePeriodTo:     targetServicePeriod.To,
 		NewFullServicePeriodTo: target.FullServicePeriod.To,
 		NewBillingPeriodTo:     target.BillingPeriod.To,
@@ -83,9 +82,8 @@ func (c *flatFeeChargeCollection) AddExtend(existing persistedstate.Item, target
 
 	targetServicePeriod := target.GetServicePeriod()
 
-	// TODO: include the charge intent target on extend patches so subscription
-	// sync mutates the base intent layer without touching API overrides.
 	patch, err := chargesmeta.NewPatchExtend(chargesmeta.NewPatchExtendInput{
+		Target:                 chargesmeta.ChangeTargetBase,
 		NewServicePeriodTo:     targetServicePeriod.To,
 		NewFullServicePeriodTo: target.FullServicePeriod.To,
 		NewBillingPeriodTo:     target.BillingPeriod.To,

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeusagebased.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeusagebased.go
@@ -51,9 +51,8 @@ func (c *usageBasedChargeCollection) AddShrink(_ string, existing persistedstate
 
 	targetServicePeriod := target.GetServicePeriod()
 
-	// TODO: include the charge intent target on shrink patches so subscription
-	// sync mutates the base intent layer without touching API overrides.
 	patch, err := chargesmeta.NewPatchShrink(chargesmeta.NewPatchShrinkInput{
+		Target:                 chargesmeta.ChangeTargetBase,
 		NewServicePeriodTo:     targetServicePeriod.To,
 		NewFullServicePeriodTo: target.FullServicePeriod.To,
 		NewBillingPeriodTo:     target.BillingPeriod.To,
@@ -83,9 +82,8 @@ func (c *usageBasedChargeCollection) AddExtend(existing persistedstate.Item, tar
 
 	targetServicePeriod := target.GetServicePeriod()
 
-	// TODO: include the charge intent target on extend patches so subscription
-	// sync mutates the base intent layer without touching API overrides.
 	patch, err := chargesmeta.NewPatchExtend(chargesmeta.NewPatchExtendInput{
+		Target:                 chargesmeta.ChangeTargetBase,
 		NewServicePeriodTo:     targetServicePeriod.To,
 		NewFullServicePeriodTo: target.FullServicePeriod.To,
 		NewBillingPeriodTo:     target.BillingPeriod.To,

--- a/test/credits/base.go
+++ b/test/credits/base.go
@@ -720,7 +720,10 @@ func (s *BaseSuite) MustRefundCharge(ctx context.Context, customerID customer.Cu
 	err := s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
 		CustomerID: customerID,
 		PatchesByChargeID: map[string]charges.Patch{
-			chargeID.ID: meta.NewPatchDelete(meta.RefundAsCreditsDeletePolicy),
+			chargeID.ID: lo.Must(meta.NewPatchDelete(meta.NewPatchDeleteInput{
+				Target: meta.ChangeTargetBase,
+				Policy: meta.RefundAsCreditsDeletePolicy,
+			})),
 		},
 	})
 	s.NoError(err)

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -2043,6 +2043,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkToZeroThe
 		// then:
 		// - the charge reaches final and the mutable standard line cleanup corrects credited usage
 		patch, err := meta.NewPatchShrink(meta.NewPatchShrinkInput{
+			Target:                 meta.ChangeTargetBase,
 			NewServicePeriodTo:     shrunkServicePeriodTo,
 			NewFullServicePeriodTo: servicePeriod.To,
 			NewBillingPeriodTo:     shrunkServicePeriodTo,
@@ -2095,6 +2096,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkToZeroThe
 		// then:
 		// - the charge returns to created with a pending gathering line and a due advance timestamp
 		patch, err := meta.NewPatchExtend(meta.NewPatchExtendInput{
+			Target:                 meta.ChangeTargetBase,
 			NewServicePeriodTo:     servicePeriod.To,
 			NewFullServicePeriodTo: servicePeriod.To,
 			NewBillingPeriodTo:     servicePeriod.To,
@@ -2396,6 +2398,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceAsyncPaymentBoo
 		// then:
 		// - the old run remains current and no replacement gathering line is created
 		patch, err := meta.NewPatchShrink(meta.NewPatchShrinkInput{
+			Target:                 meta.ChangeTargetBase,
 			NewServicePeriodTo:     shrunkServicePeriodTo,
 			NewFullServicePeriodTo: servicePeriod.To,
 			NewBillingPeriodTo:     shrunkServicePeriodTo,
@@ -2824,6 +2827,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkExtendPat
 		// then:
 		// - the pending gathering line is replaced with a prorated half amount
 		patch, err := meta.NewPatchShrink(meta.NewPatchShrinkInput{
+			Target:                 meta.ChangeTargetBase,
 			NewServicePeriodTo:     shrunkServicePeriodTo,
 			NewFullServicePeriodTo: servicePeriod.To,
 			NewBillingPeriodTo:     shrunkServicePeriodTo,
@@ -2980,6 +2984,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkPatchUpda
 		// then:
 		// - the invoice updater updates the same standard line in place
 		patch, err := meta.NewPatchShrink(meta.NewPatchShrinkInput{
+			Target:                 meta.ChangeTargetBase,
 			NewServicePeriodTo:     shrunkServicePeriodTo,
 			NewFullServicePeriodTo: servicePeriod.To,
 			NewBillingPeriodTo:     shrunkServicePeriodTo,
@@ -3150,6 +3155,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkPatchCorr
 		// then:
 		// - ReconcileCredits corrects the allocation down to the new amount
 		patch, err := meta.NewPatchShrink(meta.NewPatchShrinkInput{
+			Target:                 meta.ChangeTargetBase,
 			NewServicePeriodTo:     shrunkTo,
 			NewFullServicePeriodTo: servicePeriod.To,
 			NewBillingPeriodTo:     shrunkTo,
@@ -3311,6 +3317,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceImmutableShrink
 		// then:
 		// - the prior invoice remains, the run stays current, and no replacement gathering line is created
 		patch, err := meta.NewPatchShrink(meta.NewPatchShrinkInput{
+			Target:                 meta.ChangeTargetBase,
 			NewServicePeriodTo:     firstShrinkTo,
 			NewFullServicePeriodTo: servicePeriod.To,
 			NewBillingPeriodTo:     firstShrinkTo,
@@ -3362,6 +3369,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceImmutableShrink
 		// then:
 		// - only the charge intent changes, while immutable ledger history stays unchanged
 		extendPatch, err := meta.NewPatchExtend(meta.NewPatchExtendInput{
+			Target:                 meta.ChangeTargetBase,
 			NewServicePeriodTo:     servicePeriod.To,
 			NewFullServicePeriodTo: servicePeriod.To,
 			NewBillingPeriodTo:     servicePeriod.To,
@@ -3383,6 +3391,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceImmutableShrink
 		s.Empty(s.mustGatheringLinesForCharge(ns, cust.ID, flatFeeChargeID.ID, false))
 
 		shrinkPatch, err := meta.NewPatchShrink(meta.NewPatchShrinkInput{
+			Target:                 meta.ChangeTargetBase,
 			NewServicePeriodTo:     secondShrinkTo,
 			NewFullServicePeriodTo: servicePeriod.To,
 			NewBillingPeriodTo:     secondShrinkTo,
@@ -5291,6 +5300,7 @@ func (s *CreditThenInvoiceTestSuite) mustExtendChargeWithInvoiceAt(ctx context.C
 	s.T().Helper()
 
 	patch, err := meta.NewPatchExtend(meta.NewPatchExtendInput{
+		Target:                 meta.ChangeTargetBase,
 		NewServicePeriodTo:     servicePeriodTo,
 		NewFullServicePeriodTo: servicePeriodTo,
 		NewBillingPeriodTo:     servicePeriodTo,
@@ -5317,6 +5327,7 @@ func (s *CreditThenInvoiceTestSuite) shrinkCharge(ctx context.Context, customerI
 	s.T().Helper()
 
 	patch, err := meta.NewPatchShrink(meta.NewPatchShrinkInput{
+		Target:                 meta.ChangeTargetBase,
 		NewServicePeriodTo:     servicePeriodTo,
 		NewFullServicePeriodTo: servicePeriodTo,
 		NewBillingPeriodTo:     servicePeriodTo,

--- a/test/credits/sanity_lifecycle_test.go
+++ b/test/credits/sanity_lifecycle_test.go
@@ -51,7 +51,10 @@ func (s *SanityLifecycleSuite) TestUsageBasedCreditOnlyLifecyclePartialBackfillC
 	err := s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
 		CustomerID: state.customerID,
 		PatchesByChargeID: map[string]charges.Patch{
-			state.usageChargeID.ID: meta.NewPatchDelete(meta.RefundAsCreditsDeletePolicy),
+			state.usageChargeID.ID: lo.Must(meta.NewPatchDelete(meta.NewPatchDeleteInput{
+				Target: meta.ChangeTargetBase,
+				Policy: meta.RefundAsCreditsDeletePolicy,
+			})),
 		},
 	})
 	s.NoError(err)
@@ -96,7 +99,10 @@ func (s *SanityLifecycleSuite) TestUsageBasedCreditOnlyLifecyclePartialBackfillC
 	err := s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
 		CustomerID: state.customerID,
 		PatchesByChargeID: map[string]charges.Patch{
-			state.usageChargeID.ID: meta.NewPatchDelete(meta.RefundAsCreditsDeletePolicy),
+			state.usageChargeID.ID: lo.Must(meta.NewPatchDelete(meta.NewPatchDeleteInput{
+				Target: meta.ChangeTargetBase,
+				Policy: meta.RefundAsCreditsDeletePolicy,
+			})),
 		},
 	})
 	s.NoError(err)

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -1548,7 +1548,10 @@ func (s *SanitySuite) deleteChargeWithRefundAsCredits(ctx context.Context, custo
 	err := s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
 		CustomerID: customerID,
 		PatchesByChargeID: map[string]charges.Patch{
-			chargeID: meta.NewPatchDelete(meta.RefundAsCreditsDeletePolicy),
+			chargeID: lo.Must(meta.NewPatchDelete(meta.NewPatchDeleteInput{
+				Target: meta.ChangeTargetBase,
+				Policy: meta.RefundAsCreditsDeletePolicy,
+			})),
 		},
 	})
 	s.NoError(err)
@@ -1714,7 +1717,10 @@ func (s *SanitySuite) TestUsageBasedCreditOnlyDeleteCorrectionWithPartialBackfil
 	err = s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
 		CustomerID: cust.GetID(),
 		PatchesByChargeID: map[string]charges.Patch{
-			usageBasedCharge.ID: meta.NewPatchDelete(meta.RefundAsCreditsDeletePolicy),
+			usageBasedCharge.ID: lo.Must(meta.NewPatchDelete(meta.NewPatchDeleteInput{
+				Target: meta.ChangeTargetBase,
+				Policy: meta.RefundAsCreditsDeletePolicy,
+			})),
 		},
 	})
 	s.NoError(err)
@@ -1869,7 +1875,10 @@ func (s *SanitySuite) TestUsageBasedCreditOnlyDeleteCorrectionWithMixedFeatureAd
 	err = s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
 		CustomerID: cust.GetID(),
 		PatchesByChargeID: map[string]charges.Patch{
-			storageCharge.ID: meta.NewPatchDelete(meta.RefundAsCreditsDeletePolicy),
+			storageCharge.ID: lo.Must(meta.NewPatchDelete(meta.NewPatchDeleteInput{
+				Target: meta.ChangeTargetBase,
+				Policy: meta.RefundAsCreditsDeletePolicy,
+			})),
 		},
 	})
 	s.NoError(err)
@@ -1889,7 +1898,10 @@ func (s *SanitySuite) TestUsageBasedCreditOnlyDeleteCorrectionWithMixedFeatureAd
 	err = s.Charges.ApplyPatches(ctx, charges.ApplyPatchesInput{
 		CustomerID: cust.GetID(),
 		PatchesByChargeID: map[string]charges.Patch{
-			apiRequestsCharge.ID: meta.NewPatchDelete(meta.RefundAsCreditsDeletePolicy),
+			apiRequestsCharge.ID: lo.Must(meta.NewPatchDelete(meta.NewPatchDeleteInput{
+				Target: meta.ChangeTargetBase,
+				Policy: meta.RefundAsCreditsDeletePolicy,
+			})),
 		},
 	})
 	s.NoError(err)


### PR DESCRIPTION
## What

- Add explicit base-vs-override targets to charge patches.
- Route subscription sync charge patches to the base intent layer.
- Load persisted subscription-sync charges using base intent deletion state.
- Keep effective invoice reconciliation unchanged when a base-layer patch is hidden by an active override.

## Why

Subscription sync owns subscription-derived base charge state, while API/user overrides can own the effective customer-facing layer. Patch targeting makes that ownership explicit so sync can continue reconciling base state without accidentally mutating active overrides.

## Validation

- `go test -tags=dynamic -count=1 ./test/credits`
- `SVIX_HOST=localhost go test -tags=dynamic -count=1 ./test/notification`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Charge listings can now filter deleted charges using either “effective” or “base-intent” deletion semantics.
  * Billing patches now require explicit charge target selection, with consistent behavior for extend, shrink, and delete operations.
* **Bug Fixes**
  * Improved billing reconciliation so base/override invoice state is preserved correctly, especially when deleting charges.
  * Subscription sync reconciliation now uses base-intent deletion state to avoid hiding charges that still need reconciliation.
* **Documentation**
  * Updated “Mutable Invoice Line Edits” and charge patch target rules to clarify reconciliation side effects and target semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->