### PR TITLE
fix: handle missing namespace filter

### DIFF
--- a/openmeter/billing/adapter/gatheringinvoice.go
+++ b/openmeter/billing/adapter/gatheringinvoice.go
@@ -204,8 +204,11 @@ func (a *adapter) ListGatheringInvoices(ctx context.Context, input billing.ListG
 
 	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, tx *adapter) (pagination.Result[billing.GatheringInvoice], error) {
 		query := tx.db.BillingInvoice.Query().
-			Where(billinginvoice.NamespaceIn(input.Namespaces...)).
 			Where(billinginvoice.StatusEQ(billing.StandardInvoiceStatusGathering))
+
+		if len(input.Namespaces) > 0 {
+			query = query.Where(billinginvoice.NamespaceIn(input.Namespaces...))
+		}
 
 		if len(input.Customers) > 0 {
 			query = query.Where(billinginvoice.CustomerIDIn(input.Customers...))

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -698,6 +698,39 @@ func (s *InvoicingTestSuite) TestListGatheringInvoices_CollectionAtFilterExclude
 	require.Empty(s.T(), invoices.Items)
 }
 
+func (s *InvoicingTestSuite) TestListGatheringInvoicesWithoutNamespaceFilter() {
+	namespace := s.GetUniqueNamespace("ns-gathering-list-without-namespace-filter")
+	ctx := s.T().Context()
+
+	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
+
+	customerEntity, err := s.CustomerService.CreateCustomer(ctx, customer.CreateCustomerInput{
+		Namespace: namespace,
+		CustomerMutate: customer.CustomerMutate{
+			Name:         "Test Customer",
+			Key:          lo.ToPtr("test-customer-key"),
+			PrimaryEmail: lo.ToPtr("test@test.com"),
+			Currency:     lo.ToPtr(currencyx.Code(currency.USD)),
+		},
+	})
+	require.NoError(s.T(), err)
+
+	s.CreateGatheringInvoice(s.T(), ctx, DraftInvoiceInput{
+		Namespace: namespace,
+		Customer:  customerEntity,
+	})
+
+	invoices, err := s.BillingService.ListGatheringInvoices(ctx, billing.ListGatheringInvoicesInput{
+		Customers: []string{customerEntity.ID},
+		Expand:    billing.GatheringInvoiceExpandAll,
+	})
+	require.NoError(s.T(), err)
+	require.Len(s.T(), invoices.Items, 1)
+	require.Equal(s.T(), namespace, invoices.Items[0].Namespace)
+	require.Equal(s.T(), customerEntity.ID, invoices.Items[0].CustomerID)
+}
+
 func (s *InvoicingTestSuite) TestInvoicingFlow() {
 	cases := []struct {
 		name           string


### PR DESCRIPTION
## Summary

Fix gathering invoice listing so an omitted namespace filter means "do not filter by namespace" instead of producing an empty `NamespaceIn()` predicate.

## Details

`ListGatheringInvoices` already treats customer, currency, and ID filters as optional. This change makes namespace filtering follow the same contract by applying `NamespaceIn(...)` only when namespaces are provided.

The regression test creates a gathering invoice and lists it by customer without passing `Namespaces`, proving callers can use non-namespace filters without accidentally excluding all rows.

## Validation

- `make lint`
- `make test-nocache`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Listing gathering invoices now works correctly when no namespace filter is provided, returning matching invoices instead of excluding them.
  * Added coverage to confirm invoices can still be found by customer alone and return the expected namespace and customer details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->