### PR TITLE
feat(streaming): clickhouse meter query cache

### DIFF
--- a/api/v3/handlers/meters/query/params.go
+++ b/api/v3/handlers/meters/query/params.go
@@ -22,6 +22,10 @@ func BuildQueryParams(ctx context.Context, m meter.Meter, body api.MeterQueryReq
 	params := streaming.QueryParams{
 		From: body.From,
 		To:   body.To,
+		// The v3 meter query endpoints (query + CSV) are one of the designated meter cache
+		// opt-in call sites: their results are displayed, never persisted into billing
+		// artifacts, so serving the settled range from the cache is safe.
+		Cachable: true,
 	}
 
 	if body.Granularity != nil {

--- a/api/v3/handlers/meters/query/params_test.go
+++ b/api/v3/handlers/meters/query/params_test.go
@@ -44,6 +44,18 @@ func TestBuildQueryParams_Empty(t *testing.T) {
 	assert.Empty(t, params.GroupBy)
 }
 
+// TestBuildQueryParams_OptsIntoMeterCache pins the v3 meter query endpoints (query and
+// CSV both funnel through BuildQueryParams) as a designated meter cache opt-in call site:
+// Cachable must be true on the params handed to the streaming connector, while billing
+// paths construct their own params and must never set it.
+func TestBuildQueryParams_OptsIntoMeterCache(t *testing.T) {
+	m := newTestMeter()
+
+	params, err := BuildQueryParams(context.Background(), m, api.MeterQueryRequest{}, noopCustomerResolver)
+	require.NoError(t, err)
+	assert.True(t, params.Cachable)
+}
+
 func TestBuildQueryParams_FromTo(t *testing.T) {
 	m := newTestMeter()
 	now := time.Now().UTC().Truncate(time.Second)

--- a/app/common/metercache.go
+++ b/app/common/metercache.go
@@ -6,6 +6,8 @@ import (
 	"math/rand/v2"
 
 	"github.com/google/wire"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/meter"
@@ -28,10 +30,14 @@ func NewMeterCacheReconciler(
 	connector *clickhouseconnector.Connector,
 	meterService meter.Service,
 	driver *pgdriver.Driver,
+	metricMeter metric.Meter,
+	tracer trace.Tracer,
 ) (*metercache.Reconciler, error) {
 	if !conf.Cache.Enabled {
 		return metercache.New(metercache.Config{
 			Logger: logger,
+			Meter:  metricMeter,
+			Tracer: tracer,
 		})
 	}
 
@@ -55,6 +61,8 @@ func NewMeterCacheReconciler(
 		Connector:  connector,
 		Meters:     meterService,
 		LockClient: lockClient,
+		Meter:      metricMeter,
+		Tracer:     tracer,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize meter cache reconciler: %w", err)

--- a/app/common/metercache.go
+++ b/app/common/metercache.go
@@ -1,0 +1,64 @@
+package common
+
+import (
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+
+	"github.com/google/wire"
+
+	"github.com/openmeterio/openmeter/app/config"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	clickhouseconnector "github.com/openmeterio/openmeter/openmeter/streaming/clickhouse"
+	"github.com/openmeterio/openmeter/openmeter/streaming/clickhouse/metercache"
+	"github.com/openmeterio/openmeter/pkg/framework/pgdriver"
+	"github.com/openmeterio/openmeter/pkg/pglockx"
+)
+
+var MeterCache = wire.NewSet(
+	NewMeterCacheReconciler,
+)
+
+// NewMeterCacheReconciler provides the meter cache lifecycle reconciler. It is always
+// constructed — with the cache disabled it idles until closed — so the server's run.Group
+// wiring stays unconditional, mirroring the notification event handler.
+func NewMeterCacheReconciler(
+	conf config.AggregationConfiguration,
+	logger *slog.Logger,
+	connector *clickhouseconnector.Connector,
+	meterService meter.Service,
+	driver *pgdriver.Driver,
+) (*metercache.Reconciler, error) {
+	if !conf.Cache.Enabled {
+		return metercache.New(metercache.Config{
+			Logger: logger,
+		})
+	}
+
+	lockConfig := pglockx.Config{
+		Owner:             fmt.Sprintf("metercache.reconciler-%v", rand.Int()),
+		HeartbeatInterval: pglockx.DefaultHeartbeatInterval,
+		LeaseTime:         pglockx.DefaultLeaseTime,
+	}
+
+	logger.Debug("initializing meter cache reconciler lock client",
+		"lock.leaseTime", lockConfig.LeaseTime, "lock.heartbeatInterval", lockConfig.HeartbeatInterval, "lock.owner", lockConfig.Owner)
+
+	lockClient, err := pglockx.New(driver.DB(), lockConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize meter cache reconciler lock client: %w", err)
+	}
+
+	reconciler, err := metercache.New(metercache.Config{
+		Enabled:    true,
+		Logger:     logger,
+		Connector:  connector,
+		Meters:     meterService,
+		LockClient: lockClient,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize meter cache reconciler: %w", err)
+	}
+
+	return reconciler, nil
+}

--- a/app/common/streaming.go
+++ b/app/common/streaming.go
@@ -17,21 +17,23 @@ import (
 )
 
 var Streaming = wire.NewSet(
+	NewClickHouseStreamingConnector,
 	NewStreamingConnector,
 )
 
-func NewStreamingConnector(
+// NewClickHouseStreamingConnector provides the concrete ClickHouse connector separately
+// from the streaming.Connector interface: the meter cache lifecycle reconciler drives the
+// connector's cache manager surface (EnsureMeterCache, DropMeterCache, ListActualViews),
+// which the interface — and the retry wrapper NewStreamingConnector may add — does not
+// carry.
+func NewClickHouseStreamingConnector(
 	ctx context.Context,
 	conf config.AggregationConfiguration,
 	clickHouse clickhouse.Conn,
 	logger *slog.Logger,
 	progressmanager progressmanager.Service,
-	namespaceManager *namespace.Manager,
-) (streaming.Connector, error) {
-	var connector streaming.Connector
-	var err error
-
-	connector, err = clickhouseconnector.New(ctx, clickhouseconnector.Config{
+) (*clickhouseconnector.Connector, error) {
+	connector, err := clickhouseconnector.New(ctx, clickhouseconnector.Config{
 		ClickHouse:             clickHouse,
 		Database:               conf.ClickHouse.Database,
 		EventsTableName:        conf.EventsTableName,
@@ -48,6 +50,18 @@ func NewStreamingConnector(
 	if err != nil {
 		return nil, fmt.Errorf("init clickhouse connector: %w", err)
 	}
+
+	return connector, nil
+}
+
+func NewStreamingConnector(
+	conf config.AggregationConfiguration,
+	clickHouseConnector *clickhouseconnector.Connector,
+	logger *slog.Logger,
+	namespaceManager *namespace.Manager,
+) (streaming.Connector, error) {
+	var connector streaming.Connector = clickHouseConnector
+	var err error
 
 	if conf.ClickHouse.Retry.Enabled {
 		connector, err = streamingretry.New(streamingretry.Config{

--- a/app/common/streaming.go
+++ b/app/common/streaming.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/google/wire"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/app/config"
 	"github.com/openmeterio/openmeter/openmeter/namespace"
@@ -32,6 +34,8 @@ func NewClickHouseStreamingConnector(
 	clickHouse clickhouse.Conn,
 	logger *slog.Logger,
 	progressmanager progressmanager.Service,
+	meter metric.Meter,
+	tracer trace.Tracer,
 ) (*clickhouseconnector.Connector, error) {
 	connector, err := clickhouseconnector.New(ctx, clickhouseconnector.Config{
 		ClickHouse:             clickHouse,
@@ -46,6 +50,8 @@ func NewClickHouseStreamingConnector(
 		EnableDecimalPrecision: conf.EnableDecimalPrecision,
 		ProgressManager:        progressmanager,
 		Cache:                  mapAggregationCacheConfig(conf.Cache),
+		Meter:                  meter,
+		Tracer:                 tracer,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("init clickhouse connector: %w", err)

--- a/app/common/streaming.go
+++ b/app/common/streaming.go
@@ -43,6 +43,7 @@ func NewStreamingConnector(
 		EnablePrewhere:         conf.EnablePrewhere,
 		EnableDecimalPrecision: conf.EnableDecimalPrecision,
 		ProgressManager:        progressmanager,
+		Cache:                  mapAggregationCacheConfig(conf.Cache),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("init clickhouse connector: %w", err)
@@ -67,4 +68,18 @@ func NewStreamingConnector(
 	}
 
 	return connector, nil
+}
+
+// mapAggregationCacheConfig maps the validated app config into the clickhouse connector's
+// own CacheConfig type. The connector package must not import app/config (app/config
+// already depends on lower-level domain packages, so the reverse import would create a
+// cycle across the DI boundary), so this mapping is the only place the two types meet.
+func mapAggregationCacheConfig(conf config.AggregationCacheConfiguration) clickhouseconnector.CacheConfig {
+	return clickhouseconnector.CacheConfig{
+		Enabled:             conf.Enabled,
+		RefreshInterval:     conf.RefreshInterval,
+		MinimumUsageAge:     conf.MinimumUsageAge,
+		WindowSize:          clickhouseconnector.CacheGrain(conf.WindowSize),
+		MeterQueryThreshold: conf.MeterQueryThreshold,
+	}
 }

--- a/app/config/aggregation.go
+++ b/app/config/aggregation.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -41,23 +42,48 @@ type AggregationConfiguration struct {
 	// When enabled, values are calculated using Decimal128 instead of Float64, providing
 	// higher precision for financial calculations at the cost of some performance.
 	EnableDecimalPrecision bool
+
+	// Cache configures the refreshable materialized view based meter cache.
+	Cache AggregationCacheConfiguration
 }
 
 // Validate validates the configuration.
 func (c AggregationConfiguration) Validate() error {
+	var errs []error
+
 	if err := c.ClickHouse.Validate(); err != nil {
-		return fmt.Errorf("clickhouse: %w", err)
+		errs = append(errs, fmt.Errorf("clickhouse: %w", err))
 	}
 
 	if c.EventsTableName == "" {
-		return errors.New("events table is required")
+		errs = append(errs, errors.New("events table is required"))
 	}
 
 	if c.AsyncInsertWait && !c.AsyncInsert {
-		return errors.New("async insert wait is set but async insert is not")
+		errs = append(errs, errors.New("async insert wait is set but async insert is not"))
 	}
 
-	return nil
+	if err := c.Cache.Validate(); err != nil {
+		errs = append(errs, fmt.Errorf("cache: %w", err))
+	}
+
+	// The cache reads via the newest-wins argMax over Decimal128 columns, so it can only
+	// serve queries that already run in decimal precision mode; enabling the cache without
+	// EnableDecimalPrecision would leave every eligible query silently unservable and defeats
+	// the purpose of turning the cache on.
+	if c.Cache.Enabled && !c.EnableDecimalPrecision {
+		errs = append(errs, errors.New("cache requires enableDecimalPrecision to be true"))
+	}
+
+	// Async inserts without waiting for the buffer flush acknowledge before rows are queryable,
+	// so a refresh scheduled right after ingestion can miss just-inserted rows and never revisit
+	// them under APPEND semantics; requiring AsyncInsertWait when the cache is enabled keeps
+	// refreshes able to observe the rows they are supposed to cover.
+	if c.Cache.Enabled && c.AsyncInsert && !c.AsyncInsertWait {
+		errs = append(errs, errors.New("cache requires asyncInsertWait to be true when asyncInsert is enabled"))
+	}
+
+	return errors.Join(errs...)
 }
 
 // ClickHouseAggregationConfiguration is the configuration for the ClickHouse aggregation engine
@@ -194,6 +220,86 @@ func (c ClickhousePoolMetricsConfig) Validate() error {
 	return errors.Join(errs...)
 }
 
+// AggregationCacheGrain is the bucket width the meter cache maintains per meter.
+// It intentionally supports a narrower set of values than meter.WindowSize (which also
+// allows SECOND and MONTH): the cache tiles live queries onto fixed rollup buckets, and
+// second-level buckets are prohibitively expensive to maintain while month buckets are
+// wide enough to be assembled from day/hour buckets at read time instead.
+type AggregationCacheGrain string
+
+const (
+	AggregationCacheGrainMinute AggregationCacheGrain = "minute"
+	AggregationCacheGrainHour   AggregationCacheGrain = "hour"
+	AggregationCacheGrainDay    AggregationCacheGrain = "day"
+)
+
+// Values provides the list of valid values for the AggregationCacheGrain enum.
+func (AggregationCacheGrain) Values() []string {
+	return []string{
+		string(AggregationCacheGrainMinute),
+		string(AggregationCacheGrainHour),
+		string(AggregationCacheGrainDay),
+	}
+}
+
+// AggregationCacheConfiguration configures the refreshable materialized view based meter
+// cache. The cache is inert (Enabled: false) by default: creating and maintaining the
+// per-meter materialized views is a ClickHouse-side cost that operators must opt into
+// after confirming they run a single ClickHouse server (system.view_refreshes and the
+// scheduled refreshes it drives are per-server state; clusters/load-balanced setups are
+// not supported in v1 and the read-side gate falls back to live queries there).
+type AggregationCacheConfiguration struct {
+	// Enabled turns on materialized-view backed caching for meter queries.
+	Enabled bool
+
+	// RefreshInterval is how often ClickHouse re-runs each per-meter materialized view.
+	RefreshInterval time.Duration
+
+	// MinimumUsageAge is the freshness horizon: buckets newer than this are always served
+	// live so that in-flight, not-yet-settled usage is never read from a stale cache row.
+	MinimumUsageAge time.Duration
+
+	// WindowSize is the rollup bucket width (grain) maintained by the cache. Choosing
+	// "minute" multiplies the number of stored rows accordingly; consider the storage
+	// impact before enabling minute-grain caching on high-cardinality meters.
+	WindowSize AggregationCacheGrain
+
+	// MeterQueryThreshold reserves the "cache only hot meters" selection strategy for a
+	// future release. v1 always caches every meter (threshold == 0); a positive value is
+	// rejected at validation time so it cannot silently no-op.
+	MeterQueryThreshold int
+}
+
+// Validate validates the configuration.
+func (c AggregationCacheConfiguration) Validate() error {
+	var errs []error
+
+	if !slices.Contains(c.WindowSize.Values(), string(c.WindowSize)) {
+		errs = append(errs, fmt.Errorf("window size must be one of %v, got %q", c.WindowSize.Values(), c.WindowSize))
+	}
+
+	// Refreshes only recompute buckets covered by the dirty-window lookback (see
+	// meter_cache_mv.go); if the freshness horizon were shorter than the refresh interval,
+	// a bucket could become "settled" and eligible for caching in between two refreshes
+	// without ever having been recomputed, serving a stale (pre-settlement) row as final.
+	if c.MinimumUsageAge < c.RefreshInterval {
+		errs = append(errs, errors.New("minimum usage age must be greater than or equal to refresh interval"))
+	}
+
+	// Hot-meter selection (caching only meters above a query-volume threshold) is not
+	// implemented yet; the key is reserved so existing configs keep working once it ships
+	// without silently changing behavior for anyone who sets a positive value today.
+	if c.MeterQueryThreshold > 0 {
+		errs = append(errs, errors.New("hot-meter selection not implemented"))
+	}
+
+	if c.MeterQueryThreshold < 0 {
+		errs = append(errs, errors.New("meter query threshold must not be negative"))
+	}
+
+	return errors.Join(errs...)
+}
+
 // ConfigureAggregation configures some defaults in the Viper instance.
 func ConfigureAggregation(v *viper.Viper) {
 	v.SetDefault("aggregation.eventsTableName", "om_events")
@@ -225,4 +331,11 @@ func ConfigureAggregation(v *viper.Viper) {
 
 	// Decimal precision
 	v.SetDefault("aggregation.enableDecimalPrecision", false)
+
+	// Meter cache
+	v.SetDefault("aggregation.cache.enabled", false)
+	v.SetDefault("aggregation.cache.refreshInterval", "10m")
+	v.SetDefault("aggregation.cache.minimumUsageAge", "1h")
+	v.SetDefault("aggregation.cache.windowSize", "hour")
+	v.SetDefault("aggregation.cache.meterQueryThreshold", 0)
 }

--- a/app/config/aggregation_test.go
+++ b/app/config/aggregation_test.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregationCacheConfigurationValidate(t *testing.T) {
+	validBase := func() AggregationCacheConfiguration {
+		return AggregationCacheConfiguration{
+			Enabled:             false,
+			RefreshInterval:     10 * time.Minute,
+			MinimumUsageAge:     time.Hour,
+			WindowSize:          AggregationCacheGrainHour,
+			MeterQueryThreshold: 0,
+		}
+	}
+
+	t.Run("Valid", func(t *testing.T) {
+		require.NoError(t, validBase().Validate())
+	})
+
+	t.Run("MinimumUsageAgeBelowRefreshInterval", func(t *testing.T) {
+		cfg := validBase()
+		cfg.MinimumUsageAge = 5 * time.Minute
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "minimum usage age must be greater than or equal to refresh interval")
+	})
+
+	t.Run("MinimumUsageAgeEqualToRefreshInterval", func(t *testing.T) {
+		// Equality is the documented boundary (>=), not a rejection case.
+		cfg := validBase()
+		cfg.MinimumUsageAge = cfg.RefreshInterval
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("InvalidGrainMonth", func(t *testing.T) {
+		cfg := validBase()
+		cfg.WindowSize = "month"
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "window size must be one of")
+	})
+
+	t.Run("InvalidGrainEmpty", func(t *testing.T) {
+		cfg := validBase()
+		cfg.WindowSize = ""
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "window size must be one of")
+	})
+
+	t.Run("InvalidGrainCasingMismatchesMeterWindowSize", func(t *testing.T) {
+		// AggregationCacheGrain is intentionally lowercase and does not accept
+		// meter.WindowSize's uppercase spelling (e.g. "HOUR").
+		cfg := validBase()
+		cfg.WindowSize = "HOUR"
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "window size must be one of")
+	})
+
+	t.Run("PositiveMeterQueryThresholdReserved", func(t *testing.T) {
+		cfg := validBase()
+		cfg.MeterQueryThreshold = 1
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "hot-meter selection not implemented")
+	})
+
+	t.Run("NegativeMeterQueryThreshold", func(t *testing.T) {
+		cfg := validBase()
+		cfg.MeterQueryThreshold = -1
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "meter query threshold must not be negative")
+	})
+}
+
+func TestAggregationConfigurationValidateCache(t *testing.T) {
+	validBase := func() AggregationConfiguration {
+		return AggregationConfiguration{
+			ClickHouse: ClickHouseAggregationConfiguration{
+				Address:         "127.0.0.1:9000",
+				DialTimeout:     10 * time.Second,
+				MaxOpenConns:    5,
+				MaxIdleConns:    5,
+				ConnMaxLifetime: 10 * time.Minute,
+				BlockBufferSize: 10,
+			},
+			EventsTableName: "om_events",
+			Cache: AggregationCacheConfiguration{
+				RefreshInterval: 10 * time.Minute,
+				MinimumUsageAge: time.Hour,
+				WindowSize:      AggregationCacheGrainHour,
+			},
+		}
+	}
+
+	t.Run("DisabledCacheIgnoresDecimalPrecisionAndAsyncInsertRules", func(t *testing.T) {
+		// The cache-specific cross-field rules must only fire when the cache is enabled,
+		// so every existing (cache-disabled) deployment config keeps validating exactly
+		// as before this configuration was introduced.
+		cfg := validBase()
+		cfg.EnableDecimalPrecision = false
+		cfg.AsyncInsert = true
+		cfg.AsyncInsertWait = false
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("EnabledCacheRequiresDecimalPrecision", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Cache.Enabled = true
+		cfg.EnableDecimalPrecision = false
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "cache requires enableDecimalPrecision to be true")
+	})
+
+	t.Run("EnabledCacheRejectsAsyncInsertWithoutWait", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Cache.Enabled = true
+		cfg.EnableDecimalPrecision = true
+		cfg.AsyncInsert = true
+		cfg.AsyncInsertWait = false
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "cache requires asyncInsertWait to be true when asyncInsert is enabled")
+	})
+
+	t.Run("EnabledCacheAllowsAsyncInsertWithWait", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Cache.Enabled = true
+		cfg.EnableDecimalPrecision = true
+		cfg.AsyncInsert = true
+		cfg.AsyncInsertWait = true
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("EnabledCacheAllowsSyncInsert", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Cache.Enabled = true
+		cfg.EnableDecimalPrecision = true
+		cfg.AsyncInsert = false
+		cfg.AsyncInsertWait = false
+		require.NoError(t, cfg.Validate())
+	})
+
+	t.Run("PropagatesCacheValidationErrors", func(t *testing.T) {
+		cfg := validBase()
+		cfg.Cache.MeterQueryThreshold = 1
+		err := cfg.Validate()
+		assert.ErrorContains(t, err, "cache:")
+		assert.ErrorContains(t, err, "hot-meter selection not implemented")
+	})
+}

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -160,6 +160,13 @@ func TestComplete(t *testing.T) {
 			EventsTableName: "om_events",
 			AsyncInsert:     false,
 			AsyncInsertWait: false,
+			Cache: AggregationCacheConfiguration{
+				Enabled:             false,
+				RefreshInterval:     10 * time.Minute,
+				MinimumUsageAge:     time.Hour,
+				WindowSize:          AggregationCacheGrainHour,
+				MeterQueryThreshold: 0,
+			},
 		},
 		Entitlements: EntitlementsConfiguration{
 			GracePeriod: datetime.ISODurationString("P1D"),

--- a/app/config/testdata/complete.yaml
+++ b/app/config/testdata/complete.yaml
@@ -66,6 +66,13 @@ aggregation:
     retry:
       enabled: true
 
+  cache:
+    enabled: false
+    refreshInterval: 10m
+    minimumUsageAge: 1h
+    windowSize: hour
+    meterQueryThreshold: 0
+
 sink:
   groupId: openmeter-sink-worker
   minCommitCount: 500

--- a/cmd/balance-worker/wire_gen.go
+++ b/cmd/balance-worker/wire_gen.go
@@ -150,7 +150,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v3, logger, service)
+	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v3, logger, service, meter, tracer)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/cmd/balance-worker/wire_gen.go
+++ b/cmd/balance-worker/wire_gen.go
@@ -150,6 +150,17 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
+	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v3, logger, service)
+	if err != nil {
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
 	namespaceConfiguration := conf.Namespace
 	manager, err := common.NewNamespaceManager(namespaceConfiguration)
 	if err != nil {
@@ -162,7 +173,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	connector, err := common.NewStreamingConnector(ctx, aggregationConfiguration, v3, logger, service, manager)
+	streamingConnector, err := common.NewStreamingConnector(aggregationConfiguration, connector, logger, manager)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -207,7 +218,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	entitlement, err := common.NewEntitlementRegistry(logger, client, tracer, entitlementsConfiguration, connector, meterService, eventbusPublisher, locker, customerService)
+	entitlement, err := common.NewEntitlementRegistry(logger, client, tracer, entitlementsConfiguration, streamingConnector, meterService, eventbusPublisher, locker, customerService)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/cmd/billing-worker/wire_gen.go
+++ b/cmd/billing-worker/wire_gen.go
@@ -201,7 +201,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v3, logger, progressmanagerService)
+	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v3, logger, progressmanagerService, meter, tracer)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/cmd/billing-worker/wire_gen.go
+++ b/cmd/billing-worker/wire_gen.go
@@ -201,6 +201,17 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
+	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v3, logger, progressmanagerService)
+	if err != nil {
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
 	namespaceConfiguration := conf.Namespace
 	manager, err := common.NewNamespaceManager(namespaceConfiguration)
 	if err != nil {
@@ -213,7 +224,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	connector, err := common.NewStreamingConnector(ctx, aggregationConfiguration, v3, logger, progressmanagerService, manager)
+	streamingConnector, err := common.NewStreamingConnector(aggregationConfiguration, connector, logger, manager)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -236,7 +247,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	entitlement, err := common.NewEntitlementRegistry(logger, client, tracer, entitlementsConfiguration, connector, meterService, eventbusPublisher, locker, customerService)
+	entitlement, err := common.NewEntitlementRegistry(logger, client, tracer, entitlementsConfiguration, streamingConnector, meterService, eventbusPublisher, locker, customerService)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -353,7 +364,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	gate := featuregate.NewNoop()
 	featureGateConfiguration := conf.FeatureGate
 	featureGateChecker := common.NewFeatureGateChecker(gate, featureGateConfiguration, creditsConfiguration)
-	billingRegistry, err := common.NewBillingRegistry(logger, service, adapter, ratingService, customerService, featureConnector, meterService, connector, eventbusPublisher, billingConfiguration, subscriptionServiceWithWorkflow, client, billingFeatureSwitchesConfiguration, creditsConfiguration, tracer, taxcodeService, locker, ledger, balanceQuerier, accountResolver, accountService, breakageService, featureGateChecker)
+	billingRegistry, err := common.NewBillingRegistry(logger, service, adapter, ratingService, customerService, featureConnector, meterService, streamingConnector, eventbusPublisher, billingConfiguration, subscriptionServiceWithWorkflow, client, billingFeatureSwitchesConfiguration, creditsConfiguration, tracer, taxcodeService, locker, ledger, balanceQuerier, accountResolver, accountService, breakageService, featureGateChecker)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -501,7 +512,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		Meter:                   meterService,
 		RuntimeMetricsCollector: runtimeMetricsCollector,
 		NamespaceManager:        manager,
-		Streaming:               connector,
+		Streaming:               streamingConnector,
 	}
 	return application, func() {
 		cleanup8()

--- a/cmd/jobs/internal/wire_gen.go
+++ b/cmd/jobs/internal/wire_gen.go
@@ -209,7 +209,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v3, logger, progressmanagerService)
+	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v3, logger, progressmanagerService, meter, tracer)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/cmd/jobs/internal/wire_gen.go
+++ b/cmd/jobs/internal/wire_gen.go
@@ -209,6 +209,17 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
+	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v3, logger, progressmanagerService)
+	if err != nil {
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
 	namespaceConfiguration := conf.Namespace
 	manager, err := common.NewNamespaceManager(namespaceConfiguration)
 	if err != nil {
@@ -221,7 +232,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	connector, err := common.NewStreamingConnector(ctx, aggregationConfiguration, v3, logger, progressmanagerService, manager)
+	streamingConnector, err := common.NewStreamingConnector(aggregationConfiguration, connector, logger, manager)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -245,7 +256,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	entitlement, err := common.NewEntitlementRegistry(logger, client, tracer, entitlementsConfiguration, connector, meterService, eventbusPublisher, locker, customerService)
+	entitlement, err := common.NewEntitlementRegistry(logger, client, tracer, entitlementsConfiguration, streamingConnector, meterService, eventbusPublisher, locker, customerService)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -362,7 +373,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	gate := featuregate.NewNoop()
 	featureGateConfiguration := conf.FeatureGate
 	featureGateChecker := common.NewFeatureGateChecker(gate, featureGateConfiguration, creditsConfiguration)
-	billingRegistry, err := common.NewBillingRegistry(logger, service, adapter, ratingService, customerService, featureConnector, meterService, connector, eventbusPublisher, billingConfiguration, subscriptionServiceWithWorkflow, client, billingFeatureSwitchesConfiguration, creditsConfiguration, tracer, taxcodeService, locker, ledger, balanceQuerier, accountResolver, accountService, breakageService, featureGateChecker)
+	billingRegistry, err := common.NewBillingRegistry(logger, service, adapter, ratingService, customerService, featureConnector, meterService, streamingConnector, eventbusPublisher, billingConfiguration, subscriptionServiceWithWorkflow, client, billingFeatureSwitchesConfiguration, creditsConfiguration, tracer, taxcodeService, locker, ledger, balanceQuerier, accountResolver, accountService, breakageService, featureGateChecker)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -601,7 +612,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		Secret:                        secretserviceService,
 		Subscription:                  subscriptionServiceWithWorkflow,
 		Subject:                       subjectService,
-		StreamingConnector:            connector,
+		StreamingConnector:            streamingConnector,
 		LLMCostSyncJob:                syncJob,
 	}
 	return application, func() {

--- a/cmd/notification-service/wire_gen.go
+++ b/cmd/notification-service/wire_gen.go
@@ -203,7 +203,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v4, logger, progressmanagerService)
+	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v4, logger, progressmanagerService, meter, tracer)
 	if err != nil {
 		cleanup7()
 		cleanup6()

--- a/cmd/notification-service/wire_gen.go
+++ b/cmd/notification-service/wire_gen.go
@@ -203,6 +203,17 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
+	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v4, logger, progressmanagerService)
+	if err != nil {
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
 	namespaceConfiguration := conf.Namespace
 	manager, err := common.NewNamespaceManager(namespaceConfiguration)
 	if err != nil {
@@ -215,7 +226,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	connector, err := common.NewStreamingConnector(ctx, aggregationConfiguration, v4, logger, progressmanagerService, manager)
+	streamingConnector, err := common.NewStreamingConnector(aggregationConfiguration, connector, logger, manager)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -244,7 +255,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		MeterService:            service,
 		Notification:            notificationService,
 		RuntimeMetricsCollector: runtimeMetricsCollector,
-		StreamingConnector:      connector,
+		StreamingConnector:      streamingConnector,
 		TelemetryServer:         v5,
 	}
 	return application, func() {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -316,6 +316,31 @@ func main() {
 		group.Add(eventHandlerStart, eventHandleStop)
 	}
 
+	// Set meter cache lifecycle reconciler
+	{
+		defer func() {
+			if err = app.MeterCacheReconciler.Close(); err != nil {
+				logger.Warn("failed to close meter cache reconciler", "error", err)
+			}
+		}()
+
+		reconcilerStart := func() error {
+			logger.Info("starting meter cache reconciler")
+
+			return app.MeterCacheReconciler.Start()
+		}
+
+		reconcilerStop := func(err error) {
+			logger.Debug("shutting down meter cache reconciler gracefully...", "error", err)
+
+			if err = app.MeterCacheReconciler.Close(); err != nil {
+				logger.Warn("failed to shutdown meter cache reconciler", "error", err)
+			}
+		}
+
+		group.Add(reconcilerStart, reconcilerStop)
+	}
+
 	// Add service termination checker
 	{
 		terminationCheckerRun, terminationCheckerShutdown, err := common.NewTerminationCheckerActor(app.TerminationChecker, app.Logger)

--- a/cmd/server/wire.go
+++ b/cmd/server/wire.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/secret"
 	"github.com/openmeterio/openmeter/openmeter/server"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/openmeter/streaming/clickhouse/metercache"
 	"github.com/openmeterio/openmeter/openmeter/subject"
 	subjecthooks "github.com/openmeterio/openmeter/openmeter/subject/service/hooks"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
@@ -80,6 +81,7 @@ type Application struct {
 	LLMCostService                   llmcost.Service
 	Logger                           *slog.Logger
 	MetricMeter                      metric.Meter
+	MeterCacheReconciler             *metercache.Reconciler
 	MeterConfigInitializer           common.MeterConfigInitializer
 	MeterManageService               meter.ManageService
 	MeterEventService                meterevent.Service
@@ -131,6 +133,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		common.LLMCost,
 		common.LedgerStack,
 		common.KafkaNamespaceResolver,
+		common.MeterCache,
 		common.MeterManageWithConfigMeters,
 		common.MeterEvent,
 		common.Namespace,

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -37,6 +37,7 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/secret"
 	"github.com/openmeterio/openmeter/openmeter/server"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/openmeter/streaming/clickhouse/metercache"
 	"github.com/openmeterio/openmeter/openmeter/subject"
 	"github.com/openmeterio/openmeter/openmeter/subject/service/hooks"
 	"github.com/openmeterio/openmeter/openmeter/taxcode"
@@ -260,7 +261,18 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	connector, err := common.NewStreamingConnector(ctx, aggregationConfiguration, v3, logger, progressmanagerService, manager)
+	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v3, logger, progressmanagerService)
+	if err != nil {
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
+	streamingConnector, err := common.NewStreamingConnector(aggregationConfiguration, connector, logger, manager)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -284,7 +296,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	entitlement, err := common.NewEntitlementRegistry(logger, client, tracer, entitlementsConfiguration, connector, service, eventbusPublisher, locker, customerService)
+	entitlement, err := common.NewEntitlementRegistry(logger, client, tracer, entitlementsConfiguration, streamingConnector, service, eventbusPublisher, locker, customerService)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -357,7 +369,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	gate := featuregate.NewNoop()
 	featureGateConfiguration := conf.FeatureGate
 	featureGateChecker := common.NewFeatureGateChecker(gate, featureGateConfiguration, creditsConfiguration)
-	billingRegistry, err := common.NewBillingRegistry(logger, appService, billingAdapter, ratingService, customerService, featureConnector, service, connector, eventbusPublisher, billingConfiguration, subscriptionServiceWithWorkflow, client, billingFeatureSwitchesConfiguration, creditsConfiguration, tracer, taxcodeService, locker, ledger, balanceQuerier, accountResolver, accountService, breakageService, featureGateChecker)
+	billingRegistry, err := common.NewBillingRegistry(logger, appService, billingAdapter, ratingService, customerService, featureConnector, service, streamingConnector, eventbusPublisher, billingConfiguration, subscriptionServiceWithWorkflow, client, billingFeatureSwitchesConfiguration, creditsConfiguration, tracer, taxcodeService, locker, ledger, balanceQuerier, accountResolver, accountService, breakageService, featureGateChecker)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -514,7 +526,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	costService, err := common.NewCostService(featureConnector, service, connector, llmcostService)
+	costService, err := common.NewCostService(featureConnector, service, streamingConnector, llmcostService)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -651,6 +663,18 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	handler := common.NewLedgerNamespaceHandler(accountResolver)
+	reconciler, err := common.NewMeterCacheReconciler(aggregationConfiguration, logger, connector, service, driver)
+	if err != nil {
+		cleanup8()
+		cleanup7()
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
 	v4 := conf.Meters
 	v5 := conf.ReservedEventTypes
 	v6, err := common.NewReservedEventTypePatterns(v5)
@@ -667,7 +691,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 	}
 	manageService := common.NewMeterManageService(adapter, manager, eventbusPublisher, v6)
 	v7 := common.NewMeterConfigInitializer(logger, v4, manageService, manager)
-	metereventService := common.NewMeterEventService(connector, customerService, service)
+	metereventService := common.NewMeterEventService(streamingConnector, customerService, service)
 	notificationRepository, err := common.NewNotificationAdapter(logger, client)
 	if err != nil {
 		cleanup8()
@@ -852,6 +876,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		LLMCostService:                   llmcostService,
 		Logger:                           logger,
 		MetricMeter:                      meter,
+		MeterCacheReconciler:             reconciler,
 		MeterConfigInitializer:           v7,
 		MeterManageService:               manageService,
 		MeterEventService:                metereventService,
@@ -868,7 +893,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		SubjectService:                   subjectService,
 		SubjectCustomerHook:              v9,
 		Subscription:                     subscriptionServiceWithWorkflow,
-		StreamingConnector:               connector,
+		StreamingConnector:               streamingConnector,
 		TaxCodeNamespaceHandler:          taxcodeNamespaceHandler,
 		TaxCodeService:                   taxcodeService,
 		TelemetryServer:                  v10,
@@ -925,6 +950,7 @@ type Application struct {
 	LLMCostService                   llmcost.Service
 	Logger                           *slog.Logger
 	MetricMeter                      metric.Meter
+	MeterCacheReconciler             *metercache.Reconciler
 	MeterConfigInitializer           common.MeterConfigInitializer
 	MeterManageService               meter.ManageService
 	MeterEventService                meterevent.Service

--- a/cmd/server/wire_gen.go
+++ b/cmd/server/wire_gen.go
@@ -261,7 +261,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v3, logger, progressmanagerService)
+	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v3, logger, progressmanagerService, meter, tracer)
 	if err != nil {
 		cleanup7()
 		cleanup6()
@@ -663,7 +663,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		return Application{}, nil, err
 	}
 	handler := common.NewLedgerNamespaceHandler(accountResolver)
-	reconciler, err := common.NewMeterCacheReconciler(aggregationConfiguration, logger, connector, service, driver)
+	reconciler, err := common.NewMeterCacheReconciler(aggregationConfiguration, logger, connector, service, driver, meter, tracer)
 	if err != nil {
 		cleanup8()
 		cleanup7()

--- a/cmd/sink-worker/wire_gen.go
+++ b/cmd/sink-worker/wire_gen.go
@@ -135,6 +135,16 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
+	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v4, logger, service)
+	if err != nil {
+		cleanup6()
+		cleanup5()
+		cleanup4()
+		cleanup3()
+		cleanup2()
+		cleanup()
+		return Application{}, nil, err
+	}
 	namespaceConfiguration := conf.Namespace
 	manager, err := common.NewNamespaceManager(namespaceConfiguration)
 	if err != nil {
@@ -146,7 +156,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	connector, err := common.NewStreamingConnector(ctx, aggregationConfiguration, v4, logger, service, manager)
+	streamingConnector, err := common.NewStreamingConnector(aggregationConfiguration, connector, logger, manager)
 	if err != nil {
 		cleanup6()
 		cleanup5()
@@ -225,7 +235,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	storage, err := common.NewSinkStorage(connector)
+	storage, err := common.NewSinkStorage(streamingConnector)
 	if err != nil {
 		cleanup10()
 		cleanup9()
@@ -274,7 +284,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		Logger:                  logger,
 		Metadata:                commonMetadata,
 		Meter:                   meter,
-		Streaming:               connector,
+		Streaming:               streamingConnector,
 		TelemetryServer:         v5,
 		TopicProvisioner:        topicProvisioner,
 		TopicResolver:           namespacedTopicResolver,

--- a/cmd/sink-worker/wire_gen.go
+++ b/cmd/sink-worker/wire_gen.go
@@ -135,7 +135,7 @@ func initializeApplication(ctx context.Context, conf config.Configuration) (Appl
 		cleanup()
 		return Application{}, nil, err
 	}
-	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v4, logger, service)
+	connector, err := common.NewClickHouseStreamingConnector(ctx, aggregationConfiguration, v4, logger, service, meter, tracer)
 	if err != nil {
 		cleanup6()
 		cleanup5()

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -138,6 +138,26 @@ events:
 #   enabled: true
 #   tokenSecret: this-isnt-secure
 
+aggregation:
+  # cache configures the refreshable materialized view based meter cache. It is disabled by
+  # default: creating and maintaining a materialized view per meter is a ClickHouse-side cost
+  # operators must opt into, and it requires enableDecimalPrecision to be true (see below).
+  #
+  # IMPORTANT: the cache relies on system.view_refreshes and scheduled REFRESH VIEW, which are
+  # per-ClickHouse-server state. It is only supported against a single ClickHouse server;
+  # clusters and load-balanced setups are not supported in v1 (queries fall back to live).
+  cache:
+    enabled: false
+    refreshInterval: 10m
+    minimumUsageAge: 1h
+    # windowSize is the rollup bucket width (grain): minute, hour, or day. Minute-grain
+    # multiplies stored row counts accordingly; consider the storage impact before enabling it
+    # on high-cardinality or high-volume meters.
+    windowSize: hour
+    # meterQueryThreshold reserves a future "cache only hot meters" strategy. v1 always caches
+    # every meter; a value above 0 is rejected at startup.
+    meterQueryThreshold: 0
+
 postgres:
   url: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
   autoMigrate: ent # Runs migrations as part of the service startup, valid values are: ent, migration, false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -146,6 +146,10 @@ aggregation:
   # IMPORTANT: the cache relies on system.view_refreshes and scheduled REFRESH VIEW, which are
   # per-ClickHouse-server state. It is only supported against a single ClickHouse server;
   # clusters and load-balanced setups are not supported in v1 (queries fall back to live).
+  #
+  # Cached aggregations: SUM, COUNT, MIN, MAX, AVG, UNIQUE_COUNT. LATEST meters always read
+  # live and are never enrolled in the cache: LATEST only needs the single newest value in
+  # the queried window, so there is no re-aggregation of settled history for a cache to save.
   cache:
     enabled: false
     refreshInterval: 10m

--- a/openmeter/billing/charges/usagebased/service/rating/quantitysnapshot_test.go
+++ b/openmeter/billing/charges/usagebased/service/rating/quantitysnapshot_test.go
@@ -1,0 +1,53 @@
+package rating
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+// TestSnapshotQuantityStaysOnRawMeterQueries pins the charge rating quantity snapshot as
+// a never-cached meter consumer: the params it hands to the streaming connector must have
+// Cachable=false (the zero value). Rated charge quantities become invoice amounts, and
+// this path additionally relies on the stored_at cutoff, which the rollup cache cannot
+// evaluate — only the read-only call sites opt in (see streaming.QueryParams.Cachable).
+func TestSnapshotQuantityStaysOnRawMeterQueries(t *testing.T) {
+	m := meter.Meter{
+		Key:         "meter-1",
+		EventType:   "api-calls",
+		Aggregation: meter.MeterAggregationCount,
+	}
+
+	now := time.Now().Truncate(time.Minute)
+	period := timeutil.ClosedPeriod{From: now.Add(-2 * time.Hour), To: now.Add(-time.Hour)}
+
+	streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
+	streamingConnector.AddSimpleEvent(m.Key, 10, period.From.Add(time.Minute))
+
+	svc := &service{streamingConnector: streamingConnector}
+
+	_, err := svc.snapshotQuantity(t.Context(), snapshotQuantityInput{
+		Customer: billing.InvoiceCustomer{
+			CustomerID: "customer-1",
+			Name:       "Customer 1",
+		},
+		FeatureMeter: feature.FeatureMeter{
+			Feature: feature.Feature{Namespace: "test-ns", Key: "feature-1"},
+			Meter:   &m,
+		},
+		ServicePeriod: period,
+		StoredAtLT:    now,
+	})
+	require.NoError(t, err)
+
+	captured := streamingConnector.CapturedQueryMeterParams()
+	require.Len(t, captured, 1)
+	require.False(t, captured[0].Cachable)
+}

--- a/openmeter/billing/service/quantitysnapshot_test.go
+++ b/openmeter/billing/service/quantitysnapshot_test.go
@@ -1,0 +1,100 @@
+package billingservice
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/billing"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+// TestGetFeatureUsageStaysOnRawMeterQueries pins the invoice quantity snapshot path as a
+// never-cached meter consumer: every params it hands to the streaming connector must have
+// Cachable=false (the zero value), on both the plain and the split-line query shapes.
+// Invoiced quantities are financial records; serving them from the rollup cache would let
+// a stale bucket become a permanently wrong invoice, which is why only the read-only call
+// sites opt in (see streaming.QueryParams.Cachable).
+func TestGetFeatureUsageStaysOnRawMeterQueries(t *testing.T) {
+	m := meter.Meter{
+		Key:         "meter-1",
+		EventType:   "api-calls",
+		Aggregation: meter.MeterAggregationCount,
+	}
+
+	now := time.Now().Truncate(time.Minute)
+	period := timeutil.ClosedPeriod{From: now.Add(-2 * time.Hour), To: now.Add(-time.Hour)}
+
+	newLine := func() *billing.StandardLine {
+		return &billing.StandardLine{
+			StandardLineBase: billing.StandardLineBase{
+				ManagedResource: models.ManagedResource{
+					NamespacedModel: models.NamespacedModel{Namespace: "test-ns"},
+					ID:              "line-1",
+				},
+				Period: period,
+			},
+		}
+	}
+
+	invoiceCustomer := billing.InvoiceCustomer{
+		CustomerID: "customer-1",
+		Name:       "Customer 1",
+	}
+
+	t.Run("plain line", func(t *testing.T) {
+		streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
+		streamingConnector.AddSimpleEvent(m.Key, 10, period.From.Add(time.Minute))
+
+		svc := &Service{streamingConnector: streamingConnector}
+
+		_, err := svc.getFeatureUsage(t.Context(), getFeatureUsageInput{
+			Line:     newLine(),
+			Meter:    m,
+			Feature:  feature.Feature{Namespace: "test-ns", Key: "feature-1"},
+			Customer: invoiceCustomer,
+		})
+		require.NoError(t, err)
+
+		captured := streamingConnector.CapturedQueryMeterParams()
+		require.Len(t, captured, 1)
+		require.False(t, captured[0].Cachable)
+	})
+
+	t.Run("split line pre and up-to-end queries", func(t *testing.T) {
+		streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
+		streamingConnector.AddSimpleEvent(m.Key, 10, period.From.Add(time.Minute))
+
+		svc := &Service{streamingConnector: streamingConnector}
+
+		line := newLine()
+		line.SplitLineHierarchy = &billing.SplitLineHierarchy{
+			Group: billing.SplitLineGroup{
+				SplitLineGroupMutableFields: billing.SplitLineGroupMutableFields{
+					ServicePeriod: timeutil.ClosedPeriod{
+						From: period.From.Add(-time.Hour),
+						To:   period.To,
+					},
+				},
+			},
+		}
+
+		_, err := svc.getFeatureUsage(t.Context(), getFeatureUsageInput{
+			Line:     line,
+			Meter:    m,
+			Feature:  feature.Feature{Namespace: "test-ns", Key: "feature-1"},
+			Customer: invoiceCustomer,
+		})
+		require.NoError(t, err)
+
+		captured := streamingConnector.CapturedQueryMeterParams()
+		require.Len(t, captured, 2)
+		require.False(t, captured[0].Cachable)
+		require.False(t, captured[1].Cachable)
+	})
+}

--- a/openmeter/cost/adapter/adapter.go
+++ b/openmeter/cost/adapter/adapter.go
@@ -87,6 +87,11 @@ func (a *adapter) QueryFeatureCost(ctx context.Context, input cost.QueryFeatureC
 	params := input.QueryParams
 	params.GroupBy = slices.Clone(params.GroupBy)
 
+	// Cost reporting is one of the designated meter cache opt-in call sites: its results
+	// are informational, never persisted into billing artifacts, so serving the settled
+	// range from the cache is safe.
+	params.Cachable = true
+
 	// Merge feature's MeterGroupByFilters into query.
 	// Feature filters take precedence over request filters to prevent
 	// callers from querying usage outside the feature's filter scope.

--- a/openmeter/cost/adapter/adapter_test.go
+++ b/openmeter/cost/adapter/adapter_test.go
@@ -1,0 +1,119 @@
+package adapter
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/alpacahq/alpacadecimal"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/cost"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+	"github.com/openmeterio/openmeter/pkg/ref"
+)
+
+// stubFeatureConnector serves one fixed feature; QueryFeatureCost only calls GetFeature.
+type stubFeatureConnector struct {
+	feature feature.Feature
+}
+
+func (s stubFeatureConnector) CreateFeature(context.Context, feature.CreateFeatureInputs) (feature.Feature, error) {
+	return feature.Feature{}, errors.New("not implemented")
+}
+
+func (s stubFeatureConnector) UpdateFeature(context.Context, feature.UpdateFeatureInputs) (feature.Feature, error) {
+	return feature.Feature{}, errors.New("not implemented")
+}
+
+func (s stubFeatureConnector) ArchiveFeature(context.Context, models.NamespacedID) error {
+	return errors.New("not implemented")
+}
+
+func (s stubFeatureConnector) ListFeatures(context.Context, feature.ListFeaturesParams) (pagination.Result[feature.Feature], error) {
+	return pagination.Result[feature.Feature]{}, errors.New("not implemented")
+}
+
+func (s stubFeatureConnector) GetFeature(context.Context, string, string, feature.IncludeArchivedFeature) (*feature.Feature, error) {
+	f := s.feature
+
+	return &f, nil
+}
+
+func (s stubFeatureConnector) ResolveFeatureMeters(context.Context, string, ...ref.IDOrKey) (feature.FeatureMeters, error) {
+	return nil, errors.New("not implemented")
+}
+
+// stubMeterService serves one fixed meter; QueryFeatureCost only calls GetMeterByIDOrSlug.
+type stubMeterService struct {
+	meter meter.Meter
+}
+
+func (s stubMeterService) ListMeters(context.Context, meter.ListMetersParams) (pagination.Result[meter.Meter], error) {
+	return pagination.Result[meter.Meter]{}, errors.New("not implemented")
+}
+
+func (s stubMeterService) GetMeterByIDOrSlug(context.Context, meter.GetMeterInput) (meter.Meter, error) {
+	return s.meter, nil
+}
+
+// TestQueryFeatureCostOptsIntoMeterCache pins the cost adapter as a designated meter
+// cache opt-in call site: the params it hands to the streaming connector must carry
+// Cachable=true without mutating the caller's input params, while billing paths construct
+// their own params and must never set it.
+func TestQueryFeatureCostOptsIntoMeterCache(t *testing.T) {
+	m := meter.Meter{
+		Key:           "meter-1",
+		EventType:     "api-calls",
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
+	streamingConnector.AddSimpleEvent(m.Key, 10, time.Now().Add(-time.Hour))
+
+	costAdapter := New(
+		stubFeatureConnector{feature: feature.Feature{
+			Namespace: "test-ns",
+			Key:       "feature-1",
+			MeterID:   lo.ToPtr("meter-1"),
+			UnitCost: &feature.UnitCost{
+				Type:   feature.UnitCostTypeManual,
+				Manual: &feature.ManualUnitCost{Amount: alpacadecimal.NewFromFloat(0.5)},
+			},
+		}},
+		stubMeterService{meter: m},
+		streamingConnector,
+		nil,
+	)
+
+	from := time.Now().Add(-2 * time.Hour)
+	to := time.Now()
+
+	input := cost.QueryFeatureCostInput{
+		Namespace: "test-ns",
+		FeatureID: "feature-1",
+		QueryParams: streaming.QueryParams{
+			From: &from,
+			To:   &to,
+		},
+	}
+
+	_, err := costAdapter.QueryFeatureCost(t.Context(), input)
+	require.NoError(t, err)
+
+	captured := streamingConnector.CapturedQueryMeterParams()
+	require.Len(t, captured, 1)
+	require.True(t, captured[0].Cachable)
+
+	// The opt-in must happen on the adapter's own copy: mutating the caller's params
+	// would silently opt callers embedding these params into other queries into the cache.
+	require.False(t, input.QueryParams.Cachable)
+}

--- a/openmeter/credit/balance/usage.go
+++ b/openmeter/credit/balance/usage.go
@@ -44,6 +44,12 @@ func (u *usageQuerier) QueryUsage(ctx context.Context, ownerID models.Namespaced
 		return 0.0, err
 	}
 
+	// Credit usage reads are one of the designated meter cache opt-in call sites. Usage
+	// computed here can be persisted into grant balance snapshots, which is acceptable
+	// because the cache's always-live tail (minimumUsageAge) plus the marker heal rule
+	// bound any staleness; billing paths, in contrast, must never opt in.
+	params.Cachable = true
+
 	owner, err := u.DescribeOwner(ctx, ownerID)
 	if err != nil {
 		return 0.0, err

--- a/openmeter/credit/balance/usage_test.go
+++ b/openmeter/credit/balance/usage_test.go
@@ -1,0 +1,93 @@
+package balance_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/credit/balance"
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+// TestUsageQuerierOptsIntoMeterCache pins the credit usage querier as a designated meter
+// cache opt-in call site: every usage read it issues must hand Cachable=true to the
+// streaming connector — including both legs of the UNIQUE_COUNT subtraction, whose
+// staleness would be billing-visible through grant burn-down.
+func TestUsageQuerierOptsIntoMeterCache(t *testing.T) {
+	newQuerier := func(t *testing.T, m meter.Meter, periodStart time.Time) (balance.UsageQuerier, *streamingtestutils.MockStreamingConnector) {
+		t.Helper()
+
+		streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
+		streamingConnector.AddSimpleEvent(m.Key, 10, periodStart.Add(time.Minute))
+
+		querier := balance.NewUsageQuerier(balance.UsageQuerierConfig{
+			StreamingConnector: streamingConnector,
+			DescribeOwner: func(ctx context.Context, id models.NamespacedID) (grant.Owner, error) {
+				return grant.Owner{
+					NamespacedID: id,
+					Meter:        m,
+				}, nil
+			},
+			GetDefaultParams: func(ctx context.Context, ownerID models.NamespacedID) (streaming.QueryParams, error) {
+				return streaming.QueryParams{}, nil
+			},
+			GetUsagePeriodStartAt: func(ctx context.Context, ownerID models.NamespacedID, at time.Time) (time.Time, error) {
+				return periodStart, nil
+			},
+		})
+
+		return querier, streamingConnector
+	}
+
+	ownerID := models.NamespacedID{Namespace: "test-ns", ID: "owner-1"}
+	periodStart := time.Now().Add(-4 * time.Hour).Truncate(time.Minute)
+
+	t.Run("sum single query", func(t *testing.T) {
+		querier, streamingConnector := newQuerier(t, meter.Meter{
+			Key:           "meter-1",
+			EventType:     "api-calls",
+			Aggregation:   meter.MeterAggregationSum,
+			ValueProperty: lo.ToPtr("$.value"),
+		}, periodStart)
+
+		_, err := querier.QueryUsage(t.Context(), ownerID, timeutil.ClosedPeriod{
+			From: periodStart,
+			To:   periodStart.Add(3 * time.Hour),
+		})
+		require.NoError(t, err)
+
+		captured := streamingConnector.CapturedQueryMeterParams()
+		require.Len(t, captured, 1)
+		require.True(t, captured[0].Cachable)
+	})
+
+	t.Run("unique count subtraction queries", func(t *testing.T) {
+		querier, streamingConnector := newQuerier(t, meter.Meter{
+			Key:           "meter-1",
+			EventType:     "api-calls",
+			Aggregation:   meter.MeterAggregationUniqueCount,
+			ValueProperty: lo.ToPtr("$.value"),
+		}, periodStart)
+
+		// A period starting after the usage period start forces both subtraction legs:
+		// [periodStart, period.To) and [periodStart, period.From).
+		_, err := querier.QueryUsage(t.Context(), ownerID, timeutil.ClosedPeriod{
+			From: periodStart.Add(time.Hour),
+			To:   periodStart.Add(3 * time.Hour),
+		})
+		require.NoError(t, err)
+
+		captured := streamingConnector.CapturedQueryMeterParams()
+		require.Len(t, captured, 2)
+		require.True(t, captured[0].Cachable)
+		require.True(t, captured[1].Cachable)
+	})
+}

--- a/openmeter/entitlement/metered/balance.go
+++ b/openmeter/entitlement/metered/balance.go
@@ -377,5 +377,11 @@ func (e *connector) queryMeter(ctx context.Context, namespace string, m meter.Me
 		}, nil
 	}
 
+	// Entitlement balance reads are one of the designated meter cache opt-in call sites.
+	// Balances derived here can be persisted into balance snapshots, which is acceptable
+	// because the cache's always-live tail (minimumUsageAge) plus the marker heal rule
+	// bound any staleness; billing paths, in contrast, must never opt in.
+	params.Cachable = true
+
 	return e.streamingConnector.QueryMeter(ctx, namespace, m, params)
 }

--- a/openmeter/entitlement/metered/balance_internal_test.go
+++ b/openmeter/entitlement/metered/balance_internal_test.go
@@ -1,0 +1,48 @@
+package meteredentitlement
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+)
+
+// TestQueryMeterOptsIntoMeterCache pins the entitlement balance queryMeter wrapper as a
+// designated meter cache opt-in call site: every balance/history usage read going through
+// it must hand Cachable=true to the streaming connector. The zero-length-period shortcut
+// must keep answering locally without touching the connector at all.
+func TestQueryMeterOptsIntoMeterCache(t *testing.T) {
+	m := meter.Meter{
+		Key:           "meter-1",
+		EventType:     "api-calls",
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
+	streamingConnector.AddSimpleEvent(m.Key, 10, time.Now().Add(-time.Hour))
+
+	e := &connector{streamingConnector: streamingConnector}
+
+	from := time.Now().Add(-2 * time.Hour)
+	to := time.Now()
+
+	_, err := e.queryMeter(t.Context(), "test-ns", m, streaming.QueryParams{From: &from, To: &to})
+	require.NoError(t, err)
+
+	captured := streamingConnector.CapturedQueryMeterParams()
+	require.Len(t, captured, 1)
+	require.True(t, captured[0].Cachable)
+
+	// Zero-length period: answered locally, no connector call recorded.
+	rows, err := e.queryMeter(t.Context(), "test-ns", m, streaming.QueryParams{From: &from, To: &from})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, float64(0), rows[0].Value)
+	require.Len(t, streamingConnector.CapturedQueryMeterParams(), 1)
+}

--- a/openmeter/meter/httphandler/mapping.go
+++ b/openmeter/meter/httphandler/mapping.go
@@ -112,6 +112,10 @@ func (h *handler) toQueryParamsFromRequest(ctx context.Context, m meter.Meter, r
 		ClientID: request.ClientId,
 		From:     request.From,
 		To:       request.To,
+		// The v1 meter query endpoints (GET/POST/CSV) are one of the designated meter cache
+		// opt-in call sites: their results are displayed, never persisted into billing
+		// artifacts, so serving the settled range from the cache is safe.
+		Cachable: true,
 	}
 
 	if request.WindowSize != nil {

--- a/openmeter/meter/httphandler/mapping_test.go
+++ b/openmeter/meter/httphandler/mapping_test.go
@@ -1,0 +1,22 @@
+package httpdriver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/api"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+)
+
+// TestToQueryParamsFromRequestOptsIntoMeterCache pins the v1 meter query endpoints as a
+// designated meter cache opt-in call site: every v1 query (GET, POST and CSV all funnel
+// through toQueryParamsFromRequest) must hand Cachable=true to the streaming connector,
+// while billing paths construct their own params and must never set it.
+func TestToQueryParamsFromRequestOptsIntoMeterCache(t *testing.T) {
+	h := &handler{}
+
+	params, err := h.toQueryParamsFromRequest(t.Context(), meter.Meter{}, api.QueryMeterPostJSONRequestBody{})
+	require.NoError(t, err)
+	require.True(t, params.Cachable)
+}

--- a/openmeter/meterexport/service/funnel_test.go
+++ b/openmeter/meterexport/service/funnel_test.go
@@ -1,0 +1,61 @@
+package meterexportservice
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	streamingtestutils "github.com/openmeterio/openmeter/openmeter/streaming/testutils"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// TestFunnelStaysOnRawMeterQueries pins the meter export funnel as a never-cached meter
+// consumer: exports feed external billing/analytics pipelines, so every windowed query
+// the funnel issues must have Cachable=false (the zero value) — only the read-only call
+// sites opt in (see streaming.QueryParams.Cachable).
+func TestFunnelStaysOnRawMeterQueries(t *testing.T) {
+	m := meter.Meter{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: "test-ns"},
+		},
+		Key:         "meter-1",
+		EventType:   "api-calls",
+		Aggregation: meter.MeterAggregationCount,
+	}
+
+	from := time.Now().Add(-3 * time.Hour).Truncate(time.Hour)
+	to := from.Add(2 * time.Hour)
+
+	streamingConnector := streamingtestutils.NewMockStreamingConnector(t)
+	streamingConnector.AddSimpleEvent(m.Key, 10, from.Add(time.Minute))
+
+	svc := &service{Config: Config{StreamingConnector: streamingConnector}}
+
+	resultCh := make(chan meter.MeterQueryRow, 1024)
+	errCh := make(chan error, 16)
+
+	err := svc.funnel(t.Context(), funnelParams{
+		meter: m,
+		queryParams: streaming.QueryParams{
+			From:       &from,
+			To:         &to,
+			WindowSize: lo.ToPtr(meter.WindowSizeHour),
+		},
+	}, resultCh, errCh)
+	require.NoError(t, err)
+
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+
+	captured := streamingConnector.CapturedQueryMeterParams()
+	require.NotEmpty(t, captured)
+
+	for _, params := range captured {
+		require.False(t, params.Cachable)
+	}
+}

--- a/openmeter/streaming/clickhouse/connector.go
+++ b/openmeter/streaming/clickhouse/connector.go
@@ -117,6 +117,18 @@ func (c *Connector) createTable(ctx context.Context) error {
 		return fmt.Errorf("create events table in clickhouse: %w", err)
 	}
 
+	// The meter cache tables are only provisioned when the cache is enabled so disabled
+	// deployments keep a zero-footprint schema.
+	if c.config.Cache.Enabled {
+		if err := c.config.ClickHouse.Exec(ctx, createMeterCacheTable{Database: c.config.Database}.toSQL()); err != nil {
+			return fmt.Errorf("create meter cache table in clickhouse: %w", err)
+		}
+
+		if err := c.config.ClickHouse.Exec(ctx, createMeterCacheInvalidationsTable{Database: c.config.Database}.toSQL()); err != nil {
+			return fmt.Errorf("create meter cache invalidations table in clickhouse: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/openmeter/streaming/clickhouse/connector.go
+++ b/openmeter/streaming/clickhouse/connector.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	meterpkg "github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/progressmanager"
@@ -31,6 +33,11 @@ type Connector struct {
 	// cacheGate is non-nil only when the meter cache is enabled; QueryMeter consults it
 	// for opted-in queries and serves them from the cache when eligible.
 	cacheGate *meterCacheGate
+
+	// observability holds the meter cache's OTel instruments. It is always non-nil — see
+	// newMeterCacheObservability — so the cached read and invalidation paths can record
+	// without checking whether the cache itself is enabled or telemetry was configured.
+	observability *meterCacheObservability
 }
 
 type Config struct {
@@ -47,6 +54,14 @@ type Config struct {
 	ProgressManager        progressmanager.Service
 	SkipCreateTables       bool
 	Cache                  CacheConfig
+
+	// Meter and Tracer instrument the meter cache's health signals (gate decisions, cached
+	// query latency, invalidation marker failures, refresh triggers). Both are optional:
+	// the cache is deliberately non-critical observability-wise, so a nil Meter yields
+	// no-op instruments and a nil Tracer falls back to a no-op tracer instead of requiring
+	// every deployment to wire telemetry before the cache can be enabled.
+	Meter  metric.Meter
+	Tracer trace.Tracer
 }
 
 // CacheGrain is the rollup bucket width the meter cache maintains per meter.
@@ -103,13 +118,19 @@ func New(ctx context.Context, config Config) (*Connector, error) {
 		return nil, fmt.Errorf("validate config: %w", err)
 	}
 
+	observability, err := newMeterCacheObservability(config)
+	if err != nil {
+		return nil, fmt.Errorf("init meter cache observability: %w", err)
+	}
+
 	// Create the connector
 	connector := &Connector{
-		config: config,
+		config:        config,
+		observability: observability,
 	}
 
 	if config.Cache.Enabled {
-		connector.cacheInvalidator = newMeterCacheInvalidator(config)
+		connector.cacheInvalidator = newMeterCacheInvalidator(config, observability)
 		connector.cacheGate = newMeterCacheGate(config)
 	}
 

--- a/openmeter/streaming/clickhouse/connector.go
+++ b/openmeter/streaming/clickhouse/connector.go
@@ -27,6 +27,10 @@ type Connector struct {
 	// cacheInvalidator is non-nil only when the meter cache is enabled; BatchInsert hands
 	// it every successfully inserted batch so late events invalidate cached buckets.
 	cacheInvalidator *meterCacheInvalidator
+
+	// cacheGate is non-nil only when the meter cache is enabled; QueryMeter consults it
+	// for opted-in queries and serves them from the cache when eligible.
+	cacheGate *meterCacheGate
 }
 
 type Config struct {
@@ -106,6 +110,7 @@ func New(ctx context.Context, config Config) (*Connector, error) {
 
 	if config.Cache.Enabled {
 		connector.cacheInvalidator = newMeterCacheInvalidator(config)
+		connector.cacheGate = newMeterCacheGate(config)
 	}
 
 	if !config.SkipCreateTables {
@@ -208,20 +213,29 @@ func (c *Connector) QueryMeter(ctx context.Context, namespace string, meter mete
 		EnableDecimalPrecision: c.config.EnableDecimalPrecision,
 	}
 
-	// Load cached rows if any
-	var err error
 	var values []meterpkg.MeterQueryRow
+	var servedFromCache bool
 
-	// If the client ID is set, we track track the progress of the query
-	if params.ClientID != nil {
-		values, err = c.queryMeterWithProgress(ctx, namespace, *params.ClientID, query)
-		if err != nil {
-			return values, fmt.Errorf("query meter with progress: %w", err)
-		}
-	} else {
-		values, err = c.queryMeter(ctx, query)
-		if err != nil {
-			return values, fmt.Errorf("query meter: %w", err)
+	// Opted-in queries may be served from the meter cache; any gate rejection or
+	// cache-path failure falls through to the untouched live path below.
+	if c.cacheGate != nil && params.Cachable {
+		values, servedFromCache = c.queryMeterCached(ctx, query, params)
+	}
+
+	if !servedFromCache {
+		var err error
+
+		// If the client ID is set, we track track the progress of the query
+		if params.ClientID != nil {
+			values, err = c.queryMeterWithProgress(ctx, namespace, *params.ClientID, query)
+			if err != nil {
+				return values, fmt.Errorf("query meter with progress: %w", err)
+			}
+		} else {
+			values, err = c.queryMeter(ctx, query)
+			if err != nil {
+				return values, fmt.Errorf("query meter: %w", err)
+			}
 		}
 	}
 

--- a/openmeter/streaming/clickhouse/connector.go
+++ b/openmeter/streaming/clickhouse/connector.go
@@ -38,6 +38,31 @@ type Config struct {
 	EnableDecimalPrecision bool
 	ProgressManager        progressmanager.Service
 	SkipCreateTables       bool
+	Cache                  CacheConfig
+}
+
+// CacheGrain is the rollup bucket width the meter cache maintains per meter.
+// It is a package-local type (rather than app/config.AggregationCacheGrain) so this
+// package never imports app/config; app/common maps between the two.
+type CacheGrain string
+
+const (
+	CacheGrainMinute CacheGrain = "minute"
+	CacheGrainHour   CacheGrain = "hour"
+	CacheGrainDay    CacheGrain = "day"
+)
+
+// CacheConfig configures the refreshable materialized view based meter cache. It mirrors
+// app/config.AggregationCacheConfiguration field-for-field; app/common/streaming.go maps
+// the validated app config into this struct so this package stays free of an app/config
+// import (app/config already depends on lower-level domain packages, so the reverse
+// dependency would create an import cycle across the DI boundary).
+type CacheConfig struct {
+	Enabled             bool
+	RefreshInterval     time.Duration
+	MinimumUsageAge     time.Duration
+	WindowSize          CacheGrain
+	MeterQueryThreshold int
 }
 
 func (c Config) Validate() error {

--- a/openmeter/streaming/clickhouse/connector.go
+++ b/openmeter/streaming/clickhouse/connector.go
@@ -23,6 +23,10 @@ var _ streaming.Connector = (*Connector)(nil)
 // Connector implements `ingest.Connector" and `namespace.Handler interfaces.
 type Connector struct {
 	config Config
+
+	// cacheInvalidator is non-nil only when the meter cache is enabled; BatchInsert hands
+	// it every successfully inserted batch so late events invalidate cached buckets.
+	cacheInvalidator *meterCacheInvalidator
 }
 
 type Config struct {
@@ -98,6 +102,10 @@ func New(ctx context.Context, config Config) (*Connector, error) {
 	// Create the connector
 	connector := &Connector{
 		config: config,
+	}
+
+	if config.Cache.Enabled {
+		connector.cacheInvalidator = newMeterCacheInvalidator(config)
 	}
 
 	if !config.SkipCreateTables {
@@ -319,6 +327,15 @@ func (c *Connector) BatchInsert(ctx context.Context, rawEvents []streaming.RawEv
 
 	if err != nil {
 		return fmt.Errorf("failed to batch insert raw events: %w", err)
+	}
+
+	// The events are durably stored at this point, so late-event cache invalidation is
+	// strictly best-effort: it logs and counts its own failures and never returns one,
+	// because an error here would make the caller retry an insert that already succeeded
+	// (duplicating events) over a cache-freshness problem that scheduled refreshes and the
+	// reconciler repair anyway.
+	if c.cacheInvalidator != nil {
+		c.cacheInvalidator.invalidateLateEvents(ctx, rawEvents)
 	}
 
 	return nil

--- a/openmeter/streaming/clickhouse/meter_cache_backfill.go
+++ b/openmeter/streaming/clickhouse/meter_cache_backfill.go
@@ -1,0 +1,106 @@
+package clickhouse
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	meterpkg "github.com/openmeterio/openmeter/openmeter/meter"
+)
+
+// meterCacheBackfill generates the one-time INSERT that populates om_meter_cache with a
+// meter's full settled history when its MV is created. It renders the exact SELECT shape
+// the MV refreshes use (meterCacheSelectSQL), only without the dirty-bucket restriction:
+// backfill rows and refresh rows must be indistinguishable so their overlap around the
+// first scheduled refresh resolves by newest-wins instead of diverging.
+type meterCacheBackfill struct {
+	Database        string
+	EventsTableName string
+	Namespace       string
+	Meter           meterpkg.Meter
+	Grain           CacheGrain
+	MinimumUsageAge time.Duration
+
+	// From/To optionally chunk the backfill (see backfillMonthChunks) so a large meter's
+	// history is inserted in bounded pieces instead of one giant INSERT SELECT. From is
+	// merged with the meter's EventFrom below; To is exclusive and the settled bound
+	// still applies on top of it. Both nil = full settled history in one statement.
+	From *time.Time
+	To   *time.Time
+}
+
+func (d meterCacheBackfill) toSQL() (string, error) {
+	// Same lower-bound resolution as the live query (queryMeter.from()): the meter's
+	// EventFrom wins over an earlier chunk bound so the backfill never caches events the
+	// live query would exclude — cached and live results must stay byte-equal.
+	from := d.From
+	if d.Meter.EventFrom != nil && (from == nil || d.Meter.EventFrom.After(*from)) {
+		from = d.Meter.EventFrom
+	}
+
+	selectSQL, err := meterCacheSelectSQL(meterCacheSelectParams{
+		Database:        d.Database,
+		EventsTableName: d.EventsTableName,
+		Namespace:       d.Namespace,
+		Meter:           d.Meter,
+		Grain:           d.Grain,
+		MinimumUsageAge: d.MinimumUsageAge,
+		From:            from,
+		To:              d.To,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	getColumn := columnFactory(d.EventsTableName)
+
+	combineColumns, err := valueExprsCombine(d.Meter, getColumn("data"), getColumn("time"))
+	if err != nil {
+		return "", err
+	}
+
+	// The INSERT names its columns because the SELECT only produces the meter's own
+	// combine columns; the remaining aggregation columns take their defaults. The list
+	// must mirror the SELECT output order (meterCacheSelectSQL), so the combine column
+	// names are taken from the very expressions the SELECT emits.
+	columns := []string{"namespace", "meter_key", "meter_hash", "windowstart", "subject", "group_by", "created_at"}
+	for _, expr := range combineColumns {
+		columns = append(columns, expr[strings.LastIndex(expr, " AS ")+len(" AS "):])
+	}
+
+	return fmt.Sprintf(
+		"INSERT INTO %s (%s) %s",
+		getTableName(d.Database, meterCacheTableName),
+		strings.Join(columns, ", "),
+		selectSQL,
+	), nil
+}
+
+// backfillChunk is one [From, To) piece of a chunked backfill.
+type backfillChunk struct {
+	From time.Time
+	To   time.Time
+}
+
+// backfillMonthChunks splits [from, to) on UTC calendar month boundaries. Chunks align
+// with the events table's toYYYYMM(time) partitioning, so each backfill INSERT scans at
+// most two partitions (first chunk may start mid-month) instead of the whole history.
+// Returns nil when the range is empty.
+func backfillMonthChunks(from, to time.Time) []backfillChunk {
+	from = from.UTC()
+	to = to.UTC()
+
+	var chunks []backfillChunk
+
+	for cur := from; cur.Before(to); {
+		next := time.Date(cur.Year(), cur.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, 1, 0)
+		if next.After(to) {
+			next = to
+		}
+
+		chunks = append(chunks, backfillChunk{From: cur, To: next})
+		cur = next
+	}
+
+	return chunks
+}

--- a/openmeter/streaming/clickhouse/meter_cache_backfill_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_backfill_test.go
@@ -1,0 +1,211 @@
+package clickhouse
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+)
+
+func backfillFixture(m meter.Meter) meterCacheBackfill {
+	return meterCacheBackfill{
+		Database:        "openmeter",
+		EventsTableName: "om_events",
+		Namespace:       "my_namespace",
+		Meter:           m,
+		Grain:           CacheGrainHour,
+		MinimumUsageAge: time.Hour,
+	}
+}
+
+func TestMeterCacheBackfillSQL(t *testing.T) {
+	t.Run("golden sum full settled history", func(t *testing.T) {
+		backfill := backfillFixture(meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationSum,
+			ValueProperty: lo.ToPtr("$.value"),
+			GroupBy: map[string]string{
+				"group1": "$.group1",
+				"group2": "$.group2",
+			},
+		})
+
+		sql, err := backfill.toSQL()
+		require.NoError(t, err)
+		assert.Equal(t,
+			"INSERT INTO openmeter.om_meter_cache (namespace, meter_key, meter_hash, windowstart, subject, group_by, created_at, sum_value) "+
+				"SELECT namespace, 'meter1' AS meter_key, 12040394714864442891 AS meter_hash, "+
+				"tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, subject, "+
+				"[JSON_VALUE(om_events.data, '$.group1'), JSON_VALUE(om_events.data, '$.group2')] AS group_by, now64(3) AS created_at, "+
+				"sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS sum_value "+
+				"FROM openmeter.om_events "+
+				"WHERE om_events.namespace = 'my_namespace' AND om_events.type = 'event1' "+
+				"AND om_events.time < toStartOfInterval(now() - INTERVAL 3600 SECOND, INTERVAL 1 HOUR, 'UTC') "+
+				"GROUP BY namespace, windowstart, subject, group_by",
+			sql,
+		)
+	})
+
+	t.Run("insert column list follows the aggregation", func(t *testing.T) {
+		tests := []struct {
+			aggregation meter.MeterAggregation
+			wantColumns string
+		}{
+			{aggregation: meter.MeterAggregationSum, wantColumns: "created_at, sum_value)"},
+			{aggregation: meter.MeterAggregationCount, wantColumns: "created_at, count_value)"},
+			{aggregation: meter.MeterAggregationAvg, wantColumns: "created_at, sum_value, value_count)"},
+			{aggregation: meter.MeterAggregationMin, wantColumns: "created_at, min_value)"},
+			{aggregation: meter.MeterAggregationMax, wantColumns: "created_at, max_value)"},
+			{aggregation: meter.MeterAggregationUniqueCount, wantColumns: "created_at, uniq_state)"},
+			{aggregation: meter.MeterAggregationLatest, wantColumns: "created_at, latest_state)"},
+		}
+
+		for _, tt := range tests {
+			t.Run(string(tt.aggregation), func(t *testing.T) {
+				m := meter.Meter{Key: "meter1", EventType: "event1", Aggregation: tt.aggregation}
+				if tt.aggregation != meter.MeterAggregationCount {
+					m.ValueProperty = lo.ToPtr("$.value")
+				}
+
+				sql, err := backfillFixture(m).toSQL()
+				require.NoError(t, err)
+				assert.Contains(t, sql, "INSERT INTO openmeter.om_meter_cache (namespace, meter_key, meter_hash, windowstart, subject, group_by, "+tt.wantColumns)
+				// Backfills cover full settled history: no dirty-bucket restriction.
+				assert.NotContains(t, sql, "UNION DISTINCT")
+				assert.NotContains(t, sql, "stored_at")
+			})
+		}
+	})
+
+	t.Run("lower bound follows queryMeter.from() semantics", func(t *testing.T) {
+		earlier, err := time.Parse(time.RFC3339, "2025-01-01T00:00:00Z")
+		require.NoError(t, err)
+		later, err := time.Parse(time.RFC3339, "2025-06-01T00:00:00Z")
+		require.NoError(t, err)
+
+		m := meter.Meter{Key: "meter1", EventType: "event1", Aggregation: meter.MeterAggregationCount}
+
+		tests := []struct {
+			name      string
+			eventFrom *time.Time
+			chunkFrom *time.Time
+			wantBound *time.Time
+		}{
+			{name: "neither set means unbounded history", eventFrom: nil, chunkFrom: nil, wantBound: nil},
+			{name: "only event from", eventFrom: &earlier, chunkFrom: nil, wantBound: &earlier},
+			{name: "only chunk from", eventFrom: nil, chunkFrom: &earlier, wantBound: &earlier},
+			{name: "event from wins when later", eventFrom: &later, chunkFrom: &earlier, wantBound: &later},
+			{name: "chunk from wins when later", eventFrom: &earlier, chunkFrom: &later, wantBound: &later},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				meterWithFrom := m
+				meterWithFrom.EventFrom = tt.eventFrom
+
+				backfill := backfillFixture(meterWithFrom)
+				backfill.From = tt.chunkFrom
+
+				sql, err := backfill.toSQL()
+				require.NoError(t, err)
+
+				if tt.wantBound == nil {
+					assert.NotContains(t, sql, "om_events.time >= ")
+				} else {
+					assert.Contains(t, sql, fmt.Sprintf("om_events.time >= %d", tt.wantBound.Unix()))
+				}
+			})
+		}
+	})
+
+	t.Run("chunk upper bound applies alongside the settled bound", func(t *testing.T) {
+		chunkTo, err := time.Parse(time.RFC3339, "2025-02-01T00:00:00Z")
+		require.NoError(t, err)
+
+		backfill := backfillFixture(meter.Meter{Key: "meter1", EventType: "event1", Aggregation: meter.MeterAggregationCount})
+		backfill.To = &chunkTo
+
+		sql, err := backfill.toSQL()
+		require.NoError(t, err)
+		assert.Contains(t, sql, fmt.Sprintf("om_events.time < %d", chunkTo.Unix()))
+		assert.Contains(t, sql, "om_events.time < toStartOfInterval(now() - INTERVAL 3600 SECOND, INTERVAL 1 HOUR, 'UTC')")
+	})
+
+	t.Run("rejects reserved alias group by keys (G9)", func(t *testing.T) {
+		backfill := backfillFixture(meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationSum,
+			ValueProperty: lo.ToPtr("$.value"),
+			GroupBy:       map[string]string{"stored_at": "$.x"},
+		})
+
+		_, err := backfill.toSQL()
+		require.ErrorContains(t, err, "collide with reserved SQL aliases: stored_at")
+	})
+}
+
+func TestBackfillMonthChunks(t *testing.T) {
+	parse := func(s string) time.Time {
+		ts, err := time.Parse(time.RFC3339, s)
+		require.NoError(t, err)
+		return ts
+	}
+
+	t.Run("splits on utc month boundaries", func(t *testing.T) {
+		chunks := backfillMonthChunks(parse("2025-01-15T10:30:00Z"), parse("2025-03-02T00:00:00Z"))
+		assert.Equal(t, []backfillChunk{
+			{From: parse("2025-01-15T10:30:00Z"), To: parse("2025-02-01T00:00:00Z")},
+			{From: parse("2025-02-01T00:00:00Z"), To: parse("2025-03-01T00:00:00Z")},
+			{From: parse("2025-03-01T00:00:00Z"), To: parse("2025-03-02T00:00:00Z")},
+		}, chunks)
+	})
+
+	t.Run("range within one month is a single chunk", func(t *testing.T) {
+		chunks := backfillMonthChunks(parse("2025-01-05T00:00:00Z"), parse("2025-01-20T00:00:00Z"))
+		assert.Equal(t, []backfillChunk{
+			{From: parse("2025-01-05T00:00:00Z"), To: parse("2025-01-20T00:00:00Z")},
+		}, chunks)
+	})
+
+	t.Run("empty and inverted ranges yield no chunks", func(t *testing.T) {
+		at := parse("2025-01-05T00:00:00Z")
+		assert.Nil(t, backfillMonthChunks(at, at))
+		assert.Nil(t, backfillMonthChunks(at.Add(time.Hour), at))
+	})
+
+	t.Run("chunks always tile the range exactly", func(t *testing.T) {
+		// Property over a spread of awkward ranges: chunk edges must meet with no gap or
+		// overlap, ends must match the inputs, interior boundaries must be month starts.
+		ranges := [][2]time.Time{
+			{parse("2024-11-30T23:59:59Z"), parse("2025-03-01T00:00:01Z")},
+			{parse("2025-01-01T00:00:00Z"), parse("2026-01-01T00:00:00Z")},
+			{parse("2025-02-28T12:00:00Z"), parse("2025-03-01T00:00:00Z")},
+			{parse("2023-12-31T23:00:00-05:00"), parse("2024-02-15T08:00:00+09:00")},
+		}
+
+		for _, r := range ranges {
+			chunks := backfillMonthChunks(r[0], r[1])
+			require.NotEmpty(t, chunks)
+
+			assert.True(t, chunks[0].From.Equal(r[0].UTC()))
+			assert.True(t, chunks[len(chunks)-1].To.Equal(r[1].UTC()))
+
+			for i, chunk := range chunks {
+				require.True(t, chunk.From.Before(chunk.To))
+
+				if i > 0 {
+					require.True(t, chunks[i-1].To.Equal(chunk.From))
+					require.Equal(t, 1, chunk.From.Day())
+					require.Equal(t, 0, chunk.From.Hour())
+				}
+			}
+		}
+	})
+}

--- a/openmeter/streaming/clickhouse/meter_cache_backfill_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_backfill_test.go
@@ -63,7 +63,6 @@ func TestMeterCacheBackfillSQL(t *testing.T) {
 			{aggregation: meter.MeterAggregationMin, wantColumns: "created_at, min_value)"},
 			{aggregation: meter.MeterAggregationMax, wantColumns: "created_at, max_value)"},
 			{aggregation: meter.MeterAggregationUniqueCount, wantColumns: "created_at, uniq_state)"},
-			{aggregation: meter.MeterAggregationLatest, wantColumns: "created_at, latest_state)"},
 		}
 
 		for _, tt := range tests {

--- a/openmeter/streaming/clickhouse/meter_cache_ch_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_ch_test.go
@@ -1,0 +1,235 @@
+package clickhouse
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+)
+
+type MeterCacheCHTestSuite struct {
+	CHTestSuite
+}
+
+func TestMeterCacheClickHouse(t *testing.T) {
+	suite.Run(t, new(MeterCacheCHTestSuite))
+}
+
+// TestGeneratedSQLRoundTrip proves every generated statement is accepted by a real
+// ClickHouse and behaves per design: CREATE TABLE for both cache tables, one CREATE
+// MATERIALIZED VIEW and one backfill INSERT per aggregation against a shared target, a
+// SYSTEM REFRESH VIEW + SYSTEM WAIT VIEW round-trip, comment metadata surviving
+// system.tables, and newest-wins reads returning live-equal values with unsettled events
+// excluded.
+func (s *MeterCacheCHTestSuite) TestGeneratedSQLRoundTrip() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		eventsTable = "om_events"
+		namespace   = "cache-smoke"
+		eventType   = "api-calls"
+	)
+
+	s.NoError(s.ClickHouse.Exec(ctx, createEventsTable{Database: s.Database, EventsTableName: eventsTable}.toSQL()))
+	s.NoError(s.ClickHouse.Exec(ctx, createMeterCacheTable{Database: s.Database}.toSQL()))
+	s.NoError(s.ClickHouse.Exec(ctx, createMeterCacheInvalidationsTable{Database: s.Database}.toSQL()))
+
+	// given:
+	// - two settled events (2 and 7) in one fully settled hour bucket, stored just now so
+	//   the MV's dirty stored_at lookback picks their bucket up,
+	// - one unsettled event (100) younger than minimumUsageAge that must never be cached.
+	now := time.Now().UTC()
+	bucket := now.Add(-3 * time.Hour).Truncate(time.Hour)
+
+	newEvent := func(at time.Time, data string) streaming.RawEvent {
+		return streaming.RawEvent{
+			Namespace:  namespace,
+			ID:         ulid.Make().String(),
+			Type:       eventType,
+			Source:     "test-source",
+			Subject:    "subject-1",
+			Time:       at,
+			Data:       data,
+			IngestedAt: now,
+			StoredAt:   now,
+		}
+	}
+
+	insertSQL, insertArgs := InsertEventsQuery{
+		Database:        s.Database,
+		EventsTableName: eventsTable,
+		Events: []streaming.RawEvent{
+			newEvent(bucket.Add(5*time.Minute), `{"value": 2, "group1": "a"}`),
+			newEvent(bucket.Add(10*time.Minute), `{"value": 7, "group1": "a"}`),
+			newEvent(now.Add(-10*time.Minute), `{"value": 100, "group1": "a"}`),
+		},
+	}.ToSQL()
+	s.NoError(s.ClickHouse.Exec(ctx, insertSQL, insertArgs...))
+
+	aggregations := []meter.MeterAggregation{
+		meter.MeterAggregationSum,
+		meter.MeterAggregationCount,
+		meter.MeterAggregationAvg,
+		meter.MeterAggregationMin,
+		meter.MeterAggregationMax,
+		meter.MeterAggregationUniqueCount,
+		meter.MeterAggregationLatest,
+	}
+
+	meters := make(map[meter.MeterAggregation]meter.Meter, len(aggregations))
+	for _, aggregation := range aggregations {
+		m := meter.Meter{
+			Key:         fmt.Sprintf("meter-%s", aggregation),
+			EventType:   eventType,
+			Aggregation: aggregation,
+			GroupBy:     map[string]string{"group1": "$.group1"},
+		}
+		if aggregation != meter.MeterAggregationCount {
+			m.ValueProperty = lo.ToPtr("$.value")
+		}
+		meters[aggregation] = m
+	}
+
+	// when:
+	// - the generated MV is created (all seven share om_meter_cache as APPEND target),
+	// - the initial refresh triggered by CREATE is awaited so the explicit refresh below
+	//   cannot race it,
+	// - the generated backfill INSERT runs,
+	// - an explicit SYSTEM REFRESH VIEW + SYSTEM WAIT VIEW round-trip completes. The
+	//   backfill/refresh overlap is intentional: newest-wins must absorb it.
+	for _, aggregation := range aggregations {
+		mv := createMeterCacheMV{
+			Database:        s.Database,
+			EventsTableName: eventsTable,
+			Namespace:       namespace,
+			Meter:           meters[aggregation],
+			Grain:           CacheGrainHour,
+			RefreshInterval: 10 * time.Minute,
+			MinimumUsageAge: time.Hour,
+		}
+
+		createSQL, err := mv.toSQL()
+		s.NoError(err)
+		s.NoError(s.ClickHouse.Exec(ctx, createSQL), "create MV for %s", aggregation)
+
+		qualifiedView := getTableName(s.Database, mv.name())
+		s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+
+		backfillSQL, err := meterCacheBackfill{
+			Database:        s.Database,
+			EventsTableName: eventsTable,
+			Namespace:       namespace,
+			Meter:           meters[aggregation],
+			Grain:           CacheGrainHour,
+			MinimumUsageAge: time.Hour,
+		}.toSQL()
+		s.NoError(err)
+		s.NoError(s.ClickHouse.Exec(ctx, backfillSQL), "backfill for %s", aggregation)
+
+		s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM REFRESH VIEW "+qualifiedView))
+		s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+	}
+
+	// then:
+	// - all seven views are registered and none recorded an exception
+	var viewCount, exceptionCount uint64
+	s.NoError(s.ClickHouse.QueryRow(ctx,
+		"SELECT count(), countIf(exception != '') FROM system.view_refreshes WHERE database = ?", s.Database,
+	).Scan(&viewCount, &exceptionCount))
+	s.Equal(uint64(len(aggregations)), viewCount)
+	s.Equal(uint64(0), exceptionCount)
+
+	// then:
+	// - the COMMENT metadata written at CREATE survives the system.tables round-trip and
+	//   is unstamped (backfilled_at is a lifecycle stamp added later via MODIFY COMMENT)
+	for _, aggregation := range aggregations {
+		m := meters[aggregation]
+
+		var comment string
+		s.NoError(s.ClickHouse.QueryRow(ctx,
+			"SELECT comment FROM system.tables WHERE database = ? AND name = ?",
+			s.Database, mvName(namespace, meterHash(m, CacheGrainHour)),
+		).Scan(&comment))
+
+		metadata, err := parseMeterCacheMVMetadata(comment)
+		s.NoError(err)
+		s.Equal(m.Key, metadata.MeterKey)
+		s.Equal(eventType, metadata.EventType)
+		s.Equal(formatCacheHash(meterHash(m, CacheGrainHour)), metadata.MeterHash)
+		s.Nil(metadata.BackfilledAt)
+	}
+
+	// then:
+	// - despite backfill and refresh both appending the bucket, newest-wins (FINAL on
+	//   ReplacingMergeTree(created_at)) yields exactly one row per meter with the settled
+	//   events aggregated and the unsettled event excluded
+	cacheTable := getTableName(s.Database, meterCacheTableName)
+
+	requireSingleBucketRow := func(aggregation meter.MeterAggregation) {
+		var rowCount uint64
+		var windowstart time.Time
+		var groupBy []string
+		s.NoError(s.ClickHouse.QueryRow(ctx,
+			fmt.Sprintf("SELECT count(), any(windowstart), any(group_by) FROM %s FINAL WHERE namespace = ? AND meter_hash = ?", cacheTable),
+			namespace, meterHash(meters[aggregation], CacheGrainHour),
+		).Scan(&rowCount, &windowstart, &groupBy))
+		s.Equal(uint64(1), rowCount, "aggregation %s", aggregation)
+		s.True(windowstart.UTC().Equal(bucket), "aggregation %s: windowstart %s != %s", aggregation, windowstart, bucket)
+		s.Equal([]string{"a"}, groupBy)
+	}
+
+	scanDecimal := func(aggregation meter.MeterAggregation, column string) float64 {
+		var value NullDecimal
+		s.NoError(s.ClickHouse.QueryRow(ctx,
+			fmt.Sprintf("SELECT %s FROM %s FINAL WHERE namespace = ? AND meter_hash = ?", column, cacheTable),
+			namespace, meterHash(meters[aggregation], CacheGrainHour),
+		).Scan(&value))
+		s.True(value.Valid, "aggregation %s: %s is NULL", aggregation, column)
+		return value.Decimal.InexactFloat64()
+	}
+
+	for _, aggregation := range aggregations {
+		requireSingleBucketRow(aggregation)
+	}
+
+	s.Equal(float64(9), scanDecimal(meter.MeterAggregationSum, "sum_value"))
+	s.Equal(float64(2), scanDecimal(meter.MeterAggregationMin, "min_value"))
+	s.Equal(float64(7), scanDecimal(meter.MeterAggregationMax, "max_value"))
+	s.Equal(float64(9), scanDecimal(meter.MeterAggregationAvg, "sum_value"))
+
+	var countValue uint64
+	s.NoError(s.ClickHouse.QueryRow(ctx,
+		fmt.Sprintf("SELECT count_value FROM %s FINAL WHERE namespace = ? AND meter_hash = ?", cacheTable),
+		namespace, meterHash(meters[meter.MeterAggregationCount], CacheGrainHour),
+	).Scan(&countValue))
+	s.Equal(uint64(2), countValue)
+
+	var valueCount uint64
+	s.NoError(s.ClickHouse.QueryRow(ctx,
+		fmt.Sprintf("SELECT value_count FROM %s FINAL WHERE namespace = ? AND meter_hash = ?", cacheTable),
+		namespace, meterHash(meters[meter.MeterAggregationAvg], CacheGrainHour),
+	).Scan(&valueCount))
+	s.Equal(uint64(2), valueCount)
+
+	var uniqCount uint64
+	s.NoError(s.ClickHouse.QueryRow(ctx,
+		fmt.Sprintf("SELECT uniqExactMerge(uniq_state) FROM %s FINAL WHERE namespace = ? AND meter_hash = ?", cacheTable),
+		namespace, meterHash(meters[meter.MeterAggregationUniqueCount], CacheGrainHour),
+	).Scan(&uniqCount))
+	s.Equal(uint64(2), uniqCount)
+
+	var latest NullDecimal
+	s.NoError(s.ClickHouse.QueryRow(ctx,
+		fmt.Sprintf("SELECT argMaxMerge(latest_state) FROM %s FINAL WHERE namespace = ? AND meter_hash = ?", cacheTable),
+		namespace, meterHash(meters[meter.MeterAggregationLatest], CacheGrainHour),
+	).Scan(&latest))
+	s.True(latest.Valid)
+	s.Equal(float64(7), latest.Decimal.InexactFloat64())
+}

--- a/openmeter/streaming/clickhouse/meter_cache_ch_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_ch_test.go
@@ -77,6 +77,8 @@ func (s *MeterCacheCHTestSuite) TestGeneratedSQLRoundTrip() {
 	}.ToSQL()
 	s.NoError(s.ClickHouse.Exec(ctx, insertSQL, insertArgs...))
 
+	// LATEST is excluded from the cache entirely (meterCacheStaticReject): it has no MV, no
+	// combine form, and always reads live, so it is not part of this generation round-trip.
 	aggregations := []meter.MeterAggregation{
 		meter.MeterAggregationSum,
 		meter.MeterAggregationCount,
@@ -84,7 +86,6 @@ func (s *MeterCacheCHTestSuite) TestGeneratedSQLRoundTrip() {
 		meter.MeterAggregationMin,
 		meter.MeterAggregationMax,
 		meter.MeterAggregationUniqueCount,
-		meter.MeterAggregationLatest,
 	}
 
 	meters := make(map[meter.MeterAggregation]meter.Meter, len(aggregations))
@@ -102,7 +103,7 @@ func (s *MeterCacheCHTestSuite) TestGeneratedSQLRoundTrip() {
 	}
 
 	// when:
-	// - the generated MV is created (all seven share om_meter_cache as APPEND target),
+	// - the generated MV is created (all six share om_meter_cache as APPEND target),
 	// - the initial refresh triggered by CREATE is awaited so the explicit refresh below
 	//   cannot race it,
 	// - the generated backfill INSERT runs,
@@ -142,7 +143,7 @@ func (s *MeterCacheCHTestSuite) TestGeneratedSQLRoundTrip() {
 	}
 
 	// then:
-	// - all seven views are registered and none recorded an exception
+	// - all six views are registered and none recorded an exception
 	var viewCount, exceptionCount uint64
 	s.NoError(s.ClickHouse.QueryRow(ctx,
 		"SELECT count(), countIf(exception != '') FROM system.view_refreshes WHERE database = ?", s.Database,
@@ -228,14 +229,6 @@ func (s *MeterCacheCHTestSuite) TestGeneratedSQLRoundTrip() {
 		namespace, meterHash(meters[meter.MeterAggregationUniqueCount], CacheGrainHour),
 	).Scan(&uniqCount))
 	s.Equal(uint64(2), uniqCount)
-
-	var latest NullDecimal
-	s.NoError(s.ClickHouse.QueryRow(ctx,
-		fmt.Sprintf("SELECT argMaxMerge(latest_state) FROM %s FINAL WHERE namespace = ? AND meter_hash = ?", cacheTable),
-		namespace, meterHash(meters[meter.MeterAggregationLatest], CacheGrainHour),
-	).Scan(&latest))
-	s.True(latest.Valid)
-	s.Equal(float64(7), latest.Decimal.InexactFloat64())
 }
 
 // TestLateEventInvalidation drives events through Connector.BatchInsert against a real

--- a/openmeter/streaming/clickhouse/meter_cache_ch_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_ch_test.go
@@ -2,6 +2,7 @@ package clickhouse
 
 import (
 	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/openmeterio/openmeter/openmeter/meter"
+	progressmanageradapter "github.com/openmeterio/openmeter/openmeter/progressmanager/adapter"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 )
 
@@ -232,4 +234,153 @@ func (s *MeterCacheCHTestSuite) TestGeneratedSQLRoundTrip() {
 	).Scan(&latest))
 	s.True(latest.Valid)
 	s.Equal(float64(7), latest.Decimal.InexactFloat64())
+}
+
+// TestLateEventInvalidation drives events through Connector.BatchInsert against a real
+// ClickHouse and proves the invalidation hook contract: an on-time batch leaves no trace,
+// a late batch writes one server-timestamped marker per (namespace, event type) and
+// triggers the affected MV's refresh, and further late batches within the throttle window
+// still write markers but do not re-trigger.
+func (s *MeterCacheCHTestSuite) TestLateEventInvalidation() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		eventsTable = "om_events"
+		namespace   = "cache-invalidation"
+		eventType   = "api-calls"
+	)
+
+	// given:
+	// - a cache-enabled connector (New provisions the events table and both cache tables),
+	// - one SUM meter with its cache MV deployed and its CREATE-time refresh awaited so
+	//   later refresh accounting is unambiguous
+	connector, err := New(ctx, Config{
+		Logger:          slog.Default(),
+		ClickHouse:      s.ClickHouse,
+		Database:        s.Database,
+		EventsTableName: eventsTable,
+		ProgressManager: progressmanageradapter.NewMockProgressManager(),
+		Cache: CacheConfig{
+			Enabled:         true,
+			RefreshInterval: 10 * time.Minute,
+			MinimumUsageAge: time.Hour,
+			WindowSize:      CacheGrainHour,
+		},
+	})
+	s.NoError(err)
+
+	m := meter.Meter{
+		Key:           "meter-sum",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	mv := createMeterCacheMV{
+		Database:        s.Database,
+		EventsTableName: eventsTable,
+		Namespace:       namespace,
+		Meter:           m,
+		Grain:           CacheGrainHour,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+	}
+
+	createSQL, err := mv.toSQL()
+	s.NoError(err)
+	s.NoError(s.ClickHouse.Exec(ctx, createSQL))
+
+	qualifiedView := getTableName(s.Database, mv.name())
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+
+	now := time.Now().UTC()
+
+	newEvent := func(at time.Time, data string) streaming.RawEvent {
+		return streaming.RawEvent{
+			Namespace:  namespace,
+			ID:         ulid.Make().String(),
+			Type:       eventType,
+			Source:     "test-source",
+			Subject:    "subject-1",
+			Time:       at,
+			Data:       data,
+			IngestedAt: now,
+			StoredAt:   now,
+		}
+	}
+
+	invalidationsTable := getTableName(s.Database, meterCacheInvalidationsTableName)
+
+	// when:
+	// - a batch containing only an on-time event is inserted
+	s.NoError(connector.BatchInsert(ctx, []streaming.RawEvent{
+		newEvent(now.Add(-10*time.Minute), `{"value": 100}`),
+	}))
+
+	// then:
+	// - no marker is written and no refresh is triggered
+	var markerCount uint64
+	s.NoError(s.ClickHouse.QueryRow(ctx, "SELECT count() FROM "+invalidationsTable).Scan(&markerCount))
+	s.Equal(uint64(0), markerCount)
+	s.Equal(uint64(0), connector.cacheInvalidator.refreshTriggersFired.Load())
+
+	// when:
+	// - a batch with two late events in two different settled buckets is inserted
+	bucketA := now.Add(-4 * time.Hour).Truncate(time.Hour)
+	bucketB := now.Add(-3 * time.Hour).Truncate(time.Hour)
+
+	s.NoError(connector.BatchInsert(ctx, []streaming.RawEvent{
+		newEvent(bucketA.Add(5*time.Minute), `{"value": 2}`),
+		newEvent(bucketB.Add(10*time.Minute), `{"value": 7}`),
+	}))
+
+	// then:
+	// - exactly one marker spans both buckets, and its created_at was stamped by the
+	//   ClickHouse clock (the structural guarantee that the INSERT carries no client
+	//   timestamp is TestInsertInvalidationMarkersToSQL; here we prove the DEFAULT
+	//   actually produced a sane server-side value)
+	var (
+		markerNamespace, markerEventType string
+		windowLo, windowHi               time.Time
+		createdAt, serverNow             time.Time
+	)
+	s.NoError(s.ClickHouse.QueryRow(ctx,
+		"SELECT namespace, event_type, window_lo, window_hi, created_at, now64(3) FROM "+invalidationsTable,
+	).Scan(&markerNamespace, &markerEventType, &windowLo, &windowHi, &createdAt, &serverNow))
+	s.Equal(namespace, markerNamespace)
+	s.Equal(eventType, markerEventType)
+	s.True(windowLo.UTC().Equal(bucketA), "window_lo %s != %s", windowLo, bucketA)
+	s.True(windowHi.UTC().Equal(bucketB.Add(time.Hour)), "window_hi %s != %s", windowHi, bucketB.Add(time.Hour))
+	s.Less(serverNow.Sub(createdAt).Abs(), time.Minute)
+
+	// then:
+	// - exactly one best-effort refresh was triggered, with no failure counted
+	s.Equal(uint64(1), connector.cacheInvalidator.refreshTriggersFired.Load())
+	s.Equal(uint64(0), connector.cacheInvalidator.markerInsertFailures.Load())
+	s.Equal(uint64(0), connector.cacheInvalidator.refreshTriggerFailures.Load())
+
+	// then:
+	// - the triggered refresh converges the late buckets into the cache (both are settled
+	//   and carry a fresh stored_at, so the dirty filter picks them up)
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+
+	var cachedRows uint64
+	s.NoError(s.ClickHouse.QueryRow(ctx,
+		fmt.Sprintf("SELECT count() FROM %s FINAL WHERE namespace = ? AND meter_hash = ?", getTableName(s.Database, meterCacheTableName)),
+		namespace, meterHash(m, CacheGrainHour),
+	).Scan(&cachedRows))
+	s.Equal(uint64(2), cachedRows)
+
+	// when:
+	// - another late batch arrives within the throttle window
+	s.NoError(connector.BatchInsert(ctx, []streaming.RawEvent{
+		newEvent(bucketB.Add(20*time.Minute), `{"value": 1}`),
+	}))
+
+	// then:
+	// - markers are never throttled (correctness), refresh triggers are (best-effort)
+	s.NoError(s.ClickHouse.QueryRow(ctx, "SELECT count() FROM "+invalidationsTable).Scan(&markerCount))
+	s.Equal(uint64(2), markerCount)
+	s.Equal(uint64(1), connector.cacheInvalidator.refreshTriggersFired.Load())
 }

--- a/openmeter/streaming/clickhouse/meter_cache_ch_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_ch_test.go
@@ -1,6 +1,8 @@
 package clickhouse
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"log/slog"
 	"testing"
@@ -383,4 +385,284 @@ func (s *MeterCacheCHTestSuite) TestLateEventInvalidation() {
 	s.NoError(s.ClickHouse.QueryRow(ctx, "SELECT count() FROM "+invalidationsTable).Scan(&markerCount))
 	s.Equal(uint64(2), markerCount)
 	s.Equal(uint64(1), connector.cacheInvalidator.refreshTriggersFired.Load())
+}
+
+// deployMeterCacheMV provisions one meter's cache the way the WP6 reconciler will:
+// CREATE MATERIALIZED VIEW, wait for its initial refresh, run the backfill INSERT,
+// force one more refresh so view_refreshes reflects a post-backfill success, and only
+// then stamp backfilled_at (G3) via MODIFY COMMENT.
+func (s *MeterCacheCHTestSuite) deployMeterCacheMV(ctx context.Context, mv createMeterCacheMV) {
+	createSQL, err := mv.toSQL()
+	s.NoError(err)
+	s.NoError(s.ClickHouse.Exec(ctx, createSQL))
+
+	qualifiedView := getTableName(s.Database, mv.name())
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+
+	backfillSQL, err := meterCacheBackfill{
+		Database:        mv.Database,
+		EventsTableName: mv.EventsTableName,
+		Namespace:       mv.Namespace,
+		Meter:           mv.Meter,
+		Grain:           mv.Grain,
+		MinimumUsageAge: mv.MinimumUsageAge,
+	}.toSQL()
+	s.NoError(err)
+	s.NoError(s.ClickHouse.Exec(ctx, backfillSQL))
+
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM REFRESH VIEW "+qualifiedView))
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+
+	metadata, err := mv.metadata()
+	s.NoError(err)
+	metadata.BackfilledAt = lo.ToPtr(time.Now().UTC().Truncate(time.Second))
+
+	comment, err := metadata.marshal()
+	s.NoError(err)
+	s.NoError(s.ClickHouse.Exec(ctx, fmt.Sprintf("ALTER TABLE %s MODIFY COMMENT %s", qualifiedView, sqlStringLiteral(comment))))
+}
+
+// TestCachedReadParity is the WP5 parity spot-check: for SUM, UNIQUE_COUNT and AVG, a
+// cache-served Connector.QueryMeter must return exactly the rows the live path returns —
+// windowed and total, on-grid and off-grid, UTC and a whole-hour-offset timezone — and a
+// poison write proves the cached rows really came from the cache leg, not from a silent
+// live fallback (the full aggregation × window × filter matrix lands with WP7).
+//
+// Watched RED with the guard reverted: short-circuiting queryMeterCached to
+// `return nil, false` (forcing the silent-fallback failure mode this test exists to
+// catch) fails the first cached subtest on the "serving live" log assertion.
+func (s *MeterCacheCHTestSuite) TestCachedReadParity() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		eventsTable = "om_events"
+		namespace   = "cache-parity"
+		eventType   = "api-calls"
+	)
+
+	// The connector logs "serving live" on every cache fallback path; capturing the logs
+	// lets each cached query assert it was actually served from the cache, so a silently
+	// falling-back gate cannot make the parity checks pass trivially.
+	var logBuffer bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	connector, err := New(ctx, Config{
+		Logger:                 logger,
+		ClickHouse:             s.ClickHouse,
+		Database:               s.Database,
+		EventsTableName:        eventsTable,
+		EnableDecimalPrecision: true,
+		ProgressManager:        progressmanageradapter.NewMockProgressManager(),
+		Cache: CacheConfig{
+			Enabled:         true,
+			RefreshInterval: 10 * time.Minute,
+			MinimumUsageAge: time.Hour,
+			WindowSize:      CacheGrainHour,
+		},
+	})
+	s.NoError(err)
+
+	newYork, err := time.LoadLocation("America/New_York")
+	s.NoError(err)
+
+	// given:
+	// - settled events in two fully settled hour buckets (bucketOld, bucketMid) covering
+	//   two subjects, two dimension values, a JSON-null value, a missing value property,
+	//   and the value 7 repeated across buckets and later in the live tail (the
+	//   UNIQUE_COUNT cross-leg dedupe case),
+	// - one event between the cache horizon and the freshness cutoff (post-leg only),
+	// - two events in the always-live tail.
+	now := time.Now().UTC()
+	bucketOld := now.Add(-5 * time.Hour).Truncate(time.Hour)
+	bucketMid := now.Add(-4 * time.Hour).Truncate(time.Hour)
+
+	newEvent := func(subject string, at time.Time, data string) streaming.RawEvent {
+		return streaming.RawEvent{
+			Namespace:  namespace,
+			ID:         ulid.Make().String(),
+			Type:       eventType,
+			Source:     "test-source",
+			Subject:    subject,
+			Time:       at,
+			Data:       data,
+			IngestedAt: now,
+			StoredAt:   now,
+		}
+	}
+
+	// Inserted directly (not through BatchInsert) so no invalidation markers are written:
+	// this test exercises the clean read path, not marker healing.
+	insertSQL, insertArgs := InsertEventsQuery{
+		Database:        s.Database,
+		EventsTableName: eventsTable,
+		Events: []streaming.RawEvent{
+			newEvent("subject-1", bucketOld.Add(5*time.Minute), `{"value": 2, "group1": "a"}`),
+			newEvent("subject-1", bucketOld.Add(10*time.Minute), `{"value": 7, "group1": "a"}`),
+			newEvent("subject-2", bucketOld.Add(20*time.Minute), `{"value": 5, "group1": "b"}`),
+			newEvent("subject-1", bucketOld.Add(25*time.Minute), `{"value": null, "group1": "b"}`),
+			newEvent("subject-2", bucketOld.Add(30*time.Minute), `{"group1": "a"}`),
+			newEvent("subject-1", bucketMid.Add(5*time.Minute), `{"value": 7, "group1": "a"}`),
+			newEvent("subject-2", bucketMid.Add(15*time.Minute), `{"value": 3.5, "group1": "b"}`),
+			newEvent("subject-1", bucketMid.Add(40*time.Minute), `{"value": 1, "group1": "a"}`),
+			newEvent("subject-1", now.Add(-90*time.Minute), `{"value": 11, "group1": "a"}`),
+			newEvent("subject-1", now.Add(-30*time.Minute), `{"value": 13, "group1": "a"}`),
+			newEvent("subject-2", now.Add(-10*time.Minute), `{"value": 7, "group1": "b"}`),
+		},
+	}.ToSQL()
+	s.NoError(s.ClickHouse.Exec(ctx, insertSQL, insertArgs...))
+
+	aggregations := []meter.MeterAggregation{
+		meter.MeterAggregationSum,
+		meter.MeterAggregationUniqueCount,
+		meter.MeterAggregationAvg,
+	}
+
+	meters := make(map[meter.MeterAggregation]meter.Meter, len(aggregations))
+	for _, aggregation := range aggregations {
+		meters[aggregation] = meter.Meter{
+			Key:           fmt.Sprintf("meter-%s", aggregation),
+			EventType:     eventType,
+			Aggregation:   aggregation,
+			ValueProperty: lo.ToPtr("$.value"),
+			GroupBy:       map[string]string{"group1": "$.group1"},
+		}
+
+		s.deployMeterCacheMV(ctx, createMeterCacheMV{
+			Database:        s.Database,
+			EventsTableName: eventsTable,
+			Namespace:       namespace,
+			Meter:           meters[aggregation],
+			Grain:           CacheGrainHour,
+			RefreshInterval: 10 * time.Minute,
+			MinimumUsageAge: time.Hour,
+		})
+	}
+
+	windowSizeHour := meter.WindowSizeHour
+	windowSizeDay := meter.WindowSizeDay
+
+	fromOnGrid := bucketOld
+	toOnGrid := now.Truncate(time.Hour).Add(time.Hour)
+	fromOffGrid := bucketOld.Add(7 * time.Minute)
+	toOffGrid := now.Add(-3 * time.Minute)
+
+	queryCases := []struct {
+		name   string
+		params streaming.QueryParams
+	}{
+		{
+			name: "windowed hour utc on grid",
+			params: streaming.QueryParams{
+				From:       &fromOnGrid,
+				To:         &toOnGrid,
+				WindowSize: &windowSizeHour,
+				GroupBy:    []string{"subject", "group1"},
+			},
+		},
+		{
+			name: "windowed hour utc off grid",
+			params: streaming.QueryParams{
+				From:       &fromOffGrid,
+				To:         &toOffGrid,
+				WindowSize: &windowSizeHour,
+				GroupBy:    []string{"subject", "group1"},
+			},
+		},
+		{
+			name: "windowed day new york off grid",
+			params: streaming.QueryParams{
+				From:           &fromOnGrid,
+				To:             &toOffGrid,
+				WindowSize:     &windowSizeDay,
+				WindowTimeZone: newYork,
+				GroupBy:        []string{"subject"},
+			},
+		},
+		{
+			name: "total off grid",
+			params: streaming.QueryParams{
+				From: &fromOffGrid,
+				To:   &toOffGrid,
+			},
+		},
+		{
+			name: "total on grid with subject filter",
+			params: streaming.QueryParams{
+				From:          &fromOnGrid,
+				To:            &toOnGrid,
+				FilterSubject: []string{"subject-1"},
+			},
+		},
+	}
+
+	queryBothPaths := func(m meter.Meter, params streaming.QueryParams) ([]meter.MeterQueryRow, []meter.MeterQueryRow) {
+		params.Cachable = false
+		live, err := connector.QueryMeter(ctx, namespace, m, params)
+		s.NoError(err)
+
+		logBuffer.Reset()
+
+		params.Cachable = true
+		cached, err := connector.QueryMeter(ctx, namespace, m, params)
+		s.NoError(err)
+		s.NotContains(logBuffer.String(), "serving live", "cached query fell back to the live path")
+
+		return live, cached
+	}
+
+	// when/then:
+	// - each aggregation × query shape returns byte-equal rows on both paths, with the
+	//   cached run proven not to have fallen back
+	for _, aggregation := range aggregations {
+		for _, queryCase := range queryCases {
+			s.Run(fmt.Sprintf("%s %s", aggregation, queryCase.name), func() {
+				live, cached := queryBothPaths(meters[aggregation], queryCase.params)
+
+				s.NotEmpty(live, "parity would be trivial on an empty result")
+				s.ElementsMatch(live, cached)
+			})
+		}
+	}
+
+	// given:
+	// - a late event written into a settled, cached bucket bypassing BatchInsert (no
+	//   invalidation marker) and with no refresh afterwards
+	poisonSQL, poisonArgs := InsertEventsQuery{
+		Database:        s.Database,
+		EventsTableName: eventsTable,
+		Events: []streaming.RawEvent{
+			newEvent("subject-1", bucketOld.Add(40*time.Minute), `{"value": 1000, "group1": "a"}`),
+		},
+	}.ToSQL()
+	s.NoError(s.ClickHouse.Exec(ctx, poisonSQL, poisonArgs...))
+
+	// then:
+	// - the live path sees the poison, the cached path serves the stale cached bucket.
+	//   This is the proof the cache leg produced the parity rows above: had the cached
+	//   path silently served live, both paths would now agree and the inequality below
+	//   would go red.
+	sumParams := streaming.QueryParams{
+		From:       &fromOnGrid,
+		To:         &toOnGrid,
+		WindowSize: &windowSizeHour,
+		GroupBy:    []string{"subject", "group1"},
+	}
+
+	live, cached := queryBothPaths(meters[meter.MeterAggregationSum], sumParams)
+
+	findPoisonedBucketValue := func(rows []meter.MeterQueryRow) float64 {
+		for _, row := range rows {
+			if row.WindowStart.Equal(bucketOld) && lo.FromPtr(row.Subject) == "subject-1" && lo.FromPtr(row.GroupBy["group1"]) == "a" {
+				return row.Value
+			}
+		}
+
+		s.Failf("poisoned bucket row not found", "rows: %v", rows)
+
+		return 0
+	}
+
+	s.Equal(float64(1009), findPoisonedBucketValue(live))
+	s.Equal(float64(9), findPoisonedBucketValue(cached))
 }

--- a/openmeter/streaming/clickhouse/meter_cache_credit_ch_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_credit_ch_test.go
@@ -1,0 +1,164 @@
+package clickhouse
+
+import (
+	"context"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/credit/balance"
+	"github.com/openmeterio/openmeter/openmeter/credit/grant"
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/timeutil"
+)
+
+// TestCreditUniqueCountThroughCache drives the real credit usage querier
+// (balance.NewUsageQuerier — the exact code grant burn-down uses) against a cache-enabled
+// connector and proves, for the UNIQUE_COUNT aggregation whose inexactness would be
+// billing-visible:
+//
+//   - the subtraction path (two cached-leg queries whose results are subtracted) matches
+//     a live-forced run of the same subtraction exactly,
+//   - a poison unique value bypassing BatchInsert stays invisible to the querier (the
+//     proof its reads came from the cache leg, not a silent live fallback),
+//   - a marker + refresh + wait converges the querier to the live answer.
+func (s *MeterCacheCHTestSuite) TestCreditUniqueCountThroughCache() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-credit-uniq"
+		eventType = "api-calls"
+	)
+
+	c := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	m := meter.Meter{
+		Key:           "meter-uniq",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationUniqueCount,
+		ValueProperty: lo.ToPtr("$.user"),
+	}
+
+	now := time.Now().UTC()
+	periodStart := now.Add(-6 * time.Hour).Truncate(time.Hour)
+	cachedBucket := now.Add(-4 * time.Hour).Truncate(time.Hour)
+
+	// given:
+	// - two unique users in a fully settled (cached) bucket, one of them repeated (uniq
+	//   must not double count), and a third unique user in the always-live tail
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", cachedBucket.Add(5*time.Minute), `{"user": "u1"}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-1", cachedBucket.Add(10*time.Minute), `{"user": "u2"}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-1", cachedBucket.Add(15*time.Minute), `{"user": "u1"}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-1", now.Add(-30*time.Minute), `{"user": "u3"}`, now),
+	)
+
+	mv := createMeterCacheMV{
+		Database:        s.Database,
+		EventsTableName: e2eEventsTable,
+		Namespace:       namespace,
+		Meter:           m,
+		Grain:           CacheGrainHour,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+	}
+	s.deployMeterCacheMV(ctx, mv)
+
+	newUsageQuerier := func(connector streaming.Connector) balance.UsageQuerier {
+		return balance.NewUsageQuerier(balance.UsageQuerierConfig{
+			StreamingConnector: connector,
+			DescribeOwner: func(ctx context.Context, id models.NamespacedID) (grant.Owner, error) {
+				return grant.Owner{
+					NamespacedID: id,
+					Meter:        m,
+				}, nil
+			},
+			GetDefaultParams: func(ctx context.Context, ownerID models.NamespacedID) (streaming.QueryParams, error) {
+				return streaming.QueryParams{
+					FilterSubject: []string{"subject-1"},
+				}, nil
+			},
+			GetUsagePeriodStartAt: func(ctx context.Context, ownerID models.NamespacedID, at time.Time) (time.Time, error) {
+				return periodStart, nil
+			},
+		})
+	}
+
+	// QueryUsage opts into the cache itself (the WP7 credit call site sets Cachable=true
+	// on every read), so the ground truth cannot be produced by the same querier with a
+	// flag flipped — it comes from an identical querier bound to a cache-disabled
+	// connector, whose gate rejects every query into the untouched live path.
+	cachedQuerier := newUsageQuerier(c.Connector)
+	liveQuerier := newUsageQuerier(s.newCacheConnector(ctx, CacheConfig{}).Connector)
+
+	ownerID := models.NamespacedID{Namespace: namespace, ID: "owner-1"}
+
+	queryBothUsage := func(period timeutil.ClosedPeriod) (liveUsage, cachedUsage float64) {
+		liveUsage, err := liveQuerier.QueryUsage(ctx, ownerID, period)
+		s.NoError(err)
+
+		c.logs.Reset()
+
+		cachedUsage, err = cachedQuerier.QueryUsage(ctx, ownerID, period)
+		s.NoError(err)
+		s.NotContains(c.logs.String(), "serving live", "credit querier fell back to the live path")
+
+		return liveUsage, cachedUsage
+	}
+
+	// then:
+	// - the two-leg subtraction (period.From after the usage period start forces both the
+	//   uniq-at-To and uniq-at-From queries) matches live exactly: u1..u3 by To, u1+u2 by
+	//   From → 1
+	subtractionPeriod := timeutil.ClosedPeriod{From: now.Add(-2 * time.Hour), To: now}
+
+	liveUsage, cachedUsage := queryBothUsage(subtractionPeriod)
+	s.Equal(float64(1), liveUsage)
+	s.Equal(liveUsage, cachedUsage)
+
+	// given:
+	// - a poison unique user lands in the cached bucket bypassing BatchInsert (no marker,
+	//   no refresh)
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", cachedBucket.Add(20*time.Minute), `{"user": "u4"}`, time.Now().UTC()),
+	)
+
+	// then:
+	// - a single-leg usage read over the whole period (period.From equals the usage
+	//   period start, so only the uniq-at-To query runs) serves the stale cached state:
+	//   live counts u4, cached does not — the proof the querier's reads are cache-served
+	fullPeriod := timeutil.ClosedPeriod{From: periodStart, To: now}
+
+	liveUsage, cachedUsage = queryBothUsage(fullPeriod)
+	s.Equal(float64(4), liveUsage)
+	s.Equal(float64(3), cachedUsage)
+
+	// when:
+	// - the marker the ingestion hook would have written lands together with a refresh
+	//   (modeling the BatchInsert direction through the credit path)
+	windows, err := lateEventWindows([]streaming.RawEvent{
+		rawCacheTestEvent(namespace, eventType, "subject-1", cachedBucket.Add(20*time.Minute), `{"user": "u4"}`, time.Now().UTC()),
+	}, time.Now().UTC(), time.Hour, CacheGrainHour)
+	s.NoError(err)
+	s.Len(windows, 1)
+
+	markerSQL, markerArgs := insertInvalidationMarkers{Database: s.Database, Windows: windows}.toSQL()
+	s.NoError(s.ClickHouse.Exec(ctx, markerSQL, markerArgs...))
+
+	s.refreshViewUntilMarkersHealed(ctx, mv.name())
+
+	// then:
+	// - the refresh healed the marker and recomputed the bucket: the cached usage
+	//   converges to live, u4 included
+	liveUsage, cachedUsage = queryBothUsage(fullPeriod)
+	s.Equal(float64(4), liveUsage)
+	s.Equal(liveUsage, cachedUsage)
+}

--- a/openmeter/streaming/clickhouse/meter_cache_ddl.go
+++ b/openmeter/streaming/clickhouse/meter_cache_ddl.go
@@ -65,7 +65,6 @@ func (d createMeterCacheTable) toSQL() string {
 	// and ClickHouse rejects inserting a Nullable-argument aggregate state into a
 	// non-Nullable-argument state column (verified on 25.12: CANNOT_CONVERT_TYPE).
 	sb.Define("uniq_state", "AggregateFunction(uniqExact, Nullable(String))")
-	sb.Define("latest_state", "AggregateFunction(argMax, Nullable(Decimal128(19)), DateTime)")
 	sb.SQL("ENGINE = ReplacingMergeTree(created_at)")
 	sb.SQL("ORDER BY (namespace, meter_key, meter_hash, windowstart, subject, group_by)")
 

--- a/openmeter/streaming/clickhouse/meter_cache_ddl.go
+++ b/openmeter/streaming/clickhouse/meter_cache_ddl.go
@@ -1,0 +1,105 @@
+package clickhouse
+
+import (
+	"github.com/huandu/go-sqlbuilder"
+)
+
+const (
+	// meterCacheTableName is the shared rollup table all per-meter refreshable
+	// materialized views append into.
+	meterCacheTableName = "om_meter_cache"
+	// meterCacheInvalidationsTableName holds late-event invalidation markers the reader
+	// consults before trusting cached buckets.
+	meterCacheInvalidationsTableName = "om_meter_cache_invalidations"
+	// meterCacheMVNamePrefix is the naming prefix of every generated cache MV. The
+	// lifecycle reconciler discovers the actual MV set by scanning system.tables for this
+	// prefix, so all cache MV names must be produced by mvName.
+	meterCacheMVNamePrefix = "om_meter_cache_mv_"
+)
+
+// createMeterCacheTable creates the shared meter cache rollup table.
+//
+// The engine is ReplacingMergeTree(created_at) on purpose: refreshes and backfills
+// re-append full recomputations of dirty buckets, and readers pick the newest version per
+// bucket (argMax over created_at), which makes overlapping backfills, retried refreshes,
+// and late-event recomputes idempotent. An AggregatingMergeTree target would silently
+// double-count re-appended additive columns instead.
+//
+// There is deliberately no TTL on created_at: refreshes only re-append dirty buckets, so
+// settled rows keep their old versions forever; a version TTL would eventually delete the
+// only remaining copy of valid data. Orphaned meter shapes are garbage collected by the
+// lifecycle reconciler instead.
+type createMeterCacheTable struct {
+	Database string
+}
+
+func (d createMeterCacheTable) toSQL() string {
+	sb := sqlbuilder.ClickHouse.NewCreateTableBuilder()
+	sb.CreateTable(getTableName(d.Database, meterCacheTableName))
+	sb.IfNotExists()
+	sb.Define("namespace", "String")
+	sb.Define("meter_key", "LowCardinality(String)")
+	// meter_hash identifies the cached shape (event type, aggregation, value property,
+	// group-by dimensions, grain). Every read filters on it, so rows written for an old
+	// shape or grain are never co-read with rows for the current one.
+	sb.Define("meter_hash", "UInt64")
+	sb.Define("windowstart", "DateTime")
+	sb.Define("subject", "String")
+	// The meter's configured group-by dimension values in sorted key order. The key list
+	// is part of meter_hash, so positional decoding on the read side is unambiguous.
+	sb.Define("group_by", "Array(String)")
+	sb.Define("created_at", "DateTime64(3)")
+	// sum/min/max are Nullable so a bucket whose values are all JSON null stays NULL and
+	// is dropped on read exactly like the live query drops it; non-null zero would
+	// fabricate usage. The counts are non-null: an all-null bucket legitimately counts 0.
+	sb.Define("sum_value", "Nullable(Decimal128(19))")
+	sb.Define("count_value", "UInt64")
+	// value_count is the non-null value count, the AVG denominator. It is distinct from
+	// count_value (count of all events) because events missing the value property must
+	// not deflate the average.
+	sb.Define("value_count", "UInt64")
+	sb.Define("min_value", "Nullable(Decimal128(19))")
+	sb.Define("max_value", "Nullable(Decimal128(19))")
+	// The state parameter is Nullable(String), not String: the shared value expression
+	// (rawStringValueExpr) yields Nullable(String) so explicit JSON nulls are skipped,
+	// and ClickHouse rejects inserting a Nullable-argument aggregate state into a
+	// non-Nullable-argument state column (verified on 25.12: CANNOT_CONVERT_TYPE).
+	sb.Define("uniq_state", "AggregateFunction(uniqExact, Nullable(String))")
+	sb.Define("latest_state", "AggregateFunction(argMax, Nullable(Decimal128(19)), DateTime)")
+	sb.SQL("ENGINE = ReplacingMergeTree(created_at)")
+	sb.SQL("ORDER BY (namespace, meter_key, meter_hash, windowstart, subject, group_by)")
+
+	sql, _ := sb.Build()
+	return sql
+}
+
+// createMeterCacheInvalidationsTable creates the late-event invalidation marker table.
+//
+// created_at is a server-side DEFAULT, never a client-supplied timestamp: the reader's
+// heal rule compares marker time against refresh times reported by ClickHouse
+// (system.view_refreshes), and mixing an app clock into one side of that comparison would
+// let clock skew mark stale buckets as healed. Writers must therefore omit created_at on
+// insert.
+//
+// Markers only matter until a refresh provably re-covered their window, so a 7 day TTL
+// bounds the table; gaps older than that are repaired by the reconciler, not by markers.
+type createMeterCacheInvalidationsTable struct {
+	Database string
+}
+
+func (d createMeterCacheInvalidationsTable) toSQL() string {
+	sb := sqlbuilder.ClickHouse.NewCreateTableBuilder()
+	sb.CreateTable(getTableName(d.Database, meterCacheInvalidationsTableName))
+	sb.IfNotExists()
+	sb.Define("namespace", "String")
+	sb.Define("event_type", "LowCardinality(String)")
+	sb.Define("window_lo", "DateTime")
+	sb.Define("window_hi", "DateTime")
+	sb.Define("created_at", "DateTime64(3) DEFAULT now64(3)")
+	sb.SQL("ENGINE = MergeTree")
+	sb.SQL("ORDER BY (namespace, event_type, window_lo)")
+	sb.SQL("TTL toDateTime(created_at) + toIntervalDay(7)")
+
+	sql, _ := sb.Build()
+	return sql
+}

--- a/openmeter/streaming/clickhouse/meter_cache_ddl_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_ddl_test.go
@@ -1,0 +1,93 @@
+package clickhouse
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	progressmanager "github.com/openmeterio/openmeter/openmeter/progressmanager/adapter"
+)
+
+func TestCreateMeterCacheTableSQL(t *testing.T) {
+	assert.Equal(t,
+		"CREATE TABLE IF NOT EXISTS openmeter.om_meter_cache (namespace String, meter_key LowCardinality(String), meter_hash UInt64, windowstart DateTime, subject String, group_by Array(String), created_at DateTime64(3), sum_value Nullable(Decimal128(19)), count_value UInt64, value_count UInt64, min_value Nullable(Decimal128(19)), max_value Nullable(Decimal128(19)), uniq_state AggregateFunction(uniqExact, Nullable(String)), latest_state AggregateFunction(argMax, Nullable(Decimal128(19)), DateTime)) ENGINE = ReplacingMergeTree(created_at) ORDER BY (namespace, meter_key, meter_hash, windowstart, subject, group_by)",
+		createMeterCacheTable{Database: "openmeter"}.toSQL(),
+	)
+}
+
+func TestCreateMeterCacheInvalidationsTableSQL(t *testing.T) {
+	assert.Equal(t,
+		"CREATE TABLE IF NOT EXISTS openmeter.om_meter_cache_invalidations (namespace String, event_type LowCardinality(String), window_lo DateTime, window_hi DateTime, created_at DateTime64(3) DEFAULT now64(3)) ENGINE = MergeTree ORDER BY (namespace, event_type, window_lo) TTL toDateTime(created_at) + toIntervalDay(7)",
+		createMeterCacheInvalidationsTable{Database: "openmeter"}.toSQL(),
+	)
+}
+
+func TestConnectorCreatesMeterCacheTables(t *testing.T) {
+	newConfig := func(mockCH *MockClickHouse) Config {
+		return Config{
+			Logger:          slog.Default(),
+			ClickHouse:      mockCH,
+			Database:        "testdb",
+			EventsTableName: "events",
+			ProgressManager: progressmanager.NewMockProgressManager(),
+		}
+	}
+
+	execWithPrefix := func(prefix string) interface{} {
+		return mock.MatchedBy(func(sql string) bool {
+			return strings.HasPrefix(sql, prefix)
+		})
+	}
+
+	enabledCache := CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	}
+
+	t.Run("cache enabled provisions both cache tables", func(t *testing.T) {
+		mockCH := NewMockClickHouse()
+		mockCH.On("Exec", mock.Anything, execWithPrefix("CREATE TABLE IF NOT EXISTS testdb.events"), mock.Anything).Return(nil).Once()
+		mockCH.On("Exec", mock.Anything, execWithPrefix("CREATE TABLE IF NOT EXISTS testdb.om_meter_cache ("), mock.Anything).Return(nil).Once()
+		mockCH.On("Exec", mock.Anything, execWithPrefix("CREATE TABLE IF NOT EXISTS testdb.om_meter_cache_invalidations"), mock.Anything).Return(nil).Once()
+
+		config := newConfig(mockCH)
+		config.Cache = enabledCache
+
+		_, err := New(t.Context(), config)
+		require.NoError(t, err)
+
+		mockCH.AssertExpectations(t)
+		mockCH.AssertNumberOfCalls(t, "Exec", 3)
+	})
+
+	t.Run("cache disabled keeps a zero-footprint schema", func(t *testing.T) {
+		mockCH := NewMockClickHouse()
+		mockCH.On("Exec", mock.Anything, execWithPrefix("CREATE TABLE IF NOT EXISTS testdb.events"), mock.Anything).Return(nil).Once()
+
+		_, err := New(t.Context(), newConfig(mockCH))
+		require.NoError(t, err)
+
+		mockCH.AssertExpectations(t)
+		mockCH.AssertNumberOfCalls(t, "Exec", 1)
+	})
+
+	t.Run("SkipCreateTables wins over cache enabled", func(t *testing.T) {
+		mockCH := NewMockClickHouse()
+
+		config := newConfig(mockCH)
+		config.SkipCreateTables = true
+		config.Cache = enabledCache
+
+		_, err := New(t.Context(), config)
+		require.NoError(t, err)
+
+		mockCH.AssertNumberOfCalls(t, "Exec", 0)
+	})
+}

--- a/openmeter/streaming/clickhouse/meter_cache_ddl_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_ddl_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCreateMeterCacheTableSQL(t *testing.T) {
 	assert.Equal(t,
-		"CREATE TABLE IF NOT EXISTS openmeter.om_meter_cache (namespace String, meter_key LowCardinality(String), meter_hash UInt64, windowstart DateTime, subject String, group_by Array(String), created_at DateTime64(3), sum_value Nullable(Decimal128(19)), count_value UInt64, value_count UInt64, min_value Nullable(Decimal128(19)), max_value Nullable(Decimal128(19)), uniq_state AggregateFunction(uniqExact, Nullable(String)), latest_state AggregateFunction(argMax, Nullable(Decimal128(19)), DateTime)) ENGINE = ReplacingMergeTree(created_at) ORDER BY (namespace, meter_key, meter_hash, windowstart, subject, group_by)",
+		"CREATE TABLE IF NOT EXISTS openmeter.om_meter_cache (namespace String, meter_key LowCardinality(String), meter_hash UInt64, windowstart DateTime, subject String, group_by Array(String), created_at DateTime64(3), sum_value Nullable(Decimal128(19)), count_value UInt64, value_count UInt64, min_value Nullable(Decimal128(19)), max_value Nullable(Decimal128(19)), uniq_state AggregateFunction(uniqExact, Nullable(String))) ENGINE = ReplacingMergeTree(created_at) ORDER BY (namespace, meter_key, meter_hash, windowstart, subject, group_by)",
 		createMeterCacheTable{Database: "openmeter"}.toSQL(),
 	)
 }

--- a/openmeter/streaming/clickhouse/meter_cache_e2e_ch_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_e2e_ch_test.go
@@ -143,7 +143,10 @@ func (s *MeterCacheCHTestSuite) refreshViewUntilMarkersHealed(ctx context.Contex
 }
 
 // allCacheTestAggregations is every meter aggregation the cache supports; the parity
-// matrix runs each query shape over all of them.
+// matrix runs each query shape over all of them. LATEST is excluded entirely (see
+// meterCacheStaticReject): it only ever needs the single newest value in the queried
+// window, so there is no re-aggregation of settled history for the cache to save, and it
+// always takes the live path — there is no cached leg for it to have parity with.
 var allCacheTestAggregations = []meter.MeterAggregation{
 	meter.MeterAggregationSum,
 	meter.MeterAggregationCount,
@@ -151,7 +154,6 @@ var allCacheTestAggregations = []meter.MeterAggregation{
 	meter.MeterAggregationMin,
 	meter.MeterAggregationMax,
 	meter.MeterAggregationUniqueCount,
-	meter.MeterAggregationLatest,
 }
 
 // deployCacheTestMeters creates one meter per aggregation (two JSON dimensions, value
@@ -196,7 +198,9 @@ func (s *MeterCacheCHTestSuite) deployCacheTestMeters(ctx context.Context, names
 // mid-hour from, mid-hour to, both off-grid), group-by shapes (none, subject, two JSON
 // dimensions, subset), filters (FilterSubject, FilterGroupBy $eq/$ne/$in), timezones (UTC
 // and America/New_York), and data shapes (all-null buckets, empty buckets, missing value
-// property, duplicate values across the cache/live boundary, null-latest).
+// property, duplicate values across the cache/live boundary). LATEST is not part of this
+// matrix: it is excluded from the cache entirely and always reads live (see
+// allCacheTestAggregations).
 //
 // Every cached run asserts the absence of the "serving live" fallback log, so parity can
 // never pass because the gate silently served the live path twice.
@@ -224,7 +228,7 @@ func (s *MeterCacheCHTestSuite) TestCachedReadParityMatrix() {
 	//   and D, covering two subjects and two JSON dimensions,
 	// - a JSON-null value and a missing value property in bucket A,
 	// - the series (subject-2, b, y) having only a NULL value in bucket D: sum/min/max/avg
-	//   drop that row, UNIQUE_COUNT emits it with 0, LATEST drops it (the null-latest case),
+	//   drop that row, UNIQUE_COUNT emits it with 0,
 	// - the value 7 repeated in cached buckets and again in the live tail (UNIQUE_COUNT
 	//   cross-leg dedupe: states must merge, never sum),
 	// - one event between the cache horizon and now-1h (post leg) and two tail events.
@@ -408,6 +412,78 @@ func (s *MeterCacheCHTestSuite) TestCachedReadParityMatrix() {
 			})
 		}
 	}
+}
+
+// TestLatestAggregationAlwaysRoutesLive proves LATEST is excluded from the cache at the
+// gate, not merely undeployed: even with Cachable set, a LATEST query never reaches the
+// cache leg — it logs the gate's rejection reason and its result is exactly what an
+// otherwise-identical query with the cache disabled entirely would produce.
+//
+// Watched RED: commenting out the meterCacheStaticReject LATEST check (so the gate falls
+// through to cacheRejectReasonViewMissing instead, since no LATEST MV is ever deployed)
+// still leaves this test green on the "serving live" and result-equality assertions —
+// those degrade gracefully either way. Only the reject-reason assertion below distinguishes
+// "excluded by design" from "happens to have no view deployed", which is why
+// TestMeterCacheStaticReject's dedicated LATEST case (asserting the exact reject reason) is
+// the real red/green vehicle for the gate change; this test is the complementary proof that
+// the exclusion holds end to end against a real ClickHouse.
+func (s *MeterCacheCHTestSuite) TestLatestAggregationAlwaysRoutesLive() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-latest-routing"
+		eventType = "api-calls"
+	)
+
+	cache := CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	}
+	c := s.newCacheConnector(ctx, cache)
+	noCache := s.newCacheConnector(ctx, CacheConfig{})
+
+	m := meter.Meter{
+		Key:           "meter-latest-routing",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationLatest,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	now := time.Now().UTC()
+	bucket := now.Add(-3 * time.Hour).Truncate(time.Hour)
+
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(5*time.Minute), `{"value": 2}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(10*time.Minute), `{"value": 7}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-2", now.Add(-30*time.Minute), `{"value": 13}`, now),
+	)
+
+	from := bucket
+	to := now.Truncate(time.Hour).Add(time.Hour)
+	params := streaming.QueryParams{From: &from, To: &to, WindowSize: lo.ToPtr(meter.WindowSizeHour)}
+
+	// A cache-disabled connector's gate never runs at all — cacheGate is nil and QueryMeter
+	// always serves live for it — so it is the independent ground truth for "no cache leg
+	// was ever consulted", distinct from the Cachable=true run under test.
+	paramsLive := params
+	paramsLive.Cachable = false
+	wantRows, err := noCache.QueryMeter(ctx, namespace, m, paramsLive)
+	s.NoError(err)
+	s.NotEmpty(wantRows, "routing proof would be trivial on an empty result")
+
+	c.logs.Reset()
+
+	paramsCachable := params
+	paramsCachable.Cachable = true
+	gotRows, err := c.QueryMeter(ctx, namespace, m, paramsCachable)
+	s.NoError(err)
+
+	s.Contains(c.logs.String(), "serving live", "a Cachable LATEST query must be rejected by the gate, not silently served some other way")
+	s.Contains(c.logs.String(), string(cacheRejectReasonLatestAggregation), "the gate must reject LATEST specifically, not fall through to a different reason")
+	s.Equal(wantRows, gotRows)
 }
 
 // TestCachedReadParityAcrossDST extends the parity matrix's timezone axis over both 2025

--- a/openmeter/streaming/clickhouse/meter_cache_e2e_ch_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_e2e_ch_test.go
@@ -1,0 +1,541 @@
+package clickhouse
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	progressmanageradapter "github.com/openmeterio/openmeter/openmeter/progressmanager/adapter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/pkg/filter"
+)
+
+// e2eEventsTable is the events table name shared by the WP7 end-to-end cache tests; each
+// suite test runs in its own temp database, so the constant name never collides.
+const e2eEventsTable = "om_events"
+
+// cacheTestConnector bundles a cache-enabled connector with its captured logs so tests can
+// assert the gate's serve/fallback decision: the connector logs "serving live" on every
+// cache fallback, so its absence after a cached query proves the cache leg produced the
+// rows (a silently falling-back gate would make any parity assertion pass trivially).
+type cacheTestConnector struct {
+	*Connector
+
+	logs *bytes.Buffer
+}
+
+func (s *MeterCacheCHTestSuite) newCacheConnector(ctx context.Context, cache CacheConfig) cacheTestConnector {
+	logs := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	connector, err := New(ctx, Config{
+		Logger:                 logger,
+		ClickHouse:             s.ClickHouse,
+		Database:               s.Database,
+		EventsTableName:        e2eEventsTable,
+		EnableDecimalPrecision: true,
+		ProgressManager:        progressmanageradapter.NewMockProgressManager(),
+		Cache:                  cache,
+	})
+	s.NoError(err)
+
+	// Tests drive refreshes explicitly (SYSTEM REFRESH VIEW + SYSTEM WAIT VIEW) and then
+	// query immediately; the production view-state memo (G13) would serve a pre-refresh
+	// snapshot for up to its TTL, making assertions time-dependent.
+	if connector.cacheGate != nil {
+		connector.cacheGate.viewStateTTL = 0
+	}
+
+	return cacheTestConnector{Connector: connector, logs: logs}
+}
+
+func (s *MeterCacheCHTestSuite) insertRawEvents(ctx context.Context, events ...streaming.RawEvent) {
+	insertSQL, args := InsertEventsQuery{
+		Database:        s.Database,
+		EventsTableName: e2eEventsTable,
+		Events:          events,
+	}.ToSQL()
+	s.NoError(s.ClickHouse.Exec(ctx, insertSQL, args...))
+}
+
+func rawCacheTestEvent(namespace, eventType, subject string, at time.Time, data string, storedAt time.Time) streaming.RawEvent {
+	return streaming.RawEvent{
+		Namespace:  namespace,
+		ID:         ulid.Make().String(),
+		Type:       eventType,
+		Source:     "test-source",
+		Subject:    subject,
+		Time:       at,
+		Data:       data,
+		IngestedAt: storedAt,
+		StoredAt:   storedAt,
+	}
+}
+
+// queryBothPaths runs the same query on the live path (Cachable=false) and the cached
+// path (Cachable=true), asserting the cached run did not silently fall back to live.
+func (s *MeterCacheCHTestSuite) queryBothPaths(ctx context.Context, c cacheTestConnector, namespace string, m meter.Meter, params streaming.QueryParams) (live, cached []meter.MeterQueryRow) {
+	params.Cachable = false
+	live, err := c.QueryMeter(ctx, namespace, m, params)
+	s.NoError(err)
+
+	c.logs.Reset()
+
+	params.Cachable = true
+	cached, err = c.QueryMeter(ctx, namespace, m, params)
+	s.NoError(err)
+	s.NotContains(c.logs.String(), "serving live", "cached query fell back to the live path")
+
+	return live, cached
+}
+
+// totalValue extracts the single row value of a windowless total query.
+func (s *MeterCacheCHTestSuite) totalValue(rows []meter.MeterQueryRow) float64 {
+	s.Len(rows, 1)
+
+	return rows[0].Value
+}
+
+// refreshViewUntilMarkersHealed forces refreshes until the view's derived refresh start
+// (second-resolution last_success_time minus last_success_duration_ms) lands strictly
+// after the newest invalidation marker even when truncated to whole seconds — the
+// clickhouse-go driver binds time.Time query arguments at second precision, so the
+// gate's heal comparison is effectively second-granular and a refresh racing a marker
+// within the same second looks unhealed. That is the conservative direction (production
+// merely stays live until the next scheduled refresh), but a test asserting the healed
+// state must drive refreshes until the ordering is measurable through the truncation.
+func (s *MeterCacheCHTestSuite) refreshViewUntilMarkersHealed(ctx context.Context, viewName string) {
+	qualifiedView := getTableName(s.Database, viewName)
+	deadline := time.Now().Add(30 * time.Second)
+
+	for {
+		s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM REFRESH VIEW "+qualifiedView))
+		s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+
+		var (
+			lastSuccess time.Time
+			durationMS  uint64
+		)
+		s.NoError(s.ClickHouse.QueryRow(ctx,
+			"SELECT last_success_time, last_success_duration_ms FROM system.view_refreshes WHERE database = ? AND view = ?",
+			s.Database, viewName,
+		).Scan(&lastSuccess, &durationMS))
+
+		var newestMarker time.Time
+		s.NoError(s.ClickHouse.QueryRow(ctx,
+			"SELECT max(created_at) FROM "+getTableName(s.Database, meterCacheInvalidationsTableName),
+		).Scan(&newestMarker))
+
+		refreshStart := lastSuccess.Add(-time.Duration(durationMS) * time.Millisecond)
+		if refreshStart.Truncate(time.Second).After(newestMarker) {
+			return
+		}
+
+		s.Less(time.Now(), deadline, "no refresh started measurably after the newest marker")
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// allCacheTestAggregations is every meter aggregation the cache supports; the parity
+// matrix runs each query shape over all of them.
+var allCacheTestAggregations = []meter.MeterAggregation{
+	meter.MeterAggregationSum,
+	meter.MeterAggregationCount,
+	meter.MeterAggregationAvg,
+	meter.MeterAggregationMin,
+	meter.MeterAggregationMax,
+	meter.MeterAggregationUniqueCount,
+	meter.MeterAggregationLatest,
+}
+
+// deployCacheTestMeters creates one meter per aggregation (two JSON dimensions, value
+// property except COUNT) and deploys each meter's cache MV fully (create, backfill,
+// refresh, stamp).
+func (s *MeterCacheCHTestSuite) deployCacheTestMeters(ctx context.Context, namespace, eventType, keyPrefix string, cache CacheConfig) map[meter.MeterAggregation]meter.Meter {
+	meters := make(map[meter.MeterAggregation]meter.Meter, len(allCacheTestAggregations))
+
+	for _, aggregation := range allCacheTestAggregations {
+		m := meter.Meter{
+			Key:         fmt.Sprintf("%s-%s", keyPrefix, aggregation),
+			EventType:   eventType,
+			Aggregation: aggregation,
+			GroupBy: map[string]string{
+				"group1": "$.group1",
+				"group2": "$.group2",
+			},
+		}
+		if aggregation != meter.MeterAggregationCount {
+			m.ValueProperty = lo.ToPtr("$.value")
+		}
+
+		meters[aggregation] = m
+
+		s.deployMeterCacheMV(ctx, createMeterCacheMV{
+			Database:        s.Database,
+			EventsTableName: e2eEventsTable,
+			Namespace:       namespace,
+			Meter:           m,
+			Grain:           cache.WindowSize,
+			RefreshInterval: cache.RefreshInterval,
+			MinimumUsageAge: cache.MinimumUsageAge,
+		})
+	}
+
+	return meters
+}
+
+// TestCachedReadParityMatrix is the WP7 parity matrix: for every supported aggregation,
+// cached and live results must be row-for-row equal across the query-shape axes of the
+// test plan — window sizes (total, =grain hour, day, month), grid alignment (on-grid,
+// mid-hour from, mid-hour to, both off-grid), group-by shapes (none, subject, two JSON
+// dimensions, subset), filters (FilterSubject, FilterGroupBy $eq/$ne/$in), timezones (UTC
+// and America/New_York), and data shapes (all-null buckets, empty buckets, missing value
+// property, duplicate values across the cache/live boundary, null-latest).
+//
+// Every cached run asserts the absence of the "serving live" fallback log, so parity can
+// never pass because the gate silently served the live path twice.
+func (s *MeterCacheCHTestSuite) TestCachedReadParityMatrix() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-parity-matrix"
+		eventType = "api-calls"
+	)
+
+	c := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	newYork, err := time.LoadLocation("America/New_York")
+	s.NoError(err)
+
+	// given:
+	// - three settled hour buckets (A, B, D) with an intentionally empty bucket between B
+	//   and D, covering two subjects and two JSON dimensions,
+	// - a JSON-null value and a missing value property in bucket A,
+	// - the series (subject-2, b, y) having only a NULL value in bucket D: sum/min/max/avg
+	//   drop that row, UNIQUE_COUNT emits it with 0, LATEST drops it (the null-latest case),
+	// - the value 7 repeated in cached buckets and again in the live tail (UNIQUE_COUNT
+	//   cross-leg dedupe: states must merge, never sum),
+	// - one event between the cache horizon and now-1h (post leg) and two tail events.
+	now := time.Now().UTC()
+	bucketA := now.Add(-6 * time.Hour).Truncate(time.Hour)
+	bucketB := now.Add(-5 * time.Hour).Truncate(time.Hour)
+	bucketD := now.Add(-3 * time.Hour).Truncate(time.Hour)
+
+	event := func(subject string, at time.Time, data string) streaming.RawEvent {
+		return rawCacheTestEvent(namespace, eventType, subject, at, data, now)
+	}
+
+	// Inserted directly (not through BatchInsert) so no invalidation markers are written:
+	// the matrix exercises the clean read path, not marker healing.
+	s.insertRawEvents(ctx,
+		event("subject-1", bucketA.Add(5*time.Minute), `{"value": 2, "group1": "a", "group2": "x"}`),
+		event("subject-1", bucketA.Add(10*time.Minute), `{"value": 7, "group1": "a", "group2": "y"}`),
+		event("subject-2", bucketA.Add(20*time.Minute), `{"value": 5, "group1": "b", "group2": "x"}`),
+		event("subject-1", bucketA.Add(25*time.Minute), `{"value": null, "group1": "b", "group2": "x"}`),
+		event("subject-2", bucketA.Add(30*time.Minute), `{"group1": "a", "group2": "y"}`),
+		event("subject-1", bucketB.Add(5*time.Minute), `{"value": 7, "group1": "a", "group2": "x"}`),
+		event("subject-2", bucketB.Add(15*time.Minute), `{"value": 3.5, "group1": "b", "group2": "y"}`),
+		event("subject-1", bucketB.Add(40*time.Minute), `{"value": 1, "group1": "a", "group2": "x"}`),
+		event("subject-2", bucketD.Add(10*time.Minute), `{"value": null, "group1": "b", "group2": "y"}`),
+		event("subject-1", bucketD.Add(35*time.Minute), `{"value": 11, "group1": "a", "group2": "y"}`),
+		event("subject-1", now.Add(-90*time.Minute), `{"value": 13, "group1": "b", "group2": "x"}`),
+		event("subject-2", now.Add(-30*time.Minute), `{"value": 7, "group1": "a", "group2": "x"}`),
+		event("subject-1", now.Add(-10*time.Minute), `{"value": 17, "group1": "b", "group2": "y"}`),
+	)
+
+	meters := s.deployCacheTestMeters(ctx, namespace, eventType, "meter", c.config.Cache)
+
+	fromOn := bucketA
+	toOn := now.Truncate(time.Hour).Add(time.Hour)
+	fromMid := bucketA.Add(25 * time.Minute)
+	toMid := now.Add(-7 * time.Minute)
+
+	queryCases := []struct {
+		name   string
+		params streaming.QueryParams
+	}{
+		{
+			name:   "total on grid no group by",
+			params: streaming.QueryParams{From: &fromOn, To: &toOn},
+		},
+		{
+			name: "total both off grid subject group by",
+			params: streaming.QueryParams{
+				From:    &fromMid,
+				To:      &toMid,
+				GroupBy: []string{"subject"},
+			},
+		},
+		{
+			name: "hour on grid two dims and subject",
+			params: streaming.QueryParams{
+				From:       &fromOn,
+				To:         &toOn,
+				WindowSize: lo.ToPtr(meter.WindowSizeHour),
+				GroupBy:    []string{"subject", "group1", "group2"},
+			},
+		},
+		{
+			name: "hour mid from subset group by",
+			params: streaming.QueryParams{
+				From:       &fromMid,
+				To:         &toOn,
+				WindowSize: lo.ToPtr(meter.WindowSizeHour),
+				GroupBy:    []string{"subject", "group1"},
+			},
+		},
+		{
+			name: "hour mid to no group by",
+			params: streaming.QueryParams{
+				From:       &fromOn,
+				To:         &toMid,
+				WindowSize: lo.ToPtr(meter.WindowSizeHour),
+			},
+		},
+		{
+			name: "hour subject filter",
+			params: streaming.QueryParams{
+				From:          &fromOn,
+				To:            &toOn,
+				WindowSize:    lo.ToPtr(meter.WindowSizeHour),
+				FilterSubject: []string{"subject-1"},
+			},
+		},
+		{
+			name: "hour group by filter eq",
+			params: streaming.QueryParams{
+				From:       &fromOn,
+				To:         &toOn,
+				WindowSize: lo.ToPtr(meter.WindowSizeHour),
+				GroupBy:    []string{"group1"},
+				FilterGroupBy: map[string]filter.FilterString{
+					"group1": {Eq: lo.ToPtr("a")},
+				},
+			},
+		},
+		{
+			name: "total group by filters in and ne",
+			params: streaming.QueryParams{
+				From:    &fromOn,
+				To:      &toOn,
+				GroupBy: []string{"group1", "group2"},
+				FilterGroupBy: map[string]filter.FilterString{
+					"group1": {In: lo.ToPtr([]string{"a", "b"})},
+					"group2": {Ne: lo.ToPtr("y")},
+				},
+			},
+		},
+		{
+			name: "day utc subject group by",
+			params: streaming.QueryParams{
+				From:       &fromOn,
+				To:         &toOn,
+				WindowSize: lo.ToPtr(meter.WindowSizeDay),
+				GroupBy:    []string{"subject"},
+			},
+		},
+		{
+			name: "day new york both off grid",
+			params: streaming.QueryParams{
+				From:           &fromMid,
+				To:             &toMid,
+				WindowSize:     lo.ToPtr(meter.WindowSizeDay),
+				WindowTimeZone: newYork,
+				GroupBy:        []string{"subject", "group2"},
+			},
+		},
+		{
+			name: "month utc no group by",
+			params: streaming.QueryParams{
+				From:       &fromOn,
+				To:         &toOn,
+				WindowSize: lo.ToPtr(meter.WindowSizeMonth),
+			},
+		},
+		{
+			name: "month new york subject group by",
+			params: streaming.QueryParams{
+				From:           &fromMid,
+				To:             &toOn,
+				WindowSize:     lo.ToPtr(meter.WindowSizeMonth),
+				WindowTimeZone: newYork,
+				GroupBy:        []string{"subject"},
+			},
+		},
+		{
+			name: "hour new york multi subject filter",
+			params: streaming.QueryParams{
+				From:           &fromOn,
+				To:             &toMid,
+				WindowSize:     lo.ToPtr(meter.WindowSizeHour),
+				WindowTimeZone: newYork,
+				FilterSubject:  []string{"subject-1", "subject-2"},
+				GroupBy:        []string{"subject"},
+			},
+		},
+		{
+			name: "total off grid dim filter subset group by",
+			params: streaming.QueryParams{
+				From:    &fromMid,
+				To:      &toMid,
+				GroupBy: []string{"group1"},
+				FilterGroupBy: map[string]filter.FilterString{
+					"group2": {Eq: lo.ToPtr("x")},
+				},
+			},
+		},
+	}
+
+	for _, aggregation := range allCacheTestAggregations {
+		for _, queryCase := range queryCases {
+			s.Run(fmt.Sprintf("%s %s", aggregation, queryCase.name), func() {
+				live, cached := s.queryBothPaths(ctx, c, namespace, meters[aggregation], queryCase.params)
+
+				s.NotEmpty(live, "parity would be trivial on an empty result")
+				s.ElementsMatch(live, cached)
+			})
+		}
+	}
+}
+
+// TestCachedReadParityAcrossDST extends the parity matrix's timezone axis over both 2025
+// US DST transitions (2025-03-09 spring forward, 2025-11-02 fall back, both fully settled
+// history served entirely by the backfilled cache): day and month windows in
+// America/New_York re-window UTC cache buckets across a UTC-offset change, including an
+// event in the repeated local hour of fall-back and events on the far side of local
+// midnight where the NY calendar day differs from the UTC day.
+func (s *MeterCacheCHTestSuite) TestCachedReadParityAcrossDST() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-parity-dst"
+		eventType = "api-calls"
+	)
+
+	c := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	newYork, err := time.LoadLocation("America/New_York")
+	s.NoError(err)
+
+	storedAt := time.Now().UTC()
+
+	event := func(subject string, at time.Time, data string) streaming.RawEvent {
+		return rawCacheTestEvent(namespace, eventType, subject, at, data, storedAt)
+	}
+
+	utc := func(value string) time.Time {
+		at, err := time.Parse(time.RFC3339, value)
+		s.NoError(err)
+
+		return at.UTC()
+	}
+
+	s.insertRawEvents(ctx,
+		// Spring forward (2025-03-09 07:00Z): 04:30Z is still NY day Mar 8, 06:30Z is the
+		// last EST hour, 07:30Z the first EDT hour (local 02:00-03:00 never happened).
+		event("subject-1", utc("2025-03-09T04:30:00Z"), `{"value": 2, "group1": "a", "group2": "x"}`),
+		event("subject-1", utc("2025-03-09T06:30:00Z"), `{"value": 7, "group1": "a", "group2": "y"}`),
+		event("subject-2", utc("2025-03-09T07:30:00Z"), `{"value": 5, "group1": "b", "group2": "x"}`),
+		event("subject-1", utc("2025-03-09T08:30:00Z"), `{"value": null, "group1": "b", "group2": "y"}`),
+		// Mid-summer: 03:30Z is NY day Jun 14 but UTC day Jun 15 (day-boundary divergence).
+		event("subject-2", utc("2025-06-15T03:30:00Z"), `{"value": 3.5, "group1": "a", "group2": "x"}`),
+		// Fall back (2025-11-02 06:00Z): 05:30Z is local 01:30 EDT, 06:30Z is local 01:30
+		// EST — the repeated local hour; 07:30Z is unambiguous again. The value 7 repeats
+		// across the transition for UNIQUE_COUNT dedupe.
+		event("subject-1", utc("2025-11-02T04:30:00Z"), `{"value": 7, "group1": "a", "group2": "x"}`),
+		event("subject-2", utc("2025-11-02T05:30:00Z"), `{"value": 11, "group1": "b", "group2": "x"}`),
+		event("subject-1", utc("2025-11-02T06:30:00Z"), `{"value": 13, "group1": "a", "group2": "y"}`),
+		event("subject-2", utc("2025-11-02T07:30:00Z"), `{"group1": "b", "group2": "y"}`),
+	)
+
+	meters := s.deployCacheTestMeters(ctx, namespace, eventType, "dst-meter", c.config.Cache)
+
+	fromFull := utc("2025-03-01T00:00:00Z")
+	toFull := utc("2025-11-30T00:00:00Z")
+	fromSpring := utc("2025-03-09T00:00:00Z")
+	toSpring := utc("2025-03-10T00:00:00Z")
+	fromFall := utc("2025-11-02T00:00:00Z")
+	toFall := utc("2025-11-03T00:00:00Z")
+
+	queryCases := []struct {
+		name   string
+		params streaming.QueryParams
+	}{
+		{
+			name: "day new york across both transitions",
+			params: streaming.QueryParams{
+				From:           &fromFull,
+				To:             &toFull,
+				WindowSize:     lo.ToPtr(meter.WindowSizeDay),
+				WindowTimeZone: newYork,
+				GroupBy:        []string{"subject"},
+			},
+		},
+		{
+			name: "month new york across both transitions",
+			params: streaming.QueryParams{
+				From:           &fromFull,
+				To:             &toFull,
+				WindowSize:     lo.ToPtr(meter.WindowSizeMonth),
+				WindowTimeZone: newYork,
+				GroupBy:        []string{"subject", "group1"},
+			},
+		},
+		{
+			name: "day utc across both transitions",
+			params: streaming.QueryParams{
+				From:       &fromFull,
+				To:         &toFull,
+				WindowSize: lo.ToPtr(meter.WindowSizeDay),
+			},
+		},
+		{
+			name: "hour new york spring forward day",
+			params: streaming.QueryParams{
+				From:           &fromSpring,
+				To:             &toSpring,
+				WindowSize:     lo.ToPtr(meter.WindowSizeHour),
+				WindowTimeZone: newYork,
+				GroupBy:        []string{"subject", "group2"},
+			},
+		},
+		{
+			name: "hour new york fall back day",
+			params: streaming.QueryParams{
+				From:           &fromFall,
+				To:             &toFall,
+				WindowSize:     lo.ToPtr(meter.WindowSizeHour),
+				WindowTimeZone: newYork,
+			},
+		},
+	}
+
+	for _, aggregation := range allCacheTestAggregations {
+		for _, queryCase := range queryCases {
+			s.Run(fmt.Sprintf("%s %s", aggregation, queryCase.name), func() {
+				live, cached := s.queryBothPaths(ctx, c, namespace, meters[aggregation], queryCase.params)
+
+				s.NotEmpty(live, "parity would be trivial on an empty result")
+				s.ElementsMatch(live, cached)
+			})
+		}
+	}
+}

--- a/openmeter/streaming/clickhouse/meter_cache_gate.go
+++ b/openmeter/streaming/clickhouse/meter_cache_gate.go
@@ -321,8 +321,13 @@ func (g *meterCacheGate) cacheEligibility(ctx context.Context, query queryMeter,
 
 	// Two meters with identical shape but different keys share a meter hash and thus an
 	// MV name; the MV can only serve the meter key it was generated for, because its
-	// SELECT stamps that key into every row.
-	if state.Metadata.MeterKey != query.Meter.Key ||
+	// SELECT stamps that key into every row. The namespace must match exactly as well:
+	// the MV name only folds the namespace to 8 hex chars, so a colliding namespace with
+	// a same-shape, same-key meter resolves to this very view while its cache leg
+	// (filtered on the querying namespace) would match zero rows — the gate must send it
+	// live, not serve empty settled history.
+	if state.Metadata.Namespace != query.Namespace ||
+		state.Metadata.MeterKey != query.Meter.Key ||
 		state.Metadata.EventType != query.Meter.EventType ||
 		state.Metadata.MeterHash != formatCacheHash(hash) {
 		return meterCacheLegBounds{}, cacheRejectReasonViewForeign, nil
@@ -368,6 +373,7 @@ func (g *meterCacheGate) cacheEligibility(ctx context.Context, query queryMeter,
 		CacheHi:      bounds.CacheHi,
 		RefreshStart: refreshStart,
 		HealBound:    meterCacheHealBound(g.cache.MinimumUsageAge, g.cache.RefreshInterval),
+		BackfilledAt: *state.Metadata.BackfilledAt,
 	}.toSQL()
 
 	var unhealed uint64

--- a/openmeter/streaming/clickhouse/meter_cache_gate.go
+++ b/openmeter/streaming/clickhouse/meter_cache_gate.go
@@ -24,6 +24,7 @@ const (
 	cacheRejectReasonNone                 cacheRejectReason = ""
 	cacheRejectReasonNotOptedIn           cacheRejectReason = "not_opted_in"
 	cacheRejectReasonCacheDisabled        cacheRejectReason = "cache_disabled"
+	cacheRejectReasonLatestAggregation    cacheRejectReason = "latest_aggregation"
 	cacheRejectReasonDecimalDisabled      cacheRejectReason = "decimal_precision_disabled"
 	cacheRejectReasonNoTo                 cacheRejectReason = "to_required"
 	cacheRejectReasonTotalWithoutFrom     cacheRejectReason = "total_without_from"
@@ -106,6 +107,18 @@ func meterCacheStaticReject(m meterpkg.Meter, params streaming.QueryParams, cach
 
 	if !cache.Enabled {
 		return cacheRejectReasonCacheDisabled
+	}
+
+	// LATEST only ever needs the single newest value in the queried window, so unlike the
+	// other aggregations there is no re-aggregation of settled history for the cache to
+	// save — a cached LATEST bucket costs a write and a read merge to save recomputing an
+	// argMax ClickHouse would otherwise do once, live, over a narrow tail. Excluding it
+	// also removes a real correctness surface: the 100M-row benchmark's cache/live parity
+	// gate caught non-deterministic value mismatches on cached LATEST multi-subject
+	// windowed reads (open finding at the time of this change) that the exclusion sidesteps
+	// entirely rather than papering over. LATEST meters always take the live path.
+	if m.Aggregation == meterpkg.MeterAggregationLatest {
+		return cacheRejectReasonLatestAggregation
 	}
 
 	// The cache stores Decimal128 only; the float and decimal live legs have no UNION

--- a/openmeter/streaming/clickhouse/meter_cache_gate.go
+++ b/openmeter/streaming/clickhouse/meter_cache_gate.go
@@ -1,0 +1,445 @@
+package clickhouse
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+
+	meterpkg "github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+)
+
+// cacheRejectReason enumerates why a meter query is not served from the cache. Every
+// rejection falls back to the untouched live query path; the reasons exist so tests can
+// assert the exact gate decision and operators can see why a query stayed live.
+type cacheRejectReason string
+
+const (
+	cacheRejectReasonNone                 cacheRejectReason = ""
+	cacheRejectReasonNotOptedIn           cacheRejectReason = "not_opted_in"
+	cacheRejectReasonCacheDisabled        cacheRejectReason = "cache_disabled"
+	cacheRejectReasonDecimalDisabled      cacheRejectReason = "decimal_precision_disabled"
+	cacheRejectReasonNoTo                 cacheRejectReason = "to_required"
+	cacheRejectReasonTotalWithoutFrom     cacheRejectReason = "total_without_from"
+	cacheRejectReasonWindowBelowGrain     cacheRejectReason = "window_size_below_grain"
+	cacheRejectReasonInvalidGrain         cacheRejectReason = "invalid_grain"
+	cacheRejectReasonTimezone             cacheRejectReason = "timezone_not_cacheable"
+	cacheRejectReasonDayGrainTimezone     cacheRejectReason = "day_grain_requires_utc"
+	cacheRejectReasonFilterCustomer       cacheRejectReason = "filter_customer"
+	cacheRejectReasonCustomerIDGroupBy    cacheRejectReason = "customer_id_group_by"
+	cacheRejectReasonClientID             cacheRejectReason = "client_id"
+	cacheRejectReasonFilterStoredAt       cacheRejectReason = "filter_stored_at"
+	cacheRejectReasonGroupByUnknownKey    cacheRejectReason = "group_by_unknown_key"
+	cacheRejectReasonFilterGroupByUnknown cacheRejectReason = "filter_group_by_unknown_key"
+	cacheRejectReasonReservedAlias        cacheRejectReason = "reserved_alias"
+	cacheRejectReasonViewMissing          cacheRejectReason = "view_missing"
+	cacheRejectReasonViewForeign          cacheRejectReason = "view_foreign"
+	cacheRejectReasonBackfillUnstamped    cacheRejectReason = "backfill_unstamped"
+	cacheRejectReasonViewException        cacheRejectReason = "view_exception"
+	cacheRejectReasonViewStale            cacheRejectReason = "view_stale"
+	cacheRejectReasonEmptyCacheRange      cacheRejectReason = "empty_cache_range"
+	cacheRejectReasonUnhealedMarkers      cacheRejectReason = "unhealed_markers"
+)
+
+// meterCacheViewStateTTL memoizes per-view system.tables/system.view_refreshes lookups
+// (G13). The window is deliberately short (the design allows 5-15s): a stale snapshot only
+// delays noticing a new stamp or a fresh refresh by a few seconds — refreshStart moving
+// backward in the reader's view is safe because it shrinks cacheHi and heals fewer markers
+// — while an unmemoized gate would pay two system-table lookups on every meter query.
+const meterCacheViewStateTTL = 10 * time.Second
+
+// meterCacheStaleRefreshFactor: a view whose last successful refresh is older than this
+// many refresh intervals is treated as unhealthy and the query served live. Scheduled
+// refreshes run every interval with up to interval/3 randomization, so three intervals
+// without a success means refreshes are failing or stopped and the cache tail is growing
+// stale beyond what the read bounds assume.
+const meterCacheStaleRefreshFactor = 3
+
+// meterCacheHealBound is the G1-tightened marker heal window: an invalidation marker is
+// healed by a refresh only when the refresh started after the marker AND
+// refreshStart − marker.created_at < healBound. The bound is dirtyWindow −
+// minimumUsageAge − refreshInterval because the refresh's stored_at lookback is measured
+// from the refresh's own now() (≥ refreshStart), the late events' stored_at is at most a
+// beat before the marker's created_at, and the affected buckets additionally had to be
+// past the settled bound for the refresh to recompute them at all. Anything looser would
+// declare markers healed by refreshes whose lookback provably could not have covered the
+// late events, silently serving stale buckets; markers older than any refresh can heal
+// are repaired by the reconciler's re-backfill, never assumed healed.
+func meterCacheHealBound(minimumUsageAge, refreshInterval time.Duration) time.Duration {
+	return meterCacheDirtyWindow(minimumUsageAge, refreshInterval) - minimumUsageAge - refreshInterval
+}
+
+// meterCacheWindowSizeRank orders query window sizes for the WindowSize >= grain gate
+// rule; -1 means unknown (reject). SECOND ranks below every grain on purpose: the live
+// path has no second-window support either, so the gate sends it live to fail there.
+func meterCacheWindowSizeRank(w meterpkg.WindowSize) int {
+	switch w {
+	case meterpkg.WindowSizeSecond:
+		return 0
+	case meterpkg.WindowSizeMinute:
+		return 1
+	case meterpkg.WindowSizeHour:
+		return 2
+	case meterpkg.WindowSizeDay:
+		return 3
+	case meterpkg.WindowSizeMonth:
+		return 4
+	default:
+		return -1
+	}
+}
+
+// meterCacheStaticReject evaluates the query-shape half of the cache gate: everything
+// decidable from the meter, the query params, and the configuration alone, without
+// touching ClickHouse. It returns the first matching reject reason, or
+// cacheRejectReasonNone when the dynamic checks (view state, markers) may proceed.
+func meterCacheStaticReject(m meterpkg.Meter, params streaming.QueryParams, cache CacheConfig, enableDecimalPrecision bool) cacheRejectReason {
+	if !params.Cachable {
+		return cacheRejectReasonNotOptedIn
+	}
+
+	if !cache.Enabled {
+		return cacheRejectReasonCacheDisabled
+	}
+
+	// The cache stores Decimal128 only; the float and decimal live legs have no UNION
+	// supertype, so a float-mode deployment can never combine cache and live legs.
+	if !enableDecimalPrecision {
+		return cacheRejectReasonDecimalDisabled
+	}
+
+	if params.To == nil {
+		return cacheRejectReasonNoTo
+	}
+
+	// A total (nil window) with a nil From keeps its computed WindowStart — the live
+	// query derives it from the earliest event's timestamp, which cache buckets cannot
+	// reproduce; with From set both window bounds are overwritten with the requested
+	// period on every path, so parity holds.
+	if params.WindowSize == nil && params.From == nil {
+		return cacheRejectReasonTotalWithoutFrom
+	}
+
+	grainSpec, err := grainSpecFor(cache.WindowSize)
+	if err != nil {
+		return cacheRejectReasonInvalidGrain
+	}
+
+	// Query windows narrower than the cache grain cannot be reassembled from grain
+	// buckets. Totals (nil window) are allowed: they aggregate whole buckets.
+	if params.WindowSize != nil {
+		rank := meterCacheWindowSizeRank(*params.WindowSize)
+		if rank < 0 || rank < meterCacheWindowSizeRank(grainSpec.windowSize) {
+			return cacheRejectReasonWindowBelowGrain
+		}
+	}
+
+	if reason := meterCacheTimezoneReject(params.WindowTimeZone, params.From, *params.To, cache.WindowSize); reason != cacheRejectReasonNone {
+		return reason
+	}
+
+	// Customer attribution resolves subjects through a query-time map that cache rows
+	// do not carry, in both its filter and group-by forms.
+	if len(params.FilterCustomer) > 0 {
+		return cacheRejectReasonFilterCustomer
+	}
+
+	if slices.Contains(params.GroupBy, "customer_id") {
+		return cacheRejectReasonCustomerIDGroupBy
+	}
+
+	// Progress tracking counts scanned event rows; a cache-leg query scans rollup rows,
+	// so the reported progress would be meaningless.
+	if params.ClientID != nil {
+		return cacheRejectReasonClientID
+	}
+
+	// stored_at is not part of the cached rollup: rows aggregate away individual events'
+	// storage times, so a stored-at cutoff can only be applied to the raw events table.
+	if params.FilterStoredAt != nil && !params.FilterStoredAt.IsEmpty() {
+		return cacheRejectReasonFilterStoredAt
+	}
+
+	for _, key := range params.GroupBy {
+		if key == "subject" || key == "customer_id" {
+			continue
+		}
+
+		if _, ok := m.GroupBy[key]; !ok {
+			return cacheRejectReasonGroupByUnknownKey
+		}
+	}
+
+	for key := range params.FilterGroupBy {
+		if _, ok := m.GroupBy[key]; !ok {
+			return cacheRejectReasonFilterGroupByUnknown
+		}
+	}
+
+	// G9: such meters never get cache SQL generated (no MV exists either), and their
+	// group-by keys would shadow columns the read legs depend on.
+	if err := reservedAliasCheck(slices.Sorted(maps.Keys(m.GroupBy))); err != nil {
+		return cacheRejectReasonReservedAlias
+	}
+
+	return cacheRejectReasonNone
+}
+
+// meterCacheTimezoneReject decides whether the query's window timezone lets grain-aligned
+// UTC cache buckets be re-windowed exactly. Buckets nest into the query's windows only if
+// every window boundary in the queried range falls on a bucket boundary:
+//
+//   - day grain: only UTC itself is accepted (per design; even a zone that happens to sit
+//     at offset 0 for the whole range is rejected to keep the rule trivially auditable),
+//   - minute/hour grain: the zone's UTC offset must be a whole hour at every sampled
+//     instant of [from, to]. Sampling is weekly plus both endpoints, which cannot miss a
+//     DST period (real zones hold each offset for months at a time); zones with permanent
+//     fractional offsets (Asia/Kathmandu +05:45) fail at the endpoints already,
+//   - a nil From with a non-UTC zone is rejected because the window boundaries extend over
+//     unbounded history where offsets cannot be sampled (many zones had fractional
+//     offsets in the distant past).
+func meterCacheTimezoneReject(loc *time.Location, from *time.Time, to time.Time, grain CacheGrain) cacheRejectReason {
+	// The live query defaults a nil timezone to UTC.
+	if loc == nil || loc == time.UTC || loc.String() == "UTC" {
+		return cacheRejectReasonNone
+	}
+
+	if grain == CacheGrainDay {
+		return cacheRejectReasonDayGrainTimezone
+	}
+
+	if from == nil {
+		return cacheRejectReasonTimezone
+	}
+
+	for t := *from; t.Before(to); t = t.Add(7 * 24 * time.Hour) {
+		if _, offset := t.In(loc).Zone(); offset%3600 != 0 {
+			return cacheRejectReasonTimezone
+		}
+	}
+
+	if _, offset := to.In(loc).Zone(); offset%3600 != 0 {
+		return cacheRejectReasonTimezone
+	}
+
+	return cacheRejectReasonNone
+}
+
+// meterCacheViewState is the reader-relevant snapshot of one deployed cache MV, joined
+// from system.tables (comment metadata) and system.view_refreshes (health).
+type meterCacheViewState struct {
+	Exists bool
+	// MetadataOK is false when the comment did not parse as valid cache MV metadata; the
+	// view must then be treated as foreign or corrupt, never served from.
+	MetadataOK bool
+	Metadata   meterCacheMVMetadata
+
+	// LastSuccessTime/LastSuccessDurationMS come from system.view_refreshes and are nil
+	// until the view's first successful refresh. refreshStart is derived from them.
+	LastSuccessTime       *time.Time
+	LastSuccessDurationMS *uint64
+	Exception             string
+}
+
+type meterCacheViewStateEntry struct {
+	fetchedAt time.Time
+	state     meterCacheViewState
+}
+
+// meterCacheGate decides per query whether the cached read path may serve it. All state
+// it keeps is a short-TTL memo of per-view system-table lookups; every decision it makes
+// falls back to the live path on rejection or error.
+type meterCacheGate struct {
+	logger     *slog.Logger
+	clickhouse clickhouse.Conn
+	database   string
+	cache      CacheConfig
+
+	enableDecimalPrecision bool
+
+	// fetchViewState is indirect so unit tests can exercise the memoization and the
+	// dynamic reject rules without a ClickHouse connection.
+	fetchViewState func(ctx context.Context, viewName string) (meterCacheViewState, error)
+
+	viewStateTTL time.Duration
+	viewsMu      sync.Mutex
+	viewStates   map[string]meterCacheViewStateEntry
+}
+
+func newMeterCacheGate(config Config) *meterCacheGate {
+	gate := &meterCacheGate{
+		logger:                 config.Logger,
+		clickhouse:             config.ClickHouse,
+		database:               config.Database,
+		cache:                  config.Cache,
+		enableDecimalPrecision: config.EnableDecimalPrecision,
+		viewStateTTL:           meterCacheViewStateTTL,
+		viewStates:             map[string]meterCacheViewStateEntry{},
+	}
+
+	gate.fetchViewState = gate.fetchViewStateFromClickHouse
+
+	return gate
+}
+
+// cacheEligibility runs the full cache gate for one meter query: the static shape checks,
+// then the view-state checks (existence, metadata, backfill stamp, refresh health), the
+// cache leg bounds, and the invalidation marker scan. It returns the leg bounds and
+// cacheRejectReasonNone when the query may be served from the cache; a non-empty reason
+// when it must be served live; and an error only for infrastructure failures (which
+// callers also treat as "serve live").
+//
+// The marker scan deliberately happens on every request while the view state is memoized:
+// markers are the correctness signal for buckets the cache already published, so a stale
+// marker view could serve poisoned buckets, whereas a stale refresh state only makes the
+// gate more conservative.
+func (g *meterCacheGate) cacheEligibility(ctx context.Context, query queryMeter, params streaming.QueryParams) (meterCacheLegBounds, cacheRejectReason, error) {
+	if reason := meterCacheStaticReject(query.Meter, params, g.cache, g.enableDecimalPrecision); reason != cacheRejectReasonNone {
+		return meterCacheLegBounds{}, reason, nil
+	}
+
+	hash := meterHash(query.Meter, g.cache.WindowSize)
+
+	state, err := g.viewState(ctx, mvName(query.Namespace, hash))
+	if err != nil {
+		return meterCacheLegBounds{}, cacheRejectReasonNone, fmt.Errorf("meter cache view state: %w", err)
+	}
+
+	if !state.Exists {
+		return meterCacheLegBounds{}, cacheRejectReasonViewMissing, nil
+	}
+
+	if !state.MetadataOK {
+		return meterCacheLegBounds{}, cacheRejectReasonViewForeign, nil
+	}
+
+	// Two meters with identical shape but different keys share a meter hash and thus an
+	// MV name; the MV can only serve the meter key it was generated for, because its
+	// SELECT stamps that key into every row.
+	if state.Metadata.MeterKey != query.Meter.Key ||
+		state.Metadata.EventType != query.Meter.EventType ||
+		state.Metadata.MeterHash != formatCacheHash(hash) {
+		return meterCacheLegBounds{}, cacheRejectReasonViewForeign, nil
+	}
+
+	// G3: an unstamped MV only contains recently refreshed buckets; serving it would
+	// silently drop all history older than its first refresh.
+	if state.Metadata.BackfilledAt == nil {
+		return meterCacheLegBounds{}, cacheRejectReasonBackfillUnstamped, nil
+	}
+
+	if state.Exception != "" {
+		return meterCacheLegBounds{}, cacheRejectReasonViewException, nil
+	}
+
+	if state.LastSuccessTime == nil || state.LastSuccessDurationMS == nil {
+		return meterCacheLegBounds{}, cacheRejectReasonViewStale, nil
+	}
+
+	if time.Since(*state.LastSuccessTime) > meterCacheStaleRefreshFactor*g.cache.RefreshInterval {
+		return meterCacheLegBounds{}, cacheRejectReasonViewStale, nil
+	}
+
+	// refreshStart, not last_success_time: the refresh evaluated its settled bound at the
+	// moment it started, so everything derived from it (cache horizon, marker healing)
+	// must be anchored there.
+	refreshStart := state.LastSuccessTime.Add(-time.Duration(*state.LastSuccessDurationMS) * time.Millisecond)
+
+	bounds, ok, err := meterCacheBounds(query.from(), *query.To, refreshStart, g.cache.MinimumUsageAge, g.cache.WindowSize)
+	if err != nil {
+		return meterCacheLegBounds{}, cacheRejectReasonNone, fmt.Errorf("meter cache bounds: %w", err)
+	}
+
+	if !ok {
+		return meterCacheLegBounds{}, cacheRejectReasonEmptyCacheRange, nil
+	}
+
+	markerSQL, markerArgs := meterCacheMarkerOverlapQuery{
+		Database:     g.database,
+		Namespace:    query.Namespace,
+		EventType:    query.Meter.EventType,
+		CacheLo:      bounds.CacheLo,
+		CacheHi:      bounds.CacheHi,
+		RefreshStart: refreshStart,
+		HealBound:    meterCacheHealBound(g.cache.MinimumUsageAge, g.cache.RefreshInterval),
+	}.toSQL()
+
+	var unhealed uint64
+	if err := g.clickhouse.QueryRow(ctx, markerSQL, markerArgs...).Scan(&unhealed); err != nil {
+		return meterCacheLegBounds{}, cacheRejectReasonNone, fmt.Errorf("meter cache marker overlap: %w", err)
+	}
+
+	if unhealed > 0 {
+		return meterCacheLegBounds{}, cacheRejectReasonUnhealedMarkers, nil
+	}
+
+	return bounds, cacheRejectReasonNone, nil
+}
+
+// viewState returns the memoized view snapshot, refreshing it when older than the TTL
+// (G13). The lock is not held across the fetch: a burst of queries on an expired entry
+// may fetch redundantly, which is cheaper than serializing every meter's gate behind one
+// ClickHouse round-trip.
+func (g *meterCacheGate) viewState(ctx context.Context, viewName string) (meterCacheViewState, error) {
+	g.viewsMu.Lock()
+	entry, ok := g.viewStates[viewName]
+	g.viewsMu.Unlock()
+
+	if ok && time.Since(entry.fetchedAt) < g.viewStateTTL {
+		return entry.state, nil
+	}
+
+	state, err := g.fetchViewState(ctx, viewName)
+	if err != nil {
+		return meterCacheViewState{}, err
+	}
+
+	g.viewsMu.Lock()
+	g.viewStates[viewName] = meterCacheViewStateEntry{fetchedAt: time.Now(), state: state}
+	g.viewsMu.Unlock()
+
+	return state, nil
+}
+
+func (g *meterCacheGate) fetchViewStateFromClickHouse(ctx context.Context, viewName string) (meterCacheViewState, error) {
+	rows, err := g.clickhouse.Query(ctx,
+		"SELECT t.comment, r.last_success_time, r.last_success_duration_ms, r.exception "+
+			"FROM system.tables AS t "+
+			"LEFT JOIN system.view_refreshes AS r ON r.database = t.database AND r.view = t.name "+
+			"WHERE t.database = ? AND t.name = ?",
+		g.database, viewName,
+	)
+	if err != nil {
+		return meterCacheViewState{}, err
+	}
+
+	defer rows.Close()
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return meterCacheViewState{}, err
+		}
+
+		return meterCacheViewState{Exists: false}, nil
+	}
+
+	state := meterCacheViewState{Exists: true}
+
+	var comment string
+	if err := rows.Scan(&comment, &state.LastSuccessTime, &state.LastSuccessDurationMS, &state.Exception); err != nil {
+		return meterCacheViewState{}, err
+	}
+
+	if metadata, err := parseMeterCacheMVMetadata(comment); err == nil {
+		state.MetadataOK = true
+		state.Metadata = metadata
+	}
+
+	return state, nil
+}

--- a/openmeter/streaming/clickhouse/meter_cache_gate_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_gate_test.go
@@ -1,0 +1,628 @@
+package clickhouse
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/pkg/filter"
+)
+
+func TestMeterCacheHealBound(t *testing.T) {
+	// dirty window above the floor: bound reduces to two refresh intervals
+	assert.Equal(t, 20*time.Minute, meterCacheHealBound(time.Hour, 10*time.Minute))
+
+	// dirty window floored at one hour: bound is what the floor leaves after age and one
+	// interval
+	assert.Equal(t, 45*time.Minute, meterCacheHealBound(10*time.Minute, 5*time.Minute))
+}
+
+func TestMeterCacheStaticReject(t *testing.T) {
+	newYork, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	kathmandu, err := time.LoadLocation("Asia/Kathmandu")
+	require.NoError(t, err)
+	lordHowe, err := time.LoadLocation("Australia/Lord_Howe")
+	require.NoError(t, err)
+
+	parse := func(s string) time.Time {
+		ts, err := time.Parse(time.RFC3339, s)
+		require.NoError(t, err)
+		return ts
+	}
+
+	baseMeter := meter.Meter{
+		Key:           "meter1",
+		EventType:     "event1",
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+		GroupBy:       map[string]string{"group1": "$.group1"},
+	}
+
+	baseCache := CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	}
+
+	baseParams := func() streaming.QueryParams {
+		return streaming.QueryParams{
+			Cachable:   true,
+			From:       lo.ToPtr(parse("2025-01-01T00:00:00Z")),
+			To:         lo.ToPtr(parse("2025-02-01T00:00:00Z")),
+			WindowSize: lo.ToPtr(meter.WindowSizeHour),
+		}
+	}
+
+	tests := []struct {
+		name string
+
+		meter   func(m meter.Meter) meter.Meter
+		params  func(p streaming.QueryParams) streaming.QueryParams
+		cache   func(c CacheConfig) CacheConfig
+		decimal *bool
+
+		want cacheRejectReason
+	}{
+		{
+			name: "windowed query is admitted",
+			want: cacheRejectReasonNone,
+		},
+		{
+			name: "total with from is admitted (G10)",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.WindowSize = nil
+				return p
+			},
+			want: cacheRejectReasonNone,
+		},
+		{
+			name: "window size above grain is admitted",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.WindowSize = lo.ToPtr(meter.WindowSizeMonth)
+				return p
+			},
+			want: cacheRejectReasonNone,
+		},
+		{
+			name: "whole hour offset timezone is admitted",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.WindowTimeZone = newYork
+				return p
+			},
+			want: cacheRejectReasonNone,
+		},
+		{
+			name: "empty stored at filter is admitted",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.FilterStoredAt = &filter.FilterTimeUnix{}
+				return p
+			},
+			want: cacheRejectReasonNone,
+		},
+		{
+			name: "not opted in",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.Cachable = false
+				return p
+			},
+			want: cacheRejectReasonNotOptedIn,
+		},
+		{
+			name: "cache disabled",
+			cache: func(c CacheConfig) CacheConfig {
+				c.Enabled = false
+				return c
+			},
+			want: cacheRejectReasonCacheDisabled,
+		},
+		{
+			name:    "decimal precision disabled",
+			decimal: lo.ToPtr(false),
+			want:    cacheRejectReasonDecimalDisabled,
+		},
+		{
+			name: "missing to",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.To = nil
+				return p
+			},
+			want: cacheRejectReasonNoTo,
+		},
+		{
+			name: "total without from",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.WindowSize = nil
+				p.From = nil
+				return p
+			},
+			want: cacheRejectReasonTotalWithoutFrom,
+		},
+		{
+			name: "window size below grain",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.WindowSize = lo.ToPtr(meter.WindowSizeMinute)
+				return p
+			},
+			want: cacheRejectReasonWindowBelowGrain,
+		},
+		{
+			name: "second window size",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.WindowSize = lo.ToPtr(meter.WindowSizeSecond)
+				return p
+			},
+			want: cacheRejectReasonWindowBelowGrain,
+		},
+		{
+			name: "invalid grain",
+			cache: func(c CacheConfig) CacheConfig {
+				c.WindowSize = CacheGrain("week")
+				return c
+			},
+			want: cacheRejectReasonInvalidGrain,
+		},
+		{
+			name: "fractional offset timezone",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.WindowTimeZone = kathmandu
+				return p
+			},
+			want: cacheRejectReasonTimezone,
+		},
+		{
+			// Lord Howe uses +10:30 in standard time and +11:00 in DST: a range inside
+			// the DST period is admissible, one covering standard time is not — the
+			// weekly offset sampling must see the fractional period.
+			name: "half hour standard time zone inside whole hour dst period is admitted",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.WindowTimeZone = lordHowe
+				p.From = lo.ToPtr(parse("2025-01-05T00:00:00Z"))
+				p.To = lo.ToPtr(parse("2025-01-20T00:00:00Z"))
+				return p
+			},
+			want: cacheRejectReasonNone,
+		},
+		{
+			name: "half hour standard time period is rejected by sampling",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.WindowTimeZone = lordHowe
+				p.From = lo.ToPtr(parse("2025-01-05T00:00:00Z"))
+				p.To = lo.ToPtr(parse("2025-06-20T00:00:00Z"))
+				return p
+			},
+			want: cacheRejectReasonTimezone,
+		},
+		{
+			name: "non utc timezone with unbounded from",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.WindowTimeZone = newYork
+				p.From = nil
+				return p
+			},
+			want: cacheRejectReasonTimezone,
+		},
+		{
+			name: "day grain requires utc",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.WindowSize = lo.ToPtr(meter.WindowSizeDay)
+				p.WindowTimeZone = newYork
+				return p
+			},
+			cache: func(c CacheConfig) CacheConfig {
+				c.WindowSize = CacheGrainDay
+				return c
+			},
+			want: cacheRejectReasonDayGrainTimezone,
+		},
+		{
+			name: "day grain with utc is admitted",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.WindowSize = lo.ToPtr(meter.WindowSizeDay)
+				return p
+			},
+			cache: func(c CacheConfig) CacheConfig {
+				c.WindowSize = CacheGrainDay
+				return c
+			},
+			want: cacheRejectReasonNone,
+		},
+		{
+			name: "customer filter",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.FilterCustomer = []streaming.Customer{nil}
+				return p
+			},
+			want: cacheRejectReasonFilterCustomer,
+		},
+		{
+			name: "customer id group by",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.GroupBy = []string{"customer_id"}
+				return p
+			},
+			want: cacheRejectReasonCustomerIDGroupBy,
+		},
+		{
+			name: "client id progress tracking",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.ClientID = lo.ToPtr("client-1")
+				return p
+			},
+			want: cacheRejectReasonClientID,
+		},
+		{
+			name: "stored at filter",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.FilterStoredAt = &filter.FilterTimeUnix{
+					FilterTime: filter.FilterTime{Lt: lo.ToPtr(parse("2025-01-15T00:00:00Z"))},
+				}
+				return p
+			},
+			want: cacheRejectReasonFilterStoredAt,
+		},
+		{
+			name: "group by outside the meter",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.GroupBy = []string{"group2"}
+				return p
+			},
+			want: cacheRejectReasonGroupByUnknownKey,
+		},
+		{
+			name: "filter group by outside the meter",
+			params: func(p streaming.QueryParams) streaming.QueryParams {
+				p.FilterGroupBy = map[string]filter.FilterString{"group2": {Eq: lo.ToPtr("a")}}
+				return p
+			},
+			want: cacheRejectReasonFilterGroupByUnknown,
+		},
+		{
+			name: "reserved alias group by key",
+			meter: func(m meter.Meter) meter.Meter {
+				m.GroupBy = map[string]string{"namespace": "$.namespace"}
+				return m
+			},
+			want: cacheRejectReasonReservedAlias,
+		},
+		{
+			name: "reserved suffix group by key",
+			meter: func(m meter.Meter) meter.Meter {
+				m.GroupBy = map[string]string{"custom_value": "$.custom"}
+				return m
+			},
+			want: cacheRejectReasonReservedAlias,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := baseMeter
+			if tt.meter != nil {
+				m = tt.meter(m)
+			}
+
+			params := baseParams()
+			if tt.params != nil {
+				params = tt.params(params)
+			}
+
+			cache := baseCache
+			if tt.cache != nil {
+				cache = tt.cache(cache)
+			}
+
+			decimal := true
+			if tt.decimal != nil {
+				decimal = *tt.decimal
+			}
+
+			assert.Equal(t, tt.want, meterCacheStaticReject(m, params, cache, decimal))
+		})
+	}
+}
+
+// fakeCountRow implements driver.Row for the gate's marker overlap scan.
+type fakeCountRow struct {
+	count uint64
+	err   error
+}
+
+func (r fakeCountRow) Err() error { return r.err }
+
+func (r fakeCountRow) ScanStruct(any) error { return fmt.Errorf("not implemented") }
+
+func (r fakeCountRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+
+	*(dest[0].(*uint64)) = r.count
+
+	return nil
+}
+
+func TestMeterCacheGateEligibility(t *testing.T) {
+	baseMeter := meter.Meter{
+		Key:           "meter1",
+		EventType:     "event1",
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	cache := CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	}
+
+	hash := meterHash(baseMeter, cache.WindowSize)
+
+	now := time.Now().UTC()
+	lastSuccess := now.Add(-time.Minute)
+	refreshStart := lastSuccess.Add(-5 * time.Second)
+
+	healthyState := func() meterCacheViewState {
+		return meterCacheViewState{
+			Exists:     true,
+			MetadataOK: true,
+			Metadata: meterCacheMVMetadata{
+				MeterKey:     baseMeter.Key,
+				EventType:    baseMeter.EventType,
+				MeterHash:    formatCacheHash(hash),
+				DDLHash:      formatCacheHash(hash),
+				BackfilledAt: lo.ToPtr(now.Add(-24 * time.Hour)),
+			},
+			LastSuccessTime:       &lastSuccess,
+			LastSuccessDurationMS: lo.ToPtr(uint64(5000)),
+		}
+	}
+
+	newGate := func(state meterCacheViewState, unhealedMarkers uint64) *meterCacheGate {
+		mockCH := NewMockClickHouse()
+		mockCH.On("QueryRow", mock.Anything, mock.Anything, mock.Anything).
+			Return(fakeCountRow{count: unhealedMarkers})
+
+		gate := &meterCacheGate{
+			logger:                 slog.Default(),
+			clickhouse:             mockCH,
+			database:               "openmeter",
+			cache:                  cache,
+			enableDecimalPrecision: true,
+			viewStateTTL:           meterCacheViewStateTTL,
+			viewStates:             map[string]meterCacheViewStateEntry{},
+		}
+
+		gate.fetchViewState = func(ctx context.Context, viewName string) (meterCacheViewState, error) {
+			return state, nil
+		}
+
+		return gate
+	}
+
+	baseQuery := func() (queryMeter, streaming.QueryParams) {
+		from := now.Add(-5 * time.Hour)
+		to := now
+
+		params := streaming.QueryParams{
+			Cachable:   true,
+			From:       &from,
+			To:         &to,
+			WindowSize: lo.ToPtr(meter.WindowSizeHour),
+		}
+
+		return queryMeter{
+			Database:               "openmeter",
+			EventsTableName:        "om_events",
+			Namespace:              "my_namespace",
+			Meter:                  baseMeter,
+			From:                   params.From,
+			To:                     params.To,
+			WindowSize:             params.WindowSize,
+			EnableDecimalPrecision: true,
+		}, params
+	}
+
+	t.Run("healthy stamped view with healed markers is eligible", func(t *testing.T) {
+		gate := newGate(healthyState(), 0)
+		query, params := baseQuery()
+
+		bounds, reason, err := gate.cacheEligibility(t.Context(), query, params)
+		require.NoError(t, err)
+		require.Equal(t, cacheRejectReasonNone, reason)
+
+		wantBounds, ok, err := meterCacheBounds(query.From, *query.To, refreshStart, cache.MinimumUsageAge, cache.WindowSize)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.NotNil(t, bounds.CacheLo)
+		assert.True(t, bounds.CacheLo.Equal(*wantBounds.CacheLo))
+		assert.True(t, bounds.CacheHi.Equal(wantBounds.CacheHi))
+	})
+
+	t.Run("static reject short circuits before any lookup", func(t *testing.T) {
+		gate := newGate(healthyState(), 0)
+		gate.fetchViewState = func(ctx context.Context, viewName string) (meterCacheViewState, error) {
+			t.Fatal("view state must not be fetched for statically rejected queries")
+			return meterCacheViewState{}, nil
+		}
+
+		query, params := baseQuery()
+		params.Cachable = false
+
+		_, reason, err := gate.cacheEligibility(t.Context(), query, params)
+		require.NoError(t, err)
+		assert.Equal(t, cacheRejectReasonNotOptedIn, reason)
+	})
+
+	t.Run("missing view", func(t *testing.T) {
+		gate := newGate(meterCacheViewState{Exists: false}, 0)
+		query, params := baseQuery()
+
+		_, reason, err := gate.cacheEligibility(t.Context(), query, params)
+		require.NoError(t, err)
+		assert.Equal(t, cacheRejectReasonViewMissing, reason)
+	})
+
+	t.Run("unparseable metadata is foreign", func(t *testing.T) {
+		state := healthyState()
+		state.MetadataOK = false
+
+		gate := newGate(state, 0)
+		query, params := baseQuery()
+
+		_, reason, err := gate.cacheEligibility(t.Context(), query, params)
+		require.NoError(t, err)
+		assert.Equal(t, cacheRejectReasonViewForeign, reason)
+	})
+
+	t.Run("same shape sibling meter owning the view is foreign", func(t *testing.T) {
+		state := healthyState()
+		state.Metadata.MeterKey = "meter2"
+
+		gate := newGate(state, 0)
+		query, params := baseQuery()
+
+		_, reason, err := gate.cacheEligibility(t.Context(), query, params)
+		require.NoError(t, err)
+		assert.Equal(t, cacheRejectReasonViewForeign, reason)
+	})
+
+	t.Run("unstamped backfill (G3)", func(t *testing.T) {
+		state := healthyState()
+		state.Metadata.BackfilledAt = nil
+
+		gate := newGate(state, 0)
+		query, params := baseQuery()
+
+		_, reason, err := gate.cacheEligibility(t.Context(), query, params)
+		require.NoError(t, err)
+		assert.Equal(t, cacheRejectReasonBackfillUnstamped, reason)
+	})
+
+	t.Run("refresh exception", func(t *testing.T) {
+		state := healthyState()
+		state.Exception = "boom"
+
+		gate := newGate(state, 0)
+		query, params := baseQuery()
+
+		_, reason, err := gate.cacheEligibility(t.Context(), query, params)
+		require.NoError(t, err)
+		assert.Equal(t, cacheRejectReasonViewException, reason)
+	})
+
+	t.Run("never refreshed view is stale", func(t *testing.T) {
+		state := healthyState()
+		state.LastSuccessTime = nil
+		state.LastSuccessDurationMS = nil
+
+		gate := newGate(state, 0)
+		query, params := baseQuery()
+
+		_, reason, err := gate.cacheEligibility(t.Context(), query, params)
+		require.NoError(t, err)
+		assert.Equal(t, cacheRejectReasonViewStale, reason)
+	})
+
+	t.Run("refresh older than three intervals is stale", func(t *testing.T) {
+		state := healthyState()
+		state.LastSuccessTime = lo.ToPtr(now.Add(-31 * time.Minute))
+
+		gate := newGate(state, 0)
+		query, params := baseQuery()
+
+		_, reason, err := gate.cacheEligibility(t.Context(), query, params)
+		require.NoError(t, err)
+		assert.Equal(t, cacheRejectReasonViewStale, reason)
+	})
+
+	t.Run("range without a settled bucket is empty", func(t *testing.T) {
+		gate := newGate(healthyState(), 0)
+		query, params := baseQuery()
+
+		from := now.Add(-30 * time.Minute)
+		params.From = &from
+		query.From = &from
+
+		_, reason, err := gate.cacheEligibility(t.Context(), query, params)
+		require.NoError(t, err)
+		assert.Equal(t, cacheRejectReasonEmptyCacheRange, reason)
+	})
+
+	t.Run("unhealed markers send the whole query live (G1)", func(t *testing.T) {
+		gate := newGate(healthyState(), 1)
+		query, params := baseQuery()
+
+		_, reason, err := gate.cacheEligibility(t.Context(), query, params)
+		require.NoError(t, err)
+		assert.Equal(t, cacheRejectReasonUnhealedMarkers, reason)
+	})
+
+	t.Run("view state fetch failure is an error", func(t *testing.T) {
+		gate := newGate(healthyState(), 0)
+		gate.fetchViewState = func(ctx context.Context, viewName string) (meterCacheViewState, error) {
+			return meterCacheViewState{}, fmt.Errorf("boom")
+		}
+
+		query, params := baseQuery()
+
+		_, _, err := gate.cacheEligibility(t.Context(), query, params)
+		require.Error(t, err)
+	})
+}
+
+func TestMeterCacheGateViewStateMemoization(t *testing.T) {
+	fetches := 0
+
+	gate := &meterCacheGate{
+		logger:       slog.Default(),
+		viewStateTTL: meterCacheViewStateTTL,
+		viewStates:   map[string]meterCacheViewStateEntry{},
+	}
+
+	gate.fetchViewState = func(ctx context.Context, viewName string) (meterCacheViewState, error) {
+		fetches++
+		return meterCacheViewState{Exists: true}, nil
+	}
+
+	// given:
+	// - two lookups within the TTL
+	// then:
+	// - only one fetch hits the backend (G13)
+	_, err := gate.viewState(t.Context(), "view1")
+	require.NoError(t, err)
+	_, err = gate.viewState(t.Context(), "view1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, fetches)
+
+	// given:
+	// - a different view
+	// then:
+	// - the memo is per view
+	_, err = gate.viewState(t.Context(), "view2")
+	require.NoError(t, err)
+	assert.Equal(t, 2, fetches)
+
+	// given:
+	// - the entry aged past the TTL
+	// then:
+	// - the next lookup re-fetches
+	entry := gate.viewStates["view1"]
+	entry.fetchedAt = time.Now().Add(-gate.viewStateTTL - time.Second)
+	gate.viewStates["view1"] = entry
+
+	_, err = gate.viewState(t.Context(), "view1")
+	require.NoError(t, err)
+	assert.Equal(t, 3, fetches)
+}

--- a/openmeter/streaming/clickhouse/meter_cache_gate_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_gate_test.go
@@ -378,6 +378,7 @@ func TestMeterCacheGateEligibility(t *testing.T) {
 			Exists:     true,
 			MetadataOK: true,
 			Metadata: meterCacheMVMetadata{
+				Namespace:    "my_namespace",
 				MeterKey:     baseMeter.Key,
 				EventType:    baseMeter.EventType,
 				MeterHash:    formatCacheHash(hash),
@@ -489,6 +490,27 @@ func TestMeterCacheGateEligibility(t *testing.T) {
 	t.Run("same shape sibling meter owning the view is foreign", func(t *testing.T) {
 		state := healthyState()
 		state.Metadata.MeterKey = "meter2"
+
+		gate := newGate(state, 0)
+		query, params := baseQuery()
+
+		_, reason, err := gate.cacheEligibility(t.Context(), query, params)
+		require.NoError(t, err)
+		assert.Equal(t, cacheRejectReasonViewForeign, reason)
+	})
+
+	t.Run("name fold colliding namespace owning the view is foreign", func(t *testing.T) {
+		// The view name folds the namespace to fnv32 8-hex, so another namespace defining
+		// the same meter (same key, event type, and shape hash — the hash excludes the
+		// namespace) can resolve to this very view. Admitting it would serve an empty
+		// cache leg (rows carry the owner's namespace) and silently zero all settled
+		// history, so only the exact recorded namespace passes.
+		//
+		// Watched RED with the guard reverted: removing the namespace comparison from
+		// cacheEligibility's foreign-view check makes this query eligible (every other
+		// metadata field matches).
+		state := healthyState()
+		state.Metadata.Namespace = "colliding_namespace"
 
 		gate := newGate(state, 0)
 		query, params := baseQuery()

--- a/openmeter/streaming/clickhouse/meter_cache_gate_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_gate_test.go
@@ -127,6 +127,21 @@ func TestMeterCacheStaticReject(t *testing.T) {
 			want: cacheRejectReasonCacheDisabled,
 		},
 		{
+			// LATEST is excluded from the cache entirely (no MV, no combine form): it only
+			// ever needs the newest value in the queried window, so there is no
+			// re-aggregation of settled history to save.
+			//
+			// Watched RED: commenting out the meterCacheStaticReject LATEST check flips this
+			// case's result to cacheRejectReasonNone, proving the gate is what excludes it
+			// rather than some downstream failure.
+			name: "latest aggregation is excluded from the cache",
+			meter: func(m meter.Meter) meter.Meter {
+				m.Aggregation = meter.MeterAggregationLatest
+				return m
+			},
+			want: cacheRejectReasonLatestAggregation,
+		},
+		{
 			name:    "decimal precision disabled",
 			decimal: lo.ToPtr(false),
 			want:    cacheRejectReasonDecimalDisabled,

--- a/openmeter/streaming/clickhouse/meter_cache_hash.go
+++ b/openmeter/streaming/clickhouse/meter_cache_hash.go
@@ -62,18 +62,27 @@ func hashComponent(h hash.Hash64, s string) {
 	_, _ = fmt.Fprintf(h, "%d:%s", len(s), s)
 }
 
-// mvName returns the deterministic name of the cache MV for a meter shape in a namespace:
-// om_meter_cache_mv_<ns8>_<hash16>. The namespace is folded to 8 hex chars because
-// namespace strings can be long and contain characters invalid in identifiers; hash is
-// the meterHash of the shape. Data safety does not depend on this name (rows are keyed by
-// namespace + meter_hash), it only has to be unique enough for the reconciler's
-// system.tables prefix scan.
-func mvName(namespace string, hash uint64) string {
+// mvNamePrefixForNamespace returns the name prefix shared by every cache MV of one
+// namespace: om_meter_cache_mv_<ns8>_. The namespace is folded to 8 hex chars because
+// namespace strings can be long and contain characters invalid in identifiers. Distinct
+// namespaces can collide on the folded prefix, which is acceptable because the prefix is
+// only used for discovery (refresh triggering, reconciler scans) where a collision at
+// worst touches another namespace's views; data reads are keyed by the full namespace and
+// meter_hash columns, never by this name.
+func mvNamePrefixForNamespace(namespace string) string {
 	ns := fnv.New32a()
 	// hash.Hash Write never returns an error
 	_, _ = ns.Write([]byte(namespace))
 
-	return fmt.Sprintf("%s%08x_%016x", meterCacheMVNamePrefix, ns.Sum32(), hash)
+	return fmt.Sprintf("%s%08x_", meterCacheMVNamePrefix, ns.Sum32())
+}
+
+// mvName returns the deterministic name of the cache MV for a meter shape in a namespace:
+// om_meter_cache_mv_<ns8>_<hash16>, where hash is the meterHash of the shape. Data safety
+// does not depend on this name (rows are keyed by namespace + meter_hash), it only has to
+// be unique enough for the reconciler's system.tables prefix scan.
+func mvName(namespace string, hash uint64) string {
+	return fmt.Sprintf("%s%016x", mvNamePrefixForNamespace(namespace), hash)
 }
 
 // ddlHash detects drift between a deployed MV and the DDL the generator would emit today,

--- a/openmeter/streaming/clickhouse/meter_cache_hash.go
+++ b/openmeter/streaming/clickhouse/meter_cache_hash.go
@@ -1,0 +1,194 @@
+package clickhouse
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"maps"
+	"slices"
+	"strconv"
+	"time"
+
+	meterpkg "github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// meterHash identifies the cached shape of a meter: which rows in om_meter_cache belong
+// to this meter's current definition. It covers everything that changes what a cached row
+// means — event type, aggregation, value property, the group-by dimension map, and the
+// cache grain. The grain is included deliberately (a grain config change reads as a shape
+// change): rows bucketed at the old grain must be filtered out by hash and GC'd, never
+// co-read with rows at the new grain.
+//
+// The meter key and namespace are intentionally excluded: rows carry both as columns and
+// every read co-filters on namespace, so the hash only needs to capture shape.
+func meterHash(m meterpkg.Meter, grain CacheGrain) uint64 {
+	h := fnv.New64a()
+
+	hashComponent(h, m.EventType)
+	hashComponent(h, string(m.Aggregation))
+
+	// Presence marker distinguishes a nil value property from an empty one and anchors
+	// the section so group-by content cannot bleed into it.
+	if m.ValueProperty == nil {
+		hashComponent(h, "0")
+	} else {
+		hashComponent(h, "1")
+		hashComponent(h, *m.ValueProperty)
+	}
+
+	keys := slices.Sorted(maps.Keys(m.GroupBy))
+
+	// The pair count anchors the group-by section so its content cannot bleed into the
+	// grain component.
+	hashComponent(h, strconv.Itoa(len(keys)))
+
+	for _, key := range keys {
+		hashComponent(h, key)
+		hashComponent(h, m.GroupBy[key])
+	}
+
+	hashComponent(h, string(grain))
+
+	return h.Sum64()
+}
+
+// hashComponent writes s length-prefixed so component boundaries stay unambiguous:
+// ("ab", "c") must never hash equal to ("a", "bc").
+func hashComponent(h hash.Hash64, s string) {
+	// hash.Hash Write never returns an error
+	_, _ = fmt.Fprintf(h, "%d:%s", len(s), s)
+}
+
+// mvName returns the deterministic name of the cache MV for a meter shape in a namespace:
+// om_meter_cache_mv_<ns8>_<hash16>. The namespace is folded to 8 hex chars because
+// namespace strings can be long and contain characters invalid in identifiers; hash is
+// the meterHash of the shape. Data safety does not depend on this name (rows are keyed by
+// namespace + meter_hash), it only has to be unique enough for the reconciler's
+// system.tables prefix scan.
+func mvName(namespace string, hash uint64) string {
+	ns := fnv.New32a()
+	// hash.Hash Write never returns an error
+	_, _ = ns.Write([]byte(namespace))
+
+	return fmt.Sprintf("%s%08x_%016x", meterCacheMVNamePrefix, ns.Sum32(), hash)
+}
+
+// ddlHash detects drift between a deployed MV and the DDL the generator would emit today,
+// beyond what meterHash covers: refresh cadence, freshness horizon, EventFrom, and the
+// full generated SELECT (so any generator change is treated as drift). The reconciler
+// drops and recreates the MV when it differs; whether that recreate also needs a
+// re-backfill depends on which input moved, which is why the inputs are hashed alongside
+// the SELECT instead of relying on the SELECT text alone.
+func ddlHash(grain CacheGrain, refreshInterval, minimumUsageAge time.Duration, eventFrom *time.Time, selectSQL string) uint64 {
+	h := fnv.New64a()
+
+	hashComponent(h, string(grain))
+	hashComponent(h, refreshInterval.String())
+	hashComponent(h, minimumUsageAge.String())
+
+	if eventFrom == nil {
+		hashComponent(h, "0")
+	} else {
+		hashComponent(h, "1")
+		hashComponent(h, strconv.FormatInt(eventFrom.Unix(), 10))
+	}
+
+	hashComponent(h, selectSQL)
+
+	return h.Sum64()
+}
+
+// formatCacheHash renders a meterHash or ddlHash for the MV comment metadata. Hashes are
+// stored as fixed-width hex strings, not JSON numbers, because uint64 values above 2^53
+// do not survive a JSON number round-trip through arbitrary tooling.
+func formatCacheHash(hash uint64) string {
+	return fmt.Sprintf("%016x", hash)
+}
+
+// parseCacheHash parses a hash formatted by formatCacheHash. The fixed 16-char width is
+// enforced so hand-edited or foreign comments fail parsing instead of silently comparing
+// unequal to freshly formatted hashes.
+func parseCacheHash(s string) (uint64, error) {
+	if len(s) != 16 {
+		return 0, fmt.Errorf("cache hash must be 16 hex characters, got %d", len(s))
+	}
+
+	hash, err := strconv.ParseUint(s, 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("cache hash is not valid hex: %w", err)
+	}
+
+	return hash, nil
+}
+
+// meterCacheMVMetadata is the JSON document stored in the cache MV's COMMENT. It is the
+// reconciler's and reader's only source of truth about a deployed MV: which meter it
+// serves, which shape (meter_hash) and generator output (ddl_hash) it was created from,
+// and whether its backfill completed.
+//
+// BackfilledAt is nil until the one-time backfill finishes; it is stamped afterwards via
+// ALTER TABLE ... MODIFY COMMENT. Readers must refuse the cache while it is unstamped: an
+// MV that exists but was never backfilled only contains recently refreshed buckets, and
+// serving it would silently drop all older history from query results.
+type meterCacheMVMetadata struct {
+	MeterKey     string     `json:"meter_key"`
+	EventType    string     `json:"event_type"`
+	MeterHash    string     `json:"meter_hash"`
+	DDLHash      string     `json:"ddl_hash"`
+	BackfilledAt *time.Time `json:"backfilled_at,omitempty"`
+}
+
+func (m meterCacheMVMetadata) Validate() error {
+	var errs []error
+
+	if m.MeterKey == "" {
+		errs = append(errs, errors.New("meter_key is required"))
+	}
+
+	if m.EventType == "" {
+		errs = append(errs, errors.New("event_type is required"))
+	}
+
+	if _, err := parseCacheHash(m.MeterHash); err != nil {
+		errs = append(errs, fmt.Errorf("meter_hash: %w", err))
+	}
+
+	if _, err := parseCacheHash(m.DDLHash); err != nil {
+		errs = append(errs, fmt.Errorf("ddl_hash: %w", err))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+func (m meterCacheMVMetadata) marshal() (string, error) {
+	if err := m.Validate(); err != nil {
+		return "", fmt.Errorf("validate meter cache mv metadata: %w", err)
+	}
+
+	data, err := json.Marshal(m)
+	if err != nil {
+		return "", fmt.Errorf("marshal meter cache mv metadata: %w", err)
+	}
+
+	return string(data), nil
+}
+
+// parseMeterCacheMVMetadata parses an MV comment read back from system.tables. A non-nil
+// error means the view must be treated as foreign or corrupt (read live, let the
+// reconciler repair it), never trusted as a healthy cache MV.
+func parseMeterCacheMVMetadata(comment string) (meterCacheMVMetadata, error) {
+	var metadata meterCacheMVMetadata
+
+	if err := json.Unmarshal([]byte(comment), &metadata); err != nil {
+		return meterCacheMVMetadata{}, fmt.Errorf("unmarshal meter cache mv metadata: %w", err)
+	}
+
+	if err := metadata.Validate(); err != nil {
+		return meterCacheMVMetadata{}, fmt.Errorf("validate meter cache mv metadata: %w", err)
+	}
+
+	return metadata, nil
+}

--- a/openmeter/streaming/clickhouse/meter_cache_hash.go
+++ b/openmeter/streaming/clickhouse/meter_cache_hash.go
@@ -134,24 +134,48 @@ func parseCacheHash(s string) (uint64, error) {
 }
 
 // meterCacheMVMetadata is the JSON document stored in the cache MV's COMMENT. It is the
-// reconciler's and reader's only source of truth about a deployed MV: which meter it
-// serves, which shape (meter_hash) and generator output (ddl_hash) it was created from,
-// and whether its backfill completed.
+// reconciler's and reader's only source of truth about a deployed MV: which meter (and
+// namespace) it serves, which shape (meter_hash) and generator output (ddl_hash) it was
+// created from, and whether its backfill completed.
+//
+// Namespace is the exact namespace the MV was generated for. The MV name only carries an
+// 8-hex fold of the namespace, so two namespaces can collide on the same view name; a
+// same-shape meter in the colliding namespace would then pass every hash/key comparison
+// against the other namespace's view while its cache leg matches zero rows (rows are
+// written with the owner's namespace column). Recording the full namespace lets the read
+// gate and the reconciler refuse such a view instead of silently serving empty history.
 //
 // BackfilledAt is nil until the one-time backfill finishes; it is stamped afterwards via
-// ALTER TABLE ... MODIFY COMMENT. Readers must refuse the cache while it is unstamped: an
-// MV that exists but was never backfilled only contains recently refreshed buckets, and
-// serving it would silently drop all older history from query results.
+// ALTER TABLE ... MODIFY COMMENT, but its value is the ClickHouse-clock instant the
+// backfill started scanning. Readers must refuse the cache while it is unstamped: an MV
+// that exists but was never backfilled only contains recently refreshed buckets, and
+// serving it would silently drop all older history from query results. The start-time
+// value is what makes it usable as a marker heal bound: every invalidation marker written
+// before the backfill started describes late events the full-history backfill has
+// provably re-aggregated.
+//
+// CoveredAt is the durable refresh-coverage watermark: the newest successful refresh time
+// the reconciler observed while coverage was still provably continuous. It exists because
+// system.view_refreshes is per-server in-memory state — a ClickHouse restart wipes it, so
+// last_success_time alone cannot reveal that refreshes were absent for longer than the
+// dirty-window slack before the restart. Without the watermark such an outage would leave
+// buckets settled mid-outage permanently missing from the cache.
 type meterCacheMVMetadata struct {
+	Namespace    string     `json:"namespace"`
 	MeterKey     string     `json:"meter_key"`
 	EventType    string     `json:"event_type"`
 	MeterHash    string     `json:"meter_hash"`
 	DDLHash      string     `json:"ddl_hash"`
 	BackfilledAt *time.Time `json:"backfilled_at,omitempty"`
+	CoveredAt    *time.Time `json:"covered_at,omitempty"`
 }
 
 func (m meterCacheMVMetadata) Validate() error {
 	var errs []error
+
+	if m.Namespace == "" {
+		errs = append(errs, errors.New("namespace is required"))
+	}
 
 	if m.MeterKey == "" {
 		errs = append(errs, errors.New("meter_key is required"))

--- a/openmeter/streaming/clickhouse/meter_cache_hash_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_hash_test.go
@@ -1,0 +1,221 @@
+package clickhouse
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+)
+
+func pinnedHashMeter() meter.Meter {
+	return meter.Meter{
+		EventType:     "api-calls",
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.tokens"),
+		GroupBy:       map[string]string{"model": "$.model", "region": "$.region"},
+	}
+}
+
+func TestMeterHash(t *testing.T) {
+	base := pinnedHashMeter()
+
+	t.Run("pinned value", func(t *testing.T) {
+		// Cached rows are keyed by this hash in production: an unintended algorithm or
+		// input-ordering change would orphan every cached row (and re-backfill every
+		// meter), so the exact value is pinned. Update the constant only for a
+		// deliberate, migration-aware hash change.
+		require.Equal(t, uint64(0xfe20ef28411f6935), meterHash(base, CacheGrainHour))
+	})
+
+	t.Run("independent of group by map iteration order", func(t *testing.T) {
+		// Maps iterate in random order; repeated calls only agree if keys are sorted.
+		for range 100 {
+			require.Equal(t, uint64(0xfe20ef28411f6935), meterHash(pinnedHashMeter(), CacheGrainHour))
+		}
+	})
+
+	t.Run("grain is part of the shape (G4)", func(t *testing.T) {
+		// A grain config change must read as a shape change so old-grain rows are
+		// filtered out by hash instead of being co-read with new-grain rows.
+		hour := meterHash(base, CacheGrainHour)
+		require.NotEqual(t, hour, meterHash(base, CacheGrainMinute))
+		require.NotEqual(t, hour, meterHash(base, CacheGrainDay))
+	})
+
+	t.Run("sensitive to every shape input", func(t *testing.T) {
+		pinned := meterHash(base, CacheGrainHour)
+
+		mutations := map[string]func(m *meter.Meter){
+			"event type":           func(m *meter.Meter) { m.EventType = "other" },
+			"aggregation":          func(m *meter.Meter) { m.Aggregation = meter.MeterAggregationAvg },
+			"value property":       func(m *meter.Meter) { m.ValueProperty = lo.ToPtr("$.other") },
+			"nil value property":   func(m *meter.Meter) { m.ValueProperty = nil },
+			"group by path":        func(m *meter.Meter) { m.GroupBy["model"] = "$.other" },
+			"group by key added":   func(m *meter.Meter) { m.GroupBy["extra"] = "$.extra" },
+			"group by key removed": func(m *meter.Meter) { delete(m.GroupBy, "region") },
+			"empty group by":       func(m *meter.Meter) { m.GroupBy = nil },
+		}
+
+		for name, mutate := range mutations {
+			t.Run(name, func(t *testing.T) {
+				m := pinnedHashMeter()
+				mutate(&m)
+				require.NotEqual(t, pinned, meterHash(m, CacheGrainHour))
+			})
+		}
+	})
+
+	t.Run("insensitive to non-shape fields", func(t *testing.T) {
+		m := pinnedHashMeter()
+		m.Key = "renamed-meter"
+		m.EventFrom = lo.ToPtr(time.Now())
+		require.Equal(t, meterHash(base, CacheGrainHour), meterHash(m, CacheGrainHour))
+	})
+
+	t.Run("component boundaries do not bleed", func(t *testing.T) {
+		a := meter.Meter{EventType: "e", Aggregation: meter.MeterAggregationCount, GroupBy: map[string]string{"ab": "cd"}}
+		b := meter.Meter{EventType: "e", Aggregation: meter.MeterAggregationCount, GroupBy: map[string]string{"a": "bcd"}}
+		require.NotEqual(t, meterHash(a, CacheGrainHour), meterHash(b, CacheGrainHour))
+
+		// nil vs empty value property differ via the presence marker
+		c := meter.Meter{EventType: "e", Aggregation: meter.MeterAggregationCount, ValueProperty: lo.ToPtr("")}
+		d := meter.Meter{EventType: "e", Aggregation: meter.MeterAggregationCount}
+		require.NotEqual(t, meterHash(c, CacheGrainHour), meterHash(d, CacheGrainHour))
+	})
+}
+
+func TestMVName(t *testing.T) {
+	hash := meterHash(pinnedHashMeter(), CacheGrainHour)
+
+	t.Run("pinned format", func(t *testing.T) {
+		// The reconciler discovers cache MVs by this prefix and correlates them to
+		// meters by the hash16 suffix; the format is part of the deployed contract.
+		require.Equal(t, "om_meter_cache_mv_933b5bde_fe20ef28411f6935", mvName("default", hash))
+	})
+
+	t.Run("namespace changes the name", func(t *testing.T) {
+		require.NotEqual(t, mvName("default", hash), mvName("other", hash))
+	})
+
+	t.Run("always carries the reconciler scan prefix", func(t *testing.T) {
+		assert.Regexp(t, `^om_meter_cache_mv_[0-9a-f]{8}_[0-9a-f]{16}$`, mvName("Any Namespace ✔", hash))
+	})
+}
+
+func TestDDLHash(t *testing.T) {
+	eventFrom, err := time.Parse(time.RFC3339, "2025-01-01T00:00:00Z")
+	require.NoError(t, err)
+
+	base := ddlHash(CacheGrainHour, 10*time.Minute, time.Hour, nil, "SELECT 1")
+
+	t.Run("pinned value", func(t *testing.T) {
+		// Pinned for the same reason as meterHash: an accidental change would make the
+		// reconciler drop and recreate (and possibly re-backfill) every deployed MV at
+		// once on the next pass.
+		require.Equal(t, uint64(0x863516d3145c3294), base)
+	})
+
+	t.Run("sensitive to every input", func(t *testing.T) {
+		require.NotEqual(t, base, ddlHash(CacheGrainMinute, 10*time.Minute, time.Hour, nil, "SELECT 1"))
+		require.NotEqual(t, base, ddlHash(CacheGrainHour, 5*time.Minute, time.Hour, nil, "SELECT 1"))
+		require.NotEqual(t, base, ddlHash(CacheGrainHour, 10*time.Minute, 2*time.Hour, nil, "SELECT 1"))
+		require.NotEqual(t, base, ddlHash(CacheGrainHour, 10*time.Minute, time.Hour, &eventFrom, "SELECT 1"))
+		require.NotEqual(t, base, ddlHash(CacheGrainHour, 10*time.Minute, time.Hour, nil, "SELECT 2"))
+	})
+}
+
+func TestCacheHashFormat(t *testing.T) {
+	t.Run("round trip", func(t *testing.T) {
+		for _, hash := range []uint64{0, 1, 0xfe20ef28411f6935, ^uint64(0)} {
+			formatted := formatCacheHash(hash)
+			require.Len(t, formatted, 16)
+
+			parsed, err := parseCacheHash(formatted)
+			require.NoError(t, err)
+			require.Equal(t, hash, parsed)
+		}
+	})
+
+	t.Run("rejects non-canonical widths and non-hex", func(t *testing.T) {
+		_, err := parseCacheHash("2a")
+		require.ErrorContains(t, err, "16 hex characters")
+
+		_, err = parseCacheHash("zzzzzzzzzzzzzzzz")
+		require.ErrorContains(t, err, "not valid hex")
+	})
+}
+
+func TestMeterCacheMVMetadata(t *testing.T) {
+	backfilledAt, err := time.Parse(time.RFC3339, "2026-07-03T09:00:00Z")
+	require.NoError(t, err)
+
+	valid := meterCacheMVMetadata{
+		MeterKey:  "meter1",
+		EventType: "event1",
+		MeterHash: formatCacheHash(0xfe20ef28411f6935),
+		DDLHash:   formatCacheHash(0x863516d3145c3294),
+	}
+
+	t.Run("marshal is stable and unstamped by default", func(t *testing.T) {
+		comment, err := valid.marshal()
+		require.NoError(t, err)
+		// backfilled_at must be absent (not null) while unstamped: its presence is the
+		// reader's G3 gate.
+		require.Equal(t, `{"meter_key":"meter1","event_type":"event1","meter_hash":"fe20ef28411f6935","ddl_hash":"863516d3145c3294"}`, comment)
+	})
+
+	t.Run("round trip with backfilled_at stamp", func(t *testing.T) {
+		stamped := valid
+		stamped.BackfilledAt = &backfilledAt
+
+		comment, err := stamped.marshal()
+		require.NoError(t, err)
+
+		parsed, err := parseMeterCacheMVMetadata(comment)
+		require.NoError(t, err)
+		require.Equal(t, stamped, parsed)
+	})
+
+	t.Run("round trip without stamp", func(t *testing.T) {
+		comment, err := valid.marshal()
+		require.NoError(t, err)
+
+		parsed, err := parseMeterCacheMVMetadata(comment)
+		require.NoError(t, err)
+		require.Equal(t, valid, parsed)
+		require.Nil(t, parsed.BackfilledAt)
+	})
+
+	t.Run("parse rejects foreign comments", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			comment string
+			wantErr string
+		}{
+			{name: "not json", comment: "some human comment", wantErr: "unmarshal"},
+			{name: "empty json", comment: "{}", wantErr: "meter_key is required"},
+			{name: "missing event type", comment: `{"meter_key":"m","meter_hash":"fe20ef28411f6935","ddl_hash":"863516d3145c3294"}`, wantErr: "event_type is required"},
+			{name: "short hash", comment: `{"meter_key":"m","event_type":"e","meter_hash":"2a","ddl_hash":"863516d3145c3294"}`, wantErr: "meter_hash"},
+			{name: "non-hex ddl hash", comment: `{"meter_key":"m","event_type":"e","meter_hash":"fe20ef28411f6935","ddl_hash":"zzzzzzzzzzzzzzzz"}`, wantErr: "ddl_hash"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				_, err := parseMeterCacheMVMetadata(tt.comment)
+				require.ErrorContains(t, err, tt.wantErr)
+			})
+		}
+	})
+
+	t.Run("marshal refuses invalid metadata", func(t *testing.T) {
+		invalid := valid
+		invalid.MeterHash = "2a"
+
+		_, err := invalid.marshal()
+		require.ErrorContains(t, err, "meter_hash")
+	})
+}

--- a/openmeter/streaming/clickhouse/meter_cache_hash_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_hash_test.go
@@ -154,6 +154,7 @@ func TestMeterCacheMVMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	valid := meterCacheMVMetadata{
+		Namespace: "ns1",
 		MeterKey:  "meter1",
 		EventType: "event1",
 		MeterHash: formatCacheHash(0xfe20ef28411f6935),
@@ -164,13 +165,15 @@ func TestMeterCacheMVMetadata(t *testing.T) {
 		comment, err := valid.marshal()
 		require.NoError(t, err)
 		// backfilled_at must be absent (not null) while unstamped: its presence is the
-		// reader's G3 gate.
-		require.Equal(t, `{"meter_key":"meter1","event_type":"event1","meter_hash":"fe20ef28411f6935","ddl_hash":"863516d3145c3294"}`, comment)
+		// reader's G3 gate. covered_at likewise starts absent and only appears once the
+		// reconciler advances the coverage watermark.
+		require.Equal(t, `{"namespace":"ns1","meter_key":"meter1","event_type":"event1","meter_hash":"fe20ef28411f6935","ddl_hash":"863516d3145c3294"}`, comment)
 	})
 
-	t.Run("round trip with backfilled_at stamp", func(t *testing.T) {
+	t.Run("round trip with backfilled_at and covered_at stamps", func(t *testing.T) {
 		stamped := valid
 		stamped.BackfilledAt = &backfilledAt
+		stamped.CoveredAt = lo.ToPtr(backfilledAt.Add(30 * time.Minute))
 
 		comment, err := stamped.marshal()
 		require.NoError(t, err)
@@ -198,9 +201,13 @@ func TestMeterCacheMVMetadata(t *testing.T) {
 		}{
 			{name: "not json", comment: "some human comment", wantErr: "unmarshal"},
 			{name: "empty json", comment: "{}", wantErr: "meter_key is required"},
-			{name: "missing event type", comment: `{"meter_key":"m","meter_hash":"fe20ef28411f6935","ddl_hash":"863516d3145c3294"}`, wantErr: "event_type is required"},
-			{name: "short hash", comment: `{"meter_key":"m","event_type":"e","meter_hash":"2a","ddl_hash":"863516d3145c3294"}`, wantErr: "meter_hash"},
-			{name: "non-hex ddl hash", comment: `{"meter_key":"m","event_type":"e","meter_hash":"fe20ef28411f6935","ddl_hash":"zzzzzzzzzzzzzzzz"}`, wantErr: "ddl_hash"},
+			// A namespace-less comment is a pre-namespace-metadata deployment: the reader
+			// cannot tell whether it belongs to the querying namespace or a name-fold
+			// colliding one, so it must be treated as foreign and recreated.
+			{name: "missing namespace", comment: `{"meter_key":"m","event_type":"e","meter_hash":"fe20ef28411f6935","ddl_hash":"863516d3145c3294"}`, wantErr: "namespace is required"},
+			{name: "missing event type", comment: `{"namespace":"ns1","meter_key":"m","meter_hash":"fe20ef28411f6935","ddl_hash":"863516d3145c3294"}`, wantErr: "event_type is required"},
+			{name: "short hash", comment: `{"namespace":"ns1","meter_key":"m","event_type":"e","meter_hash":"2a","ddl_hash":"863516d3145c3294"}`, wantErr: "meter_hash"},
+			{name: "non-hex ddl hash", comment: `{"namespace":"ns1","meter_key":"m","event_type":"e","meter_hash":"fe20ef28411f6935","ddl_hash":"zzzzzzzzzzzzzzzz"}`, wantErr: "ddl_hash"},
 		}
 
 		for _, tt := range tests {

--- a/openmeter/streaming/clickhouse/meter_cache_invalidation.go
+++ b/openmeter/streaming/clickhouse/meter_cache_invalidation.go
@@ -12,6 +12,9 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/huandu/go-sqlbuilder"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/openmeterio/openmeter/openmeter/streaming"
 )
@@ -220,6 +223,8 @@ type meterCacheInvalidator struct {
 	database   string
 	cache      CacheConfig
 
+	observability *meterCacheObservability
+
 	throttler *refreshThrottler
 
 	viewListingTTL time.Duration
@@ -227,7 +232,9 @@ type meterCacheInvalidator struct {
 	viewsFetchedAt time.Time
 	views          []deployedCacheMV
 
-	// Metric-style counters, process-local until real metrics wiring exists.
+	// Process-local counters kept alongside the OTel instruments in observability: tests
+	// assert on these directly without needing a metrics reader, while observability
+	// carries the same signal to operators.
 	// markerInsertFailures is the one to alert on (G11): a lost marker is the only failure
 	// mode in this pipeline that can leave cached reads silently stale.
 	markerInsertFailures   atomic.Uint64
@@ -235,38 +242,78 @@ type meterCacheInvalidator struct {
 	refreshTriggersFired   atomic.Uint64
 }
 
-func newMeterCacheInvalidator(config Config) *meterCacheInvalidator {
+func newMeterCacheInvalidator(config Config, observability *meterCacheObservability) *meterCacheInvalidator {
 	return &meterCacheInvalidator{
 		logger:         config.Logger,
 		clickhouse:     config.ClickHouse,
 		database:       config.Database,
 		cache:          config.Cache,
+		observability:  observability,
 		throttler:      newRefreshThrottler(config.Cache.RefreshInterval),
 		viewListingTTL: meterCacheMVListingTTL,
 	}
 }
 
+// meterCacheMarkerFailureStage is the streaming.meter_cache.marker_failures counter's stage
+// attribute, identifying which of the two failure modes in the invalidation pipeline
+// occurred (G11): classification never reaching a marker, or a computed marker failing to
+// persist.
+type meterCacheMarkerFailureStage string
+
+const (
+	meterCacheMarkerFailureStageClassify meterCacheMarkerFailureStage = "classify"
+	meterCacheMarkerFailureStageInsert   meterCacheMarkerFailureStage = "insert"
+)
+
+// meterCacheRefreshTriggerOutcome is the streaming.meter_cache.refresh_triggers counter's
+// outcome attribute for one candidate view's best-effort refresh trigger.
+type meterCacheRefreshTriggerOutcome string
+
+const (
+	meterCacheRefreshTriggerOutcomeOK        meterCacheRefreshTriggerOutcome = "ok"
+	meterCacheRefreshTriggerOutcomeError     meterCacheRefreshTriggerOutcome = "error"
+	meterCacheRefreshTriggerOutcomeThrottled meterCacheRefreshTriggerOutcome = "throttled"
+	meterCacheRefreshTriggerOutcomeListError meterCacheRefreshTriggerOutcome = "list_error"
+)
+
 // invalidateLateEvents inspects a just-inserted batch for late events and, when found,
 // persists invalidation markers and nudges the affected MVs to refresh. It never returns
 // an error: see the meterCacheInvalidator contract.
+//
+// Classification runs before the span starts: BatchInsert calls this on every batch
+// regardless of whether the batch contains late events, and the zero-late-events case is
+// the steady-state majority. Starting the span only once there is something to report
+// (a classification error, or at least one marker window) keeps streaming.meter_cache.invalidate
+// from emitting a span per insert when the cache is enabled and no late events occur.
 func (i *meterCacheInvalidator) invalidateLateEvents(ctx context.Context, events []streaming.RawEvent) {
 	windows, err := lateEventWindows(events, time.Now().UTC(), i.cache.MinimumUsageAge, i.cache.WindowSize)
+	if err == nil && len(windows) == 0 {
+		return
+	}
+
+	ctx, span := i.observability.tracer.Start(ctx, "streaming.meter_cache.invalidate")
+	defer span.End()
+
 	if err != nil {
 		i.markerInsertFailures.Add(1)
+		i.recordMarkerFailure(ctx, meterCacheMarkerFailureStageClassify)
 		i.logger.Error("meter cache: late event classification failed, cached reads may serve stale buckets", "error", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "late event classification failed")
 
 		return
 	}
 
-	if len(windows) == 0 {
-		return
-	}
+	span.SetAttributes(attribute.Int("markers", len(windows)))
 
 	sql, args := insertInvalidationMarkers{Database: i.database, Windows: windows}.toSQL()
 
 	if err := i.clickhouse.Exec(ctx, sql, args...); err != nil {
 		i.markerInsertFailures.Add(1)
+		i.recordMarkerFailure(ctx, meterCacheMarkerFailureStageInsert)
 		i.logger.Error("meter cache: invalidation marker insert failed, cached reads may serve stale buckets", "error", err, "markers", len(windows))
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "invalidation marker insert failed")
 	}
 
 	// Refresh triggering proceeds even when the marker insert failed: a completed refresh
@@ -275,10 +322,22 @@ func (i *meterCacheInvalidator) invalidateLateEvents(ctx context.Context, events
 	i.triggerRefreshes(ctx, windows)
 }
 
+// recordMarkerFailure emits the streaming.meter_cache.marker_failures counter (G11): this is
+// the silent-staleness alert signal, so every classify/insert failure must reach it, not
+// just the process-local atomic counters.
+func (i *meterCacheInvalidator) recordMarkerFailure(ctx context.Context, stage meterCacheMarkerFailureStage) {
+	i.observability.markerFailures.Add(ctx, 1, metric.WithAttributes(attribute.String("stage", string(stage))))
+}
+
+func (i *meterCacheInvalidator) recordRefreshTrigger(ctx context.Context, outcome meterCacheRefreshTriggerOutcome) {
+	i.observability.refreshTriggers.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", string(outcome))))
+}
+
 func (i *meterCacheInvalidator) triggerRefreshes(ctx context.Context, windows []invalidationWindow) {
 	views, err := i.listDeployedCacheMVs(ctx, time.Now())
 	if err != nil {
 		i.refreshTriggerFailures.Add(1)
+		i.recordRefreshTrigger(ctx, meterCacheRefreshTriggerOutcomeListError)
 		i.logger.Warn("meter cache: listing cache views for refresh triggering failed", "error", err)
 
 		return
@@ -286,17 +345,21 @@ func (i *meterCacheInvalidator) triggerRefreshes(ctx context.Context, windows []
 
 	for _, view := range affectedViewNames(views, windows) {
 		if !i.throttler.allow(view, time.Now()) {
+			i.recordRefreshTrigger(ctx, meterCacheRefreshTriggerOutcomeThrottled)
+
 			continue
 		}
 
 		if err := i.clickhouse.Exec(ctx, "SYSTEM REFRESH VIEW "+getTableName(i.database, view)); err != nil {
 			i.refreshTriggerFailures.Add(1)
+			i.recordRefreshTrigger(ctx, meterCacheRefreshTriggerOutcomeError)
 			i.logger.Warn("meter cache: refresh trigger failed", "view", view, "error", err)
 
 			continue
 		}
 
 		i.refreshTriggersFired.Add(1)
+		i.recordRefreshTrigger(ctx, meterCacheRefreshTriggerOutcomeOK)
 	}
 }
 

--- a/openmeter/streaming/clickhouse/meter_cache_invalidation.go
+++ b/openmeter/streaming/clickhouse/meter_cache_invalidation.go
@@ -1,0 +1,358 @@
+package clickhouse
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/huandu/go-sqlbuilder"
+
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+)
+
+// meterCacheMVListingTTL bounds how often the invalidator rescans system.tables during a
+// late-event burst (G7). The deployed MV set only changes when the lifecycle reconciler
+// creates or drops views, so a short TTL trades at most a few seconds of trigger lag on a
+// brand-new view for not paying a system.tables scan on every ingest batch.
+const meterCacheMVListingTTL = 15 * time.Second
+
+// invalidationWindow is one late-event invalidation marker payload: the half-open
+// [WindowLo, WindowHi) range of UTC-aligned cache grain buckets in one (namespace, event
+// type) pair that received events after those buckets had already settled. Readers treat
+// cached buckets overlapping an unhealed marker as untrustworthy and serve them live.
+type invalidationWindow struct {
+	Namespace string
+	EventType string
+	WindowLo  time.Time
+	WindowHi  time.Time
+}
+
+// invalidationKey groups late events into one marker per (namespace, event type): markers
+// gate reads per meter event type, so finer per-bucket markers would only grow the table
+// without changing reader behavior.
+type invalidationKey struct {
+	namespace string
+	eventType string
+}
+
+// lateEventWindows computes the invalidation markers a freshly ingested batch requires:
+// one (namespace, event type) marker spanning the min..max grain buckets that received
+// late events. An event is late when its event time is older than the freshness horizon
+// (now − minimumUsageAge): its bucket is already settled — scheduled refreshes have
+// published it as final and readers serve it from the cache — so without a marker cached
+// reads would silently miss the new event until a refresh happens to recompute the bucket.
+//
+// The lateness cutoff is deliberately the raw horizon, not the grain-aligned settled bound
+// the MVs use: the app clock here and the ClickHouse clock deciding settlement can differ,
+// and over-marking a not-yet-settled bucket only costs a spurious live fallback, while
+// under-marking a settled one would leave cached reads stale. Bucket bounds are truncated
+// in UTC to match om_meter_cache windowstart alignment.
+func lateEventWindows(events []streaming.RawEvent, now time.Time, minimumUsageAge time.Duration, grain CacheGrain) ([]invalidationWindow, error) {
+	spec, err := grainSpecFor(grain)
+	if err != nil {
+		return nil, err
+	}
+
+	grainDuration := time.Duration(spec.seconds) * time.Second
+	cutoff := now.Add(-minimumUsageAge)
+
+	merged := map[invalidationKey]invalidationWindow{}
+
+	for _, event := range events {
+		if !event.Time.Before(cutoff) {
+			continue
+		}
+
+		bucketLo := event.Time.UTC().Truncate(grainDuration)
+		bucketHi := bucketLo.Add(grainDuration)
+
+		key := invalidationKey{namespace: event.Namespace, eventType: event.Type}
+
+		window, ok := merged[key]
+		if !ok {
+			merged[key] = invalidationWindow{
+				Namespace: event.Namespace,
+				EventType: event.Type,
+				WindowLo:  bucketLo,
+				WindowHi:  bucketHi,
+			}
+
+			continue
+		}
+
+		if bucketLo.Before(window.WindowLo) {
+			window.WindowLo = bucketLo
+		}
+
+		if bucketHi.After(window.WindowHi) {
+			window.WindowHi = bucketHi
+		}
+
+		merged[key] = window
+	}
+
+	windows := slices.Collect(maps.Values(merged))
+
+	// Sorted so marker inserts and tests are deterministic regardless of map iteration
+	slices.SortFunc(windows, func(a, b invalidationWindow) int {
+		if c := strings.Compare(a.Namespace, b.Namespace); c != 0 {
+			return c
+		}
+
+		return strings.Compare(a.EventType, b.EventType)
+	})
+
+	return windows, nil
+}
+
+// insertInvalidationMarkers renders the INSERT persisting late-event invalidation markers.
+//
+// created_at is deliberately absent from the column list so ClickHouse fills it from the
+// table's DEFAULT now64(3) — server time, never the app clock (G6). The reader's heal rule
+// compares marker time against refresh times reported by system.view_refreshes; if one
+// side of that comparison came from a skewed app clock, a marker could be judged healed by
+// a refresh that never saw the late events, silently serving stale buckets.
+type insertInvalidationMarkers struct {
+	Database string
+	Windows  []invalidationWindow
+}
+
+func (q insertInvalidationMarkers) toSQL() (string, []interface{}) {
+	query := sqlbuilder.ClickHouse.NewInsertBuilder()
+	query.InsertInto(getTableName(q.Database, meterCacheInvalidationsTableName))
+	query.Cols("namespace", "event_type", "window_lo", "window_hi")
+
+	for _, window := range q.Windows {
+		query.Values(window.Namespace, window.EventType, window.WindowLo, window.WindowHi)
+	}
+
+	return query.Build()
+}
+
+// refreshThrottler rate limits best-effort SYSTEM REFRESH VIEW triggers per view. Late
+// events tend to arrive in bursts (a delayed producer flushing its backlog), and each
+// batch would otherwise fire another refresh at the same MV; one trigger per interval is
+// enough because a refresh recomputes every dirty bucket, not just one event's.
+//
+// The state is in-process only: sink replicas throttle independently, and concurrent
+// triggers from different replicas are absorbed server-side (a refresh request on an
+// already-refreshing view is a no-op).
+type refreshThrottler struct {
+	minInterval time.Duration
+
+	mu          sync.Mutex
+	lastTrigger map[string]time.Time
+}
+
+func newRefreshThrottler(minInterval time.Duration) *refreshThrottler {
+	return &refreshThrottler{
+		minInterval: minInterval,
+		lastTrigger: map[string]time.Time{},
+	}
+}
+
+// allow reports whether a refresh of view may fire at now, and when it may, records now as
+// the view's last trigger so further calls within minInterval are suppressed. The slot is
+// consumed by the decision, not by trigger success: callers deliberately do not roll back
+// on a failed trigger so persistent errors (e.g. a missing SYSTEM REFRESH grant) surface
+// once per interval instead of once per ingest batch.
+func (t *refreshThrottler) allow(view string, now time.Time) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if last, ok := t.lastTrigger[view]; ok && now.Sub(last) < t.minInterval {
+		return false
+	}
+
+	t.lastTrigger[view] = now
+
+	return true
+}
+
+// deployedCacheMV is one cache MV discovered in system.tables: its object name and the
+// parsed comment metadata.
+type deployedCacheMV struct {
+	Name     string
+	Metadata meterCacheMVMetadata
+}
+
+// affectedViewNames returns the deployed cache MVs serving any of the invalidated
+// (namespace, event type) pairs, matched by the per-namespace name prefix plus the
+// event_type recorded in the MV comment metadata.
+//
+// The prefix folds the namespace to 8 hex chars, so distinct namespaces can collide; a
+// collision at worst triggers a refresh of another namespace's view, which is harmless
+// (refreshes only recompute that view's own dirty buckets). Correctness never depends on
+// this matching — markers gate the reads — it only decides which views get nudged early.
+func affectedViewNames(views []deployedCacheMV, windows []invalidationWindow) []string {
+	var names []string
+
+	for _, window := range windows {
+		prefix := mvNamePrefixForNamespace(window.Namespace)
+
+		for _, view := range views {
+			if strings.HasPrefix(view.Name, prefix) && view.Metadata.EventType == window.EventType {
+				names = append(names, view.Name)
+			}
+		}
+	}
+
+	slices.Sort(names)
+
+	return slices.Compact(names)
+}
+
+// meterCacheInvalidator reacts to late events observed at ingestion: it writes
+// invalidation markers so cached reads stop trusting the affected buckets, then
+// best-effort triggers the affected MVs' refresh so those buckets converge sooner than the
+// next scheduled refresh.
+//
+// Everything here is strictly best-effort with respect to ingestion: the events are
+// already durably stored when this runs, so no failure below may reach the ingest caller —
+// a lost marker degrades cache freshness (bounded by the scheduled refresh dirty window
+// and the reconciler), while a failed ingest response would make the caller re-send events
+// that were already written. Failures are logged and counted instead.
+type meterCacheInvalidator struct {
+	logger     *slog.Logger
+	clickhouse clickhouse.Conn
+	database   string
+	cache      CacheConfig
+
+	throttler *refreshThrottler
+
+	viewListingTTL time.Duration
+	viewsMu        sync.Mutex
+	viewsFetchedAt time.Time
+	views          []deployedCacheMV
+
+	// Metric-style counters, process-local until real metrics wiring exists.
+	// markerInsertFailures is the one to alert on (G11): a lost marker is the only failure
+	// mode in this pipeline that can leave cached reads silently stale.
+	markerInsertFailures   atomic.Uint64
+	refreshTriggerFailures atomic.Uint64
+	refreshTriggersFired   atomic.Uint64
+}
+
+func newMeterCacheInvalidator(config Config) *meterCacheInvalidator {
+	return &meterCacheInvalidator{
+		logger:         config.Logger,
+		clickhouse:     config.ClickHouse,
+		database:       config.Database,
+		cache:          config.Cache,
+		throttler:      newRefreshThrottler(config.Cache.RefreshInterval),
+		viewListingTTL: meterCacheMVListingTTL,
+	}
+}
+
+// invalidateLateEvents inspects a just-inserted batch for late events and, when found,
+// persists invalidation markers and nudges the affected MVs to refresh. It never returns
+// an error: see the meterCacheInvalidator contract.
+func (i *meterCacheInvalidator) invalidateLateEvents(ctx context.Context, events []streaming.RawEvent) {
+	windows, err := lateEventWindows(events, time.Now().UTC(), i.cache.MinimumUsageAge, i.cache.WindowSize)
+	if err != nil {
+		i.markerInsertFailures.Add(1)
+		i.logger.Error("meter cache: late event classification failed, cached reads may serve stale buckets", "error", err)
+
+		return
+	}
+
+	if len(windows) == 0 {
+		return
+	}
+
+	sql, args := insertInvalidationMarkers{Database: i.database, Windows: windows}.toSQL()
+
+	if err := i.clickhouse.Exec(ctx, sql, args...); err != nil {
+		i.markerInsertFailures.Add(1)
+		i.logger.Error("meter cache: invalidation marker insert failed, cached reads may serve stale buckets", "error", err, "markers", len(windows))
+	}
+
+	// Refresh triggering proceeds even when the marker insert failed: a completed refresh
+	// re-appends the affected buckets, shrinking the very staleness window the lost marker
+	// would have guarded.
+	i.triggerRefreshes(ctx, windows)
+}
+
+func (i *meterCacheInvalidator) triggerRefreshes(ctx context.Context, windows []invalidationWindow) {
+	views, err := i.listDeployedCacheMVs(ctx, time.Now())
+	if err != nil {
+		i.refreshTriggerFailures.Add(1)
+		i.logger.Warn("meter cache: listing cache views for refresh triggering failed", "error", err)
+
+		return
+	}
+
+	for _, view := range affectedViewNames(views, windows) {
+		if !i.throttler.allow(view, time.Now()) {
+			continue
+		}
+
+		if err := i.clickhouse.Exec(ctx, "SYSTEM REFRESH VIEW "+getTableName(i.database, view)); err != nil {
+			i.refreshTriggerFailures.Add(1)
+			i.logger.Warn("meter cache: refresh trigger failed", "view", view, "error", err)
+
+			continue
+		}
+
+		i.refreshTriggersFired.Add(1)
+	}
+}
+
+// listDeployedCacheMVs returns the cache MVs deployed in the database, served from an
+// in-process snapshot refreshed at most every viewListingTTL (G7). The mutex is held
+// across the rescan on purpose: concurrent ingest batches hitting an expired snapshot
+// should share one system.tables scan, not race to repeat it.
+func (i *meterCacheInvalidator) listDeployedCacheMVs(ctx context.Context, now time.Time) ([]deployedCacheMV, error) {
+	i.viewsMu.Lock()
+	defer i.viewsMu.Unlock()
+
+	if !i.viewsFetchedAt.IsZero() && now.Sub(i.viewsFetchedAt) < i.viewListingTTL {
+		return i.views, nil
+	}
+
+	rows, err := i.clickhouse.Query(ctx,
+		"SELECT name, comment FROM system.tables WHERE database = ? AND engine = 'MaterializedView' AND startsWith(name, ?)",
+		i.database, meterCacheMVNamePrefix,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	var views []deployedCacheMV
+
+	for rows.Next() {
+		var name, comment string
+
+		if err := rows.Scan(&name, &comment); err != nil {
+			return nil, err
+		}
+
+		metadata, err := parseMeterCacheMVMetadata(comment)
+		if err != nil {
+			// A prefix-matching view without valid metadata is foreign or corrupt; refresh
+			// triggering must not touch it, and repairing it is the reconciler's job.
+			i.logger.Debug("meter cache: skipping view with unparseable comment metadata", "view", name, "error", err)
+
+			continue
+		}
+
+		views = append(views, deployedCacheMV{Name: name, Metadata: metadata})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	i.views = views
+	i.viewsFetchedAt = now
+
+	return views, nil
+}

--- a/openmeter/streaming/clickhouse/meter_cache_invalidation.go
+++ b/openmeter/streaming/clickhouse/meter_cache_invalidation.go
@@ -183,21 +183,17 @@ type deployedCacheMV struct {
 }
 
 // affectedViewNames returns the deployed cache MVs serving any of the invalidated
-// (namespace, event type) pairs, matched by the per-namespace name prefix plus the
-// event_type recorded in the MV comment metadata.
-//
-// The prefix folds the namespace to 8 hex chars, so distinct namespaces can collide; a
-// collision at worst triggers a refresh of another namespace's view, which is harmless
-// (refreshes only recompute that view's own dirty buckets). Correctness never depends on
-// this matching — markers gate the reads — it only decides which views get nudged early.
+// (namespace, event type) pairs, matched against the exact namespace and event_type
+// recorded in the MV comment metadata — the folded name prefix is not consulted, so a
+// namespace collision on the 8-hex fold never nudges another namespace's view.
+// Correctness never depends on this matching — markers gate the reads — it only decides
+// which views get refreshed early.
 func affectedViewNames(views []deployedCacheMV, windows []invalidationWindow) []string {
 	var names []string
 
 	for _, window := range windows {
-		prefix := mvNamePrefixForNamespace(window.Namespace)
-
 		for _, view := range views {
-			if strings.HasPrefix(view.Name, prefix) && view.Metadata.EventType == window.EventType {
+			if view.Metadata.Namespace == window.Namespace && view.Metadata.EventType == window.EventType {
 				names = append(names, view.Name)
 			}
 		}

--- a/openmeter/streaming/clickhouse/meter_cache_invalidation_observability_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_invalidation_observability_test.go
@@ -1,0 +1,200 @@
+package clickhouse
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+)
+
+func newTestInvalidator(t *testing.T, cache CacheConfig) (*meterCacheInvalidator, *MockClickHouse, *testTelemetry) {
+	t.Helper()
+
+	telemetry, telemetryConfig := newTestTelemetry()
+	mockCH := NewMockClickHouse()
+
+	observability, err := newMeterCacheObservability(Config{
+		Meter:  telemetryConfig.Meter,
+		Tracer: telemetryConfig.Tracer,
+	})
+	require.NoError(t, err)
+
+	invalidator := newMeterCacheInvalidator(Config{
+		Logger:     slog.Default(),
+		ClickHouse: mockCH,
+		Database:   "testdb",
+		Cache:      cache,
+	}, observability)
+
+	return invalidator, mockCH, telemetry
+}
+
+// sumAttrValue finds the counter data point matching every expected attribute and returns
+// its value, failing the test if no matching data point was recorded — the same "assert
+// emission, not attachment" requirement as the query-path observability tests.
+func sumAttrValue(t *testing.T, m metricdata.Metrics, expected map[string]string) int64 {
+	t.Helper()
+
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.Truef(t, ok, "%s must be a counter", m.Name)
+
+	for _, dp := range sum.DataPoints {
+		matched := true
+
+		for key, want := range expected {
+			got, ok := dp.Attributes.Value(attribute.Key(key))
+			if !ok || got.AsString() != want {
+				matched = false
+				break
+			}
+		}
+
+		if matched {
+			return dp.Value
+		}
+	}
+
+	require.Failf(t, "no matching data point", "metric %s has no data point with attributes %v", m.Name, expected)
+
+	return 0
+}
+
+// TestInvalidateLateEvents_ClassifyFailureEmitsMarkerFailureAndSpanError forces
+// lateEventWindows to fail (an invalid cache grain) and proves the classify-stage failure
+// reaches the marker_failures counter with stage=classify, and the invalidate span records
+// the error and sets its status to codes.Error — this is the G11 silent-staleness alert
+// signal for the classification half of the pipeline.
+func TestInvalidateLateEvents_ClassifyFailureEmitsMarkerFailureAndSpanError(t *testing.T) {
+	invalidator, _, telemetry := newTestInvalidator(t, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrain("bogus-grain"),
+	})
+
+	invalidator.invalidateLateEvents(t.Context(), []streaming.RawEvent{
+		{Namespace: "ns1", Type: "api-calls", Time: time.Now().UTC().Add(-3 * time.Hour)},
+	})
+
+	require.Equal(t, uint64(1), invalidator.markerInsertFailures.Load())
+
+	m := collectMetric(t, telemetry.reader, "streaming.meter_cache.marker_failures")
+	require.EqualValues(t, 1, sumAttrValue(t, m, map[string]string{"stage": "classify"}))
+
+	spans := telemetry.recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "streaming.meter_cache.invalidate", spans[0].Name())
+	require.NotEmpty(t, spans[0].Events(), "span must record the classification error")
+	require.Equal(t, codes.Error, spans[0].Status().Code, "span status must be set on an error exit for status-based error dashboards")
+}
+
+// TestInvalidateLateEvents_NoLateEventsEmitsNoSpan proves the steady-state majority path —
+// a batch with no late events — never starts the streaming.meter_cache.invalidate span.
+// BatchInsert calls invalidateLateEvents on every insert while the cache is enabled, so
+// starting a span unconditionally would emit one per insert; the span must exist only when
+// there is something to report (a classification error or at least one marker window).
+func TestInvalidateLateEvents_NoLateEventsEmitsNoSpan(t *testing.T) {
+	invalidator, _, telemetry := newTestInvalidator(t, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	invalidator.invalidateLateEvents(t.Context(), []streaming.RawEvent{
+		{Namespace: "ns1", Type: "api-calls", Time: time.Now().UTC()},
+	})
+
+	require.Equal(t, uint64(0), invalidator.markerInsertFailures.Load())
+	require.Empty(t, telemetry.recorder.Ended(), "a batch with no late events must not start the invalidate span")
+}
+
+// TestInvalidateLateEvents_InsertFailureEmitsMarkerFailure forces the marker INSERT to fail
+// and proves the insert-stage failure reaches marker_failures with stage=insert, distinct
+// from the classify stage.
+func TestInvalidateLateEvents_InsertFailureEmitsMarkerFailure(t *testing.T) {
+	invalidator, mockCH, telemetry := newTestInvalidator(t, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	mockCH.On("Exec", mock.Anything, mock.MatchedBy(func(sql string) bool {
+		return len(sql) > 0
+	}), mock.Anything).Return(errors.New("insert failed")).Once()
+
+	mockCH.On("Query", mock.Anything, mock.Anything, mock.Anything).Return(NewMockRows(), errors.New("listing failed")).Maybe()
+
+	invalidator.invalidateLateEvents(t.Context(), []streaming.RawEvent{
+		{Namespace: "ns1", Type: "api-calls", Time: time.Now().UTC().Add(-3 * time.Hour)},
+	})
+
+	require.Equal(t, uint64(1), invalidator.markerInsertFailures.Load())
+
+	m := collectMetric(t, telemetry.reader, "streaming.meter_cache.marker_failures")
+	require.EqualValues(t, 1, sumAttrValue(t, m, map[string]string{"stage": "insert"}))
+}
+
+// TestTriggerRefreshes_ListErrorEmitsRefreshTriggerOutcome proves a failed view listing
+// (the prerequisite for any refresh trigger) is counted as outcome=list_error.
+func TestTriggerRefreshes_ListErrorEmitsRefreshTriggerOutcome(t *testing.T) {
+	invalidator, mockCH, telemetry := newTestInvalidator(t, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	mockCH.On("Query", mock.Anything, mock.Anything, mock.Anything).Return(NewMockRows(), errors.New("listing failed")).Once()
+
+	invalidator.triggerRefreshes(t.Context(), []invalidationWindow{
+		{Namespace: "ns1", EventType: "api-calls", WindowLo: time.Now(), WindowHi: time.Now()},
+	})
+
+	m := collectMetric(t, telemetry.reader, "streaming.meter_cache.refresh_triggers")
+	require.EqualValues(t, 1, sumAttrValue(t, m, map[string]string{"outcome": "list_error"}))
+}
+
+// TestNewMeterCacheInvalidator_NilObservabilityDependenciesDoNotPanic proves the
+// invalidator's instrumented paths run without panicking when built from an observability
+// instance constructed with nil Meter/Tracer.
+func TestNewMeterCacheInvalidator_NilObservabilityDependenciesDoNotPanic(t *testing.T) {
+	observability, err := newMeterCacheObservability(Config{})
+	require.NoError(t, err)
+
+	emptyRows := NewMockRows()
+	emptyRows.On("Next").Return(false)
+	emptyRows.On("Err").Return(nil)
+	emptyRows.On("Close").Return(nil)
+
+	mockCH := NewMockClickHouse()
+	mockCH.On("Exec", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	mockCH.On("Query", mock.Anything, mock.Anything, mock.Anything).Return(emptyRows, nil).Once()
+
+	invalidator := newMeterCacheInvalidator(Config{
+		Logger:     slog.Default(),
+		ClickHouse: mockCH,
+		Database:   "testdb",
+		Cache: CacheConfig{
+			Enabled:         true,
+			RefreshInterval: 10 * time.Minute,
+			MinimumUsageAge: time.Hour,
+			WindowSize:      CacheGrainHour,
+		},
+	}, observability)
+
+	require.NotPanics(t, func() {
+		invalidator.invalidateLateEvents(t.Context(), []streaming.RawEvent{
+			{Namespace: "ns1", Type: "api-calls", Time: time.Now().UTC().Add(-3 * time.Hour)},
+		})
+	})
+}

--- a/openmeter/streaming/clickhouse/meter_cache_invalidation_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_invalidation_test.go
@@ -1,0 +1,380 @@
+package clickhouse
+
+import (
+	"errors"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+)
+
+func TestLateEventWindows(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+	age := time.Hour
+
+	newEvent := func(namespace, eventType string, at time.Time) streaming.RawEvent {
+		return streaming.RawEvent{Namespace: namespace, Type: eventType, Time: at}
+	}
+
+	t.Run("NoLateEvents", func(t *testing.T) {
+		windows, err := lateEventWindows([]streaming.RawEvent{
+			newEvent("ns1", "api-calls", now.Add(-10*time.Minute)),
+			newEvent("ns1", "api-calls", now),
+		}, now, age, CacheGrainHour)
+		require.NoError(t, err)
+		require.Empty(t, windows)
+	})
+
+	t.Run("EventExactlyAtCutoffIsNotLate", func(t *testing.T) {
+		// The cutoff is exclusive: an event exactly minimumUsageAge old sits at the
+		// freshness horizon the reader always serves live, so no marker is needed.
+		windows, err := lateEventWindows([]streaming.RawEvent{
+			newEvent("ns1", "api-calls", now.Add(-age)),
+		}, now, age, CacheGrainHour)
+		require.NoError(t, err)
+		require.Empty(t, windows)
+
+		windows, err = lateEventWindows([]streaming.RawEvent{
+			newEvent("ns1", "api-calls", now.Add(-age).Add(-time.Second)),
+		}, now, age, CacheGrainHour)
+		require.NoError(t, err)
+		require.Len(t, windows, 1)
+	})
+
+	t.Run("MergesMinAndMaxBucketsPerNamespaceAndType", func(t *testing.T) {
+		windows, err := lateEventWindows([]streaming.RawEvent{
+			newEvent("ns1", "api-calls", now.Add(-3*time.Hour).Add(10*time.Minute)),
+			newEvent("ns1", "api-calls", now.Add(-6*time.Hour).Add(59*time.Minute)),
+			newEvent("ns1", "api-calls", now.Add(-4*time.Hour)),
+		}, now, age, CacheGrainHour)
+		require.NoError(t, err)
+		require.Equal(t, []invalidationWindow{
+			{
+				Namespace: "ns1",
+				EventType: "api-calls",
+				WindowLo:  now.Add(-6 * time.Hour),
+				WindowHi:  now.Add(-2 * time.Hour),
+			},
+		}, windows)
+	})
+
+	t.Run("SeparatesNamespacesAndTypesSorted", func(t *testing.T) {
+		windows, err := lateEventWindows([]streaming.RawEvent{
+			newEvent("ns2", "api-calls", now.Add(-3*time.Hour)),
+			newEvent("ns1", "tokens", now.Add(-3*time.Hour)),
+			newEvent("ns1", "api-calls", now.Add(-3*time.Hour)),
+		}, now, age, CacheGrainHour)
+		require.NoError(t, err)
+		require.Equal(t, []invalidationWindow{
+			{Namespace: "ns1", EventType: "api-calls", WindowLo: now.Add(-3 * time.Hour), WindowHi: now.Add(-2 * time.Hour)},
+			{Namespace: "ns1", EventType: "tokens", WindowLo: now.Add(-3 * time.Hour), WindowHi: now.Add(-2 * time.Hour)},
+			{Namespace: "ns2", EventType: "api-calls", WindowLo: now.Add(-3 * time.Hour), WindowHi: now.Add(-2 * time.Hour)},
+		}, windows)
+	})
+
+	t.Run("DayGrainTruncatesToUTCDays", func(t *testing.T) {
+		windows, err := lateEventWindows([]streaming.RawEvent{
+			newEvent("ns1", "api-calls", time.Date(2026, 7, 1, 18, 30, 0, 0, time.UTC)),
+		}, now, age, CacheGrainDay)
+		require.NoError(t, err)
+		require.Equal(t, []invalidationWindow{
+			{
+				Namespace: "ns1",
+				EventType: "api-calls",
+				WindowLo:  time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+				WindowHi:  time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC),
+			},
+		}, windows)
+	})
+
+	t.Run("NonUTCEventTimesAlignToUTCBuckets", func(t *testing.T) {
+		// Cache buckets are UTC-aligned; an event carrying a zoned wall clock must land in
+		// the bucket of its UTC instant.
+		budapest, err := time.LoadLocation("Europe/Budapest")
+		require.NoError(t, err)
+
+		windows, err := lateEventWindows([]streaming.RawEvent{
+			// 08:30 CEST == 06:30 UTC
+			newEvent("ns1", "api-calls", time.Date(2026, 7, 3, 8, 30, 0, 0, budapest)),
+		}, now, age, CacheGrainHour)
+		require.NoError(t, err)
+		require.Equal(t, []invalidationWindow{
+			{
+				Namespace: "ns1",
+				EventType: "api-calls",
+				WindowLo:  time.Date(2026, 7, 3, 6, 0, 0, 0, time.UTC),
+				WindowHi:  time.Date(2026, 7, 3, 7, 0, 0, 0, time.UTC),
+			},
+		}, windows)
+	})
+
+	t.Run("InvalidGrain", func(t *testing.T) {
+		_, err := lateEventWindows([]streaming.RawEvent{
+			newEvent("ns1", "api-calls", now.Add(-3*time.Hour)),
+		}, now, age, CacheGrain("fortnight"))
+		require.Error(t, err)
+	})
+}
+
+// TestInsertInvalidationMarkersToSQL is the structural proof of G6: created_at must not
+// appear in the INSERT column list, so ClickHouse stamps it from the table's DEFAULT
+// now64(3) (server time) instead of an app clock.
+func TestInsertInvalidationMarkersToSQL(t *testing.T) {
+	windowLo := time.Date(2026, 7, 3, 6, 0, 0, 0, time.UTC)
+	windowHi := windowLo.Add(2 * time.Hour)
+
+	sql, args := insertInvalidationMarkers{
+		Database: "openmeter",
+		Windows: []invalidationWindow{
+			{Namespace: "ns1", EventType: "api-calls", WindowLo: windowLo, WindowHi: windowHi},
+			{Namespace: "ns2", EventType: "tokens", WindowLo: windowLo, WindowHi: windowHi},
+		},
+	}.toSQL()
+
+	require.Equal(t, "INSERT INTO openmeter.om_meter_cache_invalidations (namespace, event_type, window_lo, window_hi) VALUES (?, ?, ?, ?), (?, ?, ?, ?)", sql)
+	require.NotContains(t, sql, "created_at")
+	require.Equal(t, []interface{}{
+		"ns1", "api-calls", windowLo, windowHi,
+		"ns2", "tokens", windowLo, windowHi,
+	}, args)
+}
+
+func TestRefreshThrottler(t *testing.T) {
+	now := time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
+
+	t.Run("PerViewMinInterval", func(t *testing.T) {
+		throttler := newRefreshThrottler(10 * time.Minute)
+
+		require.True(t, throttler.allow("view_a", now))
+		require.False(t, throttler.allow("view_a", now))
+		require.False(t, throttler.allow("view_a", now.Add(10*time.Minute-time.Second)))
+		require.True(t, throttler.allow("view_a", now.Add(10*time.Minute)))
+
+		// Distinct views throttle independently
+		require.True(t, throttler.allow("view_b", now))
+	})
+
+	t.Run("ConcurrentCallersGetOneSlot", func(t *testing.T) {
+		throttler := newRefreshThrottler(10 * time.Minute)
+
+		var wg sync.WaitGroup
+		var allowed atomic.Uint64
+
+		for range 50 {
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+
+				if throttler.allow("view_a", now) {
+					allowed.Add(1)
+				}
+			}()
+		}
+
+		wg.Wait()
+		require.Equal(t, uint64(1), allowed.Load())
+	})
+}
+
+func TestAffectedViewNames(t *testing.T) {
+	metadataFor := func(eventType string) meterCacheMVMetadata {
+		return meterCacheMVMetadata{
+			MeterKey:  "meter-1",
+			EventType: eventType,
+			MeterHash: formatCacheHash(1),
+			DDLHash:   formatCacheHash(2),
+		}
+	}
+
+	views := []deployedCacheMV{
+		{Name: mvName("ns1", 1), Metadata: metadataFor("api-calls")},
+		{Name: mvName("ns1", 2), Metadata: metadataFor("api-calls")},
+		{Name: mvName("ns1", 3), Metadata: metadataFor("tokens")},
+		{Name: mvName("ns2", 4), Metadata: metadataFor("api-calls")},
+	}
+
+	t.Run("MatchesNamespacePrefixAndEventType", func(t *testing.T) {
+		names := affectedViewNames(views, []invalidationWindow{
+			{Namespace: "ns1", EventType: "api-calls"},
+		})
+
+		expected := []string{mvName("ns1", 1), mvName("ns1", 2)}
+		slices.Sort(expected)
+		require.Equal(t, expected, names)
+	})
+
+	t.Run("NoMatchForUnknownPair", func(t *testing.T) {
+		require.Empty(t, affectedViewNames(views, []invalidationWindow{
+			{Namespace: "ns3", EventType: "api-calls"},
+			{Namespace: "ns2", EventType: "tokens"},
+		}))
+	})
+
+	t.Run("DeduplicatesAcrossWindows", func(t *testing.T) {
+		names := affectedViewNames(views, []invalidationWindow{
+			{Namespace: "ns1", EventType: "tokens"},
+			{Namespace: "ns1", EventType: "tokens"},
+		})
+		require.Equal(t, []string{mvName("ns1", 3)}, names)
+	})
+}
+
+func withCacheEnabled(c Config) Config {
+	c.Cache = CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	}
+
+	return c
+}
+
+// TestBatchInsertMarkerFailureDoesNotFailIngest forces both the invalidation marker insert
+// and the view listing to fail and proves BatchInsert still succeeds: invalidation is
+// best-effort, failing ingestion over it would make callers re-send already-stored events.
+func TestBatchInsertMarkerFailureDoesNotFailIngest(t *testing.T) {
+	connector, mockCH := GetMockConnector(t, withCacheEnabled)
+
+	// The events insert itself succeeds
+	mockCH.On("Exec", mock.Anything, mock.MatchedBy(func(sql string) bool {
+		return strings.HasPrefix(sql, "INSERT INTO testdb.events")
+	}), mock.Anything).Return(nil).Once()
+
+	// The invalidation marker insert fails
+	mockCH.On("Exec", mock.Anything, mock.MatchedBy(func(sql string) bool {
+		return strings.HasPrefix(sql, "INSERT INTO testdb.om_meter_cache_invalidations")
+	}), mock.Anything).Return(errors.New("marker insert failed")).Once()
+
+	// The system.tables listing for refresh triggering fails too
+	mockCH.On("Query", mock.Anything, mock.MatchedBy(func(sql string) bool {
+		return strings.Contains(sql, "system.tables")
+	}), mock.Anything).Return(NewMockRows(), errors.New("listing failed")).Once()
+
+	err := connector.BatchInsert(t.Context(), []streaming.RawEvent{{
+		Namespace: "ns1",
+		Type:      "api-calls",
+		Subject:   "subject-1",
+		Time:      time.Now().UTC().Add(-3 * time.Hour),
+		Data:      `{"value": 1}`,
+	}})
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(1), connector.cacheInvalidator.markerInsertFailures.Load())
+	require.Equal(t, uint64(1), connector.cacheInvalidator.refreshTriggerFailures.Load())
+	require.Equal(t, uint64(0), connector.cacheInvalidator.refreshTriggersFired.Load())
+	mockCH.AssertExpectations(t)
+}
+
+// TestBatchInsertLateEventTriggersThrottledRefresh drives two late batches through
+// BatchInsert and asserts: markers are written per batch, the system.tables listing is
+// scanned once (TTL cache, G7), and SYSTEM REFRESH VIEW fires exactly once (throttle).
+func TestBatchInsertLateEventTriggersThrottledRefresh(t *testing.T) {
+	connector, mockCH := GetMockConnector(t, withCacheEnabled)
+
+	viewName := mvName("ns1", 1)
+	comment, err := meterCacheMVMetadata{
+		MeterKey:  "meter-1",
+		EventType: "api-calls",
+		MeterHash: formatCacheHash(1),
+		DDLHash:   formatCacheHash(2),
+	}.marshal()
+	require.NoError(t, err)
+
+	// Events and marker inserts succeed for both batches
+	mockCH.On("Exec", mock.Anything, mock.MatchedBy(func(sql string) bool {
+		return strings.HasPrefix(sql, "INSERT INTO testdb.events")
+	}), mock.Anything).Return(nil).Twice()
+	mockCH.On("Exec", mock.Anything, mock.MatchedBy(func(sql string) bool {
+		return strings.HasPrefix(sql, "INSERT INTO testdb.om_meter_cache_invalidations")
+	}), mock.Anything).Return(nil).Twice()
+
+	// The system.tables listing is served exactly once; the second batch arrives within
+	// the listing TTL and must reuse the in-process snapshot
+	listRows := NewMockRows()
+	listRows.On("Next").Return(true).Once()
+	listRows.On("Scan", mock.Anything).Run(func(args mock.Arguments) {
+		dest := args.Get(0).([]interface{})
+		*(dest[0].(*string)) = viewName
+		*(dest[1].(*string)) = comment
+	}).Return(nil).Once()
+	listRows.On("Next").Return(false).Once()
+	listRows.On("Err").Return(nil).Once()
+	listRows.On("Close").Return(nil).Once()
+
+	mockCH.On("Query", mock.Anything, mock.MatchedBy(func(sql string) bool {
+		return strings.Contains(sql, "system.tables")
+	}), mock.Anything).Return(listRows, nil).Once()
+
+	// The refresh trigger fires exactly once across both batches (throttle window is the
+	// refresh interval)
+	mockCH.On("Exec", mock.Anything, "SYSTEM REFRESH VIEW testdb."+viewName, mock.Anything).Return(nil).Once()
+
+	lateEvent := streaming.RawEvent{
+		Namespace: "ns1",
+		Type:      "api-calls",
+		Subject:   "subject-1",
+		Time:      time.Now().UTC().Add(-3 * time.Hour),
+		Data:      `{"value": 1}`,
+	}
+
+	require.NoError(t, connector.BatchInsert(t.Context(), []streaming.RawEvent{lateEvent}))
+	require.NoError(t, connector.BatchInsert(t.Context(), []streaming.RawEvent{lateEvent}))
+
+	require.Equal(t, uint64(1), connector.cacheInvalidator.refreshTriggersFired.Load())
+	require.Equal(t, uint64(0), connector.cacheInvalidator.markerInsertFailures.Load())
+	require.Equal(t, uint64(0), connector.cacheInvalidator.refreshTriggerFailures.Load())
+	mockCH.AssertExpectations(t)
+}
+
+// TestBatchInsertOnTimeEventsSkipInvalidation proves a batch without late events performs
+// only the events insert: no marker, no listing, no refresh trigger.
+func TestBatchInsertOnTimeEventsSkipInvalidation(t *testing.T) {
+	connector, mockCH := GetMockConnector(t, withCacheEnabled)
+
+	mockCH.On("Exec", mock.Anything, mock.MatchedBy(func(sql string) bool {
+		return strings.HasPrefix(sql, "INSERT INTO testdb.events")
+	}), mock.Anything).Return(nil).Once()
+
+	require.NoError(t, connector.BatchInsert(t.Context(), []streaming.RawEvent{{
+		Namespace: "ns1",
+		Type:      "api-calls",
+		Subject:   "subject-1",
+		Time:      time.Now().UTC().Add(-10 * time.Minute),
+		Data:      `{"value": 1}`,
+	}}))
+
+	mockCH.AssertExpectations(t)
+	mockCH.AssertNumberOfCalls(t, "Exec", 1)
+	mockCH.AssertNumberOfCalls(t, "Query", 0)
+}
+
+// TestBatchInsertCacheDisabledSkipsInvalidation proves the hook is inert when the cache is
+// disabled: no invalidator is constructed and late events cause no extra statements.
+func TestBatchInsertCacheDisabledSkipsInvalidation(t *testing.T) {
+	connector, mockCH := GetMockConnector(t)
+	require.Nil(t, connector.cacheInvalidator)
+
+	mockCH.On("Exec", mock.Anything, mock.MatchedBy(func(sql string) bool {
+		return strings.HasPrefix(sql, "INSERT INTO testdb.events")
+	}), mock.Anything).Return(nil).Once()
+
+	require.NoError(t, connector.BatchInsert(t.Context(), []streaming.RawEvent{{
+		Namespace: "ns1",
+		Type:      "api-calls",
+		Subject:   "subject-1",
+		Time:      time.Now().UTC().Add(-3 * time.Hour),
+		Data:      `{"value": 1}`,
+	}}))
+
+	mockCH.AssertExpectations(t)
+	mockCH.AssertNumberOfCalls(t, "Exec", 1)
+}

--- a/openmeter/streaming/clickhouse/meter_cache_invalidation_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_invalidation_test.go
@@ -185,8 +185,9 @@ func TestRefreshThrottler(t *testing.T) {
 }
 
 func TestAffectedViewNames(t *testing.T) {
-	metadataFor := func(eventType string) meterCacheMVMetadata {
+	metadataFor := func(namespace, eventType string) meterCacheMVMetadata {
 		return meterCacheMVMetadata{
+			Namespace: namespace,
 			MeterKey:  "meter-1",
 			EventType: eventType,
 			MeterHash: formatCacheHash(1),
@@ -195,13 +196,13 @@ func TestAffectedViewNames(t *testing.T) {
 	}
 
 	views := []deployedCacheMV{
-		{Name: mvName("ns1", 1), Metadata: metadataFor("api-calls")},
-		{Name: mvName("ns1", 2), Metadata: metadataFor("api-calls")},
-		{Name: mvName("ns1", 3), Metadata: metadataFor("tokens")},
-		{Name: mvName("ns2", 4), Metadata: metadataFor("api-calls")},
+		{Name: mvName("ns1", 1), Metadata: metadataFor("ns1", "api-calls")},
+		{Name: mvName("ns1", 2), Metadata: metadataFor("ns1", "api-calls")},
+		{Name: mvName("ns1", 3), Metadata: metadataFor("ns1", "tokens")},
+		{Name: mvName("ns2", 4), Metadata: metadataFor("ns2", "api-calls")},
 	}
 
-	t.Run("MatchesNamespacePrefixAndEventType", func(t *testing.T) {
+	t.Run("MatchesExactNamespaceAndEventType", func(t *testing.T) {
 		names := affectedViewNames(views, []invalidationWindow{
 			{Namespace: "ns1", EventType: "api-calls"},
 		})
@@ -282,6 +283,7 @@ func TestBatchInsertLateEventTriggersThrottledRefresh(t *testing.T) {
 
 	viewName := mvName("ns1", 1)
 	comment, err := meterCacheMVMetadata{
+		Namespace: "ns1",
 		MeterKey:  "meter-1",
 		EventType: "api-calls",
 		MeterHash: formatCacheHash(1),

--- a/openmeter/streaming/clickhouse/meter_cache_manager.go
+++ b/openmeter/streaming/clickhouse/meter_cache_manager.go
@@ -30,20 +30,30 @@ type MeterCacheView struct {
 	// reconciler must treat such a view as foreign or corrupt and recreate it rather than
 	// trust any of the metadata fields below.
 	MetadataOK bool
-	MeterKey   string
-	EventType  string
+	// Namespace is the exact namespace recorded at creation; the view name only carries an
+	// 8-hex fold of it, so name-colliding namespaces are told apart by this field alone.
+	Namespace string
+	MeterKey  string
+	EventType string
 	// MeterHash and DDLHash are the formatted (16 hex char) hashes recorded at creation.
 	MeterHash string
 	DDLHash   string
 	// BackfilledAt is nil while the one-time backfill has not completed (G3): either it is
 	// still running, or the actor performing it died in between. Readers refuse such views
-	// and the reconciler re-runs backfill + stamp.
+	// and the reconciler re-runs backfill + stamp. Its value is the ClickHouse-clock
+	// instant the backfill started, which doubles as a marker heal bound.
 	BackfilledAt *time.Time
+	// CoveredAt is the durable refresh-coverage watermark the reconciler advances while
+	// refreshes stay continuous; nil until first advanced. See meterCacheMVMetadata.
+	CoveredAt *time.Time
 
 	// LastSuccessTime is nil until the view's first successful refresh since ClickHouse
 	// startup (system.view_refreshes is per-server, in-memory state).
 	LastSuccessTime *time.Time
-	Exception       string
+	// LastSuccessDurationMS is the matching refresh duration; refreshStart (the instant
+	// heal comparisons must anchor on) is LastSuccessTime − LastSuccessDurationMS.
+	LastSuccessDurationMS *uint64
+	Exception             string
 }
 
 // MeterCacheDesiredView is the cache view one meter definition maps to under the current
@@ -100,7 +110,7 @@ func (c *Connector) ListActualViews(ctx context.Context) ([]MeterCacheView, erro
 	}
 
 	rows, err := c.config.ClickHouse.Query(ctx,
-		"SELECT t.name, t.comment, r.last_success_time, r.exception "+
+		"SELECT t.name, t.comment, r.last_success_time, r.last_success_duration_ms, r.exception "+
 			"FROM system.tables AS t "+
 			"LEFT JOIN system.view_refreshes AS r ON r.database = t.database AND r.view = t.name "+
 			"WHERE t.database = ? AND t.engine = 'MaterializedView' AND startsWith(t.name, ?)",
@@ -120,17 +130,19 @@ func (c *Connector) ListActualViews(ctx context.Context) ([]MeterCacheView, erro
 			comment string
 		)
 
-		if err := rows.Scan(&view.Name, &comment, &view.LastSuccessTime, &view.Exception); err != nil {
+		if err := rows.Scan(&view.Name, &comment, &view.LastSuccessTime, &view.LastSuccessDurationMS, &view.Exception); err != nil {
 			return nil, fmt.Errorf("scan meter cache view: %w", err)
 		}
 
 		if metadata, err := parseMeterCacheMVMetadata(comment); err == nil {
 			view.MetadataOK = true
+			view.Namespace = metadata.Namespace
 			view.MeterKey = metadata.MeterKey
 			view.EventType = metadata.EventType
 			view.MeterHash = metadata.MeterHash
 			view.DDLHash = metadata.DDLHash
 			view.BackfilledAt = metadata.BackfilledAt
+			view.CoveredAt = metadata.CoveredAt
 		}
 
 		views = append(views, view)
@@ -150,6 +162,12 @@ func (c *Connector) ListActualViews(ctx context.Context) ([]MeterCacheView, erro
 // this sequence leaves a visibly unfinished view the next reconciliation pass re-runs this
 // exact method on. Re-running over an already-deployed view is safe end to end because
 // backfill rows resolve against refresh rows by newest-wins.
+//
+// The stamped value is the ClickHouse-clock instant read before the backfill starts
+// scanning, not the app-clock completion time: marker healing compares it against marker
+// created_at (also ClickHouse clock), and a marker written before the backfill started is
+// provably covered by its full-history scan, while a marker written during the backfill
+// may describe events a chunk already passed over and must stay unhealed by it.
 func (c *Connector) EnsureMeterCache(ctx context.Context, namespace string, m meterpkg.Meter) error {
 	if !c.config.Cache.Enabled {
 		return errors.New("meter cache is disabled")
@@ -166,6 +184,11 @@ func (c *Connector) EnsureMeterCache(ctx context.Context, namespace string, m me
 		return fmt.Errorf("create meter cache mv: %w", err)
 	}
 
+	var backfillStartedAt time.Time
+	if err := c.config.ClickHouse.QueryRow(ctx, "SELECT now64(3)").Scan(&backfillStartedAt); err != nil {
+		return fmt.Errorf("query backfill start time: %w", err)
+	}
+
 	if err := c.backfillMeterCache(ctx, namespace, m); err != nil {
 		return fmt.Errorf("backfill meter cache: %w", err)
 	}
@@ -175,7 +198,9 @@ func (c *Connector) EnsureMeterCache(ctx context.Context, namespace string, m me
 		return fmt.Errorf("generate meter cache mv metadata: %w", err)
 	}
 
-	metadata.BackfilledAt = lo.ToPtr(time.Now().UTC().Truncate(time.Second))
+	// Truncating down keeps the heal bound conservative: a sub-second-older marker is
+	// treated as not covered by the backfill rather than the other way around.
+	metadata.BackfilledAt = lo.ToPtr(backfillStartedAt.UTC().Truncate(time.Second))
 
 	comment, err := metadata.marshal()
 	if err != nil {
@@ -185,6 +210,44 @@ func (c *Connector) EnsureMeterCache(ctx context.Context, namespace string, m me
 	stampSQL := fmt.Sprintf("ALTER TABLE %s MODIFY COMMENT %s", getTableName(c.config.Database, mv.name()), sqlStringLiteral(comment))
 	if err := c.config.ClickHouse.Exec(ctx, stampSQL); err != nil {
 		return fmt.Errorf("stamp meter cache mv backfill: %w", err)
+	}
+
+	return nil
+}
+
+// StampMeterCacheCoverage rewrites a deployed view's comment metadata with an advanced
+// coverage watermark (covered_at), preserving every other recorded field. The reconciler
+// calls it while refreshes stay continuous so that after a ClickHouse restart — which
+// wipes system.view_refreshes — the durable watermark still reveals how long refreshes had
+// been absent, letting the outage-repair rule fire instead of trusting the fresh-looking
+// post-restart refresh state.
+func (c *Connector) StampMeterCacheCoverage(ctx context.Context, view MeterCacheView, coveredAt time.Time) error {
+	if !c.config.Cache.Enabled {
+		return errors.New("meter cache is disabled")
+	}
+
+	if !view.MetadataOK || view.BackfilledAt == nil {
+		return fmt.Errorf("refusing to stamp coverage on %q: view metadata is not converged", view.Name)
+	}
+
+	metadata := meterCacheMVMetadata{
+		Namespace:    view.Namespace,
+		MeterKey:     view.MeterKey,
+		EventType:    view.EventType,
+		MeterHash:    view.MeterHash,
+		DDLHash:      view.DDLHash,
+		BackfilledAt: view.BackfilledAt,
+		CoveredAt:    lo.ToPtr(coveredAt.UTC().Truncate(time.Second)),
+	}
+
+	comment, err := metadata.marshal()
+	if err != nil {
+		return fmt.Errorf("marshal meter cache mv metadata: %w", err)
+	}
+
+	stampSQL := fmt.Sprintf("ALTER TABLE %s MODIFY COMMENT %s", getTableName(c.config.Database, view.Name), sqlStringLiteral(comment))
+	if err := c.config.ClickHouse.Exec(ctx, stampSQL); err != nil {
+		return fmt.Errorf("stamp meter cache mv coverage: %w", err)
 	}
 
 	return nil

--- a/openmeter/streaming/clickhouse/meter_cache_manager.go
+++ b/openmeter/streaming/clickhouse/meter_cache_manager.go
@@ -1,0 +1,384 @@
+package clickhouse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
+
+	meterpkg "github.com/openmeterio/openmeter/openmeter/meter"
+)
+
+// ErrMeterCacheUnsupported marks capability-probe failures that no amount of retrying can
+// fix on this ClickHouse deployment (no refreshable view support, missing SYSTEM REFRESH
+// VIEW grant). The lifecycle reconciler distinguishes it from transient probe errors: an
+// unsupported deployment disables reconciliation for the process lifetime, while transient
+// failures are retried on the next tick.
+var ErrMeterCacheUnsupported = errors.New("meter cache is unsupported by this ClickHouse deployment")
+
+// MeterCacheView is one deployed cache MV as the lifecycle reconciler sees it: the object
+// name discovered in system.tables, the parsed comment metadata, and the refresh health
+// reported by system.view_refreshes.
+type MeterCacheView struct {
+	Name string
+
+	// MetadataOK is false when the comment did not parse as valid cache MV metadata; the
+	// reconciler must treat such a view as foreign or corrupt and recreate it rather than
+	// trust any of the metadata fields below.
+	MetadataOK bool
+	MeterKey   string
+	EventType  string
+	// MeterHash and DDLHash are the formatted (16 hex char) hashes recorded at creation.
+	MeterHash string
+	DDLHash   string
+	// BackfilledAt is nil while the one-time backfill has not completed (G3): either it is
+	// still running, or the actor performing it died in between. Readers refuse such views
+	// and the reconciler re-runs backfill + stamp.
+	BackfilledAt *time.Time
+
+	// LastSuccessTime is nil until the view's first successful refresh since ClickHouse
+	// startup (system.view_refreshes is per-server, in-memory state).
+	LastSuccessTime *time.Time
+	Exception       string
+}
+
+// MeterCacheDesiredView is the cache view one meter definition maps to under the current
+// cache configuration: the deterministic MV name plus the formatted hashes the deployed
+// view's metadata must match to be considered converged.
+type MeterCacheDesiredView struct {
+	Name      string
+	MeterHash string
+	DDLHash   string
+}
+
+func (c *Connector) meterCacheMV(namespace string, m meterpkg.Meter) createMeterCacheMV {
+	return createMeterCacheMV{
+		Database:        c.config.Database,
+		EventsTableName: c.config.EventsTableName,
+		Namespace:       namespace,
+		Meter:           m,
+		Grain:           c.config.Cache.WindowSize,
+		RefreshInterval: c.config.Cache.RefreshInterval,
+		MinimumUsageAge: c.config.Cache.MinimumUsageAge,
+	}
+}
+
+// DesiredMeterCacheView maps a meter definition to its desired cache view. A non-nil error
+// means the meter cannot be cached at all under the current configuration (reserved
+// group-by aliases, G9); callers must skip the meter and let it be served live, never
+// treat the error as fatal for other meters.
+func (c *Connector) DesiredMeterCacheView(namespace string, m meterpkg.Meter) (MeterCacheDesiredView, error) {
+	if !c.config.Cache.Enabled {
+		return MeterCacheDesiredView{}, errors.New("meter cache is disabled")
+	}
+
+	mv := c.meterCacheMV(namespace, m)
+
+	metadata, err := mv.metadata()
+	if err != nil {
+		return MeterCacheDesiredView{}, err
+	}
+
+	return MeterCacheDesiredView{
+		Name:      mv.name(),
+		MeterHash: metadata.MeterHash,
+		DDLHash:   metadata.DDLHash,
+	}, nil
+}
+
+// ListActualViews returns every deployed meter cache MV in the database, joined with its
+// refresh health. Views with unparseable comment metadata are returned with MetadataOK
+// false instead of being filtered out: the reconciler owns the om_meter_cache_mv_ name
+// prefix and must see foreign or corrupt views to recreate them.
+func (c *Connector) ListActualViews(ctx context.Context) ([]MeterCacheView, error) {
+	if !c.config.Cache.Enabled {
+		return nil, errors.New("meter cache is disabled")
+	}
+
+	rows, err := c.config.ClickHouse.Query(ctx,
+		"SELECT t.name, t.comment, r.last_success_time, r.exception "+
+			"FROM system.tables AS t "+
+			"LEFT JOIN system.view_refreshes AS r ON r.database = t.database AND r.view = t.name "+
+			"WHERE t.database = ? AND t.engine = 'MaterializedView' AND startsWith(t.name, ?)",
+		c.config.Database, meterCacheMVNamePrefix,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list meter cache views: %w", err)
+	}
+
+	defer rows.Close()
+
+	var views []MeterCacheView
+
+	for rows.Next() {
+		var (
+			view    MeterCacheView
+			comment string
+		)
+
+		if err := rows.Scan(&view.Name, &comment, &view.LastSuccessTime, &view.Exception); err != nil {
+			return nil, fmt.Errorf("scan meter cache view: %w", err)
+		}
+
+		if metadata, err := parseMeterCacheMVMetadata(comment); err == nil {
+			view.MetadataOK = true
+			view.MeterKey = metadata.MeterKey
+			view.EventType = metadata.EventType
+			view.MeterHash = metadata.MeterHash
+			view.DDLHash = metadata.DDLHash
+			view.BackfilledAt = metadata.BackfilledAt
+		}
+
+		views = append(views, view)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list meter cache views: %w", err)
+	}
+
+	return views, nil
+}
+
+// EnsureMeterCache converges one meter's cache view to fully deployed: CREATE the MV (IF
+// NOT EXISTS, so repairing a half-deployed view and losing a create race are both benign),
+// backfill full settled history in month chunks, then stamp backfilled_at. The stamp is
+// deliberately last: readers refuse unstamped views (G3), so an actor dying anywhere in
+// this sequence leaves a visibly unfinished view the next reconciliation pass re-runs this
+// exact method on. Re-running over an already-deployed view is safe end to end because
+// backfill rows resolve against refresh rows by newest-wins.
+func (c *Connector) EnsureMeterCache(ctx context.Context, namespace string, m meterpkg.Meter) error {
+	if !c.config.Cache.Enabled {
+		return errors.New("meter cache is disabled")
+	}
+
+	mv := c.meterCacheMV(namespace, m)
+
+	createSQL, err := mv.toSQL()
+	if err != nil {
+		return fmt.Errorf("generate meter cache mv: %w", err)
+	}
+
+	if err := c.config.ClickHouse.Exec(ctx, createSQL); err != nil {
+		return fmt.Errorf("create meter cache mv: %w", err)
+	}
+
+	if err := c.backfillMeterCache(ctx, namespace, m); err != nil {
+		return fmt.Errorf("backfill meter cache: %w", err)
+	}
+
+	metadata, err := mv.metadata()
+	if err != nil {
+		return fmt.Errorf("generate meter cache mv metadata: %w", err)
+	}
+
+	metadata.BackfilledAt = lo.ToPtr(time.Now().UTC().Truncate(time.Second))
+
+	comment, err := metadata.marshal()
+	if err != nil {
+		return fmt.Errorf("marshal meter cache mv metadata: %w", err)
+	}
+
+	stampSQL := fmt.Sprintf("ALTER TABLE %s MODIFY COMMENT %s", getTableName(c.config.Database, mv.name()), sqlStringLiteral(comment))
+	if err := c.config.ClickHouse.Exec(ctx, stampSQL); err != nil {
+		return fmt.Errorf("stamp meter cache mv backfill: %w", err)
+	}
+
+	return nil
+}
+
+// backfillMeterCache inserts the meter's full settled history into om_meter_cache, chunked
+// on UTC month boundaries so each INSERT scans a bounded slice of the toYYYYMM-partitioned
+// events table instead of all history at once.
+func (c *Connector) backfillMeterCache(ctx context.Context, namespace string, m meterpkg.Meter) error {
+	// The chunk range starts at the earliest event of the meter's event type; scanning for
+	// it costs one aggregation over the type's rows, paid only on (re-)backfill.
+	var (
+		minTime    time.Time
+		eventCount uint64
+	)
+
+	minTimeSQL := fmt.Sprintf("SELECT min(time), count() FROM %s WHERE namespace = ? AND type = ?", getTableName(c.config.Database, c.config.EventsTableName))
+	if err := c.config.ClickHouse.QueryRow(ctx, minTimeSQL, namespace, m.EventType).Scan(&minTime, &eventCount); err != nil {
+		return fmt.Errorf("query earliest event time: %w", err)
+	}
+
+	// No events at all: there is no settled history to backfill, and stamping right away is
+	// correct because scheduled refreshes cover everything that arrives from here on.
+	if eventCount == 0 {
+		return nil
+	}
+
+	from := minTime.UTC()
+	if m.EventFrom != nil && m.EventFrom.After(from) {
+		from = m.EventFrom.UTC()
+	}
+
+	chunks := backfillMonthChunks(from, time.Now().UTC())
+
+	for i, chunk := range chunks {
+		backfill := meterCacheBackfill{
+			Database:        c.config.Database,
+			EventsTableName: c.config.EventsTableName,
+			Namespace:       namespace,
+			Meter:           m,
+			Grain:           c.config.Cache.WindowSize,
+			MinimumUsageAge: c.config.Cache.MinimumUsageAge,
+			From:            &chunk.From,
+		}
+
+		// The final chunk is deliberately unbounded above: its real upper limit is the
+		// ClickHouse-evaluated settled bound, and capping it at the app clock's now could
+		// fall below that bound under clock skew, silently skipping freshly settled buckets.
+		if i < len(chunks)-1 {
+			backfill.To = &chunk.To
+		}
+
+		backfillSQL, err := backfill.toSQL()
+		if err != nil {
+			return err
+		}
+
+		if err := c.config.ClickHouse.Exec(ctx, backfillSQL); err != nil {
+			return fmt.Errorf("backfill chunk [%s, %s): %w", chunk.From, chunk.To, err)
+		}
+	}
+
+	return nil
+}
+
+// DropMeterCache drops one deployed cache MV. Dropping the view never touches its rows in
+// om_meter_cache: they are unreachable for reads the moment no meter resolves to their
+// meter_hash, and the reconciler's orphan-row GC removes them.
+func (c *Connector) DropMeterCache(ctx context.Context, viewName string) error {
+	if !c.config.Cache.Enabled {
+		return errors.New("meter cache is disabled")
+	}
+
+	// The reconciler only owns objects under the cache MV name prefix; refusing anything
+	// else keeps a buggy or confused caller from dropping unrelated database objects.
+	if !strings.HasPrefix(viewName, meterCacheMVNamePrefix) {
+		return fmt.Errorf("refusing to drop %q: not a meter cache view name", viewName)
+	}
+
+	if err := c.config.ClickHouse.Exec(ctx, "DROP VIEW IF EXISTS "+getTableName(c.config.Database, viewName)); err != nil {
+		return fmt.Errorf("drop meter cache view %s: %w", viewName, err)
+	}
+
+	return nil
+}
+
+// DeleteMeterCacheOrphanRows deletes cached rows whose meter_hash no meter resolves to
+// anymore (deleted meters, pre-change shapes). Orphan rows are correctness-neutral —
+// every read filters on the current meter_hash (G8) — so this is storage hygiene that runs
+// every reconciliation pass, guarded by a cheap existence probe so the steady state pays
+// one indexed SELECT instead of a delete mutation.
+//
+// keepMeterHashes carries formatted (16 hex char) hashes as recorded in MV metadata. The
+// keep set is hash-only on purpose: meters of different namespaces can share a shape hash,
+// and rows must survive as long as any meter anywhere still resolves to their hash.
+func (c *Connector) DeleteMeterCacheOrphanRows(ctx context.Context, keepMeterHashes []string) error {
+	if !c.config.Cache.Enabled {
+		return errors.New("meter cache is disabled")
+	}
+
+	hashes := make([]string, 0, len(keepMeterHashes))
+
+	for _, formatted := range keepMeterHashes {
+		hash, err := parseCacheHash(formatted)
+		if err != nil {
+			return fmt.Errorf("keep meter hash %q: %w", formatted, err)
+		}
+
+		hashes = append(hashes, strconv.FormatUint(hash, 10))
+	}
+
+	// An empty keep set means no meter is cacheable at all: every cached row is an orphan.
+	where := "true"
+	if len(hashes) > 0 {
+		where = fmt.Sprintf("meter_hash NOT IN (%s)", strings.Join(hashes, ", "))
+	}
+
+	table := getTableName(c.config.Database, meterCacheTableName)
+
+	rows, err := c.config.ClickHouse.Query(ctx, fmt.Sprintf("SELECT 1 FROM %s WHERE %s LIMIT 1", table, where))
+	if err != nil {
+		return fmt.Errorf("probe orphan meter cache rows: %w", err)
+	}
+
+	orphansExist := rows.Next()
+
+	if err := rows.Err(); err != nil {
+		rows.Close()
+
+		return fmt.Errorf("probe orphan meter cache rows: %w", err)
+	}
+
+	rows.Close()
+
+	if !orphansExist {
+		return nil
+	}
+
+	if err := c.config.ClickHouse.Exec(ctx, fmt.Sprintf("DELETE FROM %s WHERE %s", table, where)); err != nil {
+		return fmt.Errorf("delete orphan meter cache rows: %w", err)
+	}
+
+	return nil
+}
+
+// ProbeMeterCacheCapabilities checks whether this ClickHouse deployment can run the meter
+// cache: refreshable materialized view state must be readable (system.view_refreshes) and
+// the connecting user must hold the SYSTEM REFRESH VIEW grant the invalidator's
+// best-effort refresh triggers need. It returns the server version for operator logs.
+//
+// Errors wrapping ErrMeterCacheUnsupported are permanent for the deployment and callers
+// should disable cache reconciliation; any other error is transient (connectivity) and
+// worth retrying.
+func (c *Connector) ProbeMeterCacheCapabilities(ctx context.Context) (string, error) {
+	if !c.config.Cache.Enabled {
+		return "", errors.New("meter cache is disabled")
+	}
+
+	var version string
+	if err := c.config.ClickHouse.QueryRow(ctx, "SELECT version()").Scan(&version); err != nil {
+		return "", fmt.Errorf("clickhouse version query: %w", err)
+	}
+
+	var refreshableViews uint64
+	if err := c.config.ClickHouse.QueryRow(ctx, "SELECT count() FROM system.view_refreshes WHERE database = ?", c.config.Database).Scan(&refreshableViews); err != nil {
+		// Code 60 (UNKNOWN_TABLE) means this server has no refreshable view bookkeeping at
+		// all — the feature the whole cache design schedules recomputation with.
+		if strings.Contains(err.Error(), "code: 60") {
+			return "", fmt.Errorf("%w: system.view_refreshes is not readable: %v", ErrMeterCacheUnsupported, err)
+		}
+
+		return "", fmt.Errorf("system.view_refreshes query: %w", err)
+	}
+
+	// Grant probe against a deliberately nonexistent view: ClickHouse checks access control
+	// before resolving the target, so ACCESS_DENIED (code 497) proves the missing SYSTEM
+	// REFRESH VIEW grant while an unknown-table error proves the statement passed it. The
+	// probe name can never collide with a real cache MV because generated names are all-hex
+	// after the prefix.
+	err := c.config.ClickHouse.Exec(ctx, "SYSTEM REFRESH VIEW "+getTableName(c.config.Database, meterCacheMVNamePrefix+"grant_probe"))
+	if err != nil && strings.Contains(err.Error(), "code: 497") {
+		return "", fmt.Errorf("%w: missing SYSTEM REFRESH VIEW grant: %v", ErrMeterCacheUnsupported, err)
+	}
+
+	return version, nil
+}
+
+// MeterCacheRepairAge is the maximum age of a view's last successful refresh before the
+// lifecycle reconciler must treat its cache content as gapped and re-backfill: the slack
+// portion of the dirty window (dirty window minus the freshness horizon). Buckets settle
+// continuously, and a refresh only provably covers buckets that settled within this slack
+// of it (via the stored_at lookback and the newly-settled strip, both sized from it); once
+// refreshes have been absent longer, buckets settled early in the outage may never be
+// recomputed by any future refresh, which silent gap only a re-backfill closes.
+func (c *Connector) MeterCacheRepairAge() time.Duration {
+	return meterCacheDirtyWindow(c.config.Cache.MinimumUsageAge, c.config.Cache.RefreshInterval) - c.config.Cache.MinimumUsageAge
+}

--- a/openmeter/streaming/clickhouse/meter_cache_manager.go
+++ b/openmeter/streaming/clickhouse/meter_cache_manager.go
@@ -86,6 +86,14 @@ func (c *Connector) DesiredMeterCacheView(namespace string, m meterpkg.Meter) (M
 		return MeterCacheDesiredView{}, errors.New("meter cache is disabled")
 	}
 
+	// LATEST is never cacheable (see meterCacheStaticReject): rejecting it here, before any
+	// MV metadata is generated, keeps it out of the reconciler's desired set entirely, so a
+	// LATEST meter never gets an MV created and any pre-existing LATEST MV from an earlier
+	// deploy is dropped as undesired by the reconciler's diff.
+	if m.Aggregation == meterpkg.MeterAggregationLatest {
+		return MeterCacheDesiredView{}, errors.New("meter cache does not support the LATEST aggregation: always served live")
+	}
+
 	mv := c.meterCacheMV(namespace, m)
 
 	metadata, err := mv.metadata()

--- a/openmeter/streaming/clickhouse/meter_cache_manager_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_manager_test.go
@@ -1,0 +1,54 @@
+package clickhouse
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+)
+
+// managerFixtureConnector builds a *Connector directly (bypassing New, which requires a
+// live ClickHouse connection) for exercising the CH-free branches of the cache manager
+// surface: config field reads and SQL/metadata generation, no round-trips.
+func managerFixtureConnector(cache CacheConfig) *Connector {
+	return &Connector{
+		config: Config{
+			Database:        "openmeter",
+			EventsTableName: "om_events",
+			Cache:           cache,
+		},
+	}
+}
+
+func TestDesiredMeterCacheViewRejectsLatest(t *testing.T) {
+	c := managerFixtureConnector(CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	// LATEST is excluded from the cache entirely (meterCacheStaticReject): the reconciler's
+	// desired-state map must never resolve a name/hash for it, which is what keeps a LATEST
+	// meter out of both MV creation and the orphan-row GC keep set.
+	_, err := c.DesiredMeterCacheView("my_namespace", meter.Meter{
+		Key:           "meter1",
+		EventType:     "event1",
+		Aggregation:   meter.MeterAggregationLatest,
+		ValueProperty: lo.ToPtr("$.value"),
+	})
+	require.ErrorContains(t, err, "LATEST")
+
+	// A non-LATEST meter on the same connector still resolves normally, proving the
+	// rejection is aggregation-specific and not a fixture-wiring accident.
+	_, err = c.DesiredMeterCacheView("my_namespace", meter.Meter{
+		Key:           "meter2",
+		EventType:     "event1",
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	})
+	require.NoError(t, err)
+}

--- a/openmeter/streaming/clickhouse/meter_cache_markers.go
+++ b/openmeter/streaming/clickhouse/meter_cache_markers.go
@@ -1,0 +1,258 @@
+package clickhouse
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
+)
+
+// meterCacheMarkerHealScope is one deployed view's heal evidence against invalidation
+// markers of its (namespace, event type): the ClickHouse-clock instant its full-history
+// backfill started, and the start of its latest observed successful refresh (nil while
+// system.view_refreshes reports none, e.g. right after a ClickHouse restart).
+type meterCacheMarkerHealScope struct {
+	BackfilledAt time.Time
+	RefreshStart *time.Time
+}
+
+// healedExpr renders the predicate under which a marker is healed for this view, with the
+// same two arms the reader's meterCacheMarkerOverlapQuery uses: covered by the backfill
+// (created_at < BackfilledAt) or covered by the latest refresh's stored_at lookback (G1:
+// started after the marker, within the heal bound of it).
+func (s meterCacheMarkerHealScope) healedExpr(healBound time.Duration) (string, []interface{}) {
+	if s.RefreshStart == nil {
+		return "created_at < ?", []interface{}{s.BackfilledAt}
+	}
+
+	return "(created_at < ? OR (created_at > ? AND created_at < ?))",
+		[]interface{}{s.BackfilledAt, s.RefreshStart.Add(-healBound), *s.RefreshStart}
+}
+
+// unhealedExpr renders the complement of healedExpr. The refresh arm is present only when
+// a refresh was observed; without one, only the backfill can heal.
+func (s meterCacheMarkerHealScope) unhealedExpr(healBound time.Duration) (string, []interface{}) {
+	if s.RefreshStart == nil {
+		return "created_at >= ?", []interface{}{s.BackfilledAt}
+	}
+
+	return "created_at >= ? AND (created_at >= ? OR created_at <= ?)",
+		[]interface{}{s.BackfilledAt, *s.RefreshStart, s.RefreshStart.Add(-healBound)}
+}
+
+// meterCacheHealedMarkersQuery selects or deletes the invalidation markers of one
+// (namespace, event type) pair that every deployed stamped view of the pair has healed.
+// Deleting such markers is what keeps marker healing from regressing: the reader's heal
+// rule can only consult the latest refresh, so a marker healed within its window would
+// flip back to unhealed once refreshes advance past created_at + heal bound, forcing the
+// marked range live until the marker's TTL.
+type meterCacheHealedMarkersQuery struct {
+	Database  string
+	Namespace string
+	EventType string
+	HealBound time.Duration
+	Scopes    []meterCacheMarkerHealScope
+}
+
+func (q meterCacheHealedMarkersQuery) where() (string, []interface{}) {
+	conds := []string{"namespace = ?", "event_type = ?"}
+	args := []interface{}{q.Namespace, q.EventType}
+
+	for _, scope := range q.Scopes {
+		cond, condArgs := scope.healedExpr(q.HealBound)
+		conds = append(conds, cond)
+		args = append(args, condArgs...)
+	}
+
+	return strings.Join(conds, " AND "), args
+}
+
+func (q meterCacheHealedMarkersQuery) countSQL() (string, []interface{}) {
+	where, args := q.where()
+
+	return fmt.Sprintf("SELECT count() FROM %s WHERE %s", getTableName(q.Database, meterCacheInvalidationsTableName), where), args
+}
+
+func (q meterCacheHealedMarkersQuery) deleteSQL() (string, []interface{}) {
+	where, args := q.where()
+
+	return fmt.Sprintf("DELETE FROM %s WHERE %s", getTableName(q.Database, meterCacheInvalidationsTableName), where), args
+}
+
+// meterCacheExpiredUnhealedMarkersQuery counts one view's markers that are unhealed and
+// whose heal window has already expired: no refresh starting from now on can satisfy
+// refreshStart − created_at < healBound anymore, so the only way the marked buckets ever
+// converge is a re-backfill. The expiry cutoff is evaluated on the ClickHouse clock
+// (now64) against the server-stamped created_at, keeping app clock skew out of the
+// decision.
+type meterCacheExpiredUnhealedMarkersQuery struct {
+	Database  string
+	Namespace string
+	EventType string
+	HealBound time.Duration
+	Scope     meterCacheMarkerHealScope
+}
+
+func (q meterCacheExpiredUnhealedMarkersQuery) toSQL() (string, []interface{}) {
+	unhealed, args := q.Scope.unhealedExpr(q.HealBound)
+
+	sql := fmt.Sprintf(
+		"SELECT count() FROM %s WHERE namespace = ? AND event_type = ? AND %s AND created_at <= now64(3) - INTERVAL %d SECOND",
+		getTableName(q.Database, meterCacheInvalidationsTableName),
+		unhealed,
+		int64(q.HealBound/time.Second),
+	)
+
+	return sql, append([]interface{}{q.Namespace, q.EventType}, args...)
+}
+
+// ReconcileMeterCacheMarkers is the reconciler's per-pass invalidation marker
+// maintenance. It deletes markers that every deployed stamped view of their (namespace,
+// event type) has healed, and returns the names of views holding expired-unhealed markers
+// — markers no future refresh can heal — which only a re-backfill (viewActionEnsure) can
+// converge.
+//
+// Views without a successful refresh are never reported for repair: their reads are
+// already refused as stale, and once refreshes resume the next pass re-evaluates against
+// real heal evidence. Repairs are self-throttling: a completed re-backfill advances the
+// view's BackfilledAt past the offending markers' created_at, so they count as healed on
+// the following pass and get deleted instead of re-reported.
+//
+// Marker groups without any deployed stamped view are left alone: no read consults the
+// cache for them (the gate refuses on view_missing/backfill_unstamped), a future view's
+// backfill starts after the markers and heals them, and the 7 day TTL bounds the table.
+func (c *Connector) ReconcileMeterCacheMarkers(ctx context.Context, views []MeterCacheView) ([]string, error) {
+	if !c.config.Cache.Enabled {
+		return nil, errors.New("meter cache is disabled")
+	}
+
+	type markerGroup struct {
+		namespace string
+		eventType string
+	}
+
+	viewsByGroup := map[markerGroup][]MeterCacheView{}
+
+	for _, view := range views {
+		if !view.MetadataOK || view.BackfilledAt == nil {
+			continue
+		}
+
+		key := markerGroup{namespace: view.Namespace, eventType: view.EventType}
+		viewsByGroup[key] = append(viewsByGroup[key], view)
+	}
+
+	if len(viewsByGroup) == 0 {
+		return nil, nil
+	}
+
+	rows, err := c.config.ClickHouse.Query(ctx,
+		"SELECT DISTINCT namespace, event_type FROM "+getTableName(c.config.Database, meterCacheInvalidationsTableName))
+	if err != nil {
+		return nil, fmt.Errorf("list meter cache marker groups: %w", err)
+	}
+
+	defer rows.Close()
+
+	var groups []markerGroup
+
+	for rows.Next() {
+		var group markerGroup
+
+		if err := rows.Scan(&group.namespace, &group.eventType); err != nil {
+			return nil, fmt.Errorf("scan meter cache marker group: %w", err)
+		}
+
+		groups = append(groups, group)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list meter cache marker groups: %w", err)
+	}
+
+	healBound := meterCacheHealBound(c.config.Cache.MinimumUsageAge, c.config.Cache.RefreshInterval)
+
+	var (
+		needRepair []string
+		errs       []error
+	)
+
+	for _, group := range groups {
+		matching := viewsByGroup[group]
+		if len(matching) == 0 {
+			continue
+		}
+
+		scopes := make([]meterCacheMarkerHealScope, 0, len(matching))
+
+		for _, view := range matching {
+			scope := meterCacheMarkerHealScope{BackfilledAt: *view.BackfilledAt}
+
+			if view.LastSuccessTime != nil && view.LastSuccessDurationMS != nil {
+				scope.RefreshStart = lo.ToPtr(view.LastSuccessTime.Add(-time.Duration(*view.LastSuccessDurationMS) * time.Millisecond))
+			}
+
+			scopes = append(scopes, scope)
+		}
+
+		healed := meterCacheHealedMarkersQuery{
+			Database:  c.config.Database,
+			Namespace: group.namespace,
+			EventType: group.eventType,
+			HealBound: healBound,
+			Scopes:    scopes,
+		}
+
+		countSQL, countArgs := healed.countSQL()
+
+		// The count probe guards the delete so the steady state (no healed markers, or no
+		// markers at all once this pass deleted them) pays one indexed SELECT instead of a
+		// delete mutation.
+		var healedCount uint64
+		if err := c.config.ClickHouse.QueryRow(ctx, countSQL, countArgs...).Scan(&healedCount); err != nil {
+			errs = append(errs, fmt.Errorf("count healed markers for %s/%s: %w", group.namespace, group.eventType, err))
+
+			continue
+		}
+
+		if healedCount > 0 {
+			deleteSQL, deleteArgs := healed.deleteSQL()
+			if err := c.config.ClickHouse.Exec(ctx, deleteSQL, deleteArgs...); err != nil {
+				errs = append(errs, fmt.Errorf("delete healed markers for %s/%s: %w", group.namespace, group.eventType, err))
+			}
+		}
+
+		for i, view := range matching {
+			if scopes[i].RefreshStart == nil {
+				continue
+			}
+
+			expiredSQL, expiredArgs := meterCacheExpiredUnhealedMarkersQuery{
+				Database:  c.config.Database,
+				Namespace: group.namespace,
+				EventType: group.eventType,
+				HealBound: healBound,
+				Scope:     scopes[i],
+			}.toSQL()
+
+			var expiredCount uint64
+			if err := c.config.ClickHouse.QueryRow(ctx, expiredSQL, expiredArgs...).Scan(&expiredCount); err != nil {
+				errs = append(errs, fmt.Errorf("count expired unhealed markers for view %s: %w", view.Name, err))
+
+				continue
+			}
+
+			if expiredCount > 0 {
+				needRepair = append(needRepair, view.Name)
+			}
+		}
+	}
+
+	slices.Sort(needRepair)
+
+	return slices.Compact(needRepair), errors.Join(errs...)
+}

--- a/openmeter/streaming/clickhouse/meter_cache_markers_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_markers_test.go
@@ -1,0 +1,86 @@
+package clickhouse
+
+import (
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMeterCacheMarkerMaintenanceQueries(t *testing.T) {
+	parse := func(s string) time.Time {
+		ts, err := time.Parse(time.RFC3339, s)
+		require.NoError(t, err)
+		return ts
+	}
+
+	healBound := 20 * time.Minute
+	backfilledAt := parse("2025-03-01T00:00:00Z")
+	refreshStart := parse("2025-03-01T09:10:00Z")
+
+	refreshed := meterCacheMarkerHealScope{
+		BackfilledAt: backfilledAt,
+		RefreshStart: lo.ToPtr(refreshStart),
+	}
+
+	// A view without an observed refresh (system.view_refreshes wiped by a ClickHouse
+	// restart) can only heal through its backfill.
+	unrefreshed := meterCacheMarkerHealScope{BackfilledAt: backfilledAt}
+
+	t.Run("healed markers golden with mixed scopes", func(t *testing.T) {
+		q := meterCacheHealedMarkersQuery{
+			Database:  "openmeter",
+			Namespace: "my_namespace",
+			EventType: "event1",
+			HealBound: healBound,
+			Scopes:    []meterCacheMarkerHealScope{refreshed, unrefreshed},
+		}
+
+		// Deletion requires the marker healed by EVERY view of the (namespace, event
+		// type): one still-unhealed view keeps the marker gating reads until that view
+		// re-backfills.
+		wantWhere := "namespace = ? AND event_type = ? " +
+			"AND (created_at < ? OR (created_at > ? AND created_at < ?)) " +
+			"AND created_at < ?"
+		wantArgs := []interface{}{
+			"my_namespace", "event1",
+			backfilledAt, refreshStart.Add(-healBound), refreshStart,
+			backfilledAt,
+		}
+
+		countSQL, countArgs := q.countSQL()
+		assert.Equal(t, "SELECT count() FROM openmeter.om_meter_cache_invalidations WHERE "+wantWhere, countSQL)
+		assert.Equal(t, wantArgs, countArgs)
+
+		deleteSQL, deleteArgs := q.deleteSQL()
+		assert.Equal(t, "DELETE FROM openmeter.om_meter_cache_invalidations WHERE "+wantWhere, deleteSQL)
+		assert.Equal(t, wantArgs, deleteArgs)
+	})
+
+	t.Run("expired unhealed markers golden", func(t *testing.T) {
+		sql, args := meterCacheExpiredUnhealedMarkersQuery{
+			Database:  "openmeter",
+			Namespace: "my_namespace",
+			EventType: "event1",
+			HealBound: healBound,
+			Scope:     refreshed,
+		}.toSQL()
+
+		// The unhealed complement mirrors the reader's meterCacheMarkerOverlapQuery arms;
+		// the trailing now64 cutoff keeps markers whose heal window is still open (a
+		// coming refresh may yet heal them) from triggering a premature re-backfill.
+		assert.Equal(t,
+			"SELECT count() FROM openmeter.om_meter_cache_invalidations "+
+				"WHERE namespace = ? AND event_type = ? "+
+				"AND created_at >= ? AND (created_at >= ? OR created_at <= ?) "+
+				"AND created_at <= now64(3) - INTERVAL 1200 SECOND",
+			sql,
+		)
+		assert.Equal(t, []interface{}{
+			"my_namespace", "event1",
+			backfilledAt, refreshStart, refreshStart.Add(-healBound),
+		}, args)
+	})
+}

--- a/openmeter/streaming/clickhouse/meter_cache_mv.go
+++ b/openmeter/streaming/clickhouse/meter_cache_mv.go
@@ -287,6 +287,7 @@ func (d createMeterCacheMV) metadata() (meterCacheMVMetadata, error) {
 	}
 
 	return meterCacheMVMetadata{
+		Namespace: d.Namespace,
 		MeterKey:  d.Meter.Key,
 		EventType: d.Meter.EventType,
 		MeterHash: formatCacheHash(meterHash(d.Meter, d.Grain)),

--- a/openmeter/streaming/clickhouse/meter_cache_mv.go
+++ b/openmeter/streaming/clickhouse/meter_cache_mv.go
@@ -131,13 +131,21 @@ func meterCacheSelectSQL(p meterCacheSelectParams) (string, error) {
 		groupByElements = append(groupByElements, groupByJSONExpr(dataColumn, p.Meter.GroupBy[key]))
 	}
 
+	// A meter without group-by dimensions must still produce an Array(String) column: the
+	// bare empty literal [] types as Array(Nothing), which ClickHouse rejects when the
+	// SELECT feeds a materialized view or table column.
+	groupByArrayExpr := "emptyArrayString() AS group_by"
+	if len(groupByElements) > 0 {
+		groupByArrayExpr = fmt.Sprintf("[%s] AS group_by", strings.Join(groupByElements, ", "))
+	}
+
 	selectColumns := []string{
 		"namespace",
 		fmt.Sprintf("%s AS meter_key", sqlStringLiteral(p.Meter.Key)),
 		fmt.Sprintf("%d AS meter_hash", meterHash(p.Meter, p.Grain)),
 		windowColumns[0],
 		"subject",
-		fmt.Sprintf("[%s] AS group_by", strings.Join(groupByElements, ", ")),
+		groupByArrayExpr,
 		"now64(3) AS created_at",
 	}
 	selectColumns = append(selectColumns, combineColumns...)

--- a/openmeter/streaming/clickhouse/meter_cache_mv.go
+++ b/openmeter/streaming/clickhouse/meter_cache_mv.go
@@ -16,6 +16,8 @@ type grainSpec struct {
 	windowSize meterpkg.WindowSize
 	// intervalUnit is used in INTERVAL 1 <unit> / toStartOfInterval expressions.
 	intervalUnit string
+	// tumbleInterval is the toIntervalX(1) form used in tumbleStart expressions.
+	tumbleInterval string
 	// seconds is the fixed bucket width. Day is a constant 86400 because cache buckets
 	// are always UTC-aligned and UTC has no DST transitions.
 	seconds int64
@@ -24,14 +26,29 @@ type grainSpec struct {
 func grainSpecFor(grain CacheGrain) (grainSpec, error) {
 	switch grain {
 	case CacheGrainMinute:
-		return grainSpec{windowSize: meterpkg.WindowSizeMinute, intervalUnit: "MINUTE", seconds: 60}, nil
+		return grainSpec{windowSize: meterpkg.WindowSizeMinute, intervalUnit: "MINUTE", tumbleInterval: "toIntervalMinute(1)", seconds: 60}, nil
 	case CacheGrainHour:
-		return grainSpec{windowSize: meterpkg.WindowSizeHour, intervalUnit: "HOUR", seconds: 3600}, nil
+		return grainSpec{windowSize: meterpkg.WindowSizeHour, intervalUnit: "HOUR", tumbleInterval: "toIntervalHour(1)", seconds: 3600}, nil
 	case CacheGrainDay:
-		return grainSpec{windowSize: meterpkg.WindowSizeDay, intervalUnit: "DAY", seconds: 86400}, nil
+		return grainSpec{windowSize: meterpkg.WindowSizeDay, intervalUnit: "DAY", tumbleInterval: "toIntervalDay(1)", seconds: 86400}, nil
 	default:
 		return grainSpec{}, fmt.Errorf("invalid meter cache grain: %s", grain)
 	}
+}
+
+// meterCacheDirtyWindow is the stored_at lookback a scheduled refresh scans for
+// recently-touched buckets. Buckets first become cacheable minimumUsageAge after their
+// events arrive, so the lookback must exceed age + one refresh interval; the extra
+// intervals and the one-hour floor absorb refresh scheduling jitter. The reader's marker
+// heal rule (meterCacheHealBound) is derived from the same value, which is why it is a
+// shared helper instead of arithmetic inlined at each site.
+func meterCacheDirtyWindow(minimumUsageAge, refreshInterval time.Duration) time.Duration {
+	dirtyWindow := minimumUsageAge + 3*refreshInterval
+	if dirtyWindow < time.Hour {
+		dirtyWindow = time.Hour
+	}
+
+	return dirtyWindow
 }
 
 // sqlStringLiteral renders s as a single-quoted ClickHouse string literal, escaping
@@ -203,10 +220,7 @@ func dirtyBucketFilterExpr(p meterCacheSelectParams, spec grainSpec, timeColumn 
 		return "", fmt.Errorf("meter cache refresh interval must be at least one second, got %s", p.RefreshInterval)
 	}
 
-	dirtyWindow := p.MinimumUsageAge + 3*p.RefreshInterval
-	if dirtyWindow < time.Hour {
-		dirtyWindow = time.Hour
-	}
+	dirtyWindow := meterCacheDirtyWindow(p.MinimumUsageAge, p.RefreshInterval)
 
 	stripSeconds := int64((3 * p.RefreshInterval) / time.Second)
 	stripBuckets := (stripSeconds + spec.seconds - 1) / spec.seconds

--- a/openmeter/streaming/clickhouse/meter_cache_mv.go
+++ b/openmeter/streaming/clickhouse/meter_cache_mv.go
@@ -1,0 +1,324 @@
+package clickhouse
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"time"
+
+	meterpkg "github.com/openmeterio/openmeter/openmeter/meter"
+)
+
+// grainSpec describes how a cache grain is expressed in generated SQL.
+type grainSpec struct {
+	windowSize meterpkg.WindowSize
+	// intervalUnit is used in INTERVAL 1 <unit> / toStartOfInterval expressions.
+	intervalUnit string
+	// seconds is the fixed bucket width. Day is a constant 86400 because cache buckets
+	// are always UTC-aligned and UTC has no DST transitions.
+	seconds int64
+}
+
+func grainSpecFor(grain CacheGrain) (grainSpec, error) {
+	switch grain {
+	case CacheGrainMinute:
+		return grainSpec{windowSize: meterpkg.WindowSizeMinute, intervalUnit: "MINUTE", seconds: 60}, nil
+	case CacheGrainHour:
+		return grainSpec{windowSize: meterpkg.WindowSizeHour, intervalUnit: "HOUR", seconds: 3600}, nil
+	case CacheGrainDay:
+		return grainSpec{windowSize: meterpkg.WindowSizeDay, intervalUnit: "DAY", seconds: 86400}, nil
+	default:
+		return grainSpec{}, fmt.Errorf("invalid meter cache grain: %s", grain)
+	}
+}
+
+// sqlStringLiteral renders s as a single-quoted ClickHouse string literal, escaping
+// backslashes and single quotes. Generated cache SQL cannot use query arguments (a
+// materialized view definition is stored verbatim), so every user-influenced string that
+// ends up in cache DDL must go through this.
+func sqlStringLiteral(s string) string {
+	escaped := strings.ReplaceAll(s, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+
+	return fmt.Sprintf("'%s'", escaped)
+}
+
+// settledBoundExpr is the exclusive upper event-time bound of cacheable data: the start
+// of the grain bucket that lies minimumUsageAge before now. Events at or above it are in
+// buckets that may still receive on-time events, so caching them would freeze a partial
+// aggregate; the reader serves that tail from the live table instead.
+//
+// The bucket alignment is explicitly 'UTC' to match the windowstart expression
+// (tumbleStart(..., 'UTC')): with the server default timezone, a non-UTC or
+// non-whole-hour-offset server would align the bound differently than the buckets it is
+// supposed to guard, letting a partially settled bucket slip into the cache.
+func settledBoundExpr(minimumUsageAge time.Duration, spec grainSpec) string {
+	return fmt.Sprintf(
+		"toStartOfInterval(now() - INTERVAL %d SECOND, INTERVAL 1 %s, 'UTC')",
+		int64(minimumUsageAge/time.Second),
+		spec.intervalUnit,
+	)
+}
+
+// meterCacheSelectParams parameterizes the single SELECT shape shared by the cache MV
+// definition and the backfill INSERT. Both must aggregate identically — the backfill is
+// simply the same query over full settled history — so they are rendered by one builder
+// and only differ in their time bounds and the dirty-bucket restriction.
+type meterCacheSelectParams struct {
+	Database        string
+	EventsTableName string
+	Namespace       string
+	Meter           meterpkg.Meter
+	Grain           CacheGrain
+	MinimumUsageAge time.Duration
+
+	// From is the inclusive lower event-time bound (already resolved against the meter's
+	// EventFrom by the caller); nil means unbounded history.
+	From *time.Time
+	// To is an exclusive upper event-time bound applied in addition to the settled bound;
+	// backfill chunking uses it, the MV never does.
+	To *time.Time
+
+	// DirtyBucketsOnly restricts the query to recently-touched buckets plus the
+	// newly-settled strip. The MV sets it so scheduled refreshes only recompute buckets
+	// that can have changed; the backfill leaves it unset to cover full settled history.
+	DirtyBucketsOnly bool
+	// RefreshInterval sizes the dirty stored_at lookback and the newly-settled strip;
+	// required when DirtyBucketsOnly is set.
+	RefreshInterval time.Duration
+}
+
+// meterCacheSelectSQL renders the aggregation SELECT that populates om_meter_cache rows
+// for one meter. Output columns, in order: namespace, meter_key, meter_hash, windowstart,
+// subject, group_by, created_at, then the meter's combine columns (valueExprsCombine).
+func meterCacheSelectSQL(p meterCacheSelectParams) (string, error) {
+	groupByKeys := slices.Sorted(maps.Keys(p.Meter.GroupBy))
+
+	// G9: a group-by key shadowing a source column or a generated alias would silently
+	// neutralize the WHERE filters of this very query, so such meters must not get cache
+	// SQL generated at all. Callers treat the error as "skip this meter, read it live".
+	if err := reservedAliasCheck(groupByKeys); err != nil {
+		return "", err
+	}
+
+	spec, err := grainSpecFor(p.Grain)
+	if err != nil {
+		return "", err
+	}
+
+	getColumn := columnFactory(p.EventsTableName)
+	timeColumn := getColumn("time")
+	dataColumn := getColumn("data")
+
+	// Cache buckets are always UTC: the reader re-windows them into the query's timezone,
+	// and a single canonical alignment is what lets every query share the same rows.
+	windowColumns, err := windowExprs(spec.windowSize, timeColumn, "UTC")
+	if err != nil {
+		return "", err
+	}
+
+	combineColumns, err := valueExprsCombine(p.Meter, dataColumn, timeColumn)
+	if err != nil {
+		return "", err
+	}
+
+	// The meter's group-by dimension values in sorted key order; the same order the
+	// reader uses to decode the array positionally.
+	groupByElements := make([]string, 0, len(groupByKeys))
+	for _, key := range groupByKeys {
+		groupByElements = append(groupByElements, groupByJSONExpr(dataColumn, p.Meter.GroupBy[key]))
+	}
+
+	selectColumns := []string{
+		"namespace",
+		fmt.Sprintf("%s AS meter_key", sqlStringLiteral(p.Meter.Key)),
+		fmt.Sprintf("%d AS meter_hash", meterHash(p.Meter, p.Grain)),
+		windowColumns[0],
+		"subject",
+		fmt.Sprintf("[%s] AS group_by", strings.Join(groupByElements, ", ")),
+		"now64(3) AS created_at",
+	}
+	selectColumns = append(selectColumns, combineColumns...)
+
+	wheres := []string{
+		fmt.Sprintf("%s = %s", getColumn("namespace"), sqlStringLiteral(p.Namespace)),
+		fmt.Sprintf("%s = %s", getColumn("type"), sqlStringLiteral(p.Meter.EventType)),
+	}
+
+	if p.From != nil {
+		wheres = append(wheres, fmt.Sprintf("%s >= %d", timeColumn, p.From.Unix()))
+	}
+
+	if p.To != nil {
+		wheres = append(wheres, fmt.Sprintf("%s < %d", timeColumn, p.To.Unix()))
+	}
+
+	wheres = append(wheres, fmt.Sprintf("%s < %s", timeColumn, settledBoundExpr(p.MinimumUsageAge, spec)))
+
+	if p.DirtyBucketsOnly {
+		dirtyFilter, err := dirtyBucketFilterExpr(p, spec, timeColumn)
+		if err != nil {
+			return "", err
+		}
+
+		wheres = append(wheres, dirtyFilter)
+	}
+
+	return fmt.Sprintf(
+		"SELECT %s FROM %s WHERE %s GROUP BY namespace, windowstart, subject, group_by",
+		strings.Join(selectColumns, ", "),
+		getTableName(p.Database, p.EventsTableName),
+		strings.Join(wheres, " AND "),
+	), nil
+}
+
+// dirtyBucketFilterExpr restricts a scheduled refresh to the buckets that can have
+// changed since recent refreshes, as the union of two bucket sets:
+//
+//   - Recently-touched buckets: any bucket containing an event whose stored_at falls in
+//     the dirty window (minimumUsageAge + 3 refresh intervals, floored at 1h). Buckets
+//     first become cacheable minimumUsageAge after their events arrive, so the lookback
+//     must exceed age + one interval; the extra intervals and the floor absorb refresh
+//     scheduling jitter. Any late arrival carries a fresh stored_at, so it lands here on
+//     the next refresh.
+//   - The newly-settled strip (G2): the buckets whose event time crossed the settled
+//     bound since up to 3 refresh intervals ago. Future-dated events and events ingested
+//     while their bucket was still unsettled have an old stored_at by the time the bucket
+//     settles, so the stored_at lookback alone would never cache them; unconditionally
+//     recomputing the strip just below the settled bound closes that gap at a bounded
+//     cost. At least one strip bucket is always recomputed even when the refresh interval
+//     is shorter than the grain, because the bound advances one whole grain at a time.
+func dirtyBucketFilterExpr(p meterCacheSelectParams, spec grainSpec, timeColumn string) (string, error) {
+	if p.RefreshInterval < time.Second {
+		return "", fmt.Errorf("meter cache refresh interval must be at least one second, got %s", p.RefreshInterval)
+	}
+
+	dirtyWindow := p.MinimumUsageAge + 3*p.RefreshInterval
+	if dirtyWindow < time.Hour {
+		dirtyWindow = time.Hour
+	}
+
+	stripSeconds := int64((3 * p.RefreshInterval) / time.Second)
+	stripBuckets := (stripSeconds + spec.seconds - 1) / spec.seconds
+	if stripBuckets < 1 {
+		stripBuckets = 1
+	}
+
+	return fmt.Sprintf(
+		"toStartOfInterval(%s, INTERVAL 1 %s, 'UTC') IN ("+
+			"SELECT DISTINCT toStartOfInterval(time, INTERVAL 1 %s, 'UTC') FROM %s WHERE namespace = %s AND type = %s AND stored_at >= now() - INTERVAL %d SECOND"+
+			" UNION DISTINCT "+
+			"SELECT subtractSeconds(%s, (number + 1) * %d) FROM numbers(%d))",
+		timeColumn,
+		spec.intervalUnit,
+		spec.intervalUnit,
+		getTableName(p.Database, p.EventsTableName),
+		sqlStringLiteral(p.Namespace),
+		sqlStringLiteral(p.Meter.EventType),
+		int64(dirtyWindow/time.Second),
+		settledBoundExpr(p.MinimumUsageAge, spec),
+		spec.seconds,
+		stripBuckets,
+	), nil
+}
+
+// createMeterCacheMV generates the per-meter refreshable materialized view that maintains
+// om_meter_cache rows for one meter shape.
+type createMeterCacheMV struct {
+	Database        string
+	EventsTableName string
+	Namespace       string
+	Meter           meterpkg.Meter
+	Grain           CacheGrain
+	RefreshInterval time.Duration
+	MinimumUsageAge time.Duration
+}
+
+func (d createMeterCacheMV) name() string {
+	return mvName(d.Namespace, meterHash(d.Meter, d.Grain))
+}
+
+func (d createMeterCacheMV) selectSQL() (string, error) {
+	return meterCacheSelectSQL(meterCacheSelectParams{
+		Database:         d.Database,
+		EventsTableName:  d.EventsTableName,
+		Namespace:        d.Namespace,
+		Meter:            d.Meter,
+		Grain:            d.Grain,
+		MinimumUsageAge:  d.MinimumUsageAge,
+		From:             d.Meter.EventFrom,
+		DirtyBucketsOnly: true,
+		RefreshInterval:  d.RefreshInterval,
+	})
+}
+
+// metadata returns the comment metadata the MV is created with. BackfilledAt is always
+// nil here: the stamp is only added (via ALTER ... MODIFY COMMENT) after the backfill
+// completes, so a leader crash between CREATE and backfill leaves a visibly unstamped MV
+// that readers refuse and the reconciler re-backfills.
+func (d createMeterCacheMV) metadata() (meterCacheMVMetadata, error) {
+	selectSQL, err := d.selectSQL()
+	if err != nil {
+		return meterCacheMVMetadata{}, err
+	}
+
+	return meterCacheMVMetadata{
+		MeterKey:  d.Meter.Key,
+		EventType: d.Meter.EventType,
+		MeterHash: formatCacheHash(meterHash(d.Meter, d.Grain)),
+		DDLHash:   formatCacheHash(ddlHash(d.Grain, d.RefreshInterval, d.MinimumUsageAge, d.Meter.EventFrom, selectSQL)),
+	}, nil
+}
+
+func (d createMeterCacheMV) toSQL() (string, error) {
+	if d.RefreshInterval < time.Second {
+		return "", fmt.Errorf("meter cache refresh interval must be at least one second, got %s", d.RefreshInterval)
+	}
+
+	selectSQL, err := d.selectSQL()
+	if err != nil {
+		return "", err
+	}
+
+	metadata, err := d.metadata()
+	if err != nil {
+		return "", err
+	}
+
+	comment, err := metadata.marshal()
+	if err != nil {
+		return "", err
+	}
+
+	refreshSeconds := int64(d.RefreshInterval / time.Second)
+	refreshClause := fmt.Sprintf("REFRESH EVERY %d SECOND", refreshSeconds)
+
+	// RANDOMIZE FOR spreads the refresh load of many MVs sharing the same interval; it is
+	// omitted below one second because ClickHouse rejects a zero interval.
+	if randomizeSeconds := refreshSeconds / 3; randomizeSeconds >= 1 {
+		refreshClause += fmt.Sprintf(" RANDOMIZE FOR %d SECOND", randomizeSeconds)
+	}
+
+	// IF NOT EXISTS keeps concurrent reconciler passes benign: the diff decided this MV
+	// is missing, and losing a create race must not surface as an error.
+	sql := fmt.Sprintf(
+		"CREATE MATERIALIZED VIEW IF NOT EXISTS %s %s APPEND TO %s AS %s COMMENT %s",
+		getTableName(d.Database, d.name()),
+		refreshClause,
+		getTableName(d.Database, meterCacheTableName),
+		selectSQL,
+		sqlStringLiteral(comment),
+	)
+
+	// APPEND is load-bearing for the shared target: a non-APPEND refresh atomically
+	// replaces the entire om_meter_cache table with this one meter's rows, wiping every
+	// other meter's cache. This guard exists so no future edit (e.g. making the refresh
+	// mode conditional) can ever emit a non-APPEND cache MV.
+	if !strings.Contains(sql, " APPEND TO ") {
+		return "", errors.New("generated meter cache MV DDL must contain APPEND TO: a non-APPEND refresh would wipe the shared cache table")
+	}
+
+	return sql, nil
+}

--- a/openmeter/streaming/clickhouse/meter_cache_mv_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_mv_test.go
@@ -244,6 +244,21 @@ func TestCreateMeterCacheMVSQL(t *testing.T) {
 		_, err := mv.toSQL()
 		require.ErrorContains(t, err, "meter value property is required")
 	})
+
+	t.Run("rejects latest aggregation", func(t *testing.T) {
+		// LATEST is excluded from the cache entirely (meterCacheStaticReject / (*Connector).
+		// DesiredMeterCacheView both reject it before this point); the MV generator's combine
+		// form must never be reachable for it either.
+		mv := mvFixture(meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationLatest,
+			ValueProperty: lo.ToPtr("$.value"),
+		}, CacheGrainHour)
+
+		_, err := mv.toSQL()
+		require.ErrorContains(t, err, "invalid aggregation type: LATEST")
+	})
 }
 
 // TestCreateMeterCacheMVMatrix sweeps the generator over every aggregation x group-by
@@ -258,6 +273,8 @@ func TestCreateMeterCacheMVMatrix(t *testing.T) {
 	eventFrom, err := time.Parse(time.RFC3339, "2025-01-01T00:00:00Z")
 	require.NoError(t, err)
 
+	// LATEST is excluded from the cache entirely (meterCacheStaticReject) and covered by its
+	// own rejection test above, not this matrix.
 	aggregations := []meter.MeterAggregation{
 		meter.MeterAggregationSum,
 		meter.MeterAggregationCount,
@@ -265,7 +282,6 @@ func TestCreateMeterCacheMVMatrix(t *testing.T) {
 		meter.MeterAggregationMin,
 		meter.MeterAggregationMax,
 		meter.MeterAggregationUniqueCount,
-		meter.MeterAggregationLatest,
 	}
 
 	wantCombineAliases := map[meter.MeterAggregation][]string{
@@ -275,7 +291,6 @@ func TestCreateMeterCacheMVMatrix(t *testing.T) {
 		meter.MeterAggregationMin:         {"min_value"},
 		meter.MeterAggregationMax:         {"max_value"},
 		meter.MeterAggregationUniqueCount: {"uniq_state"},
-		meter.MeterAggregationLatest:      {"latest_state"},
 	}
 
 	groupByShapes := map[string]map[string]string{

--- a/openmeter/streaming/clickhouse/meter_cache_mv_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_mv_test.go
@@ -80,7 +80,7 @@ func TestCreateMeterCacheMVSQL(t *testing.T) {
 				"REFRESH EVERY 600 SECOND RANDOMIZE FOR 200 SECOND APPEND TO openmeter.om_meter_cache AS "+
 				"SELECT namespace, 'meter1' AS meter_key, 2639070960583832132 AS meter_hash, "+
 				"tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, subject, "+
-				"[] AS group_by, now64(3) AS created_at, "+
+				"emptyArrayString() AS group_by, now64(3) AS created_at, "+
 				"sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS sum_value, "+
 				"count(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS value_count "+
 				"FROM openmeter.om_events "+
@@ -93,7 +93,7 @@ func TestCreateMeterCacheMVSQL(t *testing.T) {
 				"UNION DISTINCT "+
 				"SELECT subtractSeconds(toStartOfInterval(now() - INTERVAL 3600 SECOND, INTERVAL 1 HOUR, 'UTC'), (number + 1) * 3600) FROM numbers(1)) "+
 				"GROUP BY namespace, windowstart, subject, group_by "+
-				`COMMENT '{"meter_key":"meter1","event_type":"event1","meter_hash":"249fdd0e66a5f244","ddl_hash":"6cd549e19c33de11"}'`,
+				`COMMENT '{"meter_key":"meter1","event_type":"event1","meter_hash":"249fdd0e66a5f244","ddl_hash":"6eca4aaec943452f"}'`,
 			sql,
 		)
 	})

--- a/openmeter/streaming/clickhouse/meter_cache_mv_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_mv_test.go
@@ -1,0 +1,345 @@
+package clickhouse
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+)
+
+func mvFixture(m meter.Meter, grain CacheGrain) createMeterCacheMV {
+	return createMeterCacheMV{
+		Database:        "openmeter",
+		EventsTableName: "om_events",
+		Namespace:       "my_namespace",
+		Meter:           m,
+		Grain:           grain,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+	}
+}
+
+func TestCreateMeterCacheMVSQL(t *testing.T) {
+	t.Run("golden sum hour with group bys", func(t *testing.T) {
+		mv := mvFixture(meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationSum,
+			ValueProperty: lo.ToPtr("$.value"),
+			GroupBy: map[string]string{
+				"group1": "$.group1",
+				"group2": "$.group2",
+			},
+		}, CacheGrainHour)
+
+		sql, err := mv.toSQL()
+		require.NoError(t, err)
+		assert.Equal(t,
+			"CREATE MATERIALIZED VIEW IF NOT EXISTS openmeter.om_meter_cache_mv_814585ab_a71813334efc5e0b "+
+				"REFRESH EVERY 600 SECOND RANDOMIZE FOR 200 SECOND APPEND TO openmeter.om_meter_cache AS "+
+				"SELECT namespace, 'meter1' AS meter_key, 12040394714864442891 AS meter_hash, "+
+				"tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, subject, "+
+				"[JSON_VALUE(om_events.data, '$.group1'), JSON_VALUE(om_events.data, '$.group2')] AS group_by, now64(3) AS created_at, "+
+				"sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS sum_value "+
+				"FROM openmeter.om_events "+
+				"WHERE om_events.namespace = 'my_namespace' AND om_events.type = 'event1' "+
+				"AND om_events.time < toStartOfInterval(now() - INTERVAL 3600 SECOND, INTERVAL 1 HOUR, 'UTC') "+
+				"AND toStartOfInterval(om_events.time, INTERVAL 1 HOUR, 'UTC') IN ("+
+				"SELECT DISTINCT toStartOfInterval(time, INTERVAL 1 HOUR, 'UTC') FROM openmeter.om_events "+
+				"WHERE namespace = 'my_namespace' AND type = 'event1' AND stored_at >= now() - INTERVAL 5400 SECOND "+
+				"UNION DISTINCT "+
+				"SELECT subtractSeconds(toStartOfInterval(now() - INTERVAL 3600 SECOND, INTERVAL 1 HOUR, 'UTC'), (number + 1) * 3600) FROM numbers(1)) "+
+				"GROUP BY namespace, windowstart, subject, group_by "+
+				`COMMENT '{"meter_key":"meter1","event_type":"event1","meter_hash":"a71813334efc5e0b","ddl_hash":"49eab5c7b097a200"}'`,
+			sql,
+		)
+	})
+
+	t.Run("golden avg with event from and no group by", func(t *testing.T) {
+		eventFrom, err := time.Parse(time.RFC3339, "2025-01-01T00:00:00Z")
+		require.NoError(t, err)
+
+		mv := mvFixture(meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationAvg,
+			ValueProperty: lo.ToPtr("$.value"),
+			EventFrom:     &eventFrom,
+		}, CacheGrainHour)
+
+		sql, err := mv.toSQL()
+		require.NoError(t, err)
+		assert.Equal(t,
+			"CREATE MATERIALIZED VIEW IF NOT EXISTS openmeter.om_meter_cache_mv_814585ab_249fdd0e66a5f244 "+
+				"REFRESH EVERY 600 SECOND RANDOMIZE FOR 200 SECOND APPEND TO openmeter.om_meter_cache AS "+
+				"SELECT namespace, 'meter1' AS meter_key, 2639070960583832132 AS meter_hash, "+
+				"tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart, subject, "+
+				"[] AS group_by, now64(3) AS created_at, "+
+				"sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS sum_value, "+
+				"count(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS value_count "+
+				"FROM openmeter.om_events "+
+				"WHERE om_events.namespace = 'my_namespace' AND om_events.type = 'event1' "+
+				"AND om_events.time >= 1735689600 "+
+				"AND om_events.time < toStartOfInterval(now() - INTERVAL 3600 SECOND, INTERVAL 1 HOUR, 'UTC') "+
+				"AND toStartOfInterval(om_events.time, INTERVAL 1 HOUR, 'UTC') IN ("+
+				"SELECT DISTINCT toStartOfInterval(time, INTERVAL 1 HOUR, 'UTC') FROM openmeter.om_events "+
+				"WHERE namespace = 'my_namespace' AND type = 'event1' AND stored_at >= now() - INTERVAL 5400 SECOND "+
+				"UNION DISTINCT "+
+				"SELECT subtractSeconds(toStartOfInterval(now() - INTERVAL 3600 SECOND, INTERVAL 1 HOUR, 'UTC'), (number + 1) * 3600) FROM numbers(1)) "+
+				"GROUP BY namespace, windowstart, subject, group_by "+
+				`COMMENT '{"meter_key":"meter1","event_type":"event1","meter_hash":"249fdd0e66a5f244","ddl_hash":"6cd549e19c33de11"}'`,
+			sql,
+		)
+	})
+
+	t.Run("string literals are escaped", func(t *testing.T) {
+		mv := mvFixture(meter.Meter{
+			Key:         `it's "quoted" \meter`,
+			EventType:   "event'1",
+			Aggregation: meter.MeterAggregationCount,
+		}, CacheGrainHour)
+		mv.Namespace = `ns\'1`
+
+		sql, err := mv.toSQL()
+		require.NoError(t, err)
+		assert.Contains(t, sql, `'it\'s "quoted" \\meter' AS meter_key`)
+		assert.Contains(t, sql, `om_events.namespace = 'ns\\\'1'`)
+		assert.Contains(t, sql, `om_events.type = 'event\'1'`)
+	})
+
+	t.Run("grain drives bucket arithmetic", func(t *testing.T) {
+		m := meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationSum,
+			ValueProperty: lo.ToPtr("$.value"),
+		}
+
+		tests := []struct {
+			grain           CacheGrain
+			wantWindowstart string
+			wantBound       string
+			// 3 x 10m refresh interval, rounded up to whole buckets, floored at one:
+			// 30 minute-buckets, 1 hour-bucket, 1 day-bucket.
+			wantStrip string
+		}{
+			{
+				grain:           CacheGrainMinute,
+				wantWindowstart: "tumbleStart(om_events.time, toIntervalMinute(1), 'UTC') AS windowstart",
+				wantBound:       "om_events.time < toStartOfInterval(now() - INTERVAL 3600 SECOND, INTERVAL 1 MINUTE, 'UTC')",
+				wantStrip:       "(number + 1) * 60) FROM numbers(30))",
+			},
+			{
+				grain:           CacheGrainHour,
+				wantWindowstart: "tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart",
+				wantBound:       "om_events.time < toStartOfInterval(now() - INTERVAL 3600 SECOND, INTERVAL 1 HOUR, 'UTC')",
+				wantStrip:       "(number + 1) * 3600) FROM numbers(1))",
+			},
+			{
+				grain:           CacheGrainDay,
+				wantWindowstart: "tumbleStart(om_events.time, toIntervalDay(1), 'UTC') AS windowstart",
+				wantBound:       "om_events.time < toStartOfInterval(now() - INTERVAL 3600 SECOND, INTERVAL 1 DAY, 'UTC')",
+				wantStrip:       "(number + 1) * 86400) FROM numbers(1))",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(string(tt.grain), func(t *testing.T) {
+				sql, err := mvFixture(m, tt.grain).toSQL()
+				require.NoError(t, err)
+				assert.Contains(t, sql, tt.wantWindowstart)
+				assert.Contains(t, sql, tt.wantBound)
+				assert.Contains(t, sql, tt.wantStrip)
+			})
+		}
+	})
+
+	t.Run("dirty window is floored at one hour", func(t *testing.T) {
+		// minimumUsageAge 10m + 3 x 5m = 25m lookback would be shorter than the floor;
+		// the floor keeps slow-arriving stored_at updates coverable.
+		mv := mvFixture(meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationSum,
+			ValueProperty: lo.ToPtr("$.value"),
+		}, CacheGrainMinute)
+		mv.RefreshInterval = 5 * time.Minute
+		mv.MinimumUsageAge = 10 * time.Minute
+
+		sql, err := mv.toSQL()
+		require.NoError(t, err)
+		assert.Contains(t, sql, "stored_at >= now() - INTERVAL 3600 SECOND")
+	})
+
+	t.Run("randomize is omitted below one second", func(t *testing.T) {
+		mv := mvFixture(meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationSum,
+			ValueProperty: lo.ToPtr("$.value"),
+		}, CacheGrainHour)
+		mv.RefreshInterval = 2 * time.Second
+
+		sql, err := mv.toSQL()
+		require.NoError(t, err)
+		assert.Contains(t, sql, "REFRESH EVERY 2 SECOND APPEND TO")
+		assert.NotContains(t, sql, "RANDOMIZE")
+	})
+
+	t.Run("rejects sub-second refresh interval", func(t *testing.T) {
+		mv := mvFixture(meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationSum,
+			ValueProperty: lo.ToPtr("$.value"),
+		}, CacheGrainHour)
+		mv.RefreshInterval = 500 * time.Millisecond
+
+		_, err := mv.toSQL()
+		require.ErrorContains(t, err, "refresh interval must be at least one second")
+	})
+
+	t.Run("rejects invalid grain", func(t *testing.T) {
+		mv := mvFixture(meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationSum,
+			ValueProperty: lo.ToPtr("$.value"),
+		}, CacheGrain("month"))
+
+		_, err := mv.toSQL()
+		require.ErrorContains(t, err, "invalid meter cache grain: month")
+	})
+
+	t.Run("rejects reserved alias group by keys (G9)", func(t *testing.T) {
+		for _, key := range []string{"namespace", "time", "windowstart", "meter_hash", "total_value", "uniq_state"} {
+			t.Run(key, func(t *testing.T) {
+				mv := mvFixture(meter.Meter{
+					Key:           "meter1",
+					EventType:     "event1",
+					Aggregation:   meter.MeterAggregationSum,
+					ValueProperty: lo.ToPtr("$.value"),
+					GroupBy:       map[string]string{key: "$.x"},
+				}, CacheGrainHour)
+
+				_, err := mv.toSQL()
+				require.ErrorContains(t, err, "collide with reserved SQL aliases: "+key)
+			})
+		}
+	})
+
+	t.Run("rejects missing value property", func(t *testing.T) {
+		mv := mvFixture(meter.Meter{
+			Key:         "meter1",
+			EventType:   "event1",
+			Aggregation: meter.MeterAggregationSum,
+		}, CacheGrainHour)
+
+		_, err := mv.toSQL()
+		require.ErrorContains(t, err, "meter value property is required")
+	})
+}
+
+// TestCreateMeterCacheMVMatrix sweeps the generator over every aggregation x group-by
+// shape x grain x EventFrom combination and asserts the structural invariants of the
+// emitted DDL. APPEND is the load-bearing one: a single non-APPEND cache MV refresh
+// atomically wipes the entire shared om_meter_cache table.
+//
+// Watched RED: with `%s APPEND TO %s` changed to `%s TO %s` in createMeterCacheMV.toSQL
+// and the runtime guard disabled (`if false && !strings.Contains(...)`), this matrix and
+// the golden tests fail on the missing APPEND.
+func TestCreateMeterCacheMVMatrix(t *testing.T) {
+	eventFrom, err := time.Parse(time.RFC3339, "2025-01-01T00:00:00Z")
+	require.NoError(t, err)
+
+	aggregations := []meter.MeterAggregation{
+		meter.MeterAggregationSum,
+		meter.MeterAggregationCount,
+		meter.MeterAggregationAvg,
+		meter.MeterAggregationMin,
+		meter.MeterAggregationMax,
+		meter.MeterAggregationUniqueCount,
+		meter.MeterAggregationLatest,
+	}
+
+	wantCombineAliases := map[meter.MeterAggregation][]string{
+		meter.MeterAggregationSum:         {"sum_value"},
+		meter.MeterAggregationCount:       {"count_value"},
+		meter.MeterAggregationAvg:         {"sum_value", "value_count"},
+		meter.MeterAggregationMin:         {"min_value"},
+		meter.MeterAggregationMax:         {"max_value"},
+		meter.MeterAggregationUniqueCount: {"uniq_state"},
+		meter.MeterAggregationLatest:      {"latest_state"},
+	}
+
+	groupByShapes := map[string]map[string]string{
+		"none":     nil,
+		"one dim":  {"group1": "$.group1"},
+		"two dims": {"group1": "$.group1", "group2": "$.nested.group2"},
+	}
+
+	for _, aggregation := range aggregations {
+		for grainName, grain := range map[string]CacheGrain{"minute": CacheGrainMinute, "hour": CacheGrainHour, "day": CacheGrainDay} {
+			for shapeName, groupBy := range groupByShapes {
+				for _, withEventFrom := range []bool{false, true} {
+					name := fmt.Sprintf("%s/%s/%s/eventFrom=%t", aggregation, grainName, shapeName, withEventFrom)
+
+					t.Run(name, func(t *testing.T) {
+						m := meter.Meter{
+							Key:         "meter1",
+							EventType:   "event1",
+							Aggregation: aggregation,
+							GroupBy:     groupBy,
+						}
+						if aggregation != meter.MeterAggregationCount {
+							m.ValueProperty = lo.ToPtr("$.value")
+						}
+						if withEventFrom {
+							m.EventFrom = &eventFrom
+						}
+
+						mv := mvFixture(m, grain)
+
+						sql, err := mv.toSQL()
+						require.NoError(t, err)
+
+						// APPEND is mandatory on every emitted cache MV, no exceptions.
+						require.Contains(t, sql, " APPEND TO openmeter.om_meter_cache AS ")
+						require.True(t, strings.HasPrefix(sql, "CREATE MATERIALIZED VIEW IF NOT EXISTS openmeter.om_meter_cache_mv_"))
+
+						// Settled bound and the dirty union strip are always present.
+						require.Contains(t, sql, "toStartOfInterval(now() - INTERVAL 3600 SECOND, INTERVAL 1")
+						require.Contains(t, sql, "UNION DISTINCT")
+						require.Contains(t, sql, "stored_at >= now() - INTERVAL 5400 SECOND")
+
+						for _, alias := range wantCombineAliases[aggregation] {
+							require.Contains(t, sql, " AS "+alias)
+						}
+
+						if withEventFrom {
+							require.Contains(t, sql, fmt.Sprintf("om_events.time >= %d", eventFrom.Unix()))
+						} else {
+							require.NotContains(t, sql, "om_events.time >= ")
+						}
+
+						// The comment always carries parseable, unstamped metadata.
+						comment := sql[strings.LastIndex(sql, "COMMENT '")+len("COMMENT '"):]
+						comment = strings.TrimSuffix(comment, "'")
+						metadata, err := parseMeterCacheMVMetadata(comment)
+						require.NoError(t, err)
+						require.Equal(t, "meter1", metadata.MeterKey)
+						require.Equal(t, "event1", metadata.EventType)
+						require.Equal(t, formatCacheHash(meterHash(m, grain)), metadata.MeterHash)
+						require.Nil(t, metadata.BackfilledAt)
+					})
+				}
+			}
+		}
+	}
+}

--- a/openmeter/streaming/clickhouse/meter_cache_mv_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_mv_test.go
@@ -56,7 +56,7 @@ func TestCreateMeterCacheMVSQL(t *testing.T) {
 				"UNION DISTINCT "+
 				"SELECT subtractSeconds(toStartOfInterval(now() - INTERVAL 3600 SECOND, INTERVAL 1 HOUR, 'UTC'), (number + 1) * 3600) FROM numbers(1)) "+
 				"GROUP BY namespace, windowstart, subject, group_by "+
-				`COMMENT '{"meter_key":"meter1","event_type":"event1","meter_hash":"a71813334efc5e0b","ddl_hash":"49eab5c7b097a200"}'`,
+				`COMMENT '{"namespace":"my_namespace","meter_key":"meter1","event_type":"event1","meter_hash":"a71813334efc5e0b","ddl_hash":"49eab5c7b097a200"}'`,
 			sql,
 		)
 	})
@@ -93,7 +93,7 @@ func TestCreateMeterCacheMVSQL(t *testing.T) {
 				"UNION DISTINCT "+
 				"SELECT subtractSeconds(toStartOfInterval(now() - INTERVAL 3600 SECOND, INTERVAL 1 HOUR, 'UTC'), (number + 1) * 3600) FROM numbers(1)) "+
 				"GROUP BY namespace, windowstart, subject, group_by "+
-				`COMMENT '{"meter_key":"meter1","event_type":"event1","meter_hash":"249fdd0e66a5f244","ddl_hash":"6eca4aaec943452f"}'`,
+				`COMMENT '{"namespace":"my_namespace","meter_key":"meter1","event_type":"event1","meter_hash":"249fdd0e66a5f244","ddl_hash":"6eca4aaec943452f"}'`,
 			sql,
 		)
 	})

--- a/openmeter/streaming/clickhouse/meter_cache_observability.go
+++ b/openmeter/streaming/clickhouse/meter_cache_observability.go
@@ -1,0 +1,103 @@
+package clickhouse
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// meterCacheMetricPrefix namespaces every meter cache instrument so they group together in
+// any metrics backend regardless of what else the process emits.
+const meterCacheMetricPrefix = "streaming.meter_cache."
+
+// meterCacheObservability holds the OTel instruments the meter cache's cached read path,
+// invalidation pipeline, and lifecycle reconciler emit. It is always constructed — with a
+// nil Config.Meter/Config.Tracer the underlying instruments are no-ops — so callers never
+// need a nil check before recording: see newMeterCacheObservability.
+type meterCacheObservability struct {
+	tracer trace.Tracer
+
+	// queries counts every Cachable QueryMeter call that consulted the gate, tagged with
+	// the gate's decision (result=cached|live_fallback|live_reject) and, for rejections,
+	// the gate's reject reason. The pure live path for non-Cachable queries deliberately
+	// never touches this counter (see queryMeterCached): instrumenting it would add
+	// overhead to the byte-identical, unopted-in majority of traffic for a signal that
+	// only matters for opted-in queries.
+	queries metric.Int64Counter
+
+	// queryDurationMS measures only the cached arm's execution (cache leg SQL plus the
+	// outer merge across live pre/post legs); the plain live path is intentionally
+	// unmeasured for the same reason queries is.
+	queryDurationMS metric.Int64Histogram
+
+	// markerFailures is the silent-staleness alert signal (G11): a lost classify or
+	// insert failure is the only failure mode in the invalidation pipeline that can leave
+	// cached reads serving stale buckets indefinitely, so this is the counter operators
+	// must alert on, not merely observe.
+	markerFailures metric.Int64Counter
+
+	// refreshTriggers counts every best-effort SYSTEM REFRESH VIEW attempt the invalidator
+	// makes after writing invalidation markers, tagged with its outcome.
+	refreshTriggers metric.Int64Counter
+}
+
+// newMeterCacheObservability builds the instrument set from config.Meter and config.Tracer,
+// substituting no-op implementations when either is nil. Substituting here — rather than
+// nil-checking at every call site — keeps the cache's instrumentation calls unconditional:
+// a deployment that never wires telemetry pays the (negligible) cost of a no-op instrument
+// call instead of every recording site needing to guard against a nil dependency.
+func newMeterCacheObservability(config Config) (*meterCacheObservability, error) {
+	meter := config.Meter
+	if meter == nil {
+		meter = metricnoop.NewMeterProvider().Meter("noop")
+	}
+
+	tracer := config.Tracer
+	if tracer == nil {
+		tracer = noop.NewTracerProvider().Tracer("noop")
+	}
+
+	queries, err := meter.Int64Counter(
+		meterCacheMetricPrefix+"queries",
+		metric.WithDescription("Number of Cachable meter queries the cache gate decided on, by result"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metric: %squeries: %w", meterCacheMetricPrefix, err)
+	}
+
+	queryDurationMS, err := meter.Int64Histogram(
+		meterCacheMetricPrefix+"query_duration_ms",
+		metric.WithDescription("Duration of meter queries served from the cache, including the live leg merge"),
+		metric.WithUnit("ms"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metric: %squery_duration_ms: %w", meterCacheMetricPrefix, err)
+	}
+
+	markerFailures, err := meter.Int64Counter(
+		meterCacheMetricPrefix+"marker_failures",
+		metric.WithDescription("Number of invalidation marker classify/insert failures; any non-zero rate risks silently stale cached reads"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metric: %smarker_failures: %w", meterCacheMetricPrefix, err)
+	}
+
+	refreshTriggers, err := meter.Int64Counter(
+		meterCacheMetricPrefix+"refresh_triggers",
+		metric.WithDescription("Number of best-effort SYSTEM REFRESH VIEW triggers fired after late-event invalidation, by outcome"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metric: %srefresh_triggers: %w", meterCacheMetricPrefix, err)
+	}
+
+	return &meterCacheObservability{
+		tracer:          tracer,
+		queries:         queries,
+		queryDurationMS: queryDurationMS,
+		markerFailures:  markerFailures,
+		refreshTriggers: refreshTriggers,
+	}, nil
+}

--- a/openmeter/streaming/clickhouse/meter_cache_observability_ch_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_observability_ch_test.go
@@ -1,0 +1,181 @@
+package clickhouse
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/suite"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	progressmanageradapter "github.com/openmeterio/openmeter/openmeter/progressmanager/adapter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+)
+
+// MeterCacheObservabilityCHTestSuite embeds CHTestSuite directly rather than
+// MeterCacheCHTestSuite: stretchr/testify suite.Run executes every exported Test* method
+// reachable on the suite value, including ones promoted from an embedded suite type, so
+// embedding MeterCacheCHTestSuite here would re-run its entire test file set under this
+// suite's name too.
+type MeterCacheObservabilityCHTestSuite struct {
+	CHTestSuite
+}
+
+func TestMeterCacheObservabilityClickHouse(t *testing.T) {
+	suite.Run(t, new(MeterCacheObservabilityCHTestSuite))
+}
+
+// TestCachedQueryEmitsQueriesCounterAndDurationHistogram is the real-ClickHouse companion
+// to the mock-based unit tests: it drives one meter query all the way through a genuinely
+// deployed cache MV and proves the streaming.meter_cache.queries counter records
+// result=cached and the query_duration_ms histogram observes the cached arm — the mock-based
+// unit tests in meter_cache_observability_test.go only exercise the gate-reject path, which
+// never reaches the ClickHouse round trip this test covers.
+func (s *MeterCacheObservabilityCHTestSuite) TestCachedQueryEmitsQueriesCounterAndDurationHistogram() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		eventsTable = "om_events"
+		namespace   = "cache-observability"
+		eventType   = "api-calls"
+	)
+
+	telemetry, telemetryConfig := newTestTelemetry()
+
+	cache := CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	}
+
+	connector, err := New(ctx, Config{
+		Logger:                 slog.Default(),
+		ClickHouse:             s.ClickHouse,
+		Database:               s.Database,
+		EventsTableName:        eventsTable,
+		EnableDecimalPrecision: true,
+		ProgressManager:        progressmanageradapter.NewMockProgressManager(),
+		Cache:                  cache,
+		Meter:                  telemetryConfig.Meter,
+		Tracer:                 telemetryConfig.Tracer,
+	})
+	s.Require().NoError(err)
+
+	// Tests query immediately after an explicit refresh; the production view-state memo
+	// (G13) would serve a pre-refresh snapshot for up to its TTL, making this assertion
+	// time-dependent.
+	connector.cacheGate.viewStateTTL = 0
+
+	now := time.Now().UTC()
+	bucket := now.Add(-3 * time.Hour).Truncate(time.Hour)
+
+	newEvent := func(at time.Time, value int) streaming.RawEvent {
+		return streaming.RawEvent{
+			Namespace:  namespace,
+			ID:         ulid.Make().String(),
+			Type:       eventType,
+			Source:     "test-source",
+			Subject:    "subject-1",
+			Time:       at,
+			Data:       fmt.Sprintf(`{"value": %d}`, value),
+			IngestedAt: now,
+			StoredAt:   now,
+		}
+	}
+
+	insertSQL, insertArgs := InsertEventsQuery{
+		Database:        s.Database,
+		EventsTableName: eventsTable,
+		Events: []streaming.RawEvent{
+			newEvent(bucket.Add(5*time.Minute), 2),
+			newEvent(bucket.Add(10*time.Minute), 7),
+		},
+	}.ToSQL()
+	s.Require().NoError(s.ClickHouse.Exec(ctx, insertSQL, insertArgs...))
+
+	m := meter.Meter{
+		Key:           "observability-meter",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	s.deployMV(ctx, createMeterCacheMV{
+		Database:        s.Database,
+		EventsTableName: eventsTable,
+		Namespace:       namespace,
+		Meter:           m,
+		Grain:           cache.WindowSize,
+		RefreshInterval: cache.RefreshInterval,
+		MinimumUsageAge: cache.MinimumUsageAge,
+	})
+
+	values, err := connector.QueryMeter(ctx, namespace, m, streaming.QueryParams{
+		Cachable:   true,
+		From:       lo.ToPtr(bucket),
+		To:         lo.ToPtr(now),
+		WindowSize: lo.ToPtr(meter.WindowSizeHour),
+	})
+	s.Require().NoError(err)
+	s.Require().Len(values, 1)
+	s.Require().Equal(float64(9), values[0].Value)
+
+	metricData := collectMetric(t, telemetry.reader, "streaming.meter_cache.queries")
+	s.Require().EqualValues(1, sumAttrValue(t, metricData, map[string]string{"result": "cached", "reject_reason": ""}))
+
+	durationMetric := collectMetric(t, telemetry.reader, "streaming.meter_cache.query_duration_ms")
+	hist, ok := durationMetric.Data.(metricdata.Histogram[int64])
+	s.Require().True(ok, "query_duration_ms must be a histogram")
+	s.Require().Len(hist.DataPoints, 1)
+
+	arm, ok := hist.DataPoints[0].Attributes.Value(attribute.Key("arm"))
+	s.Require().True(ok)
+	s.Require().Equal("cached", arm.AsString())
+
+	spans := telemetry.recorder.Ended()
+	s.Require().Len(spans, 1)
+	s.Require().Equal("streaming.meter_cache.query", spans[0].Name())
+}
+
+// deployMV deploys one cache MV fully: create, wait for the initial refresh, backfill,
+// explicit refresh, wait, then stamp backfilled_at. This mirrors
+// MeterCacheCHTestSuite.deployMeterCacheMV; it is not shared because the two suites are
+// independent stretchr/testify suite types with no common base beyond CHTestSuite.
+func (s *MeterCacheObservabilityCHTestSuite) deployMV(ctx context.Context, mv createMeterCacheMV) {
+	createSQL, err := mv.toSQL()
+	s.Require().NoError(err)
+	s.Require().NoError(s.ClickHouse.Exec(ctx, createSQL))
+
+	qualifiedView := getTableName(s.Database, mv.name())
+	s.Require().NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+
+	backfillSQL, err := meterCacheBackfill{
+		Database:        mv.Database,
+		EventsTableName: mv.EventsTableName,
+		Namespace:       mv.Namespace,
+		Meter:           mv.Meter,
+		Grain:           mv.Grain,
+		MinimumUsageAge: mv.MinimumUsageAge,
+	}.toSQL()
+	s.Require().NoError(err)
+	s.Require().NoError(s.ClickHouse.Exec(ctx, backfillSQL))
+
+	s.Require().NoError(s.ClickHouse.Exec(ctx, "SYSTEM REFRESH VIEW "+qualifiedView))
+	s.Require().NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+
+	metadata, err := mv.metadata()
+	s.Require().NoError(err)
+	metadata.BackfilledAt = lo.ToPtr(time.Now().UTC().Truncate(time.Second))
+
+	comment, err := metadata.marshal()
+	s.Require().NoError(err)
+	s.Require().NoError(s.ClickHouse.Exec(ctx, fmt.Sprintf("ALTER TABLE %s MODIFY COMMENT %s", qualifiedView, sqlStringLiteral(comment))))
+}

--- a/openmeter/streaming/clickhouse/meter_cache_observability_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_observability_test.go
@@ -1,0 +1,259 @@
+package clickhouse
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	progressmanager "github.com/openmeterio/openmeter/openmeter/progressmanager/adapter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+)
+
+// testTelemetry bundles a ManualReader-backed MeterProvider and a SpanRecorder-backed
+// TracerProvider so tests can assert both that an instrument fired and its attributes,
+// and that the expected spans were recorded. See the R4 lesson referenced across the
+// meter cache observability code: a detached instrument silently looks like a healthy
+// quiet system, so tests must assert emission, not merely that construction succeeded.
+type testTelemetry struct {
+	reader   *sdkmetric.ManualReader
+	recorder *tracetest.SpanRecorder
+}
+
+func newTestTelemetry() (*testTelemetry, Config) {
+	reader := sdkmetric.NewManualReader()
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	recorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+
+	return &testTelemetry{reader: reader, recorder: recorder}, Config{
+		Meter:  meterProvider.Meter("test"),
+		Tracer: tracerProvider.Tracer("test"),
+	}
+}
+
+// collectMetric returns the collected data points for one instrument name, failing the
+// test if the instrument never recorded (the exact failure mode a detached instrument
+// produces: Collect succeeds, but the metric is simply absent).
+func collectMetric(t *testing.T, reader *sdkmetric.ManualReader, name string) metricdata.Metrics {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m
+			}
+		}
+	}
+
+	require.Failf(t, "metric not emitted", "expected metric %q to have been recorded", name)
+
+	return metricdata.Metrics{}
+}
+
+func newMeterCacheTestConfig(cache CacheConfig, telemetry Config) Config {
+	return Config{
+		Logger:           slog.Default(),
+		ClickHouse:       NewMockClickHouse(),
+		Database:         "testdb",
+		EventsTableName:  "events",
+		ProgressManager:  progressmanager.NewMockProgressManager(),
+		SkipCreateTables: true,
+		Cache:            cache,
+		Meter:            telemetry.Meter,
+		Tracer:           telemetry.Tracer,
+	}
+}
+
+// TestQueryMeterCached_EmitsLiveRejectMetricsAndSpan proves a gate-rejected Cachable query
+// records the queries counter with result=live_reject and the reject reason, and starts the
+// streaming.meter_cache.query span — the health signal operators dashboard for "why isn't
+// this meter using the cache".
+func TestQueryMeterCached_EmitsLiveRejectMetricsAndSpan(t *testing.T) {
+	telemetry, telemetryConfig := newTestTelemetry()
+
+	cache := CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	}
+
+	connector, err := New(t.Context(), newMeterCacheTestConfig(cache, telemetryConfig))
+	require.NoError(t, err)
+
+	query := queryMeter{
+		Database:        "testdb",
+		EventsTableName: "events",
+		Namespace:       "ns1",
+		Meter: meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationLatest, // LATEST is always a static reject
+			ValueProperty: lo.ToPtr("$.value"),
+		},
+		To: lo.ToPtr(time.Now()),
+	}
+
+	values, served := connector.queryMeterCached(t.Context(), query, streaming.QueryParams{Cachable: true, To: query.To})
+	require.False(t, served)
+	require.Nil(t, values)
+
+	m := collectMetric(t, telemetry.reader, "streaming.meter_cache.queries")
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok, "queries must be a counter")
+	require.Len(t, sum.DataPoints, 1)
+
+	dp := sum.DataPoints[0]
+	result, ok := dp.Attributes.Value(attribute.Key("result"))
+	require.True(t, ok)
+	require.Equal(t, "live_reject", result.AsString())
+
+	reason, ok := dp.Attributes.Value(attribute.Key("reject_reason"))
+	require.True(t, ok)
+	require.Equal(t, string(cacheRejectReasonLatestAggregation), reason.AsString())
+
+	spans := telemetry.recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "streaming.meter_cache.query", spans[0].Name())
+}
+
+// TestQueryMeterCached_EmitsLiveFallbackMetricsAndSpanError proves an infrastructure
+// failure in the gate's dynamic checks (the view-state lookup) — as opposed to a static
+// reject — records the queries counter with result=live_fallback, and the
+// streaming.meter_cache.query span records the error, sets its status to codes.Error, and
+// carries both live_fallback=true and result=live_fallback (the same result attribute the
+// cached and live_reject exits set, so span filtering can rely on it being present on every
+// exit path). This is the cache-degradation signal: if it silently detached, an operator's
+// dashboard would look like a healthy, quiet system while every opted-in query is actually
+// falling back to the live path.
+func TestQueryMeterCached_EmitsLiveFallbackMetricsAndSpanError(t *testing.T) {
+	telemetry, telemetryConfig := newTestTelemetry()
+
+	cache := CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	}
+
+	config := newMeterCacheTestConfig(cache, telemetryConfig)
+	// The static reject checks require decimal precision to be enabled (see
+	// meterCacheStaticReject); this test exercises the dynamic (ClickHouse-backed) checks,
+	// so the query must clear every static check first.
+	config.EnableDecimalPrecision = true
+
+	connector, err := New(t.Context(), config)
+	require.NoError(t, err)
+
+	// Forces the gate past the static reject checks into the dynamic (ClickHouse-backed)
+	// checks, then fails there — the infrastructure-failure branch of cacheEligibility,
+	// distinct from a static reject reason.
+	connector.cacheGate.fetchViewState = func(context.Context, string) (meterCacheViewState, error) {
+		return meterCacheViewState{}, errors.New("view state lookup failed")
+	}
+
+	query := queryMeter{
+		Database:        "testdb",
+		EventsTableName: "events",
+		Namespace:       "ns1",
+		Meter: meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationSum,
+			ValueProperty: lo.ToPtr("$.value"),
+		},
+		From:       lo.ToPtr(time.Now().Add(-time.Hour)),
+		To:         lo.ToPtr(time.Now()),
+		WindowSize: lo.ToPtr(meter.WindowSizeHour),
+	}
+
+	values, served := connector.queryMeterCached(t.Context(), query, streaming.QueryParams{
+		Cachable:   true,
+		From:       query.From,
+		To:         query.To,
+		WindowSize: query.WindowSize,
+	})
+	require.False(t, served)
+	require.Nil(t, values)
+
+	m := collectMetric(t, telemetry.reader, "streaming.meter_cache.queries")
+	require.EqualValues(t, 1, sumAttrValue(t, m, map[string]string{"result": "live_fallback", "reject_reason": ""}))
+
+	spans := telemetry.recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "streaming.meter_cache.query", spans[0].Name())
+	require.NotEmpty(t, spans[0].Events(), "span must record the eligibility check error")
+	require.Equal(t, codes.Error, spans[0].Status().Code, "span status must be set on an error exit for status-based error dashboards")
+
+	var sawLiveFallback, sawResultAttr bool
+	for _, attr := range spans[0].Attributes() {
+		if attr.Key == "live_fallback" && attr.Value.AsBool() {
+			sawLiveFallback = true
+		}
+
+		if attr.Key == "result" && attr.Value.AsString() == string(meterCacheQueryResultLiveFallback) {
+			sawResultAttr = true
+		}
+	}
+	require.True(t, sawLiveFallback, "span must carry live_fallback=true")
+	require.True(t, sawResultAttr, "span must carry result=live_fallback so every exit path shares the same result attribute")
+}
+
+// TestNewMeterCacheObservability_NilDependenciesDoNotPanic proves the connector is
+// constructible, and its instrumented paths runnable, with nil Config.Meter and
+// Config.Tracer — the deployment shape where telemetry was never wired.
+func TestNewMeterCacheObservability_NilDependenciesDoNotPanic(t *testing.T) {
+	cache := CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	}
+
+	connector, err := New(t.Context(), Config{
+		Logger:           slog.Default(),
+		ClickHouse:       NewMockClickHouse(),
+		Database:         "testdb",
+		EventsTableName:  "events",
+		ProgressManager:  progressmanager.NewMockProgressManager(),
+		SkipCreateTables: true,
+		Cache:            cache,
+		// Meter and Tracer deliberately left nil.
+	})
+	require.NoError(t, err)
+	require.NotNil(t, connector.observability)
+
+	query := queryMeter{
+		Database:        "testdb",
+		EventsTableName: "events",
+		Namespace:       "ns1",
+		Meter: meter.Meter{
+			Key:           "meter1",
+			EventType:     "event1",
+			Aggregation:   meter.MeterAggregationLatest,
+			ValueProperty: lo.ToPtr("$.value"),
+		},
+		To: lo.ToPtr(time.Now()),
+	}
+
+	require.NotPanics(t, func() {
+		_, served := connector.queryMeterCached(t.Context(), query, streaming.QueryParams{Cachable: true, To: query.To})
+		require.False(t, served)
+	})
+}

--- a/openmeter/streaming/clickhouse/meter_cache_read.go
+++ b/openmeter/streaming/clickhouse/meter_cache_read.go
@@ -99,10 +99,8 @@ func meterCacheBounds(from *time.Time, to time.Time, refreshStart time.Time, min
 // fail with an aggregate-inside-aggregate error (hit live with AVG's two picks). The
 // picked_* names are in reservedMeterSQLAliases so group-by keys cannot shadow them.
 //
-// Note the two distinct argMax semantics around LATEST (G14): the pick below is the
-// newest-wins re-read by created_at and must not skip anything, while the latest_state
-// column it picks internally carries live argMax(value, time) semantics, which does skip
-// NULL values to match the live query.
+// LATEST has no case here: it is excluded from the cache entirely (see
+// meterCacheStaticReject), so this function is never called for it.
 func meterCacheNewestWinsExprs(aggregation meterpkg.MeterAggregation) ([]string, error) {
 	switch aggregation {
 	case meterpkg.MeterAggregationSum:
@@ -120,8 +118,6 @@ func meterCacheNewestWinsExprs(aggregation meterpkg.MeterAggregation) ([]string,
 		return []string{"tupleElement(argMax(tuple(count_value), created_at), 1) AS picked_count_value"}, nil
 	case meterpkg.MeterAggregationUniqueCount:
 		return []string{"tupleElement(argMax(tuple(uniq_state), created_at), 1) AS picked_uniq_state"}, nil
-	case meterpkg.MeterAggregationLatest:
-		return []string{"tupleElement(argMax(tuple(latest_state), created_at), 1) AS picked_latest_state"}, nil
 	default:
 		return nil, models.NewGenericValidationError(
 			fmt.Errorf("invalid aggregation type: %s", aggregation),
@@ -137,8 +133,10 @@ func meterCacheNewestWinsExprs(aggregation meterpkg.MeterAggregation) ([]string,
 //     is converted to Float64 before the division because that is precisely how ClickHouse
 //     computes avg() over Decimal inputs, keeping the result bit-identical to live,
 //   - UNIQUE_COUNT merges the uniqExact states — distinct counts of two legs can never be
-//     summed, shared values would double count,
-//   - LATEST merges argMax states, picking the newest event's value across all legs.
+//     summed, shared values would double count.
+//
+// LATEST has no case here: it is excluded from the cache entirely (see
+// meterCacheStaticReject), so this function is never called for it.
 //
 // NULL propagation is load-bearing for row-emission parity: sum/min/max/avg over
 // all-NULL inputs yield NULL and scanRows drops the row exactly like the live query,
@@ -160,8 +158,6 @@ func meterCacheCombinedValueExpr(aggregation meterpkg.MeterAggregation) (string,
 		return "sum(picked_count_value) AS value", nil
 	case meterpkg.MeterAggregationUniqueCount:
 		return "uniqExactMerge(picked_uniq_state) AS value", nil
-	case meterpkg.MeterAggregationLatest:
-		return "argMaxMerge(picked_latest_state) AS value", nil
 	default:
 		return "", models.NewGenericValidationError(
 			fmt.Errorf("invalid aggregation type: %s", aggregation),

--- a/openmeter/streaming/clickhouse/meter_cache_read.go
+++ b/openmeter/streaming/clickhouse/meter_cache_read.go
@@ -10,6 +10,10 @@ import (
 	"time"
 
 	"github.com/huandu/go-sqlbuilder"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	meterpkg "github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/streaming"
@@ -519,22 +523,57 @@ func (q meterCacheMarkerOverlapQuery) toSQL() (string, []interface{}) {
 	return sb.Build()
 }
 
+// meterCacheQueryResult is the streaming.meter_cache.queries counter's result attribute:
+// the outcome of one gate consultation for a Cachable QueryMeter call.
+type meterCacheQueryResult string
+
+const (
+	meterCacheQueryResultCached       meterCacheQueryResult = "cached"
+	meterCacheQueryResultLiveFallback meterCacheQueryResult = "live_fallback"
+	meterCacheQueryResultLiveReject   meterCacheQueryResult = "live_reject"
+)
+
 // queryMeterCached attempts to serve the meter query from the cache. served is false —
 // and no error is ever returned — whenever the query must run on the live path instead:
 // gate rejections are expected steady-state behavior, and infrastructure failures on the
 // cache path must degrade to a slower correct answer, never to a failed query.
+//
+// Every call records exactly one streaming.meter_cache.queries observation: this is the
+// cache health counter operators dashboard, so a query that reaches this function must
+// contribute one and only one result, whichever path it takes out.
 func (c *Connector) queryMeterCached(ctx context.Context, query queryMeter, params streaming.QueryParams) ([]meterpkg.MeterQueryRow, bool) {
+	ctx, span := c.observability.tracer.Start(ctx, "streaming.meter_cache.query", trace.WithAttributes(
+		attribute.String("namespace", query.Namespace),
+		attribute.String("meter", query.Meter.Key),
+	))
+	defer span.End()
+
 	bounds, reason, err := c.cacheGate.cacheEligibility(ctx, query, params)
 	if err != nil {
 		c.config.Logger.Warn("meter cache: eligibility check failed, serving live", "meter", query.Meter.Key, "error", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "eligibility check failed")
+		span.SetAttributes(attribute.String("result", string(meterCacheQueryResultLiveFallback)), attribute.Bool("live_fallback", true))
+		c.recordCacheQuery(ctx, meterCacheQueryResultLiveFallback, cacheRejectReasonNone)
 
 		return nil, false
 	}
 
 	if reason != cacheRejectReasonNone {
 		c.config.Logger.Debug("meter cache: serving live", "meter", query.Meter.Key, "reason", string(reason))
+		span.SetAttributes(attribute.String("result", string(meterCacheQueryResultLiveReject)), attribute.String("reject_reason", string(reason)))
+		c.recordCacheQuery(ctx, meterCacheQueryResultLiveReject, reason)
 
 		return nil, false
+	}
+
+	span.SetAttributes(
+		attribute.Int64("cache_hi", bounds.CacheHi.Unix()),
+		attribute.Bool("cache_lo_bounded", bounds.CacheLo != nil),
+	)
+
+	if bounds.CacheLo != nil {
+		span.SetAttributes(attribute.Int64("cache_lo", bounds.CacheLo.Unix()))
 	}
 
 	readQuery := meterCacheReadQuery{
@@ -547,6 +586,10 @@ func (c *Connector) queryMeterCached(ctx context.Context, query queryMeter, para
 	sql, args, err := readQuery.toSQL()
 	if err != nil {
 		c.config.Logger.Warn("meter cache: building cached query failed, serving live", "meter", query.Meter.Key, "error", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "building cached query failed")
+		span.SetAttributes(attribute.String("result", string(meterCacheQueryResultLiveFallback)), attribute.Bool("live_fallback", true))
+		c.recordCacheQuery(ctx, meterCacheQueryResultLiveFallback, cacheRejectReasonNone)
 
 		return nil, false
 	}
@@ -556,6 +599,10 @@ func (c *Connector) queryMeterCached(ctx context.Context, query queryMeter, para
 	rows, err := c.config.ClickHouse.Query(ctx, sql, args...)
 	if err != nil {
 		c.config.Logger.Warn("meter cache: cached query failed, serving live", "meter", query.Meter.Key, "error", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "cached query failed")
+		span.SetAttributes(attribute.String("result", string(meterCacheQueryResultLiveFallback)), attribute.Bool("live_fallback", true))
+		c.recordCacheQuery(ctx, meterCacheQueryResultLiveFallback, cacheRejectReasonNone)
 
 		return nil, false
 	}
@@ -567,9 +614,27 @@ func (c *Connector) queryMeterCached(ctx context.Context, query queryMeter, para
 	values, err := query.scanRows(rows)
 	if err != nil {
 		c.config.Logger.Warn("meter cache: scanning cached query rows failed, serving live", "meter", query.Meter.Key, "error", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "scanning cached query rows failed")
+		span.SetAttributes(attribute.String("result", string(meterCacheQueryResultLiveFallback)), attribute.Bool("live_fallback", true))
+		c.recordCacheQuery(ctx, meterCacheQueryResultLiveFallback, cacheRejectReasonNone)
 
 		return nil, false
 	}
 
+	c.observability.queryDurationMS.Record(ctx, time.Since(start).Milliseconds(), metric.WithAttributes(attribute.String("arm", "cached")))
+	span.SetAttributes(attribute.String("result", string(meterCacheQueryResultCached)))
+	c.recordCacheQuery(ctx, meterCacheQueryResultCached, cacheRejectReasonNone)
+
 	return values, true
+}
+
+// recordCacheQuery emits the streaming.meter_cache.queries counter. reason is only attached
+// for live_reject results; other results carry an empty reject_reason so every observation
+// has a stable attribute set.
+func (c *Connector) recordCacheQuery(ctx context.Context, result meterCacheQueryResult, reason cacheRejectReason) {
+	c.observability.queries.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("result", string(result)),
+		attribute.String("reject_reason", string(reason)),
+	))
 }

--- a/openmeter/streaming/clickhouse/meter_cache_read.go
+++ b/openmeter/streaming/clickhouse/meter_cache_read.go
@@ -468,15 +468,25 @@ func (d meterCacheReadQuery) applyGroupByFilters(sb *sqlbuilder.SelectBuilder, c
 }
 
 // meterCacheMarkerOverlapQuery counts the late-event invalidation markers that overlap
-// the cache leg's bucket range and are not healed by the serving view's last refresh.
-// Any non-zero count sends the whole query live: an unhealed marker means a settled
-// bucket in range received events the cache has not provably recomputed yet.
+// the cache leg's bucket range and are healed by neither the serving view's backfill nor
+// its last refresh. Any non-zero count sends the whole query live: an unhealed marker
+// means a settled bucket in range received events the cache has not provably recomputed
+// yet.
 //
-// The heal rule (G1) compares two ClickHouse-sourced timestamps — marker created_at
-// (server-side DEFAULT) and refreshStart (derived from system.view_refreshes) — so app
-// clock skew can never mark a stale bucket healed. A marker is healed iff
-// refreshStart > created_at AND refreshStart − created_at < HealBound; the query counts
-// the complement.
+// The heal rules compare ClickHouse-sourced timestamps — marker created_at (server-side
+// DEFAULT), refreshStart (derived from system.view_refreshes), and BackfilledAt (read
+// from the ClickHouse clock when the backfill started) — so app clock skew can never mark
+// a stale bucket healed. A marker is healed iff
+//
+//   - created_at < BackfilledAt: the view's full-history (re-)backfill started after the
+//     marker was written, so it re-aggregated every settled bucket including the marker's
+//     late events (this is what lets a reconciler repair converge reads instead of
+//     forcing the marked range live until the marker's TTL), or
+//   - refreshStart > created_at AND refreshStart − created_at < HealBound (G1): a refresh
+//     started after the marker, recently enough that its stored_at lookback provably
+//     covered the late events.
+//
+// The query counts the complement.
 type meterCacheMarkerOverlapQuery struct {
 	Database  string
 	Namespace string
@@ -487,6 +497,7 @@ type meterCacheMarkerOverlapQuery struct {
 
 	RefreshStart time.Time
 	HealBound    time.Duration
+	BackfilledAt time.Time
 }
 
 func (q meterCacheMarkerOverlapQuery) toSQL() (string, []interface{}) {
@@ -503,6 +514,7 @@ func (q meterCacheMarkerOverlapQuery) toSQL() (string, []interface{}) {
 		sb.Where(sb.GreaterThan("window_hi", q.CacheLo.Unix()))
 	}
 
+	sb.Where(sb.GreaterEqualThan("created_at", q.BackfilledAt))
 	sb.Where(sb.Or(
 		sb.GreaterEqualThan("created_at", q.RefreshStart),
 		sb.LessEqualThan("created_at", q.RefreshStart.Add(-q.HealBound)),

--- a/openmeter/streaming/clickhouse/meter_cache_read.go
+++ b/openmeter/streaming/clickhouse/meter_cache_read.go
@@ -1,0 +1,567 @@
+package clickhouse
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/huandu/go-sqlbuilder"
+
+	meterpkg "github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// meterCacheBucketAlias is the column name under which every leg subquery of the cached
+// read emits its grain-aligned UTC bucket start. It is deliberately distinct from
+// windowstart: the outer query re-windows buckets into the query's window size and
+// timezone under the windowstart alias, and ClickHouse resolving that alias against a
+// same-named source column would be ambiguous. The name is in reservedMeterSQLAliases so
+// meter group-by keys can never shadow it.
+const meterCacheBucketAlias = "windowstart_bucket"
+
+// meterCacheLegBounds is the half-open bucket range [CacheLo, CacheHi) the cache leg of a
+// query serves; everything outside it is served by live legs over raw events.
+type meterCacheLegBounds struct {
+	// CacheLo is the first cached bucket; nil means unbounded below (the query has no
+	// lower bound and neither does the meter, so the backfilled cache covers all history).
+	CacheLo *time.Time
+	CacheHi time.Time
+}
+
+// meterCacheBounds computes the cache leg bounds for a query over [from, to) given the
+// serving view's last refresh start. from is the query's effective lower bound (already
+// merged with the meter's EventFrom, see queryMeter.from); nil means unbounded history.
+//
+//	cacheLo = ceil(from, grain)
+//	cacheHi = floor(min(to, refreshStart − minimumUsageAge), grain) − one grain
+//
+// The trailing one-grain subtraction is the G5 epsilon: refreshStart is reconstructed
+// from second-resolution last_success_time minus a millisecond duration, so it can
+// overestimate the instant at which the refresh evaluated its settled bound; backing off
+// one whole grain guarantees the reader never serves a bucket the refresh had not
+// computed yet. The epsilon is applied unconditionally (even when to is far in the past
+// and the min is not the horizon) to keep the tiling arithmetic uniform.
+//
+// ok is false when the range contains no whole cached bucket; the caller must then run
+// the entire query live.
+func meterCacheBounds(from *time.Time, to time.Time, refreshStart time.Time, minimumUsageAge time.Duration, grain CacheGrain) (meterCacheLegBounds, bool, error) {
+	spec, err := grainSpecFor(grain)
+	if err != nil {
+		return meterCacheLegBounds{}, false, err
+	}
+
+	grainDuration := time.Duration(spec.seconds) * time.Second
+
+	hi := to
+	if horizon := refreshStart.Add(-minimumUsageAge); horizon.Before(hi) {
+		hi = horizon
+	}
+
+	cacheHi := hi.Truncate(grainDuration).Add(-grainDuration)
+
+	bounds := meterCacheLegBounds{CacheHi: cacheHi.UTC()}
+
+	if from == nil {
+		return bounds, true, nil
+	}
+
+	cacheLo := from.Truncate(grainDuration)
+	if cacheLo.Before(*from) {
+		cacheLo = cacheLo.Add(grainDuration)
+	}
+
+	cacheLo = cacheLo.UTC()
+	bounds.CacheLo = &cacheLo
+
+	return bounds, bounds.CacheHi.After(cacheLo), nil
+}
+
+// meterCacheNewestWinsExprs returns the cache leg SELECT expressions picking the newest
+// version of each combine column per stored bucket. om_meter_cache is a
+// ReplacingMergeTree: refreshes and backfills re-append full bucket recomputations, so
+// the reader must pick the row with the greatest created_at per key instead of trusting
+// background merges.
+//
+// Every pick is argMax over a single tuple of all the aggregation's columns:
+//   - the tuple wrap makes argMax keep NULL values (bare argMax skips NULL arguments, so
+//     a newer recompute that turned sum_value NULL would lose to an older non-NULL row),
+//   - one shared tuple per aggregation makes multi-column picks (AVG's sum + count)
+//     always come from the same row version, never mixing versions on created_at ties.
+//
+// The picks are aliased picked_<column>, never the source column name: ClickHouse
+// substitutes SELECT-list aliases into sibling expressions, so aliasing a pick AS
+// sum_value would turn a sibling's sum_value argument into the pick expression itself and
+// fail with an aggregate-inside-aggregate error (hit live with AVG's two picks). The
+// picked_* names are in reservedMeterSQLAliases so group-by keys cannot shadow them.
+//
+// Note the two distinct argMax semantics around LATEST (G14): the pick below is the
+// newest-wins re-read by created_at and must not skip anything, while the latest_state
+// column it picks internally carries live argMax(value, time) semantics, which does skip
+// NULL values to match the live query.
+func meterCacheNewestWinsExprs(aggregation meterpkg.MeterAggregation) ([]string, error) {
+	switch aggregation {
+	case meterpkg.MeterAggregationSum:
+		return []string{"tupleElement(argMax(tuple(sum_value), created_at), 1) AS picked_sum_value"}, nil
+	case meterpkg.MeterAggregationAvg:
+		return []string{
+			"tupleElement(argMax(tuple(sum_value, value_count), created_at), 1) AS picked_sum_value",
+			"tupleElement(argMax(tuple(sum_value, value_count), created_at), 2) AS picked_value_count",
+		}, nil
+	case meterpkg.MeterAggregationMin:
+		return []string{"tupleElement(argMax(tuple(min_value), created_at), 1) AS picked_min_value"}, nil
+	case meterpkg.MeterAggregationMax:
+		return []string{"tupleElement(argMax(tuple(max_value), created_at), 1) AS picked_max_value"}, nil
+	case meterpkg.MeterAggregationCount:
+		return []string{"tupleElement(argMax(tuple(count_value), created_at), 1) AS picked_count_value"}, nil
+	case meterpkg.MeterAggregationUniqueCount:
+		return []string{"tupleElement(argMax(tuple(uniq_state), created_at), 1) AS picked_uniq_state"}, nil
+	case meterpkg.MeterAggregationLatest:
+		return []string{"tupleElement(argMax(tuple(latest_state), created_at), 1) AS picked_latest_state"}, nil
+	default:
+		return nil, models.NewGenericValidationError(
+			fmt.Errorf("invalid aggregation type: %s", aggregation),
+		)
+	}
+}
+
+// meterCacheCombinedValueExpr returns the outer SELECT expression combining the legs'
+// combine columns into the final value, matching the live query's result exactly:
+//
+//   - SUM/MIN/MAX/COUNT re-aggregate with themselves across legs and buckets,
+//   - AVG divides the summed numerators by the summed non-null value counts; the numerator
+//     is converted to Float64 before the division because that is precisely how ClickHouse
+//     computes avg() over Decimal inputs, keeping the result bit-identical to live,
+//   - UNIQUE_COUNT merges the uniqExact states — distinct counts of two legs can never be
+//     summed, shared values would double count,
+//   - LATEST merges argMax states, picking the newest event's value across all legs.
+//
+// NULL propagation is load-bearing for row-emission parity: sum/min/max/avg over
+// all-NULL inputs yield NULL and scanRows drops the row exactly like the live query,
+// while uniqExactMerge and sum(count_value) yield 0 and the row is emitted with 0, again
+// like live.
+// The combiners reference the picked_* column names because UNION ALL takes its column
+// names from the first (cache) leg; live legs align positionally.
+func meterCacheCombinedValueExpr(aggregation meterpkg.MeterAggregation) (string, error) {
+	switch aggregation {
+	case meterpkg.MeterAggregationSum:
+		return "sum(picked_sum_value) AS value", nil
+	case meterpkg.MeterAggregationAvg:
+		return "toFloat64(sum(picked_sum_value)) / sum(picked_value_count) AS value", nil
+	case meterpkg.MeterAggregationMin:
+		return "min(picked_min_value) AS value", nil
+	case meterpkg.MeterAggregationMax:
+		return "max(picked_max_value) AS value", nil
+	case meterpkg.MeterAggregationCount:
+		return "sum(picked_count_value) AS value", nil
+	case meterpkg.MeterAggregationUniqueCount:
+		return "uniqExactMerge(picked_uniq_state) AS value", nil
+	case meterpkg.MeterAggregationLatest:
+		return "argMaxMerge(picked_latest_state) AS value", nil
+	default:
+		return "", models.NewGenericValidationError(
+			fmt.Errorf("invalid aggregation type: %s", aggregation),
+		)
+	}
+}
+
+// meterCacheReadQuery assembles the cached meter query: up to three legs tiling
+// [from, to) exactly — a live leg over raw events for [from, cacheLo), the cache leg for
+// [cacheLo, cacheHi), and a live leg for [cacheHi, to) — UNION ALL'd in combine form and
+// re-aggregated by an outer query into the exact column layout the live meter query
+// produces (windowstart, windowend, value, group-by dimensions), so queryMeter.scanRows
+// consumes both paths' results identically.
+type meterCacheReadQuery struct {
+	queryMeter
+
+	Grain   CacheGrain
+	CacheLo *time.Time
+	CacheHi time.Time
+}
+
+func (d meterCacheReadQuery) toSQL() (string, []interface{}, error) {
+	if d.To == nil {
+		return "", nil, fmt.Errorf("meter cache read requires an upper bound")
+	}
+
+	if d.WindowSize == nil && d.From == nil {
+		return "", nil, fmt.Errorf("meter cache read requires a lower bound for total queries")
+	}
+
+	spec, err := grainSpecFor(d.Grain)
+	if err != nil {
+		return "", nil, err
+	}
+
+	cacheLeg, err := d.cacheLeg()
+	if err != nil {
+		return "", nil, err
+	}
+
+	legs := []sqlbuilder.Builder{cacheLeg}
+
+	// The pre leg only exists when the query's effective lower bound lies strictly below
+	// the first cached bucket; a grain-aligned bound makes the cache leg start exactly
+	// there. An unbounded query (CacheLo nil) has no pre leg by construction.
+	effectiveFrom := d.from()
+	if effectiveFrom != nil && d.CacheLo != nil && effectiveFrom.Before(*d.CacheLo) {
+		preLeg, err := d.liveLeg(spec, *effectiveFrom, *d.CacheLo)
+		if err != nil {
+			return "", nil, err
+		}
+
+		legs = append(legs, preLeg)
+	}
+
+	// The post leg always exists: cacheHi is strictly below to by construction (G5
+	// epsilon), so the freshest tail is always served live.
+	postLeg, err := d.liveLeg(spec, d.CacheHi, *d.To)
+	if err != nil {
+		return "", nil, err
+	}
+
+	legs = append(legs, postLeg)
+
+	valueExpr, err := meterCacheCombinedValueExpr(d.Meter.Aggregation)
+	if err != nil {
+		return "", nil, err
+	}
+
+	outer := sqlbuilder.ClickHouse.NewSelectBuilder()
+
+	tz := "UTC"
+	if d.WindowTimeZone != nil {
+		tz = d.WindowTimeZone.String()
+	}
+
+	var selectColumns, groupByColumns []string
+
+	if d.WindowSize != nil {
+		windowColumns, err := windowExprs(*d.WindowSize, meterCacheBucketAlias, tz)
+		if err != nil {
+			return "", nil, err
+		}
+
+		selectColumns = append(selectColumns, windowColumns...)
+		groupByColumns = append(groupByColumns, "windowstart", "windowend")
+	} else {
+		// Total queries: the live path derives these bounds from min/max event times, but
+		// every consumer sees them overwritten with the requested period by
+		// Connector.QueryMeter (the gate requires From and To for totals), so constants
+		// carrying the right type are sufficient here.
+		selectColumns = append(selectColumns,
+			fmt.Sprintf("toDateTime(%d) AS windowstart", d.From.Unix()),
+			fmt.Sprintf("toDateTime(%d) AS windowend", d.To.Unix()),
+		)
+	}
+
+	selectColumns = append(selectColumns, valueExpr)
+
+	for _, key := range d.GroupBy {
+		if key == "subject" {
+			selectColumns = append(selectColumns, "subject")
+			groupByColumns = append(groupByColumns, "subject")
+
+			continue
+		}
+
+		column := sqlbuilder.Escape(key)
+		selectColumns = append(selectColumns, column)
+		groupByColumns = append(groupByColumns, column)
+	}
+
+	outer.Select(selectColumns...)
+	outer.From(outer.BuilderAs(sqlbuilder.UnionAll(legs...), "legs"))
+
+	if len(groupByColumns) > 0 {
+		outer.GroupBy(groupByColumns...)
+	}
+
+	if d.WindowSize != nil {
+		outer.OrderBy("windowstart")
+	}
+
+	sql, args := outer.Build()
+
+	if len(d.QuerySettings) > 0 {
+		settings := make([]string, 0, len(d.QuerySettings))
+		for _, key := range slices.Sorted(maps.Keys(d.QuerySettings)) {
+			settings = append(settings, fmt.Sprintf("%s = %s", key, d.QuerySettings[key]))
+		}
+
+		sql += fmt.Sprintf(" SETTINGS %s", strings.Join(settings, ", "))
+	}
+
+	return sql, args, nil
+}
+
+// cacheLeg builds the leg reading [CacheLo, CacheHi) from om_meter_cache. It groups by
+// the full stored row key (bucket, subject, full group_by array) so newest-wins picks one
+// version per stored row; collapsing to the query's dimensionality happens in the outer
+// query together with the cross-leg combine.
+func (d meterCacheReadQuery) cacheLeg() (*sqlbuilder.SelectBuilder, error) {
+	sb := sqlbuilder.ClickHouse.NewSelectBuilder()
+
+	selectColumns := []string{fmt.Sprintf("windowstart AS %s", meterCacheBucketAlias)}
+
+	meterGroupByKeys := slices.Sorted(maps.Keys(d.Meter.GroupBy))
+
+	groupByArrayIndex := func(key string) (int, error) {
+		// group_by array elements are stored in sorted meter group-by key order (see
+		// meterCacheSelectSQL), which makes this positional decoding unambiguous.
+		idx := slices.Index(meterGroupByKeys, key)
+		if idx < 0 {
+			return 0, fmt.Errorf("query group by %s is not a meter group by", key)
+		}
+
+		return idx + 1, nil
+	}
+
+	for _, key := range d.GroupBy {
+		if key == "subject" {
+			selectColumns = append(selectColumns, "subject")
+
+			continue
+		}
+
+		idx, err := groupByArrayIndex(key)
+		if err != nil {
+			return nil, err
+		}
+
+		selectColumns = append(selectColumns, fmt.Sprintf("group_by[%d] AS %s", idx, sqlbuilder.Escape(key)))
+	}
+
+	pickExprs, err := meterCacheNewestWinsExprs(d.Meter.Aggregation)
+	if err != nil {
+		return nil, err
+	}
+
+	selectColumns = append(selectColumns, pickExprs...)
+
+	sb.Select(selectColumns...)
+	sb.From(getTableName(d.Database, meterCacheTableName))
+
+	sb.Where(sb.Equal("namespace", d.Namespace))
+	// meter_key on top of meter_hash: meters with identical shape share a hash, and rows
+	// of a same-shape sibling meter must never be co-read.
+	sb.Where(sb.Equal("meter_key", d.Meter.Key))
+	sb.Where(sb.Equal("meter_hash", meterHash(d.Meter, d.Grain)))
+
+	if d.CacheLo != nil {
+		sb.Where(sb.GreaterEqualThan("windowstart", d.CacheLo.Unix()))
+	}
+
+	sb.Where(sb.LessThan("windowstart", d.CacheHi.Unix()))
+
+	if len(d.FilterSubject) > 0 {
+		sb.Where(sb.In("subject", d.FilterSubject))
+	}
+
+	err = d.applyGroupByFilters(sb, func(key string) (string, error) {
+		idx, err := groupByArrayIndex(key)
+		if err != nil {
+			return "", err
+		}
+
+		return fmt.Sprintf("group_by[%d]", idx), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sb.GroupBy("windowstart", "subject", "group_by")
+
+	return sb, nil
+}
+
+// liveLeg builds a leg aggregating raw events of [from, to) into grain buckets in combine
+// form, using the exact value/group-by expressions the live query uses so leg rows are
+// interchangeable with cache rows.
+func (d meterCacheReadQuery) liveLeg(spec grainSpec, from, to time.Time) (*sqlbuilder.SelectBuilder, error) {
+	sb := sqlbuilder.ClickHouse.NewSelectBuilder()
+
+	getColumn := columnFactory(d.EventsTableName)
+	timeColumn := getColumn("time")
+	dataColumn := getColumn("data")
+
+	// Buckets are aligned to UTC like the cache rows; the outer query re-windows both
+	// into the query's timezone.
+	selectColumns := []string{
+		fmt.Sprintf("tumbleStart(%s, %s, 'UTC') AS %s", timeColumn, spec.tumbleInterval, meterCacheBucketAlias),
+	}
+
+	groupBySelectColumns, groupByGroupByColumns := groupBySelectExprs(d.GroupBy, d.Meter.GroupBy, getColumn("subject"), dataColumn)
+	selectColumns = append(selectColumns, groupBySelectColumns...)
+
+	combineColumns, err := valueExprsCombine(d.Meter, dataColumn, timeColumn)
+	if err != nil {
+		return nil, err
+	}
+
+	selectColumns = append(selectColumns, combineColumns...)
+
+	sb.Select(selectColumns...)
+	sb.From(getTableName(d.Database, d.EventsTableName))
+
+	sb.Where(sb.Equal(getColumn("namespace"), d.Namespace))
+	sb.Where(sb.Equal(getColumn("type"), d.Meter.EventType))
+	sb = subjectWhere(d.EventsTableName, d.FilterSubject, sb)
+	sb.Where(sb.GreaterEqualThan(timeColumn, from.Unix()))
+	sb.Where(sb.LessThan(timeColumn, to.Unix()))
+
+	err = d.applyGroupByFilters(sb, func(key string) (string, error) {
+		jsonPath, ok := d.Meter.GroupBy[key]
+		if !ok {
+			return "", fmt.Errorf("filter group by %s is not a meter group by", key)
+		}
+
+		return groupByJSONExpr(dataColumn, jsonPath), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sb.GroupBy(append([]string{meterCacheBucketAlias}, groupByGroupByColumns...)...)
+
+	return sb, nil
+}
+
+// applyGroupByFilters applies the query's FilterGroupBy predicates to one leg. columnFor
+// maps a group-by key to that leg's expression for the dimension (a group_by array
+// element on the cache leg, a JSON extraction on live legs). The gate guarantees filter
+// keys are meter group-by dimensions — subject and customer_id can never appear here
+// because meters carrying them as group-by keys are reserved-alias rejected.
+func (d meterCacheReadQuery) applyGroupByFilters(sb *sqlbuilder.SelectBuilder, columnFor func(string) (string, error)) error {
+	keys := make([]string, 0, len(d.FilterGroupBy))
+	for key := range d.FilterGroupBy {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		filterString := d.FilterGroupBy[key]
+
+		if filterString.IsEmpty() {
+			continue
+		}
+
+		if err := filterString.Validate(); err != nil {
+			return models.NewGenericValidationError(
+				fmt.Errorf("invalid filter for group by %s: %w", key, err),
+			)
+		}
+
+		column, err := columnFor(key)
+		if err != nil {
+			return err
+		}
+
+		sb.Where(filterString.SelectWhereExpr(column, sb))
+	}
+
+	return nil
+}
+
+// meterCacheMarkerOverlapQuery counts the late-event invalidation markers that overlap
+// the cache leg's bucket range and are not healed by the serving view's last refresh.
+// Any non-zero count sends the whole query live: an unhealed marker means a settled
+// bucket in range received events the cache has not provably recomputed yet.
+//
+// The heal rule (G1) compares two ClickHouse-sourced timestamps — marker created_at
+// (server-side DEFAULT) and refreshStart (derived from system.view_refreshes) — so app
+// clock skew can never mark a stale bucket healed. A marker is healed iff
+// refreshStart > created_at AND refreshStart − created_at < HealBound; the query counts
+// the complement.
+type meterCacheMarkerOverlapQuery struct {
+	Database  string
+	Namespace string
+	EventType string
+
+	CacheLo *time.Time
+	CacheHi time.Time
+
+	RefreshStart time.Time
+	HealBound    time.Duration
+}
+
+func (q meterCacheMarkerOverlapQuery) toSQL() (string, []interface{}) {
+	sb := sqlbuilder.ClickHouse.NewSelectBuilder()
+
+	sb.Select("count()")
+	sb.From(getTableName(q.Database, meterCacheInvalidationsTableName))
+
+	sb.Where(sb.Equal("namespace", q.Namespace))
+	sb.Where(sb.Equal("event_type", q.EventType))
+	sb.Where(sb.LessThan("window_lo", q.CacheHi.Unix()))
+
+	if q.CacheLo != nil {
+		sb.Where(sb.GreaterThan("window_hi", q.CacheLo.Unix()))
+	}
+
+	sb.Where(sb.Or(
+		sb.GreaterEqualThan("created_at", q.RefreshStart),
+		sb.LessEqualThan("created_at", q.RefreshStart.Add(-q.HealBound)),
+	))
+
+	return sb.Build()
+}
+
+// queryMeterCached attempts to serve the meter query from the cache. served is false —
+// and no error is ever returned — whenever the query must run on the live path instead:
+// gate rejections are expected steady-state behavior, and infrastructure failures on the
+// cache path must degrade to a slower correct answer, never to a failed query.
+func (c *Connector) queryMeterCached(ctx context.Context, query queryMeter, params streaming.QueryParams) ([]meterpkg.MeterQueryRow, bool) {
+	bounds, reason, err := c.cacheGate.cacheEligibility(ctx, query, params)
+	if err != nil {
+		c.config.Logger.Warn("meter cache: eligibility check failed, serving live", "meter", query.Meter.Key, "error", err)
+
+		return nil, false
+	}
+
+	if reason != cacheRejectReasonNone {
+		c.config.Logger.Debug("meter cache: serving live", "meter", query.Meter.Key, "reason", string(reason))
+
+		return nil, false
+	}
+
+	readQuery := meterCacheReadQuery{
+		queryMeter: query,
+		Grain:      c.config.Cache.WindowSize,
+		CacheLo:    bounds.CacheLo,
+		CacheHi:    bounds.CacheHi,
+	}
+
+	sql, args, err := readQuery.toSQL()
+	if err != nil {
+		c.config.Logger.Warn("meter cache: building cached query failed, serving live", "meter", query.Meter.Key, "error", err)
+
+		return nil, false
+	}
+
+	start := time.Now()
+
+	rows, err := c.config.ClickHouse.Query(ctx, sql, args...)
+	if err != nil {
+		c.config.Logger.Warn("meter cache: cached query failed, serving live", "meter", query.Meter.Key, "error", err)
+
+		return nil, false
+	}
+
+	defer rows.Close()
+
+	c.config.Logger.Debug("clickhouse cached meter query executed", "elapsed", time.Since(start).String(), "sql", sql, "args", args)
+
+	values, err := query.scanRows(rows)
+	if err != nil {
+		c.config.Logger.Warn("meter cache: scanning cached query rows failed, serving live", "meter", query.Meter.Key, "error", err)
+
+		return nil, false
+	}
+
+	return values, true
+}

--- a/openmeter/streaming/clickhouse/meter_cache_read_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_read_test.go
@@ -418,7 +418,7 @@ func TestMeterCacheReadQueryToSQL(t *testing.T) {
 		}, args)
 	})
 
-	t.Run("golden latest windowed unbounded from", func(t *testing.T) {
+	t.Run("latest aggregation is rejected: excluded from the cache entirely", func(t *testing.T) {
 		to := parse("2025-01-02T00:00:00Z")
 		cacheHi := parse("2025-01-01T22:00:00Z")
 		windowSize := meter.WindowSizeHour
@@ -440,33 +440,8 @@ func TestMeterCacheReadQueryToSQL(t *testing.T) {
 			CacheHi: cacheHi,
 		}
 
-		sql, args, err := q.toSQL()
-		require.NoError(t, err)
-
-		// G14's two argMax semantics side by side: the cache leg's argMax by created_at
-		// is the newest-wins re-read, while argMaxState(value, time)/argMaxMerge carry
-		// the live LATEST semantics.
-		assert.Equal(t,
-			"SELECT tumbleStart(windowstart_bucket, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(windowstart_bucket, toIntervalHour(1), 'UTC') AS windowend, argMaxMerge(picked_latest_state) AS value "+
-				"FROM ("+
-				"(SELECT windowstart AS windowstart_bucket, tupleElement(argMax(tuple(latest_state), created_at), 1) AS picked_latest_state "+
-				"FROM openmeter.om_meter_cache "+
-				"WHERE namespace = ? AND meter_key = ? AND meter_hash = ? AND windowstart < ? "+
-				"GROUP BY windowstart, subject, group_by) "+
-				"UNION ALL "+
-				"(SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart_bucket, argMaxState(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19), om_events.time) AS latest_state "+
-				"FROM openmeter.om_events "+
-				"WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? "+
-				"GROUP BY windowstart_bucket)"+
-				") AS legs "+
-				"GROUP BY windowstart, windowend ORDER BY windowstart",
-			sql,
-		)
-
-		assert.Equal(t, []interface{}{
-			"my_namespace", "meter1", meterHash(m, CacheGrainHour), cacheHi.Unix(),
-			"my_namespace", "event1", cacheHi.Unix(), to.Unix(),
-		}, args)
+		_, _, err := q.toSQL()
+		require.ErrorContains(t, err, "invalid aggregation type: LATEST")
 	})
 
 	t.Run("total without from is rejected", func(t *testing.T) {
@@ -573,11 +548,6 @@ func TestMeterCacheCombinerExprs(t *testing.T) {
 			wantPicks:   []string{"tupleElement(argMax(tuple(uniq_state), created_at), 1) AS picked_uniq_state"},
 			wantValue:   "uniqExactMerge(picked_uniq_state) AS value",
 		},
-		{
-			aggregation: meter.MeterAggregationLatest,
-			wantPicks:   []string{"tupleElement(argMax(tuple(latest_state), created_at), 1) AS picked_latest_state"},
-			wantValue:   "argMaxMerge(picked_latest_state) AS value",
-		},
 	}
 
 	for _, tt := range tests {
@@ -598,6 +568,16 @@ func TestMeterCacheCombinerExprs(t *testing.T) {
 
 		_, err = meterCacheCombinedValueExpr(meter.MeterAggregation("INVALID"))
 		require.Error(t, err)
+	})
+
+	t.Run("latest is not a valid cache-leg aggregation", func(t *testing.T) {
+		// LATEST is excluded from the cache entirely (meterCacheStaticReject); neither the
+		// newest-wins pick nor the cross-leg combiner may ever be generated for it.
+		_, err := meterCacheNewestWinsExprs(meter.MeterAggregationLatest)
+		require.ErrorContains(t, err, "invalid aggregation type: LATEST")
+
+		_, err = meterCacheCombinedValueExpr(meter.MeterAggregationLatest)
+		require.ErrorContains(t, err, "invalid aggregation type: LATEST")
 	})
 }
 

--- a/openmeter/streaming/clickhouse/meter_cache_read_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_read_test.go
@@ -1,0 +1,662 @@
+package clickhouse
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/pkg/filter"
+)
+
+func TestMeterCacheBounds(t *testing.T) {
+	parse := func(s string) time.Time {
+		ts, err := time.Parse(time.RFC3339, s)
+		require.NoError(t, err)
+		return ts
+	}
+
+	refreshStart := parse("2025-03-01T12:10:30Z")
+	age := time.Hour
+
+	tests := []struct {
+		name string
+
+		from  *time.Time
+		to    time.Time
+		grain CacheGrain
+
+		wantLo *time.Time
+		wantHi time.Time
+		wantOK bool
+	}{
+		{
+			// horizon = 11:10:30 > to, so to governs: floor(to) − 1h
+			name:   "on grid from and to below horizon",
+			from:   lo.ToPtr(parse("2025-03-01T00:00:00Z")),
+			to:     parse("2025-03-01T06:00:00Z"),
+			grain:  CacheGrainHour,
+			wantLo: lo.ToPtr(parse("2025-03-01T00:00:00Z")),
+			wantHi: parse("2025-03-01T05:00:00Z"),
+			wantOK: true,
+		},
+		{
+			name:   "off grid from is ceiled and off grid to floored",
+			from:   lo.ToPtr(parse("2025-03-01T00:12:00Z")),
+			to:     parse("2025-03-01T06:45:00Z"),
+			grain:  CacheGrainHour,
+			wantLo: lo.ToPtr(parse("2025-03-01T01:00:00Z")),
+			wantHi: parse("2025-03-01T05:00:00Z"),
+			wantOK: true,
+		},
+		{
+			// G5 epsilon at the horizon: horizon 11:10:30 floors to 11:00, minus one
+			// grain = 10:00 — bucket [10:00, 11:00) is never served even though the
+			// refresh may have computed it, because refreshStart is an estimate.
+			name:   "to above horizon is capped with one grain epsilon",
+			from:   lo.ToPtr(parse("2025-03-01T00:00:00Z")),
+			to:     parse("2025-03-01T12:00:00Z"),
+			grain:  CacheGrainHour,
+			wantLo: lo.ToPtr(parse("2025-03-01T00:00:00Z")),
+			wantHi: parse("2025-03-01T10:00:00Z"),
+			wantOK: true,
+		},
+		{
+			// exact-horizon variant: refreshStart − age exactly on grid still backs off a
+			// full grain
+			name:   "on grid horizon still backs off one grain",
+			from:   lo.ToPtr(parse("2025-03-01T00:00:00Z")),
+			to:     parse("2025-03-01T11:10:30Z"),
+			grain:  CacheGrainHour,
+			wantLo: lo.ToPtr(parse("2025-03-01T00:00:00Z")),
+			wantHi: parse("2025-03-01T10:00:00Z"),
+			wantOK: true,
+		},
+		{
+			name:   "nil from is unbounded below",
+			from:   nil,
+			to:     parse("2025-03-01T06:00:00Z"),
+			grain:  CacheGrainHour,
+			wantLo: nil,
+			wantHi: parse("2025-03-01T05:00:00Z"),
+			wantOK: true,
+		},
+		{
+			name:   "zero width range is fully live",
+			from:   lo.ToPtr(parse("2025-03-01T05:10:00Z")),
+			to:     parse("2025-03-01T06:00:00Z"),
+			grain:  CacheGrainHour,
+			wantOK: false,
+		},
+		{
+			name:   "range entirely above horizon is fully live",
+			from:   lo.ToPtr(parse("2025-03-01T11:30:00Z")),
+			to:     parse("2025-03-01T12:00:00Z"),
+			grain:  CacheGrainHour,
+			wantOK: false,
+		},
+		{
+			name:   "day grain floors to utc midnight",
+			from:   lo.ToPtr(parse("2025-02-01T05:00:00Z")),
+			to:     parse("2025-02-20T00:00:00Z"),
+			grain:  CacheGrainDay,
+			wantLo: lo.ToPtr(parse("2025-02-02T00:00:00Z")),
+			wantHi: parse("2025-02-19T00:00:00Z"),
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bounds, ok, err := meterCacheBounds(tt.from, tt.to, refreshStart, age, tt.grain)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantOK, ok)
+
+			if !tt.wantOK {
+				return
+			}
+
+			if tt.wantLo == nil {
+				assert.Nil(t, bounds.CacheLo)
+			} else {
+				require.NotNil(t, bounds.CacheLo)
+				assert.True(t, bounds.CacheLo.Equal(*tt.wantLo), "cacheLo %s != %s", bounds.CacheLo, tt.wantLo)
+			}
+
+			assert.True(t, bounds.CacheHi.Equal(tt.wantHi), "cacheHi %s != %s", bounds.CacheHi, tt.wantHi)
+		})
+	}
+
+	t.Run("invalid grain", func(t *testing.T) {
+		_, _, err := meterCacheBounds(nil, refreshStart, refreshStart, age, CacheGrain("week"))
+		require.Error(t, err)
+	})
+}
+
+// TestMeterCacheBoundsTilingProperty asserts the R4 tiling invariant on randomized
+// inputs: whenever the bounds admit a cache leg, the three legs
+// [from, cacheLo) ∪ [cacheLo, cacheHi) ∪ [cacheHi, to) tile [from, to) exactly — shared
+// endpoints, aligned cache bucket bounds, non-empty cache leg, always-live tail — and
+// whenever they do not, there genuinely is no whole settled bucket to serve.
+func TestMeterCacheBoundsTilingProperty(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+
+	grains := []CacheGrain{CacheGrainMinute, CacheGrainHour, CacheGrainDay}
+	base := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	for i := 0; i < 2000; i++ {
+		grain := grains[rng.Intn(len(grains))]
+		spec, err := grainSpecFor(grain)
+		require.NoError(t, err)
+
+		grainDuration := time.Duration(spec.seconds) * time.Second
+
+		from := base.Add(time.Duration(rng.Int63n(int64(30 * 24 * time.Hour))))
+		to := from.Add(time.Second + time.Duration(rng.Int63n(int64(60*24*time.Hour))))
+		refreshStart := from.Add(time.Duration(rng.Int63n(int64(90 * 24 * time.Hour))))
+		age := time.Duration(1+rng.Int63n(int64(6*time.Hour)/int64(time.Second))) * time.Second
+
+		fromArg := &from
+		if rng.Intn(10) == 0 {
+			fromArg = nil
+		}
+
+		bounds, ok, err := meterCacheBounds(fromArg, to, refreshStart, age, grain)
+		require.NoError(t, err)
+
+		horizon := refreshStart.Add(-age)
+		hi := to
+		if horizon.Before(hi) {
+			hi = horizon
+		}
+
+		if !ok {
+			// The independent predicate: no whole grain bucket fits between the ceiled
+			// lower bound and the epsilon-backed-off upper bound.
+			require.NotNil(t, fromArg, "unbounded ranges always admit a cache leg")
+
+			ceiledFrom := from.Truncate(grainDuration)
+			if ceiledFrom.Before(from) {
+				ceiledFrom = ceiledFrom.Add(grainDuration)
+			}
+
+			require.False(t, hi.Truncate(grainDuration).Add(-grainDuration).After(ceiledFrom))
+
+			continue
+		}
+
+		// Cache bucket bounds are grain aligned.
+		require.True(t, bounds.CacheHi.Equal(bounds.CacheHi.Truncate(grainDuration)))
+
+		// G5 epsilon: the last served bucket ends at least one grain before the
+		// estimated settled horizon (or the query end, whichever is lower).
+		require.False(t, bounds.CacheHi.Add(grainDuration).After(hi))
+
+		// The tail [cacheHi, to) is never empty: the freshest data is always live.
+		require.True(t, bounds.CacheHi.Before(to))
+
+		if fromArg == nil {
+			require.Nil(t, bounds.CacheLo)
+
+			continue
+		}
+
+		require.NotNil(t, bounds.CacheLo)
+		require.True(t, bounds.CacheLo.Equal(bounds.CacheLo.Truncate(grainDuration)))
+
+		// Tiling: from <= cacheLo < cacheHi < to with shared leg endpoints means
+		// [from, cacheLo) ∪ [cacheLo, cacheHi) ∪ [cacheHi, to) = [from, to) exactly.
+		require.False(t, bounds.CacheLo.Before(from))
+		require.True(t, bounds.CacheLo.Sub(from) < grainDuration, "pre leg wider than one grain")
+		require.True(t, bounds.CacheHi.After(*bounds.CacheLo))
+	}
+}
+
+func TestMeterCacheReadQueryToSQL(t *testing.T) {
+	parse := func(s string) time.Time {
+		ts, err := time.Parse(time.RFC3339, s)
+		require.NoError(t, err)
+		return ts
+	}
+
+	newYork, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	baseMeter := meter.Meter{
+		Key:           "meter1",
+		EventType:     "event1",
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+		GroupBy: map[string]string{
+			"group1": "$.group1",
+			"group2": "$.group2",
+		},
+	}
+
+	t.Run("golden sum windowed day in new york with filters", func(t *testing.T) {
+		from := parse("2025-01-01T10:30:00Z")
+		to := parse("2025-03-01T00:15:00Z")
+		cacheLo := parse("2025-01-01T11:00:00Z")
+		cacheHi := parse("2025-02-28T22:00:00Z")
+		windowSize := meter.WindowSizeDay
+
+		q := meterCacheReadQuery{
+			queryMeter: queryMeter{
+				Database:               "openmeter",
+				EventsTableName:        "om_events",
+				Namespace:              "my_namespace",
+				Meter:                  baseMeter,
+				From:                   &from,
+				To:                     &to,
+				FilterSubject:          []string{"subject1"},
+				FilterGroupBy:          map[string]filter.FilterString{"group1": {Eq: lo.ToPtr("a")}},
+				GroupBy:                []string{"group1", "subject"},
+				WindowSize:             &windowSize,
+				WindowTimeZone:         newYork,
+				EnableDecimalPrecision: true,
+			},
+			Grain:   CacheGrainHour,
+			CacheLo: &cacheLo,
+			CacheHi: cacheHi,
+		}
+
+		sql, args, err := q.toSQL()
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			"SELECT tumbleStart(windowstart_bucket, toIntervalDay(1), 'America/New_York') AS windowstart, windowstart + toIntervalDay(1) AS windowend, sum(picked_sum_value) AS value, group1, subject "+
+				"FROM ("+
+				"(SELECT windowstart AS windowstart_bucket, group_by[1] AS group1, subject, tupleElement(argMax(tuple(sum_value), created_at), 1) AS picked_sum_value "+
+				"FROM openmeter.om_meter_cache "+
+				"WHERE namespace = ? AND meter_key = ? AND meter_hash = ? AND windowstart >= ? AND windowstart < ? AND subject IN (?) AND group_by[1] = ? "+
+				"GROUP BY windowstart, subject, group_by) "+
+				"UNION ALL "+
+				"(SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart_bucket, JSON_VALUE(om_events.data, '$.group1') as group1, om_events.subject, sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS sum_value "+
+				"FROM openmeter.om_events "+
+				"WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) AND om_events.time >= ? AND om_events.time < ? AND JSON_VALUE(om_events.data, '$.group1') = ? "+
+				"GROUP BY windowstart_bucket, group1, subject) "+
+				"UNION ALL "+
+				"(SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart_bucket, JSON_VALUE(om_events.data, '$.group1') as group1, om_events.subject, sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS sum_value "+
+				"FROM openmeter.om_events "+
+				"WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.subject IN (?) AND om_events.time >= ? AND om_events.time < ? AND JSON_VALUE(om_events.data, '$.group1') = ? "+
+				"GROUP BY windowstart_bucket, group1, subject)"+
+				") AS legs "+
+				"GROUP BY windowstart, windowend, group1, subject ORDER BY windowstart",
+			sql,
+		)
+
+		assert.Equal(t, []interface{}{
+			// cache leg [cacheLo, cacheHi)
+			"my_namespace", "meter1", meterHash(baseMeter, CacheGrainHour), cacheLo.Unix(), cacheHi.Unix(),
+			[]string{"subject1"},
+			"a",
+			// pre live leg [from, cacheLo)
+			"my_namespace", "event1",
+			[]string{"subject1"},
+			from.Unix(), cacheLo.Unix(), "a",
+			// post live leg [cacheHi, to)
+			"my_namespace", "event1",
+			[]string{"subject1"},
+			cacheHi.Unix(), to.Unix(), "a",
+		}, args)
+	})
+
+	t.Run("golden unique count total", func(t *testing.T) {
+		from := parse("2025-01-01T10:30:00Z")
+		to := parse("2025-03-01T00:15:00Z")
+		cacheLo := parse("2025-01-01T11:00:00Z")
+		cacheHi := parse("2025-02-28T22:00:00Z")
+
+		m := baseMeter
+		m.Aggregation = meter.MeterAggregationUniqueCount
+
+		q := meterCacheReadQuery{
+			queryMeter: queryMeter{
+				Database:               "openmeter",
+				EventsTableName:        "om_events",
+				Namespace:              "my_namespace",
+				Meter:                  m,
+				From:                   &from,
+				To:                     &to,
+				EnableDecimalPrecision: true,
+			},
+			Grain:   CacheGrainHour,
+			CacheLo: &cacheLo,
+			CacheHi: cacheHi,
+		}
+
+		sql, args, err := q.toSQL()
+		require.NoError(t, err)
+
+		// UNIQUE_COUNT stays state-level across legs: cached uniqExact states and live
+		// uniqExactState legs are merged, never summed.
+		assert.Equal(t,
+			"SELECT toDateTime(1735727400) AS windowstart, toDateTime(1740788100) AS windowend, uniqExactMerge(picked_uniq_state) AS value "+
+				"FROM ("+
+				"(SELECT windowstart AS windowstart_bucket, tupleElement(argMax(tuple(uniq_state), created_at), 1) AS picked_uniq_state "+
+				"FROM openmeter.om_meter_cache "+
+				"WHERE namespace = ? AND meter_key = ? AND meter_hash = ? AND windowstart >= ? AND windowstart < ? "+
+				"GROUP BY windowstart, subject, group_by) "+
+				"UNION ALL "+
+				"(SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart_bucket, uniqExactState(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null')) AS uniq_state "+
+				"FROM openmeter.om_events "+
+				"WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? "+
+				"GROUP BY windowstart_bucket) "+
+				"UNION ALL "+
+				"(SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart_bucket, uniqExactState(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null')) AS uniq_state "+
+				"FROM openmeter.om_events "+
+				"WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? "+
+				"GROUP BY windowstart_bucket)"+
+				") AS legs",
+			sql,
+		)
+
+		assert.Equal(t, []interface{}{
+			"my_namespace", "meter1", meterHash(m, CacheGrainHour), cacheLo.Unix(), cacheHi.Unix(),
+			"my_namespace", "event1", from.Unix(), cacheLo.Unix(),
+			"my_namespace", "event1", cacheHi.Unix(), to.Unix(),
+		}, args)
+	})
+
+	t.Run("golden avg windowed hour on grid has no pre leg", func(t *testing.T) {
+		from := parse("2025-01-01T10:00:00Z")
+		to := parse("2025-01-02T00:00:00Z")
+		cacheHi := parse("2025-01-01T22:00:00Z")
+		windowSize := meter.WindowSizeHour
+
+		m := baseMeter
+		m.Aggregation = meter.MeterAggregationAvg
+
+		q := meterCacheReadQuery{
+			queryMeter: queryMeter{
+				Database:               "openmeter",
+				EventsTableName:        "om_events",
+				Namespace:              "my_namespace",
+				Meter:                  m,
+				From:                   &from,
+				To:                     &to,
+				GroupBy:                []string{"subject"},
+				WindowSize:             &windowSize,
+				QuerySettings:          map[string]string{"max_execution_time": "600"},
+				EnableDecimalPrecision: true,
+			},
+			Grain:   CacheGrainHour,
+			CacheLo: &from,
+			CacheHi: cacheHi,
+		}
+
+		sql, args, err := q.toSQL()
+		require.NoError(t, err)
+
+		// AVG combines as Σsum ÷ Σvalue_count — an average of averages would be wrong —
+		// and the AVG pick carries both columns in one argMax tuple so they always come
+		// from the same row version.
+		assert.Equal(t,
+			"SELECT tumbleStart(windowstart_bucket, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(windowstart_bucket, toIntervalHour(1), 'UTC') AS windowend, toFloat64(sum(picked_sum_value)) / sum(picked_value_count) AS value, subject "+
+				"FROM ("+
+				"(SELECT windowstart AS windowstart_bucket, subject, tupleElement(argMax(tuple(sum_value, value_count), created_at), 1) AS picked_sum_value, tupleElement(argMax(tuple(sum_value, value_count), created_at), 2) AS picked_value_count "+
+				"FROM openmeter.om_meter_cache "+
+				"WHERE namespace = ? AND meter_key = ? AND meter_hash = ? AND windowstart >= ? AND windowstart < ? "+
+				"GROUP BY windowstart, subject, group_by) "+
+				"UNION ALL "+
+				"(SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart_bucket, om_events.subject, sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS sum_value, count(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS value_count "+
+				"FROM openmeter.om_events "+
+				"WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? "+
+				"GROUP BY windowstart_bucket, subject)"+
+				") AS legs "+
+				"GROUP BY windowstart, windowend, subject ORDER BY windowstart SETTINGS max_execution_time = 600",
+			sql,
+		)
+
+		assert.Equal(t, []interface{}{
+			"my_namespace", "meter1", meterHash(m, CacheGrainHour), from.Unix(), cacheHi.Unix(),
+			"my_namespace", "event1", cacheHi.Unix(), to.Unix(),
+		}, args)
+	})
+
+	t.Run("golden latest windowed unbounded from", func(t *testing.T) {
+		to := parse("2025-01-02T00:00:00Z")
+		cacheHi := parse("2025-01-01T22:00:00Z")
+		windowSize := meter.WindowSizeHour
+
+		m := baseMeter
+		m.Aggregation = meter.MeterAggregationLatest
+
+		q := meterCacheReadQuery{
+			queryMeter: queryMeter{
+				Database:               "openmeter",
+				EventsTableName:        "om_events",
+				Namespace:              "my_namespace",
+				Meter:                  m,
+				To:                     &to,
+				WindowSize:             &windowSize,
+				EnableDecimalPrecision: true,
+			},
+			Grain:   CacheGrainHour,
+			CacheHi: cacheHi,
+		}
+
+		sql, args, err := q.toSQL()
+		require.NoError(t, err)
+
+		// G14's two argMax semantics side by side: the cache leg's argMax by created_at
+		// is the newest-wins re-read, while argMaxState(value, time)/argMaxMerge carry
+		// the live LATEST semantics.
+		assert.Equal(t,
+			"SELECT tumbleStart(windowstart_bucket, toIntervalHour(1), 'UTC') AS windowstart, tumbleEnd(windowstart_bucket, toIntervalHour(1), 'UTC') AS windowend, argMaxMerge(picked_latest_state) AS value "+
+				"FROM ("+
+				"(SELECT windowstart AS windowstart_bucket, tupleElement(argMax(tuple(latest_state), created_at), 1) AS picked_latest_state "+
+				"FROM openmeter.om_meter_cache "+
+				"WHERE namespace = ? AND meter_key = ? AND meter_hash = ? AND windowstart < ? "+
+				"GROUP BY windowstart, subject, group_by) "+
+				"UNION ALL "+
+				"(SELECT tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart_bucket, argMaxState(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19), om_events.time) AS latest_state "+
+				"FROM openmeter.om_events "+
+				"WHERE om_events.namespace = ? AND om_events.type = ? AND om_events.time >= ? AND om_events.time < ? "+
+				"GROUP BY windowstart_bucket)"+
+				") AS legs "+
+				"GROUP BY windowstart, windowend ORDER BY windowstart",
+			sql,
+		)
+
+		assert.Equal(t, []interface{}{
+			"my_namespace", "meter1", meterHash(m, CacheGrainHour), cacheHi.Unix(),
+			"my_namespace", "event1", cacheHi.Unix(), to.Unix(),
+		}, args)
+	})
+
+	t.Run("total without from is rejected", func(t *testing.T) {
+		to := parse("2025-01-02T00:00:00Z")
+
+		q := meterCacheReadQuery{
+			queryMeter: queryMeter{
+				Database:               "openmeter",
+				EventsTableName:        "om_events",
+				Namespace:              "my_namespace",
+				Meter:                  baseMeter,
+				To:                     &to,
+				EnableDecimalPrecision: true,
+			},
+			Grain:   CacheGrainHour,
+			CacheHi: parse("2025-01-01T22:00:00Z"),
+		}
+
+		_, _, err := q.toSQL()
+		require.Error(t, err)
+	})
+
+	t.Run("nil to is rejected", func(t *testing.T) {
+		q := meterCacheReadQuery{
+			queryMeter: queryMeter{
+				Database:        "openmeter",
+				EventsTableName: "om_events",
+				Namespace:       "my_namespace",
+				Meter:           baseMeter,
+			},
+			Grain: CacheGrainHour,
+		}
+
+		_, _, err := q.toSQL()
+		require.Error(t, err)
+	})
+
+	t.Run("query group by outside the meter fails leg build", func(t *testing.T) {
+		from := parse("2025-01-01T10:00:00Z")
+		to := parse("2025-01-02T00:00:00Z")
+		windowSize := meter.WindowSizeHour
+
+		q := meterCacheReadQuery{
+			queryMeter: queryMeter{
+				Database:               "openmeter",
+				EventsTableName:        "om_events",
+				Namespace:              "my_namespace",
+				Meter:                  baseMeter,
+				From:                   &from,
+				To:                     &to,
+				GroupBy:                []string{"group3"},
+				WindowSize:             &windowSize,
+				EnableDecimalPrecision: true,
+			},
+			Grain:   CacheGrainHour,
+			CacheLo: &from,
+			CacheHi: parse("2025-01-01T22:00:00Z"),
+		}
+
+		_, _, err := q.toSQL()
+		require.Error(t, err)
+	})
+}
+
+func TestMeterCacheCombinerExprs(t *testing.T) {
+	// The per-aggregation pairs of newest-wins pick (cache leg) and cross-leg combiner
+	// (outer query); additive aggregations re-aggregate, AVG divides sums by counts,
+	// UNIQUE_COUNT and LATEST stay state-level.
+	tests := []struct {
+		aggregation meter.MeterAggregation
+		wantPicks   []string
+		wantValue   string
+	}{
+		{
+			aggregation: meter.MeterAggregationSum,
+			wantPicks:   []string{"tupleElement(argMax(tuple(sum_value), created_at), 1) AS picked_sum_value"},
+			wantValue:   "sum(picked_sum_value) AS value",
+		},
+		{
+			aggregation: meter.MeterAggregationCount,
+			wantPicks:   []string{"tupleElement(argMax(tuple(count_value), created_at), 1) AS picked_count_value"},
+			wantValue:   "sum(picked_count_value) AS value",
+		},
+		{
+			aggregation: meter.MeterAggregationAvg,
+			wantPicks: []string{
+				"tupleElement(argMax(tuple(sum_value, value_count), created_at), 1) AS picked_sum_value",
+				"tupleElement(argMax(tuple(sum_value, value_count), created_at), 2) AS picked_value_count",
+			},
+			wantValue: "toFloat64(sum(picked_sum_value)) / sum(picked_value_count) AS value",
+		},
+		{
+			aggregation: meter.MeterAggregationMin,
+			wantPicks:   []string{"tupleElement(argMax(tuple(min_value), created_at), 1) AS picked_min_value"},
+			wantValue:   "min(picked_min_value) AS value",
+		},
+		{
+			aggregation: meter.MeterAggregationMax,
+			wantPicks:   []string{"tupleElement(argMax(tuple(max_value), created_at), 1) AS picked_max_value"},
+			wantValue:   "max(picked_max_value) AS value",
+		},
+		{
+			aggregation: meter.MeterAggregationUniqueCount,
+			wantPicks:   []string{"tupleElement(argMax(tuple(uniq_state), created_at), 1) AS picked_uniq_state"},
+			wantValue:   "uniqExactMerge(picked_uniq_state) AS value",
+		},
+		{
+			aggregation: meter.MeterAggregationLatest,
+			wantPicks:   []string{"tupleElement(argMax(tuple(latest_state), created_at), 1) AS picked_latest_state"},
+			wantValue:   "argMaxMerge(picked_latest_state) AS value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.aggregation), func(t *testing.T) {
+			picks, err := meterCacheNewestWinsExprs(tt.aggregation)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPicks, picks)
+
+			value, err := meterCacheCombinedValueExpr(tt.aggregation)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantValue, value)
+		})
+	}
+
+	t.Run("invalid aggregation", func(t *testing.T) {
+		_, err := meterCacheNewestWinsExprs(meter.MeterAggregation("INVALID"))
+		require.Error(t, err)
+
+		_, err = meterCacheCombinedValueExpr(meter.MeterAggregation("INVALID"))
+		require.Error(t, err)
+	})
+}
+
+func TestMeterCacheMarkerOverlapQueryToSQL(t *testing.T) {
+	parse := func(s string) time.Time {
+		ts, err := time.Parse(time.RFC3339, s)
+		require.NoError(t, err)
+		return ts
+	}
+
+	cacheLo := parse("2025-01-01T11:00:00Z")
+	cacheHi := parse("2025-02-28T22:00:00Z")
+	refreshStart := parse("2025-03-01T00:10:00Z")
+
+	t.Run("golden with bounded cache leg", func(t *testing.T) {
+		sql, args := meterCacheMarkerOverlapQuery{
+			Database:     "openmeter",
+			Namespace:    "my_namespace",
+			EventType:    "event1",
+			CacheLo:      &cacheLo,
+			CacheHi:      cacheHi,
+			RefreshStart: refreshStart,
+			HealBound:    20 * time.Minute,
+		}.toSQL()
+
+		assert.Equal(t,
+			"SELECT count() FROM openmeter.om_meter_cache_invalidations "+
+				"WHERE namespace = ? AND event_type = ? AND window_lo < ? AND window_hi > ? AND (created_at >= ? OR created_at <= ?)",
+			sql,
+		)
+
+		// The heal complement: a marker is unhealed when it was written at or after the
+		// refresh started, or so long before it that the refresh's stored_at lookback
+		// provably no longer covered the late events (G1).
+		assert.Equal(t, []interface{}{
+			"my_namespace", "event1", cacheHi.Unix(), cacheLo.Unix(),
+			refreshStart, refreshStart.Add(-20 * time.Minute),
+		}, args)
+	})
+
+	t.Run("golden with unbounded cache leg", func(t *testing.T) {
+		sql, args := meterCacheMarkerOverlapQuery{
+			Database:     "openmeter",
+			Namespace:    "my_namespace",
+			EventType:    "event1",
+			CacheHi:      cacheHi,
+			RefreshStart: refreshStart,
+			HealBound:    20 * time.Minute,
+		}.toSQL()
+
+		assert.Equal(t,
+			"SELECT count() FROM openmeter.om_meter_cache_invalidations "+
+				"WHERE namespace = ? AND event_type = ? AND window_lo < ? AND (created_at >= ? OR created_at <= ?)",
+			sql,
+		)
+
+		assert.Equal(t, []interface{}{
+			"my_namespace", "event1", cacheHi.Unix(),
+			refreshStart, refreshStart.Add(-20 * time.Minute),
+		}, args)
+	})
+}

--- a/openmeter/streaming/clickhouse/meter_cache_read_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_read_test.go
@@ -611,6 +611,7 @@ func TestMeterCacheMarkerOverlapQueryToSQL(t *testing.T) {
 	cacheLo := parse("2025-01-01T11:00:00Z")
 	cacheHi := parse("2025-02-28T22:00:00Z")
 	refreshStart := parse("2025-03-01T00:10:00Z")
+	backfilledAt := parse("2025-01-15T08:00:00Z")
 
 	t.Run("golden with bounded cache leg", func(t *testing.T) {
 		sql, args := meterCacheMarkerOverlapQuery{
@@ -621,20 +622,22 @@ func TestMeterCacheMarkerOverlapQueryToSQL(t *testing.T) {
 			CacheHi:      cacheHi,
 			RefreshStart: refreshStart,
 			HealBound:    20 * time.Minute,
+			BackfilledAt: backfilledAt,
 		}.toSQL()
 
 		assert.Equal(t,
 			"SELECT count() FROM openmeter.om_meter_cache_invalidations "+
-				"WHERE namespace = ? AND event_type = ? AND window_lo < ? AND window_hi > ? AND (created_at >= ? OR created_at <= ?)",
+				"WHERE namespace = ? AND event_type = ? AND window_lo < ? AND window_hi > ? AND created_at >= ? AND (created_at >= ? OR created_at <= ?)",
 			sql,
 		)
 
-		// The heal complement: a marker is unhealed when it was written at or after the
-		// refresh started, or so long before it that the refresh's stored_at lookback
-		// provably no longer covered the late events (G1).
+		// The heal complement: a marker is unhealed when the view's backfill started
+		// before it was written, and it was written at or after the latest refresh
+		// started or so long before that refresh that its stored_at lookback provably no
+		// longer covered the late events (G1).
 		assert.Equal(t, []interface{}{
 			"my_namespace", "event1", cacheHi.Unix(), cacheLo.Unix(),
-			refreshStart, refreshStart.Add(-20 * time.Minute),
+			backfilledAt, refreshStart, refreshStart.Add(-20 * time.Minute),
 		}, args)
 	})
 
@@ -646,17 +649,18 @@ func TestMeterCacheMarkerOverlapQueryToSQL(t *testing.T) {
 			CacheHi:      cacheHi,
 			RefreshStart: refreshStart,
 			HealBound:    20 * time.Minute,
+			BackfilledAt: backfilledAt,
 		}.toSQL()
 
 		assert.Equal(t,
 			"SELECT count() FROM openmeter.om_meter_cache_invalidations "+
-				"WHERE namespace = ? AND event_type = ? AND window_lo < ? AND (created_at >= ? OR created_at <= ?)",
+				"WHERE namespace = ? AND event_type = ? AND window_lo < ? AND created_at >= ? AND (created_at >= ? OR created_at <= ?)",
 			sql,
 		)
 
 		assert.Equal(t, []interface{}{
 			"my_namespace", "event1", cacheHi.Unix(),
-			refreshStart, refreshStart.Add(-20 * time.Minute),
+			backfilledAt, refreshStart, refreshStart.Add(-20 * time.Minute),
 		}, args)
 	})
 }

--- a/openmeter/streaming/clickhouse/meter_cache_regression_ch_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_regression_ch_test.go
@@ -1,0 +1,853 @@
+package clickhouse
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+)
+
+// TestPoisonThroughBatchInsertConverges drives a late event through the production
+// ingestion hook (Connector.BatchInsert) and proves the full invalidation lifecycle: the
+// marker is written with a server-side timestamp, the affected MV's refresh is triggered,
+// and once that refresh completes the marker is healed under the G1 rule (it started
+// after the marker, well within the heal bound) so the cached read serves the recomputed
+// bucket — poison included — byte-equal with live.
+func (s *MeterCacheCHTestSuite) TestPoisonThroughBatchInsertConverges() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-poison-ingest"
+		eventType = "api-calls"
+	)
+
+	c := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	m := meter.Meter{
+		Key:           "meter-sum",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	now := time.Now().UTC()
+	bucket := now.Add(-4 * time.Hour).Truncate(time.Hour)
+
+	// given:
+	// - two settled events cached via deploy (insert bypasses BatchInsert so the baseline
+	//   has no markers)
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(5*time.Minute), `{"value": 2}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(10*time.Minute), `{"value": 7}`, now),
+	)
+
+	mv := createMeterCacheMV{
+		Database:        s.Database,
+		EventsTableName: e2eEventsTable,
+		Namespace:       namespace,
+		Meter:           m,
+		Grain:           CacheGrainHour,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+	}
+	s.deployMeterCacheMV(ctx, mv)
+
+	from := bucket
+	to := now.Truncate(time.Hour).Add(time.Hour)
+	totalParams := streaming.QueryParams{From: &from, To: &to}
+
+	live, cached := s.queryBothPaths(ctx, c, namespace, m, totalParams)
+	s.Equal(float64(9), s.totalValue(live))
+	s.Equal(float64(9), s.totalValue(cached))
+
+	// when:
+	// - a late event lands through BatchInsert (the production ingestion path)
+	s.NoError(c.BatchInsert(ctx, []streaming.RawEvent{
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(40*time.Minute), `{"value": 1000}`, now),
+	}))
+
+	// then:
+	// - one marker was written and one best-effort refresh trigger fired
+	var markerCount uint64
+	s.NoError(s.ClickHouse.QueryRow(ctx,
+		"SELECT count() FROM "+getTableName(s.Database, meterCacheInvalidationsTableName),
+	).Scan(&markerCount))
+	s.Equal(uint64(1), markerCount)
+	s.Equal(uint64(1), c.cacheInvalidator.refreshTriggersFired.Load())
+	s.Equal(uint64(0), c.cacheInvalidator.markerInsertFailures.Load())
+
+	// when:
+	// - a refresh completes measurably after the marker (the invalidator-triggered one
+	//   usually is that refresh already; extra refreshes only compensate the
+	//   second-resolution refresh-start bookkeeping, see refreshViewUntilMarkersHealed)
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+getTableName(s.Database, mv.name())))
+	s.refreshViewUntilMarkersHealed(ctx, mv.name())
+
+	// then:
+	// - the marker is healed (the refresh started after it, delta far below the 20m heal
+	//   bound) and the cached read serves the recomputed bucket including the poison
+	live, cached = s.queryBothPaths(ctx, c, namespace, m, totalParams)
+	s.Equal(float64(1009), s.totalValue(live))
+	s.Equal(float64(1009), s.totalValue(cached))
+}
+
+// TestPoisonBypassStaysCachedUntilRefresh proves the cache leg really serves cached
+// buckets by poisoning one behind the invalidation machinery's back: a late event
+// inserted with direct SQL (no BatchInsert, hence no marker) must stay invisible to the
+// cached read — had the gate silently fallen back to live, cached and live would agree —
+// and the next refresh must converge the bucket because the poison carries a fresh
+// stored_at that the dirty-bucket lookback picks up.
+func (s *MeterCacheCHTestSuite) TestPoisonBypassStaysCachedUntilRefresh() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-poison-bypass"
+		eventType = "api-calls"
+	)
+
+	c := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	m := meter.Meter{
+		Key:           "meter-sum",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	now := time.Now().UTC()
+	bucket := now.Add(-4 * time.Hour).Truncate(time.Hour)
+
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(5*time.Minute), `{"value": 2}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(10*time.Minute), `{"value": 7}`, now),
+	)
+
+	mv := createMeterCacheMV{
+		Database:        s.Database,
+		EventsTableName: e2eEventsTable,
+		Namespace:       namespace,
+		Meter:           m,
+		Grain:           CacheGrainHour,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+	}
+	s.deployMeterCacheMV(ctx, mv)
+
+	from := bucket
+	to := now.Truncate(time.Hour).Add(time.Hour)
+	totalParams := streaming.QueryParams{From: &from, To: &to}
+
+	live, cached := s.queryBothPaths(ctx, c, namespace, m, totalParams)
+	s.Equal(float64(9), s.totalValue(live))
+	s.Equal(float64(9), s.totalValue(cached))
+
+	// when:
+	// - a late event is inserted bypassing BatchInsert: no marker, no refresh trigger
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(40*time.Minute), `{"value": 1000}`, now),
+	)
+
+	// then:
+	// - live sees the poison, the cached read serves the stale cached bucket: the
+	//   inequality is the proof the cache leg (not a silent live fallback) produced the
+	//   cached rows
+	live, cached = s.queryBothPaths(ctx, c, namespace, m, totalParams)
+	s.Equal(float64(1009), s.totalValue(live))
+	s.Equal(float64(9), s.totalValue(cached))
+
+	// when:
+	// - a refresh runs: the poison's stored_at is fresh, so the dirty-bucket filter
+	//   recomputes its bucket even without any marker
+	qualifiedView := getTableName(s.Database, mv.name())
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM REFRESH VIEW "+qualifiedView))
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+
+	// then:
+	// - the cached read converges to live
+	live, cached = s.queryBothPaths(ctx, c, namespace, m, totalParams)
+	s.Equal(float64(1009), s.totalValue(live))
+	s.Equal(float64(1009), s.totalValue(cached))
+}
+
+// TestMeterHashFilterGuardsShapeCollision pins the cache leg's meter_hash filter (G8): a
+// meter shape change leaves the old shape's rows in om_meter_cache under the same
+// namespace and meter key until the reconciler GCs them, and reads of the new shape must
+// never co-read them. The old shape is deployed second, so its row versions are newer: a
+// read missing the hash filter would newest-wins-pick the old shape's value and return 3
+// instead of 30 for the settled bucket.
+//
+// Watched RED with the guard reverted: removing the meter_hash WHERE clause from
+// meterCacheReadQuery.cacheLeg fails the "current shape" assertions below with a cached
+// total of 43 (the old shape's newer row wins the settled bucket: 3, plus the 40 live
+// tail) instead of 70, proving cross-shape pollution.
+func (s *MeterCacheCHTestSuite) TestMeterHashFilterGuardsShapeCollision() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-shape-collision"
+		eventType = "api-calls"
+	)
+
+	c := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	// The same meter key with two value properties models a meter shape edit: the current
+	// shape reads $.value2, the pre-edit shape read $.value.
+	currentShape := meter.Meter{
+		Key:           "meter-shape",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value2"),
+	}
+
+	oldShape := meter.Meter{
+		Key:           "meter-shape",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	now := time.Now().UTC()
+	bucket := now.Add(-4 * time.Hour).Truncate(time.Hour)
+
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(5*time.Minute), `{"value": 1, "value2": 10}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(10*time.Minute), `{"value": 2, "value2": 20}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-1", now.Add(-30*time.Minute), `{"value": 4, "value2": 40}`, now),
+	)
+
+	// Deploy order is load-bearing: the old shape second, so its cache rows carry newer
+	// created_at versions and would win a hash-less newest-wins pick.
+	for _, m := range []meter.Meter{currentShape, oldShape} {
+		s.deployMeterCacheMV(ctx, createMeterCacheMV{
+			Database:        s.Database,
+			EventsTableName: e2eEventsTable,
+			Namespace:       namespace,
+			Meter:           m,
+			Grain:           CacheGrainHour,
+			RefreshInterval: 10 * time.Minute,
+			MinimumUsageAge: time.Hour,
+		})
+	}
+
+	// Sanity: both shapes' rows share (namespace, meter_key) and differ only in hash.
+	var distinctHashes uint64
+	s.NoError(s.ClickHouse.QueryRow(ctx,
+		fmt.Sprintf("SELECT uniqExact(meter_hash) FROM %s WHERE namespace = ? AND meter_key = ?", getTableName(s.Database, meterCacheTableName)),
+		namespace, "meter-shape",
+	).Scan(&distinctHashes))
+	s.Equal(uint64(2), distinctHashes)
+
+	from := bucket
+	to := now.Truncate(time.Hour).Add(time.Hour)
+	totalParams := streaming.QueryParams{From: &from, To: &to}
+
+	// then:
+	// - the current shape reads only its own rows (30 cached + 40 live tail)
+	live, cached := s.queryBothPaths(ctx, c, namespace, currentShape, totalParams)
+	s.Equal(float64(70), s.totalValue(live))
+	s.Equal(float64(70), s.totalValue(cached))
+
+	// then:
+	// - the old shape also reads only its own rows (3 cached + 4 live tail)
+	live, cached = s.queryBothPaths(ctx, c, namespace, oldShape, totalParams)
+	s.Equal(float64(7), s.totalValue(live))
+	s.Equal(float64(7), s.totalValue(cached))
+}
+
+// TestGrainChangeIsolatesOldGrainRows is the G4 regression: a cache grain change is a
+// shape change, so rows rolled up at the previous grain must be invisible to reads at the
+// current grain even while both row sets coexist in om_meter_cache (the reconciler GCs
+// the old ones eventually, but reads must be correct immediately).
+//
+// Watched RED with the guard reverted: dropping the grain component from meterHash's
+// input (meter_cache_hash.go) collapses the two deployments onto one hash — the
+// distinct-hash sanity assertion below reads 1 instead of 2, and past it the hour read
+// would co-read the minute-grain rows and double the total.
+func (s *MeterCacheCHTestSuite) TestGrainChangeIsolatesOldGrainRows() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-grain-change"
+		eventType = "api-calls"
+	)
+
+	m := meter.Meter{
+		Key:           "meter-sum",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	now := time.Now().UTC()
+	bucket := now.Add(-4 * time.Hour).Truncate(time.Hour)
+
+	// Two events in distinct minute buckets of the same hour bucket: at minute grain they
+	// roll up into two cache rows, at hour grain into one — co-reading both grains would
+	// double the hour total.
+	minuteConnector := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainMinute,
+	})
+
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(5*time.Minute), `{"value": 2}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(10*time.Minute), `{"value": 7}`, now),
+	)
+
+	for _, grain := range []CacheGrain{CacheGrainMinute, CacheGrainHour} {
+		s.deployMeterCacheMV(ctx, createMeterCacheMV{
+			Database:        s.Database,
+			EventsTableName: e2eEventsTable,
+			Namespace:       namespace,
+			Meter:           m,
+			Grain:           grain,
+			RefreshInterval: 10 * time.Minute,
+			MinimumUsageAge: time.Hour,
+		})
+	}
+
+	hourConnector := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	// Sanity: both grains' row sets coexist under distinct hashes (2 minute rows + 1 hour
+	// row) — the exact situation a grain change leaves behind until GC.
+	var distinctHashes, rowCount uint64
+	s.NoError(s.ClickHouse.QueryRow(ctx,
+		fmt.Sprintf("SELECT uniqExact(meter_hash), count() FROM %s FINAL WHERE namespace = ?", getTableName(s.Database, meterCacheTableName)),
+		namespace,
+	).Scan(&distinctHashes, &rowCount))
+	s.Equal(uint64(2), distinctHashes)
+	s.Equal(uint64(3), rowCount)
+
+	from := bucket
+	to := now.Truncate(time.Hour).Add(time.Hour)
+	totalParams := streaming.QueryParams{From: &from, To: &to}
+
+	// then:
+	// - the hour-grain connector reads only hour-hash rows
+	live, cached := s.queryBothPaths(ctx, hourConnector, namespace, m, totalParams)
+	s.Equal(float64(9), s.totalValue(live))
+	s.Equal(float64(9), s.totalValue(cached))
+
+	// then:
+	// - the minute-grain connector reads only minute-hash rows (windowed to prove the
+	//   finer buckets re-window into hour windows correctly)
+	live, cached = s.queryBothPaths(ctx, minuteConnector, namespace, m, streaming.QueryParams{
+		From:       &from,
+		To:         &to,
+		WindowSize: lo.ToPtr(meter.WindowSizeHour),
+	})
+	s.NotEmpty(live)
+	s.ElementsMatch(live, cached)
+}
+
+// TestStaleMarkerKeepsReaderLive is the G1 regression: an invalidation marker that aged
+// past what any refresh's stored_at lookback provably covered must never be considered
+// healed — the reader stays live for the marked range (correctly seeing the late event in
+// the raw table) until the reconciler re-backfills, while ranges no marker overlaps keep
+// serving from the cache.
+//
+// The extended outage is modeled without waiting: the late event and its marker are
+// backdated (stored_at and created_at two hours in the past, beyond the 1h30m dirty
+// window and the 20m heal bound) exactly as an outage would leave them — production
+// markers always carry the server-side DEFAULT timestamp, the explicit value here only
+// simulates their age. The view is STOPped across the "outage" and resumed before the
+// verifying refresh, mirroring the plan's stop → late event + marker → age → resume
+// sequence.
+//
+// Watched RED with the guard reverted: removing the
+// `created_at <= refreshStart - healBound` arm from meterCacheMarkerOverlapQuery.toSQL
+// wrongly heals the aged marker and the marked-range read below executes the cached
+// query — the unhealed_markers log assertion goes red first, and the total would read 9
+// (the cached bucket that never saw the late event) instead of 109.
+func (s *MeterCacheCHTestSuite) TestStaleMarkerKeepsReaderLive() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-stale-marker"
+		eventType = "api-calls"
+	)
+
+	c := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	m := meter.Meter{
+		Key:           "meter-sum",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	now := time.Now().UTC()
+	bucketP := now.Add(-5 * time.Hour).Truncate(time.Hour)
+	bucketQ := now.Add(-3 * time.Hour).Truncate(time.Hour)
+
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucketP.Add(10*time.Minute), `{"value": 2}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucketQ.Add(10*time.Minute), `{"value": 7}`, now),
+	)
+
+	mv := createMeterCacheMV{
+		Database:        s.Database,
+		EventsTableName: e2eEventsTable,
+		Namespace:       namespace,
+		Meter:           m,
+		Grain:           CacheGrainHour,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+	}
+	s.deployMeterCacheMV(ctx, mv)
+
+	qualifiedView := getTableName(s.Database, mv.name())
+
+	// when:
+	// - refreshing stops (the outage begins)
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM STOP VIEW "+qualifiedView))
+
+	// - a late event lands during the outage; by resume time its stored_at (now-2h) has
+	//   aged out of the 1h30m dirty lookback, so no future refresh will ever recompute its
+	//   bucket
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucketP.Add(20*time.Minute), `{"value": 100}`, now.Add(-2*time.Hour)),
+	)
+
+	// - its marker aged with it (2h > the 20m heal bound)
+	s.NoError(s.ClickHouse.Exec(ctx,
+		fmt.Sprintf("INSERT INTO %s (namespace, event_type, window_lo, window_hi, created_at) VALUES (?, ?, ?, ?, ?)",
+			getTableName(s.Database, meterCacheInvalidationsTableName)),
+		namespace, eventType, bucketP, bucketP.Add(time.Hour), now.Add(-2*time.Hour),
+	))
+
+	// - refreshing resumes and a refresh completes
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM START VIEW "+qualifiedView))
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM REFRESH VIEW "+qualifiedView))
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+
+	to := now.Truncate(time.Hour).Add(time.Hour)
+
+	// then:
+	// - the marked range is served live (the resumed refresh could not have covered the
+	//   marker) and therefore sees the late event the cache is missing
+	c.logs.Reset()
+
+	overlapping, err := c.QueryMeter(ctx, namespace, m, streaming.QueryParams{From: &bucketP, To: &to, Cachable: true})
+	s.NoError(err)
+	s.Contains(c.logs.String(), "reason=unhealed_markers")
+	s.Equal(float64(109), s.totalValue(overlapping))
+
+	// then:
+	// - a range the marker does not overlap still serves from the cache
+	live, cached := s.queryBothPaths(ctx, c, namespace, m, streaming.QueryParams{From: &bucketQ, To: &to})
+	s.Equal(float64(7), s.totalValue(live))
+	s.Equal(float64(7), s.totalValue(cached))
+}
+
+// TestFutureDatedEventCachedAfterSettling is the G2 regression: an event whose stored_at
+// is far in the past relative to its event time (a future-dated ingest) is invisible to
+// the dirty stored_at lookback by the time its bucket settles, so only the newly-settled
+// strip can bring it into the cache. The scheduled refresh must recompute the strip
+// bucket and the cache row must include the event's contribution.
+//
+// Watched RED with the guard reverted: removing the "UNION DISTINCT ... numbers(...)"
+// newly-settled-strip arm from dirtyBucketFilterExpr leaves the strip bucket
+// unrecomputed (its only events' stored_at is days old) and the newest cache row below
+// stays at 3 instead of 8.
+func (s *MeterCacheCHTestSuite) TestFutureDatedEventCachedAfterSettling() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-future-dated"
+		eventType = "api-calls"
+	)
+
+	// 30m interval → the strip unconditionally recomputes the 2 grain buckets below the
+	// settled bound, tolerating the bound advancing one bucket mid-test.
+	c := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 30 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	m := meter.Meter{
+		Key:           "meter-sum",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	now := time.Now().UTC()
+	settledBound := now.Add(-time.Hour).Truncate(time.Hour)
+	stripBucket := settledBound.Add(-time.Hour)
+	oldStoredAt := now.Add(-3 * 24 * time.Hour)
+
+	// given:
+	// - the strip bucket already holds one settled event with a days-old stored_at (it
+	//   reaches the cache via the deploy backfill, which has no stored_at restriction)
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", stripBucket.Add(10*time.Minute), `{"value": 3}`, oldStoredAt),
+	)
+
+	mv := createMeterCacheMV{
+		Database:        s.Database,
+		EventsTableName: e2eEventsTable,
+		Namespace:       namespace,
+		Meter:           m,
+		Grain:           CacheGrainHour,
+		RefreshInterval: 30 * time.Minute,
+		MinimumUsageAge: time.Hour,
+	}
+	s.deployMeterCacheMV(ctx, mv)
+
+	newestStripBucketSum := func() float64 {
+		var value NullDecimal
+		s.NoError(s.ClickHouse.QueryRow(ctx,
+			fmt.Sprintf("SELECT argMax(sum_value, created_at) FROM %s WHERE namespace = ? AND meter_hash = ? AND windowstart = ?",
+				getTableName(s.Database, meterCacheTableName)),
+			namespace, meterHash(m, CacheGrainHour), stripBucket,
+		).Scan(&value))
+		s.True(value.Valid)
+
+		return value.Decimal.InexactFloat64()
+	}
+
+	s.Equal(float64(3), newestStripBucketSum())
+
+	// when:
+	// - a future-dated event lands in the already-settled strip bucket: its event time is
+	//   fresh but its stored_at is days old, so the dirty stored_at lookback (2h30m here)
+	//   can never see it — only the strip recompute can
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", stripBucket.Add(30*time.Minute), `{"value": 5}`, oldStoredAt),
+	)
+
+	qualifiedView := getTableName(s.Database, mv.name())
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM REFRESH VIEW "+qualifiedView))
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+
+	// then:
+	// - the strip recompute appended a bucket version that includes the future-dated event
+	s.Equal(float64(8), newestStripBucketSum())
+
+	// then:
+	// - reads stay in parity throughout (the strip bucket itself sits at the G5 epsilon
+	//   boundary and is served by the live post leg today; the cache row matters the
+	//   moment the horizon advances past it)
+	from := stripBucket.Add(-time.Hour)
+	to := now.Truncate(time.Hour).Add(time.Hour)
+
+	live, cached := s.queryBothPaths(ctx, c, namespace, m, streaming.QueryParams{From: &from, To: &to})
+	s.Equal(float64(8), s.totalValue(live))
+	s.Equal(float64(8), s.totalValue(cached))
+}
+
+// TestUnstampedBackfillServesLive is the G3 regression on a real ClickHouse: a healthy,
+// refreshing MV whose comment has no backfilled_at stamp must be refused by the reader —
+// its cache rows only cover recently refreshed buckets, so serving it would silently drop
+// older history. Stamping the very same view flips the gate to cache-serving without any
+// other change.
+func (s *MeterCacheCHTestSuite) TestUnstampedBackfillServesLive() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-unstamped"
+		eventType = "api-calls"
+	)
+
+	c := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	m := meter.Meter{
+		Key:           "meter-sum",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	now := time.Now().UTC()
+	bucket := now.Add(-4 * time.Hour).Truncate(time.Hour)
+
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(5*time.Minute), `{"value": 2}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(10*time.Minute), `{"value": 7}`, now),
+	)
+
+	// given:
+	// - a healthy view (created, refreshed, even backfilled) that was never stamped: the
+	//   exact state a leader crash between backfill and MODIFY COMMENT leaves behind
+	mv := createMeterCacheMV{
+		Database:        s.Database,
+		EventsTableName: e2eEventsTable,
+		Namespace:       namespace,
+		Meter:           m,
+		Grain:           CacheGrainHour,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+	}
+
+	createSQL, err := mv.toSQL()
+	s.NoError(err)
+	s.NoError(s.ClickHouse.Exec(ctx, createSQL))
+
+	qualifiedView := getTableName(s.Database, mv.name())
+	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+
+	backfillSQL, err := meterCacheBackfill{
+		Database:        s.Database,
+		EventsTableName: e2eEventsTable,
+		Namespace:       namespace,
+		Meter:           m,
+		Grain:           CacheGrainHour,
+		MinimumUsageAge: time.Hour,
+	}.toSQL()
+	s.NoError(err)
+	s.NoError(s.ClickHouse.Exec(ctx, backfillSQL))
+
+	from := bucket
+	to := now.Truncate(time.Hour).Add(time.Hour)
+
+	// then:
+	// - the cached read refuses the unstamped view and serves live (correct values via
+	//   the raw table)
+	c.logs.Reset()
+
+	rows, err := c.QueryMeter(ctx, namespace, m, streaming.QueryParams{From: &from, To: &to, Cachable: true})
+	s.NoError(err)
+	s.Contains(c.logs.String(), "reason=backfill_unstamped")
+	s.Equal(float64(9), s.totalValue(rows))
+
+	// when:
+	// - the stamp lands (what EnsureMeterCache does last)
+	metadata, err := mv.metadata()
+	s.NoError(err)
+	metadata.BackfilledAt = lo.ToPtr(time.Now().UTC().Truncate(time.Second))
+
+	comment, err := metadata.marshal()
+	s.NoError(err)
+	s.NoError(s.ClickHouse.Exec(ctx, fmt.Sprintf("ALTER TABLE %s MODIFY COMMENT %s", qualifiedView, sqlStringLiteral(comment))))
+
+	// then:
+	// - the same query is now served from the cache with identical values
+	live, cached := s.queryBothPaths(ctx, c, namespace, m, streaming.QueryParams{From: &from, To: &to})
+	s.Equal(float64(9), s.totalValue(live))
+	s.Equal(float64(9), s.totalValue(cached))
+}
+
+// TestHorizonBucketParity is the G5 regression: with events in every hour bucket up to
+// now, the cached read must be row-for-row equal with live across the cache horizon —
+// the epsilon bucket (one grain below the horizon) and everything above it are served by
+// the live post leg, everything below by the cache leg, and the seams must be invisible
+// in the result.
+func (s *MeterCacheCHTestSuite) TestHorizonBucketParity() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-horizon"
+		eventType = "api-calls"
+	)
+
+	c := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	m := meter.Meter{
+		Key:           "meter-sum",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	now := time.Now().UTC()
+
+	// One event in every hour bucket of the last six hours with distinct powers of two:
+	// any bucket lost or double-counted at the cache/live seam changes the total to a
+	// value no other combination of buckets can produce.
+	events := make([]streaming.RawEvent, 0, 6)
+	for i := 1; i <= 6; i++ {
+		bucket := now.Add(-time.Duration(i) * time.Hour).Truncate(time.Hour)
+		events = append(events, rawCacheTestEvent(
+			namespace, eventType, "subject-1",
+			bucket.Add(30*time.Minute),
+			fmt.Sprintf(`{"value": %d}`, 1<<i),
+			now,
+		))
+	}
+	s.insertRawEvents(ctx, events...)
+
+	s.deployMeterCacheMV(ctx, createMeterCacheMV{
+		Database:        s.Database,
+		EventsTableName: e2eEventsTable,
+		Namespace:       namespace,
+		Meter:           m,
+		Grain:           CacheGrainHour,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+	})
+
+	from := now.Add(-6 * time.Hour).Truncate(time.Hour)
+	to := now.Truncate(time.Hour).Add(time.Hour)
+
+	// then:
+	// - windowed rows match bucket by bucket across the horizon
+	live, cached := s.queryBothPaths(ctx, c, namespace, m, streaming.QueryParams{
+		From:       &from,
+		To:         &to,
+		WindowSize: lo.ToPtr(meter.WindowSizeHour),
+	})
+	s.Len(live, 6)
+	s.ElementsMatch(live, cached)
+
+	// then:
+	// - the total across the horizon equals the exact sum of all six buckets
+	live, cached = s.queryBothPaths(ctx, c, namespace, m, streaming.QueryParams{From: &from, To: &to})
+	s.Equal(float64(126), s.totalValue(live))
+	s.Equal(float64(126), s.totalValue(cached))
+}
+
+// TestNewestWinsRecomputedBucket is the 15/5/3 newest-wins regression from the R4 live
+// demo, driven through the real machinery: a bucket is cached at sum 15, then the
+// underlying events are rewritten twice (delete + reinsert with fresh stored_at, so each
+// refresh recomputes and re-appends the bucket). Every read must return exactly the
+// newest recompute — 5 then 3 — never 20/23 (summing appended versions, the
+// AggregatingMergeTree failure mode the design rejected) and never a stale 15/5.
+func (s *MeterCacheCHTestSuite) TestNewestWinsRecomputedBucket() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-newest-wins"
+		eventType = "api-calls"
+	)
+
+	c := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	m := meter.Meter{
+		Key:           "meter-sum",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	now := time.Now().UTC()
+	bucket := now.Add(-4 * time.Hour).Truncate(time.Hour)
+
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(5*time.Minute), `{"value": 7}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(10*time.Minute), `{"value": 8}`, now),
+	)
+
+	mv := createMeterCacheMV{
+		Database:        s.Database,
+		EventsTableName: e2eEventsTable,
+		Namespace:       namespace,
+		Meter:           m,
+		Grain:           CacheGrainHour,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+	}
+	s.deployMeterCacheMV(ctx, mv)
+
+	from := bucket
+	to := now.Truncate(time.Hour).Add(time.Hour)
+	totalParams := streaming.QueryParams{From: &from, To: &to}
+
+	qualifiedView := getTableName(s.Database, mv.name())
+
+	rewriteBucketEvents := func(value int) {
+		// Lightweight delete + reinsert models history rewrites (dedupe, GDPR erasure,
+		// corrections); the fresh stored_at makes the next refresh recompute the bucket.
+		s.NoError(s.ClickHouse.Exec(ctx,
+			fmt.Sprintf("DELETE FROM %s WHERE namespace = ?", getTableName(s.Database, e2eEventsTable)),
+			namespace,
+		))
+
+		s.insertRawEvents(ctx,
+			rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(15*time.Minute), fmt.Sprintf(`{"value": %d}`, value), time.Now().UTC()),
+		)
+
+		s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM REFRESH VIEW "+qualifiedView))
+		s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM WAIT VIEW "+qualifiedView))
+	}
+
+	// then: the initial state reads 15 on both paths
+	live, cached := s.queryBothPaths(ctx, c, namespace, m, totalParams)
+	s.Equal(float64(15), s.totalValue(live))
+	s.Equal(float64(15), s.totalValue(cached))
+
+	// when/then: first recompute — 5, not 20 (15+5 would mean appended versions summed)
+	rewriteBucketEvents(5)
+
+	live, cached = s.queryBothPaths(ctx, c, namespace, m, totalParams)
+	s.Equal(float64(5), s.totalValue(live))
+	s.Equal(float64(5), s.totalValue(cached))
+
+	// when/then: second recompute — 3, not 23/8/15
+	rewriteBucketEvents(3)
+
+	live, cached = s.queryBothPaths(ctx, c, namespace, m, totalParams)
+	s.Equal(float64(3), s.totalValue(live))
+	s.Equal(float64(3), s.totalValue(cached))
+
+	// then:
+	// - all three appended versions coexist in storage and FINAL collapses them to the
+	//   newest, proving the reads above picked by version, not by luck of a merge
+	var versions, finalRows uint64
+	s.NoError(s.ClickHouse.QueryRow(ctx,
+		fmt.Sprintf("SELECT count() FROM %s WHERE namespace = ? AND windowstart = ?", getTableName(s.Database, meterCacheTableName)),
+		namespace, bucket,
+	).Scan(&versions))
+	s.NoError(s.ClickHouse.QueryRow(ctx,
+		fmt.Sprintf("SELECT count() FROM %s FINAL WHERE namespace = ? AND windowstart = ?", getTableName(s.Database, meterCacheTableName)),
+		namespace, bucket,
+	).Scan(&finalRows))
+	s.GreaterOrEqual(versions, uint64(1))
+	s.Equal(uint64(1), finalRows)
+}

--- a/openmeter/streaming/clickhouse/meter_cache_regression_ch_test.go
+++ b/openmeter/streaming/clickhouse/meter_cache_regression_ch_test.go
@@ -433,6 +433,19 @@ func (s *MeterCacheCHTestSuite) TestStaleMarkerKeepsReaderLive() {
 
 	qualifiedView := getTableName(s.Database, mv.name())
 
+	// The deploy helper stamps backfilled_at at the wall clock, but the fabricated
+	// timeline below predates it by hours; the stamp is backdated with the rest so the
+	// aged marker cannot read as healed-by-backfill (in production the ordering invariant
+	// holds naturally: markers are server-timestamped at insert, so created_at <
+	// backfilled_at implies the full-history backfill really saw the late events).
+	metadata, err := mv.metadata()
+	s.NoError(err)
+	metadata.BackfilledAt = lo.ToPtr(now.Add(-3 * time.Hour).Truncate(time.Second))
+
+	comment, err := metadata.marshal()
+	s.NoError(err)
+	s.NoError(s.ClickHouse.Exec(ctx, fmt.Sprintf("ALTER TABLE %s MODIFY COMMENT %s", qualifiedView, sqlStringLiteral(comment))))
+
 	// when:
 	// - refreshing stops (the outage begins)
 	s.NoError(s.ClickHouse.Exec(ctx, "SYSTEM STOP VIEW "+qualifiedView))
@@ -850,4 +863,165 @@ func (s *MeterCacheCHTestSuite) TestNewestWinsRecomputedBucket() {
 	).Scan(&finalRows))
 	s.GreaterOrEqual(versions, uint64(1))
 	s.Equal(uint64(1), finalRows)
+}
+
+// TestNamespaceFoldCollisionServesLive pins the namespace half of the view identity
+// check: MV names fold the namespace to fnv32a 8-hex, so two namespaces can resolve to
+// the same view name, and a same-shape, same-key meter in the colliding namespace matches
+// the view's meter_key/event_type/meter_hash metadata perfectly. The gate must still
+// refuse the view for the non-owner namespace: its cache leg filters rows on the querying
+// namespace and would match nothing, silently zeroing all settled history.
+//
+// The two namespaces are a precomputed fnv32a collision (both fold to 60e0a981), asserted
+// below so the constant pair cannot silently rot.
+//
+// Watched RED with the guard reverted: removing the Namespace comparison from
+// cacheEligibility's foreign-view check makes the non-owner query eligible — the
+// view_foreign log assertion goes red first, and the total reads 11 (live tail only, the
+// settled bucket zeroed by the empty cache leg) instead of 16.
+func (s *MeterCacheCHTestSuite) TestNamespaceFoldCollisionServesLive() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		nsOwner   = "cache-ns-collision-658829"
+		nsOther   = "cache-ns-collision-1558496"
+		eventType = "api-calls"
+	)
+
+	c := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	m := meter.Meter{
+		Key:           "meter-sum",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	// Sanity: the namespaces really collide on the folded view name (meterHash excludes
+	// the namespace, so identical shapes complete the collision).
+	s.Equal(mvName(nsOwner, meterHash(m, CacheGrainHour)), mvName(nsOther, meterHash(m, CacheGrainHour)))
+
+	now := time.Now().UTC()
+	bucket := now.Add(-4 * time.Hour).Truncate(time.Hour)
+
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(nsOwner, eventType, "subject-1", bucket.Add(5*time.Minute), `{"value": 2}`, now),
+		rawCacheTestEvent(nsOwner, eventType, "subject-1", bucket.Add(10*time.Minute), `{"value": 7}`, now),
+		rawCacheTestEvent(nsOther, eventType, "subject-1", bucket.Add(15*time.Minute), `{"value": 5}`, now),
+		rawCacheTestEvent(nsOther, eventType, "subject-1", now.Add(-30*time.Minute), `{"value": 11}`, now),
+	)
+
+	// given:
+	// - the shared-name view is deployed for the owner namespace only (in production the
+	//   reconciler's same-name conflict resolution guarantees a single owner)
+	s.deployMeterCacheMV(ctx, createMeterCacheMV{
+		Database:        s.Database,
+		EventsTableName: e2eEventsTable,
+		Namespace:       nsOwner,
+		Meter:           m,
+		Grain:           CacheGrainHour,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+	})
+
+	from := bucket
+	to := now.Truncate(time.Hour).Add(time.Hour)
+	totalParams := streaming.QueryParams{From: &from, To: &to}
+
+	// then:
+	// - the owner namespace serves from the cache with full parity
+	live, cached := s.queryBothPaths(ctx, c, nsOwner, m, totalParams)
+	s.Equal(float64(9), s.totalValue(live))
+	s.Equal(float64(9), s.totalValue(cached))
+
+	// then:
+	// - the colliding namespace is refused (foreign view) and served live, seeing its own
+	//   settled bucket instead of an empty cache leg
+	c.logs.Reset()
+
+	rows, err := c.QueryMeter(ctx, nsOther, m, streaming.QueryParams{From: &from, To: &to, Cachable: true})
+	s.NoError(err)
+	s.Contains(c.logs.String(), "reason=view_foreign")
+	s.Equal(float64(16), s.totalValue(rows))
+}
+
+// TestMarkerOlderThanBackfillIsHealed pins the backfill arm of the marker heal rule: a
+// marker written before the view's full-history backfill started is provably covered by
+// it — the backfill re-aggregated every settled bucket, late events included — so the
+// marked range must serve from the cache no matter how far the latest refresh has
+// advanced past the marker's refresh-heal window. Without this arm, heal status regresses
+// with time: any marker older than refreshStart − healBound reads as unhealed forever,
+// forcing the marked range live until the marker's 7 day TTL even after a re-backfill
+// recomputed it.
+//
+// Watched RED with the guard reverted: removing the `created_at >= backfilled_at` clause
+// from meterCacheMarkerOverlapQuery.toSQL makes the hour-old marker unhealed (it is far
+// outside the 20m refresh heal window) and the cached run below logs the
+// unhealed_markers fallback, failing queryBothPaths.
+func (s *MeterCacheCHTestSuite) TestMarkerOlderThanBackfillIsHealed() {
+	t := s.T()
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-marker-backfill-heal"
+		eventType = "api-calls"
+	)
+
+	c := s.newCacheConnector(ctx, CacheConfig{
+		Enabled:         true,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+		WindowSize:      CacheGrainHour,
+	})
+
+	m := meter.Meter{
+		Key:           "meter-sum",
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+	}
+
+	now := time.Now().UTC()
+	bucket := now.Add(-4 * time.Hour).Truncate(time.Hour)
+
+	s.insertRawEvents(ctx,
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(5*time.Minute), `{"value": 2}`, now),
+		rawCacheTestEvent(namespace, eventType, "subject-1", bucket.Add(10*time.Minute), `{"value": 7}`, now),
+	)
+
+	// given:
+	// - the view deployed and backfilled now, with a marker created an hour before the
+	//   backfill (production markers carry server-side timestamps; the explicit created_at
+	//   only backdates it into the covered-by-backfill regime)
+	s.deployMeterCacheMV(ctx, createMeterCacheMV{
+		Database:        s.Database,
+		EventsTableName: e2eEventsTable,
+		Namespace:       namespace,
+		Meter:           m,
+		Grain:           CacheGrainHour,
+		RefreshInterval: 10 * time.Minute,
+		MinimumUsageAge: time.Hour,
+	})
+
+	s.NoError(s.ClickHouse.Exec(ctx,
+		fmt.Sprintf("INSERT INTO %s (namespace, event_type, window_lo, window_hi, created_at) VALUES (?, ?, ?, ?, ?)",
+			getTableName(s.Database, meterCacheInvalidationsTableName)),
+		namespace, eventType, bucket, bucket.Add(time.Hour), now.Add(-time.Hour),
+	))
+
+	from := bucket
+	to := now.Truncate(time.Hour).Add(time.Hour)
+
+	// then:
+	// - the marked range still serves from the cache (queryBothPaths fails on any live
+	//   fallback) with live-equal values
+	live, cached := s.queryBothPaths(ctx, c, namespace, m, streaming.QueryParams{From: &from, To: &to})
+	s.Equal(float64(9), s.totalValue(live))
+	s.Equal(float64(9), s.totalValue(cached))
 }

--- a/openmeter/streaming/clickhouse/meter_expressions.go
+++ b/openmeter/streaming/clickhouse/meter_expressions.go
@@ -276,6 +276,15 @@ var reservedMeterSQLAliases = map[string]struct{}{
 	"group_by":    {},
 	"created_at":  {},
 	"value":       {},
+	// value_count is the one om_meter_cache combine column not covered by the suffix
+	// families below (it ends in _count)
+	"value_count": {},
+	// aliases the cached read path's leg subqueries claim: the grain-bucket column and
+	// the AVG newest-wins pick not covered by the suffix families; a group-by key with
+	// one of these names would shadow the outer re-window / combine expressions (the
+	// remaining picked_* aliases end in _value or _state and are covered below)
+	"windowstart_bucket": {},
+	"picked_value_count": {},
 }
 
 // reservedAliasCheck rejects meter group-by keys (the meter's configured JSON dimensions,

--- a/openmeter/streaming/clickhouse/meter_expressions.go
+++ b/openmeter/streaming/clickhouse/meter_expressions.go
@@ -144,11 +144,18 @@ func valueExprPlain(m meterpkg.Meter, dataColumn, timeColumn string, enableDecim
 //     is wrong; the reader computes sum(sum_value) / sum(value_count) at the end.
 //   - UNIQUE_COUNT stores uniqExactState: distinct counts of two buckets cannot be summed
 //     (shared values would double count), the states must be merged for an exact result.
-//   - LATEST stores argMaxState(value, time) so the reader picks the newest event across
-//     cached and live legs instead of comparing per-leg collapsed values.
+//
+// LATEST is not a valid input here: it is excluded from the cache entirely (see
+// meterCacheStaticReject) because it only ever needs the single newest value in the
+// queried window, so there is no re-aggregation of settled history for a cached combine
+// form to save.
 //
 // The cache stores decimals only (the cache read gate requires EnableDecimalPrecision), so
 // numeric expressions always use the Decimal128 leg.
+//
+// timeColumn is unused now that LATEST (the only combine-form case that needed event time)
+// is excluded; the parameter is kept to match valueExprPlain's signature since both
+// builders are called side by side from the same sites for a given aggregation.
 func valueExprsCombine(m meterpkg.Meter, dataColumn, timeColumn string) ([]string, error) {
 	switch m.Aggregation {
 	case meterpkg.MeterAggregationSum,
@@ -156,8 +163,7 @@ func valueExprsCombine(m meterpkg.Meter, dataColumn, timeColumn string) ([]strin
 		meterpkg.MeterAggregationMin,
 		meterpkg.MeterAggregationMax,
 		meterpkg.MeterAggregationUniqueCount,
-		meterpkg.MeterAggregationCount,
-		meterpkg.MeterAggregationLatest:
+		meterpkg.MeterAggregationCount:
 	default:
 		return nil, models.NewGenericValidationError(
 			fmt.Errorf("invalid aggregation type: %s", m.Aggregation),
@@ -188,8 +194,12 @@ func valueExprsCombine(m meterpkg.Meter, dataColumn, timeColumn string) ([]strin
 		return []string{fmt.Sprintf("uniqExactState(%s) AS uniq_state", rawStringValueExpr(dataColumn, *m.ValueProperty))}, nil
 	case meterpkg.MeterAggregationCount:
 		return []string{"count(*) AS count_value"}, nil
-	default: // meterpkg.MeterAggregationLatest, the first switch rejected everything else
-		return []string{fmt.Sprintf("argMaxState(%s, %s) AS latest_state", numericValueExpr(dataColumn, *m.ValueProperty, true), timeColumn)}, nil
+	default:
+		// Unreachable: the first switch above already rejected every aggregation not
+		// handled by one of the cases here.
+		return nil, models.NewGenericValidationError(
+			fmt.Errorf("invalid aggregation type: %s", m.Aggregation),
+		)
 	}
 }
 

--- a/openmeter/streaming/clickhouse/meter_expressions.go
+++ b/openmeter/streaming/clickhouse/meter_expressions.go
@@ -1,0 +1,307 @@
+package clickhouse
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/huandu/go-sqlbuilder"
+
+	meterpkg "github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// This file is the single source of truth for the SQL expressions shared between the live
+// meter query (meter_query.go) and the meter cache (per-meter refreshable materialized
+// views, their backfill inserts, and the cached read legs). The cache must serve rows that
+// are byte-equal to what the live query would return, so window bucketing, value
+// extraction, and group-by dimensions have to be built from these builders on both paths;
+// duplicating the expressions would let cached and live results drift apart silently.
+
+// windowExprs returns the windowstart/windowend SELECT expressions bucketing timeExpr into
+// windowSize windows, evaluated in the tz timezone (an IANA name embedded as a literal).
+func windowExprs(windowSize meterpkg.WindowSize, timeExpr string, tz string) ([]string, error) {
+	switch windowSize {
+	case meterpkg.WindowSizeMinute:
+		return []string{
+			fmt.Sprintf("tumbleStart(%s, toIntervalMinute(1), '%s') AS windowstart", timeExpr, tz),
+			fmt.Sprintf("tumbleEnd(%s, toIntervalMinute(1), '%s') AS windowend", timeExpr, tz),
+		}, nil
+
+	case meterpkg.WindowSizeHour:
+		return []string{
+			fmt.Sprintf("tumbleStart(%s, toIntervalHour(1), '%s') AS windowstart", timeExpr, tz),
+			fmt.Sprintf("tumbleEnd(%s, toIntervalHour(1), '%s') AS windowend", timeExpr, tz),
+		}, nil
+
+	case meterpkg.WindowSizeDay:
+		return []string{
+			fmt.Sprintf("tumbleStart(%s, toIntervalDay(1), '%s') AS windowstart", timeExpr, tz),
+			"windowstart + toIntervalDay(1) AS windowend",
+		}, nil
+
+	case meterpkg.WindowSizeMonth:
+		return []string{
+			// We need to convert the tumbleStart and tumbleEnd to DateTime, as otherwise we got a Date type. Given
+			// we are scanning the result into a time.Time, we will end up with the correct date in UTC. In case the timezone
+			// is not UTC, the returned values will be offset by the timezone difference.
+			//
+			// e.g.:
+			//  if timezone is Europe/Budapest, then if we are not casting to DateTime, then:
+			// 	 tumbleStart will return 2025-01-01 which will become 2025-01-01 00:00:00 in UTC
+			//   this is wrong, as in CET this is 2024-12-31 23:00:00
+			//  if we are casting to DateTime, then:
+			// 	 tumbleStart will return 2025-01-01 00:00:00 in Europe/Budapest
+
+			// Other queries are not affected by this, as for anything < Month, the result is always a DateTime (most probably due to
+			// DST changes).
+			fmt.Sprintf("toDateTime(tumbleStart(%s, toIntervalMonth(1), '%s'), '%s') AS windowstart", timeExpr, tz, tz),
+			fmt.Sprintf("toDateTime(tumbleEnd(%s, toIntervalMonth(1), '%s'), '%s') AS windowend", timeExpr, tz, tz),
+		}, nil
+
+	default:
+		return nil, models.NewGenericValidationError(
+			fmt.Errorf("invalid window size type: %s", windowSize),
+		)
+	}
+}
+
+// rawStringValueExpr extracts the meter's value property from the event JSON payload as a
+// string, mapping an explicit JSON null (which JSON_VALUE yields as the literal 'null') to
+// SQL NULL so aggregations skip it. UNIQUE_COUNT aggregates over exactly this expression:
+// distinctness is defined on the raw string representation of the property, never on a
+// numeric conversion of it.
+func rawStringValueExpr(dataColumn, valueProperty string) string {
+	return fmt.Sprintf("nullIf(JSON_VALUE(%s, '%s'), 'null')", dataColumn, escapeJSONPathLiteral(valueProperty))
+}
+
+// numericValueExpr extracts the meter's value property from the event JSON payload as a
+// number. The decimal and float legs intentionally produce different SQL types
+// (Nullable(Decimal128(19)) vs Nullable(Float64)) with no UNION supertype; the meter cache
+// stores decimals only, which is why the cache read gate requires EnableDecimalPrecision.
+func numericValueExpr(dataColumn, valueProperty string, enableDecimalPrecision bool) string {
+	if enableDecimalPrecision {
+		return fmt.Sprintf("toDecimal128OrNull(%s, 19)", rawStringValueExpr(dataColumn, valueProperty))
+	}
+
+	// JSON_VALUE returns an empty string if the JSON Path is not found. With toFloat64OrNull we convert it to NULL so the aggregation function can handle it properly.
+	return fmt.Sprintf("ifNotFinite(toFloat64OrNull(JSON_VALUE(%s, '%s')), null)", dataColumn, escapeJSONPathLiteral(valueProperty))
+}
+
+// valueExprPlain returns the aggregated value SELECT expression (aliased AS value) exactly
+// as the live meter query emits it. The cached read path re-emits this shape on its outer
+// query so cached and live results stay byte-equal.
+func valueExprPlain(m meterpkg.Meter, dataColumn, timeColumn string, enableDecimalPrecision bool) (string, error) {
+	sqlAggregation := ""
+
+	switch m.Aggregation {
+	case meterpkg.MeterAggregationSum:
+		sqlAggregation = "sum"
+	case meterpkg.MeterAggregationAvg:
+		sqlAggregation = "avg"
+	case meterpkg.MeterAggregationMin:
+		sqlAggregation = "min"
+	case meterpkg.MeterAggregationMax:
+		sqlAggregation = "max"
+	case meterpkg.MeterAggregationUniqueCount:
+		// Use the uniqExact function if you absolutely need an exact result.
+		// See: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/uniqexact
+		sqlAggregation = "uniqExact"
+	case meterpkg.MeterAggregationCount:
+		sqlAggregation = "count"
+	case meterpkg.MeterAggregationLatest:
+		sqlAggregation = "argMax"
+	default:
+		return "", models.NewGenericValidationError(
+			fmt.Errorf("invalid aggregation type: %s", m.Aggregation),
+		)
+	}
+
+	if err := requireValueProperty(m); err != nil {
+		return "", err
+	}
+
+	switch m.Aggregation {
+	case meterpkg.MeterAggregationCount:
+		return fmt.Sprintf("%s(*) AS value", sqlAggregation), nil
+	case meterpkg.MeterAggregationUniqueCount:
+		return fmt.Sprintf("%s(%s) AS value", sqlAggregation, rawStringValueExpr(dataColumn, *m.ValueProperty)), nil
+	case meterpkg.MeterAggregationLatest:
+		return fmt.Sprintf("%s(%s, %s) AS value", sqlAggregation, numericValueExpr(dataColumn, *m.ValueProperty, enableDecimalPrecision), timeColumn), nil
+	default:
+		return fmt.Sprintf("%s(%s) AS value", sqlAggregation, numericValueExpr(dataColumn, *m.ValueProperty, enableDecimalPrecision)), nil
+	}
+}
+
+// valueExprsCombine returns the SELECT expressions that persist a meter's aggregation into
+// the om_meter_cache combine columns. Unlike the plain form, these shapes must compose
+// under a second aggregation pass: cached buckets are re-windowed against each other and
+// combined with an always-live tail leg, so a column holding an already-collapsed result
+// would be wrong to combine.
+//
+//   - SUM/MIN/MAX/COUNT re-aggregate with themselves (sum of sums, min of mins, ...).
+//   - AVG is stored as the sum + non-null value count pair because an average of averages
+//     is wrong; the reader computes sum(sum_value) / sum(value_count) at the end.
+//   - UNIQUE_COUNT stores uniqExactState: distinct counts of two buckets cannot be summed
+//     (shared values would double count), the states must be merged for an exact result.
+//   - LATEST stores argMaxState(value, time) so the reader picks the newest event across
+//     cached and live legs instead of comparing per-leg collapsed values.
+//
+// The cache stores decimals only (the cache read gate requires EnableDecimalPrecision), so
+// numeric expressions always use the Decimal128 leg.
+func valueExprsCombine(m meterpkg.Meter, dataColumn, timeColumn string) ([]string, error) {
+	switch m.Aggregation {
+	case meterpkg.MeterAggregationSum,
+		meterpkg.MeterAggregationAvg,
+		meterpkg.MeterAggregationMin,
+		meterpkg.MeterAggregationMax,
+		meterpkg.MeterAggregationUniqueCount,
+		meterpkg.MeterAggregationCount,
+		meterpkg.MeterAggregationLatest:
+	default:
+		return nil, models.NewGenericValidationError(
+			fmt.Errorf("invalid aggregation type: %s", m.Aggregation),
+		)
+	}
+
+	if err := requireValueProperty(m); err != nil {
+		return nil, err
+	}
+
+	switch m.Aggregation {
+	case meterpkg.MeterAggregationSum:
+		return []string{fmt.Sprintf("sum(%s) AS sum_value", numericValueExpr(dataColumn, *m.ValueProperty, true))}, nil
+	case meterpkg.MeterAggregationAvg:
+		valueExpr := numericValueExpr(dataColumn, *m.ValueProperty, true)
+
+		return []string{
+			fmt.Sprintf("sum(%s) AS sum_value", valueExpr),
+			// count(expr) counts non-null values only: events whose value property is
+			// missing or a JSON null must not inflate the AVG denominator.
+			fmt.Sprintf("count(%s) AS value_count", valueExpr),
+		}, nil
+	case meterpkg.MeterAggregationMin:
+		return []string{fmt.Sprintf("min(%s) AS min_value", numericValueExpr(dataColumn, *m.ValueProperty, true))}, nil
+	case meterpkg.MeterAggregationMax:
+		return []string{fmt.Sprintf("max(%s) AS max_value", numericValueExpr(dataColumn, *m.ValueProperty, true))}, nil
+	case meterpkg.MeterAggregationUniqueCount:
+		return []string{fmt.Sprintf("uniqExactState(%s) AS uniq_state", rawStringValueExpr(dataColumn, *m.ValueProperty))}, nil
+	case meterpkg.MeterAggregationCount:
+		return []string{"count(*) AS count_value"}, nil
+	default: // meterpkg.MeterAggregationLatest, the first switch rejected everything else
+		return []string{fmt.Sprintf("argMaxState(%s, %s) AS latest_state", numericValueExpr(dataColumn, *m.ValueProperty, true), timeColumn)}, nil
+	}
+}
+
+// requireValueProperty guards the *m.ValueProperty dereferences in the value expression
+// builders. Meter validation guarantees a value property for every non-COUNT aggregation,
+// but SQL generation must degrade to an error rather than panic when handed a meter that
+// bypassed validation (e.g. loaded from a store that predates the rule).
+func requireValueProperty(m meterpkg.Meter) error {
+	if m.Aggregation != meterpkg.MeterAggregationCount && m.ValueProperty == nil {
+		return models.NewGenericValidationError(
+			fmt.Errorf("meter value property is required for %s aggregation", m.Aggregation),
+		)
+	}
+
+	return nil
+}
+
+// groupByJSONExpr returns the expression extracting a group-by dimension from the event
+// JSON payload at jsonPath (unescaped; escaping happens here). The live query uses it for
+// both SELECT dimensions and FilterGroupBy predicates, and the cache MV uses it for the
+// group_by array, so cached dimension values match live ones byte-for-byte.
+func groupByJSONExpr(dataColumn, jsonPath string) string {
+	return fmt.Sprintf("JSON_VALUE(%s, '%s')", dataColumn, escapeJSONPathLiteral(jsonPath))
+}
+
+// groupBySelectExprs returns the SELECT expressions and GROUP BY columns for the requested
+// group-by keys as the live meter query emits them.
+//
+// subject and customer_id are top-level event columns, not JSON dimensions: subject is
+// selected directly, while customer_id is only added to GROUP BY because its SELECT
+// expression (a subject-to-customer map lookup) is attached separately by
+// selectCustomerIdColumn. Every other key is extracted from the JSON payload at the
+// meter's configured path and aliased to the group-by key.
+func groupBySelectExprs(groupBy []string, meterGroupBy map[string]string, subjectColumn, dataColumn string) ([]string, []string) {
+	var selectColumns, groupByColumns []string
+
+	for _, groupByKey := range groupBy {
+		// Subject is a special case as it's a top level column
+		if groupByKey == "subject" {
+			selectColumns = append(selectColumns, subjectColumn)
+			groupByColumns = append(groupByColumns, "subject")
+			continue
+		}
+
+		// Customer ID is a special case as it's a top level column
+		if groupByKey == "customer_id" {
+			groupByColumns = append(groupByColumns, "customer_id")
+			continue
+		}
+
+		// Group by columns need to be parsed from the JSON data
+		groupByColumn := sqlbuilder.Escape(groupByKey)
+
+		selectColumns = append(selectColumns, fmt.Sprintf("%s as %s", groupByJSONExpr(dataColumn, meterGroupBy[groupByKey]), groupByColumn))
+		groupByColumns = append(groupByColumns, groupByColumn)
+	}
+
+	return selectColumns, groupByColumns
+}
+
+// reservedMeterSQLAliases lists the exact identifiers the generated meter SQL claims for
+// itself: the om_events source columns plus the om_meter_cache columns and query output
+// aliases. Meter group-by keys become SELECT aliases in generated SQL, and ClickHouse
+// resolves SELECT aliases inside WHERE — a group-by key shadowing a source column would
+// silently neutralize generated filters (an alias named namespace, for example, would
+// defeat tenant isolation without any error).
+var reservedMeterSQLAliases = map[string]struct{}{
+	// om_events columns
+	"namespace":    {},
+	"id":           {},
+	"type":         {},
+	"subject":      {},
+	"source":       {},
+	"time":         {},
+	"data":         {},
+	"ingested_at":  {},
+	"stored_at":    {},
+	"store_row_id": {},
+	// om_meter_cache columns and meter query output aliases
+	"meter_key":   {},
+	"meter_hash":  {},
+	"windowstart": {},
+	"windowend":   {},
+	"group_by":    {},
+	"created_at":  {},
+	"value":       {},
+}
+
+// reservedAliasCheck rejects meter group-by keys (the meter's configured JSON dimensions,
+// not a query's group-by selection) that would collide with identifiers the generated
+// cache SQL depends on. Beyond the exact reserved names, the *_value and *_state suffix
+// families are reserved because they are the om_meter_cache combine column families.
+//
+// Callers must treat a non-nil error as "this meter cannot be cached" — skip the meter and
+// read it live — never as a hard failure: the live query path tolerates these keys today
+// and existing meters must keep working when the cache is enabled.
+func reservedAliasCheck(groupByKeys []string) error {
+	var offending []string
+
+	for _, key := range groupByKeys {
+		_, reserved := reservedMeterSQLAliases[key]
+		if reserved || strings.HasSuffix(key, "_value") || strings.HasSuffix(key, "_state") {
+			offending = append(offending, key)
+		}
+	}
+
+	if len(offending) == 0 {
+		return nil
+	}
+
+	// Sorted so the error is deterministic when keys come from map iteration
+	slices.Sort(offending)
+
+	return fmt.Errorf("meter group by keys collide with reserved SQL aliases: %s", strings.Join(offending, ", "))
+}

--- a/openmeter/streaming/clickhouse/meter_expressions_test.go
+++ b/openmeter/streaming/clickhouse/meter_expressions_test.go
@@ -195,11 +195,6 @@ func TestValueExprsCombine(t *testing.T) {
 			aggregation: meter.MeterAggregationUniqueCount,
 			want:        []string{"uniqExactState(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null')) AS uniq_state"},
 		},
-		{
-			name:        "latest stores a mergeable argMax state over event time",
-			aggregation: meter.MeterAggregationLatest,
-			want:        []string{"argMaxState(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19), om_events.time) AS latest_state"},
-		},
 	}
 
 	for _, tt := range tests {
@@ -218,6 +213,13 @@ func TestValueExprsCombine(t *testing.T) {
 	t.Run("invalid aggregation", func(t *testing.T) {
 		_, err := valueExprsCombine(meter.Meter{Aggregation: meter.MeterAggregation("MEDIAN")}, "om_events.data", "om_events.time")
 		require.ErrorContains(t, err, "invalid aggregation type: MEDIAN")
+	})
+
+	t.Run("latest is not a valid combine-form aggregation", func(t *testing.T) {
+		// LATEST is excluded from the cache entirely (meterCacheStaticReject); the combine
+		// form must never be generated for it.
+		_, err := valueExprsCombine(meter.Meter{Aggregation: meter.MeterAggregationLatest, ValueProperty: lo.ToPtr("$.value")}, "om_events.data", "om_events.time")
+		require.ErrorContains(t, err, "invalid aggregation type: LATEST")
 	})
 
 	t.Run("missing value property", func(t *testing.T) {

--- a/openmeter/streaming/clickhouse/meter_expressions_test.go
+++ b/openmeter/streaming/clickhouse/meter_expressions_test.go
@@ -1,0 +1,303 @@
+package clickhouse
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+)
+
+func TestWindowExprs(t *testing.T) {
+	tests := []struct {
+		name       string
+		windowSize meter.WindowSize
+		tz         string
+		want       []string
+	}{
+		{
+			name:       "minute",
+			windowSize: meter.WindowSizeMinute,
+			tz:         "UTC",
+			want: []string{
+				"tumbleStart(om_events.time, toIntervalMinute(1), 'UTC') AS windowstart",
+				"tumbleEnd(om_events.time, toIntervalMinute(1), 'UTC') AS windowend",
+			},
+		},
+		{
+			name:       "hour",
+			windowSize: meter.WindowSizeHour,
+			tz:         "UTC",
+			want: []string{
+				"tumbleStart(om_events.time, toIntervalHour(1), 'UTC') AS windowstart",
+				"tumbleEnd(om_events.time, toIntervalHour(1), 'UTC') AS windowend",
+			},
+		},
+		{
+			name:       "day derives windowend from windowstart",
+			windowSize: meter.WindowSizeDay,
+			tz:         "Asia/Shanghai",
+			want: []string{
+				"tumbleStart(om_events.time, toIntervalDay(1), 'Asia/Shanghai') AS windowstart",
+				"windowstart + toIntervalDay(1) AS windowend",
+			},
+		},
+		{
+			name:       "month keeps the toDateTime cast",
+			windowSize: meter.WindowSizeMonth,
+			tz:         "Europe/Budapest",
+			want: []string{
+				"toDateTime(tumbleStart(om_events.time, toIntervalMonth(1), 'Europe/Budapest'), 'Europe/Budapest') AS windowstart",
+				"toDateTime(tumbleEnd(om_events.time, toIntervalMonth(1), 'Europe/Budapest'), 'Europe/Budapest') AS windowend",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := windowExprs(tt.windowSize, "om_events.time", tt.tz)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("invalid window size", func(t *testing.T) {
+		_, err := windowExprs(meter.WindowSize("SECOND"), "om_events.time", "UTC")
+		require.ErrorContains(t, err, "invalid window size type: SECOND")
+	})
+}
+
+func TestValueExprPlain(t *testing.T) {
+	tests := []struct {
+		name                   string
+		aggregation            meter.MeterAggregation
+		enableDecimalPrecision bool
+		want                   string
+	}{
+		{
+			name:        "count ignores value property",
+			aggregation: meter.MeterAggregationCount,
+			want:        "count(*) AS value",
+		},
+		{
+			name:        "unique count aggregates the raw string regardless of decimal precision",
+			aggregation: meter.MeterAggregationUniqueCount,
+			want:        "uniqExact(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null')) AS value",
+		},
+		{
+			name:                   "unique count with decimal precision",
+			aggregation:            meter.MeterAggregationUniqueCount,
+			enableDecimalPrecision: true,
+			want:                   "uniqExact(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null')) AS value",
+		},
+		{
+			name:        "latest float",
+			aggregation: meter.MeterAggregationLatest,
+			want:        "argMax(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null), om_events.time) AS value",
+		},
+		{
+			name:                   "latest decimal",
+			aggregation:            meter.MeterAggregationLatest,
+			enableDecimalPrecision: true,
+			want:                   "argMax(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19), om_events.time) AS value",
+		},
+		{
+			name:        "sum float",
+			aggregation: meter.MeterAggregationSum,
+			want:        "sum(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value",
+		},
+		{
+			name:                   "sum decimal",
+			aggregation:            meter.MeterAggregationSum,
+			enableDecimalPrecision: true,
+			want:                   "sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS value",
+		},
+		{
+			name:                   "avg decimal",
+			aggregation:            meter.MeterAggregationAvg,
+			enableDecimalPrecision: true,
+			want:                   "avg(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS value",
+		},
+		{
+			name:        "min float",
+			aggregation: meter.MeterAggregationMin,
+			want:        "min(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value",
+		},
+		{
+			name:        "max float",
+			aggregation: meter.MeterAggregationMax,
+			want:        "max(ifNotFinite(toFloat64OrNull(JSON_VALUE(om_events.data, '$.value')), null)) AS value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := meter.Meter{Aggregation: tt.aggregation}
+			if tt.aggregation != meter.MeterAggregationCount {
+				m.ValueProperty = lo.ToPtr("$.value")
+			}
+
+			got, err := valueExprPlain(m, "om_events.data", "om_events.time", tt.enableDecimalPrecision)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("invalid aggregation", func(t *testing.T) {
+		_, err := valueExprPlain(meter.Meter{Aggregation: meter.MeterAggregation("MEDIAN")}, "om_events.data", "om_events.time", false)
+		require.ErrorContains(t, err, "invalid aggregation type: MEDIAN")
+	})
+
+	t.Run("missing value property", func(t *testing.T) {
+		_, err := valueExprPlain(meter.Meter{Aggregation: meter.MeterAggregationSum}, "om_events.data", "om_events.time", false)
+		require.ErrorContains(t, err, "meter value property is required for SUM aggregation")
+	})
+}
+
+func TestValueExprsCombine(t *testing.T) {
+	tests := []struct {
+		name        string
+		aggregation meter.MeterAggregation
+		want        []string
+	}{
+		{
+			name:        "sum",
+			aggregation: meter.MeterAggregationSum,
+			want:        []string{"sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS sum_value"},
+		},
+		{
+			name:        "count",
+			aggregation: meter.MeterAggregationCount,
+			want:        []string{"count(*) AS count_value"},
+		},
+		{
+			name:        "avg stores the sum plus non-null value count pair",
+			aggregation: meter.MeterAggregationAvg,
+			want: []string{
+				"sum(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS sum_value",
+				"count(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS value_count",
+			},
+		},
+		{
+			name:        "min",
+			aggregation: meter.MeterAggregationMin,
+			want:        []string{"min(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS min_value"},
+		},
+		{
+			name:        "max",
+			aggregation: meter.MeterAggregationMax,
+			want:        []string{"max(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19)) AS max_value"},
+		},
+		{
+			name:        "unique count stores a mergeable state over the raw string",
+			aggregation: meter.MeterAggregationUniqueCount,
+			want:        []string{"uniqExactState(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null')) AS uniq_state"},
+		},
+		{
+			name:        "latest stores a mergeable argMax state over event time",
+			aggregation: meter.MeterAggregationLatest,
+			want:        []string{"argMaxState(toDecimal128OrNull(nullIf(JSON_VALUE(om_events.data, '$.value'), 'null'), 19), om_events.time) AS latest_state"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := meter.Meter{Aggregation: tt.aggregation}
+			if tt.aggregation != meter.MeterAggregationCount {
+				m.ValueProperty = lo.ToPtr("$.value")
+			}
+
+			got, err := valueExprsCombine(m, "om_events.data", "om_events.time")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("invalid aggregation", func(t *testing.T) {
+		_, err := valueExprsCombine(meter.Meter{Aggregation: meter.MeterAggregation("MEDIAN")}, "om_events.data", "om_events.time")
+		require.ErrorContains(t, err, "invalid aggregation type: MEDIAN")
+	})
+
+	t.Run("missing value property", func(t *testing.T) {
+		_, err := valueExprsCombine(meter.Meter{Aggregation: meter.MeterAggregationUniqueCount}, "om_events.data", "om_events.time")
+		require.ErrorContains(t, err, "meter value property is required for UNIQUE_COUNT aggregation")
+	})
+}
+
+func TestGroupBySelectExprs(t *testing.T) {
+	meterGroupBy := map[string]string{
+		"group1": "$.group1",
+		"group2": "$.nested.group2",
+	}
+
+	t.Run("subject, customer_id and JSON dimensions", func(t *testing.T) {
+		selectColumns, groupByColumns := groupBySelectExprs(
+			[]string{"subject", "customer_id", "group1", "group2"},
+			meterGroupBy,
+			"om_events.subject",
+			"om_events.data",
+		)
+
+		// customer_id contributes no SELECT expression: its select column (a
+		// subject-to-customer map lookup) is attached by selectCustomerIdColumn.
+		assert.Equal(t, []string{
+			"om_events.subject",
+			"JSON_VALUE(om_events.data, '$.group1') as group1",
+			"JSON_VALUE(om_events.data, '$.nested.group2') as group2",
+		}, selectColumns)
+		assert.Equal(t, []string{"subject", "customer_id", "group1", "group2"}, groupByColumns)
+	})
+
+	t.Run("empty group by", func(t *testing.T) {
+		selectColumns, groupByColumns := groupBySelectExprs(nil, meterGroupBy, "om_events.subject", "om_events.data")
+		assert.Empty(t, selectColumns)
+		assert.Empty(t, groupByColumns)
+	})
+
+	t.Run("JSON path literal is escaped", func(t *testing.T) {
+		selectColumns, _ := groupBySelectExprs(
+			[]string{"weird"},
+			map[string]string{"weird": `$.it's`},
+			"om_events.subject",
+			"om_events.data",
+		)
+		assert.Equal(t, []string{`JSON_VALUE(om_events.data, '$.it\'s') as weird`}, selectColumns)
+	})
+}
+
+func TestReservedAliasCheck(t *testing.T) {
+	t.Run("accepts ordinary group by keys", func(t *testing.T) {
+		require.NoError(t, reservedAliasCheck([]string{"model", "region", "valuex", "statement"}))
+	})
+
+	t.Run("accepts no keys", func(t *testing.T) {
+		require.NoError(t, reservedAliasCheck(nil))
+	})
+
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "om_events column", key: "namespace"},
+		{name: "om_events time column", key: "time"},
+		{name: "cache column", key: "meter_hash"},
+		{name: "query output alias", key: "value"},
+		{name: "window alias", key: "windowstart"},
+		{name: "value column family suffix", key: "total_value"},
+		{name: "state column family suffix", key: "uniq_state"},
+	}
+
+	for _, tt := range tests {
+		t.Run("rejects "+tt.name, func(t *testing.T) {
+			err := reservedAliasCheck([]string{"model", tt.key})
+			require.ErrorContains(t, err, "meter group by keys collide with reserved SQL aliases: "+tt.key)
+		})
+	}
+
+	t.Run("reports all offenders sorted", func(t *testing.T) {
+		err := reservedAliasCheck([]string{"windowstart", "region", "data"})
+		require.ErrorContains(t, err, "meter group by keys collide with reserved SQL aliases: data, windowstart")
+	})
+}

--- a/openmeter/streaming/clickhouse/meter_query.go
+++ b/openmeter/streaming/clickhouse/meter_query.go
@@ -121,54 +121,12 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 	}
 
 	if groupByWindowSize {
-		switch *d.WindowSize {
-		case meterpkg.WindowSizeMinute:
-			selectColumns = append(
-				selectColumns,
-				fmt.Sprintf("tumbleStart(%s, toIntervalMinute(1), '%s') AS windowstart", timeColumn, tz),
-				fmt.Sprintf("tumbleEnd(%s, toIntervalMinute(1), '%s') AS windowend", timeColumn, tz),
-			)
-
-		case meterpkg.WindowSizeHour:
-			selectColumns = append(
-				selectColumns,
-				fmt.Sprintf("tumbleStart(%s, toIntervalHour(1), '%s') AS windowstart", timeColumn, tz),
-				fmt.Sprintf("tumbleEnd(%s, toIntervalHour(1), '%s') AS windowend", timeColumn, tz),
-			)
-
-		case meterpkg.WindowSizeDay:
-			selectColumns = append(
-				selectColumns,
-				fmt.Sprintf("tumbleStart(%s, toIntervalDay(1), '%s') AS windowstart", timeColumn, tz),
-				"windowstart + toIntervalDay(1) AS windowend",
-			)
-
-		case meterpkg.WindowSizeMonth:
-			selectColumns = append(
-				selectColumns,
-				// We need to convert the tumbleStart and tumbleEnd to DateTime, as otherwise we got a Date type. Given
-				// we are scanning the result into a time.Time, we will end up with the correct date in UTC. In case the timezone
-				// is not UTC, the returned values will be offset by the timezone difference.
-				//
-				// e.g.:
-				//  if timezone is Europe/Budapest, then if we are not casting to DateTime, then:
-				// 	 tumbleStart will return 2025-01-01 which will become 2025-01-01 00:00:00 in UTC
-				//   this is wrong, as in CET this is 2024-12-31 23:00:00
-				//  if we are casting to DateTime, then:
-				// 	 tumbleStart will return 2025-01-01 00:00:00 in Europe/Budapest
-
-				// Other queries are not affected by this, as for anything < Month, the result is always a DateTime (most probably due to
-				// DST changes).
-				fmt.Sprintf("toDateTime(tumbleStart(%s, toIntervalMonth(1), '%s'), '%s') AS windowstart", timeColumn, tz, tz),
-				fmt.Sprintf("toDateTime(tumbleEnd(%s, toIntervalMonth(1), '%s'), '%s') AS windowend", timeColumn, tz, tz),
-			)
-
-		default:
-			return "", nil, models.NewGenericValidationError(
-				fmt.Errorf("invalid window size type: %s", *d.WindowSize),
-			)
+		windowSelectColumns, err := windowExprs(*d.WindowSize, timeColumn, tz)
+		if err != nil {
+			return "", nil, err
 		}
 
+		selectColumns = append(selectColumns, windowSelectColumns...)
 		groupByColumns = append(groupByColumns, "windowstart", "windowend")
 	} else {
 		// TODO: remove this when we don't round to the nearest minute anymore
@@ -179,72 +137,17 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 	}
 
 	// Select Value
-	sqlAggregation := ""
-	switch d.Meter.Aggregation {
-	case meterpkg.MeterAggregationSum:
-		sqlAggregation = "sum"
-	case meterpkg.MeterAggregationAvg:
-		sqlAggregation = "avg"
-	case meterpkg.MeterAggregationMin:
-		sqlAggregation = "min"
-	case meterpkg.MeterAggregationMax:
-		sqlAggregation = "max"
-	case meterpkg.MeterAggregationUniqueCount:
-		// Use the uniqExact function if you absolutely need an exact result.
-		// See: https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/uniqexact
-		sqlAggregation = "uniqExact"
-	case meterpkg.MeterAggregationCount:
-		sqlAggregation = "count"
-	case meterpkg.MeterAggregationLatest:
-		sqlAggregation = "argMax"
-	default:
-		return "", []interface{}{}, models.NewGenericValidationError(
-			fmt.Errorf("invalid aggregation type: %s", d.Meter.Aggregation),
-		)
+	valueSelectColumn, err := valueExprPlain(d.Meter, getColumn("data"), timeColumn, d.EnableDecimalPrecision)
+	if err != nil {
+		return "", []interface{}{}, err
 	}
 
-	switch d.Meter.Aggregation {
-	case meterpkg.MeterAggregationCount:
-		selectColumns = append(selectColumns, fmt.Sprintf("%s(*) AS value", sqlAggregation))
-	case meterpkg.MeterAggregationUniqueCount:
-		selectColumns = append(selectColumns, fmt.Sprintf("%s(nullIf(JSON_VALUE(%s, '%s'), 'null')) AS value", sqlAggregation, getColumn("data"), escapeJSONPathLiteral(*d.Meter.ValueProperty)))
-	case meterpkg.MeterAggregationLatest:
-		if d.EnableDecimalPrecision {
-			selectColumns = append(selectColumns, fmt.Sprintf("%s(toDecimal128OrNull(nullIf(JSON_VALUE(%s, '%s'), 'null'), 19), %s) AS value", sqlAggregation, getColumn("data"), escapeJSONPathLiteral(*d.Meter.ValueProperty), timeColumn))
-		} else {
-			selectColumns = append(selectColumns, fmt.Sprintf("%s(ifNotFinite(toFloat64OrNull(JSON_VALUE(%s, '%s')), null), %s) AS value", sqlAggregation, getColumn("data"), escapeJSONPathLiteral(*d.Meter.ValueProperty), timeColumn))
-		}
-	default:
-		if d.EnableDecimalPrecision {
-			selectColumns = append(selectColumns, fmt.Sprintf("%s(toDecimal128OrNull(nullIf(JSON_VALUE(%s, '%s'), 'null'), 19)) AS value", sqlAggregation, getColumn("data"), escapeJSONPathLiteral(*d.Meter.ValueProperty)))
-		} else {
-			// JSON_VALUE returns an empty string if the JSON Path is not found. With toFloat64OrNull we convert it to NULL so the aggregation function can handle it properly.
-			selectColumns = append(selectColumns, fmt.Sprintf("%s(ifNotFinite(toFloat64OrNull(JSON_VALUE(%s, '%s')), null)) AS value", sqlAggregation, getColumn("data"), escapeJSONPathLiteral(*d.Meter.ValueProperty)))
-		}
-	}
+	selectColumns = append(selectColumns, valueSelectColumn)
 
-	for _, groupByKey := range d.GroupBy {
-		// Subject is a special case as it's a top level column
-		if groupByKey == "subject" {
-			selectColumns = append(selectColumns, getColumn("subject"))
-			groupByColumns = append(groupByColumns, "subject")
-			continue
-		}
-
-		// Customer ID is a special case as it's a top level column
-		if groupByKey == "customer_id" {
-			groupByColumns = append(groupByColumns, "customer_id")
-			continue
-		}
-
-		// Group by columns need to be parsed from the JSON data
-		groupByColumn := sqlbuilder.Escape(groupByKey)
-		groupByJSONPath := escapeJSONPathLiteral(d.Meter.GroupBy[groupByKey])
-		selectColumn := fmt.Sprintf("JSON_VALUE(%s, '%s') as %s", getColumn("data"), groupByJSONPath, groupByColumn)
-
-		selectColumns = append(selectColumns, selectColumn)
-		groupByColumns = append(groupByColumns, groupByColumn)
-	}
+	// Select group by dimensions
+	groupBySelectColumns, groupByGroupByColumns := groupBySelectExprs(d.GroupBy, d.Meter.GroupBy, getColumn("subject"), getColumn("data"))
+	selectColumns = append(selectColumns, groupBySelectColumns...)
+	groupByColumns = append(groupByColumns, groupByGroupByColumns...)
 
 	query := sqlbuilder.ClickHouse.NewSelectBuilder()
 	query.Select(selectColumns...)
@@ -299,7 +202,7 @@ func (d *queryMeter) toSQL() (string, []interface{}, error) {
 			}
 
 			// Determine the column name
-			column := fmt.Sprintf("JSON_VALUE(%s, '%s')", dataColumn, escapeJSONPathLiteral(groupByJSONPath))
+			column := groupByJSONExpr(dataColumn, groupByJSONPath)
 
 			// Subject is a special case
 			if groupByKey == "subject" {

--- a/openmeter/streaming/clickhouse/metercache/observability.go
+++ b/openmeter/streaming/clickhouse/metercache/observability.go
@@ -1,0 +1,168 @@
+package metercache
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// metercacheMetricPrefix namespaces every reconciler instrument alongside the connector's
+// streaming.meter_cache.* instruments (see clickhouse.meterCacheMetricPrefix); the two
+// packages intentionally share one metric namespace since both describe the same cache's
+// health from different vantage points.
+const metercacheMetricPrefix = "streaming.meter_cache."
+
+// passStatus is the per-view health classification the reconcile_pass_views gauge reports
+// (see passStatusFor in reconciler.go): healthy (the view is converged, no action needed),
+// stale (no deployed view yet, or a deployed view still converging via repair/recreate/
+// marker-expiry backfill), unstamped (a deployed view whose BackfilledAt is nil, i.e. a
+// create-or-backfill sequence left mid-flight per G3), or exception. exception is the one
+// pass-level status: it is tallied once when reconcile() itself aborts (ListMeters or
+// ListActualViews failed) rather than per view, so a nonzero exception count on this
+// per-view gauge means the whole pass failed before any view could be classified, not that
+// one view is broken.
+type passStatus string
+
+const (
+	passStatusHealthy   passStatus = "healthy"
+	passStatusStale     passStatus = "stale"
+	passStatusException passStatus = "exception"
+	passStatusUnstamped passStatus = "unstamped"
+)
+
+// reconcileOp is the reconcile_ops counter's op attribute: the convergence action the
+// reconciler took for one desired view, plus gc for the orphan-row cleanup that runs once
+// per pass rather than once per view.
+type reconcileOp string
+
+const (
+	reconcileOpCreate   reconcileOp = "create"
+	reconcileOpBackfill reconcileOp = "backfill"
+	reconcileOpDrop     reconcileOp = "drop"
+	reconcileOpRepair   reconcileOp = "repair"
+	reconcileOpGC       reconcileOp = "gc"
+)
+
+type reconcileOpOutcome string
+
+const (
+	reconcileOpOutcomeOK    reconcileOpOutcome = "ok"
+	reconcileOpOutcomeError reconcileOpOutcome = "error"
+)
+
+// passSnapshot is the most recent pass's status-per-view counts, read by the observable
+// gauge callback. It is stored behind an atomic.Pointer so the callback (invoked by the
+// SDK's collection goroutine) never races with the reconcile loop publishing a new pass.
+type passSnapshot struct {
+	counts map[passStatus]int64
+}
+
+// observability holds the meter cache reconciler's OTel instruments plus the atomic
+// snapshot its observable gauge callback reads. It is always non-nil on a constructed
+// Reconciler — see newObservability — so reconcile() never needs a nil check before
+// recording.
+type observability struct {
+	tracer trace.Tracer
+
+	reconcileOps        metric.Int64Counter
+	reconcileDurationMS metric.Int64Histogram
+	capabilityDisabled  metric.Int64Counter
+
+	lastPass atomic.Pointer[passSnapshot]
+}
+
+// newObservability builds the instrument set from meter and tracer, substituting no-op
+// implementations when either is nil (the reconciler's cache observability is optional,
+// matching the clickhouse connector's Config.Meter/Config.Tracer contract).
+func newObservability(meter metric.Meter, tracer trace.Tracer) (*observability, error) {
+	if meter == nil {
+		meter = metricnoop.NewMeterProvider().Meter("noop")
+	}
+
+	if tracer == nil {
+		tracer = noop.NewTracerProvider().Tracer("noop")
+	}
+
+	o := &observability{tracer: tracer}
+	o.lastPass.Store(&passSnapshot{counts: map[passStatus]int64{}})
+
+	reconcileOps, err := meter.Int64Counter(
+		metercacheMetricPrefix+"reconcile_ops",
+		metric.WithDescription("Number of meter cache view convergence operations the reconciler performed, by op and outcome"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metric: %sreconcile_ops: %w", metercacheMetricPrefix, err)
+	}
+	o.reconcileOps = reconcileOps
+
+	reconcileDurationMS, err := meter.Int64Histogram(
+		metercacheMetricPrefix+"reconcile_duration_ms",
+		metric.WithDescription("Duration of one meter cache reconciliation pass"),
+		metric.WithUnit("ms"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metric: %sreconcile_duration_ms: %w", metercacheMetricPrefix, err)
+	}
+	o.reconcileDurationMS = reconcileDurationMS
+
+	capabilityDisabled, err := meter.Int64Counter(
+		metercacheMetricPrefix+"capability_disabled",
+		metric.WithDescription("Incremented once when the capability probe permanently disables the meter cache reconciler for this process"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metric: %scapability_disabled: %w", metercacheMetricPrefix, err)
+	}
+	o.capabilityDisabled = capabilityDisabled
+
+	views, err := meter.Int64ObservableGauge(
+		metercacheMetricPrefix+"reconcile_pass_views",
+		metric.WithDescription("Number of views in the most recent reconciliation pass, by status"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metric: %sreconcile_pass_views: %w", metercacheMetricPrefix, err)
+	}
+
+	_, err = meter.RegisterCallback(func(_ context.Context, obs metric.Observer) error {
+		snapshot := o.lastPass.Load()
+
+		for status, count := range snapshot.counts {
+			obs.ObserveInt64(views, count, metric.WithAttributes(attribute.String("status", string(status))))
+		}
+
+		return nil
+	}, views)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register callback for %sreconcile_pass_views: %w", metercacheMetricPrefix, err)
+	}
+
+	return o, nil
+}
+
+// recordOp emits the reconcile_ops counter for one convergence action.
+func (o *observability) recordOp(ctx context.Context, op reconcileOp, outcome reconcileOpOutcome) {
+	o.reconcileOps.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("op", string(op)),
+		attribute.String("outcome", string(outcome)),
+	))
+}
+
+// recordPass publishes the pass's per-view status counts for the reconcile_pass_views
+// observable gauge and records the pass duration histogram.
+func (o *observability) recordPass(ctx context.Context, counts map[passStatus]int64, duration int64) {
+	o.lastPass.Store(&passSnapshot{counts: counts})
+	o.reconcileDurationMS.Record(ctx, duration)
+}
+
+// recordCapabilityDisabled increments the capability_disabled counter. It is expected to
+// fire at most once per process lifetime (the reconciler latches disabled and never probes
+// again), so any value above 1 across a fleet points at repeated restarts hitting the same
+// unsupported deployment.
+func (o *observability) recordCapabilityDisabled(ctx context.Context) {
+	o.capabilityDisabled.Add(ctx, 1)
+}

--- a/openmeter/streaming/clickhouse/metercache/observability_test.go
+++ b/openmeter/streaming/clickhouse/metercache/observability_test.go
@@ -1,0 +1,236 @@
+package metercache
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming/clickhouse"
+)
+
+// testTelemetry bundles a ManualReader-backed MeterProvider and a SpanRecorder-backed
+// TracerProvider, mirroring the clickhouse package's own testTelemetry: tests must assert
+// that an instrument actually recorded, not merely that construction succeeded (a
+// detached instrument looks like a healthy quiet system).
+type testTelemetry struct {
+	reader   *sdkmetric.ManualReader
+	recorder *tracetest.SpanRecorder
+}
+
+func newTestTelemetry() *testTelemetry {
+	return &testTelemetry{
+		reader:   sdkmetric.NewManualReader(),
+		recorder: tracetest.NewSpanRecorder(),
+	}
+}
+
+// newInstrumentedTestReconciler builds a pass-only reconciler like newTestReconciler, but
+// wired to real (ManualReader/SpanRecorder-backed) instruments instead of no-ops, so tests
+// can assert emission.
+func newInstrumentedTestReconciler(t *testing.T, connector Connector, meters meter.Service, telemetry *testTelemetry) *Reconciler {
+	t.Helper()
+
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(telemetry.reader))
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(telemetry.recorder))
+
+	observability, err := newObservability(meterProvider.Meter("test"), tracerProvider.Tracer("test"))
+	require.NoError(t, err)
+
+	return &Reconciler{
+		logger:        slog.Default(),
+		connector:     connector,
+		meters:        meters,
+		observability: observability,
+	}
+}
+
+func collectMetric(t *testing.T, reader *sdkmetric.ManualReader, name string) metricdata.Metrics {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m
+			}
+		}
+	}
+
+	require.Failf(t, "metric not emitted", "expected metric %q to have been recorded", name)
+
+	return metricdata.Metrics{}
+}
+
+func sumAttrValue(t *testing.T, m metricdata.Metrics, expected map[string]string) int64 {
+	t.Helper()
+
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.Truef(t, ok, "%s must be a counter", m.Name)
+
+	for _, dp := range sum.DataPoints {
+		matched := true
+
+		for key, want := range expected {
+			got, ok := dp.Attributes.Value(attribute.Key(key))
+			if !ok || got.AsString() != want {
+				matched = false
+				break
+			}
+		}
+
+		if matched {
+			return dp.Value
+		}
+	}
+
+	require.Failf(t, "no matching data point", "metric %s has no data point with attributes %v", m.Name, expected)
+
+	return 0
+}
+
+func gaugeAttrValue(t *testing.T, m metricdata.Metrics, expected map[string]string) (int64, bool) {
+	t.Helper()
+
+	gauge, ok := m.Data.(metricdata.Gauge[int64])
+	require.Truef(t, ok, "%s must be a gauge", m.Name)
+
+	for _, dp := range gauge.DataPoints {
+		matched := true
+
+		for key, want := range expected {
+			got, ok := dp.Attributes.Value(attribute.Key(key))
+			if !ok || got.AsString() != want {
+				matched = false
+				break
+			}
+		}
+
+		if matched {
+			return dp.Value, true
+		}
+	}
+
+	return 0, false
+}
+
+// TestReconcile_EmitsCreateOpsAndPassMetrics proves a pass that creates a missing view
+// records reconcile_ops with op=create and op=backfill (EnsureMeterCache performs both
+// atomically, see reconcileOpsFor), op=gc for the orphan-row cleanup, records a
+// reconcile_pass span, and records the reconcile_pass_views gauge with the new view under
+// status=stale (passStatusFor classifies a nil actualView as stale: fakeConnector's
+// ListActualViews reflects the pre-ensure state, since the fake does not model
+// EnsureMeterCache's effect on actual view state).
+func TestReconcile_EmitsCreateOpsAndPassMetrics(t *testing.T) {
+	telemetry := newTestTelemetry()
+
+	m := newTestMeter("ns-1", "meter-1", "api-calls", nil)
+	connector := &fakeConnector{}
+
+	r := newInstrumentedTestReconciler(t, connector, &fakeMeterService{meters: []meter.Meter{m}}, telemetry)
+	require.NoError(t, r.reconcile(t.Context()))
+
+	ops := collectMetric(t, telemetry.reader, "streaming.meter_cache.reconcile_ops")
+	require.EqualValues(t, 1, sumAttrValue(t, ops, map[string]string{"op": "create", "outcome": "ok"}))
+	require.EqualValues(t, 1, sumAttrValue(t, ops, map[string]string{"op": "backfill", "outcome": "ok"}))
+	require.EqualValues(t, 1, sumAttrValue(t, ops, map[string]string{"op": "gc", "outcome": "ok"}))
+
+	durationMetric := collectMetric(t, telemetry.reader, "streaming.meter_cache.reconcile_duration_ms")
+	hist, ok := durationMetric.Data.(metricdata.Histogram[int64])
+	require.True(t, ok, "reconcile_duration_ms must be a histogram")
+	require.Len(t, hist.DataPoints, 1)
+
+	viewsMetric := collectMetric(t, telemetry.reader, "streaming.meter_cache.reconcile_pass_views")
+	count, ok := gaugeAttrValue(t, viewsMetric, map[string]string{"status": "stale"})
+	require.True(t, ok, "a missing-view pass must report at least one stale-status view")
+	require.EqualValues(t, 1, count)
+
+	spans := telemetry.recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "streaming.meter_cache.reconcile_pass", spans[0].Name())
+}
+
+// TestReconcile_DropOpEmitsOutcome proves dropping an undesired view (a meter no longer
+// exists) is credited to reconcile_ops with op=drop, outcome=ok.
+func TestReconcile_DropOpEmitsOutcome(t *testing.T) {
+	telemetry := newTestTelemetry()
+
+	m := newTestMeter("ns-1", "meter-1", "api-calls", nil)
+	view := deployedView("ns-1", m, "", time.Now())
+	connector := &fakeConnector{actual: []clickhouse.MeterCacheView{view}}
+
+	r := newInstrumentedTestReconciler(t, connector, &fakeMeterService{}, telemetry)
+	require.NoError(t, r.reconcile(t.Context()))
+
+	ops := collectMetric(t, telemetry.reader, "streaming.meter_cache.reconcile_ops")
+	require.EqualValues(t, 1, sumAttrValue(t, ops, map[string]string{"op": "drop", "outcome": "ok"}))
+}
+
+// TestReconcile_CapabilityDisabledEmitsCounter proves the capability probe's permanent
+// disablement is counted, distinct from a transient probe failure.
+func TestReconcile_CapabilityDisabledEmitsCounter(t *testing.T) {
+	telemetry := newTestTelemetry()
+
+	meterProvider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(telemetry.reader))
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(telemetry.recorder))
+
+	observability, err := newObservability(meterProvider.Meter("test"), tracerProvider.Tracer("test"))
+	require.NoError(t, err)
+
+	connector := &fakeConnector{probeErr: clickhouse.ErrMeterCacheUnsupported}
+
+	r := &Reconciler{
+		logger:            slog.Default(),
+		connector:         connector,
+		meters:            &fakeMeterService{},
+		observability:     observability,
+		enabled:           true,
+		reconcileInterval: time.Millisecond,
+		stopCh:            make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	err = r.lead(ctx)
+	require.NoError(t, err)
+	require.True(t, r.disabled.Load())
+
+	m := collectMetric(t, telemetry.reader, "streaming.meter_cache.capability_disabled")
+	sum, ok := m.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, sum.DataPoints, 1)
+	require.EqualValues(t, 1, sum.DataPoints[0].Value)
+}
+
+// TestNewObservability_NilDependenciesDoNotPanic proves the reconciler's instrumented
+// paths run without panicking when observability is built from nil Meter/Tracer — the
+// deployment shape where telemetry was never wired.
+func TestNewObservability_NilDependenciesDoNotPanic(t *testing.T) {
+	observability, err := newObservability(nil, nil)
+	require.NoError(t, err)
+
+	m := newTestMeter("ns-1", "meter-1", "api-calls", nil)
+	connector := &fakeConnector{}
+
+	r := &Reconciler{
+		logger:        slog.Default(),
+		connector:     connector,
+		meters:        &fakeMeterService{meters: []meter.Meter{m}},
+		observability: observability,
+	}
+
+	require.NotPanics(t, func() {
+		require.NoError(t, r.reconcile(t.Context()))
+	})
+}

--- a/openmeter/streaming/clickhouse/metercache/reconciler.go
+++ b/openmeter/streaming/clickhouse/metercache/reconciler.go
@@ -20,6 +20,10 @@ import (
 	"time"
 
 	"cirello.io/pglock"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/streaming/clickhouse"
@@ -64,6 +68,13 @@ type Config struct {
 	LockClient *pglock.Client
 
 	ReconcileInterval time.Duration
+
+	// Meter and Tracer instrument reconciliation health (pass status, convergence
+	// operations, pass duration, capability disablement). Both are optional: a nil Meter
+	// yields no-op instruments and a nil Tracer falls back to a no-op tracer, matching the
+	// clickhouse connector's Config.Meter/Config.Tracer contract.
+	Meter  metric.Meter
+	Tracer trace.Tracer
 }
 
 func (c Config) Validate() error {
@@ -104,6 +115,9 @@ type Reconciler struct {
 	meters     meter.Service
 	lockClient *pglock.Client
 
+	// observability is always non-nil on a Reconciler built via New; see newObservability.
+	observability *observability
+
 	enabled           bool
 	reconcileInterval time.Duration
 
@@ -125,6 +139,11 @@ func New(config Config) (*Reconciler, error) {
 		config.ReconcileInterval = DefaultReconcileInterval
 	}
 
+	observability, err := newObservability(config.Meter, config.Tracer)
+	if err != nil {
+		return nil, fmt.Errorf("init meter cache reconciler observability: %w", err)
+	}
+
 	stopCh := make(chan struct{})
 
 	return &Reconciler{
@@ -132,6 +151,7 @@ func New(config Config) (*Reconciler, error) {
 		connector:         config.Connector,
 		meters:            config.Meters,
 		lockClient:        config.LockClient,
+		observability:     observability,
 		enabled:           config.Enabled,
 		reconcileInterval: config.ReconcileInterval,
 		stopCh:            stopCh,
@@ -223,6 +243,7 @@ func (r *Reconciler) lead(ctx context.Context) error {
 				if err != nil {
 					if errors.Is(err, clickhouse.ErrMeterCacheUnsupported) {
 						r.disabled.Store(true)
+						r.observability.recordCapabilityDisabled(ctx)
 						r.logger.ErrorContext(ctx, "meter cache reconciler disabled: ClickHouse deployment lacks required capabilities", "error", err)
 
 						return nil
@@ -250,15 +271,43 @@ func (r *Reconciler) lead(ctx context.Context) error {
 // failures are collected instead of aborting the pass so one broken meter cannot block
 // every other meter's lifecycle.
 func (r *Reconciler) reconcile(ctx context.Context) error {
+	ctx, span := r.observability.tracer.Start(ctx, "streaming.meter_cache.reconcile_pass")
+	defer span.End()
+
+	passStart := time.Now()
+	statusCounts := map[passStatus]int64{}
+	opCounts := map[reconcileOp]int64{}
+
+	// recordOp both emits the reconcile_ops counter and tallies the pass-local count the
+	// reconcile_pass span reports as op_counts, so the span carries a same-pass summary
+	// without re-deriving it from the counter after the fact.
+	recordOp := func(op reconcileOp, outcome reconcileOpOutcome) {
+		opCounts[op]++
+		r.observability.recordOp(ctx, op, outcome)
+	}
+
+	defer func() {
+		span.SetAttributes(attribute.String("op_counts", formatOpCounts(opCounts)))
+		r.observability.recordPass(ctx, statusCounts, time.Since(passStart).Milliseconds())
+	}()
+
 	// The zero page returns all meters; soft-deleted ones are excluded by default, which is
 	// exactly the deletion signal: a deleted meter's view stops being desired.
 	meterList, err := r.meters.ListMeters(ctx, meter.ListMetersParams{WithoutNamespace: true})
 	if err != nil {
+		statusCounts[passStatusException]++
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "list meters failed")
+
 		return fmt.Errorf("list meters: %w", err)
 	}
 
 	actual, err := r.connector.ListActualViews(ctx)
 	if err != nil {
+		statusCounts[passStatusException]++
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "list actual meter cache views failed")
+
 		return fmt.Errorf("list actual meter cache views: %w", err)
 	}
 
@@ -268,6 +317,11 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 	}
 
 	desired, keepHashes := r.desiredState(meterList.Items, actualByName)
+
+	span.SetAttributes(
+		attribute.Int("desired_count", len(desired)),
+		attribute.Int("actual_count", len(actual)),
+	)
 
 	var errs []error
 
@@ -293,6 +347,9 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 
 		if err := r.connector.DropMeterCache(ctx, view.Name); err != nil {
 			errs = append(errs, fmt.Errorf("drop meter cache view %s: %w", view.Name, err))
+			recordOp(reconcileOpDrop, reconcileOpOutcomeError)
+		} else {
+			recordOp(reconcileOpDrop, reconcileOpOutcomeOK)
 		}
 	}
 
@@ -309,6 +366,8 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 
 		action, reason := planViewAction(d, actualView, slices.Contains(markerRepairs, name), repairAge, now)
 		if action == viewActionNone {
+			statusCounts[passStatusHealthy]++
+
 			// A converged view's coverage watermark advances with its refreshes so it stays
 			// meaningful across ClickHouse restarts (which wipe system.view_refreshes); the
 			// stamp fires at most once per refresh cycle because LastSuccessTime only moves
@@ -323,19 +382,34 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 			continue
 		}
 
+		statusCounts[passStatusFor(actualView)]++
+
 		r.logger.InfoContext(ctx, "meter cache: converging view",
 			"view", name, "namespace", d.meter.Namespace, "meter", d.meter.Key, "action", string(action), "reason", reason)
 
 		if action == viewActionRecreate {
 			if err := r.connector.DropMeterCache(ctx, name); err != nil {
 				errs = append(errs, fmt.Errorf("drop meter cache view %s: %w", name, err))
+				recordOp(reconcileOpDrop, reconcileOpOutcomeError)
 
 				continue
 			}
+
+			recordOp(reconcileOpDrop, reconcileOpOutcomeOK)
 		}
+
+		ensureOps := reconcileOpsFor(action, actualView)
 
 		if err := r.connector.EnsureMeterCache(ctx, d.meter.Namespace, d.meter); err != nil {
 			errs = append(errs, fmt.Errorf("ensure meter cache for %s/%s: %w", d.meter.Namespace, d.meter.Key, err))
+
+			for _, ensureOp := range ensureOps {
+				recordOp(ensureOp, reconcileOpOutcomeError)
+			}
+		} else {
+			for _, ensureOp := range ensureOps {
+				recordOp(ensureOp, reconcileOpOutcomeOK)
+			}
 		}
 	}
 
@@ -346,9 +420,64 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 	// current meter hash and never see them (G8).
 	if err := r.connector.DeleteMeterCacheOrphanRows(ctx, keepHashes); err != nil {
 		errs = append(errs, fmt.Errorf("delete orphan meter cache rows: %w", err))
+		recordOp(reconcileOpGC, reconcileOpOutcomeError)
+	} else {
+		recordOp(reconcileOpGC, reconcileOpOutcomeOK)
 	}
 
-	return errors.Join(errs...)
+	joined := errors.Join(errs...)
+	if joined != nil {
+		span.RecordError(joined)
+		span.SetStatus(codes.Error, "meter cache reconciliation pass had per-view or gc errors")
+	}
+
+	return joined
+}
+
+// passStatusFor classifies one desired view's health for the reconcile_pass_views gauge: no
+// deployed counterpart yet is stale (a create is pending), an unstamped deployed view is
+// unstamped (G3: a create-or-backfill sequence left mid-flight), and any other converging
+// view is stale (repair, recreate, or marker-expiry driven re-backfill).
+func passStatusFor(actualView *clickhouse.MeterCacheView) passStatus {
+	if actualView == nil {
+		return passStatusStale
+	}
+
+	if actualView.BackfilledAt == nil {
+		return passStatusUnstamped
+	}
+
+	return passStatusStale
+}
+
+// reconcileOpsFor maps a planned convergence action to the reconcile_ops op attribute(s).
+// EnsureMeterCache performs CREATE MV, backfill, and the backfill stamp as one atomic
+// sequence (see clickhouse.Connector.EnsureMeterCache), so a first-time deploy — no deployed
+// view, or the deployed one was just dropped for recreation — is credited with both create
+// and backfill, while re-running the same call over an existing, still-deployed view (drift
+// repair, an unstamped view, a refresh outage, or expired unhealed markers) is a repair: no
+// new object is created, only its content re-backfilled.
+func reconcileOpsFor(action viewAction, actualView *clickhouse.MeterCacheView) []reconcileOp {
+	if action == viewActionRecreate || actualView == nil {
+		return []reconcileOp{reconcileOpCreate, reconcileOpBackfill}
+	}
+
+	return []reconcileOp{reconcileOpRepair}
+}
+
+// formatOpCounts renders one pass's convergence-op tally as a deterministic
+// "op=count" comma-joined string for the reconcile_pass span's op_counts attribute
+// (per-op counts already exist as a proper dimension on the reconcile_ops counter; the
+// span carries a same-pass summary for quick operator inspection of one trace).
+func formatOpCounts(counts map[reconcileOp]int64) string {
+	ops := slices.Sorted(maps.Keys(counts))
+
+	parts := make([]string, 0, len(ops))
+	for _, op := range ops {
+		parts = append(parts, fmt.Sprintf("%s=%d", op, counts[op]))
+	}
+
+	return strings.Join(parts, ",")
 }
 
 // desiredView is one entry of the reconciler's desired state: the meter that should be

--- a/openmeter/streaming/clickhouse/metercache/reconciler.go
+++ b/openmeter/streaming/clickhouse/metercache/reconciler.go
@@ -45,6 +45,8 @@ type Connector interface {
 	EnsureMeterCache(ctx context.Context, namespace string, m meter.Meter) error
 	DropMeterCache(ctx context.Context, viewName string) error
 	DeleteMeterCacheOrphanRows(ctx context.Context, keepMeterHashes []string) error
+	StampMeterCacheCoverage(ctx context.Context, view clickhouse.MeterCacheView, coveredAt time.Time) error
+	ReconcileMeterCacheMarkers(ctx context.Context, views []clickhouse.MeterCacheView) ([]string, error)
 	ProbeMeterCacheCapabilities(ctx context.Context) (string, error)
 	MeterCacheRepairAge() time.Duration
 }
@@ -269,6 +271,16 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 
 	var errs []error
 
+	// Marker maintenance runs before planning: expired-unhealed markers force a re-backfill
+	// of their view, and healed markers must be deleted while the healing refresh is still
+	// the latest one observable — the reader's heal rule regresses once refreshes advance
+	// past the heal bound. A failed maintenance pass degrades to conservative reads (live
+	// fallback on the marked ranges), never to trusting a stale bucket.
+	markerRepairs, err := r.connector.ReconcileMeterCacheMarkers(ctx, actual)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("reconcile meter cache markers: %w", err))
+	}
+
 	// Undesired views first (deleted meters, pre-change shapes, foreign prefix squatters):
 	// dropping before creating keeps a shape swap from briefly running two refresh
 	// schedules against the shared target.
@@ -295,8 +307,19 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 			actualView = &view
 		}
 
-		action, reason := planViewAction(d, actualView, repairAge, now)
+		action, reason := planViewAction(d, actualView, slices.Contains(markerRepairs, name), repairAge, now)
 		if action == viewActionNone {
+			// A converged view's coverage watermark advances with its refreshes so it stays
+			// meaningful across ClickHouse restarts (which wipe system.view_refreshes); the
+			// stamp fires at most once per refresh cycle because LastSuccessTime only moves
+			// when a refresh completes.
+			if watermark, ok := coverageWatermark(actualView); ok &&
+				actualView.LastSuccessTime != nil && actualView.LastSuccessTime.After(watermark) {
+				if err := r.connector.StampMeterCacheCoverage(ctx, *actualView, *actualView.LastSuccessTime); err != nil {
+					errs = append(errs, fmt.Errorf("stamp meter cache coverage for %s: %w", name, err))
+				}
+			}
+
 			continue
 		}
 
@@ -373,12 +396,16 @@ func (r *Reconciler) desiredState(meters []meter.Meter, actualByName map[string]
 		}
 
 		// Same-shape conflict: meters with identical shape share a meter hash and thus one
-		// view name, but the view stamps a single meter_key into its rows, so it can only
-		// ever serve one of them; the read gate refuses it for the others (they stay live).
-		// Ownership prefers the meter the deployed view was created for so it does not flap
-		// between passes; without a deployed view the (namespace, key)-first meter wins.
+		// view name — either within one namespace or across namespaces whose 8-hex name
+		// folds collide — but the view stamps a single namespace and meter_key into its
+		// rows, so it can only ever serve one of them; the read gate refuses it for the
+		// others (they stay live). Ownership prefers the meter the deployed view was
+		// created for so it does not flap between passes; without a deployed view the
+		// (namespace, key)-first meter wins.
 		loser := m
-		if actual, ok := actualByName[dv.Name]; ok && actual.MetadataOK && actual.MeterKey == m.Key && current.meter.Key != m.Key {
+		if actual, ok := actualByName[dv.Name]; ok && actual.MetadataOK &&
+			actual.Namespace == m.Namespace && actual.MeterKey == m.Key &&
+			(current.meter.Namespace != m.Namespace || current.meter.Key != m.Key) {
 			loser = current.meter
 			desired[dv.Name] = desiredView{meter: m, view: dv}
 		}
@@ -404,9 +431,29 @@ const (
 	viewActionRecreate viewAction = "recreate"
 )
 
+// coverageWatermark returns a deployed view's durable coverage watermark: the newest
+// instant up to which its cache content is known continuously maintained. It is the later
+// of the backfill stamp (a completed backfill covers all history settled before it) and
+// the covered_at stamp the reconciler advances while refreshes stay continuous. ok is
+// false while the view is unstamped — there is no coverage to speak of before the first
+// backfill completes.
+func coverageWatermark(view *clickhouse.MeterCacheView) (time.Time, bool) {
+	if view == nil || view.BackfilledAt == nil {
+		return time.Time{}, false
+	}
+
+	watermark := *view.BackfilledAt
+	if view.CoveredAt != nil && view.CoveredAt.After(watermark) {
+		watermark = *view.CoveredAt
+	}
+
+	return watermark, true
+}
+
 // planViewAction decides how to converge one desired view given its deployed counterpart
-// (nil when not deployed). It returns the action plus a short reason for operator logs.
-func planViewAction(d desiredView, actual *clickhouse.MeterCacheView, repairAge time.Duration, now time.Time) (viewAction, string) {
+// (nil when not deployed) and whether marker maintenance flagged it for repair. It returns
+// the action plus a short reason for operator logs.
+func planViewAction(d desiredView, actual *clickhouse.MeterCacheView, needsMarkerRepair bool, repairAge time.Duration, now time.Time) (viewAction, string) {
 	if actual == nil {
 		return viewActionEnsure, "view missing"
 	}
@@ -416,10 +463,12 @@ func planViewAction(d desiredView, actual *clickhouse.MeterCacheView, repairAge 
 	}
 
 	// A hash mismatch at the desired name means the deployed object was not produced by the
-	// current generator for this meter (corrupt or hand-altered comment); a key/event-type
-	// mismatch means it was created for a same-shape meter that is no longer desired (had
-	// it been, ownership in desiredState would have followed the deployed view).
-	if actual.MeterKey != d.meter.Key || actual.EventType != d.meter.EventType || actual.MeterHash != d.view.MeterHash {
+	// current generator for this meter (corrupt or hand-altered comment); a
+	// namespace/key/event-type mismatch means it was created for a same-shape meter — or a
+	// name-fold-colliding namespace's meter — that is no longer desired (had it been,
+	// ownership in desiredState would have followed the deployed view).
+	if actual.Namespace != d.meter.Namespace || actual.MeterKey != d.meter.Key ||
+		actual.EventType != d.meter.EventType || actual.MeterHash != d.view.MeterHash {
 		return viewActionRecreate, "view metadata mismatch"
 	}
 
@@ -440,19 +489,45 @@ func planViewAction(d desiredView, actual *clickhouse.MeterCacheView, repairAge 
 		return viewActionEnsure, "backfill unstamped"
 	}
 
-	// Extended refresh outage: once the last successful refresh is older than the dirty
-	// window slack, buckets that settled early in the outage may never be recomputed by any
-	// future refresh, so the cache content must be rebuilt. The backfill stamp doubles as
-	// the repair throttle — a repair refreshes it, so a view whose refreshes stay broken is
-	// re-repaired at most once per repairAge instead of on every pass. A nil
-	// LastSuccessTime is deliberately not repaired: it means no successful refresh since
-	// ClickHouse startup (fresh view or recent server restart), and mass re-backfilling
-	// every view on each ClickHouse restart would be a self-inflicted load storm while the
-	// read gate already refuses stale views.
-	if actual.LastSuccessTime != nil &&
-		now.Sub(*actual.LastSuccessTime) > repairAge &&
-		now.Sub(*actual.BackfilledAt) > repairAge {
-		return viewActionEnsure, "refresh outage"
+	// Extended refresh outage: refreshes only recompute buckets that settled within the
+	// dirty-window slack (repairAge) of them, so any longer refresh gap leaves buckets
+	// settled early in the gap permanently missing from the cache, and only a re-backfill
+	// closes it. The gap is measured against the durable coverage watermark, not against
+	// system.view_refreshes alone: that table is per-server in-memory state a ClickHouse
+	// restart wipes, so after a restart the refresh state is first nil and then fresh —
+	// both would hide an outage that preceded or spanned the restart. A repair re-stamps
+	// the backfill (advancing the watermark), which doubles as the repair throttle: a view
+	// whose refreshes stay broken is re-repaired at most once per repairAge instead of on
+	// every pass. All three arms below share that throttle:
+	//
+	//   - refreshes resumed after a gap wider than the watermark can vouch for,
+	//   - refreshes have been failing for longer than repairAge (the watermark stopped
+	//     advancing with them),
+	//   - no refresh since ClickHouse startup while the watermark already aged out — the
+	//     restart followed an outage the post-restart refresh state cannot reveal. A fresh
+	//     watermark with nil refresh state is a fresh restart and deliberately not
+	//     repaired: the first scheduled refresh covers it, and mass re-backfilling every
+	//     view on every ClickHouse restart would be a self-inflicted load storm.
+	if watermark, ok := coverageWatermark(actual); ok {
+		if actual.LastSuccessTime != nil {
+			if actual.LastSuccessTime.Sub(watermark) > repairAge {
+				return viewActionEnsure, "refresh outage"
+			}
+
+			if now.Sub(*actual.LastSuccessTime) > repairAge && now.Sub(watermark) > repairAge {
+				return viewActionEnsure, "refresh outage"
+			}
+		} else if now.Sub(watermark) > repairAge {
+			return viewActionEnsure, "refresh outage"
+		}
+	}
+
+	// Expired-unhealed invalidation markers: late events landed in settled buckets while
+	// refreshes could not cover them, and the heal window has passed — no future refresh
+	// can prove the buckets converged, so reads of the marked ranges stay live until a
+	// re-backfill covers the markers (after which marker maintenance deletes them).
+	if needsMarkerRepair {
+		return viewActionEnsure, "expired unhealed markers"
 	}
 
 	return viewActionNone, ""

--- a/openmeter/streaming/clickhouse/metercache/reconciler.go
+++ b/openmeter/streaming/clickhouse/metercache/reconciler.go
@@ -1,0 +1,459 @@
+// Package metercache runs the meter cache lifecycle reconciler: the periodic in-server
+// service that converges the deployed set of per-meter refreshable materialized views onto
+// the current meter definitions. ClickHouse owns refresh scheduling and recomputation; the
+// reconciler owns everything with a lifecycle — creating views for new meters, swapping
+// views whose meter shape changed, dropping views of deleted meters, repairing half-done
+// or gapped deployments, and garbage collecting orphaned rollup rows.
+package metercache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"runtime/debug"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"cirello.io/pglock"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming/clickhouse"
+	"github.com/openmeterio/openmeter/pkg/models"
+)
+
+// DefaultReconcileInterval paces reconciliation passes. One minute is deliberately much
+// shorter than the cache refresh interval: meter CRUD is only observed by polling (the
+// server consumes no Kafka in-process), so this bounds how long a new or changed meter
+// reads live before its view exists.
+const DefaultReconcileInterval = time.Minute
+
+// reconcilerLeaderLockKey serializes reconciliation globally: DDL against the shared
+// om_meter_cache target and full-history backfills must run from a single actor at a time.
+const reconcilerLeaderLockKey = "streaming.meter_cache.reconcile_lock"
+
+// Connector is the meter cache manager surface of the ClickHouse streaming connector the
+// reconciler drives. It is an interface so reconciliation planning is testable without a
+// ClickHouse connection; *clickhouse.Connector is the production implementation.
+type Connector interface {
+	DesiredMeterCacheView(namespace string, m meter.Meter) (clickhouse.MeterCacheDesiredView, error)
+	ListActualViews(ctx context.Context) ([]clickhouse.MeterCacheView, error)
+	EnsureMeterCache(ctx context.Context, namespace string, m meter.Meter) error
+	DropMeterCache(ctx context.Context, viewName string) error
+	DeleteMeterCacheOrphanRows(ctx context.Context, keepMeterHashes []string) error
+	ProbeMeterCacheCapabilities(ctx context.Context) (string, error)
+	MeterCacheRepairAge() time.Duration
+}
+
+var _ Connector = (*clickhouse.Connector)(nil)
+
+type Config struct {
+	// Enabled mirrors aggregation.cache.enabled. A disabled reconciler is still constructed
+	// and started so the server wiring stays unconditional; it parks idle until closed.
+	Enabled bool
+
+	Logger     *slog.Logger
+	Connector  Connector
+	Meters     meter.Service
+	LockClient *pglock.Client
+
+	ReconcileInterval time.Duration
+}
+
+func (c Config) Validate() error {
+	var errs []error
+
+	if c.Logger == nil {
+		errs = append(errs, errors.New("logger is required"))
+	}
+
+	if c.Enabled {
+		if c.Connector == nil {
+			errs = append(errs, errors.New("connector is required"))
+		}
+
+		if c.Meters == nil {
+			errs = append(errs, errors.New("meter service is required"))
+		}
+
+		if c.LockClient == nil {
+			errs = append(errs, errors.New("distributed lock client is required"))
+		}
+	}
+
+	if c.ReconcileInterval < 0 {
+		errs = append(errs, errors.New("reconcile interval must not be negative"))
+	}
+
+	return models.NewNillableGenericValidationError(errors.Join(errs...))
+}
+
+// Reconciler is the meter cache lifecycle reconciler. Start blocks running reconciliation
+// passes until Close, holding one global Postgres lock across each leadership term so at
+// most one instance mutates cache views at a time (same actor pattern as the notification
+// event handler).
+type Reconciler struct {
+	logger     *slog.Logger
+	connector  Connector
+	meters     meter.Service
+	lockClient *pglock.Client
+
+	enabled           bool
+	reconcileInterval time.Duration
+
+	running atomic.Bool
+	// disabled latches when the capability probe reports the deployment can never run the
+	// cache; it stops reconciliation attempts without stopping the process.
+	disabled    atomic.Bool
+	ctxCancel   context.CancelFunc
+	stopCh      chan struct{}
+	stopChClose func()
+}
+
+func New(config Config) (*Reconciler, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	if config.ReconcileInterval == 0 {
+		config.ReconcileInterval = DefaultReconcileInterval
+	}
+
+	stopCh := make(chan struct{})
+
+	return &Reconciler{
+		logger:            config.Logger,
+		connector:         config.Connector,
+		meters:            config.Meters,
+		lockClient:        config.LockClient,
+		enabled:           config.Enabled,
+		reconcileInterval: config.ReconcileInterval,
+		stopCh:            stopCh,
+		stopChClose:       sync.OnceFunc(func() { close(stopCh) }),
+	}, nil
+}
+
+func (r *Reconciler) Start() error {
+	if !r.running.CompareAndSwap(false, true) {
+		return errors.New("meter cache reconciler is already running")
+	}
+
+	defer func() {
+		if err := recover(); err != nil {
+			r.logger.Error("meter cache reconciler panicked",
+				"error", err,
+				"code.stacktrace", string(debug.Stack()))
+			_ = r.Close()
+		}
+	}()
+
+	var ctx context.Context
+
+	ctx, r.ctxCancel = context.WithCancel(context.Background())
+	defer r.ctxCancel()
+
+	if !r.enabled {
+		r.logger.Debug("meter cache is disabled, reconciler is idle")
+	}
+
+	for r.running.Load() && r.enabled && !r.disabled.Load() {
+		err := r.lockClient.Do(ctx, reconcilerLeaderLockKey, func(rCtx context.Context, _ *pglock.Lock) error {
+			return r.lead(rCtx)
+		})
+		if err != nil {
+			if errors.Is(err, pglock.ErrNotAcquired) {
+				r.logger.DebugContext(ctx, "meter cache reconciliation skipped: lock is not acquired")
+				continue
+			}
+
+			return fmt.Errorf("failed to acquire meter cache reconciliation lock: %w", err)
+		}
+	}
+
+	// This method runs as a run.Group actor: returning shuts the whole process down. A
+	// reconciler that has nothing to do (disabled by config or by the capability probe)
+	// therefore parks here until Close instead of returning early.
+	<-r.stopCh
+
+	return nil
+}
+
+func (r *Reconciler) Close() error {
+	if r.running.CompareAndSwap(true, false) {
+		r.logger.Debug("closing meter cache reconciler")
+
+		r.ctxCancel()
+		r.stopChClose()
+	}
+
+	return nil
+}
+
+// lead runs reconciliation passes while this instance holds the leader lock. The lock
+// client cancels ctx when the lease is lost, aborting a pass mid-flight; that is safe
+// because every pass operation is idempotent and a duplicate backfill from the next leader
+// resolves by newest-wins against whatever the aborted one already inserted.
+func (r *Reconciler) lead(ctx context.Context) error {
+	ticker := time.NewTicker(r.reconcileInterval)
+	defer ticker.Stop()
+
+	probed := false
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-r.stopCh:
+			r.logger.DebugContext(ctx, "close event received: stopping meter cache reconciler")
+			return nil
+		case <-ticker.C:
+			// The capability probe gates the first pass of each leadership term: an
+			// unsupported deployment (no refreshable views, missing grants) disables the
+			// reconciler for the process lifetime instead of failing the server, while a
+			// transient probe failure (ClickHouse briefly unreachable) is retried on the
+			// next tick.
+			if !probed {
+				version, err := r.connector.ProbeMeterCacheCapabilities(ctx)
+				if err != nil {
+					if errors.Is(err, clickhouse.ErrMeterCacheUnsupported) {
+						r.disabled.Store(true)
+						r.logger.ErrorContext(ctx, "meter cache reconciler disabled: ClickHouse deployment lacks required capabilities", "error", err)
+
+						return nil
+					}
+
+					r.logger.WarnContext(ctx, "meter cache capability probe failed, retrying", "error", err)
+
+					continue
+				}
+
+				r.logger.InfoContext(ctx, "meter cache reconciler active", "clickhouse_version", version)
+
+				probed = true
+			}
+
+			if err := r.reconcile(ctx); err != nil {
+				r.logger.ErrorContext(ctx, "meter cache reconciliation pass failed", "error", err)
+			}
+		}
+	}
+}
+
+// reconcile runs one full reconciliation pass: desired state from the meter definitions,
+// actual state from ClickHouse, then per-view convergence and orphan-row GC. Per-view
+// failures are collected instead of aborting the pass so one broken meter cannot block
+// every other meter's lifecycle.
+func (r *Reconciler) reconcile(ctx context.Context) error {
+	// The zero page returns all meters; soft-deleted ones are excluded by default, which is
+	// exactly the deletion signal: a deleted meter's view stops being desired.
+	meterList, err := r.meters.ListMeters(ctx, meter.ListMetersParams{WithoutNamespace: true})
+	if err != nil {
+		return fmt.Errorf("list meters: %w", err)
+	}
+
+	actual, err := r.connector.ListActualViews(ctx)
+	if err != nil {
+		return fmt.Errorf("list actual meter cache views: %w", err)
+	}
+
+	actualByName := make(map[string]clickhouse.MeterCacheView, len(actual))
+	for _, view := range actual {
+		actualByName[view.Name] = view
+	}
+
+	desired, keepHashes := r.desiredState(meterList.Items, actualByName)
+
+	var errs []error
+
+	// Undesired views first (deleted meters, pre-change shapes, foreign prefix squatters):
+	// dropping before creating keeps a shape swap from briefly running two refresh
+	// schedules against the shared target.
+	for _, view := range actual {
+		if _, ok := desired[view.Name]; ok {
+			continue
+		}
+
+		r.logger.InfoContext(ctx, "meter cache: dropping view without a desired meter", "view", view.Name, "meter", view.MeterKey)
+
+		if err := r.connector.DropMeterCache(ctx, view.Name); err != nil {
+			errs = append(errs, fmt.Errorf("drop meter cache view %s: %w", view.Name, err))
+		}
+	}
+
+	repairAge := r.connector.MeterCacheRepairAge()
+	now := time.Now()
+
+	for _, name := range slices.Sorted(maps.Keys(desired)) {
+		d := desired[name]
+
+		var actualView *clickhouse.MeterCacheView
+		if view, ok := actualByName[name]; ok {
+			actualView = &view
+		}
+
+		action, reason := planViewAction(d, actualView, repairAge, now)
+		if action == viewActionNone {
+			continue
+		}
+
+		r.logger.InfoContext(ctx, "meter cache: converging view",
+			"view", name, "namespace", d.meter.Namespace, "meter", d.meter.Key, "action", string(action), "reason", reason)
+
+		if action == viewActionRecreate {
+			if err := r.connector.DropMeterCache(ctx, name); err != nil {
+				errs = append(errs, fmt.Errorf("drop meter cache view %s: %w", name, err))
+
+				continue
+			}
+		}
+
+		if err := r.connector.EnsureMeterCache(ctx, d.meter.Namespace, d.meter); err != nil {
+			errs = append(errs, fmt.Errorf("ensure meter cache for %s/%s: %w", d.meter.Namespace, d.meter.Key, err))
+		}
+	}
+
+	// Orphan-row GC runs every pass, last: the ensures above may have written new-shape
+	// rows whose hashes must be in the keep set by the time old-shape rows are deleted.
+	// Rows a dying previous leader's in-flight old-shape backfill lands after this delete
+	// stay orphaned until the next pass, which is acceptable because reads filter on the
+	// current meter hash and never see them (G8).
+	if err := r.connector.DeleteMeterCacheOrphanRows(ctx, keepHashes); err != nil {
+		errs = append(errs, fmt.Errorf("delete orphan meter cache rows: %w", err))
+	}
+
+	return errors.Join(errs...)
+}
+
+// desiredView is one entry of the reconciler's desired state: the meter that should be
+// served by the view and the name/hashes its deployment must converge to.
+type desiredView struct {
+	meter meter.Meter
+	view  clickhouse.MeterCacheDesiredView
+}
+
+// desiredState maps the current meter definitions onto desired cache views, keyed by view
+// name, plus the meter-hash keep set for orphan-row GC.
+//
+// Meters the generator refuses (reserved group-by aliases, G9) are logged and skipped —
+// they are served live by the read gate, never a reconciliation error. Their hashes are
+// also absent from the keep set, which is safe because the same generator refusal means no
+// rows were ever written for such a shape.
+func (r *Reconciler) desiredState(meters []meter.Meter, actualByName map[string]clickhouse.MeterCacheView) (map[string]desiredView, []string) {
+	// Deterministic order makes same-shape conflict resolution stable across passes.
+	sorted := slices.SortedFunc(slices.Values(meters), func(a, b meter.Meter) int {
+		if c := strings.Compare(a.Namespace, b.Namespace); c != 0 {
+			return c
+		}
+
+		return strings.Compare(a.Key, b.Key)
+	})
+
+	desired := make(map[string]desiredView, len(sorted))
+	keepHashes := make([]string, 0, len(sorted))
+
+	for _, m := range sorted {
+		dv, err := r.connector.DesiredMeterCacheView(m.Namespace, m)
+		if err != nil {
+			r.logger.Warn("meter cache: meter is not cacheable, serving it live", "namespace", m.Namespace, "meter", m.Key, "error", err)
+
+			continue
+		}
+
+		keepHashes = append(keepHashes, dv.MeterHash)
+
+		current, taken := desired[dv.Name]
+		if !taken {
+			desired[dv.Name] = desiredView{meter: m, view: dv}
+
+			continue
+		}
+
+		// Same-shape conflict: meters with identical shape share a meter hash and thus one
+		// view name, but the view stamps a single meter_key into its rows, so it can only
+		// ever serve one of them; the read gate refuses it for the others (they stay live).
+		// Ownership prefers the meter the deployed view was created for so it does not flap
+		// between passes; without a deployed view the (namespace, key)-first meter wins.
+		loser := m
+		if actual, ok := actualByName[dv.Name]; ok && actual.MetadataOK && actual.MeterKey == m.Key && current.meter.Key != m.Key {
+			loser = current.meter
+			desired[dv.Name] = desiredView{meter: m, view: dv}
+		}
+
+		r.logger.Warn("meter cache: meter shares its cache shape with another meter, serving it live",
+			"namespace", loser.Namespace, "meter", loser.Key, "owner", desired[dv.Name].meter.Key)
+	}
+
+	slices.Sort(keepHashes)
+
+	return desired, slices.Compact(keepHashes)
+}
+
+// viewAction is the reconciler's convergence decision for one desired cache view.
+type viewAction string
+
+const (
+	viewActionNone viewAction = "none"
+	// viewActionEnsure creates the view if missing, backfills settled history, and stamps
+	// backfilled_at; over an existing view it is the repair path (re-backfill + re-stamp).
+	viewActionEnsure viewAction = "ensure"
+	// viewActionRecreate drops the deployed view first, then performs ensure.
+	viewActionRecreate viewAction = "recreate"
+)
+
+// planViewAction decides how to converge one desired view given its deployed counterpart
+// (nil when not deployed). It returns the action plus a short reason for operator logs.
+func planViewAction(d desiredView, actual *clickhouse.MeterCacheView, repairAge time.Duration, now time.Time) (viewAction, string) {
+	if actual == nil {
+		return viewActionEnsure, "view missing"
+	}
+
+	if !actual.MetadataOK {
+		return viewActionRecreate, "unparseable view metadata"
+	}
+
+	// A hash mismatch at the desired name means the deployed object was not produced by the
+	// current generator for this meter (corrupt or hand-altered comment); a key/event-type
+	// mismatch means it was created for a same-shape meter that is no longer desired (had
+	// it been, ownership in desiredState would have followed the deployed view).
+	if actual.MeterKey != d.meter.Key || actual.EventType != d.meter.EventType || actual.MeterHash != d.view.MeterHash {
+		return viewActionRecreate, "view metadata mismatch"
+	}
+
+	// DDL drift: refresh cadence, freshness horizon, EventFrom, or the generated SELECT
+	// changed since deployment. The recreate always re-backfills even though only some
+	// drifts strictly need it (a decreased usage age or an earlier EventFrom leave settled
+	// history the old view never cached): the stored hash cannot reveal which input moved,
+	// skipping a needed re-backfill silently undercounts forever, and a redundant one is
+	// idempotent under newest-wins.
+	if actual.DDLHash != d.view.DDLHash {
+		return viewActionRecreate, "ddl drift"
+	}
+
+	// G3: an unstamped view is a create-or-backfill sequence some actor started and never
+	// finished (leader crash mid-backfill). Ensure re-runs backfill and stamps; the create
+	// inside it is a no-op on the existing view.
+	if actual.BackfilledAt == nil {
+		return viewActionEnsure, "backfill unstamped"
+	}
+
+	// Extended refresh outage: once the last successful refresh is older than the dirty
+	// window slack, buckets that settled early in the outage may never be recomputed by any
+	// future refresh, so the cache content must be rebuilt. The backfill stamp doubles as
+	// the repair throttle — a repair refreshes it, so a view whose refreshes stay broken is
+	// re-repaired at most once per repairAge instead of on every pass. A nil
+	// LastSuccessTime is deliberately not repaired: it means no successful refresh since
+	// ClickHouse startup (fresh view or recent server restart), and mass re-backfilling
+	// every view on each ClickHouse restart would be a self-inflicted load storm while the
+	// read gate already refuses stale views.
+	if actual.LastSuccessTime != nil &&
+		now.Sub(*actual.LastSuccessTime) > repairAge &&
+		now.Sub(*actual.BackfilledAt) > repairAge {
+		return viewActionEnsure, "refresh outage"
+	}
+
+	return viewActionNone, ""
+}

--- a/openmeter/streaming/clickhouse/metercache/reconciler_ch_test.go
+++ b/openmeter/streaming/clickhouse/metercache/reconciler_ch_test.go
@@ -339,3 +339,294 @@ func TestReconcilerLifecycle(t *testing.T) {
 		require.Equal(t, uint64(0), env.totalCachedRowCount(t, ctx))
 	})
 }
+
+// rewriteViewMetadata mutates a deployed view's comment metadata JSON in place, modeling
+// stamps a past deployment would carry (backdated backfilled_at, adjusted covered_at)
+// without waiting real time. Keys mapped to nil are removed.
+func rewriteViewMetadata(t *testing.T, ctx context.Context, env *chTestEnv, viewName string, fields map[string]any) {
+	t.Helper()
+
+	var comment string
+	require.NoError(t, env.conn.QueryRow(ctx,
+		"SELECT comment FROM system.tables WHERE database = ? AND name = ?", env.database, viewName,
+	).Scan(&comment))
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal([]byte(comment), &metadata))
+
+	for key, value := range fields {
+		if value == nil {
+			delete(metadata, key)
+
+			continue
+		}
+
+		metadata[key] = value
+	}
+
+	rewritten, err := json.Marshal(metadata)
+	require.NoError(t, err)
+
+	escaped := strings.ReplaceAll(string(rewritten), `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+	require.NoError(t, env.conn.Exec(ctx, fmt.Sprintf("ALTER TABLE %s.%s MODIFY COMMENT '%s'", env.database, viewName, escaped)))
+}
+
+// queryCachedIntent runs one meter query with Cachable set and reports whether the cache
+// path actually served it (no "serving live" fallback logged).
+func queryCachedIntent(t *testing.T, ctx context.Context, env *chTestEnv, namespace string, m meter.Meter, params streaming.QueryParams) ([]meter.MeterQueryRow, bool) {
+	t.Helper()
+
+	env.logs.Reset()
+
+	params.Cachable = true
+	rows, err := env.connector.QueryMeter(ctx, namespace, m, params)
+	require.NoError(t, err)
+
+	return rows, !strings.Contains(env.logs.String(), "serving live")
+}
+
+// TestWatermarkRepairsRestartOutageGap is the extended-outage regression the durable
+// coverage watermark exists for: buckets that settled while refreshes were absent longer
+// than the dirty-window slack are recomputed by no future refresh — their events'
+// stored_at has aged out of the lookback and the newly-settled strip has moved past them
+// — and system.view_refreshes cannot reveal the gap after a ClickHouse restart (it is
+// wiped: first nil, then fresh again the moment one refresh succeeds). Only the durable
+// watermark stamped in the view's comment still shows how old the last covered refresh
+// was, and the reconciler must react with a re-backfill.
+//
+// The outage is modeled without waiting: the gap event's stored_at is backdated beyond
+// the dirty window and the deployed view's stamps are rewritten to the pre-outage past,
+// exactly the state a restart-after-outage leaves behind, while the refresh state is
+// genuinely fresh.
+//
+// Watched RED with the guard reverted: making planViewAction consult only
+// now − LastSuccessTime (the pre-watermark rule) lets the fresh post-outage refresh mask
+// the gap — the repair pass becomes a no-op and the final cached read returns 2 instead
+// of 102, permanently missing the gap bucket's usage.
+func TestWatermarkRepairsRestartOutageGap(t *testing.T) {
+	env := newCHTestEnv(t)
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-restart-outage"
+		eventType = "api-calls"
+	)
+
+	now := time.Now().UTC()
+	bucketCovered := now.Add(-4 * time.Hour).Truncate(time.Hour)
+	bucketGap := now.Add(-6 * time.Hour).Truncate(time.Hour)
+
+	newEvent := func(at time.Time, data string, storedAt time.Time) streaming.RawEvent {
+		return streaming.RawEvent{
+			Namespace:  namespace,
+			ID:         ulid.Make().String(),
+			Type:       eventType,
+			Source:     "test-source",
+			Subject:    "subject-1",
+			Time:       at,
+			Data:       data,
+			IngestedAt: storedAt,
+			StoredAt:   storedAt,
+		}
+	}
+
+	insertEvents := func(events ...streaming.RawEvent) {
+		insertSQL, insertArgs := clickhouse.InsertEventsQuery{
+			Database:        env.database,
+			EventsTableName: "om_events",
+			Events:          events,
+		}.ToSQL()
+		require.NoError(t, env.conn.Exec(ctx, insertSQL, insertArgs...))
+	}
+
+	// given:
+	// - one settled event covered by the initial deploy
+	insertEvents(newEvent(bucketCovered.Add(5*time.Minute), `{"value": 2}`, now))
+
+	m := newTestMeter(namespace, "meter-sum", eventType, nil)
+
+	meterService := &fakeMeterService{meters: []meter.Meter{m}}
+	reconciler := newTestReconciler(env.connector, meterService)
+
+	require.NoError(t, reconciler.reconcile(ctx))
+
+	desired, err := env.connector.DesiredMeterCacheView(namespace, m)
+	require.NoError(t, err)
+	require.NoError(t, env.conn.Exec(ctx, fmt.Sprintf("SYSTEM WAIT VIEW %s.%s", env.database, desired.Name)))
+
+	// given:
+	// - a gap event: stored before the modeled outage (stored_at aged beyond the 1h30m
+	//   dirty lookback), in a bucket the newly-settled strip has long moved past — the
+	//   state an on-time event ends up in when its bucket settles mid-outage. It lands
+	//   after the deploy backfill, so only a repair re-backfill can ever cache it.
+	insertEvents(newEvent(bucketGap.Add(10*time.Minute), `{"value": 100}`, now.Add(-3*time.Hour)))
+
+	require.NoError(t, env.conn.Exec(ctx, fmt.Sprintf("SYSTEM REFRESH VIEW %s.%s", env.database, desired.Name)))
+	require.NoError(t, env.conn.Exec(ctx, fmt.Sprintf("SYSTEM WAIT VIEW %s.%s", env.database, desired.Name)))
+
+	from := bucketGap
+	to := now.Truncate(time.Hour).Add(time.Hour)
+	params := streaming.QueryParams{From: &from, To: &to}
+
+	// then:
+	// - the refresh proved unable to recover the gap: the cached read really serves the
+	//   cache leg and undercounts by the gap bucket
+	rows, servedCached := queryCachedIntent(t, ctx, env, namespace, m, params)
+	require.True(t, servedCached, "cached read fell back to the live path")
+	require.Len(t, rows, 1)
+	require.Equal(t, float64(2), rows[0].Value)
+
+	// given:
+	// - the durable stamps say coverage was last provably continuous two hours ago, while
+	//   the refresh state is fresh — the exact post-restart shape
+	rewriteViewMetadata(t, ctx, env, desired.Name, map[string]any{
+		"backfilled_at": now.Add(-2 * time.Hour).Format(time.RFC3339),
+		"covered_at":    nil,
+	})
+
+	// when:
+	// - the next reconciliation pass runs
+	require.NoError(t, reconciler.reconcile(ctx))
+
+	// then:
+	// - the pass re-backfilled (fresh stamp) and the cached read converges to live,
+	//   gap bucket included
+	views, err := env.connector.ListActualViews(ctx)
+	require.NoError(t, err)
+	require.Len(t, views, 1)
+	require.NotNil(t, views[0].BackfilledAt)
+	require.True(t, views[0].BackfilledAt.After(now.Add(-time.Hour)), "repair must re-stamp the backfill")
+
+	paramsLive := params
+	paramsLive.Cachable = false
+	live, err := env.connector.QueryMeter(ctx, namespace, m, paramsLive)
+	require.NoError(t, err)
+	require.Len(t, live, 1)
+	require.Equal(t, float64(102), live[0].Value)
+
+	rows, servedCached = queryCachedIntent(t, ctx, env, namespace, m, params)
+	require.True(t, servedCached, "cached read fell back to the live path")
+	require.Len(t, rows, 1)
+	require.Equal(t, float64(102), rows[0].Value)
+}
+
+// TestExpiredUnhealedMarkersRepairAndGC drives the reconciler's marker maintenance end to
+// end: a marker whose heal window expired unhealed (its late events aged out of every
+// future refresh's lookback during a refresh gap) forces a re-backfill of the serving
+// view, after which the marker counts as healed-by-backfill and is deleted — so the
+// marked range returns to cache-serving instead of staying live until the marker's 7 day
+// TTL.
+//
+// covered_at is pinned fresh while backfilled_at is backdated so the marker path is
+// isolated from the watermark outage rule: only the marker report can trigger the repair
+// here.
+//
+// Watched RED with the guard reverted: dropping the ReconcileMeterCacheMarkers call from
+// reconcile (returning nil) leaves the marker in place forever — the final marker-count
+// assertion reads 1 and the last cached read falls back live (unhealed_markers).
+func TestExpiredUnhealedMarkersRepairAndGC(t *testing.T) {
+	env := newCHTestEnv(t)
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-marker-repair"
+		eventType = "api-calls"
+	)
+
+	now := time.Now().UTC()
+	bucket := now.Add(-5 * time.Hour).Truncate(time.Hour)
+
+	newEvent := func(at time.Time, data string, storedAt time.Time) streaming.RawEvent {
+		return streaming.RawEvent{
+			Namespace:  namespace,
+			ID:         ulid.Make().String(),
+			Type:       eventType,
+			Source:     "test-source",
+			Subject:    "subject-1",
+			Time:       at,
+			Data:       data,
+			IngestedAt: storedAt,
+			StoredAt:   storedAt,
+		}
+	}
+
+	insertEvents := func(events ...streaming.RawEvent) {
+		insertSQL, insertArgs := clickhouse.InsertEventsQuery{
+			Database:        env.database,
+			EventsTableName: "om_events",
+			Events:          events,
+		}.ToSQL()
+		require.NoError(t, env.conn.Exec(ctx, insertSQL, insertArgs...))
+	}
+
+	insertEvents(
+		newEvent(bucket.Add(5*time.Minute), `{"value": 2}`, now),
+		newEvent(bucket.Add(10*time.Minute), `{"value": 7}`, now),
+	)
+
+	m := newTestMeter(namespace, "meter-sum", eventType, nil)
+
+	meterService := &fakeMeterService{meters: []meter.Meter{m}}
+	reconciler := newTestReconciler(env.connector, meterService)
+
+	require.NoError(t, reconciler.reconcile(ctx))
+
+	desired, err := env.connector.DesiredMeterCacheView(namespace, m)
+	require.NoError(t, err)
+	require.NoError(t, env.conn.Exec(ctx, fmt.Sprintf("SYSTEM WAIT VIEW %s.%s", env.database, desired.Name)))
+
+	// given:
+	// - a late event whose stored_at already aged out of the dirty lookback (no refresh
+	//   will ever recompute its bucket) and its marker, created 25 minutes ago — past the
+	//   20m heal bound, so no future refresh can heal it either,
+	// - stamps rewritten so the backfill predates the marker (the deploy really ran before
+	//   the modeled outage) while covered_at stays fresh (isolates the marker repair from
+	//   the watermark rule)
+	insertEvents(newEvent(bucket.Add(20*time.Minute), `{"value": 100}`, now.Add(-3*time.Hour)))
+
+	require.NoError(t, env.conn.Exec(ctx,
+		fmt.Sprintf("INSERT INTO %s.om_meter_cache_invalidations (namespace, event_type, window_lo, window_hi, created_at) VALUES (?, ?, ?, ?, ?)", env.database),
+		namespace, eventType, bucket, bucket.Add(time.Hour), now.Add(-25*time.Minute),
+	))
+
+	rewriteViewMetadata(t, ctx, env, desired.Name, map[string]any{
+		"backfilled_at": now.Add(-2 * time.Hour).Format(time.RFC3339),
+		"covered_at":    now.Format(time.RFC3339),
+	})
+
+	from := bucket
+	to := now.Truncate(time.Hour).Add(time.Hour)
+	params := streaming.QueryParams{From: &from, To: &to}
+
+	// then:
+	// - while the marker is unhealed the reader stays conservative: the query is served
+	//   live and therefore already sees the late event
+	rows, servedCached := queryCachedIntent(t, ctx, env, namespace, m, params)
+	require.False(t, servedCached, "unhealed marker must force the live path")
+	require.Contains(t, env.logs.String(), "unhealed_markers")
+	require.Len(t, rows, 1)
+	require.Equal(t, float64(109), rows[0].Value)
+
+	// when:
+	// - the next pass runs: marker maintenance reports the view, the repair re-backfills
+	//   (picking up the late event, stamping a fresh backfilled_at past the marker)
+	require.NoError(t, reconciler.reconcile(ctx))
+
+	// - and the pass after that deletes the marker, now healed by the fresh backfill
+	require.NoError(t, reconciler.reconcile(ctx))
+
+	// then:
+	// - the marker is gone and the marked range serves from the cache again, late event
+	//   included
+	var markerCount uint64
+	require.NoError(t, env.conn.QueryRow(ctx,
+		fmt.Sprintf("SELECT count() FROM %s.om_meter_cache_invalidations", env.database),
+	).Scan(&markerCount))
+	require.Equal(t, uint64(0), markerCount)
+
+	rows, servedCached = queryCachedIntent(t, ctx, env, namespace, m, params)
+	require.True(t, servedCached, "cached read fell back to the live path")
+	require.Len(t, rows, 1)
+	require.Equal(t, float64(109), rows[0].Value)
+}

--- a/openmeter/streaming/clickhouse/metercache/reconciler_ch_test.go
+++ b/openmeter/streaming/clickhouse/metercache/reconciler_ch_test.go
@@ -1,0 +1,341 @@
+package metercache
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	clickhousego "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	progressmanageradapter "github.com/openmeterio/openmeter/openmeter/progressmanager/adapter"
+	"github.com/openmeterio/openmeter/openmeter/streaming"
+	"github.com/openmeterio/openmeter/openmeter/streaming/clickhouse"
+)
+
+// chTestEnv is the metercache package's ClickHouse harness: a temp database, a raw
+// connection for assertions, and a cache-enabled connector. It mirrors the clickhouse
+// package's CHTestSuite, which is not importable from here (test-file only).
+type chTestEnv struct {
+	conn      clickhousego.Conn
+	database  string
+	connector *clickhouse.Connector
+	logs      *bytes.Buffer
+}
+
+func newCHTestEnv(t *testing.T) *chTestEnv {
+	t.Helper()
+
+	dsn := os.Getenv("TEST_CLICKHOUSE_DSN")
+	if dsn == "" {
+		t.Skip("TEST_CLICKHOUSE_DSN is not set; skipping integration tests")
+	}
+
+	opts, err := clickhousego.ParseDSN(dsn)
+	require.NoError(t, err, "failed to parse ClickHouse DSN")
+
+	conn, err := clickhousego.Open(opts)
+	require.NoError(t, err, "failed to open ClickHouse connection")
+
+	database := fmt.Sprintf("test_%s", ulid.MustNew(ulid.Timestamp(time.Now().UTC()), rand.Reader).String())
+	require.NoError(t, conn.Exec(t.Context(), fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", database)))
+
+	t.Cleanup(func() {
+		if !t.Failed() {
+			_ = conn.Exec(context.Background(), fmt.Sprintf("DROP DATABASE IF EXISTS %s SYNC", database))
+			_ = conn.Close()
+		}
+	})
+
+	// The connector logs "serving live" on every cache fallback; capturing the logs lets
+	// cached queries assert they were really served from the cache leg.
+	logs := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	connector, err := clickhouse.New(t.Context(), clickhouse.Config{
+		Logger:                 logger,
+		ClickHouse:             conn,
+		Database:               database,
+		EventsTableName:        "om_events",
+		EnableDecimalPrecision: true,
+		ProgressManager:        progressmanageradapter.NewMockProgressManager(),
+		Cache: clickhouse.CacheConfig{
+			Enabled:         true,
+			RefreshInterval: 10 * time.Minute,
+			MinimumUsageAge: time.Hour,
+			WindowSize:      clickhouse.CacheGrainHour,
+		},
+	})
+	require.NoError(t, err)
+
+	return &chTestEnv{
+		conn:      conn,
+		database:  database,
+		connector: connector,
+		logs:      logs,
+	}
+}
+
+func (e *chTestEnv) cachedRowCount(t *testing.T, ctx context.Context, formattedMeterHash string) uint64 {
+	t.Helper()
+
+	hash, err := strconv.ParseUint(formattedMeterHash, 16, 64)
+	require.NoError(t, err)
+
+	// FINAL folds re-appended bucket versions (backfill overlapping the initial refresh)
+	// into the newest-wins view the readers see, so counts are version-independent.
+	var count uint64
+	require.NoError(t, e.conn.QueryRow(ctx,
+		fmt.Sprintf("SELECT count() FROM %s.om_meter_cache FINAL WHERE meter_hash = ?", e.database), hash,
+	).Scan(&count))
+
+	return count
+}
+
+func (e *chTestEnv) totalCachedRowCount(t *testing.T, ctx context.Context) uint64 {
+	t.Helper()
+
+	var count uint64
+	require.NoError(t, e.conn.QueryRow(ctx, fmt.Sprintf("SELECT count() FROM %s.om_meter_cache FINAL", e.database)).Scan(&count))
+
+	return count
+}
+
+// TestReconcilerLifecycle drives the reconciler's full MV lifecycle against a real
+// ClickHouse through sequential phases sharing one database: create, leader crash
+// mid-backfill repair, meter shape change swap, and meter deletion. Phases build on each
+// other on purpose — each starts from the state the previous one converged to, exactly
+// like consecutive reconciliation passes in production.
+//
+// Watched RED with guards reverted: making planViewAction return viewActionNone for the
+// unstamped case fails the crash-repair phase (stamp never restored), and dropping the
+// DeleteMeterCacheOrphanRows call from reconcile fails the shape-change phase on the
+// old-hash row count.
+func TestReconcilerLifecycle(t *testing.T) {
+	env := newCHTestEnv(t)
+	ctx := t.Context()
+
+	const (
+		namespace = "cache-lifecycle"
+		eventType = "api-calls"
+	)
+
+	now := time.Now().UTC()
+	bucketA := now.Add(-4 * time.Hour).Truncate(time.Hour)
+	bucketB := now.Add(-3 * time.Hour).Truncate(time.Hour)
+
+	// given:
+	// - settled events in two hour buckets (two subjects, two dimension values) plus one
+	//   event in the always-live tail, inserted directly so no invalidation markers exist
+	newEvent := func(subject string, at time.Time, data string) streaming.RawEvent {
+		return streaming.RawEvent{
+			Namespace:  namespace,
+			ID:         ulid.Make().String(),
+			Type:       eventType,
+			Source:     "test-source",
+			Subject:    subject,
+			Time:       at,
+			Data:       data,
+			IngestedAt: now,
+			StoredAt:   now,
+		}
+	}
+
+	insertSQL, insertArgs := clickhouse.InsertEventsQuery{
+		Database:        env.database,
+		EventsTableName: "om_events",
+		Events: []streaming.RawEvent{
+			newEvent("subject-1", bucketA.Add(5*time.Minute), `{"value": 2, "group1": "a"}`),
+			newEvent("subject-1", bucketA.Add(10*time.Minute), `{"value": 7, "group1": "a"}`),
+			newEvent("subject-2", bucketA.Add(20*time.Minute), `{"value": 5, "group1": "b"}`),
+			newEvent("subject-1", bucketB.Add(15*time.Minute), `{"value": 3, "group1": "b"}`),
+			newEvent("subject-2", now.Add(-20*time.Minute), `{"value": 11, "group1": "a"}`),
+		},
+	}.ToSQL()
+	require.NoError(t, env.conn.Exec(ctx, insertSQL, insertArgs...))
+
+	meterService := &fakeMeterService{}
+	reconciler := newTestReconciler(env.connector, meterService)
+
+	from := now.Add(-6 * time.Hour).Truncate(time.Hour)
+	to := now.Truncate(time.Hour).Add(time.Hour)
+	windowSizeHour := meter.WindowSizeHour
+
+	queryParams := streaming.QueryParams{
+		From:       &from,
+		To:         &to,
+		WindowSize: &windowSizeHour,
+		GroupBy:    []string{"subject", "group1"},
+	}
+
+	// requireCachedReadParity proves cached rows are what reads actually serve: the cached
+	// run must not log a live fallback and must return exactly the live path's rows.
+	requireCachedReadParity := func(m meter.Meter) {
+		t.Helper()
+
+		params := queryParams
+		params.Cachable = false
+		live, err := env.connector.QueryMeter(ctx, namespace, m, params)
+		require.NoError(t, err)
+		require.NotEmpty(t, live, "parity would be trivial on an empty result")
+
+		env.logs.Reset()
+
+		params.Cachable = true
+		cached, err := env.connector.QueryMeter(ctx, namespace, m, params)
+		require.NoError(t, err)
+		require.NotContains(t, env.logs.String(), "serving live", "cached query fell back to the live path")
+
+		require.ElementsMatch(t, live, cached)
+	}
+
+	// the capability probe must pass on the test deployment before anything else would run
+	version, err := env.connector.ProbeMeterCacheCapabilities(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, version)
+
+	meterV1 := newTestMeter(namespace, "meter-sum", eventType, map[string]string{"group1": "$.group1"})
+	desiredV1, err := env.connector.DesiredMeterCacheView(namespace, meterV1)
+	require.NoError(t, err)
+
+	t.Run("CreateDeploysBackfillsAndStamps", func(t *testing.T) {
+		// when:
+		// - the meter appears and a pass runs
+		meterService.meters = []meter.Meter{meterV1}
+		require.NoError(t, reconciler.reconcile(ctx))
+
+		// then:
+		// - the view is deployed with converged metadata and a backfill stamp
+		views, err := env.connector.ListActualViews(ctx)
+		require.NoError(t, err)
+		require.Len(t, views, 1)
+		require.Equal(t, desiredV1.Name, views[0].Name)
+		require.True(t, views[0].MetadataOK)
+		require.Equal(t, meterV1.Key, views[0].MeterKey)
+		require.Equal(t, desiredV1.MeterHash, views[0].MeterHash)
+		require.Equal(t, desiredV1.DDLHash, views[0].DDLHash)
+		require.NotNil(t, views[0].BackfilledAt)
+
+		// then:
+		// - the backfill populated the settled buckets (3 subject × dimension rows)
+		require.Equal(t, uint64(3), env.cachedRowCount(t, ctx, desiredV1.MeterHash))
+
+		// then:
+		// - a converged view is left alone by the next pass
+		require.NoError(t, reconciler.reconcile(ctx))
+		require.Equal(t, uint64(3), env.cachedRowCount(t, ctx, desiredV1.MeterHash))
+
+		// then:
+		// - once the view has a successful refresh, cached reads serve live-equal rows
+		require.NoError(t, env.conn.Exec(ctx, fmt.Sprintf("SYSTEM WAIT VIEW %s.%s", env.database, desiredV1.Name)))
+		requireCachedReadParity(meterV1)
+	})
+
+	t.Run("CrashMidBackfillIsRepairedByNextPass", func(t *testing.T) {
+		// given:
+		// - the exact state a leader crash between CREATE and backfill leaves behind: the
+		//   view exists with an unstamped comment and the cache holds none of its rows
+		var comment string
+		require.NoError(t, env.conn.QueryRow(ctx,
+			"SELECT comment FROM system.tables WHERE database = ? AND name = ?", env.database, desiredV1.Name,
+		).Scan(&comment))
+
+		var metadata map[string]any
+		require.NoError(t, json.Unmarshal([]byte(comment), &metadata))
+		delete(metadata, "backfilled_at")
+
+		unstamped, err := json.Marshal(metadata)
+		require.NoError(t, err)
+
+		escaped := strings.ReplaceAll(string(unstamped), `\`, `\\`)
+		escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+		require.NoError(t, env.conn.Exec(ctx, fmt.Sprintf("ALTER TABLE %s.%s MODIFY COMMENT '%s'", env.database, desiredV1.Name, escaped)))
+
+		require.NoError(t, env.conn.Exec(ctx, fmt.Sprintf("DELETE FROM %s.om_meter_cache WHERE true", env.database)))
+		require.Equal(t, uint64(0), env.totalCachedRowCount(t, ctx))
+
+		// when:
+		// - the next pass runs
+		require.NoError(t, reconciler.reconcile(ctx))
+
+		// then:
+		// - the pass re-backfilled in place (no drop, so the same view object) and stamped
+		views, err := env.connector.ListActualViews(ctx)
+		require.NoError(t, err)
+		require.Len(t, views, 1)
+		require.True(t, views[0].MetadataOK)
+		require.NotNil(t, views[0].BackfilledAt)
+		require.Equal(t, uint64(3), env.cachedRowCount(t, ctx, desiredV1.MeterHash))
+	})
+
+	meterV2 := newTestMeter(namespace, "meter-sum", eventType, map[string]string{"group2": "$.group1"})
+	desiredV2, err := env.connector.DesiredMeterCacheView(namespace, meterV2)
+	require.NoError(t, err)
+
+	t.Run("ShapeChangeSwapsViewAndGCsOldRows", func(t *testing.T) {
+		// when:
+		// - the meter's group-by dimension is renamed (new meter hash, new view name)
+		meterService.meters = []meter.Meter{meterV2}
+		require.NoError(t, reconciler.reconcile(ctx))
+
+		// then:
+		// - the old view is gone, the new one is deployed and stamped
+		views, err := env.connector.ListActualViews(ctx)
+		require.NoError(t, err)
+		require.Len(t, views, 1)
+		require.Equal(t, desiredV2.Name, views[0].Name)
+		require.NotNil(t, views[0].BackfilledAt)
+
+		// then:
+		// - the old shape's rows were GC'd in the same pass, the new shape's rows exist
+		require.Equal(t, uint64(0), env.cachedRowCount(t, ctx, desiredV1.MeterHash))
+		require.Equal(t, uint64(3), env.cachedRowCount(t, ctx, desiredV2.MeterHash))
+
+		// then:
+		// - reads under the new shape serve live-equal rows (the meter_hash filter keeps any
+		//   old-shape leftovers out of results even before GC lands)
+		require.NoError(t, env.conn.Exec(ctx, fmt.Sprintf("SYSTEM WAIT VIEW %s.%s", env.database, desiredV2.Name)))
+
+		params := queryParams
+		params.GroupBy = []string{"subject", "group2"}
+
+		paramsLive := params
+		paramsLive.Cachable = false
+		live, err := env.connector.QueryMeter(ctx, namespace, meterV2, paramsLive)
+		require.NoError(t, err)
+		require.NotEmpty(t, live)
+
+		env.logs.Reset()
+
+		paramsCached := params
+		paramsCached.Cachable = true
+		cached, err := env.connector.QueryMeter(ctx, namespace, meterV2, paramsCached)
+		require.NoError(t, err)
+		require.NotContains(t, env.logs.String(), "serving live", "cached query fell back to the live path")
+		require.ElementsMatch(t, live, cached)
+	})
+
+	t.Run("MeterDeletionDropsViewAndRows", func(t *testing.T) {
+		// when:
+		// - the meter disappears from the desired set (soft delete excludes it from listing)
+		meterService.meters = nil
+		require.NoError(t, reconciler.reconcile(ctx))
+
+		// then:
+		// - no cache view remains and every cached row was GC'd
+		views, err := env.connector.ListActualViews(ctx)
+		require.NoError(t, err)
+		require.Empty(t, views)
+		require.Equal(t, uint64(0), env.totalCachedRowCount(t, ctx))
+	})
+}

--- a/openmeter/streaming/clickhouse/metercache/reconciler_test.go
+++ b/openmeter/streaming/clickhouse/metercache/reconciler_test.go
@@ -178,12 +178,20 @@ func newTestMeter(namespace, key, eventType string, groupBy map[string]string) m
 }
 
 // newTestReconciler builds a pass-only reconciler: unit tests drive reconcile directly, so
-// the leader lock and lifecycle fields stay zero.
+// the leader lock and lifecycle fields stay zero. observability is built with nil
+// Meter/Tracer (the same as a production reconciler with telemetry unconfigured) so
+// reconcile's recording calls exercise the real no-op fallback instead of a nil pointer.
 func newTestReconciler(connector Connector, meters meter.Service) *Reconciler {
+	observability, err := newObservability(nil, nil)
+	if err != nil {
+		panic(err)
+	}
+
 	return &Reconciler{
-		logger:    slog.Default(),
-		connector: connector,
-		meters:    meters,
+		logger:        slog.Default(),
+		connector:     connector,
+		meters:        meters,
+		observability: observability,
 	}
 }
 

--- a/openmeter/streaming/clickhouse/metercache/reconciler_test.go
+++ b/openmeter/streaming/clickhouse/metercache/reconciler_test.go
@@ -1,0 +1,499 @@
+package metercache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"log/slog"
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openmeterio/openmeter/openmeter/meter"
+	"github.com/openmeterio/openmeter/openmeter/streaming/clickhouse"
+	"github.com/openmeterio/openmeter/pkg/models"
+	"github.com/openmeterio/openmeter/pkg/pagination"
+)
+
+// fakeMeterShapeHash mirrors the production property the reconciler depends on — meters
+// with identical shape map to identical view names and meter hashes — without depending on
+// the clickhouse package's unexported hash implementation.
+func fakeMeterShapeHash(m meter.Meter) uint64 {
+	h := fnv.New64a()
+
+	parts := []string{m.EventType, string(m.Aggregation), lo.FromPtr(m.ValueProperty)}
+	for _, key := range slices.Sorted(maps.Keys(m.GroupBy)) {
+		parts = append(parts, key, m.GroupBy[key])
+	}
+
+	_, _ = h.Write([]byte(strings.Join(parts, "|")))
+
+	return h.Sum64()
+}
+
+func fakeDesiredView(namespace string, m meter.Meter, ddlSalt string) clickhouse.MeterCacheDesiredView {
+	shapeHash := fakeMeterShapeHash(m)
+
+	ns := fnv.New32a()
+	_, _ = ns.Write([]byte(namespace))
+
+	ddl := fnv.New64a()
+	_, _ = fmt.Fprintf(ddl, "%016x|%s", shapeHash, ddlSalt)
+
+	return clickhouse.MeterCacheDesiredView{
+		Name:      fmt.Sprintf("om_meter_cache_mv_%08x_%016x", ns.Sum32(), shapeHash),
+		MeterHash: fmt.Sprintf("%016x", shapeHash),
+		DDLHash:   fmt.Sprintf("%016x", ddl.Sum64()),
+	}
+}
+
+type fakeConnector struct {
+	repairAge time.Duration
+	// ddlSalt feeds the fake DDL hash so tests can simulate config-driven DDL drift by
+	// deploying an actual view recorded under a different salt.
+	ddlSalt string
+
+	actual []clickhouse.MeterCacheView
+
+	desiredErr map[string]error
+	ensureErr  map[string]error
+
+	ensured     []string
+	dropped     []string
+	gcKeepSets  [][]string
+	probeCalled int
+	probeErr    error
+}
+
+func meterRef(namespace string, m meter.Meter) string {
+	return namespace + "/" + m.Key
+}
+
+func (f *fakeConnector) DesiredMeterCacheView(namespace string, m meter.Meter) (clickhouse.MeterCacheDesiredView, error) {
+	if err := f.desiredErr[meterRef(namespace, m)]; err != nil {
+		return clickhouse.MeterCacheDesiredView{}, err
+	}
+
+	return fakeDesiredView(namespace, m, f.ddlSalt), nil
+}
+
+func (f *fakeConnector) ListActualViews(ctx context.Context) ([]clickhouse.MeterCacheView, error) {
+	return slices.Clone(f.actual), nil
+}
+
+func (f *fakeConnector) EnsureMeterCache(ctx context.Context, namespace string, m meter.Meter) error {
+	f.ensured = append(f.ensured, meterRef(namespace, m))
+
+	return f.ensureErr[meterRef(namespace, m)]
+}
+
+func (f *fakeConnector) DropMeterCache(ctx context.Context, viewName string) error {
+	f.dropped = append(f.dropped, viewName)
+
+	return nil
+}
+
+func (f *fakeConnector) DeleteMeterCacheOrphanRows(ctx context.Context, keepMeterHashes []string) error {
+	f.gcKeepSets = append(f.gcKeepSets, slices.Clone(keepMeterHashes))
+
+	return nil
+}
+
+func (f *fakeConnector) ProbeMeterCacheCapabilities(ctx context.Context) (string, error) {
+	f.probeCalled++
+
+	return "25.12.3.12345", f.probeErr
+}
+
+func (f *fakeConnector) MeterCacheRepairAge() time.Duration {
+	// A zero repair age would make every deployed view look outage-aged; default to a value
+	// comfortably above the freshly-refreshed timestamps deployedView fabricates.
+	if f.repairAge == 0 {
+		return 30 * time.Minute
+	}
+
+	return f.repairAge
+}
+
+type fakeMeterService struct {
+	meters     []meter.Meter
+	lastParams meter.ListMetersParams
+}
+
+func (f *fakeMeterService) ListMeters(ctx context.Context, params meter.ListMetersParams) (pagination.Result[meter.Meter], error) {
+	f.lastParams = params
+
+	return pagination.Result[meter.Meter]{Items: slices.Clone(f.meters), TotalCount: len(f.meters)}, nil
+}
+
+func (f *fakeMeterService) GetMeterByIDOrSlug(ctx context.Context, input meter.GetMeterInput) (meter.Meter, error) {
+	return meter.Meter{}, errors.New("not implemented")
+}
+
+func newTestMeter(namespace, key, eventType string, groupBy map[string]string) meter.Meter {
+	return meter.Meter{
+		ManagedResource: models.ManagedResource{
+			NamespacedModel: models.NamespacedModel{Namespace: namespace},
+			ID:              key,
+			Name:            key,
+		},
+		Key:           key,
+		EventType:     eventType,
+		Aggregation:   meter.MeterAggregationSum,
+		ValueProperty: lo.ToPtr("$.value"),
+		GroupBy:       groupBy,
+	}
+}
+
+// newTestReconciler builds a pass-only reconciler: unit tests drive reconcile directly, so
+// the leader lock and lifecycle fields stay zero.
+func newTestReconciler(connector Connector, meters meter.Service) *Reconciler {
+	return &Reconciler{
+		logger:    slog.Default(),
+		connector: connector,
+		meters:    meters,
+	}
+}
+
+// deployedView renders the actual-state view EnsureMeterCache would leave behind for a
+// meter under the fake hash scheme: matching hashes, stamped, recently refreshed.
+func deployedView(namespace string, m meter.Meter, ddlSalt string, now time.Time) clickhouse.MeterCacheView {
+	desired := fakeDesiredView(namespace, m, ddlSalt)
+
+	return clickhouse.MeterCacheView{
+		Name:            desired.Name,
+		MetadataOK:      true,
+		MeterKey:        m.Key,
+		EventType:       m.EventType,
+		MeterHash:       desired.MeterHash,
+		DDLHash:         desired.DDLHash,
+		BackfilledAt:    lo.ToPtr(now.Add(-time.Minute)),
+		LastSuccessTime: lo.ToPtr(now.Add(-time.Minute)),
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	now := time.Now()
+
+	t.Run("CreatesMissingViewAndListsWithoutNamespace", func(t *testing.T) {
+		// given:
+		// - one meter, no deployed views
+		// when:
+		// - a pass runs
+		// then:
+		// - the meter's view is ensured, its hash is kept by GC, and the meter listing is
+		//   cross-namespace excluding soft-deleted meters
+		m := newTestMeter("ns-1", "meter-1", "api-calls", nil)
+		connector := &fakeConnector{}
+		meterService := &fakeMeterService{meters: []meter.Meter{m}}
+
+		r := newTestReconciler(connector, meterService)
+		require.NoError(t, r.reconcile(t.Context()))
+
+		require.Equal(t, []string{"ns-1/meter-1"}, connector.ensured)
+		require.Empty(t, connector.dropped)
+		require.Equal(t, [][]string{{fakeDesiredView("ns-1", m, "").MeterHash}}, connector.gcKeepSets)
+
+		require.True(t, meterService.lastParams.WithoutNamespace)
+		require.False(t, meterService.lastParams.IncludeDeleted)
+	})
+
+	t.Run("ConvergedViewIsLeftAlone", func(t *testing.T) {
+		// given:
+		// - one meter whose deployed view matches on every axis (hashes, key, stamp, health)
+		// then:
+		// - the pass performs no view mutation, only the GC probe
+		m := newTestMeter("ns-1", "meter-1", "api-calls", nil)
+		connector := &fakeConnector{actual: []clickhouse.MeterCacheView{deployedView("ns-1", m, "", now)}}
+
+		r := newTestReconciler(connector, &fakeMeterService{meters: []meter.Meter{m}})
+		require.NoError(t, r.reconcile(t.Context()))
+
+		require.Empty(t, connector.ensured)
+		require.Empty(t, connector.dropped)
+		require.Len(t, connector.gcKeepSets, 1)
+	})
+
+	t.Run("DropsViewOfDeletedMeter", func(t *testing.T) {
+		// given:
+		// - a deployed view but no meter desiring it (the meter was deleted)
+		// then:
+		// - the view is dropped and the GC keep set is empty (rows are orphans)
+		m := newTestMeter("ns-1", "meter-1", "api-calls", nil)
+		view := deployedView("ns-1", m, "", now)
+		connector := &fakeConnector{actual: []clickhouse.MeterCacheView{view}}
+
+		r := newTestReconciler(connector, &fakeMeterService{})
+		require.NoError(t, r.reconcile(t.Context()))
+
+		require.Empty(t, connector.ensured)
+		require.Equal(t, []string{view.Name}, connector.dropped)
+		require.Len(t, connector.gcKeepSets, 1)
+		require.Empty(t, connector.gcKeepSets[0])
+	})
+
+	t.Run("ShapeChangeSwapsView", func(t *testing.T) {
+		// given:
+		// - a view deployed for the meter's previous shape (no group-by), while the meter now
+		//   has a group-by dimension (different hash, different name)
+		// then:
+		// - the old view is dropped, the new one is ensured, and only the new hash is kept
+		oldShape := newTestMeter("ns-1", "meter-1", "api-calls", nil)
+		newShape := newTestMeter("ns-1", "meter-1", "api-calls", map[string]string{"group1": "$.group1"})
+
+		oldView := deployedView("ns-1", oldShape, "", now)
+		connector := &fakeConnector{actual: []clickhouse.MeterCacheView{oldView}}
+
+		r := newTestReconciler(connector, &fakeMeterService{meters: []meter.Meter{newShape}})
+		require.NoError(t, r.reconcile(t.Context()))
+
+		require.Equal(t, []string{oldView.Name}, connector.dropped)
+		require.Equal(t, []string{"ns-1/meter-1"}, connector.ensured)
+		require.Equal(t, [][]string{{fakeDesiredView("ns-1", newShape, "").MeterHash}}, connector.gcKeepSets)
+	})
+
+	t.Run("DDLDriftRecreatesView", func(t *testing.T) {
+		// given:
+		// - a deployed view recorded under a different DDL hash (config or generator change)
+		// then:
+		// - the view is dropped and re-ensured (re-backfill is implied by ensure)
+		m := newTestMeter("ns-1", "meter-1", "api-calls", nil)
+		staleView := deployedView("ns-1", m, "old-config", now)
+		connector := &fakeConnector{actual: []clickhouse.MeterCacheView{staleView}}
+
+		r := newTestReconciler(connector, &fakeMeterService{meters: []meter.Meter{m}})
+		require.NoError(t, r.reconcile(t.Context()))
+
+		require.Equal(t, []string{staleView.Name}, connector.dropped)
+		require.Equal(t, []string{"ns-1/meter-1"}, connector.ensured)
+	})
+
+	t.Run("UnstampedViewIsEnsuredWithoutDrop", func(t *testing.T) {
+		// given:
+		// - a matching view whose backfill stamp is missing (leader died mid-backfill)
+		// then:
+		// - ensure repairs it in place; no drop, so scheduled refreshes keep running
+		m := newTestMeter("ns-1", "meter-1", "api-calls", nil)
+		view := deployedView("ns-1", m, "", now)
+		view.BackfilledAt = nil
+		connector := &fakeConnector{actual: []clickhouse.MeterCacheView{view}}
+
+		r := newTestReconciler(connector, &fakeMeterService{meters: []meter.Meter{m}})
+		require.NoError(t, r.reconcile(t.Context()))
+
+		require.Empty(t, connector.dropped)
+		require.Equal(t, []string{"ns-1/meter-1"}, connector.ensured)
+	})
+
+	t.Run("AliasRejectedMeterIsSkipped", func(t *testing.T) {
+		// given:
+		// - a meter the generator refuses (simulated via desiredErr) and a healthy meter
+		// then:
+		// - only the healthy meter is ensured and only its hash is kept
+		rejected := newTestMeter("ns-1", "meter-rejected", "api-calls", map[string]string{"windowstart": "$.ws"})
+		healthy := newTestMeter("ns-1", "meter-healthy", "api-calls", nil)
+
+		connector := &fakeConnector{
+			desiredErr: map[string]error{"ns-1/meter-rejected": errors.New("reserved alias")},
+		}
+
+		r := newTestReconciler(connector, &fakeMeterService{meters: []meter.Meter{rejected, healthy}})
+		require.NoError(t, r.reconcile(t.Context()))
+
+		require.Equal(t, []string{"ns-1/meter-healthy"}, connector.ensured)
+		require.Equal(t, [][]string{{fakeDesiredView("ns-1", healthy, "").MeterHash}}, connector.gcKeepSets)
+	})
+
+	t.Run("EnsureFailureDoesNotBlockOtherMeters", func(t *testing.T) {
+		// given:
+		// - two missing views where the first ensure fails
+		// then:
+		// - the pass still ensures the second and runs GC, and reports the failure
+		m1 := newTestMeter("ns-1", "meter-1", "api-calls", nil)
+		m2 := newTestMeter("ns-1", "meter-2", "other-calls", nil)
+
+		connector := &fakeConnector{
+			ensureErr: map[string]error{"ns-1/meter-1": errors.New("boom")},
+		}
+
+		r := newTestReconciler(connector, &fakeMeterService{meters: []meter.Meter{m1, m2}})
+		err := r.reconcile(t.Context())
+		require.ErrorContains(t, err, "ns-1/meter-1")
+
+		require.ElementsMatch(t, []string{"ns-1/meter-1", "ns-1/meter-2"}, connector.ensured)
+		require.Len(t, connector.gcKeepSets, 1)
+	})
+
+	t.Run("SameShapeConflictOwnershipFollowsDeployedView", func(t *testing.T) {
+		// given:
+		// - two meters with identical shape in one namespace (one hash, one view name) where
+		//   the deployed view was created for the (namespace, key)-later meter
+		// then:
+		// - the deployed owner keeps the view (no flapping) and the other meter reads live
+		first := newTestMeter("ns-1", "meter-a", "api-calls", nil)
+		second := newTestMeter("ns-1", "meter-b", "api-calls", nil)
+
+		connector := &fakeConnector{actual: []clickhouse.MeterCacheView{deployedView("ns-1", second, "", now)}}
+
+		r := newTestReconciler(connector, &fakeMeterService{meters: []meter.Meter{first, second}})
+		require.NoError(t, r.reconcile(t.Context()))
+
+		require.Empty(t, connector.dropped)
+		require.Empty(t, connector.ensured, "the deployed view already serves the owner")
+	})
+
+	t.Run("SameShapeConflictWithoutDeployedViewFirstKeyWins", func(t *testing.T) {
+		// given:
+		// - the same conflict with nothing deployed yet
+		// then:
+		// - exactly one view is ensured, for the (namespace, key)-first meter
+		first := newTestMeter("ns-1", "meter-a", "api-calls", nil)
+		second := newTestMeter("ns-1", "meter-b", "api-calls", nil)
+
+		connector := &fakeConnector{}
+
+		r := newTestReconciler(connector, &fakeMeterService{meters: []meter.Meter{second, first}})
+		require.NoError(t, r.reconcile(t.Context()))
+
+		require.Equal(t, []string{"ns-1/meter-a"}, connector.ensured)
+	})
+}
+
+func TestDisabledReconcilerParksUntilClose(t *testing.T) {
+	// given:
+	// - a reconciler constructed with the cache disabled (the unconditional server wiring)
+	// when/then:
+	// - Start must block until Close: it runs as a run.Group actor, and an early return
+	//   would shut down the whole server
+	r, err := New(Config{Logger: slog.Default()})
+	require.NoError(t, err)
+
+	started := make(chan error, 1)
+	go func() {
+		started <- r.Start()
+	}()
+
+	select {
+	case err := <-started:
+		t.Fatalf("disabled reconciler returned from Start before Close: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	require.NoError(t, r.Close())
+
+	select {
+	case err := <-started:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("disabled reconciler did not stop after Close")
+	}
+}
+
+func TestPlanViewAction(t *testing.T) {
+	now := time.Now()
+	repairAge := 30 * time.Minute
+
+	m := newTestMeter("ns-1", "meter-1", "api-calls", nil)
+	desired := desiredView{meter: m, view: fakeDesiredView("ns-1", m, "")}
+
+	healthy := deployedView("ns-1", m, "", now)
+
+	tests := []struct {
+		name   string
+		actual func() *clickhouse.MeterCacheView
+		action viewAction
+	}{
+		{
+			name:   "missing view is ensured",
+			actual: func() *clickhouse.MeterCacheView { return nil },
+			action: viewActionEnsure,
+		},
+		{
+			name: "healthy converged view needs nothing",
+			actual: func() *clickhouse.MeterCacheView {
+				view := healthy
+				return &view
+			},
+			action: viewActionNone,
+		},
+		{
+			name: "unparseable metadata is recreated",
+			actual: func() *clickhouse.MeterCacheView {
+				view := healthy
+				view.MetadataOK = false
+				return &view
+			},
+			action: viewActionRecreate,
+		},
+		{
+			name: "meter key mismatch is recreated",
+			actual: func() *clickhouse.MeterCacheView {
+				view := healthy
+				view.MeterKey = "someone-else"
+				return &view
+			},
+			action: viewActionRecreate,
+		},
+		{
+			name: "ddl drift is recreated",
+			actual: func() *clickhouse.MeterCacheView {
+				view := healthy
+				view.DDLHash = "0000000000000000"
+				return &view
+			},
+			action: viewActionRecreate,
+		},
+		{
+			name: "unstamped backfill is ensured",
+			actual: func() *clickhouse.MeterCacheView {
+				view := healthy
+				view.BackfilledAt = nil
+				return &view
+			},
+			action: viewActionEnsure,
+		},
+		{
+			name: "extended refresh outage is repaired",
+			actual: func() *clickhouse.MeterCacheView {
+				view := healthy
+				view.LastSuccessTime = lo.ToPtr(now.Add(-repairAge - time.Minute))
+				view.BackfilledAt = lo.ToPtr(now.Add(-repairAge - time.Minute))
+				return &view
+			},
+			action: viewActionEnsure,
+		},
+		{
+			name: "outage repair is throttled by a fresh backfill stamp",
+			actual: func() *clickhouse.MeterCacheView {
+				view := healthy
+				view.LastSuccessTime = lo.ToPtr(now.Add(-repairAge - time.Minute))
+				view.BackfilledAt = lo.ToPtr(now.Add(-time.Minute))
+				return &view
+			},
+			action: viewActionNone,
+		},
+		{
+			name: "never refreshed view is not repaired",
+			actual: func() *clickhouse.MeterCacheView {
+				view := healthy
+				view.LastSuccessTime = nil
+				view.BackfilledAt = lo.ToPtr(now.Add(-repairAge - time.Minute))
+				return &view
+			},
+			action: viewActionNone,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			action, _ := planViewAction(desired, test.actual(), repairAge, now)
+			require.Equal(t, test.action, action)
+		})
+	}
+}

--- a/openmeter/streaming/clickhouse/metercache/reconciler_test.go
+++ b/openmeter/streaming/clickhouse/metercache/reconciler_test.go
@@ -337,6 +337,35 @@ func TestReconcile(t *testing.T) {
 		require.Equal(t, [][]string{{fakeDesiredView("ns-1", healthy, "").MeterHash}}, connector.gcKeepSets)
 	})
 
+	t.Run("LatestMeterIsSkippedAndItsExistingViewIsDropped", func(t *testing.T) {
+		// given:
+		// - a LATEST meter (rejected by DesiredMeterCacheView in production; simulated here
+		//   via desiredErr the same way AliasRejectedMeterIsSkipped models a G9 rejection)
+		//   that still has a deployed view from before LATEST was excluded from the cache,
+		// - a healthy SUM meter
+		// then:
+		// - the LATEST meter is never ensured, its stale view is dropped like any other
+		//   undesired view, and its hash is absent from the GC keep set so its rows are
+		//   collected as orphans
+		latest := newTestMeter("ns-1", "meter-latest", "api-calls", nil)
+		latest.Aggregation = meter.MeterAggregationLatest
+		healthy := newTestMeter("ns-1", "meter-healthy", "api-calls", nil)
+
+		staleView := deployedView("ns-1", latest, "", now)
+
+		connector := &fakeConnector{
+			actual:     []clickhouse.MeterCacheView{staleView},
+			desiredErr: map[string]error{"ns-1/meter-latest": errors.New("meter cache does not support the LATEST aggregation: always served live")},
+		}
+
+		r := newTestReconciler(connector, &fakeMeterService{meters: []meter.Meter{latest, healthy}})
+		require.NoError(t, r.reconcile(t.Context()))
+
+		require.Equal(t, []string{"ns-1/meter-healthy"}, connector.ensured)
+		require.Equal(t, []string{staleView.Name}, connector.dropped)
+		require.Equal(t, [][]string{{fakeDesiredView("ns-1", healthy, "").MeterHash}}, connector.gcKeepSets)
+	})
+
 	t.Run("EnsureFailureDoesNotBlockOtherMeters", func(t *testing.T) {
 		// given:
 		// - two missing views where the first ensure fails

--- a/openmeter/streaming/clickhouse/metercache/reconciler_test.go
+++ b/openmeter/streaming/clickhouse/metercache/reconciler_test.go
@@ -63,12 +63,18 @@ type fakeConnector struct {
 
 	desiredErr map[string]error
 	ensureErr  map[string]error
+	// markerRepairs is what ReconcileMeterCacheMarkers reports back: view names holding
+	// expired-unhealed invalidation markers.
+	markerRepairs []string
 
-	ensured     []string
-	dropped     []string
-	gcKeepSets  [][]string
-	probeCalled int
-	probeErr    error
+	ensured          []string
+	dropped          []string
+	gcKeepSets       [][]string
+	coverageStamps   map[string]time.Time
+	markerReconciles int
+	markerViewsSeen  []string
+	probeCalled      int
+	probeErr         error
 }
 
 func meterRef(namespace string, m meter.Meter) string {
@@ -103,6 +109,26 @@ func (f *fakeConnector) DeleteMeterCacheOrphanRows(ctx context.Context, keepMete
 	f.gcKeepSets = append(f.gcKeepSets, slices.Clone(keepMeterHashes))
 
 	return nil
+}
+
+func (f *fakeConnector) StampMeterCacheCoverage(ctx context.Context, view clickhouse.MeterCacheView, coveredAt time.Time) error {
+	if f.coverageStamps == nil {
+		f.coverageStamps = map[string]time.Time{}
+	}
+
+	f.coverageStamps[view.Name] = coveredAt
+
+	return nil
+}
+
+func (f *fakeConnector) ReconcileMeterCacheMarkers(ctx context.Context, views []clickhouse.MeterCacheView) ([]string, error) {
+	f.markerReconciles++
+
+	for _, view := range views {
+		f.markerViewsSeen = append(f.markerViewsSeen, view.Name)
+	}
+
+	return slices.Clone(f.markerRepairs), nil
 }
 
 func (f *fakeConnector) ProbeMeterCacheCapabilities(ctx context.Context) (string, error) {
@@ -169,6 +195,7 @@ func deployedView(namespace string, m meter.Meter, ddlSalt string, now time.Time
 	return clickhouse.MeterCacheView{
 		Name:            desired.Name,
 		MetadataOK:      true,
+		Namespace:       namespace,
 		MeterKey:        m.Key,
 		EventType:       m.EventType,
 		MeterHash:       desired.MeterHash,
@@ -363,6 +390,63 @@ func TestReconcile(t *testing.T) {
 
 		require.Equal(t, []string{"ns-1/meter-a"}, connector.ensured)
 	})
+
+	t.Run("AdvancedRefreshStampsCoverageWatermark", func(t *testing.T) {
+		// given:
+		// - a converged view whose latest successful refresh is newer than its durable
+		//   coverage watermark (backfill stamp), with the gap inside the repair slack
+		// then:
+		// - the pass performs no view mutation but stamps covered_at forward to the
+		//   refresh time, so a later ClickHouse restart cannot hide how recent coverage was
+		m := newTestMeter("ns-1", "meter-1", "api-calls", nil)
+		view := deployedView("ns-1", m, "", now)
+		view.BackfilledAt = lo.ToPtr(now.Add(-20 * time.Minute))
+		view.LastSuccessTime = lo.ToPtr(now.Add(-time.Minute))
+
+		connector := &fakeConnector{actual: []clickhouse.MeterCacheView{view}}
+
+		r := newTestReconciler(connector, &fakeMeterService{meters: []meter.Meter{m}})
+		require.NoError(t, r.reconcile(t.Context()))
+
+		require.Empty(t, connector.ensured)
+		require.Equal(t, map[string]time.Time{view.Name: *view.LastSuccessTime}, connector.coverageStamps)
+
+		// given:
+		// - the watermark already caught up with the latest refresh
+		// then:
+		// - no re-stamp fires (the stamp is per refresh cycle, not per pass)
+		view.CoveredAt = view.LastSuccessTime
+		connector = &fakeConnector{actual: []clickhouse.MeterCacheView{view}}
+
+		r = newTestReconciler(connector, &fakeMeterService{meters: []meter.Meter{m}})
+		require.NoError(t, r.reconcile(t.Context()))
+
+		require.Empty(t, connector.coverageStamps)
+	})
+
+	t.Run("MarkerRepairReportEnsuresView", func(t *testing.T) {
+		// given:
+		// - a converged, healthy view that marker maintenance reports as holding
+		//   expired-unhealed invalidation markers
+		// then:
+		// - the pass re-backfills it in place (ensure, no drop) so the markers become
+		//   healed-by-backfill and the marked ranges can serve from the cache again
+		m := newTestMeter("ns-1", "meter-1", "api-calls", nil)
+		view := deployedView("ns-1", m, "", now)
+
+		connector := &fakeConnector{
+			actual:        []clickhouse.MeterCacheView{view},
+			markerRepairs: []string{view.Name},
+		}
+
+		r := newTestReconciler(connector, &fakeMeterService{meters: []meter.Meter{m}})
+		require.NoError(t, r.reconcile(t.Context()))
+
+		require.Equal(t, 1, connector.markerReconciles)
+		require.Equal(t, []string{view.Name}, connector.markerViewsSeen)
+		require.Empty(t, connector.dropped)
+		require.Equal(t, []string{"ns-1/meter-1"}, connector.ensured)
+	})
 }
 
 func TestDisabledReconcilerParksUntilClose(t *testing.T) {
@@ -405,9 +489,10 @@ func TestPlanViewAction(t *testing.T) {
 	healthy := deployedView("ns-1", m, "", now)
 
 	tests := []struct {
-		name   string
-		actual func() *clickhouse.MeterCacheView
-		action viewAction
+		name         string
+		actual       func() *clickhouse.MeterCacheView
+		markerRepair bool
+		action       viewAction
 	}{
 		{
 			name:   "missing view is ensured",
@@ -441,6 +526,18 @@ func TestPlanViewAction(t *testing.T) {
 			action: viewActionRecreate,
 		},
 		{
+			// A name-fold-colliding namespace's same-shape, same-key view matches on every
+			// hash yet serves rows of the other namespace; only the exact recorded
+			// namespace converges.
+			name: "namespace mismatch is recreated",
+			actual: func() *clickhouse.MeterCacheView {
+				view := healthy
+				view.Namespace = "colliding-namespace"
+				return &view
+			},
+			action: viewActionRecreate,
+		},
+		{
 			name: "ddl drift is recreated",
 			actual: func() *clickhouse.MeterCacheView {
 				view := healthy
@@ -469,6 +566,36 @@ func TestPlanViewAction(t *testing.T) {
 			action: viewActionEnsure,
 		},
 		{
+			// The findings-confirmed restart gap: refreshes resumed (fresh
+			// last_success_time) after an outage wider than the durable watermark can
+			// vouch for — buckets settled mid-outage were never recomputed, only a
+			// re-backfill recovers them.
+			//
+			// Watched RED with the guard reverted: the pre-watermark rule compared
+			// now − LastSuccessTime only, so a fresh post-outage refresh made the view
+			// look healthy and this case returned viewActionNone.
+			name: "refreshes resumed past the watermark are repaired",
+			actual: func() *clickhouse.MeterCacheView {
+				view := healthy
+				view.LastSuccessTime = lo.ToPtr(now)
+				view.BackfilledAt = lo.ToPtr(now.Add(-2 * time.Hour))
+				view.CoveredAt = lo.ToPtr(now.Add(-repairAge - time.Minute))
+				return &view
+			},
+			action: viewActionEnsure,
+		},
+		{
+			name: "refreshes resumed within the watermark's coverage need nothing",
+			actual: func() *clickhouse.MeterCacheView {
+				view := healthy
+				view.LastSuccessTime = lo.ToPtr(now)
+				view.BackfilledAt = lo.ToPtr(now.Add(-2 * time.Hour))
+				view.CoveredAt = lo.ToPtr(now.Add(-repairAge + time.Minute))
+				return &view
+			},
+			action: viewActionNone,
+		},
+		{
 			name: "outage repair is throttled by a fresh backfill stamp",
 			actual: func() *clickhouse.MeterCacheView {
 				view := healthy
@@ -479,20 +606,51 @@ func TestPlanViewAction(t *testing.T) {
 			action: viewActionNone,
 		},
 		{
-			name: "never refreshed view is not repaired",
+			// A ClickHouse restart wipes system.view_refreshes; a stale watermark under a
+			// nil refresh state means the restart followed (or interrupted) an outage
+			// longer than any future refresh's lookback covers.
+			//
+			// Watched RED with the guard reverted: the pre-watermark rule exempted nil
+			// LastSuccessTime unconditionally, returning viewActionNone here.
+			name: "never refreshed view with a stale watermark is repaired",
 			actual: func() *clickhouse.MeterCacheView {
 				view := healthy
 				view.LastSuccessTime = nil
 				view.BackfilledAt = lo.ToPtr(now.Add(-repairAge - time.Minute))
 				return &view
 			},
+			action: viewActionEnsure,
+		},
+		{
+			// A fresh watermark under a nil refresh state is a plain restart after healthy
+			// operation: the first scheduled refresh covers the gap, and repairing here
+			// would re-backfill every view on every ClickHouse restart.
+			name: "never refreshed view with a fresh watermark waits for refreshes",
+			actual: func() *clickhouse.MeterCacheView {
+				view := healthy
+				view.LastSuccessTime = nil
+				view.BackfilledAt = lo.ToPtr(now.Add(-repairAge - time.Minute))
+				view.CoveredAt = lo.ToPtr(now.Add(-time.Minute))
+				return &view
+			},
 			action: viewActionNone,
+		},
+		{
+			// Expired-unhealed markers can only converge through a re-backfill; the flag
+			// comes from the pass's marker maintenance.
+			name: "expired unhealed markers are repaired",
+			actual: func() *clickhouse.MeterCacheView {
+				view := healthy
+				return &view
+			},
+			markerRepair: true,
+			action:       viewActionEnsure,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			action, _ := planViewAction(desired, test.actual(), repairAge, now)
+			action, _ := planViewAction(desired, test.actual(), test.markerRepair, repairAge, now)
 			require.Equal(t, test.action, action)
 		})
 	}

--- a/openmeter/streaming/query_params.go
+++ b/openmeter/streaming/query_params.go
@@ -23,6 +23,12 @@ type QueryParams struct {
 	GroupBy        []string
 	WindowSize     *meter.WindowSize
 	WindowTimeZone *time.Location
+
+	// Cachable opts this query into the materialized-view backed meter cache when the
+	// cache is enabled and the query is otherwise eligible (see the clickhouse connector's
+	// cache gate). It defaults to false so every call site stays live unless explicitly
+	// opted in; billing paths must never set this to true.
+	Cachable bool
 }
 
 // Validate validates query params focusing on `from` and `to` being aligned with query and meter window sizes

--- a/openmeter/streaming/testutils/streaming.go
+++ b/openmeter/streaming/testutils/streaming.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -34,11 +35,31 @@ type SimpleEvent struct {
 type MockStreamingConnector struct {
 	rows   map[string][]meter.MeterQueryRow
 	events map[string][]SimpleEvent
+
+	// queryMeterParamsMu guards queryMeterParams: billing snapshots run QueryMeter from
+	// parallel workers, so capture must be safe under -race.
+	queryMeterParamsMu sync.Mutex
+	queryMeterParams   []streaming.QueryParams
 }
 
 func (m *MockStreamingConnector) Reset() {
 	m.rows = map[string][]meter.MeterQueryRow{}
 	m.events = map[string][]SimpleEvent{}
+
+	m.queryMeterParamsMu.Lock()
+	m.queryMeterParams = nil
+	m.queryMeterParamsMu.Unlock()
+}
+
+// CapturedQueryMeterParams returns the QueryParams of every QueryMeter call in order.
+// It exists so call sites can be regression-tested for the meter cache opt-in flag:
+// Cachable must be true at the designated read-only call sites (meter query handlers,
+// cost, entitlement balance, credit usage) and false everywhere billing snapshots usage.
+func (m *MockStreamingConnector) CapturedQueryMeterParams() []streaming.QueryParams {
+	m.queryMeterParamsMu.Lock()
+	defer m.queryMeterParamsMu.Unlock()
+
+	return slices.Clone(m.queryMeterParams)
 }
 
 type AddOption func(event *SimpleEvent)
@@ -105,6 +126,10 @@ func (m *MockStreamingConnector) ListEventsV2(ctx context.Context, params stream
 // Returns the result query set for the given params. If the query set is not found,
 // it will try to approximate the result by aggregating the simple events
 func (m *MockStreamingConnector) QueryMeter(ctx context.Context, namespace string, mm meter.Meter, params streaming.QueryParams) ([]meter.MeterQueryRow, error) {
+	m.queryMeterParamsMu.Lock()
+	m.queryMeterParams = append(m.queryMeterParams, params)
+	m.queryMeterParamsMu.Unlock()
+
 	rows := []meter.MeterQueryRow{}
 	_, rowOk := m.rows[mm.Key]
 


### PR DESCRIPTION
## What

An opt-in meter query cache, maintained entirely by ClickHouse: one refreshable
materialized view per meter (`REFRESH EVERY … APPEND`) keeps a shared rollup
table up to date, and eligible queries are served as *settled range from the
rollup + live tail*, merged. Supports SUM, COUNT, MIN, MAX, AVG and exact
UNIQUE_COUNT (via `uniqExactState`); LATEST deliberately always reads live.
Off by default (`aggregation.cache.*`), opt-in per call site — meter HTTP
endpoints, cost, and entitlement/credit balance paths. Billing always reads
raw (regression-tested). Ships with an in-server MV lifecycle reconciler and
OTel metrics/traces for cache health.

## Why

Every meter query re-aggregates raw events, so cost grows with history while
dashboards and entitlement checks keep re-reading the same settled past.
Benchmarked at 100M events / 365 days / 30 meters: **3.78×** on entitlement
balance totals, rollup storage ≈ 30% of the events table, ingest overhead
+2ms p50, and refresh cost tracks *recent ingest rate*, not table age — full
history is scanned exactly once at backfill. Unlike the legacy per-meter MVs
there is no insert-path amplification, and unlike an app-managed cache there
is no populate-on-read machinery: ClickHouse owns scheduling and recompute.

## How

- **Shared rollup table** (`ReplacingMergeTree(created_at)`, keyed by
  namespace/meter/shape-hash/window/subject/group-bys): every row is a full
  bucket recompute, so newest-wins reads make re-appends idempotent — refresh
  retries, backfill overlap, and late-event recomputes are all safe by
  construction (AggregatingMergeTree double-counts here; verified and rejected).
- **Incremental refreshes**: each refresh recomputes only *dirty* buckets —
  those touched by recently-arrived events (`stored_at` lookback) plus a
  small newly-settled strip — never the whole history.
- **Correctness rails**: freshness horizon keeps the tail always-live;
  late events write invalidation markers that route affected reads to live
  until a covering refresh heals them (plus a throttled immediate refresh);
  a durable coverage watermark repairs extended refresh outages; every gate
  rejection or cache error falls back to the untouched live path.
- **Reconciler** (leader-elected, in server) diffs meters against MVs:
  create + backfill + stamp, drop on delete, rebuild on shape/config change,
  GC orphaned shapes.
- **Verification**: golden SQL suites, a parity matrix (aggregations ×
  window sizes × off-grid bounds × DST timezones × null values), poison
  tests, and a 100M-event benchmark that doubles as a parity soak — which
  caught the LATEST discrepancy that motivated excluding it.

Requires `enableDecimalPrecision`; single-ClickHouse-server topologies only
in v1 (gate fails safe to live elsewhere).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an opt-in ClickHouse-backed cache for meter queries. The main changes are:

- Shared rollup and invalidation tables for cached meter aggregates.
- Per-meter refreshable materialized views with backfill and reconciliation.
- Cache/live query merging for selected read-only meter consumers.
- Late-event invalidation, refresh nudging, and cache health observability.
- Configuration and server wiring for the cache reconciler.

<h3>Confidence Score: 4/5</h3>

The cached query path can return incorrect values for DST-spanning local windows, and late-event marker failures can leave stale buckets readable.

- Cached reads re-window UTC buckets after aggregation, which can differ from live event-time windowing.
- Late-event marker insert errors are swallowed after events are committed.
- Most other cache gates and lifecycle paths fall back to live or repair conservatively.

openmeter/streaming/clickhouse/meter_cache_gate.go, openmeter/streaming/clickhouse/meter_cache_invalidation.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| openmeter/streaming/clickhouse/meter_cache_read.go | Builds the cache/live query split and outer merge; the re-windowing path depends on safe timezone gating. |
| openmeter/streaming/clickhouse/meter_cache_gate.go | Adds cache eligibility checks, but whole-hour zones with offset changes can still reach the cached path. |
| openmeter/streaming/clickhouse/meter_cache_invalidation.go | Adds late-event markers and refresh nudging; marker write failures can leave stale cache data readable. |
| openmeter/streaming/clickhouse/metercache/reconciler.go | Adds lifecycle reconciliation for cache views, backfills, repairs, drops, and orphan cleanup. |
| app/config/aggregation.go | Adds cache configuration, defaults, and validation for supported deployment modes. |

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Q[Opt-in meter query] --> G[Cache eligibility gate]
  G -->|reject or error| L[Live raw events query]
  G -->|eligible| R[Cached read]
  R --> C[Rollup settled range]
  R --> T[Live pre and tail ranges]
  C --> M[Merge and re-window]
  T --> M
  M --> O[Meter query rows]
  I[BatchInsert events] --> W[Late-event classifier]
  W --> P[Persist invalidation markers]
  P --> H[Best-effort refresh trigger]
  G --> S[Marker overlap scan]
  S -->|unhealed marker| L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  Q[Opt-in meter query] --> G[Cache eligibility gate]
  G -->|reject or error| L[Live raw events query]
  G -->|eligible| R[Cached read]
  R --> C[Rollup settled range]
  R --> T[Live pre and tail ranges]
  C --> M[Merge and re-window]
  T --> M
  M --> O[Meter query rows]
  I[BatchInsert events] --> W[Late-event classifier]
  W --> P[Persist invalidation markers]
  P --> H[Best-effort refresh trigger]
  G --> S[Marker overlap scan]
  S -->|unhealed marker| L
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aopenmeter%2Fstreaming%2Fclickhouse%2Fmeter_cache_gate.go%3A234-238%0A**DST%20Buckets%20Shift%20Windows**%0A%0AWhen%20an%20hourly%20cached%20query%20spans%20a%20DST%20transition%20in%20a%20whole-hour-offset%20zone%20such%20as%20%60America%2FNew_York%60%2C%20this%20gate%20still%20allows%20the%20cached%20path.%20The%20cache%20has%20already%20collapsed%20events%20into%20UTC%20grain%20buckets%2C%20so%20the%20later%20re-windowing%20assigns%20the%20whole%20bucket%20by%20%60windowstart_bucket%60%20instead%20of%20by%20each%20event%20timestamp%3B%20callers%20can%20receive%20different%20per-window%20values%20than%20the%20live%20query.%0A%0A%23%23%23%20Issue%202%20of%203%0Aopenmeter%2Fstreaming%2Fclickhouse%2Fmeter_cache_invalidation.go%3A311-317%0A**Lost%20Marker%20Leaves%20Stale%20Cache**%0A%0AIf%20this%20insert%20fails%20after%20%60BatchInsert%60%20has%20already%20committed%20the%20late%20events%2C%20no%20durable%20invalidation%20reaches%20%60om_meter_cache_invalidations%60.%20Cached%20reads%20only%20consult%20that%20table%20to%20decide%20whether%20to%20fall%20back%20to%20live%2C%20so%20they%20can%20keep%20serving%20stale%20settled%20buckets%20until%20a%20later%20refresh%20happens%20to%20cover%20them.%0A%0A%23%23%23%20Issue%203%20of%203%0Aopenmeter%2Fstreaming%2Fclickhouse%2Fmeter_cache_invalidation.go%3A289%0A**App%20Clock%20Decides%20Lateness**%0A%0ALate-event%20classification%20uses%20the%20application%20clock%2C%20while%20cache%20settlement%20and%20marker%20%60created_at%60%20are%20evaluated%20on%20the%20ClickHouse%20server%20clock.%20If%20the%20app%20clock%20lags%20behind%20ClickHouse%2C%20an%20event%20that%20ClickHouse%20already%20considers%20settled%20can%20skip%20marker%20creation%2C%20leaving%20cached%20reads%20free%20to%20serve%20the%20old%20bucket.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4657&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22openmeterio%2Fopenmeter%22%20on%20the%20existing%20branch%20%22feat%2Fclickhouse-meter-query-cache%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fclickhouse-meter-query-cache%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aopenmeter%2Fstreaming%2Fclickhouse%2Fmeter_cache_gate.go%3A234-238%0A**DST%20Buckets%20Shift%20Windows**%0A%0AWhen%20an%20hourly%20cached%20query%20spans%20a%20DST%20transition%20in%20a%20whole-hour-offset%20zone%20such%20as%20%60America%2FNew_York%60%2C%20this%20gate%20still%20allows%20the%20cached%20path.%20The%20cache%20has%20already%20collapsed%20events%20into%20UTC%20grain%20buckets%2C%20so%20the%20later%20re-windowing%20assigns%20the%20whole%20bucket%20by%20%60windowstart_bucket%60%20instead%20of%20by%20each%20event%20timestamp%3B%20callers%20can%20receive%20different%20per-window%20values%20than%20the%20live%20query.%0A%0A%23%23%23%20Issue%202%20of%203%0Aopenmeter%2Fstreaming%2Fclickhouse%2Fmeter_cache_invalidation.go%3A311-317%0A**Lost%20Marker%20Leaves%20Stale%20Cache**%0A%0AIf%20this%20insert%20fails%20after%20%60BatchInsert%60%20has%20already%20committed%20the%20late%20events%2C%20no%20durable%20invalidation%20reaches%20%60om_meter_cache_invalidations%60.%20Cached%20reads%20only%20consult%20that%20table%20to%20decide%20whether%20to%20fall%20back%20to%20live%2C%20so%20they%20can%20keep%20serving%20stale%20settled%20buckets%20until%20a%20later%20refresh%20happens%20to%20cover%20them.%0A%0A%23%23%23%20Issue%203%20of%203%0Aopenmeter%2Fstreaming%2Fclickhouse%2Fmeter_cache_invalidation.go%3A289%0A**App%20Clock%20Decides%20Lateness**%0A%0ALate-event%20classification%20uses%20the%20application%20clock%2C%20while%20cache%20settlement%20and%20marker%20%60created_at%60%20are%20evaluated%20on%20the%20ClickHouse%20server%20clock.%20If%20the%20app%20clock%20lags%20behind%20ClickHouse%2C%20an%20event%20that%20ClickHouse%20already%20considers%20settled%20can%20skip%20marker%20creation%2C%20leaving%20cached%20reads%20free%20to%20serve%20the%20old%20bucket.%0A%0A&repo=openmeterio%2Fopenmeter&pr=4657&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
openmeter/streaming/clickhouse/meter_cache_gate.go:234-238
**DST Buckets Shift Windows**

When an hourly cached query spans a DST transition in a whole-hour-offset zone such as `America/New_York`, this gate still allows the cached path. The cache has already collapsed events into UTC grain buckets, so the later re-windowing assigns the whole bucket by `windowstart_bucket` instead of by each event timestamp; callers can receive different per-window values than the live query.

### Issue 2 of 3
openmeter/streaming/clickhouse/meter_cache_invalidation.go:311-317
**Lost Marker Leaves Stale Cache**

If this insert fails after `BatchInsert` has already committed the late events, no durable invalidation reaches `om_meter_cache_invalidations`. Cached reads only consult that table to decide whether to fall back to live, so they can keep serving stale settled buckets until a later refresh happens to cover them.

### Issue 3 of 3
openmeter/streaming/clickhouse/meter_cache_invalidation.go:289
**App Clock Decides Lateness**

Late-event classification uses the application clock, while cache settlement and marker `created_at` are evaluated on the ClickHouse server clock. If the app clock lags behind ClickHouse, an event that ClickHouse already considers settled can skip marker creation, leaving cached reads free to serve the old bucket.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(streaming): otel metrics and tracin..."](https://github.com/openmeterio/openmeter/commit/518b686fde30ed38fab40cb77d35e23430d17db7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42390302)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->