### PR TITLE
feat: remove usage-based legacy realization statuses

### DIFF
--- a/openmeter/billing/charges/meta/triggers.go
+++ b/openmeter/billing/charges/meta/triggers.go
@@ -9,7 +9,6 @@ var (
 	TriggerInvoiceCreated         Trigger = "invoice_created"
 	TriggerCollectionCompleted    Trigger = "collection_completed"
 	TriggerInvoiceIssued          Trigger = "invoice_issued"
-	TriggerAllPaymentsSettled     Trigger = "all_payments_settled"
 	TriggerLineManualEdit         Trigger = "line_manual_edit"
 	TriggerShrinkToRealizedPeriod Trigger = "shrink_to_realized_period"
 	TriggerAttachInvoiceLine      Trigger = "attach_invoice_line"

--- a/openmeter/billing/charges/meta/triggers.go
+++ b/openmeter/billing/charges/meta/triggers.go
@@ -9,6 +9,7 @@ var (
 	TriggerInvoiceCreated         Trigger = "invoice_created"
 	TriggerCollectionCompleted    Trigger = "collection_completed"
 	TriggerInvoiceIssued          Trigger = "invoice_issued"
+	TriggerAllPaymentsSettled     Trigger = "all_payments_settled"
 	TriggerLineManualEdit         Trigger = "line_manual_edit"
 	TriggerShrinkToRealizedPeriod Trigger = "shrink_to_realized_period"
 	TriggerAttachInvoiceLine      Trigger = "attach_invoice_line"

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -172,7 +172,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 	// Payment + final
 
 	s.Configure(usagebased.StatusActiveAwaitingPaymentSettlement).
-		Permit(meta.TriggerAllPaymentsSettled, usagebased.StatusFinal, statelessx.BoolFn(s.AreAllInvoicedRunsSettled)).
+		Permit(meta.TriggerNext, usagebased.StatusFinal, statelessx.BoolFn(s.AreAllInvoicedRunsSettled)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).

--- a/openmeter/billing/charges/usagebased/service/creditheninvoice.go
+++ b/openmeter/billing/charges/usagebased/service/creditheninvoice.go
@@ -114,7 +114,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
 		InternalTransition(meta.TriggerShrinkToRealizedPeriod, statelessx.WithParameters(s.ShrinkToRealizedPeriod)).
-		OnEntry(statelessx.WithParameters(s.StartInvoiceRun))
+		OnEntryFrom(meta.TriggerInvoiceCreated, statelessx.WithParameters(s.StartInvoiceRun))
 
 	s.Configure(usagebased.StatusActiveRealizationWaitingForCollection).
 		Permit(
@@ -172,7 +172,7 @@ func (s *CreditThenInvoiceStateMachine) configureStates() {
 	// Payment + final
 
 	s.Configure(usagebased.StatusActiveAwaitingPaymentSettlement).
-		Permit(meta.TriggerNext, usagebased.StatusFinal, statelessx.BoolFn(s.AreAllInvoicedRunsSettled)).
+		Permit(meta.TriggerAllPaymentsSettled, usagebased.StatusFinal, statelessx.BoolFn(s.AreAllInvoicedRunsSettled)).
 		InternalTransition(meta.TriggerDelete, statelessx.WithParameters(s.DeleteCharge)).
 		InternalTransition(meta.TriggerExtend, statelessx.WithParameters(s.ExtendCharge)).
 		InternalTransition(meta.TriggerShrink, statelessx.WithParameters(s.ShrinkCharge)).
@@ -662,10 +662,6 @@ func (s *CreditThenInvoiceStateMachine) handleFinalRunOnExtend(ctx context.Conte
 	}
 
 	finalRuns := lo.Filter(s.Charge.Realizations, func(run usagebased.RealizationRun, _ int) bool {
-		if run.Type != usagebased.RealizationRunTypeFinalRealization {
-			return false
-		}
-
 		// Voided realizations no longer preserve invoice lifecycle state, so they
 		// cannot be reclassified when an already-extended charge is patched again.
 		if run.IsVoidedBillingHistory() {

--- a/openmeter/billing/charges/usagebased/service/creditsonly_test.go
+++ b/openmeter/billing/charges/usagebased/service/creditsonly_test.go
@@ -15,75 +15,11 @@ import (
 	"github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased"
 	usagebasedrating "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/rating"
 	usagebasedrun "github.com/openmeterio/openmeter/openmeter/billing/charges/usagebased/service/run"
-	"github.com/openmeterio/openmeter/openmeter/customer"
-	"github.com/openmeterio/openmeter/openmeter/meter"
 	"github.com/openmeterio/openmeter/openmeter/productcatalog"
-	"github.com/openmeterio/openmeter/openmeter/productcatalog/feature"
 	"github.com/openmeterio/openmeter/pkg/currencyx"
-	"github.com/openmeterio/openmeter/pkg/datetime"
 	"github.com/openmeterio/openmeter/pkg/models"
 	"github.com/openmeterio/openmeter/pkg/timeutil"
 )
-
-func TestNewStateMachineBaseNormalizesLegacyStatus(t *testing.T) {
-	for _, tc := range []struct {
-		from usagebased.Status
-		to   usagebased.Status
-	}{
-		{from: usagebased.StatusActivePartialInvoiceStarted, to: usagebased.StatusActiveRealizationStarted},
-		{from: usagebased.StatusActivePartialInvoiceWaitingForCollection, to: usagebased.StatusActiveRealizationWaitingForCollection},
-		{from: usagebased.StatusActivePartialInvoiceProcessing, to: usagebased.StatusActiveRealizationProcessing},
-		{from: usagebased.StatusActivePartialInvoiceIssuing, to: usagebased.StatusActiveRealizationIssuing},
-		{from: usagebased.StatusActivePartialInvoiceCompleted, to: usagebased.StatusActiveRealizationCompleted},
-		{from: usagebased.StatusActiveFinalRealizationStarted, to: usagebased.StatusActiveRealizationStarted},
-		{from: usagebased.StatusActiveFinalRealizationWaitingForCollection, to: usagebased.StatusActiveRealizationWaitingForCollection},
-		{from: usagebased.StatusActiveFinalRealizationProcessing, to: usagebased.StatusActiveRealizationProcessing},
-		{from: usagebased.StatusActiveFinalRealizationIssuing, to: usagebased.StatusActiveRealizationIssuing},
-		{from: usagebased.StatusActiveFinalRealizationCompleted, to: usagebased.StatusActiveRealizationCompleted},
-	} {
-		t.Run(string(tc.from), func(t *testing.T) {
-			servicePeriod := timeutil.ClosedPeriod{
-				From: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
-				To:   time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
-			}
-			charge := usagebased.Charge{
-				ChargeBase: usagebased.ChargeBase{
-					ManagedResource: newUsageBasedChargeTestManagedResource("charge-id"),
-					Intent:          newUsageBasedIntentForCreditOnlyTest(servicePeriod),
-					Status:          tc.from,
-					State: usagebased.State{
-						FeatureID:    "feature-id",
-						RatingEngine: usagebased.RatingEngineDelta,
-					},
-				},
-			}
-
-			adapter := newCreditsOnlyStateMachineAdapter(charge)
-			runService, err := usagebasedrun.New(usagebasedrun.Config{
-				Adapter: adapter,
-				Rater:   creditsOnlyStateMachineRater{},
-				Handler: usagebased.UnimplementedHandler{},
-				Lineage: creditsOnlyStateMachineLineage{},
-			})
-			require.NoError(t, err)
-
-			currencyCalculator, err := currencyx.Code("USD").Calculator()
-			require.NoError(t, err)
-
-			machine, err := newStateMachineBase(StateMachineConfig{
-				Charge:             charge,
-				Adapter:            adapter,
-				Rater:              creditsOnlyStateMachineRater{},
-				Runs:               runService,
-				CustomerOverride:   newUsageBasedStateMachineTestCustomerOverride(t),
-				FeatureMeter:       newUsageBasedStateMachineTestFeatureMeter(),
-				CurrencyCalculator: currencyCalculator,
-			})
-			require.NoError(t, err)
-			require.Equal(t, tc.to, machine.GetCharge().Status)
-		})
-	}
-}
 
 func TestCreditsOnlyPeriodPatchIsConfiguredForPatchableStates(t *testing.T) {
 	for _, status := range []usagebased.Status{
@@ -401,74 +337,6 @@ func newUsageBasedChargeTestManagedResource(id string) meta.ManagedResource {
 			UpdatedAt: now,
 		},
 		ID: id,
-	}
-}
-
-func newUsageBasedStateMachineTestCustomerOverride(t *testing.T) billing.CustomerOverrideWithDetails {
-	t.Helper()
-
-	country := models.CountryCode("US")
-	customerKey := "customer-key"
-
-	return billing.CustomerOverrideWithDetails{
-		Customer: &customer.Customer{
-			ManagedResource: models.ManagedResource{
-				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
-				ID:              "customer-id",
-				Name:            "customer",
-			},
-			Key: &customerKey,
-		},
-		MergedProfile: billing.Profile{
-			BaseProfile: billing.BaseProfile{
-				Namespace: "namespace",
-				ID:        "profile-id",
-				Name:      "profile",
-				WorkflowConfig: billing.WorkflowConfig{
-					Collection: billing.CollectionConfig{
-						Alignment: billing.AlignmentKindSubscription,
-						Interval:  datetime.MustParseDuration(t, "PT1H"),
-					},
-					Invoicing: billing.InvoicingConfig{
-						SubscriptionEndProrationMode: billing.SubscriptionEndProrationModeBillFullPeriod,
-					},
-					Payment: billing.PaymentConfig{
-						CollectionMethod: billing.CollectionMethodChargeAutomatically,
-					},
-				},
-				Supplier: billing.SupplierContact{
-					Name: "supplier",
-					Address: models.Address{
-						Country: &country,
-					},
-				},
-			},
-		},
-	}
-}
-
-func newUsageBasedStateMachineTestFeatureMeter() feature.FeatureMeter {
-	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-
-	return feature.FeatureMeter{
-		Feature: feature.Feature{
-			Namespace: "namespace",
-			ID:        "feature-id",
-			Name:      "feature",
-			Key:       "feature-key",
-			CreatedAt: now,
-			UpdatedAt: now,
-		},
-		Meter: &meter.Meter{
-			ManagedResource: models.ManagedResource{
-				NamespacedModel: models.NamespacedModel{Namespace: "namespace"},
-				ID:              "meter-id",
-				Name:            "meter",
-			},
-			Key:         "meter-key",
-			Aggregation: meter.MeterAggregationSum,
-			EventType:   "event",
-		},
 	}
 }
 

--- a/openmeter/billing/charges/usagebased/service/statemachine.go
+++ b/openmeter/billing/charges/usagebased/service/statemachine.go
@@ -91,9 +91,6 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 		return nil, fmt.Errorf("config: %w", err)
 	}
 
-	// TODO: remove normalization once we are in prod and we have an SQL migration to rewrite status_detailed.
-	charge := config.Charge.WithStatus(usagebased.NormalizeLegacyStatus(config.Charge.GetStatus()))
-
 	out := &stateMachine{
 		Logger:             lo.CoalesceOrEmpty(config.Logger, slog.Default()),
 		Adapter:            config.Adapter,
@@ -105,7 +102,7 @@ func newStateMachineBase(config StateMachineConfig) (*stateMachine, error) {
 	}
 
 	machine, err := chargestatemachine.New(chargestatemachine.Config[usagebased.Charge, usagebased.ChargeBase, usagebased.Status]{
-		Charge: charge,
+		Charge: config.Charge,
 		Persistence: chargestatemachine.Persistence[usagebased.Charge, usagebased.ChargeBase]{
 			UpdateBase: func(ctx context.Context, base usagebased.ChargeBase) (usagebased.ChargeBase, error) {
 				return out.Adapter.UpdateCharge(ctx, base)

--- a/openmeter/billing/charges/usagebased/statemachine.go
+++ b/openmeter/billing/charges/usagebased/statemachine.go
@@ -16,74 +16,16 @@ const (
 	// Active status and substates
 	StatusActive Status = Status(meta.ChargeStatusActive)
 
-	// Deprecated: use StatusActiveRealizationStarted. Kept temporarily so
-	// persisted rows can load until the SQL migration rewrites legacy statuses.
-	StatusActivePartialInvoiceStarted Status = "active.partial_invoice.started"
-	// Deprecated: use StatusActiveRealizationWaitingForCollection. Kept
-	// temporarily so persisted rows can load until the SQL migration rewrites
-	// legacy statuses.
-	StatusActivePartialInvoiceWaitingForCollection Status = "active.partial_invoice.waiting_for_collection"
-	// Deprecated: use StatusActiveRealizationProcessing. Kept temporarily so
-	// persisted rows can load until the SQL migration rewrites legacy statuses.
-	StatusActivePartialInvoiceProcessing Status = "active.partial_invoice.processing"
-	// Deprecated: use StatusActiveRealizationIssuing. Kept temporarily so
-	// persisted rows can load until the SQL migration rewrites legacy statuses.
-	StatusActivePartialInvoiceIssuing Status = "active.partial_invoice.issuing"
-	// Deprecated: use StatusActiveRealizationCompleted. Kept temporarily so
-	// persisted rows can load until the SQL migration rewrites legacy statuses.
-	StatusActivePartialInvoiceCompleted         Status = "active.partial_invoice.completed"
 	StatusActiveRealizationStarted              Status = "active.realization.started"
 	StatusActiveRealizationWaitingForCollection Status = "active.realization.waiting_for_collection"
 	StatusActiveRealizationProcessing           Status = "active.realization.processing"
 	StatusActiveRealizationIssuing              Status = "active.realization.issuing"
 	StatusActiveRealizationCompleted            Status = "active.realization.completed"
-	// Deprecated: use StatusActiveRealizationStarted. Kept temporarily so
-	// persisted rows can load until the SQL migration rewrites legacy statuses.
-	StatusActiveFinalRealizationStarted Status = "active.final_realization.started"
-	// Deprecated: use StatusActiveRealizationWaitingForCollection. Kept
-	// temporarily so persisted rows can load until the SQL migration rewrites
-	// legacy statuses.
-	StatusActiveFinalRealizationWaitingForCollection Status = "active.final_realization.waiting_for_collection"
-	// Deprecated: use StatusActiveRealizationProcessing. Kept temporarily so
-	// persisted rows can load until the SQL migration rewrites legacy statuses.
-	StatusActiveFinalRealizationProcessing Status = "active.final_realization.processing"
-	// Deprecated: use StatusActiveRealizationIssuing. Kept temporarily so
-	// persisted rows can load until the SQL migration rewrites legacy statuses.
-	StatusActiveFinalRealizationIssuing Status = "active.final_realization.issuing"
-	// Deprecated: use StatusActiveRealizationCompleted. Kept temporarily so
-	// persisted rows can load until the SQL migration rewrites legacy statuses.
-	StatusActiveFinalRealizationCompleted Status = "active.final_realization.completed"
-	StatusActiveAwaitingPaymentSettlement Status = "active.awaiting_payment_settlement"
+	StatusActiveAwaitingPaymentSettlement       Status = "active.awaiting_payment_settlement"
 
 	StatusFinal   Status = Status(meta.ChargeStatusFinal)
 	StatusDeleted Status = Status(meta.ChargeStatusDeleted)
 )
-
-var legacyStatusMap = map[Status]Status{
-	StatusActivePartialInvoiceStarted:                StatusActiveRealizationStarted,
-	StatusActivePartialInvoiceWaitingForCollection:   StatusActiveRealizationWaitingForCollection,
-	StatusActivePartialInvoiceProcessing:             StatusActiveRealizationProcessing,
-	StatusActivePartialInvoiceIssuing:                StatusActiveRealizationIssuing,
-	StatusActivePartialInvoiceCompleted:              StatusActiveRealizationCompleted,
-	StatusActiveFinalRealizationStarted:              StatusActiveRealizationStarted,
-	StatusActiveFinalRealizationWaitingForCollection: StatusActiveRealizationWaitingForCollection,
-	StatusActiveFinalRealizationProcessing:           StatusActiveRealizationProcessing,
-	StatusActiveFinalRealizationIssuing:              StatusActiveRealizationIssuing,
-	StatusActiveFinalRealizationCompleted:            StatusActiveRealizationCompleted,
-}
-
-// NormalizeLegacyStatus maps persisted pre-unification realization statuses to
-// the canonical active.realization.* status branch. We do this at state-machine
-// load time so old rows keep working without keeping legacy states in the
-// lifecycle graph. The legacy values stay accepted until a follow-up SQL
-// migration rewrites status_detailed in storage and the enum can be tightened.
-func NormalizeLegacyStatus(status Status) Status {
-	if normalized, ok := legacyStatusMap[status]; ok {
-		return normalized
-	}
-
-	return status
-}
 
 // mutableRealizationStatuses are states where the current realization can still
 // be rebuilt by period changes instead of touching immutable invoice or ledger
@@ -95,28 +37,18 @@ var mutableRealizationStatuses = []Status{
 }
 
 func IsMutableRealizationStatus(status Status) bool {
-	return slices.Contains(mutableRealizationStatuses, NormalizeLegacyStatus(status))
+	return slices.Contains(mutableRealizationStatuses, status)
 }
 
 func (Status) Values() []string {
 	return []string{
 		string(StatusCreated),
 		string(StatusActive),
-		string(StatusActivePartialInvoiceStarted),
-		string(StatusActivePartialInvoiceWaitingForCollection),
-		string(StatusActivePartialInvoiceProcessing),
-		string(StatusActivePartialInvoiceIssuing),
-		string(StatusActivePartialInvoiceCompleted),
 		string(StatusActiveRealizationStarted),
 		string(StatusActiveRealizationWaitingForCollection),
 		string(StatusActiveRealizationProcessing),
 		string(StatusActiveRealizationIssuing),
 		string(StatusActiveRealizationCompleted),
-		string(StatusActiveFinalRealizationStarted),
-		string(StatusActiveFinalRealizationWaitingForCollection),
-		string(StatusActiveFinalRealizationProcessing),
-		string(StatusActiveFinalRealizationIssuing),
-		string(StatusActiveFinalRealizationCompleted),
 		string(StatusActiveAwaitingPaymentSettlement),
 		string(StatusFinal),
 		string(StatusDeleted),

--- a/openmeter/ent/db/chargeusagebased/chargeusagebased.go
+++ b/openmeter/ent/db/chargeusagebased/chargeusagebased.go
@@ -328,7 +328,7 @@ func RatingEngineValidator(re usagebased.RatingEngine) error {
 // StatusDetailedValidator is a validator for the "status_detailed" field enum values. It is called by the builders before save.
 func StatusDetailedValidator(sd usagebased.Status) error {
 	switch sd {
-	case "created", "active", "active.partial_invoice.started", "active.partial_invoice.waiting_for_collection", "active.partial_invoice.processing", "active.partial_invoice.issuing", "active.partial_invoice.completed", "active.realization.started", "active.realization.waiting_for_collection", "active.realization.processing", "active.realization.issuing", "active.realization.completed", "active.final_realization.started", "active.final_realization.waiting_for_collection", "active.final_realization.processing", "active.final_realization.issuing", "active.final_realization.completed", "active.awaiting_payment_settlement", "final", "deleted":
+	case "created", "active", "active.realization.started", "active.realization.waiting_for_collection", "active.realization.processing", "active.realization.issuing", "active.realization.completed", "active.awaiting_payment_settlement", "final", "deleted":
 		return nil
 	default:
 		return fmt.Errorf("chargeusagebased: invalid enum value for status_detailed field: %q", sd)

--- a/openmeter/ent/db/migrate/schema.go
+++ b/openmeter/ent/db/migrate/schema.go
@@ -2481,7 +2481,7 @@ var (
 		{Name: "rating_engine", Type: field.TypeEnum, Enums: []string{"delta", "period_preserving"}},
 		{Name: "price", Type: field.TypeString, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "unit_config", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
-		{Name: "status_detailed", Type: field.TypeEnum, Enums: []string{"created", "active", "active.partial_invoice.started", "active.partial_invoice.waiting_for_collection", "active.partial_invoice.processing", "active.partial_invoice.issuing", "active.partial_invoice.completed", "active.realization.started", "active.realization.waiting_for_collection", "active.realization.processing", "active.realization.issuing", "active.realization.completed", "active.final_realization.started", "active.final_realization.waiting_for_collection", "active.final_realization.processing", "active.final_realization.issuing", "active.final_realization.completed", "active.awaiting_payment_settlement", "final", "deleted"}},
+		{Name: "status_detailed", Type: field.TypeEnum, Enums: []string{"created", "active", "active.realization.started", "active.realization.waiting_for_collection", "active.realization.processing", "active.realization.issuing", "active.realization.completed", "active.awaiting_payment_settlement", "final", "deleted"}},
 		{Name: "current_realization_run_id", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "customer_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},
 		{Name: "feature_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "char(26)"}},

--- a/openmeter/ledger/chargeadapter/usagebased_test.go
+++ b/openmeter/ledger/chargeadapter/usagebased_test.go
@@ -644,7 +644,7 @@ func (e *usageBasedHandlerTestEnv) newCharge(settlementMode productcatalog.Settl
 				FeatureKey:     "api_requests",
 				SettlementMode: settlementMode,
 			}.AsOverridableIntent(),
-			Status: chargeusagebased.StatusActiveFinalRealizationProcessing,
+			Status: chargeusagebased.StatusActiveRealizationProcessing,
 			State: chargeusagebased.State{
 				FeatureID:    featureID,
 				RatingEngine: chargeusagebased.RatingEngineDelta,

--- a/tools/migrate/migrations/20260714144104_consolidate_usage_based_realization_statuses.down.sql
+++ b/tools/migrate/migrations/20260714144104_consolidate_usage_based_realization_statuses.down.sql
@@ -1,0 +1,1 @@
+-- no down migration: legacy usage-based realization statuses are intentionally not restored

--- a/tools/migrate/migrations/20260714144104_consolidate_usage_based_realization_statuses.up.sql
+++ b/tools/migrate/migrations/20260714144104_consolidate_usage_based_realization_statuses.up.sql
@@ -1,0 +1,27 @@
+-- consolidate legacy usage-based realization statuses into the canonical realization branch
+UPDATE "charge_usage_based"
+SET "status_detailed" = CASE "status_detailed"
+    WHEN 'active.partial_invoice.started' THEN 'active.realization.started'
+    WHEN 'active.final_realization.started' THEN 'active.realization.started'
+    WHEN 'active.partial_invoice.waiting_for_collection' THEN 'active.realization.waiting_for_collection'
+    WHEN 'active.final_realization.waiting_for_collection' THEN 'active.realization.waiting_for_collection'
+    WHEN 'active.partial_invoice.processing' THEN 'active.realization.processing'
+    WHEN 'active.final_realization.processing' THEN 'active.realization.processing'
+    WHEN 'active.partial_invoice.issuing' THEN 'active.realization.issuing'
+    WHEN 'active.final_realization.issuing' THEN 'active.realization.issuing'
+    WHEN 'active.partial_invoice.completed' THEN 'active.realization.completed'
+    WHEN 'active.final_realization.completed' THEN 'active.realization.completed'
+    ELSE "status_detailed"
+END
+WHERE "status_detailed" IN (
+    'active.partial_invoice.started',
+    'active.final_realization.started',
+    'active.partial_invoice.waiting_for_collection',
+    'active.final_realization.waiting_for_collection',
+    'active.partial_invoice.processing',
+    'active.final_realization.processing',
+    'active.partial_invoice.issuing',
+    'active.final_realization.issuing',
+    'active.partial_invoice.completed',
+    'active.final_realization.completed'
+);

--- a/tools/migrate/migrations/atlas.sum
+++ b/tools/migrate/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:q2q3y5w5ZGJ22djQeI+8x1yz6exFby1c4ZYDpzRkpxA=
+h1:MP+4ibn/VPIA2p9vT3ekYsnlkSYx3rroWbiJ2xHl2xk=
 20240826120919_init.up.sql h1:tc1V91/smlmaeJGQ8h+MzTEeFjjnrrFDbDAjOYJK91o=
 20240903155435_entitlement-expired-index.up.sql h1:Hp8u5uckmLXc1cRvWU0AtVnnK8ShlpzZNp8pbiJLhac=
 20240917172257_billing-entities.up.sql h1:Q1dAMo0Vjiit76OybClNfYPGC5nmvov2/M2W1ioi4Kw=
@@ -230,3 +230,4 @@ h1:q2q3y5w5ZGJ22djQeI+8x1yz6exFby1c4ZYDpzRkpxA=
 20260709134500_add_credit_purchase_voided_at.up.sql h1:+LXY/WI+kvHKOCh4VQXdswI7O+PPnqHKk/o7snTxlxk=
 20260709134600_add_ledger_credit_void_records.up.sql h1:o5C0cNz9b50BMgQcn1lp3BtlBYx8ETeOs2m8Ck6OiXc=
 20260714140423_set_billing_invoice_schema_level_2.up.sql h1:4SzI0XyP9hXBxwdeTNEf2r55KY6vDRUgkbaZAK8rwWA=
+20260714144104_consolidate_usage_based_realization_statuses.up.sql h1:ihKrZw9u8mv3TxideKQB5ZeakiKVfjf6UeLidLGPRoU=


### PR DESCRIPTION
## Summary

Stacked on #4660.

Removes the temporary usage-based legacy realization status compatibility layer after the consolidated `active.realization.*` states were introduced.

## Details

- Removes legacy partial/final realization status constants and load-time normalization.
- Tightens generated Ent enum validation and migration schema to canonical usage-based realization statuses only.
- Adds a forward-only SQL migration that rewrites persisted `active.partial_invoice.*` and `active.final_realization.*` values into `active.realization.*`.
- Leaves the down migration intentionally empty so legacy statuses are not restored.

## Validation

Not run locally for this draft stack PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear “Awaiting Payment Settlement” status for usage-based charges.
  * Consolidated legacy realization statuses into the current canonical status flow.

* **Bug Fixes**
  * Improved invoice-run handling when charges transition between realization states.
  * Corrected final-run selection during extended billing periods.

* **Maintenance**
  * Removed support for deprecated realization statuses and their compatibility handling.
  * Updated existing data to use the consolidated status values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the temporary legacy realization status compatibility layer. The main changes are:

- Drops legacy partial and final realization status constants.
- Stops normalizing legacy statuses when building the usage-based state machine.
- Tightens generated Ent status validation to canonical realization states.
- Adds a forward SQL migration that rewrites stored legacy statuses.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tools/migrate/migrations/20260714144104_consolidate_usage_based_realization_statuses.up.sql | Adds the forward migration that maps stored legacy realization statuses to canonical realization statuses. |
| openmeter/billing/charges/usagebased/service/statemachine.go | Removes load-time legacy status normalization from usage-based state machine construction. |
| openmeter/billing/charges/usagebased/statemachine.go | Removes legacy realization status constants and keeps only canonical status validation. |
| openmeter/ent/db/chargeusagebased/chargeusagebased.go | Updates generated Ent validation to reject legacy detailed status values. |
| openmeter/billing/charges/usagebased/service/creditheninvoice.go | Updates realization entry behavior and extension handling for the consolidated status flow. |

<sub>Reviews (2): Last reviewed commit: ["feat: remove usage-based legacy statuses"](https://github.com/openmeterio/openmeter/commit/4e16598603cfaf90d5430bc80db0f7578f0959ab) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42635462)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=3a13001c-408b-4c9c-b373-c5111c5e920b))
- Context used - AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=eb020e3b-8e3b-45ea-a8b7-4006b2b2065b))
- Context used - api/spec/AGENTS.md ([source](https://app.greptile.com/openmeter/github/openmeterio/openmeter/-/custom-context?memory=28ba6068-00f9-4629-9b78-8e49cc802858))
</details>

<!-- /greptile_comment -->