### PR TITLE
[codex] Exclude locked namespaces from invoice collection

### DIFF
--- a/openmeter/billing/adapter/gatheringinvoice.go
+++ b/openmeter/billing/adapter/gatheringinvoice.go
@@ -210,6 +210,10 @@ func (a *adapter) ListGatheringInvoices(ctx context.Context, input billing.ListG
 			query = query.Where(billinginvoice.NamespaceIn(input.Namespaces...))
 		}
 
+		if len(input.ExcludedNamespaces) > 0 {
+			query = query.Where(billinginvoice.NamespaceNotIn(input.ExcludedNamespaces...))
+		}
+
 		if len(input.Customers) > 0 {
 			query = query.Where(billinginvoice.CustomerIDIn(input.Customers...))
 		}

--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -942,15 +942,16 @@ type UpdateGatheringInvoiceAdapterInput = GatheringInvoice
 type ListGatheringInvoicesInput struct {
 	pagination.Page
 
-	Namespaces     []string
-	IDs            []string
-	Customers      []string
-	Currencies     []currencyx.Code
-	OrderBy        api.InvoiceOrderBy
-	Order          sortx.Order
-	IncludeDeleted bool
-	Expand         GatheringInvoiceExpands
-	CollectionAt   filter.FilterTime
+	Namespaces         []string
+	ExcludedNamespaces []string
+	IDs                []string
+	Customers          []string
+	Currencies         []currencyx.Code
+	OrderBy            api.InvoiceOrderBy
+	Order              sortx.Order
+	IncludeDeleted     bool
+	Expand             GatheringInvoiceExpands
+	CollectionAt       filter.FilterTime
 }
 
 func (i ListGatheringInvoicesInput) Validate() error {

--- a/openmeter/billing/worker/collect/collect.go
+++ b/openmeter/billing/worker/collect/collect.go
@@ -47,8 +47,9 @@ func (a *InvoiceCollector) ListCollectableInvoices(ctx context.Context, params L
 	}
 
 	input := billing.ListGatheringInvoicesInput{
-		Namespaces: params.Namespaces,
-		Customers:  params.Customers,
+		Namespaces:         params.Namespaces,
+		ExcludedNamespaces: a.lockedNamespaces,
+		Customers:          params.Customers,
 		CollectionAt: filter.FilterTime{
 			Or: &[]filter.FilterTime{
 				{Lte: lo.ToPtr(params.CollectionAt)},


### PR DESCRIPTION
## Summary
- add an excluded-namespace filter to gathering invoice listing
- apply the collector lockdown namespaces when listing collectible invoices

## Impact
Locked namespaces are skipped by collection discovery without blocking explicit namespace/customer filtering for the remaining collection path.

## Validation
- go test ./openmeter/billing/worker/collect ./openmeter/billing/adapter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for excluding specific namespaces when listing gathering invoices.
  * Invoice collection now respects locked namespaces and leaves them out of eligible invoice results.
* **Bug Fixes**
  * Improved invoice filtering so results are narrowed by both included and excluded namespaces, reducing incorrect invoice selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->