### PR TITLE
Validate customer billing for invoice-funded credit grants

### DIFF
--- a/app/common/creditgrant.go
+++ b/app/common/creditgrant.go
@@ -25,6 +25,7 @@ func NewCreditGrantService(
 	svc, err := creditgrantservice.New(creditgrantservice.Config{
 		CreditPurchaseService: billingRegistry.Charges.CreditPurchaseService,
 		ChargesService:        billingRegistry.Charges.Service,
+		BillingService:        billingRegistry.Billing,
 		CustomerService:       customerService,
 	})
 	if err != nil {

--- a/openmeter/billing/creditgrant/service/service.go
+++ b/openmeter/billing/creditgrant/service/service.go
@@ -10,11 +10,13 @@ import (
 	"github.com/alpacahq/alpacadecimal"
 	"github.com/samber/lo"
 
+	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/creditgrant"
+	customerbilling "github.com/openmeterio/openmeter/openmeter/billing/validators/customerbilling"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
@@ -29,6 +31,7 @@ import (
 type Config struct {
 	CreditPurchaseService creditpurchase.Service
 	ChargesService        charges.Service
+	BillingService        billing.Service
 	CustomerService       customer.Service
 }
 
@@ -41,6 +44,10 @@ func (c Config) Validate() error {
 
 	if c.ChargesService == nil {
 		errs = append(errs, errors.New("charges service is required"))
+	}
+
+	if c.BillingService == nil {
+		errs = append(errs, errors.New("billing service is required"))
 	}
 
 	if c.CustomerService == nil {
@@ -58,6 +65,7 @@ func New(config Config) (creditgrant.Service, error) {
 	return &service{
 		creditPurchaseService: config.CreditPurchaseService,
 		chargesService:        config.ChargesService,
+		billingService:        config.BillingService,
 		customerService:       config.CustomerService,
 	}, nil
 }
@@ -65,6 +73,7 @@ func New(config Config) (creditgrant.Service, error) {
 type service struct {
 	creditPurchaseService creditpurchase.Service
 	chargesService        charges.Service
+	billingService        billing.Service
 	customerService       customer.Service
 }
 
@@ -82,6 +91,24 @@ func (s *service) Create(ctx context.Context, input creditgrant.CreateInput) (cr
 	})
 	if err != nil {
 		return creditpurchase.Charge{}, fmt.Errorf("get customer: %w", err)
+	}
+
+	if input.FundingMethod == creditgrant.FundingMethodInvoice {
+		if err := customerbilling.ValidateCustomerInvoicingApp(
+			ctx,
+			s.billingService,
+			customer.CustomerID{
+				Namespace: input.Namespace,
+				ID:        input.CustomerID,
+			},
+			[]app.CapabilityType{
+				app.CapabilityTypeCalculateTax,
+				app.CapabilityTypeInvoiceCustomers,
+				app.CapabilityTypeCollectPayments,
+			},
+		); err != nil {
+			return creditpurchase.Charge{}, fmt.Errorf("invalid billing setup: %w", err)
+		}
 	}
 
 	// Build the credit purchase intent

--- a/openmeter/billing/validators/customerbilling/validator.go
+++ b/openmeter/billing/validators/customerbilling/validator.go
@@ -1,0 +1,43 @@
+package customerbilling
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/app"
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	customerapp "github.com/openmeterio/openmeter/openmeter/customer/app"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func ValidateCustomerInvoicingApp(ctx context.Context, billingService billing.Service, customerID customer.CustomerID, capabilities []app.CapabilityType) error {
+	if billingService == nil {
+		return fmt.Errorf("billing service is required")
+	}
+
+	customerProfile, err := billingService.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
+		Customer: customerID,
+		Expand: billing.CustomerOverrideExpand{
+			Apps:     true,
+			Customer: true,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	appBase := customerProfile.MergedProfile.Apps.Invoicing
+	if appBase == nil {
+		return models.NewGenericPreConditionFailedError(
+			fmt.Errorf("customer with id %s has no invoicing app configured in namespace %s", customerID.ID, customerID.Namespace),
+		)
+	}
+
+	customerApp, err := customerapp.AsCustomerApp(appBase)
+	if err != nil {
+		return err
+	}
+
+	return customerApp.ValidateCustomer(ctx, customerProfile.Customer, capabilities)
+}

--- a/openmeter/billing/validators/subscription/validator.go
+++ b/openmeter/billing/validators/subscription/validator.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	customerbilling "github.com/openmeterio/openmeter/openmeter/billing/validators/customerbilling"
 	"github.com/openmeterio/openmeter/openmeter/customer"
-	customerapp "github.com/openmeterio/openmeter/openmeter/customer/app"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/pkg/models"
 )
@@ -53,34 +53,20 @@ func (v Validator) validateBillingSetup(ctx context.Context, view subscription.S
 		return nil
 	}
 
-	// Check if the customer has a billing setup
-	customerProfile, err := v.billingService.GetCustomerOverride(ctx, billing.GetCustomerOverrideInput{
-		Customer: customer.CustomerID{
+	return customerbilling.ValidateCustomerInvoicingApp(
+		ctx,
+		v.billingService,
+		customer.CustomerID{
 			Namespace: view.Subscription.Namespace,
 			ID:        view.Subscription.CustomerId,
 		},
-		Expand: billing.CustomerOverrideExpand{
-			Apps:     true,
-			Customer: true,
+		[]app.CapabilityType{
+			// For now we only support Stripe with automatic tax calculation and payment collection.
+			app.CapabilityTypeCalculateTax,
+			app.CapabilityTypeInvoiceCustomers,
+			app.CapabilityTypeCollectPayments,
 		},
-	})
-	if err != nil {
-		return err
-	}
-
-	appBase := customerProfile.MergedProfile.Apps.Invoicing
-	customerApp, err := customerapp.AsCustomerApp(appBase)
-	if err != nil {
-		// This should not happen, as the app should have been already verified by the billing service, but let's make sure
-		return err
-	}
-
-	return customerApp.ValidateCustomer(ctx, customerProfile.Customer, []app.CapabilityType{
-		// For now now we only support Stripe with automatic tax calculation and payment collection.
-		app.CapabilityTypeCalculateTax,
-		app.CapabilityTypeInvoiceCustomers,
-		app.CapabilityTypeCollectPayments,
-	})
+	)
 }
 
 func (v Validator) hasBillableItems(view subscription.SubscriptionView) bool {

--- a/test/app/stripe/invoice_credits_test.go
+++ b/test/app/stripe/invoice_credits_test.go
@@ -19,14 +19,55 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/models/payment"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
+	creditgrant "github.com/openmeterio/openmeter/openmeter/billing/creditgrant"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
 	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/datetime"
+	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 	billingtest "github.com/openmeterio/openmeter/test/billing"
 )
+
+func (s *StripeInvoiceTestSuite) TestInvoiceFundedCreditGrantRequiresStripeCustomerData() {
+	t := s.T()
+	ctx := t.Context()
+	ns := s.GetUniqueNamespace("stripe-credit-grant-missing-customer-data")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	stripeApp, err := s.Fixture.setupApp(ctx, ns)
+	s.NoError(err)
+
+	cust := s.createStripeLedgerBackedCustomer(ctx, ns, "test-subject")
+
+	s.ProvisionBillingProfile(ctx, ns, stripeApp.GetID(),
+		billingtest.WithManualApproval(),
+	)
+
+	_, err = s.CreditGrant.Create(ctx, creditgrant.CreateInput{
+		Namespace:     ns,
+		CustomerID:    cust.ID,
+		Name:          "Invoice-funded credit grant",
+		Currency:      currencyx.Code("USD"),
+		Amount:        alpacadecimal.NewFromInt(10),
+		FundingMethod: creditgrant.FundingMethodInvoice,
+		Purchase: &creditgrant.PurchaseTerms{
+			Currency:         currencyx.Code("USD"),
+			PerUnitCostBasis: lo.ToPtr(alpacadecimal.NewFromInt(1)),
+		},
+	})
+	s.Error(err)
+	s.ErrorContains(err, "invalid billing setup")
+	s.ErrorContains(err, "customer has no data for stripe app")
+	s.True(models.IsGenericPreConditionFailedError(err))
+
+	invoices, err := s.BillingService.ListStandardInvoices(ctx, billing.ListStandardInvoicesInput{
+		Namespaces: []string{ns},
+	})
+	s.NoError(err)
+	s.Empty(invoices.Items)
+}
 
 func (s *StripeInvoiceTestSuite) TestUsageBasedCreditThenInvoiceProgressiveBillingCreditAllocation() {
 	t := s.T()

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	chargestestutils "github.com/openmeterio/openmeter/openmeter/billing/charges/testutils"
+	creditgrant "github.com/openmeterio/openmeter/openmeter/billing/creditgrant"
+	creditgrantservice "github.com/openmeterio/openmeter/openmeter/billing/creditgrant/service"
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	enttx "github.com/openmeterio/openmeter/openmeter/ent/tx"
 	ledgerbreakage "github.com/openmeterio/openmeter/openmeter/ledger/breakage"
@@ -57,6 +59,7 @@ type StripeInvoiceTestSuite struct {
 	SecretService    secret.Service
 	StripeAppClient  *StripeAppClientMock
 	Charges          charges.Service
+	CreditGrant      creditgrant.Service
 	LedgerResolver   *ledgerresolvers.AccountResolver
 }
 
@@ -150,6 +153,15 @@ func (s *StripeInvoiceTestSuite) SetupSuite() {
 	})
 	s.Require().NoError(err, "failed to initialize charges service")
 	s.Charges = chargeStack.ChargesService
+
+	creditGrantService, err := creditgrantservice.New(creditgrantservice.Config{
+		CreditPurchaseService: chargeStack.CreditPurchaseService,
+		ChargesService:        chargeStack.ChargesService,
+		BillingService:        s.BillingService,
+		CustomerService:       s.CustomerService,
+	})
+	s.Require().NoError(err, "failed to initialize credit grant service")
+	s.CreditGrant = creditGrantService
 
 	// Fixture
 	s.Fixture = NewFixture(s.AppService, s.CustomerService, stripeClient, stripeAppClient)

--- a/test/credits/creditgrant_test.go
+++ b/test/credits/creditgrant_test.go
@@ -87,6 +87,7 @@ func (s *CreditGrantTestSuite) SetupSuite() {
 	svc, err := creditgrantservice.New(creditgrantservice.Config{
 		CreditPurchaseService: s.CreditPurchaseService,
 		ChargesService:        s.Charges,
+		BillingService:        s.BillingService,
 		CustomerService:       s.CustomerService,
 	})
 	s.Require().NoError(err)


### PR DESCRIPTION
## What
- Add shared customer billing app validation for invoicing-capable customer apps.
- Reuse the shared validator from subscription billing validation.
- Validate invoice-funded credit grants before creating charge/invoice artifacts, so Stripe billing setups without customer Stripe app data fail immediately.

## Why
Invoice-funded credit grants could create pending invoice artifacts for customers whose billing profile uses the Stripe app but whose customer app data is missing. The later invoice issuing path then failed with a Stripe customer precondition error, leaving the grant invoice in a pending state.

## Validation
- `go test -tags=dynamic ./openmeter/billing/validators/... ./openmeter/billing/creditgrant/service ./app/common`
- `go vet -tags=dynamic ./openmeter/billing/validators/... ./openmeter/billing/creditgrant/service ./app/common ./test/app/stripe ./test/credits`
- `env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./test/app/stripe -run TestStripeInvoicing/TestInvoiceFundedCreditGrantRequiresStripeCustomerData`
- `env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./test/credits -run TestCreditGrantTestSuite/TestCreateInvoiceFundedCreatesInvoiceArtifacts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invoice-funded credit grants now perform stricter billing setup validation before creation, including required invoicing and payment capabilities.
* **Bug Fixes**
  * Prevents credit-grant creation when customer invoicing app or required billing data is missing, reducing unintended invoice generation.
  * Subscription billing validation now uses the shared invoicing-capability checks for consistency.
* **Tests**
  * Added coverage to ensure invoice-funded credit grants fail when required customer billing data (e.g., for invoicing/Stripe) is incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->