### PR TITLE
refactor: clean up charge patch mutation APIs

### DIFF
--- a/openmeter/billing/charges/flatfee/adapter/charge.go
+++ b/openmeter/billing/charges/flatfee/adapter/charge.go
@@ -146,9 +146,8 @@ func (a *adapter) DeleteCharge(ctx context.Context, charge flatfee.Charge) error
 		update := tx.db.ChargeFlatFee.UpdateOneID(charge.ID).
 			Where(dbchargeflatfee.NamespaceEQ(charge.Namespace))
 
-		err := charge.Intent.MutateEffective(func(intentMutableFields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+		err := charge.Intent.MutateEffective(func(intentMutableFields *flatfee.IntentMutableFields) {
 			intentMutableFields.IntentDeletedAt = lo.ToPtr(clock.Now())
-			return intentMutableFields, nil
 		})
 		if err != nil {
 			return err

--- a/openmeter/billing/charges/flatfee/adapter/intentoverride_test.go
+++ b/openmeter/billing/charges/flatfee/adapter/intentoverride_test.go
@@ -103,9 +103,8 @@ func (s *FlatFeeIntentOverrideAdapterSuite) TestUpdateAndReadIntentOverride() {
 		Mode:    productcatalog.ProRatingModeProratePrices,
 	}
 
-	s.Require().NoError(charge.Intent.Mutate(chargesmeta.ChangeTargetBase, func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+	s.Require().NoError(charge.Intent.Mutate(chargesmeta.ChangeTargetBase, func(fields *flatfee.IntentMutableFields) {
 		fields.IntentDeletedAt = lo.ToPtr(time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC))
-		return fields, nil
 	}))
 	override := flatfee.IntentMutableFields{
 		IntentMutableFields: chargesmeta.IntentMutableFields{
@@ -156,22 +155,20 @@ func (s *FlatFeeIntentOverrideAdapterSuite) TestUpdateAndReadIntentOverride() {
 	s.Require().Error(err)
 
 	overrideInvoiceAt = time.Date(2026, 1, 22, 0, 0, 0, 0, time.UTC)
-	s.Require().NoError(updated.Intent.Mutate(chargesmeta.ChangeTargetOverride, func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+	s.Require().NoError(updated.Intent.Mutate(chargesmeta.ChangeTargetOverride, func(fields *flatfee.IntentMutableFields) {
 		fields.InvoiceAt = overrideInvoiceAt
-		return fields, nil
 	}))
 	updated, err = s.adapter.UpdateCharge(ctx, updated)
 	s.Require().NoError(err)
 	s.requireOverrideMatches(updated.Intent.GetOverrideLayerMutableFields(), overrideServicePeriod, overrideFullServicePeriod, overrideBillingPeriod, overrideInvoiceAt, overrideTaxCodeID)
 
-	s.Require().NoError(updated.Intent.Mutate(chargesmeta.ChangeTargetOverride, func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+	s.Require().NoError(updated.Intent.Mutate(chargesmeta.ChangeTargetOverride, func(fields *flatfee.IntentMutableFields) {
 		fields.Description = nil
 		fields.Metadata = nil
 		fields.TaxConfig.Behavior = nil
 		fields.TaxConfig.TaxCodeID = overrideTaxCodeID
 		fields.FeatureKey = ""
 		fields.PercentageDiscounts = nil
-		return fields, nil
 	}))
 	updated, err = s.adapter.UpdateCharge(ctx, updated)
 	s.Require().NoError(err)

--- a/openmeter/billing/charges/flatfee/charge.go
+++ b/openmeter/billing/charges/flatfee/charge.go
@@ -408,7 +408,7 @@ func (i OverridableIntent) CalculateAmountAfterProration() (alpacadecimal.Decima
 	return i.GetEffectiveIntent().CalculateAmountAfterProration()
 }
 
-func (i *OverridableIntent) MutateEffective(editFn func(IntentMutableFields) (IntentMutableFields, error)) error {
+func (i *OverridableIntent) MutateEffective(editFn func(*IntentMutableFields)) error {
 	target := meta.ChangeTargetBase
 	if i.overrideLayer != nil {
 		target = meta.ChangeTargetOverride
@@ -417,7 +417,12 @@ func (i *OverridableIntent) MutateEffective(editFn func(IntentMutableFields) (In
 	return i.Mutate(target, editFn)
 }
 
-func (i *OverridableIntent) Mutate(target meta.ChangeTarget, editFn func(IntentMutableFields) (IntentMutableFields, error)) error {
+// Mutate edits the requested intent mutable field layer.
+//
+// The callback always receives a non-nil pointer to a cloned mutable-field value.
+// The clone is written back only after it normalizes and validates, so validation
+// errors do not partially mutate the intent.
+func (i *OverridableIntent) Mutate(target meta.ChangeTarget, editFn func(*IntentMutableFields)) error {
 	var targetFields IntentMutableFields
 	switch target {
 	case meta.ChangeTargetBase:
@@ -430,10 +435,7 @@ func (i *OverridableIntent) Mutate(target meta.ChangeTarget, editFn func(IntentM
 		targetFields = i.overrideLayer.Clone()
 	}
 
-	targetFields, err := editFn(targetFields)
-	if err != nil {
-		return fmt.Errorf("editing intent mutable fields: %w", err)
-	}
+	editFn(&targetFields)
 
 	normalizedFields := targetFields.Normalized(i.intent.Currency)
 	if err := normalizedFields.Validate(); err != nil {

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -147,9 +147,8 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 }
 
 func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
-	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields *flatfee.IntentMutableFields) {
 		fields.IntentDeletedAt = lo.ToPtr(clock.Now())
-		return fields, nil
 	}); err != nil {
 		return fmt.Errorf("mutating %s intent deleted at: %w", patch.GetTarget(), err)
 	}
@@ -232,12 +231,11 @@ func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(patch periodPatch) (rec
 		return reconcileInvoicingStateInput{}, fmt.Errorf("validate %s patch: %w", patch.Op(), err)
 	}
 	intent := s.Charge.Intent
-	if err := intent.Mutate(patch.GetTarget(), func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+	if err := intent.Mutate(patch.GetTarget(), func(fields *flatfee.IntentMutableFields) {
 		fields.ServicePeriod.To = patch.GetNewServicePeriodTo()
 		fields.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
 		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
 		fields.InvoiceAt = patch.GetNewInvoiceAt()
-		return fields, nil
 	}); err != nil {
 		return reconcileInvoicingStateInput{}, fmt.Errorf("mutating %s intent: %w", patch.GetTarget(), err)
 	}

--- a/openmeter/billing/charges/flatfee/service/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/creditsonly.go
@@ -116,9 +116,8 @@ func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {
 }
 
 func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
-	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields flatfee.IntentMutableFields) (flatfee.IntentMutableFields, error) {
+	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields *flatfee.IntentMutableFields) {
 		fields.IntentDeletedAt = lo.ToPtr(clock.Now())
-		return fields, nil
 	}); err != nil {
 		return fmt.Errorf("mutating %s intent deleted at: %w", patch.GetTarget(), err)
 	}

--- a/openmeter/billing/charges/flatfee/service/triggers.go
+++ b/openmeter/billing/charges/flatfee/service/triggers.go
@@ -56,7 +56,7 @@ func (s *service) TriggerPatch(ctx context.Context, chargeID meta.ChargeID, patc
 			return nil, fmt.Errorf("new state machine: %w", err)
 		}
 
-		err = stateMachine.FireAndActivate(ctx, patch.Trigger(), patch.TriggerParams())
+		err = stateMachine.FireAndActivate(ctx, patch.Trigger(), patch)
 		if err != nil {
 			return nil, err
 		}

--- a/openmeter/billing/charges/meta/patch.go
+++ b/openmeter/billing/charges/meta/patch.go
@@ -46,8 +46,6 @@ type Patch interface {
 	Op() PatchType
 	GetTarget() ChangeTarget
 	Trigger() stateless.Trigger
-	// Note: trigger params is any as stateless only support this as an input argument
-	TriggerParams() any
 }
 
 type TriggerPatchResult[T any] struct {

--- a/openmeter/billing/charges/meta/patchdelete.go
+++ b/openmeter/billing/charges/meta/patchdelete.go
@@ -74,10 +74,6 @@ func (p PatchDelete) Trigger() stateless.Trigger {
 	return TriggerDelete
 }
 
-func (p PatchDelete) TriggerParams() any {
-	return p
-}
-
 func (p PatchDelete) Validate() error {
 	var errs []error
 

--- a/openmeter/billing/charges/meta/patchextend.go
+++ b/openmeter/billing/charges/meta/patchextend.go
@@ -119,10 +119,6 @@ func (p PatchExtend) Trigger() stateless.Trigger {
 	return TriggerExtend
 }
 
-func (p PatchExtend) TriggerParams() any {
-	return p
-}
-
 func (p PatchExtend) Validate() error {
 	var errs []error
 

--- a/openmeter/billing/charges/meta/patchshrink.go
+++ b/openmeter/billing/charges/meta/patchshrink.go
@@ -117,10 +117,6 @@ func (p PatchShrink) Trigger() stateless.Trigger {
 	return TriggerShrink
 }
 
-func (p PatchShrink) TriggerParams() any {
-	return p
-}
-
 func (p PatchShrink) Validate() error {
 	if err := p.GetTarget().Validate(); err != nil {
 		return fmt.Errorf("target: %w", err)

--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -121,9 +121,8 @@ func (a *adapter) DeleteCharge(ctx context.Context, charge usagebased.Charge) er
 	}
 
 	return entutils.TransactingRepoWithNoValue(ctx, a, func(ctx context.Context, tx *adapter) error {
-		if err := charge.Intent.MutateEffective(func(intentMutableFields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+		if err := charge.Intent.MutateEffective(func(intentMutableFields *usagebased.IntentMutableFields) {
 			intentMutableFields.IntentDeletedAt = lo.ToPtr(clock.Now())
-			return intentMutableFields, nil
 		}); err != nil {
 			return err
 		}

--- a/openmeter/billing/charges/usagebased/adapter/intentoverride_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/intentoverride_test.go
@@ -108,9 +108,8 @@ func (s *UsageBasedIntentOverrideAdapterSuite) TestUpdateAndReadIntentOverride()
 		}),
 	}
 
-	s.Require().NoError(charge.Intent.Mutate(chargesmeta.ChangeTargetBase, func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+	s.Require().NoError(charge.Intent.Mutate(chargesmeta.ChangeTargetBase, func(fields *usagebased.IntentMutableFields) {
 		fields.IntentDeletedAt = lo.ToPtr(time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC))
-		return fields, nil
 	}))
 	override := usagebased.IntentMutableFields{
 		IntentMutableFields: chargesmeta.IntentMutableFields{

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -461,7 +461,7 @@ func (i OverridableIntent) GetDeletedAt() *time.Time {
 	return i.baseLayer.IntentDeletedAt
 }
 
-func (i *OverridableIntent) MutateEffective(editFn func(IntentMutableFields) (IntentMutableFields, error)) error {
+func (i *OverridableIntent) MutateEffective(editFn func(*IntentMutableFields)) error {
 	target := meta.ChangeTargetBase
 	if i.overrideLayer != nil {
 		target = meta.ChangeTargetOverride
@@ -470,7 +470,12 @@ func (i *OverridableIntent) MutateEffective(editFn func(IntentMutableFields) (In
 	return i.Mutate(target, editFn)
 }
 
-func (i *OverridableIntent) Mutate(target meta.ChangeTarget, editFn func(IntentMutableFields) (IntentMutableFields, error)) error {
+// Mutate edits the requested intent mutable field layer.
+//
+// The callback always receives a non-nil pointer to a cloned mutable-field value.
+// The clone is written back only after it normalizes and validates, so validation
+// errors do not partially mutate the intent.
+func (i *OverridableIntent) Mutate(target meta.ChangeTarget, editFn func(*IntentMutableFields)) error {
 	var targetFields IntentMutableFields
 	switch target {
 	case meta.ChangeTargetBase:
@@ -483,10 +488,7 @@ func (i *OverridableIntent) Mutate(target meta.ChangeTarget, editFn func(IntentM
 		targetFields = i.overrideLayer.Clone()
 	}
 
-	targetFields, err := editFn(targetFields)
-	if err != nil {
-		return fmt.Errorf("editing intent mutable fields: %w", err)
-	}
+	editFn(&targetFields)
 
 	normalizedFields := targetFields.Normalized()
 

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -255,9 +255,8 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 }
 
 func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
-	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields *usagebased.IntentMutableFields) {
 		fields.IntentDeletedAt = lo.ToPtr(clock.Now())
-		return fields, nil
 	}); err != nil {
 		return fmt.Errorf("mutating %s intent deleted at: %w", patch.GetTarget(), err)
 	}
@@ -373,12 +372,11 @@ func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(patch periodPatch) (app
 
 	oldServicePeriod := meta.NormalizeClosedPeriod(targetIntent.IntentMutableFields.ServicePeriod)
 
-	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields *usagebased.IntentMutableFields) {
 		fields.ServicePeriod.To = patch.GetNewServicePeriodTo()
 		fields.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
 		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
 		fields.InvoiceAt = patch.GetNewInvoiceAt()
-		return fields, nil
 	}); err != nil {
 		return applyPeriodPatchResult{}, fmt.Errorf("mutating %s intent: %w", patch.GetTarget(), err)
 	}

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice_test.go
@@ -67,7 +67,7 @@ func TestUnsupportedExtendOperationIsConfiguredForFinalRealizationBoundary(t *te
 			require.NoError(t, err)
 			require.True(t, canFire)
 
-			err = machine.FireAndActivate(t.Context(), patch.Trigger(), patch.TriggerParams())
+			err = machine.FireAndActivate(t.Context(), patch.Trigger(), patch)
 			require.Error(t, err)
 			require.True(t, models.IsGenericPreConditionFailedError(err))
 			require.ErrorContains(t, err, "cannot extend usage-based charge in status "+string(status))
@@ -130,7 +130,7 @@ func TestUnsupportedShrinkOperationIsConfiguredForImmutableBoundaries(t *testing
 			require.NoError(t, err)
 			require.True(t, canFire)
 
-			err = machine.FireAndActivate(t.Context(), patch.Trigger(), patch.TriggerParams())
+			err = machine.FireAndActivate(t.Context(), patch.Trigger(), patch)
 			require.Error(t, err)
 			require.True(t, models.IsGenericPreConditionFailedError(err))
 			require.ErrorContains(t, err, "cannot shrink usage-based charge in status "+string(status))

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -118,9 +118,8 @@ func (s *CreditsOnlyStateMachine) ClearAdvanceAfter(ctx context.Context) error {
 }
 
 func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
-	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields *usagebased.IntentMutableFields) {
 		fields.IntentDeletedAt = lo.ToPtr(clock.Now())
-		return fields, nil
 	}); err != nil {
 		return fmt.Errorf("mutating %s intent deleted at: %w", patch.GetTarget(), err)
 	}

--- a/openmeter/billing/charges/usagebased/service/rating/service_test.go
+++ b/openmeter/billing/charges/usagebased/service/rating/service_test.go
@@ -397,14 +397,13 @@ func TestGetTotalsForUsageMinimumCommitment(t *testing.T) {
 			require.NoError(t, err)
 
 			charge := newDetailedRatingTestCharge(servicePeriod, usagebased.RealizationRuns{})
-			err = charge.Intent.MutateEffective(func(fields usagebased.IntentMutableFields) (usagebased.IntentMutableFields, error) {
+			err = charge.Intent.MutateEffective(func(fields *usagebased.IntentMutableFields) {
 				fields.Price = *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 					Amount: alpacadecimal.NewFromInt(3),
 					Commitments: productcatalog.Commitments{
 						MinimumAmount: lo.ToPtr(alpacadecimal.NewFromInt(100)),
 					},
 				})
-				return fields, nil
 			})
 			require.NoError(t, err)
 

--- a/openmeter/billing/charges/usagebased/service/triggers.go
+++ b/openmeter/billing/charges/usagebased/service/triggers.go
@@ -69,7 +69,7 @@ func (s *service) TriggerPatch(ctx context.Context, chargeID meta.ChargeID, patc
 			return nil, fmt.Errorf("new state machine: %w", err)
 		}
 
-		if err := stateMachine.FireAndActivate(ctx, patch.Trigger(), patch.TriggerParams()); err != nil {
+		if err := stateMachine.FireAndActivate(ctx, patch.Trigger(), patch); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
## What changed

This stacked cleanup removes the leftover patch trigger parameter adapter now that charge state machines receive the patch payload directly.

It also simplifies flat-fee and usage-based intent mutation callbacks so callers mutate the provided non-nil cloned mutable-field pointer directly. The mutator still owns target validation, normalization, and final validation before writing the layer back.

## Why

The previous shape kept extra API surface around the transition: patches exposed TriggerParams even though the patch itself is the trigger payload, and mutate callbacks returned values/errors even though production mutations are simple in-place field edits.

## Validation

- go test -tags=dynamic ./openmeter/billing/charges/meta ./openmeter/billing/charges/flatfee/service ./openmeter/billing/charges/usagebased/service
- go test -tags=dynamic ./openmeter/billing/charges/flatfee/adapter ./openmeter/billing/charges/usagebased/adapter ./openmeter/billing/charges/usagebased/service/rating

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved charge update handling so delete, extend, and shrink actions apply changes more reliably.
  * Fixed trigger processing for charge patches, helping ensure the correct action is used during charge lifecycle updates.
  * Updated mutation handling to reduce the risk of inconsistent charge details being saved during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->