### PR TITLE
fix: remove duplicate e2e credit grant helper

### DIFF
--- a/e2e/v3helpers_test.go
+++ b/e2e/v3helpers_test.go
@@ -324,14 +324,6 @@ func (c *v3Client) GetCustomerEntitlementAccess(customerID string) (int, *apiv3.
 	return decodeTyped[apiv3.ListCustomerEntitlementAccessResponseData](c, status, raw, problem, http.StatusOK)
 }
 
-// CreateCreditGrant posts a credit grant for the given customer. customerID is
-// the customer's ULID. Returns the decoded grant on 201, or (status, nil,
-// problem) otherwise so error-path tests can assert the status and problem body.
-func (c *v3Client) CreateCreditGrant(customerID string, body apiv3.CreateCreditGrantRequest) (int, *apiv3.BillingCreditGrant, *v3Problem) {
-	status, raw, problem := c.do(http.MethodPost, "/customers/"+customerID+"/credits/grants", body)
-	return decodeTyped[apiv3.BillingCreditGrant](c, status, raw, problem, http.StatusCreated)
-}
-
 // --- Subscriptions ---
 
 func (c *v3Client) CreateSubscription(body apiv3.BillingSubscriptionCreate) (int, *apiv3.BillingSubscription, *v3Problem) {
@@ -365,6 +357,9 @@ func (c *v3Client) GetBillingInvoice(invoiceID string) (int, *apiv3.BillingInvoi
 
 // --- Credits ---
 
+// CreateCreditGrant posts a credit grant for the given customer. customerID is
+// the customer's ULID. Returns the decoded grant on 201, or (status, nil,
+// problem) otherwise so error-path tests can assert the status and problem body.
 func (c *v3Client) CreateCreditGrant(customerID string, body apiv3.CreateCreditGrantRequest) (int, *apiv3.BillingCreditGrant, *v3Problem) {
 	status, raw, problem := c.do(http.MethodPost, "/customers/"+customerID+"/credits/grants", body)
 	return decodeTyped[apiv3.BillingCreditGrant](c, status, raw, problem, http.StatusCreated)


### PR DESCRIPTION
## Summary

Removes the duplicate `v3Client.CreateCreditGrant` helper declaration introduced in `e2e/v3helpers_test.go`, keeping the helper in the dedicated Credits section with its explanatory docstring.

## Root Cause

The same method was present twice on `v3Client`, which caused the full lint/typecheck gate to fail with a duplicate method declaration error.

## Validation

- `nix develop --impure .#ci -c make lint`
- `nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 make test`
- `nix develop --impure .#ci -c make etoe`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the helper reference into a clearer “Credits” section.
  * Updated the surrounding comment formatting for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->