### PR TITLE
fix(billing): route API invoice delete to line engines

### DIFF
--- a/openmeter/billing/gatheringinvoice.go
+++ b/openmeter/billing/gatheringinvoice.go
@@ -626,6 +626,10 @@ func (g GatheringLineBase) GetEngine() LineEngineType {
 	return g.Engine
 }
 
+func (g GatheringLineBase) GetLineEngineType() LineEngineType {
+	return g.Engine
+}
+
 func (g GatheringLineBase) GetRateCardDiscounts() Discounts {
 	return g.RateCardDiscounts
 }

--- a/openmeter/billing/httpdriver/invoice.go
+++ b/openmeter/billing/httpdriver/invoice.go
@@ -367,6 +367,10 @@ func (h *handler) DeleteInvoice() DeleteInvoiceHandler {
 			}, nil
 		},
 		func(ctx context.Context, request DeleteInvoiceRequest) (DeleteInvoiceResponse, error) {
+			if err := h.validateAPIInvoiceDeleteSupported(ctx, request); err != nil {
+				return DeleteInvoiceResponse{}, err
+			}
+
 			invoice, err := h.service.DeleteInvoice(ctx, request)
 			if err != nil {
 				return DeleteInvoiceResponse{}, err
@@ -397,6 +401,49 @@ func (h *handler) DeleteInvoice() DeleteInvoiceHandler {
 			httptransport.WithErrorEncoder(errorEncoder()),
 		)...,
 	)
+}
+
+// validateAPIInvoiceDeleteSupported is a temporary HTTP-level guard until
+// usage-based invoice-scope deletion is implemented. It blocks the public API
+// before DeleteInvoice can run side-effectful line-engine cleanup on other
+// charge-backed lines in the same invoice.
+func (h *handler) validateAPIInvoiceDeleteSupported(ctx context.Context, request DeleteInvoiceRequest) error {
+	invoice, err := h.service.GetInvoiceById(ctx, billing.GetInvoiceByIdInput{
+		Invoice: request.Invoice,
+		Expand:  billing.InvoiceExpandAll,
+	})
+	if err != nil {
+		return err
+	}
+
+	genericInvoice, err := invoice.AsGenericInvoice()
+	if err != nil {
+		return err
+	}
+
+	return validateAPIGenericInvoiceDeleteSupported(genericInvoice)
+}
+
+func validateAPIGenericInvoiceDeleteSupported(invoice billing.GenericInvoice) error {
+	for _, line := range invoice.GetGenericLines().OrEmpty() {
+		if line == nil || line.GetDeletedAt() != nil {
+			continue
+		}
+
+		// Usage-based charge deletion at invoice scope is not implemented yet.
+		// Keep this HTTP-only guard ahead of DeleteInvoice so mixed invoices
+		// cannot run flat-fee cleanup before a usage-based line rejects.
+		if line.GetLineEngineType() == billing.LineEngineTypeChargeUsageBased {
+			return billing.ValidationError{
+				Err: billing.ValidationWithComponent(
+					billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased),
+					billing.ErrCannotUpdateChargeManagedLine,
+				),
+			}
+		}
+	}
+
+	return nil
 }
 
 type (

--- a/openmeter/billing/httpdriver/invoice.go
+++ b/openmeter/billing/httpdriver/invoice.go
@@ -367,29 +367,29 @@ func (h *handler) DeleteInvoice() DeleteInvoiceHandler {
 			}, nil
 		},
 		func(ctx context.Context, request DeleteInvoiceRequest) (DeleteInvoiceResponse, error) {
-			if err := h.validateAPIInvoiceDeleteSupported(ctx, request); err != nil {
-				return DeleteInvoiceResponse{}, err
-			}
-
-			invoice, err := h.service.DeleteInvoice(ctx, request)
+			invoice, err := h.service.GetInvoiceById(ctx, billing.GetInvoiceByIdInput{
+				Invoice: request.Invoice,
+				Expand:  billing.InvoiceExpandAll,
+			})
 			if err != nil {
 				return DeleteInvoiceResponse{}, err
 			}
 
-			// Given we are doing background processing, we might be in any delete.* state, but in case we ended up in delete.failed let's have
-			// proper return code for the API (otherwise we would return 200)
-			if invoice.Status == billing.StandardInvoiceStatusDeleteFailed {
-				// If we have validation issues we return them as the deletion sync handler
-				// yields validation errors
-				if len(invoice.ValidationIssues) > 0 {
-					return DeleteInvoiceResponse{}, billing.ValidationError{
-						Err: invoice.ValidationIssues.AsError(),
-					}
-				}
+			if err := validateAPIInvoiceDeleteSupported(invoice); err != nil {
+				return DeleteInvoiceResponse{}, err
+			}
 
-				return DeleteInvoiceResponse{}, billing.ValidationError{
-					Err: fmt.Errorf("%w [status=%s]", billing.ErrInvoiceDeleteFailed, invoice.Status),
+			switch invoice.Type() {
+			case billing.InvoiceTypeGathering:
+				if _, err := h.service.DeleteGatheringInvoice(ctx, request); err != nil {
+					return DeleteInvoiceResponse{}, fmt.Errorf("deleting gathering invoice: %w", err)
 				}
+			case billing.InvoiceTypeStandard:
+				if err := h.deleteStandardInvoice(ctx, request); err != nil {
+					return DeleteInvoiceResponse{}, fmt.Errorf("deleting standard invoice: %w", err)
+				}
+			default:
+				return DeleteInvoiceResponse{}, models.NewNillableGenericValidationError(fmt.Errorf("invalid invoice type: %s", invoice.Type()))
 			}
 
 			return DeleteInvoiceResponse{}, nil
@@ -403,17 +403,56 @@ func (h *handler) DeleteInvoice() DeleteInvoiceHandler {
 	)
 }
 
-// validateAPIInvoiceDeleteSupported is a temporary HTTP-level guard until
-// usage-based invoice-scope deletion is implemented. It blocks the public API
-// before DeleteInvoice can run side-effectful line-engine cleanup on other
-// charge-backed lines in the same invoice.
-func (h *handler) validateAPIInvoiceDeleteSupported(ctx context.Context, request DeleteInvoiceRequest) error {
-	invoice, err := h.service.GetInvoiceById(ctx, billing.GetInvoiceByIdInput{
-		Invoice: request.Invoice,
-		Expand:  billing.InvoiceExpandAll,
-	})
+func (h *handler) deleteStandardInvoice(ctx context.Context, request DeleteInvoiceRequest) error {
+	invoice, err := h.service.DeleteInvoice(ctx, request)
 	if err != nil {
 		return err
+	}
+
+	// Given we are doing background processing, we might be in any delete.* state, but in case we ended up in delete.failed let's have
+	// proper return code for the API (otherwise we would return 200)
+	if invoice.Status == billing.StandardInvoiceStatusDeleteFailed {
+		// If we have validation issues we return them as the deletion sync handler
+		// yields validation errors
+		if len(invoice.ValidationIssues) > 0 {
+			return billing.ValidationError{
+				Err: invoice.ValidationIssues.AsError(),
+			}
+		}
+
+		return billing.ValidationError{
+			Err: fmt.Errorf("%w [status=%s]", billing.ErrInvoiceDeleteFailed, invoice.Status),
+		}
+	}
+
+	return nil
+}
+
+// validateAPIInvoiceDeleteSupported is a temporary HTTP-level guard until
+// usage-based invoice-scope deletion is implemented. It blocks the public API
+// before standard DeleteInvoice or gathering DeleteGatheringInvoice can run
+// side-effectful line-engine cleanup on other charge-backed lines in the same
+// invoice.
+func validateAPIInvoiceDeleteSupported(invoice billing.Invoice) error {
+	switch invoice.Type() {
+	case billing.InvoiceTypeGathering:
+		gatheringInvoice, err := invoice.AsGatheringInvoice()
+		if err != nil {
+			return err
+		}
+		if gatheringInvoice.DeletedAt != nil {
+			return nil
+		}
+	case billing.InvoiceTypeStandard:
+		standardInvoice, err := invoice.AsStandardInvoice()
+		if err != nil {
+			return err
+		}
+		if standardInvoice.DeletedAt != nil {
+			return nil
+		}
+	default:
+		return models.NewNillableGenericValidationError(fmt.Errorf("invalid invoice type: %s", invoice.Type()))
 	}
 
 	genericInvoice, err := invoice.AsGenericInvoice()
@@ -431,8 +470,9 @@ func validateAPIGenericInvoiceDeleteSupported(invoice billing.GenericInvoice) er
 		}
 
 		// Usage-based charge deletion at invoice scope is not implemented yet.
-		// Keep this HTTP-only guard ahead of DeleteInvoice so mixed invoices
-		// cannot run flat-fee cleanup before a usage-based line rejects.
+		// Keep this temporary HTTP-only guard ahead of both standard and
+		// gathering invoice deletion so mixed invoices cannot run flat-fee
+		// cleanup before a usage-based line rejects.
 		if line.GetLineEngineType() == billing.LineEngineTypeChargeUsageBased {
 			return billing.ValidationError{
 				Err: billing.ValidationWithComponent(

--- a/openmeter/billing/httpdriver/invoice_test.go
+++ b/openmeter/billing/httpdriver/invoice_test.go
@@ -71,6 +71,114 @@ func TestMapInvoiceLineCreditsToAPIOmitsEmptyCredits(t *testing.T) {
 	require.Nil(t, mapInvoiceLineCreditsToAPI(nil))
 }
 
+func TestValidateAPIGenericInvoiceDeleteSupported(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	testCases := []struct {
+		name      string
+		invoice   billing.GenericInvoice
+		wantError bool
+	}{
+		{
+			name: "standard invoice flat fee line is supported",
+			invoice: standardInvoiceDeleteSupportTestInvoice(
+				standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeFlatFee, nil),
+			),
+		},
+		{
+			name: "standard invoice deleted usage-based line is ignored",
+			invoice: standardInvoiceDeleteSupportTestInvoice(
+				standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, &now),
+			),
+		},
+		{
+			name: "standard invoice active usage-based line is rejected",
+			invoice: standardInvoiceDeleteSupportTestInvoice(
+				standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
+			),
+			wantError: true,
+		},
+		{
+			name: "standard invoice mixed flat fee and active usage-based line is rejected before delete",
+			invoice: standardInvoiceDeleteSupportTestInvoice(
+				standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeFlatFee, nil),
+				standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
+			),
+			wantError: true,
+		},
+		{
+			name: "gathering invoice active usage-based line is rejected",
+			invoice: gatheringInvoiceDeleteSupportTestInvoice(
+				gatheringInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
+			),
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateAPIGenericInvoiceDeleteSupported(tc.invoice)
+
+			if !tc.wantError {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			require.ErrorIs(t, err, billing.ErrCannotUpdateChargeManagedLine)
+
+			var validationErr billing.ValidationError
+			require.ErrorAs(t, err, &validationErr)
+
+			issues, conversionErr := billing.ToValidationIssues(err)
+			require.NoError(t, conversionErr)
+			require.Len(t, issues, 1)
+			require.Equal(t, billing.ErrCannotUpdateChargeManagedLine.Code, issues[0].Code)
+			require.Equal(t, billing.ErrCannotUpdateChargeManagedLine.Message, issues[0].Message)
+			require.Equal(t, billing.ValidationIssueSeverityCritical, issues[0].Severity)
+			require.Equal(t, billing.LineEngineValidationComponent(billing.LineEngineTypeChargeUsageBased), issues[0].Component)
+		})
+	}
+}
+
+func standardInvoiceDeleteSupportTestInvoice(lines ...*billing.StandardLine) *billing.StandardInvoice {
+	return &billing.StandardInvoice{
+		Lines: billing.NewStandardInvoiceLines(lines),
+	}
+}
+
+func standardInvoiceDeleteSupportTestLine(engine billing.LineEngineType, deletedAt *time.Time) *billing.StandardLine {
+	line := &billing.StandardLine{
+		StandardLineBase: billing.StandardLineBase{
+			Engine: engine,
+		},
+	}
+	line.DeletedAt = deletedAt
+
+	return line
+}
+
+func gatheringInvoiceDeleteSupportTestInvoice(lines ...billing.GatheringLine) *billing.GatheringInvoice {
+	return &billing.GatheringInvoice{
+		Lines: billing.NewGatheringInvoiceLines(lines),
+	}
+}
+
+func gatheringInvoiceDeleteSupportTestLine(engine billing.LineEngineType, deletedAt *time.Time) billing.GatheringLine {
+	line := billing.GatheringLine{
+		GatheringLineBase: billing.GatheringLineBase{
+			Engine: engine,
+		},
+	}
+	line.DeletedAt = deletedAt
+
+	return line
+}
+
 func (s *InvoicingTestSuite) TestGatheringInvoiceSerialization() {
 	namespace := "ns-invoice-serialization"
 	ctx := s.T().Context()

--- a/openmeter/billing/httpdriver/invoice_test.go
+++ b/openmeter/billing/httpdriver/invoice_test.go
@@ -115,6 +115,12 @@ func TestValidateAPIGenericInvoiceDeleteSupported(t *testing.T) {
 			),
 			wantError: true,
 		},
+		{
+			name: "gathering invoice flat fee line is supported",
+			invoice: gatheringInvoiceDeleteSupportTestInvoice(
+				gatheringInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeFlatFee, nil),
+			),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -145,6 +151,53 @@ func TestValidateAPIGenericInvoiceDeleteSupported(t *testing.T) {
 	}
 }
 
+func TestValidateAPIInvoiceDeleteSupportedIgnoresDeletedInvoice(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	invoice := standardInvoiceDeleteSupportTestInvoice(
+		standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
+	)
+	invoice.DeletedAt = &now
+
+	err := validateAPIInvoiceDeleteSupported(billing.NewInvoice(*invoice))
+
+	require.NoError(t, err)
+}
+
+func TestValidateAPIInvoiceDeleteSupportedRejectsUsageBasedInvoices(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		invoice billing.Invoice
+	}{
+		{
+			name: "standard invoice",
+			invoice: billing.NewInvoice(*standardInvoiceDeleteSupportTestInvoice(
+				standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
+			)),
+		},
+		{
+			name: "gathering invoice",
+			invoice: billing.NewInvoice(*gatheringInvoiceDeleteSupportTestInvoice(
+				gatheringInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
+			)),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateAPIInvoiceDeleteSupported(tc.invoice)
+
+			require.Error(t, err)
+			require.ErrorIs(t, err, billing.ErrCannotUpdateChargeManagedLine)
+		})
+	}
+}
+
 func standardInvoiceDeleteSupportTestInvoice(lines ...*billing.StandardLine) *billing.StandardInvoice {
 	return &billing.StandardInvoice{
 		Lines: billing.NewStandardInvoiceLines(lines),
@@ -156,6 +209,9 @@ func standardInvoiceDeleteSupportTestLine(engine billing.LineEngineType, deleted
 		StandardLineBase: billing.StandardLineBase{
 			Engine: engine,
 		},
+	}
+	if engine == billing.LineEngineTypeChargeUsageBased {
+		line.UsageBased = &billing.UsageBasedLine{}
 	}
 	line.DeletedAt = deletedAt
 
@@ -169,11 +225,16 @@ func gatheringInvoiceDeleteSupportTestInvoice(lines ...billing.GatheringLine) *b
 }
 
 func gatheringInvoiceDeleteSupportTestLine(engine billing.LineEngineType, deletedAt *time.Time) billing.GatheringLine {
+	return gatheringInvoiceDeleteSupportTestLineWithID("", engine, deletedAt)
+}
+
+func gatheringInvoiceDeleteSupportTestLineWithID(id string, engine billing.LineEngineType, deletedAt *time.Time) billing.GatheringLine {
 	line := billing.GatheringLine{
 		GatheringLineBase: billing.GatheringLineBase{
 			Engine: engine,
 		},
 	}
+	line.ID = id
 	line.DeletedAt = deletedAt
 
 	return line

--- a/openmeter/billing/invoiceline.go
+++ b/openmeter/billing/invoiceline.go
@@ -102,6 +102,7 @@ type GenericInvoiceLineReader interface {
 	GetAnnotations() models.Annotations
 	GetInvoiceID() string
 	GetEngine() LineEngineType
+	GetLineEngineType() LineEngineType
 	GetCurrency() currencyx.Code
 	GetPrice() *productcatalog.Price
 	GetTaxConfig() *TaxConfig

--- a/openmeter/billing/service.go
+++ b/openmeter/billing/service.go
@@ -127,6 +127,7 @@ type GatheringInvoiceService interface {
 	ListGatheringInvoices(ctx context.Context, input ListGatheringInvoicesInput) (pagination.Result[GatheringInvoice], error)
 	GetGatheringInvoiceById(ctx context.Context, input GetGatheringInvoiceByIdInput) (GatheringInvoice, error)
 	UpdateGatheringInvoice(ctx context.Context, input UpdateGatheringInvoiceInput) (GatheringInvoice, error)
+	DeleteGatheringInvoice(ctx context.Context, input DeleteInvoiceInput) (GatheringInvoice, error)
 	RecalculateGatheringInvoices(ctx context.Context, input RecalculateGatheringInvoicesInput) error
 }
 

--- a/openmeter/billing/service/gatheringinvoice.go
+++ b/openmeter/billing/service/gatheringinvoice.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/rating"
 	"github.com/openmeterio/openmeter/openmeter/billing/service/invoicecalc"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/pkg/clock"
 	"github.com/openmeterio/openmeter/pkg/framework/transaction"
 	"github.com/openmeterio/openmeter/pkg/pagination"
 )
@@ -25,6 +26,47 @@ func (s *Service) ListGatheringInvoices(ctx context.Context, input billing.ListG
 	return transaction.Run(ctx, s.adapter, func(ctx context.Context) (pagination.Result[billing.GatheringInvoice], error) {
 		return s.adapter.ListGatheringInvoices(ctx, input)
 	})
+}
+
+func (s *Service) DeleteGatheringInvoice(ctx context.Context, input billing.DeleteInvoiceInput) (billing.GatheringInvoice, error) {
+	if err := input.Validate(); err != nil {
+		return billing.GatheringInvoice{}, billing.ValidationError{
+			Err: err,
+		}
+	}
+
+	gatheringInvoice, err := s.adapter.GetGatheringInvoiceById(ctx, billing.GetGatheringInvoiceByIdInput{
+		Invoice: input.Invoice,
+	})
+	if err != nil {
+		return billing.GatheringInvoice{}, fmt.Errorf("fetching invoice: %w", err)
+	}
+
+	if gatheringInvoice.DeletedAt != nil {
+		return gatheringInvoice, nil
+	}
+
+	return s.UpdateGatheringInvoice(ctx, billing.UpdateGatheringInvoiceInput{
+		Invoice:      input.Invoice,
+		ChangeSource: input.DeletionSource,
+		EditFn:       markGatheringInvoiceLinesDeleted,
+	})
+}
+
+func markGatheringInvoiceLinesDeleted(invoice *billing.GatheringInvoice) error {
+	now := clock.Now()
+	for _, line := range invoice.Lines.OrEmpty() {
+		if line.DeletedAt != nil {
+			continue
+		}
+
+		line.DeletedAt = lo.ToPtr(now)
+		if err := invoice.Lines.ReplaceByID(line); err != nil {
+			return fmt.Errorf("setting line[%s]: %w", line.ID, err)
+		}
+	}
+
+	return nil
 }
 
 func (s *Service) UpdateGatheringInvoice(ctx context.Context, input billing.UpdateGatheringInvoiceInput) (billing.GatheringInvoice, error) {

--- a/openmeter/billing/service/invoiceupdate.go
+++ b/openmeter/billing/service/invoiceupdate.go
@@ -885,6 +885,60 @@ func validateLineEngineResult(expectedLines []billing.GenericInvoiceLine, actual
 	return errors.Join(errs...)
 }
 
+func (s *Service) dispatchAPIStandardLineDeletions(ctx context.Context, invoice billing.StandardInvoice, deletedLinesIn billing.StandardLines) error {
+	if len(deletedLinesIn) == 0 {
+		return nil
+	}
+
+	for _, stdLine := range deletedLinesIn {
+		if err := s.lineEngines.populateStandardLineEngine(stdLine); err != nil {
+			return fmt.Errorf("line[%s]: inferring engine: %w", stdLine.GetID(), err)
+		}
+	}
+
+	input := billing.OnMutableInvoiceUpdateInput{
+		Invoice:                 invoice,
+		DefaultTaxCodeResolvers: s.defaultTaxCodeResolversForInvoiceUpdate(invoice),
+		Deleted:                 deletedLinesIn.AsGenericLines(),
+	}
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("validating mutable invoice line delete input: %w", err)
+	}
+
+	changesByEngine, err := input.GroupByLineEngine()
+	if err != nil {
+		return fmt.Errorf("grouping mutable invoice line deletes by engine: %w", err)
+	}
+
+	for engineType, groupedInput := range changesByEngine {
+		engine, err := s.lineEngines.Get(engineType)
+		if err != nil {
+			return fmt.Errorf("getting engine %s: %w", engineType, err)
+		}
+
+		if err := groupedInput.Validate(); err != nil {
+			return fmt.Errorf("validating API invoice line delete input for engine %s: %w", engine.GetLineEngineType(), err)
+		}
+
+		engineResult, err := engine.OnMutableInvoiceLinesEditedViaAPI(ctx, groupedInput)
+		if err != nil {
+			return billing.NewLineEngineValidationError(engine, err)
+		}
+
+		if err := validateLineEngineResult(groupedInput.Created, engineResult.CreatedLines); err != nil {
+			return fmt.Errorf("validating API invoice line delete created output for engine %s: %w", engine.GetLineEngineType(), err)
+		}
+
+		if err := validateLineEngineResult(lo.Map(groupedInput.Updated, func(override billing.InvoiceLineOverride, _ int) billing.GenericInvoiceLine {
+			return override.ExistingLine
+		}), engineResult.UpdatedLines); err != nil {
+			return fmt.Errorf("validating API invoice line delete updated output for engine %s: %w", engine.GetLineEngineType(), err)
+		}
+	}
+
+	return nil
+}
+
 func (s *Service) dispatchSystemStandardLineDeletions(ctx context.Context, invoice billing.StandardInvoice, deletedLinesIn []billing.GenericInvoiceLine) error {
 	if len(deletedLinesIn) == 0 {
 		return nil

--- a/openmeter/billing/service/lineengine_test.go
+++ b/openmeter/billing/service/lineengine_test.go
@@ -199,7 +199,7 @@ func TestDeleteInvoiceSystemDeletionSourceDispatchesOnlyNonDeletedLines(t *testi
 	require.Equal(t, []string{"line-1"}, lineIDs(invoiceEngine.deletedBySystemInputs[0].Lines))
 }
 
-func TestDeleteInvoiceAPIRequestDoesNotDispatchSystemLineDeletion(t *testing.T) {
+func TestDeleteInvoiceAPIRequestDispatchesNonDeletedLinesToAPIEditHook(t *testing.T) {
 	invoiceEngine := &recordingLineEngine{
 		NoopLineEngine: billingtestutils.NoopLineEngine{
 			EngineType: billing.LineEngineTypeInvoice,
@@ -211,6 +211,9 @@ func TestDeleteInvoiceAPIRequestDoesNotDispatchSystemLineDeletion(t *testing.T) 
 	}
 	require.NoError(t, svc.RegisterLineEngine(invoiceEngine))
 
+	activeLine := newStandardLineForLineEngineTest("line-1", billing.LineEngineTypeInvoice, false)
+	deletedLine := newStandardLineForLineEngineTest("line-2", billing.LineEngineTypeInvoice, true)
+
 	sm := &InvoiceStateMachine{
 		Service: svc,
 		Invoice: billing.StandardInvoice{
@@ -219,7 +222,8 @@ func TestDeleteInvoiceAPIRequestDoesNotDispatchSystemLineDeletion(t *testing.T) 
 				ID:        "invoice-1",
 			},
 			Lines: billing.NewStandardInvoiceLines(billing.StandardLines{
-				newStandardLineForLineEngineTest("line-1", billing.LineEngineTypeInvoice, true),
+				activeLine,
+				deletedLine,
 			}),
 		},
 	}
@@ -230,7 +234,47 @@ func TestDeleteInvoiceAPIRequestDoesNotDispatchSystemLineDeletion(t *testing.T) 
 
 	require.NotNil(t, sm.Invoice.DeletedAt)
 	require.Equal(t, billing.ChangeSourceAPIRequest, sm.Invoice.DeletionSource)
+	require.Len(t, invoiceEngine.apiEditInputs, 1)
+	require.Equal(t, "invoice-1", invoiceEngine.apiEditInputs[0].Invoice.GetID())
+	require.Equal(t, []string{"line-1"}, genericLineIDs(invoiceEngine.apiEditInputs[0].Deleted))
 	require.Empty(t, invoiceEngine.deletedBySystemInputs)
+}
+
+func TestDeleteInvoiceAPIRequestReturnsChargeManagedLineErrorBeforeDeletingInvoice(t *testing.T) {
+	chargeEngine := &recordingLineEngine{
+		NoopLineEngine: billingtestutils.NoopLineEngine{
+			EngineType: billing.LineEngineTypeChargeUsageBased,
+		},
+		changeErr: billing.ErrCannotUpdateChargeManagedLine,
+	}
+
+	svc := &Service{
+		lineEngines: newEngineRegistry(),
+	}
+	require.NoError(t, svc.RegisterLineEngine(chargeEngine))
+
+	sm := &InvoiceStateMachine{
+		Service: svc,
+		Invoice: billing.StandardInvoice{
+			StandardInvoiceBase: billing.StandardInvoiceBase{
+				Namespace: "ns",
+				ID:        "invoice-1",
+			},
+			Lines: billing.NewStandardInvoiceLines(billing.StandardLines{
+				newStandardLineForLineEngineTest("line-1", billing.LineEngineTypeChargeUsageBased, false),
+			}),
+		},
+	}
+
+	err := sm.deleteInvoice(t.Context(), billing.DeleteInvoiceTriggerInput{
+		Source: billing.ChangeSourceAPIRequest,
+	})
+
+	require.ErrorIs(t, err, billing.ErrCannotUpdateChargeManagedLine)
+	require.Nil(t, sm.Invoice.DeletedAt)
+	require.Len(t, chargeEngine.apiEditInputs, 1)
+	require.Equal(t, []string{"line-1"}, genericLineIDs(chargeEngine.apiEditInputs[0].Deleted))
+	require.Empty(t, chargeEngine.deletedBySystemInputs)
 }
 
 func TestEngineRegistryAllowsSingleCreateLineRouter(t *testing.T) {

--- a/openmeter/billing/service/stdinvoicestate.go
+++ b/openmeter/billing/service/stdinvoicestate.go
@@ -897,7 +897,19 @@ func (m *InvoiceStateMachine) deleteInvoice(ctx context.Context, input billing.D
 
 	switch input.Source {
 	case billing.ChangeSourceAPIRequest:
-		// API deletes are user initiated invoice deletes, not system line deletes.
+		// API deletes are user-initiated invoice line deletes at invoice scope.
+		// Let line engines reject unsupported charge-managed deletes or perform
+		// their own manual-override side effects before the invoice is marked
+		// deleted.
+		if err := m.Service.dispatchAPIStandardLineDeletions(
+			ctx,
+			m.Invoice,
+			lo.Filter(m.Invoice.Lines.OrEmpty(), func(line *billing.StandardLine, _ int) bool {
+				return line != nil && line.DeletedAt == nil
+			}),
+		); err != nil {
+			return err
+		}
 	case billing.ChangeSourceSystem:
 		// System invoice deletes keep the invoice lines visible on the deleted
 		// invoice, but charge-backed engines still need the same notification they

--- a/openmeter/billing/stdinvoiceline.go
+++ b/openmeter/billing/stdinvoiceline.go
@@ -361,6 +361,10 @@ func (i StandardLine) GetEngine() LineEngineType {
 	return i.Engine
 }
 
+func (i StandardLine) GetLineEngineType() LineEngineType {
+	return i.Engine
+}
+
 func (i StandardLine) GetChildUniqueReferenceID() *string {
 	return i.ChildUniqueReferenceID
 }

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -4751,6 +4751,230 @@ func (s *CreditThenInvoiceTestSuite) TestStandardInvoiceManualDeleteSync() {
 	s.assertCreditThenInvoiceBalances(startBalances)
 }
 
+func (s *CreditThenInvoiceTestSuite) TestDeleteStandardInvoiceWithUsageBasedLineReturnsChargeManagedValidationIssue() {
+	ctx := s.T().Context()
+	start := s.mustParseTime("2024-01-01T00:00:00Z")
+	clock.FreezeTime(start)
+	defer clock.UnFreeze()
+
+	// given:
+	// - a credit-then-invoice subscription has one usage-based item and one flat-fee item
+	// - progressive billing collects the usage-based line before the full period invoice
+	// when:
+	// - the progressive standard invoice is deleted through the invoice API
+	// then:
+	// - usage-based line cleanup fails the invoice deletion as charge-managed
+	// - the invoice remains undeleted
+	s.updateProfile(func(profile *billing.Profile) {
+		profile.WorkflowConfig.Invoicing.AutoAdvance = false
+		profile.WorkflowConfig.Invoicing.ProgressiveBilling = true
+	})
+
+	s.MockStreamingConnector.AddSimpleEvent(
+		*s.APIRequestsTotalFeature.MeterSlug,
+		10,
+		s.mustParseTime("2024-01-02T00:00:00Z"))
+
+	subsView := s.createSubscriptionFromPlan(plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: s.Namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Test Plan",
+				Key:            "test-plan",
+				Version:        1,
+				Currency:       currency.USD,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+				ProRatingConfig: productcatalog.ProRatingConfig{
+					Enabled: true,
+					Mode:    productcatalog.ProRatingModeProratePrices,
+				},
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: s.phaseMeta("first-phase", ""),
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:        s.APIRequestsTotalFeature.Key,
+								Name:       s.APIRequestsTotalFeature.Key,
+								FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+								FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
+								Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+									Amount: alpacadecimal.NewFromFloat(5),
+								}),
+							},
+							BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+						},
+						&productcatalog.FlatFeeRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:  "flat-fee",
+								Name: "flat-fee",
+								Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+									Amount:      alpacadecimal.NewFromFloat(7),
+									PaymentTerm: productcatalog.InArrearsPaymentTerm,
+								}),
+							},
+							BillingCadence: lo.ToPtr(datetime.MustParseDuration(s.T(), "P1M")),
+						},
+					},
+				},
+			},
+		},
+	})
+
+	clock.FreezeTime(start.Add(time.Minute))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+
+	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
+	s.Require().Len(gatheringInvoice.Lines.OrEmpty(), 2)
+
+	clock.FreezeTime(s.mustParseTime("2024-01-15T00:00:01Z"))
+	draftInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: s.Customer.GetID(),
+		AsOf:     lo.ToPtr(s.mustParseTime("2024-01-15T00:00:00Z")),
+	})
+	s.NoError(err)
+	s.Require().Len(draftInvoices, 1)
+
+	draftInvoice := draftInvoices[0]
+	s.DebugDumpInvoice("progressive draft invoice", draftInvoice)
+	s.Equal(billing.StandardInvoiceStatusDraftWaitingForCollection, draftInvoice.Status)
+	s.Require().Len(draftInvoice.Lines.OrEmpty(), 1)
+
+	usageBasedLine := draftInvoice.Lines.OrEmpty()[0]
+	s.Equal(billing.LineEngineTypeChargeUsageBased, usageBasedLine.Engine)
+	s.Require().NotNil(usageBasedLine.ChargeID)
+
+	deletedInvoice, err := s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+		Invoice:        draftInvoice.GetInvoiceID(),
+		DeletionSource: billing.ChangeSourceAPIRequest,
+	})
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDeleteFailed, deletedInvoice.Status)
+	s.ErrorContains(deletedInvoice.ValidationIssues.AsError(), billing.ErrCannotUpdateChargeManagedLine.Error())
+
+	refetchedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+		Invoice: draftInvoice.GetInvoiceID(),
+		Expand:  billing.StandardInvoiceExpandAll,
+	})
+	s.NoError(err)
+	s.Nil(refetchedInvoice.DeletedAt)
+	s.Equal(billing.StandardInvoiceStatusDeleteFailed, refetchedInvoice.Status)
+	s.ErrorContains(refetchedInvoice.ValidationIssues.AsError(), billing.ErrCannotUpdateChargeManagedLine.Error())
+}
+
+func (s *CreditThenInvoiceTestSuite) TestDeleteStandardInvoiceWithFlatFeeOnlyDeletesFlatFeeLine() {
+	ctx := s.T().Context()
+	start := s.mustParseTime("2024-01-01T00:00:00Z")
+	clock.FreezeTime(start)
+	defer clock.UnFreeze()
+
+	// given:
+	// - a credit-then-invoice subscription has only one recurring flat-fee charge
+	// - the flat-fee line is collected into a mutable draft standard invoice
+	// when:
+	// - the standard invoice is deleted through the invoice API
+	// then:
+	// - the invoice deletion succeeds
+	// - the flat-fee charge records the customer-facing line deletion
+	s.updateProfile(func(profile *billing.Profile) {
+		profile.WorkflowConfig.Invoicing.AutoAdvance = false
+	})
+
+	subsView := s.createSubscriptionFromPlan(plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: s.Namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Test Plan",
+				Key:            "test-plan",
+				Version:        1,
+				Currency:       currency.USD,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+				ProRatingConfig: productcatalog.ProRatingConfig{
+					Enabled: true,
+					Mode:    productcatalog.ProRatingModeProratePrices,
+				},
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: s.phaseMeta("first-phase", ""),
+					RateCards: productcatalog.RateCards{
+						&productcatalog.FlatFeeRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:  "flat-fee",
+								Name: "flat-fee",
+								Price: productcatalog.NewPriceFrom(productcatalog.FlatPrice{
+									Amount:      alpacadecimal.NewFromFloat(7),
+									PaymentTerm: productcatalog.InArrearsPaymentTerm,
+								}),
+							},
+							BillingCadence: lo.ToPtr(datetime.MustParseDuration(s.T(), "P1M")),
+						},
+					},
+				},
+			},
+		},
+	})
+
+	clock.FreezeTime(start.Add(time.Minute))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+
+	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
+	s.Require().Len(gatheringInvoice.Lines.OrEmpty(), 1)
+
+	clock.FreezeTime(s.mustParseTime("2024-02-01T00:00:00Z"))
+	draftInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: s.Customer.GetID(),
+		AsOf:     lo.ToPtr(clock.Now()),
+	})
+	s.NoError(err)
+	s.Require().Len(draftInvoices, 1)
+
+	draftInvoice := draftInvoices[0]
+	s.DebugDumpInvoice("flat-fee draft invoice", draftInvoice)
+	s.Equal(billing.StandardInvoiceStatusDraftManualApprovalNeeded, draftInvoice.Status)
+	s.Require().Len(draftInvoice.Lines.OrEmpty(), 1)
+
+	flatFeeLine, err := draftInvoice.Lines.OrEmpty()[0].Clone()
+	s.NoError(err)
+	s.Equal(billing.LineEngineTypeChargeFlatFee, flatFeeLine.Engine)
+	s.Require().NotNil(flatFeeLine.ChargeID)
+
+	chargeBeforeDelete := s.mustGetFlatFeeChargeForInvoiceLineWithExpands(ctx, flatFeeLine, chargesmeta.Expands{chargesmeta.ExpandRealizations})
+	s.Equal(flatfee.StatusActiveRealizationProcessing, chargeBeforeDelete.Status)
+	s.Require().NotNil(chargeBeforeDelete.Realizations.CurrentRun)
+	s.Require().NotNil(chargeBeforeDelete.Realizations.CurrentRun.LineID)
+	s.Equal(flatFeeLine.ID, *chargeBeforeDelete.Realizations.CurrentRun.LineID)
+
+	deletedInvoice, err := s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+		Invoice:        draftInvoice.GetInvoiceID(),
+		DeletionSource: billing.ChangeSourceAPIRequest,
+	})
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDeleted, deletedInvoice.Status)
+	s.NotNil(deletedInvoice.DeletedAt)
+
+	chargeAfterDelete := s.mustGetFlatFeeChargeForInvoiceLineWithExpands(ctx, flatFeeLine, chargesmeta.Expands{
+		chargesmeta.ExpandRealizations,
+		chargesmeta.ExpandDeletedRealizations,
+	})
+	s.Equal(flatfee.StatusDeleted, chargeAfterDelete.Status)
+	s.True(chargeAfterDelete.Intent.HasOverrideLayer(), "override layer")
+	s.Nil(chargeAfterDelete.Intent.GetBaseIntent().IntentDeletedAt)
+	overrideIntent, err := chargeAfterDelete.Intent.GetIntentForTarget(chargesmeta.ChangeTargetOverride)
+	s.NoError(err)
+	s.NotNil(overrideIntent.IntentDeletedAt)
+	s.Nil(chargeAfterDelete.Realizations.CurrentRun)
+}
+
 func (s *CreditThenInvoiceTestSuite) TestInArrearsOneTimeFeeSyncing() {
 	ctx := s.T().Context()
 	start := s.mustParseTime("2024-01-01T00:00:00Z")

--- a/openmeter/server/server_test.go
+++ b/openmeter/server/server_test.go
@@ -1962,6 +1962,10 @@ func (n NoopBillingService) UpdateGatheringInvoice(ctx context.Context, input bi
 	return billing.GatheringInvoice{}, nil
 }
 
+func (n NoopBillingService) DeleteGatheringInvoice(ctx context.Context, input billing.DeleteInvoiceInput) (billing.GatheringInvoice, error) {
+	return billing.GatheringInvoice{}, nil
+}
+
 func (n NoopBillingService) GetGatheringInvoiceById(ctx context.Context, input billing.GetGatheringInvoiceByIdInput) (billing.GatheringInvoice, error) {
 	return billing.GatheringInvoice{}, nil
 }

--- a/test/billing/invoice_test.go
+++ b/test/billing/invoice_test.go
@@ -4147,6 +4147,84 @@ func (s *InvoicingTestSuite) TestGatheringInvoicePeriodPersisting() {
 	s.NotNil(gatheringInvoice.DeletedAt)
 }
 
+func (s *InvoicingTestSuite) TestDeleteGatheringInvoiceViaService() {
+	ctx := s.T().Context()
+	namespace := s.GetUniqueNamespace("ns-delete-gathering-invoice")
+
+	sandboxApp := s.InstallSandboxApp(s.T(), namespace)
+	s.ProvisionBillingProfile(ctx, namespace, sandboxApp.GetID())
+	s.ProvisionProviderDefaultTaxCode(ctx, namespace)
+
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	periodStart := now.Add(-24 * time.Hour)
+	periodEnd := now
+	clock.FreezeTime(now)
+	defer clock.UnFreeze()
+
+	customer := s.CreateTestCustomer(namespace, "test-delete-gathering-invoice")
+
+	// given:
+	// - a gathering invoice with two active flat-fee lines
+	pendingLines, err := s.BillingService.CreatePendingInvoiceLines(ctx, billing.CreatePendingInvoiceLinesInput{
+		Customer: customer.GetID(),
+		Currency: currencyx.Code(currency.USD),
+		Lines: []billing.GatheringLine{
+			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
+				Namespace: namespace,
+				Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
+				InvoiceAt: now,
+				Name:      "Flat fee 1",
+
+				PerUnitAmount: alpacadecimal.NewFromFloat(10),
+				PaymentTerm:   productcatalog.InAdvancePaymentTerm,
+			}),
+			billing.NewFlatFeeGatheringLine(billing.NewFlatFeeLineInput{
+				Namespace: namespace,
+				Period:    timeutil.ClosedPeriod{From: periodStart, To: periodEnd},
+				InvoiceAt: now,
+				Name:      "Flat fee 2",
+
+				PerUnitAmount: alpacadecimal.NewFromFloat(20),
+				PaymentTerm:   productcatalog.InAdvancePaymentTerm,
+			}),
+		},
+	})
+	require.NoError(s.T(), err)
+	require.Len(s.T(), pendingLines.Lines, 2)
+
+	gatheringInvoiceID := pendingLines.Invoice.GetInvoiceID()
+
+	// when:
+	// - deleting the gathering invoice through the billing service
+	deletedInvoice, err := s.BillingService.DeleteGatheringInvoice(ctx, billing.DeleteInvoiceInput{
+		Invoice:        gatheringInvoiceID,
+		DeletionSource: billing.ChangeSourceAPIRequest,
+	})
+
+	// then:
+	// - all active gathering lines are marked deleted
+	// - the empty gathering invoice is marked deleted
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), deletedInvoice.DeletedAt)
+	require.Len(s.T(), deletedInvoice.Lines.OrEmpty(), 0)
+
+	reloadedInvoice, err := s.BillingService.GetGatheringInvoiceById(ctx, billing.GetGatheringInvoiceByIdInput{
+		Invoice: gatheringInvoiceID,
+		Expand: billing.GatheringInvoiceExpands{
+			billing.GatheringInvoiceExpandLines,
+			billing.GatheringInvoiceExpandDeletedLines,
+		},
+	})
+	require.NoError(s.T(), err)
+	require.NotNil(s.T(), reloadedInvoice.DeletedAt)
+	require.Len(s.T(), reloadedInvoice.Lines.OrEmpty(), 2)
+
+	for _, line := range reloadedInvoice.Lines.OrEmpty() {
+		require.NotNil(s.T(), line.DeletedAt, "line[%s] should be deleted", line.ID)
+		require.Equal(s.T(), now, *line.DeletedAt)
+	}
+}
+
 func (s *InvoicingTestSuite) TestCreatePendingInvoiceLinesForDeletedCustomers() {
 	namespace := "ns-create-pending-invoice-lines-for-deleted-customers"
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- route API standard-invoice deletion through mutable invoice line API delete hooks before marking the invoice deleted
- let usage-based charge-managed lines reject unsupported invoice deletion with the existing charge-managed validation issue
- let flat-fee-only invoice deletion run the flat-fee manual delete cleanup path
- add billing service and subscription-sync regression coverage for the API-delete behavior

## Root Cause

API standard-invoice deletion previously skipped `OnMutableInvoiceLinesEditedViaAPI`. That meant charge-backed lines were not asked to validate or perform their manual-delete side effects before the invoice entered deletion. Usage-based progressive invoice lines could therefore be deleted at invoice scope without surfacing the charge-managed-line rejection, while flat-fee-only invoice deletion did not exercise the same manual cleanup path as deleting the line through the invoice API.

## Validation

- `env GOCACHE=/private/tmp/openmeter-go-build-cache POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/worker/subscriptionsync/service -run 'TestCreditThenInvoiceScenarios/TestDeleteStandardInvoice' -count=1 -v`\n- `env GOCACHE=/private/tmp/openmeter-go-build-cache POSTGRES_HOST=127.0.0.1 go vet -tags=dynamic ./openmeter/billing/service ./openmeter/billing/worker/subscriptionsync/service`\n- `env GOCACHE=/private/tmp/openmeter-go-build-cache POSTGRES_HOST=127.0.0.1 go test -tags=dynamic ./openmeter/billing/service -run TestDeleteInvoice -count=1 -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API-driven invoice deletions now pre-validate which standard lines are eligible, rejecting invoices containing active usage-based (charge-managed) lines with a clear validation error.
  * Deletion dispatch now correctly processes only still-active deleted standard lines and validates line-engine outcomes before completing.
  * Deletion operations now fail early and avoid marking the invoice deleted when charge-managed updates can’t be applied.
* **Tests**
  * Added/updated coverage for API delete behaviors across usage-based, flat-fee-only, and mixed/edge invoice scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->