### PR TITLE
feat: add async invoice collection event

### DIFF
--- a/app/common/openmeter_billingworker.go
+++ b/app/common/openmeter_billingworker.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openmeterio/openmeter/app/config"
 	billingworker "github.com/openmeterio/openmeter/openmeter/billing/worker"
+	billingworkercollect "github.com/openmeterio/openmeter/openmeter/billing/worker/collect"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync"
 	watermillkafka "github.com/openmeterio/openmeter/openmeter/watermill/driver/kafka"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
@@ -38,6 +39,7 @@ var BillingWorker = wire.NewSet(
 
 	NewBillingWorkerOptions,
 	NewBillingWorker,
+	NewBillingCollector,
 	NewBillingSubscriptionSyncAdapter,
 	NewBillingSubscriptionSyncService,
 	BillingWorkerGroup,
@@ -77,6 +79,7 @@ func NewBillingWorkerOptions(
 	billingRegistry BillingRegistry,
 	subscriptionServices SubscriptionServiceWithWorkflow,
 	subscriptionSyncService subscriptionsync.Service,
+	billingCollector *billingworkercollect.InvoiceCollector,
 	billingFsConfig config.BillingFeatureSwitchesConfiguration,
 	logger *slog.Logger,
 ) billingworker.WorkerOptions {
@@ -86,6 +89,7 @@ func NewBillingWorkerOptions(
 		Router:                  routerOptions,
 		EventBus:                eventBus,
 		BillingService:          billingRegistry.Billing,
+		BillingCollector:        billingCollector,
 		ChargesService:          billingRegistry.ChargesServiceOrNil(),
 		SubscriptionService:     subscriptionServices.Service,
 		BillingSubscriptionSync: subscriptionSyncService,

--- a/cmd/billing-worker/wire_gen.go
+++ b/cmd/billing-worker/wire_gen.go
@@ -385,7 +385,18 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	workerOptions := common.NewBillingWorkerOptions(eventsConfiguration, options, eventbusPublisher, billingRegistry, subscriptionServiceWithWorkflow, subscriptionsyncService, billingFeatureSwitchesConfiguration, logger)
+	invoiceCollector, err := common.NewBillingCollector(logger, billingRegistry, billingFeatureSwitchesConfiguration)
+	if err != nil {
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
+	workerOptions := common.NewBillingWorkerOptions(eventsConfiguration, options, eventbusPublisher, billingRegistry, subscriptionServiceWithWorkflow, subscriptionsyncService, invoiceCollector, billingFeatureSwitchesConfiguration, logger)
 	worker, err := common.NewBillingWorker(workerOptions)
 	if err != nil {
 		cleanup7()

--- a/openmeter/billing/eventscollection.go
+++ b/openmeter/billing/eventscollection.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/openmeterio/openmeter/openmeter/event/metadata"
+	"github.com/openmeterio/openmeter/pkg/models"
 )
 
 type CollectCustomerInvoicesEvent struct {
@@ -44,5 +45,5 @@ func (e CollectCustomerInvoicesEvent) Validate() error {
 		errs = append(errs, fmt.Errorf("as_of cannot be zero"))
 	}
 
-	return errors.Join(errs...)
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
 }

--- a/openmeter/billing/eventscollection.go
+++ b/openmeter/billing/eventscollection.go
@@ -1,0 +1,48 @@
+package billing
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/openmeterio/openmeter/openmeter/event/metadata"
+)
+
+type CollectCustomerInvoicesEvent struct {
+	Namespace  string    `json:"namespace"`
+	CustomerID string    `json:"customer_id"`
+	AsOf       time.Time `json:"as_of"`
+}
+
+func (e CollectCustomerInvoicesEvent) EventName() string {
+	return metadata.GetEventName(metadata.EventType{
+		Subsystem: EventSubsystem,
+		Name:      "invoice.collect",
+		Version:   "v1",
+	})
+}
+
+func (e CollectCustomerInvoicesEvent) EventMetadata() metadata.EventMetadata {
+	return metadata.EventMetadata{
+		Source:  metadata.ComposeResourcePath(e.Namespace, metadata.EntityCustomer, e.CustomerID),
+		Subject: metadata.ComposeResourcePath(e.Namespace, metadata.EntityCustomer, e.CustomerID),
+	}
+}
+
+func (e CollectCustomerInvoicesEvent) Validate() error {
+	var errs []error
+
+	if e.Namespace == "" {
+		errs = append(errs, fmt.Errorf("namespace cannot be empty"))
+	}
+
+	if e.CustomerID == "" {
+		errs = append(errs, fmt.Errorf("customer_id cannot be empty"))
+	}
+
+	if e.AsOf.IsZero() {
+		errs = append(errs, fmt.Errorf("as_of cannot be zero"))
+	}
+
+	return errors.Join(errs...)
+}

--- a/openmeter/billing/eventscollection_test.go
+++ b/openmeter/billing/eventscollection_test.go
@@ -1,0 +1,73 @@
+package billing_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/event/metadata"
+)
+
+func TestCollectCustomerInvoicesEvent(t *testing.T) {
+	asOf := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+
+	event := billing.CollectCustomerInvoicesEvent{
+		Namespace:  "ns",
+		CustomerID: "customer-id",
+		AsOf:       asOf,
+	}
+
+	require.NoError(t, event.Validate())
+	require.Equal(t, metadata.GetEventName(metadata.EventType{
+		Subsystem: billing.EventSubsystem,
+		Name:      "invoice.collect",
+		Version:   "v1",
+	}), event.EventName())
+
+	eventMetadata := event.EventMetadata()
+	require.Equal(t, metadata.ComposeResourcePath("ns", metadata.EntityCustomer, "customer-id"), eventMetadata.Source)
+	require.Equal(t, metadata.ComposeResourcePath("ns", metadata.EntityCustomer, "customer-id"), eventMetadata.Subject)
+}
+
+func TestCollectCustomerInvoicesEventValidate(t *testing.T) {
+	asOf := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		event   billing.CollectCustomerInvoicesEvent
+		wantErr string
+	}{
+		{
+			name: "namespace is required",
+			event: billing.CollectCustomerInvoicesEvent{
+				CustomerID: "customer-id",
+				AsOf:       asOf,
+			},
+			wantErr: "namespace cannot be empty",
+		},
+		{
+			name: "customer id is required",
+			event: billing.CollectCustomerInvoicesEvent{
+				Namespace: "ns",
+				AsOf:      asOf,
+			},
+			wantErr: "customer_id cannot be empty",
+		},
+		{
+			name: "as of is required",
+			event: billing.CollectCustomerInvoicesEvent{
+				Namespace:  "ns",
+				CustomerID: "customer-id",
+			},
+			wantErr: "as_of cannot be zero",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorContains(t, tt.event.Validate(), tt.wantErr)
+		})
+	}
+}

--- a/openmeter/billing/worker/collect/asynccollect.go
+++ b/openmeter/billing/worker/collect/asynccollect.go
@@ -1,0 +1,29 @@
+package billingworkercollect
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/customer"
+)
+
+func (a *InvoiceCollector) HandleCollectCustomerInvoicesEvent(ctx context.Context, event *billing.CollectCustomerInvoicesEvent) error {
+	if event == nil {
+		return nil
+	}
+
+	if err := event.Validate(); err != nil {
+		return fmt.Errorf("invalid collect customer invoices event: %w", err)
+	}
+
+	_, err := a.CollectCustomerInvoice(ctx, CollectCustomerInvoiceInput{
+		CustomerID: customer.CustomerID{
+			Namespace: event.Namespace,
+			ID:        event.CustomerID,
+		},
+		AsOf: event.AsOf,
+	})
+
+	return err
+}

--- a/openmeter/billing/worker/collect/asynccollect_test.go
+++ b/openmeter/billing/worker/collect/asynccollect_test.go
@@ -1,0 +1,27 @@
+package billingworkercollect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+)
+
+func TestInvoiceCollectorHandleCollectCustomerInvoicesEvent(t *testing.T) {
+	collector := &InvoiceCollector{}
+
+	t.Run("nil event", func(t *testing.T) {
+		require.NoError(t, collector.HandleCollectCustomerInvoicesEvent(t.Context(), nil))
+	})
+
+	t.Run("invalid event", func(t *testing.T) {
+		err := collector.HandleCollectCustomerInvoicesEvent(t.Context(), &billing.CollectCustomerInvoicesEvent{
+			Namespace:  "ns",
+			CustomerID: "customer-id",
+		})
+
+		require.ErrorContains(t, err, "invalid collect customer invoices event")
+		require.ErrorContains(t, err, "as_of cannot be zero")
+	})
+}

--- a/openmeter/billing/worker/collect/collect.go
+++ b/openmeter/billing/worker/collect/collect.go
@@ -106,6 +106,7 @@ func (a *InvoiceCollector) CollectCustomerInvoice(ctx context.Context, params Co
 		ctx,
 		billing.InvoicePendingLinesInput{
 			Customer: params.CustomerID,
+			AsOf:     lo.ToPtr(params.AsOf),
 		},
 		// We want to make sure that system collection does not use progressive billing.
 		billing.WithPartialInvoiceLinesDisabled(),

--- a/openmeter/billing/worker/worker.go
+++ b/openmeter/billing/worker/worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges"
 	chargesasyncadvance "github.com/openmeterio/openmeter/openmeter/billing/charges/worker/asyncadvance"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/asyncadvance"
+	billingworkercollect "github.com/openmeterio/openmeter/openmeter/billing/worker/collect"
 	"github.com/openmeterio/openmeter/openmeter/billing/worker/subscriptionsync"
 	"github.com/openmeterio/openmeter/openmeter/subscription"
 	"github.com/openmeterio/openmeter/openmeter/watermill/eventbus"
@@ -30,6 +31,7 @@ type WorkerOptions struct {
 
 	BillingService          billing.Service
 	BillingSubscriptionSync subscriptionsync.Service
+	BillingCollector        *billingworkercollect.InvoiceCollector
 	// ChargesService is optional; when non-nil the worker handles AdvanceChargesEvent.
 	ChargesService charges.ChargeService
 	// External connectors
@@ -67,6 +69,10 @@ func (w WorkerOptions) Validate() error {
 		return fmt.Errorf("billing subscription sync handler is required")
 	}
 
+	if w.BillingCollector == nil {
+		return fmt.Errorf("billing collector is required")
+	}
+
 	return nil
 }
 
@@ -75,6 +81,7 @@ type Worker struct {
 
 	billingService             billing.Service
 	subscriptionSync           subscriptionsync.Service
+	invoiceCollector           *billingworkercollect.InvoiceCollector
 	asyncAdvanceHandler        *asyncadvance.Handler
 	asyncAdvanceChargesHandler *chargesasyncadvance.Handler
 	nonPublishingHandler       *grouphandler.NoPublishingHandler
@@ -109,6 +116,7 @@ func New(opts WorkerOptions) (*Worker, error) {
 	worker := &Worker{
 		billingService:             opts.BillingService,
 		subscriptionSync:           opts.BillingSubscriptionSync,
+		invoiceCollector:           opts.BillingCollector,
 		asyncAdvanceHandler:        asyncAdvancer,
 		asyncAdvanceChargesHandler: asyncAdvanceChargesHandler,
 		lockdownNamespaces:         opts.LockdownNamespaces,
@@ -198,6 +206,13 @@ func (w *Worker) eventHandler(opts WorkerOptions) (*grouphandler.NoPublishingHan
 			}
 
 			return w.asyncAdvanceHandler.Handle(ctx, event)
+		}),
+		grouphandler.NewGroupEventHandler(func(ctx context.Context, event *billing.CollectCustomerInvoicesEvent) error {
+			if event != nil && slices.Contains(w.lockdownNamespaces, event.Namespace) {
+				return nil
+			}
+
+			return w.invoiceCollector.HandleCollectCustomerInvoicesEvent(ctx, event)
 		}),
 		grouphandler.NewGroupEventHandler(func(ctx context.Context, event *charges.AdvanceChargesEvent) error {
 			if w.asyncAdvanceChargesHandler == nil {


### PR DESCRIPTION
## Summary

Adds an OSS billing command event for customer-scoped invoice collection and wires the billing worker to consume it through the existing invoice collector path.

This keeps OSS collection triggering unchanged while allowing external scanners, such as Cloud Temporal workflows, to publish `billing.invoice.collect.v1` events for due customers.

## Changes

- Add `billing.CollectCustomerInvoicesEvent` with customer resource metadata and validation.
- Add an async collect handler that maps the event to `InvoiceCollector.CollectCustomerInvoice`.
- Register the event in the billing worker and wire the collector into the worker DI graph.
- Add focused event and handler tests.

## Validation

- `make generate`
- `go test ./openmeter/billing ./openmeter/billing/worker/collect`
- `go test ./openmeter/billing/worker/...`
- `go test ./app/common/...`
- `go vet ./openmeter/billing ./openmeter/billing/worker/... ./app/common`
- `go test ./openmeter/billing/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customer invoice collection to the billing worker, including a new `invoice.collect` event with validation and standardized event metadata.
  * Extended worker setup to include the invoice collector and handle the new event type.
* **Bug Fixes**
  * Added safe handling for nil/invalid invoice-collection events and ensured `AsOf` is forwarded when collecting pending invoice lines.
  * Event handling now skips processing for restricted namespaces.
* **Tests**
  * Added unit tests covering event validation/metadata and invoice-collector event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->