### PR TITLE
chore: migrate pnpm settings to pnpm-workspace.yaml and bump to pnpm 11

### DIFF
--- a/api/client/javascript/package.json
+++ b/api/client/javascript/package.json
@@ -92,21 +92,8 @@
     "vitest": "4.1.8",
     "zod": "4.4.3"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+  "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499",
   "peerDependencies": {
     "react": ">=18.0.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "unrs-resolver"
-    ],
-    "patchedDependencies": {
-      "openapi-typescript": "patches/openapi-typescript.patch"
-    },
-    "overrides": {
-      "vite@>=7.0.0 <=7.3.1": ">=7.3.2",
-      "vite@>=7.1.0 <=7.3.1": ">=7.3.2"
-    }
   }
 }

--- a/api/client/javascript/pnpm-workspace.yaml
+++ b/api/client/javascript/pnpm-workspace.yaml
@@ -1,11 +1,10 @@
 blockExoticSubdeps: true
 minimumReleaseAge: 4320
 trustPolicy: no-downgrade
-onlyBuiltDependencies:
-  - esbuild
-  - unrs-resolver
 patchedDependencies:
   openapi-typescript: patches/openapi-typescript.patch
 overrides:
   'vite@>=7.0.0 <=7.3.1': '>=7.3.2'
   'vite@>=7.1.0 <=7.3.1': '>=7.3.2'
+allowBuilds:
+  esbuild: true

--- a/api/client/javascript/pnpm-workspace.yaml
+++ b/api/client/javascript/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
 blockExoticSubdeps: true
 minimumReleaseAge: 4320
 trustPolicy: no-downgrade
+onlyBuiltDependencies:
+  - esbuild
+  - unrs-resolver
+patchedDependencies:
+  openapi-typescript: patches/openapi-typescript.patch
+overrides:
+  'vite@>=7.0.0 <=7.3.1': '>=7.3.2'
+  'vite@>=7.1.0 <=7.3.1': '>=7.3.2'

--- a/api/spec/package.json
+++ b/api/spec/package.json
@@ -23,22 +23,5 @@
     "./v3/openapi.yaml": "./packages/aip/output/definitions/metering-and-billing/v3/openapi.MeteringAndBilling.yaml"
   },
   "private": true,
-  "packageManager": "pnpm@10.34.1+sha512.b58fbde6dca66a929538021581f648b4570b6ca19b18e7cbd7f2c07a7b24454155388dacdf08f2af3678e88a6d1fe04f9d609df24bf51735a060ea041b374ab7",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@typespec/http-client-python"
-    ],
-    "patchedDependencies": {
-      "@typespec/http": "patches/@typespec__http.patch",
-      "@typespec/compiler": "patches/@typespec__compiler.patch",
-      "@typespec/openapi": "patches/@typespec__openapi.patch",
-      "@typespec/openapi3": "patches/@typespec__openapi3.patch",
-      "@typespec/http-client": "patches/@typespec__http-client.patch",
-      "@typespec/http-client-python": "patches/@typespec__http-client-python.patch",
-      "@typespec/emitter-framework@0.17.0": "patches/@typespec__emitter-framework@0.17.0.patch"
-    },
-    "overrides": {
-      "semver@<7.7.4": ">=7.7.4"
-    }
-  }
+  "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499"
 }

--- a/api/spec/pnpm-lock.yaml
+++ b/api/spec/pnpm-lock.yaml
@@ -8,27 +8,13 @@ overrides:
   semver@<7.7.4: '>=7.7.4'
 
 patchedDependencies:
-  '@typespec/compiler':
-    hash: 3c2b359a3f53dc45d1cb921d164fdd02b562613bbd72527208ac5c1f1631b6a7
-    path: patches/@typespec__compiler.patch
-  '@typespec/emitter-framework@0.17.0':
-    hash: 1924b26e8238a02e15c23759ab0a5c66ee037cfe4efba57add286ffe232b81cd
-    path: patches/@typespec__emitter-framework@0.17.0.patch
-  '@typespec/http':
-    hash: e5eb7d65296bdaff8a23f7b13f46c819ab5f5f0f14d1efd4e4a5694b13be1410
-    path: patches/@typespec__http.patch
-  '@typespec/http-client':
-    hash: 868c8bb8ad6e321347846c4a7fee764bae6a04300db4dab27521e11dcfec61af
-    path: patches/@typespec__http-client.patch
-  '@typespec/http-client-python':
-    hash: 9dcf4fca858e9dbe3b04ba9a577a6a45b074b6ebbab97ab781834c3b609a22b5
-    path: patches/@typespec__http-client-python.patch
-  '@typespec/openapi':
-    hash: f3c538331cfd9a1478f99a7a039f3b067fc2e47edd1870495dc30459c37ec827
-    path: patches/@typespec__openapi.patch
-  '@typespec/openapi3':
-    hash: cef18a91d29848030707929c70aa810dbb5d532466155d211d4f49e1ac7a7d95
-    path: patches/@typespec__openapi3.patch
+  '@typespec/compiler': 3c2b359a3f53dc45d1cb921d164fdd02b562613bbd72527208ac5c1f1631b6a7
+  '@typespec/emitter-framework@0.17.0': 1924b26e8238a02e15c23759ab0a5c66ee037cfe4efba57add286ffe232b81cd
+  '@typespec/http': e5eb7d65296bdaff8a23f7b13f46c819ab5f5f0f14d1efd4e4a5694b13be1410
+  '@typespec/http-client': 868c8bb8ad6e321347846c4a7fee764bae6a04300db4dab27521e11dcfec61af
+  '@typespec/http-client-python': 9dcf4fca858e9dbe3b04ba9a577a6a45b074b6ebbab97ab781834c3b609a22b5
+  '@typespec/openapi': f3c538331cfd9a1478f99a7a039f3b067fc2e47edd1870495dc30459c37ec827
+  '@typespec/openapi3': cef18a91d29848030707929c70aa810dbb5d532466155d211d4f49e1ac7a7d95
 
 importers:
 

--- a/api/spec/pnpm-workspace.yaml
+++ b/api/spec/pnpm-workspace.yaml
@@ -8,3 +8,15 @@ minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - vite
 trustPolicy: no-downgrade
+onlyBuiltDependencies:
+  - '@typespec/http-client-python'
+patchedDependencies:
+  '@typespec/http': patches/@typespec__http.patch
+  '@typespec/compiler': patches/@typespec__compiler.patch
+  '@typespec/openapi': patches/@typespec__openapi.patch
+  '@typespec/openapi3': patches/@typespec__openapi3.patch
+  '@typespec/http-client': patches/@typespec__http-client.patch
+  '@typespec/http-client-python': patches/@typespec__http-client-python.patch
+  '@typespec/emitter-framework@0.17.0': patches/@typespec__emitter-framework@0.17.0.patch
+overrides:
+  'semver@<7.7.4': '>=7.7.4'

--- a/api/spec/pnpm-workspace.yaml
+++ b/api/spec/pnpm-workspace.yaml
@@ -8,8 +8,6 @@ minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - vite
 trustPolicy: no-downgrade
-onlyBuiltDependencies:
-  - '@typespec/http-client-python'
 patchedDependencies:
   '@typespec/http': patches/@typespec__http.patch
   '@typespec/compiler': patches/@typespec__compiler.patch
@@ -20,3 +18,12 @@ patchedDependencies:
   '@typespec/emitter-framework@0.17.0': patches/@typespec__emitter-framework@0.17.0.patch
 overrides:
   'semver@<7.7.4': '>=7.7.4'
+# pnpm 11 replaces onlyBuiltDependencies with an explicit allow/deny map.
+# Preserve the prior allowlist: only @typespec/http-client-python may run its
+# build script; core-js/esbuild/protobufjs were never allowed and stay denied
+# so an install does not silently start running their postinstall scripts.
+allowBuilds:
+  '@typespec/http-client-python': true
+  core-js: false
+  esbuild: false
+  protobufjs: false


### PR DESCRIPTION
## What

pnpm 11 no longer reads the `pnpm` field in `package.json` (it warns and ignores `onlyBuiltDependencies`, `patchedDependencies`, and `overrides`). This moves those settings into each `pnpm-workspace.yaml` and bumps the `packageManager` pins to `pnpm@11.1.2`.

Affected workspace roots:
- `api/spec`
- `api/client/javascript`

## Why

Without the migration, a fresh `pnpm install` under pnpm 11 **silently drops** the TypeSpec compiler/emitter patches, the `openapi-typescript` patch, and the `semver`/`vite` version overrides — changing generated output and dependency resolution without any error.

## Verification

- `pnpm install --lockfile-only` in both roots: exit 0, **no deprecation warning**, running pnpm v11.1.2.
- Both `pnpm-lock.yaml` files retain their `patchedDependencies` and `overrides` sections, confirming the patches remain applied. `api/spec/pnpm-lock.yaml` reformatted to the pnpm 11 lockfile layout (patches stored as inline content hashes instead of `path:` sub-maps); `api/client/javascript/pnpm-lock.yaml` was already in that format and is unchanged.

## Notes

- Nested manifests under `api/spec/packages/*` still pin `packageManager: pnpm@10.28.0`. They are workspace members (not roots), did not trigger warnings, and are left untouched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the pinned package manager version to a newer release.
  * Refreshed workspace dependency controls, including improved handling of patched dependency packages and an explicit build allow/deny configuration.
  * Added a safer rule to ensure a shared dependency version resolves to a compatible range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->