### PR TITLE
feat: support usage-based invoice line deletes

### DIFF
--- a/api/v3/handlers/billinginvoices/delete.go
+++ b/api/v3/handlers/billinginvoices/delete.go
@@ -87,6 +87,7 @@ func (h *handler) DeleteBillingInvoice() DeleteBillingInvoiceHandler {
 			h.options,
 			httptransport.WithOperationName("delete-invoice"),
 			httptransport.WithErrorEncoder(apierrors.GenericErrorEncoder()),
+			httptransport.WithErrorEncoder(encodeValidationIssue()),
 			httptransport.WithErrorEncoder(errorEncoder()),
 		)...,
 	)

--- a/app/common/charges.go
+++ b/app/common/charges.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	flatfeeadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/adapter"
 	flatfeeservice "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	lineageadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/adapter"
 	lineageservice "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/service"
@@ -249,6 +250,7 @@ func NewChargesUsageBasedService(
 	lineageService lineage.Service,
 	locker *lockr.Locker,
 	metaAdapter meta.Adapter,
+	invoiceUpdater invoiceupdater.Updater,
 	billingService billing.Service,
 	featureService feature.FeatureConnector,
 	ratingService rating.Service,
@@ -260,6 +262,7 @@ func NewChargesUsageBasedService(
 		Lineage:                 lineageService,
 		Locker:                  locker,
 		MetaAdapter:             metaAdapter,
+		InvoiceUpdater:          invoiceUpdater,
 		CustomerOverrideService: billingService,
 		FeatureService:          featureService,
 		RatingService:           ratingService,
@@ -270,6 +273,21 @@ func NewChargesUsageBasedService(
 	}
 
 	return usageBasedSvc, nil
+}
+
+func NewChargesInvoiceUpdater(
+	billingService billing.Service,
+	logger *slog.Logger,
+) (invoiceupdater.Updater, error) {
+	updater, err := invoiceupdater.New(invoiceupdater.Config{
+		BillingService: billingService,
+		Logger:         logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create charges invoice updater: %w", err)
+	}
+
+	return updater, nil
 }
 
 func NewChargesCreditPurchaseAdapter(
@@ -465,12 +483,18 @@ func newChargesRegistry(
 		return nil, err
 	}
 
+	invoiceUpdater, err := NewChargesInvoiceUpdater(billingService, logger)
+	if err != nil {
+		return nil, err
+	}
+
 	usageBasedSvc, err := NewChargesUsageBasedService(
 		usageBasedAdapter,
 		usageBasedHandler,
 		lineageService,
 		locker,
 		metaAdapter,
+		invoiceUpdater,
 		billingService,
 		featureService,
 		ratingService,

--- a/openmeter/billing/charges/creditpurchase/lineengine/engine.go
+++ b/openmeter/billing/charges/creditpurchase/lineengine/engine.go
@@ -90,6 +90,10 @@ func (e *Engine) OnStandardInvoiceCreated(_ context.Context, input billing.OnSta
 	return input.Lines, nil
 }
 
+func (e *Engine) ValidateMutableInvoiceLineEditViaAPI(_ context.Context, _ billing.OnMutableInvoiceUpdateInput) error {
+	return billing.ErrCannotUpdateChargeManagedLine
+}
+
 func (e *Engine) OnMutableInvoiceLinesEditedViaAPI(_ context.Context, _ billing.OnMutableInvoiceUpdateInput) (billing.OnMutableInvoiceUpdateResult, error) {
 	return billing.OnMutableInvoiceUpdateResult{}, billing.ErrCannotUpdateChargeManagedLine
 }

--- a/openmeter/billing/charges/flatfee/service/creditheninvoice.go
+++ b/openmeter/billing/charges/flatfee/service/creditheninvoice.go
@@ -181,7 +181,7 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch 
 
 	s.Charge.Status = flatfee.StatusDeleted
 
-	patches := []invoiceupdater.Patch{
+	patches := invoiceupdater.Patches{
 		invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID),
 	}
 	currentRun := s.Charge.Realizations.CurrentRun

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -247,56 +247,36 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 		}
 
 		patches := creditThenInvoiceStateMachine.DrainInvoicePatches()
-		if len(patches) != 1 {
-			return nil, fmt.Errorf("line[%s]: expected exactly one line manual edit invoice patch, got %d [%v]",
-				override.ExistingLine.GetID(),
-				len(patches),
-				invoicePatchOps(patches),
-			)
-		}
-
 		var targetLine billing.GenericInvoiceLine
 		switch override.ExistingLine.AsInvoiceLine().Type() {
 		case billing.InvoiceLineTypeStandard:
-			updatePatch, err := patches[0].AsUpdateLinePatch()
+			updatePatch, err := patches.RequireSingularLineUpdatePatchForTarget(override.ExistingLine)
 			if err != nil {
-				return nil, fmt.Errorf("line[%s]: expected line manual edit update line patch, got %s: %w", override.ExistingLine.GetID(), patches[0].Op(), err)
-			}
-
-			if err := updatePatch.RequireTarget(override.ExistingLine); err != nil {
 				return nil, fmt.Errorf("line[%s]: validating line manual edit update patch target: %w", override.ExistingLine.GetID(), err)
 			}
 
 			targetLine = updatePatch.TargetState
 		case billing.InvoiceLineTypeGathering:
-			switch patches[0].Op() {
-			case invoiceupdater.PatchOpUpsertGatheringLineByChargeID:
-				upsertPatch, err := patches[0].AsUpsertGatheringLineByChargeIDPatch()
-				if err != nil {
-					return nil, fmt.Errorf("line[%s]: expected line manual edit gathering line upsert patch, got %s: %w", override.ExistingLine.GetID(), patches[0].Op(), err)
-				}
+			gatheringPatch, err := patches.RequireSingularGatheringLinePatchForCharge(*chargeID)
+			if err != nil {
+				return nil, fmt.Errorf("line[%s]: validating line manual edit gathering patch target: %w", override.ExistingLine.GetID(), err)
+			}
 
-				if err := upsertPatch.RequireCharge(*chargeID); err != nil {
-					return nil, fmt.Errorf("line[%s]: validating line manual edit upsert patch target: %w", override.ExistingLine.GetID(), err)
+			switch gatheringPatch.Op() {
+			case invoiceupdater.PatchOpUpsertGatheringLineByChargeID:
+				upsertPatch, err := gatheringPatch.AsUpsertGatheringLineByChargeIDPatch()
+				if err != nil {
+					return nil, fmt.Errorf("line[%s]: getting line manual edit gathering upsert patch: %w", override.ExistingLine.GetID(), err)
 				}
 
 				targetLine = upsertPatch.TargetState.AsGenericLine()
 			case invoiceupdater.PatchOpDeleteGatheringLineByChargeID:
-				deletePatch, err := patches[0].AsDeleteGatheringLineByChargeIDPatch()
-				if err != nil {
-					return nil, fmt.Errorf("line[%s]: expected line manual edit gathering line delete patch, got %s: %w", override.ExistingLine.GetID(), patches[0].Op(), err)
-				}
-
-				if err := deletePatch.RequireCharge(*chargeID); err != nil {
-					return nil, fmt.Errorf("line[%s]: validating line manual edit delete patch target: %w", override.ExistingLine.GetID(), err)
-				}
-
 				// TODO: support zero-proration manual gathering-line edits by
 				// modeling the API result as a line deletion/detach instead of
 				// an updated line.
 				return nil, fmt.Errorf("line[%s]: zero-proration manual gathering-line edits are not supported yet: %w", override.ExistingLine.GetID(), billing.ErrInvoiceLineZeroAmountDeleteInstead)
 			default:
-				return nil, fmt.Errorf("line[%s]: expected line manual edit gathering line upsert patch, got %s", override.ExistingLine.GetID(), patches[0].Op())
+				return nil, fmt.Errorf("line[%s]: expected line manual edit gathering patch, got %s", override.ExistingLine.GetID(), gatheringPatch.Op())
 			}
 		default:
 			return nil, billing.ErrCannotUpdateChargeManagedLine
@@ -499,20 +479,8 @@ func (e *LineEngine) attachManualStandardLine(ctx context.Context, invoice billi
 	}
 
 	patches := creditThenInvoiceStateMachine.DrainInvoicePatches()
-	if len(patches) != 1 {
-		return nil, fmt.Errorf("line[%s]: expected exactly one attach invoice patch, got %d [%v]",
-			sourceLine.GetID(),
-			len(patches),
-			invoicePatchOps(patches),
-		)
-	}
-
-	updatePatch, err := patches[0].AsUpdateLinePatch()
+	updatePatch, err := patches.RequireSingularLineUpdatePatchForTarget(sourceLine)
 	if err != nil {
-		return nil, fmt.Errorf("line[%s]: expected attach update line patch, got %s: %w", sourceLine.GetID(), patches[0].Op(), err)
-	}
-
-	if err := updatePatch.RequireTarget(sourceLine); err != nil {
 		return nil, fmt.Errorf("line[%s]: validating attach update patch target: %w", sourceLine.GetID(), err)
 	}
 
@@ -558,7 +526,7 @@ func validateManualDeleteLine(charge flatfee.Charge, line billing.GenericInvoice
 	return nil
 }
 
-func (e *LineEngine) handleManualDeleteInvoicePatches(ctx context.Context, invoice billing.GenericInvoiceReader, line billing.GenericInvoiceLine, chargeID string, patches []invoiceupdater.Patch) error {
+func (e *LineEngine) handleManualDeleteInvoicePatches(ctx context.Context, invoice billing.GenericInvoiceReader, line billing.GenericInvoiceLine, chargeID string, patches invoiceupdater.Patches) error {
 	if len(patches) == 0 {
 		return fmt.Errorf("line[%s]: expected manual delete invoice patches", line.GetID())
 	}
@@ -606,12 +574,6 @@ func (e *LineEngine) handleManualDeleteInvoicePatches(ctx context.Context, invoi
 	}
 
 	return nil
-}
-
-func invoicePatchOps(patches []invoiceupdater.Patch) []invoiceupdater.PatchOperation {
-	return lo.Map(patches, func(patch invoiceupdater.Patch, _ int) invoiceupdater.PatchOperation {
-		return patch.Op()
-	})
 }
 
 func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, input billing.OnMutableStandardLinesDeletedInput) error {

--- a/openmeter/billing/charges/flatfee/service/lineengine.go
+++ b/openmeter/billing/charges/flatfee/service/lineengine.go
@@ -363,6 +363,107 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 	}, nil
 }
 
+func (e *LineEngine) ValidateMutableInvoiceLineEditViaAPI(ctx context.Context, input billing.OnMutableInvoiceUpdateInput) error {
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("validating input: %w", err)
+	}
+
+	for _, line := range input.Created {
+		if _, err := intentFromManualCreatedLine(ctx, input.Invoice, line, input.DefaultTaxCodeResolvers.Invoicing); err != nil {
+			if line == nil {
+				return fmt.Errorf("building manually created flat-fee charge intent: %w", err)
+			}
+
+			return fmt.Errorf("building manually created flat-fee charge intent for line[%s]: %w", line.GetID(), err)
+		}
+	}
+
+	for _, override := range input.Updated {
+		if err := e.validateManualUpdateLineViaAPI(ctx, override); err != nil {
+			return err
+		}
+	}
+
+	for _, line := range input.Deleted {
+		if err := e.validateManualDeleteLineViaAPI(ctx, line); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *LineEngine) validateManualUpdateLineViaAPI(ctx context.Context, override billing.InvoiceLineOverride) error {
+	chargeID := override.ExistingLine.GetChargeID()
+	if chargeID == nil || *chargeID == "" {
+		return fmt.Errorf("flat fee line[%s]: charge id is required", override.ExistingLine.GetID())
+	}
+
+	charge, err := e.service.GetByID(ctx, flatfee.GetByIDInput{
+		ChargeID: meta.ChargeID{
+			Namespace: override.ExistingLine.GetLineID().Namespace,
+			ID:        *chargeID,
+		},
+		Expands: meta.Expands{
+			meta.ExpandRealizations,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("getting flat fee charge for line[%s]: %w", override.ExistingLine.GetID(), err)
+	}
+
+	if charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+		return fmt.Errorf(
+			"flat fee line[%s]: unsupported settlement mode for API edit: %s",
+			override.ExistingLine.GetID(),
+			charge.Intent.GetSettlementMode(),
+		)
+	}
+
+	if err := override.ExistingLine.AsInvoiceLine().Type().Require(billing.InvoiceLineTypeStandard, billing.InvoiceLineTypeGathering); err != nil {
+		return fmt.Errorf("flat fee line[%s]: unsupported line type for API edit: %s", override.ExistingLine.GetID(), override.ExistingLine.AsInvoiceLine().Type())
+	}
+
+	if _, err := meta.NewPatchLineManualEdit(meta.NewPatchLineManualEditInput{
+		ChangeSource: billing.ChangeSourceAPIRequest,
+		Override:     override,
+	}); err != nil {
+		return fmt.Errorf("validating flat-fee line manual edit patch for line[%s]: %w", override.ExistingLine.GetID(), err)
+	}
+
+	return nil
+}
+
+func (e *LineEngine) validateManualDeleteLineViaAPI(ctx context.Context, line billing.GenericInvoiceLine) error {
+	chargeID := line.GetChargeID()
+	if chargeID == nil || *chargeID == "" {
+		return fmt.Errorf("flat fee line[%s]: charge id is required", line.GetID())
+	}
+
+	charge, err := e.service.GetByID(ctx, flatfee.GetByIDInput{
+		ChargeID: meta.ChargeID{
+			Namespace: line.GetLineID().Namespace,
+			ID:        *chargeID,
+		},
+		Expands: meta.Expands{
+			meta.ExpandRealizations,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("getting flat fee charge for deleted line[%s]: %w", line.GetID(), err)
+	}
+
+	if charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+		return fmt.Errorf(
+			"flat fee line[%s]: unsupported settlement mode for API delete: %s",
+			line.GetID(),
+			charge.Intent.GetSettlementMode(),
+		)
+	}
+
+	return validateManualDeleteLine(charge, line)
+}
+
 type manualCreatedInvoiceLine struct {
 	sourceLine billing.GenericInvoiceLine
 	intent     flatfee.Intent

--- a/openmeter/billing/charges/invoiceupdater/invoiceupdate.go
+++ b/openmeter/billing/charges/invoiceupdater/invoiceupdate.go
@@ -2,6 +2,7 @@ package invoiceupdater
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -18,19 +19,46 @@ import (
 
 const invoiceUpdaterComponentName billing.ComponentName = "charges.invoiceupdater"
 
-type Updater struct {
+type Updater interface {
+	ApplyPatches(ctx context.Context, customerID customer.CustomerID, patches Patches) error
+}
+
+type updater struct {
 	billingService billing.Service
 	logger         *slog.Logger
 }
 
-func New(billingService billing.Service, logger *slog.Logger) *Updater {
-	return &Updater{
-		billingService: billingService,
-		logger:         logger,
-	}
+type Config struct {
+	BillingService billing.Service
+	Logger         *slog.Logger
 }
 
-func (u *Updater) ApplyPatches(ctx context.Context, customerID customer.CustomerID, patches []Patch) error {
+func (c Config) Validate() error {
+	var errs []error
+
+	if c.BillingService == nil {
+		errs = append(errs, errors.New("billing service cannot be null"))
+	}
+
+	if c.Logger == nil {
+		errs = append(errs, errors.New("logger cannot be null"))
+	}
+
+	return errors.Join(errs...)
+}
+
+func New(config Config) (Updater, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &updater{
+		billingService: config.BillingService,
+		logger:         config.Logger,
+	}, nil
+}
+
+func (u *updater) ApplyPatches(ctx context.Context, customerID customer.CustomerID, patches Patches) error {
 	patchesParsed, err := u.parsePatches(patches)
 	if err != nil {
 		return fmt.Errorf("parsing patches: %w", err)
@@ -94,7 +122,7 @@ func (u *Updater) ApplyPatches(ctx context.Context, customerID customer.Customer
 	return nil
 }
 
-func (u *Updater) listInvoicesByID(ctx context.Context, namespace string, invoiceIDs []string) (map[string]billing.Invoice, error) {
+func (u *updater) listInvoicesByID(ctx context.Context, namespace string, invoiceIDs []string) (map[string]billing.Invoice, error) {
 	if len(invoiceIDs) == 0 {
 		return map[string]billing.Invoice{}, nil
 	}
@@ -121,7 +149,7 @@ func (u *Updater) listInvoicesByID(ctx context.Context, namespace string, invoic
 	return invoicesByID, nil
 }
 
-func (u *Updater) LogPatches(patches []Patch, invoicesByID map[string]billing.Invoice) {
+func (u *updater) LogPatches(patches Patches, invoicesByID map[string]billing.Invoice) {
 	suppressedDryRunPatches := 0
 
 	for _, patch := range patches {
@@ -226,7 +254,7 @@ type invoiceLineDeletePatch struct {
 	op   PatchOperation
 }
 
-func (u *Updater) parsePatches(patches []Patch) (patchesParsed, error) {
+func (u *updater) parsePatches(patches Patches) (patchesParsed, error) {
 	parsed := patchesParsed{
 		updatedLinesByInvoiceID:        make(map[string]invoicePatches),
 		gatheringLineUpsertsByChargeID: make(map[string]PatchUpsertGatheringLineByChargeID),
@@ -287,7 +315,7 @@ func (u *Updater) parsePatches(patches []Patch) (patchesParsed, error) {
 	return parsed, nil
 }
 
-func (u *Updater) provisionUpcomingLines(ctx context.Context, customerID customer.CustomerID, lines []billing.GatheringLine) error {
+func (u *updater) provisionUpcomingLines(ctx context.Context, customerID customer.CustomerID, lines []billing.GatheringLine) error {
 	if len(lines) == 0 {
 		return nil
 	}
@@ -310,7 +338,7 @@ func (u *Updater) provisionUpcomingLines(ctx context.Context, customerID custome
 	return nil
 }
 
-func (u *Updater) resolveGatheringLineDeletesByChargeID(ctx context.Context, customerID customer.CustomerID, parsed *patchesParsed) error {
+func (u *updater) resolveGatheringLineDeletesByChargeID(ctx context.Context, customerID customer.CustomerID, parsed *patchesParsed) error {
 	if len(parsed.gatheringLineDeletesByChargeID) == 0 {
 		return nil
 	}
@@ -353,7 +381,7 @@ func (u *Updater) resolveGatheringLineDeletesByChargeID(ctx context.Context, cus
 	return nil
 }
 
-func (u *Updater) resolveGatheringLineUpsertsByChargeID(ctx context.Context, customerID customer.CustomerID, parsed *patchesParsed) error {
+func (u *updater) resolveGatheringLineUpsertsByChargeID(ctx context.Context, customerID customer.CustomerID, parsed *patchesParsed) error {
 	if len(parsed.gatheringLineUpsertsByChargeID) == 0 {
 		return nil
 	}
@@ -403,7 +431,7 @@ func (u *Updater) resolveGatheringLineUpsertsByChargeID(ctx context.Context, cus
 	return nil
 }
 
-func (u *Updater) updateMutableStandardInvoice(ctx context.Context, invoice billing.StandardInvoice, linePatches invoicePatches) error {
+func (u *updater) updateMutableStandardInvoice(ctx context.Context, invoice billing.StandardInvoice, linePatches invoicePatches) error {
 	updatedInvoice, err := u.billingService.UpdateStandardInvoice(ctx, billing.UpdateStandardInvoiceInput{
 		Invoice:             invoice.GetInvoiceID(),
 		ChangeSource:        billing.ChangeSourceSystem,
@@ -484,7 +512,7 @@ func (u *Updater) updateMutableStandardInvoice(ctx context.Context, invoice bill
 	return nil
 }
 
-func (u *Updater) updateGatheringInvoice(ctx context.Context, invoiceID billing.InvoiceID, linePatches invoicePatches) error {
+func (u *updater) updateGatheringInvoice(ctx context.Context, invoiceID billing.InvoiceID, linePatches invoicePatches) error {
 	_, err := u.billingService.UpdateGatheringInvoice(ctx, billing.UpdateGatheringInvoiceInput{
 		Invoice:             invoiceID,
 		ChangeSource:        billing.ChangeSourceSystem,
@@ -529,7 +557,7 @@ func (u *Updater) updateGatheringInvoice(ctx context.Context, invoiceID billing.
 	return err
 }
 
-func (u *Updater) updateImmutableInvoice(ctx context.Context, invoice billing.StandardInvoice, linePatches invoicePatches) error {
+func (u *updater) updateImmutableInvoice(ctx context.Context, invoice billing.StandardInvoice, linePatches invoicePatches) error {
 	invoice, err := u.billingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
 		Invoice: invoice.GetInvoiceID(),
 		Expand:  billing.StandardInvoiceExpandAll,
@@ -694,7 +722,7 @@ func newValidationIssueOnLine(line *billing.StandardLine, message string, a ...a
 	}
 }
 
-func (u *Updater) mergeValidationIssues(invoice billing.StandardInvoice, issues []billing.ValidationIssue) (billing.ValidationIssues, bool) {
+func (u *updater) mergeValidationIssues(invoice billing.StandardInvoice, issues []billing.ValidationIssue) (billing.ValidationIssues, bool) {
 	changed := false
 
 	for _, issue := range issues {

--- a/openmeter/billing/charges/invoiceupdater/patch.go
+++ b/openmeter/billing/charges/invoiceupdater/patch.go
@@ -26,6 +26,19 @@ type PatchLineDelete struct {
 	InvoiceID string
 }
 
+func (p PatchLineDelete) RequireTarget(line billing.GenericInvoiceLineReader) error {
+	if line == nil {
+		return fmt.Errorf("line is required")
+	}
+
+	lineID := line.GetLineID()
+	if p.Line != lineID {
+		return fmt.Errorf("target line[%s] does not match line[%s]", p.Line, lineID)
+	}
+
+	return nil
+}
+
 type PatchLineUpdate struct {
 	TargetState billing.GenericInvoiceLine
 }
@@ -94,23 +107,6 @@ func (p PatchLineUpdate) RequireTarget(line billing.GenericInvoiceLineReader) er
 
 	if p.TargetState.GetInvoiceID() != line.GetInvoiceID() {
 		return fmt.Errorf("target invoice[%s] does not match invoice[%s]", p.TargetState.GetInvoiceID(), line.GetInvoiceID())
-	}
-
-	return nil
-}
-
-func (p PatchLineDelete) RequireTarget(line billing.GenericInvoiceLineReader) error {
-	if line == nil {
-		return fmt.Errorf("line is required")
-	}
-
-	lineID := line.GetLineID()
-	if p.Line != lineID {
-		return fmt.Errorf("target line[%s] does not match line[%s]", p.Line, lineID)
-	}
-
-	if p.InvoiceID != line.GetInvoiceID() {
-		return fmt.Errorf("target invoice[%s] does not match invoice[%s]", p.InvoiceID, line.GetInvoiceID())
 	}
 
 	return nil

--- a/openmeter/billing/charges/invoiceupdater/patch.go
+++ b/openmeter/billing/charges/invoiceupdater/patch.go
@@ -36,6 +36,10 @@ func (p PatchLineDelete) RequireTarget(line billing.GenericInvoiceLineReader) er
 		return fmt.Errorf("target line[%s] does not match line[%s]", p.Line, lineID)
 	}
 
+	if p.InvoiceID != line.GetInvoiceID() {
+		return fmt.Errorf("target invoice[%s] does not match invoice[%s]", p.InvoiceID, line.GetInvoiceID())
+	}
+
 	return nil
 }
 

--- a/openmeter/billing/charges/invoiceupdater/patches.go
+++ b/openmeter/billing/charges/invoiceupdater/patches.go
@@ -1,0 +1,145 @@
+package invoiceupdater
+
+import (
+	"fmt"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+)
+
+type Patches []Patch
+
+// BisectByInvoiceID splits the patches into two groups: one for the invoice ID before the patch and one for the invoice ID after the patch.
+//
+// First return value is the patches with the invoice ID, the second return value is the patches without the invoice ID.
+// Corner cases:
+// - Any gathering invoice line patch will be in the `rest` group.
+// - Any create line patch will be in the `rest` group.
+func (p Patches) BisectByStandardInvoiceID(invoiceID string) (Patches, Patches, error) {
+	invoicePatches := make(Patches, 0, len(p))
+	rest := make(Patches, 0, len(p))
+
+	for _, patch := range p {
+		switch patch.Op() {
+		case PatchOpLineDelete:
+			val, err := patch.AsDeleteLinePatch()
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to convert patch to delete line patch: %w", err)
+			}
+			if val.InvoiceID == invoiceID {
+				invoicePatches = append(invoicePatches, patch)
+			} else {
+				rest = append(rest, patch)
+			}
+		case PatchOpLineUpdate:
+			val, err := patch.AsUpdateLinePatch()
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to convert patch to update line patch: %w", err)
+			}
+			if val.TargetState.GetInvoiceID() == invoiceID {
+				invoicePatches = append(invoicePatches, patch)
+			} else {
+				rest = append(rest, patch)
+			}
+		default:
+			rest = append(rest, patch)
+		}
+	}
+
+	return invoicePatches, rest, nil
+}
+
+func (p Patches) RequireSingularStandardInvoiceLineDeletePatch() (PatchLineDelete, error) {
+	patch, err := p.requireSingularPatch("standard invoice line delete")
+	if err != nil {
+		return PatchLineDelete{}, err
+	}
+
+	return patch.AsDeleteLinePatch()
+}
+
+func (p Patches) RequireSingularLineUpdatePatchForTarget(line billing.GenericInvoiceLineReader) (PatchLineUpdate, error) {
+	patch, err := p.requireSingularPatch("line update")
+	if err != nil {
+		return PatchLineUpdate{}, err
+	}
+
+	updatePatch, err := patch.AsUpdateLinePatch()
+	if err != nil {
+		return PatchLineUpdate{}, err
+	}
+
+	if err := updatePatch.RequireTarget(line); err != nil {
+		return PatchLineUpdate{}, err
+	}
+
+	return updatePatch, nil
+}
+
+func (p Patches) RequireSingularGatheringLinePatchForCharge(chargeID string) (Patch, error) {
+	patch, err := p.requireSingularPatch("gathering line by charge")
+	if err != nil {
+		return Patch{}, err
+	}
+
+	switch patch.Op() {
+	case PatchOpUpsertGatheringLineByChargeID:
+		upsertPatch, err := patch.AsUpsertGatheringLineByChargeIDPatch()
+		if err != nil {
+			return Patch{}, err
+		}
+
+		if err := upsertPatch.RequireCharge(chargeID); err != nil {
+			return Patch{}, err
+		}
+
+		return patch, nil
+	case PatchOpDeleteGatheringLineByChargeID:
+		deletePatch, err := patch.AsDeleteGatheringLineByChargeIDPatch()
+		if err != nil {
+			return Patch{}, err
+		}
+
+		if err := deletePatch.RequireCharge(chargeID); err != nil {
+			return Patch{}, err
+		}
+
+		return patch, nil
+	default:
+		return Patch{}, fmt.Errorf("expected gathering line by charge patch, got %s", patch.Op())
+	}
+}
+
+func (p Patches) RequireType(op PatchOperation, countMatcher func(int) error) error {
+	if err := countMatcher(len(p)); err != nil {
+		return err
+	}
+
+	for _, patch := range p {
+		if patch.Op() != op {
+			return fmt.Errorf("expected %s patch, got %s", op, patch.Op())
+		}
+	}
+
+	return nil
+}
+
+func CountLessThanOrEqualTo(c int) func(int) error {
+	return func(count int) error {
+		if count > c {
+			return fmt.Errorf("expected less than or equal to %d, got %d", c, count)
+		}
+		return nil
+	}
+}
+
+func (p Patches) requireSingularPatch(kind string) (Patch, error) {
+	if len(p) == 0 {
+		return Patch{}, fmt.Errorf("no %s patches provided", kind)
+	}
+
+	if len(p) > 1 {
+		return Patch{}, fmt.Errorf("expected singular %s patch, got %d", kind, len(p))
+	}
+
+	return p[0], nil
+}

--- a/openmeter/billing/charges/invoiceupdater/testutils.go
+++ b/openmeter/billing/charges/invoiceupdater/testutils.go
@@ -1,0 +1,27 @@
+package invoiceupdater
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/openmeterio/openmeter/openmeter/customer"
+)
+
+type unimplementedUpdater struct {
+	t testing.TB
+}
+
+func NewUnimplementedUpdater(t testing.TB) Updater {
+	return unimplementedUpdater{
+		t: t,
+	}
+}
+
+func (u unimplementedUpdater) ApplyPatches(context.Context, customer.CustomerID, Patches) error {
+	if u.t != nil {
+		u.t.Helper()
+	}
+
+	return errors.New("invoice updater is not implemented")
+}

--- a/openmeter/billing/charges/meta/patch.go
+++ b/openmeter/billing/charges/meta/patch.go
@@ -70,7 +70,7 @@ type Patch interface {
 
 type TriggerPatchResult[T any] struct {
 	Charge         *T
-	InvoicePatches []invoiceupdater.Patch
+	InvoicePatches invoiceupdater.Patches
 }
 
 // PatchAction adapts a generic Patch action to a concrete patch action when

--- a/openmeter/billing/charges/service/base_test.go
+++ b/openmeter/billing/charges/service/base_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	flatfeeadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/adapter"
 	flatfeeservice "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	lineageadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/adapter"
 	lineageservice "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/service"
 	chargeslinerouter "github.com/openmeterio/openmeter/openmeter/billing/charges/linerouter"
@@ -111,12 +112,19 @@ func (s *BaseSuite) SetupSuite() {
 	})
 	s.NoError(err)
 
+	invoiceUpdater, err := invoiceupdater.New(invoiceupdater.Config{
+		BillingService: s.BillingService,
+		Logger:         slog.Default(),
+	})
+	s.NoError(err)
+
 	usageBasedService, err := usagebasedservice.New(usagebasedservice.Config{
 		Adapter:                 usageBasedAdapter,
 		Handler:                 s.UsageBasedTestHandler,
 		Lineage:                 lineageService,
 		Locker:                  locker,
 		MetaAdapter:             metaAdapter,
+		InvoiceUpdater:          invoiceUpdater,
 		CustomerOverrideService: s.BillingService,
 		FeatureService:          s.FeatureService,
 		RatingService:           billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: s.UnitConfigEnabled}),

--- a/openmeter/billing/charges/service/patch.go
+++ b/openmeter/billing/charges/service/patch.go
@@ -71,7 +71,7 @@ func (s *service) applyPatches(ctx context.Context, customerID customer.Customer
 		return err
 	}
 
-	var invoicePatches []invoiceupdater.Patch
+	var invoicePatches invoiceupdater.Patches
 
 	for chargeID, patch := range patchesByChargeID {
 		invocableCharge, ok := invocableChargesByID[chargeID]

--- a/openmeter/billing/charges/service/service.go
+++ b/openmeter/billing/charges/service/service.go
@@ -23,7 +23,7 @@ type service struct {
 	// Note: if meta has a service layer, we should use it here instead of the adapter
 	metaAdapter    meta.Adapter
 	billingService billing.Service
-	invoiceUpdater *invoiceupdater.Updater
+	invoiceUpdater invoiceupdater.Updater
 	featureService feature.FeatureConnector
 
 	flatFeeService        flatfee.Service
@@ -105,10 +105,18 @@ func New(config Config) (*service, error) {
 		return nil, err
 	}
 
+	invoiceUpdater, err := invoiceupdater.New(invoiceupdater.Config{
+		BillingService: config.BillingService,
+		Logger:         config.Logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating invoice updater: %w", err)
+	}
+
 	svc := &service{
 		adapter:               config.Adapter,
 		billingService:        config.BillingService,
-		invoiceUpdater:        invoiceupdater.New(config.BillingService, config.Logger),
+		invoiceUpdater:        invoiceUpdater,
 		featureService:        config.FeatureService,
 		metaAdapter:           config.MetaAdapter,
 		flatFeeService:        config.FlatFeeService,

--- a/openmeter/billing/charges/statemachine/machine.go
+++ b/openmeter/billing/charges/statemachine/machine.go
@@ -41,8 +41,8 @@ type StateMachine[CHARGE any] interface {
 	CanFire(ctx context.Context, trigger meta.Trigger) (bool, error)
 	FireAndActivate(ctx context.Context, trigger meta.Trigger, args ...models.Validator) error
 	GetCharge() CHARGE
-	InvoicePatches() []invoiceupdater.Patch
-	DrainInvoicePatches() []invoiceupdater.Patch
+	InvoicePatches() invoiceupdater.Patches
+	DrainInvoicePatches() invoiceupdater.Patches
 }
 
 func (c Config[CHARGE, BASE, STATUS]) Validate() error {
@@ -63,7 +63,7 @@ type Machine[CHARGE ChargeLike[CHARGE, BASE, STATUS], BASE any, STATUS Status] s
 	Charge         CHARGE
 	stateMachine   *stateless.StateMachine
 	config         Config[CHARGE, BASE, STATUS]
-	invoicePatches []invoiceupdater.Patch
+	invoicePatches invoiceupdater.Patches
 }
 
 func New[CHARGE ChargeLike[CHARGE, BASE, STATUS], BASE any, STATUS Status](config Config[CHARGE, BASE, STATUS]) (*Machine[CHARGE, BASE, STATUS], error) {
@@ -108,11 +108,11 @@ func (m *Machine[CHARGE, BASE, STATUS]) GetCharge() CHARGE {
 	return m.Charge
 }
 
-func (m *Machine[CHARGE, BASE, STATUS]) InvoicePatches() []invoiceupdater.Patch {
+func (m *Machine[CHARGE, BASE, STATUS]) InvoicePatches() invoiceupdater.Patches {
 	return slices.Clone(m.invoicePatches)
 }
 
-func (m *Machine[CHARGE, BASE, STATUS]) DrainInvoicePatches() []invoiceupdater.Patch {
+func (m *Machine[CHARGE, BASE, STATUS]) DrainInvoicePatches() invoiceupdater.Patches {
 	patches := m.invoicePatches
 	m.invoicePatches = nil
 	return patches

--- a/openmeter/billing/charges/testutils/service.go
+++ b/openmeter/billing/charges/testutils/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	flatfeeadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/adapter"
 	flatfeeservice "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	lineageadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/adapter"
 	lineageservice "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/service"
 	metaadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/meta/adapter"
@@ -172,12 +173,21 @@ func NewServices(t testing.TB, config Config) (*Services, error) {
 		return nil, fmt.Errorf("creating usage based adapter: %w", err)
 	}
 
+	invoiceUpdater, err := invoiceupdater.New(invoiceupdater.Config{
+		BillingService: config.BillingService,
+		Logger:         logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating invoice updater: %w", err)
+	}
+
 	usageBasedService, err := usagebasedservice.New(usagebasedservice.Config{
 		Adapter:                 usageBasedAdapter,
 		Handler:                 config.UsageBasedHandler,
 		Lineage:                 lineageService,
 		Locker:                  locker,
 		MetaAdapter:             metaAdapter,
+		InvoiceUpdater:          invoiceUpdater,
 		CustomerOverrideService: config.BillingService,
 		FeatureService:          config.FeatureService,
 		RatingService:           billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: true}),

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -270,7 +270,7 @@ func (s *CreditThenInvoiceStateMachine) DeleteCharge(ctx context.Context, patch 
 
 	s.Charge.Status = usagebased.StatusDeleted
 
-	patches := []invoiceupdater.Patch{
+	patches := invoiceupdater.Patches{
 		invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(s.Charge.ID),
 	}
 

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -417,17 +417,17 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 
 		charge, patches, err := e.applyChargePatchForInvoiceLineEditViaAPI(ctx, charge, deletePatch)
 		if err != nil {
-			return err
+			return fmt.Errorf("usage based line[%s]: applying charge delete patch for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
 
 		standardInvoice, err := invoice.AsInvoice().AsStandardInvoice()
 		if err != nil {
-			return err
+			return fmt.Errorf("usage based line[%s]: getting standard invoice: %w", line.GetID(), err)
 		}
 
 		stdInvoicePatches, rest, err := patches.BisectByStandardInvoiceID(standardInvoice.ID)
 		if err != nil {
-			return err
+			return fmt.Errorf("usage based line[%s]: bisecting invoice patches for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
 
 		if len(stdInvoicePatches) != 1 {
@@ -436,32 +436,32 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 
 		stdInvoicePatch, err := stdInvoicePatches.RequireSingularStandardInvoiceLineDeletePatch()
 		if err != nil {
-			return err
+			return fmt.Errorf("usage based line[%s]: requiring singular standard invoice line delete patch for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
 
 		if err := stdInvoicePatch.RequireTarget(line); err != nil {
-			return err
+			return fmt.Errorf("usage based line[%s]: validating standard invoice line delete patch target for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
 
 		standardLine, err := line.AsInvoiceLine().AsStandardLine()
 		if err != nil {
-			return err
+			return fmt.Errorf("usage based line[%s]: getting standard line for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
 
-		charge, err = e.deleteMutableStandardLineRealization(ctx, charge, standardInvoice, &standardLine)
+		_, err = e.deleteMutableStandardLineRealization(ctx, charge, standardInvoice, &standardLine)
 		if err != nil {
-			return err
+			return fmt.Errorf("usage based line[%s]: deleting mutable standard line realization for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
 
 		// Handle the remaining gathering line patches
 		if err := rest.RequireType(invoiceupdater.PatchOpDeleteGatheringLineByChargeID, invoiceupdater.CountLessThanOrEqualTo(1)); err != nil {
-			return err
+			return fmt.Errorf("usage based line[%s]: validating remaining gathering line delete patches for charge[%s]: %w", line.GetID(), charge.ID, err)
 		}
 
 		if len(rest) > 0 {
 			err := e.service.invoiceUpdater.ApplyPatches(ctx, invoice.GetCustomerID(), rest)
 			if err != nil {
-				return err
+				return fmt.Errorf("usage based line[%s]: applying remaining gathering line delete patches for charge[%s]: %w", line.GetID(), charge.ID, err)
 			}
 		}
 
@@ -511,6 +511,7 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 		return err
 	}
 
+	gatheringLineDeletePatches := make(invoiceupdater.Patches, 0, len(input.Lines))
 	for _, stdLine := range input.Lines {
 		charge, ok := chargesByID[*stdLine.ChargeID]
 		if !ok {
@@ -523,6 +524,13 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 		}
 
 		chargesByID[*stdLine.ChargeID] = charge
+		gatheringLineDeletePatches = append(gatheringLineDeletePatches, invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(*stdLine.ChargeID))
+	}
+
+	if len(gatheringLineDeletePatches) > 0 {
+		if err := e.service.invoiceUpdater.ApplyPatches(ctx, input.Invoice.GetCustomerID(), gatheringLineDeletePatches); err != nil {
+			return fmt.Errorf("applying gathering line delete patches for deleted usage based standard lines: %w", err)
+		}
 	}
 
 	return nil

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -553,6 +553,11 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 		return err
 	}
 
+	// Whole-invoice deletion needs to remove the leftover gathering line for the
+	// same charge. Charge patch updates can delete a mutable standard line while
+	// also emitting replacement gathering-line patches, so this hook must not
+	// apply an extra delete for ordinary system line updates.
+	isInvoiceDelete := input.Invoice.DeletionSource != ""
 	gatheringLineDeletePatches := make(invoiceupdater.Patches, 0, len(input.Lines))
 	for _, stdLine := range input.Lines {
 		charge, ok := chargesByID[*stdLine.ChargeID]
@@ -566,7 +571,9 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 		}
 
 		chargesByID[*stdLine.ChargeID] = charge
-		gatheringLineDeletePatches = append(gatheringLineDeletePatches, invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(*stdLine.ChargeID))
+		if isInvoiceDelete {
+			gatheringLineDeletePatches = append(gatheringLineDeletePatches, invoiceupdater.NewDeleteGatheringLineByChargeIDPatch(*stdLine.ChargeID))
+		}
 	}
 
 	if len(gatheringLineDeletePatches) > 0 {

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -9,6 +9,7 @@ import (
 	"github.com/samber/mo"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
@@ -325,17 +326,176 @@ func (e *LineEngine) OnCollectionCompleted(ctx context.Context, input billing.On
 	return input.Lines, nil
 }
 
-func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(_ context.Context, input billing.OnMutableInvoiceUpdateInput) (billing.OnMutableInvoiceUpdateResult, error) {
-	// TODO: implement charge-backed manual creates by creating
-	// a manually managed charge and attaching its realization to the
-	// preallocated invoice line ID provided by billing.
-	for _, override := range input.Updated {
-		if err := meta.ValidateInvoiceLineOverrideDoesNotChangeImmutableChargeIntentFields(override); err != nil {
+func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, input billing.OnMutableInvoiceUpdateInput) (billing.OnMutableInvoiceUpdateResult, error) {
+	if err := input.Validate(); err != nil {
+		return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("validating input: %w", err)
+	}
+
+	if len(input.Created) > 0 {
+		return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("usage-based charge create: %w", billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	if len(input.Updated) > 0 {
+		return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("usage-based charge update: %w", billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	for _, line := range input.Deleted {
+		if err := e.handleInvoiceLineDeleteViaAPI(ctx, input.Invoice, line); err != nil {
 			return billing.OnMutableInvoiceUpdateResult{}, err
 		}
 	}
 
-	return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("usage-based charge: %w", billing.ErrCannotUpdateChargeManagedLine)
+	return billing.OnMutableInvoiceUpdateResult{}, nil
+}
+
+func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice billing.GenericInvoiceReader, line billing.GenericInvoiceLine) error {
+	if invoice == nil {
+		return fmt.Errorf("invoice is required")
+	}
+
+	chargeID := line.GetChargeID()
+	if chargeID == nil || *chargeID == "" {
+		return fmt.Errorf("usage based line[%s]: charge id is required", line.GetID())
+	}
+
+	charge, err := e.service.GetByID(ctx, usagebased.GetByIDInput{
+		ChargeID: meta.ChargeID{
+			Namespace: line.GetLineID().Namespace,
+			ID:        *chargeID,
+		},
+		Expands: meta.Expands{
+			meta.ExpandRealizations,
+			meta.ExpandDetailedLines,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("getting usage based charge for deleted line[%s]: %w", line.GetID(), err)
+	}
+
+	if charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
+		return fmt.Errorf(
+			"usage based line[%s]: unsupported settlement mode for API delete: %s",
+			line.GetID(),
+			charge.Intent.GetSettlementMode(),
+		)
+	}
+
+	nonVoidedRuns := charge.Realizations.WithoutVoidedBillingHistory()
+	switch line.AsInvoiceLine().Type() {
+	case billing.InvoiceLineTypeGathering:
+		if len(nonVoidedRuns) > 0 {
+			// TODO: Treat deleting the remaining gathering tail after prior
+			// usage-based realizations as a service-period shortening instead
+			// of deleting the whole charge and touching already-realized
+			// invoice history.
+			return fmt.Errorf("usage based gathering line[%s] cannot be deleted with existing realization runs: %w",
+				line.GetID(),
+				billing.ErrCannotEditProgressivelyBilledUsageBasedLine)
+		}
+
+		// TODO: implement
+		return billing.ErrCannotUpdateChargeManagedLine
+	case billing.InvoiceLineTypeStandard:
+		if len(nonVoidedRuns) > 1 {
+			return fmt.Errorf("usage based standard line[%s] cannot be deleted with multiple realization runs: %w",
+				line.GetID(),
+				billing.ErrCannotEditProgressivelyBilledUsageBasedLine)
+		}
+
+		if len(nonVoidedRuns) == 0 {
+			// This is an internal consistency error, we are not supposed to surface this to the user, so no typed error wrapping.
+			return fmt.Errorf("usage based standard line[%s] cannot be deleted with no realization runs", line.GetID())
+		}
+
+		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
+			ChangeSource: billing.ChangeSourceAPIRequest,
+			Policy:       meta.RefundAsCreditsDeletePolicy,
+		})
+		if err != nil {
+			return fmt.Errorf("creating usage based charge[%s] API delete patch: %w", charge.ID, err)
+		}
+
+		charge, patches, err := e.applyChargePatchForInvoiceLineEditViaAPI(ctx, charge, deletePatch)
+		if err != nil {
+			return err
+		}
+
+		standardInvoice, err := invoice.AsInvoice().AsStandardInvoice()
+		if err != nil {
+			return err
+		}
+
+		stdInvoicePatches, rest, err := patches.BisectByStandardInvoiceID(standardInvoice.ID)
+		if err != nil {
+			return err
+		}
+
+		if len(stdInvoicePatches) != 1 {
+			return fmt.Errorf("received unexpected number of standard invoice patches for line[%s]: count=%d %v", line.GetID(), len(stdInvoicePatches), stdInvoicePatches)
+		}
+
+		stdInvoicePatch, err := stdInvoicePatches.RequireSingularStandardInvoiceLineDeletePatch()
+		if err != nil {
+			return err
+		}
+
+		if err := stdInvoicePatch.RequireTarget(line); err != nil {
+			return err
+		}
+
+		standardLine, err := line.AsInvoiceLine().AsStandardLine()
+		if err != nil {
+			return err
+		}
+
+		charge, err = e.deleteMutableStandardLineRealization(ctx, charge, standardInvoice, &standardLine)
+		if err != nil {
+			return err
+		}
+
+		// Handle the remaining gathering line patches
+		if err := rest.RequireType(invoiceupdater.PatchOpDeleteGatheringLineByChargeID, invoiceupdater.CountLessThanOrEqualTo(1)); err != nil {
+			return err
+		}
+
+		if len(rest) > 0 {
+			err := e.service.invoiceUpdater.ApplyPatches(ctx, invoice.GetCustomerID(), rest)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	default:
+		return fmt.Errorf("usage based line[%s]: unexpected line type: %s", line.GetID(), line.AsInvoiceLine().Type())
+	}
+}
+
+func (e *LineEngine) applyChargePatchForInvoiceLineEditViaAPI(ctx context.Context, charge usagebased.Charge, patch meta.Patch) (usagebased.Charge, invoiceupdater.Patches, error) {
+	if err := patch.Validate(); err != nil {
+		return usagebased.Charge{}, nil, fmt.Errorf("validating usage based charge[%s] API line edit patch: %w", charge.ID, err)
+	}
+
+	stateMachineConfig, err := e.service.getStateMachineConfigForPatch(ctx, charge)
+	if err != nil {
+		return usagebased.Charge{}, nil, fmt.Errorf("getting state machine config for charge[%s]: %w", charge.ID, err)
+	}
+
+	stateMachine, err := e.service.newStateMachine(stateMachineConfig)
+	if err != nil {
+		return usagebased.Charge{}, nil, fmt.Errorf("new state machine for usage based charge[%s]: %w", charge.ID, err)
+	}
+
+	creditThenInvoiceStateMachine, ok := stateMachine.(*CreditThenInvoiceStateMachine)
+	if !ok {
+		return usagebased.Charge{}, nil, fmt.Errorf("BUG: usage based charge[%s]: expected credit_then_invoice state machine, got %T", charge.ID, stateMachine)
+	}
+
+	if err := creditThenInvoiceStateMachine.FireAndActivate(ctx, patch.Trigger(), patch); err != nil {
+		return usagebased.Charge{}, nil, fmt.Errorf("triggering %s for charge[%s]: %w", patch.Trigger(), charge.ID, err)
+	}
+
+	return creditThenInvoiceStateMachine.GetCharge(), creditThenInvoiceStateMachine.DrainInvoicePatches(), nil
 }
 
 func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, input billing.OnMutableStandardLinesDeletedInput) error {
@@ -357,52 +517,69 @@ func (e *LineEngine) OnMutableStandardLinesDeletedBySystem(ctx context.Context, 
 			return fmt.Errorf("usage based charge[%s] not found for deleted standard line[%s]", *stdLine.ChargeID, stdLine.ID)
 		}
 
-		run, err := charge.Realizations.GetByLineID(stdLine.ID)
+		charge, err = e.deleteMutableStandardLineRealization(ctx, charge, input.Invoice, stdLine)
 		if err != nil {
 			return err
-		}
-		// Deleted realizations have already been cleaned up through a prior line deletion,
-		// so billing must not run the cleanup path for them again.
-		if run.DeletedAt != nil {
-			return fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] is already deleted", stdLine.ID, run.ID.ID)
-		}
-
-		if run.InvoiceID == nil || *run.InvoiceID != input.Invoice.ID {
-			return fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] is not associated with invoice[%s]", stdLine.ID, run.ID.ID, input.Invoice.ID)
-		}
-
-		if run.Payment != nil {
-			return fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] has payment allocation", stdLine.ID, run.ID.ID)
-		}
-
-		if run.InvoiceUsage != nil {
-			return fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] has invoice accrued allocation", stdLine.ID, run.ID.ID)
-		}
-
-		currencyCalculator, err := charge.Intent.GetCurrency().Calculator()
-		if err != nil {
-			return fmt.Errorf("getting currency calculator for charge[%s]: %w", charge.ID, err)
-		}
-
-		now := clock.Now()
-		if _, err := e.service.runs.CorrectAllCredits(ctx, usagebasedrun.CorrectAllCreditRealizationsInput{
-			Charge:             charge,
-			Run:                run,
-			AllocateAt:         run.ServicePeriodTo,
-			CurrencyCalculator: currencyCalculator,
-		}); err != nil {
-			return fmt.Errorf("correcting credits for deleted usage based standard line[%s] run[%s]: %w", stdLine.ID, run.ID.ID, err)
-		}
-
-		charge, err = e.markMutableStandardLineRunDeleted(ctx, charge, run, now)
-		if err != nil {
-			return fmt.Errorf("marking realization run[%s] deleted for usage based standard line[%s]: %w", run.ID.ID, stdLine.ID, err)
 		}
 
 		chargesByID[*stdLine.ChargeID] = charge
 	}
 
 	return nil
+}
+
+// deleteMutableStandardLineRealization removes the usage-based realization
+// backing a mutable deleted standard invoice line, including credit correction
+// and current-run detachment.
+func (e *LineEngine) deleteMutableStandardLineRealization(
+	ctx context.Context,
+	charge usagebased.Charge,
+	invoice billing.StandardInvoice,
+	stdLine *billing.StandardLine,
+) (usagebased.Charge, error) {
+	run, err := charge.Realizations.GetByLineID(stdLine.ID)
+	if err != nil {
+		return usagebased.Charge{}, err
+	}
+	// Deleted realizations have already been cleaned up through a prior line deletion,
+	// so billing must not run the cleanup path for them again.
+	if run.DeletedAt != nil {
+		return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] is already deleted", stdLine.ID, run.ID.ID)
+	}
+
+	if run.InvoiceID == nil || *run.InvoiceID != invoice.ID {
+		return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] is not associated with invoice[%s]", stdLine.ID, run.ID.ID, invoice.ID)
+	}
+
+	if run.Payment != nil {
+		return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] has payment allocation", stdLine.ID, run.ID.ID)
+	}
+
+	if run.InvoiceUsage != nil {
+		return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted because realization run[%s] has invoice accrued allocation", stdLine.ID, run.ID.ID)
+	}
+
+	currencyCalculator, err := charge.Intent.GetCurrency().Calculator()
+	if err != nil {
+		return usagebased.Charge{}, fmt.Errorf("getting currency calculator for charge[%s]: %w", charge.ID, err)
+	}
+
+	now := clock.Now()
+	if _, err := e.service.runs.CorrectAllCredits(ctx, usagebasedrun.CorrectAllCreditRealizationsInput{
+		Charge:             charge,
+		Run:                run,
+		AllocateAt:         run.ServicePeriodTo,
+		CurrencyCalculator: currencyCalculator,
+	}); err != nil {
+		return usagebased.Charge{}, fmt.Errorf("correcting credits for deleted usage based standard line[%s] run[%s]: %w", stdLine.ID, run.ID.ID, err)
+	}
+
+	charge, err = e.markMutableStandardLineRunDeleted(ctx, charge, run, now)
+	if err != nil {
+		return usagebased.Charge{}, fmt.Errorf("marking realization run[%s] deleted for usage based standard line[%s]: %w", run.ID.ID, stdLine.ID, err)
+	}
+
+	return charge, nil
 }
 
 func (e *LineEngine) OnUnsupportedCreditNote(ctx context.Context, input billing.OnUnsupportedCreditNoteInput) error {

--- a/openmeter/billing/charges/usagebased/service/lineengine.go
+++ b/openmeter/billing/charges/usagebased/service/lineengine.go
@@ -348,14 +348,36 @@ func (e *LineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, inpu
 	return billing.OnMutableInvoiceUpdateResult{}, nil
 }
 
-func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice billing.GenericInvoiceReader, line billing.GenericInvoiceLine) error {
+func (e *LineEngine) ValidateMutableInvoiceLineEditViaAPI(ctx context.Context, input billing.OnMutableInvoiceUpdateInput) error {
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("validating input: %w", err)
+	}
+
+	if len(input.Created) > 0 {
+		return fmt.Errorf("usage-based charge create: %w", billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	if len(input.Updated) > 0 {
+		return fmt.Errorf("usage-based charge update: %w", billing.ErrCannotUpdateChargeManagedLine)
+	}
+
+	for _, line := range input.Deleted {
+		if _, err := e.validateInvoiceLineDeleteViaAPI(ctx, input.Invoice, line); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (e *LineEngine) validateInvoiceLineDeleteViaAPI(ctx context.Context, invoice billing.GenericInvoiceReader, line billing.GenericInvoiceLine) (usagebased.Charge, error) {
 	if invoice == nil {
-		return fmt.Errorf("invoice is required")
+		return usagebased.Charge{}, fmt.Errorf("invoice is required")
 	}
 
 	chargeID := line.GetChargeID()
 	if chargeID == nil || *chargeID == "" {
-		return fmt.Errorf("usage based line[%s]: charge id is required", line.GetID())
+		return usagebased.Charge{}, fmt.Errorf("usage based line[%s]: charge id is required", line.GetID())
 	}
 
 	charge, err := e.service.GetByID(ctx, usagebased.GetByIDInput{
@@ -369,11 +391,11 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("getting usage based charge for deleted line[%s]: %w", line.GetID(), err)
+		return usagebased.Charge{}, fmt.Errorf("getting usage based charge for deleted line[%s]: %w", line.GetID(), err)
 	}
 
 	if charge.Intent.GetSettlementMode() != productcatalog.CreditThenInvoiceSettlementMode {
-		return fmt.Errorf(
+		return usagebased.Charge{}, fmt.Errorf(
 			"usage based line[%s]: unsupported settlement mode for API delete: %s",
 			line.GetID(),
 			charge.Intent.GetSettlementMode(),
@@ -388,24 +410,44 @@ func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice 
 			// usage-based realizations as a service-period shortening instead
 			// of deleting the whole charge and touching already-realized
 			// invoice history.
-			return fmt.Errorf("usage based gathering line[%s] cannot be deleted with existing realization runs: %w",
+			return usagebased.Charge{}, fmt.Errorf("usage based gathering line[%s] cannot be deleted with existing realization runs: %w",
 				line.GetID(),
 				billing.ErrCannotEditProgressivelyBilledUsageBasedLine)
 		}
 
 		// TODO: implement
-		return billing.ErrCannotUpdateChargeManagedLine
+		return usagebased.Charge{}, billing.ErrCannotUpdateChargeManagedLine
 	case billing.InvoiceLineTypeStandard:
 		if len(nonVoidedRuns) > 1 {
-			return fmt.Errorf("usage based standard line[%s] cannot be deleted with multiple realization runs: %w",
+			return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted with multiple realization runs: %w",
 				line.GetID(),
 				billing.ErrCannotEditProgressivelyBilledUsageBasedLine)
 		}
 
 		if len(nonVoidedRuns) == 0 {
 			// This is an internal consistency error, we are not supposed to surface this to the user, so no typed error wrapping.
-			return fmt.Errorf("usage based standard line[%s] cannot be deleted with no realization runs", line.GetID())
+			return usagebased.Charge{}, fmt.Errorf("usage based standard line[%s] cannot be deleted with no realization runs", line.GetID())
 		}
+	default:
+		return usagebased.Charge{}, fmt.Errorf("usage based line[%s]: unexpected line type: %s", line.GetID(), line.AsInvoiceLine().Type())
+	}
+
+	return charge, nil
+}
+
+func (e *LineEngine) handleInvoiceLineDeleteViaAPI(ctx context.Context, invoice billing.GenericInvoiceReader, line billing.GenericInvoiceLine) error {
+	chargeID := line.GetChargeID()
+	if chargeID == nil || *chargeID == "" {
+		return fmt.Errorf("usage based line[%s]: charge id is required", line.GetID())
+	}
+
+	charge, err := e.validateInvoiceLineDeleteViaAPI(ctx, invoice, line)
+	if err != nil {
+		return err
+	}
+
+	switch line.AsInvoiceLine().Type() {
+	case billing.InvoiceLineTypeStandard:
 
 		deletePatch, err := meta.NewPatchDelete(meta.NewPatchDeleteInput{
 			ChangeSource: billing.ChangeSourceAPIRequest,

--- a/openmeter/billing/charges/usagebased/service/service.go
+++ b/openmeter/billing/charges/usagebased/service/service.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/lineage"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
@@ -21,6 +22,7 @@ type Config struct {
 	Lineage                 lineage.Service
 	Locker                  *lockr.Locker
 	MetaAdapter             meta.Adapter
+	InvoiceUpdater          invoiceupdater.Updater
 	CustomerOverrideService billing.CustomerOverrideService
 	FeatureService          feature.FeatureConnector
 	RatingService           rating.Service
@@ -49,6 +51,10 @@ func (c Config) Validate() error {
 
 	if c.MetaAdapter == nil {
 		errs = append(errs, errors.New("meta adapter cannot be null"))
+	}
+
+	if c.InvoiceUpdater == nil {
+		errs = append(errs, errors.New("invoice updater cannot be null"))
 	}
 
 	if c.CustomerOverrideService == nil {
@@ -98,6 +104,7 @@ func New(config Config) (usagebased.Service, error) {
 		adapter:                 config.Adapter,
 		locker:                  config.Locker,
 		metaAdapter:             config.MetaAdapter,
+		invoiceUpdater:          config.InvoiceUpdater,
 		customerOverrideService: config.CustomerOverrideService,
 		featureService:          config.FeatureService,
 		ratingService:           config.RatingService,
@@ -110,6 +117,7 @@ type service struct {
 	adapter                 usagebased.Adapter
 	locker                  *lockr.Locker
 	metaAdapter             meta.Adapter
+	invoiceUpdater          invoiceupdater.Updater
 	customerOverrideService billing.CustomerOverrideService
 	featureService          feature.FeatureConnector
 	ratingService           rating.Service

--- a/openmeter/billing/errors.go
+++ b/openmeter/billing/errors.go
@@ -61,12 +61,13 @@ var (
 
 	ErrNamespaceLocked = NewValidationError("namespace_locked", "namespace is locked")
 
-	ErrInvoiceLineCreditsNotConsumedFully    = NewValidationError("invoice_line_credits_not_consumed_fully", "credits not consumed fully")
-	ErrCannotUpdateChargeManagedLine         = NewValidationError("cannot_update_charge_managed_line", "cannot update charge managed lines, please update the charge instead")
-	ErrInvoiceLineFeatureKeyEditNotSupported = NewValidationError("invoice_line_feature_key_edit_not_supported", "feature key editing is not supported for charge-managed invoice lines, please delete the charge instead")
-	ErrInvoiceLineTaxConfigEditNotSupported  = NewValidationError("invoice_line_tax_config_edit_not_supported", "tax config editing is not supported for charge-managed invoice lines, please delete the charge instead")
-	ErrInvoiceLineZeroAmountDeleteInstead    = NewValidationError("invoice_line_zero_amount_delete_instead", "invoice line amount cannot be updated to zero, please delete the line instead")
-	ErrInvoiceLineZeroAmountCreate           = NewValidationError("invoice_line_zero_amount_create", "creating zero amount flat fee invoice lines is not supported")
+	ErrInvoiceLineCreditsNotConsumedFully          = NewValidationError("invoice_line_credits_not_consumed_fully", "credits not consumed fully")
+	ErrCannotUpdateChargeManagedLine               = NewValidationError("cannot_update_charge_managed_line", "cannot update charge managed lines, please update the charge instead")
+	ErrCannotEditProgressivelyBilledUsageBasedLine = NewValidationError("cannot_edit_progressively_billed_usagebased_line", "cannot edit usagebased items that are progressively billed, update the charge instead")
+	ErrInvoiceLineFeatureKeyEditNotSupported       = NewValidationError("invoice_line_feature_key_edit_not_supported", "feature key editing is not supported for charge-managed invoice lines, please delete the charge instead")
+	ErrInvoiceLineTaxConfigEditNotSupported        = NewValidationError("invoice_line_tax_config_edit_not_supported", "tax config editing is not supported for charge-managed invoice lines, please delete the charge instead")
+	ErrInvoiceLineZeroAmountDeleteInstead          = NewValidationError("invoice_line_zero_amount_delete_instead", "invoice line amount cannot be updated to zero, please delete the line instead")
+	ErrInvoiceLineZeroAmountCreate                 = NewValidationError("invoice_line_zero_amount_create", "creating zero amount flat fee invoice lines is not supported")
 )
 
 const (

--- a/openmeter/billing/httpdriver/invoice.go
+++ b/openmeter/billing/httpdriver/invoice.go
@@ -375,12 +375,12 @@ func (h *handler) DeleteInvoice() DeleteInvoiceHandler {
 				return DeleteInvoiceResponse{}, err
 			}
 
-			if err := billing.ValidateAPIInvoiceDeleteSupported(invoice); err != nil {
-				return DeleteInvoiceResponse{}, err
-			}
-
 			switch invoice.Type() {
 			case billing.InvoiceTypeGathering:
+				if err := billing.ValidateAPIInvoiceDeleteSupported(invoice); err != nil {
+					return DeleteInvoiceResponse{}, err
+				}
+
 				if _, err := h.service.DeleteGatheringInvoice(ctx, request); err != nil {
 					return DeleteInvoiceResponse{}, fmt.Errorf("deleting gathering invoice: %w", err)
 				}

--- a/openmeter/billing/httpdriver/invoice_test.go
+++ b/openmeter/billing/httpdriver/invoice_test.go
@@ -71,7 +71,7 @@ func TestMapInvoiceLineCreditsToAPIOmitsEmptyCredits(t *testing.T) {
 	require.Nil(t, mapInvoiceLineCreditsToAPI(nil))
 }
 
-func TestValidateAPIGenericInvoiceDeleteSupported(t *testing.T) {
+func TestValidateAPIGenericInvoiceDeleteSupportedForGatheringInvoices(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -82,41 +82,20 @@ func TestValidateAPIGenericInvoiceDeleteSupported(t *testing.T) {
 		wantError bool
 	}{
 		{
-			name: "standard invoice flat fee line is supported",
-			invoice: standardInvoiceDeleteSupportTestInvoice(
-				standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeFlatFee, nil),
-			),
-		},
-		{
-			name: "standard invoice deleted usage-based line is ignored",
-			invoice: standardInvoiceDeleteSupportTestInvoice(
-				standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, &now),
-			),
-		},
-		{
-			name: "standard invoice active usage-based line is rejected",
-			invoice: standardInvoiceDeleteSupportTestInvoice(
-				standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
-			),
-			wantError: true,
-		},
-		{
-			name: "standard invoice mixed flat fee and active usage-based line is rejected before delete",
-			invoice: standardInvoiceDeleteSupportTestInvoice(
-				standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeFlatFee, nil),
-				standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
-			),
-			wantError: true,
-		},
-		{
-			name: "gathering invoice active usage-based line is rejected",
+			name: "active usage-based line is rejected",
 			invoice: gatheringInvoiceDeleteSupportTestInvoice(
 				gatheringInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
 			),
 			wantError: true,
 		},
 		{
-			name: "gathering invoice flat fee line is supported",
+			name: "deleted usage-based line is ignored",
+			invoice: gatheringInvoiceDeleteSupportTestInvoice(
+				gatheringInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, &now),
+			),
+		},
+		{
+			name: "flat fee line is supported",
 			invoice: gatheringInvoiceDeleteSupportTestInvoice(
 				gatheringInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeFlatFee, nil),
 			),
@@ -151,12 +130,12 @@ func TestValidateAPIGenericInvoiceDeleteSupported(t *testing.T) {
 	}
 }
 
-func TestValidateAPIInvoiceDeleteSupportedIgnoresDeletedInvoice(t *testing.T) {
+func TestValidateAPIInvoiceDeleteSupportedIgnoresDeletedGatheringInvoice(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	invoice := standardInvoiceDeleteSupportTestInvoice(
-		standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
+	invoice := gatheringInvoiceDeleteSupportTestInvoice(
+		gatheringInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
 	)
 	invoice.DeletedAt = &now
 
@@ -165,57 +144,30 @@ func TestValidateAPIInvoiceDeleteSupportedIgnoresDeletedInvoice(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestValidateAPIInvoiceDeleteSupportedRejectsUsageBasedInvoices(t *testing.T) {
+func TestValidateAPIInvoiceDeleteSupportedSkipsStandardInvoices(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
-		name    string
-		invoice billing.Invoice
-	}{
-		{
-			name: "standard invoice",
-			invoice: billing.NewInvoice(*standardInvoiceDeleteSupportTestInvoice(
-				standardInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
-			)),
-		},
-		{
-			name: "gathering invoice",
-			invoice: billing.NewInvoice(*gatheringInvoiceDeleteSupportTestInvoice(
-				gatheringInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
-			)),
-		},
-	}
+	err := billing.ValidateAPIInvoiceDeleteSupported(billing.NewInvoice(billing.StandardInvoice{
+		Lines: billing.NewStandardInvoiceLines([]*billing.StandardLine{{
+			StandardLineBase: billing.StandardLineBase{
+				Engine: billing.LineEngineTypeChargeUsageBased,
+			},
+			UsageBased: &billing.UsageBasedLine{},
+		}}),
+	}))
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			err := billing.ValidateAPIInvoiceDeleteSupported(tc.invoice)
-
-			require.Error(t, err)
-			require.ErrorIs(t, err, billing.ErrCannotUpdateChargeManagedLine)
-		})
-	}
+	require.NoError(t, err)
 }
 
-func standardInvoiceDeleteSupportTestInvoice(lines ...*billing.StandardLine) *billing.StandardInvoice {
-	return &billing.StandardInvoice{
-		Lines: billing.NewStandardInvoiceLines(lines),
-	}
-}
+func TestValidateAPIInvoiceDeleteSupportedRejectsUsageBasedGatheringInvoice(t *testing.T) {
+	t.Parallel()
 
-func standardInvoiceDeleteSupportTestLine(engine billing.LineEngineType, deletedAt *time.Time) *billing.StandardLine {
-	line := &billing.StandardLine{
-		StandardLineBase: billing.StandardLineBase{
-			Engine: engine,
-		},
-	}
-	if engine == billing.LineEngineTypeChargeUsageBased {
-		line.UsageBased = &billing.UsageBasedLine{}
-	}
-	line.DeletedAt = deletedAt
+	err := billing.ValidateAPIInvoiceDeleteSupported(billing.NewInvoice(*gatheringInvoiceDeleteSupportTestInvoice(
+		gatheringInvoiceDeleteSupportTestLine(billing.LineEngineTypeChargeUsageBased, nil),
+	)))
 
-	return line
+	require.Error(t, err)
+	require.ErrorIs(t, err, billing.ErrCannotUpdateChargeManagedLine)
 }
 
 func gatheringInvoiceDeleteSupportTestInvoice(lines ...billing.GatheringLine) *billing.GatheringInvoice {

--- a/openmeter/billing/invoice_validator.go
+++ b/openmeter/billing/invoice_validator.go
@@ -6,11 +6,9 @@ import (
 	"github.com/openmeterio/openmeter/pkg/models"
 )
 
-// ValidateAPIInvoiceDeleteSupported is a temporary HTTP-level guard until
-// usage-based invoice-scope deletion is implemented. It blocks the public API
-// before standard DeleteInvoice or gathering DeleteGatheringInvoice can run
-// side-effectful line-engine cleanup on other charge-backed lines in the same
-// invoice.
+// ValidateAPIInvoiceDeleteSupported is a temporary HTTP-level guard for
+// gathering invoice deletion until usage-based gathering-line deletion is
+// implemented.
 func ValidateAPIInvoiceDeleteSupported(invoice Invoice) error {
 	switch invoice.Type() {
 	case InvoiceTypeGathering:
@@ -22,13 +20,7 @@ func ValidateAPIInvoiceDeleteSupported(invoice Invoice) error {
 			return nil
 		}
 	case InvoiceTypeStandard:
-		standardInvoice, err := invoice.AsStandardInvoice()
-		if err != nil {
-			return err
-		}
-		if standardInvoice.DeletedAt != nil {
-			return nil
-		}
+		return nil
 	default:
 		return models.NewNillableGenericValidationError(fmt.Errorf("invalid invoice type: %s", invoice.Type()))
 	}
@@ -47,10 +39,10 @@ func ValidateAPIGenericInvoiceDeleteSupported(invoice GenericInvoice) error {
 			continue
 		}
 
-		// Usage-based charge deletion at invoice scope is not implemented yet.
-		// Keep this temporary HTTP-only guard ahead of both standard and
-		// gathering invoice deletion so mixed invoices cannot run flat-fee
-		// cleanup before a usage-based line rejects.
+		// Usage-based gathering-line deletion is not implemented yet. Keep this
+		// temporary HTTP-only guard ahead of gathering invoice deletion so mixed
+		// gathering invoices cannot run flat-fee cleanup before a usage-based
+		// line rejects.
 		if line.GetLineEngineType() == LineEngineTypeChargeUsageBased {
 			return ValidationError{
 				Err: ValidationWithComponent(

--- a/openmeter/billing/invoiceline.go
+++ b/openmeter/billing/invoiceline.go
@@ -147,6 +147,14 @@ func (t InvoiceLineType) Validate() error {
 	return nil
 }
 
+func (t InvoiceLineType) Require(types ...InvoiceLineType) error {
+	if !slices.Contains(types, t) {
+		return fmt.Errorf("invoice line type: %s", t)
+	}
+
+	return nil
+}
+
 type InvoiceLine struct {
 	t             InvoiceLineType
 	standardLine  *StandardLine

--- a/openmeter/billing/lineengine.go
+++ b/openmeter/billing/lineengine.go
@@ -261,6 +261,18 @@ type LineEngine interface {
 	OnCollectionCompleted(ctx context.Context, input OnCollectionCompletedInput) (StandardLines, error)
 	// OnMutableStandardLinesDeletedBySystem is invoked after mutable standard invoice lines are marked deleted by the system.
 	OnMutableStandardLinesDeletedBySystem(ctx context.Context, input OnMutableStandardLinesDeletedInput) error
+	// ValidateMutableInvoiceLineEditViaAPI is invoked before mutable invoice lines are edited through the API.
+	// Can be used to reject edits that are not supported by the engine (including deletion, etc.) to prevent the
+	// invoice from entering an invalid state without recovery.
+	//
+	// Additional checks can be performed in OnMutableInvoiceLinesEditedViaAPI but those errors will become
+	// validation issues, thus alter the invoice state.
+	//
+	// For API requests it is better to reject and edit before, the existing validation issue logic is geared
+	// towards state machine failures.
+	//
+	// Implementations must not mutate invoice, charge, ledger, or external state from this hook.
+	ValidateMutableInvoiceLineEditViaAPI(ctx context.Context, input OnMutableInvoiceUpdateInput) error
 	// OnMutableInvoiceLinesEditedViaAPI is invoked after mutable invoice lines are edited through the API.
 	// Implementations must return exactly one CreatedLines entry for each input Created line and
 	// exactly one UpdatedLines entry for each input Updated override, even when they only accept

--- a/openmeter/billing/lineengine/engine.go
+++ b/openmeter/billing/lineengine/engine.go
@@ -95,6 +95,20 @@ func (e *Engine) OnCollectionCompleted(ctx context.Context, input billing.OnColl
 	return input.Lines, nil
 }
 
+func (e *Engine) ValidateMutableInvoiceLineEditViaAPI(_ context.Context, input billing.OnMutableInvoiceUpdateInput) error {
+	if err := input.Validate(); err != nil {
+		return fmt.Errorf("validating input: %w", err)
+	}
+
+	for _, override := range input.Updated {
+		if err := validateLegacyLineOverride(override); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (e *Engine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, input billing.OnMutableInvoiceUpdateInput) (billing.OnMutableInvoiceUpdateResult, error) {
 	if err := input.Validate(); err != nil {
 		return billing.OnMutableInvoiceUpdateResult{}, fmt.Errorf("validating input: %w", err)

--- a/openmeter/billing/service/invoice.go
+++ b/openmeter/billing/service/invoice.go
@@ -584,11 +584,13 @@ func (s *Service) RetryInvoice(ctx context.Context, input billing.RetryInvoiceIn
 
 type (
 	editCallbackFunc              func(ctx context.Context, sm *InvoiceStateMachine) error
+	preTriggerCallbackFunc        func(ctx context.Context, sm *InvoiceStateMachine) error
 	executeTriggerApplyOptionFunc func(opts *executeTriggerOnInvoiceOptions)
 )
 
 type executeTriggerOnInvoiceOptions struct {
 	editCallback        editCallbackFunc
+	preTriggerCallback  preTriggerCallbackFunc
 	allowInStates       []billing.StandardInvoiceStatus
 	includeDeletedLines bool
 	triggerArgs         []any
@@ -597,6 +599,12 @@ type executeTriggerOnInvoiceOptions struct {
 func ExecuteTriggerWithEditCallback(cb editCallbackFunc) executeTriggerApplyOptionFunc {
 	return func(opts *executeTriggerOnInvoiceOptions) {
 		opts.editCallback = cb
+	}
+}
+
+func ExecuteTriggerWithPreTriggerCallback(cb preTriggerCallbackFunc) executeTriggerApplyOptionFunc {
+	return func(opts *executeTriggerOnInvoiceOptions) {
+		opts.preTriggerCallback = cb
 	}
 }
 
@@ -647,6 +655,12 @@ func (s *Service) executeTriggerOnInvoice(ctx context.Context, invoiceID billing
 				if !canFire && !slices.Contains(options.allowInStates, sm.Invoice.Status) {
 					return billing.ValidationError{
 						Err: fmt.Errorf("cannot %s invoice in status [%s]: %w", trigger, sm.Invoice.Status, billing.ErrInvoiceActionNotAvailable),
+					}
+				}
+
+				if options.preTriggerCallback != nil {
+					if err := options.preTriggerCallback(ctx, sm); err != nil {
+						return err
 					}
 				}
 
@@ -745,6 +759,25 @@ func (s *Service) DeleteInvoice(ctx context.Context, input billing.DeleteInvoice
 		billing.TriggerDelete,
 		ExecuteTriggerWithArgs(billing.DeleteInvoiceTriggerInput{
 			Source: input.DeletionSource,
+		}),
+		ExecuteTriggerWithPreTriggerCallback(func(ctx context.Context, sm *InvoiceStateMachine) error {
+			if input.DeletionSource != billing.ChangeSourceAPIRequest {
+				return nil
+			}
+
+			if err := s.validateAPIStandardLineDeletions(
+				ctx,
+				sm.Invoice,
+				lo.Filter(sm.Invoice.Lines.OrEmpty(), func(line *billing.StandardLine, _ int) bool {
+					return line != nil && line.DeletedAt == nil
+				}),
+			); err != nil {
+				return billing.ValidationError{
+					Err: err,
+				}
+			}
+
+			return nil
 		}),
 	)
 }

--- a/openmeter/billing/service/invoiceupdate.go
+++ b/openmeter/billing/service/invoiceupdate.go
@@ -574,6 +574,10 @@ func (s *Service) applyAPIInvoiceLineEdits(
 		return nil, fmt.Errorf("grouping mutable invoice line changes by engine: %w", err)
 	}
 
+	if err := s.validateAPIInvoiceLineEdits(ctx, changesByEngine); err != nil {
+		return nil, err
+	}
+
 	resultingLines := make([]billing.GenericInvoiceLine, 0, len(lineDiff.Created)+len(lineDiff.Updated)+len(lineDiff.Deleted)+len(lineDiff.Unchanged))
 	resultingLines = append(resultingLines, lineDiff.Unchanged...)
 
@@ -630,6 +634,29 @@ func (s *Service) applyAPIInvoiceLineEdits(
 	}
 
 	return edited, nil
+}
+
+func (s *Service) validateAPIInvoiceLineEdits(ctx context.Context, changesByEngine map[billing.LineEngineType]billing.OnMutableInvoiceUpdateInput) error {
+	var errs []error
+
+	for engineType, input := range changesByEngine {
+		engine, err := s.lineEngines.Get(engineType)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("getting engine %s: %w", engineType, err))
+			continue
+		}
+
+		if err := input.Validate(); err != nil {
+			errs = append(errs, fmt.Errorf("validating API invoice line edit input for engine %s: %w", engine.GetLineEngineType(), err))
+			continue
+		}
+
+		if err := engine.ValidateMutableInvoiceLineEditViaAPI(ctx, input); err != nil {
+			errs = append(errs, billing.NewLineEngineValidationError(engine, err))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 func (s *Service) defaultTaxCodeResolversForInvoiceUpdate(invoice billing.GenericInvoiceReader) billing.DefaultTaxCodeResolvers {
@@ -886,38 +913,15 @@ func validateLineEngineResult(expectedLines []billing.GenericInvoiceLine, actual
 }
 
 func (s *Service) dispatchAPIStandardLineDeletions(ctx context.Context, invoice billing.StandardInvoice, deletedLinesIn billing.StandardLines) error {
-	if len(deletedLinesIn) == 0 {
-		return nil
-	}
-
-	for _, stdLine := range deletedLinesIn {
-		if err := s.lineEngines.populateStandardLineEngine(stdLine); err != nil {
-			return fmt.Errorf("line[%s]: inferring engine: %w", stdLine.GetID(), err)
-		}
-	}
-
-	input := billing.OnMutableInvoiceUpdateInput{
-		Invoice:                 invoice,
-		DefaultTaxCodeResolvers: s.defaultTaxCodeResolversForInvoiceUpdate(invoice),
-		Deleted:                 deletedLinesIn.AsGenericLines(),
-	}
-	if err := input.Validate(); err != nil {
-		return fmt.Errorf("validating mutable invoice line delete input: %w", err)
-	}
-
-	changesByEngine, err := input.GroupByLineEngine()
+	changesByEngine, err := s.groupAPIStandardLineDeletionsByEngine(invoice, deletedLinesIn)
 	if err != nil {
-		return fmt.Errorf("grouping mutable invoice line deletes by engine: %w", err)
+		return err
 	}
 
 	for engineType, groupedInput := range changesByEngine {
 		engine, err := s.lineEngines.Get(engineType)
 		if err != nil {
 			return fmt.Errorf("getting engine %s: %w", engineType, err)
-		}
-
-		if err := groupedInput.Validate(); err != nil {
-			return fmt.Errorf("validating API invoice line delete input for engine %s: %w", engine.GetLineEngineType(), err)
 		}
 
 		engineResult, err := engine.OnMutableInvoiceLinesEditedViaAPI(ctx, groupedInput)
@@ -937,6 +941,53 @@ func (s *Service) dispatchAPIStandardLineDeletions(ctx context.Context, invoice 
 	}
 
 	return nil
+}
+
+func (s *Service) validateAPIStandardLineDeletions(ctx context.Context, invoice billing.StandardInvoice, deletedLinesIn billing.StandardLines) error {
+	changesByEngine, err := s.groupAPIStandardLineDeletionsByEngine(invoice, deletedLinesIn)
+	if err != nil {
+		return err
+	}
+
+	return s.validateAPIInvoiceLineEdits(ctx, changesByEngine)
+}
+
+func (s *Service) groupAPIStandardLineDeletionsByEngine(invoice billing.StandardInvoice, deletedLinesIn billing.StandardLines) (map[billing.LineEngineType]billing.OnMutableInvoiceUpdateInput, error) {
+	if len(deletedLinesIn) == 0 {
+		return nil, nil
+	}
+
+	var errs []error
+
+	for _, stdLine := range deletedLinesIn {
+		if stdLine == nil {
+			errs = append(errs, errors.New("line is nil"))
+			continue
+		}
+
+		if err := s.lineEngines.populateStandardLineEngine(stdLine); err != nil {
+			errs = append(errs, fmt.Errorf("line[%s]: inferring engine: %w", stdLine.GetID(), err))
+		}
+	}
+	if err := errors.Join(errs...); err != nil {
+		return nil, err
+	}
+
+	input := billing.OnMutableInvoiceUpdateInput{
+		Invoice:                 invoice,
+		DefaultTaxCodeResolvers: s.defaultTaxCodeResolversForInvoiceUpdate(invoice),
+		Deleted:                 deletedLinesIn.AsGenericLines(),
+	}
+	if err := input.Validate(); err != nil {
+		return nil, fmt.Errorf("validating mutable invoice line delete input: %w", err)
+	}
+
+	changesByEngine, err := input.GroupByLineEngine()
+	if err != nil {
+		return nil, fmt.Errorf("grouping mutable invoice line deletes by engine: %w", err)
+	}
+
+	return changesByEngine, nil
 }
 
 func (s *Service) dispatchSystemStandardLineDeletions(ctx context.Context, invoice billing.StandardInvoice, deletedLinesIn []billing.GenericInvoiceLine) error {

--- a/openmeter/billing/service/lineengine_test.go
+++ b/openmeter/billing/service/lineengine_test.go
@@ -321,6 +321,10 @@ func (r staticCreateLineRouter) GetLineEngineForCreateLine(billing.GenericInvoic
 	return r.engine, nil
 }
 
+func (e *recordingLineEngine) ValidateMutableInvoiceLineEditViaAPI(_ context.Context, _ billing.OnMutableInvoiceUpdateInput) error {
+	return nil
+}
+
 func (e *recordingLineEngine) OnMutableInvoiceLinesEditedViaAPI(_ context.Context, input billing.OnMutableInvoiceUpdateInput) (billing.OnMutableInvoiceUpdateResult, error) {
 	e.apiEditInputs = append(e.apiEditInputs, input)
 	for _, line := range input.Created {

--- a/openmeter/billing/testutils/lineengine.go
+++ b/openmeter/billing/testutils/lineengine.go
@@ -48,6 +48,10 @@ func (NoopLineEngine) OnCollectionCompleted(_ context.Context, input billing.OnC
 	return input.Lines, nil
 }
 
+func (NoopLineEngine) ValidateMutableInvoiceLineEditViaAPI(_ context.Context, input billing.OnMutableInvoiceUpdateInput) error {
+	return input.Validate()
+}
+
 func (NoopLineEngine) OnMutableInvoiceLinesEditedViaAPI(_ context.Context, input billing.OnMutableInvoiceUpdateInput) (billing.OnMutableInvoiceUpdateResult, error) {
 	updatedLines := make([]billing.GenericInvoiceLine, 0, len(input.Updated))
 	for _, override := range input.Updated {

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -6778,6 +6778,12 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedProgressiveStandardInvoiceDel
 	}
 
 	s.Run("create progressive draft invoice", func() {
+		// given:
+		// - a credit-then-invoice usage-based subscription with progressive billing enabled
+		// when:
+		// - sync creates the subscription charges and two progressive standard invoices
+		// then:
+		// - the second draft invoice and its backing charge are ready for deletion assertions
 		s.enableProgressiveBilling()
 
 		s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 0, s.mustParseTime("2023-01-01T00:00:00Z"))

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -4751,7 +4751,7 @@ func (s *CreditThenInvoiceTestSuite) TestStandardInvoiceManualDeleteSync() {
 	s.assertCreditThenInvoiceBalances(startBalances)
 }
 
-func (s *CreditThenInvoiceTestSuite) TestDeleteStandardInvoiceWithUsageBasedLineReturnsChargeManagedValidationIssue() {
+func (s *CreditThenInvoiceTestSuite) TestDeleteStandardInvoiceWithSingleUsageBasedRunDeletesUsageBasedLine() {
 	ctx := s.T().Context()
 	start := s.mustParseTime("2024-01-01T00:00:00Z")
 	clock.FreezeTime(start)
@@ -4763,8 +4763,8 @@ func (s *CreditThenInvoiceTestSuite) TestDeleteStandardInvoiceWithUsageBasedLine
 	// when:
 	// - the progressive standard invoice is deleted through the invoice API
 	// then:
-	// - usage-based line cleanup fails the invoice deletion as charge-managed
-	// - the invoice remains undeleted
+	// - usage-based line cleanup deletes the invoice
+	// - the usage-based charge records the customer-facing line deletion
 	s.updateProfile(func(profile *billing.Profile) {
 		profile.WorkflowConfig.Invoicing.AutoAdvance = false
 		profile.WorkflowConfig.Invoicing.ProgressiveBilling = true
@@ -4854,17 +4854,163 @@ func (s *CreditThenInvoiceTestSuite) TestDeleteStandardInvoiceWithUsageBasedLine
 		DeletionSource: billing.ChangeSourceAPIRequest,
 	})
 	s.NoError(err)
-	s.Equal(billing.StandardInvoiceStatusDeleteFailed, deletedInvoice.Status)
-	s.ErrorContains(deletedInvoice.ValidationIssues.AsError(), billing.ErrCannotUpdateChargeManagedLine.Error())
+	s.Equal(billing.StandardInvoiceStatusDeleted, deletedInvoice.Status)
+	s.NotNil(deletedInvoice.DeletedAt)
 
 	refetchedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
 		Invoice: draftInvoice.GetInvoiceID(),
+		Expand:  billing.StandardInvoiceExpandAll.With(billing.StandardInvoiceExpandDeletedLines),
+	})
+	s.NoError(err)
+	s.NotNil(refetchedInvoice.DeletedAt)
+	s.Equal(billing.StandardInvoiceStatusDeleted, refetchedInvoice.Status)
+	s.Require().Len(refetchedInvoice.Lines.OrEmpty(), 1)
+
+	chargeAfterDelete := s.mustGetUsageBasedChargeByIDWithExpands(ctx, chargesmeta.ChargeID{
+		Namespace: usageBasedLine.Namespace,
+		ID:        *usageBasedLine.ChargeID,
+	}, chargesmeta.Expands{
+		chargesmeta.ExpandRealizations,
+		chargesmeta.ExpandDeletedRealizations,
+	})
+	s.Equal(usagebased.StatusDeleted, chargeAfterDelete.Status)
+	s.True(chargeAfterDelete.Intent.HasOverrideLayer(), "override layer")
+	s.Nil(chargeAfterDelete.Intent.GetBaseIntent().IntentDeletedAt)
+	overrideIntent, err := chargeAfterDelete.Intent.GetIntentForTarget(chargesmeta.ChangeTargetOverride)
+	s.NoError(err)
+	s.NotNil(overrideIntent.IntentDeletedAt)
+	s.Require().Len(chargeAfterDelete.Realizations, 1)
+	s.NotNil(chargeAfterDelete.Realizations[0].DeletedAt)
+}
+
+func (s *CreditThenInvoiceTestSuite) TestDeleteStandardInvoiceWithMultipleUsageBasedRunsReturnsProgressiveBillingValidationIssue() {
+	ctx := s.T().Context()
+	start := s.mustParseTime("2024-01-01T00:00:00Z")
+	clock.FreezeTime(start)
+	defer clock.UnFreeze()
+
+	// given:
+	// - progressive billing has already realized one usage-based standard line
+	// - a second progressive standard invoice is waiting for collection
+	// when:
+	// - the second standard invoice is deleted through the invoice API
+	// then:
+	// - the delete is rejected because the usage-based charge has multiple non-voided runs
+	// - the second invoice remains undeleted
+	s.enableProgressiveBilling()
+
+	s.MockStreamingConnector.AddSimpleEvent(
+		*s.APIRequestsTotalFeature.MeterSlug,
+		10,
+		s.mustParseTime("2024-01-02T00:00:00Z"))
+	s.MockStreamingConnector.AddSimpleEvent(
+		*s.APIRequestsTotalFeature.MeterSlug,
+		5,
+		s.mustParseTime("2024-01-16T00:00:00Z"))
+
+	subsView := s.createSubscriptionFromPlan(plan.CreatePlanInput{
+		NamespacedModel: models.NamespacedModel{
+			Namespace: s.Namespace,
+		},
+		Plan: productcatalog.Plan{
+			PlanMeta: productcatalog.PlanMeta{
+				Name:           "Test Plan",
+				Key:            "test-plan",
+				Version:        1,
+				Currency:       currency.USD,
+				SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+				BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+				ProRatingConfig: productcatalog.ProRatingConfig{
+					Enabled: true,
+					Mode:    productcatalog.ProRatingModeProratePrices,
+				},
+			},
+			Phases: []productcatalog.Phase{
+				{
+					PhaseMeta: s.phaseMeta("first-phase", ""),
+					RateCards: productcatalog.RateCards{
+						&productcatalog.UsageBasedRateCard{
+							RateCardMeta: productcatalog.RateCardMeta{
+								Key:        s.APIRequestsTotalFeature.Key,
+								Name:       s.APIRequestsTotalFeature.Key,
+								FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+								FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
+								Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+									Amount: alpacadecimal.NewFromFloat(5),
+								}),
+							},
+							BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+						},
+					},
+				},
+			},
+		},
+	})
+
+	clock.FreezeTime(start.Add(time.Minute))
+	s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-02-01T00:00:00Z")))
+
+	clock.FreezeTime(s.mustParseTime("2024-01-15T00:00:01Z"))
+	firstDraftInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: s.Customer.GetID(),
+		AsOf:     lo.ToPtr(s.mustParseTime("2024-01-15T00:00:00Z")),
+	})
+	s.NoError(err)
+	s.Require().Len(firstDraftInvoices, 1)
+
+	firstInvoice := firstDraftInvoices[0]
+	s.DebugDumpInvoice("first progressive draft invoice", firstInvoice)
+	s.Equal(billing.StandardInvoiceStatusDraftWaitingForCollection, firstInvoice.Status)
+	s.Require().NotNil(firstInvoice.CollectionAt)
+
+	clock.FreezeTime(firstInvoice.CollectionAt.Add(time.Minute))
+	firstInvoice, err = s.BillingService.AdvanceInvoice(ctx, firstInvoice.GetInvoiceID())
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDraftWaitingAutoApproval, firstInvoice.Status)
+
+	firstInvoice, err = s.BillingService.ApproveInvoice(ctx, firstInvoice.GetInvoiceID())
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusPaid, firstInvoice.Status)
+
+	clock.FreezeTime(s.mustParseTime("2024-01-20T00:00:01Z"))
+	secondDraftInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+		Customer: s.Customer.GetID(),
+		AsOf:     lo.ToPtr(s.mustParseTime("2024-01-20T00:00:00Z")),
+	})
+	s.NoError(err)
+	s.Require().Len(secondDraftInvoices, 1)
+
+	secondInvoice := secondDraftInvoices[0]
+	s.DebugDumpInvoice("second progressive draft invoice", secondInvoice)
+	s.Equal(billing.StandardInvoiceStatusDraftWaitingForCollection, secondInvoice.Status)
+	s.Require().Len(secondInvoice.Lines.OrEmpty(), 1)
+
+	usageBasedLine := secondInvoice.Lines.OrEmpty()[0]
+	s.Equal(billing.LineEngineTypeChargeUsageBased, usageBasedLine.Engine)
+	s.Require().NotNil(usageBasedLine.ChargeID)
+
+	chargeBeforeDelete := s.mustGetUsageBasedChargeByIDWithExpands(ctx, chargesmeta.ChargeID{
+		Namespace: usageBasedLine.Namespace,
+		ID:        *usageBasedLine.ChargeID,
+	}, chargesmeta.Expands{chargesmeta.ExpandRealizations})
+	s.Len(chargeBeforeDelete.Realizations.WithoutVoidedBillingHistory(), 2)
+
+	deletedInvoice, err := s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+		Invoice:        secondInvoice.GetInvoiceID(),
+		DeletionSource: billing.ChangeSourceAPIRequest,
+	})
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDeleteFailed, deletedInvoice.Status)
+	s.ErrorContains(deletedInvoice.ValidationIssues.AsError(), billing.ErrCannotEditProgressivelyBilledUsageBasedLine.Error())
+
+	refetchedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+		Invoice: secondInvoice.GetInvoiceID(),
 		Expand:  billing.StandardInvoiceExpandAll,
 	})
 	s.NoError(err)
 	s.Nil(refetchedInvoice.DeletedAt)
 	s.Equal(billing.StandardInvoiceStatusDeleteFailed, refetchedInvoice.Status)
-	s.ErrorContains(refetchedInvoice.ValidationIssues.AsError(), billing.ErrCannotUpdateChargeManagedLine.Error())
+	s.ErrorContains(refetchedInvoice.ValidationIssues.AsError(), billing.ErrCannotEditProgressivelyBilledUsageBasedLine.Error())
 }
 
 func (s *CreditThenInvoiceTestSuite) TestDeleteStandardInvoiceWithFlatFeeOnlyDeletesFlatFeeLine() {
@@ -5454,6 +5600,10 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 
 	draftInvoice := draftInvoices[0]
 	s.DebugDumpInvoice("draft invoice", draftInvoice)
+	s.Equal(billing.StandardInvoiceStatusDraftWaitingForCollection, draftInvoice.Status)
+	s.Require().Len(draftInvoice.Lines.OrEmpty(), 1)
+	finalRealizationLine := draftInvoice.Lines.OrEmpty()[0]
+	s.Require().NotNil(finalRealizationLine.ChargeID)
 	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
 	s.assertCharges(ctx, subsView, []expectedCharge{
 		{
@@ -5669,7 +5819,21 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateDraftInvoice()
 	s.NoError(err)
 	s.DebugDumpInvoice("draft invoice - 2nd sync", updatedDraftInvoice)
 	s.assertCreditThenInvoiceBalances(expectedCreditThenInvoiceBalances{})
+	s.Equal(billing.StandardInvoiceStatusDeleted, updatedDraftInvoice.Status)
 	s.expectLines(updatedDraftInvoice, subsView.Subscription.ID, nil)
+
+	chargeAfterDelete := s.mustGetUsageBasedChargeByIDWithExpands(ctx, chargesmeta.ChargeID{
+		Namespace: finalRealizationLine.Namespace,
+		ID:        *finalRealizationLine.ChargeID,
+	}, chargesmeta.Expands{
+		chargesmeta.ExpandRealizations,
+		chargesmeta.ExpandDeletedRealizations,
+	})
+	s.Equal(usagebased.StatusActive, chargeAfterDelete.Status)
+	s.Nil(chargeAfterDelete.State.CurrentRealizationRunID)
+	deletedRun, err := chargeAfterDelete.Realizations.GetByLineID(finalRealizationLine.ID)
+	s.NoError(err)
+	s.NotNil(deletedRun.DeletedAt)
 }
 
 func (s *CreditThenInvoiceTestSuite) TestUsageBasedGatheringUpdateIssuedInvoice() {
@@ -6290,6 +6454,13 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedUpdateWithLineSplits() {
 	s.populateChildIDsFromParents(&draftInvoice2)
 	s.DebugDumpInvoice("draft invoice2", draftInvoice2)
 	s.Equal(billing.StandardInvoiceStatusDraftWaitingForCollection, draftInvoice2.Status)
+	s.Require().Len(draftInvoice2.Lines.OrEmpty(), 1)
+	draftInvoice2Line := draftInvoice2.Lines.OrEmpty()[0]
+	s.Require().NotNil(draftInvoice2Line.ChargeID)
+	progressiveRemainingPeriodBeforeDelete := timeutil.ClosedPeriod{
+		From: s.mustParseTime("2024-01-18T00:00:00Z"),
+		To:   s.mustParseTime("2024-02-01T00:00:00Z"),
+	}
 
 	s.assertCharges(ctx, subsView, []expectedCharge{
 		{
@@ -6378,6 +6549,12 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedUpdateWithLineSplits() {
 	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.populateChildIDsFromParents(&gatheringInvoice)
 	s.DebugDumpInvoice("gathering invoice", gatheringInvoice)
+	_, foundProgressiveRemainingLine := lo.Find(gatheringInvoice.Lines.OrEmpty(), func(line billing.GatheringLine) bool {
+		return line.ChargeID != nil &&
+			*line.ChargeID == *draftInvoice2Line.ChargeID &&
+			line.ServicePeriod == progressiveRemainingPeriodBeforeDelete
+	})
+	s.True(foundProgressiveRemainingLine, "progressive remaining gathering line should exist before draft standard-line delete")
 
 	clock.FreezeTime(s.mustParseTime("2024-01-09T12:00:00Z"))
 
@@ -6415,6 +6592,12 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedUpdateWithLineSplits() {
 	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
 	s.populateChildIDsFromParents(&gatheringInvoice)
 	s.DebugDumpInvoice("gathering invoice - 2nd sync", gatheringInvoice)
+	_, foundProgressiveRemainingLine = lo.Find(gatheringInvoice.Lines.OrEmpty(), func(line billing.GatheringLine) bool {
+		return line.ChargeID != nil &&
+			*line.ChargeID == *draftInvoice2Line.ChargeID &&
+			line.ServicePeriod == progressiveRemainingPeriodBeforeDelete
+	})
+	s.False(foundProgressiveRemainingLine, "progressive standard-line delete should delete the remaining gathering line for the same charge")
 
 	s.assertCharges(ctx, updatedSubsView, []expectedCharge{
 		{
@@ -6556,6 +6739,181 @@ func (s *CreditThenInvoiceTestSuite) TestUsageBasedUpdateWithLineSplits() {
 	s.DebugDumpInvoice("draft invoice2 - 2nd sync", updatedDraftInvoice)
 	s.Len(updatedDraftInvoice.Lines.OrEmpty(), 0)
 	s.Equal(billing.StandardInvoiceStatusDeleted, updatedDraftInvoice.Status)
+
+	chargeAfterDraftLineDelete := s.mustGetUsageBasedChargeByIDWithExpands(ctx, chargesmeta.ChargeID{
+		Namespace: draftInvoice2Line.Namespace,
+		ID:        *draftInvoice2Line.ChargeID,
+	}, chargesmeta.Expands{
+		chargesmeta.ExpandRealizations,
+		chargesmeta.ExpandDeletedRealizations,
+	})
+	s.Equal(usagebased.StatusActive, chargeAfterDraftLineDelete.Status)
+	s.Nil(chargeAfterDraftLineDelete.State.CurrentRealizationRunID)
+	deletedRun, err := chargeAfterDraftLineDelete.Realizations.GetByLineID(draftInvoice2Line.ID)
+	s.NoError(err)
+	s.NotNil(deletedRun.DeletedAt)
+}
+
+func (s *CreditThenInvoiceTestSuite) TestUsageBasedProgressiveStandardInvoiceDeletionDeletesGatheringLine() {
+	ctx := s.T().Context()
+	clock.FreezeTime(s.mustParseTime("2024-01-01T00:00:00Z"))
+	defer clock.UnFreeze()
+
+	// given:
+	// - a credit-then-invoice usage-based charge has one paid progressive run
+	// - a second mutable progressive standard invoice is waiting for collection
+	// - that second run has a remaining gathering line on the same charge
+	// when:
+	// - system code deletes the progressive standard invoice
+	// then:
+	// - the standard invoice is deleted
+	// - the current realization run is deleted and detached from the charge
+	// - the remaining gathering line is deleted with the standard invoice line
+	var draftInvoice billing.StandardInvoice
+	var draftLine *billing.StandardLine
+	var chargeID chargesmeta.ChargeID
+	remainingGatheringPeriod := timeutil.ClosedPeriod{
+		From: s.mustParseTime("2024-01-18T00:00:00Z"),
+		To:   s.mustParseTime("2024-02-01T00:00:00Z"),
+	}
+
+	s.Run("create progressive draft invoice", func() {
+		s.enableProgressiveBilling()
+
+		s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 0, s.mustParseTime("2023-01-01T00:00:00Z"))
+		s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 1, s.mustParseTime("2024-01-01T00:00:00Z"))
+		s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 1, s.mustParseTime("2024-01-12T09:30:00Z"))
+		s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 3, s.mustParseTime("2024-01-15T11:00:00Z"))
+		s.MockStreamingConnector.AddSimpleEvent(*s.APIRequestsTotalFeature.MeterSlug, 7, s.mustParseTime("2024-01-18T12:30:00Z"))
+
+		subsView := s.createSubscriptionFromPlan(plan.CreatePlanInput{
+			NamespacedModel: models.NamespacedModel{
+				Namespace: s.Namespace,
+			},
+			Plan: productcatalog.Plan{
+				PlanMeta: productcatalog.PlanMeta{
+					Name:           "Test Plan",
+					Key:            "test-plan",
+					Version:        1,
+					Currency:       currency.USD,
+					SettlementMode: productcatalog.CreditThenInvoiceSettlementMode,
+					BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+					ProRatingConfig: productcatalog.ProRatingConfig{
+						Enabled: true,
+						Mode:    productcatalog.ProRatingModeProratePrices,
+					},
+				},
+				Phases: []productcatalog.Phase{
+					{
+						PhaseMeta: s.phaseMeta("first-phase", ""),
+						RateCards: productcatalog.RateCards{
+							&productcatalog.UsageBasedRateCard{
+								RateCardMeta: productcatalog.RateCardMeta{
+									Key:        s.APIRequestsTotalFeature.Key,
+									Name:       s.APIRequestsTotalFeature.Key,
+									FeatureKey: lo.ToPtr(s.APIRequestsTotalFeature.Key),
+									FeatureID:  lo.ToPtr(s.APIRequestsTotalFeature.ID),
+									Price: productcatalog.NewPriceFrom(productcatalog.UnitPrice{
+										Amount: alpacadecimal.NewFromFloat(10),
+									}),
+								},
+								BillingCadence: datetime.MustParseDuration(s.T(), "P1M"),
+							},
+						},
+					},
+				},
+			},
+		})
+
+		clock.FreezeTime(clock.Now().Add(time.Minute))
+		s.NoError(s.Service.SyncByView(ctx, subsView, s.mustParseTime("2024-03-01T00:00:00Z")))
+
+		clock.FreezeTime(s.mustParseTime("2024-01-15T00:00:00Z"))
+		firstDraftInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: s.Customer.GetID(),
+			AsOf:     lo.ToPtr(s.mustParseTime("2024-01-15T00:00:00Z")),
+		})
+		s.NoError(err)
+		s.Require().Len(firstDraftInvoices, 1)
+
+		firstInvoice := firstDraftInvoices[0]
+		s.Require().NotNil(firstInvoice.CollectionAt)
+		clock.FreezeTime(firstInvoice.CollectionAt.Add(time.Minute))
+		firstInvoice, err = s.BillingService.AdvanceInvoice(ctx, firstInvoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusDraftWaitingAutoApproval, firstInvoice.Status)
+
+		firstInvoice, err = s.BillingService.ApproveInvoice(ctx, firstInvoice.GetInvoiceID())
+		s.NoError(err)
+		s.Equal(billing.StandardInvoiceStatusPaid, firstInvoice.Status)
+
+		clock.FreezeTime(s.mustParseTime("2024-01-18T00:00:00Z"))
+		secondDraftInvoices, err := s.BillingService.InvoicePendingLines(ctx, billing.InvoicePendingLinesInput{
+			Customer: s.Customer.GetID(),
+			AsOf:     lo.ToPtr(s.mustParseTime("2024-01-18T00:00:00Z")),
+		})
+		s.NoError(err)
+		s.Require().Len(secondDraftInvoices, 1)
+
+		draftInvoice = secondDraftInvoices[0]
+		s.Equal(billing.StandardInvoiceStatusDraftWaitingForCollection, draftInvoice.Status)
+		s.Require().Len(draftInvoice.Lines.OrEmpty(), 1)
+		draftLine = draftInvoice.Lines.OrEmpty()[0]
+		s.Equal(billing.LineEngineTypeChargeUsageBased, draftLine.Engine)
+		s.Require().NotNil(draftLine.ChargeID)
+
+		chargeID = chargesmeta.ChargeID{
+			Namespace: draftLine.Namespace,
+			ID:        *draftLine.ChargeID,
+		}
+	})
+
+	gatheringInvoice := s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	s.populateChildIDsFromParents(&gatheringInvoice)
+	s.DebugDumpInvoice("gathering invoice before standard invoice delete", gatheringInvoice)
+	_, foundRemainingLine := lo.Find(gatheringInvoice.Lines.OrEmpty(), func(line billing.GatheringLine) bool {
+		return line.ChargeID != nil &&
+			*line.ChargeID == chargeID.ID &&
+			line.ServicePeriod == remainingGatheringPeriod
+	})
+	s.True(foundRemainingLine, "progressive remaining gathering line should exist before standard invoice delete")
+
+	deletedInvoice, err := s.BillingService.DeleteInvoice(ctx, billing.DeleteInvoiceInput{
+		Invoice:        draftInvoice.GetInvoiceID(),
+		DeletionSource: billing.ChangeSourceSystem,
+	})
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDeleted, deletedInvoice.Status)
+	s.NotNil(deletedInvoice.DeletedAt)
+
+	refetchedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
+		Invoice: draftInvoice.GetInvoiceID(),
+		Expand:  billing.StandardInvoiceExpandAll.With(billing.StandardInvoiceExpandDeletedLines),
+	})
+	s.NoError(err)
+	s.Equal(billing.StandardInvoiceStatusDeleted, refetchedInvoice.Status)
+	s.NotNil(refetchedInvoice.DeletedAt)
+	s.Require().Len(refetchedInvoice.Lines.OrEmpty(), 1)
+
+	gatheringInvoice = s.gatheringInvoice(ctx, s.Namespace, s.Customer.ID)
+	s.populateChildIDsFromParents(&gatheringInvoice)
+	s.DebugDumpInvoice("gathering invoice after standard invoice delete", gatheringInvoice)
+	_, foundRemainingLine = lo.Find(gatheringInvoice.Lines.OrEmpty(), func(line billing.GatheringLine) bool {
+		return line.ChargeID != nil &&
+			*line.ChargeID == chargeID.ID &&
+			line.ServicePeriod == remainingGatheringPeriod
+	})
+	s.False(foundRemainingLine, "progressive standard invoice delete should delete the remaining gathering line for the same charge")
+
+	chargeAfterInvoiceDelete := s.mustGetUsageBasedChargeByIDWithExpands(ctx, chargeID, chargesmeta.Expands{
+		chargesmeta.ExpandRealizations,
+		chargesmeta.ExpandDeletedRealizations,
+	})
+	s.Equal(usagebased.StatusActive, chargeAfterInvoiceDelete.Status)
+	s.Nil(chargeAfterInvoiceDelete.State.CurrentRealizationRunID)
+	deletedRun, err := chargeAfterInvoiceDelete.Realizations.GetByLineID(draftLine.ID)
+	s.NoError(err)
+	s.NotNil(deletedRun.DeletedAt)
 }
 
 func (s *CreditThenInvoiceTestSuite) TestRateCardTaxSyncFlatFee() {

--- a/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
+++ b/openmeter/billing/worker/subscriptionsync/service/sync_credittheninvoice_test.go
@@ -4999,9 +4999,9 @@ func (s *CreditThenInvoiceTestSuite) TestDeleteStandardInvoiceWithMultipleUsageB
 		Invoice:        secondInvoice.GetInvoiceID(),
 		DeletionSource: billing.ChangeSourceAPIRequest,
 	})
-	s.NoError(err)
-	s.Equal(billing.StandardInvoiceStatusDeleteFailed, deletedInvoice.Status)
-	s.ErrorContains(deletedInvoice.ValidationIssues.AsError(), billing.ErrCannotEditProgressivelyBilledUsageBasedLine.Error())
+	s.Error(err)
+	s.ErrorContains(err, billing.ErrCannotEditProgressivelyBilledUsageBasedLine.Error())
+	s.Empty(deletedInvoice.ID)
 
 	refetchedInvoice, err := s.BillingService.GetStandardInvoiceById(ctx, billing.GetStandardInvoiceByIdInput{
 		Invoice: secondInvoice.GetInvoiceID(),
@@ -5009,8 +5009,8 @@ func (s *CreditThenInvoiceTestSuite) TestDeleteStandardInvoiceWithMultipleUsageB
 	})
 	s.NoError(err)
 	s.Nil(refetchedInvoice.DeletedAt)
-	s.Equal(billing.StandardInvoiceStatusDeleteFailed, refetchedInvoice.Status)
-	s.ErrorContains(refetchedInvoice.ValidationIssues.AsError(), billing.ErrCannotEditProgressivelyBilledUsageBasedLine.Error())
+	s.Equal(billing.StandardInvoiceStatusDraftWaitingForCollection, refetchedInvoice.Status)
+	s.Empty(refetchedInvoice.ValidationIssues)
 }
 
 func (s *CreditThenInvoiceTestSuite) TestDeleteStandardInvoiceWithFlatFeeOnlyDeletesFlatFeeLine() {

--- a/openmeter/ledger/customerbalance/testenv_test.go
+++ b/openmeter/ledger/customerbalance/testenv_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee"
 	flatfeeadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/adapter"
 	flatfeeservice "github.com/openmeterio/openmeter/openmeter/billing/charges/flatfee/service"
+	"github.com/openmeterio/openmeter/openmeter/billing/charges/invoiceupdater"
 	lineageadapter "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/adapter"
 	lineageservice "github.com/openmeterio/openmeter/openmeter/billing/charges/lineage/service"
 	chargemeta "github.com/openmeterio/openmeter/openmeter/billing/charges/meta"
@@ -247,6 +248,7 @@ func newTestEnv(t *testing.T) *testEnv {
 		Lineage:                 lineageService,
 		Locker:                  locker,
 		MetaAdapter:             metaAdapter,
+		InvoiceUpdater:          invoiceupdater.NewUnimplementedUpdater(t),
 		CustomerOverrideService: billingService,
 		FeatureService:          featureService,
 		RatingService:           billingratingservice.New(billingratingservice.Config{UnitConfigEnabled: true}),

--- a/test/billing/lineengine_test.go
+++ b/test/billing/lineengine_test.go
@@ -111,6 +111,10 @@ func (m *mockCollectionCompletedLineEngine) OnStandardInvoiceCreated(ctx context
 	return m.onStandardInvoiceCreated(ctx, input)
 }
 
+func (m *mockCollectionCompletedLineEngine) ValidateMutableInvoiceLineEditViaAPI(_ context.Context, input ombilling.OnMutableInvoiceUpdateInput) error {
+	return input.Validate()
+}
+
 func (m *mockCollectionCompletedLineEngine) OnMutableInvoiceLinesEditedViaAPI(ctx context.Context, input ombilling.OnMutableInvoiceUpdateInput) (ombilling.OnMutableInvoiceUpdateResult, error) {
 	if m.onMutableLinesChanged == nil {
 		return ombilling.OnMutableInvoiceUpdateResult{


### PR DESCRIPTION
## Summary

1. Delete support for usage-based standard invoice lines.
2. Prevalidation support for mutable invoice-line API edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage-based charge processing now applies invoice updates as part of the end-to-end charge flow.
  * Added pre-validation for API-driven mutable invoice line edits, enabling safer handling of deletions.
* **Bug Fixes**
  * Strengthened validation and correctness around mutable invoice line deletion, including progressive standard/gathering-line scenarios.
  * Improved invoice delete validation behavior to better distinguish standard vs. gathering invoices.
* **Tests**
  * Expanded/refactored invoice deletion, line editing, and credit-then-invoice sync coverage, including progressive deletion and draft-invoice cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds support for deleting usage-based invoice lines through the billing API. The main changes are:

- Usage-based standard invoice line delete handling.
- Pre-validation for mutable invoice line edits.
- Invoice updater wiring for usage-based charge cleanup.
- Patch helpers for invoice line update and delete flows.
- Tests for invoice deletion and credit-then-invoice sync paths.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/billing/charges/usagebased/service/lineengine.go | Adds usage-based API standard-line delete validation, charge patch handling, realization cleanup, and gathering-line patch application. |
| openmeter/billing/service/invoice.go | Adds pre-trigger validation for API standard invoice deletion before invoice state is mutated. |
| openmeter/billing/service/invoiceupdate.go | Adds shared validation and grouping for API invoice line edits and standard-line delete dispatch. |
| openmeter/billing/charges/invoiceupdater/patches.go | Adds patch collection helpers for invoice bisection and singular patch validation. |
| openmeter/billing/invoice_validator.go | Allows API standard invoice deletion while keeping the gathering-invoice guard for unsupported usage-based gathering-line deletes. |

<sub>Reviews (4): Last reviewed commit: ["fix: stabilize usage-based delete CI"](https://github.com/openmeterio/openmeter/commit/5880f69ca32a0c95ffe6a535f6d02eb7d45c6c7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42337546)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->