### PR TITLE
fix(ledger): prioritize free grants in collection

### DIFF
--- a/openmeter/ledger/annotations.go
+++ b/openmeter/ledger/annotations.go
@@ -14,13 +14,14 @@ const (
 	AnnotationSubscriptionItemID  = "ledger.subscription.item.id"
 	AnnotationFeatureID           = "ledger.feature.id"
 
-	AnnotationTransactionTemplateCode = "ledger.transaction.template_code"
-	AnnotationTransactionDirection    = "ledger.transaction.direction"
-	AnnotationCollectionType          = "ledger.collection.type"
-	AnnotationCollectionSourceOrder   = "ledger.collection.source_order"
-	AnnotationBreakageKind            = "ledger.breakage.kind"
-	AnnotationBreakageRecordID        = "ledger.breakage.record_id"
-	AnnotationBreakagePlanID          = "ledger.breakage.plan_id"
+	AnnotationTransactionTemplateCode   = "ledger.transaction.template_code"
+	AnnotationTransactionDirection      = "ledger.transaction.direction"
+	AnnotationCollectionType            = "ledger.collection.type"
+	AnnotationCollectionSourceOrder     = "ledger.collection.source_order"
+	AnnotationCollectionPriorityVersion = "ledger.collection.priority_version"
+	AnnotationBreakageKind              = "ledger.breakage.kind"
+	AnnotationBreakageRecordID          = "ledger.breakage.record_id"
+	AnnotationBreakagePlanID            = "ledger.breakage.plan_id"
 )
 
 type ChargeTransactionAnnotationsInput struct {

--- a/openmeter/ledger/collector/collection_fbo.go
+++ b/openmeter/ledger/collector/collection_fbo.go
@@ -320,5 +320,5 @@ func customerFBOPriority(route ledger.Route) int {
 }
 
 func freeCostBasis(costBasis *alpacadecimal.Decimal) bool {
-	return costBasis != nil && costBasis.IsZero()
+	return costBasis == nil || costBasis.IsZero()
 }

--- a/openmeter/ledger/collector/collection_fbo.go
+++ b/openmeter/ledger/collector/collection_fbo.go
@@ -115,6 +115,7 @@ func (c *accrualCollector) mapBreakagePlansToFBOCollectionSources(
 				sourceChargeID:    reservedSource.sourceChargeID,
 				available:         reservedSource.available,
 				creditPriority:    plan.CreditPriority,
+				freeCostBasis:     freeCostBasis(route.CostBasis),
 				featureRestricted: len(route.Features) > 0,
 				expiresAt:         &expiresAt,
 				cursor:            plan.ID.ID + ":" + reservedSource.cursor,
@@ -198,6 +199,7 @@ func (c *accrualCollector) listCustomerFBOBalanceBucketSources(
 			sourceChargeID:    bucket.GroupByValues[ledger.BalanceBucketGroupBySourceChargeID],
 			available:         bucket.SettledAmount,
 			creditPriority:    customerFBOPriority(route),
+			freeCostBasis:     freeCostBasis(route.CostBasis),
 			featureRestricted: len(route.Features) > 0,
 			cursor:            fboBalanceBucketCursor(bucket),
 		}
@@ -315,4 +317,8 @@ func customerFBOPriority(route ledger.Route) int {
 	}
 
 	return *route.CreditPriority
+}
+
+func freeCostBasis(costBasis *alpacadecimal.Decimal) bool {
+	return costBasis != nil && costBasis.IsZero()
 }

--- a/openmeter/ledger/collector/collection_fbo_test.go
+++ b/openmeter/ledger/collector/collection_fbo_test.go
@@ -184,6 +184,49 @@ func TestCollectCustomerFBOUsesPriorityBeforeFeatureRestriction(t *testing.T) {
 	require.True(t, alpacadecimal.NewFromInt(30).Equal(sources[1].Amount), "lower-priority restricted amount: %s", sources[1].Amount)
 }
 
+func TestCollectCustomerFBOUsesFreeCostBasisBeforePaidTieBreaker(t *testing.T) {
+	env := ledgertestutils.NewIntegrationEnv(t, "collector")
+	breakageService := newTestBreakageService(t, env)
+	collector := newTestAccrualCollectorWithBreakage(env, breakageService)
+
+	// given:
+	// - same-priority free and paid credit sources
+	// - paid credit has the earlier expiration and was created first
+	// when:
+	// - collection consumes less than the free source amount
+	// then:
+	// - free cost-basis credit is consumed before the paid source
+	priority := 1
+	freeCostBasis := alpacadecimal.Zero
+	paidCostBasis := alpacadecimal.NewFromInt(1)
+	freeSourceCharge := testChargeID(1)
+	paidSourceCharge := testChargeID(2)
+	spendCharge := testChargeID(3)
+	spendAmount := int64(5)
+
+	bookExpiringCreditWithCostBasis(t, env, breakageService, priority, 10, &paidCostBasis, nil, &paidSourceCharge, env.Now().Add(10*time.Hour))
+	bookExpiringCreditWithCostBasis(t, env, breakageService, priority, 15, &freeCostBasis, nil, &freeSourceCharge, env.Now().Add(15*time.Hour))
+
+	allocations, err := collector.collect(t.Context(), collectToAccruedInputForTest(
+		env,
+		spendCharge,
+		alpacadecimal.NewFromInt(spendAmount),
+		productcatalog.CreditThenInvoiceSettlementMode,
+	))
+	require.NoError(t, err)
+	require.Len(t, allocations, 1)
+	require.Equal(t, float64(spendAmount), allocations[0].Amount.InexactFloat64())
+
+	requireAccruedBalanceBuckets(t, env, map[string]float64{
+		sourceSpendChargeKey(&freeSourceCharge, &spendCharge): float64(spendAmount),
+	})
+	requireFBOBalanceBuckets(t, env, map[string]float64{})
+	requireBreakageBalanceBuckets(t, env, map[string]float64{
+		sourceSpendChargeKey(&paidSourceCharge, nil): 10,
+		sourceSpendChargeKey(&freeSourceCharge, nil): 10,
+	})
+}
+
 func TestCollectCustomerFBOReleasesBreakageInExpiryOrder(t *testing.T) {
 	env := ledgertestutils.NewIntegrationEnv(t, "collector")
 	breakageService := newTestBreakageService(t, env)
@@ -771,6 +814,22 @@ func bookExpiringCreditWithFeatures(
 ) string {
 	t.Helper()
 
+	return bookExpiringCreditWithCostBasis(t, env, breakageService, priority, amount, nil, features, sourceChargeID, expiresAt)
+}
+
+func bookExpiringCreditWithCostBasis(
+	t *testing.T,
+	env *ledgertestutils.IntegrationEnv,
+	breakageService ledgerbreakage.Service,
+	priority int,
+	amount int64,
+	costBasis *alpacadecimal.Decimal,
+	features []string,
+	sourceChargeID *string,
+	expiresAt time.Time,
+) string {
+	t.Helper()
+
 	creditAmount := alpacadecimal.NewFromInt(amount)
 	inputs, err := transactions.ResolveTransactions(
 		t.Context(),
@@ -787,6 +846,7 @@ func bookExpiringCreditWithFeatures(
 			At:             env.Now(),
 			Amount:         creditAmount,
 			Currency:       env.Currency,
+			CostBasis:      costBasis,
 			SourceChargeID: sourceChargeID,
 			CreditPriority: &priority,
 			Features:       features,
@@ -799,6 +859,7 @@ func bookExpiringCreditWithFeatures(
 		Amount:         creditAmount,
 		Currency:       env.Currency,
 		CreditPriority: &priority,
+		CostBasis:      costBasis,
 		Features:       features,
 		ExpiresAt:      expiresAt,
 		SourceChargeID: sourceChargeID,

--- a/openmeter/ledger/collector/collection_fbo_test.go
+++ b/openmeter/ledger/collector/collection_fbo_test.go
@@ -184,28 +184,27 @@ func TestCollectCustomerFBOUsesPriorityBeforeFeatureRestriction(t *testing.T) {
 	require.True(t, alpacadecimal.NewFromInt(30).Equal(sources[1].Amount), "lower-priority restricted amount: %s", sources[1].Amount)
 }
 
-func TestCollectCustomerFBOUsesFreeCostBasisBeforePaidTieBreaker(t *testing.T) {
+func TestCollectCustomerFBOUsesNilCostBasisBeforePaidTieBreaker(t *testing.T) {
 	env := ledgertestutils.NewIntegrationEnv(t, "collector")
 	breakageService := newTestBreakageService(t, env)
 	collector := newTestAccrualCollectorWithBreakage(env, breakageService)
 
 	// given:
-	// - same-priority free and paid credit sources
+	// - same-priority free/missing-cost-basis and paid credit sources
 	// - paid credit has the earlier expiration and was created first
 	// when:
-	// - collection consumes less than the free source amount
+	// - collection consumes less than the nil-cost-basis source amount
 	// then:
-	// - free cost-basis credit is consumed before the paid source
+	// - nil-cost-basis credit is consumed before the paid source
 	priority := 1
-	freeCostBasis := alpacadecimal.Zero
 	paidCostBasis := alpacadecimal.NewFromInt(1)
-	freeSourceCharge := testChargeID(1)
+	nilCostBasisSourceCharge := testChargeID(1)
 	paidSourceCharge := testChargeID(2)
 	spendCharge := testChargeID(3)
 	spendAmount := int64(5)
 
 	bookExpiringCreditWithCostBasis(t, env, breakageService, priority, 10, &paidCostBasis, nil, &paidSourceCharge, env.Now().Add(10*time.Hour))
-	bookExpiringCreditWithCostBasis(t, env, breakageService, priority, 15, &freeCostBasis, nil, &freeSourceCharge, env.Now().Add(15*time.Hour))
+	bookExpiringCreditWithCostBasis(t, env, breakageService, priority, 15, nil, nil, &nilCostBasisSourceCharge, env.Now().Add(15*time.Hour))
 
 	allocations, err := collector.collect(t.Context(), collectToAccruedInputForTest(
 		env,
@@ -218,12 +217,12 @@ func TestCollectCustomerFBOUsesFreeCostBasisBeforePaidTieBreaker(t *testing.T) {
 	require.Equal(t, float64(spendAmount), allocations[0].Amount.InexactFloat64())
 
 	requireAccruedBalanceBuckets(t, env, map[string]float64{
-		sourceSpendChargeKey(&freeSourceCharge, &spendCharge): float64(spendAmount),
+		sourceSpendChargeKey(&nilCostBasisSourceCharge, &spendCharge): float64(spendAmount),
 	})
 	requireFBOBalanceBuckets(t, env, map[string]float64{})
 	requireBreakageBalanceBuckets(t, env, map[string]float64{
-		sourceSpendChargeKey(&paidSourceCharge, nil): 10,
-		sourceSpendChargeKey(&freeSourceCharge, nil): 10,
+		sourceSpendChargeKey(&paidSourceCharge, nil):         10,
+		sourceSpendChargeKey(&nilCostBasisSourceCharge, nil): 10,
 	})
 }
 

--- a/openmeter/ledger/collector/types.go
+++ b/openmeter/ledger/collector/types.go
@@ -30,7 +30,7 @@ type fboCollectionSource struct {
 
 var _ cmpx.Comparable[fboCollectionSource] = fboCollectionSource{}
 
-const collectionPriorityVersionFreeCostBasisFirst = 2
+const collectionPriorityVersionFreeOrMissingCostBasisFirst = 2
 
 func (s fboCollectionSource) Compare(other fboCollectionSource) int {
 	if c := cmp.Compare(s.creditPriority, other.creditPriority); c != 0 {
@@ -95,7 +95,7 @@ func (s fboCollectionSelections) postingAmounts(spendChargeID *string) []transac
 			},
 			Annotations: models.Annotations{
 				ledger.AnnotationCollectionSourceOrder:     idx,
-				ledger.AnnotationCollectionPriorityVersion: collectionPriorityVersionFreeCostBasisFirst,
+				ledger.AnnotationCollectionPriorityVersion: collectionPriorityVersionFreeOrMissingCostBasisFirst,
 			},
 		})
 	}

--- a/openmeter/ledger/collector/types.go
+++ b/openmeter/ledger/collector/types.go
@@ -21,6 +21,7 @@ type fboCollectionSource struct {
 	sourceChargeID    *string
 	available         alpacadecimal.Decimal
 	creditPriority    int
+	freeCostBasis     bool
 	featureRestricted bool
 	expiresAt         *time.Time
 	cursor            string
@@ -29,11 +30,19 @@ type fboCollectionSource struct {
 
 var _ cmpx.Comparable[fboCollectionSource] = fboCollectionSource{}
 
-// TODO: Version this contract before changing it. Corrections and breakage
-// releases depend on collection selecting sources deterministically.
+const collectionPriorityVersionFreeCostBasisFirst = 2
+
 func (s fboCollectionSource) Compare(other fboCollectionSource) int {
 	if c := cmp.Compare(s.creditPriority, other.creditPriority); c != 0 {
 		return c
+	}
+
+	if s.freeCostBasis != other.freeCostBasis {
+		if s.freeCostBasis {
+			return -1
+		}
+
+		return 1
 	}
 
 	if s.featureRestricted != other.featureRestricted {
@@ -85,7 +94,8 @@ func (s fboCollectionSelections) postingAmounts(spendChargeID *string) []transac
 				SpendChargeID:    spendChargeID,
 			},
 			Annotations: models.Annotations{
-				ledger.AnnotationCollectionSourceOrder: idx,
+				ledger.AnnotationCollectionSourceOrder:     idx,
+				ledger.AnnotationCollectionPriorityVersion: collectionPriorityVersionFreeCostBasisFirst,
 			},
 		})
 	}

--- a/test/credits/sanity_test.go
+++ b/test/credits/sanity_test.go
@@ -2663,6 +2663,152 @@ func (s *SanitySuite) TestFlatFeeCreditThenInvoiceSanity() {
 	})
 }
 
+func (s *SanitySuite) TestFlatFeeCreditThenInvoiceUsesFreeGrantBeforePaidPriorityTie() {
+	ctx := s.T().Context()
+	ns := s.GetUniqueNamespace("charges-sanity-free-before-paid")
+	s.ProvisionDefaultTaxCodes(ctx, ns)
+
+	customInvoicing := s.SetupCustomInvoicing(ns)
+	cust := s.CreateLedgerBackedCustomer(ns, "test-subject")
+	s.NotEmpty(cust.ID)
+
+	_ = s.ProvisionBillingProfile(ctx, ns, customInvoicing.App.GetID(),
+		billingtest.WithProgressiveBilling(),
+		billingtest.WithCollectionInterval(datetime.MustParseDuration(s.T(), "PT1H")),
+		billingtest.WithManualApproval(),
+	)
+
+	setupAt := datetime.MustParseTimeInLocation(s.T(), "2025-12-31T00:00:00Z", time.UTC).AsTime()
+	servicePeriod := timeutil.ClosedPeriod{
+		From: datetime.MustParseTimeInLocation(s.T(), "2026-01-01T00:00:00Z", time.UTC).AsTime(),
+		To:   datetime.MustParseTimeInLocation(s.T(), "2026-02-01T00:00:00Z", time.UTC).AsTime(),
+	}
+	clock.SetTime(setupAt)
+	defer clock.ResetTime()
+
+	priority := 1
+	freeAmount := alpacadecimal.NewFromInt(20)
+	paidAmount := alpacadecimal.NewFromInt(20)
+	paidCostBasis := alpacadecimal.NewFromFloat(0.5)
+	freeCostBasis := alpacadecimal.Zero
+
+	var paidSourceChargeID string
+	s.Run("the customer purchases paid credits first", func() {
+		intent := s.CreateCreditPurchaseIntent(CreateCreditPurchaseIntentInput{
+			Customer:      cust.GetID(),
+			Currency:      USD,
+			Amount:        paidAmount,
+			Priority:      &priority,
+			ServicePeriod: timeutil.ClosedPeriod{From: setupAt, To: setupAt},
+			Settlement: creditpurchase.NewSettlement(creditpurchase.ExternalSettlement{
+				GenericSettlement: creditpurchase.GenericSettlement{
+					Currency:  USD,
+					CostBasis: paidCostBasis,
+				},
+				InitialStatus: creditpurchase.CreatedInitialPaymentSettlementStatus,
+			}),
+		})
+
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents:   charges.ChargeIntents{intent},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+		cpCharge, err := res[0].AsCreditPurchaseCharge()
+		s.NoError(err)
+
+		_, err = s.Charges.HandleCreditPurchaseExternalPaymentStateTransition(ctx, charges.HandleCreditPurchaseExternalPaymentStateTransitionInput{
+			ChargeID:           cpCharge.GetChargeID(),
+			TargetPaymentState: payment.StatusAuthorized,
+		})
+		s.NoError(err)
+		_, err = s.Charges.HandleCreditPurchaseExternalPaymentStateTransition(ctx, charges.HandleCreditPurchaseExternalPaymentStateTransitionInput{
+			ChargeID:           cpCharge.GetChargeID(),
+			TargetPaymentState: payment.StatusSettled,
+		})
+		s.NoError(err)
+
+		paidSourceChargeID = cpCharge.ID
+		s.AssertDecimalEqual(paidAmount, s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&paidCostBasis), priority), "paid FBO before usage")
+	})
+
+	var freeSourceChargeID string
+	s.Run("the customer receives same-priority free credits second", func() {
+		result := s.CreatePromotionalCreditFunding(ctx, CreatePromotionalCreditFundingInput{
+			Namespace: ns,
+			Customer:  cust.GetID(),
+			Amount:    freeAmount,
+			At:        setupAt,
+			CostBasis: freeCostBasis,
+			Priority:  &priority,
+		})
+		freeSourceChargeID = result.Charge.ID
+		s.AssertDecimalEqual(freeAmount, s.MustCustomerFBOBalanceWithPriority(cust.GetID(), USD, mo.Some(&freeCostBasis), priority), "free FBO before usage")
+	})
+
+	var flatFeeChargeID meta.ChargeID
+	s.Run("a flat fee is created", func() {
+		res, err := s.Charges.Create(ctx, charges.CreateInput{
+			Namespace: ns,
+			Intents: charges.ChargeIntents{
+				s.CreateMockChargeIntent(CreateMockChargeIntentInput{
+					Customer:       cust.GetID(),
+					Currency:       USD,
+					ServicePeriod:  servicePeriod,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+						Amount:      alpacadecimal.NewFromInt(30),
+						PaymentTerm: productcatalog.InAdvancePaymentTerm,
+					}),
+					Name:              "flat-fee-free-before-paid",
+					ManagedBy:         billing.SubscriptionManagedLine,
+					UniqueReferenceID: "flat-fee-free-before-paid",
+				}),
+			},
+		})
+		s.NoError(err)
+		s.Len(res, 1)
+
+		flatFeeCharge, err := res[0].AsFlatFeeCharge()
+		s.NoError(err)
+		flatFeeChargeID = flatFeeCharge.GetChargeID()
+	})
+
+	clock.SetTime(servicePeriod.From)
+	s.Run("invoice assignment consumes free credits before paid credits", func() {
+		invoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: cust.GetID(),
+			AsOf:     lo.ToPtr(servicePeriod.From),
+		})
+		s.NoError(err)
+		s.Len(invoices, 1)
+
+		charge := s.MustGetChargeByID(flatFeeChargeID)
+		updatedFlatFeeCharge, err := charge.AsFlatFeeCharge()
+		s.NoError(err)
+		s.Require().NotNil(updatedFlatFeeCharge.Realizations.CurrentRun)
+		s.Len(updatedFlatFeeCharge.Realizations.CurrentRun.CreditRealizations, 2)
+
+		s.requireCustomerFBOSourceBalanceBuckets(cust.GetID(), ledger.RouteFilter{
+			Currency:  USD,
+			CostBasis: mo.Some(&paidCostBasis),
+		}, map[string]float64{
+			sourceSpendChargeBucketKey(&paidSourceChargeID, nil): 10, // 10 = paid source remains because free credit tied by priority is collected first.
+		})
+		s.requireCustomerFBOSourceBalanceBuckets(cust.GetID(), ledger.RouteFilter{
+			Currency:  USD,
+			CostBasis: mo.Some(&freeCostBasis),
+		}, map[string]float64{})
+		s.requireCustomerAccruedSourceSpendBalanceBuckets(cust.GetID(), ledger.RouteFilter{
+			Currency: USD,
+		}, map[string]float64{
+			sourceSpendChargeBucketKey(&freeSourceChargeID, &flatFeeChargeID.ID): 20, // 20 = full free source is used before paid credit.
+			sourceSpendChargeBucketKey(&paidSourceChargeID, &flatFeeChargeID.ID): 10, // 10 = remaining spend spills into paid credit.
+		})
+	})
+}
+
 type meteredFeatureSetup struct {
 	key  string
 	name string


### PR DESCRIPTION
## Summary
- prioritizes nil/missing-cost-basis and explicit zero-cost-basis customer FBO sources before paid sources when credit priority ties
- stamps collection source entries with a priority version annotation for future ordering changes
- adds focused collector coverage and credits sanity coverage for the new burn-down order

## Notes
- current promotional credit-purchase settlement still maps through the charge adapter as explicit zero cost basis; the collector rule now also handles nil/missing cost basis as free
- existing correction safety comes from persisted collection source order; old entries do not need migration
- legacy credit engine grant burn-down history cannot express this cost-basis tie-break because its grant model has no cost-basis field

## Validation
- nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go vet -tags=dynamic ./openmeter/ledger/collector ./test/credits
- nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic -run 'TestCollectCustomerFBOUsesNilCostBasisBeforePaidTieBreaker|TestCollectCustomerFBOUsesPriorityOrder|TestCollectCustomerFBOReleasesBreakageInExpiryOrder' ./openmeter/ledger/collector
- nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -tags=dynamic -run 'TestSanitySuite/TestFlatFeeCreditThenInvoiceUsesFreeGrantBeforePaidPriorityTie' ./test/credits