### PR TITLE
fix(ledger): annotate breakage expiry charges

### DIFF
--- a/openmeter/ledger/breakage/breakage_impacts.go
+++ b/openmeter/ledger/breakage/breakage_impacts.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
 
 	"github.com/openmeterio/openmeter/openmeter/ledger"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
@@ -76,15 +77,17 @@ func (s *service) ListExpiredBreakageImpacts(ctx context.Context, input ListExpi
 	groups := make(map[expiredBreakageImpactGroupKey]*expiredBreakageImpactGroup)
 	for _, record := range records {
 		key := expiredBreakageImpactGroupKey{
-			expiresAt: record.ExpiresAt,
-			currency:  record.Currency,
+			expiresAt:      record.ExpiresAt,
+			currency:       record.Currency,
+			sourceChargeID: lo.FromPtr(record.SourceChargeID),
 		}
 
 		group := groups[key]
 		if group == nil {
 			group = &expiredBreakageImpactGroup{
-				expiresAt: record.ExpiresAt,
-				currency:  record.Currency,
+				expiresAt:      record.ExpiresAt,
+				currency:       record.Currency,
+				sourceChargeID: record.SourceChargeID,
 			}
 			groups[key] = group
 		}
@@ -120,16 +123,21 @@ func (s *service) ListExpiredBreakageImpacts(ctx context.Context, input ListExpi
 			return ListExpiredBreakageImpactsResult{}, fmt.Errorf("expired breakage impact has no plan record for %s %s", group.expiresAt, group.currency)
 		}
 
+		annotations := models.Annotations{
+			ledger.AnnotationCollectionType: ledger.CollectionTypeBreakage,
+		}
+		if group.sourceChargeID != nil {
+			annotations[ledger.AnnotationChargeID] = *group.sourceChargeID
+		}
+
 		item := BreakageImpact{
-			ID:         group.cursorID,
-			CreatedAt:  group.expiresAt,
-			BookedAt:   group.expiresAt,
-			CustomerID: input.CustomerID,
-			Currency:   group.currency,
-			Amount:     group.amount.Neg(),
-			Annotations: models.Annotations{
-				ledger.AnnotationCollectionType: ledger.CollectionTypeBreakage,
-			},
+			ID:          group.cursorID,
+			CreatedAt:   group.expiresAt,
+			BookedAt:    group.expiresAt,
+			CustomerID:  input.CustomerID,
+			Currency:    group.currency,
+			Amount:      group.amount.Neg(),
+			Annotations: annotations,
 		}
 
 		if !breakageImpactMatchesCursorWindow(item, input.After, input.Before) {
@@ -192,13 +200,15 @@ func breakageImpactMatchesCursorWindow(item BreakageImpact, after, before *ledge
 }
 
 type expiredBreakageImpactGroupKey struct {
-	expiresAt time.Time
-	currency  currencyx.Code
+	expiresAt      time.Time
+	currency       currencyx.Code
+	sourceChargeID string
 }
 
 type expiredBreakageImpactGroup struct {
-	expiresAt time.Time
-	currency  currencyx.Code
-	amount    alpacadecimal.Decimal
-	cursorID  models.NamespacedID
+	expiresAt      time.Time
+	currency       currencyx.Code
+	sourceChargeID *string
+	amount         alpacadecimal.Decimal
+	cursorID       models.NamespacedID
 }

--- a/openmeter/ledger/breakage/breakage_impacts_test.go
+++ b/openmeter/ledger/breakage/breakage_impacts_test.go
@@ -1,0 +1,101 @@
+package breakage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/customer"
+	"github.com/openmeterio/openmeter/openmeter/ledger"
+	"github.com/openmeterio/openmeter/pkg/currencyx"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+func TestListExpiredBreakageImpactsGroupsBySourceChargeID(t *testing.T) {
+	expiresAt := time.Date(2026, 4, 11, 9, 0, 0, 0, time.UTC)
+	customerID := customer.CustomerID{
+		Namespace: "ns",
+		ID:        "customer-id",
+	}
+	currency := currencyx.Code("USD")
+	chargeA := "charge-a"
+	chargeB := "charge-b"
+
+	svc := &service{
+		adapter: fakeBreakageAdapter{
+			expiredRecords: []Record{
+				{
+					ID:             models.NamespacedID{Namespace: "ns", ID: "01KBREAKAGE000000000000000001"},
+					Kind:           ledger.BreakageKindPlan,
+					Amount:         alpacadecimal.NewFromInt(10),
+					CustomerID:     customerID,
+					Currency:       currency,
+					ExpiresAt:      expiresAt,
+					SourceChargeID: &chargeA,
+				},
+				{
+					ID:             models.NamespacedID{Namespace: "ns", ID: "01KBREAKAGE000000000000000002"},
+					Kind:           ledger.BreakageKindRelease,
+					Amount:         alpacadecimal.NewFromInt(3),
+					CustomerID:     customerID,
+					Currency:       currency,
+					ExpiresAt:      expiresAt,
+					SourceChargeID: &chargeA,
+				},
+				{
+					ID:             models.NamespacedID{Namespace: "ns", ID: "01KBREAKAGE000000000000000003"},
+					Kind:           ledger.BreakageKindPlan,
+					Amount:         alpacadecimal.NewFromInt(7),
+					CustomerID:     customerID,
+					Currency:       currency,
+					ExpiresAt:      expiresAt,
+					SourceChargeID: &chargeB,
+				},
+			},
+		},
+	}
+
+	got, err := svc.ListExpiredBreakageImpacts(t.Context(), ListExpiredBreakageImpactsInput{
+		CustomerID: customerID,
+		Currency:   &currency,
+		AsOf:       expiresAt,
+		Limit:      20,
+	})
+	require.NoError(t, err)
+	require.Len(t, got.Items, 2)
+
+	amountByChargeID := make(map[string]float64, len(got.Items))
+	for _, item := range got.Items {
+		require.Equal(t, ledger.CollectionTypeBreakage, item.Annotations[ledger.AnnotationCollectionType])
+
+		chargeID, ok := item.Annotations[ledger.AnnotationChargeID].(string)
+		require.True(t, ok)
+		amountByChargeID[chargeID] = item.Amount.InexactFloat64()
+	}
+
+	require.Equal(t, float64(-7), amountByChargeID[chargeA])
+	require.Equal(t, float64(-7), amountByChargeID[chargeB])
+}
+
+type fakeBreakageAdapter struct {
+	expiredRecords []Record
+}
+
+func (a fakeBreakageAdapter) CreateRecords(context.Context, CreateRecordsInput) error {
+	return nil
+}
+
+func (a fakeBreakageAdapter) ListCandidateRecords(context.Context, ListPlansInput) ([]Record, error) {
+	return nil, nil
+}
+
+func (a fakeBreakageAdapter) ListReleaseRecords(context.Context, ListReleasesInput) ([]Record, error) {
+	return nil, nil
+}
+
+func (a fakeBreakageAdapter) ListExpiredRecords(context.Context, ListExpiredRecordsInput) ([]Record, error) {
+	return a.expiredRecords, nil
+}

--- a/openmeter/ledger/customerbalance/expired_loader_test.go
+++ b/openmeter/ledger/customerbalance/expired_loader_test.go
@@ -212,6 +212,30 @@ func TestListCreditTransactionsExpiredBreakageFeatureFilter(t *testing.T) {
 	}
 }
 
+func TestListCreditTransactionsExpiredBreakageChargeAnnotations(t *testing.T) {
+	env := newTestEnv(t)
+	t.Cleanup(func() {
+		clock.UnFreeze()
+		clock.ResetTime()
+	})
+
+	issuedAt := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+	expiresAt := issuedAt.Add(10 * time.Hour)
+	charge := env.createPromotionalCreditFunding(t, issuedAt, alpacadecimal.NewFromInt(20), expiresAt)
+
+	expiredType := CreditTransactionTypeExpired
+	got, err := env.Service.ListCreditTransactions(t.Context(), ListCreditTransactionsInput{
+		CustomerID: env.CustomerID,
+		Limit:      20,
+		Type:       &expiredType,
+		Currency:   &env.Currency,
+		AsOf:       &expiresAt,
+	})
+	require.NoError(t, err)
+	require.Len(t, got.Items, 1)
+	require.Equal(t, charge.ID, got.Items[0].Annotations[ledger.AnnotationChargeID])
+}
+
 func TestListCreditTransactionsCombinesFundedConsumedAndExpired(t *testing.T) {
 	issuedAt := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
 
@@ -426,13 +450,15 @@ func TestListCreditTransactionsFeatureFilter(t *testing.T) {
 			featureFilter: NewFeatureFilter([]string{"storage"}),
 			expectedTypes: []CreditTransactionType{
 				CreditTransactionTypeExpired,
+				CreditTransactionTypeExpired,
 				CreditTransactionTypeConsumed,
 				CreditTransactionTypeFunded,
 				CreditTransactionTypeFunded,
 				CreditTransactionTypeFunded,
 			},
 			expected: []expectedCreditTransaction{
-				{txType: CreditTransactionTypeExpired, bookedAfter: 24 * time.Hour, amount: -45, balanceBefore: 45, balanceAfter: 0},
+				{txType: CreditTransactionTypeExpired, bookedAfter: 24 * time.Hour, amount: -30, balanceBefore: 30, balanceAfter: 0},
+				{txType: CreditTransactionTypeExpired, bookedAfter: 24 * time.Hour, amount: -15, balanceBefore: 45, balanceAfter: 30},
 				{txType: CreditTransactionTypeConsumed, bookedAfter: time.Hour, amount: -105, balanceBefore: 150, balanceAfter: 45},
 				{txType: CreditTransactionTypeFunded, bookedAfter: 3 * time.Minute, amount: 30, balanceBefore: 120, balanceAfter: 150},
 				{txType: CreditTransactionTypeFunded, bookedAfter: 2 * time.Minute, amount: 20, balanceBefore: 100, balanceAfter: 120},


### PR DESCRIPTION
## Summary

- Group expired breakage impacts by source charge so charge-scoped expiry rows stay attributable.
- Add ledger charge id annotations to expired breakage impacts for customer balance transaction labels.
- Cover source-scoped netting and customerbalance transaction listing with regression tests.

## Validation

- nix develop --impure .#ci -c go test -count=1 -tags=dynamic ./openmeter/ledger/breakage
- nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -count=1 -tags=dynamic -run ^TestListCreditTransactionsExpiredBreakageChargeAnnotations$ ./openmeter/ledger/customerbalance
- nix develop --impure .#ci -c env POSTGRES_HOST=127.0.0.1 go test -count=1 -tags=dynamic -run ^TestListCreditTransactionsFeatureFilter$ ./openmeter/ledger/customerbalance
- nix develop --impure .#ci -c go vet -tags=dynamic ./openmeter/ledger/breakage ./openmeter/ledger/customerbalance
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expired breakage impacts are now grouped more precisely, so records from different originating charges are handled separately.
  * Breakage-related results now consistently include collection details, and charge references are preserved when available.
  * Expired credit transaction views now better reflect split entries after expiry, with updated balances and amounts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->