### PR TITLE
fix(billing): support credit-only period patches

### DIFF
--- a/openmeter/billing/charges/flatfee/service/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/creditsonly.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
+	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	flatfeerealizations "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service/realizations"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	"github.com/openmeterio/openmeter/openmeter/billing/models/totals"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/statelessx"
@@ -44,6 +47,8 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 	s.Configure(flatfee.StatusCreated).
 		Permit(meta.TriggerNext, flatfee.StatusActive, statelessx.BoolFn(s.IsInsideServicePeriod)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
 			s.AdvanceAfterServicePeriodFrom,
 		)
@@ -51,12 +56,16 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 	s.Configure(flatfee.StatusActive).
 		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.IsAfterInvoiceAt)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
 			s.AdvanceAfterInvoiceAt,
 		)
 
 	s.Configure(flatfee.StatusFinal).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
 			statelessx.AllOf(
 				s.AllocateCredits,
@@ -102,6 +111,10 @@ func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {
 		}
 	}
 
+	if s.Charge.Realizations.CurrentRun != nil && len(s.Charge.Realizations.CurrentRun.CreditRealizations) > 0 {
+		return s.reconcileCurrentRunCredits(ctx, amount)
+	}
+
 	result, err := s.Realizations.AllocateCreditsOnly(ctx, flatfeerealizations.AllocateCreditsOnlyInput{
 		Charge:             s.Charge,
 		Amount:             amount,
@@ -112,6 +125,104 @@ func (s *CreditsOnlyStateMachine) AllocateCredits(ctx context.Context) error {
 	}
 
 	s.Charge.Realizations.CurrentRun.CreditRealizations = append(s.Charge.Realizations.CurrentRun.CreditRealizations, result.Realizations...)
+	return nil
+}
+
+func (s *CreditsOnlyStateMachine) ExtendCharge(ctx context.Context, patch meta.PatchExtend) error {
+	return s.applyPeriodPatch(ctx, patch)
+}
+
+func (s *CreditsOnlyStateMachine) ShrinkCharge(ctx context.Context, patch meta.PatchShrink) error {
+	return s.applyPeriodPatch(ctx, patch)
+}
+
+func (s *CreditsOnlyStateMachine) applyPeriodPatch(ctx context.Context, patch periodPatch) error {
+	targetIntent, err := s.Charge.Intent.GetIntentForTarget(patch.GetTarget())
+	if err != nil {
+		return fmt.Errorf("getting %s intent: %w", patch.GetTarget(), err)
+	}
+
+	if err := patch.ValidateWith(targetIntent.IntentMutableFields.IntentMutableFields); err != nil {
+		return fmt.Errorf("validate %s patch: %w", patch.Op(), err)
+	}
+
+	intent := s.Charge.Intent
+	if err := intent.Mutate(patch.GetTarget(), func(fields *flatfee.IntentMutableFields) {
+		fields.ServicePeriod.To = patch.GetNewServicePeriodTo()
+		fields.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
+		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
+		fields.InvoiceAt = patch.GetNewInvoiceAt()
+	}); err != nil {
+		return fmt.Errorf("mutating %s intent: %w", patch.GetTarget(), err)
+	}
+
+	s.Charge.Intent = intent
+
+	if patch.GetTarget() == meta.ChangeTargetBase && s.Charge.Intent.HasOverrideLayer() {
+		// Subscription sync targets the base intent. When an override is active,
+		// customer-facing credit allocations remain owned by the override.
+		return nil
+	}
+
+	amountAfterProration, err := intent.CalculateAmountAfterProration()
+	if err != nil {
+		return fmt.Errorf("calculating amount after proration: %w", err)
+	}
+	s.Charge.State.AmountAfterProration = amountAfterProration
+
+	if s.Charge.Realizations.CurrentRun == nil {
+		return nil
+	}
+
+	return s.reconcileCurrentRunCredits(ctx, amountAfterProration)
+}
+
+func (s *CreditsOnlyStateMachine) reconcileCurrentRunCredits(ctx context.Context, amount alpacadecimal.Decimal) error {
+	currentRun := s.Charge.Realizations.CurrentRun
+	if currentRun == nil {
+		return nil
+	}
+
+	currencyCalculator, err := s.Charge.Intent.GetCurrency().Calculator()
+	if err != nil {
+		return fmt.Errorf("get currency calculator: %w", err)
+	}
+
+	amount = currencyCalculator.RoundToPrecision(amount)
+	servicePeriod := s.Charge.Intent.GetEffectiveServicePeriod()
+	run := *currentRun
+	run.ServicePeriod = servicePeriod
+
+	reconcileResult, err := s.Realizations.ReconcileCredits(ctx, flatfeerealizations.ReconcileCreditRealizationsInput{
+		Charge:             s.Charge,
+		Run:                run,
+		AllocateAt:         flatfee.UsageBookedAt(s.Charge.Intent.GetEffectivePaymentTerm(), servicePeriod),
+		TargetAmount:       amount,
+		CurrencyCalculator: currencyCalculator,
+	})
+	if err != nil {
+		return fmt.Errorf("reconcile credits for run %s: %w", run.ID.ID, err)
+	}
+
+	run.CreditRealizations = append(run.CreditRealizations, reconcileResult.Realizations...)
+
+	runBase, err := s.Adapter.UpdateRealizationRun(ctx, flatfee.UpdateRealizationRunInput{
+		ID:                   run.ID,
+		ServicePeriod:        mo.Some(servicePeriod),
+		AmountAfterProration: mo.Some(amount),
+		Totals: mo.Some(totals.Totals{
+			Amount:       amount,
+			CreditsTotal: amount,
+			Total:        alpacadecimal.Zero,
+		}),
+		NoFiatTransactionRequired: mo.Some(true),
+	})
+	if err != nil {
+		return fmt.Errorf("update credit-only run: %w", err)
+	}
+
+	run.RealizationRunBase = runBase
+	s.Charge.Realizations.CurrentRun = &run
 	return nil
 }
 

--- a/openmeter/billing/charges/meta/patch.go
+++ b/openmeter/billing/charges/meta/patch.go
@@ -1,6 +1,7 @@
 package meta
 
 import (
+	"context"
 	"fmt"
 	"slices"
 
@@ -52,4 +53,12 @@ type Patch interface {
 type TriggerPatchResult[T any] struct {
 	Charge         *T
 	InvoicePatches []invoiceupdater.Patch
+}
+
+// PatchAction adapts a generic Patch action to a concrete patch action when
+// statelessx.AllOfWithParameters requires strict typing for composed actions.
+func PatchAction[T Patch](fn func(context.Context, Patch) error) func(context.Context, T) error {
+	return func(ctx context.Context, patch T) error {
+		return fn(ctx, patch)
+	}
 }

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -36,11 +36,6 @@ type periodPatch interface {
 	ValidateWith(meta.IntentMutableFields) error
 }
 
-type applyPeriodPatchResult struct {
-	ShouldReconcile  bool
-	OldServicePeriod timeutil.ClosedPeriod
-}
-
 var (
 	_ periodPatch = meta.PatchExtend{}
 	_ periodPatch = meta.PatchShrink{}
@@ -398,14 +393,19 @@ func (s *CreditThenInvoiceStateMachine) ShrinkCharge(_ context.Context, patch me
 	return nil
 }
 
-func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(patch periodPatch) (applyPeriodPatchResult, error) {
+type creditThenInvoiceApplyPeriodPatchResult struct {
+	ShouldReconcile  bool
+	OldServicePeriod timeutil.ClosedPeriod
+}
+
+func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(patch periodPatch) (creditThenInvoiceApplyPeriodPatchResult, error) {
 	targetIntent, err := s.Charge.Intent.GetIntentForTarget(patch.GetTarget())
 	if err != nil {
-		return applyPeriodPatchResult{}, fmt.Errorf("getting %s intent: %w", patch.GetTarget(), err)
+		return creditThenInvoiceApplyPeriodPatchResult{}, fmt.Errorf("getting %s intent: %w", patch.GetTarget(), err)
 	}
 
 	if err := patch.ValidateWith(targetIntent.IntentMutableFields.IntentMutableFields); err != nil {
-		return applyPeriodPatchResult{}, fmt.Errorf("validate %s patch: %w", patch.Op(), err)
+		return creditThenInvoiceApplyPeriodPatchResult{}, fmt.Errorf("validate %s patch: %w", patch.Op(), err)
 	}
 
 	oldServicePeriod := meta.NormalizeClosedPeriod(targetIntent.IntentMutableFields.ServicePeriod)
@@ -416,16 +416,16 @@ func (s *CreditThenInvoiceStateMachine) applyPeriodPatch(patch periodPatch) (app
 		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
 		fields.InvoiceAt = patch.GetNewInvoiceAt()
 	}); err != nil {
-		return applyPeriodPatchResult{}, fmt.Errorf("mutating %s intent: %w", patch.GetTarget(), err)
+		return creditThenInvoiceApplyPeriodPatchResult{}, fmt.Errorf("mutating %s intent: %w", patch.GetTarget(), err)
 	}
 
 	if patch.GetTarget() == meta.ChangeTargetBase && s.Charge.Intent.HasOverrideLayer() {
 		// Subscription sync targets the base intent. When an override is active,
 		// customer-facing invoice/run state remains owned by the override layer.
-		return applyPeriodPatchResult{}, nil
+		return creditThenInvoiceApplyPeriodPatchResult{}, nil
 	}
 
-	return applyPeriodPatchResult{
+	return creditThenInvoiceApplyPeriodPatchResult{
 		ShouldReconcile:  true,
 		OldServicePeriod: oldServicePeriod,
 	}, nil

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -52,6 +52,8 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			statelessx.BoolFn(s.IsInsideServicePeriod),
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
 			s.AdvanceAfterServicePeriodFrom,
 		)
@@ -63,6 +65,8 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			statelessx.BoolFn(s.IsAfterServicePeriod),
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
 			statelessx.AllOf(
 				s.SyncFeatureIDFromFeatureMeter,
@@ -76,6 +80,8 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			usagebased.StatusActiveFinalRealizationWaitingForCollection,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
 			s.StartFinalRealizationRun,
 		)
@@ -87,6 +93,8 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			s.IsAfterCollectionPeriod,
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		// TODO: Transition to a failed state if the collection period end is not set
 		OnActive(s.AdvanceAfterCollectionPeriodEnd)
 
@@ -105,10 +113,14 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			meta.TriggerNext,
 			usagebased.StatusFinal,
 		).
-		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge))
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge))
 
 	s.Configure(usagebased.StatusFinal).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(s.ClearAdvanceAfter)
 }
 
@@ -154,6 +166,131 @@ func (s *CreditsOnlyStateMachine) DeleteCharge(ctx context.Context, patch meta.P
 	}
 
 	return nil
+}
+
+func (s *CreditsOnlyStateMachine) ExtendCharge(ctx context.Context, patch meta.PatchExtend) error {
+	patchResult, err := s.applyPeriodPatch(patch)
+	if err != nil {
+		return err
+	}
+
+	if !patchResult.ShouldReconcile {
+		return nil
+	}
+
+	if err := s.voidAllRuns(ctx); err != nil {
+		return err
+	}
+
+	return s.persistActivePeriodPatch(ctx)
+}
+
+func (s *CreditsOnlyStateMachine) ShrinkCharge(ctx context.Context, patch meta.PatchShrink) error {
+	patchResult, err := s.applyPeriodPatch(patch)
+	if err != nil {
+		return err
+	}
+
+	if !patchResult.ShouldReconcile {
+		return nil
+	}
+
+	if err := s.voidAllRuns(ctx); err != nil {
+		return err
+	}
+
+	return s.persistActivePeriodPatch(ctx)
+}
+
+type creditsOnlyApplyPeriodPatchResult struct {
+	ShouldReconcile bool
+}
+
+func (s *CreditsOnlyStateMachine) applyPeriodPatch(patch periodPatch) (creditsOnlyApplyPeriodPatchResult, error) {
+	targetIntent, err := s.Charge.Intent.GetIntentForTarget(patch.GetTarget())
+	if err != nil {
+		return creditsOnlyApplyPeriodPatchResult{}, fmt.Errorf("getting %s intent: %w", patch.GetTarget(), err)
+	}
+
+	if err := patch.ValidateWith(targetIntent.IntentMutableFields.IntentMutableFields); err != nil {
+		return creditsOnlyApplyPeriodPatchResult{}, fmt.Errorf("validate %s patch: %w", patch.Op(), err)
+	}
+
+	if err := s.Charge.Intent.Mutate(patch.GetTarget(), func(fields *usagebased.IntentMutableFields) {
+		fields.ServicePeriod.To = patch.GetNewServicePeriodTo()
+		fields.FullServicePeriod.To = patch.GetNewFullServicePeriodTo()
+		fields.BillingPeriod.To = patch.GetNewBillingPeriodTo()
+		fields.InvoiceAt = patch.GetNewInvoiceAt()
+	}); err != nil {
+		return creditsOnlyApplyPeriodPatchResult{}, fmt.Errorf("mutating %s intent: %w", patch.GetTarget(), err)
+	}
+
+	if patch.GetTarget() == meta.ChangeTargetBase && s.Charge.Intent.HasOverrideLayer() {
+		// Subscription sync targets the base intent. When an override is active,
+		// customer-facing credit allocations remain owned by the override.
+		return creditsOnlyApplyPeriodPatchResult{}, nil
+	}
+
+	return creditsOnlyApplyPeriodPatchResult{
+		ShouldReconcile: true,
+	}, nil
+}
+
+func (s *CreditsOnlyStateMachine) persistActivePeriodPatch(ctx context.Context) error {
+	s.Charge.Status = usagebased.StatusActive
+	s.Charge.State.CurrentRealizationRunID = nil
+	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().To))
+
+	updatedBase, err := s.Adapter.UpdateCharge(ctx, s.Charge.ChargeBase)
+	if err != nil {
+		return fmt.Errorf("update charge after period patch: %w", err)
+	}
+	s.Charge.ChargeBase = updatedBase
+
+	return nil
+}
+
+func (s *CreditsOnlyStateMachine) voidAllRuns(ctx context.Context) error {
+	// Credit-only usage-based charges currently have one realization run for the
+	// whole service period. Void every run until periodic reconciliation and
+	// progressive "billing" are implemented for usage-based charges.
+	for _, run := range s.Charge.Realizations {
+		if run.IsVoidedBillingHistory() {
+			continue
+		}
+
+		if _, err := s.voidRealizationRun(ctx, run); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *CreditsOnlyStateMachine) voidRealizationRun(ctx context.Context, run usagebased.RealizationRun) (usagebased.RealizationRun, error) {
+	if _, err := s.Runs.CorrectAllCredits(ctx, usagebasedrun.CorrectAllCreditRealizationsInput{
+		Charge:             s.Charge,
+		Run:                run,
+		AllocateAt:         run.ServicePeriodTo,
+		CurrencyCalculator: s.CurrencyCalculator,
+	}); err != nil {
+		return usagebased.RealizationRun{}, fmt.Errorf("correct credits for run %s: %w", run.ID.ID, err)
+	}
+
+	runBase, err := s.Adapter.UpdateRealizationRun(ctx, usagebased.UpdateRealizationRunInput{
+		ID:        run.ID,
+		DeletedAt: mo.Some(lo.ToPtr(clock.Now())),
+	})
+	if err != nil {
+		return usagebased.RealizationRun{}, fmt.Errorf("void realization run %s: %w", run.ID.ID, err)
+	}
+
+	run.RealizationRunBase = runBase
+	if err := s.Charge.Realizations.SetRealizationRun(run); err != nil {
+		return usagebased.RealizationRun{}, fmt.Errorf("update voided realization run %s: %w", run.ID.ID, err)
+	}
+
+	return run, nil
 }
 
 func (s *CreditsOnlyStateMachine) StartFinalRealizationRun(ctx context.Context) error {

--- a/openmeter/billing/charges/usagebased/service/creditsonly.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly.go
@@ -52,8 +52,8 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 			statelessx.BoolFn(s.IsInsideServicePeriod),
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
-		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
-		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
+		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(argAsPeriodPatch[meta.PatchExtend](s.patchCreatedChargePeriod))).
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(argAsPeriodPatch[meta.PatchShrink](s.patchCreatedChargePeriod))).
 		OnActive(
 			s.AdvanceAfterServicePeriodFrom,
 		)
@@ -234,6 +234,26 @@ func (s *CreditsOnlyStateMachine) applyPeriodPatch(patch periodPatch) (creditsOn
 	return creditsOnlyApplyPeriodPatchResult{
 		ShouldReconcile: true,
 	}, nil
+}
+
+func (s *CreditsOnlyStateMachine) patchCreatedChargePeriod(ctx context.Context, patch periodPatch) error {
+	patchResult, err := s.applyPeriodPatch(patch)
+	if err != nil {
+		return err
+	}
+
+	if !patchResult.ShouldReconcile {
+		return nil
+	}
+
+	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().From))
+	return nil
+}
+
+func argAsPeriodPatch[T periodPatch](fn func(context.Context, periodPatch) error) func(context.Context, T) error {
+	return func(ctx context.Context, arg T) error {
+		return fn(ctx, arg)
+	}
 }
 
 func (s *CreditsOnlyStateMachine) persistActivePeriodPatch(ctx context.Context) error {

--- a/openmeter/billing/charges/usagebased/service/creditsonly_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly_test.go
@@ -1,0 +1,315 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	decimal "github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
+	chargestatemachine "github.com/openmeterio/openmeter/openmeter/billing/charges/statemachine"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	usagebasedrating "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/rating"
+	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+func TestCreditsOnlyPeriodPatchIsConfiguredForFinalRealizationBoundaries(t *testing.T) {
+	for _, status := range []usagebased.Status{
+		usagebased.StatusActiveFinalRealizationStarted,
+		usagebased.StatusActiveFinalRealizationWaitingForCollection,
+		usagebased.StatusActiveFinalRealizationCompleted,
+		usagebased.StatusFinal,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			machine := newCreditsOnlyStateMachineForTest(t, status)
+
+			canFire, err := machine.CanFire(t.Context(), meta.TriggerShrink)
+			require.NoError(t, err)
+			require.True(t, canFire)
+
+			canFire, err = machine.CanFire(t.Context(), meta.TriggerExtend)
+			require.NoError(t, err)
+			require.True(t, canFire)
+		})
+	}
+}
+
+func TestCreditsOnlyExtendWhileFinalRealizationInProgressVoidsCurrentRunAndMovesActive(t *testing.T) {
+	for _, status := range []usagebased.Status{
+		usagebased.StatusActiveFinalRealizationStarted,
+		usagebased.StatusActiveFinalRealizationWaitingForCollection,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			servicePeriod := timeutil.ClosedPeriod{
+				From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+				To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+			}
+			extendedServicePeriodTo := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+			currentRunID := "run-1"
+
+			machine := newCreditsOnlyStateMachineWithChargeForTest(t, usagebased.Charge{
+				ChargeBase: usagebased.ChargeBase{
+					ManagedResource: newUsageBasedChargeTestManagedResource("charge-id"),
+					Intent:          newUsageBasedIntentForCreditOnlyTest(servicePeriod),
+					Status:          status,
+					State: usagebased.State{
+						CurrentRealizationRunID: &currentRunID,
+						FeatureID:               "feature-id",
+						RatingEngine:            usagebased.RatingEngineDelta,
+					},
+				},
+				Realizations: usagebased.RealizationRuns{
+					newUsageBasedRunForShrinkTest(currentRunID, usagebased.RealizationRunTypeFinalRealization, servicePeriod.To),
+				},
+			})
+
+			patch := mustNewPatchExtend(t, extendedServicePeriodTo)
+			err := machine.FireAndActivate(t.Context(), patch.Trigger(), patch)
+			require.NoError(t, err)
+
+			charge := machine.GetCharge()
+			require.Equal(t, usagebased.StatusActive, charge.Status)
+			require.Nil(t, charge.State.CurrentRealizationRunID)
+			require.NotNil(t, charge.State.AdvanceAfter)
+			require.Equal(t, extendedServicePeriodTo, *charge.State.AdvanceAfter)
+			require.Equal(t, extendedServicePeriodTo, charge.Intent.GetEffectiveServicePeriod().To)
+
+			run, err := charge.Realizations.GetByID(currentRunID)
+			require.NoError(t, err)
+			require.NotNil(t, run.DeletedAt)
+		})
+	}
+}
+
+func TestCreditsOnlyShrinkWhileCompletedVoidsRunBeyondNewEndAndMovesActive(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	newServicePeriodTo := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	machine := newCreditsOnlyStateMachineWithChargeForTest(t, usagebased.Charge{
+		ChargeBase: usagebased.ChargeBase{
+			ManagedResource: newUsageBasedChargeTestManagedResource("charge-id"),
+			Intent:          newUsageBasedIntentForCreditOnlyTest(servicePeriod),
+			Status:          usagebased.StatusActiveFinalRealizationCompleted,
+			State: usagebased.State{
+				FeatureID:    "feature-id",
+				RatingEngine: usagebased.RatingEngineDelta,
+			},
+		},
+		Realizations: usagebased.RealizationRuns{
+			newUsageBasedRunForShrinkTest("run-1", usagebased.RealizationRunTypeFinalRealization, servicePeriod.To),
+		},
+	})
+
+	patch := mustNewPatchShrink(t, newServicePeriodTo)
+	err := machine.FireAndActivate(t.Context(), patch.Trigger(), patch)
+	require.NoError(t, err)
+
+	charge := machine.GetCharge()
+	require.Equal(t, usagebased.StatusActive, charge.Status)
+	require.Nil(t, charge.State.CurrentRealizationRunID)
+	require.NotNil(t, charge.State.AdvanceAfter)
+	require.Equal(t, newServicePeriodTo, *charge.State.AdvanceAfter)
+	require.Equal(t, newServicePeriodTo, charge.Intent.GetEffectiveServicePeriod().To)
+
+	run, err := charge.Realizations.GetByID("run-1")
+	require.NoError(t, err)
+	require.NotNil(t, run.DeletedAt)
+}
+
+func TestCreditsOnlyExtendWhileCompletedVoidsRunAndMovesActive(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	extendedServicePeriodTo := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	machine := newCreditsOnlyStateMachineWithChargeForTest(t, usagebased.Charge{
+		ChargeBase: usagebased.ChargeBase{
+			ManagedResource: newUsageBasedChargeTestManagedResource("charge-id"),
+			Intent:          newUsageBasedIntentForCreditOnlyTest(servicePeriod),
+			Status:          usagebased.StatusActiveFinalRealizationCompleted,
+			State: usagebased.State{
+				FeatureID:    "feature-id",
+				RatingEngine: usagebased.RatingEngineDelta,
+			},
+		},
+		Realizations: usagebased.RealizationRuns{
+			newUsageBasedRunForShrinkTest("run-1", usagebased.RealizationRunTypeFinalRealization, servicePeriod.To),
+		},
+	})
+
+	patch := mustNewPatchExtend(t, extendedServicePeriodTo)
+	err := machine.FireAndActivate(t.Context(), patch.Trigger(), patch)
+	require.NoError(t, err)
+
+	charge := machine.GetCharge()
+	require.Equal(t, usagebased.StatusActive, charge.Status)
+	require.Nil(t, charge.State.CurrentRealizationRunID)
+	require.NotNil(t, charge.State.AdvanceAfter)
+	require.Equal(t, extendedServicePeriodTo, *charge.State.AdvanceAfter)
+	require.Equal(t, extendedServicePeriodTo, charge.Intent.GetEffectiveServicePeriod().To)
+
+	run, err := charge.Realizations.GetByID("run-1")
+	require.NoError(t, err)
+	require.NotNil(t, run.DeletedAt)
+}
+
+func newUsageBasedIntentForCreditOnlyTest(servicePeriod timeutil.ClosedPeriod) usagebased.OverridableIntent {
+	return usagebased.Intent{
+		Intent: meta.Intent{
+			ManagedBy:  billing.SubscriptionManagedLine,
+			CustomerID: "customer-id",
+			Currency:   currencyx.Code("USD"),
+		},
+		IntentMutableFields: usagebased.IntentMutableFields{
+			IntentMutableFields: meta.IntentMutableFields{
+				Name:              "usage",
+				ServicePeriod:     servicePeriod,
+				FullServicePeriod: servicePeriod,
+				BillingPeriod:     servicePeriod,
+				TaxConfig: productcatalog.TaxCodeConfig{
+					TaxCodeID: "tax-code-id",
+				},
+			},
+			InvoiceAt:  servicePeriod.To,
+			FeatureKey: "feature-key",
+			Price: *productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+				Amount: decimal.NewFromInt(1),
+			}),
+		},
+		SettlementMode: productcatalog.CreditOnlySettlementMode,
+	}.AsOverridableIntent()
+}
+
+func newCreditsOnlyStateMachineForTest(t *testing.T, status usagebased.Status) *CreditsOnlyStateMachine {
+	t.Helper()
+
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	return newCreditsOnlyStateMachineWithChargeForTest(t, usagebased.Charge{
+		ChargeBase: usagebased.ChargeBase{
+			ManagedResource: newUsageBasedChargeTestManagedResource("charge-id"),
+			Intent:          newUsageBasedIntentForCreditOnlyTest(servicePeriod),
+			Status:          status,
+			State: usagebased.State{
+				FeatureID:    "feature-id",
+				RatingEngine: usagebased.RatingEngineDelta,
+			},
+		},
+	})
+}
+
+func newCreditsOnlyStateMachineWithChargeForTest(t *testing.T, charge usagebased.Charge) *CreditsOnlyStateMachine {
+	t.Helper()
+
+	adapter := newCreditsOnlyStateMachineAdapter(charge)
+	runService, err := usagebasedrun.New(usagebasedrun.Config{
+		Adapter: adapter,
+		Rater:   creditsOnlyStateMachineRater{},
+		Handler: usagebased.UnimplementedHandler{},
+		Lineage: creditsOnlyStateMachineLineage{},
+	})
+	require.NoError(t, err)
+
+	currencyCalculator, err := currencyx.Code("USD").Calculator()
+	require.NoError(t, err)
+
+	machine, err := chargestatemachine.New(chargestatemachine.Config[usagebased.Charge, usagebased.ChargeBase, usagebased.Status]{
+		Charge: charge,
+		Persistence: chargestatemachine.Persistence[usagebased.Charge, usagebased.ChargeBase]{
+			UpdateBase: func(_ context.Context, base usagebased.ChargeBase) (usagebased.ChargeBase, error) {
+				return base, nil
+			},
+			Refetch: func(_ context.Context, _ meta.ChargeID) (usagebased.Charge, error) {
+				return charge, nil
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	out := &CreditsOnlyStateMachine{
+		stateMachine: &stateMachine{
+			Machine:            machine,
+			Adapter:            adapter,
+			Runs:               runService,
+			CurrencyCalculator: currencyCalculator,
+		},
+	}
+	out.configureStates()
+
+	return out
+}
+
+func newUsageBasedChargeTestManagedResource(id string) meta.ManagedResource {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	return meta.ManagedResource{
+		NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
+		ManagedModel: models.ManagedModel{
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		ID: id,
+	}
+}
+
+type creditsOnlyStateMachineAdapter struct {
+	usagebased.Adapter
+
+	runs map[string]usagebased.RealizationRunBase
+}
+
+func newCreditsOnlyStateMachineAdapter(charge usagebased.Charge) *creditsOnlyStateMachineAdapter {
+	runs := make(map[string]usagebased.RealizationRunBase, len(charge.Realizations))
+	for _, run := range charge.Realizations {
+		runs[run.ID.ID] = run.RealizationRunBase
+	}
+
+	return &creditsOnlyStateMachineAdapter{
+		runs: runs,
+	}
+}
+
+func (a *creditsOnlyStateMachineAdapter) UpdateCharge(_ context.Context, base usagebased.ChargeBase) (usagebased.ChargeBase, error) {
+	return base, nil
+}
+
+func (a *creditsOnlyStateMachineAdapter) UpdateRealizationRun(_ context.Context, input usagebased.UpdateRealizationRunInput) (usagebased.RealizationRunBase, error) {
+	run, ok := a.runs[input.ID.ID]
+	if !ok {
+		return usagebased.RealizationRunBase{}, nil
+	}
+
+	if input.DeletedAt.IsPresent() {
+		run.DeletedAt = input.DeletedAt.OrEmpty()
+	}
+
+	a.runs[input.ID.ID] = run
+	return run, nil
+}
+
+type creditsOnlyStateMachineRater struct {
+	usagebasedrating.Service
+}
+
+type creditsOnlyStateMachineLineage struct {
+	lineage.Service
+}
+
+func (creditsOnlyStateMachineLineage) LoadActiveSegmentsByRealizationID(_ context.Context, _ string, _ []string) (lineage.ActiveSegmentsByRealizationID, error) {
+	return lineage.ActiveSegmentsByRealizationID{}, nil
+}

--- a/openmeter/billing/charges/usagebased/service/creditsonly_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly_test.go
@@ -21,14 +21,22 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func TestCreditsOnlyPeriodPatchIsConfiguredForFinalRealizationBoundaries(t *testing.T) {
+func TestCreditsOnlyPeriodPatchIsConfiguredForPatchableStates(t *testing.T) {
 	for _, status := range []usagebased.Status{
+		usagebased.StatusCreated,
+		usagebased.StatusActive,
 		usagebased.StatusActiveFinalRealizationStarted,
 		usagebased.StatusActiveFinalRealizationWaitingForCollection,
 		usagebased.StatusActiveFinalRealizationCompleted,
 		usagebased.StatusFinal,
 	} {
 		t.Run(string(status), func(t *testing.T) {
+			// given:
+			// - a credit-only usage-based charge state machine in a patchable state
+			// when:
+			// - shrink and extend patch triggers are checked
+			// then:
+			// - both period patches are accepted by the state machine
 			machine := newCreditsOnlyStateMachineForTest(t, status)
 
 			canFire, err := machine.CanFire(t.Context(), meta.TriggerShrink)
@@ -42,12 +50,77 @@ func TestCreditsOnlyPeriodPatchIsConfiguredForFinalRealizationBoundaries(t *test
 	}
 }
 
+func TestCreditsOnlyPeriodPatchWhileCreatedUpdatesIntentAndKeepsCreatedSchedule(t *testing.T) {
+	servicePeriod := timeutil.ClosedPeriod{
+		From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	for _, tc := range []struct {
+		name string
+		to   time.Time
+		new  func(t *testing.T, to time.Time) meta.Patch
+	}{
+		{
+			name: "shrink",
+			to:   time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
+			new: func(t *testing.T, to time.Time) meta.Patch {
+				return mustNewPatchShrink(t, to)
+			},
+		},
+		{
+			name: "extend",
+			to:   time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			new: func(t *testing.T, to time.Time) meta.Patch {
+				return mustNewPatchExtend(t, to)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// given:
+			// - a created credit-only usage-based charge before realization
+			// when:
+			// - a period patch is applied
+			// then:
+			// - the charge stays created and remains scheduled from service-period start
+			machine := newCreditsOnlyStateMachineWithChargeForTest(t, usagebased.Charge{
+				ChargeBase: usagebased.ChargeBase{
+					ManagedResource: newUsageBasedChargeTestManagedResource("charge-id"),
+					Intent:          newUsageBasedIntentForCreditOnlyTest(servicePeriod),
+					Status:          usagebased.StatusCreated,
+					State: usagebased.State{
+						FeatureID:    "feature-id",
+						RatingEngine: usagebased.RatingEngineDelta,
+					},
+				},
+			})
+
+			patch := tc.new(t, tc.to)
+			err := machine.FireAndActivate(t.Context(), patch.Trigger(), patch)
+			require.NoError(t, err)
+
+			charge := machine.GetCharge()
+			require.Equal(t, usagebased.StatusCreated, charge.Status)
+			require.Nil(t, charge.State.CurrentRealizationRunID)
+			require.NotNil(t, charge.State.AdvanceAfter)
+			require.Equal(t, servicePeriod.From, *charge.State.AdvanceAfter)
+			require.Equal(t, tc.to, charge.Intent.GetEffectiveServicePeriod().To)
+		})
+	}
+}
+
 func TestCreditsOnlyExtendWhileFinalRealizationInProgressVoidsCurrentRunAndMovesActive(t *testing.T) {
 	for _, status := range []usagebased.Status{
 		usagebased.StatusActiveFinalRealizationStarted,
 		usagebased.StatusActiveFinalRealizationWaitingForCollection,
 	} {
 		t.Run(string(status), func(t *testing.T) {
+			// given:
+			// - a credit-only usage-based charge with final realization in progress
+			// when:
+			// - the service period is extended
+			// then:
+			// - the current final run is voided and the charge moves back to active
 			servicePeriod := timeutil.ClosedPeriod{
 				From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 				To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),

--- a/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
@@ -459,6 +459,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeMidPerio
 		},
 	}
 
+	var originalFirstPeriodCharge flatfee.Charge
 	var originalSecondPeriodCharge flatfee.Charge
 
 	s.Run("provisions the current and next billing cycle", func() {
@@ -467,6 +468,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeMidPerio
 		provisionedCharges := s.expectCreditsOnlyFlatFeeCharges(ctx, subscriptionView.Subscription.ID, expectedCharges)
 		s.Len(provisionedCharges, 2)
 
+		originalFirstPeriodCharge = provisionedCharges[0]
 		originalSecondPeriodCharge = provisionedCharges[1]
 	})
 
@@ -506,6 +508,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyFlatFeeMidPerio
 			},
 		})
 		s.Len(remainingCharges, 1)
+		s.Equal(originalFirstPeriodCharge.ID, remainingCharges[0].ID)
 
 		deletedChargeRes, err := s.Charges.GetByID(ctx, charges.GetByIDInput{
 			ChargeID: chargesmeta.ChargeID{
@@ -942,6 +945,7 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedMidPe
 			},
 		})
 		s.Len(remainingCharges, 1)
+		s.Equal(originalFirstPeriodCharge.ID, remainingCharges[0].ID)
 
 		afterShrinkChargeRes, err := s.Charges.GetByID(ctx, charges.GetByIDInput{
 			ChargeID: chargesmeta.ChargeID{
@@ -956,14 +960,10 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedMidPe
 
 		afterShrinkCharge, err := afterShrinkChargeRes.AsUsageBasedCharge()
 		s.NoError(err)
-		s.Len(afterShrinkCharge.Realizations, 1)
-
-		finalRun := afterShrinkCharge.Realizations[0]
-		s.Equal(float64(8), finalRun.MeteredQuantity.InexactFloat64())
-		s.Equal(float64(0), finalRun.Totals.Total.InexactFloat64())
-		s.Equal(float64(8), finalRun.Totals.CreditsTotal.InexactFloat64())
-		s.Len(finalRun.CreditsAllocated, 1)
-		s.Equal(float64(8), finalRun.CreditsAllocated[0].Amount.InexactFloat64())
+		s.Equal(usagebased.StatusActive, afterShrinkCharge.Status)
+		s.Require().NotNil(afterShrinkCharge.State.AdvanceAfter)
+		s.True(afterShrinkCharge.State.AdvanceAfter.Equal(s.mustParseTime("2024-02-16T00:00:00Z")))
+		s.Empty(afterShrinkCharge.Realizations)
 
 		deletedChargeRes, err := s.Charges.GetByID(ctx, charges.GetByIDInput{
 			ChargeID: chargesmeta.ChargeID{

--- a/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/creditsonly_test.go
@@ -787,8 +787,9 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedMidPe
 	// - the subscription is synchronized again
 	//
 	// Then:
-	// - the current usage based charge is shrunk to the cancellation boundary
-	// - the recreated shrunk charge realizes only the pre-cancellation usage
+	// - the current usage based charge is shrunk in place to the cancellation boundary
+	// - the remaining charge stays created and scheduled from the service-period start
+	// - no realization is created before the next advancement
 	// - the future usage based charge is deleted
 	ctx := s.testContext()
 	setupAt := s.mustParseTime("2024-01-01T00:00:00Z")
@@ -960,9 +961,9 @@ func (s *CreditsOnlySubscriptionHandlerTestSuite) TestCreditsOnlyUsageBasedMidPe
 
 		afterShrinkCharge, err := afterShrinkChargeRes.AsUsageBasedCharge()
 		s.NoError(err)
-		s.Equal(usagebased.StatusActive, afterShrinkCharge.Status)
+		s.Equal(usagebased.StatusCreated, afterShrinkCharge.Status)
 		s.Require().NotNil(afterShrinkCharge.State.AdvanceAfter)
-		s.True(afterShrinkCharge.State.AdvanceAfter.Equal(s.mustParseTime("2024-02-16T00:00:00Z")))
+		s.True(afterShrinkCharge.State.AdvanceAfter.Equal(s.mustParseTime("2024-02-01T00:00:00Z")))
 		s.Empty(afterShrinkCharge.Realizations)
 
 		deletedChargeRes, err := s.Charges.GetByID(ctx, charges.GetByIDInput{

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge_test.go
@@ -28,7 +28,7 @@ func TestFlatFeeCreditOnlyChargeCollectionShrinkEmitsNativePatch(t *testing.T) {
 		From: target.GetServicePeriod().From,
 		To:   target.GetServicePeriod().To.AddDate(0, 1, 0),
 	}
-	existingIntent := newChargePatchTestExistingIntent(target)
+	existingIntent := newChargePatchTestExistingFlatFeeIntent(target)
 	existingIntent.ServicePeriod = existingServicePeriod
 	existing := newChargePatchTestFlatFeeItemWithIntent(t, target, "flat-fee-charge", existingIntent)
 
@@ -170,11 +170,11 @@ func TestUsageBasedCreditThenInvoiceChargeCollectionExtendEmitsNativePatch(t *te
 func newChargePatchTestFlatFeeItem(t *testing.T, target targetstate.StateItem, id string) persistedstate.Item {
 	t.Helper()
 
-	existingIntent := newChargePatchTestExistingIntent(target)
+	existingIntent := newChargePatchTestExistingFlatFeeIntent(target)
 	return newChargePatchTestFlatFeeItemWithIntent(t, target, id, existingIntent)
 }
 
-func newChargePatchTestFlatFeeItemWithIntent(t *testing.T, target targetstate.StateItem, id string, existingIntent chargesusagebased.Intent) persistedstate.Item {
+func newChargePatchTestFlatFeeItemWithIntent(t *testing.T, target targetstate.StateItem, id string, existingIntent chargesflatfee.Intent) persistedstate.Item {
 	t.Helper()
 
 	charge := chargesflatfee.Charge{
@@ -202,6 +202,21 @@ func newChargePatchTestFlatFeeItemWithIntent(t *testing.T, target targetstate.St
 	require.NoError(t, err)
 
 	return item
+}
+
+func newChargePatchTestExistingFlatFeeIntent(target targetstate.StateItem) chargesflatfee.Intent {
+	existingIntent := newChargePatchTestExistingIntent(target)
+
+	return chargesflatfee.Intent{
+		Intent: existingIntent.Intent,
+		IntentMutableFields: chargesflatfee.IntentMutableFields{
+			IntentMutableFields: existingIntent.IntentMutableFields.IntentMutableFields,
+			InvoiceAt:           target.GetInvoiceAt(),
+			PaymentTerm:         productcatalog.InAdvancePaymentTerm,
+			ProRating:           target.Subscription.ProRatingConfig,
+		},
+		SettlementMode: target.Subscription.SettlementMode,
+	}
 }
 
 func newChargePatchTestUsageBasedItem(t *testing.T, target targetstate.StateItem, id string, settlementMode productcatalog.SettlementMode) persistedstate.Item {

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchcharge_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
-	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	chargesflatfee "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	chargesmeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	chargesusagebased "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
@@ -22,63 +21,80 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func TestFlatFeeChargeCollectionPeriodChangesEmitEmulatedReplacement(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		add  func(*flatFeeChargeCollection, persistedstate.Item, targetstate.StateItem) error
-	}{
-		{
-			name: "shrink",
-			add: func(c *flatFeeChargeCollection, existing persistedstate.Item, target targetstate.StateItem) error {
-				return c.AddShrink(target.UniqueID, existing, target)
-			},
-		},
-		{
-			name: "extend",
-			add: func(c *flatFeeChargeCollection, existing persistedstate.Item, target targetstate.StateItem) error {
-				return c.AddExtend(existing, target)
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			collection := newFlatFeeChargeCollection(1)
-			target := newChargePatchTestTarget(t, productcatalog.CreditOnlySettlementMode, newChargePatchTestFlatRateCard())
-			existing := newChargePatchTestFlatFeeItem(t, target, "flat-fee-charge")
-
-			require.NoError(t, tc.add(collection, existing, target))
-
-			assertEmulatedReplacement(t, collection.Patches(), "flat-fee-charge", func(intent charges.ChargeIntent) {
-				flatFeeIntent, err := intent.AsFlatFeeIntent()
-				require.NoError(t, err)
-				require.Equal(t, target.GetServicePeriod(), flatFeeIntent.ServicePeriod)
-				require.Equal(t, target.FullServicePeriod, flatFeeIntent.FullServicePeriod)
-				require.Equal(t, target.BillingPeriod, flatFeeIntent.BillingPeriod)
-				require.Equal(t, productcatalog.CreditOnlySettlementMode, flatFeeIntent.SettlementMode)
-			})
-		})
+func TestFlatFeeCreditOnlyChargeCollectionShrinkEmitsNativePatch(t *testing.T) {
+	collection := newFlatFeeChargeCollection(1)
+	target := newChargePatchTestTarget(t, productcatalog.CreditOnlySettlementMode, newChargePatchTestFlatRateCard())
+	existingServicePeriod := timeutil.ClosedPeriod{
+		From: target.GetServicePeriod().From,
+		To:   target.GetServicePeriod().To.AddDate(0, 1, 0),
 	}
-}
-
-func TestUsageBasedCreditOnlyChargeCollectionShrinkEmitsEmulatedReplacement(t *testing.T) {
-	collection := newUsageBasedChargeCollection(1)
-	target := newChargePatchTestTarget(t, productcatalog.CreditOnlySettlementMode, newChargePatchTestUsageRateCard())
-	existingFullServicePeriod := timeutil.ClosedPeriod{
-		From: target.FullServicePeriod.From,
-		To:   target.FullServicePeriod.To.AddDate(0, 1, 0),
-	}
-	existing := newChargePatchTestUsageBasedItemWithFullServicePeriod(t, target, "usage-based-charge", productcatalog.CreditOnlySettlementMode, existingFullServicePeriod)
+	existingIntent := newChargePatchTestExistingIntent(target)
+	existingIntent.ServicePeriod = existingServicePeriod
+	existing := newChargePatchTestFlatFeeItemWithIntent(t, target, "flat-fee-charge", existingIntent)
 
 	require.NoError(t, collection.AddShrink(target.UniqueID, existing, target))
 
-	assertEmulatedReplacement(t, collection.Patches(), "usage-based-charge", func(intent charges.ChargeIntent) {
-		usageBasedIntent, err := intent.AsUsageBasedIntent()
-		require.NoError(t, err)
-		require.Equal(t, target.GetServicePeriod(), usageBasedIntent.ServicePeriod)
-		require.Equal(t, target.FullServicePeriod, usageBasedIntent.FullServicePeriod)
-		require.Equal(t, target.BillingPeriod, usageBasedIntent.BillingPeriod)
-		require.Equal(t, target.GetInvoiceAt(), usageBasedIntent.InvoiceAt)
-		require.Equal(t, productcatalog.CreditOnlySettlementMode, usageBasedIntent.SettlementMode)
-	})
+	patches := collection.Patches()
+	require.Empty(t, patches.Creates)
+	require.Len(t, patches.PatchesByChargeID, 1)
+
+	patch, ok := patches.PatchesByChargeID["flat-fee-charge"]
+	require.True(t, ok)
+
+	shrinkPatch, ok := patch.(chargesmeta.PatchShrink)
+	require.True(t, ok, "expected native shrink patch, got %T", patch)
+	require.Equal(t, target.GetServicePeriod().To, shrinkPatch.GetNewServicePeriodTo())
+	require.Equal(t, target.FullServicePeriod.To, shrinkPatch.GetNewFullServicePeriodTo())
+	require.Equal(t, target.BillingPeriod.To, shrinkPatch.GetNewBillingPeriodTo())
+	require.Equal(t, target.GetInvoiceAt(), shrinkPatch.GetNewInvoiceAt())
+}
+
+func TestFlatFeeCreditOnlyChargeCollectionExtendEmitsNativePatch(t *testing.T) {
+	collection := newFlatFeeChargeCollection(1)
+	target := newChargePatchTestTarget(t, productcatalog.CreditOnlySettlementMode, newChargePatchTestFlatRateCard())
+	existing := newChargePatchTestFlatFeeItem(t, target, "flat-fee-charge")
+
+	require.NoError(t, collection.AddExtend(existing, target))
+
+	patches := collection.Patches()
+	require.Empty(t, patches.Creates)
+	require.Len(t, patches.PatchesByChargeID, 1)
+
+	patch, ok := patches.PatchesByChargeID["flat-fee-charge"]
+	require.True(t, ok)
+
+	extendPatch, ok := patch.(chargesmeta.PatchExtend)
+	require.True(t, ok, "expected native extend patch, got %T", patch)
+	require.Equal(t, target.GetServicePeriod().To, extendPatch.GetNewServicePeriodTo())
+	require.Equal(t, target.FullServicePeriod.To, extendPatch.GetNewFullServicePeriodTo())
+	require.Equal(t, target.BillingPeriod.To, extendPatch.GetNewBillingPeriodTo())
+	require.Equal(t, target.GetInvoiceAt(), extendPatch.GetNewInvoiceAt())
+}
+
+func TestUsageBasedCreditOnlyChargeCollectionShrinkEmitsNativePatch(t *testing.T) {
+	collection := newUsageBasedChargeCollection(1)
+	target := newChargePatchTestTarget(t, productcatalog.CreditOnlySettlementMode, newChargePatchTestUsageRateCard())
+	existingServicePeriod := timeutil.ClosedPeriod{
+		From: target.GetServicePeriod().From,
+		To:   target.GetServicePeriod().To.AddDate(0, 1, 0),
+	}
+	existing := newChargePatchTestUsageBasedItemWithServicePeriod(t, target, "usage-based-charge", productcatalog.CreditOnlySettlementMode, existingServicePeriod)
+
+	require.NoError(t, collection.AddShrink(target.UniqueID, existing, target))
+
+	patches := collection.Patches()
+	require.Empty(t, patches.Creates)
+	require.Len(t, patches.PatchesByChargeID, 1)
+
+	patch, ok := patches.PatchesByChargeID["usage-based-charge"]
+	require.True(t, ok)
+
+	shrinkPatch, ok := patch.(chargesmeta.PatchShrink)
+	require.True(t, ok, "expected native shrink patch, got %T", patch)
+	require.Equal(t, target.GetServicePeriod().To, shrinkPatch.GetNewServicePeriodTo())
+	require.Equal(t, target.FullServicePeriod.To, shrinkPatch.GetNewFullServicePeriodTo())
+	require.Equal(t, target.BillingPeriod.To, shrinkPatch.GetNewBillingPeriodTo())
+	require.Equal(t, target.GetInvoiceAt(), shrinkPatch.GetNewInvoiceAt())
 }
 
 func TestUsageBasedCreditThenInvoiceChargeCollectionShrinkEmitsNativePatch(t *testing.T) {
@@ -107,21 +123,26 @@ func TestUsageBasedCreditThenInvoiceChargeCollectionShrinkEmitsNativePatch(t *te
 	require.Equal(t, target.GetInvoiceAt(), shrinkPatch.GetNewInvoiceAt())
 }
 
-func TestUsageBasedCreditOnlyChargeCollectionExtendEmitsEmulatedReplacement(t *testing.T) {
+func TestUsageBasedCreditOnlyChargeCollectionExtendEmitsNativePatch(t *testing.T) {
 	collection := newUsageBasedChargeCollection(1)
 	target := newChargePatchTestTarget(t, productcatalog.CreditOnlySettlementMode, newChargePatchTestUsageRateCard())
 	existing := newChargePatchTestUsageBasedItem(t, target, "usage-based-charge", productcatalog.CreditOnlySettlementMode)
 
 	require.NoError(t, collection.AddExtend(existing, target))
 
-	assertEmulatedReplacement(t, collection.Patches(), "usage-based-charge", func(intent charges.ChargeIntent) {
-		usageBasedIntent, err := intent.AsUsageBasedIntent()
-		require.NoError(t, err)
-		require.Equal(t, target.GetServicePeriod(), usageBasedIntent.ServicePeriod)
-		require.Equal(t, target.FullServicePeriod, usageBasedIntent.FullServicePeriod)
-		require.Equal(t, target.BillingPeriod, usageBasedIntent.BillingPeriod)
-		require.Equal(t, productcatalog.CreditOnlySettlementMode, usageBasedIntent.SettlementMode)
-	})
+	patches := collection.Patches()
+	require.Empty(t, patches.Creates)
+	require.Len(t, patches.PatchesByChargeID, 1)
+
+	patch, ok := patches.PatchesByChargeID["usage-based-charge"]
+	require.True(t, ok)
+
+	extendPatch, ok := patch.(chargesmeta.PatchExtend)
+	require.True(t, ok, "expected native extend patch, got %T", patch)
+	require.Equal(t, target.GetServicePeriod().To, extendPatch.GetNewServicePeriodTo())
+	require.Equal(t, target.FullServicePeriod.To, extendPatch.GetNewFullServicePeriodTo())
+	require.Equal(t, target.BillingPeriod.To, extendPatch.GetNewBillingPeriodTo())
+	require.Equal(t, target.GetInvoiceAt(), extendPatch.GetNewInvoiceAt())
 }
 
 func TestUsageBasedCreditThenInvoiceChargeCollectionExtendEmitsNativePatch(t *testing.T) {
@@ -146,25 +167,15 @@ func TestUsageBasedCreditThenInvoiceChargeCollectionExtendEmitsNativePatch(t *te
 	require.Equal(t, target.GetInvoiceAt(), extendPatch.GetNewInvoiceAt())
 }
 
-func assertEmulatedReplacement(t *testing.T, patches charges.ApplyPatchesInput, chargeID string, assertCreate func(charges.ChargeIntent)) {
-	t.Helper()
-
-	require.Len(t, patches.PatchesByChargeID, 1)
-	require.Len(t, patches.Creates, 1)
-
-	patch, ok := patches.PatchesByChargeID[chargeID]
-	require.True(t, ok)
-
-	_, ok = patch.(chargesmeta.PatchDelete)
-	require.True(t, ok, "expected delete patch, got %T", patch)
-
-	assertCreate(patches.Creates[0])
-}
-
 func newChargePatchTestFlatFeeItem(t *testing.T, target targetstate.StateItem, id string) persistedstate.Item {
 	t.Helper()
 
 	existingIntent := newChargePatchTestExistingIntent(target)
+	return newChargePatchTestFlatFeeItemWithIntent(t, target, id, existingIntent)
+}
+
+func newChargePatchTestFlatFeeItemWithIntent(t *testing.T, target targetstate.StateItem, id string, existingIntent chargesusagebased.Intent) persistedstate.Item {
+	t.Helper()
 
 	charge := chargesflatfee.Charge{
 		ChargeBase: chargesflatfee.ChargeBase{

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeflatfee.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeflatfee.go
@@ -35,25 +35,14 @@ func (c *flatFeeChargeCollection) AddCreate(target targetstate.StateItem) error 
 }
 
 func (c *flatFeeChargeCollection) AddShrink(_ string, existing persistedstate.Item, target targetstate.StateItem) error {
-	existingCharge, ok := existing.(persistedstate.FlatFeeChargeGetter)
+	_, ok := existing.(persistedstate.FlatFeeChargeGetter)
 	if !ok {
 		return fmt.Errorf("existing item is not a flat fee charge [item_type=%s,id=%s]", existing.Type(), existing.ID())
 	}
 
-	if existingCharge.GetFlatFeeCharge().Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
-		intent, err := newFlatFeeChargeIntent(target)
-		if err != nil {
-			return err
-		}
-
-		return c.addEmulatedReplacement(existing, intent)
-	}
-
-	targetServicePeriod := target.GetServicePeriod()
-
 	patch, err := chargesmeta.NewPatchShrink(chargesmeta.NewPatchShrinkInput{
 		Target:                 chargesmeta.ChangeTargetBase,
-		NewServicePeriodTo:     targetServicePeriod.To,
+		NewServicePeriodTo:     target.GetServicePeriod().To,
 		NewFullServicePeriodTo: target.FullServicePeriod.To,
 		NewBillingPeriodTo:     target.BillingPeriod.To,
 		NewInvoiceAt:           target.GetInvoiceAt(),
@@ -66,25 +55,14 @@ func (c *flatFeeChargeCollection) AddShrink(_ string, existing persistedstate.It
 }
 
 func (c *flatFeeChargeCollection) AddExtend(existing persistedstate.Item, target targetstate.StateItem) error {
-	existingCharge, ok := existing.(persistedstate.FlatFeeChargeGetter)
+	_, ok := existing.(persistedstate.FlatFeeChargeGetter)
 	if !ok {
 		return fmt.Errorf("existing item is not a flat fee charge [item_type=%s,id=%s]", existing.Type(), existing.ID())
 	}
 
-	if existingCharge.GetFlatFeeCharge().Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
-		intent, err := newFlatFeeChargeIntent(target)
-		if err != nil {
-			return err
-		}
-
-		return c.addEmulatedReplacement(existing, intent)
-	}
-
-	targetServicePeriod := target.GetServicePeriod()
-
 	patch, err := chargesmeta.NewPatchExtend(chargesmeta.NewPatchExtendInput{
 		Target:                 chargesmeta.ChangeTargetBase,
-		NewServicePeriodTo:     targetServicePeriod.To,
+		NewServicePeriodTo:     target.GetServicePeriod().To,
 		NewFullServicePeriodTo: target.FullServicePeriod.To,
 		NewBillingPeriodTo:     target.BillingPeriod.To,
 		NewInvoiceAt:           target.GetInvoiceAt(),

--- a/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeusagebased.go
+++ b/openmeter/billing/worker/subscriptionsync/service/reconciler/patchchargeusagebased.go
@@ -35,18 +35,8 @@ func (c *usageBasedChargeCollection) AddCreate(target targetstate.StateItem) err
 }
 
 func (c *usageBasedChargeCollection) AddShrink(_ string, existing persistedstate.Item, target targetstate.StateItem) error {
-	existingCharge, ok := existing.(persistedstate.UsageBasedChargeGetter)
-	if !ok {
+	if _, ok := existing.(persistedstate.UsageBasedChargeGetter); !ok {
 		return fmt.Errorf("existing item is not a usage based charge [item_type=%s,id=%s]", existing.Type(), existing.ID())
-	}
-
-	if existingCharge.GetUsageBasedCharge().Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
-		intent, err := newUsageBasedChargeIntent(target)
-		if err != nil {
-			return err
-		}
-
-		return c.addEmulatedReplacement(existing, intent)
 	}
 
 	targetServicePeriod := target.GetServicePeriod()
@@ -66,18 +56,8 @@ func (c *usageBasedChargeCollection) AddShrink(_ string, existing persistedstate
 }
 
 func (c *usageBasedChargeCollection) AddExtend(existing persistedstate.Item, target targetstate.StateItem) error {
-	existingCharge, ok := existing.(persistedstate.UsageBasedChargeGetter)
-	if !ok {
+	if _, ok := existing.(persistedstate.UsageBasedChargeGetter); !ok {
 		return fmt.Errorf("existing item is not a usage based charge [item_type=%s,id=%s]", existing.Type(), existing.ID())
-	}
-
-	if existingCharge.GetUsageBasedCharge().Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
-		intent, err := newUsageBasedChargeIntent(target)
-		if err != nil {
-			return err
-		}
-
-		return c.addEmulatedReplacement(existing, intent)
 	}
 
 	targetServicePeriod := target.GetServicePeriod()

--- a/pkg/statelessx/actions.go
+++ b/pkg/statelessx/actions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/samber/lo"
 )
 
 type ActionFn func(context.Context) error
@@ -49,5 +50,15 @@ func WithParameters[T models.Validator](fn func(context.Context, T) error) func(
 		}
 
 		return fn(ctx, converted)
+	}
+}
+
+func AllOfWithParameters[T models.Validator](fn ...func(context.Context, T) error) func(context.Context, ...any) error {
+	return func(ctx context.Context, args ...any) error {
+		return errors.Join(
+			lo.Map(fn, func(fn func(context.Context, T) error, _ int) error {
+				return WithParameters[T](fn)(ctx, args...)
+			})...,
+		)
 	}
 }

--- a/pkg/statelessx/actions.go
+++ b/pkg/statelessx/actions.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type ActionFn func(context.Context) error


### PR DESCRIPTION
## Summary

- Support direct shrink/extend patch reconciliation for credit-only flat-fee and usage-based charges.
- Move targeted credit-only period patches away from emulated replacement behavior.
- For credit-only usage-based patches, void existing realization runs, persist the charge back to active, and advance from the patched service-period end.

## Validation

- `env POSTGRES_HOST=127.0.0.1 go test -count=1 -tags=dynamic ./pkg/statelessx ./openmeter/billing/charges/meta ./openmeter/billing/charges/flatfee/... ./openmeter/billing/charges/usagebased/... ./openmeter/billing/worker/subscriptionsync/service/...`
- `nix develop --impure .#ci -c make lint-go-fast`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded end-user support for extending and shrinking credit-only charges across additional lifecycle statuses.
  * Charge period updates now more consistently propagate to related service, billing, and invoice timing.
* **Bug Fixes**
  * Credit allocations now reconcile against existing credit runs rather than creating new ones unnecessarily.
  * Period-change events for credit-only settlement now emit native shrink/extend patches.
  * Mid-period cancellations preserve the remaining charge identity and align post-cancellation state expectations.
* **Tests**
  * Added and updated test coverage for period patching, final-realization boundaries, and native patch emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->