### PR TITLE
chore(flake): bump codegraph to 1.2.0, run pnpx tooling via pnpm dlx

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -113,15 +113,17 @@
               # Multi-platform support makes this a bit more difficult
               postgresql
 
-              # node
-              corepack_24
+              # node: pnpm (from javascript.pnpm) provides `pnpm dlx` as the
+              # npx-style runner for these one-off CLIs. The invoked bin runs
+              # under the dev shell's `node` (nodejs-slim_26) via its env-node
+              # shebang, so no separate corepack/Node runtime is needed.
               # We can consider adding a pkgs.buildNpmPackage for spectral-cli if build takes a lot of time, but for now
               # this is a quick fix to get it working.
               (writeShellScriptBin "spectral" ''
-                exec ${pkgs.corepack_24}/bin/pnpx @stoplight/spectral-cli@6.16.0 "$@"
+                exec ${pkgs.pnpm}/bin/pnpm dlx @stoplight/spectral-cli@6.16.0 "$@"
               '')
               (writeShellScriptBin "codegraph" ''
-                exec ${pkgs.corepack_24}/bin/pnpx @colbymchenry/codegraph@0.9.6 "$@"
+                exec ${pkgs.pnpm}/bin/pnpm dlx @colbymchenry/codegraph@1.2.0 "$@"
               '')
 
               # python


### PR DESCRIPTION
## What

Bump `codegraph` `0.9.6 → 1.2.0` and drop the `corepack_24` dev-shell dependency, running the `spectral` and `codegraph` CLIs via `pnpm dlx` instead.

## Why

`nodejs-slim_26` ships no bundled corepack, so `corepack_24` was pulled in solely to provide `pnpx` — a redundant second Node runtime. `pnpm` (already provided by `languages.javascript`) exposes `pnpm dlx`, the same npx-style runner.

## How

- Repoint the `spectral` and `codegraph` `writeShellScriptBin` wrappers from `${corepack_24}/bin/pnpx` to `${pkgs.pnpm}/bin/pnpm dlx`.
- Remove the `corepack_24` package from the shell.

The invoked bin runs under the dev shell's `node` (`nodejs-slim_26`, v26.4.0) via its env-node shebang — verified: `codegraph --version` → `1.2.0`, `make gen-api` (spectral) green, `.nvmrc` unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the developer shell wrappers for the `spectral` and `codegraph` commands to use a more reliable invocation method.
  - Bumped the bundled `codegraph` tool to a newer version, which may improve compatibility and behavior.
  - Added clearer notes for how these commands are launched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->