### PR TITLE
feat: unit config authoring on v3 api - OM-396

### DIFF
--- a/api/v3/handlers/plans/convert.go
+++ b/api/v3/handlers/plans/convert.go
@@ -174,12 +174,24 @@ func ToAPIBillingRateCard(rc productcatalog.RateCard) (api.BillingRateCard, erro
 		result.Entitlement = ent
 	}
 
-	unitConfig, err := ToAPIBillingRateCardUnitConfig(meta.Price)
-	if err != nil {
-		return result, fmt.Errorf("failed to convert unit config: %w", err)
-	}
+	// Prefer a stored unit config; fall back to synthesizing one from a v1
+	// dynamic/package price when none is stored. These two sources never coexist on
+	// a rate card reachable here: the v3 write path cannot author a package/dynamic
+	// price (only free/flat/unit/graduated/volume), and the v1 API has no unit_config
+	// field — so a stored unit_config and a package/dynamic price cannot be produced
+	// through either API, and there is no double-conversion ambiguity to resolve.
+	// (The RateCardMeta.Validate price-type rule is a publish-blocking warning, not a
+	// hard write-time reject, so it is not what guarantees this.)
+	if meta.UnitConfig != nil {
+		result.UnitConfig = lo.ToPtr(ToAPIBillingUnitConfig(*meta.UnitConfig))
+	} else {
+		unitConfig, err := ToAPIBillingRateCardUnitConfig(meta.Price)
+		if err != nil {
+			return result, fmt.Errorf("failed to convert unit config: %w", err)
+		}
 
-	result.UnitConfig = unitConfig
+		result.UnitConfig = unitConfig
+	}
 
 	return result, nil
 }
@@ -282,6 +294,54 @@ func ToAPIBillingRateCardUnitConfig(p *productcatalog.Price) (*api.BillingUnitCo
 	default:
 		return nil, nil
 	}
+}
+
+// ToAPIBillingUnitConfig maps a stored domain unit config to its API
+// representation. Rounding and Precision are omitted when no rounding is applied,
+// mirroring the domain semantics where both are inert for the "none" mode.
+func ToAPIBillingUnitConfig(uc productcatalog.UnitConfig) api.BillingUnitConfig {
+	out := api.BillingUnitConfig{
+		Operation:        api.BillingUnitConfigOperation(uc.Operation),
+		ConversionFactor: uc.ConversionFactor.String(),
+		DisplayUnit:      uc.DisplayUnit,
+	}
+
+	if !uc.Rounding.IsNone() {
+		out.Rounding = lo.ToPtr(api.BillingUnitConfigRoundingMode(uc.Rounding))
+		out.Precision = lo.ToPtr(uc.Precision)
+	}
+
+	return out
+}
+
+// FromAPIBillingUnitConfig maps the API unit config to the domain type. The enum
+// values are identical across the two layers, so operation and rounding are direct
+// casts; UnitConfig.Validate (run via RateCardMeta.Validate) rejects unknown enum
+// values and a non-positive conversion factor.
+func FromAPIBillingUnitConfig(uc api.BillingUnitConfig) (*productcatalog.UnitConfig, error) {
+	conversionFactor, err := decimal.NewFromString(uc.ConversionFactor)
+	if err != nil {
+		return nil, fmt.Errorf("invalid conversion factor: %w", err)
+	}
+
+	out := &productcatalog.UnitConfig{
+		Operation:        productcatalog.UnitConfigOperation(uc.Operation),
+		ConversionFactor: conversionFactor,
+		DisplayUnit:      uc.DisplayUnit,
+	}
+
+	if uc.Rounding != nil {
+		out.Rounding = productcatalog.UnitConfigRoundingMode(*uc.Rounding)
+	}
+
+	// Precision is inert without rounding; only carry it when rounding is active so
+	// it round-trips consistently with ToAPIBillingUnitConfig, which omits Precision
+	// in the "none" case.
+	if !out.Rounding.IsNone() {
+		out.Precision = lo.FromPtr(uc.Precision)
+	}
+
+	return out, nil
 }
 
 func ToAPIBillingPrice(p *productcatalog.Price) (api.BillingPrice, error) {
@@ -675,6 +735,21 @@ func FromAPIBillingRateCard(rc api.BillingRateCard) (productcatalog.RateCard, er
 		}
 
 		meta.EntitlementTemplate = tmpl
+	}
+
+	// Set the unit config up front: meta is copied by value into both the flat and
+	// usage-based rate cards below, so it must be populated before the switch. We do
+	// not branch on price type here; the price-type restriction lives in
+	// RateCardMeta.Validate as a publish-blocking warning, so an invalid combination
+	// (e.g. unit_config on a flat price) is mapped through and surfaces as a
+	// validation issue on the draft rather than being rejected at create/update.
+	if rc.UnitConfig != nil {
+		unitConfig, err := FromAPIBillingUnitConfig(*rc.UnitConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert unit config: %w", err)
+		}
+
+		meta.UnitConfig = unitConfig
 	}
 
 	switch priceType {

--- a/api/v3/handlers/plans/convert_test.go
+++ b/api/v3/handlers/plans/convert_test.go
@@ -726,6 +726,149 @@ func TestFromRateCard_DynamicAndPackagePrices(t *testing.T) {
 	})
 }
 
+func TestUnitConfigMapping(t *testing.T) {
+	t.Run("FromAPI maps all five fields", func(t *testing.T) {
+		uc, err := FromAPIBillingUnitConfig(api.BillingUnitConfig{
+			Operation:        api.BillingUnitConfigOperationDivide,
+			ConversionFactor: api.Numeric("1000"),
+			Rounding:         lo.ToPtr(api.BillingUnitConfigRoundingModeCeiling),
+			Precision:        lo.ToPtr(2),
+			DisplayUnit:      lo.ToPtr("K"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, uc)
+		assert.Equal(t, productcatalog.UnitConfigOperationDivide, uc.Operation)
+		assert.Equal(t, float64(1000), uc.ConversionFactor.InexactFloat64())
+		assert.Equal(t, productcatalog.UnitConfigRoundingModeCeiling, uc.Rounding)
+		assert.Equal(t, 2, uc.Precision)
+		assert.Equal(t, "K", lo.FromPtr(uc.DisplayUnit))
+	})
+
+	t.Run("FromAPI defaults rounding to none and precision to zero when omitted", func(t *testing.T) {
+		uc, err := FromAPIBillingUnitConfig(api.BillingUnitConfig{
+			Operation:        api.BillingUnitConfigOperationMultiply,
+			ConversionFactor: api.Numeric("1.2"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, uc)
+		assert.True(t, uc.Rounding.IsNone())
+		assert.Equal(t, 0, uc.Precision)
+		assert.Nil(t, uc.DisplayUnit)
+	})
+
+	t.Run("FromAPI drops precision when rounding is omitted, mirroring ToAPI", func(t *testing.T) {
+		// Precision is inert without rounding; carrying it would make From/To
+		// disagree about what is stored across a round-trip.
+		uc, err := FromAPIBillingUnitConfig(api.BillingUnitConfig{
+			Operation:        api.BillingUnitConfigOperationMultiply,
+			ConversionFactor: api.Numeric("1.2"),
+			Precision:        lo.ToPtr(3),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, uc)
+		assert.True(t, uc.Rounding.IsNone())
+		assert.Equal(t, 0, uc.Precision)
+	})
+
+	t.Run("FromAPI rejects a non-numeric conversion factor", func(t *testing.T) {
+		_, err := FromAPIBillingUnitConfig(api.BillingUnitConfig{
+			Operation:        api.BillingUnitConfigOperationDivide,
+			ConversionFactor: api.Numeric("not-a-number"),
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("ToAPI omits rounding and precision when rounding is none", func(t *testing.T) {
+		out := ToAPIBillingUnitConfig(productcatalog.UnitConfig{
+			Operation:        productcatalog.UnitConfigOperationMultiply,
+			ConversionFactor: decimal.NewFromFloat(1.2),
+			Precision:        3, // inert without rounding, must not surface
+		})
+		assert.Equal(t, api.BillingUnitConfigOperationMultiply, out.Operation)
+		assert.Equal(t, api.Numeric("1.2"), out.ConversionFactor)
+		assert.Nil(t, out.Rounding)
+		assert.Nil(t, out.Precision)
+	})
+
+	t.Run("round-trips through FromAPI and ToAPI", func(t *testing.T) {
+		in := api.BillingUnitConfig{
+			Operation:        api.BillingUnitConfigOperationDivide,
+			ConversionFactor: api.Numeric("1000"),
+			Rounding:         lo.ToPtr(api.BillingUnitConfigRoundingModeCeiling),
+			Precision:        lo.ToPtr(0),
+			DisplayUnit:      lo.ToPtr("GB"),
+		}
+
+		domain, err := FromAPIBillingUnitConfig(in)
+		require.NoError(t, err)
+
+		assert.Equal(t, in, ToAPIBillingUnitConfig(*domain))
+	})
+
+	t.Run("a stored unit config is surfaced verbatim on read, ahead of v1 synthesis", func(t *testing.T) {
+		cadence, err := datetime.ISODurationString("P1M").Parse()
+		require.NoError(t, err)
+
+		rc := &productcatalog.UsageBasedRateCard{
+			RateCardMeta: productcatalog.RateCardMeta{
+				Key:   "storage",
+				Name:  "Storage",
+				Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: decimal.NewFromFloat(0.05)}),
+				UnitConfig: &productcatalog.UnitConfig{
+					Operation:        productcatalog.UnitConfigOperationDivide,
+					ConversionFactor: decimal.NewFromInt(1_000_000_000),
+					Rounding:         productcatalog.UnitConfigRoundingModeCeiling,
+					DisplayUnit:      lo.ToPtr("GB"),
+				},
+			},
+			BillingCadence: cadence,
+		}
+
+		result, err := ToAPIBillingRateCard(rc)
+		require.NoError(t, err)
+		require.NotNil(t, result.UnitConfig)
+		assert.Equal(t, api.BillingUnitConfigOperationDivide, result.UnitConfig.Operation)
+		assert.Equal(t, api.Numeric("1000000000"), result.UnitConfig.ConversionFactor)
+		require.NotNil(t, result.UnitConfig.Rounding)
+		assert.Equal(t, api.BillingUnitConfigRoundingModeCeiling, *result.UnitConfig.Rounding)
+		assert.Equal(t, lo.ToPtr("GB"), result.UnitConfig.DisplayUnit)
+	})
+
+	t.Run("FromAPIBillingRateCard propagates unit_config into the rate card meta", func(t *testing.T) {
+		// Guards the authoring wiring directly: a unit_config on an api.BillingRateCard
+		// must survive into meta.UnitConfig. Without this, dropping the propagation in
+		// FromAPIBillingRateCard would still leave the helper round-trip tests green.
+		var price api.BillingPrice
+		require.NoError(t, price.FromBillingPriceUnit(api.BillingPriceUnit{Amount: "0.05", Type: "unit"}))
+
+		bc := api.ISO8601Duration("P1M")
+		rc := api.BillingRateCard{
+			Key:            "storage",
+			Name:           "Storage",
+			Price:          price,
+			BillingCadence: &bc,
+			UnitConfig: &api.BillingUnitConfig{
+				Operation:        api.BillingUnitConfigOperationDivide,
+				ConversionFactor: api.Numeric("1000000000"),
+				Rounding:         lo.ToPtr(api.BillingUnitConfigRoundingModeCeiling),
+				Precision:        lo.ToPtr(0),
+				DisplayUnit:      lo.ToPtr("GB"),
+			},
+		}
+
+		result, err := FromAPIBillingRateCard(rc)
+		require.NoError(t, err)
+
+		uc := result.AsMeta().UnitConfig
+		require.NotNil(t, uc)
+		assert.Equal(t, productcatalog.UnitConfigOperationDivide, uc.Operation)
+		assert.Equal(t, float64(1_000_000_000), uc.ConversionFactor.InexactFloat64())
+		assert.Equal(t, productcatalog.UnitConfigRoundingModeCeiling, uc.Rounding)
+		assert.Equal(t, 0, uc.Precision)
+		assert.Equal(t, lo.ToPtr("GB"), uc.DisplayUnit)
+	})
+}
+
 func TestFromBillingDiscounts(t *testing.T) {
 	t.Run("nil when no discounts", func(t *testing.T) {
 		result := ToAPIBillingRateCardDiscount(productcatalog.Discounts{})

--- a/openmeter/productcatalog/addon/adapter/adapter_test.go
+++ b/openmeter/productcatalog/addon/adapter/adapter_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/addon/adapter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	pctestutils "github.com/openmeterio/openmeter/openmeter/productcatalog/testutils"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
@@ -446,4 +448,32 @@ func TestPostgresAdapter(t *testing.T) {
 			}
 		})
 	})
+}
+
+// TestFromPlanRateCardRowMapsUnitConfig guards the cross-package mapper used when an
+// add-on is loaded with expanded linked plans
+// (FromAddonRow → FromPlanAddonRow → FromPlanRow → FromPlanPhaseRow → FromPlanRateCardRow).
+// This mapper is separate from the own-type add-on rate-card mapper, so a RateCardMeta field
+// added to one is not automatically carried by the other; UnitConfig dropping here would
+// surface a stored config as nil and rate raw usage instead of converted units.
+func TestFromPlanRateCardRowMapsUnitConfig(t *testing.T) {
+	unitConfig := &productcatalog.UnitConfig{
+		Operation:        productcatalog.UnitConfigOperationDivide,
+		ConversionFactor: decimal.NewFromInt(1000),
+		Rounding:         productcatalog.UnitConfigRoundingModeCeiling,
+		Precision:        0,
+		DisplayUnit:      lo.ToPtr("K"),
+	}
+
+	rc, err := adapter.FromPlanRateCardRow(entdb.PlanRateCard{
+		Key:        "rc",
+		Name:       "RC",
+		Type:       productcatalog.UsageBasedRateCardType,
+		Price:      productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: decimal.NewFromInt(1)}),
+		UnitConfig: unitConfig,
+	})
+	require.NoError(t, err, "mapping plan rate card row must not fail")
+
+	require.Equal(t, unitConfig, rc.AsMeta().UnitConfig,
+		"UnitConfig must survive the add-on adapter's linked plan mapper")
 }

--- a/openmeter/productcatalog/addon/adapter/mapping.go
+++ b/openmeter/productcatalog/addon/adapter/mapping.go
@@ -312,6 +312,7 @@ func FromPlanRateCardRow(r entdb.PlanRateCard) (productcatalog.RateCard, error) 
 		TaxConfig:           r.TaxConfig,
 		Price:               r.Price,
 		Discounts:           lo.FromPtr(r.Discounts),
+		UnitConfig:          r.UnitConfig,
 	}
 
 	// Map TaxCode if eagerly loaded.

--- a/openmeter/productcatalog/errors.go
+++ b/openmeter/productcatalog/errors.go
@@ -376,6 +376,16 @@ var ErrRateCardUsageBasedPriceWithNoFeature = models.NewValidationIssue(
 	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
 )
 
+const ErrCodeRateCardUnitConfigRequiresUsageBasedPrice models.ErrorCode = "unit_config_requires_usage_based_price"
+
+var ErrRateCardUnitConfigRequiresUsageBasedPrice = models.NewValidationIssue(
+	ErrCodeRateCardUnitConfigRequiresUsageBasedPrice,
+	"unit config requires a usage-based price (unit, graduated, or volume)",
+	models.WithFieldString("unit_config"),
+	models.WithWarningSeverity(),
+	commonhttp.WithHTTPStatusCodeAttribute(http.StatusBadRequest),
+)
+
 const ErrCodeRateCardUsageBasedPriceWithFeatureAndNoMeter models.ErrorCode = "usage_based_price_with_feature_and_no_meter"
 
 var ErrRateCardUsageBasedPriceWithFeatureAndNoMeter = models.NewValidationIssue(

--- a/openmeter/productcatalog/plan/adapter/adapter_test.go
+++ b/openmeter/productcatalog/plan/adapter/adapter_test.go
@@ -10,10 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	entdb "github.com/openmeterio/openmeter/openmeter/ent/db"
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/plan/adapter"
 	pctestutils "github.com/openmeterio/openmeter/openmeter/productcatalog/testutils"
 	"github.com/openmeterio/openmeter/openmeter/testutils"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -389,6 +391,33 @@ func TestPostgresAdapter(t *testing.T) {
 			testListPlanStatusFilter(t.Context(), t, env.PlanRepository)
 		})
 	})
+}
+
+// TestFromAddonRateCardRowMapsUnitConfig guards the cross-package mapper used when a
+// plan is loaded with expanded add-ons (FromPlanRow → FromAddonRow → FromAddonRateCardRow).
+// This mapper is separate from the own-type plan rate-card mapper, so a RateCardMeta field
+// added to one is not automatically carried by the other; UnitConfig dropping here would
+// surface a stored config as nil and rate raw usage instead of converted units.
+func TestFromAddonRateCardRowMapsUnitConfig(t *testing.T) {
+	unitConfig := &productcatalog.UnitConfig{
+		Operation:        productcatalog.UnitConfigOperationDivide,
+		ConversionFactor: decimal.NewFromInt(1000),
+		Rounding:         productcatalog.UnitConfigRoundingModeCeiling,
+		Precision:        0,
+		DisplayUnit:      lo.ToPtr("K"),
+	}
+
+	rc, err := adapter.FromAddonRateCardRow(entdb.AddonRateCard{
+		Key:        "rc",
+		Name:       "RC",
+		Type:       productcatalog.UsageBasedRateCardType,
+		Price:      productcatalog.NewPriceFrom(productcatalog.UnitPrice{Amount: decimal.NewFromInt(1)}),
+		UnitConfig: unitConfig,
+	})
+	require.NoError(t, err, "mapping addon rate card row must not fail")
+
+	require.Equal(t, unitConfig, rc.AsMeta().UnitConfig,
+		"UnitConfig must survive the plan adapter's linked add-on mapper")
 }
 
 type createPlanVersionInput struct {

--- a/openmeter/productcatalog/plan/adapter/mapping.go
+++ b/openmeter/productcatalog/plan/adapter/mapping.go
@@ -183,6 +183,7 @@ func FromAddonRateCardRow(r entdb.AddonRateCard) (productcatalog.RateCard, error
 		TaxConfig:           r.TaxConfig,
 		Price:               r.Price,
 		Discounts:           lo.FromPtr(r.Discounts),
+		UnitConfig:          r.UnitConfig,
 	}
 
 	// Map TaxCode if eagerly loaded.

--- a/openmeter/productcatalog/ratecard.go
+++ b/openmeter/productcatalog/ratecard.go
@@ -296,6 +296,16 @@ func (r RateCardMeta) Validate() error {
 				),
 			))
 		}
+
+		// A unit_config is a per-quantity conversion applied before rating, so it is
+		// only valid on a unit or tiered (graduated/volume) price. It is rejected on
+		// flat prices (not per-quantity) and on package/dynamic prices (which already
+		// carry their own conversion and would otherwise convert twice).
+		priceAllowsUnitConfig := r.Price != nil &&
+			(r.Price.Type() == UnitPriceType || r.Price.Type() == TieredPriceType)
+		if !priceAllowsUnitConfig {
+			errs = append(errs, ErrRateCardUnitConfigRequiresUsageBasedPrice)
+		}
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/productcatalog/ratecard_test.go
+++ b/openmeter/productcatalog/ratecard_test.go
@@ -361,6 +361,90 @@ func TestUsageBasedRateCard(t *testing.T) {
 	})
 }
 
+func TestRateCardMetaUnitConfigValidation(t *testing.T) {
+	unitConfig := func() *UnitConfig {
+		return &UnitConfig{
+			Operation:        UnitConfigOperationDivide,
+			ConversionFactor: decimal.NewFromInt(1000),
+			Rounding:         UnitConfigRoundingModeCeiling,
+			DisplayUnit:      lo.ToPtr("K"),
+		}
+	}
+
+	tieredPrice := NewPriceFrom(TieredPrice{
+		Mode: VolumeTieredPrice,
+		Tiers: []PriceTier{
+			{
+				UpToAmount: lo.ToPtr(decimal.NewFromInt(1000)),
+				FlatPrice:  &PriceTierFlatPrice{Amount: decimal.NewFromInt(100)},
+				UnitPrice:  &PriceTierUnitPrice{Amount: decimal.NewFromInt(50)},
+			},
+			{
+				UpToAmount: nil,
+				FlatPrice:  &PriceTierFlatPrice{Amount: decimal.NewFromInt(5)},
+				UnitPrice:  &PriceTierUnitPrice{Amount: decimal.NewFromInt(25)},
+			},
+		},
+	})
+
+	tests := []struct {
+		Name        string
+		Price       *Price
+		ExpectError bool
+	}{
+		{
+			Name:        "unit price allows unit config",
+			Price:       NewPriceFrom(UnitPrice{Amount: decimal.NewFromInt(1)}),
+			ExpectError: false,
+		},
+		{
+			Name:        "tiered (volume) price allows unit config",
+			Price:       tieredPrice,
+			ExpectError: false,
+		},
+		{
+			Name:        "flat price rejects unit config",
+			Price:       NewPriceFrom(FlatPrice{Amount: decimal.NewFromInt(1)}),
+			ExpectError: true,
+		},
+		{
+			Name:        "package price rejects unit config",
+			Price:       NewPriceFrom(PackagePrice{Amount: decimal.NewFromInt(1), QuantityPerPackage: decimal.NewFromInt(1000)}),
+			ExpectError: true,
+		},
+		{
+			Name:        "dynamic price rejects unit config",
+			Price:       NewPriceFrom(DynamicPrice{Multiplier: decimal.NewFromFloat(1.2)}),
+			ExpectError: true,
+		},
+		{
+			Name:        "missing price rejects unit config",
+			Price:       nil,
+			ExpectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			meta := RateCardMeta{
+				Key:        "feat-1",
+				Name:       "RC",
+				FeatureKey: lo.ToPtr("feat-1"),
+				FeatureID:  lo.ToPtr("01JBP3SGZ20Y7VRVC351TDFXYZ"),
+				Price:      test.Price,
+				UnitConfig: unitConfig(),
+			}
+
+			err := meta.Validate()
+			if test.ExpectError {
+				assert.ErrorContains(t, err, "unit config requires a usage-based price")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestRateCardsEqual(t *testing.T) {
 	feat1 := &feature.Feature{
 		Namespace:           "namespace-1",
@@ -1216,10 +1300,17 @@ func TestRateCardsCompatible(t *testing.T) {
 }
 
 func TestRateCardMetaUnitConfig(t *testing.T) {
+	// A feature-backed unit price keeps the unrelated price-type and
+	// usage-based-price-requires-feature rules satisfied, so these subtests stay
+	// focused on UnitConfig's own behavior (clone/equal/nested validation). The
+	// price-type requirement itself is covered by TestRateCardMetaUnitConfigValidation.
 	withUnitConfig := func(uc *UnitConfig) RateCardMeta {
 		return RateCardMeta{
 			Key:        "feat-1",
 			Name:       "Usage 1",
+			FeatureKey: lo.ToPtr("feat-1"),
+			FeatureID:  lo.ToPtr("01JBP3SGZ20Y7VRVC351TDFXYZ"),
+			Price:      NewPriceFrom(UnitPrice{Amount: decimal.NewFromInt(1)}),
 			UnitConfig: uc,
 		}
 	}


### PR DESCRIPTION
## Overview

Wires unit_config through the v3 plan create/update path, all gated behind the dark unitConfig.enabled flag, plus a fix for the OM-395 adapter mappers that dropped  unit_config on expanded plan/add-on relations. 

### Note to reviewers

- the v1 read-side coexistence gap (a v3-authored unit_config silently dropped when listed on v1) is a known and is deferred to a later ticket


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit unit configuration support for v3 rate-card conversions, including new bidirectional unit-config conversion helpers.
* **Bug Fixes**
  * Preserved stored unit configuration when converting and mapping plan/addon rate-cards into product-catalog models.
  * Enforced that unit configuration is only valid with usage-based or tiered price types; invalid requests now return a dedicated “unit config requires usage-based price” validation error.
  * Improved conversion-factor handling by surfacing errors for non-numeric values and aligning precision/rounding behavior.
* **Tests**
  * Added/extended unit-config mapping, round-trip, and validation coverage across v3 conversions and adapter mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->