### PR TITLE
refactor: [OM-387] governance entitlement performance improvement

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -8,19 +8,47 @@ OPENMETER_ADDRESS ?= http://localhost:38888
 BENCHTIME ?= 20x
 # Number of times to repeat the whole benchmark (feed >1 into benchstat for variance).
 COUNT ?= 1
+# Entitlement kind the seeded features use: boolean (default, cheap algorithmic baseline),
+# metered (forces the ClickHouse balance query in GetAccess — production-representative),
+# mixed (~50/50 boolean+metered), or all (runs all three kinds back to back).
+GOV_BENCH_KIND ?= boolean
 OPENMETER_E2E_EXTRA_COMPOSE_FILES ?=
 
 .PHONY: bench-governance
 bench-governance: ## Benchmark governance query latency (1x1 baseline + 10/50/100 diagonal)
 	$(call print-target)
-	TZ=UTC OPENMETER_ADDRESS=$(OPENMETER_ADDRESS) \
+	TZ=UTC OPENMETER_ADDRESS=$(OPENMETER_ADDRESS) GOV_BENCH_KIND=$(GOV_BENCH_KIND) \
 		go test -run='^$$' -bench='^BenchmarkGovernanceQuery$$' -benchmem -benchtime=$(BENCHTIME) -count=$(COUNT) ./...
 
 .PHONY: bench-governance-matrix
 bench-governance-matrix: ## Benchmark governance query latency (full 3x3 customers x features matrix)
 	$(call print-target)
-	TZ=UTC OPENMETER_ADDRESS=$(OPENMETER_ADDRESS) GOV_BENCH_FULL_MATRIX=1 \
+	TZ=UTC OPENMETER_ADDRESS=$(OPENMETER_ADDRESS) GOV_BENCH_FULL_MATRIX=1 GOV_BENCH_KIND=$(GOV_BENCH_KIND) \
 		go test -run='^$$' -bench='^BenchmarkGovernanceQuery$$' -benchmem -benchtime=$(BENCHTIME) -count=$(COUNT) ./...
+
+.PHONY: bench-governance-metered
+bench-governance-metered: ## Benchmark governance query latency, metered entitlements (diagonal)
+	$(MAKE) bench-governance GOV_BENCH_KIND=metered
+
+.PHONY: bench-governance-matrix-metered
+bench-governance-matrix-metered: ## Benchmark governance query latency, metered entitlements (full 3x3 matrix)
+	$(MAKE) bench-governance-matrix GOV_BENCH_KIND=metered
+
+# --- Trace capture ---
+# Capturing traces for big metered cells (50x50, 100x100) OOMs the local Tempo and the
+# traces are too large to open anyway (>16MiB query cap). This target captures ONE SMALL
+# cell, which shows the SAME per-entitlement query structure (query counts are per
+# entitlement). Low benchtime keeps the number of huge traces ingested down.
+# Override: TRACE_KIND=mixed, BENCH_CELL=customers=1/features=1, TRACE_BENCHTIME=1x.
+TRACE_KIND ?= metered
+BENCH_CELL ?= customers=10/features=10
+TRACE_BENCHTIME ?= 2x
+
+.PHONY: bench-governance-trace
+bench-governance-trace: ## Capture traces for ONE small cell (default metered 10x10, 2x) — safe for local Tempo
+	$(call print-target)
+	TZ=UTC OPENMETER_ADDRESS=$(OPENMETER_ADDRESS) GOV_BENCH_KIND=$(TRACE_KIND) \
+		go test -run='^$$' -bench='^BenchmarkGovernanceQuery$$/kind=$(TRACE_KIND)/$(BENCH_CELL)$$' -benchmem -benchtime=$(TRACE_BENCHTIME) -count=1 ./...
 
 .PHONY: test-local
 test-local: ## Run tests against local openmeter

--- a/e2e/governance_bench_test.go
+++ b/e2e/governance_bench_test.go
@@ -30,13 +30,13 @@ const (
 	// kindMetered grants every feature a metered entitlement, so GetAccess runs a
 	// ClickHouse usage query per entitlement — the production-representative path.
 	kindMetered entKind = "metered"
-	// kindMixed grants alternating boolean/metered entitlements (~50/50), modelling a
+	// kindMixed grants alternating boolean/metered entitlements (~50/50), modeling a
 	// realistic tenant where only some features are usage-metered.
 	kindMixed entKind = "mixed"
 )
 
 // selectedKinds reads GOV_BENCH_KIND and returns the entitlement kinds to benchmark.
-// Default is boolean only, so the existing `make -C e2e bench-governance` behaviour
+// Default is boolean only, so the existing `make -C e2e bench-governance` behavior
 // (and its baseline numbers) is unchanged. Set GOV_BENCH_KIND=metered|mixed|all to
 // measure the metered balance path.
 func selectedKinds() []entKind {

--- a/e2e/governance_bench_test.go
+++ b/e2e/governance_bench_test.go
@@ -6,13 +6,51 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	api "github.com/openmeterio/openmeter/api/client/go"
 	apiv3 "github.com/openmeterio/openmeter/api/v3"
+	"github.com/openmeterio/openmeter/pkg/convert"
 )
+
+// entKind selects which entitlement type the seeded features use. It is the third
+// benchmark axis (alongside customer and feature counts) and is what makes the
+// benchmark representative of the production cost: boolean entitlements skip the
+// metered balance path (ClickHouse), while metered entitlements force the
+// per-entitlement usage query inside GetAccess that dominates real latency.
+type entKind string
+
+const (
+	// kindBoolean grants every feature a boolean entitlement. GetAccess short-circuits
+	// the balance calculation, so this is the cheap, algorithmic-only baseline.
+	kindBoolean entKind = "boolean"
+	// kindMetered grants every feature a metered entitlement, so GetAccess runs a
+	// ClickHouse usage query per entitlement — the production-representative path.
+	kindMetered entKind = "metered"
+	// kindMixed grants alternating boolean/metered entitlements (~50/50), modelling a
+	// realistic tenant where only some features are usage-metered.
+	kindMixed entKind = "mixed"
+)
+
+// selectedKinds reads GOV_BENCH_KIND and returns the entitlement kinds to benchmark.
+// Default is boolean only, so the existing `make -C e2e bench-governance` behaviour
+// (and its baseline numbers) is unchanged. Set GOV_BENCH_KIND=metered|mixed|all to
+// measure the metered balance path.
+func selectedKinds() []entKind {
+	switch os.Getenv("GOV_BENCH_KIND") {
+	case "metered":
+		return []entKind{kindMetered}
+	case "mixed":
+		return []entKind{kindMixed}
+	case "all":
+		return []entKind{kindBoolean, kindMetered, kindMixed}
+	default:
+		return []entKind{kindBoolean}
+	}
+}
 
 // BenchmarkGovernanceQuery measures end-to-end latency of
 // POST /api/v3/openmeter/governance/query against a running stack
@@ -23,11 +61,27 @@ import (
 // performance work — it exercises the real router, the OAS layer, real Postgres,
 // and the real entitlement GetAccess fan-out over HTTP.
 //
-// What it is NOT: a production-latency oracle. Entitlements seeded here are
-// boolean, so GetAccess skips the metered balance path (ClickHouse). That path is
-// the larger production cost and is instrumented separately (entitlement package).
-// A metered variant — seeding usage events and waiting for ClickHouse ingestion —
-// is the follow-up for measuring it.
+// Entitlement kind (GOV_BENCH_KIND) selects what GetAccess actually does:
+//   - boolean (default): the balance path is short-circuited — algorithmic baseline.
+//   - metered / mixed:   GetAccess runs a ClickHouse usage query per metered
+//     entitlement, the larger production cost. This is the path the deferred
+//     resolveAccess parallelization is meant to speed up, so measuring it here is
+//     what tells us whether that optimization moves the ceiling.
+//
+// Caveat: the metered path is exercised by the per-entitlement usage query inside
+// GetAccess; this fixture does NOT ingest usage events (that would require waiting
+// for ClickHouse ingestion and is flaky/slow). So row volume is minimal — the cost
+// measured is the per-entitlement query overhead × N customers, which is exactly the
+// serial structure parallelization targets, not absolute production row-scan time.
+//
+// The ClickHouse query is issued even with no grants and no events: with zero grants
+// the burndown engine still produces a single full-period phase (credit/engine
+// burnphase.go) and runBetweenResets calls QueryUsage for it (credit/engine run.go).
+// So there is no zero-grant/zero-usage short-circuit that would collapse the metered
+// path back to the boolean one — verified, which is why seeding grants or events is
+// unnecessary to make the metered benchmark meaningful. Ingesting events would only
+// add row-scan volume on top, material only at production data scale this harness is
+// not built to seed.
 //
 // Sizes scale customers x features. The customer-count axis drives the GetAccess
 // fan-out (the dominant cost); the feature-count axis drives the per-customer
@@ -66,55 +120,83 @@ func BenchmarkGovernanceQuery(b *testing.B) {
 		}
 	}
 
-	for _, s := range sizes {
-		b.Run(s.name, func(b *testing.B) {
-			custKeys, featKeys := seedGovernanceFixture(b, client, s.customers, s.features)
+	for _, kind := range selectedKinds() {
+		for _, s := range sizes {
+			b.Run(fmt.Sprintf("kind=%s/%s", kind, s.name), func(b *testing.B) {
+				custKeys, featKeys := seedGovernanceFixture(b, client, s.customers, s.features, kind)
 
-			reqBody := apiv3.GovernanceQueryRequest{
-				Customer: apiv3.GovernanceQueryRequestCustomers{Keys: custKeys},
-				Feature:  &apiv3.GovernanceQueryRequestFeatures{Keys: featKeys},
-			}
-
-			// Warm-up + correctness gate: a wrong result (e.g. missing customers)
-			// would make the latency number meaningless.
-			status, resp, problem := v3.QueryGovernance(reqBody)
-			require.Equalf(b, http.StatusOK, status, "governance query failed: %+v", problem)
-			require.Lenf(b, resp.Data, s.customers, "expected %d resolved customers", s.customers)
-			require.Lenf(b, resp.Data[0].Features, s.features, "expected %d features per customer", s.features)
-
-			b.ReportAllocs()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				status, _, _ := v3.QueryGovernance(reqBody)
-				if status != http.StatusOK {
-					b.Fatalf("governance query returned %d", status)
+				reqBody := apiv3.GovernanceQueryRequest{
+					Customer: apiv3.GovernanceQueryRequestCustomers{Keys: custKeys},
+					Feature:  &apiv3.GovernanceQueryRequestFeatures{Keys: featKeys},
 				}
-			}
-			b.StopTimer()
-		})
+
+				// Warm-up + correctness gate: a wrong result (e.g. missing customers)
+				// would make the latency number meaningless.
+				status, resp, problem := v3.QueryGovernance(reqBody)
+				require.Equalf(b, http.StatusOK, status, "governance query failed: %+v", problem)
+				require.Lenf(b, resp.Data, s.customers, "expected %d resolved customers", s.customers)
+				require.Lenf(b, resp.Data[0].Features, s.features, "expected %d features per customer", s.features)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					status, _, _ := v3.QueryGovernance(reqBody)
+					if status != http.StatusOK {
+						b.Fatalf("governance query returned %d", status)
+					}
+				}
+				b.StopTimer()
+			})
+		}
 	}
 }
 
-// seedGovernanceFixture creates nFeatures boolean features and nCustomers
-// customers, granting each customer a boolean entitlement for every feature
-// (nCustomers x nFeatures entitlements). Keys carry a per-run unique prefix so
-// repeated runs against the same database do not collide. Returns the customer
+// seedGovernanceFixture creates nFeatures features and nCustomers customers, granting
+// each customer one entitlement per feature (nCustomers x nFeatures entitlements). The
+// entitlement type is chosen per feature by kind: boolean for kindBoolean, metered for
+// kindMetered, and alternating boolean/metered (~50/50) for kindMixed. Metered features
+// are backed by a single SUM meter created once per run. Keys carry a per-run unique
+// prefix so repeated runs against the same database do not collide. Returns the customer
 // keys and feature keys to query.
-func seedGovernanceFixture(b *testing.B, client *api.ClientWithResponses, nCustomers, nFeatures int) (custKeys, featKeys []string) {
+func seedGovernanceFixture(b *testing.B, client *api.ClientWithResponses, nCustomers, nFeatures int, kind entKind) (custKeys, featKeys []string) {
 	b.Helper()
 	ctx := b.Context()
 	run := uniqueKey("gov_bench")
 
+	// isMetered reports whether feature i is metered, given the kind.
+	isMetered := func(i int) bool {
+		switch kind {
+		case kindMetered:
+			return true
+		case kindMixed:
+			return i%2 == 1
+		default: // kindBoolean
+			return false
+		}
+	}
+
+	// Any metered feature needs a meter to point at; create one SUM meter for the run.
+	var meterSlug string
+	for i := 0; i < nFeatures; i++ {
+		if isMetered(i) {
+			meterSlug = createGovernanceMeter(b, client, ctx, run)
+			break
+		}
+	}
+
 	featKeys = make([]string, 0, nFeatures)
+	featMetered := make([]bool, 0, nFeatures)
 	for i := 0; i < nFeatures; i++ {
 		fkey := fmt.Sprintf("%s_feat_%d", run, i)
-		resp, err := client.CreateFeatureWithResponse(ctx, api.CreateFeatureJSONRequestBody{
-			Key:  fkey,
-			Name: fkey,
-		})
+		body := api.CreateFeatureJSONRequestBody{Key: fkey, Name: fkey}
+		if isMetered(i) {
+			body.MeterSlug = convert.ToPointer(meterSlug)
+		}
+		resp, err := client.CreateFeatureWithResponse(ctx, body)
 		require.NoError(b, err)
 		require.Equalf(b, http.StatusCreated, resp.StatusCode(), "create feature: %s", resp.Body)
 		featKeys = append(featKeys, fkey)
+		featMetered = append(featMetered, isMetered(i))
 	}
 
 	custKeys = make([]string, 0, nCustomers)
@@ -135,13 +217,38 @@ func seedGovernanceFixture(b *testing.B, client *api.ClientWithResponses, nCusto
 		require.Equalf(b, http.StatusCreated, custResp.StatusCode(), "create customer: %s", custResp.Body)
 		custID := custResp.JSON201.Id
 
-		for _, fkey := range featKeys {
-			grantBooleanEntitlement(b, client, ctx, custID, fkey)
+		for i, fkey := range featKeys {
+			if featMetered[i] {
+				grantMeteredEntitlement(b, client, ctx, custID, fkey)
+			} else {
+				grantBooleanEntitlement(b, client, ctx, custID, fkey)
+			}
 		}
 		custKeys = append(custKeys, ckey)
 	}
 
 	return custKeys, featKeys
+}
+
+// createGovernanceMeter creates a single SUM meter for the benchmark run and returns its
+// slug. All metered features in the run share this meter; the meter exists only so
+// metered entitlements resolve a usage query — no events are ingested against it.
+func createGovernanceMeter(b *testing.B, client *api.ClientWithResponses, ctx context.Context, run string) string {
+	b.Helper()
+
+	slug := run + "_meter"
+	resp, err := client.CreateMeterWithResponse(ctx, api.MeterCreate{
+		Slug:          slug,
+		Name:          convert.ToPointer(slug),
+		Aggregation:   api.MeterAggregationSum,
+		EventType:     run + "_event",
+		ValueProperty: convert.ToPointer("$.value"),
+	})
+	require.NoError(b, err)
+	// The meter API returns 200 (not 201) on create.
+	require.Equalf(b, http.StatusOK, resp.StatusCode(), "create meter: %s", resp.Body)
+
+	return slug
 }
 
 // grantBooleanEntitlement creates a boolean entitlement for the given customer and
@@ -158,4 +265,28 @@ func grantBooleanEntitlement(b *testing.B, client *api.ClientWithResponses, ctx 
 	resp, err := client.CreateCustomerEntitlementV2WithResponse(ctx, custID, body)
 	require.NoError(b, err)
 	require.Equalf(b, http.StatusCreated, resp.StatusCode(), "create boolean entitlement: %s", resp.Body)
+}
+
+// grantMeteredEntitlement creates a metered entitlement for the given customer and
+// feature key via the V2 customer-entitlement endpoint. The metered type is what forces
+// GetAccess to run a balance/usage query (ClickHouse) when governance resolves access.
+func grantMeteredEntitlement(b *testing.B, client *api.ClientWithResponses, ctx context.Context, custID, featureKey string) {
+	b.Helper()
+
+	month := &api.RecurringPeriodInterval{}
+	require.NoError(b, month.FromRecurringPeriodIntervalEnum(api.RecurringPeriodIntervalEnumMONTH))
+
+	var body api.CreateCustomerEntitlementV2JSONRequestBody
+	require.NoError(b, body.FromEntitlementMeteredV2CreateInputs(api.EntitlementMeteredV2CreateInputs{
+		Type:       "metered",
+		FeatureKey: lo.ToPtr(featureKey),
+		UsagePeriod: api.RecurringPeriodCreateInput{
+			Anchor:   convert.ToPointer(time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)),
+			Interval: *month,
+		},
+	}))
+
+	resp, err := client.CreateCustomerEntitlementV2WithResponse(ctx, custID, body)
+	require.NoError(b, err)
+	require.Equalf(b, http.StatusCreated, resp.StatusCode(), "create metered entitlement: %s", resp.Body)
 }

--- a/e2e/governance_bench_test.go
+++ b/e2e/governance_bench_test.go
@@ -281,7 +281,10 @@ func grantMeteredEntitlement(b *testing.B, client *api.ClientWithResponses, ctx 
 		Type:       "metered",
 		FeatureKey: lo.ToPtr(featureKey),
 		UsagePeriod: api.RecurringPeriodCreateInput{
-			Anchor:   convert.ToPointer(time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)),
+			// Anchor at seed time so only the current usage period is evaluated. A fixed past
+			// anchor would let the balance engine accrue a monthly reset period per elapsed
+			// month, drifting benchmark cost over time and breaking cross-run comparisons.
+			Anchor:   convert.ToPointer(time.Now().UTC()),
 			Interval: *month,
 		},
 	}))

--- a/openmeter/credit/helper.go
+++ b/openmeter/credit/helper.go
@@ -177,6 +177,35 @@ func (m *connector) snapshotEngineResult(ctx context.Context, snapParams snapsho
 	ctx, span := m.Tracer.Start(ctx, "credit.snapshotEngineResult", cTrace.WithOwner(snapParams.owner))
 	defer span.End()
 
+	// Skip snapshotting for LATEST type entitlements as the values fluctuate and snapshots can't be used
+	if snapParams.meter.Aggregation == meter.MeterAggregationLatest {
+		m.Logger.Debug("skipping snapshot for LATEST aggregation type entitlement", "owner", snapParams.owner, "meter", snapParams.meter.Key)
+		return nil
+	}
+
+	// Decide which segment (if any) to snapshot BEFORE acquiring the owner lock. This scan is
+	// pure (in-memory over the engine history), so when nothing qualifies we can skip the
+	// advisory-lock transaction entirely. That matters on the read path (GetBalanceAt runs this
+	// once per metered entitlement): without a qualifying segment the lock transaction would
+	// otherwise hold a pool connection for no persisted result.
+	segs := runRes.History.Segments()
+
+	snapshotIdx := -1
+
+	// i >= 1 because:
+	// The first segment starts with the last valid snapshot and we don't want to create another snapshot for that same time
+	for i := len(segs) - 1; i >= 1; i-- {
+		// We can save a segment if its not after the current period start (this way backfilling, granting, resetting, etc... will work for the current UsagePeriod)
+		if !segs[i].From.After(snapParams.notAfter) {
+			snapshotIdx = i
+			break
+		}
+	}
+
+	if snapshotIdx == -1 {
+		return nil
+	}
+
 	if err := transaction.RunWithNoValue(ctx, m.GrantRepo, func(ctx context.Context) error {
 		return m.OwnerConnector.LockOwnerForTx(ctx, snapParams.owner, false)
 	}); err != nil {
@@ -184,32 +213,13 @@ func (m *connector) snapshotEngineResult(ctx context.Context, snapParams snapsho
 		return nil
 	}
 
-	// Skip snapshotting for LATEST type entitlements as the values fluctuate and snapshots can't be used
-	if snapParams.meter.Aggregation == meter.MeterAggregationLatest {
-		m.Logger.Debug("skipping snapshot for LATEST aggregation type entitlement", "owner", snapParams.owner, "meter", snapParams.meter.Key)
-		return nil
+	snap, err := runRes.History.GetSnapshotAtStartOfSegment(snapshotIdx)
+	if err != nil {
+		return fmt.Errorf("failed to get snapshot at start of segment: %w", err)
 	}
 
-	segs := runRes.History.Segments()
-
-	// i >= 1 because:
-	// The first segment starts with the last valid snapshot and we don't want to create another snapshot for that same time
-	for i := len(segs) - 1; i >= 1; i-- {
-		seg := segs[i]
-
-		// We can save a segment if its not after the current period start (this way backfilling, granting, resetting, etc... will work for the current UsagePeriod)
-		if !seg.From.After(snapParams.notAfter) {
-			snap, err := runRes.History.GetSnapshotAtStartOfSegment(i)
-			if err != nil {
-				return fmt.Errorf("failed to get snapshot at start of segment: %w", err)
-			}
-
-			if _, err := m.saveSnapshot(ctx, snapParams, snap); err != nil {
-				return fmt.Errorf("failed to save snapshot: %w", err)
-			}
-
-			break
-		}
+	if _, err := m.saveSnapshot(ctx, snapParams, snap); err != nil {
+		return fmt.Errorf("failed to save snapshot: %w", err)
 	}
 
 	return nil

--- a/openmeter/entitlement/metered/balance.go
+++ b/openmeter/entitlement/metered/balance.go
@@ -72,7 +72,7 @@ func (e *connector) GetEntitlementBalance(ctx context.Context, entitlementID mod
 	// below (usage period start, describe owner, reset timeline, start of measurement) each
 	// re-fetch it. Memoize it for the duration of this balance calculation so they share one
 	// GetEntitlement query instead of issuing ~6 identical ones per entitlement.
-	ctx = WithEntitlementCache(ctx)
+	ctx = withEntitlementCache(ctx)
 
 	// We round up to closest full minute to include all the partial usage in the last minute of querying
 	// Not that this will never throw us to a different usage period

--- a/openmeter/entitlement/metered/balance.go
+++ b/openmeter/entitlement/metered/balance.go
@@ -68,6 +68,12 @@ func (e *connector) GetEntitlementBalance(ctx context.Context, entitlementID mod
 
 	e.logger.DebugContext(ctx, "Getting entitlement balance", "entitlement", entitlementID, "at", at)
 
+	// The owner entitlement is immutable for this read, but the owner-adapter methods invoked
+	// below (usage period start, describe owner, reset timeline, start of measurement) each
+	// re-fetch it. Memoize it for the duration of this balance calculation so they share one
+	// GetEntitlement query instead of issuing ~6 identical ones per entitlement.
+	ctx = WithEntitlementCache(ctx)
+
 	// We round up to closest full minute to include all the partial usage in the last minute of querying
 	// Not that this will never throw us to a different usage period
 	if trunc := at.Truncate(time.Minute); trunc.Before(at) {

--- a/openmeter/entitlement/metered/grant_owner_adapter.go
+++ b/openmeter/entitlement/metered/grant_owner_adapter.go
@@ -68,10 +68,22 @@ type entitlementCacheEntry struct {
 	err  error
 }
 
-// WithEntitlementCache installs a request-scoped cache for the owner-entitlement lookups made
-// by this adapter. It is opt-in: callers that do not install it (e.g. one-off value reads) hit
-// the database directly and are unaffected. Nesting is a no-op so the outermost scope wins.
-func WithEntitlementCache(ctx context.Context) context.Context {
+// withEntitlementCache installs a scoped cache for the owner-entitlement lookups made by this
+// adapter. It is opt-in: callers that do not install it (e.g. one-off value reads) hit the
+// database directly and are unaffected. Nesting is a no-op so the outermost scope wins.
+//
+// INVARIANT — install ONLY around read-only operations. Cached entries are never invalidated
+// within their scope, so if this cache is installed around a call stack that MUTATES the owner
+// entitlement, any getEntitlement after that write returns the stale, pre-write row. This is
+// safe today because the sole installer is GetEntitlementBalance, whose call tree performs no
+// entitlement writes (it only writes balance_snapshot); the only entitlement mutation on this
+// adapter, EndCurrentUsagePeriod, lives in the reset flow, which the cache never wraps.
+//
+// It is unexported deliberately: keeping installation inside this package prevents callers from
+// enabling the cache around a write-containing stack. If a future read-only path wants the same
+// memo, install it here at that entry point — do not expose it. If you ever need it around a
+// stack that can write an entitlement, add an eviction (delete the owner key) on the write.
+func withEntitlementCache(ctx context.Context) context.Context {
 	if _, ok := ctx.Value(entitlementCacheCtxKey{}).(*sync.Map); ok {
 		return ctx
 	}
@@ -79,8 +91,8 @@ func WithEntitlementCache(ctx context.Context) context.Context {
 	return context.WithValue(ctx, entitlementCacheCtxKey{}, &sync.Map{})
 }
 
-// getEntitlement fetches the owner entitlement, serving it from the context-scoped cache when
-// one is installed (see WithEntitlementCache). Without a cache it falls back to a direct fetch,
+// getEntitlement fetches the owner entitlement, serving it from the scoped cache when one is
+// installed (see withEntitlementCache). Without a cache it falls back to a direct fetch,
 // preserving the previous behavior for callers that do not opt in.
 func (e *entitlementGrantOwner) getEntitlement(ctx context.Context, owner models.NamespacedID) (*entitlement.Entitlement, error) {
 	cache, ok := ctx.Value(entitlementCacheCtxKey{}).(*sync.Map)

--- a/openmeter/entitlement/metered/grant_owner_adapter.go
+++ b/openmeter/entitlement/metered/grant_owner_adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/samber/lo"
@@ -52,6 +53,51 @@ func NewEntitlementGrantOwnerAdapter(
 	}
 }
 
+// entitlementCacheCtxKey scopes a per-operation memo of owner-entitlement lookups. Within a
+// single balance calculation the same owner entitlement is read by several methods here
+// (DescribeOwner, GetStartOfMeasurement, GetUsagePeriodStartAt, GetResetTimelineInclusive),
+// each issuing its own GetEntitlement query for the same immutable row. The entitlement cannot
+// change for the duration of that read, so the cache lets those methods share one fetch.
+type entitlementCacheCtxKey struct{}
+
+// entitlementCacheEntry memoizes one owner's GetEntitlement result (value or error) so
+// concurrent readers of the same owner resolve to a single DB fetch.
+type entitlementCacheEntry struct {
+	once sync.Once
+	ent  *entitlement.Entitlement
+	err  error
+}
+
+// WithEntitlementCache installs a request-scoped cache for the owner-entitlement lookups made
+// by this adapter. It is opt-in: callers that do not install it (e.g. one-off value reads) hit
+// the database directly and are unaffected. Nesting is a no-op so the outermost scope wins.
+func WithEntitlementCache(ctx context.Context) context.Context {
+	if _, ok := ctx.Value(entitlementCacheCtxKey{}).(*sync.Map); ok {
+		return ctx
+	}
+
+	return context.WithValue(ctx, entitlementCacheCtxKey{}, &sync.Map{})
+}
+
+// getEntitlement fetches the owner entitlement, serving it from the context-scoped cache when
+// one is installed (see WithEntitlementCache). Without a cache it falls back to a direct fetch,
+// preserving the previous behavior for callers that do not opt in.
+func (e *entitlementGrantOwner) getEntitlement(ctx context.Context, owner models.NamespacedID) (*entitlement.Entitlement, error) {
+	cache, ok := ctx.Value(entitlementCacheCtxKey{}).(*sync.Map)
+	if !ok {
+		return e.entitlementRepo.GetEntitlement(ctx, owner)
+	}
+
+	v, _ := cache.LoadOrStore(owner.Namespace+"/"+owner.ID, &entitlementCacheEntry{})
+	entry := v.(*entitlementCacheEntry)
+
+	entry.once.Do(func() {
+		entry.ent, entry.err = e.entitlementRepo.GetEntitlement(ctx, owner)
+	})
+
+	return entry.ent, entry.err
+}
+
 func (e *entitlementGrantOwner) DescribeOwner(ctx context.Context, id models.NamespacedID) (grant.Owner, error) {
 	ctx, span := e.tracer.Start(ctx, "meteredentitlement.DescribeOwner", mTrace.WithOwner(id))
 	defer span.End()
@@ -59,7 +105,7 @@ func (e *entitlementGrantOwner) DescribeOwner(ctx context.Context, id models.Nam
 	var def grant.Owner
 
 	// get feature of ent
-	ent, err := e.entitlementRepo.GetEntitlement(ctx, id)
+	ent, err := e.getEntitlement(ctx, id)
 	if err != nil {
 		if _, ok := lo.ErrorsAs[*entitlement.NotFoundError](err); ok {
 			return def, grant.NewOwnerNotFoundError(id, "entitlement")
@@ -138,7 +184,7 @@ func (e *entitlementGrantOwner) GetStartOfMeasurement(ctx context.Context, owner
 	ctx, span := e.tracer.Start(ctx, "meteredentitlement.GetStartOfMeasurement", mTrace.WithOwner(owner))
 	defer span.End()
 
-	owningEntitlement, err := e.entitlementRepo.GetEntitlement(ctx, owner)
+	owningEntitlement, err := e.getEntitlement(ctx, owner)
 	if err != nil {
 		if _, ok := lo.ErrorsAs[*entitlement.NotFoundError](err); ok {
 			return time.Time{}, grant.NewOwnerNotFoundError(owner, "entitlement")
@@ -160,7 +206,7 @@ func (e *entitlementGrantOwner) GetUsagePeriodStartAt(ctx context.Context, owner
 	ctx, span := e.tracer.Start(ctx, "meteredentitlement.GetUsagePeriodStartAt", mTrace.WithOwner(owner), trace.WithAttributes(attribute.String("at", at.String())))
 	defer span.End()
 
-	ent, err := e.entitlementRepo.GetEntitlement(ctx, owner)
+	ent, err := e.getEntitlement(ctx, owner)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -186,7 +232,7 @@ func (e *entitlementGrantOwner) GetResetTimelineInclusive(ctx context.Context, o
 	var def timeutil.SimpleTimeline
 
 	// Let's fetch the owner entitlement
-	ent, err := e.entitlementRepo.GetEntitlement(ctx, owner)
+	ent, err := e.getEntitlement(ctx, owner)
 	if err != nil {
 		return def, err
 	}

--- a/openmeter/governance/service/service.go
+++ b/openmeter/governance/service/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"sort"
 	"time"
 
@@ -28,15 +29,16 @@ import (
 const featureFetchLimit = 10_000
 
 // maxCustomerConcurrency bounds how many customers on a page resolve access in parallel.
-// It is deliberately conservative because the pressure multiplies: entitlementService.GetAccess
-// ALREADY fans a customer's entitlements out ~10-wide internally, so the peak number of
-// concurrent per-entitlement DB/ClickHouse operations is roughly maxCustomerConcurrency × 10.
-// The Postgres pool defaults to ~NumCPU connections (pgxpool with no pool_max_conns), and each
-// metered value calc holds a connection (including a short snapshot lock transaction), so a
-// larger value would mostly queue on connection acquisition and, under concurrent request load,
-// risk acquire timeouts. Lower it if pool-acquisition latency shows up. A single-request
-// benchmark will NOT reveal that pressure, since it never runs two requests at once.
-const maxCustomerConcurrency = 5
+//
+// It scales with the machine (GOMAXPROCS) so the bound tracks the pgx pool, which also defaults
+// to ~NumCPU connections (pgxpool with no pool_max_conns). It is HALVED rather than set to full
+// GOMAXPROCS because the pressure multiplies: entitlementService.GetAccess ALREADY fans a
+// customer's entitlements out ~10-wide internally, so peak concurrent per-entitlement DB/ClickHouse
+// operations is roughly maxCustomerConcurrency × 10. Halving keeps some pool headroom for
+// concurrent requests; the pgx pool (which blocks on acquire rather than erroring) is the real
+// backstop, so this mainly bounds goroutines and queue depth. A single-request benchmark will NOT
+// reveal cross-request pool pressure. Floor of 2 guarantees some parallelism on small boxes.
+var maxCustomerConcurrency = max(2, runtime.GOMAXPROCS(0)/2)
 
 // Config holds the collaborating services for the governance Service.
 type Config struct {

--- a/openmeter/governance/service/service.go
+++ b/openmeter/governance/service/service.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/openmeterio/openmeter/openmeter/customer"
 	"github.com/openmeterio/openmeter/openmeter/entitlement"
@@ -25,6 +26,17 @@ import (
 // featureFetchLimit caps the org-wide feature fetch used when no feature filter is given.
 // Acceptable for prototype scale; revisit if feature counts grow large.
 const featureFetchLimit = 10_000
+
+// maxCustomerConcurrency bounds how many customers on a page resolve access in parallel.
+// It is deliberately conservative because the pressure multiplies: entitlementService.GetAccess
+// ALREADY fans a customer's entitlements out ~10-wide internally, so the peak number of
+// concurrent per-entitlement DB/ClickHouse operations is roughly maxCustomerConcurrency × 10.
+// The Postgres pool defaults to ~NumCPU connections (pgxpool with no pool_max_conns), and each
+// metered value calc holds a connection (including a short snapshot lock transaction), so a
+// larger value would mostly queue on connection acquisition and, under concurrent request load,
+// risk acquire timeouts. Lower it if pool-acquisition latency shows up. A single-request
+// benchmark will NOT reveal that pressure, since it never runs two requests at once.
+const maxCustomerConcurrency = 5
 
 // Config holds the collaborating services for the governance Service.
 type Config struct {
@@ -392,35 +404,50 @@ func (s *service) resolveAccess(ctx context.Context, input governance.QueryAcces
 		}
 
 		now := clock.Now()
-		results := make([]governance.CustomerAccess, 0, len(customers))
-		absentFeatureLookups := 0
-		featureAccessTotal := 0
 
-		for _, rc := range customers {
-			access, err := s.entitlementService.GetAccess(ctx, input.Namespace, rc.customer.ID)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get access for customer %s: %w", rc.customer.ID, err)
-			}
+		// Resolve customers concurrently but bounded (see maxCustomerConcurrency). Results and
+		// per-customer span counters are written into pre-sized slices by index so the page keeps
+		// its (CreatedAt, ID) sort order and there is no shared-state mutation across goroutines.
+		results := make([]governance.CustomerAccess, len(customers))
+		absentLookupsPer := make([]int, len(customers))
+		featureAccessPer := make([]int, len(customers))
 
-			featureAccessResult, err := s.buildFeatureAccess(ctx, input.Namespace, input.FeatureKeys, orgFeatures, access)
-			if err != nil {
-				return nil, fmt.Errorf("failed to build feature access for customer %s: %w", rc.customer.ID, err)
-			}
+		g, ctx := errgroup.WithContext(ctx)
+		g.SetLimit(maxCustomerConcurrency)
 
-			absentFeatureLookups += featureAccessResult.absentLookups
-			featureAccessTotal += len(featureAccessResult.featureAccess)
+		for i, rc := range customers {
+			g.Go(func() error {
+				access, err := s.entitlementService.GetAccess(ctx, input.Namespace, rc.customer.ID)
+				if err != nil {
+					return fmt.Errorf("failed to get access for customer %s: %w", rc.customer.ID, err)
+				}
 
-			results = append(results, governance.CustomerAccess{
-				Customer:  rc.customer,
-				Matched:   rc.matched,
-				Features:  featureAccessResult.featureAccess,
-				UpdatedAt: now,
+				featureAccessResult, err := s.buildFeatureAccess(ctx, input.Namespace, input.FeatureKeys, orgFeatures, access)
+				if err != nil {
+					return fmt.Errorf("failed to build feature access for customer %s: %w", rc.customer.ID, err)
+				}
+
+				absentLookupsPer[i] = featureAccessResult.absentLookups
+				featureAccessPer[i] = len(featureAccessResult.featureAccess)
+
+				results[i] = governance.CustomerAccess{
+					Customer:  rc.customer,
+					Matched:   rc.matched,
+					Features:  featureAccessResult.featureAccess,
+					UpdatedAt: now,
+				}
+
+				return nil
 			})
 		}
 
+		if err := g.Wait(); err != nil {
+			return nil, err
+		}
+
 		span.SetAttributes(
-			attribute.Int("absent_feature_lookups", absentFeatureLookups),
-			attribute.Int("feature_access_total", featureAccessTotal),
+			attribute.Int("absent_feature_lookups", lo.Sum(absentLookupsPer)),
+			attribute.Int("feature_access_total", lo.Sum(featureAccessPer)),
 		)
 
 		return results, nil


### PR DESCRIPTION
## Governance query performance improvements

### What

Speeds up `POST /governance/query` for metered entitlements (~40% lower latency; 100×100 ≈25s → ≈12.5s) and extends the benchmark to cover the metered path.

### Why

The endpoint resolves access per customer, and each metered entitlement's `GetAccess` did far more Postgres work than necessary: the same entitlement row was re-fetched ~6× per balance calc, the customer loop ran serially, and every read took an advisory-lock transaction even when no snapshot was written. The existing benchmark only exercised boolean entitlements, so none of this was visible.

### How

- **Benchmark**: added an entitlement-kind axis (`GOV_BENCH_KIND=boolean|metered|mixed|all`) plus a `bench-governance-trace` target for capturing a single small cell's trace safely.
- **Fewer queries** (`metered/grant_owner_adapter.go`): memoize the owner-entitlement lookup within one balance calculation via a context-scoped cache, collapsing ~6 `GetEntitlement` fetches to 1 (~23 → ~13 SQL/entitlement). Installer is unexported and read-only-scoped by design (documented invariant).
- **Parallel resolution** (`governance/service/service.go`): resolve a page's customers concurrently with a bounded `errgroup`, limit `max(2, GOMAXPROCS/2)` — scales with the box and the ~NumCPU pgx pool, halved because `GetAccess` already fans out ~10-wide internally. Results written by index to preserve sort order.
- **No lock on empty reads** (`credit/helper.go`): check whether a snapshot segment actually qualifies *before* taking the owner lock, skipping the lock transaction (and its held connection) on steady-state metered reads.

Behavior-preserving and verified via traces. The credit/entitlement changes also benefit other metered balance reads (e.g. the balance worker), not just governance. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded the governance end-to-end benchmark to cover multiple entitlement resolution patterns (boolean, metered, and mixed).
  * Added a pre-benchmark validation step to verify governance query results match expected counts for each tested scenario.
  * Enhanced benchmark data setup to generate the appropriate entitlement mix per feature and to create required metered entitlements for the metered cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->