### PR TITLE
fix: invoice edit tax code diff

### DIFF
--- a/app/config/taxcode.go
+++ b/app/config/taxcode.go
@@ -98,7 +98,7 @@ func (c TaxCodeConfiguration) Validate() error {
 func ConfigureTaxCode(v *viper.Viper) {
 	v.SetDefault("taxcode.seeds", []map[string]any{
 		{
-			"key":              "default",
+			"key":              taxcode.ProviderDefaultTaxCodeKey,
 			"name":             "Provider default",
 			"defaultInvoicing": true,
 		},

--- a/e2e/billinginvoice_discount_edit_test.go
+++ b/e2e/billinginvoice_discount_edit_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-func TestInvoiceEditFlatFeeDiscountCreditThenInvoice(t *testing.T) {
+func TestInvoiceEditFlatFeeDiscountCreditThenInvoiceWithDefaultedTaxCode(t *testing.T) {
 	ctx := t.Context()
 	client := initClient(t)
 	prefix := "discount_edit_" + strings.ToLower(ulid.Make().String())
@@ -111,6 +111,9 @@ func TestInvoiceEditFlatFeeDiscountCreditThenInvoice(t *testing.T) {
 			PaymentTerm: lo.ToPtr(api.PricePaymentTermInAdvance),
 		},
 		BillingCadence: lo.ToPtr("P1M"),
+		TaxConfig: &api.TaxConfig{
+			Behavior: lo.ToPtr(api.TaxBehaviorExclusive),
+		},
 	}))
 
 	planResp, err := client.CreatePlanWithResponse(ctx, api.PlanCreate{
@@ -156,6 +159,7 @@ func TestInvoiceEditFlatFeeDiscountCreditThenInvoice(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, subscriptionResp.StatusCode(), "create subscription: %s", string(subscriptionResp.Body))
 	require.NotNil(t, subscriptionResp.JSON201)
+	t.Logf("created customer=%s subscription=%s", customerResp.JSON201.Id, subscriptionResp.JSON201.Id)
 
 	customers := api.InvoiceListParamsCustomers{customerResp.JSON201.Id}
 	invoiceExpand := api.InvoiceListParamsExpand{api.InvoiceExpandLines, api.InvoiceExpandWorkflowApps}
@@ -214,10 +218,13 @@ func TestInvoiceEditFlatFeeDiscountCreditThenInvoice(t *testing.T) {
 	require.NotNil(t, invoice.Lines)
 
 	lineIdx := slices.IndexFunc(*invoice.Lines, func(line api.InvoiceLine) bool {
-		return line.Name == lineName
+		return line.Name == lineName && line.Subscription != nil
 	})
 	require.NotEqual(t, -1, lineIdx, "invoice line %q", lineName)
 	lineID := (*invoice.Lines)[lineIdx].Id
+	require.NotNil(t, (*invoice.Lines)[lineIdx].TaxConfig, "line[%s] tax config", lineID)
+	require.NotNil(t, (*invoice.Lines)[lineIdx].TaxConfig.TaxCodeId, "line[%s] defaulted tax code", lineID)
+	t.Logf("editing invoice=%s line=%s default_tax_code=%s", invoice.Id, lineID, *(*invoice.Lines)[lineIdx].TaxConfig.TaxCodeId)
 
 	replacementLines := make([]api.InvoiceLineReplaceUpdate, 0, len(*invoice.Lines))
 	for _, line := range *invoice.Lines {
@@ -235,6 +242,10 @@ func TestInvoiceEditFlatFeeDiscountCreditThenInvoice(t *testing.T) {
 		}
 		if line.Id == lineID {
 			require.NotNil(t, lineUpdate.RateCard, "line[%s] rate card", line.Id)
+			require.NotNil(t, lineUpdate.RateCard.TaxConfig, "line[%s] rate card tax config", line.Id)
+			lineUpdate.RateCard.TaxConfig.TaxCodeId = nil
+			require.NotNil(t, lineUpdate.TaxConfig, "line[%s] tax config", line.Id)
+			lineUpdate.TaxConfig.TaxCodeId = nil
 			lineUpdate.RateCard.Discounts = &api.BillingDiscounts{
 				Percentage: &api.BillingDiscountPercentage{
 					Percentage: models.NewPercentage(50),

--- a/openmeter/billing/httpdriver/invoiceline.go
+++ b/openmeter/billing/httpdriver/invoiceline.go
@@ -787,18 +787,57 @@ func mergeStandardLineFromInvoiceLineReplaceUpdate(existing *billing.StandardLin
 	existing.Period.To = line.Period.To.Truncate(streaming.MinimumWindowSizeDuration)
 	existing.InvoiceAt = line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration)
 
-	taxConfig := billing.FromProductCatalog(rateCardParsed.TaxConfig)
-	if existing.TaxConfig != nil && existing.TaxConfig.ToProductCatalog().Equal(rateCardParsed.TaxConfig) {
-		clonedTaxConfig := existing.TaxConfig.Clone()
-		taxConfig = &clonedTaxConfig
-	}
-
-	existing.TaxConfig = taxConfig
+	existing.TaxConfig = mergeStandardLineTaxConfigFromInvoiceLineReplaceUpdate(existing.TaxConfig, rateCardParsed.TaxConfig)
 	existing.UsageBased.Price = rateCardParsed.Price
 	existing.UsageBased.FeatureKey = rateCardParsed.FeatureKey
 	existing.RateCardDiscounts = rateCardParsed.Discounts
 
 	return existing, nil
+}
+
+// mergeStandardLineTaxConfigFromInvoiceLineReplaceUpdate preserves the resolved provider-default
+// tax-code snapshot when a replace-style invoice edit omits tax-code identity. In invoice edit
+// payloads that omission means "use the provider default"; without preserving the already-resolved
+// line snapshot, any edit to the line can look like a tax-code edit after diffing.
+func mergeStandardLineTaxConfigFromInvoiceLineReplaceUpdate(existing *billing.TaxConfig, incoming *productcatalog.TaxConfig) *billing.TaxConfig {
+	taxConfig := billing.FromProductCatalog(incoming)
+	if existing == nil {
+		return taxConfig
+	}
+
+	if existing.ToProductCatalog().Equal(incoming) || invoiceLineTaxConfigOmitsProviderDefaultTaxCode(existing, incoming) {
+		clonedTaxConfig := existing.Clone()
+		taxConfig = &clonedTaxConfig
+	}
+
+	return taxConfig
+}
+
+// invoiceLineTaxConfigOmitsProviderDefaultTaxCode reports whether incoming expresses the provider
+// default tax code by omission and otherwise matches the existing tax config. Because this HTTP
+// merge layer does not resolve defaults, the omission is only a no-op when the existing line already
+// carries a resolved tax-code snapshot to preserve.
+func invoiceLineTaxConfigOmitsProviderDefaultTaxCode(existing *billing.TaxConfig, incoming *productcatalog.TaxConfig) bool {
+	if incoming == nil {
+		return false
+	}
+
+	incomingUsesExplicitTaxCode := incoming.TaxCodeID != nil || incoming.Stripe != nil
+	if incomingUsesExplicitTaxCode {
+		return false
+	}
+
+	existingIntent := existing.ToProductCatalog()
+	existingHasResolvedTaxCode := existingIntent.TaxCodeID != nil || existingIntent.Stripe != nil || existing.TaxCode != nil
+	if !existingHasResolvedTaxCode {
+		return false
+	}
+
+	existingWithoutResolvedTaxCode := existingIntent.Clone()
+	existingWithoutResolvedTaxCode.TaxCodeID = nil
+	existingWithoutResolvedTaxCode.Stripe = nil
+
+	return existingWithoutResolvedTaxCode.Equal(incoming)
 }
 
 func mergeGatheringLineFromInvoiceLineReplaceUpdate(existing billing.GatheringLine, line api.InvoiceLineReplaceUpdate) (billing.GatheringLine, error) {

--- a/openmeter/billing/httpdriver/invoiceline.go
+++ b/openmeter/billing/httpdriver/invoiceline.go
@@ -787,57 +787,12 @@ func mergeStandardLineFromInvoiceLineReplaceUpdate(existing *billing.StandardLin
 	existing.Period.To = line.Period.To.Truncate(streaming.MinimumWindowSizeDuration)
 	existing.InvoiceAt = line.InvoiceAt.Truncate(streaming.MinimumWindowSizeDuration)
 
-	existing.TaxConfig = mergeStandardLineTaxConfigFromInvoiceLineReplaceUpdate(existing.TaxConfig, rateCardParsed.TaxConfig)
+	existing.TaxConfig = billing.FromProductCatalog(rateCardParsed.TaxConfig)
 	existing.UsageBased.Price = rateCardParsed.Price
 	existing.UsageBased.FeatureKey = rateCardParsed.FeatureKey
 	existing.RateCardDiscounts = rateCardParsed.Discounts
 
 	return existing, nil
-}
-
-// mergeStandardLineTaxConfigFromInvoiceLineReplaceUpdate preserves the resolved provider-default
-// tax-code snapshot when a replace-style invoice edit omits tax-code identity. In invoice edit
-// payloads that omission means "use the provider default"; without preserving the already-resolved
-// line snapshot, any edit to the line can look like a tax-code edit after diffing.
-func mergeStandardLineTaxConfigFromInvoiceLineReplaceUpdate(existing *billing.TaxConfig, incoming *productcatalog.TaxConfig) *billing.TaxConfig {
-	taxConfig := billing.FromProductCatalog(incoming)
-	if existing == nil {
-		return taxConfig
-	}
-
-	if existing.ToProductCatalog().Equal(incoming) || invoiceLineTaxConfigOmitsProviderDefaultTaxCode(existing, incoming) {
-		clonedTaxConfig := existing.Clone()
-		taxConfig = &clonedTaxConfig
-	}
-
-	return taxConfig
-}
-
-// invoiceLineTaxConfigOmitsProviderDefaultTaxCode reports whether incoming expresses the provider
-// default tax code by omission and otherwise matches the existing tax config. Because this HTTP
-// merge layer does not resolve defaults, the omission is only a no-op when the existing line already
-// carries a resolved tax-code snapshot to preserve.
-func invoiceLineTaxConfigOmitsProviderDefaultTaxCode(existing *billing.TaxConfig, incoming *productcatalog.TaxConfig) bool {
-	if incoming == nil {
-		return false
-	}
-
-	incomingUsesExplicitTaxCode := incoming.TaxCodeID != nil || incoming.Stripe != nil
-	if incomingUsesExplicitTaxCode {
-		return false
-	}
-
-	existingIntent := existing.ToProductCatalog()
-	existingHasResolvedTaxCode := existingIntent.TaxCodeID != nil || existingIntent.Stripe != nil || existing.TaxCode != nil
-	if !existingHasResolvedTaxCode {
-		return false
-	}
-
-	existingWithoutResolvedTaxCode := existingIntent.Clone()
-	existingWithoutResolvedTaxCode.TaxCodeID = nil
-	existingWithoutResolvedTaxCode.Stripe = nil
-
-	return existingWithoutResolvedTaxCode.Equal(incoming)
 }
 
 func mergeGatheringLineFromInvoiceLineReplaceUpdate(existing billing.GatheringLine, line api.InvoiceLineReplaceUpdate) (billing.GatheringLine, error) {

--- a/openmeter/billing/httpdriver/invoiceline_test.go
+++ b/openmeter/billing/httpdriver/invoiceline_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
-func TestMergeStandardLineFromInvoiceLineReplaceUpdatePreservesResolvedTaxCode(t *testing.T) {
+func TestMergeStandardLineFromInvoiceLineReplaceUpdateOverwritesTaxConfig(t *testing.T) {
 	price := api.RateCardUsageBasedPrice{}
 	require.NoError(t, price.FromUnitPriceWithCommitments(api.UnitPriceWithCommitments{
 		Amount: "1",
@@ -84,11 +84,11 @@ func TestMergeStandardLineFromInvoiceLineReplaceUpdatePreservesResolvedTaxCode(t
 	})
 	require.NoError(t, err)
 	require.NotNil(t, mergedLine.TaxConfig)
-	require.NotNil(t, mergedLine.TaxConfig.TaxCode)
-	require.Equal(t, taxCodeID, mergedLine.TaxConfig.TaxCode.ID)
+	require.Equal(t, taxCodeID, *mergedLine.TaxConfig.TaxCodeID)
+	require.Nil(t, mergedLine.TaxConfig.TaxCode)
 }
 
-func TestMergeStandardLineFromInvoiceLineReplaceUpdatePreservesResolvedTaxCodeWhenPayloadOmitsDefaultTaxCode(t *testing.T) {
+func TestMergeStandardLineFromInvoiceLineReplaceUpdateLeavesProviderDefaultOmissionForInvoiceNormalization(t *testing.T) {
 	period := invoiceLineTestPeriod()
 	line := standardInvoiceLineForMergeTest(t, period)
 
@@ -117,10 +117,41 @@ func TestMergeStandardLineFromInvoiceLineReplaceUpdatePreservesResolvedTaxCodeWh
 	}))
 	require.NoError(t, err)
 	require.NotNil(t, mergedLine.TaxConfig)
-	require.NotNil(t, mergedLine.TaxConfig.TaxCodeID)
-	require.Equal(t, defaultTaxCodeID, *mergedLine.TaxConfig.TaxCodeID)
-	require.NotNil(t, mergedLine.TaxConfig.TaxCode)
-	require.Equal(t, defaultTaxCodeID, mergedLine.TaxConfig.TaxCode.ID)
+	require.Nil(t, mergedLine.TaxConfig.TaxCodeID)
+	require.Nil(t, mergedLine.TaxConfig.TaxCode)
+}
+
+func TestMergeStandardLineFromInvoiceLineReplaceUpdateDoesNotPreserveExplicitTaxCodeWhenPayloadOmitsTaxCodeIdentity(t *testing.T) {
+	period := invoiceLineTestPeriod()
+	line := standardInvoiceLineForMergeTest(t, period)
+
+	explicitTaxCodeID := "explicit-tax-code-id"
+	productCatalogTaxBehavior := productcatalog.ExclusiveTaxBehavior
+	line.TaxConfig = &billing.TaxConfig{
+		TaxConfig: productcatalog.TaxConfig{
+			Behavior:  &productCatalogTaxBehavior,
+			TaxCodeID: &explicitTaxCodeID,
+		},
+		TaxCode: &taxcode.TaxCode{
+			NamespacedID: models.NamespacedID{
+				Namespace: "ns",
+				ID:        explicitTaxCodeID,
+			},
+			Name: "Explicit Tax Code",
+		},
+	}
+
+	taxBehavior := api.TaxBehaviorExclusive
+	mergedLine, err := mergeStandardLineFromInvoiceLineReplaceUpdate(line, invoiceLineReplaceUpdateForMergeTest(t, period, line.UsageBased.FeatureKey, "1", func(update *api.InvoiceLineReplaceUpdate) {
+		update.RateCard.TaxConfig = &api.TaxConfig{
+			Behavior: &taxBehavior,
+		}
+		update.TaxConfig = update.RateCard.TaxConfig
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, mergedLine.TaxConfig)
+	require.Nil(t, mergedLine.TaxConfig.TaxCodeID)
+	require.Nil(t, mergedLine.TaxConfig.TaxCode)
 }
 
 func TestMergeStandardLineFromInvoiceLineReplaceUpdateDropsResolvedTaxCodeWhenTaxConfigChanges(t *testing.T) {

--- a/openmeter/billing/httpdriver/invoiceline_test.go
+++ b/openmeter/billing/httpdriver/invoiceline_test.go
@@ -88,6 +88,41 @@ func TestMergeStandardLineFromInvoiceLineReplaceUpdatePreservesResolvedTaxCode(t
 	require.Equal(t, taxCodeID, mergedLine.TaxConfig.TaxCode.ID)
 }
 
+func TestMergeStandardLineFromInvoiceLineReplaceUpdatePreservesResolvedTaxCodeWhenPayloadOmitsDefaultTaxCode(t *testing.T) {
+	period := invoiceLineTestPeriod()
+	line := standardInvoiceLineForMergeTest(t, period)
+
+	defaultTaxCodeID := "default-tax-code-id"
+	productCatalogTaxBehavior := productcatalog.ExclusiveTaxBehavior
+	line.TaxConfig = &billing.TaxConfig{
+		TaxConfig: productcatalog.TaxConfig{
+			Behavior:  &productCatalogTaxBehavior,
+			TaxCodeID: &defaultTaxCodeID,
+		},
+		TaxCode: &taxcode.TaxCode{
+			NamespacedID: models.NamespacedID{
+				Namespace: "ns",
+				ID:        defaultTaxCodeID,
+			},
+			Name: "Default Tax Code",
+		},
+	}
+
+	taxBehavior := api.TaxBehaviorExclusive
+	mergedLine, err := mergeStandardLineFromInvoiceLineReplaceUpdate(line, invoiceLineReplaceUpdateForMergeTest(t, period, line.UsageBased.FeatureKey, "1", func(update *api.InvoiceLineReplaceUpdate) {
+		update.RateCard.TaxConfig = &api.TaxConfig{
+			Behavior: &taxBehavior,
+		}
+		update.TaxConfig = update.RateCard.TaxConfig
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, mergedLine.TaxConfig)
+	require.NotNil(t, mergedLine.TaxConfig.TaxCodeID)
+	require.Equal(t, defaultTaxCodeID, *mergedLine.TaxConfig.TaxCodeID)
+	require.NotNil(t, mergedLine.TaxConfig.TaxCode)
+	require.Equal(t, defaultTaxCodeID, mergedLine.TaxConfig.TaxCode.ID)
+}
+
 func TestMergeStandardLineFromInvoiceLineReplaceUpdateDropsResolvedTaxCodeWhenTaxConfigChanges(t *testing.T) {
 	period := invoiceLineTestPeriod()
 	line := standardInvoiceLineForMergeTest(t, period)

--- a/openmeter/billing/service/gatheringinvoice.go
+++ b/openmeter/billing/service/gatheringinvoice.go
@@ -72,7 +72,7 @@ func (s *Service) UpdateGatheringInvoice(ctx context.Context, input billing.Upda
 			return billing.GatheringInvoice{}, fmt.Errorf("normalizing lines: %w", err)
 		}
 
-		lineDiff, err := s.diffMutableInvoiceLines(originalInvoice, invoice, input.ChangeSource)
+		lineDiff, err := s.diffMutableInvoiceLines(ctx, originalInvoice, invoice, input.ChangeSource)
 		if err != nil {
 			return billing.GatheringInvoice{}, billing.ValidationError{
 				Err: fmt.Errorf("collecting mutable invoice line changes: %w", err),

--- a/openmeter/billing/service/invoiceupdate.go
+++ b/openmeter/billing/service/invoiceupdate.go
@@ -437,11 +437,11 @@ func taxConfigOverride(a, b *billing.TaxConfig, source billing.ChangeSource) mo.
 		return mo.Some(b)
 	}
 
-	if a.Equal(b) {
-		return mo.Some(b)
+	if taxConfigsEqual(a, b) {
+		return mo.None[*billing.TaxConfig]()
 	}
 
-	return mo.None[*billing.TaxConfig]()
+	return mo.Some(b)
 }
 
 func taxConfigsEqual(a, b *billing.TaxConfig) bool {
@@ -486,7 +486,7 @@ func metadataOverride(a, b models.Metadata) mo.Option[models.Metadata] {
 		return mo.Some(b)
 	}
 
-	if !taxConfigsEqual(a, b) {
+	if !a.Equal(b) {
 		return mo.Some(b)
 	}
 

--- a/openmeter/billing/service/invoiceupdate.go
+++ b/openmeter/billing/service/invoiceupdate.go
@@ -39,7 +39,12 @@ func (d mutableInvoiceLineDiff) Validate() error {
 	return d.OnMutableInvoiceUpdateInput.Validate()
 }
 
-func diffMutableInvoiceLines(before, after billing.GenericInvoiceReader, createLineRouter billing.CreateLineRouter) (mutableInvoiceLineDiff, error) {
+func diffMutableInvoiceLines(
+	before billing.GenericInvoiceReader,
+	after billing.GenericInvoiceReader,
+	source billing.ChangeSource,
+	createLineRouter billing.CreateLineRouter,
+) (mutableInvoiceLineDiff, error) {
 	if err := validateInvoiceReaderForDiff(before); err != nil {
 		return mutableInvoiceLineDiff{}, fmt.Errorf("validating before invoice: %w", err)
 	}
@@ -133,7 +138,7 @@ func diffMutableInvoiceLines(before, after billing.GenericInvoiceReader, createL
 				return nil
 			}
 
-			override, err := diffInvoiceLine(beforeLine, afterLine)
+			override, err := diffInvoiceLine(beforeLine, afterLine, source)
 			if err != nil {
 				return fmt.Errorf("line[%s]: building override: %w", afterLine.GetID(), err)
 			}
@@ -158,12 +163,34 @@ func diffMutableInvoiceLines(before, after billing.GenericInvoiceReader, createL
 	return diff, nil
 }
 
-func (s *Service) diffMutableInvoiceLines(before, after billing.GenericInvoiceReader, source billing.ChangeSource) (mutableInvoiceLineDiff, error) {
+func (s *Service) diffMutableInvoiceLines(ctx context.Context, before billing.GenericInvoiceReader, after billing.GenericInvoiceReader, source billing.ChangeSource) (mutableInvoiceLineDiff, error) {
 	if err := source.Validate(); err != nil {
 		return mutableInvoiceLineDiff{}, err
 	}
 
-	diff, err := diffMutableInvoiceLines(before, after, s.lineEngines.GetCreateLineRouter())
+	if err := validateInvoiceReaderForDiff(before); err != nil {
+		return mutableInvoiceLineDiff{}, fmt.Errorf("validating before invoice: %w", err)
+	}
+
+	if err := validateInvoiceReaderForDiff(after); err != nil {
+		return mutableInvoiceLineDiff{}, fmt.Errorf("validating after invoice: %w", err)
+	}
+
+	defaultTaxCodeResolvers := s.defaultTaxCodeResolversForInvoiceUpdate(after)
+	if source == billing.ChangeSourceAPIRequest {
+		var err error
+		before, err = s.invoiceWithSanitizedTaxConfigForDiff(ctx, defaultTaxCodeResolvers, before)
+		if err != nil {
+			return mutableInvoiceLineDiff{}, fmt.Errorf("sanitizing persisted invoice line tax configs for diff: %w", err)
+		}
+
+		after, err = s.invoiceWithSanitizedTaxConfigForDiff(ctx, defaultTaxCodeResolvers, after)
+		if err != nil {
+			return mutableInvoiceLineDiff{}, fmt.Errorf("sanitizing expected invoice line tax configs for diff: %w", err)
+		}
+	}
+
+	diff, err := diffMutableInvoiceLines(before, after, source, s.lineEngines.GetCreateLineRouter())
 	if err != nil {
 		return mutableInvoiceLineDiff{}, err
 	}
@@ -174,12 +201,152 @@ func (s *Service) diffMutableInvoiceLines(before, after billing.GenericInvoiceRe
 		}
 	}
 
-	diff.DefaultTaxCodeResolvers = s.defaultTaxCodeResolversForInvoiceUpdate(after)
+	diff.DefaultTaxCodeResolvers = defaultTaxCodeResolvers
 	if err := diff.Validate(); err != nil {
 		return mutableInvoiceLineDiff{}, err
 	}
 
 	return diff, nil
+}
+
+// invoiceWithSanitizedTaxConfigForDiff returns an invoice clone whose line tax
+// configs are normalized for API edit diffing. The diff is the source of truth
+// for line-engine inputs, so both the persisted and expected invoice states are
+// compared in the same resolved representation: nil or identity-less tax configs
+// use the provider-default tax code, explicit provider codes resolve to
+// TaxCodeID, and diff equality ignores resolved TaxCode object snapshots.
+func (s *Service) invoiceWithSanitizedTaxConfigForDiff(
+	ctx context.Context,
+	defaultTaxCodeResolvers billing.DefaultTaxCodeResolvers,
+	invoice billing.GenericInvoiceReader,
+) (billing.GenericInvoice, error) {
+	if err := defaultTaxCodeResolvers.Validate(); err != nil {
+		return nil, fmt.Errorf("default tax code resolvers: %w", err)
+	}
+
+	if invoice == nil {
+		return nil, fmt.Errorf("invoice is required")
+	}
+
+	sanitizedInvoice, err := invoice.CloneAsGenericInvoice()
+	if err != nil {
+		return nil, fmt.Errorf("cloning invoice: %w", err)
+	}
+
+	if sanitizedInvoice.GetGenericLines().IsAbsent() {
+		return sanitizedInvoice, nil
+	}
+
+	namespace := sanitizedInvoice.GetInvoiceID().Namespace
+	lines := sanitizedInvoice.GetGenericLines().OrEmpty()
+	for i, line := range lines {
+		sanitizedLine, err := s.sanitizeInvoiceLineTaxConfigForDiff(ctx, namespace, line)
+		if err != nil {
+			return nil, fmt.Errorf("line[%s]: %w", line.GetID(), err)
+		}
+
+		lines[i] = sanitizedLine
+	}
+
+	if err := sanitizedInvoice.SetLines(lines); err != nil {
+		return nil, fmt.Errorf("setting sanitized invoice lines: %w", err)
+	}
+
+	return sanitizedInvoice, nil
+}
+
+func (s *Service) sanitizeInvoiceLineTaxConfigForDiff(
+	ctx context.Context,
+	namespace string,
+	line billing.GenericInvoiceLine,
+) (billing.GenericInvoiceLine, error) {
+	taxConfig, err := s.sanitizeTaxConfigForDiff(ctx, namespace, line.GetTaxConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	invoiceLine := line.AsInvoiceLine()
+	switch invoiceLine.Type() {
+	case billing.InvoiceLineTypeStandard:
+		standardLine, err := invoiceLine.AsStandardLine()
+		if err != nil {
+			return nil, err
+		}
+
+		standardLine.TaxConfig = taxConfig
+		return standardLine.AsGenericLine(), nil
+
+	case billing.InvoiceLineTypeGathering:
+		gatheringLine, err := invoiceLine.AsGatheringLine()
+		if err != nil {
+			return nil, err
+		}
+
+		gatheringLine.TaxConfig = taxConfig.ToProductCatalog()
+		return gatheringLine.AsGenericLine(), nil
+
+	default:
+		return nil, fmt.Errorf("unsupported invoice line type: %s", invoiceLine.Type())
+	}
+}
+
+func (s *Service) sanitizeTaxConfigForDiff(
+	ctx context.Context,
+	namespace string,
+	taxConfig *billing.TaxConfig,
+) (*billing.TaxConfig, error) {
+	var sanitized billing.TaxConfig
+	if taxConfig != nil {
+		sanitized = taxConfig.Clone()
+	}
+
+	if sanitized.TaxCodeID != nil && *sanitized.TaxCodeID == "" {
+		sanitized.TaxCodeID = nil
+	}
+
+	if sanitized.TaxCodeID != nil {
+		return &sanitized, nil
+	}
+
+	if sanitized.Stripe == nil || sanitized.Stripe.Code == "" {
+		providerDefaultTaxCode, err := s.taxCodeService.GetTaxCodeByKey(ctx, taxcode.GetTaxCodeByKeyInput{
+			Namespace: namespace,
+			Key:       taxcode.ProviderDefaultTaxCodeKey,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("resolving provider default tax code: %w", err)
+		}
+
+		sanitized.TaxCodeID = lo.ToPtr(providerDefaultTaxCode.ID)
+
+		if err := validateTaxConfigTaxCodeIDResolvedForDiff(&sanitized); err != nil {
+			return nil, err
+		}
+
+		return &sanitized, nil
+	}
+
+	productCatalogTaxConfig := sanitized.ToProductCatalog()
+	if err := productcatalog.ResolveTaxConfig(ctx, s.taxCodeService, namespace, productCatalogTaxConfig); err != nil {
+		return nil, err
+	}
+
+	sanitized.TaxConfig = productCatalogTaxConfig.Clone()
+	if err := validateTaxConfigTaxCodeIDResolvedForDiff(&sanitized); err != nil {
+		return nil, err
+	}
+
+	return &sanitized, nil
+}
+
+func validateTaxConfigTaxCodeIDResolvedForDiff(taxConfig *billing.TaxConfig) error {
+	if taxConfig != nil && taxConfig.TaxCodeID != nil && *taxConfig.TaxCodeID != "" {
+		return nil
+	}
+
+	return billing.ValidationError{
+		Err: models.NewGenericValidationError(errors.New("cannot resolve tax code id")),
+	}
 }
 
 func validateInvoiceReaderForDiff(invoice billing.GenericInvoiceReader) error {
@@ -200,7 +367,7 @@ func validateInvoiceReaderForDiff(invoice billing.GenericInvoiceReader) error {
 	return nil
 }
 
-func diffInvoiceLine(before, after billing.GenericInvoiceLineReader) (*billing.ExistingLineOverride, error) {
+func diffInvoiceLine(before, after billing.GenericInvoiceLineReader, source billing.ChangeSource) (*billing.ExistingLineOverride, error) {
 	if before == nil {
 		return nil, fmt.Errorf("before line is required")
 	}
@@ -214,7 +381,7 @@ func diffInvoiceLine(before, after billing.GenericInvoiceLineReader) (*billing.E
 		Description: comparablePtrOverride(before.GetDescription(), after.GetDescription()),
 		Metadata:    metadataOverride(before.GetMetadata(), after.GetMetadata()),
 		Period:      equalerOverride(before.GetServicePeriod(), after.GetServicePeriod()),
-		TaxConfig:   taxConfigOverride(before.GetTaxConfig(), after.GetTaxConfig()),
+		TaxConfig:   taxConfigOverride(before.GetTaxConfig(), after.GetTaxConfig(), source),
 		Price:       equalerOverride(before.GetPrice(), after.GetPrice()),
 		FeatureKey:  comparableOverride(before.GetFeatureKey(), after.GetFeatureKey()),
 		Discounts:   equalerOverride(before.GetRateCardDiscounts(), after.GetRateCardDiscounts()),
@@ -261,12 +428,53 @@ func equalerOverride[T equal.Equaler[T]](a, b T) mo.Option[T] {
 	return mo.None[T]()
 }
 
-func taxConfigOverride(a, b *billing.TaxConfig) mo.Option[*billing.TaxConfig] {
-	if !a.Equal(b) {
+func taxConfigOverride(a, b *billing.TaxConfig, source billing.ChangeSource) mo.Option[*billing.TaxConfig] {
+	if source == billing.ChangeSourceAPIRequest {
+		if taxConfigsEqualForInvoiceLineDiff(a, b) {
+			return mo.None[*billing.TaxConfig]()
+		}
+
+		return mo.Some(b)
+	}
+
+	if a.Equal(b) {
 		return mo.Some(b)
 	}
 
 	return mo.None[*billing.TaxConfig]()
+}
+
+func taxConfigsEqual(a, b *billing.TaxConfig) bool {
+	if a == nil && b == nil {
+		return true
+	}
+
+	if a == nil || b == nil {
+		return false
+	}
+
+	return a.Equal(b)
+}
+
+// taxConfigsEqualForInvoiceLineDiff compares only the fields that represent an
+// invoice-line tax edit after diff normalization. Both sides have already had
+// provider-specific tax code intent resolved into TaxCodeID, so Behavior and
+// TaxCodeID fully describe the editable state; resolved TaxCode snapshots are
+// ignored because they are invoice snapshot metadata, not edit intent.
+func taxConfigsEqualForInvoiceLineDiff(a, b *billing.TaxConfig) bool {
+	if a == nil && b == nil {
+		return true
+	}
+
+	if a == nil || b == nil {
+		return false
+	}
+
+	if !equal.ComparablePtrEqual(a.Behavior, b.Behavior) {
+		return false
+	}
+
+	return equal.ComparablePtrEqual(a.TaxCodeID, b.TaxCodeID)
 }
 
 func metadataOverride(a, b models.Metadata) mo.Option[models.Metadata] {
@@ -278,7 +486,7 @@ func metadataOverride(a, b models.Metadata) mo.Option[models.Metadata] {
 		return mo.Some(b)
 	}
 
-	if !a.Equal(b) {
+	if !taxConfigsEqual(a, b) {
 		return mo.Some(b)
 	}
 

--- a/openmeter/billing/service/invoiceupdate_test.go
+++ b/openmeter/billing/service/invoiceupdate_test.go
@@ -10,16 +10,28 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openmeterio/openmeter/openmeter/app"
 	"github.com/openmeterio/openmeter/openmeter/billing"
 	billingtestutils "github.com/openmeterio/openmeter/openmeter/billing/testutils"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
+	"github.com/openmeterio/openmeter/openmeter/taxcode"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
 	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
 
 func diffMutableInvoiceLinesForTest(before, after billing.GenericInvoiceReader, createLineRouter billing.CreateLineRouter) (mutableInvoiceLineDiff, error) {
-	diff, err := diffMutableInvoiceLines(before, after, createLineRouter)
+	return diffMutableInvoiceLinesForTestWithSource(before, after, billing.ChangeSourceAPIRequest, createLineRouter)
+}
+
+func diffMutableInvoiceLinesForTestWithSource(
+	before billing.GenericInvoiceReader,
+	after billing.GenericInvoiceReader,
+	source billing.ChangeSource,
+	createLineRouter billing.CreateLineRouter,
+) (mutableInvoiceLineDiff, error) {
+	diff, err := diffMutableInvoiceLines(before, after, source, createLineRouter)
 	if err != nil {
 		return mutableInvoiceLineDiff{}, err
 	}
@@ -42,6 +54,8 @@ func noopDefaultTaxCodeResolvers() billing.DefaultTaxCodeResolvers {
 		},
 	}
 }
+
+const invoiceUpdateDefaultTaxCodeID = "default-tax-code-id"
 
 func TestDiffInvoiceLinesByEngine(t *testing.T) {
 	before := billing.StandardInvoice{
@@ -225,6 +239,237 @@ func TestDiffInvoiceLinesByEngineReturnsErrorForChangedLineEngine(t *testing.T) 
 	require.ErrorContains(t, err, "line[updated]: line engine cannot be changed")
 }
 
+func TestDiffMutableInvoiceLinesSanitizesNilTaxConfigToDefaultNoDiff(t *testing.T) {
+	invoice, edited := standardInvoicePairForTaxConfigDiffTest(nil, nil)
+	svc := serviceForInvoiceTaxConfigDiffTest()
+
+	lineDiff, err := svc.diffMutableInvoiceLines(t.Context(), &invoice, &edited, billing.ChangeSourceAPIRequest)
+	require.NoError(t, err)
+	require.True(t, lineDiff.IsEmpty())
+
+	require.Nil(t, invoice.Lines.OrEmpty()[0].TaxConfig)
+	require.Nil(t, edited.Lines.OrEmpty()[0].TaxConfig)
+
+	sanitizedInvoice, err := svc.invoiceWithSanitizedTaxConfigForDiff(
+		t.Context(),
+		svc.defaultTaxCodeResolversForInvoiceUpdate(&invoice),
+		&invoice,
+	)
+	require.NoError(t, err)
+	require.Equal(t, invoiceUpdateDefaultTaxCodeID, *sanitizedInvoice.GetGenericLines().OrEmpty()[0].GetTaxConfig().TaxCodeID)
+}
+
+func TestDiffMutableInvoiceLinesKeepsExplicitTaxCodeToDefaultDiff(t *testing.T) {
+	explicitTaxCodeID := "explicit-tax-code-id"
+	taxBehavior := productcatalog.ExclusiveTaxBehavior
+	invoice, edited := standardInvoicePairForTaxConfigDiffTest(
+		&billing.TaxConfig{
+			TaxConfig: productcatalog.TaxConfig{
+				Behavior:  &taxBehavior,
+				TaxCodeID: lo.ToPtr(explicitTaxCodeID),
+			},
+		},
+		nil,
+	)
+	svc := serviceForInvoiceTaxConfigDiffTest()
+
+	lineDiff, err := svc.diffMutableInvoiceLines(t.Context(), &invoice, &edited, billing.ChangeSourceAPIRequest)
+	require.NoError(t, err)
+	require.Len(t, lineDiff.Updated, 1)
+
+	updatedTaxConfig, ok := lineDiff.Updated[0].ChangesToApply.TaxConfig.Get()
+	require.True(t, ok)
+	require.NotNil(t, updatedTaxConfig)
+	require.Equal(t, invoiceUpdateDefaultTaxCodeID, *updatedTaxConfig.TaxCodeID)
+}
+
+func TestDiffMutableInvoiceLinesResolvesProviderDefaultTaxCodeIDMatchNoDiff(t *testing.T) {
+	invoice, edited := standardInvoicePairForTaxConfigDiffTest(
+		&billing.TaxConfig{
+			TaxConfig: productcatalog.TaxConfig{
+				TaxCodeID: lo.ToPtr(invoiceUpdateDefaultTaxCodeID),
+			},
+		},
+		&billing.TaxConfig{
+			TaxConfig: productcatalog.TaxConfig{
+				Stripe: &productcatalog.StripeTaxConfig{},
+			},
+		},
+	)
+	svc := serviceForInvoiceTaxConfigDiffTest()
+
+	lineDiff, err := svc.diffMutableInvoiceLines(t.Context(), &invoice, &edited, billing.ChangeSourceAPIRequest)
+	require.NoError(t, err)
+	require.True(t, lineDiff.IsEmpty())
+
+	require.Nil(t, edited.Lines.OrEmpty()[0].TaxConfig.TaxCodeID)
+	require.NotNil(t, edited.Lines.OrEmpty()[0].TaxConfig.Stripe)
+	require.Empty(t, edited.Lines.OrEmpty()[0].TaxConfig.Stripe.Code)
+}
+
+func TestDiffMutableInvoiceLinesResolvedExplicitTaxCodeIDMatchNoDiff(t *testing.T) {
+	explicitTaxCodeID := "explicit-tax-code-id"
+	taxBehavior := productcatalog.ExclusiveTaxBehavior
+	invoiceTaxConfig := &billing.TaxConfig{
+		TaxConfig: productcatalog.TaxConfig{
+			Behavior:  &taxBehavior,
+			TaxCodeID: lo.ToPtr(explicitTaxCodeID),
+		},
+		TaxCode: &taxcode.TaxCode{
+			NamespacedID: models.NamespacedID{
+				Namespace: "ns",
+				ID:        explicitTaxCodeID,
+			},
+			Key:  "explicit",
+			Name: "Explicit Tax Code",
+		},
+	}
+	editedTaxConfig := &billing.TaxConfig{
+		TaxConfig: productcatalog.TaxConfig{
+			Behavior:  &taxBehavior,
+			TaxCodeID: lo.ToPtr(explicitTaxCodeID),
+		},
+	}
+	invoice, edited := standardInvoicePairForTaxConfigDiffTest(invoiceTaxConfig, editedTaxConfig)
+	svc := serviceForInvoiceTaxConfigDiffTest()
+
+	lineDiff, err := svc.diffMutableInvoiceLines(t.Context(), &invoice, &edited, billing.ChangeSourceAPIRequest)
+	require.NoError(t, err)
+	require.True(t, lineDiff.IsEmpty())
+}
+
+func TestDiffMutableInvoiceLinesSystemSourceUsesFullTaxConfigEquality(t *testing.T) {
+	explicitTaxCodeID := "explicit-tax-code-id"
+	taxBehavior := productcatalog.ExclusiveTaxBehavior
+	invoiceTaxConfig := &billing.TaxConfig{
+		TaxConfig: productcatalog.TaxConfig{
+			Behavior:  &taxBehavior,
+			TaxCodeID: lo.ToPtr(explicitTaxCodeID),
+		},
+		TaxCode: &taxcode.TaxCode{
+			NamespacedID: models.NamespacedID{
+				Namespace: "ns",
+				ID:        explicitTaxCodeID,
+			},
+			Key:  "explicit",
+			Name: "Explicit Tax Code",
+		},
+	}
+	editedTaxConfig := &billing.TaxConfig{
+		TaxConfig: productcatalog.TaxConfig{
+			Behavior:  &taxBehavior,
+			TaxCodeID: lo.ToPtr(explicitTaxCodeID),
+		},
+	}
+	invoice, edited := standardInvoicePairForTaxConfigDiffTest(invoiceTaxConfig, editedTaxConfig)
+
+	apiLineDiff, err := diffMutableInvoiceLinesForTestWithSource(&invoice, &edited, billing.ChangeSourceAPIRequest, billing.DefaultCreateLineRouter{})
+	require.NoError(t, err)
+	require.True(t, apiLineDiff.IsEmpty())
+
+	systemLineDiff, err := diffMutableInvoiceLinesForTestWithSource(&invoice, &edited, billing.ChangeSourceSystem, billing.DefaultCreateLineRouter{})
+	require.NoError(t, err)
+	require.Len(t, systemLineDiff.Updated, 1)
+
+	updatedTaxConfig, ok := systemLineDiff.Updated[0].ChangesToApply.TaxConfig.Get()
+	require.True(t, ok)
+	require.Equal(t, editedTaxConfig, updatedTaxConfig)
+}
+
+func TestDiffMutableInvoiceLinesResolvesProviderTaxCodeIDMatchNoDiff(t *testing.T) {
+	explicitTaxCodeID := "explicit-tax-code-id"
+	stripeCode := "txcd_10000000"
+	taxBehavior := productcatalog.ExclusiveTaxBehavior
+	invoice, edited := standardInvoicePairForTaxConfigDiffTest(
+		&billing.TaxConfig{
+			TaxConfig: productcatalog.TaxConfig{
+				Behavior:  &taxBehavior,
+				TaxCodeID: lo.ToPtr(explicitTaxCodeID),
+			},
+		},
+		&billing.TaxConfig{
+			TaxConfig: productcatalog.TaxConfig{
+				Behavior: &taxBehavior,
+				Stripe:   &productcatalog.StripeTaxConfig{Code: stripeCode},
+			},
+		},
+	)
+	svc := serviceForInvoiceTaxConfigDiffTest()
+	svc.taxCodeService.(*invoiceUpdateTaxCodeService).taxCodes[explicitTaxCodeID] = taxcode.TaxCode{
+		NamespacedID: models.NamespacedID{
+			Namespace: "ns",
+			ID:        explicitTaxCodeID,
+		},
+		Key:  "explicit",
+		Name: "Explicit Tax Code",
+		AppMappings: taxcode.TaxCodeAppMappings{
+			{AppType: app.AppTypeStripe, TaxCode: stripeCode},
+		},
+	}
+
+	lineDiff, err := svc.diffMutableInvoiceLines(t.Context(), &invoice, &edited, billing.ChangeSourceAPIRequest)
+	require.NoError(t, err)
+	require.True(t, lineDiff.IsEmpty())
+}
+
+func TestDiffMutableInvoiceLinesBehaviorOnlyDifferenceProducesTaxConfigDiff(t *testing.T) {
+	exclusiveBehavior := productcatalog.ExclusiveTaxBehavior
+	inclusiveBehavior := productcatalog.InclusiveTaxBehavior
+	invoice, edited := standardInvoicePairForTaxConfigDiffTest(
+		&billing.TaxConfig{
+			TaxConfig: productcatalog.TaxConfig{
+				Behavior:  &exclusiveBehavior,
+				TaxCodeID: lo.ToPtr(invoiceUpdateDefaultTaxCodeID),
+			},
+		},
+		&billing.TaxConfig{
+			TaxConfig: productcatalog.TaxConfig{
+				Behavior:  &inclusiveBehavior,
+				TaxCodeID: lo.ToPtr(invoiceUpdateDefaultTaxCodeID),
+			},
+		},
+	)
+	svc := serviceForInvoiceTaxConfigDiffTest()
+
+	lineDiff, err := svc.diffMutableInvoiceLines(t.Context(), &invoice, &edited, billing.ChangeSourceAPIRequest)
+	require.NoError(t, err)
+	require.Len(t, lineDiff.Updated, 1)
+
+	updatedTaxConfig, ok := lineDiff.Updated[0].ChangesToApply.TaxConfig.Get()
+	require.True(t, ok)
+	require.NotNil(t, updatedTaxConfig)
+	require.Equal(t, inclusiveBehavior, *updatedTaxConfig.Behavior)
+	require.Equal(t, invoiceUpdateDefaultTaxCodeID, *updatedTaxConfig.TaxCodeID)
+}
+
+func TestInvoiceWithSanitizedTaxConfigForDiffReturnsValidationErrorWhenTaxCodeIDCannotBeResolved(t *testing.T) {
+	invoice, _ := standardInvoicePairForTaxConfigDiffTest(nil, nil)
+	svc := serviceForInvoiceTaxConfigDiffTest()
+	svc.taxCodeService = &invoiceUpdateTaxCodeService{
+		taxCodes: map[string]taxcode.TaxCode{
+			"empty-id-provider-default-tax-code": {
+				NamespacedID: models.NamespacedID{
+					Namespace: "ns",
+				},
+				Key: taxcode.ProviderDefaultTaxCodeKey,
+			},
+		},
+	}
+
+	_, err := svc.invoiceWithSanitizedTaxConfigForDiff(t.Context(), billing.DefaultTaxCodeResolvers{
+		Invoicing: func(context.Context) (string, error) {
+			return "", nil
+		},
+		CreditGrant: func(context.Context) (string, error) {
+			return "", nil
+		},
+	}, &invoice)
+	require.ErrorContains(t, err, "validation error: cannot resolve tax code id")
+
+	var validationErr billing.ValidationError
+	require.ErrorAs(t, err, &validationErr)
+}
+
 func TestWithLineEngineInvoiceLineChangesGroupsAPIEditsByEngine(t *testing.T) {
 	invoiceEngine := &recordingLineEngine{
 		NoopLineEngine: billingtestutils.NoopLineEngine{
@@ -266,7 +511,7 @@ func TestWithLineEngineInvoiceLineChangesGroupsAPIEditsByEngine(t *testing.T) {
 	edited := invoice
 	edited.Lines = billing.NewStandardInvoiceLines(billing.StandardLines{updatedInvoiceLine, updatedChargeLine, createdInvoiceLine})
 
-	lineDiff, err := svc.diffMutableInvoiceLines(invoice, edited, billing.ChangeSourceAPIRequest)
+	lineDiff, err := svc.diffMutableInvoiceLines(t.Context(), &invoice, &edited, billing.ChangeSourceAPIRequest)
 	require.NoError(t, err)
 
 	editedInvoice, err := svc.applyAPIInvoiceLineEdits(t.Context(), applyAPIInvoiceLineEditsInput{
@@ -321,7 +566,7 @@ func TestWithLineEngineInvoiceLineChangesReturnsEngineError(t *testing.T) {
 	edited := invoice
 	edited.Lines = billing.NewStandardInvoiceLines(billing.StandardLines{updatedLine})
 
-	lineDiff, err := svc.diffMutableInvoiceLines(invoice, edited, billing.ChangeSourceAPIRequest)
+	lineDiff, err := svc.diffMutableInvoiceLines(t.Context(), &invoice, &edited, billing.ChangeSourceAPIRequest)
 	require.NoError(t, err)
 
 	_, err = svc.applyAPIInvoiceLineEdits(t.Context(), applyAPIInvoiceLineEditsInput{
@@ -361,7 +606,7 @@ func TestWithLineEngineInvoiceLineChangesPreallocatesCreatedLineID(t *testing.T)
 	edited := invoice
 	edited.Lines = billing.NewStandardInvoiceLines(billing.StandardLines{createdLine})
 
-	lineDiff, err := svc.diffMutableInvoiceLines(invoice, edited, billing.ChangeSourceAPIRequest)
+	lineDiff, err := svc.diffMutableInvoiceLines(t.Context(), &invoice, &edited, billing.ChangeSourceAPIRequest)
 	require.NoError(t, err)
 
 	editedInvoice, err := svc.applyAPIInvoiceLineEdits(t.Context(), applyAPIInvoiceLineEditsInput{
@@ -418,7 +663,7 @@ func TestApplyManualInvoiceLineOverridesMarksManualChanges(t *testing.T) {
 	edited := invoice
 	edited.Lines = billing.NewStandardInvoiceLines(billing.StandardLines{updatedLine, createdLine})
 
-	lineDiff, err := svc.diffMutableInvoiceLines(invoice, edited, billing.ChangeSourceAPIRequest)
+	lineDiff, err := svc.diffMutableInvoiceLines(t.Context(), &invoice, &edited, billing.ChangeSourceAPIRequest)
 	require.NoError(t, err)
 
 	editedInvoice, err := svc.applyAPIInvoiceLineEdits(t.Context(), applyAPIInvoiceLineEditsInput{
@@ -469,7 +714,7 @@ func TestApplyManualInvoiceLineOverridesMarksManualDeletes(t *testing.T) {
 	edited := invoice
 	edited.Lines = billing.NewStandardInvoiceLines(billing.StandardLines{deletedLine})
 
-	lineDiff, err := svc.diffMutableInvoiceLines(invoice, edited, billing.ChangeSourceAPIRequest)
+	lineDiff, err := svc.diffMutableInvoiceLines(t.Context(), &invoice, &edited, billing.ChangeSourceAPIRequest)
 	require.NoError(t, err)
 
 	editedInvoice, err := svc.applyAPIInvoiceLineEdits(t.Context(), applyAPIInvoiceLineEditsInput{
@@ -530,7 +775,7 @@ func TestApplyManualInvoiceLineOverridesMarksGatheringManualChanges(t *testing.T
 	edited := invoice
 	edited.Lines = billing.NewGatheringInvoiceLines(billing.GatheringLines{updatedLine, createdLine})
 
-	lineDiff, err := svc.diffMutableInvoiceLines(invoice, edited, billing.ChangeSourceAPIRequest)
+	lineDiff, err := svc.diffMutableInvoiceLines(t.Context(), &invoice, &edited, billing.ChangeSourceAPIRequest)
 	require.NoError(t, err)
 
 	editedInvoice, err := svc.applyAPIInvoiceLineEdits(t.Context(), applyAPIInvoiceLineEditsInput{
@@ -577,6 +822,11 @@ func newStandardLineForLineEngineTest(id string, engine billing.LineEngineType, 
 				To:   now.Add(time.Hour),
 			},
 			InvoiceAt: now.Add(time.Hour),
+			TaxConfig: &billing.TaxConfig{
+				TaxConfig: productcatalog.TaxConfig{
+					TaxCodeID: lo.ToPtr(invoiceUpdateDefaultTaxCodeID),
+				},
+			},
 		},
 		UsageBased: &billing.UsageBasedLine{
 			Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
@@ -612,6 +862,9 @@ func newGatheringLineForLineEngineTest(id string, engine billing.LineEngineType,
 				To:   now.Add(time.Hour),
 			},
 			InvoiceAt: now.Add(time.Hour),
+			TaxConfig: &productcatalog.TaxConfig{
+				TaxCodeID: lo.ToPtr(invoiceUpdateDefaultTaxCodeID),
+			},
 			Price: *productcatalog.NewPriceFrom(productcatalog.FlatPrice{
 				Amount: alpacadecimal.NewFromInt(100),
 			}),
@@ -623,6 +876,128 @@ func genericLineIDs(lines []billing.GenericInvoiceLine) []string {
 	return lo.Map(lines, func(line billing.GenericInvoiceLine, _ int) string {
 		return line.GetID()
 	})
+}
+
+func standardInvoicePairForTaxConfigDiffTest(beforeTaxConfig, afterTaxConfig *billing.TaxConfig) (billing.StandardInvoice, billing.StandardInvoice) {
+	beforeLine := newStandardLineForLineEngineTest("line-1", billing.LineEngineTypeInvoice, false)
+	beforeLine.TaxConfig = cloneBillingTaxConfigForTest(beforeTaxConfig)
+
+	afterLine := newStandardLineForLineEngineTest("line-1", billing.LineEngineTypeInvoice, false)
+	afterLine.TaxConfig = cloneBillingTaxConfigForTest(afterTaxConfig)
+
+	invoice := billing.StandardInvoice{
+		StandardInvoiceBase: billing.StandardInvoiceBase{
+			Namespace:   "ns",
+			ID:          "invoice-1",
+			SchemaLevel: 1,
+			Workflow: billing.InvoiceWorkflow{
+				Config: billing.WorkflowConfig{
+					Invoicing: billing.InvoicingConfig{
+						DefaultTaxConfig: &productcatalog.TaxConfig{
+							TaxCodeID: lo.ToPtr(invoiceUpdateDefaultTaxCodeID),
+						},
+					},
+				},
+			},
+		},
+		Lines: billing.NewStandardInvoiceLines(billing.StandardLines{beforeLine}),
+	}
+
+	edited := invoice
+	edited.Lines = billing.NewStandardInvoiceLines(billing.StandardLines{afterLine})
+
+	return invoice, edited
+}
+
+func cloneBillingTaxConfigForTest(taxConfig *billing.TaxConfig) *billing.TaxConfig {
+	if taxConfig == nil {
+		return nil
+	}
+
+	cloned := taxConfig.Clone()
+	return &cloned
+}
+
+func serviceForInvoiceTaxConfigDiffTest() *Service {
+	return &Service{
+		lineEngines: newEngineRegistry(),
+		taxCodeService: &invoiceUpdateTaxCodeService{
+			taxCodes: map[string]taxcode.TaxCode{
+				invoiceUpdateDefaultTaxCodeID: {
+					NamespacedID: models.NamespacedID{
+						Namespace: "ns",
+						ID:        invoiceUpdateDefaultTaxCodeID,
+					},
+					Key:  taxcode.ProviderDefaultTaxCodeKey,
+					Name: "Default Tax Code",
+				},
+			},
+		},
+	}
+}
+
+var _ taxcode.Service = (*invoiceUpdateTaxCodeService)(nil)
+
+type invoiceUpdateTaxCodeService struct {
+	taxCodes map[string]taxcode.TaxCode
+}
+
+func (s *invoiceUpdateTaxCodeService) CreateTaxCode(context.Context, taxcode.CreateTaxCodeInput) (taxcode.TaxCode, error) {
+	return taxcode.TaxCode{}, errors.New("CreateTaxCode is not supported in this test")
+}
+
+func (s *invoiceUpdateTaxCodeService) UpdateTaxCode(context.Context, taxcode.UpdateTaxCodeInput) (taxcode.TaxCode, error) {
+	return taxcode.TaxCode{}, errors.New("UpdateTaxCode is not supported in this test")
+}
+
+func (s *invoiceUpdateTaxCodeService) ListTaxCodes(context.Context, taxcode.ListTaxCodesInput) (pagination.Result[taxcode.TaxCode], error) {
+	return pagination.Result[taxcode.TaxCode]{}, errors.New("ListTaxCodes is not supported in this test")
+}
+
+func (s *invoiceUpdateTaxCodeService) GetTaxCode(_ context.Context, input taxcode.GetTaxCodeInput) (taxcode.TaxCode, error) {
+	tc, ok := s.taxCodes[input.ID]
+	if !ok || tc.Namespace != input.Namespace {
+		return taxcode.TaxCode{}, taxcode.NewTaxCodeNotFoundError(input.ID)
+	}
+
+	return tc, nil
+}
+
+func (s *invoiceUpdateTaxCodeService) GetTaxCodeByKey(_ context.Context, input taxcode.GetTaxCodeByKeyInput) (taxcode.TaxCode, error) {
+	for _, tc := range s.taxCodes {
+		if tc.Namespace == input.Namespace && tc.Key == input.Key {
+			return tc, nil
+		}
+	}
+
+	return taxcode.TaxCode{}, taxcode.NewTaxCodeByKeyNotFoundError(input.Key)
+}
+
+func (s *invoiceUpdateTaxCodeService) GetTaxCodeByAppMapping(context.Context, taxcode.GetTaxCodeByAppMappingInput) (taxcode.TaxCode, error) {
+	return taxcode.TaxCode{}, errors.New("GetTaxCodeByAppMapping is not supported in this test")
+}
+
+func (s *invoiceUpdateTaxCodeService) GetOrCreateByAppMapping(_ context.Context, input taxcode.GetOrCreateByAppMappingInput) (taxcode.TaxCode, error) {
+	for _, tc := range s.taxCodes {
+		mapping, ok := tc.GetAppMapping(input.AppType)
+		if ok && mapping.TaxCode == input.TaxCode {
+			return tc, nil
+		}
+	}
+
+	return taxcode.TaxCode{}, taxcode.NewTaxCodeByAppMappingNotFoundError(string(input.AppType), input.TaxCode)
+}
+
+func (s *invoiceUpdateTaxCodeService) DeleteTaxCode(context.Context, taxcode.DeleteTaxCodeInput) error {
+	return errors.New("DeleteTaxCode is not supported in this test")
+}
+
+func (s *invoiceUpdateTaxCodeService) GetOrganizationDefaultTaxCodes(context.Context, taxcode.GetOrganizationDefaultTaxCodesInput) (taxcode.OrganizationDefaultTaxCodes, error) {
+	return taxcode.OrganizationDefaultTaxCodes{}, errors.New("GetOrganizationDefaultTaxCodes is not supported in this test")
+}
+
+func (s *invoiceUpdateTaxCodeService) UpsertOrganizationDefaultTaxCodes(context.Context, taxcode.UpsertOrganizationDefaultTaxCodesInput) (taxcode.OrganizationDefaultTaxCodes, error) {
+	return taxcode.OrganizationDefaultTaxCodes{}, errors.New("UpsertOrganizationDefaultTaxCodes is not supported in this test")
 }
 
 type preallocatingInvoiceLineAdapter struct {

--- a/openmeter/billing/service/stdinvoice.go
+++ b/openmeter/billing/service/stdinvoice.go
@@ -33,7 +33,7 @@ func (s *Service) UpdateStandardInvoice(ctx context.Context, input billing.Updat
 				return fmt.Errorf("editing invoice: %w", err)
 			}
 
-			lineDiff, err := s.diffMutableInvoiceLines(originalInvoice, sm.Invoice, input.ChangeSource)
+			lineDiff, err := s.diffMutableInvoiceLines(ctx, originalInvoice, sm.Invoice, input.ChangeSource)
 			if err != nil {
 				return billing.ValidationError{
 					Err: fmt.Errorf("collecting mutable invoice line changes: %w", err),

--- a/openmeter/billing/worker/subscriptionsync/service/sync_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_test.go
@@ -3271,6 +3271,7 @@ func (s *SubscriptionHandlerTestSuite) TestGatheringManualEditSync() {
 
 	s.NoError(err)
 	s.DebugDumpInvoice("edited invoice", editedInvoice)
+	updatedLine = *s.getGatheringLineByChildID(editedInvoice, *updatedLine.ChildUniqueReferenceID)
 
 	// When resyncing the subscription
 	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-01-05T12:00:00Z")))

--- a/openmeter/productcatalog/tax_test.go
+++ b/openmeter/productcatalog/tax_test.go
@@ -683,6 +683,10 @@ func (s *stubTaxCodeService) GetTaxCode(ctx context.Context, input taxcode.GetTa
 	return s.getTaxCode(ctx, input)
 }
 
+func (s *stubTaxCodeService) GetTaxCodeByKey(_ context.Context, _ taxcode.GetTaxCodeByKeyInput) (taxcode.TaxCode, error) {
+	panic("not implemented")
+}
+
 func (s *stubTaxCodeService) GetOrCreateByAppMapping(ctx context.Context, input taxcode.GetOrCreateByAppMappingInput) (taxcode.TaxCode, error) {
 	return s.getOrCreateByAppMapping(ctx, input)
 }

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -2027,6 +2027,10 @@ func (n NoopTaxCodeService) GetTaxCode(ctx context.Context, input taxcode.GetTax
 	return taxcode.TaxCode{}, nil
 }
 
+func (n NoopTaxCodeService) GetTaxCodeByKey(ctx context.Context, input taxcode.GetTaxCodeByKeyInput) (taxcode.TaxCode, error) {
+	return taxcode.TaxCode{}, nil
+}
+
 func (n NoopTaxCodeService) DeleteTaxCode(ctx context.Context, input taxcode.DeleteTaxCodeInput) error {
 	return nil
 }

--- a/openmeter/taxcode/adapter/taxcode.go
+++ b/openmeter/taxcode/adapter/taxcode.go
@@ -129,6 +129,30 @@ func (a *adapter) GetTaxCode(ctx context.Context, input taxcode.GetTaxCodeInput)
 	})
 }
 
+func (a *adapter) GetTaxCodeByKey(ctx context.Context, input taxcode.GetTaxCodeByKeyInput) (taxcode.TaxCode, error) {
+	if err := input.Validate(); err != nil {
+		return taxcode.TaxCode{}, err
+	}
+
+	return entutils.TransactingRepo(ctx, a, func(ctx context.Context, a *adapter) (taxcode.TaxCode, error) {
+		query := a.db.TaxCode.Query().
+			Where(taxcodedb.Namespace(input.Namespace)).
+			Where(taxcodedb.Key(input.Key)).
+			Where(taxcodedb.DeletedAtIsNil())
+
+		entity, err := query.Only(ctx)
+		if err != nil {
+			if db.IsNotFound(err) {
+				return taxcode.TaxCode{}, taxcode.NewTaxCodeByKeyNotFoundError(input.Key)
+			}
+
+			return taxcode.TaxCode{}, fmt.Errorf("failed to get tax code by key: %w", err)
+		}
+
+		return MapTaxCodeFromEntity(entity)
+	})
+}
+
 func (a *adapter) GetTaxCodeByAppMapping(ctx context.Context, input taxcode.GetTaxCodeByAppMappingInput) (taxcode.TaxCode, error) {
 	if err := input.Validate(); err != nil {
 		return taxcode.TaxCode{}, err

--- a/openmeter/taxcode/errors.go
+++ b/openmeter/taxcode/errors.go
@@ -72,6 +72,12 @@ func NewTaxCodeNotFoundError(id string) error {
 		WithAttr("id", id)
 }
 
+func NewTaxCodeByKeyNotFoundError(key string) error {
+	return ErrTaxCodeNotFound.
+		WithPathString("key").
+		WithAttr("key", key)
+}
+
 func NewTaxCodeByAppMappingNotFoundError(appType, taxCode string) error {
 	return ErrTaxCodeNotFound.
 		WithPathString("app_mappings").

--- a/openmeter/taxcode/namespacehandler_test.go
+++ b/openmeter/taxcode/namespacehandler_test.go
@@ -19,7 +19,7 @@ import (
 func makeTestSeeds() []taxcode.SeedEntry {
 	return []taxcode.SeedEntry{
 		{
-			Key:              "default",
+			Key:              taxcode.ProviderDefaultTaxCodeKey,
 			Name:             "Default Tax",
 			DefaultInvoicing: true,
 		},
@@ -91,7 +91,7 @@ func TestNamespaceHandler(t *testing.T) {
 		// Pre-seed a "default" tax code with a different name and no annotations.
 		preExisting, err := env.Service.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
 			Namespace: ns,
-			Key:       "default",
+			Key:       taxcode.ProviderDefaultTaxCodeKey,
 			Name:      "Pre-Existing Default",
 		})
 		require.NoError(t, err)
@@ -140,7 +140,7 @@ func TestNamespaceHandler(t *testing.T) {
 		// Pre-seed both tax codes and a complete org defaults row.
 		defaultTC, err := env.Service.CreateTaxCode(t.Context(), taxcode.CreateTaxCodeInput{
 			Namespace: ns,
-			Key:       "default",
+			Key:       taxcode.ProviderDefaultTaxCodeKey,
 			Name:      "Default Tax",
 			Annotations: models.Annotations{
 				taxcode.AnnotationKeyManagedBy: taxcode.AnnotationValueManagedBySystem,

--- a/openmeter/taxcode/repository.go
+++ b/openmeter/taxcode/repository.go
@@ -14,6 +14,7 @@ type Repository interface {
 	UpdateTaxCode(ctx context.Context, input UpdateTaxCodeInput) (TaxCode, error)
 	ListTaxCodes(ctx context.Context, input ListTaxCodesInput) (pagination.Result[TaxCode], error)
 	GetTaxCode(ctx context.Context, input GetTaxCodeInput) (TaxCode, error)
+	GetTaxCodeByKey(ctx context.Context, input GetTaxCodeByKeyInput) (TaxCode, error)
 	GetTaxCodeByAppMapping(ctx context.Context, input GetTaxCodeByAppMappingInput) (TaxCode, error)
 	DeleteTaxCode(ctx context.Context, input DeleteTaxCodeInput) error
 

--- a/openmeter/taxcode/service.go
+++ b/openmeter/taxcode/service.go
@@ -19,6 +19,7 @@ type TaxCodeService interface {
 	UpdateTaxCode(ctx context.Context, input UpdateTaxCodeInput) (TaxCode, error)
 	ListTaxCodes(ctx context.Context, input ListTaxCodesInput) (pagination.Result[TaxCode], error)
 	GetTaxCode(ctx context.Context, input GetTaxCodeInput) (TaxCode, error)
+	GetTaxCodeByKey(ctx context.Context, input GetTaxCodeByKeyInput) (TaxCode, error)
 	GetTaxCodeByAppMapping(ctx context.Context, input GetTaxCodeByAppMappingInput) (TaxCode, error)
 	GetOrCreateByAppMapping(ctx context.Context, input GetOrCreateByAppMappingInput) (TaxCode, error)
 	DeleteTaxCode(ctx context.Context, input DeleteTaxCodeInput) error
@@ -38,6 +39,7 @@ var (
 	_ models.Validator = (*UpdateTaxCodeInput)(nil)
 	_ models.Validator = (*ListTaxCodesInput)(nil)
 	_ models.Validator = (*GetTaxCodeInput)(nil)
+	_ models.Validator = (*GetTaxCodeByKeyInput)(nil)
 	_ models.Validator = (*GetTaxCodeByAppMappingInput)(nil)
 	_ models.Validator = (*GetOrCreateByAppMappingInput)(nil)
 	_ models.Validator = (*DeleteTaxCodeInput)(nil)
@@ -141,6 +143,25 @@ func (i GetTaxCodeInput) Validate() error {
 	var errs []error
 	if err := i.NamespacedID.Validate(); err != nil {
 		errs = append(errs, err)
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+type GetTaxCodeByKeyInput struct {
+	Namespace string
+	Key       string
+}
+
+func (i GetTaxCodeByKeyInput) Validate() error {
+	var errs []error
+
+	if i.Namespace == "" {
+		errs = append(errs, ErrResourceNamespaceEmpty)
+	}
+
+	if i.Key == "" {
+		errs = append(errs, ErrResourceKeyEmpty)
 	}
 
 	return models.NewNillableGenericValidationError(errors.Join(errs...))

--- a/openmeter/taxcode/service/taxcode.go
+++ b/openmeter/taxcode/service/taxcode.go
@@ -59,6 +59,16 @@ func (s *Service) GetTaxCode(ctx context.Context, input taxcode.GetTaxCodeInput)
 	})
 }
 
+func (s *Service) GetTaxCodeByKey(ctx context.Context, input taxcode.GetTaxCodeByKeyInput) (taxcode.TaxCode, error) {
+	if err := input.Validate(); err != nil {
+		return taxcode.TaxCode{}, err
+	}
+
+	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (taxcode.TaxCode, error) {
+		return s.adapter.GetTaxCodeByKey(ctx, input)
+	})
+}
+
 func (s *Service) GetTaxCodeByAppMapping(ctx context.Context, input taxcode.GetTaxCodeByAppMappingInput) (taxcode.TaxCode, error) {
 	if err := input.Validate(); err != nil {
 		return taxcode.TaxCode{}, err

--- a/openmeter/taxcode/service/taxcode_test.go
+++ b/openmeter/taxcode/service/taxcode_test.go
@@ -21,6 +21,21 @@ func TestTaxCodeService(t *testing.T) {
 	ns := testutils.NameGenerator.Generate().Key
 	env.SetupNamespaceDefaults(t, ns)
 
+	t.Run("GetByKey", func(t *testing.T) {
+		// given:
+		// - namespace defaults have seeded the provider-default tax code
+		// when:
+		// - resolving by the stable provider default key
+		// then:
+		// - the seeded tax code is returned
+		got, err := env.Service.GetTaxCodeByKey(t.Context(), taxcode.GetTaxCodeByKeyInput{
+			Namespace: ns,
+			Key:       taxcode.ProviderDefaultTaxCodeKey,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, taxcode.ProviderDefaultTaxCodeKey, got.Key)
+	})
+
 	t.Run("SystemManaged", func(t *testing.T) {
 		// Create a system-managed tax code by explicitly setting the annotation.
 		name := testutils.NameGenerator.Generate()

--- a/openmeter/taxcode/taxcode.go
+++ b/openmeter/taxcode/taxcode.go
@@ -12,6 +12,8 @@ import (
 
 var TaxCodeStripeRegexp = regexp.MustCompile(`^txcd_\d{8}$`)
 
+const ProviderDefaultTaxCodeKey = "default"
+
 // TaxCodeAppMapping represents a mapping of an app type to a tax code.
 type TaxCodeAppMapping struct {
 	AppType app.AppType `json:"app_type"`

--- a/openmeter/taxcode/testutils/env.go
+++ b/openmeter/taxcode/testutils/env.go
@@ -82,6 +82,7 @@ func (e *TestEnv) CreateTaxCode(t *testing.T, namespace string, opts ...taxcode.
 func (e *TestEnv) SetupNamespaceDefaults(t *testing.T, namespace string) {
 	t.Helper()
 	invoicing := e.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{
+		Key:  taxcode.ProviderDefaultTaxCodeKey,
 		Name: "Provider Default",
 	})
 	creditGrant := e.CreateTaxCode(t, namespace, taxcode.CreateTaxCodeInput{

--- a/test/app/stripe/invoice_test.go
+++ b/test/app/stripe/invoice_test.go
@@ -1201,6 +1201,7 @@ func (s *StripeInvoiceTestSuite) TestEmptyInvoiceGenerationZeroUsage() {
 		// manual advancement for testing the update invoice flow
 		profile.WorkflowConfig.Invoicing.AutoAdvance = false
 	}))
+	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
 
 	// Setup the app with the customer
 

--- a/test/billing/collection_test.go
+++ b/test/billing/collection_test.go
@@ -386,6 +386,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithFlatFeeEditing() {
 
 	res := s.setupNS(ctx, namespace)
 	defer res.Cleanup()
+	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
 
 	customer := res.customer
 	apiRequestsTotalFeature := res.TestFeature
@@ -742,6 +743,7 @@ func (s *CollectionTestSuite) TestCollectionFlowWithUBPEditingExtendingCollectio
 
 	res := s.setupNS(ctx, namespace)
 	defer res.Cleanup()
+	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
 
 	customer := res.customer
 	apiRequestsTotalFeature := res.TestFeature

--- a/test/billing/discount_test.go
+++ b/test/billing/discount_test.go
@@ -36,6 +36,7 @@ func (s *DiscountsTestSuite) TestCorrelationIDHandling() {
 	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
 
 	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), WithProgressiveBilling())
+	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
 
 	customerEntity := s.CreateTestCustomer(namespace, "test-customer")
 	s.NotNil(customerEntity)

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -924,6 +924,7 @@ func (s *InvoicingTestSuite) TestInvoicingFlow() {
 			s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), WithBillingProfileEditFn(func(profile *billing.CreateProfileInput) {
 				profile.WorkflowConfig = tc.workflowConfig
 			}))
+			s.ProvisionProviderDefaultTaxCode(ctx, namespace)
 
 			invoice := s.CreateDraftInvoice(s.T(), ctx, DraftInvoiceInput{
 				Namespace: namespace,
@@ -1579,6 +1580,7 @@ func (s *InvoicingTestSuite) TestUBPProgressiveInvoicing() {
 
 	// Given we have a default profile for the namespace
 	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID(), WithProgressiveBilling())
+	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
 
 	lines := ubpPendingLines{}
 	s.Run("create pending invoice items", func() {
@@ -4457,6 +4459,7 @@ func (s *InvoicingTestSuite) TestUpdateInvoice() {
 			},
 		}
 	}))
+	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
 
 	s.Run("gathering invoice", func() {
 		var gatheringInvoiceID billing.InvoiceID

--- a/test/billing/suite.go
+++ b/test/billing/suite.go
@@ -679,19 +679,8 @@ func (s *BaseSuite) SeedProfileDefaultTaxConfigViaAdapter(ctx context.Context, p
 func (s *BaseSuite) ProvisionDefaultTaxCodes(ctx context.Context, ns string) taxcode.OrganizationDefaultTaxCodes {
 	s.T().Helper()
 
-	invoicing, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: ns,
-		Key:       "default-invoicing",
-		Name:      "Default Invoicing",
-	})
-	s.Require().NoError(err, "creating default invoicing tax code")
-
-	creditGrant, err := s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
-		Namespace: ns,
-		Key:       "default-credit-grant",
-		Name:      "Default Credit Grant",
-	})
-	s.Require().NoError(err, "creating default credit grant tax code")
+	invoicing := s.ProvisionProviderDefaultTaxCode(ctx, ns)
+	creditGrant := s.getOrCreateTaxCodeByKey(ctx, ns, "default-credit-grant", "Default Credit Grant")
 
 	defaults, err := s.TaxCodeService.UpsertOrganizationDefaultTaxCodes(ctx, taxcode.UpsertOrganizationDefaultTaxCodesInput{
 		Namespace:            ns,
@@ -700,6 +689,40 @@ func (s *BaseSuite) ProvisionDefaultTaxCodes(ctx context.Context, ns string) tax
 	})
 	s.Require().NoError(err, "upserting organization default tax codes")
 	return defaults
+}
+
+// ProvisionProviderDefaultTaxCode creates the tax code used when an invoicing app
+// omits an app-specific provider code. This is distinct from organization default
+// tax-code settings: API invoice edit diffing needs the provider-default tax code
+// row to resolve empty provider tax config, but it must not imply that the
+// namespace has configured org-level default tax codes.
+func (s *BaseSuite) ProvisionProviderDefaultTaxCode(ctx context.Context, ns string) taxcode.TaxCode {
+	s.T().Helper()
+
+	return s.getOrCreateTaxCodeByKey(ctx, ns, taxcode.ProviderDefaultTaxCodeKey, "Provider Default")
+}
+
+func (s *BaseSuite) getOrCreateTaxCodeByKey(ctx context.Context, ns string, key string, name string) taxcode.TaxCode {
+	s.T().Helper()
+
+	taxCode, err := s.TaxCodeService.GetTaxCodeByKey(ctx, taxcode.GetTaxCodeByKeyInput{
+		Namespace: ns,
+		Key:       key,
+	})
+	if err == nil {
+		return taxCode
+	}
+
+	s.Require().True(taxcode.IsTaxCodeNotFoundError(err), "getting tax code by key should either succeed or return not found")
+
+	taxCode, err = s.TaxCodeService.CreateTaxCode(ctx, taxcode.CreateTaxCodeInput{
+		Namespace: ns,
+		Key:       key,
+		Name:      name,
+	})
+	s.Require().NoError(err, "creating tax code")
+
+	return taxCode
 }
 
 type SetupCustomInvoicingResponse struct {

--- a/test/billing/tax_test.go
+++ b/test/billing/tax_test.go
@@ -122,6 +122,7 @@ func (s *InvoicingTaxTestSuite) TestDefaultTaxConfigProfileSnapshotting() {
 
 		draftInvoice := s.generateDraftInvoice(ctx, cust)
 		s.Nil(draftInvoice.Workflow.Config.Invoicing.DefaultTaxConfig)
+		s.ProvisionProviderDefaultTaxCode(ctx, namespace)
 
 		// let's update the invoice
 		updatedInvoice, err := s.BillingService.UpdateStandardInvoice(ctx, billing.UpdateStandardInvoiceInput{


### PR DESCRIPTION
## Overview

Fix invoice editing for charge-backed lines whose tax config is represented by provider-default omission in API edit payloads.

For API-originated invoice edits, billing now normalizes both the persisted invoice and the edited invoice before line diffing. Nil or identity-less tax configs are resolved to the namespace provider-default tax code, explicit provider codes are resolved to `TaxCodeID`, and API diff equality compares only tax behavior and resolved `TaxCodeID`. This prevents unrelated invoice edits from being interpreted as tax-code edits while keeping charge-managed tax config immutable.

System-originated edits continue to use full `TaxConfig.Equal`, so resolved tax-code snapshots are not ignored outside the API edit path.

## Changes

- Normalize invoice-line tax configs before API edit diffing, including provider-default lookup by `taxcode.ProviderDefaultTaxCodeKey`.
- Keep the diff-specific tax config equality scoped to `ChangeSourceAPIRequest`; system edits use full tax config equality.
- Add tax-code service lookup support by key and seed the provider-default tax code where e2e/local fixtures exercise API invoice edits with omitted tax config.
- Add unit coverage for provider-default resolution, explicit provider-code resolution, API-vs-system diff behavior, and unresolved tax-code validation.
- Extend the invoice edit e2e scenario to reproduce the staging shape: the line has a defaulted tax code, the edit payload omits it, and the edit applies a discount.

## Validation

- `env POSTGRES_HOST=127.0.0.1 make test-nocache`
- `make etoe`
- `direnv exec . make lint-go-fast`
- Focused billing/Stripe/notification tests while iterating:
  - `env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic -count=1 ./test/billing`
  - `env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic -count=1 -run TestStripeInvoicing/TestEmptyInvoiceGenerationZeroUsage ./test/app/stripe`
  - `env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic -count=1 ./test/notification`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving tax codes by key, including the provider default tax code.
  * Default tax code handling is now consistent across billing flows and test setups.

* **Bug Fixes**
  * Invoice line edits now handle defaulted tax codes more reliably.
  * Tax configuration comparisons during invoice updates now better preserve expected editable values while avoiding unnecessary changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->