### PR TITLE
Persist unit config - OM-395

### DIFF
--- a/openmeter/billing/charges/usagebased/adapter/charge.go
+++ b/openmeter/billing/charges/usagebased/adapter/charge.go
@@ -49,6 +49,12 @@ func (a *adapter) UpdateCharge(ctx context.Context, charge usagebased.ChargeBase
 			SetStatusDetailed(charge.Status).
 			SetOrClearCurrentRealizationRunID(charge.State.CurrentRealizationRunID)
 
+		if baseIntent.UnitConfig != nil {
+			update = update.SetUnitConfig(baseIntent.UnitConfig)
+		} else {
+			update = update.ClearUnitConfig()
+		}
+
 		update, err = chargemeta.Update(update, chargemeta.UpdateInput{
 			ManagedResource:     charge.ManagedResource,
 			IntentMutableFields: baseIntent.IntentMutableFields.IntentMutableFields,
@@ -310,6 +316,10 @@ func (a *adapter) buildCreateUsageBasedCharge(ctx context.Context, ns string, in
 		SetFeatureKey(baseIntent.FeatureKey).
 		SetInvoiceAt(meta.NormalizeTimestamp(baseIntent.InvoiceAt).In(time.UTC)).
 		SetSettlementMode(baseIntent.SettlementMode)
+
+	if baseIntent.UnitConfig != nil {
+		create = create.SetUnitConfig(baseIntent.UnitConfig)
+	}
 
 	create, err := chargemeta.Create[*db.ChargeUsageBasedCreate](create, chargemeta.CreateInput{
 		Namespace:           ns,

--- a/openmeter/billing/charges/usagebased/adapter/intentoverride.go
+++ b/openmeter/billing/charges/usagebased/adapter/intentoverride.go
@@ -42,6 +42,7 @@ func mapIntentOverrideFromDB(dbOverride *entdb.ChargeUsageBasedOverride) *usageb
 		FeatureKey:      dbOverride.FeatureKey,
 		Price:           lo.FromPtr(dbOverride.Price),
 		Discounts:       lo.FromPtr(dbOverride.Discounts),
+		UnitConfig:      dbOverride.UnitConfig,
 	}
 }
 
@@ -155,6 +156,9 @@ func (a *adapter) createIntentOverride(ctx context.Context, chargeID meta.Charge
 		SetFeatureKey(normalized.FeatureKey).
 		SetPrice(&normalized.Price).
 		SetDiscounts(&normalized.Discounts)
+	if normalized.UnitConfig != nil {
+		create = create.SetUnitConfig(normalized.UnitConfig)
+	}
 	if normalized.Metadata != nil {
 		create = create.SetMetadata(&normalized.Metadata)
 	}
@@ -190,6 +194,11 @@ func (a *adapter) updateIntentOverride(ctx context.Context, chargeID meta.Charge
 		SetFeatureKey(normalized.FeatureKey).
 		SetPrice(&normalized.Price).
 		SetDiscounts(&normalized.Discounts)
+	if normalized.UnitConfig != nil {
+		update = update.SetUnitConfig(normalized.UnitConfig)
+	} else {
+		update = update.ClearUnitConfig()
+	}
 	if normalized.Metadata == nil {
 		update = update.ClearMetadata()
 	} else {

--- a/openmeter/billing/charges/usagebased/adapter/intentoverride_test.go
+++ b/openmeter/billing/charges/usagebased/adapter/intentoverride_test.go
@@ -265,6 +265,108 @@ func (s *UsageBasedIntentOverrideAdapterSuite) TestDeleteChargeWithIntentOverrid
 	s.Equal(deletedAt, *fetched.DeletedAt)
 }
 
+// newTestUnitConfig builds a deterministic unit config for round-trip assertions.
+func newTestUnitConfig(factor int64, displayUnit string) *productcatalog.UnitConfig {
+	return &productcatalog.UnitConfig{
+		Operation:        productcatalog.UnitConfigOperationDivide,
+		ConversionFactor: alpacadecimal.NewFromInt(factor),
+		Rounding:         productcatalog.UnitConfigRoundingModeCeiling,
+		Precision:        0,
+		DisplayUnit:      lo.ToPtr(displayUnit),
+	}
+}
+
+// TestUnitConfigRoundTrip verifies unit_config persists through the charge write
+// sites. unit_config is a mutable field in IntentMutableFields (alongside price),
+// so it round-trips through both the base layer (create/update/clear) and the
+// override layer (create/update/clear).
+func (s *UsageBasedIntentOverrideAdapterSuite) TestUnitConfigRoundTrip() {
+	ctx := s.T().Context()
+	namespace := "usagebased-unitconfig-adapter"
+	charge := s.createCharge(namespace)
+
+	// base create→read: createCharge persisted a base unit_config (divide 1000)
+	fetched, err := s.adapter.GetByID(ctx, usagebased.GetByIDInput{ChargeID: charge.GetChargeID()})
+	s.Require().NoError(err)
+	s.Require().NotNil(fetched.Intent.GetBaseIntent().UnitConfig)
+	s.True(fetched.Intent.GetBaseIntent().UnitConfig.Equal(newTestUnitConfig(1000, "K")))
+
+	// base update→read: the base unit_config is mutable (lives alongside price)
+	s.Require().NoError(fetched.Intent.Mutate(chargesmeta.ChangeTargetBase, func(f *usagebased.IntentMutableFields) {
+		f.UnitConfig = newTestUnitConfig(1000000, "M")
+	}))
+	updated, err := s.adapter.UpdateCharge(ctx, fetched.ChargeBase)
+	s.Require().NoError(err)
+	s.True(updated.Intent.GetBaseIntent().UnitConfig.Equal(newTestUnitConfig(1000000, "M")))
+
+	fetched, err = s.adapter.GetByID(ctx, usagebased.GetByIDInput{ChargeID: charge.GetChargeID()})
+	s.Require().NoError(err)
+	s.True(fetched.Intent.GetBaseIntent().UnitConfig.Equal(newTestUnitConfig(1000000, "M")))
+
+	// base clear→read
+	s.Require().NoError(fetched.Intent.Mutate(chargesmeta.ChangeTargetBase, func(f *usagebased.IntentMutableFields) {
+		f.UnitConfig = nil
+	}))
+	updated, err = s.adapter.UpdateCharge(ctx, fetched.ChargeBase)
+	s.Require().NoError(err)
+	s.Nil(updated.Intent.GetBaseIntent().UnitConfig)
+
+	fetched, err = s.adapter.GetByID(ctx, usagebased.GetByIDInput{ChargeID: charge.GetChargeID()})
+	s.Require().NoError(err)
+	s.Nil(fetched.Intent.GetBaseIntent().UnitConfig)
+
+	// override create→read: the override layer carries its own unit_config snapshot
+	baseIntent := fetched.Intent.GetBaseIntent()
+	override := usagebased.IntentMutableFields{
+		IntentMutableFields: chargesmeta.IntentMutableFields{
+			Name:              "override with unit config",
+			TaxConfig:         baseIntent.TaxConfig,
+			ServicePeriod:     baseIntent.ServicePeriod,
+			FullServicePeriod: baseIntent.FullServicePeriod,
+			BillingPeriod:     baseIntent.BillingPeriod,
+		},
+		InvoiceAt:  baseIntent.InvoiceAt,
+		FeatureKey: baseIntent.FeatureKey,
+		Price:      baseIntent.Price,
+		Discounts:  baseIntent.Discounts,
+		UnitConfig: newTestUnitConfig(1000, "K"),
+	}
+	withOverride, err := s.adapter.CreateChargeOverride(ctx, fetched.ChargeBase, override)
+	s.Require().NoError(err)
+	s.Require().NotNil(withOverride.Intent.GetOverrideLayerMutableFields())
+	s.True(withOverride.Intent.GetOverrideLayerMutableFields().UnitConfig.Equal(newTestUnitConfig(1000, "K")))
+
+	fetched, err = s.adapter.GetByID(ctx, usagebased.GetByIDInput{ChargeID: charge.GetChargeID()})
+	s.Require().NoError(err)
+	s.Require().NotNil(fetched.Intent.GetOverrideLayerMutableFields())
+	s.True(fetched.Intent.GetOverrideLayerMutableFields().UnitConfig.Equal(newTestUnitConfig(1000, "K")))
+
+	// override update→read
+	override = *fetched.Intent.GetOverrideLayerMutableFields()
+	override.UnitConfig = newTestUnitConfig(1000000, "M")
+	fetched.Intent = usagebased.NewOverridableIntent(fetched.Intent.GetBaseIntent(), &override)
+	updated, err = s.adapter.UpdateCharge(ctx, fetched.ChargeBase)
+	s.Require().NoError(err)
+	s.True(updated.Intent.GetOverrideLayerMutableFields().UnitConfig.Equal(newTestUnitConfig(1000000, "M")))
+
+	fetched, err = s.adapter.GetByID(ctx, usagebased.GetByIDInput{ChargeID: charge.GetChargeID()})
+	s.Require().NoError(err)
+	s.True(fetched.Intent.GetOverrideLayerMutableFields().UnitConfig.Equal(newTestUnitConfig(1000000, "M")))
+
+	// override clear→read
+	override = *fetched.Intent.GetOverrideLayerMutableFields()
+	override.UnitConfig = nil
+	fetched.Intent = usagebased.NewOverridableIntent(fetched.Intent.GetBaseIntent(), &override)
+	updated, err = s.adapter.UpdateCharge(ctx, fetched.ChargeBase)
+	s.Require().NoError(err)
+	s.Nil(updated.Intent.GetOverrideLayerMutableFields().UnitConfig)
+
+	fetched, err = s.adapter.GetByID(ctx, usagebased.GetByIDInput{ChargeID: charge.GetChargeID()})
+	s.Require().NoError(err)
+	s.Require().NotNil(fetched.Intent.GetOverrideLayerMutableFields())
+	s.Nil(fetched.Intent.GetOverrideLayerMutableFields().UnitConfig)
+}
+
 func (s *UsageBasedIntentOverrideAdapterSuite) requireOverrideMatches(
 	override *usagebased.IntentMutableFields,
 	servicePeriod timeutil.ClosedPeriod,
@@ -331,6 +433,7 @@ func (s *UsageBasedIntentOverrideAdapterSuite) createCharge(namespace string) us
 						Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
 							Amount: alpacadecimal.NewFromFloat(0.1),
 						}),
+						UnitConfig: newTestUnitConfig(1000, "K"),
 					},
 					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
 				}.AsOverridableIntent(),

--- a/openmeter/billing/charges/usagebased/adapter/mapper.go
+++ b/openmeter/billing/charges/usagebased/adapter/mapper.go
@@ -51,6 +51,7 @@ func MapChargeBaseFromDB(entity *entdb.ChargeUsageBased) usagebased.ChargeBase {
 			FeatureKey:          entity.FeatureKey,
 			Discounts:           lo.FromPtr(entity.Discounts),
 			Price:               lo.FromPtr(entity.Price),
+			UnitConfig:          entity.UnitConfig,
 		},
 		SettlementMode: entity.SettlementMode,
 	}

--- a/openmeter/billing/charges/usagebased/charge.go
+++ b/openmeter/billing/charges/usagebased/charge.go
@@ -526,6 +526,11 @@ type IntentMutableFields struct {
 	Price productcatalog.Price `json:"price"`
 
 	Discounts productcatalog.Discounts `json:"discounts"`
+
+	// UnitConfig is the optional unit conversion snapshotted from the effective
+	// rate card. Like Price it is a mutable rating input (set on create and
+	// update) so re-rates read the config in effect for the charge.
+	UnitConfig *productcatalog.UnitConfig `json:"unitConfig,omitempty"`
 }
 
 func (f IntentMutableFields) Normalized() IntentMutableFields {
@@ -540,6 +545,10 @@ func (f IntentMutableFields) Clone() IntentMutableFields {
 	out.IntentMutableFields = f.IntentMutableFields.Clone()
 	out.Price = *f.Price.Clone()
 	out.Discounts = f.Discounts.Clone()
+
+	if f.UnitConfig != nil {
+		out.UnitConfig = lo.ToPtr(f.UnitConfig.Clone())
+	}
 
 	return out
 }
@@ -561,6 +570,10 @@ func (f IntentMutableFields) Validate() error {
 
 	if err := f.Price.Validate(); err != nil {
 		errs = append(errs, fmt.Errorf("price: %w", err))
+	}
+
+	if err := f.UnitConfig.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("unit config: %w", err))
 	}
 
 	if f.FeatureKey == "" {

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeusagebased.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeusagebased.go
@@ -121,6 +121,9 @@ func newUsageBasedChargeIntent(target targetstate.StateItem) (charges.ChargeInte
 			FeatureKey: lo.FromPtr(rateCardMeta.FeatureKey),
 			Price:      *price,
 			Discounts:  rateCardMeta.Discounts,
+			// TODO(unit-config): copy rateCardMeta.UnitConfig here (with a
+			// round-trip test) when the "snapshot unit_config onto subscriptions"
+			// ticket lands; the charge adapter already persists Intent.UnitConfig.
 		},
 		SettlementMode: target.Subscription.SettlementMode,
 	}), nil

--- a/openmeter/ent/db/addonratecard.go
+++ b/openmeter/ent/db/addonratecard.go
@@ -57,6 +57,8 @@ type AddonRateCard struct {
 	Price *productcatalog.Price `json:"price,omitempty"`
 	// Discounts holds the value of the "discounts" field.
 	Discounts *productcatalog.Discounts `json:"discounts,omitempty"`
+	// UnitConfig holds the value of the "unit_config" field.
+	UnitConfig *productcatalog.UnitConfig `json:"unit_config,omitempty"`
 	// The add-on identifier the ratecard is assigned to.
 	AddonID string `json:"addon_id,omitempty"`
 	// The feature identifier the ratecard is related to.
@@ -132,6 +134,8 @@ func (*AddonRateCard) scanValues(columns []string) ([]any, error) {
 			values[i] = addonratecard.ValueScanner.Price.ScanValue()
 		case addonratecard.FieldDiscounts:
 			values[i] = addonratecard.ValueScanner.Discounts.ScanValue()
+		case addonratecard.FieldUnitConfig:
+			values[i] = addonratecard.ValueScanner.UnitConfig.ScanValue()
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -262,6 +266,12 @@ func (_m *AddonRateCard) assignValues(columns []string, values []any) error {
 				return err
 			} else {
 				_m.Discounts = value
+			}
+		case addonratecard.FieldUnitConfig:
+			if value, err := addonratecard.ValueScanner.UnitConfig.FromValue(values[i]); err != nil {
+				return err
+			} else {
+				_m.UnitConfig = value
 			}
 		case addonratecard.FieldAddonID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -395,6 +405,11 @@ func (_m *AddonRateCard) String() string {
 	builder.WriteString(", ")
 	if v := _m.Discounts; v != nil {
 		builder.WriteString("discounts=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	if v := _m.UnitConfig; v != nil {
+		builder.WriteString("unit_config=")
 		builder.WriteString(fmt.Sprintf("%v", *v))
 	}
 	builder.WriteString(", ")

--- a/openmeter/ent/db/addonratecard/addonratecard.go
+++ b/openmeter/ent/db/addonratecard/addonratecard.go
@@ -51,6 +51,8 @@ const (
 	FieldPrice = "price"
 	// FieldDiscounts holds the string denoting the discounts field in the database.
 	FieldDiscounts = "discounts"
+	// FieldUnitConfig holds the string denoting the unit_config field in the database.
+	FieldUnitConfig = "unit_config"
 	// FieldAddonID holds the string denoting the addon_id field in the database.
 	FieldAddonID = "addon_id"
 	// FieldFeatureID holds the string denoting the feature_id field in the database.
@@ -106,6 +108,7 @@ var Columns = []string{
 	FieldBillingCadence,
 	FieldPrice,
 	FieldDiscounts,
+	FieldUnitConfig,
 	FieldAddonID,
 	FieldFeatureID,
 }
@@ -141,6 +144,7 @@ var (
 		TaxConfig           field.TypeValueScanner[*productcatalog.TaxConfig]
 		Price               field.TypeValueScanner[*productcatalog.Price]
 		Discounts           field.TypeValueScanner[*productcatalog.Discounts]
+		UnitConfig          field.TypeValueScanner[*productcatalog.UnitConfig]
 	}
 )
 
@@ -250,6 +254,11 @@ func ByPrice(opts ...sql.OrderTermOption) OrderOption {
 // ByDiscounts orders the results by the discounts field.
 func ByDiscounts(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDiscounts, opts...).ToFunc()
+}
+
+// ByUnitConfig orders the results by the unit_config field.
+func ByUnitConfig(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldUnitConfig, opts...).ToFunc()
 }
 
 // ByAddonID orders the results by the addon_id field.

--- a/openmeter/ent/db/addonratecard/where.go
+++ b/openmeter/ent/db/addonratecard/where.go
@@ -892,6 +892,16 @@ func DiscountsNotNil() predicate.AddonRateCard {
 	return predicate.AddonRateCard(sql.FieldNotNull(FieldDiscounts))
 }
 
+// UnitConfigIsNil applies the IsNil predicate on the "unit_config" field.
+func UnitConfigIsNil() predicate.AddonRateCard {
+	return predicate.AddonRateCard(sql.FieldIsNull(FieldUnitConfig))
+}
+
+// UnitConfigNotNil applies the NotNil predicate on the "unit_config" field.
+func UnitConfigNotNil() predicate.AddonRateCard {
+	return predicate.AddonRateCard(sql.FieldNotNull(FieldUnitConfig))
+}
+
 // AddonIDEQ applies the EQ predicate on the "addon_id" field.
 func AddonIDEQ(v string) predicate.AddonRateCard {
 	return predicate.AddonRateCard(sql.FieldEQ(FieldAddonID, v))

--- a/openmeter/ent/db/addonratecard_create.go
+++ b/openmeter/ent/db/addonratecard_create.go
@@ -194,6 +194,12 @@ func (_c *AddonRateCardCreate) SetDiscounts(v *productcatalog.Discounts) *AddonR
 	return _c
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_c *AddonRateCardCreate) SetUnitConfig(v *productcatalog.UnitConfig) *AddonRateCardCreate {
+	_c.mutation.SetUnitConfig(v)
+	return _c
+}
+
 // SetAddonID sets the "addon_id" field.
 func (_c *AddonRateCardCreate) SetAddonID(v string) *AddonRateCardCreate {
 	_c.mutation.SetAddonID(v)
@@ -366,6 +372,11 @@ func (_c *AddonRateCardCreate) check() error {
 			return &ValidationError{Name: "discounts", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.discounts": %w`, err)}
 		}
 	}
+	if v, ok := _c.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.unit_config": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.AddonID(); !ok {
 		return &ValidationError{Name: "addon_id", err: errors.New(`db: missing required field "AddonRateCard.addon_id"`)}
 	}
@@ -495,6 +506,14 @@ func (_c *AddonRateCardCreate) createSpec() (*AddonRateCard, *sqlgraph.CreateSpe
 		}
 		_spec.SetField(addonratecard.FieldDiscounts, field.TypeString, vv)
 		_node.Discounts = value
+	}
+	if value, ok := _c.mutation.UnitConfig(); ok {
+		vv, err := addonratecard.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return nil, nil, err
+		}
+		_spec.SetField(addonratecard.FieldUnitConfig, field.TypeString, vv)
+		_node.UnitConfig = value
 	}
 	if nodes := _c.mutation.AddonIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -818,6 +837,24 @@ func (u *AddonRateCardUpsert) UpdateDiscounts() *AddonRateCardUpsert {
 // ClearDiscounts clears the value of the "discounts" field.
 func (u *AddonRateCardUpsert) ClearDiscounts() *AddonRateCardUpsert {
 	u.SetNull(addonratecard.FieldDiscounts)
+	return u
+}
+
+// SetUnitConfig sets the "unit_config" field.
+func (u *AddonRateCardUpsert) SetUnitConfig(v *productcatalog.UnitConfig) *AddonRateCardUpsert {
+	u.Set(addonratecard.FieldUnitConfig, v)
+	return u
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *AddonRateCardUpsert) UpdateUnitConfig() *AddonRateCardUpsert {
+	u.SetExcluded(addonratecard.FieldUnitConfig)
+	return u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *AddonRateCardUpsert) ClearUnitConfig() *AddonRateCardUpsert {
+	u.SetNull(addonratecard.FieldUnitConfig)
 	return u
 }
 
@@ -1167,6 +1204,27 @@ func (u *AddonRateCardUpsertOne) UpdateDiscounts() *AddonRateCardUpsertOne {
 func (u *AddonRateCardUpsertOne) ClearDiscounts() *AddonRateCardUpsertOne {
 	return u.Update(func(s *AddonRateCardUpsert) {
 		s.ClearDiscounts()
+	})
+}
+
+// SetUnitConfig sets the "unit_config" field.
+func (u *AddonRateCardUpsertOne) SetUnitConfig(v *productcatalog.UnitConfig) *AddonRateCardUpsertOne {
+	return u.Update(func(s *AddonRateCardUpsert) {
+		s.SetUnitConfig(v)
+	})
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *AddonRateCardUpsertOne) UpdateUnitConfig() *AddonRateCardUpsertOne {
+	return u.Update(func(s *AddonRateCardUpsert) {
+		s.UpdateUnitConfig()
+	})
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *AddonRateCardUpsertOne) ClearUnitConfig() *AddonRateCardUpsertOne {
+	return u.Update(func(s *AddonRateCardUpsert) {
+		s.ClearUnitConfig()
 	})
 }
 
@@ -1691,6 +1749,27 @@ func (u *AddonRateCardUpsertBulk) UpdateDiscounts() *AddonRateCardUpsertBulk {
 func (u *AddonRateCardUpsertBulk) ClearDiscounts() *AddonRateCardUpsertBulk {
 	return u.Update(func(s *AddonRateCardUpsert) {
 		s.ClearDiscounts()
+	})
+}
+
+// SetUnitConfig sets the "unit_config" field.
+func (u *AddonRateCardUpsertBulk) SetUnitConfig(v *productcatalog.UnitConfig) *AddonRateCardUpsertBulk {
+	return u.Update(func(s *AddonRateCardUpsert) {
+		s.SetUnitConfig(v)
+	})
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *AddonRateCardUpsertBulk) UpdateUnitConfig() *AddonRateCardUpsertBulk {
+	return u.Update(func(s *AddonRateCardUpsert) {
+		s.UpdateUnitConfig()
+	})
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *AddonRateCardUpsertBulk) ClearUnitConfig() *AddonRateCardUpsertBulk {
+	return u.Update(func(s *AddonRateCardUpsert) {
+		s.ClearUnitConfig()
 	})
 }
 

--- a/openmeter/ent/db/addonratecard_update.go
+++ b/openmeter/ent/db/addonratecard_update.go
@@ -233,6 +233,18 @@ func (_u *AddonRateCardUpdate) ClearDiscounts() *AddonRateCardUpdate {
 	return _u
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_u *AddonRateCardUpdate) SetUnitConfig(v *productcatalog.UnitConfig) *AddonRateCardUpdate {
+	_u.mutation.SetUnitConfig(v)
+	return _u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (_u *AddonRateCardUpdate) ClearUnitConfig() *AddonRateCardUpdate {
+	_u.mutation.ClearUnitConfig()
+	return _u
+}
+
 // SetAddonID sets the "addon_id" field.
 func (_u *AddonRateCardUpdate) SetAddonID(v string) *AddonRateCardUpdate {
 	_u.mutation.SetAddonID(v)
@@ -382,6 +394,11 @@ func (_u *AddonRateCardUpdate) check() error {
 			return &ValidationError{Name: "discounts", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.discounts": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.unit_config": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.AddonID(); ok {
 		if err := addonratecard.AddonIDValidator(v); err != nil {
 			return &ValidationError{Name: "addon_id", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.addon_id": %w`, err)}
@@ -486,6 +503,16 @@ func (_u *AddonRateCardUpdate) sqlSave(ctx context.Context) (_node int, err erro
 	}
 	if _u.mutation.DiscountsCleared() {
 		_spec.ClearField(addonratecard.FieldDiscounts, field.TypeString)
+	}
+	if value, ok := _u.mutation.UnitConfig(); ok {
+		vv, err := addonratecard.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return 0, err
+		}
+		_spec.SetField(addonratecard.FieldUnitConfig, field.TypeString, vv)
+	}
+	if _u.mutation.UnitConfigCleared() {
+		_spec.ClearField(addonratecard.FieldUnitConfig, field.TypeString)
 	}
 	if _u.mutation.AddonCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -794,6 +821,18 @@ func (_u *AddonRateCardUpdateOne) ClearDiscounts() *AddonRateCardUpdateOne {
 	return _u
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_u *AddonRateCardUpdateOne) SetUnitConfig(v *productcatalog.UnitConfig) *AddonRateCardUpdateOne {
+	_u.mutation.SetUnitConfig(v)
+	return _u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (_u *AddonRateCardUpdateOne) ClearUnitConfig() *AddonRateCardUpdateOne {
+	_u.mutation.ClearUnitConfig()
+	return _u
+}
+
 // SetAddonID sets the "addon_id" field.
 func (_u *AddonRateCardUpdateOne) SetAddonID(v string) *AddonRateCardUpdateOne {
 	_u.mutation.SetAddonID(v)
@@ -956,6 +995,11 @@ func (_u *AddonRateCardUpdateOne) check() error {
 			return &ValidationError{Name: "discounts", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.discounts": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.unit_config": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.AddonID(); ok {
 		if err := addonratecard.AddonIDValidator(v); err != nil {
 			return &ValidationError{Name: "addon_id", err: fmt.Errorf(`db: validator failed for field "AddonRateCard.addon_id": %w`, err)}
@@ -1077,6 +1121,16 @@ func (_u *AddonRateCardUpdateOne) sqlSave(ctx context.Context) (_node *AddonRate
 	}
 	if _u.mutation.DiscountsCleared() {
 		_spec.ClearField(addonratecard.FieldDiscounts, field.TypeString)
+	}
+	if value, ok := _u.mutation.UnitConfig(); ok {
+		vv, err := addonratecard.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return nil, err
+		}
+		_spec.SetField(addonratecard.FieldUnitConfig, field.TypeString, vv)
+	}
+	if _u.mutation.UnitConfigCleared() {
+		_spec.ClearField(addonratecard.FieldUnitConfig, field.TypeString)
 	}
 	if _u.mutation.AddonCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/openmeter/ent/db/chargeusagebased.go
+++ b/openmeter/ent/db/chargeusagebased.go
@@ -99,6 +99,8 @@ type ChargeUsageBased struct {
 	RatingEngine usagebased.RatingEngine `json:"rating_engine,omitempty"`
 	// Price holds the value of the "price" field.
 	Price *productcatalog.Price `json:"price,omitempty"`
+	// UnitConfig holds the value of the "unit_config" field.
+	UnitConfig *productcatalog.UnitConfig `json:"unit_config,omitempty"`
 	// CurrentRealizationRunID holds the value of the "current_realization_run_id" field.
 	CurrentRealizationRunID *string `json:"current_realization_run_id,omitempty"`
 	// StatusDetailed holds the value of the "status_detailed" field.
@@ -270,6 +272,8 @@ func (*ChargeUsageBased) scanValues(columns []string) ([]any, error) {
 			values[i] = chargeusagebased.ValueScanner.Discounts.ScanValue()
 		case chargeusagebased.FieldPrice:
 			values[i] = chargeusagebased.ValueScanner.Price.ScanValue()
+		case chargeusagebased.FieldUnitConfig:
+			values[i] = chargeusagebased.ValueScanner.UnitConfig.ScanValue()
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -502,6 +506,12 @@ func (_m *ChargeUsageBased) assignValues(columns []string, values []any) error {
 			} else {
 				_m.Price = value
 			}
+		case chargeusagebased.FieldUnitConfig:
+			if value, err := chargeusagebased.ValueScanner.UnitConfig.FromValue(values[i]); err != nil {
+				return err
+			} else {
+				_m.UnitConfig = value
+			}
 		case chargeusagebased.FieldCurrentRealizationRunID:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field current_realization_run_id", values[i])
@@ -724,6 +734,11 @@ func (_m *ChargeUsageBased) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("price=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Price))
+	builder.WriteString(", ")
+	if v := _m.UnitConfig; v != nil {
+		builder.WriteString("unit_config=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
 	builder.WriteString(", ")
 	if v := _m.CurrentRealizationRunID; v != nil {
 		builder.WriteString("current_realization_run_id=")

--- a/openmeter/ent/db/chargeusagebased/chargeusagebased.go
+++ b/openmeter/ent/db/chargeusagebased/chargeusagebased.go
@@ -86,6 +86,8 @@ const (
 	FieldRatingEngine = "rating_engine"
 	// FieldPrice holds the string denoting the price field in the database.
 	FieldPrice = "price"
+	// FieldUnitConfig holds the string denoting the unit_config field in the database.
+	FieldUnitConfig = "unit_config"
 	// FieldCurrentRealizationRunID holds the string denoting the current_realization_run_id field in the database.
 	FieldCurrentRealizationRunID = "current_realization_run_id"
 	// FieldStatusDetailed holds the string denoting the status_detailed field in the database.
@@ -229,6 +231,7 @@ var Columns = []string{
 	FieldFeatureID,
 	FieldRatingEngine,
 	FieldPrice,
+	FieldUnitConfig,
 	FieldCurrentRealizationRunID,
 	FieldStatusDetailed,
 }
@@ -266,8 +269,9 @@ var (
 	DefaultID func() string
 	// ValueScanner of all ChargeUsageBased fields.
 	ValueScanner struct {
-		Discounts field.TypeValueScanner[*productcatalog.Discounts]
-		Price     field.TypeValueScanner[*productcatalog.Price]
+		Discounts  field.TypeValueScanner[*productcatalog.Discounts]
+		Price      field.TypeValueScanner[*productcatalog.Price]
+		UnitConfig field.TypeValueScanner[*productcatalog.UnitConfig]
 	}
 )
 
@@ -492,6 +496,11 @@ func ByRatingEngine(opts ...sql.OrderTermOption) OrderOption {
 // ByPrice orders the results by the price field.
 func ByPrice(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldPrice, opts...).ToFunc()
+}
+
+// ByUnitConfig orders the results by the unit_config field.
+func ByUnitConfig(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldUnitConfig, opts...).ToFunc()
 }
 
 // ByCurrentRealizationRunID orders the results by the current_realization_run_id field.

--- a/openmeter/ent/db/chargeusagebased/where.go
+++ b/openmeter/ent/db/chargeusagebased/where.go
@@ -1745,6 +1745,16 @@ func RatingEngineNotIn(vs ...usagebased.RatingEngine) predicate.ChargeUsageBased
 	return predicate.ChargeUsageBased(sql.FieldNotIn(FieldRatingEngine, v...))
 }
 
+// UnitConfigIsNil applies the IsNil predicate on the "unit_config" field.
+func UnitConfigIsNil() predicate.ChargeUsageBased {
+	return predicate.ChargeUsageBased(sql.FieldIsNull(FieldUnitConfig))
+}
+
+// UnitConfigNotNil applies the NotNil predicate on the "unit_config" field.
+func UnitConfigNotNil() predicate.ChargeUsageBased {
+	return predicate.ChargeUsageBased(sql.FieldNotNull(FieldUnitConfig))
+}
+
 // CurrentRealizationRunIDEQ applies the EQ predicate on the "current_realization_run_id" field.
 func CurrentRealizationRunIDEQ(v string) predicate.ChargeUsageBased {
 	return predicate.ChargeUsageBased(sql.FieldEQ(FieldCurrentRealizationRunID, v))

--- a/openmeter/ent/db/chargeusagebased_create.go
+++ b/openmeter/ent/db/chargeusagebased_create.go
@@ -325,6 +325,12 @@ func (_c *ChargeUsageBasedCreate) SetPrice(v *productcatalog.Price) *ChargeUsage
 	return _c
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_c *ChargeUsageBasedCreate) SetUnitConfig(v *productcatalog.UnitConfig) *ChargeUsageBasedCreate {
+	_c.mutation.SetUnitConfig(v)
+	return _c
+}
+
 // SetCurrentRealizationRunID sets the "current_realization_run_id" field.
 func (_c *ChargeUsageBasedCreate) SetCurrentRealizationRunID(v string) *ChargeUsageBasedCreate {
 	_c.mutation.SetCurrentRealizationRunID(v)
@@ -655,6 +661,11 @@ func (_c *ChargeUsageBasedCreate) check() error {
 			return &ValidationError{Name: "price", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.price": %w`, err)}
 		}
 	}
+	if v, ok := _c.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.unit_config": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.StatusDetailed(); !ok {
 		return &ValidationError{Name: "status_detailed", err: errors.New(`db: missing required field "ChargeUsageBased.status_detailed"`)}
 	}
@@ -826,6 +837,14 @@ func (_c *ChargeUsageBasedCreate) createSpec() (*ChargeUsageBased, *sqlgraph.Cre
 		}
 		_spec.SetField(chargeusagebased.FieldPrice, field.TypeString, vv)
 		_node.Price = value
+	}
+	if value, ok := _c.mutation.UnitConfig(); ok {
+		vv, err := chargeusagebased.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return nil, nil, err
+		}
+		_spec.SetField(chargeusagebased.FieldUnitConfig, field.TypeString, vv)
+		_node.UnitConfig = value
 	}
 	if value, ok := _c.mutation.StatusDetailed(); ok {
 		_spec.SetField(chargeusagebased.FieldStatusDetailed, field.TypeEnum, value)
@@ -1420,6 +1439,24 @@ func (u *ChargeUsageBasedUpsert) UpdatePrice() *ChargeUsageBasedUpsert {
 	return u
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (u *ChargeUsageBasedUpsert) SetUnitConfig(v *productcatalog.UnitConfig) *ChargeUsageBasedUpsert {
+	u.Set(chargeusagebased.FieldUnitConfig, v)
+	return u
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *ChargeUsageBasedUpsert) UpdateUnitConfig() *ChargeUsageBasedUpsert {
+	u.SetExcluded(chargeusagebased.FieldUnitConfig)
+	return u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *ChargeUsageBasedUpsert) ClearUnitConfig() *ChargeUsageBasedUpsert {
+	u.SetNull(chargeusagebased.FieldUnitConfig)
+	return u
+}
+
 // SetCurrentRealizationRunID sets the "current_realization_run_id" field.
 func (u *ChargeUsageBasedUpsert) SetCurrentRealizationRunID(v string) *ChargeUsageBasedUpsert {
 	u.Set(chargeusagebased.FieldCurrentRealizationRunID, v)
@@ -1932,6 +1969,27 @@ func (u *ChargeUsageBasedUpsertOne) SetPrice(v *productcatalog.Price) *ChargeUsa
 func (u *ChargeUsageBasedUpsertOne) UpdatePrice() *ChargeUsageBasedUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedUpsert) {
 		s.UpdatePrice()
+	})
+}
+
+// SetUnitConfig sets the "unit_config" field.
+func (u *ChargeUsageBasedUpsertOne) SetUnitConfig(v *productcatalog.UnitConfig) *ChargeUsageBasedUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.SetUnitConfig(v)
+	})
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *ChargeUsageBasedUpsertOne) UpdateUnitConfig() *ChargeUsageBasedUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.UpdateUnitConfig()
+	})
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *ChargeUsageBasedUpsertOne) ClearUnitConfig() *ChargeUsageBasedUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.ClearUnitConfig()
 	})
 }
 
@@ -2622,6 +2680,27 @@ func (u *ChargeUsageBasedUpsertBulk) SetPrice(v *productcatalog.Price) *ChargeUs
 func (u *ChargeUsageBasedUpsertBulk) UpdatePrice() *ChargeUsageBasedUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedUpsert) {
 		s.UpdatePrice()
+	})
+}
+
+// SetUnitConfig sets the "unit_config" field.
+func (u *ChargeUsageBasedUpsertBulk) SetUnitConfig(v *productcatalog.UnitConfig) *ChargeUsageBasedUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.SetUnitConfig(v)
+	})
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *ChargeUsageBasedUpsertBulk) UpdateUnitConfig() *ChargeUsageBasedUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.UpdateUnitConfig()
+	})
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *ChargeUsageBasedUpsertBulk) ClearUnitConfig() *ChargeUsageBasedUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedUpsert) {
+		s.ClearUnitConfig()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebased_update.go
+++ b/openmeter/ent/db/chargeusagebased_update.go
@@ -403,6 +403,18 @@ func (_u *ChargeUsageBasedUpdate) SetPrice(v *productcatalog.Price) *ChargeUsage
 	return _u
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_u *ChargeUsageBasedUpdate) SetUnitConfig(v *productcatalog.UnitConfig) *ChargeUsageBasedUpdate {
+	_u.mutation.SetUnitConfig(v)
+	return _u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (_u *ChargeUsageBasedUpdate) ClearUnitConfig() *ChargeUsageBasedUpdate {
+	_u.mutation.ClearUnitConfig()
+	return _u
+}
+
 // SetCurrentRealizationRunID sets the "current_realization_run_id" field.
 func (_u *ChargeUsageBasedUpdate) SetCurrentRealizationRunID(v string) *ChargeUsageBasedUpdate {
 	_u.mutation.SetCurrentRealizationRunID(v)
@@ -680,6 +692,11 @@ func (_u *ChargeUsageBasedUpdate) check() error {
 			return &ValidationError{Name: "price", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.price": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.unit_config": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.StatusDetailed(); ok {
 		if err := chargeusagebased.StatusDetailedValidator(v); err != nil {
 			return &ValidationError{Name: "status_detailed", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.status_detailed": %w`, err)}
@@ -809,6 +826,16 @@ func (_u *ChargeUsageBasedUpdate) sqlSave(ctx context.Context) (_node int, err e
 			return 0, err
 		}
 		_spec.SetField(chargeusagebased.FieldPrice, field.TypeString, vv)
+	}
+	if value, ok := _u.mutation.UnitConfig(); ok {
+		vv, err := chargeusagebased.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return 0, err
+		}
+		_spec.SetField(chargeusagebased.FieldUnitConfig, field.TypeString, vv)
+	}
+	if _u.mutation.UnitConfigCleared() {
+		_spec.ClearField(chargeusagebased.FieldUnitConfig, field.TypeString)
 	}
 	if value, ok := _u.mutation.StatusDetailed(); ok {
 		_spec.SetField(chargeusagebased.FieldStatusDetailed, field.TypeEnum, value)
@@ -1432,6 +1459,18 @@ func (_u *ChargeUsageBasedUpdateOne) SetPrice(v *productcatalog.Price) *ChargeUs
 	return _u
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_u *ChargeUsageBasedUpdateOne) SetUnitConfig(v *productcatalog.UnitConfig) *ChargeUsageBasedUpdateOne {
+	_u.mutation.SetUnitConfig(v)
+	return _u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (_u *ChargeUsageBasedUpdateOne) ClearUnitConfig() *ChargeUsageBasedUpdateOne {
+	_u.mutation.ClearUnitConfig()
+	return _u
+}
+
 // SetCurrentRealizationRunID sets the "current_realization_run_id" field.
 func (_u *ChargeUsageBasedUpdateOne) SetCurrentRealizationRunID(v string) *ChargeUsageBasedUpdateOne {
 	_u.mutation.SetCurrentRealizationRunID(v)
@@ -1722,6 +1761,11 @@ func (_u *ChargeUsageBasedUpdateOne) check() error {
 			return &ValidationError{Name: "price", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.price": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.unit_config": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.StatusDetailed(); ok {
 		if err := chargeusagebased.StatusDetailedValidator(v); err != nil {
 			return &ValidationError{Name: "status_detailed", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBased.status_detailed": %w`, err)}
@@ -1868,6 +1912,16 @@ func (_u *ChargeUsageBasedUpdateOne) sqlSave(ctx context.Context) (_node *Charge
 			return nil, err
 		}
 		_spec.SetField(chargeusagebased.FieldPrice, field.TypeString, vv)
+	}
+	if value, ok := _u.mutation.UnitConfig(); ok {
+		vv, err := chargeusagebased.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return nil, err
+		}
+		_spec.SetField(chargeusagebased.FieldUnitConfig, field.TypeString, vv)
+	}
+	if _u.mutation.UnitConfigCleared() {
+		_spec.ClearField(chargeusagebased.FieldUnitConfig, field.TypeString)
 	}
 	if value, ok := _u.mutation.StatusDetailed(); ok {
 		_spec.SetField(chargeusagebased.FieldStatusDetailed, field.TypeEnum, value)

--- a/openmeter/ent/db/chargeusagebasedoverride.go
+++ b/openmeter/ent/db/chargeusagebasedoverride.go
@@ -57,6 +57,8 @@ type ChargeUsageBasedOverride struct {
 	Price *productcatalog.Price `json:"price,omitempty"`
 	// Discounts holds the value of the "discounts" field.
 	Discounts *productcatalog.Discounts `json:"discounts,omitempty"`
+	// UnitConfig holds the value of the "unit_config" field.
+	UnitConfig *productcatalog.UnitConfig `json:"unit_config,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the ChargeUsageBasedOverrideQuery when eager-loading is set.
 	Edges        ChargeUsageBasedOverrideEdges `json:"edges"`
@@ -111,6 +113,8 @@ func (*ChargeUsageBasedOverride) scanValues(columns []string) ([]any, error) {
 			values[i] = chargeusagebasedoverride.ValueScanner.Price.ScanValue()
 		case chargeusagebasedoverride.FieldDiscounts:
 			values[i] = chargeusagebasedoverride.ValueScanner.Discounts.ScanValue()
+		case chargeusagebasedoverride.FieldUnitConfig:
+			values[i] = chargeusagebasedoverride.ValueScanner.UnitConfig.ScanValue()
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -244,6 +248,12 @@ func (_m *ChargeUsageBasedOverride) assignValues(columns []string, values []any)
 			} else {
 				_m.Discounts = value
 			}
+		case chargeusagebasedoverride.FieldUnitConfig:
+			if value, err := chargeusagebasedoverride.ValueScanner.UnitConfig.FromValue(values[i]); err != nil {
+				return err
+			} else {
+				_m.UnitConfig = value
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -353,6 +363,11 @@ func (_m *ChargeUsageBasedOverride) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("discounts=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Discounts))
+	builder.WriteString(", ")
+	if v := _m.UnitConfig; v != nil {
+		builder.WriteString("unit_config=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/openmeter/ent/db/chargeusagebasedoverride/chargeusagebasedoverride.go
+++ b/openmeter/ent/db/chargeusagebasedoverride/chargeusagebasedoverride.go
@@ -51,6 +51,8 @@ const (
 	FieldPrice = "price"
 	// FieldDiscounts holds the string denoting the discounts field in the database.
 	FieldDiscounts = "discounts"
+	// FieldUnitConfig holds the string denoting the unit_config field in the database.
+	FieldUnitConfig = "unit_config"
 	// EdgeUsageBased holds the string denoting the usage_based edge name in mutations.
 	EdgeUsageBased = "usage_based"
 	// EdgeTaxCode holds the string denoting the tax_code edge name in mutations.
@@ -94,6 +96,7 @@ var Columns = []string{
 	FieldFeatureKey,
 	FieldPrice,
 	FieldDiscounts,
+	FieldUnitConfig,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -117,9 +120,10 @@ var (
 	DefaultID func() string
 	// ValueScanner of all ChargeUsageBasedOverride fields.
 	ValueScanner struct {
-		Metadata  field.TypeValueScanner[*models.Metadata]
-		Price     field.TypeValueScanner[*productcatalog.Price]
-		Discounts field.TypeValueScanner[*productcatalog.Discounts]
+		Metadata   field.TypeValueScanner[*models.Metadata]
+		Price      field.TypeValueScanner[*productcatalog.Price]
+		Discounts  field.TypeValueScanner[*productcatalog.Discounts]
+		UnitConfig field.TypeValueScanner[*productcatalog.UnitConfig]
 	}
 )
 
@@ -219,6 +223,11 @@ func ByPrice(opts ...sql.OrderTermOption) OrderOption {
 // ByDiscounts orders the results by the discounts field.
 func ByDiscounts(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDiscounts, opts...).ToFunc()
+}
+
+// ByUnitConfig orders the results by the unit_config field.
+func ByUnitConfig(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldUnitConfig, opts...).ToFunc()
 }
 
 // ByUsageBasedField orders the results by usage_based field.

--- a/openmeter/ent/db/chargeusagebasedoverride/where.go
+++ b/openmeter/ent/db/chargeusagebasedoverride/where.go
@@ -986,6 +986,16 @@ func FeatureKeyContainsFold(v string) predicate.ChargeUsageBasedOverride {
 	return predicate.ChargeUsageBasedOverride(sql.FieldContainsFold(FieldFeatureKey, v))
 }
 
+// UnitConfigIsNil applies the IsNil predicate on the "unit_config" field.
+func UnitConfigIsNil() predicate.ChargeUsageBasedOverride {
+	return predicate.ChargeUsageBasedOverride(sql.FieldIsNull(FieldUnitConfig))
+}
+
+// UnitConfigNotNil applies the NotNil predicate on the "unit_config" field.
+func UnitConfigNotNil() predicate.ChargeUsageBasedOverride {
+	return predicate.ChargeUsageBasedOverride(sql.FieldNotNull(FieldUnitConfig))
+}
+
 // HasUsageBased applies the HasEdge predicate on the "usage_based" edge.
 func HasUsageBased() predicate.ChargeUsageBasedOverride {
 	return predicate.ChargeUsageBasedOverride(func(s *sql.Selector) {

--- a/openmeter/ent/db/chargeusagebasedoverride_create.go
+++ b/openmeter/ent/db/chargeusagebasedoverride_create.go
@@ -167,6 +167,12 @@ func (_c *ChargeUsageBasedOverrideCreate) SetDiscounts(v *productcatalog.Discoun
 	return _c
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_c *ChargeUsageBasedOverrideCreate) SetUnitConfig(v *productcatalog.UnitConfig) *ChargeUsageBasedOverrideCreate {
+	_c.mutation.SetUnitConfig(v)
+	return _c
+}
+
 // SetID sets the "id" field.
 func (_c *ChargeUsageBasedOverrideCreate) SetID(v string) *ChargeUsageBasedOverrideCreate {
 	_c.mutation.SetID(v)
@@ -309,6 +315,11 @@ func (_c *ChargeUsageBasedOverrideCreate) check() error {
 			return &ValidationError{Name: "discounts", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedOverride.discounts": %w`, err)}
 		}
 	}
+	if v, ok := _c.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedOverride.unit_config": %w`, err)}
+		}
+	}
 	if len(_c.mutation.UsageBasedIDs()) == 0 {
 		return &ValidationError{Name: "usage_based", err: errors.New(`db: missing required edge "ChargeUsageBasedOverride.usage_based"`)}
 	}
@@ -426,6 +437,14 @@ func (_c *ChargeUsageBasedOverrideCreate) createSpec() (*ChargeUsageBasedOverrid
 		}
 		_spec.SetField(chargeusagebasedoverride.FieldDiscounts, field.TypeString, vv)
 		_node.Discounts = value
+	}
+	if value, ok := _c.mutation.UnitConfig(); ok {
+		vv, err := chargeusagebasedoverride.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return nil, nil, err
+		}
+		_spec.SetField(chargeusagebasedoverride.FieldUnitConfig, field.TypeString, vv)
+		_node.UnitConfig = value
 	}
 	if nodes := _c.mutation.UsageBasedIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -732,6 +751,24 @@ func (u *ChargeUsageBasedOverrideUpsert) SetDiscounts(v *productcatalog.Discount
 // UpdateDiscounts sets the "discounts" field to the value that was provided on create.
 func (u *ChargeUsageBasedOverrideUpsert) UpdateDiscounts() *ChargeUsageBasedOverrideUpsert {
 	u.SetExcluded(chargeusagebasedoverride.FieldDiscounts)
+	return u
+}
+
+// SetUnitConfig sets the "unit_config" field.
+func (u *ChargeUsageBasedOverrideUpsert) SetUnitConfig(v *productcatalog.UnitConfig) *ChargeUsageBasedOverrideUpsert {
+	u.Set(chargeusagebasedoverride.FieldUnitConfig, v)
+	return u
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *ChargeUsageBasedOverrideUpsert) UpdateUnitConfig() *ChargeUsageBasedOverrideUpsert {
+	u.SetExcluded(chargeusagebasedoverride.FieldUnitConfig)
+	return u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *ChargeUsageBasedOverrideUpsert) ClearUnitConfig() *ChargeUsageBasedOverrideUpsert {
+	u.SetNull(chargeusagebasedoverride.FieldUnitConfig)
 	return u
 }
 
@@ -1045,6 +1082,27 @@ func (u *ChargeUsageBasedOverrideUpsertOne) SetDiscounts(v *productcatalog.Disco
 func (u *ChargeUsageBasedOverrideUpsertOne) UpdateDiscounts() *ChargeUsageBasedOverrideUpsertOne {
 	return u.Update(func(s *ChargeUsageBasedOverrideUpsert) {
 		s.UpdateDiscounts()
+	})
+}
+
+// SetUnitConfig sets the "unit_config" field.
+func (u *ChargeUsageBasedOverrideUpsertOne) SetUnitConfig(v *productcatalog.UnitConfig) *ChargeUsageBasedOverrideUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedOverrideUpsert) {
+		s.SetUnitConfig(v)
+	})
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *ChargeUsageBasedOverrideUpsertOne) UpdateUnitConfig() *ChargeUsageBasedOverrideUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedOverrideUpsert) {
+		s.UpdateUnitConfig()
+	})
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *ChargeUsageBasedOverrideUpsertOne) ClearUnitConfig() *ChargeUsageBasedOverrideUpsertOne {
+	return u.Update(func(s *ChargeUsageBasedOverrideUpsert) {
+		s.ClearUnitConfig()
 	})
 }
 
@@ -1528,6 +1586,27 @@ func (u *ChargeUsageBasedOverrideUpsertBulk) SetDiscounts(v *productcatalog.Disc
 func (u *ChargeUsageBasedOverrideUpsertBulk) UpdateDiscounts() *ChargeUsageBasedOverrideUpsertBulk {
 	return u.Update(func(s *ChargeUsageBasedOverrideUpsert) {
 		s.UpdateDiscounts()
+	})
+}
+
+// SetUnitConfig sets the "unit_config" field.
+func (u *ChargeUsageBasedOverrideUpsertBulk) SetUnitConfig(v *productcatalog.UnitConfig) *ChargeUsageBasedOverrideUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedOverrideUpsert) {
+		s.SetUnitConfig(v)
+	})
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *ChargeUsageBasedOverrideUpsertBulk) UpdateUnitConfig() *ChargeUsageBasedOverrideUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedOverrideUpsert) {
+		s.UpdateUnitConfig()
+	})
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *ChargeUsageBasedOverrideUpsertBulk) ClearUnitConfig() *ChargeUsageBasedOverrideUpsertBulk {
+	return u.Update(func(s *ChargeUsageBasedOverrideUpsert) {
+		s.ClearUnitConfig()
 	})
 }
 

--- a/openmeter/ent/db/chargeusagebasedoverride_update.go
+++ b/openmeter/ent/db/chargeusagebasedoverride_update.go
@@ -261,6 +261,18 @@ func (_u *ChargeUsageBasedOverrideUpdate) SetDiscounts(v *productcatalog.Discoun
 	return _u
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_u *ChargeUsageBasedOverrideUpdate) SetUnitConfig(v *productcatalog.UnitConfig) *ChargeUsageBasedOverrideUpdate {
+	_u.mutation.SetUnitConfig(v)
+	return _u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (_u *ChargeUsageBasedOverrideUpdate) ClearUnitConfig() *ChargeUsageBasedOverrideUpdate {
+	_u.mutation.ClearUnitConfig()
+	return _u
+}
+
 // SetTaxCode sets the "tax_code" edge to the TaxCode entity.
 func (_u *ChargeUsageBasedOverrideUpdate) SetTaxCode(v *TaxCode) *ChargeUsageBasedOverrideUpdate {
 	return _u.SetTaxCodeID(v.ID)
@@ -329,6 +341,11 @@ func (_u *ChargeUsageBasedOverrideUpdate) check() error {
 	if v, ok := _u.mutation.Discounts(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "discounts", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedOverride.discounts": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedOverride.unit_config": %w`, err)}
 		}
 	}
 	if _u.mutation.UsageBasedCleared() && len(_u.mutation.UsageBasedIDs()) > 0 {
@@ -417,6 +434,16 @@ func (_u *ChargeUsageBasedOverrideUpdate) sqlSave(ctx context.Context) (_node in
 			return 0, err
 		}
 		_spec.SetField(chargeusagebasedoverride.FieldDiscounts, field.TypeString, vv)
+	}
+	if value, ok := _u.mutation.UnitConfig(); ok {
+		vv, err := chargeusagebasedoverride.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return 0, err
+		}
+		_spec.SetField(chargeusagebasedoverride.FieldUnitConfig, field.TypeString, vv)
+	}
+	if _u.mutation.UnitConfigCleared() {
+		_spec.ClearField(chargeusagebasedoverride.FieldUnitConfig, field.TypeString)
 	}
 	if _u.mutation.TaxCodeCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -697,6 +724,18 @@ func (_u *ChargeUsageBasedOverrideUpdateOne) SetDiscounts(v *productcatalog.Disc
 	return _u
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_u *ChargeUsageBasedOverrideUpdateOne) SetUnitConfig(v *productcatalog.UnitConfig) *ChargeUsageBasedOverrideUpdateOne {
+	_u.mutation.SetUnitConfig(v)
+	return _u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (_u *ChargeUsageBasedOverrideUpdateOne) ClearUnitConfig() *ChargeUsageBasedOverrideUpdateOne {
+	_u.mutation.ClearUnitConfig()
+	return _u
+}
+
 // SetTaxCode sets the "tax_code" edge to the TaxCode entity.
 func (_u *ChargeUsageBasedOverrideUpdateOne) SetTaxCode(v *TaxCode) *ChargeUsageBasedOverrideUpdateOne {
 	return _u.SetTaxCodeID(v.ID)
@@ -778,6 +817,11 @@ func (_u *ChargeUsageBasedOverrideUpdateOne) check() error {
 	if v, ok := _u.mutation.Discounts(); ok {
 		if err := v.Validate(); err != nil {
 			return &ValidationError{Name: "discounts", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedOverride.discounts": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "ChargeUsageBasedOverride.unit_config": %w`, err)}
 		}
 	}
 	if _u.mutation.UsageBasedCleared() && len(_u.mutation.UsageBasedIDs()) > 0 {
@@ -883,6 +927,16 @@ func (_u *ChargeUsageBasedOverrideUpdateOne) sqlSave(ctx context.Context) (_node
 			return nil, err
 		}
 		_spec.SetField(chargeusagebasedoverride.FieldDiscounts, field.TypeString, vv)
+	}
+	if value, ok := _u.mutation.UnitConfig(); ok {
+		vv, err := chargeusagebasedoverride.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return nil, err
+		}
+		_spec.SetField(chargeusagebasedoverride.FieldUnitConfig, field.TypeString, vv)
+	}
+	if _u.mutation.UnitConfigCleared() {
+		_spec.ClearField(chargeusagebasedoverride.FieldUnitConfig, field.TypeString)
 	}
 	if _u.mutation.TaxCodeCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -92,6 +92,7 @@ var (
 		{Name: "billing_cadence", Type: field.TypeString, Nullable: true},
 		{Name: "price", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "discounts", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
+		{Name: "unit_config", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "addon_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "feature_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "tax_code_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -104,19 +105,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "addon_rate_cards_addons_ratecards",
-				Columns:    []*schema.Column{AddonRateCardsColumns[17]},
+				Columns:    []*schema.Column{AddonRateCardsColumns[18]},
 				RefColumns: []*schema.Column{AddonsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "addon_rate_cards_features_addon_ratecard",
-				Columns:    []*schema.Column{AddonRateCardsColumns[18]},
+				Columns:    []*schema.Column{AddonRateCardsColumns[19]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "addon_rate_cards_tax_codes_addon_rate_cards",
-				Columns:    []*schema.Column{AddonRateCardsColumns[19]},
+				Columns:    []*schema.Column{AddonRateCardsColumns[20]},
 				RefColumns: []*schema.Column{TaxCodesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -145,12 +146,12 @@ var (
 			{
 				Name:    "addonratecard_tax_code_id",
 				Unique:  false,
-				Columns: []*schema.Column{AddonRateCardsColumns[19]},
+				Columns: []*schema.Column{AddonRateCardsColumns[20]},
 			},
 			{
 				Name:    "addonratecard_addon_id_key",
 				Unique:  true,
-				Columns: []*schema.Column{AddonRateCardsColumns[17], AddonRateCardsColumns[8]},
+				Columns: []*schema.Column{AddonRateCardsColumns[18], AddonRateCardsColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "deleted_at IS NULL",
 				},
@@ -158,7 +159,7 @@ var (
 			{
 				Name:    "addonratecard_addon_id_feature_key",
 				Unique:  true,
-				Columns: []*schema.Column{AddonRateCardsColumns[17], AddonRateCardsColumns[11]},
+				Columns: []*schema.Column{AddonRateCardsColumns[18], AddonRateCardsColumns[11]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "deleted_at IS NULL",
 				},
@@ -2467,6 +2468,7 @@ var (
 		{Name: "feature_key", Type: field.TypeString},
 		{Name: "rating_engine", Type: field.TypeEnum, Enums: []string{"delta", "period_preserving"}},
 		{Name: "price", Type: field.TypeString, SchemaType: map[string]string{"postgres": "jsonb"}},
+		{Name: "unit_config", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "status_detailed", Type: field.TypeEnum, Enums: []string{"created", "active", "active.partial_invoice.started", "active.partial_invoice.waiting_for_collection", "active.partial_invoice.processing", "active.partial_invoice.issuing", "active.partial_invoice.completed", "active.final_realization.started", "active.final_realization.waiting_for_collection", "active.final_realization.processing", "active.final_realization.issuing", "active.final_realization.completed", "active.awaiting_payment_settlement", "final", "deleted"}},
 		{Name: "current_realization_run_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "customer_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -2484,43 +2486,43 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_charge_usage_based_runs_current_run",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[29]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[30]},
 				RefColumns: []*schema.Column{ChargeUsageBasedRunsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_customers_charges_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[30]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[31]},
 				RefColumns: []*schema.Column{CustomersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "charge_usage_based_features_usage_based_charges",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[31]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[32]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "charge_usage_based_subscriptions_charges_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[32]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[33]},
 				RefColumns: []*schema.Column{SubscriptionsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_subscription_items_charges_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[33]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[34]},
 				RefColumns: []*schema.Column{SubscriptionItemsColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_subscription_phases_charges_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[34]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[35]},
 				RefColumns: []*schema.Column{SubscriptionPhasesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "charge_usage_based_tax_codes_charge_usage_based",
-				Columns:    []*schema.Column{ChargeUsageBasedColumns[35]},
+				Columns:    []*schema.Column{ChargeUsageBasedColumns[36]},
 				RefColumns: []*schema.Column{TaxCodesColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -2529,7 +2531,7 @@ var (
 			{
 				Name:    "chargeusagebased_namespace_customer_id_unique_reference_id",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeUsageBasedColumns[14], ChargeUsageBasedColumns[30], ChargeUsageBasedColumns[8]},
+				Columns: []*schema.Column{ChargeUsageBasedColumns[14], ChargeUsageBasedColumns[31], ChargeUsageBasedColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "unique_reference_id IS NOT NULL AND deleted_at IS NULL",
 				},
@@ -2562,7 +2564,7 @@ var (
 			{
 				Name:    "chargeusagebased_tax_code_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedColumns[35]},
+				Columns: []*schema.Column{ChargeUsageBasedColumns[36]},
 			},
 		},
 	}
@@ -2585,6 +2587,7 @@ var (
 		{Name: "feature_key", Type: field.TypeString},
 		{Name: "price", Type: field.TypeString, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "discounts", Type: field.TypeString, SchemaType: map[string]string{"postgres": "jsonb"}},
+		{Name: "unit_config", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "charge_id", Type: field.TypeString, Unique: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "tax_code_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 	}
@@ -2596,13 +2599,13 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "charge_usage_based_overrides_charge_usage_based_intent_override",
-				Columns:    []*schema.Column{ChargeUsageBasedOverridesColumns[17]},
+				Columns:    []*schema.Column{ChargeUsageBasedOverridesColumns[18]},
 				RefColumns: []*schema.Column{ChargeUsageBasedColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "charge_usage_based_overrides_tax_codes_charge_usage_based_overrides",
-				Columns:    []*schema.Column{ChargeUsageBasedOverridesColumns[18]},
+				Columns:    []*schema.Column{ChargeUsageBasedOverridesColumns[19]},
 				RefColumns: []*schema.Column{TaxCodesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -2621,12 +2624,12 @@ var (
 			{
 				Name:    "chargeusagebasedoverrides_tax_code_id",
 				Unique:  false,
-				Columns: []*schema.Column{ChargeUsageBasedOverridesColumns[18]},
+				Columns: []*schema.Column{ChargeUsageBasedOverridesColumns[19]},
 			},
 			{
 				Name:    "chargeusagebasedoverride_namespace_charge_id",
 				Unique:  true,
-				Columns: []*schema.Column{ChargeUsageBasedOverridesColumns[1], ChargeUsageBasedOverridesColumns[17]},
+				Columns: []*schema.Column{ChargeUsageBasedOverridesColumns[1], ChargeUsageBasedOverridesColumns[18]},
 			},
 		},
 	}
@@ -4609,6 +4612,7 @@ var (
 		{Name: "billing_cadence", Type: field.TypeString, Nullable: true},
 		{Name: "price", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "discounts", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
+		{Name: "unit_config", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "feature_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "phase_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "tax_code_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
@@ -4621,19 +4625,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "plan_rate_cards_features_ratecard",
-				Columns:    []*schema.Column{PlanRateCardsColumns[17]},
+				Columns:    []*schema.Column{PlanRateCardsColumns[18]},
 				RefColumns: []*schema.Column{FeaturesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
 			{
 				Symbol:     "plan_rate_cards_plan_phases_ratecards",
-				Columns:    []*schema.Column{PlanRateCardsColumns[18]},
+				Columns:    []*schema.Column{PlanRateCardsColumns[19]},
 				RefColumns: []*schema.Column{PlanPhasesColumns[0]},
 				OnDelete:   schema.Cascade,
 			},
 			{
 				Symbol:     "plan_rate_cards_tax_codes_plan_rate_cards",
-				Columns:    []*schema.Column{PlanRateCardsColumns[19]},
+				Columns:    []*schema.Column{PlanRateCardsColumns[20]},
 				RefColumns: []*schema.Column{TaxCodesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -4662,12 +4666,12 @@ var (
 			{
 				Name:    "planratecard_tax_code_id",
 				Unique:  false,
-				Columns: []*schema.Column{PlanRateCardsColumns[19]},
+				Columns: []*schema.Column{PlanRateCardsColumns[20]},
 			},
 			{
 				Name:    "planratecard_phase_id_key",
 				Unique:  true,
-				Columns: []*schema.Column{PlanRateCardsColumns[18], PlanRateCardsColumns[8]},
+				Columns: []*schema.Column{PlanRateCardsColumns[19], PlanRateCardsColumns[8]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "deleted_at IS NULL",
 				},
@@ -4675,7 +4679,7 @@ var (
 			{
 				Name:    "planratecard_phase_id_feature_key",
 				Unique:  true,
-				Columns: []*schema.Column{PlanRateCardsColumns[18], PlanRateCardsColumns[11]},
+				Columns: []*schema.Column{PlanRateCardsColumns[19], PlanRateCardsColumns[11]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "deleted_at IS NULL",
 				},

--- a/openmeter/ent/db/mutation.go
+++ b/openmeter/ent/db/mutation.go
@@ -1680,6 +1680,7 @@ type AddonRateCardMutation struct {
 	billing_cadence      *datetime.ISODurationString
 	price                **productcatalog.Price
 	discounts            **productcatalog.Discounts
+	unit_config          **productcatalog.UnitConfig
 	clearedFields        map[string]struct{}
 	addon                *string
 	clearedaddon         bool
@@ -2551,6 +2552,55 @@ func (m *AddonRateCardMutation) ResetDiscounts() {
 	delete(m.clearedFields, addonratecard.FieldDiscounts)
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (m *AddonRateCardMutation) SetUnitConfig(pc *productcatalog.UnitConfig) {
+	m.unit_config = &pc
+}
+
+// UnitConfig returns the value of the "unit_config" field in the mutation.
+func (m *AddonRateCardMutation) UnitConfig() (r *productcatalog.UnitConfig, exists bool) {
+	v := m.unit_config
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldUnitConfig returns the old "unit_config" field's value of the AddonRateCard entity.
+// If the AddonRateCard object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *AddonRateCardMutation) OldUnitConfig(ctx context.Context) (v *productcatalog.UnitConfig, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldUnitConfig is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldUnitConfig requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldUnitConfig: %w", err)
+	}
+	return oldValue.UnitConfig, nil
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (m *AddonRateCardMutation) ClearUnitConfig() {
+	m.unit_config = nil
+	m.clearedFields[addonratecard.FieldUnitConfig] = struct{}{}
+}
+
+// UnitConfigCleared returns if the "unit_config" field was cleared in this mutation.
+func (m *AddonRateCardMutation) UnitConfigCleared() bool {
+	_, ok := m.clearedFields[addonratecard.FieldUnitConfig]
+	return ok
+}
+
+// ResetUnitConfig resets all changes to the "unit_config" field.
+func (m *AddonRateCardMutation) ResetUnitConfig() {
+	m.unit_config = nil
+	delete(m.clearedFields, addonratecard.FieldUnitConfig)
+}
+
 // SetAddonID sets the "addon_id" field.
 func (m *AddonRateCardMutation) SetAddonID(s string) {
 	m.addon = &s
@@ -2764,7 +2814,7 @@ func (m *AddonRateCardMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *AddonRateCardMutation) Fields() []string {
-	fields := make([]string, 0, 19)
+	fields := make([]string, 0, 20)
 	if m.namespace != nil {
 		fields = append(fields, addonratecard.FieldNamespace)
 	}
@@ -2816,6 +2866,9 @@ func (m *AddonRateCardMutation) Fields() []string {
 	if m.discounts != nil {
 		fields = append(fields, addonratecard.FieldDiscounts)
 	}
+	if m.unit_config != nil {
+		fields = append(fields, addonratecard.FieldUnitConfig)
+	}
 	if m.addon != nil {
 		fields = append(fields, addonratecard.FieldAddonID)
 	}
@@ -2864,6 +2917,8 @@ func (m *AddonRateCardMutation) Field(name string) (ent.Value, bool) {
 		return m.Price()
 	case addonratecard.FieldDiscounts:
 		return m.Discounts()
+	case addonratecard.FieldUnitConfig:
+		return m.UnitConfig()
 	case addonratecard.FieldAddonID:
 		return m.AddonID()
 	case addonratecard.FieldFeatureID:
@@ -2911,6 +2966,8 @@ func (m *AddonRateCardMutation) OldField(ctx context.Context, name string) (ent.
 		return m.OldPrice(ctx)
 	case addonratecard.FieldDiscounts:
 		return m.OldDiscounts(ctx)
+	case addonratecard.FieldUnitConfig:
+		return m.OldUnitConfig(ctx)
 	case addonratecard.FieldAddonID:
 		return m.OldAddonID(ctx)
 	case addonratecard.FieldFeatureID:
@@ -3043,6 +3100,13 @@ func (m *AddonRateCardMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetDiscounts(v)
 		return nil
+	case addonratecard.FieldUnitConfig:
+		v, ok := value.(*productcatalog.UnitConfig)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetUnitConfig(v)
+		return nil
 	case addonratecard.FieldAddonID:
 		v, ok := value.(string)
 		if !ok {
@@ -3120,6 +3184,9 @@ func (m *AddonRateCardMutation) ClearedFields() []string {
 	if m.FieldCleared(addonratecard.FieldDiscounts) {
 		fields = append(fields, addonratecard.FieldDiscounts)
 	}
+	if m.FieldCleared(addonratecard.FieldUnitConfig) {
+		fields = append(fields, addonratecard.FieldUnitConfig)
+	}
 	if m.FieldCleared(addonratecard.FieldFeatureID) {
 		fields = append(fields, addonratecard.FieldFeatureID)
 	}
@@ -3169,6 +3236,9 @@ func (m *AddonRateCardMutation) ClearField(name string) error {
 		return nil
 	case addonratecard.FieldDiscounts:
 		m.ClearDiscounts()
+		return nil
+	case addonratecard.FieldUnitConfig:
+		m.ClearUnitConfig()
 		return nil
 	case addonratecard.FieldFeatureID:
 		m.ClearFeatureID()
@@ -3231,6 +3301,9 @@ func (m *AddonRateCardMutation) ResetField(name string) error {
 		return nil
 	case addonratecard.FieldDiscounts:
 		m.ResetDiscounts()
+		return nil
+	case addonratecard.FieldUnitConfig:
+		m.ResetUnitConfig()
 		return nil
 	case addonratecard.FieldAddonID:
 		m.ResetAddonID()
@@ -55240,6 +55313,7 @@ type ChargeUsageBasedMutation struct {
 	feature_key               *string
 	rating_engine             *usagebased.RatingEngine
 	price                     **productcatalog.Price
+	unit_config               **productcatalog.UnitConfig
 	status_detailed           *usagebased.Status
 	clearedFields             map[string]struct{}
 	runs                      map[string]struct{}
@@ -56719,6 +56793,55 @@ func (m *ChargeUsageBasedMutation) ResetPrice() {
 	m.price = nil
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (m *ChargeUsageBasedMutation) SetUnitConfig(pc *productcatalog.UnitConfig) {
+	m.unit_config = &pc
+}
+
+// UnitConfig returns the value of the "unit_config" field in the mutation.
+func (m *ChargeUsageBasedMutation) UnitConfig() (r *productcatalog.UnitConfig, exists bool) {
+	v := m.unit_config
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldUnitConfig returns the old "unit_config" field's value of the ChargeUsageBased entity.
+// If the ChargeUsageBased object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedMutation) OldUnitConfig(ctx context.Context) (v *productcatalog.UnitConfig, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldUnitConfig is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldUnitConfig requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldUnitConfig: %w", err)
+	}
+	return oldValue.UnitConfig, nil
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (m *ChargeUsageBasedMutation) ClearUnitConfig() {
+	m.unit_config = nil
+	m.clearedFields[chargeusagebased.FieldUnitConfig] = struct{}{}
+}
+
+// UnitConfigCleared returns if the "unit_config" field was cleared in this mutation.
+func (m *ChargeUsageBasedMutation) UnitConfigCleared() bool {
+	_, ok := m.clearedFields[chargeusagebased.FieldUnitConfig]
+	return ok
+}
+
+// ResetUnitConfig resets all changes to the "unit_config" field.
+func (m *ChargeUsageBasedMutation) ResetUnitConfig() {
+	m.unit_config = nil
+	delete(m.clearedFields, chargeusagebased.FieldUnitConfig)
+}
+
 // SetCurrentRealizationRunID sets the "current_realization_run_id" field.
 func (m *ChargeUsageBasedMutation) SetCurrentRealizationRunID(s string) {
 	m.current_run = &s
@@ -57226,7 +57349,7 @@ func (m *ChargeUsageBasedMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedMutation) Fields() []string {
-	fields := make([]string, 0, 35)
+	fields := make([]string, 0, 36)
 	if m.customer != nil {
 		fields = append(fields, chargeusagebased.FieldCustomerID)
 	}
@@ -57326,6 +57449,9 @@ func (m *ChargeUsageBasedMutation) Fields() []string {
 	if m.price != nil {
 		fields = append(fields, chargeusagebased.FieldPrice)
 	}
+	if m.unit_config != nil {
+		fields = append(fields, chargeusagebased.FieldUnitConfig)
+	}
 	if m.current_run != nil {
 		fields = append(fields, chargeusagebased.FieldCurrentRealizationRunID)
 	}
@@ -57406,6 +57532,8 @@ func (m *ChargeUsageBasedMutation) Field(name string) (ent.Value, bool) {
 		return m.RatingEngine()
 	case chargeusagebased.FieldPrice:
 		return m.Price()
+	case chargeusagebased.FieldUnitConfig:
+		return m.UnitConfig()
 	case chargeusagebased.FieldCurrentRealizationRunID:
 		return m.CurrentRealizationRunID()
 	case chargeusagebased.FieldStatusDetailed:
@@ -57485,6 +57613,8 @@ func (m *ChargeUsageBasedMutation) OldField(ctx context.Context, name string) (e
 		return m.OldRatingEngine(ctx)
 	case chargeusagebased.FieldPrice:
 		return m.OldPrice(ctx)
+	case chargeusagebased.FieldUnitConfig:
+		return m.OldUnitConfig(ctx)
 	case chargeusagebased.FieldCurrentRealizationRunID:
 		return m.OldCurrentRealizationRunID(ctx)
 	case chargeusagebased.FieldStatusDetailed:
@@ -57729,6 +57859,13 @@ func (m *ChargeUsageBasedMutation) SetField(name string, value ent.Value) error 
 		}
 		m.SetPrice(v)
 		return nil
+	case chargeusagebased.FieldUnitConfig:
+		v, ok := value.(*productcatalog.UnitConfig)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetUnitConfig(v)
+		return nil
 	case chargeusagebased.FieldCurrentRealizationRunID:
 		v, ok := value.(string)
 		if !ok {
@@ -57809,6 +57946,9 @@ func (m *ChargeUsageBasedMutation) ClearedFields() []string {
 	if m.FieldCleared(chargeusagebased.FieldDiscounts) {
 		fields = append(fields, chargeusagebased.FieldDiscounts)
 	}
+	if m.FieldCleared(chargeusagebased.FieldUnitConfig) {
+		fields = append(fields, chargeusagebased.FieldUnitConfig)
+	}
 	if m.FieldCleared(chargeusagebased.FieldCurrentRealizationRunID) {
 		fields = append(fields, chargeusagebased.FieldCurrentRealizationRunID)
 	}
@@ -57861,6 +58001,9 @@ func (m *ChargeUsageBasedMutation) ClearField(name string) error {
 		return nil
 	case chargeusagebased.FieldDiscounts:
 		m.ClearDiscounts()
+		return nil
+	case chargeusagebased.FieldUnitConfig:
+		m.ClearUnitConfig()
 		return nil
 	case chargeusagebased.FieldCurrentRealizationRunID:
 		m.ClearCurrentRealizationRunID()
@@ -57971,6 +58114,9 @@ func (m *ChargeUsageBasedMutation) ResetField(name string) error {
 		return nil
 	case chargeusagebased.FieldPrice:
 		m.ResetPrice()
+		return nil
+	case chargeusagebased.FieldUnitConfig:
+		m.ResetUnitConfig()
 		return nil
 	case chargeusagebased.FieldCurrentRealizationRunID:
 		m.ResetCurrentRealizationRunID()
@@ -58276,6 +58422,7 @@ type ChargeUsageBasedOverrideMutation struct {
 	feature_key              *string
 	price                    **productcatalog.Price
 	discounts                **productcatalog.Discounts
+	unit_config              **productcatalog.UnitConfig
 	clearedFields            map[string]struct{}
 	usage_based              *string
 	clearedusage_based       bool
@@ -59103,6 +59250,55 @@ func (m *ChargeUsageBasedOverrideMutation) ResetDiscounts() {
 	m.discounts = nil
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (m *ChargeUsageBasedOverrideMutation) SetUnitConfig(pc *productcatalog.UnitConfig) {
+	m.unit_config = &pc
+}
+
+// UnitConfig returns the value of the "unit_config" field in the mutation.
+func (m *ChargeUsageBasedOverrideMutation) UnitConfig() (r *productcatalog.UnitConfig, exists bool) {
+	v := m.unit_config
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldUnitConfig returns the old "unit_config" field's value of the ChargeUsageBasedOverride entity.
+// If the ChargeUsageBasedOverride object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ChargeUsageBasedOverrideMutation) OldUnitConfig(ctx context.Context) (v *productcatalog.UnitConfig, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldUnitConfig is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldUnitConfig requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldUnitConfig: %w", err)
+	}
+	return oldValue.UnitConfig, nil
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (m *ChargeUsageBasedOverrideMutation) ClearUnitConfig() {
+	m.unit_config = nil
+	m.clearedFields[chargeusagebasedoverride.FieldUnitConfig] = struct{}{}
+}
+
+// UnitConfigCleared returns if the "unit_config" field was cleared in this mutation.
+func (m *ChargeUsageBasedOverrideMutation) UnitConfigCleared() bool {
+	_, ok := m.clearedFields[chargeusagebasedoverride.FieldUnitConfig]
+	return ok
+}
+
+// ResetUnitConfig resets all changes to the "unit_config" field.
+func (m *ChargeUsageBasedOverrideMutation) ResetUnitConfig() {
+	m.unit_config = nil
+	delete(m.clearedFields, chargeusagebasedoverride.FieldUnitConfig)
+}
+
 // SetUsageBasedID sets the "usage_based" edge to the ChargeUsageBased entity by id.
 func (m *ChargeUsageBasedOverrideMutation) SetUsageBasedID(id string) {
 	m.usage_based = &id
@@ -59204,7 +59400,7 @@ func (m *ChargeUsageBasedOverrideMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ChargeUsageBasedOverrideMutation) Fields() []string {
-	fields := make([]string, 0, 18)
+	fields := make([]string, 0, 19)
 	if m.namespace != nil {
 		fields = append(fields, chargeusagebasedoverride.FieldNamespace)
 	}
@@ -59259,6 +59455,9 @@ func (m *ChargeUsageBasedOverrideMutation) Fields() []string {
 	if m.discounts != nil {
 		fields = append(fields, chargeusagebasedoverride.FieldDiscounts)
 	}
+	if m.unit_config != nil {
+		fields = append(fields, chargeusagebasedoverride.FieldUnitConfig)
+	}
 	return fields
 }
 
@@ -59303,6 +59502,8 @@ func (m *ChargeUsageBasedOverrideMutation) Field(name string) (ent.Value, bool) 
 		return m.Price()
 	case chargeusagebasedoverride.FieldDiscounts:
 		return m.Discounts()
+	case chargeusagebasedoverride.FieldUnitConfig:
+		return m.UnitConfig()
 	}
 	return nil, false
 }
@@ -59348,6 +59549,8 @@ func (m *ChargeUsageBasedOverrideMutation) OldField(ctx context.Context, name st
 		return m.OldPrice(ctx)
 	case chargeusagebasedoverride.FieldDiscounts:
 		return m.OldDiscounts(ctx)
+	case chargeusagebasedoverride.FieldUnitConfig:
+		return m.OldUnitConfig(ctx)
 	}
 	return nil, fmt.Errorf("unknown ChargeUsageBasedOverride field %s", name)
 }
@@ -59483,6 +59686,13 @@ func (m *ChargeUsageBasedOverrideMutation) SetField(name string, value ent.Value
 		}
 		m.SetDiscounts(v)
 		return nil
+	case chargeusagebasedoverride.FieldUnitConfig:
+		v, ok := value.(*productcatalog.UnitConfig)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetUnitConfig(v)
+		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedOverride field %s", name)
 }
@@ -59528,6 +59738,9 @@ func (m *ChargeUsageBasedOverrideMutation) ClearedFields() []string {
 	if m.FieldCleared(chargeusagebasedoverride.FieldIntentDeletedAt) {
 		fields = append(fields, chargeusagebasedoverride.FieldIntentDeletedAt)
 	}
+	if m.FieldCleared(chargeusagebasedoverride.FieldUnitConfig) {
+		fields = append(fields, chargeusagebasedoverride.FieldUnitConfig)
+	}
 	return fields
 }
 
@@ -59556,6 +59769,9 @@ func (m *ChargeUsageBasedOverrideMutation) ClearField(name string) error {
 		return nil
 	case chargeusagebasedoverride.FieldIntentDeletedAt:
 		m.ClearIntentDeletedAt()
+		return nil
+	case chargeusagebasedoverride.FieldUnitConfig:
+		m.ClearUnitConfig()
 		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedOverride nullable field %s", name)
@@ -59618,6 +59834,9 @@ func (m *ChargeUsageBasedOverrideMutation) ResetField(name string) error {
 		return nil
 	case chargeusagebasedoverride.FieldDiscounts:
 		m.ResetDiscounts()
+		return nil
+	case chargeusagebasedoverride.FieldUnitConfig:
+		m.ResetUnitConfig()
 		return nil
 	}
 	return fmt.Errorf("unknown ChargeUsageBasedOverride field %s", name)
@@ -98970,6 +99189,7 @@ type PlanRateCardMutation struct {
 	billing_cadence      *datetime.ISODurationString
 	price                **productcatalog.Price
 	discounts            **productcatalog.Discounts
+	unit_config          **productcatalog.UnitConfig
 	clearedFields        map[string]struct{}
 	phase                *string
 	clearedphase         bool
@@ -99841,6 +100061,55 @@ func (m *PlanRateCardMutation) ResetDiscounts() {
 	delete(m.clearedFields, planratecard.FieldDiscounts)
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (m *PlanRateCardMutation) SetUnitConfig(pc *productcatalog.UnitConfig) {
+	m.unit_config = &pc
+}
+
+// UnitConfig returns the value of the "unit_config" field in the mutation.
+func (m *PlanRateCardMutation) UnitConfig() (r *productcatalog.UnitConfig, exists bool) {
+	v := m.unit_config
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldUnitConfig returns the old "unit_config" field's value of the PlanRateCard entity.
+// If the PlanRateCard object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PlanRateCardMutation) OldUnitConfig(ctx context.Context) (v *productcatalog.UnitConfig, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldUnitConfig is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldUnitConfig requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldUnitConfig: %w", err)
+	}
+	return oldValue.UnitConfig, nil
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (m *PlanRateCardMutation) ClearUnitConfig() {
+	m.unit_config = nil
+	m.clearedFields[planratecard.FieldUnitConfig] = struct{}{}
+}
+
+// UnitConfigCleared returns if the "unit_config" field was cleared in this mutation.
+func (m *PlanRateCardMutation) UnitConfigCleared() bool {
+	_, ok := m.clearedFields[planratecard.FieldUnitConfig]
+	return ok
+}
+
+// ResetUnitConfig resets all changes to the "unit_config" field.
+func (m *PlanRateCardMutation) ResetUnitConfig() {
+	m.unit_config = nil
+	delete(m.clearedFields, planratecard.FieldUnitConfig)
+}
+
 // SetPhaseID sets the "phase_id" field.
 func (m *PlanRateCardMutation) SetPhaseID(s string) {
 	m.phase = &s
@@ -100054,7 +100323,7 @@ func (m *PlanRateCardMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PlanRateCardMutation) Fields() []string {
-	fields := make([]string, 0, 19)
+	fields := make([]string, 0, 20)
 	if m.namespace != nil {
 		fields = append(fields, planratecard.FieldNamespace)
 	}
@@ -100106,6 +100375,9 @@ func (m *PlanRateCardMutation) Fields() []string {
 	if m.discounts != nil {
 		fields = append(fields, planratecard.FieldDiscounts)
 	}
+	if m.unit_config != nil {
+		fields = append(fields, planratecard.FieldUnitConfig)
+	}
 	if m.phase != nil {
 		fields = append(fields, planratecard.FieldPhaseID)
 	}
@@ -100154,6 +100426,8 @@ func (m *PlanRateCardMutation) Field(name string) (ent.Value, bool) {
 		return m.Price()
 	case planratecard.FieldDiscounts:
 		return m.Discounts()
+	case planratecard.FieldUnitConfig:
+		return m.UnitConfig()
 	case planratecard.FieldPhaseID:
 		return m.PhaseID()
 	case planratecard.FieldFeatureID:
@@ -100201,6 +100475,8 @@ func (m *PlanRateCardMutation) OldField(ctx context.Context, name string) (ent.V
 		return m.OldPrice(ctx)
 	case planratecard.FieldDiscounts:
 		return m.OldDiscounts(ctx)
+	case planratecard.FieldUnitConfig:
+		return m.OldUnitConfig(ctx)
 	case planratecard.FieldPhaseID:
 		return m.OldPhaseID(ctx)
 	case planratecard.FieldFeatureID:
@@ -100333,6 +100609,13 @@ func (m *PlanRateCardMutation) SetField(name string, value ent.Value) error {
 		}
 		m.SetDiscounts(v)
 		return nil
+	case planratecard.FieldUnitConfig:
+		v, ok := value.(*productcatalog.UnitConfig)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetUnitConfig(v)
+		return nil
 	case planratecard.FieldPhaseID:
 		v, ok := value.(string)
 		if !ok {
@@ -100410,6 +100693,9 @@ func (m *PlanRateCardMutation) ClearedFields() []string {
 	if m.FieldCleared(planratecard.FieldDiscounts) {
 		fields = append(fields, planratecard.FieldDiscounts)
 	}
+	if m.FieldCleared(planratecard.FieldUnitConfig) {
+		fields = append(fields, planratecard.FieldUnitConfig)
+	}
 	if m.FieldCleared(planratecard.FieldFeatureID) {
 		fields = append(fields, planratecard.FieldFeatureID)
 	}
@@ -100459,6 +100745,9 @@ func (m *PlanRateCardMutation) ClearField(name string) error {
 		return nil
 	case planratecard.FieldDiscounts:
 		m.ClearDiscounts()
+		return nil
+	case planratecard.FieldUnitConfig:
+		m.ClearUnitConfig()
 		return nil
 	case planratecard.FieldFeatureID:
 		m.ClearFeatureID()
@@ -100521,6 +100810,9 @@ func (m *PlanRateCardMutation) ResetField(name string) error {
 		return nil
 	case planratecard.FieldDiscounts:
 		m.ResetDiscounts()
+		return nil
+	case planratecard.FieldUnitConfig:
+		m.ResetUnitConfig()
 		return nil
 	case planratecard.FieldPhaseID:
 		m.ResetPhaseID()

--- a/openmeter/ent/db/planratecard.go
+++ b/openmeter/ent/db/planratecard.go
@@ -57,6 +57,8 @@ type PlanRateCard struct {
 	Price *productcatalog.Price `json:"price,omitempty"`
 	// Discounts holds the value of the "discounts" field.
 	Discounts *productcatalog.Discounts `json:"discounts,omitempty"`
+	// UnitConfig holds the value of the "unit_config" field.
+	UnitConfig *productcatalog.UnitConfig `json:"unit_config,omitempty"`
 	// The phase identifier the ratecard is assigned to.
 	PhaseID string `json:"phase_id,omitempty"`
 	// The feature identifier the ratecard is related to.
@@ -132,6 +134,8 @@ func (*PlanRateCard) scanValues(columns []string) ([]any, error) {
 			values[i] = planratecard.ValueScanner.Price.ScanValue()
 		case planratecard.FieldDiscounts:
 			values[i] = planratecard.ValueScanner.Discounts.ScanValue()
+		case planratecard.FieldUnitConfig:
+			values[i] = planratecard.ValueScanner.UnitConfig.ScanValue()
 		default:
 			values[i] = new(sql.UnknownType)
 		}
@@ -262,6 +266,12 @@ func (_m *PlanRateCard) assignValues(columns []string, values []any) error {
 				return err
 			} else {
 				_m.Discounts = value
+			}
+		case planratecard.FieldUnitConfig:
+			if value, err := planratecard.ValueScanner.UnitConfig.FromValue(values[i]); err != nil {
+				return err
+			} else {
+				_m.UnitConfig = value
 			}
 		case planratecard.FieldPhaseID:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -395,6 +405,11 @@ func (_m *PlanRateCard) String() string {
 	builder.WriteString(", ")
 	if v := _m.Discounts; v != nil {
 		builder.WriteString("discounts=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	if v := _m.UnitConfig; v != nil {
+		builder.WriteString("unit_config=")
 		builder.WriteString(fmt.Sprintf("%v", *v))
 	}
 	builder.WriteString(", ")

--- a/openmeter/ent/db/planratecard/planratecard.go
+++ b/openmeter/ent/db/planratecard/planratecard.go
@@ -51,6 +51,8 @@ const (
 	FieldPrice = "price"
 	// FieldDiscounts holds the string denoting the discounts field in the database.
 	FieldDiscounts = "discounts"
+	// FieldUnitConfig holds the string denoting the unit_config field in the database.
+	FieldUnitConfig = "unit_config"
 	// FieldPhaseID holds the string denoting the phase_id field in the database.
 	FieldPhaseID = "phase_id"
 	// FieldFeatureID holds the string denoting the feature_id field in the database.
@@ -106,6 +108,7 @@ var Columns = []string{
 	FieldBillingCadence,
 	FieldPrice,
 	FieldDiscounts,
+	FieldUnitConfig,
 	FieldPhaseID,
 	FieldFeatureID,
 }
@@ -141,6 +144,7 @@ var (
 		TaxConfig           field.TypeValueScanner[*productcatalog.TaxConfig]
 		Price               field.TypeValueScanner[*productcatalog.Price]
 		Discounts           field.TypeValueScanner[*productcatalog.Discounts]
+		UnitConfig          field.TypeValueScanner[*productcatalog.UnitConfig]
 	}
 )
 
@@ -250,6 +254,11 @@ func ByPrice(opts ...sql.OrderTermOption) OrderOption {
 // ByDiscounts orders the results by the discounts field.
 func ByDiscounts(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDiscounts, opts...).ToFunc()
+}
+
+// ByUnitConfig orders the results by the unit_config field.
+func ByUnitConfig(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldUnitConfig, opts...).ToFunc()
 }
 
 // ByPhaseID orders the results by the phase_id field.

--- a/openmeter/ent/db/planratecard/where.go
+++ b/openmeter/ent/db/planratecard/where.go
@@ -892,6 +892,16 @@ func DiscountsNotNil() predicate.PlanRateCard {
 	return predicate.PlanRateCard(sql.FieldNotNull(FieldDiscounts))
 }
 
+// UnitConfigIsNil applies the IsNil predicate on the "unit_config" field.
+func UnitConfigIsNil() predicate.PlanRateCard {
+	return predicate.PlanRateCard(sql.FieldIsNull(FieldUnitConfig))
+}
+
+// UnitConfigNotNil applies the NotNil predicate on the "unit_config" field.
+func UnitConfigNotNil() predicate.PlanRateCard {
+	return predicate.PlanRateCard(sql.FieldNotNull(FieldUnitConfig))
+}
+
 // PhaseIDEQ applies the EQ predicate on the "phase_id" field.
 func PhaseIDEQ(v string) predicate.PlanRateCard {
 	return predicate.PlanRateCard(sql.FieldEQ(FieldPhaseID, v))

--- a/openmeter/ent/db/planratecard_create.go
+++ b/openmeter/ent/db/planratecard_create.go
@@ -194,6 +194,12 @@ func (_c *PlanRateCardCreate) SetDiscounts(v *productcatalog.Discounts) *PlanRat
 	return _c
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_c *PlanRateCardCreate) SetUnitConfig(v *productcatalog.UnitConfig) *PlanRateCardCreate {
+	_c.mutation.SetUnitConfig(v)
+	return _c
+}
+
 // SetPhaseID sets the "phase_id" field.
 func (_c *PlanRateCardCreate) SetPhaseID(v string) *PlanRateCardCreate {
 	_c.mutation.SetPhaseID(v)
@@ -366,6 +372,11 @@ func (_c *PlanRateCardCreate) check() error {
 			return &ValidationError{Name: "discounts", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.discounts": %w`, err)}
 		}
 	}
+	if v, ok := _c.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.unit_config": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.PhaseID(); !ok {
 		return &ValidationError{Name: "phase_id", err: errors.New(`db: missing required field "PlanRateCard.phase_id"`)}
 	}
@@ -495,6 +506,14 @@ func (_c *PlanRateCardCreate) createSpec() (*PlanRateCard, *sqlgraph.CreateSpec,
 		}
 		_spec.SetField(planratecard.FieldDiscounts, field.TypeString, vv)
 		_node.Discounts = value
+	}
+	if value, ok := _c.mutation.UnitConfig(); ok {
+		vv, err := planratecard.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return nil, nil, err
+		}
+		_spec.SetField(planratecard.FieldUnitConfig, field.TypeString, vv)
+		_node.UnitConfig = value
 	}
 	if nodes := _c.mutation.PhaseIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -818,6 +837,24 @@ func (u *PlanRateCardUpsert) UpdateDiscounts() *PlanRateCardUpsert {
 // ClearDiscounts clears the value of the "discounts" field.
 func (u *PlanRateCardUpsert) ClearDiscounts() *PlanRateCardUpsert {
 	u.SetNull(planratecard.FieldDiscounts)
+	return u
+}
+
+// SetUnitConfig sets the "unit_config" field.
+func (u *PlanRateCardUpsert) SetUnitConfig(v *productcatalog.UnitConfig) *PlanRateCardUpsert {
+	u.Set(planratecard.FieldUnitConfig, v)
+	return u
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *PlanRateCardUpsert) UpdateUnitConfig() *PlanRateCardUpsert {
+	u.SetExcluded(planratecard.FieldUnitConfig)
+	return u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *PlanRateCardUpsert) ClearUnitConfig() *PlanRateCardUpsert {
+	u.SetNull(planratecard.FieldUnitConfig)
 	return u
 }
 
@@ -1167,6 +1204,27 @@ func (u *PlanRateCardUpsertOne) UpdateDiscounts() *PlanRateCardUpsertOne {
 func (u *PlanRateCardUpsertOne) ClearDiscounts() *PlanRateCardUpsertOne {
 	return u.Update(func(s *PlanRateCardUpsert) {
 		s.ClearDiscounts()
+	})
+}
+
+// SetUnitConfig sets the "unit_config" field.
+func (u *PlanRateCardUpsertOne) SetUnitConfig(v *productcatalog.UnitConfig) *PlanRateCardUpsertOne {
+	return u.Update(func(s *PlanRateCardUpsert) {
+		s.SetUnitConfig(v)
+	})
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *PlanRateCardUpsertOne) UpdateUnitConfig() *PlanRateCardUpsertOne {
+	return u.Update(func(s *PlanRateCardUpsert) {
+		s.UpdateUnitConfig()
+	})
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *PlanRateCardUpsertOne) ClearUnitConfig() *PlanRateCardUpsertOne {
+	return u.Update(func(s *PlanRateCardUpsert) {
+		s.ClearUnitConfig()
 	})
 }
 
@@ -1691,6 +1749,27 @@ func (u *PlanRateCardUpsertBulk) UpdateDiscounts() *PlanRateCardUpsertBulk {
 func (u *PlanRateCardUpsertBulk) ClearDiscounts() *PlanRateCardUpsertBulk {
 	return u.Update(func(s *PlanRateCardUpsert) {
 		s.ClearDiscounts()
+	})
+}
+
+// SetUnitConfig sets the "unit_config" field.
+func (u *PlanRateCardUpsertBulk) SetUnitConfig(v *productcatalog.UnitConfig) *PlanRateCardUpsertBulk {
+	return u.Update(func(s *PlanRateCardUpsert) {
+		s.SetUnitConfig(v)
+	})
+}
+
+// UpdateUnitConfig sets the "unit_config" field to the value that was provided on create.
+func (u *PlanRateCardUpsertBulk) UpdateUnitConfig() *PlanRateCardUpsertBulk {
+	return u.Update(func(s *PlanRateCardUpsert) {
+		s.UpdateUnitConfig()
+	})
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (u *PlanRateCardUpsertBulk) ClearUnitConfig() *PlanRateCardUpsertBulk {
+	return u.Update(func(s *PlanRateCardUpsert) {
+		s.ClearUnitConfig()
 	})
 }
 

--- a/openmeter/ent/db/planratecard_update.go
+++ b/openmeter/ent/db/planratecard_update.go
@@ -233,6 +233,18 @@ func (_u *PlanRateCardUpdate) ClearDiscounts() *PlanRateCardUpdate {
 	return _u
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_u *PlanRateCardUpdate) SetUnitConfig(v *productcatalog.UnitConfig) *PlanRateCardUpdate {
+	_u.mutation.SetUnitConfig(v)
+	return _u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (_u *PlanRateCardUpdate) ClearUnitConfig() *PlanRateCardUpdate {
+	_u.mutation.ClearUnitConfig()
+	return _u
+}
+
 // SetPhaseID sets the "phase_id" field.
 func (_u *PlanRateCardUpdate) SetPhaseID(v string) *PlanRateCardUpdate {
 	_u.mutation.SetPhaseID(v)
@@ -382,6 +394,11 @@ func (_u *PlanRateCardUpdate) check() error {
 			return &ValidationError{Name: "discounts", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.discounts": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.unit_config": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.PhaseID(); ok {
 		if err := planratecard.PhaseIDValidator(v); err != nil {
 			return &ValidationError{Name: "phase_id", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.phase_id": %w`, err)}
@@ -486,6 +503,16 @@ func (_u *PlanRateCardUpdate) sqlSave(ctx context.Context) (_node int, err error
 	}
 	if _u.mutation.DiscountsCleared() {
 		_spec.ClearField(planratecard.FieldDiscounts, field.TypeString)
+	}
+	if value, ok := _u.mutation.UnitConfig(); ok {
+		vv, err := planratecard.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return 0, err
+		}
+		_spec.SetField(planratecard.FieldUnitConfig, field.TypeString, vv)
+	}
+	if _u.mutation.UnitConfigCleared() {
+		_spec.ClearField(planratecard.FieldUnitConfig, field.TypeString)
 	}
 	if _u.mutation.PhaseCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -794,6 +821,18 @@ func (_u *PlanRateCardUpdateOne) ClearDiscounts() *PlanRateCardUpdateOne {
 	return _u
 }
 
+// SetUnitConfig sets the "unit_config" field.
+func (_u *PlanRateCardUpdateOne) SetUnitConfig(v *productcatalog.UnitConfig) *PlanRateCardUpdateOne {
+	_u.mutation.SetUnitConfig(v)
+	return _u
+}
+
+// ClearUnitConfig clears the value of the "unit_config" field.
+func (_u *PlanRateCardUpdateOne) ClearUnitConfig() *PlanRateCardUpdateOne {
+	_u.mutation.ClearUnitConfig()
+	return _u
+}
+
 // SetPhaseID sets the "phase_id" field.
 func (_u *PlanRateCardUpdateOne) SetPhaseID(v string) *PlanRateCardUpdateOne {
 	_u.mutation.SetPhaseID(v)
@@ -956,6 +995,11 @@ func (_u *PlanRateCardUpdateOne) check() error {
 			return &ValidationError{Name: "discounts", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.discounts": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.UnitConfig(); ok {
+		if err := v.Validate(); err != nil {
+			return &ValidationError{Name: "unit_config", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.unit_config": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.PhaseID(); ok {
 		if err := planratecard.PhaseIDValidator(v); err != nil {
 			return &ValidationError{Name: "phase_id", err: fmt.Errorf(`db: validator failed for field "PlanRateCard.phase_id": %w`, err)}
@@ -1077,6 +1121,16 @@ func (_u *PlanRateCardUpdateOne) sqlSave(ctx context.Context) (_node *PlanRateCa
 	}
 	if _u.mutation.DiscountsCleared() {
 		_spec.ClearField(planratecard.FieldDiscounts, field.TypeString)
+	}
+	if value, ok := _u.mutation.UnitConfig(); ok {
+		vv, err := planratecard.ValueScanner.UnitConfig.Value(value)
+		if err != nil {
+			return nil, err
+		}
+		_spec.SetField(planratecard.FieldUnitConfig, field.TypeString, vv)
+	}
+	if _u.mutation.UnitConfigCleared() {
+		_spec.ClearField(planratecard.FieldUnitConfig, field.TypeString)
 	}
 	if _u.mutation.PhaseCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/openmeter/ent/db/runtime.go
+++ b/openmeter/ent/db/runtime.go
@@ -180,8 +180,11 @@ func init() {
 	// addonratecardDescDiscounts is the schema descriptor for discounts field.
 	addonratecardDescDiscounts := addonratecardFields[6].Descriptor()
 	addonratecard.ValueScanner.Discounts = addonratecardDescDiscounts.ValueScanner.(field.TypeValueScanner[*productcatalog.Discounts])
+	// addonratecardDescUnitConfig is the schema descriptor for unit_config field.
+	addonratecardDescUnitConfig := addonratecardFields[7].Descriptor()
+	addonratecard.ValueScanner.UnitConfig = addonratecardDescUnitConfig.ValueScanner.(field.TypeValueScanner[*productcatalog.UnitConfig])
 	// addonratecardDescAddonID is the schema descriptor for addon_id field.
-	addonratecardDescAddonID := addonratecardFields[7].Descriptor()
+	addonratecardDescAddonID := addonratecardFields[8].Descriptor()
 	// addonratecard.AddonIDValidator is a validator for the "addon_id" field. It is called by the builders before save.
 	addonratecard.AddonIDValidator = addonratecardDescAddonID.Validators[0].(func(string) error)
 	// addonratecardDescID is the schema descriptor for id field.
@@ -1358,6 +1361,9 @@ func init() {
 	// chargeusagebasedDescPrice is the schema descriptor for price field.
 	chargeusagebasedDescPrice := chargeusagebasedFields[7].Descriptor()
 	chargeusagebased.ValueScanner.Price = chargeusagebasedDescPrice.ValueScanner.(field.TypeValueScanner[*productcatalog.Price])
+	// chargeusagebasedDescUnitConfig is the schema descriptor for unit_config field.
+	chargeusagebasedDescUnitConfig := chargeusagebasedFields[8].Descriptor()
+	chargeusagebased.ValueScanner.UnitConfig = chargeusagebasedDescUnitConfig.ValueScanner.(field.TypeValueScanner[*productcatalog.UnitConfig])
 	// chargeusagebasedDescID is the schema descriptor for id field.
 	chargeusagebasedDescID := chargeusagebasedMixinFields0[18].Descriptor()
 	// chargeusagebased.DefaultID holds the default value on creation for the id field.
@@ -1390,6 +1396,9 @@ func init() {
 	// chargeusagebasedoverrideDescDiscounts is the schema descriptor for discounts field.
 	chargeusagebasedoverrideDescDiscounts := chargeusagebasedoverrideFields[16].Descriptor()
 	chargeusagebasedoverride.ValueScanner.Discounts = chargeusagebasedoverrideDescDiscounts.ValueScanner.(field.TypeValueScanner[*productcatalog.Discounts])
+	// chargeusagebasedoverrideDescUnitConfig is the schema descriptor for unit_config field.
+	chargeusagebasedoverrideDescUnitConfig := chargeusagebasedoverrideFields[17].Descriptor()
+	chargeusagebasedoverride.ValueScanner.UnitConfig = chargeusagebasedoverrideDescUnitConfig.ValueScanner.(field.TypeValueScanner[*productcatalog.UnitConfig])
 	// chargeusagebasedoverrideDescID is the schema descriptor for id field.
 	chargeusagebasedoverrideDescID := chargeusagebasedoverrideMixinFields1[0].Descriptor()
 	// chargeusagebasedoverride.DefaultID holds the default value on creation for the id field.
@@ -2569,8 +2578,11 @@ func init() {
 	// planratecardDescDiscounts is the schema descriptor for discounts field.
 	planratecardDescDiscounts := planratecardFields[6].Descriptor()
 	planratecard.ValueScanner.Discounts = planratecardDescDiscounts.ValueScanner.(field.TypeValueScanner[*productcatalog.Discounts])
+	// planratecardDescUnitConfig is the schema descriptor for unit_config field.
+	planratecardDescUnitConfig := planratecardFields[7].Descriptor()
+	planratecard.ValueScanner.UnitConfig = planratecardDescUnitConfig.ValueScanner.(field.TypeValueScanner[*productcatalog.UnitConfig])
 	// planratecardDescPhaseID is the schema descriptor for phase_id field.
-	planratecardDescPhaseID := planratecardFields[7].Descriptor()
+	planratecardDescPhaseID := planratecardFields[8].Descriptor()
 	// planratecard.PhaseIDValidator is a validator for the "phase_id" field. It is called by the builders before save.
 	planratecard.PhaseIDValidator = planratecardDescPhaseID.Validators[0].(func(string) error)
 	// planratecardDescID is the schema descriptor for id field.

--- a/openmeter/ent/db/setorclear.go
+++ b/openmeter/ent/db/setorclear.go
@@ -257,6 +257,20 @@ func (u *AddonRateCardUpdateOne) SetOrClearDiscounts(value **productcatalog.Disc
 	return u.SetDiscounts(*value)
 }
 
+func (u *AddonRateCardUpdate) SetOrClearUnitConfig(value **productcatalog.UnitConfig) *AddonRateCardUpdate {
+	if value == nil {
+		return u.ClearUnitConfig()
+	}
+	return u.SetUnitConfig(*value)
+}
+
+func (u *AddonRateCardUpdateOne) SetOrClearUnitConfig(value **productcatalog.UnitConfig) *AddonRateCardUpdateOne {
+	if value == nil {
+		return u.ClearUnitConfig()
+	}
+	return u.SetUnitConfig(*value)
+}
+
 func (u *AddonRateCardUpdate) SetOrClearFeatureID(value *string) *AddonRateCardUpdate {
 	if value == nil {
 		return u.ClearFeatureID()
@@ -3169,6 +3183,20 @@ func (u *ChargeUsageBasedUpdateOne) SetOrClearDiscounts(value **productcatalog.D
 	return u.SetDiscounts(*value)
 }
 
+func (u *ChargeUsageBasedUpdate) SetOrClearUnitConfig(value **productcatalog.UnitConfig) *ChargeUsageBasedUpdate {
+	if value == nil {
+		return u.ClearUnitConfig()
+	}
+	return u.SetUnitConfig(*value)
+}
+
+func (u *ChargeUsageBasedUpdateOne) SetOrClearUnitConfig(value **productcatalog.UnitConfig) *ChargeUsageBasedUpdateOne {
+	if value == nil {
+		return u.ClearUnitConfig()
+	}
+	return u.SetUnitConfig(*value)
+}
+
 func (u *ChargeUsageBasedUpdate) SetOrClearCurrentRealizationRunID(value *string) *ChargeUsageBasedUpdate {
 	if value == nil {
 		return u.ClearCurrentRealizationRunID()
@@ -3251,6 +3279,20 @@ func (u *ChargeUsageBasedOverrideUpdateOne) SetOrClearIntentDeletedAt(value *tim
 		return u.ClearIntentDeletedAt()
 	}
 	return u.SetIntentDeletedAt(*value)
+}
+
+func (u *ChargeUsageBasedOverrideUpdate) SetOrClearUnitConfig(value **productcatalog.UnitConfig) *ChargeUsageBasedOverrideUpdate {
+	if value == nil {
+		return u.ClearUnitConfig()
+	}
+	return u.SetUnitConfig(*value)
+}
+
+func (u *ChargeUsageBasedOverrideUpdateOne) SetOrClearUnitConfig(value **productcatalog.UnitConfig) *ChargeUsageBasedOverrideUpdateOne {
+	if value == nil {
+		return u.ClearUnitConfig()
+	}
+	return u.SetUnitConfig(*value)
 }
 
 func (u *ChargeUsageBasedRunCreditAllocationsUpdate) SetOrClearLineID(value *string) *ChargeUsageBasedRunCreditAllocationsUpdate {
@@ -5127,6 +5169,20 @@ func (u *PlanRateCardUpdateOne) SetOrClearDiscounts(value **productcatalog.Disco
 		return u.ClearDiscounts()
 	}
 	return u.SetDiscounts(*value)
+}
+
+func (u *PlanRateCardUpdate) SetOrClearUnitConfig(value **productcatalog.UnitConfig) *PlanRateCardUpdate {
+	if value == nil {
+		return u.ClearUnitConfig()
+	}
+	return u.SetUnitConfig(*value)
+}
+
+func (u *PlanRateCardUpdateOne) SetOrClearUnitConfig(value **productcatalog.UnitConfig) *PlanRateCardUpdateOne {
+	if value == nil {
+		return u.ClearUnitConfig()
+	}
+	return u.SetUnitConfig(*value)
 }
 
 func (u *PlanRateCardUpdate) SetOrClearFeatureID(value *string) *PlanRateCardUpdate {

--- a/openmeter/ent/schema/chargesusagebased.go
+++ b/openmeter/ent/schema/chargesusagebased.go
@@ -72,6 +72,19 @@ func (ChargeUsageBased) Fields() []ent.Field {
 				dialect.Postgres: "jsonb",
 			}),
 
+		// unit_config is a mutable rating input snapshotted from the effective rate
+		// card, living in the mutable-fields layer alongside price and discounts
+		// (price is mutable here, so the conversion that feeds it follows). Set on
+		// create and update; cleared when absent.
+		field.String("unit_config").
+			GoType(&productcatalog.UnitConfig{}).
+			ValueScanner(UnitConfigValueScanner).
+			SchemaType(map[string]string{
+				dialect.Postgres: "jsonb",
+			}).
+			Optional().
+			Nillable(),
+
 		field.String("current_realization_run_id").
 			SchemaType(map[string]string{
 				dialect.Postgres: "char(26)",
@@ -221,6 +234,14 @@ func (ChargeUsageBasedOverride) Fields() []ent.Field {
 			SchemaType(map[string]string{
 				dialect.Postgres: "jsonb",
 			}),
+		field.String("unit_config").
+			GoType(&productcatalog.UnitConfig{}).
+			ValueScanner(UnitConfigValueScanner).
+			SchemaType(map[string]string{
+				dialect.Postgres: "jsonb",
+			}).
+			Optional().
+			Nillable(),
 	}
 }
 

--- a/openmeter/ent/schema/productcatalog.go
+++ b/openmeter/ent/schema/productcatalog.go
@@ -203,5 +203,6 @@ var (
 	TaxConfigValueScanner           = entutils.JSONStringValueScanner[*productcatalog.TaxConfig]()
 	PriceValueScanner               = entutils.JSONStringValueScanner[*productcatalog.Price]()
 	DiscountsValueScanner           = entutils.JSONStringValueScanner[*productcatalog.Discounts]()
+	UnitConfigValueScanner          = entutils.JSONStringValueScanner[*productcatalog.UnitConfig]()
 	ProRatingConfigValueScanner     = entutils.JSONStringValueScanner[productcatalog.ProRatingConfig]()
 )

--- a/openmeter/ent/schema/ratecard.go
+++ b/openmeter/ent/schema/ratecard.go
@@ -62,6 +62,14 @@ func (RateCard) Fields() []ent.Field {
 			}).
 			Optional().
 			Nillable(),
+		field.String("unit_config").
+			GoType(&productcatalog.UnitConfig{}).
+			ValueScanner(UnitConfigValueScanner).
+			SchemaType(map[string]string{
+				dialect.Postgres: "jsonb",
+			}).
+			Optional().
+			Nillable(),
 	)
 
 	return fields

--- a/openmeter/productcatalog/addon/adapter/adapter_test.go
+++ b/openmeter/productcatalog/addon/adapter/adapter_test.go
@@ -111,6 +111,13 @@ func TestPostgresAdapter(t *testing.T) {
 								MaximumAmount: nil,
 							},
 						}),
+						UnitConfig: &productcatalog.UnitConfig{
+							Operation:        productcatalog.UnitConfigOperationDivide,
+							ConversionFactor: decimal.NewFromInt(1000),
+							Rounding:         productcatalog.UnitConfigRoundingModeCeiling,
+							Precision:        0,
+							DisplayUnit:      lo.ToPtr("K"),
+						},
 					},
 					BillingCadence: MonthPeriod,
 				},

--- a/openmeter/productcatalog/addon/adapter/addon.go
+++ b/openmeter/productcatalog/addon/adapter/addon.go
@@ -250,6 +250,10 @@ func rateCardBulkCreate(c *entdb.AddonRateCardClient, rateCards productcatalog.R
 			q.SetPrice(rateCardEntity.Price)
 		}
 
+		if rateCardEntity.UnitConfig != nil {
+			q.SetUnitConfig(rateCardEntity.UnitConfig)
+		}
+
 		bulk = append(bulk, q)
 	}
 

--- a/openmeter/productcatalog/addon/adapter/mapping.go
+++ b/openmeter/productcatalog/addon/adapter/mapping.go
@@ -96,6 +96,7 @@ func FromAddonRateCardRow(r entdb.AddonRateCard) (*addon.RateCard, error) {
 		TaxConfig:           r.TaxConfig,
 		Price:               r.Price,
 		Discounts:           lo.FromPtr(r.Discounts),
+		UnitConfig:          r.UnitConfig,
 	}
 
 	if r.FeatureID != nil || r.FeatureKey != nil {
@@ -369,6 +370,7 @@ func asAddonRateCardRow(r productcatalog.RateCard) (entdb.AddonRateCard, error) 
 		Price:               meta.Price,
 		Type:                r.Type(),
 		Discounts:           lo.EmptyableToPtr(meta.Discounts),
+		UnitConfig:          meta.UnitConfig,
 	}
 
 	if managed, ok := r.(addon.ManagedRateCard); ok {

--- a/openmeter/productcatalog/addon/assert.go
+++ b/openmeter/productcatalog/addon/assert.go
@@ -125,6 +125,8 @@ func AssertRateCardEqual(t *testing.T, r1, r2 productcatalog.RateCard) {
 
 	assert.Truef(t, m1.Price.Equal(m2.Price), "price mismatch")
 
+	assert.Truef(t, m1.UnitConfig.Equal(m2.UnitConfig), "unit config mismatch")
+
 	billingCadence1 := r1.GetBillingCadence().ISOStringPtrOrNil()
 	billingCadence2 := r2.GetBillingCadence().ISOStringPtrOrNil()
 

--- a/openmeter/productcatalog/plan/adapter/adapter_test.go
+++ b/openmeter/productcatalog/plan/adapter/adapter_test.go
@@ -143,6 +143,13 @@ func TestPostgresAdapter(t *testing.T) {
 								MaximumAmount: nil,
 							},
 						}),
+						UnitConfig: &productcatalog.UnitConfig{
+							Operation:        productcatalog.UnitConfigOperationDivide,
+							ConversionFactor: decimal.NewFromInt(1000),
+							Rounding:         productcatalog.UnitConfigRoundingModeCeiling,
+							Precision:        0,
+							DisplayUnit:      lo.ToPtr("K"),
+						},
 					},
 					BillingCadence: pctestutils.MonthPeriod,
 				},

--- a/openmeter/productcatalog/plan/adapter/mapping.go
+++ b/openmeter/productcatalog/plan/adapter/mapping.go
@@ -297,6 +297,7 @@ func fromPlanRateCardRow(r entdb.PlanRateCard) (productcatalog.RateCard, error) 
 		TaxConfig:           r.TaxConfig,
 		Price:               r.Price,
 		Discounts:           lo.FromPtr(r.Discounts),
+		UnitConfig:          r.UnitConfig,
 	}
 
 	if r.FeatureID != nil || r.FeatureKey != nil {
@@ -388,6 +389,7 @@ func asPlanRateCardRow(r productcatalog.RateCard) (entdb.PlanRateCard, error) {
 		Price:               meta.Price,
 		Type:                r.Type(),
 		Discounts:           lo.EmptyableToPtr(meta.Discounts),
+		UnitConfig:          meta.UnitConfig,
 	}
 
 	if managed, ok := r.(plan.ManagedRateCard); ok {

--- a/openmeter/productcatalog/plan/adapter/phase.go
+++ b/openmeter/productcatalog/plan/adapter/phase.go
@@ -135,6 +135,10 @@ func rateCardBulkCreate(c *entdb.PlanRateCardClient, rateCards productcatalog.Ra
 			q.SetPrice(rateCardEntity.Price)
 		}
 
+		if rateCardEntity.UnitConfig != nil {
+			q.SetUnitConfig(rateCardEntity.UnitConfig)
+		}
+
 		bulk = append(bulk, q)
 	}
 

--- a/openmeter/productcatalog/plan/assert.go
+++ b/openmeter/productcatalog/plan/assert.go
@@ -200,6 +200,8 @@ func AssertRateCardEqual(t *testing.T, r1, r2 productcatalog.RateCard) {
 
 	assert.Truef(t, m1.Price.Equal(m2.Price), "price mismatch")
 
+	assert.Truef(t, m1.UnitConfig.Equal(m2.UnitConfig), "unit config mismatch")
+
 	billingCadence1 := r1.GetBillingCadence().ISOStringPtrOrNil()
 	billingCadence2 := r2.GetBillingCadence().ISOStringPtrOrNil()
 

--- a/tools/migrate/migrations/20260625202530_add_unit_config.down.sql
+++ b/tools/migrate/migrations/20260625202530_add_unit_config.down.sql
@@ -1,0 +1,8 @@
+-- reverse: modify "plan_rate_cards" table
+ALTER TABLE "plan_rate_cards" DROP COLUMN "unit_config";
+-- reverse: modify "charge_usage_based_overrides" table
+ALTER TABLE "charge_usage_based_overrides" DROP COLUMN "unit_config";
+-- reverse: modify "charge_usage_based" table
+ALTER TABLE "charge_usage_based" DROP COLUMN "unit_config";
+-- reverse: modify "addon_rate_cards" table
+ALTER TABLE "addon_rate_cards" DROP COLUMN "unit_config";

--- a/tools/migrate/migrations/20260625202530_add_unit_config.up.sql
+++ b/tools/migrate/migrations/20260625202530_add_unit_config.up.sql
@@ -1,0 +1,8 @@
+-- modify "addon_rate_cards" table
+ALTER TABLE "addon_rate_cards" ADD COLUMN "unit_config" jsonb NULL;
+-- modify "charge_usage_based" table
+ALTER TABLE "charge_usage_based" ADD COLUMN "unit_config" jsonb NULL;
+-- modify "charge_usage_based_overrides" table
+ALTER TABLE "charge_usage_based_overrides" ADD COLUMN "unit_config" jsonb NULL;
+-- modify "plan_rate_cards" table
+ALTER TABLE "plan_rate_cards" ADD COLUMN "unit_config" jsonb NULL;

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:gIzIGyRiTLdD7VJUBDwhabcYeuZhTHJeBqg1kXJEF7E=
+h1:fVjzHgerEpm1WalMpLe3OYgss0yr4JmrC6kI+m5+a1U=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -214,3 +214,4 @@ h1:gIzIGyRiTLdD7VJUBDwhabcYeuZhTHJeBqg1kXJEF7E=
 20260623101013_add_billing_profile_subscription_end_proration_mode.up.sql h1:XtiMtYP8QL7Z5Lt04VCZ3mf3gMbqZOuu9/EMOnn21Sk=
 20260624043300_charge_intent_override_ddl.up.sql h1:IQckC6jS1yadEgZqiGkOgn51lhdwTt7d2IVDsIWipts=
 20260624135146_remove_deprecated_ent_fields.up.sql h1:x5paHYKtNbRUBkY9UEHdc+fCkdIxIMt3tqfkMDEtfUM=
+20260625202530_add_unit_config.up.sql h1:Ta8PhtlFboqQfTpJ6zhK4HDyivXu5bVAyV75YUxi9QE=


### PR DESCRIPTION
## Overview 

Adds a unit_config jsonb column to the shared rate-card Ent mixin (plan + addon
rate cards), ChargeUsageBased, and ChargeUsageBasedOverride, with a value scanner
and migration, and wires the field through every owned write/read path.

**Where it's wired**
- Plan & addon rate-card adapters: entity mapping (To/FromDB) and the bulk-create
Set* chain (the two paths that silently diverge).
- Charge adapter: create, update, and read mapping — unit_config lives in
IntentMutableFields alongside price/discounts, so it's mutable and set on create
+ update for the base charge and the intent override.
- Round-trip persistence test at each write site (plan, addon, charge base +
override).

**Safety / rollout**
Additive and gated: authoring is rejected unless unitConfig.enabled is set, so
with the flag off the column is always NULL and behavior is unchanged. Nothing
reads unit_config in rating yet (separate ticket), so this is a no-op in
production.

**Out of scope (own tickets)**
Invoice-line snapshot, subscription-sync population of the charge intent and the rating mutator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for unit conversion settings (`unit_config`) across rate cards, usage-based charges, and charge overrides.
  * Usage-based charge intents and overrides now snapshot and validate `unit_config`, with proper deep-copy behavior.
* **Bug Fixes**
  * Fixed missing `unit_config` mapping on charge and override reads, and ensured create/update flows correctly persist or clear `unit_config`.
* **Tests**
  * Added deterministic round-trip tests covering persistence, updates, and clearing of `unit_config` across base and override intent layers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->