### PR TITLE
Support flat fee invoice line delete overrides

### DIFF
--- a/.agents/skills/charges/SKILL.md
+++ b/.agents/skills/charges/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Read, Edit, Write, Bash, Grep, Glob, Agent
 
 Guidance for working with OpenMeter billing charges.
 
-This skill describes the charges package generically. Lifecycle state machines exist for both usage-based and flat-fee credit-only branches. All three charge types (usage-based, flat-fee, credit-purchase) follow the same structural pattern: `ChargeBase`/`Charge` with `Realizations`, own `Status` type, `status_detailed` DB column, and composite adapter interfaces.
+This skill describes the charges package generically. Lifecycle state machines exist for type-specific settlement modes. All three charge types (usage-based, flat-fee, credit-purchase) follow the same structural pattern: `ChargeBase`/`Charge` with `Realizations`, own `Status` type, `status_detailed` DB column, and composite adapter interfaces.
 
 ## Scope
 
@@ -68,6 +68,7 @@ The generic rule is:
 Adapter rules:
 
 - Keep Ent access transaction-aware in `openmeter/billing/charges/.../adapter`, including shared helper functions. Prefer helpers to accept the adapter/repo handle rather than a raw `*entdb.Client`, so `entutils.TransactingRepo(...)` or `entutils.TransactingRepoWithNoValue(...)` can pass the transaction-bound handle from `ctx`. If a helper must accept a raw client, only call it with the swapped handle's client, such as `tx.db` inside the transacting callback.
+- For flat-fee and usage-based adapters, `UpdateCharge(ctx, ChargeBase)` persists charge base-row fields only. Realization-side rows, such as detailed lines, credit allocations/corrections, invoice accruals, payment records, and run/linkage rows, must be persisted through their dedicated adapter methods. Do not call `UpdateCharge(...)` only because expanded `Realizations` changed; expanded realizations are read-model state on the aggregate, not implicit write input.
 
 Important types:
 
@@ -87,7 +88,7 @@ Important types:
   - `Payment`
   - `DetailedLines`
 - `flatfee.Intent.CalculateAmountAfterProration()` computes the prorated amount from `AmountBeforeProration`, `ServicePeriod/FullServicePeriod` ratio, and `ProRating` config, with currency-precision rounding
-- Charge-backed targets do not use invoice-style semantic proration or empty-period filtering; the charge stack materializes and prorates state itself, and the flat fee charge is responsible for omitting empty lines
+- Flat-fee and usage-based charge-backed targets do not use invoice-style semantic proration or empty-period filtering. The charge stack materializes, prorates, and omits empty invoice artifacts according to the charge type's lifecycle rules.
 - `usagebased.OverridableIntent` carries the immutable usage-based intent plus base and optional override mutable layers. Use accessors instead of reading layer fields directly unless the caller explicitly owns the base layer.
 - `usagebased.Intent` is the concrete base/effective intent shape used when creating or cloning a usage-based intent. `Intent.AsOverridableIntent()` maps it into the base layer.
 - `usagebased.ChargeBase` stores the current `Status` and `State`
@@ -143,6 +144,7 @@ Do not emulate every billing rating mutator in the line mapper. Usage discounts 
 Detailed-line expansion rules:
 
 - `meta.ExpandDetailedLines` is not standalone for charge reads; it requires `meta.ExpandRealizations`
+- `meta.ExpandDeletedRealizations` is not standalone for charge reads; it requires `meta.ExpandRealizations`
 - usage-based deleted realization runs are hidden from `meta.ExpandRealizations` by default because their invoice/ledger effect has been cleaned up; request `meta.ExpandDeletedRealizations` together with `meta.ExpandRealizations` only when a caller must inspect cleanup state, such as frontend audit views or deletion tests
 - production code that sums or interprets realization history must explicitly skip runs with `DeletedAt != nil`, documenting the business reason at the guard, because deleted realizations are no longer effective billable history
 - usage-based `invalid_due_to_unsupported_credit_note` realization runs are audit history for immutable invoice lines that should have been removed by prorating/credit-note support. They must not count as billing history for rating, pre-line quantities, or balance-style aggregate checks. Prefer the domain helper (`RealizationRun.IsVoidedBillingHistory()` / `RealizationRuns.WithoutVoidedBillingHistory()`) over ad hoc checks for deleted or unsupported-credit-note runs.
@@ -176,9 +178,12 @@ Important rules:
 - charge-enabled app/test wiring must also register the charge-aware `CreateLineRouter`; billing's default create router intentionally falls back to legacy `billing.LineEngineTypeInvoice`
 - if a charge create path stamps a new `LineEngineType`, app wiring and charge test wiring must register a matching implementation in the same change
 - for charge-backed standard line creation through invoice API edits, billing preallocates the standard line ID before invoking the charge line engine; charge engines should attach charge/realization state to that existing line identity instead of creating a separate line identity
-- usage-based exposes its billing line engine from `usagebased.Service.GetLineEngine()`; register that returned engine instead of reusing the service type directly
-- flat-fee now follows the same pattern: `flatfee.Service.GetLineEngine()` returns the engine owned by the service package
+- flat-fee and usage-based services expose billing line engines through `GetLineEngine()`; register the returned engine instead of reusing the service type directly
 - because flat-fee owns its line engine, `flatfee/service.New(...)` requires a `rating.Service`; forgetting that dependency breaks app/test wiring with `rating service cannot be null`
+- invoice-backed charge line engines must map persisted run/realization state back onto returned standard invoice lines after run creation. Do not rely on state-machine methods mutating a standard-line pointer as their public contract.
+- For invoice-backed charge line engines, flat-fee and usage-based should follow the same structural contract: charge state machines emit invoice patches, and line engines consume those patches at the billing boundary. Standard-line delete patches must flow through the same deleted-standard-line cleanup used by `OnMutableStandardLinesDeletedBySystem(...)` so credit corrections, charge-owned detailed-line cleanup, and deleted-run marking stay consistent.
+- Invoice-backed charge API invoice-line edits/deletes are mediated by emitted invoice patches. Standard-line edits use update target-state patches, gathering-line edits use upsert target-state patches, gathering-line delete patches are validated locally, and standard-line delete patches invoke deleted-standard-line cleanup after the state machine detaches the current run. Zero-proration delete patches are currently rejected unless the charge engine explicitly models that delete result.
+- Usage-based API invoice-line edit/delete support is currently unimplemented; keep returning `billing.ErrCannotUpdateChargeManagedLine` there until it follows the same patch-mediated contract as flat-fee. Credit-purchase is a separate lifecycle and should not be forced into this flat-fee/usage-based structure.
 - for usage-based realization creation, validate at the run-creation boundary (`usagebased/service/run.CreateRatedRunInput.Validate`) that `Charge.State.CurrentRealizationRunID` is nil before creating a new run; keep the line-engine-side early return too so `InvoicePendingLines` fails with the charge-specific validation error at the billing boundary. In both places, key the guard off `CurrentRealizationRunID`, not a specific status prefix such as `partial_invoice`
 - usage-based payment handling is intentionally different from flat-fee and credit-purchase: the usage-based state machine owns realization only, while the usage-based line engine/run service records payment authorization/settlement directly on historical runs and only re-enters the state machine through an aggregate trigger (for example `all_payments_settled`) once all invoiced runs on the charge are settled. Do not apply this rule generically to flat-fee or credit-purchase; those charge types may still keep payment states inside their own state machines.
 - usage-based invoice branches should read in this order: `started -> waiting_for_collection -> processing -> issuing -> completed`, then auto-advance out of the branch. Keep `invoice_issued` as the boundary between `processing` and `issuing`, run `FinalizeInvoiceRun(...)` from the `issuing` state, and let `completed` be the last branch-local status before `next` returns a partial invoice to `active` or moves a final invoice to `active.awaiting_payment_settlement`
@@ -191,12 +196,10 @@ Flat-fee credit-then-invoice lifecycle rules:
 - The charges standard-invoice hook may still run for cross-charge concerns such as revenue recognition and credit-purchase callbacks. For flat-fee invoice statuses, keep the hook processors as no-ops and let the line engine own `OnStandardInvoiceCreated`, `OnCollectionCompleted`, `OnInvoiceIssued`, `OnPaymentAuthorized`, `OnPaymentSettled`, and mutable-line cleanup.
 - Flat-fee `credit_only` is not a line-engine flow; the flat-fee line engine should treat non-`credit_then_invoice` standard invoice callbacks as lifecycle misuse.
 - Flat-fee `credit_then_invoice` charges start as `created`, become `active` at the service-period start, and use `active.realization.*` substates for invoice lifecycle. Keep invoice-issued work in the `issuing` state and only move to `final` after required fiat payment settlement or a no-fiat run.
-- The flat-fee line engine should map persisted run state back onto returned standard invoice lines after run creation. Do not rely on state-machine methods mutating a standard-line pointer as their public contract.
 - `CreateCurrentRun(...)` must fail when the charge already has a non-detached current run. It may be created with invoice and line IDs when the standard line is known; otherwise the caller should pass the required run period and amount explicitly and attach line references later through the normal lifecycle.
 - Flat-fee realization runs use `Immutable` to choose invoice patching behavior. Mutable runs may update the standard line in place; immutable runs require deleting the old invoice line and creating a replacement gathering line when the amount changes. A deleted realization run must never remain the charge's current run.
-- Flat-fee mutable-line deletion cleanup is owned by the line engine callback. The shrink/extend/delete state-machine path should detach the current run before emitting a delete-line patch; `OnMutableStandardLinesDeletedBySystem(...)` should then correct credits, clear charge-owned detailed lines, and mark only the detached run deleted.
 - For flat-fee shrink/extend/manual edit before standard-line creation, update the pending gathering line by charge ID using a full target-state gathering-line patch. Only zero-proration pending gathering targets should emit a delete-by-charge patch. For a mutable standard-line-backed current run, update the same standard line in place. For an immutable current run, keep the old invoice history intact; if the recalculated amount is unchanged, emit no customer-visible invoice change, and if the amount changes, detach the run, create a replacement gathering line, reset the charge to `created`, and set `AdvanceAfter` to the replacement service-period start.
-- Flat-fee API invoice-line edits are handled by the flat-fee line engine through the `ManualEdit` trigger. The state machine owns override persistence. Supported manual API edits must emit exactly one invoice patch scoped to the edited line: standard lines use update target-state patches, gathering lines use upsert target-state patches, and zero-proration delete patches are currently rejected. The line engine consumes that patch locally and returns the target line merged onto the existing invoice-line identity.
+- Flat-fee API invoice-line edits are handled by the flat-fee line engine through the `ManualEdit` trigger. The state machine owns override persistence. The line engine consumes the emitted invoice patch locally and returns the target line merged onto the existing invoice-line identity.
 - Flat-fee shrink/extend should reject while invoice issuing/completion callbacks own the charge state. Subscription sync can retry after billing advances out of those transient states.
 - Flat-fee invoice accrual should not create an accrued-usage row or call the ledger-backed accrual handler when the standard line total is zero. The run can still become immutable and move through the no-fiat finalization path.
 - Flat-fee payment booking is line/run based rather than current-run only: asynchronous payment callbacks must locate the realization run by standard-line ID so detached historical runs can still receive authorization/settlement. No-fiat runs skip payment booking callbacks.
@@ -329,7 +332,7 @@ Current expected behavior:
 - ledger handlers may still defensively tolerate zero and return `ledgertransaction.GroupReference{}`
 - when a service proceeds with non-zero invoice accrual, it must require a non-empty transaction group reference before storing accrued usage
 
-Zero invoice accrual is different from payment booking. Usage-based invoice payment records (`charges/models/payment`) require a positive amount and a real ledger transaction reference. A fully credit-covered standard invoice can reach `payment_processing.pending` with `Totals.Total == 0`, but blindly sending `TriggerPaid` through the normal payment authorization/settlement path can fail with validation errors such as `amount must be positive` and `transaction group ID is required`. Add an explicit zero-total payment no-op path before expecting fully credited invoice-backed usage runs to reach settled payment state.
+Zero invoice accrual is different from payment booking. Invoice-backed charge payment records (`charges/models/payment`) require a positive amount and a real ledger transaction reference. A fully credit-covered standard invoice can reach `payment_processing.pending` with `Totals.Total == 0`, but blindly sending `TriggerPaid` through the normal payment authorization/settlement path can fail with validation errors such as `amount must be positive` and `transaction group ID is required`. Add an explicit zero-total payment no-op path before expecting fully credited invoice-backed runs to reach settled payment state.
 
 ## HTTP/API Conversion
 
@@ -396,12 +399,11 @@ This means a newly created credit-only charge (usage-based or flat fee) that is 
 
 For invoice-settled charges:
 
-- flat fee and credit purchase creation now stamp the gathering line engine in their type-specific `Create(...)` flows
-- usage-based charge creation also stamps `LineEngineTypeChargeUsageBased`; do not introduce this discriminator unless a corresponding billing engine exists or the path is intentionally blocked
+- invoice-settled charge creation must stamp gathering lines with the matching billing line engine whenever that charge type participates in billing line-engine collection. Flat-fee and usage-based must stamp `LineEngineTypeChargeFlatFee` / `LineEngineTypeChargeUsageBased` respectively; credit-purchase has a separate line-engine lifecycle and should be handled explicitly instead of forced into flat-fee/usage-based rules.
 - usage-based `IsLineBillableAsOf(...)` is currently billable only once `asOf >= resolved service period end`; keep the existing progressive-billing TODO in place when touching that logic
-- for usage-based `credit_then_invoice`, `BuildStandardInvoiceLines(...)` is allowed to drive charge lifecycle transitions needed to create the invoice-backed realization run
+- for invoice-backed flat-fee and usage-based charges, `BuildStandardInvoiceLines(...)` is allowed to drive charge lifecycle transitions needed to create or attach the invoice-backed realization/run state
 - `OnCollectionCompleted(...)` is the single collection-time line-engine hook; do not reintroduce a generic shared `SnapshotLines()` abstraction for charge engines
-- prefer explicit usage-based lifecycle triggers such as `invoice_created` and `collection_completed` over generic line-snapshot callbacks
+- prefer explicit charge lifecycle triggers such as `invoice_created` and `collection_completed` over generic line-snapshot callbacks
 - collection-time charge-engine failures must surface as invoice validation issues through the billing line-engine validation flow, not as raw invoice-state-machine failures
 
 ## Root Charges Advance Flow
@@ -625,8 +627,8 @@ Use these conventions for lifecycle tests:
 - prefer `clock.FreezeTime(...)` for exact `StoredAtLT` / `AllocateAt` assertions
 - rely on the default billing profile unless the test explicitly needs customer-specific override behavior
 - for credit-only charges (usage-based or flat fee), `Create(...)` itself may return an already-advanced charge — assert the returned charge's status, do not assume it will be `created`
+- for credit-only charges (usage-based or flat fee), handler callbacks must not return credit allocations above the requested amount; exact allocation paths must return allocations that sum to the requested amount
 - for flat fee credit-only tests, use `mustAdvanceFlatFeeCharges(...)` helper — it filters the advance result to flat fee charges only
-- flat fee credit-only handler callbacks (`onCreditsOnlyUsageAccrued`) must return credit allocations that sum to the input `AmountToAllocate`
 - for credit-purchase state-machine unit tests, use testify `mock.Mock` with `On(...).Run(...).Return(...).Once()` for expected handler callbacks so missing or unexpected calls fail; in service-suite tests, leave callbacks unset when validating that a flow fails before callbacks, because the shared `CreditPurchaseTestHandler` already errors if an unset callback is invoked
 - when testing timestamp truncation, use sub-second fixtures and assert the persisted charge/run fields are second-aligned after create/advance
 - `time.Time` fields on domain models are value typed; use `s.False(ts.IsZero())` instead of `s.NotNil(ts)` when asserting they are populated
@@ -672,6 +674,7 @@ When changing usage-based charges:
 - keep `StoredAtLT`, `ServicePeriodTo`, and `MeteredQuantity` persisted on realization runs
 - keep the `stored_at < cutoff` behavior explicit in tests
 - update lifecycle tests if late-event visibility changes
+
 When changing flat-fee charges:
 
 - the invoiced path (CreditThenInvoice/InvoiceOnly) starts as `Active` and is driven by invoice lifecycle hooks
@@ -679,8 +682,6 @@ When changing flat-fee charges:
 - `AmountAfterProration` lives on `flatfee.State`, not `flatfee.Intent` — it is computed at creation via `Intent.CalculateAmountAfterProration()` and persisted on the base charge row. Callers must not provide it; they set `AmountBeforeProration`, `ServicePeriod`, `FullServicePeriod`, and `ProRating` on the Intent
 - `IntentWithInitialStatus` carries `AmountAfterProration` alongside `InitialStatus` to pass the computed value from the service to the adapter at creation time
 - `flatfee.State.AdvanceAfter` must be passed through `chargemeta.UpdateInput.AdvanceAfter` on every `UpdateCharge(...)` call
-- `flatfee.Adapter.UpdateCharge(...)` takes `flatfee.ChargeBase` and persists only base-row fields; do not call it just because `flatfee.Realizations` changed
-- `CreatePayment(...)`, `UpdatePayment(...)`, `CreateInvoicedUsage(...)`, and `CreateCreditAllocations(...)` already persist the realization-side rows; a follow-up `UpdateCharge(...)` is redundant unless base-row fields changed too
 - `flatfee.Charge.Realizations` is expand-only data loaded from child tables; tests and service code should read payment/accrued-usage/credit-allocation state there, not from `flatfee.State`
 - `charge_flat_fees.status_detailed` mirrors `status` today; schema changes or migrations that introduce new flat-fee statuses must keep both columns consistent through `ToMetaChargeStatus()`
 - the `flatfee.Handler` interface has both invoiced-path methods and credits-only methods — implementors must satisfy all of them

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -157,10 +157,24 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 }
 
 func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch meta.PatchDelete) error {
-	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields *flatfee.IntentMutableFields) {
-		fields.IntentDeletedAt = lo.ToPtr(clock.Now())
-	}); err != nil {
-		return fmt.Errorf("mutating %s intent deleted at: %w", patch.GetTarget(), err)
+	deletedAt := lo.ToPtr(clock.Now())
+
+	if patch.GetTarget() == meta.ChangeTargetOverride && !s.Charge.Intent.HasOverrideLayer() {
+		overrideFields := s.Charge.Intent.GetEffectiveIntent().IntentMutableFields
+		overrideFields.IntentDeletedAt = deletedAt
+
+		base, err := s.Adapter.CreateChargeOverride(ctx, s.Charge.ChargeBase, overrideFields)
+		if err != nil {
+			return fmt.Errorf("creating deleted override intent: %w", err)
+		}
+
+		s.Charge.ChargeBase = base
+	} else {
+		if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields *flatfee.IntentMutableFields) {
+			fields.IntentDeletedAt = deletedAt
+		}); err != nil {
+			return fmt.Errorf("mutating %s intent deleted at: %w", patch.GetTarget(), err)
+		}
 	}
 
 	if patch.GetTarget() == meta.ChangeTargetBase && s.Charge.Intent.HasOverrideLayer() {

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -186,7 +186,7 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 		return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("validating input: %w", err)
 	}
 
-	if len(input.Created) > 0 || len(input.Deleted) > 0 {
+	if len(input.Created) > 0 {
 		return billing.OnMutableInvoiceUpdateResult{}, billing.ErrCannotUpdateChargeManagedLine
 	}
 
@@ -315,9 +315,153 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 		return billing.OnMutableInvoiceUpdateResult{}, err
 	}
 
+	for _, line := range input.Deleted {
+		chargeID := line.GetChargeID()
+		if chargeID == nil || *chargeID == "" {
+			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("flat fee line[%s]: charge id is required", line.GetID())
+		}
+
+		charge, err := e.service.GetByID(ctx, flatfee.GetByIDInput{
+			ChargeID: meta.ChargeID{
+				Namespace: line.GetLineID().Namespace,
+				ID:        *chargeID,
+			},
+			Expands: meta.Expands{
+				meta.ExpandRealizations,
+			},
+		})
+		if err != nil {
+			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("getting flat fee charge for deleted line[%s]: %w", line.GetID(), err)
+		}
+
+		if charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf(
+				"flat fee line[%s]: unsupported settlement mode for API delete: %s",
+				line.GetID(),
+				charge.Intent.GetSettlementMode(),
+			)
+		}
+
+		if err := validateManualDeleteLine(charge, line); err != nil {
+			return billing.OnMutableInvoiceUpdateResult{}, err
+		}
+
+		stateMachine, err := e.service.newStateMachine(StateMachineConfig{
+			Charge:               charge,
+			Adapter:              e.service.adapter,
+			Realizations:         e.service.realizations,
+			Service:              e.service,
+			CreditNotesSupported: e.service.creditNotesSupported.Load(),
+		})
+		if err != nil {
+			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("new state machine for flat fee charge[%s]: %w", charge.ID, err)
+		}
+
+		creditThenInvoiceStateMachine, ok := stateMachine.(*CreditThenInvoiceStateMachine)
+		if !ok {
+			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("BUG: flat fee charge[%s]: expected credit_then_invoice state machine, got %T", charge.ID, stateMachine)
+		}
+
+		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+			Target: meta.ChangeTargetOverride,
+			Policy: meta.RefundAsCreditsDeletePolicy,
+		})
+		if err != nil {
+			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("creating flat fee line[%s] manual delete patch: %w", line.GetID(), err)
+		}
+
+		if err := creditThenInvoiceStateMachine.FireAndActivate(ctx, meta.TriggerDelete, deletePatch); err != nil {
+			return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("triggering %s for charge[%s]: %w", meta.TriggerDelete, charge.ID, err)
+		}
+
+		if err := e.handleManualDeleteInvoicePatches(ctx, input.Invoice, line, *chargeID, creditThenInvoiceStateMachine.DrainInvoicePatches()); err != nil {
+			return billing.OnMutableInvoiceUpdateResult{}, err
+		}
+	}
+
 	return billing.OnMutableInvoiceUpdateResult{
 		UpdatedLines: updatedLines,
 	}, nil
+}
+
+func validateManualDeleteLine(charge flatfee.Charge, line billing.GenericInvoiceLine) error {
+	switch line.AsInvoiceLine().Type() {
+	case billing.InvoiceLineTypeGathering:
+		if charge.Realizations.CurrentRun != nil {
+			return billing.ErrCannotUpdateChargeManagedLine
+		}
+	case billing.InvoiceLineTypeStandard:
+		currentRun := charge.Realizations.CurrentRun
+		if currentRun == nil || currentRun.Immutable {
+			return billing.ErrCannotUpdateChargeManagedLine
+		}
+
+		if currentRun.LineID == nil || *currentRun.LineID != line.GetID() {
+			return fmt.Errorf("line[%s]: current realization run must be attached to deleted line", line.GetID())
+		}
+
+		if currentRun.InvoiceID == nil || *currentRun.InvoiceID != line.GetInvoiceID() {
+			return fmt.Errorf("line[%s]: current realization run must be attached to deleted invoice", line.GetID())
+		}
+	default:
+		return billing.ErrCannotUpdateChargeManagedLine
+	}
+
+	return nil
+}
+
+func (e *LineEngine) handleManualDeleteInvoicePatches(ctx context.Context, invoice billing.GenericInvoiceReader, line billing.GenericInvoiceLine, chargeID string, patches []invoiceupdater.Patch) error {
+	if len(patches) == 0 {
+		return fmt.Errorf("line[%s]: expected manual delete invoice patches", line.GetID())
+	}
+
+	for _, patch := range patches {
+		switch patch.Op() {
+		case invoiceupdater.PatchOpDeleteGatheringLineByChargeID:
+			deletePatch, err := patch.AsDeleteGatheringLineByChargeIDPatch()
+			if err != nil {
+				return fmt.Errorf("line[%s]: getting manual delete gathering-line patch: %w", line.GetID(), err)
+			}
+
+			if deletePatch.ChargeID != chargeID {
+				return fmt.Errorf("line[%s]: manual delete gathering-line patch targets unexpected charge[%s]", line.GetID(), deletePatch.ChargeID)
+			}
+		case invoiceupdater.PatchOpLineDelete:
+			deletePatch, err := patch.AsDeleteLinePatch()
+			if err != nil {
+				return fmt.Errorf("line[%s]: getting manual delete line patch: %w", line.GetID(), err)
+			}
+
+			if deletePatch.Line.ID != line.GetID() {
+				return fmt.Errorf("line[%s]: manual delete line patch targets unexpected line[%s]", line.GetID(), deletePatch.Line.ID)
+			}
+
+			if deletePatch.InvoiceID != line.GetInvoiceID() {
+				return fmt.Errorf("line[%s]: manual delete line patch targets unexpected invoice[%s]", line.GetID(), deletePatch.InvoiceID)
+			}
+
+			standardInvoice, err := invoice.AsInvoice().AsStandardInvoice()
+			if err != nil {
+				return fmt.Errorf("line[%s]: getting standard invoice for manual delete cleanup: %w", line.GetID(), err)
+			}
+
+			standardLine, err := line.AsInvoiceLine().AsStandardLine()
+			if err != nil {
+				return fmt.Errorf("line[%s]: getting standard line for manual delete cleanup: %w", line.GetID(), err)
+			}
+
+			if err := e.cleanupDeletedStandardLines(ctx, billing.StandardLineEventInput{
+				Invoice: standardInvoice,
+				Lines:   billing.StandardLines{&standardLine},
+			}); err != nil {
+				return fmt.Errorf("line[%s]: cleaning up manual delete line patch: %w", line.GetID(), err)
+			}
+		default:
+			return fmt.Errorf("line[%s]: unexpected manual delete invoice patch %s", line.GetID(), patch.Op())
+		}
+	}
+
+	return nil
 }
 
 func invoicePatchOps(patches []invoiceupdater.Patch) []invoiceupdater.PatchOperation {
@@ -331,6 +475,10 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 		return fmt.Errorf("validating input: %w", err)
 	}
 
+	return e.cleanupDeletedStandardLines(ctx, input)
+}
+
+func (e *LineEngine) cleanupDeletedStandardLines(ctx context.Context, input billing.StandardLineEventInput) error {
 	chargesByID, err := e.getChargesForStandardLineEvent(ctx, input, meta.Expands{
 		meta.ExpandRealizations,
 	})

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -3584,6 +3584,119 @@ func (s *CreditThenInvoiceTestSuite) TestGatheringManualEditSync() {
 	})
 }
 
+func (s *CreditThenInvoiceTestSuite) TestGatheringManualDeleteSync() {
+	ctx := s.T().Context()
+	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:00Z"))
+	defer clock.UnFreeze()
+
+	// given:
+	// - subscription sync owns the flat-fee charge base intent
+	// - the initial sync creates one charge-backed gathering line
+	// when:
+	// - the user deletes the gathering line through the invoice API
+	// then:
+	// - the API delete is persisted as a deleted override intent
+	// - subscription sync keeps owning the undeleted base intent
+	// - resync does not recreate the customer-facing gathering line
+
+	defaultTaxCodes, err := s.TaxCodeService.GetOrganizationDefaultTaxCodes(ctx, taxcode.GetOrganizationDefaultTaxCodesInput{Namespace: s.Namespace})
+	s.NoError(err)
+	baseTaxConfig := &productcatalog.TaxConfig{
+		Behavior:  lo.ToPtr(productcatalog.ExclusiveTaxBehavior),
+		TaxCodeID: lo.ToPtr(defaultTaxCodes.InvoicingTaxCodeID),
+	}
+
+	subsView := s.createSubscriptionFromPlan(plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: s.Namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Test Plan",
+				Key:            "test-plan",
+				Version:        1,
+				Currency:       currency.USD,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+				ProRatingConfig: productcatalog.ProRatingConfig{
+					Enabled: true,
+					Mode:    productcatalog.ProRatingModeProratePrices,
+				},
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: s.phaseMeta("first-phase", ""),
+					RateCards: productcatalog.RateCards{
+						&productcatalog.FlatFeeRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:  "in-arrears",
+								Name: "in-arrears",
+								Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+									Amount:      alpacadecimal.NewFromFloat(5),
+									PaymentTerm: productcatalog.InArrearsPaymentTerm,
+								}),
+								TaxConfig: baseTaxConfig,
+							},
+							BillingCadence: lo.ToPtr(datetime.MustParseDuration(s.T(), "P1M")),
+						},
+					},
+				},
+			},
+		},
+	})
+
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))
+	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
+	s.Require().Len(gatheringInvoice.Lines.OrEmpty(), 1)
+
+	var deletedLine billing.GatheringLine
+	_, err = s.BillingService.UpdateGatheringInvoice(ctx, billing.UpdateGatheringInvoiceInput{
+		Invoice:      gatheringInvoice.GetInvoiceID(),
+		ChangeSource: billing.ChangeSourceAPIRequest,
+		EditFn: func(invoice *billing.GatheringInvoice) error {
+			lines := invoice.Lines.OrEmpty()
+			s.Require().Len(lines, 1)
+			line := &lines[0]
+
+			line.DeletedAt = lo.ToPtr(clock.Now())
+
+			deletedLine, err = line.Clone()
+			s.NoError(err)
+			return nil
+		},
+		IncludeDeletedLines: true,
+	})
+	s.NoError(err)
+
+	editedInvoice, err := s.BillingService.GetGatheringInvoiceById(ctx, billing.GetGatheringInvoiceByIdInput{
+		Invoice: gatheringInvoice.GetInvoiceID(),
+		Expand: billing.GatheringInvoiceExpands{
+			billing.GatheringInvoiceExpandLines,
+			billing.GatheringInvoiceExpandDeletedLines,
+		},
+	})
+	s.NoError(err)
+	s.DebugDumpInvoice("deleted invoice", editedInvoice)
+
+	invoiceLine, found := lo.Find(editedInvoice.Lines.OrEmpty(), func(line billing.GatheringLine) bool {
+		return line.ID == deletedLine.ID
+	})
+	s.True(found, "deleted line should be found")
+	s.NotNil(invoiceLine.DeletedAt)
+	s.Equal(billing.ManuallyManagedLine, invoiceLine.ManagedBy)
+
+	flatFeeCharge := s.mustGetFlatFeeChargeForInvoiceLine(ctx, deletedLine.AsGenericLine())
+	s.True(flatFeeCharge.Intent.HasOverrideLayer(), "override layer")
+	s.Nil(flatFeeCharge.Intent.GetBaseIntent().IntentDeletedAt)
+	overrideIntent, err := flatFeeCharge.Intent.GetIntentForTarget(chargesmeta.ChangeTargetOverride)
+	s.NoError(err)
+	s.NotNil(overrideIntent.IntentDeletedAt)
+
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.expectNoGatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+}
+
 func (s *CreditThenInvoiceTestSuite) TestStandardInvoiceManualEditSync() {
 	ctx := s.T().Context()
 	start := s.mustParseTime("2024-01-01T00:00:00Z")
@@ -3803,6 +3916,174 @@ func (s *CreditThenInvoiceTestSuite) TestStandardInvoiceManualEditSync() {
 		CreditsTotal: 2,
 		Total:        5,
 	})
+}
+
+func (s *CreditThenInvoiceTestSuite) TestStandardInvoiceManualDeleteSync() {
+	ctx := s.T().Context()
+	start := s.mustParseTime("2024-01-01T00:00:00Z")
+	clock.FreezeTime(start)
+	defer clock.UnFreeze()
+
+	// given:
+	// - a credit-then-invoice subscription has one recurring flat-fee charge
+	// - the customer has promotional credits that partially cover the draft standard invoice line
+	// - the billing profile requires manual invoice approval so the standard line remains mutable
+	// when:
+	// - the standard invoice line is deleted through the invoice API
+	// then:
+	// - the charge override intent records the customer-facing deletion
+	// - the charge detaches from the mutable standard line
+	// - the promotional credit allocation is corrected back to customer FBO
+	s.updateProfile(func(profile *billing.Profile) {
+		profile.WorkflowConfig.Invoicing.AutoAdvance = false
+	})
+
+	s.createPromotionalCreditFunding(ctx, createPromotionalCreditFundingInput{
+		Namespace: s.Namespace,
+		Customer:  s.Customer.GetID(),
+		Currency:  currencyx.Code(currency.USD),
+		Amount:    alpacadecimal.NewFromInt(2),
+		At:        start,
+	})
+	startBalances := expectedCreditThenInvoiceBalances{
+		FBOAll:          2,
+		FBOPromotional:  2,
+		WashAll:         -2,
+		WashPromotional: -2,
+	}
+	s.assertCreditThenInvoiceBalances(startBalances)
+
+	subsView := s.createSubscriptionFromPlan(plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: s.Namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Test Plan",
+				Key:            "test-plan",
+				Version:        1,
+				Currency:       currency.USD,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+				ProRatingConfig: productcatalog.ProRatingConfig{
+					Enabled: true,
+					Mode:    productcatalog.ProRatingModeProratePrices,
+				},
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: s.phaseMeta("first-phase", ""),
+					RateCards: productcatalog.RateCards{
+						&productcatalog.FlatFeeRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:  "in-arrears",
+								Name: "in-arrears",
+								Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+									Amount:      alpacadecimal.NewFromFloat(5),
+									PaymentTerm: productcatalog.InArrearsPaymentTerm,
+								}),
+							},
+							BillingCadence: lo.ToPtr(datetime.MustParseDuration(s.T(), "P1M")),
+						},
+					},
+				},
+			},
+		},
+	})
+
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	s.assertCreditThenInvoiceBalances(startBalances)
+	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
+	s.Require().Len(gatheringInvoice.Lines.OrEmpty(), 1)
+
+	clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
+	draftInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: s.Customer.GetID(),
+		AsOf:     lo.ToPtr(clock.Now()),
+	})
+	s.NoError(err)
+	s.Require().Len(draftInvoices, 1)
+
+	draftInvoice := draftInvoices[0]
+	s.DebugDumpInvoice("draft invoice", draftInvoice)
+	s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, draftInvoice.Status)
+	s.Require().Len(draftInvoice.Lines.OrEmpty(), 1)
+	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{
+		FBOAll:             0,
+		FBOPromotional:     0,
+		AccruedAll:         2,
+		AccruedPromotional: 2,
+		WashAll:            -2,
+		WashPromotional:    -2,
+	})
+
+	originalLine, err := draftInvoice.Lines.OrEmpty()[0].Clone()
+	s.NoError(err)
+
+	chargeBeforeDelete := s.mustGetFlatFeeChargeForInvoiceLineWithExpands(ctx, originalLine, chargesmeta.Expands{chargesmeta.ExpandRealizations})
+	s.Equal(flatfee.StatusActiveRealizationProcessing, chargeBeforeDelete.Status)
+	s.Require().NotNil(chargeBeforeDelete.Realizations.CurrentRun)
+	s.Require().NotNil(chargeBeforeDelete.Realizations.CurrentRun.LineID)
+	s.Equal(originalLine.ID, *chargeBeforeDelete.Realizations.CurrentRun.LineID)
+	s.assertTotals(chargeBeforeDelete.Realizations.CurrentRun.Totals, expectedTotalsInput{
+		Amount:       5,
+		CreditsTotal: 2,
+		Total:        3,
+	})
+
+	var deletedLine *billing.StandardLine
+	deletedInvoice, err := s.BillingService.UpdateStandardInvoice(ctx, billing.UpdateStandardInvoiceInput{
+		Invoice:      draftInvoice.GetInvoiceID(),
+		ChangeSource: billing.ChangeSourceAPIRequest,
+		EditFn: func(invoice *billing.StandardInvoice) error {
+			lines := invoice.Lines.OrEmpty()
+			s.Require().Len(lines, 1)
+			line := lines[0]
+
+			line.DeletedAt = lo.ToPtr(clock.Now())
+
+			deletedLine, err = line.Clone()
+			s.NoError(err)
+			return nil
+		},
+		IncludeDeletedLines: true,
+	})
+	s.Require().NoError(err)
+	s.DebugDumpInvoice("deleted draft invoice", deletedInvoice)
+
+	deletedInvoiceLine, found := lo.Find(deletedInvoice.Lines.OrEmpty(), func(line *billing.StandardLine) bool {
+		return line != nil && line.ID == deletedLine.ID
+	})
+	s.Require().True(found, "deleted standard line should be found")
+	s.NotNil(deletedInvoiceLine.DeletedAt)
+	s.Equal(billing.ManuallyManagedLine, deletedInvoiceLine.ManagedBy)
+
+	chargeAfterDelete := s.mustGetFlatFeeChargeForInvoiceLineWithExpands(ctx, deletedLine, chargesmeta.Expands{chargesmeta.ExpandRealizations})
+	s.Equal(flatfee.StatusDeleted, chargeAfterDelete.Status)
+	s.True(chargeAfterDelete.Intent.HasOverrideLayer(), "override layer")
+	s.Nil(chargeAfterDelete.Intent.GetBaseIntent().IntentDeletedAt)
+	overrideIntent, err := chargeAfterDelete.Intent.GetIntentForTarget(chargesmeta.ChangeTargetOverride)
+	s.NoError(err)
+	s.NotNil(overrideIntent.IntentDeletedAt)
+	s.Nil(chargeAfterDelete.Realizations.CurrentRun)
+	s.assertCreditThenInvoiceBalances(startBalances)
+
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+	resyncedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+		Invoice: deletedInvoice.GetInvoiceID(),
+		Expand:  billing.StandardInvoiceExpandAll.With(billing.StandardInvoiceExpandDeletedLines),
+	})
+	s.NoError(err)
+	s.DebugDumpInvoice("resynced deleted draft invoice", resyncedInvoice)
+
+	resyncedDeletedLine, found := lo.Find(resyncedInvoice.Lines.OrEmpty(), func(line *billing.StandardLine) bool {
+		return line != nil && line.ID == deletedLine.ID
+	})
+	s.Require().True(found, "deleted standard line should remain on the invoice")
+	s.NotNil(resyncedDeletedLine.DeletedAt)
+	s.Equal(billing.ManuallyManagedLine, resyncedDeletedLine.ManagedBy)
+	s.assertCreditThenInvoiceBalances(startBalances)
 }
 
 func (s *CreditThenInvoiceTestSuite) TestInArrearsOneTimeFeeSyncing() {


### PR DESCRIPTION
## Summary

This PR extends the flat-fee invoice-line override flow so manual API deletes are handled through the same charge-owned state-machine and line-engine boundary as manual edits.

When a customer deletes a mutable charge-backed invoice line, the flat-fee state machine records the delete on the override layer and emits invoice patches. The line engine consumes those patches locally, validates that they only affect the edited line, and reuses the standard-line deletion cleanup path for standard invoices so credit corrections, charge-owned detailed-line cleanup, and realization-run deletion remain consistent.

The PR also adds subscription-sync coverage for gathering-line and standard-line delete behavior, including promotional-credit ledger expectations for standard invoices, and updates the charges skill with the shared flat-fee/usage-based line-engine rules.

## Validation

- direnv exec . env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic -count=1 -run 'TestCreditThenInvoiceScenarios/Test(GatheringManual(Edit|Delete)Sync|StandardInvoiceManual(Edit|Delete)Sync)' ./openmeter/billing/worker/subscriptionsync/service
- direnv exec . go test -tags=dynamic -count=1 ./openmeter/billing/charges/flatfee/service
- direnv exec . go vet ./openmeter/billing/charges/flatfee/service ./openmeter/billing/worker/subscriptionsync/service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the charges guidance to clarify charge lifecycle/settlement semantics across adapters, expansions, billing line engine wiring, and realization flows.
* **Bug Fixes**
  * Improved charge deletion handling to use consistent deletion timestamps and correctly create/update deleted override records when applicable.
  * Enabled manual deletion of flat-fee credit-then-invoice invoice lines, including correct cleanup and balance behavior.
  * Adjusted how standard-line deletion cleanup is applied to ensure stable invoice state.
* **Tests**
  * Added subscription sync coverage for manual deletion of both gathering and standard invoice lines, ensuring deleted lines are preserved across resync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->