### PR TITLE
fix: flat fee invoice-at lifecycle

### DIFF
--- a/openmeter/billing/charges/flatfee/service/create.go
+++ b/openmeter/billing/charges/flatfee/service/create.go
@@ -49,7 +49,7 @@ func (s *service) Create(ctx context.Context, input flatfee.CreateInput) ([]flat
 				Intent:                    chargeIntent,
 				FeatureID:                 featureID,
 				InitialStatus:             flatfee.StatusCreated,
-				InitialAdvanceAfter:       lo.ToPtr(meta.NormalizeTimestamp(chargeIntent.ServicePeriod.From)),
+				InitialAdvanceAfter:       lo.ToPtr(meta.NormalizeTimestamp(chargeIntent.InvoiceAt)),
 				AmountAfterProration:      amountAfterProration,
 				NoFiatTransactionRequired: chargeIntent.SettlementMode == productcatalog.CreditOnlySettlementMode || amountAfterProration.IsZero(),
 			}, nil

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -65,27 +65,29 @@ func NewCreditThenInvoiceStateMachine(config StateMachineConfig) (*CreditThenInv
 func (s *CreditThenInvoiceStateMachine) configureStates() {
 	s.Configure(flatfee.StatusCreated).
 		// Zero-amount CTI flat fees intentionally skip the billing line
-		// engine. Once the service period starts there will be no gathering
+		// engine. Once invoice_at is reached there will be no gathering
 		// line to produce TriggerFinalInvoiceCreated, so the charge closes
 		// directly from created.
 		Permit(
 			meta.TriggerNext,
 			flatfee.StatusFinal,
-			statelessx.BoolFn(s.IsInsideServicePeriodAndZeroAmount),
+			statelessx.BoolFn(s.IsAfterInvoiceAtAndZeroAmount),
 		).
-		// Non-zero CTI flat fees still wait in active for the flat-fee line
-		// engine to create a realization run from the standard invoice line.
+		// Non-zero CTI flat fees become invoiceable at invoice_at. The line
+		// engine creates the realization run from the standard invoice line,
+		// which can happen before the service period starts for in-advance
+		// flat fees.
 		Permit(
 			meta.TriggerNext,
 			flatfee.StatusActive,
-			statelessx.BoolFn(s.IsInsideServicePeriodAndNonZeroAmount),
+			statelessx.BoolFn(s.IsAfterInvoiceAtAndNonZeroAmount),
 		).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerLineManualEdit, statelessx.WithParameters(s.LineManualEdit)).
 		Permit(meta.TriggerAttachInvoiceLine, flatfee.StatusActiveRealizationProcessing).
-		OnActive(s.AdvanceAfterServicePeriodFrom)
+		OnActive(s.AdvanceAfterInvoiceAt)
 
 	s.Configure(flatfee.StatusActive).
 		// This also repairs previously active zero-amount charges. They have

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -605,11 +605,10 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 		// pending line identity.
 		s.AddInvoicePatch(invoiceupdater.NewUpsertGatheringLineByChargeIDPatch(s.Charge.ID, updatedGatheringLine))
 		// A zero charge can become billable again after extend/shrink. Move it
-		// back to created so normal service-period advancement and invoicing
-		// can recreate the CTI lifecycle.
+		// back to created so normal invoice_at advancement and invoicing can
+		// recreate the CTI lifecycle.
 		s.Charge.Status = flatfee.StatusCreated
-		s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(input.Period.From))
-		return nil
+		return s.AdvanceAfterInvoiceAt(ctx)
 	}
 
 	// Run exists, so we started the billing cycle, thus we don't have a gathering line, but we do have a standard line
@@ -713,8 +712,5 @@ func (s *CreditThenInvoiceStateMachine) reconcileInvoicingState(ctx context.Cont
 	s.Charge.Realizations.CurrentRun = nil
 
 	s.Charge.Status = flatfee.StatusCreated
-	advanceAfter := meta.NormalizeTimestamp(input.Period.From)
-	s.Charge.State.AdvanceAfter = &advanceAfter
-
-	return nil
+	return s.AdvanceAfterInvoiceAt(ctx)
 }

--- a/openmeter/billing/charges/flatfee/service/creditsonly.go
+++ b/openmeter/billing/charges/flatfee/service/creditsonly.go
@@ -45,21 +45,21 @@ func NewCreditsOnlyStateMachine(config StateMachineConfig) (*CreditsOnlyStateMac
 
 func (s *CreditsOnlyStateMachine) configureStates() {
 	s.Configure(flatfee.StatusCreated).
-		Permit(meta.TriggerNext, flatfee.StatusActive, statelessx.BoolFn(s.IsInsideServicePeriod)).
-		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
-		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
-		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
-		OnActive(
-			s.AdvanceAfterServicePeriodFrom,
-		)
-
-	s.Configure(flatfee.StatusActive).
-		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.IsAfterInvoiceAt)).
+		Permit(meta.TriggerNext, flatfee.StatusActive, statelessx.BoolFn(s.IsAfterInvoiceAt)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		OnActive(
 			s.AdvanceAfterInvoiceAt,
+		)
+
+	s.Configure(flatfee.StatusActive).
+		Permit(meta.TriggerNext, flatfee.StatusFinal, statelessx.BoolFn(s.IsAfterBookedAt)).
+		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
+		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
+		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
+		OnActive(
+			s.AdvanceAfterBookedAt,
 		)
 
 	s.Configure(flatfee.StatusFinal).
@@ -74,12 +74,18 @@ func (s *CreditsOnlyStateMachine) configureStates() {
 		)
 }
 
-func (s *CreditsOnlyStateMachine) IsAfterInvoiceAt() bool {
-	return !clock.Now().Before(s.Charge.Intent.GetEffectiveInvoiceAt())
+func (s *CreditsOnlyStateMachine) IsAfterBookedAt() bool {
+	return !clock.Now().Before(flatfee.UsageBookedAt(
+		s.Charge.Intent.GetEffectivePaymentTerm(),
+		s.Charge.Intent.GetEffectiveServicePeriod(),
+	))
 }
 
-func (s *CreditsOnlyStateMachine) AdvanceAfterInvoiceAt(ctx context.Context) error {
-	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveInvoiceAt()))
+func (s *CreditsOnlyStateMachine) AdvanceAfterBookedAt(ctx context.Context) error {
+	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(flatfee.UsageBookedAt(
+		s.Charge.Intent.GetEffectivePaymentTerm(),
+		s.Charge.Intent.GetEffectiveServicePeriod(),
+	)))
 	return nil
 }
 

--- a/openmeter/billing/charges/flatfee/service/statemachine.go
+++ b/openmeter/billing/charges/flatfee/service/statemachine.go
@@ -143,12 +143,29 @@ func (s *stateMachine) IsInsideServicePeriodAndNonZeroAmount() bool {
 	return s.IsInsideServicePeriod() && !s.Charge.State.AmountAfterProration.IsZero()
 }
 
+func (s *stateMachine) IsAfterInvoiceAt() bool {
+	return !clock.Now().Before(s.Charge.Intent.GetEffectiveInvoiceAt())
+}
+
+func (s *stateMachine) IsAfterInvoiceAtAndZeroAmount() bool {
+	return s.IsAfterInvoiceAt() && s.Charge.State.AmountAfterProration.IsZero()
+}
+
+func (s *stateMachine) IsAfterInvoiceAtAndNonZeroAmount() bool {
+	return s.IsAfterInvoiceAt() && !s.Charge.State.AmountAfterProration.IsZero()
+}
+
 func (s *stateMachine) IsZeroAmount() bool {
 	return s.Charge.State.AmountAfterProration.IsZero()
 }
 
 func (s *stateMachine) AdvanceAfterServicePeriodFrom(ctx context.Context) error {
 	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveServicePeriod().From))
+	return nil
+}
+
+func (s *stateMachine) AdvanceAfterInvoiceAt(ctx context.Context) error {
+	s.Charge.State.AdvanceAfter = lo.ToPtr(meta.NormalizeTimestamp(s.Charge.Intent.GetEffectiveInvoiceAt()))
 	return nil
 }
 

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -859,6 +859,150 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceInAdvanceWithPr
 	})
 }
 
+func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceInvoiceAtBeforeServicePeriodStart() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-before-service-period")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateTestCustomer(ns, "test-subject")
+	s.NotEmpty(cust.ID)
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "PT1H")),
+		billingtest.WithManualApproval(),
+	)
+
+	createAt := datetime.MustParseTimeInLocation(s.T(), "2026-05-28T18:00:00Z", time.UTC).AsTime()
+	invoiceAt := datetime.MustParseTimeInLocation(s.T(), "2026-06-28T17:38:30Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-06-30T17:38:30Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-07-01T17:38:30Z", time.UTC).AsTime(),
+	}
+	billingPeriod := timeutil.ClosedPeriod{
+		From: invoiceAt,
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-07-28T17:38:30Z", time.UTC).AsTime(),
+	}
+
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	flatFeeChargeID := meta.ChargeID{}
+
+	s.Run("given a flat fee invoiceable before service period start", func() {
+		// given:
+		// - a non-zero CTI flat fee has invoice_at before service period start
+		// - invoice_at belongs to the billing period, while service period carries the charged usage window
+		// when:
+		// - the charge is created before invoice_at
+		// then:
+		// - the charge waits for invoice_at, not service period start
+		created, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				charges.NewChargeIntent(flatfee.Intent{
+					Intent: meta.Intent{
+						ManagedBy:         billing.SubscriptionManagedLine,
+						UniqueReferenceID: lo.ToPtr("flat-fee-invoice-at-before-service-period"),
+						CustomerID:        cust.ID,
+						Currency:          USD,
+					},
+					IntentMutableFields: flatfee.IntentMutableFields{
+						IntentMutableFields: meta.IntentMutableFields{
+							Name:              "flat-fee-invoice-at-before-service-period",
+							ServicePeriod:     servicePeriod,
+							FullServicePeriod: servicePeriod,
+							BillingPeriod:     billingPeriod,
+						},
+						InvoiceAt:             invoiceAt,
+						PaymentTerm:           productcatalog.InAdvancePaymentTerm,
+						AmountBeforeProration: alpacadecimal.NewFromInt(100),
+						ProRating: productcatalog.ProRatingConfig{
+							Enabled: true,
+							Mode:    productcatalog.ProRatingModeProratePrices,
+						},
+					},
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(created, 1)
+
+		flatFeeCharge, err := created[0].AsFlatFeeCharge()
+		s.NoError(err)
+		flatFeeChargeID = flatFeeCharge.GetChargeID()
+
+		fetchedCharge := s.mustGetChargeByID(flatFeeChargeID)
+		fetchedFF, err := fetchedCharge.AsFlatFeeCharge()
+		s.NoError(err)
+		s.Equal(flatfee.StatusCreated, fetchedFF.Status)
+		s.Require().NotNil(fetchedFF.State.AdvanceAfter)
+		s.True(invoiceAt.Equal(*fetchedFF.State.AdvanceAfter))
+		s.Nil(fetchedFF.Realizations.CurrentRun)
+	})
+
+	s.Run("when pending lines are invoiced at invoice_at", func() {
+		defer s.FlatFeeTestHandler.Reset()
+
+		creditAllocationCallback := newCountedCreditAllocationCallback[flatfee.OnAllocateCreditsInput]()
+		s.FlatFeeTestHandler.onAllocateCredits = creditAllocationCallback.Handler(
+			s.T(),
+			func(flatfee.OnAllocateCreditsInput, ledgertransaction.GroupReference) creditrealization.CreateAllocationInputs {
+				return nil
+			},
+			func(t *testing.T, input flatfee.OnAllocateCreditsInput) {
+				assert.Equal(t, flatFeeChargeID.ID, input.Charge.ID)
+				assert.Equal(t, servicePeriod, input.ServicePeriod)
+				assert.Equal(t, float64(100), input.PreTaxAmountToAllocate.InexactFloat64())
+			},
+		)
+
+		// given:
+		// - wall clock has reached invoice_at but is still before service period start
+		// when:
+		// - pending flat-fee lines are invoiced
+		// then:
+		// - the CTI lifecycle accepts final_invoice_created and creates the run
+		clock.FreezeTime(invoiceAt)
+
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(invoiceAt),
+		})
+		s.NoError(err)
+		s.Len(invoices, 1)
+		s.Equal(1, creditAllocationCallback.nrInvocations)
+
+		invoice := invoices[0]
+		s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, invoice.Status)
+		s.Require().Len(invoice.Lines.OrEmpty(), 1)
+
+		stdLine := invoice.Lines.OrEmpty()[0]
+		s.Equal(flatFeeChargeID.ID, lo.FromPtr(stdLine.ChargeID))
+		s.Equal(servicePeriod, stdLine.Period)
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount: 100,
+			Total:  100,
+		}, stdLine.Totals)
+
+		flatFeeWithDetailedLines := s.mustGetFlatFeeChargeByIDWithDetailedLines(flatFeeChargeID)
+		s.Equal(flatfee.StatusActiveRealizationProcessing, flatFeeWithDetailedLines.Status)
+		s.Require().NotNil(flatFeeWithDetailedLines.Realizations.CurrentRun)
+
+		currentRun := flatFeeWithDetailedLines.Realizations.CurrentRun
+		s.Equal(servicePeriod, currentRun.ServicePeriod)
+		s.Require().NotNil(currentRun.LineID)
+		s.Equal(stdLine.ID, *currentRun.LineID)
+		s.Require().NotNil(currentRun.InvoiceID)
+		s.Equal(invoice.ID, *currentRun.InvoiceID)
+		s.RequireTotals(billingtest.ExpectedTotals{
+			Amount: 100,
+			Total:  100,
+		}, currentRun.Totals)
+	})
+}
+
 func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceFullyCreditedDoesNotAccrueInvoiceUsage() {
 	ctx := s.T().Context()
 	ns := s.GetUniqueNamespace("charges-service-flatfee-credit-then-invoice-fully-credited")
@@ -2773,7 +2917,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyCreateImmediatelyFinal
 	s.Equal(float64(50), dbFF.Realizations.CurrentRun.CreditRealizations[0].Amount.InexactFloat64())
 }
 
-func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyInArrearsActivatesAtServiceStartAndAllocatesAtInvoiceAt() {
+func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyInArrearsAllocatesAtInvoiceAt() {
 	defer s.FlatFeeTestHandler.Reset()
 
 	ctx := s.T().Context()
@@ -2836,19 +2980,13 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditOnlyInArrearsActivatesAtSe
 	s.NoError(err)
 	s.Equal(flatfee.StatusCreated, createdCharge.Status)
 	s.NotNil(createdCharge.State.AdvanceAfter)
-	s.True(servicePeriod.From.Equal(*createdCharge.State.AdvanceAfter))
+	s.True(servicePeriod.To.Equal(*createdCharge.State.AdvanceAfter))
 	s.Nil(createdCharge.Realizations.CurrentRun)
 	s.Zero(allocateCreditsCallback.nrInvocations)
 
 	clock.FreezeTime(servicePeriod.From)
 	advancedCharges := s.mustAdvanceFlatFeeCharges(ctx, cust.GetID())
-	s.Len(advancedCharges, 1)
-	activeCharge, err := advancedCharges[0].AsFlatFeeCharge()
-	s.NoError(err)
-	s.Equal(flatfee.StatusActive, activeCharge.Status)
-	s.NotNil(activeCharge.State.AdvanceAfter)
-	s.True(servicePeriod.To.Equal(*activeCharge.State.AdvanceAfter))
-	s.Nil(activeCharge.Realizations.CurrentRun)
+	s.Empty(advancedCharges)
 	s.Zero(allocateCreditsCallback.nrInvocations)
 
 	clock.FreezeTime(servicePeriod.To)

--- a/openmeter/billing/charges/service/invoicable_test.go
+++ b/openmeter/billing/charges/service/invoicable_test.go
@@ -944,6 +944,7 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceInvoiceAtBefore
 
 	s.Run("when pending lines are invoiced at invoice_at", func() {
 		defer s.FlatFeeTestHandler.Reset()
+		defer clock.UnFreeze()
 
 		creditAllocationCallback := newCountedCreditAllocationCallback[flatfee.OnAllocateCreditsInput]()
 		s.FlatFeeTestHandler.onAllocateCredits = creditAllocationCallback.Handler(
@@ -959,14 +960,29 @@ func (s *InvoicableChargesTestSuite) TestFlatFeeCreditThenInvoiceInvoiceAtBefore
 		)
 
 		// given:
+		// - wall clock is still before invoice_at
+		// when:
+		// - pending flat-fee lines are invoiced
+		// then:
+		// - no invoice is created yet
+		beforeInvoiceAt := invoiceAt.Add(-time.Nanosecond)
+		clock.FreezeTime(beforeInvoiceAt)
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(beforeInvoiceAt),
+		})
+		s.ErrorIs(err, billing.ErrInvoiceCreateNoLines)
+		s.Empty(invoices)
+		s.Equal(0, creditAllocationCallback.nrInvocations)
+
+		// given:
 		// - wall clock has reached invoice_at but is still before service period start
 		// when:
 		// - pending flat-fee lines are invoiced
 		// then:
 		// - the CTI lifecycle accepts final_invoice_created and creates the run
 		clock.FreezeTime(invoiceAt)
-
-		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		invoices, err = s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 			Customer: cust.GetID(),
 			AsOf:     lo.ToPtr(invoiceAt),
 		})

--- a/openmeter/ledger/customerbalance/service.go
+++ b/openmeter/ledger/customerbalance/service.go
@@ -754,7 +754,7 @@ func chargeHasStarted(charge charges.Charge) bool {
 			return false
 		}
 
-		return !now.Before(flatFeeCharge.Intent.GetEffectiveServicePeriod().From)
+		return !now.Before(flatFeeCharge.Intent.GetEffectiveInvoiceAt())
 	case meta.ChargeTypeUsageBased:
 		usageBasedCharge, err := charge.AsUsageBasedCharge()
 		if err != nil {

--- a/openmeter/ledger/customerbalance/service_test.go
+++ b/openmeter/ledger/customerbalance/service_test.go
@@ -336,6 +336,9 @@ func TestGetBalanceForFlatFeeCreditOnlyInvoiceAtBeforeServiceStart(t *testing.T)
 					ManagedBy:  billing.SystemManagedLine,
 					CustomerID: env.CustomerID.ID,
 					Currency:   env.Currency,
+					TaxConfig: productcatalog.TaxCodeConfig{
+						TaxCodeID: env.taxCodeID,
+					},
 				},
 				IntentMutableFields: flatfee.IntentMutableFields{
 					IntentMutableFields: chargemeta.IntentMutableFields{
@@ -343,9 +346,6 @@ func TestGetBalanceForFlatFeeCreditOnlyInvoiceAtBeforeServiceStart(t *testing.T)
 						ServicePeriod:     servicePeriod,
 						FullServicePeriod: servicePeriod,
 						BillingPeriod:     servicePeriod,
-						TaxConfig: productcatalog.TaxCodeConfig{
-							TaxCodeID: env.taxCodeID,
-						},
 					},
 					InvoiceAt:             invoiceAt,
 					PaymentTerm:           productcatalog.InAdvancePaymentTerm,

--- a/openmeter/ledger/customerbalance/service_test.go
+++ b/openmeter/ledger/customerbalance/service_test.go
@@ -368,6 +368,12 @@ func TestGetBalanceForFlatFeeCreditOnlyInvoiceAtBeforeServiceStart(t *testing.T)
 	requireBalance(t, 100, 100)
 
 	clock.FreezeTime(invoiceAt)
+
+	// then:
+	// - once invoice_at is current, the created charge impacts live balance
+	// - the future booked_at ledger allocation is not visible in settled balance yet
+	requireBalance(t, 100, 70)
+
 	advancedCharge, err := env.flatFeeService.AdvanceCharge(t.Context(), flatfee.AdvanceChargeInput{
 		ChargeID: charge.GetChargeID(),
 	})
@@ -379,8 +385,7 @@ func TestGetBalanceForFlatFeeCreditOnlyInvoiceAtBeforeServiceStart(t *testing.T)
 	require.Nil(t, advancedCharge.Realizations.CurrentRun)
 
 	// then:
-	// - after invoice_at the open charge impacts live balance
-	// - the future booked_at ledger allocation is not visible in settled balance yet
+	// - after advancement, the active charge still impacts live balance
 	requireBalance(t, 100, 70)
 
 	clock.FreezeTime(servicePeriod.From)

--- a/openmeter/ledger/customerbalance/service_test.go
+++ b/openmeter/ledger/customerbalance/service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/samber/mo"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/billing"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/creditpurchase"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
@@ -228,7 +229,7 @@ func TestGetBalance(t *testing.T) {
 			wantLive:    -130,
 		},
 		{
-			name: "future charges are excluded until service period starts",
+			name: "future usage-based charges are excluded until service period starts",
 			setup: func(t *testing.T, env *testEnv) {
 				futureServicePeriod := timeutil.ClosedPeriod{
 					From: clock.Now().Add(time.Hour),
@@ -238,11 +239,25 @@ func TestGetBalance(t *testing.T) {
 				env.addUsage(30, clock.Now().Add(-30*time.Minute))
 				env.bookFBOBalance(t, alpacadecimal.NewFromInt(100))
 				env.fundOpenReceivable(t, alpacadecimal.NewFromInt(100))
-				env.createFlatFeeCharge(t, alpacadecimal.NewFromInt(30), productcatalog.CreditOnlySettlementMode, futureServicePeriod)
 				env.createUsageBasedCharge(t, alpacadecimal.NewFromInt(1), productcatalog.CreditOnlySettlementMode, futureServicePeriod)
 			},
 			wantSettled: 100,
 			wantLive:    100,
+		},
+		{
+			name: "future in-advance flat fee impacts live balance at invoice_at",
+			setup: func(t *testing.T, env *testEnv) {
+				futureServicePeriod := timeutil.ClosedPeriod{
+					From: clock.Now().Add(time.Hour),
+					To:   clock.Now().Add(2 * time.Hour),
+				}
+
+				env.bookFBOBalance(t, alpacadecimal.NewFromInt(100))
+				env.fundOpenReceivable(t, alpacadecimal.NewFromInt(100))
+				env.createFlatFeeCharge(t, alpacadecimal.NewFromInt(30), productcatalog.CreditThenInvoiceSettlementMode, futureServicePeriod)
+			},
+			wantSettled: 100,
+			wantLive:    70,
 		},
 		{
 			name: "usage is settled",
@@ -278,6 +293,114 @@ func TestGetBalance(t *testing.T) {
 			require.Equal(t, float64(tt.wantLive), balance.Live().InexactFloat64(), "live: %s", balance.Live())
 		})
 	}
+}
+
+func TestGetBalanceForFlatFeeCreditOnlyInvoiceAtBeforeServiceStart(t *testing.T) {
+	createAt := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	invoiceAt := createAt.Add(time.Hour)
+	servicePeriod := timeutil.ClosedPeriod{
+		From: createAt.Add(2 * time.Hour),
+		To:   createAt.Add(3 * time.Hour),
+	}
+
+	clock.FreezeTime(createAt)
+	defer clock.UnFreeze()
+
+	env := newTestEnv(t)
+	env.bookFBOBalance(t, alpacadecimal.NewFromInt(100))
+	env.fundOpenReceivable(t, alpacadecimal.NewFromInt(100))
+
+	requireBalance := func(t *testing.T, settled float64, live float64) {
+		t.Helper()
+
+		balance, err := env.Service.GetBalance(t.Context(), GetBalanceServiceInput{
+			CustomerID:    env.CustomerID,
+			Currency:      env.Currency,
+			FeatureFilter: AllFeatureFilter(),
+		})
+		require.NoError(t, err)
+		require.Equal(t, settled, balance.Settled().InexactFloat64(), "settled: %s", balance.Settled())
+		require.Equal(t, live, balance.Live().InexactFloat64(), "live: %s", balance.Live())
+	}
+
+	// given:
+	// - the customer has enough credit before the charge exists
+	requireBalance(t, 100, 100)
+
+	createdCharges, err := env.flatFeeService.Create(t.Context(), flatfee.CreateInput{
+		Namespace:     env.Namespace,
+		FeatureMeters: env.featureMeters,
+		Intents: []flatfee.Intent{
+			{
+				Intent: chargemeta.Intent{
+					ManagedBy:  billing.SystemManagedLine,
+					CustomerID: env.CustomerID.ID,
+					Currency:   env.Currency,
+				},
+				IntentMutableFields: flatfee.IntentMutableFields{
+					IntentMutableFields: chargemeta.IntentMutableFields{
+						Name:              "Platform Fee",
+						ServicePeriod:     servicePeriod,
+						FullServicePeriod: servicePeriod,
+						BillingPeriod:     servicePeriod,
+						TaxConfig: productcatalog.TaxCodeConfig{
+							TaxCodeID: env.taxCodeID,
+						},
+					},
+					InvoiceAt:             invoiceAt,
+					PaymentTerm:           productcatalog.InAdvancePaymentTerm,
+					AmountBeforeProration: alpacadecimal.NewFromInt(30),
+				},
+				SettlementMode: productcatalog.CreditOnlySettlementMode,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, createdCharges, 1)
+
+	charge := createdCharges[0].Charge
+	require.Equal(t, flatfee.StatusCreated, charge.Status)
+	require.NotNil(t, charge.State.AdvanceAfter)
+	require.True(t, invoiceAt.Equal(*charge.State.AdvanceAfter))
+
+	// then:
+	// - before invoice_at the charge exists but does not impact live balance
+	requireBalance(t, 100, 100)
+
+	clock.FreezeTime(invoiceAt)
+	advancedCharge, err := env.flatFeeService.AdvanceCharge(t.Context(), flatfee.AdvanceChargeInput{
+		ChargeID: charge.GetChargeID(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, advancedCharge)
+	require.Equal(t, flatfee.StatusActive, advancedCharge.Status)
+	require.NotNil(t, advancedCharge.State.AdvanceAfter)
+	require.True(t, servicePeriod.From.Equal(*advancedCharge.State.AdvanceAfter))
+	require.Nil(t, advancedCharge.Realizations.CurrentRun)
+
+	// then:
+	// - after invoice_at the open charge impacts live balance
+	// - the future booked_at ledger allocation is not visible in settled balance yet
+	requireBalance(t, 100, 70)
+
+	clock.FreezeTime(servicePeriod.From)
+	advancedCharge, err = env.flatFeeService.AdvanceCharge(t.Context(), flatfee.AdvanceChargeInput{
+		ChargeID: charge.GetChargeID(),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, advancedCharge)
+	require.Equal(t, flatfee.StatusFinal, advancedCharge.Status)
+	require.Nil(t, advancedCharge.State.AdvanceAfter)
+	require.NotNil(t, advancedCharge.Realizations.CurrentRun)
+	require.Len(t, advancedCharge.Realizations.CurrentRun.CreditRealizations, 1)
+	require.Equal(t, float64(30), advancedCharge.Realizations.CurrentRun.CreditRealizations[0].Amount.InexactFloat64())
+
+	// then:
+	// - once booked_at is current, the ledger allocation carries the balance
+	requireBalance(t, 70, 70)
+
+	clock.FreezeTime(servicePeriod.To)
+	requireBalance(t, 70, 70)
 }
 
 func TestImpactRealizedCreditsSkipsVoidedUsageBasedBillingHistory(t *testing.T) {

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -2113,7 +2113,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkToZeroThe
 		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusCreated)
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(1), charge.State.AmountAfterProration, "extended amount should become non-zero")
 		s.Require().NotNil(charge.State.AdvanceAfter)
-		s.True(servicePeriod.From.Equal(*charge.State.AdvanceAfter))
+		s.True(servicePeriod.To.Equal(*charge.State.AdvanceAfter))
 		s.Nil(charge.Realizations.CurrentRun)
 
 		activeLine := s.mustSingleActiveGatheringLineForCharge(ns, cust.ID, flatFeeChargeID.ID)
@@ -2127,12 +2127,12 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkToZeroThe
 
 	s.Run("when charges advance after the non-zero extension", func() {
 		// given:
-		// - the non-zero charge is created again and its service period has started
+		// - the non-zero charge is created again and invoice_at has passed
 		// when:
 		// - charge advancement runs
 		// then:
 		// - the charge becomes active and waits for normal invoice-line lifecycle callbacks
-		clock.FreezeTime(servicePeriod.From)
+		clock.FreezeTime(servicePeriod.To)
 		advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
 			Customer: cust.GetID(),
 		})
@@ -2494,7 +2494,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceAsyncPaymentBoo
 	})
 }
 
-func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceInArrearsActivatesAtServiceStartAndInvoicesAtInvoiceAt() {
+func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceInArrearsActivatesAndInvoicesAtInvoiceAt() {
 	t := s.T()
 	ctx := t.Context()
 	ns := s.GetUniqueNamespace("charges-credits-flatfee-credit-then-invoice-in-arrears")
@@ -2588,14 +2588,14 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceInArrearsActiva
 		// when:
 		// - charges are advanced
 		// then:
-		// - the flat fee becomes active
+		// - the flat fee remains created because invoice_at is at service period end
 		clock.FreezeTime(servicePeriod.From)
 		advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
 			Customer: cust.GetID(),
 		})
 		s.NoError(err)
-		s.Len(advancedCharges, 1)
-		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusActive)
+		s.Empty(advancedCharges)
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusCreated)
 		s.AssertLedgerSnapshotUnchanged(ledgerSnapshotInput, startLedger)
 	})
 
@@ -2619,10 +2619,17 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceInArrearsActiva
 		// given:
 		// - the clock is at service period end
 		// when:
-		// - billing invoices pending lines
+		// - charges advance and billing invoices pending lines
 		// then:
 		// - the in-arrears flat fee is collected into a standard invoice
 		clock.FreezeTime(servicePeriod.To)
+		advancedCharges, err := s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
+			Customer: cust.GetID(),
+		})
+		s.NoError(err)
+		s.Len(advancedCharges, 1)
+		s.RequireChargeStatus(flatFeeChargeID, flatfee.StatusActive)
+
 		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
 			Customer: cust.GetID(),
 			AsOf:     lo.ToPtr(servicePeriod.To),
@@ -2676,7 +2683,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteActiveCha
 		// given:
 		// - an in-arrears flat fee has a pending gathering line
 		// when:
-		// - the service period starts and charges advance
+		// - invoice_at arrives and charges advance
 		// then:
 		// - the charge becomes active but no standard invoice exists yet
 		res, err := s.Charges.Create(ctx, charges.CreateInput{
@@ -2704,7 +2711,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceDeleteActiveCha
 		s.NoError(err)
 		flatFeeChargeID = flatFeeCharge.GetChargeID()
 
-		clock.FreezeTime(servicePeriod.From)
+		clock.FreezeTime(servicePeriod.To)
 		_, err = s.Charges.AdvanceCharges(ctx, charges.AdvanceChargesInput{
 			Customer: cust.GetID(),
 		})

--- a/test/credits/credit_then_invoice_test.go
+++ b/test/credits/credit_then_invoice_test.go
@@ -2762,7 +2762,7 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkExtendPat
 	}
 	shrunkServicePeriodTo := datetime.MustParseTimeInLocation(t, "2026-02-01T00:00:00Z", time.UTC).AsTime()
 	extendedServicePeriodTo := datetime.MustParseTimeInLocation(t, "2026-04-01T00:00:00Z", time.UTC).AsTime()
-	extendedInvoiceAt := datetime.MustParseTimeInLocation(t, "2026-04-02T00:00:00Z", time.UTC).AsTime()
+	extendedInvoiceAt := datetime.MustParseTimeInLocation(t, "2025-12-15T00:00:00Z", time.UTC).AsTime()
 
 	clock.FreezeTime(setupAt)
 	defer clock.UnFreeze()
@@ -2850,6 +2850,8 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkExtendPat
 
 		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusCreated)
 		s.Equal(shrunkServicePeriodTo, charge.Intent.GetEffectiveServicePeriod().To)
+		s.Require().NotNil(charge.State.AdvanceAfter)
+		s.True(shrunkServicePeriodTo.Equal(*charge.State.AdvanceAfter))
 		shrunkAmount, err := alpacadecimal.NewFromString("63.05")
 		s.NoError(err)
 		s.AssertDecimalEqual(shrunkAmount, charge.State.AmountAfterProration, "charge state amount should be prorated for the shrunk period")
@@ -2876,6 +2878,8 @@ func (s *CreditThenInvoiceTestSuite) TestFlatFeeCreditThenInvoiceShrinkExtendPat
 
 		charge := s.RequireFlatFeeChargeStatus(flatFeeChargeID, flatfee.StatusCreated)
 		s.Equal(extendedServicePeriodTo, charge.Intent.GetEffectiveServicePeriod().To)
+		s.Require().NotNil(charge.State.AdvanceAfter)
+		s.True(extendedInvoiceAt.Equal(*charge.State.AdvanceAfter))
 		s.AssertDecimalEqual(alpacadecimal.NewFromInt(120), charge.State.AmountAfterProration, "extension past full period should not exceed the full flat fee amount")
 
 		activeLine := s.mustSingleActiveGatheringLineForCharge(ns, cust.ID, flatFeeChargeID.ID)


### PR DESCRIPTION
## Summary

Fixes flat-fee lifecycle scheduling when `invoice_at` and the service period do not start at the same time.

- credit-then-invoice flat fees become invoiceable based on `invoice_at`
- credit-only flat fees move from `created` to `active` at `invoice_at`, then remain open until the flat-fee ledger `booked_at`
- customer balance treats flat-fee live impact as started at `invoice_at`
- adds regression coverage for the invoice-at-before-service-start balance window

## Root Cause

Flat-fee invoice collection was governed by `invoice_at`, but the charge lifecycle and customer balance gates still assumed service-period start for flat fees. That let invoice collection try to process charge lines while the charge remained `created`, producing unsupported `final_invoice_created` transitions.

For credits-only flat fees, there is an additional balance window: allocation is booked at flat-fee `booked_at` (`service_period.from` for in-advance, `service_period.to` for in-arrears), while invoice readiness can be earlier. The charge must remain non-final until `booked_at` so customer balance can continue projecting the live impact before the ledger booking is visible.

## Validation

- PASS: `env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/ledger/customerbalance`
- PASS: `env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/charges/flatfee/service ./openmeter/billing/charges/service`
- PASS: `env POSTGRES_HOST=127.0.0.1 go vet -tags=dynamic ./openmeter/ledger/customerbalance ./openmeter/billing/charges/flatfee/service ./openmeter/billing/charges/service`
- FAIL: `make test-nocache` currently fails in `test/credits` because existing flat-fee credit-then-invoice tests still expect service-period-start activation.
- FAIL: `make lint-go-fast` could not run in the ambient shell because `golangci-lint` is not installed there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Flat-fee charge progression, activation, and customer-balance “has started” logic now consistently follow **invoice_at** timing (including when invoicing occurs before service start).
  * Credit-then-invoice and credit-only flows were adjusted so state transitions and scheduled advancement use the correct **invoice_at** (and for later credits-only steps, **booked usage** timing).

* **Tests**
  * Added/updated coverage for cases where **invoice_at precedes service start**, including verification of **Live vs. Settled** balance behavior and expected charge advancement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->